### PR TITLE
Send and handle DHT Discover requests

### DIFF
--- a/base_layer/p2p/src/dht_service/dht_messages.rs
+++ b/base_layer/p2p/src/dht_service/dht_messages.rs
@@ -27,15 +27,13 @@ use tari_comms::{
     connection::NetAddress,
     message::{Message, MessageError},
     peer_manager::NodeId,
-    types::CommsPublicKey,
 };
 
 /// The JoinMessage stores the information required for a network join request. It has all the information required to
-/// locate and contact a specific node.
+/// locate and contact the source node, but network behaviour is different compared to DiscoverMessage.
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub struct JoinMessage {
     pub node_id: NodeId,
-    pub public_key: CommsPublicKey, // TODO this should be moved to be part of received info - msg origin source
     // TODO: node_type
     pub net_address: Vec<NetAddress>,
 }
@@ -45,5 +43,22 @@ impl TryInto<Message> for JoinMessage {
 
     fn try_into(self) -> Result<Message, Self::Error> {
         Ok((TariMessageType::new(NetMessage::Join), self).try_into()?)
+    }
+}
+
+/// The DiscoverMessage stores the information required for a network discover request. It has all the information
+/// required to locate and contact the source node, but network behaviour is different compared to JoinMessage.
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, Hash)]
+pub struct DiscoverMessage {
+    pub node_id: NodeId,
+    // TODO: node_type
+    pub net_address: Vec<NetAddress>,
+}
+
+impl TryInto<Message> for DiscoverMessage {
+    type Error = MessageError;
+
+    fn try_into(self) -> Result<Message, Self::Error> {
+        Ok((TariMessageType::new(NetMessage::Discover), self).try_into()?)
     }
 }

--- a/base_layer/p2p/src/dht_service/error.rs
+++ b/base_layer/p2p/src/dht_service/error.rs
@@ -27,12 +27,17 @@ use tari_comms::{
     peer_manager::PeerManagerError,
 };
 
+use tari_comms::message::MessageError;
+use tari_utilities::message_format::MessageFormatError;
+
 #[derive(Debug, Error)]
 pub enum DHTError {
     OutboundError(OutboundError),
     ConnectorError(ConnectorError),
     /// OMS has not been initialized
     OMSUndefined,
+    /// The current nodes identity is undefined
+    NodeIdentityUndefined,
     /// PeerManager has not been initialized
     PeerManagerUndefined,
     PeerManagerError(PeerManagerError),
@@ -42,4 +47,6 @@ pub enum DHTError {
     ApiReceiveFailed,
     /// Received an unexpected response type from the API
     UnexpectedApiResponse,
+    MessageFormatError(MessageFormatError),
+    MessageSerializationError(MessageError),
 }

--- a/base_layer/p2p/src/dht_service/mod.rs
+++ b/base_layer/p2p/src/dht_service/mod.rs
@@ -25,7 +25,7 @@ mod dht_service;
 mod error;
 
 pub use self::{
-    dht_messages::JoinMessage,
+    dht_messages::{DiscoverMessage, JoinMessage},
     dht_service::{DHTService, DHTServiceApi},
     error::DHTError,
 };

--- a/base_layer/p2p/src/ping_pong.rs
+++ b/base_layer/p2p/src/ping_pong.rs
@@ -131,22 +131,19 @@ impl PingPongService {
                     debug!(
                         target: LOG_TARGET,
                         "Received ping from {}",
-                        info.source_identity.public_key.to_hex(),
+                        info.peer_source.public_key.to_hex(),
                     );
 
                     self.ping_count += 1;
 
                     // Reply with Pong
-                    self.send_msg(
-                        BroadcastStrategy::DirectNodeId(info.source_identity.node_id.clone()),
-                        PingPong::Pong,
-                    )?;
+                    self.send_msg(BroadcastStrategy::DirectPublicKey(info.origin_source), PingPong::Pong)?;
                 },
                 PingPong::Pong => {
                     debug!(
                         target: LOG_TARGET,
                         "Received pong from {}",
-                        info.source_identity.public_key.to_hex()
+                        info.peer_source.public_key.to_hex()
                     );
 
                     self.pong_count += 1;

--- a/base_layer/p2p/src/services/executor.rs
+++ b/base_layer/p2p/src/services/executor.rs
@@ -31,7 +31,7 @@ use std::{
 use tari_comms::{
     builder::CommsServices,
     outbound_message_service::outbound_message_service::OutboundMessageService,
-    peer_manager::PeerManager,
+    peer_manager::{NodeIdentity, PeerManager},
     DomainConnector,
 };
 use threadpool::ThreadPool;
@@ -168,6 +168,11 @@ impl ServiceContext {
     /// Retrieve and `Arc` of the PeerManager. Used for managing peers.
     pub fn peer_manager(&self) -> Arc<PeerManager> {
         self.comms_services.peer_manager.clone()
+    }
+
+    /// Retrieve and `Arc` of the NodeIdentity. Used for managing the current Nodes Identity.
+    pub fn node_identity(&self) -> Arc<NodeIdentity> {
+        self.comms_services.node_identity.clone()
     }
 
     /// Create a [DomainConnector] which listens for a particular [TariMessageType].

--- a/base_layer/wallet/src/text_message_service/service.rs
+++ b/base_layer/wallet/src/text_message_service/service.rs
@@ -156,7 +156,7 @@ impl TextMessageService {
 
             let text_message_ack = TextMessageAck { id: msg.clone().id };
             oms.send_message(
-                BroadcastStrategy::DirectPublicKey(info.source_identity.public_key),
+                BroadcastStrategy::DirectPublicKey(info.origin_source),
                 MessageFlags::ENCRYPTED,
                 text_message_ack,
             )?;

--- a/comms/src/builder/builder.rs
+++ b/comms/src/builder/builder.rs
@@ -310,7 +310,7 @@ where
         let inbound_message_broker = self.make_inbound_message_broker(&routes)?;
 
         let inbound_message_service = self.make_inbound_message_service(
-            node_identity,
+            node_identity.clone(),
             peer_conn_config.message_sink_address,
             inbound_message_broker.clone(),
             outbound_message_service.clone(),
@@ -327,6 +327,7 @@ where
             outbound_message_pool,
             outbound_message_service,
             peer_manager,
+            node_identity,
         })
     }
 }
@@ -362,6 +363,7 @@ where
     outbound_message_pool: OutboundMessagePool,
     outbound_message_service: Arc<OutboundMessageService>,
     peer_manager: Arc<PeerManager>,
+    node_identity: Arc<NodeIdentity>,
 }
 
 impl<MType> CommsServiceContainer<MType>
@@ -399,6 +401,7 @@ where
             inbound_message_broker: self.inbound_message_broker,
             peer_manager: self.peer_manager,
             outbound_message_pool: self.outbound_message_pool,
+            node_identity: self.node_identity,
             // Add handles for started services
             control_service_handle,
         })
@@ -417,6 +420,7 @@ pub struct CommsServices<MType> {
     control_service_handle: Option<ControlServiceHandle>,
     inbound_message_broker: Arc<InboundMessageBroker<MType>>,
     outbound_message_pool: OutboundMessagePool,
+    pub node_identity: Arc<NodeIdentity>,
     connection_manager: Arc<ConnectionManager>,
     pub peer_manager: Arc<PeerManager>,
 }

--- a/comms/src/consts.rs
+++ b/comms/src/consts.rs
@@ -26,3 +26,5 @@ use std::time::Duration;
 pub const DHT_MSG_CACHE_STORAGE_CAPACITY: usize = 1000;
 /// The time-to-live duration used by the MessageCache for tracking received and handled messages
 pub const DHT_MSG_CACHE_TTL: Duration = Duration::from_secs(300);
+/// The number of neighbouring nodes that a received message will be forwarded to
+pub const DHT_FORWARD_NODE_COUNT: usize = 8;

--- a/comms/src/control_service/client.rs
+++ b/comms/src/control_service/client.rs
@@ -110,7 +110,7 @@ impl ControlServiceClient {
                 }
                 let envelope: MessageEnvelope = frames.try_into()?;
                 let header = envelope.deserialize_header()?;
-                if header.verify_signature(&envelope.body_frame())? {
+                if header.verify_signatures(envelope.body_frame().clone())? {
                     let msg =
                         envelope.deserialize_encrypted_body(&self.node_identity.secret_key, &self.dest_public_key)?;
                     Ok(Some(msg))
@@ -190,7 +190,8 @@ mod test {
             .unwrap();
 
         let header = envelope.deserialize_header().unwrap();
-        assert_eq!(header.source, node_identity.identity.public_key);
+        assert_eq!(header.origin_source, node_identity.identity.public_key);
+        assert_eq!(header.peer_source, node_identity.identity.public_key);
         assert_eq!(header.dest, NodeDestination::PublicKey(public_key));
         assert_eq!(header.flags, MessageFlags::ENCRYPTED);
     }

--- a/comms/src/domain_connector.rs
+++ b/comms/src/domain_connector.rs
@@ -22,8 +22,9 @@
 
 use crate::{
     connection::{zmq::ZmqEndpoint, Connection, ConnectionError, Direction, EstablishedConnection, ZmqContext},
-    message::{DomainMessageContext, Frame, FrameSet, MessageError},
+    message::{DomainMessageContext, Frame, FrameSet, MessageEnvelope, MessageError},
     peer_manager::PeerNodeIdentity,
+    types::CommsPublicKey,
 };
 use derive_error::Error;
 use serde::{Deserialize, Serialize};
@@ -44,7 +45,9 @@ pub enum ConnectorError {
 /// Information about the message received
 #[derive(Debug)]
 pub struct MessageInfo {
-    pub source_identity: PeerNodeIdentity,
+    pub peer_source: PeerNodeIdentity,
+    pub origin_source: CommsPublicKey,
+    pub message_envelope: MessageEnvelope,
 }
 
 /// # DomainConnector
@@ -75,7 +78,9 @@ impl<'de> DomainConnector<'de> {
         match self.connector.receive_timeout(duration)? {
             Some(domain_context) => Ok(Some((
                 MessageInfo {
-                    source_identity: domain_context.source_identity,
+                    peer_source: domain_context.peer_source,
+                    origin_source: domain_context.origin_source,
+                    message_envelope: domain_context.message_envelope,
                 },
                 domain_context
                     .message
@@ -203,12 +208,10 @@ mod test {
     use super::*;
     use crate::{
         connection::InprocAddress,
-        message::{Message, MessageHeader},
-        peer_manager::NodeId,
-        types::CommsPublicKey,
+        message::{Message, MessageFlags, MessageHeader, NodeDestination},
+        peer_manager::NodeIdentity,
     };
-    use rand::rngs::OsRng;
-    use tari_crypto::keys::PublicKey;
+    use std::sync::Arc;
 
     #[derive(Clone, Eq, PartialEq, Debug, Serialize, Deserialize)]
     struct TestMessage {
@@ -324,15 +327,24 @@ mod test {
             poem: "meow meow".to_string(),
         };
 
+        let node_identity = Arc::new(NodeIdentity::random_for_test(None));
+        let dest_node_identity = Arc::new(NodeIdentity::random_for_test(None));
         let header = MessageHeader::new(123).unwrap();
+        let message = Message::from_message_format(header, expected_message.clone()).unwrap();
+        let message_envelope = MessageEnvelope::construct(
+            &node_identity,
+            dest_node_identity.identity.public_key.clone(),
+            NodeDestination::Unknown,
+            message.to_binary().unwrap(),
+            MessageFlags::NONE,
+        )
+        .unwrap();
 
-        let expected_pub_key = CommsPublicKey::random_keypair(&mut OsRng::new().unwrap()).1;
         let domain_message_context = DomainMessageContext {
-            source_identity: PeerNodeIdentity::new(
-                NodeId::from_key(&expected_pub_key).unwrap(),
-                expected_pub_key.clone(),
-            ),
-            message: Message::from_message_format(header, expected_message.clone()).unwrap(),
+            peer_source: node_identity.identity.clone(),
+            origin_source: node_identity.identity.public_key.clone(),
+            message,
+            message_envelope,
         };
 
         source.send(&[domain_message_context.to_binary().unwrap()]).unwrap();
@@ -341,7 +353,7 @@ mod test {
             Some((info, resp)) => {
                 let msg: TestMessage = resp;
                 assert_eq!(msg, expected_message);
-                assert_eq!(info.source_identity.public_key, expected_pub_key);
+                assert_eq!(info.peer_source.public_key, node_identity.identity.public_key);
             },
             None => panic!("DomainConnector Timed out"),
         }

--- a/comms/src/message/domain_message_context.rs
+++ b/comms/src/message/domain_message_context.rs
@@ -20,24 +20,38 @@
 //  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 //  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use crate::{message::message::Message, peer_manager::PeerNodeIdentity};
+use crate::{
+    message::{envelope::MessageEnvelope, message::Message},
+    peer_manager::PeerNodeIdentity,
+    types::CommsPublicKey,
+};
 use serde::{Deserialize, Serialize};
 
 /// The DomainMessageContext is the container that will be dispatched to the domain handlers. It contains the received
 /// message and source identity after the comms level envelope has been removed.
 #[derive(Serialize, Deserialize)]
 pub struct DomainMessageContext {
-    pub source_identity: PeerNodeIdentity,
+    pub peer_source: PeerNodeIdentity,
+    pub origin_source: CommsPublicKey,
     pub message: Message,
+    pub message_envelope: MessageEnvelope,
 }
 
 impl DomainMessageContext {
     /// Construct a new DomainMessageContext that consist of the peer connection information and the received message
     /// header and body
-    pub fn new(source_identity: PeerNodeIdentity, message: Message) -> Self {
+    pub fn new(
+        peer_source: PeerNodeIdentity,
+        origin_source: CommsPublicKey,
+        message: Message,
+        message_envelope: MessageEnvelope,
+    ) -> Self
+    {
         DomainMessageContext {
-            source_identity,
+            peer_source,
+            origin_source,
             message,
+            message_envelope,
         }
     }
 }

--- a/comms/src/message/envelope.rs
+++ b/comms/src/message/envelope.rs
@@ -35,21 +35,79 @@ use tari_utilities::{ciphers::cipher::Cipher, message_format::MessageFormat};
 
 const FRAMES_PER_MESSAGE: usize = 3;
 
+/// Generate the challenge for the origin signature
+fn origin_challenge(dest: NodeDestination<CommsPublicKey>, mut body: Vec<u8>) -> Result<Vec<u8>, MessageError> {
+    let mut challenge = dest.to_binary().map_err(MessageError::MessageFormatError)?;
+    challenge.append(&mut body);
+    Ok(challenge)
+}
+
+/// Generate the challenge for the peer signature
+fn peer_challenge(origin_signature: Vec<u8>, mut body: Vec<u8>) -> Result<Vec<u8>, MessageError> {
+    let mut challenge = origin_signature;
+    challenge.append(&mut body);
+    Ok(challenge)
+}
+
+/// Generate a signature for the origin that confirms the dest and body
+fn origin_signature(
+    node_identity: &NodeIdentity,
+    dest: NodeDestination<CommsPublicKey>,
+    body: Vec<u8>,
+) -> Result<Vec<u8>, MessageError>
+{
+    let origin_signature = crypto::sign(
+        &mut OsRng::new().unwrap(),
+        node_identity.secret_key.clone(),
+        &origin_challenge(dest, body)?,
+    )
+    .map_err(MessageError::SchnorrSignatureError)?;
+    origin_signature.to_binary().map_err(MessageError::MessageFormatError)
+}
+
+/// Generate a signature for the peer that confirms the origin_source and body
+fn peer_signature(
+    node_identity: &NodeIdentity,
+    origin_signature: Vec<u8>,
+    body: Vec<u8>,
+) -> Result<Vec<u8>, MessageError>
+{
+    let peer_signature = crypto::sign(
+        &mut OsRng::new().unwrap(),
+        node_identity.secret_key.clone(),
+        &peer_challenge(origin_signature, body)?,
+    )
+    .map_err(MessageError::SchnorrSignatureError)?;
+    peer_signature.to_binary().map_err(MessageError::MessageFormatError)
+}
+
 /// Represents data that every message contains.
 /// As described in [RFC-0172](https://rfc.tari.com/RFC-0172_PeerToPeerMessagingProtocol.html#messaging-structure)
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
 pub struct MessageEnvelopeHeader {
     pub version: u8,
-    pub source: CommsPublicKey,
+    pub origin_source: CommsPublicKey,
+    pub peer_source: CommsPublicKey,
     pub dest: NodeDestination<CommsPublicKey>,
-    pub signature: Vec<u8>,
+    pub origin_signature: Vec<u8>,
+    pub peer_signature: Vec<u8>,
     pub flags: MessageFlags,
 }
 
 impl MessageEnvelopeHeader {
     /// Verify that the signature provided is valid for the given body
-    pub fn verify_signature(&self, body: &Frame) -> Result<bool, MessageError> {
-        crypto::verify(&self.source, self.signature.as_slice(), body)
+    pub fn verify_signatures(&self, body: Frame) -> Result<bool, MessageError> {
+        let origin_verif = crypto::verify(
+            &self.origin_source,
+            self.origin_signature.as_slice(),
+            origin_challenge(self.dest.clone(), body.clone())?,
+        )?;
+        let peer_verif = crypto::verify(
+            &self.peer_source,
+            self.peer_signature.as_slice(),
+            peer_challenge(self.origin_signature.clone(), body)?,
+        )?;
+        Ok(origin_verif & peer_verif)
     }
 }
 
@@ -81,15 +139,16 @@ impl MessageEnvelope {
             body = encrypt_envelope_body(&node_identity.secret_key, &dest_public_key, &body)?
         }
 
-        let signature = crypto::sign(&mut OsRng::new().unwrap(), node_identity.secret_key.clone(), &body)
-            .map_err(MessageError::SchnorrSignatureError)?;
-        let signature = signature.to_binary().map_err(MessageError::MessageFormatError)?;
+        let origin_signature = origin_signature(node_identity, dest.clone(), body.clone())?;
+        let peer_signature = peer_signature(node_identity, origin_signature.clone(), body.clone())?;
 
         let header = MessageEnvelopeHeader {
             version: MESSAGE_PROTOCOL_VERSION,
-            source: node_identity.identity.public_key.clone(),
+            origin_source: node_identity.identity.public_key.clone(),
+            peer_source: node_identity.identity.public_key.clone(),
             dest,
-            signature,
+            origin_signature,
+            peer_signature,
             flags,
         };
 
@@ -97,6 +156,29 @@ impl MessageEnvelope {
             vec![WIRE_PROTOCOL_VERSION],
             header.to_binary().map_err(MessageError::MessageFormatError)?,
             body,
+        ))
+    }
+
+    /// Modify and sign a forwarded MessageEnvelope
+    pub fn forward_construct(
+        node_identity: &NodeIdentity,
+        message_envelope: MessageEnvelope,
+    ) -> Result<Self, MessageError>
+    {
+        let mut message_envelope_header = message_envelope.deserialize_header()?;
+        message_envelope_header.peer_source = node_identity.identity.public_key.clone();
+        message_envelope_header.peer_signature = peer_signature(
+            node_identity,
+            message_envelope_header.origin_signature.clone(),
+            message_envelope.body_frame().clone(),
+        )?;
+
+        Ok(Self::new(
+            vec![WIRE_PROTOCOL_VERSION],
+            message_envelope_header
+                .to_binary()
+                .map_err(MessageError::MessageFormatError)?,
+            message_envelope.body_frame().clone(),
         ))
     }
 
@@ -120,6 +202,21 @@ impl MessageEnvelope {
         &self.frames[2]
     }
 
+    /// Returns the frame that is expected to be body frame
+    pub fn decrypted_body_frame<PK>(
+        &self,
+        dest_secret_key: &PK::K,
+        source_public_key: &PK,
+    ) -> Result<Frame, MessageError>
+    where
+        PK: PublicKey + DiffieHellmanSharedSecret<PK = PK>,
+    {
+        let ecdh_shared_secret = PK::shared_secret(dest_secret_key, source_public_key).to_vec();
+        let decrypted_frame: Frame = CommsCipher::open_with_integral_nonce(self.body_frame(), &ecdh_shared_secret)
+            .map_err(MessageError::CipherError)?;
+        Ok(decrypted_frame)
+    }
+
     /// Returns the Message deserialized from the body frame
     pub fn deserialize_body(&self) -> Result<Message, MessageError> {
         Message::from_binary(self.body_frame()).map_err(Into::into)
@@ -134,10 +231,7 @@ impl MessageEnvelope {
     where
         PK: PublicKey + DiffieHellmanSharedSecret<PK = PK>,
     {
-        let ecdh_shared_secret = PK::shared_secret(dest_secret_key, source_public_key).to_vec();
-        let decrypted_frame: Frame = CommsCipher::open_with_integral_nonce(self.body_frame(), &ecdh_shared_secret)
-            .map_err(MessageError::CipherError)?;
-        Message::from_binary(&decrypted_frame).map_err(Into::into)
+        Message::from_binary(&self.decrypted_body_frame(dest_secret_key, source_public_key)?).map_err(Into::into)
     }
 
     /// This struct is consumed and the contained FrameSet is returned.
@@ -213,9 +307,11 @@ mod test {
         let (_sk, pk) = RistrettoPublicKey::random_keypair(&mut rand::OsRng::new().unwrap());
         let header = MessageEnvelopeHeader {
             version: 0,
-            source: pk,
+            origin_source: pk.clone(),
+            peer_source: pk,
             dest: NodeDestination::Unknown,
-            signature: vec![0],
+            origin_signature: vec![0],
+            peer_signature: vec![0],
             flags: MessageFlags::ENCRYPTED,
         };
 
@@ -248,11 +344,48 @@ mod test {
         .unwrap();
         assert_eq!("00", to_hex(envelope.version_frame()));
         let header = MessageEnvelopeHeader::from_binary(envelope.header_frame()).unwrap();
-        assert_eq!(dest_public_key, &header.source);
+        assert_eq!(dest_public_key, &header.origin_source);
         assert_eq!(MessageFlags::NONE, header.flags);
         assert_eq!(NodeDestination::Unknown, header.dest);
-        assert!(!header.signature.is_empty());
+        assert!(!header.origin_signature.is_empty());
         assert_eq!(&message_envelope_body_frame, envelope.body_frame());
+    }
+
+    #[test]
+    fn forward_construct() {
+        let origin_node_identity = Arc::new(NodeIdentity::random_for_test(None));
+        let peer_node_identity = Arc::new(NodeIdentity::random_for_test(None));
+        let dest_node_identity = Arc::new(NodeIdentity::random_for_test(None));
+
+        // Original MessageEnvelope
+        let message_envelope_body_frame = make_test_message_frame();
+        let origin_envelope = MessageEnvelope::construct(
+            &origin_node_identity,
+            dest_node_identity.identity.public_key.clone(),
+            NodeDestination::Unknown,
+            message_envelope_body_frame.clone(),
+            MessageFlags::ENCRYPTED,
+        )
+        .unwrap();
+
+        // Forwarded MessageEnvelope
+        let peer_envelope = MessageEnvelope::forward_construct(&peer_node_identity, origin_envelope).unwrap();;
+        let peer_header = MessageEnvelopeHeader::from_binary(peer_envelope.header_frame()).unwrap();
+
+        assert_eq!(peer_header.origin_source, origin_node_identity.identity.public_key);
+        assert_eq!(peer_header.peer_source, peer_node_identity.identity.public_key);
+        assert_eq!(
+            peer_envelope
+                .decrypted_body_frame(
+                    &dest_node_identity.secret_key,
+                    &origin_node_identity.identity.public_key
+                )
+                .unwrap(),
+            message_envelope_body_frame
+        );
+        assert!(peer_header
+            .verify_signatures(peer_envelope.body_frame().clone())
+            .unwrap());
     }
 
     #[test]
@@ -314,9 +447,9 @@ mod test {
 
         let header = envelope.deserialize_header().unwrap();
         let mut body = envelope.body_frame().clone();
-        assert!(header.verify_signature(&body).unwrap());
+        assert!(header.verify_signatures(body.clone()).unwrap());
 
         body.push(0);
-        assert!(!header.verify_signature(&body).unwrap());
+        assert!(!header.verify_signatures(body.clone()).unwrap());
     }
 }


### PR DESCRIPTION
## Description
- Added ability to send and handle DHT discover requests
- Added forwarding mechanic of private messages in comms handlers
- Added forward and discover Broadcast Strategies
- Added DiscoverMessage type
- Added forward_message function to OutboundMessageService
- Added a test where two nodes discover each other through peer nodes
- Made changes that allows the current nodes identity to be retrieved like an api or service 
- Modified MessageEnvelopeHeader so that it specifies the origin source and peer source and have signatures for both
- Changed signature verification to check the origin and peer signature

Closes #501, #502 and partially closes #499

## Motivation and Context
This will allow unknown nodes to discover each other using neighbouring peer nodes.

## How Has This Been Tested?
New tests have been added

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [x] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [x] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch
* [x] I ran `cargo-fmt --all` before pushing
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
