### PR TITLE
Discard duplicate inbound messages

### DIFF
--- a/comms/Cargo.toml
+++ b/comms/Cargo.toml
@@ -22,6 +22,7 @@ zmq = "0.9.1"
 digest = "0.8.0"
 time = "0.1.42"
 lmdb-zero = "0.4.4"
+ttl_cache = "0.5.1"
 
 tari_crypto = { version="^0.0",  path = "../infrastructure/crypto"}
 tari_utilities = { version="^0.0",  path = "../infrastructure/tari_util"}

--- a/comms/src/consts.rs
+++ b/comms/src/consts.rs
@@ -20,29 +20,9 @@
 //  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 //  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use crate::{
-    connection::{error::ConnectionError, DealerProxyError},
-    inbound_message_service::{inbound_message_broker::BrokerError, message_cache::MessageCacheError},
-};
-use derive_error::Error;
-use tari_utilities::thread_join::ThreadError;
+use std::time::Duration;
 
-/// Error type for InboundMessageService subsystem
-#[derive(Debug, Error)]
-pub enum InboundError {
-    /// Failed to connect to inbound socket
-    InboundConnectionError(ConnectionError),
-    DealerProxyError(DealerProxyError),
-    BrokerError(BrokerError),
-    MessageCacheError(MessageCacheError),
-    #[error(msg_embedded, non_std, no_from)]
-    ControlSendError(String),
-    /// Unable to send a control message as the control sync sender is undefined
-    ControlSenderUndefined,
-    /// Could not join the InboundMessageWorker thread
-    ThreadJoinError(ThreadError),
-    /// The thread handle is undefined and could have not been properly created
-    ThreadHandleUndefined,
-    /// Inbound message worker thread failed to start
-    ThreadInitializationError,
-}
+/// The maximum number of messages that can be stored using the MessageCache of the DHT
+pub const DHT_MSG_CACHE_STORAGE_CAPACITY: usize = 1000;
+/// The time-to-live duration used by the MessageCache for tracking received and handled messages
+pub const DHT_MSG_CACHE_TTL: Duration = Duration::from_secs(300);

--- a/comms/src/inbound_message_service/inbound_message_worker.rs
+++ b/comms/src/inbound_message_service/inbound_message_worker.rs
@@ -34,8 +34,10 @@ use crate::{
     inbound_message_service::{
         inbound_message_broker::InboundMessageBroker,
         inbound_message_service::InboundMessageServiceConfig,
+        MessageCache,
+        MessageCacheConfig,
     },
-    message::{FrameSet, MessageContext, MessageData},
+    message::{Frame, FrameSet, MessageContext, MessageData},
     outbound_message_service::outbound_message_service::OutboundMessageService,
     peer_manager::{peer_manager::PeerManager, NodeId, NodeIdentity, Peer},
     types::MessageDispatcher,
@@ -71,6 +73,7 @@ where
     inbound_message_broker: Arc<InboundMessageBroker<MType>>,
     outbound_message_service: Arc<OutboundMessageService>,
     peer_manager: Arc<PeerManager>,
+    msg_cache: MessageCache<Frame>,
     control_receiver: Option<Receiver<ControlMessage>>,
     is_running: bool,
 }
@@ -102,6 +105,7 @@ where
             inbound_message_broker,
             outbound_message_service,
             peer_manager,
+            msg_cache: MessageCache::new(MessageCacheConfig::default()),
             control_receiver: None,
             is_running: false,
         }
@@ -132,33 +136,40 @@ where
 
                         match MessageData::try_from(frame_set) {
                             Ok(message_data) => {
-                                let peer = match self.lookup_peer(&message_data.source_node_id) {
-                                    Some(peer) => peer,
-                                    None => {
+                                if !self.msg_cache.contains(message_data.message_envelope.body_frame()) {
+                                    self.msg_cache
+                                        .insert(message_data.message_envelope.body_frame().clone())?;
+
+                                    let peer = match self.lookup_peer(&message_data.source_node_id) {
+                                        Some(peer) => peer,
+                                        None => {
+                                            warn!(
+                                                target: LOG_TARGET,
+                                                "Received unknown node id from peer connection. Discarding message \
+                                                 from NodeId={:?}",
+                                                message_data.source_node_id
+                                            );
+                                            continue;
+                                        },
+                                    };
+
+                                    let message_context = MessageContext::new(
+                                        self.node_identity.clone(),
+                                        peer,
+                                        message_data.message_envelope,
+                                        self.outbound_message_service.clone(),
+                                        self.peer_manager.clone(),
+                                        self.inbound_message_broker.clone(),
+                                    );
+                                    self.message_dispatcher.dispatch(message_context).unwrap_or_else(|e| {
                                         warn!(
                                             target: LOG_TARGET,
-                                            "Received unknown node id from peer connection. Discarding message from \
-                                             NodeId={:?}",
-                                            message_data.source_node_id
+                                            "Could not dispatch message to handler - Error: {:?}", e
                                         );
-                                        continue;
-                                    },
-                                };
-
-                                let message_context = MessageContext::new(
-                                    self.node_identity.clone(),
-                                    peer,
-                                    message_data.message_envelope,
-                                    self.outbound_message_service.clone(),
-                                    self.peer_manager.clone(),
-                                    self.inbound_message_broker.clone(),
-                                );
-                                self.message_dispatcher.dispatch(message_context).unwrap_or_else(|e| {
-                                    warn!(
-                                        target: LOG_TARGET,
-                                        "Could not dispatch message to handler - Error: {:?}", e
-                                    );
-                                });
+                                    });
+                                } else {
+                                    debug!(target: LOG_TARGET, "Duplicate message discarded");
+                                }
                             },
                             Err(e) => {
                                 // if unable to deserialize the MessageHeader then MUST discard the
@@ -371,6 +382,8 @@ mod test {
         // Submit Messages to the Worker
         pause();
         client_connection.send(message1_frame_set.clone()).unwrap();
+        client_connection.send(message2_frame_set.clone()).unwrap();
+        // Send duplicate message
         client_connection.send(message2_frame_set).unwrap();
 
         // Retrieve messages at handler services
@@ -385,6 +398,8 @@ mod test {
         let received_domain_message_context =
             DomainMessageContext::from_binary(&received_message_data_bytes[0]).unwrap();
         assert_eq!(received_domain_message_context.message, message_envelope_body2);
+        // Ensure duplicate message never reach handler service
+        assert!(handler2_queue_connection.receive(100).is_err());
 
         // Test worker clean shutdown
         control_sync_sender.send(ControlMessage::Shutdown).unwrap();

--- a/comms/src/inbound_message_service/message_cache.rs
+++ b/comms/src/inbound_message_service/message_cache.rs
@@ -1,0 +1,129 @@
+//  Copyright 2019 The Tari Project
+//
+//  Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+//  following conditions are met:
+//
+//  1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+//  disclaimer.
+//
+//  2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+//  following disclaimer in the documentation and/or other materials provided with the distribution.
+//
+//  3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+//  products derived from this software without specific prior written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+//  INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+//  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+//  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+//  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+//  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+//  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+use crate::consts::{DHT_MSG_CACHE_STORAGE_CAPACITY, DHT_MSG_CACHE_TTL};
+use derive_error::Error;
+use std::{hash::Hash, time::Duration};
+use ttl_cache::TtlCache;
+
+#[derive(Debug, Error)]
+pub enum MessageCacheError {
+    /// A duplicate entry existed in the message cache
+    DuplicateEntry,
+}
+
+#[derive(Clone, Copy)]
+pub struct MessageCacheConfig {
+    /// The maximum number of messages that can be tracked using the MessageCache
+    storage_capacity: usize,
+    /// The Time-to-live for each stored message
+    msg_ttl: Duration,
+}
+
+impl Default for MessageCacheConfig {
+    fn default() -> Self {
+        MessageCacheConfig {
+            storage_capacity: DHT_MSG_CACHE_STORAGE_CAPACITY,
+            msg_ttl: DHT_MSG_CACHE_TTL,
+        }
+    }
+}
+
+/// The MessageCache is used to track handled messages to ensure that processing resources are not wasted on
+/// duplicate messages and that these duplicate messages are not sent to services or propagate through the network.
+pub struct MessageCache<K: Eq + Hash> {
+    config: MessageCacheConfig,
+    cache: TtlCache<K, ()>,
+}
+
+impl<K> MessageCache<K>
+where K: Eq + Hash
+{
+    /// Create a new MessageCache with the specified configuration
+    pub fn new(config: MessageCacheConfig) -> Self {
+        Self {
+            config,
+            cache: TtlCache::new(config.storage_capacity),
+        }
+    }
+
+    /// Insert a new message into the MessageCache with a time-to-live starting at the insertion time. It will
+    /// return a DuplicateEntry Error if the message has already been added into the cache.
+    pub fn insert(&mut self, msg: K) -> Result<(), MessageCacheError> {
+        match self.cache.insert(msg, (), self.config.msg_ttl) {
+            Some(_) => Err(MessageCacheError::DuplicateEntry),
+            None => Ok(()),
+        }
+    }
+
+    /// Check if the message is available in the MessageCache
+    pub fn contains(&self, msg: &K) -> bool {
+        self.cache.contains_key(msg)
+    }
+}
+#[cfg(test)]
+mod test {
+    use super::*;
+    use std::{thread, time::Duration};
+
+    #[test]
+    fn test_msg_rlu_and_ttl() {
+        let mut msg_cache: MessageCache<String> = MessageCache::new(MessageCacheConfig {
+            storage_capacity: 3,
+            msg_ttl: Duration::from_millis(100),
+        });
+        let msg1 = "msg1".to_string();
+        let msg2 = "msg2".to_string();
+        let msg3 = "msg3".to_string();
+        let msg4 = "msg4".to_string();
+
+        msg_cache.insert(msg1.clone()).unwrap();
+        assert!(msg_cache.contains(&msg1));
+        assert!(!msg_cache.contains(&msg2));
+
+        msg_cache.insert(msg2.clone()).unwrap();
+        assert!(msg_cache.contains(&msg1));
+        assert!(msg_cache.contains(&msg2));
+        assert!(!msg_cache.contains(&msg3));
+
+        msg_cache.insert(msg3.clone()).unwrap();
+        assert!(msg_cache.contains(&msg1));
+        assert!(msg_cache.contains(&msg2));
+        assert!(msg_cache.contains(&msg3));
+        assert!(!msg_cache.contains(&msg4));
+
+        thread::sleep(Duration::from_millis(50));
+        msg_cache.insert(msg4.clone()).unwrap();
+
+        // Due to storage limits, msg1 was removed when msg4 was added
+        assert!(!msg_cache.contains(&msg1));
+        assert!(msg_cache.contains(&msg2));
+        assert!(msg_cache.contains(&msg3));
+        assert!(msg_cache.contains(&msg4));
+
+        // msg2 and msg3 would have reached their ttl thresholds
+        thread::sleep(Duration::from_millis(51));
+        assert!(!msg_cache.contains(&msg2));
+        assert!(!msg_cache.contains(&msg3));
+        assert!(msg_cache.contains(&msg4));
+    }
+}

--- a/comms/src/inbound_message_service/mod.rs
+++ b/comms/src/inbound_message_service/mod.rs
@@ -41,5 +41,9 @@ pub mod error;
 pub mod inbound_message_broker;
 pub mod inbound_message_service;
 pub mod inbound_message_worker;
+pub mod message_cache;
 
-pub use self::error::InboundError;
+pub use self::{
+    error::InboundError,
+    message_cache::{MessageCache, MessageCacheConfig},
+};

--- a/comms/src/lib.rs
+++ b/comms/src/lib.rs
@@ -16,6 +16,7 @@ pub mod builder;
 #[macro_use]
 pub mod connection;
 pub mod connection_manager;
+mod consts;
 pub mod control_service;
 pub mod dispatcher;
 pub mod domain_connector;


### PR DESCRIPTION
## Description
- Added DuplicateMsgCache for detecting and discarding duplicate inbound messages.
- Integrated The DuplicateMsgCache into the InboundMessageWorker.
- Modified InboundMessageService and InboundMessageWorker tests to not send duplicate messages.
- Added extra tests to check that the detection and discarding of duplicate messages work correctly.

## Motivation and Context
With the propagation of messages on the DHT, the same message can be received from multiple peers.
Only the first one should be processed and the rest should be discarded.
This is important for the functioning of the DHT, otherwise peers will get stuck in an endless loop attempting to send join requests to each other.

## How Has This Been Tested?
Test were modified and new tests were added

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [x] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch
* [x] I ran `cargo-fmt --all` before pushing
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
