### PR TITLE
Move transaction validation code from `Transaction` to `AggregateBody`

### DIFF
--- a/base_layer/core/src/block.rs
+++ b/base_layer/core/src/block.rs
@@ -207,7 +207,7 @@ impl AggregateBody {
     {
         self.verify_kernel_signatures()?;
         self.validate_kernel_sum(offset, factory)?;
-        self.validate_range_proofs(&prover)
+        self.validate_range_proofs(prover)
     }
 
     /// Calculate the sum of the inputs and outputs including fees

--- a/base_layer/core/src/transaction.rs
+++ b/base_layer/core/src/transaction.rs
@@ -25,13 +25,13 @@
 
 use crate::{
     block::AggregateBody,
-    tari_amount::*,
+    tari_amount::MicroTari,
     types::{BlindingFactor, Commitment, CommitmentFactory, Signature},
 };
 
 use crate::{
     transaction_protocol::{build_challenge, TransactionMetadata},
-    types::{HashDigest, PrivateKey, PublicKey, RangeProof, RangeProofService},
+    types::{HashDigest, RangeProof, RangeProofService},
 };
 use derive_error::Error;
 use digest::Input;
@@ -39,9 +39,7 @@ use serde::{Deserialize, Serialize};
 use std::cmp::Ordering;
 use tari_crypto::{
     commitment::HomomorphicCommitmentFactory,
-    keys::PublicKey as PK,
     range_proof::{RangeProofError, RangeProofService as RangeProofServiceTrait},
-    ristretto::pedersen::PedersenCommitment,
 };
 use tari_utilities::{ByteArray, Hashable};
 
@@ -434,56 +432,6 @@ impl Transaction {
         }
     }
 
-    /// Calculate the sum of the inputs and outputs including the fees
-    fn sum_commitments(&self, fees: u64, factory: &CommitmentFactory) -> Commitment {
-        let fee_commitment = factory.commit(&PrivateKey::default(), &PrivateKey::from(fees));
-        let sum_inputs = &self.body.inputs.iter().map(|i| &i.commitment).sum::<Commitment>();
-        let sum_outputs = &self.body.outputs.iter().map(|o| &o.commitment).sum::<Commitment>();
-        &(sum_outputs - sum_inputs) + &fee_commitment
-    }
-
-    /// Calculate the sum of the kernels, taking into account the offset if it exists, and their constituent fees
-    fn sum_kernels(&self) -> KernelSum {
-        let public_offset = PublicKey::from_secret_key(&self.offset);
-        let offset_commitment = PedersenCommitment::from_public_key(&public_offset);
-        // Sum all kernel excesses and fees
-        self.body.kernels.iter().fold(
-            KernelSum {
-                fees: MicroTari(0),
-                sum: offset_commitment,
-            },
-            |acc, val| KernelSum {
-                fees: &acc.fees + &val.fee,
-                sum: &acc.sum + &val.excess,
-            },
-        )
-    }
-
-    /// Confirm that the (sum of the outputs) - (sum of inputs) = Kernel excess
-    fn validate_kernel_sum(&self, factory: &CommitmentFactory) -> Result<(), TransactionError> {
-        let kernel_sum = self.sum_kernels();
-        let sum_io = self.sum_commitments(kernel_sum.fees.into(), factory);
-
-        if kernel_sum.sum != sum_io {
-            return Err(TransactionError::ValidationError(
-                "Sum of inputs and outputs did not equal sum of kernels with fees".into(),
-            ));
-        }
-
-        Ok(())
-    }
-
-    fn validate_range_proofs(&self, range_proof_service: &RangeProofService) -> Result<(), TransactionError> {
-        for o in &self.body.outputs {
-            if !o.verify_range_proof(&range_proof_service)? {
-                return Err(TransactionError::ValidationError(
-                    "Range proof could not be verified".into(),
-                ));
-            }
-        }
-        Ok(())
-    }
-
     /// Validate this transaction by checking the following:
     /// 1. The sum of inputs, outputs and fees equal the (public excess value + offset)
     /// 1. The signature signs the canonical message with the private excess
@@ -496,13 +444,11 @@ impl Transaction {
         factory: &CommitmentFactory,
     ) -> Result<(), TransactionError>
     {
-        self.body.verify_kernel_signatures()?;
-        self.validate_kernel_sum(factory)?;
-        self.validate_range_proofs(&prover)
+        self.body.validate_internal_consistency(&self.offset, prover, factory)
     }
 }
 
-/// This will ecapsulate the aggregatebody inside a transaction with a zero offset.
+/// This will encapsulate the aggregate body inside a transaction with a zero offset.
 impl From<AggregateBody> for Transaction {
     fn from(body: AggregateBody) -> Self {
         Transaction {
@@ -513,14 +459,6 @@ impl From<AggregateBody> for Transaction {
 }
 
 //----------------------------------------  Transaction Builder   ----------------------------------------------------//
-
-/// This struct holds the result of calculating the sum of the kernels in a Transaction
-/// and returns the summed commitments and the total fees
-pub struct KernelSum {
-    pub sum: Commitment,
-    pub fees: MicroTari,
-}
-
 pub struct TransactionBuilder {
     body: AggregateBody,
     offset: Option<BlindingFactor>,
@@ -602,7 +540,7 @@ mod test {
     use super::*;
     use crate::{
         transaction::OutputFeatures,
-        types::{BlindingFactor, RangeProof},
+        types::{BlindingFactor, PrivateKey, RangeProof},
     };
     use rand;
     use tari_crypto::{


### PR DESCRIPTION
Nearly all the transaction validation code currently in `Transaction`
involves references to `self.body.some_field`. This suggests that
it should really live in `AggregateBody`.

As it stands _block_ validation code has to do some yucky copying
to get at the same code (blocks have an AggregateBody, not a
Transaction).

This PR moves all the validation code into `AggregateBody` which
both cleans up the code smell, and allows a more efficient and
ergonomic call through to validation code when validating `Block`s

