### PR TITLE
Implement Display for RistrettoPublicKey

### DIFF
--- a/infrastructure/crypto/src/ristretto/ristretto_keys.rs
+++ b/infrastructure/crypto/src/ristretto/ristretto_keys.rs
@@ -34,10 +34,11 @@ use digest::Digest;
 use rand::{CryptoRng, Rng};
 use std::{
     cmp::Ordering,
+    fmt,
     hash::{Hash, Hasher},
     ops::{Add, Mul, Sub},
 };
-use tari_utilities::{ByteArray, ByteArrayError, ExtendBytes, Hashable};
+use tari_utilities::{hex::Hex, ByteArray, ByteArrayError, ExtendBytes, Hashable};
 
 type HashDigest = Blake2b;
 
@@ -270,6 +271,14 @@ impl Default for RistrettoPublicKey {
     }
 }
 
+//------------------------------------ PublicKey Display impl ---------------------------------------------//
+
+impl fmt::Display for RistrettoPublicKey {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", self.to_hex())
+    }
+}
+
 //------------------------------------ PublicKey PartialEq, Eq, Ord impl ---------------------------------------------//
 
 impl PartialEq for RistrettoPublicKey {
@@ -416,7 +425,7 @@ mod test {
     use super::*;
     use crate::{keys::PublicKey, ristretto::test_common::get_keypair};
     use rand;
-    use tari_utilities::{hex::Hex, message_format::MessageFormat, ByteArray};
+    use tari_utilities::{message_format::MessageFormat, ByteArray};
 
     fn assert_completely_equal(k1: &RistrettoPublicKey, k2: &RistrettoPublicKey) {
         assert_eq!(k1, k2);
@@ -650,5 +659,12 @@ mod test {
         assert_eq!(k, k2);
         let pk2: RistrettoPublicKey = RistrettoPublicKey::from_binary(&ser_pk).unwrap();
         assert_completely_equal(&pk, &pk2);
+    }
+
+    #[test]
+    fn display() {
+        let hex = "e2f2ae0a6abc4e71a884a961c500515f58e30b6aa582dd8db6a65945e08d2d76";
+        let pk = RistrettoPublicKey::from_hex(hex).unwrap();
+        assert_eq!(format!("{}", pk), hex);
     }
 }


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Implement `fmt::Display` as a hex representation of a Ristretto public
key. This can be used to display the public key instead of the Debug
implementation and dramatically cuts down on log clutter.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Unit tested

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [x] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [x] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch
* [x] I ran `cargo-fmt --all` before pushing
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
