### PR TITLE
Removed CommsServices ownership from ServiceExecutor

### DIFF
--- a/applications/console_text_messenger/src/main.rs
+++ b/applications/console_text_messenger/src/main.rs
@@ -282,7 +282,7 @@ pub fn main() {
             let pk = CommsPublicKey::from_hex(p.pub_key.as_str()).expect("Error parsing pub key from Hex");
             if let Ok(na) = p.address.clone().parse::<NetAddress>() {
                 let peer = Peer::from_public_key_and_address(pk.clone(), na.clone()).unwrap();
-                wallet.comms_services.peer_manager.add_peer(peer).unwrap();
+                wallet.comms_services.peer_manager().add_peer(peer).unwrap();
                 // If the contacts already exist we don't mind
                 if let Err(e) = wallet.text_message_service.add_contact(Contact {
                     screen_name: p.screen_name.clone(),

--- a/applications/grpc_wallet/src/main.rs
+++ b/applications/grpc_wallet/src/main.rs
@@ -262,7 +262,7 @@ pub fn main() {
             let pk = CommsPublicKey::from_hex(p.pub_key.as_str()).expect("Error parsing pub key from Hex");
             if let Ok(na) = p.address.clone().parse::<NetAddress>() {
                 let peer = Peer::from_public_key_and_address(pk.clone(), na.clone()).unwrap();
-                wallet.comms_services.peer_manager.add_peer(peer).unwrap();
+                wallet.comms_services.peer_manager().add_peer(peer).unwrap();
                 if let Err(e) = wallet.text_message_service.add_contact(Contact {
                     screen_name: p.screen_name.clone(),
                     pub_key: pk.clone(),

--- a/base_layer/p2p/examples/pingpong.rs
+++ b/base_layer/p2p/examples/pingpong.rs
@@ -137,9 +137,9 @@ fn main() {
         peer_identity.control_service_address.into(),
         PeerFlags::empty(),
     );
-    comms.peer_manager.add_peer(peer).unwrap();
+    comms.peer_manager().add_peer(peer).unwrap();
 
-    let services = ServiceExecutor::execute(comms.clone(), services);
+    let services = ServiceExecutor::execute(&comms, services);
 
     run_ui(services, peer_identity.identity, pingpong);
 

--- a/base_layer/p2p/src/services/error.rs
+++ b/base_layer/p2p/src/services/error.rs
@@ -22,10 +22,11 @@
 
 use derive_error::Error;
 use serde::export::fmt::Debug;
-use tari_comms::builder::CommsServicesError;
+use tari_comms::{builder::CommsServicesError, domain_connector::ConnectorError};
 
 #[derive(Debug, Error)]
 pub enum ServiceError {
+    ConnectorError(ConnectorError),
     #[error(msg_embedded, non_std, no_from)]
     ServiceInitializationFailed(String),
     CommsServicesError(CommsServicesError),

--- a/base_layer/p2p/src/services/executor.rs
+++ b/base_layer/p2p/src/services/executor.rs
@@ -38,6 +38,10 @@ use threadpool::ThreadPool;
 
 use crossbeam_channel as channel;
 use crossbeam_channel::{Receiver, RecvTimeoutError, Sender};
+use tari_comms::{
+    builder::{CommsRoutes, CommsServicesError},
+    connection::ZmqContext,
+};
 
 const LOG_TARGET: &str = "base_layer::p2p::services";
 
@@ -56,7 +60,7 @@ pub struct ServiceExecutor {
 
 impl ServiceExecutor {
     /// Execute the services contained in the given [ServiceRegistry].
-    pub fn execute(comms_services: Arc<CommsServices<TariMessageType>>, mut registry: ServiceRegistry) -> Self {
+    pub fn execute(comms_services: &CommsServices<TariMessageType>, registry: ServiceRegistry) -> Self {
         let thread_pool = threadpool::Builder::new()
             .thread_name("DomainServices".to_string())
             .num_threads(registry.num_services())
@@ -65,17 +69,20 @@ impl ServiceExecutor {
 
         let mut senders = Vec::new();
 
-        for mut service in registry.services.drain(..) {
+        for mut service in registry.services.into_iter() {
             let (sender, receiver) = channel::unbounded();
             senders.push(sender);
 
             let service_context = ServiceContext {
-                comms_services: comms_services.clone(),
+                oms: comms_services.outbound_message_service(),
+                peer_manager: comms_services.peer_manager(),
                 receiver,
+                routes: comms_services.routes().clone(),
+                zmq_context: comms_services.zmq_context().clone(),
             };
 
             thread_pool.execute(move || {
-                info!(target: LOG_TARGET, "Starting service {}", service.get_name(),);
+                info!(target: LOG_TARGET, "Starting service {}", service.get_name());
 
                 match service.execute(service_context) {
                     Ok(_) => {
@@ -143,8 +150,11 @@ impl ServiceExecutor {
 /// access the outbound message service and create [DomainConnector]s to receive comms messages of
 /// a particular [TariMessageType].
 pub struct ServiceContext {
-    comms_services: Arc<CommsServices<TariMessageType>>,
+    oms: Arc<OutboundMessageService>,
+    peer_manager: Arc<PeerManager>,
     receiver: Receiver<ServiceControlMessage>,
+    routes: CommsRoutes<TariMessageType>,
+    zmq_context: ZmqContext,
 }
 
 impl ServiceContext {
@@ -162,19 +172,24 @@ impl ServiceContext {
 
     /// Retrieve and `Arc` of the outbound message service. Used for sending outbound messages.
     pub fn outbound_message_service(&self) -> Arc<OutboundMessageService> {
-        self.comms_services.outbound_message_service()
+        Arc::clone(&self.oms)
     }
 
     /// Retrieve and `Arc` of the PeerManager. Used for managing peers.
     pub fn peer_manager(&self) -> Arc<PeerManager> {
-        self.comms_services.peer_manager.clone()
+        Arc::clone(&self.peer_manager)
     }
 
     /// Create a [DomainConnector] which listens for a particular [TariMessageType].
-    pub fn create_connector(&self, message_type: &TariMessageType) -> Result<DomainConnector<'static>, ServiceError> {
-        self.comms_services
-            .create_connector(message_type)
-            .map_err(ServiceError::CommsServicesError)
+    pub fn create_connector<'de>(&self, message_type: &TariMessageType) -> Result<DomainConnector<'de>, ServiceError> {
+        let addr = self
+            .routes
+            .get_address(&message_type)
+            .ok_or(ServiceError::CommsServicesError(
+                CommsServicesError::MessageTypeNotRegistered,
+            ))?;
+
+        DomainConnector::listen(&self.zmq_context, &addr).map_err(ServiceError::ConnectorError)
     }
 }
 
@@ -263,7 +278,7 @@ mod test {
             .map(Arc::new)
             .unwrap();
 
-        let services = ServiceExecutor::execute(comms_services.clone(), registry);
+        let services = ServiceExecutor::execute(&comms_services, registry);
 
         services.shutdown().unwrap();
         services.join_timeout(Duration::from_millis(100)).unwrap();

--- a/base_layer/p2p/tests/dht/mod.rs
+++ b/base_layer/p2p/tests/dht/mod.rs
@@ -25,6 +25,7 @@ use crate::support::random_string;
 use rand::rngs::OsRng;
 use std::{sync::Arc, thread, time::Duration};
 use tari_comms::{
+    builder::CommsServices,
     connection::NetAddress,
     connection_manager::PeerConnectionConfig,
     control_service::ControlServiceConfig,
@@ -65,7 +66,7 @@ fn create_peer_storage(tmpdir: &TempDir, database_name: &str, peers: Vec<Peer>) 
 fn setup_dht_service(
     node_identity: NodeIdentity,
     peer_storage: CommsDatabase,
-) -> (ServiceExecutor, Arc<DHTServiceApi>)
+) -> (ServiceExecutor, Arc<DHTServiceApi>, Arc<CommsServices<TariMessageType>>)
 {
     let control_service_address = node_identity.control_service_address.clone(); // TODO Remove
     let dht_service = DHTService::new(
@@ -93,9 +94,10 @@ fn setup_dht_service(
         .build()
         .unwrap()
         .start()
+        .map(Arc::new)
         .unwrap();
 
-    (ServiceExecutor::execute(Arc::new(comms), services), dht_api)
+    (ServiceExecutor::execute(&comms, services), dht_api, comms)
 }
 
 fn pause() {
@@ -105,8 +107,6 @@ fn pause() {
 #[test]
 #[allow(non_snake_case)]
 fn test_dht_join_propagation() {
-    let _ = simple_logger::init();
-
     // Create 3 nodes where only Node B knows A and C, but A and C want to talk to each other
     let node_A_identity = new_node_identity("127.0.0.1:11113".parse().unwrap());
     let node_B_identity = new_node_identity("127.0.0.1:11114".parse().unwrap());
@@ -115,7 +115,7 @@ fn test_dht_join_propagation() {
     // Setup Node A
     let node_A_tmpdir = TempDir::new(random_string(8).as_str()).unwrap();
     let node_A_database_name = "node_A";
-    let (node_A_services, node_A_dht_service_api) = setup_dht_service(
+    let (node_A_services, node_A_dht_service_api, _comms_A) = setup_dht_service(
         node_A_identity.clone(),
         create_peer_storage(&node_A_tmpdir, node_A_database_name, vec![node_B_identity
             .clone()
@@ -124,7 +124,7 @@ fn test_dht_join_propagation() {
     // Setup Node B
     let node_B_tmpdir = TempDir::new(random_string(8).as_str()).unwrap();
     let node_B_database_name = "node_B";
-    let (node_B_services, _node_B_dht_service_api) = setup_dht_service(
+    let (node_B_services, _node_B_dht_service_api, _comms_B) = setup_dht_service(
         node_B_identity.clone(),
         create_peer_storage(&node_B_tmpdir, node_B_database_name, vec![
             node_A_identity.clone().into(),
@@ -134,7 +134,7 @@ fn test_dht_join_propagation() {
     // Setup Node C
     let node_C_tmpdir = TempDir::new(random_string(8).as_str()).unwrap();
     let node_C_database_name = "node_C";
-    let (node_C_services, _node_C_dht_service_api) = setup_dht_service(
+    let (node_C_services, _node_C_dht_service_api, _comms_C) = setup_dht_service(
         node_C_identity.clone(),
         create_peer_storage(&node_C_tmpdir, node_C_database_name, vec![node_B_identity
             .clone()

--- a/base_layer/wallet/src/wallet.rs
+++ b/base_layer/wallet/src/wallet.rs
@@ -67,7 +67,7 @@ impl Wallet {
 
         let comm_routes = registry.build_comms_routes();
         let comms_services = initialize_comms(config.comms.clone(), comm_routes)?;
-        let service_executor = ServiceExecutor::execute(comms_services.clone(), registry);
+        let service_executor = ServiceExecutor::execute(&comms_services, registry);
 
         Ok(Wallet {
             text_message_service: text_message_service_api,

--- a/base_layer/wallet/tests/support/comms_and_services.rs
+++ b/base_layer/wallet/tests/support/comms_and_services.rs
@@ -22,6 +22,7 @@
 
 use std::{sync::Arc, time::Duration};
 use tari_comms::{
+    builder::CommsServices,
     connection_manager::PeerConnectionConfig,
     control_service::ControlServiceConfig,
     peer_manager::{NodeIdentity, Peer},
@@ -39,7 +40,11 @@ pub fn setup_text_message_service(
     peers: Vec<NodeIdentity>,
     peer_database: LMDBDatabase,
     database_path: String,
-) -> (ServiceExecutor, Arc<TextMessageServiceApi>)
+) -> (
+    ServiceExecutor,
+    Arc<TextMessageServiceApi>,
+    CommsServices<TariMessageType>,
+)
 {
     let tms = TextMessageService::new(node_identity.identity.public_key.clone(), database_path);
     let tms_api = tms.get_api();
@@ -74,5 +79,5 @@ pub fn setup_text_message_service(
             .unwrap();
     }
 
-    (ServiceExecutor::execute(Arc::new(comms), services), tms_api)
+    (ServiceExecutor::execute(&comms, services), tms_api, comms)
 }

--- a/base_layer/wallet/tests/text_message_service/mod.rs
+++ b/base_layer/wallet/tests/text_message_service/mod.rs
@@ -92,19 +92,19 @@ fn test_text_message_service() {
     let db_path3 = get_path(Some(db_name3));
     init_sql_database(db_name3);
 
-    let (node_1_services, node_1_tms) = setup_text_message_service(
+    let (node_1_services, node_1_tms, _comms_1) = setup_text_message_service(
         node_1_identity.clone(),
         vec![node_2_identity.clone(), node_3_identity.clone()],
         node_1_peer_database,
         db_path1,
     );
-    let (node_2_services, node_2_tms) = setup_text_message_service(
+    let (node_2_services, node_2_tms, _comms_2) = setup_text_message_service(
         node_2_identity.clone(),
         vec![node_1_identity.clone()],
         node_2_peer_database,
         db_path2,
     );
-    let (node_3_services, node_3_tms) = setup_text_message_service(
+    let (node_3_services, node_3_tms, _comms_3) = setup_text_message_service(
         node_3_identity.clone(),
         vec![node_1_identity.clone()],
         node_3_peer_database,

--- a/comms/src/builder/builder.rs
+++ b/comms/src/builder/builder.rs
@@ -437,7 +437,7 @@ pub struct CommsServices<MType> {
     inbound_message_broker: Arc<InboundMessageBroker<MType>>,
     outbound_message_pool: OutboundMessagePool,
     connection_manager: Arc<ConnectionManager>,
-    pub peer_manager: Arc<PeerManager>,
+    peer_manager: Arc<PeerManager>,
 }
 
 impl<MType> CommsServices<MType>
@@ -445,12 +445,20 @@ where
     MType: DispatchableKey,
     MType: Clone,
 {
-    pub fn peer_manager(&self) -> &PeerManager {
-        &self.peer_manager
+    pub fn zmq_context(&self) -> &ZmqContext {
+        &self.zmq_context
+    }
+
+    pub fn peer_manager(&self) -> Arc<PeerManager> {
+        Arc::clone(&self.peer_manager)
     }
 
     pub fn outbound_message_service(&self) -> Arc<OutboundMessageService> {
         Arc::clone(&self.outbound_message_service)
+    }
+
+    pub fn routes(&self) -> &CommsRoutes<MType> {
+        &self.routes
     }
 
     pub fn create_connector<'de>(&self, message_type: &MType) -> Result<DomainConnector<'de>, CommsServicesError> {

--- a/comms/src/outbound_message_service/outbound_message_pool/message_retry_service.rs
+++ b/comms/src/outbound_message_service/outbound_message_pool/message_retry_service.rs
@@ -290,7 +290,7 @@ mod test {
         let (tx, rx) = sync_channel(0);
         let handle = MessageRetryService::start(context, config.clone(), rx, InprocAddress::random());
         tx.send(RetryServiceMessage::Shutdown).unwrap();
-        handle.timeout_join(Duration::from_millis(10)).unwrap();
+        handle.timeout_join(Duration::from_millis(3000)).unwrap();
     }
 
     #[test]
@@ -317,7 +317,7 @@ mod test {
         }
         tx.send(RetryServiceMessage::Shutdown).unwrap();
 
-        handle.timeout_join(Duration::from_millis(10)).unwrap();
+        handle.timeout_join(Duration::from_millis(3000)).unwrap();
     }
 
     #[test]
@@ -350,6 +350,6 @@ mod test {
         assert_eq!(msg.message_frames()[0], "EXPECTED".as_bytes().to_vec());
 
         tx.send(RetryServiceMessage::Shutdown).unwrap();
-        handle.timeout_join(Duration::from_millis(10)).unwrap();
+        handle.timeout_join(Duration::from_millis(3000)).unwrap();
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
The ServiceExecutor does not need to own the Arc<CommsServices>.
This change removes the constraint that all comms services need to be Sync.
Specifically, the mpsc::Receiver is !Sync which will come into play
in the coming OMP refactor PR.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Prerequisite for #562  

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Existing tests compile. Tests now need to hold onto the CommsServices so that it doesn't drop prematurely.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [x] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch
* [x] I ran `cargo-fmt --all` before pushing
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
