### PR TITLE
DHT network join on startup and control_service_address change

### DIFF
--- a/base_layer/p2p/examples/pingpong.rs
+++ b/base_layer/p2p/examples/pingpong.rs
@@ -109,12 +109,12 @@ fn main() {
         host: "0.0.0.0".parse().unwrap(),
         socks_proxy_address: None,
         control_service: ControlServiceConfig {
-            listener_address: node_identity.control_service_address.clone(),
+            listener_address: node_identity.control_service_address().unwrap(),
             socks_proxy_address: None,
             requested_connection_timeout: Duration::from_millis(2000),
         },
         secret_key: node_identity.secret_key.clone(),
-        public_address: node_identity.control_service_address,
+        public_address: node_identity.control_service_address().unwrap(),
         datastore_path: TempDir::new(random_string(8).as_str())
             .unwrap()
             .path()
@@ -132,7 +132,7 @@ fn main() {
     let peer = Peer::new(
         peer_identity.identity.public_key.clone(),
         peer_identity.identity.node_id.clone(),
-        peer_identity.control_service_address.into(),
+        peer_identity.control_service_address().unwrap().into(),
         PeerFlags::empty(),
     );
     comms.peer_manager().add_peer(peer).unwrap();

--- a/base_layer/p2p/src/dht_service/error.rs
+++ b/base_layer/p2p/src/dht_service/error.rs
@@ -27,7 +27,7 @@ use tari_comms::{
     peer_manager::PeerManagerError,
 };
 
-use tari_comms::message::MessageError;
+use tari_comms::{message::MessageError, peer_manager::node_identity::NodeIdentityError};
 use tari_utilities::message_format::MessageFormatError;
 
 #[derive(Debug, Error)]
@@ -49,4 +49,5 @@ pub enum DHTError {
     UnexpectedApiResponse,
     MessageFormatError(MessageFormatError),
     MessageSerializationError(MessageError),
+    NodeIdentityError(NodeIdentityError),
 }

--- a/base_layer/p2p/tests/ping_pong/mod.rs
+++ b/base_layer/p2p/tests/ping_pong/mod.rs
@@ -87,7 +87,7 @@ fn setup_ping_pong_service(
         })
         .configure_control_service(ControlServiceConfig {
             socks_proxy_address: None,
-            listener_address: node_identity.control_service_address.clone(),
+            listener_address: node_identity.control_service_address().unwrap(),
             requested_connection_timeout: Duration::from_millis(5000),
         })
         .build()

--- a/base_layer/wallet/tests/support/comms_and_services.rs
+++ b/base_layer/wallet/tests/support/comms_and_services.rs
@@ -73,7 +73,7 @@ pub fn setup_comms_services(
         })
         .configure_control_service(ControlServiceConfig {
             socks_proxy_address: None,
-            listener_address: node_identity.control_service_address.clone(),
+            listener_address: node_identity.control_service_address().unwrap(),
             requested_connection_timeout: Duration::from_millis(5000),
         })
         .build()
@@ -85,7 +85,8 @@ pub fn setup_comms_services(
         comms
             .peer_manager()
             .add_peer(
-                Peer::from_public_key_and_address(p.identity.public_key.clone(), p.control_service_address).unwrap(),
+                Peer::from_public_key_and_address(p.identity.public_key.clone(), p.control_service_address().unwrap())
+                    .unwrap(),
             )
             .unwrap();
     }

--- a/base_layer/wallet/tests/text_message_service/mod.rs
+++ b/base_layer/wallet/tests/text_message_service/mod.rs
@@ -77,14 +77,14 @@ fn test_text_message_service() {
         .add_contact(Contact::new(
             "Bob".to_string(),
             node_2_identity.identity.public_key.clone(),
-            node_2_identity.control_service_address.clone(),
+            node_2_identity.control_service_address().unwrap(),
         ))
         .unwrap();
     node_1_tms
         .add_contact(Contact::new(
             "Carol".to_string(),
             node_3_identity.identity.public_key.clone(),
-            node_3_identity.control_service_address.clone(),
+            node_3_identity.control_service_address().unwrap(),
         ))
         .unwrap();
 
@@ -92,7 +92,7 @@ fn test_text_message_service() {
         .add_contact(Contact::new(
             "Alice".to_string(),
             node_1_identity.identity.public_key.clone(),
-            node_1_identity.control_service_address.clone(),
+            node_1_identity.control_service_address().unwrap(),
         ))
         .unwrap();
 
@@ -100,7 +100,7 @@ fn test_text_message_service() {
         .add_contact(Contact::new(
             "Alice".to_string(),
             node_1_identity.identity.public_key.clone(),
-            node_1_identity.control_service_address.clone(),
+            node_1_identity.control_service_address().unwrap(),
         ))
         .unwrap();
 

--- a/comms/src/connection_manager/error.rs
+++ b/comms/src/connection_manager/error.rs
@@ -24,7 +24,7 @@ use crate::{
     connection::ConnectionError,
     control_service::{messages::RejectReason, ControlServiceError},
     message::MessageError,
-    peer_manager::PeerManagerError,
+    peer_manager::{node_identity::NodeIdentityError, PeerManagerError},
 };
 use derive_error::Error;
 use tari_utilities::{
@@ -76,4 +76,5 @@ pub enum ConnectionManagerError {
     /// Failed to receive a connection request outcome before the timeout
     ConnectionRequestOutcomeTimeout,
     ControlServiceError(ControlServiceError),
+    NodeIdentityError(NodeIdentityError),
 }

--- a/comms/src/connection_manager/protocol.rs
+++ b/comms/src/connection_manager/protocol.rs
@@ -60,7 +60,7 @@ impl<'e, 'ni> PeerConnectionProtocol<'e, 'ni> {
         // 2. Send a request to connect
         control_client
             .send_request_connection(
-                self.node_identity.control_service_address.clone(),
+                self.node_identity.control_service_address()?,
                 self.node_identity.identity.node_id.clone(),
             )
             .map_err(|err| ConnectionManagerError::SendRequestConnectionFailed(format!("{:?}", err)))?;

--- a/comms/src/control_service/error.rs
+++ b/comms/src/control_service/error.rs
@@ -23,7 +23,7 @@
 use crate::{
     connection::{ConnectionError, NetAddressError},
     message::MessageError,
-    peer_manager::PeerManagerError,
+    peer_manager::{node_identity::NodeIdentityError, PeerManagerError},
 };
 use derive_error::Error;
 use tari_utilities::{ciphers::cipher::CipherError, message_format::MessageFormatError, thread_join::ThreadError};
@@ -58,4 +58,5 @@ pub enum ControlServiceError {
     ConnectionAddressNotEstablished,
     #[error(non_std, no_from, msg_embedded)]
     ConnectionProtocolFailed(String),
+    NodeIdentityError(NodeIdentityError),
 }

--- a/comms/src/control_service/worker.rs
+++ b/comms/src/control_service/worker.rs
@@ -270,8 +270,12 @@ impl ControlServiceWorker {
                     return Err(ControlServiceError::PeerBanned);
                 }
 
-                pm.add_net_address(&peer.node_id, &message.control_service_address)
-                    .map_err(ControlServiceError::PeerManagerError)?;
+                pm.update_peer(
+                    &peer.public_key,
+                    None,
+                    Some(vec![message.control_service_address.clone()]),
+                    None,
+                )?;
 
                 peer
             },
@@ -357,7 +361,7 @@ impl ControlServiceWorker {
                 );
 
                 // Create an address which can be connected to externally
-                let our_host = self.node_identity.control_service_address.host();
+                let our_host = self.node_identity.control_service_address()?.host();
                 let external_address = address
                     .maybe_port()
                     .map(|port| format!("{}:{}", our_host, port))

--- a/comms/tests/control_service/service.rs
+++ b/comms/tests/control_service/service.rs
@@ -127,7 +127,7 @@ fn request_connection() {
     // --- Request a connection to the peer connection
     client
         .send_request_connection(
-            node_identity_b.control_service_address.clone(),
+            node_identity_b.control_service_address().unwrap(),
             NodeId::from_key(&node_identity_b.identity.public_key).unwrap(),
         )
         .unwrap();
@@ -143,7 +143,7 @@ fn request_connection() {
     assert_eq!(peer.node_id, node_identity_b.identity.node_id);
     assert_eq!(
         peer.addresses[0],
-        node_identity_b.control_service_address.clone().into()
+        node_identity_b.control_service_address().unwrap().into()
     );
     assert_eq!(peer.flags, PeerFlags::empty());
 

--- a/comms/tests/support/factories/node_identity.rs
+++ b/comms/tests/support/factories/node_identity.rs
@@ -24,7 +24,7 @@ use super::{TestFactory, TestFactoryError};
 use rand::OsRng;
 use tari_comms::{
     connection::NetAddress,
-    peer_manager::{NodeId, NodeIdentity, PeerNodeIdentity},
+    peer_manager::NodeIdentity,
     types::{CommsPublicKey, CommsSecretKey},
 };
 use tari_crypto::keys::{PublicKey, SecretKey};
@@ -38,7 +38,6 @@ pub struct NodeIdentityFactory {
     control_service_address: Option<NetAddress>,
     secret_key: Option<CommsSecretKey>,
     public_key: Option<CommsPublicKey>,
-    node_id: Option<NodeId>,
 }
 
 impl NodeIdentityFactory {
@@ -51,8 +50,6 @@ impl NodeIdentityFactory {
     factory_setter!(with_secret_key, secret_key, Option<CommsSecretKey>);
 
     factory_setter!(with_public_key, public_key, Option<CommsPublicKey>);
-
-    factory_setter!(with_node_id, node_id, Option<NodeId>);
 }
 
 impl TestFactory for NodeIdentityFactory {
@@ -70,21 +67,11 @@ impl TestFactory for NodeIdentityFactory {
             .public_key
             .or(Some(CommsPublicKey::from_secret_key(&secret_key)))
             .unwrap();
-        let node_id = self
-            .node_id
-            .or(Some(
-                NodeId::from_key(&public_key).map_err(TestFactoryError::build_failed())?,
-            ))
-            .unwrap();
         let control_service_address = self
             .control_service_address
             .or(Some(super::net_address::create().build()?))
             .unwrap();
 
-        Ok(NodeIdentity {
-            identity: PeerNodeIdentity::new(node_id, public_key),
-            secret_key,
-            control_service_address,
-        })
+        NodeIdentity::new(secret_key, public_key, control_service_address).map_err(TestFactoryError::build_failed())
     }
 }


### PR DESCRIPTION
##  Description
- The DHTService will join the network on service start and on detection of control_service_address change
- Added test for new join mechanisms
- Modified control_service worker to not add but replace the control_service_address
- Changed NodeIdentity to allow changing of the control_service_address
- Modified node identity factory to use the NodeIdentity constructor

## Motivation and Context
Node will automatically inform neighbouring nodes of latest control_service_address.

## How Has This Been Tested?
New test has been added

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [x] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch
* [x] I ran `cargo-fmt --all` before pushing
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
