### PR TITLE
Timeout for joins is a bit short when run in CI

### DIFF
--- a/comms/tests/connection_manager/establisher.rs
+++ b/comms/tests/connection_manager/establisher.rs
@@ -187,7 +187,7 @@ fn establish_peer_connection_outbound() {
 
     assert_eq!(msg_counter.count(), 2);
 
-    peer_conn_handle.timeout_join(Duration::from_millis(100)).unwrap();
+    peer_conn_handle.timeout_join(Duration::from_millis(1000)).unwrap();
 
     clean_up_datastore(database_name);
 }
@@ -251,7 +251,7 @@ fn establish_peer_connection_inbound() {
 
     assert_eq!(msg_counter.count(), 2);
 
-    peer_conn_handle.timeout_join(Duration::from_millis(100)).unwrap();
+    peer_conn_handle.timeout_join(Duration::from_millis(1000)).unwrap();
 
     clean_up_datastore(database_name);
 }

--- a/comms/tests/connection_manager/manager.rs
+++ b/comms/tests/connection_manager/manager.rs
@@ -187,8 +187,8 @@ fn establish_peer_connection() {
         Ok(())
     });
 
-    handle1.timeout_join(Duration::from_millis(100)).unwrap();
-    handle2.timeout_join(Duration::from_millis(100)).unwrap();
+    handle1.timeout_join(Duration::from_millis(2000)).unwrap();
+    handle2.timeout_join(Duration::from_millis(2000)).unwrap();
 
     // Give the peer connections a moment to receive and the message sink connections to send
     pause();


### PR DESCRIPTION
Tests should have ample time to complete successfully
