### PR TITLE
Fix best_block check bug

### DIFF
--- a/base_layer/core/src/chain_storage/blockchain_database.rs
+++ b/base_layer/core/src/chain_storage/blockchain_database.rs
@@ -338,7 +338,7 @@ where T: BlockchainBackend
                 db.best_block.clone().unwrap(),
             )
         };
-        let best_block = self.fetch_header(height - 1)?;
+        let best_block = self.fetch_header(height)?;
         let result = block.header.prev_hash == parent_hash &&
             block.header.height == best_block.height + 1 &&
             block.header.total_difficulty > best_block.total_difficulty;


### PR DESCRIPTION
The wrong height was used to fetch the best block header when
adding a new block to the BlockchainDB.

This is fixed; ands a new test has been added that catches the
old bug and now passes.


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [x] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch
* [x] I ran `cargo-fmt --all` before pushing
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
