### PR TITLE
Added Async Liveness (PingPong) Service

### DIFF
--- a/base_layer/p2p/src/services/liveness/error.rs
+++ b/base_layer/p2p/src/services/liveness/error.rs
@@ -20,12 +20,12 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-mod comms_outbound;
-mod liveness;
-mod service_name;
+use crate::services::comms_outbound::CommsOutboundServiceError;
+use derive_error::Error;
 
-use crate::executor::handles;
-
-pub use self::service_name::ServiceName;
-
-pub type ServiceHandles = handles::ServiceHandles<ServiceName>;
+#[derive(Debug, Error)]
+pub enum LivenessError {
+    CommsOutboundError(CommsOutboundServiceError),
+    /// Failed to send a ping
+    SendPingFailed,
+}

--- a/base_layer/p2p/src/services/liveness/messages.rs
+++ b/base_layer/p2p/src/services/liveness/messages.rs
@@ -20,12 +20,22 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-mod comms_outbound;
-mod liveness;
-mod service_name;
+use tari_comms::types::CommsPublicKey;
 
-use crate::executor::handles;
+/// API Request enum
+#[derive(Debug)]
+pub enum LivenessRequest {
+    /// Send a ping to the given public key
+    SendPing(CommsPublicKey),
+    /// Retrieve the total number of pings received
+    GetPingCount,
+    /// Retrieve the total number of pongs received
+    GetPongCount,
+}
 
-pub use self::service_name::ServiceName;
-
-pub type ServiceHandles = handles::ServiceHandles<ServiceName>;
+/// API Response enum
+#[derive(Debug)]
+pub enum LivenessResponse {
+    PingSent,
+    Count(usize),
+}

--- a/base_layer/p2p/src/services/liveness/mod.rs
+++ b/base_layer/p2p/src/services/liveness/mod.rs
@@ -1,0 +1,47 @@
+//  Copyright 2019 The Tari Project
+//
+//  Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+//  following conditions are met:
+//
+//  1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+//  disclaimer.
+//
+//  2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+//  following disclaimer in the documentation and/or other materials provided with the distribution.
+//
+//  3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+//  products derived from this software without specific prior written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+//  INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+//  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+//  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+//  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+//  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+//  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+mod error;
+mod messages;
+mod service;
+mod state;
+
+use self::messages::{LivenessRequest, LivenessResponse};
+use crate::{
+    executor::transport::{self, Requester, Responder},
+    services::{
+        liveness::{error::LivenessError, service::LivenessService, state::LivenessState},
+        ServiceHandles,
+    },
+};
+use std::sync::Arc;
+
+pub type LivenessRequester = Requester<LivenessRequest, Result<LivenessResponse, LivenessError>>;
+pub type LivenessResponder = Responder<LivenessService, LivenessRequest>;
+
+/// Create a liveness service pair.
+///
+/// This function implicitly implements the MakeServicePair trait.
+fn make_service(handles: Arc<ServiceHandles>) -> (LivenessRequester, LivenessResponder) {
+    let state = Arc::new(LivenessState::new());
+    transport::channel(LivenessService::new(state, handles))
+}

--- a/base_layer/p2p/src/services/liveness/service.rs
+++ b/base_layer/p2p/src/services/liveness/service.rs
@@ -1,0 +1,223 @@
+// Copyright 2019 The Tari Project
+//
+// Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+// following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+// disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+// following disclaimer in the documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+// products derived from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+// INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+// WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+// USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+use super::{error::LivenessError, state::LivenessState, LivenessRequest, LivenessResponse};
+use crate::{
+    services::{comms_outbound::CommsOutboundHandle, ServiceHandles, ServiceName},
+    tari_message::{NetMessage, TariMessageType},
+};
+use futures::{
+    future::{self, Either},
+    Future,
+    Poll,
+};
+use serde::{Deserialize, Serialize};
+use std::{convert::TryInto, sync::Arc};
+use tari_comms::{
+    message::{Message, MessageError, MessageFlags},
+    outbound_message_service::BroadcastStrategy,
+    types::CommsPublicKey,
+};
+use tower_service::Service;
+
+/// The PingPong message
+#[derive(Serialize, Deserialize)]
+pub enum PingPong {
+    Ping,
+    Pong,
+}
+
+impl TryInto<Message> for PingPong {
+    type Error = MessageError;
+
+    fn try_into(self) -> Result<Message, Self::Error> {
+        Ok((TariMessageType::new(NetMessage::PingPong), self).try_into()?)
+    }
+}
+
+/// Service responsible for testing Liveness for Peers.
+///
+/// Very basic global ping and pong counter stats are implemented. In future,
+/// peer latency and availability stats will be added.
+pub struct LivenessService {
+    state: Arc<LivenessState>,
+    handles: Arc<ServiceHandles>,
+    oms_handle: Option<CommsOutboundHandle>,
+}
+
+impl LivenessService {
+    pub fn new(state: Arc<LivenessState>, handles: Arc<ServiceHandles>) -> Self {
+        Self {
+            state,
+            handles,
+            oms_handle: None,
+        }
+    }
+
+    /// Get the CommsOutboundHandle.
+    ///
+    /// This function will panic if the handle does not exist.
+    fn oms_handle(&mut self) -> &mut CommsOutboundHandle {
+        match self.oms_handle {
+            Some(ref mut h) => h,
+            None => {
+                // Memoize the handle for later use
+                self.oms_handle = Some(
+                    self.handles
+                        .get_handle::<CommsOutboundHandle>(&ServiceName::CommsOutbound)
+                        .expect("LivenessService requires CommsOutboundHandle"),
+                );
+                self.oms_handle()
+            },
+        }
+    }
+
+    fn send_ping(
+        &mut self,
+        pub_key: CommsPublicKey,
+    ) -> impl Future<Item = Result<LivenessResponse, LivenessError>, Error = ()>
+    {
+        let state = self.state.clone();
+        self.oms_handle()
+            .send_message(
+                BroadcastStrategy::DirectPublicKey(pub_key),
+                MessageFlags::empty(),
+                TariMessageType::new(NetMessage::PingPong),
+                PingPong::Ping,
+            )
+            .and_then(move |res| {
+                state.inc_pings_sent();
+                future::ok(
+                    res.map(|_| LivenessResponse::PingSent)
+                        .map_err(LivenessError::CommsOutboundError),
+                )
+            })
+            .or_else(|_| future::ok(Err(LivenessError::SendPingFailed)))
+    }
+
+    fn get_ping_count(&self) -> usize {
+        self.state.pings_received()
+    }
+
+    fn get_pong_count(&self) -> usize {
+        self.state.pongs_received()
+    }
+}
+
+impl Service<LivenessRequest> for LivenessService {
+    type Error = ();
+    type Response = Result<LivenessResponse, LivenessError>;
+
+    existential type Future: Future<Item = Self::Response, Error = Self::Error>;
+
+    fn poll_ready(&mut self) -> Poll<(), Self::Error> {
+        Ok(().into())
+    }
+
+    fn call(&mut self, req: LivenessRequest) -> Self::Future {
+        match req {
+            LivenessRequest::SendPing(pub_key) => Either::A(
+                self.send_ping(pub_key)
+                    .or_else(|_| future::ok(Err(LivenessError::SendPingFailed))),
+            ),
+            LivenessRequest::GetPingCount => Either::B(future::ok(Result::<_, LivenessError>::Ok(
+                LivenessResponse::Count(self.get_ping_count()),
+            ))),
+            LivenessRequest::GetPongCount => Either::B(future::ok(Result::<_, LivenessError>::Ok(
+                LivenessResponse::Count(self.get_pong_count()),
+            ))),
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::executor::transport;
+    use futures::Async;
+    use rand::rngs::OsRng;
+    use tari_crypto::keys::PublicKey;
+    use tokio::runtime::Runtime;
+    use tower_util::service_fn;
+
+    #[test]
+    fn get_ping_pong_count() {
+        let state = Arc::new(LivenessState::new());
+        state.inc_pings_received();
+        state.inc_pongs_received();
+        state.inc_pongs_received();
+        let handles = Arc::new(ServiceHandles::new());
+
+        let mut service = LivenessService::new(state, handles);
+
+        let mut fut = service.call(LivenessRequest::GetPingCount);
+        match fut.poll().unwrap() {
+            Async::Ready(Ok(LivenessResponse::Count(n))) => assert_eq!(n, 1),
+            _ => panic!(),
+        }
+
+        let mut fut = service.call(LivenessRequest::GetPongCount);
+        match fut.poll().unwrap() {
+            Async::Ready(Ok(LivenessResponse::Count(n))) => assert_eq!(n, 2),
+            _ => panic!(),
+        }
+    }
+
+    #[test]
+    fn send_ping() {
+        let mut rt = Runtime::new().unwrap();
+        let state = Arc::new(LivenessState::new());
+        let handles = Arc::new(ServiceHandles::new());
+
+        // This service stubs out CommsOutboundService and always returns a successful result.
+        // Therefore, LivenessService will behave as if it was able to send the ping
+        // without actually sending it.
+        let outbound_service = service_fn(|_| future::ok::<_, ()>(Ok(())));
+        let (req, res) = transport::channel(outbound_service);
+        rt.spawn(res);
+
+        handles.insert(ServiceName::CommsOutbound, CommsOutboundHandle::new(req));
+
+        let mut service = LivenessService::new(Arc::clone(&state), handles);
+
+        let mut rng = OsRng::new().unwrap();
+        let (_, pk) = CommsPublicKey::random_keypair(&mut rng);
+        let fut = service.call(LivenessRequest::SendPing(pk));
+        match rt.block_on(fut).unwrap() {
+            Ok(LivenessResponse::PingSent) => {},
+            Ok(_) => panic!("received unexpected response from liveness service"),
+            Err(err) => panic!("received unexpected error from liveness service: {:?}", err),
+        }
+
+        assert_eq!(state.pings_sent(), 1);
+    }
+
+    #[test]
+    #[should_panic]
+    fn oms_handle_no_handle() {
+        let state = Arc::new(LivenessState::new());
+        let handles = Arc::new(ServiceHandles::new());
+        let mut service = LivenessService::new(Arc::clone(&state), handles);
+
+        service.oms_handle();
+    }
+}

--- a/base_layer/p2p/src/services/liveness/state.rs
+++ b/base_layer/p2p/src/services/liveness/state.rs
@@ -1,0 +1,127 @@
+// Copyright 2019 The Tari Project
+//
+// Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+// following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+// disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+// following disclaimer in the documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+// products derived from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+// INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+// WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+// USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+/// State for the LivenessService.
+#[derive(Default)]
+pub struct LivenessState {
+    pings_received: AtomicUsize,
+    pongs_received: AtomicUsize,
+
+    pings_sent: AtomicUsize,
+    pongs_sent: AtomicUsize,
+}
+
+impl LivenessState {
+    pub fn new() -> Self {
+        Default::default()
+    }
+
+    pub fn inc_pings_sent(&self) -> usize {
+        self.pings_sent.fetch_add(1, Ordering::Relaxed)
+    }
+
+    pub fn inc_pongs_sent(&self) -> usize {
+        self.pongs_sent.fetch_add(1, Ordering::Relaxed)
+    }
+
+    pub fn pings_sent(&self) -> usize {
+        self.pings_sent.load(Ordering::Relaxed)
+    }
+
+    pub fn pongs_sent(&self) -> usize {
+        self.pongs_sent.load(Ordering::Relaxed)
+    }
+
+    pub fn inc_pings_received(&self) -> usize {
+        self.pings_received.fetch_add(1, Ordering::Relaxed)
+    }
+
+    pub fn inc_pongs_received(&self) -> usize {
+        self.pongs_received.fetch_add(1, Ordering::Relaxed)
+    }
+
+    pub fn pings_received(&self) -> usize {
+        self.pings_received.load(Ordering::Relaxed)
+    }
+
+    pub fn pongs_received(&self) -> usize {
+        self.pongs_received.load(Ordering::Relaxed)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn new() {
+        let state = LivenessState::new();
+        assert_eq!(state.pings_received.load(Ordering::SeqCst), 0);
+        assert_eq!(state.pongs_received.load(Ordering::SeqCst), 0);
+        assert_eq!(state.pings_sent.load(Ordering::SeqCst), 0);
+        assert_eq!(state.pongs_sent.load(Ordering::SeqCst), 0);
+    }
+
+    #[test]
+    fn getters() {
+        let state = LivenessState::new();
+        state.pings_received.store(5, Ordering::SeqCst);
+        assert_eq!(state.pings_received(), 5);
+        assert_eq!(state.pongs_received(), 0);
+        assert_eq!(state.pings_sent(), 0);
+        assert_eq!(state.pongs_sent(), 0);
+    }
+
+    #[test]
+    fn inc_pings_sent() {
+        let state = LivenessState::new();
+        assert_eq!(state.pings_sent.load(Ordering::SeqCst), 0);
+        assert_eq!(state.inc_pings_sent(), 0);
+        assert_eq!(state.pings_sent.load(Ordering::SeqCst), 1);
+    }
+
+    #[test]
+    fn inc_pongs_sent() {
+        let state = LivenessState::new();
+        assert_eq!(state.pongs_sent.load(Ordering::SeqCst), 0);
+        assert_eq!(state.inc_pongs_sent(), 0);
+        assert_eq!(state.pongs_sent.load(Ordering::SeqCst), 1);
+    }
+
+    #[test]
+    fn inc_pings_received() {
+        let state = LivenessState::new();
+        assert_eq!(state.pings_received.load(Ordering::SeqCst), 0);
+        assert_eq!(state.inc_pings_received(), 0);
+        assert_eq!(state.pings_received.load(Ordering::SeqCst), 1);
+    }
+
+    #[test]
+    fn inc_pongs_received() {
+        let state = LivenessState::new();
+        assert_eq!(state.pongs_received.load(Ordering::SeqCst), 0);
+        assert_eq!(state.inc_pongs_received(), 0);
+        assert_eq!(state.pongs_received.load(Ordering::SeqCst), 1);
+    }
+}


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR adds an async replacement for the sync pingpong service. IT uses
the CommsOutboundService to send pings. Inbound ping and pong messages
are not read from the comms layer, this will be in a subsequent PR.


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Ref #673 
Ref #621  

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Unit tests

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [x] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [x] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch
* [x] I ran `cargo-fmt --all` before pushing
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
