### PR TITLE
Abstraction of zmq::proxy

### DIFF
--- a/comms/src/connection/dealer_proxy.rs
+++ b/comms/src/connection/dealer_proxy.rs
@@ -1,0 +1,110 @@
+//  Copyright 2019 The Tari Project
+//
+//  Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+//  following conditions are met:
+//
+//  1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+//  disclaimer.
+//
+//  2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+//  following disclaimer in the documentation and/or other materials provided with the distribution.
+//
+//  3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+//  products derived from this software without specific prior written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+//  INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+//  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+//  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+//  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+//  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+//  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+use std::thread;
+
+use derive_error::Error;
+
+use crate::connection::{Connection, ConnectionError, Context, Direction, InprocAddress, SocketEstablishment};
+
+#[derive(Debug, Error)]
+pub enum DealerProxyError {
+    #[error(msg_embedded, no_from, non_std)]
+    SocketError(String),
+    ConnectionError(ConnectionError),
+}
+
+/// A DealerProxy Result
+pub type Result<T> = std::result::Result<T, DealerProxyError>;
+
+/// Proxies two addresses, receiving from the source_address and fair dealing to the
+/// sink_address.
+pub struct DealerProxy {
+    source_address: InprocAddress,
+    sink_address: InprocAddress,
+}
+
+impl DealerProxy {
+    /// Creates a new DealerProxy.
+    pub fn new(source_address: InprocAddress, sink_address: InprocAddress) -> Self {
+        Self {
+            source_address,
+            sink_address,
+        }
+    }
+
+    /// Proxy the source and sink addresses. This method does not block and returns
+    /// a [thread::JoinHandle] of the proxy thread.
+    pub fn spawn_proxy(self, context: Context) -> thread::JoinHandle<Result<()>> {
+        thread::spawn(move || self.proxy(&context))
+    }
+
+    /// Proxy the source and sink addresses. This method will block the current thread.
+    pub fn proxy(&self, context: &Context) -> Result<()> {
+        let source = Connection::new(context, Direction::Inbound)
+            .set_socket_establishment(SocketEstablishment::Bind)
+            .establish(&self.source_address)
+            .map_err(|err| DealerProxyError::ConnectionError(err))?;
+
+        let sink = Connection::new(context, Direction::Outbound)
+            .set_socket_establishment(SocketEstablishment::Bind)
+            .establish(&self.sink_address)
+            .map_err(|err| DealerProxyError::ConnectionError(err))?;
+
+        zmq::proxy(source.get_socket(), sink.get_socket()).map_err(|err| DealerProxyError::SocketError(err.to_string()))
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn threaded_proxy() {
+        let context = Context::new();
+        let sender_addr = InprocAddress::random();
+        let receiver_addr = InprocAddress::random();
+        let sender = Connection::new(&context, Direction::Outbound)
+            .establish(&sender_addr)
+            .unwrap();
+
+        let receiver = Connection::new(&context, Direction::Outbound)
+            .establish(&receiver_addr)
+            .unwrap();
+
+        let proxy = DealerProxy::new(sender_addr, receiver_addr);
+        proxy.spawn_proxy(context);
+
+        sender.send_sync(&["HELLO".as_bytes()]).unwrap();
+
+        let msg = receiver.receive(2000).unwrap();
+        assert_eq!("HELLO".as_bytes().to_vec(), msg[1]);
+
+        // You need to attach the identity frame to the head of the message
+        // so that the internal ZMQ_ROUTER will send messages back to the
+        // connection which sent the message
+        receiver.send_sync(&[&msg[0], "WORLD".as_bytes()]).unwrap();
+
+        let msg = sender.receive(2000).unwrap();
+        assert_eq!("WORLD".as_bytes().to_vec(), msg[0]);
+    }
+}

--- a/comms/src/connection/mod.rs
+++ b/comms/src/connection/mod.rs
@@ -21,6 +21,7 @@
 //  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 pub mod connection;
+pub mod dealer_proxy;
 pub mod error;
 pub mod message;
 pub mod monitor;
@@ -31,6 +32,7 @@ pub mod zmq;
 
 pub use self::{
     connection::Connection,
+    dealer_proxy::{DealerProxy, DealerProxyError},
     error::ConnectionError,
     message::MessageError,
     net_address::{NetAddress, NetAddressError},

--- a/comms/src/connection/types.rs
+++ b/comms/src/connection/types.rs
@@ -57,3 +57,19 @@ pub enum Direction {
     /// Connection establishes an outbound connection
     Outbound,
 }
+
+/// Used to select the method to use when establishing the connection.
+pub enum SocketEstablishment {
+    /// Select bind or connect based on connection [Direction](./enum.Direction.html)
+    Auto,
+    /// Always bind on the socket
+    Bind,
+    /// Always connect on the socket
+    Connect,
+}
+
+impl Default for SocketEstablishment {
+    fn default() -> Self {
+        SocketEstablishment::Auto
+    }
+}

--- a/comms/src/outbound_message_service/outbound_message.rs
+++ b/comms/src/outbound_message_service/outbound_message.rs
@@ -86,15 +86,12 @@ impl<T: Serialize + DeserializeOwned> TryFrom<Frame> for OutboundMessage<T> {
 #[cfg(test)]
 mod test {
     use super::*;
-    use tari_crypto::{
-        keys::{PublicKey, SecretKey},
-        ristretto::{RistrettoPublicKey, RistrettoSecretKey},
-    };
+    use tari_crypto::{keys::PublicKey, ristretto::RistrettoPublicKey};
 
     #[test]
     fn test_outbound_message() {
         let mut rng = rand::OsRng::new().unwrap();
-        let (sk, pk) = RistrettoPublicKey::random_keypair(&mut rng);
+        let (_sk, pk) = RistrettoPublicKey::random_keypair(&mut rng);
         let destination_node_id = NodeId::from_key(&pk).unwrap();
         let message_envelope: Frame = vec![0, 1, 2, 3, 4];
         let mut desired_outbound_message = OutboundMessage::<Frame>::new(destination_node_id, message_envelope);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Small abstraction of zmq proxy which is used in inbound message service. This may also be needed elsewhere (e.g. ControlService). The proxy requires `Connection` to be able to bind with an Inbound direction, so I've added another property to connections which allows you to optionally select the way the socket establishes connections (`Bind`, `Connect` or `Auto`(default))

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Related to #247 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tests for spawn proxy - inbound message service tests remain the same

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [x] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [x] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch
* [x] I ran `cargo-fmt --all` before pushing
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
