### PR TITLE
Added initial portion of OutboundMessagePool

### DIFF
--- a/comms/Cargo.toml
+++ b/comms/Cargo.toml
@@ -28,6 +28,8 @@ digest = "0.8.0"
 [dev-dependencies]
 criterion = "0.2"
 rand = "0.5.5"
+tari_common = { path = "../common"}
+simple_logger = "1.2.0"
 
 [[bench]]
 name = "benches_main"

--- a/comms/src/connection/mod.rs
+++ b/comms/src/connection/mod.rs
@@ -33,7 +33,7 @@ pub mod types;
 pub mod zmq;
 
 pub use self::{
-    connection::Connection,
+    connection::{Connection, EstablishedConnection},
     dealer_proxy::{DealerProxy, DealerProxyError},
     error::ConnectionError,
     net_address::{NetAddress, NetAddressError, NetAddresses},

--- a/comms/src/connection/net_address/net_addresses.rs
+++ b/comms/src/connection/net_address/net_addresses.rs
@@ -6,7 +6,7 @@ use chrono::prelude::*;
 use serde::{Deserialize, Serialize};
 use std::time::Duration;
 
-const MAX_CONNECTION_ATTEMPTS: u32 = 3;
+pub const MAX_CONNECTION_ATTEMPTS: u32 = 3;
 
 /// This struct is used to store a set of different net addresses such as IPv4, IPv6, Tor or I2P for a single peer.
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq)]

--- a/comms/src/outbound_message_service/error.rs
+++ b/comms/src/outbound_message_service/error.rs
@@ -1,0 +1,56 @@
+// Copyright 2019 The Tari Project
+//
+// Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+// following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+// disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+// following disclaimer in the documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+// products derived from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+// INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+// WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+// USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE
+
+use crate::{
+    connection::{ConnectionError, NetAddressError},
+    message::MessageError,
+    peer_manager::peer_manager::PeerManagerError,
+};
+use derive_error::Error;
+use tari_crypto::signatures::SchnorrSignatureError;
+use tari_utilities::{message_format::MessageFormatError, ByteArrayError};
+
+#[derive(Debug, Error)]
+pub enum OutboundError {
+    /// Could not connect to the outbound message pool
+    SocketConnectionError(zmq::Error),
+    /// Problem communicating to the outbound message pool
+    ConnectionError(ConnectionError),
+    /// The secret key was not defined in the node identity
+    UndefinedSecretKey,
+    /// The message signature could not be serialized to a vector of bytes
+    SignatureSerializationError,
+    /// The generated shared secret could not be serialized to a vector of bytes
+    SharedSecretSerializationError(ByteArrayError),
+    /// The message could not be serialized
+    MessageSerializationError(MessageError),
+    /// Could not successfully sign the message
+    SignatureError(SchnorrSignatureError),
+    /// Error during serialization or deserialization
+    MessageFormatError(MessageFormatError),
+    /// Problem encountered with Broadcast Strategy and PeerManager
+    PeerManagerError(PeerManagerError),
+    /// The Thread Safety has been breached and the data access has become poisoned
+    PoisonedAccess,
+    /// Error requesting or updating a net address
+    NetAddressError(NetAddressError),
+}

--- a/comms/src/outbound_message_service/message_pool_worker.rs
+++ b/comms/src/outbound_message_service/message_pool_worker.rs
@@ -1,0 +1,193 @@
+// Copyright 2019 The Tari Project
+//
+// Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+// following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+// disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+// following disclaimer in the documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+// products derived from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+// INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+// WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+// USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE
+
+use crate::{
+    connection::{
+        zmq::{Context, InprocAddress},
+        Connection,
+        ConnectionError,
+        Direction,
+        SocketEstablishment,
+    },
+    message::{FrameSet, MessageEnvelope},
+    outbound_message_service::{OutboundError, OutboundMessage},
+    peer_manager::PeerManager,
+};
+
+use crate::connection::net_address::NetAddressError;
+use log::*;
+#[cfg(test)]
+use std::sync::mpsc::SyncSender;
+use std::{convert::TryFrom, hash::Hash, sync::Arc, thread};
+use tari_crypto::keys::PublicKey;
+
+use tari_storage::keyvalue_store::DataStore;
+
+const LOG_TARGET: &'static str = "comms::outbound_message_service::pool::worker";
+
+#[derive(Debug)]
+pub enum WorkerError {
+    /// Problem with inbound connection
+    InboundConnectionError(ConnectionError),
+    /// Failed to connect to message queue
+    MessageQueueConnectionError(ConnectionError),
+}
+
+pub struct MessagePoolWorker<P, DS> {
+    context: Context,
+    inbound_address: InprocAddress,
+    message_queue_address: InprocAddress,
+    peer_manager: Arc<PeerManager<P, DS>>,
+    #[cfg(test)]
+    test_sync_sender: Option<SyncSender<String>>,
+}
+
+impl<P, DS> MessagePoolWorker<P, DS>
+where
+    P: PublicKey + Hash + Send + Sync + 'static,
+    DS: DataStore + Send + Sync + 'static,
+{
+    pub fn new(
+        context: Context,
+        inbound_address: InprocAddress,
+        message_queue_address: InprocAddress,
+        peer_manager: Arc<PeerManager<P, DS>>,
+    ) -> MessagePoolWorker<P, DS>
+    {
+        MessagePoolWorker {
+            context,
+            inbound_address,
+            message_queue_address,
+            peer_manager,
+            #[cfg(test)]
+            test_sync_sender: None,
+        }
+    }
+
+    /// Start MessagePoolWorker which will connect to the inbound message dealer, accept messages from the queue,
+    /// attempt to send them and if it cannot send then requeue the message
+    fn start_worker(&mut self) -> Result<(), WorkerError> {
+        #[cfg(test)]
+        let tx = self.test_sync_sender.clone().unwrap();
+
+        // Connection to the message dealer proxy
+        let inbound_connection = Connection::new(&self.context, Direction::Inbound)
+            .set_socket_establishment(SocketEstablishment::Connect)
+            .establish(&self.inbound_address)
+            .map_err(|e| WorkerError::InboundConnectionError(e))?;
+
+        loop {
+            match inbound_connection.receive(100) {
+                Ok(mut frame_set) => {
+                    // This strips off the two ZeroMQ Identity frames introduced by the transmission to the proxy and
+                    // from the proxy to this worker
+                    let data: FrameSet = frame_set.drain(2..).collect();
+                    if let Ok(mut msg) = OutboundMessage::<MessageEnvelope>::try_from(data) {
+                        match self.attempt_message_transmission(&mut msg) {
+                            Ok(()) => {
+                                #[cfg(test)]
+                                tx.send(String::from(format!("Attempt {:?}", msg.number_of_retries())))
+                                    .unwrap();
+                            },
+                            Err(e) => match e {
+                                OutboundError::NetAddressError(e) => match e {
+                                    NetAddressError::ConnectionAttemptsExceeded => {
+                                        warn!(
+                                            target: LOG_TARGET,
+                                            "Number of Connection Attempts Exceeded - Error: {}", e
+                                        );
+                                        #[cfg(test)]
+                                        tx.send(String::from("Connection Attempts Exceeded")).unwrap()
+                                    },
+                                    _ => (),
+                                },
+                                _ => (),
+                            },
+                        }
+                    }
+                },
+                Err(ConnectionError::Timeout) => (),
+                Err(e) => {
+                    error!(
+                        target: LOG_TARGET,
+                        "Failed to receive messages from outbound message queue - Error: {}", e
+                    );
+                },
+            };
+        }
+    }
+
+    /// Start the MessagePoolWorker thread
+    pub fn start(mut self) {
+        thread::spawn(move || {
+            loop {
+                match self.start_worker() {
+                    Ok(_) => (),
+                    Err(_e) => {
+                        // TODO Write WorkerError as a Log Error
+                    },
+                }
+            }
+        });
+    }
+
+    /// Attempt to send a message to the NodeId specified in the message. If the the attempt is not successful then mark
+    /// the failed connection attempt and requeue the message for another attempt
+    fn attempt_message_transmission(
+        &mut self,
+        msg: &mut OutboundMessage<MessageEnvelope>,
+    ) -> Result<(), OutboundError>
+    {
+        // Should attempt to connect and send, just mark as failed attempt
+        let mut peer = self.peer_manager.find_with_node_id(&msg.destination_node_id)?;
+        let net_address = peer.addresses.get_best_net_address()?;
+        self.peer_manager.mark_failed_connection_attempt(&net_address)?;
+
+        // TODO Actually try send
+
+        msg.mark_transmission_attempt();
+        self.requeue_message(msg)?;
+
+        Ok(())
+    }
+
+    /// Send a message back to the Outbound Message Pool message queue.
+    fn requeue_message(&self, msg: &OutboundMessage<MessageEnvelope>) -> Result<(), OutboundError> {
+        let outbound_message_buffer = vec![msg
+            .to_frame()
+            .map_err(|e| OutboundError::MessageSerializationError(e))?];
+
+        let outbound_connection = Connection::new(&self.context, Direction::Outbound)
+            .set_socket_establishment(SocketEstablishment::Connect)
+            .establish(&self.message_queue_address)
+            .map_err(|e| OutboundError::ConnectionError(e))?;
+        outbound_connection
+            .send(&outbound_message_buffer)
+            .map_err(|e| OutboundError::ConnectionError(e))?;
+        Ok(())
+    }
+
+    #[cfg(test)]
+    pub fn set_test_channel(&mut self, tx: SyncSender<String>) {
+        self.test_sync_sender = Some(tx);
+    }
+}

--- a/comms/src/outbound_message_service/mod.rs
+++ b/comms/src/outbound_message_service/mod.rs
@@ -21,5 +21,15 @@
 //  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 pub mod broadcast_strategy;
+pub mod error;
+pub mod message_pool_worker;
 pub mod outbound_message;
+pub mod outbound_message_pool;
 pub mod outbound_message_service;
+
+pub use self::{
+    broadcast_strategy::BroadcastStrategy,
+    error::OutboundError,
+    message_pool_worker::MessagePoolWorker,
+    outbound_message::OutboundMessage,
+};

--- a/comms/src/outbound_message_service/outbound_message.rs
+++ b/comms/src/outbound_message_service/outbound_message.rs
@@ -36,9 +36,9 @@ use std::convert::TryFrom;
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
 pub struct OutboundMessage<T> {
     pub destination_node_id: NodeId,
-    pub retry_count: u32,
-    pub creation_timestamp: DateTime<Utc>,
-    pub last_retry_timestamp: Option<DateTime<Utc>>,
+    retry_count: u32,
+    creation_timestamp: DateTime<Utc>,
+    last_retry_timestamp: Option<DateTime<Utc>>,
     pub message_envelope: T,
 }
 
@@ -67,6 +67,14 @@ impl<T: Serialize + DeserializeOwned> OutboundMessage<T> {
     pub fn mark_transmission_attempt(&mut self) {
         self.retry_count += 1;
         self.last_retry_timestamp = Some(Utc::now());
+    }
+
+    pub fn number_of_retries(&self) -> u32 {
+        self.retry_count
+    }
+
+    pub fn last_retry_timestamp(&self) -> Option<DateTime<Utc>> {
+        self.last_retry_timestamp
     }
 }
 

--- a/comms/src/outbound_message_service/outbound_message_pool.rs
+++ b/comms/src/outbound_message_service/outbound_message_pool.rs
@@ -1,0 +1,220 @@
+// Copyright 2019 The Tari Project
+//
+// Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+// following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+// disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+// following disclaimer in the documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+// products derived from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+// INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+// WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+// USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE
+use std::thread;
+
+use crate::{
+    connection::{
+        zmq::{Context, InprocAddress},
+        DealerProxy,
+        DealerProxyError,
+    },
+    outbound_message_service::{MessagePoolWorker, OutboundError},
+    peer_manager::PeerManager,
+};
+
+use log::*;
+#[cfg(test)]
+use std::sync::mpsc::{sync_channel, Receiver, SyncSender};
+use std::{hash::Hash, sync::Arc};
+use tari_crypto::keys::PublicKey;
+use tari_storage::keyvalue_store::DataStore;
+
+/// The maximum number of processing worker threads that will be created by the OutboundMessageService
+const MAX_OUTBOUND_MSG_PROCESSING_WORKERS: u8 = 8;
+
+const LOG_TARGET: &'static str = "comms::outbound_message_service::pool";
+
+/// The OutboundMessagePool will field outbound messages received from multiple OutboundMessageService instance that
+/// it will receive via the Inbound Inproc connection. It will handle the messages in the queue one at a time and
+/// attempt to send them. If they cannot be sent then the Retry count will be incremented and the message pushed to
+/// the back of the queue.
+struct OutboundMessagePool<P, DS> {
+    context: Context,
+    message_queue_address: InprocAddress,
+    worker_dealer_address: InprocAddress,
+    peer_manager: Arc<PeerManager<P, DS>>,
+    #[cfg(test)]
+    test_sync_sender: Vec<SyncSender<String>>, /* These channels will be to test the pool workers threaded
+                                                * operation */
+}
+impl<P, DS> OutboundMessagePool<P, DS>
+where
+    P: PublicKey + Hash + Send + Sync + 'static,
+    DS: DataStore + Send + Sync + 'static,
+{
+    /// Construct a new Outbound Message Pool.
+    /// # Arguments
+    /// `context` - A ZeroMQ context  
+    /// `message_queue_address` - The InProc address that will be used to send message to this message pool  
+    /// `peer_manager` - a reference to the peer manager to be used when sending messages
+    pub fn new(
+        context: Context,
+        message_queue_address: InprocAddress,
+        peer_manager: Arc<PeerManager<P, DS>>,
+    ) -> Result<OutboundMessagePool<P, DS>, OutboundError>
+    {
+        Ok(OutboundMessagePool {
+            context,
+            message_queue_address,
+            worker_dealer_address: InprocAddress::random(),
+            peer_manager,
+            #[cfg(test)]
+            test_sync_sender: Vec::new(),
+        })
+    }
+
+    fn start_dealer(&self) -> Result<(), DealerProxyError> {
+        DealerProxy::new(self.message_queue_address.clone(), self.worker_dealer_address.clone()).proxy(&self.context)
+    }
+
+    /// Start the Outbound Message Pool. This will spawn a thread that services the message queue that is sent to the
+    /// Inproc address.
+    pub fn start(self) {
+        thread::spawn(move || {
+            // Start workers
+            for _i in 0..MAX_OUTBOUND_MSG_PROCESSING_WORKERS as usize {
+                #[allow(unused_mut)] // For testing purposes
+                let mut worker = MessagePoolWorker::new(
+                    self.context.clone(),
+                    self.worker_dealer_address.clone(),
+                    self.message_queue_address.clone(),
+                    self.peer_manager.clone(),
+                );
+
+                #[cfg(test)]
+                worker.set_test_channel(self.test_sync_sender[_i].clone());
+
+                worker.start();
+            }
+
+            // Start dealer
+            loop {
+                if let Err(e) = self.start_dealer() {
+                    error!(
+                        target: LOG_TARGET,
+                        "Could not start dealer for Outbound Message Pool - Error {:?}", e
+                    );
+                }
+            }
+        });
+    }
+
+    /// Create a channel pairs for use during testing the workers, the sync sender will be passed into the worker's
+    /// threads and the receivers returned to the test function.
+    #[cfg(test)]
+    fn create_test_channels(&mut self) -> Vec<Receiver<String>> {
+        let mut receivers = Vec::new();
+        for _ in 0..MAX_OUTBOUND_MSG_PROCESSING_WORKERS {
+            let (tx, rx) = sync_channel::<String>(0);
+            self.test_sync_sender.push(tx);
+            receivers.push(rx);
+        }
+        receivers
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::{connection::Context, outbound_message_service::outbound_message_service::OutboundMessageService};
+    use std::sync::Arc;
+    use tari_crypto::{keys::PublicKey, ristretto::RistrettoPublicKey};
+
+    use crate::{message::MessageFlags, outbound_message_service::BroadcastStrategy};
+
+    use crate::{
+        connection::{net_address::net_addresses::MAX_CONNECTION_ATTEMPTS, NetAddress, NetAddresses},
+        peer_manager::{peer::PeerFlags, NodeId, Peer},
+        types::CommsPublicKey,
+    };
+    use log::*;
+    use tari_storage::lmdb::LMDBStore;
+
+    fn init() {
+        simple_logger::init();
+    }
+
+    #[test]
+    /// Test that when a message is sent via the pool that it is retried and requeued the correct amount of times and
+    /// that ConnectionRetryAttempts error is thrown
+    fn test_requeuing_messages() {
+        // init();
+
+        let mut rng = rand::OsRng::new().unwrap();
+        let context = Context::new();
+        let omp_inbound_address = InprocAddress::random();
+        let peer_manager = Arc::new(PeerManager::<CommsPublicKey, LMDBStore>::new(None).unwrap());
+
+        let mut omp =
+            OutboundMessagePool::new(context.clone(), omp_inbound_address.clone(), peer_manager.clone()).unwrap();
+
+        let (_dest_sk, pk) = RistrettoPublicKey::random_keypair(&mut rng);
+        let node_id = NodeId::from_key(&pk).unwrap();
+        let net_addresses = NetAddresses::from("1.2.3.4:8000".parse::<NetAddress>().unwrap());
+        let dest_peer: Peer<RistrettoPublicKey> =
+            Peer::<RistrettoPublicKey>::new(pk, node_id, net_addresses, PeerFlags::default());
+        peer_manager.add_peer(dest_peer.clone()).unwrap();
+        let oms = OutboundMessageService::new(context, omp_inbound_address, peer_manager.clone()).unwrap();
+        let receivers = omp.create_test_channels();
+        let _omp = omp.start();
+        let message_envelope_body: Vec<u8> = vec![0, 1, 2, 3];
+        oms.send(
+            BroadcastStrategy::Direct(dest_peer.node_id.clone()),
+            MessageFlags::ENCRYPTED,
+            &message_envelope_body,
+            &mut rng,
+        )
+        .unwrap();
+
+        // This array marks which workers responded. If fairly dealt each index should be set to 1
+        let mut worker_responses = [0; MAX_OUTBOUND_MSG_PROCESSING_WORKERS as usize];
+        let expected_responses = vec!["Attempt 1", "Attempt 2", "Attempt 3", "Connection Attempts Exceeded"];
+
+        let mut resp_count = 0;
+        loop {
+            for i in 0..MAX_OUTBOUND_MSG_PROCESSING_WORKERS as usize {
+                if let Ok(recv) = receivers[i].try_recv() {
+                    assert_eq!(recv, expected_responses[resp_count].to_string());
+                    resp_count += 1;
+
+                    // If this worker responded multiple times then the message were not fairly dealt so bork the count
+                    if worker_responses[i] > 0 {
+                        worker_responses[i] = MAX_OUTBOUND_MSG_PROCESSING_WORKERS + 1;
+                    } else {
+                        worker_responses[i] = 1;
+                    }
+                }
+            }
+
+            // For this test we expect 3 retries + the response for the Connection Attempts Exceeded error
+            if resp_count >= MAX_CONNECTION_ATTEMPTS as usize + 1 {
+                break;
+            }
+        }
+
+        // Confirm that the messages were fairly dealt to different worker threads
+        assert_eq!(
+            worker_responses.iter().fold(0, |acc, x| acc + x),
+            MAX_CONNECTION_ATTEMPTS as u8 + 1
+        );
+    }
+}

--- a/comms/src/outbound_message_service/outbound_message_service.rs
+++ b/comms/src/outbound_message_service/outbound_message_service.rs
@@ -22,60 +22,28 @@
 
 use crate::{
     connection::{
-        connection::EstablishedConnection,
-        error::ConnectionError,
-        types::SocketType,
-        zmq::{Context, InprocAddress, ZmqEndpoint, ZmqError},
+        zmq::{Context, InprocAddress},
+        Connection,
+        Direction,
+        SocketEstablishment,
     },
     message::{Frame, MessageEnvelope, MessageEnvelopeHeader, MessageFlags, NodeDestination},
-    outbound_message_service::{broadcast_strategy::BroadcastStrategy, outbound_message::OutboundMessage},
-    peer_manager::{
-        node_identity::CommsNodeIdentity,
-        peer_manager::{PeerManager, PeerManagerError},
-    },
+    outbound_message_service::{BroadcastStrategy, OutboundError, OutboundMessage},
+    peer_manager::{node_identity::CommsNodeIdentity, peer_manager::PeerManager},
     types::{Challenge, CommsPublicKey, CommsSecretKey, MESSAGE_PROTOCOL_VERSION, WIRE_PROTOCOL_VERSION},
 };
-use derive_error::Error;
+
 use digest::Digest;
 use rand::{CryptoRng, Rng};
 use rmp_serde;
 use serde::Serialize;
-use std::{convert::TryInto, sync::Arc};
+use std::sync::Arc;
 use tari_crypto::{
     keys::{DiffieHellmanSharedSecret, SecretKey},
-    signatures::{SchnorrSignature, SchnorrSignatureError},
+    signatures::SchnorrSignature,
 };
 use tari_storage::keyvalue_store::DataStore;
-use tari_utilities::{
-    chacha20,
-    message_format::{MessageFormat, MessageFormatError},
-    ByteArray,
-    ByteArrayError,
-};
-
-#[derive(Debug, Error)]
-pub enum OutboundError {
-    /// Problem setting up a socket to an outbound message pool
-    SocketError(ZmqError),
-    /// Could not connect to the outbound message pool
-    SocketConnectionError(zmq::Error),
-    /// Problem sending message to outbound message pool
-    SendError(ConnectionError),
-    /// The secret key was not defined in the node identity
-    UndefinedSecretKey,
-    /// The message signature could not be serialized to a vector of bytes
-    SignatureSerializationError,
-    /// The generated shared secret could not be serialized to a vector of bytes
-    SharedSecretSerializationError(ByteArrayError),
-    /// The message could not be serialized
-    MessageSerializationError(MessageFormatError),
-    /// Could not successfully sign the message
-    SignatureError(SchnorrSignatureError),
-    /// Problem encountered with Broadcast Strategy and PeerManager
-    BroadcastStrategyError(PeerManagerError),
-    /// The Thread Safety has been breached and the data access has become poisoned
-    PoisonedAccess,
-}
+use tari_utilities::{chacha20, message_format::MessageFormat, ByteArray};
 
 /// Handler functions use the OutboundMessageService to send messages to peers. The OutboundMessage service will receive
 /// messages from handlers, apply a broadcasting strategy, encrypted and serialized the messages into OutboundMessages
@@ -158,10 +126,7 @@ where DS: DataStore
         let node_identity = CommsNodeIdentity::global().ok_or(OutboundError::UndefinedSecretKey)?;
         // Use the BroadcastStrategy to select appropriate peer(s) from PeerManager and then construct and send a
         // personalised message to each selected peer
-        let selected_node_identities = self
-            .peer_manager
-            .get_broadcast_identities(broadcast_strategy)
-            .map_err(|e| OutboundError::BroadcastStrategyError(e))?;
+        let selected_node_identities = self.peer_manager.get_broadcast_identities(broadcast_strategy)?;
         for dest_node_identity in &selected_node_identities {
             // Constructing a MessageEnvelope
             let message_envelope_body = if flags.contains(MessageFlags::ENCRYPTED) {
@@ -179,7 +144,7 @@ where DS: DataStore
             };
             let message_envelope_header_frame = message_envelope_header
                 .to_binary()
-                .map_err(OutboundError::MessageSerializationError)?;
+                .map_err(|e| OutboundError::MessageFormatError(e))?;
             let message_envelope = MessageEnvelope::new(
                 vec![WIRE_PROTOCOL_VERSION],
                 message_envelope_header_frame,
@@ -190,20 +155,15 @@ where DS: DataStore
                 OutboundMessage::<MessageEnvelope>::new(dest_node_identity.node_id.clone(), message_envelope);
             let outbound_message_buffer = vec![outbound_message
                 .to_binary()
-                .map_err(|e| OutboundError::MessageSerializationError(e))?];
-
+                .map_err(|e| OutboundError::MessageFormatError(e))?];
             // Send message to outbound message pool
-            let outbound_socket = self
-                .context
-                .socket(SocketType::Request)
-                .map_err(|e| OutboundError::SocketError(e))?;
-            outbound_socket
-                .connect(&self.outbound_address.to_zmq_endpoint())
-                .map_err(|e| OutboundError::SocketConnectionError(e))?;
-            let outbound_connection: EstablishedConnection = outbound_socket.try_into()?;
+            let outbound_connection = Connection::new(&self.context, Direction::Outbound)
+                .set_socket_establishment(SocketEstablishment::Connect)
+                .establish(&self.outbound_address)
+                .map_err(|e| OutboundError::ConnectionError(e))?;
             outbound_connection
                 .send(&outbound_message_buffer)
-                .map_err(|e| OutboundError::SendError(e))?;
+                .map_err(|e| OutboundError::ConnectionError(e))?;
         }
         Ok(())
     }
@@ -214,10 +174,8 @@ mod test {
     use super::*;
 
     use crate::{
-        connection::{
-            net_address::{net_addresses::NetAddresses, NetAddress},
-            zmq::{Context, InprocAddress, ZmqEndpoint},
-        },
+        connection::net_address::{net_addresses::NetAddresses, NetAddress},
+        message::FrameSet,
         peer_manager::{
             node_id::NodeId,
             peer::{Peer, PeerFlags},
@@ -237,14 +195,10 @@ mod test {
         let mut rng = rand::OsRng::new().unwrap();
         let outbound_address = InprocAddress::random();
 
-        // Create a client that will retrieve messages from the outbound message pool
-        let omp_socket = context
-            .socket(SocketType::Reply)
-            .map_err(|e| OutboundError::SocketError(e))
-            .unwrap();
-        omp_socket
-            .bind(&outbound_address.to_zmq_endpoint())
-            .map_err(|e| OutboundError::SocketConnectionError(e))
+        // Create a Outbound Message Pool connection that will receive messages from the outbound message service
+        let message_queue_connection = Connection::new(&context, Direction::Inbound)
+            .set_socket_establishment(SocketEstablishment::Bind)
+            .establish(&outbound_address)
             .unwrap();
 
         let node_identity = CommsNodeIdentity::global().unwrap();
@@ -271,11 +225,11 @@ mod test {
             )
             .is_ok());
 
-        let msg_bytes = omp_socket.recv_multipart(0).unwrap();
+        let msg_bytes: FrameSet = message_queue_connection.receive(100).unwrap().drain(1..).collect();
         let outbound_message = OutboundMessage::<MessageEnvelope>::try_from(msg_bytes).unwrap();
         assert_eq!(outbound_message.destination_node_id, dest_peer.node_id);
-        assert_eq!(outbound_message.retry_count, 0);
-        assert_eq!(outbound_message.last_retry_timestamp, None);
+        assert_eq!(outbound_message.number_of_retries(), 0);
+        assert_eq!(outbound_message.last_retry_timestamp(), None);
         let message_envelope_header: MessageEnvelopeHeader<RistrettoPublicKey> =
             outbound_message.message_envelope.to_header().unwrap();
         assert_eq!(message_envelope_header.source, node_identity.identity.public_key);
@@ -301,7 +255,5 @@ mod test {
             &ecdh_shared_secret_bytes,
         );
         assert_eq!(message_envelope_body, decoded_message_envelope_body);
-
-        assert!(omp_socket.send("OK".as_bytes(), 0).is_ok());
     }
 }


### PR DESCRIPTION
## Description
The Outbound Message Pool (OMP) fields requests to send OutboundMessages from the various OutboundMessageService's (OMS's) in the system. OMS's assemble the OutboundMessages to be sent and then write them to the OMP's inbound InProc address which acts as a queue. The OMP spins up a series of workers to which the messages are fairly dealt and each worker will attempt to send the message, if it has failed it will requeue the message to the OMP queue to be attempted again in the future.

Currently the OMP is almost done, all the threading, worker logic and queuing is done. it is just waiting on the ConnectionService to be completed to actually attempt to make connection and attempt to transmit the message.

Waiting on https://github.com/tari-project/tari/issues/195

## Motivation and Context
Related to issue https://github.com/tari-project/tari/issues/325 but not finished yet.

## How Has This Been Tested?
Test is provided

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [x] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch
* [x] I ran `cargo-fmt --all` before pushing
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
