### PR TITLE
Refactored all fee as MicroTari struct and not u64 anymore

### DIFF
--- a/base_layer/core/src/block.rs
+++ b/base_layer/core/src/block.rs
@@ -24,6 +24,8 @@
 // Version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0.
 use crate::{
     blockheader::BlockHeader,
+    emission::*,
+    tari_amount::*,
     transaction::*,
     transaction_protocol::{build_challenge, TransactionMetadata},
     types::*,
@@ -68,10 +70,11 @@ impl Block {
 
 // todo this probably need to move somewhere else
 /// This function will create the correct amount for the coinbase given the block height, it will provide the answer in
-/// nanoTari
-pub fn calculate_coinbase(block_height: u64) -> u64 {
+/// µTari (micro Tari)
+pub fn calculate_coinbase(block_height: u64) -> MicroTari {
     // todo fill this in properly as a function and not a constant
-    ((block_height * 0) + 60) * 1000_000_000
+    let schedule = EmissionSchedule::new(MicroTari::from(10_000_000), 0.999, MicroTari::from(100));
+    schedule.block_reward(block_height)
 }
 
 //----------------------------------------     AggregateBody      ----------------------------------------------------//
@@ -169,8 +172,8 @@ impl AggregateBody {
         Ok(())
     }
 
-    pub fn get_total_fee(&self) -> u64 {
-        let mut fee = 0;
+    pub fn get_total_fee(&self) -> MicroTari {
+        let mut fee = MicroTari::from(0);
         for kernel in &self.kernels {
             fee += kernel.fee;
         }
@@ -191,7 +194,7 @@ pub struct BlockBuilder {
     pub inputs: Vec<TransactionInput>,
     pub outputs: Vec<TransactionOutput>,
     pub kernels: Vec<TransactionKernel>,
-    pub total_fee: u64,
+    pub total_fee: MicroTari,
 }
 
 impl BlockBuilder {
@@ -201,7 +204,7 @@ impl BlockBuilder {
             inputs: Vec::new(),
             outputs: Vec::new(),
             kernels: Vec::new(),
-            total_fee: 0,
+            total_fee: MicroTari::from(0),
         }
     }
 
@@ -270,10 +273,10 @@ impl BlockBuilder {
     pub fn create_coinbase(mut self, key: PrivateKey) -> Self {
         let mut rng = rand::OsRng::new().unwrap();
         // build output
-        let amount = calculate_coinbase(self.header.height) + self.total_fee;
-        let v = PrivateKey::from(amount);
+        let amount = self.total_fee + calculate_coinbase(self.header.height);
+        let v = PrivateKey::from(u64::from(amount));
         let commitment = COMMITMENT_FACTORY.commit(&key, &v);
-        let rr = PROVER.construct_proof(&v, amount).unwrap();
+        let rr = PROVER.construct_proof(&v, amount.into()).unwrap();
         let output = TransactionOutput::new(
             OutputFeatures::COINBASE_OUTPUT,
             commitment,
@@ -281,14 +284,17 @@ impl BlockBuilder {
         );
 
         // create kernel
-        let tx_meta = TransactionMetadata { fee: 0, lock_height: 0 };
+        let tx_meta = TransactionMetadata {
+            fee: 0.into(),
+            lock_height: 0,
+        };
         let r = PrivateKey::random(&mut rng);
         let e = build_challenge(&PublicKey::from_secret_key(&r), &tx_meta);
         let s = Signature::sign(key.clone(), r, &e).unwrap();
         let excess = COMMITMENT_FACTORY.commit_value(&key, 0);
         let kernel = KernelBuilder::new()
             .with_features(KernelFeatures::COINBASE_KERNEL)
-            .with_fee(0)
+            .with_fee(0.into())
             .with_lock_height(0)
             .with_excess(&excess)
             .with_signature(&s)

--- a/base_layer/core/src/fee.rs
+++ b/base_layer/core/src/fee.rs
@@ -20,7 +20,7 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use crate::transaction::MINIMUM_TRANSACTION_FEE;
+use crate::{tari_amount::*, transaction::MINIMUM_TRANSACTION_FEE};
 
 pub struct Fee {}
 
@@ -30,13 +30,15 @@ pub const BASE_COST: u64 = 1;
 
 impl Fee {
     /// Computes the absolute transaction fee given the fee-per-gram, and the size of the transaction
-    pub fn calculate(fee_per_gram: u64, num_inputs: usize, num_outputs: usize) -> u64 {
-        BASE_COST + (COST_PER_INPUT * num_inputs as u64 + COST_PER_OUTPUT * num_outputs as u64) * fee_per_gram
+    pub fn calculate(fee_per_gram: MicroTari, num_inputs: usize, num_outputs: usize) -> MicroTari {
+        (BASE_COST +
+            (COST_PER_INPUT * num_inputs as u64 + COST_PER_OUTPUT * num_outputs as u64) * u64::from(fee_per_gram))
+        .into()
     }
 
     /// Computes the absolute transaction fee using `calculate`, but the resulting fee will always be at least the
     /// minimum network transaction fee.
-    pub fn calculate_with_minimum(fee_per_gram: u64, num_inputs: usize, num_outputs: usize) -> u64 {
+    pub fn calculate_with_minimum(fee_per_gram: MicroTari, num_inputs: usize, num_outputs: usize) -> MicroTari {
         let fee = Fee::calculate(fee_per_gram, num_inputs, num_outputs);
         if fee < MINIMUM_TRANSACTION_FEE {
             MINIMUM_TRANSACTION_FEE

--- a/base_layer/core/src/transaction_protocol/mod.rs
+++ b/base_layer/core/src/transaction_protocol/mod.rs
@@ -58,6 +58,7 @@ pub mod single_receiver;
 pub mod transaction_initializer;
 
 use crate::{
+    tari_amount::*,
     transaction::TransactionError,
     types::{Challenge, MessageHash, PublicKey},
 };
@@ -97,7 +98,7 @@ pub enum TransactionProtocolError {
 #[derive(Debug, Clone, PartialEq, Eq, Default, Deserialize, Serialize)]
 pub struct TransactionMetadata {
     /// The absolute fee for the transaction
-    pub fee: u64,
+    pub fee: MicroTari,
     /// The earliest block this transaction can be mined
     pub lock_height: u64,
 }
@@ -106,7 +107,7 @@ pub struct TransactionMetadata {
 pub fn build_challenge(sum_public_nonces: &PublicKey, metadata: &TransactionMetadata) -> MessageHash {
     Challenge::new()
         .chain(sum_public_nonces.as_bytes())
-        .chain(&metadata.fee.to_le_bytes())
+        .chain(&u64::from(metadata.fee).to_le_bytes())
         .chain(&metadata.lock_height.to_le_bytes())
         .result()
         .to_vec()

--- a/base_layer/core/src/transaction_protocol/recipient.rs
+++ b/base_layer/core/src/transaction_protocol/recipient.rs
@@ -151,6 +151,7 @@ impl ReceiverTransactionProtocol {
 #[cfg(test)]
 mod test {
     use crate::{
+        tari_amount::*,
         transaction::OutputFeatures,
         transaction_protocol::{
             build_challenge,
@@ -169,12 +170,12 @@ mod test {
         let mut rng = OsRng::new().unwrap();
         let p = TestParams::new(&mut rng);
         let m = TransactionMetadata {
-            fee: 125,
+            fee: MicroTari(125),
             lock_height: 0,
         };
         let msg = SingleRoundSenderData {
             tx_id: 15,
-            amount: 500,
+            amount: MicroTari(500),
             public_excess: PublicKey::from_secret_key(&p.spend_key), // any random key will do
             public_nonce: PublicKey::from_secret_key(&p.change_key), // any random key will do
             metadata: m.clone(),

--- a/base_layer/core/src/transaction_protocol/test_common.rs
+++ b/base_layer/core/src/transaction_protocol/test_common.rs
@@ -23,6 +23,7 @@
 // Used in tests only
 
 use crate::{
+    tari_amount::*,
     transaction::{OutputFeatures, TransactionInput, UnblindedOutput},
     types::{PrivateKey, PublicKey, COMMITMENT_FACTORY},
 };
@@ -53,7 +54,7 @@ impl TestParams {
     }
 }
 
-pub fn make_input<R: Rng + CryptoRng>(rng: &mut R, val: u64) -> (TransactionInput, UnblindedOutput) {
+pub fn make_input<R: Rng + CryptoRng>(rng: &mut R, val: MicroTari) -> (TransactionInput, UnblindedOutput) {
     let key = PrivateKey::random(rng);
     let v = PrivateKey::from(val);
     let commitment = COMMITMENT_FACTORY.commit(&key, &v);

--- a/base_layer/wallet/src/transaction_manager.rs
+++ b/base_layer/wallet/src/transaction_manager.rs
@@ -204,6 +204,7 @@ mod test {
     use crate::transaction_manager::{TransactionManager, TransactionManagerError};
     use rand::{CryptoRng, OsRng, Rng};
     use tari_core::{
+        tari_amount::*,
         transaction::{OutputFeatures, TransactionInput, UnblindedOutput},
         transaction_protocol::{sender::SenderMessage, TransactionProtocolError},
         types::{PrivateKey, PublicKey, RangeProof, COMMITMENT_FACTORY, PROVER},
@@ -237,9 +238,9 @@ mod test {
         }
     }
 
-    pub fn make_input<R: Rng + CryptoRng>(rng: &mut R, val: u64) -> (TransactionInput, UnblindedOutput) {
+    pub fn make_input<R: Rng + CryptoRng>(rng: &mut R, val: MicroTari) -> (TransactionInput, UnblindedOutput) {
         let key = PrivateKey::random(rng);
-        let commitment = COMMITMENT_FACTORY.commit_value(&key, val);
+        let commitment = COMMITMENT_FACTORY.commit_value(&key, val.into());
         let input = TransactionInput::new(OutputFeatures::empty(), commitment);
         (input, UnblindedOutput::new(val, key, None))
     }
@@ -251,16 +252,16 @@ mod test {
         let a = TestParams::new(&mut rng);
         // Bob's parameters
         let b = TestParams::new(&mut rng);
-        let (utxo, input) = make_input(&mut rng, 2500);
+        let (utxo, input) = make_input(&mut rng, MicroTari(2500));
         let mut builder = SenderTransactionProtocol::builder(1);
         builder
             .with_lock_height(0)
-            .with_fee_per_gram(20)
+            .with_fee_per_gram(MicroTari(20))
             .with_offset(a.offset.clone())
             .with_private_nonce(a.nonce.clone())
             .with_change_secret(a.change_key.clone())
             .with_input(utxo.clone(), input)
-            .with_amount(0, 500);
+            .with_amount(0, MicroTari(500));
         let alice_stp = builder.build::<Blake256>(&PROVER, &COMMITMENT_FACTORY).unwrap();
 
         let mut alice_tx_manager = TransactionManager::new();
@@ -306,53 +307,53 @@ mod test {
 
         // Initializing all the sending transaction protocols
         // Alice
-        let (utxo_a1, input_a1) = make_input(&mut rng, 2500);
+        let (utxo_a1, input_a1) = make_input(&mut rng, MicroTari(2500));
         let mut builder_a1 = SenderTransactionProtocol::builder(1);
         builder_a1
             .with_lock_height(0)
-            .with_fee_per_gram(20)
+            .with_fee_per_gram(MicroTari(20))
             .with_offset(a_send1.offset.clone())
             .with_private_nonce(a_send1.nonce.clone())
             .with_change_secret(a_send1.change_key.clone())
             .with_input(utxo_a1.clone(), input_a1)
-            .with_amount(0, 500);
+            .with_amount(0, MicroTari(500));
         let alice_stp1 = builder_a1.build::<Blake256>(&PROVER, &COMMITMENT_FACTORY).unwrap();
 
-        let (utxo_a2, input_a2) = make_input(&mut rng, 2500);
+        let (utxo_a2, input_a2) = make_input(&mut rng, MicroTari(2500));
         let mut builder_a2 = SenderTransactionProtocol::builder(1);
         builder_a2
             .with_lock_height(0)
-            .with_fee_per_gram(20)
+            .with_fee_per_gram(MicroTari(20))
             .with_offset(a_send2.offset.clone())
             .with_private_nonce(a_send2.nonce.clone())
             .with_change_secret(a_send2.change_key.clone())
             .with_input(utxo_a2.clone(), input_a2)
-            .with_amount(0, 500);
+            .with_amount(0, MicroTari(500));
         let alice_stp2 = builder_a2.build::<Blake256>(&PROVER, &COMMITMENT_FACTORY).unwrap();
 
-        let (utxo_a3, input_a3) = make_input(&mut rng, 2500);
+        let (utxo_a3, input_a3) = make_input(&mut rng, MicroTari(2500));
         let mut builder_a3 = SenderTransactionProtocol::builder(1);
         builder_a3
             .with_lock_height(0)
-            .with_fee_per_gram(20)
+            .with_fee_per_gram(MicroTari(20))
             .with_offset(a_send3.offset.clone())
             .with_private_nonce(a_send3.nonce.clone())
             .with_change_secret(a_send3.change_key.clone())
             .with_input(utxo_a3.clone(), input_a3)
-            .with_amount(0, 500);
+            .with_amount(0, MicroTari(500));
         let alice_stp3 = builder_a3.build::<Blake256>(&PROVER, &COMMITMENT_FACTORY).unwrap();
 
         // Bob
-        let (utxo_b1, input_b1) = make_input(&mut rng, 2500);
+        let (utxo_b1, input_b1) = make_input(&mut rng, MicroTari(2500));
         let mut builder_b1 = SenderTransactionProtocol::builder(1);
         builder_b1
             .with_lock_height(0)
-            .with_fee_per_gram(20)
+            .with_fee_per_gram(MicroTari(20))
             .with_offset(b_send1.offset.clone())
             .with_private_nonce(b_send1.nonce.clone())
             .with_change_secret(b_send1.change_key.clone())
             .with_input(utxo_b1.clone(), input_b1)
-            .with_amount(0, 500);
+            .with_amount(0, MicroTari(500));
         let bob_stp1 = builder_b1.build::<Blake256>(&PROVER, &COMMITMENT_FACTORY).unwrap();
 
         let mut alice_tx_manager = TransactionManager::new();
@@ -470,16 +471,16 @@ mod test {
         let a = TestParams::new(&mut rng);
         // Bob's parameters
         let b = TestParams::new(&mut rng);
-        let (utxo, input) = make_input(&mut rng, 2500);
+        let (utxo, input) = make_input(&mut rng, MicroTari(2500));
         let mut builder = SenderTransactionProtocol::builder(1);
         builder
             .with_lock_height(0)
-            .with_fee_per_gram(20)
+            .with_fee_per_gram(MicroTari(20))
             .with_offset(a.offset.clone())
             .with_private_nonce(a.nonce.clone())
             .with_change_secret(a.change_key.clone())
             .with_input(utxo.clone(), input)
-            .with_amount(0, 500);
+            .with_amount(0, MicroTari(500));
         let alice_stp = builder.build::<Blake256>(&PROVER, &COMMITMENT_FACTORY).unwrap();
 
         let mut alice_tx_manager = TransactionManager::new();
@@ -528,16 +529,16 @@ mod test {
         let a = TestParams::new(&mut rng);
         // Bob's parameters
         let b = TestParams::new(&mut rng);
-        let (utxo, input) = make_input(&mut rng, 2500);
+        let (utxo, input) = make_input(&mut rng, MicroTari(2500));
         let mut builder = SenderTransactionProtocol::builder(1);
         builder
             .with_lock_height(0)
-            .with_fee_per_gram(20)
+            .with_fee_per_gram(MicroTari(20))
             .with_offset(a.offset.clone())
             .with_private_nonce(a.nonce.clone())
             .with_change_secret(a.change_key.clone())
             .with_input(utxo.clone(), input)
-            .with_amount(0, 500);
+            .with_amount(0, MicroTari(500));
         let alice_stp = builder.build::<Blake256>(&PROVER, &COMMITMENT_FACTORY).unwrap();
 
         let mut alice_tx_manager = TransactionManager::new();
@@ -573,16 +574,16 @@ mod test {
         let a = TestParams::new(&mut rng);
         // Bob's parameters
         let b = TestParams::new(&mut rng);
-        let (utxo, input) = make_input(&mut rng, 2500);
+        let (utxo, input) = make_input(&mut rng, MicroTari(2500));
         let mut builder = SenderTransactionProtocol::builder(1);
         builder
             .with_lock_height(0)
-            .with_fee_per_gram(20)
+            .with_fee_per_gram(MicroTari(20))
             .with_offset(a.offset.clone())
             .with_private_nonce(a.nonce.clone())
             .with_change_secret(a.change_key.clone())
             .with_input(utxo.clone(), input)
-            .with_amount(0, 500);
+            .with_amount(0, MicroTari(500));
         let alice_stp = builder.build::<Blake256>(&PROVER, &COMMITMENT_FACTORY).unwrap();
 
         let mut alice_tx_manager = TransactionManager::new();


### PR DESCRIPTION
## Description
All fees and amounts where just u64. This was all refactored to the microtari newtype struct

## Motivation and Context
By having the amounts just as u64, it makes it easy to assume its just Tari and get the magnitude wrong which could cause significant issues. 

## How Has This Been Tested?
All unit tests are still passing

## Types of changes
* [ ] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [x] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
* [x] I'm merging against the `development` branch
* [x] I ran `cargo-fmt --all` before pushing
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
