### PR TITLE
make the PR and issue template a bit more ergonomic

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -6,7 +6,6 @@ labels: 'bug-report'
 assignees: ''
 
 ---
-# [TITLE]
 
 **Describe the bug**
 A clear and concise description of what the bug is.

--- a/.github/ISSUE_TEMPLATE/new_proposal.md
+++ b/.github/ISSUE_TEMPLATE/new_proposal.md
@@ -7,10 +7,6 @@ assignees: ''
 
 ---
 
-# [TITLE]
-
-## Metadata
-
 This proposal is (tick applicable):
 
 * [ ] A new feature

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,18 +1,30 @@
-# [TITLE]
+<!--- Provide a general summary of your changes in the Title above -->
 
-This PR
- * [ ] fixes issue #nnn
- * [ ] adds a new feature
- * [ ] refactors a feature
- * [ ] adds new tests
- * [ ] adds cosmetic changes (typos, formatting)
- * [ ] Other: (...)
+## Description
+<!--- Describe your changes in detail -->
 
-# Reminders checklist
-* [ ] Merging against the `development` branch
-* [ ] Ran `cargo-fmt --all` before pushing
+## Motivation and Context
+<!--- Why is this change required? What problem does it solve? -->
+<!--- If it fixes an open issue, please link to the issue here. -->
 
-# Description
+## How Has This Been Tested?
+<!--- Please describe in detail how you tested your changes. -->
+<!--- Include details of your testing environment, and the tests you ran to -->
+<!--- see how your change affects other areas of the code, etc. -->
 
-Describe briefly what this PR does
+## Types of changes
+<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
+* [ ] Bug fix (non-breaking change which fixes an issue)
+* [ ] New feature (non-breaking change which adds functionality)
+* [ ] Breaking change (fix or feature that would cause existing functionality to change)
+* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
+* [ ] New Tests
+* [ ] Documentation
 
+## Checklist:
+<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
+* [ ] I'm merging against the `development` branch
+* [ ] I ran `cargo-fmt --all` before pushing
+* [ ] My change requires a change to the documentation.
+* [ ] I have updated the documentation accordingly.
+* [ ] I have added tests to cover my changes.


### PR DESCRIPTION
This PR
changes this template

# Description

The current templates look fine for issues; for PRs, they're a bit clunky. 
The proposed changes put comments in HTML comments (so no need to delete them); reorders sections to prioritise the description; and modifies checklists to better represent use cases.
