### PR TITLE
Removed 1.2.3.4 IP addresses in OMS tests

### DIFF
--- a/comms/src/outbound_message_service/outbound_message_pool.rs
+++ b/comms/src/outbound_message_service/outbound_message_pool.rs
@@ -193,7 +193,7 @@ impl OutboundMessagePool {
 #[cfg(test)]
 mod test {
     use crate::{
-        connection::{InprocAddress, NetAddress, NetAddressesWithStats, ZmqContext},
+        connection::{InprocAddress, NetAddress, ZmqContext},
         connection_manager::{ConnectionManager, PeerConnectionConfig},
         message::MessageFlags,
         outbound_message_service::{
@@ -242,7 +242,7 @@ mod test {
 
         let (_dest_sk, pk) = RistrettoPublicKey::random_keypair(&mut rng);
         let node_id = NodeId::from_key(&pk.clone()).unwrap();
-        let net_addresses = NetAddressesWithStats::from("1.2.3.4:45325".parse::<NetAddress>().unwrap());
+        let net_addresses = "127.0.0.1:45326".parse::<NetAddress>().unwrap().into();
         let dest_peer: Peer<RistrettoPublicKey> =
             Peer::<RistrettoPublicKey>::new(pk.clone(), node_id, net_addresses, PeerFlags::default());
         peer_manager.add_peer(dest_peer.clone()).unwrap();
@@ -323,7 +323,7 @@ mod test {
 
         let (_dest_sk, pk) = RistrettoPublicKey::random_keypair(&mut rng);
         let node_id = NodeId::from_key(&pk.clone()).unwrap();
-        let net_addresses = NetAddressesWithStats::from("1.2.3.4:45325".parse::<NetAddress>().unwrap());
+        let net_addresses = "127.0.0.1:45325".parse::<NetAddress>().unwrap().into();
         let dest_peer: Peer<RistrettoPublicKey> =
             Peer::<RistrettoPublicKey>::new(pk.clone(), node_id, net_addresses, PeerFlags::default());
         peer_manager.add_peer(dest_peer.clone()).unwrap();

--- a/comms/src/outbound_message_service/outbound_message_service.rs
+++ b/comms/src/outbound_message_service/outbound_message_service.rs
@@ -114,7 +114,7 @@ mod test {
     use super::*;
 
     use crate::{
-        connection::net_address::{net_addresses::NetAddressesWithStats, NetAddress},
+        connection::net_address::NetAddress,
         message::{FrameSet, Message},
         peer_manager::{
             node_id::NodeId,
@@ -147,7 +147,7 @@ mod test {
 
         let (dest_sk, pk) = RistrettoPublicKey::random_keypair(&mut rng);
         let node_id = NodeId::from_key(&pk).unwrap();
-        let net_addresses = NetAddressesWithStats::from("1.2.3.4:8000".parse::<NetAddress>().unwrap());
+        let net_addresses = "127.0.0.1:55445".parse::<NetAddress>().unwrap().into();
         let dest_peer: Peer<RistrettoPublicKey> =
             Peer::<RistrettoPublicKey>::new(pk, node_id, net_addresses, PeerFlags::default());
 


### PR DESCRIPTION
#  Description
<!--- Describe your changes in detail -->
It's possible that these IP addresses will hit a firewall in circle CI
which cause the connection to "hang" for an extended period of time.

This PR changes those to use the local loopback address.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [x] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch
* [x] I ran `cargo-fmt --all` before pushing
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
