### PR TITLE
Decreased LLVM inline to improve grcov code viewing

### DIFF
--- a/scripts/code_coverage.sh
+++ b/scripts/code_coverage.sh
@@ -66,10 +66,11 @@ fi
 mkdir $build_dir
 mkdir -p $report_dir
 
-echo "Build project.."
+echo "Setup project.."
 export CARGO_INCREMENTAL=0
-export RUSTFLAGS="-Zprofile -Ccodegen-units=1 -Cinline-threshold=0 -Clink-dead-code -Coverflow-checks=off -Zno-landing-pads"
-cargo +nightly build -q $CARGO_OPTIONS
+export RUSTFLAGS="-Zprofile -Ccodegen-units=1 -Clink-dead-code -Copt-level=0 -Coverflow-checks=off -Zno-landing-pads"
+echo "Build project.."
+cargo +nightly build $CARGO_OPTIONS
 
 echo "Perform project Tests.."
 cargo_filename="Cargo.toml"


### PR DESCRIPTION
Increasing code coverage on the tari project

## Description
LLVM automatically inlines some function to improve performance, I have reduced this so that grcov can see more functions and more correctly report on the lines hit metric. 

## Motivation and Context
More accurate reporting on lines of code hit metric

## Types of changes
* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
* [x] I'm merging against the `development` branch
* [ ] I ran `cargo-fmt --all` before pushing
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
