### PR TITLE
Circle CI config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,66 @@
+version: 2
+
+defaults:
+  rust_base_image: &rust_base_image rust:1.32
+
+jobs:
+  test-docs:
+    docker:
+      - image: *rust_base_image
+    steps:
+      - checkout
+      - run:
+          name: RFC documentation
+          command: |
+            (test -x $HOME/.cargo/bin/mdbook || cargo install --vers "^0.2" mdbook)
+            cd RFC && mdbook test && mdbook build
+
+      - persist_to_workspace:
+          root: .
+          paths: book
+
+  deploy-docs:
+    docker:
+      - image: node:8.10.0
+    steps:
+      - checkout
+      - attach_workspace:
+          at: book
+      - run:
+          name: Install and configure dependencies
+          command: |
+            npm install -g --silent gh-pages@2.0.1
+            git config user.email "ci-build@klukas.net"
+            git config user.name "ci-build"
+      - run:
+          name: Deploy docs to gh-pages branch
+          command: gh-pages --dist book
+
+  test-tari:
+    docker:
+      - image: *rust_base_image
+    steps:
+      - checkout
+      - run:
+          name: Tari source code
+          command: |
+            # https://mexus.github.io/rustup-components-history/x86_64-unknown-linux-gnu.html
+            rustup update nightly-2019-02-13
+            rustup default nightly-2019-02-13
+            rustup component add --toolchain nightly-2019-02-13 rustfmt
+            cargo fmt --all -- --check
+            cargo test --all
+
+workflows:
+  version: 2
+  workflow:
+    jobs:
+      - test-docs
+      - test-tari
+      - deploy-docs:
+          requires:
+            - test-docs
+          filters:
+            branches:
+              only: development
+

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,12 +1,12 @@
 version: 2
 
 defaults:
-  rust_base_image: &rust_base_image rust:1.32
+  rust_image: &rust_image rust:1.32
 
 jobs:
   test-docs:
     docker:
-      - image: *rust_base_image
+      - image: *rust_image
     steps:
       - checkout
       - run:
@@ -38,7 +38,7 @@ jobs:
 
   test-tari:
     docker:
-      - image: *rust_base_image
+      - image: *rust_image
     steps:
       - checkout
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,6 +32,9 @@ jobs:
             npm install -g --silent gh-pages@2.0.1
             git config user.email "ci-build@tari.com"
             git config user.name "ci-build"
+      - add_ssh_keys:
+          fingerprints:
+            - "a6:a6:e2:be:a3:94:3e:4c:9d:51:25:f6:98:f9:0c:a4"
       - run:
           name: Deploy docs to gh-pages branch
           command: gh-pages --dist book

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,7 +30,7 @@ jobs:
           name: Install and configure dependencies
           command: |
             npm install -g --silent gh-pages@2.0.1
-            git config user.email "ci-build@klukas.net"
+            git config user.email "ci-build@tari.com"
             git config user.name "ci-build"
       - run:
           name: Deploy docs to gh-pages branch

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,10 @@ rust:
 
 before_install:
   - export PATH="$PATH:$HOME/.cargo/bin"
-  - rustup component add rustfmt
+  # https://mexus.github.io/rustup-components-history/x86_64-unknown-linux-gnu.html
+  - rustup update nightly-2019-02-13
+  - rustup default nightly-2019-02-13
+  - rustup component add --toolchain nightly-2019-02-13 rustfmt
 
 before_script:
   - (test -x $HOME/.cargo/bin/cargo-install-update || cargo install cargo-update)


### PR DESCRIPTION
## Description
Added circle CI config which mirrors the current `travis.yml`.

## Motivation and Context
We have more control over the build environment with Circle CI.
To deploy GitHub pages a deploy key with write access needs to be added to Circle CI (private key in pem format) and to GitHub (public key).

`ssh-keygen -m pem -t rsa -b 4096 -C "my@email.address"`

The key fingerprint must be added as a step before ghpages deploy as follows

```yaml
 - add_ssh_keys:
          fingerprints:
            - "SO:ME:FIN:G:ER:PR:IN:T"
```

More Info:
https://circleci.com/blog/deploying-documentation-to-github-pages-with-continuous-integration/ 
https://circleci.com/docs/2.0/add-ssh-key/

## How Has This Been Tested?
I tested by activating Circle CI on my fork. https://circleci.com/gh/sdbondi/tari/44 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch
* [ ] I ran `cargo-fmt --all` before pushing
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
