### PR TITLE
Update Comms crate to use Futures 0.3

### DIFF
--- a/base_layer/p2p/src/ping_pong.rs
+++ b/base_layer/p2p/src/ping_pong.rs
@@ -42,7 +42,7 @@ use std::{
     time::Duration,
 };
 use tari_comms::{
-    domain_subscriber::MessageInfo,
+    domain_subscriber::{MessageInfo, SyncDomainSubscription},
     message::{Message, MessageError, MessageFlags},
     outbound_message_service::{outbound_message_service::OutboundMessageService, BroadcastStrategy, OutboundError},
     types::CommsPublicKey,
@@ -176,7 +176,11 @@ impl Service for PingPongService {
     }
 
     fn execute(&mut self, context: ServiceContext) -> Result<(), ServiceError> {
-        let mut subscription = context.create_sync_subscription(NetMessage::PingPong.into());
+        let mut subscription = SyncDomainSubscription::new(
+            context
+                .inbound_message_subscription_factory()
+                .get_subscription_fused(NetMessage::PingPong.into()),
+        );
 
         self.oms = Some(context.outbound_message_service());
 

--- a/base_layer/wallet/src/text_message_service/service.rs
+++ b/base_layer/wallet/src/text_message_service/service.rs
@@ -36,7 +36,7 @@ use std::{
     time::Duration,
 };
 use tari_comms::{
-    domain_subscriber::MessageInfo,
+    domain_subscriber::{MessageInfo, SyncDomainSubscription},
     message::{Message, MessageError, MessageFlags},
     outbound_message_service::{outbound_message_service::OutboundMessageService, BroadcastStrategy},
     types::CommsPublicKey,
@@ -349,8 +349,16 @@ impl Service for TextMessageService {
     /// Function called by the Service Executor in its own thread. This function polls for both API request and Comms
     /// layer messages from the Message Broker
     fn execute(&mut self, context: ServiceContext) -> Result<(), ServiceError> {
-        let mut subscription_text = context.create_sync_subscription(ExtendedMessage::Text.into());
-        let mut subscription_text_ack = context.create_sync_subscription(ExtendedMessage::Text.into());
+        let mut subscription_text = SyncDomainSubscription::new(
+            context
+                .inbound_message_subscription_factory()
+                .get_subscription_fused(ExtendedMessage::Text.into()),
+        );
+        let mut subscription_text_ack = SyncDomainSubscription::new(
+            context
+                .inbound_message_subscription_factory()
+                .get_subscription_fused(ExtendedMessage::TextAck.into()),
+        );
 
         self.oms = Some(context.outbound_message_service());
 

--- a/comms/Cargo.toml
+++ b/comms/Cargo.toml
@@ -14,14 +14,14 @@ tari_utilities = { version="^0.0",  path = "../infrastructure/tari_util" }
 tari_storage = { version="^0.0", path = "../infrastructure/storage" }
 
 bitflags ="1.0.4"
-bus_queue = { version = "0.4.1", features=["async"] }
+bus_queue = { git = "https://github.com/tari-project/bus-queue.git"}
 chrono = { version = "0.4.6", features = ["serde"] }
 clear_on_drop = "0.2.3"
 crossbeam-channel = "0.3.9"
 crossbeam-deque = "0.7.1"
 derive-error = "0.0.4"
 digest = "0.8.0"
-futures = {version = "0.1"}
+futures =  { version = "=0.3.0-alpha.18", package = "futures-preview", features = ["async-await", "nightly", "io-compat", "compat"] }
 lazy_static = "1.3.0"
 lmdb-zero = "0.4.4"
 log = { version = "0.4.0", features = ["std"] }

--- a/comms/src/domain_subscriber.rs
+++ b/comms/src/domain_subscriber.rs
@@ -19,24 +19,18 @@
 // SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
-use crate::{
-    message::InboundMessage,
-    peer_manager::PeerNodeIdentity,
-    pub_sub_channel::{SubscriptionReader, TopicPublisherSubscriberError, TopicSubscription},
-    types::CommsPublicKey,
-};
+use crate::{futures::StreamExt, message::InboundMessage, peer_manager::PeerNodeIdentity, types::CommsPublicKey};
 use derive_error::Error;
-use std::{fmt::Debug, sync::Arc};
+use futures::{executor::block_on, future::select, stream::FusedStream, Stream};
+use std::fmt::Debug;
 use tari_utilities::message_format::MessageFormat;
-use tokio::runtime::Runtime;
 
-#[derive(Debug, Error)]
+#[derive(Debug, Error, PartialEq)]
 pub enum DomainSubscriberError {
-    /// Error reading from subscription
-    TopicPublisherSubscriberError(TopicPublisherSubscriberError),
     /// Subscription stream ended
     SubscriptionStreamEnded,
+    /// Error reading from the stream
+    StreamError,
     /// Message deserialization error
     MessageError,
     /// Subscription Reader is not initialized
@@ -49,49 +43,155 @@ pub struct MessageInfo {
     pub peer_source: PeerNodeIdentity,
     pub origin_source: CommsPublicKey,
 }
-
-pub struct SyncDomainSubscription<MType>
-where MType: Eq + Send + Debug
-{
-    reader: Option<SubscriptionReader<MType, InboundMessage>>,
-    runtime: Runtime,
+pub struct SyncDomainSubscription<S> {
+    subscription: Option<S>,
 }
-
-impl<MType> SyncDomainSubscription<MType>
-where MType: Eq + Send + Debug + Sync + 'static
+impl<S> SyncDomainSubscription<S>
+where S: Stream<Item = InboundMessage> + Unpin + FusedStream
 {
-    pub fn new(subscription: TopicSubscription<MType, InboundMessage>) -> Self {
+    pub fn new(stream: S) -> Self {
         SyncDomainSubscription {
-            reader: Some(SubscriptionReader::new(Arc::new(subscription))),
-            runtime: Runtime::new().expect("Tokio could not create a Runtime"),
+            subscription: Some(stream),
         }
     }
 
     pub fn receive_messages<T>(&mut self) -> Result<Vec<(MessageInfo, T)>, DomainSubscriberError>
     where T: MessageFormat {
-        if let Some(s) = self.reader.take() {
-            let (messages, returned_arc) = self.runtime.block_on(s)?;
-            self.reader = Some(SubscriptionReader::new(
-                returned_arc.ok_or(DomainSubscriberError::SubscriptionStreamEnded)?,
-            ));
+        let subscription = self.subscription.take();
 
-            let mut result = Vec::new();
+        match subscription {
+            Some(mut s) => {
+                let (stream_messages, stream_complete): (Vec<InboundMessage>, bool) = block_on(async {
+                    let mut result = Vec::new();
+                    let mut complete = false;
+                    loop {
+                        select!(
+                            item = s.next() => {
+                                if let Some(item) = item {
+                                    result.push(item)
+                                }
+                            },
+                            complete => {
+                                complete = true;
+                                break
+                            },
+                            default => break,
+                        );
+                    }
+                    (result, complete)
+                });
 
-            for m in messages {
-                result.push((
-                    MessageInfo {
-                        peer_source: m.peer_source,
-                        origin_source: m.origin_source,
-                    },
-                    m.message
-                        .deserialize_message()
-                        .map_err(|_| DomainSubscriberError::MessageError)?,
-                ));
-            }
+                let mut messages = Vec::new();
 
-            Ok(result)
-        } else {
-            Err(DomainSubscriberError::SubscriptionReaderNotInitialized)
+                for m in stream_messages {
+                    messages.push((
+                        MessageInfo {
+                            peer_source: m.peer_source,
+                            origin_source: m.origin_source,
+                        },
+                        m.message
+                            .deserialize_message()
+                            .map_err(|_| DomainSubscriberError::MessageError)?,
+                    ));
+                }
+
+                if !stream_complete {
+                    self.subscription = Some(s);
+                }
+
+                return Ok(messages);
+            },
+            None => return Err(DomainSubscriberError::SubscriptionStreamEnded),
         }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::{
+        message::Message,
+        peer_manager::NodeIdentity,
+        pub_sub_channel::{pubsub_channel, TopicPayload},
+    };
+    use futures::{executor::block_on, future::select, stream::TryStreamExt, SinkExt};
+    use serde::{Deserialize, Serialize};
+    use std::sync::Arc;
+    #[test]
+    fn topic_pub_sub() {
+        let (mut publisher, subscriber_factory) = pubsub_channel(10);
+
+        #[derive(Serialize, Deserialize, Debug, Clone)]
+        struct Dummy {
+            a: u32,
+            b: String,
+        }
+
+        let node_id = NodeIdentity::random_for_test(None);
+
+        let messages = vec![
+            ("Topic1".to_string(), Dummy {
+                a: 1u32,
+                b: "one".to_string(),
+            }),
+            ("Topic2".to_string(), Dummy {
+                a: 2u32,
+                b: "two".to_string(),
+            }),
+            ("Topic1".to_string(), Dummy {
+                a: 3u32,
+                b: "three".to_string(),
+            }),
+            ("Topic2".to_string(), Dummy {
+                a: 4u32,
+                b: "four".to_string(),
+            }),
+            ("Topic1".to_string(), Dummy {
+                a: 5u32,
+                b: "five".to_string(),
+            }),
+            ("Topic2".to_string(), Dummy {
+                a: 6u32,
+                b: "size".to_string(),
+            }),
+            ("Topic1".to_string(), Dummy {
+                a: 7u32,
+                b: "seven".to_string(),
+            }),
+        ];
+
+        let serialized_messages = messages.iter().map(|m| {
+            TopicPayload::new(
+                m.0.clone(),
+                InboundMessage::new(
+                    node_id.identity.clone(),
+                    node_id.identity.public_key.clone(),
+                    Message::from_message_format(m.0.clone(), m.1.clone()).unwrap(),
+                ),
+            )
+        });
+
+        block_on(async {
+            for m in serialized_messages {
+                publisher.send(m).await.unwrap();
+            }
+        });
+        drop(publisher);
+
+        let mut domain_sub =
+            SyncDomainSubscription::new(subscriber_factory.get_subscription("Topic1".to_string()).fuse());
+
+        let messages = domain_sub.receive_messages::<Dummy>().unwrap();
+
+        assert_eq!(
+            domain_sub.receive_messages::<Dummy>().unwrap_err(),
+            DomainSubscriberError::SubscriptionStreamEnded
+        );
+
+        assert_eq!(messages.len(), 4);
+        assert_eq!(messages[0].1.a, 1);
+        assert_eq!(messages[1].1.a, 3);
+        assert_eq!(messages[2].1.a, 5);
+        assert_eq!(messages[3].1.a, 7);
     }
 }

--- a/comms/src/inbound_message_service/mod.rs
+++ b/comms/src/inbound_message_service/mod.rs
@@ -43,11 +43,11 @@ pub mod inbound_message_service;
 pub mod inbound_message_worker;
 pub mod message_cache;
 
-use crate::{message::InboundMessage, pub_sub_channel::TopicSubscriber};
+use crate::{message::InboundMessage, pub_sub_channel::TopicSubscriptionFactory};
 
 pub use self::{
     error::InboundError,
     message_cache::{MessageCache, MessageCacheConfig},
 };
 
-pub type InboundTopicSubscriber<MType> = TopicSubscriber<MType, InboundMessage>;
+pub type InboundTopicSubscriptionFactory<MType> = TopicSubscriptionFactory<MType, InboundMessage>;


### PR DESCRIPTION
## Description

In this PR the comms crate is updated to use the new Futures 0.3. This was done while keeping the interface used by domain level services consistent but required some work to make the modules using Futures 0.1 be able to use the new futures stuff.
## Motivation and Context
Closes https://github.com/tari-project/tari/issues/708
Closes https://github.com/tari-project/tari/issues/690

## How Has This Been Tested?
Tests have been provided and updated

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [x] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [x] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch
* [x] I ran `cargo-fmt --all` before pushing
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
