### PR TITLE
Add support for Pruned MMRs

### DIFF
--- a/base_layer/mmr/src/error.rs
+++ b/base_layer/mmr/src/error.rs
@@ -32,4 +32,7 @@ pub enum MerkleMountainRangeError {
     InvalidMerkleTree,
     // The tree has reached its maximum size
     MaximumSizeReached,
+    // A node hash was not found for the given node index
+    #[error(non_std, no_from)]
+    HashNotFound(usize),
 }

--- a/base_layer/mmr/src/lib.rs
+++ b/base_layer/mmr/src/lib.rs
@@ -139,14 +139,17 @@ mod backend;
 mod merkle_mountain_range;
 mod merkle_proof;
 mod mutable_mmr;
+mod pruned_hashset;
 
 // Less commonly used exports
 pub mod common;
 pub mod error;
+/// A function for snapshotting and pruning a Merkle Mountain Range
+pub mod pruned_mmr;
 
 // Commonly used exports
 /// A vector-based backend for [MerkleMountainRange]
-pub use backend::VectorBackend;
+pub use backend::ArrayLike;
 /// An immutable, append-only Merkle Mountain range (MMR) data structure
 pub use merkle_mountain_range::MerkleMountainRange;
 /// A data structure for proving a hash inclusion in an MMR

--- a/base_layer/mmr/src/merkle_mountain_range.rs
+++ b/base_layer/mmr/src/merkle_mountain_range.rs
@@ -41,8 +41,8 @@ const LOG_TARGET: &str = "mmr::merkle_mountain_range";
 pub struct MerkleMountainRange<D, B>
 where B: ArrayLike
 {
-    hashes: B,
-    _hasher: PhantomData<D>,
+    pub(crate) hashes: B,
+    pub(crate) _hasher: PhantomData<D>,
 }
 
 impl<D, B> MerkleMountainRange<D, B>

--- a/base_layer/mmr/src/mutable_mmr.rs
+++ b/base_layer/mmr/src/mutable_mmr.rs
@@ -37,11 +37,11 @@ where
     B: ArrayLike<Value = Hash>,
 {
     pub(crate) mmr: MerkleMountainRange<D, B>,
-    deleted: Bitmap,
+    pub(crate) deleted: Bitmap,
     // The number of leaf nodes in the MutableMmr. Bitmap is limited to 4 billion elements, which is plenty.
     // [croaring::Treemap] is a 64bit alternative, but this would break things on 32bit systems. A good TODO would be
     // to select the bitmap backend using a feature flag
-    size: u32,
+    pub(crate) size: u32,
 }
 
 impl<D, B> MutableMmr<D, B>

--- a/base_layer/mmr/src/pruned_hashset.rs
+++ b/base_layer/mmr/src/pruned_hashset.rs
@@ -1,0 +1,102 @@
+// Copyright 2019. The Tari Project
+//
+// Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+// following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+// disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+// following disclaimer in the documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+// products derived from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+// INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+// WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+// USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+use crate::{common::find_peaks, error::MerkleMountainRangeError, ArrayLike, Hash, MerkleMountainRange};
+use digest::Digest;
+use std::convert::TryFrom;
+
+/// This is a specialised struct that represents a pruned hash set for Merkle Mountain Ranges.
+///
+/// The basic idea is that when adding a new hash, only the peaks to the left of the new node hierarchy are ever needed.
+/// This means that if we don't care about the data earlier than a given leaf node index, n_0, (i.e. we still have the
+/// hashes, but can't recalculate them from source), we _only need to store the local peaks for the MMR at that time_
+/// and we can forget about the rest. There will never be a request for a hash other than those at the peaks for the
+/// MMR with n_0 leaf nodes.
+///
+/// The awesome thing is that this struct can be dropped into [MerkleMountainRange] as a backend and it. just. works.
+pub struct PrunedHashSet {
+    /// The size of the base MMR. Only peaks are available for indices less than this value
+    base_offset: usize,
+    /// The array of peak indices for an MMR of size `base_offset`
+    peak_indices: Vec<usize>,
+    /// The array of hashes at the MMR peaks
+    peak_hashes: Vec<Hash>,
+    /// New hashes added subsequent to `base_offset`.
+    hashes: Vec<Hash>,
+}
+
+impl<D, B> TryFrom<&MerkleMountainRange<D, B>> for PrunedHashSet
+where
+    D: Digest,
+    B: ArrayLike<Value = Hash>,
+{
+    type Error = MerkleMountainRangeError;
+
+    fn try_from(base_mmr: &MerkleMountainRange<D, B>) -> Result<Self, Self::Error> {
+        let base_offset = base_mmr.len();
+        let peak_indices = find_peaks(base_offset);
+        let peak_hashes = peak_indices
+            .iter()
+            .map(|i| match base_mmr.get_node_hash(*i) {
+                Some(h) => Ok(h.clone()),
+                None => Err(MerkleMountainRangeError::HashNotFound(*i)),
+            })
+            .collect::<Result<_, _>>()?;
+        Ok(PrunedHashSet {
+            base_offset,
+            peak_indices,
+            peak_hashes,
+            hashes: Vec::new(),
+        })
+    }
+}
+
+impl ArrayLike for PrunedHashSet {
+    type Error = MerkleMountainRangeError;
+    type Value = Hash;
+
+    #[inline(always)]
+    fn len(&self) -> usize {
+        self.base_offset + self.hashes.len()
+    }
+
+    fn push(&mut self, item: Self::Value) -> Result<usize, Self::Error> {
+        self.hashes.push(item);
+        Ok(self.len() - 1)
+    }
+
+    fn get(&self, index: usize) -> Option<&Self::Value> {
+        // If the index is from before we started adding hashes, we can return the hash *if and only if* it is a peak
+        if index < self.base_offset {
+            return match self.peak_indices.binary_search(&index) {
+                Ok(nth_peak) => Some(&self.peak_hashes[nth_peak]),
+                Err(_) => None,
+            };
+        }
+        self.hashes.get(index - self.base_offset)
+    }
+
+    fn get_or_panic(&self, index: usize) -> &Self::Value {
+        self.get(index)
+            .expect("PrunedHashSet only tracks peaks before the offset")
+    }
+}

--- a/base_layer/mmr/tests/merkle_mountain_range.rs
+++ b/base_layer/mmr/tests/merkle_mountain_range.rs
@@ -24,12 +24,12 @@ mod support;
 
 use digest::Digest;
 use support::{combine_hashes, create_mmr, int_to_hash, Hasher};
-use tari_mmr::{MerkleMountainRange, VectorBackend};
+use tari_mmr::MerkleMountainRange;
 
 /// MMRs with no elements should provide sane defaults. The merkle root must be the hash of an empty string, b"".
 #[test]
 fn zero_length_mmr() {
-    let mmr = MerkleMountainRange::<Hasher, _>::new(VectorBackend::default());
+    let mmr = MerkleMountainRange::<Hasher, _>::new(Vec::default());
     assert_eq!(mmr.len(), 0);
     assert!(mmr.is_empty());
     let empty_hash = Hasher::digest(b"").to_vec();
@@ -39,7 +39,7 @@ fn zero_length_mmr() {
 /// Successively build up an MMR and check that the roots, heights and indices are all correct.
 #[test]
 fn build_mmr() {
-    let mut mmr = MerkleMountainRange::<Hasher, _>::new(VectorBackend::default());
+    let mut mmr = MerkleMountainRange::<Hasher, _>::new(Vec::default());
     // Add a single item
     let h0 = int_to_hash(0);
 
@@ -97,8 +97,8 @@ fn build_mmr() {
 
 #[test]
 fn equality_check() {
-    let mut ma = MerkleMountainRange::<Hasher, _>::new(VectorBackend::default());
-    let mut mb = MerkleMountainRange::<Hasher, _>::new(VectorBackend::default());
+    let mut ma = MerkleMountainRange::<Hasher, _>::new(Vec::default());
+    let mut mb = MerkleMountainRange::<Hasher, _>::new(Vec::default());
     assert!(ma == mb);
     assert!(ma.push(&int_to_hash(1)).is_ok());
     assert!(ma != mb);

--- a/base_layer/mmr/tests/support/mod.rs
+++ b/base_layer/mmr/tests/support/mod.rs
@@ -23,12 +23,12 @@
 
 use digest::Digest;
 use tari_crypto::common::Blake256;
-use tari_mmr::{Hash, HashSlice, MerkleMountainRange, VectorBackend};
+use tari_mmr::{Hash, HashSlice, MerkleMountainRange};
 
 pub type Hasher = Blake256;
 
-pub fn create_mmr(size: usize) -> MerkleMountainRange<Hasher, VectorBackend> {
-    let mut mmr = MerkleMountainRange::<Hasher, _>::new(VectorBackend::default());
+pub fn create_mmr(size: usize) -> MerkleMountainRange<Hasher, Vec<Hash>> {
+    let mut mmr = MerkleMountainRange::<Hasher, _>::new(Vec::default());
     for i in 0..size {
         let hash = int_to_hash(i);
         assert!(mmr.push(&hash).is_ok());


### PR DESCRIPTION
Part 3 of an MMR refactor focusing on ergonomics and performance.

This PR leverages the ArrayLike trait to provide a very elegant implementation
of a pruned MMR. See notes in `pruned_hashet` for details.

Also as part of this, the `VectorBackend` implementation of `ArrayLike` is deprecated in favour of just implementing `ArrayLike` straight onto `Vec<T>`.

The test file `MutableMmr` was renamed to `mutable_mmr`; it looks like Github didn't notice the rename.



<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [x] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [x] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch
* [x] I ran `cargo-fmt --all` before pushing
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
