### PR TITLE
Remove Debug RistrettoPublicKey from log output

### DIFF
--- a/base_layer/p2p/src/ping_pong.rs
+++ b/base_layer/p2p/src/ping_pong.rs
@@ -162,19 +162,14 @@ impl PingPongService {
     }
 
     fn handle_api_message(&self, msg: PingPongApiRequest) -> Result<(), ServiceError> {
-        trace!(
-            target: LOG_TARGET,
-            "[{}] Received API message: {:?}",
-            self.get_name(),
-            msg
-        );
+        trace!(target: LOG_TARGET, "[{}] Received API message", self.get_name());
         let resp = match msg {
             PingPongApiRequest::Ping(pk) => self.ping(pk).map(|_| PingPongApiResponse::PingSent),
             PingPongApiRequest::GetPingCount => Ok(PingPongApiResponse::Count(self.ping_count)),
             PingPongApiRequest::GetPongCount => Ok(PingPongApiResponse::Count(self.pong_count)),
         };
 
-        trace!(target: LOG_TARGET, "[{}] Replying to API: {:?}", self.get_name(), resp);
+        trace!(target: LOG_TARGET, "[{}] Replying to API", self.get_name());
         self.api
             .send_reply(resp)
             .map_err(ServiceError::internal_service_error())

--- a/base_layer/wallet/src/text_message_service.rs
+++ b/base_layer/wallet/src/text_message_service.rs
@@ -239,11 +239,7 @@ impl TextMessageService {
         self.pending_messages
             .insert(text_message.id.clone(), text_message.clone());
 
-        trace!(
-            target: LOG_TARGET,
-            "Text Message Sent to {:?}",
-            text_message.dest_pub_key.to_hex()
-        );
+        trace!(target: LOG_TARGET, "Text Message Sent to {}", text_message.dest_pub_key);
 
         Ok(())
     }
@@ -259,9 +255,9 @@ impl TextMessageService {
         if let Some((info, msg)) = incoming_msg {
             trace!(
                 target: LOG_TARGET,
-                "Text Message received with ID: {:?} from {:?} with message: {:?}",
+                "Text Message received with ID: {:?} from {} with message: {:?}",
                 msg.id.clone(),
-                msg.source_pub_key.to_hex(),
+                msg.source_pub_key,
                 msg.message.clone()
             );
 
@@ -371,9 +367,9 @@ impl TextMessageService {
 
         trace!(
             target: LOG_TARGET,
-            "Contact Added: Screen name: {:?} - Pub-key: {:?} - Address: {:?}",
+            "Contact Added: Screen name: {:?} - Pub-key: {} - Address: {:?}",
             contact.screen_name.clone(),
-            contact.pub_key.clone().to_hex(),
+            contact.pub_key.clone(),
             contact.address.clone()
         );
         Ok(())
@@ -390,9 +386,9 @@ impl TextMessageService {
 
         trace!(
             target: LOG_TARGET,
-            "Contact Added: Screen name: {:?} - Pub-key: {:?} - Address: {:?}",
+            "Contact Added: Screen name: {:?} - Pub-key: {} - Address: {:?}",
             contact.screen_name.clone(),
-            contact.pub_key.clone().to_hex(),
+            contact.pub_key.clone(),
             contact.address.clone()
         );
 
@@ -414,9 +410,9 @@ impl TextMessageService {
 
         trace!(
             target: LOG_TARGET,
-            "Contact Added: Screen name: {:?} - Pub-key: {:?} - Address: {:?}",
+            "Contact Added: Screen name: {:?} - Pub-key: {} - Address: {:?}",
             found_contact.screen_name.clone(),
-            found_contact.pub_key.clone().to_hex(),
+            found_contact.pub_key.clone(),
             found_contact.address.clone()
         );
 
@@ -425,12 +421,7 @@ impl TextMessageService {
 
     /// This handler is called when the Service executor loops receives an API request
     fn handle_api_message(&mut self, msg: TextMessageApiRequest) -> Result<(), ServiceError> {
-        trace!(
-            target: LOG_TARGET,
-            "[{}] Received API message: {:?}",
-            self.get_name(),
-            msg
-        );
+        trace!(target: LOG_TARGET, "[{}] Received API message", self.get_name(),);
         let resp = match msg {
             TextMessageApiRequest::SendTextMessage((destination, message)) => self
                 .send_text_message(destination, message)
@@ -456,7 +447,7 @@ impl TextMessageService {
                 .map(|_| TextMessageApiResponse::ContactUpdated),
         };
 
-        trace!(target: LOG_TARGET, "[{}] Replying to API: {:?}", self.get_name(), resp);
+        trace!(target: LOG_TARGET, "[{}] Replying to API", self.get_name());
         self.api
             .send_reply(resp)
             .map_err(ServiceError::internal_service_error())


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
 Removed some large log debug output from RistrettoPublicKey in text
 message service and ping pong service

Depends on #516 
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Logs will be less cluttered 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
N/A

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [x] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch
* [x] I ran `cargo-fmt --all` before pushing
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
