### PR TITLE
travis: move deploy job into docs stage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,19 +24,16 @@ matrix:
       if: branch = development
       name: RFC documentation
       script: cd RFC && mdbook test && mdbook build
+      # Deploy RFC docs for github pages
+      deploy:
+        provider: pages
+        skip-cleanup: true
+        github-token: $GITHUB_TOKEN
+        local-dir: book
+        keep-history: false
+        target-branch: gh-pages
     - stage: build
       name: Tari source code
       script:
         - cargo fmt --all -- --check
         - cargo test --all
-
-# Deploy RFC docs for github pages
-deploy:
-  provider: pages
-  skip-cleanup: true
-  github-token: $GITHUB_TOKEN
-  local-dir: book
-  keep-history: false
-  target-branch: gh-pages
-  on:
-    branch: development


### PR DESCRIPTION
This PR
 * [x] fixes issue: RFC docs aren't being built

# Reminders checklist
* [x] Merging against the `development` branch
* [x] Ran `cargo-fmt --all` before pushing

# Description

Moving `deploy` section into `docs` stage so that it doesn't run for normal tests and break the docs build

