### PR TITLE
Add boilerplate for base node FSM

### DIFF
--- a/base_layer/core/src/base_node/states/fetching_horizon_state.rs
+++ b/base_layer/core/src/base_node/states/fetching_horizon_state.rs
@@ -19,52 +19,36 @@
 // SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-//
 
 use crate::{
-    base_node::states::{Starting, StateEvent, StateEvent::FatalError},
-    chain_storage::{BlockchainBackend, BlockchainDatabase},
+    base_node::states::{listening::Listening, InitialSync, StateEvent, StateEvent::FatalError},
+    chain_storage::BlockchainBackend,
 };
 use log::*;
 
-const LOG_TARGET: &str = "base_node::initial_sync";
+const LOG_TARGET: &str = "base_node::fetching_horizon_state";
 
-pub struct InitialSync<B>
-where B: BlockchainBackend
-{
-    pub(crate) db: BlockchainDatabase<B>,
-}
+pub struct FetchHorizonState;
 
-impl<B: BlockchainBackend> InitialSync<B> {
+impl FetchHorizonState {
     pub fn next_event(&mut self) -> StateEvent {
-        info!(target: LOG_TARGET, "Starting blockchain metadata sync");
-        self.sync_metadata()
-    }
-
-    /// Fetch the blockchain metadata from our internal database and compare it to data received from peers to decide
-    /// on the next phase of the blockchain synchronisation.
-    fn sync_metadata(&self) -> StateEvent {
-        info!(target: LOG_TARGET, "Loading local blockchain metadata.");
-        let metadata = match self.db.get_metadata() {
-            Ok(m) => m,
-            Err(e) => {
-                let msg = format!("Could not get local blockchain metadata. {}", e.to_string());
-                return FatalError(msg);
-            },
-        };
-        info!(
-            target: LOG_TARGET,
-            "Current local blockchain database information:\n {}", metadata
-        );
-        // TODO async fetch peer metadata
-
+        info!(target: LOG_TARGET, "Starting synchronization of pruning horizon state");
         FatalError("Unimplemented".into())
     }
 }
 
-/// State management for Starting -> InitialSync. This state change occurs every time a node is restarted.
-impl<B: BlockchainBackend> From<Starting<B>> for InitialSync<B> {
-    fn from(old_state: Starting<B>) -> Self {
-        InitialSync { db: old_state.db }
+/// State management for InitialSync -> FetchingHorizonState. This is the typical transition for a new node joining
+/// the network
+impl<B: BlockchainBackend> From<InitialSync<B>> for FetchHorizonState {
+    fn from(_old: InitialSync<B>) -> Self {
+        unimplemented!()
+    }
+}
+
+/// State management for Listening -> FetchingHorizonState. This can occur if a node has been disconnected from the
+/// network for a long time.
+impl From<Listening> for FetchHorizonState {
+    fn from(_old: Listening) -> Self {
+        unimplemented!()
     }
 }

--- a/base_layer/core/src/base_node/states/listening.rs
+++ b/base_layer/core/src/base_node/states/listening.rs
@@ -19,52 +19,36 @@
 // SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-//
 
 use crate::{
-    base_node::states::{Starting, StateEvent, StateEvent::FatalError},
-    chain_storage::{BlockchainBackend, BlockchainDatabase},
+    base_node::states::{block_sync::BlockSync, InitialSync, StateEvent, StateEvent::FatalError},
+    chain_storage::BlockchainBackend,
 };
 use log::*;
 
-const LOG_TARGET: &str = "base_node::initial_sync";
+const LOG_TARGET: &str = "base_node::listening";
 
-pub struct InitialSync<B>
-where B: BlockchainBackend
-{
-    pub(crate) db: BlockchainDatabase<B>,
-}
+pub struct Listening;
 
-impl<B: BlockchainBackend> InitialSync<B> {
+impl Listening {
     pub fn next_event(&mut self) -> StateEvent {
-        info!(target: LOG_TARGET, "Starting blockchain metadata sync");
-        self.sync_metadata()
-    }
-
-    /// Fetch the blockchain metadata from our internal database and compare it to data received from peers to decide
-    /// on the next phase of the blockchain synchronisation.
-    fn sync_metadata(&self) -> StateEvent {
-        info!(target: LOG_TARGET, "Loading local blockchain metadata.");
-        let metadata = match self.db.get_metadata() {
-            Ok(m) => m,
-            Err(e) => {
-                let msg = format!("Could not get local blockchain metadata. {}", e.to_string());
-                return FatalError(msg);
-            },
-        };
-        info!(
-            target: LOG_TARGET,
-            "Current local blockchain database information:\n {}", metadata
-        );
-        // TODO async fetch peer metadata
-
+        info!(target: LOG_TARGET, "Listening for new blocks");
         FatalError("Unimplemented".into())
     }
 }
 
-/// State management for Starting -> InitialSync. This state change occurs every time a node is restarted.
-impl<B: BlockchainBackend> From<Starting<B>> for InitialSync<B> {
-    fn from(old_state: Starting<B>) -> Self {
-        InitialSync { db: old_state.db }
+/// State management for BlockSync -> Listening. This change is part of the typical flow for new nodes joining the
+/// network, or established nodes that have caught up to the chain tip again.
+impl From<BlockSync> for Listening {
+    fn from(_old: BlockSync) -> Self {
+        unimplemented!()
+    }
+}
+
+/// State management for BlockSync -> Listening. This state change happens when a node restarts and still happens to
+/// be in sync with the network.
+impl<B: BlockchainBackend> From<InitialSync<B>> for Listening {
+    fn from(_old: InitialSync<B>) -> Self {
+        unimplemented!()
     }
 }

--- a/base_layer/core/src/base_node/states/mod.rs
+++ b/base_layer/core/src/base_node/states/mod.rs
@@ -114,9 +114,9 @@ pub enum BaseNodeState<B: BlockchainBackend> {
     None,
     Starting(Starting<B>),
     InitialSync(InitialSync<B>),
-    FetchingHorizonState,
-    BlockSync,
-    Listening,
+    FetchingHorizonState(FetchHorizonState),
+    BlockSync(BlockSync),
+    Listening(Listening),
     Shutdown(Shutdown),
 }
 
@@ -146,9 +146,9 @@ impl<B: BlockchainBackend> Display for BaseNodeState<B> {
         let s = match self {
             Self::Starting(_) => "Initializing",
             Self::InitialSync(_) => "Synchronizing blockchain metadata",
-            Self::FetchingHorizonState => "Fetching horizon state",
-            Self::BlockSync => "Synchronizing blocks",
-            Self::Listening => "Listening",
+            Self::FetchingHorizonState(_) => "Fetching horizon state",
+            Self::BlockSync(_) => "Synchronizing blocks",
+            Self::Listening(_) => "Listening",
             Self::Shutdown(_) => "Shutting down",
             Self::None => "None",
         };
@@ -156,10 +156,18 @@ impl<B: BlockchainBackend> Display for BaseNodeState<B> {
     }
 }
 
+mod block_sync;
+mod fetching_horizon_state;
 mod initial_sync;
+mod listening;
 mod shutdown_state;
 mod starting_state;
 
+use crate::base_node::states::{
+    block_sync::BlockSync,
+    fetching_horizon_state::FetchHorizonState,
+    listening::Listening,
+};
 pub use initial_sync::InitialSync;
 pub use shutdown_state::Shutdown;
 pub use starting_state::Starting;


### PR DESCRIPTION
    Adds stubs for the missing state structs in the base node FSM.
    Provide comments for allowed state conversions.
    
    What's quite nice about doing it this way is that the _compiler_ will tell you
    if you try and enact an illegal state change, e.g. from Startup -> Listening;
    becuase the From trait isn't written for that change.
