### PR TITLE
Added PeerConnection level protocol messages

### DIFF
--- a/comms/src/connection/peer_connection/connection.rs
+++ b/comms/src/connection/peer_connection/connection.rs
@@ -45,6 +45,27 @@ use std::{
 };
 use tari_utilities::hex::to_hex;
 
+/// Represents messages that must be sent to a PeerConnection.
+pub enum PeerConnectionProtoMessage {
+    /// Sent to establish the identity frame for a PeerConnection. This must be sent by an
+    /// Outbound connection to an Inbound connection before any other communication occurs.
+    Identify = 0,
+    /// A peer message to be forwarded to the message sink (the IMS)
+    Message = 1,
+    /// Any other message is invalid and is discarded
+    Invalid,
+}
+
+impl From<u8> for PeerConnectionProtoMessage {
+    fn from(val: u8) -> Self {
+        match val {
+            0 => PeerConnectionProtoMessage::Identify,
+            1 => PeerConnectionProtoMessage::Message,
+            _ => PeerConnectionProtoMessage::Invalid,
+        }
+    }
+}
+
 /// Represents the ID of a PeerConnection. This is sent as the first frame
 /// to the message sink on the peer connection.
 #[derive(Debug, Clone, Eq, PartialEq)]

--- a/comms/src/connection/peer_connection/mod.rs
+++ b/comms/src/connection/peer_connection/mod.rs
@@ -88,7 +88,7 @@ mod error;
 mod worker;
 
 pub use self::{
-    connection::{ConnectionId, PeerConnection, PeerConnectionSimpleState},
+    connection::{ConnectionId, PeerConnection, PeerConnectionProtoMessage, PeerConnectionSimpleState},
     context::{PeerConnectionContext, PeerConnectionContextBuilder},
     control::ControlMessage,
     error::PeerConnectionError,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Added some basic PeerConnection protocol messages implemented as a
frame containing a single `u8`:

- `Identify` (`0u8`): The outbound connection is identifying itself (as in ZMQ identity) to the
inbound connection. This message MUST be sent by an outbound connection
before any others (this now happens automatically inside an outbound PeerConnection).
- `Message` (`1u8`): The peer is sending a domain message, which should be
forwarded downstream to the IMS.
- `Invalid`: Every other value is treated as invalid and ignored (in
future, this could effect ban heuristics)


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Currently, the control service has to send a (pretty useless) domain-level message to the remote peer before both sides of the peer connection can say they are connected. This change will move that message to the peer connection protocol-level. A PR which changes the protocol for the control service is simplified by this change (as in, generics removed, not sending a silly message for seemingly no reason). This also allows for any future peer connection level protocol messages.
Ref #445 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
New integration test, and changes to existing peer connection tests (change is transparent to other components/tests)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [x] Breaking change (fix or feature that would cause existing functionality to change)
* [x] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [x] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch
* [x] I ran `cargo-fmt --all` before pushing
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
