### PR TITLE
Make RFC code highlight text colour lighter for readability

### DIFF
--- a/RFC/src/theme/css/variables.css
+++ b/RFC/src/theme/css/variables.css
@@ -67,7 +67,7 @@ background:#f9f9f9;
 
     --links: #4183c4;
 
-    --inline-code-color: #6e6b5e;
+    --inline-code-color: #c4c2ba;
 
     --theme-popup-bg: #fafafa;
     --theme-popup-border: #cccccc;


### PR DESCRIPTION
Quick CSS update for the RFC mdbook theme to improve code highlighting readability

## Description
Updated the styling

## Motivation and Context
It was hard to read

## How Has This Been Tested?
just a CSS change

## Types of changes
* [ ] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [x] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch
* [ ] I ran `cargo-fmt --all` before pushing
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
