### PR TITLE
Created async outbound messsage service

### DIFF
--- a/comms/src/outbound_service/broadcast_strategy.rs
+++ b/comms/src/outbound_service/broadcast_strategy.rs
@@ -1,0 +1,130 @@
+//  Copyright 2019 The Tari Project
+//
+//  Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+//  following conditions are met:
+//
+//  1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+//  disclaimer.
+//
+//  2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+//  following disclaimer in the documentation and/or other materials provided with the distribution.
+//
+//  3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+//  products derived from this software without specific prior written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+//  INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+//  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+//  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+//  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+//  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+//  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+use crate::{
+    consts::DHT_FORWARD_NODE_COUNT,
+    message::NodeDestination,
+    peer_manager::{node_id::NodeId, peer_manager::PeerManager, PeerManagerError},
+    types::CommsPublicKey,
+};
+use derive_error::Error;
+use std::sync::Arc;
+
+#[derive(Debug, Error)]
+pub enum BroadcastStrategyError {
+    PeerManagerError(PeerManagerError),
+}
+
+#[derive(Debug)]
+pub struct ClosestRequest {
+    pub n: usize,
+    pub node_id: NodeId,
+    pub excluded_peers: Vec<CommsPublicKey>,
+}
+
+#[derive(Debug)]
+pub enum BroadcastStrategy {
+    /// Send to a particular peer matching the given node ID
+    DirectNodeId(NodeId),
+    /// Send to a particular peer matching the given Public Key
+    DirectPublicKey(CommsPublicKey),
+    /// Send to all known Communication Node peers
+    Flood,
+    /// Send to all n nearest neighbour Communication Nodes
+    Closest(ClosestRequest),
+    /// Send to a random set of peers of size n that are Communication Nodes
+    Random(usize),
+}
+
+impl BroadcastStrategy {
+    /// The forward function selects the most appropriate broadcast strategy based on the received messages destination
+    pub fn forward(
+        source_node_id: NodeId,
+        peer_manager: &Arc<PeerManager>,
+        header_dest: NodeDestination<CommsPublicKey>,
+        excluded_peers: Vec<CommsPublicKey>,
+    ) -> Result<Self, BroadcastStrategyError>
+    {
+        Ok(match header_dest {
+            NodeDestination::Unknown => {
+                // Send to the current nodes nearest neighbours
+                BroadcastStrategy::Closest(ClosestRequest {
+                    n: DHT_FORWARD_NODE_COUNT,
+                    node_id: source_node_id,
+                    excluded_peers,
+                })
+            },
+            NodeDestination::PublicKey(dest_public_key) => {
+                if peer_manager.exists(&dest_public_key)? {
+                    // Send to destination peer directly if the current node knows that peer
+                    BroadcastStrategy::DirectPublicKey(dest_public_key)
+                } else {
+                    // Send to the current nodes nearest neighbours
+                    BroadcastStrategy::Closest(ClosestRequest {
+                        n: DHT_FORWARD_NODE_COUNT,
+                        node_id: source_node_id,
+                        excluded_peers,
+                    })
+                }
+            },
+            NodeDestination::NodeId(dest_node_id) => {
+                match peer_manager.find_with_node_id(&dest_node_id) {
+                    Ok(dest_peer) => {
+                        // Send to destination peer directly if the current node knows that peer
+                        BroadcastStrategy::DirectPublicKey(dest_peer.public_key)
+                    },
+                    Err(_) => {
+                        // Send to peers that are closest to the destination network region
+                        BroadcastStrategy::Closest(ClosestRequest {
+                            n: DHT_FORWARD_NODE_COUNT,
+                            node_id: dest_node_id,
+                            excluded_peers,
+                        })
+                    },
+                }
+            },
+        })
+    }
+
+    /// The discover function selects an appropriate broadcast strategy for the discovery of a specific node
+    pub fn discover(
+        source_node_id: NodeId,
+        dest_node_id: Option<NodeId>,
+        header_dest: NodeDestination<CommsPublicKey>,
+        excluded_peers: Vec<CommsPublicKey>,
+    ) -> Self
+    {
+        let network_location_node_id = match dest_node_id {
+            Some(node_id) => node_id,
+            None => match header_dest.clone() {
+                NodeDestination::Unknown => source_node_id,
+                NodeDestination::PublicKey(_) => source_node_id,
+                NodeDestination::NodeId(node_id) => node_id,
+            },
+        };
+        BroadcastStrategy::Closest(ClosestRequest {
+            n: DHT_FORWARD_NODE_COUNT,
+            node_id: network_location_node_id,
+            excluded_peers,
+        })
+    }
+}

--- a/comms/src/outbound_service/error.rs
+++ b/comms/src/outbound_service/error.rs
@@ -1,0 +1,41 @@
+// Copyright 2019 The Tari Project
+//
+// Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+// following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+// disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+// following disclaimer in the documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+// products derived from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+// INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+// WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+// USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+use crate::{
+    connection::ConnectionError,
+    connection_manager::ConnectionManagerError,
+    message::MessageError,
+    peer_manager::PeerManagerError,
+};
+use derive_error::Error;
+use futures::channel::mpsc::SendError;
+use tari_utilities::message_format::MessageFormatError;
+
+#[derive(Debug, Error)]
+pub enum OutboundServiceError {
+    SendError(SendError),
+    MessageSerializationError(MessageError),
+    MessageFormatError(MessageFormatError),
+    PeerManagerError(PeerManagerError),
+    ConnectionManagerError(ConnectionManagerError),
+    ConnectionError(ConnectionError),
+}

--- a/comms/src/outbound_service/messages.rs
+++ b/comms/src/outbound_service/messages.rs
@@ -1,0 +1,101 @@
+// Copyright 2019 The Tari Project
+//
+// Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+// following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+// disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+// following disclaimer in the documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+// products derived from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+// INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+// WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+// USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+use crate::{
+    message::{Frame, FrameSet, MessageEnvelope, MessageFlags},
+    outbound_message_service::broadcast_strategy::BroadcastStrategy,
+    peer_manager::node_id::NodeId,
+};
+use serde::{Deserialize, Serialize};
+
+/// Represents requests to the CommsOutboundService
+#[derive(Debug)]
+pub enum OutboundRequest {
+    /// Send a message using the given broadcast strategy
+    SendMsg {
+        broadcast_strategy: BroadcastStrategy,
+        flags: MessageFlags,
+        body: Box<Frame>,
+    },
+    /// Forward a message envelope
+    Forward {
+        broadcast_strategy: BroadcastStrategy,
+        message_envelope: Box<MessageEnvelope>,
+    },
+}
+
+/// The OutboundMessage has a copy of the MessageEnvelope. OutboundMessageService will create the
+/// OutboundMessage and forward it to the OutboundMessagePool.
+#[derive(Clone, Debug, Deserialize, Serialize, Eq, PartialEq)]
+pub struct OutboundMessage {
+    destination_node_id: NodeId,
+    message_frames: FrameSet,
+}
+
+impl OutboundMessage {
+    /// Create a new OutboundMessage from the destination_node_id and message_frames
+    pub fn new(destination: NodeId, message_frames: FrameSet) -> OutboundMessage {
+        OutboundMessage {
+            destination_node_id: destination,
+            message_frames,
+        }
+    }
+
+    /// Get a reference to the destination NodeID
+    pub fn destination_node_id(&self) -> &NodeId {
+        &self.destination_node_id
+    }
+
+    /// Get a reference to the message frames
+    pub fn message_frames(&self) -> &FrameSet {
+        &self.message_frames
+    }
+
+    /// Consume this wrapper and return ownership of the frames
+    pub fn into_frames(self) -> FrameSet {
+        self.message_frames
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn new() {
+        let node_id = NodeId::new();
+        let subject = OutboundMessage::new(node_id.clone(), vec![vec![1]]);
+        assert_eq!(subject.message_frames[0].len(), 1);
+        assert_eq!(subject.destination_node_id, node_id);
+    }
+
+    #[test]
+    fn getters() {
+        let node_id = NodeId::new();
+        let frames = vec![vec![1]];
+        let subject = OutboundMessage::new(node_id.clone(), frames.clone());
+
+        assert_eq!(subject.destination_node_id(), &node_id);
+        assert_eq!(subject.message_frames(), &frames);
+        assert_eq!(subject.into_frames(), frames);
+    }
+}

--- a/comms/src/outbound_service/mod.rs
+++ b/comms/src/outbound_service/mod.rs
@@ -1,0 +1,34 @@
+// Copyright 2019 The Tari Project
+//
+// Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+// following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+// disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+// following disclaimer in the documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+// products derived from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+// INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+// WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+// USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+pub mod broadcast_strategy;
+mod error;
+mod messages;
+mod service;
+mod worker;
+
+pub use self::{
+    broadcast_strategy::BroadcastStrategy,
+    error::OutboundServiceError,
+    messages::OutboundRequest,
+    service::{OutboundMessageService, OutboundServiceConfig, OutboundServiceRequester},
+};

--- a/comms/src/outbound_service/service.rs
+++ b/comms/src/outbound_service/service.rs
@@ -1,0 +1,389 @@
+// Copyright 2019 The Tari Project
+//
+// Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+// following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+// disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+// following disclaimer in the documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+// products derived from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+// INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+// WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+// USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+use super::messages::OutboundRequest;
+use crate::{
+    connection_manager::ConnectionManagerRequester,
+    message::{Frame, Message, MessageEnvelope, MessageFlags, MessageHeader, NodeDestination},
+    outbound_message_service::{
+        broadcast_strategy::BroadcastStrategy,
+        error::OutboundServiceError,
+        messages::OutboundMessage,
+        worker::OutboundMessageWorker,
+    },
+    peer_manager::{NodeIdentity, PeerManager},
+};
+use futures::{
+    channel::{mpsc, oneshot},
+    SinkExt,
+    StreamExt,
+};
+use log::*;
+use std::{error::Error, sync::Arc};
+use tari_utilities::message_format::MessageFormat;
+use tokio::runtime::TaskExecutor;
+
+const LOG_TARGET: &'static str = "comms::outbound_message_service::service";
+
+/// Configuration for the OutboundService
+pub struct OutboundServiceConfig {
+    pub max_attempts: usize,
+}
+
+impl Default for OutboundServiceConfig {
+    fn default() -> Self {
+        Self { max_attempts: 10 }
+    }
+}
+
+#[derive(Clone)]
+pub struct OutboundServiceRequester {
+    sender: mpsc::UnboundedSender<OutboundRequest>,
+}
+
+impl OutboundServiceRequester {
+    pub fn new(sender: mpsc::UnboundedSender<OutboundRequest>) -> Self {
+        Self { sender }
+    }
+
+    /// Send a comms message
+    pub async fn send_message<T, MType>(
+        &mut self,
+        broadcast_strategy: BroadcastStrategy,
+        flags: MessageFlags,
+        message_type: MType,
+        message: T,
+    ) -> Result<(), OutboundServiceError>
+    where
+        MessageHeader<MType>: MessageFormat,
+        T: MessageFormat,
+    {
+        let frame = serialize_message(message_type, message)?;
+        self.send_raw(broadcast_strategy, flags, frame).await
+    }
+
+    /// Send a raw comms message
+    pub async fn send_raw(
+        &mut self,
+        broadcast_strategy: BroadcastStrategy,
+        flags: MessageFlags,
+        frame: Frame,
+    ) -> Result<(), OutboundServiceError>
+    {
+        self.sender
+            .send(OutboundRequest::SendMsg {
+                broadcast_strategy,
+                flags,
+                body: Box::new(frame),
+            })
+            .await
+            .map_err(Into::into)
+    }
+
+    /// Forward a comms message
+    pub async fn forward_message(
+        &mut self,
+        broadcast_strategy: BroadcastStrategy,
+        envelope: MessageEnvelope,
+    ) -> Result<(), OutboundServiceError>
+    {
+        self.sender
+            .send(OutboundRequest::Forward {
+                broadcast_strategy,
+                message_envelope: Box::new(envelope),
+            })
+            .await
+            .map_err(Into::into)
+    }
+}
+
+fn serialize_message<T, MType>(message_type: MType, message: T) -> Result<Frame, OutboundServiceError>
+where
+    T: MessageFormat,
+    MessageHeader<MType>: MessageFormat,
+{
+    let header = MessageHeader::new(message_type)?;
+    let msg = Message::from_message_format(header, message)?;
+
+    msg.to_binary().map_err(Into::into)
+}
+
+/// Responsible for constructing messages using a broadcast strategy and passing them on to
+/// the worker task.
+pub struct OutboundMessageService {
+    executor: TaskExecutor,
+    outbound_tx: mpsc::UnboundedSender<Vec<OutboundMessage>>,
+    request_rx: mpsc::UnboundedReceiver<OutboundRequest>,
+    worker: Option<OutboundMessageWorker<mpsc::UnboundedReceiver<Vec<OutboundMessage>>>>,
+    peer_manager: Arc<PeerManager>,
+    node_identity: Arc<NodeIdentity>,
+    worker_shutdown_tx: oneshot::Sender<()>,
+}
+
+impl OutboundMessageService {
+    pub fn new(
+        config: OutboundServiceConfig,
+        executor: TaskExecutor,
+        request_rx: mpsc::UnboundedReceiver<OutboundRequest>,
+        peer_manager: Arc<PeerManager>,
+        conn_manager: ConnectionManagerRequester,
+        node_identity: Arc<NodeIdentity>,
+    ) -> Self
+    {
+        let (outbound_tx, outbound_rx) = mpsc::unbounded();
+        let (worker_shutdown_tx, worker_shutdown_rx) = oneshot::channel();
+        let worker = OutboundMessageWorker::new(config, outbound_rx, conn_manager, worker_shutdown_rx);
+
+        Self {
+            executor,
+            outbound_tx,
+            worker: Some(worker),
+            request_rx,
+            peer_manager,
+            node_identity,
+            worker_shutdown_tx,
+        }
+    }
+}
+
+impl OutboundMessageService {
+    pub async fn start(mut self) {
+        self.start_outbound_worker();
+
+        loop {
+            futures::select! {
+                request = self.request_rx.select_next_some() => {
+                    if let Err(err) = self.handle_request(request).await {
+                        error!(target: LOG_TARGET, "{}", err.description());
+                    }
+                },
+
+                complete => {
+                    info!(target: LOG_TARGET, "OutboundService shutting down");
+                    let _ = self.worker_shutdown_tx.send(());
+                    break;
+                }
+            }
+        }
+    }
+
+    fn start_outbound_worker(&mut self) {
+        let worker = self.worker.take().expect("start_outbound_worker called more than once");
+        self.executor.spawn(worker.start())
+    }
+
+    async fn handle_request(&mut self, request: OutboundRequest) -> Result<(), OutboundServiceError> {
+        match request {
+            OutboundRequest::SendMsg {
+                broadcast_strategy,
+                flags,
+                body,
+            } => self.send_msg(broadcast_strategy, flags, body).await,
+
+            OutboundRequest::Forward {
+                broadcast_strategy,
+                message_envelope,
+            } => self.forward_message(broadcast_strategy, message_envelope).await,
+        }
+    }
+
+    async fn send_msg(
+        &mut self,
+        broadcast_strategy: BroadcastStrategy,
+        flags: MessageFlags,
+        body: Box<Frame>,
+    ) -> Result<(), OutboundServiceError>
+    {
+        // Use the BroadcastStrategy to select appropriate peer(s) from PeerManager and then construct and send a
+        // individually wrapped MessageEnvelope to each selected peer
+        let selected_node_identities = self.peer_manager.get_broadcast_identities(broadcast_strategy)?;
+
+        // Construct a MessageEnvelope for each recipient
+        let mut outbound_messages = Vec::with_capacity(selected_node_identities.len());
+        for dest_node_identity in selected_node_identities {
+            let message_envelope = MessageEnvelope::construct(
+                &self.node_identity,
+                dest_node_identity.public_key.clone(),
+                NodeDestination::NodeId(dest_node_identity.node_id.clone()),
+                *body.clone(),
+                flags,
+            )?;
+
+            outbound_messages.push(OutboundMessage::new(
+                dest_node_identity.node_id,
+                message_envelope.into_frame_set(),
+            ));
+        }
+
+        if !outbound_messages.is_empty() {
+            self.outbound_tx
+                .send(outbound_messages)
+                .await
+                .map_err(OutboundServiceError::SendError)?;
+        }
+
+        Ok(())
+    }
+
+    async fn forward_message(
+        &mut self,
+        broadcast_strategy: BroadcastStrategy,
+        envelope: Box<MessageEnvelope>,
+    ) -> Result<(), OutboundServiceError>
+    {
+        // Use the BroadcastStrategy to select appropriate peer(s) from PeerManager and then forward the
+        // received message to each selected peer
+        let selected_node_identities = self.peer_manager.get_broadcast_identities(broadcast_strategy)?;
+        // Modify MessageEnvelope for forwarding
+        let message_envelope = MessageEnvelope::forward_construct(&self.node_identity, *envelope)?;
+        let message_envelope_frames = message_envelope.into_frame_set();
+
+        let outbound_messages = selected_node_identities
+            .into_iter()
+            .map(|dest_node_identity| OutboundMessage::new(dest_node_identity.node_id, message_envelope_frames.clone()))
+            .collect::<Vec<_>>();
+
+        if !outbound_messages.is_empty() {
+            self.outbound_tx
+                .send(outbound_messages)
+                .await
+                .map_err(OutboundServiceError::SendError)?;
+        }
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::{
+        connection::NetAddress,
+        connection_manager::actor::ConnectionManagerRequest,
+        peer_manager::{NodeId, Peer, PeerFlags},
+        test_utils::node_identity,
+        types::{CommsDatabase, CommsPublicKey},
+    };
+    use tokio::runtime::Runtime;
+
+    #[test]
+    fn send_msg_then_shutdown() {
+        let rt = Runtime::new().unwrap();
+        let (request_tx, request_rx) = mpsc::unbounded();
+        let mut sender = OutboundServiceRequester::new(request_tx);
+
+        let (conn_man_tx, mut conn_man_rx) = mpsc::channel(1);
+        let conn_manager = ConnectionManagerRequester::new(conn_man_tx);
+
+        let peer_manager = PeerManager::new(CommsDatabase::new()).map(Arc::new).unwrap();
+        let pk = CommsPublicKey::default();
+        let example_peer = Peer::new(
+            pk.clone(),
+            NodeId::from_key(&pk).unwrap(),
+            vec!["127.0.0.1:9999".parse::<NetAddress>().unwrap()].into(),
+            PeerFlags::empty(),
+        );
+        peer_manager.add_peer(example_peer.clone()).unwrap();
+
+        let node_identity = Arc::new(node_identity::random(None));
+        let service = OutboundMessageService::new(
+            Default::default(),
+            rt.executor(),
+            request_rx,
+            peer_manager,
+            conn_manager,
+            node_identity,
+        );
+        rt.spawn(service.start());
+
+        rt.block_on(sender.send_message(
+            BroadcastStrategy::Flood,
+            MessageFlags::NONE,
+            "custom_msg".to_string(),
+            "Hi everyone!".to_string(),
+        ))
+        .unwrap();
+
+        let msg = rt.block_on(conn_man_rx.next()).unwrap();
+        match msg {
+            ConnectionManagerRequest::DialPeer(boxed) => {
+                let (node_id, _) = *boxed;
+                assert_eq!(node_id, example_peer.node_id);
+            },
+        }
+
+        drop(sender);
+        rt.shutdown_on_idle();
+    }
+
+    #[test]
+    fn forward_msg_then_shutdown() {
+        let rt = Runtime::new().unwrap();
+        let (request_tx, request_rx) = mpsc::unbounded();
+        let mut sender = OutboundServiceRequester::new(request_tx);
+
+        let (conn_man_tx, mut conn_man_rx) = mpsc::channel(1);
+        let conn_manager = ConnectionManagerRequester::new(conn_man_tx);
+
+        let peer_manager = PeerManager::new(CommsDatabase::new()).map(Arc::new).unwrap();
+        let pk = CommsPublicKey::default();
+        let example_peer = Peer::new(
+            pk.clone(),
+            NodeId::from_key(&pk).unwrap(),
+            vec!["127.0.0.1:9999".parse::<NetAddress>().unwrap()].into(),
+            PeerFlags::empty(),
+        );
+        peer_manager.add_peer(example_peer.clone()).unwrap();
+
+        let node_identity = Arc::new(node_identity::random(None));
+        let service = OutboundMessageService::new(
+            Default::default(),
+            rt.executor(),
+            request_rx,
+            peer_manager,
+            conn_manager,
+            Arc::clone(&node_identity),
+        );
+        rt.spawn(service.start());
+        let envelope = MessageEnvelope::construct(
+            &node_identity,
+            example_peer.public_key.clone(),
+            NodeDestination::Unknown,
+            vec![],
+            MessageFlags::empty(),
+        )
+        .unwrap();
+        rt.block_on(sender.forward_message(BroadcastStrategy::Flood, envelope))
+            .unwrap();
+
+        let msg = rt.block_on(conn_man_rx.next()).unwrap();
+        match msg {
+            ConnectionManagerRequest::DialPeer(boxed) => {
+                let (node_id, _) = *boxed;
+                assert_eq!(node_id, example_peer.node_id);
+            },
+        }
+
+        drop(sender);
+        rt.shutdown_on_idle();
+    }
+}

--- a/comms/src/outbound_service/worker.rs
+++ b/comms/src/outbound_service/worker.rs
@@ -1,0 +1,404 @@
+// Copyright 2019 The Tari Project
+//
+// Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+// following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+// disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+// following disclaimer in the documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+// products derived from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+// INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+// WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+// USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+use crate::{
+    connection::PeerConnection,
+    connection_manager::ConnectionManagerRequester,
+    outbound_message_service::{
+        error::OutboundServiceError,
+        messages::OutboundMessage,
+        service::OutboundServiceConfig,
+    },
+    peer_manager::NodeId,
+};
+use futures::{
+    channel::oneshot,
+    future::Fuse,
+    stream::{FusedStream, FuturesUnordered},
+    FutureExt,
+    Stream,
+    StreamExt,
+};
+use log::*;
+use std::{
+    cmp,
+    collections::HashMap,
+    sync::Arc,
+    time::{Duration, Instant},
+};
+use tokio::timer;
+
+const LOG_TARGET: &'static str = "comms::outbound_message_service::worker";
+
+/// The state of the dial request
+pub struct DialState {
+    /// Number of dial attempts
+    attempts: usize,
+    /// The node id being dialed
+    node_id: NodeId,
+    /// Cancel signal
+    cancel_rx: Option<Fuse<oneshot::Receiver<()>>>,
+}
+
+impl DialState {
+    /// Create a new DialState for the given NodeId
+    pub fn new(node_id: NodeId) -> Self {
+        Self {
+            node_id,
+            attempts: 0,
+            cancel_rx: None,
+        }
+    }
+
+    /// Set the cancel receiver for this DialState
+    pub fn set_cancel_receiver(&mut self, cancel_rx: Fuse<oneshot::Receiver<()>>) -> &mut Self {
+        self.cancel_rx = Some(cancel_rx);
+        self
+    }
+
+    /// Take ownership of the cancel receiver if this DialState has ownership of one
+    pub fn take_cancel_receiver(&mut self) -> Option<Fuse<oneshot::Receiver<()>>> {
+        self.cancel_rx.take()
+    }
+
+    /// Increment the number of attempts
+    pub fn inc_attempts(&mut self) -> &mut Self {
+        self.attempts += 1;
+        self
+    }
+
+    /// Calculates the time from now that this dial attempt should be retried.
+    pub fn backoff_duration(&mut self) -> Duration {
+        Duration::from_millis(self.exponential_backoff_offset())
+    }
+
+    /// Calculates the offset in seconds based on `self.attempts`.
+    fn exponential_backoff_offset(&self) -> u64 {
+        if self.attempts == 0 {
+            return 0;
+        }
+        let secs = 0.5 * (f32::powf(2.0, self.attempts as f32) - 1.0);
+        cmp::max(2, secs.ceil() as u64)
+    }
+}
+
+/// Responsible for dialing peers and sending queued messages
+pub struct OutboundMessageWorker<TMsgStream> {
+    config: OutboundServiceConfig,
+    connection_manager: ConnectionManagerRequester,
+    incoming_message_stream: TMsgStream,
+    pending_connect_requests: HashMap<NodeId, Vec<OutboundMessage>>,
+    shutdown_rx: Option<oneshot::Receiver<()>>,
+    dial_cancel_signals: HashMap<NodeId, oneshot::Sender<()>>,
+}
+
+impl<TMsgStream> OutboundMessageWorker<TMsgStream>
+where TMsgStream: Stream<Item = Vec<OutboundMessage>> + FusedStream + Unpin
+{
+    pub fn new(
+        config: OutboundServiceConfig,
+        incoming_message_stream: TMsgStream,
+        connection_manager: ConnectionManagerRequester,
+        shutdown_rx: oneshot::Receiver<()>,
+    ) -> Self
+    {
+        Self {
+            config,
+            connection_manager,
+            incoming_message_stream,
+            pending_connect_requests: HashMap::new(),
+            shutdown_rx: Some(shutdown_rx),
+            dial_cancel_signals: HashMap::new(),
+        }
+    }
+
+    pub async fn start(mut self) {
+        let mut pending_connects = FuturesUnordered::new();
+        let mut shutdown_rx = self
+            .shutdown_rx
+            .take()
+            .expect("OutboundMessageActor initialized without shutdown_rx")
+            .fuse();
+        loop {
+            futures::select! {
+                new_messages = self.incoming_message_stream.select_next_some() => {
+                    let pending_connect_states = self.enqueue_new_messages(new_messages)
+                        .into_iter()
+                        // Wrap node ids to connect in a DialState
+                        .map(DialState::new);
+
+                    for mut state in pending_connect_states {
+                        let (cancel_tx, cancel_rx) = oneshot::channel();
+                        self.dial_cancel_signals.insert(state.node_id.clone(), cancel_tx);
+                        state.set_cancel_receiver(cancel_rx.fuse());
+                        pending_connects.push(
+                            Self::connect_to(self.connection_manager.clone(), state)
+                        );
+                    }
+                },
+
+                maybe_result = pending_connects.select_next_some() => {
+                    // maybe_result could be None if the connection attempt was canceled
+                    if let Some((state, result)) = maybe_result {
+                        if let Some(mut state) = self.handle_connect_result(state, result) {
+                            if state.attempts >= self.config.max_attempts {
+                                warn!(target: LOG_TARGET, "Failed to connect to NodeId={}", state.node_id);
+                            } else {
+                                // Should retry this connection attempt
+                                state.inc_attempts();
+                                pending_connects.push(
+                                    Self::connect_to(self.connection_manager.clone(), state)
+                                );
+                            }
+                        }
+                    }
+                },
+
+                _ = shutdown_rx => {
+                    info!(target: LOG_TARGET, "Outbound message service received shutdown signal.");
+                    self.cancel_connection_attempts();
+                    break;
+                },
+
+                complete => break,
+            }
+        }
+    }
+
+    fn cancel_connection_attempts(&mut self) {
+        for (_, cancel_tx) in self.dial_cancel_signals.drain() {
+            let _ = cancel_tx.send(());
+        }
+    }
+
+    async fn connect_to(
+        mut connection_manager: ConnectionManagerRequester,
+        mut state: DialState,
+    ) -> Option<(DialState, Result<Arc<PeerConnection>, OutboundServiceError>)>
+    {
+        let mut cancel_rx = state
+            .take_cancel_receiver()
+            .expect("It is incorrect to attempt to connect without setting a cancel receiver");
+
+        let offset = state.backoff_duration();
+        let mut delay = timer::delay(Instant::now() + offset).fuse();
+        futures::select! {
+            _ = delay => {
+                let result = connection_manager
+                    .dial_node(state.node_id.clone())
+                    .await
+                    .map_err(Into::into);
+                // Put the cancel receiver back
+                state.set_cancel_receiver(cancel_rx);
+                Some((state, result))
+            },
+            _ = cancel_rx => None,
+        }
+    }
+
+    fn enqueue_new_messages(&mut self, batch: Vec<OutboundMessage>) -> Vec<NodeId> {
+        let mut pending_node_ids = Vec::new();
+        for msg in batch {
+            match self.pending_connect_requests.get_mut(msg.destination_node_id()) {
+                // Connection being attempted for peer. Add the message to the queue to be sent once connected.
+                Some(msgs) => msgs.push(msg),
+
+                // No connection currently being attempted for this peer.
+                None => {
+                    let node_id = msg.destination_node_id().clone();
+                    self.pending_connect_requests.insert(node_id.clone(), vec![msg]);
+                    pending_node_ids.push(node_id);
+                },
+            }
+        }
+
+        pending_node_ids
+    }
+
+    fn handle_connect_result(
+        &mut self,
+        state: DialState,
+        connect_result: Result<Arc<PeerConnection>, OutboundServiceError>,
+    ) -> Option<DialState>
+    {
+        match connect_result {
+            Ok(conn) => {
+                if let Err(err) = self.handle_new_connection(&state.node_id, conn) {
+                    error!(
+                        target: LOG_TARGET,
+                        "Error when sending messages for new connection: {:?}", err
+                    );
+                }
+                None
+            },
+            Err(err) => {
+                error!(target: LOG_TARGET, "Failed to connect to node: {}", err);
+                Some(state)
+            },
+        }
+    }
+
+    fn handle_new_connection(
+        &mut self,
+        node_id: &NodeId,
+        conn: Arc<PeerConnection>,
+    ) -> Result<(), OutboundServiceError>
+    {
+        self.dial_cancel_signals.remove(node_id);
+        match self.pending_connect_requests.remove(node_id) {
+            Some(messages) => {
+                for message in messages {
+                    conn.send(message.message_frames().clone())
+                        .map_err(OutboundServiceError::ConnectionError)?;
+                }
+            },
+            None => {
+                // This should never happen
+                warn!(
+                    target: LOG_TARGET,
+                    "No messages to send for new connection to NodeId {}", node_id
+                );
+            },
+        }
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::{
+        connection::peer_connection,
+        connection_manager::actor::ConnectionManagerRequest,
+        test_utils::node_id,
+    };
+    use futures::{channel::mpsc, SinkExt};
+    use tokio::runtime::Runtime;
+
+    #[test]
+    fn multiple_send_in_batch() {
+        // Tests sending 3 messages to 2 recipients simultaneously.
+        // This checks that messages from separate requests are batched and a single dial request per
+        // peer is made.
+        let rt = Runtime::new().unwrap();
+        let (mut new_message_tx, new_message_rx) = mpsc::unbounded();
+
+        let (conn_man_tx, mut conn_man_rx) = mpsc::channel(1);
+        let conn_manager = ConnectionManagerRequester::new(conn_man_tx);
+
+        let (shutdown_tx, shutdown_rx) = oneshot::channel();
+
+        let service = OutboundMessageWorker::new(
+            OutboundServiceConfig::default(),
+            new_message_rx,
+            conn_manager,
+            shutdown_rx,
+        );
+        rt.spawn(service.start());
+
+        let node_id1 = node_id::random();
+        let node_id2 = node_id::random();
+
+        // Send a batch of messages
+        let messages = vec![
+            OutboundMessage::new(node_id1.clone(), vec![b"A".to_vec()]),
+            OutboundMessage::new(node_id2.clone(), vec![b"B".to_vec()]),
+        ];
+        rt.block_on(new_message_tx.send(messages)).unwrap();
+        // Another message for node_id1
+        let messages = vec![OutboundMessage::new(node_id1.clone(), vec![b"C".to_vec()])];
+        rt.block_on(new_message_tx.send(messages)).unwrap();
+
+        // There should be 2 connection requests.
+        let conn_man_req1 = rt.block_on(conn_man_rx.next()).unwrap();
+        // This should be followed by the next connection message
+        let conn_man_req2 = rt.block_on(conn_man_rx.next()).unwrap();
+        // Then, the stream should be empty (try_next errors on Poll::Pending)
+        assert!(conn_man_rx.try_next().is_err());
+
+        // Check that the dial request for node_id1 is made and, when a peer connection is passed back,
+        // that peer connection is used to send the correct messages
+        match conn_man_req1 {
+            ConnectionManagerRequest::DialPeer(boxed) => {
+                let (node_id, reply_tx) = *boxed;
+                assert_eq!(node_id, node_id1);
+                let (conn, rx) = PeerConnection::new_with_connecting_state_for_test();
+                assert!(reply_tx.send(Ok(Arc::new(conn))).is_ok());
+                // Check that pending messages are sent
+                let msg = rx.recv_timeout(Duration::from_millis(100)).unwrap();
+                match msg {
+                    peer_connection::ControlMessage::SendMsg(frames) => {
+                        assert_eq!(&frames[0], b"A");
+                    },
+                    _ => panic!(),
+                }
+                let msg = rx.recv_timeout(Duration::from_millis(100)).unwrap();
+                match msg {
+                    peer_connection::ControlMessage::SendMsg(frames) => {
+                        assert_eq!(&frames[0], b"C");
+                    },
+                    _ => panic!(),
+                }
+            },
+        }
+
+        // Check that the dial request for node_id2 is made
+        match conn_man_req2 {
+            ConnectionManagerRequest::DialPeer(boxed) => {
+                let (node_id, _) = *boxed;
+                assert_eq!(node_id, node_id2);
+            },
+        }
+
+        // Abort pending connections and shutdown the service
+        shutdown_tx.send(()).unwrap();
+        rt.shutdown_on_idle();
+    }
+
+    #[test]
+    fn exponential_backoff_calc() {
+        let mut state = DialState::new(NodeId::new());
+        state.attempts = 0;
+        assert_eq!(state.exponential_backoff_offset(), 0);
+        state.attempts = 1;
+        assert_eq!(state.exponential_backoff_offset(), 2);
+        state.attempts = 2;
+        assert_eq!(state.exponential_backoff_offset(), 2);
+        state.attempts = 3;
+        assert_eq!(state.exponential_backoff_offset(), 4);
+        state.attempts = 4;
+        assert_eq!(state.exponential_backoff_offset(), 8);
+        state.attempts = 5;
+        assert_eq!(state.exponential_backoff_offset(), 16);
+        state.attempts = 6;
+        assert_eq!(state.exponential_backoff_offset(), 32);
+        state.attempts = 7;
+        assert_eq!(state.exponential_backoff_offset(), 64);
+        state.attempts = 8;
+        assert_eq!(state.exponential_backoff_offset(), 128);
+        state.attempts = 9;
+        assert_eq!(state.exponential_backoff_offset(), 256);
+        state.attempts = 10;
+        assert_eq!(state.exponential_backoff_offset(), 512);
+    }
+}


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Created an async outbound message service which is responsible for
constructing messages from a broadcast strategy, requesting connections
from the ConnectionManager and sending batches of messages. As before, failed
connections to a peer are retried using a exponential backoff strategy.

Functionally similar to the current OMS, except that it is asynchronous and lock free (it
connects and sends messages on two tasks).

Currently this is not included in the module tree to keep the PR
smaller. A subsequent PR will make use of the async OMS.


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Ref #655 
Ref #708 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Unit test in the module - subsequent PR will contain integration tests using the new OMS 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [x] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch
* [x] I ran `cargo-fmt --all` before pushing
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
