### PR TITLE
Remove ImboundMessageService threading

### DIFF
--- a/comms/src/inbound_message_service/comms_msg_handlers.rs
+++ b/comms/src/inbound_message_service/comms_msg_handlers.rs
@@ -171,7 +171,7 @@ where
     // Construct DomainMessageContext and dispatch to handler services using domain message broker
     let header: MessageHeader<MType> = message.to_header().map_err(DispatchError::handler_error())?;
 
-    debug!(target: LOG_TARGET, "Received message type {:?}", header.message_type);
+    debug!(target: LOG_TARGET, "Received message type: {:?}", header.message_type);
     let domain_message_context = DomainMessageContext::new(message_context.peer.into(), message);
     let domain_message_context_buffer = vec![domain_message_context
         .to_binary()
@@ -199,7 +199,6 @@ where
 
 fn handler_discard<MType>(_message_context: MessageContext<MType>) -> Result<(), DispatchError>
 where
-    //    PK: PublicKey,
     MType: DispatchableKey,
     MType: Serialize + DeserializeOwned,
 {

--- a/comms/src/inbound_message_service/error.rs
+++ b/comms/src/inbound_message_service/error.rs
@@ -21,22 +21,24 @@
 //  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 use crate::{
-    connection::{error::ConnectionError, zmq::ZmqError, DealerProxyError},
+    connection::{error::ConnectionError, DealerProxyError},
     inbound_message_service::inbound_message_broker::BrokerError,
 };
 use derive_error::Error;
 
-/// Error type for IMS
+/// Error type for InboundMessageService subsystem
 #[derive(Debug, Error)]
-pub enum InboundMessageServiceError {
-    /// Problem with inbound socket
-    InboundSocketError(ZmqError),
+pub enum InboundError {
     /// Failed to connect to inbound socket
     InboundConnectionError(ConnectionError),
     DealerProxyError(DealerProxyError),
     BrokerError(BrokerError),
     #[error(msg_embedded, non_std, no_from)]
     ControlSendError(String),
-    /// Could not join the dealer or worker threads
+    /// Unable to send a control message as the control sync sender is undefined
+    ControlSenderUndefined,
+    /// Could not join the InboundMessageWorker thread
     ThreadJoinError,
+    /// The thread handle is undefined and could have not been properly created
+    ThreadHandleUndefined,
 }

--- a/comms/src/inbound_message_service/mod.rs
+++ b/comms/src/inbound_message_service/mod.rs
@@ -24,4 +24,4 @@ pub mod comms_msg_handlers;
 pub mod error;
 pub mod inbound_message_broker;
 pub mod inbound_message_service;
-pub mod msg_processing_worker;
+pub mod inbound_message_worker;

--- a/comms/src/outbound_message_service/error.rs
+++ b/comms/src/outbound_message_service/error.rs
@@ -30,6 +30,7 @@ use derive_error::Error;
 use tari_crypto::signatures::SchnorrSignatureError;
 use tari_utilities::{ciphers::cipher::CipherError, message_format::MessageFormatError, ByteArrayError};
 
+/// Error type for OutboundMessageService subsystem
 #[derive(Debug, Error)]
 pub enum OutboundError {
     /// Could not connect to the outbound message pool

--- a/comms/src/outbound_message_service/message_pool_worker.rs
+++ b/comms/src/outbound_message_service/message_pool_worker.rs
@@ -46,7 +46,6 @@ use std::{
         Arc,
     },
     thread,
-    time::Duration,
 };
 use tari_utilities::message_format::MessageFormat;
 
@@ -119,7 +118,7 @@ impl MessagePoolWorker {
             self.process_control_messages();
 
             if self.is_running {
-                match inbound_connection.receive(self.config.worker_timeout_in_ms) {
+                match inbound_connection.receive(self.config.worker_timeout_in_ms.as_millis() as u32) {
                     Ok(mut frame_set) => {
                         // This strips off the two ZeroMQ Identity frames introduced by the transmission to the proxy
                         // and from the proxy to this worker
@@ -260,7 +259,7 @@ impl MessagePoolWorker {
     fn process_control_messages(&mut self) {
         match &self.control_receiver {
             Some(control_receiver) => {
-                if let Some(control_msg) = control_receiver.recv_timeout(Duration::from_millis(5)).ok() {
+                if let Some(control_msg) = control_receiver.recv_timeout(self.config.control_timeout_in_ms).ok() {
                     debug!(target: LOG_TARGET, "Received control message: {:?}", control_msg);
                     match control_msg {
                         ControlMessage::Shutdown => {

--- a/comms/tests/outbound_message_service/outbound_message_pool.rs
+++ b/comms/tests/outbound_message_service/outbound_message_pool.rs
@@ -129,8 +129,7 @@ mod test {
             omp_inbound_address.clone(),
             node_A_peer_manager.clone(),
             node_A_connection_manager.clone(),
-        )
-        .unwrap();
+        );
 
         let oms = OutboundMessageService::new(
             context.clone(),
@@ -213,7 +212,8 @@ mod test {
         let omp_config = OutboundMessagePoolConfig {
             max_num_of_retries: 3,
             retry_wait_time: chrono::Duration::milliseconds(100),
-            worker_timeout_in_ms: 100,
+            worker_timeout_in_ms: Duration::from_millis(100),
+            control_timeout_in_ms: Duration::from_millis(5),
         };
         let mut omp = OutboundMessagePool::new(
             omp_config.clone(),
@@ -222,8 +222,7 @@ mod test {
             omp_requeue_address.clone(),
             node_A_peer_manager.clone(),
             node_A_connection_manager.clone(),
-        )
-        .unwrap();
+        );
 
         let oms = OutboundMessageService::new(
             context.clone(),


### PR DESCRIPTION
## Description
- Removed threading from the InboundMessageService
- Added a config to the InboundMessageService and InboundMessageWorker
- Added the control_timeout_in_ms to the config of the InboundMessageService and OutboundMessageService
- Renamed InboundMessageService to InboundError so it is similar to OutboundError from the OutboundMessageService. Also, inbound_address is now message_queue_address like the OutboundMessageService
- Removed unused results from the constructors of the InboundMessageService and OutboundMessagePool
- The InboundMessageService and InboundMessageWorker tests were updated 

## Motivation and Context
This will reduce the complexity of the InboundMessageService, which might result in improved reliability.

## How Has This Been Tested?
The InboundMessageService and InboundMessageWorker tests were updated 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [x] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch
* [x] I ran `cargo-fmt --all` before pushing
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
