### PR TITLE
Remove need to double deserialize EnvelopeHeader to verify msg signature

### DIFF
--- a/comms/src/control_service/worker.rs
+++ b/comms/src/control_service/worker.rs
@@ -195,7 +195,7 @@ where
             .try_into()
             .map_err(|err| ControlServiceError::MessageError(err))?;
 
-        let envelope_header = envelope.to_header()?;
+        let envelope_header = envelope.deserialize_header()?;
         if !envelope_header.flags.contains(MessageFlags::ENCRYPTED) {
             return Err(ControlServiceError::ReceivedUnencryptedMessage);
         }

--- a/comms/src/utils.rs
+++ b/comms/src/utils.rs
@@ -48,11 +48,10 @@ pub mod crypto {
     }
 
     /// Verify that the signature is valid for the message body
-    pub fn verify<B>(public_key: &CommsPublicKey, signature: Vec<u8>, body: B) -> Result<bool, MessageError>
+    pub fn verify<B>(public_key: &CommsPublicKey, signature: &[u8], body: B) -> Result<bool, MessageError>
     where B: AsRef<[u8]> {
-        let signature =
-            SchnorrSignature::<CommsPublicKey, <CommsPublicKey as PublicKey>::K>::from_binary(signature.as_slice())
-                .map_err(MessageError::MessageFormatError)?;
+        let signature = SchnorrSignature::<CommsPublicKey, <CommsPublicKey as PublicKey>::K>::from_binary(signature)
+            .map_err(MessageError::MessageFormatError)?;
         let challenge = Challenge::new().chain(body).result().to_vec();
         Ok(signature.verify_challenge(public_key, &challenge))
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Moved verify signature into MessageEnvelopeHeader so that
MessageEnvelope doesn't have to deserialize the header to verify.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Small optimisation of message signature verification

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Split up a few unit tests and added a new one specifically for signature verification 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [x] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [x] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch
* [x] I ran `cargo-fmt --all` before pushing
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
