### PR TITLE
Sending and handling DHT join requests

### DIFF
--- a/base_layer/p2p/src/consts.rs
+++ b/base_layer/p2p/src/consts.rs
@@ -20,26 +20,5 @@
 //  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 //  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use derive_error::Error;
-use tari_comms::{
-    domain_connector::ConnectorError,
-    outbound_message_service::OutboundError,
-    peer_manager::PeerManagerError,
-};
-
-#[derive(Debug, Error)]
-pub enum DHTError {
-    OutboundError(OutboundError),
-    ConnectorError(ConnectorError),
-    /// OMS has not been initialized
-    OMSUndefined,
-    /// PeerManager has not been initialized
-    PeerManagerUndefined,
-    PeerManagerError(PeerManagerError),
-    /// Failed to send from API
-    ApiSendFailed,
-    /// Failed to receive in API from service
-    ApiReceiveFailed,
-    /// Received an unexpected response type from the API
-    UnexpectedApiResponse,
-}
+/// The maximum number of peer nodes that a message will be sent to
+pub const DHT_BROADCAST_NODE_COUNT: usize = 8;

--- a/base_layer/p2p/src/dht_service/mod.rs
+++ b/base_layer/p2p/src/dht_service/mod.rs
@@ -20,10 +20,12 @@
 //  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 //  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+mod dht_messages;
 mod dht_service;
 mod error;
 
 pub use self::{
+    dht_messages::JoinMessage,
     dht_service::{DHTService, DHTServiceApi},
     error::DHTError,
 };

--- a/base_layer/p2p/src/lib.rs
+++ b/base_layer/p2p/src/lib.rs
@@ -22,6 +22,7 @@
 
 #[macro_use]
 mod macros;
+mod consts;
 pub mod dht_service;
 pub mod initialization;
 pub mod peer;

--- a/base_layer/p2p/tests/dht/mod.rs
+++ b/base_layer/p2p/tests/dht/mod.rs
@@ -20,15 +20,15 @@
 //  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 //  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-// NOTE: This test uses ports 11113 and 11114
+// NOTE: This test uses ports 11113, 11114 and 11115
 use crate::support::random_string;
 use rand::rngs::OsRng;
-use std::{sync::Arc, time::Duration};
+use std::{sync::Arc, thread, time::Duration};
 use tari_comms::{
     connection::NetAddress,
     connection_manager::PeerConnectionConfig,
     control_service::ControlServiceConfig,
-    peer_manager::{peer_storage::PeerStorage, NodeIdentity, Peer},
+    peer_manager::{peer_storage::PeerStorage, NodeIdentity, Peer, PeerManager},
     types::CommsDatabase,
     CommsBuilder,
 };
@@ -67,13 +67,18 @@ fn setup_dht_service(
     peer_storage: CommsDatabase,
 ) -> (ServiceExecutor, Arc<DHTServiceApi>)
 {
-    let dht_service = DHTService::new();
+    let control_service_address = node_identity.control_service_address.clone(); // TODO Remove
+    let dht_service = DHTService::new(
+        node_identity.identity.node_id.clone(),
+        node_identity.identity.public_key.clone(),
+        node_identity.control_service_address.clone(),
+    );
     let dht_api = dht_service.get_api();
 
     let services = ServiceRegistry::new().register(dht_service);
     let comms = CommsBuilder::new()
         .with_routes(services.build_comms_routes())
-        .with_node_identity(node_identity.clone())
+        .with_node_identity(node_identity)
         .with_peer_storage(peer_storage)
         .configure_peer_connections(PeerConnectionConfig {
             host: "127.0.0.1".parse().unwrap(),
@@ -81,7 +86,7 @@ fn setup_dht_service(
         })
         .configure_control_service(ControlServiceConfig {
             socks_proxy_address: None,
-            listener_address: node_identity.control_service_address.clone(),
+            listener_address: control_service_address,
             accept_message_type: TariMessageType::new(NetMessage::Accept),
             requested_outbound_connection_timeout: Duration::from_millis(5000),
         })
@@ -93,32 +98,69 @@ fn setup_dht_service(
     (ServiceExecutor::execute(Arc::new(comms), services), dht_api)
 }
 
+fn pause() {
+    thread::sleep(Duration::from_millis(1000));
+}
+
 #[test]
 #[allow(non_snake_case)]
-fn test_dht_service() {
+fn test_dht_join_propagation() {
     let _ = simple_logger::init();
 
+    // Create 3 nodes where only Node B knows A and C, but A and C want to talk to each other
     let node_A_identity = new_node_identity("127.0.0.1:11113".parse().unwrap());
     let node_B_identity = new_node_identity("127.0.0.1:11114".parse().unwrap());
+    let node_C_identity = new_node_identity("127.0.0.1:11115".parse().unwrap());
 
     // Setup Node A
     let node_A_tmpdir = TempDir::new(random_string(8).as_str()).unwrap();
+    let node_A_database_name = "node_A";
     let (node_A_services, node_A_dht_service_api) = setup_dht_service(
         node_A_identity.clone(),
-        create_peer_storage(&node_A_tmpdir, "node_A", vec![node_B_identity.clone().into()]),
+        create_peer_storage(&node_A_tmpdir, node_A_database_name, vec![node_B_identity
+            .clone()
+            .into()]),
     );
     // Setup Node B
     let node_B_tmpdir = TempDir::new(random_string(8).as_str()).unwrap();
-    let (node_B_services, node_B_dht_service_api) = setup_dht_service(
+    let node_B_database_name = "node_B";
+    let (node_B_services, _node_B_dht_service_api) = setup_dht_service(
         node_B_identity.clone(),
-        create_peer_storage(&node_B_tmpdir, "node_B", vec![node_A_identity.clone().into()]),
+        create_peer_storage(&node_B_tmpdir, node_B_database_name, vec![
+            node_A_identity.clone().into(),
+            node_C_identity.clone().into(),
+        ]),
+    );
+    // Setup Node C
+    let node_C_tmpdir = TempDir::new(random_string(8).as_str()).unwrap();
+    let node_C_database_name = "node_C";
+    let (node_C_services, _node_C_dht_service_api) = setup_dht_service(
+        node_C_identity.clone(),
+        create_peer_storage(&node_C_tmpdir, node_C_database_name, vec![node_B_identity
+            .clone()
+            .into()]),
     );
 
+    // Send a join request from Node A, through B to C. As all Nodes are in the same network region, once Node C
+    // receives the join request from Node A, it will send a direct join request back to A.
+    pause();
     assert!(node_A_dht_service_api.send_join().is_ok());
-    assert!(node_B_dht_service_api
-        .send_discover(node_A_identity.identity.public_key)
-        .is_ok());
 
+    pause();
     node_A_services.shutdown().unwrap();
     node_B_services.shutdown().unwrap();
+    node_C_services.shutdown().unwrap();
+
+    // Restore PeerStorage of Node A and Node C and check that they are aware of each other
+    pause();
+    let node_A_peer_manager =
+        PeerManager::new(create_peer_storage(&node_A_tmpdir, node_A_database_name, vec![])).unwrap();
+    let node_C_peer_manager =
+        PeerManager::new(create_peer_storage(&node_C_tmpdir, node_C_database_name, vec![])).unwrap();
+    assert!(node_A_peer_manager
+        .exists(&node_C_identity.identity.public_key)
+        .unwrap());
+    assert!(node_C_peer_manager
+        .exists(&node_A_identity.identity.public_key)
+        .unwrap());
 }

--- a/comms/src/domain_connector.rs
+++ b/comms/src/domain_connector.rs
@@ -42,6 +42,7 @@ pub enum ConnectorError {
 }
 
 /// Information about the message received
+#[derive(Debug)]
 pub struct MessageInfo {
     pub source_identity: PeerNodeIdentity,
 }


### PR DESCRIPTION
## Description
- Added ability to send join messages and handle received join requests
- Added initial join DHT message struct
- Implemented propagation of join messages
- Added test for join propagation

## Motivation and Context
The join request is used to inform neighbouring peers in the network about the identity and contact details of a new node.

## How Has This Been Tested?
A new test has been addded.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [x] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch
* [x] I ran `cargo-fmt --all` before pushing
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
