### PR TITLE
Added nonce to MessageHeader

### DIFF
--- a/comms/src/control_service/client.rs
+++ b/comms/src/control_service/client.rs
@@ -163,7 +163,7 @@ impl ControlServiceClient {
     where
         T: MessageFormat,
     {
-        let header = MessageHeader { message_type };
+        let header = MessageHeader::new(message_type)?;
         let msg = Message::from_message_format(header, msg)?;
 
         MessageEnvelope::construct(

--- a/comms/src/control_service/worker.rs
+++ b/comms/src/control_service/worker.rs
@@ -417,7 +417,7 @@ where
         MT: Serialize + DeserializeOwned,
         MT: MessageFormat,
     {
-        let header = MessageHeader { message_type };
+        let header = MessageHeader::new(message_type)?;
         let msg = Message::from_message_format(header, msg).map_err(ControlServiceError::MessageError)?;
 
         MessageEnvelope::construct(

--- a/comms/src/domain_connector.rs
+++ b/comms/src/domain_connector.rs
@@ -323,7 +323,7 @@ mod test {
             poem: "meow meow".to_string(),
         };
 
-        let header = MessageHeader { message_type: 123 };
+        let header = MessageHeader::new(123).unwrap();
 
         let expected_pub_key = CommsPublicKey::random_keypair(&mut OsRng::new().unwrap()).1;
         let domain_message_context = DomainMessageContext {

--- a/comms/src/inbound_message_service/inbound_message_service.rs
+++ b/comms/src/inbound_message_service/inbound_message_service.rs
@@ -264,9 +264,7 @@ mod test {
         let mut message_envelope_body_list = Vec::new();
         for i in 0..test_message_count {
             // Construct a test message
-            let message_header = MessageHeader {
-                message_type: DomainBrokerType::Type1,
-            };
+            let message_header = MessageHeader::new(DomainBrokerType::Type1).unwrap();
             // Messages with the same message body will be discarded by the DuplicateMsgCache
             let message_body = format!("Test Message Body {}", i).as_bytes().to_vec();
             let message_envelope_body = Message::from_message_format(message_header, message_body).unwrap();
@@ -290,9 +288,7 @@ mod test {
         inbound_message_service.shutdown().unwrap();
         std::thread::sleep(Duration::from_millis(200));
 
-        let message_header = MessageHeader {
-            message_type: DomainBrokerType::Type1,
-        };
+        let message_header = MessageHeader::new(DomainBrokerType::Type1).unwrap();
         let message_body = "Test Message Body".as_bytes().to_vec();
         let message_envelope_body = Message::from_message_format(message_header, message_body).unwrap();
         let message_data_buffer = create_message_data_buffer(node_identity.clone(), message_envelope_body);

--- a/comms/src/inbound_message_service/inbound_message_worker.rs
+++ b/comms/src/inbound_message_service/inbound_message_worker.rs
@@ -337,9 +337,7 @@ mod test {
             .unwrap();
 
         // Construct test message 1
-        let message_header = MessageHeader {
-            message_type: DomainBrokerType::Type1,
-        };
+        let message_header = MessageHeader::new(DomainBrokerType::Type1).unwrap();
         let message_body = "Test Message Body1".as_bytes().to_vec();
         let message_envelope_body1 = Message::from_message_format(message_header, message_body).unwrap();
         let dest_public_key = node_identity.identity.public_key.clone(); // Send to self
@@ -359,9 +357,7 @@ mod test {
         message1_frame_set.extend(message_data1.clone().try_into_frame_set().unwrap());
 
         // Construct test message 2
-        let message_header = MessageHeader {
-            message_type: DomainBrokerType::Type2,
-        };
+        let message_header = MessageHeader::new(DomainBrokerType::Type2).unwrap();
         let message_body = "Test Message Body2".as_bytes().to_vec();
         let message_envelope_body2 = Message::from_message_format(message_header, message_body).unwrap();
         let message_envelope = MessageEnvelope::construct(

--- a/comms/src/message/error.rs
+++ b/comms/src/message/error.rs
@@ -42,4 +42,6 @@ pub enum MessageError {
     /// Failed to Encode or Decode the message using the Cipher
     CipherError(CipherError),
     NodeIdError(NodeIdError),
+    /// Problem initializing the RNG
+    RngError,
 }

--- a/comms/tests/connection_manager/establisher.rs
+++ b/comms/tests/connection_manager/establisher.rs
@@ -141,9 +141,7 @@ fn establish_control_service_connection_succeed() {
             node_identity1.identity.public_key.clone(),
             NodeDestination::PublicKey(node_identity1.identity.public_key.clone()),
             Message::from_message_format(
-                MessageHeader {
-                    message_type: ControlServiceMessageType::Pong,
-                },
+                MessageHeader::new(ControlServiceMessageType::Pong).unwrap(),
                 Pong {}.to_binary().unwrap(),
             )
             .unwrap()


### PR DESCRIPTION
## Description
Included a nonce in MessageHeader to distinguish multiple requests from duplicate messages

## Motivation and Context
Currently, when multiple duplicate messages are received from different peers only the first one will be processed. Messages from different requests might look the same, resulting in only the first one being processed. Adding a nonce in the header will eliminate the misclassification of duplicate messages.

## How Has This Been Tested?
Test was modified

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch
* [x] I ran `cargo-fmt --all` before pushing
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
