### PR TITLE
Block builder additional coinbase constructer function

### DIFF
--- a/base_layer/core/src/transaction.rs
+++ b/base_layer/core/src/transaction.rs
@@ -30,7 +30,7 @@ use crate::{
 
 use crate::{
     transaction_protocol::{build_challenge, TransactionMetadata},
-    types::{HashDigest, PublicKey, RangeProof, RangeProofService, SecretKey},
+    types::{HashDigest, PrivateKey, PublicKey, RangeProof, RangeProofService},
 };
 use derive_error::Error;
 use digest::Input;
@@ -413,7 +413,7 @@ impl Transaction {
 
     /// Calculate the sum of the inputs and outputs including the fees
     fn sum_commitments(&self, fees: u64, factory: &CommitmentFactory) -> Commitment {
-        let fee_commitment = factory.commit(&SecretKey::default(), &SecretKey::from(fees));
+        let fee_commitment = factory.commit(&PrivateKey::default(), &PrivateKey::from(fees));
         let sum_inputs = &self.body.inputs.iter().map(|i| &i.commitment).sum::<Commitment>();
         let sum_outputs = &self.body.outputs.iter().map(|o| &o.commitment).sum::<Commitment>();
         &(sum_outputs - sum_inputs) + &fee_commitment
@@ -624,7 +624,7 @@ mod test {
                 TransactionError::ValidationError("Range proof could not be verified".to_string())
             ),
         }
-        let v = SecretKey::from(2u64.pow(32) + 1);
+        let v = PrivateKey::from(2u64.pow(32) + 1);
         let c = factory.commit(&k2, &v);
         let proof = prover.construct_proof(&k2, 2u64.pow(32) + 1).unwrap();
         let tx_output3 = TransactionOutput::new(OutputFeatures::empty(), c, RangeProof::from_bytes(&proof).unwrap());

--- a/base_layer/core/src/transaction_protocol/recipient.rs
+++ b/base_layer/core/src/transaction_protocol/recipient.rs
@@ -27,7 +27,7 @@ use crate::{
         single_receiver::SingleReceiverTransactionProtocol,
         TransactionProtocolError,
     },
-    types::{CommitmentFactory, MessageHash, PublicKey, RangeProofService, SecretKey, Signature},
+    types::{CommitmentFactory, MessageHash, PrivateKey, PublicKey, RangeProofService, Signature},
 };
 use std::collections::HashMap;
 pub enum RecipientState {
@@ -75,8 +75,8 @@ pub struct ReceiverTransactionProtocol {
 impl ReceiverTransactionProtocol {
     pub fn new(
         info: SenderMessage,
-        nonce: SecretKey,
-        spending_key: SecretKey,
+        nonce: PrivateKey,
+        spending_key: PrivateKey,
         features: OutputFeatures,
         prover: &RangeProofService,
         factory: &CommitmentFactory,
@@ -126,8 +126,8 @@ impl ReceiverTransactionProtocol {
 
     /// Run the single-round recipient protocol, which can immediately construct an output and sign the data
     fn single_round(
-        nonce: SecretKey,
-        key: SecretKey,
+        nonce: PrivateKey,
+        key: PrivateKey,
         features: OutputFeatures,
         data: &SD,
         prover: &RangeProofService,

--- a/base_layer/core/src/transaction_protocol/sender.rs
+++ b/base_layer/core/src/transaction_protocol/sender.rs
@@ -22,7 +22,7 @@
 
 use crate::{
     transaction::{KernelFeatures, Transaction, TransactionBuilder, TransactionInput, TransactionOutput},
-    types::{BlindingFactor, CommitmentFactory, PublicKey, RangeProofService, SecretKey, Signature},
+    types::{BlindingFactor, CommitmentFactory, PrivateKey, PublicKey, RangeProofService, Signature},
 };
 
 use crate::{
@@ -59,7 +59,7 @@ pub(super) struct RawTransactionInfo {
     pub offset_blinding_factor: BlindingFactor,
     pub public_excess: PublicKey,
     // The sender's private nonce
-    pub private_nonce: SecretKey,
+    pub private_nonce: PrivateKey,
     // The sender's public nonce
     pub public_nonce: PublicKey,
     // The sum of all public nonces

--- a/base_layer/core/src/transaction_protocol/single_receiver.rs
+++ b/base_layer/core/src/transaction_protocol/single_receiver.rs
@@ -28,7 +28,7 @@ use crate::{
         sender::SingleRoundSenderData as SD,
         TransactionProtocolError as TPE,
     },
-    types::{CommitmentFactory, PublicKey, RangeProof, RangeProofService, SecretKey as SK, Signature},
+    types::{CommitmentFactory, PrivateKey as SK, PublicKey, RangeProof, RangeProofService, Signature},
 };
 use tari_crypto::{
     commitment::HomomorphicCommitmentFactory,
@@ -109,7 +109,7 @@ mod test {
             TransactionMetadata,
             TransactionProtocolError,
         },
-        types::{PublicKey, SecretKey, COMMITMENT_FACTORY, PROVER},
+        types::{PrivateKey, PublicKey, COMMITMENT_FACTORY, PROVER},
     };
     use rand::OsRng;
     use tari_crypto::{
@@ -117,10 +117,10 @@ mod test {
         keys::{PublicKey as PK, SecretKey as SK},
     };
 
-    fn generate_output_parms() -> (SecretKey, SecretKey, OutputFeatures) {
+    fn generate_output_parms() -> (PrivateKey, PrivateKey, OutputFeatures) {
         let mut rng = OsRng::new().unwrap();
-        let r = SecretKey::random(&mut rng);
-        let k = SecretKey::random(&mut rng);
+        let r = PrivateKey::random(&mut rng);
+        let k = PrivateKey::random(&mut rng);
         let of = OutputFeatures::empty();
         (r, k, of)
     }

--- a/base_layer/core/src/transaction_protocol/test_common.rs
+++ b/base_layer/core/src/transaction_protocol/test_common.rs
@@ -24,29 +24,29 @@
 
 use crate::{
     transaction::{OutputFeatures, TransactionInput, UnblindedOutput},
-    types::{PublicKey, SecretKey, COMMITMENT_FACTORY},
+    types::{PrivateKey, PublicKey, COMMITMENT_FACTORY},
 };
 use rand::{CryptoRng, Rng};
 use tari_crypto::{
     commitment::HomomorphicCommitmentFactory,
-    keys::{PublicKey as PK, SecretKey as SK},
+    keys::{PublicKey as PK, SecretKey},
 };
 
 pub struct TestParams {
-    pub spend_key: SecretKey,
-    pub change_key: SecretKey,
-    pub offset: SecretKey,
-    pub nonce: SecretKey,
+    pub spend_key: PrivateKey,
+    pub change_key: PrivateKey,
+    pub offset: PrivateKey,
+    pub nonce: PrivateKey,
     pub public_nonce: PublicKey,
 }
 
 impl TestParams {
     pub fn new<R: Rng + CryptoRng>(rng: &mut R) -> TestParams {
-        let r = SecretKey::random(rng);
+        let r = PrivateKey::random(rng);
         TestParams {
-            spend_key: SecretKey::random(rng),
-            change_key: SecretKey::random(rng),
-            offset: SecretKey::random(rng),
+            spend_key: PrivateKey::random(rng),
+            change_key: PrivateKey::random(rng),
+            offset: PrivateKey::random(rng),
             public_nonce: PublicKey::from_secret_key(&r),
             nonce: r,
         }
@@ -54,8 +54,8 @@ impl TestParams {
 }
 
 pub fn make_input<R: Rng + CryptoRng>(rng: &mut R, val: u64) -> (TransactionInput, UnblindedOutput) {
-    let key = SecretKey::random(rng);
-    let v = SecretKey::from(val);
+    let key = PrivateKey::random(rng);
+    let v = PrivateKey::from(val);
     let commitment = COMMITMENT_FACTORY.commit(&key, &v);
     let input = TransactionInput::new(OutputFeatures::empty(), commitment);
     (input, UnblindedOutput::new(val, key, None))

--- a/base_layer/core/src/transaction_protocol/transaction_initializer.rs
+++ b/base_layer/core/src/transaction_protocol/transaction_initializer.rs
@@ -35,7 +35,7 @@ use crate::{
         sender::{calculate_tx_id, RawTransactionInfo, SenderState, SenderTransactionProtocol},
         TransactionMetadata,
     },
-    types::{BlindingFactor, CommitmentFactory, PublicKey, RangeProofService, SecretKey},
+    types::{BlindingFactor, CommitmentFactory, PrivateKey, PublicKey, RangeProofService},
 };
 use digest::Digest;
 use std::{
@@ -66,7 +66,7 @@ pub struct SenderTransactionInitializer {
     change_secret: Option<BlindingFactor>,
     offset: Option<BlindingFactor>,
     excess_blinding_factor: BlindingFactor,
-    private_nonce: Option<SecretKey>,
+    private_nonce: Option<PrivateKey>,
 }
 
 pub struct BuildError {
@@ -146,7 +146,7 @@ impl SenderTransactionInitializer {
     }
 
     /// Provide the private nonce that will be used for the sender's partial signature for the transaction.
-    pub fn with_private_nonce(&mut self, nonce: SecretKey) -> &mut Self {
+    pub fn with_private_nonce(&mut self, nonce: PrivateKey) -> &mut Self {
         self.private_nonce = Some(nonce);
         self
     }

--- a/base_layer/core/src/types.rs
+++ b/base_layer/core/src/types.rs
@@ -46,7 +46,7 @@ pub type Commitment = PedersenCommitment;
 pub type CommitmentFactory = PedersenCommitmentFactory;
 
 /// Define the explicit Secret key implementation for the Tari base layer.
-pub type SecretKey = RistrettoSecretKey;
+pub type PrivateKey = RistrettoSecretKey;
 pub type BlindingFactor = RistrettoSecretKey;
 
 /// Define the explicit Public key implementation for the Tari base layer
@@ -74,6 +74,8 @@ pub const MAX_RANGE_PROOF_RANGE: usize = 64; // 2^64
 
 /// Current version of the blockchain
 pub const BLOCKCHAIN_VERSION: u16 = 0;
+/// The min required lock height before coinbase utxos are spendable
+pub const COINBASE_LOCK_HEIGHT: u64 = 1440;
 
 // Set up some "global" services for the Tari blockchain - These are most likely not threadsafe as written, but haven't
 // checked.

--- a/base_layer/wallet/src/transaction_manager.rs
+++ b/base_layer/wallet/src/transaction_manager.rs
@@ -29,7 +29,7 @@ use tari_core::{
         sender::SenderMessage,
         TransactionProtocolError,
     },
-    types::{CommitmentFactory, RangeProofService, SecretKey},
+    types::{CommitmentFactory, PrivateKey, RangeProofService},
     ReceiverTransactionProtocol,
     SenderTransactionProtocol,
 };
@@ -149,8 +149,8 @@ impl TransactionManager {
     pub fn accept_transaction(
         &mut self,
         sender_message: SenderMessage,
-        nonce: SecretKey,
-        spending_key: SecretKey,
+        nonce: PrivateKey,
+        spending_key: PrivateKey,
         prover: &RangeProofService,
         factory: &CommitmentFactory,
     ) -> Result<RecipientSignedTransactionData, TransactionManagerError>
@@ -206,7 +206,7 @@ mod test {
     use tari_core::{
         transaction::{OutputFeatures, TransactionInput, UnblindedOutput},
         transaction_protocol::{sender::SenderMessage, TransactionProtocolError},
-        types::{PublicKey, RangeProof, SecretKey, COMMITMENT_FACTORY, PROVER},
+        types::{PrivateKey, PublicKey, RangeProof, COMMITMENT_FACTORY, PROVER},
         SenderTransactionProtocol,
     };
     use tari_crypto::{
@@ -217,20 +217,20 @@ mod test {
     use tari_utilities::ByteArray;
 
     pub struct TestParams {
-        pub spend_key: SecretKey,
-        pub change_key: SecretKey,
-        pub offset: SecretKey,
-        pub nonce: SecretKey,
+        pub spend_key: PrivateKey,
+        pub change_key: PrivateKey,
+        pub offset: PrivateKey,
+        pub nonce: PrivateKey,
         pub public_nonce: PublicKey,
     }
 
     impl TestParams {
         pub fn new<R: Rng + CryptoRng>(rng: &mut R) -> TestParams {
-            let r = SecretKey::random(rng);
+            let r = PrivateKey::random(rng);
             TestParams {
-                spend_key: SecretKey::random(rng),
-                change_key: SecretKey::random(rng),
-                offset: SecretKey::random(rng),
+                spend_key: PrivateKey::random(rng),
+                change_key: PrivateKey::random(rng),
+                offset: PrivateKey::random(rng),
                 public_nonce: PublicKey::from_secret_key(&r),
                 nonce: r,
             }
@@ -238,7 +238,7 @@ mod test {
     }
 
     pub fn make_input<R: Rng + CryptoRng>(rng: &mut R, val: u64) -> (TransactionInput, UnblindedOutput) {
-        let key = SecretKey::random(rng);
+        let key = PrivateKey::random(rng);
         let commitment = COMMITMENT_FACTORY.commit_value(&key, val);
         let input = TransactionInput::new(OutputFeatures::empty(), commitment);
         (input, UnblindedOutput::new(val, key, None))


### PR DESCRIPTION
Added additional coinbase constructer function
Renamed Type::SecretKey to Type::PrivateKey because we already have a SecretKey trait

## Motivation and Context
The current coinbase function in the block builder might not be very usefull. The new one only takes a SecretKey in as parameter to construct the coinbase.  


## Types of changes
* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [x] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
* [x] I'm merging against the `development` branch
* [x] I ran `cargo-fmt --all` before pushing
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
