### PR TITLE
Add local docker test script

### DIFF
--- a/scripts/test_in_docker.sh
+++ b/scripts/test_in_docker.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+# Run the Tari test suite locally inside a suitable docker container
+
+IMAGE=quay.io/tarilabs/rust_tari-build-with-deps:nightly-2019-10-04
+TOOLCHAIN_VERSION=nightly-2019-10-04
+CONTAINER=tari_test
+
+echo "Deleting old container"
+docker rm -f $CONTAINER
+echo "Checking for docker image"
+docker pull $IMAGE
+
+echo "Creating doc
+ker container.."
+# sleep infinity is used to keep the container alive forever
+docker run -dv`pwd`:/src --name $CONTAINER $IMAGE /bin/sleep infinity
+echo "Container is ready"
+
+#echo "Copying source files..."
+## The simplest and laziest approach to not copying 6+GB of irrelevant files to the container
+#cargo clean
+## We could pull this from git, but this lets you test local changes
+#docker cp . $CONTAINER:/src/
+#echo "Source files copied."
+
+CMD="cd src; cargo build; cargo test"
+
+docker exec -ti $CONTAINER /bin/bash -c "$CMD"
+
+echo "Tests complete. You can play with the build interactively by running this command:"
+echo "docker exec -ti -w /src $CONTAINER /bin/bash"


### PR DESCRIPTION
Have you ever wished you could run tari tests in Ubuntu on OSX but had no
idea how to do it? Well now you can! If you have Docker installed,
this script will pull a docker image (with the required libraries
precompiled), copy your local source over,
and run the tests.

