### PR TITLE
Remove asset discovery RFC

### DIFF
--- a/RFC/src/RFC-0314_AssetDiscovery.md
+++ b/RFC/src/RFC-0314_AssetDiscovery.md
@@ -1,6 +1,0 @@
-# RFC-0314/AssetDiscovery
-
-RFC placeholder.
-
-This document will describe how clients can discover which assets are being managed on the network and the basic ways of
-interacting with them.

--- a/RFC/src/SUMMARY.md
+++ b/RFC/src/SUMMARY.md
@@ -26,7 +26,6 @@
 - [RFC-0310: Asset Management](RFC-0310_AssetManagement.md)
   - [RFC-0311: Digital Asset templates](RFC-0311_AssetTemplates.md)
   - [RFC-0313: The asset read-only API](RFC-0313_AssetReadAPI.md)
-  - [RFC-0314: Asset discovery](RFC-0314_AssetDiscovery.md)
   - [RFC-0315: Asset transfer mechanism](RFC-0315_AssetTransfer.md)
   - [RFC-0316: Asset retirement](RFC-0316_AssetRetirement.md)
 - [RFC-0340: Validator Node Consensus](RFC-0340_VNConsensusOverview.md)


### PR DESCRIPTION
Asset discovery is simple enough that it can fall under the Tari Collections API
RFC.

Closes #88

<!--- Provide a general summary of your changes in the Title above -->

