### PR TITLE
Make NetAddresses::add_net_address idempotent

### DIFF
--- a/comms/src/connection/net_address/mod.rs
+++ b/comms/src/connection/net_address/mod.rs
@@ -41,8 +41,6 @@ pub enum NetAddressError {
     ParseFailed,
     /// Specified port range is invalid
     InvalidPortRange,
-    /// The net address couldn't be added to net addresses as a duplicate net address exist
-    DuplicateAddress,
     /// The specified net address does not exist
     AddressNotFound,
     /// Empty set of net addresses


### PR DESCRIPTION
Adding an existing address to NetAddresses should not result in an
error.
