### PR TITLE
Changed local_ip to pnet

### DIFF
--- a/applications/console_text_messenger/Cargo.toml
+++ b/applications/console_text_messenger/Cargo.toml
@@ -16,7 +16,6 @@ tari_crypto = { path = "../../infrastructure/crypto"}
 clap = "2.33.0"
 serde = "1.0.90"
 serde_derive = "1.0.90"
-local-ip = "0.1.0"
 chrono = { version = "0.4.6", features = ["serde"]}
 config = { version = "0.9.3" }
 simple_logger = "1.2.0"
@@ -24,3 +23,6 @@ log = { version = "0.4.0", features = ["std"] }
 crossbeam-channel = "0.3.8"
 log4rs = {version ="0.8.3",features = ["console_appender", "file_appender", "file", "yaml_format"]}
 ctrlc = "3.1.3"
+
+[dependencies.pnet]
+version = "0.22.0"

--- a/applications/console_text_messenger/Cargo.toml
+++ b/applications/console_text_messenger/Cargo.toml
@@ -23,6 +23,4 @@ log = { version = "0.4.0", features = ["std"] }
 crossbeam-channel = "0.3.8"
 log4rs = {version ="0.8.3",features = ["console_appender", "file_appender", "file", "yaml_format"]}
 ctrlc = "3.1.3"
-
-[dependencies.pnet]
-version = "0.22.0"
+pnet = "0.22.0"

--- a/applications/console_text_messenger/src/main.rs
+++ b/applications/console_text_messenger/src/main.rs
@@ -237,12 +237,7 @@ pub fn main() {
 
     // get network interface and retrieve ipv4 address
     let interface = interfaces.first().unwrap().clone();
-    let mut local_ip = String::new();
-    for addr in interface.ips {
-        if addr.is_ipv4() {
-            local_ip = addr.ip().to_string();
-        }
-    }
+    let local_ip = interface.ips.iter().find(|addr| addr.is_ipv4()).unwrap().ip().to_string();
 
     let local_net_address = match format!("{}:{}", local_ip, settings.control_port.unwrap()).parse() {
         Ok(na) => na,

--- a/applications/console_text_messenger/src/main.rs
+++ b/applications/console_text_messenger/src/main.rs
@@ -237,8 +237,15 @@ pub fn main() {
 
     // get network interface and retrieve ipv4 address
     let interface = interfaces.first().unwrap().clone();
-    let local_ip = interface.ips.iter().find(|addr| addr.is_ipv4()).unwrap().ip().to_string();
+    let local_ip = interface
+        .ips
+        .iter()
+        .find(|addr| addr.is_ipv4())
+        .unwrap()
+        .ip()
+        .to_string();
 
+    println!("{}", local_ip);
     let local_net_address = match format!("{}:{}", local_ip, settings.control_port.unwrap()).parse() {
         Ok(na) => na,
         Err(_) => {


### PR DESCRIPTION
## Description
libpnet was added to replace local-ip in the console_text_messenger application. 
See: [https://crates.io/crates/pnet/](https://crates.io/crates/pnet/)

The application now loops through available network interfaces, finds an available interface which is not a loopback interface and which also has an IPV4 address. If none is found the application is terminated.

## Motivation and Context
libpnet has support for both windows and unix, fixes a TODO in the code.

## How Has This Been Tested?
Multiple terminal windows were run with different configurations (N1,N2,..) to ensure the application still functions correctly as it did prior to the change.

## Types of changes
* [ ] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [x] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
* [x] I'm merging against the `development` branch
* [x] I ran `cargo-fmt --all` before pushing
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
