### PR TITLE
Allow RangeProofService to be passed in for transaction verification

### DIFF
--- a/base_layer/core/src/transaction_protocol/recipient.rs
+++ b/base_layer/core/src/transaction_protocol/recipient.rs
@@ -181,7 +181,7 @@ mod test {
         assert_eq!(data.tx_id, 15);
         assert_eq!(data.public_spend_key, pubkey);
         assert!(data.output.commitment.validate(500, &p.spend_key));
-        assert!(data.output.verify_range_proof().unwrap());
+        assert!(data.output.verify_range_proof(None).unwrap());
         let r_sum = &msg.public_nonce + &p.public_nonce;
         let e = build_challenge(&r_sum, &m);
         let s = Signature::sign(p.spend_key.clone(), p.nonce.clone(), &e).unwrap();

--- a/base_layer/core/src/transaction_protocol/single_receiver.rs
+++ b/base_layer/core/src/transaction_protocol/single_receiver.rs
@@ -143,7 +143,7 @@ mod test {
         let out = &prot.output;
         // Check the output that was constructed
         assert!(out.commitment.validate(info.amount, &k), "Output commitment is invalid");
-        assert!(out.verify_range_proof().unwrap(), "Range proof is invalid");
+        assert!(out.verify_range_proof(None).unwrap(), "Range proof is invalid");
         assert!(out.features.is_empty(), "Output features have changed");
     }
 }


### PR DESCRIPTION
## Description
Originally a new RangeProofService was created for each transaction range proof verification. When verifying large batches of transactions it would be faster to create a single instance of a service and pass it in. This PR adds an Option<&RangeProofService> parameter to the verification methods so that if an RPS is provided it will be used or else a new one will be created. 

This parameter was set to None for all the transaction builder functions as this optimization is intended for batch verification of large sets of existing transactions and will not be a large overhead during the construction of a single transaction.

## Motivation and Context

## How Has This Been Tested?
Tests have been updated to use this parameter. Tests use both pass in an RPS and pass in None to test both cases.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [x] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch
* [x] I ran `cargo-fmt --all` before pushing
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
