### PR TITLE
KeyValueStore convenience functions + small perf improvements

### DIFF
--- a/comms/src/consts.rs
+++ b/comms/src/consts.rs
@@ -21,14 +21,17 @@
 //  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 use crate::types::CommsRng;
-use std::time::Duration;
+use std::{cell::RefCell, time::Duration};
 
 thread_local! {
     /// Thread local RNG for comms
-    pub(crate) static COMMS_RNG: CommsRng = CommsRng::new().expect("Failed to initialize CommsRng");
+    pub(crate) static COMMS_RNG: RefCell<CommsRng> = RefCell::new(CommsRng::new().expect("Failed to initialize CommsRng"));
 }
 
 /// The maximum number of messages that can be stored using the MessageCache of the DHT
 pub const IMS_MSG_CACHE_STORAGE_CAPACITY: usize = 1000;
 /// The time-to-live duration used by the MessageCache for tracking received and handled messages
 pub const IMS_MSG_CACHE_TTL: Duration = Duration::from_secs(300);
+
+/// The maximum number of peers to return from the flood_identities method in peer manager
+pub const PEER_MANAGER_MAX_FLOOD_PEERS: usize = 1000;

--- a/comms/src/message/envelope.rs
+++ b/comms/src/message/envelope.rs
@@ -35,9 +35,11 @@ const FRAMES_PER_MESSAGE: usize = 3;
 
 /// Generate a signature for the peer that confirms the origin_source and body
 fn peer_signature(secret_key: CommsSecretKey, body: &Vec<u8>) -> Result<Vec<u8>, MessageError> {
-    let mut rng = COMMS_RNG.with(|rng| rng.clone());
-    let peer_signature = signature::sign(&mut rng, secret_key, body).map_err(MessageError::SchnorrSignatureError)?;
-    peer_signature.to_binary().map_err(MessageError::MessageFormatError)
+    COMMS_RNG.with(|rng| {
+        let peer_signature =
+            signature::sign(&mut *rng.borrow_mut(), secret_key, body).map_err(MessageError::SchnorrSignatureError)?;
+        peer_signature.to_binary().map_err(MessageError::MessageFormatError)
+    })
 }
 
 /// Represents data that every message contains.

--- a/comms/src/outbound_message_service/service.rs
+++ b/comms/src/outbound_message_service/service.rs
@@ -391,8 +391,8 @@ where TMsgStream: Stream<Item = OutboundMessage> + Unpin
         let OutboundMessage { flags, body, .. } = message;
 
         // Sign the comms envelope
-        let mut rng = COMMS_RNG.with(|rng| rng.clone());
-        let signature = signature::sign(&mut rng, self.node_identity.secret_key.clone(), &body)?;
+        let signature = COMMS_RNG
+            .with(|rng| signature::sign(&mut *rng.borrow_mut(), self.node_identity.secret_key.clone(), &body))?;
 
         let header = MessageEnvelopeHeader {
             version: MESSAGE_PROTOCOL_VERSION,

--- a/infrastructure/storage/src/key_val_store/hmap_database.rs
+++ b/infrastructure/storage/src/key_val_store/hmap_database.rs
@@ -20,7 +20,10 @@
 //  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 //  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use crate::key_val_store::{error::KeyValStoreError, key_val_store::KeyValueStore};
+use crate::key_val_store::{
+    error::KeyValStoreError,
+    key_val_store::{IterationResult, KeyValueStore},
+};
 use std::{collections::HashMap, hash::Hash, sync::RwLock};
 
 ///  The HMapDatabase mimics the behaviour of LMDBDatabase without keeping a persistent copy of the key-value records.
@@ -68,9 +71,12 @@ impl<K: Clone + Eq + Hash, V: Clone> HMapDatabase<K, V> {
 
     /// Iterate over all the stored records and execute the function `f` for each pair in the key-value database.
     pub fn for_each<F>(&self, mut f: F) -> Result<(), KeyValStoreError>
-    where F: FnMut(Result<(K, V), KeyValStoreError>) {
+    where F: FnMut(Result<(K, V), KeyValStoreError>) -> IterationResult {
         for (key, val) in self.db.read().map_err(|_| KeyValStoreError::PoisonedAccess)?.iter() {
-            f(Ok((key.clone(), val.clone())));
+            match f(Ok((key.clone(), val.clone()))) {
+                IterationResult::Break => break,
+                IterationResult::Continue => {},
+            }
         }
         Ok(())
     }
@@ -116,7 +122,7 @@ impl<K: Clone + Eq + Hash, V: Clone> KeyValueStore<K, V> for HMapDatabase<K, V> 
 
     /// Iterate over all the stored records and execute the function `f` for each pair in the key-value database.
     fn for_each<F>(&self, f: F) -> Result<(), KeyValStoreError>
-    where F: FnMut(Result<(K, V), KeyValStoreError>) {
+    where F: FnMut(Result<(K, V), KeyValStoreError>) -> IterationResult {
         self.for_each(f)
     }
 
@@ -192,6 +198,7 @@ mod test {
                 key3_found = true;
                 assert_eq!(val, val3);
             }
+            IterationResult::Continue
         });
         assert!(key1_found);
         assert!(key3_found);

--- a/infrastructure/storage/src/key_val_store/key_val_store.rs
+++ b/infrastructure/storage/src/key_val_store/key_val_store.rs
@@ -22,6 +22,20 @@
 
 use crate::key_val_store::KeyValStoreError;
 
+/// Used to indicate whether an iteration should continue or break (i.e not called again)
+pub enum IterationResult {
+    /// Continue the iteration
+    Continue,
+    /// Stop the iteration (i.e break)
+    Break,
+}
+
+impl Default for IterationResult {
+    fn default() -> Self {
+        IterationResult::Continue
+    }
+}
+
 /// General CRUD behaviour of Key-value store implementations.
 pub trait KeyValueStore<K, V> {
     /// Inserts a key-value pair into the key-value database.
@@ -35,8 +49,10 @@ pub trait KeyValueStore<K, V> {
 
     /// Execute function `f` for each value in the database.
     ///
-    /// `f` is a closure of form `|pair: Result<(K,V), KeyValStoreError>| -> ()`. You will usually need to include type
-    /// inference to let Rust know which type to deserialise to:
+    /// `f` is a closure of form `|pair: Result<(K,V), KeyValStoreError>| -> IterationResult`.
+    /// If `IterationResult::Break` is returned the closure will not be called again and
+    /// `for_each` will return. You will usually need to include type inference to let
+    /// Rust know which type to deserialise to:
     /// ```nocompile
     ///    let res = db.for_each::<Key, Val, _>(|pair| {
     ///        let (key, val) = pair.unwrap();
@@ -45,11 +61,63 @@ pub trait KeyValueStore<K, V> {
     fn for_each<F>(&self, f: F) -> Result<(), KeyValStoreError>
     where
         Self: Sized,
-        F: FnMut(Result<(K, V), KeyValStoreError>);
+        F: FnMut(Result<(K, V), KeyValStoreError>) -> IterationResult;
 
     /// Checks whether the provided `key` exists in the key-value database.
     fn exists(&self, key: &K) -> Result<bool, KeyValStoreError>;
 
     /// Delete a key-pair record associated with the provided `key` from the key-pair database.
     fn delete(&self, key: &K) -> Result<(), KeyValStoreError>;
+
+    /// Execute function `f` for each value in the database. Any errors are filtered out.
+    /// This is useful for any caller which could not do any better with an error
+    /// than filtering it out.
+    ///
+    /// `f` is a closure of form `|pair: (K,V)| -> ()`. You will usually need to include type
+    /// inference to let Rust know which type to deserialise to:
+    /// ```nocompile
+    ///    let res = db.for_each_ok::<Key, Val, _>(|(key, val)| {
+    ///        //.. do stuff with key and val..
+    ///    });
+    fn for_each_ok<F>(&self, mut f: F) -> Result<(), KeyValStoreError>
+    where
+        Self: Sized,
+        F: FnMut((K, V)) -> IterationResult,
+    {
+        self.for_each(|result| match result {
+            Ok(pair) => f(pair),
+            Err(_) => IterationResult::Continue,
+        })
+    }
+
+    /// Return a `Vec<(K, V)>` filtered by the predicate.
+    ///
+    /// Bare in mind that this is not an `Iterator` and filter will fetch data eagerly.
+    fn filter<F>(&self, predicate: F) -> Result<Vec<(K, V)>, KeyValStoreError>
+    where
+        Self: Sized,
+        F: FnMut(&(K, V)) -> bool,
+    {
+        self.filter_take(self.size()?, predicate)
+    }
+
+    /// Return a `Vec<(K, V)>` filtered by the predicate. At most `n` pairs are returned.
+    fn filter_take<F>(&self, n: usize, mut predicate: F) -> Result<Vec<(K, V)>, KeyValStoreError>
+    where
+        Self: Sized,
+        F: FnMut(&(K, V)) -> bool,
+    {
+        let mut values = Vec::with_capacity(n);
+        self.for_each_ok(|pair| {
+            if predicate(&pair) {
+                values.push(pair);
+            }
+            if values.len() == n {
+                return IterationResult::Break;
+            }
+            IterationResult::Continue
+        })?;
+
+        Ok(values)
+    }
 }

--- a/infrastructure/storage/src/key_val_store/lmdb_database.rs
+++ b/infrastructure/storage/src/key_val_store/lmdb_database.rs
@@ -21,7 +21,10 @@
 //  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 use crate::{
-    key_val_store::{key_val_store::KeyValueStore, KeyValStoreError},
+    key_val_store::{
+        key_val_store::{IterationResult, KeyValueStore},
+        KeyValStoreError,
+    },
     lmdb_store::LMDBDatabase,
 };
 use lmdb_zero::traits::AsLmdbBytes;
@@ -82,7 +85,7 @@ where
 
     /// Iterate over all the stored records and execute the function `f` for each pair in the key-value database.
     fn for_each<F>(&self, f: F) -> Result<(), KeyValStoreError>
-    where F: FnMut(Result<(K, V), KeyValStoreError>) {
+    where F: FnMut(Result<(K, V), KeyValStoreError>) -> IterationResult {
         self.inner
             .for_each::<K, V, F>(f)
             .map_err(|e| KeyValStoreError::DatabaseError(e.to_string()))
@@ -192,6 +195,7 @@ mod test {
                 key3_found = true;
                 assert_eq!(val, val3);
             }
+            IterationResult::Continue
         });
         assert!(key1_found);
         assert!(key3_found);

--- a/infrastructure/storage/src/lib.rs
+++ b/infrastructure/storage/src/lib.rs
@@ -1,4 +1,10 @@
 mod key_val_store;
 pub mod lmdb_store;
 
-pub use key_val_store::{lmdb_database::LMDBWrapper, HMapDatabase, KeyValStoreError, KeyValueStore};
+pub use key_val_store::{
+    key_val_store::IterationResult,
+    lmdb_database::LMDBWrapper,
+    HMapDatabase,
+    KeyValStoreError,
+    KeyValueStore,
+};

--- a/infrastructure/storage/src/lmdb_store/store.rs
+++ b/infrastructure/storage/src/lmdb_store/store.rs
@@ -1,6 +1,9 @@
 //! An ergonomic, multithreaded API for an LMDB datastore
 
-use crate::{key_val_store::error::KeyValStoreError, lmdb_store::error::LMDBError};
+use crate::{
+    key_val_store::{error::KeyValStoreError, key_val_store::IterationResult},
+    lmdb_store::error::LMDBError,
+};
 use lmdb_zero::{
     db,
     error::{self, LmdbResultExt},
@@ -417,8 +420,9 @@ impl LMDBDatabase {
     /// The underlying LMDB library does not permit database cursors to be returned from functions to preserve Rust
     /// memory guarantees, so this is the closest thing to an iterator that you're going to get :/
     ///
-    /// `f` is a closure of form `|pair: Result<(K,V), LMDBError>| -> ()`. You will usually need to include type
-    /// inference to let Rust know which type to deserialise to:
+    /// `f` is a closure of form `|pair: Result<(K,V), LMDBError>| -> IterationResult`. If `IterationResult::Break` is
+    /// returned the closure will not be called again and `for_each` will return. You will usually need to include
+    /// type inference to let Rust know which type to deserialise to:
     /// ```nocompile
     ///    let res = db.for_each::<Key, User, _>(|pair| {
     ///        let (key, user) = pair.unwrap();
@@ -428,7 +432,7 @@ impl LMDBDatabase {
     where
         K: DeserializeOwned,
         V: DeserializeOwned,
-        F: FnMut(Result<(K, V), KeyValStoreError>),
+        F: FnMut(Result<(K, V), KeyValStoreError>) -> IterationResult,
     {
         let env = self.env.clone();
         let db = self.db.clone();
@@ -446,7 +450,10 @@ impl LMDBDatabase {
         let iter = CursorIter::new(cursor, &access, head, ReadOnlyIterator::next).map_err(LMDBError::DatabaseError)?;
 
         for p in iter {
-            f(p.map_err(|e| KeyValStoreError::DatabaseError(e.to_string())));
+            match f(p.map_err(|e| KeyValStoreError::DatabaseError(e.to_string()))) {
+                IterationResult::Break => break,
+                IterationResult::Continue => {},
+            }
         }
 
         Ok(())

--- a/infrastructure/storage/tests/lmdb.rs
+++ b/infrastructure/storage/tests/lmdb.rs
@@ -22,7 +22,10 @@
 
 use serde::{Deserialize, Serialize};
 use std::{net::Ipv4Addr, path::PathBuf, str::FromStr, sync::Arc, thread};
-use tari_storage::lmdb_store::{db, LMDBBuilder, LMDBDatabase, LMDBError, LMDBStore};
+use tari_storage::{
+    lmdb_store::{db, LMDBBuilder, LMDBDatabase, LMDBError, LMDBStore},
+    IterationResult,
+};
 use tari_utilities::ExtendBytes;
 
 #[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]
@@ -233,6 +236,7 @@ fn pair_iterator() {
         let (key, user) = pair.unwrap();
         assert_eq!(user.id, key);
         assert_eq!(users[key as usize - 1], user);
+        IterationResult::Continue
     });
     assert!(res.is_ok());
     clean_up("pair_iterator");


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
- `for_each` closure now must return a `ForEachLoop` enum to indicate
  whether the for_each closure should be called again
- Added convenience functions: `for_each_ok`, `filter`, `filter_take` as
  default impls on `KeyValueStore` trait
- Few small optimisations on peer manager (avoid clones, exit loop early)
- COMMS_RNG is now a `RefCell` to avoid cloning the rng each time it is
  needed.


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Part of #824 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Existing tests pass

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [x] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch
* [x] I ran `cargo-fmt --all` before pushing
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
