### PR TITLE
Send connection ID as first frame to consumer connection

### DIFF
--- a/comms/Cargo.toml
+++ b/comms/Cargo.toml
@@ -9,17 +9,17 @@ version = "0.0.1"
 edition = "2018"
 
 [dependencies]
+bitflags ="1.0.4"
+chrono ="0.4.6"
 clear_on_drop = "0.2.3"
 derive-error = "0.0.4"
 rand = "0.5.5"
+rmp-serde = "0.13.7"
+serde = "1.0.90"
+serde_derive = "1.0.90"
 tari_crypto = { path = "../infrastructure/crypto"}
 tari_utilities = { path = "../infrastructure/tari_util"}
 zmq = "0.9"
-chrono ="0.4.6"
-bitflags ="1.0.4"
-serde = "1.0.90"
-serde_derive = "1.0.90"
-rmp-serde = "0.13.7"
 
 [dev-dependencies]
 criterion = "0.2"

--- a/comms/src/connection/peer_connection/connection.rs
+++ b/comms/src/connection/peer_connection/connection.rs
@@ -108,6 +108,7 @@ macro_rules! is_state {
 /// let addr: NetAddress = "127.0.0.1:8080".parse().unwrap();
 ///
 /// let peer_context = PeerConnectionContextBuilder::new()
+///    .set_id("123")
 ///    .set_context(&ctx)
 ///    .set_direction(Direction::Outbound)
 ///    .set_consumer_address(InprocAddress::random())

--- a/comms/src/connection/peer_connection/error.rs
+++ b/comms/src/connection/peer_connection/error.rs
@@ -41,6 +41,6 @@ pub enum PeerConnectionError {
     ShutdownError,
     /// Failed to establish a connection
     ConnectFailed,
-    /// An unexpected connection error occurred
-    UnexpectedConnectionError,
+    #[error(msg_embedded, non_std, no_from)]
+    UnexpectedConnectionError(String),
 }

--- a/comms/src/connection/peer_connection/mod.rs
+++ b/comms/src/connection/peer_connection/mod.rs
@@ -36,7 +36,7 @@
 /// A [PeerConnection] consists of these modules:
 ///
 /// 1. `connection` - responsible for starting and sending control messages to the PeerConnection
-///                   worker thread. This has a
+///                   worker thread.
 /// 2. `context` - Builder for a `PeerConnectionContext` which is owned by a PeerConnection worker
 ///                thread. This provides all the information required to create the underlying
 ///                connections to the peer and consumer.
@@ -62,12 +62,12 @@
 /// |     Connecting     |       |         |                  |
 /// |                    |-      |         +------------------+
 /// +---------|----------+ \ +-----+       +------------------+
-///          |              |     |       |                  |
-///          |              |     |-------+  Disconnected    |
-/// Accepted / Connected     |     |       |                  |
-///          |             /+-----+       +------------------+
-///          |            /     |         +------------------+
-///          |           /      |         |                  |
+///           |              |     |       |                  |
+///           |              |     |-------+  Disconnected    |
+///  Accepted / Connected    |     |       |                  |
+///           |             /+-----+       +------------------+
+///           |            /     |         +------------------+
+///           |           /      |         |                  |
 /// +---------------------       |         |     Failed       |
 /// |                    |       +----------                  |
 /// |     Connected      |                 +------------------+
@@ -86,6 +86,8 @@ mod context;
 mod control;
 mod error;
 mod worker;
+
+pub type ConnectionId = super::message::Frame;
 
 pub use self::{
     connection::PeerConnection,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR adds the connection id frame as the first frame on the consumer side of the PeerConnection. This will be used to map connections to peers.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Related #293 - We'll likely only need to connection ID added as the first frame without other metadata. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
The expected ID frame is checked on the consumer side in existing tests.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [x] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch
* [x] I ran `cargo-fmt --all` before pushing
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
