### PR TITLE
Fix doc generation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,10 +19,10 @@ before_script:
 matrix:
   fast_finish: true
   include:
-    # Only generate docs when on the master branch
+    # Only generate docs when on the development branch
     - stage: docs
-      if: branch = master
-      name: RFC docs
+      if: branch = development
+      name: RFC documentation
       script: cd RFC && mdbook test && mdbook build
     - stage: build
       name: Tari source code


### PR DESCRIPTION
Align RFC deployment to github pages with RFC doc generation, by making both tasks run off develoment branch

This PR
 * [X] fixes issue

# Reminders checklist
* [x] Merging against the `development` branch
* [x] Ran `cargo-fmt --all` before pushing

# Description

Align RFC deployment to github pages with RFC doc generation, by making both tasks run off develoment branch

