### PR TITLE
Follow the Rust convention for `as_bytes`

### DIFF
--- a/base_layer/core/src/transaction.rs
+++ b/base_layer/core/src/transaction.rs
@@ -200,8 +200,8 @@ impl TransactionKernel {
         let excess = excess.as_public_key();
         let r = signature.get_public_nonce();
         let c = Challenge::<SignatureHash>::new()
-            .concat(r.to_bytes())
-            .concat(excess.clone().to_bytes())
+            .concat(r.as_bytes())
+            .concat(excess.clone().as_bytes())
             .concat(&self.fee.to_le_bytes())
             .concat(&self.lock_height.to_le_bytes());
 
@@ -226,7 +226,7 @@ impl Hashable for TransactionKernel {
             hasher.input(self.excess.unwrap().to_bytes());
         }
         if self.excess_sig.is_some() {
-            hasher.input(self.excess_sig.unwrap().get_signature().to_bytes());
+            hasher.input(self.excess_sig.unwrap().get_signature().as_bytes());
         }
         hasher.result().to_vec()
     }
@@ -474,8 +474,8 @@ mod test {
         let receiver_public_key = PublicKey::from_secret_key(&receiver_full_secret_key);
 
         let challenge = Challenge::<Blake256>::new()
-            .concat((&sender_public_nonce + &receiver_public_nonce).to_bytes())
-            .concat((&sender_public_excess + &receiver_public_key).to_bytes())
+            .concat((&sender_public_nonce + &receiver_public_nonce).as_bytes())
+            .concat((&sender_public_excess + &receiver_public_key).as_bytes())
             .concat(&fee.to_le_bytes())
             .concat(&lock_height.to_le_bytes());
 

--- a/infrastructure/crypto/src/common.rs
+++ b/infrastructure/crypto/src/common.rs
@@ -62,7 +62,7 @@ pub trait ByteArray {
 
     /// Return the type as a byte vector
     fn to_vec(&self) -> Vec<u8> {
-        self.to_bytes().to_vec()
+        self.as_bytes().to_vec()
     }
 
     /// Try and convert the given byte vector to the implemented type. Any failures (incorrect string length etc)
@@ -78,7 +78,7 @@ pub trait ByteArray {
     where Self: Sized;
 
     /// Return the type as a byte array
-    fn to_bytes(&self) -> &[u8];
+    fn as_bytes(&self) -> &[u8];
 }
 
 impl ByteArray for Vec<u8> {
@@ -108,7 +108,7 @@ impl ByteArray for Vec<u8> {
         Ok(bytes.to_vec())
     }
 
-    fn to_bytes(&self) -> &[u8] {
+    fn as_bytes(&self) -> &[u8] {
         Vec::as_slice(self)
     }
 }
@@ -124,7 +124,7 @@ impl ByteArray for [u8; 32] {
         Ok(a)
     }
 
-    fn to_bytes(&self) -> &[u8] {
+    fn as_bytes(&self) -> &[u8] {
         self
     }
 }

--- a/infrastructure/crypto/src/musig.rs
+++ b/infrastructure/crypto/src/musig.rs
@@ -194,7 +194,7 @@ where
     fn calculate_common<D: Digest>(&self) -> K {
         let mut common = Challenge::<D>::new();
         for k in self.pub_keys.iter() {
-            common = common.concat(k.to_bytes());
+            common = common.concat(k.as_bytes());
         }
         K::from_vec(&common.hash())
             .expect("Could not calculate Scalar from hash value. Your crypto/hash combination might be inconsistent")
@@ -206,7 +206,7 @@ where
     /// You should ensure that the SecretKey constructor protects against failures and that the hash digest given
     /// produces a byte array of the correct length.
     fn calculate_partial_key<D: Digest>(common: &[u8], pubkey: &P) -> K {
-        let k = Challenge::<D>::new().concat(common).concat(pubkey.to_bytes()).hash();
+        let k = Challenge::<D>::new().concat(common).concat(pubkey.as_bytes()).hash();
         K::from_vec(&k)
             .expect("Could not calculate Scalar from hash value. Your crypto/hash combination might be inconsistent")
     }
@@ -220,7 +220,7 @@ where
 
     /// Utility function that produces the vector of MuSig private key modifiers, \\( a_i = H(\ell || P_i) \\)
     fn calculate_musig_scalars<D: Digest>(&self, common: &K) -> Vec<K> {
-        self.pub_keys.iter().map(|p| JointKeyBuilder::calculate_partial_key::<D>(common.to_bytes(), p)).collect()
+        self.pub_keys.iter().map(|p| JointKeyBuilder::calculate_partial_key::<D>(common.as_bytes(), p)).collect()
     }
 
     /// Calculate the value of the Joint MuSig public key. **NB**: you should usually sort the participant's keys

--- a/infrastructure/crypto/src/ristretto/musig.rs
+++ b/infrastructure/crypto/src/ristretto/musig.rs
@@ -550,7 +550,7 @@ impl SignatureCollection {
         m: &MessageHash,
     ) -> RistrettoSecretKey
     {
-        let e = Challenge::<D>::new().concat(r_agg.to_bytes()).concat(p_agg.to_bytes()).concat(m).hash();
+        let e = Challenge::<D>::new().concat(r_agg.as_bytes()).concat(p_agg.as_bytes()).concat(m).hash();
         RistrettoSecretKey::from_vec(&e).expect("Found a u256 that does not map to a valid Ristretto scalar")
     }
 
@@ -899,7 +899,7 @@ mod test {
         let p_agg = musig.get_aggregated_public_key().unwrap();
         let m_hash = Challenge::<Sha256>::hash_input(b"message".to_vec());
         let challenge =
-            Challenge::<Sha256>::new().concat(data.r_agg.to_bytes()).concat(p_agg.to_bytes()).concat(&m_hash);
+            Challenge::<Sha256>::new().concat(data.r_agg.as_bytes()).concat(p_agg.as_bytes()).concat(&m_hash);
         assert!(sig.verify_challenge(p_agg, challenge));
         assert_eq!(&s_agg, sig);
     }
@@ -1013,13 +1013,13 @@ mod test_joint_key {
         assert_eq!(joint_key.get_pub_keys(1), &p1);
         assert_eq!(joint_key.get_pub_keys(2), &p3);
         // Calculate ell and partials
-        let ell = Sha256::new().chain(p2.to_bytes()).chain(p1.to_bytes()).chain(p3.to_bytes()).result().to_vec();
+        let ell = Sha256::new().chain(p2.as_bytes()).chain(p1.as_bytes()).chain(p3.as_bytes()).result().to_vec();
         // Check Ell
         let ell = RistrettoSecretKey::from_vec(&ell).unwrap();
         assert_eq!(joint_key.get_common(), &ell);
         // Check partial scalars
         let hash = |p: &RistrettoPublicKey| {
-            let h = Sha256::new().chain(ell.to_bytes()).chain(p.to_bytes()).result().to_vec();
+            let h = Sha256::new().chain(ell.as_bytes()).chain(p.as_bytes()).result().to_vec();
             RistrettoSecretKey::from_vec(&h).unwrap()
         };
         let a1 = hash(&p1);

--- a/infrastructure/crypto/src/ristretto/pedersen.rs
+++ b/infrastructure/crypto/src/ristretto/pedersen.rs
@@ -89,7 +89,7 @@ impl HomomorphicCommitment for PedersenOnRistretto255 {
     }
 
     fn to_bytes(&self) -> &[u8] {
-        self.commitment.to_bytes()
+        self.commitment.as_bytes()
     }
 }
 

--- a/infrastructure/crypto/src/ristretto/ristretto_keys.rs
+++ b/infrastructure/crypto/src/ristretto/ristretto_keys.rs
@@ -100,7 +100,7 @@ impl ByteArray for RistrettoSecretKey {
     }
 
     /// Return the byte array for the secret key in little-endian order
-    fn to_bytes(&self) -> &[u8] {
+    fn as_bytes(&self) -> &[u8] {
         self.0.as_bytes()
     }
 }
@@ -245,7 +245,7 @@ impl ByteArray for RistrettoPublicKey {
     }
 
     /// Return the little-endian byte array representation of the compressed public key
-    fn to_bytes(&self) -> &[u8] {
+    fn as_bytes(&self) -> &[u8] {
         self.compressed.as_bytes()
     }
 }

--- a/infrastructure/crypto/src/ristretto/ristretto_sig.rs
+++ b/infrastructure/crypto/src/ristretto/ristretto_sig.rs
@@ -124,7 +124,7 @@ mod test {
         let (k, P) = get_keypair();
         let (r, R) = get_keypair();
         let c = Challenge::<Blake256>::new();
-        let e = c.concat(P.to_bytes()).concat(R.to_bytes()).concat(b"Small Gods");
+        let e = c.concat(P.as_bytes()).concat(R.as_bytes()).concat(b"Small Gods");
         let sig = RistrettoSchnorr::sign(k, r, e.clone()).unwrap();
         let R_calc = sig.get_public_nonce();
         assert_eq!(R, *R_calc);
@@ -148,10 +148,10 @@ mod test {
         let (r2, R2) = get_keypair();
         // Each of them creates the Challenge = H(R1 || R2 || P1 || P2 || m)
         let challenge = Challenge::<Blake256>::new()
-            .concat(R1.to_bytes())
-            .concat(R2.to_bytes())
-            .concat(P1.to_bytes())
-            .concat(P2.to_bytes())
+            .concat(R1.as_bytes())
+            .concat(R2.as_bytes())
+            .concat(P1.as_bytes())
+            .concat(P2.as_bytes())
             .concat(b"Moving Pictures");
         let e1 = challenge.clone();
         let e2 = challenge.clone();


### PR DESCRIPTION
## Description

By convention, if a function returns a reference, it is called `as_xxx`.
The ByteArray implementation called this `to_bytes`; so renaming it
to fit with the convention.

## Motivation and Context
Keep with Rust convention. It reduces confusion for newcomers to the project
Fixes #106 

## How Has This Been Tested?
Existing tests pass

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [x] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch
* [x] I ran `cargo-fmt --all` before pushing
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
