### PR TITLE
OMS send api ergonomic improvement

### DIFF
--- a/base_layer/p2p/src/ping_pong.rs
+++ b/base_layer/p2p/src/ping_pong.rs
@@ -195,7 +195,7 @@ impl Service for PingPongService {
             ServiceError::ServiceInitializationFailed(format!("Failed to create connector for service: {}", err))
         })?;
 
-        self.oms = Some(context.get_outbound_message_service());
+        self.oms = Some(context.outbound_message_service());
 
         loop {
             if let Some(msg) = context.get_control_message(Duration::from_millis(5)) {

--- a/base_layer/p2p/src/services/executor.rs
+++ b/base_layer/p2p/src/services/executor.rs
@@ -154,8 +154,8 @@ impl ServiceContext {
     }
 
     /// Retrieve and `Arc` of the outbound message service. Used for sending outbound messages.
-    pub fn get_outbound_message_service(&self) -> Arc<OutboundMessageService> {
-        self.comms_services.get_outbound_message_service()
+    pub fn outbound_message_service(&self) -> Arc<OutboundMessageService> {
+        self.comms_services.outbound_message_service()
     }
 
     /// Create a [DomainConnector] which listens for a particular [TariMessageType].

--- a/base_layer/wallet/src/text_message_service.rs
+++ b/base_layer/wallet/src/text_message_service.rs
@@ -329,7 +329,7 @@ impl Service for TextMessageService {
                 ServiceError::ServiceInitializationFailed(format!("Failed to create connector for service: {}", err))
             })?;
 
-        self.oms = Some(context.get_outbound_message_service());
+        self.oms = Some(context.outbound_message_service());
         debug!(target: LOG_TARGET, "Starting Text Message Service executor");
         loop {
             if let Some(msg) = context.get_control_message(Duration::from_millis(5)) {

--- a/base_layer/wallet/tests/support/comms_and_services.rs
+++ b/base_layer/wallet/tests/support/comms_and_services.rs
@@ -74,7 +74,7 @@ pub fn setup_text_message_service(
 
     for p in peers {
         comms
-            .peer_manager
+            .peer_manager()
             .add_peer(create_peer(p.identity.public_key.clone(), p.control_service_address))
             .unwrap();
     }

--- a/base_layer/wallet/tests/text_message_service/mod.rs
+++ b/base_layer/wallet/tests/text_message_service/mod.rs
@@ -76,7 +76,7 @@ fn test_text_message_service() {
             (msgs.sent_messages.len(), msgs.received_messages.len())
         },
         (5, 4),
-        50,
+        100,
     );
 
     assert_change(
@@ -85,7 +85,7 @@ fn test_text_message_service() {
             (msgs.sent_messages.len(), msgs.received_messages.len())
         },
         (4, 5),
-        50,
+        100,
     );
 
     node_1_services.shutdown().unwrap();

--- a/base_layer/wallet/tests/wallet/mod.rs
+++ b/base_layer/wallet/tests/wallet/mod.rs
@@ -91,13 +91,13 @@ fn test_wallet() {
 
     wallet1
         .comms_services
-        .peer_manager
+        .peer_manager()
         .add_peer(create_peer(public_key2.clone(), listener_address2))
         .unwrap();
 
     wallet2
         .comms_services
-        .peer_manager
+        .peer_manager()
         .add_peer(create_peer(public_key1.clone(), listener_address1))
         .unwrap();
 

--- a/comms/src/builder/builder.rs
+++ b/comms/src/builder/builder.rs
@@ -424,7 +424,7 @@ pub struct CommsServices<MType> {
     #[allow(dead_code)]
     inbound_message_broker: Arc<InboundMessageBroker<MType>>,
     connection_manager: Arc<ConnectionManager>,
-    pub peer_manager: Arc<PeerManager<CommsDataStore>>,
+    peer_manager: Arc<PeerManager<CommsDataStore>>,
 }
 
 impl<MType> CommsServices<MType>
@@ -432,8 +432,12 @@ where
     MType: DispatchableKey,
     MType: Clone,
 {
-    pub fn get_outbound_message_service(&self) -> Arc<OutboundMessageService> {
-        self.outbound_message_service.clone()
+    pub fn peer_manager(&self) -> &PeerManager<CommsDataStore> {
+        &self.peer_manager
+    }
+
+    pub fn outbound_message_service(&self) -> Arc<OutboundMessageService> {
+        Arc::clone(&self.outbound_message_service)
     }
 
     pub fn create_connector<'de>(&self, message_type: &MType) -> Result<DomainConnector<'de>, CommsServicesError> {

--- a/comms/src/message/message.rs
+++ b/comms/src/message/message.rs
@@ -25,6 +25,7 @@ use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use tari_utilities::message_format::MessageFormat;
 
 use crate::message::{Frame, MessageError};
+use std::convert::TryFrom;
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct MessageHeader<MType> {
@@ -63,6 +64,18 @@ impl Message {
     pub fn to_message<T>(&self) -> Result<T, MessageError>
     where T: MessageFormat {
         T::from_binary(&self.body).map_err(Into::into)
+    }
+}
+
+impl<MType, T> TryFrom<(MType, T)> for Message
+where
+    MessageHeader<MType>: MessageFormat,
+    T: MessageFormat,
+{
+    type Error = MessageError;
+
+    fn try_from((message_type, msg): (MType, T)) -> Result<Self, Self::Error> {
+        Ok(Self::from_message_format(MessageHeader { message_type }, msg)?)
     }
 }
 

--- a/comms/src/outbound_message_service/outbound_message_pool.rs
+++ b/comms/src/outbound_message_service/outbound_message_pool.rs
@@ -223,88 +223,88 @@ mod test {
         }
     }
 
-    //    #[test]
-    //    fn outbound_message_pool_threading_test() {
-    //        init();
-    //        let mut rng = rand::OsRng::new().unwrap();
-    //        let context = ZmqContext::new();
-    //        let node_identity = Arc::new(NodeIdentity::random_for_test(None));
-    //
-    //        let peer_manager = Arc::new(PeerManager::<CommsDataStore>::new(None).unwrap());
-    //
-    //        let local_consumer_address = InprocAddress::random();
-    //        let connection_manager = Arc::new(ConnectionManager::new(
-    //            context.clone(),
-    //            node_identity.clone(),
-    //            peer_manager.clone(),
-    //            make_peer_connection_config(local_consumer_address.clone()),
-    //        ));
-    //
-    //        let (_dest_sk, pk) = RistrettoPublicKey::random_keypair(&mut rng);
-    //        let node_id = NodeId::from_key(&pk.clone()).unwrap();
-    //        let net_addresses = "127.0.0.1:45326".parse::<NetAddress>().unwrap().into();
-    //        let dest_peer = Peer::new(pk.clone(), node_id, net_addresses, PeerFlags::default());
-    //        peer_manager.add_peer(dest_peer.clone()).unwrap();
-    //
-    //        let omp_inbound_address = InprocAddress::random();
-    //        let omp_config = OutboundMessagePoolConfig::default();
-    //        let mut omp = OutboundMessagePool::new(
-    //            omp_config.clone(),
-    //            context.clone(),
-    //            omp_inbound_address.clone(),
-    //            omp_inbound_address.clone(),
-    //            peer_manager.clone(),
-    //            connection_manager.clone(),
-    //        );
-    //
-    //        let oms =
-    //            OutboundMessageService::new(context, node_identity, omp_inbound_address,
-    // peer_manager.clone()).unwrap();        // Instantiate the channels that will be used in the tests.
-    //        let receivers = omp.create_test_channels();
-    //        omp.start();
-    //
-    //        let message_envelope_body: Vec<u8> = vec![0, 1, 2, 3];
-    //
-    //        // Send a message for each thread so we can test that each worker receives one
-    //        for _ in 0..MAX_OUTBOUND_MSG_PROCESSING_WORKERS {
-    //            oms.send(
-    //                BroadcastStrategy::DirectNodeId(dest_peer.node_id.clone()),
-    //                MessageFlags::ENCRYPTED,
-    //                message_envelope_body.clone(),
-    //            )
-    //            .unwrap();
-    //            thread::sleep(Duration::from_millis(100));
-    //        }
-    //
-    //        // This array marks which workers responded. If fairly dealt each index should be set to 1
-    //        let mut worker_responses = [0; MAX_OUTBOUND_MSG_PROCESSING_WORKERS as usize];
-    //
-    //        let mut resp_count = 0;
-    //        loop {
-    //            for i in 0..MAX_OUTBOUND_MSG_PROCESSING_WORKERS as usize {
-    //                if let Ok(_recv) = receivers[i].try_recv() {
-    //                    resp_count += 1;
-    //                    // If this worker responded multiple times then the message were not fairly dealt so bork the
-    // count                    if worker_responses[i] > 0 {
-    //                        worker_responses[i] = MAX_OUTBOUND_MSG_PROCESSING_WORKERS + 1;
-    //                    } else {
-    //                        worker_responses[i] = 1;
-    //                    }
-    //                }
-    //            }
-    //
-    //            // For this test we expect 1 message to reach each worker
-    //            if resp_count >= MAX_OUTBOUND_MSG_PROCESSING_WORKERS as usize {
-    //                break;
-    //            }
-    //        }
-    //
-    //        // Confirm that the messages were fairly dealt to different worker threads
-    //        assert_eq!(
-    //            worker_responses.iter().fold(0, |acc, x| acc + x),
-    //            MAX_OUTBOUND_MSG_PROCESSING_WORKERS
-    //        );
-    //    }
+//    #[test]
+//    fn outbound_message_pool_threading_test() {
+//        init();
+//        let mut rng = rand::OsRng::new().unwrap();
+//        let context = ZmqContext::new();
+//        let node_identity = Arc::new(NodeIdentity::random_for_test(None));
+//
+//        let peer_manager = Arc::new(PeerManager::<CommsDataStore>::new(None).unwrap());
+//
+//        let local_consumer_address = InprocAddress::random();
+//        let connection_manager = Arc::new(ConnectionManager::new(
+//            context.clone(),
+//            node_identity.clone(),
+//            peer_manager.clone(),
+//            make_peer_connection_config(local_consumer_address.clone()),
+//        ));
+//
+//        let (_dest_sk, pk) = RistrettoPublicKey::random_keypair(&mut rng);
+//        let node_id = NodeId::from_key(&pk.clone()).unwrap();
+//        let net_addresses = "127.0.0.1:45326".parse::<NetAddress>().unwrap().into();
+//        let dest_peer = Peer::new(pk.clone(), node_id, net_addresses, PeerFlags::default());
+//        peer_manager.add_peer(dest_peer.clone()).unwrap();
+//
+//        let omp_inbound_address = InprocAddress::random();
+//        let omp_config = OutboundMessagePoolConfig::default();
+//        let mut omp = OutboundMessagePool::new(
+//            omp_config.clone(),
+//            context.clone(),
+//            omp_inbound_address.clone(),
+//            omp_inbound_address.clone(),
+//            peer_manager.clone(),
+//            connection_manager.clone(),
+//        );
+//
+//        let oms =
+//            OutboundMessageService::new(context, node_identity, omp_inbound_address, peer_manager.clone()).unwrap();
+//        // Instantiate the channels that will be used in the tests.
+//        let receivers = omp.create_test_channels();
+//        omp.start();
+//
+//        let message_envelope_body: Vec<u8> = vec![0, 1, 2, 3];
+//
+//        // Send a message for each thread so we can test that each worker receives one
+//        for _ in 0..MAX_OUTBOUND_MSG_PROCESSING_WORKERS {
+//            oms.send_raw(
+//                BroadcastStrategy::DirectNodeId(dest_peer.node_id.clone()),
+//                MessageFlags::ENCRYPTED,
+//                message_envelope_body.clone(),
+//            )
+//            .unwrap();
+//            thread::sleep(Duration::from_millis(100));
+//        }
+//
+//        // This array marks which workers responded. If fairly dealt each index should be set to 1
+//        let mut worker_responses = [0; MAX_OUTBOUND_MSG_PROCESSING_WORKERS as usize];
+//
+//        let mut resp_count = 0;
+//        loop {
+//            for i in 0..MAX_OUTBOUND_MSG_PROCESSING_WORKERS as usize {
+//                if let Ok(_recv) = receivers[i].try_recv() {
+//                    resp_count += 1;
+//                    // If this worker responded multiple times then the message were not fairly dealt so bork the count
+//                    if worker_responses[i] > 0 {
+//                        worker_responses[i] = MAX_OUTBOUND_MSG_PROCESSING_WORKERS + 1;
+//                    } else {
+//                        worker_responses[i] = 1;
+//                    }
+//                }
+//            }
+//
+//            // For this test we expect 1 message to reach each worker
+//            if resp_count >= MAX_OUTBOUND_MSG_PROCESSING_WORKERS as usize {
+//                break;
+//            }
+//        }
+//
+//        // Confirm that the messages were fairly dealt to different worker threads
+//        assert_eq!(
+//            worker_responses.iter().fold(0, |acc, x| acc + x),
+//            MAX_OUTBOUND_MSG_PROCESSING_WORKERS
+//        );
+//    }
 
     #[test]
     fn clean_shutdown() {

--- a/comms/src/outbound_message_service/outbound_message_pool.rs
+++ b/comms/src/outbound_message_service/outbound_message_pool.rs
@@ -223,88 +223,88 @@ mod test {
         }
     }
 
-//    #[test]
-//    fn outbound_message_pool_threading_test() {
-//        init();
-//        let mut rng = rand::OsRng::new().unwrap();
-//        let context = ZmqContext::new();
-//        let node_identity = Arc::new(NodeIdentity::random_for_test(None));
-//
-//        let peer_manager = Arc::new(PeerManager::<CommsDataStore>::new(None).unwrap());
-//
-//        let local_consumer_address = InprocAddress::random();
-//        let connection_manager = Arc::new(ConnectionManager::new(
-//            context.clone(),
-//            node_identity.clone(),
-//            peer_manager.clone(),
-//            make_peer_connection_config(local_consumer_address.clone()),
-//        ));
-//
-//        let (_dest_sk, pk) = RistrettoPublicKey::random_keypair(&mut rng);
-//        let node_id = NodeId::from_key(&pk.clone()).unwrap();
-//        let net_addresses = "127.0.0.1:45326".parse::<NetAddress>().unwrap().into();
-//        let dest_peer = Peer::new(pk.clone(), node_id, net_addresses, PeerFlags::default());
-//        peer_manager.add_peer(dest_peer.clone()).unwrap();
-//
-//        let omp_inbound_address = InprocAddress::random();
-//        let omp_config = OutboundMessagePoolConfig::default();
-//        let mut omp = OutboundMessagePool::new(
-//            omp_config.clone(),
-//            context.clone(),
-//            omp_inbound_address.clone(),
-//            omp_inbound_address.clone(),
-//            peer_manager.clone(),
-//            connection_manager.clone(),
-//        );
-//
-//        let oms =
-//            OutboundMessageService::new(context, node_identity, omp_inbound_address, peer_manager.clone()).unwrap();
-//        // Instantiate the channels that will be used in the tests.
-//        let receivers = omp.create_test_channels();
-//        omp.start();
-//
-//        let message_envelope_body: Vec<u8> = vec![0, 1, 2, 3];
-//
-//        // Send a message for each thread so we can test that each worker receives one
-//        for _ in 0..MAX_OUTBOUND_MSG_PROCESSING_WORKERS {
-//            oms.send_raw(
-//                BroadcastStrategy::DirectNodeId(dest_peer.node_id.clone()),
-//                MessageFlags::ENCRYPTED,
-//                message_envelope_body.clone(),
-//            )
-//            .unwrap();
-//            thread::sleep(Duration::from_millis(100));
-//        }
-//
-//        // This array marks which workers responded. If fairly dealt each index should be set to 1
-//        let mut worker_responses = [0; MAX_OUTBOUND_MSG_PROCESSING_WORKERS as usize];
-//
-//        let mut resp_count = 0;
-//        loop {
-//            for i in 0..MAX_OUTBOUND_MSG_PROCESSING_WORKERS as usize {
-//                if let Ok(_recv) = receivers[i].try_recv() {
-//                    resp_count += 1;
-//                    // If this worker responded multiple times then the message were not fairly dealt so bork the count
-//                    if worker_responses[i] > 0 {
-//                        worker_responses[i] = MAX_OUTBOUND_MSG_PROCESSING_WORKERS + 1;
-//                    } else {
-//                        worker_responses[i] = 1;
-//                    }
-//                }
-//            }
-//
-//            // For this test we expect 1 message to reach each worker
-//            if resp_count >= MAX_OUTBOUND_MSG_PROCESSING_WORKERS as usize {
-//                break;
-//            }
-//        }
-//
-//        // Confirm that the messages were fairly dealt to different worker threads
-//        assert_eq!(
-//            worker_responses.iter().fold(0, |acc, x| acc + x),
-//            MAX_OUTBOUND_MSG_PROCESSING_WORKERS
-//        );
-//    }
+    //    #[test]
+    //    fn outbound_message_pool_threading_test() {
+    //        init();
+    //        let mut rng = rand::OsRng::new().unwrap();
+    //        let context = ZmqContext::new();
+    //        let node_identity = Arc::new(NodeIdentity::random_for_test(None));
+    //
+    //        let peer_manager = Arc::new(PeerManager::<CommsDataStore>::new(None).unwrap());
+    //
+    //        let local_consumer_address = InprocAddress::random();
+    //        let connection_manager = Arc::new(ConnectionManager::new(
+    //            context.clone(),
+    //            node_identity.clone(),
+    //            peer_manager.clone(),
+    //            make_peer_connection_config(local_consumer_address.clone()),
+    //        ));
+    //
+    //        let (_dest_sk, pk) = RistrettoPublicKey::random_keypair(&mut rng);
+    //        let node_id = NodeId::from_key(&pk.clone()).unwrap();
+    //        let net_addresses = "127.0.0.1:45326".parse::<NetAddress>().unwrap().into();
+    //        let dest_peer = Peer::new(pk.clone(), node_id, net_addresses, PeerFlags::default());
+    //        peer_manager.add_peer(dest_peer.clone()).unwrap();
+    //
+    //        let omp_inbound_address = InprocAddress::random();
+    //        let omp_config = OutboundMessagePoolConfig::default();
+    //        let mut omp = OutboundMessagePool::new(
+    //            omp_config.clone(),
+    //            context.clone(),
+    //            omp_inbound_address.clone(),
+    //            omp_inbound_address.clone(),
+    //            peer_manager.clone(),
+    //            connection_manager.clone(),
+    //        );
+    //
+    //        let oms =
+    //            OutboundMessageService::new(context, node_identity, omp_inbound_address,
+    // peer_manager.clone()).unwrap();        // Instantiate the channels that will be used in the tests.
+    //        let receivers = omp.create_test_channels();
+    //        omp.start();
+    //
+    //        let message_envelope_body: Vec<u8> = vec![0, 1, 2, 3];
+    //
+    //        // Send a message for each thread so we can test that each worker receives one
+    //        for _ in 0..MAX_OUTBOUND_MSG_PROCESSING_WORKERS {
+    //            oms.send_raw(
+    //                BroadcastStrategy::DirectNodeId(dest_peer.node_id.clone()),
+    //                MessageFlags::ENCRYPTED,
+    //                message_envelope_body.clone(),
+    //            )
+    //            .unwrap();
+    //            thread::sleep(Duration::from_millis(100));
+    //        }
+    //
+    //        // This array marks which workers responded. If fairly dealt each index should be set to 1
+    //        let mut worker_responses = [0; MAX_OUTBOUND_MSG_PROCESSING_WORKERS as usize];
+    //
+    //        let mut resp_count = 0;
+    //        loop {
+    //            for i in 0..MAX_OUTBOUND_MSG_PROCESSING_WORKERS as usize {
+    //                if let Ok(_recv) = receivers[i].try_recv() {
+    //                    resp_count += 1;
+    //                    // If this worker responded multiple times then the message were not fairly dealt so bork the
+    // count                    if worker_responses[i] > 0 {
+    //                        worker_responses[i] = MAX_OUTBOUND_MSG_PROCESSING_WORKERS + 1;
+    //                    } else {
+    //                        worker_responses[i] = 1;
+    //                    }
+    //                }
+    //            }
+    //
+    //            // For this test we expect 1 message to reach each worker
+    //            if resp_count >= MAX_OUTBOUND_MSG_PROCESSING_WORKERS as usize {
+    //                break;
+    //            }
+    //        }
+    //
+    //        // Confirm that the messages were fairly dealt to different worker threads
+    //        assert_eq!(
+    //            worker_responses.iter().fold(0, |acc, x| acc + x),
+    //            MAX_OUTBOUND_MSG_PROCESSING_WORKERS
+    //        );
+    //    }
 
     #[test]
     fn clean_shutdown() {

--- a/comms/tests/outbound_message_service/outbound_message_pool.rs
+++ b/comms/tests/outbound_message_service/outbound_message_pool.rs
@@ -148,13 +148,13 @@ fn test_outbound_message_pool() {
 
     // Send 8 message alternating two different OMS's
     for _ in 0..4 {
-        oms.send(
+        oms.send_raw(
             BroadcastStrategy::DirectNodeId(node_B_peer.node_id.clone()),
             MessageFlags::ENCRYPTED,
             message_envelope_body.clone(),
         )
         .unwrap();
-        oms2.send(
+        oms2.send_raw(
             BroadcastStrategy::DirectNodeId(node_B_peer.node_id.clone()),
             MessageFlags::ENCRYPTED,
             message_envelope_body.clone(),
@@ -240,7 +240,7 @@ fn test_outbound_message_pool_requeuing() {
         .establish(&omp_inbound_address)
         .unwrap();
 
-    oms.send(
+    oms.send_raw(
         BroadcastStrategy::DirectNodeId(node_B_peer.node_id.clone()),
         MessageFlags::ENCRYPTED,
         message_envelope_body,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Sending a message through the OMS changed from this:

```rust
        oms.send(
            BroadcastStrategy::DirectPublicKey(text_message.dest_pub_key.clone()),
            MessageFlags::ENCRYPTED,
            Message::try_from(text_message)?.to_binary()?,
        )?;
```

To this:

```rust
        oms.send_message(
            BroadcastStrategy::DirectPublicKey(text_message.dest_pub_key.clone()),
            MessageFlags::ENCRYPTED,
            text_message,
        )?;
```

In either case you need to implement `TryInto<Message>` (or `TryFrom<YourMessage> for Message`) for your message type.

Renamed getters in CommsServices as per rust [checklist recommendations](https://rust-lang-nursery.github.io/api-guidelines/checklist.html)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Remove serialization concern from the domain service, it should be the OMS's responsibility

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [x] Breaking change (fix or feature that would cause existing functionality to change)
* [x] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch
* [x] I ran `cargo-fmt --all` before pushing
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
