### PR TITLE
Replaced gh-pages with script

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,24 +21,46 @@ jobs:
 
   deploy-docs:
     docker:
-      - image: node:9.11.1
+      - image: quay.io/tarilabs/git-ssh-client:0.2-alpine
     steps:
       - checkout
       - attach_workspace:
           at: book
-      - run:
-          name: Install and configure dependencies
-          command: |
-            npm install -g --silent gh-pages@2.0.1
-            git config user.email "ci-build@tari.com"
-            git config user.name "ci-build"
       - add_ssh_keys:
           fingerprints:
             - "a6:a6:e2:be:a3:94:3e:4c:9d:51:25:f6:98:f9:0c:a4"
       - run:
           name: Deploy docs to gh-pages branch
           command: |
-            cd book && NODE_DEBUG=gh-pages gh-pages --dotfiles --message "[skip ci] Update RFC docs" --dist . --dest .
+            DEST_BRANCH=gh-pages
+            DEST_PATH=book/
+
+            if [[ ! -d $DEST_PATH ]]; then
+              echo "$DEST_PATH directory not found!"
+              exit 1
+            fi
+
+            TMP_DIR=$(mktemp -d /tmp/ghpages_XXXX)
+
+            echo "Copying book files to temporary location $TMP_DIR"
+            cp -R $DEST_PATH $TMP_DIR
+
+            REMOTE=$(git remote get-url origin)
+
+            cd $TMP_DIR
+
+            git config --global user.email "ci-build@tari.com"
+            git config --global user.name "ci-build"
+
+            git init
+            git checkout -b $DEST_BRANCH
+            git remote add origin $REMOTE
+            git add --all .
+            git commit -m "[skip ci] Update RFC docs"
+            git push origin $DEST_BRANCH --force
+
+            echo "Published."
+
   test-tari:
     docker:
       - image: *rust_image


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Replaced `gh-pages` with a simple script 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
`gh-pages` doesn't seem able to listen to it's `--dest` flag

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I've run this successfully locally on the same docker quay.io image as used in circleci

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch
* [ ] I ran `cargo-fmt --all` before pushing
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
