### PR TITLE
Add CLI and logging init to base node binary

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ members = [
     "infrastructure/storage",
     "infrastructure/test_utils",
     "applications/tari_testnet_miner",
+    "applications/tari_base_node",
     #Needs to be updated to make its calls using an Tokio runtime block_on function.
     #"ffi"
     #The wallet gRPC is based on the old Futures and not part of the Testnet scope

--- a/applications/tari_base_node/Cargo.toml
+++ b/applications/tari_base_node/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "tari_base_node"
+version = "0.0.1"
+authors = ["The Tari Development Community"]
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+log = { version = "0.4.8", features = ["std"] }
+tokio = "=0.2.0-alpha.6"
+futures-preview = { version = "=0.3.0-alpha.19", default-features = false, features = ["alloc"]}
+clap = "2.33.0"
+config = { version = "0.9.3" }
+dirs = "2.0.2"
+log4rs = { version = "0.8.3", features = ["toml_format"] }
+tari_core = {path = "../../base_layer/core", version= "^0.0"}
+tari_common = {path = "../../common", version= "^0.0"}

--- a/applications/tari_base_node/src/cli.rs
+++ b/applications/tari_base_node/src/cli.rs
@@ -1,0 +1,98 @@
+// Copyright 2019. The Tari Project
+//
+// Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+// following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+// disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+// following disclaimer in the documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+// products derived from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+// INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+// WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+// USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+
+use crate::consts;
+use clap::clap_app;
+use dirs;
+use std::path::{Path, PathBuf};
+
+/// A minimal parsed configuration object that's used to bootstrap the main Configuration.
+pub struct ConfigBootstrap {
+    pub config: PathBuf,
+    /// The path to the log configuration file. It is set using the following precedence set:
+    ///   1. from the command-line parameter,
+    ///   2. from the `TARI_LOG_CONFIGURATION` environment variable,
+    ///   3. from a default value, usually `~/.tari/log4rs.yml` (or OS equivalent).
+    pub log_config: PathBuf,
+}
+
+/// Parse the command-line args and populate the minimal bootstrap config object
+pub fn parse_cli_args() -> ConfigBootstrap {
+    let matches = clap_app!(myapp =>
+        (version: consts::VERSION)
+        (author: consts::AUTHOR)
+        (about: "The reference Tari cryptocurrency base node implementation")
+        (@arg config: -c --config +takes_value {exists} "A path to the configuration file to use (tari_conf.toml)")
+        (@arg log_config: -l --log_config +takes_value {exists} "A path to the logfile configuration (log4rs.yml))")
+        (@arg init: --init "Create a default configuration file if it doesn't exist")
+    )
+    .get_matches();
+
+    let config = matches
+        .value_of("config")
+        .map(PathBuf::from)
+        .unwrap_or(default_path(consts::DEFAULT_CONFIG));
+    let log_config = matches.value_of("log_config").map(PathBuf::from);
+    let log_config = tari_common::get_log_configuration_path(log_config);
+
+    if !config.exists() && matches.is_present("init") {
+        println!("Installing new config file at {}", config.to_str().unwrap_or("[??]"));
+        install_configuration(&config, tari_common::install_default_config_file);
+    }
+
+    if !log_config.exists() && matches.is_present("init") {
+        println!(
+            "Installing new logfile configuration at {}",
+            log_config.to_str().unwrap_or("[??]")
+        );
+        install_configuration(&log_config, tari_common::install_default_logfile_config);
+    }
+    ConfigBootstrap { config, log_config }
+}
+
+fn exists(s: String) -> Result<(), String> {
+    let path = Path::new(&s);
+    if path.exists() {
+        Ok(())
+    } else {
+        Err(format!("{} does not exist", s))
+    }
+}
+
+fn default_path(filename: &str) -> PathBuf {
+    let mut home = dirs::home_dir().unwrap_or(PathBuf::from("."));
+    home.push(".tari");
+    home.push(filename);
+    home
+}
+
+fn install_configuration<F>(path: &Path, installer: F)
+where F: Fn(&Path) -> Result<u64, std::io::Error> {
+    if let Err(e) = installer(path) {
+        println!(
+            "We could not install a new configuration file in {}: {}",
+            path.to_str().unwrap_or("?"),
+            e.to_string()
+        )
+    }
+}

--- a/applications/tari_base_node/src/consts.rs
+++ b/applications/tari_base_node/src/consts.rs
@@ -1,0 +1,27 @@
+// Copyright 2019. The Tari Project
+//
+// Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+// following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+// disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+// following disclaimer in the documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+// products derived from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+// INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+// WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+// USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+
+pub const VERSION: &str = "0.0.5";
+pub const AUTHOR: &str = "The Tari Community";
+pub const DEFAULT_CONFIG: &str = "config.toml";
+pub const DEFAULT_LOGCONFIG: &str = "log4rs.yml";

--- a/applications/tari_base_node/src/main.rs
+++ b/applications/tari_base_node/src/main.rs
@@ -1,0 +1,69 @@
+// Copyright 2019. The Tari Project
+//
+// Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+// following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+// disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+// following disclaimer in the documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+// products derived from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+// INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+// WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+// USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+
+mod cli;
+mod consts;
+
+use crate::cli::ConfigBootstrap;
+use log::*;
+
+fn main() {
+    // Create the tari data directory
+    if let Err(e) = tari_common::create_data_directory() {
+        println!(
+            "We couldn't create a default Tari data directory and have to quit now. This makes us sad :(\n {}",
+            e.to_string()
+        );
+        return;
+    }
+
+    // Parse and validate command-line arguments
+    let bootstrap = cli::parse_cli_args();
+
+    // Initialise the logger
+    if !initialize_logging(&bootstrap) {
+        return;
+    }
+
+    // Load and apply configuration file
+    debug!(
+        "Loading configuration file from  {}",
+        bootstrap.config.to_str().unwrap_or("[??]")
+    );
+    // Set up the Tokio runtime
+    // Configure the shutdown daemon to listen for CTRL-C
+    // Build, node, build!
+    // Run, node, run!
+}
+
+fn initialize_logging(bootstrap: &ConfigBootstrap) -> bool {
+    println!(
+        "Initializing logging according to {:?}",
+        bootstrap.log_config.to_str().unwrap_or("[??]")
+    );
+    if let Err(e) = log4rs::init_file(bootstrap.log_config.clone(), Default::default()) {
+        println!("We couldn't load a logging configuration file. {}", e.to_string());
+        return false;
+    }
+    true
+}

--- a/applications/tari_basenode/Cargo.toml
+++ b/applications/tari_basenode/Cargo.toml
@@ -1,5 +1,0 @@
-[package]
-name = "tari_basenode"
-version = "0.0.1"
-
-[dependencies]


### PR DESCRIPTION
The start of the base node executable.

Included:
- Scaffolding
- Configuration file handling
- Log file configuration and handling
