### PR TITLE
Update the Wallet container and reintroduce it to the applications + integration tests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,8 +17,9 @@ members = [
     "infrastructure/pubsub",
     "infrastructure/storage",
     "infrastructure/test_utils",
-    #TODO Reintroduce these once the comms stack and wallet is stable
-    #"applications/grpc_wallet",
-    #"applications/console_text_messenger",
+    "applications/console_text_messenger",
+    #Needs to be updated to make its calls using an Tokio runtime block_on function.
     #"ffi"
+    #The wallet gRPC is based on the old Futures and not part of the Testnet scope
+    #"applications/grpc_wallet",
 ]

--- a/applications/console_text_messenger/Cargo.toml
+++ b/applications/console_text_messenger/Cargo.toml
@@ -19,10 +19,11 @@ clap = "2.33.0"
 config = { version = "0.9.3" }
 crossbeam-channel = "0.3.8"
 ctrlc = "3.1.3"
-futures =  { version = "=0.3.0-alpha.19", package = "futures-preview", features =["compat", "std"]}
+futures =  { version = "=0.3.0-alpha.18", package = "futures-preview", features =["compat", "std"]}
 log = { version = "0.4.0", features = ["std"] }
 log4rs = {version ="0.8.3",features = ["console_appender", "file_appender", "file", "yaml_format"]}
 pnet = "0.22.0"
 serde = "1.0.90"
 serde_derive = "1.0.90"
 simple_logger = "1.2.0"
+tokio = "0.2.0-alpha.4"

--- a/applications/grpc_wallet/src/grpc_interface.rs
+++ b/applications/grpc_wallet/src/grpc_interface.rs
@@ -79,6 +79,7 @@ impl From<SentTextMessage> for SentTextMessageRpc {
 #[derive(Clone)]
 pub struct WalletRPC {
     pub wallet: Arc<Wallet>,
+    pub runtime: Runtime,
 }
 
 /// Implementation of the the gRPC service methods.

--- a/applications/grpc_wallet/src/main.rs
+++ b/applications/grpc_wallet/src/main.rs
@@ -38,7 +38,12 @@ use tari_crypto::keys::PublicKey;
 use tari_grpc_wallet::wallet_server::WalletServer;
 use tari_p2p::initialization::CommsConfig;
 use tari_utilities::{hex::Hex, message_format::MessageFormat};
-use tari_wallet::{text_message_service_sync::Contact, wallet::WalletConfig, Wallet};
+use tari_wallet::{
+    text_message_service::model::Contact,
+    text_message_service_sync::Contact,
+    wallet::WalletConfig,
+    Wallet,
+};
 
 const LOG_TARGET: &str = "applications::grpc_wallet";
 
@@ -237,7 +242,7 @@ pub fn main() {
         .unwrap();
 
     let config = WalletConfig {
-        comms: CommsConfig {
+        comms_config: CommsConfig {
             control_service: ControlServiceConfig {
                 listener_address: listener_address.clone(),
                 socks_proxy_address: None,
@@ -257,8 +262,8 @@ pub fn main() {
         public_key,
         database_path,
     };
-
-    let wallet = Wallet::new(config).unwrap();
+    let runtime = Runtime::new().unwrap();
+    let mut wallet = Wallet::new(config, &runtime).unwrap();
 
     // Add any provided peers to Peer Manager and Text Message Service Contacts
     if !contacts.peers.is_empty() {

--- a/base_layer/p2p/Cargo.toml
+++ b/base_layer/p2p/Cargo.toml
@@ -17,7 +17,7 @@ tari_service_framework = { version = "^0.0", path = "../service_framework"}
 tari_storage = {version = "^0.0", path = "../../infrastructure/storage"}
 tari_utilities = { version = "^0.0", path = "../../infrastructure/tari_util"}
 tari_comms_dht = { version = "^0.0", path = "../../comms/dht"}
-
+tari_broadcast_channel = { version="^0.0",  path = "../../infrastructure/broadcast_channel" }
 chrono = { version = "0.4.6", features = ["serde"]}
 crossbeam-channel = "0.3.8"
 derive-error = "0.0.4"
@@ -32,6 +32,7 @@ threadpool = "1.7.1"
 tokio = "0.2.0-alpha.4"
 tower-service = { version="0.3.0-alpha.1" }
 tracing = "0.1.5"
+ttl_cache = "0.5.1"
 tower = "0.3.0-alpha.1a"
 
 [dev-dependencies]

--- a/base_layer/p2p/src/services/liveness/error.rs
+++ b/base_layer/p2p/src/services/liveness/error.rs
@@ -23,6 +23,7 @@
 use derive_error::Error;
 use tari_comms::message::MessageError;
 use tari_comms_dht::outbound::DhtOutboundError;
+use tari_service_framework::reply_channel::TransportChannelError;
 
 #[derive(Debug, Error)]
 pub enum LivenessError {
@@ -31,6 +32,11 @@ pub enum LivenessError {
     SendPongFailed,
     /// Failed to send a ping message
     SendPingFailed,
-    // Occurs when a message cannot deserialize into a PingPong message
+    /// Occurs when a message cannot deserialize into a PingPong message
     MessageError(MessageError),
+    /// The Handle repsonse was not what was expected for this request
+    UnexpectedApiResponse,
+    /// An error has occurred reading from the event subscriber stream
+    EventStreamError,
+    TransportChannelError(TransportChannelError),
 }

--- a/base_layer/p2p/src/services/liveness/state.rs
+++ b/base_layer/p2p/src/services/liveness/state.rs
@@ -45,16 +45,6 @@ impl LivenessState {
         self.pongs_sent.fetch_add(1, Ordering::Relaxed)
     }
 
-    #[cfg(test)]
-    pub fn pings_sent(&self) -> usize {
-        self.pings_sent.load(Ordering::Relaxed)
-    }
-
-    #[cfg(test)]
-    pub fn pongs_sent(&self) -> usize {
-        self.pongs_sent.load(Ordering::Relaxed)
-    }
-
     pub fn inc_pings_received(&self) -> usize {
         self.pings_received.fetch_add(1, Ordering::Relaxed)
     }
@@ -69,6 +59,16 @@ impl LivenessState {
 
     pub fn pongs_received(&self) -> usize {
         self.pongs_received.load(Ordering::Relaxed)
+    }
+
+    #[cfg(test)]
+    pub fn pings_sent(&self) -> usize {
+        self.pings_sent.load(Ordering::Relaxed)
+    }
+
+    #[cfg(test)]
+    pub fn pongs_sent(&self) -> usize {
+        self.pongs_sent.load(Ordering::Relaxed)
     }
 }
 

--- a/base_layer/p2p/tests/mod.rs
+++ b/base_layer/p2p/tests/mod.rs
@@ -23,5 +23,5 @@
 // TODO Put this back in after Futures Comms stack refactor
 // mod dht;
 // mod saf;
-// mod ping_pong;
-// mod support;
+mod services;
+mod support;

--- a/base_layer/p2p/tests/support/comms_and_services.rs
+++ b/base_layer/p2p/tests/support/comms_and_services.rs
@@ -20,7 +20,7 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use crate::support::utils::random_string;
+use crate::support::random_string;
 use futures::Sink;
 use std::{error::Error, sync::Arc, time::Duration};
 use tari_comms::{
@@ -63,8 +63,8 @@ where
             .unwrap()
             .to_string(),
         peer_database_name: random_string(8),
-        inbound_buffer_size: 100,
-        outbound_buffer_size: 100,
+        inbound_buffer_size: 10,
+        outbound_buffer_size: 10,
         dht: Default::default(),
     };
 

--- a/base_layer/p2p/tests/support/mod.rs
+++ b/base_layer/p2p/tests/support/mod.rs
@@ -21,35 +21,13 @@
 //  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 use rand::{distributions::Alphanumeric, rngs::OsRng, Rng};
-use std::{fmt::Debug, iter, thread, time::Duration};
+use std::iter;
+
+// pub mod comms_outbound;
+pub mod comms_and_services;
+pub mod utils;
 
 pub fn random_string(len: usize) -> String {
     let mut rng = OsRng::new().unwrap();
     iter::repeat(()).map(|_| rng.sample(Alphanumeric)).take(len).collect()
-}
-
-pub fn assert_change<F, T>(func: F, to: T, poll_count: usize)
-where
-    F: Fn() -> T,
-    T: Eq + Debug,
-{
-    let mut i = 0;
-    loop {
-        let new_val = func();
-        if new_val == to {
-            break;
-        }
-
-        i += 1;
-        if i >= poll_count {
-            panic!(
-                "Value did not change to {:?} within {}ms (last value: {:?})",
-                to,
-                poll_count * 100,
-                new_val,
-            );
-        }
-
-        thread::sleep(Duration::from_millis(100));
-    }
 }

--- a/base_layer/wallet/src/text_message_service/error.rs
+++ b/base_layer/wallet/src/text_message_service/error.rs
@@ -24,7 +24,7 @@ use derive_error::Error;
 use diesel::result::{ConnectionError as DieselConnectionError, Error as DieselError};
 use tari_comms::{builder::CommsError, connection::NetAddressError, message::MessageError};
 use tari_comms_dht::outbound::DhtOutboundError;
-use tari_p2p::sync_services::ServiceError;
+use tari_p2p::{services::liveness::error::LivenessError, sync_services::ServiceError};
 use tari_service_framework::reply_channel::TransportChannelError;
 use tari_utilities::{hex::HexError, message_format::MessageFormatError};
 use tokio_executor::threadpool::BlockingError;
@@ -44,8 +44,10 @@ pub enum TextMessageError {
     NetAddressError(NetAddressError),
     DatabaseConnectionError(DieselConnectionError),
     BlockingError(BlockingError),
-    EventStreamError,
     R2d2Error,
+    LivenessError(LivenessError),
+    /// An error has occurred reading from the event subscriber stream
+    EventStreamError,
     /// If a received TextMessageAck doesn't matching any pending messages
     MessageNotFound,
     /// Failed to send from API

--- a/base_layer/wallet/src/text_message_service/mod.rs
+++ b/base_layer/wallet/src/text_message_service/mod.rs
@@ -37,7 +37,7 @@ use tari_p2p::{
     comms_connector::PeerMessage,
     domain_message::DomainMessage,
     services::{
-        liveness::LivenessHandle,
+        liveness::handle::LivenessHandle,
         utils::{map_deserialized, ok_or_skip_result},
     },
     tari_message::{ExtendedMessage, TariMessageType},

--- a/base_layer/wallet/src/text_message_service/service.rs
+++ b/base_layer/wallet/src/text_message_service/service.rs
@@ -44,7 +44,7 @@ use tari_comms_dht::{
 };
 use tari_p2p::{
     domain_message::DomainMessage,
-    services::liveness::LivenessHandle,
+    services::liveness::handle::LivenessHandle,
     tari_message::{ExtendedMessage, TariMessageType},
 };
 use tari_service_framework::reply_channel;
@@ -169,7 +169,7 @@ where
         let connection = SqliteConnection::establish(&database_path)?;
 
         connection.execute("PRAGMA foreign_keys = ON")?;
-
+        println!("establish DB? {:?} PAth: {:?}", db_exists, database_path);
         if !db_exists {
             embed_migrations!("./migrations");
             embedded_migrations::run_with_output(&connection, &mut io::stdout()).map_err(|err| {
@@ -415,16 +415,7 @@ where
         );
 
         // Send ping to the contact so that if they are online they will flush all outstanding messages for this node
-        // TODO This was removed as it created random lock ups in the tests, Once the new Future based comms Middleware
-        // is in put this back
-        //        let _ = self
-        //            .liveness
-        //            .call(LivenessRequest::SendPing(contact.pub_key))
-        //            .await
-        //            .or_else(|err| {
-        //                error!(target: LOG_TARGET, "{:?}", err);
-        //                Err(err)
-        //            });
+        self.liveness.send_ping(contact.pub_key).await?;
 
         Ok(())
     }

--- a/base_layer/wallet/tests/wallet/mod.rs
+++ b/base_layer/wallet/tests/wallet/mod.rs
@@ -20,17 +20,26 @@
 //  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 //  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use crate::support::utils::assert_change;
-use std::{path::PathBuf, time::Duration};
+use crate::support::{
+    data::{clean_up_sql_database, get_path, init_sql_database},
+    utils::{event_stream_count, random_string},
+};
+use log::*;
+use std::{sync::Arc, time::Duration};
 use tari_comms::{
     connection::{net_address::NetAddressWithStats, NetAddress, NetAddressesWithStats},
     control_service::ControlServiceConfig,
-    peer_manager::{peer::PeerFlags, NodeId, Peer},
-    types::{CommsPublicKey, CommsSecretKey},
+    peer_manager::{peer::PeerFlags, NodeId, NodeIdentity, Peer},
+    types::CommsPublicKey,
 };
-use tari_crypto::keys::{PublicKey, SecretKey};
-use tari_p2p::initialization::CommsConfig;
-use tari_wallet::{text_message_service_sync::Contact, wallet::WalletConfig, Wallet};
+use tari_p2p::{initialization::CommsConfig, services::liveness::handle::LivenessEvent};
+use tari_wallet::{
+    text_message_service::{handle::TextMessageEvent, model::Contact},
+    wallet::WalletConfig,
+    Wallet,
+};
+use tempdir::TempDir;
+use tokio::runtime::Runtime;
 
 fn create_peer(public_key: CommsPublicKey, net_address: NetAddress) -> Peer {
     Peer::new(
@@ -41,31 +50,10 @@ fn create_peer(public_key: CommsPublicKey, net_address: NetAddress) -> Peer {
     )
 }
 
-fn get_path(name: Option<&str>) -> String {
-    let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-    path.push("tests/data");
-    path.push(name.unwrap_or(""));
-    path.to_str().unwrap().to_string()
-}
-
-fn clean_up_datastore(name: &str) {
-    std::fs::remove_dir_all(get_path(Some(name))).unwrap();
-}
-
-fn clean_up_sql_database(name: &str) {
-    if std::fs::metadata(get_path(Some(name))).is_ok() {
-        std::fs::remove_file(get_path(Some(name))).unwrap();
-    }
-}
-
-fn init_sql_database(name: &str) {
-    clean_up_sql_database(name);
-    let path = get_path(None);
-    let _ = std::fs::create_dir(&path).unwrap_or_default();
-}
-
 #[test]
 fn test_wallet() {
+    let runtime = Runtime::new().unwrap();
+
     let mut rng = rand::OsRng::new().unwrap();
 
     let db_name1 = "test_wallet1.sqlite3";
@@ -76,125 +64,170 @@ fn test_wallet() {
     let db_path2 = get_path(Some(db_name2));
     init_sql_database(db_name2);
 
-    let listener_address1: NetAddress = "127.0.0.1:32775".parse().unwrap();
-    let secret_key1 = CommsSecretKey::random(&mut rng);
-    let public_key1 = CommsPublicKey::from_secret_key(&secret_key1);
-    let wallet1_peer_database_name = "wallet1_peer_database".to_string();
-    let config1 = WalletConfig {
-        comms: CommsConfig {
-            control_service: ControlServiceConfig {
-                listener_address: listener_address1.clone(),
-                socks_proxy_address: None,
-                requested_connection_timeout: Duration::from_millis(5000),
-            },
+    let node_1_identity = NodeIdentity::random(&mut rng, "127.0.0.1:22523".parse().unwrap()).unwrap();
+    let node_2_identity = NodeIdentity::random(&mut rng, "127.0.0.1:22145".parse().unwrap()).unwrap();
+    let comms_config1 = CommsConfig {
+        node_identity: Arc::new(node_1_identity.clone()),
+        host: "127.0.0.1".parse().unwrap(),
+        socks_proxy_address: None,
+        control_service: ControlServiceConfig {
+            listener_address: node_1_identity.control_service_address(),
             socks_proxy_address: None,
-            host: "127.0.0.1".parse().unwrap(),
-            public_key: public_key1.clone(),
-            secret_key: secret_key1,
-            public_address: listener_address1.clone(),
-            datastore_path: get_path(Some(&wallet1_peer_database_name)),
-            peer_database_name: wallet1_peer_database_name.clone(),
+            requested_connection_timeout: Duration::from_millis(2000),
         },
-        public_key: public_key1.clone(),
+        datastore_path: TempDir::new(random_string(8).as_str())
+            .unwrap()
+            .path()
+            .to_str()
+            .unwrap()
+            .to_string(),
+        peer_database_name: random_string(8),
+        inbound_buffer_size: 100,
+        outbound_buffer_size: 100,
+        dht: Default::default(),
+    };
+    let comms_config2 = CommsConfig {
+        node_identity: Arc::new(node_2_identity.clone()),
+        host: "127.0.0.1".parse().unwrap(),
+        socks_proxy_address: None,
+        control_service: ControlServiceConfig {
+            listener_address: node_2_identity.control_service_address(),
+            socks_proxy_address: None,
+            requested_connection_timeout: Duration::from_millis(2000),
+        },
+        datastore_path: TempDir::new(random_string(8).as_str())
+            .unwrap()
+            .path()
+            .to_str()
+            .unwrap()
+            .to_string(),
+        peer_database_name: random_string(8),
+        inbound_buffer_size: 100,
+        outbound_buffer_size: 100,
+        dht: Default::default(),
+    };
+    let config1 = WalletConfig {
+        comms_config: comms_config1,
+        inbound_message_buffer_size: 100,
+        public_key: node_1_identity.identity.public_key.clone(),
         database_path: db_path1,
     };
-
-    let wallet1 = Wallet::new(config1).unwrap();
-
-    let listener_address2: NetAddress = "127.0.0.1:32776".parse().unwrap();
-    let secret_key2 = CommsSecretKey::random(&mut rng);
-    let public_key2 = CommsPublicKey::from_secret_key(&secret_key2);
-    let wallet2_peer_database_name = "wallet2_peer_database".to_string();
     let config2 = WalletConfig {
-        comms: CommsConfig {
-            control_service: ControlServiceConfig {
-                listener_address: listener_address2.clone(),
-                socks_proxy_address: None,
-                requested_connection_timeout: Duration::from_millis(5000),
-            },
-            socks_proxy_address: None,
-            host: "127.0.0.1".parse().unwrap(),
-            public_key: public_key2.clone(),
-            secret_key: secret_key2,
-            public_address: listener_address2.clone(),
-            datastore_path: get_path(Some(&wallet2_peer_database_name)),
-            peer_database_name: wallet2_peer_database_name.clone(),
-        },
-        public_key: public_key2.clone(),
+        comms_config: comms_config2,
+        inbound_message_buffer_size: 100,
+        public_key: node_1_identity.identity.public_key.clone(),
         database_path: db_path2,
     };
-
-    let wallet2 = Wallet::new(config2).unwrap();
-
-    wallet1
-        .comms_services
-        .peer_manager()
-        .add_peer(create_peer(public_key2.clone(), listener_address2.clone()))
-        .unwrap();
-
-    wallet2
-        .comms_services
-        .peer_manager()
-        .add_peer(create_peer(public_key1.clone(), listener_address1.clone()))
-        .unwrap();
+    let runtime_node1 = Runtime::new().unwrap();
+    let runtime_node2 = Runtime::new().unwrap();
+    let mut wallet1 = Wallet::new(config1, runtime_node1).unwrap();
+    let mut wallet2 = Wallet::new(config2, runtime_node2).unwrap();
 
     wallet1
-        .text_message_service
-        .add_contact(Contact::new(
-            "Alice".to_string(),
-            public_key2.clone(),
-            listener_address2,
+        .comms_service
+        .peer_manager()
+        .add_peer(create_peer(
+            node_2_identity.identity.public_key.clone(),
+            node_2_identity.control_service_address(),
         ))
         .unwrap();
 
     wallet2
-        .text_message_service
-        .add_contact(Contact::new("Bob".to_string(), public_key1.clone(), listener_address1))
+        .comms_service
+        .peer_manager()
+        .add_peer(create_peer(
+            node_1_identity.identity.public_key.clone(),
+            node_1_identity.control_service_address(),
+        ))
+        .unwrap();
+    error!("Starting tests");
+    runtime
+        .block_on(wallet2.text_message_service.add_contact(Contact::new(
+            "Alice".to_string(),
+            node_1_identity.identity.public_key.clone(),
+            node_1_identity.control_service_address(),
+        )))
         .unwrap();
 
-    wallet1
-        .text_message_service
-        .send_text_message(public_key2.clone(), "Say Hello,".to_string())
+    runtime
+        .block_on(wallet1.text_message_service.add_contact(Contact::new(
+            "Bob".to_string(),
+            node_2_identity.identity.public_key.clone(),
+            node_2_identity.control_service_address(),
+        )))
         .unwrap();
 
-    wallet2
-        .text_message_service
-        .send_text_message(public_key1.clone(), "hello?".to_string())
+    runtime
+        .block_on(
+            wallet1
+                .text_message_service
+                .send_text_message(node_2_identity.identity.public_key.clone(), "Say Hello,".to_string()),
+        )
         .unwrap();
 
-    wallet1
-        .text_message_service
-        .send_text_message(public_key2.clone(), "to my little friend!".to_string())
+    runtime
+        .block_on(
+            wallet2
+                .text_message_service
+                .send_text_message(node_1_identity.identity.public_key.clone(), "hello?".to_string()),
+        )
         .unwrap();
 
-    assert_change(
-        || {
-            let msgs = wallet1.text_message_service.get_text_messages().unwrap();
-            (msgs.sent_messages.len(), msgs.received_messages.len())
-        },
-        (2, 1),
-        50,
-    );
+    runtime
+        .block_on(wallet1.text_message_service.send_text_message(
+            node_2_identity.identity.public_key.clone(),
+            "to my little friend!".to_string(),
+        ))
+        .unwrap();
 
-    assert_change(
-        || {
-            let msgs = wallet2.text_message_service.get_text_messages().unwrap();
-            (msgs.sent_messages.len(), msgs.received_messages.len())
-        },
-        (1, 2),
-        50,
-    );
+    let mut result = runtime.block_on(async {
+        event_stream_count(
+            wallet1.text_message_service.get_event_stream_fused(),
+            3,
+            Duration::from_secs(10),
+        )
+        .await
+    });
+    assert_eq!(result.remove(&TextMessageEvent::ReceivedTextMessage), Some(1));
+    assert_eq!(result.remove(&TextMessageEvent::ReceivedTextMessageAck), Some(2));
 
-    wallet1.ping_pong_service.ping(public_key2.clone()).unwrap();
-    wallet2.ping_pong_service.ping(public_key1.clone()).unwrap();
+    runtime
+        .block_on(
+            wallet1
+                .liveness_service
+                .send_ping(node_2_identity.identity.public_key.clone()),
+        )
+        .unwrap();
 
-    assert_change(|| wallet1.ping_pong_service.ping_count().unwrap(), 2, 20);
-    assert_change(|| wallet1.ping_pong_service.pong_count().unwrap(), 2, 20);
-    assert_change(|| wallet2.ping_pong_service.ping_count().unwrap(), 2, 20);
-    assert_change(|| wallet2.ping_pong_service.pong_count().unwrap(), 2, 20);
+    runtime
+        .block_on(
+            wallet2
+                .liveness_service
+                .send_ping(node_1_identity.identity.public_key.clone()),
+        )
+        .unwrap();
 
-    clean_up_datastore(&wallet1_peer_database_name);
-    clean_up_datastore(&wallet2_peer_database_name);
+    let mut result = runtime.block_on(async {
+        event_stream_count(
+            wallet1.liveness_service.get_event_stream_fused(),
+            2,
+            Duration::from_secs(3),
+        )
+        .await
+    });
+    assert_eq!(result.remove(&LivenessEvent::ReceivedPing), Some(1));
+
+    let mut result = runtime.block_on(async {
+        event_stream_count(
+            wallet2.liveness_service.get_event_stream_fused(),
+            2,
+            Duration::from_secs(3),
+        )
+        .await
+    });
+
+    assert_eq!(result.remove(&LivenessEvent::ReceivedPing), Some(1));
+
     clean_up_sql_database(db_name1);
     clean_up_sql_database(db_name2);
 }


### PR DESCRIPTION
## Description

This PR updates the Waller container object to support the new async services. 
Integration tests were added for the current Wallet services such as the wallet itself, TMS and the Liveness service.
The new wallet object was then plumbed into the Console Text Messenger application.

The gRPC wallet was not updated as it is not due for MVP and the FFI bindings still need to be updated to use a Tokio runtime.

## Motivation and Context
Closes https://github.com/tari-project/tari/issues/796
Closes https://github.com/tari-project/tari/issues/797

## How Has This Been Tested?
Integration tests provided

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [x] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch
* [x] I ran `cargo-fmt --all` before pushing
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
