### PR TITLE
Add benchmarks for Range Proofs

### DIFF
--- a/infrastructure/crypto/Cargo.toml
+++ b/infrastructure/crypto/Cargo.toml
@@ -34,6 +34,11 @@ avx2 = ["curve25519-dalek/avx2_backend", "bulletproofs/avx2_backend"]
 criterion = "0.2"
 bincode = "1.1.4"
 
+[lib]
+# Disable benchmarks to allow Criterion to take over
+bench = false
+
 [[bench]]
-name = "signatures"
+name = "benches"
+path = "benches/mod.rs"
 harness = false

--- a/infrastructure/crypto/benches/mod.rs
+++ b/infrastructure/crypto/benches/mod.rs
@@ -23,7 +23,7 @@
 // Portions of this file were originally copyrighted (c) 2018 The Grin Developers, issued under the Apache License,
 // Version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0.
 
-extern crate criterion;
+use criterion::criterion_main;
 
 pub mod range_proof;
 pub mod signatures;

--- a/infrastructure/crypto/benches/mod.rs
+++ b/infrastructure/crypto/benches/mod.rs
@@ -1,0 +1,35 @@
+// Copyright 2019. The Tari Project
+//
+// Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+// following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+// disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+// following disclaimer in the documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+// products derived from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+// INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+// WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+// USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Portions of this file were originally copyrighted (c) 2018 The Grin Developers, issued under the Apache License,
+// Version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0.
+
+#[macro_use]
+extern crate criterion;
+
+pub mod range_proof;
+pub mod signatures;
+
+use range_proof::range_proofs;
+use signatures::signatures;
+
+criterion_main!(signatures, range_proofs);

--- a/infrastructure/crypto/benches/mod.rs
+++ b/infrastructure/crypto/benches/mod.rs
@@ -23,7 +23,6 @@
 // Portions of this file were originally copyrighted (c) 2018 The Grin Developers, issued under the Apache License,
 // Version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0.
 
-#[macro_use]
 extern crate criterion;
 
 pub mod range_proof;

--- a/infrastructure/crypto/benches/range_proof.rs
+++ b/infrastructure/crypto/benches/range_proof.rs
@@ -1,0 +1,78 @@
+// Copyright 2019. The Tari Project
+//
+// Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+// following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+// disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+// following disclaimer in the documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+// products derived from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+// INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+// WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+// USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Portions of this file were originally copyrighted (c) 2018 The Grin Developers, issued under the Apache License,
+// Version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0.
+
+use criterion::{criterion_group, Criterion};
+use rand::{OsRng, Rng};
+use std::time::Duration;
+use tari_crypto::{
+    commitment::HomomorphicCommitmentFactory,
+    keys::SecretKey,
+    range_proof::RangeProofService,
+    ristretto::{
+        dalek_range_proof::DalekRangeProofService,
+        pedersen::{PedersenCommitment, PedersenCommitmentFactory},
+        RistrettoSecretKey,
+    },
+};
+
+fn setup(n: usize) -> (DalekRangeProofService, RistrettoSecretKey, u64, PedersenCommitment) {
+    let mut rng = OsRng::new().unwrap();
+    let base = PedersenCommitmentFactory::default();
+    let prover = DalekRangeProofService::new(n, &base).unwrap();
+    let k = RistrettoSecretKey::random(&mut rng);
+    let n_max = 1u64 << (n - 1);
+    let v = rng.gen_range(1, n_max);
+    let c = base.commit_value(&k, v);
+    (prover, k, v, c)
+}
+
+pub fn generate_rangeproof(c: &mut Criterion) {
+    c.bench_function_over_inputs(
+        "Generate range proofs",
+        |b, range| {
+            let (prover, k, v, _) = setup(**range);
+            b.iter(move || prover.construct_proof(&k, v).unwrap());
+        },
+        &[8, 16, 32, 64],
+    );
+}
+
+pub fn verify_rangeproof_valid(c: &mut Criterion) {
+    c.bench_function_over_inputs(
+        "Validate valid range proofs",
+        |b, range| {
+            let (prover, k, v, c) = setup(**range);
+            let proof = prover.construct_proof(&k, v).unwrap();
+            b.iter(move || assert!(prover.verify(&proof, &c)));
+        },
+        &[8, 16, 32, 64],
+    );
+}
+
+criterion_group!(
+name = range_proofs;
+config = Criterion::default().warm_up_time(Duration::from_millis(1_500));
+targets = generate_rangeproof, verify_rangeproof_valid
+);

--- a/infrastructure/crypto/benches/signatures.rs
+++ b/infrastructure/crypto/benches/signatures.rs
@@ -1,7 +1,4 @@
-#[macro_use]
-extern crate criterion;
-
-use criterion::{BatchSize, Criterion};
+use criterion::{criterion_group, BatchSize, Criterion};
 use rand::{OsRng, RngCore};
 use std::time::Duration;
 use tari_crypto::{
@@ -11,7 +8,7 @@ use tari_crypto::{
 use tari_utilities::byte_array::ByteArray;
 
 fn generate_secret_key(c: &mut Criterion) {
-    c.bench_function("generate secret key", |b| {
+    c.bench_function("Generate secret key", |b| {
         let mut rng = OsRng::new().unwrap();
         b.iter(|| {
             let _ = RistrettoSecretKey::random(&mut rng);
@@ -76,4 +73,3 @@ name = signatures;
 config = Criterion::default().warm_up_time(Duration::from_millis(500));
 targets = generate_secret_key, native_keypair, sign_message, verify_message
 );
-criterion_main!(signatures);


### PR DESCRIPTION
This PR adds a few small benches for the Dalek Range proof module.
Some refactoring on the `benches` folder was required to allow
the tests to be split into several files

New benchmarks:

```
Generate range proofs/8 
                        time:   [2.3685 ms 2.3853 ms 2.4022 ms]                                     
Found 5 outliers among 100 measurements (5.00%)
  1 (1.00%) low mild
  2 (2.00%) high mild
  2 (2.00%) high severe

Generate range proofs/16                                                                             
                        time:   [4.1531 ms 4.1979 ms 4.2501 ms]
Found 8 outliers among 100 measurements (8.00%)
  2 (2.00%) high mild
  6 (6.00%) high severe

Generate range proofs/32                                                                             
                        time:   [7.3179 ms 7.3504 ms 7.3888 ms]
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high mild

Generate range proofs/64                                                                             
                        time:   [13.592 ms 13.645 ms 13.705 ms]
Found 2 outliers among 100 measurements (2.00%)
  1 (1.00%) high mild
  1 (1.00%) high severe

Validate valid range proofs/8                                                                            
                        time:   [437.42 us 440.45 us 443.41 us]
Found 4 outliers among 100 measurements (4.00%)
  4 (4.00%) high mild

Validate valid range proofs/16                                                                            
                        time:   [682.64 us 688.65 us 695.07 us]
Found 5 outliers among 100 measurements (5.00%)
  4 (4.00%) high mild
  1 (1.00%) high severe

Validate valid range proofs/32                                                                             
                        time:   [1.0633 ms 1.0713 ms 1.0805 ms]
Found 2 outliers among 100 measurements (2.00%)
  2 (2.00%) high mild

Validate valid range proofs/64                                                                             
                        time:   [1.8601 ms 1.8726 ms 1.8848 ms]
Found 2 outliers among 100 measurements (2.00%)
  2 (2.00%) high mild

```