### PR TITLE
Use keys as specified in types.rs

### DIFF
--- a/comms/src/peer_manager/node_id.rs
+++ b/comms/src/peer_manager/node_id.rs
@@ -184,10 +184,8 @@ impl fmt::Display for NodeId {
 #[cfg(test)]
 mod test {
     use super::*;
-    use tari_crypto::{
-        keys::{PublicKey, SecretKey},
-        ristretto::{RistrettoPublicKey, RistrettoSecretKey},
-    };
+    use crate::types::{CommsPublicKey, CommsSecretKey};
+    use tari_crypto::keys::{PublicKey, SecretKey};
     use tari_utilities::byte_array::ByteArray;
 
     #[test]
@@ -211,8 +209,8 @@ mod test {
     #[test]
     fn test_from_public_key() {
         let mut rng = rand::OsRng::new().unwrap();
-        let sk = RistrettoSecretKey::random(&mut rng);
-        let pk = RistrettoPublicKey::from_secret_key(&sk);
+        let sk = CommsSecretKey::random(&mut rng);
+        let pk = CommsPublicKey::from_secret_key(&sk);
         let node_id = NodeId::from_key(&pk).unwrap();
         assert_ne!(node_id.0.to_vec(), NodeId::new().0.to_vec());
         // Ensure node id is different to original public key


### PR DESCRIPTION
Tests are more future proof now if the key type ever changes

