### PR TITLE
Remove generics from MessageEnvelopeHeader

### DIFF
--- a/comms/src/control_service/types.rs
+++ b/comms/src/control_service/types.rs
@@ -27,7 +27,6 @@ use crate::{
     dispatcher::Dispatcher,
     message::{Message, MessageEnvelopeHeader},
     peer_manager::{NodeIdentity, PeerManager},
-    types::CommsPublicKey,
 };
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use std::sync::Arc;
@@ -69,7 +68,7 @@ where
 pub struct ControlServiceMessageContext<MType>
 where MType: Clone
 {
-    pub envelope_header: MessageEnvelopeHeader<CommsPublicKey>,
+    pub envelope_header: MessageEnvelopeHeader,
     pub message: Message,
     pub connection_manager: Arc<ConnectionManager>,
     pub peer_manager: Arc<PeerManager>,

--- a/comms/src/control_service/worker.rs
+++ b/comms/src/control_service/worker.rs
@@ -35,7 +35,7 @@ use crate::{
         ZmqContext,
     },
     connection_manager::ConnectionManager,
-    message::{Frame, FrameSet, Message, MessageEnvelope, MessageEnvelopeHeader, MessageFlags},
+    message::{Frame, FrameSet, Message, MessageEnvelope, MessageFlags},
     peer_manager::NodeIdentity,
     types::{CommsCipher, CommsPublicKey},
 };
@@ -195,7 +195,7 @@ where
             .try_into()
             .map_err(|err| ControlServiceError::MessageError(err))?;
 
-        let envelope_header: MessageEnvelopeHeader<CommsPublicKey> = envelope.to_header()?;
+        let envelope_header = envelope.to_header()?;
         if !envelope_header.flags.contains(MessageFlags::ENCRYPTED) {
             return Err(ControlServiceError::ReceivedUnencryptedMessage);
         }

--- a/comms/src/inbound_message_service/comms_msg_handlers.rs
+++ b/comms/src/inbound_message_service/comms_msg_handlers.rs
@@ -22,16 +22,8 @@
 
 use crate::{
     dispatcher::{DispatchError, DispatchResolver, DispatchableKey},
-    message::{
-        DomainMessageContext,
-        Message,
-        MessageContext,
-        MessageEnvelopeHeader,
-        MessageFlags,
-        MessageHeader,
-        NodeDestination,
-    },
-    types::{CommsPublicKey, MessageDispatcher},
+    message::{DomainMessageContext, Message, MessageContext, MessageFlags, MessageHeader, NodeDestination},
+    types::MessageDispatcher,
 };
 use log::*;
 use serde::{de::DeserializeOwned, Serialize};
@@ -84,7 +76,7 @@ where
             return Ok(CommsDispatchType::Discard);
         }
         // Check destination of message
-        let message_envelope_header: MessageEnvelopeHeader<CommsPublicKey> = message_context
+        let message_envelope_header = message_context
             .message_envelope
             .to_header()
             .map_err(|e| DispatchError::HandlerError(format!("{}", e)))?;
@@ -124,7 +116,7 @@ where
     );
 
     // Check encryption and retrieved Message
-    let message_envelope_header: MessageEnvelopeHeader<CommsPublicKey> = envelope
+    let message_envelope_header = envelope
         .to_header()
         .map_err(|e| DispatchError::HandlerError(format!("{}", e)))?;
 

--- a/comms/src/message/envelope.rs
+++ b/comms/src/message/envelope.rs
@@ -38,10 +38,10 @@ const FRAMES_PER_MESSAGE: usize = 3;
 /// Represents data that every message contains.
 /// As described in [RFC-0172](https://rfc.tari.com/RFC-0172_PeerToPeerMessagingProtocol.html#messaging-structure)
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
-pub struct MessageEnvelopeHeader<PK> {
+pub struct MessageEnvelopeHeader {
     pub version: u8,
-    pub source: PK,
-    pub dest: NodeDestination<PK>,
+    pub source: CommsPublicKey,
+    pub dest: NodeDestination<CommsPublicKey>,
     pub signature: Vec<u8>,
     pub flags: MessageFlags,
 }
@@ -101,7 +101,7 @@ impl MessageEnvelope {
     /// Verify that the signature provided in the message header is valid for the specified source and body of the
     /// message envelope
     pub fn verify_signature(&self) -> Result<bool, MessageError> {
-        let message_envelope_header: MessageEnvelopeHeader<CommsPublicKey> = self.to_header()?;
+        let message_envelope_header = self.to_header()?;
         crypto::verify(
             &message_envelope_header.source,
             message_envelope_header.signature,
@@ -120,11 +120,7 @@ impl MessageEnvelope {
     }
 
     /// Returns the [MessageEnvelopeHeader] deserialized from the header frame
-    pub fn to_header<PK>(&self) -> Result<MessageEnvelopeHeader<PK>, MessageError>
-    where
-        PK: PublicKey,
-        MessageEnvelopeHeader<PK>: MessageFormat,
-    {
+    pub fn to_header(&self) -> Result<MessageEnvelopeHeader, MessageError> {
         MessageEnvelopeHeader::from_binary(self.header_frame()).map_err(Into::into)
     }
 

--- a/comms/src/outbound_message_service/outbound_message_service.rs
+++ b/comms/src/outbound_message_service/outbound_message_service.rs
@@ -143,7 +143,6 @@ mod test {
             node_id::NodeId,
             peer::{Peer, PeerFlags},
         },
-        types::CommsPublicKey,
     };
     use log::*;
     use std::path::PathBuf;
@@ -228,7 +227,7 @@ mod test {
         assert_eq!(outbound_message.num_attempts(), 0);
         assert_eq!(outbound_message.is_scheduled(), true);
         let message_envelope: MessageEnvelope = outbound_message.message_frames().clone().try_into().unwrap();
-        let message_envelope_header = message_envelope.to_header::<CommsPublicKey>().unwrap();
+        let message_envelope_header = message_envelope.to_header().unwrap();
         assert_eq!(message_envelope_header.source, node_identity.identity.public_key);
         assert_eq!(
             message_envelope_header.dest,


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Removed generic public key from MessageEnvelopeHeader in favour of
CommsPublicKey.


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This generic could not be used in the comms crate and this change cuts down on some generics cruft. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Existing tests updated and pass

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [x] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch
* [x] I ran `cargo-fmt --all` before pushing
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
