### PR TITLE
Fixed "dropping monitor" bug in connection manager

### DIFF
--- a/base_layer/p2p/examples/pingpong.rs
+++ b/base_layer/p2p/examples/pingpong.rs
@@ -209,7 +209,7 @@ fn update_count(s: &mut Cursive) {
     s.call_on_id("counter", move |view: &mut TextView| {
         let lock = COUNTER_STATE.read().unwrap();
         view.set_content(format!(
-            "Pings sent:{}\nPings Received: {}\nPongs Received: {}\n\n(p) Send ping (q) Quit",
+            "Pings sent: {}\nPings Received: {}\nPongs Received: {}\n\n(p) Send ping (q) Quit",
             lock.0, lock.1, lock.2
         ));
     });

--- a/comms/src/connection/monitor.rs
+++ b/comms/src/connection/monitor.rs
@@ -31,10 +31,13 @@ use crate::{
     message::FrameSet,
 };
 use derive_error::Error;
+use log::*;
 use std::{
     convert::{TryFrom, TryInto},
     fmt,
 };
+
+const LOG_TARGET: &'static str = "comms::connection::monitor";
 
 #[derive(Debug, Error, PartialEq)]
 pub enum ConnectionMonitorError {
@@ -100,6 +103,8 @@ impl ConnectionMonitor {
             )))
         })?;
 
+        debug!(target: LOG_TARGET, "Connection monitor connected on {}", address);
+
         Ok(Self { socket })
     }
 
@@ -157,6 +162,12 @@ impl ConnectionMonitor {
 
             Err(e) => Err(ConnectionError::SocketError(format!("Failed to poll: {}", e))),
         }
+    }
+}
+
+impl Drop for ConnectionMonitor {
+    fn drop(&mut self) {
+        debug!(target: LOG_TARGET, "Connection monitor dropped")
     }
 }
 

--- a/comms/src/connection/net_address/i2p.rs
+++ b/comms/src/connection/net_address/i2p.rs
@@ -30,6 +30,12 @@ pub struct I2PAddress {
     pub name: String,
 }
 
+impl I2PAddress {
+    pub fn host(&self) -> String {
+        format!("{}.b32.i2p", self.name)
+    }
+}
+
 impl FromStr for I2PAddress {
     type Err = NetAddressError;
 

--- a/comms/src/connection/net_address/ip.rs
+++ b/comms/src/connection/net_address/ip.rs
@@ -37,6 +37,10 @@ impl SocketAddress {
         self.0.ip()
     }
 
+    pub fn host(&self) -> String {
+        self.0.ip().to_string()
+    }
+
     pub fn port(&self) -> u16 {
         self.0.port()
     }

--- a/comms/src/connection/net_address/mod.rs
+++ b/comms/src/connection/net_address/mod.rs
@@ -97,6 +97,14 @@ impl NetAddress {
         }
     }
 
+    pub fn host(&self) -> String {
+        match self {
+            NetAddress::Onion(addr) => addr.host(),
+            NetAddress::IP(addr) => addr.host(),
+            NetAddress::I2P(addr) => addr.host(),
+        }
+    }
+
     /// Returns the port for the NetAddress if applicable, otherwise None
     pub fn maybe_port(&self) -> Option<u16> {
         match self {

--- a/comms/src/connection/net_address/onion.rs
+++ b/comms/src/connection/net_address/onion.rs
@@ -34,6 +34,10 @@ pub struct OnionAddress {
 }
 
 impl OnionAddress {
+    pub fn host(&self) -> String {
+        format!("{}.onion", self.public_key)
+    }
+
     pub fn port(&self) -> u16 {
         self.port
     }

--- a/comms/src/connection/peer_connection/control.rs
+++ b/comms/src/connection/peer_connection/control.rs
@@ -71,6 +71,10 @@ impl ThreadControlMessenger {
             PeerConnectionError::ControlSendError(format!("Failed to send control message: {:?}", e)).into()
         })
     }
+
+    pub fn get_sender(&self) -> &SyncSender<ControlMessage> {
+        &self.0
+    }
 }
 
 impl From<SyncSender<ControlMessage>> for ThreadControlMessenger {

--- a/comms/src/connection/zmq/inproc_address.rs
+++ b/comms/src/connection/zmq/inproc_address.rs
@@ -22,7 +22,7 @@
 
 use crate::connection::zmq::{ZmqEndpoint, ZmqError};
 use rand::{distributions::Alphanumeric, EntropyRng, Rng};
-use std::{iter, str::FromStr};
+use std::{fmt, iter, str::FromStr};
 
 const DEFAULT_INPROC: &'static str = "inproc://default";
 
@@ -58,6 +58,12 @@ impl FromStr for InprocAddress {
         } else {
             Err(ZmqError::MalformedInprocAddress)
         }
+    }
+}
+
+impl fmt::Display for InprocAddress {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", self.0)
     }
 }
 

--- a/comms/src/control_service/error.rs
+++ b/comms/src/control_service/error.rs
@@ -55,4 +55,6 @@ pub enum ControlServiceError {
     /// Received an unencrypted message. Discarding it.
     ReceivedUnencryptedMessage,
     CipherError(CipherError),
+    /// Peer is banned, refusing connection request
+    PeerBanned,
 }

--- a/comms/src/control_service/worker.rs
+++ b/comms/src/control_service/worker.rs
@@ -54,6 +54,8 @@ use tari_crypto::keys::DiffieHellmanSharedSecret;
 use tari_utilities::{byte_array::ByteArray, ciphers::cipher::Cipher, message_format::MessageFormat};
 
 const LOG_TARGET: &'static str = "comms::control_service::worker";
+/// The maximum message size allowed for the control service.
+/// Messages will transparently drop if this size is exceeded.
 const CONTROL_SERVICE_MAX_MSG_SIZE: u64 = 1024; // 1kb
 
 /// The [ControlService] worker is responsible for handling incoming messages
@@ -109,7 +111,7 @@ where
         };
 
         let handle = thread::Builder::new()
-            .name("control-service".into())
+            .name("control-service".to_string())
             .spawn(move || {
                 loop {
                     match worker.main_loop() {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
The outbound control port connection would drop the attached connection
monitor before the connection terminates, which causes the connection to
stop working. This is likely the cause of test flakiness in establish_peer_connection_by_peer

Additional changes:
- [bug] Ensure that the address sent to the target peer's control port
is the external host of the node.
- [bug] Correctly handle an existing peer establishing a new connection
- Some peer connection unit tests
- More logging

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Used the pingpong example to test sending messages back and forth between two laptops.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [x] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [x] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch
* [x] I ran `cargo-fmt --all` before pushing
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
