### PR TITLE
Set 0 linger on peer connection when dropped 

### DIFF
--- a/comms/src/connection/connection.rs
+++ b/comms/src/connection/connection.rs
@@ -451,6 +451,10 @@ impl EstablishedConnection {
     pub(crate) fn get_socket_mut(&mut self) -> &mut zmq::Socket {
         &mut self.socket
     }
+
+    pub fn direction(&self) -> &Direction {
+        &self.direction
+    }
 }
 
 impl Drop for EstablishedConnection {

--- a/comms/src/connection/peer_connection/control.rs
+++ b/comms/src/connection/peer_connection/control.rs
@@ -87,7 +87,7 @@ impl From<SyncSender<ControlMessage>> for ThreadControlMessenger {
 impl Drop for ThreadControlMessenger {
     /// Send a ControlMessage::Shutdown on drop.
     fn drop(&mut self) {
-        debug!(target: LOG_TARGET, "ThreadControlMessager dropped");
+        debug!(target: LOG_TARGET, "ThreadControlMessenger dropped");
         // We assume here that the thread responds to the shutdown request.
         let _ = self.0.try_send(ControlMessage::Shutdown);
     }

--- a/comms/tests/connection/peer_connection.rs
+++ b/comms/tests/connection/peer_connection.rs
@@ -364,7 +364,7 @@ fn connection_stats() {
             stats.messages_recv()
         },
         4,
-        20,
+        40,
     );
 
     assert_change(
@@ -377,5 +377,5 @@ fn connection_stats() {
     );
 
     let stats = conn.connection_stats();
-    assert_ne!(stats.last_activity(), initial_stats.last_activity());
+    assert!(stats.last_activity() > initial_stats.last_activity());
 }


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
0MQ suggest that a low or zero linger is set before disconnecting.
+ Minor improvements to peer connection logs.


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
http://api.zeromq.org/2-1:zmq-setsockopt#toc15

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Existing tests pass

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch
* [x] I ran `cargo-fmt --all` before pushing
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
