### PR TITLE
Message retry service using mpsc channel

### DIFF
--- a/comms/src/outbound_message_service/error.rs
+++ b/comms/src/outbound_message_service/error.rs
@@ -24,7 +24,7 @@ use crate::{
     connection::{dealer_proxy::DealerProxyError, ConnectionError, NetAddressError, PeerConnectionError},
     connection_manager::ConnectionManagerError,
     message::MessageError,
-    outbound_message_service::outbound_message_pool::OutboundMessagePoolError,
+    outbound_message_service::outbound_message_pool::{OutboundMessagePoolError, RetryServiceError},
     peer_manager::PeerManagerError,
 };
 use derive_error::Error;
@@ -75,4 +75,5 @@ pub enum OutboundError {
     /// Could not join the dealer or worker threads
     ThreadJoinError(ThreadError),
     OutboundMessagePoolError(OutboundMessagePoolError),
+    RetryServiceError(RetryServiceError),
 }

--- a/comms/src/outbound_message_service/outbound_message_pool/error.rs
+++ b/comms/src/outbound_message_service/outbound_message_pool/error.rs
@@ -36,11 +36,19 @@ pub enum OutboundMessagePoolError {
     #[error(msg_embedded, non_std, no_from)]
     InvalidFrameFormat(String),
     MessageFormatError(MessageFormatError),
-    /// Control message sender disconnected without sending shutdown signal
-    ControlMessageSenderDisconnected,
     PeerManagerError(PeerManagerError),
     ConnectionManagerError(ConnectionManagerError),
     DealerProxyError(DealerProxyError),
     /// Unable to allocate message pool worker thread
     ThreadInitializationError,
+    /// The message retry service has unexpectedly disconnected from it's channel
+    MessageRetryServiceDisconnected,
+}
+
+#[derive(Error, Debug)]
+pub enum RetryServiceError {
+    ConnectionError(ConnectionError),
+    /// Control message sender disconnected without sending shutdown signal
+    ControlMessageSenderDisconnected,
+    MessageFormatError(MessageFormatError),
 }

--- a/comms/src/outbound_message_service/outbound_message_pool/mod.rs
+++ b/comms/src/outbound_message_service/outbound_message_pool/mod.rs
@@ -27,8 +27,8 @@ mod outbound_message_pool;
 mod outbound_message_worker;
 
 pub use self::{
-    error::OutboundMessagePoolError,
-    message_retry_service::MessageRetryService,
+    error::{OutboundMessagePoolError, RetryServiceError},
+    message_retry_service::{MessageRetryService, RetryServiceMessage},
     outbound_message::OutboundMessage,
     outbound_message_pool::{OutboundMessagePool, OutboundMessagePoolConfig},
     outbound_message_worker::MessagePoolWorker,


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Changed the MessageRetryService to use a mpsc channel as part of a
larger refactor away from inprocs and a more stable OMP.

Messages:
`Shutdown` - Shut the MessageRetryService down
`AttemptFailed(OutboundMessage)` - Add the failed message to the retry queue
`Flush(NodeId)` - Flush all message for a given Node ID and queue for sending

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Part of a larger refactor of the OMP to use concurrency primitives (channels, work stealing) rather than Zmq inprocs. 

Ref #445 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Unit tested behaviour for all types of `RetryServiceMessage`s, updated existing tests where applicable. 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [x] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [x] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch
* [x] I ran `cargo-fmt --all` before pushing
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
