### PR TITLE
Sizeable refactor and comms builder

### DIFF
--- a/base_layer/p2p/Cargo.toml
+++ b/base_layer/p2p/Cargo.toml
@@ -13,3 +13,4 @@ serde = "1.0.90"
 serde_derive = "1.0.90"
 
 [dev-dependencies]
+rand = "0.6.5"

--- a/base_layer/p2p/src/handlers.rs
+++ b/base_layer/p2p/src/handlers.rs
@@ -164,9 +164,9 @@ mod test {
         connection::{
             types::SocketType,
             zmq::{InprocAddress, ZmqEndpoint},
-            Context,
             EstablishedConnection,
             NetAddress,
+            ZmqContext,
         },
         inbound_message_service::{
             comms_msg_handlers::construct_comms_msg_dispatcher,
@@ -206,7 +206,7 @@ mod test {
         // Setup Comms system
         init_node_identity();
         let node_identity = CommsNodeIdentity::global().unwrap();
-        let context = Context::new();
+        let context = ZmqContext::new();
         let inbound_msg_pool_address = InprocAddress::random();
         // Create a conn_client that can submit messages to the InboundMessageService
         let client_socket = context.socket(SocketType::Request).unwrap();

--- a/base_layer/p2p/src/handlers.rs
+++ b/base_layer/p2p/src/handlers.rs
@@ -22,54 +22,30 @@
 
 use crate::tari_message::{BlockchainMessage, NetMessage, PeerMessage, TariMessageType, ValidatorNodeMessage};
 use tari_comms::{
-    dispatcher::{DispatchError, DispatchResolver},
-    message::{DomainMessageContext, MessageHeader},
-    types::DomainMessageDispatcher,
+    dispatcher::{DomainMessageDispatcher, HandlerError},
+    message::DomainMessageContext,
 };
-use tari_crypto::keys::PublicKey;
 
 // Create a common variable that the worker can change and the test can read to determine that the message was
 // correctly dispatched
 #[cfg(test)]
 static mut TEST_CALLED_FN_TYPE: u8 = 0;
 
-#[derive(Clone)]
-pub struct DomainInboundMessageResolver;
-
-impl<PubKey: PublicKey> DispatchResolver<TariMessageType, DomainMessageContext<PubKey>>
-    for DomainInboundMessageResolver
-{
-    /// The dispatch type is determined from the content of the DomainMessageContext, which is used to dispatch the
-    /// message to the correct domain handler
-    fn resolve(&self, message_context: &DomainMessageContext<PubKey>) -> Result<TariMessageType, DispatchError> {
-        let message_header: MessageHeader<TariMessageType> = message_context
-            .message
-            .to_header()
-            .map_err(|err| DispatchError::HandlerError(format!("{}", err)))?;
-        Ok(message_header.message_type)
-    }
-}
-
 /// Specify what handler function should be called for messages with different domain message types
-pub fn construct_domain_msg_dispatcher<PubKey: PublicKey>(
-) -> DomainMessageDispatcher<PubKey, TariMessageType, DomainInboundMessageResolver> {
-    DomainMessageDispatcher::<PubKey, TariMessageType, DomainInboundMessageResolver>::new(
-        DomainInboundMessageResolver {},
-    )
-    .route(NetMessage::Join.into(), handler_net_message_join)
-    .route(NetMessage::Discover.into(), handler_net_message_discover)
-    .route(PeerMessage::Connect.into(), handler_peer_message_connect)
-    .route(BlockchainMessage::NewBlock.into(), handler_blockchain_message_new_block)
-    .route(
-        ValidatorNodeMessage::Instruction.into(),
-        handler_validator_node_message_instruction,
-    )
-    .catch_all(handler_catch_all)
+pub fn construct_domain_msg_dispatcher() -> DomainMessageDispatcher<TariMessageType> {
+    DomainMessageDispatcher::<TariMessageType>::default()
+        .route(NetMessage::Join.into(), handler_net_message_join)
+        .route(NetMessage::Discover.into(), handler_net_message_discover)
+        .route(PeerMessage::Connect.into(), handler_peer_message_connect)
+        .route(BlockchainMessage::NewBlock.into(), handler_blockchain_message_new_block)
+        .route(
+            ValidatorNodeMessage::Instruction.into(),
+            handler_validator_node_message_instruction,
+        )
+        .catch_all(handler_catch_all)
 }
 
-fn handler_net_message_join<PubKey: PublicKey>(
-    _message_context: DomainMessageContext<PubKey>,
-) -> Result<(), DispatchError> {
+fn handler_net_message_join(_message_context: DomainMessageContext) -> Result<(), HandlerError> {
     #[cfg(test)]
     {
         unsafe {
@@ -82,9 +58,7 @@ fn handler_net_message_join<PubKey: PublicKey>(
     Ok(())
 }
 
-fn handler_net_message_discover<PubKey: PublicKey>(
-    _message_context: DomainMessageContext<PubKey>,
-) -> Result<(), DispatchError> {
+fn handler_net_message_discover(_message_context: DomainMessageContext) -> Result<(), HandlerError> {
     #[cfg(test)]
     {
         unsafe {
@@ -97,9 +71,7 @@ fn handler_net_message_discover<PubKey: PublicKey>(
     Ok(())
 }
 
-fn handler_peer_message_connect<PubKey: PublicKey>(
-    _message_context: DomainMessageContext<PubKey>,
-) -> Result<(), DispatchError> {
+fn handler_peer_message_connect(_message_context: DomainMessageContext) -> Result<(), HandlerError> {
     #[cfg(test)]
     {
         unsafe {
@@ -112,9 +84,7 @@ fn handler_peer_message_connect<PubKey: PublicKey>(
     Ok(())
 }
 
-fn handler_blockchain_message_new_block<PubKey: PublicKey>(
-    _message_context: DomainMessageContext<PubKey>,
-) -> Result<(), DispatchError> {
+fn handler_blockchain_message_new_block(_message_context: DomainMessageContext) -> Result<(), HandlerError> {
     #[cfg(test)]
     {
         unsafe {
@@ -127,9 +97,7 @@ fn handler_blockchain_message_new_block<PubKey: PublicKey>(
     Ok(())
 }
 
-fn handler_validator_node_message_instruction<PubKey: PublicKey>(
-    _message_context: DomainMessageContext<PubKey>,
-) -> Result<(), DispatchError> {
+fn handler_validator_node_message_instruction(_message_context: DomainMessageContext) -> Result<(), HandlerError> {
     #[cfg(test)]
     {
         unsafe {
@@ -142,7 +110,7 @@ fn handler_validator_node_message_instruction<PubKey: PublicKey>(
     Ok(())
 }
 
-fn handler_catch_all<PubKey: PublicKey>(_message_context: DomainMessageContext<PubKey>) -> Result<(), DispatchError> {
+fn handler_catch_all(_message_context: DomainMessageContext) -> Result<(), HandlerError> {
     #[cfg(test)]
     {
         unsafe {
@@ -159,53 +127,36 @@ fn handler_catch_all<PubKey: PublicKey>(_message_context: DomainMessageContext<P
 mod test {
     use super::*;
     use crate::tari_message::TariMessageType;
+    use rand::rngs::OsRng;
     use std::{convert::TryInto, sync::Arc, thread, time::Duration};
     use tari_comms::{
         connection::{
             types::SocketType,
             zmq::{InprocAddress, ZmqEndpoint},
             EstablishedConnection,
-            NetAddress,
             ZmqContext,
         },
         inbound_message_service::{
             comms_msg_handlers::construct_comms_msg_dispatcher,
             inbound_message_service::InboundMessageService,
         },
-        message::{Message, MessageData, MessageEnvelope, MessageFlags, NodeDestination},
+        message::{Message, MessageData, MessageEnvelope, MessageFlags, MessageHeader, NodeDestination},
         outbound_message_service::outbound_message_service::OutboundMessageService,
-        peer_manager::{node_id::NodeId, peer_manager::PeerManager, CommsNodeIdentity, NodeIdentity, PeerNodeIdentity},
+        peer_manager::{peer_manager::PeerManager, NodeIdentity},
         types::{CommsDataStore, CommsPublicKey},
     };
-    use tari_crypto::{
-        keys::PublicKey,
-        ristretto::{RistrettoPublicKey, RistrettoSecretKey},
-    };
-    use tari_utilities::{byte_array::ByteArray, message_format::MessageFormat};
+    use tari_crypto::ristretto::RistrettoPublicKey;
+    use tari_utilities::message_format::MessageFormat;
 
     fn pause() {
         thread::sleep(Duration::from_millis(5));
     }
 
-    fn init_node_identity() {
-        let secret_key = RistrettoSecretKey::from_bytes(&[
-            1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-        ])
-        .unwrap();
-        let public_key = RistrettoPublicKey::from_secret_key(&secret_key);
-        let node_id = NodeId::from_key(&public_key).unwrap();
-        NodeIdentity::<RistrettoPublicKey>::set_global(CommsNodeIdentity {
-            identity: PeerNodeIdentity::new(node_id, public_key),
-            secret_key,
-            control_service_address: "127.0.0.1:9090".parse::<NetAddress>().unwrap(),
-        });
-    }
-
     #[test]
     fn test_handlers() {
         // Setup Comms system
-        init_node_identity();
-        let node_identity = CommsNodeIdentity::global().unwrap();
+        let node_identity =
+            Arc::new(NodeIdentity::random(&mut OsRng::new().unwrap(), "127.0.0.1:9000".parse().unwrap()).unwrap());
         let context = ZmqContext::new();
         let inbound_msg_pool_address = InprocAddress::random();
         // Create a conn_client that can submit messages to the InboundMessageService
@@ -215,18 +166,21 @@ mod test {
             .unwrap();
         let conn_client: EstablishedConnection = client_socket.try_into().unwrap();
         // Setup Dispatchers, InboundMessageService and OutboundMessageService
-        let domain_dispatcher = Arc::new(construct_domain_msg_dispatcher::<RistrettoPublicKey>());
-        let comms_dispatcher = Arc::new(construct_comms_msg_dispatcher::<
-            RistrettoPublicKey,
-            TariMessageType,
-            DomainInboundMessageResolver,
-        >());
+        let domain_dispatcher = Arc::new(construct_domain_msg_dispatcher());
+        let comms_dispatcher = Arc::new(construct_comms_msg_dispatcher::<TariMessageType>());
         let peer_manager = Arc::new(PeerManager::<CommsPublicKey, CommsDataStore>::new(None).unwrap());
         let outbound_message_service = Arc::new(
-            OutboundMessageService::new(context.clone(), InprocAddress::random(), peer_manager.clone()).unwrap(),
+            OutboundMessageService::new(
+                context.clone(),
+                node_identity.clone(),
+                InprocAddress::random(),
+                peer_manager.clone(),
+            )
+            .unwrap(),
         );
         let inbound_message_service = InboundMessageService::new(
             context,
+            node_identity.clone(),
             inbound_msg_pool_address,
             comms_dispatcher,
             domain_dispatcher,
@@ -246,10 +200,10 @@ mod test {
         let dest_public_key = node_identity.identity.public_key.clone(); // Send to self
         let dest_node_id = node_identity.identity.node_id.clone(); // Send to self
         let message_envelope = MessageEnvelope::construct(
-            node_identity.clone(),
+            &node_identity,
             dest_public_key.clone(),
             NodeDestination::Unknown,
-            &message_envelope_body.to_binary().unwrap(),
+            message_envelope_body.to_binary().unwrap(),
             MessageFlags::NONE,
         )
         .unwrap();
@@ -272,10 +226,10 @@ mod test {
         let message_body = "Test Message Body2".as_bytes().to_vec();
         let message_envelope_body = Message::from_message_format(message_header, message_body).unwrap();
         let message_envelope = MessageEnvelope::construct(
-            node_identity,
+            &node_identity,
             dest_public_key,
             NodeDestination::NodeId(dest_node_id),
-            &message_envelope_body.to_binary().unwrap(),
+            message_envelope_body.to_binary().unwrap(),
             MessageFlags::ENCRYPTED,
         )
         .unwrap();

--- a/base_layer/p2p/src/tari_message.rs
+++ b/base_layer/p2p/src/tari_message.rs
@@ -40,7 +40,7 @@ pub struct TariMessageType(u8);
 #[allow(non_snake_case, non_upper_case_globals)]
 pub mod NetMessage {
     pub(super) const START_RANGE: u8 = 1;
-    pub(super) const END_RANGE: u8 = 2; // Can be extended to 32
+    pub(super) const END_RANGE: u8 = 3; // Can be extended to 32
     /// Message sent when a request to establish a peer connection has been accepted
     pub const Accept: u8 = 1;
     pub const Join: u8 = 2;
@@ -114,7 +114,7 @@ mod test {
     #[test]
     fn create_message() {
         // When reading from the wire, the message type will be a byte value
-        let t = TariMessageType::from(2);
+        let t = TariMessageType::from(3);
         assert_eq!(t.value(), NetMessage::Discover);
         assert!(t.is_net_message());
         assert!(t.is_known_message());

--- a/base_layer/p2p/src/tari_message.rs
+++ b/base_layer/p2p/src/tari_message.rs
@@ -41,8 +41,10 @@ pub struct TariMessageType(u8);
 pub mod NetMessage {
     pub(super) const START_RANGE: u8 = 1;
     pub(super) const END_RANGE: u8 = 2; // Can be extended to 32
-    pub const Join: u8 = 1;
-    pub const Discover: u8 = 2;
+    /// Message sent when a request to establish a peer connection has been accepted
+    pub const Accept: u8 = 1;
+    pub const Join: u8 = 2;
+    pub const Discover: u8 = 3;
 }
 
 #[allow(non_snake_case, non_upper_case_globals)]

--- a/comms/benches/connection/connection.rs
+++ b/comms/benches/connection/connection.rs
@@ -23,13 +23,13 @@
 use criterion::Criterion;
 
 use std::{iter::repeat, time::Duration};
-use tari_comms::connection::{Connection, Context, Direction, InprocAddress};
+use tari_comms::connection::{Connection, Direction, InprocAddress, ZmqContext};
 
 /// Connection benchmark
 ///
 /// Benchmark a message being sent and received between two connections
 fn bench_connection(c: &mut Criterion) {
-    let ctx = Context::new();
+    let ctx = ZmqContext::new();
     let addr = InprocAddress::random();
 
     let bytes = repeat(88u8).take(1 * 1024 * 1024 /* 10Mb */).collect::<Vec<u8>>();

--- a/comms/benches/connection/peer_connection.rs
+++ b/comms/benches/connection/peer_connection.rs
@@ -32,12 +32,12 @@ use tari_comms::{
     connection::{
         peer_connection::PeerConnectionContext,
         Connection,
-        Context,
         Direction,
         InprocAddress,
         NetAddress,
         PeerConnection,
         PeerConnectionContextBuilder,
+        ZmqContext,
     },
     message::FrameSet,
 };
@@ -63,7 +63,7 @@ enum WorkerTask {
 
 /// Build a context for the connections to be used in the benchmark
 fn build_context(
-    ctx: &Context,
+    ctx: &ZmqContext,
     dir: Direction,
     addr: &NetAddress,
     consumer_addr: &InprocAddress,
@@ -83,7 +83,7 @@ fn build_context(
 /// Start a consumer thread.
 /// This listens for control messages, execute the given task and signal when it's done (`signal` field)
 fn start_message_sink_consumer(
-    ctx: &Context,
+    ctx: &ZmqContext,
     addr: &InprocAddress,
     peer_conn: &PeerConnection,
     signal: Sender<()>,
@@ -135,7 +135,7 @@ fn start_message_sink_consumer(
 /// 2. All connections go out of scope (i.e. are dropped)
 fn bench_peer_connection(c: &mut Criterion) {
     // Setup
-    let ctx = Context::new();
+    let ctx = ZmqContext::new();
     let addr = BENCH_SOCKET_ADDRESS.parse::<NetAddress>().unwrap();
     let consumer1 = InprocAddress::random();
     let consumer2 = InprocAddress::random();

--- a/comms/src/builder/builder.rs
+++ b/comms/src/builder/builder.rs
@@ -107,7 +107,7 @@ where
     MType: Serialize + DeserializeOwned,
     MType: Clone,
 {
-    comms_context: ZmqContext,
+    zmq_context: ZmqContext,
     // Factories
     control_service_config_factory: Option<Box<Factory<ControlServiceConfig<MType>>>>,
     dispatcher_factory: Box<Factory<DomainMessageDispatcher<MType>>>,
@@ -128,10 +128,10 @@ where
         F: Factory<DomainMessageDispatcher<MType>>,
         F: 'static,
     {
-        let comms_context = ZmqContext::new();
+        let zmq_context = ZmqContext::new();
 
         Self {
-            comms_context,
+            zmq_context,
             control_service_config_factory: None,
             peer_conn_config_factory: None,
             omp_config_factory: None,
@@ -196,7 +196,7 @@ where
         self.control_service_config_factory
             .take()
             .map(|f| f.make())
-            .map(|config| ControlService::new(self.comms_context.clone(), node_identity, config))
+            .map(|config| ControlService::new(self.zmq_context.clone(), node_identity, config))
     }
 
     fn make_connection_manager(
@@ -207,7 +207,7 @@ where
     ) -> Arc<ConnectionManager>
     {
         Arc::new(ConnectionManager::new(
-            self.comms_context.clone(),
+            self.zmq_context.clone(),
             node_identity,
             peer_manager,
             config,
@@ -242,7 +242,7 @@ where
     ) -> Result<OutboundMessageService, CommsBuilderError>
     {
         OutboundMessageService::new(
-            self.comms_context.clone(),
+            self.zmq_context.clone(),
             node_identity,
             message_sink_address,
             peer_manager,
@@ -261,7 +261,7 @@ where
 
         OutboundMessagePool::new(
             config,
-            self.comms_context.clone(),
+            self.zmq_context.clone(),
             // OMP can requeue back onto itself
             message_sink_address.clone(),
             message_sink_address.clone(),
@@ -281,7 +281,7 @@ where
     ) -> Result<InboundMessageService<MType>, CommsBuilderError>
     {
         InboundMessageService::new(
-            self.comms_context.clone(),
+            self.zmq_context.clone(),
             node_identity,
             message_sink_address,
             Arc::new(construct_comms_msg_dispatcher()),

--- a/comms/src/builder/builder.rs
+++ b/comms/src/builder/builder.rs
@@ -271,7 +271,7 @@ where
         .map_err(CommsBuilderError::OutboundMessagePoolError)
     }
 
-    pub fn make_inbound_message_service(
+    pub fn make_ims(
         &mut self,
         node_identity: Arc<NodeIdentity<CommsPublicKey>>,
         message_sink_address: InprocAddress,
@@ -319,7 +319,7 @@ where
 
         let dispatcher = self.dispatcher_factory.make();
 
-        let ims = self.make_inbound_message_service(
+        let ims = self.make_ims(
             node_identity,
             peer_conn_config.message_sink_address,
             dispatcher,

--- a/comms/src/builder/builder.rs
+++ b/comms/src/builder/builder.rs
@@ -1,0 +1,491 @@
+//  Copyright 2019 The Tari Project
+//
+//  Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+//  following conditions are met:
+//
+//  1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+//  disclaimer.
+//
+//  2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+//  following disclaimer in the documentation and/or other materials provided with the distribution.
+//
+//  3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+//  products derived from this software without specific prior written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+//  INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+//  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+//  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+//  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+//  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+//  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+use super::types::Factory;
+use crate::{
+    connection::{ConnectionError, DealerProxyError, InprocAddress, ZmqContext},
+    connection_manager::{ConnectionManager, PeerConnectionConfig},
+    control_service::{ControlService, ControlServiceConfig, ControlServiceError, ControlServiceHandle},
+    dispatcher::{DispatchableKey, DomainMessageDispatcher},
+    inbound_message_service::{
+        comms_msg_handlers::construct_comms_msg_dispatcher,
+        error::InboundMessageServiceError,
+        inbound_message_service::InboundMessageService,
+    },
+    outbound_message_service::{
+        outbound_message_pool::OutboundMessagePoolConfig,
+        outbound_message_service::OutboundMessageService,
+        OutboundError,
+        OutboundMessagePool,
+    },
+    peer_manager::{NodeIdentity, PeerManager, PeerManagerError},
+    types::{CommsDataStore, CommsPublicKey},
+};
+use derive_error::Error;
+use log::*;
+use serde::{de::DeserializeOwned, Serialize};
+use std::{sync::Arc, thread::JoinHandle};
+
+const LOG_TARGET: &'static str = "comms::builder";
+
+#[derive(Debug, Error)]
+pub enum CommsBuilderError {
+    PeerManagerError(PeerManagerError),
+    InboundMessageServiceError(ConnectionError),
+    #[error(no_from)]
+    OutboundMessageServiceError(OutboundError),
+    #[error(no_from)]
+    OutboundMessagePoolError(OutboundError),
+    /// Node identity not set. Call `with_node_identity(node_identity)` on [CommsBuilder]
+    NodeIdentityNotSet,
+    #[error(no_from)]
+    DealerProxyError(DealerProxyError),
+    /// The dispatcher has not been defined. Call `with_dispatcher` on [CommsBuilder]
+    DispatcherNotDefined,
+}
+
+trait CommsBuilable {
+    type PublicKey;
+    type DispatcherFactory;
+}
+
+/// ## CommsBuilder
+///
+/// This builder give the Comms crate user everything they need to
+/// get a p2p messaging layer up and running.
+///
+/// ```edition2018
+/// use tari_comms::builder::CommsBuilder;
+/// use tari_comms::dispatcher::{DomainMessageDispatcher, HandlerError};
+/// use tari_comms::message::DomainMessageContext;
+/// use tari_comms::control_service::ControlServiceConfig;
+/// use tari_comms::peer_manager::NodeIdentity;
+/// use std::sync::Arc;
+/// use rand::OsRng;
+///
+/// // This should be loaded up from storage
+/// let my_node_identity = NodeIdentity::random(&mut OsRng::new().unwrap(), "127.0.0.1:9000".parse().unwrap()).unwrap();
+///
+/// fn my_handler(_: DomainMessageContext) -> Result<(), HandlerError> {
+///     println!("Your handler is called!");
+///     Ok(())
+/// }
+///
+/// let services = CommsBuilder::new(|| DomainMessageDispatcher::default()
+/// .route("my message type".to_string(), my_handler))
+/// // This enables the control service - allowing another peer to connect to this node
+/// .configure_control_service(|| ControlServiceConfig::default())
+/// .with_node_identity(my_node_identity)
+/// .build()
+/// .unwrap();
+///
+/// let handle = services.start().unwrap();
+/// // Call shutdown when program shuts down
+/// handle.shutdown();
+/// ```
+pub struct CommsBuilder<MType>
+where
+    MType: Serialize + DeserializeOwned,
+    MType: Clone,
+{
+    comms_context: ZmqContext,
+    // Factories
+    control_service_config_factory: Option<Box<Factory<ControlServiceConfig<MType>>>>,
+    dispatcher_factory: Box<Factory<DomainMessageDispatcher<MType>>>,
+    peer_storage_factory: Option<Box<Factory<CommsDataStore>>>,
+    peer_conn_config_factory: Option<Box<Factory<PeerConnectionConfig>>>,
+    node_identity: Option<NodeIdentity<CommsPublicKey>>,
+    omp_config_factory: Option<Box<Factory<OutboundMessagePoolConfig>>>,
+}
+
+impl<MType> CommsBuilder<MType>
+where
+    MType: DispatchableKey,
+    MType: Serialize + DeserializeOwned,
+    MType: Clone,
+{
+    pub fn new<F>(dispatcher_factory: F) -> Self
+    where
+        F: Factory<DomainMessageDispatcher<MType>>,
+        F: 'static,
+    {
+        let comms_context = ZmqContext::new();
+
+        Self {
+            comms_context,
+            control_service_config_factory: None,
+            peer_conn_config_factory: None,
+            omp_config_factory: None,
+            peer_storage_factory: None,
+            dispatcher_factory: Box::new(dispatcher_factory),
+            node_identity: None,
+        }
+    }
+
+    pub fn with_peer_storage<F>(mut self, factory: F) -> Self
+    where
+        F: Factory<CommsDataStore>,
+        F: 'static,
+    {
+        self.peer_storage_factory = Some(Box::new(factory));
+        self
+    }
+
+    pub fn configure_control_service<F>(mut self, factory: F) -> Self
+    where
+        F: Factory<ControlServiceConfig<MType>>,
+        F: 'static,
+    {
+        self.control_service_config_factory = Some(Box::new(factory));
+        self
+    }
+
+    pub fn with_node_identity(mut self, node_identity: NodeIdentity<CommsPublicKey>) -> Self {
+        self.node_identity = Some(node_identity);
+        self
+    }
+
+    pub fn configure_peer_connections<F>(mut self, factory: F) -> Self
+    where
+        F: Factory<PeerConnectionConfig>,
+        F: 'static,
+    {
+        self.peer_conn_config_factory = Some(Box::new(factory));
+        self
+    }
+
+    pub fn configure_outbound_message_pool<F>(mut self, factory: F) -> Self
+    where
+        F: Factory<OutboundMessagePoolConfig>,
+        F: 'static,
+    {
+        self.omp_config_factory = Some(Box::new(factory));
+        self
+    }
+
+    fn make_peer_manager(&mut self) -> Result<Arc<PeerManager<CommsPublicKey, CommsDataStore>>, CommsBuilderError> {
+        let storage = self.peer_storage_factory.take().map(|f| f.make());
+        let peer_manager = PeerManager::new(storage).map_err(CommsBuilderError::PeerManagerError)?;
+        Ok(Arc::new(peer_manager))
+    }
+
+    fn make_control_service(
+        &mut self,
+        node_identity: Arc<NodeIdentity<CommsPublicKey>>,
+    ) -> Option<ControlService<MType>>
+    {
+        self.control_service_config_factory
+            .take()
+            .map(|f| f.make())
+            .map(|config| ControlService::new(self.comms_context.clone(), node_identity, config))
+    }
+
+    fn make_connection_manager(
+        &mut self,
+        node_identity: Arc<NodeIdentity<CommsPublicKey>>,
+        peer_manager: Arc<PeerManager<CommsPublicKey, CommsDataStore>>,
+        config: PeerConnectionConfig,
+    ) -> Arc<ConnectionManager>
+    {
+        Arc::new(ConnectionManager::new(
+            self.comms_context.clone(),
+            node_identity,
+            peer_manager,
+            config,
+        ))
+    }
+
+    fn make_peer_connection_config(&mut self) -> PeerConnectionConfig {
+        let mut config = self
+            .peer_conn_config_factory
+            .take()
+            .map(|f| f.make())
+            .unwrap_or_default();
+        // If the message_sink_address is not set (is default) set it to a random inproc address
+        if config.message_sink_address.is_default() {
+            config.message_sink_address = InprocAddress::random();
+        }
+        config
+    }
+
+    fn make_node_identity(&mut self) -> Result<Arc<NodeIdentity<CommsPublicKey>>, CommsBuilderError> {
+        self.node_identity
+            .take()
+            .map(Arc::new)
+            .ok_or(CommsBuilderError::NodeIdentityNotSet)
+    }
+
+    fn make_oms(
+        &self,
+        node_identity: Arc<NodeIdentity<CommsPublicKey>>,
+        message_sink_address: InprocAddress,
+        peer_manager: Arc<PeerManager<CommsPublicKey, CommsDataStore>>,
+    ) -> Result<OutboundMessageService, CommsBuilderError>
+    {
+        OutboundMessageService::new(
+            self.comms_context.clone(),
+            node_identity,
+            message_sink_address,
+            peer_manager,
+        )
+        .map_err(CommsBuilderError::OutboundMessageServiceError)
+    }
+
+    fn make_omp(
+        &mut self,
+        message_sink_address: InprocAddress,
+        peer_manager: Arc<PeerManager<CommsPublicKey, CommsDataStore>>,
+        connection_manager: Arc<ConnectionManager>,
+    ) -> Result<OutboundMessagePool, CommsBuilderError>
+    {
+        let config = self.omp_config_factory.take().map(|f| f.make()).unwrap_or_default();
+
+        OutboundMessagePool::new(
+            config,
+            self.comms_context.clone(),
+            // OMP can requeue back onto itself
+            message_sink_address.clone(),
+            message_sink_address.clone(),
+            peer_manager,
+            connection_manager,
+        )
+        .map_err(CommsBuilderError::OutboundMessagePoolError)
+    }
+
+    pub fn make_inbound_message_service(
+        &mut self,
+        node_identity: Arc<NodeIdentity<CommsPublicKey>>,
+        message_sink_address: InprocAddress,
+        dispatcher: DomainMessageDispatcher<MType>,
+        oms: OutboundMessageService,
+        peer_manager: Arc<PeerManager<CommsPublicKey, CommsDataStore>>,
+    ) -> Result<InboundMessageService<MType>, CommsBuilderError>
+    {
+        InboundMessageService::new(
+            self.comms_context.clone(),
+            node_identity,
+            message_sink_address,
+            Arc::new(construct_comms_msg_dispatcher()),
+            Arc::new(dispatcher),
+            Arc::new(oms),
+            peer_manager,
+        )
+        .map_err(CommsBuilderError::InboundMessageServiceError)
+    }
+
+    pub fn build(mut self) -> Result<CommsServices<MType>, CommsBuilderError> {
+        let node_identity = self.make_node_identity()?;
+
+        let peer_manager = self.make_peer_manager()?;
+
+        let peer_conn_config = self.make_peer_connection_config();
+
+        let control_service = self.make_control_service(node_identity.clone());
+
+        let connection_manager =
+            self.make_connection_manager(node_identity.clone(), peer_manager.clone(), peer_conn_config.clone());
+
+        let outbound_message_sink_address = InprocAddress::random();
+        let oms = self.make_oms(
+            node_identity.clone(),
+            outbound_message_sink_address.clone(),
+            peer_manager.clone(),
+        )?;
+
+        let omp = self.make_omp(
+            outbound_message_sink_address,
+            peer_manager.clone(),
+            connection_manager.clone(),
+        )?;
+
+        let dispatcher = self.dispatcher_factory.make();
+
+        let ims = self.make_inbound_message_service(
+            node_identity,
+            peer_conn_config.message_sink_address,
+            dispatcher,
+            oms,
+            peer_manager.clone(),
+        )?;
+
+        Ok(CommsServices {
+            control_service,
+            ims,
+            connection_manager,
+            omp,
+        })
+    }
+}
+
+#[derive(Debug, Error)]
+pub enum CommsServicesError {
+    ControlServiceError(ControlServiceError),
+    ConnectionManagerError(ConnectionError),
+    /// Comms services shut down uncleanly
+    UncleanShutdown,
+}
+
+pub struct CommsServices<MType>
+where
+    MType: Serialize + DeserializeOwned,
+    MType: DispatchableKey,
+    MType: Clone,
+{
+    connection_manager: Arc<ConnectionManager>,
+    control_service: Option<ControlService<MType>>,
+    ims: InboundMessageService<MType>,
+    omp: OutboundMessagePool,
+}
+
+impl<MType> CommsServices<MType>
+where
+    MType: Serialize + DeserializeOwned,
+    MType: DispatchableKey,
+    MType: Clone,
+{
+    pub fn start(self) -> Result<CommsServicesHandle, CommsServicesError> {
+        let mut control_service_handle = None;
+        if let Some(control_service) = self.control_service {
+            control_service_handle = Some(
+                control_service
+                    .serve(self.connection_manager.clone())
+                    .map_err(CommsServicesError::ControlServiceError)?,
+            );
+        }
+
+        let ims_handle = self.ims.start();
+        self.omp.start();
+
+        Ok(CommsServicesHandle {
+            connection_manager: self.connection_manager.clone(),
+            control_service_handle,
+            ims_handle,
+        })
+    }
+}
+
+pub struct CommsServicesHandle {
+    control_service_handle: Option<ControlServiceHandle>,
+    #[allow(dead_code)]
+    ims_handle: JoinHandle<Result<(), InboundMessageServiceError>>,
+    connection_manager: Arc<ConnectionManager>,
+}
+
+impl CommsServicesHandle {
+    pub fn shutdown(self) -> Result<(), CommsServicesError> {
+        info!(target: LOG_TARGET, "Comms is shutting down");
+        let mut shutdown_results = Vec::new();
+        // Shutdown control service
+        if let Some(control_service_shutdown_result) = self.control_service_handle.map(|hnd| hnd.shutdown()) {
+            shutdown_results.push(control_service_shutdown_result.map_err(CommsServicesError::ControlServiceError));
+        }
+
+        // TODO: Shutdown other services
+
+        // Lastly, Shutdown connection manager
+        match Arc::try_unwrap(self.connection_manager) {
+            Ok(conn_manager) => {
+                for result in conn_manager.shutdown() {
+                    shutdown_results.push(result.map_err(CommsServicesError::ConnectionManagerError));
+                }
+            },
+            Err(_) => error!(
+                target: LOG_TARGET,
+                "Unable to cleanly shutdown connection manager because references are still held by other threads"
+            ),
+        }
+
+        Self::check_clean_shutdown(shutdown_results)
+    }
+
+    fn check_clean_shutdown(results: Vec<Result<(), CommsServicesError>>) -> Result<(), CommsServicesError> {
+        let mut has_error = false;
+        for result in results {
+            if let Err(err) = result {
+                error!(target: LOG_TARGET, "Error occurred when shutting down {:?}", err);
+                has_error = true;
+            }
+        }
+
+        if has_error {
+            Err(CommsServicesError::UncleanShutdown)
+        } else {
+            Ok(())
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    mod handlers {
+        use super::*;
+        use crate::{dispatcher::HandlerError, message::DomainMessageContext};
+        use serde::Deserialize;
+
+        #[derive(Serialize, Deserialize)]
+        pub struct TestMessage {
+            name: String,
+            age: u8,
+        }
+
+        pub fn hello(context: DomainMessageContext) -> Result<(), HandlerError> {
+            let msg: TestMessage = context.message.to_message().map_err(HandlerError::failed())?;
+            debug!("Hello: {:?}, you are {} years old", msg.name, msg.age);
+            Ok(())
+        }
+
+        pub fn catch_all(msg: DomainMessageContext) -> Result<(), HandlerError> {
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn new_no_control_service() {
+        let comms_services = CommsBuilder::new(|| {
+            DomainMessageDispatcher::default()
+                .route("hello".to_owned(), handlers::hello)
+                .catch_all(handlers::catch_all)
+        })
+        .with_node_identity(NodeIdentity::random_for_test(None))
+        .build()
+        .unwrap();
+
+        assert!(comms_services.control_service.is_none());
+    }
+
+    #[test]
+    fn new_with_control_service() {
+        let comms_services = CommsBuilder::new(|| {
+            DomainMessageDispatcher::default()
+                .route("hello".to_owned(), handlers::hello)
+                .catch_all(handlers::catch_all)
+        })
+        .with_node_identity(NodeIdentity::random_for_test(None))
+        .configure_control_service(|| ControlServiceConfig::default())
+        .build()
+        .unwrap();
+
+        assert!(comms_services.control_service.is_some());
+    }
+}

--- a/comms/src/builder/mod.rs
+++ b/comms/src/builder/mod.rs
@@ -20,38 +20,8 @@
 //  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 //  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use rand::OsRng;
-use std::sync::{Arc, Mutex};
-use tari_comms::{
-    connection::NetAddress,
-    peer_manager::{CommsNodeIdentity, NodeId, PeerNodeIdentity},
-};
-use tari_crypto::{
-    keys::{PublicKey, SecretKey},
-    ristretto::{RistrettoPublicKey, RistrettoSecretKey},
-};
+mod builder;
+mod types;
 
-lazy_static! {
-    static ref IDENTITY_RACE_CONDITION_LOCK: Mutex<()> = Mutex::new(());
-}
-
-/// Sets the global node identity using random values
-pub fn set_test_node_identity() -> Arc<CommsNodeIdentity> {
-    let _lock = IDENTITY_RACE_CONDITION_LOCK.lock().unwrap();
-    match CommsNodeIdentity::global() {
-        Some(identity) => identity,
-        None => {
-            // Generate a test identity, set it and return it
-            let secret_key = RistrettoSecretKey::random(&mut OsRng::new().unwrap());
-            let public_key = RistrettoPublicKey::from_secret_key(&secret_key);
-            let node_id = NodeId::from_key(&public_key).unwrap();
-            let node_identity = CommsNodeIdentity {
-                identity: PeerNodeIdentity::new(node_id, public_key),
-                secret_key,
-                control_service_address: "127.0.0.1:9090".parse::<NetAddress>().unwrap(),
-            };
-
-            CommsNodeIdentity::set_global(node_identity)
-        },
-    }
-}
+pub use builder::{CommsBuilder, CommsBuilderError};
+pub use types::Factory;

--- a/comms/src/builder/types.rs
+++ b/comms/src/builder/types.rs
@@ -20,17 +20,14 @@
 //  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 //  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-pub mod curve_keypair;
+pub trait Factory<T> {
+    fn make(&self) -> T;
+}
 
-mod context;
-mod endpoint;
-mod error;
-mod inproc_address;
-
-pub use self::{
-    context::ZmqContext,
-    curve_keypair::{CurveEncryption, CurvePublicKey, CurveSecretKey},
-    endpoint::ZmqEndpoint,
-    error::ZmqError,
-    inproc_address::InprocAddress,
-};
+impl<F, T> Factory<T> for F
+where F: Fn() -> T
+{
+    fn make(&self) -> T {
+        (self)()
+    }
+}

--- a/comms/src/connection/connection.rs
+++ b/comms/src/connection/connection.rs
@@ -26,7 +26,7 @@ use crate::{
     connection::{
         net_address::ip::SocketAddress,
         types::{Direction, Linger, Result, SocketEstablishment, SocketType},
-        zmq::{Context, CurveEncryption, InprocAddress, ZmqEndpoint},
+        zmq::{CurveEncryption, InprocAddress, ZmqContext, ZmqEndpoint},
         ConnectionError,
     },
     message::FrameSet,
@@ -41,12 +41,12 @@ const LOG_TARGET: &'static str = "comms::connection::Connection";
 ///
 /// ```edition2018
 /// # use tari_comms::connection::{
-/// #   zmq::{Context, InprocAddress, CurveEncryption},
+/// #   zmq::{ZmqContext, InprocAddress, CurveEncryption},
 /// #   connection::Connection,
 /// #   types::{Linger, Direction},
 /// # };
 ///
-///  let ctx  = Context::new();
+///  let ctx  = ZmqContext::new();
 ///
 ///  let (secret_key, _public_key) =CurveEncryption::generate_keypair().unwrap();
 ///
@@ -67,7 +67,7 @@ const LOG_TARGET: &'static str = "comms::connection::Connection";
 /// ```
 /// [`ZeroMQ`]: http://zeromq.org/
 pub struct Connection<'a> {
-    pub(super) context: &'a Context,
+    pub(super) context: &'a ZmqContext,
     pub(super) curve_encryption: CurveEncryption,
     pub(super) direction: Direction,
     pub(super) identity: Option<String>,
@@ -82,7 +82,7 @@ pub struct Connection<'a> {
 
 impl<'a> Connection<'a> {
     /// Create a new InboundConnection
-    pub fn new(context: &'a Context, direction: Direction) -> Self {
+    pub fn new(context: &'a ZmqContext, direction: Direction) -> Self {
         Self {
             context,
             curve_encryption: Default::default(),
@@ -405,7 +405,7 @@ mod test {
 
     #[test]
     fn sets_socketopts() {
-        let ctx = Context::new();
+        let ctx = ZmqContext::new();
 
         let addr = InprocAddress::random();
         let monitor_addr = InprocAddress::random();
@@ -433,7 +433,7 @@ mod test {
 
     #[test]
     fn set_server_encryption() {
-        let ctx = Context::new();
+        let ctx = ZmqContext::new();
 
         let addr = InprocAddress::random();
 
@@ -452,7 +452,7 @@ mod test {
 
     #[test]
     fn set_client_encryption() {
-        let ctx = Context::new();
+        let ctx = ZmqContext::new();
 
         let addr = InprocAddress::random();
 

--- a/comms/src/connection/dealer_proxy.rs
+++ b/comms/src/connection/dealer_proxy.rs
@@ -28,8 +28,8 @@ use crate::connection::{
     types::{Direction, SocketEstablishment},
     Connection,
     ConnectionError,
-    Context,
     InprocAddress,
+    ZmqContext,
 };
 
 #[derive(Debug, Error)]
@@ -60,12 +60,12 @@ impl DealerProxy {
 
     /// Proxy the source and sink addresses. This method does not block and returns
     /// a [thread::JoinHandle] of the proxy thread.
-    pub fn spawn_proxy(self, context: Context) -> thread::JoinHandle<Result<()>> {
+    pub fn spawn_proxy(self, context: ZmqContext) -> thread::JoinHandle<Result<()>> {
         thread::spawn(move || self.proxy(&context))
     }
 
     /// Proxy the source and sink addresses. This method will block the current thread.
-    pub fn proxy(&self, context: &Context) -> Result<()> {
+    pub fn proxy(&self, context: &ZmqContext) -> Result<()> {
         let source = Connection::new(context, Direction::Inbound)
             .set_socket_establishment(SocketEstablishment::Bind)
             .establish(&self.source_address)
@@ -86,7 +86,7 @@ mod test {
 
     #[test]
     fn threaded_proxy() {
-        let context = Context::new();
+        let context = ZmqContext::new();
         let sender_addr = InprocAddress::random();
         let receiver_addr = InprocAddress::random();
         let sender = Connection::new(&context, Direction::Outbound)

--- a/comms/src/connection/mod.rs
+++ b/comms/src/connection/mod.rs
@@ -44,5 +44,5 @@ pub use self::{
         PeerConnectionSimpleState as PeerConnectionState,
     },
     types::{Direction, SocketEstablishment},
-    zmq::{curve_keypair, Context, CurveEncryption, CurvePublicKey, CurveSecretKey, InprocAddress},
+    zmq::{curve_keypair, CurveEncryption, CurvePublicKey, CurveSecretKey, InprocAddress, ZmqContext},
 };

--- a/comms/src/connection/monitor.rs
+++ b/comms/src/connection/monitor.rs
@@ -25,8 +25,8 @@ use crate::{
         types::{Result, SocketType},
         zmq::ZmqEndpoint,
         ConnectionError,
-        Context,
         InprocAddress,
+        ZmqContext,
     },
     message::FrameSet,
 };
@@ -54,9 +54,9 @@ pub enum ConnectionMonitorError {
 /// More details here: http://api.zeromq.org/4-1:zmq-socket-monitor
 ///
 /// ```edition2018
-/// # use tari_comms::connection::{Context, monitor::ConnectionMonitor, Connection, Direction, InprocAddress, NetAddress};
+/// # use tari_comms::connection::{ZmqContext, monitor::ConnectionMonitor, Connection, Direction, InprocAddress, NetAddress};
 ///
-/// let ctx = Context::new();
+/// let ctx = ZmqContext::new();
 /// let monitor_addr = InprocAddress::random();
 /// let address = "127.0.0.1:9999".parse::<NetAddress>().unwrap();
 ///
@@ -85,7 +85,7 @@ impl ConnectionMonitor {
     /// ## Arguments
     /// `context` - Connection context. Must be the same context as the connection being monitored
     /// `address` - The inproc address from which to read socket events
-    pub fn connect(context: &Context, address: &InprocAddress) -> Result<Self> {
+    pub fn connect(context: &ZmqContext, address: &InprocAddress) -> Result<Self> {
         let socket = context.socket(SocketType::Pair).map_err(|e| {
             ConnectionError::MonitorError(ConnectionMonitorError::CreateSocketFailed(format!(
                 "Failed to create monitor pair socket: {}",

--- a/comms/src/connection/peer_connection/connection.rs
+++ b/comms/src/connection/peer_connection/connection.rs
@@ -160,7 +160,7 @@ macro_rules! is_state {
 /// # use tari_comms::connection::*;
 /// # use std::time::Duration;
 ///
-/// let ctx = Context::new();
+/// let ctx = ZmqContext::new();
 /// let addr: NetAddress = "127.0.0.1:8080".parse().unwrap();
 ///
 /// let peer_context = PeerConnectionContextBuilder::new()

--- a/comms/src/connection/peer_connection/context.rs
+++ b/comms/src/connection/peer_connection/context.rs
@@ -27,7 +27,7 @@ use super::{ConnectionId, PeerConnectionError};
 use crate::connection::{
     net_address::ip::SocketAddress,
     types::{Direction, Linger, Result},
-    zmq::{Context, CurveEncryption, InprocAddress},
+    zmq::{CurveEncryption, InprocAddress, ZmqContext},
     ConnectionError,
     NetAddress,
 };
@@ -51,7 +51,7 @@ const DEFAULT_MAX_RETRY_ATTEMPTS: u16 = 10;
 ///
 /// [CurveEncryption]: ./../zmq/CurveEncryption/struct.CurveEncryption.html
 pub struct PeerConnectionContext {
-    pub(crate) context: Context,
+    pub(crate) context: ZmqContext,
     pub(crate) peer_address: NetAddress,
     pub(crate) message_sink_address: InprocAddress,
     pub(crate) direction: Direction,
@@ -114,14 +114,14 @@ fn unwrap_prop<T>(prop: Option<T>, prop_name: &str) -> Result<T> {
 ///
 /// ```edition2018
 /// # use tari_comms::connection::{
-/// #     Context,
+/// #     ZmqContext,
 /// #     InprocAddress,
 /// #     Direction,
 /// #     PeerConnectionContextBuilder,
 /// #     PeerConnection,
 /// # };
 ///
-/// let ctx = Context::new();
+/// let ctx = ZmqContext::new();
 ///
 /// let peer_context = PeerConnectionContextBuilder::new()
 ///    .set_id("123")
@@ -138,7 +138,7 @@ fn unwrap_prop<T>(prop: Option<T>, prop_name: &str) -> Result<T> {
 pub struct PeerConnectionContextBuilder<'c> {
     pub(super) address: Option<NetAddress>,
     pub(super) message_sink_address: Option<InprocAddress>,
-    pub(super) context: Option<&'c Context>,
+    pub(super) context: Option<&'c ZmqContext>,
     pub(super) curve_encryption: CurveEncryption,
     pub(super) direction: Option<Direction>,
     pub(super) id: Option<ConnectionId>,
@@ -150,28 +150,28 @@ pub struct PeerConnectionContextBuilder<'c> {
 
 impl<'c> PeerConnectionContextBuilder<'c> {
     /// Set the peer address
-    setter!(set_address, address, NetAddress);
+    setter!(set_address, address, Option<NetAddress>);
 
     /// Set the address where incoming peer messages are forwarded
-    setter!(set_message_sink_address, message_sink_address, InprocAddress);
+    setter!(set_message_sink_address, message_sink_address, Option<InprocAddress>);
 
     /// Set the zmq context
-    setter!(set_context, context, &'c Context);
+    setter!(set_context, context, Option<&'c ZmqContext>);
 
     /// Set the connection direction
-    setter!(set_direction, direction, Direction);
+    setter!(set_direction, direction, Option<Direction>);
 
     /// Set the maximum connection retry attempts
-    setter!(set_max_retry_attempts, max_retry_attempts, u16);
+    setter!(set_max_retry_attempts, max_retry_attempts, Option<u16>);
 
     /// Set the maximum message size in bytes
-    setter!(set_max_msg_size, max_msg_size, u64);
+    setter!(set_max_msg_size, max_msg_size, Option<u64>);
 
     /// Set the socks proxy address
-    setter!(set_socks_proxy, socks_address, SocketAddress);
+    setter!(set_socks_proxy, socks_address, Option<SocketAddress>);
 
     /// Set the [Linger] for this connection
-    setter!(set_linger, linger, Linger);
+    setter!(set_linger, linger, Option<Linger>);
 
     /// Return a new PeerConnectionContextBuilder
     pub fn new() -> Self {
@@ -237,7 +237,7 @@ mod test {
     use crate::connection::{
         peer_connection::PeerConnectionError,
         types::{Direction, Result},
-        zmq::{Context, CurveEncryption, InprocAddress},
+        zmq::{CurveEncryption, InprocAddress, ZmqContext},
         ConnectionError,
         NetAddress,
     };
@@ -260,7 +260,7 @@ mod test {
 
     #[test]
     fn valid_build() {
-        let ctx = Context::new();
+        let ctx = ZmqContext::new();
 
         let recv_addr = InprocAddress::random();
         let peer_addr = "127.0.0.1:80".parse::<NetAddress>().unwrap();
@@ -287,7 +287,7 @@ mod test {
     #[test]
     fn invalid_build() {
         let (sk, pk) = CurveEncryption::generate_keypair().unwrap();
-        let ctx = Context::new();
+        let ctx = ZmqContext::new();
 
         let result = PeerConnectionContextBuilder::new()
             .set_id("123")

--- a/comms/src/connection/zmq/context.rs
+++ b/comms/src/connection/zmq/context.rs
@@ -25,9 +25,9 @@ use zmq;
 use crate::connection::{types::SocketType, zmq::ZmqError};
 
 #[derive(Clone)]
-pub struct Context(zmq::Context);
+pub struct ZmqContext(zmq::Context);
 
-impl Context {
+impl ZmqContext {
     pub fn new() -> Self {
         Self(zmq::Context::new())
     }

--- a/comms/src/connection/zmq/inproc_address.rs
+++ b/comms/src/connection/zmq/inproc_address.rs
@@ -24,6 +24,8 @@ use crate::connection::zmq::{ZmqEndpoint, ZmqError};
 use rand::{distributions::Alphanumeric, EntropyRng, Rng};
 use std::{iter, str::FromStr};
 
+const DEFAULT_INPROC: &'static str = "inproc://default";
+
 /// Represents a zMQ inproc address
 #[derive(Eq, PartialEq, Debug, Clone)]
 pub struct InprocAddress(String);
@@ -34,6 +36,16 @@ impl InprocAddress {
         let mut rng = EntropyRng::new();
         let rand_str: String = iter::repeat(()).map(|_| rng.sample(Alphanumeric)).take(8).collect();
         Self(format!("inproc://{}", rand_str))
+    }
+
+    pub fn is_default(&self) -> bool {
+        self.0 == DEFAULT_INPROC
+    }
+}
+
+impl Default for InprocAddress {
+    fn default() -> Self {
+        Self(DEFAULT_INPROC.to_owned())
     }
 }
 

--- a/comms/src/connection_manager/manager.rs
+++ b/comms/src/connection_manager/manager.rs
@@ -20,19 +20,6 @@
 //  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 //  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use std::{
-    collections::HashMap,
-    sync::{Arc, Mutex},
-};
-
-use log::*;
-
-use crate::{
-    connection::{ConnectionError, CurvePublicKey, NetAddress, PeerConnection, PeerConnectionState},
-    peer_manager::{NodeId, Peer, PeerManager},
-    types::{CommsDataStore, CommsPublicKey},
-};
-
 use super::{
     connections::LivePeerConnections,
     establisher::ConnectionEstablisher,
@@ -40,6 +27,16 @@ use super::{
     ConnectionManagerError,
     PeerConnectionConfig,
     Result,
+};
+use crate::{
+    connection::{ConnectionError, CurvePublicKey, NetAddress, PeerConnection, PeerConnectionState, ZmqContext},
+    peer_manager::{NodeId, NodeIdentity, Peer, PeerManager},
+    types::{CommsDataStore, CommsPublicKey},
+};
+use log::*;
+use std::{
+    collections::HashMap,
+    sync::{Arc, Mutex},
 };
 
 const LOG_TARGET: &'static str = "comms::connection_manager::manager";
@@ -54,14 +51,16 @@ const LOG_TARGET: &'static str = "comms::connection_manager::manager";
 /// # use std::time::Duration;
 /// # use std::sync::Arc;
 /// # use tari_comms::connection_manager::{ConnectionManager, PeerConnectionConfig};
-/// # use tari_comms::peer_manager::PeerManager;
-/// # use tari_comms::connection::{Context, InprocAddress};
+/// # use tari_comms::peer_manager::{PeerManager, NodeIdentity};
+/// # use tari_comms::connection::{ZmqContext, InprocAddress};
+/// # use rand::OsRng;
 ///
-/// let context = Context::new();
+/// let node_identity = Arc::new(NodeIdentity::random(&mut OsRng::new().unwrap(), "127.0.0.1:9000".parse().unwrap()).unwrap());
+///
+/// let context = ZmqContext::new();
 /// let peer_manager = Arc::new(PeerManager::new(None).unwrap());
 ///
-/// let manager = ConnectionManager::new(peer_manager, PeerConnectionConfig {
-///     context: context.clone(),
+/// let manager = ConnectionManager::new(context, node_identity, peer_manager, PeerConnectionConfig {
 ///     control_service_establish_timeout: Duration::from_millis(2000),
 ///     peer_connection_establish_timeout: Duration::from_secs(5),
 ///     max_message_size: 1024,
@@ -75,18 +74,26 @@ const LOG_TARGET: &'static str = "comms::connection_manager::manager";
 /// assert_eq!(manager.get_active_connection_count(), 0);
 /// ```
 pub struct ConnectionManager {
+    node_identity: Arc<NodeIdentity<CommsPublicKey>>,
     connections: LivePeerConnections,
-    establisher: Arc<ConnectionEstablisher>,
+    establisher: Arc<ConnectionEstablisher<CommsPublicKey>>,
     peer_manager: Arc<PeerManager<CommsPublicKey, CommsDataStore>>,
     establish_locks: Mutex<HashMap<NodeId, Arc<Mutex<()>>>>,
 }
 
 impl ConnectionManager {
     /// Create a new connection manager
-    pub fn new(peer_manager: Arc<PeerManager<CommsPublicKey, CommsDataStore>>, config: PeerConnectionConfig) -> Self {
+    pub fn new(
+        comms_context: ZmqContext,
+        node_identity: Arc<NodeIdentity<CommsPublicKey>>,
+        peer_manager: Arc<PeerManager<CommsPublicKey, CommsDataStore>>,
+        config: PeerConnectionConfig,
+    ) -> Self
+    {
         Self {
+            node_identity,
             connections: LivePeerConnections::new(),
-            establisher: Arc::new(ConnectionEstablisher::new(config, peer_manager.clone())),
+            establisher: Arc::new(ConnectionEstablisher::new(comms_context, config, peer_manager.clone())),
             peer_manager,
             establish_locks: Mutex::new(HashMap::new()),
         }
@@ -234,8 +241,18 @@ impl ConnectionManager {
         Ok(peer_conn.clone())
     }
 
+    /// Get the peer manager
+    pub(crate) fn get_peer_manager(&self) -> Arc<PeerManager<CommsPublicKey, CommsDataStore>> {
+        self.peer_manager.clone()
+    }
+
+    /// Return the number of _active_ peer connections currently managed by this instance
+    pub fn get_active_connection_count(&self) -> usize {
+        self.connections.get_active_connection_count()
+    }
+
     fn initiate_peer_connection(&self, peer: &Peer<CommsPublicKey>) -> Result<Arc<PeerConnection>> {
-        let protocol = PeerConnectionProtocol::new(&self.establisher)?;
+        let protocol = PeerConnectionProtocol::new(&self.node_identity, &self.establisher);
 
         protocol
             .negotiate_peer_connection(peer)
@@ -273,30 +290,20 @@ impl ConnectionManager {
                 Err(err)
             })
     }
-
-    /// Get the peer manager
-    pub(crate) fn get_peer_manager(&self) -> Arc<PeerManager<CommsPublicKey, CommsDataStore>> {
-        self.peer_manager.clone()
-    }
-
-    /// Return the number of _active_ peer connections currently managed by this instance
-    pub fn get_active_connection_count(&self) -> usize {
-        self.connections.get_active_connection_count()
-    }
 }
 
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::connection::{Context, InprocAddress};
+    use crate::connection::{InprocAddress, ZmqContext};
     use std::time::Duration;
 
     #[test]
     fn get_active_connection_count() {
-        let context = Context::new();
+        let context = ZmqContext::new();
+        let node_identity = Arc::new(NodeIdentity::random_for_test(None));
         let peer_manager = Arc::new(PeerManager::new(None).unwrap());
-        let manager = ConnectionManager::new(peer_manager, PeerConnectionConfig {
-            context: context.clone(),
+        let manager = ConnectionManager::new(context, node_identity, peer_manager, PeerConnectionConfig {
             control_service_establish_timeout: Duration::from_millis(2000),
             peer_connection_establish_timeout: Duration::from_secs(5),
             max_message_size: 1024,

--- a/comms/src/connection_manager/manager.rs
+++ b/comms/src/connection_manager/manager.rs
@@ -84,7 +84,7 @@ pub struct ConnectionManager {
 impl ConnectionManager {
     /// Create a new connection manager
     pub fn new(
-        comms_context: ZmqContext,
+        zmq_context: ZmqContext,
         node_identity: Arc<NodeIdentity<CommsPublicKey>>,
         peer_manager: Arc<PeerManager<CommsPublicKey, CommsDataStore>>,
         config: PeerConnectionConfig,
@@ -93,7 +93,7 @@ impl ConnectionManager {
         Self {
             node_identity,
             connections: LivePeerConnections::new(),
-            establisher: Arc::new(ConnectionEstablisher::new(comms_context, config, peer_manager.clone())),
+            establisher: Arc::new(ConnectionEstablisher::new(zmq_context, config, peer_manager.clone())),
             peer_manager,
             establish_locks: Mutex::new(HashMap::new()),
         }

--- a/comms/src/control_service/mod.rs
+++ b/comms/src/control_service/mod.rs
@@ -28,6 +28,6 @@ mod worker;
 
 pub use self::{
     error::ControlServiceError,
-    service::{ControlService, ControlServiceConfig},
+    service::{ControlService, ControlServiceConfig, ControlServiceHandle},
     types::{ControlServiceMessageContext, ControlServiceMessageType},
 };

--- a/comms/src/control_service/service.rs
+++ b/comms/src/control_service/service.rs
@@ -20,39 +20,50 @@
 //  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 //  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use log::*;
-use std::{sync::mpsc::SyncSender, thread};
-
-use crate::{
-    connection::{net_address::ip::SocketAddress, Context, NetAddress},
-    connection_manager::ConnectionManager,
-    dispatcher::{DispatchResolver, DispatchableKey},
-    types::DEFAULT_LISTENER_ADDRESS,
-};
-
 use super::{
     error::ControlServiceError,
-    types::{ControlMessage, ControlServiceDispatcher, ControlServiceMessageContext, Result},
+    types::{ControlMessage, Result},
     worker::ControlServiceWorker,
 };
-use std::sync::Arc;
+use crate::{
+    connection::{net_address::ip::SocketAddress, NetAddress, ZmqContext},
+    connection_manager::ConnectionManager,
+    control_service::types::ControlServiceDispatcher,
+    peer_manager::NodeIdentity,
+    types::{CommsPublicKey, DEFAULT_LISTENER_ADDRESS},
+};
+use log::*;
+use serde::{de::DeserializeOwned, Serialize};
+use std::{
+    sync::{mpsc::SyncSender, Arc},
+    thread,
+};
 
 const LOG_TARGET: &'static str = "comms::control_service::service";
 
 /// Configuration for [ControlService]
-pub struct ControlServiceConfig {
+#[derive(Clone)]
+pub struct ControlServiceConfig<T>
+where T: Clone
+{
     /// Which address to open a port
     pub listener_address: NetAddress,
     /// Optional SOCKS proxy
     pub socks_proxy_address: Option<SocketAddress>,
+    pub accept_message_type: T,
 }
 
-impl Default for ControlServiceConfig {
+impl<T> Default for ControlServiceConfig<T>
+where
+    T: Default,
+    T: Clone,
+{
     fn default() -> Self {
         let listener_address = DEFAULT_LISTENER_ADDRESS.parse::<NetAddress>().unwrap();
         ControlServiceConfig {
             listener_address,
             socks_proxy_address: None,
+            accept_message_type: T::default(),
         }
     }
 }
@@ -67,25 +78,16 @@ impl Default for ControlServiceConfig {
 /// # use std::{time::Duration, sync::Arc};
 /// # use tari_storage::lmdb::LMDBStore;
 /// # use std::collections::HashMap;
-/// # use tari_crypto::{ristretto::{RistrettoSecretKey, RistrettoPublicKey}, keys::{PublicKey, SecretKey}};
+/// # use rand::OsRng;
 ///
-/// # let secret_key = RistrettoSecretKey::random(&mut rand::OsRng::new().unwrap());
-/// # let public_key = RistrettoPublicKey::from_secret_key(&secret_key);
-/// # let node_id = NodeId::from_key(&public_key).unwrap();
-/// # let node_identity = CommsNodeIdentity {
-/// #      identity: PeerNodeIdentity::new(node_id, public_key),
-/// #      secret_key,
-/// #      control_service_address: "127.0.0.1:9090".parse::<NetAddress>().unwrap(),
-/// # };
-/// # CommsNodeIdentity::set_global(node_identity);
+/// let node_identity = Arc::new(NodeIdentity::random(&mut OsRng::new().unwrap(), "127.0.0.1:9000".parse().unwrap()).unwrap());
 ///
-/// let context = Context::new();
+/// let context = ZmqContext::new();
 /// let listener_address = "127.0.0.1:9000".parse::<NetAddress>().unwrap();
 ///
 /// let peer_manager = Arc::new(PeerManager::<CommsPublicKey, LMDBStore>::new(None).unwrap());
 ///
-/// let conn_manager = Arc::new(ConnectionManager::new(peer_manager.clone(), PeerConnectionConfig {
-///      context: context.clone(),
+/// let conn_manager = Arc::new(ConnectionManager::new(context.clone(), node_identity.clone(), peer_manager.clone(), PeerConnectionConfig {
 ///      max_message_size: 1024,
 ///      max_connect_retries: 1,
 ///      socks_proxy_address: None,
@@ -95,47 +97,72 @@ impl Default for ControlServiceConfig {
 ///      peer_connection_establish_timeout: Duration::from_secs(4),
 /// }));
 ///
-/// let dispatcher = Dispatcher::new(comms_handlers::ControlServiceResolver{})
-///     .route(ControlServiceMessageType::EstablishConnection, comms_handlers::establish_connection)
-///     .route(ControlServiceMessageType::Accept, comms_handlers::accept)
-///     .catch_all(comms_handlers::discard);
-///
-/// let service = ControlService::new(&context)
-///     .configure(ControlServiceConfig {
-///         listener_address,
-///         socks_proxy_address: None,
-///     })
-///     .serve(dispatcher, conn_manager)
+/// let service = ControlService::<u8>::with_default_config(
+///       context,
+///       node_identity,
+///     )
+///     .serve(conn_manager)
 ///     .unwrap();
 ///
 /// service.shutdown().unwrap();
 /// ```
-pub struct ControlService<'c> {
-    context: &'c Context,
-    config: ControlServiceConfig,
+pub struct ControlService<MType>
+where MType: Clone
+{
+    context: ZmqContext,
+    dispatcher: ControlServiceDispatcher<MType>,
+    config: ControlServiceConfig<MType>,
+    node_identity: Arc<NodeIdentity<CommsPublicKey>>,
 }
 
-impl<'c> ControlService<'c> {
-    pub fn new(context: &'c Context) -> Self {
+impl<MType> ControlService<MType>
+where
+    MType: Default,
+    MType: Clone,
+    MType: Serialize + DeserializeOwned,
+{
+    pub fn with_default_config(context: ZmqContext, node_identity: Arc<NodeIdentity<CommsPublicKey>>) -> Self {
         Self {
             context,
-            config: ControlServiceConfig::default(),
+            dispatcher: Default::default(),
+            config: Default::default(),
+            node_identity,
+        }
+    }
+}
+
+impl<MType> ControlService<MType>
+where
+    MType: Send + Sync + 'static,
+    MType: Serialize + DeserializeOwned,
+    MType: Clone,
+{
+    setter!(with_custom_dispatcher, dispatcher, ControlServiceDispatcher<MType>);
+
+    pub fn new(
+        context: ZmqContext,
+        node_identity: Arc<NodeIdentity<CommsPublicKey>>,
+        config: ControlServiceConfig<MType>,
+    ) -> Self
+    {
+        Self {
+            context,
+            dispatcher: Default::default(),
+            config,
+            node_identity,
         }
     }
 
-    pub fn configure(mut self, config: ControlServiceConfig) -> Self {
-        self.config = config;
-        self
-    }
-
-    pub fn serve<MType: DispatchableKey, R: DispatchResolver<MType, ControlServiceMessageContext>>(
-        self,
-        dispatcher: ControlServiceDispatcher<MType, R>,
-        connection_manager: Arc<ConnectionManager>,
-    ) -> Result<ControlServiceHandle>
-    {
+    pub fn serve(self, connection_manager: Arc<ConnectionManager>) -> Result<ControlServiceHandle> {
         let config = self.config;
-        Ok(ControlServiceWorker::start(self.context.clone(), config, dispatcher, connection_manager)?.into())
+        Ok(ControlServiceWorker::start(
+            self.context.clone(),
+            self.node_identity,
+            self.dispatcher,
+            config,
+            connection_manager,
+        )?
+        .into())
     }
 }
 
@@ -169,12 +196,14 @@ mod test {
 
     #[test]
     fn control_service_has_default() {
-        let context = Context::new();
-        let control_service = ControlService::new(&context);
+        let context = ZmqContext::new();
+        let node_identity = Arc::new(NodeIdentity::random_for_test(None));
+        let control_service = ControlService::<u8>::with_default_config(context, node_identity);
         assert_eq!(
             control_service.config.listener_address,
             DEFAULT_LISTENER_ADDRESS.parse::<NetAddress>().unwrap()
         );
         assert!(control_service.config.socks_proxy_address.is_none());
+        assert_eq!(control_service.config.accept_message_type, 0);
     }
 }

--- a/comms/src/control_service/worker.rs
+++ b/comms/src/control_service/worker.rs
@@ -20,29 +20,27 @@
 //  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 //  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use log::*;
-
 use super::{
     error::ControlServiceError,
     service::ControlServiceConfig,
     types::{ControlMessage, ControlServiceDispatcher, ControlServiceMessageContext, Result},
 };
-
 use crate::{
     connection::{
         connection::EstablishedConnection,
         monitor::{ConnectionMonitor, SocketEvent, SocketEventType},
         types::Direction,
         Connection,
-        Context,
         InprocAddress,
+        ZmqContext,
     },
     connection_manager::ConnectionManager,
-    dispatcher::{DispatchResolver, DispatchableKey},
     message::{Frame, FrameSet, Message, MessageEnvelope, MessageEnvelopeHeader, MessageFlags},
-    peer_manager::CommsNodeIdentity,
+    peer_manager::NodeIdentity,
     types::{CommsCipher, CommsPublicKey},
 };
+use log::*;
+use serde::{de::DeserializeOwned, Serialize};
 use std::{
     convert::TryInto,
     sync::{
@@ -60,35 +58,36 @@ const CONTROL_SERVICE_MAX_MSG_SIZE: u64 = 1024; // 1kb
 
 /// The [ControlService] worker is responsible for handling incoming messages
 /// to the control port and dispatching them using the message dispatcher.
-pub struct ControlServiceWorker<MType, R>
-where MType: DispatchableKey
+pub struct ControlServiceWorker<MType>
+where MType: Clone
 {
-    context: Context,
-    config: ControlServiceConfig,
+    context: ZmqContext,
+    config: ControlServiceConfig<MType>,
     monitor_address: InprocAddress,
     receiver: Receiver<ControlMessage>,
     is_running: bool,
-    dispatcher: ControlServiceDispatcher<MType, R>,
+    dispatcher: ControlServiceDispatcher<MType>,
     connection_manager: Arc<ConnectionManager>,
-    node_identity: Arc<CommsNodeIdentity>,
+    node_identity: Arc<NodeIdentity<CommsPublicKey>>,
 }
 
-impl<MType, R> ControlServiceWorker<MType, R>
+impl<MType> ControlServiceWorker<MType>
 where
-    MType: DispatchableKey,
-    R: DispatchResolver<MType, ControlServiceMessageContext>,
+    MType: Send + Sync + 'static,
+    MType: Serialize + DeserializeOwned,
+    MType: Clone,
 {
     /// Start the worker
     ///
     /// # Arguments
     /// - `context` - Connection context
     /// - `config` - ControlServiceConfig
-    /// - `dispatcher` - the `Dispatcher` to use when message are received
     /// - `connection_manager` - the `ConnectionManager`
     pub fn start(
-        context: Context,
-        config: ControlServiceConfig,
-        dispatcher: ControlServiceDispatcher<MType, R>,
+        context: ZmqContext,
+        node_identity: Arc<NodeIdentity<CommsPublicKey>>,
+        dispatcher: ControlServiceDispatcher<MType>,
+        config: ControlServiceConfig<MType>,
         connection_manager: Arc<ConnectionManager>,
     ) -> Result<(thread::JoinHandle<Result<()>>, SyncSender<ControlMessage>)>
     {
@@ -98,17 +97,15 @@ where
         );
         let (sender, receiver) = sync_channel(5);
 
-        let node_identity = CommsNodeIdentity::global().ok_or(ControlServiceError::NodeIdentityNotSet)?;
-
         let mut worker = Self {
-            context,
             config,
-            monitor_address: InprocAddress::random(),
-            receiver,
-            is_running: false,
-            dispatcher,
             connection_manager,
+            context,
+            dispatcher,
+            is_running: false,
+            monitor_address: InprocAddress::random(),
             node_identity,
+            receiver,
         };
 
         let handle = thread::Builder::new()
@@ -190,7 +187,7 @@ where
             .try_into()
             .map_err(|err| ControlServiceError::MessageError(err))?;
 
-        let envelope_header: MessageEnvelopeHeader = envelope.to_header()?;
+        let envelope_header: MessageEnvelopeHeader<CommsPublicKey> = envelope.to_header()?;
         if !envelope_header.flags.contains(MessageFlags::ENCRYPTED) {
             return Err(ControlServiceError::ReceivedUnencryptedMessage);
         }
@@ -204,6 +201,8 @@ where
             message,
             connection_manager: self.connection_manager.clone(),
             peer_manager: self.connection_manager.get_peer_manager(),
+            node_identity: self.node_identity.clone(),
+            config: self.config.clone(),
         };
 
         debug!(target: LOG_TARGET, "Dispatching message");
@@ -212,13 +211,6 @@ where
 
     fn decrypt_body(&self, body: &Frame, public_key: &CommsPublicKey) -> Result<Frame> {
         let ecdh_shared_secret = CommsPublicKey::shared_secret(&self.node_identity.secret_key, public_key).to_vec();
-        use tari_utilities::hex::to_hex;
-        debug!(
-            target: LOG_TARGET,
-            "Control service shared key: {} SK: {}",
-            to_hex(ecdh_shared_secret.as_bytes()),
-            to_hex(self.node_identity.secret_key.as_bytes())
-        );
         CommsCipher::open_with_integral_nonce(&body, &ecdh_shared_secret).map_err(ControlServiceError::CipherError)
     }
 

--- a/comms/src/dispatcher/domain.rs
+++ b/comms/src/dispatcher/domain.rs
@@ -20,17 +20,44 @@
 //  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 //  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-pub mod curve_keypair;
-
-mod context;
-mod endpoint;
-mod error;
-mod inproc_address;
-
-pub use self::{
-    context::ZmqContext,
-    curve_keypair::{CurveEncryption, CurvePublicKey, CurveSecretKey},
-    endpoint::ZmqEndpoint,
-    error::ZmqError,
-    inproc_address::InprocAddress,
+use super::{DispatchError, DispatchResolver, Dispatcher};
+use crate::{
+    dispatcher::{DispatchableKey, HandlerError},
+    message::{DomainMessageContext, MessageHeader},
 };
+use serde::{de::DeserializeOwned, Serialize};
+use std::{error::Error, marker::PhantomData};
+
+/// Domain-level dispatch resolver
+pub struct DomainDispatchResolver<MType>(PhantomData<MType>);
+
+impl<MType> DomainDispatchResolver<MType> {
+    pub fn new() -> Self {
+        Self(PhantomData)
+    }
+}
+
+impl<MType> DispatchResolver<MType, DomainMessageContext> for DomainDispatchResolver<MType>
+where MType: DeserializeOwned + Serialize
+{
+    fn resolve(&self, msg: &DomainMessageContext) -> Result<MType, DispatchError> {
+        let header: MessageHeader<MType> = msg.message.to_header().map_err(DispatchError::resolve_failed())?;
+
+        Ok(header.message_type)
+    }
+}
+
+/// Dispatcher format for domain level dispatching to handlers
+pub type DomainMessageDispatcher<MType, E = HandlerError> =
+    Dispatcher<MType, DomainMessageContext, DomainDispatchResolver<MType>, E>;
+
+impl<MType, E> Default for DomainMessageDispatcher<MType, E>
+where
+    MType: DispatchableKey,
+    MType: DeserializeOwned + Serialize,
+    E: Error,
+{
+    fn default() -> Self {
+        DomainMessageDispatcher::<MType, E>::new(DomainDispatchResolver::<MType>::new())
+    }
+}

--- a/comms/src/dispatcher/mod.rs
+++ b/comms/src/dispatcher/mod.rs
@@ -20,17 +20,7 @@
 //  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 //  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-pub mod curve_keypair;
+mod dispatcher;
+pub mod domain;
 
-mod context;
-mod endpoint;
-mod error;
-mod inproc_address;
-
-pub use self::{
-    context::ZmqContext,
-    curve_keypair::{CurveEncryption, CurvePublicKey, CurveSecretKey},
-    endpoint::ZmqEndpoint,
-    error::ZmqError,
-    inproc_address::InprocAddress,
-};
+pub use self::{dispatcher::*, domain::DomainMessageDispatcher};

--- a/comms/src/inbound_message_service/error.rs
+++ b/comms/src/inbound_message_service/error.rs
@@ -20,17 +20,15 @@
 //  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 //  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-pub mod curve_keypair;
+use crate::connection::{zmq::ZmqError, DealerProxyError};
+use derive_error::Error;
 
-mod context;
-mod endpoint;
-mod error;
-mod inproc_address;
-
-pub use self::{
-    context::ZmqContext,
-    curve_keypair::{CurveEncryption, CurvePublicKey, CurveSecretKey},
-    endpoint::ZmqEndpoint,
-    error::ZmqError,
-    inproc_address::InprocAddress,
-};
+/// Error type for IMS
+#[derive(Debug, Error)]
+pub enum InboundMessageServiceError {
+    /// Problem with inbound socket
+    InboundSocketError(ZmqError),
+    /// Failed to connect to inbound socket
+    InboundConnectionError(zmq::Error),
+    DealerProxyError(DealerProxyError),
+}

--- a/comms/src/inbound_message_service/mod.rs
+++ b/comms/src/inbound_message_service/mod.rs
@@ -21,5 +21,6 @@
 //  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 pub mod comms_msg_handlers;
+pub mod error;
 pub mod inbound_message_service;
 pub mod msg_processing_worker;

--- a/comms/src/inbound_message_service/msg_processing_worker.rs
+++ b/comms/src/inbound_message_service/msg_processing_worker.rs
@@ -20,68 +20,62 @@
 //  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 //  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+use super::error::InboundMessageServiceError;
 use crate::{
     connection::{
         types::SocketType,
-        zmq::{Context, InprocAddress, ZmqEndpoint, ZmqError},
+        zmq::{InprocAddress, ZmqContext, ZmqEndpoint},
     },
-    dispatcher::{DispatchResolver, DispatchableKey},
-    message::{DomainMessageContext, MessageContext, MessageData},
+    dispatcher::{DispatchableKey, DomainMessageDispatcher},
+    message::{MessageContext, MessageData},
     outbound_message_service::outbound_message_service::OutboundMessageService,
-    peer_manager::peer_manager::PeerManager,
-    types::{CommsDataStore, CommsPublicKey, DomainMessageDispatcher, MessageDispatcher},
+    peer_manager::{peer_manager::PeerManager, NodeIdentity},
+    types::{CommsDataStore, CommsPublicKey, MessageDispatcher},
 };
+use serde::{de::DeserializeOwned, Serialize};
 #[cfg(test)]
 use std::sync::mpsc::SyncSender;
 use std::{
     convert::TryFrom,
-    hash::Hash,
-    marker::{Send, Sync},
     sync::Arc,
-    thread,
+    thread::{self, JoinHandle},
 };
-use tari_crypto::keys::PublicKey;
 
-/// As DealerError is handled in a thread it needs to be written to the error log
-#[derive(Debug)]
-pub enum WorkerError {
-    /// Problem with inbound socket
-    InboundSocketError(ZmqError),
-    /// Failed to connect to inbound socket
-    InboundConnectionError(zmq::Error),
-}
-
-pub struct MsgProcessingWorker<PubKey, DispKey, DispRes>
-where DispKey: DispatchableKey
+pub struct MsgProcessingWorker<MType>
+where
+    MType: DispatchableKey,
+    MType: Serialize + DeserializeOwned,
 {
-    context: Context,
+    context: ZmqContext,
+    node_identity: Arc<NodeIdentity<CommsPublicKey>>,
     inbound_address: InprocAddress,
-    message_dispatcher: Arc<MessageDispatcher<MessageContext<PubKey, DispKey, DispRes>>>,
-    domain_dispatcher: Arc<DomainMessageDispatcher<PubKey, DispKey, DispRes>>,
+    message_dispatcher: Arc<MessageDispatcher<MessageContext<MType>>>,
+    domain_dispatcher: Arc<DomainMessageDispatcher<MType>>,
     outbound_message_service: Arc<OutboundMessageService>,
     peer_manager: Arc<PeerManager<CommsPublicKey, CommsDataStore>>,
     #[cfg(test)]
     test_sync_sender: Option<SyncSender<String>>,
 }
 
-impl<PubKey, DispKey, DispRes> MsgProcessingWorker<PubKey, DispKey, DispRes>
+impl<MType> MsgProcessingWorker<MType>
 where
-    PubKey: PublicKey + Send + 'static + Sync + Hash,
-    DispKey: DispatchableKey,
-    DispRes: DispatchResolver<DispKey, DomainMessageContext<PubKey>> + Sync,
+    MType: DispatchableKey,
+    MType: Serialize + DeserializeOwned,
 {
     /// Setup a new MsgProcessingWorker that will read incoming messages and dispatch them using the message_dispatcher
     pub fn new(
-        context: Context,
+        context: ZmqContext,
+        node_identity: Arc<NodeIdentity<CommsPublicKey>>,
         inbound_address: InprocAddress,
-        message_dispatcher: Arc<MessageDispatcher<MessageContext<PubKey, DispKey, DispRes>>>,
-        domain_dispatcher: Arc<DomainMessageDispatcher<PubKey, DispKey, DispRes>>,
+        message_dispatcher: Arc<MessageDispatcher<MessageContext<MType>>>,
+        domain_dispatcher: Arc<DomainMessageDispatcher<MType>>,
         outbound_message_service: Arc<OutboundMessageService>,
         peer_manager: Arc<PeerManager<CommsPublicKey, CommsDataStore>>,
-    ) -> MsgProcessingWorker<PubKey, DispKey, DispRes>
+    ) -> Self
     {
         MsgProcessingWorker {
             context,
+            node_identity,
             inbound_address,
             message_dispatcher,
             domain_dispatcher,
@@ -92,15 +86,15 @@ where
         }
     }
 
-    fn start_worker(&self) -> Result<(), WorkerError> {
+    fn start_worker(&self) -> Result<(), InboundMessageServiceError> {
         // Establish connection inbound socket
         let inbound_socket = self
             .context
             .socket(SocketType::Reply)
-            .map_err(|e| WorkerError::InboundSocketError(e))?;
+            .map_err(|e| InboundMessageServiceError::InboundSocketError(e))?;
         inbound_socket
             .connect(&self.inbound_address.to_zmq_endpoint())
-            .map_err(|e| WorkerError::InboundConnectionError(e))?;
+            .map_err(|e| InboundMessageServiceError::InboundConnectionError(e))?;
         // Retrieve, process and dispatch messages
         loop {
             #[cfg(test)]
@@ -118,7 +112,8 @@ where
 
             match MessageData::try_from(frames) {
                 Ok(message_data) => {
-                    let message_context = MessageContext::<PubKey, DispKey, DispRes>::new(
+                    let message_context = MessageContext::new(
+                        self.node_identity.clone(),
                         message_data,
                         self.outbound_message_service.clone(),
                         self.peer_manager.clone(),
@@ -155,15 +150,10 @@ where
 
     /// Start the MsgProcessingWorker thread, connect to reply socket, retrieve and dispatch incoming messages to
     /// handlers
-    pub fn start(self) {
-        thread::spawn(move || {
-            loop {
-                match self.start_worker() {
-                    Ok(_) => (),
-                    Err(_e) => (/*TODO Write WorkerError as a Log Error*/),
-                }
-            }
-        });
+    pub fn start(self) -> JoinHandle<Result<(), InboundMessageServiceError>> {
+        thread::spawn(move || loop {
+            self.start_worker()?;
+        })
     }
 
     #[cfg(test)]
@@ -178,43 +168,20 @@ mod test {
 
     use crate::{
         connection::connection::EstablishedConnection,
-        dispatcher::DispatchError,
+        dispatcher::{domain::DomainDispatchResolver, DispatchError, HandlerError},
         inbound_message_service::comms_msg_handlers::{CommsDispatchType, InboundMessageServiceResolver},
-        message::{Message, MessageEnvelope, MessageHeader},
-        peer_manager::peer_manager::PeerManager,
+        message::{DomainMessageContext, Message, MessageEnvelope, MessageFlags, MessageHeader, NodeDestination},
+        peer_manager::{peer_manager::PeerManager, NodeIdentity},
         types::{CommsDataStore, CommsPublicKey},
     };
     use serde::{Deserialize, Serialize};
-    use std::{convert::TryInto, time};
-    use tari_crypto::ristretto::{RistrettoPublicKey, RistrettoSecretKey};
+    use std::{convert::TryInto, sync::Arc, time};
+    use tari_crypto::ristretto::RistrettoPublicKey;
     use tari_utilities::message_format::MessageFormat;
-
-    use crate::{
-        connection::net_address::NetAddress,
-        message::{MessageFlags, NodeDestination},
-        peer_manager::{node_id::NodeId, node_identity::CommsNodeIdentity, NodeIdentity, PeerNodeIdentity},
-    };
-    use std::sync::Arc;
-    use tari_utilities::byte_array::ByteArray;
-
-    fn init_node_identity() {
-        let secret_key = RistrettoSecretKey::from_bytes(&[
-            1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-        ])
-        .unwrap();
-        let public_key = RistrettoPublicKey::from_secret_key(&secret_key);
-        let node_id = NodeId::from_key(&public_key).unwrap();
-        NodeIdentity::<RistrettoPublicKey>::set_global(CommsNodeIdentity {
-            identity: PeerNodeIdentity::new(node_id, public_key),
-            secret_key,
-            control_service_address: "127.0.0.1:9090".parse::<NetAddress>().unwrap(),
-        });
-    }
 
     #[test]
     fn test_new_and_start() {
-        init_node_identity();
-        let node_identity = CommsNodeIdentity::global().unwrap();
+        let node_identity = Arc::new(NodeIdentity::random_for_test(None));
         // Create a common variable that the worker can change and the test can read to determine that the message was
         // correctly dispatched
         static mut CALLED_FN_TYPE: CommsDispatchType = CommsDispatchType::Discard;
@@ -224,29 +191,14 @@ mod test {
             Default,
         }
 
-        pub struct DomainResolver;
-
-        impl DispatchResolver<DomainDispatchType, DomainMessageContext<RistrettoPublicKey>> for DomainResolver {
-            fn resolve(
-                &self,
-                _msg: &DomainMessageContext<RistrettoPublicKey>,
-            ) -> Result<DomainDispatchType, DispatchError>
-            {
-                Ok(DomainDispatchType::Default)
-            }
-        }
-        fn domain_test_fn(_message_context: DomainMessageContext<RistrettoPublicKey>) -> Result<(), DispatchError> {
+        fn domain_test_fn(_message_context: DomainMessageContext) -> Result<(), HandlerError> {
             Ok(())
         }
 
-        let domain_dispatcher = Arc::new(
-            DomainMessageDispatcher::<RistrettoPublicKey, DomainDispatchType, DomainResolver>::new(DomainResolver {})
-                .catch_all(domain_test_fn),
-        );
+        let domain_dispatcher =
+            Arc::new(DomainMessageDispatcher::new(DomainDispatchResolver::new()).catch_all(domain_test_fn));
 
-        fn test_fn_handle(
-            _msg_context: MessageContext<RistrettoPublicKey, DomainDispatchType, DomainResolver>,
-        ) -> Result<(), DispatchError> {
+        fn test_fn_handle(_msg_context: MessageContext<DomainDispatchType>) -> Result<(), DispatchError> {
             unsafe {
                 CALLED_FN_TYPE = CommsDispatchType::Handle;
             }
@@ -258,14 +210,21 @@ mod test {
         );
 
         // Create the message worker
-        let context = Context::new();
+        let context = ZmqContext::new();
         let inbound_address = InprocAddress::random();
         let peer_manager = Arc::new(PeerManager::<CommsPublicKey, CommsDataStore>::new(None).unwrap());
         let outbound_message_service = Arc::new(
-            OutboundMessageService::new(context.clone(), InprocAddress::random(), peer_manager.clone()).unwrap(),
+            OutboundMessageService::new(
+                context.clone(),
+                node_identity.clone(),
+                InprocAddress::random(),
+                peer_manager.clone(),
+            )
+            .unwrap(),
         );
         let worker = MsgProcessingWorker::new(
             context.clone(),
+            node_identity.clone(),
             inbound_address.clone(),
             message_dispatcher,
             domain_dispatcher,
@@ -291,10 +250,10 @@ mod test {
         let dest_node_public_key = node_identity.identity.public_key.clone();
         let dest = NodeDestination::Unknown;
         let message_envelope = MessageEnvelope::construct(
-            node_identity.clone(),
+            &node_identity,
             dest_node_public_key.clone(),
             dest,
-            &message_envelope_body.to_binary().unwrap(),
+            message_envelope_body.to_binary().unwrap(),
             MessageFlags::NONE,
         )
         .unwrap();

--- a/comms/src/lib.rs
+++ b/comms/src/lib.rs
@@ -4,6 +4,7 @@ extern crate lazy_static;
 #[macro_use]
 mod macros;
 
+pub mod builder;
 #[macro_use]
 pub mod connection;
 pub mod connection_manager;
@@ -15,3 +16,5 @@ pub mod outbound_message_service;
 pub mod peer_manager;
 pub mod types;
 mod utils;
+
+pub use builder::CommsBuilder;

--- a/comms/src/macros.rs
+++ b/comms/src/macros.rs
@@ -22,12 +22,18 @@
 
 /// Creates a setter function used with the builder pattern
 macro_rules! setter {
+ ($func:ident, $name: ident, Option<$type: ty>) => {
+        pub fn $func(mut self, val: $type) -> Self {
+            self.$name = Some(val);
+            self
+        }
+    };
  ($func:ident, $name: ident, $type: ty) => {
-	pub fn $func(mut self, val: $type) -> Self {
-	    self.$name = Some(val);
-	    self
-	}
-    }
+        pub fn $func(mut self, val: $type) -> Self {
+            self.$name = val;
+            self
+        }
+    };
 }
 
 macro_rules! acquire_lock {

--- a/comms/src/message/domain_message_context.rs
+++ b/comms/src/message/domain_message_context.rs
@@ -27,30 +27,27 @@ use crate::{
     types::{CommsDataStore, CommsPublicKey},
 };
 use std::sync::Arc;
-use tari_crypto::keys::PublicKey;
 
 /// The DomainMessageContext is the container that will be dispatched to the domain handlers. It contains the received
 /// message after the comms level envelope has been removed. It also has handles to the PeerManager and
 /// OutboundMessageService.
 #[derive(Clone)]
-pub struct DomainMessageContext<PubKey> {
-    pub source_node_identity: Option<PubKey>,
+pub struct DomainMessageContext {
+    pub source_node_identity: Option<CommsPublicKey>,
     pub message: Message,
     pub outbound_message_service: Arc<OutboundMessageService>,
     pub peer_manager: Arc<PeerManager<CommsPublicKey, CommsDataStore>>,
 }
 
-impl<PubKey> DomainMessageContext<PubKey>
-where PubKey: PublicKey
-{
+impl DomainMessageContext {
     /// Construct a new DomainMessageContext that consist of the peer connection information and the received message
     /// header and body
     pub fn new(
-        source_node_identity: Option<PubKey>,
+        source_node_identity: Option<CommsPublicKey>,
         message: Message,
         outbound_message_service: Arc<OutboundMessageService>,
         peer_manager: Arc<PeerManager<CommsPublicKey, CommsDataStore>>,
-    ) -> DomainMessageContext<PubKey>
+    ) -> Self
     {
         DomainMessageContext {
             source_node_identity,

--- a/comms/src/message/envelope.rs
+++ b/comms/src/message/envelope.rs
@@ -23,27 +23,25 @@
 use super::Message;
 use crate::{
     message::{error::MessageError, Frame, FrameSet, MessageFlags, NodeDestination},
-    peer_manager::CommsNodeIdentity,
-    types::{CommsPublicKey, MESSAGE_PROTOCOL_VERSION, WIRE_PROTOCOL_VERSION},
+    peer_manager::NodeIdentity,
+    types::{CommsCipher, CommsPublicKey, MESSAGE_PROTOCOL_VERSION, WIRE_PROTOCOL_VERSION},
     utils::crypto,
 };
-
-use crate::types::{CommsCipher, CommsSecretKey};
 use rand::OsRng;
 use serde::{Deserialize, Serialize};
 use std::{convert::TryFrom, sync::Arc};
-use tari_crypto::keys::DiffieHellmanSharedSecret;
-use tari_utilities::{ciphers::cipher::Cipher, message_format::MessageFormat, ByteArray};
+use tari_crypto::keys::{DiffieHellmanSharedSecret, PublicKey};
+use tari_utilities::{ciphers::cipher::Cipher, message_format::MessageFormat};
 
 const FRAMES_PER_MESSAGE: usize = 3;
 
 /// Represents data that every message contains.
 /// As described in [RFC-0172](https://rfc.tari.com/RFC-0172_PeerToPeerMessagingProtocol.html#messaging-structure)
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
-pub struct MessageEnvelopeHeader {
+pub struct MessageEnvelopeHeader<PK> {
     pub version: u8,
-    pub source: CommsPublicKey,
-    pub dest: NodeDestination<CommsPublicKey>,
+    pub source: PK,
+    pub dest: NodeDestination<PK>,
     pub signature: Vec<u8>,
     pub flags: MessageFlags,
 }
@@ -65,21 +63,24 @@ impl MessageEnvelope {
 
     /// Sign a message, construct a MessageEnvelopeHeader and return the resulting MessageEnvelope
     pub fn construct(
-        node_identity: Arc<CommsNodeIdentity>,
+        node_identity: &Arc<NodeIdentity<CommsPublicKey>>,
         dest_public_key: CommsPublicKey,
         dest: NodeDestination<CommsPublicKey>,
-        body: &Frame,
+        body: Frame,
         flags: MessageFlags,
     ) -> Result<Self, MessageError>
     {
-        let body = if flags.contains(MessageFlags::ENCRYPTED) {
-            encrypt_envelope_body(&node_identity.secret_key, &dest_public_key, &body)?
-        } else {
-            body.clone()
-        };
+        let mut clear_body = body;
+        if flags.contains(MessageFlags::ENCRYPTED) {
+            clear_body = encrypt_envelope_body(&node_identity.secret_key, &dest_public_key, &clear_body)?
+        }
 
-        let signature = crypto::sign(&mut OsRng::new().unwrap(), node_identity.secret_key.clone(), &body)
-            .map_err(MessageError::SchnorrSignatureError)?;
+        let signature = crypto::sign(
+            &mut OsRng::new().unwrap(),
+            node_identity.secret_key.clone(),
+            &clear_body,
+        )
+        .map_err(MessageError::SchnorrSignatureError)?;
         let signature = signature.to_binary().map_err(MessageError::MessageFormatError)?;
 
         let header = MessageEnvelopeHeader {
@@ -93,16 +94,16 @@ impl MessageEnvelope {
         Ok(Self::new(
             vec![WIRE_PROTOCOL_VERSION],
             header.to_binary().map_err(MessageError::MessageFormatError)?,
-            body,
+            clear_body,
         ))
     }
 
     /// Verify that the signature provided in the message header is valid for the specified source and body of the
     /// message envelope
     pub fn verify_signature(&self) -> Result<bool, MessageError> {
-        let message_envelope_header: MessageEnvelopeHeader = self.to_header()?;
+        let message_envelope_header: MessageEnvelopeHeader<CommsPublicKey> = self.to_header()?;
         crypto::verify(
-            message_envelope_header.source,
+            &message_envelope_header.source,
             message_envelope_header.signature,
             self.body_frame(),
         )
@@ -119,8 +120,11 @@ impl MessageEnvelope {
     }
 
     /// Returns the [MessageEnvelopeHeader] deserialized from the header frame
-    pub fn to_header(&self) -> Result<MessageEnvelopeHeader, MessageError>
-    where MessageEnvelopeHeader: MessageFormat {
+    pub fn to_header<PK>(&self) -> Result<MessageEnvelopeHeader<PK>, MessageError>
+    where
+        PK: PublicKey,
+        MessageEnvelopeHeader<PK>: MessageFormat,
+    {
         MessageEnvelopeHeader::from_binary(self.header_frame()).map_err(Into::into)
     }
 
@@ -135,13 +139,15 @@ impl MessageEnvelope {
     }
 
     /// Returns the decrypted and deserialized Message from the body frame
-    pub fn decrypted_message_body(
+    pub fn decrypted_message_body<PK>(
         &self,
-        dest_secret_key: &CommsSecretKey,
-        source_public_key: &CommsPublicKey,
+        dest_secret_key: &PK::K,
+        source_public_key: &PK,
     ) -> Result<Message, MessageError>
+    where
+        PK: PublicKey + DiffieHellmanSharedSecret<PK = PK>,
     {
-        let decrypted_frame = decrypted_envelope_body(&dest_secret_key, &source_public_key, self.body_frame())?;
+        let decrypted_frame = decrypted_envelope_body(dest_secret_key, source_public_key, self.body_frame())?;
         Message::from_binary(&decrypted_frame).map_err(Into::into)
     }
 
@@ -165,24 +171,28 @@ impl TryFrom<FrameSet> for MessageEnvelope {
 }
 
 /// Encrypt the message_envelope_body with the generated shared secret
-fn encrypt_envelope_body(
-    source_secret_key: &CommsSecretKey,
-    dest_public_key: &CommsPublicKey,
+fn encrypt_envelope_body<PK>(
+    source_secret_key: &PK::K,
+    dest_public_key: &PK,
     message_body: &Frame,
 ) -> Result<Frame, MessageError>
+where
+    PK: PublicKey + DiffieHellmanSharedSecret<PK = PK>,
 {
-    let ecdh_shared_secret = CommsPublicKey::shared_secret(&source_secret_key, &dest_public_key).to_vec();
+    let ecdh_shared_secret = PK::shared_secret(source_secret_key, dest_public_key).to_vec();
     CommsCipher::seal_with_integral_nonce(message_body, &ecdh_shared_secret).map_err(|e| MessageError::CipherError(e))
 }
 
 /// Decrypt the message_envelope_body with the generated shared secret
-fn decrypted_envelope_body(
-    dest_secret_key: &CommsSecretKey,
-    source_public_key: &CommsPublicKey,
+fn decrypted_envelope_body<PK>(
+    dest_secret_key: &PK::K,
+    source_public_key: &PK,
     encrypted_message_body: &Frame,
 ) -> Result<Frame, MessageError>
+where
+    PK: PublicKey + DiffieHellmanSharedSecret<PK = PK>,
 {
-    let ecdh_shared_secret = CommsPublicKey::shared_secret(&dest_secret_key, &source_public_key).to_vec();
+    let ecdh_shared_secret = PK::shared_secret(dest_secret_key, source_public_key).to_vec();
     CommsCipher::open_with_integral_nonce(encrypted_message_body, &ecdh_shared_secret)
         .map_err(|e| MessageError::CipherError(e))
 }
@@ -267,24 +277,25 @@ mod test {
         header.serialize(&mut rmp_serde::Serializer::new(&mut buf)).unwrap();
         let serialized = buf.to_vec();
         let mut de = rmp_serde::Deserializer::new(serialized.as_slice());
-        let deserialized: MessageEnvelopeHeader = Deserialize::deserialize(&mut de).unwrap();
+        let deserialized: MessageEnvelopeHeader<RistrettoPublicKey> = Deserialize::deserialize(&mut de).unwrap();
         assert_eq!(deserialized, header);
     }
 
     #[test]
     fn construct() {
-        let node_identity = CommsNodeIdentity::global().unwrap();
+        let node_identity = Arc::new(NodeIdentity::random_for_test(None));
         let dest_secret_key = node_identity.secret_key.clone();
         let dest_public_key = node_identity.identity.public_key.clone(); // Send to self
+
         let message_header = "Test Message Header".as_bytes().to_vec();
         let message_body = "Test Message Body".as_bytes().to_vec();
         let message_envelope_body = Message::from_message_format(message_header, message_body.clone()).unwrap();
         let message_envelope_body_frame = message_envelope_body.to_binary().unwrap();
         let envelope = MessageEnvelope::construct(
-            node_identity.clone(),
+            &node_identity,
             dest_public_key.clone(),
             NodeDestination::Unknown,
-            &message_envelope_body_frame,
+            message_envelope_body_frame.clone(),
             MessageFlags::NONE,
         )
         .unwrap();
@@ -294,15 +305,15 @@ mod test {
         assert_eq!(MessageFlags::NONE, header.flags);
         assert_eq!(NodeDestination::Unknown, header.dest);
         assert_eq!(71, header.signature.len());
-        assert_eq!(message_envelope_body_frame, *envelope.body_frame());
+        assert_eq!(message_envelope_body_frame.clone(), *envelope.body_frame());
         assert!(envelope.verify_signature().unwrap());
 
         // Check Encrypted MessageEnvelope construction
         let envelope = MessageEnvelope::construct(
-            node_identity.clone(),
+            &node_identity,
             dest_public_key.clone(),
             NodeDestination::Unknown,
-            &message_envelope_body_frame,
+            message_envelope_body_frame.clone(),
             MessageFlags::ENCRYPTED,
         )
         .unwrap();

--- a/comms/src/message/mod.rs
+++ b/comms/src/message/mod.rs
@@ -37,7 +37,7 @@ pub use self::{
     envelope::*,
     error::MessageError,
     message::*,
-    message_context::*,
+    message_context::MessageContext,
     message_data::*,
 };
 

--- a/comms/src/message/p2p/mod.rs
+++ b/comms/src/message/p2p/mod.rs
@@ -22,8 +22,6 @@
 
 use serde::{Deserialize, Serialize};
 
-use tari_crypto::ristretto::RistrettoPublicKey;
-
 use crate::{
     connection::{net_address::NetAddress, zmq::CurvePublicKey},
     peer_manager::NodeId,
@@ -32,7 +30,7 @@ use crate::{
 /// This represents a request to open a peer connection
 /// to a remote peer.
 #[derive(Serialize, Deserialize, Debug)]
-pub struct EstablishConnection {
+pub struct EstablishConnection<PK> {
     pub control_service_address: NetAddress,
     /// The zeroMQ Curve public key to use for the peer connection
     pub server_key: CurvePublicKey,
@@ -41,7 +39,7 @@ pub struct EstablishConnection {
     /// The address to which to connect
     pub address: NetAddress,
     /// The requesting node's public key
-    pub public_key: RistrettoPublicKey,
+    pub public_key: PK,
 }
 
 /// Sent to show that the connection has been accepted

--- a/comms/src/outbound_message_service/message_pool_worker.rs
+++ b/comms/src/outbound_message_service/message_pool_worker.rs
@@ -20,29 +20,19 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE
 
+use super::{outbound_message_pool::OutboundMessagePoolConfig, OutboundError, OutboundMessage};
 use crate::{
-    connection::{
-        zmq::{Context, InprocAddress},
-        Connection,
-        ConnectionError,
-        Direction,
-        SocketEstablishment,
-    },
+    connection::{Connection, ConnectionError, Direction, InprocAddress, SocketEstablishment, ZmqContext},
     connection_manager::ConnectionManager,
     message::{FrameSet, MessageEnvelope},
-    outbound_message_service::{OutboundError, OutboundMessage},
     peer_manager::PeerManager,
     types::{CommsDataStore, CommsPublicKey},
 };
-
-use crate::outbound_message_service::outbound_message_pool::OutboundMessagePoolConfig;
-
+use chrono::Utc;
 use log::*;
 #[cfg(test)]
 use std::sync::mpsc::SyncSender;
 use std::{convert::TryFrom, sync::Arc, thread};
-
-use chrono::Utc;
 use tari_utilities::message_format::MessageFormat;
 
 const LOG_TARGET: &'static str = "comms::outbound_message_service::pool::worker";
@@ -58,7 +48,7 @@ pub enum WorkerError {
 /// This is an instance of a single Worker thread for the Outbound Message Pool
 pub struct MessagePoolWorker {
     config: OutboundMessagePoolConfig,
-    context: Context,
+    context: ZmqContext,
     inbound_address: InprocAddress,
     message_queue_address: InprocAddress,
     message_requeue_address: InprocAddress,
@@ -71,7 +61,7 @@ pub struct MessagePoolWorker {
 impl MessagePoolWorker {
     pub fn new(
         config: OutboundMessagePoolConfig,
-        context: Context,
+        context: ZmqContext,
         inbound_address: InprocAddress,
         message_queue_address: InprocAddress,
         message_requeue_address: InprocAddress,

--- a/comms/src/peer_manager/mod.rs
+++ b/comms/src/peer_manager/mod.rs
@@ -56,7 +56,7 @@ pub mod peer_storage;
 
 pub use self::{
     node_id::NodeId,
-    node_identity::{CommsNodeIdentity, NodeIdentity, PeerNodeIdentity},
+    node_identity::{NodeIdentity, PeerNodeIdentity},
     peer::{Peer, PeerFlags},
     peer_manager::{PeerManager, PeerManagerError},
 };

--- a/comms/src/peer_manager/node_identity.rs
+++ b/comms/src/peer_manager/node_identity.rs
@@ -20,17 +20,20 @@
 //  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 //  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use std::sync::{Arc, RwLock};
+use crate::{
+    connection::NetAddress,
+    peer_manager::node_id::{NodeId, NodeIdError},
+};
+use derive_error::Error;
+use rand::{CryptoRng, Rng};
+use tari_crypto::{
+    keys::{PublicKey, SecretKey},
+    ristretto::{RistrettoPublicKey, RistrettoSecretKey},
+};
 
-use crate::{connection::NetAddress, peer_manager::node_id::NodeId, types::CommsPublicKey};
-
-use tari_crypto::keys::PublicKey;
-use tari_utilities::Hashable;
-
-pub type CommsNodeIdentity = NodeIdentity<CommsPublicKey>;
-
-lazy_static! {
-    static ref GLOBAL_NODE_IDENTITY: RwLock<Option<Arc<CommsNodeIdentity>>> = RwLock::new(None);
+#[derive(Debug, Error)]
+pub enum NodeIdentityError {
+    NodeIdError(NodeIdError),
 }
 
 /// Identity of this node
@@ -40,60 +43,37 @@ lazy_static! {
 /// `secret_key`: The secret key corresponding to the public key of this node
 ///
 /// `control_service_address`: The NetAddress of the local node's Control port
-pub struct NodeIdentity<P: PublicKey> {
-    pub identity: PeerNodeIdentity<P>,
-    pub secret_key: P::K,
+pub struct NodeIdentity<PK: PublicKey> {
+    pub identity: PeerNodeIdentity<PK>,
+    pub secret_key: PK::K,
     pub control_service_address: NetAddress,
 }
 
-impl<P> NodeIdentity<P>
-where P: PublicKey + Hashable
-{
-    #[cfg(not(test))]
-    /// Fetches the static global NodeIdentity for this node
-    pub fn global() -> Option<Arc<CommsNodeIdentity>> {
-        let lock = acquire_read_lock!(GLOBAL_NODE_IDENTITY);
-        lock.clone()
-    }
-
-    #[cfg(test)]
-    /// Fetches the test local NodeIdentity
-    pub fn global() -> Option<Arc<CommsNodeIdentity>> {
-        use tari_crypto::{
-            keys::SecretKey,
-            ristretto::{RistrettoPublicKey, RistrettoSecretKey},
-        };
-        //        use tari_utilities::byte_array::ByteArray;
-        use rand::OsRng;
-
-        {
-            let lock = acquire_read_lock!(GLOBAL_NODE_IDENTITY);
-            if lock.is_some() {
-                return lock.clone();
-            }
-        }
-
-        let mut lock = acquire_write_lock!(GLOBAL_NODE_IDENTITY);
-        // Generate a test identity, set it and return it
-        let secret_key = RistrettoSecretKey::random(&mut OsRng::new().unwrap());
+impl NodeIdentity<RistrettoPublicKey> {
+    /// Generates a new random NodeIdentity for Ristretto
+    pub fn random<R>(rng: &mut R, control_service_address: NetAddress) -> Result<Self, NodeIdentityError>
+    where R: CryptoRng + Rng {
+        let secret_key = RistrettoSecretKey::random(rng);
         let public_key = RistrettoPublicKey::from_secret_key(&secret_key);
-        let node_id = NodeId::from_key(&public_key).unwrap();
-        let node_identity = CommsNodeIdentity {
+        let node_id = NodeId::from_key(&public_key).map_err(NodeIdentityError::NodeIdError)?;
+
+        Ok(NodeIdentity {
             identity: PeerNodeIdentity::new(node_id, public_key),
             secret_key,
-            control_service_address: "127.0.0.1:9090".parse::<NetAddress>().unwrap(),
-        };
-        let new_identity = Some(Arc::new(node_identity));
-        *lock = new_identity.clone();
-        new_identity
+            control_service_address,
+        })
     }
 
-    /// Sets the global node identity.
-    pub fn set_global(node_identity: CommsNodeIdentity) -> Arc<CommsNodeIdentity> {
-        let mut lock = acquire_write_lock!(GLOBAL_NODE_IDENTITY);
-        let new_identity = Arc::new(node_identity);
-        *lock = Some(new_identity.clone());
-        new_identity
+    /// This returns a random NodeIdentity for testing purposes. This function can panic. If a control_service_address
+    /// is None, 127.0.0.1:9000 will be used (i.e. the caller doesn't care what the control_service_address is).
+    #[cfg(test)]
+    pub fn random_for_test(control_service_address: Option<NetAddress>) -> Self {
+        use rand::OsRng;
+        Self::random(
+            &mut OsRng::new().unwrap(),
+            control_service_address.or("127.0.0.1:9000".parse().ok()).unwrap(),
+        )
+        .unwrap()
     }
 }
 
@@ -109,18 +89,5 @@ impl<PubKey: PublicKey> PeerNodeIdentity<PubKey> {
     /// Construct a new identity for a node that contains its NodeId and identification key pair
     pub fn new(node_id: NodeId, public_key: PubKey) -> PeerNodeIdentity<PubKey> {
         PeerNodeIdentity { node_id, public_key }
-    }
-}
-
-#[cfg(test)]
-mod test {
-    use super::*;
-
-    #[test]
-    fn global() {
-        let ident = CommsNodeIdentity::global().unwrap();
-        let ident_again = CommsNodeIdentity::global().unwrap();
-        assert_eq!(ident.identity, ident_again.identity);
-        assert_eq!(ident.secret_key, ident_again.secret_key);
     }
 }

--- a/comms/src/types.rs
+++ b/comms/src/types.rs
@@ -23,7 +23,6 @@
 use crate::{
     dispatcher::{DispatchError, Dispatcher},
     inbound_message_service::comms_msg_handlers::{CommsDispatchType, InboundMessageServiceResolver},
-    message::DomainMessageContext,
 };
 use tari_crypto::{common::Blake256, keys::PublicKey, ristretto::RistrettoPublicKey};
 use tari_storage::lmdb::LMDBStore;
@@ -55,8 +54,4 @@ pub type CommsCipher = ChaCha20;
 pub type CommsDataStore = LMDBStore;
 
 /// Dispatcher format for comms level dispatching to handlers
-pub type MessageDispatcher<M> = Dispatcher<CommsDispatchType, M, DispatchError, InboundMessageServiceResolver>;
-
-/// Dispatcher format for domain level dispatching to handlers
-pub type DomainMessageDispatcher<PubKey, DispKey, DispRes> =
-    Dispatcher<DispKey, DomainMessageContext<PubKey>, DispatchError, DispRes>;
+pub type MessageDispatcher<M> = Dispatcher<CommsDispatchType, M, InboundMessageServiceResolver, DispatchError>;

--- a/comms/src/utils.rs
+++ b/comms/src/utils.rs
@@ -23,36 +23,37 @@
 pub mod crypto {
     use crate::{
         message::MessageError,
-        types::{Challenge, CommsPublicKey, CommsSecretKey},
+        types::{Challenge, CommsPublicKey},
     };
     use digest::Digest;
     use rand::{CryptoRng, Rng};
     use tari_crypto::{
-        keys::SecretKey,
+        keys::{PublicKey, SecretKey},
         signatures::{SchnorrSignature, SchnorrSignatureError},
     };
     use tari_utilities::message_format::MessageFormat;
 
     pub fn sign<R, B>(
         rng: &mut R,
-        secret_key: CommsSecretKey,
+        secret_key: <CommsPublicKey as PublicKey>::K,
         body: B,
-    ) -> Result<SchnorrSignature<CommsPublicKey, CommsSecretKey>, SchnorrSignatureError>
+    ) -> Result<SchnorrSignature<CommsPublicKey, <CommsPublicKey as PublicKey>::K>, SchnorrSignatureError>
     where
         R: CryptoRng + Rng,
         B: AsRef<[u8]>,
     {
         let challenge = Challenge::new().chain(body).result().to_vec();
-        let nonce = CommsSecretKey::random(rng);
+        let nonce = <CommsPublicKey as PublicKey>::K::random(rng);
         SchnorrSignature::sign(secret_key, nonce, &challenge)
     }
 
     /// Verify that the signature is valid for the message body
-    pub fn verify<B>(public_key: CommsPublicKey, signature: Vec<u8>, body: B) -> Result<bool, MessageError>
+    pub fn verify<B>(public_key: &CommsPublicKey, signature: Vec<u8>, body: B) -> Result<bool, MessageError>
     where B: AsRef<[u8]> {
-        let signature = SchnorrSignature::<CommsPublicKey, CommsSecretKey>::from_binary(signature.as_slice())
-            .map_err(MessageError::MessageFormatError)?;
+        let signature =
+            SchnorrSignature::<CommsPublicKey, <CommsPublicKey as PublicKey>::K>::from_binary(signature.as_slice())
+                .map_err(MessageError::MessageFormatError)?;
         let challenge = Challenge::new().chain(body).result().to_vec();
-        Ok(signature.verify_challenge(&public_key, &challenge))
+        Ok(signature.verify_challenge(public_key, &challenge))
     }
 }

--- a/comms/tests/connection/connection.rs
+++ b/comms/tests/connection/connection.rs
@@ -26,17 +26,17 @@ use tari_comms::connection::{
     connection::Connection,
     error::ConnectionError,
     types::{Direction, Linger},
-    Context,
     CurveEncryption,
     InprocAddress,
     NetAddress,
+    ZmqContext,
 };
 
-use crate::support::factories::{self, Factory};
+use crate::support::factories::{self, TestFactory};
 
 #[test]
 fn inbound_receive_timeout() {
-    let ctx = Context::new();
+    let ctx = ZmqContext::new();
 
     let addr = InprocAddress::random();
 
@@ -56,7 +56,7 @@ fn inbound_receive_timeout() {
 
 #[test]
 fn inbound_recv_send_inproc() {
-    let ctx = Context::new();
+    let ctx = ZmqContext::new();
 
     let addr = InprocAddress::random();
 
@@ -92,7 +92,7 @@ fn inbound_recv_send_inproc() {
 
 #[test]
 fn inbound_recv_send_encrypted_tcp() {
-    let ctx = Context::new();
+    let ctx = ZmqContext::new();
 
     let addr = factories::net_address::create().use_os_port().build().unwrap();
 
@@ -126,7 +126,7 @@ fn inbound_recv_send_encrypted_tcp() {
 
 #[test]
 fn outbound_send_recv_inproc() {
-    let ctx = Context::new();
+    let ctx = ZmqContext::new();
 
     let addr = InprocAddress::random();
 
@@ -156,7 +156,7 @@ fn outbound_send_recv_inproc() {
 
 #[test]
 fn outbound_send_recv_encrypted_tcp() {
-    let ctx = Context::new();
+    let ctx = ZmqContext::new();
 
     let addr = factories::net_address::create().build().unwrap();
 

--- a/comms/tests/connection/monitor.rs
+++ b/comms/tests/connection/monitor.rs
@@ -25,16 +25,16 @@ use tari_comms::connection::{
     connection::Connection,
     monitor::{ConnectionMonitor, SocketEventType},
     types::Direction,
-    zmq::{Context, ZmqEndpoint},
+    zmq::{ZmqContext, ZmqEndpoint},
     InprocAddress,
     NetAddress,
 };
 
-use crate::support::factories::{self, Factory};
+use crate::support::factories::{self, TestFactory};
 
 #[test]
 fn recv_socket_events() {
-    let ctx = Context::new();
+    let ctx = ZmqContext::new();
     let monitor_addr = InprocAddress::random();
     let address = factories::net_address::create().use_os_port().build().unwrap();
 

--- a/comms/tests/connection/peer_connection.rs
+++ b/comms/tests/connection/peer_connection.rs
@@ -25,21 +25,21 @@ use tari_comms::connection::{
     types::{Direction, Linger},
     Connection,
     ConnectionError,
-    Context,
     CurveEncryption,
     InprocAddress,
     NetAddress,
     PeerConnection,
     PeerConnectionContextBuilder,
     PeerConnectionError,
+    ZmqContext,
 };
 
-use crate::support::factories::{self, Factory};
+use crate::support::factories::{self, TestFactory};
 
 #[test]
 fn connection_in() {
     let addr = factories::net_address::create().build().unwrap();
-    let ctx = Context::new();
+    let ctx = ZmqContext::new();
 
     let (server_sk, server_pk) = CurveEncryption::generate_keypair().unwrap();
     let (client_sk, client_pk) = CurveEncryption::generate_keypair().unwrap();
@@ -91,7 +91,7 @@ fn connection_in() {
 #[test]
 fn connection_out() {
     let addr = factories::net_address::create().build().unwrap();
-    let ctx = Context::new();
+    let ctx = ZmqContext::new();
 
     let (server_sk, server_pk) = CurveEncryption::generate_keypair().unwrap();
     let (client_sk, client_pk) = CurveEncryption::generate_keypair().unwrap();
@@ -146,7 +146,7 @@ fn connection_out() {
 #[test]
 fn connection_wait_connect_shutdown() {
     let addr = factories::net_address::create().build().unwrap();
-    let ctx = Context::new();
+    let ctx = ZmqContext::new();
 
     let receiver = Connection::new(&ctx, Direction::Inbound).establish(&addr).unwrap();
 
@@ -181,7 +181,7 @@ fn connection_wait_connect_shutdown() {
 #[test]
 fn connection_wait_connect_failed() {
     let addr = factories::net_address::create().use_os_port().build().unwrap();
-    let ctx = Context::new();
+    let ctx = ZmqContext::new();
 
     let consumer_addr = InprocAddress::random();
 
@@ -218,7 +218,7 @@ fn connection_wait_connect_failed() {
 #[test]
 fn connection_pause_resume() {
     let addr = factories::net_address::create().build().unwrap();
-    let ctx = Context::new();
+    let ctx = ZmqContext::new();
 
     let consumer_addr = InprocAddress::random();
 
@@ -282,7 +282,7 @@ fn connection_pause_resume() {
 #[test]
 fn connection_disconnect() {
     let addr = factories::net_address::create().use_os_port().build().unwrap();
-    let ctx = Context::new();
+    let ctx = ZmqContext::new();
 
     let consumer_addr = InprocAddress::random();
 

--- a/comms/tests/connection_manager/manager.rs
+++ b/comms/tests/connection_manager/manager.rs
@@ -20,26 +20,21 @@
 //  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 //  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use std::{sync::Arc, thread, time::Duration};
-
 use crate::support::{
-    factories::{self, Factory},
+    factories::{self, TestFactory},
     helpers::ConnectionMessageCounter,
-    node_identity::set_test_node_identity,
 };
-
+use std::{sync::Arc, thread, time::Duration};
 use tari_comms::{
-    connection::{types::Linger, Context, InprocAddress},
+    connection::{types::Linger, InprocAddress, ZmqContext},
     connection_manager::{ConnectionManager, PeerConnectionConfig},
-    control_service::{handlers, ControlService, ControlServiceConfig, ControlServiceMessageType},
-    dispatcher::Dispatcher,
-    peer_manager::{CommsNodeIdentity, Peer, PeerManager},
+    control_service::{ControlService, ControlServiceConfig},
+    peer_manager::{Peer, PeerManager},
     types::{CommsDataStore, CommsPublicKey},
 };
 
-fn make_peer_connection_config(context: &Context, consumer_address: InprocAddress) -> PeerConnectionConfig {
+fn make_peer_connection_config(consumer_address: InprocAddress) -> PeerConnectionConfig {
     PeerConnectionConfig {
-        context: context.clone(),
         control_service_establish_timeout: Duration::from_millis(2000),
         peer_connection_establish_timeout: Duration::from_secs(5),
         max_message_size: 1024,
@@ -58,15 +53,9 @@ fn make_peer_manager(peers: Vec<Peer<CommsPublicKey>>) -> Arc<PeerManager<CommsP
 #[allow(non_snake_case)]
 fn establish_peer_connection_by_peer() {
     let _ = simple_logger::init();
-    set_test_node_identity();
-    let context = Context::new();
+    let context = ZmqContext::new();
 
-    let dispatcher = Dispatcher::new(handlers::ControlServiceResolver::new()).route(
-        ControlServiceMessageType::EstablishConnection,
-        handlers::establish_connection,
-    );
-
-    let node_identity = CommsNodeIdentity::global().unwrap();
+    let node_identity = Arc::new(factories::node_identity::create::<CommsPublicKey>().build().unwrap());
 
     //---------------------------------- Node B Setup --------------------------------------------//
 
@@ -86,19 +75,24 @@ fn establish_peer_connection_by_peer() {
 
     // Node B knows no peers
     let node_B_peer_manager = make_peer_manager(vec![]);
-    let node_B_connection_manager = Arc::new(ConnectionManager::new(
-        node_B_peer_manager,
-        make_peer_connection_config(&context, node_B_consumer_address.clone()),
-    ));
+    let node_B_connection_manager = Arc::new(
+        factories::connection_manager::create()
+            .with_context(context.clone())
+            .with_node_identity(node_identity.clone())
+            .with_peer_manager(node_B_peer_manager)
+            .with_peer_connection_config(make_peer_connection_config(node_B_consumer_address.clone()))
+            .build()
+            .unwrap(),
+    );
 
     // Start node B's control service
-    let node_B_control_service = ControlService::new(&context)
-        .configure(ControlServiceConfig {
-            socks_proxy_address: None,
-            listener_address: node_B_control_port_address,
-        })
-        .serve(dispatcher, node_B_connection_manager)
-        .unwrap();
+    let node_B_control_service = ControlService::new(context.clone(), node_identity.clone(), ControlServiceConfig {
+        socks_proxy_address: None,
+        listener_address: node_B_control_port_address,
+        accept_message_type: 123,
+    })
+    .serve(node_B_connection_manager)
+    .unwrap();
 
     //---------------------------------- Node A setup --------------------------------------------//
 
@@ -107,8 +101,10 @@ fn establish_peer_connection_by_peer() {
     // Add node B to node A's peer manager
     let node_A_peer_manager = make_peer_manager(vec![node_B_peer.clone()]);
     let node_A_connection_manager = Arc::new(ConnectionManager::new(
+        context.clone(),
+        node_identity.clone(),
         node_A_peer_manager,
-        make_peer_connection_config(&context, node_A_consumer_address),
+        make_peer_connection_config(node_A_consumer_address),
     ));
 
     //------------------------------ Negotiate connection to node B -----------------------------------//

--- a/comms/tests/control_service/service.rs
+++ b/comms/tests/control_service/service.rs
@@ -20,26 +20,29 @@
 //  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 //  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use serde::{Deserialize, Serialize};
-
+use crate::support::factories::{self, TestFactory};
 use std::{
     sync::{mpsc::channel, Arc, RwLock},
     thread,
     time::Duration,
 };
-
 use tari_comms::{
     connection::{
         types::{Direction, Linger},
         Connection,
-        Context,
         CurveEncryption,
-        InprocAddress,
         NetAddress,
+        ZmqContext,
     },
-    connection_manager::{ConnectionManager, PeerConnectionConfig},
-    control_service::{ControlService, ControlServiceConfig, ControlServiceError, ControlServiceMessageContext},
-    dispatcher::{DispatchError, DispatchResolver, Dispatcher},
+    control_service::{
+        handlers::ControlServiceResolver,
+        ControlService,
+        ControlServiceConfig,
+        ControlServiceError,
+        ControlServiceMessageContext,
+        ControlServiceMessageType,
+    },
+    dispatcher::{DispatchError, Dispatcher},
     message::{
         p2p::EstablishConnection,
         Message,
@@ -50,30 +53,18 @@ use tari_comms::{
         MessageHeader,
         NodeDestination,
     },
-    peer_manager::{CommsNodeIdentity, NodeId, PeerManager},
+    peer_manager::{NodeId, NodeIdentity},
     types::{CommsCipher, CommsPublicKey, CommsSecretKey},
 };
 use tari_crypto::keys::DiffieHellmanSharedSecret;
-use tari_storage::lmdb::LMDBStore;
 use tari_utilities::{byte_array::ByteArray, ciphers::cipher::Cipher, message_format::MessageFormat};
-
-use crate::support::{
-    factories::{self, Factory},
-    node_identity::set_test_node_identity,
-};
-
-#[derive(Eq, PartialEq, Hash, Serialize, Deserialize)]
-enum MessageType {
-    EstablishConnection = 1,
-    InvalidMessage = 2,
-}
 
 lazy_static! {
     static ref HANDLER_CALL_COUNT: RwLock<u8> = RwLock::new(0);
 }
 
-fn test_handler(context: ControlServiceMessageContext) -> Result<(), ControlServiceError> {
-    let msg: EstablishConnection = context
+fn test_handler(context: ControlServiceMessageContext<u8>) -> Result<(), ControlServiceError> {
+    let msg: EstablishConnection<CommsPublicKey> = context
         .message
         .to_message()
         .map_err(|err| DispatchError::HandlerError(format!("Failed to parse message: {}", err)))?;
@@ -86,27 +77,14 @@ fn test_handler(context: ControlServiceMessageContext) -> Result<(), ControlServ
     Ok(())
 }
 
-struct CustomTestResolver;
-
-impl DispatchResolver<MessageType, ControlServiceMessageContext> for CustomTestResolver {
-    fn resolve(&self, context: &ControlServiceMessageContext) -> Result<MessageType, DispatchError> {
-        let header: MessageHeader<MessageType> = context
-            .message
-            .to_header()
-            .map_err(|err| DispatchError::HandlerError(format!("Failed to parse header: {}", err)))?;
-
-        Ok(header.message_type)
-    }
-}
-
 fn encrypt_message(secret_key: &CommsSecretKey, public_key: &CommsPublicKey, msg: Vec<u8>) -> Vec<u8> {
     let shared_secret = CommsPublicKey::shared_secret(secret_key, public_key);
     CommsCipher::seal_with_integral_nonce(&msg, &shared_secret.to_vec()).unwrap()
 }
 
 fn construct_envelope<T: MessageFormat>(
-    node_identity: &Arc<CommsNodeIdentity>,
-    message_type: MessageType,
+    node_identity: &Arc<NodeIdentity<CommsPublicKey>>,
+    message_type: ControlServiceMessageType,
     msg: T,
 ) -> Result<MessageEnvelope, MessageError>
 {
@@ -147,40 +125,34 @@ fn poll_handler_call_count_change(initial: u8, ms: u64) -> Option<u8> {
     None
 }
 
-fn make_connection_manager(context: &Context) -> Arc<ConnectionManager> {
-    Arc::new(ConnectionManager::new(make_peer_manager(), PeerConnectionConfig {
-        context: context.clone(),
-        control_service_establish_timeout: Duration::from_millis(1000),
-        peer_connection_establish_timeout: Duration::from_secs(4),
-        max_message_size: 1024 * 1024,
-        socks_proxy_address: None,
-        message_sink_address: InprocAddress::random(),
-        host: "127.0.0.1".parse().unwrap(),
-        max_connect_retries: 1,
-    }))
-}
-
-fn make_peer_manager() -> Arc<PeerManager<CommsPublicKey, LMDBStore>> {
-    Arc::new(PeerManager::<CommsPublicKey, LMDBStore>::new(None).unwrap())
-}
-
 #[test]
 fn recv_message() {
-    let node_identity = set_test_node_identity();
-
-    let context = Context::new();
-    let connection_manager = make_connection_manager(&context);
+    let context = ZmqContext::new();
+    let connection_manager = Arc::new(
+        factories::connection_manager::create()
+            .with_context(context.clone())
+            .build()
+            .unwrap(),
+    );
     let control_service_address = factories::net_address::create().build().unwrap();
+    let node_identity = Arc::new(
+        factories::node_identity::create::<CommsPublicKey>()
+            .with_control_service_address(control_service_address.clone())
+            .build()
+            .unwrap(),
+    );
 
-    let dispatcher = Dispatcher::new(CustomTestResolver {}).route(MessageType::EstablishConnection, test_handler);
+    let dispatcher = Dispatcher::new(ControlServiceResolver::new())
+        .route(ControlServiceMessageType::EstablishConnection, test_handler);
 
-    let service = ControlService::new(&context)
-        .configure(ControlServiceConfig {
-            socks_proxy_address: None,
-            listener_address: control_service_address.clone(),
-        })
-        .serve(dispatcher, connection_manager)
-        .unwrap();
+    let service = ControlService::new(context.clone(), node_identity.clone(), ControlServiceConfig {
+        socks_proxy_address: None,
+        listener_address: control_service_address.clone(),
+        accept_message_type: 123,
+    })
+    .with_custom_dispatcher(dispatcher)
+    .serve(connection_manager)
+    .unwrap();
 
     // A "remote" node sends an EstablishConnection message to this node's control port
     let requesting_node_address = factories::net_address::create().build().unwrap();
@@ -194,7 +166,7 @@ fn recv_message() {
         control_service_address: control_service_address.clone(),
     };
 
-    let envelope = construct_envelope(&node_identity, MessageType::EstablishConnection, msg).unwrap();
+    let envelope = construct_envelope(&node_identity, ControlServiceMessageType::EstablishConnection, msg).unwrap();
 
     let remote_conn = Connection::new(&context, Direction::Outbound)
         .set_linger(Linger::Indefinitely)
@@ -223,32 +195,27 @@ fn recv_message() {
     service.shutdown().unwrap();
 }
 
-struct TestResolver;
-
-impl DispatchResolver<u8, ControlServiceMessageContext> for TestResolver {
-    fn resolve(&self, _context: &ControlServiceMessageContext) -> std::result::Result<u8, DispatchError> {
-        Ok(0u8)
-    }
-}
-
 #[test]
 fn serve_and_shutdown() {
-    set_test_node_identity();
+    let node_identity = Arc::new(factories::node_identity::create::<CommsPublicKey>().build().unwrap());
     let (tx, rx) = channel();
-    let context = Context::new();
-    let connection_manager = make_connection_manager(&context);
+    let context = ZmqContext::new();
+    let connection_manager = Arc::new(
+        factories::connection_manager::create()
+            .with_context(context.clone())
+            .build()
+            .unwrap(),
+    );
 
     let listener_address: NetAddress = "127.0.0.1:0".parse().unwrap(); // factories::net_address::create().use_os_port().build().unwrap();
     thread::spawn(move || {
-        let dispatcher = Dispatcher::new(TestResolver {});
-
-        let service = ControlService::new(&context)
-            .configure(ControlServiceConfig {
-                listener_address,
-                socks_proxy_address: None,
-            })
-            .serve(dispatcher, connection_manager)
-            .unwrap();
+        let service = ControlService::new(context, node_identity, ControlServiceConfig {
+            listener_address,
+            socks_proxy_address: None,
+            accept_message_type: 123,
+        })
+        .serve(connection_manager)
+        .unwrap();
 
         service.shutdown().unwrap();
         tx.send(()).unwrap();

--- a/comms/tests/support/comms_patterns.rs
+++ b/comms/tests/support/comms_patterns.rs
@@ -28,8 +28,8 @@ use tari_comms::{
     connection::{
         types::{Direction, SocketType},
         zmq::{CurvePublicKey, CurveSecretKey, ZmqEndpoint},
-        Context,
         CurveEncryption,
+        ZmqContext,
     },
     message::FrameSet,
 };
@@ -101,7 +101,7 @@ where T: ZmqEndpoint + Clone + Send + Sync + 'static
     }
 
     /// Start the thread and run the pattern!
-    pub fn run(self, ctx: Context) -> Receiver<()> {
+    pub fn run(self, ctx: ZmqContext) -> Receiver<()> {
         let (tx, rx) = channel();
         let identity = self.identity.clone();
         let secret_key = self.secret_key.clone();

--- a/comms/tests/support/factories/connection_manager.rs
+++ b/comms/tests/support/factories/connection_manager.rs
@@ -1,0 +1,103 @@
+//  Copyright 2019 The Tari Project
+//
+//  Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+//  following conditions are met:
+//
+//  1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+//  disclaimer.
+//
+//  2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+//  following disclaimer in the documentation and/or other materials provided with the distribution.
+//
+//  3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+//  products derived from this software without specific prior written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+//  INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+//  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+//  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+//  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+//  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+//  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+use std::sync::Arc;
+
+use super::{TestFactory, TestFactoryError};
+
+use crate::support::factories::peer_manager::PeerManagerFactory;
+
+use crate::support::factories::node_identity::NodeIdentityFactory;
+use tari_comms::{
+    connection::ZmqContext,
+    connection_manager::{ConnectionManager, PeerConnectionConfig},
+    peer_manager::{NodeIdentity, PeerManager},
+    types::{CommsDataStore, CommsPublicKey},
+};
+
+pub fn create() -> ConnectionManagerFactory {
+    ConnectionManagerFactory::default()
+}
+
+#[derive(Default)]
+pub struct ConnectionManagerFactory {
+    comms_context: Option<ZmqContext>,
+    peer_connection_config: PeerConnectionConfig,
+    peer_manager: Option<Arc<PeerManager<CommsPublicKey, CommsDataStore>>>,
+    peer_manager_factory: PeerManagerFactory,
+    node_identity_factory: NodeIdentityFactory<CommsPublicKey>,
+    node_identity: Option<Arc<NodeIdentity<CommsPublicKey>>>,
+}
+
+impl ConnectionManagerFactory {
+    factory_setter!(
+        with_peer_connection_config,
+        peer_connection_config,
+        PeerConnectionConfig
+    );
+
+    factory_setter!(
+        with_peer_manager,
+        peer_manager,
+        Option<Arc<PeerManager<CommsPublicKey, CommsDataStore>>>
+    );
+
+    factory_setter!(with_peer_manager_factory, peer_manager_factory, PeerManagerFactory);
+
+    factory_setter!(with_context, comms_context, Option<ZmqContext>);
+
+    factory_setter!(
+        with_node_identity,
+        node_identity,
+        Option<Arc<NodeIdentity<CommsPublicKey>>>
+    );
+
+    factory_setter!(
+        with_node_identity_factory,
+        node_identity_factory,
+        NodeIdentityFactory<CommsPublicKey>
+    );
+}
+
+impl TestFactory for ConnectionManagerFactory {
+    type Object = ConnectionManager;
+
+    fn build(self) -> Result<Self::Object, TestFactoryError> {
+        let comms_context = self.comms_context.unwrap_or(ZmqContext::new());
+
+        let peer_manager = self
+            .peer_manager
+            .or(Some(Arc::new(self.peer_manager_factory.build()?)))
+            .unwrap();
+
+        let node_identity = self
+            .node_identity
+            .or(Some(Arc::new(self.node_identity_factory.build()?)))
+            .unwrap();
+
+        let config = self.peer_connection_config;
+
+        let conn_manager = ConnectionManager::new(comms_context, node_identity, peer_manager, config);
+
+        Ok(conn_manager)
+    }
+}

--- a/comms/tests/support/factories/connection_manager.rs
+++ b/comms/tests/support/factories/connection_manager.rs
@@ -40,7 +40,7 @@ pub fn create() -> ConnectionManagerFactory {
 
 #[derive(Default)]
 pub struct ConnectionManagerFactory {
-    comms_context: Option<ZmqContext>,
+    zmq_context: Option<ZmqContext>,
     peer_connection_config: PeerConnectionConfig,
     peer_manager: Option<Arc<PeerManager<CommsPublicKey, CommsDataStore>>>,
     peer_manager_factory: PeerManagerFactory,
@@ -63,7 +63,7 @@ impl ConnectionManagerFactory {
 
     factory_setter!(with_peer_manager_factory, peer_manager_factory, PeerManagerFactory);
 
-    factory_setter!(with_context, comms_context, Option<ZmqContext>);
+    factory_setter!(with_context, zmq_context, Option<ZmqContext>);
 
     factory_setter!(
         with_node_identity,
@@ -82,7 +82,7 @@ impl TestFactory for ConnectionManagerFactory {
     type Object = ConnectionManager;
 
     fn build(self) -> Result<Self::Object, TestFactoryError> {
-        let comms_context = self.comms_context.unwrap_or(ZmqContext::new());
+        let zmq_context = self.zmq_context.unwrap_or(ZmqContext::new());
 
         let peer_manager = self
             .peer_manager
@@ -96,7 +96,7 @@ impl TestFactory for ConnectionManagerFactory {
 
         let config = self.peer_connection_config;
 
-        let conn_manager = ConnectionManager::new(comms_context, node_identity, peer_manager, config);
+        let conn_manager = ConnectionManager::new(zmq_context, node_identity, peer_manager, config);
 
         Ok(conn_manager)
     }

--- a/comms/tests/support/factories/mod.rs
+++ b/comms/tests/support/factories/mod.rs
@@ -27,7 +27,11 @@ use serde::export::fmt::Debug;
 mod macros;
 
 #[allow(dead_code)]
+pub mod connection_manager;
+#[allow(dead_code)]
 pub mod net_address;
+#[allow(dead_code)]
+pub mod node_identity;
 #[allow(dead_code)]
 pub mod peer;
 #[allow(dead_code)]
@@ -37,22 +41,22 @@ pub mod peer_connection_context;
 #[allow(dead_code)]
 pub mod peer_manager;
 
-pub trait Factory: Default {
+pub trait TestFactory: Default {
     type Object;
 
-    fn build(self) -> Result<Self::Object, FactoryError>;
+    fn build(self) -> Result<Self::Object, TestFactoryError>;
 }
 
 #[derive(Debug, Error)]
-pub enum FactoryError {
+pub enum TestFactoryError {
     /// Failed to build object
     #[error(msg_embedded, non_std, no_from)]
     BuildFailed(String),
 }
 
-impl FactoryError {
+impl TestFactoryError {
     pub fn build_failed<E>() -> impl Fn(E) -> Self
     where E: Debug {
-        |err| FactoryError::BuildFailed(format!("Factory failed to build: {:?}", err))
+        |err| TestFactoryError::BuildFailed(format!("Factory failed to build: {:?}", err))
     }
 }

--- a/comms/tests/support/factories/net_address.rs
+++ b/comms/tests/support/factories/net_address.rs
@@ -20,7 +20,7 @@
 //  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 //  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use super::{Factory, FactoryError};
+use super::{TestFactory, TestFactoryError};
 
 use crate::support::helpers::ports::get_next_local_port;
 
@@ -53,10 +53,10 @@ impl NetAddressesFactory {
     }
 }
 
-impl Factory for NetAddressesFactory {
+impl TestFactory for NetAddressesFactory {
     type Object = Vec<NetAddress>;
 
-    fn build(self) -> Result<Self::Object, FactoryError> {
+    fn build(self) -> Result<Self::Object, TestFactoryError> {
         Ok(repeat_with(|| self.make_one())
             .take(self.count.or(Some(1)).unwrap())
             .collect::<Vec<NetAddress>>())
@@ -95,10 +95,10 @@ impl NetAddressFactory {
     }
 }
 
-impl Factory for NetAddressFactory {
+impl TestFactory for NetAddressFactory {
     type Object = NetAddress;
 
-    fn build(self) -> Result<Self::Object, FactoryError> {
+    fn build(self) -> Result<Self::Object, TestFactoryError> {
         let host = self.host.clone().or(Some("127.0.0.1".to_string())).unwrap();
         let port = self
             .port
@@ -114,6 +114,6 @@ impl Factory for NetAddressFactory {
 
         format!("{}:{}", host, port)
             .parse()
-            .map_err(|err| FactoryError::BuildFailed(format!("Failed to build NetAddress: {:?}", err)))
+            .map_err(|err| TestFactoryError::BuildFailed(format!("Failed to build NetAddress: {:?}", err)))
     }
 }

--- a/comms/tests/support/factories/node_identity.rs
+++ b/comms/tests/support/factories/node_identity.rs
@@ -1,0 +1,96 @@
+//  Copyright 2019 The Tari Project
+//
+//  Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+//  following conditions are met:
+//
+//  1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+//  disclaimer.
+//
+//  2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+//  following disclaimer in the documentation and/or other materials provided with the distribution.
+//
+//  3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+//  products derived from this software without specific prior written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+//  INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+//  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+//  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+//  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+//  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+//  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+use super::{TestFactory, TestFactoryError};
+use rand::OsRng;
+use tari_comms::{
+    connection::NetAddress,
+    peer_manager::{NodeId, NodeIdentity, PeerNodeIdentity},
+};
+use tari_crypto::keys::{PublicKey, SecretKey};
+use tari_utilities::Hashable;
+
+pub fn create<PK>() -> NodeIdentityFactory<PK>
+where PK: PublicKey {
+    NodeIdentityFactory::<PK>::default()
+}
+
+#[derive(Default, Clone)]
+pub struct NodeIdentityFactory<PK>
+where PK: PublicKey
+{
+    control_service_address: Option<NetAddress>,
+    secret_key: Option<PK::K>,
+    public_key: Option<PK>,
+    node_id: Option<NodeId>,
+}
+
+impl<PK> NodeIdentityFactory<PK>
+where PK: PublicKey
+{
+    factory_setter!(
+        with_control_service_address,
+        control_service_address,
+        Option<NetAddress>
+    );
+
+    factory_setter!(with_secret_key, secret_key, Option<PK::K>);
+
+    factory_setter!(with_public_key, public_key, Option<PK>);
+
+    factory_setter!(with_node_id, node_id, Option<NodeId>);
+}
+
+impl<PK> TestFactory for NodeIdentityFactory<PK>
+where
+    PK: PublicKey,
+    PK: Hashable,
+{
+    type Object = NodeIdentity<PK>;
+
+    fn build(self) -> Result<Self::Object, TestFactoryError> {
+        // Generate a test identity, set it and return it
+        let secret_key = self
+            .secret_key
+            .or(Some(PK::K::random(
+                &mut OsRng::new().map_err(TestFactoryError::build_failed())?,
+            )))
+            .unwrap();
+        let public_key = self.public_key.or(Some(PK::from_secret_key(&secret_key))).unwrap();
+        let node_id = self
+            .node_id
+            .or(Some(
+                NodeId::from_key(&public_key).map_err(TestFactoryError::build_failed())?,
+            ))
+            .unwrap();
+        let control_service_address = self
+            .control_service_address
+            .or(Some(super::net_address::create().build()?))
+            .unwrap();
+
+        Ok(NodeIdentity {
+            identity: PeerNodeIdentity::new(node_id, public_key),
+            secret_key,
+            control_service_address,
+        })
+    }
+}

--- a/comms/tests/support/factories/peer.rs
+++ b/comms/tests/support/factories/peer.rs
@@ -20,7 +20,7 @@
 //  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 //  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use super::{net_address::NetAddressesFactory, Factory, FactoryError};
+use super::{net_address::NetAddressesFactory, TestFactory, TestFactoryError};
 
 use tari_comms::{
     connection::NetAddress,
@@ -61,10 +61,10 @@ impl PeerFactory {
     factory_setter!(with_net_addresses, net_addresses, Option<Vec<NetAddress>>);
 }
 
-impl Factory for PeerFactory {
+impl TestFactory for PeerFactory {
     type Object = Peer<CommsPublicKey>;
 
-    fn build(self) -> Result<Self::Object, FactoryError> {
+    fn build(self) -> Result<Self::Object, TestFactoryError> {
         let node_id = self.node_id.clone().or(Some(node_id_maker::make_node_id())).unwrap();
         let flags = self.flags.clone().or(Some(PeerFlags::empty())).unwrap().clone();
         let public_key = self
@@ -79,7 +79,7 @@ impl Factory for PeerFactory {
         let addresses =
             self.net_addresses
                 .or(self.net_addresses_factory.build().ok())
-                .ok_or(FactoryError::BuildFailed(format!(
+                .ok_or(TestFactoryError::BuildFailed(format!(
                     "Failed to build net addresses for peer"
                 )))?;
 
@@ -110,10 +110,10 @@ impl PeersFactory {
     }
 }
 
-impl Factory for PeersFactory {
+impl TestFactory for PeersFactory {
     type Object = Vec<Peer<CommsPublicKey>>;
 
-    fn build(self) -> Result<Self::Object, FactoryError> {
+    fn build(self) -> Result<Self::Object, TestFactoryError> {
         Ok(repeat_with(|| self.create_peer())
             .take(self.count.or(Some(1)).unwrap())
             .collect::<Vec<Peer<CommsPublicKey>>>())

--- a/comms/tests/support/factories/peer_connection.rs
+++ b/comms/tests/support/factories/peer_connection.rs
@@ -20,7 +20,7 @@
 //  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 //  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use super::{peer_connection_context::PeerConnectionContextFactory, Factory, FactoryError};
+use super::{peer_connection_context::PeerConnectionContextFactory, TestFactory, TestFactoryError};
 
 use tari_comms::connection::{CurvePublicKey, CurveSecretKey, PeerConnection};
 
@@ -40,17 +40,18 @@ impl<'c> PeerConnectionFactory<'c> {
     }
 }
 
-impl<'c> Factory for PeerConnectionFactory<'c> {
+impl<'c> TestFactory for PeerConnectionFactory<'c> {
     type Object = (PeerConnection, CurveSecretKey, CurvePublicKey);
 
-    fn build(self) -> Result<Self::Object, FactoryError> {
+    fn build(self) -> Result<Self::Object, TestFactoryError> {
         let (peer_conn_context, secret_key, public_key) = self
             .peer_connection_context_factory
             .build()
-            .map_err(FactoryError::build_failed())?;
+            .map_err(TestFactoryError::build_failed())?;
 
         let mut conn = PeerConnection::new();
-        conn.start(peer_conn_context).map_err(FactoryError::build_failed())?;
+        conn.start(peer_conn_context)
+            .map_err(TestFactoryError::build_failed())?;
 
         Ok((conn, secret_key, public_key))
     }

--- a/comms/tests/support/factories/peer_manager.rs
+++ b/comms/tests/support/factories/peer_manager.rs
@@ -20,7 +20,7 @@
 //  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 //  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use super::{peer::PeersFactory, Factory, FactoryError};
+use super::{peer::PeersFactory, TestFactory, TestFactoryError};
 
 use tari_comms::{
     peer_manager::{Peer, PeerManager},
@@ -43,20 +43,20 @@ impl PeerManagerFactory {
     factory_setter!(with_peers, peers, Option<Vec<Peer<CommsPublicKey>>>);
 }
 
-impl Factory for PeerManagerFactory {
+impl TestFactory for PeerManagerFactory {
     type Object = PeerManager<CommsPublicKey, CommsDataStore>;
 
-    fn build(self) -> Result<Self::Object, FactoryError> {
+    fn build(self) -> Result<Self::Object, TestFactoryError> {
         let pm = PeerManager::<CommsPublicKey, CommsDataStore>::new(None)
-            .map_err(|err| FactoryError::BuildFailed(format!("Failed to build peer manager: {:?}", err)))?;
+            .map_err(|err| TestFactoryError::BuildFailed(format!("Failed to build peer manager: {:?}", err)))?;
 
         let peers = self
             .peers
             .or(self.peers_factory.build().ok())
-            .ok_or(FactoryError::BuildFailed("Failed to build peers".into()))?;
+            .ok_or(TestFactoryError::BuildFailed("Failed to build peers".into()))?;
         for peer in peers {
             pm.add_peer(peer)
-                .map_err(|err| FactoryError::BuildFailed(format!("Failed to build peer manager: {:?}", err)))?;
+                .map_err(|err| TestFactoryError::BuildFailed(format!("Failed to build peer manager: {:?}", err)))?;
         }
         Ok(pm)
     }

--- a/comms/tests/support/helpers/connection_message_counter.rs
+++ b/comms/tests/support/helpers/connection_message_counter.rs
@@ -22,7 +22,7 @@
 
 use log::*;
 
-use tari_comms::connection::{zmq::ZmqEndpoint, Connection, Context, Direction};
+use tari_comms::connection::{zmq::ZmqEndpoint, Connection, Direction, ZmqContext};
 
 use std::{
     sync::{Arc, RwLock},
@@ -34,11 +34,11 @@ const LOG_TARGET: &'static str = "comms::test_support::connection_message_counte
 
 pub struct ConnectionMessageCounter<'c> {
     counter: Arc<RwLock<u32>>,
-    context: &'c Context,
+    context: &'c ZmqContext,
 }
 
 impl<'c> ConnectionMessageCounter<'c> {
-    pub fn new(context: &'c Context) -> Self {
+    pub fn new(context: &'c ZmqContext) -> Self {
         Self {
             counter: Arc::new(RwLock::new(0)),
             context,

--- a/comms/tests/support/mod.rs
+++ b/comms/tests/support/mod.rs
@@ -24,7 +24,6 @@
 mod macros;
 
 pub mod comms_patterns;
-pub mod node_identity;
 
 pub mod factories;
 pub mod helpers;

--- a/infrastructure/crypto/src/keys.rs
+++ b/infrastructure/crypto/src/keys.rs
@@ -76,8 +76,7 @@ pub trait PublicKey:
 
 /// This trait provides a common mechanism to calculate a shared secret using the private and public key of two parties
 pub trait DiffieHellmanSharedSecret: ByteArray + Clone + PartialEq + Eq + Add<Output = Self> + Default {
-    type K: SecretKey;
     type PK: PublicKey;
     /// Generate a shared secret from one party's private key and another party's public key
-    fn shared_secret(k: &Self::K, pk: &Self::PK) -> Self::PK;
+    fn shared_secret(k: &<Self::PK as PublicKey>::K, pk: &Self::PK) -> Self::PK;
 }

--- a/infrastructure/crypto/src/ristretto/ristretto_keys.rs
+++ b/infrastructure/crypto/src/ristretto/ristretto_keys.rs
@@ -232,11 +232,10 @@ impl PublicKey for RistrettoPublicKey {
 }
 
 impl DiffieHellmanSharedSecret for RistrettoPublicKey {
-    type K = RistrettoSecretKey;
     type PK = RistrettoPublicKey;
 
     /// Generate a shared secret from one party's private key and another party's public key
-    fn shared_secret(k: &Self::K, pk: &Self::PK) -> Self::PK {
+    fn shared_secret(k: &<Self::PK as PublicKey>::K, pk: &Self::PK) -> Self::PK {
         k * pk
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This should be the last of the large refactors on the comms layer. This PR introduces a CommsBuilder which is the  public interface for starting up the various comms services. 

What was done:
- Renamed Context to `ZmqContext`
- Added CommsBuilder 
- Control Service will now send a domain-level message type to the peer connection
- Refactored the generics to make them simpler to use - the only generic we need to know from the domain layer is 'what type of the MessageType'.
- Removed some message copies 
- Removed the global node identity static in favour of passing the node identity to the components which require it
- More sensible defaults to make the public api simpler
- Added test factories for connection manager
- Some docs

What needs to be completed:
- Tech debt (docs and tests)
- Comms builder will need some work but this should work for hooking things up

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #367 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Existing tests pass (with  updates to accommodate breaking api changes)
Basic comms builder test

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [x] Breaking change (fix or feature that would cause existing functionality to change)
* [x] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [x] New Tests
* [x] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch
* [x] I ran `cargo-fmt --all` before pushing
* [x] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [~] I have added tests to cover my changes.
