### PR TITLE
Refactor KeyValStore trait to be less restrictive

### DIFF
--- a/base_layer/p2p/src/initialization.rs
+++ b/base_layer/p2p/src/initialization.rs
@@ -32,7 +32,7 @@ use tari_comms::{
     types::{CommsPublicKey, CommsSecretKey},
     CommsBuilder,
 };
-use tari_storage::lmdb_store::LMDBBuilder;
+use tari_storage::{key_val_store::lmdb_database::LMDBWrapper, lmdb_store::LMDBBuilder};
 
 #[derive(Debug, Error)]
 pub enum CommsInitializationError {
@@ -70,6 +70,7 @@ pub fn initialize_comms(
         .build()
         .unwrap();
     let peer_database = datastore.get_handle(&config.peer_database_name).unwrap();
+    let peer_database = LMDBWrapper::new(Arc::new(peer_database));
 
     let builder = CommsBuilder::new()
         .with_routes(comms_routes.clone())

--- a/base_layer/p2p/src/services/executor.rs
+++ b/base_layer/p2p/src/services/executor.rs
@@ -51,7 +51,7 @@ pub enum ServiceControlMessage {
     Shutdown,
 }
 
-/// This is reponsible for creating and managing the thread pool for
+/// This is responsible for creating and managing the thread pool for
 /// services that should be executed.
 pub struct ServiceExecutor {
     thread_pool: Mutex<ThreadPool>,
@@ -219,7 +219,10 @@ mod test {
     use rand::rngs::OsRng;
     use std::{path::PathBuf, sync::RwLock};
     use tari_comms::{peer_manager::NodeIdentity, CommsBuilder};
-    use tari_storage::lmdb_store::{LMDBBuilder, LMDBError, LMDBStore};
+    use tari_storage::{
+        key_val_store::lmdb_database::LMDBWrapper,
+        lmdb_store::{LMDBBuilder, LMDBError, LMDBStore},
+    };
 
     #[derive(Clone)]
     struct AddWordService(Arc<RwLock<String>>, &'static str);
@@ -286,6 +289,7 @@ mod test {
         let database_name = "executor_execute"; // Note: every test should have unique database
         let datastore = init_datastore(database_name).unwrap();
         let peer_database = datastore.get_handle(database_name).unwrap();
+        let peer_database = LMDBWrapper::new(Arc::new(peer_database));
 
         let comms_services = CommsBuilder::new()
             .with_routes(registry.build_comms_routes())

--- a/base_layer/p2p/tests/dht/mod.rs
+++ b/base_layer/p2p/tests/dht/mod.rs
@@ -39,7 +39,7 @@ use tari_p2p::{
     services::{ServiceExecutor, ServiceRegistry},
     tari_message::TariMessageType,
 };
-use tari_storage::lmdb_store::LMDBBuilder;
+use tari_storage::{key_val_store::lmdb_database::LMDBWrapper, lmdb_store::LMDBBuilder};
 use tempdir::TempDir;
 
 fn new_node_identity(control_service_address: NetAddress) -> NodeIdentity {
@@ -56,6 +56,7 @@ fn create_peer_storage(tmpdir: &TempDir, database_name: &str, peers: Vec<Peer>) 
         .unwrap();
 
     let peer_database = datastore.get_handle(database_name).unwrap();
+    let peer_database = LMDBWrapper::new(Arc::new(peer_database));
     let mut storage = PeerStorage::new(peer_database).unwrap();
     for peer in peers {
         storage.add_peer(peer).unwrap();

--- a/base_layer/p2p/tests/ping_pong/mod.rs
+++ b/base_layer/p2p/tests/ping_pong/mod.rs
@@ -39,7 +39,7 @@ use tari_p2p::{
     services::{ServiceExecutor, ServiceRegistry},
     tari_message::TariMessageType,
 };
-use tari_storage::lmdb_store::LMDBBuilder;
+use tari_storage::{key_val_store::lmdb_database::LMDBWrapper, lmdb_store::LMDBBuilder};
 use tempdir::TempDir;
 
 fn new_node_identity(control_service_address: NetAddress) -> NodeIdentity {
@@ -56,6 +56,7 @@ fn create_peer_storage(tmpdir: &TempDir, database_name: &str, peers: Vec<Peer>) 
         .unwrap();
 
     let peer_database = datastore.get_handle(database_name).unwrap();
+    let peer_database = LMDBWrapper::new(Arc::new(peer_database));
     let mut storage = PeerStorage::new(peer_database).unwrap();
     for peer in peers {
         storage.add_peer(peer).unwrap();

--- a/base_layer/p2p/tests/saf/mod.rs
+++ b/base_layer/p2p/tests/saf/mod.rs
@@ -40,7 +40,7 @@ use tari_p2p::{
     services::{ServiceExecutor, ServiceRegistry},
     tari_message::TariMessageType,
 };
-use tari_storage::lmdb_store::LMDBBuilder;
+use tari_storage::{key_val_store::lmdb_database::LMDBWrapper, lmdb_store::LMDBBuilder};
 use tari_utilities::message_format::MessageFormat;
 use tempdir::TempDir;
 
@@ -58,6 +58,7 @@ fn create_peer_storage(tmpdir: &TempDir, database_name: &str, peers: Vec<Peer>) 
         .unwrap();
 
     let peer_database = datastore.get_handle(database_name).unwrap();
+    let peer_database = LMDBWrapper::new(Arc::new(peer_database));
     let mut storage = PeerStorage::new(peer_database).unwrap();
     for peer in peers {
         storage.add_peer(peer).unwrap();

--- a/base_layer/wallet/tests/support/comms_and_services.rs
+++ b/base_layer/wallet/tests/support/comms_and_services.rs
@@ -20,7 +20,7 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use std::time::Duration;
+use std::{sync::Arc, time::Duration};
 use tari_comms::{
     builder::CommsServices,
     connection_manager::PeerConnectionConfig,
@@ -29,7 +29,8 @@ use tari_comms::{
     CommsBuilder,
 };
 use tari_p2p::{services::ServiceRegistry, tari_message::TariMessageType};
-use tari_storage::lmdb_store::LMDBDatabase;
+use tari_storage::{key_val_store::lmdb_database::LMDBWrapper, lmdb_store::LMDBDatabase};
+
 pub fn setup_comms_services(
     node_identity: NodeIdentity,
     peers: Vec<NodeIdentity>,
@@ -37,6 +38,7 @@ pub fn setup_comms_services(
     services: &ServiceRegistry,
 ) -> CommsServices<TariMessageType>
 {
+    let peer_database = LMDBWrapper::new(Arc::new(peer_database));
     let comms = CommsBuilder::new()
         .with_routes(services.build_comms_routes())
         .with_node_identity(node_identity.clone())

--- a/comms/src/builder/mod.rs
+++ b/comms/src/builder/mod.rs
@@ -34,6 +34,7 @@
 //! # use rand::OsRng;
 //! # use tari_storage::lmdb_store::LMDBBuilder;
 //! # use lmdb_zero::db;
+//! # use tari_storage::key_val_store::lmdb_database::LMDBWrapper;
 //!
 //! // This should be loaded up from storage
 //! let my_node_identity = NodeIdentity::random(&mut OsRng::new().unwrap(), "127.0.0.1:9000".parse().unwrap()).unwrap();
@@ -51,6 +52,7 @@
 //!            .add_database(database_name, lmdb_zero::db::CREATE)
 //!           .build().unwrap();
 //! let peer_database = datastore.get_handle(database_name).unwrap();
+//! let peer_database = LMDBWrapper::new(Arc::new(peer_database));
 //!
 //! let services = CommsBuilder::new()
 //!    .with_routes(CommsRoutes::<u8>::new())

--- a/comms/src/connection_manager/mod.rs
+++ b/comms/src/connection_manager/mod.rs
@@ -55,6 +55,7 @@
 //! # use rand::OsRng;
 //! # use tari_storage::lmdb_store::LMDBBuilder;
 //! # use lmdb_zero::db;
+//! # use tari_storage::key_val_store::lmdb_database::LMDBWrapper;
 //!
 //! let node_identity = Arc::new(NodeIdentity::random(&mut OsRng::new().unwrap(), "127.0.0.1:9000".parse().unwrap()).unwrap());
 //!
@@ -68,6 +69,7 @@
 //!            .add_database(database_name, lmdb_zero::db::CREATE)
 //!           .build().unwrap();
 //! let peer_database = datastore.get_handle(database_name).unwrap();
+//! let peer_database = LMDBWrapper::new(Arc::new(peer_database));
 //! let peer_manager = Arc::new(PeerManager::new(peer_database).unwrap());
 //!
 //! let manager = ConnectionManager::new(context, node_identity, peer_manager, PeerConnectionConfig {

--- a/comms/src/control_service/mod.rs
+++ b/comms/src/control_service/mod.rs
@@ -52,6 +52,7 @@
 //! # use rand::OsRng;
 //! # use tari_storage::lmdb_store::LMDBBuilder;
 //! # use lmdb_zero::db;
+//! # use tari_storage::key_val_store::lmdb_database::LMDBWrapper;
 //!
 //! let node_identity = Arc::new(NodeIdentity::random(&mut OsRng::new().unwrap(), "127.0.0.1:9000".parse().unwrap()).unwrap());
 //!
@@ -66,6 +67,7 @@
 //!            .add_database(database_name, lmdb_zero::db::CREATE)
 //!           .build().unwrap();
 //! let peer_database = datastore.get_handle(database_name).unwrap();
+//!     let peer_database = LMDBWrapper::new(Arc::new(peer_database));
 //! let peer_manager = Arc::new(PeerManager::new(peer_database).unwrap());
 //!
 //! let conn_manager = Arc::new(ConnectionManager::new(context.clone(), node_identity.clone(), peer_manager.clone(), PeerConnectionConfig {

--- a/comms/src/peer_manager/mod.rs
+++ b/comms/src/peer_manager/mod.rs
@@ -37,6 +37,8 @@
 //! # use tari_crypto::keys::PublicKey;
 //! # use tari_storage::lmdb_store::LMDBBuilder;
 //! # use lmdb_zero::db;
+//! # use std::sync::Arc;
+//! # use tari_storage::key_val_store::lmdb_database::LMDBWrapper;
 //!
 //! let mut rng = rand::OsRng::new().unwrap();
 //! let (dest_sk, pk) = CommsPublicKey::random_keypair(&mut rng);
@@ -51,6 +53,7 @@
 //!            .add_database(database_name, lmdb_zero::db::CREATE)
 //!           .build().unwrap();
 //! let peer_database = datastore.get_handle(database_name).unwrap();
+//! let peer_database = LMDBWrapper::new(Arc::new(peer_database));
 //! let peer_manager = PeerManager::new(peer_database).unwrap();
 //!
 //! peer_manager.add_peer(peer.clone());

--- a/comms/src/types.rs
+++ b/comms/src/types.rs
@@ -23,13 +23,14 @@
 use crate::{
     dispatcher::{DispatchError, Dispatcher},
     inbound_message_service::comms_msg_handlers::{CommsDispatchType, InboundMessageServiceResolver},
+    peer_manager::{peer_key::PeerKey, Peer},
 };
 use tari_crypto::{common::Blake256, keys::PublicKey, ristretto::RistrettoPublicKey};
 #[cfg(test)]
 use tari_storage::key_val_store::HMapDatabase;
 #[cfg(not(test))]
 use tari_storage::lmdb_store::LMDBDatabase;
-use tari_storage::lmdb_store::LMDBStore;
+use tari_storage::{key_val_store::lmdb_database::LMDBWrapper, lmdb_store::LMDBStore};
 use tari_utilities::ciphers::chacha20::ChaCha20;
 
 /// The message protocol version for the MessageEnvelopeHeader
@@ -58,9 +59,9 @@ pub type CommsCipher = ChaCha20;
 pub type CommsDataStore = LMDBStore;
 
 #[cfg(not(test))]
-pub type CommsDatabase = LMDBDatabase;
+pub type CommsDatabase = LMDBWrapper<PeerKey, Peer>;
 #[cfg(test)]
-pub type CommsDatabase = HMapDatabase;
+pub type CommsDatabase = HMapDatabase<PeerKey, Peer>;
 
 /// Dispatcher format for comms level dispatching to handlers
 pub type MessageDispatcher<M> = Dispatcher<CommsDispatchType, M, InboundMessageServiceResolver, DispatchError>;

--- a/comms/tests/connection_manager/establisher.rs
+++ b/comms/tests/connection_manager/establisher.rs
@@ -31,7 +31,10 @@ use tari_comms::{
     control_service::messages::{ControlServiceResponseType, Pong},
     message::{Message, MessageEnvelope, MessageFlags, MessageHeader, NodeDestination},
 };
-use tari_storage::lmdb_store::{LMDBBuilder, LMDBError, LMDBStore};
+use tari_storage::{
+    key_val_store::lmdb_database::LMDBWrapper,
+    lmdb_store::{LMDBBuilder, LMDBError, LMDBStore},
+};
 use tari_utilities::{message_format::MessageFormat, thread_join::ThreadJoinWithTimeout};
 
 fn make_peer_connection_config(message_sink_address: InprocAddress) -> PeerConnectionConfig {
@@ -95,6 +98,7 @@ fn establish_control_service_connection_fail() {
     let database_name = "establisher_establish_control_service_connection_fail";
     let datastore = init_datastore(database_name).unwrap();
     let database = datastore.get_handle(database_name).unwrap();
+    let database = LMDBWrapper::new(Arc::new(database));
     let peer_manager = Arc::new(
         factories::peer_manager::create()
             .with_database(database)
@@ -163,6 +167,7 @@ fn establish_control_service_connection_succeed() {
     let database_name = "establisher_establish_control_service_connection_succeed"; // Note: every test should have unique database
     let datastore = init_datastore(database_name).unwrap();
     let database = datastore.get_handle(database_name).unwrap();
+    let database = LMDBWrapper::new(Arc::new(database));
     let peer_manager = Arc::new(
         factories::peer_manager::create()
             .with_database(database)
@@ -220,6 +225,7 @@ fn establish_peer_connection_outbound() {
     let database_name = "establisher_establish_peer_connection_outbound"; // Note: every test should have unique database
     let datastore = init_datastore(database_name).unwrap();
     let database = datastore.get_handle(database_name).unwrap();
+    let database = LMDBWrapper::new(Arc::new(database));
     let peer_manager = Arc::new(
         factories::peer_manager::create()
             .with_database(database)
@@ -266,6 +272,7 @@ fn establish_peer_connection_inbound() {
     let database_name = "establish_peer_connection_inbound"; // Note: every test should have unique database
     let datastore = init_datastore(database_name).unwrap();
     let database = datastore.get_handle(database_name).unwrap();
+    let database = LMDBWrapper::new(Arc::new(database));
     let peer_manager = Arc::new(
         factories::peer_manager::create()
             .with_database(database)

--- a/comms/tests/connection_manager/manager.rs
+++ b/comms/tests/connection_manager/manager.rs
@@ -32,7 +32,10 @@ use tari_comms::{
     peer_manager::{Peer, PeerManager},
     types::CommsDatabase,
 };
-use tari_storage::lmdb_store::{LMDBBuilder, LMDBError, LMDBStore};
+use tari_storage::{
+    key_val_store::lmdb_database::LMDBWrapper,
+    lmdb_store::{LMDBBuilder, LMDBError, LMDBStore},
+};
 use tari_utilities::thread_join::ThreadJoinWithTimeout;
 
 fn make_peer_connection_config(consumer_address: InprocAddress) -> PeerConnectionConfig {
@@ -114,6 +117,7 @@ fn establish_peer_connection() {
     let node_B_database_name = "connection_manager_node_B_peer_manager";
     let datastore = init_datastore(node_B_database_name).unwrap();
     let database = datastore.get_handle(node_B_database_name).unwrap();
+    let database = LMDBWrapper::new(Arc::new(database));
     let node_B_peer_manager = make_peer_manager(vec![], database);
     let node_B_connection_manager = Arc::new(
         factories::connection_manager::create()
@@ -145,6 +149,7 @@ fn establish_peer_connection() {
     let node_A_database_name = "connection_manager_node_A_peer_manager"; // Note: every test should have unique database
     let datastore = init_datastore(node_A_database_name).unwrap();
     let database = datastore.get_handle(node_A_database_name).unwrap();
+    let database = LMDBWrapper::new(Arc::new(database));
     let node_A_peer_manager = make_peer_manager(vec![node_B_peer.clone()], database);
     let node_A_connection_manager = Arc::new(
         factories::connection_manager::create()

--- a/comms/tests/control_service/service.rs
+++ b/comms/tests/control_service/service.rs
@@ -31,14 +31,17 @@ use tari_comms::{
     control_service::{messages::ConnectRequestOutcome, ControlService, ControlServiceClient, ControlServiceConfig},
     peer_manager::{NodeId, NodeIdentity, Peer, PeerFlags, PeerManager},
 };
-use tari_storage::lmdb_store::{LMDBBuilder, LMDBDatabase, LMDBError, LMDBStore};
+use tari_storage::{
+    key_val_store::lmdb_database::LMDBWrapper,
+    lmdb_store::{LMDBBuilder, LMDBDatabase, LMDBError, LMDBStore},
+};
 use tari_utilities::thread_join::ThreadJoinWithTimeout;
 
 fn make_peer_manager(peers: Vec<Peer>, database: LMDBDatabase) -> Arc<PeerManager> {
     Arc::new(
         factories::peer_manager::create()
             .with_peers(peers)
-            .with_database(database)
+            .with_database(LMDBWrapper::new(Arc::new(database)))
             .build()
             .unwrap(),
     )

--- a/comms/tests/outbound_message_service/outbound_message_pool.rs
+++ b/comms/tests/outbound_message_service/outbound_message_pool.rs
@@ -39,7 +39,10 @@ use tari_comms::{
     peer_manager::{Peer, PeerManager},
     types::CommsDatabase,
 };
-use tari_storage::lmdb_store::{LMDBBuilder, LMDBError, LMDBStore};
+use tari_storage::{
+    key_val_store::lmdb_database::LMDBWrapper,
+    lmdb_store::{LMDBBuilder, LMDBError, LMDBStore},
+};
 
 fn make_peer_connection_config(message_sink_address: InprocAddress) -> PeerConnectionConfig {
     PeerConnectionConfig {
@@ -112,6 +115,7 @@ fn outbound_message_pool_no_retry() {
     let node_B_database_name = "omp_node_B_peer_manager"; // Note: every test should have unique database
     let datastore = init_datastore(node_B_database_name).unwrap();
     let database = datastore.get_handle(node_B_database_name).unwrap();
+    let database = LMDBWrapper::new(Arc::new(database));
     let node_B_peer_manager = make_peer_manager(vec![], database);
     let node_B_connection_manager = Arc::new(ConnectionManager::new(
         context.clone(),
@@ -137,6 +141,7 @@ fn outbound_message_pool_no_retry() {
     let node_A_database_name = "omp_node_A_peer_manager"; // Note: every test should have unique database
     let datastore = init_datastore(node_A_database_name).unwrap();
     let database = datastore.get_handle(node_A_database_name).unwrap();
+    let database = LMDBWrapper::new(Arc::new(database));
     let node_A_peer_manager = make_peer_manager(vec![node_B_peer.clone()], database);
     let node_A_connection_manager = Arc::new(
         factories::connection_manager::create()
@@ -232,6 +237,7 @@ fn test_outbound_message_pool_fail_and_retry() {
     let database_name = "omp_test_outbound_message_pool_fail_and_retry"; // Note: every test should have unique database
     let datastore = init_datastore(database_name).unwrap();
     let database = datastore.get_handle(database_name).unwrap();
+    let database = LMDBWrapper::new(Arc::new(database));
     let node_A_peer_manager = factories::peer_manager::create()
         .with_peers(vec![node_B_peer.clone()])
         .with_database(database)
@@ -275,6 +281,7 @@ fn test_outbound_message_pool_fail_and_retry() {
     let node_B_database_name = "omp_node_B_peer_manager"; // Note: every test should have unique database
     let datastore = init_datastore(node_B_database_name).unwrap();
     let database = datastore.get_handle(node_B_database_name).unwrap();
+    let database = LMDBWrapper::new(Arc::new(database));
     let node_B_peer_manager = make_peer_manager(vec![], database);
     let node_B_connection_manager = factories::connection_manager::create()
         .with_context(context.clone())

--- a/infrastructure/storage/src/key_val_store/key_val_store.rs
+++ b/infrastructure/storage/src/key_val_store/key_val_store.rs
@@ -21,21 +21,14 @@
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 use crate::key_val_store::KeyValStoreError;
-use lmdb_zero::traits::AsLmdbBytes;
 
 /// General CRUD behaviour of Key-value store implementations.
-pub trait KeyValStore {
+pub trait KeyValStore<K, V> {
     /// Inserts a key-value pair into the key-value database.
-    fn insert_pair<K, V>(&self, key: &K, value: &V) -> Result<(), KeyValStoreError>
-    where
-        K: AsLmdbBytes + ?Sized,
-        V: serde::Serialize;
+    fn insert_pair(&self, key: K, value: V) -> Result<(), KeyValStoreError>;
 
     /// Get the value corresponding to the provided key from the key-value database.
-    fn get_value<K, V>(&self, key: &K) -> Result<Option<V>, KeyValStoreError>
-    where
-        K: AsLmdbBytes + ?Sized,
-        for<'t> V: serde::de::DeserializeOwned;
+    fn get_value(&self, key: &K) -> Result<Option<V>, KeyValStoreError>;
 
     /// Returns the total number of entries recorded in the key-value database.
     fn size(&self) -> Result<usize, KeyValStoreError>;
@@ -49,17 +42,12 @@ pub trait KeyValStore {
     ///        let (key, val) = pair.unwrap();
     ///        //.. do stuff with key and val..
     ///    });
-    fn for_each<K, V, F>(&self, f: F) -> Result<(), KeyValStoreError>
-    where
-        K: serde::de::DeserializeOwned,
-        V: serde::de::DeserializeOwned,
-        F: FnMut(Result<(K, V), KeyValStoreError>);
+    fn for_each<F>(&self, f: F) -> Result<(), KeyValStoreError>
+    where F: FnMut(Result<(K, V), KeyValStoreError>);
 
     /// Checks whether the provided `key` exists in the key-value database.
-    fn exists<K>(&self, key: &K) -> Result<bool, KeyValStoreError>
-    where K: AsLmdbBytes + ?Sized;
+    fn exists(&self, key: &K) -> Result<bool, KeyValStoreError>;
 
     /// Delete a key-pair record associated with the provided `key` from the key-pair database.
-    fn delete<K>(&self, key: &K) -> Result<(), KeyValStoreError>
-    where K: AsLmdbBytes + ?Sized;
+    fn delete(&self, key: &K) -> Result<(), KeyValStoreError>;
 }


### PR DESCRIPTION
As it stands, the `KeyValStore` trait has some pretty restrictive constraints
on it, inlcuding the very ugly dependency on an LMDB type.

There's no reason to impose these constraints, actually. Every implementation
is free to impose additional constraints to limit its applicability.

The main change of this PR is to remove the bounds on the `K` and `V`
generics in the trait, and shift them up into the implementations.

This allows us to use `KeyValStore` as a backend trait in e.g.
MerkleMountainRange without having to carry things like `AsLMDBBytes`
into the MMR crate :O

It also lets us massively simply the `HMapDatabase` type (no serialisation
required!)

So, two big wins!!

But..it makes things a little messy with LMDB.
There's a conflict between where the Generic specifications (K,V) live.
It makes sense to have them at the trait level for the trait; but I couldn't
find a way to put them on the struct level for LMDBDatabase; primarily
because `LMDBStore` holds a map of `LMDBDatabase` instances, each with
their own, potentially different `K` and `V` types - i.e. `LMDBDatabase` can't
be `LMDBDatabase<K,V>`.

So my workaround was to create a small wrapper struct that lifts the <K,V> to
the struct, and we implement `KeyValStore` on `LMDBWrapper` instead, which
works fine, but required quite a few changes across the codebase filling
this wrapper in.

If you can think of a better way to do this, I'm all ears :)

<!--- Provide a general summary of your changes in the Title above -->


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [x] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch
* [x] I ran `cargo-fmt --all` before pushing
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
