### PR TITLE
Refactor ConsensusRules Struct for More Test Ergonomics

### DIFF
--- a/base_layer/core/src/blockchain/block_chain_state.rs
+++ b/base_layer/core/src/blockchain/block_chain_state.rs
@@ -28,8 +28,7 @@
 use crate::{
     blockchain::error::StateError,
     blocks::{block::Block, blockheader::BlockHeader, genesis_block::*},
-    emission::EmissionSchedule,
-    tari_amount::MicroTari,
+    consensus::ConsensusRules,
     transaction::{TransactionInput, TransactionKernel},
     types::*,
 };
@@ -45,9 +44,9 @@ pub struct BlockchainState {
     utxos: MerkleMountainRange<TransactionInput, SignatureHash>,
     kernels: MerkleMountainRange<TransactionKernel, SignatureHash>,
     rangeproofs: MerkleMountainRange<RangeProof, SignatureHash>,
-    schedule: EmissionSchedule,
     store: LMDBStore,
 }
+
 #[allow(clippy::new_without_default)]
 impl BlockchainState {
     /// Creates a new empty blockchainstate
@@ -63,24 +62,16 @@ impl BlockchainState {
         kernels.init_persistance_store(&"kernels".to_string(), std::usize::MAX);
         let mut rangeproofs = MerkleMountainRange::new();
         rangeproofs.init_persistance_store(&"rangeproofs".to_string(), 5000);
-        let schedule = EmissionSchedule::new();
         let mut block_chain_state = BlockchainState {
             headers,
             utxos,
             kernels,
-            schedule,
             rangeproofs,
             store,
         };
         block_chain_state.add_genesis_block();
 
         Ok(block_chain_state)
-    }
-
-    /// This function will create the correct amount for the coinbase given the block height, it will provide the answer
-    /// in µTari (micro Tari)
-    fn calculate_coinbase(&self, block_height: u64) -> MicroTari {
-        self.schedule.block_reward(block_height)
     }
 
     // add the genesis block
@@ -128,12 +119,12 @@ impl BlockchainState {
 
     /// This function  will process a new block.
     /// Note the block is consumed by the function.
-    pub fn process_new_block(&mut self, new_block: &Block) -> Result<(), StateError> {
+    pub fn process_new_block(&mut self, new_block: &Block, consensus_rules: &ConsensusRules) -> Result<(), StateError> {
         let found = self.headers.get_object(&new_block.header.hash());
         if found.is_some() {
             return Err(StateError::DuplicateBlock);
         }
-        self.validate_new_block(&new_block)?;
+        self.validate_new_block(&new_block, consensus_rules)?;
         // let add the rangeproofs
         for output in &new_block.body.outputs {
             self.rangeproofs.push(output.proof().clone())?;
@@ -151,9 +142,9 @@ impl BlockchainState {
     }
 
     /// This function will validate the block in terms of the current state.
-    pub fn validate_new_block(&self, new_block: &Block) -> Result<(), StateError> {
+    pub fn validate_new_block(&self, new_block: &Block, consensus_rules: &ConsensusRules) -> Result<(), StateError> {
         new_block
-            .check_internal_consistency(self.calculate_coinbase(new_block.header.height))
+            .check_internal_consistency(consensus_rules)
             .map_err(|e| StateError::InvalidBlock(e))?;
         // we assume that we have atleast in block in the headers mmr even if this is the genesis one
         if self.headers.get_last_added_object().unwrap().hash() != new_block.header.prev_hash {

--- a/base_layer/core/src/blocks/blockheader.rs
+++ b/base_layer/core/src/blocks/blockheader.rs
@@ -37,7 +37,7 @@
 //! state = Hash(Hash(mmr_root)|| Hash(roaring_bitmap))
 //! This hash is called the UTXO merkle root, and is used as the output_mr
 
-use crate::{consensus::*, pow::*, types::*};
+use crate::{pow::*, types::*};
 use chrono::{DateTime, NaiveDate, Utc};
 use digest::Input;
 use serde::{
@@ -89,12 +89,10 @@ impl BlockHeader {
     pub fn validate_pow(&self) -> bool {
         unimplemented!();
     }
-}
 
-impl Default for BlockHeader {
-    fn default() -> Self {
+    pub fn new(blockchain_version: u16) -> BlockHeader {
         BlockHeader {
-            version: ConsensusRules::get_blockchain_version(),
+            version: blockchain_version,
             height: 0,
             prev_hash: [0; 32],
             timestamp: DateTime::<Utc>::from_utc(NaiveDate::from_ymd(2000, 1, 1).and_hms(1, 1, 1), Utc),

--- a/base_layer/core/src/consensus.rs
+++ b/base_layer/core/src/consensus.rs
@@ -20,114 +20,40 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use crate::{tari_amount::MicroTari, types::CONSENSUS_RULES};
-use std::env;
+use crate::emission::EmissionSchedule;
 
 /// This is used to control all consensus values.
-#[derive(Clone, Copy)]
 pub struct ConsensusRules {
     /// The min height maturity a coinbase utxo must have
-    pub coinbase_lock_height: u64,
-    /// The max range proof size that is allowed to be created
-    pub max_range_proof_range: usize,
-    /// This is emission schedule initial amount, the decay and the tail emission
-    pub emission_schedule: EmissionParameters,
+    coinbase_lock_height: u64,
+    /// The emission schedule to use for coinbase rewards
+    emission_schedule: EmissionSchedule,
     /// Current version of the blockchain
-    pub blockchain_version: u16,
-}
-
-#[derive(Clone, Copy)]
-pub struct EmissionParameters {
-    pub initial: MicroTari,
-    pub decay: f64,
-    pub tail: MicroTari,
-}
-
-impl Default for ConsensusRules {
-    fn default() -> Self {
-        ConsensusRules {
-            coinbase_lock_height: 1440,
-            max_range_proof_range: 64,
-            emission_schedule: EmissionParameters {
-                initial: MicroTari::from(10_000_000),
-                decay: 0.999,
-                tail: MicroTari::from(100),
-            },
-            blockchain_version: 0,
-        }
-    }
+    blockchain_version: u16,
 }
 
 impl ConsensusRules {
-    pub fn new_as_test() -> Self {
+    pub fn current() -> Self {
+        //        CONSENSUS_RULES
         ConsensusRules {
             coinbase_lock_height: 1,
-            max_range_proof_range: 32,
-            emission_schedule: EmissionParameters {
-                initial: MicroTari::from(10_000_000),
-                decay: 0.999,
-                tail: MicroTari::from(100),
-            },
-            blockchain_version: 0,
+            emission_schedule: EmissionSchedule::new(10_000_000.into(), 0.999, 100.into()),
+            blockchain_version: 1,
         }
     }
 
-    pub fn new_as_integration_test() -> Self {
-        ConsensusRules {
-            coinbase_lock_height: 1,
-            max_range_proof_range: 64,
-            emission_schedule: EmissionParameters {
-                initial: MicroTari::from(10_000_000),
-                decay: 0.999,
-                tail: MicroTari::from(100),
-            },
-            blockchain_version: 0,
-        }
+    /// The min height maturity a coinbase utxo must have
+    pub fn coinbase_lock_height(&self) -> u64 {
+        self.coinbase_lock_height
     }
 
-    pub fn new_as_prod() -> Self {
-        ConsensusRules::default()
+    /// Current version of the blockchain
+    pub fn blockchain_version(&self) -> u16 {
+        self.blockchain_version
     }
 
-    pub fn get_coinbase_lock_height() -> u64 {
-        CONSENSUS_RULES.coinbase_lock_height
-    }
-
-    pub fn get_max_range_proof_range() -> usize {
-        CONSENSUS_RULES.max_range_proof_range
-    }
-
-    pub fn get_blockchain_version() -> u16 {
-        CONSENSUS_RULES.blockchain_version
-    }
-
-    pub fn set_prod() {
-        let key = "CONSENSUSRULES";
-        env::set_var(key, "PRODUCTION");
-    }
-
-    pub fn set_test() {
-        let key = "CONSENSUSRULES";
-        env::set_var(key, "UNIT_TEST");
-    }
-
-    pub fn set_integration_test() {
-        let key = "CONSENSUSRULES";
-        env::set_var(key, "INTEGRATION_TEST");
-    }
-
-    pub fn get_emission_parameters() -> EmissionParameters {
-        CONSENSUS_RULES.emission_schedule
-    }
-}
-#[cfg(test)]
-mod test1 {
-    use super::*;
-
-    #[test]
-    fn debug() {
-        ConsensusRules::set_test();
-        assert_eq!(ConsensusRules::get_coinbase_lock_height(), 1);
-        assert_eq!(ConsensusRules::get_max_range_proof_range(), 32);
+    /// The emission schedule to use for coinbase rewards
+    pub fn emission_schedule(&self) -> &EmissionSchedule {
+        &self.emission_schedule
     }
 }

--- a/base_layer/core/src/emission.rs
+++ b/base_layer/core/src/emission.rs
@@ -20,13 +20,14 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use crate::{consensus::ConsensusRules, tari_amount::MicroTari};
+use crate::tari_amount::MicroTari;
 
 /// The Tari emission schedule. The emission schedule determines how much Tari is mined as a block reward at every
 /// block.
 ///
 /// NB: We don't know what the final emission schedule will be on Tari yet, so do not give any weight to values or
 /// formulae provided in this file, they will almost certainly change ahead of main-net release.
+#[derive(Clone)]
 pub struct EmissionSchedule {
     initial: MicroTari,
     decay: f64,
@@ -46,18 +47,8 @@ impl EmissionSchedule {
     ///  * $$A_0$$ is the genesis block reward
     ///  * $$1-r$$ is the decay rate
     ///  * $$t$$ is the constant tail emission rate
-    pub fn new_with(initial: MicroTari, decay: f64, tail: MicroTari) -> EmissionSchedule {
+    pub fn new(initial: MicroTari, decay: f64, tail: MicroTari) -> EmissionSchedule {
         EmissionSchedule { initial, decay, tail }
-    }
-
-    /// Creates a new emssion schedule instance from the conensus rules
-    pub fn new() -> EmissionSchedule {
-        let emission = ConsensusRules::get_emission_parameters();
-        EmissionSchedule {
-            initial: emission.initial,
-            decay: emission.decay,
-            tail: emission.tail,
-        }
     }
 
     /// Calculate the block reward for the given block height, in µTari
@@ -91,7 +82,7 @@ impl EmissionSchedule {
     /// use tari_core::emission::EmissionSchedule;
     /// use tari_core::tari_amount::MicroTari;
     /// // Print the reward and supply for first 100 blocks
-    /// let schedule = EmissionSchedule::new();
+    /// let schedule = EmissionSchedule::new(10.into(), 0.9, 1.into());
     /// for (n, reward, supply) in schedule.iter().take(100) {
     ///     println!("{:3} {:9} {:9}", n, reward, supply);
     /// }
@@ -137,7 +128,7 @@ mod test {
 
     #[test]
     fn schedule() {
-        let schedule = EmissionSchedule::new_with(MicroTari::from(10_000_000), 0.999, MicroTari::from(100));
+        let schedule = EmissionSchedule::new(MicroTari::from(10_000_000), 0.999, MicroTari::from(100));
         let r0 = schedule.block_reward(0);
         assert_eq!(r0, MicroTari::from(10_000_100));
         let s0 = schedule.supply_at_block(0);
@@ -149,7 +140,7 @@ mod test {
     #[test]
     fn huge_block_number() {
         let mut n = (std::i32::MAX - 1) as u64;
-        let schedule = EmissionSchedule::new_with(MicroTari::from(1e21 as u64), 0.999_9999, MicroTari::from(100));
+        let schedule = EmissionSchedule::new(MicroTari::from(1e21 as u64), 0.999_9999, MicroTari::from(100));
         for _ in 0..3 {
             assert_eq!(schedule.block_reward(n), MicroTari::from(100));
             n += 1;
@@ -157,47 +148,8 @@ mod test {
     }
 
     #[test]
-    fn iterator() {
-        let schedule = EmissionSchedule::new_with(MicroTari::from(10_000_000), 0.999, MicroTari::from(100));
-        let values: Vec<(u64, MicroTari, MicroTari)> = schedule.iter().take(101).collect();
-        assert_eq!(values[0].0, 0);
-        assert_eq!(values[0].1, MicroTari::from(10_000_100));
-        assert_eq!(values[0].2, MicroTari::from(10_000_100));
-        assert_eq!(values[100].0, 100);
-        assert_eq!(values[100].1, MicroTari::from(9_048_021));
-        assert_eq!(values[100].2, MicroTari::from(961_136_499));
-
-        let mut tot_supply = MicroTari::default();
-        for (_, reward, supply) in schedule.iter().take(1000) {
-            tot_supply += reward;
-            assert_eq!(tot_supply, supply);
-        }
-    }
-
-    #[test]
-    fn schedule_with_consensus() {
-        let schedule = EmissionSchedule::new();
-        let r0 = schedule.block_reward(0);
-        assert_eq!(r0, MicroTari::from(10_000_100));
-        let s0 = schedule.supply_at_block(0);
-        assert_eq!(s0, MicroTari::from(10_000_100));
-        assert_eq!(schedule.block_reward(100), MicroTari::from(9_048_021));
-        assert_eq!(schedule.supply_at_block(100), MicroTari::from(961_136_499));
-    }
-
-    #[test]
-    fn huge_block_number_with_consensus() {
-        let mut n = (std::i32::MAX - 1) as u64;
-        let schedule = EmissionSchedule::new();
-        for _ in 0..3 {
-            assert_eq!(schedule.block_reward(n), MicroTari::from(100));
-            n += 1;
-        }
-    }
-
-    #[test]
-    fn iterator_with_consensus() {
-        let schedule = EmissionSchedule::new();
+    fn generate_emission_schedule_as_iterator() {
+        let schedule = EmissionSchedule::new(MicroTari::from(10_000_000), 0.999, MicroTari::from(100));
         let values: Vec<(u64, MicroTari, MicroTari)> = schedule.iter().take(101).collect();
         assert_eq!(values[0].0, 0);
         assert_eq!(values[0].1, MicroTari::from(10_000_100));

--- a/base_layer/core/src/transaction.rs
+++ b/base_layer/core/src/transaction.rs
@@ -79,10 +79,10 @@ impl OutputFeatures {
         buf
     }
 
-    pub fn create_coinbase(current_block_height: u64) -> OutputFeatures {
+    pub fn create_coinbase(current_block_height: u64, consensus_rules: &ConsensusRules) -> OutputFeatures {
         OutputFeatures {
             flags: OutputFlags::COINBASE_OUTPUT,
-            maturity: ConsensusRules::get_coinbase_lock_height() + current_block_height,
+            maturity: consensus_rules.coinbase_lock_height() + current_block_height,
         }
     }
 }

--- a/base_layer/core/src/types.rs
+++ b/base_layer/core/src/types.rs
@@ -23,8 +23,7 @@
 // Portions of this file were originally copyrighted (c) 2018 The Grin Developers, issued under the Apache License,
 // Version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0.
 
-use crate::{bullet_rangeproofs::BulletRangeProof, consensus::ConsensusRules, pow::*};
-use std::env;
+use crate::{bullet_rangeproofs::BulletRangeProof, pow::*};
 use tari_crypto::{
     common::Blake256,
     ristretto::{
@@ -71,30 +70,13 @@ pub type RangeProof = BulletRangeProof;
 
 /// Specify the Proof of Work
 pub type ProofOfWork = MockProofOfWork;
+#[cfg(test)]
+pub const MAX_RANGE_PROOF_RANGE: usize = 32; // 2^32 This is the only way to produce failing range proofs for the tests
+#[cfg(not(test))]
+pub const MAX_RANGE_PROOF_RANGE: usize = 64; // 2^64
 
-// Set up some "global" services for the Tari blockchain - These are most likely not threadsafe as written, but haven't
-// checked.
-
-// This looks for a CONSENSUSRULES in the env vars.
-// This is used to "pass-in" a parameter to lazy static so that it knows which constructor to use.
-lazy_static! {
-    pub static ref CONSENSUS_RULES: ConsensusRules = {
-        let key = "CONSENSUSRULES";
-        let consensus = match env::var(key) {
-            Ok(val) => match val.as_ref() {
-                "PRODUCTION" => ConsensusRules::new_as_prod(),
-                "UNIT_TEST" => ConsensusRules::new_as_test(),
-                "INTEGRATION_TEST" => ConsensusRules::new_as_integration_test(),
-                _ => ConsensusRules::new_as_test(),
-            },
-            Err(_e) => ConsensusRules::new_as_test(),
-        };
-        env::remove_var(key); //we dont want to leave the key in the env
-        consensus
-    };
-}
 lazy_static! {
     pub static ref COMMITMENT_FACTORY: CommitmentFactory = CommitmentFactory::default();
     pub static ref PROVER: RangeProofService =
-        RangeProofService::new(ConsensusRules::get_max_range_proof_range(), &COMMITMENT_FACTORY).unwrap();
+        RangeProofService::new(MAX_RANGE_PROOF_RANGE, &COMMITMENT_FACTORY).unwrap();
 }

--- a/base_layer/core/tests/support/simple_block_chain.rs
+++ b/base_layer/core/tests/support/simple_block_chain.rs
@@ -30,7 +30,6 @@ use std::{fs::File, io::prelude::*};
 use tari_core::{
     blocks::{block::*, blockheader::*},
     consensus::ConsensusRules,
-    emission::EmissionSchedule,
     fee::Fee,
     tari_amount::MicroTari,
     transaction::*,
@@ -74,22 +73,60 @@ pub struct SimpleBlockChain {
 }
 
 /// This is used to represent a block chain in memory for testing purposes
-#[derive(PartialEq)]
 pub struct SimpleBlockChainBuilder {
     blockchain: SimpleBlockChain,
     headers: MerkleMountainRange<BlockHeader, SignatureHash>,
     utxos: MerkleMountainRange<TransactionInput, SignatureHash>,
     kernels: MerkleMountainRange<TransactionKernel, SignatureHash>,
     rangeproofs: MerkleMountainRange<RangeProof, SignatureHash>,
+    rules: ConsensusRules,
 }
 
 impl SimpleBlockChainBuilder {
     /// This will create a new test block_chain with a Genesis block
     pub fn new() -> SimpleBlockChainBuilder {
-        let mut chain = SimpleBlockChainBuilder::default();
+        let mut chain = SimpleBlockChainBuilder {
+            blockchain: Default::default(),
+            headers: Default::default(),
+            utxos: Default::default(),
+            kernels: Default::default(),
+            rangeproofs: Default::default(),
+            rules: ConsensusRules::current(),
+        };
         let mut rng = OsRng::new().unwrap();
         // create Genesis block
         chain.add_block(&mut rng, Vec::new());
+        chain
+    }
+
+    /// This will create a new test block_chain with random txs spending all the utxo's at the spend height
+    pub fn new_with_spending(block_amount: u64, spending_height: u64) -> SimpleBlockChainBuilder {
+        let mut chain = SimpleBlockChainBuilder::new();
+
+        let mut rng = OsRng::new().unwrap();
+        // create gen block
+        let priv_key = PrivateKey::random(&mut rng);
+        chain.blockchain.spending_keys.push(vec![SpendInfo::new(
+            priv_key.clone(),
+            chain.rules.emission_schedule().block_reward(0),
+            OutputFeatures::create_coinbase(0, &chain.rules),
+        )]);
+        let (cb_utxo, cb_kernel) = create_coinbase(priv_key, 0, 0.into(), &chain.rules);
+        let block = BlockBuilder::new().with_coinbase_utxo(cb_utxo, cb_kernel).build();
+        chain.processes_new_block(block);
+
+        // lets mine some empty blocks
+        if spending_height > 1 {
+            chain.add_empty_blocks(&mut rng, spending_height - 1);
+        }
+
+        // lets mine some more blocks, but spending the utxo's in the older blocks
+        for i in spending_height..(block_amount) {
+            chain.blockchain.spending_keys.push(Vec::new());
+            let (tx, mut spends) = chain.spend_block_utxos((i - spending_height) as usize);
+            chain.add_block(&mut rng, tx);
+            chain.blockchain.spending_keys[i as usize].append(&mut spends);
+        }
         chain
     }
 
@@ -112,11 +149,11 @@ impl SimpleBlockChainBuilder {
         let total_fee = tx
             .iter()
             .fold(MicroTari::default(), |tot, tx| tot + tx.get_body().get_total_fee());
-        let (cb_utxo, cb_kernel) = create_coinbase(priv_key.clone(), header.height, total_fee);
+        let (cb_utxo, cb_kernel) = create_coinbase(priv_key.clone(), header.height, total_fee, &self.rules);
         self.blockchain.spending_keys.push(vec![SpendInfo::new(
             priv_key,
-            calculate_coinbase(height) + total_fee,
-            OutputFeatures::create_coinbase(height),
+            self.rules.emission_schedule().block_reward(height) + total_fee,
+            OutputFeatures::create_coinbase(height, &self.rules),
         )]);
         let block = BlockBuilder::new()
             .with_header(header)
@@ -124,37 +161,6 @@ impl SimpleBlockChainBuilder {
             .with_transactions(tx)
             .build();
         self.processes_new_block(block);
-    }
-
-    /// This will create a new test block_chain with random txs spending all the utxo's at the spend height
-    pub fn new_with_spending(block_amount: u64, spending_height: u64) -> SimpleBlockChainBuilder {
-        let mut chain = SimpleBlockChainBuilder::default();
-
-        let mut rng = OsRng::new().unwrap();
-        // create gen block
-        let priv_key = PrivateKey::random(&mut rng);
-        chain.blockchain.spending_keys.push(vec![SpendInfo::new(
-            priv_key.clone(),
-            calculate_coinbase(0),
-            OutputFeatures::create_coinbase(0),
-        )]);
-        let (cb_utxo, cb_kernel) = create_coinbase(priv_key, 0, 0.into());
-        let block = BlockBuilder::new().with_coinbase_utxo(cb_utxo, cb_kernel).build();
-        chain.processes_new_block(block);
-
-        // lets mine some empty blocks
-        if spending_height > 1 {
-            chain.add_empty_blocks(&mut rng, spending_height - 1);
-        }
-
-        // lets mine some more blocks, but spending the utxo's in the older blocks
-        for i in spending_height..(block_amount) {
-            chain.blockchain.spending_keys.push(Vec::new());
-            let (tx, mut spends) = chain.spend_block_utxos((i - spending_height) as usize);
-            chain.add_block(&mut rng, tx);
-            chain.blockchain.spending_keys[i as usize].append(&mut spends);
-        }
-        chain
     }
 
     /// This will blocks to the chain with random txs spending all the utxo's at the spend height
@@ -204,7 +210,7 @@ impl SimpleBlockChainBuilder {
     }
 
     fn generate_genesis_block_header(&self) -> BlockHeader {
-        BlockHeader::default()
+        BlockHeader::new(self.rules.blockchain_version())
     }
 
     /// This function will generate a new header, assuming it will follow on the last created block.
@@ -219,7 +225,7 @@ impl SimpleBlockChainBuilder {
         let kernal_mmr = self.kernels.get_merkle_root();
         let rr_mmr = self.rangeproofs.get_merkle_root();
         BlockHeader {
-            version: ConsensusRules::get_blockchain_version(),
+            version: self.rules.blockchain_version(),
             height: self.blockchain.blocks[counter].header.height + 1,
             prev_hash: hash,
             timestamp: self.blockchain.blocks[counter]
@@ -348,18 +354,6 @@ impl SimpleBlockChainBuilder {
     }
 }
 
-impl Default for SimpleBlockChainBuilder {
-    fn default() -> Self {
-        SimpleBlockChainBuilder {
-            blockchain: SimpleBlockChain::default(),
-            headers: MerkleMountainRange::new(),
-            utxos: MerkleMountainRange::new(),
-            kernels: MerkleMountainRange::new(),
-            rangeproofs: MerkleMountainRange::new(),
-        }
-    }
-}
-
 impl Default for SimpleBlockChain {
     fn default() -> Self {
         SimpleBlockChain {
@@ -369,26 +363,23 @@ impl Default for SimpleBlockChain {
     }
 }
 
-// todo this probably need to move somewhere else
-/// This function will create the correct amount for the coinbase given the block height, it will provide the answer in
-/// µTari (micro Tari)
-pub fn calculate_coinbase(block_height: u64) -> MicroTari {
-    // todo fill this in properly as a function and not a constant
-    let schedule = EmissionSchedule::new();
-    schedule.block_reward(block_height)
-}
-
 /// This function will create a coinbase from the provided secret key. The coinbase will be added to the outputs and
 /// kernels.
-fn create_coinbase(key: PrivateKey, height: u64, total_fee: MicroTari) -> (TransactionOutput, TransactionKernel) {
+fn create_coinbase(
+    key: PrivateKey,
+    height: u64,
+    total_fee: MicroTari,
+    rules: &ConsensusRules,
+) -> (TransactionOutput, TransactionKernel)
+{
     let mut rng = rand::OsRng::new().unwrap();
     // build output
-    let amount = total_fee + calculate_coinbase(height);
+    let amount = total_fee + rules.emission_schedule().block_reward(height);
     let v = PrivateKey::from(u64::from(amount));
     let commitment = COMMITMENT_FACTORY.commit(&key, &v);
     let rr = PROVER.construct_proof(&key, amount.into()).unwrap();
     let output = TransactionOutput::new(
-        OutputFeatures::create_coinbase(height),
+        OutputFeatures::create_coinbase(height, rules),
         commitment,
         RangeProof::from_bytes(&rr).unwrap(),
     );

--- a/base_layer/core/tests/tests/block_validation.rs
+++ b/base_layer/core/tests/tests/block_validation.rs
@@ -24,19 +24,18 @@ use crate::support::simple_block_chain::*;
 use std::fs;
 use tari_core::consensus::ConsensusRules;
 
-fn create_block_chain() -> SimpleBlockChain {
+fn load_test_block_chain_from_file() -> SimpleBlockChain {
     let read_json = fs::read_to_string("tests/chain/chain.json").unwrap();
     let blockchain: SimpleBlockChain = serde_json::from_str(&read_json).unwrap();
     blockchain
 }
 #[test]
 fn test_valid_blocks() {
-    ConsensusRules::set_integration_test();
-    let chain = create_block_chain();
+    let rules = ConsensusRules::current();
+    let chain = load_test_block_chain_from_file();
     for i in 0..chain.blocks.len() {
-        let coinbase = calculate_coinbase(i as u64);
         chain.blocks[i]
-            .check_internal_consistency(coinbase)
+            .check_internal_consistency(&rules)
             .expect("Block validation failed")
     }
 }

--- a/base_layer/wallet/tests/output_manager_service/mod.rs
+++ b/base_layer/wallet/tests/output_manager_service/mod.rs
@@ -31,6 +31,7 @@ use rand::RngCore;
 use std::{thread, time::Duration};
 use tari_comms::peer_manager::NodeIdentity;
 use tari_core::{
+    consensus::ConsensusRules,
     fee::Fee,
     tari_amount::MicroTari,
     transaction::{KernelFeatures, OutputFeatures, TransactionOutput, UnblindedOutput},
@@ -229,7 +230,7 @@ fn receiving_and_confirmation() {
     let commitment = COMMITMENT_FACTORY.commit(&recv_key, &value.into());
     let rr = PROVER.construct_proof(&recv_key, value.into()).unwrap();
     let output = TransactionOutput::new(
-        OutputFeatures::create_coinbase(0),
+        OutputFeatures::create_coinbase(0, &ConsensusRules::current()),
         commitment,
         RangeProof::from_bytes(&rr).unwrap(),
     );
@@ -378,7 +379,7 @@ fn test_api() {
     let commitment = COMMITMENT_FACTORY.commit(&recv_key, &value.into());
     let rr = PROVER.construct_proof(&recv_key, value.into()).unwrap();
     let output = TransactionOutput::new(
-        OutputFeatures::create_coinbase(0),
+        OutputFeatures::create_coinbase(0, &ConsensusRules::current()),
         commitment,
         RangeProof::from_bytes(&rr).unwrap(),
     );


### PR DESCRIPTION
* Changed a number of methods to take ConsensusRules in a parameter so
that testing is simpler.
* Renamed a few methods for clarity

## Description
This PR mainly passes around a `ConsensusRules` struct instead of using a global instance. This allows tests to set individual parameters and emission schedules, and also allows different rules for different threads. This main not be desired in production, but is IMHO more flexible for testing.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
See above


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Ran `cargo test` locally. No new members were created, so coverage is the same

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [x] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [ ] I'm merging against the `development` branch
* [x] I ran `cargo-fmt --all` before pushing
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
