### PR TITLE
Tari transactions

### DIFF
--- a/base_layer/core/src/block.rs
+++ b/base_layer/core/src/block.rs
@@ -26,8 +26,8 @@
 use crate::{
     blockheader::BlockHeader,
     transaction::{TransactionError, TransactionInput, TransactionKernel, TransactionOutput},
+    types::{BlindingFactor, PublicKey},
 };
-use crate::types::{PublicKey, BlindingFactor};
 
 //----------------------------------------         Blocks         ----------------------------------------------------//
 

--- a/base_layer/core/src/block.rs
+++ b/base_layer/core/src/block.rs
@@ -26,7 +26,6 @@
 use crate::{
     blockheader::BlockHeader,
     transaction::{TransactionError, TransactionInput, TransactionKernel, TransactionOutput},
-    types::{BlindingFactor, PublicKey},
 };
 
 //----------------------------------------         Blocks         ----------------------------------------------------//

--- a/base_layer/core/src/block.rs
+++ b/base_layer/core/src/block.rs
@@ -27,6 +27,7 @@ use crate::{
     blockheader::BlockHeader,
     transaction::{TransactionError, TransactionInput, TransactionKernel, TransactionOutput},
 };
+use crate::types::PublicKey;
 
 //----------------------------------------         Blocks         ----------------------------------------------------//
 
@@ -122,8 +123,9 @@ impl AggregateBody {
         self.sorted = true;
     }
 
-    /// Verify the signatures in all kernels contained in this aggregate body
-    pub fn verify_kernel_signatures(&mut self) -> Result<(), TransactionError> {
+    /// Verify the signatures in all kernels contained in this aggregate body. Clients must provide an offset that
+    /// will be added to the public key used in the signature verification.
+    pub fn verify_kernel_signatures(&mut self, offset: &PublicKey) -> Result<(), TransactionError> {
         if !self.sorted {
             self.sort();
         }

--- a/base_layer/core/src/block.rs
+++ b/base_layer/core/src/block.rs
@@ -27,7 +27,7 @@ use crate::{
     blockheader::BlockHeader,
     transaction::{TransactionError, TransactionInput, TransactionKernel, TransactionOutput},
 };
-use crate::types::PublicKey;
+use crate::types::{PublicKey, BlindingFactor};
 
 //----------------------------------------         Blocks         ----------------------------------------------------//
 
@@ -125,7 +125,7 @@ impl AggregateBody {
 
     /// Verify the signatures in all kernels contained in this aggregate body. Clients must provide an offset that
     /// will be added to the public key used in the signature verification.
-    pub fn verify_kernel_signatures(&mut self, offset: &PublicKey) -> Result<(), TransactionError> {
+    pub fn verify_kernel_signatures(&mut self) -> Result<(), TransactionError> {
         if !self.sorted {
             self.sort();
         }

--- a/base_layer/core/src/blockheader.rs
+++ b/base_layer/core/src/blockheader.rs
@@ -26,8 +26,7 @@
 use crate::{pow::ProofOfWork, types::*};
 use chrono::{DateTime, Utc};
 use digest::Input;
-use tari_crypto::{common::Blake256, ristretto::RistrettoSecretKey};
-use tari_infra_derive::{ExtendBytes, Hashable};
+use tari_infra_derive::Hashable;
 use tari_utilities::{ExtendBytes, Hashable};
 
 type BlockHash = [u8; 32];

--- a/base_layer/core/src/lib.rs
+++ b/base_layer/core/src/lib.rs
@@ -34,4 +34,4 @@ pub mod transaction_protocol;
 pub mod types;
 
 // Re-export commonly used structs
-pub use transaction_protocol::{receiver::ReceiverTransactionProtocol, sender::SenderTransactionProtocol};
+pub use transaction_protocol::{recipient::ReceiverTransactionProtocol, sender::SenderTransactionProtocol};

--- a/base_layer/core/src/lib.rs
+++ b/base_layer/core/src/lib.rs
@@ -32,3 +32,6 @@ pub mod range_proof;
 pub mod transaction;
 pub mod transaction_protocol;
 pub mod types;
+
+// Re-export commonly used structs
+pub use transaction_protocol::{receiver::ReceiverTransactionProtocol, sender::SenderTransactionProtocol};

--- a/base_layer/core/src/pow.rs
+++ b/base_layer/core/src/pow.rs
@@ -22,7 +22,7 @@
 
 use crate::types::*;
 use digest::Input;
-use tari_infra_derive::{ExtendBytes, Hashable};
+use tari_infra_derive::Hashable;
 use tari_utilities::{ExtendBytes, Hashable};
 
 #[derive(Clone, Debug, PartialEq, Hashable)]

--- a/base_layer/core/src/transaction.rs
+++ b/base_layer/core/src/transaction.rs
@@ -31,7 +31,7 @@ use crate::{
 
 use crate::{
     transaction_protocol::{build_challenge, TransactionMetadata},
-    types::{HashDigest, PublicKey, SecretKey, SignatureHash},
+    types::{HashDigest, PublicKey, SecretKey},
 };
 use derive_error::Error;
 use digest::Input;
@@ -514,14 +514,11 @@ impl TransactionBuilder {
 mod test {
     use super::*;
     use crate::{
-        transaction::{KernelFeatures, OutputFeatures, TransactionInput, TransactionKernel, TransactionOutput},
-        types::{BlindingFactor, PublicKey, SecretKey},
+        transaction::{OutputFeatures, TransactionInput},
+        types::BlindingFactor,
     };
     use rand;
-    use tari_crypto::{
-        common::Blake256,
-        keys::{PublicKey as PublicKeyTrait, SecretKey as SecretKeyTrait},
-    };
+    use tari_crypto::keys::SecretKey as SecretKeyTrait;
 
     #[test]
     fn unblinded_input() {

--- a/base_layer/core/src/transaction.rs
+++ b/base_layer/core/src/transaction.rs
@@ -29,15 +29,17 @@ use crate::{
     types::{BlindingFactor, Commitment, CommitmentFactory, Signature},
 };
 
-use crate::types::{HashDigest, SecretKey, SignatureHash, PublicKey};
+use crate::{
+    transaction_protocol::{build_challenge, TransactionMetadata},
+    types::{HashDigest, PublicKey, SecretKey, SignatureHash},
+};
 use derive_error::Error;
 use digest::Input;
 use tari_crypto::{
-    keys::PublicKey as PK,
     commitment::{HomomorphicCommitment, HomomorphicCommitmentFactory},
+    keys::PublicKey as PK,
 };
 use tari_utilities::{ByteArray, Hashable};
-use crate::transaction_protocol::{build_challenge, TransactionMetadata};
 
 // These are set fairly arbitrarily at the moment. We'll need to do some modelling / testing to tune these values.
 pub const MAX_TRANSACTION_INPUTS: usize = 500;
@@ -320,7 +322,10 @@ impl TransactionKernel {
     pub fn verify_signature(&self) -> Result<(), TransactionError> {
         let excess = self.excess.as_public_key();
         let r = self.excess_sig.get_public_nonce();
-        let m = TransactionMetadata { lock_height: self.lock_height, fee: self.fee };
+        let m = TransactionMetadata {
+            lock_height: self.lock_height,
+            fee: self.fee,
+        };
         let c = build_challenge(r, &m);
         if self.excess_sig.verify_challenge(excess, c) {
             return Ok(());
@@ -372,7 +377,7 @@ impl Transaction {
     ) -> Transaction
     {
         Transaction {
-            offset: offset,
+            offset,
             body: AggregateBody::new(inputs, outputs, kernels),
         }
     }

--- a/base_layer/core/src/transaction_protocol/mod.rs
+++ b/base_layer/core/src/transaction_protocol/mod.rs
@@ -17,22 +17,22 @@
 //!   sequenceDiagram
 //!   participant Sender
 //!   participant Receivers
-//!
+//!#
 //!   activate Sender
 //!   Sender-->>Sender: initialize
 //!   deactivate Sender
-//!
+//!#
 //!   activate Sender
 //!   Sender-->>+Receivers: [tx_id, amount_i]
 //!   note left of Sender: CollectingPubKeys
 //!   note right of Receivers: Initialization
 //!   Receivers-->>-Sender: [tx_id, Pi, Ri]
 //!   deactivate Sender
-//!
+//!#
 //!   alt invalid
 //!   Sender--XSender: failed
 //!   end
-//!
+//!#
 //!   activate Sender
 //!   Sender-->>+Receivers: [tx_id, ΣR, ΣP]
 //!   note left of Sender: CollectingSignatures
@@ -40,7 +40,7 @@
 //!   Receivers-->>Receivers: create output and sign
 //!   Receivers-->>-Sender: [tx_id, Output_i, s_i]
 //!   deactivate Sender
-//!
+//!#
 //!   note left of Sender: Finalizing
 //!   alt is_valid()
 //!   Sender-->>Sender: Finalized
@@ -53,6 +53,8 @@ pub mod receiver;
 pub mod sender;
 pub mod single_receiver;
 pub mod transaction_initializer;
+#[cfg(test)]
+pub mod test_common;
 
 use crate::{
     transaction::TransactionError,
@@ -96,7 +98,7 @@ pub struct TransactionMetadata {
 }
 
 /// Convenience function that calculates the challenge for the Schnorr signatures
-pub(self) fn build_challenge(
+pub fn build_challenge(
     sum_public_nonces: &PublicKey,
     sum_public_keys: &PublicKey,
     metadata: &TransactionMetadata,

--- a/base_layer/core/src/transaction_protocol/mod.rs
+++ b/base_layer/core/src/transaction_protocol/mod.rs
@@ -17,22 +17,22 @@
 //!   sequenceDiagram
 //!   participant Sender
 //!   participant Receivers
-//!#
+//! #
 //!   activate Sender
 //!   Sender-->>Sender: initialize
 //!   deactivate Sender
-//!#
+//! #
 //!   activate Sender
 //!   Sender-->>+Receivers: [tx_id, amount_i]
 //!   note left of Sender: CollectingPubKeys
 //!   note right of Receivers: Initialization
 //!   Receivers-->>-Sender: [tx_id, Pi, Ri]
 //!   deactivate Sender
-//!#
+//! #
 //!   alt invalid
 //!   Sender--XSender: failed
 //!   end
-//!#
+//! #
 //!   activate Sender
 //!   Sender-->>+Receivers: [tx_id, ΣR, ΣP]
 //!   note left of Sender: CollectingSignatures
@@ -40,7 +40,7 @@
 //!   Receivers-->>Receivers: create output and sign
 //!   Receivers-->>-Sender: [tx_id, Output_i, s_i]
 //!   deactivate Sender
-//!#
+//! #
 //!   note left of Sender: Finalizing
 //!   alt is_valid()
 //!   Sender-->>Sender: Finalized
@@ -52,9 +52,9 @@
 pub mod receiver;
 pub mod sender;
 pub mod single_receiver;
-pub mod transaction_initializer;
 #[cfg(test)]
 pub mod test_common;
+pub mod transaction_initializer;
 
 use crate::{
     transaction::TransactionError,
@@ -98,11 +98,7 @@ pub struct TransactionMetadata {
 }
 
 /// Convenience function that calculates the challenge for the Schnorr signatures
-pub fn build_challenge(
-    sum_public_nonces: &PublicKey,
-    metadata: &TransactionMetadata,
-) -> Challenge<SignatureHash>
-{
+pub fn build_challenge(sum_public_nonces: &PublicKey, metadata: &TransactionMetadata) -> Challenge<SignatureHash> {
     Challenge::<SignatureHash>::new()
         .concat(sum_public_nonces.as_bytes())
         .concat(&metadata.fee.to_le_bytes())

--- a/base_layer/core/src/transaction_protocol/mod.rs
+++ b/base_layer/core/src/transaction_protocol/mod.rs
@@ -49,7 +49,7 @@
 //!   end
 //! </div>
 
-pub mod receiver;
+pub mod recipient;
 pub mod sender;
 pub mod single_receiver;
 #[cfg(test)]

--- a/base_layer/core/src/transaction_protocol/mod.rs
+++ b/base_layer/core/src/transaction_protocol/mod.rs
@@ -92,21 +92,19 @@ pub enum TransactionProtocolError {
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub struct TransactionMetadata {
     /// The absolute fee for the transaction
-    fee: u64,
+    pub fee: u64,
     /// The earliest block this transaction can be mined
-    lock_height: u64,
+    pub lock_height: u64,
 }
 
 /// Convenience function that calculates the challenge for the Schnorr signatures
 pub fn build_challenge(
     sum_public_nonces: &PublicKey,
-    sum_public_keys: &PublicKey,
     metadata: &TransactionMetadata,
 ) -> Challenge<SignatureHash>
 {
     Challenge::<SignatureHash>::new()
         .concat(sum_public_nonces.as_bytes())
-        .concat(sum_public_keys.as_bytes())
         .concat(&metadata.fee.to_le_bytes())
         .concat(&metadata.lock_height.to_le_bytes())
 }

--- a/base_layer/core/src/transaction_protocol/receiver.rs
+++ b/base_layer/core/src/transaction_protocol/receiver.rs
@@ -69,7 +69,7 @@ pub struct RecipientSignedTransactionData {
 //}
 
 pub struct ReceiverTransactionProtocol {
-    _state: RecipientState,
+    state: RecipientState,
 }
 
 impl ReceiverTransactionProtocol {
@@ -87,7 +87,21 @@ impl ReceiverTransactionProtocol {
             },
             SenderMessage::Multiple => Self::run_multi_recipient_protocol(),
         };
-        ReceiverTransactionProtocol { _state: state }
+        ReceiverTransactionProtocol { state }
+    }
+
+    pub fn is_finalized(&self) -> bool {
+        match self.state {
+            RecipientState::Finalized(_) => true,
+            _ => false,
+        }
+    }
+
+    pub fn get_signed_data(&self) -> Result<&RecipientSignedTransactionData, TransactionProtocolError> {
+        match &self.state {
+            RecipientState::Finalized(data) => Ok(&data),
+            _ => Err(TransactionProtocolError::InvalidStateError),
+        }
     }
 
     fn run_single_recipient_protocol(

--- a/base_layer/core/src/transaction_protocol/receiver.rs
+++ b/base_layer/core/src/transaction_protocol/receiver.rs
@@ -21,14 +21,16 @@
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 use crate::{
-    transaction::{ OutputFeatures, TransactionOutput},
-    transaction_protocol::TransactionProtocolError,
+    transaction::{OutputFeatures, TransactionOutput},
+    transaction_protocol::{
+        sender::{SenderMessage, SingleRoundSenderData},
+        single_receiver::SingleReceiverTransactionProtocol,
+        TransactionProtocolError,
+    },
     types::{PublicKey, SecretKey, Signature},
 };
 use std::collections::HashMap;
 use tari_crypto::challenge::MessageHash;
-use crate::transaction_protocol::sender::{SenderMessage, SingleRoundSenderData};
-use crate::transaction_protocol::single_receiver::SingleReceiverTransactionProtocol;
 
 pub enum RecipientState {
     Finalized(RecipientSignedTransactionData),
@@ -67,7 +69,7 @@ pub struct RecipientSignedTransactionData {
 //}
 
 pub struct ReceiverTransactionProtocol {
-    state: RecipientState,
+    _state: RecipientState,
 }
 
 impl ReceiverTransactionProtocol {
@@ -85,7 +87,7 @@ impl ReceiverTransactionProtocol {
             },
             SenderMessage::Multiple => Self::run_multi_recipient_protocol(),
         };
-        ReceiverTransactionProtocol { state }
+        ReceiverTransactionProtocol { _state: state }
     }
 
     fn run_single_recipient_protocol(

--- a/base_layer/core/src/transaction_protocol/sender.rs
+++ b/base_layer/core/src/transaction_protocol/sender.rs
@@ -227,7 +227,6 @@ impl SenderTransactionProtocol {
         }
         tx_builder.add_offset(info.offset.clone());
         let mut s_agg = info.signatures[0].clone();
-        let mut r_sum = info.public_nonce.clone();
         info.signatures.iter().skip(1).for_each(|s| s_agg = &s_agg + s);
         let excess = CommitmentFactory::from_public_key(&info.public_excess);
         let kernel = KernelBuilder::new()
@@ -305,7 +304,7 @@ impl SenderTransactionProtocol {
     pub fn finalize(&mut self, features: KernelFeatures) -> Result<bool, TPE> {
         // Create the final aggregated signature, moving to the Failed state if anything goes wrong
         match &mut self.state {
-            SenderState::Finalizing(info) => {
+            SenderState::Finalizing(_) => {
                 if let Err(e) = self.sign() {
                     self.state = SenderState::Failed(e);
                     return Ok(false);

--- a/base_layer/core/src/transaction_protocol/sender.rs
+++ b/base_layer/core/src/transaction_protocol/sender.rs
@@ -389,12 +389,10 @@ mod test {
         fee::Fee,
         transaction::{KernelFeatures, OutputFeatures, UnblindedOutput},
         transaction_protocol::{
-            receiver::RecipientSignedTransactionData,
             sender::SenderTransactionProtocol,
             single_receiver::SingleReceiverTransactionProtocol,
             test_common::{make_input, TestParams},
         },
-        types::PublicKey,
     };
     use rand::OsRng;
     use tari_crypto::common::Blake256;

--- a/base_layer/core/src/transaction_protocol/sender.rs
+++ b/base_layer/core/src/transaction_protocol/sender.rs
@@ -34,7 +34,7 @@ use crate::{
     transaction::{KernelBuilder, MAX_TRANSACTION_INPUTS, MAX_TRANSACTION_OUTPUTS, MINIMUM_TRANSACTION_FEE},
     transaction_protocol::{
         build_challenge,
-        receiver::{RecipientInfo, RecipientSignedTransactionData},
+        recipient::{RecipientInfo, RecipientSignedTransactionData},
         transaction_initializer::SenderTransactionInitializer,
         TransactionMetadata,
         TransactionProtocolError as TPE,

--- a/base_layer/core/src/transaction_protocol/sender.rs
+++ b/base_layer/core/src/transaction_protocol/sender.rs
@@ -36,12 +36,13 @@ use crate::{
         receiver::{RecipientInfo, RecipientSignedTransactionData},
         transaction_initializer::SenderTransactionInitializer,
         TransactionMetadata,
-        TransactionProtocolError,
+        TransactionProtocolError as TPE,
     },
 };
 use digest::Digest;
 use tari_crypto::commitment::HomomorphicCommitmentFactory;
 use tari_utilities::ByteArray;
+use crate::transaction::KernelBuilder;
 
 //----------------------------------------   Local Data types     ----------------------------------------------------//
 
@@ -85,6 +86,13 @@ pub struct SingleRoundSenderData {
     pub metadata: TransactionMetadata,
 }
 
+pub enum SenderMessage {
+    None,
+    Single(Box<SingleRoundSenderData>),
+    // TODO: Three round types
+    Multiple,
+}
+
 //----------------------------------------  Sender State Protocol ----------------------------------------------------//
 #[derive(Debug)]
 pub struct SenderTransactionProtocol {
@@ -96,6 +104,185 @@ impl SenderTransactionProtocol {
     /// builder function
     pub fn new(num_recipients: usize) -> SenderTransactionInitializer {
         SenderTransactionInitializer::new(num_recipients)
+    }
+
+    /// Convenience method to check whether we're receiving recipient data
+    pub fn is_collecting_single_signature(&self) -> bool {
+        match &self.state {
+            SenderState::CollectingSingleSignature(_) => true,
+            _ => false,
+        }
+    }
+
+    /// Method to determine if we are in the SenderState::FinalizedTransaction state
+    pub fn is_finalized(&self) -> bool {
+        match &self.state {
+            SenderState::FinalizedTransaction(_) => true,
+            _ => false,
+        }
+    }
+
+    /// Method to determine if the transaction protocol has failed
+    pub fn is_failed(&self) -> bool {
+        match &self.state {
+            SenderState::Failed(_) => true,
+            _ => false,
+        }
+    }
+
+    /// Method to return the error behind a failure, if one has occurred
+    pub fn failure_reason(&self) -> Option<TPE> {
+        match &self.state {
+            SenderState::Failed(e) => Some(e.clone()),
+            _ => None,
+        }
+    }
+
+    pub fn get_total_amount(&self) -> Result<u64, TPE> {
+        match &self.state {
+            SenderState::Initializing(info) |
+            SenderState::Finalizing(info) |
+            SenderState::SingleRoundMessageReady(info) |
+            SenderState::CollectingSingleSignature(info) => Ok(info.amounts.iter().sum::<u64>()),
+            SenderState::FinalizedTransaction(_) => Err(TPE::InvalidStateError),
+            SenderState::Failed(_) => Err(TPE::InvalidStateError),
+        }
+    }
+
+    /// Build the sender's message for the single-round protocol (one recipient) and move to next State
+    pub fn build_single_round_message(&mut self) -> Result<SingleRoundSenderData, TPE> {
+        match &self.state {
+            SenderState::SingleRoundMessageReady(info) => {
+                let result = SingleRoundSenderData {
+                    tx_id: info.ids[0],
+                    amount: self.get_total_amount().unwrap(),
+                    public_nonce: info.public_nonce.clone(),
+                    public_excess: info.public_nonce.clone(),
+                    metadata: info.metadata.clone(),
+                };
+                self.state = SenderState::CollectingSingleSignature(info.clone());
+                Ok(result)
+            },
+            _ => Err(TPE::InvalidStateError),
+        }
+    }
+
+    /// Add the signed transaction from the recipient and move to the next state
+    pub fn add_single_recipient_info(&mut self, rec: RecipientSignedTransactionData) -> Result<(), TPE> {
+        match &mut self.state {
+            SenderState::CollectingSingleSignature(info) => {
+                // Consolidate transaction info
+                info.outputs.push(rec.output);
+                info.signatures.push(rec.partial_signature);
+                self.state = SenderState::Finalizing(info.clone());
+                Ok(())
+            },
+            _ => Err(TPE::InvalidStateError),
+        }
+    }
+
+    /// Attempts to build the final transaction.
+    fn build_transaction(info: &RawTransactionInfo, features: KernelFeatures) -> Result<Transaction, TPE> {
+        let mut tx_builder = TransactionBuilder::new();
+        for i in &info.inputs {
+            tx_builder.add_input(i.clone());
+        }
+
+        for o in &info.outputs {
+            tx_builder.add_output(o.clone());
+        }
+        tx_builder.add_offset(info.offset.clone());
+        let mut s_agg = info.signatures[0].clone();
+        info.signatures.iter().take(1).for_each(|s| s_agg = &s_agg + s);
+        let excess = CommitmentFactory::from_public_key(&info.public_excess);
+        let kernel = KernelBuilder::new()
+            .with_fee(info.metadata.fee)
+            .with_features(features)
+            .with_lock_height(info.metadata.lock_height)
+            .with_excess(&excess)
+            .with_signature(&s_agg)
+            .build()?;
+        tx_builder.with_kernel(kernel);
+        let tx = tx_builder.build()?;
+        Ok(tx)
+    }
+
+    /// Performs sanitary checks on the collected transaction pieces prior to building the final Transaction instance
+    fn validate(&self) -> Result<(), TPE> {
+        if let SenderState::Finalizing(info) = &self.state {
+            // The fee should be less than the amount. This isn't a protocol requirement, but it's what you want 99.999%
+            // of the time, and our users will thank us if we reject a tx where they put the amount in the fee field by
+            // mistake!
+            let total_amount = info.calculate_total_amount();
+            let fee = info.metadata.fee;
+            if fee > total_amount {
+                return Err(TPE::ValidationError(
+                    "Fee is greater than amount".into(),
+                ));
+            }
+            // The fee must be greater than MIN_FEE to prevent spam attacks
+            if fee < MINIMUM_TRANSACTION_FEE {
+                return Err(TPE::ValidationError(
+                    "Fee is less than the minimum".into(),
+                ));
+            }
+            // Prevent overflow attacks by imposing sane limits on some key parameters
+            if info.inputs.len() > MAX_TRANSACTION_INPUTS {
+                return Err(TPE::ValidationError(
+                    "Too many inputs in transaction".into(),
+                ));
+            }
+            if info.outputs.len() > MAX_TRANSACTION_OUTPUTS {
+                return Err(TPE::ValidationError(
+                    "Too many outputs in transaction".into(),
+                ));
+            }
+            if info.inputs.len() == 0 {
+                return Err(TPE::ValidationError(
+                    "A transaction cannot have zero inputs".into(),
+                ));
+            }
+            if info.signatures.len() != 1 + info.num_recipients {
+                return Err(TPE::ValidationError(format!(
+                    "Incorrect number of signatures ({})",
+                    info.signatures.len()
+                )));
+            }
+            Ok(())
+        } else {
+            Err(TPE::InvalidStateError)
+        }
+    }
+
+    /// Try and finalise the transaction. If the current state is Finalizing, the result will be whether the
+    /// transaction was valid or not. If the result is false, the transaction will be in a Failed state. Calling
+    /// finalize while in any other state will result in an error.
+    ///
+    /// First we validate against internal sanity checks, then try build the transaction, and then
+    /// formally validate the transaction terms (no inflation, signature matches etc). If any step fails,
+    /// the transaction protocol moves to Failed state and we are done; you can't rescue the situation. The function
+    /// returns `Ok(false)` in this instance.
+    pub fn finalize(&mut self, features: KernelFeatures) -> Result<bool, TPE> {
+        match &self.state {
+            SenderState::Finalizing(info) => {
+                let result = self.validate().and_then(|_| Self::build_transaction(info, features));
+                if let Err(e) = result {
+                    self.state = SenderState::Failed(e);
+                    return Ok(false);
+                }
+                let mut transaction = result.unwrap();
+                let result = transaction
+                    .validate_internal_consistency()
+                    .map_err(|e| TPE::TransactionBuildError(e));
+                if let Err(e) = result {
+                    self.state = SenderState::Failed(e);
+                    return Ok(false);
+                }
+                self.state = SenderState::FinalizedTransaction(transaction);
+                Ok(true)
+            },
+            _ => Err(TPE::InvalidStateError),
+        }
     }
 }
 
@@ -123,20 +310,20 @@ pub(super) enum SenderState {
     /// The final transaction is ready to be broadcast
     FinalizedTransaction(Transaction),
     /// An unrecoverable failure has occurred and the transaction must be abandoned
-    Failed(TransactionProtocolError),
+    Failed(TPE),
 }
 
 impl SenderState {
-    pub fn initialize(self) -> Result<SenderState, TransactionProtocolError> {
+    pub fn initialize(self) -> Result<SenderState, TPE> {
         match self {
             SenderState::Initializing(info) => match info.num_recipients {
                 0 => Ok(SenderState::Finalizing(info)),
                 1 => Ok(SenderState::SingleRoundMessageReady(info)),
-                _ => Ok(SenderState::Failed(TransactionProtocolError::UnsupportedError(
+                _ => Ok(SenderState::Failed(TPE::UnsupportedError(
                     "Multiple recipients are not supported yet".into(),
                 ))),
             },
-            _ => Err(TransactionProtocolError::InvalidTransitionError),
+            _ => Err(TPE::InvalidTransitionError),
         }
     }
 }

--- a/base_layer/core/src/transaction_protocol/single_receiver.rs
+++ b/base_layer/core/src/transaction_protocol/single_receiver.rs
@@ -25,7 +25,7 @@ use crate::{
     transaction::{OutputFeatures, TransactionOutput},
     transaction_protocol::{
         build_challenge,
-        receiver::RecipientSignedTransactionData as RD,
+        recipient::RecipientSignedTransactionData as RD,
         sender::SingleRoundSenderData as SD,
         TransactionProtocolError as TPE,
     },

--- a/base_layer/core/src/transaction_protocol/single_receiver.rs
+++ b/base_layer/core/src/transaction_protocol/single_receiver.rs
@@ -49,7 +49,6 @@ impl SingleReceiverTransactionProtocol {
         let public_spending_key = PublicKey::from_secret_key(&spending_key);
         let e = build_challenge(
             &(&sender_info.public_nonce + &public_nonce),
-            &(&sender_info.public_excess + &public_spending_key),
             &sender_info.metadata,
         );
         let signature = Signature::sign(spending_key, nonce, e).map_err(|e| TPE::SigningError(e))?;
@@ -135,7 +134,7 @@ mod test {
         assert_eq!(prot.tx_id, 500, "tx_id is incorrect");
         // Check the signature
         assert_eq!(prot.public_spend_key, pubkey, "Public key is incorrect");
-        let e = build_challenge(&(&pub_rs + &pubnonce), &(&pub_xs + &pubkey), &m);
+        let e = build_challenge(&(&pub_rs + &pubnonce), &m);
         assert!(
             prot.partial_signature.verify_challenge(&pubkey, e),
             "Partial signature is incorrect"

--- a/base_layer/core/src/transaction_protocol/single_receiver.rs
+++ b/base_layer/core/src/transaction_protocol/single_receiver.rs
@@ -111,8 +111,8 @@ mod test {
     #[test]
     fn valid_request() {
         let mut rng = OsRng::new().unwrap();
-        let (xs, pub_xs) = PublicKey::random_keypair(&mut rng);
-        let (rs, pub_rs) = PublicKey::random_keypair(&mut rng);
+        let (_xs, pub_xs) = PublicKey::random_keypair(&mut rng);
+        let (_rs, pub_rs) = PublicKey::random_keypair(&mut rng);
         let (r, k, of) = generate_output_parms();
         let pubkey = PublicKey::from_secret_key(&k);
         let pubnonce = PublicKey::from_secret_key(&r);

--- a/base_layer/core/src/transaction_protocol/single_receiver.rs
+++ b/base_layer/core/src/transaction_protocol/single_receiver.rs
@@ -47,10 +47,7 @@ impl SingleReceiverTransactionProtocol {
         let output = SingleReceiverTransactionProtocol::build_output(sender_info, &spending_key, features)?;
         let public_nonce = PublicKey::from_secret_key(&nonce);
         let public_spending_key = PublicKey::from_secret_key(&spending_key);
-        let e = build_challenge(
-            &(&sender_info.public_nonce + &public_nonce),
-            &sender_info.metadata,
-        );
+        let e = build_challenge(&(&sender_info.public_nonce + &public_nonce), &sender_info.metadata);
         let signature = Signature::sign(spending_key, nonce, e).map_err(|e| TPE::SigningError(e))?;
         let data = RD {
             tx_id: sender_info.tx_id,

--- a/base_layer/core/src/transaction_protocol/test_common.rs
+++ b/base_layer/core/src/transaction_protocol/test_common.rs
@@ -1,0 +1,61 @@
+// Copyright 2019. The Tari Project
+//
+// Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+// following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+// disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+// following disclaimer in the documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+// products derived from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+// INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+// WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+// USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+// Used in tests only
+
+use crate::types::{SecretKey, PublicKey, CommitmentFactory};
+use rand::{Rng, CryptoRng};
+use crate::transaction::{TransactionInput, UnblindedOutput, OutputFeatures};
+use tari_crypto::{
+    commitment::HomomorphicCommitmentFactory,
+    keys::{PublicKey as PK, SecretKey as SK},
+};
+
+pub struct TestParams {
+    pub spend_key: SecretKey,
+    pub change_key: SecretKey,
+    pub offset: SecretKey,
+    pub nonce: SecretKey,
+    pub public_nonce: PublicKey,
+}
+
+impl TestParams {
+    pub fn new<R: Rng + CryptoRng>(rng: &mut R) -> TestParams {
+        let r = SecretKey::random(rng);
+        TestParams {
+            spend_key: SecretKey::random(rng),
+            change_key: SecretKey::random(rng),
+            offset: SecretKey::random(rng),
+            public_nonce: PublicKey::from_secret_key(&r),
+            nonce: r,
+        }
+    }
+}
+
+pub fn make_input<R: Rng + CryptoRng>(rng: &mut R, val: u64) -> (TransactionInput, UnblindedOutput) {
+    let key = SecretKey::random(rng);
+    let v = SecretKey::from(val);
+    let commitment = CommitmentFactory::create(&key, &v);
+    let input = TransactionInput::new(OutputFeatures::empty(), commitment);
+    (input, UnblindedOutput::new(val, key, None))
+}
+

--- a/base_layer/core/src/transaction_protocol/test_common.rs
+++ b/base_layer/core/src/transaction_protocol/test_common.rs
@@ -22,9 +22,11 @@
 
 // Used in tests only
 
-use crate::types::{SecretKey, PublicKey, CommitmentFactory};
-use rand::{Rng, CryptoRng};
-use crate::transaction::{TransactionInput, UnblindedOutput, OutputFeatures};
+use crate::{
+    transaction::{OutputFeatures, TransactionInput, UnblindedOutput},
+    types::{CommitmentFactory, PublicKey, SecretKey},
+};
+use rand::{CryptoRng, Rng};
 use tari_crypto::{
     commitment::HomomorphicCommitmentFactory,
     keys::{PublicKey as PK, SecretKey as SK},
@@ -58,4 +60,3 @@ pub fn make_input<R: Rng + CryptoRng>(rng: &mut R, val: u64) -> (TransactionInpu
     let input = TransactionInput::new(OutputFeatures::empty(), commitment);
     (input, UnblindedOutput::new(val, key, None))
 }
-

--- a/base_layer/core/src/transaction_protocol/transaction_initializer.rs
+++ b/base_layer/core/src/transaction_protocol/transaction_initializer.rs
@@ -30,7 +30,7 @@ use crate::{
         MINIMUM_TRANSACTION_FEE,
     },
     transaction_protocol::{
-        receiver::RecipientInfo,
+        recipient::RecipientInfo,
         sender::{calculate_tx_id, RawTransactionInfo, SenderState, SenderTransactionProtocol},
         TransactionMetadata,
     },

--- a/base_layer/core/src/transaction_protocol/transaction_initializer.rs
+++ b/base_layer/core/src/transaction_protocol/transaction_initializer.rs
@@ -267,7 +267,8 @@ impl SenderTransactionInitializer {
             offset_blinding_factor,
             public_excess: excess,
             private_nonce: nonce,
-            public_nonce,
+            public_nonce: public_nonce.clone(),
+            public_nonce_sum: public_nonce,
             recipient_info,
             signatures: Vec::new(),
         };
@@ -287,14 +288,14 @@ mod test {
         fee::{Fee, BASE_COST, COST_PER_INPUT, COST_PER_OUTPUT},
         transaction::{UnblindedOutput, MAX_TRANSACTION_INPUTS},
         transaction_protocol::{
-            sender::{SenderState},
+            sender::SenderState,
+            test_common::{make_input, TestParams},
             transaction_initializer::SenderTransactionInitializer,
             TransactionProtocolError,
         },
     };
-    use rand::{OsRng};
-    use tari_crypto::{common::Blake256};
-    use crate::transaction_protocol::test_common::{TestParams, make_input};
+    use rand::OsRng;
+    use tari_crypto::common::Blake256;
 
     /// One input, 2 outputs
     #[test]


### PR DESCRIPTION
## Description

This PR closes #42.

@philipr-za did most of the work here; this is largely a re-org of his code and generalisation to permit multi-receivers in future.

### Implement the sender protocol
 Implement the Sender side of the Tari transaction protocol using a finite state machine

### Fix mermaid diagram
    
cargo doc inserts `<p>` tags in paragraphs, so insert comments in the    mermaid diagram to keep formatting clear and still produce the correct    output

### Test for no recipient case

### Add single-round tests
    
 Add a test (and fix the bugs) for a single sender and recipient   including one with no change and one with change
 
 All that remains is to integrate range proofs!

### Add general Receiver protocol
    
 Receiver will need to figure out whether they're in a single- or multi-round    transaction

### Tidying up

* Clean up unused imports
* Add some colour to RecipientProtocol
* Add docstrings and tests for `ReceiverTransactionProtocol`

## Motivation and Context
Tari needs Transactions. This PR closes #42, and provides the core backend functionality for handling Tari transactions (multi-recipients are not supported yet)

## How Has This Been Tested?
Unit tests have been added

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [x] New Tests
* [x] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch
* [x] I ran `cargo-fmt --all` before pushing
* [x] My change requires a change to the documentation.
* [x] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
