### PR TITLE
Remove tari_p2p dependency in tari_core

### DIFF
--- a/base_layer/core/Cargo.toml
+++ b/base_layer/core/Cargo.toml
@@ -13,9 +13,7 @@ edition = "2018"
 tari_utilities = { path = "../../infrastructure/tari_util", version = "^0.0", features = ["chrono_dt"]}
 tari_infra_derive = { path = "../../infrastructure/derive", version = "^0.0" }
 tari_crypto = { path = "../../infrastructure/crypto", version = "^0.0" }
-tari_p2p = {path = "../../base_layer/p2p", version = "^0.0"}
 tari_storage = { path = "../../infrastructure/storage", version = "^0.0" }
-tari_comms = { version = "^0.0", path = "../../comms"}
 tari_mmr = { path = "../../base_layer/mmr", version = "^0.0" }
 bitflags = "1.0.4"
 chrono = { version = "0.4.6", features = ["serde"]}

--- a/base_layer/core/src/transaction_protocol/recipient.rs
+++ b/base_layer/core/src/transaction_protocol/recipient.rs
@@ -31,8 +31,6 @@ use crate::{
 };
 use serde::{Deserialize, Serialize};
 use std::{collections::HashMap, convert::TryInto};
-use tari_comms::message::{Message, MessageError};
-use tari_p2p::tari_message::{BlockchainMessage, TariMessageType};
 
 #[derive(Clone, Debug)]
 pub enum RecipientState {
@@ -61,15 +59,6 @@ pub struct RecipientSignedMessage {
     pub output: TransactionOutput,
     pub public_spend_key: PublicKey,
     pub partial_signature: Signature,
-}
-
-/// Convert `RecipientSignedMessage` into a Tari Message that can be sent via the tari comms stack
-impl TryInto<Message> for RecipientSignedMessage {
-    type Error = MessageError;
-
-    fn try_into(self) -> Result<Message, Self::Error> {
-        Ok((TariMessageType::new(BlockchainMessage::TransactionReply), self).try_into()?)
-    }
 }
 
 /// The generalised transaction recipient protocol. A different state transition network is followed depending on

--- a/base_layer/core/src/transaction_protocol/sender.rs
+++ b/base_layer/core/src/transaction_protocol/sender.rs
@@ -39,9 +39,7 @@ use crate::{
 use digest::Digest;
 use serde::{Deserialize, Serialize};
 use std::convert::TryInto;
-use tari_comms::message::{Message, MessageError};
 use tari_crypto::ristretto::pedersen::PedersenCommitment;
-use tari_p2p::tari_message::{BlockchainMessage, TariMessageType};
 use tari_utilities::ByteArray;
 
 //----------------------------------------   Local Data types     ----------------------------------------------------//
@@ -99,15 +97,6 @@ pub enum TransactionSenderMessage {
     Single(Box<SingleRoundSenderData>),
     // TODO: Three round types
     Multiple,
-}
-
-/// Convert `SenderMessage` into a Tari Message that can be sent via the tari comms stack
-impl TryInto<Message> for TransactionSenderMessage {
-    type Error = MessageError;
-
-    fn try_into(self) -> Result<Message, Self::Error> {
-        Ok((TariMessageType::new(BlockchainMessage::Transaction), self).try_into()?)
-    }
 }
 
 //----------------------------------------  Sender State Protocol ----------------------------------------------------//


### PR DESCRIPTION
The core blockchain code shouldn't need to know about peer-to-peer comms