### PR TITLE
BaseNodeService: request and provide historical blocks

### DIFF
--- a/applications/tari_base_node/src/builder.rs
+++ b/applications/tari_base_node/src/builder.rs
@@ -259,12 +259,7 @@ fn setup_comms_services<T: BlockchainBackend + 'static>(
 
     let fut = StackBuilder::new(rt.executor(), comms.shutdown_signal())
         .add_initializer(CommsOutboundServiceInitializer::new(dht.outbound_requester()))
-        .add_initializer(BaseNodeServiceInitializer::new(
-            subscription_factory,
-            id.clone(),
-            db,
-            node_config,
-        ))
+        .add_initializer(BaseNodeServiceInitializer::new(subscription_factory, db, node_config))
         .finish();
 
     info!(target: LOG_TARGET, "Initializing communications stack...");

--- a/base_layer/core/src/base_node/comms_interface/comms_request.rs
+++ b/base_layer/core/src/base_node/comms_interface/comms_request.rs
@@ -40,4 +40,5 @@ pub enum NodeCommsRequest {
     FetchKernels(Vec<HashOutput>),
     FetchHeaders(Vec<u64>),
     FetchUtxos(Vec<HashOutput>),
+    FetchBlocks(Vec<u64>),
 }

--- a/base_layer/core/src/base_node/comms_interface/comms_response.rs
+++ b/base_layer/core/src/base_node/comms_interface/comms_response.rs
@@ -22,7 +22,7 @@
 
 use crate::{
     blocks::blockheader::BlockHeader,
-    chain_storage::ChainMetadata,
+    chain_storage::{ChainMetadata, HistoricalBlock},
     transaction::{TransactionKernel, TransactionOutput},
 };
 use serde::{Deserialize, Serialize};
@@ -34,4 +34,5 @@ pub enum NodeCommsResponse {
     TransactionKernels(Vec<TransactionKernel>),
     BlockHeaders(Vec<BlockHeader>),
     TransactionOutputs(Vec<TransactionOutput>),
+    HistoricalBlocks(Vec<HistoricalBlock>),
 }

--- a/base_layer/core/src/base_node/comms_interface/error.rs
+++ b/base_layer/core/src/base_node/comms_interface/error.rs
@@ -29,6 +29,9 @@ pub enum CommsInterfaceError {
     /// Access to the underlying storage mechanism failed
     UnexpectedApiResponse,
     RequestTimedOut,
+    NoBootstrapNodesConfigured,
     TransportChannelError(TransportChannelError),
     ChainStorageError(ChainStorageError),
+    #[error(non_std, no_from)]
+    OutboundMessageService(String),
 }

--- a/base_layer/core/src/base_node/comms_interface/inbound_interface.rs
+++ b/base_layer/core/src/base_node/comms_interface/inbound_interface.rs
@@ -23,7 +23,7 @@
 use crate::{
     base_node::comms_interface::{error::CommsInterfaceError, NodeCommsRequest, NodeCommsResponse},
     blocks::blockheader::BlockHeader,
-    chain_storage::{async_db, BlockchainBackend, BlockchainDatabase},
+    chain_storage::{async_db, BlockchainBackend, BlockchainDatabase, HistoricalBlock},
     transaction::{TransactionKernel, TransactionOutput},
 };
 
@@ -74,6 +74,15 @@ where T: BlockchainBackend
                     }
                 }
                 Ok(NodeCommsResponse::TransactionOutputs(utxos))
+            },
+            NodeCommsRequest::FetchBlocks(block_nums) => {
+                let mut blocks = Vec::<HistoricalBlock>::new();
+                for block_num in block_nums {
+                    if let Ok(block) = async_db::fetch_block(self.blockchain_db.clone(), *block_num).await {
+                        blocks.push(block);
+                    }
+                }
+                Ok(NodeCommsResponse::HistoricalBlocks(blocks))
             },
         }
     }

--- a/base_layer/core/src/base_node/comms_interface/outbound_interface.rs
+++ b/base_layer/core/src/base_node/comms_interface/outbound_interface.rs
@@ -28,7 +28,7 @@ use crate::{
         NodeCommsResponse,
     },
     blocks::blockheader::BlockHeader,
-    chain_storage::ChainMetadata,
+    chain_storage::{ChainMetadata, HistoricalBlock},
     transaction::{TransactionKernel, TransactionOutput},
     types::HashOutput,
 };
@@ -114,6 +114,20 @@ impl OutboundNodeCommsInterface {
             .first()
         {
             Ok(utxos.clone())
+        } else {
+            Err(CommsInterfaceError::UnexpectedApiResponse)
+        }
+    }
+
+    /// Fetch the Historical Blocks corresponding to the provided block numbers from remote base nodes.
+    pub async fn fetch_blocks(&mut self, block_nums: Vec<u64>) -> Result<Vec<HistoricalBlock>, CommsInterfaceError> {
+        if let Some(NodeCommsResponse::HistoricalBlocks(blocks)) = self
+            .sender
+            .call((NodeCommsRequest::FetchBlocks(block_nums), NodeCommsRequestType::Single))
+            .await??
+            .first()
+        {
+            Ok(blocks.clone())
         } else {
             Err(CommsInterfaceError::UnexpectedApiResponse)
         }

--- a/base_layer/core/src/base_node/service/initializer.rs
+++ b/base_layer/core/src/base_node/service/initializer.rs
@@ -34,7 +34,6 @@ use crate::{
 use futures::{future, Future, Stream, StreamExt};
 use log::*;
 use std::sync::Arc;
-use tari_comms::peer_manager::NodeIdentity;
 use tari_comms_dht::outbound::OutboundMessageRequester;
 use tari_p2p::{
     comms_connector::PeerMessage,
@@ -60,7 +59,6 @@ where T: BlockchainBackend
 {
     inbound_message_subscription_factory:
         Arc<TopicSubscriptionFactory<TariMessageType, Arc<PeerMessage<TariMessageType>>>>,
-    node_identity: Arc<NodeIdentity>,
     blockchain_db: BlockchainDatabase<T>,
     config: BaseNodeServiceConfig,
 }
@@ -73,14 +71,12 @@ where T: BlockchainBackend
         inbound_message_subscription_factory: Arc<
             TopicSubscriptionFactory<TariMessageType, Arc<PeerMessage<TariMessageType>>>,
         >,
-        node_identity: Arc<NodeIdentity>,
         blockchain_db: BlockchainDatabase<T>,
         config: BaseNodeServiceConfig,
     ) -> Self
     {
         Self {
             inbound_message_subscription_factory,
-            node_identity,
             blockchain_db,
             config,
         }
@@ -120,7 +116,6 @@ where T: BlockchainBackend + 'static
         // Create streams for receiving Base Node requests and response messages from comms
         let inbound_request_stream = self.inbound_request_stream();
         let inbound_response_stream = self.inbound_response_stream();
-        let node_identity = self.node_identity.clone();
         // Connect InboundNodeCommsInterface and OutboundNodeCommsInterface to BaseNodeService
         let (outbound_request_sender_service, outbound_request_stream) = reply_channel::unbounded();
         let outbound_nci = OutboundNodeCommsInterface::new(outbound_request_sender_service);
@@ -144,7 +139,6 @@ where T: BlockchainBackend + 'static
                 inbound_request_stream,
                 inbound_response_stream,
                 outbound_message_service,
-                node_identity,
                 inbound_nci,
                 config,
             )

--- a/base_layer/core/src/chain_storage/historical_block.rs
+++ b/base_layer/core/src/chain_storage/historical_block.rs
@@ -21,9 +21,11 @@
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 use crate::{blocks::Block, transaction::TransactionOutput, types::Commitment};
+use serde::{Deserialize, Serialize};
 
 /// The representation of a historical block in the blockchain. It is essentially identical to a protocol-defined
 /// block but contains some extra metadata that clients such as Block Explorers will find interesting.
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 pub struct HistoricalBlock {
     /// The number of blocks that have been mined since this block, including this one. The current tip will have one
     /// confirmation.

--- a/base_layer/core/src/consts.rs
+++ b/base_layer/core/src/consts.rs
@@ -48,7 +48,5 @@ thread_local! {
 }
 /// The allocated waiting time for a request waiting for service responses from remote base nodes.
 pub const BASE_NODE_SERVICE_REQUEST_TIMEOUT: Duration = Duration::from_secs(5);
-/// The number of remote peers that Base Node Service requests are sent to.
-pub const BASE_NODE_SERVICE_BROADCAST_PEER_COUNT: usize = 8;
-/// The number of responses that need to be received for a corresponding service request to be finalize.
-pub const BASE_NODE_SERVICE_DESIRED_RESPONSE_COUNT: usize = 5;
+/// The fraction of responses that need to be received for a corresponding service request to be finalize.
+pub const BASE_NODE_SERVICE_DESIRED_RESPONSE_FRACTION: f32 = 0.6;


### PR DESCRIPTION
## Description
- Added ability to request and provide historical blocks.
- Update the BaseNodeService to make use of the new and simplified BroadcastStrategies. This allowed the BaseNodeService to no longer need access to the NodeIdentity and allow the BaseNodeServiceConfig to be simplified.
- Waiting requests in the BaseNodeService can now wait for an adjustable fraction of the responses from the contacted remote base nodes.

## Motivation and Context
These changes simplified the BaseNodeService and allow base nodes to share blocks.

## How Has This Been Tested?
Tests for testing the request and response of historical blocks were also added.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [x] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch
* [x] I ran `cargo-fmt --all` before pushing
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.

Closes #854 and #855
