### PR TITLE
Remove RFC-315

### DIFF
--- a/RFC/src/RFC-0315_AssetTransfer.md
+++ b/RFC/src/RFC-0315_AssetTransfer.md
@@ -1,5 +1,0 @@
-# RFC-0315/AssetTransfer
-
-RFC placeholder.
-
-This document will describe the process for third-party asset transfer; i.e. Collections <-> Collections transfer

--- a/RFC/src/SUMMARY.md
+++ b/RFC/src/SUMMARY.md
@@ -27,7 +27,6 @@
     - [Asset Management](AssetManagement.md)
         - [RFC-0311: Digital Asset templates](RFC-0311_AssetTemplates.md)
         - [RFC-0313: The asset read-only API](RFC-0313_AssetReadAPI.md)
-        - [RFC-0315: Asset transfer mechanism](RFC-0315_AssetTransfer.md)
         - [RFC-0316: Asset retirement](RFC-0316_AssetRetirement.md)
     - [RFC-0340: Validator Node Consensus](RFC-0340_VNConsensusOverview.md)
         - [RFC-0342: Validator node instructions](RFC-0342_VNInstructions.md)


### PR DESCRIPTION

## Description
Transfers are a privilege, not a right ;)

There is no requirement that assets be transferable, therefore this shouldn't be
a generic RFC, but soemthing that is left to the individual templates to
implement.

Closes #90


