### PR TITLE
New KeyValStore trait and LMDBDatabase implementation for trait

### DIFF
--- a/comms/src/peer_manager/peer_storage.rs
+++ b/comms/src/peer_manager/peer_storage.rs
@@ -105,7 +105,7 @@ impl PeerStorage {
             .ok_or(PeerManagerError::PeerNotFoundError)?;
         self.remove_hashmap_links(peer_key)?;
         self.peers
-            .delete(&peer_key)
+            .remove(&peer_key)
             .map_err(|e| PeerManagerError::DatabaseError(e))?;;
         Ok(())
     }
@@ -553,7 +553,7 @@ mod test {
             assert!(peer_storage.add_peer(peer2.clone()).is_ok());
             assert!(peer_storage.add_peer(peer3.clone()).is_ok());
 
-            assert_eq!(peer_storage.peers.size().unwrap(), 3);
+            assert_eq!(peer_storage.peers.len().unwrap(), 3);
             assert!(peer_storage.find_with_public_key(&peer1.public_key).is_ok());
             assert!(peer_storage.find_with_public_key(&peer2.public_key).is_ok());
             assert!(peer_storage.find_with_public_key(&peer3.public_key).is_ok());
@@ -563,7 +563,7 @@ mod test {
         let peer_database = datastore.get_handle(database_name).unwrap();
         let peer_storage = PeerStorage::new(peer_database).unwrap();
 
-        assert_eq!(peer_storage.peers.size().unwrap(), 3);
+        assert_eq!(peer_storage.peers.len().unwrap(), 3);
         assert!(peer_storage.find_with_public_key(&peer1.public_key).is_ok());
         assert!(peer_storage.find_with_public_key(&peer2.public_key).is_ok());
         assert!(peer_storage.find_with_public_key(&peer3.public_key).is_ok());
@@ -608,7 +608,7 @@ mod test {
         assert!(peer_storage.add_peer(peer2.clone()).is_ok());
         assert!(peer_storage.add_peer(peer3.clone()).is_ok());
 
-        assert_eq!(peer_storage.peers.size().unwrap(), 3);
+        assert_eq!(peer_storage.peers.len().unwrap(), 3);
 
         assert_eq!(
             peer_storage.find_with_public_key(&peer1.public_key).unwrap().public_key,
@@ -668,7 +668,7 @@ mod test {
         // Test delete of border case peer
         assert!(peer_storage.delete_peer(&peer3.node_id).is_ok());
 
-        assert_eq!(peer_storage.peers.size().unwrap(), 2);
+        assert_eq!(peer_storage.peers.len().unwrap(), 2);
 
         assert_eq!(
             peer_storage.find_with_public_key(&peer1.public_key).unwrap().public_key,
@@ -717,7 +717,7 @@ mod test {
         assert!(peer_storage.add_peer(peer3.clone()).is_ok());
         assert!(peer_storage.delete_peer(&peer2.node_id).is_ok());
 
-        assert_eq!(peer_storage.peers.size().unwrap(), 2);
+        assert_eq!(peer_storage.peers.len().unwrap(), 2);
 
         assert_eq!(
             peer_storage.find_with_public_key(&peer1.public_key).unwrap().public_key,

--- a/infrastructure/storage/src/key_val_store/error.rs
+++ b/infrastructure/storage/src/key_val_store/error.rs
@@ -1,0 +1,38 @@
+// Copyright 2019. The Tari Project
+//
+// Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+// following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+// disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+// following disclaimer in the documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+// products derived from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+// INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+// WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+// USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+use derive_error::Error;
+
+#[derive(Debug, Error)]
+pub enum KeyValStoreError {
+    /// The Thread Safety has been breached and the data access has become poisoned
+    PoisonedAccess,
+    /// An error occurred with the key value query or store
+    #[error(no_from, non_std)]
+    DatabaseError(String),
+    /// An error occurred during serialization
+    #[error(no_from, non_std)]
+    SerializationError(String),
+    /// An error occurred during deserialization
+    #[error(no_from, non_std)]
+    DeserializationError(String),
+}

--- a/infrastructure/storage/src/key_val_store/key_val_store.rs
+++ b/infrastructure/storage/src/key_val_store/key_val_store.rs
@@ -1,0 +1,65 @@
+// Copyright 2019. The Tari Project
+//
+// Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+// following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+// disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+// following disclaimer in the documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+// products derived from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+// INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+// WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+// USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+use crate::key_val_store::KeyValStoreError;
+use lmdb_zero::traits::AsLmdbBytes;
+
+/// General CRUD behaviour of Key-value store implementations.
+pub trait KeyValStore {
+    /// Inserts a key-value pair into the key-value database.
+    fn insert_pair<K, V>(&self, key: &K, value: &V) -> Result<(), KeyValStoreError>
+    where
+        K: AsLmdbBytes + ?Sized,
+        V: serde::Serialize;
+
+    /// Get the value corresponding to the provided key from the key-value database.
+    fn get_value<K, V>(&self, key: &K) -> Result<Option<V>, KeyValStoreError>
+    where
+        K: AsLmdbBytes + ?Sized,
+        for<'t> V: serde::de::DeserializeOwned;
+
+    /// Returns the total number of entries recorded in the key-value database.
+    fn size(&self) -> Result<usize, KeyValStoreError>;
+
+    /// Execute function `f` for each value in the database.
+    ///
+    /// `f` is a closure of form `|pair: Result<(K,V), KeyValStoreError>| -> ()`. You will usually need to include type
+    /// inference to let Rust know which type to deserialise to:
+    /// ```nocompile
+    ///    let res = db.for_each::<Key, Val, _>(|pair| {
+    ///        let (key, val) = pair.unwrap();
+    ///        //.. do stuff with key and val..
+    ///    });
+    fn for_each<K, V, F>(&self, f: F) -> Result<(), KeyValStoreError>
+    where
+        K: serde::de::DeserializeOwned,
+        V: serde::de::DeserializeOwned,
+        F: FnMut(Result<(K, V), KeyValStoreError>);
+
+    /// Checks whether the provided `key` exists in the key-value database.
+    fn exists<K>(&self, key: &K) -> Result<bool, KeyValStoreError>
+    where K: AsLmdbBytes + ?Sized;
+
+    /// Delete a key-pair record associated with the provided `key` from the key-pair database.
+    fn delete<K>(&self, key: &K) -> Result<(), KeyValStoreError>
+    where K: AsLmdbBytes + ?Sized;
+}

--- a/infrastructure/storage/src/key_val_store/lmdb_database.rs
+++ b/infrastructure/storage/src/key_val_store/lmdb_database.rs
@@ -1,0 +1,176 @@
+//  Copyright 2019 The Tari Project
+//
+//  Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+//  following conditions are met:
+//
+//  1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+//  disclaimer.
+//
+//  2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+//  following disclaimer in the documentation and/or other materials provided with the distribution.
+//
+//  3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+//  products derived from this software without specific prior written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+//  INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+//  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+//  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+//  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+//  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+//  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+use crate::{
+    key_val_store::{key_val_store::KeyValStore, KeyValStoreError},
+    lmdb_store::LMDBDatabase,
+};
+use lmdb_zero::traits::AsLmdbBytes;
+
+impl KeyValStore for LMDBDatabase {
+    /// Inserts a key-value pair into the key-value database.
+    fn insert_pair<K, V>(&self, key: &K, value: &V) -> Result<(), KeyValStoreError>
+    where
+        K: AsLmdbBytes + ?Sized,
+        V: serde::Serialize,
+    {
+        self.insert::<K, V>(key, value)
+            .map_err(|e| KeyValStoreError::DatabaseError(e.to_string()))
+    }
+
+    /// Get the value corresponding to the provided key from the key-value database.
+    fn get_value<K, V>(&self, key: &K) -> Result<Option<V>, KeyValStoreError>
+    where
+        K: AsLmdbBytes + ?Sized,
+        for<'t> V: serde::de::DeserializeOwned,
+    {
+        self.get::<K, V>(key)
+            .map_err(|e| KeyValStoreError::DatabaseError(e.to_string()))
+    }
+
+    /// Returns the total number of entries recorded in the key-value database.
+    fn size(&self) -> Result<usize, KeyValStoreError> {
+        self.len().map_err(|e| KeyValStoreError::DatabaseError(e.to_string()))
+    }
+
+    /// Iterate over all the stored records and execute the function `f` for each pair in the key-value database.
+    fn for_each<K, V, F>(&self, f: F) -> Result<(), KeyValStoreError>
+    where
+        K: serde::de::DeserializeOwned,
+        V: serde::de::DeserializeOwned,
+        F: FnMut(Result<(K, V), KeyValStoreError>),
+    {
+        self.for_each::<K, V, F>(f)
+            .map_err(|e| KeyValStoreError::DatabaseError(e.to_string()))
+    }
+
+    /// Checks whether a record exist in the key-value database that corresponds to the provided `key`.
+    fn exists<K>(&self, key: &K) -> Result<bool, KeyValStoreError>
+    where K: AsLmdbBytes + ?Sized {
+        self.contains_key::<K>(key)
+            .map_err(|e| KeyValStoreError::DatabaseError(e.to_string()))
+    }
+
+    /// Remove the record from the key-value database that corresponds with the provided `key`.
+    fn delete<K>(&self, key: &K) -> Result<(), KeyValStoreError>
+    where K: AsLmdbBytes + ?Sized {
+        self.remove::<K>(key)
+            .map_err(|e| KeyValStoreError::DatabaseError(e.to_string()))
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::lmdb_store::{LMDBBuilder, LMDBError, LMDBStore};
+    use serde::{Deserialize, Serialize};
+    use std::path::PathBuf;
+
+    fn get_path(name: &str) -> String {
+        let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+        path.push("tests/data");
+        path.push(name);
+        path.to_str().unwrap().to_string()
+    }
+
+    fn init_datastore(name: &str) -> Result<LMDBStore, LMDBError> {
+        let path = get_path(name);
+        let _ = std::fs::create_dir(&path).unwrap_or_default();
+        LMDBBuilder::new()
+            .set_path(&path)
+            .set_environment_size(10)
+            .set_max_number_of_databases(2)
+            .add_database(name, lmdb_zero::db::CREATE)
+            .build()
+    }
+
+    fn clean_up_datastore(name: &str) {
+        std::fs::remove_dir_all(get_path(name)).unwrap();
+    }
+
+    #[test]
+    fn test_lmdb_kvstore() {
+        let database_name = "test_lmdb_kvstore"; // Note: every test should have unique database
+        let datastore = init_datastore(database_name).unwrap();
+        let db = datastore.get_handle(database_name).unwrap();
+
+        #[derive(Debug, Clone, Deserialize, Serialize, PartialEq)]
+        struct R {
+            value: String,
+        }
+        let key1 = 1 as u64;
+        let key2 = 2 as u64;
+        let key3 = 3 as u64;
+        let key4 = 4 as u64;
+        let val1 = R {
+            value: "one".to_string(),
+        };
+        let val2 = R {
+            value: "two".to_string(),
+        };
+        let val3 = R {
+            value: "three".to_string(),
+        };
+        db.insert_pair(&key1, &val1).unwrap();
+        db.insert_pair(&key2, &val2).unwrap();
+        db.insert_pair(&key3, &val3).unwrap();
+
+        assert_eq!(db.get_value::<u64, R>(&key1).unwrap().unwrap(), val1);
+        assert_eq!(db.get_value::<u64, R>(&key2).unwrap().unwrap(), val2);
+        assert_eq!(db.get_value::<u64, R>(&key3).unwrap().unwrap(), val3);
+        assert!(db.get_value::<u64, R>(&key4).unwrap().is_none());
+        assert_eq!(db.size().unwrap(), 3);
+        assert!(db.exists(&key1).unwrap());
+        assert!(db.exists(&key2).unwrap());
+        assert!(db.exists(&key3).unwrap());
+        assert!(!db.exists(&key4).unwrap());
+
+        db.remove(&key2).unwrap();
+        assert_eq!(db.get_value::<u64, R>(&key1).unwrap().unwrap(), val1);
+        assert!(db.get_value::<u64, R>(&key2).unwrap().is_none());
+        assert_eq!(db.get_value::<u64, R>(&key3).unwrap().unwrap(), val3);
+        assert!(db.get_value::<u64, R>(&key4).unwrap().is_none());
+        assert_eq!(db.size().unwrap(), 2);
+        assert!(db.exists(&key1).unwrap());
+        assert!(!db.exists(&key2).unwrap());
+        assert!(db.exists(&key3).unwrap());
+        assert!(!db.exists(&key4).unwrap());
+
+        // Only Key1 and Key3 should be in key-value database, but order is not known
+        let mut key1_found = false;
+        let mut key3_found = false;
+        let _res = db.for_each::<u64, R, _>(|pair| {
+            let (key, val) = pair.unwrap();
+            if key == key1 {
+                key1_found = true;
+                assert_eq!(val, val1);
+            } else if key == key3 {
+                key3_found = true;
+                assert_eq!(val, val3);
+            }
+        });
+        assert!(key1_found);
+        assert!(key3_found);
+
+        clean_up_datastore(database_name);
+    }
+}

--- a/infrastructure/storage/src/key_val_store/mod.rs
+++ b/infrastructure/storage/src/key_val_store/mod.rs
@@ -1,0 +1,28 @@
+// Copyright 2019. The Tari Project
+//
+// Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+// following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+// disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+// following disclaimer in the documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+// products derived from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+// INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+// WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+// USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+pub mod error;
+pub mod key_val_store;
+pub mod lmdb_database;
+
+pub use error::KeyValStoreError;
+pub use key_val_store::KeyValStore;

--- a/infrastructure/storage/src/lib.rs
+++ b/infrastructure/storage/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod key_val_store;
 pub mod keyvalue_store;
 pub mod lmdb;
 pub mod lmdb_store;

--- a/infrastructure/storage/tests/lmdb.rs
+++ b/infrastructure/storage/tests/lmdb.rs
@@ -124,7 +124,7 @@ fn single_thread() {
         let check: User = db.get(&user.id).unwrap().unwrap();
         assert_eq!(check, *user);
     }
-    assert_eq!(db.size().unwrap(), 1000);
+    assert_eq!(db.len().unwrap(), 1000);
     clean_up("single_thread");
 }
 
@@ -200,7 +200,7 @@ fn multi_thread_writes() {
 
     let db = env.get_handle("users").unwrap();
 
-    assert_eq!(db.size().unwrap(), 1000);
+    assert_eq!(db.len().unwrap(), 1000);
     for i in 0..1000 {
         let value: i32 = db.get(&i).unwrap().unwrap();
         assert_eq!(i, value);
@@ -244,8 +244,8 @@ fn pair_iterator() {
 #[test]
 fn exists_and_delete() {
     let (_, db) = insert_all_users("delete");
-    assert!(db.exists(&525u64).unwrap());
-    db.delete(&525u64).unwrap();
-    assert_eq!(db.exists(&525u64).unwrap(), false);
+    assert!(db.contains_key(&525u64).unwrap());
+    db.remove(&525u64).unwrap();
+    assert_eq!(db.contains_key(&525u64).unwrap(), false);
     clean_up("delete");
 }


### PR DESCRIPTION
##  Description
- Renamed LMDBDatabase delete, size and exist functions to be similar to HashMap naming convention and so that those names can be used by the KeyValStore trait
- Added new KeyValStore trait that has a similar interface to LMDBDatabase
- Added KeyValStoreError used by new KeyValStore trait
- Implemented KeyValStore for LMDBDatabase 

## Motivation and Context
This trait will make it easier to switch to a HashMap implementation when persistent storage is not required, such as during testing.

## How Has This Been Tested?
New test added.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [x] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch
* [x] I ran `cargo-fmt --all` before pushing
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
