### PR TITLE
Limit number of active peer connections

### DIFF
--- a/base_layer/p2p/src/services/executor.rs
+++ b/base_layer/p2p/src/services/executor.rs
@@ -74,7 +74,6 @@ impl ServiceExecutor {
             senders.push(sender);
 
             let service_context = ServiceContext {
-                node_identity: Arc::clone(&comms_services.node_identity),
                 oms: comms_services.outbound_message_service(),
                 peer_manager: comms_services.peer_manager(),
                 node_identity: comms_services.node_identity(),
@@ -152,7 +151,6 @@ impl ServiceExecutor {
 /// access the outbound message service and create [DomainConnector]s to receive comms messages of
 /// a particular [TariMessageType].
 pub struct ServiceContext {
-    node_identity: Arc<NodeIdentity>,
     oms: Arc<OutboundMessageService>,
     peer_manager: Arc<PeerManager>,
     node_identity: Arc<NodeIdentity>,

--- a/comms/src/connection/peer_connection/connection.rs
+++ b/comms/src/connection/peer_connection/connection.rs
@@ -286,22 +286,25 @@ pub struct PeerConnection {
 }
 
 impl PeerConnection {
-    /// Returns true if the PeerConnection is in a connected state, otherwise false
+    /// Returns true if the PeerConnection is in an `Initial` state, otherwise false
+    is_state!(is_initial, Initial);
+
+    /// Returns true if the PeerConnection is in a `Connected` state, otherwise false
     is_state!(is_connected, Connected(_));
 
-    /// Returns true if the PeerConnection is in a shutdown state, otherwise false
+    /// Returns true if the PeerConnection is in a `Shutdown` state, otherwise false
     is_state!(is_shutdown, Shutdown);
 
-    /// Returns true if the PeerConnection is in a listening state, otherwise false
+    /// Returns true if the PeerConnection is in a `Listening` state, otherwise false
     is_state!(is_listening, Listening(_));
 
     /// Returns true if the PeerConnection is in a `Disconnected`/`Shutdown`/`Failed` state, otherwise false
     is_state!(is_disconnected, Disconnected | Shutdown | Failed(_));
 
-    /// Returns true if the PeerConnection is in a failed state, otherwise false
+    /// Returns true if the PeerConnection is in a `Failed` state, otherwise false
     is_state!(is_failed, Failed(_));
 
-    /// Returns true if the PeerConnection is in a connecting, listening or connected state, otherwise false
+    /// Returns true if the PeerConnection is in a `Connecting`, `Listening` or `Connected` state, otherwise false
     is_state!(is_active, Connecting(_) | Connected(_) | Listening(_));
 
     /// Create a new PeerConnection
@@ -328,9 +331,14 @@ impl PeerConnection {
 
     /// Tell the underlying thread to shut down. The connection will not immediately
     /// be in a `Shutdown` state. [wait_shutdown] can be used to wait for the
-    /// connection to shut down.
+    /// connection to shut down. If the connection is not active, this method does nothing.
     pub fn shutdown(&self) -> Result<()> {
-        self.send_control_message(ControlMessage::Shutdown)
+        match self.send_control_message(ControlMessage::Shutdown) {
+            // StateError only returns from send_control_message
+            // if the connection worker is not active
+            Ok(_) | Err(ConnectionError::PeerError(PeerConnectionError::StateError(_))) => Ok(()),
+            e => e,
+        }
     }
 
     /// Send frames to the connected Peer. An Err will be returned if the
@@ -508,6 +516,19 @@ impl PeerConnection {
         } else {
             Err(ConnectionError::Timeout)
         }
+    }
+
+    #[cfg(test)]
+    pub fn new_with_connecting_state_for_test() -> (Self, std::sync::mpsc::Receiver<ControlMessage>) {
+        use std::sync::mpsc::sync_channel;
+        let (tx, rx) = sync_channel(1);
+        (
+            Self {
+                state: Arc::new(RwLock::new(PeerConnectionState::Connecting(Arc::new(tx.into())))),
+                ..Default::default()
+            },
+            rx,
+        )
     }
 }
 

--- a/comms/src/connection/peer_connection/context.rs
+++ b/comms/src/connection/peer_connection/context.rs
@@ -60,7 +60,7 @@ pub struct PeerConnectionContext {
     pub(crate) max_msg_size: u64,
     pub(crate) max_retry_attempts: u16,
     pub(crate) socks_address: Option<SocketAddress>,
-    pub(super) linger: Linger,
+    pub(crate) linger: Linger,
 }
 
 impl<'a> TryFrom<PeerConnectionContextBuilder<'a>> for PeerConnectionContext {

--- a/comms/src/connection/types.rs
+++ b/comms/src/connection/types.rs
@@ -51,6 +51,12 @@ pub enum Linger {
     Timeout(u32),
 }
 
+impl Default for Linger {
+    fn default() -> Self {
+        Linger::Never
+    }
+}
+
 /// Direction of the connection
 #[derive(Clone, Eq, PartialEq, Debug)]
 pub enum Direction {

--- a/comms/src/connection_manager/connections.rs
+++ b/comms/src/connection_manager/connections.rs
@@ -48,14 +48,30 @@ const THREAD_JOIN_TIMEOUT_IN_MS: Duration = Duration::from_millis(100);
 pub(super) struct LivePeerConnections {
     repository: RwLock<ConnectionRepository>,
     connection_thread_handles: RwLock<HashMap<NodeId, PeerConnectionJoinHandle>>,
+    max_connections: usize,
 }
 
-impl LivePeerConnections {
-    /// Create a new live peer connection
-    pub fn new() -> Self {
+impl Default for LivePeerConnections {
+    fn default() -> Self {
         Self {
             repository: RwLock::new(ConnectionRepository::default()),
             connection_thread_handles: RwLock::new(HashMap::new()),
+            max_connections: 100,
+        }
+    }
+}
+
+impl LivePeerConnections {
+    #[cfg(test)]
+    pub fn new() -> Self {
+        Default::default()
+    }
+
+    /// Create a new live peer connection
+    pub fn with_max_connections(max_connections: usize) -> Self {
+        Self {
+            max_connections,
+            ..Default::default()
         }
     }
 
@@ -79,31 +95,68 @@ impl LivePeerConnections {
     }
 
     /// Add a connection to live peer connections
-    pub fn add_connection(&self, node_id: NodeId, conn: Arc<PeerConnection>, handle: PeerConnectionJoinHandle) {
-        acquire_write_lock!(self.connection_thread_handles).insert(node_id.clone(), handle);
+    pub fn add_connection(
+        &self,
+        node_id: NodeId,
+        conn: Arc<PeerConnection>,
+        handle: PeerConnectionJoinHandle,
+    ) -> Result<()>
+    {
+        self.cleanup_inactive_connections();
 
         self.atomic_write(|mut repo| {
+            let active_count = repo.count_where(|conn| conn.is_active());
+            // If we're full drop the connection which has least recently been used
+            if active_count >= self.max_connections {
+                let recent_list = repo.sorted_recent_activity();
+                if let Some(node_id) = recent_list.last().map(|(node_id, _)| node_id.clone().clone()) {
+                    let conn = repo.remove(&node_id).expect(
+                        "Invariant check: Unable to remove connection that was returned from \
+                         ConnectionRepository::sorted_recent_activity",
+                    );
+
+                    conn.shutdown()
+                        .map_err(|err| ConnectionManagerError::ConnectionShutdownFailed(err))?;
+                }
+            }
+
+            acquire_write_lock!(self.connection_thread_handles).insert(node_id.clone(), handle);
             repo.insert(node_id, conn);
+            Ok(())
         })
+    }
+
+    /// Removes inactive connections from the live connection list
+    fn cleanup_inactive_connections(&self) {
+        self.atomic_write(|mut repo| {
+            // Drain the connections, and immediately drop them
+            let entries = repo.drain_filter(|(_, conn)| !conn.is_active() && !conn.is_initial());
+            debug!(target: LOG_TARGET, "Discarding {} inactive connections", entries.len());
+        });
     }
 
     /// If the connection exists, it is removed, shut down and returned. Otherwise
     /// `ConnectionManagerError::PeerConnectionNotFound` is returned
-    pub fn drop_connection(&self, node_id: &NodeId) -> Result<(Arc<PeerConnection>, Option<PeerConnectionJoinHandle>)> {
-        let conn = self.atomic_write(|mut repo| {
-            repo.remove(node_id)
+    pub fn shutdown_connection(&self, node_id: &NodeId) -> Result<(Arc<PeerConnection>, PeerConnectionJoinHandle)> {
+        self.atomic_write(|mut repo| {
+            let conn = repo
+                .remove(node_id)
                 .ok_or(ConnectionManagerError::PeerConnectionNotFound)
-                .map(|conn| conn.clone())
-        })?;
+                .map(|conn| conn.clone())?;
 
-        let handle = acquire_write_lock!(self.connection_thread_handles).remove(node_id);
+            let handle = acquire_write_lock!(self.connection_thread_handles)
+                .remove(node_id)
+                .expect(
+                    "Invariant check: the peer connection join handle was not found. This is a bug as each peer \
+                     connection should have an associated join handle.",
+                );
 
-        debug!(target: LOG_TARGET, "Dropping connection for NodeID={}", node_id);
+            debug!(target: LOG_TARGET, "Dropping connection for NodeID={}", node_id);
 
-        if conn.is_active() {
             conn.shutdown().map_err(ConnectionManagerError::ConnectionError)?;
-        }
-        Ok((conn, handle))
+
+            Ok((conn, handle))
+        })
     }
 
     /// Send a shutdown signal to all peer connections, returning their worker thread handles
@@ -139,6 +192,25 @@ impl LivePeerConnections {
         results
     }
 
+    /// Returns true if the maximum number of connections has been reached, otherwise false
+    pub fn has_reached_max_active_connections(&self) -> bool {
+        let conn_count = self.get_active_connection_count();
+        assert!(
+            conn_count <= self.max_connections,
+            "Invariant check: the active connection count is more than the max allowed connections. This is a bug as \
+             active connections should never exceed max_connections."
+        );
+        conn_count == self.max_connections
+    }
+
+    /// Returns the number of connections (active and inactive) contained in the connection
+    /// repository.
+    #[cfg(test)]
+    pub fn repository_len(&self) -> usize {
+        let lock = acquire_read_lock!(self.repository);
+        lock.len()
+    }
+
     fn atomic_write<F, T>(&self, f: F) -> T
     where F: FnOnce(RwLockWriteGuard<ConnectionRepository>) -> T {
         let lock = acquire_write_lock!(self.repository);
@@ -155,11 +227,9 @@ impl LivePeerConnections {
 #[cfg(test)]
 mod test {
     use super::*;
-
     use rand::OsRng;
-    use tari_crypto::{keys::PublicKey, ristretto::RistrettoPublicKey};
-
     use std::thread;
+    use tari_crypto::{keys::PublicKey, ristretto::RistrettoPublicKey};
 
     fn make_join_handle() -> PeerConnectionJoinHandle {
         thread::spawn(move || Ok(()))
@@ -177,6 +247,13 @@ mod test {
     }
 
     #[test]
+    fn with_max_connections() {
+        let connections = LivePeerConnections::with_max_connections(10);
+        assert_eq!(0, connections.get_active_connection_count());
+        assert_eq!(10, connections.max_connections);
+    }
+
+    #[test]
     fn crud() {
         let connections = LivePeerConnections::new();
 
@@ -184,7 +261,7 @@ mod test {
         let conn = Arc::new(PeerConnection::new());
         let join_handle = make_join_handle();
 
-        connections.add_connection(node_id.clone(), conn, join_handle);
+        connections.add_connection(node_id.clone(), conn, join_handle).unwrap();
         assert_eq!(
             1,
             acquire_read_lock!(connections.connection_thread_handles)
@@ -192,7 +269,7 @@ mod test {
                 .count()
         );
         connections.get_connection(&node_id).unwrap();
-        connections.drop_connection(&node_id).unwrap();
+        connections.shutdown_connection(&node_id).unwrap();
         assert_eq!(
             0,
             acquire_read_lock!(connections.connection_thread_handles)
@@ -207,7 +284,7 @@ mod test {
     fn drop_connection_fail() {
         let connections = LivePeerConnections::new();
         let node_id = make_node_id();
-        match connections.drop_connection(&node_id) {
+        match connections.shutdown_connection(&node_id) {
             Err(ConnectionManagerError::PeerConnectionNotFound) => {},
             Err(err) => panic!("Unexpected error: {:?}", err),
             Ok(_) => panic!("Unexpected Ok result"),
@@ -223,11 +300,40 @@ mod test {
             let conn = Arc::new(PeerConnection::new());
             let join_handle = make_join_handle();
 
-            connections.add_connection(node_id, conn, join_handle);
+            connections.add_connection(node_id, conn, join_handle).unwrap();
         }
 
         let results = connections.shutdown_joined();
         assert_eq!(3, results.len());
         assert!(results.iter().all(|r| r.is_ok()));
+    }
+
+    #[test]
+    fn has_reached_max_active_connections() {
+        let connections = LivePeerConnections::with_max_connections(2);
+
+        let add_active_conn = |node_id| {
+            let (conn, rx) = PeerConnection::new_with_connecting_state_for_test();
+            let join_handle = make_join_handle();
+
+            (connections.add_connection(node_id, Arc::new(conn), join_handle), rx)
+        };
+
+        let mut receivers = Vec::new();
+        let mut node_ids = Vec::new();
+        for _ in 0..3 {
+            let node_id = make_node_id();
+            let (res, rx) = add_active_conn(node_id.clone());
+            node_ids.push(node_id);
+            receivers.push(rx);
+            res.unwrap();
+        }
+
+        assert_eq!(connections.repository_len(), 2);
+        assert!(connections.get_connection(&node_ids[0]).is_none());
+        assert!(connections.get_connection(&node_ids[1]).is_some());
+        assert!(connections.get_connection(&node_ids[2]).is_some());
+
+        drop(receivers);
     }
 }

--- a/comms/src/connection_manager/error.rs
+++ b/comms/src/connection_manager/error.rs
@@ -27,7 +27,12 @@ use crate::{
     peer_manager::PeerManagerError,
 };
 use derive_error::Error;
-use tari_utilities::{ciphers::cipher::CipherError, message_format::MessageFormatError, ByteArrayError};
+use tari_utilities::{
+    ciphers::cipher::CipherError,
+    message_format::MessageFormatError,
+    thread_join::ThreadError,
+    ByteArrayError,
+};
 
 #[derive(Error, Debug)]
 pub enum ConnectionManagerError {
@@ -54,6 +59,12 @@ pub enum ConnectionManagerError {
     DatastoreError,
     /// Connection timed out before it was able to connect
     TimeoutBeforeConnected,
+    /// The maximum number of peer connections has been reached
+    MaxConnectionsReached,
+    /// Failed to shutdown a peer connection
+    #[error(no_from)]
+    ConnectionShutdownFailed(ConnectionError),
+    PeerConnectionThreadError(ThreadError),
     #[error(msg_embedded, non_std, no_from)]
     ControlServicePingPongFailed(String),
     #[error(msg_embedded, non_std, no_from)]

--- a/comms/src/connection_manager/establisher.rs
+++ b/comms/src/connection_manager/establisher.rs
@@ -50,7 +50,7 @@ const LOG_TARGET: &str = "comms::connection_manager::establisher";
 pub struct PeerConnectionConfig {
     /// Maximum number of peer connections. Newer connections will be rejected until there are
     /// less than `max_connections` active connections.
-    pub max_connections: u64,
+    pub max_connections: usize,
     /// Maximum size of inbound messages - messages larger than this will be dropped
     pub max_message_size: u64,
     /// The number of connection attempts to make to one address before giving up

--- a/comms/tests/connection/peer_connection.rs
+++ b/comms/tests/connection/peer_connection.rs
@@ -283,18 +283,18 @@ fn connection_pause_resume() {
     sender.send(&[msg_type_frame, &[3u8]]).unwrap();
     sender.send(&[msg_type_frame, &[4u8]]).unwrap();
 
-    let err = consumer.receive(100).unwrap_err();
+    let err = consumer.receive(3000).unwrap_err();
     assert!(err.is_timeout());
 
     // Resume connection
     conn.resume().unwrap();
 
     // Should receive all the pending messages
-    let frames = consumer.receive(100).unwrap();
+    let frames = consumer.receive(3000).unwrap();
     assert_eq!(vec![2u8], frames[2]);
-    let frames = consumer.receive(100).unwrap();
+    let frames = consumer.receive(3000).unwrap();
     assert_eq!(vec![3u8], frames[2]);
-    let frames = consumer.receive(100).unwrap();
+    let frames = consumer.receive(3000).unwrap();
     assert_eq!(vec![4u8], frames[2]);
 }
 

--- a/comms/tests/connection_manager/manager.rs
+++ b/comms/tests/connection_manager/manager.rs
@@ -111,7 +111,7 @@ fn establish_peer_connection() {
         .unwrap();
 
     // Node B knows no peers
-    let node_B_database_name = "connection_manager_node_B_peer_manager"; // Note: every test should have unique database
+    let node_B_database_name = "connection_manager_node_B_peer_manager";
     let datastore = init_datastore(node_B_database_name).unwrap();
     let database = datastore.get_handle(node_B_database_name).unwrap();
     let node_B_peer_manager = make_peer_manager(vec![], database);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->    
 ConnectionManager now limits the number of peer connections to
 `PeerConnectionConfig::max_connections`.
    
 If the number of active connections is reached, one of two scenarios
 exist:
 - if this node is initiating the connection, the connection which has
 seen the least recent activity is dropped in favour of the new
connection.
- if another node is initiating the new peer connection through the control service, existing
connections are preferred and the new connection is denied.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #385 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
New unit tests

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [x] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [x] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch
* [x] I ran `cargo-fmt --all` before pushing
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
