### PR TITLE
Allow OMS, IMS and OMP to shutdown cleanly

### DIFF
--- a/base_layer/p2p/Cargo.toml
+++ b/base_layer/p2p/Cargo.toml
@@ -18,6 +18,6 @@ rand = "0.6.5"
 crossbeam-channel = "0.3.8"
 
 [dev-dependencies]
-tari_storage = { version = "0.0.1", path = "../../infrastructure/storage"}
+tari_storage = { version = "0.0.2", path = "../../infrastructure/storage"}
 tempdir = "0.3.7"
 simple_logger = "1.3.0"

--- a/base_layer/p2p/src/ping_pong.rs
+++ b/base_layer/p2p/src/ping_pong.rs
@@ -337,8 +337,6 @@ impl PingPongServiceApi {
 #[cfg(test)]
 mod test {
     use super::*;
-    use rand::rngs::OsRng;
-    use tari_crypto::keys::PublicKey;
 
     #[test]
     fn new() {

--- a/comms/Cargo.toml
+++ b/comms/Cargo.toml
@@ -22,7 +22,7 @@ serde_derive = "1.0.90"
 tari_crypto = { path = "../infrastructure/crypto"}
 tari_utilities = { path = "../infrastructure/tari_util"}
 tari_storage = { path = "../infrastructure/storage"}
-zmq = "0.9"
+zmq = "0.9.1"
 digest = "0.8.0"
 
 [dev-dependencies]

--- a/comms/src/connection/connection.rs
+++ b/comms/src/connection/connection.rs
@@ -357,6 +357,10 @@ impl EstablishedConnection {
     pub(crate) fn get_socket(&self) -> &zmq::Socket {
         &self.socket
     }
+
+    pub(crate) fn get_mut_socket(&mut self) -> &mut zmq::Socket {
+        &mut self.socket
+    }
 }
 
 impl Drop for EstablishedConnection {

--- a/comms/src/connection/peer_connection/mod.rs
+++ b/comms/src/connection/peer_connection/mod.rs
@@ -90,5 +90,6 @@ mod worker;
 pub use self::{
     connection::{ConnectionId, PeerConnection, PeerConnectionSimpleState},
     context::{PeerConnectionContext, PeerConnectionContextBuilder},
+    control::ControlMessage,
     error::PeerConnectionError,
 };

--- a/comms/src/inbound_message_service/error.rs
+++ b/comms/src/inbound_message_service/error.rs
@@ -35,4 +35,8 @@ pub enum InboundMessageServiceError {
     InboundConnectionError(ConnectionError),
     DealerProxyError(DealerProxyError),
     BrokerError(BrokerError),
+    #[error(msg_embedded, non_std, no_from)]
+    ControlSendError(String),
+    /// Could not join the dealer or worker threads
+    ThreadJoinError,
 }

--- a/comms/src/outbound_message_service/error.rs
+++ b/comms/src/outbound_message_service/error.rs
@@ -21,7 +21,7 @@
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE
 
 use crate::{
-    connection::{ConnectionError, NetAddressError, PeerConnectionError},
+    connection::{dealer_proxy::DealerProxyError, ConnectionError, NetAddressError, PeerConnectionError},
     connection_manager::ConnectionManagerError,
     message::MessageError,
     peer_manager::peer_manager::PeerManagerError,
@@ -62,4 +62,9 @@ pub enum OutboundError {
     PeerConnectionError(PeerConnectionError),
     /// Number of retry attempts exceeded
     RetryAttemptsExceedError,
+    #[error(msg_embedded, non_std, no_from)]
+    ControlSendError(String),
+    DealerProxyError(DealerProxyError),
+    /// Could not join the dealer or worker threads
+    ThreadJoinError,
 }

--- a/comms/tests/outbound_message_service/outbound_message_pool.rs
+++ b/comms/tests/outbound_message_service/outbound_message_pool.rs
@@ -122,7 +122,7 @@ mod test {
         // Setup Node A OMP and OMS
         let omp_inbound_address = InprocAddress::random();
         let omp_config = OutboundMessagePoolConfig::default();
-        let omp = OutboundMessagePool::new(
+        let mut omp = OutboundMessagePool::new(
             omp_config.clone(),
             context.clone(),
             omp_inbound_address.clone(),
@@ -215,7 +215,7 @@ mod test {
             retry_wait_time: chrono::Duration::milliseconds(100),
             worker_timeout_in_ms: 100,
         };
-        let omp = OutboundMessagePool::new(
+        let mut omp = OutboundMessagePool::new(
             omp_config.clone(),
             context.clone(),
             omp_inbound_address.clone(),
@@ -233,7 +233,7 @@ mod test {
         )
         .unwrap();
 
-        let _omp = omp.start();
+        omp.start();
         let message_envelope_body: Vec<u8> = vec![0, 1, 2, 3];
 
         // Now check that the requeuing happens


### PR DESCRIPTION
## Description
- Changed DealerProxy to allow shutdown. of dealer and make use of proxy_steerable
- Update IMS, OMS and Workers to allow safe shutdown using Control Messages
- Modified tests to demonstrate safe shutdown

## Motivation and Context
Shutdown of threads and dealers were unsafe

## How Has This Been Tested?
Tests were modified

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [x] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [x] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch
* [x] I ran `cargo-fmt --all` before pushing
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
