### PR TITLE
Fix race condition when establishing a connection to a single peer

### DIFF
--- a/comms/src/macros.rs
+++ b/comms/src/macros.rs
@@ -37,6 +37,9 @@ macro_rules! acquire_lock {
             Err(poisoned) => poisoned.into_inner(),
         }
     };
+    ($e:expr) => {
+        acquire_lock!($e, lock)
+    };
 }
 
 macro_rules! acquire_write_lock {

--- a/comms/tests/connection_manager/manager.rs
+++ b/comms/tests/connection_manager/manager.rs
@@ -115,25 +115,31 @@ fn establish_peer_connection_by_peer() {
 
     let node_B_peer_copy = node_B_peer.clone();
     let node_A_connection_manager_cloned = node_A_connection_manager.clone();
-    let handle1 = thread::spawn(move || {
+    let handle1 = thread::spawn(move || -> Result<(), String> {
         let to_node_B_conn = node_A_connection_manager_cloned
             .establish_connection_to_peer(&node_B_peer)
-            .unwrap();
+            .map_err(|err| format!("{:?}", err))?;
         to_node_B_conn.set_linger(Linger::Indefinitely);
-        to_node_B_conn.send(vec!["THREAD1".as_bytes().to_vec()]).unwrap();
+        to_node_B_conn
+            .send(vec!["THREAD1".as_bytes().to_vec()])
+            .map_err(|err| format!("{:?}", err))?;
+        Ok(())
     });
 
     let node_A_connection_manager_cloned = node_A_connection_manager.clone();
-    let handle2 = thread::spawn(move || {
+    let handle2 = thread::spawn(move || -> Result<(), String> {
         let to_node_B_conn = node_A_connection_manager_cloned
             .establish_connection_to_peer(&node_B_peer_copy)
-            .unwrap();
+            .map_err(|err| format!("{:?}", err))?;
         to_node_B_conn.set_linger(Linger::Indefinitely);
-        to_node_B_conn.send(vec!["THREAD2".as_bytes().to_vec()]).unwrap();
+        to_node_B_conn
+            .send(vec!["THREAD2".as_bytes().to_vec()])
+            .map_err(|err| format!("{:?}", err))?;
+        Ok(())
     });
 
-    handle1.join().unwrap();
-    handle2.join().unwrap();
+    handle1.join().unwrap().unwrap();
+    handle2.join().unwrap().unwrap();
 
     node_B_control_service.shutdown().unwrap();
     node_B_control_service.handle.join().unwrap().unwrap();

--- a/comms/tests/connection_manager/manager.rs
+++ b/comms/tests/connection_manager/manager.rs
@@ -20,7 +20,7 @@
 //  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 //  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use std::{sync::Arc, time::Duration};
+use std::{sync::Arc, thread, time::Duration};
 
 use crate::support::{
     factories::{self, Factory},
@@ -29,7 +29,7 @@ use crate::support::{
 };
 
 use tari_comms::{
-    connection::{types::Linger, Context, InprocAddress, NetAddress},
+    connection::{types::Linger, Context, InprocAddress},
     connection_manager::{ConnectionManager, PeerConnectionConfig},
     control_service::{handlers, ControlService, ControlServiceConfig, ControlServiceMessageType},
     dispatcher::Dispatcher,
@@ -71,7 +71,7 @@ fn establish_peer_connection_by_peer() {
     //---------------------------------- Node B Setup --------------------------------------------//
 
     let node_B_consumer_address = InprocAddress::random();
-    let node_B_control_port_address: NetAddress = factories::net_address::create().build().unwrap();
+    let node_B_control_port_address = factories::net_address::create().build().unwrap();
 
     let node_B_msg_counter = ConnectionMessageCounter::new(&context);
     node_B_msg_counter.start(node_B_consumer_address.clone());
@@ -113,18 +113,27 @@ fn establish_peer_connection_by_peer() {
 
     //------------------------------ Negotiate connection to node B -----------------------------------//
 
-    let to_node_B_conn = node_A_connection_manager
-        .establish_connection_to_peer(&node_B_peer)
-        .unwrap();
+    let node_B_peer_copy = node_B_peer.clone();
+    let node_A_connection_manager_cloned = node_A_connection_manager.clone();
+    let handle1 = thread::spawn(move || {
+        let to_node_B_conn = node_A_connection_manager_cloned
+            .establish_connection_to_peer(&node_B_peer)
+            .unwrap();
+        to_node_B_conn.set_linger(Linger::Indefinitely);
+        to_node_B_conn.send(vec!["THREAD1".as_bytes().to_vec()]).unwrap();
+    });
 
-    to_node_B_conn.set_linger(Linger::Indefinitely).unwrap();
+    let node_A_connection_manager_cloned = node_A_connection_manager.clone();
+    let handle2 = thread::spawn(move || {
+        let to_node_B_conn = node_A_connection_manager_cloned
+            .establish_connection_to_peer(&node_B_peer_copy)
+            .unwrap();
+        to_node_B_conn.set_linger(Linger::Indefinitely);
+        to_node_B_conn.send(vec!["THREAD2".as_bytes().to_vec()]).unwrap();
+    });
 
-    assert_eq!(node_A_connection_manager.get_active_connection_count(), 1);
-
-    assert!(to_node_B_conn.is_active());
-
-    to_node_B_conn.send(vec!["HELLO".as_bytes().to_vec()]).unwrap();
-    to_node_B_conn.send(vec!["TARI".as_bytes().to_vec()]).unwrap();
+    handle1.join().unwrap();
+    handle2.join().unwrap();
 
     node_B_control_service.shutdown().unwrap();
     node_B_control_service.handle.join().unwrap().unwrap();

--- a/comms/tests/support/helpers/connection_message_counter.rs
+++ b/comms/tests/support/helpers/connection_message_counter.rs
@@ -59,8 +59,15 @@ impl<'c> ConnectionMessageCounter<'c> {
     pub fn assert_count(&self, count: u32, timeout_ms: u64) -> () {
         for _i in 0..timeout_ms {
             thread::sleep(Duration::from_millis(1));
-            if self.count() >= count {
+            let curr_count = self.count();
+            if curr_count == count {
                 return;
+            }
+            if curr_count > count {
+                panic!(
+                    "Message count exceeded the expected count. Expected={} Actual={}",
+                    count, curr_count
+                );
             }
         }
         panic!(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
@philipr-za Identified a race condition in connection manager when a new peer connection is being requested at the same time by two or more threads. This results in the connection being established twice. This fix locks the connection establishment code for a given node id ensuring that only one connection establishment per node id can occur simultaneously.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Updated the connection manager test to use two threads that simultaneously request a peer connection. The updated test failed until after this fix was applied.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch
* [x] I ran `cargo-fmt --all` before pushing
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
