### PR TITLE
Implement the binary interface for the grpc-wallet server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,4 +32,4 @@ Cargo.lock
 
 # Ignore DataStore and Database files
 *.mdb
-
+.data/

--- a/applications/grpc_wallet/Cargo.toml
+++ b/applications/grpc_wallet/Cargo.toml
@@ -11,7 +11,6 @@ tari_utilities = { path = "../../infrastructure/tari_util", version = "^0.0"}
 tari_comms = { path = "../../comms", version = "^0.0"}
 tari_p2p = {path = "../../base_layer/p2p", version = "^0.0"}
 tari_crypto = { path = "../../infrastructure/crypto"}
-rand = "0.5"
 chrono = { version = "0.4.6", features = ["serde"]}
 config = { version = "0.9.3" }
 crossbeam-channel = "0.3.8"
@@ -28,6 +27,9 @@ hyper = "0.12"
 tower-grpc = { git = "https://github.com/tower-rs/tower-grpc.git", features = ["tower-hyper"] }
 tower-grpc-build = { git = "https://github.com/tower-rs/tower-grpc.git", features = ["tower-hyper"]}
 simple_logger = "1.2.0"
+clap = "2.33.0"
+serde = "1.0.90"
+serde_derive = "1.0.90"
 
 [dev-dependencies]
 tari_crypto = { path = "../../infrastructure/crypto"}

--- a/applications/grpc_wallet/proto/wallet_rpc.proto
+++ b/applications/grpc_wallet/proto/wallet_rpc.proto
@@ -20,6 +20,7 @@ service WalletRpc {
     rpc GetContacts(VoidParams) returns (Contacts) {}
     //This method will update the screen_name of the contact with Pub-key contained in the argument Contact
     rpc UpdateContact(Contact) returns (RpcResponse) {}
+    rpc GetPublicKey(VoidParams) returns (PublicKey) {}
 }
 
 // A generic RPC call response message to convey the result of the call
@@ -36,7 +37,7 @@ message TextMessageToSend {
 
 // A Received Tari Text Message
 message ReceivedTextMessage {
-    bytes id = 1;
+    string id = 1;
     string source_pub_key = 2;
     string dest_pub_key = 3;
     string message = 4;
@@ -45,7 +46,7 @@ message ReceivedTextMessage {
 
 // A Sent Tari Text Message
 message SentTextMessage {
-    bytes id = 1;
+    string id = 1;
     string source_pub_key = 2;
     string dest_pub_key = 3;
     string message = 4;
@@ -77,4 +78,8 @@ message Contact {
 // A list of contacts
 message Contacts {
     repeated Contact contacts = 1;
+}
+// Returns your node's communication public key
+message PublicKey {
+    string pub_key = 1;
 }

--- a/applications/grpc_wallet/sample_config/node1_peers.json
+++ b/applications/grpc_wallet/sample_config/node1_peers.json
@@ -1,0 +1,8 @@
+{
+  "peers": [
+    {"screen_name": "Bob",
+      "pub_key": "IAAAAAAAAACY+Cgi1TeA3WQm+UqoNwChJ8btAvTl/ozUVWuTJhIGFw==",
+      "address": "127.0.0.1:20000"
+    }
+  ]
+}

--- a/applications/grpc_wallet/sample_config/node2_peers.json
+++ b/applications/grpc_wallet/sample_config/node2_peers.json
@@ -1,0 +1,8 @@
+{
+  "peers": [
+    {"screen_name": "Alice",
+      "pub_key": "IAAAAAAAAABcWUYkstZ2BQpNoUBOKp9a0OICVsU0p+fBPO+u4NP0cQ==",
+      "address": "127.0.0.1:10000"
+    }
+  ]
+}

--- a/applications/grpc_wallet/sample_config/wallet_config_node1.toml
+++ b/applications/grpc_wallet/sample_config/wallet_config_node1.toml
@@ -1,0 +1,16 @@
+########################################################################################################################
+#                                                                                                                      #
+#                                          Wallet Configuration Options                                                #
+#                                                                                                                      #
+########################################################################################################################
+
+# TODO Finalize this config file
+
+control_port = 10000
+grpc_port = 10001
+secret_key = "IAAAAAAAAAA3jIh+jLlar7bQGOSfQ/QvCXMh6JAWljXoQ5DJ5TcxDA=="# Base64 encoded Ristretto Secret Key
+data_path = "./data"
+
+
+
+

--- a/applications/grpc_wallet/sample_config/wallet_config_node2.toml
+++ b/applications/grpc_wallet/sample_config/wallet_config_node2.toml
@@ -1,0 +1,12 @@
+########################################################################################################################
+#                                                                                                                      #
+#                                          Wallet Configuration Options                                                #
+#                                                                                                                      #
+########################################################################################################################
+
+# TODO Finalize this config file
+
+control_port = 20000
+grpc_port = 20001
+secret_key = "IAAAAAAAAABRGY57eFIdqjMJS9yhyk65j7LfvryTmEA+w0Qt+6b5Dw==" # Base64 encoded Ristretto Secret Key
+data_path = "./data"

--- a/applications/grpc_wallet/src/main.rs
+++ b/applications/grpc_wallet/src/main.rs
@@ -1,0 +1,210 @@
+// Copyright 2019. The Tari Project
+//
+// Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+// following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+// disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+// following disclaimer in the documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+// products derived from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+// INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+// WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+// USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#[macro_use]
+extern crate clap;
+
+use clap::{App, Arg};
+use log::*;
+use serde::{Deserialize, Serialize};
+use std::{fs, sync::Arc, time::Duration};
+use tari_comms::{
+    connection::NetAddress,
+    control_service::ControlServiceConfig,
+    peer_manager::Peer,
+    types::{CommsPublicKey, CommsSecretKey},
+};
+use tari_crypto::keys::PublicKey;
+use tari_grpc_wallet::wallet_server::WalletServer;
+use tari_p2p::{
+    initialization::CommsConfig,
+    tari_message::{NetMessage, TariMessageType},
+};
+use tari_utilities::message_format::MessageFormat;
+use tari_wallet::{text_message_service::Contact, wallet::WalletConfig, Wallet};
+
+const LOG_TARGET: &'static str = "applications::grpc_wallet";
+
+#[derive(Debug, Default, Deserialize)]
+struct Settings {
+    control_port: Option<u32>,
+    grpc_port: Option<u32>,
+    secret_key: Option<String>,
+    data_path: Option<String>,
+}
+#[derive(Debug, Serialize, Deserialize)]
+struct ConfigPeer {
+    screen_name: String,
+    pub_key: String,
+    address: String,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct Peers {
+    peers: Vec<ConfigPeer>,
+}
+
+/// Entry point into the gRPC server binary
+pub fn main() {
+    let _ = simple_logger::init_with_level(log::Level::Info);
+
+    let matches = App::new("Tari Wallet gRPC server")
+        .version("0.1")
+        .arg(
+            Arg::with_name("config")
+                .value_name("FILE")
+                .long("config")
+                .short("c")
+                .help("The relative path of a wallet config.toml file")
+                .takes_value(true)
+                .required(false),
+        )
+        .arg(
+            Arg::with_name("grpc-port")
+                .long("grpc")
+                .short("g")
+                .help("The port the gRPC server will listen on")
+                .takes_value(true)
+                .required(false),
+        )
+        .arg(
+            Arg::with_name("control-port")
+                .long("control-port")
+                .short("p")
+                .help("The port the p2p stack will listen on")
+                .takes_value(true)
+                .required(false),
+        )
+        .arg(
+            Arg::with_name("secret-key")
+                .long("secret")
+                .short("s")
+                .help("This nodes communication secret key")
+                .takes_value(true)
+                .required(false),
+        )
+        .arg(
+            Arg::with_name("data-path")
+                .long("data-path")
+                .short("d")
+                .help("Path where this node's database files will be stored")
+                .takes_value(true)
+                .required(false),
+        )
+        .arg(
+            Arg::with_name("peers")
+                .value_name("FILE")
+                .long("peers")
+                .takes_value(true)
+                .required(false),
+        )
+        .get_matches();
+
+    let mut settings = Settings::default();
+    if matches.is_present("config") {
+        let mut settings_file = config::Config::default();
+        settings_file
+            .merge(config::File::with_name(matches.value_of("config").unwrap()))
+            .unwrap();
+        settings = settings_file.try_into().unwrap();
+    }
+
+    if let Some(_c) = matches.values_of("control-port") {
+        if let Ok(v) = value_t!(matches, "control-port", u32) {
+            settings.control_port = Some(v)
+        }
+    }
+    if let Some(_c) = matches.values_of("grpc-port") {
+        if let Ok(v) = value_t!(matches, "grpc-port", u32) {
+            settings.grpc_port = Some(v);
+        }
+    }
+    if let Some(c) = matches.value_of("secret-key") {
+        settings.secret_key = Some(c.to_string())
+    }
+    if let Some(p) = matches.value_of("data-path") {
+        settings.data_path = Some(p.to_string())
+    }
+
+    if settings.secret_key.is_none() ||
+        settings.control_port.is_none() ||
+        settings.grpc_port.is_none() ||
+        settings.data_path.is_none()
+    {
+        error!(
+            target: LOG_TARGET,
+            "Control port, gRPC port, Data path or Secret Key has not been provided via command line or config file"
+        );
+        std::process::exit(1);
+    }
+    let mut contacts = Peers { peers: Vec::new() };
+    if let Some(f) = matches.value_of("peers") {
+        let contents = fs::read_to_string(f).unwrap();
+        contacts = Peers::from_json(contents.as_str()).unwrap();
+    }
+
+    let listener_address: NetAddress = format!("127.0.0.1:{}", settings.control_port.unwrap()).parse().unwrap();
+    let secret_key = CommsSecretKey::from_base64(settings.secret_key.unwrap().as_str()).unwrap();
+    let public_key = CommsPublicKey::from_secret_key(&secret_key);
+
+    let config = WalletConfig {
+        comms: CommsConfig {
+            control_service: ControlServiceConfig {
+                listener_address: listener_address.clone(),
+                socks_proxy_address: None,
+                accept_message_type: TariMessageType::new(NetMessage::Accept),
+                requested_outbound_connection_timeout: Duration::from_millis(5000),
+            },
+            socks_proxy_address: None,
+            host: "127.0.0.1".parse().unwrap(),
+            public_key: public_key.clone(),
+            secret_key: secret_key.clone(),
+            datastore_path: settings.data_path.unwrap(),
+            peer_database_name: public_key.to_base64().unwrap(),
+        },
+        public_key: public_key.clone(),
+    };
+
+    let wallet = Wallet::new(config).unwrap();
+
+    // Add any provided peers to Peer Manager and Text Message Service Contacts
+    if contacts.peers.len() > 0 {
+        for p in contacts.peers.iter() {
+            if let Ok(pk) = CommsPublicKey::from_base64(p.pub_key.as_str()) {
+                if let Ok(na) = p.address.clone().parse::<NetAddress>() {
+                    let peer = Peer::from_public_key_and_address(pk.clone(), na.clone()).unwrap();
+                    wallet.comms_services.peer_manager.add_peer(peer).unwrap();
+                    wallet
+                        .text_message_service
+                        .add_contact(Contact {
+                            screen_name: p.screen_name.clone(),
+                            pub_key: pk.clone(),
+                            address: na.clone(),
+                        })
+                        .unwrap();
+                }
+            }
+        }
+    }
+
+    let wallet_server = WalletServer::new(settings.grpc_port.unwrap(), Arc::new(wallet));
+    let _res = wallet_server.start();
+}

--- a/applications/grpc_wallet/src/wallet_server.rs
+++ b/applications/grpc_wallet/src/wallet_server.rs
@@ -40,29 +40,16 @@ pub enum WalletServerError {
     MessageFormatError(MessageFormatError),
 }
 
-pub struct WalletServerConfig {
-    pub port: u32,
-}
-
-impl Default for WalletServerConfig {
-    fn default() -> Self {
-        Self { port: 50051 }
-    }
-}
-
 /// Instance of the Wallet RPC Server with a reference to the Wallet API and the config
 pub struct WalletServer {
     // TODO some form of authentication
-    config: WalletServerConfig,
+    port: u32,
     wallet: Arc<Wallet>,
 }
 
 impl WalletServer {
-    pub fn new(config: Option<WalletServerConfig>, wallet: Arc<Wallet>) -> WalletServer {
-        WalletServer {
-            config: config.unwrap_or(WalletServerConfig::default()),
-            wallet,
-        }
+    pub fn new(port: u32, wallet: Arc<Wallet>) -> WalletServer {
+        WalletServer { port, wallet }
     }
 
     pub fn start(self) -> Result<(), WalletServerError> {
@@ -73,7 +60,7 @@ impl WalletServer {
         let mut server = Server::new(new_service);
 
         let http = Http::new().http2_only(true).clone();
-        let addr = format!("127.0.0.1:{}", self.config.port);
+        let addr = format!("127.0.0.1:{}", self.port);
         let bind = TcpListener::bind(&addr.clone().as_str().parse()?)?;
         let serve = bind
             .incoming()

--- a/base_layer/wallet/src/text_message_service.rs
+++ b/base_layer/wallet/src/text_message_service.rs
@@ -116,7 +116,7 @@ impl TryInto<Message> for TextMessageAck {
 }
 
 /// A message contact
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
 pub struct Contact {
     pub screen_name: String,
     pub pub_key: CommsPublicKey,

--- a/base_layer/wallet/src/wallet.rs
+++ b/base_layer/wallet/src/wallet.rs
@@ -49,6 +49,7 @@ pub struct Wallet {
     pub text_message_service: Arc<TextMessageServiceApi>,
     pub comms_services: Arc<CommsServices<TariMessageType>>,
     pub service_executor: Arc<ServiceExecutor>,
+    pub public_key: CommsPublicKey,
 }
 
 impl Wallet {
@@ -72,6 +73,7 @@ impl Wallet {
             ping_pong_service: ping_pong_service_api,
             comms_services,
             service_executor: Arc::new(service_executor),
+            public_key: config.public_key.clone(),
         })
     }
 }


### PR DESCRIPTION
## Description
This PR provides the binary for the gRPC wallet server. This includes the command line switches, support for config files and support for loading peer data from json files.

Also adds one CRUD to the gRPC interface to return the current nodes public key.

## Motivation and Context
Closes https://github.com/tari-project/tari/issues/457

## How Has This Been Tested?
No tests as this is just the binary.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch
* [x] I ran `cargo-fmt --all` before pushing
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
