### PR TITLE
Refactor Signature to use generic structs

### DIFF
--- a/infrastructure/crypto/src/lib.rs
+++ b/infrastructure/crypto/src/lib.rs
@@ -1,3 +1,5 @@
+#[macro_use]
+pub mod macros;
 pub mod challenge;
 pub mod commitment;
 pub mod common;

--- a/infrastructure/crypto/src/macros.rs
+++ b/infrastructure/crypto/src/macros.rs
@@ -1,0 +1,105 @@
+// Copyright 2019 The Tari Project
+//
+// Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+// following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+// disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+// following disclaimer in the documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+// products derived from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+// INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+// WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+// USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+macro_rules! define_add_variants {
+    (LHS = $lhs:ty, RHS = $rhs:ty, Output = $out:ty) => {
+        impl<'b> Add<&'b $rhs> for $lhs {
+            type Output = $out;
+
+            fn add(self, rhs: &'b $rhs) -> $out {
+                &self + rhs
+            }
+        }
+
+        impl<'a> Add<$rhs> for &'a $lhs {
+            type Output = $out;
+
+            fn add(self, rhs: $rhs) -> $out {
+                self + &rhs
+            }
+        }
+
+        impl Add<$rhs> for $lhs {
+            type Output = $out;
+
+            fn add(self, rhs: $rhs) -> $out {
+                &self + &rhs
+            }
+        }
+    };
+}
+
+macro_rules! define_sub_variants {
+    (LHS = $lhs:ty, RHS = $rhs:ty, Output = $out:ty) => {
+        impl<'b> Sub<&'b $rhs> for $lhs {
+            type Output = $out;
+
+            fn sub(self, rhs: &'b $rhs) -> $out {
+                &self - rhs
+            }
+        }
+
+        impl<'a> Sub<$rhs> for &'a $lhs {
+            type Output = $out;
+
+            fn sub(self, rhs: $rhs) -> $out {
+                self - &rhs
+            }
+        }
+
+        impl Sub<$rhs> for $lhs {
+            type Output = $out;
+
+            fn sub(self, rhs: $rhs) -> $out {
+                &self - &rhs
+            }
+        }
+    };
+}
+
+macro_rules! define_mul_variants {
+    (LHS = $lhs:ty, RHS = $rhs:ty, Output = $out:ty) => {
+        impl<'b> Mul<&'b $rhs> for $lhs {
+            type Output = $out;
+
+            fn mul(self, rhs: &'b $rhs) -> $out {
+                &self * rhs
+            }
+        }
+
+        impl<'a> Mul<$rhs> for &'a $lhs {
+            type Output = $out;
+
+            fn mul(self, rhs: $rhs) -> $out {
+                self * &rhs
+            }
+        }
+
+        impl Mul<$rhs> for $lhs {
+            type Output = $out;
+
+            fn mul(self, rhs: $rhs) -> $out {
+                &self * &rhs
+            }
+        }
+    };
+}

--- a/infrastructure/crypto/src/ristretto/test_common.rs
+++ b/infrastructure/crypto/src/ristretto/test_common.rs
@@ -20,14 +20,14 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-pub mod constants;
-pub mod pedersen;
-pub mod ristretto_keys;
-pub mod ristretto_sig;
-pub mod test_common;
-
-// Re-export
-pub use self::{
-    ristretto_keys::{RistrettoPublicKey, RistrettoSecretKey},
-    ristretto_sig::RistrettoSchnorr,
+use crate::{
+    keys::{PublicKey, SecretKeyFactory},
+    ristretto::{RistrettoPublicKey, RistrettoSecretKey},
 };
+use rand;
+pub fn get_keypair() -> (RistrettoSecretKey, RistrettoPublicKey) {
+    let mut rng = rand::OsRng::new().unwrap();
+    let k = RistrettoSecretKey::random(&mut rng);
+    let pk = RistrettoPublicKey::from_secret_key(&k);
+    (k, pk)
+}

--- a/infrastructure/crypto/src/signatures.rs
+++ b/infrastructure/crypto/src/signatures.rs
@@ -2,25 +2,98 @@
 //! This module defines generic traits for handling the digital signature operations, agnostic
 //! of the underlying elliptic curve implementation
 
-use crate::keys::{PublicKey, SecretKey};
+use crate::{
+    challenge::Challenge,
+    keys::{PublicKey, SecretKey},
+};
+use derive_error::Error;
+use digest::Digest;
+use std::ops::{Add, Mul};
 
-/// Generic definition of Schnorr Signature functionality, agnostic of the elliptic curve used.
-/// Schnorr signatures are linear and have the form _s = r + ek_, where _r_ is a nonce (secret key),
-/// _k_ is a secret key, and _s_ is the signature.
+#[derive(Debug, Error, PartialEq, Eq)]
+pub enum SchnorrSignatureError {
+    // An invalid challenge was provided
+    InvalidChallenge,
+}
+
 #[allow(non_snake_case)]
-pub trait SchnorrSignature {
-    type Scalar: SecretKey;
-    type Point: PublicKey;
-    type Challenge;
+#[derive(PartialEq, Eq, Copy, Debug, Clone)]
+pub struct SchnorrSignature<P, K>
+where
+    P: PublicKey<K = K>,
+    K: SecretKey,
+{
+    public_nonce: P,
+    signature: K,
+}
 
-    fn new(public_nonce: Self::Point, signature: Self::Scalar) -> Self;
+impl<P, K> SchnorrSignature<P, K>
+where
+    P: PublicKey<K = K>,
+    K: SecretKey,
+{
+    pub fn new(public_nonce: P, signature: K) -> Self {
+        SchnorrSignature { public_nonce, signature }
+    }
 
-    fn sign(secret: &Self::Scalar, nonce: &Self::Scalar, challenge: Self::Challenge) -> Self;
+    pub fn calc_signature_verifier(&self) -> P {
+        P::from_secret_key(&self.signature)
+    }
 
-    /// Check whether the given signature is valid for the given message and public key
-    fn verify(&self, public_key: &Self::Point, challenge: &Self::Challenge) -> bool;
+    pub fn sign<'a, 'b, D: Digest>(
+        secret: K,
+        nonce: K,
+        challenge: Challenge<D>,
+    ) -> Result<Self, SchnorrSignatureError>
+    where
+        K: Add<Output = K> + Mul<P, Output = P> + Mul<Output = K>,
+    {
+        // s = r + e.k
+        let e = match K::from_vec(&challenge.hash()) {
+            Ok(e) => e,
+            Err(_) => return Err(SchnorrSignatureError::InvalidChallenge),
+        };
+        let public_nonce = P::from_secret_key(&nonce);
+        let ek = e * secret;
+        let s = ek + nonce;
+        Ok(Self::new(public_nonce, s))
+    }
 
-    fn get_signature(&self) -> &Self::Scalar;
+    pub fn verify<'a, D: Digest>(&self, public_key: &'a P, challenge: Challenge<D>) -> bool
+    where K: Mul<&'a P, Output = P> {
+        let lhs = self.calc_signature_verifier();
+        let e = match K::from_vec(&challenge.hash()) {
+            Ok(e) => e,
+            Err(_) => return false,
+        };
+        let rhs = self.public_nonce.clone() + e * public_key;
+        // Implementors should make this a constant time comparison
+        lhs == rhs
+    }
 
-    fn get_public_nonce(&self) -> &Self::Point;
+    #[inline]
+    pub fn get_signature(&self) -> &K {
+        &self.signature
+    }
+
+    #[inline]
+    pub fn get_public_nonce(&self) -> &P {
+        &self.public_nonce
+    }
+}
+
+impl<'a, 'b, P, K> Add<&'b SchnorrSignature<P, K>> for &'a SchnorrSignature<P, K>
+where
+    P: PublicKey<K = K>,
+    &'a P: Add<&'b P, Output = P>,
+    K: SecretKey,
+    &'a K: Add<&'b K, Output = K>,
+{
+    type Output = SchnorrSignature<P, K>;
+
+    fn add(self, rhs: &'b SchnorrSignature<P, K>) -> SchnorrSignature<P, K> {
+        let r_sum = self.get_public_nonce() + rhs.get_public_nonce();
+        let s_sum = self.get_signature() + rhs.get_signature();
+        SchnorrSignature::new(r_sum, s_sum)
+    }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Mostly what it says on the box.

Sone ergonomic / breaking changes:
* `Signature::sign` takes ownership of the secret and nonce, so you have to explicitly clone them beforehand if you want to re-use them. It's a bit less user friendly, but reduces the risk of bad things happening due to nonce re-use
* Added a macro (thanks dalek!) to generate all the `Add`, `Sub` and `Mul` variants.


## Motivation and Context
This is much closer to the intent I had for this module initially. `SchnorrSignature` should only really be implemented once, and now it is! The `RistrettoSchnorr` file now contains one line: An alias type mapping the <P,K> types to the Ristretto pub/secret keys, and tests.

## How Has This Been Tested?
All existing tests pass

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [x] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch
* [x] I ran `cargo-fmt --all` before pushing
* [ ] My change requires a change to the documentation.
* [x] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
