### PR TITLE
Improve inbound_message_service test

### DIFF
--- a/comms/src/inbound_message_service/msg_processing_worker.rs
+++ b/comms/src/inbound_message_service/msg_processing_worker.rs
@@ -27,9 +27,10 @@ use crate::{
     },
     inbound_message_service::{message_context::MessageContext, message_dispatcher::MessageDispatcher},
 };
+#[cfg(test)]
+use std::sync::mpsc::SyncSender;
 use std::{convert::TryFrom, marker::Send, thread};
 use tari_crypto::keys::PublicKey;
-
 /// As DealerError is handled in a thread it needs to be written to the error log
 #[derive(Debug)]
 pub enum WorkerError {
@@ -45,6 +46,8 @@ pub struct MsgProcessingWorker<PubKey> {
     #[allow(dead_code)]
     node_identity: PubKey,
     message_dispatcher: MessageDispatcher<MessageContext<PubKey>>,
+    #[cfg(test)]
+    test_sync_sender: Option<SyncSender<String>>,
 }
 
 impl<PubKey: PublicKey + Send + 'static> MsgProcessingWorker<PubKey> {
@@ -61,6 +64,8 @@ impl<PubKey: PublicKey + Send + 'static> MsgProcessingWorker<PubKey> {
             inbound_address,
             node_identity,
             message_dispatcher,
+            #[cfg(test)]
+            test_sync_sender: None,
         }
     }
 
@@ -75,6 +80,9 @@ impl<PubKey: PublicKey + Send + 'static> MsgProcessingWorker<PubKey> {
             .map_err(|e| WorkerError::InboundConnectionError(e))?;
         // Retrieve, process and dispatch messages
         loop {
+            #[cfg(test)]
+            let tx = self.test_sync_sender.clone().unwrap();
+
             let frames = match inbound_socket.recv_multipart(0) {
                 Ok(frames) => frames,
                 Err(_e) => {
@@ -95,6 +103,11 @@ impl<PubKey: PublicKey + Send + 'static> MsgProcessingWorker<PubKey> {
                     inbound_socket.send("OK".as_bytes(), 0).unwrap_or_else(|_e| {
                         (/*TODO Log Warning: could not return status message*/)
                     });
+
+                    #[cfg(test)]
+                    {
+                        tx.send("Message dispatched".to_string()).unwrap();
+                    }
                 },
                 Err(_e) => {
                     // if unable to deserialize the MessageHeader then MUST discard the
@@ -119,6 +132,11 @@ impl<PubKey: PublicKey + Send + 'static> MsgProcessingWorker<PubKey> {
                 }
             }
         });
+    }
+
+    #[cfg(test)]
+    pub fn set_test_channel(&mut self, tx: SyncSender<String>) {
+        self.test_sync_sender = Some(tx);
     }
 }
 

--- a/comms/src/inbound_message_service/msg_processing_worker.rs
+++ b/comms/src/inbound_message_service/msg_processing_worker.rs
@@ -81,7 +81,7 @@ impl<PubKey: PublicKey + Send + 'static> MsgProcessingWorker<PubKey> {
         // Retrieve, process and dispatch messages
         loop {
             #[cfg(test)]
-            let tx = self.test_sync_sender.clone().unwrap();
+            let sync_sender = self.test_sync_sender.clone();
 
             let frames = match inbound_socket.recv_multipart(0) {
                 Ok(frames) => frames,
@@ -106,7 +106,9 @@ impl<PubKey: PublicKey + Send + 'static> MsgProcessingWorker<PubKey> {
 
                     #[cfg(test)]
                     {
-                        tx.send("Message dispatched".to_string()).unwrap();
+                        if let Some(tx) = sync_sender {
+                            tx.send("Message dispatched".to_string()).unwrap();
+                        }
                     }
                 },
                 Err(_e) => {


### PR DESCRIPTION
## Description
Used MPSC channels to exhaustively test all the worker threads in in the `inbound_message_service` unit tests.

## Motivation and Context
The test didn't test the fair dealing aspect of the message service, now it explicitly tests the dealing of messages to the workers in addition to testing that the dispatcher handle is called.

## How Has This Been Tested?
It is a test.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [x] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch
* [x] I ran `cargo-fmt --all` before pushing
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
