### PR TITLE
Allow connections in tests to linger to complete sending

### DIFF
--- a/comms/tests/connection/connection.rs
+++ b/comms/tests/connection/connection.rs
@@ -27,6 +27,7 @@ use tari_comms::connection::{
     types::Direction,
     zmq::{curve_keypair, Context, CurveEncryption, InprocAddress},
     ConnectionError,
+    Linger,
 };
 
 #[test]
@@ -35,7 +36,10 @@ fn inbound_receive_timeout() {
 
     let addr = InprocAddress::random();
 
-    let conn = Connection::new(&ctx, Direction::Inbound).establish(&addr).unwrap();
+    let conn = Connection::new(&ctx, Direction::Inbound)
+        .set_linger(Linger::Indefinitely)
+        .establish(&addr)
+        .unwrap();
 
     let result = conn.receive(1);
     assert!(result.is_err());
@@ -54,7 +58,10 @@ fn inbound_recv_send_inproc() {
 
     let req_rep_pattern = support::comms_patterns::async_request_reply(Direction::Outbound);
 
-    let conn = Connection::new(&ctx, Direction::Inbound).establish(&addr).unwrap();
+    let conn = Connection::new(&ctx, Direction::Inbound)
+        .set_linger(Linger::Indefinitely)
+        .establish(&addr)
+        .unwrap();
 
     let signal = req_rep_pattern
         .set_endpoint(addr.clone())
@@ -90,6 +97,7 @@ fn inbound_recv_send_encrypted_tcp() {
     let (sk, pk) = curve_keypair::generate().unwrap();
 
     let conn = Connection::new(&ctx, Direction::Inbound)
+        .set_linger(Linger::Indefinitely)
         .set_curve_encryption(CurveEncryption::Server { secret_key: sk })
         .establish(&addr)
         .unwrap();
@@ -124,6 +132,7 @@ fn outbound_send_recv_inproc() {
         .run(ctx.clone());
 
     let conn = Connection::new(&ctx, Direction::Outbound)
+        .set_linger(Linger::Indefinitely)
         .set_identity("identity")
         .establish(&addr)
         .unwrap();
@@ -157,6 +166,7 @@ fn outbound_send_recv_encrypted_tcp() {
         .run(ctx.clone());
 
     let conn = Connection::new(&ctx, Direction::Outbound)
+        .set_linger(Linger::Indefinitely)
         .set_curve_encryption(CurveEncryption::Client {
             secret_key: csk,
             public_key: cpk,

--- a/comms/tests/connection/peer_connection.rs
+++ b/comms/tests/connection/peer_connection.rs
@@ -21,7 +21,7 @@
 //  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 use crate::support::utils::find_available_tcp_net_address;
-use std::{thread, time::Duration};
+use std::time::Duration;
 use tari_comms::connection::{
     curve_keypair,
     Connection,
@@ -30,6 +30,7 @@ use tari_comms::connection::{
     CurveEncryption,
     Direction,
     InprocAddress,
+    Linger,
     PeerConnection,
     PeerConnectionContextBuilder,
     PeerConnectionError,
@@ -223,7 +224,10 @@ fn connection_pause_resume() {
     let consumer_addr = InprocAddress::random();
 
     // Connect to the sender (peer)
-    let sender = Connection::new(&ctx, Direction::Outbound).establish(&addr).unwrap();
+    let sender = Connection::new(&ctx, Direction::Outbound)
+        .set_linger(Linger::Indefinitely)
+        .establish(&addr)
+        .unwrap();
     let conn_id = "123".as_bytes();
 
     // Initialize and start peer connection
@@ -299,11 +303,11 @@ fn connection_disconnect() {
 
     {
         // Connect to the inbound connection and send a message
-        let sender = Connection::new(&ctx, Direction::Outbound).establish(&addr).unwrap();
+        let sender = Connection::new(&ctx, Direction::Outbound)
+            .set_linger(Linger::Indefinitely)
+            .establish(&addr)
+            .unwrap();
         sender.send(&[&[123u8]]).unwrap();
-        // Without this pause, it's possible for the connection to drop before it
-        // has connected.
-        thread::sleep(Duration::from_millis(50));
     }
 
     conn.wait_disconnected(Duration::from_millis(2000)).unwrap();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This is a fix for flaky connection tests. This change sets connections to linger for as long as they need to complete sending. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Should fix failing tests like this one: https://circleci.com/gh/tari-project/tari/1458

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
`while true;do cargo test||break; done` was not able to produce a failure in comms tests with the fix

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch
* [x] I ran `cargo-fmt --all` before pushing
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
