### PR TITLE
Replace double bars in table

### DIFF
--- a/RFC/src/RFC-0311_AssetTemplates.md
+++ b/RFC/src/RFC-0311_AssetTemplates.md
@@ -107,8 +107,8 @@ The instruction is in JSON format and MUST contain the following fields:
 | **template-specific data**         | Object        | Template-specific metadata can be defined in this section                                                                   |
 | **Signatures**                     |               |                                                                                                                             |
 | metadata_hash                      | `u256`        | A hash of the previous three sections' data, in canonical format (`m`)                                                      |
-| creator_sig                        | `u256`        | A digital signature of the message `H(R || P || m)` using the asset creator’s private key corresponding to the `issuer` PKH |
-| raid_signature                     | `u256`        | Digital signature for the given RAID, signing the message `H(R || P || RAID_ID || m)`                                       |
+| creator_sig                        | `u256`        | A digital signature of the message `H(R ‖ P ‖ m)` using the asset creator’s private key corresponding to the `issuer` PKH |
+| raid_signature                     | `u256`        | Digital signature for the given RAID, signing the message `H(R ‖ P ‖ RAID_ID ‖ m)`                                       |
 | commitment_sig                     | `u256`        | A signature proving the issuer is able to spend the commitment to the asset fee                                             |
 
 #### Committee parameters


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
MDBook does not render `||` in table rows properly, so replace them with the unicode ‖ (double bar)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Broken rendering in mdbook

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [x] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch
* [ ] I ran `cargo-fmt --all` before pushing
* [ ] My change requires a change to the documentation.
* [x] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
