### PR TITLE
Peer exclusions on closest peers and Peer Updating

### DIFF
--- a/comms/src/outbound_message_service/broadcast_strategy.rs
+++ b/comms/src/outbound_message_service/broadcast_strategy.rs
@@ -26,6 +26,7 @@ use crate::{peer_manager::node_id::NodeId, types::CommsPublicKey};
 pub struct ClosestRequest {
     pub n: usize,
     pub node_id: NodeId,
+    pub excluded_peers: Vec<CommsPublicKey>,
 }
 
 #[derive(Debug)]

--- a/comms/src/outbound_message_service/mod.rs
+++ b/comms/src/outbound_message_service/mod.rs
@@ -62,7 +62,7 @@ pub mod outbound_message_pool;
 pub mod outbound_message_service;
 
 pub use self::{
-    broadcast_strategy::BroadcastStrategy,
+    broadcast_strategy::{BroadcastStrategy, ClosestRequest},
     error::OutboundError,
     outbound_message_pool::{OutboundMessage, OutboundMessagePool},
 };

--- a/comms/src/peer_manager/error.rs
+++ b/comms/src/peer_manager/error.rs
@@ -45,8 +45,6 @@ pub enum PeerManagerError {
     EmptyDatastoreQuery,
     // A NetAddressError occurred
     NetAddressError(NetAddressError),
-    /// The PeerManager doesn't have enough peers to fill the identity request
-    InsufficientPeers,
     /// The peer has been banned
     BannedPeer,
     /// Problem initializing the RNG

--- a/comms/src/peer_manager/peer_storage.rs
+++ b/comms/src/peer_manager/peer_storage.rs
@@ -25,14 +25,14 @@ use crate::{
     peer_manager::{
         node_id::{NodeDistance, NodeId},
         node_identity::PeerNodeIdentity,
-        peer::Peer,
+        peer::{Peer, PeerFlags},
         peer_key::{generate_peer_key, PeerKey},
         PeerManagerError,
     },
     types::{CommsPublicKey, CommsRng},
 };
 use rand::Rng;
-use std::{collections::HashMap, time::Duration};
+use std::{cmp::min, collections::HashMap, time::Duration};
 use tari_storage::key_val_store::KeyValStore;
 
 /// PeerStorage provides a mechanism to keep a datastore and a local copy of all peers in sync and allow fast searches
@@ -97,6 +97,38 @@ where DS: KeyValStore
                     .map_err(|e| PeerManagerError::DatabaseError(e))?;
                 Ok(())
             },
+        }
+    }
+
+    /// Adds a peer to the routing table of the PeerManager if the peer does not already exist. When a peer already
+    /// exist, the stored version will be replaced with the newly provided peer.
+    pub fn update_peer(
+        &mut self,
+        public_key: &CommsPublicKey,
+        node_id: Option<NodeId>,
+        net_addresses: Option<Vec<NetAddress>>,
+        flags: Option<PeerFlags>,
+    ) -> Result<(), PeerManagerError>
+    {
+        match self.public_key_hm.get(public_key) {
+            Some(peer_key) => {
+                let peer_key = *peer_key;
+                self.remove_hashmap_links(peer_key)?;
+
+                let mut stored_peer: Peer = self
+                    .peers
+                    .get_value(&peer_key)
+                    .map_err(|e| PeerManagerError::DatabaseError(e))?
+                    .ok_or(PeerManagerError::PeerNotFoundError)?;
+                stored_peer.update(node_id, net_addresses, flags);
+
+                self.add_hashmap_links(peer_key, &stored_peer);
+                self.peers
+                    .insert_pair(&peer_key, &stored_peer)
+                    .map_err(|e| PeerManagerError::DatabaseError(e))?;
+                Ok(())
+            },
+            None => Err(PeerManagerError::PeerNotFoundError),
         }
     }
 
@@ -174,6 +206,11 @@ where DS: KeyValStore
             .ok_or(PeerManagerError::PeerNotFoundError)
     }
 
+    /// Check if a peer exist using the specified public_key
+    pub fn exists(&self, public_key: &CommsPublicKey) -> bool {
+        self.public_key_hm.get(&public_key).is_some()
+    }
+
     /// Constructs a single NodeIdentity for the peer corresponding to the provided NodeId
     pub fn direct_identity_node_id(&self, node_id: &NodeId) -> Result<Vec<PeerNodeIdentity>, PeerManagerError> {
         let peer_key = *self
@@ -230,39 +267,47 @@ where DS: KeyValStore
     }
 
     /// Compile a list of node identities that can be used for the closest BroadcastStrategy
-    pub fn closest_identities(&self, node_id: NodeId, n: usize) -> Result<Vec<PeerNodeIdentity>, PeerManagerError> {
+    pub fn closest_identities(
+        &self,
+        node_id: &NodeId,
+        n: usize,
+        excluded_peers: &Vec<CommsPublicKey>,
+    ) -> Result<Vec<PeerNodeIdentity>, PeerManagerError>
+    {
         let mut peer_keys: Vec<PeerKey> = Vec::new();
         let mut dists: Vec<NodeDistance> = Vec::new();
         self.peers
             .for_each::<PeerKey, Peer, _>(|pair| {
                 let (peer_key, peer) = pair.unwrap();
-                if !peer.is_banned() {
+                if !peer.is_banned() && !excluded_peers.contains(&peer.public_key) {
                     peer_keys.push(peer_key.clone());
                     dists.push(node_id.distance(&peer.node_id));
                 }
             })
             .map_err(|e| PeerManagerError::DatabaseError(e))?;
-
-        if n > peer_keys.len() {
-            return Err(PeerManagerError::InsufficientPeers);
-        }
-        // Perform partial sort of elements only up to N elements
-        let mut nearest_identities: Vec<PeerNodeIdentity> = Vec::with_capacity(n);
-        for i in 0..n {
-            for j in (i + 1)..peer_keys.len() {
-                if dists[i] > dists[j] {
-                    dists.swap(i, j);
-                    peer_keys.swap(i, j);
+        // Use all available peers up to a maximum of N
+        let max_available = if n > peer_keys.len() { peer_keys.len() } else { n };
+        if max_available > 0 {
+            // Perform partial sort of elements only up to N elements
+            let mut nearest_identities: Vec<PeerNodeIdentity> = Vec::with_capacity(max_available);
+            for i in 0..max_available {
+                for j in (i + 1)..peer_keys.len() {
+                    if dists[i] > dists[j] {
+                        dists.swap(i, j);
+                        peer_keys.swap(i, j);
+                    }
                 }
+                let peer: Peer = self
+                    .peers
+                    .get_value(&peer_keys[i])
+                    .map_err(|e| PeerManagerError::DatabaseError(e))?
+                    .ok_or(PeerManagerError::PeerNotFoundError)?;
+                nearest_identities.push(PeerNodeIdentity::new(peer.node_id.clone(), peer.public_key.clone()));
             }
-            let peer: Peer = self
-                .peers
-                .get_value(&peer_keys[i])
-                .map_err(|e| PeerManagerError::DatabaseError(e))?
-                .ok_or(PeerManagerError::PeerNotFoundError)?;
-            nearest_identities.push(PeerNodeIdentity::new(peer.node_id.clone(), peer.public_key.clone()));
+            Ok(nearest_identities)
+        } else {
+            Ok(Vec::new())
         }
-        Ok(nearest_identities)
     }
 
     /// Compile a list of node identities that can be used for the random BroadcastStrategy
@@ -278,25 +323,28 @@ where DS: KeyValStore
             })
             .map_err(|e| PeerManagerError::DatabaseError(e))?;
 
-        if n > peer_keys.len() {
-            return Err(PeerManagerError::InsufficientPeers);
+        // Use all available peers up to a maximum of N
+        let max_available = min(peer_keys.len(), n);
+        if max_available > 0 {
+            // Shuffle first n elements
+            for i in 0..max_available {
+                let j = self.rng.gen_range(0, peer_keys.len());
+                peer_keys.swap(i, j);
+            }
+            // Compile list of first n shuffled elements
+            let mut random_identities: Vec<PeerNodeIdentity> = Vec::with_capacity(max_available);
+            for i in 0..max_available {
+                let peer: Peer = self
+                    .peers
+                    .get_value(&peer_keys[i])
+                    .map_err(|e| PeerManagerError::DatabaseError(e))?
+                    .ok_or(PeerManagerError::PeerNotFoundError)?;
+                random_identities.push(PeerNodeIdentity::new(peer.node_id.clone(), peer.public_key.clone()));
+            }
+            Ok(random_identities)
+        } else {
+            Ok(Vec::new())
         }
-        // Shuffle first n elements
-        for i in 0..n {
-            let j = self.rng.gen_range(0, peer_keys.len());
-            peer_keys.swap(i, j);
-        }
-        // Compile list of first n shuffled elements
-        let mut random_identities: Vec<PeerNodeIdentity> = Vec::with_capacity(n);
-        for i in 0..n {
-            let peer: Peer = self
-                .peers
-                .get_value(&peer_keys[i])
-                .map_err(|e| PeerManagerError::DatabaseError(e))?
-                .ok_or(PeerManagerError::PeerNotFoundError)?;
-            random_identities.push(PeerNodeIdentity::new(peer.node_id.clone(), peer.public_key.clone()));
-        }
-        Ok(random_identities)
     }
 
     /// Enables Thread safe access - Changes the ban flag bit of the peer
@@ -327,9 +375,7 @@ where DS: KeyValStore
             .get_value(&peer_key)
             .map_err(|e| PeerManagerError::DatabaseError(e))?
             .ok_or(PeerManagerError::PeerNotFoundError)?;
-        peer.addresses
-            .add_net_address(net_address)
-            .map_err(PeerManagerError::NetAddressError)?;
+        peer.addresses.add_net_address(net_address);
         self.net_address_hm.insert(net_address.clone(), peer_key);
         self.peers
             .insert_pair(&peer_key, &peer)
@@ -529,8 +575,8 @@ mod test {
         let net_address2 = NetAddress::from("5.6.7.8:8000".parse::<NetAddress>().unwrap());
         let net_address3 = NetAddress::from("5.6.7.8:7000".parse::<NetAddress>().unwrap());
         let mut net_addresses = NetAddressesWithStats::from(net_address1.clone());
-        net_addresses.add_net_address(&net_address2).unwrap();
-        net_addresses.add_net_address(&net_address3).unwrap();
+        net_addresses.add_net_address(&net_address2);
+        net_addresses.add_net_address(&net_address3);
         let peer1 = Peer::new(pk, node_id, net_addresses, PeerFlags::default());
 
         let (_sk, pk) = RistrettoPublicKey::random_keypair(&mut rng);
@@ -544,7 +590,7 @@ mod test {
         let net_address5 = NetAddress::from("13.14.15.16:6000".parse::<NetAddress>().unwrap());
         let net_address6 = NetAddress::from("17.18.19.20:8000".parse::<NetAddress>().unwrap());
         let mut net_addresses = NetAddressesWithStats::from(net_address5.clone());
-        net_addresses.add_net_address(&net_address6).unwrap();
+        net_addresses.add_net_address(&net_address6);
         let peer3 = Peer::new(pk, node_id, net_addresses, PeerFlags::default());
 
         // Create new datastore with a peer database
@@ -589,8 +635,8 @@ mod test {
         let net_address2 = NetAddress::from("5.6.7.8:8000".parse::<NetAddress>().unwrap());
         let net_address3 = NetAddress::from("5.6.7.8:7000".parse::<NetAddress>().unwrap());
         let mut net_addresses = NetAddressesWithStats::from(net_address1.clone());
-        net_addresses.add_net_address(&net_address2).unwrap();
-        net_addresses.add_net_address(&net_address3).unwrap();
+        net_addresses.add_net_address(&net_address2);
+        net_addresses.add_net_address(&net_address3);
         let peer1 = Peer::new(pk, node_id, net_addresses, PeerFlags::default());
 
         let (_sk, pk) = RistrettoPublicKey::random_keypair(&mut rng);
@@ -604,7 +650,7 @@ mod test {
         let net_address5 = NetAddress::from("13.14.15.16:6000".parse::<NetAddress>().unwrap());
         let net_address6 = NetAddress::from("17.18.19.20:8000".parse::<NetAddress>().unwrap());
         let mut net_addresses = NetAddressesWithStats::from(net_address5.clone());
-        net_addresses.add_net_address(&net_address6).unwrap();
+        net_addresses.add_net_address(&net_address6);
         let peer3 = Peer::new(pk, node_id, net_addresses, PeerFlags::default());
         // Test adding and searching for peers
         assert!(peer_storage.add_peer(peer1.clone()).is_ok());


### PR DESCRIPTION
## Description
- Modified Closest Broadcast strategy to have peer exclusions.
- Changed Closest and Random peer functions to return all available peers up to the requested number, without throwing an insufficient peers errors.
- Added Test for new functionality.
- Added ability to update the NetAddresses without discarding usage stats.
- Added ability to update a peers NodeID, Flags and NetAddresses.
- Added exists method to check if peer exists in the PeerManager.

## Motivation and Context
These changes are need for sending and receiving DHT join requests

## How Has This Been Tested?
New tests have been added

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [x] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [x] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch
* [x] I ran `cargo-fmt --all` before pushing
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
