### PR TITLE
Allow DNS addresses to be used for peer connections

### DIFF
--- a/applications/tari_base_node/src/builder.rs
+++ b/applications/tari_base_node/src/builder.rs
@@ -255,7 +255,7 @@ where
     let subscription_factory = Arc::new(subscription_factory);
     let comms_config = CommsConfig {
         node_identity: id.clone(),
-        host: host.parse().unwrap(),
+        peer_connection_listening_address: host.parse().unwrap(),
         socks_proxy_address: None,
         control_service: ControlServiceConfig {
             listener_address: id.control_service_address(),

--- a/base_layer/core/src/base_node/test/service.rs
+++ b/base_layer/core/src/base_node/test/service.rs
@@ -79,7 +79,7 @@ where
 {
     let comms_config = CommsConfig {
         node_identity: Arc::clone(&node_identity),
-        host: "127.0.0.1".parse().unwrap(),
+        peer_connection_listening_address: "127.0.0.1".parse().unwrap(),
         socks_proxy_address: None,
         control_service: ControlServiceConfig {
             listener_address: node_identity.control_service_address(),

--- a/base_layer/p2p/Cargo.toml
+++ b/base_layer/p2p/Cargo.toml
@@ -46,6 +46,7 @@ futures-timer = "0.3.0"
 lazy_static = "1.3.0"
 stream-cancel = "0.4.4"
 tempdir = "0.3.7"
+get_if_addrs = "0.5.3"
 
 [dev-dependencies.log4rs]
 version ="0.8.3"

--- a/base_layer/p2p/src/initialization.rs
+++ b/base_layer/p2p/src/initialization.rs
@@ -49,15 +49,15 @@ pub enum CommsInitializationError {
 /// Configuration for a comms node
 #[derive(Clone)]
 pub struct CommsConfig {
-    /// Control service config
+    /// Control service config.
     pub control_service: ControlServiceConfig,
-    /// An optional SOCKS address
+    /// An optional SOCKS address.
     pub socks_proxy_address: Option<SocketAddress>,
-    /// The host IP that all peer connections will use.
-    pub host: IpAddr,
-    /// Identity of this node on the network
+    /// The host IP that all inbound peer connections will listen (bind) on. This is usually 0.0.0.0
+    pub peer_connection_listening_address: IpAddr,
+    /// Identity of this node on the network.
     pub node_identity: Arc<NodeIdentity>,
-    /// Path to the LMDB file
+    /// Path to the LMDB file.
     pub datastore_path: String,
     /// Name to use for the peer database
     pub peer_database_name: String,
@@ -110,7 +110,7 @@ where
         .configure_control_service(config.control_service)
         .configure_peer_connections(PeerConnectionConfig {
             socks_proxy_address: config.socks_proxy_address,
-            host: config.host,
+            host: config.peer_connection_listening_address,
             peer_connection_establish_timeout: config.establish_connection_timeout,
             ..Default::default()
         })

--- a/base_layer/p2p/tests/support/comms_and_services.rs
+++ b/base_layer/p2p/tests/support/comms_and_services.rs
@@ -48,7 +48,7 @@ where
 {
     let comms_config = CommsConfig {
         node_identity: Arc::clone(&node_identity),
-        host: "127.0.0.1".parse().unwrap(),
+        peer_connection_listening_address: "127.0.0.1".parse().unwrap(),
         socks_proxy_address: None,
         control_service: ControlServiceConfig {
             listener_address: node_identity.control_service_address(),

--- a/base_layer/wallet/src/testnet_utils.rs
+++ b/base_layer/wallet/src/testnet_utils.rs
@@ -93,7 +93,7 @@ pub fn create_wallet(secret_key: CommsSecretKey, net_address: String) -> Wallet<
 
     let comms_config = CommsConfig {
         node_identity: Arc::new(node_id.clone()),
-        host: "127.0.0.1".parse().unwrap(),
+        peer_connection_listening_address: "127.0.0.1".parse().unwrap(),
         socks_proxy_address: None,
         control_service: ControlServiceConfig {
             listener_address: node_id.control_service_address(),

--- a/base_layer/wallet/tests/support/comms_and_services.rs
+++ b/base_layer/wallet/tests/support/comms_and_services.rs
@@ -53,7 +53,7 @@ where
 {
     let comms_config = CommsConfig {
         node_identity: Arc::clone(&node_identity),
-        host: "127.0.0.1".parse().unwrap(),
+        peer_connection_listening_address: "127.0.0.1".parse().unwrap(),
         socks_proxy_address: None,
         control_service: ControlServiceConfig {
             listener_address: node_identity.control_service_address(),

--- a/base_layer/wallet/tests/wallet/mod.rs
+++ b/base_layer/wallet/tests/wallet/mod.rs
@@ -72,7 +72,7 @@ fn test_wallet() {
     .unwrap();
     let comms_config1 = CommsConfig {
         node_identity: Arc::new(alice_identity.clone()),
-        host: "127.0.0.1".parse().unwrap(),
+        peer_connection_listening_address: "127.0.0.1".parse().unwrap(),
         socks_proxy_address: None,
         control_service: ControlServiceConfig {
             listener_address: alice_identity.control_service_address(),
@@ -93,7 +93,7 @@ fn test_wallet() {
     };
     let comms_config2 = CommsConfig {
         node_identity: Arc::new(bob_identity.clone()),
-        host: "127.0.0.1".parse().unwrap(),
+        peer_connection_listening_address: "127.0.0.1".parse().unwrap(),
         socks_proxy_address: None,
         control_service: ControlServiceConfig {
             listener_address: bob_identity.control_service_address(),

--- a/base_layer/wallet_ffi/src/lib.rs
+++ b/base_layer/wallet_ffi/src/lib.rs
@@ -293,7 +293,7 @@ pub unsafe extern "C" fn comms_config_create(
 
     let config = TariCommsConfig {
         node_identity: Arc::new(ni.clone()),
-        host: net_address.host().parse().unwrap(),
+        peer_connection_listening_address: net_address.host().parse().unwrap(),
         socks_proxy_address: None,
         control_service: ControlServiceConfig {
             listener_address: ni.control_service_address(),

--- a/comms/src/connection/net_address/i2p.rs
+++ b/comms/src/connection/net_address/i2p.rs
@@ -63,12 +63,12 @@ mod test {
         let addr1 = "ukeu3k5oycgaauneqgtnvselmt4yemvoilkln7jpvamvfx7dnkdq.b32.i2p".parse::<I2PAddress>();
         assert!(addr1.is_ok(), "failed to parse valid I2P address");
         let addr1 = addr1.unwrap();
-        assert_eq!("UKEU3K5OYCGAAUNEQGTNVSELMT4YEMVOILKLN7JPVAMVFX7DNKDQ", addr1.name);
+        assert_eq!("ukeu3k5oycgaauneqgtnvselmt4yemvoilkln7jpvamvfx7dnkdq", addr1.name);
 
-        let addr2 = "UKEU3K5OYCGAAUNEQGTNVSELMT4YEMVOILKLN7JPVAMVFX7DNKDQ.b32.i2p".parse::<I2PAddress>();
+        let addr2 = "ukeu3k5oycgaauNEQGTNVSELMT4YEMVOILKLN7JPVAMVFX7DNKDQ.b32.i2p".parse::<I2PAddress>();
         assert!(addr2.is_ok(), "failed to parse valid mixed case I2P address");
         let addr2 = addr2.unwrap();
-        assert_eq!("UKEU3K5OYCGAAUNEQGTNVSELMT4YEMVOILKLN7JPVAMVFX7DNKDQ", addr2.name);
+        assert_eq!("ukeu3k5oycgaauneqgtnvselmt4yemvoilkln7jpvamvfx7dnkdq", addr2.name);
 
         assert_eq!(addr1, addr2);
 

--- a/comms/src/connection/net_address/ip_dns.rs
+++ b/comms/src/connection/net_address/ip_dns.rs
@@ -1,0 +1,100 @@
+// Copyright 2019, The Tari Project
+//
+// Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+// following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+// disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+// following disclaimer in the documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+// products derived from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+// INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+// WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+// USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+use std::{fmt, str::FromStr};
+
+use serde::{Deserialize, Serialize};
+
+use super::{parser::AddressParser, NetAddressError};
+
+/// Represents a Tor Onion address
+#[derive(Clone, PartialEq, Eq, Debug, Hash, Serialize, Deserialize)]
+pub struct IpDnsAddress {
+    pub host: String,
+    pub port: u16,
+}
+
+impl IpDnsAddress {
+    pub fn host(&self) -> String {
+        self.host.clone()
+    }
+
+    pub fn port(&self) -> u16 {
+        self.port
+    }
+}
+
+impl FromStr for IpDnsAddress {
+    type Err = NetAddressError;
+
+    /// String parsing to an `IpDns`
+    fn from_str(addr: &str) -> Result<Self, Self::Err> {
+        match AddressParser::new(addr).parse_ip_dns() {
+            Some(a) => Ok(a),
+            None => Err(NetAddressError::ParseFailed),
+        }
+    }
+}
+
+impl fmt::Display for IpDnsAddress {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}:{}", self.host, self.port)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn parse() {
+        let addr1 = "foo.com:8080".parse::<IpDnsAddress>();
+        assert!(addr1.is_ok(), "failed to parse valid address");
+        let addr1 = addr1.unwrap();
+        assert_eq!("foo.com", addr1.host);
+        assert_eq!(8080, addr1.port);
+
+        let addr1 = "nqblqa3x7ddnkp664cowka6jx4mlc26vpgdksj6uya2kbyvi77aqpqqd.onion:1234".parse::<IpDnsAddress>();
+        assert!(addr1.is_ok(), "failed to parse valid address");
+        let addr1 = addr1.unwrap();
+        assert_eq!(
+            "nqblqa3x7ddnkp664cowka6jx4mlc26vpgdksj6uya2kbyvi77aqpqqd.onion",
+            addr1.host
+        );
+        assert_eq!(1234, addr1.port);
+
+        let addr = "".parse::<IpDnsAddress>();
+        assert!(addr.is_err(), "erroneously parsed a blank string");
+
+        let addr = "文字漢字漢字字字字字字字字字字字.com:2020".parse::<IpDnsAddress>();
+        assert!(addr.is_err(), "erroneously parsed an invalid string");
+
+        let addr = "localhost:9999".parse::<IpDnsAddress>();
+        assert!(addr.is_ok(), "failed to parse valid DNS address");
+
+        let addr = "my-site.com:99999".parse::<IpDnsAddress>();
+        assert!(addr.is_err(), "erroneously parsed invalid address");
+
+        let addr = "my-site:9999".parse::<IpDnsAddress>();
+        assert!(addr.is_err(), "erroneously parsed invalid address");
+    }
+}

--- a/comms/src/connection/net_address/onion.rs
+++ b/comms/src/connection/net_address/onion.rs
@@ -71,7 +71,7 @@ mod test {
         assert!(addr1.is_ok(), "failed to parse valid onion address");
         let addr1 = addr1.unwrap();
         assert_eq!(
-            "NQBLQA3X7DDNKP664COWKA6JX4MLC26VPGDKSJ6UYA2KBYVI77AQPQQD",
+            "nqblqa3x7ddnkp664cowka6jx4mlc26vpgdksj6uya2kbyvi77aqpqqd",
             addr1.public_key
         );
         assert_eq!(1234, addr1.port);
@@ -80,7 +80,7 @@ mod test {
         assert!(addr2.is_ok(), "failed to parse valid mixed case onion address");
         let addr2 = addr2.unwrap();
         assert_eq!(
-            "NQBLQA3X7DDNKP664COWKA6JX4MLC26VPGDKSJ6UYA2KBYVI77AQPQQD",
+            "nqblqa3x7ddnkp664cowka6jx4mlc26vpgdksj6uya2kbyvi77aqpqqd",
             addr2.public_key
         );
         assert_eq!(1234, addr2.port);
@@ -90,7 +90,7 @@ mod test {
         let addr = "propub3r6espa33w.onion:32123".parse::<OnionAddress>();
         assert!(addr.is_ok(), "failed to parse valid onion address");
         let addr = addr.unwrap();
-        assert_eq!("PROPUB3R6ESPA33W", addr.public_key);
+        assert_eq!("propub3r6espa33w", addr.public_key);
         assert_eq!(32123, addr.port);
 
         let addr = "".parse::<OnionAddress>();

--- a/comms/src/control_service/service.rs
+++ b/comms/src/control_service/service.rs
@@ -44,7 +44,7 @@ const LOG_TARGET: &str = "comms::control_service::service";
 /// Configuration for [ControlService]
 #[derive(Clone)]
 pub struct ControlServiceConfig {
-    /// Which address to open a port
+    /// Which address to listen on.
     pub listener_address: NetAddress,
     /// Optional SOCKS proxy
     pub socks_proxy_address: Option<SocketAddress>,


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This allows users to advertise a DNS address if they so wish.

Useful if a user does not have a static IP address and wishes to use
services like no-ip.

Updated pingpong example to use local LAN address

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
DNS addresses are a quick addition and may be useful to users

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Unit tests for new net address type

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [x] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [x] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch
* [x] I ran `cargo-fmt --all` before pushing
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
