### PR TITLE
Changed ArrayLike and ArrayLikeExt to return owned copies

### DIFF
--- a/base_layer/mmr/src/merkle_mountain_range.rs
+++ b/base_layer/mmr/src/merkle_mountain_range.rs
@@ -70,12 +70,12 @@ where
     }
 
     /// This function returns the hash of the node index provided indexed from 0
-    pub fn get_node_hash(&self, node_index: usize) -> Option<&Hash> {
+    pub fn get_node_hash(&self, node_index: usize) -> Option<Hash> {
         self.hashes.get(node_index)
     }
 
     /// This function returns the hash of the leaf index provided, indexed from 0
-    pub fn get_leaf_hash(&self, leaf_node_index: usize) -> Option<&Hash> {
+    pub fn get_leaf_hash(&self, leaf_node_index: usize) -> Option<Hash> {
         self.get_node_hash(leaf_index(leaf_node_index))
     }
 
@@ -142,8 +142,8 @@ where
                     .get_node_hash(right_pos)
                     .ok_or(MerkleMountainRangeError::CorruptDataStructure)?;
                 // hash the two child nodes together with parent_pos and compare
-                let hash_check = hash_together::<D>(left_child_hash, right_child_hash);
-                if &hash_check != hash {
+                let hash_check = hash_together::<D>(&left_child_hash, &right_child_hash);
+                if hash_check != hash {
                     return Err(MerkleMountainRangeError::InvalidMerkleTree);
                 }
             }

--- a/base_layer/mmr/src/mutable_mmr.rs
+++ b/base_layer/mmr/src/mutable_mmr.rs
@@ -82,7 +82,7 @@ where
 
     /// This function returns the hash of the leaf index provided, indexed from 0. If the hash does not exist, or if it
     /// has been marked for deletion, `None` is returned.
-    pub fn get_leaf_hash(&self, leaf_node_index: u32) -> Option<&Hash> {
+    pub fn get_leaf_hash(&self, leaf_node_index: u32) -> Option<Hash> {
         if self.deleted.contains(leaf_node_index) {
             return None;
         }
@@ -91,7 +91,7 @@ where
 
     /// Returns the hash of the leaf index provided, as well as its deletion status. The node has been marked for
     /// deletion if the boolean value is true.
-    pub fn get_leaf_status(&self, leaf_node_index: u32) -> (Option<&Hash>, bool) {
+    pub fn get_leaf_status(&self, leaf_node_index: u32) -> (Option<Hash>, bool) {
         let hash = self.mmr.get_node_hash(leaf_index(leaf_node_index as usize));
         let deleted = self.deleted.contains(leaf_node_index);
         (hash, deleted)

--- a/base_layer/mmr/src/pruned_hashset.rs
+++ b/base_layer/mmr/src/pruned_hashset.rs
@@ -84,19 +84,20 @@ impl ArrayLike for PrunedHashSet {
         Ok(self.len() - 1)
     }
 
-    fn get(&self, index: usize) -> Option<&Self::Value> {
+    fn get(&self, index: usize) -> Option<Self::Value> {
         // If the index is from before we started adding hashes, we can return the hash *if and only if* it is a peak
         if index < self.base_offset {
             return match self.peak_indices.binary_search(&index) {
-                Ok(nth_peak) => Some(&self.peak_hashes[nth_peak]),
+                Ok(nth_peak) => Some(self.peak_hashes[nth_peak].clone()),
                 Err(_) => None,
             };
         }
-        self.hashes.get(index - self.base_offset)
+        self.hashes.get(index - self.base_offset).map(|v| v.clone())
     }
 
-    fn get_or_panic(&self, index: usize) -> &Self::Value {
+    fn get_or_panic(&self, index: usize) -> Self::Value {
         self.get(index)
             .expect("PrunedHashSet only tracks peaks before the offset")
+            .clone()
     }
 }

--- a/base_layer/mmr/tests/pruned_mmr.rs
+++ b/base_layer/mmr/tests/pruned_mmr.rs
@@ -51,6 +51,6 @@ fn pruned_mmrs() {
         assert_eq!(pruned.get_merkle_root(), mmr2.get_merkle_root());
         // But you can only get recent hashes
         assert!(pruned.get_leaf_hash(*size / 2).is_none());
-        assert_eq!(pruned.get_leaf_hash(*size).unwrap(), &new_hash)
+        assert_eq!(pruned.get_leaf_hash(*size).unwrap(), new_hash)
     }
 }


### PR DESCRIPTION
## Description
Changed ArrayLike and ArrayLikeExt to rather return owned copies. This change was required to simplify the integration of LMDB for blockchain storage.

## How Has This Been Tested?
No tests were added.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [x] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch
* [x] I ran `cargo-fmt --all` before pushing
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
