### PR TITLE
Removed CommsPublicKey generic from NodeDestination

### DIFF
--- a/base_layer/p2p/src/domain_subscriber.rs
+++ b/base_layer/p2p/src/domain_subscriber.rs
@@ -107,10 +107,10 @@ mod test {
     use serde::{Deserialize, Serialize};
     use tari_comms::{
         connection::NetAddress,
-        message::{MessageEnvelopeHeader, MessageFlags, MessageHeader, NodeDestination},
+        message::{MessageEnvelopeHeader, MessageFlags, MessageHeader},
         peer_manager::{NodeIdentity, Peer, PeerFlags},
     };
-    use tari_comms_dht::message::{DhtHeader, DhtMessageFlags, DhtMessageType};
+    use tari_comms_dht::message::{DhtHeader, DhtMessageFlags, DhtMessageType, NodeDestination};
     use tari_pubsub::{pubsub_channel, TopicPayload};
 
     #[test]

--- a/base_layer/p2p/src/ping_pong.rs
+++ b/base_layer/p2p/src/ping_pong.rs
@@ -42,12 +42,9 @@ use std::{
     sync::{Arc, Mutex},
     time::Duration,
 };
-use tari_comms::{
-    message::{MessageError, NodeDestination},
-    types::CommsPublicKey,
-};
+use tari_comms::{message::MessageError, types::CommsPublicKey};
 use tari_comms_dht::{
-    message::DhtMessageFlags,
+    message::{DhtMessageFlags, NodeDestination},
     outbound::{BroadcastStrategy, DhtOutboundError, OutboundMessageRequester},
 };
 use tari_utilities::{hex::Hex, message_format::MessageFormatError};

--- a/base_layer/p2p/src/services/liveness/service.rs
+++ b/base_layer/p2p/src/services/liveness/service.rs
@@ -29,9 +29,9 @@ use crate::{
 use futures::{pin_mut, stream::StreamExt, Stream};
 use log::*;
 use std::sync::Arc;
-use tari_comms::{message::NodeDestination, types::CommsPublicKey};
+use tari_comms::types::CommsPublicKey;
 use tari_comms_dht::{
-    message::DhtMessageFlags,
+    message::{DhtMessageFlags, NodeDestination},
     outbound::{BroadcastStrategy, DhtOutboundError},
 };
 use tari_service_framework::RequestContext;

--- a/base_layer/p2p/src/test_utils.rs
+++ b/base_layer/p2p/src/test_utils.rs
@@ -29,14 +29,14 @@ use std::sync::{
 };
 use tari_comms::{
     connection::NetAddress,
-    message::{InboundMessage, MessageEnvelopeHeader, MessageFlags, NodeDestination},
+    message::{InboundMessage, MessageEnvelopeHeader, MessageFlags},
     peer_manager::{NodeIdentity, Peer, PeerFlags, PeerManager},
     types::CommsDatabase,
     utils::signature,
 };
 use tari_comms_dht::{
     inbound::DhtInboundMessage,
-    message::{DhtEnvelope, DhtHeader, DhtMessageFlags, DhtMessageType},
+    message::{DhtEnvelope, DhtHeader, DhtMessageFlags, DhtMessageType, NodeDestination},
 };
 use tari_storage::lmdb_store::LMDBBuilder;
 use tari_test_utils::{paths::create_random_database_path, random};

--- a/base_layer/wallet/src/text_message_service/service.rs
+++ b/base_layer/wallet/src/text_message_service/service.rs
@@ -37,9 +37,9 @@ use log::*;
 use serde::{Deserialize, Serialize};
 use std::{io, path::Path, time::Duration};
 use tari_broadcast_channel::Publisher;
-use tari_comms::{message::NodeDestination, types::CommsPublicKey};
+use tari_comms::types::CommsPublicKey;
 use tari_comms_dht::{
-    message::DhtMessageFlags,
+    message::{DhtMessageFlags, NodeDestination},
     outbound::{BroadcastStrategy, OutboundMessageRequester},
 };
 use tari_p2p::{

--- a/base_layer/wallet/src/transaction_service.rs
+++ b/base_layer/wallet/src/transaction_service.rs
@@ -32,9 +32,9 @@ use std::{
     sync::{Arc, Mutex},
     time::Duration,
 };
-use tari_comms::{message::NodeDestination, types::CommsPublicKey};
+use tari_comms::types::CommsPublicKey;
 use tari_comms_dht::{
-    message::DhtMessageFlags,
+    message::{DhtMessageFlags, NodeDestination},
     outbound::{BroadcastStrategy, DhtOutboundError, OutboundMessageRequester},
 };
 use tari_core::{

--- a/comms/dht/src/inbound/dht_handler/task.rs
+++ b/comms/dht/src/inbound/dht_handler/task.rs
@@ -24,14 +24,13 @@ use super::message::{DiscoverMessage, JoinMessage};
 use crate::{
     config::DhtConfig,
     inbound::{error::DhtInboundError, message::DecryptedDhtMessage},
-    message::{DhtMessageFlags, DhtMessageType},
+    message::{DhtMessageFlags, DhtMessageType, NodeDestination},
     outbound::{BroadcastStrategy, OutboundMessageRequester},
 };
 use log::*;
 use std::sync::Arc;
 use tari_comms::{
     connection::NetAddress,
-    message::NodeDestination,
     peer_manager::{NodeId, NodeIdentity, Peer, PeerFlags, PeerManager},
     types::CommsPublicKey,
 };

--- a/comms/dht/src/message.rs
+++ b/comms/dht/src/message.rs
@@ -24,7 +24,7 @@ use crate::consts::DHT_ENVELOPE_HEADER_VERSION;
 use bitflags::bitflags;
 use serde::{Deserialize, Serialize};
 use serde_repr::{Deserialize_repr, Serialize_repr};
-use tari_comms::{message::NodeDestination, types::CommsPublicKey, utils::signature};
+use tari_comms::{peer_manager::NodeId, types::CommsPublicKey, utils::signature};
 
 bitflags! {
     /// Used to indicate characteristics of the incoming or outgoing message, such
@@ -47,7 +47,7 @@ pub enum DhtMessageType {
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub struct DhtHeader {
     pub version: u8,
-    pub destination: NodeDestination<CommsPublicKey>,
+    pub destination: NodeDestination,
     pub origin_public_key: CommsPublicKey,
     pub origin_signature: Vec<u8>,
     pub message_type: DhtMessageType,
@@ -56,7 +56,7 @@ pub struct DhtHeader {
 
 impl DhtHeader {
     pub fn new(
-        destination: NodeDestination<CommsPublicKey>,
+        destination: NodeDestination,
         origin_pubkey: CommsPublicKey,
         origin_signature: Vec<u8>,
         message_type: DhtMessageType,
@@ -95,5 +95,22 @@ impl DhtEnvelope {
             Ok(is_valid) => is_valid,
             Err(_) => false,
         }
+    }
+}
+
+/// Represents the ways a destination node can be represented.
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
+pub enum NodeDestination {
+    /// The sender has chosen not to disclose the message destination
+    Undisclosed,
+    /// Destined for a particular public key
+    PublicKey(CommsPublicKey),
+    /// Destined for a particular node id, or network region
+    NodeId(NodeId),
+}
+
+impl Default for NodeDestination {
+    fn default() -> Self {
+        NodeDestination::Undisclosed
     }
 }

--- a/comms/dht/src/outbound/broadcast.rs
+++ b/comms/dht/src/outbound/broadcast.rs
@@ -277,7 +277,7 @@ where
 mod test {
     use super::*;
     use crate::{
-        message::{DhtMessageFlags, DhtMessageType},
+        message::{DhtMessageFlags, DhtMessageType, NodeDestination},
         test_utils::{make_peer_manager, service_fn},
     };
     use futures::future;
@@ -285,7 +285,7 @@ mod test {
     use std::sync::Mutex;
     use tari_comms::{
         connection::NetAddress,
-        message::{MessageFlags, NodeDestination},
+        message::MessageFlags,
         peer_manager::{NodeId, Peer, PeerFlags},
         types::CommsPublicKey,
     };

--- a/comms/dht/src/outbound/broadcast_strategy.rs
+++ b/comms/dht/src/outbound/broadcast_strategy.rs
@@ -20,10 +20,10 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+use crate::message::NodeDestination;
 use derive_error::Error;
 use std::{fmt, fmt::Formatter};
 use tari_comms::{
-    message::NodeDestination,
     peer_manager::{node_id::NodeId, peer_manager::PeerManager, PeerManagerError},
     types::CommsPublicKey,
 };
@@ -93,7 +93,7 @@ impl BroadcastStrategy {
         // This node's node ID
         source_node_id: NodeId,
         peer_manager: &PeerManager,
-        header_dest: NodeDestination<CommsPublicKey>,
+        header_dest: NodeDestination,
         excluded_peers: Vec<CommsPublicKey>,
     ) -> Result<Self, BroadcastStrategyError>
     {
@@ -142,7 +142,7 @@ impl BroadcastStrategy {
     pub fn discover(
         source_node_id: NodeId,
         dest_node_id: Option<NodeId>,
-        header_dest: NodeDestination<CommsPublicKey>,
+        header_dest: NodeDestination,
         excluded_peers: Vec<CommsPublicKey>,
     ) -> Self
     {

--- a/comms/dht/src/outbound/message.rs
+++ b/comms/dht/src/outbound/message.rs
@@ -21,20 +21,16 @@
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 use super::broadcast_strategy::BroadcastStrategy;
-use crate::message::{DhtHeader, DhtMessageFlags, DhtMessageType};
+use crate::message::{DhtHeader, DhtMessageFlags, DhtMessageType, NodeDestination};
 use std::fmt;
-use tari_comms::{
-    message::{MessageFlags, NodeDestination},
-    peer_manager::PeerNodeIdentity,
-    types::CommsPublicKey,
-};
+use tari_comms::{message::MessageFlags, peer_manager::PeerNodeIdentity, types::CommsPublicKey};
 
 #[derive(Debug, Clone)]
 pub struct SendMessageRequest {
     /// Broadcast strategy to use when sending the message
     pub broadcast_strategy: BroadcastStrategy,
     /// The intended destination for this message
-    pub destination: NodeDestination<CommsPublicKey>,
+    pub destination: NodeDestination,
     /// Comms-level message flags
     pub comms_flags: MessageFlags,
     /// Dht-level message flags

--- a/comms/dht/src/outbound/requester.rs
+++ b/comms/dht/src/outbound/requester.rs
@@ -22,17 +22,14 @@
 
 use super::{broadcast_strategy::BroadcastStrategy, message::DhtOutboundRequest};
 use crate::{
-    message::{DhtHeader, DhtMessageFlags, DhtMessageType},
+    message::{DhtHeader, DhtMessageFlags, DhtMessageType, NodeDestination},
     outbound::{
         message::{ForwardRequest, SendMessageRequest},
         DhtOutboundError,
     },
 };
 use futures::{channel::mpsc, SinkExt};
-use tari_comms::{
-    message::{Frame, Message, MessageFlags, MessageHeader, NodeDestination},
-    types::CommsPublicKey,
-};
+use tari_comms::message::{Frame, Message, MessageFlags, MessageHeader};
 use tari_utilities::message_format::MessageFormat;
 
 #[derive(Clone)]
@@ -49,7 +46,7 @@ impl OutboundMessageRequester {
     pub async fn send_message<T, MType>(
         &mut self,
         broadcast_strategy: BroadcastStrategy,
-        destination: NodeDestination<CommsPublicKey>,
+        destination: NodeDestination,
         dht_flags: DhtMessageFlags,
         message_type: MType,
         message: T,
@@ -67,7 +64,7 @@ impl OutboundMessageRequester {
     pub async fn send_dht_message<T>(
         &mut self,
         broadcast_strategy: BroadcastStrategy,
-        destination: NodeDestination<CommsPublicKey>,
+        destination: NodeDestination,
         dht_flags: DhtMessageFlags,
         message_type: DhtMessageType,
         message: T,
@@ -84,7 +81,7 @@ impl OutboundMessageRequester {
     pub async fn send_raw(
         &mut self,
         broadcast_strategy: BroadcastStrategy,
-        destination: NodeDestination<CommsPublicKey>,
+        destination: NodeDestination,
         dht_flags: DhtMessageFlags,
         dht_message_type: DhtMessageType,
         body: Frame,

--- a/comms/dht/src/test_utils.rs
+++ b/comms/dht/src/test_utils.rs
@@ -22,7 +22,7 @@
 
 use crate::{
     inbound::DhtInboundMessage,
-    message::{DhtEnvelope, DhtHeader, DhtMessageFlags, DhtMessageType},
+    message::{DhtEnvelope, DhtHeader, DhtMessageFlags, DhtMessageType, NodeDestination},
 };
 use futures::{future, task::Context, Future, Poll};
 use rand::rngs::OsRng;
@@ -33,7 +33,7 @@ use std::sync::{
 };
 use tari_comms::{
     connection::NetAddress,
-    message::{InboundMessage, MessageEnvelopeHeader, MessageFlags, NodeDestination},
+    message::{InboundMessage, MessageEnvelopeHeader, MessageFlags},
     peer_manager::{NodeIdentity, Peer, PeerFlags, PeerManager},
     types::CommsDatabase,
     utils::signature,

--- a/comms/src/message/mod.rs
+++ b/comms/src/message/mod.rs
@@ -59,7 +59,6 @@
 //! [MessageHeader]: ./message/struct.MessageHeader.html
 //! [MessageData]: ./message/struct.MessageData.html
 //! [DomainConnector]: ../domain_connector/struct.DomainConnector.html
-use crate::peer_manager::node_id::NodeId;
 use bitflags::*;
 use serde::{Deserialize, Serialize};
 
@@ -90,15 +89,4 @@ bitflags! {
         const NONE = 0b0000_0000;
         const ENCRYPTED = 0b0000_0001;
     }
-}
-
-/// Represents the ways a destination node can be represented.
-#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
-pub enum NodeDestination<P> {
-    /// The sender has chosen not to disclose the message destination
-    Undisclosed,
-    /// Destined for a particular public key
-    PublicKey(P),
-    /// Destined for a particular node id, or network region
-    NodeId(NodeId),
 }


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Generic still left over from attempt to generalise the public key used
in comms. Moved NodeDestination to DHT crate as it is no longer in the
comms header.

