### PR TITLE
Close datastore

### DIFF
--- a/infrastructure/storage/src/keyvalue_store.rs
+++ b/infrastructure/storage/src/keyvalue_store.rs
@@ -73,6 +73,10 @@ pub trait DataStore {
         let val = serialize(value)?;
         self.put_raw(key, val)
     }
+
+    /// Close and release any underlying resources associated with the datastore. The instance is no longer
+    /// accessible from this point
+    fn close(self) -> Result<(), DatastoreError>;
 }
 
 /// BatchWrite is implemented on Datastores if it supports batch writes, or transactions, to efficiently write

--- a/infrastructure/storage/src/lmdb.rs
+++ b/infrastructure/storage/src/lmdb.rs
@@ -233,11 +233,11 @@ mod test {
             assert!(fs::remove_dir_all(test_dir).is_ok());
         }
         let msg = match sys_info::os_type() {
-            Ok(ref msg) if msg.to_uppercase() == "WINDOWS" => {
+            Ok(ref msg) if msg == "Windows" => {
                 "LMDB Error: The system cannot find the path specified.\r\n"
             },
-            Ok(ref msg) if msg.to_uppercase() == "LINUX" || msg == "DARWIN" => "LMDB Error: No such file or directory",
-            _ => ":(",
+            Ok(ref msg) if msg == "Linux" || msg == "Darwin" => "LMDB Error: No such file or directory",
+            _ => "LMDB Error: File or directory not found",
         };
         let builder = LMDBBuilder::new();
         match builder.set_mapsize(1).set_path(test_dir).build() {


### PR DESCRIPTION
There needs to be a general way to release resources from Datastores.
    LMDBStore recently implemented this in #303 ; now it is included in the trait