### PR TITLE
Decoupling of pubsub and domain-level messages

### DIFF
--- a/comms/middleware/src/lib.rs
+++ b/comms/middleware/src/lib.rs
@@ -55,7 +55,9 @@
 pub mod encryption;
 pub mod error;
 pub mod forward;
+pub mod inbound_connector;
 pub mod inbound_message;
+pub mod message;
 pub mod pubsub;
 
 #[cfg(test)]

--- a/comms/middleware/src/message.rs
+++ b/comms/middleware/src/message.rs
@@ -25,11 +25,14 @@ use tari_comms::{
     peer_manager::Peer,
 };
 
-/// Information about the message received
-#[derive(Debug)]
+/// A domain-level message
 pub struct DomainMessage<MType> {
-    pub envelope_header: MessageEnvelopeHeader,
-    pub message_header: MessageHeader<MType>,
-    pub source_peer: Peer,
+    /// Serialized message data
     pub message: Message,
+    /// Domain message header
+    pub message_header: MessageHeader<MType>,
+    /// The message envelope header
+    pub envelope_header: MessageEnvelopeHeader,
+    /// The connected peer which sent this message
+    pub source_peer: Peer,
 }

--- a/comms/middleware/tests/stack.rs
+++ b/comms/middleware/tests/stack.rs
@@ -91,7 +91,7 @@ fn create_peer_storage(tmpdir: &TempDir, database_name: &str, peers: Vec<Peer>) 
 fn stack_unencrypted() {
     let node_identity = Arc::new(make_node_identity());
     let rt = Runtime::new().unwrap();
-    let (service, subscription_factory) = pubsub_service(rt.executor(), 1);
+    let (pubsub_service, subscription_factory) = pubsub_service(rt.executor(), 1);
 
     let tmpdir = TempDir::new(random::string(8).as_str()).unwrap();
     let database_name = "middleware_stack";
@@ -108,7 +108,7 @@ fn stack_unencrypted() {
             Arc::clone(&node_identity),
             oms.clone(),
         ))
-        .service(service);
+        .service(pubsub_service);
 
     let header = MessageHeader::new("fake_type".to_string()).unwrap();
     let msg = Message::from_message_format(header, "secret".to_string()).unwrap();
@@ -128,7 +128,7 @@ fn stack_unencrypted() {
 #[test]
 fn stack_encrypted() {
     let rt = Runtime::new().unwrap();
-    let (pubsub, subscription_factory) = pubsub_service(rt.executor(), 1);
+    let (pubsub_service, subscription_factory) = pubsub_service(rt.executor(), 1);
 
     let node_identity = Arc::new(make_node_identity());
     let tmpdir = TempDir::new(random::string(8).as_str()).unwrap();
@@ -146,7 +146,7 @@ fn stack_encrypted() {
             Arc::clone(&node_identity),
             oms.clone(),
         ))
-        .service(pubsub);
+        .service(pubsub_service);
 
     let header = MessageHeader::new("fake_type".to_string()).unwrap();
     let msg = Message::from_message_format(header, "secret".to_string()).unwrap();
@@ -169,7 +169,7 @@ fn stack_encrypted() {
 #[test]
 fn stack_forward() {
     let rt = Runtime::new().unwrap();
-    let (pubsub, _) = pubsub_service::<()>(rt.executor(), 1);
+    let (pubsub_service, _) = pubsub_service::<()>(rt.executor(), 1);
 
     let node_identity = Arc::new(make_node_identity());
     let tmpdir = TempDir::new(random::string(8).as_str()).unwrap();
@@ -187,7 +187,7 @@ fn stack_forward() {
             Arc::clone(&node_identity),
             oms.clone(),
         ))
-        .service(pubsub);
+        .service(pubsub_service);
 
     let msg = "garbage".as_bytes().to_vec();
     // Encrypt for self


### PR DESCRIPTION
Small change removing unnecessary coupling of inbound domain message
middleware and pubsub.

InboundDomainConnector deserializes domain-level header, assembles a
domain-level message and sends that along a given sink.
`pubsub_service` simply connects a pubsub Publisher and the
InboundDomainConnector

Flow from comms middleware to domain services
`mpsc send DomainMessage<MType> >-- mpsc receive and forward to TopicPublisher --< received by domain-level subscribers`

Ref #761 