### PR TITLE
Implemented resetting connection_attempts to all net_addresses in a peer

### DIFF
--- a/comms/src/connection/mod.rs
+++ b/comms/src/connection/mod.rs
@@ -36,7 +36,7 @@ pub use self::{
     connection::{Connection, EstablishedConnection},
     dealer_proxy::{DealerProxy, DealerProxyError},
     error::ConnectionError,
-    net_address::{NetAddress, NetAddressError, NetAddresses},
+    net_address::{NetAddress, NetAddressError, NetAddressesWithStats},
     peer_connection::{
         PeerConnection,
         PeerConnectionContextBuilder,

--- a/comms/src/connection/net_address/mod.rs
+++ b/comms/src/connection/net_address/mod.rs
@@ -33,7 +33,7 @@ use derive_error::Error;
 use serde::{Deserialize, Serialize};
 use std::{fmt, str::FromStr};
 
-pub use self::{net_address_with_stats::NetAddressWithStats, net_addresses::NetAddresses};
+pub use self::{net_address_with_stats::NetAddressWithStats, net_addresses::NetAddressesWithStats};
 
 #[derive(Debug, Error)]
 pub enum NetAddressError {

--- a/comms/src/connection/net_address/net_address_with_stats.rs
+++ b/comms/src/connection/net_address/net_address_with_stats.rs
@@ -74,6 +74,11 @@ impl NetAddressWithStats {
         self.connection_attempts = 0;
     }
 
+    /// Reset the connection attempts on this net address for a later session of retries
+    pub fn reset_connection_attempts(&mut self) {
+        self.connection_attempts = 0;
+    }
+
     /// Mark that a connection could not be established with this net address
     pub fn mark_failed_connection_attempt(&mut self) {
         self.connection_attempts += 1;
@@ -193,6 +198,17 @@ mod test {
         assert_eq!(net_address_with_stats.connection_attempts, 2);
         net_address_with_stats.mark_successful_connection_attempt();
         assert!(net_address_with_stats.last_seen.is_some());
+        assert_eq!(net_address_with_stats.connection_attempts, 0);
+    }
+
+    #[test]
+    fn test_reseting_connection_attempts() {
+        let net_address = "123.0.0.123:8000".parse::<NetAddress>().unwrap();
+        let mut net_address_with_stats = NetAddressWithStats::from(net_address);
+        net_address_with_stats.mark_failed_connection_attempt();
+        net_address_with_stats.mark_failed_connection_attempt();
+        assert_eq!(net_address_with_stats.connection_attempts, 2);
+        net_address_with_stats.reset_connection_attempts();
         assert_eq!(net_address_with_stats.connection_attempts, 0);
     }
 

--- a/comms/src/connection/net_address/net_addresses.rs
+++ b/comms/src/connection/net_address/net_addresses.rs
@@ -12,12 +12,16 @@ pub const MAX_CONNECTION_ATTEMPTS: u32 = 3;
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Default)]
 pub struct NetAddresses {
     pub addresses: Vec<NetAddressWithStats>,
+    last_attempted: Option<DateTime<Utc>>,
 }
 
 impl NetAddresses {
     /// Constructs a new list of addresses with usage stats from a list of net addresses
     pub fn new(addresses: Vec<NetAddressWithStats>) -> NetAddresses {
-        NetAddresses { addresses }
+        NetAddresses {
+            addresses,
+            last_attempted: None,
+        }
     }
 
     /// Finds the specified address in the set and allow updating of its variables such as its usage stats
@@ -47,6 +51,11 @@ impl NetAddresses {
             }
         }
         latest_valid_datetime
+    }
+
+    /// Return the time of last attempted connection to this collection of addresses
+    pub fn last_attempted(&self) -> Option<DateTime<Utc>> {
+        self.last_attempted
     }
 
     /// Adds a new net address to the peer if it doesn't yet exist
@@ -116,6 +125,7 @@ impl NetAddresses {
     pub fn mark_successful_connection_attempt(&mut self, address: &NetAddress) -> Result<(), NetAddressError> {
         let updatable_address = self.find_address_mut(address)?;
         updatable_address.mark_successful_connection_attempt();
+        self.last_attempted = Some(Utc::now());
         Ok(())
     }
 
@@ -123,7 +133,15 @@ impl NetAddresses {
     pub fn mark_failed_connection_attempt(&mut self, address: &NetAddress) -> Result<(), NetAddressError> {
         let updatable_address = self.find_address_mut(address)?;
         updatable_address.mark_failed_connection_attempt();
+        self.last_attempted = Some(Utc::now());
         Ok(())
+    }
+
+    /// Reset the connection attempts stat on all of this Peers net addresses to retry connection
+    pub fn reset_connection_attempts(&mut self) {
+        for a in self.addresses.iter_mut() {
+            a.reset_connection_attempts();
+        }
     }
 
     /// Returns the number of addresses
@@ -137,6 +155,7 @@ impl From<NetAddress> for NetAddresses {
     fn from(net_address: NetAddress) -> Self {
         NetAddresses {
             addresses: vec![NetAddressWithStats::from(net_address)],
+            last_attempted: None,
         }
     }
 }
@@ -149,6 +168,7 @@ impl From<Vec<NetAddress>> for NetAddresses {
                 .into_iter()
                 .map(|addr| NetAddressWithStats::from(addr))
                 .collect::<Vec<NetAddressWithStats>>(),
+            last_attempted: None,
         }
     }
 }
@@ -156,7 +176,10 @@ impl From<Vec<NetAddress>> for NetAddresses {
 impl From<Vec<NetAddressWithStats>> for NetAddresses {
     /// Constructs NetAddresses from a list of addresses with usage stats
     fn from(addresses: Vec<NetAddressWithStats>) -> Self {
-        NetAddresses { addresses }
+        NetAddresses {
+            addresses,
+            last_attempted: None,
+        }
     }
 }
 
@@ -283,4 +306,29 @@ mod test {
         assert_eq!(net_addresses.addresses[1].connection_attempts, 0);
         assert_eq!(net_addresses.addresses[2].connection_attempts, 1);
     }
+
+    #[test]
+    fn test_resetting_all_connection_attempts() {
+        let net_address1 = "123.0.0.123:8000".parse::<NetAddress>().unwrap();
+        let net_address2 = "125.1.54.254:7999".parse::<NetAddress>().unwrap();
+        let net_address3 = "175.6.3.145:8000".parse::<NetAddress>().unwrap();
+        let mut addresses: Vec<NetAddressWithStats> = Vec::new();
+        addresses.push(NetAddressWithStats::from(net_address1.clone()));
+        addresses.push(NetAddressWithStats::from(net_address2.clone()));
+        addresses.push(NetAddressWithStats::from(net_address3.clone()));
+        let mut net_addresses = NetAddresses::new(addresses);
+        assert!(net_addresses.mark_failed_connection_attempt(&net_address1).is_ok());
+        assert!(net_addresses.mark_failed_connection_attempt(&net_address2).is_ok());
+        assert!(net_addresses.mark_failed_connection_attempt(&net_address3).is_ok());
+        assert!(net_addresses.mark_failed_connection_attempt(&net_address1).is_ok());
+
+        assert_eq!(net_addresses.addresses[0].connection_attempts, 2);
+        assert_eq!(net_addresses.addresses[1].connection_attempts, 1);
+        assert_eq!(net_addresses.addresses[2].connection_attempts, 1);
+        net_addresses.reset_connection_attempts();
+        assert_eq!(net_addresses.addresses[0].connection_attempts, 0);
+        assert_eq!(net_addresses.addresses[1].connection_attempts, 0);
+        assert_eq!(net_addresses.addresses[2].connection_attempts, 0);
+    }
+
 }

--- a/comms/src/connection/net_address/net_addresses.rs
+++ b/comms/src/connection/net_address/net_addresses.rs
@@ -10,15 +10,15 @@ pub const MAX_CONNECTION_ATTEMPTS: u32 = 3;
 
 /// This struct is used to store a set of different net addresses such as IPv4, IPv6, Tor or I2P for a single peer.
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Default)]
-pub struct NetAddresses {
+pub struct NetAddressesWithStats {
     pub addresses: Vec<NetAddressWithStats>,
     last_attempted: Option<DateTime<Utc>>,
 }
 
-impl NetAddresses {
+impl NetAddressesWithStats {
     /// Constructs a new list of addresses with usage stats from a list of net addresses
-    pub fn new(addresses: Vec<NetAddressWithStats>) -> NetAddresses {
-        NetAddresses {
+    pub fn new(addresses: Vec<NetAddressWithStats>) -> NetAddressesWithStats {
+        NetAddressesWithStats {
             addresses,
             last_attempted: None,
         }
@@ -150,20 +150,20 @@ impl NetAddresses {
     }
 }
 
-impl From<NetAddress> for NetAddresses {
+impl From<NetAddress> for NetAddressesWithStats {
     /// Constructs a new list of addresses with usage stats from a single net address
     fn from(net_address: NetAddress) -> Self {
-        NetAddresses {
+        NetAddressesWithStats {
             addresses: vec![NetAddressWithStats::from(net_address)],
             last_attempted: None,
         }
     }
 }
 
-impl From<Vec<NetAddress>> for NetAddresses {
+impl From<Vec<NetAddress>> for NetAddressesWithStats {
     /// Constructs a new list of addresses with usage stats from a Vec<NetAddress>
     fn from(net_addresses: Vec<NetAddress>) -> Self {
-        NetAddresses {
+        NetAddressesWithStats {
             addresses: net_addresses
                 .into_iter()
                 .map(|addr| NetAddressWithStats::from(addr))
@@ -173,10 +173,10 @@ impl From<Vec<NetAddress>> for NetAddresses {
     }
 }
 
-impl From<Vec<NetAddressWithStats>> for NetAddresses {
-    /// Constructs NetAddresses from a list of addresses with usage stats
+impl From<Vec<NetAddressWithStats>> for NetAddressesWithStats {
+    /// Constructs NetAddressesWithStats from a list of addresses with usage stats
     fn from(addresses: Vec<NetAddressWithStats>) -> Self {
-        NetAddresses {
+        NetAddressesWithStats {
             addresses,
             last_attempted: None,
         }
@@ -187,7 +187,7 @@ impl From<Vec<NetAddressWithStats>> for NetAddresses {
 mod test {
     use super::*;
     use crate::connection::{
-        net_address::{net_address_with_stats::NetAddressWithStats, net_addresses::NetAddresses},
+        net_address::{net_address_with_stats::NetAddressWithStats, net_addresses::NetAddressesWithStats},
         NetAddress,
     };
     use std::thread;
@@ -197,7 +197,7 @@ mod test {
         let net_address1 = "123.0.0.123:8000".parse::<NetAddress>().unwrap();
         let net_address2 = "125.1.54.254:7999".parse::<NetAddress>().unwrap();
         let net_address3 = "175.6.3.145:8000".parse::<NetAddress>().unwrap();
-        let mut net_addresses = NetAddresses::from(net_address1.clone());
+        let mut net_addresses = NetAddressesWithStats::from(net_address1.clone());
         assert!(net_addresses.add_net_address(&net_address2).is_ok());
         assert!(net_addresses.add_net_address(&net_address3).is_ok());
 
@@ -216,7 +216,7 @@ mod test {
         let net_address1 = "123.0.0.123:8000".parse::<NetAddress>().unwrap();
         let net_address2 = "125.1.54.254:7999".parse::<NetAddress>().unwrap();
         let net_address3 = "175.6.3.145:8000".parse::<NetAddress>().unwrap();
-        let mut net_addresses = NetAddresses::from(net_address1.clone());
+        let mut net_addresses = NetAddressesWithStats::from(net_address1.clone());
         assert!(net_addresses.add_net_address(&net_address2).is_ok());
         assert!(net_addresses.add_net_address(&net_address3).is_ok());
         assert!(net_addresses.add_net_address(&net_address2).is_err()); // Add duplicate address
@@ -231,7 +231,7 @@ mod test {
         let net_address1 = "123.0.0.123:8000".parse::<NetAddress>().unwrap();
         let net_address2 = "125.1.54.254:7999".parse::<NetAddress>().unwrap();
         let net_address3 = "175.6.3.145:8000".parse::<NetAddress>().unwrap();
-        let mut net_addresses = NetAddresses::from(net_address1.clone());
+        let mut net_addresses = NetAddressesWithStats::from(net_address1.clone());
         assert!(net_addresses.add_net_address(&net_address2).is_ok());
         assert!(net_addresses.add_net_address(&net_address3).is_ok());
 
@@ -274,7 +274,7 @@ mod test {
         addresses.push(NetAddressWithStats::from(net_address1.clone()));
         addresses.push(NetAddressWithStats::from(net_address2.clone()));
         addresses.push(NetAddressWithStats::from(net_address3.clone()));
-        let mut net_addresses = NetAddresses::new(addresses);
+        let mut net_addresses = NetAddressesWithStats::new(addresses);
 
         assert!(net_addresses
             .update_latency(&net_address2, Duration::from_millis(200))
@@ -316,7 +316,7 @@ mod test {
         addresses.push(NetAddressWithStats::from(net_address1.clone()));
         addresses.push(NetAddressWithStats::from(net_address2.clone()));
         addresses.push(NetAddressWithStats::from(net_address3.clone()));
-        let mut net_addresses = NetAddresses::new(addresses);
+        let mut net_addresses = NetAddressesWithStats::new(addresses);
         assert!(net_addresses.mark_failed_connection_attempt(&net_address1).is_ok());
         assert!(net_addresses.mark_failed_connection_attempt(&net_address2).is_ok());
         assert!(net_addresses.mark_failed_connection_attempt(&net_address3).is_ok());

--- a/comms/src/outbound_message_service/outbound_message_pool.rs
+++ b/comms/src/outbound_message_service/outbound_message_pool.rs
@@ -143,7 +143,7 @@ mod test {
     use crate::{message::MessageFlags, outbound_message_service::BroadcastStrategy};
 
     use crate::{
-        connection::{net_address::net_addresses::MAX_CONNECTION_ATTEMPTS, NetAddress, NetAddresses},
+        connection::{net_address::net_addresses::MAX_CONNECTION_ATTEMPTS, NetAddress, NetAddressesWithStats},
         peer_manager::{peer::PeerFlags, NodeId, Peer},
     };
 
@@ -161,7 +161,7 @@ mod test {
 
         let (_dest_sk, pk) = RistrettoPublicKey::random_keypair(&mut rng);
         let node_id = NodeId::from_key(&pk).unwrap();
-        let net_addresses = NetAddresses::from("1.2.3.4:8000".parse::<NetAddress>().unwrap());
+        let net_addresses = NetAddressesWithStats::from("1.2.3.4:8000".parse::<NetAddress>().unwrap());
         let dest_peer: Peer<RistrettoPublicKey> =
             Peer::<RistrettoPublicKey>::new(pk, node_id, net_addresses, PeerFlags::default());
         peer_manager.add_peer(dest_peer.clone()).unwrap();

--- a/comms/src/outbound_message_service/outbound_message_service.rs
+++ b/comms/src/outbound_message_service/outbound_message_service.rs
@@ -112,7 +112,7 @@ mod test {
     use super::*;
 
     use crate::{
-        connection::net_address::{net_addresses::NetAddresses, NetAddress},
+        connection::net_address::{net_addresses::NetAddressesWithStats, NetAddress},
         message::{FrameSet, Message},
         peer_manager::{
             node_id::NodeId,
@@ -139,7 +139,7 @@ mod test {
 
         let (dest_sk, pk) = RistrettoPublicKey::random_keypair(&mut rng);
         let node_id = NodeId::from_key(&pk).unwrap();
-        let net_addresses = NetAddresses::from("1.2.3.4:8000".parse::<NetAddress>().unwrap());
+        let net_addresses = NetAddressesWithStats::from("1.2.3.4:8000".parse::<NetAddress>().unwrap());
         let dest_peer: Peer<RistrettoPublicKey> =
             Peer::<RistrettoPublicKey>::new(pk, node_id, net_addresses, PeerFlags::default());
 

--- a/comms/src/peer_manager/mod.rs
+++ b/comms/src/peer_manager/mod.rs
@@ -34,13 +34,13 @@
 //! # use tari_comms::peer_manager::{NodeId, Peer, PeerManager, PeerFlags};
 //! # use tari_comms::types::CommsPublicKey;
 //! # use tari_storage::lmdb::LMDBStore;
-//! # use tari_comms::connection::{NetAddress, NetAddresses};
+//! # use tari_comms::connection::{NetAddress, NetAddressesWithStats};
 //! # use tari_crypto::keys::PublicKey;
 //!
 //! let mut rng = rand::OsRng::new().unwrap();
 //! let (dest_sk, pk) = CommsPublicKey::random_keypair(&mut rng);
 //! let node_id = NodeId::from_key(&pk).unwrap();
-//! let net_addresses = NetAddresses::from("1.2.3.4:8000".parse::<NetAddress>().unwrap());
+//! let net_addresses = NetAddressesWithStats::from("1.2.3.4:8000".parse::<NetAddress>().unwrap());
 //! let peer: Peer<CommsPublicKey> = Peer::<CommsPublicKey>::new(pk, node_id.clone(), net_addresses, PeerFlags::default());
 //! let peer_manager = PeerManager::<CommsPublicKey, LMDBStore>::new(None).unwrap();
 //! peer_manager.add_peer(peer.clone());

--- a/comms/src/peer_manager/peer.rs
+++ b/comms/src/peer_manager/peer.rs
@@ -28,7 +28,7 @@ use tari_crypto::{
     ristretto::serialize::{pubkey_from_hex, serialize_to_hex},
 };
 
-use crate::{connection::net_address::net_addresses::NetAddresses, peer_manager::node_id::NodeId};
+use crate::{connection::net_address::net_addresses::NetAddressesWithStats, peer_manager::node_id::NodeId};
 // TODO reputation metric?
 
 bitflags! {
@@ -40,14 +40,14 @@ bitflags! {
 
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq)]
 /// A Peer represents a communication peer that is identified by a Public Key and NodeId. The Peer struct maintains a
-/// collection of the NetAddresses that this Peer can be reached by. The struct also maintains a set of flags describing
-/// the status of the Peer.
+/// collection of the NetAddressesWithStats that this Peer can be reached by. The struct also maintains a set of flags
+/// describing the status of the Peer.
 pub struct Peer<K> {
     #[serde(serialize_with = "serialize_to_hex", bound(serialize = "K: PublicKey"))]
     #[serde(deserialize_with = "pubkey_from_hex", bound(deserialize = "K: PublicKey"))]
     pub public_key: K,
     pub node_id: NodeId,
-    pub addresses: NetAddresses,
+    pub addresses: NetAddressesWithStats,
     pub flags: PeerFlags,
 }
 
@@ -55,7 +55,7 @@ impl<K> Peer<K>
 where K: PublicKey
 {
     /// Constructs a new peer
-    pub fn new(public_key: K, node_id: NodeId, addresses: NetAddresses, flags: PeerFlags) -> Peer<K> {
+    pub fn new(public_key: K, node_id: NodeId, addresses: NetAddressesWithStats, flags: PeerFlags) -> Peer<K> {
         Peer {
             public_key,
             node_id,
@@ -84,7 +84,7 @@ where K: PublicKey
 mod test {
     use super::*;
     use crate::{
-        connection::{net_address::net_addresses::NetAddresses, NetAddress},
+        connection::{net_address::net_addresses::NetAddressesWithStats, NetAddress},
         peer_manager::node_id::NodeId,
     };
     use tari_crypto::{
@@ -98,7 +98,7 @@ mod test {
         let sk = RistrettoSecretKey::random(&mut rng);
         let pk = RistrettoPublicKey::from_secret_key(&sk);
         let node_id = NodeId::from_key(&pk).unwrap();
-        let addresses = NetAddresses::from("123.0.0.123:8000".parse::<NetAddress>().unwrap());
+        let addresses = NetAddressesWithStats::from("123.0.0.123:8000".parse::<NetAddress>().unwrap());
         let mut peer: Peer<RistrettoPublicKey> =
             Peer::<RistrettoPublicKey>::new(pk, node_id, addresses, PeerFlags::default());
         assert_eq!(peer.is_banned(), false);

--- a/comms/src/peer_manager/peer_manager.rs
+++ b/comms/src/peer_manager/peer_manager.rs
@@ -246,7 +246,7 @@ where
 mod test {
     use super::*;
     use crate::{
-        connection::net_address::{net_addresses::NetAddresses, NetAddress},
+        connection::net_address::{net_addresses::NetAddressesWithStats, NetAddress},
         outbound_message_service::broadcast_strategy::ClosestRequest,
         peer_manager::{
             node_id::NodeId,
@@ -261,7 +261,7 @@ mod test {
     fn create_test_peer(rng: &mut OsRng, ban_flag: bool) -> Peer<RistrettoPublicKey> {
         let (_sk, pk) = RistrettoPublicKey::random_keypair(rng);
         let node_id = NodeId::from_key(&pk).unwrap();
-        let net_addresses = NetAddresses::from("1.2.3.4:8000".parse::<NetAddress>().unwrap());
+        let net_addresses = NetAddressesWithStats::from("1.2.3.4:8000".parse::<NetAddress>().unwrap());
         let mut peer = Peer::<RistrettoPublicKey>::new(pk, node_id, net_addresses, PeerFlags::default());
         peer.set_banned(ban_flag);
         peer

--- a/comms/src/peer_manager/peer_manager.rs
+++ b/comms/src/peer_manager/peer_manager.rs
@@ -232,6 +232,14 @@ where
             .map_err(|_| PeerManagerError::PoisonedAccess)?
             .mark_failed_connection_attempt(net_address)
     }
+
+    /// Thread safe access to peer - Reset all connection attempts on all net addresses for peer
+    pub fn reset_connection_attempts(&self, node_id: &NodeId) -> Result<(), PeerManagerError> {
+        self.peer_storage
+            .write()
+            .map_err(|_| PeerManagerError::PoisonedAccess)?
+            .reset_connection_attempts(node_id)
+    }
 }
 
 #[cfg(test)]
@@ -342,4 +350,40 @@ mod test {
             .unwrap();
         assert_ne!(identities1, identities2);
     }
+
+    #[test]
+    fn test_peer_reset_connection_attempts() {
+        // Create peer manager with random peers
+        let peer_manager = PeerManager::<CommsPublicKey, LMDBStore>::new(None).unwrap();
+        let mut rng = rand::OsRng::new().unwrap();
+        let peer = create_test_peer(&mut rng, false);
+        peer_manager.add_peer(peer.clone()).unwrap();
+
+        peer_manager
+            .mark_failed_connection_attempt(&peer.addresses.addresses[0].clone().as_net_address())
+            .unwrap();
+        peer_manager
+            .mark_failed_connection_attempt(&peer.addresses.addresses[0].clone().as_net_address())
+            .unwrap();
+        assert_eq!(
+            peer_manager
+                .find_with_node_id(&peer.node_id.clone())
+                .unwrap()
+                .addresses
+                .addresses[0]
+                .connection_attempts,
+            2
+        );
+        peer_manager.reset_connection_attempts(&peer.node_id.clone()).unwrap();
+        assert_eq!(
+            peer_manager
+                .find_with_node_id(&peer.node_id.clone())
+                .unwrap()
+                .addresses
+                .addresses[0]
+                .connection_attempts,
+            0
+        );
+    }
+
 }

--- a/comms/src/peer_manager/peer_storage.rs
+++ b/comms/src/peer_manager/peer_storage.rs
@@ -403,6 +403,17 @@ where
             .mark_failed_connection_attempt(net_address)
             .map_err(|_| PeerManagerError::DataUpdateError)
     }
+
+    /// Enables Thread safe access - Finds a peer and if it exists resets all connection attempts on all net address
+    /// belonging to that peer
+    pub fn reset_connection_attempts(&mut self, node_id: &NodeId) -> Result<(), PeerManagerError> {
+        let peer_index = *self
+            .node_id_hm
+            .get(&node_id)
+            .ok_or(PeerManagerError::PeerNotFoundError)?;
+        self.peers[peer_index].addresses.reset_connection_attempts();
+        Ok(())
+    }
 }
 
 #[cfg(test)]

--- a/comms/src/peer_manager/peer_storage.rs
+++ b/comms/src/peer_manager/peer_storage.rs
@@ -420,7 +420,7 @@ where
 mod test {
     use super::*;
     use crate::{
-        connection::net_address::{net_addresses::NetAddresses, NetAddress},
+        connection::net_address::{net_addresses::NetAddressesWithStats, NetAddress},
         peer_manager::peer::PeerFlags,
     };
     use std::fs;
@@ -454,7 +454,7 @@ mod test {
         let net_address1 = NetAddress::from("1.2.3.4:8000".parse::<NetAddress>().unwrap());
         let net_address2 = NetAddress::from("5.6.7.8:8000".parse::<NetAddress>().unwrap());
         let net_address3 = NetAddress::from("5.6.7.8:7000".parse::<NetAddress>().unwrap());
-        let mut net_addresses = NetAddresses::from(net_address1.clone());
+        let mut net_addresses = NetAddressesWithStats::from(net_address1.clone());
         net_addresses.add_net_address(&net_address2).unwrap();
         net_addresses.add_net_address(&net_address3).unwrap();
         let peer1: Peer<RistrettoPublicKey> =
@@ -463,7 +463,7 @@ mod test {
         let (_sk, pk) = RistrettoPublicKey::random_keypair(&mut rng);
         let node_id = NodeId::from_key(&pk).unwrap();
         let net_address4 = NetAddress::from("9.10.11.12:7000".parse::<NetAddress>().unwrap());
-        let net_addresses = NetAddresses::from(net_address4.clone());
+        let net_addresses = NetAddressesWithStats::from(net_address4.clone());
         let peer2: Peer<RistrettoPublicKey> =
             Peer::<RistrettoPublicKey>::new(pk, node_id, net_addresses, PeerFlags::default());
 
@@ -471,7 +471,7 @@ mod test {
         let node_id = NodeId::from_key(&pk).unwrap();
         let net_address5 = NetAddress::from("13.14.15.16:6000".parse::<NetAddress>().unwrap());
         let net_address6 = NetAddress::from("17.18.19.20:8000".parse::<NetAddress>().unwrap());
-        let mut net_addresses = NetAddresses::from(net_address5.clone());
+        let mut net_addresses = NetAddressesWithStats::from(net_address5.clone());
         net_addresses.add_net_address(&net_address6).unwrap();
         let peer3: Peer<RistrettoPublicKey> =
             Peer::<RistrettoPublicKey>::new(pk, node_id, net_addresses, PeerFlags::default());
@@ -669,7 +669,7 @@ mod test {
         let node_id = NodeId::from_key(&pk).unwrap();
         let net_address1 = NetAddress::from("1.2.3.4:8000".parse::<NetAddress>().unwrap());
         let net_address2 = NetAddress::from("5.6.7.8:8000".parse::<NetAddress>().unwrap());
-        let mut net_addresses = NetAddresses::from(net_address1.clone());
+        let mut net_addresses = NetAddressesWithStats::from(net_address1.clone());
         assert!(net_addresses.add_net_address(&net_address2).is_ok());
         let peer1: Peer<RistrettoPublicKey> =
             Peer::<RistrettoPublicKey>::new(pk, node_id, net_addresses, PeerFlags::default());
@@ -677,7 +677,7 @@ mod test {
         let (_sk, pk) = RistrettoPublicKey::random_keypair(&mut rng);
         let node_id = NodeId::from_key(&pk).unwrap();
         let net_address3 = NetAddress::from("9.10.11.12:7000".parse::<NetAddress>().unwrap());
-        let net_addresses = NetAddresses::from(net_address3.clone());
+        let net_addresses = NetAddressesWithStats::from(net_address3.clone());
         let peer2: Peer<RistrettoPublicKey> =
             Peer::<RistrettoPublicKey>::new(pk, node_id, net_addresses, PeerFlags::default());
 


### PR DESCRIPTION
## Description
When attempting a connection to a Peer the ConnectionManager will attempt to contact all NetAddress associated with that peer for a set amount of attempts before giving up. If you want to try connect to that Peer again at a later stage you need to reset the connection_attempt stats to allow another attempt. This PR enabled that.

## Motivation and Context
Closes #365 

## How Has This Been Tested?
Tests have been provided

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [x] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch
* [x] I ran `cargo-fmt --all` before pushing
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
