### PR TITLE
Add path helpers to tari_test_utils (DRYer tests)

### DIFF
--- a/infrastructure/test_utils/src/lib.rs
+++ b/infrastructure/test_utils/src/lib.rs
@@ -5,5 +5,8 @@
 //! ## Modules
 //!
 //! - `futures` - Contains utilities which make testing future-based code easier
+//! - `paths` - Contains utilities which return and create paths which are useful for tests involving files
+//! - `random` - Contains utilities to making generating random values easier
 pub mod futures;
+pub mod paths;
 pub mod random;

--- a/infrastructure/test_utils/src/paths.rs
+++ b/infrastructure/test_utils/src/paths.rs
@@ -1,0 +1,40 @@
+// Copyright 2019, The Tari Project
+//
+// Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+// following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+// disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+// following disclaimer in the documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+// products derived from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+// INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+// WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+// USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+use crate::random;
+use std::{fs, path::PathBuf};
+
+pub const RELATIVE_DATA_PATH: &'static str = "tests/data";
+
+pub fn create_random_database_path() -> PathBuf {
+    let path = database_path().join(random::string(8));
+    fs::create_dir_all(&path).unwrap();
+    path
+}
+
+pub fn database_path() -> PathBuf {
+    cargo_path().join(RELATIVE_DATA_PATH)
+}
+
+pub fn cargo_path() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+}


### PR DESCRIPTION
These are useful when creating temporary database paths which are (still) needed for peer manager.

- cargo_path returns the path to the cargo manifest dir
- database_path returns the test data path
- create_random_database_path creates a random path in the database_path and return it
