### PR TITLE
Failed messages sent as soon as peer is sendable

### DIFF
--- a/comms/src/connection/dealer_proxy.rs
+++ b/comms/src/connection/dealer_proxy.rs
@@ -145,6 +145,11 @@ impl DealerProxy {
                 .context
                 .socket(SocketType::Pub)
                 .map_err(|err| DealerProxyError::ZmqError(err.to_string()))?;
+
+            control
+                .set_linger(3000)
+                .map_err(|err| DealerProxyError::ZmqError(err.to_string()))?;
+
             control
                 .bind(&self.control_address.to_zmq_endpoint())
                 .map_err(|err| DealerProxyError::ZmqError(err.to_string()))?;

--- a/comms/src/outbound_message_service/outbound_message_pool/message_retry_service.rs
+++ b/comms/src/outbound_message_service/outbound_message_pool/message_retry_service.rs
@@ -25,6 +25,7 @@ use crate::{
     connection::{Connection, Direction, EstablishedConnection, InprocAddress, ZmqContext},
     message::FrameSet,
     outbound_message_service::{outbound_message_pool::OutboundMessagePoolConfig, OutboundMessage},
+    peer_manager::NodeId,
 };
 use log::*;
 use std::{
@@ -33,10 +34,10 @@ use std::{
     thread::{self, JoinHandle},
     time::Duration,
 };
-use tari_utilities::message_format::MessageFormat;
+use tari_utilities::{byte_array::ByteArray, message_format::MessageFormat};
 
 const LOG_TARGET: &'static str = "comms::outbound_message_service::outbound_message_pool::message_retry_pool";
-const THREAD_STACK_SIZE: usize = 512_000;
+const THREAD_STACK_SIZE: usize = 256 * 1024; // 256kb
 
 /// # MessageRetryService
 ///
@@ -55,6 +56,10 @@ pub struct MessageRetryService {
 }
 
 impl MessageRetryService {
+    /// Control message which indicates that all messages for a node ID should be
+    /// immediately queued for sending.
+    pub(super) const CTL_FLUSH_NODE_MSGS: &'static str = "FLUSH_NODE_MSGS";
+
     /// Start the message retry service.
     ///
     /// This method will panic if the OS-level thread is unable to start.
@@ -124,7 +129,25 @@ impl MessageRetryService {
     ) -> Result<(), OutboundMessagePoolError>
     {
         loop {
+            trace!(
+                target: LOG_TARGET,
+                "MessageRetryService loop (queue_size: {})",
+                self.queue.len()
+            );
             if let Some(frames) = connection_try!(inbound_conn.receive(1000)) {
+                if let Some(node_id) = Self::maybe_parse_node_flush_msg(&frames) {
+                    debug!(
+                        target: LOG_TARGET,
+                        "Immediately retrying messages from NodeId={}", node_id
+                    );
+                    let num_flushed = self.flush_messages_for_node_id(&outbound_conn, &node_id)?;
+                    debug!(
+                        target: LOG_TARGET,
+                        "Flushed {} messages from NodeId={}", num_flushed, node_id
+                    );
+                    continue;
+                }
+
                 let mut msg = Self::deserialize_outbound_message(frames)?;
                 msg.mark_failed_attempt();
 
@@ -140,11 +163,19 @@ impl MessageRetryService {
                 }
 
                 // Add it to the queue for later retry
+                debug!(
+                    target: LOG_TARGET,
+                    "Message failed to send. Message will be retried in {}s",
+                    msg.scheduled_duration().num_seconds()
+                );
                 self.queue.push(msg);
             }
 
             match self.shutdown_signal_rx.recv_timeout(Duration::from_millis(1)) {
-                Ok(_) => break,
+                Ok(_) => {
+                    info!(target: LOG_TARGET, "SHUTDOWN SIGNAL RECEIVED");
+                    break;
+                },
                 Err(RecvTimeoutError::Timeout) => {},
                 Err(RecvTimeoutError::Disconnected) => {
                     return Err(OutboundMessagePoolError::ControlMessageSenderDisconnected)
@@ -157,17 +188,49 @@ impl MessageRetryService {
                 }
 
                 let msg = self.queue.pop().unwrap();
-
-                let frame = msg.to_binary().map_err(OutboundMessagePoolError::MessageFormatError)?;
-                outbound_conn
-                    .send(&[frame])
-                    .map_err(OutboundMessagePoolError::ConnectionError)?;
+                self.send_msg(&outbound_conn, msg)?;
             }
         }
 
         Ok(())
     }
 
+    /// Flush all messages for a particular peer from the queue and add to the sending queue
+    fn flush_messages_for_node_id(
+        &mut self,
+        outbound_conn: &EstablishedConnection,
+        node_id: &NodeId,
+    ) -> Result<usize, OutboundMessagePoolError>
+    {
+        // TODO(sdbondi): Use drain_filter when it's available (https://github.com/rust-lang/rust/issues/43244)
+        let queue = self.queue.drain().collect::<BinaryHeap<OutboundMessage>>();
+        let (msgs_to_send, queue) = queue.into_iter().partition(|msg| msg.destination_node_id() == node_id);
+        self.queue = queue;
+
+        let len = msgs_to_send.len();
+
+        for msg in msgs_to_send {
+            self.send_msg(&outbound_conn, msg)?;
+        }
+
+        Ok(len)
+    }
+
+    /// If the frameset is a CTL_FLUSH_NODE_MSGS, return the NodeId to flush, otherwise None
+    fn maybe_parse_node_flush_msg(frames: &FrameSet) -> Option<NodeId> {
+        match frames.len() {
+            3 if frames[1] == Self::CTL_FLUSH_NODE_MSGS.as_bytes() => NodeId::from_bytes(&frames[2]).ok(),
+            _ => None,
+        }
+    }
+
+    /// Serialize and send a message on a given connection
+    fn send_msg(&self, conn: &EstablishedConnection, msg: OutboundMessage) -> Result<(), OutboundMessagePoolError> {
+        let frame = msg.to_binary().map_err(OutboundMessagePoolError::MessageFormatError)?;
+        conn.send(&[frame]).map_err(OutboundMessagePoolError::ConnectionError)
+    }
+
+    /// Expect the given frameset to contain an outbound message
     fn deserialize_outbound_message(mut frames: FrameSet) -> Result<OutboundMessage, OutboundMessagePoolError> {
         match frames.drain(1..).next() {
             Some(frame) => OutboundMessage::from_binary(&frame).map_err(OutboundMessagePoolError::MessageFormatError),
@@ -199,5 +262,125 @@ mod test {
         let frames = vec![vec![1, 2, 3, 4], msg_frame];
         let result_msg = MessageRetryService::deserialize_outbound_message(frames).unwrap();
         assert_eq!(result_msg, msg);
+    }
+
+    #[test]
+    fn maybe_parse_node_flush_msg() {
+        let node_id = NodeId::new();
+        let maybe_node_id = MessageRetryService::maybe_parse_node_flush_msg(&vec![
+            vec![],
+            MessageRetryService::CTL_FLUSH_NODE_MSGS.as_bytes().to_vec(),
+            node_id.as_bytes().to_vec(),
+        ]);
+
+        assert!(maybe_node_id.is_some());
+        assert_eq!(maybe_node_id.unwrap(), node_id);
+    }
+
+    #[test]
+    fn maybe_parse_node_flush_msg_fail() {
+        let node_id = NodeId::new();
+
+        // Not enough frames
+        let maybe_node_id = MessageRetryService::maybe_parse_node_flush_msg(&vec![
+            MessageRetryService::CTL_FLUSH_NODE_MSGS.as_bytes().to_vec(),
+            node_id.as_bytes().to_vec(),
+        ]);
+
+        assert!(maybe_node_id.is_none());
+
+        // Too many frames
+        let maybe_node_id = MessageRetryService::maybe_parse_node_flush_msg(&vec![
+            vec![],
+            MessageRetryService::CTL_FLUSH_NODE_MSGS.as_bytes().to_vec(),
+            node_id.as_bytes().to_vec(),
+            vec![],
+        ]);
+
+        assert!(maybe_node_id.is_none());
+
+        // Bad flush message identifier
+        let maybe_node_id = MessageRetryService::maybe_parse_node_flush_msg(&vec![
+            vec![],
+            "BAD".as_bytes().to_vec(),
+            node_id.as_bytes().to_vec(),
+        ]);
+
+        assert!(maybe_node_id.is_none());
+
+        // Bad node id
+        let maybe_node_id = MessageRetryService::maybe_parse_node_flush_msg(&vec![
+            vec![],
+            MessageRetryService::CTL_FLUSH_NODE_MSGS.as_bytes().to_vec(),
+            node_id.as_bytes().to_vec().drain(1..).collect::<Vec<u8>>(),
+        ]);
+
+        assert!(maybe_node_id.is_none());
+    }
+
+    #[test]
+    fn flush_messages_for_node_id() {
+        let node_id1 = NodeId::new();
+        let node_id2 = NodeId::from_bytes(
+            [
+                144, 28, 106, 112, 220, 197, 216, 119, 9, 217, 42, 77, 159, 211, 53, 207, 0, 157, 5, 55, 235, 247, 160,
+                195, 240, 48, 146, 168, 119, 15, 241, 54,
+            ]
+            .as_bytes(),
+        )
+        .unwrap();
+        let (_shutdown_signal_tx, shutdown_signal_rx) = sync_channel(1);
+
+        let mut service = MessageRetryService::new(OutboundMessagePoolConfig::default(), shutdown_signal_rx);
+        let dummy_frames = vec![vec![]];
+        let dummy_frames2 = vec!["EXPECTED".as_bytes().to_vec()];
+        service
+            .queue
+            .push(OutboundMessage::new(node_id1.clone(), dummy_frames.clone()));
+        service
+            .queue
+            .push(OutboundMessage::new(node_id1.clone(), dummy_frames.clone()));
+        service
+            .queue
+            .push(OutboundMessage::new(node_id2.clone(), dummy_frames2.clone()));
+        service
+            .queue
+            .push(OutboundMessage::new(node_id1.clone(), dummy_frames.clone()));
+        service
+            .queue
+            .push(OutboundMessage::new(node_id2.clone(), dummy_frames2.clone()));
+        service
+            .queue
+            .push(OutboundMessage::new(node_id2.clone(), dummy_frames2.clone()));
+        service
+            .queue
+            .push(OutboundMessage::new(node_id1.clone(), dummy_frames.clone()));
+        service
+            .queue
+            .push(OutboundMessage::new(node_id1.clone(), dummy_frames.clone()));
+
+        let context = ZmqContext::new();
+        let address = InprocAddress::random();
+        let out_conn = Connection::new(&context, Direction::Outbound)
+            .establish(&address)
+            .unwrap();
+
+        let in_conn = Connection::new(&context, Direction::Inbound)
+            .establish(&address)
+            .unwrap();
+
+        service.flush_messages_for_node_id(&out_conn, &node_id2).unwrap();
+
+        let mut msg_count = 0;
+
+        for _ in 0..3 {
+            let frames = in_conn.receive(2000).unwrap();
+            let msg = OutboundMessage::from_binary(&frames[1]).unwrap();
+            assert_eq!(msg.message_frames()[0], "EXPECTED".as_bytes());
+            msg_count += 1;
+        }
+
+        assert_eq!(msg_count, 3);
+        assert_eq!(service.queue.len(), 5);
     }
 }

--- a/comms/src/peer_manager/peer_manager.rs
+++ b/comms/src/peer_manager/peer_manager.rs
@@ -29,7 +29,6 @@ use crate::{
 
 use crate::peer_manager::PeerManagerError;
 use std::{sync::RwLock, time::Duration};
-use tari_storage::keyvalue_store::{DataStore, DatastoreError};
 
 /// The PeerManager consist of a routing table of previously discovered peers.
 /// It also provides functionality to add, find and delete peers. A subset of peers can also be requested from the


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
The OutboundMessageWorker notifies the MessageRetryService once a
message has been successfully sent to a peer. The MessageRetryService in
turn flushes all the messages it destined for that peer to be sent by
the worker.


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Ref #325 
Ref #461 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Unit and integration tests

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [x] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [x] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch
* [x] I ran `cargo-fmt --all` before pushing
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
