### PR TITLE
Initial LMDB BlockchainBackend implementation

### DIFF
--- a/base_layer/core/Cargo.toml
+++ b/base_layer/core/Cargo.toml
@@ -36,6 +36,8 @@ croaring = "^0.4.0"
 tokio = { version="^0.2.0-alpha.4" }
 tokio-executor = { version ="^0.2.0-alpha.4", features = ["threadpool"] }
 futures-preview = {version = "0.3.0-alpha.18", features = ["nightly", "async-await"] }
+lmdb-zero = "0.4.4"
 
 [dev-dependencies]
 env_logger = "0.7.0"
+tari_test_utils = { path = "../../infrastructure/test_utils", version = "^0.0" }

--- a/base_layer/core/src/chain_storage/db_transaction.rs
+++ b/base_layer/core/src/chain_storage/db_transaction.rs
@@ -26,6 +26,7 @@ use crate::{
     transaction::{TransactionInput, TransactionKernel, TransactionOutput},
     types::HashOutput,
 };
+use serde::{Deserialize, Serialize};
 use std::fmt::{Display, Error, Formatter};
 use tari_utilities::{hex::to_hex, Hashable};
 
@@ -189,7 +190,7 @@ pub enum MetadataKey {
     PruningHorizon,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Deserialize, Serialize)]
 pub enum MetadataValue {
     ChainHeight(Option<u64>),
     BestBlock(Option<BlockHash>),

--- a/base_layer/core/src/chain_storage/lmdb_db/lmdb.rs
+++ b/base_layer/core/src/chain_storage/lmdb_db/lmdb.rs
@@ -1,0 +1,148 @@
+// Copyright 2019. The Tari Project
+//
+// Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+// following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+// disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+// following disclaimer in the documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+// products derived from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+// INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+// WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+// USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+use crate::chain_storage::error::ChainStorageError;
+use lmdb_zero::{
+    error::{self, LmdbResultExt},
+    put,
+    ConstAccessor,
+    Cursor,
+    CursorIter,
+    Database,
+    Environment,
+    Ignore,
+    MaybeOwned,
+    ReadTransaction,
+    WriteTransaction,
+};
+use serde::{de::DeserializeOwned, Serialize};
+
+// TODO: Calling `access` for every lmdb operation has some overhead (an atomic read and set). Check if is possible to
+// pass an Accessor instead of the WriteTransaction?
+
+pub fn serialize<T>(data: &T) -> Result<Vec<u8>, ChainStorageError>
+where T: Serialize {
+    let mut buf = Vec::with_capacity(512);
+    bincode::serialize_into(&mut buf, data).map_err(|e| ChainStorageError::AccessError(e.to_string()))?;
+    Ok(buf)
+}
+
+pub fn deserialize<T>(buf_bytes: &[u8]) -> Result<T, error::Error>
+where T: DeserializeOwned {
+    bincode::deserialize(buf_bytes).map_err(|e| error::Error::ValRejected(e.to_string()))
+}
+
+pub fn lmdb_insert<K, V>(txn: &WriteTransaction, db: &Database, key: &K, val: &V) -> Result<(), ChainStorageError>
+where
+    K: Serialize,
+    V: Serialize,
+{
+    let key_buf = serialize(key)?;
+    let val_buf = serialize(val)?;
+    txn.access()
+        .put(&db, &key_buf, &val_buf, put::Flags::empty())
+        .map_err(|e| ChainStorageError::AccessError(e.to_string()))
+}
+
+pub fn lmdb_delete<K>(txn: &WriteTransaction, db: &Database, key: &K) -> Result<(), ChainStorageError>
+where K: Serialize {
+    let key_buf = serialize(key)?;
+    txn.access()
+        .del_key(&db, &key_buf)
+        .map_err(|e| ChainStorageError::AccessError(e.to_string()))
+}
+
+pub fn lmdb_get<K, V>(env: &Environment, db: &Database, key: &K) -> Result<Option<V>, ChainStorageError>
+where
+    K: Serialize,
+    V: DeserializeOwned,
+{
+    let txn = ReadTransaction::new(env).map_err(|e| ChainStorageError::AccessError(e.to_string()))?;
+    let access = txn.access();
+    let key_buf = serialize(key)?;
+    match access.get(&db, &key_buf).to_opt() {
+        Ok(None) => Ok(None),
+        Err(e) => Err(ChainStorageError::AccessError(e.to_string())),
+        Ok(Some(v)) => match deserialize(v) {
+            Ok(val) => Ok(Some(val)),
+            Err(e) => Err(ChainStorageError::AccessError(e.to_string())),
+        },
+    }
+}
+
+pub fn lmdb_exists<K>(env: &Environment, db: &Database, key: &K) -> Result<bool, ChainStorageError>
+where K: Serialize {
+    let txn = ReadTransaction::new(env).map_err(|e| ChainStorageError::AccessError(e.to_string()))?;
+    let access = txn.access();
+    let key_buf = serialize(key)?;
+    let res: error::Result<&Ignore> = access.get(&db, &key_buf);
+    let res = res
+        .to_opt()
+        .map_err(|e| ChainStorageError::AccessError(e.to_string()))?
+        .is_some();
+    Ok(res)
+}
+
+pub fn lmdb_len(env: &Environment, db: &Database) -> Result<usize, ChainStorageError> {
+    let txn = ReadTransaction::new(env).map_err(|e| ChainStorageError::AccessError(e.to_string()))?;
+    let stats = txn
+        .db_stat(&db)
+        .map_err(|e| ChainStorageError::AccessError(e.to_string()))?;
+    Ok(stats.entries)
+}
+
+pub fn lmdb_iter_next<K, V>(c: &mut Cursor, access: &ConstAccessor) -> Result<(K, V), error::Error>
+where
+    K: DeserializeOwned,
+    V: DeserializeOwned,
+{
+    let (key_bytes, val_bytes) = c.next(access)?;
+    let key = deserialize::<K>(key_bytes)?;
+    let val = deserialize::<V>(val_bytes)?;
+    Ok((key, val))
+}
+
+pub fn lmdb_for_each<F, K, V>(env: &Environment, db: &Database, mut f: F) -> Result<(), ChainStorageError>
+where
+    F: FnMut(Result<(K, V), ChainStorageError>),
+    K: DeserializeOwned,
+    V: DeserializeOwned,
+{
+    let txn = ReadTransaction::new(env).map_err(|e| ChainStorageError::AccessError(e.to_string()))?;
+    let access = txn.access();
+    let cursor = txn
+        .cursor(db)
+        .map_err(|e| ChainStorageError::AccessError(e.to_string()))?;
+    let head = |c: &mut Cursor, a: &ConstAccessor| {
+        let (key_bytes, val_bytes) = c.first(a)?;
+        let key = deserialize::<K>(key_bytes)?;
+        let val = deserialize::<V>(val_bytes)?;
+        Ok((key, val))
+    };
+    let cursor = MaybeOwned::Owned(cursor);
+    let iter = CursorIter::new(cursor, &access, head, lmdb_iter_next)
+        .map_err(|e| ChainStorageError::AccessError(e.to_string()))?;
+    for p in iter {
+        f(p.map_err(|e| ChainStorageError::AccessError(e.to_string())));
+    }
+    Ok(())
+}

--- a/base_layer/core/src/chain_storage/lmdb_db/lmdb_db.rs
+++ b/base_layer/core/src/chain_storage/lmdb_db/lmdb_db.rs
@@ -1,0 +1,646 @@
+// Copyright 2019. The Tari Project
+//
+// Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+// following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+// disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+// following disclaimer in the documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+// products derived from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+// INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+// WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+// USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+use crate::{
+    blocks::{blockheader::BlockHeader, Block},
+    chain_storage::{
+        blockchain_database::BlockchainBackend,
+        db_transaction::{DbKey, DbKeyValuePair, DbTransaction, DbValue, MetadataValue, MmrTree, WriteOperation},
+        error::ChainStorageError,
+        lmdb_db::{
+            lmdb::{lmdb_delete, lmdb_exists, lmdb_for_each, lmdb_get, lmdb_insert},
+            LMDBVec,
+            LMDB_DB_BLOCK_HASHES,
+            LMDB_DB_HEADERS,
+            LMDB_DB_HEADER_MMR_BASE_BACKEND,
+            LMDB_DB_HEADER_MMR_CP_BACKEND,
+            LMDB_DB_KERNELS,
+            LMDB_DB_KERNEL_MMR_BASE_BACKEND,
+            LMDB_DB_KERNEL_MMR_CP_BACKEND,
+            LMDB_DB_METADATA,
+            LMDB_DB_ORPHANS,
+            LMDB_DB_RANGE_PROOF_MMR_BASE_BACKEND,
+            LMDB_DB_RANGE_PROOF_MMR_CP_BACKEND,
+            LMDB_DB_STXOS,
+            LMDB_DB_UTXOS,
+            LMDB_DB_UTXO_MMR_BASE_BACKEND,
+            LMDB_DB_UTXO_MMR_CP_BACKEND,
+        },
+    },
+    transaction::{TransactionKernel, TransactionOutput},
+    types::{HashDigest, HashOutput},
+};
+use digest::Digest;
+use lmdb_zero::{Database, Environment, WriteTransaction};
+use serde::{Deserialize, Serialize};
+use std::{
+    path::Path,
+    sync::{Arc, RwLock},
+};
+use tari_mmr::{Hash as MmrHash, MerkleChangeTracker, MerkleCheckPoint, MerkleProof, MutableMmr};
+use tari_storage::lmdb_store::{db, LMDBBuilder, LMDBStore};
+use tari_utilities::hash::Hashable;
+
+type DatabaseRef = Arc<Database<'static>>;
+
+/// A generic struct for storing node objects in the BlockchainDB that also form part of an MMR. The index field makes
+/// reverse lookups (find by hash) possible.
+#[derive(Serialize, Deserialize)]
+struct MerkleNode<T> {
+    index: usize,
+    value: T,
+}
+
+/// This is a lmdb-based blockchain database for persistent storage of the chain state.
+pub struct LMDBDatabase<D>
+where D: Digest
+{
+    env: Arc<Environment>,
+    metadata_db: DatabaseRef,
+    headers_db: DatabaseRef,
+    block_hashes_db: DatabaseRef,
+    utxos_db: DatabaseRef,
+    stxos_db: DatabaseRef,
+    kernels_db: DatabaseRef,
+    orphans_db: DatabaseRef,
+    utxo_mmr: RwLock<MerkleChangeTracker<D, LMDBVec<MmrHash>, Vec<MerkleCheckPoint> /* LMDBVec<MerkleCheckPoint> */>>,
+    header_mmr: RwLock<MerkleChangeTracker<D, LMDBVec<MmrHash>, Vec<MerkleCheckPoint> /* LMDBVec<MerkleCheckPoint> */>>,
+    kernel_mmr: RwLock<MerkleChangeTracker<D, LMDBVec<MmrHash>, Vec<MerkleCheckPoint> /* LMDBVec<MerkleCheckPoint> */>>,
+    range_proof_mmr:
+        RwLock<MerkleChangeTracker<D, LMDBVec<MmrHash>, Vec<MerkleCheckPoint> /* LMDBVec<MerkleCheckPoint> */>>,
+}
+
+impl<D> LMDBDatabase<D>
+where D: Digest + Send + Sync
+{
+    pub fn new(store: LMDBStore) -> Result<Self, ChainStorageError> {
+        let utxo_mmr_base_backend = LMDBVec::new(
+            store.env(),
+            store
+                .get_handle(LMDB_DB_UTXO_MMR_BASE_BACKEND)
+                .ok_or(ChainStorageError::CriticalError)?
+                .db()
+                .clone(),
+        );
+        // let utxo_mmr_cp_backend = LMDBVec::new(
+        // store.env(),
+        // store
+        // .get_handle(LMDB_DB_UTXO_MMR_CP_BACKEND)
+        // .ok_or(ChainStorageError::CriticalError)?
+        // .db()
+        // .clone(),
+        // );
+        let header_mmr_base_backend = LMDBVec::new(
+            store.env(),
+            store
+                .get_handle(LMDB_DB_HEADER_MMR_BASE_BACKEND)
+                .ok_or(ChainStorageError::CriticalError)?
+                .db()
+                .clone(),
+        );
+        // let header_mmr_cp_backend = LMDBVec::new(store.env(),
+        // store
+        // .get_handle(LMDB_DB_HEADER_MMR_CP_BACKEND)
+        // .ok_or(ChainStorageError::CriticalError)?.db()
+        //                .clone(),
+        // );
+        let kernel_mmr_base_backend = LMDBVec::new(
+            store.env(),
+            store
+                .get_handle(LMDB_DB_KERNEL_MMR_BASE_BACKEND)
+                .ok_or(ChainStorageError::CriticalError)?
+                .db()
+                .clone(),
+        );
+        // let kernel_mmr_cp_backend = LMDBVec::new(store.env(),
+        // store
+        // .get_handle(LMDB_DB_KERNEL_MMR_CP_BACKEND)
+        // .ok_or(ChainStorageError::CriticalError)?.db()
+        //                .clone(),
+        // );
+        let range_proof_mmr_base_backend = LMDBVec::new(
+            store.env(),
+            store
+                .get_handle(LMDB_DB_RANGE_PROOF_MMR_BASE_BACKEND)
+                .ok_or(ChainStorageError::CriticalError)?
+                .db()
+                .clone(),
+        );
+        // let range_proof_mmr_cp_backend = LMDBVec::new(store.env(),
+        // store
+        // .get_handle(LMDB_DB_RANGE_PROOF_MMR_CP_BACKEND)
+        // .ok_or(ChainStorageError::CriticalError)?.db()
+        //                .clone(),
+        // );
+        Ok(Self {
+            metadata_db: store
+                .get_handle(LMDB_DB_METADATA)
+                .ok_or(ChainStorageError::CriticalError)?
+                .db()
+                .clone(),
+            headers_db: store
+                .get_handle(LMDB_DB_HEADERS)
+                .ok_or(ChainStorageError::CriticalError)?
+                .db()
+                .clone(),
+            block_hashes_db: store
+                .get_handle(LMDB_DB_BLOCK_HASHES)
+                .ok_or(ChainStorageError::CriticalError)?
+                .db()
+                .clone(),
+            utxos_db: store
+                .get_handle(LMDB_DB_UTXOS)
+                .ok_or(ChainStorageError::CriticalError)?
+                .db()
+                .clone(),
+            stxos_db: store
+                .get_handle(LMDB_DB_STXOS)
+                .ok_or(ChainStorageError::CriticalError)?
+                .db()
+                .clone(),
+            kernels_db: store
+                .get_handle(LMDB_DB_KERNELS)
+                .ok_or(ChainStorageError::CriticalError)?
+                .db()
+                .clone(),
+            orphans_db: store
+                .get_handle(LMDB_DB_ORPHANS)
+                .ok_or(ChainStorageError::CriticalError)?
+                .db()
+                .clone(),
+            utxo_mmr: RwLock::new(MerkleChangeTracker::new(
+                MutableMmr::new(utxo_mmr_base_backend),
+                Vec::new(), // utxo_mmr_cp_backend,
+            )?),
+            header_mmr: RwLock::new(MerkleChangeTracker::new(
+                MutableMmr::new(header_mmr_base_backend),
+                Vec::new(), // header_mmr_cp_backend
+            )?),
+            kernel_mmr: RwLock::new(MerkleChangeTracker::new(
+                MutableMmr::new(kernel_mmr_base_backend),
+                Vec::new(), // kernel_mmr_cp_backend
+            )?),
+            range_proof_mmr: RwLock::new(MerkleChangeTracker::new(
+                MutableMmr::new(range_proof_mmr_base_backend),
+                Vec::new(), // range_proof_mmr_cp_backend
+            )?),
+            env: store.env(),
+        })
+    }
+}
+
+#[allow(dead_code)]
+pub fn create_lmdb_database(path: &Path) -> Result<LMDBDatabase<HashDigest>, ChainStorageError> {
+    let _ = std::fs::create_dir(&path).unwrap_or_default();
+    let lmdb_store = LMDBBuilder::new()
+        .set_path(path.to_str().unwrap())
+        .set_environment_size(15)
+        .set_max_number_of_databases(15)
+        .add_database(LMDB_DB_METADATA, db::CREATE)
+        .add_database(LMDB_DB_HEADERS, db::CREATE)
+        .add_database(LMDB_DB_BLOCK_HASHES, db::CREATE)
+        .add_database(LMDB_DB_UTXOS, db::CREATE)
+        .add_database(LMDB_DB_STXOS, db::CREATE)
+        .add_database(LMDB_DB_KERNELS, db::CREATE)
+        .add_database(LMDB_DB_ORPHANS, db::CREATE)
+        .add_database(LMDB_DB_UTXO_MMR_BASE_BACKEND, db::CREATE)
+        .add_database(LMDB_DB_UTXO_MMR_CP_BACKEND, db::CREATE)
+        .add_database(LMDB_DB_HEADER_MMR_BASE_BACKEND, db::CREATE)
+        .add_database(LMDB_DB_HEADER_MMR_CP_BACKEND, db::CREATE)
+        .add_database(LMDB_DB_KERNEL_MMR_BASE_BACKEND, db::CREATE)
+        .add_database(LMDB_DB_KERNEL_MMR_CP_BACKEND, db::CREATE)
+        .add_database(LMDB_DB_RANGE_PROOF_MMR_BASE_BACKEND, db::CREATE)
+        .add_database(LMDB_DB_RANGE_PROOF_MMR_CP_BACKEND, db::CREATE)
+        .build()
+        .map_err(|_| ChainStorageError::CriticalError)?;
+    LMDBDatabase::<HashDigest>::new(lmdb_store)
+}
+
+impl<D> BlockchainBackend for LMDBDatabase<D>
+where D: Digest + Send + Sync
+{
+    fn write(&self, tx: DbTransaction) -> Result<(), ChainStorageError> {
+        let txn = WriteTransaction::new(self.env.clone()).map_err(|e| ChainStorageError::AccessError(e.to_string()))?;
+        {
+            for op in tx.operations.into_iter() {
+                match op {
+                    WriteOperation::Insert(insert) => match insert {
+                        DbKeyValuePair::Metadata(k, v) => {
+                            lmdb_insert(&txn, &self.metadata_db, &(k as u32), &v)?;
+                        },
+                        DbKeyValuePair::BlockHeader(k, v) => {
+                            let hash = v.hash();
+                            lmdb_insert(&txn, &self.block_hashes_db, &hash, &k)?;
+                            let index = self
+                                .header_mmr
+                                .write()
+                                .map_err(|e| ChainStorageError::AccessError(e.to_string()))?
+                                .push(&hash)? -
+                                1 as usize;
+                            let v = MerkleNode { index, value: *v };
+                            lmdb_insert(&txn, &self.headers_db, &k, &v)?;
+                        },
+                        DbKeyValuePair::UnspentOutput(k, v) => {
+                            self.utxo_mmr
+                                .write()
+                                .map_err(|e| ChainStorageError::AccessError(e.to_string()))?
+                                .push(&k)?;
+                            let proof_hash = v.proof().hash();
+                            let index = self
+                                .range_proof_mmr
+                                .write()
+                                .map_err(|e| ChainStorageError::AccessError(e.to_string()))?
+                                .push(&proof_hash)? -
+                                1;
+                            let v = MerkleNode { index, value: *v };
+                            lmdb_insert(&txn, &self.utxos_db, &k, &v)?;
+                        },
+                        DbKeyValuePair::TransactionKernel(k, v) => {
+                            let index = self
+                                .kernel_mmr
+                                .write()
+                                .map_err(|e| ChainStorageError::AccessError(e.to_string()))?
+                                .push(&k)? -
+                                1;
+                            let v = MerkleNode { index, value: *v };
+                            lmdb_insert(&txn, &self.kernels_db, &k, &v)?;
+                        },
+                        DbKeyValuePair::OrphanBlock(k, v) => {
+                            lmdb_insert(&txn, &self.orphans_db, &k, &v)?;
+                        },
+                        DbKeyValuePair::CommitBlock => {
+                            self.utxo_mmr
+                                .write()
+                                .map_err(|e| ChainStorageError::AccessError(e.to_string()))?
+                                .commit()
+                                .map_err(|e| ChainStorageError::AccessError(e.to_string()))?;
+                            self.header_mmr
+                                .write()
+                                .map_err(|e| ChainStorageError::AccessError(e.to_string()))?
+                                .commit()
+                                .map_err(|e| ChainStorageError::AccessError(e.to_string()))?;
+                            self.range_proof_mmr
+                                .write()
+                                .map_err(|e| ChainStorageError::AccessError(e.to_string()))?
+                                .commit()
+                                .map_err(|e| ChainStorageError::AccessError(e.to_string()))?;
+                            self.kernel_mmr
+                                .write()
+                                .map_err(|e| ChainStorageError::AccessError(e.to_string()))?
+                                .commit()
+                                .map_err(|e| ChainStorageError::AccessError(e.to_string()))?;
+                        },
+                    },
+                    WriteOperation::Delete(delete) => match delete {
+                        DbKey::Metadata(_) => {}, // no-op
+                        DbKey::BlockHeader(k) => {
+                            lmdb_delete(&txn, &self.headers_db, &k)?;
+                            // TODO: shouldn't blockhash also be deleted
+                        },
+                        DbKey::BlockHash(hash) => {
+                            let result: Option<u64> = lmdb_get(&self.env, &self.block_hashes_db, &hash)?;
+                            if let Some(k) = result {
+                                lmdb_delete(&txn, &self.block_hashes_db, &hash)?;
+                                lmdb_delete(&txn, &self.headers_db, &k)?;
+                            }
+                        },
+                        DbKey::UnspentOutput(k) => {
+                            lmdb_delete(&txn, &self.utxos_db, &k)?;
+                        },
+                        DbKey::SpentOutput(k) => {
+                            lmdb_delete(&txn, &self.stxos_db, &k)?;
+                        },
+                        DbKey::TransactionKernel(k) => {
+                            lmdb_delete(&txn, &self.kernels_db, &k)?;
+                        },
+                        DbKey::OrphanBlock(k) => {
+                            lmdb_delete(&txn, &self.orphans_db, &k)?;
+                        },
+                    },
+                    WriteOperation::Spend(key) => match key {
+                        DbKey::UnspentOutput(hash) => {
+                            let utxo_result: Option<MerkleNode<TransactionOutput>> =
+                                lmdb_get(&self.env, &self.utxos_db, &hash)?;
+                            match utxo_result {
+                                Some(utxo) => {
+                                    lmdb_delete(&txn, &self.utxos_db, &hash)?;
+                                    self.utxo_mmr
+                                        .write()
+                                        .map_err(|e| ChainStorageError::AccessError(e.to_string()))?
+                                        .delete(utxo.index as u32);
+                                    lmdb_insert(&txn, &self.stxos_db, &hash, &utxo)?;
+                                },
+                                None => return Err(ChainStorageError::UnspendableInput),
+                            }
+                        },
+                        _ => return Err(ChainStorageError::InvalidOperation("Only UTXOs can be spent".into())),
+                    },
+                    WriteOperation::UnSpend(key) => match key {
+                        DbKey::SpentOutput(hash) => {
+                            let stxo_result: Option<MerkleNode<TransactionOutput>> =
+                                lmdb_get(&self.env, &self.stxos_db, &hash)?;
+                            match stxo_result {
+                                Some(stxo) => {
+                                    lmdb_delete(&txn, &self.stxos_db, &hash)?;
+                                    lmdb_insert(&txn, &self.utxos_db, &hash, &stxo)?;
+                                },
+                                None => return Err(ChainStorageError::UnspendError),
+                            }
+                        },
+                        _ => return Err(ChainStorageError::InvalidOperation("Only STXOs can be unspent".into())),
+                    },
+                    WriteOperation::CreateMmrCheckpoint(tree) => match tree {
+                        MmrTree::Header => {
+                            self.header_mmr
+                                .write()
+                                .map_err(|e| ChainStorageError::AccessError(e.to_string()))?
+                                .commit()
+                                .map_err(|e| ChainStorageError::AccessError(e.to_string()))?;
+                        },
+                        MmrTree::Kernel => {
+                            self.kernel_mmr
+                                .write()
+                                .map_err(|e| ChainStorageError::AccessError(e.to_string()))?
+                                .commit()
+                                .map_err(|e| ChainStorageError::AccessError(e.to_string()))?;
+                        },
+                        MmrTree::Utxo => {
+                            self.utxo_mmr
+                                .write()
+                                .map_err(|e| ChainStorageError::AccessError(e.to_string()))?
+                                .commit()
+                                .map_err(|e| ChainStorageError::AccessError(e.to_string()))?;
+                        },
+                        MmrTree::RangeProof => {
+                            self.range_proof_mmr
+                                .write()
+                                .map_err(|e| ChainStorageError::AccessError(e.to_string()))?
+                                .commit()
+                                .map_err(|e| ChainStorageError::AccessError(e.to_string()))?;
+                        },
+                    },
+                    WriteOperation::RewindMmr(tree, steps_back) => match tree {
+                        MmrTree::Header => {
+                            self.header_mmr
+                                .write()
+                                .map_err(|e| ChainStorageError::AccessError(e.to_string()))?
+                                .rewind(steps_back)
+                                .map_err(|e| ChainStorageError::AccessError(e.to_string()))?;
+                        },
+                        MmrTree::Kernel => {
+                            self.kernel_mmr
+                                .write()
+                                .map_err(|e| ChainStorageError::AccessError(e.to_string()))?
+                                .rewind(steps_back)
+                                .map_err(|e| ChainStorageError::AccessError(e.to_string()))?;
+                        },
+                        MmrTree::Utxo => {
+                            self.utxo_mmr
+                                .write()
+                                .map_err(|e| ChainStorageError::AccessError(e.to_string()))?
+                                .rewind(steps_back)
+                                .map_err(|e| ChainStorageError::AccessError(e.to_string()))?;
+                        },
+                        MmrTree::RangeProof => {
+                            self.range_proof_mmr
+                                .write()
+                                .map_err(|e| ChainStorageError::AccessError(e.to_string()))?
+                                .rewind(steps_back)
+                                .map_err(|e| ChainStorageError::AccessError(e.to_string()))?;
+                        },
+                    },
+                }
+            }
+        }
+        txn.commit().map_err(|e| ChainStorageError::AccessError(e.to_string()))
+    }
+
+    fn fetch(&self, key: &DbKey) -> Result<Option<DbValue>, ChainStorageError> {
+        let result = match key {
+            DbKey::Metadata(k) => {
+                let val: Option<MetadataValue> = lmdb_get(&self.env, &self.metadata_db, &(k.clone() as u32))?;
+                val.map(|val| DbValue::Metadata(val))
+            },
+            DbKey::BlockHeader(k) => {
+                let val: Option<MerkleNode<BlockHeader>> = lmdb_get(&self.env, &self.headers_db, k)?;
+                val.map(|val| DbValue::BlockHeader(Box::new(val.value)))
+            },
+            DbKey::BlockHash(hash) => {
+                let k: Option<u64> = lmdb_get(&self.env, &self.block_hashes_db, hash)?;
+                match k {
+                    Some(k) => {
+                        let val: Option<MerkleNode<BlockHeader>> = lmdb_get(&self.env, &self.headers_db, &k)?;
+                        val.map(|val| DbValue::BlockHash(Box::new(val.value)))
+                    },
+                    None => None,
+                }
+            },
+            DbKey::UnspentOutput(k) => {
+                let val: Option<MerkleNode<TransactionOutput>> = lmdb_get(&self.env, &self.utxos_db, k)?;
+                val.map(|val| DbValue::UnspentOutput(Box::new(val.value)))
+            },
+            DbKey::SpentOutput(k) => {
+                let val: Option<MerkleNode<TransactionOutput>> = lmdb_get(&self.env, &self.stxos_db, k)?;
+                val.map(|val| DbValue::SpentOutput(Box::new(val.value)))
+            },
+            DbKey::TransactionKernel(k) => {
+                let val: Option<MerkleNode<TransactionKernel>> = lmdb_get(&self.env, &self.kernels_db, k)?;
+                val.map(|val| DbValue::TransactionKernel(Box::new(val.value)))
+            },
+            DbKey::OrphanBlock(k) => {
+                let val: Option<Block> = lmdb_get(&self.env, &self.orphans_db, k)?;
+                val.map(|val| DbValue::OrphanBlock(Box::new(val)))
+            },
+        };
+        Ok(result)
+    }
+
+    fn contains(&self, key: &DbKey) -> Result<bool, ChainStorageError> {
+        let result = match key {
+            DbKey::Metadata(k) => lmdb_exists(&self.env, &self.metadata_db, &(k.clone() as u32))?,
+            DbKey::BlockHeader(k) => lmdb_exists(&self.env, &self.headers_db, k)?,
+            DbKey::BlockHash(h) => lmdb_exists(&self.env, &self.block_hashes_db, h)?,
+            DbKey::UnspentOutput(k) => lmdb_exists(&self.env, &self.utxos_db, k)?,
+            DbKey::SpentOutput(k) => lmdb_exists(&self.env, &self.stxos_db, k)?,
+            DbKey::TransactionKernel(k) => lmdb_exists(&self.env, &self.kernels_db, k)?,
+            DbKey::OrphanBlock(k) => lmdb_exists(&self.env, &self.orphans_db, k)?,
+        };
+        Ok(result)
+    }
+
+    fn fetch_mmr_root(&self, tree: MmrTree) -> Result<Vec<u8>, ChainStorageError> {
+        let root = match tree {
+            MmrTree::Utxo => self
+                .utxo_mmr
+                .read()
+                .map_err(|e| ChainStorageError::AccessError(e.to_string()))?
+                .get_merkle_root()?,
+            MmrTree::Kernel => self
+                .kernel_mmr
+                .read()
+                .map_err(|e| ChainStorageError::AccessError(e.to_string()))?
+                .get_merkle_root()?,
+            MmrTree::RangeProof => self
+                .range_proof_mmr
+                .read()
+                .map_err(|e| ChainStorageError::AccessError(e.to_string()))?
+                .get_merkle_root()?,
+            MmrTree::Header => self
+                .header_mmr
+                .read()
+                .map_err(|e| ChainStorageError::AccessError(e.to_string()))?
+                .get_merkle_root()?,
+        };
+        Ok(root)
+    }
+
+    fn fetch_mmr_only_root(&self, tree: MmrTree) -> Result<Vec<u8>, ChainStorageError> {
+        let root = match tree {
+            MmrTree::Utxo => self
+                .utxo_mmr
+                .read()
+                .map_err(|e| ChainStorageError::AccessError(e.to_string()))?
+                .get_mmr_only_root()?,
+            MmrTree::Kernel => self
+                .kernel_mmr
+                .read()
+                .map_err(|e| ChainStorageError::AccessError(e.to_string()))?
+                .get_mmr_only_root()?,
+            MmrTree::RangeProof => self
+                .range_proof_mmr
+                .read()
+                .map_err(|e| ChainStorageError::AccessError(e.to_string()))?
+                .get_mmr_only_root()?,
+            MmrTree::Header => self
+                .header_mmr
+                .read()
+                .map_err(|e| ChainStorageError::AccessError(e.to_string()))?
+                .get_mmr_only_root()?,
+        };
+        Ok(root)
+    }
+
+    /// Returns an MMR proof extracted from the full Merkle mountain range without trimming the MMR using the roaring
+    /// bitmap
+    fn fetch_mmr_proof(&self, tree: MmrTree, leaf_pos: usize) -> Result<MerkleProof, ChainStorageError> {
+        let proof = match tree {
+            MmrTree::Utxo => MerkleProof::for_leaf_node(
+                &self
+                    .utxo_mmr
+                    .read()
+                    .map_err(|e| ChainStorageError::AccessError(e.to_string()))?
+                    .mmr(),
+                leaf_pos,
+            )?,
+            MmrTree::Kernel => MerkleProof::for_leaf_node(
+                &self
+                    .kernel_mmr
+                    .read()
+                    .map_err(|e| ChainStorageError::AccessError(e.to_string()))?
+                    .mmr(),
+                leaf_pos,
+            )?,
+            MmrTree::RangeProof => MerkleProof::for_leaf_node(
+                &self
+                    .range_proof_mmr
+                    .read()
+                    .map_err(|e| ChainStorageError::AccessError(e.to_string()))?
+                    .mmr(),
+                leaf_pos,
+            )?,
+            MmrTree::Header => MerkleProof::for_leaf_node(
+                &self
+                    .header_mmr
+                    .read()
+                    .map_err(|e| ChainStorageError::AccessError(e.to_string()))?
+                    .mmr(),
+                leaf_pos,
+            )?,
+        };
+        Ok(proof)
+    }
+
+    fn fetch_mmr_checkpoint(&self, tree: MmrTree, index: u64) -> Result<MerkleCheckPoint, ChainStorageError> {
+        let index = index as usize;
+        let cp = match tree {
+            MmrTree::Kernel => self
+                .kernel_mmr
+                .read()
+                .map_err(|e| ChainStorageError::AccessError(e.to_string()))?
+                .get_checkpoint(index),
+            MmrTree::Utxo => self
+                .utxo_mmr
+                .read()
+                .map_err(|e| ChainStorageError::AccessError(e.to_string()))?
+                .get_checkpoint(index),
+            MmrTree::RangeProof => self
+                .range_proof_mmr
+                .read()
+                .map_err(|e| ChainStorageError::AccessError(e.to_string()))?
+                .get_checkpoint(index),
+            MmrTree::Header => self
+                .header_mmr
+                .read()
+                .map_err(|e| ChainStorageError::AccessError(e.to_string()))?
+                .get_checkpoint(index),
+        };
+        cp.map_err(|e| ChainStorageError::AccessError(format!("MMR Checkpoint error: {}", e.to_string())))
+    }
+
+    fn fetch_mmr_node(&self, tree: MmrTree, pos: u32) -> Result<(Vec<u8>, bool), ChainStorageError> {
+        let (hash, deleted) = match tree {
+            MmrTree::Kernel => self
+                .kernel_mmr
+                .read()
+                .map_err(|e| ChainStorageError::AccessError(e.to_string()))?
+                .get_leaf_status(pos)?,
+            MmrTree::Header => self
+                .header_mmr
+                .read()
+                .map_err(|e| ChainStorageError::AccessError(e.to_string()))?
+                .get_leaf_status(pos)?,
+            MmrTree::Utxo => self
+                .utxo_mmr
+                .read()
+                .map_err(|e| ChainStorageError::AccessError(e.to_string()))?
+                .get_leaf_status(pos)?,
+            MmrTree::RangeProof => self
+                .range_proof_mmr
+                .read()
+                .map_err(|e| ChainStorageError::AccessError(e.to_string()))?
+                .get_leaf_status(pos)?,
+        };
+        let hash = hash
+            .ok_or(ChainStorageError::UnexpectedResult(format!(
+                "A leaf node hash in the {} MMR tree was not found",
+                tree
+            )))?
+            .clone();
+        Ok((hash, deleted))
+    }
+
+    /// Iterate over all the stored orphan blocks and execute the function `f` for each block.
+    fn for_each_orphan<F>(&self, f: F) -> Result<(), ChainStorageError>
+    where F: FnMut(Result<(HashOutput, Block), ChainStorageError>) {
+        lmdb_for_each::<F, HashOutput, Block>(&self.env, &self.orphans_db, f)
+    }
+}

--- a/base_layer/core/src/chain_storage/lmdb_db/lmdb_vec.rs
+++ b/base_layer/core/src/chain_storage/lmdb_db/lmdb_vec.rs
@@ -1,0 +1,165 @@
+// Copyright 2019. The Tari Project
+//
+// Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+// following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+// disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+// following disclaimer in the documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+// products derived from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+// INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+// WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+// USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+use crate::chain_storage::{
+    error::ChainStorageError,
+    lmdb_db::lmdb::{lmdb_delete, lmdb_get, lmdb_insert, lmdb_len},
+};
+use derive_error::Error;
+use lmdb_zero::{Database, Environment, WriteTransaction};
+use std::{marker::PhantomData, sync::Arc};
+use tari_mmr::{error::MerkleMountainRangeError, ArrayLike, ArrayLikeExt};
+use tari_storage::lmdb_store::LMDBError;
+use tari_utilities::message_format::MessageFormatError;
+
+#[derive(Debug, Error)]
+pub enum LMDBVecError {
+    MessageFormatError(MessageFormatError),
+    LMDBError(LMDBError),
+    ChainStorageError(ChainStorageError),
+}
+
+pub struct LMDBVec<T> {
+    env: Arc<Environment>,
+    db: Arc<Database<'static>>,
+    _t: PhantomData<T>,
+}
+
+impl<T> LMDBVec<T> {
+    pub fn new(env: Arc<Environment>, db: Arc<Database<'static>>) -> Self {
+        Self {
+            env,
+            db,
+            _t: PhantomData,
+        }
+    }
+}
+
+impl<T> ArrayLike for LMDBVec<T>
+where
+    T: serde::Serialize,
+    for<'t> T: serde::de::DeserializeOwned,
+{
+    type Error = LMDBVecError;
+    type Value = T;
+
+    fn len(&self) -> Result<usize, Self::Error> {
+        Ok(lmdb_len(&self.env, &self.db)?)
+    }
+
+    fn push(&mut self, item: Self::Value) -> Result<usize, Self::Error> {
+        let index = self.len()?;
+        let txn = WriteTransaction::new(self.env.clone()).map_err(|e| ChainStorageError::AccessError(e.to_string()))?;
+        {
+            lmdb_insert::<usize, T>(&txn, &self.db, &index, &item)?;
+        }
+        txn.commit()
+            .map_err(|e| ChainStorageError::AccessError(e.to_string()))?;
+        Ok(index)
+    }
+
+    fn get(&self, index: usize) -> Result<Option<Self::Value>, Self::Error> {
+        Ok(lmdb_get::<usize, T>(&self.env, &self.db, &index)?)
+    }
+
+    fn get_or_panic(&self, index: usize) -> Self::Value {
+        self.get(index).unwrap().unwrap()
+    }
+}
+
+impl<T> ArrayLikeExt for LMDBVec<T>
+where for<'t> T: serde::de::DeserializeOwned
+{
+    type Value = T;
+
+    fn truncate(&mut self, len: usize) -> Result<(), MerkleMountainRangeError> {
+        let n_elements =
+            lmdb_len(&self.env, &self.db).map_err(|e| MerkleMountainRangeError::BackendError(e.to_string()))?;
+        if n_elements > len {
+            let txn = WriteTransaction::new(self.env.clone())
+                .map_err(|e| MerkleMountainRangeError::BackendError(e.to_string()))?;
+            {
+                for index in len..n_elements {
+                    lmdb_delete(&txn, &self.db, &index)
+                        .map_err(|e| MerkleMountainRangeError::BackendError(e.to_string()))?;
+                }
+            }
+            txn.commit()
+                .map_err(|e| MerkleMountainRangeError::BackendError(e.to_string()))?;
+        }
+        Ok(())
+    }
+
+    fn for_each<F>(&self, mut f: F) -> Result<(), MerkleMountainRangeError>
+    where F: FnMut(Result<Self::Value, MerkleMountainRangeError>) {
+        let n_elements =
+            lmdb_len(&self.env, &self.db).map_err(|e| MerkleMountainRangeError::BackendError(e.to_string()))?;
+        for index in 0..n_elements {
+            let val = lmdb_get::<usize, T>(&self.env, &self.db, &index)
+                .map_err(|e| MerkleMountainRangeError::BackendError(e.to_string()))?
+                .ok_or(MerkleMountainRangeError::BackendError("Unexpected error".into()))?;
+            f(Ok(val))
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use tari_storage::lmdb_store::{db, LMDBBuilder};
+    use tari_test_utils::paths::create_random_database_path;
+
+    #[test]
+    fn len_push_get_truncate_for_each() {
+        let path = create_random_database_path().to_str().unwrap().to_string();
+        let _ = std::fs::create_dir(&path).unwrap_or_default();
+        let lmdb_store = LMDBBuilder::new()
+            .set_path(&path)
+            .set_environment_size(1)
+            .set_max_number_of_databases(1)
+            .add_database("db", db::CREATE)
+            .build()
+            .unwrap();
+        let mut lmdb_vec = LMDBVec::<i32>::new(lmdb_store.env(), lmdb_store.get_handle("db").unwrap().db().clone());
+        let mut mem_vec = vec![100, 200, 300, 400];
+        assert_eq!(lmdb_vec.len().unwrap(), 0);
+
+        mem_vec
+            .iter()
+            .for_each(|val| assert!(lmdb_vec.push(val.clone()).is_ok()));
+        assert_eq!(lmdb_vec.len().unwrap(), mem_vec.len());
+
+        mem_vec
+            .iter()
+            .enumerate()
+            .for_each(|(i, val)| assert_eq!(lmdb_vec.get(i).unwrap(), Some(val.clone())));
+        assert_eq!(lmdb_vec.get(mem_vec.len()).unwrap(), None);
+
+        mem_vec.truncate(2);
+        assert!(lmdb_vec.truncate(2).is_ok());
+        assert_eq!(lmdb_vec.len().unwrap(), mem_vec.len());
+        lmdb_vec
+            .for_each(|val| assert!(mem_vec.contains(&val.unwrap())))
+            .unwrap();
+    }
+}

--- a/base_layer/core/src/chain_storage/lmdb_db/mod.rs
+++ b/base_layer/core/src/chain_storage/lmdb_db/mod.rs
@@ -20,47 +20,26 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-//! This module is responsible for handling logic responsible for storing the blockchain state.
-//!
-//! It is structured in such a way that clients (e.g. base nodes) can configure the various components of the state
-//! (kernels, utxos, etc) in whichever way they like. It's possible to have the UTXO set in memory, and the kernels
-//! backed by LMDB, while the merkle trees are stored in flat files for example.
-
-mod blockchain_database;
-mod db_transaction;
-mod error;
-mod historical_block;
+mod lmdb;
 mod lmdb_db;
-mod memory_db;
-mod metadata;
-#[cfg(test)]
-mod test;
-
-// public modules
-pub mod async_db;
+mod lmdb_vec;
 
 // Public API exports
-pub use blockchain_database::{BlockAddResult, BlockchainBackend, BlockchainDatabase};
-pub use db_transaction::{DbTransaction, MmrTree};
-pub use error::ChainStorageError;
-pub use historical_block::HistoricalBlock;
-pub use lmdb_db::{
-    LMDBDatabase,
-    LMDB_DB_BLOCK_HASHES,
-    LMDB_DB_HEADERS,
-    LMDB_DB_HEADER_MMR_BASE_BACKEND,
-    LMDB_DB_HEADER_MMR_CP_BACKEND,
-    LMDB_DB_KERNELS,
-    LMDB_DB_KERNEL_MMR_BASE_BACKEND,
-    LMDB_DB_KERNEL_MMR_CP_BACKEND,
-    LMDB_DB_METADATA,
-    LMDB_DB_ORPHANS,
-    LMDB_DB_RANGE_PROOF_MMR_BASE_BACKEND,
-    LMDB_DB_RANGE_PROOF_MMR_CP_BACKEND,
-    LMDB_DB_STXOS,
-    LMDB_DB_UTXOS,
-    LMDB_DB_UTXO_MMR_BASE_BACKEND,
-    LMDB_DB_UTXO_MMR_CP_BACKEND,
-};
-pub use memory_db::MemoryDatabase;
-pub use metadata::ChainMetadata;
+pub use lmdb_db::{create_lmdb_database, LMDBDatabase};
+pub use lmdb_vec::LMDBVec;
+
+pub const LMDB_DB_METADATA: &str = "metadata";
+pub const LMDB_DB_HEADERS: &str = "headers";
+pub const LMDB_DB_BLOCK_HASHES: &str = "block_hashes";
+pub const LMDB_DB_UTXOS: &str = "utxos";
+pub const LMDB_DB_STXOS: &str = "stxos";
+pub const LMDB_DB_KERNELS: &str = "kernels";
+pub const LMDB_DB_ORPHANS: &str = "orphans";
+pub const LMDB_DB_UTXO_MMR_BASE_BACKEND: &str = "utxo_mmr_base_backend";
+pub const LMDB_DB_UTXO_MMR_CP_BACKEND: &str = "utxo_mmr_cp_backend";
+pub const LMDB_DB_HEADER_MMR_BASE_BACKEND: &str = "header_mmr_base_backend";
+pub const LMDB_DB_HEADER_MMR_CP_BACKEND: &str = "header_mmr_cp_backend";
+pub const LMDB_DB_KERNEL_MMR_BASE_BACKEND: &str = "kernel_mmr_base_backend";
+pub const LMDB_DB_KERNEL_MMR_CP_BACKEND: &str = "kernel_mmr_cp_backend";
+pub const LMDB_DB_RANGE_PROOF_MMR_BASE_BACKEND: &str = "range_proof_mmr_base_backend";
+pub const LMDB_DB_RANGE_PROOF_MMR_CP_BACKEND: &str = "range_proof_mmr_cp_backend";

--- a/base_layer/core/src/chain_storage/memory_db.rs
+++ b/base_layer/core/src/chain_storage/memory_db.rs
@@ -142,6 +142,7 @@ where D: Digest + Send + Sync
                     DbKey::Metadata(_) => {}, // no-op
                     DbKey::BlockHeader(k) => {
                         db.headers.remove(&k);
+                        // TODO: shouldn't blockhash also be deleted
                     },
                     DbKey::BlockHash(hash) => match db.block_hashes.remove(&hash) {
                         Some(i) => {

--- a/base_layer/core/src/chain_storage/test/chain_backend.rs
+++ b/base_layer/core/src/chain_storage/test/chain_backend.rs
@@ -1,0 +1,663 @@
+// Copyright 2019. The Tari Project
+//
+// Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+// following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+// disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+// following disclaimer in the documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+// products derived from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+// INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+// WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+// USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+
+use crate::{
+    blocks::BlockHeader,
+    chain_storage::{
+        blockchain_database::BlockchainBackend,
+        db_transaction::{DbKey, DbKeyValuePair, DbValue, MetadataKey, MetadataValue},
+        lmdb_db::create_lmdb_database,
+        DbTransaction,
+        MemoryDatabase,
+        MmrTree,
+    },
+    tari_amount::MicroTari,
+    test_utils::builders::{create_test_block, create_test_kernel, create_utxo},
+    tx,
+    types::HashDigest,
+};
+use tari_mmr::MutableMmr;
+use tari_test_utils::paths::create_random_database_path;
+use tari_utilities::{hex::Hex, Hashable};
+
+fn insert_contains_delete_and_fetch_header<T: BlockchainBackend>(db: T) {
+    let mut header = BlockHeader::new(0);
+    header.height = 42;
+    let hash = header.hash();
+    assert_eq!(db.contains(&DbKey::BlockHeader(header.height)), Ok(false));
+    assert_eq!(db.contains(&DbKey::BlockHash(hash.clone())), Ok(false));
+
+    let mut txn = DbTransaction::new();
+    txn.insert_header(header.clone());
+    assert!(db.write(txn).is_ok());
+    assert_eq!(db.contains(&DbKey::BlockHeader(header.height)), Ok(true));
+    assert_eq!(db.contains(&DbKey::BlockHash(hash.clone())), Ok(true));
+    if let Some(DbValue::BlockHeader(retrieved_header)) = db.fetch(&DbKey::BlockHeader(header.height)).unwrap() {
+        assert_eq!(*retrieved_header, header);
+    } else {
+        assert!(false);
+    }
+    if let Some(DbValue::BlockHash(retrieved_header)) = db.fetch(&DbKey::BlockHash(hash.clone())).unwrap() {
+        assert_eq!(*retrieved_header, header);
+    } else {
+        assert!(false);
+    }
+
+    let mut txn = DbTransaction::new();
+    txn.delete(DbKey::BlockHash(hash.clone()));
+    assert!(db.write(txn).is_ok());
+    assert_eq!(db.contains(&DbKey::BlockHeader(header.height)), Ok(false));
+    assert_eq!(db.contains(&DbKey::BlockHash(hash)), Ok(false));
+}
+
+#[test]
+fn memory_insert_contains_delete_and_fetch_header() {
+    let db = MemoryDatabase::<HashDigest>::default();
+    insert_contains_delete_and_fetch_header(db);
+}
+
+#[test]
+fn lmdb_insert_contains_delete_and_fetch_header() {
+    let db = create_lmdb_database(&create_random_database_path()).unwrap();
+    insert_contains_delete_and_fetch_header(db);
+}
+
+fn insert_contains_delete_and_fetch_utxo<T: BlockchainBackend>(db: T) {
+    let (utxo, _) = create_utxo(MicroTari(10_000));
+    let hash = utxo.hash();
+    assert_eq!(db.contains(&DbKey::UnspentOutput(hash.clone())), Ok(false));
+
+    let mut txn = DbTransaction::new();
+    txn.insert_utxo(utxo.clone());
+    assert!(db.write(txn).is_ok());
+    assert_eq!(db.contains(&DbKey::UnspentOutput(hash.clone())), Ok(true));
+    if let Some(DbValue::UnspentOutput(retrieved_utxo)) = db.fetch(&DbKey::UnspentOutput(hash.clone())).unwrap() {
+        assert_eq!(*retrieved_utxo, utxo);
+    } else {
+        assert!(false);
+    }
+
+    let mut txn = DbTransaction::new();
+    txn.delete(DbKey::UnspentOutput(hash.clone()));
+    assert!(db.write(txn).is_ok());
+    assert_eq!(db.contains(&DbKey::UnspentOutput(hash)), Ok(false));
+}
+
+#[test]
+fn memory_insert_contains_delete_and_fetch_utxo() {
+    let db = MemoryDatabase::<HashDigest>::default();
+    insert_contains_delete_and_fetch_utxo(db);
+}
+
+#[test]
+fn lmdb_insert_contains_delete_and_fetch_utxo() {
+    let db = create_lmdb_database(&create_random_database_path()).unwrap();
+    insert_contains_delete_and_fetch_utxo(db);
+}
+
+fn insert_contains_delete_and_fetch_kernel<T: BlockchainBackend>(db: T) {
+    let kernel = create_test_kernel(5.into(), 0);
+    let hash = kernel.hash();
+    assert_eq!(db.contains(&DbKey::TransactionKernel(hash.clone())), Ok(false));
+
+    let mut txn = DbTransaction::new();
+    txn.insert_kernel(kernel.clone());
+    assert!(db.write(txn).is_ok());
+    assert_eq!(db.contains(&DbKey::TransactionKernel(hash.clone())), Ok(true));
+    if let Some(DbValue::TransactionKernel(retrieved_kernel)) =
+        db.fetch(&DbKey::TransactionKernel(hash.clone())).unwrap()
+    {
+        assert_eq!(*retrieved_kernel, kernel);
+    } else {
+        assert!(false);
+    }
+
+    let mut txn = DbTransaction::new();
+    txn.delete(DbKey::TransactionKernel(hash.clone()));
+    assert!(db.write(txn).is_ok());
+    assert_eq!(db.contains(&DbKey::TransactionKernel(hash)), Ok(false));
+}
+
+#[test]
+fn memory_insert_contains_delete_and_fetch_kernel() {
+    let db = MemoryDatabase::<HashDigest>::default();
+    insert_contains_delete_and_fetch_kernel(db);
+}
+
+#[test]
+fn lmdb_insert_contains_delete_and_fetch_kernel() {
+    let db = create_lmdb_database(&create_random_database_path()).unwrap();
+    insert_contains_delete_and_fetch_kernel(db);
+}
+
+fn insert_contains_delete_and_fetch_orphan<T: BlockchainBackend>(db: T) {
+    let txs = vec![
+        (tx!(1000.into(), fee: 20.into(), inputs: 2, outputs: 1)).0,
+        (tx!(2000.into(), fee: 30.into(), inputs: 1, outputs: 1)).0,
+    ];
+    let orphan = create_test_block(10, None, txs);
+    let hash = orphan.hash();
+    assert_eq!(db.contains(&DbKey::OrphanBlock(hash.clone())), Ok(false));
+
+    let mut txn = DbTransaction::new();
+    txn.insert_orphan(orphan.clone());
+    assert!(db.write(txn).is_ok());
+
+    assert_eq!(db.contains(&DbKey::OrphanBlock(hash.clone())), Ok(true));
+    if let Some(DbValue::OrphanBlock(retrieved_orphan)) = db.fetch(&DbKey::OrphanBlock(hash.clone())).unwrap() {
+        assert_eq!(*retrieved_orphan, orphan);
+    } else {
+        assert!(false);
+    }
+
+    let mut txn = DbTransaction::new();
+    txn.delete(DbKey::OrphanBlock(hash.clone()));
+    assert!(db.write(txn).is_ok());
+    assert_eq!(db.contains(&DbKey::OrphanBlock(hash)), Ok(false));
+}
+
+#[test]
+fn memory_insert_contains_delete_and_fetch_orphan() {
+    let db = MemoryDatabase::<HashDigest>::default();
+    insert_contains_delete_and_fetch_orphan(db);
+}
+
+#[test]
+fn lmdb_insert_contains_delete_and_fetch_orphan() {
+    let db = create_lmdb_database(&create_random_database_path()).unwrap();
+    insert_contains_delete_and_fetch_orphan(db);
+}
+
+fn spend_utxo_and_unspend_stxo<T: BlockchainBackend>(db: T) {
+    let (utxo1, _) = create_utxo(MicroTari(10_000));
+    let (utxo2, _) = create_utxo(MicroTari(15_000));
+    let hash1 = utxo1.hash();
+    let hash2 = utxo2.hash();
+
+    let mut txn = DbTransaction::new();
+    txn.insert_utxo(utxo1.clone());
+    txn.insert_utxo(utxo2.clone());
+    assert!(db.write(txn).is_ok());
+
+    let mut txn = DbTransaction::new();
+    txn.spend_utxo(hash1.clone());
+    assert!(db.write(txn).is_ok());
+    assert_eq!(db.contains(&DbKey::UnspentOutput(hash1.clone())), Ok(false));
+    assert_eq!(db.contains(&DbKey::UnspentOutput(hash2.clone())), Ok(true));
+    assert_eq!(db.contains(&DbKey::SpentOutput(hash1.clone())), Ok(true));
+    assert_eq!(db.contains(&DbKey::SpentOutput(hash2.clone())), Ok(false));
+
+    let mut txn = DbTransaction::new();
+    txn.spend_utxo(hash2.clone());
+    txn.unspend_stxo(hash1.clone());
+    assert!(db.write(txn).is_ok());
+    assert_eq!(db.contains(&DbKey::UnspentOutput(hash1.clone())), Ok(true));
+    assert_eq!(db.contains(&DbKey::UnspentOutput(hash2.clone())), Ok(false));
+    assert_eq!(db.contains(&DbKey::SpentOutput(hash1.clone())), Ok(false));
+    assert_eq!(db.contains(&DbKey::SpentOutput(hash2.clone())), Ok(true));
+
+    if let Some(DbValue::UnspentOutput(retrieved_utxo)) = db.fetch(&DbKey::UnspentOutput(hash1.clone())).unwrap() {
+        assert_eq!(*retrieved_utxo, utxo1);
+    } else {
+        assert!(false);
+    }
+    if let Some(DbValue::SpentOutput(retrieved_utxo)) = db.fetch(&DbKey::SpentOutput(hash2.clone())).unwrap() {
+        assert_eq!(*retrieved_utxo, utxo2);
+    } else {
+        assert!(false);
+    }
+
+    let mut txn = DbTransaction::new();
+    txn.delete(DbKey::SpentOutput(hash2.clone()));
+    assert!(db.write(txn).is_ok());
+    assert_eq!(db.contains(&DbKey::UnspentOutput(hash1.clone())), Ok(true));
+    assert_eq!(db.contains(&DbKey::UnspentOutput(hash2.clone())), Ok(false));
+    assert_eq!(db.contains(&DbKey::SpentOutput(hash1)), Ok(false));
+    assert_eq!(db.contains(&DbKey::SpentOutput(hash2)), Ok(false));
+}
+
+#[test]
+fn memory_spend_utxo_and_unspend_stxo() {
+    let db = MemoryDatabase::<HashDigest>::default();
+    spend_utxo_and_unspend_stxo(db);
+}
+
+#[test]
+fn lmdb_spend_utxo_and_unspend_stxo() {
+    let db = create_lmdb_database(&create_random_database_path()).unwrap();
+    spend_utxo_and_unspend_stxo(db);
+}
+
+#[test]
+fn lmdb_insert_fetch_metadata() {
+    let db = create_lmdb_database(&create_random_database_path()).unwrap();
+
+    assert!(db.fetch(&DbKey::Metadata(MetadataKey::ChainHeight)).unwrap().is_none());
+    assert!(db
+        .fetch(&DbKey::Metadata(MetadataKey::AccumulatedWork))
+        .unwrap()
+        .is_none());
+    assert!(db
+        .fetch(&DbKey::Metadata(MetadataKey::PruningHorizon))
+        .unwrap()
+        .is_none());
+    assert!(db.fetch(&DbKey::Metadata(MetadataKey::BestBlock)).unwrap().is_none());
+
+    let header = BlockHeader::new(0);
+    let hash = header.hash();
+    let pruning_horizon = 1u64;
+    let chain_height = 2u64;
+    let accumulated_work = 3u64;
+
+    let mut txn = DbTransaction::new();
+    txn.insert(DbKeyValuePair::Metadata(
+        MetadataKey::ChainHeight,
+        MetadataValue::ChainHeight(Some(chain_height)),
+    ));
+    txn.insert(DbKeyValuePair::Metadata(
+        MetadataKey::AccumulatedWork,
+        MetadataValue::AccumulatedWork(accumulated_work),
+    ));
+    txn.insert(DbKeyValuePair::Metadata(
+        MetadataKey::PruningHorizon,
+        MetadataValue::PruningHorizon(pruning_horizon),
+    ));
+    txn.insert(DbKeyValuePair::Metadata(
+        MetadataKey::BestBlock,
+        MetadataValue::BestBlock(Some(hash.clone())),
+    ));
+    assert!(db.write(txn).is_ok());
+
+    if let Some(DbValue::Metadata(MetadataValue::ChainHeight(Some(retrieved_chain_height)))) =
+        db.fetch(&DbKey::Metadata(MetadataKey::ChainHeight)).unwrap()
+    {
+        assert_eq!(retrieved_chain_height, chain_height);
+    } else {
+        assert!(false);
+    }
+    if let Some(DbValue::Metadata(MetadataValue::AccumulatedWork(retrieved_accumulated_work))) =
+        db.fetch(&DbKey::Metadata(MetadataKey::AccumulatedWork)).unwrap()
+    {
+        assert_eq!(retrieved_accumulated_work, accumulated_work);
+    } else {
+        assert!(false);
+    }
+    if let Some(DbValue::Metadata(MetadataValue::PruningHorizon(retrieved_pruning_horizon))) =
+        db.fetch(&DbKey::Metadata(MetadataKey::PruningHorizon)).unwrap()
+    {
+        assert_eq!(retrieved_pruning_horizon, pruning_horizon);
+    } else {
+        assert!(false);
+    }
+    if let Some(DbValue::Metadata(MetadataValue::BestBlock(Some(retrieved_hash)))) =
+        db.fetch(&DbKey::Metadata(MetadataKey::BestBlock)).unwrap()
+    {
+        assert_eq!(retrieved_hash, hash);
+    } else {
+        assert!(false);
+    }
+}
+
+fn fetch_mmr_root_and_proof_for_utxo_and_rp<T: BlockchainBackend>(db: T) {
+    // This is the zero-length MMR of a mutable MMR with Blake256 as hasher
+    assert_eq!(
+        db.fetch_mmr_root(MmrTree::Utxo).unwrap().to_hex(),
+        "26146a5435ef15e8cf7dc3354cb7268137e8be211794e93d04551576c6561565"
+    );
+    assert_eq!(
+        db.fetch_mmr_root(MmrTree::RangeProof).unwrap().to_hex(),
+        "26146a5435ef15e8cf7dc3354cb7268137e8be211794e93d04551576c6561565"
+    );
+
+    let (utxo1, _) = create_utxo(MicroTari(10_000));
+    let (utxo2, _) = create_utxo(MicroTari(15_000));
+    let (utxo3, _) = create_utxo(MicroTari(20_000));
+    let utxo_hash1 = utxo1.hash();
+    let utxo_hash2 = utxo2.hash();
+    let utxo_hash3 = utxo3.hash();
+    let rp_hash1 = utxo1.proof.hash();
+    let rp_hash2 = utxo2.proof.hash();
+    let rp_hash3 = utxo3.proof.hash();
+
+    let mut txn = DbTransaction::new();
+    txn.insert_utxo(utxo1.clone());
+    txn.insert_utxo(utxo2.clone());
+    txn.insert_utxo(utxo3.clone());
+    assert!(db.write(txn).is_ok());
+
+    let mut utxo_mmr_check = MutableMmr::<HashDigest, _>::new(Vec::new());
+    assert!(utxo_mmr_check.push(&utxo_hash1).is_ok());
+    assert!(utxo_mmr_check.push(&utxo_hash2).is_ok());
+    assert!(utxo_mmr_check.push(&utxo_hash3).is_ok());
+    assert_eq!(
+        db.fetch_mmr_root(MmrTree::Utxo).unwrap().to_hex(),
+        utxo_mmr_check.get_merkle_root().unwrap().to_hex()
+    );
+
+    let mmr_only_root = db.fetch_mmr_only_root(MmrTree::Utxo).unwrap();
+    let proof1 = db.fetch_mmr_proof(MmrTree::Utxo, 0).unwrap();
+    let proof2 = db.fetch_mmr_proof(MmrTree::Utxo, 1).unwrap();
+    let proof3 = db.fetch_mmr_proof(MmrTree::Utxo, 2).unwrap();
+    assert!(proof1.verify_leaf::<HashDigest>(&mmr_only_root, &utxo_hash1, 0).is_ok());
+    assert!(proof2.verify_leaf::<HashDigest>(&mmr_only_root, &utxo_hash2, 1).is_ok());
+    assert!(proof3.verify_leaf::<HashDigest>(&mmr_only_root, &utxo_hash3, 2).is_ok());
+
+    let mut rp_mmr_check = MutableMmr::<HashDigest, _>::new(Vec::new());
+    assert_eq!(rp_mmr_check.push(&rp_hash1), Ok(1));
+    assert_eq!(rp_mmr_check.push(&rp_hash2), Ok(2));
+    assert_eq!(rp_mmr_check.push(&rp_hash3), Ok(3));
+    assert_eq!(
+        db.fetch_mmr_root(MmrTree::RangeProof).unwrap().to_hex(),
+        rp_mmr_check.get_merkle_root().unwrap().to_hex()
+    );
+
+    let mmr_only_root = db.fetch_mmr_only_root(MmrTree::RangeProof).unwrap();
+    let proof1 = db.fetch_mmr_proof(MmrTree::RangeProof, 0).unwrap();
+    let proof2 = db.fetch_mmr_proof(MmrTree::RangeProof, 1).unwrap();
+    let proof3 = db.fetch_mmr_proof(MmrTree::RangeProof, 2).unwrap();
+    assert!(proof1.verify_leaf::<HashDigest>(&mmr_only_root, &rp_hash1, 0).is_ok());
+    assert!(proof2.verify_leaf::<HashDigest>(&mmr_only_root, &rp_hash2, 1).is_ok());
+    assert!(proof3.verify_leaf::<HashDigest>(&mmr_only_root, &rp_hash3, 2).is_ok());
+}
+
+#[test]
+fn memory_fetch_mmr_root_and_proof_for_utxo_and_rp() {
+    let db = MemoryDatabase::<HashDigest>::default();
+    fetch_mmr_root_and_proof_for_utxo_and_rp(db);
+}
+
+#[test]
+fn lmdb_fetch_mmr_root_and_proof_for_utxo_and_rp() {
+    let db = create_lmdb_database(&create_random_database_path()).unwrap();
+    fetch_mmr_root_and_proof_for_utxo_and_rp(db);
+}
+
+fn fetch_mmr_root_and_proof_for_kernel<T: BlockchainBackend>(db: T) {
+    // This is the zero-length MMR of a mutable MMR with Blake256 as hasher
+    assert_eq!(
+        db.fetch_mmr_root(MmrTree::Kernel).unwrap().to_hex(),
+        "26146a5435ef15e8cf7dc3354cb7268137e8be211794e93d04551576c6561565"
+    );
+
+    let kernel1 = create_test_kernel(100.into(), 0);
+    let kernel2 = create_test_kernel(200.into(), 1);
+    let kernel3 = create_test_kernel(300.into(), 2);
+    let hash1 = kernel1.hash();
+    let hash2 = kernel2.hash();
+    let hash3 = kernel3.hash();
+
+    let mut txn = DbTransaction::new();
+    txn.insert_kernel(kernel1);
+    txn.insert_kernel(kernel2);
+    txn.insert_kernel(kernel3);
+    assert!(db.write(txn).is_ok());
+
+    let mut kernel_mmr_check = MutableMmr::<HashDigest, _>::new(Vec::new());
+    assert!(kernel_mmr_check.push(&hash1).is_ok());
+    assert!(kernel_mmr_check.push(&hash2).is_ok());
+    assert!(kernel_mmr_check.push(&hash3).is_ok());
+    assert_eq!(
+        db.fetch_mmr_root(MmrTree::Kernel).unwrap().to_hex(),
+        kernel_mmr_check.get_merkle_root().unwrap().to_hex()
+    );
+
+    let mmr_only_root = db.fetch_mmr_only_root(MmrTree::Kernel).unwrap();
+    let proof1 = db.fetch_mmr_proof(MmrTree::Kernel, 0).unwrap();
+    let proof2 = db.fetch_mmr_proof(MmrTree::Kernel, 1).unwrap();
+    let proof3 = db.fetch_mmr_proof(MmrTree::Kernel, 2).unwrap();
+    assert!(proof1.verify_leaf::<HashDigest>(&mmr_only_root, &hash1, 0).is_ok());
+    assert!(proof2.verify_leaf::<HashDigest>(&mmr_only_root, &hash2, 1).is_ok());
+    assert!(proof3.verify_leaf::<HashDigest>(&mmr_only_root, &hash3, 2).is_ok());
+}
+
+#[test]
+fn memory_fetch_mmr_root_and_proof_for_kernel() {
+    let db = MemoryDatabase::<HashDigest>::default();
+    fetch_mmr_root_and_proof_for_kernel(db);
+}
+
+#[test]
+fn lmdb_fetch_mmr_root_and_proof_for_kernel() {
+    let db = create_lmdb_database(&create_random_database_path()).unwrap();
+    fetch_mmr_root_and_proof_for_kernel(db);
+}
+
+fn fetch_mmr_root_and_proof_for_header<T: BlockchainBackend>(db: T) {
+    // This is the zero-length MMR of a mutable MMR with Blake256 as hasher
+    assert_eq!(
+        db.fetch_mmr_root(MmrTree::Header).unwrap().to_hex(),
+        "26146a5435ef15e8cf7dc3354cb7268137e8be211794e93d04551576c6561565"
+    );
+
+    let mut header1 = BlockHeader::new(0);
+    header1.height = 1;
+    let mut header2 = BlockHeader::new(0);
+    header2.height = 2;
+    let mut header3 = BlockHeader::new(0);
+    header3.height = 3;
+    let hash1 = header1.hash();
+    let hash2 = header2.hash();
+    let hash3 = header3.hash();
+
+    let mut txn = DbTransaction::new();
+    txn.insert_header(header1);
+    txn.insert_header(header2);
+    txn.insert_header(header3);
+    assert!(db.write(txn).is_ok());
+
+    let mut header_mmr_check = MutableMmr::<HashDigest, _>::new(Vec::new());
+    assert!(header_mmr_check.push(&hash1).is_ok());
+    assert!(header_mmr_check.push(&hash2).is_ok());
+    assert!(header_mmr_check.push(&hash3).is_ok());
+    assert_eq!(
+        db.fetch_mmr_root(MmrTree::Header).unwrap().to_hex(),
+        header_mmr_check.get_merkle_root().unwrap().to_hex()
+    );
+
+    let mmr_only_root = db.fetch_mmr_only_root(MmrTree::Header).unwrap();
+    let proof1 = db.fetch_mmr_proof(MmrTree::Header, 0).unwrap();
+    let proof2 = db.fetch_mmr_proof(MmrTree::Header, 1).unwrap();
+    let proof3 = db.fetch_mmr_proof(MmrTree::Header, 2).unwrap();
+    assert!(proof1.verify_leaf::<HashDigest>(&mmr_only_root, &hash1, 0).is_ok());
+    assert!(proof2.verify_leaf::<HashDigest>(&mmr_only_root, &hash2, 1).is_ok());
+    assert!(proof3.verify_leaf::<HashDigest>(&mmr_only_root, &hash3, 2).is_ok());
+}
+
+#[test]
+fn memory_fetch_mmr_root_and_proof_for_header() {
+    let db = MemoryDatabase::<HashDigest>::default();
+    fetch_mmr_root_and_proof_for_header(db);
+}
+
+#[test]
+fn lmdb_fetch_mmr_root_and_proof_for_header() {
+    let db = create_lmdb_database(&create_random_database_path()).unwrap();
+    fetch_mmr_root_and_proof_for_header(db);
+}
+
+fn commit_block_and_create_fetch_checkpoint_and_rewind_mmr<T: BlockchainBackend>(db: T) {
+    let (utxo1, _) = create_utxo(MicroTari(10_000));
+    let kernel1 = create_test_kernel(100.into(), 0);
+    let mut header1 = BlockHeader::new(0);
+    header1.height = 1;
+    let utxo_hash1 = utxo1.hash();
+    let kernel_hash1 = kernel1.hash();
+    let rp_hash1 = utxo1.proof.hash();
+    let header_hash1 = header1.hash();
+
+    let mut txn = DbTransaction::new();
+    txn.insert_utxo(utxo1);
+    txn.insert_kernel(kernel1);
+    txn.insert_header(header1);
+    assert!(db.write(txn).is_ok());
+    let mut txn = DbTransaction::new();
+    txn.commit_block();
+    assert!(db.write(txn).is_ok());
+    let (utxo2, _) = create_utxo(MicroTari(15_000));
+    let kernel2 = create_test_kernel(200.into(), 0);
+    let mut header2 = BlockHeader::new(0);
+    header2.height = 2;
+    let utxo_hash2 = utxo2.hash();
+    let kernel_hash2 = kernel2.hash();
+    let rp_hash2 = utxo2.proof.hash();
+    let header_hash2 = header2.hash();
+
+    let mut txn = DbTransaction::new();
+    txn.insert_utxo(utxo2);
+    txn.insert_kernel(kernel2);
+    txn.insert_header(header2);
+    assert!(db.write(txn).is_ok());
+    let mut txn = DbTransaction::new();
+    txn.commit_block();
+    assert!(db.write(txn).is_ok());
+
+    assert_eq!(
+        db.fetch_mmr_checkpoint(MmrTree::Utxo, 0).unwrap().nodes_added()[0],
+        utxo_hash1
+    );
+    assert_eq!(
+        db.fetch_mmr_checkpoint(MmrTree::Kernel, 0).unwrap().nodes_added()[0],
+        kernel_hash1
+    );
+    assert_eq!(
+        db.fetch_mmr_checkpoint(MmrTree::RangeProof, 0).unwrap().nodes_added()[0],
+        rp_hash1
+    );
+    assert_eq!(
+        db.fetch_mmr_checkpoint(MmrTree::Header, 0).unwrap().nodes_added()[0],
+        header_hash1
+    );
+    assert_eq!(
+        db.fetch_mmr_checkpoint(MmrTree::Utxo, 1).unwrap().nodes_added()[0],
+        utxo_hash2
+    );
+    assert_eq!(
+        db.fetch_mmr_checkpoint(MmrTree::Kernel, 1).unwrap().nodes_added()[0],
+        kernel_hash2
+    );
+    assert_eq!(
+        db.fetch_mmr_checkpoint(MmrTree::RangeProof, 1).unwrap().nodes_added()[0],
+        rp_hash2
+    );
+    assert_eq!(
+        db.fetch_mmr_checkpoint(MmrTree::Header, 1).unwrap().nodes_added()[0],
+        header_hash2
+    );
+
+    let mut txn = DbTransaction::new();
+    txn.rewind_header_mmr(1);
+    txn.rewind_kernel_mmr(1);
+    txn.rewind_utxo_mmr(1);
+    txn.rewind_rp_mmr(1);
+    assert!(db.write(txn).is_ok());
+
+    assert_eq!(
+        db.fetch_mmr_checkpoint(MmrTree::Utxo, 0).unwrap().nodes_added()[0],
+        utxo_hash1
+    );
+    assert_eq!(
+        db.fetch_mmr_checkpoint(MmrTree::Kernel, 0).unwrap().nodes_added()[0],
+        kernel_hash1
+    );
+    assert_eq!(
+        db.fetch_mmr_checkpoint(MmrTree::RangeProof, 0).unwrap().nodes_added()[0],
+        rp_hash1
+    );
+    assert_eq!(
+        db.fetch_mmr_checkpoint(MmrTree::Header, 0).unwrap().nodes_added()[0],
+        header_hash1
+    );
+    assert!(db.fetch_mmr_checkpoint(MmrTree::Utxo, 1).is_err());
+    assert!(db.fetch_mmr_checkpoint(MmrTree::Kernel, 1).is_err());
+    assert!(db.fetch_mmr_checkpoint(MmrTree::RangeProof, 1).is_err());
+    assert!(db.fetch_mmr_checkpoint(MmrTree::Header, 1).is_err());
+}
+
+#[test]
+fn memory_commit_block_and_create_fetch_checkpoint_and_rewind_mmr() {
+    let db = MemoryDatabase::<HashDigest>::default();
+    commit_block_and_create_fetch_checkpoint_and_rewind_mmr(db);
+}
+
+#[test]
+fn lmdb_commit_block_and_create_fetch_checkpoint_and_rewind_mmr() {
+    let db = create_lmdb_database(&create_random_database_path()).unwrap();
+    commit_block_and_create_fetch_checkpoint_and_rewind_mmr(db);
+}
+
+// TODO: Test Needed: fetch_mmr_node
+
+fn for_each_orphan<T: BlockchainBackend>(db: T) {
+    let orphan1 = create_test_block(5, None, vec![
+        (tx!(1000.into(), fee: 20.into(), inputs: 2, outputs: 1)).0,
+    ]);
+    let orphan2 = create_test_block(10, None, vec![
+        (tx!(2000.into(), fee: 30.into(), inputs: 1, outputs: 1)).0,
+    ]);
+    let orphan3 = create_test_block(15, None, vec![
+        (tx!(3000.into(), fee: 40.into(), inputs: 1, outputs: 2)).0,
+    ]);
+    let hash1 = orphan1.hash();
+    let hash2 = orphan2.hash();
+    let hash3 = orphan3.hash();
+
+    let mut txn = DbTransaction::new();
+    txn.insert_orphan(orphan1.clone());
+    txn.insert_orphan(orphan2.clone());
+    txn.insert_orphan(orphan3.clone());
+    assert!(db.write(txn).is_ok());
+    assert_eq!(db.contains(&DbKey::OrphanBlock(hash1.clone())), Ok(true));
+    assert_eq!(db.contains(&DbKey::OrphanBlock(hash2.clone())), Ok(true));
+    assert_eq!(db.contains(&DbKey::OrphanBlock(hash3.clone())), Ok(true));
+
+    let mut orphan1_found = false;
+    let mut orphan2_found = false;
+    let mut orphan3_found = false;
+    assert!(db
+        .for_each_orphan(|pair| {
+            let (hash, block) = pair.unwrap();
+            if (hash == hash1) && (block == orphan1) {
+                orphan1_found = true;
+            } else if (hash == hash2) && (block == orphan2) {
+                orphan2_found = true;
+            } else if (hash == hash3) && (block == orphan3) {
+                orphan3_found = true;
+            }
+        })
+        .is_ok());
+    assert!(orphan1_found & orphan2_found & orphan3_found);
+}
+
+#[test]
+fn memory_for_each_orphan() {
+    let db = MemoryDatabase::<HashDigest>::default();
+    for_each_orphan(db);
+}
+
+#[test]
+fn lmdb_for_each_orphan() {
+    let db = create_lmdb_database(&create_random_database_path()).unwrap();
+    for_each_orphan(db);
+}
+
+// TODO: Restore from persistent backend test needed

--- a/base_layer/core/src/chain_storage/test/mod.rs
+++ b/base_layer/core/src/chain_storage/test/mod.rs
@@ -22,4 +22,5 @@
 //
 
 mod async_db;
+mod chain_backend;
 mod chain_storage;

--- a/base_layer/core/tests/data/.gitkeep
+++ b/base_layer/core/tests/data/.gitkeep
@@ -1,0 +1,1 @@
+Temp folder for LMDB database files

--- a/base_layer/mmr/src/change_tracker.rs
+++ b/base_layer/mmr/src/change_tracker.rs
@@ -29,7 +29,11 @@ use crate::{
 };
 use croaring::Bitmap;
 use digest::Digest;
-use std::{mem, ops::Deref};
+use serde::{
+    de::{self, Deserialize, Deserializer, MapAccess, SeqAccess, Visitor},
+    ser::{Serialize, SerializeStruct, Serializer},
+};
+use std::{fmt, mem, ops::Deref};
 
 /// A struct that wraps an MMR to keep track of changes to the MMR over time. This enables one to roll
 /// back changes to a point in history. Think of `MerkleChangeTracker` as 'git' for MMRs.
@@ -277,5 +281,99 @@ impl MerkleCheckPoint {
     /// Break a checkpoint up into its constituent parts
     pub fn into_parts(self) -> (Vec<Hash>, Bitmap) {
         (self.nodes_added, self.nodes_deleted)
+    }
+}
+
+impl Serialize for MerkleCheckPoint {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where S: Serializer {
+        let mut state = serializer.serialize_struct("MerkleCheckPoint", 2)?;
+        state.serialize_field("nodes_added", &self.nodes_added)?;
+        state.serialize_field("nodes_deleted", &self.nodes_deleted.serialize())?;
+        state.end()
+    }
+}
+
+impl<'de> Deserialize<'de> for MerkleCheckPoint {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where D: Deserializer<'de> {
+        enum Field {
+            NodesAdded,
+            NodesDeleted,
+        };
+
+        impl<'de> Deserialize<'de> for Field {
+            fn deserialize<D>(deserializer: D) -> Result<Field, D::Error>
+            where D: Deserializer<'de> {
+                struct FieldVisitor;
+
+                impl<'de> Visitor<'de> for FieldVisitor {
+                    type Value = Field;
+
+                    fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+                        formatter.write_str("`nodes_added` or `nodes_deleted`")
+                    }
+
+                    fn visit_str<E>(self, value: &str) -> Result<Field, E>
+                    where E: de::Error {
+                        match value {
+                            "nodes_added" => Ok(Field::NodesAdded),
+                            "nodes_deleted" => Ok(Field::NodesDeleted),
+                            _ => Err(de::Error::unknown_field(value, FIELDS)),
+                        }
+                    }
+                }
+
+                deserializer.deserialize_identifier(FieldVisitor)
+            }
+        }
+
+        struct MerkleCheckPointVisitor;
+
+        impl<'de> Visitor<'de> for MerkleCheckPointVisitor {
+            type Value = MerkleCheckPoint;
+
+            fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+                formatter.write_str("struct MerkleCheckPoint")
+            }
+
+            fn visit_seq<V>(self, mut seq: V) -> Result<MerkleCheckPoint, V::Error>
+            where V: SeqAccess<'de> {
+                let nodes_added = seq.next_element()?.ok_or_else(|| de::Error::invalid_length(0, &self))?;
+                let nodes_deleted_buf: Vec<u8> =
+                    seq.next_element()?.ok_or_else(|| de::Error::invalid_length(1, &self))?;
+                let nodes_deleted: Bitmap = Bitmap::deserialize(&nodes_deleted_buf);
+                Ok(MerkleCheckPoint::new(nodes_added, nodes_deleted))
+            }
+
+            fn visit_map<V>(self, mut map: V) -> Result<MerkleCheckPoint, V::Error>
+            where V: MapAccess<'de> {
+                let mut nodes_added = None;
+                let mut nodes_deleted = None;
+                while let Some(key) = map.next_key()? {
+                    match key {
+                        Field::NodesAdded => {
+                            if nodes_added.is_some() {
+                                return Err(de::Error::duplicate_field("nodes_added"));
+                            }
+                            nodes_added = Some(map.next_value()?);
+                        },
+                        Field::NodesDeleted => {
+                            if nodes_deleted.is_some() {
+                                return Err(de::Error::duplicate_field("nodes_deleted"));
+                            }
+                            let nodes_deleted_buf: Vec<u8> = map.next_value()?;
+                            nodes_deleted = Some(Bitmap::deserialize(&nodes_deleted_buf));
+                        },
+                    }
+                }
+                let nodes_added = nodes_added.ok_or_else(|| de::Error::missing_field("nodes_added"))?;
+                let nodes_deleted = nodes_deleted.ok_or_else(|| de::Error::missing_field("nodes_deleted"))?;
+                Ok(MerkleCheckPoint::new(nodes_added, nodes_deleted))
+            }
+        }
+
+        const FIELDS: &'static [&'static str] = &["nodes_added", "nodes_deleted"];
+        deserializer.deserialize_struct("MerkleCheckPoint", FIELDS, MerkleCheckPointVisitor)
     }
 }

--- a/base_layer/mmr/src/lib.rs
+++ b/base_layer/mmr/src/lib.rs
@@ -151,7 +151,7 @@ pub mod pruned_mmr;
 
 // Commonly used exports
 /// A vector-based backend for [MerkleMountainRange]
-pub use backend::ArrayLike;
+pub use backend::{ArrayLike, ArrayLikeExt};
 /// A data structure that maintains a list of diffs on an MMR, enabling you to rewind to a previous state
 pub use change_tracker::{MerkleChangeTracker, MerkleCheckPoint};
 /// An immutable, append-only Merkle Mountain range (MMR) data structure

--- a/base_layer/mmr/tests/change_tracker.rs
+++ b/base_layer/mmr/tests/change_tracker.rs
@@ -24,7 +24,7 @@ mod support;
 
 use croaring::Bitmap;
 use support::{create_mmr, int_to_hash, Hasher};
-use tari_mmr::{MerkleChangeTracker, MutableMmr};
+use tari_mmr::{MerkleChangeTracker, MerkleCheckPoint, MutableMmr};
 use tari_utilities::hex::Hex;
 
 #[test]
@@ -148,4 +148,17 @@ fn reset_and_replay() {
     assert_eq!(mmr.len(), 3);
 
     assert_eq!(mmr.get_merkle_root(), root);
+}
+
+#[test]
+fn serialize_and_deserialize_merklecheckpoint() {
+    let nodes_added = vec![int_to_hash(0), int_to_hash(1)];
+    let mut nodes_deleted = Bitmap::create();
+    nodes_deleted.add(1);
+    nodes_deleted.add(5);
+    let mcp = MerkleCheckPoint::new(nodes_added, nodes_deleted);
+
+    let ser_buf = bincode::serialize(&mcp).unwrap();
+    let des_mcp: MerkleCheckPoint = bincode::deserialize(&ser_buf).unwrap();
+    assert_eq!(mcp.into_parts(), des_mcp.into_parts());
 }

--- a/infrastructure/storage/src/lmdb_store/store.rs
+++ b/infrastructure/storage/src/lmdb_store/store.rs
@@ -320,6 +320,10 @@ impl LMDBStore {
             None => None,
         }
     }
+
+    pub fn env(&self) -> Arc<Environment> {
+        self.env.clone()
+    }
 }
 
 #[derive(Clone)]
@@ -492,6 +496,10 @@ impl LMDBDatabase {
         let wrapper = LMDBWriteTransaction { db: &self.db, access };
         f(wrapper)?;
         txn.commit().map_err(|e| LMDBError::CommitError(e.to_string()))
+    }
+
+    pub fn db(&self) -> &DatabaseRef {
+        &self.db
     }
 }
 


### PR DESCRIPTION
## Description
- Added LMDBDatabase chain storage backend with helper functions to perform lmdb operations
- Added LMDBVec that can be used as a persistent backend for the MerkleChangeTracker
- A set of tests for testing only the backend functionality of memory_db and lmdb_db was added under chain_backend tests
- A custom serializer  and deserializer was added for MerkeCheckPoint, this was required as croaring bitmap doesn't implement serialize and deserialize.

Note: The persistent storage of the MerkleChangeTrackers needs to be improved so that only a single WriteTransaction is used, this will also allow a single lmdb commit to be performed once all the changes have successfully been set.

## Motivation and Context
The Blockchain state requires persistent storage

## How Has This Been Tested?
A set of backend tests were added.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [x] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch
* [x] I ran `cargo-fmt --all` before pushing
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
