### PR TITLE
Increase timeout on sporadically failing tests

### DIFF
--- a/comms/src/outbound_message_service/outbound_message_pool/message_retry_service.rs
+++ b/comms/src/outbound_message_service/outbound_message_pool/message_retry_service.rs
@@ -290,7 +290,7 @@ mod test {
         let (tx, rx) = sync_channel(0);
         let handle = MessageRetryService::start(context, config.clone(), rx, InprocAddress::random());
         tx.send(RetryServiceMessage::Shutdown).unwrap();
-        handle.timeout_join(Duration::from_millis(10)).unwrap();
+        handle.timeout_join(Duration::from_millis(3000)).unwrap();
     }
 
     #[test]
@@ -317,7 +317,7 @@ mod test {
         }
         tx.send(RetryServiceMessage::Shutdown).unwrap();
 
-        handle.timeout_join(Duration::from_millis(10)).unwrap();
+        handle.timeout_join(Duration::from_millis(3000)).unwrap();
     }
 
     #[test]
@@ -350,6 +350,6 @@ mod test {
         assert_eq!(msg.message_frames()[0], "EXPECTED".as_bytes().to_vec());
 
         tx.send(RetryServiceMessage::Shutdown).unwrap();
-        handle.timeout_join(Duration::from_millis(10)).unwrap();
+        handle.timeout_join(Duration::from_millis(3000)).unwrap();
     }
 }

--- a/comms/tests/connection_manager/establisher.rs
+++ b/comms/tests/connection_manager/establisher.rs
@@ -205,9 +205,11 @@ fn establish_peer_connection_outbound() {
         .unwrap();
 
     other_peer_conn
-        .wait_listening_or_failure(&Duration::from_millis(200))
+        .wait_listening_or_failure(&Duration::from_millis(2000))
         .unwrap();
 
+    let address = other_peer_conn.get_connected_address().unwrap().to_string();
+    assert_ne!(address, "127.0.0.1:0");
     let address: NetAddress = other_peer_conn.get_connected_address().unwrap().into();
 
     let example_peer = factories::peer::create()
@@ -236,17 +238,17 @@ fn establish_peer_connection_outbound() {
     connection.send(vec!["TARI".as_bytes().to_vec()]).unwrap();
 
     connection.shutdown().unwrap();
-    connection.wait_disconnected(&Duration::from_millis(1000)).unwrap();
+    connection.wait_disconnected(&Duration::from_millis(3000)).unwrap();
 
     other_peer_conn.shutdown().unwrap();
-    other_peer_conn.wait_disconnected(&Duration::from_millis(1000)).unwrap();
+    other_peer_conn.wait_disconnected(&Duration::from_millis(3000)).unwrap();
     other_peer_conn_handle
-        .timeout_join(Duration::from_millis(1000))
+        .timeout_join(Duration::from_millis(3000))
         .unwrap();
 
     assert_eq!(msg_counter.count(), 2);
 
-    peer_conn_handle.timeout_join(Duration::from_millis(1000)).unwrap();
+    peer_conn_handle.timeout_join(Duration::from_millis(3000)).unwrap();
 
     clean_up_datastore(database_name);
 }
@@ -284,7 +286,7 @@ fn establish_peer_connection_inbound() {
         .unwrap();
 
     connection
-        .wait_listening_or_failure(&Duration::from_millis(2000))
+        .wait_listening_or_failure(&Duration::from_millis(3000))
         .unwrap();
     let address: NetAddress = connection.get_connected_address().unwrap().into();
 
@@ -301,19 +303,19 @@ fn establish_peer_connection_inbound() {
         .unwrap();
 
     other_peer_conn
-        .wait_connected_or_failure(&Duration::from_millis(2000))
+        .wait_connected_or_failure(&Duration::from_millis(3000))
         .unwrap();
     // Start sending messages
     other_peer_conn.send(vec!["HELLO".as_bytes().to_vec()]).unwrap();
     other_peer_conn.send(vec!["TARI".as_bytes().to_vec()]).unwrap();
     let _ = other_peer_conn.shutdown();
-    other_peer_conn.wait_disconnected(&Duration::from_millis(1000)).unwrap();
+    other_peer_conn.wait_disconnected(&Duration::from_millis(3000)).unwrap();
 
     assert_eq!(msg_counter.count(), 2);
 
-    peer_conn_handle.timeout_join(Duration::from_millis(1000)).unwrap();
+    peer_conn_handle.timeout_join(Duration::from_millis(3000)).unwrap();
     other_peer_conn_handle
-        .timeout_join(Duration::from_millis(1000))
+        .timeout_join(Duration::from_millis(3000))
         .unwrap();
 
     clean_up_datastore(database_name);


### PR DESCRIPTION
Theory goes: Circle CI shared infra will have widely varying
performance depending on current load. Timeouts should allow
enough time to complete.

Ref #445 