### PR TITLE
Drop dalek dependency in tari_core

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -337,8 +337,8 @@ dependencies = [
  "blake2 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "derive-error 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "digest 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.89 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.89 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.90 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.90 (registry+https://github.com/rust-lang/crates.io-index)",
  "tari_infra_derive 0.0.1",
  "tari_utilities 0.0.1",
 ]
@@ -715,7 +715,6 @@ version = "0.0.1"
 dependencies = [
  "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "curve25519-dalek 1.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "derive-error 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "digest 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/base_layer/core/Cargo.toml
+++ b/base_layer/core/Cargo.toml
@@ -16,7 +16,6 @@ chrono = "0.4.6"
 tari_infra_derive = { path = "../../infrastructure/derive", version = "0.0.1" }
 digest = "0.8.0"
 tari_crypto = { path = "../../infrastructure/crypto", version = "0.0.1" }
-curve25519-dalek = "1.1.3"
 derive-error = "0.0.4"
 rand = "0.5.5"
 serde = "1.0.89"


### PR DESCRIPTION
We shouldn't explicitly depend on the dalek libraries in the domain layer

