### PR TITLE
BaseNodeService: request, provide and restore MMR state

### DIFF
--- a/applications/tari_base_node/Cargo.toml
+++ b/applications/tari_base_node/Cargo.toml
@@ -16,6 +16,7 @@ tari_p2p = {path = "../../base_layer/p2p", version= "^0.0"}
 tari_service_framework = { version = "^0.0", path = "../../base_layer/service_framework"}
 tari_shutdown = { path = "../../infrastructure/shutdown", version = "^0.0" }
 tari_utilities = { version = "^0.0", path = "../../infrastructure/tari_util"}
+tari_mmr = { path = "../../base_layer/mmr", version = "^0.0" }
 
 clap = "2.33.0"
 config = { version = "0.9.3" }

--- a/applications/tari_base_node/src/builder.rs
+++ b/applications/tari_base_node/src/builder.rs
@@ -41,6 +41,7 @@ use tari_core::{
     },
     chain_storage::{create_lmdb_database, BlockchainBackend, BlockchainDatabase, LMDBDatabase, MemoryDatabase},
 };
+use tari_mmr::MerkleChangeTrackerConfig;
 use tari_p2p::{
     comms_connector::pubsub_connector,
     initialization::{initialize_comms, CommsConfig},
@@ -165,7 +166,11 @@ pub fn configure_and_initialize_node(
             )
         },
         DatabaseType::LMDB(p) => {
-            let backend = create_lmdb_database(&p).map_err(|e| e.to_string())?;
+            let mct_config = MerkleChangeTrackerConfig {
+                min_history_len: 900,
+                max_history_len: 1000,
+            };
+            let backend = create_lmdb_database(&p, mct_config).map_err(|e| e.to_string())?;
             let db = BlockchainDatabase::new(backend).map_err(|e| e.to_string())?;
             let (comms, handles) = setup_comms_services(&rt, id.clone(), peers, &config.peer_db_path, db.clone());
             let outbound_interface = handles.get_handle::<OutboundNodeCommsInterface>().unwrap();

--- a/base_layer/core/src/base_node/comms_interface/comms_request.rs
+++ b/base_layer/core/src/base_node/comms_interface/comms_request.rs
@@ -20,6 +20,7 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+use crate::chain_storage::MmrTree;
 use serde::{Deserialize, Serialize};
 use tari_transactions::types::HashOutput;
 
@@ -33,6 +34,14 @@ pub enum NodeCommsRequestType {
     Many,
 }
 
+/// A container for the parameters required for a FetchMmrState request.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct MmrStateRequest {
+    pub tree: MmrTree,
+    pub index: u64,
+    pub count: u64,
+}
+
 /// API Request enum
 #[derive(Debug, Serialize, Deserialize)]
 pub enum NodeCommsRequest {
@@ -41,4 +50,5 @@ pub enum NodeCommsRequest {
     FetchHeaders(Vec<u64>),
     FetchUtxos(Vec<HashOutput>),
     FetchBlocks(Vec<u64>),
+    FetchMmrState(MmrStateRequest),
 }

--- a/base_layer/core/src/base_node/comms_interface/comms_response.rs
+++ b/base_layer/core/src/base_node/comms_interface/comms_response.rs
@@ -22,7 +22,7 @@
 
 use crate::{
     blocks::blockheader::BlockHeader,
-    chain_storage::{ChainMetadata, HistoricalBlock},
+    chain_storage::{ChainMetadata, HistoricalBlock, MutableMmrState},
 };
 use serde::{Deserialize, Serialize};
 use tari_transactions::transaction::{TransactionKernel, TransactionOutput};
@@ -35,4 +35,5 @@ pub enum NodeCommsResponse {
     BlockHeaders(Vec<BlockHeader>),
     TransactionOutputs(Vec<TransactionOutput>),
     HistoricalBlocks(Vec<HistoricalBlock>),
+    MmrState(MutableMmrState),
 }

--- a/base_layer/core/src/base_node/comms_interface/inbound_interface.rs
+++ b/base_layer/core/src/base_node/comms_interface/inbound_interface.rs
@@ -84,6 +84,15 @@ where T: BlockchainBackend
                 }
                 Ok(NodeCommsResponse::HistoricalBlocks(blocks))
             },
+            NodeCommsRequest::FetchMmrState(mmr_state_request) => Ok(NodeCommsResponse::MmrState(
+                async_db::fetch_mmr_base_leaf_nodes(
+                    self.blockchain_db.clone(),
+                    mmr_state_request.tree.clone(),
+                    mmr_state_request.index as usize,
+                    mmr_state_request.count as usize,
+                )
+                .await?,
+            )),
         }
     }
 }

--- a/base_layer/core/src/base_node/comms_interface/outbound_interface.rs
+++ b/base_layer/core/src/base_node/comms_interface/outbound_interface.rs
@@ -22,13 +22,14 @@
 
 use crate::{
     base_node::comms_interface::{
+        comms_request::MmrStateRequest,
         error::CommsInterfaceError,
         NodeCommsRequest,
         NodeCommsRequestType,
         NodeCommsResponse,
     },
     blocks::blockheader::BlockHeader,
-    chain_storage::{ChainMetadata, HistoricalBlock},
+    chain_storage::{ChainMetadata, HistoricalBlock, MmrTree, MutableMmrState},
 };
 use tari_service_framework::reply_channel::SenderService;
 use tari_transactions::{
@@ -130,6 +131,29 @@ impl OutboundNodeCommsInterface {
             .first()
         {
             Ok(blocks.clone())
+        } else {
+            Err(CommsInterfaceError::UnexpectedApiResponse)
+        }
+    }
+
+    /// Fetch the base MMR state of the specified merkle mountain range.
+    pub async fn fetch_mmr_state(
+        &mut self,
+        tree: MmrTree,
+        index: u64,
+        count: u64,
+    ) -> Result<MutableMmrState, CommsInterfaceError>
+    {
+        if let Some(NodeCommsResponse::MmrState(mmr_state)) = self
+            .sender
+            .call((
+                NodeCommsRequest::FetchMmrState(MmrStateRequest { tree, index, count }),
+                NodeCommsRequestType::Single,
+            ))
+            .await??
+            .first()
+        {
+            Ok(mmr_state.clone())
         } else {
             Err(CommsInterfaceError::UnexpectedApiResponse)
         }

--- a/base_layer/core/src/base_node/proto/mmr_state_request.proto
+++ b/base_layer/core/src/base_node/proto/mmr_state_request.proto
@@ -1,0 +1,12 @@
+syntax = "proto3";
+
+import "mmr_tree.proto";
+
+package tari.base_node;
+
+message MmrStateRequest
+{
+    MmrTree tree = 1;
+    uint64 index = 2;
+    uint64 count = 3;
+}

--- a/base_layer/core/src/base_node/proto/mmr_state_request.rs
+++ b/base_layer/core/src/base_node/proto/mmr_state_request.rs
@@ -20,15 +20,32 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-mod comms_request;
-mod comms_response;
-mod error;
-mod inbound_interface;
-mod outbound_interface;
+use crate::base_node::{
+    comms_interface::MmrStateRequest,
+    proto::base_node::{MmrStateRequest as ProtoMmrStateRequest, MmrTree as ProtoMmrTree},
+};
+use std::convert::{TryFrom, TryInto};
 
-// Public re-exports
-pub use comms_request::{MmrStateRequest, NodeCommsRequest, NodeCommsRequestType};
-pub use comms_response::NodeCommsResponse;
-pub use error::CommsInterfaceError;
-pub use inbound_interface::InboundNodeCommsInterface;
-pub use outbound_interface::OutboundNodeCommsInterface;
+impl TryFrom<ProtoMmrStateRequest> for MmrStateRequest {
+    type Error = String;
+
+    fn try_from(request: ProtoMmrStateRequest) -> Result<Self, Self::Error> {
+        let tree = ProtoMmrTree::from_i32(request.tree).ok_or("Invalid or unrecognised `MmrTree` enum".to_string())?;
+        Ok(Self {
+            tree: tree.try_into()?,
+            index: request.index,
+            count: request.count,
+        })
+    }
+}
+
+impl From<MmrStateRequest> for ProtoMmrStateRequest {
+    fn from(request: MmrStateRequest) -> Self {
+        let tree: ProtoMmrTree = request.tree.into();
+        Self {
+            tree: tree as i32,
+            index: request.index,
+            count: request.count,
+        }
+    }
+}

--- a/base_layer/core/src/base_node/proto/mmr_tree.proto
+++ b/base_layer/core/src/base_node/proto/mmr_tree.proto
@@ -1,0 +1,13 @@
+syntax = "proto3";
+
+import "google/protobuf/wrappers.proto";
+
+package tari.base_node;
+
+enum MmrTree {
+    MmrTreeNone = 0;
+    MmrTreeUtxo = 1;
+    MmrTreeKernel = 2;
+    MmrTreeRangeProof = 3;
+    MmrTreeHeader = 4;
+}

--- a/base_layer/core/src/base_node/proto/mmr_tree.rs
+++ b/base_layer/core/src/base_node/proto/mmr_tree.rs
@@ -1,4 +1,4 @@
-// Copyright 2019. The Tari Project
+// Copyright 2019, The Tari Project
 //
 // Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
 // following conditions are met:
@@ -20,15 +20,33 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-mod comms_request;
-mod comms_response;
-mod error;
-mod inbound_interface;
-mod outbound_interface;
+use super::base_node as proto;
+use crate::chain_storage::MmrTree;
+use std::convert::TryFrom;
 
-// Public re-exports
-pub use comms_request::{MmrStateRequest, NodeCommsRequest, NodeCommsRequestType};
-pub use comms_response::NodeCommsResponse;
-pub use error::CommsInterfaceError;
-pub use inbound_interface::InboundNodeCommsInterface;
-pub use outbound_interface::OutboundNodeCommsInterface;
+impl TryFrom<proto::MmrTree> for MmrTree {
+    type Error = String;
+
+    fn try_from(tree: proto::MmrTree) -> Result<Self, Self::Error> {
+        use proto::MmrTree::*;
+        Ok(match tree {
+            None => return Err("MmrTree not provided".to_string()),
+            Utxo => MmrTree::Utxo,
+            Kernel => MmrTree::Kernel,
+            RangeProof => MmrTree::RangeProof,
+            Header => MmrTree::Header,
+        })
+    }
+}
+
+impl From<MmrTree> for proto::MmrTree {
+    fn from(tree: MmrTree) -> Self {
+        use MmrTree::*;
+        match tree {
+            Utxo => proto::MmrTree::Utxo,
+            Kernel => proto::MmrTree::Kernel,
+            RangeProof => proto::MmrTree::RangeProof,
+            Header => proto::MmrTree::Header,
+        }
+    }
+}

--- a/base_layer/core/src/base_node/proto/mod.rs
+++ b/base_layer/core/src/base_node/proto/mod.rs
@@ -29,6 +29,10 @@ use crate::proto::core;
 use tari_transactions::proto::types;
 
 pub mod chain_metadata;
+pub mod mmr_state_request;
+pub mod mmr_tree;
+pub mod mutable_mmr_leaf_nodes;
+pub mod mutable_mmr_state;
 pub mod request;
 pub mod response;
 

--- a/base_layer/core/src/base_node/proto/mutable_mmr_state.proto
+++ b/base_layer/core/src/base_node/proto/mutable_mmr_state.proto
@@ -1,0 +1,15 @@
+syntax = "proto3";
+
+import "types.proto";
+
+package tari.base_node;
+
+message MutableMmrLeafNodes {
+    repeated tari.types.HashOutput leaf_hashes = 1;
+    repeated uint32 deleted = 2;
+}
+
+message MutableMmrState {
+    uint64 total_leaf_count = 1;
+    MutableMmrLeafNodes leaf_nodes = 2;
+}

--- a/base_layer/core/src/base_node/proto/request.proto
+++ b/base_layer/core/src/base_node/proto/request.proto
@@ -1,6 +1,7 @@
 syntax = "proto3";
 
 package tari.base_node;
+import "mmr_state_request.proto";
 
 // Request type for a received BaseNodeService request.
 message BaseNodeServiceRequest {
@@ -16,6 +17,8 @@ message BaseNodeServiceRequest {
         HashOutputs fetch_utxos = 5;
         // Indicates a FetchBlocks request.
         BlockHeights fetch_blocks = 6;
+        // Indicates a FetchMmrState request.
+        MmrStateRequest fetch_mmr_state = 7;
     }
 }
 

--- a/base_layer/core/src/base_node/proto/response.proto
+++ b/base_layer/core/src/base_node/proto/response.proto
@@ -3,6 +3,7 @@ syntax = "proto3";
 import "transaction.proto";
 import "block.proto";
 import "chain_metadata.proto";
+import "mutable_mmr_state.proto";
 
 package tari.base_node;
 
@@ -15,6 +16,7 @@ message BaseNodeServiceResponse {
         BlockHeaders block_headers = 4;
         TransactionOutputs transaction_outputs = 5;
         HistoricalBlocks historical_blocks = 6;
+        MutableMmrState mmr_state = 7;
     }
 }
 

--- a/base_layer/core/src/base_node/proto/response.rs
+++ b/base_layer/core/src/base_node/proto/response.rs
@@ -59,6 +59,7 @@ impl TryInto<ci::NodeCommsResponse> for ProtoNodeCommsResponse {
                 let blocks = try_convert_all(blocks.blocks)?;
                 ci::NodeCommsResponse::HistoricalBlocks(blocks)
             },
+            MmrState(state) => ci::NodeCommsResponse::MmrState(state.try_into()?),
         };
 
         Ok(response)
@@ -86,6 +87,7 @@ impl From<ci::NodeCommsResponse> for ProtoNodeCommsResponse {
                 let historical_blocks = historical_blocks.into_iter().map(Into::into).collect();
                 ProtoNodeCommsResponse::HistoricalBlocks(historical_blocks)
             },
+            MmrState(state) => ProtoNodeCommsResponse::MmrState(state.into()),
         }
     }
 }

--- a/base_layer/core/src/base_node/service/service.rs
+++ b/base_layer/core/src/base_node/service/service.rs
@@ -252,7 +252,14 @@ where B: BlockchainBackend
             "Received invalid base node request".to_string(),
         ))?;
 
-        let response = self.inbound_nci.handle_request(&request.into()).await?;
+        let response = self
+            .inbound_nci
+            .handle_request(
+                &request
+                    .try_into()
+                    .map_err(|e| BaseNodeServiceError::InvalidRequest(e))?,
+            )
+            .await?;
 
         let message = proto::BaseNodeServiceResponse {
             request_key: inner.request_key,

--- a/base_layer/core/src/chain_storage/db_transaction.rs
+++ b/base_layer/core/src/chain_storage/db_transaction.rs
@@ -178,7 +178,7 @@ pub enum DbKeyValuePair {
     OrphanBlock(HashOutput, Box<Block>),
 }
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub enum MmrTree {
     Utxo,
     Kernel,

--- a/base_layer/core/src/chain_storage/mod.rs
+++ b/base_layer/core/src/chain_storage/mod.rs
@@ -40,7 +40,7 @@ mod test;
 pub mod async_db;
 
 // Public API exports
-pub use blockchain_database::{BlockAddResult, BlockchainBackend, BlockchainDatabase};
+pub use blockchain_database::{BlockAddResult, BlockchainBackend, BlockchainDatabase, MutableMmrState};
 pub use db_transaction::{DbTransaction, MmrTree};
 pub use error::ChainStorageError;
 pub use historical_block::HistoricalBlock;

--- a/base_layer/core/src/chain_storage/test/chain_backend.rs
+++ b/base_layer/core/src/chain_storage/test/chain_backend.rs
@@ -34,7 +34,7 @@ use crate::{
     test_utils::builders::{create_test_block, create_test_kernel, create_utxo},
     tx,
 };
-use tari_mmr::MutableMmr;
+use tari_mmr::{Hash, MerkleChangeTrackerConfig, MutableMmr};
 use tari_test_utils::paths::create_random_database_path;
 use tari_transactions::{tari_amount::MicroTari, types::HashDigest};
 use tari_utilities::{hex::Hex, Hashable};
@@ -77,7 +77,11 @@ fn memory_insert_contains_delete_and_fetch_header() {
 
 #[test]
 fn lmdb_insert_contains_delete_and_fetch_header() {
-    let db = create_lmdb_database(&create_random_database_path()).unwrap();
+    let mct_config = MerkleChangeTrackerConfig {
+        min_history_len: 10,
+        max_history_len: 20,
+    };
+    let db = create_lmdb_database(&create_random_database_path(), mct_config).unwrap();
     insert_contains_delete_and_fetch_header(db);
 }
 
@@ -110,7 +114,11 @@ fn memory_insert_contains_delete_and_fetch_utxo() {
 
 #[test]
 fn lmdb_insert_contains_delete_and_fetch_utxo() {
-    let db = create_lmdb_database(&create_random_database_path()).unwrap();
+    let mct_config = MerkleChangeTrackerConfig {
+        min_history_len: 10,
+        max_history_len: 20,
+    };
+    let db = create_lmdb_database(&create_random_database_path(), mct_config).unwrap();
     insert_contains_delete_and_fetch_utxo(db);
 }
 
@@ -145,7 +153,11 @@ fn memory_insert_contains_delete_and_fetch_kernel() {
 
 #[test]
 fn lmdb_insert_contains_delete_and_fetch_kernel() {
-    let db = create_lmdb_database(&create_random_database_path()).unwrap();
+    let mct_config = MerkleChangeTrackerConfig {
+        min_history_len: 10,
+        max_history_len: 20,
+    };
+    let db = create_lmdb_database(&create_random_database_path(), mct_config).unwrap();
     insert_contains_delete_and_fetch_kernel(db);
 }
 
@@ -183,7 +195,11 @@ fn memory_insert_contains_delete_and_fetch_orphan() {
 
 #[test]
 fn lmdb_insert_contains_delete_and_fetch_orphan() {
-    let db = create_lmdb_database(&create_random_database_path()).unwrap();
+    let mct_config = MerkleChangeTrackerConfig {
+        min_history_len: 10,
+        max_history_len: 20,
+    };
+    let db = create_lmdb_database(&create_random_database_path(), mct_config).unwrap();
     insert_contains_delete_and_fetch_orphan(db);
 }
 
@@ -243,13 +259,21 @@ fn memory_spend_utxo_and_unspend_stxo() {
 
 #[test]
 fn lmdb_spend_utxo_and_unspend_stxo() {
-    let db = create_lmdb_database(&create_random_database_path()).unwrap();
+    let mct_config = MerkleChangeTrackerConfig {
+        min_history_len: 10,
+        max_history_len: 20,
+    };
+    let db = create_lmdb_database(&create_random_database_path(), mct_config).unwrap();
     spend_utxo_and_unspend_stxo(db);
 }
 
 #[test]
 fn lmdb_insert_fetch_metadata() {
-    let db = create_lmdb_database(&create_random_database_path()).unwrap();
+    let mct_config = MerkleChangeTrackerConfig {
+        min_history_len: 10,
+        max_history_len: 20,
+    };
+    let db = create_lmdb_database(&create_random_database_path(), mct_config).unwrap();
 
     assert!(db.fetch(&DbKey::Metadata(MetadataKey::ChainHeight)).unwrap().is_none());
     assert!(db
@@ -387,7 +411,11 @@ fn memory_fetch_mmr_root_and_proof_for_utxo_and_rp() {
 
 #[test]
 fn lmdb_fetch_mmr_root_and_proof_for_utxo_and_rp() {
-    let db = create_lmdb_database(&create_random_database_path()).unwrap();
+    let mct_config = MerkleChangeTrackerConfig {
+        min_history_len: 10,
+        max_history_len: 20,
+    };
+    let db = create_lmdb_database(&create_random_database_path(), mct_config).unwrap();
     fetch_mmr_root_and_proof_for_utxo_and_rp(db);
 }
 
@@ -437,7 +465,11 @@ fn memory_fetch_mmr_root_and_proof_for_kernel() {
 
 #[test]
 fn lmdb_fetch_mmr_root_and_proof_for_kernel() {
-    let db = create_lmdb_database(&create_random_database_path()).unwrap();
+    let mct_config = MerkleChangeTrackerConfig {
+        min_history_len: 10,
+        max_history_len: 20,
+    };
+    let db = create_lmdb_database(&create_random_database_path(), mct_config).unwrap();
     fetch_mmr_root_and_proof_for_kernel(db);
 }
 
@@ -490,7 +522,11 @@ fn memory_fetch_mmr_root_and_proof_for_header() {
 
 #[test]
 fn lmdb_fetch_mmr_root_and_proof_for_header() {
-    let db = create_lmdb_database(&create_random_database_path()).unwrap();
+    let mct_config = MerkleChangeTrackerConfig {
+        min_history_len: 10,
+        max_history_len: 20,
+    };
+    let db = create_lmdb_database(&create_random_database_path(), mct_config).unwrap();
     fetch_mmr_root_and_proof_for_header(db);
 }
 
@@ -597,7 +633,11 @@ fn memory_commit_block_and_create_fetch_checkpoint_and_rewind_mmr() {
 
 #[test]
 fn lmdb_commit_block_and_create_fetch_checkpoint_and_rewind_mmr() {
-    let db = create_lmdb_database(&create_random_database_path()).unwrap();
+    let mct_config = MerkleChangeTrackerConfig {
+        min_history_len: 10,
+        max_history_len: 20,
+    };
+    let db = create_lmdb_database(&create_random_database_path(), mct_config).unwrap();
     commit_block_and_create_fetch_checkpoint_and_rewind_mmr(db);
 }
 
@@ -652,12 +692,21 @@ fn memory_for_each_orphan() {
 
 #[test]
 fn lmdb_for_each_orphan() {
-    let db = create_lmdb_database(&create_random_database_path()).unwrap();
+    let mct_config = MerkleChangeTrackerConfig {
+        min_history_len: 10,
+        max_history_len: 20,
+    };
+    let db = create_lmdb_database(&create_random_database_path(), mct_config).unwrap();
     for_each_orphan(db);
 }
 
 #[test]
 fn lmdb_backend_restore() {
+    let mct_config = MerkleChangeTrackerConfig {
+        min_history_len: 10,
+        max_history_len: 20,
+    };
+
     let txs = vec![(tx!(1000.into(), fee: 20.into(), inputs: 2, outputs: 1)).0];
     let orphan = create_test_block(10, None, txs);
     let (utxo1, _) = create_utxo(MicroTari(10_000));
@@ -674,7 +723,7 @@ fn lmdb_backend_restore() {
     // Create backend storage
     let path = create_random_database_path();
     {
-        let db = create_lmdb_database(&path).unwrap();
+        let db = create_lmdb_database(&path, mct_config).unwrap();
         let mut txn = DbTransaction::new();
         txn.insert_orphan(orphan.clone());
         txn.insert_utxo(utxo1);
@@ -695,7 +744,7 @@ fn lmdb_backend_restore() {
         assert_eq!(db.contains(&DbKey::OrphanBlock(orphan_hash.clone())), Ok(true));
     }
     // Restore backend storage
-    let db = create_lmdb_database(&path).unwrap();
+    let db = create_lmdb_database(&path, mct_config).unwrap();
     assert_eq!(db.contains(&DbKey::BlockHeader(header.height)), Ok(true));
     assert_eq!(db.contains(&DbKey::BlockHash(header_hash)), Ok(true));
     assert_eq!(db.contains(&DbKey::UnspentOutput(utxo_hash)), Ok(true));
@@ -706,7 +755,11 @@ fn lmdb_backend_restore() {
 
 #[test]
 fn lmdb_mmr_reset_and_commit() {
-    let db = create_lmdb_database(&create_random_database_path()).unwrap();
+    let mct_config = MerkleChangeTrackerConfig {
+        min_history_len: 10,
+        max_history_len: 20,
+    };
+    let db = create_lmdb_database(&create_random_database_path(), mct_config).unwrap();
 
     let (utxo1, _) = create_utxo(MicroTari(10_000));
     let (utxo2, _) = create_utxo(MicroTari(15_000));
@@ -797,4 +850,132 @@ fn lmdb_mmr_reset_and_commit() {
     assert!(db.fetch_mmr_checkpoint(MmrTree::Kernel, 1).is_err());
     assert!(db.fetch_mmr_checkpoint(MmrTree::RangeProof, 1).is_err());
     assert!(db.fetch_mmr_checkpoint(MmrTree::Header, 1).is_err());
+}
+
+fn fetch_mmr_base_leaf_nodes_and_restore<T: BlockchainBackend>(db: T) {
+    struct R {
+        utxo: Hash,
+        kernel: Hash,
+        rp: Hash,
+        header: Hash,
+    }
+    let mut test_hashes = Vec::<R>::new();
+    for height in 0..10 {
+        let (utxo, _) = create_utxo(MicroTari(10_000));
+        let kernel = create_test_kernel(100.into(), 0);
+        let mut header = BlockHeader::new(0);
+        header.height = height;
+        let mut txn = DbTransaction::new();
+        txn.insert_utxo(utxo.clone());
+        txn.insert_kernel(kernel.clone());
+        txn.insert_header(header.clone());
+        txn.commit_block();
+        assert!(db.write(txn).is_ok());
+
+        test_hashes.push(R {
+            utxo: utxo.hash(),
+            kernel: kernel.hash(),
+            rp: utxo.proof.hash(),
+            header: header.hash(),
+        });
+    }
+
+    let utxo_mmr_state = db.fetch_mmr_base_leaf_nodes(MmrTree::Utxo, 0, 100).unwrap();
+    let kernel_mmr_state = db.fetch_mmr_base_leaf_nodes(MmrTree::Kernel, 0, 100).unwrap();
+    let rp_mmr_state = db.fetch_mmr_base_leaf_nodes(MmrTree::RangeProof, 0, 100).unwrap();
+    let header_mmr_state = db.fetch_mmr_base_leaf_nodes(MmrTree::Header, 0, 100).unwrap();
+    assert_eq!(utxo_mmr_state.total_leaf_count, 4);
+    assert_eq!(kernel_mmr_state.total_leaf_count, 4);
+    assert_eq!(rp_mmr_state.total_leaf_count, 4);
+    assert_eq!(header_mmr_state.total_leaf_count, 4);
+
+    assert_eq!(utxo_mmr_state.leaf_nodes.leaf_hashes.len(), 4);
+    assert_eq!(kernel_mmr_state.leaf_nodes.leaf_hashes.len(), 4);
+    assert_eq!(rp_mmr_state.leaf_nodes.leaf_hashes.len(), 4);
+    assert_eq!(header_mmr_state.leaf_nodes.leaf_hashes.len(), 4);
+    for i in 0..4 {
+        assert_eq!(utxo_mmr_state.leaf_nodes.leaf_hashes[i], test_hashes[i].utxo);
+        assert_eq!(kernel_mmr_state.leaf_nodes.leaf_hashes[i], test_hashes[i].kernel);
+        assert_eq!(rp_mmr_state.leaf_nodes.leaf_hashes[i], test_hashes[i].rp);
+        assert_eq!(header_mmr_state.leaf_nodes.leaf_hashes[i], test_hashes[i].header);
+    }
+
+    // Adding one more set of data will make the base MMR grow from 4 to 8
+    let (utxo, _) = create_utxo(MicroTari(10_000));
+    let kernel = create_test_kernel(100.into(), 0);
+    let mut header = BlockHeader::new(0);
+    header.height = 10;
+    let mut txn = DbTransaction::new();
+    txn.insert_utxo(utxo.clone());
+    txn.insert_kernel(kernel.clone());
+    txn.insert_header(header.clone());
+    txn.commit_block();
+    assert!(db.write(txn).is_ok());
+
+    let utxo_mmr_leaf_count = db
+        .fetch_mmr_base_leaf_nodes(MmrTree::Utxo, 0, 100)
+        .unwrap()
+        .total_leaf_count;
+    let kernel_mmr_leaf_count = db
+        .fetch_mmr_base_leaf_nodes(MmrTree::Kernel, 0, 100)
+        .unwrap()
+        .total_leaf_count;
+    let rp_mmr_leaf_count = db
+        .fetch_mmr_base_leaf_nodes(MmrTree::RangeProof, 0, 100)
+        .unwrap()
+        .total_leaf_count;
+    let header_mmr_leaf_count = db
+        .fetch_mmr_base_leaf_nodes(MmrTree::Header, 0, 100)
+        .unwrap()
+        .total_leaf_count;
+    assert_eq!(utxo_mmr_leaf_count, 8);
+    assert_eq!(kernel_mmr_leaf_count, 8);
+    assert_eq!(rp_mmr_leaf_count, 8);
+    assert_eq!(header_mmr_leaf_count, 8);
+
+    // Restore previously retrieved MMR state
+    assert!(db.restore_mmr(MmrTree::Utxo, utxo_mmr_state.leaf_nodes).is_ok());
+    assert!(db.restore_mmr(MmrTree::Kernel, kernel_mmr_state.leaf_nodes).is_ok());
+    assert!(db.restore_mmr(MmrTree::RangeProof, rp_mmr_state.leaf_nodes).is_ok());
+    assert!(db.restore_mmr(MmrTree::Header, header_mmr_state.leaf_nodes).is_ok());
+
+    let utxo_mmr_state = db.fetch_mmr_base_leaf_nodes(MmrTree::Utxo, 0, 100).unwrap();
+    let kernel_mmr_state = db.fetch_mmr_base_leaf_nodes(MmrTree::Kernel, 0, 100).unwrap();
+    let rp_mmr_state = db.fetch_mmr_base_leaf_nodes(MmrTree::RangeProof, 0, 100).unwrap();
+    let header_mmr_state = db.fetch_mmr_base_leaf_nodes(MmrTree::Header, 0, 100).unwrap();
+    assert_eq!(utxo_mmr_state.total_leaf_count, 4);
+    assert_eq!(kernel_mmr_state.total_leaf_count, 4);
+    assert_eq!(rp_mmr_state.total_leaf_count, 4);
+    assert_eq!(header_mmr_state.total_leaf_count, 4);
+
+    assert_eq!(utxo_mmr_state.leaf_nodes.leaf_hashes.len(), 4);
+    assert_eq!(kernel_mmr_state.leaf_nodes.leaf_hashes.len(), 4);
+    assert_eq!(rp_mmr_state.leaf_nodes.leaf_hashes.len(), 4);
+    assert_eq!(header_mmr_state.leaf_nodes.leaf_hashes.len(), 4);
+    for i in 0..4 {
+        assert_eq!(utxo_mmr_state.leaf_nodes.leaf_hashes[i], test_hashes[i].utxo);
+        assert_eq!(kernel_mmr_state.leaf_nodes.leaf_hashes[i], test_hashes[i].kernel);
+        assert_eq!(rp_mmr_state.leaf_nodes.leaf_hashes[i], test_hashes[i].rp);
+        assert_eq!(header_mmr_state.leaf_nodes.leaf_hashes[i], test_hashes[i].header);
+    }
+}
+
+#[test]
+fn memory_fetch_mmr_base_leaf_nodes_and_restore() {
+    let mct_config = MerkleChangeTrackerConfig {
+        min_history_len: 3,
+        max_history_len: 6,
+    };
+    let db = MemoryDatabase::<HashDigest>::new(mct_config);
+    fetch_mmr_base_leaf_nodes_and_restore(db);
+}
+
+#[test]
+fn lmdb_fetch_mmr_base_leaf_nodes_and_restore() {
+    let mct_config = MerkleChangeTrackerConfig {
+        min_history_len: 3,
+        max_history_len: 6,
+    };
+    let db = create_lmdb_database(&create_random_database_path(), mct_config).unwrap();
+    fetch_mmr_base_leaf_nodes_and_restore(db);
 }

--- a/base_layer/mmr/src/change_tracker.rs
+++ b/base_layer/mmr/src/change_tracker.rs
@@ -286,6 +286,11 @@ where
             .map(|i| self.mmr.len() as usize - self.current_additions.len() + i)
     }
 
+    /// Returns the number of leave nodes in the base MMR.
+    pub fn get_base_leaf_count(&self) -> usize {
+        self.base.get_leaf_count()
+    }
+
     /// Returns the MMR state of the base MMR.
     pub fn to_base_leaf_nodes(
         &self,

--- a/base_layer/mmr/src/merkle_mountain_range.rs
+++ b/base_layer/mmr/src/merkle_mountain_range.rs
@@ -31,7 +31,10 @@ use crate::{
 };
 use digest::Digest;
 use log::*;
-use std::{cmp::max, marker::PhantomData};
+use std::{
+    cmp::{max, min},
+    marker::PhantomData,
+};
 
 const LOG_TARGET: &str = "mmr::merkle_mountain_range";
 
@@ -102,9 +105,13 @@ where
 
     /// Returns a set of leaf hashes from the MMR.
     pub fn get_leaf_hashes(&self, index: usize, count: usize) -> Result<Vec<Hash>, MerkleMountainRangeError> {
+        let leaf_count = self.get_leaf_count()?;
+        if index >= leaf_count {
+            return Ok(Vec::new());
+        }
         let count = max(1, count);
-        let last_index = index + count - 1;
-        let mut leaf_hashes = Vec::with_capacity(count as usize);
+        let last_index = min(index + count - 1, leaf_count);
+        let mut leaf_hashes = Vec::with_capacity((last_index - index + 1) as usize);
         for index in index..=last_index {
             if let Some(hash) = self.get_leaf_hash(index)? {
                 leaf_hashes.push(hash);

--- a/base_layer/mmr/tests/change_tracker.rs
+++ b/base_layer/mmr/tests/change_tracker.rs
@@ -187,23 +187,23 @@ fn update_of_base_mmr_with_history_bounds() {
         assert!(mmr.push(&int_to_hash(i)).is_ok());
         assert!(mmr.commit().is_ok());
     }
-    let mmr_state = mmr.to_base_leaf_nodes(0, mmr.get_leaf_count()).unwrap();
+    let mmr_state = mmr.to_base_leaf_nodes(0, mmr.get_base_leaf_count()).unwrap();
     assert_eq!(mmr_state.leaf_hashes.len(), 0);
 
     assert!(mmr.push(&int_to_hash(6)).is_ok());
     assert!(mmr.commit().is_ok());
-    let mmr_state = mmr.to_base_leaf_nodes(0, mmr.get_leaf_count()).unwrap();
+    let mmr_state = mmr.to_base_leaf_nodes(0, mmr.get_base_leaf_count()).unwrap();
     assert_eq!(mmr_state.leaf_hashes.len(), 3);
 
     for i in 7..=8 {
         assert!(mmr.push(&int_to_hash(i)).is_ok());
         assert!(mmr.commit().is_ok());
     }
-    let mmr_state = mmr.to_base_leaf_nodes(0, mmr.get_leaf_count()).unwrap();
+    let mmr_state = mmr.to_base_leaf_nodes(0, mmr.get_base_leaf_count()).unwrap();
     assert_eq!(mmr_state.leaf_hashes.len(), 3);
 
     assert!(mmr.push(&int_to_hash(9)).is_ok());
     assert!(mmr.commit().is_ok());
-    let mmr_state = mmr.to_base_leaf_nodes(0, mmr.get_leaf_count()).unwrap();
+    let mmr_state = mmr.to_base_leaf_nodes(0, mmr.get_base_leaf_count()).unwrap();
     assert_eq!(mmr_state.leaf_hashes.len(), 6);
 }


### PR DESCRIPTION
## Description
- Added FetchMmrState comms request to base node service, with MmrStateRequest for specifying the MMR tree and range that should be used.
- Added MmrState comms response for providing the MutableMmrState to requesting remote nodes.
- Changed the Proto NodeCommsRequest Into implementation to a TryInto to allow conversions that could fail such as the MmrTree enum.
- Changed the make_async macro to support 2 and 3 param functions.
- Added the fetch_mmr_base_leaf_nodes and restore_mmr functionality to the BlockchainDatabase and LDMB and Memory Db backends.
- Added a MemoryDatabase new constructor that allow the configuration of the MerkleChangeTrackerConfig.
- Changed the existing LMDBDatabase new constructor to allow the configuration of the MerkleChangeTrackerConfig.

Closes #952, #953

## Motivation and Context
This functionality is required to enable syncing between nodes.

## How Has This Been Tested?
Added tests that test the new service functionality and test the MMR state retrieval and restore functions of the databases.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [x] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch
* [x] I ran `cargo-fmt --all` before pushing
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
