### PR TITLE
Added destination field to InboundMessage

### DIFF
--- a/comms/src/domain_subscriber.rs
+++ b/comms/src/domain_subscriber.rs
@@ -110,12 +110,13 @@ where S: Stream<Item = InboundMessage> + Unpin + FusedStream
 mod test {
     use super::*;
     use crate::{
-        message::Message,
+        message::{Message, NodeDestination},
         peer_manager::NodeIdentity,
         pub_sub_channel::{pubsub_channel, TopicPayload},
     };
     use futures::{executor::block_on, SinkExt};
     use serde::{Deserialize, Serialize};
+
     #[test]
     fn topic_pub_sub() {
         let (mut publisher, subscriber_factory) = pubsub_channel(10);
@@ -165,6 +166,7 @@ mod test {
                 InboundMessage::new(
                     node_id.identity.clone(),
                     node_id.identity.public_key.clone(),
+                    NodeDestination::Unknown,
                     Message::from_message_format(m.0.clone(), m.1.clone()).unwrap(),
                 ),
             )

--- a/comms/src/inbound_message_pipeline/inbound_message_pipeline.rs
+++ b/comms/src/inbound_message_pipeline/inbound_message_pipeline.rs
@@ -219,7 +219,8 @@ where MType: Eq + Send + Sync + Debug + Serialize + DeserializeOwned + 'static
         debug!(target: LOG_TARGET, "Received message type: {:?}", header.message_type);
         let inbound_message = InboundMessage::new(
             source_peer.clone().into(),
-            message_envelope_header.origin_source.clone(),
+            message_envelope_header.origin_source,
+            message_envelope_header.dest,
             message,
         );
 

--- a/comms/src/message/inbound_message.rs
+++ b/comms/src/message/inbound_message.rs
@@ -20,7 +20,11 @@
 //  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 //  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use crate::{message::message::Message, peer_manager::PeerNodeIdentity, types::CommsPublicKey};
+use crate::{
+    message::{message::Message, NodeDestination},
+    peer_manager::PeerNodeIdentity,
+    types::CommsPublicKey,
+};
 use serde::{Deserialize, Serialize};
 
 /// The InboundMessage is the container that will be dispatched to the domain handlers. It contains the received
@@ -30,16 +34,24 @@ pub struct InboundMessage {
     pub peer_source: PeerNodeIdentity,
     pub origin_source: CommsPublicKey,
     pub message: Message,
+    pub destination: NodeDestination<CommsPublicKey>,
 }
 
 impl InboundMessage {
     /// Construct a new InboundMessage that consist of the peer connection information and the received message
     /// header and body
-    pub fn new(peer_source: PeerNodeIdentity, origin_source: CommsPublicKey, message: Message) -> Self {
-        InboundMessage {
+    pub fn new(
+        peer_source: PeerNodeIdentity,
+        origin_source: CommsPublicKey,
+        destination: NodeDestination<CommsPublicKey>,
+        message: Message,
+    ) -> Self
+    {
+        Self {
             peer_source,
             origin_source,
             message,
+            destination,
         }
     }
 }

--- a/comms/src/message/mod.rs
+++ b/comms/src/message/mod.rs
@@ -63,16 +63,16 @@ use crate::peer_manager::node_id::NodeId;
 use bitflags::*;
 use serde::{Deserialize, Serialize};
 
-mod domain_message_context;
 mod envelope;
 mod error;
+mod inbound_message;
 mod message;
 mod message_data;
 
 pub use self::{
-    domain_message_context::*,
     envelope::{MessageEnvelope, MessageEnvelopeHeader},
     error::MessageError,
+    inbound_message::*,
     message::{Message, MessageHeader},
     message_data::*,
 };


### PR DESCRIPTION
The destination will be used in domain middlewares and services.

`domain_message_context` module renamed to `inbound_message`