### PR TITLE
Removed generic type param from NodeIdentity

### DIFF
--- a/base_layer/p2p/tests/ping_pong.rs
+++ b/base_layer/p2p/tests/ping_pong.rs
@@ -71,7 +71,7 @@ where
     }
 }
 
-fn new_node_identity(control_service_address: NetAddress) -> NodeIdentity<CommsPublicKey> {
+fn new_node_identity(control_service_address: NetAddress) -> NodeIdentity {
     NodeIdentity::random(&mut OsRng::new().unwrap(), control_service_address).unwrap()
 }
 
@@ -92,7 +92,7 @@ fn create_peer_storage(tmpdir: &TempDir, name: &str, peers: Vec<Peer<CommsPublic
 }
 
 fn setup_ping_pong_service(
-    node_identity: NodeIdentity<CommsPublicKey>,
+    node_identity: NodeIdentity,
     peer_storage: CommsDataStore,
 ) -> (ServiceExecutor, Arc<PingPongServiceApi>)
 {

--- a/comms/src/builder/builder.rs
+++ b/comms/src/builder/builder.rs
@@ -108,7 +108,7 @@ where MType: Clone
     peer_storage: Option<CommsDataStore>,
     control_service_config: Option<ControlServiceConfig<MType>>,
     omp_config: Option<OutboundMessagePoolConfig>,
-    node_identity: Option<NodeIdentity<CommsPublicKey>>,
+    node_identity: Option<NodeIdentity>,
     peer_conn_config: Option<PeerConnectionConfig>,
 }
 
@@ -153,7 +153,7 @@ where
         self
     }
 
-    pub fn with_node_identity(mut self, node_identity: NodeIdentity<CommsPublicKey>) -> Self {
+    pub fn with_node_identity(mut self, node_identity: NodeIdentity) -> Self {
         self.node_identity = Some(node_identity);
         self
     }
@@ -169,11 +169,7 @@ where
         Ok(Arc::new(peer_manager))
     }
 
-    fn make_control_service(
-        &mut self,
-        node_identity: Arc<NodeIdentity<CommsPublicKey>>,
-    ) -> Option<ControlService<MType>>
-    {
+    fn make_control_service(&mut self, node_identity: Arc<NodeIdentity>) -> Option<ControlService<MType>> {
         self.control_service_config
             .take()
             .map(|config| ControlService::new(self.zmq_context.clone(), node_identity, config))
@@ -181,7 +177,7 @@ where
 
     fn make_connection_manager(
         &mut self,
-        node_identity: Arc<NodeIdentity<CommsPublicKey>>,
+        node_identity: Arc<NodeIdentity>,
         peer_manager: Arc<PeerManager<CommsPublicKey, CommsDataStore>>,
         config: PeerConnectionConfig,
     ) -> Arc<ConnectionManager>
@@ -203,7 +199,7 @@ where
         config
     }
 
-    fn make_node_identity(&mut self) -> Result<Arc<NodeIdentity<CommsPublicKey>>, CommsBuilderError> {
+    fn make_node_identity(&mut self) -> Result<Arc<NodeIdentity>, CommsBuilderError> {
         self.node_identity
             .take()
             .map(Arc::new)
@@ -212,7 +208,7 @@ where
 
     fn make_outbound_message_service(
         &self,
-        node_identity: Arc<NodeIdentity<CommsPublicKey>>,
+        node_identity: Arc<NodeIdentity>,
         message_sink_address: InprocAddress,
         peer_manager: Arc<PeerManager<CommsPublicKey, CommsDataStore>>,
     ) -> Result<Arc<OutboundMessageService>, CommsBuilderError>
@@ -250,7 +246,7 @@ where
 
     fn make_inbound_message_service(
         &mut self,
-        node_identity: Arc<NodeIdentity<CommsPublicKey>>,
+        node_identity: Arc<NodeIdentity>,
         message_sink_address: InprocAddress,
         inbound_message_broker: Arc<InboundMessageBroker<MType>>,
         oms: Arc<OutboundMessageService>,

--- a/comms/src/connection_manager/manager.rs
+++ b/comms/src/connection_manager/manager.rs
@@ -73,7 +73,7 @@ const LOG_TARGET: &'static str = "comms::connection_manager::manager";
 /// assert_eq!(manager.get_active_connection_count(), 0);
 /// ```
 pub struct ConnectionManager {
-    node_identity: Arc<NodeIdentity<CommsPublicKey>>,
+    node_identity: Arc<NodeIdentity>,
     connections: LivePeerConnections,
     establisher: Arc<ConnectionEstablisher<CommsPublicKey>>,
     peer_manager: Arc<PeerManager<CommsPublicKey, CommsDataStore>>,
@@ -84,7 +84,7 @@ impl ConnectionManager {
     /// Create a new connection manager
     pub fn new(
         zmq_context: ZmqContext,
-        node_identity: Arc<NodeIdentity<CommsPublicKey>>,
+        node_identity: Arc<NodeIdentity>,
         peer_manager: Arc<PeerManager<CommsPublicKey, CommsDataStore>>,
         config: PeerConnectionConfig,
     ) -> Self

--- a/comms/src/connection_manager/protocol.rs
+++ b/comms/src/connection_manager/protocol.rs
@@ -35,16 +35,12 @@ use tari_utilities::message_format::MessageFormat;
 const LOG_TARGET: &'static str = "comms::connection_manager::protocol";
 
 pub(crate) struct PeerConnectionProtocol<'e, 'ni> {
-    node_identity: &'ni Arc<NodeIdentity<CommsPublicKey>>,
+    node_identity: &'ni Arc<NodeIdentity>,
     establisher: &'e ConnectionEstablisher<CommsPublicKey>,
 }
 
 impl<'e, 'ni> PeerConnectionProtocol<'e, 'ni> {
-    pub fn new(
-        node_identity: &'ni Arc<NodeIdentity<CommsPublicKey>>,
-        establisher: &'e ConnectionEstablisher<CommsPublicKey>,
-    ) -> Self
-    {
+    pub fn new(node_identity: &'ni Arc<NodeIdentity>, establisher: &'e ConnectionEstablisher<CommsPublicKey>) -> Self {
         Self {
             node_identity,
             establisher,

--- a/comms/src/control_service/service.rs
+++ b/comms/src/control_service/service.rs
@@ -30,7 +30,7 @@ use crate::{
     connection_manager::ConnectionManager,
     control_service::types::ControlServiceDispatcher,
     peer_manager::NodeIdentity,
-    types::{CommsPublicKey, DEFAULT_LISTENER_ADDRESS},
+    types::DEFAULT_LISTENER_ADDRESS,
 };
 use log::*;
 use serde::{de::DeserializeOwned, Serialize};
@@ -117,7 +117,7 @@ where MType: Clone
     context: ZmqContext,
     dispatcher: ControlServiceDispatcher<MType>,
     config: ControlServiceConfig<MType>,
-    node_identity: Arc<NodeIdentity<CommsPublicKey>>,
+    node_identity: Arc<NodeIdentity>,
 }
 
 impl<MType> ControlService<MType>
@@ -126,7 +126,7 @@ where
     MType: Clone,
     MType: Serialize + DeserializeOwned,
 {
-    pub fn with_default_config(context: ZmqContext, node_identity: Arc<NodeIdentity<CommsPublicKey>>) -> Self {
+    pub fn with_default_config(context: ZmqContext, node_identity: Arc<NodeIdentity>) -> Self {
         Self {
             context,
             dispatcher: Default::default(),
@@ -144,12 +144,7 @@ where
 {
     setter!(with_custom_dispatcher, dispatcher, ControlServiceDispatcher<MType>);
 
-    pub fn new(
-        context: ZmqContext,
-        node_identity: Arc<NodeIdentity<CommsPublicKey>>,
-        config: ControlServiceConfig<MType>,
-    ) -> Self
-    {
+    pub fn new(context: ZmqContext, node_identity: Arc<NodeIdentity>, config: ControlServiceConfig<MType>) -> Self {
         Self {
             context,
             dispatcher: Default::default(),

--- a/comms/src/control_service/types.rs
+++ b/comms/src/control_service/types.rs
@@ -74,7 +74,7 @@ where MType: Clone
     pub message: Message,
     pub connection_manager: Arc<ConnectionManager>,
     pub peer_manager: Arc<PeerManager<CommsPublicKey, LMDBStore>>,
-    pub node_identity: Arc<NodeIdentity<CommsPublicKey>>,
+    pub node_identity: Arc<NodeIdentity>,
     pub config: ControlServiceConfig<MType>,
 }
 

--- a/comms/src/control_service/worker.rs
+++ b/comms/src/control_service/worker.rs
@@ -68,7 +68,7 @@ where MType: Clone
     is_running: bool,
     dispatcher: ControlServiceDispatcher<MType>,
     connection_manager: Arc<ConnectionManager>,
-    node_identity: Arc<NodeIdentity<CommsPublicKey>>,
+    node_identity: Arc<NodeIdentity>,
 }
 
 impl<MType> ControlServiceWorker<MType>
@@ -85,7 +85,7 @@ where
     /// - `connection_manager` - the `ConnectionManager`
     pub fn start(
         context: ZmqContext,
-        node_identity: Arc<NodeIdentity<CommsPublicKey>>,
+        node_identity: Arc<NodeIdentity>,
         dispatcher: ControlServiceDispatcher<MType>,
         config: ControlServiceConfig<MType>,
         connection_manager: Arc<ConnectionManager>,

--- a/comms/src/inbound_message_service/inbound_message_service.rs
+++ b/comms/src/inbound_message_service/inbound_message_service.rs
@@ -55,7 +55,7 @@ where
     MType: Serialize + DeserializeOwned,
 {
     context: ZmqContext,
-    node_identity: Arc<NodeIdentity<CommsPublicKey>>,
+    node_identity: Arc<NodeIdentity>,
     dealer_address: InprocAddress,
     message_dispatcher: Arc<MessageDispatcher<MessageContext<MType>>>,
     inbound_message_broker: Arc<InboundMessageBroker<MType>>,
@@ -78,7 +78,7 @@ where
     /// threads
     pub fn new(
         context: ZmqContext,
-        node_identity: Arc<NodeIdentity<CommsPublicKey>>,
+        node_identity: Arc<NodeIdentity>,
         inbound_address: InprocAddress,
         message_dispatcher: Arc<MessageDispatcher<MessageContext<MType>>>,
         inbound_message_broker: Arc<InboundMessageBroker<MType>>,

--- a/comms/src/inbound_message_service/msg_processing_worker.rs
+++ b/comms/src/inbound_message_service/msg_processing_worker.rs
@@ -59,7 +59,7 @@ where
     MType: Serialize + DeserializeOwned,
 {
     context: ZmqContext,
-    node_identity: Arc<NodeIdentity<CommsPublicKey>>,
+    node_identity: Arc<NodeIdentity>,
     inbound_address: InprocAddress,
     message_dispatcher: Arc<MessageDispatcher<MessageContext<MType>>>,
     inbound_message_broker: Arc<InboundMessageBroker<MType>>,
@@ -79,7 +79,7 @@ where
     /// Setup a new MsgProcessingWorker that will read incoming messages and dispatch them using the message_dispatcher
     pub fn new(
         context: ZmqContext,
-        node_identity: Arc<NodeIdentity<CommsPublicKey>>,
+        node_identity: Arc<NodeIdentity>,
         inbound_address: InprocAddress,
         message_dispatcher: Arc<MessageDispatcher<MessageContext<MType>>>,
         inbound_message_broker: Arc<InboundMessageBroker<MType>>,

--- a/comms/src/message/envelope.rs
+++ b/comms/src/message/envelope.rs
@@ -29,7 +29,7 @@ use crate::{
 };
 use rand::OsRng;
 use serde::{Deserialize, Serialize};
-use std::{convert::TryFrom, sync::Arc};
+use std::convert::TryFrom;
 use tari_crypto::keys::{DiffieHellmanSharedSecret, PublicKey};
 use tari_utilities::{ciphers::cipher::Cipher, message_format::MessageFormat};
 
@@ -63,7 +63,7 @@ impl MessageEnvelope {
 
     /// Sign a message, construct a MessageEnvelopeHeader and return the resulting MessageEnvelope
     pub fn construct(
-        node_identity: &Arc<NodeIdentity<CommsPublicKey>>,
+        node_identity: &NodeIdentity,
         dest_public_key: CommsPublicKey,
         dest: NodeDestination<CommsPublicKey>,
         body: Frame,
@@ -209,7 +209,7 @@ mod test {
         ristretto::{RistrettoPublicKey, RistrettoSecretKey},
     };
 
-    use std::convert::TryInto;
+    use std::{convert::TryInto, sync::Arc};
     use tari_utilities::hex::to_hex;
 
     #[test]

--- a/comms/src/message/message_context.rs
+++ b/comms/src/message/message_context.rs
@@ -37,7 +37,7 @@ pub struct MessageContext<MType> {
     pub outbound_message_service: Arc<OutboundMessageService>,
     pub peer_manager: Arc<PeerManager<CommsPublicKey, CommsDataStore>>,
     pub inbound_message_broker: Arc<InboundMessageBroker<MType>>,
-    pub node_identity: Arc<NodeIdentity<CommsPublicKey>>,
+    pub node_identity: Arc<NodeIdentity>,
 }
 
 impl<MType> MessageContext<MType>
@@ -48,7 +48,7 @@ where
     /// Construct a new MessageContext that consist of the peer connection information and the received message header
     /// and body
     pub fn new(
-        node_identity: Arc<NodeIdentity<CommsPublicKey>>,
+        node_identity: Arc<NodeIdentity>,
         peer: Peer<CommsPublicKey>,
         message_envelope: MessageEnvelope,
         outbound_message_service: Arc<OutboundMessageService>,

--- a/comms/src/outbound_message_service/outbound_message_service.rs
+++ b/comms/src/outbound_message_service/outbound_message_service.rs
@@ -41,7 +41,7 @@ use tari_utilities::message_format::MessageFormat;
 pub struct OutboundMessageService {
     context: ZmqContext,
     outbound_address: InprocAddress,
-    node_identity: Arc<NodeIdentity<CommsPublicKey>>,
+    node_identity: Arc<NodeIdentity>,
     peer_manager: Arc<PeerManager<CommsPublicKey, CommsDataStore>>,
 }
 
@@ -49,7 +49,7 @@ impl OutboundMessageService {
     /// Constructs a new OutboundMessageService from the context, node_identity and outbound_address
     pub fn new(
         context: ZmqContext,
-        node_identity: Arc<NodeIdentity<CommsPublicKey>>,
+        node_identity: Arc<NodeIdentity>,
         outbound_address: InprocAddress, /* The outbound_address is an inproc that connects the OutboundMessagePool
                                           * and the OutboundMessageService */
         peer_manager: Arc<PeerManager<CommsPublicKey, CommsDataStore>>,

--- a/comms/src/peer_manager/peer.rs
+++ b/comms/src/peer_manager/peer.rs
@@ -37,10 +37,10 @@ bitflags! {
     }
 }
 
-#[derive(Debug, Clone, Deserialize, Serialize, PartialEq)]
 /// A Peer represents a communication peer that is identified by a Public Key and NodeId. The Peer struct maintains a
 /// collection of the NetAddressesWithStats that this Peer can be reached by. The struct also maintains a set of flags
 /// describing the status of the Peer.
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq)]
 pub struct Peer<K> {
     #[serde(serialize_with = "serialize_to_hex", bound(serialize = "K: PublicKey"))]
     #[serde(deserialize_with = "pubkey_from_hex", bound(deserialize = "K: PublicKey"))]

--- a/comms/tests/connection_manager/manager.rs
+++ b/comms/tests/connection_manager/manager.rs
@@ -54,7 +54,7 @@ fn establish_peer_connection_by_peer() {
     let _ = simple_logger::init();
     let context = ZmqContext::new();
 
-    let node_identity = Arc::new(factories::node_identity::create::<CommsPublicKey>().build().unwrap());
+    let node_identity = Arc::new(factories::node_identity::create().build().unwrap());
 
     //---------------------------------- Node B Setup --------------------------------------------//
 

--- a/comms/tests/control_service/service.rs
+++ b/comms/tests/control_service/service.rs
@@ -83,7 +83,7 @@ fn encrypt_message(secret_key: &CommsSecretKey, public_key: &CommsPublicKey, msg
 }
 
 fn construct_envelope<T: MessageFormat>(
-    node_identity: &Arc<NodeIdentity<CommsPublicKey>>,
+    node_identity: &Arc<NodeIdentity>,
     message_type: ControlServiceMessageType,
     msg: T,
 ) -> Result<MessageEnvelope, MessageError>
@@ -136,7 +136,7 @@ fn recv_message() {
     );
     let control_service_address = factories::net_address::create().build().unwrap();
     let node_identity = Arc::new(
-        factories::node_identity::create::<CommsPublicKey>()
+        factories::node_identity::create()
             .with_control_service_address(control_service_address.clone())
             .build()
             .unwrap(),
@@ -198,7 +198,7 @@ fn recv_message() {
 
 #[test]
 fn serve_and_shutdown() {
-    let node_identity = Arc::new(factories::node_identity::create::<CommsPublicKey>().build().unwrap());
+    let node_identity = Arc::new(factories::node_identity::create().build().unwrap());
     let (tx, rx) = channel();
     let context = ZmqContext::new();
     let connection_manager = Arc::new(

--- a/comms/tests/outbound_message_service/outbound_message_pool.rs
+++ b/comms/tests/outbound_message_service/outbound_message_pool.rs
@@ -68,7 +68,7 @@ mod test {
     fn test_outbound_message_pool() {
         init();
         let context = ZmqContext::new();
-        let node_identity = Arc::new(factories::node_identity::create::<CommsPublicKey>().build().unwrap());
+        let node_identity = Arc::new(factories::node_identity::create().build().unwrap());
 
         //---------------------------------- Node B Setup --------------------------------------------//
 
@@ -177,7 +177,7 @@ mod test {
         init();
         let context = ZmqContext::new();
 
-        let node_identity = Arc::new(factories::node_identity::create::<CommsPublicKey>().build().unwrap());
+        let node_identity = Arc::new(factories::node_identity::create().build().unwrap());
 
         //---------------------------------- Node B Setup --------------------------------------------//
         let node_B_control_port_address: NetAddress = "127.0.0.1:45845".parse().unwrap();

--- a/comms/tests/support/factories/connection_manager.rs
+++ b/comms/tests/support/factories/connection_manager.rs
@@ -44,8 +44,8 @@ pub struct ConnectionManagerFactory {
     peer_connection_config: PeerConnectionConfig,
     peer_manager: Option<Arc<PeerManager<CommsPublicKey, CommsDataStore>>>,
     peer_manager_factory: PeerManagerFactory,
-    node_identity_factory: NodeIdentityFactory<CommsPublicKey>,
-    node_identity: Option<Arc<NodeIdentity<CommsPublicKey>>>,
+    node_identity_factory: NodeIdentityFactory,
+    node_identity: Option<Arc<NodeIdentity>>,
 }
 
 impl ConnectionManagerFactory {
@@ -65,17 +65,9 @@ impl ConnectionManagerFactory {
 
     factory_setter!(with_context, zmq_context, Option<ZmqContext>);
 
-    factory_setter!(
-        with_node_identity,
-        node_identity,
-        Option<Arc<NodeIdentity<CommsPublicKey>>>
-    );
+    factory_setter!(with_node_identity, node_identity, Option<Arc<NodeIdentity>>);
 
-    factory_setter!(
-        with_node_identity_factory,
-        node_identity_factory,
-        NodeIdentityFactory<CommsPublicKey>
-    );
+    factory_setter!(with_node_identity_factory, node_identity_factory, NodeIdentityFactory);
 }
 
 impl TestFactory for ConnectionManagerFactory {

--- a/comms/tests/support/factories/node_identity.rs
+++ b/comms/tests/support/factories/node_identity.rs
@@ -25,57 +25,51 @@ use rand::OsRng;
 use tari_comms::{
     connection::NetAddress,
     peer_manager::{NodeId, NodeIdentity, PeerNodeIdentity},
+    types::{CommsPublicKey, CommsSecretKey},
 };
 use tari_crypto::keys::{PublicKey, SecretKey};
-use tari_utilities::Hashable;
 
-pub fn create<PK>() -> NodeIdentityFactory<PK>
-where PK: PublicKey {
-    NodeIdentityFactory::<PK>::default()
+pub fn create() -> NodeIdentityFactory {
+    NodeIdentityFactory::default()
 }
 
 #[derive(Default, Clone)]
-pub struct NodeIdentityFactory<PK>
-where PK: PublicKey
-{
+pub struct NodeIdentityFactory {
     control_service_address: Option<NetAddress>,
-    secret_key: Option<PK::K>,
-    public_key: Option<PK>,
+    secret_key: Option<CommsSecretKey>,
+    public_key: Option<CommsPublicKey>,
     node_id: Option<NodeId>,
 }
 
-impl<PK> NodeIdentityFactory<PK>
-where PK: PublicKey
-{
+impl NodeIdentityFactory {
     factory_setter!(
         with_control_service_address,
         control_service_address,
         Option<NetAddress>
     );
 
-    factory_setter!(with_secret_key, secret_key, Option<PK::K>);
+    factory_setter!(with_secret_key, secret_key, Option<CommsSecretKey>);
 
-    factory_setter!(with_public_key, public_key, Option<PK>);
+    factory_setter!(with_public_key, public_key, Option<CommsPublicKey>);
 
     factory_setter!(with_node_id, node_id, Option<NodeId>);
 }
 
-impl<PK> TestFactory for NodeIdentityFactory<PK>
-where
-    PK: PublicKey,
-    PK: Hashable,
-{
-    type Object = NodeIdentity<PK>;
+impl TestFactory for NodeIdentityFactory {
+    type Object = NodeIdentity;
 
     fn build(self) -> Result<Self::Object, TestFactoryError> {
         // Generate a test identity, set it and return it
         let secret_key = self
             .secret_key
-            .or(Some(PK::K::random(
+            .or(Some(CommsSecretKey::random(
                 &mut OsRng::new().map_err(TestFactoryError::build_failed())?,
             )))
             .unwrap();
-        let public_key = self.public_key.or(Some(PK::from_secret_key(&secret_key))).unwrap();
+        let public_key = self
+            .public_key
+            .or(Some(CommsPublicKey::from_secret_key(&secret_key)))
+            .unwrap();
         let node_id = self
             .node_id
             .or(Some(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Removed the redundant public key type param from `NodeIdentity`. Serde
required type annotations to serialize the secret key (was `PK::K`). I
tried explicitly adding trait bounds for `PK::K` but it seems that
serde's proc macro has a limitation for handling associated types.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Existing tests compile and pass

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [x] Breaking change (fix or feature that would cause existing functionality to change)
* [x] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch
* [x] I ran `cargo-fmt --all` before pushing
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
