### PR TITLE
Add coinbase maturity check

### DIFF
--- a/base_layer/core/src/error.rs
+++ b/base_layer/core/src/error.rs
@@ -26,7 +26,7 @@
 // this file is used for all blockchain error types
 use crate::transaction::TransactionError;
 use derive_error::Error;
-use merklemountainrange::{error::MerkleMountainRangeError, merkle_storage::MerkleStorageError};
+use merklemountainrange::error::{MerkleMountainRangeError, MerkleStorageError};
 use tari_storage::keyvalue_store::*;
 
 /// The ChainError is used to present all generic chain error of the actual blockchain
@@ -55,4 +55,6 @@ pub enum StateError {
     OrphanBlock,
     // Duplicate block
     DuplicateBlock,
+    // Coinbase not all enough
+    CoinbaseMaturityNotReached,
 }

--- a/infrastructure/merklemountainrange/src/error.rs
+++ b/infrastructure/merklemountainrange/src/error.rs
@@ -32,4 +32,29 @@ pub enum MerkleMountainRangeError {
     CannotAddToMMR,
     // Object was already pruned
     ObjectAlreadyPruned,
+    // PersistanceNotEnabled
+    MerkleStorageError(MerkleStorageError),
+}
+
+#[derive(Debug, Error)]
+pub enum MerkleStorageError {
+    /// An error occurred with the underlying data store implementation
+    #[error(embedded_msg, no_from, non_std)]
+    InternalError(String),
+    /// An error occurred during serialization
+    #[error(no_from, non_std)]
+    SerializationErr(String),
+    /// An error occurred during deserialization
+    #[error(no_from, non_std)]
+    DeserializationErr(String),
+    /// An error occurred during a put query
+    #[error(embedded_msg, no_from, non_std)]
+    PutError(String),
+    /// An error occurred during a get query
+    #[error(embedded_msg, no_from, non_std)]
+    GetError(String),
+    /// Sync error, expected some value where it found none
+    SyncError,
+    /// The persistant storage was not enabled
+    StoreNotEnabledError,
 }

--- a/infrastructure/merklemountainrange/src/merkle_change_tracker.rs
+++ b/infrastructure/merklemountainrange/src/merkle_change_tracker.rs
@@ -187,7 +187,7 @@ impl MerkleChangeTracker {
 
     /// This function steps through all the checkpoints and looks at which len their mmr's ended.
     /// It will compare the given len and give age at which the len was exceeded.
-    pub fn find_mmr_len_age<S: MerkleStorage>(&self, len: usize, store: &mut S) -> Result<usize, MerkleStorageError> {
+    pub fn get_checkpoint_age_at_index<S: MerkleStorage>(&self, index: usize, store: &mut S) -> Result<usize, MerkleStorageError> {
         let mut age = 0;
         for i in (0..self.unsaved_checkpoints.len()).rev() {
             if len >= self.unsaved_checkpoints[i].tree_height_at_checkpoint[0]

--- a/infrastructure/merklemountainrange/src/merkle_storage.rs
+++ b/infrastructure/merklemountainrange/src/merkle_storage.rs
@@ -20,33 +20,10 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use derive_error::Error;
+use crate::error::MerkleStorageError;
 use serde::{de::DeserializeOwned, Serialize};
 use tari_storage::{keyvalue_store::DataStore, lmdb::*};
 use tari_utilities::message_format::MessageFormat;
-
-#[derive(Debug, Error)]
-pub enum MerkleStorageError {
-    /// An error occurred with the underlying data store implementation
-    #[error(embedded_msg, no_from, non_std)]
-    InternalError(String),
-    /// An error occurred during serialization
-    #[error(no_from, non_std)]
-    SerializationErr(String),
-    /// An error occurred during deserialization
-    #[error(no_from, non_std)]
-    DeserializationErr(String),
-    /// An error occurred during a put query
-    #[error(embedded_msg, no_from, non_std)]
-    PutError(String),
-    /// An error occurred during a get query
-    #[error(embedded_msg, no_from, non_std)]
-    GetError(String),
-    /// Sync error, expected some value where it found none
-    SyncError,
-    /// The persistant storage was not enabled
-    StoreNotEnabledError,
-}
 
 /// This trait proves an interface for the MMR to store and retrieve data from some storage medium.
 pub trait MerkleStorage {

--- a/infrastructure/merklemountainrange/src/merklemountainrange.rs
+++ b/infrastructure/merklemountainrange/src/merklemountainrange.rs
@@ -435,7 +435,7 @@ where
 
     /// This function will get the age of an object when it was added. This will only work if the persistance store is
     /// enabled as it tracks the age at which checkpoint it was added
-    pub fn get_object_checkpoint_age<S: MerkleStorage>(
+    pub fn get_checkpoint_age<S: MerkleStorage>(
         &self,
         hash: &ObjectHashSlice,
         store: &mut S,


### PR DESCRIPTION
## Description
Added age calculation to the MMR. The MMR will now calculate the age that an object was added to the MMR
Coinbase maturity is now added to the chain state so that block validation can check that

## Motivation and Context
We need to check how old a certain UTXO is. Coinbase utxo needs to reach the maturity before we can spend them. The changes above will now check that they are old enough

## How Has This Been Tested?
New unit tests in the MMR covering the changes

## Types of changes
* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [x] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [x] New Tests
* [ ] Documentation

## Checklist:
* [x] I'm merging against the `development` branch
* [x] I ran `cargo-fmt --all` before pushing
* [ ] My change requires a change to the documentation.
* [x] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
