### PR TITLE
Add back-off retries to InitialSync

### DIFF
--- a/base_layer/core/src/base_node/backoff.rs
+++ b/base_layer/core/src/base_node/backoff.rs
@@ -1,0 +1,138 @@
+// Copyright 2019. The Tari Project
+//
+// Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+// following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+// disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+// following disclaimer in the documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+// products derived from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+// INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+// WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+// USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+
+use std::time::{Duration, Instant};
+use tokio::timer;
+
+/// A simple back-off strategy. `BackOff` is typically used in situations where you want to retry an operation a
+/// number of times, with an increasing delay between attempts
+///
+/// # Examples
+///
+/// ```no_run
+/// use std::time::Duration;
+/// use tari_core::base_node::BackOff;
+///
+/// fn foo(n: u64) -> Result<(), u64> {
+///     if n < 3 {
+///         Err(n)
+///     } else {
+///         Ok(())
+///     }
+/// }
+/// let mut backoff = BackOff::new(5, Duration::from_millis(100), 1.5);
+/// async {
+///     let mut attempts = 1;
+///     while !backoff.is_finished() {
+///         match foo(attempts) {
+///             Ok(_) => backoff.stop(),
+///             Err(n) => {
+///                 assert!(n < 3);
+///                 backoff.wait().await;
+///                 attempts += 1;
+///             },
+///         }
+///     }
+/// };
+/// assert_eq!(backoff.attempts(), 4);
+/// ```
+pub struct BackOff {
+    max_attempts: usize,
+    current_attempts: usize,
+    delay: Duration,
+    backoff: f64,
+    stopped: bool,
+}
+
+impl BackOff {
+    /// Create a new `BackOff` timer.
+    ///
+    /// # Parameters
+    /// * max_attempts: The total number of attempts to make
+    /// * delay: The initial duration to wait for after the first attempt
+    /// * factor: The factor to apply to the delay after each attempt
+    pub fn new(max_attempts: usize, delay: Duration, factor: f64) -> Self {
+        BackOff {
+            max_attempts,
+            current_attempts: 0,
+            delay,
+            backoff: factor,
+            stopped: false,
+        }
+    }
+
+    pub fn attempts(&self) -> usize {
+        self.current_attempts
+    }
+
+    pub fn max_attempts(&self) -> usize {
+        self.max_attempts
+    }
+
+    pub fn is_finished(&self) -> bool {
+        self.current_attempts >= self.max_attempts || self.stopped
+    }
+
+    pub fn is_stopped(&self) -> bool {
+        self.stopped
+    }
+
+    pub fn stop(&mut self) {
+        self.stopped = true
+    }
+
+    pub async fn wait(&mut self) -> () {
+        if self.is_finished() {
+            return;
+        }
+        let deadline = Instant::now() + self.delay;
+        let delay = timer::delay(deadline);
+        delay.await;
+        self.current_attempts += 1;
+        self.delay = self.delay.mul_f64(self.backoff);
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::base_node::BackOff;
+    use std::time::Duration;
+
+    #[tokio::test]
+    async fn retry() {
+        let mut retry = BackOff::new(3, Duration::from_millis(100), 1.5);
+        assert_eq!(retry.attempts(), 0);
+        retry.wait().await;
+        assert_eq!(retry.attempts(), 1);
+        assert_eq!(retry.is_finished(), false);
+        retry.wait().await;
+        assert_eq!(retry.attempts(), 2);
+        assert_eq!(retry.is_finished(), false);
+        retry.wait().await;
+        assert_eq!(retry.attempts(), 3);
+        assert_eq!(retry.is_finished(), true);
+        retry.wait().await;
+        assert_eq!(retry.attempts(), 3);
+        assert_eq!(retry.is_finished(), true);
+    }
+}

--- a/base_layer/core/src/base_node/base_node.rs
+++ b/base_layer/core/src/base_node/base_node.rs
@@ -32,7 +32,7 @@ use bitflags::_core::sync::atomic::AtomicBool;
 use log::*;
 use std::sync::{atomic::Ordering, Arc};
 
-const TARGET: &str = "core::base_node";
+const LOG_TARGET: &str = "core::base_node";
 
 /// A Tari full node, aka Base Node.
 ///
@@ -73,7 +73,7 @@ impl<B: BlockchainBackend> BaseNodeStateMachine<B> {
             (_, FatalError(s)) => Shutdown(states::Shutdown::with_reason(s)),
             (s, e) => {
                 debug!(
-                    target: TARGET,
+                    target: LOG_TARGET,
                     "No state transition occurs for event {:?} in state {}", e, s
                 );
                 s
@@ -101,6 +101,10 @@ impl<B: BlockchainBackend> BaseNodeStateMachine<B> {
                 Listening(s) => s.next_event().await,
                 Shutdown(_) => break,
             };
+            debug!(
+                target: LOG_TARGET,
+                "=== Base Node event in State [{}]:  {:?}", state, next_event
+            );
             state = BaseNodeStateMachine::<B>::transition(state, next_event);
         }
     }

--- a/base_layer/core/src/base_node/mod.rs
+++ b/base_layer/core/src/base_node/mod.rs
@@ -32,6 +32,7 @@
 //! More details about the implementation are presented in
 //! [RFC-0111](https://rfc.tari.com/RFC-0111_BaseNodeArchitecture.html).
 
+mod backoff;
 mod base_node;
 mod comms_interface;
 #[cfg(test)]
@@ -41,5 +42,6 @@ pub mod service;
 pub mod states;
 
 // Public re-exports
+pub use backoff::BackOff;
 pub use base_node::BaseNodeStateMachine;
 pub use comms_interface::OutboundNodeCommsInterface;

--- a/base_layer/core/src/base_node/states/initial_sync.rs
+++ b/base_layer/core/src/base_node/states/initial_sync.rs
@@ -27,20 +27,33 @@ use crate::{
         states::{
             Starting,
             StateEvent,
-            StateEvent::{FallenBehind, FatalError, MetadataSynced},
+            StateEvent::{FatalError, MetadataSynced},
             SyncStatus,
         },
+        BackOff,
         BaseNodeStateMachine,
     },
     chain_storage::{BlockchainBackend, ChainMetadata},
 };
+
 use log::*;
+use std::time::Duration;
 
 const LOG_TARGET: &str = "base_node::initial_sync";
+// The number of times we'll request the chain metadata before giving up
+const MAX_SYNC_ATTEMPTS: usize = 8;
 
-pub struct InitialSync;
+pub struct InitialSync {
+    // keeps track of how many times we've tried to sync with the network
+    backoff: BackOff,
+}
 
 impl InitialSync {
+    pub fn new() -> Self {
+        let backoff = BackOff::new(MAX_SYNC_ATTEMPTS, Duration::from_secs(30), 1.0);
+        InitialSync { backoff }
+    }
+
     pub async fn next_event<B: BlockchainBackend>(&mut self, shared: &mut BaseNodeStateMachine<B>) -> StateEvent {
         info!(target: LOG_TARGET, "Starting blockchain metadata sync");
         self.sync_metadata(shared).await
@@ -48,7 +61,7 @@ impl InitialSync {
 
     /// Fetch the blockchain metadata from our internal database and compare it to data received from peers to decide
     /// on the next phase of the blockchain synchronisation.
-    async fn sync_metadata<B: BlockchainBackend>(&self, shared: &mut BaseNodeStateMachine<B>) -> StateEvent {
+    async fn sync_metadata<B: BlockchainBackend>(&mut self, shared: &mut BaseNodeStateMachine<B>) -> StateEvent {
         info!(target: LOG_TARGET, "Loading local blockchain metadata.");
         let ours = match shared.db.get_metadata() {
             Ok(m) => m,
@@ -62,20 +75,24 @@ impl InitialSync {
             "Current local blockchain database information:\n {}", ours
         );
         // Fetch peer metadata
-        match shared.comms.get_metadata().await {
-            Err(e) => self.retry_or_fail(e),
-            Ok(theirs) => self.evaluate_data(ours, theirs),
+        let mut theirs = vec![];
+        while !self.backoff.is_finished() {
+            match shared.comms.get_metadata().await {
+                Err(e) => {
+                    log_error(e, self.backoff.attempts(), self.backoff.max_attempts());
+                    self.backoff.wait().await;
+                },
+                Ok(data) => {
+                    theirs = data;
+                    self.backoff.stop();
+                },
+            }
         }
-    }
-
-    fn retry_or_fail(&self, e: CommsInterfaceError) -> StateEvent {
-        // TODO - implement a general back-off retry strategy. This would be used in various places around the state
-        // machine, but for now we're just going to give up
-        let msg = format!(
-            "Unable to retrieve blockchain metadata from the network. {}",
-            e.to_string()
-        );
-        StateEvent::FatalError(msg)
+        if self.backoff.is_stopped() {
+            self.evaluate_data(ours, theirs)
+        } else {
+            StateEvent::FatalError("Too many chain metadata attempts failed".into())
+        }
     }
 
     fn evaluate_data(&self, ours: ChainMetadata, theirs: Vec<ChainMetadata>) -> StateEvent {
@@ -124,6 +141,53 @@ impl InitialSync {
 /// State management for Starting -> InitialSync. This state change occurs every time a node is restarted.
 impl From<Starting> for InitialSync {
     fn from(_old_state: Starting) -> Self {
-        InitialSync
+        InitialSync::new()
+    }
+}
+
+fn log_error(e: CommsInterfaceError, att: usize, max_att: usize) {
+    let msg = format!("Attempt {} of {}.", att, max_att);
+    match e {
+        // If the request timed out, we may be the only node on the network, thus we're up to date by definition
+        CommsInterfaceError::RequestTimedOut => {
+            debug!(
+                target: LOG_TARGET,
+                "Network request for chain metadata timed out. {}", msg
+            );
+        },
+        CommsInterfaceError::TransportChannelError(e) => {
+            error!(
+                target: LOG_TARGET,
+                "The base node input channel has closed unexpectedly. The best way to resolve this issue is to \
+                 restart the node. {}. {}",
+                e.to_string(),
+                msg
+            );
+        },
+        CommsInterfaceError::ChainStorageError(e) => {
+            error!(
+                target: LOG_TARGET,
+                "There was a problem accessing the blockchain database. {}. {}.",
+                e.to_string(),
+                msg
+            );
+        },
+        CommsInterfaceError::UnexpectedApiResponse => {
+            warn!(target: LOG_TARGET, "MetadataSync got an unexpected response. {}", msg);
+        },
+        CommsInterfaceError::NoBootstrapNodesConfigured => {
+            warn!(
+                target: LOG_TARGET,
+                "Cannot connect to the network; No seed nodes are configured. {}", msg
+            );
+        },
+        CommsInterfaceError::OutboundMessageService(e) => {
+            error!(
+                target: LOG_TARGET,
+                "There was a problem with the outbound message service. {}. {}.",
+                e.to_string(),
+                msg
+            );
+        },
     }
 }

--- a/base_layer/core/src/base_node/states/listening.rs
+++ b/base_layer/core/src/base_node/states/listening.rs
@@ -29,7 +29,7 @@ pub struct Listening;
 
 impl Listening {
     pub async fn next_event(&mut self) -> StateEvent {
-        info!(target: LOG_TARGET, "Listening for new blocks");
+        info!(target: LOG_TARGET, "Listening for new blocks and transactions");
         FatalError("Unimplemented".into())
     }
 }

--- a/base_layer/core/src/base_node/states/shutdown_state.rs
+++ b/base_layer/core/src/base_node/states/shutdown_state.rs
@@ -29,10 +29,7 @@ pub struct Shutdown {
 
 impl Shutdown {
     pub fn with_reason(reason: String) -> Self {
+        info!(target: LOG_TARGET, "A fatal error has occurred. {}", reason);
         Self { reason }
-    }
-
-    pub async fn shutdown(&self) {
-        info!(target: LOG_TARGET, "Node is shutting down. {}", self.reason);
     }
 }


### PR DESCRIPTION
Provides a new `BackOff` struct that facilitates backoff retry logic.
`BackOff` is used in the InitialSync base node state to retry
fetching the chain state metadata.

Added some more colour to log messages,