### PR TITLE
Kernel builder

### DIFF
--- a/base_layer/core/src/types.rs
+++ b/base_layer/core/src/types.rs
@@ -52,6 +52,9 @@ pub type PublicKey = RistrettoPublicKey;
 /// Define the hash function that will be used to produce a signature challenge
 pub type SignatureHash = Blake256;
 
+/// Specify the Hash function for general hashing
+pub type HashDigest = Blake256;
+
 /// Convenience type wrapper for creating output commitments directly from values and spending_keys
 pub trait TariCommitment {
     fn commit(value: u64, spending_key: &SecretKey) -> Commitment;


### PR DESCRIPTION
## Description

Removing `Option`s from `TransactionKernel` provides stringer guarantees about data integrity when building blocks and passing TX data around.
Code is also cleaner because checks for `is_some()` aren't necessary anymore.

However, we now require a "Builder" struct while collecting Kernel information. This adds some boilerplate but is a good tradeoff to grab the
benefits describes above.

Part of #42 
<!--- Provide a general summary of your changes in the Title above -->


<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [x] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [ ] I'm merging against the `development` branch
* [ ] I ran `cargo-fmt --all` before pushing
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
