### PR TITLE
Added limited query interface for PeerManager + Peer Connection stats

### DIFF
--- a/base_layer/core/src/transaction_protocol/proto/transaction_metadata.rs
+++ b/base_layer/core/src/transaction_protocol/proto/transaction_metadata.rs
@@ -23,7 +23,6 @@
 use super::protocol as proto;
 
 use crate::transaction_protocol::TransactionMetadata;
-use std::convert::TryFrom;
 
 impl From<proto::TransactionMetadata> for TransactionMetadata {
     fn from(metadata: proto::TransactionMetadata) -> Self {

--- a/comms/dht/src/inbound/dht_handler/task.rs
+++ b/comms/dht/src/inbound/dht_handler/task.rs
@@ -112,7 +112,7 @@ where
     {
         let peer_manager = &self.peer_manager;
         // Add peer or modify existing peer using received join request
-        if peer_manager.exists(pubkey)? {
+        if peer_manager.exists(pubkey) {
             peer_manager.update_peer(pubkey, Some(node_id), Some(net_addresses), None, Some(peer_features))?;
         } else {
             peer_manager.add_peer(Peer::new(
@@ -124,7 +124,7 @@ where
             ))?;
         }
 
-        let peer = peer_manager.find_with_public_key(&pubkey)?;
+        let peer = peer_manager.find_by_public_key(&pubkey)?;
 
         Ok(peer)
     }

--- a/comms/dht/src/store_forward/forward.rs
+++ b/comms/dht/src/store_forward/forward.rs
@@ -178,7 +178,7 @@ where
                 BroadcastStrategy::Neighbours(Box::new(excluded_peers))
             },
             NodeDestination::PublicKey(dest_public_key) => {
-                if self.peer_manager.exists(&dest_public_key)? {
+                if self.peer_manager.exists(&dest_public_key) {
                     // Send to destination peer directly if the current node knows that peer
                     BroadcastStrategy::DirectPublicKey(dest_public_key)
                 } else {
@@ -187,7 +187,7 @@ where
                 }
             },
             NodeDestination::NodeId(dest_node_id) => {
-                match self.peer_manager.find_with_node_id(&dest_node_id) {
+                match self.peer_manager.find_by_node_id(&dest_node_id) {
                     Ok(dest_peer) => {
                         // Send to destination peer directly if the current node knows that peer
                         BroadcastStrategy::DirectPublicKey(dest_peer.public_key)

--- a/comms/dht/src/store_forward/saf_handler/task.rs
+++ b/comms/dht/src/store_forward/saf_handler/task.rs
@@ -327,7 +327,7 @@ where S: Service<DecryptedDhtMessage, Response = (), Error = MiddlewareError>
 
             // TODO: We may not know the peer. The following line rejects these messages,
             //       however we may want to accept (some?) messages from unknown peers
-            let peer = peer_manager.find_with_public_key(&dht_header.origin_public_key)?;
+            let peer = peer_manager.find_by_public_key(&dht_header.origin_public_key)?;
 
             let inbound_msg = DhtInboundMessage::new(dht_header, peer, message.encrypted_body);
 

--- a/comms/dht/src/store_forward/store.rs
+++ b/comms/dht/src/store_forward/store.rs
@@ -203,7 +203,7 @@ where
                 );
             },
             NodeDestination::PublicKey(dest_public_key) => {
-                if peer_manager.exists(&dest_public_key)? {
+                if peer_manager.exists(&dest_public_key) {
                     self.storage.insert(
                         dht_header.origin_signature.clone(),
                         StoredMessage::new(version, dht_header, encrypted_body),
@@ -212,7 +212,7 @@ where
                 }
             },
             NodeDestination::NodeId(dest_node_id) => {
-                if (peer_manager.exists_node_id(&dest_node_id)?) |
+                if (peer_manager.exists_node_id(&dest_node_id)) |
                     (peer_manager.in_network_region(
                         &dest_node_id,
                         &node_identity.identity.node_id,

--- a/comms/dht/tests/dht.rs
+++ b/comms/dht/tests/dht.rs
@@ -181,20 +181,20 @@ fn dht_join_propagation() {
 
             // Check that Node A knows about Node C and vice versa
             async_assert_eventually!(
-                node_A_peer_manager.exists(node_C_node_identity.public_key()).unwrap(),
+                node_A_peer_manager.exists(node_C_node_identity.public_key()),
                 expect = true,
                 max_attempts = 10,
                 interval = Duration::from_millis(500)
             );
             async_assert_eventually!(
-                node_C_peer_manager.exists(node_A_node_identity.public_key()).unwrap(),
+                node_C_peer_manager.exists(node_A_node_identity.public_key()),
                 expect = true,
                 max_attempts = 10,
                 interval = Duration::from_millis(500)
             );
 
             let node_C_peer = node_A_peer_manager
-                .find_with_public_key(node_C_node_identity.public_key())
+                .find_by_public_key(node_C_node_identity.public_key())
                 .unwrap();
             assert_eq!(&node_C_peer.features, node_C_node_identity.features());
 
@@ -216,6 +216,7 @@ fn dht_join_propagation() {
 #[test]
 #[allow(non_snake_case)]
 fn dht_discover_propagation() {
+    env_logger::init();
     // Create 4 nodes where A knows B, B knows A and C, C knows B and D, and D knows C
     let node_A_identity = new_node_identity("127.0.0.1:11116".parse().unwrap());
     let node_B_identity = new_node_identity("127.0.0.1:11117".parse().unwrap());
@@ -277,14 +278,14 @@ fn dht_discover_propagation() {
 
             // Check that Node A knows about Node D and vice versa
             async_assert_eventually!(
-                node_A_peer_manager.exists(node_D_node_identity.public_key()).unwrap(),
+                node_A_peer_manager.exists(node_D_node_identity.public_key()),
                 expect = true,
                 max_attempts = 10,
                 interval = Duration::from_millis(500)
             );
 
             async_assert_eventually!(
-                node_D_peer_manager.exists(node_A_node_identity.public_key()).unwrap(),
+                node_D_peer_manager.exists(node_A_node_identity.public_key()),
                 expect = true,
                 max_attempts = 10,
                 interval = Duration::from_millis(500)

--- a/comms/src/connection_manager/connectivity.rs
+++ b/comms/src/connection_manager/connectivity.rs
@@ -31,4 +31,6 @@ pub trait Connectivity {
     fn get_active_connection_count(&self) -> usize;
 
     fn disconnect_peer(&self, node_id: &NodeId) -> Result<Option<Arc<PeerConnection>>>;
+
+    //    fn set_peer_connection_eligibility(&self, node_id: &NodeId, eligibility: ConnectEligibility);
 }

--- a/comms/src/connection_manager/dialer.rs
+++ b/comms/src/connection_manager/dialer.rs
@@ -32,5 +32,5 @@ pub trait Dialer<T> {
     type Future: Future<Output = Result<Self::Output, Self::Error>>;
 
     /// Asynchronously establish a connection (dial) to a remote peer
-    fn dial(&self, dial_key: &T) -> Self::Future;
+    fn dial(&self, peer: &T) -> Self::Future;
 }

--- a/comms/src/control_service/worker.rs
+++ b/comms/src/control_service/worker.rs
@@ -285,7 +285,7 @@ impl ControlServiceWorker {
 
         let pm = &self.connection_manager.peer_manager();
         let public_key = &envelope_header.public_key;
-        let peer = match pm.find_with_public_key(&public_key) {
+        let peer = match pm.find_by_public_key(&public_key) {
             Ok(peer) => {
                 if peer.is_banned() {
                     return Err(ControlServiceError::PeerBanned);
@@ -463,7 +463,7 @@ impl ControlServiceWorker {
 
     fn get_peer(&self, public_key: &CommsPublicKey) -> Result<Option<Peer>> {
         let peer_manager = &self.connection_manager.peer_manager();
-        match peer_manager.find_with_public_key(public_key) {
+        match peer_manager.find_by_public_key(public_key) {
             Ok(peer) => Ok(Some(peer)),
             Err(PeerManagerError::PeerNotFoundError) => Ok(None),
             Err(err) => Err(ControlServiceError::PeerManagerError(err)),

--- a/comms/src/inbound_message_service/inbound_message_service.rs
+++ b/comms/src/inbound_message_service/inbound_message_service.rs
@@ -149,7 +149,7 @@ where
     /// Check whether the the source of the message is known to our Peer Manager, if it is return the peer but otherwise
     /// we discard the message as it should be in our Peer Manager
     fn find_known_peer(&self, source_node_id: &NodeId) -> Result<Peer, InboundMessageServiceError> {
-        match self.peer_manager.find_with_node_id(source_node_id).ok() {
+        match self.peer_manager.find_by_node_id(source_node_id).ok() {
             Some(peer) => Ok(peer),
             None => {
                 warn!(

--- a/comms/src/peer_manager/mod.rs
+++ b/comms/src/peer_manager/mod.rs
@@ -58,7 +58,7 @@
 //!
 //! peer_manager.add_peer(peer.clone());
 //!
-//! let returned_peer = peer_manager.find_with_node_id(&node_id).unwrap();
+//! let returned_peer = peer_manager.find_by_node_id(&node_id).unwrap();
 //! ```
 
 mod peer_features;
@@ -69,6 +69,7 @@ pub mod node_identity;
 pub mod peer;
 pub mod peer_key;
 mod peer_manager;
+mod peer_query;
 pub mod peer_storage;
 
 pub use self::{
@@ -78,4 +79,5 @@ pub use self::{
     peer::{Peer, PeerFlags},
     peer_features::PeerFeatures,
     peer_manager::PeerManager,
+    peer_query::{PeerQuery, PeerQuerySortBy},
 };

--- a/comms/src/peer_manager/peer.rs
+++ b/comms/src/peer_manager/peer.rs
@@ -38,6 +38,16 @@ bitflags! {
     }
 }
 
+/// Peer connection statistics
+#[derive(Debug, Clone, Default, Deserialize, Serialize, PartialOrd, PartialEq)]
+pub struct PeerConnectionStats {
+    /// The last time that a successful connection was made, None if this has never happened
+    pub connected_at: Option<NaiveDateTime>,
+    /// The time that the last connection attempt failed. If the last connection attempt succeeded
+    /// this is None
+    pub last_connect_failed_at: Option<NaiveDateTime>,
+}
+
 /// A Peer represents a communication peer that is identified by a Public Key and NodeId. The Peer struct maintains a
 /// collection of the NetAddressesWithStats that this Peer can be reached by. The struct also maintains a set of flags
 /// describing the status of the Peer.
@@ -50,7 +60,7 @@ pub struct Peer {
     pub addresses: NetAddressesWithStats,
     pub flags: PeerFlags,
     pub features: PeerFeatures,
-    // TODO reputation metric?
+    pub connection_stats: PeerConnectionStats,
 }
 
 impl Peer {
@@ -69,6 +79,7 @@ impl Peer {
             addresses,
             flags,
             features,
+            connection_stats: Default::default(),
         }
     }
 
@@ -112,6 +123,10 @@ impl Peer {
     /// Changes the ban flag bit of the peer
     pub fn set_banned(&mut self, ban_flag: bool) {
         self.flags.set(PeerFlags::BANNED, ban_flag);
+    }
+
+    pub fn set_connection_stats(&mut self, connection_stats: PeerConnectionStats) {
+        self.connection_stats = connection_stats;
     }
 }
 

--- a/comms/src/peer_manager/peer_manager.rs
+++ b/comms/src/peer_manager/peer_manager.rs
@@ -29,6 +29,7 @@ use crate::{
         peer_storage::PeerStorage,
         PeerFeatures,
         PeerManagerError,
+        PeerQuery,
     },
     types::{CommsDatabase, CommsPublicKey},
 };
@@ -52,10 +53,7 @@ impl PeerManager {
     /// Adds a peer to the routing table of the PeerManager if the peer does not already exist. When a peer already
     /// exist, the stored version will be replaced with the newly provided peer.
     pub fn add_peer(&self, peer: Peer) -> Result<(), PeerManagerError> {
-        self.peer_storage
-            .write()
-            .map_err(|_| PeerManagerError::PoisonedAccess)?
-            .add_peer(peer)
+        acquire_write_lock!(self.peer_storage).add_peer(peer)
     }
 
     pub fn update_peer(
@@ -67,68 +65,44 @@ impl PeerManager {
         peer_features: Option<PeerFeatures>,
     ) -> Result<(), PeerManagerError>
     {
-        self.peer_storage
-            .write()
-            .map_err(|_| PeerManagerError::PoisonedAccess)?
-            .update_peer(public_key, node_id, net_addresses, flags, peer_features)
+        acquire_write_lock!(self.peer_storage).update_peer(public_key, node_id, net_addresses, flags, peer_features)
     }
 
     /// The peer with the specified public_key will be removed from the PeerManager
     pub fn delete_peer(&self, node_id: &NodeId) -> Result<(), PeerManagerError> {
-        self.peer_storage
-            .write()
-            .map_err(|_| PeerManagerError::PoisonedAccess)?
-            .delete_peer(node_id)
+        acquire_write_lock!(self.peer_storage).delete_peer(node_id)
+    }
+
+    /// Performs the given [PeerQuery].
+    ///
+    /// [PeerQuery]: crate::peer_manager::peer_query::PeerQuery
+    pub fn perform_query(&self, peer_query: PeerQuery) -> Result<Vec<Peer>, PeerManagerError> {
+        acquire_read_lock!(self.peer_storage).perform_query(peer_query)
     }
 
     /// Find the peer with the provided NodeID
-    pub fn find_with_node_id(&self, node_id: &NodeId) -> Result<Peer, PeerManagerError> {
-        self.peer_storage
-            .read()
-            .map_err(|_| PeerManagerError::PoisonedAccess)?
-            .find_with_node_id(node_id)
+    pub fn find_by_node_id(&self, node_id: &NodeId) -> Result<Peer, PeerManagerError> {
+        acquire_read_lock!(self.peer_storage).find_by_node_id(node_id)
     }
 
     /// Find the peer with the provided PublicKey
-    pub fn find_with_public_key(&self, public_key: &CommsPublicKey) -> Result<Peer, PeerManagerError> {
-        self.peer_storage
-            .read()
-            .map_err(|_| PeerManagerError::PoisonedAccess)?
-            .find_with_public_key(public_key)
-    }
-
-    /// Find the peer with the provided NetAddress
-    pub fn find_with_net_address(&self, net_address: &NetAddress) -> Result<Peer, PeerManagerError> {
-        self.peer_storage
-            .read()
-            .map_err(|_| PeerManagerError::PoisonedAccess)?
-            .find_with_net_address(net_address)
+    pub fn find_by_public_key(&self, public_key: &CommsPublicKey) -> Result<Peer, PeerManagerError> {
+        acquire_read_lock!(self.peer_storage).find_by_public_key(public_key)
     }
 
     /// Check if a peer exist using the specified public_key
-    pub fn exists(&self, public_key: &CommsPublicKey) -> Result<bool, PeerManagerError> {
-        Ok(self
-            .peer_storage
-            .read()
-            .map_err(|_| PeerManagerError::PoisonedAccess)?
-            .exists(public_key))
+    pub fn exists(&self, public_key: &CommsPublicKey) -> bool {
+        acquire_read_lock!(self.peer_storage).exists(public_key)
     }
 
     /// Check if a peer exist using the specified node_id
-    pub fn exists_node_id(&self, node_id: &NodeId) -> Result<bool, PeerManagerError> {
-        Ok(self
-            .peer_storage
-            .read()
-            .map_err(|_| PeerManagerError::PoisonedAccess)?
-            .exists_node_id(node_id))
+    pub fn exists_node_id(&self, node_id: &NodeId) -> bool {
+        acquire_read_lock!(self.peer_storage).exists_node_id(node_id)
     }
 
     /// Get a peer matching the given node ID
     pub fn direct_identity_node_id(&self, node_id: &NodeId) -> Result<PeerNodeIdentity, PeerManagerError> {
-        self.peer_storage
-            .read()
-            .map_err(|_| PeerManagerError::PoisonedAccess)?
-            .direct_identity_node_id(&node_id)
+        acquire_read_lock!(self.peer_storage).direct_identity_node_id(&node_id)
     }
 
     /// Get a peer matching the given public key
@@ -137,18 +111,12 @@ impl PeerManager {
         public_key: &CommsPublicKey,
     ) -> Result<PeerNodeIdentity, PeerManagerError>
     {
-        self.peer_storage
-            .read()
-            .map_err(|_| PeerManagerError::PoisonedAccess)?
-            .direct_identity_public_key(public_key)
+        acquire_read_lock!(self.peer_storage).direct_identity_public_key(public_key)
     }
 
     /// Fetch all peers (except banned ones)
     pub fn flood_identities(&self) -> Result<Vec<PeerNodeIdentity>, PeerManagerError> {
-        self.peer_storage
-            .read()
-            .map_err(|_| PeerManagerError::PoisonedAccess)?
-            .flood_identities()
+        acquire_read_lock!(self.peer_storage).flood_identities()
     }
 
     /// Fetch n nearest neighbour Communication Nodes
@@ -159,19 +127,13 @@ impl PeerManager {
         excluded_peers: &Vec<CommsPublicKey>,
     ) -> Result<Vec<PeerNodeIdentity>, PeerManagerError>
     {
-        self.peer_storage
-            .read()
-            .map_err(|_| PeerManagerError::PoisonedAccess)?
-            .closest_identities(node_id, n, excluded_peers)
+        acquire_read_lock!(self.peer_storage).closest_identities(node_id, n, excluded_peers)
     }
 
     /// Fetch n random identioties
     pub fn random_identities(&self, n: usize) -> Result<Vec<PeerNodeIdentity>, PeerManagerError> {
         // Send to a random set of peers of size n that are Communication Nodes
-        self.peer_storage
-            .write()
-            .map_err(|_| PeerManagerError::PoisonedAccess)?
-            .random_identities(n)
+        acquire_read_lock!(self.peer_storage).random_identities(n)
     }
 
     /// Check if a specific node_id is in the network region of the N nearest neighbours of the region specified by
@@ -183,35 +145,23 @@ impl PeerManager {
         n: usize,
     ) -> Result<bool, PeerManagerError>
     {
-        self.peer_storage
-            .read()
-            .map_err(|_| PeerManagerError::PoisonedAccess)?
-            .in_network_region(node_id, region_node_id, n)
+        acquire_read_lock!(self.peer_storage).in_network_region(node_id, region_node_id, n)
     }
 
     /// Thread safe access to peer - Changes the ban flag bit of the peer
     pub fn set_banned(&self, node_id: &NodeId, ban_flag: bool) -> Result<(), PeerManagerError> {
-        self.peer_storage
-            .write()
-            .map_err(|_| PeerManagerError::PoisonedAccess)?
-            .set_banned(node_id, ban_flag)
+        acquire_write_lock!(self.peer_storage).set_banned(node_id, ban_flag)
     }
 
     /// Thread safe access to peer - Adds a new net address to the peer if it doesn't yet exist
     pub fn add_net_address(&self, node_id: &NodeId, net_address: &NetAddress) -> Result<(), PeerManagerError> {
-        self.peer_storage
-            .write()
-            .map_err(|_| PeerManagerError::PoisonedAccess)?
-            .add_net_address(node_id, net_address)
+        acquire_write_lock!(self.peer_storage).add_net_address(node_id, net_address)
     }
 
     /// Thread safe access to peer - Finds and returns the highest priority net address until all connection attempts
     /// for each net address have been reached
     pub fn get_best_net_address(&self, node_id: &NodeId) -> Result<NetAddress, PeerManagerError> {
-        self.peer_storage
-            .write()
-            .map_err(|_| PeerManagerError::PoisonedAccess)?
-            .get_best_net_address(node_id)
+        acquire_write_lock!(self.peer_storage).get_best_net_address(node_id)
     }
 
     /// Thread safe access to peer - The average connection latency of the provided net address will be updated to
@@ -222,50 +172,32 @@ impl PeerManager {
         latency_measurement: Duration,
     ) -> Result<(), PeerManagerError>
     {
-        self.peer_storage
-            .write()
-            .map_err(|_| PeerManagerError::PoisonedAccess)?
-            .update_latency(net_address, latency_measurement)
+        acquire_write_lock!(self.peer_storage).update_latency(net_address, latency_measurement)
     }
 
     /// Thread safe access to peer - Mark that a message was received from the specified net address
     pub fn mark_message_received(&self, net_address: &NetAddress) -> Result<(), PeerManagerError> {
-        self.peer_storage
-            .write()
-            .map_err(|_| PeerManagerError::PoisonedAccess)?
-            .mark_message_received(net_address)
+        acquire_write_lock!(self.peer_storage).mark_message_received(net_address)
     }
 
     /// Thread safe access to peer - Mark that a rejected message was received from the specified net address
     pub fn mark_message_rejected(&self, net_address: &NetAddress) -> Result<(), PeerManagerError> {
-        self.peer_storage
-            .write()
-            .map_err(|_| PeerManagerError::PoisonedAccess)?
-            .mark_message_rejected(net_address)
+        acquire_write_lock!(self.peer_storage).mark_message_rejected(net_address)
     }
 
     /// Thread safe access to peer - Mark that a successful connection was established with the specified net address
     pub fn mark_successful_connection_attempt(&self, net_address: &NetAddress) -> Result<(), PeerManagerError> {
-        self.peer_storage
-            .write()
-            .map_err(|_| PeerManagerError::PoisonedAccess)?
-            .mark_successful_connection_attempt(net_address)
+        acquire_write_lock!(self.peer_storage).mark_successful_connection_attempt(net_address)
     }
 
     /// Thread safe access to peer - Mark that a connection could not be established with the specified net address
     pub fn mark_failed_connection_attempt(&self, net_address: &NetAddress) -> Result<(), PeerManagerError> {
-        self.peer_storage
-            .write()
-            .map_err(|_| PeerManagerError::PoisonedAccess)?
-            .mark_failed_connection_attempt(net_address)
+        acquire_write_lock!(self.peer_storage).mark_failed_connection_attempt(net_address)
     }
 
     /// Thread safe access to peer - Reset all connection attempts on all net addresses for peer
     pub fn reset_connection_attempts(&self, node_id: &NodeId) -> Result<(), PeerManagerError> {
-        self.peer_storage
-            .write()
-            .map_err(|_| PeerManagerError::PoisonedAccess)?
-            .reset_connection_attempts(node_id)
+        acquire_write_lock!(self.peer_storage).reset_connection_attempts(node_id)
     }
 }
 
@@ -329,7 +261,7 @@ mod test {
         for peer_identity in &identities {
             assert_eq!(
                 peer_manager
-                    .find_with_node_id(&peer_identity.node_id)
+                    .find_by_node_id(&peer_identity.node_id)
                     .unwrap()
                     .is_banned(),
                 false
@@ -446,7 +378,7 @@ mod test {
             .unwrap();
         assert_eq!(
             peer_manager
-                .find_with_node_id(&peer.node_id.clone())
+                .find_by_node_id(&peer.node_id.clone())
                 .unwrap()
                 .addresses
                 .addresses[0]
@@ -456,25 +388,12 @@ mod test {
         peer_manager.reset_connection_attempts(&peer.node_id.clone()).unwrap();
         assert_eq!(
             peer_manager
-                .find_with_node_id(&peer.node_id.clone())
+                .find_by_node_id(&peer.node_id.clone())
                 .unwrap()
                 .addresses
                 .addresses[0]
                 .connection_attempts,
             0
         );
-    }
-
-    #[test]
-    fn test_adding_and_searching_by_net_address() {
-        // Create peer manager with random peers
-        let peer_manager = PeerManager::new(HMapDatabase::new()).unwrap();
-        let mut rng = rand::OsRng::new().unwrap();
-        let peer = create_test_peer(&mut rng, false);
-        peer_manager.add_peer(peer.clone()).unwrap();
-        // Test NetAddress adding and searching
-        let net_address = NetAddress::from("1.2.3.4:7000".parse::<NetAddress>().unwrap());
-        assert!(peer_manager.add_net_address(&peer.node_id, &net_address).is_ok());
-        assert!(peer_manager.find_with_net_address(&net_address).is_ok());
     }
 }

--- a/comms/src/peer_manager/peer_query.rs
+++ b/comms/src/peer_manager/peer_query.rs
@@ -1,0 +1,358 @@
+// Copyright 2019, The Tari Project
+//
+// Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+// following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+// disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+// following disclaimer in the documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+// products derived from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+// INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+// WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+// USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+use crate::peer_manager::{peer_key::PeerKey, NodeId, Peer, PeerManagerError};
+use std::cmp::min;
+use tari_storage::{IterationResult, KeyValueStore};
+
+type Predicate<'a> = Box<dyn FnMut(&Peer) -> bool + 'a>;
+
+/// Sort options for `PeerQuery`
+#[derive(Debug, Clone)]
+pub enum PeerQuerySortBy<'a> {
+    /// No sorting
+    None,
+    /// Sort by distance from a given node id
+    DistanceFrom(&'a NodeId),
+}
+
+impl Default for PeerQuerySortBy<'_> {
+    fn default() -> Self {
+        PeerQuerySortBy::None
+    }
+}
+
+/// Represents a query which can be performed on the peer database
+#[derive(Default)]
+pub struct PeerQuery<'a> {
+    select_predicate: Option<Predicate<'a>>,
+    limit: Option<usize>,
+    sort_by: PeerQuerySortBy<'a>,
+}
+
+impl<'a> PeerQuery<'a> {
+    /// Create a new `PeerQuery`
+    pub fn new() -> Self {
+        Default::default()
+    }
+
+    /// Set the selection predicate. This predicate should return `true` to include a `Peer`
+    /// in the result set.
+    pub fn select_where<F>(mut self, select_predicate: F) -> Self
+    where F: FnMut(&Peer) -> bool + 'a {
+        self.select_predicate = Some(Box::new(select_predicate));
+        self
+    }
+
+    /// Set a limit on the number of results returned
+    pub fn limit(mut self, limit: usize) -> Self {
+        self.limit = Some(limit);
+        self
+    }
+
+    /// Sort by the given `PeerSortBy` criteria
+    pub fn sort_by(mut self, sort_by: PeerQuerySortBy<'a>) -> Self {
+        self.sort_by = sort_by;
+        self
+    }
+
+    /// Returns a `PeerQueryExecutor` with this `PeerQuery`
+    pub(super) fn executor<DS>(self, store: &DS) -> PeerQueryExecutor<'a, '_, DS>
+    where DS: KeyValueStore<PeerKey, Peer> {
+        PeerQueryExecutor::new(self, store)
+    }
+
+    /// Returns true if the given limit is within the specified limit. If the limit
+    /// was not specified, this always returns true
+    fn within_limit(&self, limit: usize) -> bool {
+        self.limit.map(|inner_limit| inner_limit > limit).unwrap_or(true)
+    }
+
+    /// Returns true if the specified select predicate returns true. If the
+    /// select predicate was not specified, this always returns true.
+    fn is_selected(&mut self, peer: &Peer) -> bool {
+        self.select_predicate
+            .as_mut()
+            .map(|predicate| (predicate)(peer))
+            .unwrap_or(true)
+    }
+}
+
+/// This struct executes the query using the given store
+pub(super) struct PeerQueryExecutor<'a, 'b, DS> {
+    query: PeerQuery<'a>,
+    store: &'b DS,
+}
+
+impl<'a, 'b, DS> PeerQueryExecutor<'a, 'b, DS>
+where DS: KeyValueStore<PeerKey, Peer>
+{
+    pub fn new(query: PeerQuery<'a>, store: &'b DS) -> Self {
+        Self { query, store }
+    }
+
+    pub fn get_results(&mut self) -> Result<Vec<Peer>, PeerManagerError> {
+        match self.query.sort_by {
+            PeerQuerySortBy::None => self.get_query_results(),
+            PeerQuerySortBy::DistanceFrom(node_id) => self.get_distance_sorted_results(node_id),
+        }
+    }
+
+    pub fn get_distance_sorted_results(&mut self, node_id: &NodeId) -> Result<Vec<Peer>, PeerManagerError> {
+        let mut peer_keys = Vec::new();
+        let mut distances = Vec::new();
+        self.store
+            .for_each_ok(|(peer_key, peer)| {
+                if self.query.is_selected(&peer) {
+                    peer_keys.push(peer_key);
+                    distances.push(node_id.distance(&peer.node_id));
+                }
+
+                IterationResult::Continue
+            })
+            .map_err(PeerManagerError::DatabaseError)?;
+
+        // Use all available peers up to a maximum of N
+        let max_available = self
+            .query
+            .limit
+            .map(|limit| min(peer_keys.len(), limit))
+            .unwrap_or(peer_keys.len());
+        if max_available == 0 {
+            return Ok(Vec::new());
+        }
+
+        // Perform partial sort of elements only up to N elements
+        let mut selected_peers = Vec::with_capacity(max_available);
+        for i in 0..max_available {
+            for j in (i + 1)..peer_keys.len() {
+                if distances[i] > distances[j] {
+                    distances.swap(i, j);
+                    peer_keys.swap(i, j);
+                }
+            }
+            let peer = self
+                .store
+                .get(&peer_keys[i])
+                .map_err(PeerManagerError::DatabaseError)?
+                .ok_or(PeerManagerError::PeerNotFoundError)?;
+
+            selected_peers.push(peer);
+        }
+
+        Ok(selected_peers)
+    }
+
+    pub fn get_query_results(&mut self) -> Result<Vec<Peer>, PeerManagerError> {
+        let mut selected_peers = match self.query.limit {
+            Some(n) => Vec::with_capacity(n),
+            None => Vec::new(),
+        };
+
+        self.store
+            .for_each_ok(|(_, peer)| {
+                if self.query.within_limit(selected_peers.len()) {
+                    if self.query.is_selected(&peer) {
+                        selected_peers.push(peer);
+                    }
+                } else {
+                    return IterationResult::Break;
+                }
+
+                IterationResult::Continue
+            })
+            .map_err(PeerManagerError::DatabaseError)?;
+
+        Ok(selected_peers)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::{
+        connection::net_address::{net_addresses::NetAddressesWithStats, NetAddress},
+        peer_manager::{
+            node_id::NodeId,
+            peer::{Peer, PeerFlags},
+            PeerFeatures,
+        },
+    };
+    use rand::OsRng;
+    use std::iter::repeat_with;
+    use tari_crypto::{keys::PublicKey, ristretto::RistrettoPublicKey};
+    use tari_storage::HMapDatabase;
+
+    fn create_test_peer(rng: &mut OsRng, ban_flag: bool) -> Peer {
+        let (_sk, pk) = RistrettoPublicKey::random_keypair(rng);
+        let node_id = NodeId::from_key(&pk).unwrap();
+        let net_addresses = NetAddressesWithStats::from("1.2.3.4:8000".parse::<NetAddress>().unwrap());
+        let mut peer = Peer::new(
+            pk,
+            node_id,
+            net_addresses,
+            PeerFlags::default(),
+            PeerFeatures::MESSAGE_PROPAGATION,
+        );
+        peer.set_banned(ban_flag);
+        peer
+    }
+
+    #[test]
+    fn limit_query() {
+        // Create peer manager with random peers
+        let mut sample_peers = Vec::new();
+        // Create 20 peers were the 1st and last one is bad
+        let mut rng = rand::OsRng::new().unwrap();
+        sample_peers.push(create_test_peer(&mut rng, true));
+        let db = HMapDatabase::new();
+        let mut id_counter = 0;
+
+        repeat_with(|| create_test_peer(&mut rng, false))
+            .take(5)
+            .for_each(|peer| {
+                db.insert(id_counter, peer).unwrap();
+                id_counter += 1;
+            });
+
+        let peers = PeerQuery::new().limit(4).executor(&db).get_results().unwrap();
+
+        assert_eq!(peers.len(), 4);
+    }
+
+    #[test]
+    fn select_where_query() {
+        // Create peer manager with random peers
+        let mut sample_peers = Vec::new();
+        // Create 20 peers were the 1st and last one is bad
+        let mut rng = rand::OsRng::new().unwrap();
+        sample_peers.push(create_test_peer(&mut rng, true));
+        let db = HMapDatabase::new();
+        let mut id_counter = 0;
+
+        repeat_with(|| create_test_peer(&mut rng, true))
+            .take(2)
+            .for_each(|peer| {
+                db.insert(id_counter, peer).unwrap();
+                id_counter += 1;
+            });
+
+        repeat_with(|| create_test_peer(&mut rng, false))
+            .take(5)
+            .for_each(|peer| {
+                db.insert(id_counter, peer).unwrap();
+                id_counter += 1;
+            });
+
+        let peers = PeerQuery::new()
+            .select_where(|peer| !peer.is_banned())
+            .executor(&db)
+            .get_results()
+            .unwrap();
+
+        assert_eq!(peers.len(), 5);
+        assert!(peers.iter().all(|peer| !peer.is_banned()));
+    }
+
+    #[test]
+    fn select_where_limit_query() {
+        // Create peer manager with random peers
+        let mut sample_peers = Vec::new();
+        // Create 20 peers were the 1st and last one is bad
+        let mut rng = rand::OsRng::new().unwrap();
+        sample_peers.push(create_test_peer(&mut rng, true));
+        let db = HMapDatabase::new();
+        let mut id_counter = 0;
+
+        repeat_with(|| create_test_peer(&mut rng, true))
+            .take(3)
+            .for_each(|peer| {
+                db.insert(id_counter, peer).unwrap();
+                id_counter += 1;
+            });
+
+        repeat_with(|| create_test_peer(&mut rng, false))
+            .take(5)
+            .for_each(|peer| {
+                db.insert(id_counter, peer).unwrap();
+                id_counter += 1;
+            });
+
+        let peers = PeerQuery::new()
+            .select_where(|peer| peer.is_banned())
+            .limit(2)
+            .executor(&db)
+            .get_results()
+            .unwrap();
+
+        assert_eq!(peers.len(), 2);
+        assert!(peers.iter().all(|peer| peer.is_banned()));
+    }
+
+    #[test]
+    fn sort_by_query() {
+        // Create peer manager with random peers
+        let mut sample_peers = Vec::new();
+        // Create 20 peers were the 1st and last one is bad
+        let mut rng = rand::OsRng::new().unwrap();
+        sample_peers.push(create_test_peer(&mut rng, true));
+        let db = HMapDatabase::new();
+        let mut id_counter = 0;
+
+        repeat_with(|| create_test_peer(&mut rng, true))
+            .take(3)
+            .for_each(|peer| {
+                db.insert(id_counter, peer).unwrap();
+                id_counter += 1;
+            });
+
+        repeat_with(|| create_test_peer(&mut rng, false))
+            .take(5)
+            .for_each(|peer| {
+                db.insert(id_counter, peer).unwrap();
+                id_counter += 1;
+            });
+
+        let node_id = NodeId::default();
+
+        let peers = PeerQuery::new()
+            .sort_by(PeerQuerySortBy::DistanceFrom(&node_id))
+            .limit(2)
+            .executor(&db)
+            .get_results()
+            .unwrap();
+
+        assert_eq!(peers.len(), 2);
+
+        db.for_each_ok(|(_, current_peer)| {
+            // Exclude selected peers
+            if !peers.contains(&current_peer) {
+                // Every selected peer's distance from node_id is less than every other peer's distance from node_id
+                for selected_peer in &peers {
+                    assert!(selected_peer.node_id.distance(&node_id) <= current_peer.node_id.distance(&node_id));
+                }
+            }
+            IterationResult::Continue
+        })
+        .unwrap();
+    }
+}

--- a/comms/tests/connection_manager/manager.rs
+++ b/comms/tests/connection_manager/manager.rs
@@ -127,7 +127,7 @@ fn establish_peer_connection() {
     let node_A_connection_manager_cloned = node_A_connection_manager.clone();
     let handle1 = thread::spawn(move || -> Result<(), String> {
         let to_node_B_conn = node_A_connection_manager_cloned
-            .establish_connection_to_peer(&node_B_peer)
+            .establish_connection_to_node_id(&node_B_peer.node_id)
             .map_err(|err| format!("{:?}", err))?;
         to_node_B_conn.set_linger(Linger::Indefinitely).unwrap();
         to_node_B_conn
@@ -139,7 +139,7 @@ fn establish_peer_connection() {
     let node_A_connection_manager_cloned = node_A_connection_manager.clone();
     let handle2 = thread::spawn(move || -> Result<(), String> {
         let to_node_B_conn = node_A_connection_manager_cloned
-            .establish_connection_to_peer(&node_B_peer_copy)
+            .establish_connection_to_node_id(&node_B_peer_copy.node_id)
             .map_err(|err| format!("{:?}", err))?;
         to_node_B_conn.set_linger(Linger::Indefinitely).unwrap();
         to_node_B_conn

--- a/comms/tests/control_service/service.rs
+++ b/comms/tests/control_service/service.rs
@@ -137,7 +137,7 @@ fn request_connection() {
         .unwrap();
 
     let peer = peer_manager
-        .find_with_public_key(&node_identity_b.identity.public_key)
+        .find_by_public_key(&node_identity_b.identity.public_key)
         .unwrap();
     assert_eq!(peer.public_key, node_identity_b.identity.public_key);
     assert_eq!(peer.node_id, node_identity_b.identity.node_id);

--- a/comms/tests/support/factories/peer.rs
+++ b/comms/tests/support/factories/peer.rs
@@ -93,6 +93,7 @@ impl TestFactory for PeerFactory {
             public_key,
             addresses: addresses.into(),
             features: self.peer_features,
+            connection_stats: Default::default(),
         })
     }
 }


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
- Peer manager has `perform_query` method (example below)
- Added basic peer connection stats to `Peer`, this determines
  eligibility for connection at the broadcast strategy level
- Queries sorted by Distance require searching through entire peer database.
  However, this is no different from the existing `closest_identities` function.

```rust
let query = PeerQuery::new()
  .select_where(|peer| !peer.is_banned())
  .sort_by(PeerQuerySortBy::DistanceFrom(&node_id))
  .limit(10);

let selected_peers = peer_manager.perform_query(query)?;
```

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #951 
Ref #928 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Unit tests 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [x] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [x] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch
* [x] I ran `cargo-fmt --all` before pushing
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
