### PR TITLE
Renamed DomainMessageContext to InboundMessage

### DIFF
--- a/base_layer/p2p/src/services/domain_deserializer.rs
+++ b/base_layer/p2p/src/services/domain_deserializer.rs
@@ -24,21 +24,21 @@ use futures::{Future, Poll};
 use serde::export::PhantomData;
 use tari_comms::{
     domain_subscriber::MessageInfo,
-    message::{DomainMessageContext, MessageError},
+    message::{InboundMessage, MessageError},
 };
 use tari_utilities::message_format::MessageFormat;
 use tokio_threadpool::{blocking, BlockingError};
 
-/// Future which asynchonously attempts to deserialize DomainMessageContext into
+/// Future which asynchonously attempts to deserialize InboundMessage into
 /// a `(MessageInfo, T)` tuple where T is [MessageFormat].
 pub struct DomainMessageDeserializer<T> {
-    message: Option<DomainMessageContext>,
+    message: Option<InboundMessage>,
     _t: PhantomData<T>,
 }
 
 impl<T> DomainMessageDeserializer<T> {
-    /// Create a new DomainMessageDeserializer from the given DomainMessageContext
-    pub fn new(message: DomainMessageContext) -> Self {
+    /// Create a new DomainMessageDeserializer from the given InboundMessage
+    pub fn new(message: InboundMessage) -> Self {
         Self {
             message: Some(message),
             _t: PhantomData,
@@ -75,13 +75,13 @@ mod test {
     use tari_crypto::keys::PublicKey;
     use tokio::runtime::Runtime;
 
-    fn create_domain_message<T: MessageFormat>(message_type: u8, inner_msg: T) -> DomainMessageContext {
+    fn create_domain_message<T: MessageFormat>(message_type: u8, inner_msg: T) -> InboundMessage {
         let mut rng = OsRng::new().unwrap();
         let (_, pk) = CommsPublicKey::random_keypair(&mut rng);
         let peer_source = PeerNodeIdentity::new(NodeId::from_key(&pk).unwrap(), pk.clone());
         let header = MessageHeader::new(message_type).unwrap();
         let msg = Message::from_message_format(header, inner_msg).unwrap();
-        DomainMessageContext::new(peer_source, pk, msg)
+        InboundMessage::new(peer_source, pk, msg)
     }
 
     #[test]

--- a/comms/src/builder/builder.rs
+++ b/comms/src/builder/builder.rs
@@ -33,7 +33,7 @@ use crate::{
         inbound_message_service::{InboundMessageService, InboundMessageServiceConfig},
         InboundTopicSubscriber,
     },
-    message::DomainMessageContext,
+    message::InboundMessage,
     outbound_message_service::{
         outbound_message_pool::{OutboundMessagePoolConfig, OutboundMessagePoolError},
         outbound_message_service::OutboundMessageService,
@@ -230,8 +230,8 @@ where
     // TODO Remove this Arc + RwLock when the IMS worker is refactored to be future based.
     fn make_inbound_message_publisher(
         &mut self,
-        publisher: TopicPublisher<MType, DomainMessageContext>,
-    ) -> Arc<RwLock<InboundMessagePublisher<MType, DomainMessageContext>>>
+        publisher: TopicPublisher<MType, InboundMessage>,
+    ) -> Arc<RwLock<InboundMessagePublisher<MType, InboundMessage>>>
     {
         Arc::new(RwLock::new(InboundMessagePublisher::new(publisher)))
     }
@@ -240,7 +240,7 @@ where
         &mut self,
         node_identity: Arc<NodeIdentity>,
         message_sink_address: InprocAddress,
-        inbound_message_publisher: Arc<RwLock<InboundMessagePublisher<MType, DomainMessageContext>>>,
+        inbound_message_publisher: Arc<RwLock<InboundMessagePublisher<MType, InboundMessage>>>,
         oms: Arc<OutboundMessageService>,
         peer_manager: Arc<PeerManager>,
     ) -> InboundMessageService<MType>

--- a/comms/src/builder/mod.rs
+++ b/comms/src/builder/mod.rs
@@ -27,7 +27,7 @@
 //! ```edition2018
 //! # use tari_comms::builder::CommsBuilder;
 //! # use tari_comms::dispatcher::HandlerError;
-//! # use tari_comms::message::DomainMessageContext;
+//! # use tari_comms::message::InboundMessage;
 //! # use tari_comms::control_service::ControlServiceConfig;
 //! # use tari_comms::peer_manager::NodeIdentity;
 //! # use std::sync::Arc;
@@ -39,7 +39,7 @@
 //! // This should be loaded up from storage
 //! let my_node_identity = NodeIdentity::random(&mut OsRng::new().unwrap(), "127.0.0.1:9000".parse().unwrap()).unwrap();
 //!
-//! fn my_handler(_: DomainMessageContext) -> Result<(), HandlerError> {
+//! fn my_handler(_: InboundMessage) -> Result<(), HandlerError> {
 //!     println!("Your handler is called!");
 //!     Ok(())
 //! }

--- a/comms/src/domain_subscriber.rs
+++ b/comms/src/domain_subscriber.rs
@@ -21,7 +21,7 @@
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 use crate::{
-    message::DomainMessageContext,
+    message::InboundMessage,
     peer_manager::PeerNodeIdentity,
     pub_sub_channel::{SubscriptionReader, TopicPublisherSubscriberError, TopicSubscription},
     types::CommsPublicKey,
@@ -53,14 +53,14 @@ pub struct MessageInfo {
 pub struct SyncDomainSubscription<MType>
 where MType: Eq + Send + Debug
 {
-    reader: Option<SubscriptionReader<MType, DomainMessageContext>>,
+    reader: Option<SubscriptionReader<MType, InboundMessage>>,
     runtime: Runtime,
 }
 
 impl<MType> SyncDomainSubscription<MType>
 where MType: Eq + Send + Debug + Sync + 'static
 {
-    pub fn new(subscription: TopicSubscription<MType, DomainMessageContext>) -> Self {
+    pub fn new(subscription: TopicSubscription<MType, InboundMessage>) -> Self {
         SyncDomainSubscription {
             reader: Some(SubscriptionReader::new(Arc::new(subscription))),
             runtime: Runtime::new().expect("Tokio could not create a Runtime"),

--- a/comms/src/inbound_message_service/comms_msg_handlers.rs
+++ b/comms/src/inbound_message_service/comms_msg_handlers.rs
@@ -23,7 +23,7 @@
 use crate::{
     consts::DHT_FORWARD_NODE_COUNT,
     dispatcher::{DispatchError, DispatchResolver, DispatchableKey},
-    message::{DomainMessageContext, Message, MessageContext, MessageFlags, MessageHeader, NodeDestination},
+    message::{InboundMessage, Message, MessageContext, MessageFlags, MessageHeader, NodeDestination},
     outbound_message_service::BroadcastStrategy,
     types::MessageDispatcher,
 };
@@ -175,11 +175,11 @@ where
             .map_err(DispatchError::handler_error())?;
     };
 
-    // Construct DomainMessageContext and dispatch to handler services using domain message broker
+    // Construct InboundMessage and dispatch to handler services using domain message broker
     let header: MessageHeader<MType> = message.deserialize_header().unwrap(); //.map_err(DispatchError::handler_error())?;
 
     debug!(target: LOG_TARGET, "Received message type: {:?}", header.message_type);
-    let domain_message_context = DomainMessageContext::new(
+    let domain_message_context = InboundMessage::new(
         message_context.peer.into(),
         message_envelope_header.origin_source,
         message,

--- a/comms/src/inbound_message_service/inbound_message_service.rs
+++ b/comms/src/inbound_message_service/inbound_message_service.rs
@@ -28,7 +28,7 @@ use crate::{
     },
     dispatcher::DispatchableKey,
     inbound_message_service::inbound_message_publisher::InboundMessagePublisher,
-    message::{DomainMessageContext, MessageContext},
+    message::{InboundMessage, MessageContext},
     outbound_message_service::outbound_message_service::OutboundMessageService,
     peer_manager::{peer_manager::PeerManager, NodeIdentity},
     types::MessageDispatcher,
@@ -80,7 +80,7 @@ where
     node_identity: Arc<NodeIdentity>,
     message_queue_address: InprocAddress,
     message_dispatcher: Arc<MessageDispatcher<MessageContext<MType>>>,
-    inbound_message_publisher: Arc<RwLock<InboundMessagePublisher<MType, DomainMessageContext>>>,
+    inbound_message_publisher: Arc<RwLock<InboundMessagePublisher<MType, InboundMessage>>>,
     outbound_message_service: Arc<OutboundMessageService>,
     peer_manager: Arc<PeerManager>,
     worker_thread_handle: Option<JoinHandle<()>>,
@@ -101,7 +101,7 @@ where
         node_identity: Arc<NodeIdentity>,
         message_queue_address: InprocAddress,
         message_dispatcher: Arc<MessageDispatcher<MessageContext<MType>>>,
-        inbound_message_publisher: Arc<RwLock<InboundMessagePublisher<MType, DomainMessageContext>>>,
+        inbound_message_publisher: Arc<RwLock<InboundMessagePublisher<MType, InboundMessage>>>,
         outbound_message_service: Arc<OutboundMessageService>,
         peer_manager: Arc<PeerManager>,
     ) -> Self
@@ -165,7 +165,7 @@ mod test {
         },
         inbound_message_service::comms_msg_handlers::*,
         message::{
-            DomainMessageContext,
+            InboundMessage,
             Message,
             MessageData,
             MessageEnvelope,
@@ -270,7 +270,7 @@ mod test {
         std::thread::sleep(Duration::from_millis(500));
         let mut rt = Runtime::new().unwrap();
         let sr = SubscriptionReader::new(Arc::new(message_subscription));
-        let (msgs, _): (Vec<DomainMessageContext>, _) = rt.block_on(sr).unwrap();
+        let (msgs, _): (Vec<InboundMessage>, _) = rt.block_on(sr).unwrap();
         assert_eq!(msgs.len(), TEST_MESSAGE_COUNT);
         for m in msgs.iter() {
             assert!(message_envelope_body_list.contains(&m.message));

--- a/comms/src/inbound_message_service/inbound_message_worker.rs
+++ b/comms/src/inbound_message_service/inbound_message_worker.rs
@@ -37,7 +37,7 @@ use crate::{
         MessageCache,
         MessageCacheConfig,
     },
-    message::{DomainMessageContext, Frame, FrameSet, MessageContext, MessageData},
+    message::{Frame, FrameSet, InboundMessage, MessageContext, MessageData},
     outbound_message_service::outbound_message_service::OutboundMessageService,
     peer_manager::{peer_manager::PeerManager, NodeId, NodeIdentity, Peer},
     types::MessageDispatcher,
@@ -73,7 +73,7 @@ where
     node_identity: Arc<NodeIdentity>,
     message_queue_address: InprocAddress,
     message_dispatcher: Arc<MessageDispatcher<MessageContext<MType>>>,
-    inbound_message_publisher: Arc<RwLock<InboundMessagePublisher<MType, DomainMessageContext>>>,
+    inbound_message_publisher: Arc<RwLock<InboundMessagePublisher<MType, InboundMessage>>>,
     outbound_message_service: Arc<OutboundMessageService>,
     peer_manager: Arc<PeerManager>,
     msg_cache: MessageCache<Frame>,
@@ -95,7 +95,7 @@ where
         node_identity: Arc<NodeIdentity>,
         message_queue_address: InprocAddress,
         message_dispatcher: Arc<MessageDispatcher<MessageContext<MType>>>,
-        inbound_message_publisher: Arc<RwLock<InboundMessagePublisher<MType, DomainMessageContext>>>,
+        inbound_message_publisher: Arc<RwLock<InboundMessagePublisher<MType, InboundMessage>>>,
         outbound_message_service: Arc<OutboundMessageService>,
         peer_manager: Arc<PeerManager>,
     ) -> Self
@@ -247,7 +247,7 @@ mod test {
     use crate::{
         connection::{Connection, Direction, NetAddress},
         inbound_message_service::comms_msg_handlers::construct_comms_msg_dispatcher,
-        message::{DomainMessageContext, Message, MessageEnvelope, MessageFlags, MessageHeader, NodeDestination},
+        message::{InboundMessage, Message, MessageEnvelope, MessageFlags, MessageHeader, NodeDestination},
         peer_manager::{peer_manager::PeerManager, NodeIdentity, PeerFlags},
         pub_sub_channel::{pubsub_channel, SubscriptionReader},
     };
@@ -370,7 +370,7 @@ mod test {
 
         let mut rt = Runtime::new().unwrap();
         let sr = SubscriptionReader::new(Arc::new(message_subscription_type1));
-        let (msgs_type1, _): (Vec<DomainMessageContext>, _) = rt.block_on(sr).unwrap();
+        let (msgs_type1, _): (Vec<InboundMessage>, _) = rt.block_on(sr).unwrap();
         assert_eq!(msgs_type1.len(), 1);
         assert_eq!(msgs_type1[0].message, message_envelope_body1);
 

--- a/comms/src/inbound_message_service/mod.rs
+++ b/comms/src/inbound_message_service/mod.rs
@@ -43,11 +43,11 @@ pub mod inbound_message_service;
 pub mod inbound_message_worker;
 pub mod message_cache;
 
-use crate::{message::DomainMessageContext, pub_sub_channel::TopicSubscriber};
+use crate::{message::InboundMessage, pub_sub_channel::TopicSubscriber};
 
 pub use self::{
     error::InboundError,
     message_cache::{MessageCache, MessageCacheConfig},
 };
 
-pub type InboundTopicSubscriber<MType> = TopicSubscriber<MType, DomainMessageContext>;
+pub type InboundTopicSubscriber<MType> = TopicSubscriber<MType, InboundMessage>;

--- a/comms/src/message/domain_message_context.rs
+++ b/comms/src/message/domain_message_context.rs
@@ -23,20 +23,20 @@
 use crate::{message::message::Message, peer_manager::PeerNodeIdentity, types::CommsPublicKey};
 use serde::{Deserialize, Serialize};
 
-/// The DomainMessageContext is the container that will be dispatched to the domain handlers. It contains the received
+/// The InboundMessage is the container that will be dispatched to the domain handlers. It contains the received
 /// message and source identity after the comms level envelope has been removed.
 #[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct DomainMessageContext {
+pub struct InboundMessage {
     pub peer_source: PeerNodeIdentity,
     pub origin_source: CommsPublicKey,
     pub message: Message,
 }
 
-impl DomainMessageContext {
-    /// Construct a new DomainMessageContext that consist of the peer connection information and the received message
+impl InboundMessage {
+    /// Construct a new InboundMessage that consist of the peer connection information and the received message
     /// header and body
     pub fn new(peer_source: PeerNodeIdentity, origin_source: CommsPublicKey, message: Message) -> Self {
-        DomainMessageContext {
+        InboundMessage {
             peer_source,
             origin_source,
             message,

--- a/comms/src/message/message_context.rs
+++ b/comms/src/message/message_context.rs
@@ -22,7 +22,7 @@
 use crate::{
     dispatcher::DispatchableKey,
     inbound_message_service::inbound_message_publisher::InboundMessagePublisher,
-    message::{DomainMessageContext, MessageEnvelope},
+    message::{InboundMessage, MessageEnvelope},
     outbound_message_service::outbound_message_service::OutboundMessageService,
     peer_manager::{peer_manager::PeerManager, NodeIdentity, Peer},
 };
@@ -41,7 +41,7 @@ where MType: Send + Sync + Debug
     pub peer: Peer,
     pub outbound_message_service: Arc<OutboundMessageService>,
     pub peer_manager: Arc<PeerManager>,
-    pub inbound_message_publisher: Arc<RwLock<InboundMessagePublisher<MType, DomainMessageContext>>>,
+    pub inbound_message_publisher: Arc<RwLock<InboundMessagePublisher<MType, InboundMessage>>>,
     pub node_identity: Arc<NodeIdentity>,
 }
 
@@ -60,7 +60,7 @@ where
         message_envelope: MessageEnvelope,
         outbound_message_service: Arc<OutboundMessageService>,
         peer_manager: Arc<PeerManager>,
-        inbound_message_publisher: Arc<RwLock<InboundMessagePublisher<MType, DomainMessageContext>>>,
+        inbound_message_publisher: Arc<RwLock<InboundMessagePublisher<MType, InboundMessage>>>,
     ) -> Self
     {
         MessageContext {


### PR DESCRIPTION

## Description
<!--- Describe your changes in detail -->
DomainMessageContext no longer makes sense for what it's being used for.
InboundMessage is better.
