### PR TITLE
OutboundMessageService

### DIFF
--- a/comms/Cargo.toml
+++ b/comms/Cargo.toml
@@ -20,6 +20,7 @@ serde_derive = "1.0.90"
 tari_crypto = { path = "../infrastructure/crypto"}
 tari_utilities = { path = "../infrastructure/tari_util"}
 zmq = "0.9"
+digest = "0.8.0"
 
 [dev-dependencies]
 criterion = "0.2"

--- a/comms/src/lib.rs
+++ b/comms/src/lib.rs
@@ -2,3 +2,4 @@ pub mod connection;
 pub mod inbound_message_service;
 pub mod outbound_message_service;
 pub mod peer_manager;
+pub mod types;

--- a/comms/src/outbound_message_service/broadcast_strategy.rs
+++ b/comms/src/outbound_message_service/broadcast_strategy.rs
@@ -20,6 +20,11 @@
 //  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 //  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-pub mod broadcast_strategy;
-pub mod outbound_message;
-pub mod outbound_message_service;
+use crate::peer_manager::node_id::NodeId;
+
+pub enum BroadcastStrategy {
+    Direct(NodeId), // Send to a particular peer matching the given node ID
+    Flood,          // Send to all known Communication Node peers
+    Closest(u32),   // Send to all n nearest neighbour Communication Nodes
+    Random(u32),    // Send to a random set of peers of size n that are Communication Nodes
+}

--- a/comms/src/outbound_message_service/outbound_message.rs
+++ b/comms/src/outbound_message_service/outbound_message.rs
@@ -21,7 +21,7 @@
 //  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 use crate::{
-    connection::message::{Frame, MessageError},
+    connection::message::{Frame, FrameSet, MessageError},
     peer_manager::node_id::NodeId,
 };
 use chrono::prelude::*;
@@ -79,6 +79,19 @@ impl<T: Serialize + DeserializeOwned> TryFrom<Frame> for OutboundMessage<T> {
         match Deserialize::deserialize(&mut de) {
             Ok(outbound_message) => Ok(outbound_message),
             Err(_) => Err(MessageError::DeserializeFailed),
+        }
+    }
+}
+
+impl<T: Serialize + DeserializeOwned> TryFrom<FrameSet> for OutboundMessage<T> {
+    type Error = MessageError;
+
+    /// Construct an OutboundMessage from a Frame
+    fn try_from(frames: FrameSet) -> Result<Self, Self::Error> {
+        if frames.len() == 1 {
+            OutboundMessage::try_from(frames[0].clone())
+        } else {
+            Err(MessageError::DeserializeFailed)
         }
     }
 }

--- a/comms/src/outbound_message_service/outbound_message_service.rs
+++ b/comms/src/outbound_message_service/outbound_message_service.rs
@@ -1,0 +1,301 @@
+//  Copyright 2019 The Tari Project
+//
+//  Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+//  following conditions are met:
+//
+//  1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+//  disclaimer.
+//
+//  2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+//  following disclaimer in the documentation and/or other materials provided with the distribution.
+//
+//  3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+//  products derived from this software without specific prior written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+//  INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+//  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+//  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+//  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+//  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+//  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+use crate::{
+    connection::{
+        connection::EstablishedConnection,
+        error::ConnectionError,
+        message::{Frame, IdentityFlags, MessageEnvelope, MessageEnvelopeHeader, MessageError, NodeDestination},
+        types::SocketType,
+        zmq::{Context, InprocAddress, ZmqEndpoint, ZmqError},
+    },
+    outbound_message_service::{broadcast_strategy::BroadcastStrategy, outbound_message::OutboundMessage},
+    peer_manager::node_identity::NodeIdentity,
+    types::{Challenge, MESSAGE_PROTOCOL_VERSION, WIRE_PROTOCOL_VERSION},
+};
+use derive_error::Error;
+use digest::Digest;
+use rand::{CryptoRng, Rng};
+use rmp_serde;
+use serde::Serialize;
+use std::{ops::Mul, sync::Arc};
+use tari_crypto::{
+    keys::{DiffieHellmanSharedSecret, PublicKey, SecretKey},
+    signatures::{SchnorrSignature, SchnorrSignatureError},
+};
+use tari_utilities::{chacha20, ByteArray, ByteArrayError, Hashable};
+
+#[derive(Debug, Error)]
+pub enum OutboundError {
+    /// Problem setting up a socket to an outbound message pool
+    SocketError(ZmqError),
+    /// Could not connect to the outbound message pool
+    SocketConnectionError(zmq::Error),
+    /// Problem sending message to outbound message pool
+    SendError(ConnectionError),
+    /// The secret key was not defined in the node identity
+    UndefinedSecretKey,
+    /// The message signature could not be serialized to a vector of bytes
+    SignatureSerializationError,
+    /// The generated shared secret could not be serialized to a vector of bytes
+    SharedSecretSerializationError(ByteArrayError),
+    /// The message could not be serialized
+    MessageSerializationError(MessageError),
+    /// Could not successfully sign the message
+    SignatureError(SchnorrSignatureError),
+}
+
+/// Handler functions use the OutboundMessageService to send messages to peers. The OutboundMessage service will receive
+/// messages from handlers, apply a broadcasting strategy, encrypted and serialized the messages into OutboundMessages
+/// and write them to the outbound message pool.
+pub struct OutboundMessageService<PubKey, SecKey> {
+    context: Context,
+    outbound_address: InprocAddress,
+    node_identity: Arc<NodeIdentity<PubKey, SecKey>>,
+}
+
+impl<PubKey, SecKey> OutboundMessageService<PubKey, SecKey>
+where
+    PubKey: PublicKey<K = SecKey> + Hashable + DiffieHellmanSharedSecret<K = SecKey, PK = PubKey>,
+    SecKey: SecretKey + Mul<PubKey, Output = PubKey> + Mul<Output = SecKey> + Serialize,
+{
+    /// Constructs a new OutboundMessageService from the context, node_identity and outbound_address
+    pub fn new(
+        context: Context,
+        outbound_address: InprocAddress, /* The outbound_address is an inproc that connects the OutboundMessagePool
+                                          * and the OutboundMessageService */
+        node_identity: Arc<NodeIdentity<PubKey, SecKey>>,
+    ) -> OutboundMessageService<PubKey, SecKey>
+    {
+        OutboundMessageService {
+            context,
+            outbound_address,
+            node_identity,
+        }
+    }
+
+    /// Encrypt the message_envelope_body with the generated shared secret if the Encrypted IdentityFlag is set
+    fn encrypt_envelope_body(
+        &self,
+        message_envelope_body: &Frame,
+        dest_node_public_key: &PubKey,
+    ) -> Result<Frame, OutboundError>
+    {
+        let node_secret_key = self
+            .node_identity
+            .secret_key
+            .clone()
+            .ok_or(OutboundError::UndefinedSecretKey)?;
+        let ecdh_shared_secret = PubKey::shared_secret(&node_secret_key, &dest_node_public_key).to_vec();
+        let ecdh_shared_secret_bytes: [u8; 32] =
+            ByteArray::from_bytes(&ecdh_shared_secret).map_err(|e| OutboundError::SharedSecretSerializationError(e))?;
+        Ok(chacha20::encode(message_envelope_body, &ecdh_shared_secret_bytes))
+    }
+
+    /// Generate a signature for the MessageEnvelopeHeader from the MessageEnvelopeBody
+    fn sign_envelope_body<R: Rng + CryptoRng>(
+        &self,
+        message_envelope_body: &Frame,
+        rng: &mut R,
+    ) -> Result<Vec<u8>, OutboundError>
+    {
+        let challenge = Challenge::new().chain(message_envelope_body.clone()).result().to_vec();
+        let nonce = SecKey::random(rng);
+        let signature = SchnorrSignature::<PubKey, SecKey>::sign(
+            self.node_identity
+                .secret_key
+                .clone()
+                .ok_or(OutboundError::UndefinedSecretKey)?,
+            nonce,
+            &challenge,
+        )
+        .map_err(|e| OutboundError::SignatureError(e))?;
+        let mut buf: Vec<u8> = Vec::new();
+        signature
+            .serialize(&mut rmp_serde::Serializer::new(&mut buf))
+            .map_err(|_| OutboundError::SignatureSerializationError)?;
+        Ok(buf.to_vec())
+    }
+
+    /// Handler functions use the send function to transmit a message to a peer or set of peers based on the
+    /// BroadcastStrategy
+    pub fn send<R: Rng + CryptoRng>(
+        &self,
+        _broadcast_strategy: BroadcastStrategy, /* TODO: make use of BroadcastStrategy once the PeerManager has been
+                                                 * implemented */
+        flags: IdentityFlags,
+        message_envelope_body: &Frame,
+        rng: &mut R,
+        dest_node_identity: Arc<NodeIdentity<PubKey, SecKey>>, /* TODO: This field is temporary until routing table
+                                                                * has been implemented */
+    ) -> Result<(), OutboundError>
+    {
+        // Todo: use the BroadcastStrategy to select appropriate peer(s) from PeerManager and then construct and send a
+        // personalised message to each selected peer
+        let selected_node_identities = vec![Arc::clone(&dest_node_identity)]; // TODO: Remove with PeerManager call after PeerManager has been implemented
+
+        for dest_node_identity in &selected_node_identities {
+            // Constructing a MessageEnvelope
+            let message_envelope_body = if flags.contains(IdentityFlags::ENCRYPTED) {
+                self.encrypt_envelope_body(message_envelope_body, &dest_node_identity.public_key)?
+            } else {
+                message_envelope_body.clone()
+            };
+            let signature = self.sign_envelope_body(&message_envelope_body, rng)?;
+            let message_envelope_header = MessageEnvelopeHeader::<PubKey>::new(
+                MESSAGE_PROTOCOL_VERSION,
+                self.node_identity.public_key.clone(),
+                NodeDestination::<PubKey>::NodeId(dest_node_identity.node_id.clone()),
+                signature,
+                flags,
+            );
+            let message_envelope_header_frame = message_envelope_header
+                .to_frame()
+                .map_err(|e| OutboundError::MessageSerializationError(e))?;
+            let message_envelope = MessageEnvelope::new(
+                vec![WIRE_PROTOCOL_VERSION],
+                message_envelope_header_frame,
+                message_envelope_body,
+            );
+            // Construct an OutboundMessage
+            let outbound_message =
+                OutboundMessage::<MessageEnvelope>::new(dest_node_identity.node_id.clone(), message_envelope);
+            let outbound_message_buffer = vec![outbound_message
+                .to_frame()
+                .map_err(|e| OutboundError::MessageSerializationError(e))?];
+
+            // Send message to outbound message pool
+            let outbound_socket = self
+                .context
+                .socket(SocketType::Request)
+                .map_err(|e| OutboundError::SocketError(e))?;
+            outbound_socket
+                .connect(&self.outbound_address.to_zmq_endpoint())
+                .map_err(|e| OutboundError::SocketConnectionError(e))?;
+            let outbound_connection = EstablishedConnection {
+                socket: outbound_socket,
+            };
+            outbound_connection
+                .send(&outbound_message_buffer)
+                .map_err(|e| OutboundError::SendError(e))?;
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    use crate::{
+        connection::zmq::{Context, InprocAddress, ZmqEndpoint},
+        peer_manager::node_id::NodeId,
+    };
+    use serde::Deserialize;
+    use std::{convert::TryFrom, sync::Arc};
+    use tari_crypto::ristretto::{RistrettoPublicKey, RistrettoSecretKey};
+
+    #[test]
+    fn test_outbound_send() {
+        let context = Context::new();
+        let mut rng = rand::OsRng::new().unwrap();
+        let outbound_address = InprocAddress::random();
+
+        // Create a client that will retrieve messages from the outbound message pool
+        let omp_socket = context
+            .socket(SocketType::Reply)
+            .map_err(|e| OutboundError::SocketError(e))
+            .unwrap();
+        omp_socket
+            .bind(&outbound_address.to_zmq_endpoint())
+            .map_err(|e| OutboundError::SocketConnectionError(e))
+            .unwrap();
+
+        // Create an identity for the current node and the destination node
+        let (sk, pk) = RistrettoPublicKey::random_keypair(&mut rng);
+        let node_identity = Arc::new(NodeIdentity::<RistrettoPublicKey, RistrettoSecretKey>::new(
+            NodeId::from_key(&pk).unwrap(),
+            pk,
+            Some(sk),
+        ));
+
+        let (sk, pk) = RistrettoPublicKey::random_keypair(&mut rng);
+        let dest_node_identity = Arc::new(NodeIdentity::<RistrettoPublicKey, RistrettoSecretKey>::new(
+            NodeId::from_key(&pk).unwrap(),
+            pk,
+            Some(sk),
+        ));
+
+        // Setup OutboundMessageService and transmit a message to the destination
+        let outbound_message_service = OutboundMessageService::<RistrettoPublicKey, RistrettoSecretKey>::new(
+            context,
+            outbound_address,
+            node_identity.clone(),
+        );
+
+        let message_envelope_body: Vec<u8> = vec![0, 1, 2, 3];
+        assert!(outbound_message_service
+            .send(
+                BroadcastStrategy::Direct(dest_node_identity.node_id.clone()),
+                IdentityFlags::ENCRYPTED,
+                &message_envelope_body,
+                &mut rng,
+                dest_node_identity.clone(), // TODO Remove, this is temporary until the routing table is implemented
+            )
+            .is_ok());
+
+        let msg_bytes = omp_socket.recv_multipart(0).unwrap();
+        let outbound_message = OutboundMessage::<MessageEnvelope>::try_from(msg_bytes).unwrap();
+        assert_eq!(outbound_message.destination_node_id, dest_node_identity.node_id);
+        assert_eq!(outbound_message.retry_count, 0);
+        assert_eq!(outbound_message.last_retry_timestamp, None);
+        let message_envelope_header =
+            MessageEnvelopeHeader::<RistrettoPublicKey>::try_from(outbound_message.message_envelope.header().clone())
+                .unwrap();
+        assert_eq!(message_envelope_header.source, node_identity.public_key);
+        assert_eq!(
+            message_envelope_header.dest,
+            NodeDestination::<RistrettoPublicKey>::NodeId(dest_node_identity.node_id.clone())
+        );
+        // Verify message signature
+        let mut de = rmp_serde::Deserializer::new(message_envelope_header.signature.as_slice());
+        let signature = SchnorrSignature::<RistrettoPublicKey, RistrettoSecretKey>::deserialize(&mut de).unwrap();
+        let challenge = Challenge::new()
+            .chain(outbound_message.message_envelope.body())
+            .result()
+            .to_vec();
+        assert!(signature.verify_challenge(&node_identity.public_key, &challenge));
+        // Check Encryption
+        assert_eq!(message_envelope_header.flags, IdentityFlags::ENCRYPTED);
+        let ecdh_shared_secret = RistrettoPublicKey::shared_secret(
+            &dest_node_identity.secret_key.clone().unwrap(),
+            &node_identity.public_key,
+        )
+        .to_vec();
+        let ecdh_shared_secret_bytes: [u8; 32] = ByteArray::from_bytes(&ecdh_shared_secret).unwrap();
+        let decoded_message_envelope_body =
+            chacha20::decode(outbound_message.message_envelope.body(), &ecdh_shared_secret_bytes);
+        assert_eq!(message_envelope_body, decoded_message_envelope_body);
+
+        assert!(omp_socket.send("OK".as_bytes(), 0).is_ok());
+    }
+}

--- a/comms/src/peer_manager/mod.rs
+++ b/comms/src/peer_manager/mod.rs
@@ -24,6 +24,7 @@ pub mod ban_list;
 pub mod liveness;
 pub mod manager;
 pub mod node_id;
+pub mod node_identity;
 pub mod peer;
 pub mod routing_table;
 pub mod storage;

--- a/comms/src/peer_manager/node_identity.rs
+++ b/comms/src/peer_manager/node_identity.rs
@@ -20,6 +20,23 @@
 //  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 //  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-pub mod broadcast_strategy;
-pub mod outbound_message;
-pub mod outbound_message_service;
+use crate::peer_manager::node_id::NodeId;
+use tari_crypto::keys::{PublicKey, SecretKey};
+
+/// The NodeIdentity is a container that stores the identity (NodeId, Identification Key pair) of a single node
+pub struct NodeIdentity<PubKey, SecKey> {
+    pub node_id: NodeId,
+    pub public_key: PubKey,
+    pub secret_key: Option<SecKey>,
+}
+
+impl<PubKey: PublicKey, SecKey: SecretKey> NodeIdentity<PubKey, SecKey> {
+    /// Construct a new identity for a node that contains its NodeId and identification key pair
+    pub fn new(node_id: NodeId, public_key: PubKey, secret_key: Option<SecKey>) -> NodeIdentity<PubKey, SecKey> {
+        NodeIdentity {
+            node_id,
+            public_key,
+            secret_key,
+        }
+    }
+}

--- a/comms/src/types.rs
+++ b/comms/src/types.rs
@@ -20,6 +20,13 @@
 //  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 //  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-pub mod broadcast_strategy;
-pub mod outbound_message;
-pub mod outbound_message_service;
+use tari_crypto::common::Blake256;
+
+/// The message protocol version for the MessageEnvelopeHeader
+pub const MESSAGE_PROTOCOL_VERSION: u8 = 0;
+
+/// The wire protocol version for the MessageEnvelope wire format
+pub const WIRE_PROTOCOL_VERSION: u8 = 0;
+
+/// Specify the digest type for the signature challenges
+pub type Challenge = Blake256;

--- a/infrastructure/crypto/src/keys.rs
+++ b/infrastructure/crypto/src/keys.rs
@@ -73,3 +73,11 @@ pub trait PublicKey:
         (k, pk)
     }
 }
+
+/// This trait provides a common mechanism to calculate a shared secret using the private and public key of two parties
+pub trait DiffieHellmanSharedSecret: ByteArray + Clone + PartialEq + Eq + Add<Output = Self> + Default {
+    type K: SecretKey;
+    type PK: PublicKey;
+    /// Generate a shared secret from one party's private key and another party's public key
+    fn shared_secret(k: &Self::K, pk: &Self::PK) -> Self::PK;
+}

--- a/infrastructure/crypto/src/ristretto/ristretto_keys.rs
+++ b/infrastructure/crypto/src/ristretto/ristretto_keys.rs
@@ -21,7 +21,7 @@
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 //! The Tari-compatible implementation of Ristretto based on the curve25519-dalek implementation
-use crate::keys::{PublicKey, SecretKey};
+use crate::keys::{DiffieHellmanSharedSecret, PublicKey, SecretKey};
 use blake2::Blake2b;
 use clear_on_drop::clear::Clear;
 use curve25519_dalek::{
@@ -265,6 +265,16 @@ impl PublicKey for RistrettoPublicKey {
         let s: Vec<&Scalar> = scalars.iter().map(|k| &k.0).collect();
         let p = RistrettoPoint::multiscalar_mul(s, p);
         RistrettoPublicKey::new_from_pk(p)
+    }
+}
+
+impl DiffieHellmanSharedSecret for RistrettoPublicKey {
+    type K = RistrettoSecretKey;
+    type PK = RistrettoPublicKey;
+
+    /// Generate a shared secret from one party's private key and another party's public key
+    fn shared_secret(k: &Self::K, pk: &Self::PK) -> Self::PK {
+        k * pk
     }
 }
 

--- a/infrastructure/crypto/src/signatures.rs
+++ b/infrastructure/crypto/src/signatures.rs
@@ -4,6 +4,7 @@
 
 use crate::keys::{PublicKey, SecretKey};
 use derive_error::Error;
+use serde::{Deserialize, Serialize};
 use std::{
     cmp::Ordering,
     ops::{Add, Mul},
@@ -17,7 +18,7 @@ pub enum SchnorrSignatureError {
 }
 
 #[allow(non_snake_case)]
-#[derive(PartialEq, Eq, Copy, Debug, Clone)]
+#[derive(PartialEq, Eq, Copy, Debug, Clone, Serialize, Deserialize)]
 pub struct SchnorrSignature<P, K> {
     public_nonce: P,
     signature: K,


### PR DESCRIPTION
## Description
- Added the OutboundMessageService with unit test
- Added the BroadcastStrategy enum
- Added a NodeIdentity container
- Added DiffieHellmanSharedSecret trait to Crypto

## Motivation and Context
Handler functions use the OutboundMessageService to send messages to peers. The OutboundMessage service will receive messages from handlers, apply a broadcasting strategy, encrypted and serialized the messages into OutboundMessages and write them to the outbound message pool.

## How Has This Been Tested?
A unit test was added for the OutboundMessageService.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [x] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch
* [x] I ran `cargo-fmt --all` before pushing
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
