### PR TITLE
MerkleChangeTracker persistent storage

### DIFF
--- a/base_layer/core/src/chain_storage/db_transaction.rs
+++ b/base_layer/core/src/chain_storage/db_transaction.rs
@@ -113,7 +113,12 @@ impl DbTransaction {
     /// the database.
     pub fn commit_block(&mut self) {
         self.operations
-            .push(WriteOperation::Insert(DbKeyValuePair::CommitBlock));
+            .push(WriteOperation::CreateMmrCheckpoint(MmrTree::Header));
+        self.operations
+            .push(WriteOperation::CreateMmrCheckpoint(MmrTree::Kernel));
+        self.operations.push(WriteOperation::CreateMmrCheckpoint(MmrTree::Utxo));
+        self.operations
+            .push(WriteOperation::CreateMmrCheckpoint(MmrTree::RangeProof));
     }
 
     /// Set the horizon beyond which we cannot be guaranteed provide detailed blockchain information anymore.
@@ -171,7 +176,6 @@ pub enum DbKeyValuePair {
     UnspentOutput(HashOutput, Box<TransactionOutput>),
     TransactionKernel(HashOutput, Box<TransactionKernel>),
     OrphanBlock(HashOutput, Box<Block>),
-    CommitBlock,
 }
 
 #[derive(Debug, Clone, PartialEq)]

--- a/base_layer/core/src/chain_storage/lmdb_db/mod.rs
+++ b/base_layer/core/src/chain_storage/lmdb_db/mod.rs
@@ -32,6 +32,7 @@ pub const LMDB_DB_METADATA: &str = "metadata";
 pub const LMDB_DB_HEADERS: &str = "headers";
 pub const LMDB_DB_BLOCK_HASHES: &str = "block_hashes";
 pub const LMDB_DB_UTXOS: &str = "utxos";
+pub const LMDB_DB_TXOS_HASH_TO_INDEX: &str = "txos_hash_to_index";
 pub const LMDB_DB_STXOS: &str = "stxos";
 pub const LMDB_DB_KERNELS: &str = "kernels";
 pub const LMDB_DB_ORPHANS: &str = "orphans";

--- a/base_layer/mmr/src/change_tracker.rs
+++ b/base_layer/mmr/src/change_tracker.rs
@@ -216,6 +216,7 @@ where
         result
     }
 
+    /// Returns the Merkle Checkpoint specified by the provided index.
     pub fn get_checkpoint(&self, index: usize) -> Result<MerkleCheckPoint, MerkleMountainRangeError> {
         match self
             .checkpoints
@@ -225,6 +226,14 @@ where
             None => Err(MerkleMountainRangeError::OutOfRange),
             Some(cp) => Ok(cp.clone()),
         }
+    }
+
+    /// Returns the MMR index of a newly added hash, this index is only valid if the change history is Committed.
+    pub fn index(&self, hash: &Hash) -> Option<usize> {
+        self.current_additions
+            .iter()
+            .position(|h| h == hash)
+            .map(|i| self.mmr.len() as usize - self.current_additions.len() + i)
     }
 }
 


### PR DESCRIPTION
## Description
- The MerkleChangeTrackers now have full persistent storage using LMDB backends, the issue with the clashing WriteTransactions have been resolved by splitting the processing of the MMR DbTransactions and Storage DbTransactions.
- Moved commit_block logic to db_transaction allowing the CreateMmrCheckpoint WriteOperations to be used, the CommitBlock DbKeyValuePair was removed.
- Removed some of the dependency on MerkleNode from the MemoryDatabase, now it is only used for the UTXOs and STXOs.
- Fixed issue in MemoryDatabase and LMDBDatabase where block hashes are not deleted when headers are deleted.
- Removed dependency on MerkleNode from LMDBDatabase by using a txos_hash_to_index_db to find the MMR index of a UTXO or STXO, this reduced the amount deserialisation that needs to be performed.

## Motivation and Context
These changes are required to make the Blockchain backend have full persistent storage.

## How Has This Been Tested?
Tests were added for testing the restoring functionality of the LMDBDatabase and for testing the MMR reset and commit when DBTransactions fail.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [x] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [x] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch
* [x] I ran `cargo-fmt --all` before pushing
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
