### PR TITLE
Added shutdown triggers for comms

### DIFF
--- a/base_layer/p2p/src/services/liveness/mod.rs
+++ b/base_layer/p2p/src/services/liveness/mod.rs
@@ -48,7 +48,7 @@ use crate::{
     tari_message::{NetMessage, TariMessageType},
 };
 use futures::{future, Future, Stream, StreamExt};
-use std::{fmt::Debug, sync::Arc};
+use std::sync::Arc;
 use tari_pubsub::TopicSubscriptionFactory;
 use tari_service_framework::{
     handles::ServiceHandlesFuture,
@@ -56,7 +56,6 @@ use tari_service_framework::{
     ServiceInitializationError,
     ServiceInitializer,
 };
-use tari_utilities::message_format::{MessageFormat, MessageFormatError};
 use tokio::runtime::TaskExecutor;
 
 pub use self::messages::{LivenessRequest, LivenessResponse, PingPong};

--- a/base_layer/p2p/src/services/liveness/service.rs
+++ b/base_layer/p2p/src/services/liveness/service.rs
@@ -98,7 +98,10 @@ where
                         Err(err)
                     });
                 },
-                complete => break,
+                complete => {
+                    info!(target: LOG_TARGET, "Liveness service shutting down because all streams finished");
+                    break;
+                }
             }
         }
     }

--- a/base_layer/p2p/src/services/utils.rs
+++ b/base_layer/p2p/src/services/utils.rs
@@ -22,7 +22,6 @@
 
 use crate::{comms_connector::PeerMessage, domain_message::DomainMessage, tari_message::TariMessageType};
 use std::{fmt::Debug, sync::Arc};
-use tari_comms::message::{InboundMessage, MessageError};
 use tari_utilities::message_format::{MessageFormat, MessageFormatError};
 
 const LOG_TARGET: &'static str = "base_layer::p2p::services";

--- a/base_layer/p2p/src/sync_services/executor.rs
+++ b/base_layer/p2p/src/sync_services/executor.rs
@@ -280,7 +280,7 @@ mod test {
         services.shutdown().unwrap();
         services.join_timeout(Duration::from_millis(100)).unwrap();
 
-        comms_node.shutdown().unwrap();
+        rt.block_on(comms_node.shutdown()).unwrap();
 
         {
             let lock = acquire_read_lock!(state);

--- a/comms/middleware/src/lib.rs
+++ b/comms/middleware/src/lib.rs
@@ -49,7 +49,8 @@
 //!   // (...)
 //!   .build();
 //! ```
-
+// Needed to make futures::select! work
+#![recursion_limit = "256"]
 #![feature(type_alias_impl_trait)]
 
 pub mod error;

--- a/comms/src/connection_manager/manager.rs
+++ b/comms/src/connection_manager/manager.rs
@@ -208,7 +208,7 @@ impl ConnectionManager {
     }
 
     /// Sends shutdown signals to all PeerConnections
-    pub fn shutdown(self) -> Vec<std::result::Result<(), ConnectionError>> {
+    pub fn shutdown(&self) -> Vec<std::result::Result<(), ConnectionError>> {
         self.connections.shutdown_joined()
     }
 

--- a/comms/src/lib.rs
+++ b/comms/src/lib.rs
@@ -26,6 +26,7 @@ pub mod inbound_message_pipeline;
 pub mod message;
 pub mod outbound_message_service;
 pub mod peer_manager;
+pub mod shutdown;
 pub mod types;
 pub mod utils;
 

--- a/comms/src/shutdown.rs
+++ b/comms/src/shutdown.rs
@@ -1,0 +1,153 @@
+// Copyright 2019, The Tari Project
+//
+// Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+// following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+// disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+// following disclaimer in the documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+// products derived from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+// INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+// WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+// USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+use futures::{channel::oneshot, future::join_all};
+use std::time::Duration;
+use tokio::future::FutureExt;
+
+/// Receiver end of a shutdown signal. Once the oneshot sender has been received
+/// the receiver should send on the received oneshot to indicate that it has shut down.
+pub type ShutdownSignal = oneshot::Receiver<oneshot::Sender<()>>;
+
+pub struct Shutdown {
+    signals: Vec<oneshot::Sender<oneshot::Sender<()>>>,
+    is_triggered: bool,
+    timeout: Duration,
+    on_triggered: Option<Box<dyn FnOnce() + Send + Sync>>,
+}
+
+impl Default for Shutdown {
+    fn default() -> Self {
+        Self {
+            signals: Vec::default(),
+            is_triggered: false,
+            timeout: Duration::from_secs(5),
+            on_triggered: None,
+        }
+    }
+}
+
+impl Shutdown {
+    pub fn new() -> Self {
+        Default::default()
+    }
+
+    pub fn on_triggered<F>(&mut self, on_trigger: F) -> &mut Self
+    where F: FnOnce() + Send + Sync + 'static {
+        self.on_triggered = Some(Box::new(on_trigger));
+        self
+    }
+
+    pub fn with_timeout(mut self, timeout: Duration) -> Self {
+        self.timeout = timeout;
+        self
+    }
+
+    pub fn new_signal(&mut self) -> ShutdownSignal {
+        let (tx, rx) = oneshot::channel();
+        self.signals.push(tx);
+        rx
+    }
+
+    pub async fn trigger(&mut self) -> Result<(), ()> {
+        if !self.is_triggered {
+            self.is_triggered = true;
+            let mut receivers = Vec::with_capacity(self.signals.len());
+            for signal in self.signals.drain(..) {
+                let (sender, receiver) = oneshot::channel();
+                signal.send(sender).map_err(|_| ())?;
+                receivers.push(receiver);
+            }
+
+            for result in join_all(receivers).timeout(self.timeout).await.map_err(|_| ())? {
+                result.map_err(|_| ())?
+            }
+
+            if let Some(on_triggered) = self.on_triggered.take() {
+                on_triggered();
+            }
+        }
+
+        Ok(())
+    }
+
+    pub fn is_triggered(&self) -> bool {
+        self.is_triggered
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use std::{
+        sync::{
+            atomic::{AtomicBool, Ordering},
+            Arc,
+        },
+        time::Instant,
+    };
+    use tokio::{runtime::Runtime, timer};
+
+    #[test]
+    fn trigger() {
+        let rt = Runtime::new().unwrap();
+        let mut shutdown = Shutdown::new();
+        let signal = shutdown.new_signal();
+        assert_eq!(shutdown.is_triggered(), false);
+        rt.spawn(async move {
+            signal.await.unwrap().send(()).unwrap();
+        });
+        rt.block_on(shutdown.trigger()).unwrap();
+        assert_eq!(shutdown.is_triggered(), true);
+    }
+
+    #[test]
+    fn trigger_timeout() {
+        let rt = Runtime::new().unwrap();
+        let mut shutdown = Shutdown::new().with_timeout(Duration::from_secs(0));
+        let signal = shutdown.new_signal();
+        assert_eq!(shutdown.is_triggered(), false);
+        rt.spawn(async move {
+            timer::delay(Instant::now() + Duration::from_secs(1)).await;
+            signal.await.unwrap().send(()).unwrap();
+        });
+        assert!(rt.block_on(shutdown.trigger()).is_err());
+        assert_eq!(shutdown.is_triggered(), true);
+    }
+
+    #[test]
+    fn on_trigger() {
+        let rt = Runtime::new().unwrap();
+        let spy = Arc::new(AtomicBool::new(false));
+        let spy_clone = Arc::clone(&spy);
+        let mut shutdown = Shutdown::new();
+        shutdown.on_triggered(move || {
+            spy_clone.store(true, Ordering::SeqCst);
+        });
+        let signal = shutdown.new_signal();
+        rt.spawn(async move {
+            signal.await.unwrap().send(()).unwrap();
+        });
+        rt.block_on(shutdown.trigger()).unwrap();
+        assert_eq!(spy.load(Ordering::SeqCst), true);
+    }
+}


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
The comms builder links up shutdown oneshots which trigger
when comms is shut down. The service using the trigger replies
when it has cleanly shutdown so that the shutdown procedure waits
until services have completed the work required to shutdown cleanly.


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #817 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Unit tests

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [x] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [x] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch
* [x] I ran `cargo-fmt --all` before pushing
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
