### PR TITLE
NodeId de/serialized to/from hex

### DIFF
--- a/base_layer/keymanager/src/keymanager.rs
+++ b/base_layer/keymanager/src/keymanager.rs
@@ -27,11 +27,11 @@ use rand::{CryptoRng, Rng};
 use serde::de::DeserializeOwned;
 use serde_derive::{Deserialize, Serialize};
 use std::marker::PhantomData;
-use tari_crypto::{
-    keys::SecretKey,
-    ristretto::serialize::{secret_from_hex, serialize_to_hex},
+use tari_crypto::{keys::SecretKey, ristretto::serialize::secret_from_hex};
+use tari_utilities::{
+    byte_array::ByteArrayError,
+    hex::{serialize_to_hex, Hex},
 };
-use tari_utilities::{byte_array::ByteArrayError, hex::Hex};
 
 #[derive(Debug, Error)]
 pub enum KeyManagerError {

--- a/comms/Cargo.toml
+++ b/comms/Cargo.toml
@@ -30,6 +30,7 @@ criterion = "0.2"
 rand = "0.5.5"
 tari_common = { path = "../common"}
 simple_logger = "1.2.0"
+serde_json = "1.0.39"
 
 [[bench]]
 name = "benches_main"

--- a/comms/src/connection/net_address/net_address_with_stats.rs
+++ b/comms/src/connection/net_address/net_address_with_stats.rs
@@ -3,6 +3,7 @@ use chrono::prelude::*;
 use serde::{Deserialize, Serialize};
 use std::{
     cmp::{Ord, Ordering},
+    fmt,
     time::Duration,
 };
 
@@ -148,6 +149,12 @@ impl PartialOrd for NetAddressWithStats {
 impl PartialEq for NetAddressWithStats {
     fn eq(&self, other: &NetAddressWithStats) -> bool {
         self.net_address == other.net_address
+    }
+}
+
+impl fmt::Display for NetAddressWithStats {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", self.net_address)
     }
 }
 

--- a/infrastructure/crypto/src/ristretto/serialize.rs
+++ b/infrastructure/crypto/src/ristretto/serialize.rs
@@ -42,17 +42,9 @@
 //! ```
 
 use crate::keys::{PublicKey, SecretKey};
-use serde::{de, Deserializer, Serializer};
+use serde::{de, Deserializer};
 use std::{fmt, marker::PhantomData};
 use tari_utilities::hex::Hex;
-
-pub fn serialize_to_hex<S, K>(k: &K, ser: S) -> Result<S::Ok, S::Error>
-where
-    S: Serializer,
-    K: Hex,
-{
-    ser.serialize_str(&k.to_hex())
-}
 
 pub fn secret_from_hex<'de, D, K>(des: D) -> Result<K, D::Error>
 where

--- a/infrastructure/tari_util/src/hex.rs
+++ b/infrastructure/tari_util/src/hex.rs
@@ -1,4 +1,5 @@
 use derive_error::Error;
+use serde::Serializer;
 use std::{
     fmt::{LowerHex, Write},
     num::ParseIntError,
@@ -65,6 +66,14 @@ pub fn from_hex(hex_str: &str) -> Result<Vec<u8>, HexError> {
         }
     }
     Ok(result)
+}
+
+pub fn serialize_to_hex<S, T>(t: &T, ser: S) -> Result<S::Ok, S::Error>
+where
+    S: Serializer,
+    T: Hex,
+{
+    ser.serialize_str(&t.to_hex())
 }
 
 #[cfg(test)]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
NodeId will now be de/serialized to/from hex, by implementing ByteArray. I moved the serialize_to_hex function from tari_crypto to tari_utilities as the same function can be used for serialization in that crate. I was not able to do the same for deserialization. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
NodeId was serializing to json as an array while public key was a hex string. This change makes the serialization of peers consistent. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Peer serialization to json tested

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [x] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch
* [x] I ran `cargo-fmt --all` before pushing
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
