### PR TITLE
Fix broken tests in release mode

### DIFF
--- a/comms/src/connection/net_address/net_address_with_stats.rs
+++ b/comms/src/connection/net_address/net_address_with_stats.rs
@@ -143,7 +143,7 @@ impl PartialEq for NetAddressWithStats {
 #[cfg(test)]
 mod test {
     use crate::connection::{net_address::net_address_with_stats::NetAddressWithStats, NetAddress};
-    use std::time::Duration;
+    use std::{thread, time::Duration};
 
     #[test]
     fn test_update_latency() {
@@ -195,10 +195,13 @@ mod test {
         let net_address = "123.0.0.123:8000".parse::<NetAddress>().unwrap();
         let mut na1 = NetAddressWithStats::from(net_address.clone());
         let mut na2 = NetAddressWithStats::from(net_address);
+        thread::sleep(Duration::from_millis(1));
         na1.successful_connection_attempt();
         assert!(na1 < na2);
+        thread::sleep(Duration::from_millis(1));
         na2.successful_connection_attempt();
         assert!(na1 > na2);
+        thread::sleep(Duration::from_millis(1));
         na1.message_rejected();
         assert!(na1 < na2);
         na1.update_latency(Duration::from_millis(200));

--- a/comms/src/connection/net_address/net_addresses.rs
+++ b/comms/src/connection/net_address/net_addresses.rs
@@ -142,6 +142,7 @@ mod test {
         net_address::{net_address_with_stats::NetAddressWithStats, net_addresses::NetAddresses},
         NetAddress,
     };
+    use std::thread;
 
     #[test]
     fn test_last_seen() {
@@ -234,6 +235,7 @@ mod test {
         assert_eq!(net_addresses.addresses[1].avg_latency, Duration::from_millis(200));
         assert_eq!(net_addresses.addresses[2].avg_latency, Duration::from_millis(0));
 
+        thread::sleep(Duration::from_millis(1));
         assert!(net_addresses.message_received(&net_address1).is_ok());
         assert!(net_addresses.addresses[0].last_seen.is_some());
         assert!(net_addresses.addresses[1].last_seen.is_some());

--- a/comms/src/connection/zmq/curve_keypair.rs
+++ b/comms/src/connection/zmq/curve_keypair.rs
@@ -109,10 +109,12 @@ impl Default for CurvePublicKey {
 #[cfg(test)]
 mod test {
     use super::*;
-    use std::slice;
 
     #[test]
+    // Optimisations can cause this test to erroneously fail in release mode. The value is zeroed out on drop though.
+    #[cfg(debug_assertions)]
     fn clears_secret_key_on_drop() {
+        use std::slice;
         let ptr;
         {
             let sk = generate().unwrap().0;

--- a/infrastructure/crypto/src/ristretto/ristretto_keys.rs
+++ b/infrastructure/crypto/src/ristretto/ristretto_keys.rs
@@ -439,7 +439,6 @@ mod test {
     use super::*;
     use crate::{keys::PublicKey, ristretto::test_common::get_keypair};
     use rand;
-    use std::slice;
     use tari_utilities::ByteArray;
 
     #[test]
@@ -604,8 +603,13 @@ mod test {
             let k = RistrettoSecretKey::random(&mut rng);
             ptr = (k.0).as_bytes().as_ptr();
         }
-        unsafe {
-            assert_eq!(slice::from_raw_parts(ptr, 32), zero);
+        // In release mode, the memory can already be reclaimed by this stage due to optimisations, and so this test
+        // can fail in release mode, even though the values were effectively scrubbed.
+        if cfg!(debug_assertions) {
+            unsafe {
+                use std::slice;
+                assert_eq!(slice::from_raw_parts(ptr, 32), zero);
+            }
         }
     }
 


### PR DESCRIPTION
It looks like Rust can already be reusing memory by the time the address is checked after being zeroed.
e.g. see this code
```
use rand::rngs::OsRng;
use rand::Rng;
use std::slice;
use std::mem;
use std::ptr;

pub struct Zeroed([u8; 32]);

impl Drop for Zeroed {
    fn drop(&mut self) {
        let size = mem::size_of_val(self);
        unsafe {
            let ptr = self as *mut Self;
            ptr::write_bytes(ptr as *mut u8, 0, size);
        }
        println!("In Drop: {:?}", self);
    }
}

fn main() {
    let zero = &vec![0u8; 32][..];
    let mut rng = OsRng::new().unwrap();
    let ptr;
    {
        let mut k = [0u8;32];
        rng.fill(&mut k);
        let foo = Zeroed(k);
        println!("Value: {:?}", foo);
        ptr = foo.0.as_ptr();
        println!("Address before: {:?}", ptr);
        unsafe { assert_eq!(slice::from_raw_parts(ptr, 32), k); }
    }
    unsafe {
        assert_eq!(slice::from_raw_parts(ptr, 32), zero);
        println!("Address after: {:?}", ptr);
        println!("Value after: {:?}", slice::from_raw_parts(ptr, 32));    }
}
```

It passes in Debug, but typically fails in release mode. But the memory is always correclty zeroed.
Therefore, we opt to ignore the zeroing checks in release compiles

Some tests check the value of a call to `System.now()`. In release mode, this can be so fast that the clock doesn't tick,
and tests that rely on a tick will fail. Our workaround is to add a tiny delay so that the timestamps do change when the
system time is read.



## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [x] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [ ] I'm merging against the `development` branch
* [ ] I ran `cargo-fmt --all` before pushing
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
