### PR TITLE
Implement a wallet Output Manager Service

### DIFF
--- a/base_layer/core/src/transaction.rs
+++ b/base_layer/core/src/transaction.rs
@@ -36,6 +36,7 @@ use crate::{
 use derive_error::Error;
 use digest::Input;
 use serde::{Deserialize, Serialize};
+use std::cmp::Ordering;
 use tari_crypto::{
     commitment::HomomorphicCommitmentFactory,
     keys::PublicKey as PK,
@@ -133,6 +134,27 @@ impl UnblindedOutput {
             ));
         }
         Ok(output)
+    }
+}
+
+// These implementations are used for order these outputs for UTXO selection which will be done by comparing the values
+impl Eq for UnblindedOutput {}
+
+impl PartialEq for UnblindedOutput {
+    fn eq(&self, other: &UnblindedOutput) -> bool {
+        self.value == other.value
+    }
+}
+
+impl PartialOrd<UnblindedOutput> for UnblindedOutput {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        self.value.partial_cmp(&other.value)
+    }
+}
+
+impl Ord for UnblindedOutput {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.value.cmp(&other.value)
     }
 }
 

--- a/base_layer/core/src/transaction_protocol/sender.rs
+++ b/base_layer/core/src/transaction_protocol/sender.rs
@@ -196,6 +196,18 @@ impl SenderTransactionProtocol {
         }
     }
 
+    /// This function will return the total value of outputs being sent to yourself in the transaction
+    pub fn get_amount_to_self(&self) -> Result<MicroTari, TPE> {
+        match &self.state {
+            SenderState::Initializing(info) |
+            SenderState::Finalizing(info) |
+            SenderState::SingleRoundMessageReady(info) |
+            SenderState::CollectingSingleSignature(info) => Ok(info.amount_to_self),
+            SenderState::FinalizedTransaction(_) => Err(TPE::InvalidStateError),
+            SenderState::Failed(_) => Err(TPE::InvalidStateError),
+        }
+    }
+
     /// Build the sender's message for the single-round protocol (one recipient) and move to next State
     pub fn build_single_round_message(&mut self) -> Result<SingleRoundSenderData, TPE> {
         match &self.state {

--- a/base_layer/keymanager/Cargo.toml
+++ b/base_layer/keymanager/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "keymanager"
+name = "tari_key_manager"
 version = "0.0.2"
 edition = "2018"
 

--- a/base_layer/wallet/Cargo.toml
+++ b/base_layer/wallet/Cargo.toml
@@ -9,6 +9,7 @@ tari_crypto = { path = "../../infrastructure/crypto", version = "^0.0" }
 tari_utilities = { path = "../../infrastructure/tari_util", version = "^0.0"}
 tari_comms = { path = "../../comms", version = "^0.0"}
 tari_p2p = {path = "../p2p", version = "^0.0"}
+tari_key_manager = {path = "../keymanager", version = "^0.0"}
 chrono = { version = "0.4.6", features = ["serde"]}
 derive-error = "0.0.4"
 digest = "0.8.0"
@@ -19,8 +20,8 @@ lmdb-zero = "0.4.4"
 tari_storage = { version = "0.0.2", path = "../../infrastructure/storage"}
 diesel_migrations =  "1.4"
 diesel = {version="1.4", features = ["sqlite", "serde_json", "chrono"]}
+rand = "0.5.5"
 
 [dev-dependencies]
-rand = "0.5"
 simple_logger = "1.3.0"
 

--- a/base_layer/wallet/src/lib.rs
+++ b/base_layer/wallet/src/lib.rs
@@ -5,6 +5,7 @@ extern crate diesel_migrations;
 
 #[macro_use]
 mod macros;
+pub mod output_manager_service;
 pub mod schema;
 pub mod text_message_service;
 pub mod transaction_manager;

--- a/base_layer/wallet/src/output_manager_service/error.rs
+++ b/base_layer/wallet/src/output_manager_service/error.rs
@@ -20,14 +20,22 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use rand::OsRng;
-use tari_crypto::common::Blake256;
+use derive_error::Error;
+use tari_core::transaction_protocol::TransactionProtocolError;
+use tari_utilities::ByteArrayError;
 
-/// Specify the Hash function for general hashing
-pub type HashDigest = Blake256;
-
-/// Specify the Hash function used by the key manager
-pub type KeyDigest = Blake256;
-
-/// Specify the Rng to use while building transactions for this wallet
-pub type TransactionRng = OsRng;
+#[derive(Debug, Error, PartialEq)]
+pub enum OutputManagerError {
+    #[error(msg_embedded, no_from, non_std)]
+    BuildError(String),
+    ByteArrayError(ByteArrayError),
+    TransactionProtocolError(TransactionProtocolError),
+    /// If an pending transaction does not exist to be confirmed
+    PendingTransactionNotFound,
+    /// Not all the transaction inputs and outputs are present to be confirmed
+    IncompleteTransaction,
+    /// Not enough funds to fulfill transaction
+    NotEnoughFunds,
+    /// Output already exists
+    DuplicateOutput,
+}

--- a/base_layer/wallet/src/output_manager_service/mod.rs
+++ b/base_layer/wallet/src/output_manager_service/mod.rs
@@ -20,14 +20,5 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use rand::OsRng;
-use tari_crypto::common::Blake256;
-
-/// Specify the Hash function for general hashing
-pub type HashDigest = Blake256;
-
-/// Specify the Hash function used by the key manager
-pub type KeyDigest = Blake256;
-
-/// Specify the Rng to use while building transactions for this wallet
-pub type TransactionRng = OsRng;
+pub mod error;
+pub mod output_manager_service;

--- a/base_layer/wallet/src/output_manager_service/output_manager_service.rs
+++ b/base_layer/wallet/src/output_manager_service/output_manager_service.rs
@@ -1,0 +1,413 @@
+// Copyright 2019. The Tari Project
+//
+// Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+// following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+// disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+// following disclaimer in the documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+// products derived from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+// INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+// WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+// USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+use crate::{
+    output_manager_service::error::OutputManagerError,
+    types::{HashDigest, KeyDigest, TransactionRng},
+};
+use chrono::{Duration, NaiveDateTime, Utc};
+use std::{collections::HashMap, sync::Mutex};
+use tari_core::{
+    fee::Fee,
+    tari_amount::MicroTari,
+    transaction::{OutputFeatures, TransactionInput, TransactionOutput, UnblindedOutput},
+    types::{PrivateKey, COMMITMENT_FACTORY, PROVER},
+    SenderTransactionProtocol,
+};
+use tari_crypto::keys::SecretKey;
+use tari_key_manager::keymanager::KeyManager;
+
+/// This service will manage a wallet's available outputs and the key manager that produces the keys for these outputs.
+/// The service will assemble transactions to be sent from the wallets available outputs and provide keys to receive
+/// outputs. When the outputs are detected on the blockchain the Transaction service will call this Service to confirm
+/// them to be moved to the spent and unspent output lists respectively.
+pub struct OutputManagerService {
+    key_manager: Mutex<KeyManager<PrivateKey, KeyDigest>>,
+    unspent_outputs: Vec<UnblindedOutput>,
+    spent_outputs: Vec<UnblindedOutput>,
+    pending_transactions: HashMap<u64, PendingTransactionOutputs>,
+}
+
+impl OutputManagerService {
+    pub fn new(master_key: PrivateKey, branch_seed: String, primary_key_index: usize) -> OutputManagerService {
+        OutputManagerService {
+            key_manager: Mutex::new(KeyManager::<PrivateKey, KeyDigest>::from(
+                master_key,
+                branch_seed,
+                primary_key_index,
+            )),
+            unspent_outputs: Vec::new(),
+            spent_outputs: Vec::new(),
+            pending_transactions: HashMap::new(),
+        }
+    }
+
+    /// Add an unblinded output to the unspent outputs list
+    pub fn add_output(&mut self, output: UnblindedOutput) -> Result<(), OutputManagerError> {
+        // Check it is not already present in the various output sets
+        if self.contains_output(&output) {
+            return Err(OutputManagerError::DuplicateOutput);
+        }
+
+        self.unspent_outputs.push(output);
+
+        Ok(())
+    }
+
+    /// Request a spending key to be used to accept a transaction from a sender.
+    pub fn get_recipient_spending_key(
+        &mut self,
+        tx_id: u64,
+        value: MicroTari,
+    ) -> Result<PrivateKey, OutputManagerError>
+    {
+        let mut km = acquire_lock!(self.key_manager);
+
+        let key = km.next_key()?.k;
+
+        self.pending_transactions.insert(tx_id, PendingTransactionOutputs {
+            tx_id,
+            outputs_to_be_spent: Vec::new(),
+            outputs_to_be_received: vec![UnblindedOutput {
+                value,
+                spending_key: key.clone(),
+                features: OutputFeatures::empty(),
+            }],
+            timestamp: Utc::now().naive_utc(),
+        });
+
+        Ok(key)
+    }
+
+    /// Confirm the reception of an expect transaction output. This will be called by the Transaction Service when it
+    /// detects the output on the blockchain
+    pub fn confirm_received_transaction_output(
+        &mut self,
+        tx_id: u64,
+        received_output: &TransactionOutput,
+    ) -> Result<(), OutputManagerError>
+    {
+        let pending_transaction = self
+            .pending_transactions
+            .get_mut(&tx_id)
+            .ok_or(OutputManagerError::PendingTransactionNotFound)?;
+
+        if pending_transaction.outputs_to_be_received.len() != 1 ||
+            pending_transaction.outputs_to_be_received[0]
+                .as_transaction_input(&COMMITMENT_FACTORY, OutputFeatures::empty())
+                .commitment !=
+                received_output.commitment
+        {
+            return Err(OutputManagerError::IncompleteTransaction);
+        }
+
+        self.unspent_outputs
+            .append(&mut pending_transaction.outputs_to_be_received);
+        let _ = self.pending_transactions.remove(&tx_id);
+        Ok(())
+    }
+
+    /// Prepare a Sender Transaction Protocol for the amount and fee_per_gram specified. If required a change output
+    /// will be produced.
+    pub fn prepare_transaction_to_send(
+        &mut self,
+        amount: MicroTari,
+        fee_per_gram: MicroTari,
+        lock_height: Option<u64>,
+    ) -> Result<SenderTransactionProtocol, OutputManagerError>
+    {
+        let mut rng = TransactionRng::new().unwrap();
+        let outputs = self.select_outputs(amount, fee_per_gram, UTXOSelectionStrategy::Smallest)?;
+        let total = outputs.iter().fold(MicroTari::from(0), |acc, x| acc + x.value);
+
+        let offset = PrivateKey::random(&mut rng);
+        let nonce = PrivateKey::random(&mut rng);
+
+        let mut builder = SenderTransactionProtocol::builder(1);
+        builder
+            .with_lock_height(lock_height.unwrap_or(0))
+            .with_fee_per_gram(fee_per_gram)
+            .with_offset(offset.clone())
+            .with_private_nonce(nonce.clone())
+            .with_amount(0, amount);
+
+        for uo in outputs.iter() {
+            builder.with_input(
+                uo.as_transaction_input(&COMMITMENT_FACTORY, OutputFeatures::empty()),
+                uo.clone(),
+            );
+        }
+
+        let fee_without_change = Fee::calculate(fee_per_gram, outputs.len(), 1);
+        let mut change_key: Option<PrivateKey> = None;
+        // If the input values > the amount to be sent + fees_without_change then we will need to include a change
+        // output
+        if total > amount + fee_without_change {
+            let mut km = acquire_lock!(self.key_manager);
+            let key = km.next_key()?.k;
+            change_key = Some(key.clone());
+            builder.with_change_secret(key);
+        }
+
+        let stp = builder
+            .build::<HashDigest>(&PROVER, &COMMITMENT_FACTORY)
+            .map_err(|e| OutputManagerError::BuildError(e.message))?;
+
+        // The Transaction Protocol built successfully so we will pull the unspent outputs out of the unspent list and
+        // store them until the transaction times out OR is confirmed
+        let mut outputs_to_be_spent = self.unspent_outputs.clone();
+        outputs_to_be_spent.retain(|uo| outputs.iter().any(|o| uo.spending_key == o.spending_key));
+
+        let mut pending_transaction = PendingTransactionOutputs {
+            tx_id: stp.get_tx_id()?,
+            outputs_to_be_spent,
+            outputs_to_be_received: Vec::new(),
+            timestamp: Utc::now().naive_utc(),
+        };
+
+        self.unspent_outputs
+            .retain(|uo| !outputs.iter().any(|o| uo.spending_key == o.spending_key));
+
+        // If a change output was created add it to the pending_outputs list.
+        if let Some(key) = change_key {
+            pending_transaction.outputs_to_be_received.push(UnblindedOutput {
+                value: stp.get_amount_to_self()?,
+                spending_key: key,
+                features: OutputFeatures::empty(),
+            })
+        }
+
+        self.pending_transactions
+            .insert(pending_transaction.tx_id, pending_transaction);
+
+        Ok(stp)
+    }
+
+    /// Confirm that a received or sent transaction and its outputs have been detected on the base chain. This will
+    /// usually be called by the Transaction Service which monitors the base chain.
+    pub fn confirm_sent_transaction(
+        &mut self,
+        tx_id: u64,
+        spent_outputs: &Vec<TransactionInput>,
+        received_outputs: &Vec<TransactionOutput>,
+    ) -> Result<(), OutputManagerError>
+    {
+        let pending_transaction = self
+            .pending_transactions
+            .get_mut(&tx_id)
+            .ok_or(OutputManagerError::PendingTransactionNotFound)?;
+
+        // Check that the set of TransactionInputs and TransactionOutputs provided contain all the spent and received
+        // outputs in the PendingTransaction
+        // Assumption: There will only be ONE extra output which belongs to the receiver
+        if spent_outputs.len() != pending_transaction.outputs_to_be_spent.len() ||
+            !pending_transaction.outputs_to_be_spent.iter().fold(true, |acc, i| {
+                acc && spent_outputs.iter().any(|o| {
+                    o.commitment ==
+                        i.as_transaction_input(&COMMITMENT_FACTORY, OutputFeatures::empty())
+                            .commitment
+                })
+            }) ||
+            received_outputs.len() - 1 != pending_transaction.outputs_to_be_received.len() ||
+            !pending_transaction.outputs_to_be_received.iter().fold(true, |acc, i| {
+                acc && received_outputs.iter().any(|o| {
+                    o.commitment ==
+                        i.as_transaction_input(&COMMITMENT_FACTORY, OutputFeatures::empty())
+                            .commitment
+                })
+            })
+        {
+            return Err(OutputManagerError::IncompleteTransaction);
+        }
+
+        self.unspent_outputs
+            .append(&mut pending_transaction.outputs_to_be_received);
+        self.spent_outputs.append(&mut pending_transaction.outputs_to_be_spent);
+        let _ = self.pending_transactions.remove(&tx_id);
+
+        Ok(())
+    }
+
+    /// Cancel a pending transaction and place the encumbered outputs back into the unspent pool
+    pub fn cancel_transaction(&mut self, tx_id: u64) -> Result<(), OutputManagerError> {
+        let pending_transaction = self
+            .pending_transactions
+            .get_mut(&tx_id)
+            .ok_or(OutputManagerError::PendingTransactionNotFound)?;
+
+        self.unspent_outputs
+            .append(&mut pending_transaction.outputs_to_be_spent);
+
+        Ok(())
+    }
+
+    /// Go through the pending transaction and if any have existed longer than the specified duration, cancel them
+    pub fn timeout_pending_transactions(&mut self, period: Duration) -> Result<(), OutputManagerError> {
+        let mut transactions_to_be_cancelled = Vec::new();
+        for (tx_id, pt) in self.pending_transactions.iter() {
+            if pt.timestamp + period < Utc::now().naive_utc() {
+                transactions_to_be_cancelled.push(tx_id.clone());
+            }
+        }
+
+        for t in transactions_to_be_cancelled {
+            self.cancel_transaction(t.clone())?
+        }
+
+        Ok(())
+    }
+
+    /// Select which outputs to use to send a transaction of the specified amount. Use the specified selection strategy
+    /// to choose the outputs
+    fn select_outputs(
+        &mut self,
+        amount: MicroTari,
+        fee_per_gram: MicroTari,
+        strategy: UTXOSelectionStrategy,
+    ) -> Result<Vec<UnblindedOutput>, OutputManagerError>
+    {
+        let mut outputs = Vec::new();
+        let mut total = MicroTari::from(0);
+        let mut fee_without_change = MicroTari::from(0);
+        let mut fee_with_change = MicroTari::from(0);
+
+        match strategy {
+            UTXOSelectionStrategy::Smallest => {
+                self.unspent_outputs.sort();
+                for o in self.unspent_outputs.iter() {
+                    outputs.push(o.clone());
+                    total += o.value.clone();
+                    // I am assuming that the only output will be the payment output and change if required
+                    fee_without_change = Fee::calculate(fee_per_gram, outputs.len(), 1);
+                    fee_with_change = Fee::calculate(fee_per_gram, outputs.len(), 2);
+
+                    if total == amount + fee_without_change || total >= amount + fee_with_change {
+                        break;
+                    }
+                }
+            },
+        }
+
+        if (total != amount + fee_without_change) && (total < amount + fee_with_change) {
+            return Err(OutputManagerError::NotEnoughFunds);
+        }
+
+        Ok(outputs)
+    }
+
+    pub fn pending_transactions(&self) -> &HashMap<u64, PendingTransactionOutputs> {
+        &self.pending_transactions
+    }
+
+    pub fn spent_outputs(&self) -> &Vec<UnblindedOutput> {
+        &self.spent_outputs
+    }
+
+    pub fn unspent_outputs(&self) -> &Vec<UnblindedOutput> {
+        &self.unspent_outputs
+    }
+
+    /// Utility function to determine if an output exists in the spent, unspent or pending output sets
+    pub fn contains_output(&self, output: &UnblindedOutput) -> bool {
+        self.unspent_outputs
+            .iter()
+            .any(|o| o.value == output.value && o.spending_key == output.spending_key) ||
+            self.spent_outputs
+                .iter()
+                .any(|o| o.value == output.value && o.spending_key == output.spending_key) ||
+            self.pending_transactions.values().fold(false, |acc, pt| {
+                acc || pt
+                    .outputs_to_be_spent
+                    .iter()
+                    .chain(pt.outputs_to_be_received.iter())
+                    .any(|o| o.value == output.value && o.spending_key == output.spending_key)
+            })
+    }
+}
+
+/// Holds the outputs that have been selected for a given pending transaction waiting for confirmation
+pub struct PendingTransactionOutputs {
+    pub tx_id: u64,
+    pub outputs_to_be_spent: Vec<UnblindedOutput>,
+    pub outputs_to_be_received: Vec<UnblindedOutput>,
+    pub timestamp: NaiveDateTime,
+}
+
+/// Different UTXO selection strategies for choosing which UTXO's are used to fulfill a transaction
+/// TODO Investigate and implement more optimal strategies
+pub enum UTXOSelectionStrategy {
+    // Start from the smallest UTXOs and work your way up until the amount is covered. Main benefit is removing small
+    // UTXOs from the blockchain, con is that it costs more in fees
+    Smallest,
+}
+
+#[cfg(test)]
+mod test {
+    use crate::output_manager_service::output_manager_service::{OutputManagerService, PendingTransactionOutputs};
+    use chrono::Utc;
+    use rand::{CryptoRng, Rng, RngCore};
+    use tari_core::{
+        tari_amount::MicroTari,
+        transaction::UnblindedOutput,
+        types::{PrivateKey, PublicKey},
+    };
+    use tari_crypto::keys::{PublicKey as PublicKeyTrait, SecretKey};
+
+    fn make_output<R: Rng + CryptoRng>(rng: &mut R, val: MicroTari) -> UnblindedOutput {
+        let key = PrivateKey::random(rng);
+        UnblindedOutput::new(val, key, None)
+    }
+
+    #[test]
+    fn test_contains_output_function() {
+        let mut rng = rand::OsRng::new().unwrap();
+        let (secret_key, _public_key) = PublicKey::random_keypair(&mut rng);
+
+        let mut oms = OutputManagerService::new(secret_key, "".to_string(), 0);
+
+        for _i in 0..3 {
+            let uo = make_output(&mut rng.clone(), MicroTari::from(100 + rng.next_u64() % 1000));
+            oms.add_output(uo).unwrap();
+        }
+
+        let uo1 = make_output(&mut rng.clone(), MicroTari::from(100 + rng.next_u64() % 1000));
+
+        assert!(!oms.contains_output(&uo1));
+        oms.add_output(uo1.clone()).unwrap();
+        assert!(oms.contains_output(&uo1));
+
+        let uo2 = make_output(&mut rng.clone(), MicroTari::from(100 + rng.next_u64() % 1000));
+        assert!(!oms.contains_output(&uo2));
+        oms.spent_outputs.push(uo2.clone());
+        assert!(oms.contains_output(&uo2));
+
+        let uo3 = make_output(&mut rng.clone(), MicroTari::from(100 + rng.next_u64() % 1000));
+        assert!(!oms.contains_output(&uo3));
+        oms.pending_transactions.insert(1, PendingTransactionOutputs {
+            tx_id: 1,
+            outputs_to_be_received: vec![uo3.clone()],
+            outputs_to_be_spent: Vec::new(),
+            timestamp: Utc::now().naive_utc(),
+        });
+        assert!(oms.contains_output(&uo3));
+    }
+}

--- a/base_layer/wallet/tests/mod.rs
+++ b/base_layer/wallet/tests/mod.rs
@@ -20,6 +20,7 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+pub mod output_manager_service;
 pub mod support;
 pub mod text_message_service;
 pub mod wallet;

--- a/base_layer/wallet/tests/output_manager_service/mod.rs
+++ b/base_layer/wallet/tests/output_manager_service/mod.rs
@@ -1,0 +1,290 @@
+// Copyright 2019. The Tari Project
+//
+// Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+// following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+// disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+// following disclaimer in the documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+// products derived from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+// INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+// WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+// USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+use crate::support::utils::{make_input, TestParams};
+use rand::RngCore;
+use std::{thread, time::Duration};
+use tari_core::{
+    fee::Fee,
+    tari_amount::MicroTari,
+    transaction::{KernelFeatures, OutputFeatures, TransactionOutput, UnblindedOutput},
+    transaction_protocol::single_receiver::SingleReceiverTransactionProtocol,
+    types::{PrivateKey, PublicKey, RangeProof, COMMITMENT_FACTORY, PROVER},
+};
+use tari_crypto::{
+    commitment::HomomorphicCommitmentFactory,
+    keys::{PublicKey as PublicKeyTrait, SecretKey},
+    range_proof::RangeProofService,
+};
+use tari_utilities::ByteArray;
+use tari_wallet::output_manager_service::{error::OutputManagerError, output_manager_service::OutputManagerService};
+
+#[test]
+fn sending_transaction_and_confirmation() {
+    let mut rng = rand::OsRng::new().unwrap();
+    let (secret_key, _public_key) = PublicKey::random_keypair(&mut rng);
+
+    let mut oms = OutputManagerService::new(secret_key, "".to_string(), 0);
+
+    let (_ti, uo) = make_input(&mut rng.clone(), MicroTari::from(100 + rng.next_u64() % 1000));
+    oms.add_output(uo.clone()).unwrap();
+    assert_eq!(oms.add_output(uo), Err(OutputManagerError::DuplicateOutput));
+    let num_outputs = 20;
+    for _i in 0..num_outputs {
+        let (_ti, uo) = make_input(&mut rng.clone(), MicroTari::from(100 + rng.next_u64() % 1000));
+        oms.add_output(uo).unwrap();
+    }
+
+    let mut stp = oms
+        .prepare_transaction_to_send(MicroTari::from(1000), MicroTari::from(20), None)
+        .unwrap();
+
+    let sender_tx_id = stp.get_tx_id().unwrap();
+    let mut num_change = 0;
+    // Is there change? Unlikely not to be but the random amounts MIGHT produce a no change output situation
+    if stp.get_amount_to_self().unwrap() > MicroTari::from(0) {
+        let pt = oms.pending_transactions();
+        assert_eq!(pt.len(), 1);
+        assert_eq!(
+            pt.get(&sender_tx_id).unwrap().outputs_to_be_received[0].value,
+            stp.get_amount_to_self().unwrap()
+        );
+        num_change = 1;
+    }
+
+    let msg = stp.build_single_round_message().unwrap();
+
+    let b = TestParams::new(&mut rng);
+
+    let recv_info = SingleReceiverTransactionProtocol::create(
+        &msg,
+        b.nonce,
+        b.spend_key,
+        OutputFeatures::empty(),
+        &PROVER,
+        &COMMITMENT_FACTORY,
+    )
+    .unwrap();
+
+    stp.add_single_recipient_info(recv_info.clone(), &PROVER).unwrap();
+
+    stp.finalize(KernelFeatures::empty(), &PROVER, &COMMITMENT_FACTORY)
+        .unwrap();
+
+    let tx = stp.get_transaction().unwrap();
+
+    oms.confirm_sent_transaction(sender_tx_id, &tx.body.inputs, &tx.body.outputs)
+        .unwrap();
+
+    assert_eq!(oms.pending_transactions().len(), 0);
+    assert_eq!(oms.spent_outputs().len(), tx.body.inputs.len());
+    assert_eq!(
+        oms.unspent_outputs().len(),
+        num_outputs + 1 - oms.spent_outputs().len() + num_change
+    );
+}
+
+#[test]
+fn send_not_enough_funds() {
+    let mut rng = rand::OsRng::new().unwrap();
+    let (secret_key, _public_key) = PublicKey::random_keypair(&mut rng);
+
+    let mut oms = OutputManagerService::new(secret_key, "".to_string(), 0);
+
+    let num_outputs = 20;
+    for _i in 0..num_outputs {
+        let (_ti, uo) = make_input(&mut rng.clone(), MicroTari::from(100 + rng.next_u64() % 1000));
+        oms.add_output(uo).unwrap();
+    }
+
+    match oms.prepare_transaction_to_send(MicroTari::from(num_outputs * 2000), MicroTari::from(20), None) {
+        Err(OutputManagerError::NotEnoughFunds) => assert!(true),
+        _ => assert!(false),
+    }
+}
+
+#[test]
+fn send_no_change() {
+    let mut rng = rand::OsRng::new().unwrap();
+    let (secret_key, _public_key) = PublicKey::random_keypair(&mut rng);
+
+    let mut oms = OutputManagerService::new(secret_key, "".to_string(), 0);
+    let fee_per_gram = MicroTari::from(20);
+    let fee_without_change = Fee::calculate(fee_per_gram, 2, 1);
+    let key1 = PrivateKey::random(&mut rng);
+    let value1 = 500;
+    oms.add_output(UnblindedOutput::new(MicroTari::from(value1), key1, None))
+        .unwrap();
+    let key2 = PrivateKey::random(&mut rng);
+    let value2 = 800;
+    oms.add_output(UnblindedOutput::new(MicroTari::from(value2), key2, None))
+        .unwrap();
+
+    let mut stp = oms
+        .prepare_transaction_to_send(
+            MicroTari::from(value1 + value2) - fee_without_change,
+            MicroTari::from(20),
+            None,
+        )
+        .unwrap();
+
+    let sender_tx_id = stp.get_tx_id().unwrap();
+    assert_eq!(stp.get_amount_to_self().unwrap(), MicroTari::from(0));
+    assert_eq!(oms.pending_transactions().len(), 1);
+
+    let msg = stp.build_single_round_message().unwrap();
+
+    let b = TestParams::new(&mut rng);
+
+    let recv_info = SingleReceiverTransactionProtocol::create(
+        &msg,
+        b.nonce,
+        b.spend_key,
+        OutputFeatures::empty(),
+        &PROVER,
+        &COMMITMENT_FACTORY,
+    )
+    .unwrap();
+
+    stp.add_single_recipient_info(recv_info.clone(), &PROVER).unwrap();
+
+    stp.finalize(KernelFeatures::empty(), &PROVER, &COMMITMENT_FACTORY)
+        .unwrap();
+
+    let tx = stp.get_transaction().unwrap();
+
+    oms.confirm_sent_transaction(sender_tx_id, &tx.body.inputs, &tx.body.outputs)
+        .unwrap();
+
+    assert_eq!(oms.pending_transactions().len(), 0);
+    assert_eq!(oms.spent_outputs().len(), tx.body.inputs.len());
+    assert_eq!(oms.unspent_outputs().len(), 0);
+}
+
+#[test]
+fn send_not_enough_for_change() {
+    let mut rng = rand::OsRng::new().unwrap();
+    let (secret_key, _public_key) = PublicKey::random_keypair(&mut rng);
+
+    let mut oms = OutputManagerService::new(secret_key, "".to_string(), 0);
+    let fee_per_gram = MicroTari::from(20);
+    let fee_without_change = Fee::calculate(fee_per_gram, 2, 1);
+    let key1 = PrivateKey::random(&mut rng);
+    let value1 = 500;
+    oms.add_output(UnblindedOutput::new(MicroTari::from(value1), key1, None))
+        .unwrap();
+    let key2 = PrivateKey::random(&mut rng);
+    let value2 = 800;
+    oms.add_output(UnblindedOutput::new(MicroTari::from(value2), key2, None))
+        .unwrap();
+
+    match oms.prepare_transaction_to_send(
+        MicroTari::from(value1 + value2 + 1) - fee_without_change,
+        MicroTari::from(20),
+        None,
+    ) {
+        Err(OutputManagerError::NotEnoughFunds) => assert!(true),
+        _ => assert!(false),
+    }
+}
+
+#[test]
+fn receiving_and_confirmation() {
+    let mut rng = rand::OsRng::new().unwrap();
+    let (secret_key, _public_key) = PublicKey::random_keypair(&mut rng);
+
+    let mut oms = OutputManagerService::new(secret_key, "".to_string(), 0);
+    let value = MicroTari::from(5000);
+    let recv_key = oms.get_recipient_spending_key(1, value).unwrap();
+    assert_eq!(oms.unspent_outputs().len(), 0);
+    assert_eq!(oms.pending_transactions().len(), 1);
+
+    let commitment = COMMITMENT_FACTORY.commit(&recv_key, &value.into());
+    let rr = PROVER.construct_proof(&recv_key, value.into()).unwrap();
+    let output = TransactionOutput::new(
+        OutputFeatures::COINBASE_OUTPUT,
+        commitment,
+        RangeProof::from_bytes(&rr).unwrap(),
+    );
+
+    oms.confirm_received_transaction_output(1, &output).unwrap();
+
+    assert_eq!(oms.pending_transactions().len(), 0);
+    assert_eq!(oms.unspent_outputs().len(), 1);
+}
+
+#[test]
+fn cancel_transaction() {
+    let mut rng = rand::OsRng::new().unwrap();
+    let (secret_key, _public_key) = PublicKey::random_keypair(&mut rng);
+
+    let mut oms = OutputManagerService::new(secret_key, "".to_string(), 0);
+
+    let num_outputs = 20;
+    for _i in 0..num_outputs {
+        let (_ti, uo) = make_input(&mut rng.clone(), MicroTari::from(100 + rng.next_u64() % 1000));
+        oms.add_output(uo).unwrap();
+    }
+    let stp = oms
+        .prepare_transaction_to_send(MicroTari::from(1000), MicroTari::from(20), None)
+        .unwrap();
+
+    assert_eq!(
+        oms.cancel_transaction(1),
+        Err(OutputManagerError::PendingTransactionNotFound)
+    );
+
+    oms.cancel_transaction(stp.get_tx_id().unwrap()).unwrap();
+
+    assert_eq!(oms.unspent_outputs().len(), num_outputs);
+}
+
+#[test]
+fn timeout_transaction() {
+    let mut rng = rand::OsRng::new().unwrap();
+    let (secret_key, _public_key) = PublicKey::random_keypair(&mut rng);
+
+    let mut oms = OutputManagerService::new(secret_key, "".to_string(), 0);
+
+    let num_outputs = 20;
+    for _i in 0..num_outputs {
+        let (_ti, uo) = make_input(&mut rng.clone(), MicroTari::from(100 + rng.next_u64() % 1000));
+        oms.add_output(uo).unwrap();
+    }
+    let _stp = oms
+        .prepare_transaction_to_send(MicroTari::from(1000), MicroTari::from(20), None)
+        .unwrap();
+
+    let remaining_outputs = oms.unspent_outputs().len();
+
+    thread::sleep(Duration::from_millis(2));
+
+    oms.timeout_pending_transactions(chrono::Duration::milliseconds(10))
+        .unwrap();
+
+    assert_eq!(oms.unspent_outputs().len(), remaining_outputs);
+
+    oms.timeout_pending_transactions(chrono::Duration::milliseconds(1))
+        .unwrap();
+
+    assert_eq!(oms.unspent_outputs().len(), num_outputs);
+}


### PR DESCRIPTION
## Description
This PR adds the backend of the Wallet’s output manager service that maintains the list of spent and unspent outputs for the wallet. The service contains the following functionality:
- Keeps track of unspent and spent UnblindedOutputs
- Maintains the Wallet’s Key Manager to produce keys for sending and receiving outputs
- Produce SenderTransactionProtocols by selecting outputs based on a specified strategy
- Keep track of PendingTransactions and their constituent outputs
    - Allow for the Confirmations of the transactions which moves Outputs into the Spent/Unspent lists respectively
    - Allow for cancellation of transactions
    - Allow for timeout of transactions

## Motivation and Context
Closes https://github.com/tari-project/tari/issues/553

## How Has This Been Tested?
Tests provided 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [x] New Tests
* [x] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch
* [x] I ran `cargo-fmt --all` before pushing
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
