### PR TITLE
Refactor peer manager/node identity + bug fix #959

### DIFF
--- a/applications/tari_base_node/src/main.rs
+++ b/applications/tari_base_node/src/main.rs
@@ -97,7 +97,7 @@ fn main() {
                     info!(
                         target: LOG_TARGET,
                         "New node identity [{}] with public key {} has been created.",
-                        id.identity.node_id.to_hex(),
+                        id.node_id().to_hex(),
                         id.public_key().to_hex()
                     );
                     id

--- a/base_layer/core/src/base_node/test/service.rs
+++ b/base_layer/core/src/base_node/test/service.rs
@@ -98,12 +98,11 @@ where
 
     for p in peers {
         let addr = p.control_service_address();
-        let NodeIdentity { identity, .. } = p;
         comms
             .peer_manager()
             .add_peer(Peer::new(
-                identity.public_key,
-                identity.node_id,
+                p.public_key().clone(),
+                p.node_id().clone(),
                 addr.into(),
                 PeerFlags::empty(),
                 PeerFeatures::empty(),

--- a/base_layer/p2p/examples/pingpong.rs
+++ b/base_layer/p2p/examples/pingpong.rs
@@ -146,8 +146,8 @@ fn main() {
     let (comms, dht) = initialize_comms(rt.executor(), comms_config, publisher).unwrap();
 
     let peer = Peer::new(
-        peer_identity.identity.public_key.clone(),
-        peer_identity.identity.node_id.clone(),
+        peer_identity.public_key().clone(),
+        peer_identity.node_id().clone(),
         peer_identity.control_service_address().into(),
         PeerFlags::empty(),
         peer_identity.features().clone(),
@@ -185,7 +185,7 @@ fn main() {
     });
 
     let ui_update_signal = app.cb_sink().clone();
-    let pk_to_ping = peer_identity.identity.public_key.clone();
+    let pk_to_ping = peer_identity.public_key().clone();
     rt.spawn(send_ping_on_trigger(
         send_ping_rx.fuse(),
         ui_update_signal,

--- a/base_layer/p2p/src/test_utils.rs
+++ b/base_layer/p2p/src/test_utils.rs
@@ -63,8 +63,8 @@ pub fn make_dht_header(node_identity: &NodeIdentity, message: &Vec<u8>, flags: D
     DhtMessageHeader {
         version: 0,
         destination: NodeDestination::Unknown,
-        origin_public_key: node_identity.identity.public_key.clone(),
-        origin_signature: signature::sign(&mut OsRng::new().unwrap(), node_identity.secret_key.clone(), message)
+        origin_public_key: node_identity.public_key().clone(),
+        origin_signature: signature::sign(&mut OsRng::new().unwrap(), node_identity.secret_key().clone(), message)
             .unwrap()
             .to_binary()
             .unwrap(),
@@ -82,8 +82,8 @@ pub fn make_dht_inbound_message(
     DhtInboundMessage::new(
         make_dht_header(node_identity, &message, flags),
         Peer::new(
-            node_identity.identity.public_key.clone(),
-            node_identity.identity.node_id.clone(),
+            node_identity.public_key().clone(),
+            node_identity.node_id().clone(),
             Vec::<NetAddress>::new().into(),
             PeerFlags::empty(),
             PeerFeatures::COMMUNICATION_NODE,

--- a/base_layer/p2p/tests/services/liveness.rs
+++ b/base_layer/p2p/tests/services/liveness.rs
@@ -94,7 +94,7 @@ fn end_to_end() {
 
     for _ in 0..5 {
         let _ = runtime
-            .block_on(liveness2.send_ping(node_1_identity.identity.public_key.clone()))
+            .block_on(liveness2.send_ping(node_1_identity.public_key().clone()))
             .unwrap();
         pingpong1_total = (pingpong1_total.0 + 1, pingpong1_total.1);
         pingpong2_total = (pingpong2_total.0, pingpong2_total.1 + 1);
@@ -102,7 +102,7 @@ fn end_to_end() {
 
     for _ in 0..4 {
         let _ = runtime
-            .block_on(liveness1.send_ping(node_2_identity.identity.public_key.clone()))
+            .block_on(liveness1.send_ping(node_2_identity.public_key().clone()))
             .unwrap();
         pingpong2_total = (pingpong2_total.0 + 1, pingpong2_total.1);
         pingpong1_total = (pingpong1_total.0, pingpong1_total.1 + 1);
@@ -110,7 +110,7 @@ fn end_to_end() {
 
     for _ in 0..5 {
         let _ = runtime
-            .block_on(liveness2.send_ping(node_1_identity.identity.public_key.clone()))
+            .block_on(liveness2.send_ping(node_1_identity.public_key().clone()))
             .unwrap();
         pingpong1_total = (pingpong1_total.0 + 1, pingpong1_total.1);
         pingpong2_total = (pingpong2_total.0, pingpong2_total.1 + 1);
@@ -118,7 +118,7 @@ fn end_to_end() {
 
     for _ in 0..4 {
         let _ = runtime
-            .block_on(liveness1.send_ping(node_2_identity.identity.public_key.clone()))
+            .block_on(liveness1.send_ping(node_2_identity.public_key().clone()))
             .unwrap();
         pingpong2_total = (pingpong2_total.0 + 1, pingpong2_total.1);
         pingpong1_total = (pingpong1_total.0, pingpong1_total.1 + 1);

--- a/base_layer/p2p/tests/support/comms_and_services.rs
+++ b/base_layer/p2p/tests/support/comms_and_services.rs
@@ -77,11 +77,11 @@ where
         comms
             .peer_manager()
             .add_peer(Peer::new(
-                p.identity.public_key,
-                p.identity.node_id,
+                p.public_key().clone(),
+                p.node_id().clone(),
                 addr.into(),
                 PeerFlags::default(),
-                p.identity.features,
+                p.features().clone(),
             ))
             .unwrap();
     }

--- a/base_layer/wallet/tests/support/comms_and_services.rs
+++ b/base_layer/wallet/tests/support/comms_and_services.rs
@@ -77,12 +77,11 @@ where
 
     for p in peers {
         let addr = p.control_service_address();
-        let NodeIdentity { identity, .. } = p;
         comms
             .peer_manager()
             .add_peer(Peer::new(
-                identity.public_key,
-                identity.node_id,
+                p.public_key().clone(),
+                p.node_id().clone(),
                 addr.into(),
                 PeerFlags::empty(),
                 PeerFeatures::empty(),

--- a/base_layer/wallet/tests/transaction_service/mod.rs
+++ b/base_layer/wallet/tests/transaction_service/mod.rs
@@ -221,21 +221,13 @@ fn manage_single_transaction() {
     let (_utxo, uo1) = make_input(&mut rng, MicroTari(2500));
 
     assert!(runtime
-        .block_on(alice_ts.send_transaction(
-            bob_node_identity.identity.public_key.clone(),
-            value,
-            MicroTari::from(20),
-        ))
+        .block_on(alice_ts.send_transaction(bob_node_identity.public_key().clone(), value, MicroTari::from(20),))
         .is_err());
 
     runtime.block_on(alice_oms.add_output(uo1)).unwrap();
 
     runtime
-        .block_on(alice_ts.send_transaction(
-            bob_node_identity.identity.public_key.clone(),
-            value,
-            MicroTari::from(20),
-        ))
+        .block_on(alice_ts.send_transaction(bob_node_identity.public_key().clone(), value, MicroTari::from(20)))
         .unwrap();
     let alice_pending_outbound = runtime.block_on(alice_ts.get_pending_outbound_transactions()).unwrap();
     let alice_completed_tx = runtime.block_on(alice_ts.get_completed_transactions()).unwrap();
@@ -331,14 +323,14 @@ fn manage_multiple_transactions() {
     let value_a_to_c_1 = MicroTari::from(1400);
     runtime
         .block_on(alice_ts.send_transaction(
-            bob_node_identity.identity.public_key.clone(),
+            bob_node_identity.public_key().clone(),
             value_a_to_b_1,
             MicroTari::from(20),
         ))
         .unwrap();
     runtime
         .block_on(alice_ts.send_transaction(
-            carol_node_identity.identity.public_key.clone(),
+            carol_node_identity.public_key().clone(),
             value_a_to_c_1,
             MicroTari::from(20),
         ))
@@ -365,14 +357,14 @@ fn manage_multiple_transactions() {
 
     runtime
         .block_on(bob_ts.send_transaction(
-            alice_node_identity.identity.public_key.clone(),
+            alice_node_identity.public_key().clone(),
             value_b_to_a_1,
             MicroTari::from(20),
         ))
         .unwrap();
     runtime
         .block_on(alice_ts.send_transaction(
-            bob_node_identity.identity.public_key.clone(),
+            bob_node_identity.public_key().clone(),
             value_a_to_b_2,
             MicroTari::from(20),
         ))
@@ -467,7 +459,7 @@ fn test_accepting_unknown_tx_id_and_malformed_reply() {
         futures::join!(
             alice_outbound_service.handle_next(Duration::from_millis(3000), 0),
             alice_ts.send_transaction(
-                bob_node_identity.identity.public_key.clone(),
+                bob_node_identity.public_key().clone(),
                 MicroTari::from(500),
                 MicroTari::from(1000),
             ),

--- a/base_layer/wallet/tests/wallet/mod.rs
+++ b/base_layer/wallet/tests/wallet/mod.rs
@@ -112,7 +112,7 @@ fn test_wallet() {
     let config1 = WalletConfig {
         comms_config: comms_config1,
         output_manager_config: OutputManagerConfig {
-            master_key: Some(alice_identity.secret_key.clone()),
+            master_key: Some(alice_identity.secret_key().clone()),
             seed_words: None,
             branch_seed: "".to_string(),
             primary_key_index: 0,
@@ -121,7 +121,7 @@ fn test_wallet() {
     let config2 = WalletConfig {
         comms_config: comms_config2,
         output_manager_config: OutputManagerConfig {
-            master_key: Some(bob_identity.secret_key.clone()),
+            master_key: Some(bob_identity.secret_key().clone()),
             seed_words: None,
             branch_seed: "".to_string(),
             primary_key_index: 0,
@@ -136,7 +136,7 @@ fn test_wallet() {
         .comms
         .peer_manager()
         .add_peer(create_peer(
-            bob_identity.identity.public_key.clone(),
+            bob_identity.public_key().clone(),
             bob_identity.control_service_address(),
         ))
         .unwrap();
@@ -145,7 +145,7 @@ fn test_wallet() {
         .comms
         .peer_manager()
         .add_peer(create_peer(
-            alice_identity.identity.public_key.clone(),
+            alice_identity.public_key().clone(),
             alice_identity.control_service_address(),
         ))
         .unwrap();
@@ -154,7 +154,7 @@ fn test_wallet() {
         .block_on(
             alice_wallet
                 .liveness_service
-                .send_ping(bob_identity.identity.public_key.clone()),
+                .send_ping(bob_identity.public_key().clone()),
         )
         .unwrap();
 
@@ -162,7 +162,7 @@ fn test_wallet() {
         .block_on(
             bob_wallet
                 .liveness_service
-                .send_ping(alice_identity.identity.public_key.clone()),
+                .send_ping(alice_identity.public_key().clone()),
         )
         .unwrap();
 
@@ -198,7 +198,7 @@ fn test_wallet() {
 
     runtime
         .block_on(alice_wallet.transaction_service.send_transaction(
-            bob_identity.identity.public_key.clone(),
+            bob_identity.public_key().clone(),
             value,
             MicroTari::from(20),
         ))

--- a/comms/dht/src/actor.rs
+++ b/comms/dht/src/actor.rs
@@ -258,7 +258,7 @@ impl DhtActor {
 
     async fn send_join(&mut self) -> Result<(), DhtOutboundError> {
         let message = JoinMessage {
-            node_id: self.node_identity.identity.node_id.to_vec(),
+            node_id: self.node_identity.node_id().to_vec(),
             addresses: vec![self.node_identity.control_service_address().to_string()],
             peer_features: self.node_identity.features().bits(),
         };
@@ -272,7 +272,7 @@ impl DhtActor {
             .send_dht_message(
                 BroadcastStrategy::Closest(Box::new(BroadcastClosestRequest {
                     n: self.config.num_neighbouring_nodes,
-                    node_id: self.node_identity.identity.node_id.clone(),
+                    node_id: self.node_identity.node_id().clone(),
                     excluded_peers: Vec::new(),
                 })),
                 NodeDestination::Unknown,
@@ -293,7 +293,7 @@ impl DhtActor {
     ) -> Result<(), DhtOutboundError>
     {
         let discover_msg = DiscoverMessage {
-            node_id: self.node_identity.identity.node_id.to_vec(),
+            node_id: self.node_identity.node_id().to_vec(),
             addresses: vec![self.node_identity.control_service_address().to_string()],
             peer_features: self.node_identity.features().bits(),
         };

--- a/comms/dht/src/dht.rs
+++ b/comms/dht/src/dht.rs
@@ -318,7 +318,7 @@ mod test {
 
         let msg = wrap_in_envelope_body!(b"secret".to_vec()).unwrap();
         // Encrypt for self
-        let ecdh_key = generate_ecdh_secret(&node_identity.secret_key, &node_identity.identity.public_key);
+        let ecdh_key = generate_ecdh_secret(node_identity.secret_key(), node_identity.public_key());
         let encrypted_bytes = encrypt(&ecdh_key, &msg.to_encoded_bytes().unwrap()).unwrap();
         let dht_envelope = make_dht_envelope(&node_identity, encrypted_bytes, DhtMessageFlags::ENCRYPTED);
         let inbound_message = make_comms_inbound_message(
@@ -365,7 +365,7 @@ mod test {
 
         // Encrypt for someone else
         let node_identity2 = make_node_identity();
-        let ecdh_key = generate_ecdh_secret(&node_identity2.secret_key, &node_identity2.identity.public_key);
+        let ecdh_key = generate_ecdh_secret(node_identity2.secret_key(), node_identity2.public_key());
         let encrypted_bytes = encrypt(&ecdh_key, &msg.to_encoded_bytes().unwrap()).unwrap();
         let dht_envelope = make_dht_envelope(&node_identity, encrypted_bytes, DhtMessageFlags::ENCRYPTED);
         let inbound_message = make_comms_inbound_message(

--- a/comms/dht/src/inbound/decryption.rs
+++ b/comms/dht/src/inbound/decryption.rs
@@ -105,7 +105,7 @@ where
         }
 
         debug!(target: LOG_TARGET, "Attempting to decrypt message");
-        let shared_secret = crypt::generate_ecdh_secret(&node_identity.secret_key, &dht_header.origin_public_key);
+        let shared_secret = crypt::generate_ecdh_secret(node_identity.secret_key(), &dht_header.origin_public_key);
         match crypt::decrypt(&shared_secret, &message.body) {
             Ok(decrypted) => Self::decryption_succeeded(next_service, message, decrypted).await,
             Err(err) => {
@@ -221,7 +221,7 @@ mod test {
         let mut service = DecryptionService::new(inner, Arc::clone(&node_identity));
 
         let plain_text_msg = wrap_in_envelope_body!(Vec::new()).unwrap();
-        let secret_key = crypt::generate_ecdh_secret(&node_identity.secret_key, &node_identity.identity.public_key);
+        let secret_key = crypt::generate_ecdh_secret(node_identity.secret_key(), node_identity.public_key());
         let encrypted = crypt::encrypt(&secret_key, &plain_text_msg.to_encoded_bytes().unwrap()).unwrap();
         let inbound_msg = make_dht_inbound_message(&node_identity, encrypted, DhtMessageFlags::ENCRYPTED);
 

--- a/comms/dht/src/inbound/dht_handler/task.rs
+++ b/comms/dht/src/inbound/dht_handler/task.rs
@@ -192,7 +192,7 @@ where
         if source_peer.public_key != origin_peer.public_key &&
             self.peer_manager.in_network_region(
                 &origin_peer.node_id,
-                &self.node_identity.identity.node_id,
+                self.node_identity.node_id(),
                 self.config.num_neighbouring_nodes,
             )?
         {
@@ -267,7 +267,7 @@ where
     /// Send a network join update request directly to a specific known peer
     async fn send_join_direct(&mut self, dest_public_key: CommsPublicKey) -> Result<(), DhtInboundError> {
         let join_msg = JoinMessage {
-            node_id: self.node_identity.identity.node_id.to_vec(),
+            node_id: self.node_identity.node_id().to_vec(),
             addresses: vec![self.node_identity.control_service_address().to_string()],
             peer_features: self.node_identity.features().bits(),
         };

--- a/comms/dht/src/outbound/message.rs
+++ b/comms/dht/src/outbound/message.rs
@@ -27,7 +27,7 @@ use crate::{
 };
 use futures::channel::oneshot;
 use std::fmt;
-use tari_comms::{message::MessageFlags, peer_manager::PeerNodeIdentity, types::CommsPublicKey};
+use tari_comms::{message::MessageFlags, peer_manager::Peer, types::CommsPublicKey};
 
 /// Determines if an outbound message should be Encrypted and, if so, for which public key
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -110,7 +110,7 @@ impl fmt::Display for DhtOutboundRequest {
 /// send a message
 #[derive(Clone, Debug)]
 pub struct DhtOutboundMessage {
-    pub peer_node_identity: PeerNodeIdentity,
+    pub destination_peer: Peer,
     pub dht_header: DhtMessageHeader,
     pub comms_flags: MessageFlags,
     pub encryption: OutboundEncryption,
@@ -120,7 +120,7 @@ pub struct DhtOutboundMessage {
 impl DhtOutboundMessage {
     /// Create a new DhtOutboundMessage
     pub fn new(
-        peer_node_identity: PeerNodeIdentity,
+        destination_peer: Peer,
         dht_header: DhtMessageHeader,
         encryption: OutboundEncryption,
         comms_flags: MessageFlags,
@@ -128,7 +128,7 @@ impl DhtOutboundMessage {
     ) -> Self
     {
         Self {
-            peer_node_identity,
+            destination_peer,
             dht_header,
             encryption,
             comms_flags,

--- a/comms/dht/src/store_forward/saf_handler/task.rs
+++ b/comms/dht/src/store_forward/saf_handler/task.rs
@@ -135,7 +135,7 @@ where S: Service<DecryptedDhtMessage, Response = (), Error = MiddlewareError>
 
         if !self.peer_manager.in_network_region(
             &message.source_peer.node_id,
-            &self.node_identity.identity.node_id,
+            self.node_identity.node_id(),
             self.config.saf_num_closest_nodes,
         )? {
             debug!(
@@ -398,7 +398,7 @@ where S: Service<DecryptedDhtMessage, Response = (), Error = MiddlewareError>
         encrypted_body: &[u8],
     ) -> Result<EnvelopeBody, StoreAndForwardError>
     {
-        let shared_secret = crypt::generate_ecdh_secret(&node_identity.secret_key, &dht_header.origin_public_key);
+        let shared_secret = crypt::generate_ecdh_secret(node_identity.secret_key(), &dht_header.origin_public_key);
         let decrypted_bytes = crypt::decrypt(&shared_secret, encrypted_body)?;
         EnvelopeBody::decode(&decrypted_bytes).map_err(|_| StoreAndForwardError::DecryptionFailed)
     }
@@ -509,7 +509,7 @@ mod test {
 
             let node_identity = make_node_identity();
 
-            let shared_key = crypt::generate_ecdh_secret(&node_identity.secret_key, node_identity.public_key());
+            let shared_key = crypt::generate_ecdh_secret(node_identity.secret_key(), node_identity.public_key());
             let msg_a = crypt::encrypt(
                 &shared_key,
                 &wrap_in_envelope_body!(&b"A".to_vec())

--- a/comms/dht/src/store_forward/store.rs
+++ b/comms/dht/src/store_forward/store.rs
@@ -215,7 +215,7 @@ where
                 if (peer_manager.exists_node_id(&dest_node_id)) |
                     (peer_manager.in_network_region(
                         &dest_node_id,
-                        &node_identity.identity.node_id,
+                        node_identity.node_id(),
                         self.config.num_neighbouring_nodes,
                     )?)
                 {

--- a/comms/dht/src/test_utils/makers.rs
+++ b/comms/dht/src/test_utils/makers.rs
@@ -68,14 +68,14 @@ pub fn make_comms_inbound_message(
 {
     InboundMessage::new(
         Peer::new(
-            node_identity.identity.public_key.clone(),
-            node_identity.identity.node_id.clone(),
+            node_identity.public_key().clone(),
+            node_identity.node_id().clone(),
             Vec::<NetAddress>::new().into(),
             PeerFlags::empty(),
             PeerFeatures::COMMUNICATION_NODE,
         ),
         MessageEnvelopeHeader {
-            public_key: node_identity.identity.public_key.clone(),
+            public_key: node_identity.public_key().clone(),
             signature: Vec::new(),
             flags,
         },
@@ -88,7 +88,7 @@ pub fn make_dht_header(node_identity: &NodeIdentity, message: &Vec<u8>, flags: D
         version: 0,
         destination: NodeDestination::Unknown,
         origin_public_key: node_identity.public_key().clone(),
-        origin_signature: signature::sign(&mut OsRng::new().unwrap(), node_identity.secret_key.clone(), message)
+        origin_signature: signature::sign(&mut OsRng::new().unwrap(), node_identity.secret_key().clone(), message)
             .unwrap()
             .to_binary()
             .unwrap(),
@@ -106,8 +106,8 @@ pub fn make_dht_inbound_message(
     DhtInboundMessage::new(
         make_dht_header(node_identity, &body, flags),
         Peer::new(
-            node_identity.identity.public_key.clone(),
-            node_identity.identity.node_id.clone(),
+            node_identity.public_key().clone(),
+            node_identity.node_id().clone(),
             Vec::<NetAddress>::new().into(),
             PeerFlags::empty(),
             PeerFeatures::COMMUNICATION_NODE,

--- a/comms/dht/tests/dht.rs
+++ b/comms/dht/tests/dht.rs
@@ -263,11 +263,7 @@ fn dht_discover_propagation() {
             // request back to A.
             node_A_dht
                 .dht_requester()
-                .send_discover(
-                    node_D_identity.identity.public_key.clone(),
-                    None,
-                    NodeDestination::Unknown,
-                )
+                .send_discover(node_D_identity.public_key().clone(), None, NodeDestination::Unknown)
                 .await
                 .unwrap();
 

--- a/comms/src/connection_manager/protocol.rs
+++ b/comms/src/connection_manager/protocol.rs
@@ -62,7 +62,7 @@ impl<'e, 'ni> PeerConnectionProtocol<'e, 'ni> {
         control_client
             .send_request_connection(
                 self.node_identity.control_service_address(),
-                self.node_identity.identity.node_id.clone(),
+                self.node_identity.node_id().clone(),
                 self.node_identity.features().clone(),
             )
             .map_err(|err| ConnectionManagerError::SendRequestConnectionFailed(format!("{:?}", err)))?;

--- a/comms/src/control_service/client.rs
+++ b/comms/src/control_service/client.rs
@@ -212,10 +212,7 @@ mod test {
         let envelope = client.construct_envelope(MessageType::Ping, PingMessage {}).unwrap();
 
         let header = envelope.header.unwrap();
-        assert_eq!(
-            header.get_comms_public_key().unwrap(),
-            node_identity.identity.public_key
-        );
+        assert_eq!(&header.get_comms_public_key().unwrap(), node_identity.public_key());
         assert_eq!(header.flags, MessageFlags::ENCRYPTED.bits());
     }
 }

--- a/comms/src/control_service/worker.rs
+++ b/comms/src/control_service/worker.rs
@@ -432,7 +432,7 @@ impl ControlServiceWorker {
     }
 
     fn should_reject_collision(&self, node_id: &NodeId) -> bool {
-        &self.node_identity.identity.node_id < node_id
+        self.node_identity.node_id() < node_id
     }
 
     fn reject_connection(
@@ -530,7 +530,7 @@ impl ControlServiceWorker {
     }
 
     fn decrypt_body(&self, body: &Vec<u8>, public_key: &CommsPublicKey) -> Result<Vec<u8>> {
-        let ecdh_shared_secret = crypt::generate_ecdh_secret(&self.node_identity.secret_key, public_key);
+        let ecdh_shared_secret = crypt::generate_ecdh_secret(self.node_identity.secret_key(), public_key);
         crypt::decrypt(&ecdh_shared_secret, &body).map_err(ControlServiceError::CipherError)
     }
 

--- a/comms/src/outbound_message_service/service.rs
+++ b/comms/src/outbound_message_service/service.rs
@@ -385,7 +385,7 @@ where TMsgStream: Stream<Item = OutboundMessage> + Unpin
     async fn send_message(&self, conn: &PeerConnection, message: OutboundMessage) -> Result<(), OutboundServiceError> {
         let OutboundMessage { flags, body, .. } = message;
         let envelope = Envelope::construct_signed(
-            &self.node_identity.secret_key,
+            self.node_identity.secret_key(),
             self.node_identity.public_key(),
             body,
             flags,

--- a/comms/src/peer_manager/mod.rs
+++ b/comms/src/peer_manager/mod.rs
@@ -75,7 +75,7 @@ pub mod peer_storage;
 pub use self::{
     error::PeerManagerError,
     node_id::NodeId,
-    node_identity::{NodeIdentity, PeerNodeIdentity},
+    node_identity::NodeIdentity,
     peer::{Peer, PeerFlags},
     peer_features::PeerFeatures,
     peer_manager::PeerManager,

--- a/comms/src/peer_manager/node_identity.rs
+++ b/comms/src/peer_manager/node_identity.rs
@@ -54,8 +54,12 @@ pub enum NodeIdentityError {
 /// `control_service_address`: The NetAddress of the local node's Control port
 #[derive(Serialize, Deserialize)]
 pub struct NodeIdentity {
-    pub identity: PeerNodeIdentity,
-    pub secret_key: CommsSecretKey,
+    #[serde(serialize_with = "serialize_to_hex")]
+    #[serde(deserialize_with = "deserialize_node_id_from_hex")]
+    node_id: NodeId,
+    public_key: CommsPublicKey,
+    features: PeerFeatures,
+    secret_key: CommsSecretKey,
     control_service_address: RwLock<NetAddress>,
 }
 
@@ -71,7 +75,9 @@ impl NodeIdentity {
         let node_id = NodeId::from_key(&public_key).map_err(NodeIdentityError::NodeIdError)?;
 
         Ok(NodeIdentity {
-            identity: PeerNodeIdentity::new(node_id, public_key, features),
+            node_id,
+            public_key,
+            features,
             secret_key,
             control_service_address: RwLock::new(control_service_address),
         })
@@ -91,7 +97,9 @@ impl NodeIdentity {
         let node_id = NodeId::from_key(&public_key).map_err(NodeIdentityError::NodeIdError)?;
 
         Ok(NodeIdentity {
-            identity: PeerNodeIdentity::new(node_id, public_key, features),
+            node_id,
+            public_key,
+            features,
             secret_key,
             control_service_address: RwLock::new(control_service_address),
         })
@@ -124,22 +132,27 @@ impl NodeIdentity {
         .unwrap()
     }
 
+    #[inline]
     pub fn node_id(&self) -> &NodeId {
-        &self.identity.node_id
+        &self.node_id
     }
 
+    #[inline]
     pub fn public_key(&self) -> &CommsPublicKey {
-        &self.identity.public_key
+        &self.public_key
     }
 
+    #[inline]
     pub fn secret_key(&self) -> &CommsSecretKey {
         &self.secret_key
     }
 
+    #[inline]
     pub fn features(&self) -> &PeerFeatures {
-        &self.identity.features
+        &self.features
     }
 
+    #[inline]
     pub fn has_peer_features(&self, peer_features: PeerFeatures) -> bool {
         self.features().contains(peer_features)
     }
@@ -148,11 +161,11 @@ impl NodeIdentity {
 impl From<NodeIdentity> for Peer {
     fn from(node_identity: NodeIdentity) -> Peer {
         Peer::new(
-            node_identity.identity.public_key,
-            node_identity.identity.node_id,
+            node_identity.public_key,
+            node_identity.node_id,
             node_identity.control_service_address.read().unwrap().clone().into(),
             PeerFlags::empty(),
-            node_identity.identity.features,
+            node_identity.features,
         )
     }
 }
@@ -160,42 +173,11 @@ impl From<NodeIdentity> for Peer {
 impl Clone for NodeIdentity {
     fn clone(&self) -> Self {
         Self {
-            identity: self.identity.clone(),
+            node_id: self.node_id.clone(),
+            public_key: self.public_key.clone(),
+            features: self.features.clone(),
             secret_key: self.secret_key.clone(),
             control_service_address: RwLock::new(self.control_service_address()),
-        }
-    }
-}
-
-/// The PeerNodeIdentity is a container that stores the public identity (NodeId, Identification Public Key pair) of a
-/// single node
-#[derive(Eq, PartialEq, Debug, Serialize, Deserialize, Clone)]
-pub struct PeerNodeIdentity {
-    #[serde(serialize_with = "serialize_to_hex")]
-    #[serde(deserialize_with = "deserialize_node_id_from_hex")]
-    pub node_id: NodeId,
-    pub public_key: CommsPublicKey,
-    pub features: PeerFeatures,
-}
-
-impl PeerNodeIdentity {
-    /// Construct a new identity for a node that contains its NodeId and identification key pair
-    pub fn new(node_id: NodeId, public_key: CommsPublicKey, features: PeerFeatures) -> PeerNodeIdentity {
-        PeerNodeIdentity {
-            node_id,
-            public_key,
-            features,
-        }
-    }
-}
-
-/// Construct a PeerNodeIdentity from a Peer
-impl From<Peer> for PeerNodeIdentity {
-    fn from(peer: Peer) -> Self {
-        Self {
-            public_key: peer.public_key,
-            node_id: peer.node_id,
-            features: peer.features,
         }
     }
 }

--- a/comms/tests/connection_manager/actor.rs
+++ b/comms/tests/connection_manager/actor.rs
@@ -68,8 +68,8 @@ fn with_alice_and_bob(cb: impl FnOnce(CommsTestNode, CommsTestNode)) {
 
     let bob_peer = factories::peer::create()
         .with_net_addresses(vec![bob_control_port_address.clone()])
-        .with_public_key(bob_identity.identity.public_key.clone())
-        .with_node_id(bob_identity.identity.node_id.clone())
+        .with_public_key(bob_identity.public_key().clone())
+        .with_node_id(bob_identity.node_id().clone())
         .build()
         .unwrap();
 
@@ -138,8 +138,8 @@ fn with_alice_and_bob(cb: impl FnOnce(CommsTestNode, CommsTestNode)) {
 
     let alice_peer = factories::peer::create()
         .with_net_addresses(vec![alice_control_port_address])
-        .with_public_key(alice_identity.identity.public_key.clone())
-        .with_node_id(alice_identity.identity.node_id.clone())
+        .with_public_key(alice_identity.public_key().clone())
+        .with_node_id(alice_identity.node_id().clone())
         .build()
         .unwrap();
 
@@ -191,7 +191,7 @@ fn establish_connection_simple() {
         rt.spawn(service.start());
 
         let conn = rt
-            .block_on(requester.dial_node(bob.node_identity.identity.node_id.clone()))
+            .block_on(requester.dial_node(bob.node_identity.node_id().clone()))
             .unwrap();
 
         assert!(conn.is_active());
@@ -220,8 +220,8 @@ fn establish_connection_simultaneous_connect() {
         bob.peer_manager.add_peer(alice.peer.clone()).unwrap();
         rt.spawn(service.start());
 
-        let alice_node_id = alice.node_identity.identity.node_id.clone();
-        let bob_node_id = bob.node_identity.identity.node_id.clone();
+        let alice_node_id = alice.node_identity.node_id().clone();
+        let bob_node_id = bob.node_identity.node_id().clone();
 
         let mut attempt_count = 0;
         loop {

--- a/comms/tests/connection_manager/establisher.rs
+++ b/comms/tests/connection_manager/establisher.rs
@@ -136,7 +136,7 @@ fn establish_control_service_connection_succeed() {
     let node_identity2 = factories::node_identity::create().build().map(Arc::new).unwrap();
 
     let example_peer = factories::peer::create()
-        .with_public_key(node_identity2.identity.public_key.clone())
+        .with_public_key(node_identity2.public_key().clone())
         .with_net_addresses(vec![address])
         .build()
         .unwrap();

--- a/comms/tests/connection_manager/manager.rs
+++ b/comms/tests/connection_manager/manager.rs
@@ -60,7 +60,7 @@ fn establish_peer_connection() {
 
     let node_B_peer = factories::peer::create()
         .with_net_addresses(vec![node_B_control_port_address.clone()])
-        .with_public_key(node_B_identity.identity.public_key.clone())
+        .with_public_key(node_B_identity.public_key().clone())
         .build()
         .unwrap();
 

--- a/comms/tests/control_service/client.rs
+++ b/comms/tests/control_service/client.rs
@@ -44,14 +44,14 @@ fn send_ping_recv_pong() {
 
     let out_client = ControlServiceClient::new(
         node_identity_1.clone(),
-        node_identity_2.identity.public_key.clone(),
+        node_identity_2.public_key().clone(),
         outbound_conn,
     );
     out_client.send_ping().unwrap();
 
     let in_client = ControlServiceClient::new(
         node_identity_2.clone(),
-        node_identity_1.identity.public_key.clone(),
+        node_identity_1.public_key().clone(),
         inbound_conn,
     );
 

--- a/comms/tests/control_service/service.rs
+++ b/comms/tests/control_service/service.rs
@@ -119,7 +119,7 @@ fn request_connection() {
         .unwrap();
     let client = ControlServiceClient::new(
         Arc::clone(&node_identity_b),
-        node_identity_a.identity.public_key.clone(),
+        node_identity_a.public_key().clone(),
         client_conn,
     );
 
@@ -127,7 +127,7 @@ fn request_connection() {
     client
         .send_request_connection(
             node_identity_b.control_service_address(),
-            NodeId::from_key(&node_identity_b.identity.public_key).unwrap(),
+            NodeId::from_key(node_identity_b.public_key()).unwrap(),
             node_identity_b.features().clone(),
         )
         .unwrap();
@@ -136,11 +136,9 @@ fn request_connection() {
         .unwrap()
         .unwrap();
 
-    let peer = peer_manager
-        .find_by_public_key(&node_identity_b.identity.public_key)
-        .unwrap();
-    assert_eq!(peer.public_key, node_identity_b.identity.public_key);
-    assert_eq!(peer.node_id, node_identity_b.identity.node_id);
+    let peer = peer_manager.find_by_public_key(node_identity_b.public_key()).unwrap();
+    assert_eq!(&peer.public_key, node_identity_b.public_key());
+    assert_eq!(&peer.node_id, node_identity_b.node_id());
     assert_eq!(peer.addresses[0], node_identity_b.control_service_address().into());
     assert_eq!(peer.flags, PeerFlags::empty());
     assert_eq!(peer.features, PeerFeatures::COMMUNICATION_NODE);
@@ -193,7 +191,7 @@ fn ping_pong() {
         .unwrap();
     let client = ControlServiceClient::new(
         Arc::clone(&node_identity),
-        node_identity.identity.public_key.clone(),
+        node_identity.public_key().clone(),
         client_conn,
     );
 

--- a/comms/tests/inbound_message_service/mod.rs
+++ b/comms/tests/inbound_message_service/mod.rs
@@ -63,8 +63,8 @@ fn smoke_test() {
     let node_identity = factories::node_identity::create().build().map(Arc::new).unwrap();
 
     let peer = Peer::new(
-        node_identity.identity.public_key.clone(),
-        node_identity.identity.node_id.clone(),
+        node_identity.public_key().clone(),
+        node_identity.node_id().clone(),
         "127.0.0.1:9000".parse::<NetAddress>().unwrap().into(),
         PeerFlags::empty(),
         PeerFeatures::empty(),

--- a/comms/tests/outbound_message_service/service.rs
+++ b/comms/tests/outbound_message_service/service.rs
@@ -107,7 +107,7 @@ fn outbound_message_pool_no_retry() {
     let node_B_peer = factories::peer::create()
         .with_net_addresses(vec![node_B_control_port_address.clone()])
         // Set node B's secret key to be the same as node A's so that we can generate the same shared secret
-        .with_public_key(node_identity.identity.public_key.clone())
+        .with_public_key(node_identity.public_key().clone())
         .build()
         .unwrap();
 
@@ -234,7 +234,7 @@ fn test_outbound_message_pool_fail_and_retry() {
     let node_B_peer = factories::peer::create()
         .with_net_addresses(vec![node_B_control_port_address.clone()])
         // Set node B's secret key to be the same as node A's so that we can generate the same shared secret
-        .with_public_key(node_B_identity.identity.public_key.clone())
+        .with_public_key(node_B_identity.public_key().clone())
         .build()
         .unwrap();
 


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
- When a peer is not found using the Direct broadcast strategy, the
  outbound requester will now return `0` instead of a channel closed
  error (Fixes #959)
- Removed redundant `PeerNodeIdentity`
- Consistent usage of `NodeIdentity` (private fields, use getters only)


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #959 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Existing tests updated

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [x] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch
* [x] I ran `cargo-fmt --all` before pushing
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
