### PR TITLE
Increase join thread timeout for connection manager shutdown

### DIFF
--- a/comms/src/connection_manager/connections.rs
+++ b/comms/src/connection_manager/connections.rs
@@ -42,7 +42,7 @@ use tari_utilities::thread_join::ThreadJoinWithTimeout;
 const LOG_TARGET: &str = "comms::connection_manager::connections";
 
 /// Set the maximum waiting time for LivePeerConnections threads to join
-const THREAD_JOIN_TIMEOUT_IN_MS: Duration = Duration::from_millis(100);
+const THREAD_JOIN_TIMEOUT_IN_MS: Duration = Duration::from_millis(3000);
 
 /// Stores, and establishes the live peer connections
 pub(super) struct LivePeerConnections {
@@ -183,7 +183,7 @@ impl LivePeerConnections {
                     .timeout_join(THREAD_JOIN_TIMEOUT_IN_MS)
                     .map_err(ConnectionError::ThreadJoinError)
                     .or_else(|err| {
-                        error!(target: LOG_TARGET, "Failed to join: {:?}", err);
+                        error!(target: LOG_TARGET, "Failed join on peer connection thread: {:?}", err);
                         Err(err)
                     }),
             );


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
The join timeout for threads was set to 100ms. This could be too short
in circle ci tests when there is high resource contention. Set to 3000ms.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Failing example: https://app.circleci.com/jobs/github/tari-project/tari/6508

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
N/A

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch
* [x] I ran `cargo-fmt --all` before pushing
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
