### PR TITLE
BlockchainDatabase rewind_to_height

### DIFF
--- a/base_layer/core/src/blocks/blockheader.rs
+++ b/base_layer/core/src/blocks/blockheader.rs
@@ -41,7 +41,7 @@ use crate::{
     proof_of_work::Difficulty,
     types::{BlindingFactor, HashDigest, TariProofOfWork},
 };
-use chrono::{DateTime, NaiveDate, Utc};
+use chrono::{DateTime, Utc};
 use digest::Digest;
 use serde::{
     de::{self, Visitor},
@@ -50,7 +50,7 @@ use serde::{
     Serialize,
     Serializer,
 };
-use std::{fmt, time::Instant};
+use std::fmt;
 use tari_utilities::{ByteArray, Hashable};
 
 pub type BlockHash = Vec<u8>;

--- a/base_layer/core/src/chain_storage/error.rs
+++ b/base_layer/core/src/chain_storage/error.rs
@@ -20,7 +20,7 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use crate::chain_storage::db_transaction::DbKey;
+use crate::{blocks::BlockValidationError, chain_storage::db_transaction::DbKey};
 use derive_error::Error;
 use tari_mmr::{error::MerkleMountainRangeError, MerkleProofError};
 
@@ -57,4 +57,5 @@ pub enum ChainStorageError {
     ValueNotFound(DbKey),
     MerkleMountainRangeError(MerkleMountainRangeError),
     MerkleProofError(MerkleProofError),
+    BlockValidationError(BlockValidationError),
 }

--- a/base_layer/core/src/chain_storage/historical_block.rs
+++ b/base_layer/core/src/chain_storage/historical_block.rs
@@ -51,6 +51,11 @@ impl HistoricalBlock {
     pub fn is_spent(&self, output: &TransactionOutput) -> bool {
         self.spent_commitments.contains(&output.commitment)
     }
+
+    /// Returns a reference to the block of the HistoricalBlock
+    pub fn block(&self) -> &Block {
+        &self.block
+    }
 }
 
 impl From<HistoricalBlock> for Block {

--- a/base_layer/core/src/chain_storage/memory_db.rs
+++ b/base_layer/core/src/chain_storage/memory_db.rs
@@ -47,7 +47,7 @@ use std::{
     sync::{Arc, RwLock, RwLockReadGuard, RwLockWriteGuard},
 };
 use tari_mmr::{Hash as MmrHash, MerkleChangeTracker, MerkleCheckPoint, MerkleProof, MutableMmr};
-use tari_utilities::{hash::Hashable, hex::Hex};
+use tari_utilities::hash::Hashable;
 
 /// A generic struct for storing node objects in the BlockchainDB that also form part of an MMR. The index field makes
 /// reverse lookups (find by hash) possible.
@@ -194,6 +194,24 @@ where D: Digest + Send + Sync
                     MmrTree::RangeProof => db
                         .range_proof_mmr
                         .commit()
+                        .map_err(|e| ChainStorageError::AccessError(e.to_string()))?,
+                },
+                WriteOperation::RewindMmr(tree, steps_back) => match tree {
+                    MmrTree::Header => db
+                        .header_mmr
+                        .rewind(steps_back)
+                        .map_err(|e| ChainStorageError::AccessError(e.to_string()))?,
+                    MmrTree::Kernel => db
+                        .kernel_mmr
+                        .rewind(steps_back)
+                        .map_err(|e| ChainStorageError::AccessError(e.to_string()))?,
+                    MmrTree::Utxo => db
+                        .utxo_mmr
+                        .rewind(steps_back)
+                        .map_err(|e| ChainStorageError::AccessError(e.to_string()))?,
+                    MmrTree::RangeProof => db
+                        .range_proof_mmr
+                        .rewind(steps_back)
                         .map_err(|e| ChainStorageError::AccessError(e.to_string()))?,
                 },
             }

--- a/base_layer/core/src/chain_storage/test/chain_storage.rs
+++ b/base_layer/core/src/chain_storage/test/chain_storage.rs
@@ -38,7 +38,6 @@ use crate::{
         chain_block,
         create_genesis_block,
         create_test_block,
-        create_test_input,
         create_test_kernel,
         create_test_tx_spending_utxos,
         create_tx,
@@ -381,4 +380,172 @@ fn test_checkpoints() {
     let block1 = serde_json::to_string(&block1).unwrap();
     let block_b = serde_json::to_string(&Block::from(block_b)).unwrap();
     assert_eq!(block1, block_b);
+}
+
+#[test]
+fn rewind_to_height() {
+    let store = BlockchainDatabase::new(MemoryDatabase::<HashDigest>::default()).unwrap();
+    let (block0, _) = create_genesis_block();
+    assert!(store.add_block(block0.clone()).is_ok());
+
+    let (tx1, inputs1, _) = create_tx(MicroTari(10_000), MicroTari(50), 0, 1, 0, 1);
+    let (tx2, inputs2, _) = create_tx(MicroTari(10_000), MicroTari(20), 0, 1, 0, 1);
+    let (tx3, inputs3, _) = create_tx(MicroTari(10_000), MicroTari(100), 0, 1, 0, 1);
+    let (tx4, inputs4, _) = create_tx(MicroTari(10_000), MicroTari(30), 0, 1, 0, 1);
+    let (tx5, inputs5, _) = create_tx(MicroTari(10_000), MicroTari(50), 0, 1, 0, 1);
+    let (tx6, inputs6, _) = create_tx(MicroTari(10_000), MicroTari(75), 0, 1, 0, 1);
+    let mut txn = DbTransaction::new();
+    txn.insert_utxo(
+        inputs1[0]
+            .as_transaction_output(&PROVER, &COMMITMENT_FACTORY, inputs1[0].features.clone())
+            .unwrap(),
+    );
+    txn.insert_utxo(
+        inputs2[0]
+            .as_transaction_output(&PROVER, &COMMITMENT_FACTORY, inputs2[0].features.clone())
+            .unwrap(),
+    );
+    txn.insert_utxo(
+        inputs3[0]
+            .as_transaction_output(&PROVER, &COMMITMENT_FACTORY, inputs3[0].features.clone())
+            .unwrap(),
+    );
+    txn.insert_utxo(
+        inputs4[0]
+            .as_transaction_output(&PROVER, &COMMITMENT_FACTORY, inputs4[0].features.clone())
+            .unwrap(),
+    );
+    txn.insert_utxo(
+        inputs5[0]
+            .as_transaction_output(&PROVER, &COMMITMENT_FACTORY, inputs5[0].features.clone())
+            .unwrap(),
+    );
+    txn.insert_utxo(
+        inputs6[0]
+            .as_transaction_output(&PROVER, &COMMITMENT_FACTORY, inputs6[0].features.clone())
+            .unwrap(),
+    );
+    assert!(store.commit(txn).is_ok());
+
+    let block1 = chain_block(&block0, vec![tx1.clone(), tx2.clone()]);
+    assert!(store.add_block(block1.clone()).is_ok());
+    let block2 = chain_block(&block1, vec![tx3.clone()]);
+    assert!(store.add_block(block2.clone()).is_ok());
+    let block3 = chain_block(&block2, vec![tx4.clone(), tx5.clone(), tx6.clone()]);
+    assert!(store.add_block(block3.clone()).is_ok());
+
+    assert!(store.rewind_to_height(3).is_ok());
+    assert!(store.rewind_to_height(4).is_err());
+
+    let tx1_input_hash = tx1.body.inputs[0].hash();
+    let tx2_input_hash = tx2.body.inputs[0].hash();
+    let tx3_input_hash = tx3.body.inputs[0].hash();
+    let tx4_input_hash = tx4.body.inputs[0].hash();
+    let tx5_input_hash = tx5.body.inputs[0].hash();
+    let tx6_input_hash = tx6.body.inputs[0].hash();
+    let tx1_output_hash = tx1.body.outputs[0].hash();
+    let tx2_output_hash = tx2.body.outputs[0].hash();
+    let tx3_output_hash = tx3.body.outputs[0].hash();
+    let tx4_output_hash = tx4.body.outputs[0].hash();
+    let tx5_output_hash = tx5.body.outputs[0].hash();
+    let tx6_output_hash = tx6.body.outputs[0].hash();
+    let tx1_kernel_hash = tx1.body.kernels[0].hash();
+    let tx2_kernel_hash = tx2.body.kernels[0].hash();
+    let tx3_kernel_hash = tx3.body.kernels[0].hash();
+    let tx4_kernel_hash = tx4.body.kernels[0].hash();
+    let tx5_kernel_hash = tx5.body.kernels[0].hash();
+    let tx6_kernel_hash = tx6.body.kernels[0].hash();
+    let block0_header_hash = block0.header.hash();
+    let block1_header_hash = block1.header.hash();
+    let block2_header_hash = block2.header.hash();
+    let block3_header_hash = block3.header.hash();
+
+    assert_eq!(store.fetch_header(0).unwrap().height, 0);
+    assert_eq!(store.fetch_header(1).unwrap().height, 1);
+    assert_eq!(store.fetch_header(2).unwrap().height, 2);
+    assert_eq!(store.fetch_header(3).unwrap().height, 3);
+    assert_eq!(store.fetch_header(4).is_ok(), false);
+
+    assert!(store.fetch_kernel(tx1_kernel_hash.clone()).is_ok());
+    assert!(store.fetch_kernel(tx2_kernel_hash.clone()).is_ok());
+    assert!(store.fetch_kernel(tx3_kernel_hash.clone()).is_ok());
+    assert!(store.fetch_kernel(tx4_kernel_hash.clone()).is_ok());
+    assert!(store.fetch_kernel(tx5_kernel_hash.clone()).is_ok());
+    assert!(store.fetch_kernel(tx6_kernel_hash.clone()).is_ok());
+
+    assert_eq!(store.is_utxo(tx1_input_hash.clone()), Ok(false));
+    assert_eq!(store.is_utxo(tx2_input_hash.clone()), Ok(false));
+    assert_eq!(store.is_utxo(tx3_input_hash.clone()), Ok(false));
+    assert_eq!(store.is_utxo(tx4_input_hash.clone()), Ok(false));
+    assert_eq!(store.is_utxo(tx5_input_hash.clone()), Ok(false));
+    assert_eq!(store.is_utxo(tx6_input_hash.clone()), Ok(false));
+    assert_eq!(store.is_utxo(tx1_output_hash.clone()), Ok(true));
+    assert_eq!(store.is_utxo(tx2_output_hash.clone()), Ok(true));
+    assert_eq!(store.is_utxo(tx3_output_hash.clone()), Ok(true));
+    assert_eq!(store.is_utxo(tx4_output_hash.clone()), Ok(true));
+    assert_eq!(store.is_utxo(tx5_output_hash.clone()), Ok(true));
+    assert_eq!(store.is_utxo(tx6_output_hash.clone()), Ok(true));
+
+    assert!(store.fetch_stxo(tx1_input_hash.clone()).is_ok());
+    assert!(store.fetch_stxo(tx2_input_hash.clone()).is_ok());
+    assert!(store.fetch_stxo(tx3_input_hash.clone()).is_ok());
+    assert!(store.fetch_stxo(tx4_input_hash.clone()).is_ok());
+    assert!(store.fetch_stxo(tx5_input_hash.clone()).is_ok());
+    assert!(store.fetch_stxo(tx6_input_hash.clone()).is_ok());
+    assert!(store.fetch_stxo(tx1_output_hash.clone()).is_err());
+    assert!(store.fetch_stxo(tx2_output_hash.clone()).is_err());
+    assert!(store.fetch_stxo(tx3_output_hash.clone()).is_err());
+    assert!(store.fetch_stxo(tx4_output_hash.clone()).is_err());
+    assert!(store.fetch_stxo(tx5_output_hash.clone()).is_err());
+    assert!(store.fetch_stxo(tx6_output_hash.clone()).is_err());
+
+    assert!(store.fetch_orphan(block0_header_hash.clone()).is_err());
+    assert!(store.fetch_orphan(block1_header_hash.clone()).is_err());
+    assert!(store.fetch_orphan(block2_header_hash.clone()).is_err());
+    assert!(store.fetch_orphan(block3_header_hash.clone()).is_err());
+
+    assert!(store.rewind_to_height(1).is_ok());
+
+    assert_eq!(store.fetch_header(0).unwrap().height, 0);
+    assert_eq!(store.fetch_header(1).unwrap().height, 1);
+    assert_eq!(store.fetch_header(2).is_ok(), false);
+    assert_eq!(store.fetch_header(3).is_ok(), false);
+
+    assert!(store.fetch_kernel(tx1_kernel_hash).is_ok());
+    assert!(store.fetch_kernel(tx2_kernel_hash).is_ok());
+    assert!(store.fetch_kernel(tx3_kernel_hash).is_err());
+    assert!(store.fetch_kernel(tx4_kernel_hash).is_err());
+    assert!(store.fetch_kernel(tx5_kernel_hash).is_err());
+    assert!(store.fetch_kernel(tx6_kernel_hash).is_err());
+
+    assert_eq!(store.is_utxo(tx1_input_hash.clone()), Ok(false));
+    assert_eq!(store.is_utxo(tx2_input_hash.clone()), Ok(false));
+    assert_eq!(store.is_utxo(tx3_input_hash.clone()), Ok(true));
+    assert_eq!(store.is_utxo(tx4_input_hash.clone()), Ok(true));
+    assert_eq!(store.is_utxo(tx5_input_hash.clone()), Ok(true));
+    assert_eq!(store.is_utxo(tx6_input_hash.clone()), Ok(true));
+    assert_eq!(store.is_utxo(tx1_output_hash.clone()), Ok(true));
+    assert_eq!(store.is_utxo(tx2_output_hash.clone()), Ok(true));
+    assert_eq!(store.is_utxo(tx3_output_hash.clone()), Ok(false));
+    assert_eq!(store.is_utxo(tx4_output_hash.clone()), Ok(false));
+    assert_eq!(store.is_utxo(tx5_output_hash.clone()), Ok(false));
+    assert_eq!(store.is_utxo(tx6_output_hash.clone()), Ok(false));
+
+    assert!(store.fetch_stxo(tx1_input_hash).is_ok());
+    assert!(store.fetch_stxo(tx2_input_hash).is_ok());
+    assert!(store.fetch_stxo(tx3_input_hash).is_err());
+    assert!(store.fetch_stxo(tx4_input_hash).is_err());
+    assert!(store.fetch_stxo(tx5_input_hash).is_err());
+    assert!(store.fetch_stxo(tx6_input_hash).is_err());
+    assert!(store.fetch_stxo(tx1_output_hash).is_err());
+    assert!(store.fetch_stxo(tx2_output_hash).is_err());
+    assert!(store.fetch_stxo(tx3_output_hash).is_err());
+    assert!(store.fetch_stxo(tx4_output_hash).is_err());
+    assert!(store.fetch_stxo(tx5_output_hash).is_err());
+    assert!(store.fetch_stxo(tx6_output_hash).is_err());
+
+    assert!(store.fetch_orphan(block0_header_hash).is_err());
+    assert!(store.fetch_orphan(block1_header_hash).is_err());
+    assert!(store.fetch_orphan(block2_header_hash).is_ok());
+    assert!(store.fetch_orphan(block3_header_hash).is_ok());
 }

--- a/base_layer/core/src/mempool/mempool.rs
+++ b/base_layer/core/src/mempool/mempool.rs
@@ -508,29 +508,49 @@ mod test {
         assert_eq!(stats.timelocked_txs, 0);
         assert_eq!(stats.published_txs, 6);
 
-        // TODO: Add code back in when rewind_to_height has been implemented.
-        // let mut db_txn = DbTransaction::new();
-        // db_txn.rewind_to_height(1);
-        // store.commit(db_txn).unwrap();
-        // let new_block1 = create_test_block(2, Some(published_block1), vec![(*tx7).clone()]);
-        // let new_block2 = create_test_block(3, Some(new_block1.clone()), vec![(*tx8).clone()]);
-        // mempool
-        // .process_reorg(vec![published_block2, published_block3], vec![new_block1, new_block2])
-        // .unwrap();
-        // let stats = mempool.stats().unwrap();
-        // assert_eq!(stats.unconfirmed_txs, 3);
-        // assert_eq!(stats.timelocked_txs, 0);
-        // assert_eq!(stats.published_txs, 5);
-        //
-        // assert_eq!(mempool.has_tx_with_excess_sig(&tx1.body.kernels[0].excess_sig).unwrap(),TxStorageResponse::
-        // ReorgPool); assert_eq!(mempool.has_tx_with_excess_sig(&tx2.body.kernels[0].excess_sig).unwrap(),
-        // TxStorageResponse::ReorgPool); assert_eq!(mempool.has_tx_with_excess_sig(&tx3.body.kernels[0].
-        // excess_sig).unwrap(),TxStorageResponse::ReorgPool); assert_eq!(mempool.has_tx_with_excess_sig(&tx4.
-        // body.kernels[0].excess_sig).unwrap(),TxStorageResponse::UnconfirmedPool); assert_eq!(mempool.
-        // has_tx_with_excess_sig(&tx5.body.kernels[0].excess_sig).unwrap(),TxStorageResponse::UnconfirmedPool);
-        // assert_eq!(mempool.has_tx_with_excess_sig(&tx6.body.kernels[0].excess_sig).unwrap(),TxStorageResponse::
-        // UnconfirmedPool); assert_eq!(mempool.has_tx_with_excess_sig(&tx7.body.kernels[0].excess_sig).
-        // unwrap(),TxStorageResponse::ReorgPool); assert_eq!(mempool.has_tx_with_excess_sig(&tx8.body.
-        // kernels[0].excess_sig).unwrap(),TxStorageResponse::ReorgPool);
+        assert!(store.rewind_to_height(1).is_ok());
+
+        let new_block1 = create_test_block(2, Some(published_block1), vec![(*tx7).clone()]);
+        let new_block2 = create_test_block(3, Some(new_block1.clone()), vec![(*tx8).clone()]);
+        mempool
+            .process_reorg(vec![published_block2, published_block3], vec![new_block1, new_block2])
+            .unwrap();
+        let stats = mempool.stats().unwrap();
+        assert_eq!(stats.unconfirmed_txs, 3);
+        assert_eq!(stats.timelocked_txs, 0);
+        assert_eq!(stats.published_txs, 5);
+
+        assert_eq!(
+            mempool.has_tx_with_excess_sig(&tx1.body.kernels[0].excess_sig).unwrap(),
+            TxStorageResponse::ReorgPool
+        );
+        assert_eq!(
+            mempool.has_tx_with_excess_sig(&tx2.body.kernels[0].excess_sig).unwrap(),
+            TxStorageResponse::ReorgPool
+        );
+        assert_eq!(
+            mempool.has_tx_with_excess_sig(&tx3.body.kernels[0].excess_sig).unwrap(),
+            TxStorageResponse::ReorgPool
+        );
+        assert_eq!(
+            mempool.has_tx_with_excess_sig(&tx4.body.kernels[0].excess_sig).unwrap(),
+            TxStorageResponse::UnconfirmedPool
+        );
+        assert_eq!(
+            mempool.has_tx_with_excess_sig(&tx5.body.kernels[0].excess_sig).unwrap(),
+            TxStorageResponse::UnconfirmedPool
+        );
+        assert_eq!(
+            mempool.has_tx_with_excess_sig(&tx6.body.kernels[0].excess_sig).unwrap(),
+            TxStorageResponse::UnconfirmedPool
+        );
+        assert_eq!(
+            mempool.has_tx_with_excess_sig(&tx7.body.kernels[0].excess_sig).unwrap(),
+            TxStorageResponse::ReorgPool
+        );
+        assert_eq!(
+            mempool.has_tx_with_excess_sig(&tx8.body.kernels[0].excess_sig).unwrap(),
+            TxStorageResponse::ReorgPool
+        );
     }
 }

--- a/base_layer/core/src/test_utils/builders.rs
+++ b/base_layer/core/src/test_utils/builders.rs
@@ -257,7 +257,7 @@ pub fn create_genesis_block() -> (Block, UnblindedOutput) {
     let value = MicroTari::from(100_000_000);
     let excess = Commitment::from_public_key(&PublicKey::default());
     let (utxo, key) = create_utxo(value);
-    let (pk, sig) = create_random_signature(0.into(), 0);
+    let (_pk, sig) = create_random_signature(0.into(), 0);
     let kernel = KernelBuilder::new()
         .with_signature(&sig)
         .with_excess(&excess)


### PR DESCRIPTION
## Description
- Added rewind_to_height function to BlockchainDatabase and a test for new functionality, this function can be used to rewind the blockchain state to the specified block height.
- Added RewindMmr WriteOperation to MemoryDatabase
- Added unspend_stxo function to DbTransaction to move an STXO to the UTXO set.
- Added rewind_header_mmr, rewind_kernel_mmr, rewind_utxo_mmr and rewind_rp_mmr to DbTransaction for rewinding the MMRs by the specified number of Checkpoints.
- Added an accessor function to HistoricalBlock to allow access to its Block.
- This new functionality allows the extra tests from the Mempool reorg test to be enabled. 

## Motivation and Context
Enables the rewinding of the blockchain state to the specified block height.

## How Has This Been Tested?
The rewind_to_height test was added.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [x] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch
* [x] I ran `cargo-fmt --all` before pushing
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
