### PR TITLE
Update blockheaders to include rangeproofs and utxo commitments

### DIFF
--- a/base_layer/core/src/blocks/blockheader.rs
+++ b/base_layer/core/src/blocks/blockheader.rs
@@ -67,6 +67,7 @@ pub struct BlockHeader {
     /// Timestamp at which the block was built.
     pub timestamp: DateTime<Utc>,
     /// This is the UTXO merkle root of the outputs
+    /// This is calculated as Hash (txo MMR root  || roaring bitmap hash of UTXO indices)
     #[serde(with = "hash_serializer")]
     pub output_mr: BlockHash,
     /// This is the MMRR root of the range proofs


### PR DESCRIPTION
## Description

1. I updated the Blockheaders to now include rangeproofs in them. We currently commit to the rangeproofs in a MMR. 
2. I have also changed the TXO commitment to include the UTXO commitment. 

## Motivation and Context

1. This was discussed on IRC: https://www.tari.com/2019/07/18/tari-protocol-discussion-43.html
2. This was discussed on IRC: https://www.tari.com/2019/07/15/tari-protocol-discussion-42.html


## Types of changes
* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [x] Documentation

## Checklist:
* [x] I'm merging against the `development` branch
* [x] I ran `cargo-fmt --all` before pushing
* [ ] My change requires a change to the documentation.
* [x] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
