### PR TITLE
Add roaring bitmap to the mmr so we can track the UTXO's

### DIFF
--- a/infrastructure/merklemountainrange/Cargo.toml
+++ b/infrastructure/merklemountainrange/Cargo.toml
@@ -14,9 +14,10 @@ tari_utilities = { path = "../tari_util", version = "^0.0" }
 derive-error = "0.0.4"
 digest = "0.8.0"
 tari_storage = { path = "../storage", version = "^0.0" }
-serde = "1.0.91"
-serde_derive = "1.0.91"
+serde = "1.0.94"
+serde_derive = "1.0.95"
 rmp-serde = "0.13.7"
+croaring =  "0.4.0"
 
 [dev-dependencies]
 blake2 = "0.8.0"

--- a/infrastructure/merklemountainrange/src/lib.rs
+++ b/infrastructure/merklemountainrange/src/lib.rs
@@ -115,7 +115,7 @@
 //! find peak : 2^(H+1) -2 where < total elements
 //! left down : 2^H
 //! right down: -1
-//! Note that the formulas are for direct indexes in the array, meaning the nodes count from 0 and not 1 as in
+//! Note that the formulas are for direct indices in the array, meaning the nodes count from 0 and not 1 as in
 //! the examples above. H - Height
 //! I - Index
 //!

--- a/infrastructure/merklemountainrange/tests/unit/mmr_rewinding.rs
+++ b/infrastructure/merklemountainrange/tests/unit/mmr_rewinding.rs
@@ -57,11 +57,13 @@ fn rewind_simple() {
     mmr2.init_persistance_store(&"mmr".to_string(), 20);
     assert!(mmr2.load_from_store(&mut store).is_ok());
     assert_eq!(mmr.get_merkle_root(), mmr2.get_merkle_root());
+    assert_eq!(mmr.get_unpruned_hash(), mmr2.get_unpruned_hash());
 
     let mut mmr3: MerkleMountainRange<TestObject, Blake2b> = MerkleMountainRange::new();
     mmr3.init_persistance_store(&"mmr".to_string(), 20);
     assert!(mmr3.load_from_store(&mut store).is_ok());
     assert_eq!(mmr.get_merkle_root(), mmr3.get_merkle_root());
+    assert_eq!(mmr.get_unpruned_hash(), mmr3.get_unpruned_hash());
     // add much more leaves
     for j in 0..5 {
         for i in 1..11 {
@@ -77,9 +79,11 @@ fn rewind_simple() {
 
         assert!(mmr.rewind(&mut store, j + 1).is_ok());
         assert_eq!(mmr.get_merkle_root(), mmr2.get_merkle_root());
+        assert_eq!(mmr.get_unpruned_hash(), mmr2.get_unpruned_hash());
 
         assert!(mmr.ff_to_head(&mut store).is_ok());
         assert_eq!(mmr.get_merkle_root(), mmr3.get_merkle_root()); // are we where we are suppose to be
+        assert_eq!(mmr.get_unpruned_hash(), mmr3.get_unpruned_hash());
     }
     assert!(fs::remove_dir_all("./tests/test_mmr_r").is_ok()); // we ensure that the test dir is empty
 }
@@ -106,11 +110,13 @@ fn batch_save() {
     mmr2.init_persistance_store(&"mmr".to_string(), 20);
     assert!(mmr2.load_from_store(&mut store).is_ok());
     assert_eq!(mmr.get_merkle_root(), mmr2.get_merkle_root());
+    assert_eq!(mmr.get_unpruned_hash(), mmr2.get_unpruned_hash());
 
     let mut mmr3: MerkleMountainRange<TestObject, Blake2b> = MerkleMountainRange::new();
     mmr3.init_persistance_store(&"mmr".to_string(), 20);
     assert!(mmr3.load_from_store(&mut store).is_ok());
     assert_eq!(mmr.get_merkle_root(), mmr3.get_merkle_root());
+    assert_eq!(mmr.get_unpruned_hash(), mmr3.get_unpruned_hash());
     // add much more leaves
     for j in 0..5 {
         for i in 1..11 {
@@ -129,15 +135,18 @@ fn batch_save() {
     assert!(mmr.apply_state(&mut store).is_ok());
     assert!(mmr.rewind(&mut store, 5).is_ok());
     assert_eq!(mmr.get_merkle_root(), mmr2.get_merkle_root());
+    assert_eq!(mmr.get_unpruned_hash(), mmr2.get_unpruned_hash());
 
     assert!(mmr.ff_to_head(&mut store).is_ok());
     assert_eq!(mmr.get_merkle_root(), mmr3.get_merkle_root());
+    assert_eq!(mmr.get_unpruned_hash(), mmr3.get_unpruned_hash());
 
     // have we  saved correctly and can we load again
     let mut mmr4: MerkleMountainRange<TestObject, Blake2b> = MerkleMountainRange::new();
     mmr4.init_persistance_store(&"mmr".to_string(), 20);
     assert!(mmr4.load_from_store(&mut store).is_ok());
     assert_eq!(mmr4.get_merkle_root(), mmr3.get_merkle_root());
+    assert_eq!(mmr4.get_unpruned_hash(), mmr3.get_unpruned_hash());
 
     assert!(fs::remove_dir_all("./tests/test_mmr_bs").is_ok()); // we ensure that the test dir is empty
 }


### PR DESCRIPTION
## Description
Adds Croaring dependancy to the MMR. 
Adds a roaringbitmap to track the unspent UTXO's inside the mmr. 
Adds a call to get the hash of the roaringbitmap. 

## Motivation and Context
We require some way to track to the UTXO's and not just the TXO's
See IRC discussion: https://www.tari.com/2019/07/15/tari-protocol-discussion-42.html

## How Has This Been Tested?
Added unit tests to test the roaring bitmap as well as rewinding them.

## Types of changes
* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [x] New Tests
* [ ] Documentation

## Checklist:
* [x] I'm merging against the `development` branch
* [x] I ran `cargo-fmt --all` before pushing
* [x] My change requires a change to the documentation.
* [x] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
