### PR TITLE
Implement fetch_mmr_proof for MemoryDatabase

### DIFF
--- a/base_layer/core/src/chain_storage/blockchain_database.rs
+++ b/base_layer/core/src/chain_storage/blockchain_database.rs
@@ -71,8 +71,10 @@ pub trait BlockchainBackend: Send + Sync {
     /// Fetches the merklish root for the MMR tree identified by the key. This function should only fail if there is an
     /// access or integrity issue with the back end.
     fn fetch_mmr_root(&self, tree: MmrTree) -> Result<HashOutput, ChainStorageError>;
+    /// Returns only the MMR merkle root without the state of the roaring bitmap.
+    fn fetch_mmr_only_root(&self, tree: MmrTree) -> Result<HashOutput, ChainStorageError>;
     /// Constructs a merkle proof for the specified merkle mountain range and the given leaf position.
-    fn fetch_mmr_proof(&self, tree: MmrTree, pos: u64) -> Result<MerkleProof, ChainStorageError>;
+    fn fetch_mmr_proof(&self, tree: MmrTree, pos: usize) -> Result<MerkleProof, ChainStorageError>;
     /// The nth MMR checkpoint (the list of nodes added & deleted) for the given Merkle tree. The index is the n-th
     /// checkpoint (block) from the pruning horizon block.
     fn fetch_mmr_checkpoint(&self, tree: MmrTree, index: u64) -> Result<MerkleCheckPoint, ChainStorageError>;
@@ -279,8 +281,13 @@ where T: BlockchainBackend
         self.db.fetch_mmr_root(tree)
     }
 
+    /// Returns only the MMR merkle root without the state of the roaring bitmap.
+    pub fn fetch_mmr_only_root(&self, tree: MmrTree) -> Result<HashOutput, ChainStorageError> {
+        self.db.fetch_mmr_only_root(tree)
+    }
+
     /// Fetch a Merklish proof for the given hash, tree and position in the MMR
-    pub fn fetch_mmr_proof(&self, tree: MmrTree, pos: u64) -> Result<MerkleProof, ChainStorageError> {
+    pub fn fetch_mmr_proof(&self, tree: MmrTree, pos: usize) -> Result<MerkleProof, ChainStorageError> {
         self.db.fetch_mmr_proof(tree, pos)
     }
 

--- a/base_layer/core/src/chain_storage/error.rs
+++ b/base_layer/core/src/chain_storage/error.rs
@@ -22,6 +22,7 @@
 
 use crate::chain_storage::db_transaction::DbKey;
 use derive_error::Error;
+use tari_mmr::{error::MerkleMountainRangeError, MerkleProofError};
 
 #[derive(Debug, Error, PartialEq)]
 pub enum ChainStorageError {
@@ -54,4 +55,6 @@ pub enum ChainStorageError {
     // The requested value was not found in the database
     #[error(non_std, no_from)]
     ValueNotFound(DbKey),
+    MerkleMountainRangeError(MerkleMountainRangeError),
+    MerkleProofError(MerkleProofError),
 }

--- a/base_layer/mmr/src/error.rs
+++ b/base_layer/mmr/src/error.rs
@@ -22,7 +22,7 @@
 
 use derive_error::Error;
 
-#[derive(Debug, Error)]
+#[derive(Debug, Error, PartialEq)]
 pub enum MerkleMountainRangeError {
     // The next position was not a leaf node as expected
     CorruptDataStructure,

--- a/base_layer/mmr/src/mutable_mmr.rs
+++ b/base_layer/mmr/src/mutable_mmr.rs
@@ -111,6 +111,11 @@ where
         self.hash_deleted(hasher).result().to_vec()
     }
 
+    /// Returns only the MMR merkle root without the compressed serialisation of the bitmap
+    pub fn get_mmr_only_root(&self) -> Hash {
+        self.mmr.get_merkle_root()
+    }
+
     /// Push a new element into the MMR. Computes new related peaks at the same time if applicable.
     /// Returns the new number of leaf nodes (regardless of deleted state) in the mutable MMR
     pub fn push(&mut self, hash: &Hash) -> Result<usize, MerkleMountainRangeError> {
@@ -181,6 +186,11 @@ where
         let bitmap_ser = self.deleted.serialize();
         hasher.input(&bitmap_ser);
         hasher
+    }
+
+    /// Expose the MerkleMountainRange for verifying proofs
+    pub fn mmr(&self) -> &MerkleMountainRange<D, B> {
+        &self.mmr
     }
 }
 


### PR DESCRIPTION
## Description
- Implemented fetch_mmr_proof and added utxo_and_rp_mmr_proof, header_mmr_proof and kernel_mmr_proof tests
- Added fetch_mmr_only_root to the BlockchainBackend trait, this function will return the root without the roaring bitmap contribution, it is needed for verifying proofs.
- Changed fetch_mmr_proof to rather require a usize instead of u64 as the for_leaf_node function of MerkleProof uses a usize
- Exposed the MerkleMountainRange of the MutableMmr to allow the calculation of proofs using MerkleProof::for_leaf_node function

## Motivation and Context
fetch_mmr_proof is used to construct a merkle proof for the specified merkle mountain range and the given leaf position.

## How Has This Been Tested?
New tests have been added.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [x] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch
* [x] I ran `cargo-fmt --all` before pushing
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
