### PR TITLE
Extract and restore MMR state

### DIFF
--- a/base_layer/core/src/base_node/states/mod.rs
+++ b/base_layer/core/src/base_node/states/mod.rs
@@ -20,28 +20,6 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-// Copyright 2019. The Tari Project
-//
-// Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
-// following conditions are met:
-//
-// 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
-// disclaimer.
-//
-// 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
-// following disclaimer in the documentation and/or other materials provided with the distribution.
-//
-// 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
-// products derived from this software without specific prior written permission.
-//
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
-// INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
-// WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
-// USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
 use std::fmt::{Display, Error, Formatter};
 
 /// The base node state represents the FSM of the base node synchronisation process.

--- a/base_layer/core/src/chain_storage/lmdb_db/lmdb.rs
+++ b/base_layer/core/src/chain_storage/lmdb_db/lmdb.rs
@@ -146,3 +146,9 @@ where
     }
     Ok(())
 }
+
+pub fn lmdb_clear_db(txn: &WriteTransaction, db: &Database) -> Result<(), ChainStorageError> {
+    txn.access()
+        .clear_db(&db)
+        .map_err(|e| ChainStorageError::AccessError(e.to_string()))
+}

--- a/base_layer/core/src/chain_storage/lmdb_db/lmdb_db.rs
+++ b/base_layer/core/src/chain_storage/lmdb_db/lmdb_db.rs
@@ -54,7 +54,14 @@ use std::{
     path::Path,
     sync::{Arc, RwLock},
 };
-use tari_mmr::{Hash as MmrHash, MerkleChangeTracker, MerkleCheckPoint, MerkleProof, MutableMmr};
+use tari_mmr::{
+    Hash as MmrHash,
+    MerkleChangeTracker,
+    MerkleChangeTrackerConfig,
+    MerkleCheckPoint,
+    MerkleProof,
+    MutableMmr,
+};
 use tari_storage::lmdb_store::{db, LMDBBuilder, LMDBStore};
 use tari_transactions::{
     transaction::{TransactionKernel, TransactionOutput},
@@ -151,6 +158,11 @@ where D: Digest + Send + Sync
                 .db()
                 .clone(),
         );
+        let mct_config = MerkleChangeTrackerConfig {
+            // TODO: this needs a proper config for lmdb_db
+            min_history_len: 900,
+            max_history_len: 1000,
+        };
         Ok(Self {
             metadata_db: store
                 .get_handle(LMDB_DB_METADATA)
@@ -195,18 +207,22 @@ where D: Digest + Send + Sync
             utxo_mmr: RwLock::new(MerkleChangeTracker::new(
                 MutableMmr::new(utxo_mmr_base_backend),
                 utxo_mmr_cp_backend,
+                mct_config,
             )?),
             header_mmr: RwLock::new(MerkleChangeTracker::new(
                 MutableMmr::new(header_mmr_base_backend),
                 header_mmr_cp_backend,
+                mct_config,
             )?),
             kernel_mmr: RwLock::new(MerkleChangeTracker::new(
                 MutableMmr::new(kernel_mmr_base_backend),
                 kernel_mmr_cp_backend,
+                mct_config,
             )?),
             range_proof_mmr: RwLock::new(MerkleChangeTracker::new(
                 MutableMmr::new(range_proof_mmr_base_backend),
                 range_proof_mmr_cp_backend,
+                mct_config,
             )?),
             env: store.env(),
         })

--- a/base_layer/core/src/chain_storage/memory_db.rs
+++ b/base_layer/core/src/chain_storage/memory_db.rs
@@ -44,7 +44,14 @@ use std::{
     collections::HashMap,
     sync::{Arc, RwLock, RwLockReadGuard, RwLockWriteGuard},
 };
-use tari_mmr::{Hash as MmrHash, MerkleChangeTracker, MerkleCheckPoint, MerkleProof, MutableMmr};
+use tari_mmr::{
+    Hash as MmrHash,
+    MerkleChangeTracker,
+    MerkleChangeTrackerConfig,
+    MerkleCheckPoint,
+    MerkleProof,
+    MutableMmr,
+};
 use tari_transactions::{
     transaction::{TransactionKernel, TransactionOutput},
     types::HashOutput,
@@ -341,10 +348,19 @@ impl<D> Default for InnerDatabase<D>
 where D: Digest
 {
     fn default() -> Self {
-        let utxo_mmr = MerkleChangeTracker::<D, _, _>::new(MutableMmr::new(Vec::new()), Vec::new()).unwrap();
-        let header_mmr = MerkleChangeTracker::<D, _, _>::new(MutableMmr::new(Vec::new()), Vec::new()).unwrap();
-        let kernel_mmr = MerkleChangeTracker::<D, _, _>::new(MutableMmr::new(Vec::new()), Vec::new()).unwrap();
-        let range_proof_mmr = MerkleChangeTracker::<D, _, _>::new(MutableMmr::new(Vec::new()), Vec::new()).unwrap();
+        let mct_config = MerkleChangeTrackerConfig {
+            // TODO: this needs a proper config for memory_db
+            min_history_len: 900,
+            max_history_len: 1000,
+        };
+        let utxo_mmr =
+            MerkleChangeTracker::<D, _, _>::new(MutableMmr::new(Vec::new()), Vec::new(), mct_config).unwrap();
+        let header_mmr =
+            MerkleChangeTracker::<D, _, _>::new(MutableMmr::new(Vec::new()), Vec::new(), mct_config).unwrap();
+        let kernel_mmr =
+            MerkleChangeTracker::<D, _, _>::new(MutableMmr::new(Vec::new()), Vec::new(), mct_config).unwrap();
+        let range_proof_mmr =
+            MerkleChangeTracker::<D, _, _>::new(MutableMmr::new(Vec::new()), Vec::new(), mct_config).unwrap();
         InnerDatabase {
             headers: HashMap::default(),
             block_hashes: HashMap::default(),

--- a/base_layer/mmr/src/backend.rs
+++ b/base_layer/mmr/src/backend.rs
@@ -21,6 +21,7 @@
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 use crate::error::MerkleMountainRangeError;
+use std::cmp::min;
 
 /// A trait describing generic array-like behaviour, without imposing any specific details on how this is actually done.
 pub trait ArrayLike {
@@ -39,6 +40,9 @@ pub trait ArrayLike {
     /// Return the item at the given index. Use this if you *know* that the index is valid. Requesting a hash for an
     /// invalid index may cause the a panic
     fn get_or_panic(&self, index: usize) -> Self::Value;
+
+    /// Remove all stored items from the the backend.
+    fn clear(&mut self) -> Result<(), Self::Error>;
 }
 
 pub trait ArrayLikeExt {
@@ -46,6 +50,9 @@ pub trait ArrayLikeExt {
 
     /// Shortens the array, keeping the first len elements and dropping the rest.
     fn truncate(&mut self, _len: usize) -> Result<(), MerkleMountainRangeError>;
+
+    /// Shift the array, by discarding the first n elements from the front.
+    fn shift(&mut self, n: usize) -> Result<(), MerkleMountainRangeError>;
 
     /// Execute the given closure for each value in the array
     fn for_each<F>(&self, f: F) -> Result<(), MerkleMountainRangeError>
@@ -72,6 +79,11 @@ impl<T: Clone> ArrayLike for Vec<T> {
     fn get_or_panic(&self, index: usize) -> Self::Value {
         self[index].clone()
     }
+
+    fn clear(&mut self) -> Result<(), Self::Error> {
+        Vec::clear(self);
+        Ok(())
+    }
 }
 
 impl<T: Clone> ArrayLikeExt for Vec<T> {
@@ -79,6 +91,12 @@ impl<T: Clone> ArrayLikeExt for Vec<T> {
 
     fn truncate(&mut self, len: usize) -> Result<(), MerkleMountainRangeError> {
         self.truncate(len);
+        Ok(())
+    }
+
+    fn shift(&mut self, n: usize) -> Result<(), MerkleMountainRangeError> {
+        let drain_n = min(n, self.len());
+        self.drain(0..drain_n);
         Ok(())
     }
 

--- a/base_layer/mmr/src/error.rs
+++ b/base_layer/mmr/src/error.rs
@@ -38,4 +38,6 @@ pub enum MerkleMountainRangeError {
     HashNotFound(usize),
     // A request was out of range
     OutOfRange,
+    // Conflicting or invalid configuration parameters provided.
+    InvalidConfig,
 }

--- a/base_layer/mmr/src/lib.rs
+++ b/base_layer/mmr/src/lib.rs
@@ -140,6 +140,7 @@ mod change_tracker;
 mod merkle_mountain_range;
 mod merkle_proof;
 mod mutable_mmr;
+mod mutable_mmr_leaf_nodes;
 mod serde_support;
 
 // Less commonly used exports
@@ -153,10 +154,12 @@ pub mod pruned_mmr;
 /// A vector-based backend for [MerkleMountainRange]
 pub use backend::{ArrayLike, ArrayLikeExt};
 /// A data structure that maintains a list of diffs on an MMR, enabling you to rewind to a previous state
-pub use change_tracker::{MerkleChangeTracker, MerkleCheckPoint};
+pub use change_tracker::{MerkleChangeTracker, MerkleChangeTrackerConfig, MerkleCheckPoint};
 /// An immutable, append-only Merkle Mountain range (MMR) data structure
 pub use merkle_mountain_range::MerkleMountainRange;
 /// A data structure for proving a hash inclusion in an MMR
 pub use merkle_proof::{MerkleProof, MerkleProofError};
 /// An append-only Merkle Mountain range (MMR) data structure that allows deletion of existing leaf nodes.
 pub use mutable_mmr::MutableMmr;
+/// A data structure for storing all the data required to restore the state of an MMR.
+pub use mutable_mmr_leaf_nodes::MutableMmrLeafNodes;

--- a/base_layer/mmr/src/mutable_mmr_leaf_nodes.rs
+++ b/base_layer/mmr/src/mutable_mmr_leaf_nodes.rs
@@ -1,0 +1,146 @@
+// Copyright 2019. The Tari Project
+//
+// Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+// following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+// disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+// following disclaimer in the documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+// products derived from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+// INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+// WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+// USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+use crate::Hash;
+use croaring::Bitmap;
+use serde::{
+    de::{self, Deserialize, Deserializer, MapAccess, SeqAccess, Visitor},
+    ser::{Serialize, SerializeStruct, Serializer},
+};
+use std::fmt;
+
+/// The MutableMmrLeafNodes is used to create and share a restorable state for an MMR.
+#[derive(Debug, Clone, PartialEq)]
+pub struct MutableMmrLeafNodes {
+    pub leaf_hashes: Vec<Hash>,
+    pub deleted: Bitmap,
+}
+
+impl MutableMmrLeafNodes {
+    /// Create a new MutableMmrLeafNodes using the set of leaf hashes and deleted nodes.
+    pub fn new(leaf_hashes: Vec<Hash>, deleted: Bitmap) -> Self {
+        Self { leaf_hashes, deleted }
+    }
+
+    /// Merge the current state with the next state bundle
+    pub fn combine(&mut self, next_state: MutableMmrLeafNodes) {
+        let MutableMmrLeafNodes {
+            mut leaf_hashes,
+            deleted,
+        } = next_state;
+        self.leaf_hashes.append(&mut leaf_hashes);
+        self.deleted.or_inplace(&deleted);
+    }
+}
+
+impl Serialize for MutableMmrLeafNodes {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where S: Serializer {
+        let mut state = serializer.serialize_struct("MutableMmrLeafNodes", 2)?;
+        state.serialize_field("leaf_hashes", &self.leaf_hashes)?;
+        state.serialize_field("deleted", &self.deleted.serialize())?;
+        state.end()
+    }
+}
+
+impl<'de> Deserialize<'de> for MutableMmrLeafNodes {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where D: Deserializer<'de> {
+        enum Field {
+            LeafHashes,
+            Deleted,
+        };
+
+        impl<'de> Deserialize<'de> for Field {
+            fn deserialize<D>(deserializer: D) -> Result<Field, D::Error>
+            where D: Deserializer<'de> {
+                struct FieldVisitor;
+
+                impl<'de> Visitor<'de> for FieldVisitor {
+                    type Value = Field;
+
+                    fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+                        formatter.write_str("`leaf_hashes` or `deleted`")
+                    }
+
+                    fn visit_str<E>(self, value: &str) -> Result<Field, E>
+                    where E: de::Error {
+                        match value {
+                            "leaf_hashes" => Ok(Field::LeafHashes),
+                            "deleted" => Ok(Field::Deleted),
+                            _ => Err(de::Error::unknown_field(value, FIELDS)),
+                        }
+                    }
+                }
+
+                deserializer.deserialize_identifier(FieldVisitor)
+            }
+        }
+
+        struct MutableMmrLeafNodesVisitor;
+
+        impl<'de> Visitor<'de> for MutableMmrLeafNodesVisitor {
+            type Value = MutableMmrLeafNodes;
+
+            fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+                formatter.write_str("struct MutableMmrLeafNodes")
+            }
+
+            fn visit_seq<V>(self, mut seq: V) -> Result<MutableMmrLeafNodes, V::Error>
+            where V: SeqAccess<'de> {
+                let leaf_hashes = seq.next_element()?.ok_or_else(|| de::Error::invalid_length(0, &self))?;
+                let deleted_buf: Vec<u8> = seq.next_element()?.ok_or_else(|| de::Error::invalid_length(1, &self))?;
+                let deleted: Bitmap = Bitmap::deserialize(&deleted_buf);
+                Ok(MutableMmrLeafNodes::new(leaf_hashes, deleted))
+            }
+
+            fn visit_map<V>(self, mut map: V) -> Result<MutableMmrLeafNodes, V::Error>
+            where V: MapAccess<'de> {
+                let mut leaf_hashes = None;
+                let mut deleted = None;
+                while let Some(key) = map.next_key()? {
+                    match key {
+                        Field::LeafHashes => {
+                            if leaf_hashes.is_some() {
+                                return Err(de::Error::duplicate_field("nodes_added"));
+                            }
+                            leaf_hashes = Some(map.next_value()?);
+                        },
+                        Field::Deleted => {
+                            if deleted.is_some() {
+                                return Err(de::Error::duplicate_field("nodes_deleted"));
+                            }
+                            let deleted_buf: Vec<u8> = map.next_value()?;
+                            deleted = Some(Bitmap::deserialize(&deleted_buf));
+                        },
+                    }
+                }
+                let leaf_hashes = leaf_hashes.ok_or_else(|| de::Error::missing_field("leaf_hashes"))?;
+                let deleted = deleted.ok_or_else(|| de::Error::missing_field("deleted"))?;
+                Ok(MutableMmrLeafNodes::new(leaf_hashes, deleted))
+            }
+        }
+
+        const FIELDS: &[&str] = &["leaf_hashes", "deleted"];
+        deserializer.deserialize_struct("MutableMmrLeafNodes", FIELDS, MutableMmrLeafNodesVisitor)
+    }
+}

--- a/base_layer/mmr/src/pruned_hashset.rs
+++ b/base_layer/mmr/src/pruned_hashset.rs
@@ -102,4 +102,12 @@ impl ArrayLike for PrunedHashSet {
             .expect("PrunedHashSet only tracks peaks before the offset")
             .clone()
     }
+
+    fn clear(&mut self) -> Result<(), Self::Error> {
+        self.base_offset = 0;
+        self.peak_indices.clear();
+        self.peak_hashes.clear();
+        self.hashes.clear();
+        Ok(())
+    }
 }


### PR DESCRIPTION
## Description
- Added the ability to change the configuration for the MerkleChangeTracker, this allows the minimum and maximum checkpoint history to be set.
- Added functionality to allow the base MMR of the MerkleChangeTracker to be updated using the oldest checkpoints when the maximum checkpoint history is reached.
- Added the ability to retrieve the leaf hashes from MerkleMountainRange and restore it using leaf hashes.
- The state of MutableMmr and MerkleChangeTracker can be retrieved and used to restore their previous states.
- CompactMmrState was introduced to extract a restorable state for the MerkleChangeTracker and MutableMmr. It also allows state parts to be retrieved and combined to form the full state.
- Added clear to ArrayLike trait and shift to ArrayLikeExt and provided implementations for these functions for LMDBVec and for Vec<T>, this was required to better manage checkpoints and enable the restore functionality.

## Motivation and Context
These changes are required to enable sharing of MMR state between Base Nodes.

## How Has This Been Tested?
Tests were added to test the construction and restoring from MMR states and demonstrate the updating of the base MMR of the MerkleChangeTracker.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [x] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch
* [x] I ran `cargo-fmt --all` before pushing
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
