### PR TITLE
Limit stack size of light worker threads

### DIFF
--- a/comms/src/connection/peer_connection/worker.rs
+++ b/comms/src/connection/peer_connection/worker.rs
@@ -57,6 +57,9 @@ const PEER_CONNECTION_SEND_HWM: i32 = 10;
 /// Receive HWM for peer connections
 const PEER_CONNECTION_RECV_HWM: i32 = 10;
 
+/// Set the allocated stack size for each PeerConnectionWorker thread
+const THREAD_STACK_SIZE: usize = 64 * 1024; // 64kb
+
 /// Worker which:
 /// - Establishes a connection to peer
 /// - Establishes a connection to the message consumer
@@ -99,7 +102,8 @@ impl PeerConnectionWorker {
         }
 
         let handle = thread::Builder::new()
-            .name(format!("peer-conn-{}", &self.context.id.to_short_id()))
+            .name(format!("peer-conn-{}-thread", &self.context.id.to_short_id()))
+            .stack_size(THREAD_STACK_SIZE)
             .spawn(move || -> Result<()> {
                 let result = self.main_loop();
 

--- a/comms/src/control_service/worker.rs
+++ b/comms/src/control_service/worker.rs
@@ -58,6 +58,9 @@ const LOG_TARGET: &'static str = "comms::control_service::worker";
 /// Messages will transparently drop if this size is exceeded.
 const CONTROL_SERVICE_MAX_MSG_SIZE: u64 = 1024; // 1kb
 
+/// Set the allocated stack size for each ControlServiceWorker thread
+const THREAD_STACK_SIZE: usize = 256 * 1024; // 256kb
+
 /// The [ControlService] worker is responsible for handling incoming messages
 /// to the control port and dispatching them using the message dispatcher.
 pub struct ControlServiceWorker<MType>
@@ -108,7 +111,8 @@ where
         };
 
         let handle = thread::Builder::new()
-            .name("control-service".to_string())
+            .name("control-service-worker-thread".to_string())
+            .stack_size(THREAD_STACK_SIZE)
             .spawn(move || {
                 info!(
                     target: LOG_TARGET,

--- a/comms/src/inbound_message_service/error.rs
+++ b/comms/src/inbound_message_service/error.rs
@@ -41,4 +41,6 @@ pub enum InboundError {
     ThreadJoinError,
     /// The thread handle is undefined and could have not been properly created
     ThreadHandleUndefined,
+    /// Inbound message worker thread failed to start
+    ThreadInitializationError,
 }

--- a/comms/src/inbound_message_service/inbound_message_service.rs
+++ b/comms/src/inbound_message_service/inbound_message_service.rs
@@ -114,7 +114,7 @@ where
     }
 
     /// Spawn an InboundMessageWorker for the InboundMessageService
-    pub fn start(&mut self) {
+    pub fn start(&mut self) -> Result<(), InboundError> {
         info!(target: LOG_TARGET, "Starting inbound message service");
         let worker = InboundMessageWorker::new(
             self.config.clone(),
@@ -126,9 +126,10 @@ where
             self.outbound_message_service.clone(),
             self.peer_manager.clone(),
         );
-        let (worker_thread_handle, worker_sync_sender) = worker.start();
+        let (worker_thread_handle, worker_sync_sender) = worker.start()?;
         self.worker_thread_handle = Some(worker_thread_handle);
         self.worker_control_sender = Some(worker_sync_sender);
+        Ok(())
     }
 
     /// Tell the underlying worker thread to shut down
@@ -267,7 +268,7 @@ mod test {
             outbound_message_service,
             peer_manager,
         );
-        inbound_message_service.start();
+        inbound_message_service.start().unwrap();
 
         // Construct a test message
         let message_header = MessageHeader {

--- a/comms/src/inbound_message_service/mod.rs
+++ b/comms/src/inbound_message_service/mod.rs
@@ -41,3 +41,5 @@ pub mod error;
 pub mod inbound_message_broker;
 pub mod inbound_message_service;
 pub mod inbound_message_worker;
+
+pub use self::error::InboundError;

--- a/comms/src/outbound_message_service/error.rs
+++ b/comms/src/outbound_message_service/error.rs
@@ -68,4 +68,6 @@ pub enum OutboundError {
     DealerProxyError(DealerProxyError),
     /// Could not join the dealer or worker threads
     ThreadJoinError,
+    /// Message pool worker thread failed to start
+    ThreadInitializationError,
 }

--- a/comms/tests/outbound_message_service/outbound_message_pool.rs
+++ b/comms/tests/outbound_message_service/outbound_message_pool.rs
@@ -271,7 +271,7 @@ fn test_outbound_message_pool_requeuing() {
     )
     .unwrap();
 
-    omp.start();
+    omp.start().unwrap();
     let message_envelope_body: Vec<u8> = vec![0, 1, 2, 3];
 
     // Now check that the requeuing happens


### PR DESCRIPTION
## Description
- Added ability to change allocated thread stack size to PeerConnection, DealerProxy, Peer connection worker, Control service worker, InboundMessageWorker, MessagePoolWorker, AsyncRequestReplyPattern and ConnectionMessageCounter.
- Manually selected thread stack sizes for each service/worker that are 3-4x larger than the size that caused a stack overflow error.
- The minimum stack size allocated was 16kb.

## Motivation and Context
Rust allocates a default 2mb stack for each thread, much smaller stack sizes can be used for the light threads used by many of the workers and services.

## How Has This Been Tested?
Existing tests will produce a stack overflow error if the allocated stack size was insufficient 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch
* [x] I ran `cargo-fmt --all` before pushing
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
