### PR TITLE
Outbound DHT middleware

### DIFF
--- a/comms/dht/src/outbound/broadcast.rs
+++ b/comms/dht/src/outbound/broadcast.rs
@@ -1,0 +1,348 @@
+// Copyright 2019, The Tari Project
+//
+// Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+// following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+// disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+// following disclaimer in the documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+// products derived from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+// INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+// WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+// USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+use super::{broadcast_strategy::BroadcastStrategy, error::DhtOutboundError, message::DhtOutboundRequest};
+use crate::{
+    message::DhtHeader,
+    outbound::message::{DhtOutboundMessage, ForwardRequest, SendMessageRequest},
+};
+use futures::{task::Context, Future, Poll};
+use log::*;
+use std::sync::Arc;
+use tari_comms::peer_manager::{NodeIdentity, PeerManager, PeerNodeIdentity};
+use tari_comms_middleware::error::MiddlewareError;
+use tower::{layer::Layer, Service, ServiceExt};
+
+pub struct BroadcastLayer {
+    peer_manager: Arc<PeerManager>,
+    node_identity: Arc<NodeIdentity>,
+}
+
+impl BroadcastLayer {
+    pub fn new(node_identity: Arc<NodeIdentity>, peer_manager: Arc<PeerManager>) -> Self {
+        BroadcastLayer {
+            node_identity,
+            peer_manager,
+        }
+    }
+}
+
+impl<S> Layer<S> for BroadcastLayer {
+    type Service = BroadcastMiddleware<S>;
+
+    fn layer(&self, service: S) -> Self::Service {
+        BroadcastMiddleware::new(service, Arc::clone(&self.peer_manager), Arc::clone(&self.node_identity))
+    }
+}
+const LOG_TARGET: &'static str = "comms::dht::outbound::broadcast_middleware";
+
+/// Responsible for constructing messages using a broadcast strategy and passing them on to
+/// the worker task.
+#[derive(Clone)]
+pub struct BroadcastMiddleware<S> {
+    next: S,
+    peer_manager: Arc<PeerManager>,
+    node_identity: Arc<NodeIdentity>,
+}
+
+impl<S> BroadcastMiddleware<S> {
+    pub fn new(service: S, peer_manager: Arc<PeerManager>, node_identity: Arc<NodeIdentity>) -> Self {
+        Self {
+            next: service,
+            peer_manager,
+            node_identity,
+        }
+    }
+}
+
+impl<S> Service<DhtOutboundRequest> for BroadcastMiddleware<S>
+where
+    S: Service<DhtOutboundMessage> + Clone,
+    S::Error: Into<MiddlewareError>,
+{
+    type Error = MiddlewareError;
+    type Response = ();
+
+    type Future = impl Future<Output = Result<(), Self::Error>>;
+
+    fn poll_ready(&mut self, _: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        Poll::Ready(Ok(()))
+    }
+
+    fn call(&mut self, msg: DhtOutboundRequest) -> Self::Future {
+        BroadcastTask::new(
+            self.next.clone(),
+            Arc::clone(&self.peer_manager),
+            Arc::clone(&self.node_identity),
+            msg,
+        )
+        .handle()
+    }
+}
+
+struct BroadcastTask<S> {
+    service: S,
+    peer_manager: Arc<PeerManager>,
+    node_identity: Arc<NodeIdentity>,
+    request: Option<DhtOutboundRequest>,
+}
+
+impl<S> BroadcastTask<S>
+where
+    S: Service<DhtOutboundMessage>,
+    S::Error: Into<MiddlewareError>,
+{
+    pub fn new(
+        service: S,
+        peer_manager: Arc<PeerManager>,
+        node_identity: Arc<NodeIdentity>,
+        request: DhtOutboundRequest,
+    ) -> Self
+    {
+        Self {
+            service,
+            peer_manager,
+            node_identity,
+            request: Some(request),
+        }
+    }
+
+    pub async fn handle(mut self) -> Result<(), MiddlewareError> {
+        let request = self.request.take().expect("request cannot be None");
+        // TODO: use blocking threadpool to generate messages
+        debug!(target: LOG_TARGET, "Processing outbound request {}", request);
+        let messages = self.generate_outbound_messages(request).map_err(Into::into)?;
+        debug!(target: LOG_TARGET, "Sending {} message(s)", messages.len());
+
+        for message in messages {
+            self.service.ready().await.map_err(Into::into)?;
+            self.service.call(message).await.map_err(Into::into)?;
+        }
+
+        Ok(())
+    }
+
+    pub fn generate_outbound_messages(
+        &self,
+        msg: DhtOutboundRequest,
+    ) -> Result<Vec<DhtOutboundMessage>, DhtOutboundError>
+    {
+        match msg {
+            DhtOutboundRequest::SendMsg(request) => self.generate_send_messages(*request),
+            DhtOutboundRequest::Forward(request) => self.generate_forward_messages(*request),
+        }
+    }
+
+    fn get_broadcast_identities(
+        &self,
+        broadcast_strategy: &BroadcastStrategy,
+    ) -> Result<Vec<PeerNodeIdentity>, DhtOutboundError>
+    {
+        match broadcast_strategy {
+            BroadcastStrategy::DirectNodeId(node_id) => {
+                // Send to a particular peer matching the given node ID
+                self.peer_manager
+                    .direct_identity_node_id(node_id)
+                    .map(|peer| vec![peer])
+                    .map_err(Into::into)
+            },
+            BroadcastStrategy::DirectPublicKey(public_key) => {
+                // Send to a particular peer matching the given node ID
+                self.peer_manager
+                    .direct_identity_public_key(public_key)
+                    .map(|peer| vec![peer])
+                    .map_err(Into::into)
+            },
+            BroadcastStrategy::Flood => {
+                // Send to all known Communication Node peers
+                self.peer_manager.flood_identities().map_err(Into::into)
+            },
+            BroadcastStrategy::Closest(closest_request) => {
+                // Send to all n nearest neighbour Communication Nodes
+                self.peer_manager
+                    .closest_identities(
+                        &closest_request.node_id,
+                        closest_request.n,
+                        &closest_request.excluded_peers,
+                    )
+                    .map_err(Into::into)
+            },
+            BroadcastStrategy::Random(n) => {
+                // Send to a random set of peers of size n that are Communication Nodes
+                self.peer_manager.random_identities(*n).map_err(Into::into)
+            },
+        }
+    }
+
+    fn generate_send_messages(
+        &self,
+        send_message_request: SendMessageRequest,
+    ) -> Result<Vec<DhtOutboundMessage>, DhtOutboundError>
+    {
+        let SendMessageRequest {
+            broadcast_strategy,
+            destination,
+            comms_flags,
+            dht_flags,
+            dht_message_type,
+            body,
+        } = send_message_request;
+
+        // Use the BroadcastStrategy to select appropriate peer(s) from PeerManager and then construct and send a
+        // individually wrapped MessageEnvelope to each selected peer
+        let selected_node_identities = self.get_broadcast_identities(&broadcast_strategy)?;
+
+        // Create a DHT header
+        let dht_header = DhtHeader::new(
+            // Final destination for this message
+            destination,
+            // Origin public key used to identify the origin and verify the signature
+            self.node_identity.identity.public_key.clone(),
+            // Signing will happen later in the pipeline (SerializeMiddleware) to prevent double work
+            Vec::default(),
+            dht_message_type,
+            dht_flags,
+        );
+
+        // Construct a MessageEnvelope for each recipient
+        let messages = selected_node_identities
+            .into_iter()
+            .map(|peer_node_identity| {
+                let dest_public_key = peer_node_identity.public_key.clone();
+                DhtOutboundMessage::new(
+                    peer_node_identity,
+                    dht_header.clone(),
+                    dest_public_key,
+                    comms_flags,
+                    body.clone(),
+                )
+            })
+            .collect::<Vec<_>>();
+
+        Ok(messages)
+    }
+
+    fn generate_forward_messages(
+        &self,
+        forward_request: ForwardRequest,
+    ) -> Result<Vec<DhtOutboundMessage>, DhtOutboundError>
+    {
+        let ForwardRequest {
+            broadcast_strategy,
+            dht_header,
+            comms_flags,
+            body,
+        } = forward_request;
+        // Use the BroadcastStrategy to select appropriate peer(s) from PeerManager and then forward the
+        // received message to each selected peer
+        let selected_node_identities = self.get_broadcast_identities(&broadcast_strategy)?;
+
+        let messages = selected_node_identities
+            .into_iter()
+            .map(|peer_node_identity| {
+                DhtOutboundMessage::new(
+                    peer_node_identity,
+                    dht_header.clone(),
+                    dht_header.origin_public_key.clone(),
+                    comms_flags,
+                    body.clone(),
+                )
+            })
+            .collect();
+
+        Ok(messages)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::{
+        message::{DhtMessageFlags, DhtMessageType},
+        test_utils::{make_peer_manager, service_fn},
+    };
+    use futures::future;
+    use rand::rngs::OsRng;
+    use std::sync::Mutex;
+    use tari_comms::{
+        connection::NetAddress,
+        message::{MessageFlags, NodeDestination},
+        peer_manager::{NodeId, Peer, PeerFlags},
+        types::CommsPublicKey,
+    };
+    use tari_crypto::keys::PublicKey;
+    use tokio::runtime::Runtime;
+
+    #[test]
+    fn send_message_flood() {
+        let rt = Runtime::new().unwrap();
+
+        let peer_manager = make_peer_manager();
+        let pk = CommsPublicKey::default();
+        let example_peer = Peer::new(
+            pk.clone(),
+            NodeId::from_key(&pk).unwrap(),
+            vec!["127.0.0.1:9999".parse::<NetAddress>().unwrap()].into(),
+            PeerFlags::empty(),
+        );
+        peer_manager.add_peer(example_peer.clone()).unwrap();
+        let other_peer = {
+            let mut p = example_peer.clone();
+            let (_, pk) = CommsPublicKey::random_keypair(&mut OsRng::new().unwrap());
+            p.node_id = NodeId::from_key(&pk).unwrap();
+            p.public_key = pk;
+            p
+        };
+        peer_manager.add_peer(other_peer.clone()).unwrap();
+        let node_identity =
+            NodeIdentity::random(&mut OsRng::new().unwrap(), "127.0.0.1:9000".parse().unwrap()).unwrap();
+
+        let response = Arc::new(Mutex::new(Vec::new()));
+        let next_service = service_fn(|out_msg: DhtOutboundMessage| {
+            response.clone().lock().unwrap().push(out_msg);
+            future::ready(Result::<_, MiddlewareError>::Ok(()))
+        });
+
+        let mut service = BroadcastMiddleware::new(next_service, peer_manager, Arc::new(node_identity));
+
+        rt.block_on(service.call(DhtOutboundRequest::SendMsg(Box::new(SendMessageRequest {
+            broadcast_strategy: BroadcastStrategy::Flood,
+            comms_flags: MessageFlags::NONE,
+            destination: NodeDestination::Undisclosed,
+            dht_message_type: DhtMessageType::None,
+            dht_flags: DhtMessageFlags::NONE,
+            body: "custom_msg".as_bytes().to_vec(),
+        }))))
+        .unwrap();
+
+        {
+            let lock = response.lock().unwrap();
+            assert_eq!(lock.len(), 2);
+            assert!(lock
+                .iter()
+                .any(|msg| msg.peer_node_identity.node_id == example_peer.node_id));
+            assert!(lock
+                .iter()
+                .any(|msg| msg.peer_node_identity.node_id == other_peer.node_id));
+        }
+    }
+}

--- a/comms/dht/src/outbound/broadcast_strategy.rs
+++ b/comms/dht/src/outbound/broadcast_strategy.rs
@@ -1,0 +1,163 @@
+// Copyright 2019, The Tari Project
+//
+// Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+// following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+// disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+// following disclaimer in the documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+// products derived from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+// INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+// WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+// USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+use derive_error::Error;
+use std::{fmt, fmt::Formatter};
+use tari_comms::{
+    message::NodeDestination,
+    peer_manager::{node_id::NodeId, peer_manager::PeerManager, PeerManagerError},
+    types::CommsPublicKey,
+};
+
+/// The number of neighbouring nodes that a received message will be forwarded to
+pub const DHT_FORWARD_NODE_COUNT: usize = 8;
+
+#[derive(Debug, Error)]
+pub enum BroadcastStrategyError {
+    PeerManagerError(PeerManagerError),
+}
+
+#[derive(Debug, Clone)]
+pub struct ClosestRequest {
+    pub n: usize,
+    pub node_id: NodeId,
+    pub excluded_peers: Vec<CommsPublicKey>,
+}
+
+#[derive(Debug, Clone)]
+pub enum BroadcastStrategy {
+    /// Send to a particular peer matching the given node ID
+    DirectNodeId(NodeId),
+    /// Send to a particular peer matching the given Public Key
+    DirectPublicKey(CommsPublicKey),
+    /// Send to all known Communication Node peers
+    Flood,
+    /// Send to all n nearest neighbour Communication Nodes
+    Closest(ClosestRequest),
+    /// Send to a random set of peers of size n that are Communication Nodes
+    Random(usize),
+}
+
+impl fmt::Display for BroadcastStrategy {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), fmt::Error> {
+        use BroadcastStrategy::*;
+        match self {
+            DirectPublicKey(pk) => write!(f, "DirectPublicKey({})", pk),
+            DirectNodeId(node_id) => write!(f, "DirectNodeId({})", node_id),
+            Flood => write!(f, "Flood"),
+            Closest(ClosestRequest { n, .. }) => write!(f, "Closest({})", n),
+            Random(n) => write!(f, "Random({})", n),
+        }
+    }
+}
+
+// TODO: move this logic, peer manager shouldn't be passed in to broadcast strategy
+impl BroadcastStrategy {
+    pub fn direct_node_id(&self) -> Option<&NodeId> {
+        use BroadcastStrategy::*;
+        match self {
+            DirectNodeId(node_id) => Some(node_id),
+            _ => None,
+        }
+    }
+
+    pub fn direct_public_key(&self) -> Option<&CommsPublicKey> {
+        use BroadcastStrategy::*;
+        match self {
+            DirectPublicKey(pk) => Some(pk),
+            _ => None,
+        }
+    }
+
+    /// The forward function selects the most appropriate broadcast strategy based on the received messages destination
+    pub fn forward(
+        // This node's node ID
+        source_node_id: NodeId,
+        peer_manager: &PeerManager,
+        header_dest: NodeDestination<CommsPublicKey>,
+        excluded_peers: Vec<CommsPublicKey>,
+    ) -> Result<Self, BroadcastStrategyError>
+    {
+        Ok(match header_dest {
+            NodeDestination::Undisclosed => {
+                // Send to the current nodes nearest neighbours
+                BroadcastStrategy::Closest(ClosestRequest {
+                    n: DHT_FORWARD_NODE_COUNT,
+                    node_id: source_node_id,
+                    excluded_peers,
+                })
+            },
+            NodeDestination::PublicKey(dest_public_key) => {
+                if peer_manager.exists(&dest_public_key)? {
+                    // Send to destination peer directly if the current node knows that peer
+                    BroadcastStrategy::DirectPublicKey(dest_public_key)
+                } else {
+                    // Send to the current nodes nearest neighbours
+                    BroadcastStrategy::Closest(ClosestRequest {
+                        n: DHT_FORWARD_NODE_COUNT,
+                        node_id: source_node_id,
+                        excluded_peers,
+                    })
+                }
+            },
+            NodeDestination::NodeId(dest_node_id) => {
+                match peer_manager.find_with_node_id(&dest_node_id) {
+                    Ok(dest_peer) => {
+                        // Send to destination peer directly if the current node knows that peer
+                        BroadcastStrategy::DirectPublicKey(dest_peer.public_key)
+                    },
+                    Err(_) => {
+                        // Send to peers that are closest to the destination network region
+                        BroadcastStrategy::Closest(ClosestRequest {
+                            n: DHT_FORWARD_NODE_COUNT,
+                            node_id: dest_node_id,
+                            excluded_peers,
+                        })
+                    },
+                }
+            },
+        })
+    }
+
+    /// The discover function selects an appropriate broadcast strategy for the discovery of a specific node
+    pub fn discover(
+        source_node_id: NodeId,
+        dest_node_id: Option<NodeId>,
+        header_dest: NodeDestination<CommsPublicKey>,
+        excluded_peers: Vec<CommsPublicKey>,
+    ) -> Self
+    {
+        let network_location_node_id = match dest_node_id {
+            Some(node_id) => node_id,
+            None => match header_dest.clone() {
+                NodeDestination::Undisclosed => source_node_id,
+                NodeDestination::PublicKey(_) => source_node_id,
+                NodeDestination::NodeId(node_id) => node_id,
+            },
+        };
+        BroadcastStrategy::Closest(ClosestRequest {
+            n: DHT_FORWARD_NODE_COUNT,
+            node_id: network_location_node_id,
+            excluded_peers,
+        })
+    }
+}

--- a/comms/dht/src/outbound/encryption.rs
+++ b/comms/dht/src/outbound/encryption.rs
@@ -1,0 +1,172 @@
+// Copyright 2019, The Tari Project
+//
+// Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+// following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+// disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+// following disclaimer in the documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+// products derived from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+// INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+// WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+// USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+use crate::{message::DhtMessageFlags, outbound::message::DhtOutboundMessage};
+use futures::{task::Context, Future, Poll};
+use log::*;
+use std::sync::Arc;
+use tari_comms::{peer_manager::NodeIdentity, utils::crypt};
+use tari_comms_middleware::{error::box_as_middleware_error, MiddlewareError};
+use tower::{layer::Layer, Service, ServiceExt};
+
+const LOG_TARGET: &'static str = "comms::middleware::encryption";
+
+/// This layer is responsible for attempting to decrypt inbound messages.
+pub struct EncryptionLayer {
+    node_identity: Arc<NodeIdentity>,
+}
+
+impl EncryptionLayer {
+    pub fn new(node_identity: Arc<NodeIdentity>) -> Self {
+        Self { node_identity }
+    }
+}
+
+impl<S> Layer<S> for EncryptionLayer {
+    type Service = EncryptionService<S>;
+
+    fn layer(&self, service: S) -> Self::Service {
+        EncryptionService::new(service, Arc::clone(&self.node_identity))
+    }
+}
+
+/// Responsible for decrypting InboundMessages and passing a DecryptedInboundMessage to the given service
+#[derive(Clone)]
+pub struct EncryptionService<S> {
+    node_identity: Arc<NodeIdentity>,
+    inner: S,
+}
+
+impl<S> EncryptionService<S> {
+    pub fn new(service: S, node_identity: Arc<NodeIdentity>) -> Self {
+        Self {
+            inner: service,
+            node_identity,
+        }
+    }
+}
+
+impl<S> Service<DhtOutboundMessage> for EncryptionService<S>
+where
+    S: Service<DhtOutboundMessage, Response = ()> + Clone,
+    S::Error: Into<MiddlewareError>,
+{
+    type Error = MiddlewareError;
+    type Response = ();
+
+    type Future = impl Future<Output = Result<Self::Response, Self::Error>>;
+
+    fn poll_ready(&mut self, _: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        Poll::Ready(Ok(()))
+    }
+
+    fn call(&mut self, msg: DhtOutboundMessage) -> Self::Future {
+        Self::handle_message(self.inner.clone(), Arc::clone(&self.node_identity), msg)
+    }
+}
+
+impl<S> EncryptionService<S>
+where
+    S: Service<DhtOutboundMessage, Response = ()>,
+    S::Error: Into<MiddlewareError>,
+{
+    async fn handle_message(
+        mut next_service: S,
+        node_identity: Arc<NodeIdentity>,
+        mut message: DhtOutboundMessage,
+    ) -> Result<(), MiddlewareError>
+    {
+        if message.dht_header.flags.contains(DhtMessageFlags::ENCRYPTED) {
+            debug!(target: LOG_TARGET, "Encrypting message");
+            let shared_secret = crypt::generate_ecdh_secret(&node_identity.secret_key, &message.destination_public_key);
+            let encrypted = crypt::encrypt(&shared_secret, &message.body).map_err(box_as_middleware_error)?;
+            message.body = encrypted;
+        }
+
+        next_service.ready().await.map_err(Into::into)?;
+        next_service.call(message).await.map_err(Into::into)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::{
+        message::DhtMessageFlags,
+        test_utils::{make_dht_header, make_node_identity, service_spy},
+    };
+    use futures::executor::block_on;
+    use tari_comms::{
+        message::MessageFlags,
+        peer_manager::{NodeId, PeerNodeIdentity},
+        types::CommsPublicKey,
+    };
+    use tari_test_utils::panic_context;
+
+    #[test]
+    fn no_encryption() {
+        let spy = service_spy();
+        let node_identity = make_node_identity();
+        let mut encryption = EncryptionLayer::new(Arc::clone(&node_identity)).layer(spy.service::<MiddlewareError>());
+
+        panic_context!(cx);
+        assert!(encryption.poll_ready(&mut cx).is_ready());
+
+        let body = b"A".to_vec();
+        let msg = DhtOutboundMessage::new(
+            PeerNodeIdentity::new(NodeId::default(), CommsPublicKey::default()),
+            make_dht_header(&node_identity, &body, DhtMessageFlags::empty()),
+            CommsPublicKey::default(),
+            MessageFlags::empty(),
+            body.clone(),
+        );
+        block_on(encryption.call(msg)).unwrap();
+
+        let msg = spy.pop_request().unwrap();
+        assert_eq!(msg.body, body);
+        assert_eq!(msg.peer_node_identity.node_id, NodeId::default());
+    }
+
+    #[test]
+    fn encryption() {
+        let spy = service_spy();
+        let node_identity = make_node_identity();
+        let mut encryption = EncryptionLayer::new(Arc::clone(&node_identity)).layer(spy.service::<MiddlewareError>());
+
+        panic_context!(cx);
+        assert!(encryption.poll_ready(&mut cx).is_ready());
+
+        let body = b"A".to_vec();
+        let msg = DhtOutboundMessage::new(
+            PeerNodeIdentity::new(NodeId::default(), CommsPublicKey::default()),
+            make_dht_header(&node_identity, &body, DhtMessageFlags::ENCRYPTED),
+            CommsPublicKey::default(),
+            MessageFlags::empty(),
+            body.clone(),
+        );
+        block_on(encryption.call(msg)).unwrap();
+
+        let msg = spy.pop_request().unwrap();
+        assert_ne!(msg.body, body);
+        assert_eq!(msg.peer_node_identity.node_id, NodeId::default());
+    }
+}

--- a/comms/dht/src/outbound/error.rs
+++ b/comms/dht/src/outbound/error.rs
@@ -1,0 +1,40 @@
+// Copyright 2019, The Tari Project
+//
+// Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+// following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+// disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+// following disclaimer in the documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+// products derived from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+// INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+// WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+// USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+use derive_error::Error;
+use futures::channel::mpsc::SendError;
+use tari_comms::{connection::ConnectionError, message::MessageError, peer_manager::PeerManagerError};
+use tari_comms_middleware::impl_into_middleware_error;
+use tari_crypto::signatures::SchnorrSignatureError;
+use tari_utilities::message_format::MessageFormatError;
+
+#[derive(Debug, Error)]
+pub enum DhtOutboundError {
+    SendError(SendError),
+    MessageSerializationError(MessageError),
+    MessageFormatError(MessageFormatError),
+    PeerManagerError(PeerManagerError),
+    ConnectionError(ConnectionError),
+    SignatureError(SchnorrSignatureError),
+}
+
+impl_into_middleware_error!(DhtOutboundError);

--- a/comms/dht/src/outbound/message.rs
+++ b/comms/dht/src/outbound/message.rs
@@ -1,0 +1,107 @@
+// Copyright 2019, The Tari Project
+//
+// Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+// following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+// disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+// following disclaimer in the documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+// products derived from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+// INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+// WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+// USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+use super::broadcast_strategy::BroadcastStrategy;
+use crate::message::{DhtHeader, DhtMessageFlags, DhtMessageType};
+use std::fmt;
+use tari_comms::{
+    message::{MessageFlags, NodeDestination},
+    peer_manager::PeerNodeIdentity,
+    types::CommsPublicKey,
+};
+
+#[derive(Debug, Clone)]
+pub struct SendMessageRequest {
+    /// Broadcast strategy to use when sending the message
+    pub broadcast_strategy: BroadcastStrategy,
+    /// The intended destination for this message
+    pub destination: NodeDestination<CommsPublicKey>,
+    /// Comms-level message flags
+    pub comms_flags: MessageFlags,
+    /// Dht-level message flags
+    pub dht_flags: DhtMessageFlags,
+    /// Dht-level message type (`DhtMessageType::None` for a non-DHT message)
+    pub dht_message_type: DhtMessageType,
+    /// Message body
+    pub body: Vec<u8>,
+}
+
+#[derive(Debug, Clone)]
+pub struct ForwardRequest {
+    /// Broadcast strategy to use when forwarding the message
+    pub broadcast_strategy: BroadcastStrategy,
+    /// Original header from the origin
+    pub dht_header: DhtHeader,
+    /// Comms-level message flags
+    pub comms_flags: MessageFlags,
+    /// Message body
+    pub body: Vec<u8>,
+}
+
+/// Represents requests to the CommsOutboundService
+#[derive(Debug)]
+pub enum DhtOutboundRequest {
+    /// Send a message using the given broadcast strategy
+    SendMsg(Box<SendMessageRequest>),
+    /// Forward a message envelope
+    Forward(Box<ForwardRequest>),
+}
+
+impl fmt::Display for DhtOutboundRequest {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
+        match self {
+            DhtOutboundRequest::SendMsg(request) => write!(f, "SendMsg({})", request.broadcast_strategy),
+            DhtOutboundRequest::Forward(request) => write!(f, "Forward({})", request.broadcast_strategy),
+        }
+    }
+}
+
+/// The DhtOutboundMessage has a copy of the MessageEnvelope. OutboundMessageService will create the
+/// DhtOutboundMessage and forward it to the OutboundMessagePool.
+#[derive(Clone, Debug)]
+pub struct DhtOutboundMessage {
+    pub peer_node_identity: PeerNodeIdentity,
+    pub dht_header: DhtHeader,
+    pub comms_flags: MessageFlags,
+    pub destination_public_key: CommsPublicKey,
+    pub body: Vec<u8>,
+}
+
+impl DhtOutboundMessage {
+    /// Create a new DhtOutboundMessage from the peer_node_identity and message_frames
+    pub fn new(
+        peer_node_identity: PeerNodeIdentity,
+        dht_header: DhtHeader,
+        destination_public_key: CommsPublicKey,
+        comms_flags: MessageFlags,
+        body: Vec<u8>,
+    ) -> Self
+    {
+        Self {
+            peer_node_identity,
+            dht_header,
+            destination_public_key,
+            comms_flags,
+            body,
+        }
+    }
+}

--- a/comms/dht/src/outbound/mod.rs
+++ b/comms/dht/src/outbound/mod.rs
@@ -1,0 +1,39 @@
+// Copyright 2019, The Tari Project
+//
+// Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+// following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+// disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+// following disclaimer in the documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+// products derived from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+// INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+// WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+// USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+mod broadcast;
+mod broadcast_strategy;
+mod encryption;
+mod error;
+mod message;
+mod requester;
+mod serialize;
+
+pub use self::{
+    broadcast::BroadcastLayer,
+    broadcast_strategy::{BroadcastStrategy, BroadcastStrategyError},
+    encryption::EncryptionLayer,
+    error::DhtOutboundError,
+    message::DhtOutboundRequest,
+    requester::OutboundMessageRequester,
+    serialize::SerializeLayer,
+};

--- a/comms/dht/src/outbound/requester.rs
+++ b/comms/dht/src/outbound/requester.rs
@@ -1,0 +1,138 @@
+// Copyright 2019, The Tari Project
+//
+// Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+// following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+// disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+// following disclaimer in the documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+// products derived from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+// INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+// WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+// USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+use super::{broadcast_strategy::BroadcastStrategy, message::DhtOutboundRequest};
+use crate::{
+    message::{DhtHeader, DhtMessageFlags, DhtMessageType},
+    outbound::{
+        message::{ForwardRequest, SendMessageRequest},
+        DhtOutboundError,
+    },
+};
+use futures::{channel::mpsc, SinkExt};
+use tari_comms::{
+    message::{Frame, Message, MessageFlags, MessageHeader, NodeDestination},
+    types::CommsPublicKey,
+};
+use tari_utilities::message_format::MessageFormat;
+
+#[derive(Clone)]
+pub struct OutboundMessageRequester {
+    sender: mpsc::Sender<DhtOutboundRequest>,
+}
+
+impl OutboundMessageRequester {
+    pub fn new(sender: mpsc::Sender<DhtOutboundRequest>) -> Self {
+        Self { sender }
+    }
+
+    /// Send a message
+    pub async fn send_message<T, MType>(
+        &mut self,
+        broadcast_strategy: BroadcastStrategy,
+        destination: NodeDestination<CommsPublicKey>,
+        dht_flags: DhtMessageFlags,
+        message_type: MType,
+        message: T,
+    ) -> Result<(), DhtOutboundError>
+    where
+        MessageHeader<MType>: MessageFormat,
+        T: MessageFormat,
+    {
+        let body = serialize_message(message_type, message)?;
+        self.send_raw(broadcast_strategy, destination, dht_flags, DhtMessageType::None, body)
+            .await
+    }
+
+    /// Send a DHT-level message
+    pub async fn send_dht_message<T>(
+        &mut self,
+        broadcast_strategy: BroadcastStrategy,
+        destination: NodeDestination<CommsPublicKey>,
+        dht_flags: DhtMessageFlags,
+        message_type: DhtMessageType,
+        message: T,
+    ) -> Result<(), DhtOutboundError>
+    where
+        T: MessageFormat,
+    {
+        let body = serialize_message(message_type.clone(), message)?;
+        self.send_raw(broadcast_strategy, destination, dht_flags, message_type, body)
+            .await
+    }
+
+    /// Send a raw message
+    pub async fn send_raw(
+        &mut self,
+        broadcast_strategy: BroadcastStrategy,
+        destination: NodeDestination<CommsPublicKey>,
+        dht_flags: DhtMessageFlags,
+        dht_message_type: DhtMessageType,
+        body: Frame,
+    ) -> Result<(), DhtOutboundError>
+    {
+        self.sender
+            .send(DhtOutboundRequest::SendMsg(Box::new(SendMessageRequest {
+                broadcast_strategy,
+                destination,
+                // Since NONE is the only option here, hard code to empty() rather than make this part of the public
+                // interface. If comms-level message flags become useful, it should be easy to add that to the public
+                // API from here up to domain-level
+                comms_flags: MessageFlags::empty(),
+                dht_flags,
+                dht_message_type,
+                body,
+            })))
+            .await
+            .map_err(Into::into)
+    }
+
+    /// Forward a message
+    pub async fn forward_message(
+        &mut self,
+        broadcast_strategy: BroadcastStrategy,
+        dht_header: DhtHeader,
+        body: Vec<u8>,
+    ) -> Result<(), DhtOutboundError>
+    {
+        self.sender
+            .send(DhtOutboundRequest::Forward(Box::new(ForwardRequest {
+                broadcast_strategy,
+                comms_flags: MessageFlags::empty(),
+                dht_header,
+                body,
+            })))
+            .await
+            .map_err(Into::into)
+    }
+}
+
+fn serialize_message<T, MType>(message_type: MType, message: T) -> Result<Vec<u8>, DhtOutboundError>
+where
+    T: MessageFormat,
+    MessageHeader<MType>: MessageFormat,
+{
+    let header = MessageHeader::new(message_type)?;
+    let msg = Message::from_message_format(header, message)?;
+
+    msg.to_binary().map_err(Into::into)
+}

--- a/comms/dht/src/outbound/serialize.rs
+++ b/comms/dht/src/outbound/serialize.rs
@@ -1,0 +1,165 @@
+// Copyright 2019, The Tari Project
+//
+// Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+// following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+// disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+// following disclaimer in the documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+// products derived from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+// INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+// WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+// USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+use crate::{consts::DHT_RNG, message::DhtEnvelope, outbound::message::DhtOutboundMessage};
+use futures::{task::Context, Future, Poll};
+use log::*;
+use std::sync::Arc;
+use tari_comms::{outbound_message_service::OutboundMessage, peer_manager::NodeIdentity, utils::signature};
+use tari_comms_middleware::{error::box_as_middleware_error, MiddlewareError};
+use tari_utilities::message_format::MessageFormat;
+use tower::{layer::Layer, Service, ServiceExt};
+
+const LOG_TARGET: &'static str = "comms::dht::deserialize";
+
+#[derive(Clone)]
+pub struct SerializeMiddleware<S> {
+    inner: S,
+    node_identity: Arc<NodeIdentity>,
+}
+
+impl<S> SerializeMiddleware<S> {
+    pub fn new(service: S, node_identity: Arc<NodeIdentity>) -> Self {
+        Self {
+            inner: service,
+            node_identity,
+        }
+    }
+}
+
+impl<S> Service<DhtOutboundMessage> for SerializeMiddleware<S>
+where
+    S: Service<OutboundMessage, Response = ()> + Clone + 'static,
+    S::Error: Into<MiddlewareError>,
+{
+    type Error = MiddlewareError;
+    type Response = ();
+
+    type Future = impl Future<Output = Result<Self::Response, Self::Error>>;
+
+    fn poll_ready(&mut self, _: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        Poll::Ready(Ok(()))
+    }
+
+    fn call(&mut self, msg: DhtOutboundMessage) -> Self::Future {
+        Self::serialize(self.inner.clone(), Arc::clone(&self.node_identity), msg)
+    }
+}
+
+impl<S> SerializeMiddleware<S>
+where
+    S: Service<OutboundMessage, Response = ()>,
+    S::Error: Into<MiddlewareError>,
+{
+    pub async fn serialize(
+        mut next_service: S,
+        node_identity: Arc<NodeIdentity>,
+        message: DhtOutboundMessage,
+    ) -> Result<(), MiddlewareError>
+    {
+        trace!(target: LOG_TARGET, "Serializing DhtOutboundMessage");
+        next_service.ready().await.map_err(Into::into)?;
+
+        let mut rng = DHT_RNG.with(|rng| rng.clone());
+
+        let DhtOutboundMessage {
+            mut dht_header,
+            body,
+            peer_node_identity,
+            comms_flags,
+            ..
+        } = message;
+
+        // Sign the body
+        let signature =
+            signature::sign(&mut rng, node_identity.secret_key.clone(), &*body).map_err(box_as_middleware_error)?;
+        dht_header.origin_signature = signature.to_binary().map_err(box_as_middleware_error)?;
+
+        let envelope = DhtEnvelope::new(dht_header, body);
+
+        let body = envelope.to_binary().map_err(box_as_middleware_error)?;
+
+        next_service
+            .call(OutboundMessage::new(peer_node_identity.node_id, comms_flags, body))
+            .await
+            .map_err(Into::into)
+    }
+}
+
+pub struct SerializeLayer {
+    node_identity: Arc<NodeIdentity>,
+}
+
+impl SerializeLayer {
+    pub fn new(node_identity: Arc<NodeIdentity>) -> Self {
+        Self { node_identity }
+    }
+}
+
+impl<S> Layer<S> for SerializeLayer {
+    type Service = SerializeMiddleware<S>;
+
+    fn layer(&self, service: S) -> Self::Service {
+        SerializeMiddleware::new(service, Arc::clone(&self.node_identity))
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::{
+        message::DhtMessageFlags,
+        test_utils::{make_dht_header, make_node_identity, service_spy},
+    };
+    use futures::executor::block_on;
+    use tari_comms::{
+        message::MessageFlags,
+        peer_manager::{NodeId, PeerNodeIdentity},
+        types::CommsPublicKey,
+    };
+    use tari_test_utils::panic_context;
+
+    #[test]
+    fn serialize() {
+        let spy = service_spy();
+        let node_identity = make_node_identity();
+        let mut serialize = SerializeLayer::new(Arc::clone(&node_identity)).layer(spy.service::<MiddlewareError>());
+
+        panic_context!(cx);
+
+        assert!(serialize.poll_ready(&mut cx).is_ready());
+        let body = b"A".to_vec();
+        let msg = DhtOutboundMessage::new(
+            PeerNodeIdentity::new(NodeId::default(), CommsPublicKey::default()),
+            make_dht_header(&node_identity, &body, DhtMessageFlags::empty()),
+            CommsPublicKey::default(),
+            MessageFlags::empty(),
+            body,
+        );
+        block_on(serialize.call(msg)).unwrap();
+
+        let msg = spy.pop_request().unwrap();
+        let dht_envelope = DhtEnvelope::from_binary(&msg.body).unwrap();
+        assert_eq!(dht_envelope.body, b"A".to_vec());
+        assert_eq!(msg.peer_node_id, NodeId::default());
+    }
+}


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR adds the vaious outbound DHT middleware components.

The module is currently not part of the module tree as
there are a number of changes to the comms and tari_middleware
crates that need to go along with it.

Overview of middleware architecture

The tari_comms_dht crate adds DHT functionality to tari_comms.
It provides two sets of middleware (inbound and outbound) which
process incoming requests and outgoing messages respectively.

Attaching to comms

In tari_comms, incoming and outgoing messages are connected using two mpsc sender/receiver pairs.
One for incoming messages (receiving InboundMessages) and one for outbound messages (sending OutboundMessages).

The DHT module consists of two middleware layers (as in tower_layer::Layer) which form
an inbound and outbound pipeline for augmenting messages.

 Outbound Message Flow

`OutboundMessage`s are sent to the outgoing comms channel (as in the receiver side of
of the mpsc channel which goes into `CommsBuilder::new().outgoing_message_stream(receiver)`).
Typically, a `ServicePipeline` from the `tari_comms_middleware` crate is used to connect
a stream from the domain-level to the middleware service and a `SinkMiddleware` to connect
the middleware to the OMS in comms. Outbound requests to the DHT middleware are furnished by
the `OutboundMessageRequester`, obtained from the `Dht::outbound_requester` factory method.

`DhtOutboundRequest` (domain) -> _DHT Outbound Middleware_ -> `OutboundMessage` (comms)

The DHT outbound middleware consist of:
* `BroadcastMiddleware` produces multiple outbound messages according on the `BroadcastStrategy` from the received
`DhtOutboundRequest` message. The `next_service` is called for each resulting message.
* `EncryptionMiddleware` encrypts the body of a message if `DhtMessagheFlags::ENCRYPTED` is given. The result is
passed onto the `next_service`.
* `SerializeMiddleware` wraps the body in a `DhtEnvelope`, serializes the result, constructs an `OutboundMessage`
and calls `next_service`. Typically, `next_service` will be a `SinkMiddleware` which send the message to the comms
OMS.


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Ref #621
Ref #675

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Middlewares have unit tests although they will only be connected in subsequent PRs

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [x] Breaking change (fix or feature that would cause existing functionality to change)
* [x] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch
* [x] I ran `cargo-fmt --all` before pushing
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
