### PR TITLE
Build RFCs off development branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,4 +39,4 @@ deploy:
   keep-history: false
   target-branch: gh-pages
   on:
-    branch: master
+    branch: development


### PR DESCRIPTION
This PR
 * [x] fixes issue: RFCs not building

# Reminders checklist
* [x] Merging against the `development` branch
* [ ] Ran `cargo-fmt --all` before pushing

# Description

Travis should build RFC docs off `development` rather than master now that we've moved to git-flow development.

