### PR TITLE
Convert the Text Message Service to by Async

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,8 @@ members = [
     "infrastructure/pubsub",
     "infrastructure/storage",
     "infrastructure/test_utils",
-    "applications/grpc_wallet",
-    "applications/console_text_messenger",
-    "ffi"
+    #TODO Reintroduce these once the comms stack and wallet is stable
+    #"applications/grpc_wallet",
+    #"applications/console_text_messenger",
+    #"ffi"
 ]

--- a/applications/console_text_messenger/src/main.rs
+++ b/applications/console_text_messenger/src/main.rs
@@ -43,7 +43,7 @@ use tari_crypto::keys::PublicKey;
 use tari_p2p::{initialization::CommsConfig, sync_services::ServiceError};
 use tari_utilities::{hex::Hex, message_format::MessageFormat};
 use tari_wallet::{
-    text_message_service::{Contact, ReceivedTextMessage},
+    text_message_service_sync::{Contact, ReceivedTextMessage},
     wallet::WalletConfig,
     Wallet,
 };

--- a/applications/grpc_wallet/src/lib.rs
+++ b/applications/grpc_wallet/src/lib.rs
@@ -20,5 +20,6 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-pub mod grpc_interface;
-pub mod wallet_server;
+// TODO Reintroduce the FFI once the comms stack and wallet is stable
+// pub mod grpc_interface;
+// pub mod wallet_server;

--- a/applications/grpc_wallet/src/main.rs
+++ b/applications/grpc_wallet/src/main.rs
@@ -38,7 +38,7 @@ use tari_crypto::keys::PublicKey;
 use tari_grpc_wallet::wallet_server::WalletServer;
 use tari_p2p::initialization::CommsConfig;
 use tari_utilities::{hex::Hex, message_format::MessageFormat};
-use tari_wallet::{text_message_service::Contact, wallet::WalletConfig, Wallet};
+use tari_wallet::{text_message_service_sync::Contact, wallet::WalletConfig, Wallet};
 
 const LOG_TARGET: &str = "applications::grpc_wallet";
 

--- a/applications/grpc_wallet/tests/wallet_grpc_server/wallet_grpc_server.rs
+++ b/applications/grpc_wallet/tests/wallet_grpc_server/wallet_grpc_server.rs
@@ -46,7 +46,7 @@ use tari_grpc_wallet::{
 };
 use tari_p2p::initialization::CommsConfig;
 use tari_utilities::hex::Hex;
-use tari_wallet::{text_message_service::Contact, wallet::WalletConfig, Wallet};
+use tari_wallet::{text_message_service_sync::Contact, wallet::WalletConfig, Wallet};
 use tempdir::TempDir;
 use tower_grpc::Request;
 use tower_hyper::{client, util};

--- a/base_layer/wallet/Cargo.toml
+++ b/base_layer/wallet/Cargo.toml
@@ -13,7 +13,8 @@ tari_key_manager = {path = "../keymanager", version = "^0.0"}
 tari_p2p = {path = "../p2p", version = "^0.0"}
 tari_pubsub = {path = "../../infrastructure/pubsub", version = "^0.0"}
 tari_utilities = { path = "../../infrastructure/tari_util", version = "^0.0"}
-
+tari_storage = { version = "^0.0", path = "../../infrastructure/storage"}
+tari_service_framework = { version = "^0.0", path = "../service_framework"}
 chrono = { version = "0.4.6", features = ["serde"]}
 derive-error = "0.0.4"
 digest = "0.8.0"
@@ -21,13 +22,14 @@ serde = {version = "1.0.89", features = ["derive"] }
 crossbeam-channel = "0.3.8"
 log = "0.4.6"
 lmdb-zero = "0.4.4"
-tari_storage = { version = "^0.0", path = "../../infrastructure/storage"}
 diesel_migrations =  "1.4"
-diesel = {version="1.4", features = ["sqlite", "serde_json", "chrono"]}
+diesel = {version="1.4", features = ["sqlite", "serde_json", "chrono", "r2d2"]}
 rand = "0.5.5"
 futures =  { version = "=0.3.0-alpha.18", package = "futures-preview", features =["compat", "std"]}
 tokio = "0.2.0-alpha.4"
+tower = "0.3.0-alpha.1a"
+tokio-executor = { version ="^0.2.0-alpha.4", features = ["threadpool"] }
 
 [dev-dependencies]
 env_logger = "0.6.2"
-
+tempdir = "0.3.7"

--- a/base_layer/wallet/src/lib.rs
+++ b/base_layer/wallet/src/lib.rs
@@ -1,4 +1,6 @@
+#![recursion_limit = "256"]
 #![feature(drain_filter)]
+#![feature(type_alias_impl_trait)]
 
 #[macro_use]
 extern crate diesel;

--- a/base_layer/wallet/src/text_message_service/error.rs
+++ b/base_layer/wallet/src/text_message_service/error.rs
@@ -25,7 +25,9 @@ use diesel::result::{ConnectionError as DieselConnectionError, Error as DieselEr
 use tari_comms::{builder::CommsError, connection::NetAddressError, message::MessageError};
 use tari_comms_dht::outbound::DhtOutboundError;
 use tari_p2p::sync_services::ServiceError;
+use tari_service_framework::reply_channel::TransportChannelError;
 use tari_utilities::{hex::HexError, message_format::MessageFormatError};
+use tokio_executor::threadpool::BlockingError;
 
 #[derive(Debug, Error)]
 pub enum TextMessageError {
@@ -36,8 +38,13 @@ pub enum TextMessageError {
     CommsServicesError(CommsError),
     HexError(HexError),
     DatabaseError(DieselError),
+    TransportChannelError(TransportChannelError),
+    #[error(msg_embedded, no_from, non_std)]
+    DatabaseMigrationError(String),
     NetAddressError(NetAddressError),
     DatabaseConnectionError(DieselConnectionError),
+    BlockingError(BlockingError),
+    R2d2Error,
     /// If a received TextMessageAck doesn't matching any pending messages
     MessageNotFound,
     /// Failed to send from API

--- a/base_layer/wallet/src/text_message_service/messages.rs
+++ b/base_layer/wallet/src/text_message_service/messages.rs
@@ -1,0 +1,155 @@
+// Copyright 2019 The Tari Project
+//
+// Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+// following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+// disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+// following disclaimer in the documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+// products derived from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+// INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+// WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+// USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+use super::{
+    model::{Contact, UpdateContact},
+    service::TextMessages,
+};
+use crate::text_message_service::{error::TextMessageError, TextMessageHandle};
+use tari_comms::types::CommsPublicKey;
+use tower::Service;
+
+/// API Request enum
+#[derive(Debug, PartialEq)]
+pub enum TextMessageRequest {
+    SendTextMessage((CommsPublicKey, String)),
+    GetTextMessages,
+    GetTextMessagesByPubKey(CommsPublicKey),
+    SetScreenName(String),
+    GetScreenName,
+    AddContact(Contact),
+    RemoveContact(Contact),
+    GetContacts,
+    UpdateContact((CommsPublicKey, UpdateContact)),
+}
+
+/// API Response enum
+#[derive(Debug)]
+pub enum TextMessageResponse {
+    MessageSent,
+    TextMessages(TextMessages),
+    ScreenName(Option<String>),
+    ScreenNameSet,
+    ContactAdded,
+    ContactRemoved,
+    Contacts(Vec<Contact>),
+    ContactUpdated,
+}
+
+pub struct TextMessageServiceRequester {
+    handle: TextMessageHandle,
+}
+
+impl TextMessageServiceRequester {
+    pub fn new(handle: TextMessageHandle) -> Self {
+        Self { handle }
+    }
+
+    pub async fn send_text_message(
+        &mut self,
+        dest_pubkey: CommsPublicKey,
+        message: String,
+    ) -> Result<(), TextMessageError>
+    {
+        match self
+            .handle
+            .call(TextMessageRequest::SendTextMessage((dest_pubkey, message)))
+            .await??
+        {
+            TextMessageResponse::MessageSent => Ok(()),
+            _ => Err(TextMessageError::UnexpectedApiResponse),
+        }
+    }
+
+    pub async fn get_text_messages(&mut self) -> Result<TextMessages, TextMessageError> {
+        match self.handle.call(TextMessageRequest::GetTextMessages).await?? {
+            TextMessageResponse::TextMessages(t) => Ok(t),
+            _ => Err(TextMessageError::UnexpectedApiResponse),
+        }
+    }
+
+    pub async fn get_text_messages_by_pub_key(
+        &mut self,
+        pubkey: CommsPublicKey,
+    ) -> Result<TextMessages, TextMessageError>
+    {
+        match self
+            .handle
+            .call(TextMessageRequest::GetTextMessagesByPubKey(pubkey))
+            .await??
+        {
+            TextMessageResponse::TextMessages(t) => Ok(t),
+            _ => Err(TextMessageError::UnexpectedApiResponse),
+        }
+    }
+
+    pub async fn set_screen_name(&mut self, name: String) -> Result<(), TextMessageError> {
+        match self.handle.call(TextMessageRequest::SetScreenName(name)).await?? {
+            TextMessageResponse::ScreenNameSet => Ok(()),
+            _ => Err(TextMessageError::UnexpectedApiResponse),
+        }
+    }
+
+    pub async fn get_screen_name(&mut self) -> Result<Option<String>, TextMessageError> {
+        match self.handle.call(TextMessageRequest::GetScreenName).await?? {
+            TextMessageResponse::ScreenName(s) => Ok(s),
+            _ => Err(TextMessageError::UnexpectedApiResponse),
+        }
+    }
+
+    pub async fn add_contact(&mut self, contact: Contact) -> Result<(), TextMessageError> {
+        match self.handle.call(TextMessageRequest::AddContact(contact)).await?? {
+            TextMessageResponse::ContactAdded => Ok(()),
+            _ => Err(TextMessageError::UnexpectedApiResponse),
+        }
+    }
+
+    pub async fn remove_contact(&mut self, contact: Contact) -> Result<(), TextMessageError> {
+        match self.handle.call(TextMessageRequest::RemoveContact(contact)).await?? {
+            TextMessageResponse::ContactRemoved => Ok(()),
+            _ => Err(TextMessageError::UnexpectedApiResponse),
+        }
+    }
+
+    pub async fn get_contacts(&mut self) -> Result<Vec<Contact>, TextMessageError> {
+        match self.handle.call(TextMessageRequest::GetContacts).await?? {
+            TextMessageResponse::Contacts(v) => Ok(v),
+            _ => Err(TextMessageError::UnexpectedApiResponse),
+        }
+    }
+
+    pub async fn update_contact(
+        &mut self,
+        pubkey: CommsPublicKey,
+        update_contact: UpdateContact,
+    ) -> Result<(), TextMessageError>
+    {
+        match self
+            .handle
+            .call(TextMessageRequest::UpdateContact((pubkey, update_contact)))
+            .await??
+        {
+            TextMessageResponse::ContactUpdated => Ok(()),
+            _ => Err(TextMessageError::UnexpectedApiResponse),
+        }
+    }
+}

--- a/base_layer/wallet/src/text_message_service/mod.rs
+++ b/base_layer/wallet/src/text_message_service/mod.rs
@@ -20,9 +20,134 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-mod error;
-mod model;
+pub mod error;
+pub mod messages;
+pub mod model;
 mod service;
 
-pub use model::{Contact, ReceivedTextMessage, SentTextMessage, UpdateContact};
-pub use service::{TextMessageApiResponse, TextMessageService, TextMessageServiceApi, TextMessages};
+use self::service::TextMessageService;
+use crate::text_message_service::{
+    error::TextMessageError,
+    messages::{TextMessageRequest, TextMessageResponse},
+    model::ReceivedTextMessage,
+    service::TextMessageAck,
+};
+use futures::{future, stream::StreamExt, Future, Stream};
+use log::*;
+use std::sync::Arc;
+use tari_comms::types::CommsPublicKey;
+use tari_comms_dht::outbound::OutboundMessageRequester;
+use tari_p2p::{
+    comms_connector::PeerMessage,
+    domain_message::DomainMessage,
+    services::{
+        liveness::LivenessHandle,
+        utils::{map_deserialized, ok_or_skip_result},
+    },
+    tari_message::{ExtendedMessage, TariMessageType},
+};
+use tari_pubsub::TopicSubscriptionFactory;
+use tari_service_framework::{
+    handles::ServiceHandlesFuture,
+    reply_channel,
+    reply_channel::SenderService,
+    ServiceInitializationError,
+    ServiceInitializer,
+};
+use tokio::runtime::TaskExecutor;
+
+const LOG_TARGET: &'static str = "wallet::text_message_service::initializer";
+
+pub type TextMessageHandle = SenderService<TextMessageRequest, Result<TextMessageResponse, TextMessageError>>;
+
+pub struct TextMessageServiceInitializer {
+    pub_key: Option<CommsPublicKey>,
+    database_path: Option<String>,
+    subscription_factory: Arc<TopicSubscriptionFactory<TariMessageType, Arc<PeerMessage<TariMessageType>>>>,
+}
+
+impl TextMessageServiceInitializer {
+    pub fn new(
+        subscription_factory: Arc<TopicSubscriptionFactory<TariMessageType, Arc<PeerMessage<TariMessageType>>>>,
+        pub_key: CommsPublicKey,
+        database_path: String,
+    ) -> Self
+    {
+        Self {
+            pub_key: Some(pub_key),
+            database_path: Some(database_path),
+            subscription_factory,
+        }
+    }
+
+    /// Get a stream of inbound Text messages
+    fn text_message_stream(&self) -> impl Stream<Item = DomainMessage<ReceivedTextMessage>> {
+        self.subscription_factory
+            .get_subscription(TariMessageType::new(ExtendedMessage::Text))
+            .map(map_deserialized::<ReceivedTextMessage>)
+            .filter_map(ok_or_skip_result)
+    }
+
+    fn text_message_ack_stream(&self) -> impl Stream<Item = DomainMessage<TextMessageAck>> {
+        self.subscription_factory
+            .get_subscription(TariMessageType::new(ExtendedMessage::TextAck))
+            .map(map_deserialized::<TextMessageAck>)
+            .filter_map(ok_or_skip_result)
+    }
+}
+
+impl ServiceInitializer for TextMessageServiceInitializer {
+    type Future = impl Future<Output = Result<(), ServiceInitializationError>>;
+
+    fn initialize(&mut self, executor: TaskExecutor, handles_fut: ServiceHandlesFuture) -> Self::Future {
+        let pub_key = self
+            .pub_key
+            .take()
+            .expect("text message service initializer already called");
+
+        let database_path = self
+            .database_path
+            .take()
+            .expect("text message service initializer already called");
+
+        let (sender, receiver) = reply_channel::unbounded();
+
+        let text_message_stream = self.text_message_stream();
+        let text_message_ack_stream = self.text_message_ack_stream();
+
+        // Register handle before waiting for handles to be ready
+        handles_fut.register(sender);
+
+        executor.spawn(async move {
+            let handles = handles_fut.await;
+
+            let oms = handles
+                .get_handle::<OutboundMessageRequester>()
+                .expect("OMS handle required for TextMessageService");
+            let liveness = handles
+                .get_handle::<LivenessHandle>()
+                .expect("Liveness handle required for TextMessageService");
+
+            let service = TextMessageService::new(
+                receiver,
+                text_message_stream,
+                text_message_ack_stream,
+                pub_key,
+                database_path,
+                oms,
+                liveness,
+            );
+
+            match service.start().await {
+                Ok(_) => {
+                    info!(target: LOG_TARGET, "Text message service initializer exited cleanly");
+                },
+                Err(err) => {
+                    error!(target: LOG_TARGET, "Text message service failed to start: {}", err);
+                },
+            }
+        });
+
+        future::ready(Ok(()))
+    }
+}

--- a/base_layer/wallet/src/text_message_service/service.rs
+++ b/base_layer/wallet/src/text_message_service/service.rs
@@ -20,20 +20,21 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use crate::text_message_service::{
+use super::{
     error::TextMessageError,
-    model::{ReceivedTextMessage, SentTextMessage},
-    Contact,
-    UpdateContact,
+    messages::{TextMessageRequest, TextMessageResponse},
+    model::{Contact, ReceivedTextMessage, SentTextMessage, UpdateContact},
 };
-use crossbeam_channel as channel;
-use diesel::{connection::Connection, SqliteConnection};
+
+use diesel::{
+    r2d2::{ConnectionManager, Pool},
+    Connection,
+    SqliteConnection,
+};
+use futures::{future::poll_fn, pin_mut, Stream, StreamExt};
 use log::*;
 use serde::{Deserialize, Serialize};
-use std::{
-    sync::{Arc, Mutex},
-    time::Duration,
-};
+use std::{io, path::Path, time::Duration};
 use tari_comms::{message::NodeDestination, types::CommsPublicKey};
 use tari_comms_dht::{
     message::DhtMessageFlags,
@@ -41,89 +42,205 @@ use tari_comms_dht::{
 };
 use tari_p2p::{
     domain_message::DomainMessage,
-    domain_subscriber::SyncDomainSubscription,
-    ping_pong::PingPong,
-    sync_services::{
-        Service,
-        ServiceApiWrapper,
-        ServiceContext,
-        ServiceControlMessage,
-        ServiceError,
-        DEFAULT_API_TIMEOUT_MS,
-    },
-    tari_message::{ExtendedMessage, NetMessage, TariMessageType},
+    services::liveness::LivenessHandle,
+    tari_message::{ExtendedMessage, TariMessageType},
 };
-use tokio::runtime::Runtime;
+use tari_service_framework::reply_channel;
+use tokio_executor::threadpool::blocking;
 
 const LOG_TARGET: &'static str = "base_layer::wallet::text_messsage_service";
 
 /// Represents an Acknowledgement of receiving a Text Message
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct TextMessageAck {
     id: Vec<u8>,
 }
 
-/// The TextMessageService manages the local node's text messages. It keeps track of sent messages that require an Ack
-/// (pending messages), Ack'ed sent messages and received messages.
-pub struct TextMessageService {
-    pub_key: CommsPublicKey,
-    screen_name: Option<String>,
-    oms: Option<OutboundMessageRequester>,
-    api: ServiceApiWrapper<TextMessageServiceApi, TextMessageApiRequest, TextMessageApiResult>,
-    database_path: String,
-    runtime: Runtime,
+/// A collection to hold a text message state
+#[derive(Debug)]
+pub struct TextMessages {
+    pub received_messages: Vec<ReceivedTextMessage>,
+    pub sent_messages: Vec<SentTextMessage>,
 }
 
-impl TextMessageService {
-    pub fn new(pub_key: CommsPublicKey, database_path: String) -> TextMessageService {
-        // TODO: Hack to allow async code to work, remove in next PR
-        let runtime = Runtime::new().unwrap();
-        TextMessageService {
-            pub_key,
+/// The TextMessageService manages the local node's text messages. It keeps track of sent messages that require an Ack
+/// (pending messages), Ack'ed sent messages and received messages.
+pub struct TextMessageService<TTextStream, TAckStream> {
+    pub_key: CommsPublicKey,
+    screen_name: Option<String>,
+    oms: OutboundMessageRequester,
+    database_connection_pool: Pool<ConnectionManager<SqliteConnection>>,
+    request_stream: Option<reply_channel::Receiver<TextMessageRequest, Result<TextMessageResponse, TextMessageError>>>,
+    text_message_stream: Option<TTextStream>,
+    text_message_ack_stream: Option<TAckStream>,
+    liveness: LivenessHandle,
+}
+
+impl<TTextStream, TAckStream> TextMessageService<TTextStream, TAckStream>
+where
+    TTextStream: Stream<Item = DomainMessage<ReceivedTextMessage>>,
+    TAckStream: Stream<Item = DomainMessage<TextMessageAck>>,
+{
+    pub fn new(
+        request_stream: reply_channel::Receiver<TextMessageRequest, Result<TextMessageResponse, TextMessageError>>,
+        text_message_stream: TTextStream,
+        text_message_ack_stream: TAckStream,
+        pub_key: CommsPublicKey,
+        database_path: String,
+        oms: OutboundMessageRequester,
+        liveness: LivenessHandle,
+    ) -> Self
+    {
+        let pool = Self::establish_db_connection_pool(database_path).expect("Could not establish database connection");
+
+        Self {
+            request_stream: Some(request_stream),
+            text_message_stream: Some(text_message_stream),
+            text_message_ack_stream: Some(text_message_ack_stream),
+            pub_key: pub_key.clone(),
             screen_name: None,
-            oms: None,
-            api: Self::setup_api(),
-            database_path,
-            runtime,
+            oms,
+            database_connection_pool: pool,
+            liveness,
         }
     }
 
-    /// Return this service's API
-    pub fn get_api(&self) -> Arc<TextMessageServiceApi> {
-        self.api.get_api()
+    pub async fn start(mut self) -> Result<(), TextMessageError> {
+        let request_stream = self
+            .request_stream
+            .take()
+            .expect("TextMessageService initialized without request_stream")
+            .fuse();
+        pin_mut!(request_stream);
+        let text_message_stream = self
+            .text_message_stream
+            .take()
+            .expect("TextMessageService initialized without text_message_stream")
+            .fuse();
+        pin_mut!(text_message_stream);
+        let text_message_ack_stream = self
+            .text_message_ack_stream
+            .take()
+            .expect("TextMessageService initialized without text_message_ack_stream")
+            .fuse();
+        pin_mut!(text_message_ack_stream);
+        loop {
+            futures::select! {
+                request_context = request_stream.select_next_some() => {
+                    let (request, reply_tx) = request_context.split();
+                    let _ = reply_tx.send(self.handle_request(request).await).or_else(|resp| {
+                        error!(target: LOG_TARGET, "Failed to send reply");
+                        Err(resp)
+                    });
+                },
+                // Incoming messages from the Comms layer
+                msg = text_message_stream.select_next_some() => {
+                    let _ = self.handle_incoming_text_message(msg).await.or_else(|err| {
+                        error!(target: LOG_TARGET, "Failed to handle incoming message: {:?}", err);
+                        Err(err)
+                    });
+                },
+                 // Incoming messages from the Comms layer
+                msg = text_message_ack_stream.select_next_some() => {
+                    let _ = self.handle_incoming_ack_message(msg).await.or_else(|err| {
+                        error!(target: LOG_TARGET, "Failed to handle incoming message: {:?}", err);
+                        Err(err)
+                    });
+                },
+                complete => {
+                    info!(target: LOG_TARGET, "Text message service shutting down");
+                    break;
+                }
+            }
+        }
+        Ok(())
     }
 
-    fn setup_api() -> ServiceApiWrapper<TextMessageServiceApi, TextMessageApiRequest, TextMessageApiResult> {
-        let (api_sender, service_receiver) = channel::bounded(0);
-        let (service_sender, api_receiver) = channel::bounded(0);
+    pub fn establish_db_connection_pool(
+        database_path: String,
+    ) -> Result<Pool<ConnectionManager<SqliteConnection>>, TextMessageError> {
+        let db_exists = Path::new(&database_path).exists();
 
-        let api = Arc::new(TextMessageServiceApi::new(api_sender, api_receiver));
-        ServiceApiWrapper::new(service_receiver, service_sender, api)
+        let connection = SqliteConnection::establish(&database_path)?;
+
+        connection.execute("PRAGMA foreign_keys = ON")?;
+
+        if !db_exists {
+            embed_migrations!("./migrations");
+            embedded_migrations::run_with_output(&connection, &mut io::stdout()).map_err(|err| {
+                TextMessageError::DatabaseMigrationError(format!("Database migration failed {}", err))
+            })?;
+        }
+        drop(connection);
+
+        let manager = ConnectionManager::<SqliteConnection>::new(database_path);
+        let pool = diesel::r2d2::Pool::builder()
+            .connection_timeout(Duration::from_millis(2000))
+            .idle_timeout(Some(Duration::from_millis(2000)))
+            .build(manager)
+            .map_err(|_| TextMessageError::R2d2Error)?;
+        Ok(pool)
+    }
+
+    async fn handle_request(&mut self, request: TextMessageRequest) -> Result<TextMessageResponse, TextMessageError> {
+        match request {
+            TextMessageRequest::SendTextMessage((destination, message)) => self
+                .send_text_message(destination, message)
+                .await
+                .map(|_| TextMessageResponse::MessageSent),
+            TextMessageRequest::GetTextMessages => self
+                .get_current_messages()
+                .await
+                .map(|tm| TextMessageResponse::TextMessages(tm)),
+            TextMessageRequest::GetTextMessagesByPubKey(pk) => self
+                .get_current_messages_by_pub_key(pk)
+                .await
+                .map(|tm| TextMessageResponse::TextMessages(tm)),
+            TextMessageRequest::GetScreenName => Ok(TextMessageResponse::ScreenName(self.get_screen_name())),
+            TextMessageRequest::SetScreenName(s) => {
+                self.set_screen_name(s);
+                Ok(TextMessageResponse::ScreenNameSet)
+            },
+            TextMessageRequest::AddContact(c) => self.add_contact(c).await.map(|_| TextMessageResponse::ContactAdded),
+            TextMessageRequest::RemoveContact(c) => self
+                .remove_contact(c)
+                .await
+                .map(|_| TextMessageResponse::ContactRemoved),
+            TextMessageRequest::GetContacts => self.get_contacts().await.map(|c| TextMessageResponse::Contacts(c)),
+            TextMessageRequest::UpdateContact((pk, c)) => self
+                .update_contact(pk, c)
+                .await
+                .map(|_| TextMessageResponse::ContactUpdated),
+        }
     }
 
     /// Send a text message to the specified node using the provided OMS
-    fn send_text_message(
+    async fn send_text_message(
         &mut self,
         dest_pub_key: CommsPublicKey,
         message: String,
-        conn: &SqliteConnection,
     ) -> Result<(), TextMessageError>
     {
-        let mut oms = self.oms.clone().ok_or(TextMessageError::OMSNotInitialized)?;
-
-        let count = SentTextMessage::count_by_dest_pub_key(&dest_pub_key.clone(), conn)?;
+        let conn = self
+            .database_connection_pool
+            .clone()
+            .get()
+            .map_err(|_| TextMessageError::R2d2Error)?;
+        let count = SentTextMessage::count_by_dest_pub_key(&dest_pub_key.clone(), &conn)?;
 
         let text_message = SentTextMessage::new(self.pub_key.clone(), dest_pub_key, message, Some(count as usize));
 
-        self.runtime.block_on(oms.send_message(
-            BroadcastStrategy::DirectPublicKey(text_message.dest_pub_key.clone()),
-            NodeDestination::Undisclosed,
-            DhtMessageFlags::ENCRYPTED,
-            TariMessageType::new(ExtendedMessage::Text),
-            text_message.clone(),
-        ))?;
+        self.oms
+            .send_message(
+                BroadcastStrategy::DirectPublicKey(text_message.dest_pub_key.clone()),
+                NodeDestination::Undisclosed,
+                DhtMessageFlags::ENCRYPTED,
+                TariMessageType::new(ExtendedMessage::Text),
+                text_message.clone(),
+            )
+            .await?;
 
-        text_message.commit(conn)?;
+        text_message.commit(&conn)?;
 
         trace!(target: LOG_TARGET, "Text Message Sent to {}", text_message.dest_pub_key);
 
@@ -131,85 +248,119 @@ impl TextMessageService {
     }
 
     /// Process an incoming text message
-    fn receive_text_message(
+    async fn handle_incoming_text_message(
         &mut self,
         message: DomainMessage<ReceivedTextMessage>,
-        conn: &SqliteConnection,
     ) -> Result<(), TextMessageError>
     {
-        let mut oms = self.oms.clone().ok_or(TextMessageError::OMSNotInitialized)?;
-
-        let DomainMessage {
-            origin_pubkey,
-            inner: message,
-            ..
-        } = message;
-
         trace!(
             target: LOG_TARGET,
             "Text Message received with ID: {:?} from {} with message: {:?}",
-            message.id,
-            message.source_pub_key,
-            message.message,
+            message.inner.id,
+            message.inner.source_pub_key,
+            message.inner.message,
         );
 
-        let text_message_ack = TextMessageAck { id: message.id.clone() };
-        self.runtime.block_on(oms.send_message(
-            BroadcastStrategy::DirectPublicKey(origin_pubkey),
-            NodeDestination::Undisclosed,
-            DhtMessageFlags::ENCRYPTED,
-            TariMessageType::new(ExtendedMessage::TextAck),
-            text_message_ack,
-        ))?;
+        let text_message_ack = TextMessageAck {
+            id: message.inner.id.clone(),
+        };
+        self.oms
+            .send_message(
+                BroadcastStrategy::DirectPublicKey(message.clone().origin_pubkey),
+                NodeDestination::Undisclosed,
+                DhtMessageFlags::ENCRYPTED,
+                TariMessageType::new(ExtendedMessage::TextAck),
+                text_message_ack,
+            )
+            .await?;
+        let conn = self
+            .database_connection_pool
+            .clone()
+            .get()
+            .map_err(|_| TextMessageError::R2d2Error)?;
 
-        message.commit(conn)?;
+        let message_inner = message.clone().into_inner();
+        poll_fn(move |_| blocking(|| message_inner.commit(&conn))).await??;
 
         Ok(())
     }
 
     /// Process an incoming text message Ack
-    fn receive_text_message_ack(
+    async fn handle_incoming_ack_message(
         &mut self,
-        message: DomainMessage<TextMessageAck>,
-        conn: &SqliteConnection,
+        message_ack: DomainMessage<TextMessageAck>,
     ) -> Result<(), TextMessageError>
     {
-        let message_ack = message.into_inner();
+        let message_ack_inner = message_ack.clone().into_inner();
+
+        let conn = self
+            .database_connection_pool
+            .clone()
+            .get()
+            .map_err(|_| TextMessageError::R2d2Error)?;
+
         debug!(
             target: LOG_TARGET,
-            "Text Message Ack received with ID: {:?}", message_ack.id,
+            "Text Message Ack received with ID: {:?}", message_ack_inner.id,
         );
-        SentTextMessage::mark_sent_message_ack(message_ack.id, conn)?;
+
+        poll_fn(move |_| blocking(|| SentTextMessage::mark_sent_message_ack(&message_ack_inner.id, &conn))).await??;
 
         Ok(())
     }
 
     /// Return a copy of the current lists of messages
-    fn get_current_messages(&self, conn: &SqliteConnection) -> Result<TextMessages, TextMessageError> {
+    async fn get_current_messages(&mut self) -> Result<TextMessages, TextMessageError> {
+        let sent_messages;
+        let received_messages;
+
+        let conn1 = self
+            .database_connection_pool
+            .clone()
+            .get()
+            .map_err(|_| TextMessageError::R2d2Error)?;
+
+        sent_messages = poll_fn(move |_| blocking(|| SentTextMessage::index(&conn1))).await??;
+
+        let conn2 = self
+            .database_connection_pool
+            .clone()
+            .get()
+            .map_err(|_| TextMessageError::R2d2Error)?;
+
+        received_messages = poll_fn(move |_| blocking(|| ReceivedTextMessage::index(&conn2))).await??;
         Ok(TextMessages {
-            sent_messages: SentTextMessage::index(conn)?,
-            received_messages: ReceivedTextMessage::index(conn)?,
+            sent_messages,
+            received_messages,
         })
     }
 
-    fn get_current_messages_by_pub_key(
-        &self,
-        pub_key: CommsPublicKey,
-        conn: &SqliteConnection,
-    ) -> Result<TextMessages, TextMessageError>
-    {
+    async fn get_current_messages_by_pub_key(&self, pub_key: CommsPublicKey) -> Result<TextMessages, TextMessageError> {
+        let sent_messages;
+        let received_messages;
+
+        let conn1 = self
+            .database_connection_pool
+            .clone()
+            .get()
+            .map_err(|_| TextMessageError::R2d2Error)?;
+        let pub_key1 = pub_key.clone();
+        sent_messages =
+            poll_fn(move |_| blocking(|| SentTextMessage::find_by_dest_pub_key(&pub_key1, &conn1))).await??;
+
+        let conn2 = self
+            .database_connection_pool
+            .clone()
+            .get()
+            .map_err(|_| TextMessageError::R2d2Error)?;
+        let pub_key2 = pub_key.clone();
+        received_messages =
+            poll_fn(move |_| blocking(|| ReceivedTextMessage::find_by_source_pub_key(&pub_key2, &conn2))).await??;
+
         Ok(TextMessages {
-            sent_messages: SentTextMessage::find_by_dest_pub_key(&pub_key, conn)?,
-            received_messages: ReceivedTextMessage::find_by_source_pub_key(&pub_key, conn)?,
+            sent_messages,
+            received_messages,
         })
-    }
-
-    pub fn get_pub_key(&self) -> CommsPublicKey {
-        self.pub_key.clone()
-    }
-
-    pub fn set_pub_key(&mut self, pub_key: CommsPublicKey) {
-        self.pub_key = pub_key;
     }
 
     pub fn get_screen_name(&self) -> Option<String> {
@@ -220,453 +371,114 @@ impl TextMessageService {
         self.screen_name = Some(screen_name);
     }
 
-    pub fn add_contact(&mut self, contact: Contact, conn: &SqliteConnection) -> Result<(), TextMessageError> {
-        let found_contact = Contact::find(&contact.pub_key, conn);
+    pub async fn add_contact(&mut self, contact: Contact) -> Result<(), TextMessageError> {
+        let conn1 = self
+            .database_connection_pool
+            .clone()
+            .get()
+            .map_err(|_| TextMessageError::R2d2Error)?;
+        let contact_clone = contact.clone();
+        let found_contact = poll_fn(move |_| blocking(|| Contact::find(&contact_clone.pub_key, &conn1))).await?;
         if let Ok(c) = found_contact {
             if c.pub_key == contact.pub_key {
                 return Err(TextMessageError::ContactAlreadyExists);
             }
         }
 
-        contact.commit(&conn)?;
-
-        // Send ping to the contact so that if they are online they will flush all outstanding messages for this node
-        let mut oms = self.oms.clone().ok_or(TextMessageError::OMSNotInitialized)?;
-        self.runtime.block_on(oms.send_message(
-            BroadcastStrategy::DirectPublicKey(contact.pub_key.clone()),
-            NodeDestination::Undisclosed,
-            DhtMessageFlags::ENCRYPTED,
-            TariMessageType::new(NetMessage::PingPong),
-            PingPong::Ping,
-        ))?;
+        let conn2 = self
+            .database_connection_pool
+            .clone()
+            .get()
+            .map_err(|_| TextMessageError::R2d2Error)?;
+        let contact_clone2 = contact.clone();
+        poll_fn(move |_| blocking(|| contact_clone2.commit(&conn2))).await??;
 
         trace!(
             target: LOG_TARGET,
             "Contact Added: Screen name: {:?} - Pub-key: {} - Address: {:?}",
-            contact.screen_name.clone(),
-            contact.pub_key.clone(),
-            contact.address.clone()
+            contact.screen_name,
+            contact.pub_key,
+            contact.address,
         );
+
+        // Send ping to the contact so that if they are online they will flush all outstanding messages for this node
+        // TODO This was removed as it created random lock ups in the tests, Once the new Future based comms Middleware
+        // is in put this back
+        //        let _ = self
+        //            .liveness
+        //            .call(LivenessRequest::SendPing(contact.pub_key))
+        //            .await
+        //            .or_else(|err| {
+        //                error!(target: LOG_TARGET, "{:?}", err);
+        //                Err(err)
+        //            });
+
         Ok(())
     }
 
-    pub fn remove_contact(&mut self, contact: Contact, conn: &SqliteConnection) -> Result<(), TextMessageError> {
-        contact.clone().delete(conn)?;
+    pub async fn remove_contact(&mut self, contact: Contact) -> Result<(), TextMessageError> {
+        let conn = self
+            .database_connection_pool
+            .clone()
+            .get()
+            .map_err(|_| TextMessageError::R2d2Error)?;
+        let contact_clone = contact.clone();
+        poll_fn(move |_| blocking(|| contact_clone.delete(&conn))).await??;
 
         trace!(
             target: LOG_TARGET,
             "Contact Deleted: Screen name: {:?} - Pub-key: {} - Address: {:?}",
-            contact.screen_name.clone(),
-            contact.pub_key.clone(),
-            contact.address.clone()
+            contact.screen_name,
+            contact.pub_key,
+            contact.address,
         );
 
         Ok(())
     }
 
-    pub fn get_contacts(&self, conn: &SqliteConnection) -> Result<Vec<Contact>, TextMessageError> {
-        Contact::index(conn)
+    pub async fn get_contacts(&self) -> Result<Vec<Contact>, TextMessageError> {
+        let conn = self
+            .database_connection_pool
+            .clone()
+            .get()
+            .map_err(|_| TextMessageError::R2d2Error)?;
+        poll_fn(move |_| blocking(|| Contact::index(&conn))).await?
     }
 
     /// Updates the screen_name of a contact if an existing contact with the same pub_key is found
-    pub fn update_contact(
+    pub async fn update_contact(
         &mut self,
         pub_key: CommsPublicKey,
         contact_update: UpdateContact,
-        conn: &SqliteConnection,
     ) -> Result<(), TextMessageError>
     {
-        let contact = Contact::find(&pub_key, conn)?;
+        let conn1 = self
+            .database_connection_pool
+            .clone()
+            .get()
+            .map_err(|_| TextMessageError::R2d2Error)?;
+        let pub_key1 = pub_key.clone();
+        let contact = poll_fn(move |_| blocking(|| Contact::find(&pub_key1, &conn1))).await??;
 
-        contact.clone().update(contact_update, conn)?;
+        let conn2 = self
+            .database_connection_pool
+            .clone()
+            .get()
+            .map_err(|_| TextMessageError::R2d2Error)?;
+        let contact_update = contact_update.clone();
+        let contact_clone = contact.clone();
+        poll_fn(move |_| blocking(|| contact_clone.update(contact_update.clone(), &conn2))).await??;
 
         trace!(
             target: LOG_TARGET,
             "Contact Updated: Screen name: {:?} - Pub-key: {} - Address: {:?}",
-            contact.screen_name.clone(),
-            contact.pub_key.clone(),
-            contact.address.clone()
+            contact.screen_name,
+            contact.pub_key,
+            contact.address,
         );
 
         Ok(())
-    }
-
-    /// This handler is called when the Service executor loops receives an API request
-    fn handle_api_message(
-        &mut self,
-        msg: TextMessageApiRequest,
-        connection: &SqliteConnection,
-    ) -> Result<(), ServiceError>
-    {
-        trace!(target: LOG_TARGET, "[{}] Received API message", self.get_name(),);
-        let resp = match msg {
-            TextMessageApiRequest::SendTextMessage((destination, message)) => self
-                .send_text_message(destination, message, connection)
-                .map(|_| TextMessageApiResponse::MessageSent),
-            TextMessageApiRequest::GetTextMessages => self
-                .get_current_messages(connection)
-                .map(|tm| TextMessageApiResponse::TextMessages(tm)),
-            TextMessageApiRequest::GetTextMessagesByPubKey(pk) => self
-                .get_current_messages_by_pub_key(pk, connection)
-                .map(|tm| TextMessageApiResponse::TextMessages(tm)),
-            TextMessageApiRequest::GetScreenName => Ok(TextMessageApiResponse::ScreenName(self.get_screen_name())),
-            TextMessageApiRequest::SetScreenName(s) => {
-                self.set_screen_name(s);
-                Ok(TextMessageApiResponse::ScreenNameSet)
-            },
-            TextMessageApiRequest::AddContact(c) => self
-                .add_contact(c, connection)
-                .map(|_| TextMessageApiResponse::ContactAdded),
-            TextMessageApiRequest::RemoveContact(c) => self
-                .remove_contact(c, connection)
-                .map(|_| TextMessageApiResponse::ContactRemoved),
-            TextMessageApiRequest::GetContacts => self
-                .get_contacts(connection)
-                .map(|c| TextMessageApiResponse::Contacts(c)),
-            TextMessageApiRequest::UpdateContact((pk, c)) => self
-                .update_contact(pk, c, connection)
-                .map(|_| TextMessageApiResponse::ContactUpdated),
-        };
-
-        trace!(target: LOG_TARGET, "[{}] Replying to API", self.get_name());
-        self.api
-            .send_reply(resp)
-            .map_err(ServiceError::internal_service_error())
     }
 
     // TODO Some sort of accessor that allows for pagination of messages
-}
-
-/// A collection to hold a text message state
-#[derive(Debug)]
-pub struct TextMessages {
-    pub received_messages: Vec<ReceivedTextMessage>,
-    pub sent_messages: Vec<SentTextMessage>,
-}
-
-/// The Domain Service trait implementation for the TestMessageService
-impl Service for TextMessageService {
-    fn get_name(&self) -> String {
-        "Text Message service".to_string()
-    }
-
-    fn get_message_types(&self) -> Vec<TariMessageType> {
-        vec![ExtendedMessage::Text.into(), ExtendedMessage::TextAck.into()]
-    }
-
-    /// Function called by the Service Executor in its own thread. This function polls for both API request and Comms
-    /// layer messages from the Message Broker
-    fn execute(&mut self, context: ServiceContext) -> Result<(), ServiceError> {
-        let mut subscription_text = SyncDomainSubscription::new(
-            context
-                .inbound_message_subscription_factory()
-                .get_subscription_fused(ExtendedMessage::Text.into()),
-        );
-        let mut subscription_text_ack = SyncDomainSubscription::new(
-            context
-                .inbound_message_subscription_factory()
-                .get_subscription_fused(ExtendedMessage::TextAck.into()),
-        );
-
-        self.oms = Some(context.outbound_message_service());
-
-        // Check if the database file exists
-        let mut exists = false;
-        if std::fs::metadata(self.database_path.clone()).is_ok() {
-            exists = true;
-        }
-
-        let connection = SqliteConnection::establish(&self.database_path)
-            .map_err(|e| ServiceError::ServiceInitializationFailed(format!("{}", e).to_string()))?;
-
-        connection
-            .execute("PRAGMA foreign_keys = ON")
-            .map_err(|e| ServiceError::ServiceInitializationFailed(format!("{}", e).to_string()))?;
-
-        if !exists {
-            embed_migrations!("./migrations");
-            embedded_migrations::run_with_output(&connection, &mut std::io::stdout()).map_err(|e| {
-                ServiceError::ServiceInitializationFailed(format!("Database migration failed {}", e).to_string())
-            })?;
-        }
-
-        debug!(target: LOG_TARGET, "Starting Text Message Service executor");
-        loop {
-            if let Some(msg) = context.get_control_message(Duration::from_millis(5)) {
-                match msg {
-                    ServiceControlMessage::Shutdown => break,
-                }
-            }
-            for m in subscription_text.receive_messages()?.drain(..) {
-                match self.receive_text_message(m, &connection) {
-                    Ok(_) => {},
-                    Err(err) => {
-                        error!(target: LOG_TARGET, "Text Message service had error: {:?}", err);
-                    },
-                }
-            }
-            for m in subscription_text_ack.receive_messages()?.drain(..) {
-                match self.receive_text_message_ack(m, &connection) {
-                    Ok(_) => {},
-                    Err(err) => {
-                        error!(target: LOG_TARGET, "Text Message service had error: {:?}", err);
-                    },
-                }
-            }
-            if let Some(msg) = self
-                .api
-                .recv_timeout(Duration::from_millis(50))
-                .map_err(ServiceError::internal_service_error())?
-            {
-                self.handle_api_message(msg, &connection)?;
-            }
-        }
-
-        Ok(())
-    }
-}
-
-/// API Request enum
-#[derive(Debug)]
-pub enum TextMessageApiRequest {
-    SendTextMessage((CommsPublicKey, String)),
-    GetTextMessages,
-    GetTextMessagesByPubKey(CommsPublicKey),
-    SetScreenName(String),
-    GetScreenName,
-    AddContact(Contact),
-    RemoveContact(Contact),
-    GetContacts,
-    UpdateContact((CommsPublicKey, UpdateContact)),
-}
-
-/// API Response enum
-#[derive(Debug)]
-pub enum TextMessageApiResponse {
-    MessageSent,
-    TextMessages(TextMessages),
-    ScreenName(Option<String>),
-    ScreenNameSet,
-    ContactAdded,
-    ContactRemoved,
-    Contacts(Vec<Contact>),
-    ContactUpdated,
-}
-
-/// Result for all API requests
-pub type TextMessageApiResult = Result<TextMessageApiResponse, TextMessageError>;
-
-/// The TextMessage service public API that other services and application will use to interact with this service.
-/// The requests and responses are transmitted via channels into the Service Executor thread where this service is
-/// running
-pub struct TextMessageServiceApi {
-    sender: channel::Sender<TextMessageApiRequest>,
-    receiver: channel::Receiver<TextMessageApiResult>,
-    mutex: Mutex<()>,
-    timeout: Duration,
-}
-
-impl TextMessageServiceApi {
-    fn new(sender: channel::Sender<TextMessageApiRequest>, receiver: channel::Receiver<TextMessageApiResult>) -> Self {
-        Self {
-            sender,
-            receiver,
-            mutex: Mutex::new(()),
-            timeout: Duration::from_millis(DEFAULT_API_TIMEOUT_MS),
-        }
-    }
-
-    pub fn send_text_message(&self, destination: CommsPublicKey, message: String) -> Result<(), TextMessageError> {
-        self.send_recv(TextMessageApiRequest::SendTextMessage((destination, message)))
-            .and_then(|resp| match resp {
-                TextMessageApiResponse::MessageSent => Ok(()),
-                _ => Err(TextMessageError::UnexpectedApiResponse),
-            })
-    }
-
-    pub fn get_text_messages(&self) -> Result<TextMessages, TextMessageError> {
-        self.send_recv(TextMessageApiRequest::GetTextMessages)
-            .and_then(|resp| match resp {
-                TextMessageApiResponse::TextMessages(msgs) => Ok(msgs),
-                _ => Err(TextMessageError::UnexpectedApiResponse),
-            })
-    }
-
-    pub fn get_text_messages_by_pub_key(&self, pub_key: CommsPublicKey) -> Result<TextMessages, TextMessageError> {
-        self.send_recv(TextMessageApiRequest::GetTextMessagesByPubKey(pub_key))
-            .and_then(|resp| match resp {
-                TextMessageApiResponse::TextMessages(msgs) => Ok(msgs),
-                _ => Err(TextMessageError::UnexpectedApiResponse),
-            })
-    }
-
-    pub fn get_screen_name(&self) -> Result<Option<String>, TextMessageError> {
-        self.send_recv(TextMessageApiRequest::GetScreenName)
-            .and_then(|resp| match resp {
-                TextMessageApiResponse::ScreenName(s) => Ok(s),
-                _ => Err(TextMessageError::UnexpectedApiResponse),
-            })
-    }
-
-    pub fn set_screen_name(&self, screen_name: String) -> Result<(), TextMessageError> {
-        self.send_recv(TextMessageApiRequest::SetScreenName(screen_name))
-            .and_then(|resp| match resp {
-                TextMessageApiResponse::ScreenNameSet => Ok(()),
-                _ => Err(TextMessageError::UnexpectedApiResponse),
-            })
-    }
-
-    pub fn add_contact(&self, contact: Contact) -> Result<(), TextMessageError> {
-        self.send_recv(TextMessageApiRequest::AddContact(contact))
-            .and_then(|resp| match resp {
-                TextMessageApiResponse::ContactAdded => Ok(()),
-                _ => Err(TextMessageError::UnexpectedApiResponse),
-            })
-    }
-
-    pub fn remove_contact(&self, contact: Contact) -> Result<(), TextMessageError> {
-        self.send_recv(TextMessageApiRequest::RemoveContact(contact))
-            .and_then(|resp| match resp {
-                TextMessageApiResponse::ContactRemoved => Ok(()),
-                _ => Err(TextMessageError::UnexpectedApiResponse),
-            })
-    }
-
-    pub fn get_contacts(&self) -> Result<Vec<Contact>, TextMessageError> {
-        self.send_recv(TextMessageApiRequest::GetContacts)
-            .and_then(|resp| match resp {
-                TextMessageApiResponse::Contacts(v) => Ok(v),
-                _ => Err(TextMessageError::UnexpectedApiResponse),
-            })
-    }
-
-    pub fn update_contact(&self, pub_key: CommsPublicKey, contact: UpdateContact) -> Result<(), TextMessageError> {
-        self.send_recv(TextMessageApiRequest::UpdateContact((pub_key, contact)))
-            .and_then(|resp| match resp {
-                TextMessageApiResponse::ContactUpdated => Ok(()),
-                _ => Err(TextMessageError::UnexpectedApiResponse),
-            })
-    }
-
-    fn send_recv(&self, msg: TextMessageApiRequest) -> TextMessageApiResult {
-        self.lock(|| -> TextMessageApiResult {
-            self.sender.send(msg).map_err(|_| TextMessageError::ApiSendFailed)?;
-            self.receiver
-                .recv_timeout(self.timeout.clone())
-                .map_err(|_| TextMessageError::ApiReceiveFailed)?
-        })
-    }
-
-    fn lock<F, T>(&self, func: F) -> T
-    where F: FnOnce() -> T {
-        let lock = acquire_lock!(self.mutex);
-        let res = func();
-        drop(lock);
-        res
-    }
-}
-
-#[cfg(test)]
-mod test {
-    use crate::{
-        diesel::Connection,
-        text_message_service::{error::TextMessageError, Contact, TextMessageService, UpdateContact},
-    };
-    use diesel::{result::Error as DieselError, SqliteConnection};
-    use std::path::PathBuf;
-    use tari_comms::types::CommsPublicKey;
-    use tari_crypto::keys::PublicKey;
-
-    fn get_path(name: Option<&str>) -> String {
-        let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-        path.push("tests/data");
-        path.push(name.unwrap_or(""));
-        path.to_str().unwrap().to_string()
-    }
-
-    fn clean_up(name: &str) {
-        if std::fs::metadata(get_path(Some(name))).is_ok() {
-            std::fs::remove_file(get_path(Some(name))).unwrap();
-        }
-    }
-
-    fn init(name: &str) {
-        clean_up(name);
-        let path = get_path(None);
-        let _ = std::fs::create_dir(&path).unwrap_or_default();
-    }
-
-    #[test]
-    fn test_contacts_crud() {
-        let mut rng = rand::OsRng::new().unwrap();
-
-        let (_secret_key, public_key) = CommsPublicKey::random_keypair(&mut rng);
-
-        let db_name = "test_crud.sqlite3";
-        let db_path = get_path(Some(db_name));
-        init(db_name);
-
-        let conn = SqliteConnection::establish(&db_path).unwrap();
-        embed_migrations!("./migrations");
-        embedded_migrations::run_with_output(&conn, &mut std::io::stdout()).expect("Migration failed");
-
-        let mut tms = TextMessageService::new(public_key, db_path);
-
-        let mut contacts = Vec::new();
-
-        let screen_names = vec![
-            "Alice".to_string(),
-            "Bob".to_string(),
-            "Carol".to_string(),
-            "Dave".to_string(),
-            "Eric".to_string(),
-        ];
-        for i in 0..5 {
-            let (_contact_secret_key, contact_public_key) = CommsPublicKey::random_keypair(&mut rng);
-            contacts.push(Contact::new(
-                screen_names[i].clone(),
-                contact_public_key,
-                "127.0.0.1:12345".parse().unwrap(),
-            ));
-        }
-
-        assert_eq!(tms.get_screen_name(), None);
-        tms.set_screen_name("Fred".to_string());
-        assert_eq!(tms.get_screen_name(), Some("Fred".to_string()));
-
-        for c in contacts.iter() {
-            let _ = tms.add_contact(c.clone(), &conn);
-        }
-
-        assert_eq!(tms.get_contacts(&conn).unwrap().len(), 5);
-
-        tms.remove_contact(contacts[0].clone(), &conn).unwrap();
-
-        assert_eq!(tms.get_contacts(&conn).unwrap().len(), 4);
-
-        let update_contact = UpdateContact {
-            screen_name: Some("Betty".to_string()),
-            address: Some(contacts[1].address.clone()),
-        };
-
-        tms.update_contact(contacts[1].pub_key.clone(), update_contact, &conn)
-            .unwrap();
-
-        let updated_contacts = tms.get_contacts(&conn).unwrap();
-        assert_eq!(updated_contacts[0].screen_name, "Betty".to_string());
-
-        match tms.update_contact(
-            CommsPublicKey::default(),
-            UpdateContact {
-                screen_name: Some("Whatever".to_string()),
-                address: Some("127.0.0.1:12345".parse().unwrap()),
-            },
-            &conn,
-        ) {
-            Err(TextMessageError::DatabaseError(DieselError::NotFound)) => assert!(true),
-            _ => assert!(false),
-        }
-
-        clean_up(db_name);
-    }
 }

--- a/base_layer/wallet/src/wallet.rs
+++ b/base_layer/wallet/src/wallet.rs
@@ -20,7 +20,7 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use crate::text_message_service::{TextMessageService, TextMessageServiceApi};
+// use crate::text_message_service_sync::{TextMessageService, TextMessageServiceApi};
 use derive_error::Error;
 use std::sync::Arc;
 use tari_comms::{builder::CommsNode, types::CommsPublicKey};
@@ -50,7 +50,7 @@ pub struct WalletConfig {
 pub struct Wallet {
     runtime: Runtime,
     pub ping_pong_service: Arc<PingPongServiceApi>,
-    pub text_message_service: Arc<TextMessageServiceApi>,
+    //  pub text_message_service: Arc<TextMessageServiceApi>,
     pub comms_services: Arc<CommsNode>,
     pub service_executor: ServiceExecutor,
     pub public_key: CommsPublicKey,
@@ -62,12 +62,11 @@ impl Wallet {
         let ping_pong_service = PingPongService::new();
         let ping_pong_service_api = ping_pong_service.get_api();
 
-        let text_message_service = TextMessageService::new(config.public_key.clone(), config.database_path.clone());
-        let text_message_service_api = text_message_service.get_api();
+        //        let text_message_service = TextMessageService::new(config.public_key.clone(),
+        // config.database_path.clone());        let text_message_service_api = text_message_service.get_api();
 
-        let registry = ServiceRegistry::new()
-            .register(ping_pong_service)
-            .register(text_message_service);
+        let registry = ServiceRegistry::new().register(ping_pong_service);
+        //  .register(text_message_service);
 
         let (publisher, subscription_factory) =
             pubsub_connector(runtime.executor(), config.inbound_message_buffer_size);
@@ -78,7 +77,7 @@ impl Wallet {
 
         Ok(Wallet {
             runtime,
-            text_message_service: text_message_service_api,
+            //   text_message_service: text_message_service_api,
             ping_pong_service: ping_pong_service_api,
             comms_services: Arc::new(comms_services),
             service_executor,

--- a/base_layer/wallet/tests/mod.rs
+++ b/base_layer/wallet/tests/mod.rs
@@ -20,8 +20,9 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-// pub mod output_manager_service;
 pub mod support;
-// pub mod text_message_service;
+pub mod text_message_service;
+// TODO These were removed due to Comms layer upgrades, put back once Comms layer is stable
 // pub mod transaction_service;
+// pub mod output_manager_service;
 // pub mod wallet;

--- a/base_layer/wallet/tests/support/data.rs
+++ b/base_layer/wallet/tests/support/data.rs
@@ -21,28 +21,12 @@
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 use std::path::PathBuf;
-use tari_storage::lmdb_store::{LMDBBuilder, LMDBError, LMDBStore};
 
 pub fn get_path(name: Option<&str>) -> String {
     let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     path.push("tests/data");
     path.push(name.unwrap_or(""));
     path.to_str().unwrap().to_string()
-}
-
-pub fn init_datastore(name: &str) -> Result<LMDBStore, LMDBError> {
-    let path = get_path(Some(name));
-    let _ = std::fs::create_dir(&path).unwrap_or_default();
-    LMDBBuilder::new()
-        .set_path(&path)
-        .set_environment_size(10)
-        .set_max_number_of_databases(1)
-        .add_database(name, lmdb_zero::db::CREATE)
-        .build()
-}
-
-pub fn clean_up_datastore(name: &str) {
-    std::fs::remove_dir_all(get_path(Some(name))).unwrap();
 }
 
 pub fn clean_up_sql_database(name: &str) {

--- a/base_layer/wallet/tests/support/utils.rs
+++ b/base_layer/wallet/tests/support/utils.rs
@@ -20,8 +20,8 @@
 //  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 //  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use rand::{CryptoRng, Rng};
-use std::{fmt::Debug, thread, time::Duration};
+use rand::{distributions::Alphanumeric, CryptoRng, OsRng, Rng};
+use std::{fmt::Debug, iter, thread, time::Duration};
 use tari_core::{
     tari_amount::MicroTari,
     transaction::{OutputFeatures, TransactionInput, UnblindedOutput},
@@ -31,9 +31,10 @@ use tari_crypto::{
     commitment::HomomorphicCommitmentFactory,
     keys::{PublicKey as PublicKeyTrait, SecretKey as SecretKeyTrait},
 };
-pub fn assert_change<F, T>(func: F, to: T, poll_count: usize)
+
+pub fn assert_change<F, T>(mut func: F, to: T, poll_count: usize)
 where
-    F: Fn() -> T,
+    F: FnMut() -> T,
     T: Eq + Debug,
 {
     let mut i = 0;
@@ -83,4 +84,9 @@ pub fn make_input<R: Rng + CryptoRng>(rng: &mut R, val: MicroTari) -> (Transacti
     let commitment = COMMITMENT_FACTORY.commit_value(&key, val.into());
     let input = TransactionInput::new(OutputFeatures::default(), commitment);
     (input, UnblindedOutput::new(val, key, None))
+}
+
+pub fn random_string(len: usize) -> String {
+    let mut rng = OsRng::new().unwrap();
+    iter::repeat(()).map(|_| rng.sample(Alphanumeric)).take(len).collect()
 }

--- a/base_layer/wallet/tests/text_message_service/mod.rs
+++ b/base_layer/wallet/tests/text_message_service/mod.rs
@@ -23,50 +23,57 @@
 use crate::support::{comms_and_services::setup_comms_services, data::*, utils::assert_change};
 use std::sync::Arc;
 use tari_comms::{builder::CommsNode, peer_manager::NodeIdentity};
+use tari_comms_dht::Dht;
 use tari_p2p::{
-    sync_services::{ServiceExecutor, ServiceRegistry},
-    tari_message::TariMessageType,
+    comms_connector::pubsub_connector,
+    services::{comms_outbound::CommsOutboundServiceInitializer, liveness::LivenessInitializer},
 };
-use tari_storage::lmdb_store::LMDBDatabase;
-use tari_wallet::text_message_service::{Contact, TextMessageService, TextMessageServiceApi};
-use tokio::runtime::{Runtime, TaskExecutor};
+use tari_service_framework::StackBuilder;
+use tari_wallet::text_message_service::{
+    messages::TextMessageServiceRequester,
+    model::{Contact, UpdateContact},
+    TextMessageHandle,
+    TextMessageServiceInitializer,
+};
+use tokio::runtime::Runtime;
 
 pub fn setup_text_message_service(
-    executor: TaskExecutor,
+    runtime: &Runtime,
     node_identity: NodeIdentity,
     peers: Vec<NodeIdentity>,
-    peer_database: LMDBDatabase,
     database_path: String,
-) -> (ServiceExecutor, Arc<TextMessageServiceApi>, CommsNode)
+) -> (TextMessageServiceRequester, Arc<CommsNode>, Dht)
 {
-    let tms = TextMessageService::new(node_identity.identity.public_key.clone(), database_path);
-    let tms_api = tms.get_api();
+    let (publisher, subscription_factory) = pubsub_connector(runtime.executor(), 100);
+    let subscription_factory = Arc::new(subscription_factory);
+    let (comms, dht) = setup_comms_services(runtime.executor(), Arc::new(node_identity.clone()), peers, publisher);
 
-    let services = ServiceRegistry::new().register(tms);
+    let fut = StackBuilder::new(runtime.executor())
+        .add_initializer(CommsOutboundServiceInitializer::new(dht.outbound_requester()))
+        .add_initializer(LivenessInitializer::new(Arc::clone(&subscription_factory)))
+        .add_initializer(TextMessageServiceInitializer::new(
+            subscription_factory,
+            node_identity.identity.public_key.clone(),
+            database_path,
+        ))
+        .finish();
 
-    let comms = setup_comms_services(executor, node_identity, peers, peer_database);
+    let handles = runtime.block_on(fut).expect("Service initialization failed");
 
-    (ServiceExecutor::execute(&comms, services), tms_api, comms)
+    let tms_api = TextMessageServiceRequester::new(handles.get_handle::<TextMessageHandle>().unwrap());
+
+    (tms_api, comms, dht)
 }
 
 #[test]
 fn test_text_message_service() {
     let runtime = Runtime::new().unwrap();
+
     let mut rng = rand::OsRng::new().unwrap();
 
     let node_1_identity = NodeIdentity::random(&mut rng, "127.0.0.1:31523".parse().unwrap()).unwrap();
     let node_2_identity = NodeIdentity::random(&mut rng, "127.0.0.1:31145".parse().unwrap()).unwrap();
     let node_3_identity = NodeIdentity::random(&mut rng, "127.0.0.1:31546".parse().unwrap()).unwrap();
-
-    let node_1_database_name = "node_1_test_text_message_service"; // Note: every test should have unique database
-    let node_1_datastore = init_datastore(node_1_database_name).unwrap();
-    let node_1_peer_database = node_1_datastore.get_handle(node_1_database_name).unwrap();
-    let node_2_database_name = "node_2_test_text_message_service"; // Note: every test should have unique database
-    let node_2_datastore = init_datastore(node_2_database_name).unwrap();
-    let node_2_peer_database = node_2_datastore.get_handle(node_2_database_name).unwrap();
-    let node_3_database_name = "node_3_test_text_message_service"; // Note: every test should have unique database
-    let node_3_datastore = init_datastore(node_3_database_name).unwrap();
-    let node_3_peer_database = node_3_datastore.get_handle(node_3_database_name).unwrap();
 
     let db_name1 = "test_text_message_service1.sqlite3";
     let db_path1 = get_path(Some(db_name1));
@@ -80,102 +87,100 @@ fn test_text_message_service() {
     let db_path3 = get_path(Some(db_name3));
     init_sql_database(db_name3);
 
-    let (node_1_services, node_1_tms, _comms_1) = setup_text_message_service(
-        runtime.executor(),
+    let (mut node_1_tms, _comms_1, _dht_1) = setup_text_message_service(
+        &runtime,
         node_1_identity.clone(),
         vec![node_2_identity.clone(), node_3_identity.clone()],
-        node_1_peer_database,
         db_path1,
     );
-    let (node_2_services, node_2_tms, _comms_2) = setup_text_message_service(
-        runtime.executor(),
+    let (mut node_2_tms, _comms_2, _dht_2) = setup_text_message_service(
+        &runtime,
         node_2_identity.clone(),
         vec![node_1_identity.clone()],
-        node_2_peer_database,
         db_path2,
     );
-    let (node_3_services, node_3_tms, _comms_3) = setup_text_message_service(
-        runtime.executor(),
+    let (mut node_3_tms, _comms_3, _dht_3) = setup_text_message_service(
+        &runtime,
         node_3_identity.clone(),
         vec![node_1_identity.clone()],
-        node_3_peer_database,
         db_path3,
     );
 
-    node_1_tms
-        .add_contact(Contact::new(
+    runtime
+        .block_on(node_1_tms.add_contact(Contact::new(
             "Bob".to_string(),
             node_2_identity.identity.public_key.clone(),
-            node_2_identity.control_service_address().unwrap(),
-        ))
+            node_2_identity.control_service_address(),
+        )))
         .unwrap();
-    node_1_tms
-        .add_contact(Contact::new(
+
+    runtime
+        .block_on(node_1_tms.add_contact(Contact::new(
             "Carol".to_string(),
             node_3_identity.identity.public_key.clone(),
-            node_3_identity.control_service_address().unwrap(),
-        ))
+            node_3_identity.control_service_address(),
+        )))
         .unwrap();
 
-    node_2_tms
-        .add_contact(Contact::new(
+    runtime
+        .block_on(node_2_tms.add_contact(Contact::new(
             "Alice".to_string(),
             node_1_identity.identity.public_key.clone(),
-            node_1_identity.control_service_address().unwrap(),
-        ))
+            node_1_identity.control_service_address(),
+        )))
         .unwrap();
 
-    node_3_tms
-        .add_contact(Contact::new(
+    runtime
+        .block_on(node_3_tms.add_contact(Contact::new(
             "Alice".to_string(),
             node_1_identity.identity.public_key.clone(),
-            node_1_identity.control_service_address().unwrap(),
-        ))
+            node_1_identity.control_service_address(),
+        )))
         .unwrap();
-
     let mut node1_to_node2_sent_messages = vec!["Say Hello".to_string(), "to my little friend!".to_string()];
 
-    node_1_tms
-        .send_text_message(
+    runtime
+        .block_on(node_1_tms.send_text_message(
             node_2_identity.identity.public_key.clone(),
             node1_to_node2_sent_messages[0].clone(),
-        )
-        .unwrap();
-    node_1_tms
-        .send_text_message(node_3_identity.identity.public_key.clone(), "Say Hello".to_string())
+        ))
         .unwrap();
 
-    node_2_tms
-        .send_text_message(node_1_identity.identity.public_key.clone(), "hello?".to_string())
+    runtime
+        .block_on(node_1_tms.send_text_message(node_3_identity.identity.public_key.clone(), "Say Hello".to_string()))
         .unwrap();
-    node_1_tms
-        .send_text_message(
+
+    runtime
+        .block_on(node_2_tms.send_text_message(node_1_identity.identity.public_key.clone(), "hello?".to_string()))
+        .unwrap();
+    runtime
+        .block_on(node_1_tms.send_text_message(
             node_2_identity.identity.public_key.clone(),
             node1_to_node2_sent_messages[1].clone(),
-        )
+        ))
         .unwrap();
 
     for i in 0..3 {
         node1_to_node2_sent_messages.push(format!("Message {}", i).to_string());
-        node_1_tms
-            .send_text_message(
+        runtime
+            .block_on(node_1_tms.send_text_message(
                 node_2_identity.identity.public_key.clone(),
                 node1_to_node2_sent_messages[2 + i].clone(),
-            )
+            ))
             .unwrap();
     }
     for i in 0..3 {
-        node_2_tms
-            .send_text_message(
+        runtime
+            .block_on(node_2_tms.send_text_message(
                 node_1_identity.identity.public_key.clone(),
                 format!("Message {}", i).to_string(),
-            )
+            ))
             .unwrap();
     }
 
     assert_change(
         || {
-            let msgs = node_1_tms.get_text_messages().unwrap();
+            let msgs = runtime.block_on(node_1_tms.get_text_messages()).unwrap();
 
             (msgs.sent_messages.len(), msgs.received_messages.len())
         },
@@ -185,15 +190,15 @@ fn test_text_message_service() {
 
     assert_change(
         || {
-            let msgs = node_2_tms.get_text_messages().unwrap();
+            let msgs = runtime.block_on(node_2_tms.get_text_messages()).unwrap();
             (msgs.sent_messages.len(), msgs.received_messages.len())
         },
         (4, 5),
         50,
     );
 
-    let node1_msgs = node_1_tms
-        .get_text_messages_by_pub_key(node_2_identity.identity.public_key)
+    let node1_msgs = runtime
+        .block_on(node_1_tms.get_text_messages_by_pub_key(node_2_identity.identity.public_key))
         .unwrap();
 
     assert_eq!(node1_msgs.sent_messages.len(), node1_to_node2_sent_messages.len());
@@ -201,8 +206,8 @@ fn test_text_message_service() {
         assert_eq!(node1_msgs.sent_messages[i].message, node1_to_node2_sent_messages[i]);
     }
 
-    let node2_msgs = node_2_tms
-        .get_text_messages_by_pub_key(node_1_identity.identity.public_key)
+    let node2_msgs = runtime
+        .block_on(node_2_tms.get_text_messages_by_pub_key(node_1_identity.identity.public_key))
         .unwrap();
 
     assert_eq!(node2_msgs.received_messages.len(), node1_to_node2_sent_messages.len());
@@ -210,13 +215,94 @@ fn test_text_message_service() {
         assert_eq!(node2_msgs.received_messages[i].message, node1_to_node2_sent_messages[i]);
     }
 
-    node_1_services.shutdown().unwrap();
-    node_2_services.shutdown().unwrap();
-    node_3_services.shutdown().unwrap();
-    clean_up_datastore(node_1_database_name);
-    clean_up_datastore(node_2_database_name);
-    clean_up_datastore(node_3_database_name);
     clean_up_sql_database(db_name1);
     clean_up_sql_database(db_name2);
     clean_up_sql_database(db_name3);
+}
+
+#[test]
+fn test_text_message_requester_crud() {
+    let runtime = Runtime::new().unwrap();
+    let mut rng = rand::OsRng::new().unwrap();
+    let node_1_identity = NodeIdentity::random(&mut rng, "127.0.0.1:30123".parse().unwrap()).unwrap();
+    let node_2_identity = NodeIdentity::random(&mut rng, "127.0.0.1:30145".parse().unwrap()).unwrap();
+    let node_3_identity = NodeIdentity::random(&mut rng, "127.0.0.1:30546".parse().unwrap()).unwrap();
+
+    // Note: every test should have unique database
+    let db_name1 = "test_tms_crud1.sqlite3";
+    let db_path1 = get_path(Some(db_name1));
+    init_sql_database(db_name1);
+
+    let (mut node_1_tms, _comms_1, _dht_1) = setup_text_message_service(
+        &runtime,
+        node_1_identity.clone(),
+        vec![node_2_identity.clone(), node_3_identity.clone()],
+        db_path1,
+    );
+
+    runtime
+        .block_on(node_1_tms.set_screen_name("Alice".to_string()))
+        .unwrap();
+
+    let sn = runtime.block_on(node_1_tms.get_screen_name()).unwrap();
+
+    assert_eq!(sn, Some("Alice".to_string()));
+
+    runtime
+        .block_on(node_1_tms.add_contact(Contact::new(
+            "Bob".to_string(),
+            node_2_identity.identity.public_key.clone(),
+            node_2_identity.control_service_address(),
+        )))
+        .unwrap();
+
+    runtime
+        .block_on(node_1_tms.add_contact(Contact::new(
+            "Carol".to_string(),
+            node_3_identity.identity.public_key.clone(),
+            node_3_identity.control_service_address(),
+        )))
+        .unwrap();
+
+    assert!(runtime
+        .block_on(node_1_tms.add_contact(Contact::new(
+            "Carol".to_string(),
+            node_3_identity.identity.public_key.clone(),
+            node_3_identity.control_service_address(),
+        )))
+        .is_err());
+
+    let contacts = runtime.block_on(node_1_tms.get_contacts()).unwrap();
+    assert_eq!(contacts.len(), 2);
+    assert_eq!(contacts[0].screen_name, "Bob".to_string());
+    assert_eq!(contacts[1].screen_name, "Carol".to_string());
+
+    runtime
+        .block_on(
+            node_1_tms.update_contact(node_2_identity.identity.public_key.clone(), UpdateContact {
+                screen_name: Some("Dave".to_string()),
+                address: None,
+            }),
+        )
+        .unwrap();
+
+    let contacts = runtime.block_on(node_1_tms.get_contacts()).unwrap();
+
+    assert_eq!(contacts.len(), 2);
+    assert_eq!(contacts[0].screen_name, "Dave".to_string());
+
+    runtime
+        .block_on(node_1_tms.remove_contact(Contact::new(
+            "Dave".to_string(),
+            node_2_identity.identity.public_key.clone(),
+            node_2_identity.control_service_address(),
+        )))
+        .unwrap();
+
+    let contacts = runtime.block_on(node_1_tms.get_contacts()).unwrap();
+
+    assert_eq!(contacts.len(), 1);
+    assert_eq!(contacts[0].screen_name, "Carol".to_string());
+
+    clean_up_sql_database(db_name1);
 }

--- a/base_layer/wallet/tests/wallet/mod.rs
+++ b/base_layer/wallet/tests/wallet/mod.rs
@@ -30,7 +30,7 @@ use tari_comms::{
 };
 use tari_crypto::keys::{PublicKey, SecretKey};
 use tari_p2p::initialization::CommsConfig;
-use tari_wallet::{text_message_service::Contact, wallet::WalletConfig, Wallet};
+use tari_wallet::{text_message_service_sync::Contact, wallet::WalletConfig, Wallet};
 
 fn create_peer(public_key: CommsPublicKey, net_address: NetAddress) -> Peer {
     Peer::new(

--- a/ffi/src/lib.rs
+++ b/ffi/src/lib.rs
@@ -40,12 +40,12 @@ use tari_comms::{
 use tari_crypto::keys::PublicKey;
 use tari_p2p::{initialization::CommsConfig, sync_services::ServiceError};
 use tari_utilities::hex::Hex;
-use tari_wallet::{text_message_service::Contact, wallet::WalletConfig};
+use tari_wallet::{text_message_service_sync::Contact, wallet::WalletConfig};
 
 /// Once bindings are generated via cbindgen, change the using to struct, remove the equals sign and anything after it
 /// on the line. These are used as opaque pointers
 pub type Wallet = tari_wallet::Wallet;
-pub type ReceivedTextMessage = tari_wallet::text_message_service::ReceivedTextMessage;
+pub type ReceivedTextMessage = tari_wallet::text_message_service_sync::ReceivedTextMessage;
 pub type SentTextMessage = tari_wallet::text_message_service::SentTextMessage;
 
 /// Received Messages


### PR DESCRIPTION
## Description
This PR converts the TMS to be async and use the Service Framework to be able to be compassable into domain service stacks. The TMS is now able to directly connect to pub_sub channels from the Comms layer and a Requester handle is provided that will be used as the API interface to the service from the application and other services. The Diesel db backend calls have been wrapped as Blocking futures as they are disk I/O bound. 

This PR comment out the FFI, GRPC_Wallet, Console Text Messenger application and removed the Liveness aspect in the TMS as it was causing trouble with the current version of the Comms stack which is undergoing a major refactor. Rather than fixing this now and then redoing it when the Comms stack is stable I decided to pull these items out and then return them when the comms stack is finally stable. Issues have been created for this.
https://github.com/tari-project/tari/issues/797
https://github.com/tari-project/tari/issues/796

## Motivation and Context
Closes https://github.com/tari-project/tari/issues/689

## How Has This Been Tested?
Tests have been provided 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [x] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [x] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch
* [x] I ran `cargo-fmt --all` before pushing
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
