### PR TITLE
Refactor `HomomorphicCommitment`

### DIFF
--- a/base_layer/core/src/transaction.rs
+++ b/base_layer/core/src/transaction.rs
@@ -440,9 +440,7 @@ mod test {
             RangeProof([0; 1]),
         );
 
-        let tx_builder = tx_builder
-            .add_inputs(vec![input2.clone()])
-            .add_outputs(vec![output2.clone()]);
+        let tx_builder = tx_builder.add_inputs(vec![input2.clone()]).add_outputs(vec![output2.clone()]);
 
         // Should fail the validation because there is no kernel yet.
         let tx = tx_builder.build();

--- a/base_layer/core/src/transaction.rs
+++ b/base_layer/core/src/transaction.rs
@@ -26,17 +26,17 @@
 use crate::{
     block::AggregateBody,
     range_proof::RangeProof,
-    types::{Base, BlindingFactor, Commitment, Signature},
+    types::{BlindingFactor, Commitment, CommitmentFactory, Signature},
 };
 
 use crate::types::SignatureHash;
 use crypto::{
     challenge::Challenge,
-    commitment::HomomorphicCommitment,
+    commitment::{HomomorphicCommitment, HomomorphicCommitmentFactory},
     common::{Blake256, ByteArray},
     hash::Hashable,
+    ristretto::RistrettoSecretKey,
 };
-use curve25519_dalek::scalar::Scalar;
 use derive::HashableOrdering;
 use derive_error::Error;
 use digest::Digest;
@@ -99,7 +99,7 @@ impl Hashable for TransactionInput {
     fn hash(&self) -> Vec<u8> {
         let mut hasher = Self::Hasher::new();
         hasher.input(vec![self.features.bits]);
-        hasher.input(self.commitment.to_bytes());
+        hasher.input(self.commitment.as_bytes());
         hasher.result().to_vec()
     }
 }
@@ -142,7 +142,7 @@ impl Hashable for TransactionOutput {
     fn hash(&self) -> Vec<u8> {
         let mut hasher = Self::Hasher::new();
         hasher.input(vec![self.features.bits]);
-        hasher.input(self.commitment.to_bytes());
+        hasher.input(self.commitment.as_bytes());
         hasher.input(self.proof.0);
         hasher.result().to_vec()
     }
@@ -223,7 +223,7 @@ impl Hashable for TransactionKernel {
         hasher.input(self.fee.to_le_bytes());
         hasher.input(self.lock_height.to_le_bytes());
         if self.excess.is_some() {
-            hasher.input(self.excess.unwrap().to_bytes());
+            hasher.input(self.excess.unwrap().as_bytes());
         }
         if self.excess_sig.is_some() {
             hasher.input(self.excess_sig.unwrap().get_signature().as_bytes());
@@ -240,30 +240,27 @@ pub struct Transaction {
     pub offset: BlindingFactor,
     /// The constituents of a transaction which has the same structure as the body of a block.
     pub body: AggregateBody,
-    /// reference to the Base point used in the commitments in this transaction
-    pub base: &'static Base,
 }
 
 impl Transaction {
     /// Create a new transaction from the provided inputs, outputs, kernels and offset
     pub fn new(
-        base: &'static Base,
         inputs: Vec<TransactionInput>,
         outputs: Vec<TransactionOutput>,
         kernels: Vec<TransactionKernel>,
         offset: BlindingFactor,
     ) -> Transaction
     {
-        Transaction { base, offset, body: AggregateBody::new(inputs, outputs, kernels) }
+        Transaction { offset, body: AggregateBody::new(inputs, outputs, kernels) }
     }
 
     /// Calculate the sum of the inputs and outputs including the fees
     fn sum_commitments(&self, fees: u64) -> Commitment {
-        let fee_commitment = Commitment::new(&Scalar::zero(), &Scalar::from(fees), self.base);
+        let fee_commitment = CommitmentFactory::create(&RistrettoSecretKey::default(), &RistrettoSecretKey::from(fees));
 
         let outputs_minus_inputs =
-            &self.body.outputs.iter().fold(Commitment::zero(self.base), |acc, val| &acc + &val.commitment) -
-                &self.body.inputs.iter().fold(Commitment::zero(self.base), |acc, val| &acc + &val.commitment);
+            &self.body.outputs.iter().fold(CommitmentFactory::zero(), |acc, val| &acc + &val.commitment) -
+                &self.body.inputs.iter().fold(CommitmentFactory::zero(), |acc, val| &acc + &val.commitment);
 
         &outputs_minus_inputs + &fee_commitment
     }
@@ -272,15 +269,16 @@ impl Transaction {
     fn sum_kernels(&self) -> KernelSum {
         // Sum all kernel excesses and fees
         let mut kernel_sum =
-            self.body.kernels.iter().fold(KernelSum { fees: 0u64, sum: Commitment::zero(self.base) }, |acc, val| {
+            self.body.kernels.iter().fold(KernelSum { fees: 0u64, sum: CommitmentFactory::zero() }, |acc, val| {
                 KernelSum {
                     fees: &acc.fees + val.fee,
-                    sum: &acc.sum + &val.excess.unwrap_or(Commitment::zero(self.base)),
+                    sum: &acc.sum + &val.excess.unwrap_or(CommitmentFactory::zero()),
                 }
             });
 
         // Add the offset commitment
-        kernel_sum.sum = kernel_sum.sum + Commitment::new(&self.offset.into(), &Scalar::zero(), self.base);
+        kernel_sum.sum =
+            kernel_sum.sum + CommitmentFactory::create(&self.offset.into(), &RistrettoSecretKey::default());
 
         kernel_sum
     }
@@ -313,15 +311,14 @@ pub struct KernelSum {
 }
 
 pub struct TransactionBuilder {
-    base: &'static Base,
     body: AggregateBody,
     offset: Option<BlindingFactor>,
 }
 
 impl TransactionBuilder {
     /// Create an new empty TransactionBuilder
-    pub fn new(base: &'static Base) -> Self {
-        Self { base, offset: None, body: AggregateBody::empty() }
+    pub fn new() -> Self {
+        Self { offset: None, body: AggregateBody::empty() }
     }
 
     /// Update the offset of an existing transaction
@@ -363,7 +360,6 @@ impl TransactionBuilder {
     pub fn build(&self) -> Result<Transaction, TransactionError> {
         if let Some(offset) = self.offset {
             let tx = Transaction::new(
-                self.base,
                 self.body.inputs.clone(),
                 self.body.outputs.clone(),
                 self.body.kernels.clone(),
@@ -383,22 +379,18 @@ mod test {
     use crate::{
         range_proof::RangeProof,
         transaction::{KernelFeatures, OutputFeatures, TransactionInput, TransactionKernel, TransactionOutput},
-        types::{BlindingFactor, Commitment, PublicKey},
+        types::{BlindingFactor, PublicKey},
     };
     use crypto::{
         challenge::Challenge,
-        commitment::HomomorphicCommitment,
         common::{Blake256, ByteArray},
         keys::{PublicKey as PublicKeyTrait, SecretKey},
-        ristretto::pedersen::DEFAULT_RISTRETTO_PEDERSON_BASE,
     };
-    use curve25519_dalek::scalar::Scalar;
     use rand;
 
     #[test]
     fn build_transaction_test_and_validation() {
         let mut rng = rand::OsRng::new().unwrap();
-        let base = &DEFAULT_RISTRETTO_PEDERSON_BASE;
 
         let input_secret_key = BlindingFactor::random(&mut rng);
         let input_secret_key2 = BlindingFactor::random(&mut rng);
@@ -409,18 +401,18 @@ mod test {
 
         let input = TransactionInput::new(
             OutputFeatures::empty(),
-            Commitment::new(&input_secret_key.into(), &Scalar::from(12u64), &base),
+            CommitmentFactory::create(&input_secret_key, &RistrettoSecretKey::from(12u64)),
         );
 
         let change_output = TransactionOutput::new(
             OutputFeatures::empty(),
-            Commitment::new(&change_secret_key.into(), &Scalar::from(4u64), &base),
+            CommitmentFactory::create(&change_secret_key, &RistrettoSecretKey::from(4u64)),
             RangeProof([0; 1]),
         );
 
         let output = TransactionOutput::new(
             OutputFeatures::empty(),
-            Commitment::new(&receiver_secret_key.into(), &Scalar::from(7u64), &base),
+            CommitmentFactory::create(&receiver_secret_key, &RistrettoSecretKey::from(7u64)),
             RangeProof([0; 1]),
         );
 
@@ -431,7 +423,7 @@ mod test {
         let lock_height = 0u64;
 
         // Create a transaction
-        let tx_builder = TransactionBuilder::new(&base)
+        let tx_builder = TransactionBuilder::new()
             .add_input(input.clone())
             .add_output(output)
             .add_output(change_output)
@@ -440,15 +432,17 @@ mod test {
         // Test adding inputs and outputs in vector form
         let input2 = TransactionInput::new(
             OutputFeatures::empty(),
-            Commitment::new(&input_secret_key2.into(), &Scalar::from(2u64), &base),
+            CommitmentFactory::create(&input_secret_key2, &RistrettoSecretKey::from(2u64)),
         );
         let output2 = TransactionOutput::new(
             OutputFeatures::empty(),
-            Commitment::new(&receiver_secret_key2.into(), &Scalar::from(2u64), &base),
+            CommitmentFactory::create(&receiver_secret_key2, &RistrettoSecretKey::from(2u64)),
             RangeProof([0; 1]),
         );
 
-        let tx_builder = tx_builder.add_inputs(vec![input2.clone()]).add_outputs(vec![output2.clone()]);
+        let tx_builder = tx_builder
+            .add_inputs(vec![input2.clone()])
+            .add_outputs(vec![output2.clone()]);
 
         // Should fail the validation because there is no kernel yet.
         let tx = tx_builder.build();
@@ -463,11 +457,12 @@ mod test {
         // Receiver generate partial signatures
 
         let mut final_excess = &output.commitment + &change_output.commitment;
+        let zero = RistrettoSecretKey::default();
         final_excess = &final_excess + &output2.commitment;
         final_excess = &final_excess - &input.commitment;
         final_excess = &final_excess - &input2.commitment;
-        final_excess = &final_excess + &Commitment::new(&Scalar::zero(), &Scalar::from(fee), &base); // add fee
-        final_excess = &final_excess - &Commitment::new(&offset.into(), &Scalar::zero(), &base); // subtract Offset
+        final_excess = &final_excess + &CommitmentFactory::create(&zero, &RistrettoSecretKey::from(fee)); // add fee
+        final_excess = &final_excess - &CommitmentFactory::create(&offset, &zero); // subtract Offset
 
         let receiver_private_nonce = BlindingFactor::random(&mut rng);
         let receiver_public_nonce = PublicKey::from_secret_key(&receiver_private_nonce);

--- a/base_layer/core/src/types.rs
+++ b/base_layer/core/src/types.rs
@@ -39,7 +39,7 @@ pub type Signature = RistrettoSchnorr;
 
 /// Define the explicit Commitment implementation for the Tari base layer.
 pub type Commitment = PedersenOnRistretto255;
-pub type Base = PedersenBaseOnRistretto255;
+pub type CommitmentFactory = PedersenBaseOnRistretto255;
 
 /// Define the explicit Secret key implementation for the Tari base layer.
 pub type BlindingFactor = RistrettoSecretKey;

--- a/infrastructure/crypto/src/commitment.rs
+++ b/infrastructure/crypto/src/commitment.rs
@@ -20,7 +20,7 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use curve25519_dalek::scalar::Scalar;
+use crate::keys::SecretKey;
 
 /// A commitment is like a sealed envelope. You put some information inside the envelope, and then seal (commit) it.
 /// You can't change what you've said, but also, no-one knows what you've said until you're ready to open (open) the
@@ -39,10 +39,17 @@ use curve25519_dalek::scalar::Scalar;
 ///   \therefore C_1 + C_2 &= (v_1 + v_2)G + (k_1 + k_2)H
 /// \end{aligned} $$
 pub trait HomomorphicCommitment {
-    type Base;
-    fn new(k: &Scalar, v: &Scalar, base: &'static Self::Base) -> Self;
-    /// Test whether the envelope content match the given key and value
-    fn open(&self, k: &Scalar, v: &Scalar) -> bool;
-    fn commit(&self) -> &[u8];
-    fn to_bytes(&self) -> &[u8];
+    type K: SecretKey;
+
+    fn open(&self, k: &Self::K, v: &Self::K) -> bool;
+    fn as_bytes(&self) -> &[u8];
+}
+
+pub trait HomomorphicCommitmentFactory {
+    type K: SecretKey;
+    type C: HomomorphicCommitment<K = Self::K>;
+    fn create(k: &Self::K, v: &Self::K) -> Self::C;
+    /// return an identity point for addition using the specified base point. This is a commitment to zero with a zero
+    /// blinding factor on the base point
+    fn zero() -> Self::C;
 }

--- a/infrastructure/crypto/src/ristretto/ristretto_keys.rs
+++ b/infrastructure/crypto/src/ristretto/ristretto_keys.rs
@@ -137,6 +137,15 @@ define_add_variants!(LHS = RistrettoSecretKey, RHS = RistrettoSecretKey, Output 
 define_sub_variants!(LHS = RistrettoSecretKey, RHS = RistrettoSecretKey, Output = RistrettoSecretKey);
 define_mul_variants!(LHS = RistrettoSecretKey, RHS = RistrettoPublicKey, Output = RistrettoPublicKey);
 
+//---------------------------------------------      Conversions     -------------------------------------------------//
+
+impl From<u64> for RistrettoSecretKey {
+    fn from(v: u64) -> Self {
+        let s = Scalar::from(v);
+        RistrettoSecretKey(s)
+    }
+}
+
 //--------------------------------------------- Ristretto Public Key -------------------------------------------------//
 
 /// The [PublicKey](trait.PublicKey.html) implementation for `ristretto255` is a thin wrapper around the dalek
@@ -411,6 +420,14 @@ mod test {
         let vec = pk.to_vec();
         let pk2 = RistrettoPublicKey::from_vec(&vec).unwrap();
         assert_eq!(pk, pk2);
+    }
+
+    #[test]
+    fn zero_plus_k_is_k() {
+        let zero = RistrettoSecretKey::default();
+        let mut rng = rand::OsRng::new().unwrap();
+        let k = RistrettoSecretKey::random(&mut rng);
+        assert_eq!(&k + &zero, k);
     }
 
     /// These test vectors are from https://ristretto.group/test_vectors/ristretto255.html


### PR DESCRIPTION
## Description
HomomorphicCommitment is refactored to abstract away the static reference to the Commitment
base without compromising on the ability to build commitments with different generator bases.

The explicit dependency on the `Scalar` from the Dalek library is also removed, which removes
the leaky abstraction that was present in the existing implementation.

The references to `base` that were being carried in `Transaction` structs can also now be
removed.

<!--- Provide a general summary of your changes in the Title above -->


<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [x] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [x] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch
* [x] I ran `cargo-fmt --all` before pushing
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
