### PR TITLE
Remove redundant public key field from Establishconnection message

### DIFF
--- a/comms/src/connection/net_address/mod.rs
+++ b/comms/src/connection/net_address/mod.rs
@@ -41,8 +41,6 @@ pub enum NetAddressError {
     ParseFailed,
     /// Specified port range is invalid
     InvalidPortRange,
-    /// The net address couldn't be added to net addresses as a duplicate net address exist
-    DuplicateAddress,
     /// The specified net address does not exist
     AddressNotFound,
     /// Empty set of net addresses

--- a/comms/src/connection_manager/protocol.rs
+++ b/comms/src/connection_manager/protocol.rs
@@ -26,7 +26,6 @@ use crate::{
     control_service::ControlServiceMessageType,
     message::{p2p::EstablishConnection, Message, MessageEnvelope, MessageFlags, MessageHeader, NodeDestination},
     peer_manager::{NodeIdentity, Peer},
-    types::CommsPublicKey,
 };
 use log::*;
 use std::sync::Arc;
@@ -88,7 +87,6 @@ impl<'e, 'ni> PeerConnectionProtocol<'e, 'ni> {
         let msg = EstablishConnection {
             address: external_address,
             control_service_address: self.node_identity.control_service_address.clone(),
-            public_key: self.node_identity.identity.public_key.clone(),
             node_id: self.node_identity.identity.node_id.clone(),
             server_key: curve_pk,
         };
@@ -109,7 +107,7 @@ impl<'e, 'ni> PeerConnectionProtocol<'e, 'ni> {
         &self,
         peer: &Peer,
         control_conn: &EstablishedConnection,
-        msg: EstablishConnection<CommsPublicKey>,
+        msg: EstablishConnection,
     ) -> Result<()>
     {
         let message_header = MessageHeader {

--- a/comms/src/message/p2p/mod.rs
+++ b/comms/src/message/p2p/mod.rs
@@ -29,7 +29,7 @@ use serde::{Deserialize, Serialize};
 /// This represents a request to open a peer connection
 /// to a remote peer.
 #[derive(Serialize, Deserialize, Debug)]
-pub struct EstablishConnection<PK> {
+pub struct EstablishConnection {
     pub control_service_address: NetAddress,
     /// The zeroMQ Curve public key to use for the peer connection
     pub server_key: CurvePublicKey,
@@ -37,8 +37,6 @@ pub struct EstablishConnection<PK> {
     pub node_id: NodeId,
     /// The address to which to connect
     pub address: NetAddress,
-    /// The requesting node's public key
-    pub public_key: PK,
 }
 
 /// Sent to show that the connection has been accepted

--- a/comms/tests/control_service/service.rs
+++ b/comms/tests/control_service/service.rs
@@ -66,7 +66,7 @@ lazy_static! {
 }
 
 fn test_handler(context: ControlServiceMessageContext<u8>) -> Result<(), ControlServiceError> {
-    let msg: EstablishConnection<CommsPublicKey> = context
+    let msg: EstablishConnection = context
         .message
         .to_message()
         .map_err(|err| DispatchError::HandlerError(format!("Failed to parse message: {}", err)))?;
@@ -201,7 +201,6 @@ fn recv_message() {
     let msg = EstablishConnection {
         address: requesting_node_address,
         node_id: NodeId::from_key(&node_identity.identity.public_key).unwrap(),
-        public_key: node_identity.identity.public_key.clone(),
         server_key: server_pk,
         control_service_address: control_service_address.clone(),
     };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
public key is now solely obtained from the message envelope header.

Branched from #483 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
It was redundant to have a field for the public key in the EstablishConnection message.  

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Existing tests updated

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [x] Breaking change (fix or feature that would cause existing functionality to change)
* [x] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch
* [x] I ran `cargo-fmt --all` before pushing
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
