### PR TITLE
Add LaTex markup rendering to Docs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,5 @@
+doc:
+	cargo rustdoc -p crypto --open -- --html-in-header meta/assets/rustdoc-include-katex-header.html
+doc-internal:
+	cargo rustdoc -p crypto -- --html-in-header docs/assets/rustdoc-include-katex-header.html --document-private-items
+

--- a/infrastructure/crypto/src/commitment.rs
+++ b/infrastructure/crypto/src/commitment.rs
@@ -32,7 +32,12 @@ use curve25519_dalek::scalar::Scalar;
 /// [ByteArray](trait.ByteArray.html).
 ///
 /// The Homomorphic part means, more or less, that commitments follow some of the standard rules of
-/// arithmetic. Adding two commitments is the same as committing to the sum of their parts.
+/// arithmetic. Adding two commitments is the same as committing to the sum of their parts:
+/// $$ \begin{aligned}
+///   C_1 &= v_1.G + k_1.H \\\\
+///   C_2 &= v_2.G + k_2.H \\\\
+///   \therefore C_1 + C_2 &= (v_1 + v_2)G + (k_1 + k_2)H
+/// \end{aligned} $$
 pub trait HomomorphicCommitment {
     type Base;
     fn new(k: &Scalar, v: &Scalar, base: &'static Self::Base) -> Self;

--- a/meta/assets/rustdoc-include-katex-header.html
+++ b/meta/assets/rustdoc-include-katex-header.html
@@ -1,0 +1,10 @@
+<link rel="stylesheet" href="https://doc.dalek.rs/assets/katex/katex.min.css">
+<script src="https://doc.dalek.rs/assets/katex/katex.min.js"></script>
+<script src="https://doc.dalek.rs/assets/katex/contrib/auto-render.min.js"></script>
+<script>
+document.addEventListener("DOMContentLoaded", function() { renderMathInElement(document.body); });
+</script>
+<style>
+.katex { font-size: 1em !important; }
+pre.rust, .docblock code, .docblock-short code { font-size: 0.85em !important; }
+</style>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Use a trick from the Dalek libraries to include KateX.js in the reference docs for this project.

## Motivation and Context
This change allows LaTeX markeup to be rendered in our docs, like so:

<img width="910" alt="Screenshot 2019-03-16 at 12 46 02" src="https://user-images.githubusercontent.com/7573551/54474128-a3a59280-47e9-11e9-8b6e-fa4a6a747565.png">


## How Has This Been Tested?
Added a small example equation in `HomomorphicCommitment` to illustrate the principle.
 
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [x] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch
* [x] I ran `cargo-fmt --all` before pushing
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
