### PR TITLE
Latency is recorded for neighbouring peers

### DIFF
--- a/applications/tari_base_node/src/builder.rs
+++ b/applications/tari_base_node/src/builder.rs
@@ -109,7 +109,7 @@ pub fn load_identity(path: &Path, _control_addr: &str) -> Result<NodeIdentity, S
     Ok(id)
 }
 
-fn new_node_id(pk: PrivateKey, control_addr: &str) -> Result<NodeIdentity, String> {
+fn new_node_id(private_key: PrivateKey, control_addr: &str) -> Result<NodeIdentity, String> {
     let address = control_addr.parse::<NetAddress>().map_err(|e| {
         format!(
             "Error. '{}' is not a valid control port address. {}",
@@ -117,9 +117,8 @@ fn new_node_id(pk: PrivateKey, control_addr: &str) -> Result<NodeIdentity, Strin
             e.to_string()
         )
     })?;
-    let pubkey = PublicKey::from_secret_key(&pk);
     let features = PeerFeatures::COMMUNICATION_NODE;
-    NodeIdentity::new(pk, address, features)
+    NodeIdentity::new(private_key, address, features)
         .map_err(|e| format!("We were unable to construct a node identity. {}", e.to_string()))
 }
 

--- a/base_layer/core/src/base_node/service/service.rs
+++ b/base_layer/core/src/base_node/service/service.rs
@@ -57,9 +57,10 @@ use std::{
     time::{Duration, Instant},
 };
 use tari_comms_dht::{
+    broadcast_strategy::BroadcastStrategy,
     domain_message::OutboundDomainMessage,
     envelope::NodeDestination,
-    outbound::{BroadcastStrategy, OutboundEncryption, OutboundMessageRequester},
+    outbound::{OutboundEncryption, OutboundMessageRequester},
 };
 use tari_p2p::{domain_message::DomainMessage, tari_message::TariMessageType};
 use tari_service_framework::RequestContext;
@@ -259,9 +260,8 @@ where B: BlockchainBackend
         };
 
         self.outbound_message_service
-            .send_message(
-                BroadcastStrategy::DirectPublicKey(origin_pubkey.clone()),
-                NodeDestination::PublicKey(origin_pubkey),
+            .send_direct(
+                origin_pubkey,
                 OutboundEncryption::EncryptForDestination,
                 OutboundDomainMessage::new(TariMessageType::BaseNodeResponse, message),
             )

--- a/base_layer/p2p/examples/sample_identities/node-identity1.json
+++ b/base_layer/p2p/examples/sample_identities/node-identity1.json
@@ -1,9 +1,11 @@
 {
-  "identity": {
-    "node_id": "0576e03322318da01da557f9f6c7e2b1fb03258c78445c39560cf2ed35a5161a",
-    "public_key": "fa128780ce287262af8d81d7db2b76314457ea2d07d506e40a2c35c9c5dc5f54",
-    "features": {"bits": 3}
+  "node_id": "9bc05c37b5e2af2fda98e99e768d5426cecf83b9f5692d6a4f3c12b6ffe5c58a",
+  "public_key": "d6f64db85ccd90407f20930dadba37f09ca776c334c16d4d48f984de114e7a63",
+  "features": {
+    "bits": 3
   },
-  "secret_key": "faed11687e53de44e0cc89ea095712363cc9a036524e3079143db1c6ca339b01",
-  "control_service_address": {"IP": "127.0.0.1:38345"}
+  "secret_key": "c644dadfc2a3bf7c5872342b94748809f5c6c490bfcc01903f303507a1cc640c",
+  "control_service_address": {
+    "IP": "127.0.0.1:64187"
+  }
 }

--- a/base_layer/p2p/examples/sample_identities/node-identity2.json
+++ b/base_layer/p2p/examples/sample_identities/node-identity2.json
@@ -1,11 +1,11 @@
 {
-  "identity": {
-    "node_id": "995507dd9bb03df702dacd1d221d6aa660f3aa94f216124f1d7de1d82c6877cf",
-    "public_key": "30e1dfa197794858bfdbf96cdce5dc8637d4bd1202dc694991040ddecbf42d40",
-    "features": {"bits": 3}
+  "node_id": "5436412624c4dad30ff8f19ad1c7dc32713c2b5e2337f9c0259a23c3217ddc9a",
+  "public_key": "58bd7cf3ca2b6bcc45f2cc951d513518e5af63876d6c7acca9b4865bc752f32d",
+  "features": {
+    "bits": 3
   },
-  "secret_key": "6259c39f75e27140a652a5ee8aefb3cf6c1686ef21d27793338d899380e8c801",
+  "secret_key": "15c593a986a3de8cb31faef237f80f95831f87a73ef53244f8b49001fa5eba09",
   "control_service_address": {
-    "IP": "127.0.0.1:49296"
+    "IP": "127.0.0.1:27058"
   }
 }

--- a/base_layer/p2p/src/lib.rs
+++ b/base_layer/p2p/src/lib.rs
@@ -26,6 +26,13 @@
 // Tracking issue: https://github.com/rust-lang/rust/issues/63063
 #![feature(type_alias_impl_trait)]
 
+use rand::rngs::OsRng;
+use std::cell::RefCell;
+
+thread_local! {
+    pub(crate) static THREAD_RNG: RefCell<OsRng> = RefCell::new(OsRng::new().expect("OsRng failed"));
+}
+
 #[cfg(test)]
 #[macro_use]
 mod test_utils;

--- a/base_layer/p2p/src/proto/liveness.rs
+++ b/base_layer/p2p/src/proto/liveness.rs
@@ -20,7 +20,7 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use tari_comms_dht::include_proto_package;
+use tari_utilities::include_proto_package;
 
 include_proto_package!("tari.p2p.liveness");
 

--- a/base_layer/p2p/src/services/liveness/config.rs
+++ b/base_layer/p2p/src/services/liveness/config.rs
@@ -27,12 +27,18 @@ use std::time::Duration;
 pub struct LivenessConfig {
     /// The interval to send Ping messages, or None to disable periodic pinging (default: None (disabled))
     pub auto_ping_interval: Option<Duration>,
+    /// Set to true to enable automatically joining the network on node startup (default: true)
+    pub enable_auto_join: bool,
+    /// Set to true to enable a request for stored messages on node startup (default: true)
+    pub enable_auto_stored_message_request: bool,
 }
 
 impl Default for LivenessConfig {
     fn default() -> Self {
         Self {
             auto_ping_interval: None,
+            enable_auto_join: true,
+            enable_auto_stored_message_request: true,
         }
     }
 }

--- a/base_layer/p2p/src/services/liveness/error.rs
+++ b/base_layer/p2p/src/services/liveness/error.rs
@@ -22,12 +22,13 @@
 
 use derive_error::Error;
 use tari_comms::message::MessageError;
-use tari_comms_dht::outbound::DhtOutboundError;
+use tari_comms_dht::{outbound::DhtOutboundError, DhtActorError};
 use tari_service_framework::reply_channel::TransportChannelError;
 
 #[derive(Debug, Error)]
 pub enum LivenessError {
     DhtOutboundError(DhtOutboundError),
+    DhtActorError(DhtActorError),
     /// Failed to send a pong message
     SendPongFailed,
     /// Failed to send a ping message

--- a/base_layer/p2p/tests/support/utils.rs
+++ b/base_layer/p2p/tests/support/utils.rs
@@ -22,7 +22,6 @@
 
 use futures::{select, stream::FusedStream, FutureExt, Stream, StreamExt};
 use std::{
-    collections::HashMap,
     hash::Hash,
     time::{Duration, Instant},
 };
@@ -30,18 +29,17 @@ use std::{
 /// This method will read the specified number of items from a stream and assemble a HashMap with the received item as a
 /// key and the number of occurences as a value. If the stream does not yield the desired number of items the function
 /// will return what it is has received
-pub async fn event_stream_count<TStream, I>(mut stream: TStream, num_items: usize, timeout: Duration) -> HashMap<I, u32>
+pub async fn event_stream_count<TStream, I>(mut stream: TStream, num_items: usize, timeout: Duration) -> Vec<I>
 where
     TStream: Stream<Item = I> + FusedStream + Unpin,
     I: Hash + Eq + Clone,
 {
-    let mut result = HashMap::new();
+    let mut result = Vec::new();
     let mut count = 0;
     loop {
         select! {
             item = stream.select_next_some() => {
-                let e = result.entry(item.clone()).or_insert(0);
-                *e += 1;
+                result.push(item.clone());
                 count += 1;
                 if count >= num_items {
                     break;

--- a/base_layer/wallet/src/transaction_service/service.rs
+++ b/base_layer/wallet/src/transaction_service/service.rs
@@ -42,9 +42,10 @@ use std::{collections::HashMap, convert::TryInto};
 use tari_broadcast_channel::Publisher;
 use tari_comms::types::CommsPublicKey;
 use tari_comms_dht::{
+    broadcast_strategy::BroadcastStrategy,
     domain_message::OutboundDomainMessage,
     envelope::NodeDestination,
-    outbound::{BroadcastStrategy, OutboundEncryption, OutboundMessageRequester},
+    outbound::{OutboundEncryption, OutboundMessageRequester},
 };
 use tari_crypto::keys::SecretKey;
 use tari_p2p::{domain_message::DomainMessage, tari_message::TariMessageType};

--- a/base_layer/wallet/src/wallet.rs
+++ b/base_layer/wallet/src/wallet.rs
@@ -107,6 +107,7 @@ where T: WalletBackend
             .add_initializer(LivenessInitializer::new(
                 Default::default(),
                 Arc::clone(&subscription_factory),
+                dht.dht_requester(),
             ))
             .add_initializer(OutputManagerServiceInitializer::new(
                 oms_config,

--- a/base_layer/wallet/tests/wallet/mod.rs
+++ b/base_layer/wallet/tests/wallet/mod.rs
@@ -142,19 +142,11 @@ fn test_wallet() {
         .unwrap();
 
     runtime
-        .block_on(
-            alice_wallet
-                .liveness_service
-                .send_ping(bob_identity.public_key().clone()),
-        )
+        .block_on(alice_wallet.liveness_service.send_ping(bob_identity.node_id().clone()))
         .unwrap();
 
     runtime
-        .block_on(
-            bob_wallet
-                .liveness_service
-                .send_ping(alice_identity.public_key().clone()),
-        )
+        .block_on(bob_wallet.liveness_service.send_ping(alice_identity.node_id().clone()))
         .unwrap();
 
     let mut result = runtime.block_on(async {

--- a/comms/dht/src/broadcast_strategy.rs
+++ b/comms/dht/src/broadcast_strategy.rs
@@ -43,7 +43,7 @@ pub enum BroadcastStrategy {
     /// Send to all n nearest Communication Nodes according to the given BroadcastClosestRequest
     Closest(Box<BroadcastClosestRequest>),
     /// A convenient strategy which behaves the same as the `Closest` strategy with the `NodeId` set
-    /// to this node. This strategy excludes the given public keys.
+    /// to this node and a pre-configured number of neighbours. This strategy excludes the given public keys.
     Neighbours(Box<Vec<CommsPublicKey>>),
 }
 

--- a/comms/dht/src/builder.rs
+++ b/comms/dht/src/builder.rs
@@ -68,22 +68,6 @@ impl DhtBuilder {
         self
     }
 
-    pub fn enable_auto_join(mut self, enable: bool) -> Self {
-        self.config.enable_auto_join = enable;
-        self
-    }
-
-    pub fn enable_auto_stored_message_request(mut self, enable: bool) -> Self {
-        self.config.enable_auto_stored_message_request = enable;
-        self
-    }
-
-    pub fn enable_auto_messages(mut self, enable: bool) -> Self {
-        self.config.enable_auto_join = enable;
-        self.config.enable_auto_stored_message_request = enable;
-        self
-    }
-
     pub fn with_signature_cache_ttl(mut self, ttl: Duration) -> Self {
         self.config.signature_cache_ttl = ttl;
         self

--- a/comms/dht/src/config.rs
+++ b/comms/dht/src/config.rs
@@ -54,10 +54,6 @@ pub struct DhtConfig {
     /// The time-to-live duration used for storage of high priority messages by the Store-and-forward middleware.
     /// Default: 24 hours
     pub saf_high_priority_msg_storage_ttl: Duration,
-    /// Set to true to enable automatically joining the network on node startup (default: true)
-    pub enable_auto_join: bool,
-    /// Set to true to enable a request for stored messages on node startup (default: true)
-    pub enable_auto_stored_message_request: bool,
     /// The max capacity of the signature cache (default: 1000)
     pub signature_cache_capacity: usize,
     /// The time-to-live for items in the signature cache (default: 300s)
@@ -74,8 +70,6 @@ impl Default for DhtConfig {
             saf_msg_cache_storage_capacity: SAF_MSG_CACHE_STORAGE_CAPACITY,
             saf_low_priority_msg_storage_ttl: SAF_LOW_PRIORITY_MSG_STORAGE_TTL,
             saf_high_priority_msg_storage_ttl: SAF_HIGH_PRIORITY_MSG_STORAGE_TTL,
-            enable_auto_join: true,
-            enable_auto_stored_message_request: true,
             signature_cache_capacity: 1000,
             signature_cache_ttl: Duration::from_secs(300),
         }

--- a/comms/dht/src/inbound/dedup.rs
+++ b/comms/dht/src/inbound/dedup.rs
@@ -127,11 +127,12 @@ mod test {
         let spy = service_spy();
 
         let (dht_requester, mut mock) = create_dht_actor_mock(1);
-        let mock_state = DhtMockState::new().set_signature_cache_insert(false);
+        let mock_state = DhtMockState::new();
+        mock_state.set_signature_cache_insert(false);
         mock.set_shared_state(mock_state.clone());
         rt.spawn(mock.run());
 
-        let mut dedup = DedupLayer::new(dht_requester).layer(spy.service::<MiddlewareError>());
+        let mut dedup = DedupLayer::new(dht_requester).layer(spy.to_service::<MiddlewareError>());
 
         panic_context!(cx);
 

--- a/comms/dht/src/inbound/deserialize.rs
+++ b/comms/dht/src/inbound/deserialize.rs
@@ -134,7 +134,7 @@ mod test {
     #[test]
     fn deserialize() {
         let spy = service_spy();
-        let mut deserialize = DeserializeLayer::new().layer(spy.service::<MiddlewareError>());
+        let mut deserialize = DeserializeLayer::new().layer(spy.to_service::<MiddlewareError>());
 
         panic_context!(cx);
 

--- a/comms/dht/src/inbound/dht_handler/task.rs
+++ b/comms/dht/src/inbound/dht_handler/task.rs
@@ -21,10 +21,11 @@
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 use crate::{
+    broadcast_strategy::{BroadcastClosestRequest, BroadcastStrategy},
     config::DhtConfig,
     envelope::NodeDestination,
     inbound::{error::DhtInboundError, message::DecryptedDhtMessage},
-    outbound::{BroadcastClosestRequest, BroadcastStrategy, OutboundEncryption, OutboundMessageRequester},
+    outbound::{OutboundEncryption, OutboundMessageRequester},
     proto::{
         dht::{DiscoverMessage, JoinMessage},
         envelope::DhtMessageType,
@@ -237,7 +238,7 @@ where
             .expect("already checked that this message decrypted successfully");
 
         let discover_msg = msg
-            .decode_part::<DiscoverMessage>(1)?
+            .decode_part::<DiscoverMessage>(0)?
             .ok_or(DhtInboundError::InvalidMessageBody)?;
 
         let addresses = discover_msg

--- a/comms/dht/src/lib.rs
+++ b/comms/dht/src/lib.rs
@@ -121,12 +121,14 @@ mod consts;
 mod dht;
 mod proto;
 
+pub mod broadcast_strategy;
 pub mod domain_message;
 pub mod envelope;
 pub mod inbound;
 pub mod outbound;
 pub mod store_forward;
 
+pub use actor::{DhtActorError, DhtRequest, DhtRequester};
 pub use builder::DhtBuilder;
 pub use config::DhtConfig;
 pub use dht::Dht;

--- a/comms/dht/src/outbound/encryption.rs
+++ b/comms/dht/src/outbound/encryption.rs
@@ -141,7 +141,8 @@ mod test {
     fn no_encryption() {
         let spy = service_spy();
         let node_identity = make_node_identity();
-        let mut encryption = EncryptionLayer::new(Arc::clone(&node_identity)).layer(spy.service::<MiddlewareError>());
+        let mut encryption =
+            EncryptionLayer::new(Arc::clone(&node_identity)).layer(spy.to_service::<MiddlewareError>());
 
         panic_context!(cx);
         assert!(encryption.poll_ready(&mut cx).is_ready());
@@ -171,7 +172,8 @@ mod test {
     fn encryption() {
         let spy = service_spy();
         let node_identity = make_node_identity();
-        let mut encryption = EncryptionLayer::new(Arc::clone(&node_identity)).layer(spy.service::<MiddlewareError>());
+        let mut encryption =
+            EncryptionLayer::new(Arc::clone(&node_identity)).layer(spy.to_service::<MiddlewareError>());
 
         panic_context!(cx);
         assert!(encryption.poll_ready(&mut cx).is_ready());

--- a/comms/dht/src/outbound/error.rs
+++ b/comms/dht/src/outbound/error.rs
@@ -20,9 +20,10 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+use crate::actor::DhtActorError;
 use derive_error::Error;
 use futures::channel::mpsc::SendError;
-use tari_comms::{connection::ConnectionError, message::MessageError, peer_manager::PeerManagerError};
+use tari_comms::{connection::ConnectionError, message::MessageError};
 use tari_crypto::signatures::SchnorrSignatureError;
 use tari_utilities::message_format::MessageFormatError;
 
@@ -31,7 +32,7 @@ pub enum DhtOutboundError {
     SendError(SendError),
     MessageSerializationError(MessageError),
     MessageFormatError(MessageFormatError),
-    PeerManagerError(PeerManagerError),
+    DhtActorError(DhtActorError),
     ConnectionError(ConnectionError),
     SignatureError(SchnorrSignatureError),
     RequesterReplyChannelClosed,

--- a/comms/dht/src/outbound/message.rs
+++ b/comms/dht/src/outbound/message.rs
@@ -20,8 +20,8 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use super::broadcast_strategy::BroadcastStrategy;
 use crate::{
+    broadcast_strategy::BroadcastStrategy,
     envelope::{DhtMessageFlags, DhtMessageHeader, NodeDestination},
     proto::envelope::DhtMessageType,
 };

--- a/comms/dht/src/outbound/mock.rs
+++ b/comms/dht/src/outbound/mock.rs
@@ -79,7 +79,7 @@ impl MockOutboundService {
                 reply_tx.send(response).unwrap();
                 *msg
             },
-            DhtOutboundRequest::Forward(_) => panic!("Unexpected DhtOutboundRequest::Forward message"),
+            msg => panic!("Unexpected {} message", msg),
         }
     }
 

--- a/comms/dht/src/outbound/mod.rs
+++ b/comms/dht/src/outbound/mod.rs
@@ -21,7 +21,6 @@
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 mod broadcast;
-mod broadcast_strategy;
 mod encryption;
 mod error;
 mod message;
@@ -32,7 +31,6 @@ pub mod mock;
 
 pub use self::{
     broadcast::BroadcastLayer,
-    broadcast_strategy::{BroadcastClosestRequest, BroadcastStrategy},
     encryption::EncryptionLayer,
     error::DhtOutboundError,
     message::{DhtOutboundRequest, OutboundEncryption},

--- a/comms/dht/src/outbound/serialize.rs
+++ b/comms/dht/src/outbound/serialize.rs
@@ -151,7 +151,7 @@ mod test {
     fn serialize() {
         let spy = service_spy();
         let node_identity = make_node_identity();
-        let mut serialize = SerializeLayer::new(Arc::clone(&node_identity)).layer(spy.service::<MiddlewareError>());
+        let mut serialize = SerializeLayer::new(Arc::clone(&node_identity)).layer(spy.to_service::<MiddlewareError>());
 
         panic_context!(cx);
 

--- a/comms/dht/src/store_forward/forward.rs
+++ b/comms/dht/src/store_forward/forward.rs
@@ -21,9 +21,10 @@
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 use crate::{
+    broadcast_strategy::BroadcastStrategy,
     envelope::NodeDestination,
     inbound::DecryptedDhtMessage,
-    outbound::{BroadcastStrategy, OutboundMessageRequester},
+    outbound::OutboundMessageRequester,
     store_forward::error::StoreAndForwardError,
 };
 use futures::{task::Context, Future, Poll};
@@ -219,7 +220,7 @@ mod test {
         let peer_manager = make_peer_manager();
         let (oms_tx, mut oms_rx) = mpsc::channel(1);
         let oms = OutboundMessageRequester::new(oms_tx);
-        let mut service = ForwardLayer::new(peer_manager, oms).layer(spy.service::<MiddlewareError>());
+        let mut service = ForwardLayer::new(peer_manager, oms).layer(spy.to_service::<MiddlewareError>());
 
         let inbound_msg = make_dht_inbound_message(&make_node_identity(), b"".to_vec(), DhtMessageFlags::empty());
         let msg = DecryptedDhtMessage::succeeded(wrap_in_envelope_body!(Vec::new()).unwrap(), inbound_msg);
@@ -234,7 +235,7 @@ mod test {
         let peer_manager = make_peer_manager();
         let (oms_tx, mut oms_rx) = mpsc::channel(1);
         let oms = OutboundMessageRequester::new(oms_tx);
-        let mut service = ForwardLayer::new(peer_manager, oms).layer(spy.service::<MiddlewareError>());
+        let mut service = ForwardLayer::new(peer_manager, oms).layer(spy.to_service::<MiddlewareError>());
 
         let inbound_msg = make_dht_inbound_message(&make_node_identity(), b"".to_vec(), DhtMessageFlags::empty());
         let msg = DecryptedDhtMessage::failed(inbound_msg);

--- a/comms/dht/src/store_forward/message.rs
+++ b/comms/dht/src/store_forward/message.rs
@@ -40,7 +40,6 @@ impl StoredMessagesRequest {
         Self { since: None }
     }
 
-    #[cfg(test)]
     pub fn since(since: DateTime<Utc>) -> Self {
         Self {
             since: Some(datetime_to_timestamp(since)),

--- a/comms/dht/src/store_forward/saf_handler/task.rs
+++ b/comms/dht/src/store_forward/saf_handler/task.rs
@@ -22,10 +22,11 @@
 
 use crate::{
     actor::DhtRequester,
+    broadcast_strategy::BroadcastStrategy,
     config::DhtConfig,
     envelope::{DhtMessageFlags, DhtMessageHeader, NodeDestination},
     inbound::{DecryptedDhtMessage, DhtInboundMessage},
-    outbound::{BroadcastStrategy, OutboundEncryption, OutboundMessageRequester},
+    outbound::{OutboundEncryption, OutboundMessageRequester},
     proto::{
         envelope::{DhtMessageType, NodeDestinationType},
         store_forward::{StoredMessage, StoredMessagesRequest, StoredMessagesResponse},
@@ -476,7 +477,7 @@ mod test {
 
             let task = MessageHandlerTask::new(
                 Default::default(),
-                spy.service::<MiddlewareError>(),
+                spy.to_service::<MiddlewareError>(),
                 storage,
                 dht_requester,
                 peer_manager,
@@ -553,7 +554,7 @@ mod test {
 
             let task = MessageHandlerTask::new(
                 Default::default(),
-                spy.service::<MiddlewareError>(),
+                spy.to_service::<MiddlewareError>(),
                 storage,
                 dht_requester,
                 peer_manager,

--- a/comms/dht/src/store_forward/store.rs
+++ b/comms/dht/src/store_forward/store.rs
@@ -252,7 +252,7 @@ mod test {
         let peer_manager = make_peer_manager();
         let node_identity = make_node_identity();
         let mut service = StoreLayer::new(Default::default(), peer_manager, node_identity, storage)
-            .layer(spy.service::<MiddlewareError>());
+            .layer(spy.to_service::<MiddlewareError>());
 
         let inbound_msg = make_dht_inbound_message(&make_node_identity(), b"".to_vec(), DhtMessageFlags::empty());
         let msg = DecryptedDhtMessage::succeeded(wrap_in_envelope_body!(Vec::new()).unwrap(), inbound_msg);
@@ -267,7 +267,7 @@ mod test {
         let peer_manager = make_peer_manager();
         let node_identity = make_node_identity();
         let mut service = StoreLayer::new(Default::default(), peer_manager, node_identity, Arc::clone(&storage))
-            .layer(spy.service::<MiddlewareError>());
+            .layer(spy.to_service::<MiddlewareError>());
 
         let inbound_msg = make_dht_inbound_message(&make_node_identity(), b"".to_vec(), DhtMessageFlags::empty());
         let msg = DecryptedDhtMessage::failed(inbound_msg.clone());

--- a/comms/dht/src/test_utils/service.rs
+++ b/comms/dht/src/test_utils/service.rs
@@ -60,7 +60,7 @@ where TReq: 'static
         self.requests.lock().unwrap().clear();
     }
 
-    pub fn service<TErr>(
+    pub fn to_service<TErr>(
         &self,
     ) -> impl Service<TReq, Response = (), Error = TErr, Future = impl Future<Output = Result<(), TErr>>> + Clone {
         let req_inner = Arc::clone(&self.requests);

--- a/comms/dht/tests/dht.rs
+++ b/comms/dht/tests/dht.rs
@@ -35,7 +35,7 @@ use tari_comms::{
     types::CommsDatabase,
     CommsBuilder,
 };
-use tari_comms_dht::{envelope::NodeDestination, inbound::DecryptedDhtMessage, Dht, DhtBuilder, DhtConfig};
+use tari_comms_dht::{envelope::NodeDestination, inbound::DecryptedDhtMessage, Dht, DhtBuilder};
 use tari_comms_middleware::{pipeline::ServicePipeline, sink::SinkMiddleware};
 use tari_storage::{lmdb_store::LMDBBuilder, LMDBWrapper};
 use tari_test_utils::{async_assert_eventually, paths::create_random_database_path, random, runtime};
@@ -101,9 +101,7 @@ fn setup_comms_dht(
         .unwrap();
 
     // Create a channel for outbound requests
-    let mut dht = DhtBuilder::from_comms(&mut comms)
-        .with_config(DhtConfig::default())
-        .finish();
+    let mut dht = DhtBuilder::from_comms(&mut comms).finish();
 
     //---------------------------------- Inbound Pipeline --------------------------------------------//
 
@@ -184,7 +182,7 @@ fn dht_join_propagation() {
                 node_A_peer_manager.exists(node_C_node_identity.public_key()),
                 expect = true,
                 max_attempts = 10,
-                interval = Duration::from_millis(500)
+                interval = Duration::from_millis(1000)
             );
             async_assert_eventually!(
                 node_C_peer_manager.exists(node_A_node_identity.public_key()),
@@ -216,7 +214,6 @@ fn dht_join_propagation() {
 #[test]
 #[allow(non_snake_case)]
 fn dht_discover_propagation() {
-    env_logger::init();
     // Create 4 nodes where A knows B, B knows A and C, C knows B and D, and D knows C
     let node_A_identity = new_node_identity("127.0.0.1:11116".parse().unwrap());
     let node_B_identity = new_node_identity("127.0.0.1:11117".parse().unwrap());

--- a/comms/middleware/src/lib.rs
+++ b/comms/middleware/src/lib.rs
@@ -27,28 +27,10 @@
 //!
 //! For example, should you want your messages to be encrypted, you'll add the EncryptionLayer to
 //! the outbound middleware stack and the DecryptionLayer to the inbound stack.
-//! TODO: This needs to be implemented
 //!
 //! Middlewares use `tower_layer` and `tower_service`. A Middleware is simply any service which
 //! is `Service<InboundMessage, Response = (), Error = MiddlewareError>`. This service will usually
 //! be composed of other services by using the `tower_util::ServiceBuilder`.
-//!
-//! TODO: This code doesnt work
-//! ```nocompile
-//! let inbound_middleware = ServiceBuilder::new()
-//!   .layer(DecryptionLayer::new(..))
-//!   .layer(DhtLayer::new(..))
-//!   .service(DomainPubsubService::new(..));
-//!
-//! // IdentityService does nothing
-//! let outbound_middleware = IdentityService::new();
-//!
-//! CommsBuilder::new()
-//!   .inbound_middleware(inbound_middleware)
-//!   .outbound_middleware(outbound_middleware)
-//!   // (...)
-//!   .build();
-//! ```
 // Needed to make futures::select! work
 #![recursion_limit = "256"]
 #![feature(type_alias_impl_trait)]

--- a/comms/tests/support/factories/node_identity.rs
+++ b/comms/tests/support/factories/node_identity.rs
@@ -37,7 +37,7 @@ pub fn create() -> NodeIdentityFactory {
 pub struct NodeIdentityFactory {
     control_service_address: Option<NetAddress>,
     secret_key: Option<CommsSecretKey>,
-    public_key: Option<CommsPublicKey>,
+    //    public_key: Option<CommsPublicKey>,
     peer_features: PeerFeatures,
 }
 
@@ -51,8 +51,6 @@ impl NodeIdentityFactory {
     factory_setter!(with_secret_key, secret_key, Option<CommsSecretKey>);
 
     factory_setter!(with_peer_features, peer_features, PeerFeatures);
-
-    factory_setter!(with_public_key, public_key, Option<CommsPublicKey>);
 }
 
 impl TestFactory for NodeIdentityFactory {
@@ -66,10 +64,7 @@ impl TestFactory for NodeIdentityFactory {
                 &mut OsRng::new().map_err(TestFactoryError::build_failed())?,
             )))
             .unwrap();
-        let public_key = self
-            .public_key
-            .or_else(|| Some(CommsPublicKey::from_secret_key(&secret_key)))
-            .unwrap();
+
         let control_service_address = self
             .control_service_address
             .or(Some(super::net_address::create().build()?))


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
- Added Dht actor call to select peers from a broadcast strategy
- Liveness service records latency for ping/pongs
- Dht actor can handle more than one request at a time
- Join and store and forward messages must now be explicitly sent.
- Liveness service optionally sends join and "request messages" on startup
- Updated pingpong example to display latency

<img width="233" alt="Screen Shot 2019-11-05 at 10 35 23" src="https://user-images.githubusercontent.com/1057902/68191329-038abc80-ffb8-11e9-9d39-6552621bdc60.png">


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Ref #947 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [x] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [x] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch
* [x] I ran `cargo-fmt --all` before pushing
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
