### PR TITLE
Improve in_network_region to work for unknown NodeIds

### DIFF
--- a/base_layer/p2p/src/services/executor.rs
+++ b/base_layer/p2p/src/services/executor.rs
@@ -76,6 +76,7 @@ impl ServiceExecutor {
             let service_context = ServiceContext {
                 oms: comms_services.outbound_message_service(),
                 peer_manager: comms_services.peer_manager(),
+                node_identity: comms_services.node_identity(),
                 receiver,
                 routes: comms_services.routes().clone(),
                 zmq_context: comms_services.zmq_context().clone(),
@@ -152,6 +153,7 @@ impl ServiceExecutor {
 pub struct ServiceContext {
     oms: Arc<OutboundMessageService>,
     peer_manager: Arc<PeerManager>,
+    node_identity: Arc<NodeIdentity>,
     receiver: Receiver<ServiceControlMessage>,
     routes: CommsRoutes<TariMessageType>,
     zmq_context: ZmqContext,
@@ -182,7 +184,7 @@ impl ServiceContext {
 
     /// Retrieve and `Arc` of the NodeIdentity. Used for managing the current Nodes Identity.
     pub fn node_identity(&self) -> Arc<NodeIdentity> {
-        self.comms_services.node_identity.clone()
+        Arc::clone(&self.node_identity)
     }
 
     /// Create a [DomainConnector] which listens for a particular [TariMessageType].

--- a/base_layer/p2p/tests/dht/mod.rs
+++ b/base_layer/p2p/tests/dht/mod.rs
@@ -175,7 +175,7 @@ fn test_dht_discover_propagation() {
     // Setup Node A
     let node_A_tmpdir = TempDir::new(random_string(8).as_str()).unwrap();
     let node_A_database_name = "node_A";
-    let (node_A_services, node_A_dht_service_api) = setup_dht_service(
+    let (node_A_services, node_A_dht_service_api, _comms_A) = setup_dht_service(
         node_A_identity.clone(),
         create_peer_storage(&node_A_tmpdir, node_A_database_name, vec![node_B_identity
             .clone()
@@ -184,7 +184,7 @@ fn test_dht_discover_propagation() {
     // Setup Node B
     let node_B_tmpdir = TempDir::new(random_string(8).as_str()).unwrap();
     let node_B_database_name = "node_B";
-    let (node_B_services, _node_B_dht_service_api) = setup_dht_service(
+    let (node_B_services, _node_B_dht_service_api, _comms_B) = setup_dht_service(
         node_B_identity.clone(),
         create_peer_storage(&node_B_tmpdir, node_B_database_name, vec![
             node_A_identity.clone().into(),
@@ -194,7 +194,7 @@ fn test_dht_discover_propagation() {
     // Setup Node C
     let node_C_tmpdir = TempDir::new(random_string(8).as_str()).unwrap();
     let node_C_database_name = "node_C";
-    let (node_C_services, _node_C_dht_service_api) = setup_dht_service(
+    let (node_C_services, _node_C_dht_service_api, _comms_C) = setup_dht_service(
         node_C_identity.clone(),
         create_peer_storage(&node_C_tmpdir, node_C_database_name, vec![
             node_B_identity.clone().into(),
@@ -204,7 +204,7 @@ fn test_dht_discover_propagation() {
     // Setup Node D
     let node_D_tmpdir = TempDir::new(random_string(8).as_str()).unwrap();
     let node_D_database_name = "node_D";
-    let (node_D_services, _node_D_dht_service_api) = setup_dht_service(
+    let (node_D_services, _node_D_dht_service_api, _comms_D) = setup_dht_service(
         node_D_identity.clone(),
         create_peer_storage(&node_D_tmpdir, node_D_database_name, vec![node_C_identity
             .clone()

--- a/comms/src/builder/builder.rs
+++ b/comms/src/builder/builder.rs
@@ -420,7 +420,7 @@ pub struct CommsServices<MType> {
     control_service_handle: Option<ControlServiceHandle>,
     inbound_message_broker: Arc<InboundMessageBroker<MType>>,
     outbound_message_pool: OutboundMessagePool,
-    pub node_identity: Arc<NodeIdentity>,
+    node_identity: Arc<NodeIdentity>,
     connection_manager: Arc<ConnectionManager>,
     peer_manager: Arc<PeerManager>,
 }
@@ -436,6 +436,10 @@ where
 
     pub fn peer_manager(&self) -> Arc<PeerManager> {
         Arc::clone(&self.peer_manager)
+    }
+
+    pub fn node_identity(&self) -> Arc<NodeIdentity> {
+        Arc::clone(&self.node_identity)
     }
 
     pub fn outbound_message_service(&self) -> Arc<OutboundMessageService> {

--- a/comms/src/peer_manager/node_id.rs
+++ b/comms/src/peer_manager/node_id.rs
@@ -64,6 +64,10 @@ impl NodeDistance {
         }
         nd
     }
+
+    pub fn max_distance() -> NodeDistance {
+        NodeDistance([255; NODE_ID_ARRAY_SIZE])
+    }
 }
 
 impl PartialEq for NodeDistance {


### PR DESCRIPTION
## Description
- Modified in_network_region to work for unknown NodeIDs
- Added a test for the in_network_region function
- Fixed merge issue on development

## Motivation and Context
The in_network_region function is used by the DHTService and for message forwarding

## How Has This Been Tested?
A test has been added

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [x] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch
* [x] I ran `cargo-fmt --all` before pushing
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
