### PR TITLE
BaseNodeService: request and provide UTXOs

### DIFF
--- a/base_layer/core/src/base_node/comms_interface/comms_request.rs
+++ b/base_layer/core/src/base_node/comms_interface/comms_request.rs
@@ -37,6 +37,7 @@ pub enum NodeCommsRequestType {
 #[derive(Debug, Serialize, Deserialize)]
 pub enum NodeCommsRequest {
     GetChainMetadata,
-    FetchHeaders(Vec<u64>),
     FetchKernels(Vec<HashOutput>),
+    FetchHeaders(Vec<u64>),
+    FetchUtxos(Vec<HashOutput>),
 }

--- a/base_layer/core/src/base_node/comms_interface/comms_response.rs
+++ b/base_layer/core/src/base_node/comms_interface/comms_response.rs
@@ -20,13 +20,18 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use crate::{blocks::blockheader::BlockHeader, chain_storage::ChainMetadata, transaction::TransactionKernel};
+use crate::{
+    blocks::blockheader::BlockHeader,
+    chain_storage::ChainMetadata,
+    transaction::{TransactionKernel, TransactionOutput},
+};
 use serde::{Deserialize, Serialize};
 
 /// API Response enum
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub enum NodeCommsResponse {
     ChainMetadata(ChainMetadata),
-    BlockHeaders(Vec<BlockHeader>),
     TransactionKernels(Vec<TransactionKernel>),
+    BlockHeaders(Vec<BlockHeader>),
+    TransactionOutputs(Vec<TransactionOutput>),
 }

--- a/base_layer/core/src/base_node/service/initializer.rs
+++ b/base_layer/core/src/base_node/service/initializer.rs
@@ -61,7 +61,7 @@ where T: BlockchainBackend
     inbound_message_subscription_factory:
         Arc<TopicSubscriptionFactory<TariMessageType, Arc<PeerMessage<TariMessageType>>>>,
     node_identity: Arc<NodeIdentity>,
-    blockchain_db: Arc<BlockchainDatabase<T>>,
+    blockchain_db: BlockchainDatabase<T>,
     config: BaseNodeServiceConfig,
 }
 
@@ -74,7 +74,7 @@ where T: BlockchainBackend
             TopicSubscriptionFactory<TariMessageType, Arc<PeerMessage<TariMessageType>>>,
         >,
         node_identity: Arc<NodeIdentity>,
-        blockchain_db: Arc<BlockchainDatabase<T>>,
+        blockchain_db: BlockchainDatabase<T>,
         config: BaseNodeServiceConfig,
     ) -> Self
     {


### PR DESCRIPTION
## Description
- Added functionality to request and provide UTXOs using the BaseNodeService.
- Changed the db queries to be async in InboundNodeCommsInterface.
- Removed the use of an Arc to create references to the BlockchainDatabase.
- Changed the make_async macro to allow the generation of async db queries without params.
- Removed duplicate functions create_runtime and test_async from async_db, these functions are available in tari_test_utils.

Closes #856 and #859

## Motivation and Context
This will allow the sharing of UTXOs between remote nodes.

## How Has This Been Tested?
Modified the tests to work with the async db calls and added tests for handling inbound and outbound UTXO requests.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [x] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [x] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch
* [x] I ran `cargo-fmt --all` before pushing
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
