### PR TITLE
Tidy up initial sync logic

### DIFF
--- a/base_layer/core/src/base_node/states/block_sync.rs
+++ b/base_layer/core/src/base_node/states/block_sync.rs
@@ -21,9 +21,9 @@
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 use crate::base_node::states::{
-    fetching_horizon_state::FetchHorizonState,
-    listening::Listening,
+    fetching_horizon_state::HorizonInfo,
     InitialSync,
+    ListeningInfo,
     StateEvent,
     StateEvent::FatalError,
 };
@@ -31,9 +31,9 @@ use log::*;
 
 const LOG_TARGET: &str = "base_node::block_sync";
 
-pub struct BlockSync;
+pub struct BlockSyncInfo;
 
-impl BlockSync {
+impl BlockSyncInfo {
     pub async fn next_event(&mut self) -> StateEvent {
         info!(target: LOG_TARGET, "Synchronizing missing blocks");
         FatalError("Unimplemented".into())
@@ -42,23 +42,23 @@ impl BlockSync {
 
 /// State management for FetchingHorizonState -> BlockSync. This is a typical transition for new nodes joining the
 /// network.
-impl From<FetchHorizonState> for BlockSync {
-    fn from(_old: FetchHorizonState) -> Self {
+impl From<HorizonInfo> for BlockSyncInfo {
+    fn from(_old: HorizonInfo) -> Self {
         unimplemented!()
     }
 }
 
 /// State management for Listening -> BlockSync. This change happens when a node has been temporarily disconnected
 /// from the network, or a reorg has occurred.
-impl From<Listening> for BlockSync {
-    fn from(_old: Listening) -> Self {
+impl From<ListeningInfo> for BlockSyncInfo {
+    fn from(_old: ListeningInfo) -> Self {
         unimplemented!()
     }
 }
 
 /// State management for InitialSync -> BlockSync. This change happens when a (previously synced) node is restarted
 /// after being offline for some time.
-impl From<InitialSync> for BlockSync {
+impl From<InitialSync> for BlockSyncInfo {
     fn from(_old: InitialSync) -> Self {
         unimplemented!()
     }

--- a/base_layer/core/src/base_node/states/initial_sync.rs
+++ b/base_layer/core/src/base_node/states/initial_sync.rs
@@ -46,12 +46,19 @@ const MAX_SYNC_ATTEMPTS: usize = 8;
 pub struct InitialSync {
     // keeps track of how many times we've tried to sync with the network
     backoff: BackOff,
+    // Every time the metadata request fails, vote for what to do if we ultimately fail
+    shutdown_votes: usize,
+    listen_votes: usize,
 }
 
 impl InitialSync {
     pub fn new() -> Self {
         let backoff = BackOff::new(MAX_SYNC_ATTEMPTS, Duration::from_secs(30), 1.0);
-        InitialSync { backoff }
+        InitialSync {
+            backoff,
+            shutdown_votes: 0,
+            listen_votes: 0,
+        }
     }
 
     pub async fn next_event<B: BlockchainBackend>(&mut self, shared: &mut BaseNodeStateMachine<B>) -> StateEvent {
@@ -79,7 +86,7 @@ impl InitialSync {
         while !self.backoff.is_finished() {
             match shared.comms.get_metadata().await {
                 Err(e) => {
-                    log_error(e, self.backoff.attempts(), self.backoff.max_attempts());
+                    self.log_error(e);
                     self.backoff.wait().await;
                 },
                 Ok(data) => {
@@ -91,7 +98,7 @@ impl InitialSync {
         if self.backoff.is_stopped() {
             self.evaluate_data(ours, theirs)
         } else {
-            StateEvent::FatalError("Too many chain metadata attempts failed".into())
+            self.failure_outcome()
         }
     }
 
@@ -99,7 +106,12 @@ impl InitialSync {
         // If there are no other nodes on the network, then we're at the chain tip by definition, so we go into
         // listen mode
         if theirs.is_empty() {
-            return StateEvent::BlocksSynchronized;
+            info!(
+                target: LOG_TARGET,
+                "The rest of the network doesn't appear to have any up-to-date chain data, so we're going to assume \
+                 we're at the tip"
+            );
+            return StateEvent::MetadataSynced(SyncStatus::UpToDate);
         }
         let network = self.summarize_network_data(theirs);
         MetadataSynced(InitialSync::determine_sync_mode(ours, network))
@@ -120,20 +132,120 @@ impl InitialSync {
     /// Given a local and the network chain state respectively, figure out what synchronisation state we should be in.
     fn determine_sync_mode(local: ChainMetadata, network: ChainMetadata) -> SyncStatus {
         use crate::base_node::states::SyncStatus::*;
+        // The number of blocks back from the tip to sync to when starting out
+        // TODO - make this configurable
+        const HORIZON_WHEN_SYNCING: u64 = 60;
         match network.height_of_longest_chain {
-            None => UpToDate,
+            None => {
+                info!(
+                    target: LOG_TARGET,
+                    "The rest of the network doesn't appear to have any up-to-date chain data, so we're going to \
+                     assume we're at the tip"
+                );
+                UpToDate
+            },
             Some(network_tip) => {
-                let horizon_block = local.horizon_block(network_tip);
+                let horizon_block = match network_tip.checked_sub(HORIZON_WHEN_SYNCING) {
+                    None => 0,
+                    Some(h) => h,
+                };
+                // If the user-configured pruning horizon < HORIZON_WHEN_SYNCING, then use that
+                let horizon_block = std::cmp::max(horizon_block, local.horizon_block(network_tip));
                 let local_tip = local.height_of_longest_chain.unwrap_or(0);
                 if local_tip < horizon_block {
-                    return BehindHorizon;
+                    info!(
+                        target: LOG_TARGET,
+                        "We're far behind the network chain tip (block #{}), so we're going to re-sync the entire \
+                         state at block #{} first, and then catch up.",
+                        network_tip,
+                        horizon_block
+                    );
+                    return BehindHorizon(horizon_block);
                 }
                 if local_tip < network_tip {
-                    Lagging
+                    info!(
+                        target: LOG_TARGET,
+                        "Our local blockchain history is a little behind that of the network.We're at block #{}, and \
+                         the chain tip is at #{}",
+                        local_tip,
+                        network_tip
+                    );
+                    Lagging(network_tip)
                 } else {
                     UpToDate
                 }
             },
+        }
+    }
+
+    fn log_error(&mut self, e: CommsInterfaceError) {
+        let att = self.backoff.attempts();
+        let max_att = self.backoff.max_attempts();
+        let msg = format!("Attempt {} of {}.", att, max_att);
+        match e {
+            // If the request timed out, we may be the only node on the network, thus we're up to date by definition
+            CommsInterfaceError::RequestTimedOut => {
+                self.listen_votes += 1;
+                debug!(
+                    target: LOG_TARGET,
+                    "Network request for chain metadata timed out. {}", msg
+                );
+            },
+            CommsInterfaceError::TransportChannelError(e) => {
+                self.shutdown_votes += 1;
+                error!(
+                    target: LOG_TARGET,
+                    "The base node input channel has closed unexpectedly. The best way to resolve this issue is to \
+                     restart the node. {}. {}",
+                    e.to_string(),
+                    msg
+                );
+            },
+            CommsInterfaceError::ChainStorageError(e) => {
+                self.shutdown_votes += 1;
+                error!(
+                    target: LOG_TARGET,
+                    "There was a problem accessing the blockchain database. {}. {}.",
+                    e.to_string(),
+                    msg
+                );
+            },
+            CommsInterfaceError::UnexpectedApiResponse => {
+                self.listen_votes += 1;
+                warn!(target: LOG_TARGET, "MetadataSync got an unexpected response. {}", msg);
+            },
+            CommsInterfaceError::NoBootstrapNodesConfigured => {
+                self.listen_votes += 1;
+                warn!(
+                    target: LOG_TARGET,
+                    "Cannot connect to the network; No seed nodes are configured. {}", msg
+                );
+            },
+            CommsInterfaceError::OutboundMessageService(e) => {
+                self.shutdown_votes += 1;
+                error!(
+                    target: LOG_TARGET,
+                    "There was a problem with the outbound message service. {}. {}.",
+                    e.to_string(),
+                    msg
+                );
+            },
+        }
+    }
+
+    fn failure_outcome(&self) -> StateEvent {
+        if self.shutdown_votes > self.listen_votes {
+            StateEvent::FatalError(
+                "Could not complete the initial sync. See prior log messages for further details.".to_string(),
+            )
+        } else {
+            info!(
+                target: LOG_TARGET,
+                "We could not complete the chain metadata sync, but this may because we're the only node on the \
+                 network, or can't connect to any peers. Is the seed list configured properly? We're flipping to the \
+                 listening state now and hopefully this issue will resolve itself."
+            );
+            StateEvent::MetadataSynced(SyncStatus::UpToDate)
         }
     }
 }
@@ -142,52 +254,5 @@ impl InitialSync {
 impl From<Starting> for InitialSync {
     fn from(_old_state: Starting) -> Self {
         InitialSync::new()
-    }
-}
-
-fn log_error(e: CommsInterfaceError, att: usize, max_att: usize) {
-    let msg = format!("Attempt {} of {}.", att, max_att);
-    match e {
-        // If the request timed out, we may be the only node on the network, thus we're up to date by definition
-        CommsInterfaceError::RequestTimedOut => {
-            debug!(
-                target: LOG_TARGET,
-                "Network request for chain metadata timed out. {}", msg
-            );
-        },
-        CommsInterfaceError::TransportChannelError(e) => {
-            error!(
-                target: LOG_TARGET,
-                "The base node input channel has closed unexpectedly. The best way to resolve this issue is to \
-                 restart the node. {}. {}",
-                e.to_string(),
-                msg
-            );
-        },
-        CommsInterfaceError::ChainStorageError(e) => {
-            error!(
-                target: LOG_TARGET,
-                "There was a problem accessing the blockchain database. {}. {}.",
-                e.to_string(),
-                msg
-            );
-        },
-        CommsInterfaceError::UnexpectedApiResponse => {
-            warn!(target: LOG_TARGET, "MetadataSync got an unexpected response. {}", msg);
-        },
-        CommsInterfaceError::NoBootstrapNodesConfigured => {
-            warn!(
-                target: LOG_TARGET,
-                "Cannot connect to the network; No seed nodes are configured. {}", msg
-            );
-        },
-        CommsInterfaceError::OutboundMessageService(e) => {
-            error!(
-                target: LOG_TARGET,
-                "There was a problem with the outbound message service. {}. {}.",
-                e.to_string(),
-                msg
-            );
-        },
     }
 }

--- a/base_layer/core/src/base_node/states/mod.rs
+++ b/base_layer/core/src/base_node/states/mod.rs
@@ -112,9 +112,9 @@ use std::fmt::{Display, Error, Formatter};
 pub enum BaseNodeState {
     Starting(Starting),
     InitialSync(InitialSync),
-    FetchingHorizonState(FetchHorizonState),
-    BlockSync(BlockSync),
-    Listening(Listening),
+    FetchingHorizonState(HorizonInfo),
+    BlockSync(BlockSyncInfo),
+    Listening(ListeningInfo),
     Shutdown(Shutdown),
 }
 
@@ -134,8 +134,10 @@ pub enum StateEvent {
 /// blocks to catch up, or we are `UpToDate`.
 #[derive(Debug)]
 pub enum SyncStatus {
-    BehindHorizon,
-    Lagging,
+    // We are behind the pruning horizon. The u64 parameter indicates the block height at the horizon.
+    BehindHorizon(u64),
+    // We are behind the chain tip. The usize parameter gives the network's chain height.
+    Lagging(u64),
     UpToDate,
 }
 
@@ -161,11 +163,9 @@ mod listening;
 mod shutdown_state;
 mod starting_state;
 
-use crate::base_node::states::{
-    block_sync::BlockSync,
-    fetching_horizon_state::FetchHorizonState,
-    listening::Listening,
-};
+pub use block_sync::BlockSyncInfo;
+pub use fetching_horizon_state::HorizonInfo;
 pub use initial_sync::InitialSync;
+pub use listening::ListeningInfo;
 pub use shutdown_state::Shutdown;
 pub use starting_state::Starting;


### PR DESCRIPTION
The chain metadata sync can gracefully recover when there are no
other peers, or when those peers have no data to give.

The state transition code now takes an event (and its metadata)
to properly transition and initialise the next state.

The Listening state now waits for CTRL-C rather than shutting down
immediately (a stop-gap while the rest of the state eninge in written)

Added a few more explanatory log messages.

Stubbed out Fetch Horizon state code.