### PR TITLE
Allow heartbeat to be set on Connections

### DIFF
--- a/comms/src/connection/peer_connection/worker.rs
+++ b/comms/src/connection/peer_connection/worker.rs
@@ -190,7 +190,6 @@ impl PeerConnectionWorker {
                         );
                         let payload = self.create_payload(frames)?;
                         peer_conn.send(payload)?;
-
                         acquire_write_lock!(self.connection_stats).incr_message_sent();
                     },
                     ControlMessage::Pause => {
@@ -448,6 +447,8 @@ impl PeerConnectionWorker {
         let context = &self.context;
         Connection::new(&context.context, context.direction.clone())
             .set_linger(context.linger.clone())
+            .set_heartbeat_interval(Duration::from_millis(1000))
+            .set_heartbeat_timeout(Duration::from_millis(5000))
             .set_monitor_addr(self.monitor_addr.clone())
             .set_curve_encryption(context.curve_encryption.clone())
             .set_receive_hwm(PEER_CONNECTION_RECV_HWM)


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
    Allow the connection to set the following
    [socketopts](http://api.zeromq.org/4-2:zmq-setsockopt#toc17)

    - zmq_hearbeat_ttl
    - zmq_hearbeat_timeout
    - zmq_hearbeat_ivl

    And set these on the PeerConnection. This ensures that peer connections
    remain active when no traffic is sent/received for an extended period.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
ref #445 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Socket ops unit tests

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [x] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch
* [x] I ran `cargo-fmt --all` before pushing
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
