### PR TITLE
Using original bus_queue implementation

### DIFF
--- a/comms/Cargo.toml
+++ b/comms/Cargo.toml
@@ -9,28 +9,29 @@ version = "0.0.2"
 edition = "2018"
 
 [dependencies]
+tari_crypto = { version="^0.0",  path = "../infrastructure/crypto" }
+tari_utilities = { version="^0.0",  path = "../infrastructure/tari_util" }
+tari_storage = { version="^0.0", path = "../infrastructure/storage" }
+
 bitflags ="1.0.4"
-chrono = { version = "0.4.6", features = ["serde"]}
+bus_queue = { version = "0.4.1", features=["async"] }
+chrono = { version = "0.4.6", features = ["serde"] }
 clear_on_drop = "0.2.3"
+crossbeam-channel = "0.3.9"
+crossbeam-deque = "0.7.1"
 derive-error = "0.0.4"
+digest = "0.8.0"
+futures = {version = "0.1"}
 lazy_static = "1.3.0"
+lmdb-zero = "0.4.4"
 log = { version = "0.4.0", features = ["std"] }
 rand = "0.5.5"
 serde = "1.0.90"
 serde_derive = "1.0.90"
-zmq = "0.9.1"
-digest = "0.8.0"
 time = "0.1.42"
-lmdb-zero = "0.4.4"
-ttl_cache = "0.5.1"
-tari_crypto = { version="^0.0",  path = "../infrastructure/crypto"}
-tari_utilities = { version="^0.0",  path = "../infrastructure/tari_util"}
-tari_storage = { version="^0.0", path = "../infrastructure/storage"}
-crossbeam-deque = "0.7.1"
-crossbeam-channel = "0.3.9"
-bus_queue = {git = "https://github.com/tari-project/bus-queue.git", branch = "sb-remove-waker-sleeper-from-async"}
-futures = {version = "0.1"}
 tokio = "0.1"
+ttl_cache = "0.5.1"
+zmq = "0.9.1"
 
 [dev-dependencies]
 criterion = "0.2"

--- a/comms/src/pub_sub_channel.rs
+++ b/comms/src/pub_sub_channel.rs
@@ -119,7 +119,7 @@ where
 /// The Subscription reader holds a reference to a subscription stream and provides a Future that will read any items
 /// that are currently in the stream and yield them to the synchronous caller WITHOUT ending the stream. The Stream is
 /// passed back to the caller so that it can checked for new messages in the future. This is allows non-futures code to
-/// read interrim values in a stream without the stream needing to end like the `.collect()` combinator requires.
+/// read interim values in a stream without the stream needing to end like the `.collect()` combinator requires.
 pub struct SubscriptionReader<T, M>
 where
     T: Eq + Send,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
The waker/sleeper from the bus_queue crate turns out to be more efficient
than using `task::current().notify()` which will cause the subscriber poll
function to spin.

TODO: consider contributing some benchmarks & tests to bus_queue as it appears
this project will be using it in several places


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Ref #621 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Existing tests pass

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch
* [x] I ran `cargo-fmt --all` before pushing
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
