### PR TITLE
Fix MMR benchmark

### DIFF
--- a/infrastructure/merklemountainrange/Cargo.toml
+++ b/infrastructure/merklemountainrange/Cargo.toml
@@ -14,8 +14,7 @@ tari_utilities = { path = "../tari_util", version = "^0.0" }
 derive-error = "0.0.4"
 digest = "0.8.0"
 tari_storage = { path = "../storage", version = "^0.0" }
-serde = "1.0.98"
-serde_derive="1.0.98"
+serde = { version = "1.0.97", features = ["derive"] }
 rmp-serde = "0.13.7"
 croaring =  "0.4.0"
 

--- a/infrastructure/merklemountainrange/benches/bench.rs
+++ b/infrastructure/merklemountainrange/benches/bench.rs
@@ -21,7 +21,7 @@
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 use blake2::Blake2b;
-use criterion::{Criterion, *};
+use criterion::{criterion_group, criterion_main, Criterion};
 use merklemountainrange::mmr::*;
 use rand::{rngs::OsRng, Rng, RngCore};
 use serde::{Deserialize, Serialize};

--- a/infrastructure/merklemountainrange/benches/bench.rs
+++ b/infrastructure/merklemountainrange/benches/bench.rs
@@ -20,21 +20,19 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-#[macro_use]
-extern crate criterion;
-
-#[macro_use]
-extern crate serde;
-
 use blake2::Blake2b;
-use criterion::Criterion;
+use criterion::{Criterion, *};
 use merklemountainrange::mmr::*;
 use rand::{rngs::OsRng, Rng, RngCore};
+use serde::{Deserialize, Serialize};
 use std::time::Duration;
+use tari_storage::lmdb::*;
+use tempdir::TempDir;
 
 const TEST_SIZES: &[usize] = &[10, 100, 1000, 10_000, 100_000];
 
 mod test_structures {
+    use super::*;
     use std::slice;
 
     use std::mem;
@@ -72,44 +70,40 @@ fn append(c: &mut Criterion) {
     );
 }
 
-// TODO: Can't work out the parameters needed for storage
-// fn apply_state_with_storage(c: &mut Criterion) {
-//    use test_structures::*;
-//
-//    c.bench_function_over_inputs(
-//        "apply_state_with_storage",
-//        move |b, &&size| {
-//            let name: String = OsRng.next_u64().to_string();
-//
-//
-//            let tmp_dir = TempDir::new(&name).unwrap();
-//            println!("{:?}", tmp_dir);
-//            let builder = LMDBBuilder::new();
-//            let mut store = builder
-//                .set_mapsize(5)
-//                .set_path(tmp_dir.path().to_str().unwrap())
-//                .add_database(&format!("{}_mmr_checkpoints", &name))
-//                .add_database(&format!("{}_mmr_objects", &name))
-//                .add_database(&format!("{}_init", &name))
-//                .build()
-//                .unwrap();
-//
-//            let mut mmr = MerkleMountainRange::<H, Blake2b>::new();
-//            mmr.init_persistance_store(&name, 1);
-//
-//            b.iter(|| {
-//                for _ in 0..size {
-//                    mmr.append(vec![H(OsRng.next_u64())]).unwrap();
-//                    dbg!("checkpointing");
-//                    mmr.checkpoint().unwrap();
-//                    dbg!("applying");
-//                    mmr.apply_state(&mut store).unwrap();
-//                }
-//            });
-//        },
-//        TEST_SIZES,
-//    );
-//}
+fn apply_state_with_storage(c: &mut Criterion) {
+    use test_structures::*;
+
+    c.bench_function_over_inputs(
+        "apply_state_with_storage",
+        move |b, &&size| {
+            let name: String = OsRng.next_u64().to_string();
+
+            let tmp_dir = TempDir::new(&name).unwrap();
+            println!("{:?}", tmp_dir);
+            let builder = LMDBBuilder::new();
+            let mut store = builder
+                .set_mapsize(50)
+                .set_path(tmp_dir.path().to_str().unwrap())
+                .add_database(&format!("{}_mmr_checkpoints", &name))
+                .add_database(&format!("{}_mmr_objects", &name))
+                .add_database(&format!("{}_init", &name))
+                .build()
+                .unwrap();
+
+            let mut mmr = MerkleMountainRange::<H, Blake2b>::new();
+            mmr.init_persistance_store(&name, 0);
+
+            b.iter(|| {
+                for _ in 0..size {
+                    mmr.append(vec![H(OsRng.next_u64())]).unwrap();
+                    mmr.checkpoint().unwrap();
+                    mmr.apply_state(&mut store).unwrap();
+                }
+            });
+        },
+        TEST_SIZES,
+    );
+}
 
 fn get_merkle_root(c: &mut Criterion) {
     use test_structures::*;
@@ -182,6 +176,6 @@ fn get_proof(c: &mut Criterion) {
 criterion_group!(
 name = merkle_mountain_range;
 config= Criterion::default().warm_up_time(Duration::from_millis(500)).sample_size(10);
-targets= append,get_merkle_root,get_object,get_proof);
+targets= append,get_merkle_root,get_object,get_proof,apply_state_with_storage);
 
 criterion_main!(merkle_mountain_range);

--- a/infrastructure/merklemountainrange/src/merkle_change_tracker.rs
+++ b/infrastructure/merklemountainrange/src/merkle_change_tracker.rs
@@ -22,8 +22,7 @@
 
 use crate::{merkle_storage::*, merklenode::*};
 use croaring::Treemap;
-use serde::{de::DeserializeOwned, ser::Serialize};
-use serde_derive::{Deserialize, Serialize};
+use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use std::collections::HashMap;
 use tari_utilities::hex::*;
 
@@ -434,7 +433,7 @@ mod tests {
     use crate::mmr::*;
     use blake2::Blake2b;
     use digest::Digest;
-    use serde_derive::{Deserialize, Serialize};
+    use serde::{Deserialize, Serialize};
     use std::fs;
     use tari_storage::lmdb::*;
     use tari_utilities::Hashable;

--- a/infrastructure/merklemountainrange/src/merklemountainrange.rs
+++ b/infrastructure/merklemountainrange/src/merklemountainrange.rs
@@ -153,8 +153,10 @@ where
     /// This allows the DB to store its data on a persistent medium using the tari::keyvalue_store trait
     /// store_prefix is the db file name prefix used for this mmr.
     /// pruning horizon is how far back changes are kept so that it can rewind.
+    /// the persistance store will always create more than 2 checkpoints.
     pub fn init_persistance_store(&mut self, store_prefix: &str, pruning_horizon: usize) {
-        self.change_tracker.init(store_prefix, pruning_horizon)
+        let checked_pruning_horizon = if pruning_horizon < 2 { 2 } else { pruning_horizon };
+        self.change_tracker.init(store_prefix, checked_pruning_horizon)
     }
 
     /// Allow users to change the pruning horizon after init.
@@ -719,7 +721,7 @@ mod tests {
 
     use super::*;
     use blake2::Blake2b;
-    use serde_derive::{Deserialize, Serialize};
+    use serde::{Deserialize, Serialize};
 
     #[derive(Serialize, Deserialize)]
     pub struct IWrapper(u32);

--- a/infrastructure/merklemountainrange/src/merklenode.rs
+++ b/infrastructure/merklemountainrange/src/merklenode.rs
@@ -23,8 +23,7 @@
 pub type ObjectHash = Vec<u8>;
 pub type ObjectHashSlice = [u8];
 
-use serde::{de::DeserializeOwned, ser::Serialize};
-use serde_derive::{Deserialize, Serialize};
+use serde::{de::DeserializeOwned, Deserialize, Serialize};
 
 /// This is the MerkleNode struct. This struct represents a merkle node in the tree,
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/infrastructure/merklemountainrange/tests/support/testobject.rs
+++ b/infrastructure/merklemountainrange/tests/support/testobject.rs
@@ -22,7 +22,8 @@
 
 use blake2::Blake2b;
 use digest::Digest;
-use serde_derive::{Deserialize, Serialize};
+
+use serde::{Deserialize, Serialize};
 use tari_infra_derive::Hashable;
 use tari_utilities::{ExtendBytes, Hashable};
 

--- a/infrastructure/merklemountainrange/tests/unit/examples.rs
+++ b/infrastructure/merklemountainrange/tests/unit/examples.rs
@@ -1,7 +1,7 @@
 use blake2::Blake2b;
 use digest::Digest;
 use merklemountainrange::mmr::{self, *};
-use serde_derive::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize};
 use std::convert::TryInto;
 use tari_utilities::Hashable;
 


### PR DESCRIPTION
## Description

1. This PR fixes a criterion benchmark that was not enabled.
2. Upgraded the benchmarks to rust 2018
3. Fixed a bug in the MMR change checker
#
1. The benchmark did not work do to a bug in the MMR code, more details below in 3.
2. The current code in the benchmarks was not fully in rust 2018, this was upgraded to full 2018 code, also removed the serde-derive crate from the MMR as the serde trait has this built in now.
3. The MMR change checker had a bug in it that allowed you to select a too small pruning horizon. the pruning horizon has to be 2 or larger. This is how the change checker rewrites and merges older checkpoints to create new combined checkpoints. if the pruning horizon is below 2 there is no older checker to rewrite. This was fixed be enforcing the pruning horizon to be 2 or greater. If less than 2 is selected it enforces 2. 

## Motivation and Context
There was a bug in the MMR code, described above. This was fixed as well as enabling the remaing benchmark. 

## How Has This Been Tested?
All the benchmarks successfully pass now, even with badly choses parameters. 

## Types of changes
* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [x] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
* [x] I'm merging against the `development` branch
* [x] I ran `cargo-fmt --all` before pushing
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
