### PR TITLE
Sw add extra kernel challenge

### DIFF
--- a/base_layer/core/src/test_utils/primitives.rs
+++ b/base_layer/core/src/test_utils/primitives.rs
@@ -51,7 +51,12 @@ pub fn create_random_signature(fee: MicroTari, lock_height: u64) -> (PublicKey, 
     let mut rng = rand::OsRng::new().unwrap();
     let r = PrivateKey::random(&mut rng);
     let (k, p) = PublicKey::random_keypair(&mut rng);
-    let tx_meta = TransactionMetadata { fee, lock_height };
+    let tx_meta = TransactionMetadata {
+        fee,
+        lock_height,
+        meta_info: None,
+        linked_kernel: None,
+    };
     let e = build_challenge(&PublicKey::from_secret_key(&r), &tx_meta);
     (p, Signature::sign(k, r, &e).unwrap())
 }

--- a/base_layer/core/src/transaction.rs
+++ b/base_layer/core/src/transaction.rs
@@ -477,6 +477,8 @@ impl TransactionKernel {
         let m = TransactionMetadata {
             lock_height: self.lock_height,
             fee: self.fee,
+            meta_info: None,
+            linked_kernel: None,
         };
         let c = build_challenge(r, &m);
         if self.excess_sig.verify_challenge(excess, &c) {

--- a/base_layer/core/src/transaction_protocol/recipient.rs
+++ b/base_layer/core/src/transaction_protocol/recipient.rs
@@ -176,6 +176,8 @@ mod test {
         let m = TransactionMetadata {
             fee: MicroTari(125),
             lock_height: 0,
+            meta_info: None,
+            linked_kernel: None,
         };
         let msg = SingleRoundSenderData {
             tx_id: 15,

--- a/base_layer/core/src/transaction_protocol/single_receiver.rs
+++ b/base_layer/core/src/transaction_protocol/single_receiver.rs
@@ -148,6 +148,8 @@ mod test {
         let m = TransactionMetadata {
             fee: MicroTari(100),
             lock_height: 0,
+            meta_info: None,
+            linked_kernel: None,
         };
         let info = SingleRoundSenderData {
             tx_id: 500,

--- a/base_layer/core/src/transaction_protocol/transaction_initializer.rs
+++ b/base_layer/core/src/transaction_protocol/transaction_initializer.rs
@@ -284,6 +284,8 @@ impl SenderTransactionInitializer {
             metadata: TransactionMetadata {
                 fee: total_fee,
                 lock_height: self.lock_height.unwrap(),
+                meta_info: None,
+                linked_kernel: None,
             },
             inputs: self.inputs,
             outputs,


### PR DESCRIPTION
##  Description
This PR adds optional kernel fields to the challenge as well. 
The challenge will take the fields into consideration if the fields are filled in
## Motivation and Context
#740 

## How Has This Been Tested?
This breaks none of the unit tests and these are optional fields

## Types of changes
* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
* [x] I'm merging against the `development` branch
* [x] I ran `cargo-fmt --all` before pushing
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
