### PR TITLE
Fixed all warnings on comms test support (+ fix development compile fail)

### DIFF
--- a/base_layer/p2p/src/services/executor.rs
+++ b/base_layer/p2p/src/services/executor.rs
@@ -74,7 +74,6 @@ impl ServiceExecutor {
             senders.push(sender);
 
             let service_context = ServiceContext {
-                node_identity: Arc::clone(&comms_services.node_identity),
                 oms: comms_services.outbound_message_service(),
                 peer_manager: comms_services.peer_manager(),
                 node_identity: comms_services.node_identity(),
@@ -152,7 +151,6 @@ impl ServiceExecutor {
 /// access the outbound message service and create [DomainConnector]s to receive comms messages of
 /// a particular [TariMessageType].
 pub struct ServiceContext {
-    node_identity: Arc<NodeIdentity>,
     oms: Arc<OutboundMessageService>,
     peer_manager: Arc<PeerManager>,
     node_identity: Arc<NodeIdentity>,

--- a/comms/tests/support/factories/macros.rs
+++ b/comms/tests/support/factories/macros.rs
@@ -22,12 +22,14 @@
 
 macro_rules! factory_setter {
  ($func:ident, $name: ident, Option<$type: ty>) => {
+        #[allow(dead_code)]
         pub fn $func(mut self, val: $type) -> Self {
             self.$name = Some(val);
             self
         }
     };
  ($func:ident, $name: ident, $type: ty) => {
+        #[allow(dead_code)]
         pub fn $func(mut self, val: $type) -> Self {
             self.$name = val;
             self

--- a/comms/tests/support/helpers/connection_message_counter.rs
+++ b/comms/tests/support/helpers/connection_message_counter.rs
@@ -56,11 +56,6 @@ impl<'c> ConnectionMessageCounter<'c> {
         self
     }
 
-    pub fn reset(&self) {
-        let mut counter_lock = acquire_write_lock!(self.counter);
-        *counter_lock = 0;
-    }
-
     pub fn count(&self) -> u32 {
         let counter_lock = acquire_read_lock!(self.counter);
         *counter_lock

--- a/comms/tests/support/makers/node_id.rs
+++ b/comms/tests/support/makers/node_id.rs
@@ -20,13 +20,9 @@
 //  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 //  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use std::convert::TryFrom;
-
 use rand::{CryptoRng, OsRng, Rng};
-
 use tari_comms::peer_manager::NodeId;
 use tari_crypto::{keys::PublicKey, ristretto::RistrettoPublicKey};
-use tari_utilities::{ByteArray, Hashable};
 
 /// Creates a random node ID witht he given RNG
 pub fn make_random_node_id_with_rng<RNG: CryptoRng + Rng>(rng: &mut RNG) -> NodeId {
@@ -37,21 +33,4 @@ pub fn make_random_node_id_with_rng<RNG: CryptoRng + Rng>(rng: &mut RNG) -> Node
 /// Creates a random node ID using OsRng
 pub fn make_node_id() -> NodeId {
     make_random_node_id_with_rng(&mut OsRng::new().unwrap())
-}
-
-/// Creates a random node ID using OsRng
-pub fn make_node_id_from_public_key<P: PublicKey + Hashable>(pk: &P) -> NodeId {
-    NodeId::from_key(pk).unwrap()
-}
-
-/// Creates the same node ID
-pub fn make_dummy_node_id() -> NodeId {
-    NodeId::try_from(
-        [
-            144, 28, 106, 112, 220, 197, 216, 119, 9, 217, 42, 77, 159, 211, 53, 207, 0, 157, 5, 55, 235, 247, 160,
-            195, 240, 48, 146, 168, 119, 15, 241, 54,
-        ]
-        .as_bytes(),
-    )
-    .unwrap()
 }


### PR DESCRIPTION
Removed some unused functions where appropriate.
Comms test support can have dead code as factories are meant to expose
all the ways to build a component regardless of whether it happens to be called 
by tests or not.
