### PR TITLE
`initialize_logger` takes a path to it's config.

### DIFF
--- a/base_layer/p2p/Cargo.toml
+++ b/base_layer/p2p/Cargo.toml
@@ -4,10 +4,6 @@ version = "0.0.2"
 edition = "2018"
 
 [dependencies]
-tari_crypto = { version = "^0.0", path = "../../infrastructure/crypto"}
-tari_comms = { version = "^0.0", path = "../../comms"}
-tari_core = { version = "^0.0", path = "../core"}
-tari_utilities = { version = "^0.0", path = "../../infrastructure/tari_util"}
 rmp-serde = "0.13.7"
 serde = "1.0.90"
 serde_derive = "1.0.90"
@@ -17,9 +13,16 @@ log = "0.4.6"
 rand = "0.6.5"
 crossbeam-channel = "0.3.8"
 
+tari_crypto = { version = "^0.0", path = "../../infrastructure/crypto"}
+tari_comms = { version = "^0.0", path = "../../comms"}
+tari_core = { version = "^0.0", path = "../core"}
+tari_utilities = { version = "^0.0", path = "../../infrastructure/tari_util"}
+
 [dev-dependencies]
-tari_storage = {version = "^0.0", path = "../../infrastructure/storage"}
 tempdir = "0.3.7"
 cursive = "0.12.0"
 clap = "2.33.0"
 lazy_static = "1.3.0"
+
+tari_storage = {version = "^0.0", path = "../../infrastructure/storage"}
+tari_common = { version = "^0.0", path = "../../common"}

--- a/base_layer/p2p/examples/pingpong.rs
+++ b/base_layer/p2p/examples/pingpong.rs
@@ -92,6 +92,7 @@ fn datastore_with_peer(identity: NodeIdentity) -> CommsDataStore {
 }
 
 fn main() {
+    tari_common::logging::initialize_logger_for_test();
     let matches = App::new("Peer file generator")
         .version("1.0")
         .about("PingPong between two peers")


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
`initialize_logger` now takes a path argument to the config (relative or
absolute). Added `initialize_logger_for_test` which searches up the
directory tree until it finds the git root (.git). From there it will
assume the debug config file is located in `./common/log4rs-debug.yml`.

`initialize_logger_for_test` can be safely called multiple times,
`initialize_logger` will return an error if called more than once as it
should only be called once in applications.


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Ref #328 
Ref #396 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Unit tests for `initialize_logger_for_tests` - if `initialize_logger` is called in tests, it will error as initialization is global. Since it just calls log4rs init, I figure it's fine for it not to be tested.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [x] Breaking change (fix or feature that would cause existing functionality to change)
* [x] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch
* [x] I ran `cargo-fmt --all` before pushing
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
