### PR TITLE
 Add incoming block stream to BaseNodeService

### DIFF
--- a/base_layer/core/src/base_node/base_node.rs
+++ b/base_layer/core/src/base_node/base_node.rs
@@ -71,8 +71,9 @@ impl<B: BlockchainBackend> BaseNodeStateMachine<B> {
             (Listening(_), FallenBehind(BehindHorizon(h))) => FetchingHorizonState(HorizonInfo::new(h)),
             (Listening(s), FallenBehind(Lagging(_))) => BlockSync(s.into()),
             (_, FatalError(s)) => Shutdown(states::Shutdown::with_reason(s)),
+            (_, UserQuit) => Shutdown(states::Shutdown::with_reason("Shutdown initiated by user".to_string())),
             (s, e) => {
-                debug!(
+                warn!(
                     target: LOG_TARGET,
                     "No state transition occurs for event {:?} in state {}", e, s
                 );

--- a/base_layer/core/src/base_node/states/mod.rs
+++ b/base_layer/core/src/base_node/states/mod.rs
@@ -126,6 +126,7 @@ pub enum StateEvent {
     BlocksSynchronized,
     FallenBehind(SyncStatus),
     FatalError(String),
+    UserQuit,
 }
 
 /// Some state transition functions must return `SyncStatus`. The sync status indicates how far behind the network's

--- a/base_layer/p2p/src/domain_message.rs
+++ b/base_layer/p2p/src/domain_message.rs
@@ -20,6 +20,7 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+use std::convert::{From, TryFrom};
 use tari_comms::{peer_manager::Peer, types::CommsPublicKey};
 
 /// Wrapper around a received message. Provides source peer and origin information
@@ -41,5 +42,35 @@ impl<T> DomainMessage<T> {
 
     pub fn into_inner(self) -> T {
         self.inner
+    }
+
+    /// Converts the wrapped value of a DomainMessage to another compatible type.
+    ///
+    /// Note:
+    /// The Rust compiler doesn't seem to be able to recognise that DomainMessage<T> != DomainMessage<U>, so a blanket
+    /// `From` implementation isn't possible at this time
+    pub fn convert<U>(self) -> DomainMessage<U>
+    where U: From<T> {
+        let inner = U::from(self.inner);
+        DomainMessage {
+            origin_pubkey: self.origin_pubkey,
+            source_peer: self.source_peer,
+            inner,
+        }
+    }
+
+    /// Converts the wrapped value of a DomainMessage to another compatible type.
+    ///
+    /// Note:
+    /// The Rust compiler doesn't seem to be able to recognise that DomainMessage<T> != DomainMessage<U>, so a blanket
+    /// `From` implementation isn't possible at this time
+    pub fn try_convert<U>(self) -> Result<DomainMessage<U>, U::Error>
+    where U: TryFrom<T> {
+        let inner = U::try_from(self.inner)?;
+        Ok(DomainMessage {
+            origin_pubkey: self.origin_pubkey,
+            source_peer: self.source_peer,
+            inner,
+        })
     }
 }


### PR DESCRIPTION
Added a `inbound_block_stream` to BaseNodeService.

As part of this process, the PeerMessage gets stripped and converted into a `DomainMessage<Block>` object. If any errors occur, the block is dropped and a message is logged. In future, we can add an event stream to blacklist peers that repeatedly send us invalid blocks.

I also moved the streams into a separate struct to avoid all the  `Option<S>` overhead. Though it seems that you have to call  `.fuse()` and `pin_mut` in the same function as the `select!` macro, so I'm not sure how much neater this approach is.
