### PR TITLE
Fix compile error that snuck into development

### DIFF
--- a/base_layer/p2p/tests/dht/mod.rs
+++ b/base_layer/p2p/tests/dht/mod.rs
@@ -36,6 +36,7 @@ use tari_comms::{
 use tari_p2p::{
     dht_service::{DHTService, DHTServiceApi},
     services::{ServiceExecutor, ServiceRegistry},
+    tari_message::TariMessageType,
 };
 use tari_storage::lmdb_store::LMDBBuilder;
 use tempdir::TempDir;

--- a/base_layer/p2p/tests/ping_pong/mod.rs
+++ b/base_layer/p2p/tests/ping_pong/mod.rs
@@ -37,6 +37,7 @@ use tari_comms::{
 use tari_p2p::{
     ping_pong::{PingPongService, PingPongServiceApi},
     services::{ServiceExecutor, ServiceRegistry},
+    tari_message::TariMessageType,
 };
 use tari_storage::lmdb_store::LMDBBuilder;
 use tempdir::TempDir;

--- a/base_layer/wallet/tests/support/comms_and_services.rs
+++ b/base_layer/wallet/tests/support/comms_and_services.rs
@@ -28,7 +28,10 @@ use tari_comms::{
     peer_manager::{NodeIdentity, Peer},
     CommsBuilder,
 };
-use tari_p2p::services::{ServiceExecutor, ServiceRegistry};
+use tari_p2p::{
+    services::{ServiceExecutor, ServiceRegistry},
+    tari_message::TariMessageType,
+};
 use tari_storage::lmdb_store::LMDBDatabase;
 use tari_wallet::text_message_service::{TextMessageService, TextMessageServiceApi};
 


### PR DESCRIPTION
```
error[E0412]: cannot find type `TariMessageType` in this scope
  --> base_layer/p2p/tests/dht/mod.rs:68:62
   |
68 | ) -> (ServiceExecutor, Arc<DHTServiceApi>, Arc<CommsServices<TariMessageType>>)
   |                                                              ^^^^^^^^^^^^^^^ not found in this scope
help: possible candidate is found in another module, you can import it into scope
   |
24 | use tari_p2p::tari_message::TariMessageType;
   |

error[E0412]: cannot find type `TariMessageType` in this scope
  --> base_layer/p2p/tests/ping_pong/mod.rs:72:23
   |
72 |     Arc<CommsServices<TariMessageType>>,
   |                       ^^^^^^^^^^^^^^^ not found in this scope
help: possible candidate is found in another module, you can import it into scope
   |
25 | use tari_p2p::tari_message::TariMessageType;
   |
```