### PR TITLE
Add storage abstraction and LMDB implementation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,6 +4,20 @@ version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "bincode"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "byteorder 1.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.82 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "bitflags"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "bitflags"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -151,6 +165,11 @@ version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "gcc"
+version = "0.3.55"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "generic-array"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -164,12 +183,45 @@ version = "0.2.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "liblmdb-sys"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "gcc 0.3.55 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.44 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "lmdb-zero"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bitflags 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.44 (registry+https://github.com/rust-lang/crates.io-index)",
+ "liblmdb-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "supercow 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "mempool"
 version = "0.0.1"
 
 [[package]]
 name = "mining"
 version = "0.0.1"
+
+[[package]]
+name = "num-traits"
+version = "0.1.43"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "num-traits 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "p2p"
@@ -184,9 +236,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "proc-macro2"
+version = "0.4.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "quote"
 version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "quote"
+version = "0.6.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 0.4.24 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "rand"
@@ -214,6 +282,40 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "rmp"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "byteorder 1.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.1.43 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "rmp-serde"
+version = "0.13.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "byteorder 1.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rmp 0.8.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.82 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "serde"
+version = "1.0.82"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "serde_derive"
+version = "1.0.82"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 0.4.24 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.23 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "sha2"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -227,10 +329,25 @@ dependencies = [
 [[package]]
 name = "storage"
 version = "0.0.1"
+dependencies = [
+ "bincode 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "derive-error 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lmdb-zero 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rmp 0.8.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rmp-serde 0.13.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.82 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.82 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "subtle"
 version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "supercow"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -241,6 +358,16 @@ dependencies = [
  "quote 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "synom 0.11.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-xid 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "syn"
+version = "0.15.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 0.4.24 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -266,6 +393,11 @@ version = "0.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "unicode-xid"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "winapi"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -286,6 +418,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [metadata]
 "checksum arrayref 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "0d382e583f07208808f6b1249e60848879ba3543f57c32277bf52d69c2f0f0ee"
+"checksum bincode 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "9f2fb9e29e72fd6bc12071533d5dc7664cb01480c59406f656d7ac25c7bd8ff7"
+"checksum bitflags 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4efd02e230a02e18f92fc2735f44597385ed02ad8f831e7c1c1156ee5e1ab3a5"
 "checksum bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "228047a76f468627ca71776ecdebd732a3423081fcf5125585bcd7c49886ce12"
 "checksum block-buffer 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "a076c298b9ecdb530ed9d967e74a6027d6a7478924520acddcddc24c1c8ab3ab"
 "checksum byte-tools 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "560c32574a12a89ecd91f5e742165893f86e3ab98d21f8ea548658eb9eef5f40"
@@ -303,19 +437,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum fake-simd 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e88a8acf291dafb59c2d96e8f59828f3838bb1a70398823ade51a84de6a6deed"
 "checksum fuchsia-zircon 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2e9763c69ebaae630ba35f74888db465e49e259ba1bc0eda7d06f4a067615d82"
 "checksum fuchsia-zircon-sys 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
+"checksum gcc 0.3.55 (registry+https://github.com/rust-lang/crates.io-index)" = "8f5f3913fa0bfe7ee1fd8248b6b9f42a5af4b9d65ec2dd2c3c26132b950ecfc2"
 "checksum generic-array 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ef25c5683767570c2bbd7deba372926a55eaae9982d7726ee2a1050239d45b9d"
 "checksum libc 0.2.44 (registry+https://github.com/rust-lang/crates.io-index)" = "10923947f84a519a45c8fefb7dd1b3e8c08747993381adee176d7a82b4195311"
+"checksum liblmdb-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "feed38a3a580f60bf61aaa067b0ff4123395966839adeaf67258a9e50c4d2e49"
+"checksum lmdb-zero 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "13416eee745b087c22934f35f1f24da22da41ba2a5ce197143d168ce055cc58d"
+"checksum num-traits 0.1.43 (registry+https://github.com/rust-lang/crates.io-index)" = "92e5113e9fd4cc14ded8e499429f396a20f98c772a47cc8622a736e1ec843c31"
+"checksum num-traits 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "0b3a5d7cc97d6d30d8b9bc8fa19bf45349ffe46241e8816f50f62f6d6aaabee1"
 "checksum packed_simd 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "25d36de864f7218ec5633572a800109bbe5a1cc8d9d95a967f3daf93ea7e6ddc"
+"checksum proc-macro2 0.4.24 (registry+https://github.com/rust-lang/crates.io-index)" = "77619697826f31a02ae974457af0b29b723e5619e113e9397b8b82c6bd253f09"
 "checksum quote 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)" = "7a6e920b65c65f10b2ae65c831a81a073a89edd28c7cce89475bff467ab4167a"
+"checksum quote 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)" = "53fa22a1994bd0f9372d7a816207d8a2677ad0325b073f5c5332760f0fb62b5c"
 "checksum rand 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)" = "e464cd887e869cddcae8792a4ee31d23c7edd516700695608f5b98c67ee0131c"
 "checksum rand_core 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "1961a422c4d189dfb50ffa9320bf1f2a9bd54ecb92792fb9477f99a1045f3372"
 "checksum rand_core 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "0905b6b7079ec73b314d4c748701f6931eb79fd97c668caa3f1899b22b32c6db"
+"checksum rmp 0.8.7 (registry+https://github.com/rust-lang/crates.io-index)" = "a3d45d7afc9b132b34a2479648863aa95c5c88e98b32285326a6ebadc80ec5c9"
+"checksum rmp-serde 0.13.7 (registry+https://github.com/rust-lang/crates.io-index)" = "011e1d58446e9fa3af7cdc1fb91295b10621d3ac4cb3a85cc86385ee9ca50cd3"
+"checksum serde 1.0.82 (registry+https://github.com/rust-lang/crates.io-index)" = "6fa52f19aee12441d5ad11c9a00459122bd8f98707cadf9778c540674f1935b6"
+"checksum serde_derive 1.0.82 (registry+https://github.com/rust-lang/crates.io-index)" = "96a7f9496ac65a2db5929afa087b54f8fc5008dcfbe48a8874ed20049b0d6154"
 "checksum sha2 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "9eb6be24e4c23a84d7184280d2722f7f2731fcdd4a9d886efbfe4413e4847ea0"
 "checksum subtle 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2d67a5a62ba6e01cb2192ff309324cb4875d0c451d55fe2319433abe7a05a8ee"
+"checksum supercow 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "171758edb47aa306a78dfa4ab9aeb5167405bd4e3dc2b64e88f6a84bbe98bd63"
 "checksum syn 0.11.11 (registry+https://github.com/rust-lang/crates.io-index)" = "d3b891b9015c88c576343b9b3e41c2c11a51c219ef067b264bd9c8aa9b441dad"
+"checksum syn 0.15.23 (registry+https://github.com/rust-lang/crates.io-index)" = "9545a6a093a3f0bd59adb472700acc08cad3776f860f16a897dfce8c88721cbc"
 "checksum synom 0.11.3 (registry+https://github.com/rust-lang/crates.io-index)" = "a393066ed9010ebaed60b9eafa373d4b1baac186dd7e008555b0f702b51945b6"
 "checksum typenum 1.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "612d636f949607bdf9b123b4a6f6d966dedf3ff669f7f045890d3a4a73948169"
 "checksum unicode-xid 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "8c1f860d7d29cf02cb2f3f359fd35991af3d30bac52c57d265a3c461074cb4dc"
+"checksum unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"
 "checksum winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "92c1eb33641e276cfa214a0522acad57be5c56b10cb348b3c5117db75f3ac4b0"
 "checksum winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 "checksum winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"

--- a/infrastructure/storage/Cargo.toml
+++ b/infrastructure/storage/Cargo.toml
@@ -1,5 +1,16 @@
 [package]
 name = "storage"
 version = "0.0.1"
+edition = "2018"
 
 [dependencies]
+bincode = "1.0.1"
+derive-error = "0.0.4"
+lmdb-zero = "0.4.4"
+rmp = "0.8.7"
+rmp-serde = "0.13.7"
+serde = "1.0.80"
+serde_derive = "1.0.80"
+
+[dev-dependencies]
+rand = "0.5.5"

--- a/infrastructure/storage/src/keyvalue_store.rs
+++ b/infrastructure/storage/src/keyvalue_store.rs
@@ -1,0 +1,101 @@
+//! An abstraction layer for persistent key-value storage. The Tari domain layer classes should only make use of
+//! these traits and objects and let the underlying implementations handle the details.
+
+use bincode::{deserialize, serialize, ErrorKind};
+use derive_error::Error;
+use serde::{de::DeserializeOwned, Serialize};
+use std::error::Error;
+
+#[derive(Debug, Error)]
+pub enum DatastoreError {
+    /// An error occurred with the underlying data store implementation
+    #[error(embedded_msg, no_from, non_std)]
+    InternalError(String),
+    /// An error occurred during serialization
+    #[error(no_from, non_std)]
+    SerializationErr(String),
+    /// An error occurred during deserialization
+    #[error(no_from, non_std)]
+    DeserializationErr(String),
+    /// Occurs when trying to perform an action that requires us to be in a live transaction
+    TransactionNotLiveError,
+    /// A transaction or query was attempted while no database was open.
+    DatabaseNotOpen,
+    /// A database with the requested name does not exist
+    UnknownDatabase,
+    /// An error occurred during a put query
+    #[error(embedded_msg, no_from, non_std)]
+    PutError(String),
+    /// An error occurred during a get query
+    #[error(embedded_msg, no_from, non_std)]
+    GetError(String),
+}
+
+impl From<bincode::Error> for DatastoreError {
+    fn from(e: Box<ErrorKind>) -> Self {
+        let msg = format!("Datastore conversion error: {}", e.description());
+        DatastoreError::DeserializationErr(msg)
+    }
+}
+
+/// General CRUD behaviour of KVStore implementations. Datastore is agnostic of the underlying implementation, but
+/// does assume that key-value pairs are stored using byte arrays (`&[u8]`). You can use `get_raw` or `put_raw` to
+/// read and write binary data directly, or use `#[derive(Serialize, Deserialize, PartialEq, Debug)]` on a trait to
+/// generate code for automatically de/serializing your data structures to byte strings using `bincode`.
+pub trait DataStore {
+    /// Connect to the logical database with `name`. If the Datastore does not support multiple logical databases,
+    /// this function has no effect
+    fn connect(&mut self, name: &str) -> Result<(), DatastoreError>;
+
+    /// Get the raw value at the given key, or None if the key does not exist
+    fn get_raw(&self, key: &[u8]) -> Result<Option<Vec<u8>>, DatastoreError>;
+
+    /// Retrieve a value from the store, deserialize it using bincode and return the value or None if the key does not
+    /// exist
+    fn get<T: DeserializeOwned>(&self, key: &str) -> Result<Option<T>, DatastoreError> {
+        let key = key.as_bytes();
+        let result = self.get_raw(key)?;
+        match result {
+            None => Ok(None),
+            Some(val) => Ok(Some(deserialize(&val[..])?)),
+        }
+    }
+
+    /// Check whether the given key exists in the database
+    fn exists(&self, key: &[u8]) -> Result<bool, DatastoreError>;
+
+    /// Save a value at the given key. Existing values are overwritten
+    fn put_raw(&mut self, key: &[u8], value: Vec<u8>) -> Result<(), DatastoreError>;
+
+    /// Serialize a value using Bincode and then save it value at the given key. Existing values are overwritten
+    fn put<T: Serialize>(&mut self, key: &str, value: &T) -> Result<(), DatastoreError> {
+        let key = key.as_bytes();
+        let val = serialize(value)?;
+        self.put_raw(key, val)
+    }
+}
+
+/// BatchWrite is implemented on Datastores if it supports batch writes, or transactions, to efficiently write
+/// multiple puts to the Datastore.
+pub trait BatchWrite {
+    type Store: DataStore;
+    type Batcher: BatchWrite + Sized;
+
+    fn new(store: &Self::Store) -> Result<Self::Batcher, DatastoreError>;
+
+    /// Save a value at the given key. Existing values are overwritten
+    fn put_raw(&mut self, key: &[u8], value: Vec<u8>) -> Result<(), DatastoreError>;
+
+    /// Serialize a value and then save it value at the given key. Existing values are overwritten
+    fn put<T: Serialize>(&mut self, key: &str, value: &T) -> Result<(), DatastoreError> {
+        let key = key.as_bytes();
+        let val = serialize(value)?;
+        self.put_raw(key, val)
+    }
+
+    /// Commit all puts in the batch write to the database
+    fn commit(self) -> Result<(), DatastoreError>;
+
+    /// Discard all puts that have been made in this batch
+    fn abort(self) -> Result<(), DatastoreError>;
+}

--- a/infrastructure/storage/src/lib.rs
+++ b/infrastructure/storage/src/lib.rs
@@ -1,1 +1,5 @@
+#[macro_use]
+extern crate serde_derive;
 
+pub mod keyvalue_store;
+pub mod lmdb;

--- a/infrastructure/storage/src/lmdb.rs
+++ b/infrastructure/storage/src/lmdb.rs
@@ -1,0 +1,382 @@
+//! An implementation of [KVStore](trait.KVStore.html) using [LMDB](http://www.lmdb.tech)
+
+use crate::keyvalue_store::{BatchWrite, DataStore, DatastoreError};
+use lmdb_zero as lmdb;
+use lmdb_zero::error::LmdbResultExt;
+use std::{collections::HashMap, sync::Arc};
+
+/// A builder for [LMDBStore](struct.lmdbstore.html)
+/// ## Example
+///
+/// Create a new LMDB database of 500MB in the `db` directory with two named databases: "db1" and "db2"
+///
+/// ```
+/// # use crate::storage::lmdb::LMDBBuilder;
+/// let mut store =
+///     LMDBBuilder::new().set_path("/tmp/").set_mapsize(500).add_database("db1").add_database("db2").build().unwrap();
+/// ```
+pub struct LMDBBuilder {
+    path: String,
+    db_size_mb: usize,
+    db_names: Vec<String>,
+}
+
+impl LMDBBuilder {
+    /// Create a new LMDBStore builder. Set up the database by calling `set_nnnn` and then create the database
+    /// with `build()`. The default values for the database parameters are:
+    ///
+    /// | Parameter | Default |
+    /// |:----------|---------|
+    /// | path      | ./store/|
+    /// | size      | 64 MB   |
+    /// | named DBs | none    |
+    pub fn new() -> LMDBBuilder {
+        LMDBBuilder { path: "./store/".into(), db_size_mb: 64, db_names: Vec::new() }
+    }
+
+    /// Set the directory where the LMDB database exists, or must be created.
+    /// Note: The directory must exist already; it is not created for you. If it does not exist, `build()` will
+    /// return `DataStoreError::InternalError`.
+    /// the `path` must have a trailing slash
+    pub fn set_path(mut self, path: &str) -> LMDBBuilder {
+        self.path = path.into();
+        self
+    }
+
+    /// Sets the size of the database, in MB.
+    /// The actual memory will only be allocated when #build() is called
+    pub fn set_mapsize(mut self, size: usize) -> LMDBBuilder {
+        self.db_size_mb = size;
+        self
+    }
+
+    /// Add an additional named database to the LMDB environment.If `add_database` isn't called at least once, only the
+    /// `default` database is created.
+    pub fn add_database(mut self, name: &str) -> LMDBBuilder {
+        // There will always be a 'default' database
+        if name != "default" {
+            self.db_names.push(name.into());
+        }
+        self
+    }
+
+    /// Create a new LMDBStore instance and open the underlying database environment
+    pub fn build(self) -> Result<LMDBStore, DatastoreError> {
+        let env = unsafe {
+            let mut builder = lmdb::EnvBuilder::new()?;
+            builder.set_mapsize(self.db_size_mb * 1024 * 1024)?;
+            builder.set_maxdbs(self.db_names.len() as u32 + 1)?;
+            builder.open(&self.path, lmdb::open::Flags::empty(), 0o600)?
+        };
+        let env = Arc::new(env);
+        let mut databases: HashMap<String, Arc<lmdb::Database<'static>>> = HashMap::new();
+        let opt = lmdb::DatabaseOptions::new(lmdb::db::CREATE);
+        // Add the default db
+        let default = Arc::new(lmdb::Database::open(env.clone(), None, &opt)?);
+        let curr_db = default.clone();
+        databases.insert("default".to_string(), default);
+        for name in &self.db_names {
+            let db = Arc::new(lmdb::Database::open(env.clone(), Some(name), &opt)?);
+            databases.insert(name.to_string(), db);
+        }
+        Ok(LMDBStore { env, databases, curr_db })
+    }
+}
+
+/// A Struct for holding state for the LMDB implementation of DataStore and BatchWrite. To create an instance of
+/// LMDBStore, use [LMDBBuilder](struct.lmdbbuilder.html).
+pub struct LMDBStore {
+    pub(crate) env: Arc<lmdb::Environment>,
+    pub(crate) databases: HashMap<String, Arc<lmdb::Database<'static>>>,
+    pub(crate) curr_db: Arc<lmdb::Database<'static>>,
+}
+
+impl DataStore for LMDBStore {
+    fn connect(&mut self, name: &str) -> Result<(), DatastoreError> {
+        match self.databases.get(name) {
+            Some(db) => {
+                self.curr_db = db.clone();
+                Ok(())
+            },
+            None => Err(DatastoreError::UnknownDatabase),
+        }
+    }
+
+    fn get_raw(&self, key: &[u8]) -> Result<Option<Vec<u8>>, DatastoreError> {
+        let txn = lmdb::ReadTransaction::new(self.env.clone())?;
+        let accessor = txn.access();
+        match accessor.get::<[u8], [u8]>(&self.curr_db, key).to_opt() {
+            Ok(None) => Ok(None),
+            Ok(Some(v)) => Ok(Some(v.to_vec())),
+            Err(e) => Err(DatastoreError::GetError(format!("LMDB get error: {}", e.to_string()))),
+        }
+    }
+
+    fn exists(&self, key: &[u8]) -> Result<bool, DatastoreError> {
+        let txn = lmdb::ReadTransaction::new(self.env.clone())?;
+        let accessor = txn.access();
+        let res: lmdb::error::Result<&lmdb::Ignore> = accessor.get(&self.curr_db, key);
+        Ok(res.to_opt()?.is_some())
+    }
+
+    fn put_raw(&mut self, key: &[u8], value: Vec<u8>) -> Result<(), DatastoreError> {
+        let tx = lmdb::WriteTransaction::new(self.env.clone())?;
+        {
+            let mut accessor = tx.access();
+            accessor.put(&self.curr_db, key, &value, lmdb::put::Flags::empty())?;
+        }
+        tx.commit().map_err(|e| e.into())
+    }
+}
+
+struct LMDBBatch<'a> {
+    db: Arc<lmdb::Database<'static>>,
+    tx: lmdb::WriteTransaction<'a>,
+}
+
+impl<'a> BatchWrite for LMDBBatch<'a> {
+    type Batcher = LMDBBatch<'a>;
+    type Store = LMDBStore;
+
+    fn new(store: &LMDBStore) -> Result<LMDBBatch<'a>, DatastoreError> {
+        Ok(LMDBBatch { db: store.curr_db.clone(), tx: lmdb::WriteTransaction::new(store.env.clone())? })
+    }
+
+    fn put_raw(&mut self, key: &[u8], value: Vec<u8>) -> Result<(), DatastoreError> {
+        {
+            let mut accessor = self.tx.access();
+            accessor.put(&self.db, key, &value, lmdb::put::Flags::empty())?;
+        }
+        Ok(())
+    }
+
+    fn commit(self) -> Result<(), DatastoreError> {
+        self.tx.commit().map_err(|e| e.into())
+    }
+
+    fn abort(self) -> Result<(), DatastoreError> {
+        Ok(())
+    }
+}
+
+impl From<lmdb::error::Error> for DatastoreError {
+    fn from(err: lmdb::error::Error) -> Self {
+        let err_msg = format!("LMDB Error: {}", err.to_string());
+        DatastoreError::InternalError(err_msg)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::{LMDBBuilder, LMDBStore};
+    use crate::{
+        keyvalue_store::{BatchWrite, DataStore, DatastoreError},
+        lmdb::LMDBBatch,
+    };
+    use bincode::{deserialize, serialize};
+    use rand::{OsRng, RngCore};
+    use std::{fs, str};
+
+    #[derive(Serialize, Deserialize, PartialEq, Debug)]
+    struct Entity {
+        x: f32,
+        y: f32,
+    }
+
+    #[derive(Serialize, Deserialize, PartialEq, Debug)]
+    struct World(Vec<Entity>);
+
+    fn to_bytes(i: u32) -> Vec<u8> {
+        i.to_le_bytes().to_vec()
+    }
+
+    fn from_bytes(v: &[u8]) -> u32 {
+        u32::from_le_bytes([v[0], v[1], v[2], v[3]])
+    }
+
+    fn make_vector(len: usize) -> Vec<u8> {
+        let mut vec = vec![0; len];
+        let mut rng = OsRng::new().unwrap();
+        rng.fill_bytes(&mut vec);
+        vec
+    }
+
+    #[test]
+    fn path_must_exist() {
+        let builder = LMDBBuilder::new();
+        match builder.set_mapsize(1).set_path("./tests/not_here/").build() {
+            Err(DatastoreError::InternalError(s)) => assert_eq!(s, "LMDB Error: No such file or directory"),
+            _ => panic!(),
+        }
+    }
+
+    #[test]
+    fn batch_writes() {
+        fs::create_dir("./tests/test_tx").unwrap();
+        let builder = LMDBBuilder::new();
+        let store = builder.set_mapsize(5).set_path("./tests/test_tx/").build().unwrap();
+        let mut batch = LMDBBatch::new(&store).unwrap();
+        batch.put_raw(b"a", b"apple".to_vec()).unwrap();
+        batch.put_raw(b"b", b"banana".to_vec()).unwrap();
+        batch.put_raw(b"c", b"carrot".to_vec()).unwrap();
+        batch.commit().unwrap();
+        let banana = store.get_raw(b"b").unwrap().unwrap();
+        assert_eq!(&banana, b"banana");
+        assert!(fs::remove_dir_all("./tests/test_tx").is_ok());
+    }
+
+    #[test]
+    fn writes_to_default_db() {
+        fs::create_dir("./tests/test_default").unwrap();
+        let mut store = LMDBBuilder::new().set_path("./tests/test_default/").build().unwrap();
+        store.connect("default").unwrap();
+        // Write some values
+        store.put_raw(b"England", b"rose".to_vec()).unwrap();
+        store.put_raw(b"SouthAfrica", b"protea".to_vec()).unwrap();
+        store.put_raw(b"Scotland", b"thistle".to_vec()).unwrap();
+        // And read them back
+        let val = store.get_raw(b"Scotland").unwrap().unwrap();
+        assert_eq!(str::from_utf8(&val).unwrap(), "thistle");
+        let val = store.get_raw(b"England").unwrap().unwrap();
+        assert_eq!(str::from_utf8(&val).unwrap(), "rose");
+        // Clean up
+        assert!(fs::remove_dir_all("./tests/test_default").is_ok());
+    }
+
+    #[test]
+    fn aborts_write() {
+        fs::create_dir("./tests/test_abort").unwrap();
+        let mut store = LMDBBuilder::new().set_path("./tests/test_abort/").build().unwrap();
+        store.connect("default").unwrap();
+        // Write some values
+        let mut batch = LMDBBatch::new(&store).unwrap();
+        batch.put_raw(b"England", b"rose".to_vec()).unwrap();
+        batch.put_raw(b"SouthAfrica", b"protea".to_vec()).unwrap();
+        batch.put_raw(b"Scotland", b"thistle".to_vec()).unwrap();
+        batch.abort().unwrap();
+        // And check nothing was written
+        let check = |k: &[u8], store: &LMDBStore| {
+            let val = store.get_raw(k).unwrap();
+            assert!(val.is_none());
+        };
+        check(b"Scotland", &store);
+        check(b"SouthAfrica", &store);
+        check(b"England", &store);
+        // Clean up
+        assert!(fs::remove_dir_all("./tests/test_abort").is_ok());
+    }
+
+    /// Set the DB size to 1MB and write more than a MB to it
+    #[test]
+    fn overflow_db() {
+        fs::create_dir("./tests/test_overflow").unwrap();
+        let builder = LMDBBuilder::new();
+        let mut store = builder
+            .set_path("./tests/test_overflow/")
+            // Set the max DB size to 1MB
+            .set_mapsize(1)
+            .build()
+            .unwrap();
+        assert!(store.connect("default").is_ok());
+        // Write 500,000 bytes
+        store.put_raw(b"key", make_vector(500_000)).unwrap();
+        // Try write another 600,000 bytes and watch it fail
+        match store.put_raw(b"key2", make_vector(600_000)).unwrap_err() {
+            DatastoreError::InternalError(s) => {
+                assert_eq!(s, "LMDB Error: MDB_MAP_FULL: Environment mapsize limit reached");
+            },
+            err => {
+                println!("{:?}", err);
+                assert!(fs::remove_dir_all("./tests/test_overflow").is_ok());
+                panic!()
+            },
+        }
+        assert!(fs::remove_dir_all("./tests/test_overflow").is_ok());
+    }
+
+    #[test]
+    fn read_and_write_10k_values() {
+        fs::create_dir("./tests/test_10k").unwrap();
+        let builder = LMDBBuilder::new();
+        let mut store = builder.set_path("./tests/test_10k/").add_database("test").build().unwrap();
+        assert!(store.connect("test").is_ok());
+        // Write 100,000 integers to the DB with val = 2*key
+        let mut batch = LMDBBatch::new(&store).unwrap();
+        for i in 0u32..10_000 {
+            batch.put_raw(&to_bytes(i), to_bytes(2 * i)).unwrap();
+        }
+        batch.commit().unwrap();
+        // And read them back
+        for i in 0u32..10_000 {
+            let val = store.get_raw(&to_bytes(i)).unwrap().unwrap();
+            assert_eq!(from_bytes(&val), i * 2);
+        }
+        assert!(fs::remove_dir_all("./tests/test_10k").is_ok());
+    }
+
+    #[test]
+    fn test_exist_on_different_databases() {
+        fs::create_dir("./tests/test_exist").unwrap();
+        let mut store =
+            LMDBBuilder::new().set_path("./tests/test_exist/").add_database("db1").add_database("db2").build().unwrap();
+        store.connect("db1").unwrap();
+        // Write some values
+        store.put_raw(b"db1-a", b"val1".to_vec()).unwrap();
+        store.put_raw(b"db1-b", b"val2".to_vec()).unwrap();
+        store.put_raw(b"common", b"db1".to_vec()).unwrap();
+        // Change databases
+        store.connect("db2").unwrap();
+        store.put_raw(b"db2-a", b"val3".to_vec()).unwrap();
+        store.put_raw(b"db2-b", b"val4".to_vec()).unwrap();
+        store.put_raw(b"common", b"db2".to_vec()).unwrap();
+        // Check existence and non-existence of keys
+        assert!(!store.exists(b"db1-a").unwrap());
+        assert!(!store.exists(b"db1-b").unwrap());
+        assert!(store.exists(b"db2-a").unwrap());
+        assert!(store.exists(b"db2-b").unwrap());
+        assert!(store.exists(b"common").unwrap());
+        // Change back to db1
+        store.connect("db1").unwrap();
+        // Check existence and non-existence of keys
+        assert!(store.exists(b"db1-a").unwrap());
+        assert!(store.exists(b"db1-b").unwrap());
+        assert!(!store.exists(b"db2-a").unwrap());
+        assert!(!store.exists(b"db2-b").unwrap());
+        assert!(store.exists(b"common").unwrap());
+        // Finally check the value of 'common'
+        let val = store.get_raw(b"common").unwrap().unwrap();
+        assert_eq!(&val, b"db1");
+        // Clean up
+        assert!(fs::remove_dir_all("./tests/test_exist").is_ok());
+    }
+
+    #[test]
+    fn write_structs() {
+        fs::create_dir("./tests/test_struct").unwrap();
+        let builder = LMDBBuilder::new();
+        let mut store = builder.set_path("./tests/test_struct/").build().unwrap();
+        let world = World(vec![Entity { x: 0.0, y: 4.0 }, Entity { x: 10.0, y: 20.5 }]);
+        let encoded: Vec<u8> = serialize(&world).unwrap();
+        // 8 bytes for the length of the vector, 4 bytes per float.
+        assert_eq!(encoded.len(), 8 + 4 * 4);
+        store.put_raw(b"world", encoded).unwrap();
+        // Write using `put`
+        let world_2 = World(vec![Entity { x: 100.0, y: -123.45 }, Entity { x: 42.0, y: -42.0 }]);
+        store.put("brave new world", &world_2).unwrap();
+        // Get world back using get_raw
+        let val = store.get_raw(b"world").unwrap().unwrap();
+        let decoded: World = deserialize(&val[..]).unwrap();
+        assert_eq!(world, decoded);
+        // Get world2 back using get_raw
+        let val = store.get_raw(b"brave new world").unwrap().unwrap();
+        let decoded: World = deserialize(&val[..]).unwrap();
+        assert_eq!(world_2, decoded);
+        // Get world_2 back using get
+        let val = store.get("brave new world").unwrap().unwrap();
+        assert_eq!(world_2, val);
+        // And check that get returns None
+        let val = store.get::<World>("not here").unwrap();
+        assert!(val.is_none());
+        assert!(fs::remove_dir_all("./tests/test_struct").is_ok());
+    }
+}


### PR DESCRIPTION
This PR
 * [ ] fixes issue #nnn
 * [X] adds a new feature
 * [ ] refactors a feature
 * [ ] adds new tests
 * [ ] adds cosmetic changes (typos, formatting)
 * [ ] Other: (...)

# Reminders checklist
* [x] Merging against the `development` branch
* [x] Ran `cargo-fmt --all` before pushing

# Description

This PR adds a `DataStore` trait that represents a generic key-value storage mechanism. As proof of concept, an LMDB implementation is also included


