### PR TITLE
Remove logging from tests

### DIFF
--- a/base_layer/p2p/tests/ping_pong/mod.rs
+++ b/base_layer/p2p/tests/ping_pong/mod.rs
@@ -97,7 +97,6 @@ fn setup_ping_pong_service(
 #[test]
 #[allow(non_snake_case)]
 fn end_to_end() {
-    let _ = simple_logger::init();
     let node_A_tmpdir = TempDir::new(random_string(8).as_str()).unwrap();
 
     let node_B_tmpdir = TempDir::new(random_string(8).as_str()).unwrap();

--- a/base_layer/wallet/tests/text_message_service/mod.rs
+++ b/base_layer/wallet/tests/text_message_service/mod.rs
@@ -51,8 +51,6 @@ fn clean_up_datastore(name: &str) {
 
 #[test]
 fn test_text_message_service() {
-    let _ = simple_logger::init();
-
     let mut rng = rand::OsRng::new().unwrap();
 
     let node_1_identity = NodeIdentity::random(&mut rng, "127.0.0.1:31523".parse().unwrap()).unwrap();

--- a/comms/src/inbound_message_service/inbound_message_service.rs
+++ b/comms/src/inbound_message_service/inbound_message_service.rs
@@ -178,17 +178,12 @@ mod test {
     use tari_storage::key_val_store::HMapDatabase;
     use tari_utilities::message_format::MessageFormat;
 
-    fn init() {
-        let _ = simple_logger::init();
-    }
-
     fn pause() {
         thread::sleep(Duration::from_millis(5));
     }
 
     #[test]
     fn test_message_queue() {
-        init();
         let context = ZmqContext::new();
         let node_identity = Arc::new(NodeIdentity::random_for_test(None));
 

--- a/comms/src/inbound_message_service/inbound_message_worker.rs
+++ b/comms/src/inbound_message_service/inbound_message_worker.rs
@@ -251,18 +251,12 @@ mod test {
     use tari_storage::key_val_store::HMapDatabase;
     use tari_utilities::{message_format::MessageFormat, thread_join::ThreadJoinWithTimeout};
 
-    fn init() {
-        let _ = simple_logger::init();
-    }
-
     fn pause() {
         thread::sleep(Duration::from_millis(5));
     }
 
     #[test]
     fn test_dispatch_to_multiple_service_handlers() {
-        init();
-
         let context = ZmqContext::new();
         let node_identity = Arc::new(NodeIdentity::random_for_test(None));
 

--- a/comms/src/outbound_message_service/outbound_message_service.rs
+++ b/comms/src/outbound_message_service/outbound_message_service.rs
@@ -148,13 +148,8 @@ mod test {
     use tari_crypto::{keys::PublicKey, ristretto::RistrettoPublicKey};
     use tari_storage::key_val_store::HMapDatabase;
 
-    pub fn init() {
-        let _ = simple_logger::init();
-    }
-
     #[test]
     fn test_outbound_send() {
-        init();
         let context = ZmqContext::new();
         let mut rng = rand::OsRng::new().unwrap();
         let outbound_address = InprocAddress::random();

--- a/comms/tests/connection_manager/manager.rs
+++ b/comms/tests/connection_manager/manager.rs
@@ -86,7 +86,6 @@ fn pause() {
 #[test]
 #[allow(non_snake_case)]
 fn establish_peer_connection() {
-    let _ = simple_logger::init();
     let context = ZmqContext::new();
 
     let node_A_identity = Arc::new(factories::node_identity::create().build().unwrap());

--- a/comms/tests/outbound_message_service/outbound_message_pool.rs
+++ b/comms/tests/outbound_message_service/outbound_message_pool.rs
@@ -64,10 +64,6 @@ fn make_peer_manager(peers: Vec<Peer>, database: CommsDatabase) -> Arc<PeerManag
     )
 }
 
-pub fn init_logging() {
-    let _ = simple_logger::init();
-}
-
 fn get_path(name: &str) -> String {
     let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     path.push("tests/data");
@@ -95,7 +91,6 @@ fn clean_up_datastore(name: &str) {
 #[test]
 #[allow(non_snake_case)]
 fn outbound_message_pool_no_retry() {
-    init_logging();
     let context = ZmqContext::new();
     let node_identity = Arc::new(factories::node_identity::create().build().unwrap());
 
@@ -223,7 +218,6 @@ fn outbound_message_pool_no_retry() {
 #[test]
 #[allow(non_snake_case)]
 fn test_outbound_message_pool_fail_and_retry() {
-    init_logging();
     let context = ZmqContext::new();
 
     let node_A_identity = factories::node_identity::create().build().map(Arc::new).unwrap();

--- a/infrastructure/storage/tests/lmdb.rs
+++ b/infrastructure/storage/tests/lmdb.rs
@@ -130,7 +130,6 @@ fn single_thread() {
 
 #[test]
 fn multi_thread() {
-    let _ = simple_logger::init();
     let users_arc = Arc::new(load_users());
     let env = init("multi_thread").unwrap();
     let mut threads = Vec::new();


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
The logs in CI are exceeding circle ci's maximum number of log lines
and are cluttering test output. When debugging, you can add
`simple_logger::init()` to the test you are debugging. This will
also emit a warning which would remind you to remove it afterwards.

In future, we may want logs in CI tests to write to a file and which can be
later inspected as an [artifact](https://circleci.com/docs/2.0/artifacts/).


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Makes test output nice and clean

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
N/A

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [x] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch
* [x] I ran `cargo-fmt --all` before pushing
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
