### PR TITLE
Delete obsolete "serialize_with_hex" attribute function

### DIFF
--- a/base_layer/keymanager/src/keymanager.rs
+++ b/base_layer/keymanager/src/keymanager.rs
@@ -27,11 +27,8 @@ use rand::{CryptoRng, Rng};
 use serde::de::DeserializeOwned;
 use serde_derive::{Deserialize, Serialize};
 use std::marker::PhantomData;
-use tari_crypto::{keys::SecretKey, ristretto::serialize::secret_from_hex};
-use tari_utilities::{
-    byte_array::ByteArrayError,
-    hex::{serialize_to_hex, Hex},
-};
+use tari_crypto::keys::SecretKey;
+use tari_utilities::{byte_array::ByteArrayError, hex::Hex};
 
 #[derive(Debug, Error)]
 pub enum KeyManagerError {
@@ -51,7 +48,6 @@ where K: SecretKey
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct KeyManager<K: SecretKey, D: Digest> {
-    #[serde(serialize_with = "serialize_to_hex", deserialize_with = "secret_from_hex")]
     pub master_key: K,
     pub branch_seed: String,
     pub primary_key_index: usize,

--- a/base_layer/p2p/examples/pingpong.rs
+++ b/base_layer/p2p/examples/pingpong.rs
@@ -47,7 +47,7 @@ use std::{
 use tari_comms::{
     control_service::ControlServiceConfig,
     peer_manager::{peer_storage::PeerStorage, NodeIdentity, Peer, PeerFlags, PeerNodeIdentity},
-    types::{CommsDataStore, CommsPublicKey},
+    types::CommsDataStore,
 };
 use tari_p2p::{
     initialization::{initialize_comms, CommsConfig},
@@ -149,12 +149,7 @@ lazy_static! {
     static ref COUNTER_STATE: Arc<RwLock<(usize, usize, usize)>> = Arc::new(RwLock::new((0, 0, 0)));
 }
 
-fn run_ui(
-    services: ServiceExecutor,
-    peer_identity: PeerNodeIdentity<CommsPublicKey>,
-    pingpong_api: Arc<PingPongServiceApi>,
-)
-{
+fn run_ui(services: ServiceExecutor, peer_identity: PeerNodeIdentity, pingpong_api: Arc<PingPongServiceApi>) {
     let mut app = Cursive::default();
 
     app.add_layer(

--- a/base_layer/p2p/src/peer.rs
+++ b/base_layer/p2p/src/peer.rs
@@ -1,5 +1,4 @@
 use tari_comms::peer_manager::peer::Peer;
-use tari_crypto::keys::PublicKey;
 
 #[derive(Debug)]
 pub enum PeerType {
@@ -10,16 +9,14 @@ pub enum PeerType {
 }
 
 #[derive(Debug)]
-pub struct PeerWithType<K: PublicKey> {
-    pub peer: Peer<K>,
+pub struct PeerWithType {
+    pub peer: Peer,
     pub peer_type: PeerType,
 }
 
-impl<K> PeerWithType<K>
-where K: PublicKey
-{
+impl PeerWithType {
     /// Constructs a new peer with peer type
-    pub fn new(peer: Peer<K>, peer_type: PeerType) -> PeerWithType<K> {
+    pub fn new(peer: Peer, peer_type: PeerType) -> PeerWithType {
         PeerWithType { peer, peer_type }
     }
 }

--- a/base_layer/p2p/src/ping_pong.rs
+++ b/base_layer/p2p/src/ping_pong.rs
@@ -135,12 +135,7 @@ impl PingPongService {
         ApiWrapper::new(service_receiver, service_sender, api)
     }
 
-    fn send_msg(
-        &self,
-        broadcast_strategy: BroadcastStrategy<CommsPublicKey>,
-        msg: PingPong,
-    ) -> Result<(), PingPongError>
-    {
+    fn send_msg(&self, broadcast_strategy: BroadcastStrategy, msg: PingPong) -> Result<(), PingPongError> {
         let oms = self.oms.clone().ok_or(PingPongError::OMSNotInitialized)?;
 
         let msg = Message::from_message_format(
@@ -267,9 +262,9 @@ impl Service for PingPongService {
 pub enum PingPongApiRequest {
     /// Send a ping to the given public key
     Ping(CommsPublicKey),
-    /// Retreive the total number of pings received
+    /// Retrieve the total number of pings received
     GetPingCount,
-    /// Retreive the total number of pongs received
+    /// Retrieve the total number of pongs received
     GetPongCount,
 }
 

--- a/base_layer/p2p/tests/ping_pong.rs
+++ b/base_layer/p2p/tests/ping_pong.rs
@@ -29,7 +29,7 @@ use tari_comms::{
     connection_manager::PeerConnectionConfig,
     control_service::ControlServiceConfig,
     peer_manager::{peer_storage::PeerStorage, NodeIdentity, Peer},
-    types::{CommsDataStore, CommsPublicKey},
+    types::CommsDataStore,
     CommsBuilder,
 };
 use tari_p2p::{
@@ -75,7 +75,7 @@ fn new_node_identity(control_service_address: NetAddress) -> NodeIdentity {
     NodeIdentity::random(&mut OsRng::new().unwrap(), control_service_address).unwrap()
 }
 
-fn create_peer_storage(tmpdir: &TempDir, name: &str, peers: Vec<Peer<CommsPublicKey>>) -> CommsDataStore {
+fn create_peer_storage(tmpdir: &TempDir, name: &str, peers: Vec<Peer>) -> CommsDataStore {
     let mut store = LMDBBuilder::new()
         .set_path(tmpdir.path().to_str().unwrap())
         .add_database(name)

--- a/comms/src/builder/builder.rs
+++ b/comms/src/builder/builder.rs
@@ -39,7 +39,7 @@ use crate::{
         OutboundMessagePool,
     },
     peer_manager::{NodeIdentity, PeerManager, PeerManagerError},
-    types::{CommsDataStore, CommsPublicKey},
+    types::CommsDataStore,
     DomainConnector,
 };
 use derive_error::Error;
@@ -165,7 +165,7 @@ where
         self
     }
 
-    fn make_peer_manager(&mut self) -> Result<Arc<PeerManager<CommsPublicKey, CommsDataStore>>, CommsBuilderError> {
+    fn make_peer_manager(&mut self) -> Result<Arc<PeerManager<CommsDataStore>>, CommsBuilderError> {
         let storage = self.peer_storage.take();
         let peer_manager = PeerManager::new(storage).map_err(CommsBuilderError::PeerManagerError)?;
         Ok(Arc::new(peer_manager))
@@ -180,7 +180,7 @@ where
     fn make_connection_manager(
         &mut self,
         node_identity: Arc<NodeIdentity>,
-        peer_manager: Arc<PeerManager<CommsPublicKey, CommsDataStore>>,
+        peer_manager: Arc<PeerManager<CommsDataStore>>,
         config: PeerConnectionConfig,
     ) -> Arc<ConnectionManager>
     {
@@ -212,7 +212,7 @@ where
         &self,
         node_identity: Arc<NodeIdentity>,
         message_sink_address: InprocAddress,
-        peer_manager: Arc<PeerManager<CommsPublicKey, CommsDataStore>>,
+        peer_manager: Arc<PeerManager<CommsDataStore>>,
     ) -> Result<Arc<OutboundMessageService>, CommsBuilderError>
     {
         OutboundMessageService::new(
@@ -228,7 +228,7 @@ where
     fn make_outbound_message_pool(
         &mut self,
         message_sink_address: InprocAddress,
-        peer_manager: Arc<PeerManager<CommsPublicKey, CommsDataStore>>,
+        peer_manager: Arc<PeerManager<CommsDataStore>>,
         connection_manager: Arc<ConnectionManager>,
     ) -> OutboundMessagePool
     {
@@ -251,7 +251,7 @@ where
         message_sink_address: InprocAddress,
         inbound_message_broker: Arc<InboundMessageBroker<MType>>,
         oms: Arc<OutboundMessageService>,
-        peer_manager: Arc<PeerManager<CommsPublicKey, CommsDataStore>>,
+        peer_manager: Arc<PeerManager<CommsDataStore>>,
     ) -> InboundMessageService<MType>
     {
         let config = self.ims_config.take().unwrap_or_default();

--- a/comms/src/connection/connection.rs
+++ b/comms/src/connection/connection.rs
@@ -354,7 +354,8 @@ impl EstablishedConnection {
             .map_err(|e| ConnectionError::SocketError(format!("Error sending: {} ({})", e, e.to_raw())))
     }
 
-    pub(crate) fn get_socket(&self) -> &zmq::Socket {
+    #[cfg(test)]
+    pub fn get_socket(&self) -> &zmq::Socket {
         &self.socket
     }
 

--- a/comms/src/connection_manager/establisher.rs
+++ b/comms/src/connection_manager/establisher.rs
@@ -273,7 +273,7 @@ struct ConnectionAttempts<'c, F> {
 }
 
 impl<'c, F> ConnectionAttempts<'c, F>
-where F: Fn(usize, InprocAddress) -> Result<(EstablishedConnection, NetAddress)>
+where F: Fn(InprocAddress, usize) -> Result<(EstablishedConnection, NetAddress)>
 {
     pub fn new(context: &'c ZmqContext, peer_manager: Arc<PeerManager<CommsDataStore>>, attempt_fn: F) -> Self {
         Self {

--- a/comms/src/connection_manager/establisher.rs
+++ b/comms/src/connection_manager/establisher.rs
@@ -41,8 +41,7 @@ use crate::{
     types::CommsDataStore,
 };
 use log::*;
-use std::{hash::Hash, net::IpAddr, sync::Arc, time::Duration};
-use tari_crypto::keys::PublicKey;
+use std::{net::IpAddr, sync::Arc, time::Duration};
 
 const LOG_TARGET: &'static str = "comms::connection_manager::establisher";
 
@@ -85,20 +84,18 @@ impl Default for PeerConnectionConfig {
 /// the peer stats for failed/successful connection attempts. This component does not hold any
 /// connections, but returns them so that the caller may use them as needed. This component does
 /// not complete the peer connection protocol, it simply creates connections with some reliability.
-pub struct ConnectionEstablisher<PK> {
+pub struct ConnectionEstablisher {
     context: ZmqContext,
     config: PeerConnectionConfig,
-    peer_manager: Arc<PeerManager<PK, CommsDataStore>>,
+    peer_manager: Arc<PeerManager<CommsDataStore>>,
 }
 
-impl<PK> ConnectionEstablisher<PK>
-where PK: PublicKey + Hash
-{
+impl ConnectionEstablisher {
     /// Create a new ConnectionEstablisher.
     pub fn new(
         context: ZmqContext,
         config: PeerConnectionConfig,
-        peer_manager: Arc<PeerManager<PK, CommsDataStore>>,
+        peer_manager: Arc<PeerManager<CommsDataStore>>,
     ) -> Self
     {
         Self {
@@ -119,7 +116,7 @@ where PK: PublicKey + Hash
     /// - `peer`: `&Peer<CommsPublicKey>` - The peer to connect to
     pub fn establish_control_service_connection(
         &self,
-        peer: &Peer<PK>,
+        peer: &Peer,
     ) -> Result<(EstablishedConnection, ConnectionMonitor)>
     {
         let config = &self.config;
@@ -273,19 +270,17 @@ where PK: PublicKey + Hash
 
 /// Helper struct which enables multiple attempts at connecting. This also updates the peers connection
 /// attempts statistics
-struct ConnectionAttempts<'c, PK, F> {
+struct ConnectionAttempts<'c, F> {
     context: &'c ZmqContext,
     num_attempts: usize,
     attempt_fn: F,
-    peer_manager: Arc<PeerManager<PK, CommsDataStore>>,
+    peer_manager: Arc<PeerManager<CommsDataStore>>,
 }
 
-impl<'c, PK, F> ConnectionAttempts<'c, PK, F>
-where
-    F: Fn(usize, InprocAddress) -> Result<(EstablishedConnection, NetAddress)>,
-    PK: PublicKey + Hash,
+impl<'c, F> ConnectionAttempts<'c, F>
+where F: Fn(usize, InprocAddress) -> Result<(EstablishedConnection, NetAddress)>
 {
-    pub fn new(context: &'c ZmqContext, peer_manager: Arc<PeerManager<PK, CommsDataStore>>, attempt_fn: F) -> Self {
+    pub fn new(context: &'c ZmqContext, peer_manager: Arc<PeerManager<CommsDataStore>>, attempt_fn: F) -> Self {
         Self {
             context,
             num_attempts: 0,

--- a/comms/src/connection_manager/protocol.rs
+++ b/comms/src/connection_manager/protocol.rs
@@ -36,11 +36,11 @@ const LOG_TARGET: &'static str = "comms::connection_manager::protocol";
 
 pub(crate) struct PeerConnectionProtocol<'e, 'ni> {
     node_identity: &'ni Arc<NodeIdentity>,
-    establisher: &'e ConnectionEstablisher<CommsPublicKey>,
+    establisher: &'e ConnectionEstablisher,
 }
 
 impl<'e, 'ni> PeerConnectionProtocol<'e, 'ni> {
-    pub fn new(node_identity: &'ni Arc<NodeIdentity>, establisher: &'e ConnectionEstablisher<CommsPublicKey>) -> Self {
+    pub fn new(node_identity: &'ni Arc<NodeIdentity>, establisher: &'e ConnectionEstablisher) -> Self {
         Self {
             node_identity,
             establisher,
@@ -48,11 +48,7 @@ impl<'e, 'ni> PeerConnectionProtocol<'e, 'ni> {
     }
 
     /// Send Establish connection message to the peers control port to request a connection
-    pub fn negotiate_peer_connection(
-        &self,
-        peer: &Peer<CommsPublicKey>,
-    ) -> Result<(Arc<PeerConnection>, PeerConnectionJoinHandle)>
-    {
+    pub fn negotiate_peer_connection(&self, peer: &Peer) -> Result<(Arc<PeerConnection>, PeerConnectionJoinHandle)> {
         info!(target: LOG_TARGET, "[NodeId={}] Negotiating connection", peer.node_id);
         let (control_port_conn, monitor) = self.establisher.establish_control_service_connection(&peer)?;
         info!(
@@ -111,7 +107,7 @@ impl<'e, 'ni> PeerConnectionProtocol<'e, 'ni> {
 
     fn send_establish_message(
         &self,
-        peer: &Peer<CommsPublicKey>,
+        peer: &Peer,
         control_conn: &EstablishedConnection,
         msg: EstablishConnection<CommsPublicKey>,
     ) -> Result<()>
@@ -140,7 +136,7 @@ impl<'e, 'ni> PeerConnectionProtocol<'e, 'ni> {
 
     fn open_inbound_peer_connection(
         &self,
-        peer: &Peer<CommsPublicKey>,
+        peer: &Peer,
     ) -> Result<(Arc<PeerConnection>, CurvePublicKey, PeerConnectionJoinHandle)>
     {
         let (secret_key, public_key) =

--- a/comms/src/control_service/service.rs
+++ b/comms/src/control_service/service.rs
@@ -91,7 +91,7 @@ where
 /// let context = ZmqContext::new();
 /// let listener_address = "127.0.0.1:9000".parse::<NetAddress>().unwrap();
 ///
-/// let peer_manager = Arc::new(PeerManager::<CommsPublicKey, LMDBStore>::new(None).unwrap());
+/// let peer_manager = Arc::new(PeerManager::<LMDBStore>::new(None).unwrap());
 ///
 /// let conn_manager = Arc::new(ConnectionManager::new(context.clone(), node_identity.clone(), peer_manager.clone(), PeerConnectionConfig {
 ///      max_message_size: 1024,

--- a/comms/src/control_service/types.rs
+++ b/comms/src/control_service/types.rs
@@ -73,7 +73,7 @@ where MType: Clone
     pub envelope_header: MessageEnvelopeHeader<CommsPublicKey>,
     pub message: Message,
     pub connection_manager: Arc<ConnectionManager>,
-    pub peer_manager: Arc<PeerManager<CommsPublicKey, LMDBStore>>,
+    pub peer_manager: Arc<PeerManager<LMDBStore>>,
     pub node_identity: Arc<NodeIdentity>,
     pub config: ControlServiceConfig<MType>,
 }

--- a/comms/src/domain_connector.rs
+++ b/comms/src/domain_connector.rs
@@ -28,7 +28,6 @@ use crate::{
 use derive_error::Error;
 use serde::{Deserialize, Serialize};
 use std::{marker::PhantomData, time::Duration};
-use tari_crypto::ristretto::RistrettoPublicKey;
 use tari_utilities::message_format::{MessageFormat, MessageFormatError};
 
 #[derive(Debug, Error)]
@@ -44,7 +43,7 @@ pub enum ConnectorError {
 
 /// Information about the message received
 pub struct MessageInfo {
-    pub source_identity: PeerNodeIdentity<RistrettoPublicKey>,
+    pub source_identity: PeerNodeIdentity,
 }
 
 /// # DomainConnector

--- a/comms/src/inbound_message_service/inbound_message_service.rs
+++ b/comms/src/inbound_message_service/inbound_message_service.rs
@@ -31,7 +31,7 @@ use crate::{
     message::MessageContext,
     outbound_message_service::outbound_message_service::OutboundMessageService,
     peer_manager::{peer_manager::PeerManager, NodeIdentity},
-    types::{CommsDataStore, CommsPublicKey, MessageDispatcher},
+    types::{CommsDataStore, MessageDispatcher},
 };
 use log::*;
 use serde::{de::DeserializeOwned, Serialize};
@@ -76,7 +76,7 @@ where
     message_dispatcher: Arc<MessageDispatcher<MessageContext<MType>>>,
     inbound_message_broker: Arc<InboundMessageBroker<MType>>,
     outbound_message_service: Arc<OutboundMessageService>,
-    peer_manager: Arc<PeerManager<CommsPublicKey, CommsDataStore>>,
+    peer_manager: Arc<PeerManager<CommsDataStore>>,
     worker_thread_handle: Option<JoinHandle<()>>,
     worker_control_sender: Option<SyncSender<ControlMessage>>,
 }
@@ -96,7 +96,7 @@ where
         message_dispatcher: Arc<MessageDispatcher<MessageContext<MType>>>,
         inbound_message_broker: Arc<InboundMessageBroker<MType>>,
         outbound_message_service: Arc<OutboundMessageService>,
-        peer_manager: Arc<PeerManager<CommsPublicKey, CommsDataStore>>,
+        peer_manager: Arc<PeerManager<CommsDataStore>>,
     ) -> Self
     {
         InboundMessageService {
@@ -167,7 +167,7 @@ mod test {
             NodeDestination,
         },
         peer_manager::{peer_manager::PeerManager, NodeId, NodeIdentity, Peer, PeerFlags},
-        types::{CommsDataStore, CommsPublicKey},
+        types::CommsDataStore,
     };
     use serde::{Deserialize, Serialize};
     use std::{sync::Arc, thread, time::Duration};
@@ -213,7 +213,7 @@ mod test {
                 .unwrap(),
         );
 
-        let peer_manager = Arc::new(PeerManager::<CommsPublicKey, CommsDataStore>::new(None).unwrap());
+        let peer_manager = Arc::new(PeerManager::<CommsDataStore>::new(None).unwrap());
         // Add peer to peer manager
         let peer = Peer::new(
             node_identity.identity.public_key.clone(),

--- a/comms/src/inbound_message_service/inbound_message_worker.rs
+++ b/comms/src/inbound_message_service/inbound_message_worker.rs
@@ -38,7 +38,7 @@ use crate::{
     message::{FrameSet, MessageContext, MessageData},
     outbound_message_service::outbound_message_service::OutboundMessageService,
     peer_manager::{peer_manager::PeerManager, NodeId, NodeIdentity, Peer},
-    types::{CommsDataStore, CommsPublicKey, MessageDispatcher},
+    types::{CommsDataStore, MessageDispatcher},
 };
 use log::*;
 use serde::{de::DeserializeOwned, Serialize};
@@ -67,7 +67,7 @@ where
     message_dispatcher: Arc<MessageDispatcher<MessageContext<MType>>>,
     inbound_message_broker: Arc<InboundMessageBroker<MType>>,
     outbound_message_service: Arc<OutboundMessageService>,
-    peer_manager: Arc<PeerManager<CommsPublicKey, CommsDataStore>>,
+    peer_manager: Arc<PeerManager<CommsDataStore>>,
     control_receiver: Option<Receiver<ControlMessage>>,
     is_running: bool,
 }
@@ -87,7 +87,7 @@ where
         message_dispatcher: Arc<MessageDispatcher<MessageContext<MType>>>,
         inbound_message_broker: Arc<InboundMessageBroker<MType>>,
         outbound_message_service: Arc<OutboundMessageService>,
-        peer_manager: Arc<PeerManager<CommsPublicKey, CommsDataStore>>,
+        peer_manager: Arc<PeerManager<CommsDataStore>>,
     ) -> Self
     {
         InboundMessageWorker {
@@ -104,7 +104,7 @@ where
         }
     }
 
-    fn lookup_peer(&self, node_id: &NodeId) -> Option<Peer<CommsPublicKey>> {
+    fn lookup_peer(&self, node_id: &NodeId) -> Option<Peer> {
         self.peer_manager.find_with_node_id(node_id).ok()
     }
 
@@ -235,7 +235,7 @@ mod test {
             NodeDestination,
         },
         peer_manager::{peer_manager::PeerManager, NodeIdentity, PeerFlags},
-        types::{CommsDataStore, CommsPublicKey},
+        types::CommsDataStore,
     };
     use serde::{Deserialize, Serialize};
     use std::{
@@ -285,7 +285,7 @@ mod test {
                 .start()
                 .unwrap(),
         );
-        let peer_manager = Arc::new(PeerManager::<CommsPublicKey, CommsDataStore>::new(None).unwrap());
+        let peer_manager = Arc::new(PeerManager::<CommsDataStore>::new(None).unwrap());
         // Add peer to peer manager
         let peer = Peer::new(
             node_identity.identity.public_key.clone(),

--- a/comms/src/message/domain_message_context.rs
+++ b/comms/src/message/domain_message_context.rs
@@ -20,21 +20,21 @@
 //  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 //  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use crate::{message::message::Message, peer_manager::PeerNodeIdentity, types::CommsPublicKey};
+use crate::{message::message::Message, peer_manager::PeerNodeIdentity};
 use serde::{Deserialize, Serialize};
 
 /// The DomainMessageContext is the container that will be dispatched to the domain handlers. It contains the received
 /// message and source identity after the comms level envelope has been removed.
 #[derive(Serialize, Deserialize)]
 pub struct DomainMessageContext {
-    pub source_identity: PeerNodeIdentity<CommsPublicKey>,
+    pub source_identity: PeerNodeIdentity,
     pub message: Message,
 }
 
 impl DomainMessageContext {
     /// Construct a new DomainMessageContext that consist of the peer connection information and the received message
     /// header and body
-    pub fn new(source_identity: PeerNodeIdentity<CommsPublicKey>, message: Message) -> Self {
+    pub fn new(source_identity: PeerNodeIdentity, message: Message) -> Self {
         DomainMessageContext {
             source_identity,
             message,

--- a/comms/src/message/message_context.rs
+++ b/comms/src/message/message_context.rs
@@ -25,7 +25,7 @@ use crate::{
     message::MessageEnvelope,
     outbound_message_service::outbound_message_service::OutboundMessageService,
     peer_manager::{peer_manager::PeerManager, NodeIdentity, Peer},
-    types::{CommsDataStore, CommsPublicKey},
+    types::CommsDataStore,
 };
 use serde::{de::DeserializeOwned, Serialize};
 use std::sync::Arc;
@@ -33,9 +33,9 @@ use std::sync::Arc;
 #[derive(Clone)]
 pub struct MessageContext<MType> {
     pub message_envelope: MessageEnvelope,
-    pub peer: Peer<CommsPublicKey>,
+    pub peer: Peer,
     pub outbound_message_service: Arc<OutboundMessageService>,
-    pub peer_manager: Arc<PeerManager<CommsPublicKey, CommsDataStore>>,
+    pub peer_manager: Arc<PeerManager<CommsDataStore>>,
     pub inbound_message_broker: Arc<InboundMessageBroker<MType>>,
     pub node_identity: Arc<NodeIdentity>,
 }
@@ -49,10 +49,10 @@ where
     /// and body
     pub fn new(
         node_identity: Arc<NodeIdentity>,
-        peer: Peer<CommsPublicKey>,
+        peer: Peer,
         message_envelope: MessageEnvelope,
         outbound_message_service: Arc<OutboundMessageService>,
-        peer_manager: Arc<PeerManager<CommsPublicKey, CommsDataStore>>,
+        peer_manager: Arc<PeerManager<CommsDataStore>>,
         inbound_message_broker: Arc<InboundMessageBroker<MType>>,
     ) -> Self
     {

--- a/comms/src/outbound_message_service/broadcast_strategy.rs
+++ b/comms/src/outbound_message_service/broadcast_strategy.rs
@@ -20,17 +20,17 @@
 //  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 //  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use crate::peer_manager::node_id::NodeId;
+use crate::{peer_manager::node_id::NodeId, types::CommsPublicKey};
 
 pub struct ClosestRequest {
     pub n: usize,
     pub node_id: NodeId,
 }
 
-pub enum BroadcastStrategy<PubKey> {
-    DirectNodeId(NodeId),    // Send to a particular peer matching the given node ID
-    DirectPublicKey(PubKey), // Send to a particular peer matching the given Public Key
-    Flood,                   // Send to all known Communication Node peers
-    Closest(ClosestRequest), // Send to all n nearest neighbour Communication Nodes
-    Random(usize),           // Send to a random set of peers of size n that are Communication Nodes
+pub enum BroadcastStrategy {
+    DirectNodeId(NodeId),            // Send to a particular peer matching the given node ID
+    DirectPublicKey(CommsPublicKey), // Send to a particular peer matching the given Public Key
+    Flood,                           // Send to all known Communication Node peers
+    Closest(ClosestRequest),         // Send to all n nearest neighbour Communication Nodes
+    Random(usize),                   // Send to a random set of peers of size n that are Communication Nodes
 }

--- a/comms/src/outbound_message_service/message_pool_worker.rs
+++ b/comms/src/outbound_message_service/message_pool_worker.rs
@@ -35,7 +35,7 @@ use crate::{
     connection_manager::ConnectionManager,
     message::{FrameSet, MessageEnvelope},
     peer_manager::PeerManager,
-    types::{CommsDataStore, CommsPublicKey},
+    types::CommsDataStore,
 };
 use chrono::Utc;
 use log::*;
@@ -67,7 +67,7 @@ pub struct MessagePoolWorker {
     context: ZmqContext,
     inbound_address: InprocAddress,
     message_requeue_address: InprocAddress,
-    peer_manager: Arc<PeerManager<CommsPublicKey, CommsDataStore>>,
+    peer_manager: Arc<PeerManager<CommsDataStore>>,
     connection_manager: Arc<ConnectionManager>,
     control_receiver: Option<Receiver<ControlMessage>>,
     is_running: bool,
@@ -81,7 +81,7 @@ impl MessagePoolWorker {
         context: ZmqContext,
         inbound_address: InprocAddress,
         message_requeue_address: InprocAddress,
-        peer_manager: Arc<PeerManager<CommsPublicKey, CommsDataStore>>,
+        peer_manager: Arc<PeerManager<CommsDataStore>>,
         connection_manager: Arc<ConnectionManager>,
     ) -> MessagePoolWorker
     {

--- a/comms/src/outbound_message_service/outbound_message_pool.rs
+++ b/comms/src/outbound_message_service/outbound_message_pool.rs
@@ -28,7 +28,7 @@ use crate::{
     connection_manager::ConnectionManager,
     outbound_message_service::{MessagePoolWorker, OutboundError},
     peer_manager::PeerManager,
-    types::{CommsDataStore, CommsPublicKey},
+    types::CommsDataStore,
 };
 use log::*;
 #[cfg(test)]
@@ -76,7 +76,7 @@ pub struct OutboundMessagePool {
     context: ZmqContext,
     message_requeue_address: InprocAddress,
     worker_dealer_address: InprocAddress,
-    peer_manager: Arc<PeerManager<CommsPublicKey, CommsDataStore>>,
+    peer_manager: Arc<PeerManager<CommsDataStore>>,
     connection_manager: Arc<ConnectionManager>,
     worker_thread_handles: Vec<JoinHandle<()>>,
     worker_control_senders: Vec<SyncSender<ControlMessage>>,
@@ -100,7 +100,7 @@ impl OutboundMessagePool {
         context: ZmqContext,
         message_queue_address: InprocAddress,
         message_requeue_address: InprocAddress,
-        peer_manager: Arc<PeerManager<CommsPublicKey, CommsDataStore>>,
+        peer_manager: Arc<PeerManager<CommsDataStore>>,
         connection_manager: Arc<ConnectionManager>,
     ) -> OutboundMessagePool
     {
@@ -203,7 +203,7 @@ mod test {
             OutboundMessagePool,
         },
         peer_manager::{peer::PeerFlags, NodeId, NodeIdentity, Peer, PeerManager},
-        types::{CommsDataStore, CommsPublicKey},
+        types::CommsDataStore,
     };
     use std::{sync::Arc, thread, time::Duration};
     use tari_crypto::{keys::PublicKey, ristretto::RistrettoPublicKey};
@@ -230,7 +230,7 @@ mod test {
         let context = ZmqContext::new();
         let node_identity = Arc::new(NodeIdentity::random_for_test(None));
 
-        let peer_manager = Arc::new(PeerManager::<CommsPublicKey, CommsDataStore>::new(None).unwrap());
+        let peer_manager = Arc::new(PeerManager::<CommsDataStore>::new(None).unwrap());
 
         let local_consumer_address = InprocAddress::random();
         let connection_manager = Arc::new(ConnectionManager::new(
@@ -243,8 +243,7 @@ mod test {
         let (_dest_sk, pk) = RistrettoPublicKey::random_keypair(&mut rng);
         let node_id = NodeId::from_key(&pk.clone()).unwrap();
         let net_addresses = NetAddressesWithStats::from("1.2.3.4:45325".parse::<NetAddress>().unwrap());
-        let dest_peer: Peer<RistrettoPublicKey> =
-            Peer::<RistrettoPublicKey>::new(pk.clone(), node_id, net_addresses, PeerFlags::default());
+        let dest_peer = Peer::new(pk.clone(), node_id, net_addresses, PeerFlags::default());
         peer_manager.add_peer(dest_peer.clone()).unwrap();
 
         let omp_inbound_address = InprocAddress::random();
@@ -313,7 +312,7 @@ mod test {
         let mut rng = rand::OsRng::new().unwrap();
         let context = ZmqContext::new();
         let node_identity = Arc::new(NodeIdentity::random_for_test(None));
-        let peer_manager = Arc::new(PeerManager::<CommsPublicKey, CommsDataStore>::new(None).unwrap());
+        let peer_manager = Arc::new(PeerManager::<CommsDataStore>::new(None).unwrap());
         let connection_manager = Arc::new(ConnectionManager::new(
             context.clone(),
             node_identity.clone(),
@@ -324,8 +323,7 @@ mod test {
         let (_dest_sk, pk) = RistrettoPublicKey::random_keypair(&mut rng);
         let node_id = NodeId::from_key(&pk.clone()).unwrap();
         let net_addresses = NetAddressesWithStats::from("1.2.3.4:45325".parse::<NetAddress>().unwrap());
-        let dest_peer: Peer<RistrettoPublicKey> =
-            Peer::<RistrettoPublicKey>::new(pk.clone(), node_id, net_addresses, PeerFlags::default());
+        let dest_peer = Peer::new(pk.clone(), node_id, net_addresses, PeerFlags::default());
         peer_manager.add_peer(dest_peer.clone()).unwrap();
 
         let omp_inbound_address = InprocAddress::random();

--- a/comms/src/outbound_message_service/outbound_message_service.rs
+++ b/comms/src/outbound_message_service/outbound_message_service.rs
@@ -30,7 +30,7 @@ use crate::{
     message::{Frame, MessageEnvelope, MessageFlags, NodeDestination},
     outbound_message_service::{BroadcastStrategy, OutboundError, OutboundMessage},
     peer_manager::{peer_manager::PeerManager, NodeIdentity},
-    types::{CommsDataStore, CommsPublicKey},
+    types::CommsDataStore,
 };
 use std::sync::Arc;
 use tari_utilities::message_format::MessageFormat;
@@ -42,7 +42,7 @@ pub struct OutboundMessageService {
     context: ZmqContext,
     outbound_address: InprocAddress,
     node_identity: Arc<NodeIdentity>,
-    peer_manager: Arc<PeerManager<CommsPublicKey, CommsDataStore>>,
+    peer_manager: Arc<PeerManager<CommsDataStore>>,
 }
 
 impl OutboundMessageService {
@@ -52,7 +52,7 @@ impl OutboundMessageService {
         node_identity: Arc<NodeIdentity>,
         outbound_address: InprocAddress, /* The outbound_address is an inproc that connects the OutboundMessagePool
                                           * and the OutboundMessageService */
-        peer_manager: Arc<PeerManager<CommsPublicKey, CommsDataStore>>,
+        peer_manager: Arc<PeerManager<CommsDataStore>>,
     ) -> Result<OutboundMessageService, OutboundError>
     {
         Ok(OutboundMessageService {
@@ -67,7 +67,7 @@ impl OutboundMessageService {
     /// BroadcastStrategy
     pub fn send(
         &self,
-        broadcast_strategy: BroadcastStrategy<CommsPublicKey>,
+        broadcast_strategy: BroadcastStrategy,
         flags: MessageFlags,
         message_envelope_body: Frame,
     ) -> Result<(), OutboundError>
@@ -148,11 +148,10 @@ mod test {
         let (dest_sk, pk) = RistrettoPublicKey::random_keypair(&mut rng);
         let node_id = NodeId::from_key(&pk).unwrap();
         let net_addresses = NetAddressesWithStats::from("1.2.3.4:8000".parse::<NetAddress>().unwrap());
-        let dest_peer: Peer<RistrettoPublicKey> =
-            Peer::<RistrettoPublicKey>::new(pk, node_id, net_addresses, PeerFlags::default());
+        let dest_peer = Peer::new(pk, node_id, net_addresses, PeerFlags::default());
 
         // Setup OutboundMessageService and transmit a message to the destination
-        let peer_manager = Arc::new(PeerManager::<CommsPublicKey, LMDBStore>::new(None).unwrap());
+        let peer_manager = Arc::new(PeerManager::<LMDBStore>::new(None).unwrap());
         peer_manager.add_peer(dest_peer.clone()).unwrap();
 
         let outbound_message_service =

--- a/comms/src/peer_manager/mod.rs
+++ b/comms/src/peer_manager/mod.rs
@@ -41,8 +41,8 @@
 //! let (dest_sk, pk) = CommsPublicKey::random_keypair(&mut rng);
 //! let node_id = NodeId::from_key(&pk).unwrap();
 //! let net_addresses = NetAddressesWithStats::from("1.2.3.4:8000".parse::<NetAddress>().unwrap());
-//! let peer: Peer<CommsPublicKey> = Peer::<CommsPublicKey>::new(pk, node_id.clone(), net_addresses, PeerFlags::default());
-//! let peer_manager = PeerManager::<CommsPublicKey, LMDBStore>::new(None).unwrap();
+//! let peer = Peer::new(pk, node_id.clone(), net_addresses, PeerFlags::default());
+//! let peer_manager = PeerManager::<LMDBStore>::new(None).unwrap();
 //! peer_manager.add_peer(peer.clone());
 //!
 //! let returned_peer = peer_manager.find_with_node_id(&node_id).unwrap();

--- a/comms/tests/connection_manager/manager.rs
+++ b/comms/tests/connection_manager/manager.rs
@@ -30,7 +30,7 @@ use tari_comms::{
     connection_manager::{ConnectionManager, PeerConnectionConfig},
     control_service::{ControlService, ControlServiceConfig},
     peer_manager::{Peer, PeerManager},
-    types::{CommsDataStore, CommsPublicKey},
+    types::CommsDataStore,
 };
 
 fn make_peer_connection_config(consumer_address: InprocAddress) -> PeerConnectionConfig {
@@ -44,7 +44,7 @@ fn make_peer_connection_config(consumer_address: InprocAddress) -> PeerConnectio
     }
 }
 
-fn make_peer_manager(peers: Vec<Peer<CommsPublicKey>>) -> Arc<PeerManager<CommsPublicKey, CommsDataStore>> {
+fn make_peer_manager(peers: Vec<Peer>) -> Arc<PeerManager<CommsDataStore>> {
     Arc::new(factories::peer_manager::create().with_peers(peers).build().unwrap())
 }
 

--- a/comms/tests/outbound_message_service/outbound_message_pool.rs
+++ b/comms/tests/outbound_message_service/outbound_message_pool.rs
@@ -39,7 +39,7 @@ use tari_comms::{
         OutboundMessagePool,
     },
     peer_manager::{Peer, PeerManager},
-    types::{CommsDataStore, CommsPublicKey},
+    types::CommsDataStore,
 };
 
 fn make_peer_connection_config(consumer_address: InprocAddress) -> PeerConnectionConfig {
@@ -53,7 +53,7 @@ fn make_peer_connection_config(consumer_address: InprocAddress) -> PeerConnectio
     }
 }
 
-fn make_peer_manager(peers: Vec<Peer<CommsPublicKey>>) -> Arc<PeerManager<CommsPublicKey, CommsDataStore>> {
+fn make_peer_manager(peers: Vec<Peer>) -> Arc<PeerManager<CommsDataStore>> {
     Arc::new(factories::peer_manager::create().with_peers(peers).build().unwrap())
 }
 

--- a/comms/tests/support/factories/connection_manager.rs
+++ b/comms/tests/support/factories/connection_manager.rs
@@ -31,7 +31,7 @@ use tari_comms::{
     connection::ZmqContext,
     connection_manager::{ConnectionManager, PeerConnectionConfig},
     peer_manager::{NodeIdentity, PeerManager},
-    types::{CommsDataStore, CommsPublicKey},
+    types::CommsDataStore,
 };
 
 pub fn create() -> ConnectionManagerFactory {
@@ -42,7 +42,7 @@ pub fn create() -> ConnectionManagerFactory {
 pub struct ConnectionManagerFactory {
     zmq_context: Option<ZmqContext>,
     peer_connection_config: PeerConnectionConfig,
-    peer_manager: Option<Arc<PeerManager<CommsPublicKey, CommsDataStore>>>,
+    peer_manager: Option<Arc<PeerManager<CommsDataStore>>>,
     peer_manager_factory: PeerManagerFactory,
     node_identity_factory: NodeIdentityFactory,
     node_identity: Option<Arc<NodeIdentity>>,
@@ -58,7 +58,7 @@ impl ConnectionManagerFactory {
     factory_setter!(
         with_peer_manager,
         peer_manager,
-        Option<Arc<PeerManager<CommsPublicKey, CommsDataStore>>>
+        Option<Arc<PeerManager<CommsDataStore>>>
     );
 
     factory_setter!(with_peer_manager_factory, peer_manager_factory, PeerManagerFactory);

--- a/comms/tests/support/factories/peer.rs
+++ b/comms/tests/support/factories/peer.rs
@@ -62,7 +62,7 @@ impl PeerFactory {
 }
 
 impl TestFactory for PeerFactory {
-    type Object = Peer<CommsPublicKey>;
+    type Object = Peer;
 
     fn build(self) -> Result<Self::Object, TestFactoryError> {
         let node_id = self.node_id.clone().or(Some(node_id_maker::make_node_id())).unwrap();
@@ -105,17 +105,17 @@ impl PeersFactory {
 
     factory_setter!(with_factory, peer_factory, PeerFactory);
 
-    fn create_peer(&self) -> Peer<CommsPublicKey> {
+    fn create_peer(&self) -> Peer {
         self.peer_factory.clone().build().unwrap()
     }
 }
 
 impl TestFactory for PeersFactory {
-    type Object = Vec<Peer<CommsPublicKey>>;
+    type Object = Vec<Peer>;
 
     fn build(self) -> Result<Self::Object, TestFactoryError> {
         Ok(repeat_with(|| self.create_peer())
             .take(self.count.or(Some(1)).unwrap())
-            .collect::<Vec<Peer<CommsPublicKey>>>())
+            .collect::<Vec<Peer>>())
     }
 }

--- a/comms/tests/support/factories/peer_manager.rs
+++ b/comms/tests/support/factories/peer_manager.rs
@@ -24,7 +24,7 @@ use super::{peer::PeersFactory, TestFactory, TestFactoryError};
 
 use tari_comms::{
     peer_manager::{Peer, PeerManager},
-    types::{CommsDataStore, CommsPublicKey},
+    types::CommsDataStore,
 };
 
 pub fn create() -> PeerManagerFactory {
@@ -34,20 +34,20 @@ pub fn create() -> PeerManagerFactory {
 #[derive(Default)]
 pub struct PeerManagerFactory {
     peers_factory: PeersFactory,
-    peers: Option<Vec<Peer<CommsPublicKey>>>,
+    peers: Option<Vec<Peer>>,
 }
 
 impl PeerManagerFactory {
     factory_setter!(with_peers_factory, peers_factory, PeersFactory);
 
-    factory_setter!(with_peers, peers, Option<Vec<Peer<CommsPublicKey>>>);
+    factory_setter!(with_peers, peers, Option<Vec<Peer>>);
 }
 
 impl TestFactory for PeerManagerFactory {
-    type Object = PeerManager<CommsPublicKey, CommsDataStore>;
+    type Object = PeerManager<CommsDataStore>;
 
     fn build(self) -> Result<Self::Object, TestFactoryError> {
-        let pm = PeerManager::<CommsPublicKey, CommsDataStore>::new(None)
+        let pm = PeerManager::<CommsDataStore>::new(None)
             .map_err(|err| TestFactoryError::BuildFailed(format!("Failed to build peer manager: {:?}", err)))?;
 
         let peers = self

--- a/infrastructure/crypto/src/ristretto/serialize.rs
+++ b/infrastructure/crypto/src/ristretto/serialize.rs
@@ -41,10 +41,7 @@
 //!   }
 //! ```
 
-use crate::{
-    keys::{PublicKey, SecretKey},
-    ristretto::{RistrettoPublicKey, RistrettoSecretKey},
-};
+use crate::ristretto::{RistrettoPublicKey, RistrettoSecretKey};
 use serde::{
     de::{self, Visitor},
     Deserialize,
@@ -52,56 +49,8 @@ use serde::{
     Serialize,
     Serializer,
 };
-use std::{fmt, marker::PhantomData};
+use std::fmt;
 use tari_utilities::{byte_array::ByteArray, hex::Hex};
-
-pub fn secret_from_hex<'de, D, K>(des: D) -> Result<K, D::Error>
-where
-    D: Deserializer<'de>,
-    K: Hex + SecretKey,
-{
-    struct KeyStringVisitor<K> {
-        marker: PhantomData<K>,
-    };
-
-    impl<'de, K: SecretKey> de::Visitor<'de> for KeyStringVisitor<K> {
-        type Value = K;
-
-        fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
-            formatter.write_str("a secret key in hex format")
-        }
-
-        fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
-        where E: de::Error {
-            K::from_hex(v).map_err(E::custom)
-        }
-    }
-    des.deserialize_str(KeyStringVisitor { marker: PhantomData })
-}
-
-pub fn pubkey_from_hex<'de, D, K>(des: D) -> Result<K, D::Error>
-where
-    D: Deserializer<'de>,
-    K: Hex + PublicKey,
-{
-    struct KeyStringVisitor<K> {
-        marker: PhantomData<K>,
-    };
-
-    impl<'de, K: PublicKey> Visitor<'de> for KeyStringVisitor<K> {
-        type Value = K;
-
-        fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
-            formatter.write_str("a public key in hex format")
-        }
-
-        fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
-        where E: de::Error {
-            K::from_hex(v).map_err(E::custom)
-        }
-    }
-    des.deserialize_str(KeyStringVisitor { marker: PhantomData })
-}
 
 impl<'de> Deserialize<'de> for RistrettoPublicKey {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>


### PR DESCRIPTION
Since RistrettoPubKey now has "intelligent" serialisation (it serialises to hex for
"human readable formats" and binary otherwise), we no longer need the "serialize_to_hex"
attribute on some structs with public keys.

This seemingly small change had some big effects.

Firstly, the MessageFormat trait bounds changed from Deserialize to DeserializeOwned.
This is, I believe, the correct move anyway, but this change triggered a cascade of
dependency issues among the generic type definitions in Peer and related structs.

After discussing with the team, we decided to remove the generic parameter in Peer
and use a concrete pubkey type from types.rs.

This then meant combing through nearly every file in the Comms library to strip
out the generic dependencies.

<!--- Provide a general summary of your changes in the Title above -->


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [x] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch
* [x] I ran `cargo-fmt --all` before pushing
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
