### PR TITLE
OMS concurrency improvements

### DIFF
--- a/base_layer/p2p/src/initialization.rs
+++ b/base_layer/p2p/src/initialization.rs
@@ -143,7 +143,7 @@ where
             .layer(dht.outbound_middleware_layer())
             .service(SinkMiddleware::new(outbound_tx)),
     );
-    outbound_pipeline.spawn_with(executor.clone());
+    outbound_pipeline.spawn_with(executor);
 
     Ok((comms, dht))
 }

--- a/comms/src/lib.rs
+++ b/comms/src/lib.rs
@@ -6,7 +6,7 @@
 //!
 //! [CommsBuilder]: ./builder/index.html
 // Recursion limit for futures::select!
-#![recursion_limit = "256"]
+#![recursion_limit = "512"]
 // Allow `type Future = impl Future`
 #![feature(type_alias_impl_trait)]
 

--- a/comms/src/outbound_message_service/mod.rs
+++ b/comms/src/outbound_message_service/mod.rs
@@ -29,11 +29,18 @@ pub use self::{error::OutboundServiceError, messages::OutboundMessage, service::
 
 /// Configuration for the OutboundService
 pub struct OutboundServiceConfig {
+    /// Maximum attempts to send a message before discarding it. Default: 5
     pub max_attempts: usize,
+    /// Maximum size of the recent connection cache. This cache keeps active connections
+    /// for reuse with subsequent messages without querying the connection manager. Default: 20
+    pub max_cached_connections: usize,
 }
 
 impl Default for OutboundServiceConfig {
     fn default() -> Self {
-        Self { max_attempts: 5 }
+        Self {
+            max_attempts: 5,
+            max_cached_connections: 20,
+        }
     }
 }


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
- OMS now keeps a small set of active connections so that they can be
  reused without querying connection manager. This improves performance
  when some connections are pending while new messages are incoming for
  peers that are already connected.
- Added a shutdown signal for OMS to ensure it shuts down timeously

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Ref #692 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Expanded test to test for connection reuse

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch
* [x] I ran `cargo-fmt --all` before pushing
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
