### PR TITLE
Removed race condition in dealer proxy test

### DIFF
--- a/comms/src/connection/dealer_proxy.rs
+++ b/comms/src/connection/dealer_proxy.rs
@@ -215,7 +215,5 @@ mod test {
 
         // Test steerable dealer shutdown
         proxy.shutdown().unwrap();
-        receiver.send_sync(&[&msg[0], "FAIL".as_bytes()]).unwrap();
-        assert!(sender.receive(200).is_err());
     }
 }


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
The dealer proxy tests had a race condition when testing if the dealer
proxy was no longer accepting connections. If after shutdown, the sender
connection could still send, the test would pass, otherwise the test may
block indefinitely on the `send_sync` (`send` would return an error if
unable to send).

Since the shutdown would error if it timed out (i.e. the proxy steerable does
not respond), I feel it's pretty redundant to try send afterwards as we already 
know in the test that the proxy call has returned.


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Ref #455 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch
* [x] I ran `cargo-fmt --all` before pushing
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
