### PR TITLE
Fixed DealerProxy shutdown

### DIFF
--- a/comms/src/outbound_message_service/outbound_message_pool.rs
+++ b/comms/src/outbound_message_service/outbound_message_pool.rs
@@ -120,7 +120,7 @@ impl OutboundMessagePool {
     }
 
     fn start_dealer(&mut self) {
-        self.dealer_proxy.spawn_proxy()
+        let _ = self.dealer_proxy.spawn_proxy();
     }
 
     /// Start the Outbound Message Pool. This will spawn a thread that services the message queue that is sent to the


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
The dealer proxy was silently erroring when being sent the TERMINATE
command from the control socket. The [zmq docs](http://api.zeromq.org/4-1:zmq-proxy-steerable) indicate that a PUB/SUB socket pair should be used. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tests fail with the shutdown result used. After the use of PUB/SUB they pass.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch
* [x] I ran `cargo-fmt --all` before pushing
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
