### PR TITLE
Changed ArrayLike to return results

### DIFF
--- a/base_layer/core/src/chain_storage/memory_db.rs
+++ b/base_layer/core/src/chain_storage/memory_db.rs
@@ -268,10 +268,10 @@ where D: Digest + Send + Sync
     fn fetch_mmr_root(&self, tree: MmrTree) -> Result<Vec<u8>, ChainStorageError> {
         let db = self.db_access()?;
         let root = match tree {
-            MmrTree::Utxo => db.utxo_mmr.get_merkle_root(),
-            MmrTree::Kernel => db.kernel_mmr.get_merkle_root(),
-            MmrTree::RangeProof => db.range_proof_mmr.get_merkle_root(),
-            MmrTree::Header => db.header_mmr.get_merkle_root(),
+            MmrTree::Utxo => db.utxo_mmr.get_merkle_root()?,
+            MmrTree::Kernel => db.kernel_mmr.get_merkle_root()?,
+            MmrTree::RangeProof => db.range_proof_mmr.get_merkle_root()?,
+            MmrTree::Header => db.header_mmr.get_merkle_root()?,
         };
         Ok(root)
     }
@@ -279,10 +279,10 @@ where D: Digest + Send + Sync
     fn fetch_mmr_only_root(&self, tree: MmrTree) -> Result<Vec<u8>, ChainStorageError> {
         let db = self.db_access()?;
         let root = match tree {
-            MmrTree::Utxo => db.utxo_mmr.get_mmr_only_root(),
-            MmrTree::Kernel => db.kernel_mmr.get_mmr_only_root(),
-            MmrTree::RangeProof => db.range_proof_mmr.get_mmr_only_root(),
-            MmrTree::Header => db.header_mmr.get_mmr_only_root(),
+            MmrTree::Utxo => db.utxo_mmr.get_mmr_only_root()?,
+            MmrTree::Kernel => db.kernel_mmr.get_mmr_only_root()?,
+            MmrTree::RangeProof => db.range_proof_mmr.get_mmr_only_root()?,
+            MmrTree::Header => db.header_mmr.get_mmr_only_root()?,
         };
         Ok(root)
     }
@@ -315,10 +315,10 @@ where D: Digest + Send + Sync
     fn fetch_mmr_node(&self, tree: MmrTree, pos: u32) -> Result<(Vec<u8>, bool), ChainStorageError> {
         let db = self.db_access()?;
         let (hash, deleted) = match tree {
-            MmrTree::Kernel => db.kernel_mmr.get_leaf_status(pos),
-            MmrTree::Header => db.header_mmr.get_leaf_status(pos),
-            MmrTree::Utxo => db.utxo_mmr.get_leaf_status(pos),
-            MmrTree::RangeProof => db.range_proof_mmr.get_leaf_status(pos),
+            MmrTree::Kernel => db.kernel_mmr.get_leaf_status(pos)?,
+            MmrTree::Header => db.header_mmr.get_leaf_status(pos)?,
+            MmrTree::Utxo => db.utxo_mmr.get_leaf_status(pos)?,
+            MmrTree::RangeProof => db.range_proof_mmr.get_leaf_status(pos)?,
         };
         let hash = hash
             .ok_or(ChainStorageError::UnexpectedResult(format!(

--- a/base_layer/core/src/chain_storage/test/chain_storage.rs
+++ b/base_layer/core/src/chain_storage/test/chain_storage.rs
@@ -193,8 +193,8 @@ fn utxo_and_rp_merkle_root() {
     let mut mmr_check = MutableMmr::<HashDigest, _>::new(Vec::new());
     assert!(mmr_check.push(&hash1).is_ok());
     assert!(mmr_check.push(&hash2).is_ok());
-    assert_eq!(root.to_hex(), mmr_check.get_merkle_root().to_hex());
-    assert_eq!(rp_root.to_hex(), rp_mmr_check.get_merkle_root().to_hex());
+    assert_eq!(root.to_hex(), mmr_check.get_merkle_root().unwrap().to_hex());
+    assert_eq!(rp_root.to_hex(), rp_mmr_check.get_merkle_root().unwrap().to_hex());
 }
 
 #[test]
@@ -219,7 +219,7 @@ fn header_merkle_root() {
     let mut mmr_check = MutableMmr::<HashDigest, _>::new(Vec::new());
     assert!(mmr_check.push(&hash1).is_ok());
     assert!(mmr_check.push(&hash2).is_ok());
-    assert_eq!(root.to_hex(), mmr_check.get_merkle_root().to_hex());
+    assert_eq!(root.to_hex(), mmr_check.get_merkle_root().unwrap().to_hex());
 }
 
 #[test]
@@ -247,7 +247,7 @@ fn kernel_merkle_root() {
     assert!(mmr_check.push(&hash1).is_ok());
     assert!(mmr_check.push(&hash2).is_ok());
     assert!(mmr_check.push(&hash3).is_ok());
-    assert_eq!(root.to_hex(), mmr_check.get_merkle_root().to_hex());
+    assert_eq!(root.to_hex(), mmr_check.get_merkle_root().unwrap().to_hex());
 }
 
 #[test]

--- a/base_layer/mmr/src/backend.rs
+++ b/base_layer/mmr/src/backend.rs
@@ -28,13 +28,13 @@ pub trait ArrayLike {
     type Error: std::error::Error;
 
     /// Returns the number of hashes stored in the backend
-    fn len(&self) -> usize;
+    fn len(&self) -> Result<usize, Self::Error>;
 
     /// Store a new item and return the index of the stored item
     fn push(&mut self, item: Self::Value) -> Result<usize, Self::Error>;
 
     /// Return the item at the given index
-    fn get(&self, index: usize) -> Option<Self::Value>;
+    fn get(&self, index: usize) -> Result<Option<Self::Value>, Self::Error>;
 
     /// Return the item at the given index. Use this if you *know* that the index is valid. Requesting a hash for an
     /// invalid index may cause the a panic
@@ -56,8 +56,8 @@ impl<T: Clone> ArrayLike for Vec<T> {
     type Error = MerkleMountainRangeError;
     type Value = T;
 
-    fn len(&self) -> usize {
-        Vec::len(self)
+    fn len(&self) -> Result<usize, Self::Error> {
+        Ok(Vec::len(self))
     }
 
     fn push(&mut self, item: Self::Value) -> Result<usize, Self::Error> {
@@ -65,8 +65,8 @@ impl<T: Clone> ArrayLike for Vec<T> {
         Ok(self.len() - 1)
     }
 
-    fn get(&self, index: usize) -> Option<Self::Value> {
-        (self as &[Self::Value]).get(index).map(Clone::clone)
+    fn get(&self, index: usize) -> Result<Option<Self::Value>, Self::Error> {
+        Ok((self as &[Self::Value]).get(index).map(Clone::clone))
     }
 
     fn get_or_panic(&self, index: usize) -> Self::Value {

--- a/base_layer/mmr/src/error.rs
+++ b/base_layer/mmr/src/error.rs
@@ -22,12 +22,13 @@
 
 use derive_error::Error;
 
-#[derive(Debug, Clone, Error, PartialEq)]
+#[derive(Debug, Error, PartialEq, Clone)]
 pub enum MerkleMountainRangeError {
     // The next position was not a leaf node as expected
     CorruptDataStructure,
-    // Failed to add a new hash to the backend
-    BackendPushError,
+    // A problem has been encountered with the backend
+    #[error(non_std, no_from)]
+    BackendError(String),
     // The Merkle tree is not internally consistent. A parent hash isn't equal to the hash of its children
     InvalidMerkleTree,
     // The tree has reached its maximum size

--- a/base_layer/mmr/tests/change_tracker.rs
+++ b/base_layer/mmr/tests/change_tracker.rs
@@ -31,8 +31,8 @@ use tari_utilities::hex::Hex;
 fn change_tracker() {
     let mmr = MutableMmr::<Hasher, _>::new(Vec::default());
     let mmr = MerkleChangeTracker::new(mmr, Vec::new()).unwrap();
-    assert_eq!(mmr.checkpoint_count(), 0);
-    assert!(mmr.is_empty());
+    assert_eq!(mmr.checkpoint_count(), Ok(0));
+    assert_eq!(mmr.is_empty(), Ok(true));
 }
 
 #[test]
@@ -45,11 +45,11 @@ fn checkpoints() {
         assert!(mmr.push(&int_to_hash(i)).is_ok());
     }
     assert_eq!(mmr.len(), 5);
-    assert_eq!(mmr.checkpoint_count(), 0);
+    assert_eq!(mmr.checkpoint_count(), Ok(0));
     //----------- Commit the history thus far  -----------------------------------
     assert!(mmr.commit().is_ok());
-    assert_eq!(mmr.checkpoint_count(), 1);
-    let root_at_1 = mmr.get_merkle_root();
+    assert_eq!(mmr.checkpoint_count(), Ok(1));
+    let root_at_1 = mmr.get_merkle_root().unwrap();
     assert_eq!(
         &root_at_1.to_hex(),
         "7b7ddec2af4f3d0b9b165750cf2ff15813e965d29ecd5318e0c8fea901ceaef4"
@@ -60,40 +60,40 @@ fn checkpoints() {
     assert!(mmr.delete_and_compress(2, false));
     assert!(mmr.delete_and_compress(4, true));
     //----------- Commit the history again, and check the expected sizes  --------
-    let root_at_2 = mmr.get_merkle_root();
+    let root_at_2 = mmr.get_merkle_root().unwrap();
     assert_eq!(
         &root_at_2.to_hex(),
         "69e69ba0c6222f2d9caa68282de0ba7f1259a0fa2b8d84af68f907ef4ec05054"
     );
     assert!(mmr.commit().is_ok());
     assert_eq!(mmr.len(), 3);
-    assert_eq!(mmr.checkpoint_count(), 2);
+    assert_eq!(mmr.checkpoint_count(), Ok(2));
     //----------- Generate another checkpoint, the MMR is now empty  --------
     assert!(mmr.delete_and_compress(1, false));
     assert!(mmr.delete_and_compress(5, false));
     assert!(mmr.delete(3));
     assert!(mmr.commit().is_ok());
-    assert!(mmr.is_empty());
-    assert_eq!(mmr.checkpoint_count(), 3);
-    let root = mmr.get_merkle_root();
+    assert_eq!(mmr.is_empty(), Ok(true));
+    assert_eq!(mmr.checkpoint_count(), Ok(3));
+    let root = mmr.get_merkle_root().unwrap();
     assert_eq!(
         &root.to_hex(),
         "2a540797d919e63cff8051e54ae13197315000bcfde53efd3f711bb3d24995bc"
     );
     //----------- Create an empty checkpoint -------------------------------
     assert!(mmr.commit().is_ok());
-    assert_eq!(mmr.checkpoint_count(), 4);
+    assert_eq!(mmr.checkpoint_count(), Ok(4));
     assert_eq!(
-        &mmr.get_merkle_root().to_hex(),
+        &mmr.get_merkle_root().unwrap().to_hex(),
         "2a540797d919e63cff8051e54ae13197315000bcfde53efd3f711bb3d24995bc"
     );
     //----------- Rewind the MMR two commits----------------------------------
     assert!(mmr.rewind(2).is_ok());
-    assert_eq!(mmr.get_merkle_root().to_hex(), root_at_2.to_hex());
+    assert_eq!(mmr.get_merkle_root().unwrap().to_hex(), root_at_2.to_hex());
     //----------- Perform an empty commit ------------------------------------
     assert!(mmr.commit().is_ok());
     assert_eq!(mmr.len(), 3);
-    assert_eq!(mmr.checkpoint_count(), 3);
+    assert_eq!(mmr.checkpoint_count(), Ok(3));
 }
 
 #[test]

--- a/base_layer/mmr/tests/merkle_mountain_range.rs
+++ b/base_layer/mmr/tests/merkle_mountain_range.rs
@@ -30,10 +30,10 @@ use tari_mmr::MerkleMountainRange;
 #[test]
 fn zero_length_mmr() {
     let mmr = MerkleMountainRange::<Hasher, _>::new(Vec::default());
-    assert_eq!(mmr.len(), 0);
-    assert!(mmr.is_empty());
+    assert_eq!(mmr.len(), Ok(0));
+    assert_eq!(mmr.is_empty(), Ok(true));
     let empty_hash = Hasher::digest(b"").to_vec();
-    assert_eq!(&mmr.get_merkle_root(), &empty_hash);
+    assert_eq!(mmr.get_merkle_root(), Ok(empty_hash));
 }
 
 /// Successively build up an MMR and check that the roots, heights and indices are all correct.
@@ -45,16 +45,16 @@ fn build_mmr() {
 
     assert!(mmr.push(&h0).is_ok());
     // The root of a single hash is the hash of that hash
-    assert_eq!(mmr.len(), 1);
-    assert_eq!(mmr.get_merkle_root(), combine_hashes(&[&h0]));
+    assert_eq!(mmr.len(), Ok(1));
+    assert_eq!(mmr.get_merkle_root(), Ok(combine_hashes(&[&h0])));
     // Two leaf item items:
     //    2
     //  0   1
     let h1 = int_to_hash(1);
     assert!(mmr.push(&h1).is_ok());
     let h_2 = combine_hashes(&[&h0, &h1]);
-    assert_eq!(mmr.get_merkle_root(), combine_hashes(&[&h_2]));
-    assert_eq!(mmr.len(), 3);
+    assert_eq!(mmr.get_merkle_root(), Ok(combine_hashes(&[&h_2])));
+    assert_eq!(mmr.len(), Ok(3));
     // Three leaf item items:
     //    2
     //  0   1  3
@@ -62,8 +62,8 @@ fn build_mmr() {
     assert!(mmr.push(&h3).is_ok());
     // The root is a bagged root
     let root = combine_hashes(&[&h_2, &h3]);
-    assert_eq!(mmr.get_merkle_root(), root);
-    assert_eq!(mmr.len(), 4);
+    assert_eq!(mmr.get_merkle_root(), Ok(root));
+    assert_eq!(mmr.len(), Ok(4));
     // Four leaf items:
     //        6
     //    2      5
@@ -72,8 +72,8 @@ fn build_mmr() {
     assert!(mmr.push(&h4).is_ok());
     let h_5 = combine_hashes(&[&h3, &h4]);
     let h_6 = combine_hashes(&[&h_2, &h_5]);
-    assert_eq!(mmr.get_merkle_root(), combine_hashes(&[&h_6]));
-    assert_eq!(mmr.len(), 7);
+    assert_eq!(mmr.get_merkle_root(), Ok(combine_hashes(&[&h_6])));
+    assert_eq!(mmr.len(), Ok(7));
     // Five leaf items:
     //        6
     //    2      5
@@ -81,8 +81,8 @@ fn build_mmr() {
     let h7 = int_to_hash(7);
     assert!(mmr.push(&h7).is_ok());
     let root = combine_hashes(&[&h_6, &h7]);
-    assert_eq!(mmr.get_merkle_root(), root);
-    assert_eq!(mmr.len(), 8);
+    assert_eq!(mmr.get_merkle_root(), Ok(root));
+    assert_eq!(mmr.len(), Ok(8));
     // Six leaf item items:
     //        6
     //    2      5      9
@@ -91,8 +91,8 @@ fn build_mmr() {
     let h_9 = combine_hashes(&[&h7, &h8]);
     assert!(mmr.push(&h8).is_ok());
     let root = combine_hashes(&[&h_6, &h_9]);
-    assert_eq!(mmr.get_merkle_root(), root);
-    assert_eq!(mmr.len(), 10);
+    assert_eq!(mmr.get_merkle_root(), Ok(root));
+    assert_eq!(mmr.len(), Ok(10));
 }
 
 #[test]

--- a/base_layer/mmr/tests/merkle_proof.rs
+++ b/base_layer/mmr/tests/merkle_proof.rs
@@ -45,9 +45,9 @@ fn zero_size_mmr() {
 fn merkle_proof_small_mmrs() {
     for size in 1..32 {
         let mmr = create_mmr(size);
-        let root = mmr.get_merkle_root();
+        let root = mmr.get_merkle_root().unwrap();
         let mut hash_value = 0usize;
-        for pos in 0..mmr.len() {
+        for pos in 0..mmr.len().unwrap() {
             if is_leaf(pos) {
                 let hash = int_to_hash(hash_value);
                 hash_value += 1;
@@ -64,7 +64,7 @@ fn merkle_proof_small_mmrs() {
 fn med_mmr() {
     let size = 500;
     let mmr = create_mmr(size);
-    let root = mmr.get_merkle_root();
+    let root = mmr.get_merkle_root().unwrap();
     let i = 499;
     let pos = leaf_index(i);
     let hash = int_to_hash(i);
@@ -77,7 +77,7 @@ fn a_big_proof() {
     let mmr = create_mmr(100_000);
     let leaf_pos = 28_543;
     let mmr_index = leaf_index(leaf_pos);
-    let root = mmr.get_merkle_root();
+    let root = mmr.get_merkle_root().unwrap();
     let hash = int_to_hash(leaf_pos);
     let proof = MerkleProof::for_node(&mmr, mmr_index).unwrap();
     assert!(proof.verify::<Hasher>(&root, &hash, mmr_index).is_ok())
@@ -86,7 +86,7 @@ fn a_big_proof() {
 #[test]
 fn for_leaf_node() {
     let mmr = create_mmr(100);
-    let root = mmr.get_merkle_root();
+    let root = mmr.get_merkle_root().unwrap();
     let leaf_pos = 28;
     let hash = int_to_hash(leaf_pos);
     let proof = MerkleProof::for_leaf_node(&mmr, leaf_pos).unwrap();

--- a/base_layer/mmr/tests/pruned_mmr.rs
+++ b/base_layer/mmr/tests/pruned_mmr.rs
@@ -30,7 +30,7 @@ fn pruned_mmr_empty() {
     let mmr = create_mmr(0);
     let root = mmr.get_merkle_root();
     let pruned = prune_mmr(&mmr).expect("Could not create empty pruned MMR");
-    assert!(pruned.is_empty());
+    assert_eq!(pruned.is_empty(), Ok(true));
     assert_eq!(pruned.get_merkle_root(), root);
 }
 
@@ -50,7 +50,7 @@ fn pruned_mmrs() {
         assert!(pruned.push(&int_to_hash(*size + 1)).is_ok());
         assert_eq!(pruned.get_merkle_root(), mmr2.get_merkle_root());
         // But you can only get recent hashes
-        assert!(pruned.get_leaf_hash(*size / 2).is_none());
-        assert_eq!(pruned.get_leaf_hash(*size).unwrap(), new_hash)
+        assert_eq!(pruned.get_leaf_hash(*size / 2), Ok(None));
+        assert_eq!(pruned.get_leaf_hash(*size), Ok(Some(new_hash)))
     }
 }

--- a/base_layer/mmr/tests/with_blake512_hash.rs
+++ b/base_layer/mmr/tests/with_blake512_hash.rs
@@ -92,9 +92,9 @@ fn create_mmr() -> MerkleMountainRange<Blake2b, Vec<Vec<u8>>> {
 fn check_mmr_hashes() {
     let mmr = create_mmr();
     let hashes = hash_values();
-    assert_eq!(mmr.len(), 42);
+    assert_eq!(mmr.len(), Ok(42));
     for i in 0..42 {
-        let hash = mmr.get_node_hash(i).unwrap();
+        let hash = mmr.get_node_hash(i).unwrap().unwrap();
         assert_eq!(hash.to_hex(), hashes[i]);
     }
 }


### PR DESCRIPTION
## Description
- Modified ArrayLike trait so that the len and get methods return results, this change was made so that errors can be properly handled when implementing ArrayLike for non-memory backends.
- The BackendPushError was replaced with BackendError in MerkleMountainRangeError

## Motivation and Context
These changes are required to make the MerkleChangeTracker have persistent storage.

## How Has This Been Tested?
Current test were updated to accommodate the change.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [x] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch
* [x] I ran `cargo-fmt --all` before pushing
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
