### PR TITLE
Fixed test for ZMQ V4.3.2+

### DIFF
--- a/comms/tests/connection/monitor.rs
+++ b/comms/tests/connection/monitor.rs
@@ -66,17 +66,15 @@ fn recv_socket_events() {
     let event = events.iter().find(|e| e.event_type == SocketEventType::Listening);
     assert!(event.is_some(), "Expected to find event Listening");
     let event = event.unwrap();
-    // Note! The monitor returns events with the original address given to the socket (127.0.0.2:0, and not the
-    // actual address that is connected to (if it is different)
-    assert_eq!(event.address, address.to_zmq_endpoint());
+    assert_eq!(event.address, connected_address.to_zmq_endpoint());
 
     let event = events.iter().find(|e| e.event_type == SocketEventType::Accepted);
     assert!(event.is_some(), "Expected to find event Accepted");
     let event = event.unwrap();
-    assert_eq!(event.address, address.to_zmq_endpoint());
+    assert_eq!(event.address, connected_address.to_zmq_endpoint());
 
     let event = events.iter().find(|e| e.event_type == SocketEventType::Disconnected);
     assert!(event.is_some(), "Expected to find event Disconnected");
     let event = event.unwrap();
-    assert_eq!(event.address, address.to_zmq_endpoint());
+    assert_eq!(event.address, connected_address.to_zmq_endpoint());
 }


### PR DESCRIPTION
Fixes problem with the test for ZMQ V4.3.2+.

## Description
Fixes problem with the test for ZMQ V4.3.2+. Requires ZMQ V4.3.2+

## Motivation and Context
Fixes problem with the test for ZMQ V4.3.2+.

## How Has This Been Tested?
cargo test --all

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [x] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch
* [x] I ran `cargo-fmt --all` before pushing
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
