### PR TITLE
Simplified the outbound message requester

### DIFF
--- a/base_layer/core/src/base_node/service/service.rs
+++ b/base_layer/core/src/base_node/service/service.rs
@@ -287,11 +287,11 @@ where
         };
         self.outbound_message_service
             .send_message(
-                BroadcastStrategy::Closest(BroadcastClosestRequest {
+                BroadcastStrategy::Closest(Box::new(BroadcastClosestRequest {
                     n: self.config.broadcast_peer_count,
                     node_id: self.node_identity.identity.node_id.clone(),
                     excluded_peers: Vec::new(),
-                }),
+                })),
                 NodeDestination::NodeId(self.node_identity.identity.node_id.clone()),
                 OutboundEncryption::None,
                 TariMessageType::new(BlockchainMessage::BaseNodeRequest),

--- a/base_layer/p2p/src/lib.rs
+++ b/base_layer/p2p/src/lib.rs
@@ -26,12 +26,13 @@
 // Tracking issue: https://github.com/rust-lang/rust/issues/63063
 #![feature(type_alias_impl_trait)]
 
+#[cfg(test)]
+#[macro_use]
+mod test_utils;
+
 pub mod comms_connector;
 pub mod domain_message;
 pub mod initialization;
 pub mod peer;
 pub mod services;
 pub mod tari_message;
-
-#[cfg(test)]
-pub mod test_utils;

--- a/base_layer/p2p/src/test_utils.rs
+++ b/base_layer/p2p/src/test_utils.rs
@@ -20,28 +20,34 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use futures::{future, task::Context, Future, Poll};
 use rand::rngs::OsRng;
-use std::sync::{
-    atomic::{AtomicUsize, Ordering},
-    Arc,
-    Mutex,
-};
+use std::sync::Arc;
 use tari_comms::{
     connection::NetAddress,
-    message::{InboundMessage, MessageEnvelopeHeader, MessageFlags},
-    peer_manager::{NodeIdentity, Peer, PeerFeatures, PeerFlags, PeerManager},
-    types::CommsDatabase,
+    message::{MessageEnvelopeHeader, MessageFlags},
+    peer_manager::{NodeIdentity, Peer, PeerFeatures, PeerFlags},
     utils::signature,
 };
 use tari_comms_dht::{
-    envelope::{DhtEnvelope, DhtHeader, DhtMessageFlags, DhtMessageType, NodeDestination},
+    envelope::{DhtHeader, DhtMessageFlags, DhtMessageType, NodeDestination},
     inbound::DhtInboundMessage,
 };
-use tari_storage::lmdb_store::LMDBBuilder;
-use tari_test_utils::{paths::create_random_database_path, random};
 use tari_utilities::message_format::MessageFormat;
-use tower::Service;
+
+macro_rules! unwrap_oms_send_msg {
+    ($var:expr, reply_value=$reply_value:expr) => {
+        match $var {
+            tari_comms_dht::outbound::DhtOutboundRequest::SendMsg(boxed, reply_tx) => {
+                let _ = reply_tx.send($reply_value);
+                *boxed
+            },
+            _ => panic!("Unexpected DhtOutboundRequest"),
+        }
+    };
+    ($var:expr) => {
+        unwrap_oms_send_msg!($var, reply_value = 0);
+    };
+}
 
 pub fn make_node_identity() -> Arc<NodeIdentity> {
     Arc::new(
@@ -54,35 +60,10 @@ pub fn make_node_identity() -> Arc<NodeIdentity> {
     )
 }
 
-pub fn make_comms_inbound_message(
-    node_identity: &NodeIdentity,
-    message: Vec<u8>,
-    flags: MessageFlags,
-) -> InboundMessage
-{
-    InboundMessage::new(
-        Peer::new(
-            node_identity.identity.public_key.clone(),
-            node_identity.identity.node_id.clone(),
-            Vec::<NetAddress>::new().into(),
-            PeerFlags::empty(),
-            PeerFeatures::communication_node_default(),
-        ),
-        MessageEnvelopeHeader {
-            version: 0,
-            message_public_key: node_identity.identity.public_key.clone(),
-            message_signature: Vec::new(),
-            flags,
-        },
-        0,
-        message,
-    )
-}
-
 pub fn make_dht_header(node_identity: &NodeIdentity, message: &Vec<u8>, flags: DhtMessageFlags) -> DhtHeader {
     DhtHeader {
         version: 0,
-        destination: NodeDestination::Undisclosed,
+        destination: NodeDestination::Unspecified,
         origin_public_key: node_identity.identity.public_key.clone(),
         origin_signature: signature::sign(&mut OsRng::new().unwrap(), node_identity.secret_key.clone(), message)
             .unwrap()
@@ -116,116 +97,4 @@ pub fn make_dht_inbound_message(
         },
         message,
     )
-}
-
-pub fn make_dht_envelope(node_identity: &NodeIdentity, message: Vec<u8>, flags: DhtMessageFlags) -> DhtEnvelope {
-    DhtEnvelope::new(make_dht_header(node_identity, &message, flags), message)
-}
-
-pub fn make_peer_manager() -> Arc<PeerManager> {
-    let database_name = random::string(8);
-    let path = create_random_database_path();
-    let datastore = LMDBBuilder::new()
-        .set_path(path.to_str().unwrap())
-        .set_environment_size(10)
-        .set_max_number_of_databases(1)
-        .add_database(&database_name, lmdb_zero::db::CREATE)
-        .build()
-        .unwrap();
-
-    let peer_database = datastore.get_handle(&database_name).unwrap();
-
-    PeerManager::new(CommsDatabase::new(Arc::new(peer_database)))
-        .map(Arc::new)
-        .unwrap()
-}
-
-pub fn service_spy<TReq>() -> ServiceSpy<TReq>
-where TReq: 'static {
-    ServiceSpy::new()
-}
-
-#[derive(Clone)]
-pub struct ServiceSpy<TReq> {
-    requests: Arc<Mutex<Vec<TReq>>>,
-    call_count: Arc<AtomicUsize>,
-}
-
-impl<TReq> ServiceSpy<TReq>
-where TReq: 'static
-{
-    pub fn new() -> Self {
-        let requests = Arc::new(Mutex::new(Vec::new()));
-        Self {
-            requests,
-            call_count: Arc::new(AtomicUsize::new(0)),
-        }
-    }
-
-    #[allow(dead_code)]
-    pub fn reset(&self) {
-        self.call_count.store(0, Ordering::SeqCst);
-        self.requests.lock().unwrap().clear();
-    }
-
-    pub fn service<TErr>(&self) -> impl Service<TReq, Response = (), Error = TErr> + Clone {
-        let req_inner = Arc::clone(&self.requests);
-        let call_count = Arc::clone(&self.call_count);
-        service_fn(move |req: TReq| {
-            req_inner.lock().unwrap().push(req);
-            call_count.fetch_add(1, Ordering::SeqCst);
-            future::ready(Result::<_, TErr>::Ok(()))
-        })
-    }
-
-    #[allow(dead_code)]
-    pub fn take_requests(&self) -> Vec<TReq> {
-        self.requests.lock().unwrap().drain(..).collect()
-    }
-
-    pub fn pop_request(&self) -> Option<TReq> {
-        self.requests.lock().unwrap().pop()
-    }
-
-    pub fn is_called(&self) -> bool {
-        self.call_count() > 0
-    }
-
-    #[allow(dead_code)]
-    pub fn call_count(&self) -> usize {
-        self.call_count.load(Ordering::SeqCst)
-    }
-}
-
-//---------------------------------- ServiceFn --------------------------------------------//
-
-// TODO: Remove this when https://github.com/tower-rs/tower/pull/318 is published
-
-/// Returns a new `ServiceFn` with the given closure.
-pub fn service_fn<T>(f: T) -> ServiceFn<T> {
-    ServiceFn { f }
-}
-
-/// A `Service` implemented by a closure.
-#[derive(Copy, Clone, Debug)]
-pub struct ServiceFn<T> {
-    f: T,
-}
-
-impl<T, F, Request, R, E> Service<Request> for ServiceFn<T>
-where
-    T: FnMut(Request) -> F,
-    F: Future<Output = Result<R, E>>,
-{
-    type Error = E;
-    type Future = F;
-    type Response = R;
-
-    fn poll_ready(&mut self, _: &mut Context<'_>) -> Poll<Result<(), E>> {
-        Ok(()).into()
-    }
-
-    fn call(&mut self, req: Request) -> Self::Future {
-        (self.f)(req)
-    }
 }

--- a/base_layer/wallet/src/transaction_service/service.rs
+++ b/base_layer/wallet/src/transaction_service/service.rs
@@ -230,7 +230,7 @@ where
         self.outbound_message_service
             .send_message(
                 BroadcastStrategy::DirectPublicKey(dest_pubkey.clone()),
-                NodeDestination::Undisclosed,
+                NodeDestination::Unspecified,
                 OutboundEncryption::EncryptForDestination,
                 TariMessageType::new(BlockchainMessage::Transaction),
                 TransactionSenderMessage::Single(Box::new(msg.clone())),
@@ -337,7 +337,7 @@ where
             self.outbound_message_service
                 .send_message(
                     BroadcastStrategy::DirectPublicKey(source_pubkey.clone()),
-                    NodeDestination::Undisclosed,
+                    NodeDestination::Unspecified,
                     OutboundEncryption::EncryptForDestination,
                     TariMessageType::new(BlockchainMessage::TransactionReply),
                     recipient_reply.clone(),

--- a/comms/dht/src/config.rs
+++ b/comms/dht/src/config.rs
@@ -28,6 +28,8 @@ pub const SAF_MSG_CACHE_STORAGE_CAPACITY: usize = 10_000;
 pub const SAF_LOW_PRIORITY_MSG_STORAGE_TTL: Duration = Duration::from_secs(6 * 60 * 60);
 /// The default time-to-live duration used for storage of high priority messages by the Store-and-forward middleware
 pub const SAF_HIGH_PRIORITY_MSG_STORAGE_TTL: Duration = Duration::from_secs(24 * 60 * 60);
+/// The default number of peer nodes that a message has to be closer to, to be considered a neighbour
+pub const DEFAULT_NUM_NEIGHBOURING_NODES: usize = 8;
 
 #[derive(Debug, Clone)]
 pub struct DhtConfig {
@@ -36,7 +38,7 @@ pub struct DhtConfig {
     pub outbound_buffer_size: usize,
     /// The maximum number of peer nodes that a message has to be closer to, to be considered a neighbour
     /// Default: 8
-    pub num_regional_nodes: usize,
+    pub num_neighbouring_nodes: usize,
     /// A request to retrieve stored messages will be ignored if the requesting node is
     /// not within one of this nodes _n_ closest nodes.
     /// Default 8
@@ -61,7 +63,7 @@ pub struct DhtConfig {
 impl Default for DhtConfig {
     fn default() -> Self {
         Self {
-            num_regional_nodes: 8,
+            num_neighbouring_nodes: DEFAULT_NUM_NEIGHBOURING_NODES,
             saf_num_closest_nodes: 8,
             saf_max_returned_messages: 100,
             outbound_buffer_size: 20,

--- a/comms/dht/src/dht.rs
+++ b/comms/dht/src/dht.rs
@@ -138,8 +138,6 @@ impl Dht {
             .layer(inbound::DecryptionLayer::new(Arc::clone(&self.node_identity)))
             .layer(store_forward::ForwardLayer::new(
                 Arc::clone(&self.peer_manager),
-                self.config.clone(),
-                Arc::clone(&self.node_identity),
                 self.outbound_requester(),
             ))
             .layer(store_forward::StoreLayer::new(
@@ -184,6 +182,7 @@ impl Dht {
     {
         ServiceBuilder::new()
             .layer(outbound::BroadcastLayer::new(
+                self.config.clone(),
                 Arc::clone(&self.node_identity),
                 Arc::clone(&self.peer_manager),
             ))

--- a/comms/dht/src/envelope.rs
+++ b/comms/dht/src/envelope.rs
@@ -127,13 +127,13 @@ impl DhtEnvelope {
     }
 
     pub fn is_signature_valid(&self) -> bool {
-        // error here means that the signature could not deserialize, so is invalid
         match signature::verify(
             &self.header.origin_public_key,
             &self.header.origin_signature,
             &self.body,
         ) {
             Ok(is_valid) => is_valid,
+            // error means that the signature could not deserialize, so is invalid
             Err(_) => false,
         }
     }
@@ -142,8 +142,9 @@ impl DhtEnvelope {
 /// Represents the ways a destination node can be represented.
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
 pub enum NodeDestination {
-    /// The sender has chosen not to disclose the message destination
-    Undisclosed,
+    /// The sender has chosen not to disclose the message destination, or the destination is
+    /// the peer being sent to.
+    Unspecified,
     /// Destined for a particular public key
     PublicKey(CommsPublicKey),
     /// Destined for a particular node id, or network region
@@ -152,6 +153,6 @@ pub enum NodeDestination {
 
 impl Default for NodeDestination {
     fn default() -> Self {
-        NodeDestination::Undisclosed
+        NodeDestination::Unspecified
     }
 }

--- a/comms/dht/src/inbound/deserialize.rs
+++ b/comms/dht/src/inbound/deserialize.rs
@@ -85,7 +85,6 @@ where
             Ok(dht_envelope) => {
                 trace!(target: LOG_TARGET, "Deserialization succeeded. Checking signatures");
                 if !dht_envelope.is_signature_valid() {
-                    eprintln!("GET DHT HEADER = {:?}", dht_envelope.header);
                     // The origin signature is not valid, this message should never have been sent
                     warn!(
                         target: LOG_TARGET,

--- a/comms/dht/src/inbound/dht_handler/task.rs
+++ b/comms/dht/src/inbound/dht_handler/task.rs
@@ -162,7 +162,7 @@ where
                 // Warn: This node id can be anything
                 &origin_peer.node_id,
                 &self.node_identity.identity.node_id,
-                self.config.num_regional_nodes,
+                self.config.num_neighbouring_nodes,
             )?
         {
             trace!(
@@ -176,16 +176,16 @@ where
         trace!(
             target: LOG_TARGET,
             "Propagating join message to at most {} peer(s)",
-            self.config.num_regional_nodes
+            self.config.num_neighbouring_nodes
         );
         // Propagate message to closer peers
         self.outbound_service
             .forward_message(
-                BroadcastStrategy::Closest(BroadcastClosestRequest {
-                    n: self.config.num_regional_nodes,
+                BroadcastStrategy::Closest(Box::new(BroadcastClosestRequest {
+                    n: self.config.num_neighbouring_nodes,
                     node_id: origin_peer.node_id,
                     excluded_peers: vec![dht_header.origin_public_key.clone(), comms_header.message_public_key],
-                }),
+                })),
                 dht_header,
                 msg.to_binary()?,
             )

--- a/comms/dht/src/outbound/broadcast_strategy.rs
+++ b/comms/dht/src/outbound/broadcast_strategy.rs
@@ -38,10 +38,12 @@ pub enum BroadcastStrategy {
     DirectPublicKey(CommsPublicKey),
     /// Send to all known Communication Node peers
     Flood,
-    /// Send to all n nearest neighbour Communication Nodes
-    Closest(BroadcastClosestRequest),
     /// Send to a random set of peers of size n that are Communication Nodes
     Random(usize),
+    /// Send to all n nearest Communication Nodes according to the given BroadcastClosestRequest
+    Closest(Box<BroadcastClosestRequest>),
+    /// Send to the configured number of neighbouring nodes, excluding the given peer public keys
+    Neighbours(Box<Vec<CommsPublicKey>>),
 }
 
 impl fmt::Display for BroadcastStrategy {
@@ -51,13 +53,13 @@ impl fmt::Display for BroadcastStrategy {
             DirectPublicKey(pk) => write!(f, "DirectPublicKey({})", pk),
             DirectNodeId(node_id) => write!(f, "DirectNodeId({})", node_id),
             Flood => write!(f, "Flood"),
-            Closest(BroadcastClosestRequest { n, .. }) => write!(f, "Closest({})", n),
+            Closest(request) => write!(f, "Closest({})", request.n),
             Random(n) => write!(f, "Random({})", n),
+            Neighbours(excluded) => write!(f, "Neighbours({} excluded)", excluded.len()),
         }
     }
 }
 
-// TODO: move this logic, peer manager shouldn't be passed in to broadcast strategy
 impl BroadcastStrategy {
     pub fn direct_node_id(&self) -> Option<&NodeId> {
         use BroadcastStrategy::*;

--- a/comms/dht/src/outbound/error.rs
+++ b/comms/dht/src/outbound/error.rs
@@ -34,4 +34,5 @@ pub enum DhtOutboundError {
     PeerManagerError(PeerManagerError),
     ConnectionError(ConnectionError),
     SignatureError(SchnorrSignatureError),
+    RequesterReplyChannelClosed,
 }

--- a/comms/dht/src/outbound/mock.rs
+++ b/comms/dht/src/outbound/mock.rs
@@ -1,0 +1,129 @@
+// Copyright 2019, The Tari Project
+//
+// Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+// following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+// disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+// following disclaimer in the documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+// products derived from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+// INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+// WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+// USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+use crate::outbound::{message::SendMessageRequest, DhtOutboundRequest, OutboundMessageRequester};
+use futures::{channel::mpsc, stream::Fuse, Future, StreamExt};
+use std::{
+    sync::atomic::{AtomicUsize, Ordering},
+    time::Duration,
+};
+use tokio::future::FutureExt as TokioFutureExt;
+
+/// Creates a mock outbound request "handler" for testing purposes.
+///
+/// Each time a request is expected, handle_next should be called.
+pub fn create_mock_outbound_service(size: usize) -> (OutboundMessageRequester, MockOutboundService) {
+    let (tx, rx) = mpsc::channel(size);
+    (OutboundMessageRequester::new(tx), MockOutboundService::new(rx.fuse()))
+}
+
+pub struct MockOutboundService {
+    receiver: Fuse<mpsc::Receiver<DhtOutboundRequest>>,
+    request_count: AtomicUsize,
+}
+
+impl MockOutboundService {
+    pub fn new(receiver: Fuse<mpsc::Receiver<DhtOutboundRequest>>) -> Self {
+        Self {
+            receiver,
+            request_count: AtomicUsize::new(0),
+        }
+    }
+
+    /// Return the number of requests that have been made
+    pub fn request_count(&self) -> usize {
+        self.request_count.load(Ordering::SeqCst)
+    }
+
+    /// Handles the next OMS message at the same time as making progress on other_fut.
+    /// Useful for testing an async task which uses the oms.
+    pub async fn handle_next_joined<F>(
+        &mut self,
+        timeout: Duration,
+        response: usize,
+        other_fut: F,
+    ) -> (SendMessageRequest, F::Output)
+    where
+        F: Future,
+    {
+        let (req, result) = futures::join!(self.handle_next(timeout, response), other_fut);
+        (req, result)
+    }
+
+    /// Receive and handle the next request. A panic will occur if the request times out, the receiver has closed, or a
+    /// reply cannot be sent back.
+    pub async fn handle_next(&mut self, timeout: Duration, response: usize) -> SendMessageRequest {
+        let req = self.receiver.next().timeout(timeout).await.unwrap().unwrap();
+        self.request_count.fetch_add(1, Ordering::AcqRel);
+        match req {
+            DhtOutboundRequest::SendMsg(msg, reply_tx) => {
+                reply_tx.send(response).unwrap();
+                *msg
+            },
+            DhtOutboundRequest::Forward(_) => panic!("Unexpected DhtOutboundRequest::Forward message"),
+        }
+    }
+
+    /// Handle `count` messages and return a vector of the results.
+    pub async fn handle_many(mut self, count: usize, timeout: Duration, response: usize) -> Vec<SendMessageRequest> {
+        let mut results = Vec::with_capacity(count);
+        for _ in 0..count {
+            results.push(self.handle_next(timeout.clone(), response).await);
+        }
+        results
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use futures::{future::join, FutureExt};
+    use tari_test_utils::runtime;
+
+    #[test]
+    fn handle_next() {
+        runtime::test_async(|rt| {
+            let (mut requester, mut service) = create_mock_outbound_service(1);
+
+            let (_, result) = rt.block_on(join(
+                service.handle_next(Duration::from_millis(100), 123),
+                requester.send_direct_neighbours(Default::default(), Default::default(), (), ()),
+            ));
+
+            assert_eq!(service.request_count(), 1);
+            assert_eq!(result.unwrap(), 123);
+        })
+    }
+
+    #[test]
+    fn handle_many() {
+        runtime::test_async(|rt| {
+            let (mut requester, service) = create_mock_outbound_service(1);
+            rt.spawn(service.handle_many(2, Duration::from_millis(100), 123).map(|_| ()));
+
+            let result = rt.block_on(requester.send_direct_neighbours(Default::default(), Default::default(), (), ()));
+            assert_eq!(result.unwrap(), 123);
+            let result = rt.block_on(requester.send_direct_neighbours(Default::default(), Default::default(), (), ()));
+            assert_eq!(result.unwrap(), 123);
+        })
+    }
+}

--- a/comms/dht/src/outbound/mod.rs
+++ b/comms/dht/src/outbound/mod.rs
@@ -28,6 +28,8 @@ mod message;
 mod requester;
 mod serialize;
 
+pub mod mock;
+
 pub use self::{
     broadcast::BroadcastLayer,
     broadcast_strategy::{BroadcastClosestRequest, BroadcastStrategy},

--- a/comms/dht/src/store_forward/store.rs
+++ b/comms/dht/src/store_forward/store.rs
@@ -195,7 +195,7 @@ where
         let node_identity = &self.node_identity;
 
         match &dht_header.destination {
-            NodeDestination::Undisclosed => {
+            NodeDestination::Unspecified => {
                 self.storage.insert(
                     dht_header.origin_signature.clone(),
                     StoredMessage::new(version, comms_header, dht_header, encrypted_body),
@@ -216,7 +216,7 @@ where
                     (peer_manager.in_network_region(
                         &dest_node_id,
                         &node_identity.identity.node_id,
-                        self.config.num_regional_nodes,
+                        self.config.num_neighbouring_nodes,
                     )?)
                 {
                     self.storage.insert(

--- a/comms/dht/src/test_utils/makers.rs
+++ b/comms/dht/src/test_utils/makers.rs
@@ -87,7 +87,7 @@ pub fn make_comms_inbound_message(
 pub fn make_dht_header(node_identity: &NodeIdentity, message: &Vec<u8>, flags: DhtMessageFlags) -> DhtHeader {
     DhtHeader {
         version: 0,
-        destination: NodeDestination::Undisclosed,
+        destination: NodeDestination::Unspecified,
         origin_public_key: node_identity.public_key().clone(),
         origin_signature: signature::sign(&mut OsRng::new().unwrap(), node_identity.secret_key.clone(), message)
             .unwrap()

--- a/comms/dht/src/test_utils/mod.rs
+++ b/comms/dht/src/test_utils/mod.rs
@@ -21,11 +21,17 @@
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 macro_rules! unwrap_oms_send_msg {
-    ($var:expr) => {
+    ($var:expr, reply_value=$reply_value:expr) => {
         match $var {
-            crate::outbound::DhtOutboundRequest::SendMsg(boxed) => *boxed,
+            crate::outbound::DhtOutboundRequest::SendMsg(boxed, reply_tx) => {
+                let _ = reply_tx.send($reply_value);
+                *boxed
+            },
             _ => panic!("Unexpected DhtOutboundRequest"),
         }
+    };
+    ($var:expr) => {
+        unwrap_oms_send_msg!($var, reply_value = 0);
     };
 }
 

--- a/comms/dht/tests/dht.rs
+++ b/comms/dht/tests/dht.rs
@@ -265,7 +265,7 @@ fn dht_discover_propagation() {
                 .send_discover(
                     node_D_identity.identity.public_key.clone(),
                     None,
-                    NodeDestination::Undisclosed,
+                    NodeDestination::Unspecified,
                 )
                 .await
                 .unwrap();

--- a/comms/src/connection_manager/establisher.rs
+++ b/comms/src/connection_manager/establisher.rs
@@ -73,7 +73,7 @@ impl Default for PeerConnectionConfig {
             max_message_size: 1024 * 1024,
             max_connect_retries: 5,
             socks_proxy_address: None,
-            peer_connection_establish_timeout: Duration::from_secs(10),
+            peer_connection_establish_timeout: Duration::from_secs(20),
             host: "0.0.0.0".parse().unwrap(),
         }
     }


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
- Outbound message requester has `send_direct`,
  `send_direct_neighbours`, `propagate`, `send_flood` and `send_random`
  methods.
- Requester returns the number of messages queued for sending
- Added MockOutboundService to aid in testing


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #903 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Unit tests, existing tests updated where applicable

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [x] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [x] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch
* [x] I ran `cargo-fmt --all` before pushing
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
