### PR TITLE
Replace LMDBDatabase with HMapDatabase in Comms

### DIFF
--- a/comms/src/inbound_message_service/inbound_message_worker.rs
+++ b/comms/src/inbound_message_service/inbound_message_worker.rs
@@ -245,11 +245,10 @@ mod test {
     };
     use serde::{Deserialize, Serialize};
     use std::{
-        fs,
         sync::Arc,
         time::{self, Duration},
     };
-    use tari_storage::lmdb_store::LMDBBuilder;
+    use tari_storage::key_val_store::HMapDatabase;
     use tari_utilities::{message_format::MessageFormat, thread_join::ThreadJoinWithTimeout};
 
     fn init() {
@@ -263,21 +262,6 @@ mod test {
     #[test]
     fn test_dispatch_to_multiple_service_handlers() {
         init();
-
-        // Clear and setup DB folders
-        let test_dir = "./tests/test_peer_storage";
-        let database_name = "peer_manager";
-        if fs::metadata(test_dir).is_ok() {
-            assert!(fs::remove_dir_all(test_dir).is_ok());
-        }
-        assert!(fs::create_dir(test_dir).is_ok());
-        // Setup peer storage
-        let datastore = LMDBBuilder::new()
-            .set_path(test_dir)
-            .add_database(database_name, lmdb_zero::db::CREATE)
-            .build()
-            .unwrap();
-        let database = datastore.get_handle(database_name).unwrap();
 
         let context = ZmqContext::new();
         let node_identity = Arc::new(NodeIdentity::random_for_test(None));
@@ -309,7 +293,7 @@ mod test {
                 .start()
                 .unwrap(),
         );
-        let peer_manager = Arc::new(PeerManager::new(database).unwrap());
+        let peer_manager = Arc::new(PeerManager::new(HMapDatabase::new()).unwrap());
         // Add peer to peer manager
         let peer = Peer::new(
             node_identity.identity.public_key.clone(),
@@ -413,12 +397,5 @@ mod test {
         std::thread::sleep(time::Duration::from_millis(200));
         thread_handle.timeout_join(Duration::from_millis(100)).unwrap();
         assert!(client_connection.send(message1_frame_set).is_err());
-
-        // Clear up DB folders
-        let _no_val = fs::remove_dir_all(test_dir);
-        if fs::metadata(test_dir).is_ok() {
-            println!("Database file handles not released, still open in {:?}!", test_dir);
-            assert!(fs::remove_dir_all(test_dir).is_ok());
-        }
     }
 }

--- a/comms/src/peer_manager/error.rs
+++ b/comms/src/peer_manager/error.rs
@@ -20,9 +20,9 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE
 
-use crate::{connection::NetAddressError, peer_manager::node_id::NodeIdError, types::CommsDataStoreError};
+use crate::{connection::NetAddressError, peer_manager::node_id::NodeIdError};
 use derive_error::Error;
-use tari_storage::keyvalue_store::DatastoreError;
+use tari_storage::{key_val_store::KeyValStoreError, keyvalue_store::DatastoreError};
 use tari_utilities::message_format::MessageFormatError;
 
 #[derive(Debug, Error)]
@@ -52,6 +52,6 @@ pub enum PeerManagerError {
     /// Problem initializing the RNG
     RngError,
     // An problem has been encountered with the database
-    DatabaseError(CommsDataStoreError),
+    DatabaseError(KeyValStoreError),
     NodeIdError(NodeIdError),
 }

--- a/comms/src/types.rs
+++ b/comms/src/types.rs
@@ -25,7 +25,11 @@ use crate::{
     inbound_message_service::comms_msg_handlers::{CommsDispatchType, InboundMessageServiceResolver},
 };
 use tari_crypto::{common::Blake256, keys::PublicKey, ristretto::RistrettoPublicKey};
-use tari_storage::lmdb_store::{LMDBDatabase, LMDBError, LMDBStore};
+#[cfg(test)]
+use tari_storage::key_val_store::HMapDatabase;
+#[cfg(not(test))]
+use tari_storage::lmdb_store::LMDBDatabase;
+use tari_storage::lmdb_store::LMDBStore;
 use tari_utilities::ciphers::chacha20::ChaCha20;
 
 /// The message protocol version for the MessageEnvelopeHeader
@@ -52,8 +56,11 @@ pub type CommsCipher = ChaCha20;
 
 /// Datastore and Database used for persistence storage
 pub type CommsDataStore = LMDBStore;
+
+#[cfg(not(test))]
 pub type CommsDatabase = LMDBDatabase;
-pub type CommsDataStoreError = LMDBError;
+#[cfg(test)]
+pub type CommsDatabase = HMapDatabase;
 
 /// Dispatcher format for comms level dispatching to handlers
 pub type MessageDispatcher<M> = Dispatcher<CommsDispatchType, M, InboundMessageServiceResolver, DispatchError>;

--- a/infrastructure/storage/src/key_val_store/error.rs
+++ b/infrastructure/storage/src/key_val_store/error.rs
@@ -35,4 +35,6 @@ pub enum KeyValStoreError {
     /// An error occurred during deserialization
     #[error(no_from, non_std)]
     DeserializationError(String),
+    /// The specified key did not exist in the key-val store
+    KeyNotFound,
 }

--- a/infrastructure/storage/src/key_val_store/hmap_database.rs
+++ b/infrastructure/storage/src/key_val_store/hmap_database.rs
@@ -1,0 +1,248 @@
+//  Copyright 2019 The Tari Project
+//
+//  Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+//  following conditions are met:
+//
+//  1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+//  disclaimer.
+//
+//  2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+//  following disclaimer in the documentation and/or other materials provided with the distribution.
+//
+//  3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+//  products derived from this software without specific prior written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+//  INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+//  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+//  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+//  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+//  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+//  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+use crate::key_val_store::{error::KeyValStoreError, key_val_store::KeyValStore};
+use lmdb_zero::traits::AsLmdbBytes;
+use std::{collections::HashMap, sync::RwLock};
+
+///  The HMapDatabase mimics the behaviour of LMDBDatabase without keeping a persistent copy of the key-value records.
+/// It allows key-value pairs to be inserted, retrieved and removed in a thread-safe manner.
+pub struct HMapDatabase {
+    db: RwLock<HashMap<Vec<u8>, Vec<u8>>>,
+}
+
+impl HMapDatabase {
+    /// Creates a new empty HMapDatabase with the specified name
+    pub fn new() -> Self {
+        Self {
+            db: RwLock::new(HashMap::new()),
+        }
+    }
+
+    /// Inserts a key-value record into the database. Internally, `insert` serializes the key and value using bincode
+    /// and adds the pair into HashMap guarded with a RwLock.
+    pub fn insert<K, V>(&self, key: &K, value: &V) -> Result<(), KeyValStoreError>
+    where
+        K: AsLmdbBytes + ?Sized,
+        V: serde::Serialize,
+    {
+        let mut value_buf = Vec::with_capacity(512);
+        bincode::serialize_into(&mut value_buf, value)
+            .map_err(|e| KeyValStoreError::SerializationError(e.to_string()))?;
+
+        self.db
+            .write()
+            .map_err(|_| KeyValStoreError::PoisonedAccess)?
+            .insert(key.as_lmdb_bytes().to_vec(), value_buf);
+        Ok(())
+    }
+
+    /// Get a value from the key-value database. The retrieved value is deserialized from bincode into `V`
+    pub fn get<K, V>(&self, key: &K) -> Result<Option<V>, KeyValStoreError>
+    where
+        K: AsLmdbBytes + ?Sized,
+        for<'t> V: serde::de::DeserializeOwned, // read this as, for *any* lifetime, t, we can convert a [u8] to V
+    {
+        match self
+            .db
+            .read()
+            .map_err(|_| KeyValStoreError::PoisonedAccess)?
+            .get(&key.as_lmdb_bytes().to_vec())
+        {
+            Some(val_buf) => match bincode::deserialize(val_buf) {
+                Ok(val) => Ok(Some(val)),
+                Err(_) => Ok(None),
+            },
+            None => Ok(None),
+        }
+    }
+
+    /// Returns the total number of entries recorded in the key-value database.
+    pub fn len(&self) -> Result<usize, KeyValStoreError> {
+        Ok(self.db.read().map_err(|_| KeyValStoreError::PoisonedAccess)?.len())
+    }
+
+    /// Iterate over all the stored records and execute the function `f` for each pair in the key-value database.
+    pub fn for_each<K, V, F>(&self, mut f: F) -> Result<(), KeyValStoreError>
+    where
+        K: serde::de::DeserializeOwned,
+        V: serde::de::DeserializeOwned,
+        F: FnMut(Result<(K, V), KeyValStoreError>),
+    {
+        for (key_buf, val_buf) in self
+            .db
+            .read()
+            .map_err(|_| KeyValStoreError::PoisonedAccess)?
+            .clone()
+            .into_iter()
+        {
+            let key =
+                bincode::deserialize(&key_buf).map_err(|e| KeyValStoreError::DeserializationError(e.to_string()))?;
+            let val =
+                bincode::deserialize(&val_buf).map_err(|e| KeyValStoreError::DeserializationError(e.to_string()))?;
+
+            f(Ok((key, val)));
+        }
+
+        Ok(())
+    }
+
+    /// Checks whether a record exist in the key-value database that corresponds to the provided `key`.
+    pub fn contains_key<K>(&self, key: &K) -> Result<bool, KeyValStoreError>
+    where K: AsLmdbBytes + ?Sized {
+        Ok(self
+            .db
+            .read()
+            .map_err(|_| KeyValStoreError::PoisonedAccess)?
+            .contains_key(&key.as_lmdb_bytes().to_vec()))
+    }
+
+    /// Remove the record from the key-value database that corresponds with the provided `key`.
+    pub fn remove<K>(&self, key: &K) -> Result<(), KeyValStoreError>
+    where K: AsLmdbBytes + ?Sized {
+        match self
+            .db
+            .write()
+            .map_err(|_| KeyValStoreError::PoisonedAccess)?
+            .remove(&key.as_lmdb_bytes().to_vec())
+        {
+            Some(_) => Ok(()),
+            None => Err(KeyValStoreError::KeyNotFound),
+        }
+    }
+}
+
+impl KeyValStore for HMapDatabase {
+    /// Inserts a key-value pair into the key-value database.
+    fn insert_pair<K, V>(&self, key: &K, value: &V) -> Result<(), KeyValStoreError>
+    where
+        K: AsLmdbBytes + ?Sized,
+        V: serde::Serialize,
+    {
+        self.insert::<K, V>(key, value)
+    }
+
+    /// Get the value corresponding to the provided key from the key-value database.
+    fn get_value<K, V>(&self, key: &K) -> Result<Option<V>, KeyValStoreError>
+    where
+        K: AsLmdbBytes + ?Sized,
+        for<'t> V: serde::de::DeserializeOwned,
+    {
+        self.get::<K, V>(key)
+    }
+
+    /// Returns the total number of entries recorded in the key-value database.
+    fn size(&self) -> Result<usize, KeyValStoreError> {
+        self.len()
+    }
+
+    /// Iterate over all the stored records and execute the function `f` for each pair in the key-value database.
+    fn for_each<K, V, F>(&self, f: F) -> Result<(), KeyValStoreError>
+    where
+        K: serde::de::DeserializeOwned,
+        V: serde::de::DeserializeOwned,
+        F: FnMut(Result<(K, V), KeyValStoreError>),
+    {
+        self.for_each::<K, V, F>(f)
+    }
+
+    /// Checks whether a record exist in the key-value database that corresponds to the provided `key`.
+    fn exists<K>(&self, key: &K) -> Result<bool, KeyValStoreError>
+    where K: AsLmdbBytes + ?Sized {
+        self.contains_key::<K>(key)
+    }
+
+    /// Remove the record from the key-value database that corresponds with the provided `key`.
+    fn delete<K>(&self, key: &K) -> Result<(), KeyValStoreError>
+    where K: AsLmdbBytes + ?Sized {
+        self.remove::<K>(key)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use serde::{Deserialize, Serialize};
+
+    #[test]
+    fn test_hmap_kvstore() {
+        let db = HMapDatabase::new();
+
+        #[derive(Debug, Clone, Deserialize, Serialize, PartialEq)]
+        struct R {
+            value: String,
+        }
+        let key1 = 1 as u64;
+        let key2 = 2 as u64;
+        let key3 = 3 as u64;
+        let key4 = 4 as u64;
+        let val1 = R {
+            value: "one".to_string(),
+        };
+        let val2 = R {
+            value: "two".to_string(),
+        };
+        let val3 = R {
+            value: "three".to_string(),
+        };
+        db.insert_pair(&key1, &val1).unwrap();
+        db.insert_pair(&key2, &val2).unwrap();
+        db.insert_pair(&key3, &val3).unwrap();
+
+        assert_eq!(db.get_value::<u64, R>(&key1).unwrap().unwrap(), val1);
+        assert_eq!(db.get_value::<u64, R>(&key2).unwrap().unwrap(), val2);
+        assert_eq!(db.get_value::<u64, R>(&key3).unwrap().unwrap(), val3);
+        assert!(db.get_value::<u64, R>(&key4).unwrap().is_none());
+        assert_eq!(db.size().unwrap(), 3);
+        assert!(db.exists(&key1).unwrap());
+        assert!(db.exists(&key2).unwrap());
+        assert!(db.exists(&key3).unwrap());
+        assert!(!db.exists(&key4).unwrap());
+
+        db.remove(&key2).unwrap();
+        assert_eq!(db.get_value::<u64, R>(&key1).unwrap().unwrap(), val1);
+        assert!(db.get_value::<u64, R>(&key2).unwrap().is_none());
+        assert_eq!(db.get_value::<u64, R>(&key3).unwrap().unwrap(), val3);
+        assert!(db.get_value::<u64, R>(&key4).unwrap().is_none());
+        assert_eq!(db.size().unwrap(), 2);
+        assert!(db.exists(&key1).unwrap());
+        assert!(!db.exists(&key2).unwrap());
+        assert!(db.exists(&key3).unwrap());
+        assert!(!db.exists(&key4).unwrap());
+
+        // Only Key1 and Key3 should be in key-value database, but order is not known
+        let mut key1_found = false;
+        let mut key3_found = false;
+        let _res = db.for_each::<u64, R, _>(|pair| {
+            let (key, val) = pair.unwrap();
+            if key == key1 {
+                key1_found = true;
+                assert_eq!(val, val1);
+            } else if key == key3 {
+                key3_found = true;
+                assert_eq!(val, val3);
+            }
+        });
+        assert!(key1_found);
+        assert!(key3_found);
+    }
+}

--- a/infrastructure/storage/src/key_val_store/mod.rs
+++ b/infrastructure/storage/src/key_val_store/mod.rs
@@ -21,8 +21,10 @@
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 pub mod error;
+pub mod hmap_database;
 pub mod key_val_store;
 pub mod lmdb_database;
 
 pub use error::KeyValStoreError;
+pub use hmap_database::HMapDatabase;
 pub use key_val_store::KeyValStore;


### PR DESCRIPTION
## Description
- Changed PeerStorage to use the new KeyValStore trait
- Changed tests in comms to use the HMapDatabase instead of LMDBDatabase

## Motivation and Context
The persistence storage of LMDBDatabase is not required during testing. Sometimes the Database files are not properly cleared between different test runs and could potentially result in some tests failing.

## How Has This Been Tested?
The behaviour seems to be the same as all current tests that made use of LMDBDatabase still produce the same results after HMapDatabase has been integrated

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch
* [x] I ran `cargo-fmt --all` before pushing
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
