### PR TITLE
Pruning horizon metadata

### DIFF
--- a/base_layer/core/src/blocks/block.rs
+++ b/base_layer/core/src/blocks/block.rs
@@ -28,7 +28,7 @@ use crate::{
     proof_of_work::PowError,
     tari_amount::*,
     transaction::*,
-    types::{Commitment, HashDigest, TariProofOfWork, COMMITMENT_FACTORY, PROVER},
+    types::{Commitment, TariProofOfWork, COMMITMENT_FACTORY, PROVER},
 };
 use derive_error::Error;
 use serde::{Deserialize, Serialize};

--- a/base_layer/core/src/chain_storage/memory_db.rs
+++ b/base_layer/core/src/chain_storage/memory_db.rs
@@ -86,6 +86,9 @@ where D: Digest + Send + Sync
                     DbKeyValuePair::Metadata(_, MetadataValue::AccumulatedWork(w)) => {
                         db.metadata.total_accumulated_difficulty = w;
                     },
+                    DbKeyValuePair::Metadata(_, MetadataValue::PruningHorizon(h)) => {
+                        db.metadata.pruning_horizon = h;
+                    },
                     DbKeyValuePair::BlockHeader(k, v) => {
                         let hash = v.hash();
                         db.header_mmr.push(&hash).unwrap();
@@ -151,6 +154,9 @@ where D: Digest + Send + Sync
             ))),
             DbKey::Metadata(MetadataKey::AccumulatedWork) => Some(DbValue::Metadata(MetadataValue::AccumulatedWork(
                 db.metadata.total_accumulated_difficulty,
+            ))),
+            DbKey::Metadata(MetadataKey::PruningHorizon) => Some(DbValue::Metadata(MetadataValue::PruningHorizon(
+                db.metadata.pruning_horizon,
             ))),
             DbKey::BlockHeader(k) => db.headers.get(k).map(|v| DbValue::BlockHeader(Box::new(v.clone()))),
             DbKey::UnspentOutput(k) => db.utxos.get(k).map(|v| DbValue::UnspentOutput(Box::new(v.clone()))),

--- a/base_layer/core/src/chain_storage/metadata.rs
+++ b/base_layer/core/src/chain_storage/metadata.rs
@@ -20,17 +20,29 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone)]
 pub struct ChainMetadata {
     pub height_of_longest_chain: u64,
     pub total_accumulated_difficulty: u64,
+    pub pruning_horizon: u64,
 }
 
 impl ChainMetadata {
-    pub fn new(height: u64, work: u64) -> ChainMetadata {
+    pub fn new(height: u64, work: u64, horizon: u64) -> ChainMetadata {
         ChainMetadata {
             height_of_longest_chain: height,
             total_accumulated_difficulty: work,
+            pruning_horizon: horizon,
+        }
+    }
+}
+
+impl Default for ChainMetadata {
+    fn default() -> Self {
+        ChainMetadata {
+            height_of_longest_chain: 0,
+            total_accumulated_difficulty: 0,
+            pruning_horizon: 2880,
         }
     }
 }

--- a/base_layer/core/src/proof_of_work/blake_pow.rs
+++ b/base_layer/core/src/proof_of_work/blake_pow.rs
@@ -45,11 +45,9 @@ impl BlakePow {
     /// A simple miner. It starts at nonce = 0 and iterates until it finds a header hash that meets the desired target
     pub fn mine(target_difficulty: Difficulty, header: &BlockHeader) -> u64 {
         let mut nonce = 0u64;
-        let mut difficulty = Difficulty::default();
         // We're mining over here!
         while let Ok(d) = header.pow.calculate_difficulty(nonce, &header) {
             if d >= target_difficulty {
-                difficulty = d;
                 break;
             }
             nonce += 1;
@@ -81,7 +79,7 @@ impl Default for BlakePow {
 }
 
 impl ByteArray for BlakePow {
-    fn from_bytes(bytes: &[u8]) -> Result<Self, ByteArrayError> {
+    fn from_bytes(_bytes: &[u8]) -> Result<Self, ByteArrayError> {
         Ok(BlakePow)
     }
 
@@ -100,7 +98,7 @@ impl Hashable for BlakePow {
 mod test {
     use crate::{
         blocks::blockheader::BlockHeader,
-        proof_of_work::{Difficulty, ProofOfWork},
+        proof_of_work::{ProofOfWork},
     };
 
     #[test]

--- a/base_layer/core/src/proof_of_work/blake_pow.rs
+++ b/base_layer/core/src/proof_of_work/blake_pow.rs
@@ -96,10 +96,7 @@ impl Hashable for BlakePow {
 
 #[cfg(test)]
 mod test {
-    use crate::{
-        blocks::blockheader::BlockHeader,
-        proof_of_work::{ProofOfWork},
-    };
+    use crate::{blocks::blockheader::BlockHeader, proof_of_work::ProofOfWork};
 
     #[test]
     fn validate_max_target() {

--- a/base_layer/core/src/proof_of_work/difficulty.rs
+++ b/base_layer/core/src/proof_of_work/difficulty.rs
@@ -79,6 +79,7 @@ impl From<u64> for Difficulty {
 mod test {
     use crate::proof_of_work::difficulty::Difficulty;
 
+    #[test]
     fn add_difficulty() {
         assert_eq!(
             Difficulty::from(1_000) + Difficulty::from(8_000),


### PR DESCRIPTION
The pruning horizon is an important and general piece of metadata that informs
  users of BlockchainDatabases where full storage of blockchain history begins.
    
 The pruning horizon is used in synchronisation requests and block data requests
 (e.g. from explorers).
    
 Given that this is the 3rd piece of metadata, the fetch method is DRYd up to
 eliminate a bunch of repeated code.
    
   ## Changes summary:
* Cleans up `read_metadata` by using a macro to clean out boilerplate
* Allows the setting of a pruning horizon. BAckend can use this as a
      hint to delete older data
* Clean up some compiler warnings
