### PR TITLE
Add optional kernel data

### DIFF
--- a/base_layer/core/src/transaction.rs
+++ b/base_layer/core/src/transaction.rs
@@ -33,7 +33,7 @@ use crate::{
     consensus::ConsensusRules,
     fee::Fee,
     transaction_protocol::{build_challenge, TransactionMetadata},
-    types::{HashDigest, RangeProof, RangeProofService},
+    types::{HashDigest, HashOutput, RangeProof, RangeProofService},
 };
 use derive_error::Error;
 use digest::Input;
@@ -369,10 +369,10 @@ pub struct TransactionKernel {
     /// The max lock_height of all *inputs* to this transaction
     pub lock_height: u64,
     /// This is an optional field used by committing to additional tx meta data between the two parties
-    pub meta_info: Option<MessageHash>,
+    pub meta_info: Option<HashOutput>,
     /// This is an optional field and is the hash of the kernel this kernel is linked to.
     /// This field is for example for relative time-locked transactions
-    pub linked_kernel: Option<MessageHash>,
+    pub linked_kernel: Option<HashOutput>,
     /// Remainder of the sum of all transaction commitments. If the transaction
     /// is well formed, amounts components should sum to zero and the excess
     /// is hence a valid public key.
@@ -508,8 +508,8 @@ impl Hashable for TransactionKernel {
 impl Display for TransactionKernel {
     fn fmt(&self, fmt: &mut Formatter<'_>) -> Result<(), std::fmt::Error> {
         let msg = format!(
-            "Fee: {}\nLock height: {}\nFeatures: {:?}\nExcess: {}\nExcess signature: {}\nmeta_info: \
-             {}\nlinked_kernel: {}\n",
+            "Fee: {}\nLock height: {}\nFeatures: {:?}\nExcess: {}\nExcess signature: {}\nMeta_info: \
+             {}\nLinked_kernel: {}\n",
             self.fee,
             self.lock_height,
             self.features,
@@ -517,16 +517,14 @@ impl Display for TransactionKernel {
             self.excess_sig
                 .to_json()
                 .unwrap_or("Failed to serialize signature".into()),
-            self.meta_info
-                .as_ref()
-                .unwrap_or(&vec![0])
-                .to_json()
-                .unwrap_or("Failed to serialize meta info".into()),
-            self.linked_kernel
-                .as_ref()
-                .unwrap_or(&vec![0])
-                .to_json()
-                .unwrap_or("Failed to serialize linked kernel".into())
+            match &self.meta_info {
+                None => "None".to_string(),
+                Some(v) => v.to_hex(),
+            },
+            match &self.linked_kernel {
+                None => "None".to_string(),
+                Some(v) => v.to_hex(),
+            },
         );
         fmt.write_str(&msg)
     }
@@ -696,7 +694,7 @@ mod test {
     use super::*;
     use crate::{
         transaction::OutputFeatures,
-        types::{BlindingFactor, PrivateKey, RangeProof},
+        types::{BlindingFactor, PrivateKey, PublicKey, RangeProof},
     };
     use rand;
     use tari_crypto::{
@@ -751,5 +749,47 @@ mod test {
         let proof = prover.construct_proof(&k2, 2u64.pow(32) + 1).unwrap();
         let tx_output3 = TransactionOutput::new(OutputFeatures::default(), c, RangeProof::from_bytes(&proof).unwrap());
         assert_eq!(tx_output3.verify_range_proof(&prover).unwrap(), false);
+    }
+
+    #[test]
+    fn kernel_hash() {
+        let s = PrivateKey::from_hex("6c6eebc5a9c02e1f3c16a69ba4331f9f63d0718401dea10adc4f9d3b879a2c09").unwrap();
+        let r = PublicKey::from_hex("28e8efe4e5576aac931d358d0f6ace43c55fa9d4186d1d259d1436caa876d43b").unwrap();
+        let sig = Signature::new(r, s);
+        let excess = Commitment::from_hex("9017be5092b85856ce71061cadeb20c2d1fabdf664c4b3f082bf44cf5065e650").unwrap();
+        let k = KernelBuilder::new()
+            .with_signature(&sig)
+            .with_fee(100.into())
+            .with_excess(&excess)
+            .with_lock_height(500)
+            .build()
+            .unwrap();
+        assert_eq!(
+            &k.hash().to_hex(),
+            "4471024385680c8bfa36979c588a0e06d3c3af3dd9ecff57540e01c18445f4e7"
+        );
+    }
+
+    #[test]
+    fn kernel_metadata() {
+        let s = PrivateKey::from_hex("df9a004360b1cf6488d8ff7fb625bc5877f4b013f9b2b20d84932172e605b207").unwrap();
+        let r = PublicKey::from_hex("5c6bfaceaa1c83fa4482a816b5f82ca3975cb9b61b6e8be4ee8f01c5f1bee561").unwrap();
+        let sig = Signature::new(r, s);
+        let excess = Commitment::from_hex("e0bd3f743b566272277c357075b0584fc840d79efac49e9b3b6dbaa8a351bc0c").unwrap();
+        let linked_kernel = Vec::from_hex("e605e109a5723053181e22e9a14cb9a9981dc8a2368d5aa3d09d9261e340e928").unwrap();
+        let meta = Vec::from_hex("c45d3f7903471c55e0fe77f644c1ed9b87151b50c0394f806187138eb36a4200").unwrap();
+        let k = KernelBuilder::new()
+            .with_signature(&sig)
+            .with_fee(100.into())
+            .with_excess(&excess)
+            .with_linked_kernel(linked_kernel)
+            .with_meta_info(meta)
+            .with_lock_height(500)
+            .build()
+            .unwrap();
+        assert_eq!(
+            &k.hash().to_hex(),
+            "988ed705e6509684eb78ba81cd49525692002ab4dc79025bfd3fc051e45eb0b2"
+        )
     }
 }


### PR DESCRIPTION
##  Description
This PR adds optional kernel fields that will be required by the some of the scripts. 
The one field is for a linked kernel, this is required for relative time locks.
The other field is for a meta_info, which is so that contract data can be checked by a challange without knowing what the contract data is. This will be used by the DAN etc.  

## Motivation and Context
#740 

## How Has This Been Tested?
This breaks none of the unit tests and these are optional fields

## Types of changes
* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
* [x] I'm merging against the `development` branch
* [x] I ran `cargo-fmt --all` before pushing
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
