### PR TITLE
Improvements to UnconfirmedPool, OrphanPool, PendingPool, and ReorgPool

### DIFF
--- a/base_layer/core/src/blocks/genesis_block.rs
+++ b/base_layer/core/src/blocks/genesis_block.rs
@@ -24,7 +24,7 @@
 // Version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0.
 
 // This file is used to store the genesis block
-use crate::blocks::{aggregated_body::AggregateBody, block::Block, BlockBuilder};
+use crate::blocks::{block::Block, BlockBuilder};
 
 use crate::{blocks::BlockHeader, types::TariProofOfWork};
 use chrono::{DateTime, NaiveDate, Utc};

--- a/base_layer/core/src/chain_storage/blockchain_database.rs
+++ b/base_layer/core/src/chain_storage/blockchain_database.rs
@@ -299,7 +299,7 @@ where T: BlockchainBackend
     ///   * any of the inputs were not in the UTXO set or were marked as spent already
     ///
     /// If an error does occur while writing the new block parts, all changes are reverted before returning.
-    pub fn add_block(&mut self, block: Block) -> Result<BlockAddResult, ChainStorageError> {
+    pub fn add_block(&self, block: Block) -> Result<BlockAddResult, ChainStorageError> {
         if !self.is_new_best_block(&block)? {
             return self.handle_possible_reorg(block);
         }
@@ -456,13 +456,13 @@ where T: BlockchainBackend
     }
 
     /// Atomically commit the provided transaction to the database backend. This function does not update the metadata.
-    pub(crate) fn commit(&mut self, txn: DbTransaction) -> Result<(), ChainStorageError> {
+    pub(crate) fn commit(&self, txn: DbTransaction) -> Result<(), ChainStorageError> {
         self.db.write(txn)
     }
 
     /// Checks whether we should add the block as an orphan. If it is the case, the orphan block is added and the chain
     /// is reorganised if necessary
-    fn handle_possible_reorg(&mut self, _block: Block) -> Result<BlockAddResult, ChainStorageError> {
+    fn handle_possible_reorg(&self, _block: Block) -> Result<BlockAddResult, ChainStorageError> {
         // TODO - check if block height > pruning horizon
         // TODO - check if proof of work is valid and above some spam minimum??
         unimplemented!()

--- a/base_layer/core/src/chain_storage/mod.rs
+++ b/base_layer/core/src/chain_storage/mod.rs
@@ -36,8 +36,9 @@ mod metadata;
 mod test;
 
 // Public API exports
-pub use blockchain_database::BlockchainDatabase;
+pub use blockchain_database::{BlockchainBackend, BlockchainDatabase};
 pub use db_transaction::{DbTransaction, MmrTree};
+pub use error::ChainStorageError;
 pub use historical_block::HistoricalBlock;
 pub use memory_db::MemoryDatabase;
 pub use metadata::ChainMetadata;

--- a/base_layer/core/src/mempool/orphan_pool/error.rs
+++ b/base_layer/core/src/mempool/orphan_pool/error.rs
@@ -20,18 +20,14 @@
 //  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 //  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use crate::mempool::{
-    orphan_pool::OrphanPoolError,
-    pending_pool::PendingPoolError,
-    reorg_pool::ReorgPoolError,
-    unconfirmed_pool::UnconfirmedPoolError,
-};
+use crate::chain_storage::ChainStorageError;
 use derive_error::Error;
 
 #[derive(Debug, Error)]
-pub enum MempoolError {
-    UnconfirmedPoolError(UnconfirmedPoolError),
-    OrphanPoolError(OrphanPoolError),
-    PendingPoolError(PendingPoolError),
-    ReorgPoolError(ReorgPoolError),
+pub enum OrphanPoolError {
+    /// The Thread Safety has been breached and the data access has become poisoned
+    PoisonedAccess,
+    ChainStorageError(ChainStorageError),
+    /// The Blockchain height is undefined
+    ChainHeightUndefined,
 }

--- a/base_layer/core/src/mempool/orphan_pool/mod.rs
+++ b/base_layer/core/src/mempool/orphan_pool/mod.rs
@@ -20,7 +20,11 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+mod error;
 mod orphan_pool;
+mod orphan_pool_storage;
 
 // Public re-exports
+pub use error::OrphanPoolError;
 pub use orphan_pool::{OrphanPool, OrphanPoolConfig};
+pub use orphan_pool_storage::OrphanPoolStorage;

--- a/base_layer/core/src/mempool/orphan_pool/orphan_pool.rs
+++ b/base_layer/core/src/mempool/orphan_pool/orphan_pool.rs
@@ -21,12 +21,16 @@
 //  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 use crate::{
+    chain_storage::{BlockchainBackend, BlockchainDatabase},
     consts::{MEMPOOL_ORPHAN_POOL_CACHE_TTL, MEMPOOL_ORPHAN_POOL_STORAGE_CAPACITY},
-    transaction::{Transaction, TransactionInput},
+    mempool::orphan_pool::{error::OrphanPoolError, orphan_pool_storage::OrphanPoolStorage},
+    transaction::Transaction,
     types::Signature,
 };
-use std::{sync::Arc, time::Duration};
-use ttl_cache::TtlCache;
+use std::{
+    sync::{Arc, RwLock},
+    time::Duration,
+};
 
 /// Configuration for the OrphanPool
 #[derive(Clone, Copy)]
@@ -49,84 +53,87 @@ impl Default for OrphanPoolConfig {
 /// The Orphan Pool contains all the received transactions that attempt to spend UTXOs that don't exist. These UTXOs
 /// might exist in the future if these transactions are from a series or set of transactions that need to be processed
 /// in a specific order. Some of these transactions might still be constrained by pending time-locks.
-pub struct OrphanPool {
-    config: OrphanPoolConfig,
-    txs_by_signature: TtlCache<Signature, Arc<Transaction>>,
+pub struct OrphanPool<T>
+where T: BlockchainBackend
+{
+    pool_storage: RwLock<OrphanPoolStorage<T>>,
 }
 
-impl OrphanPool {
+impl<T> OrphanPool<T>
+where T: BlockchainBackend
+{
     /// Create a new OrphanPool with the specified configuration
-    pub fn new(config: OrphanPoolConfig) -> Self {
+    pub fn new(blockchain_db: Arc<BlockchainDatabase<T>>, config: OrphanPoolConfig) -> Self {
         Self {
-            config,
-            txs_by_signature: TtlCache::new(config.storage_capacity),
+            pool_storage: RwLock::new(OrphanPoolStorage::new(blockchain_db, config)),
         }
     }
 
     /// Insert a new transaction into the OrphanPool. Orphaned transactions will have a limited Time-to-live and will be
     /// discarded if the UTXOs they require are not created before the Time-to-live threshold is reached.
-    pub fn insert(&mut self, tx: Transaction) {
-        let tx_key = tx.body.kernels[0].excess_sig.clone();
-        let _ = self.txs_by_signature.insert(tx_key, Arc::new(tx), self.config.tx_ttl);
+    pub fn insert(&self, transaction: Arc<Transaction>) -> Result<(), OrphanPoolError> {
+        Ok(self
+            .pool_storage
+            .write()
+            .map_err(|_| OrphanPoolError::PoisonedAccess)?
+            .insert(transaction))
     }
 
     /// Insert a set of new transactions into the OrphanPool
-    pub fn insert_txs(&mut self, txs: Vec<Transaction>) {
-        for tx in txs.into_iter() {
-            self.insert(tx);
-        }
+    #[allow(dead_code)]
+    pub fn insert_txs(&self, transactions: Vec<Arc<Transaction>>) -> Result<(), OrphanPoolError> {
+        Ok(self
+            .pool_storage
+            .write()
+            .map_err(|_| OrphanPoolError::PoisonedAccess)?
+            .insert_txs(transactions))
     }
 
     /// Check if a transaction is stored in the OrphanPool
-    pub fn has_tx_with_excess_sig(&self, excess_sig: &Signature) -> bool {
-        self.txs_by_signature.contains_key(excess_sig)
+    pub fn has_tx_with_excess_sig(&self, excess_sig: &Signature) -> Result<bool, OrphanPoolError> {
+        Ok(self
+            .pool_storage
+            .read()
+            .map_err(|_| OrphanPoolError::PoisonedAccess)?
+            .has_tx_with_excess_sig(excess_sig))
     }
 
     /// Check if the required UTXOs have been created and if the status of any of the transactions in the OrphanPool has
     /// changed. Remove valid transactions and valid transactions with time-locks from the OrphanPool.
-    // TODO: A reference to the UTXO set should not be passed in like this, but rather a handle or stream to the Chain
-    // (BlockchainDatabase or BlockchainService) should be provided to the OrphanPool during creation allowing a
-    // Chain call to be used to query the current block_height and UTXO set
     pub fn scan_for_and_remove_unorphaned_txs(
-        &mut self,
-        block_height: u64,
-        utxos: &[TransactionInput],
-    ) -> (Vec<Arc<Transaction>>, Vec<Arc<Transaction>>)
-    {
-        let mut removed_tx_keys: Vec<Signature> = Vec::new();
-        let mut removed_timelocked_tx_keys: Vec<Signature> = Vec::new();
-        for (tx_key, tx) in self.txs_by_signature.iter() {
-            if tx.body.inputs.iter().all(|input| utxos.contains(input)) {
-                if tx.body.kernels[0].lock_height <= block_height {
-                    removed_tx_keys.push(tx_key.clone());
-                } else {
-                    removed_timelocked_tx_keys.push(tx_key.clone());
-                }
-            }
-        }
-
-        let mut removed_txs: Vec<Arc<Transaction>> = Vec::with_capacity(removed_tx_keys.len());
-        removed_tx_keys.iter().for_each(|tx_key| {
-            if let Some(tx) = self.txs_by_signature.remove(&tx_key) {
-                removed_txs.push(tx);
-            }
-        });
-
-        let mut removed_timelocked_txs: Vec<Arc<Transaction>> = Vec::with_capacity(removed_timelocked_tx_keys.len());
-        removed_timelocked_tx_keys.iter().for_each(|tx_key| {
-            if let Some(tx) = self.txs_by_signature.remove(&tx_key) {
-                removed_timelocked_txs.push(tx);
-            }
-        });
-
-        (removed_txs, removed_timelocked_txs)
+        &self,
+    ) -> Result<(Vec<Arc<Transaction>>, Vec<Arc<Transaction>>), OrphanPoolError> {
+        self.pool_storage
+            .write()
+            .map_err(|_| OrphanPoolError::PoisonedAccess)?
+            .scan_for_and_remove_unorphaned_txs()
     }
 
     /// Returns the total number of orphaned transactions stored in the OrphanPool
-    pub fn len(&mut self) -> usize {
-        let mut count = 0;
-        self.txs_by_signature.iter().for_each(|_| count += 1);
-        (count)
+    pub fn len(&self) -> Result<usize, OrphanPoolError> {
+        Ok(self
+            .pool_storage
+            .write()
+            .map_err(|_| OrphanPoolError::PoisonedAccess)?
+            .len())
+    }
+
+    /// Returns all transaction stored in the OrphanPool.
+    pub fn snapshot(&self) -> Result<Vec<Arc<Transaction>>, OrphanPoolError> {
+        Ok(self
+            .pool_storage
+            .write()
+            .map_err(|_| OrphanPoolError::PoisonedAccess)?
+            .snapshot())
+    }
+
+    /// Returns the total weight of all transactions stored in the pool.
+    pub fn calculate_weight(&self) -> Result<u64, OrphanPoolError> {
+        Ok(self
+            .pool_storage
+            .write()
+            .map_err(|_| OrphanPoolError::PoisonedAccess)?
+            .calculate_weight())
     }
 }
 
@@ -134,70 +141,114 @@ impl OrphanPool {
 mod test {
     use super::*;
     use crate::{
+        blocks::genesis_block::get_genesis_block,
+        chain_storage::{DbTransaction, MemoryDatabase},
         tari_amount::MicroTari,
-        test_utils::builders::{create_test_block, create_test_tx, extract_outputs_as_inputs},
+        test_utils::builders::create_test_tx,
         transaction::TransactionInput,
+        types::HashDigest,
     };
     use std::{thread, time::Duration};
 
     #[test]
     fn test_insert_rlu_and_ttl() {
-        let tx1 = create_test_tx(MicroTari(10_000), MicroTari(500), 4000, 2, 1);
-        let tx2 = create_test_tx(MicroTari(10_000), MicroTari(300), 3000, 2, 1);
-        let tx3 = create_test_tx(MicroTari(10_000), MicroTari(100), 2500, 2, 1);
-        let tx4 = create_test_tx(MicroTari(10_000), MicroTari(200), 1000, 2, 1);
-        let tx5 = create_test_tx(MicroTari(10_000), MicroTari(500), 2000, 2, 1);
-        let tx6 = create_test_tx(MicroTari(10_000), MicroTari(600), 5500, 2, 1);
+        let tx1 = Arc::new(create_test_tx(MicroTari(10_000), MicroTari(500), 4000, 2, 0, 1));
+        let tx2 = Arc::new(create_test_tx(MicroTari(10_000), MicroTari(300), 3000, 2, 0, 1));
+        let tx3 = Arc::new(create_test_tx(MicroTari(10_000), MicroTari(100), 2500, 2, 0, 1));
+        let tx4 = Arc::new(create_test_tx(MicroTari(10_000), MicroTari(200), 1000, 2, 0, 1));
+        let tx5 = Arc::new(create_test_tx(MicroTari(10_000), MicroTari(500), 2000, 2, 0, 1));
+        let tx6 = Arc::new(create_test_tx(MicroTari(10_000), MicroTari(600), 5500, 2, 0, 1));
 
-        let mut orphan_pool = OrphanPool::new(OrphanPoolConfig {
+        let store = Arc::new(BlockchainDatabase::new(MemoryDatabase::<HashDigest>::default()).unwrap());
+        let orphan_pool = OrphanPool::new(store, OrphanPoolConfig {
             storage_capacity: 3,
             tx_ttl: Duration::from_millis(50),
         });
-        orphan_pool.insert_txs(vec![tx1.clone(), tx2.clone(), tx3.clone(), tx4.clone()]);
+        orphan_pool
+            .insert_txs(vec![tx1.clone(), tx2.clone(), tx3.clone(), tx4.clone()])
+            .unwrap();
         // Check that oldest utx was removed to make room for new incoming transaction
-        assert!(!orphan_pool.has_tx_with_excess_sig(&tx1.body.kernels[0].excess_sig));
-        assert!(orphan_pool.has_tx_with_excess_sig(&tx2.body.kernels[0].excess_sig));
-        assert!(orphan_pool.has_tx_with_excess_sig(&tx3.body.kernels[0].excess_sig));
-        assert!(orphan_pool.has_tx_with_excess_sig(&tx4.body.kernels[0].excess_sig));
+        assert_eq!(
+            orphan_pool
+                .has_tx_with_excess_sig(&tx1.body.kernels[0].excess_sig)
+                .unwrap(),
+            false
+        );
+        assert_eq!(
+            orphan_pool
+                .has_tx_with_excess_sig(&tx2.body.kernels[0].excess_sig)
+                .unwrap(),
+            true
+        );
+        assert_eq!(
+            orphan_pool
+                .has_tx_with_excess_sig(&tx3.body.kernels[0].excess_sig)
+                .unwrap(),
+            true
+        );
+        assert_eq!(
+            orphan_pool
+                .has_tx_with_excess_sig(&tx4.body.kernels[0].excess_sig)
+                .unwrap(),
+            true
+        );
+
+        let snapshot_txs = orphan_pool.snapshot().unwrap();
+        assert_eq!(snapshot_txs.len(), 3);
+        assert!(snapshot_txs.contains(&tx2));
+        assert!(snapshot_txs.contains(&tx3));
+        assert!(snapshot_txs.contains(&tx4));
 
         // Check that transactions that have been in the pool for longer than their Time-to-live have been removed
         thread::sleep(Duration::from_millis(51));
-        orphan_pool.insert_txs(vec![tx5.clone(), tx6.clone()]);
+        orphan_pool.insert_txs(vec![tx5.clone(), tx6.clone()]).unwrap();
+        assert_eq!(orphan_pool.len().unwrap(), 2);
         assert_eq!(
-            orphan_pool.has_tx_with_excess_sig(&tx1.body.kernels[0].excess_sig),
+            orphan_pool
+                .has_tx_with_excess_sig(&tx1.body.kernels[0].excess_sig)
+                .unwrap(),
             false
         );
         assert_eq!(
-            orphan_pool.has_tx_with_excess_sig(&tx2.body.kernels[0].excess_sig),
+            orphan_pool
+                .has_tx_with_excess_sig(&tx2.body.kernels[0].excess_sig)
+                .unwrap(),
             false
         );
         assert_eq!(
-            orphan_pool.has_tx_with_excess_sig(&tx3.body.kernels[0].excess_sig),
+            orphan_pool
+                .has_tx_with_excess_sig(&tx3.body.kernels[0].excess_sig)
+                .unwrap(),
             false
         );
         assert_eq!(
-            orphan_pool.has_tx_with_excess_sig(&tx4.body.kernels[0].excess_sig),
+            orphan_pool
+                .has_tx_with_excess_sig(&tx4.body.kernels[0].excess_sig)
+                .unwrap(),
             false
         );
         assert_eq!(
-            orphan_pool.has_tx_with_excess_sig(&tx5.body.kernels[0].excess_sig),
+            orphan_pool
+                .has_tx_with_excess_sig(&tx5.body.kernels[0].excess_sig)
+                .unwrap(),
             true
         );
         assert_eq!(
-            orphan_pool.has_tx_with_excess_sig(&tx6.body.kernels[0].excess_sig),
+            orphan_pool
+                .has_tx_with_excess_sig(&tx6.body.kernels[0].excess_sig)
+                .unwrap(),
             true
         );
-        assert_eq!(orphan_pool.len(), 2);
     }
 
     #[test]
-    fn remove_remove_valid() {
-        let tx1 = create_test_tx(MicroTari(10_000), MicroTari(500), 1100, 2, 1);
-        let tx2 = create_test_tx(MicroTari(10_000), MicroTari(300), 1700, 2, 1);
-        let tx3 = create_test_tx(MicroTari(10_000), MicroTari(100), 2500, 1, 1);
-        let mut tx4 = create_test_tx(MicroTari(10_000), MicroTari(200), 3100, 2, 1);
-        let mut tx5 = create_test_tx(MicroTari(10_000), MicroTari(500), 4500, 2, 1);
-        let tx6 = create_test_tx(MicroTari(10_000), MicroTari(600), 5200, 2, 1);
+    fn test_scan_for_and_remove_unorphaned() {
+        let tx1 = Arc::new(create_test_tx(MicroTari(10_000), MicroTari(500), 1100, 2, 0, 1));
+        let tx2 = Arc::new(create_test_tx(MicroTari(10_000), MicroTari(300), 1700, 2, 0, 1));
+        let tx3 = Arc::new(create_test_tx(MicroTari(10_000), MicroTari(100), 0, 1, 0, 1));
+        let mut tx4 = create_test_tx(MicroTari(10_000), MicroTari(200), 0, 2, 0, 1);
+        let mut tx5 = create_test_tx(MicroTari(10_000), MicroTari(500), 1000, 2, 0, 1);
+        let tx6 = Arc::new(create_test_tx(MicroTari(10_000), MicroTari(600), 5200, 2, 0, 1));
         // Publishing of tx1 and tx2 will create the UTXOs required by tx4 and tx5
         tx4.body.inputs.clear();
         tx1.body
@@ -210,31 +261,47 @@ mod test {
             .outputs
             .iter()
             .for_each(|output| tx5.body.inputs.push(TransactionInput::from(output.clone())));
+        let tx4 = Arc::new(tx4);
+        let tx5 = Arc::new(tx5);
 
-        let mut orphan_pool = OrphanPool::new(OrphanPoolConfig::default());
-        orphan_pool.insert_txs(vec![tx3.clone(), tx4.clone(), tx5.clone()]);
+        let store = Arc::new(BlockchainDatabase::new(MemoryDatabase::<HashDigest>::default()).unwrap());
+        store.add_block(get_genesis_block().clone()).unwrap();
+        let orphan_pool = OrphanPool::new(store.clone(), OrphanPoolConfig::default());
+        orphan_pool
+            .insert_txs(vec![tx3.clone(), tx4.clone(), tx5.clone(), tx6.clone()])
+            .unwrap();
 
-        let published_block = create_test_block(3000, vec![tx6.clone()]);
-        let mut utxos = Vec::new();
-        extract_outputs_as_inputs(&mut utxos, &published_block);
-        let (txs, timelocked_txs) =
-            orphan_pool.scan_for_and_remove_unorphaned_txs(published_block.header.height, &utxos);
-        assert_eq!(orphan_pool.len(), 3);
+        let (txs, timelocked_txs) = orphan_pool.scan_for_and_remove_unorphaned_txs().unwrap();
+        assert_eq!(orphan_pool.len().unwrap(), 4);
         assert_eq!(txs.len(), 0);
         assert_eq!(timelocked_txs.len(), 0);
-        assert!(orphan_pool.has_tx_with_excess_sig(&tx3.body.kernels[0].excess_sig));
-        assert!(orphan_pool.has_tx_with_excess_sig(&tx4.body.kernels[0].excess_sig));
-        assert!(orphan_pool.has_tx_with_excess_sig(&tx5.body.kernels[0].excess_sig));
+        assert!(orphan_pool
+            .has_tx_with_excess_sig(&tx3.body.kernels[0].excess_sig)
+            .unwrap());
+        assert!(orphan_pool
+            .has_tx_with_excess_sig(&tx4.body.kernels[0].excess_sig)
+            .unwrap());
+        assert!(orphan_pool
+            .has_tx_with_excess_sig(&tx5.body.kernels[0].excess_sig)
+            .unwrap());
 
-        let published_block = create_test_block(3500, vec![tx1.clone(), tx2.clone()]);
-        extract_outputs_as_inputs(&mut utxos, &published_block);
-        let (txs, timelocked_txs) =
-            orphan_pool.scan_for_and_remove_unorphaned_txs(published_block.header.height, &utxos);
-        assert_eq!(orphan_pool.len(), 1);
+        // Create UTXOs produced by tx1 and tx2
+        let mut db_txn = DbTransaction::new();
+        db_txn.insert_utxo(tx1.body.outputs[0].clone());
+        db_txn.insert_utxo(tx2.body.outputs[0].clone());
+        assert!(store.commit(db_txn).is_ok());
+
+        let (txs, timelocked_txs) = orphan_pool.scan_for_and_remove_unorphaned_txs().unwrap();
+        assert_eq!(orphan_pool.len().unwrap(), 2);
         assert_eq!(txs.len(), 1);
         assert_eq!(timelocked_txs.len(), 1);
-        assert!(orphan_pool.has_tx_with_excess_sig(&tx3.body.kernels[0].excess_sig));
-        assert!(txs.iter().any(|tx| **tx == tx4));
-        assert!(timelocked_txs.iter().any(|tx| **tx == tx5));
+        assert!(orphan_pool
+            .has_tx_with_excess_sig(&tx3.body.kernels[0].excess_sig)
+            .unwrap());
+        assert!(orphan_pool
+            .has_tx_with_excess_sig(&tx6.body.kernels[0].excess_sig)
+            .unwrap());
+        assert!(txs.contains(&tx4));
+        assert!(timelocked_txs.contains(&tx5));
     }
 }

--- a/base_layer/core/src/mempool/orphan_pool/orphan_pool_storage.rs
+++ b/base_layer/core/src/mempool/orphan_pool/orphan_pool_storage.rs
@@ -1,0 +1,142 @@
+//  Copyright 2019 The Tari Project
+//
+//  Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+//  following conditions are met:
+//
+//  1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+//  disclaimer.
+//
+//  2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+//  following disclaimer in the documentation and/or other materials provided with the distribution.
+//
+//  3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+//  products derived from this software without specific prior written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+//  INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+//  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+//  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+//  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+//  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+//  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+use crate::{
+    chain_storage::{BlockchainBackend, BlockchainDatabase},
+    mempool::orphan_pool::{error::OrphanPoolError, orphan_pool::OrphanPoolConfig},
+    transaction::Transaction,
+    types::Signature,
+};
+use std::sync::Arc;
+use tari_utilities::hash::Hashable;
+use ttl_cache::TtlCache;
+
+/// OrphanPool makes use of OrphanPoolStorage to provide thread save access to its TtlCache.
+/// The Orphan Pool contains all the received transactions that attempt to spend UTXOs that don't exist. These UTXOs
+/// might exist in the future if these transactions are from a series or set of transactions that need to be processed
+/// in a specific order. Some of these transactions might still be constrained by pending time-locks.
+pub struct OrphanPoolStorage<T>
+where T: BlockchainBackend
+{
+    blockchain_db: Arc<BlockchainDatabase<T>>,
+    config: OrphanPoolConfig,
+    txs_by_signature: TtlCache<Signature, Arc<Transaction>>,
+}
+
+impl<T> OrphanPoolStorage<T>
+where T: BlockchainBackend
+{
+    /// Create a new OrphanPoolStorage with the specified configuration
+    pub fn new(blockchain_db: Arc<BlockchainDatabase<T>>, config: OrphanPoolConfig) -> Self {
+        Self {
+            blockchain_db,
+            config,
+            txs_by_signature: TtlCache::new(config.storage_capacity),
+        }
+    }
+
+    /// Insert a new transaction into the OrphanPoolStorage. Orphaned transactions will have a limited Time-to-live and
+    /// will be discarded if the UTXOs they require are not created before the Time-to-live threshold is reached.
+    pub fn insert(&mut self, tx: Arc<Transaction>) {
+        let tx_key = tx.body.kernels[0].excess_sig.clone();
+        let _ = self.txs_by_signature.insert(tx_key, tx, self.config.tx_ttl);
+    }
+
+    /// Insert a set of new transactions into the OrphanPoolStorage
+    #[allow(dead_code)]
+    pub fn insert_txs(&mut self, txs: Vec<Arc<Transaction>>) {
+        for tx in txs.into_iter() {
+            self.insert(tx);
+        }
+    }
+
+    /// Check if a transaction is stored in the OrphanPoolStorage
+    pub fn has_tx_with_excess_sig(&self, excess_sig: &Signature) -> bool {
+        self.txs_by_signature.contains_key(excess_sig)
+    }
+
+    /// Check if the required UTXOs have been created and if the status of any of the transactions in the
+    /// OrphanPoolStorage has changed. Remove valid transactions and valid transactions with time-locks from the
+    /// OrphanPoolStorage.
+    pub fn scan_for_and_remove_unorphaned_txs(
+        &mut self,
+    ) -> Result<(Vec<Arc<Transaction>>, Vec<Arc<Transaction>>), OrphanPoolError> {
+        let mut removed_tx_keys: Vec<Signature> = Vec::new();
+        let mut removed_timelocked_tx_keys: Vec<Signature> = Vec::new();
+        let height = self
+            .blockchain_db
+            .get_height()?
+            .ok_or(OrphanPoolError::ChainHeightUndefined)?;
+        'outer: for (tx_key, tx) in self.txs_by_signature.iter() {
+            for input in &tx.body.inputs {
+                if !self.blockchain_db.is_utxo(input.hash())? {
+                    continue 'outer;
+                }
+            }
+
+            if tx.max_timelock_height() > height {
+                removed_timelocked_tx_keys.push(tx_key.clone());
+            } else {
+                removed_tx_keys.push(tx_key.clone());
+            }
+        }
+
+        let mut removed_txs: Vec<Arc<Transaction>> = Vec::with_capacity(removed_tx_keys.len());
+        removed_tx_keys.iter().for_each(|tx_key| {
+            if let Some(tx) = self.txs_by_signature.remove(&tx_key) {
+                removed_txs.push(tx);
+            }
+        });
+
+        let mut removed_timelocked_txs: Vec<Arc<Transaction>> = Vec::with_capacity(removed_timelocked_tx_keys.len());
+        removed_timelocked_tx_keys.iter().for_each(|tx_key| {
+            if let Some(tx) = self.txs_by_signature.remove(&tx_key) {
+                removed_timelocked_txs.push(tx);
+            }
+        });
+
+        Ok((removed_txs, removed_timelocked_txs))
+    }
+
+    /// Returns the total number of orphaned transactions stored in the OrphanPoolStorage
+    pub fn len(&mut self) -> usize {
+        let mut count = 0;
+        self.txs_by_signature.iter().for_each(|_| count += 1);
+        (count)
+    }
+
+    /// Returns all transaction stored in the OrphanPoolStorage.
+    pub fn snapshot(&mut self) -> Vec<Arc<Transaction>> {
+        let mut txs: Vec<Arc<Transaction>> = Vec::new();
+        self.txs_by_signature.iter().for_each(|(_, tx)| txs.push(tx.clone()));
+        txs
+    }
+
+    /// Returns the total weight of all transactions stored in the pool.
+    pub fn calculate_weight(&mut self) -> u64 {
+        let mut weight: u64 = 0;
+        self.txs_by_signature
+            .iter()
+            .for_each(|(_, tx)| weight += tx.calculate_weight());
+        (weight)
+    }
+}

--- a/base_layer/core/src/mempool/priority/prioritized_transaction.rs
+++ b/base_layer/core/src/mempool/priority/prioritized_transaction.rs
@@ -24,7 +24,7 @@ use crate::{mempool::priority::PriorityError, transaction::Transaction};
 use std::{convert::TryFrom, sync::Arc};
 use tari_utilities::message_format::MessageFormat;
 
-/// Create a unique unspent transaction priority based on the transaction fee, age of the oldest input UTXO and the
+/// Create a unique unspent transaction priority based on the transaction fee, maturity of the oldest input UTXO and the
 /// excess_sig. The excess_sig is included to ensure the the priority key unique so it can be used with a BTreeMap.
 /// Normally, duplicate keys will be overwritten in a BTreeMap.
 #[derive(PartialEq, Eq, PartialOrd, Ord, Debug)]
@@ -33,10 +33,15 @@ pub struct FeePriority(Vec<u8>);
 impl FeePriority {
     pub fn try_from(transaction: &Transaction) -> Result<Self, PriorityError> {
         let fee_per_byte = (transaction.calculate_ave_fee_per_gram() * 1000.0) as usize; // Include 3 decimal places before flooring
-        let mut priority = fee_per_byte.to_binary()?;
-        priority.reverse(); // Fee needs to be in Big-endian for sorting with BtreeMap to work correctly
-                            // TODO: Add oldest input UTXO age
-        priority.append(&mut transaction.body.kernels[0].to_binary()?);
+        let mut fee_priority = fee_per_byte.to_binary()?;
+        fee_priority.reverse(); // Requires Big-endian for BtreeMap sorting
+
+        let mut maturity_priority = (std::u64::MAX - transaction.min_input_maturity()).to_binary()?;
+        maturity_priority.reverse(); // Requires Big-endian for BtreeMap sorting
+
+        let mut priority = fee_priority;
+        priority.append(&mut maturity_priority);
+        priority.append(&mut transaction.body.kernels[0].excess_sig.to_binary()?);
         Ok(Self(priority))
     }
 }

--- a/base_layer/core/src/mempool/priority/timelocked_transaction.rs
+++ b/base_layer/core/src/mempool/priority/timelocked_transaction.rs
@@ -27,17 +27,17 @@ use crate::{
 use std::{convert::TryFrom, sync::Arc};
 use tari_utilities::message_format::MessageFormat;
 
-/// Create a unique transaction priority based on the lock_height and the excess_sig, allowing transactions to be sorted
-/// according to their time-lock expiry. The excess_sig is included to ensure the priority key is unique so it can be
-/// used with a BTreeMap.
+/// Create a unique transaction priority based on the maximum time-lock (lock_height or input UTXO maturity) and the
+/// excess_sig, allowing transactions to be sorted according to their time-lock expiry. The excess_sig is included to
+/// ensure the priority key is unique so it can be used with a BTreeMap.
 #[derive(PartialEq, Eq, PartialOrd, Ord, Debug)]
 pub struct TimelockPriority(Vec<u8>);
 
 impl TimelockPriority {
     pub fn try_from(transaction: &Transaction) -> Result<Self, PriorityError> {
-        let mut priority = transaction.body.kernels[0].lock_height.to_binary()?;
-        priority.reverse(); // Timelock needs to be in Big-endian for sorting with BtreeMap to work correctly
-        priority.append(&mut transaction.body.kernels[0].to_binary()?);
+        let mut priority = transaction.max_timelock_height().to_binary()?;
+        priority.reverse(); // Requires Big-endian for BtreeMap sorting
+        priority.append(&mut transaction.body.kernels[0].excess_sig.to_binary()?);
         Ok(Self(priority))
     }
 }
@@ -54,6 +54,7 @@ pub struct TimelockedTransaction {
     pub transaction: Arc<Transaction>,
     pub fee_priority: FeePriority,
     pub timelock_priority: TimelockPriority,
+    pub max_timelock_height: u64,
 }
 
 impl TryFrom<Transaction> for TimelockedTransaction {
@@ -63,6 +64,7 @@ impl TryFrom<Transaction> for TimelockedTransaction {
         Ok(Self {
             fee_priority: FeePriority::try_from(&transaction)?,
             timelock_priority: TimelockPriority::try_from(&transaction)?,
+            max_timelock_height: transaction.max_timelock_height(),
             transaction: Arc::new(transaction),
         })
     }

--- a/base_layer/core/src/mempool/reorg_pool/error.rs
+++ b/base_layer/core/src/mempool/reorg_pool/error.rs
@@ -20,18 +20,11 @@
 //  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 //  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use crate::mempool::{
-    orphan_pool::OrphanPoolError,
-    pending_pool::PendingPoolError,
-    reorg_pool::ReorgPoolError,
-    unconfirmed_pool::UnconfirmedPoolError,
-};
+// use crate::chain_storage::ChainStorageError;
 use derive_error::Error;
 
 #[derive(Debug, Error)]
-pub enum MempoolError {
-    UnconfirmedPoolError(UnconfirmedPoolError),
-    OrphanPoolError(OrphanPoolError),
-    PendingPoolError(PendingPoolError),
-    ReorgPoolError(ReorgPoolError),
+pub enum ReorgPoolError {
+    /// The Thread Safety has been breached and the data access has become poisoned
+    PoisonedAccess,
 }

--- a/base_layer/core/src/mempool/reorg_pool/mod.rs
+++ b/base_layer/core/src/mempool/reorg_pool/mod.rs
@@ -20,7 +20,11 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+mod error;
 mod reorg_pool;
+mod reorg_pool_storage;
 
 // Public re-exports
+pub use error::ReorgPoolError;
 pub use reorg_pool::{ReorgPool, ReorgPoolConfig};
+pub use reorg_pool_storage::ReorgPoolStorage;

--- a/base_layer/core/src/mempool/reorg_pool/reorg_pool.rs
+++ b/base_layer/core/src/mempool/reorg_pool/reorg_pool.rs
@@ -23,11 +23,14 @@
 use crate::{
     blocks::Block,
     consts::{MEMPOOL_REORG_POOL_CACHE_TTL, MEMPOOL_REORG_POOL_STORAGE_CAPACITY},
+    mempool::reorg_pool::{ReorgPoolError, ReorgPoolStorage},
     transaction::Transaction,
     types::Signature,
 };
-use std::{sync::Arc, time::Duration};
-use ttl_cache::TtlCache;
+use std::{
+    sync::{Arc, RwLock},
+    time::Duration,
+};
 
 /// Configuration for the ReorgPool
 #[derive(Clone, Copy)]
@@ -53,57 +56,76 @@ impl Default for ReorgPoolConfig {
 /// from the pool when the Time-to-live thresholds is reached. Also, when the capacity of the pool has been reached, the
 /// oldest transactions will be removed to make space for incoming transactions.
 pub struct ReorgPool {
-    config: ReorgPoolConfig,
-    txs_by_signature: TtlCache<Signature, Arc<Transaction>>,
+    pool_storage: RwLock<ReorgPoolStorage>,
 }
 
 impl ReorgPool {
     /// Create a new ReorgPool with the specified configuration
     pub fn new(config: ReorgPoolConfig) -> Self {
         Self {
-            config,
-            txs_by_signature: TtlCache::new(config.storage_capacity),
+            pool_storage: RwLock::new(ReorgPoolStorage::new(config)),
         }
     }
 
     /// Insert a new transaction into the ReorgPool. Published transactions will have a limited Time-to-live in the
     /// ReorgPool and will be discarded once the Time-to-live threshold has been reached.
-    pub fn insert(&mut self, tx: Transaction) {
-        let tx_key = tx.body.kernels[0].excess_sig.clone();
-        let _ = self.txs_by_signature.insert(tx_key, Arc::new(tx), self.config.tx_ttl);
+    #[allow(dead_code)]
+    pub fn insert(&self, transaction: Arc<Transaction>) -> Result<(), ReorgPoolError> {
+        Ok(self
+            .pool_storage
+            .write()
+            .map_err(|_| ReorgPoolError::PoisonedAccess)?
+            .insert(transaction))
     }
 
     /// Insert a set of new transactions into the ReorgPool
-    pub fn insert_txs(&mut self, txs: Vec<Transaction>) {
-        for tx in txs.into_iter() {
-            self.insert(tx);
-        }
+    pub fn insert_txs(&self, transactions: Vec<Arc<Transaction>>) -> Result<(), ReorgPoolError> {
+        Ok(self
+            .pool_storage
+            .write()
+            .map_err(|_| ReorgPoolError::PoisonedAccess)?
+            .insert_txs(transactions))
     }
 
     /// Check if a transaction is stored in the ReorgPool
-    pub fn has_tx_with_excess_sig(&self, excess_sig: &Signature) -> bool {
-        self.txs_by_signature.contains_key(excess_sig)
+    pub fn has_tx_with_excess_sig(&self, excess_sig: &Signature) -> Result<bool, ReorgPoolError> {
+        Ok(self
+            .pool_storage
+            .read()
+            .map_err(|_| ReorgPoolError::PoisonedAccess)?
+            .has_tx_with_excess_sig(excess_sig))
     }
 
     /// Remove the transactions from the ReorgPool that were used in provided removed blocks. The transactions can be
     /// resubmitted to the Unconfirmed Pool.
-    pub fn scan_for_and_remove_reorged_txs(&mut self, removed_blocks: Vec<Block>) -> Vec<Arc<Transaction>> {
-        let mut removed_txs: Vec<Arc<Transaction>> = Vec::new();
-        for block in &removed_blocks {
-            for kernel in &block.body.kernels {
-                if let Some(removed_tx) = self.txs_by_signature.remove(&kernel.excess_sig) {
-                    removed_txs.push(removed_tx);
-                }
-            }
-        }
-        removed_txs
+    pub fn scan_for_and_remove_reorged_txs(
+        &self,
+        removed_blocks: Vec<Block>,
+    ) -> Result<Vec<Arc<Transaction>>, ReorgPoolError>
+    {
+        Ok(self
+            .pool_storage
+            .write()
+            .map_err(|_| ReorgPoolError::PoisonedAccess)?
+            .scan_for_and_remove_reorged_txs(removed_blocks))
     }
 
     /// Returns the total number of published transactions stored in the ReorgPool
-    pub fn len(&mut self) -> usize {
-        let mut count = 0;
-        self.txs_by_signature.iter().for_each(|_| count += 1);
-        (count)
+    pub fn len(&self) -> Result<usize, ReorgPoolError> {
+        Ok(self
+            .pool_storage
+            .write()
+            .map_err(|_| ReorgPoolError::PoisonedAccess)?
+            .len())
+    }
+
+    /// Returns the total weight of all transactions stored in the pool.
+    pub fn calculate_weight(&self) -> Result<u64, ReorgPoolError> {
+        Ok(self
+            .pool_storage
+            .write()
+            .map_err(|_| ReorgPoolError::PoisonedAccess)?
+            .calculate_weight())
     }
 }
 
@@ -113,119 +135,202 @@ mod test {
     use crate::{
         tari_amount::MicroTari,
         test_utils::builders::{create_test_block, create_test_tx},
-        transaction::TransactionInput,
     };
     use std::{thread, time::Duration};
 
     #[test]
     fn test_insert_rlu_and_ttl() {
-        let tx1 = create_test_tx(MicroTari(10_000), MicroTari(500), 4000, 2, 1);
-        let tx2 = create_test_tx(MicroTari(10_000), MicroTari(300), 3000, 2, 1);
-        let tx3 = create_test_tx(MicroTari(10_000), MicroTari(100), 2500, 2, 1);
-        let tx4 = create_test_tx(MicroTari(10_000), MicroTari(200), 1000, 2, 1);
-        let tx5 = create_test_tx(MicroTari(10_000), MicroTari(500), 2000, 2, 1);
-        let tx6 = create_test_tx(MicroTari(10_000), MicroTari(600), 5500, 2, 1);
+        let tx1 = Arc::new(create_test_tx(MicroTari(10_000), MicroTari(500), 4000, 2, 0, 1));
+        let tx2 = Arc::new(create_test_tx(MicroTari(10_000), MicroTari(300), 3000, 2, 0, 1));
+        let tx3 = Arc::new(create_test_tx(MicroTari(10_000), MicroTari(100), 2500, 2, 0, 1));
+        let tx4 = Arc::new(create_test_tx(MicroTari(10_000), MicroTari(200), 1000, 2, 0, 1));
+        let tx5 = Arc::new(create_test_tx(MicroTari(10_000), MicroTari(500), 2000, 2, 0, 1));
+        let tx6 = Arc::new(create_test_tx(MicroTari(10_000), MicroTari(600), 5500, 2, 0, 1));
 
-        let mut reorg_pool = ReorgPool::new(ReorgPoolConfig {
+        let reorg_pool = ReorgPool::new(ReorgPoolConfig {
             storage_capacity: 3,
             tx_ttl: Duration::from_millis(50),
         });
-        reorg_pool.insert_txs(vec![tx1.clone(), tx2.clone(), tx3.clone(), tx4.clone()]);
+        reorg_pool
+            .insert_txs(vec![tx1.clone(), tx2.clone(), tx3.clone(), tx4.clone()])
+            .unwrap();
         // Check that oldest utx was removed to make room for new incoming transactions
         assert_eq!(
-            reorg_pool.has_tx_with_excess_sig(&tx1.body.kernels[0].excess_sig),
+            reorg_pool
+                .has_tx_with_excess_sig(&tx1.body.kernels[0].excess_sig)
+                .unwrap(),
             false
         );
-        assert_eq!(reorg_pool.has_tx_with_excess_sig(&tx2.body.kernels[0].excess_sig), true);
-        assert_eq!(reorg_pool.has_tx_with_excess_sig(&tx3.body.kernels[0].excess_sig), true);
-        assert_eq!(reorg_pool.has_tx_with_excess_sig(&tx4.body.kernels[0].excess_sig), true);
+        assert_eq!(
+            reorg_pool
+                .has_tx_with_excess_sig(&tx2.body.kernels[0].excess_sig)
+                .unwrap(),
+            true
+        );
+        assert_eq!(
+            reorg_pool
+                .has_tx_with_excess_sig(&tx3.body.kernels[0].excess_sig)
+                .unwrap(),
+            true
+        );
+        assert_eq!(
+            reorg_pool
+                .has_tx_with_excess_sig(&tx4.body.kernels[0].excess_sig)
+                .unwrap(),
+            true
+        );
 
         // Check that transactions that have been in the pool for longer than their Time-to-live have been removed
         thread::sleep(Duration::from_millis(51));
-        reorg_pool.insert_txs(vec![tx5.clone(), tx6.clone()]);
+        reorg_pool.insert_txs(vec![tx5.clone(), tx6.clone()]).unwrap();
+        assert_eq!(reorg_pool.len().unwrap(), 2);
         assert_eq!(
-            reorg_pool.has_tx_with_excess_sig(&tx1.body.kernels[0].excess_sig),
+            reorg_pool
+                .has_tx_with_excess_sig(&tx1.body.kernels[0].excess_sig)
+                .unwrap(),
             false
         );
         assert_eq!(
-            reorg_pool.has_tx_with_excess_sig(&tx2.body.kernels[0].excess_sig),
+            reorg_pool
+                .has_tx_with_excess_sig(&tx2.body.kernels[0].excess_sig)
+                .unwrap(),
             false
         );
         assert_eq!(
-            reorg_pool.has_tx_with_excess_sig(&tx3.body.kernels[0].excess_sig),
+            reorg_pool
+                .has_tx_with_excess_sig(&tx3.body.kernels[0].excess_sig)
+                .unwrap(),
             false
         );
         assert_eq!(
-            reorg_pool.has_tx_with_excess_sig(&tx4.body.kernels[0].excess_sig),
+            reorg_pool
+                .has_tx_with_excess_sig(&tx4.body.kernels[0].excess_sig)
+                .unwrap(),
             false
         );
-        assert_eq!(reorg_pool.has_tx_with_excess_sig(&tx5.body.kernels[0].excess_sig), true);
-        assert_eq!(reorg_pool.has_tx_with_excess_sig(&tx6.body.kernels[0].excess_sig), true);
-        assert_eq!(reorg_pool.len(), 2);
+        assert_eq!(
+            reorg_pool
+                .has_tx_with_excess_sig(&tx5.body.kernels[0].excess_sig)
+                .unwrap(),
+            true
+        );
+        assert_eq!(
+            reorg_pool
+                .has_tx_with_excess_sig(&tx6.body.kernels[0].excess_sig)
+                .unwrap(),
+            true
+        );
     }
 
     #[test]
     fn remove_scan_for_and_remove_reorged_txs() {
-        let tx1 = create_test_tx(MicroTari(10_000), MicroTari(500), 4000, 2, 1);
-        let tx2 = create_test_tx(MicroTari(10_000), MicroTari(300), 3000, 2, 1);
-        let tx3 = create_test_tx(MicroTari(10_000), MicroTari(100), 2500, 2, 1);
-        let tx4 = create_test_tx(MicroTari(10_000), MicroTari(200), 1000, 2, 1);
-        let tx5 = create_test_tx(MicroTari(10_000), MicroTari(500), 2000, 2, 1);
-        let tx6 = create_test_tx(MicroTari(10_000), MicroTari(600), 5500, 2, 1);
+        let tx1 = Arc::new(create_test_tx(MicroTari(10_000), MicroTari(50), 4000, 2, 0, 1));
+        let tx2 = Arc::new(create_test_tx(MicroTari(10_000), MicroTari(30), 3000, 2, 0, 1));
+        let tx3 = Arc::new(create_test_tx(MicroTari(10_000), MicroTari(20), 2500, 2, 0, 1));
+        let tx4 = Arc::new(create_test_tx(MicroTari(10_000), MicroTari(20), 1000, 2, 0, 1));
+        let tx5 = Arc::new(create_test_tx(MicroTari(10_000), MicroTari(50), 2000, 2, 0, 1));
+        let tx6 = Arc::new(create_test_tx(MicroTari(10_000), MicroTari(60), 5500, 2, 0, 1));
 
-        let mut reorg_pool = ReorgPool::new(ReorgPoolConfig {
+        let reorg_pool = ReorgPool::new(ReorgPoolConfig {
             storage_capacity: 5,
             tx_ttl: Duration::from_millis(50),
         });
-        reorg_pool.insert_txs(vec![
-            tx1.clone(),
-            tx2.clone(),
-            tx3.clone(),
-            tx4.clone(),
-            tx5.clone(),
-            tx6.clone(),
-        ]);
+        reorg_pool
+            .insert_txs(vec![
+                tx1.clone(),
+                tx2.clone(),
+                tx3.clone(),
+                tx4.clone(),
+                tx5.clone(),
+                tx6.clone(),
+            ])
+            .unwrap();
         // Oldest transaction tx1 is removed to make space for new incoming transactions
-        assert_eq!(reorg_pool.len(), 5);
+        assert_eq!(reorg_pool.len().unwrap(), 5);
         assert_eq!(
-            reorg_pool.has_tx_with_excess_sig(&tx1.body.kernels[0].excess_sig),
+            reorg_pool
+                .has_tx_with_excess_sig(&tx1.body.kernels[0].excess_sig)
+                .unwrap(),
             false
         );
-        assert_eq!(reorg_pool.has_tx_with_excess_sig(&tx2.body.kernels[0].excess_sig), true);
-        assert_eq!(reorg_pool.has_tx_with_excess_sig(&tx3.body.kernels[0].excess_sig), true);
-        assert_eq!(reorg_pool.has_tx_with_excess_sig(&tx4.body.kernels[0].excess_sig), true);
-        assert_eq!(reorg_pool.has_tx_with_excess_sig(&tx5.body.kernels[0].excess_sig), true);
-        assert_eq!(reorg_pool.has_tx_with_excess_sig(&tx6.body.kernels[0].excess_sig), true);
+        assert_eq!(
+            reorg_pool
+                .has_tx_with_excess_sig(&tx2.body.kernels[0].excess_sig)
+                .unwrap(),
+            true
+        );
+        assert_eq!(
+            reorg_pool
+                .has_tx_with_excess_sig(&tx3.body.kernels[0].excess_sig)
+                .unwrap(),
+            true
+        );
+        assert_eq!(
+            reorg_pool
+                .has_tx_with_excess_sig(&tx4.body.kernels[0].excess_sig)
+                .unwrap(),
+            true
+        );
+        assert_eq!(
+            reorg_pool
+                .has_tx_with_excess_sig(&tx5.body.kernels[0].excess_sig)
+                .unwrap(),
+            true
+        );
+        assert_eq!(
+            reorg_pool
+                .has_tx_with_excess_sig(&tx6.body.kernels[0].excess_sig)
+                .unwrap(),
+            true
+        );
 
         let reorg_blocks = vec![
-            create_test_block(3000, vec![tx3.clone(), tx4.clone()]),
-            create_test_block(4000, vec![tx1.clone(), tx2.clone()]),
+            create_test_block(3000, None, vec![(*tx3).clone(), (*tx4).clone()]),
+            create_test_block(4000, None, vec![(*tx1).clone(), (*tx2).clone()]),
         ];
 
-        let removed_txs = reorg_pool.scan_for_and_remove_reorged_txs(reorg_blocks);
+        let removed_txs = reorg_pool.scan_for_and_remove_reorged_txs(reorg_blocks).unwrap();
         assert_eq!(removed_txs.len(), 3);
-        assert!(removed_txs.iter().any(|tx| **tx == tx2));
-        assert!(removed_txs.iter().any(|tx| **tx == tx3));
-        assert!(removed_txs.iter().any(|tx| **tx == tx4));
+        assert!(removed_txs.contains(&tx2));
+        assert!(removed_txs.contains(&tx3));
+        assert!(removed_txs.contains(&tx4));
 
-        assert_eq!(reorg_pool.len(), 2);
+        assert_eq!(reorg_pool.len().unwrap(), 2);
         assert_eq!(
-            reorg_pool.has_tx_with_excess_sig(&tx1.body.kernels[0].excess_sig),
+            reorg_pool
+                .has_tx_with_excess_sig(&tx1.body.kernels[0].excess_sig)
+                .unwrap(),
             false
         );
         assert_eq!(
-            reorg_pool.has_tx_with_excess_sig(&tx2.body.kernels[0].excess_sig),
+            reorg_pool
+                .has_tx_with_excess_sig(&tx2.body.kernels[0].excess_sig)
+                .unwrap(),
             false
         );
         assert_eq!(
-            reorg_pool.has_tx_with_excess_sig(&tx3.body.kernels[0].excess_sig),
+            reorg_pool
+                .has_tx_with_excess_sig(&tx3.body.kernels[0].excess_sig)
+                .unwrap(),
             false
         );
         assert_eq!(
-            reorg_pool.has_tx_with_excess_sig(&tx4.body.kernels[0].excess_sig),
+            reorg_pool
+                .has_tx_with_excess_sig(&tx4.body.kernels[0].excess_sig)
+                .unwrap(),
             false
         );
-        assert_eq!(reorg_pool.has_tx_with_excess_sig(&tx5.body.kernels[0].excess_sig), true);
-        assert_eq!(reorg_pool.has_tx_with_excess_sig(&tx6.body.kernels[0].excess_sig), true);
+        assert_eq!(
+            reorg_pool
+                .has_tx_with_excess_sig(&tx5.body.kernels[0].excess_sig)
+                .unwrap(),
+            true
+        );
+        assert_eq!(
+            reorg_pool
+                .has_tx_with_excess_sig(&tx6.body.kernels[0].excess_sig)
+                .unwrap(),
+            true
+        );
     }
 }

--- a/base_layer/core/src/mempool/reorg_pool/reorg_pool_storage.rs
+++ b/base_layer/core/src/mempool/reorg_pool/reorg_pool_storage.rs
@@ -1,0 +1,100 @@
+//  Copyright 2019 The Tari Project
+//
+//  Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+//  following conditions are met:
+//
+//  1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+//  disclaimer.
+//
+//  2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+//  following disclaimer in the documentation and/or other materials provided with the distribution.
+//
+//  3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+//  products derived from this software without specific prior written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+//  INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+//  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+//  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+//  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+//  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+//  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+use crate::{
+    blocks::Block,
+    mempool::reorg_pool::reorg_pool::ReorgPoolConfig,
+    transaction::Transaction,
+    types::Signature,
+};
+use std::sync::Arc;
+use ttl_cache::TtlCache;
+
+/// Reorg makes use of ReorgPoolStorage to provide thread save access to its TtlCache.
+/// The ReorgPoolStorage consists of all transactions that have recently been added to blocks.
+/// When a potential blockchain reorganization occurs the transactions can be recovered from the ReorgPool and can be
+/// added back into the UnconfirmedPool. Transactions in the ReOrg pool have a limited Time-to-live and will be removed
+/// from the pool when the Time-to-live thresholds is reached. Also, when the capacity of the pool has been reached, the
+/// oldest transactions will be removed to make space for incoming transactions.
+pub struct ReorgPoolStorage {
+    config: ReorgPoolConfig,
+    txs_by_signature: TtlCache<Signature, Arc<Transaction>>,
+}
+
+impl ReorgPoolStorage {
+    /// Create a new ReorgPoolStorage with the specified configuration
+    pub fn new(config: ReorgPoolConfig) -> Self {
+        Self {
+            config,
+            txs_by_signature: TtlCache::new(config.storage_capacity),
+        }
+    }
+
+    /// Insert a new transaction into the ReorgPoolStorage. Published transactions will have a limited Time-to-live in
+    /// the ReorgPoolStorage and will be discarded once the Time-to-live threshold has been reached.
+    pub fn insert(&mut self, tx: Arc<Transaction>) {
+        let tx_key = tx.body.kernels[0].excess_sig.clone();
+        let _ = self.txs_by_signature.insert(tx_key, tx, self.config.tx_ttl);
+    }
+
+    /// Insert a set of new transactions into the ReorgPoolStorage
+    pub fn insert_txs(&mut self, txs: Vec<Arc<Transaction>>) {
+        for tx in txs.into_iter() {
+            self.insert(tx);
+        }
+    }
+
+    /// Check if a transaction is stored in the ReorgPoolStorage
+    pub fn has_tx_with_excess_sig(&self, excess_sig: &Signature) -> bool {
+        self.txs_by_signature.contains_key(excess_sig)
+    }
+
+    /// Remove the transactions from the ReorgPoolStorage that were used in provided removed blocks. The transactions
+    /// can be resubmitted to the Unconfirmed Pool.
+    pub fn scan_for_and_remove_reorged_txs(&mut self, removed_blocks: Vec<Block>) -> Vec<Arc<Transaction>> {
+        let mut removed_txs: Vec<Arc<Transaction>> = Vec::new();
+        for block in &removed_blocks {
+            for kernel in &block.body.kernels {
+                if let Some(removed_tx) = self.txs_by_signature.remove(&kernel.excess_sig) {
+                    removed_txs.push(removed_tx);
+                }
+            }
+        }
+        removed_txs
+    }
+
+    /// Returns the total number of published transactions stored in the ReorgPoolStorage
+    pub fn len(&mut self) -> usize {
+        let mut count = 0;
+        self.txs_by_signature.iter().for_each(|_| count += 1);
+        (count)
+    }
+
+    /// Returns the total weight of all transactions stored in the pool.
+    pub fn calculate_weight(&mut self) -> u64 {
+        let mut weight: u64 = 0;
+        self.txs_by_signature
+            .iter()
+            .for_each(|(_, tx)| weight += tx.calculate_weight());
+        (weight)
+    }
+}

--- a/base_layer/core/src/transaction_protocol/sender.rs
+++ b/base_layer/core/src/transaction_protocol/sender.rs
@@ -371,7 +371,7 @@ impl SenderTransactionProtocol {
                     self.state = SenderState::Failed(e);
                     return Ok(false);
                 }
-                let mut transaction = result.unwrap();
+                let transaction = result.unwrap();
                 let result = transaction
                     .validate_internal_consistency(prover, factory)
                     .map_err(TPE::TransactionBuildError);


### PR DESCRIPTION
## Description
- Added min_input_maturity, max_input_maturity and max_timelock_height member functions to transactions
- Removed "mut" requirements for some of the member functions of blockchain_database
- Separated OrphanPool and PendingPool into an Interface and Storage sections with RwLocks
- Changed OrphanPool to have a reference to the BlockchainDatabase so it can correctly query the UTXO set
- Added snapshot and calculate_weight functions to the UnconfirmedPool, OrphanPool, PendingPool, and ReorgPool
- Modified FeePriority to include the oldest maturity of the input UTXO
- Modified TimelockPriority to correctly use the Transactions lock_height and UTXO maturity
- Modified create_test_tx and create_test_block to create more validly constructed transactions and blocks
- Added create_test_input for creating valid transaction inputs and corresponding UTXOs

## Motivation and Context
These changes were needed for the implementation of the Mempool

## How Has This Been Tested?
The existing tests were updated.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [x] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [x] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch
* [ x] I ran `cargo-fmt --all` before pushing
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
