### PR TITLE
Add Mutable MMR Datastructure

### DIFF
--- a/base_layer/mmr/Cargo.toml
+++ b/base_layer/mmr/Cargo.toml
@@ -9,6 +9,8 @@ derive-error = "0.0.4"
 digest = "0.8.0"
 log = "0.4"
 serde = { version = "1.0.97", features = ["derive"] }
+croaring =  "0.4.0"
+tari_storage = { path = "../../infrastructure/storage", version = "^0.0" }
 
 [dev-dependencies]
 criterion = "0.2"

--- a/base_layer/mmr/src/error.rs
+++ b/base_layer/mmr/src/error.rs
@@ -30,4 +30,6 @@ pub enum MerkleMountainRangeError {
     BackendPushError,
     // The Merkle tree is not internally consistent. A parent hash isn't equal to the hash of its children
     InvalidMerkleTree,
+    // The tree has reached its maximum size
+    MaximumSizeReached,
 }

--- a/base_layer/mmr/src/lib.rs
+++ b/base_layer/mmr/src/lib.rs
@@ -138,6 +138,7 @@ pub type HashSlice = [u8];
 mod backend;
 mod merkle_mountain_range;
 mod merkle_proof;
+mod mutable_mmr;
 
 // Less commonly used exports
 pub mod common;
@@ -150,3 +151,5 @@ pub use backend::VectorBackend;
 pub use merkle_mountain_range::MerkleMountainRange;
 /// A data structure for proving a hash inclusion in an MMR
 pub use merkle_proof::{MerkleProof, MerkleProofError};
+/// An append-only Merkle Mountain range (MMR) data structure that allows deletion of existing leaf nodes.
+pub use mutable_mmr::MutableMmr;

--- a/base_layer/mmr/src/mutable_mmr.rs
+++ b/base_layer/mmr/src/mutable_mmr.rs
@@ -1,0 +1,182 @@
+// Copyright 2019. The Tari Project
+//
+// Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+// following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+// disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+// following disclaimer in the documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+// products derived from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+// INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+// WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+// USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+use crate::{backend::ArrayLike, common::leaf_index, error::MerkleMountainRangeError, Hash, MerkleMountainRange};
+use croaring::Bitmap;
+use digest::Digest;
+
+/// Unlike a pure MMR, which is append-only, in `MutableMmr`, leaf nodes can be marked as deleted.
+///
+/// In `MutableMmr` a roaring bitmap tracks which data have been marked as deleted, and the merklish root is modified
+/// to include the hash of the roaring bitmap.
+///
+/// The `MutableMmr` API maps nearly 1:1 to that of MerkleMountainRange so that you should be able to use it as a
+/// drop-in replacement for the latter in most cases.
+pub struct MutableMmr<D, B>
+where
+    D: Digest,
+    B: ArrayLike<Value = Hash>,
+{
+    pub(crate) mmr: MerkleMountainRange<D, B>,
+    deleted: Bitmap,
+    // The number of leaf nodes in the MutableMmr. Bitmap is limited to 4 billion elements, which is plenty.
+    // [croaring::Treemap] is a 64bit alternative, but this would break things on 32bit systems. A good TODO would be
+    // to select the bitmap backend using a feature flag
+    size: u32,
+}
+
+impl<D, B> MutableMmr<D, B>
+where
+    D: Digest,
+    B: ArrayLike<Value = Hash>,
+{
+    /// Create a new mutable MMR using the backend provided
+    pub fn new(mmr_backend: B) -> MutableMmr<D, B> {
+        let mmr = MerkleMountainRange::new(mmr_backend);
+        MutableMmr {
+            mmr,
+            deleted: Bitmap::create(),
+            size: 0,
+        }
+    }
+
+    /// Return the number of leaf nodes in the `MutableMmr` that have not been marked as deleted.
+    ///
+    /// NB: This is semantically different to `MerkleMountainRange::len()`. The latter returns the total number of
+    /// nodes in the MMR, while this function returns the number of leaf nodes minus the number of nodes marked for
+    /// deletion.
+    #[inline(always)]
+    pub fn len(&self) -> u32 {
+        self.size - self.deleted.cardinality() as u32
+    }
+
+    /// Returns true if the the MMR contains no nodes, OR all nodes have been marked for deletion
+    pub fn is_empty(&self) -> bool {
+        self.mmr.is_empty() || self.deleted.cardinality() == self.size as u64
+    }
+
+    /// This function returns the hash of the leaf index provided, indexed from 0. If the hash does not exist, or if it
+    /// has been marked for deletion, `None` is returned.
+    pub fn get_leaf_hash(&self, leaf_node_index: u32) -> Option<&Hash> {
+        if self.deleted.contains(leaf_node_index) {
+            return None;
+        }
+        self.mmr.get_node_hash(leaf_index(leaf_node_index as usize))
+    }
+
+    /// Returns a merkle(ish) root for this merkle set.
+    ///
+    /// The root is calculated by concatenating the MMR merkle root with the compressed serialisation of the bitmap
+    /// and then hashing the result.
+    pub fn get_merkle_root(&self) -> Hash {
+        // Note that two MutableMmrs could both return true for `is_empty()`, but have different merkle roots by
+        // virtue of the fact that the underlying MMRs could be different, but all elements are marked as deleted in
+        // both sets.
+        let mmr_root = self.mmr.get_merkle_root();
+        let mut hasher = D::new();
+        hasher.input(&mmr_root);
+        self.hash_deleted(hasher).result().to_vec()
+    }
+
+    /// Push a new element into the MMR. Computes new related peaks at
+    /// the same time if applicable.
+    pub fn push(&mut self, hash: &Hash) -> Result<usize, MerkleMountainRangeError> {
+        if self.size >= std::u32::MAX {
+            return Err(MerkleMountainRangeError::MaximumSizeReached);
+        }
+        let result = self.mmr.push(hash);
+        if result.is_ok() {
+            self.size += 1;
+        }
+        result
+    }
+
+    /// Mark a node for deletion and optionally compress the deletion bitmap. Don't call this function unless you're
+    /// in a tight loop and want to eke out some extra performance by delaying the bitmap compression until after the
+    /// batch deletion.
+    ///
+    /// Note that this function doesn't actually
+    /// delete anything (the underlying MMR structure is immutable), but marks the leaf node as deleted. Once a leaf
+    /// node has been marked for deletion:
+    /// * `get_leaf_hash(n)` will return None,
+    /// * `len()` will not count this node anymore
+    ///
+    /// # Parameters
+    /// * `leaf_node_index`: The index of the leaf node to mark for deletion, zero-based.
+    /// * `compress`: Indicates whether the roaring bitmap should be compressed after marking the node for deletion.
+    /// **NB**: You should set this to true unless you are in a loop and deleting multiple nodes, and you **must** set
+    /// this to true if you are about to call `get_merkle_root()`. If you don't, the merkle root will be incorrect.
+    ///
+    /// # Return
+    /// The function returns true if a node was actually marked for deletion. If the index is out of bounds, or was
+    /// already deleted, the function returns false.
+    pub fn delete_and_compress(&mut self, leaf_node_index: u32, compress: bool) -> bool {
+        if (leaf_node_index >= self.size) || self.deleted.contains(leaf_node_index) {
+            return false;
+        }
+        self.deleted.add(leaf_node_index);
+        // The serialization is different in compressed vs. uncompressed form, but the merkle root must be 100%
+        // deterministic based on input, so just be consistent an use the compressed form all the time.
+        if compress {
+            self.compress();
+        }
+        true
+    }
+
+    /// Mark a node for completion, and compress the roaring bitmap. See [delete_and_compress] for details.
+    pub fn delete(&mut self, leaf_node_index: u32) -> bool {
+        self.delete_and_compress(leaf_node_index, true)
+    }
+
+    /// Compress the roaring bitmap mapping deleted nodes. You never have to call this method unless you have been
+    /// calling [delete_and_compress] with `compress` set to `false` ahead of a call to [get_merkle_root].
+    pub fn compress(&mut self) -> bool {
+        self.deleted.run_optimize()
+    }
+
+    /// Walks the nodes in the MMR and validates all parent hashes
+    ///
+    /// This just calls through to the underlying MMR's validate method. There's nothing we can do to check whether
+    /// the roaring bitmap represents all the leaf nodes that we want to delete. Note: A struct that uses
+    /// `MutableMmr` and links it to actual data should be able to do this though.
+    pub fn validate(&self) -> Result<(), MerkleMountainRangeError> {
+        self.mmr.validate()
+    }
+
+    /// Hash the roaring bitmap of nodes that are marked for deletion
+    fn hash_deleted(&self, mut hasher: D) -> D {
+        let bitmap_ser = self.deleted.serialize();
+        hasher.input(&bitmap_ser);
+        hasher
+    }
+}
+
+impl<D, B, B2> PartialEq<MutableMmr<D, B2>> for MutableMmr<D, B>
+where
+    D: Digest,
+    B: ArrayLike<Value = Hash>,
+    B2: ArrayLike<Value = Hash>,
+{
+    fn eq(&self, other: &MutableMmr<D, B2>) -> bool {
+        (self.get_merkle_root() == other.get_merkle_root())
+    }
+}

--- a/base_layer/mmr/tests/MutableMmr.rs
+++ b/base_layer/mmr/tests/MutableMmr.rs
@@ -1,0 +1,141 @@
+// Copyright 2019. The Tari Project
+//
+// Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+// following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+// disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+// following disclaimer in the documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+// products derived from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+// INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+// WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+// USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+mod support;
+
+use croaring::Bitmap;
+use digest::Digest;
+use support::{combine_hashes, create_mmr, int_to_hash, Hasher};
+use tari_mmr::{Hash, HashSlice, MerkleMountainRange, MutableMmr, VectorBackend};
+use tari_utilities::hex::Hex;
+
+fn hash_with_bitmap(hash: &HashSlice, bitmap: &mut Bitmap) -> Hash {
+    bitmap.run_optimize();
+    let hasher = Hasher::new();
+    hasher.chain(hash).chain(&bitmap.serialize()).result().to_vec()
+}
+
+/// MMRs with no elements should provide sane defaults. The merkle root must be the hash of an empty string, b"".
+#[test]
+fn zero_length_mmr() {
+    let mmr = MutableMmr::<Hasher, _>::new(VectorBackend::default());
+    assert_eq!(mmr.len(), 0);
+    assert!(mmr.is_empty());
+    let empty_hash = Hasher::digest(b"").to_vec();
+    assert_eq!(
+        mmr.get_merkle_root(),
+        hash_with_bitmap(&empty_hash, &mut Bitmap::create())
+    );
+}
+
+#[test]
+// Note the hardcoded hashes are only valid when using Blake256 as the Hasher
+fn delete() {
+    let mut mmr = MutableMmr::<Hasher, _>::new(VectorBackend::default());
+    assert!(mmr.is_empty());
+    for i in 0..5 {
+        assert!(mmr.push(&int_to_hash(i)).is_ok());
+    }
+    assert_eq!(mmr.len(), 5);
+    let root = mmr.get_merkle_root();
+    // Can't delete past bounds
+    assert_eq!(mmr.delete_and_compress(5, true), false);
+    assert_eq!(mmr.len(), 5);
+    assert!(!mmr.is_empty());
+    assert_eq!(mmr.get_merkle_root(), root);
+    // Delete some nodes
+    assert!(mmr.delete_and_compress(0, false));
+    assert!(mmr.delete_and_compress(2, false));
+    assert!(mmr.delete_and_compress(4, true));
+    let root = mmr.get_merkle_root();
+    assert_eq!(
+        &root.to_hex(),
+        "e749ef3a776f13003426520911474f412dfeddf3f16b9783df935c9b4a9eb51c"
+    );
+    assert_eq!(mmr.len(), 2);
+    assert!(!mmr.is_empty());
+    // Can't delete that which has already been deleted
+    assert!(!mmr.delete_and_compress(0, false));
+    assert!(!mmr.delete_and_compress(2, false));
+    assert!(!mmr.delete_and_compress(0, true));
+    // .. or beyond bounds of MMR
+    assert!(!mmr.delete_and_compress(99, true));
+    assert_eq!(mmr.len(), 2);
+    assert!(!mmr.is_empty());
+    // Merkle root should not have changed:
+    assert_eq!(mmr.get_merkle_root(), root);
+    assert!(mmr.delete_and_compress(1, false));
+    assert!(mmr.delete(3));
+    assert_eq!(mmr.len(), 0);
+    assert!(mmr.is_empty());
+    let root = mmr.get_merkle_root();
+    assert_eq!(
+        &root.to_hex(),
+        "f7a7378dd83853047f889fad5bab3d5fb0f9c2864a89cbb6edcb1cb6897103db"
+    );
+}
+
+/// Successively build up an MMR and check that the roots, heights and indices are all correct.
+#[test]
+fn build_mmr() {
+    // Check the mutable MMR against a standard MMR and a roaring bitmap. Create one with 5 leaf nodes *8 MMR nodes)
+    let mut mmr_check = create_mmr(5);
+    assert_eq!(mmr_check.len(), 8);
+    let mut bitmap = Bitmap::create();
+    // Create a small mutable MMR
+    let mut mmr = MutableMmr::<Hasher, _>::new(VectorBackend::default());
+    for i in 0..5 {
+        assert!(mmr.push(&int_to_hash(i)).is_ok());
+    }
+    // MutableMmr::len gives the size in terms of leaf nodes:
+    assert_eq!(mmr.len(), 5);
+    let mmr_root = mmr_check.get_merkle_root();
+    let root_check = hash_with_bitmap(&mmr_root, &mut bitmap);
+    assert_eq!(mmr.get_merkle_root(), root_check);
+    // Delete a node
+    assert!(mmr.delete_and_compress(3, true));
+    bitmap.add(3);
+    let root_check = hash_with_bitmap(&mmr_root, &mut bitmap);
+    assert_eq!(mmr.get_merkle_root(), root_check);
+}
+
+#[test]
+fn equality_check() {
+    let mut ma = MutableMmr::<Hasher, _>::new(VectorBackend::default());
+    let mut mb = MutableMmr::<Hasher, _>::new(VectorBackend::default());
+    assert!(ma == mb);
+    assert!(ma.push(&int_to_hash(1)).is_ok());
+    assert!(ma != mb);
+    assert!(mb.push(&int_to_hash(1)).is_ok());
+    assert!(ma == mb);
+    assert!(ma.push(&int_to_hash(2)).is_ok());
+    assert!(ma != mb);
+    assert!(ma.delete(1));
+    // Even though the two trees have the same apparent elements, they're still not equal, because we don't actually
+    // delete anything
+    assert!(ma != mb);
+    // Add the same hash to mb and then delete it
+    assert!(mb.push(&int_to_hash(2)).is_ok());
+    assert!(mb.delete(1));
+    // Now they're equal!
+    assert!(ma == mb);
+}


### PR DESCRIPTION
Part II of the MMR refactor focusing on ergonomics, composability and performance.

Unlike a pure MMR, which is append-only, in `MutableMmr`, leaf nodes can be marked as deleted.
In `MutableMmr` a roaring bitmap tracks which data have been marked as deleted, and the merklish root is modified
to include the hash of the roaring bitmap.
The `MutableMmr` API maps nearly 1:1 to that of MerkleMountainRange so that you should be able to use it as a
drop-in replacement for the latter in most cases.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [x] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [x] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch
* [x] I ran `cargo-fmt --all` before pushing
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
