### PR TITLE
Completed Outbound Message Pool

### DIFF
--- a/comms/src/connection/error.rs
+++ b/comms/src/connection/error.rs
@@ -24,7 +24,7 @@ use derive_error::Error;
 
 use super::{monitor, NetAddressError, PeerConnectionError};
 
-#[derive(Debug, Error)]
+#[derive(Debug, Error, PartialEq)]
 pub enum ConnectionError {
     NetAddressError(NetAddressError),
     #[error(msg_embedded, no_from, non_std)]

--- a/comms/src/connection/monitor.rs
+++ b/comms/src/connection/monitor.rs
@@ -36,7 +36,7 @@ use std::{
     fmt,
 };
 
-#[derive(Debug, Error)]
+#[derive(Debug, Error, PartialEq)]
 pub enum ConnectionMonitorError {
     #[error(msg_embedded, non_std, no_from)]
     CreateSocketFailed(String),

--- a/comms/src/connection/net_address/mod.rs
+++ b/comms/src/connection/net_address/mod.rs
@@ -35,7 +35,7 @@ use std::{fmt, str::FromStr};
 
 pub use self::{net_address_with_stats::NetAddressWithStats, net_addresses::NetAddressesWithStats};
 
-#[derive(Debug, Error)]
+#[derive(Debug, Error, PartialEq)]
 pub enum NetAddressError {
     /// Failed to parse address
     ParseFailed,

--- a/comms/src/connection/peer_connection/error.rs
+++ b/comms/src/connection/peer_connection/error.rs
@@ -23,7 +23,7 @@
 use derive_error::Error;
 
 /// Represents errors which can occur in a PeerConnection.
-#[derive(Debug, Error, Clone)]
+#[derive(Debug, Error, Clone, PartialEq)]
 pub enum PeerConnectionError {
     #[error(msg_embedded, non_std, no_from)]
     InitializationError(String),

--- a/comms/src/outbound_message_service/error.rs
+++ b/comms/src/outbound_message_service/error.rs
@@ -21,7 +21,8 @@
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE
 
 use crate::{
-    connection::{ConnectionError, NetAddressError},
+    connection::{ConnectionError, NetAddressError, PeerConnectionError},
+    connection_manager::ConnectionManagerError,
     message::MessageError,
     peer_manager::peer_manager::PeerManagerError,
 };
@@ -53,6 +54,12 @@ pub enum OutboundError {
     PoisonedAccess,
     /// Error requesting or updating a net address
     NetAddressError(NetAddressError),
-    // Error using a Cipher
+    /// Error using a Cipher
     CipherError(CipherError),
+    /// Error using the ConnectionManager
+    ConnectionManagerError(ConnectionManagerError),
+    /// Error using a PeerConnection
+    PeerConnectionError(PeerConnectionError),
+    /// Number of retry attempts exceeded
+    RetryAttemptsExceedError,
 }

--- a/comms/src/outbound_message_service/mod.rs
+++ b/comms/src/outbound_message_service/mod.rs
@@ -32,4 +32,5 @@ pub use self::{
     error::OutboundError,
     message_pool_worker::MessagePoolWorker,
     outbound_message::OutboundMessage,
+    outbound_message_pool::OutboundMessagePool,
 };

--- a/comms/src/outbound_message_service/outbound_message_pool.rs
+++ b/comms/src/outbound_message_service/outbound_message_pool.rs
@@ -27,56 +27,85 @@ use crate::{
         DealerProxy,
         DealerProxyError,
     },
+    connection_manager::ConnectionManager,
     outbound_message_service::{MessagePoolWorker, OutboundError},
     peer_manager::PeerManager,
+    types::{CommsDataStore, CommsPublicKey},
 };
 
 use log::*;
 #[cfg(test)]
 use std::sync::mpsc::{sync_channel, Receiver, SyncSender};
-use std::{hash::Hash, sync::Arc};
-use tari_crypto::keys::PublicKey;
-use tari_storage::keyvalue_store::DataStore;
+use std::sync::Arc;
+
+use chrono::Duration;
 
 /// The maximum number of processing worker threads that will be created by the OutboundMessageService
-const MAX_OUTBOUND_MSG_PROCESSING_WORKERS: u8 = 8;
+pub const MAX_OUTBOUND_MSG_PROCESSING_WORKERS: u8 = 8;
 
 const LOG_TARGET: &'static str = "comms::outbound_message_service::pool";
+
+#[derive(Clone, Copy)]
+pub struct OutboundMessagePoolConfig {
+    /// How many times the pool will requeue a message to be sent
+    pub max_num_of_retries: u32,
+    pub retry_wait_time: Duration,
+    pub worker_timeout_in_ms: u32,
+}
+
+impl Default for OutboundMessagePoolConfig {
+    fn default() -> Self {
+        OutboundMessagePoolConfig {
+            max_num_of_retries: 10,
+            retry_wait_time: Duration::seconds(3600),
+            worker_timeout_in_ms: 100,
+        }
+    }
+}
 
 /// The OutboundMessagePool will field outbound messages received from multiple OutboundMessageService instance that
 /// it will receive via the Inbound Inproc connection. It will handle the messages in the queue one at a time and
 /// attempt to send them. If they cannot be sent then the Retry count will be incremented and the message pushed to
 /// the back of the queue.
-struct OutboundMessagePool<P, DS> {
+pub struct OutboundMessagePool {
+    config: OutboundMessagePoolConfig,
     context: Context,
     message_queue_address: InprocAddress,
+    message_requeue_address: InprocAddress,
     worker_dealer_address: InprocAddress,
-    peer_manager: Arc<PeerManager<P, DS>>,
+    peer_manager: Arc<PeerManager<CommsPublicKey, CommsDataStore>>,
+    connection_manager: Arc<ConnectionManager>,
     #[cfg(test)]
     test_sync_sender: Vec<SyncSender<String>>, /* These channels will be to test the pool workers threaded
                                                 * operation */
 }
-impl<P, DS> OutboundMessagePool<P, DS>
-where
-    P: PublicKey + Hash + Send + Sync + 'static,
-    DS: DataStore + Send + Sync + 'static,
-{
+impl OutboundMessagePool {
     /// Construct a new Outbound Message Pool.
     /// # Arguments
+    /// `config` - The configuration struct to use for the Outbound Message Pool  
     /// `context` - A ZeroMQ context  
     /// `message_queue_address` - The InProc address that will be used to send message to this message pool  
-    /// `peer_manager` - a reference to the peer manager to be used when sending messages
+    /// `message_requeue_address` - The InProc address that messages that are being requeued is sent to. Typically this
+    /// will be same as the `message_queue_address` but this allows for a requeue proxy to be introduced
+    /// `peer_manager` - a reference to the peer manager to be used when
+    /// sending messages
     pub fn new(
+        config: OutboundMessagePoolConfig,
         context: Context,
         message_queue_address: InprocAddress,
-        peer_manager: Arc<PeerManager<P, DS>>,
-    ) -> Result<OutboundMessagePool<P, DS>, OutboundError>
+        message_requeue_address: InprocAddress,
+        peer_manager: Arc<PeerManager<CommsPublicKey, CommsDataStore>>,
+        connection_manager: Arc<ConnectionManager>,
+    ) -> Result<OutboundMessagePool, OutboundError>
     {
         Ok(OutboundMessagePool {
+            config,
             context,
             message_queue_address,
+            message_requeue_address,
             worker_dealer_address: InprocAddress::random(),
             peer_manager,
+            connection_manager,
             #[cfg(test)]
             test_sync_sender: Vec::new(),
         })
@@ -95,10 +124,13 @@ where
             for _i in 0..MAX_OUTBOUND_MSG_PROCESSING_WORKERS as usize {
                 #[allow(unused_mut)] // For testing purposes
                 let mut worker = MessagePoolWorker::new(
+                    self.config.clone(),
                     self.context.clone(),
                     self.worker_dealer_address.clone(),
                     self.message_queue_address.clone(),
+                    self.message_requeue_address.clone(),
                     self.peer_manager.clone(),
+                    self.connection_manager.clone(),
                 );
 
                 #[cfg(test)]
@@ -135,7 +167,6 @@ where
 
 #[cfg(test)]
 mod test {
-    use super::*;
     use crate::{connection::Context, outbound_message_service::outbound_message_service::OutboundMessageService};
     use std::sync::Arc;
     use tari_crypto::{keys::PublicKey, ristretto::RistrettoPublicKey};
@@ -143,50 +174,102 @@ mod test {
     use crate::{message::MessageFlags, outbound_message_service::BroadcastStrategy};
 
     use crate::{
-        connection::{net_address::net_addresses::MAX_CONNECTION_ATTEMPTS, NetAddress, NetAddressesWithStats},
+        connection::{NetAddress, NetAddressesWithStats},
+        connection_manager::{ConnectionManager, PeerConnectionConfig},
         peer_manager::{peer::PeerFlags, NodeId, Peer},
+        types::{CommsDataStore, CommsPublicKey},
     };
 
+    use crate::outbound_message_service::OutboundMessagePool;
+
+    use crate::{
+        connection::InprocAddress,
+        outbound_message_service::outbound_message_pool::{
+            OutboundMessagePoolConfig,
+            MAX_OUTBOUND_MSG_PROCESSING_WORKERS,
+        },
+        peer_manager::PeerManager,
+    };
+
+    use std::{thread, time::Duration};
+
+    const LOG_TARGET: &'static str = "comms::outbound_message_service::pool";
+
+    pub fn init() {
+        let _ = simple_logger::init();
+    }
+
+    fn make_peer_connection_config(context: &Context, consumer_address: InprocAddress) -> PeerConnectionConfig {
+        PeerConnectionConfig {
+            context: context.clone(),
+            control_service_establish_timeout: Duration::from_millis(2000),
+            peer_connection_establish_timeout: Duration::from_secs(5),
+            max_message_size: 1024,
+            host: "127.0.0.1".parse().unwrap(),
+            max_connect_retries: 3,
+            message_sink_address: consumer_address,
+            socks_proxy_address: None,
+        }
+    }
+
     #[test]
-    /// Test that when a message is sent via the pool that it is retried and requeued the correct amount of times and
-    /// that ConnectionRetryAttempts error is thrown
-    fn test_requeuing_messages() {
+    fn outbound_message_pool_threading_test() {
+        init();
         let mut rng = rand::OsRng::new().unwrap();
         let context = Context::new();
-        let omp_inbound_address = InprocAddress::random();
-        let peer_manager = Arc::new(PeerManager::new(None).unwrap());
 
-        let mut omp =
-            OutboundMessagePool::new(context.clone(), omp_inbound_address.clone(), peer_manager.clone()).unwrap();
+        let peer_manager = Arc::new(PeerManager::<CommsPublicKey, CommsDataStore>::new(None).unwrap());
+
+        let local_consumer_address = InprocAddress::random();
+        let connection_manager = Arc::new(ConnectionManager::new(
+            peer_manager.clone(),
+            make_peer_connection_config(&context, local_consumer_address.clone()),
+        ));
 
         let (_dest_sk, pk) = RistrettoPublicKey::random_keypair(&mut rng);
-        let node_id = NodeId::from_key(&pk).unwrap();
-        let net_addresses = NetAddressesWithStats::from("1.2.3.4:8000".parse::<NetAddress>().unwrap());
+        let node_id = NodeId::from_key(&pk.clone()).unwrap();
+        let net_addresses = NetAddressesWithStats::from("1.2.3.4:45325".parse::<NetAddress>().unwrap());
         let dest_peer: Peer<RistrettoPublicKey> =
-            Peer::<RistrettoPublicKey>::new(pk, node_id, net_addresses, PeerFlags::default());
+            Peer::<RistrettoPublicKey>::new(pk.clone(), node_id, net_addresses, PeerFlags::default());
         peer_manager.add_peer(dest_peer.clone()).unwrap();
-        let oms = OutboundMessageService::new(context, omp_inbound_address, peer_manager.clone()).unwrap();
-        let receivers = omp.create_test_channels();
-        let _omp = omp.start();
-        let message_envelope_body: Vec<u8> = vec![0, 1, 2, 3];
-        oms.send(
-            BroadcastStrategy::Direct(dest_peer.node_id.clone()),
-            MessageFlags::ENCRYPTED,
-            &message_envelope_body,
+
+        let omp_inbound_address = InprocAddress::random();
+        let omp_config = OutboundMessagePoolConfig::default();
+        let mut omp = OutboundMessagePool::new(
+            omp_config.clone(),
+            context.clone(),
+            omp_inbound_address.clone(),
+            omp_inbound_address.clone(),
+            peer_manager.clone(),
+            connection_manager.clone(),
         )
         .unwrap();
 
+        let oms = OutboundMessageService::new(context, omp_inbound_address, peer_manager.clone()).unwrap();
+        let receivers = omp.create_test_channels();
+
+        let _omp = omp.start();
+        let message_envelope_body: Vec<u8> = vec![0, 1, 2, 3];
+
+        // Send a message for each thread so we can test that each worker receives one
+        for _ in 0..MAX_OUTBOUND_MSG_PROCESSING_WORKERS {
+            oms.send(
+                BroadcastStrategy::Direct(dest_peer.node_id.clone()),
+                MessageFlags::ENCRYPTED,
+                &message_envelope_body,
+            )
+            .unwrap();
+            thread::sleep(Duration::from_millis(100));
+        }
+
         // This array marks which workers responded. If fairly dealt each index should be set to 1
         let mut worker_responses = [0; MAX_OUTBOUND_MSG_PROCESSING_WORKERS as usize];
-        let expected_responses = vec!["Attempt 1", "Attempt 2", "Attempt 3", "Connection Attempts Exceeded"];
 
         let mut resp_count = 0;
         loop {
             for i in 0..MAX_OUTBOUND_MSG_PROCESSING_WORKERS as usize {
-                if let Ok(recv) = receivers[i].try_recv() {
-                    assert_eq!(recv, expected_responses[resp_count].to_string());
+                if let Ok(_recv) = receivers[i].try_recv() {
                     resp_count += 1;
-
                     // If this worker responded multiple times then the message were not fairly dealt so bork the count
                     if worker_responses[i] > 0 {
                         worker_responses[i] = MAX_OUTBOUND_MSG_PROCESSING_WORKERS + 1;
@@ -196,8 +279,8 @@ mod test {
                 }
             }
 
-            // For this test we expect 3 retries + the response for the Connection Attempts Exceeded error
-            if resp_count >= MAX_CONNECTION_ATTEMPTS as usize + 1 {
+            // For this test we expect 1 message to reach each worker
+            if resp_count >= MAX_OUTBOUND_MSG_PROCESSING_WORKERS as usize {
                 break;
             }
         }
@@ -205,7 +288,7 @@ mod test {
         // Confirm that the messages were fairly dealt to different worker threads
         assert_eq!(
             worker_responses.iter().fold(0, |acc, x| acc + x),
-            MAX_CONNECTION_ATTEMPTS as u8 + 1
+            MAX_OUTBOUND_MSG_PROCESSING_WORKERS
         );
     }
 }

--- a/comms/src/outbound_message_service/outbound_message_service.rs
+++ b/comms/src/outbound_message_service/outbound_message_service.rs
@@ -119,12 +119,18 @@ mod test {
             peer::{Peer, PeerFlags},
         },
     };
+    use log::*;
     use std::convert::TryFrom;
     use tari_crypto::{keys::PublicKey, ristretto::RistrettoPublicKey};
     use tari_storage::lmdb::LMDBStore;
 
+    pub fn init() {
+        let _ = simple_logger::init();
+    }
+
     #[test]
     fn test_outbound_send() {
+        init();
         let context = Context::new();
         let mut rng = rand::OsRng::new().unwrap();
         let outbound_address = InprocAddress::random();
@@ -162,6 +168,10 @@ mod test {
             .unwrap();
 
         let msg_bytes: FrameSet = message_queue_connection.receive(100).unwrap().drain(1..).collect();
+        debug!(
+            target: "comms::outbound_message_service::outbound_message_service",
+            "Received message bytes: {:?}", msg_bytes
+        );
         let outbound_message = OutboundMessage::<MessageEnvelope>::try_from(msg_bytes).unwrap();
         assert_eq!(outbound_message.destination_node_id, dest_peer.node_id);
         assert_eq!(outbound_message.number_of_retries(), 0);

--- a/comms/tests/connection_manager/manager.rs
+++ b/comms/tests/connection_manager/manager.rs
@@ -119,7 +119,7 @@ fn establish_peer_connection_by_peer() {
         let to_node_B_conn = node_A_connection_manager_cloned
             .establish_connection_to_peer(&node_B_peer)
             .map_err(|err| format!("{:?}", err))?;
-        to_node_B_conn.set_linger(Linger::Indefinitely);
+        to_node_B_conn.set_linger(Linger::Indefinitely).unwrap();
         to_node_B_conn
             .send(vec!["THREAD1".as_bytes().to_vec()])
             .map_err(|err| format!("{:?}", err))?;
@@ -131,7 +131,7 @@ fn establish_peer_connection_by_peer() {
         let to_node_B_conn = node_A_connection_manager_cloned
             .establish_connection_to_peer(&node_B_peer_copy)
             .map_err(|err| format!("{:?}", err))?;
-        to_node_B_conn.set_linger(Linger::Indefinitely);
+        to_node_B_conn.set_linger(Linger::Indefinitely).unwrap();
         to_node_B_conn
             .send(vec!["THREAD2".as_bytes().to_vec()])
             .map_err(|err| format!("{:?}", err))?;

--- a/comms/tests/mod.rs
+++ b/comms/tests/mod.rs
@@ -26,4 +26,5 @@ extern crate lazy_static;
 mod connection;
 mod connection_manager;
 mod control_service;
+mod outbound_message_service;
 mod support;

--- a/comms/tests/outbound_message_service/mod.rs
+++ b/comms/tests/outbound_message_service/mod.rs
@@ -1,0 +1,22 @@
+// Copyright 2019 The Tari Project
+//
+// Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+// following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+// disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+// following disclaimer in the documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+// products derived from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+// INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+// WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+// USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE
+mod outbound_message_pool;

--- a/comms/tests/outbound_message_service/outbound_message_pool.rs
+++ b/comms/tests/outbound_message_service/outbound_message_pool.rs
@@ -1,0 +1,301 @@
+// Copyright 2019 The Tari Project
+//
+// Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+// following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+// disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+// following disclaimer in the documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+// products derived from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+// INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+// WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+// USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE
+
+#[cfg(test)]
+mod test {
+    use std::sync::Arc;
+    use tari_comms::{connection::Context, outbound_message_service::outbound_message_service::OutboundMessageService};
+
+    use tari_comms::{message::MessageFlags, outbound_message_service::BroadcastStrategy};
+
+    use tari_comms::{
+        connection::NetAddress,
+        connection_manager::{ConnectionManager, PeerConnectionConfig},
+        control_service::{handlers, ControlService, ControlServiceConfig, ControlServiceMessageType},
+        dispatcher::Dispatcher,
+        peer_manager::{CommsNodeIdentity, Peer},
+        types::{CommsDataStore, CommsPublicKey},
+    };
+
+    use tari_comms::outbound_message_service::{OutboundMessage, OutboundMessagePool};
+
+    use crate::support::{
+        factories::{self, Factory},
+        helpers::ConnectionMessageCounter,
+        node_identity::set_test_node_identity,
+    };
+
+    use chrono;
+    use std::{convert::TryFrom, thread, time::Duration};
+    use tari_comms::{
+        connection::{Connection, ConnectionError, Direction, InprocAddress, SocketEstablishment},
+        message::{FrameSet, MessageEnvelope},
+        outbound_message_service::outbound_message_pool::OutboundMessagePoolConfig,
+        peer_manager::PeerManager,
+    };
+
+    const LOG_TARGET: &'static str = "comms::outbound_message_service::pool";
+
+    fn make_peer_connection_config(context: &Context, consumer_address: InprocAddress) -> PeerConnectionConfig {
+        PeerConnectionConfig {
+            context: context.clone(),
+            control_service_establish_timeout: Duration::from_millis(2000),
+            peer_connection_establish_timeout: Duration::from_secs(5),
+            max_message_size: 1024,
+            host: "127.0.0.1".parse().unwrap(),
+            max_connect_retries: 3,
+            message_sink_address: consumer_address,
+            socks_proxy_address: None,
+        }
+    }
+
+    fn make_peer_manager(peers: Vec<Peer<CommsPublicKey>>) -> Arc<PeerManager<CommsPublicKey, CommsDataStore>> {
+        Arc::new(factories::peer_manager::create().with_peers(peers).build().unwrap())
+    }
+
+    pub fn init() {
+        let _ = simple_logger::init();
+    }
+
+    #[test]
+    #[allow(non_snake_case)]
+    fn test_outbound_message_pool() {
+        init();
+        let context = Context::new();
+
+        let dispatcher = Dispatcher::new(handlers::ControlServiceResolver::new()).route(
+            ControlServiceMessageType::EstablishConnection,
+            handlers::establish_connection,
+        );
+        set_test_node_identity();
+        let node_identity = CommsNodeIdentity::global().unwrap();
+
+        //---------------------------------- Node B Setup --------------------------------------------//
+
+        let node_B_consumer_address = InprocAddress::random();
+        let node_B_control_port_address: NetAddress = "127.0.0.1:45899".parse().unwrap();
+
+        let node_B_msg_counter = ConnectionMessageCounter::new(&context);
+        node_B_msg_counter.start(node_B_consumer_address.clone());
+
+        let node_B_peer = factories::peer::create()
+            .with_net_addresses(vec![node_B_control_port_address.clone()])
+            // Set node B's secret key to be the same as node A's so that we can generate the same shared secret
+            .with_public_key(node_identity.identity.public_key.clone())
+            .build()
+            .unwrap();
+
+        // Node B knows no peers
+        let node_B_peer_manager = make_peer_manager(vec![]);
+        let node_B_connection_manager = Arc::new(ConnectionManager::new(
+            node_B_peer_manager,
+            make_peer_connection_config(&context, node_B_consumer_address.clone()),
+        ));
+
+        // Start node B's control service
+        let node_B_control_service = ControlService::new(&context)
+            .configure(ControlServiceConfig {
+                socks_proxy_address: None,
+                listener_address: node_B_control_port_address,
+            })
+            .serve(dispatcher, node_B_connection_manager)
+            .unwrap();
+
+        //---------------------------------- Node A setup --------------------------------------------//
+
+        let node_A_consumer_address = InprocAddress::random();
+
+        // Add node B to node A's peer manager
+        let node_A_peer_manager = make_peer_manager(vec![node_B_peer.clone()]);
+        let node_A_connection_manager = Arc::new(ConnectionManager::new(
+            node_A_peer_manager.clone(),
+            make_peer_connection_config(&context, node_A_consumer_address),
+        ));
+
+        // Setup Node A OMP and OMS
+        let omp_inbound_address = InprocAddress::random();
+        let omp_config = OutboundMessagePoolConfig::default();
+        let omp = OutboundMessagePool::new(
+            omp_config.clone(),
+            context.clone(),
+            omp_inbound_address.clone(),
+            omp_inbound_address.clone(),
+            node_A_peer_manager.clone(),
+            node_A_connection_manager.clone(),
+        )
+        .unwrap();
+
+        let oms = OutboundMessageService::new(
+            context.clone(),
+            omp_inbound_address.clone(),
+            node_A_peer_manager.clone(),
+        )
+        .unwrap();
+        let oms2 =
+            OutboundMessageService::new(context.clone(), omp_inbound_address, node_A_peer_manager.clone()).unwrap();
+
+        let _omp = omp.start();
+        let message_envelope_body: Vec<u8> = vec![0, 1, 2, 3];
+
+        // Send 8 message alternating two different OMS's
+        for _ in 0..4 {
+            oms.send(
+                BroadcastStrategy::Direct(node_B_peer.node_id.clone()),
+                MessageFlags::ENCRYPTED,
+                &message_envelope_body,
+            )
+            .unwrap();
+            oms2.send(
+                BroadcastStrategy::Direct(node_B_peer.node_id.clone()),
+                MessageFlags::ENCRYPTED,
+                &message_envelope_body,
+            )
+            .unwrap();
+        }
+
+        node_B_msg_counter.assert_count(8, 1000);
+        node_B_control_service.shutdown().unwrap();
+        node_B_control_service.handle.join().unwrap().unwrap();
+    }
+
+    #[test]
+    #[allow(non_snake_case)]
+    fn test_outbound_message_pool_requeuing() {
+        init();
+        let context = Context::new();
+
+        set_test_node_identity();
+        let node_identity = CommsNodeIdentity::global().unwrap();
+
+        //---------------------------------- Node B Setup --------------------------------------------//
+        let node_B_control_port_address: NetAddress = "127.0.0.1:45845".parse().unwrap();
+        let node_B_peer = factories::peer::create()
+            .with_net_addresses(vec![node_B_control_port_address.clone()])
+            // Set node B's secret key to be the same as node A's so that we can generate the same shared secret
+            .with_public_key(node_identity.identity.public_key.clone())
+            .build()
+            .unwrap();
+
+        //---------------------------------- Node A setup --------------------------------------------//
+
+        let node_A_consumer_address = InprocAddress::random();
+
+        // Add node B to node A's peer manager
+        let node_A_peer_manager = make_peer_manager(vec![node_B_peer.clone()]);
+        let node_A_connection_manager = Arc::new(ConnectionManager::new(
+            node_A_peer_manager.clone(),
+            make_peer_connection_config(&context, node_A_consumer_address),
+        ));
+
+        // Setup Node A OMP and OMS
+        let omp_inbound_address = InprocAddress::random();
+        let omp_requeue_address = InprocAddress::random();
+
+        let omp_config = OutboundMessagePoolConfig {
+            max_num_of_retries: 3,
+            retry_wait_time: chrono::Duration::milliseconds(100),
+            worker_timeout_in_ms: 100,
+        };
+        let omp = OutboundMessagePool::new(
+            omp_config.clone(),
+            context.clone(),
+            omp_inbound_address.clone(),
+            omp_requeue_address.clone(),
+            node_A_peer_manager.clone(),
+            node_A_connection_manager.clone(),
+        )
+        .unwrap();
+
+        let oms = OutboundMessageService::new(
+            context.clone(),
+            omp_inbound_address.clone(),
+            node_A_peer_manager.clone(),
+        )
+        .unwrap();
+
+        let _omp = omp.start();
+        let message_envelope_body: Vec<u8> = vec![0, 1, 2, 3];
+
+        // Now check that the requeuing happens
+        let requeue_connection = Connection::new(&context.clone(), Direction::Inbound)
+            .set_socket_establishment(SocketEstablishment::Bind)
+            .establish(&omp_requeue_address)
+            .unwrap();
+        let omp_inbound_connection = Connection::new(&context.clone(), Direction::Outbound)
+            .set_socket_establishment(SocketEstablishment::Connect)
+            .establish(&omp_inbound_address)
+            .unwrap();
+
+        oms.send(
+            BroadcastStrategy::Direct(node_B_peer.node_id.clone()),
+            MessageFlags::ENCRYPTED,
+            &message_envelope_body,
+        )
+        .unwrap();
+
+        // Receive first requeue
+        let mut frame_set = requeue_connection.receive(1000).unwrap();
+        let data: FrameSet = frame_set.drain(1..).collect();
+
+        let msg = OutboundMessage::<MessageEnvelope>::try_from(data).unwrap();
+        assert_eq!(
+            node_A_peer_manager
+                .find_with_node_id(&msg.destination_node_id.clone())
+                .unwrap()
+                .addresses
+                .addresses[0]
+                .connection_attempts,
+            0
+        );
+        assert_eq!(msg.number_of_retries(), 1);
+        omp_inbound_connection.send(vec![msg.to_frame().unwrap()]).unwrap();
+
+        // Receive second requeue that happened before retry wait time elapsed
+        let mut frame_set = requeue_connection.receive(1000).unwrap();
+        let data: FrameSet = frame_set.drain(1..).collect();
+
+        let msg = OutboundMessage::<MessageEnvelope>::try_from(data).unwrap();
+        assert_eq!(msg.number_of_retries(), 1);
+        thread::sleep(Duration::from_millis(200));
+        omp_inbound_connection.send(vec![msg.to_frame().unwrap()]).unwrap();
+
+        // Receive third requeue that happened after retry wait time elapsed
+        let mut frame_set = requeue_connection.receive(1000).unwrap();
+        let data: FrameSet = frame_set.drain(1..).collect();
+
+        let msg = OutboundMessage::<MessageEnvelope>::try_from(data).unwrap();
+        assert_eq!(msg.number_of_retries(), 2);
+        thread::sleep(Duration::from_millis(200));
+        omp_inbound_connection.send(vec![msg.to_frame().unwrap()]).unwrap();
+
+        // Receive fourth requeue that happened after retry wait time elapsed
+        let mut frame_set = requeue_connection.receive(100).unwrap();
+        let data: FrameSet = frame_set.drain(1..).collect();
+        let msg = OutboundMessage::<MessageEnvelope>::try_from(data).unwrap();
+        assert_eq!(msg.number_of_retries(), 3);
+        thread::sleep(Duration::from_millis(200));
+        omp_inbound_connection.send(vec![msg.to_frame().unwrap()]).unwrap();
+
+        // This time the requeue should not occur so this read should timeout
+        assert_eq!(requeue_connection.receive(100), Err(ConnectionError::Timeout));
+    }
+}


### PR DESCRIPTION
## Description
The Outbound Message Pool (OMP) fields requests to send OutboundMessages from the various OutboundMessageService's (OMS's) in the system. OMS's assemble the OutboundMessages to be sent and then write them to the OMP's inbound InProc address which acts as a queue. The OMP spins up a series of workers to which the messages are fairly dealt and each worker will attempt to send the message, if it has failed it will requeue the message to the OMP queue to be attempted again in the future.

## Motivation and Context
Closes #325 

## How Has This Been Tested?
Unit and Integration tests provided

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [x] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch
* [x] I ran `cargo-fmt --all` before pushing
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
