### PR TITLE
Reorg Pool

### DIFF
--- a/base_layer/core/src/consts.rs
+++ b/base_layer/core/src/consts.rs
@@ -35,3 +35,8 @@ pub const MEMPOOL_ORPHAN_POOL_CACHE_TTL: Duration = Duration::from_secs(300);
 
 /// The maximum number of transactions that can be stored in the Pending pool
 pub const MEMPOOL_PENDING_POOL_STORAGE_CAPACITY: usize = 1000;
+
+/// The maximum number of transactions that can be stored in the Reorg pool
+pub const MEMPOOL_REORG_POOL_STORAGE_CAPACITY: usize = 1000;
+/// The time-to-live duration used for transactions stored in the ReorgPool
+pub const MEMPOOL_REORG_POOL_CACHE_TTL: Duration = Duration::from_secs(300);

--- a/base_layer/core/src/mempool/mempool.rs
+++ b/base_layer/core/src/mempool/mempool.rs
@@ -26,6 +26,7 @@ use crate::{
         error::MempoolError,
         orphan_pool::{OrphanPool, OrphanPoolConfig},
         pending_pool::{PendingPool, PendingPoolConfig},
+        reorg_pool::{ReorgPool, ReorgPoolConfig},
         unconfirmed_pool::{UnconfirmedPool, UnconfirmedPoolConfig},
     },
     transaction::Transaction,
@@ -39,7 +40,7 @@ pub struct MempoolConfig {
     pub unconfirmed_pool_config: UnconfirmedPoolConfig,
     pub orphan_pool_config: OrphanPoolConfig,
     pub pending_pool_config: PendingPoolConfig,
-    // TODO: Add configs for ReOrgPool
+    pub reorg_pool_config: ReorgPoolConfig,
 }
 
 impl Default for MempoolConfig {
@@ -48,6 +49,7 @@ impl Default for MempoolConfig {
             unconfirmed_pool_config: UnconfirmedPoolConfig::default(),
             orphan_pool_config: OrphanPoolConfig::default(),
             pending_pool_config: PendingPoolConfig::default(),
+            reorg_pool_config: ReorgPoolConfig::default(),
         }
     }
 }
@@ -59,7 +61,7 @@ pub struct Mempool {
     unconfirmed_pool: UnconfirmedPool,
     orphan_pool: OrphanPool,
     pending_pool: PendingPool,
-    // TODO: Add ReOrgPool
+    reorg_pool: ReorgPool,
 }
 
 impl Mempool {
@@ -69,6 +71,7 @@ impl Mempool {
             unconfirmed_pool: UnconfirmedPool::new(config.unconfirmed_pool_config),
             orphan_pool: OrphanPool::new(config.orphan_pool_config),
             pending_pool: PendingPool::new(config.pending_pool_config),
+            reorg_pool: ReorgPool::new(config.reorg_pool_config),
         }
     }
 
@@ -101,7 +104,8 @@ impl Mempool {
     /// Update the Mempool based on the received published block
     pub fn process_published_block(&mut self, _published_block: &Block) -> Result<(), MempoolError> {
         // Move published txs to ReOrgPool and discard double spends
-        // reorg_pool.insert_txs(unconfirmed_pool.remove_published_and_discard_double_spends(published_block)?)?;
+        // self.reorg_pool.insert_txs(self.unconfirmed_pool.remove_published_and_discard_double_spends(published_block)?
+        // )?;
 
         // Move txs with valid input UTXOs and expired time-locks to UnconfirmedPool and discard double spends
         // unconfirmed_pool.insert_txs(pending_pool.remove_unlocked_and_discard_double_spends()?)?;
@@ -128,9 +132,9 @@ impl Mempool {
     /// In the event of a ReOrg, resubmit all ReOrged transactions into the Mempool and process each newly introduced
     /// block from the latest longest chain
     pub fn process_reorg(&mut self, _removed_blocks: Vec<Block>, _new_blocks: Vec<Block>) -> Result<(), MempoolError> {
-        // self.insert_txs(reorg_pool.remove_unconfirmed(removed_blocks)?)?;
-        // self.process_published_blocks(new_blocks)?;
-
+        // let reorg_txs=self.reorg_pool.scan_for_and_remove_reorged_txs(removed_blocks);
+        // self.insert_txs(reorg_txs)?;
+        // self.process_published_blocks(&new_blocks)?;
         Ok(())
     }
 

--- a/base_layer/core/src/mempool/orphan_pool/orphan_pool.rs
+++ b/base_layer/core/src/mempool/orphan_pool/orphan_pool.rs
@@ -26,7 +26,7 @@ use crate::{
     types::{Signature, SignatureHash},
 };
 use merklemountainrange::mmr::MerkleMountainRange;
-use std::time::Duration;
+use std::{sync::Arc, time::Duration};
 use ttl_cache::TtlCache;
 
 /// Configuration for the OrphanPool
@@ -52,7 +52,7 @@ impl Default for OrphanPoolConfig {
 /// in a specific order. Some of these transactions might still be constrained by pending time-locks.
 pub struct OrphanPool {
     config: OrphanPoolConfig,
-    txs_by_signature: TtlCache<Signature, Transaction>,
+    txs_by_signature: TtlCache<Signature, Arc<Transaction>>,
 }
 
 impl OrphanPool {
@@ -68,7 +68,7 @@ impl OrphanPool {
     /// discarded if the UTXOs they require are not created before the Time-to-live threshold is reached.
     pub fn insert(&mut self, tx: Transaction) {
         let tx_key = tx.body.kernels[0].excess_sig.clone();
-        let _ = self.txs_by_signature.insert(tx_key, tx, self.config.tx_ttl);
+        let _ = self.txs_by_signature.insert(tx_key, Arc::new(tx), self.config.tx_ttl);
     }
 
     /// Insert a set of new transactions into the OrphanPool
@@ -92,7 +92,7 @@ impl OrphanPool {
         &mut self,
         block_height: u64,
         utxos: &MerkleMountainRange<TransactionInput, SignatureHash>,
-    ) -> (Vec<Transaction>, Vec<Transaction>)
+    ) -> (Vec<Arc<Transaction>>, Vec<Arc<Transaction>>)
     {
         let mut removed_tx_keys: Vec<Signature> = Vec::new();
         let mut removed_timelocked_tx_keys: Vec<Signature> = Vec::new();
@@ -106,14 +106,14 @@ impl OrphanPool {
             }
         }
 
-        let mut removed_txs: Vec<Transaction> = Vec::with_capacity(removed_tx_keys.len());
+        let mut removed_txs: Vec<Arc<Transaction>> = Vec::with_capacity(removed_tx_keys.len());
         removed_tx_keys.iter().for_each(|tx_key| {
             if let Some(tx) = self.txs_by_signature.remove(&tx_key) {
                 removed_txs.push(tx);
             }
         });
 
-        let mut removed_timelocked_txs: Vec<Transaction> = Vec::with_capacity(removed_timelocked_tx_keys.len());
+        let mut removed_timelocked_txs: Vec<Arc<Transaction>> = Vec::with_capacity(removed_timelocked_tx_keys.len());
         removed_timelocked_tx_keys.iter().for_each(|tx_key| {
             if let Some(tx) = self.txs_by_signature.remove(&tx_key) {
                 removed_timelocked_txs.push(tx);
@@ -164,12 +164,30 @@ mod test {
         // Check that transactions that have been in the pool for longer than their Time-to-live have been removed
         thread::sleep(Duration::from_millis(51));
         orphan_pool.insert_txs(vec![tx5.clone(), tx6.clone()]);
-        assert!(!orphan_pool.has_tx_with_excess_sig(&tx1.body.kernels[0].excess_sig));
-        assert!(!orphan_pool.has_tx_with_excess_sig(&tx2.body.kernels[0].excess_sig));
-        assert!(!orphan_pool.has_tx_with_excess_sig(&tx3.body.kernels[0].excess_sig));
-        assert!(!orphan_pool.has_tx_with_excess_sig(&tx4.body.kernels[0].excess_sig));
-        assert!(orphan_pool.has_tx_with_excess_sig(&tx5.body.kernels[0].excess_sig));
-        assert!(orphan_pool.has_tx_with_excess_sig(&tx6.body.kernels[0].excess_sig));
+        assert_eq!(
+            orphan_pool.has_tx_with_excess_sig(&tx1.body.kernels[0].excess_sig),
+            false
+        );
+        assert_eq!(
+            orphan_pool.has_tx_with_excess_sig(&tx2.body.kernels[0].excess_sig),
+            false
+        );
+        assert_eq!(
+            orphan_pool.has_tx_with_excess_sig(&tx3.body.kernels[0].excess_sig),
+            false
+        );
+        assert_eq!(
+            orphan_pool.has_tx_with_excess_sig(&tx4.body.kernels[0].excess_sig),
+            false
+        );
+        assert_eq!(
+            orphan_pool.has_tx_with_excess_sig(&tx5.body.kernels[0].excess_sig),
+            true
+        );
+        assert_eq!(
+            orphan_pool.has_tx_with_excess_sig(&tx6.body.kernels[0].excess_sig),
+            true
+        );
         assert_eq!(orphan_pool.len(), 2);
     }
 
@@ -216,7 +234,7 @@ mod test {
         assert_eq!(txs.len(), 1);
         assert_eq!(timelocked_txs.len(), 1);
         assert!(orphan_pool.has_tx_with_excess_sig(&tx3.body.kernels[0].excess_sig));
-        assert!(txs.contains(&tx4));
-        assert!(timelocked_txs.contains(&tx5));
+        assert!(txs.iter().any(|tx| **tx == tx4));
+        assert!(timelocked_txs.iter().any(|tx| **tx == tx5));
     }
 }

--- a/base_layer/core/src/mempool/pending_pool/pending_pool.rs
+++ b/base_layer/core/src/mempool/pending_pool/pending_pool.rs
@@ -195,7 +195,7 @@ mod test {
         let tx3 = create_test_tx(MicroTari(10_000), MicroTari(1000), 1000, 2, 1);
         let tx4 = create_test_tx(MicroTari(10_000), MicroTari(200), 2450, 2, 2);
         let tx5 = create_test_tx(MicroTari(10_000), MicroTari(500), 1000, 3, 3);
-        let tx6 = create_test_tx(MicroTari(10_000), MicroTari(750), 1850, 2, 2);
+        let tx6 = create_test_tx(MicroTari(10_000), MicroTari(750), 1450, 2, 2);
 
         let mut pending_pool = PendingPool::new(PendingPoolConfig { storage_capacity: 10 });
         pending_pool

--- a/base_layer/core/src/mempool/reorg_pool/mod.rs
+++ b/base_layer/core/src/mempool/reorg_pool/mod.rs
@@ -20,14 +20,7 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-mod error;
-mod mempool;
-mod orphan_pool;
-mod pending_pool;
-mod priority;
 mod reorg_pool;
-mod unconfirmed_pool;
 
 // Public re-exports
-pub use error::MempoolError;
-pub use mempool::Mempool;
+pub use reorg_pool::{ReorgPool, ReorgPoolConfig};

--- a/base_layer/core/src/mempool/reorg_pool/reorg_pool.rs
+++ b/base_layer/core/src/mempool/reorg_pool/reorg_pool.rs
@@ -1,0 +1,232 @@
+//  Copyright 2019 The Tari Project
+//
+//  Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+//  following conditions are met:
+//
+//  1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+//  disclaimer.
+//
+//  2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+//  following disclaimer in the documentation and/or other materials provided with the distribution.
+//
+//  3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+//  products derived from this software without specific prior written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+//  INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+//  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+//  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+//  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+//  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+//  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+use crate::{
+    blocks::block::Block,
+    consts::{MEMPOOL_REORG_POOL_CACHE_TTL, MEMPOOL_REORG_POOL_STORAGE_CAPACITY},
+    transaction::Transaction,
+    types::Signature,
+};
+use merklemountainrange::mmr::MerkleMountainRange;
+use std::{sync::Arc, time::Duration};
+use ttl_cache::TtlCache;
+
+/// Configuration for the ReorgPool
+#[derive(Clone, Copy)]
+pub struct ReorgPoolConfig {
+    /// The maximum number of transactions that can be stored in the ReorgPool
+    pub storage_capacity: usize,
+    /// The Time-to-live for each stored transaction
+    pub tx_ttl: Duration,
+}
+
+impl Default for ReorgPoolConfig {
+    fn default() -> Self {
+        Self {
+            storage_capacity: MEMPOOL_REORG_POOL_STORAGE_CAPACITY,
+            tx_ttl: MEMPOOL_REORG_POOL_CACHE_TTL,
+        }
+    }
+}
+
+/// The ReorgPool consists of all transactions that have recently been added to blocks.
+/// When a potential blockchain reorganization occurs the transactions can be recovered from the ReorgPool and can be
+/// added back into the UnconfirmedPool. Transactions in the ReOrg pool have a limited Time-to-live and will be removed
+/// from the pool when the Time-to-live thresholds is reached. Also, when the capacity of the pool has been reached, the
+/// oldest transactions will be removed to make space for incoming transactions.
+pub struct ReorgPool {
+    config: ReorgPoolConfig,
+    txs_by_signature: TtlCache<Signature, Arc<Transaction>>,
+}
+
+impl ReorgPool {
+    /// Create a new ReorgPool with the specified configuration
+    pub fn new(config: ReorgPoolConfig) -> Self {
+        Self {
+            config,
+            txs_by_signature: TtlCache::new(config.storage_capacity),
+        }
+    }
+
+    /// Insert a new transaction into the ReorgPool. Published transactions will have a limited Time-to-live in the
+    /// ReorgPool and will be discarded once the Time-to-live threshold has been reached.
+    pub fn insert(&mut self, tx: Transaction) {
+        let tx_key = tx.body.kernels[0].excess_sig.clone();
+        let _ = self.txs_by_signature.insert(tx_key, Arc::new(tx), self.config.tx_ttl);
+    }
+
+    /// Insert a set of new transactions into the ReorgPool
+    pub fn insert_txs(&mut self, txs: Vec<Transaction>) {
+        for tx in txs.into_iter() {
+            self.insert(tx);
+        }
+    }
+
+    /// Check if a transaction is stored in the ReorgPool
+    pub fn has_tx_with_excess_sig(&self, excess_sig: &Signature) -> bool {
+        self.txs_by_signature.contains_key(excess_sig)
+    }
+
+    /// Remove the transactions from the ReorgPool that were used in provided removed blocks. The transactions can be
+    /// resubmitted to the Unconfirmed Pool.
+    pub fn scan_for_and_remove_reorged_txs(&mut self, removed_blocks: Vec<Block>) -> Vec<Arc<Transaction>> {
+        let mut removed_txs: Vec<Arc<Transaction>> = Vec::new();
+        for block in &removed_blocks {
+            for kernel in &block.body.kernels {
+                if let Some(removed_tx) = self.txs_by_signature.remove(&kernel.excess_sig) {
+                    removed_txs.push(removed_tx);
+                }
+            }
+        }
+        removed_txs
+    }
+
+    /// Returns the total number of published transactions stored in the ReorgPool
+    pub fn len(&mut self) -> usize {
+        let mut count = 0;
+        self.txs_by_signature.iter().for_each(|_| count += 1);
+        (count)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::{
+        tari_amount::MicroTari,
+        test_utils::builders::{create_test_block, create_test_tx, create_test_utxos, extend_test_utxos},
+        transaction::TransactionInput,
+    };
+    use std::{thread, time::Duration};
+
+    #[test]
+    fn test_insert_rlu_and_ttl() {
+        let tx1 = create_test_tx(MicroTari(10_000), MicroTari(500), 4000, 2, 1);
+        let tx2 = create_test_tx(MicroTari(10_000), MicroTari(300), 3000, 2, 1);
+        let tx3 = create_test_tx(MicroTari(10_000), MicroTari(100), 2500, 2, 1);
+        let tx4 = create_test_tx(MicroTari(10_000), MicroTari(200), 1000, 2, 1);
+        let tx5 = create_test_tx(MicroTari(10_000), MicroTari(500), 2000, 2, 1);
+        let tx6 = create_test_tx(MicroTari(10_000), MicroTari(600), 5500, 2, 1);
+
+        let mut reorg_pool = ReorgPool::new(ReorgPoolConfig {
+            storage_capacity: 3,
+            tx_ttl: Duration::from_millis(50),
+        });
+        reorg_pool.insert_txs(vec![tx1.clone(), tx2.clone(), tx3.clone(), tx4.clone()]);
+        // Check that oldest utx was removed to make room for new incoming transactions
+        assert_eq!(
+            reorg_pool.has_tx_with_excess_sig(&tx1.body.kernels[0].excess_sig),
+            false
+        );
+        assert_eq!(reorg_pool.has_tx_with_excess_sig(&tx2.body.kernels[0].excess_sig), true);
+        assert_eq!(reorg_pool.has_tx_with_excess_sig(&tx3.body.kernels[0].excess_sig), true);
+        assert_eq!(reorg_pool.has_tx_with_excess_sig(&tx4.body.kernels[0].excess_sig), true);
+
+        // Check that transactions that have been in the pool for longer than their Time-to-live have been removed
+        thread::sleep(Duration::from_millis(51));
+        reorg_pool.insert_txs(vec![tx5.clone(), tx6.clone()]);
+        assert_eq!(
+            reorg_pool.has_tx_with_excess_sig(&tx1.body.kernels[0].excess_sig),
+            false
+        );
+        assert_eq!(
+            reorg_pool.has_tx_with_excess_sig(&tx2.body.kernels[0].excess_sig),
+            false
+        );
+        assert_eq!(
+            reorg_pool.has_tx_with_excess_sig(&tx3.body.kernels[0].excess_sig),
+            false
+        );
+        assert_eq!(
+            reorg_pool.has_tx_with_excess_sig(&tx4.body.kernels[0].excess_sig),
+            false
+        );
+        assert_eq!(reorg_pool.has_tx_with_excess_sig(&tx5.body.kernels[0].excess_sig), true);
+        assert_eq!(reorg_pool.has_tx_with_excess_sig(&tx6.body.kernels[0].excess_sig), true);
+        assert_eq!(reorg_pool.len(), 2);
+    }
+
+    #[test]
+    fn remove_scan_for_and_remove_reorged_txs() {
+        let tx1 = create_test_tx(MicroTari(10_000), MicroTari(500), 4000, 2, 1);
+        let tx2 = create_test_tx(MicroTari(10_000), MicroTari(300), 3000, 2, 1);
+        let tx3 = create_test_tx(MicroTari(10_000), MicroTari(100), 2500, 2, 1);
+        let tx4 = create_test_tx(MicroTari(10_000), MicroTari(200), 1000, 2, 1);
+        let tx5 = create_test_tx(MicroTari(10_000), MicroTari(500), 2000, 2, 1);
+        let tx6 = create_test_tx(MicroTari(10_000), MicroTari(600), 5500, 2, 1);
+
+        let mut reorg_pool = ReorgPool::new(ReorgPoolConfig {
+            storage_capacity: 5,
+            tx_ttl: Duration::from_millis(50),
+        });
+        reorg_pool.insert_txs(vec![
+            tx1.clone(),
+            tx2.clone(),
+            tx3.clone(),
+            tx4.clone(),
+            tx5.clone(),
+            tx6.clone(),
+        ]);
+        // Oldest transaction tx1 is removed to make space for new incoming transactions
+        assert_eq!(reorg_pool.len(), 5);
+        assert_eq!(
+            reorg_pool.has_tx_with_excess_sig(&tx1.body.kernels[0].excess_sig),
+            false
+        );
+        assert_eq!(reorg_pool.has_tx_with_excess_sig(&tx2.body.kernels[0].excess_sig), true);
+        assert_eq!(reorg_pool.has_tx_with_excess_sig(&tx3.body.kernels[0].excess_sig), true);
+        assert_eq!(reorg_pool.has_tx_with_excess_sig(&tx4.body.kernels[0].excess_sig), true);
+        assert_eq!(reorg_pool.has_tx_with_excess_sig(&tx5.body.kernels[0].excess_sig), true);
+        assert_eq!(reorg_pool.has_tx_with_excess_sig(&tx6.body.kernels[0].excess_sig), true);
+
+        let reorg_blocks = vec![
+            create_test_block(3000, vec![tx3.clone(), tx4.clone()]),
+            create_test_block(4000, vec![tx1.clone(), tx2.clone()]),
+        ];
+
+        let removed_txs = reorg_pool.scan_for_and_remove_reorged_txs(reorg_blocks);
+        assert_eq!(removed_txs.len(), 3);
+        assert!(removed_txs.iter().any(|tx| **tx == tx2));
+        assert!(removed_txs.iter().any(|tx| **tx == tx3));
+        assert!(removed_txs.iter().any(|tx| **tx == tx4));
+
+        assert_eq!(reorg_pool.len(), 2);
+        assert_eq!(
+            reorg_pool.has_tx_with_excess_sig(&tx1.body.kernels[0].excess_sig),
+            false
+        );
+        assert_eq!(
+            reorg_pool.has_tx_with_excess_sig(&tx2.body.kernels[0].excess_sig),
+            false
+        );
+        assert_eq!(
+            reorg_pool.has_tx_with_excess_sig(&tx3.body.kernels[0].excess_sig),
+            false
+        );
+        assert_eq!(
+            reorg_pool.has_tx_with_excess_sig(&tx4.body.kernels[0].excess_sig),
+            false
+        );
+        assert_eq!(reorg_pool.has_tx_with_excess_sig(&tx5.body.kernels[0].excess_sig), true);
+        assert_eq!(reorg_pool.has_tx_with_excess_sig(&tx6.body.kernels[0].excess_sig), true);
+    }
+}


### PR DESCRIPTION
## Description
- Added implementation of ReorgPool 
- Added ReorgPool unit tests
- Modified OrphanPool to rather store and return an Arc to each transaction.

## Motivation and Context
The ReorgPool consists of all transaction that have recently been added to blocks. When a potential blockchain reorganization occurs, the transactions used to construct these discarded blocks can be recovered from the ReorgPool and can be added back into the UnconfirmedPool. 

## How Has This Been Tested?
New tests have been added.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [x] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch
* [x] I ran `cargo-fmt --all` before pushing
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
