### PR TITLE
Implement store and forward service

### DIFF
--- a/base_layer/p2p/Cargo.toml
+++ b/base_layer/p2p/Cargo.toml
@@ -22,6 +22,7 @@ chrono = { version = "0.4.6", features = ["serde"]}
 tokio = "0.1.22"
 futures = "0.1.28"
 tower-service = "0.2.0"
+ttl_cache = "0.5.1"
 
 [dev-dependencies]
 tempdir = "0.3.7"

--- a/base_layer/p2p/src/consts.rs
+++ b/base_layer/p2p/src/consts.rs
@@ -20,5 +20,14 @@
 //  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 //  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+use std::time::Duration;
+
 /// The maximum number of peer nodes that a message will be sent to
 pub const DHT_BROADCAST_NODE_COUNT: usize = 8;
+
+/// The maximum number of messages that can be stored using the Store-and-forward service
+pub const SAF_MSG_CACHE_STORAGE_CAPACITY: usize = 10000;
+/// The time-to-live duration used for storage of low priority messages by the Store-and-forward service
+pub const SAF_LOW_PRIORITY_MSG_STORAGE_TTL: Duration = Duration::from_secs(6 * 60 * 60);
+/// The time-to-live duration used for storage of high priority messages by the Store-and-forward service
+pub const SAF_HIGH_PRIORITY_MSG_STORAGE_TTL: Duration = Duration::from_secs(24 * 60 * 60);

--- a/base_layer/p2p/src/saf_service/error.rs
+++ b/base_layer/p2p/src/saf_service/error.rs
@@ -21,17 +21,35 @@
 //  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 use derive_error::Error;
-use tari_comms::domain_connector::ConnectorError;
+use tari_comms::{
+    connection::ConnectionError,
+    domain_connector::ConnectorError,
+    message::MessageError,
+    outbound_message_service::OutboundError,
+    peer_manager::PeerManagerError,
+};
 
 #[derive(Debug, Error)]
 pub enum SAFError {
+    OutboundError(OutboundError),
     ConnectorError(ConnectorError),
     /// OMS has not been initialized
     OMSUndefined,
+    /// The current nodes identity is undefined
+    NodeIdentityUndefined,
+    /// PeerManager has not been initialized
+    PeerManagerUndefined,
+    PeerManagerError(PeerManagerError),
+    ///  ZMQContext has not been initialized
+    ZMQContextUndefined,
+    /// Message Sink Address for InboundMessageService has not been initialized
+    IMSMessageSinkAddressUndefined,
     /// Failed to send from API
     ApiSendFailed,
     /// Failed to receive in API from service
     ApiReceiveFailed,
     /// Received an unexpected response type from the API
     UnexpectedApiResponse,
+    MessageError(MessageError),
+    ConnectionError(ConnectionError),
 }

--- a/base_layer/p2p/src/saf_service/saf_messages.rs
+++ b/base_layer/p2p/src/saf_service/saf_messages.rs
@@ -31,7 +31,7 @@ use tari_comms::message::{Message, MessageEnvelope, MessageError};
 /// will be sent.
 #[derive(Serialize, Deserialize)]
 pub struct RetrieveMsgsMessage {
-    start_time: Option<DateTime<Utc>>,
+    pub start_time: Option<DateTime<Utc>>,
 }
 
 impl TryInto<Message> for RetrieveMsgsMessage {
@@ -45,7 +45,7 @@ impl TryInto<Message> for RetrieveMsgsMessage {
 /// The StoredMsgsMessage contains the set of applicable messages retrieved from a neighbouring peer node.
 #[derive(Serialize, Deserialize)]
 pub struct StoredMsgsMessage {
-    pub messages: Vec<MessageEnvelope>,
+    pub message_envelopes: Vec<MessageEnvelope>,
 }
 
 impl TryInto<Message> for StoredMsgsMessage {

--- a/base_layer/p2p/src/services/executor.rs
+++ b/base_layer/p2p/src/services/executor.rs
@@ -40,7 +40,7 @@ use crossbeam_channel as channel;
 use crossbeam_channel::{Receiver, RecvTimeoutError, Sender};
 use tari_comms::{
     builder::{CommsRoutes, CommsServicesError},
-    connection::ZmqContext,
+    connection::{InprocAddress, ZmqContext},
 };
 
 const LOG_TARGET: &str = "base_layer::p2p::services";
@@ -75,6 +75,7 @@ impl ServiceExecutor {
 
             let service_context = ServiceContext {
                 oms: comms_services.outbound_message_service(),
+                ims_message_sink_address: comms_services.connection_manager().get_message_sink_address().clone(),
                 peer_manager: comms_services.peer_manager(),
                 node_identity: comms_services.node_identity(),
                 receiver,
@@ -152,6 +153,7 @@ impl ServiceExecutor {
 /// a particular [TariMessageType].
 pub struct ServiceContext {
     oms: Arc<OutboundMessageService>,
+    ims_message_sink_address: InprocAddress,
     peer_manager: Arc<PeerManager>,
     node_identity: Arc<NodeIdentity>,
     receiver: Receiver<ServiceControlMessage>,
@@ -185,6 +187,16 @@ impl ServiceContext {
     /// Retrieve and `Arc` of the NodeIdentity. Used for managing the current Nodes Identity.
     pub fn node_identity(&self) -> Arc<NodeIdentity> {
         Arc::clone(&self.node_identity)
+    }
+
+    /// Retrieve a reference to the message sink address of the InboundMessageService
+    pub fn ims_message_sink_address(&self) -> &InprocAddress {
+        &self.ims_message_sink_address
+    }
+
+    /// Retrieve a reference to the ZmqContext
+    pub fn zmq_context(&self) -> &ZmqContext {
+        &self.zmq_context
     }
 
     /// Create a [DomainConnector] which listens for a particular [TariMessageType].

--- a/base_layer/p2p/tests/mod.rs
+++ b/base_layer/p2p/tests/mod.rs
@@ -22,4 +22,5 @@
 
 mod dht;
 mod ping_pong;
+mod saf;
 mod support;

--- a/base_layer/p2p/tests/saf/mod.rs
+++ b/base_layer/p2p/tests/saf/mod.rs
@@ -1,0 +1,177 @@
+//  Copyright 2019 The Tari Project
+//
+//  Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+//  following conditions are met:
+//
+//  1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+//  disclaimer.
+//
+//  2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+//  following disclaimer in the documentation and/or other materials provided with the distribution.
+//
+//  3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+//  products derived from this software without specific prior written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+//  INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+//  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+//  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+//  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+//  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+//  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+// NOTE: These tests use ports 11123 to 11125
+use crate::support::random_string;
+use rand::rngs::OsRng;
+use std::{convert::TryInto, sync::Arc, thread, time::Duration};
+use tari_comms::{
+    builder::CommsServices,
+    connection::NetAddress,
+    connection_manager::PeerConnectionConfig,
+    control_service::ControlServiceConfig,
+    message::{Frame, Message, MessageEnvelope, MessageFlags, NodeDestination},
+    peer_manager::{peer_storage::PeerStorage, NodeIdentity, Peer, PeerManager},
+    types::CommsDatabase,
+    CommsBuilder,
+};
+use tari_p2p::{
+    dht_service::{DHTService, DHTServiceApi, DiscoverMessage},
+    saf_service::{SAFService, SAFServiceApi},
+    services::{ServiceExecutor, ServiceRegistry},
+    tari_message::TariMessageType,
+};
+use tari_storage::lmdb_store::LMDBBuilder;
+use tari_utilities::message_format::MessageFormat;
+use tempdir::TempDir;
+
+fn new_node_identity(control_service_address: NetAddress) -> NodeIdentity {
+    NodeIdentity::random(&mut OsRng::new().unwrap(), control_service_address).unwrap()
+}
+
+fn create_peer_storage(tmpdir: &TempDir, database_name: &str, peers: Vec<Peer>) -> CommsDatabase {
+    let datastore = LMDBBuilder::new()
+        .set_path(tmpdir.path().to_str().unwrap())
+        .set_environment_size(10)
+        .set_max_number_of_databases(1)
+        .add_database(database_name, lmdb_zero::db::CREATE)
+        .build()
+        .unwrap();
+
+    let peer_database = datastore.get_handle(database_name).unwrap();
+    let mut storage = PeerStorage::new(peer_database).unwrap();
+    for peer in peers {
+        storage.add_peer(peer).unwrap();
+    }
+
+    storage.into_datastore()
+}
+
+fn setup_services(
+    node_identity: NodeIdentity,
+    peer_storage: CommsDatabase,
+) -> (
+    ServiceExecutor,
+    Arc<SAFServiceApi>,
+    Arc<DHTServiceApi>,
+    Arc<CommsServices<TariMessageType>>,
+)
+{
+    let control_service_address = node_identity.control_service_address().unwrap();
+    let saf_service = SAFService::new();
+    let saf_api = saf_service.get_api();
+    let dht_service = DHTService::new();
+    let dht_api = dht_service.get_api();
+
+    let services = ServiceRegistry::new().register(saf_service).register(dht_service);
+    let comms = CommsBuilder::new()
+        .with_routes(services.build_comms_routes())
+        .with_node_identity(node_identity)
+        .with_peer_storage(peer_storage)
+        .configure_peer_connections(PeerConnectionConfig {
+            host: "127.0.0.1".parse().unwrap(),
+            ..Default::default()
+        })
+        .configure_control_service(ControlServiceConfig {
+            socks_proxy_address: None,
+            listener_address: control_service_address,
+            requested_connection_timeout: Duration::from_millis(5000),
+        })
+        .build()
+        .unwrap()
+        .start()
+        .map(Arc::new)
+        .unwrap();
+
+    (ServiceExecutor::execute(&comms, services), saf_api, dht_api, comms)
+}
+
+fn pause() {
+    thread::sleep(Duration::from_millis(3000));
+}
+
+#[test]
+#[allow(non_snake_case)]
+fn test_saf_store() {
+    // Create 3 nodes where only Node B knows A and C, but A wants to talk to Node C. Node A and C are not online at the
+    // same time.
+    let node_A_identity = new_node_identity("127.0.0.1:11123".parse().unwrap());
+    let node_B_identity = new_node_identity("127.0.0.1:11124".parse().unwrap());
+    let node_C_identity = new_node_identity("127.0.0.1:11125".parse().unwrap());
+
+    // Setup Node B
+    let node_B_tmpdir = TempDir::new(random_string(8).as_str()).unwrap();
+    let node_B_database_name = "node_B";
+    let (node_B_services, node_B_saf_service_api, _node_B_dht_service_api, _comms_B) = setup_services(
+        node_B_identity.clone(),
+        create_peer_storage(&node_B_tmpdir, node_B_database_name, vec![
+            node_A_identity.clone().into(),
+            node_C_identity.clone().into(),
+        ]),
+    );
+
+    // Node A is sending a discovery message to Node C through Node B, but Node C is offline
+    // TODO: The comms stack of Node B should automatically store the forwarded message, this is not yet implemented.
+    // This storage behaviour is mimicked by manually storing the message from Node A in Node B.
+    let discover_msg: Message = DiscoverMessage {
+        node_id: node_A_identity.identity.node_id.clone(),
+        net_address: vec![node_A_identity.control_service_address().unwrap()],
+    }
+    .try_into()
+    .unwrap();
+    let message_envelope_body: Frame = discover_msg.to_binary().unwrap();
+    let message_envelope = MessageEnvelope::construct(
+        &node_A_identity,
+        node_C_identity.identity.public_key.clone(),
+        NodeDestination::Unknown,
+        message_envelope_body.clone(),
+        MessageFlags::ENCRYPTED,
+    )
+    .unwrap();
+    node_B_saf_service_api.store(message_envelope).unwrap(); // This should happen automatically when node B tries to forward the message
+
+    pause();
+
+    // Node C comes online
+    let node_C_tmpdir = TempDir::new(random_string(8).as_str()).unwrap();
+    let node_C_database_name = "node_C";
+    let (node_C_services, node_C_saf_service_api, _node_C_dht_service_api, _comms_C) = setup_services(
+        node_C_identity.clone(),
+        create_peer_storage(&node_C_tmpdir, node_C_database_name, vec![node_B_identity
+            .clone()
+            .into()]),
+    );
+    // Retrieve messages from Node B
+    node_C_saf_service_api.retrieve(None).unwrap();
+
+    pause();
+    node_B_services.shutdown().unwrap();
+    node_C_services.shutdown().unwrap();
+
+    // Restore PeerStorage of Node C and check that it is aware of Node A
+    pause();
+    let node_C_peer_manager =
+        PeerManager::new(create_peer_storage(&node_C_tmpdir, node_C_database_name, vec![])).unwrap();
+    assert!(node_C_peer_manager
+        .exists(&node_A_identity.identity.public_key)
+        .unwrap());
+}

--- a/comms/src/builder/builder.rs
+++ b/comms/src/builder/builder.rs
@@ -426,6 +426,10 @@ where
         Arc::clone(&self.node_identity)
     }
 
+    pub fn connection_manager(&self) -> Arc<ConnectionManager> {
+        Arc::clone(&self.connection_manager)
+    }
+
     pub fn outbound_message_service(&self) -> Arc<OutboundMessageService> {
         Arc::clone(&self.outbound_message_service)
     }

--- a/comms/src/connection/peer_connection/worker.rs
+++ b/comms/src/connection/peer_connection/worker.rs
@@ -53,6 +53,7 @@ use std::{
     thread::{self, JoinHandle},
     time::Duration,
 };
+use tari_utilities::message_format::MessageFormat;
 
 const LOG_TARGET: &str = "comms::connection::peer_connection::worker";
 
@@ -483,8 +484,10 @@ impl PeerConnectionWorker {
     }
 
     fn construct_consumer_payload(&self, frames: FrameSet) -> FrameSet {
-        let mut payload = Vec::with_capacity(1 + frames.len());
+        let mut payload = Vec::with_capacity(2 + frames.len());
         payload.push(self.context.id.clone().into_inner());
+        let forwardable = true;
+        payload.extend(forwardable.to_binary());
         payload.extend_from_slice(&frames);
         payload
     }

--- a/comms/src/connection_manager/manager.rs
+++ b/comms/src/connection_manager/manager.rs
@@ -30,7 +30,15 @@ use super::{
     Result,
 };
 use crate::{
-    connection::{ConnectionError, CurveEncryption, CurvePublicKey, PeerConnection, PeerConnectionState, ZmqContext},
+    connection::{
+        zmq::InprocAddress,
+        ConnectionError,
+        CurveEncryption,
+        CurvePublicKey,
+        PeerConnection,
+        PeerConnectionState,
+        ZmqContext,
+    },
     control_service::messages::RejectReason,
     peer_manager::{NodeId, NodeIdentity, Peer, PeerManager},
 };
@@ -277,6 +285,10 @@ impl ConnectionManager {
     /// Return the number of _active_ peer connections currently managed by this instance
     pub fn get_active_connection_count(&self) -> usize {
         self.connections.get_active_connection_count()
+    }
+
+    pub fn get_message_sink_address(&self) -> &InprocAddress {
+        &self.establisher.get_config().message_sink_address
     }
 
     fn initiate_peer_connection(&self, peer: &Peer) -> Result<Arc<PeerConnection>> {

--- a/comms/src/inbound_message_service/inbound_message_service.rs
+++ b/comms/src/inbound_message_service/inbound_message_service.rs
@@ -193,8 +193,8 @@ mod test {
             MessageFlags::NONE,
         )
         .unwrap();
-        let message_data = MessageData::new(node_identity.identity.node_id.clone(), message_envelope);
-        message_data.clone().try_into_frame_set().unwrap()
+        let message_data = MessageData::new(node_identity.identity.node_id.clone(), true, message_envelope);
+        message_data.clone().into_frame_set()
     }
 
     #[test]

--- a/comms/src/inbound_message_service/inbound_message_worker.rs
+++ b/comms/src/inbound_message_service/inbound_message_worker.rs
@@ -156,6 +156,7 @@ where
                                     let message_context = MessageContext::new(
                                         self.node_identity.clone(),
                                         peer,
+                                        message_data.forwardable,
                                         message_data.message_envelope,
                                         self.outbound_message_service.clone(),
                                         self.peer_manager.clone(),
@@ -345,10 +346,11 @@ mod test {
         .unwrap();
         let message_data1 = MessageData::new(
             NodeId::from_key(&node_identity.identity.public_key).unwrap(),
+            true,
             message_envelope,
         );
         let mut message1_frame_set = Vec::new();
-        message1_frame_set.extend(message_data1.clone().try_into_frame_set().unwrap());
+        message1_frame_set.extend(message_data1.clone().into_frame_set());
 
         // Construct test message 2
         let message_header = MessageHeader::new(DomainBrokerType::Type2).unwrap();
@@ -364,10 +366,11 @@ mod test {
         .unwrap();
         let message_data2 = MessageData::new(
             NodeId::from_key(&node_identity.identity.public_key).unwrap(),
+            true,
             message_envelope,
         );
         let mut message2_frame_set = Vec::new();
-        message2_frame_set.extend(message_data2.clone().try_into_frame_set().unwrap());
+        message2_frame_set.extend(message_data2.clone().into_frame_set());
 
         // Submit Messages to the Worker
         pause();

--- a/comms/src/message/message_context.rs
+++ b/comms/src/message/message_context.rs
@@ -31,6 +31,7 @@ use std::sync::Arc;
 
 #[derive(Clone)]
 pub struct MessageContext<MType> {
+    pub forwardable: bool,
     pub message_envelope: MessageEnvelope,
     pub peer: Peer,
     pub outbound_message_service: Arc<OutboundMessageService>,
@@ -49,6 +50,7 @@ where
     pub fn new(
         node_identity: Arc<NodeIdentity>,
         peer: Peer,
+        forwardable: bool,
         message_envelope: MessageEnvelope,
         outbound_message_service: Arc<OutboundMessageService>,
         peer_manager: Arc<PeerManager>,
@@ -56,6 +58,7 @@ where
     ) -> Self
     {
         MessageContext {
+            forwardable,
             message_envelope,
             peer,
             node_identity,

--- a/comms/src/peer_manager/peer_manager.rs
+++ b/comms/src/peer_manager/peer_manager.rs
@@ -109,6 +109,15 @@ impl PeerManager {
             .exists(public_key))
     }
 
+    /// Check if a peer exist using the specified node_id
+    pub fn exists_node_id(&self, node_id: &NodeId) -> Result<bool, PeerManagerError> {
+        Ok(self
+            .peer_storage
+            .read()
+            .map_err(|_| PeerManagerError::PoisonedAccess)?
+            .exists_node_id(node_id))
+    }
+
     /// Request a sub-set of peers based on the provided BroadcastStrategy
     pub fn get_broadcast_identities(
         &self,

--- a/comms/src/peer_manager/peer_storage.rs
+++ b/comms/src/peer_manager/peer_storage.rs
@@ -209,6 +209,11 @@ where DS: KeyValStore
         self.public_key_hm.get(&public_key).is_some()
     }
 
+    /// Check if a peer exist using the specified node_id
+    pub fn exists_node_id(&self, node_id: &NodeId) -> bool {
+        self.node_id_hm.get(&node_id).is_some()
+    }
+
     /// Constructs a single NodeIdentity for the peer corresponding to the provided NodeId
     pub fn direct_identity_node_id(&self, node_id: &NodeId) -> Result<Vec<PeerNodeIdentity>, PeerManagerError> {
         let peer_key = *self

--- a/comms/tests/connection/peer_connection.rs
+++ b/comms/tests/connection/peer_connection.rs
@@ -157,7 +157,8 @@ fn connection_out() {
         .unwrap();
     let frames = consumer.receive(2000).unwrap();
     assert_eq!(conn_id.to_vec(), frames[1]);
-    assert_eq!(vec![123u8], frames[2]);
+    assert_eq!(vec![1u8], frames[2]);
+    assert_eq!(vec![123u8], frames[3]);
 }
 
 #[test]
@@ -291,11 +292,11 @@ fn connection_pause_resume() {
 
     // Should receive all the pending messages
     let frames = consumer.receive(3000).unwrap();
-    assert_eq!(vec![2u8], frames[2]);
+    assert_eq!(vec![2u8], frames[3]);
     let frames = consumer.receive(3000).unwrap();
-    assert_eq!(vec![3u8], frames[2]);
+    assert_eq!(vec![3u8], frames[3]);
     let frames = consumer.receive(3000).unwrap();
-    assert_eq!(vec![4u8], frames[2]);
+    assert_eq!(vec![4u8], frames[3]);
 }
 
 #[test]
@@ -454,6 +455,7 @@ fn ignore_invalid_message_types() {
     let frames = consumer.receive(2000).unwrap();
     assert_eq!("123".as_bytes().to_vec(), frames[1]);
     assert_eq!(vec![1u8], frames[2]);
+    assert_eq!(vec![1u8], frames[3]);
 
     // Test no more messages to receive. Since we have received above, the invalid message
     // should be already ready to receive (10ms) if it was forwarded by the peer connection.


### PR DESCRIPTION
## Description
- Implemented the Store-and-forward service functions: send_retrieval_request, receive_retrieval_request, receive_stored_messages and store_message
- Modified service executor and connection manager to provide access to the IMS message_sink_address and zmq_context
- Added a Store-and-forward test
- Added a forwardable field to MessageData to enable and disable the forwarding of a messages by the comms stack. Disabled forwarding of a message in the comms_msg_handlers when this field is set.
- Added exists_node_id function to peer_manager

## Motivation and Context
The Store-and-forward service will allow peers to send messages between each other even if they are not online at the same time.

## How Has This Been Tested?
A Store-and-forward test has been added

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [x] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch
* [x] I ran `cargo-fmt --all` before pushing
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
