### PR TITLE
Base node service skeleton

### DIFF
--- a/base_layer/core/Cargo.toml
+++ b/base_layer/core/Cargo.toml
@@ -10,12 +10,18 @@ version = "0.0.5"
 edition = "2018"
 
 [dependencies]
+tari_comms = { version = "^0.0", path = "../../comms"}
 tari_utilities = { path = "../../infrastructure/tari_util", version = "^0.0", features = ["chrono_dt"]}
 tari_infra_derive = { path = "../../infrastructure/derive", version = "^0.0" }
 tari_crypto = { path = "../../infrastructure/crypto", version = "^0.0" }
 tari_storage = { path = "../../infrastructure/storage", version = "^0.0" }
 tari_mmr = { path = "../../base_layer/mmr", version = "^0.0" }
 tari_service_framework = { version = "^0.0", path = "../service_framework"}
+tari_p2p = {path = "../../base_layer/p2p", version = "^0.0"}
+tari_comms_dht = { version = "^0.0", path = "../../comms/dht"}
+tari_broadcast_channel = { version="^0.0",  path = "../../infrastructure/broadcast_channel" }
+tari_pubsub = { version = "^0.0", path = "../../infrastructure/pubsub"}
+tari_shutdown = { path = "../../infrastructure/shutdown", version = "^0.0"}
 bitflags = "1.0.4"
 chrono = { version = "0.4.6", features = ["serde"]}
 digest = "0.8.0"
@@ -39,7 +45,9 @@ tokio-executor = { version ="^0.2.0-alpha.6", features = ["threadpool"] }
 futures-preview = {version = "0.3.0-alpha.19", features = ["async-await"] }
 lmdb-zero = "0.4.4"
 tower-service = { version="0.3.0-alpha.2" }
+crossbeam-channel = "0.3.8"
 
 [dev-dependencies]
 env_logger = "0.7.0"
 tari_test_utils = { path = "../../infrastructure/test_utils", version = "^0.0" }
+tempdir = "0.3.7"

--- a/base_layer/core/src/base_node/comms_interface/comms_request.rs
+++ b/base_layer/core/src/base_node/comms_interface/comms_request.rs
@@ -20,8 +20,10 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+use serde::{Deserialize, Serialize};
+
 /// API Request enum
-#[derive(Debug)]
+#[derive(Debug, Serialize, Deserialize)]
 pub enum NodeCommsRequest {
     GetChainMetadata,
 }

--- a/base_layer/core/src/base_node/comms_interface/error.rs
+++ b/base_layer/core/src/base_node/comms_interface/error.rs
@@ -28,6 +28,7 @@ use tari_service_framework::reply_channel::TransportChannelError;
 pub enum CommsInterfaceError {
     /// Access to the underlying storage mechanism failed
     UnexpectedApiResponse,
+    RequestTimedOut,
     TransportChannelError(TransportChannelError),
     ChainStorageError(ChainStorageError),
 }

--- a/base_layer/core/src/base_node/comms_interface/inbound_interface.rs
+++ b/base_layer/core/src/base_node/comms_interface/inbound_interface.rs
@@ -42,11 +42,11 @@ where T: BlockchainBackend
     }
 
     /// Handle inbound node comms requests from remote nodes.
-    pub async fn handle_request(&self, request: NodeCommsRequest) -> Result<NodeCommsResponse, CommsInterfaceError> {
+    pub async fn handle_request(&self, request: &NodeCommsRequest) -> Result<NodeCommsResponse, CommsInterfaceError> {
         match request {
-            NodeCommsRequest::GetChainMetadata => Ok(NodeCommsResponse::ChainMetadata(vec![self
-                .blockchain_db
-                .get_metadata()?])), // TODO: replace with async call
+            NodeCommsRequest::GetChainMetadata => {
+                Ok(NodeCommsResponse::ChainMetadata(self.blockchain_db.get_metadata()?))
+            }, // TODO: replace with async call
         }
     }
 }

--- a/base_layer/core/src/base_node/mod.rs
+++ b/base_layer/core/src/base_node/mod.rs
@@ -35,6 +35,7 @@
 mod base_node;
 mod comms_interface;
 mod config;
+mod service;
 #[cfg(test)]
 mod test;
 

--- a/base_layer/core/src/base_node/service/error.rs
+++ b/base_layer/core/src/base_node/service/error.rs
@@ -1,4 +1,4 @@
-// Copyright 2019. The Tari Project
+// Copyright 2019 The Tari Project
 //
 // Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
 // following conditions are met:
@@ -20,11 +20,12 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use crate::chain_storage::ChainMetadata;
-use serde::{Deserialize, Serialize};
+use crate::base_node::comms_interface::CommsInterfaceError;
+use derive_error::Error;
+use tari_comms_dht::outbound::DhtOutboundError;
 
-/// API Response enum
-#[derive(Debug, Serialize, Deserialize, Clone)]
-pub enum NodeCommsResponse {
-    ChainMetadata(ChainMetadata),
+#[derive(Debug, Error)]
+pub enum BaseNodeServiceError {
+    CommsInterfaceError(CommsInterfaceError),
+    DhtOutboundError(DhtOutboundError),
 }

--- a/base_layer/core/src/base_node/service/initializer.rs
+++ b/base_layer/core/src/base_node/service/initializer.rs
@@ -1,0 +1,159 @@
+// Copyright 2019. The Tari Project
+//
+// Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+// following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+// disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+// following disclaimer in the documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+// products derived from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+// INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+// WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+// USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+use crate::{
+    base_node::{
+        comms_interface::{InboundNodeCommsInterface, OutboundNodeCommsInterface},
+        service::{
+            service::{BaseNodeService, BaseNodeServiceConfig},
+            service_request::BaseNodeServiceRequest,
+            service_response::BaseNodeServiceResponse,
+        },
+    },
+    chain_storage::{BlockchainBackend, BlockchainDatabase},
+};
+use futures::{future, Future, Stream, StreamExt};
+use log::*;
+use std::sync::Arc;
+use tari_comms::peer_manager::NodeIdentity;
+use tari_comms_dht::outbound::OutboundMessageRequester;
+use tari_p2p::{
+    comms_connector::PeerMessage,
+    domain_message::DomainMessage,
+    services::utils::{map_deserialized, ok_or_skip_result},
+    tari_message::{BlockchainMessage, TariMessageType},
+};
+use tari_pubsub::TopicSubscriptionFactory;
+use tari_service_framework::{
+    handles::ServiceHandlesFuture,
+    reply_channel,
+    ServiceInitializationError,
+    ServiceInitializer,
+};
+use tari_shutdown::ShutdownSignal;
+use tokio::runtime::TaskExecutor;
+
+const LOG_TARGET: &'static str = "tari_core::base_node::base_node_service";
+
+/// Initializer for the Base Node service handle and service future.
+pub struct BaseNodeServiceInitializer<T>
+where T: BlockchainBackend
+{
+    inbound_message_subscription_factory:
+        Arc<TopicSubscriptionFactory<TariMessageType, Arc<PeerMessage<TariMessageType>>>>,
+    node_identity: Arc<NodeIdentity>,
+    blockchain_db: Arc<BlockchainDatabase<T>>,
+    config: BaseNodeServiceConfig,
+}
+
+impl<T> BaseNodeServiceInitializer<T>
+where T: BlockchainBackend
+{
+    /// Create a new BaseNodeServiceInitializer from the inbound message subscriber.
+    pub fn new(
+        inbound_message_subscription_factory: Arc<
+            TopicSubscriptionFactory<TariMessageType, Arc<PeerMessage<TariMessageType>>>,
+        >,
+        node_identity: Arc<NodeIdentity>,
+        blockchain_db: Arc<BlockchainDatabase<T>>,
+        config: BaseNodeServiceConfig,
+    ) -> Self
+    {
+        Self {
+            inbound_message_subscription_factory,
+            node_identity,
+            blockchain_db,
+            config,
+        }
+    }
+
+    /// Get a stream for inbound Base Node request messages
+    fn inbound_request_stream(&self) -> impl Stream<Item = DomainMessage<BaseNodeServiceRequest>> {
+        self.inbound_message_subscription_factory
+            .get_subscription(TariMessageType::new(BlockchainMessage::BaseNodeRequest))
+            .map(map_deserialized::<BaseNodeServiceRequest>)
+            .filter_map(ok_or_skip_result)
+    }
+
+    /// Get a stream for inbound Base Node response messages
+    fn inbound_response_stream(&self) -> impl Stream<Item = DomainMessage<BaseNodeServiceResponse>> {
+        self.inbound_message_subscription_factory
+            .get_subscription(TariMessageType::new(BlockchainMessage::BaseNodeResponse))
+            .map(map_deserialized::<BaseNodeServiceResponse>)
+            .filter_map(ok_or_skip_result)
+    }
+
+    // TODO: add streams for broadcasted blocks and transactions
+}
+
+impl<T> ServiceInitializer for BaseNodeServiceInitializer<T>
+where T: BlockchainBackend + 'static
+{
+    type Future = impl Future<Output = Result<(), ServiceInitializationError>>;
+
+    fn initialize(
+        &mut self,
+        executor: TaskExecutor,
+        handles_fut: ServiceHandlesFuture,
+        shutdown: ShutdownSignal,
+    ) -> Self::Future
+    {
+        // Create streams for receiving Base Node requests and response messages from comms
+        let inbound_request_stream = self.inbound_request_stream();
+        let inbound_response_stream = self.inbound_response_stream();
+        let node_identity = self.node_identity.clone();
+        // Connect InboundNodeCommsInterface and OutboundNodeCommsInterface to BaseNodeService
+        let (outbound_request_sender_service, outbound_request_stream) = reply_channel::unbounded();
+        let outbound_nci = OutboundNodeCommsInterface::new(outbound_request_sender_service);
+        let inbound_nci = Arc::new(InboundNodeCommsInterface::new(self.blockchain_db.clone()));
+        let executer_clone = executor.clone(); // Give BaseNodeService access to the executor
+        let config = self.config.clone();
+
+        // Register handle to OutboundNodeCommsInterface before waiting for handles to be ready
+        handles_fut.register(outbound_nci);
+
+        executor.spawn(async move {
+            let handles = handles_fut.await;
+
+            let outbound_message_service = handles
+                .get_handle::<OutboundMessageRequester>()
+                .expect("OutboundMessageRequester handle required for BaseNodeService");
+
+            let service = BaseNodeService::new(
+                executer_clone,
+                outbound_request_stream,
+                inbound_request_stream,
+                inbound_response_stream,
+                outbound_message_service,
+                node_identity,
+                inbound_nci,
+                config,
+            )
+            .start();
+            futures::pin_mut!(service);
+            future::select(service, shutdown).await;
+            info!(target: LOG_TARGET, "Base Node Service shutdown");
+        });
+
+        future::ready(Ok(()))
+    }
+}

--- a/base_layer/core/src/base_node/service/mod.rs
+++ b/base_layer/core/src/base_node/service/mod.rs
@@ -20,11 +20,14 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use crate::chain_storage::ChainMetadata;
-use serde::{Deserialize, Serialize};
+mod error;
+mod initializer;
+mod service;
+mod service_request;
+mod service_response;
 
-/// API Response enum
-#[derive(Debug, Serialize, Deserialize, Clone)]
-pub enum NodeCommsResponse {
-    ChainMetadata(ChainMetadata),
-}
+// Public re-exports
+pub use initializer::BaseNodeServiceInitializer;
+pub use service::{BaseNodeService, BaseNodeServiceConfig};
+pub use service_request::{BaseNodeServiceRequest, RequestKey};
+pub use service_response::BaseNodeServiceResponse;

--- a/base_layer/core/src/base_node/service/service.rs
+++ b/base_layer/core/src/base_node/service/service.rs
@@ -1,0 +1,339 @@
+// Copyright 2019 The Tari Project
+//
+// Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+// following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+// disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+// following disclaimer in the documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+// products derived from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+// INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+// WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+// USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+use crate::{
+    base_node::{
+        comms_interface::{CommsInterfaceError, InboundNodeCommsInterface, NodeCommsRequest, NodeCommsResponse},
+        service::{
+            error::BaseNodeServiceError,
+            service_request::{generate_request_key, BaseNodeServiceRequest, RequestKey, WaitingRequest},
+            service_response::BaseNodeServiceResponse,
+        },
+    },
+    chain_storage::BlockchainBackend,
+    consts::{
+        BASE_NODE_RNG,
+        BASE_NODE_SERVICE_BROADCAST_PEER_COUNT,
+        BASE_NODE_SERVICE_DESIRED_RESPONSE_COUNT,
+        BASE_NODE_SERVICE_REQUEST_TIMEOUT,
+    },
+};
+use futures::{
+    channel::{
+        mpsc::{channel, Receiver, Sender},
+        oneshot::Sender as OneshotSender,
+    },
+    pin_mut,
+    stream::StreamExt,
+    SinkExt,
+    Stream,
+};
+use log::*;
+use std::{
+    collections::HashMap,
+    sync::Arc,
+    time::{Duration, Instant},
+};
+use tari_comms::peer_manager::NodeIdentity;
+use tari_comms_dht::{
+    envelope::NodeDestination,
+    outbound::{BroadcastClosestRequest, BroadcastStrategy, OutboundEncryption, OutboundMessageRequester},
+};
+use tari_p2p::{
+    domain_message::DomainMessage,
+    tari_message::{BlockchainMessage, TariMessageType},
+};
+use tari_service_framework::RequestContext;
+use tokio::runtime::TaskExecutor;
+
+const LOG_TARGET: &'static str = "tari_core::base_node::base_node_service::service";
+
+// TODO: Add streams for BlockchainMessage::NewBlock and BlockchainMessage::Transaction
+
+/// Configuration for the BaseNodeService.
+#[derive(Clone, Copy)]
+pub struct BaseNodeServiceConfig {
+    /// The allocated waiting time for a request waiting for service responses from remote base nodes.
+    pub request_timeout: Duration,
+    /// The number of remote peers that Base Node Service requests are sent to.
+    pub broadcast_peer_count: usize,
+    /// The number of responses that need to be received for a corresponding service request to be finalize.
+    pub desired_response_count: usize,
+}
+
+impl Default for BaseNodeServiceConfig {
+    fn default() -> Self {
+        Self {
+            request_timeout: BASE_NODE_SERVICE_REQUEST_TIMEOUT,
+            broadcast_peer_count: BASE_NODE_SERVICE_BROADCAST_PEER_COUNT,
+            desired_response_count: BASE_NODE_SERVICE_DESIRED_RESPONSE_COUNT,
+        }
+    }
+}
+
+/// The Base Node Service is responsible for handling inbound requests and responses and for sending new requests to
+/// remote Base Node Services.
+pub struct BaseNodeService<TOutbReqStream, TInbReqStream, TInbRespStream, TChainBackend>
+where TChainBackend: BlockchainBackend
+{
+    executor: TaskExecutor,
+    outbound_request_stream: Option<TOutbReqStream>,
+    inbound_request_stream: Option<TInbReqStream>,
+    inbound_response_stream: Option<TInbRespStream>,
+    outbound_message_service: OutboundMessageRequester,
+    node_identity: Arc<NodeIdentity>,
+    inbound_nci: Arc<InboundNodeCommsInterface<TChainBackend>>,
+    waiting_requests: HashMap<RequestKey, WaitingRequest>,
+    timeout_sender: Sender<RequestKey>,
+    timeout_receiver_stream: Option<Receiver<RequestKey>>,
+    config: BaseNodeServiceConfig,
+}
+
+impl<TOutbReqStream, TInbReqStream, TInbRespStream, TChainBackend>
+    BaseNodeService<TOutbReqStream, TInbReqStream, TInbRespStream, TChainBackend>
+where
+    TOutbReqStream:
+        Stream<Item = RequestContext<NodeCommsRequest, Result<Vec<NodeCommsResponse>, CommsInterfaceError>>>,
+    TInbReqStream: Stream<Item = DomainMessage<BaseNodeServiceRequest>>,
+    TInbRespStream: Stream<Item = DomainMessage<BaseNodeServiceResponse>>,
+    TChainBackend: BlockchainBackend,
+{
+    pub fn new(
+        executor: TaskExecutor,
+        outbound_request_stream: TOutbReqStream,
+        inbound_request_stream: TInbReqStream,
+        inbound_response_stream: TInbRespStream,
+        outbound_message_service: OutboundMessageRequester,
+        node_identity: Arc<NodeIdentity>,
+        inbound_nci: Arc<InboundNodeCommsInterface<TChainBackend>>,
+        config: BaseNodeServiceConfig,
+    ) -> Self
+    {
+        let (timeout_sender, timeout_receiver) = channel(100);
+        Self {
+            executor,
+            outbound_request_stream: Some(outbound_request_stream),
+            inbound_request_stream: Some(inbound_request_stream),
+            inbound_response_stream: Some(inbound_response_stream),
+            outbound_message_service,
+            node_identity,
+            inbound_nci,
+            waiting_requests: HashMap::new(),
+            timeout_sender,
+            timeout_receiver_stream: Some(timeout_receiver),
+            config,
+        }
+    }
+
+    pub async fn start(mut self) -> Result<(), BaseNodeServiceError> {
+        let outbound_request_stream = self
+            .outbound_request_stream
+            .take()
+            .expect("Base Node Service initialized without outbound_request_stream")
+            .fuse();
+        pin_mut!(outbound_request_stream);
+        let inbound_request_stream = self
+            .inbound_request_stream
+            .take()
+            .expect("Base Node Service initialized without inbound_request_stream")
+            .fuse();
+        pin_mut!(inbound_request_stream);
+        let inbound_response_stream = self
+            .inbound_response_stream
+            .take()
+            .expect("Base Node Service initialized without inbound_response_stream")
+            .fuse();
+        pin_mut!(inbound_response_stream);
+        let timeout_receiver_stream = self
+            .timeout_receiver_stream
+            .take()
+            .expect("Base Node Service initialized without timeout_receiver_stream")
+            .fuse();
+        pin_mut!(timeout_receiver_stream);
+
+        loop {
+            futures::select! {
+                // Outbound request messages from the OutboundNodeCommsInterface
+                outbound_request_context = outbound_request_stream.select_next_some() => {
+                    let (request, reply_tx) = outbound_request_context.split();
+                    let _ = self.handle_outbound_request(reply_tx,request).await.or_else(|err| {
+                        error!(target: LOG_TARGET, "Failed to handle outbound request message: {:?}", err);
+                        Err(err)
+                    });
+                },
+
+                // Incoming request messages from the Comms layer
+                domain_msg = inbound_request_stream.select_next_some() => {
+                    let _ = self.handle_incoming_request(domain_msg).await.or_else(|err| {
+                        error!(target: LOG_TARGET, "Failed to handle incoming request message: {:?}", err);
+                        Err(err)
+                    });
+                },
+
+                // Incoming response messages from the Comms layer
+                domain_msg = inbound_response_stream.select_next_some() => {
+                    let _ = self.handle_incoming_response(&domain_msg.inner()).await.or_else(|err| {
+                        error!(target: LOG_TARGET, "Failed to handle incoming response message: {:?}", err);
+                        Err(err)
+                    });
+                },
+
+                // Timeout events for waiting requests
+                timeout_request_key = timeout_receiver_stream.select_next_some() => {
+                    let _ =self.handle_request_timeout(timeout_request_key).await.or_else(|err| {
+                        error!(target: LOG_TARGET, "Failed to handle request timeout event: {:?}", err);
+                        Err(err)
+                    });
+                },
+
+                complete => {
+                    info!(target: LOG_TARGET, "Base Node service shutting down");
+                    break;
+                }
+            }
+        }
+        Ok(())
+    }
+
+    async fn handle_incoming_request(
+        &mut self,
+        domain_request_msg: DomainMessage<BaseNodeServiceRequest>,
+    ) -> Result<(), BaseNodeServiceError>
+    {
+        self.outbound_message_service
+            .send_message(
+                BroadcastStrategy::DirectPublicKey(domain_request_msg.origin_pubkey.clone()),
+                NodeDestination::PublicKey(domain_request_msg.origin_pubkey.clone()),
+                OutboundEncryption::EncryptForDestination,
+                TariMessageType::new(BlockchainMessage::BaseNodeResponse),
+                BaseNodeServiceResponse {
+                    request_key: domain_request_msg.inner().request_key,
+                    response: self
+                        .inbound_nci
+                        .handle_request(&domain_request_msg.inner().request)
+                        .await?,
+                },
+            )
+            .await?;
+        Ok(())
+    }
+
+    async fn handle_incoming_response(
+        &mut self,
+        incoming_response: &BaseNodeServiceResponse,
+    ) -> Result<(), BaseNodeServiceError>
+    {
+        let mut finalize_request = false;
+        match self.waiting_requests.get_mut(&incoming_response.request_key) {
+            Some(waiting_request) => {
+                waiting_request
+                    .received_responses
+                    .push(incoming_response.response.clone());
+                finalize_request = waiting_request.received_responses.len() >= waiting_request.desired_resp_count;
+            },
+            None => {
+                info!(target: LOG_TARGET, "Discard incoming unmatched response");
+            },
+        }
+
+        if finalize_request {
+            if let Some(waiting_request) = self.waiting_requests.remove(&incoming_response.request_key) {
+                let WaitingRequest {
+                    mut reply_tx,
+                    received_responses,
+                    ..
+                } = waiting_request;
+                if let Some(reply_tx) = reply_tx.take() {
+                    let _ = reply_tx.send(Ok(received_responses).or_else(|resp| {
+                        error!(target: LOG_TARGET, "Failed to send outbound request from Base Node");
+                        Err(resp)
+                    }));
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    async fn handle_outbound_request(
+        &mut self,
+        reply_tx: OneshotSender<Result<Vec<NodeCommsResponse>, CommsInterfaceError>>,
+        request: NodeCommsRequest,
+    ) -> Result<(), CommsInterfaceError>
+    {
+        let request_key = BASE_NODE_RNG.with(|rng| generate_request_key(&mut *rng.borrow_mut()));
+        let service_request = BaseNodeServiceRequest {
+            request_key: request_key.clone(),
+            request,
+        };
+        self.outbound_message_service
+            .send_message(
+                BroadcastStrategy::Closest(BroadcastClosestRequest {
+                    n: self.config.broadcast_peer_count,
+                    node_id: self.node_identity.identity.node_id.clone(),
+                    excluded_peers: Vec::new(),
+                }),
+                NodeDestination::NodeId(self.node_identity.identity.node_id.clone()),
+                OutboundEncryption::None,
+                TariMessageType::new(BlockchainMessage::BaseNodeRequest),
+                service_request,
+            )
+            .await
+            .map_err(|_| CommsInterfaceError::UnexpectedApiResponse)?;
+
+        // Wait for matching responses to arrive
+        self.waiting_requests.insert(request_key, WaitingRequest {
+            reply_tx: Some(reply_tx),
+            received_responses: Vec::new(),
+            desired_resp_count: self.config.desired_response_count.clone(),
+        });
+        // Spawn timeout for waiting_request
+        self.spawn_request_timeout(request_key, self.config.request_timeout)
+            .await;
+        Ok(())
+    }
+
+    async fn handle_request_timeout(&mut self, request_key: RequestKey) -> Result<(), CommsInterfaceError> {
+        if let Some(mut waiting_request) = self.waiting_requests.remove(&request_key) {
+            if let Some(reply_tx) = waiting_request.reply_tx.take() {
+                let reply_msg = if waiting_request.received_responses.len() >= 1 {
+                    Ok(waiting_request.received_responses.clone())
+                } else {
+                    Err(CommsInterfaceError::RequestTimedOut)
+                };
+                let _ = reply_tx.send(reply_msg.or_else(|resp| {
+                    error!(target: LOG_TARGET, "Failed to send outbound request from Base Node");
+                    Err(resp)
+                }));
+            }
+        }
+        Ok(())
+    }
+
+    async fn spawn_request_timeout(&self, request_key: RequestKey, timeout: Duration) {
+        let mut timeout_sender = self.timeout_sender.clone();
+        self.executor.spawn(async move {
+            tokio::timer::delay(Instant::now() + timeout).await;
+            let _ = timeout_sender.send(request_key).await;
+        });
+    }
+}

--- a/base_layer/core/src/base_node/service/service_request.rs
+++ b/base_layer/core/src/base_node/service/service_request.rs
@@ -1,0 +1,50 @@
+//  Copyright 2019 The Tari Project
+//
+//  Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+//  following conditions are met:
+//
+//  1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+//  disclaimer.
+//
+//  2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+//  following disclaimer in the documentation and/or other materials provided with the distribution.
+//
+//  3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+//  products derived from this software without specific prior written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+//  INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+//  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+//  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+//  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+//  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+//  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+use crate::base_node::comms_interface::{CommsInterfaceError, NodeCommsRequest, NodeCommsResponse};
+use futures::channel::oneshot::Sender as OneshotSender;
+use rand::RngCore;
+use serde::{Deserialize, Serialize};
+
+pub type RequestKey = u64;
+
+/// Generate a new random request key to uniquely identify a request and its corresponding responses.
+pub fn generate_request_key<R>(rng: &mut R) -> RequestKey
+where R: RngCore {
+    rng.next_u64()
+}
+
+/// The WaitingRequest is used to link incoming responses to the original sent request. When enough responses have been
+/// received or the request timeout has been received then the received responses are returned on the reply_tx.
+#[derive(Debug)]
+pub struct WaitingRequest {
+    pub(crate) reply_tx: Option<OneshotSender<Result<Vec<NodeCommsResponse>, CommsInterfaceError>>>,
+    pub(crate) received_responses: Vec<NodeCommsResponse>,
+    pub(crate) desired_resp_count: usize,
+}
+
+/// Request type for a received BaseNodeService request.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct BaseNodeServiceRequest {
+    pub request_key: RequestKey,
+    pub request: NodeCommsRequest,
+}

--- a/base_layer/core/src/base_node/service/service_response.rs
+++ b/base_layer/core/src/base_node/service/service_response.rs
@@ -1,4 +1,4 @@
-// Copyright 2019. The Tari Project
+// Copyright 2019 The Tari Project
 //
 // Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
 // following conditions are met:
@@ -20,11 +20,12 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use crate::chain_storage::ChainMetadata;
+use crate::base_node::{comms_interface::NodeCommsResponse, service::service_request::RequestKey};
 use serde::{Deserialize, Serialize};
 
-/// API Response enum
-#[derive(Debug, Serialize, Deserialize, Clone)]
-pub enum NodeCommsResponse {
-    ChainMetadata(ChainMetadata),
+/// Response type for a received BaseNodeService requests
+#[derive(Debug, Serialize, Deserialize)]
+pub struct BaseNodeServiceResponse {
+    pub request_key: RequestKey,
+    pub response: NodeCommsResponse,
 }

--- a/base_layer/core/src/base_node/test/mod.rs
+++ b/base_layer/core/src/base_node/test/mod.rs
@@ -21,3 +21,4 @@
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 mod comms_interface;
+mod service;

--- a/base_layer/core/src/base_node/test/service.rs
+++ b/base_layer/core/src/base_node/test/service.rs
@@ -1,0 +1,264 @@
+// Copyright 2019. The Tari Project
+//
+// Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+// following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+// disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+// following disclaimer in the documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+// products derived from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+// INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+// WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+// USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+use crate::{
+    base_node::{
+        comms_interface::{CommsInterfaceError, OutboundNodeCommsInterface},
+        service::{BaseNodeServiceConfig, BaseNodeServiceInitializer},
+    },
+    chain_storage::{BlockchainDatabase, MemoryDatabase},
+    consts::BASE_NODE_SERVICE_REQUEST_TIMEOUT,
+    test_utils::builders::{add_block_and_update_header, create_genesis_block},
+    types::HashDigest,
+};
+use futures::Sink;
+use rand::{distributions::Alphanumeric, rngs::OsRng, Rng};
+use std::{error::Error, iter, sync::Arc, time::Duration};
+use tari_comms::{
+    builder::CommsNode,
+    control_service::ControlServiceConfig,
+    peer_manager::{NodeIdentity, Peer, PeerFeatures, PeerFlags},
+};
+use tari_comms_dht::Dht;
+use tari_p2p::{
+    comms_connector::{pubsub_connector, InboundDomainConnector, PeerMessage},
+    initialization::{initialize_comms, CommsConfig},
+    services::comms_outbound::CommsOutboundServiceInitializer,
+    tari_message::TariMessageType,
+};
+use tari_service_framework::StackBuilder;
+use tempdir::TempDir;
+use tokio::runtime::{Runtime, TaskExecutor};
+
+fn random_string(len: usize) -> String {
+    let mut rng = OsRng::new().unwrap();
+    iter::repeat(()).map(|_| rng.sample(Alphanumeric)).take(len).collect()
+}
+
+fn setup_comms_services<TSink>(
+    executor: TaskExecutor,
+    node_identity: Arc<NodeIdentity>,
+    peers: Vec<NodeIdentity>,
+    publisher: InboundDomainConnector<TariMessageType, TSink>,
+) -> (CommsNode, Dht)
+where
+    TSink: Sink<Arc<PeerMessage<TariMessageType>>> + Clone + Unpin + Send + Sync + 'static,
+    TSink::Error: Error + Send + Sync,
+{
+    let comms_config = CommsConfig {
+        node_identity: Arc::clone(&node_identity),
+        host: "127.0.0.1".parse().unwrap(),
+        socks_proxy_address: None,
+        control_service: ControlServiceConfig {
+            listener_address: node_identity.control_service_address(),
+            socks_proxy_address: None,
+            requested_connection_timeout: Duration::from_millis(2000),
+        },
+        datastore_path: TempDir::new(random_string(8).as_str())
+            .unwrap()
+            .path()
+            .to_str()
+            .unwrap()
+            .to_string(),
+        peer_database_name: random_string(8),
+        inbound_buffer_size: 100,
+        outbound_buffer_size: 100,
+        dht: Default::default(),
+    };
+
+    let (comms, dht) = initialize_comms(executor, comms_config, publisher).unwrap();
+
+    for p in peers {
+        let addr = p.control_service_address();
+        let NodeIdentity { identity, .. } = p;
+        comms
+            .peer_manager()
+            .add_peer(Peer::new(
+                identity.public_key,
+                identity.node_id,
+                addr.into(),
+                PeerFlags::empty(),
+                PeerFeatures::empty(),
+            ))
+            .unwrap();
+    }
+
+    (comms, dht)
+}
+
+pub fn setup_base_node_service(
+    runtime: &Runtime,
+    node_identity: NodeIdentity,
+    peers: Vec<NodeIdentity>,
+    blockchain_db: Arc<BlockchainDatabase<MemoryDatabase<HashDigest>>>,
+    config: BaseNodeServiceConfig,
+) -> (OutboundNodeCommsInterface, CommsNode)
+{
+    let node_identity = Arc::new(node_identity.clone());
+    let (publisher, subscription_factory) = pubsub_connector(runtime.executor(), 100);
+    let subscription_factory = Arc::new(subscription_factory);
+    let (comms, dht) = setup_comms_services(runtime.executor(), node_identity.clone(), peers, publisher);
+
+    let fut = StackBuilder::new(runtime.executor(), comms.shutdown_signal())
+        .add_initializer(CommsOutboundServiceInitializer::new(dht.outbound_requester()))
+        .add_initializer(BaseNodeServiceInitializer::new(
+            subscription_factory,
+            node_identity,
+            blockchain_db,
+            config,
+        ))
+        .finish();
+
+    let handles = runtime.block_on(fut).expect("Service initialization failed");
+
+    let outbound_nci = handles.get_handle::<OutboundNodeCommsInterface>().unwrap();
+
+    (outbound_nci, comms)
+}
+
+#[test]
+fn service_request_response_get_metadata() {
+    let runtime = Runtime::new().unwrap();
+    let mut rng = OsRng::new().unwrap();
+    let base_node_service_config = BaseNodeServiceConfig {
+        request_timeout: BASE_NODE_SERVICE_REQUEST_TIMEOUT,
+        broadcast_peer_count: 2,
+        desired_response_count: 2,
+    };
+
+    let alice_node_identity = NodeIdentity::random(
+        &mut rng,
+        "127.0.0.1:30500".parse().unwrap(),
+        PeerFeatures::communication_node_default(),
+    )
+    .unwrap();
+    let alice_blockchain_db = Arc::new(BlockchainDatabase::new(MemoryDatabase::<HashDigest>::default()).unwrap());
+
+    let bob_node_identity = NodeIdentity::random(
+        &mut rng,
+        "127.0.0.1:30501".parse().unwrap(),
+        PeerFeatures::communication_node_default(),
+    )
+    .unwrap();
+    let bob_blockchain_db = Arc::new(BlockchainDatabase::new(MemoryDatabase::<HashDigest>::default()).unwrap());
+
+    let carol_node_identity = NodeIdentity::random(
+        &mut rng,
+        "127.0.0.1:30502".parse().unwrap(),
+        PeerFeatures::communication_node_default(),
+    )
+    .unwrap();
+    let carol_blockchain_db = Arc::new(BlockchainDatabase::new(MemoryDatabase::<HashDigest>::default()).unwrap());
+
+    let (mut alice_outbound_nci, alice_comms) = setup_base_node_service(
+        &runtime,
+        alice_node_identity.clone(),
+        vec![bob_node_identity.clone(), carol_node_identity.clone()],
+        alice_blockchain_db,
+        base_node_service_config.clone(),
+    );
+    let (_bob_outbound_nci, bob_comms) = setup_base_node_service(
+        &runtime,
+        bob_node_identity.clone(),
+        vec![alice_node_identity.clone(), carol_node_identity.clone()],
+        bob_blockchain_db.clone(),
+        base_node_service_config.clone(),
+    );
+    let (_carol_outbound_nci, carol_comms) = setup_base_node_service(
+        &runtime,
+        carol_node_identity.clone(),
+        vec![alice_node_identity.clone(), bob_node_identity.clone()],
+        carol_blockchain_db,
+        base_node_service_config.clone(),
+    );
+
+    add_block_and_update_header(&bob_blockchain_db, create_genesis_block().0);
+
+    runtime.block_on(async {
+        let received_metadata = alice_outbound_nci.get_metadata().await.unwrap();
+        assert_eq!(received_metadata.len(), 2);
+        assert!(
+            (received_metadata[0].height_of_longest_chain == None) ||
+                (received_metadata[1].height_of_longest_chain == None)
+        );
+        assert!(
+            (received_metadata[0].height_of_longest_chain == Some(0)) ||
+                (received_metadata[1].height_of_longest_chain == Some(0))
+        );
+    });
+
+    alice_comms.shutdown().unwrap();
+    bob_comms.shutdown().unwrap();
+    carol_comms.shutdown().unwrap();
+}
+
+#[test]
+fn service_request_timeout() {
+    let runtime = Runtime::new().unwrap();
+    let mut rng = OsRng::new().unwrap();
+    let base_node_service_config = BaseNodeServiceConfig {
+        request_timeout: Duration::from_millis(10),
+        broadcast_peer_count: 2,
+        desired_response_count: 2,
+    };
+
+    let alice_node_identity = NodeIdentity::random(
+        &mut rng,
+        "127.0.0.1:30503".parse().unwrap(),
+        PeerFeatures::communication_node_default(),
+    )
+    .unwrap();
+    let alice_blockchain_db = Arc::new(BlockchainDatabase::new(MemoryDatabase::<HashDigest>::default()).unwrap());
+
+    let bob_node_identity = NodeIdentity::random(
+        &mut rng,
+        "127.0.0.1:30504".parse().unwrap(),
+        PeerFeatures::communication_node_default(),
+    )
+    .unwrap();
+    let bob_blockchain_db = Arc::new(BlockchainDatabase::new(MemoryDatabase::<HashDigest>::default()).unwrap());
+
+    let (mut alice_outbound_nci, alice_comms) = setup_base_node_service(
+        &runtime,
+        alice_node_identity.clone(),
+        vec![bob_node_identity.clone()],
+        alice_blockchain_db,
+        base_node_service_config.clone(),
+    );
+    let (_bob_outbound_nci, bob_comms) = setup_base_node_service(
+        &runtime,
+        bob_node_identity.clone(),
+        vec![alice_node_identity.clone()],
+        bob_blockchain_db.clone(),
+        base_node_service_config,
+    );
+
+    runtime.block_on(async {
+        assert_eq!(
+            alice_outbound_nci.get_metadata().await,
+            Err(CommsInterfaceError::RequestTimedOut)
+        );
+    });
+
+    alice_comms.shutdown().unwrap();
+    bob_comms.shutdown().unwrap();
+}

--- a/base_layer/core/src/chain_storage/metadata.rs
+++ b/base_layer/core/src/chain_storage/metadata.rs
@@ -21,10 +21,11 @@
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 use crate::{blocks::blockheader::BlockHash, proof_of_work::Difficulty};
+use serde::{Deserialize, Serialize};
 use std::fmt::{Display, Error, Formatter};
 use tari_utilities::hex::Hex;
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct ChainMetadata {
     /// The current chain height, or the block number of the longest valid chain, or `None` if there is no chain
     pub height_of_longest_chain: Option<u64>,

--- a/base_layer/core/src/consts.rs
+++ b/base_layer/core/src/consts.rs
@@ -20,7 +20,8 @@
 //  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 //  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use std::time::Duration;
+use crate::types::BaseNodeRng;
+use std::{cell::RefCell, time::Duration};
 
 /// The maximum number of transactions that can be stored in the Unconfirmed Transaction pool
 pub const MEMPOOL_UNCONFIRMED_POOL_STORAGE_CAPACITY: usize = 1000;
@@ -40,3 +41,14 @@ pub const MEMPOOL_PENDING_POOL_STORAGE_CAPACITY: usize = 1000;
 pub const MEMPOOL_REORG_POOL_STORAGE_CAPACITY: usize = 1000;
 /// The time-to-live duration used for transactions stored in the ReorgPool
 pub const MEMPOOL_REORG_POOL_CACHE_TTL: Duration = Duration::from_secs(300);
+
+thread_local! {
+    /// Thread local RNG for the Base Node
+    pub(crate) static BASE_NODE_RNG: RefCell<BaseNodeRng> = RefCell::new(BaseNodeRng::new().expect("Failed to initialize BaseNodeRng"));
+}
+/// The allocated waiting time for a request waiting for service responses from remote base nodes.
+pub const BASE_NODE_SERVICE_REQUEST_TIMEOUT: Duration = Duration::from_secs(5);
+/// The number of remote peers that Base Node Service requests are sent to.
+pub const BASE_NODE_SERVICE_BROADCAST_PEER_COUNT: usize = 8;
+/// The number of responses that need to be received for a corresponding service request to be finalize.
+pub const BASE_NODE_SERVICE_DESIRED_RESPONSE_COUNT: usize = 5;

--- a/base_layer/core/src/lib.rs
+++ b/base_layer/core/src/lib.rs
@@ -20,6 +20,12 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+// Needed to make futures::select! work
+#![recursion_limit = "512"]
+// Used to eliminate the need for boxing futures in many cases.
+// Tracking issue: https://github.com/rust-lang/rust/issues/63063
+#![feature(type_alias_impl_trait)]
+
 #[macro_use]
 extern crate bitflags;
 #[macro_use]

--- a/base_layer/core/src/types.rs
+++ b/base_layer/core/src/types.rs
@@ -84,3 +84,6 @@ lazy_static! {
     pub static ref PROVER: RangeProofService =
         RangeProofService::new(MAX_RANGE_PROOF_RANGE, &COMMITMENT_FACTORY).unwrap();
 }
+
+/// Specify the RNG that should be used for random selection
+pub type BaseNodeRng = rand::OsRng;

--- a/base_layer/p2p/src/tari_message.rs
+++ b/base_layer/p2p/src/tari_message.rs
@@ -65,6 +65,8 @@ pub mod BlockchainMessage {
     pub const NewBlock: u8 = 65;
     pub const Transaction: u8 = 66;
     pub const TransactionReply: u8 = 67;
+    pub const BaseNodeRequest: u8 = 68;
+    pub const BaseNodeResponse: u8 = 69;
 }
 
 #[allow(non_snake_case, non_upper_case_globals)]


### PR DESCRIPTION
## Description
- Added the skeleton of the BaseNodeService, the service connects the InboundNodeCommsInterface and OutboundNodeCommsInterface to the comms layer.
- The ability to manage the linking between sent requests and received responses and request timeouts were also added. The RequestKey field in the BaseNodeServiceRequest and BaseNodeServiceResponse is used to match the original request to the received responses.
- The comm_interface tests were modified to accommodate the change to NodeCommsResponse. Originally a vector was returned in the enum, this was changed to rather return a vector of responses. This simplified the service implementation as it is difficult to append to a vector in an enum.

## Motivation and Context
This PR allows Base node service requests to be sent to other connected Base Nodes and to respond to Base node service requests from other Base Nodes.

## How Has This Been Tested?
Tests were added for testing the get_metadata request and response system and for testing request timeouts.


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [x] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch
* [x] I ran `cargo-fmt --all` before pushing
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
