### PR TITLE
Implement basic transaction components

### DIFF
--- a/base_layer/blockchain/src/chain.rs
+++ b/base_layer/blockchain/src/chain.rs
@@ -44,7 +44,7 @@ impl Chain {
         Chain { store: dbstore, blockchainstate: BlockchainState::new(), orphans: HashMap::new(), pruning_horizon }
     }
 
-    pub fn process_new_block(&self, new_block: &Block) -> Result<(), ChainError> {
+    pub fn process_new_block(&self, _new_block: &Block) -> Result<(), ChainError> {
         Ok(())
     }
 }

--- a/base_layer/core/Cargo.toml
+++ b/base_layer/core/Cargo.toml
@@ -8,3 +8,6 @@ bitflags = "1.0.4"
 chrono = "0.4.6"
 digest = "0.8.0"
 crypto = { path = "../../infrastructure/crypto"}
+curve25519-dalek = "1.0.2"
+derive-error = "0.0.4"
+rand = "0.5.5"

--- a/base_layer/core/src/block.rs
+++ b/base_layer/core/src/block.rs
@@ -44,3 +44,68 @@ pub struct AggregateBody {
     /// Kernels contain the excesses and their signatures for transaction
     pub kernels: Vec<TransactionKernel>,
 }
+
+impl AggregateBody {
+    /// Create an empty aggregate body
+    pub fn empty() -> AggregateBody {
+        AggregateBody { inputs: vec![], outputs: vec![], kernels: vec![] }
+    }
+
+    /// Create a new aggregate body from provided inputs, outputs and kernels
+    pub fn new(
+        inputs: Vec<TransactionInput>,
+        outputs: Vec<TransactionOutput>,
+        kernels: Vec<TransactionKernel>,
+    ) -> AggregateBody
+    {
+        AggregateBody { inputs, outputs, kernels }
+    }
+
+    /// Add an input to the existing aggregate body
+    pub fn add_input(mut self, input: TransactionInput) -> AggregateBody {
+        self.inputs.push(input);
+        self.inputs.sort();
+        self
+    }
+
+    /// Add a series of inputs to the existing aggregate body
+    pub fn add_inputs(mut self, mut inputs: Vec<TransactionInput>) -> AggregateBody {
+        self.inputs.append(&mut inputs);
+        self.inputs.sort();
+        self
+    }
+
+    /// Add an output to the existing aggregate body
+    pub fn add_output(mut self, output: TransactionOutput) -> AggregateBody {
+        self.outputs.push(output);
+        self.outputs.sort();
+        self
+    }
+
+    /// Add an output to the existing aggregate body
+    pub fn add_outputs(mut self, mut outputs: Vec<TransactionOutput>) -> AggregateBody {
+        self.outputs.append(&mut outputs);
+        self.outputs.sort();
+        self
+    }
+
+    /// Add a kernel to the existing aggregate body
+    pub fn add_kernel(mut self, kernel: TransactionKernel) -> AggregateBody {
+        self.kernels.push(kernel);
+        self.kernels.sort();
+        self
+    }
+
+    /// Set the kernel of the aggregate body, replacing any previous kernels
+    pub fn set_kernel(mut self, kernel: TransactionKernel) -> AggregateBody {
+        self.kernels = vec![kernel];
+        self
+    }
+
+    /// Sort the component lists of the aggregate body
+    pub fn sort(&mut self) {
+        self.inputs.sort();
+        self.outputs.sort();
+        self.kernels.sort();
+    }
+}

--- a/base_layer/core/src/blockheader.rs
+++ b/base_layer/core/src/blockheader.rs
@@ -23,7 +23,7 @@
 // Portions of this file were originally copyrighted (c) 2018 The Grin Developers, issued under the Apache License,
 // Version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0.
 
-use crate::{pow::ProofOfWork, transaction::BlindingFactor};
+use crate::{pow::ProofOfWork, types::BlindingFactor};
 use chrono::{DateTime, Utc};
 
 type BlockHash = [u8; 32];

--- a/base_layer/core/src/range_proof.rs
+++ b/base_layer/core/src/range_proof.rs
@@ -26,6 +26,6 @@
 const RANGE_PROOF_LENGTH: usize = 1; // This will be changed
 
 #[derive(Debug, Clone)]
-pub struct RangeProof([u8; RANGE_PROOF_LENGTH]);
+pub struct RangeProof(pub [u8; RANGE_PROOF_LENGTH]);
 
 impl Copy for RangeProof {}

--- a/base_layer/core/src/transaction.rs
+++ b/base_layer/core/src/transaction.rs
@@ -24,9 +24,20 @@
 // Version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0.
 
 use crate::{
+    block::AggregateBody,
     range_proof::RangeProof,
-    types::{Commitment, Signature},
+    types::{Base, BlindingFactor, Commitment, Signature},
 };
+
+use crypto::{
+    commitment::HomomorphicCommitment,
+    common::{Blake256, ByteArray},
+    hash::Hashable,
+};
+use curve25519_dalek::scalar::Scalar;
+use derive_error::Error;
+use digest::Digest;
+use std::cmp::Ordering;
 
 bitflags! {
     /// Options for a kernel's structure or use.
@@ -44,6 +55,34 @@ bitflags! {
     }
 }
 
+/// This macro implements the Ord, PartialOrd, PartialEq and Eq traits for the Hashable struct passed in
+macro_rules! hashable_ord {
+    ($hashable:ident) => {
+        impl Ord for $hashable {
+            fn cmp(&self, other: &$hashable) -> Ordering {
+                self.hash().cmp(&other.hash())
+            }
+        }
+        impl PartialOrd for $hashable {
+            fn partial_cmp(&self, other: &$hashable) -> Option<Ordering> {
+                Some(self.cmp(other))
+            }
+        }
+        impl PartialEq for $hashable {
+            fn eq(&self, other: &$hashable) -> bool {
+                self.hash() == other.hash()
+            }
+        }
+        impl Eq for $hashable {}
+    };
+}
+
+#[derive(Debug, PartialEq, Error)]
+pub enum TransactionError {
+    // Error validating the transaction
+    ValidationError,
+}
+
 /// A transaction input.
 ///
 /// Primarily a reference to an output being spent by the transaction.
@@ -51,9 +90,36 @@ bitflags! {
 pub struct TransactionInput {
     /// The features of the output being spent. We will check maturity for coinbase output.
     pub features: OutputFeatures,
-    /// The commit referencing the output being spent.
-    pub commit: Commitment,
+    /// The commitment referencing the output being spent.
+    pub commitment: Commitment,
 }
+
+/// An input for a transaction that spends an existing output
+impl TransactionInput {
+    /// Create a new Transaction Input
+    pub fn new(features: OutputFeatures, commitment: Commitment) -> TransactionInput {
+        TransactionInput { features, commitment }
+    }
+
+    /// Accessor method for the commitment contained in an input
+    pub fn commitment(&self) -> Commitment {
+        self.commitment
+    }
+}
+
+/// Implement the canonical hashing function for TransactionInput for use in ordering
+impl Hashable for TransactionInput {
+    type Hasher = Blake256;
+
+    fn hash(&self) -> Vec<u8> {
+        let mut hasher = Self::Hasher::new();
+        hasher.input(vec![self.features.bits]);
+        hasher.input(self.commitment.to_bytes());
+        hasher.result().to_vec()
+    }
+}
+
+hashable_ord!(TransactionInput);
 
 /// Output for a transaction, defining the new ownership of coins that are being transferred. The commitment is a
 /// blinded value for the output while the range proof guarantees the commitment includes a positive value without
@@ -63,16 +129,50 @@ pub struct TransactionOutput {
     /// Options for an output's structure or use
     pub features: OutputFeatures,
     /// The homomorphic commitment representing the output amount
-    pub commit: Commitment,
+    pub commitment: Commitment,
     /// A proof that the commitment is in the right range
     pub proof: RangeProof,
 }
+
+/// An output for a transaction, includes a rangeproof
+impl TransactionOutput {
+    /// Create new Transaction Output
+    pub fn new(features: OutputFeatures, commitment: Commitment, proof: RangeProof) -> TransactionOutput {
+        TransactionOutput { features, commitment, proof }
+    }
+
+    /// Accessor method for the commitment contained in an output
+    pub fn commitment(&self) -> Commitment {
+        self.commitment
+    }
+
+    /// Accessor method for the range proof contained in an output
+    pub fn proof(&self) -> RangeProof {
+        self.proof
+    }
+}
+
+/// Implement the canonical hashing function for TransactionOutput for use in ordering
+impl Hashable for TransactionOutput {
+    type Hasher = Blake256;
+
+    fn hash(&self) -> Vec<u8> {
+        let mut hasher = Self::Hasher::new();
+        hasher.input(vec![self.features.bits]);
+        hasher.input(self.commitment.to_bytes());
+        hasher.input(self.proof.0);
+        hasher.result().to_vec()
+    }
+}
+
+hashable_ord!(TransactionOutput);
 
 /// The transaction kernel tracks the excess for a given transaction. For an explanation of what the excess is, and
 /// why it is necessary, refer to the
 /// [Mimblewimble TLU post](https://tlu.tarilabs.com/protocols/mimblewimble-1/sources/PITCHME.link.html?highlight=mimblewimble#mimblewimble).
 /// The kernel also tracks other transaction metadata, such as the lock height for the transaction (i.e. the earliest
 /// this transaction can be mined) and the transaction fee, in cleartext.
+#[derive(Debug, Clone)]
 pub struct TransactionKernel {
     /// Options for a kernel's structure or use
     pub features: KernelFeatures,
@@ -84,10 +184,122 @@ pub struct TransactionKernel {
     /// Remainder of the sum of all transaction commitments. If the transaction
     /// is well formed, amounts components should sum to zero and the excess
     /// is hence a valid public key.
-    pub excess: Commitment,
+    pub excess: Option<Commitment>,
     /// The signature proving the excess is a valid public key, which signs
     /// the transaction fee.
-    pub excess_sig: Signature,
+    pub excess_sig: Option<Signature>,
 }
 
-pub type BlindingFactor = [u8; 32];
+/// Implementation of the transaction kernel
+impl TransactionKernel {
+    /// Creates an empty transaction kernel
+    pub fn empty() -> TransactionKernel {
+        TransactionKernel { features: KernelFeatures::empty(), fee: 0, lock_height: 0, excess: None, excess_sig: None }
+    }
+
+    /// Build a transaction kernel with the provided fee
+    pub fn with_fee(mut self, fee: u64) -> TransactionKernel {
+        self.fee = fee;
+        self
+    }
+
+    /// Build a transaction kernel with the provided lock height
+    pub fn with_lock_height(mut self, lock_height: u64) -> TransactionKernel {
+        self.lock_height = lock_height;
+        self
+    }
+}
+
+/// Implement the canonical hashing function for TransactionKernel for use in ordering
+impl Hashable for TransactionKernel {
+    type Hasher = Blake256;
+
+    fn hash(&self) -> Vec<u8> {
+        let mut hasher = Self::Hasher::new();
+        hasher.input(vec![self.features.bits]);
+        hasher.input(self.fee.to_le_bytes());
+        hasher.input(self.lock_height.to_le_bytes());
+        if self.excess.is_some() {
+            hasher.input(self.excess.unwrap().to_bytes());
+        }
+        if self.excess_sig.is_some() {
+            hasher.input(self.excess_sig.unwrap().get_signature().to_bytes());
+        }
+        hasher.result().to_vec()
+    }
+}
+
+hashable_ord!(TransactionKernel);
+
+/// A transaction which consists of a kernel offset and an aggregate body made up of inputs, outputs and kernels.
+pub struct Transaction {
+    /// This kernel offset will be accumulated when transactions are aggregated to prevent the "subset" problem where
+    /// kernels can be linked to inputs and outputs by testing a series of subsets and see which produce valid
+    /// transactions
+    pub offset: BlindingFactor,
+    /// The constituents of a transaction which has the same structure as the body of a block.
+    pub body: AggregateBody,
+    /// reference to the Base point used in the commitments in this transaction
+    pub base: &'static Base,
+}
+
+impl Transaction {
+    /// Create a new transaction from the provided inputs, outputs, kernels and offset
+    pub fn new(
+        base: &'static Base,
+        inputs: Vec<TransactionInput>,
+        outputs: Vec<TransactionOutput>,
+        kernels: Vec<TransactionKernel>,
+        offset: BlindingFactor,
+    ) -> Transaction
+    {
+        Transaction { base, offset, body: AggregateBody::new(inputs, outputs, kernels) }
+    }
+
+    /// Calculate the sum of the inputs and outputs including the fees
+    pub fn sum_commitments(&self, fees: u64) -> Commitment {
+        let fee_commitment = Commitment::new(&Scalar::zero(), &Scalar::from(fees), self.base);
+
+        let outputs_minus_inputs =
+            &self.body.outputs.iter().fold(Commitment::zero(self.base), |acc, val| &acc + &val.commitment) -
+                &self.body.inputs.iter().fold(Commitment::zero(self.base), |acc, val| &acc + &val.commitment);
+
+        &outputs_minus_inputs + &fee_commitment
+    }
+
+    /// Calculate the sum of the kernels, taking into account the offset if it exists, and their constituent fees
+    pub fn sum_kernels(&self) -> KernelSum {
+        // Sum all kernel excesses and fees
+        let mut kernel_sum =
+            self.body.kernels.iter().fold(KernelSum { fees: 0u64, sum: Commitment::zero(self.base) }, |acc, val| {
+                KernelSum {
+                    fees: &acc.fees + val.fee,
+                    sum: &acc.sum + &val.excess.unwrap_or(Commitment::zero(self.base)),
+                }
+            });
+
+        // Add the offset commitment
+        kernel_sum.sum = kernel_sum.sum + Commitment::new(&self.offset.into(), &Scalar::zero(), self.base);
+
+        kernel_sum
+    }
+
+    /// Confirm that the (sum of the outputs) - (sum of inputs) = Kernel excess
+    pub fn validate_kernel_sum(&self) -> Result<(), TransactionError> {
+        let kernel_sum = self.sum_kernels();
+        let sum_io = self.sum_commitments(kernel_sum.fees);
+
+        if kernel_sum.sum != sum_io {
+            return Err(TransactionError::ValidationError);
+        }
+
+        Ok(())
+    }
+}
+
+/// This struct holds the result of calculating the sum of the kernels in a Transaction
+/// and returns the summed commitments and the total fees
+pub struct KernelSum {
+    pub sum: Commitment,
+    pub fees: u64,
+}

--- a/base_layer/core/src/transaction_builder.rs
+++ b/base_layer/core/src/transaction_builder.rs
@@ -1,0 +1,178 @@
+// Copyright 2019 The Tari Project
+//
+// Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+// following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+// disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+// following disclaimer in the documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+// products derived from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+// INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+// WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+// USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE
+
+use crate::{
+    block::AggregateBody,
+    transaction::{Transaction, TransactionError, TransactionInput, TransactionKernel, TransactionOutput},
+    types::{Base, BlindingFactor},
+};
+
+pub struct TransactionBuilder {
+    base: &'static Base,
+    body: AggregateBody,
+    offset: Option<BlindingFactor>,
+}
+
+impl TransactionBuilder {
+    /// Create an new empty TransactionBuilder
+    pub fn new(base: &'static Base) -> Self {
+        Self { base, offset: None, body: AggregateBody::empty() }
+    }
+
+    /// Update the offset of an existing transaction
+    pub fn add_offset(mut self, offset: BlindingFactor) -> Self {
+        self.offset = Some(offset);
+        self
+    }
+
+    /// Add an input to an existing transaction
+    pub fn add_input(mut self, input: TransactionInput) -> Self {
+        self.body = self.body.add_input(input);
+        self
+    }
+
+    /// Add an output to an existing transaction
+    pub fn add_output(mut self, output: TransactionOutput) -> Self {
+        self.body = self.body.add_output(output);
+        self
+    }
+
+    /// Add a series of inputs to an existing transaction
+    pub fn add_inputs(mut self, inputs: Vec<TransactionInput>) -> Self {
+        self.body = self.body.add_inputs(inputs);
+        self
+    }
+
+    /// Add a series of outputs to an existing transaction
+    pub fn add_outputs(mut self, outputs: Vec<TransactionOutput>) -> Self {
+        self.body = self.body.add_outputs(outputs);
+        self
+    }
+
+    /// Set the kernel of a transaction. Currently only one kernel is allowed per transaction
+    pub fn with_kernel(mut self, kernel: TransactionKernel) -> Self {
+        self.body = self.body.set_kernel(kernel);
+        self
+    }
+
+    pub fn build(&self) -> Result<Transaction, TransactionError> {
+        if let Some(offset) = self.offset {
+            let tx = Transaction::new(
+                self.base,
+                self.body.inputs.clone(),
+                self.body.outputs.clone(),
+                self.body.kernels.clone(),
+                offset,
+            );
+            tx.validate_kernel_sum()?;
+            Ok(tx)
+        } else {
+            return Err(TransactionError::ValidationError);
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::{
+        range_proof::RangeProof,
+        transaction::{KernelFeatures, OutputFeatures, TransactionInput, TransactionKernel, TransactionOutput},
+        types::Commitment,
+    };
+    use crypto::{
+        commitment::HomomorphicCommitment,
+        keys::SecretKeyFactory,
+        ristretto::{pedersen::DEFAULT_RISTRETTO_PEDERSON_BASE, RistrettoSecretKey},
+    };
+    use curve25519_dalek::scalar::Scalar;
+    use rand;
+
+    #[test]
+    fn build_transaction_test_kernel_sum_validation() {
+        let mut rng = rand::OsRng::new().unwrap();
+        let base = &DEFAULT_RISTRETTO_PEDERSON_BASE;
+
+        let mut inputs = Vec::new();
+        // Create an input
+        inputs.push(TransactionInput::new(
+            OutputFeatures::empty(),
+            Commitment::new(&RistrettoSecretKey::random(&mut rng).into(), &Scalar::from(12u64), &base),
+        ));
+        // Create an output
+        let mut outputs = Vec::new();
+        outputs.push(TransactionOutput::new(
+            OutputFeatures::empty(),
+            Commitment::new(&RistrettoSecretKey::random(&mut rng).into(), &Scalar::from(12u64), &base),
+            RangeProof([0; 1]),
+        ));
+
+        let sender_secret_key = RistrettoSecretKey::random(&mut rng);
+        let offset: BlindingFactor = BlindingFactor::random(&mut rng).into();
+
+        // Create a transaction
+        let tx_builder = TransactionBuilder::new(&base)
+            .add_inputs(inputs.clone())
+            .add_outputs(outputs.clone())
+            .add_offset(offset.clone());
+
+        // Create a second input
+        let input2 = TransactionInput::new(
+            OutputFeatures::empty(),
+            Commitment::new(&sender_secret_key.into(), &Scalar::from(10u64), &base),
+        );
+
+        // Create a second output
+        let output2 = TransactionOutput::new(
+            OutputFeatures::empty(),
+            Commitment::new(&RistrettoSecretKey::random(&mut rng).into(), &Scalar::from(9u64), &base),
+            RangeProof([0; 1]),
+        );
+        // Add the second input, output and kernel to the transaction using the builder methods
+        let tx_builder = tx_builder.add_input(input2.clone()).add_output(output2.clone());
+
+        // Will fail the validation because there is no kernel yet.
+        let tx = tx_builder.build();
+        assert!(tx.is_err());
+
+        // Manually calculate the excess
+        let mut manual_excess = &outputs[0].commitment + &output2.commitment;
+        manual_excess = &manual_excess - &inputs[0].commitment;
+        manual_excess = &manual_excess - &input2.commitment;
+        manual_excess = &manual_excess + &Commitment::new(&Scalar::zero(), &Scalar::from(1u64), &base); // add fee
+        manual_excess = &manual_excess - &Commitment::new(&offset.into(), &Scalar::zero(), &base); // Subtract Offset
+
+        // Create a kernel with a fee (taken into account in the creation of the inputs and outputs
+        let kernel = TransactionKernel {
+            features: KernelFeatures::empty(),
+            fee: 1,
+            lock_height: 0,
+            excess: Some(manual_excess),
+            excess_sig: None,
+        };
+
+        let tx = tx_builder.with_kernel(kernel).build().unwrap();
+
+        // Validate the transaction
+        tx.validate_kernel_sum().unwrap();
+    }
+}

--- a/base_layer/core/src/types.rs
+++ b/base_layer/core/src/types.rs
@@ -23,9 +23,19 @@
 // Portions of this file were originally copyrighted (c) 2018 The Grin Developers, issued under the Apache License,
 // Version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0.
 
+use crypto::ristretto::{
+    pedersen::{PedersenBaseOnRistretto255, PedersenOnRistretto255},
+    RistrettoSchnorr,
+    RistrettoSecretKey,
+};
+
 /// Define the explicit Signature implementation for the Tari base layer. A different signature scheme can be
 /// employed by redefining this type.
-pub type Signature = [u8; 32]; // TODO replace with a concrete signature type;
+pub type Signature = RistrettoSchnorr;
 
 /// Define the explicit Commitment implementation for the Tari base layer.
-pub type Commitment = [u8; 32]; // TODO replace with a concrete commitment type
+pub type Commitment = PedersenOnRistretto255;
+pub type Base = PedersenBaseOnRistretto255;
+
+/// Define the explicit Secret key implementation for the Tari base layer.
+pub type BlindingFactor = RistrettoSecretKey;

--- a/infrastructure/crypto/Cargo.toml
+++ b/infrastructure/crypto/Cargo.toml
@@ -10,6 +10,7 @@ curve25519-dalek = "1.0.2"
 sha2 = "0.8.0"
 derive-error = "0.0.4"
 blake2 = "0.8.0"
+lazy_static = "1.3.0"
 
 [features]
 avx2 = ["curve25519-dalek/avx2_backend"]

--- a/infrastructure/crypto/src/commitment.rs
+++ b/infrastructure/crypto/src/commitment.rs
@@ -33,10 +33,11 @@ use curve25519_dalek::scalar::Scalar;
 ///
 /// The Homomorphic part means, more or less, that commitments follow some of the standard rules of
 /// arithmetic. Adding two commitments is the same as committing to the sum of their parts.
-pub trait HomomorphicCommitment<'a> {
+pub trait HomomorphicCommitment {
     type Base;
-    fn new(k: &Scalar, v: &Scalar, base: &'a Self::Base) -> Self;
+    fn new(k: &Scalar, v: &Scalar, base: &'static Self::Base) -> Self;
     /// Test whether the envelope content match the given key and value
     fn open(&self, k: &Scalar, v: &Scalar) -> bool;
     fn commit(&self) -> &[u8];
+    fn to_bytes(&self) -> &[u8];
 }

--- a/infrastructure/crypto/src/hash.rs
+++ b/infrastructure/crypto/src/hash.rs
@@ -1,4 +1,4 @@
-// Copyright 2018 The Tari Project
+// Copyright 2019 The Tari Project
 //
 // Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
 // following conditions are met:
@@ -18,15 +18,11 @@
 // SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
 // SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
-// USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE
 
-#[macro_use]
-extern crate bitflags;
+/// A trait for structs that need to produce a canonical hash
+pub trait Hashable {
+    type Hasher;
 
-pub mod block;
-pub mod blockheader;
-pub mod pow;
-pub mod range_proof;
-pub mod transaction;
-pub mod transaction_builder;
-pub mod types;
+    fn hash(&self) -> Vec<u8>;
+}

--- a/infrastructure/crypto/src/lib.rs
+++ b/infrastructure/crypto/src/lib.rs
@@ -1,8 +1,12 @@
 #[macro_use]
+extern crate lazy_static;
+
+#[macro_use]
 pub mod macros;
 pub mod challenge;
 pub mod commitment;
 pub mod common;
+pub mod hash;
 pub mod hex;
 pub mod keys;
 pub mod signatures;

--- a/infrastructure/crypto/src/ristretto/ristretto_keys.rs
+++ b/infrastructure/crypto/src/ristretto/ristretto_keys.rs
@@ -131,6 +131,14 @@ define_add_variants!(LHS = RistrettoSecretKey, RHS = RistrettoSecretKey, Output 
 define_sub_variants!(LHS = RistrettoSecretKey, RHS = RistrettoSecretKey, Output = RistrettoSecretKey);
 define_mul_variants!(LHS = RistrettoSecretKey, RHS = RistrettoPublicKey, Output = RistrettoPublicKey);
 
+//---------------------------------------  SecretKey From Implementations ---------------------------------------------//
+
+impl From<RistrettoSecretKey> for Scalar {
+    fn from(k: RistrettoSecretKey) -> Self {
+        k.0
+    }
+}
+
 //--------------------------------------------- Ristretto Public Key -------------------------------------------------//
 
 /// The [PublicKey](trait.PublicKey.html) implementation for `ristretto255` is a thin wrapper around the dalek
@@ -280,12 +288,6 @@ define_mul_variants!(LHS = RistrettoPublicKey, RHS = RistrettoSecretKey, Output 
 define_mul_variants!(LHS = RistrettoSecretKey, RHS = RistrettoSecretKey, Output = RistrettoSecretKey);
 
 //----------------------------------         PublicKey From implementations      -------------------------------------//
-
-impl From<RistrettoSecretKey> for Scalar {
-    fn from(k: RistrettoSecretKey) -> Self {
-        k.0
-    }
-}
 
 impl From<RistrettoPublicKey> for RistrettoPoint {
     fn from(pk: RistrettoPublicKey) -> Self {


### PR DESCRIPTION
## Description
The PR implements the building blocks of a Mimblewimble Transaction. The data structures are implements and the basic methods for constructing a transaction are included. A method is provided to validate the sum of the components of the transaction against the provided kernel values taking into account the offset and fees.

Closes https://github.com/tari-project/tari/issues/128

## Motivation and Context
Beginning of the functionality required for the TransactionBuilder described in https://github.com/tari-project/tari/issues/42

## How Has This Been Tested?
A unit test is provided to test the added functionality

## Types of changes
* [ ] Bug fix (non-breaking change which fixes an issue)
* [X] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [X] New Tests
* [ ] Documentation

## Checklist:
* [X] I'm merging against the `development` branch
* [X] I ran `cargo-fmt --all` before pushing
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [X] I have added tests to cover my changes.
