### PR TITLE
Update docker image for Circle CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2
 
 defaults:
-  rust_image: &rust_image quay.io/tarilabs/rust_tari-build-zmq:nightly-2019-07-15
+  rust_image: &rust_image quay.io/tarilabs/rust_tari-build-with-deps:nightly-2019-07-15
 
 jobs:
   test-docs:


### PR DESCRIPTION
Migrate to the new Rust Build image that includes all deps,
inc libzmq, sqlite, clang (and more in future)

