### PR TITLE
Spend macro

### DIFF
--- a/base_layer/core/src/mempool/mempool.rs
+++ b/base_layer/core/src/mempool/mempool.rs
@@ -250,7 +250,8 @@ mod test {
         blocks::genesis_block::get_genesis_block,
         chain_storage::{DbTransaction, MemoryDatabase},
         tari_amount::MicroTari,
-        test_utils::builders::{create_test_block, create_test_input, create_test_tx, create_test_tx_spending_utxos},
+        test_utils::builders::{create_test_block, create_test_input, create_test_tx_spending_utxos},
+        tx,
         types::HashDigest,
     };
 
@@ -263,7 +264,7 @@ mod test {
     ) -> Transaction
     {
         if orphaned {
-            create_test_tx(MicroTari(5_000), fee_per_gram, lock_height, 2, input_maturity, 2)
+            (tx!( MicroTari(5_000), fee: fee_per_gram, lock: lock_height, inputs: 2, maturity: input_maturity, outputs: 2)).0
         } else {
             let utxo1 = create_test_input(2_500.into(), input_maturity.clone());
             let utxo2 = create_test_input(2_500.into(), input_maturity);

--- a/base_layer/core/src/mempool/orphan_pool/orphan_pool.rs
+++ b/base_layer/core/src/mempool/orphan_pool/orphan_pool.rs
@@ -144,20 +144,20 @@ mod test {
         blocks::genesis_block::get_genesis_block,
         chain_storage::{DbTransaction, MemoryDatabase},
         tari_amount::MicroTari,
-        test_utils::builders::create_test_tx,
         transaction::TransactionInput,
+        tx,
         types::HashDigest,
     };
     use std::{thread, time::Duration};
 
     #[test]
     fn test_insert_rlu_and_ttl() {
-        let tx1 = Arc::new(create_test_tx(MicroTari(10_000), MicroTari(500), 4000, 2, 0, 1));
-        let tx2 = Arc::new(create_test_tx(MicroTari(10_000), MicroTari(300), 3000, 2, 0, 1));
-        let tx3 = Arc::new(create_test_tx(MicroTari(10_000), MicroTari(100), 2500, 2, 0, 1));
-        let tx4 = Arc::new(create_test_tx(MicroTari(10_000), MicroTari(200), 1000, 2, 0, 1));
-        let tx5 = Arc::new(create_test_tx(MicroTari(10_000), MicroTari(500), 2000, 2, 0, 1));
-        let tx6 = Arc::new(create_test_tx(MicroTari(10_000), MicroTari(600), 5500, 2, 0, 1));
+        let tx1 = Arc::new(tx!(MicroTari(10_000), fee: MicroTari(500), lock: 4000, inputs: 2, outputs: 1).0);
+        let tx2 = Arc::new(tx!(MicroTari(10_000), fee: MicroTari(300), lock: 3000, inputs: 2, outputs: 1).0);
+        let tx3 = Arc::new(tx!(MicroTari(10_000), fee: MicroTari(100), lock: 2500, inputs: 2, outputs: 1).0);
+        let tx4 = Arc::new(tx!(MicroTari(10_000), fee: MicroTari(200), lock: 1000, inputs: 2, outputs: 1).0);
+        let tx5 = Arc::new(tx!(MicroTari(10_000), fee: MicroTari(500), lock: 2000, inputs: 2, outputs: 1).0);
+        let tx6 = Arc::new(tx!(MicroTari(10_000), fee: MicroTari(600), lock: 5500, inputs: 2, outputs: 1).0);
 
         let store = Arc::new(BlockchainDatabase::new(MemoryDatabase::<HashDigest>::default()).unwrap());
         let orphan_pool = OrphanPool::new(store, OrphanPoolConfig {
@@ -243,12 +243,12 @@ mod test {
 
     #[test]
     fn test_scan_for_and_remove_unorphaned() {
-        let tx1 = Arc::new(create_test_tx(MicroTari(10_000), MicroTari(500), 1100, 2, 0, 1));
-        let tx2 = Arc::new(create_test_tx(MicroTari(10_000), MicroTari(300), 1700, 2, 0, 1));
-        let tx3 = Arc::new(create_test_tx(MicroTari(10_000), MicroTari(100), 0, 1, 0, 1));
-        let mut tx4 = create_test_tx(MicroTari(10_000), MicroTari(200), 0, 2, 0, 1);
-        let mut tx5 = create_test_tx(MicroTari(10_000), MicroTari(500), 1000, 2, 0, 1);
-        let tx6 = Arc::new(create_test_tx(MicroTari(10_000), MicroTari(600), 5200, 2, 0, 1));
+        let tx1 = Arc::new(tx!(MicroTari(10_000), fee: MicroTari(500), lock: 1100, inputs: 2, outputs: 1).0);
+        let tx2 = Arc::new(tx!(MicroTari(10_000), fee: MicroTari(300), lock: 1700, inputs: 2, outputs: 1).0);
+        let tx3 = Arc::new(tx!(MicroTari(10_000), fee: MicroTari(100), lock: 0, inputs: 1, outputs: 1).0);
+        let mut tx4 = tx!(MicroTari(10_000), fee: MicroTari(200), inputs: 2, outputs: 1).0;
+        let mut tx5 = tx!(MicroTari(10_000), fee: MicroTari(500), lock: 1000, inputs: 2, outputs: 1).0;
+        let tx6 = Arc::new(tx!(MicroTari(10_000), fee: MicroTari(600), lock: 5200, inputs: 2, outputs: 1).0);
         // Publishing of tx1 and tx2 will create the UTXOs required by tx4 and tx5
         tx4.body.inputs.clear();
         tx1.body

--- a/base_layer/core/src/mempool/pending_pool/pending_pool.rs
+++ b/base_layer/core/src/mempool/pending_pool/pending_pool.rs
@@ -139,19 +139,16 @@ impl PendingPool {
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::{
-        tari_amount::MicroTari,
-        test_utils::builders::{create_test_block, create_test_tx},
-    };
+    use crate::{tari_amount::MicroTari, test_utils::builders::create_test_block, tx};
 
     #[test]
     fn test_insert_and_lru() {
-        let tx1 = Arc::new(create_test_tx(MicroTari(10_000), MicroTari(50), 500, 2, 0, 1));
-        let tx2 = Arc::new(create_test_tx(MicroTari(10_000), MicroTari(20), 2150, 1, 0, 2));
-        let tx3 = Arc::new(create_test_tx(MicroTari(10_000), MicroTari(100), 1000, 2, 0, 1));
-        let tx4 = Arc::new(create_test_tx(MicroTari(10_000), MicroTari(30), 2450, 2, 0, 2));
-        let tx5 = Arc::new(create_test_tx(MicroTari(10_000), MicroTari(50), 1000, 3, 0, 3));
-        let tx6 = Arc::new(create_test_tx(MicroTari(10_000), MicroTari(75), 1850, 2, 0, 2));
+        let tx1 = Arc::new(tx!(MicroTari(10_000), fee: MicroTari(50), lock: 500, inputs: 2, outputs: 1).0);
+        let tx2 = Arc::new(tx!(MicroTari(10_000), fee: MicroTari(20), lock: 2150, inputs: 1, outputs: 2).0);
+        let tx3 = Arc::new(tx!(MicroTari(10_000), fee: MicroTari(100), lock: 1000, inputs: 2, outputs: 1).0);
+        let tx4 = Arc::new(tx!(MicroTari(10_000), fee: MicroTari(30), lock: 2450, inputs: 2, outputs: 2).0);
+        let tx5 = Arc::new(tx!(MicroTari(10_000), fee: MicroTari(50), lock: 1000, inputs: 3, outputs: 3).0);
+        let tx6 = Arc::new(tx!(MicroTari(10_000), fee: MicroTari(75), lock: 1850, inputs: 2, outputs: 2).0);
 
         let pending_pool = PendingPool::new(PendingPoolConfig { storage_capacity: 3 });
         pending_pool
@@ -208,12 +205,18 @@ mod test {
 
     #[test]
     fn test_remove_unlocked_and_discard_double_spends() {
-        let tx1 = Arc::new(create_test_tx(MicroTari(10_000), MicroTari(50), 500, 2, 0, 1));
-        let tx2 = Arc::new(create_test_tx(MicroTari(10_000), MicroTari(20), 0, 1, 2150, 2));
-        let tx3 = Arc::new(create_test_tx(MicroTari(10_000), MicroTari(100), 0, 2, 1000, 1));
-        let tx4 = Arc::new(create_test_tx(MicroTari(10_000), MicroTari(30), 2450, 2, 0, 2));
-        let tx5 = Arc::new(create_test_tx(MicroTari(10_000), MicroTari(50), 1000, 3, 0, 3));
-        let tx6 = Arc::new(create_test_tx(MicroTari(10_000), MicroTari(75), 1450, 2, 1400, 2));
+        let tx1 = Arc::new(tx!(MicroTari(10_000), fee: MicroTari(50), lock: 500, inputs: 2, outputs: 1).0);
+        let tx2 =
+            Arc::new(tx!(MicroTari(10_000), fee: MicroTari(20), lock: 0, inputs: 1, maturity: 2150, outputs: 2).0);
+        let tx3 = Arc::new(
+            tx!(MicroTari(10_000), fee: MicroTari(100), lock: 0, inputs: 2, maturity: 1000, outputs:
+        1)
+            .0,
+        );
+        let tx4 = Arc::new(tx!(MicroTari(10_000), fee: MicroTari(30), lock: 2450, inputs: 2, outputs: 2).0);
+        let tx5 = Arc::new(tx!(MicroTari(10_000), fee: MicroTari(50), lock: 1000, inputs: 3, outputs: 3).0);
+        let tx6 =
+            Arc::new(tx!(MicroTari(10_000), fee: MicroTari(75), lock: 1450, inputs: 2, maturity: 1400, outputs: 2).0);
 
         let pending_pool = PendingPool::new(PendingPoolConfig { storage_capacity: 10 });
         pending_pool

--- a/base_layer/core/src/mempool/reorg_pool/reorg_pool.rs
+++ b/base_layer/core/src/mempool/reorg_pool/reorg_pool.rs
@@ -122,20 +122,17 @@ impl ReorgPool {
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::{
-        tari_amount::MicroTari,
-        test_utils::builders::{create_test_block, create_test_tx},
-    };
+    use crate::{tari_amount::MicroTari, test_utils::builders::create_test_block, tx};
     use std::{thread, time::Duration};
 
     #[test]
     fn test_insert_rlu_and_ttl() {
-        let tx1 = Arc::new(create_test_tx(MicroTari(10_000), MicroTari(500), 4000, 2, 0, 1));
-        let tx2 = Arc::new(create_test_tx(MicroTari(10_000), MicroTari(300), 3000, 2, 0, 1));
-        let tx3 = Arc::new(create_test_tx(MicroTari(10_000), MicroTari(100), 2500, 2, 0, 1));
-        let tx4 = Arc::new(create_test_tx(MicroTari(10_000), MicroTari(200), 1000, 2, 0, 1));
-        let tx5 = Arc::new(create_test_tx(MicroTari(10_000), MicroTari(500), 2000, 2, 0, 1));
-        let tx6 = Arc::new(create_test_tx(MicroTari(10_000), MicroTari(600), 5500, 2, 0, 1));
+        let tx1 = Arc::new(tx!(MicroTari(10_000), fee: MicroTari(500), lock: 4000, inputs: 2, outputs: 1).0);
+        let tx2 = Arc::new(tx!(MicroTari(10_000), fee: MicroTari(300), lock: 3000, inputs: 2, outputs: 1).0);
+        let tx3 = Arc::new(tx!(MicroTari(10_000), fee: MicroTari(100), lock: 2500, inputs: 2, outputs: 1).0);
+        let tx4 = Arc::new(tx!(MicroTari(10_000), fee: MicroTari(200), lock: 1000, inputs: 2, outputs: 1).0);
+        let tx5 = Arc::new(tx!(MicroTari(10_000), fee: MicroTari(500), lock: 2000, inputs: 2, outputs: 1).0);
+        let tx6 = Arc::new(tx!(MicroTari(10_000), fee: MicroTari(600), lock: 5500, inputs: 2, outputs: 1).0);
 
         let reorg_pool = ReorgPool::new(ReorgPoolConfig {
             storage_capacity: 3,
@@ -214,12 +211,12 @@ mod test {
 
     #[test]
     fn remove_scan_for_and_remove_reorged_txs() {
-        let tx1 = Arc::new(create_test_tx(MicroTari(10_000), MicroTari(50), 4000, 2, 0, 1));
-        let tx2 = Arc::new(create_test_tx(MicroTari(10_000), MicroTari(30), 3000, 2, 0, 1));
-        let tx3 = Arc::new(create_test_tx(MicroTari(10_000), MicroTari(20), 2500, 2, 0, 1));
-        let tx4 = Arc::new(create_test_tx(MicroTari(10_000), MicroTari(20), 1000, 2, 0, 1));
-        let tx5 = Arc::new(create_test_tx(MicroTari(10_000), MicroTari(50), 2000, 2, 0, 1));
-        let tx6 = Arc::new(create_test_tx(MicroTari(10_000), MicroTari(60), 5500, 2, 0, 1));
+        let tx1 = Arc::new(tx!(MicroTari(10_000), fee: MicroTari(50), lock: 4000, inputs: 2, outputs: 1).0);
+        let tx2 = Arc::new(tx!(MicroTari(10_000), fee: MicroTari(30), lock: 3000, inputs: 2, outputs: 1).0);
+        let tx3 = Arc::new(tx!(MicroTari(10_000), fee: MicroTari(20), lock: 2500, inputs: 2, outputs: 1).0);
+        let tx4 = Arc::new(tx!(MicroTari(10_000), fee: MicroTari(20), lock: 1000, inputs: 2, outputs: 1).0);
+        let tx5 = Arc::new(tx!(MicroTari(10_000), fee: MicroTari(50), lock: 2000, inputs: 2, outputs: 1).0);
+        let tx6 = Arc::new(tx!(MicroTari(10_000), fee: MicroTari(60), lock: 5500, inputs: 2, outputs: 1).0);
 
         let reorg_pool = ReorgPool::new(ReorgPoolConfig {
             storage_capacity: 5,

--- a/base_layer/core/src/mempool/unconfirmed_pool/unconfirmed_pool.rs
+++ b/base_layer/core/src/mempool/unconfirmed_pool/unconfirmed_pool.rs
@@ -151,18 +151,15 @@ impl UnconfirmedPool {
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::{
-        tari_amount::MicroTari,
-        test_utils::builders::{create_test_block, create_test_tx},
-    };
+    use crate::{tari_amount::MicroTari, test_utils::builders::create_test_block, tx};
 
     #[test]
     fn test_insert_and_retrieve_highest_priority_txs() {
-        let tx1 = Arc::new(create_test_tx(MicroTari(5_000), MicroTari(50), 0, 2, 0, 1));
-        let tx2 = Arc::new(create_test_tx(MicroTari(5_000), MicroTari(20), 0, 4, 0, 1));
-        let tx3 = Arc::new(create_test_tx(MicroTari(5_000), MicroTari(100), 0, 5, 0, 1));
-        let tx4 = Arc::new(create_test_tx(MicroTari(5_000), MicroTari(30), 0, 3, 0, 1));
-        let tx5 = Arc::new(create_test_tx(MicroTari(5_000), MicroTari(50), 0, 5, 0, 1));
+        let tx1 = Arc::new(tx!(MicroTari(5_000), fee: MicroTari(50), inputs: 2, outputs: 1).0);
+        let tx2 = Arc::new(tx!(MicroTari(5_000), fee: MicroTari(20), inputs: 4, outputs: 1).0);
+        let tx3 = Arc::new(tx!(MicroTari(5_000), fee: MicroTari(100), inputs: 5, outputs: 1).0);
+        let tx4 = Arc::new(tx!(MicroTari(5_000), fee: MicroTari(30), inputs: 3, outputs: 1).0);
+        let tx5 = Arc::new(tx!(MicroTari(5_000), fee: MicroTari(50), inputs: 5, outputs: 1).0);
 
         let unconfirmed_pool = UnconfirmedPool::new(UnconfirmedPoolConfig {
             storage_capacity: 4,
@@ -217,12 +214,12 @@ mod test {
 
     #[test]
     fn test_remove_published_txs() {
-        let tx1 = Arc::new(create_test_tx(MicroTari(10_000), MicroTari(50), 0, 2, 0, 1));
-        let tx2 = Arc::new(create_test_tx(MicroTari(10_000), MicroTari(20), 0, 3, 0, 1));
-        let tx3 = Arc::new(create_test_tx(MicroTari(10_000), MicroTari(100), 0, 2, 0, 1));
-        let tx4 = Arc::new(create_test_tx(MicroTari(10_000), MicroTari(30), 0, 4, 0, 1));
-        let tx5 = Arc::new(create_test_tx(MicroTari(10_000), MicroTari(50), 0, 3, 0, 1));
-        let tx6 = Arc::new(create_test_tx(MicroTari(10_000), MicroTari(75), 0, 2, 0, 1));
+        let tx1 = Arc::new(tx!(MicroTari(10_000), fee: MicroTari(50), inputs:2, outputs: 1).0);
+        let tx2 = Arc::new(tx!(MicroTari(10_000), fee: MicroTari(20), inputs:3, outputs: 1).0);
+        let tx3 = Arc::new(tx!(MicroTari(10_000), fee: MicroTari(100), inputs:2, outputs: 1).0);
+        let tx4 = Arc::new(tx!(MicroTari(10_000), fee: MicroTari(30), inputs:4, outputs: 1).0);
+        let tx5 = Arc::new(tx!(MicroTari(10_000), fee: MicroTari(50), inputs:3, outputs: 1).0);
+        let tx6 = Arc::new(tx!(MicroTari(10_000), fee: MicroTari(75), inputs:2, outputs: 1).0);
 
         let unconfirmed_pool = UnconfirmedPool::new(UnconfirmedPoolConfig {
             storage_capacity: 10,
@@ -287,12 +284,12 @@ mod test {
 
     #[test]
     fn test_discard_double_spend_txs() {
-        let tx1 = Arc::new(create_test_tx(MicroTari(5_000), MicroTari(50), 0, 2, 0, 1));
-        let tx2 = Arc::new(create_test_tx(MicroTari(5_000), MicroTari(20), 0, 3, 0, 1));
-        let tx3 = Arc::new(create_test_tx(MicroTari(5_000), MicroTari(100), 0, 2, 0, 1));
-        let tx4 = Arc::new(create_test_tx(MicroTari(5_000), MicroTari(30), 0, 2, 0, 1));
-        let mut tx5 = create_test_tx(MicroTari(5_000), MicroTari(50), 0, 3, 0, 1);
-        let mut tx6 = create_test_tx(MicroTari(5_000), MicroTari(75), 0, 2, 0, 1);
+        let tx1 = Arc::new(tx!(MicroTari(5_000), fee: MicroTari(50), inputs:2, outputs:1).0);
+        let tx2 = Arc::new(tx!(MicroTari(5_000), fee: MicroTari(20), inputs:3, outputs:1).0);
+        let tx3 = Arc::new(tx!(MicroTari(5_000), fee: MicroTari(100), inputs:2, outputs:1).0);
+        let tx4 = Arc::new(tx!(MicroTari(5_000), fee: MicroTari(30), inputs:2, outputs:1).0);
+        let mut tx5 = tx!(MicroTari(5_000), fee:MicroTari(50), inputs:3, outputs:1).0;
+        let mut tx6 = tx!(MicroTari(5_000), fee:MicroTari(75), inputs: 2, outputs: 1).0;
         // tx1 and tx5 have a shared input. Also, tx3 and tx6 have a shared input
         tx5.body.inputs[0] = tx1.body.inputs[0].clone();
         tx6.body.inputs[1] = tx3.body.inputs[1].clone();


### PR DESCRIPTION
Add a convenient and ergonomic wrapper for the `spend_utxo` function

Builds on #758 