### PR TITLE
Implement handle reorg and possible reorg for BlockchainDatabase

### DIFF
--- a/base_layer/core/src/chain_storage/db_transaction.rs
+++ b/base_layer/core/src/chain_storage/db_transaction.rs
@@ -91,8 +91,9 @@ impl DbTransaction {
             .push(WriteOperation::Spend(DbKey::UnspentOutput(utxo_hash)));
     }
 
-    /// Moves an STXO to the UTXO set.  If the STXO is not in the STXO set, the transaction will fail with an
+    /// Moves a STXO to the UTXO set.  If the STXO is not in the STXO set, the transaction will fail with an
     /// `UnspendError`.
+    // TODO: unspend_utxo in memory_db doesn't unmark the node in the roaring bitmap.0
     pub fn unspend_stxo(&mut self, stxo_hash: HashOutput) {
         self.operations
             .push(WriteOperation::UnSpend(DbKey::SpentOutput(stxo_hash)));

--- a/base_layer/core/src/chain_storage/memory_db.rs
+++ b/base_layer/core/src/chain_storage/memory_db.rs
@@ -234,7 +234,7 @@ where D: Digest + Send + Sync
                 .block_hashes
                 .get(hash)
                 .and_then(|i| db.headers.get(i))
-                .map(|v| DbValue::BlockHeader(Box::new(v.value.clone()))),
+                .map(|v| DbValue::BlockHash(Box::new(v.value.clone()))),
             DbKey::UnspentOutput(k) => db
                 .utxos
                 .get(k)
@@ -325,6 +325,16 @@ where D: Digest + Send + Sync
             )))?
             .clone();
         Ok((hash, deleted))
+    }
+
+    /// Iterate over all the stored orphan blocks and execute the function `f` for each block.
+    fn for_each_orphan<F>(&self, mut f: F) -> Result<(), ChainStorageError>
+    where F: FnMut(Result<(HashOutput, Block), ChainStorageError>) {
+        let db = self.db_access()?;
+        for (key, val) in db.orphans.iter() {
+            f(Ok((key.clone(), val.clone())));
+        }
+        Ok(())
     }
 }
 

--- a/base_layer/core/src/chain_storage/metadata.rs
+++ b/base_layer/core/src/chain_storage/metadata.rs
@@ -20,7 +20,7 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use crate::blocks::blockheader::BlockHash;
+use crate::{blocks::blockheader::BlockHash, proof_of_work::Difficulty};
 
 #[derive(Debug, Clone)]
 pub struct ChainMetadata {
@@ -29,14 +29,14 @@ pub struct ChainMetadata {
     /// The block hash of the current tip of the longest valid chain, or `None` for an empty chain
     pub best_block: Option<BlockHash>,
     /// The total accumulated difficulty, or work, on the longest valid chain since the genesis block.
-    pub total_accumulated_difficulty: u64,
+    pub total_accumulated_difficulty: Difficulty,
     /// The number of blocks back from the tip that this database tracks. A value of 0 indicates that all blocks are
     /// tracked (i.e. the database is in full archival mode).
     pub pruning_horizon: u64,
 }
 
 impl ChainMetadata {
-    pub fn new(height: u64, hash: BlockHash, work: u64, horizon: u64) -> ChainMetadata {
+    pub fn new(height: u64, hash: BlockHash, work: Difficulty, horizon: u64) -> ChainMetadata {
         ChainMetadata {
             height_of_longest_chain: Some(height),
             best_block: Some(hash),
@@ -72,7 +72,7 @@ impl Default for ChainMetadata {
         ChainMetadata {
             height_of_longest_chain: None,
             best_block: None,
-            total_accumulated_difficulty: 0,
+            total_accumulated_difficulty: Difficulty::default(),
             pruning_horizon: 2880,
         }
     }


### PR DESCRIPTION
## Description
- Implemented handle_possible_reorg and handle_reorg for detecting potential reorgs, constructing reorg chains and updating the main chain with higher accumulated difficulty reorg chains.
- Added the handle_reorg test for testing the reorg functionality of the BlockchainDatabase.
- Added for_each_orphan function to BlockchainBackend and MemoryDatabase to allow access to each orphan block in the orphan pool.
- Changed update_metadata to allow the updating of the chains total accumulated difficulty and made use of Difficulty instead of u64.
- Added fetch_header_with_block_hash to BlockchainDatabase to enable the retrieval of block headers using the block hash.
- Fixed an issue with rewind_to_height where the metadata was not correctly updated.
- Note: the changes to the futures was performed by the cargo fmt.

## Motivation and Context
Will enable detection and processing of chain reorgs.

## How Has This Been Tested?
The handle_reorg test for testing the reorg functionality of the BlockchainDatabase was added.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [x] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [x] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch
* [x] I ran `cargo-fmt --all` before pushing
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
