### PR TITLE
Improve establish_peer_connection test reliability

### DIFF
--- a/comms/src/connection/connection.rs
+++ b/comms/src/connection/connection.rs
@@ -32,7 +32,7 @@ use crate::{
     message::FrameSet,
 };
 
-use std::{cmp, convert::TryFrom, iter::IntoIterator, str::FromStr};
+use std::{cmp, iter::IntoIterator, str::FromStr};
 
 const LOG_TARGET: &'static str = "comms::connection::Connection";
 
@@ -245,6 +245,7 @@ impl<'a> Connection<'a> {
         Ok(EstablishedConnection {
             socket,
             connected_address,
+            direction: self.direction,
         })
     }
 }
@@ -265,6 +266,7 @@ pub struct EstablishedConnection {
     socket: zmq::Socket,
     // If the connection is a TCP connection, it will be stored here, otherwise it is None
     connected_address: Option<SocketAddress>,
+    direction: Direction,
 }
 
 impl EstablishedConnection {
@@ -354,11 +356,12 @@ impl EstablishedConnection {
             .map_err(|e| ConnectionError::SocketError(format!("Error sending: {} ({})", e, e.to_raw())))
     }
 
+    #[cfg(test)]
     pub(crate) fn get_socket(&self) -> &zmq::Socket {
         &self.socket
     }
 
-    pub(crate) fn get_mut_socket(&mut self) -> &mut zmq::Socket {
+    pub(crate) fn get_socket_mut(&mut self) -> &mut zmq::Socket {
         &mut self.socket
     }
 }
@@ -367,7 +370,8 @@ impl Drop for EstablishedConnection {
     fn drop(&mut self) {
         debug!(
             target: LOG_TARGET,
-            "Dropping connection {:?}",
+            "Dropping {} connection {:?}",
+            self.direction,
             self.get_connected_address()
         );
     }
@@ -388,18 +392,6 @@ fn get_socket_address(socket: &zmq::Socket) -> Option<SocketAddress> {
     }
     let addr = parts[1];
     SocketAddress::from_str(&addr).ok()
-}
-
-impl TryFrom<zmq::Socket> for EstablishedConnection {
-    type Error = ConnectionError;
-
-    fn try_from(socket: zmq::Socket) -> Result<Self> {
-        let connected_address = get_socket_address(&socket);
-        Ok(EstablishedConnection {
-            socket,
-            connected_address,
-        })
-    }
 }
 
 #[cfg(test)]

--- a/comms/src/connection/dealer_proxy.rs
+++ b/comms/src/connection/dealer_proxy.rs
@@ -85,7 +85,7 @@ pub fn spawn_proxy(
             .establish(&control_address.clone())
             .map_err(|err| DealerProxyError::ConnectionError(err))?;
 
-        zmq::proxy_steerable(source.get_mut_socket(), sink.get_mut_socket(), control.get_mut_socket())
+        zmq::proxy_steerable(source.get_socket_mut(), sink.get_socket_mut(), control.get_socket_mut())
             .map_err(|err| DealerProxyError::SocketError(err.to_string()))
     })
 }

--- a/comms/src/connection/types.rs
+++ b/comms/src/connection/types.rs
@@ -21,6 +21,7 @@
 //  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 use crate::connection::ConnectionError;
+use std::fmt;
 
 /// The types of socket available
 pub enum SocketType {
@@ -57,6 +58,12 @@ pub enum Direction {
     Inbound,
     /// Connection establishes an outbound connection
     Outbound,
+}
+
+impl fmt::Display for Direction {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{:?}", self)
+    }
 }
 
 /// Used to select the method to use when establishing the connection.

--- a/comms/src/connection_manager/establisher.rs
+++ b/comms/src/connection_manager/establisher.rs
@@ -124,38 +124,34 @@ where PK: PublicKey + Hash
     {
         let config = &self.config;
 
-        let mut attempt = ConnectionAttempts::new(
-            &self.context,
-            self.peer_manager.clone(),
-            |attempt_count, monitor_addr| {
-                let address = self
-                    .peer_manager
-                    .get_best_net_address(&peer.node_id)
-                    .map_err(ConnectionManagerError::PeerManagerError)?;
+        let mut attempt = ConnectionAttempts::new(&self.context, self.peer_manager.clone(), |monitor_addr, _| {
+            let address = self
+                .peer_manager
+                .get_best_net_address(&peer.node_id)
+                .map_err(ConnectionManagerError::PeerManagerError)?;
 
-                let conn = Connection::new(&self.context, Direction::Outbound)
-                    .set_linger(Linger::Timeout(3000))
-                    .set_monitor_addr(monitor_addr)
-                    .set_socks_proxy_addr(config.socks_proxy_address.clone())
-                    .set_max_message_size(Some(config.max_message_size))
-                    .set_receive_hwm(0)
-                    .establish(&address)
-                    .map_err(ConnectionManagerError::ConnectionError)?;
+            let conn = Connection::new(&self.context, Direction::Outbound)
+                .set_linger(Linger::Timeout(3000))
+                .set_monitor_addr(monitor_addr)
+                .set_socks_proxy_addr(config.socks_proxy_address.clone())
+                .set_max_message_size(Some(config.max_message_size))
+                .set_receive_hwm(0)
+                .establish(&address)
+                .map_err(ConnectionManagerError::ConnectionError)?;
 
-                debug!(
-                    target: LOG_TARGET,
-                    "Connection attempt #{} to NodeId={}", attempt_count, peer.node_id
-                );
-
-                Ok((conn, address))
-            },
-        );
+            Ok((conn, address))
+        });
 
         info!(
             target: LOG_TARGET,
-            "Attempting to connect to control port for NodeId={}", peer.node_id
+            "Starting {} attempt(s) to connect to control port for NodeId={}",
+            peer.addresses.len(),
+            peer.node_id
         );
-        attempt.try_connect(peer.addresses.len())
+        attempt.try_connect(peer.addresses.len()).or_else(|err| {
+            warn!(target: LOG_TARGET, "Failed to connect to peer control port",);
+            Err(err)
+        })
     }
 
     /// Create a new outbound PeerConnection
@@ -275,34 +271,37 @@ where PK: PublicKey + Hash
 /// attempts statistics
 struct ConnectionAttempts<'c, PK, F> {
     context: &'c ZmqContext,
-    num_attempts: usize,
     attempt_fn: F,
     peer_manager: Arc<PeerManager<PK, CommsDataStore>>,
 }
 
 impl<'c, PK, F> ConnectionAttempts<'c, PK, F>
 where
-    F: Fn(usize, InprocAddress) -> Result<(EstablishedConnection, NetAddress)>,
+    F: Fn(InprocAddress, usize) -> Result<(EstablishedConnection, NetAddress)>,
     PK: PublicKey + Hash,
 {
     pub fn new(context: &'c ZmqContext, peer_manager: Arc<PeerManager<PK, CommsDataStore>>, attempt_fn: F) -> Self {
         Self {
             context,
-            num_attempts: 0,
             attempt_fn,
             peer_manager,
         }
     }
 
     pub fn try_connect(&mut self, num_attempts: usize) -> Result<(EstablishedConnection, ConnectionMonitor)> {
-        let mut attempt_count = 0usize;
+        let mut attempt_count = 0;
         loop {
             let monitor_addr = InprocAddress::random();
             let monitor = ConnectionMonitor::connect(self.context, &monitor_addr)
                 .map_err(ConnectionManagerError::ConnectionError)?;
 
             attempt_count += 1;
-            let (conn, address) = (self.attempt_fn)(attempt_count, monitor_addr)?;
+            let (conn, address) = (self.attempt_fn)(monitor_addr, attempt_count)?;
+
+            debug!(
+                target: LOG_TARGET,
+                "Connection attempt {} of {} to {}", attempt_count, num_attempts, address
+            );
 
             if self.is_connected(&monitor)? {
                 debug!(
@@ -318,8 +317,7 @@ where
                 self.peer_manager
                     .mark_failed_connection_attempt(&address)
                     .map_err(ConnectionManagerError::PeerManagerError)?;
-                self.num_attempts += 1;
-                if self.num_attempts > num_attempts {
+                if attempt_count >= num_attempts {
                     break Err(ConnectionManagerError::MaxConnnectionAttemptsExceeded);
                 }
             }

--- a/comms/src/control_service/worker.rs
+++ b/comms/src/control_service/worker.rs
@@ -93,11 +93,8 @@ where
         connection_manager: Arc<ConnectionManager>,
     ) -> Result<(thread::JoinHandle<Result<()>>, SyncSender<ControlMessage>)>
     {
-        info!(
-            target: LOG_TARGET,
-            "Control service starting on {}...", config.listener_address
-        );
         let (sender, receiver) = sync_channel(5);
+        let listener_address = config.listener_address.clone();
 
         let mut worker = Self {
             config,
@@ -113,6 +110,10 @@ where
         let handle = thread::Builder::new()
             .name("control-service".to_string())
             .spawn(move || {
+                info!(
+                    target: LOG_TARGET,
+                    "Control service starting on {}...", listener_address
+                );
                 loop {
                     match worker.main_loop() {
                         Ok(_) => {

--- a/comms/tests/connection_manager/manager.rs
+++ b/comms/tests/connection_manager/manager.rs
@@ -27,7 +27,7 @@ use crate::support::{
 use std::{sync::Arc, thread, time::Duration};
 use tari_comms::{
     connection::{types::Linger, InprocAddress, ZmqContext},
-    connection_manager::{ConnectionManager, PeerConnectionConfig},
+    connection_manager::PeerConnectionConfig,
     control_service::{ControlService, ControlServiceConfig},
     peer_manager::{Peer, PeerManager},
     types::{CommsDataStore, CommsPublicKey},
@@ -48,27 +48,37 @@ fn make_peer_manager(peers: Vec<Peer<CommsPublicKey>>) -> Arc<PeerManager<CommsP
     Arc::new(factories::peer_manager::create().with_peers(peers).build().unwrap())
 }
 
+fn pause() {
+    thread::sleep(Duration::from_millis(200));
+}
+
 #[test]
 #[allow(non_snake_case)]
-fn establish_peer_connection_by_peer() {
+fn establish_peer_connection() {
     let _ = simple_logger::init();
     let context = ZmqContext::new();
 
-    let node_identity = Arc::new(factories::node_identity::create().build().unwrap());
+    let node_A_identity = Arc::new(factories::node_identity::create().build().unwrap());
+
+    let node_B_consumer_address = InprocAddress::random();
+    let node_B_msg_counter = ConnectionMessageCounter::new(&context);
+    node_B_msg_counter.start(node_B_consumer_address.clone());
 
     //---------------------------------- Node B Setup --------------------------------------------//
 
-    let node_B_consumer_address = InprocAddress::random();
     let node_B_control_port_address = factories::net_address::create().build().unwrap();
-
-    let node_B_msg_counter = ConnectionMessageCounter::new(&context);
-    node_B_msg_counter.start(node_B_consumer_address.clone());
+    let node_B_identity = Arc::new(
+        factories::node_identity::create()
+            .with_control_service_address(node_B_control_port_address.clone())
+            .build()
+            .unwrap(),
+    );
 
     let node_B_peer = factories::peer::create()
         .with_net_addresses(vec![node_B_control_port_address.clone()])
         // Set node B's secret key to be the same as node A's so that we can generate the same shared secret
         // TODO: we'll need a way to generate separate node identities for two nodes
-        .with_public_key(node_identity.identity.public_key.clone())
+        .with_public_key(node_B_identity.identity.public_key.clone())
         .build()
         .unwrap();
 
@@ -77,7 +87,7 @@ fn establish_peer_connection_by_peer() {
     let node_B_connection_manager = Arc::new(
         factories::connection_manager::create()
             .with_context(context.clone())
-            .with_node_identity(node_identity.clone())
+            .with_node_identity(node_B_identity.clone())
             .with_peer_manager(node_B_peer_manager)
             .with_peer_connection_config(make_peer_connection_config(node_B_consumer_address.clone()))
             .build()
@@ -85,7 +95,7 @@ fn establish_peer_connection_by_peer() {
     );
 
     // Start node B's control service
-    let node_B_control_service = ControlService::new(context.clone(), node_identity.clone(), ControlServiceConfig {
+    let node_B_control_service = ControlService::new(context.clone(), node_B_identity.clone(), ControlServiceConfig {
         socks_proxy_address: None,
         listener_address: node_B_control_port_address,
         accept_message_type: 123,
@@ -94,18 +104,24 @@ fn establish_peer_connection_by_peer() {
     .serve(node_B_connection_manager)
     .unwrap();
 
+    // Give the control service a moment to start up
+    pause();
+
     //---------------------------------- Node A setup --------------------------------------------//
 
     let node_A_consumer_address = InprocAddress::random();
 
     // Add node B to node A's peer manager
     let node_A_peer_manager = make_peer_manager(vec![node_B_peer.clone()]);
-    let node_A_connection_manager = Arc::new(ConnectionManager::new(
-        context.clone(),
-        node_identity.clone(),
-        node_A_peer_manager,
-        make_peer_connection_config(node_A_consumer_address),
-    ));
+    let node_A_connection_manager = Arc::new(
+        factories::connection_manager::create()
+            .with_context(context.clone())
+            .with_node_identity(node_A_identity.clone())
+            .with_peer_manager(node_A_peer_manager)
+            .with_peer_connection_config(make_peer_connection_config(node_A_consumer_address))
+            .build()
+            .unwrap(),
+    );
 
     //------------------------------ Negotiate connection to node B -----------------------------------//
 
@@ -137,11 +153,14 @@ fn establish_peer_connection_by_peer() {
     handle1.join().unwrap().unwrap();
     handle2.join().unwrap().unwrap();
 
+    // Give the peer connections a moment to receive and the message sink connections to send
+    pause();
+
     node_B_control_service.shutdown().unwrap();
     node_B_control_service.handle.join().unwrap().unwrap();
 
     assert_eq!(node_A_connection_manager.get_active_connection_count(), 1);
-    node_B_msg_counter.assert_count(2, 1000);
+    node_B_msg_counter.assert_count(2, 2000);
 
     match Arc::try_unwrap(node_A_connection_manager) {
         Ok(manager) => manager.shutdown().into_iter().map(|r| r.unwrap()).collect::<Vec<()>>(),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
A few pauses are currently needed in tests to ensure that the control
service has enough time to start up and peer connections can finish sending. Also fixed a bug in
ConnectionAttempts, some minor cosmetic changes and logging improvements.

Using (short) pauses never guarantee an end to flakiness and make tests run slowly, but this should greatly improve the reliability of this test.
In future we should consider some basic ready signals so that pauses won't be needed.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [x] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch
* [x] I ran `cargo-fmt --all` before pushing
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
