### PR TITLE
Increase join timeouts (flakiness)

### DIFF
--- a/comms/src/connection/peer_connection/control.rs
+++ b/comms/src/connection/peer_connection/control.rs
@@ -117,7 +117,7 @@ mod test {
         messenger.send(ControlMessage::Shutdown).unwrap();
 
         handle
-            .timeout_join(Duration::from_millis(100))
+            .timeout_join(Duration::from_millis(3000))
             .map_err(|e| format!("Test thread errored: {:?}", e))
             .unwrap();
     }

--- a/comms/src/inbound_message_service/inbound_message_worker.rs
+++ b/comms/src/inbound_message_service/inbound_message_worker.rs
@@ -395,7 +395,7 @@ mod test {
         // Test worker clean shutdown
         control_sync_sender.send(ControlMessage::Shutdown).unwrap();
         std::thread::sleep(time::Duration::from_millis(200));
-        thread_handle.timeout_join(Duration::from_millis(100)).unwrap();
+        thread_handle.timeout_join(Duration::from_millis(3000)).unwrap();
         assert!(client_connection.send(message1_frame_set).is_err());
     }
 }

--- a/comms/src/outbound_message_service/outbound_message_pool/outbound_message_worker.rs
+++ b/comms/src/outbound_message_service/outbound_message_pool/outbound_message_worker.rs
@@ -279,7 +279,7 @@ mod test {
         .unwrap();
 
         signal.send(()).unwrap();
-        handle.timeout_join(Duration::from_millis(100)).unwrap();
+        handle.timeout_join(Duration::from_millis(3000)).unwrap();
     }
 
     #[test]

--- a/comms/tests/outbound_message_service/outbound_message_pool.rs
+++ b/comms/tests/outbound_message_service/outbound_message_pool.rs
@@ -203,7 +203,7 @@ fn outbound_message_pool_no_retry() {
     node_B_control_service.shutdown().unwrap();
     node_B_control_service
         .handle
-        .timeout_join(Duration::from_millis(100))
+        .timeout_join(Duration::from_millis(3000))
         .unwrap();
 
     omp.shutdown().unwrap();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Join timeouts are set too low and cause TimeoutReached errors on
CircleCI. 3000ms chosen to give more than ample time.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Ref #441 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Existing tests pass

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch
* [x] I ran `cargo-fmt --all` before pushing
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
