### PR TITLE
Replaced (MessageInfo, T) tuple with DomainMessage

### DIFF
--- a/base_layer/p2p/src/lib.rs
+++ b/base_layer/p2p/src/lib.rs
@@ -32,6 +32,7 @@ mod consts;
 // TODO Put these back in after Futures Comms stack refactor
 // pub mod saf_service;
 // pub mod dht_service;
+pub mod domain_subscriber;
 pub mod initialization;
 pub mod peer;
 pub mod ping_pong;

--- a/base_layer/p2p/src/sync_services/error.rs
+++ b/base_layer/p2p/src/sync_services/error.rs
@@ -20,9 +20,10 @@
 //  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 //  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+use crate::domain_subscriber::DomainSubscriberError;
 use derive_error::Error;
 use serde::export::fmt::Debug;
-use tari_comms::{builder::CommsServicesError, domain_subscriber::DomainSubscriberError};
+use tari_comms::builder::CommsServicesError;
 
 #[derive(Debug, Error)]
 pub enum ServiceError {

--- a/comms/src/lib.rs
+++ b/comms/src/lib.rs
@@ -22,7 +22,6 @@ pub mod connection;
 pub mod connection_manager;
 mod consts;
 pub mod control_service;
-pub mod domain_subscriber;
 pub mod inbound_message_pipeline;
 pub mod message;
 pub mod outbound_message_service;


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
- DomainMessage<T> improves ergonomics of working with incoming messages
- Moved domain_subscriber as part of an effort to remove MType from
  comms and to allow for "add-ons"/middleware for incoming and outgoing
  messages


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Ref #675 
Ref #761 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Existing tests pass

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [x] Breaking change (fix or feature that would cause existing functionality to change)
* [x] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch
* [x] I ran `cargo-fmt --all` before pushing
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
