### PR TITLE
Towards a base node executable

### DIFF
--- a/applications/tari_base_node/Cargo.toml
+++ b/applications/tari_base_node/Cargo.toml
@@ -15,7 +15,13 @@ clap = "2.33.0"
 config = { version = "0.9.3" }
 dirs = "2.0.2"
 log4rs = { version = "0.8.3", features = ["toml_format"] }
+rand = "0.5.5"
 tari_core = {path = "../../base_layer/core", version= "^0.0"}
+tari_comms_dht = { version = "^0.0", path = "../../comms/dht"}
+tari_p2p = {path = "../../base_layer/p2p", version= "^0.0"}
 tari_common = {path = "../../common", version= "^0.0"}
 tari_shutdown = { path = "../../infrastructure/shutdown", version = "^0.0" }
 tari_service_framework = { version = "^0.0", path = "../../base_layer/service_framework"}
+tari_utilities = { version = "^0.0", path = "../../infrastructure/tari_util"}
+tari_comms = { version = "^0.0", path = "../../comms"}
+serde_json = "1.0"

--- a/applications/tari_base_node/src/cli.rs
+++ b/applications/tari_base_node/src/cli.rs
@@ -23,18 +23,8 @@
 
 use crate::consts;
 use clap::clap_app;
-use dirs;
-use std::path::{Path, PathBuf};
-
-/// A minimal parsed configuration object that's used to bootstrap the main Configuration.
-pub struct ConfigBootstrap {
-    pub config: PathBuf,
-    /// The path to the log configuration file. It is set using the following precedence set:
-    ///   1. from the command-line parameter,
-    ///   2. from the `TARI_LOG_CONFIGURATION` environment variable,
-    ///   3. from a default value, usually `~/.tari/log4rs.yml` (or OS equivalent).
-    pub log_config: PathBuf,
-}
+use std::path::Path;
+use tari_common::{bootstrap_config_from_cli, ConfigBootstrap};
 
 /// Prints a pretty banner on the console
 pub fn print_banner() {
@@ -45,38 +35,29 @@ pub fn print_banner() {
     );
 }
 
+/// Parsed command-line arguments
+pub struct Arguments {
+    pub bootstrap: ConfigBootstrap,
+    pub create_id: bool,
+}
+
 /// Parse the command-line args and populate the minimal bootstrap config object
-pub fn parse_cli_args() -> ConfigBootstrap {
+pub fn parse_cli_args() -> Arguments {
     let matches = clap_app!(myapp =>
         (version: consts::VERSION)
         (author: consts::AUTHOR)
         (about: "The reference Tari cryptocurrency base node implementation")
-        (@arg config: -c --config +takes_value {exists} "A path to the configuration file to use (tari_conf.toml)")
-        (@arg log_config: -l --log_config +takes_value {exists} "A path to the logfile configuration (log4rs.yml))")
+        (@arg config: -c --config +takes_value "A path to the configuration file to use (config.toml)")
+        (@arg log_config: -l --log_config +takes_value "A path to the logfile configuration (log4rs.yml))")
         (@arg init: --init "Create a default configuration file if it doesn't exist")
+        (@arg create_id: --create_id "Create and save new node identity if one doesn't exist ")
     )
     .get_matches();
 
-    let config = matches
-        .value_of("config")
-        .map(PathBuf::from)
-        .unwrap_or(default_path(consts::DEFAULT_CONFIG));
-    let log_config = matches.value_of("log_config").map(PathBuf::from);
-    let log_config = tari_common::get_log_configuration_path(log_config);
+    let bootstrap = bootstrap_config_from_cli(&matches);
+    let create_id = matches.is_present("create_id");
 
-    if !config.exists() && matches.is_present("init") {
-        println!("Installing new config file at {}", config.to_str().unwrap_or("[??]"));
-        install_configuration(&config, tari_common::install_default_config_file);
-    }
-
-    if !log_config.exists() && matches.is_present("init") {
-        println!(
-            "Installing new logfile configuration at {}",
-            log_config.to_str().unwrap_or("[??]")
-        );
-        install_configuration(&log_config, tari_common::install_default_logfile_config);
-    }
-    ConfigBootstrap { config, log_config }
+    Arguments { bootstrap, create_id }
 }
 
 fn exists(s: String) -> Result<(), String> {
@@ -85,23 +66,5 @@ fn exists(s: String) -> Result<(), String> {
         Ok(())
     } else {
         Err(format!("{} does not exist", s))
-    }
-}
-
-fn default_path(filename: &str) -> PathBuf {
-    let mut home = dirs::home_dir().unwrap_or(PathBuf::from("."));
-    home.push(".tari");
-    home.push(filename);
-    home
-}
-
-fn install_configuration<F>(path: &Path, installer: F)
-where F: Fn(&Path) -> Result<u64, std::io::Error> {
-    if let Err(e) = installer(path) {
-        println!(
-            "We could not install a new configuration file in {}: {}",
-            path.to_str().unwrap_or("?"),
-            e.to_string()
-        )
     }
 }

--- a/base_layer/core/src/base_node/mod.rs
+++ b/base_layer/core/src/base_node/mod.rs
@@ -34,10 +34,10 @@
 
 mod base_node;
 mod comms_interface;
-mod service;
 #[cfg(test)]
 mod test;
 
+pub mod service;
 pub mod states;
 
 // Public re-exports

--- a/base_layer/core/src/lib.rs
+++ b/base_layer/core/src/lib.rs
@@ -55,3 +55,6 @@ pub mod chain_storage;
 
 // Re-export commonly used structs
 pub use transaction_protocol::{recipient::ReceiverTransactionProtocol, sender::SenderTransactionProtocol};
+
+// Re-export the crypto crate to make exposing traits etc easier for clients of this crate
+pub use tari_crypto as crypto;

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -12,5 +12,10 @@ edition = "2018"
 
 [dependencies]
 dirs = "2.0"
+log = "0.4.8"
 log4rs = "0.8.3"
 config = { version = "0.9.3" }
+clap = "2.33.0"
+
+[dev-dependencies]
+tempdir = "0.3.7"

--- a/common/src/dir_utils.rs
+++ b/common/src/dir_utils.rs
@@ -19,7 +19,35 @@
 // SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-//
 
-pub const VERSION: &str = "0.0.5";
-pub const AUTHOR: &str = "The Tari Community";
+use std::{io::ErrorKind, path::PathBuf};
+
+/// Create the default data directory (`~/.tari` on OSx and Linux, for example) if it doesn't already exist
+pub fn create_data_directory() -> Result<(), std::io::Error> {
+    let mut home = dirs::home_dir().ok_or(std::io::Error::from(ErrorKind::NotFound))?;
+    home.push(".tari");
+    if !home.exists() {
+        std::fs::create_dir(home)
+    } else {
+        Ok(())
+    }
+}
+
+/// A convenience function for creating subfolders inside the `~/.tari` default data directory
+///
+/// # Panics
+/// This function panics if the home folder location cannot be found or if the path value is not valid UTF-8.
+/// This is a trade-off made in favour of convenience of use.
+pub fn default_subdir(path: &str) -> String {
+    let mut home = dirs::home_dir().expect("Home folder location failed");
+    home.push(".tari");
+    home.push(path);
+    String::from(home.to_str().expect("Invalid path value"))
+}
+
+pub fn default_path(filename: &str) -> PathBuf {
+    let mut home = dirs::home_dir().unwrap_or(PathBuf::from("."));
+    home.push(".tari");
+    home.push(filename);
+    home
+}

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -20,95 +20,103 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use dirs;
-use std::{
-    env,
-    io::ErrorKind,
-    path::{Path, PathBuf},
-};
+//! # Common logging and configuration utilities
+//!
+//! ## The global Tari configuration file
+//!
+//! A single configuration file (usually `~/.tari/config.toml` is used to manage settings for all Tari applications
+//! and nodes running on a single system, whether it's a base node, validator node, or wallet.
+//!
+//! Setting of configuration parameters is applied using the following order of precedence:
+//!
+//! 1. Command-line argument
+//! 2. Environment variable
+//! 3. `config.toml` file value
+//! 4. Configuration default
+//!
+//! The utilities exposed in this crate are opinionated, but flexible. In general, all data is stored in a `.tari`
+//! folder under your home folder.
+//!
+//! ### Example - Loading and deserializing the global config file
+//!
+//! ```edition2018
+//! # use tari_common::*;
+//! let config = default_config();
+//! let config = GlobalConfig::convert_from(config).unwrap();
+//! assert_eq!(config.network, Network::MainNet);
+//! assert_eq!(config.blocking_threads, 4);
+//! ```
+
+use clap::ArgMatches;
+use std::path::{Path, PathBuf};
 
 mod configuration;
+mod logging;
 
-pub use configuration::{default_config, ConfigurationError, DatabaseType, Network, NodeBuilderConfig};
+pub mod dir_utils;
+pub use configuration::{
+    default_config,
+    install_default_config_file,
+    load_configuration,
+    ConfigurationError,
+    DatabaseType,
+    GlobalConfig,
+    Network,
+};
+pub use logging::initialize_logging;
 
-/// Determine the path to a log configuration file using the following precedence rules:
-/// 1. Use the provided path (usually pulled from a CLI argument)
-/// 2. Use the value in the `TARI_LOG_CONFIGURATION` envar
-/// 3. The default path (OS-dependent), "~/.tari/log4rs.toml`
-/// 4. The current directory
-pub fn get_log_configuration_path(cli_path: Option<PathBuf>) -> PathBuf {
-    cli_path
-        .or_else(|| {
-            env::var_os("TARI_LOG_CONFIGURATION")
-                .filter(|s| !s.is_empty())
-                .map(PathBuf::from)
-        })
-        .or_else(|| dirs::home_dir().map(|path| path.join(".tari/log4rs.yml")))
-        .or_else(|| {
-            Some(env::current_dir().expect(
-                "Could find a suitable path to the log configuration file. Consider setting the \
-                 TARI_LOG_CONFIGURATION envar, or check that the current directory exists and that you have \
-                 permission to read it",
-            ))
-        })
-        .unwrap()
+pub const DEFAULT_CONFIG: &str = "config.toml";
+pub const DEFAULT_LOG_CONFIG: &str = "log4rs.yml";
+
+/// A minimal parsed configuration object that's used to bootstrap the main Configuration.
+pub struct ConfigBootstrap {
+    pub config: PathBuf,
+    /// The path to the log configuration file. It is set using the following precedence set:
+    ///   1. from the command-line parameter,
+    ///   2. from the `TARI_LOG_CONFIGURATION` environment variable,
+    ///   3. from a default value, usually `~/.tari/log4rs.yml` (or OS equivalent).
+    pub log_config: PathBuf,
 }
 
-/// Create the default data directory (`~/.tari` on OSx and Linux, for example) if it doesn't already exist
-pub fn create_data_directory() -> Result<(), std::io::Error> {
-    let mut home = dirs::home_dir().ok_or(std::io::Error::from(ErrorKind::NotFound))?;
-    home.push(".tari");
-    if !home.exists() {
-        std::fs::create_dir(home)
-    } else {
-        Ok(())
+impl Default for ConfigBootstrap {
+    fn default() -> Self {
+        ConfigBootstrap {
+            config: dir_utils::default_path(DEFAULT_CONFIG),
+            log_config: dir_utils::default_path(DEFAULT_LOG_CONFIG),
+        }
     }
 }
 
-/// A convenience function for creating subfolders inside the `~/.tari` default data directory
-///
-/// # Panics
-/// This function panics if the home folder location cannot be found or if the path value is not valid UTF-8.
-/// This is a trade-off made in favour of convenience of use.
-pub fn default_subdir(path: &str) -> String {
-    let mut home = dirs::home_dir().expect("Home folder location failed");
-    home.push(".tari");
-    home.push(path);
-    String::from(home.to_str().expect("Invalid path value"))
-}
+pub fn bootstrap_config_from_cli(matches: &ArgMatches) -> ConfigBootstrap {
+    let config = matches
+        .value_of("config")
+        .map(PathBuf::from)
+        .unwrap_or(dir_utils::default_path(DEFAULT_CONFIG));
+    let log_config = matches.value_of("log_config").map(PathBuf::from);
+    let log_config = logging::get_log_configuration_path(log_config);
 
-/// Installs a new configuration file template, copied from `tari_config_sample.toml` to the given path.
-/// When bundled as a binary, the config sample file must be bundled in `common/config`.
-pub fn install_default_config_file(path: &Path) -> Result<u64, std::io::Error> {
-    let mut source = env::current_dir()?;
-    source.push(Path::new("common/config/tari_config_sample.toml"));
-    std::fs::copy(source, path)
-}
-
-/// Installs a new default logfile configuration, copied from `log4rs-sample.yml` to the given path.
-/// When bundled as a binary, the config sample file must be bundled in `common/config`.
-pub fn install_default_logfile_config(path: &Path) -> Result<u64, std::io::Error> {
-    let mut source = env::current_dir()?;
-    source.push(Path::new("common/logging/log4rs-sample.yml"));
-    std::fs::copy(source, path)
-}
-
-#[cfg(test)]
-mod test {
-    use super::*;
-    use std::env;
-
-    #[test]
-    fn get_log_configuration_path_cli() {
-        let path = get_log_configuration_path(Some(PathBuf::from("~/my-tari")));
-        assert_eq!(path.to_str().unwrap(), "~/my-tari");
+    if !config.exists() && matches.is_present("init") {
+        println!("Installing new config file at {}", config.to_str().unwrap_or("[??]"));
+        install_configuration(&config, configuration::install_default_config_file);
     }
 
-    #[test]
-    fn get_log_configuration_path_by_env_var() {
-        env::set_var("TARI_LOG_CONFIGURATION", "~/fake-example");
-        let path = get_log_configuration_path(None);
-        assert_eq!(path.to_str().unwrap(), "~/fake-example");
-        env::set_var("TARI_LOG_CONFIGURATION", "");
+    if !log_config.exists() && matches.is_present("init") {
+        println!(
+            "Installing new logfile configuration at {}",
+            log_config.to_str().unwrap_or("[??]")
+        );
+        install_configuration(&log_config, logging::install_default_logfile_config);
+    }
+    ConfigBootstrap { config, log_config }
+}
+
+pub fn install_configuration<F>(path: &Path, installer: F)
+where F: Fn(&Path) -> Result<u64, std::io::Error> {
+    if let Err(e) = installer(path) {
+        println!(
+            "We could not install a new configuration file in {}: {}",
+            path.to_str().unwrap_or("?"),
+            e.to_string()
+        )
     }
 }

--- a/common/src/logging.rs
+++ b/common/src/logging.rs
@@ -1,0 +1,91 @@
+// Copyright 2019. The Tari Project
+//
+// Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+// following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+// disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+// following disclaimer in the documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+// products derived from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+// INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+// WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+// USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+
+use std::{
+    env,
+    path::{Path, PathBuf},
+};
+
+/// Determine the path to a log configuration file using the following precedence rules:
+/// 1. Use the provided path (usually pulled from a CLI argument)
+/// 2. Use the value in the `TARI_LOG_CONFIGURATION` envar
+/// 3. The default path (OS-dependent), "~/.tari/log4rs.toml`
+/// 4. The current directory
+pub fn get_log_configuration_path(cli_path: Option<PathBuf>) -> PathBuf {
+    cli_path
+        .or_else(|| {
+            env::var_os("TARI_LOG_CONFIGURATION")
+                .filter(|s| !s.is_empty())
+                .map(PathBuf::from)
+        })
+        .or_else(|| dirs::home_dir().map(|path| path.join(".tari/log4rs.yml")))
+        .or_else(|| {
+            Some(env::current_dir().expect(
+                "Could find a suitable path to the log configuration file. Consider setting the \
+                 TARI_LOG_CONFIGURATION envar, or check that the current directory exists and that you have \
+                 permission to read it",
+            ))
+        })
+        .unwrap()
+}
+
+/// Set up application-level logging using the Log4rs configuration file specified in
+pub fn initialize_logging(config_file: &Path) -> bool {
+    println!(
+        "Initializing logging according to {:?}",
+        config_file.to_str().unwrap_or("[??]")
+    );
+    if let Err(e) = log4rs::init_file(config_file.clone(), Default::default()) {
+        println!("We couldn't load a logging configuration file. {}", e.to_string());
+        return false;
+    }
+    true
+}
+
+/// Installs a new default logfile configuration, copied from `log4rs-sample.yml` to the given path.
+/// When bundled as a binary, the config sample file must be bundled in `common/config`.
+pub fn install_default_logfile_config(path: &Path) -> Result<u64, std::io::Error> {
+    let mut source = env::current_dir()?;
+    source.push(Path::new("common/logging/log4rs-sample.yml"));
+    std::fs::copy(source, path)
+}
+
+#[cfg(test)]
+mod test {
+    use crate::logging::get_log_configuration_path;
+    use std::{env, path::PathBuf};
+
+    #[test]
+    fn get_log_configuration_path_cli() {
+        let path = get_log_configuration_path(Some(PathBuf::from("~/my-tari")));
+        assert_eq!(path.to_str().unwrap(), "~/my-tari");
+    }
+
+    #[test]
+    fn get_log_configuration_path_by_env_var() {
+        env::set_var("TARI_LOG_CONFIGURATION", "~/fake-example");
+        let path = get_log_configuration_path(None);
+        assert_eq!(path.to_str().unwrap(), "~/fake-example");
+        env::set_var("TARI_LOG_CONFIGURATION", "");
+    }
+}

--- a/config/tari_config_sample.toml
+++ b/config/tari_config_sample.toml
@@ -26,13 +26,6 @@
 # minutes = or 24 hrs.
 #message_cache_ttl = 1440
 
-# When first logging onto the Tari network, you need to find a few peers to bootstrap the process. In the absence of
-# any servers, this is a little more challenging than usual. Our best strategy is just to try and connect to the peers
-# you knew about last time you ran the software. But what about when you run the software for the first time? That's
-# where this whitelist comes in. It's a list of known Tari nodes that are likely to be around for a long time and that
-# new nodes can use to introduce themselves to the network.
-peer_whitelist = [ "8.8.8.8", "6.6.6.6", "7.7.7.7"] # TODO actually populate this with a list of bootstrap nodes
-
 # The peer database list is stored in a database file at this location
 #peer_database = "~/.tari/peers"
 
@@ -87,8 +80,16 @@ peer_whitelist = [ "8.8.8.8", "6.6.6.6", "7.7.7.7"] # TODO actually populate thi
 # almost all use cases.
 #db_type = "lmdb"
 
-# For LMDB backends, the folder to use to store the blockchain database.
-#db = "~/.tari/testnet/db/"
+# The path to store persistent data
+#data_dir = "~/.tari/testnet/"
+
+# When first logging onto the Tari network, you need to find a few peers to bootstrap the process. In the absence of
+# any servers, this is a little more challenging than usual. Our best strategy is just to try and connect to the peers
+# you knew about last time you ran the software. But what about when you run the software for the first time? That's
+# where this whitelist comes in. It's a list of known Tari nodes that are likely to be around for a long time and that
+# new nodes can use to introduce themselves to the network.
+# peer_seeds = ["public_key1::address1", "public_key2::address2",... ]
+peer_seeds = []
 
 # Configure the number of threads to spawn for long-running tasks, like block and transaction validation. A good choice
 # for this value is somewhere between n/2 and n - 1, where n is the number of cores on your machine.
@@ -100,22 +101,32 @@ peer_whitelist = [ "8.8.8.8", "6.6.6.6", "7.7.7.7"] # TODO actually populate thi
 
 # The address and port to listen for peer connections. This is the address that is advertised on the network so that
 # peers can find you.
-#address = "tcp://0.0.0.0:81898"
+#address = "tcp://0.0.0.0:18189"
 
 # Enable the gRPC server for the base node. Set this to true if you want to enable third-party wallet software
 #grpc_enabled = false
 
 # The socket to expose for the gRPC base node server. This value is ignored if grpc_enabled is false.
 # Valid values here are IPv4 and IPv6 TCP sockets, local unix sockets (e.g. "ipc://base-node-gprc.sock.100")
-#grpc_address = "tcp://127.0.0.1:81410"
+#grpc_address = "tcp://127.0.0.1:18141"
+
+# A path to the file that stores your node identity and secret key
+#identity_file = "~/.tari/testnet/node_id.json"
 
 [base_node.mainnet]
 # The type of database backend to use. Currently supported options are "memory" and "lmdb". LMDB is recommnded for
 # almost all use cases.
 #db_type = "lmdb"
 
-# For LMDB backends, the folder to use to store the blockchain database.
-#db = "~/.tari/mainnet/db/"
+# The path to store persistent data
+#data_dir = "~/.tari/mainnet/"
+
+# When first logging onto the Tari network, you need to find a few peers to bootstrap the process. In the absence of
+# any servers, this is a little more challenging than usual. Our best strategy is just to try and connect to the peers
+# you knew about last time you ran the software. But what about when you run the software for the first time? That's
+# where this whitelist comes in. It's a list of known Tari nodes that are likely to be around for a long time and that
+# new nodes can use to introduce themselves to the network.
+peer_seeds = []
 
 # Configure the number of threads to spawn for long-running tasks, like block and transaction validation. A good choice
 # for this value is somewhere between n/2 and n - 1, where n is the number of cores on your machine.
@@ -127,14 +138,18 @@ peer_whitelist = [ "8.8.8.8", "6.6.6.6", "7.7.7.7"] # TODO actually populate thi
 
 # The address and port to listen for peer connections. This is the address that is advertised on the network so that
 # peers can find you. You may specify more than one address here
-#address = "tcp://0.0.0.0:80898"
+#address = "tcp://0.0.0.0:18089"
 
 # Enable the gRPC server for the base node. Set this to true if you want to enable third-party wallet software
 #grpc_enabled = false
 
 # The socket to expose for the gRPC base node server. This value is ignored if grpc_enabled is false.
 # Valid values here are IPv4 and IPv6 TCP sockets, local unix sockets (e.g. "ipc://base-node-gprc.sock.100")
-#grpc_address = "tcp://127.0.0.1:80410"
+#grpc_address = "tcp://127.0.0.1:18041"
+
+# A path to the file that stores your node identity and secret key
+#identity_file = "~/.tari/mainnet/node_id.json"
+
 ########################################################################################################################
 #                                                                                                                      #
 #                                         Validator Node Configuration Options                                         #
@@ -152,4 +167,4 @@ peer_whitelist = [ "8.8.8.8", "6.6.6.6", "7.7.7.7"] # TODO actually populate thi
 
 # The socket to expose for the gRPC base node server. This value is ignored if grpc_enabled is false.
 # Valid values here are IPv4 and IPv6 TCP sockets, local unix sockets (e.g. "ipc://base-node-gprc.sock.100")
-#grpc_address = "tcp://127.0.0.1:80420"
+#grpc_address = "tcp://127.0.0.1:18042"


### PR DESCRIPTION
Changes:
* `create_id` CLI flag to create and save a new node ID
* Reads seed peers from config file and assigns them to Comms Stack
* Instantiates and starts the base Node service
* Sets up and starts the Comms stack
* Load global config file from disk
* envars starting with `TARI_xxx` are automatically applied over the config