### PR TITLE
Prevent over eager broadcast cooldown

### DIFF
--- a/base_layer/core/src/base_node/service/service.rs
+++ b/base_layer/core/src/base_node/service/service.rs
@@ -335,7 +335,7 @@ where B: BlockchainBackend
 
         let broadcast_strategy = match request_type {
             NodeCommsRequestType::Single => BroadcastStrategy::Random(1),
-            NodeCommsRequestType::Many => BroadcastStrategy::Neighbours(Box::new(Vec::new())),
+            NodeCommsRequestType::Many => BroadcastStrategy::Neighbours(Vec::new()),
         };
 
         let dest_count = self

--- a/base_layer/p2p/src/services/liveness/service.rs
+++ b/base_layer/p2p/src/services/liveness/service.rs
@@ -226,7 +226,7 @@ where
     async fn ping_neighbours(&mut self) -> Result<(), LivenessError> {
         let peers = self
             .dht_requester
-            .select_peers(BroadcastStrategy::Neighbours(Box::new(Vec::new())))
+            .select_peers(BroadcastStrategy::Neighbours(Vec::new()))
             .await?;
         trace!(
             target: LOG_TARGET,

--- a/base_layer/p2p/tests/services/liveness.rs
+++ b/base_layer/p2p/tests/services/liveness.rs
@@ -39,7 +39,7 @@ use tari_p2p::{
     },
 };
 use tari_service_framework::StackBuilder;
-use tari_test_utils::stream_collect;
+use tari_test_utils::collect_stream;
 use tokio::runtime::Runtime;
 
 pub fn setup_liveness_service(
@@ -131,7 +131,7 @@ fn end_to_end() {
         pingpong1_total = (pingpong1_total.0, pingpong1_total.1 + 1);
     }
 
-    let events = stream_collect!(
+    let events = collect_stream!(
         runtime,
         liveness1.get_event_stream_fused(),
         take = 18,
@@ -158,7 +158,7 @@ fn end_to_end() {
 
     assert_eq!(pong_count, 8);
 
-    let events = stream_collect!(
+    let events = collect_stream!(
         runtime,
         liveness2.get_event_stream_fused(),
         take = 18,

--- a/comms/dht/src/broadcast_strategy.rs
+++ b/comms/dht/src/broadcast_strategy.rs
@@ -44,7 +44,7 @@ pub enum BroadcastStrategy {
     Closest(Box<BroadcastClosestRequest>),
     /// A convenient strategy which behaves the same as the `Closest` strategy with the `NodeId` set
     /// to this node and a pre-configured number of neighbours. This strategy excludes the given public keys.
-    Neighbours(Box<Vec<CommsPublicKey>>),
+    Neighbours(Vec<CommsPublicKey>),
 }
 
 impl fmt::Display for BroadcastStrategy {

--- a/comms/dht/src/config.rs
+++ b/comms/dht/src/config.rs
@@ -54,10 +54,21 @@ pub struct DhtConfig {
     /// The time-to-live duration used for storage of high priority messages by the Store-and-forward middleware.
     /// Default: 24 hours
     pub saf_high_priority_msg_storage_ttl: Duration,
-    /// The max capacity of the signature cache (default: 1000)
+    /// The max capacity of the signature cache
+    /// Default: 1000
     pub signature_cache_capacity: usize,
-    /// The time-to-live for items in the signature cache (default: 300s)
+    /// The time-to-live for items in the signature cache
+    /// Default: 300s
     pub signature_cache_ttl: Duration,
+    /// Sets the number of failed attempts in-a-row to tolerate before temporarily excluding this peer from broadcast
+    /// messages.
+    /// Default: 3
+    pub broadcast_cooldown_max_attempts: usize,
+    /// Sets the period to wait before including this peer in broadcast messages after
+    /// `broadcast_cooldown_max_attempts` failed attempts. This helps prevent thrashing the comms layer
+    /// with connection attempts to a peer which is offline.
+    /// Default: 30 minutes
+    pub broadcast_cooldown_period: Duration,
 }
 
 impl Default for DhtConfig {
@@ -72,6 +83,8 @@ impl Default for DhtConfig {
             saf_high_priority_msg_storage_ttl: SAF_HIGH_PRIORITY_MSG_STORAGE_TTL,
             signature_cache_capacity: 1000,
             signature_cache_ttl: Duration::from_secs(300),
+            broadcast_cooldown_max_attempts: 3,
+            broadcast_cooldown_period: Duration::from_secs(60 * 30),
         }
     }
 }

--- a/comms/dht/src/inbound/dht_handler/task.rs
+++ b/comms/dht/src/inbound/dht_handler/task.rs
@@ -114,7 +114,14 @@ where
         let peer_manager = &self.peer_manager;
         // Add peer or modify existing peer using received join request
         if peer_manager.exists(pubkey) {
-            peer_manager.update_peer(pubkey, Some(node_id), Some(net_addresses), None, Some(peer_features))?;
+            peer_manager.update_peer(
+                pubkey,
+                Some(node_id),
+                Some(net_addresses),
+                None,
+                Some(peer_features),
+                None,
+            )?;
         } else {
             peer_manager.add_peer(Peer::new(
                 pubkey.clone(),
@@ -159,7 +166,7 @@ where
         let body = decryption_result.expect("already checked that this message decrypted successfully");
         let join_msg = body
             .decode_part::<JoinMessage>(0)?
-            .ok_or(DhtInboundError::InvalidMessageBody)?;
+            .ok_or(DhtInboundError::InvalidJoinNetAddresses)?;
 
         let addresses = join_msg
             .addresses
@@ -176,7 +183,9 @@ where
         // TODO: Check/Verify the received peers information. We know that the join request was signed by
         //       the origin_public_key and that the node id is valid. All that may be needed is to ping
         //       the address to confirm that it is working. If it isn't, do we disregard the join request,
-        //       or try other known addresses or ?
+        //       or try other known addresses or ?.
+        //       Perhaps we can eagerly
+
         let origin_peer = self.add_or_update_peer(
             &dht_header.origin_public_key,
             node_id,

--- a/comms/dht/src/inbound/error.rs
+++ b/comms/dht/src/inbound/error.rs
@@ -39,4 +39,6 @@ pub enum DhtInboundError {
     InvalidNodeId,
     /// All given addresses were invalid
     InvalidAddresses,
+    /// One or more NetAddress in the join message were invalid
+    InvalidJoinNetAddresses,
 }

--- a/comms/dht/src/outbound/requester.rs
+++ b/comms/dht/src/outbound/requester.rs
@@ -129,7 +129,7 @@ impl OutboundMessageRequester {
         T: prost::Message,
     {
         self.send_message(
-            BroadcastStrategy::Neighbours(Box::new(exclude_peers)),
+            BroadcastStrategy::Neighbours(exclude_peers),
             destination,
             encryption,
             message,

--- a/comms/dht/src/proto/dht.proto
+++ b/comms/dht/src/proto/dht.proto
@@ -2,8 +2,10 @@ syntax = "proto3";
 
 package tari.dht;
 
-// The JoinMessage stores the information required for a network join request. It has all the information required to
-// locate and contact the source node, but network behaviour is different compared to DiscoverMessage.
+// JoinMessage contains the information required for a network join request.
+//
+// Message containing contact information for a node wishing to join the network.
+// When this message is received, the
 message JoinMessage {
     bytes node_id = 1;
     repeated string addresses = 2;
@@ -11,7 +13,7 @@ message JoinMessage {
 }
 
 // The DiscoverMessage stores the information required for a network discover request. It has all the information
-// required to locate and contact the source node, but network behaviour is different compared to JoinMessage.
+// required to locate and contact the source node.
 message DiscoverMessage {
     bytes node_id = 1;
     repeated string addresses = 2;

--- a/comms/dht/src/store_forward/forward.rs
+++ b/comms/dht/src/store_forward/forward.rs
@@ -176,7 +176,7 @@ where
         Ok(match header_dest {
             NodeDestination::Unknown => {
                 // Send to the current nodes nearest neighbours
-                BroadcastStrategy::Neighbours(Box::new(excluded_peers))
+                BroadcastStrategy::Neighbours(excluded_peers)
             },
             NodeDestination::PublicKey(dest_public_key) => {
                 if self.peer_manager.exists(&dest_public_key) {
@@ -184,7 +184,7 @@ where
                     BroadcastStrategy::DirectPublicKey(dest_public_key)
                 } else {
                     // Send to the current nodes nearest neighbours
-                    BroadcastStrategy::Neighbours(Box::new(excluded_peers))
+                    BroadcastStrategy::Neighbours(excluded_peers)
                 }
             },
             NodeDestination::NodeId(dest_node_id) => {
@@ -195,7 +195,7 @@ where
                     },
                     Err(_) => {
                         // Send to peers that are closest to the destination network region
-                        BroadcastStrategy::Neighbours(Box::new(excluded_peers))
+                        BroadcastStrategy::Neighbours(excluded_peers)
                     },
                 }
             },

--- a/comms/src/connection_manager/connectivity.rs
+++ b/comms/src/connection_manager/connectivity.rs
@@ -32,5 +32,6 @@ pub trait Connectivity {
 
     fn disconnect_peer(&self, node_id: &NodeId) -> Result<Option<Arc<PeerConnection>>>;
 
-    //    fn set_peer_connection_eligibility(&self, node_id: &NodeId, eligibility: ConnectEligibility);
+    fn set_last_connection_failed(&self, node_id: &NodeId) -> Result<()>;
+    fn set_last_connection_succeeded(&self, node_id: &NodeId) -> Result<()>;
 }

--- a/comms/src/control_service/worker.rs
+++ b/comms/src/control_service/worker.rs
@@ -45,11 +45,10 @@ use crate::{
     },
     connection_manager::{ConnectionManager, EstablishLockResult},
     message::{Envelope, EnvelopeBody, Frame, FrameSet, MessageEnvelopeHeader, MessageExt, MessageFlags},
-    peer_manager::{peer::PeerConnectionStats, NodeId, NodeIdentity, Peer, PeerFeatures, PeerFlags, PeerManagerError},
+    peer_manager::{NodeId, NodeIdentity, Peer, PeerFeatures, PeerFlags, PeerManagerError},
     types::CommsPublicKey,
     utils::crypt,
 };
-use chrono::Utc;
 use log::*;
 use prost::Message;
 use std::{
@@ -298,6 +297,7 @@ impl ControlServiceWorker {
                     Some(vec![control_service_address.clone()]),
                     None,
                     Some(peer_features),
+                    None,
                 )?;
 
                 peer
@@ -329,21 +329,7 @@ impl ControlServiceWorker {
         });
 
         match establish_lock_result {
-            EstablishLockResult::Ok(result) => {
-                let _ = self
-                    .connection_manager
-                    .peer_manager()
-                    .update_peer_connection_stats(&peer.public_key, PeerConnectionStats {
-                        connected_at: Some(Utc::now().naive_utc()),
-                        last_connect_failed_at: None,
-                    })
-                    .or_else(|err| {
-                        warn!(target: LOG_TARGET, "Failed to update peer because '{}'", err);
-                        Err(err)
-                    });
-
-                result
-            },
+            EstablishLockResult::Ok(result) => result,
             EstablishLockResult::Collision => {
                 warn!(
                     target: LOG_TARGET,

--- a/comms/src/peer_manager/connection_stats.rs
+++ b/comms/src/peer_manager/connection_stats.rs
@@ -1,0 +1,167 @@
+// Copyright 2019, The Tari Project
+//
+// Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+// following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+// disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+// following disclaimer in the documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+// products derived from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+// INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+// WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+// USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+use chrono::{NaiveDateTime, Utc};
+use serde::{Deserialize, Serialize};
+use std::{
+    fmt,
+    fmt::{Display, Formatter},
+    time::Duration,
+};
+
+#[derive(Debug, Clone, Default, Deserialize, Serialize, PartialEq)]
+pub struct PeerConnectionStats {
+    /// The last time a connection was successfully made or, None if a successful
+    /// connection has never been made.
+    pub last_connected_at: Option<NaiveDateTime>,
+    /// Represents the last connection attempt
+    pub last_connection_attempt: LastConnectionAttempt,
+}
+
+impl PeerConnectionStats {
+    pub fn new() -> Self {
+        Default::default()
+    }
+
+    /// Sets the last connection as a success. `has_connected()` will return true from here on.
+    pub fn set_connection_success(&mut self) {
+        self.last_connected_at = Some(Utc::now().naive_utc());
+        self.last_connection_attempt = LastConnectionAttempt::Succeeded(Utc::now().naive_utc());
+    }
+
+    /// Sets the last connection as a failure
+    pub fn set_connection_failed(&mut self) {
+        self.last_connection_attempt = LastConnectionAttempt::Failed {
+            failed_at: Utc::now().naive_utc(),
+            num_attempts: self.failed_attempts() + 1,
+        };
+    }
+
+    /// Returns true if a successful connection has ever been recorded, otherwise false
+    pub fn has_ever_connected(&self) -> bool {
+        self.last_connected_at.is_some()
+    }
+
+    /// Returns the number of failed attempts. 0 is returned if the `last_connection_attempt` is not `Failed`
+    pub fn failed_attempts(&self) -> usize {
+        match self.last_connection_attempt {
+            LastConnectionAttempt::Failed { num_attempts, .. } => num_attempts,
+            _ => 0,
+        }
+    }
+
+    /// Returns the date time (UTC) since the last failed connection occurred. None is returned if the
+    /// `last_connection_attempt` is not `Failed`
+    pub fn failed_at(&self) -> Option<&NaiveDateTime> {
+        match &self.last_connection_attempt {
+            LastConnectionAttempt::Failed { failed_at, .. } => Some(failed_at),
+            _ => None,
+        }
+    }
+
+    /// Returns the Duration since the last failed connection occurred. None is returned if the
+    /// `last_connection_attempt` is not `Failed`
+    pub fn time_since_last_failure(&self) -> Option<Duration> {
+        self.failed_at()
+            .map(|failed_at| Utc::now().naive_utc() - *failed_at)
+            .map(convert_to_std_duration)
+    }
+}
+
+/// Peer connection statistics
+#[derive(Debug, Clone, Deserialize, Serialize, PartialOrd, PartialEq)]
+pub enum LastConnectionAttempt {
+    /// This node has never attempted to connect to this peer
+    Never,
+    /// The last connection attempt was successful
+    Succeeded(NaiveDateTime),
+    /// The last connection attempt failed.
+    Failed {
+        /// Timestamp of the last failed attempt
+        failed_at: NaiveDateTime,
+        /// Number of failed attempts in a row
+        num_attempts: usize,
+    },
+}
+
+/// Convert `chrono::Duration` to `std::time::Duration`
+fn convert_to_std_duration(old_duration: chrono::Duration) -> Duration {
+    Duration::from_millis(old_duration.num_milliseconds() as u64)
+}
+
+impl Default for LastConnectionAttempt {
+    fn default() -> Self {
+        LastConnectionAttempt::Never
+    }
+}
+
+impl Display for LastConnectionAttempt {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), fmt::Error> {
+        write!(f, "Last connection to peer\n")?;
+        use LastConnectionAttempt::*;
+        match self {
+            Never => write!(f, "Connection never attempted"),
+            Succeeded(succeeded_at) => write!(f, "Connection succeeded at {}", succeeded_at),
+            Failed {
+                failed_at,
+                num_attempts,
+            } => write!(
+                f,
+                "Connection failed at {} after {} attempt(s)",
+                failed_at, num_attempts
+            ),
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn peer_connection_stats() {
+        let state = PeerConnectionStats::new();
+        assert!(state.failed_at().is_none());
+        assert_eq!(state.failed_attempts(), 0);
+        assert!(state.time_since_last_failure().is_none());
+        assert_eq!(state.has_ever_connected(), false);
+
+        let mut state = PeerConnectionStats::new();
+        state.set_connection_success();
+        assert!(state.failed_at().is_none());
+        assert_eq!(state.failed_attempts(), 0);
+        assert!(state.time_since_last_failure().is_none());
+        assert_eq!(state.has_ever_connected(), true);
+
+        let mut state = PeerConnectionStats::new();
+        state.set_connection_failed();
+        state.set_connection_failed();
+        state.set_connection_failed();
+        assert!(state.failed_at().is_some());
+        assert_eq!(state.failed_attempts(), 3);
+        assert!(state.time_since_last_failure().unwrap().as_millis() < 100);
+
+        assert_eq!(state.has_ever_connected(), false);
+        state.set_connection_success();
+        assert_eq!(state.has_ever_connected(), true);
+    }
+}

--- a/comms/src/peer_manager/error.rs
+++ b/comms/src/peer_manager/error.rs
@@ -29,8 +29,6 @@ use tari_utilities::message_format::MessageFormatError;
 pub enum PeerManagerError {
     /// The requested peer does not exist or could not be located
     PeerNotFoundError,
-    /// The Thread Safety has been breached and the data access has become poisoned
-    PoisonedAccess,
     // A problem occurred during the serialization of the keys or data
     SerializationError(MessageFormatError),
     /// A problem occurred converting the serialized data into peers

--- a/comms/src/peer_manager/mod.rs
+++ b/comms/src/peer_manager/mod.rs
@@ -63,6 +63,7 @@
 
 mod peer_features;
 
+mod connection_stats;
 mod error;
 pub mod node_id;
 pub mod node_identity;

--- a/comms/src/peer_manager/peer_storage.rs
+++ b/comms/src/peer_manager/peer_storage.rs
@@ -24,8 +24,9 @@ use crate::{
     connection::net_address::NetAddress,
     consts::{COMMS_RNG, PEER_MANAGER_MAX_FLOOD_PEERS},
     peer_manager::{
+        connection_stats::PeerConnectionStats,
         node_id::{NodeDistance, NodeId},
-        peer::{Peer, PeerConnectionStats, PeerFlags},
+        peer::{Peer, PeerFlags},
         peer_key::{generate_peer_key, PeerKey},
         PeerFeatures,
         PeerManagerError,
@@ -505,7 +506,7 @@ where DS: KeyValueStore<PeerKey, Peer>
             .map_err(PeerManagerError::DatabaseError)
     }
 
-    /// Enables Thread safe access - Mark that a successful connection was established with the specified net address
+    /// Mark that a successful connection was established with the specified net address
     pub fn mark_successful_connection_attempt(&mut self, net_address: &NetAddress) -> Result<(), PeerManagerError> {
         let peer_key = *self
             .net_address_hm
@@ -516,6 +517,7 @@ where DS: KeyValueStore<PeerKey, Peer>
             .get(&peer_key)
             .map_err(PeerManagerError::DatabaseError)?
             .ok_or(PeerManagerError::PeerNotFoundError)?;
+
         peer.addresses
             .mark_successful_connection_attempt(net_address)
             .map_err(PeerManagerError::NetAddressError)?;
@@ -524,7 +526,7 @@ where DS: KeyValueStore<PeerKey, Peer>
             .map_err(PeerManagerError::DatabaseError)
     }
 
-    /// Enables Thread safe access - Mark that a connection could not be established with the specified net address
+    /// Mark that a connection could not be established with the specified net address
     pub fn mark_failed_connection_attempt(&mut self, net_address: &NetAddress) -> Result<(), PeerManagerError> {
         let peer_key = *self
             .net_address_hm
@@ -535,6 +537,7 @@ where DS: KeyValueStore<PeerKey, Peer>
             .get(&peer_key)
             .map_err(PeerManagerError::DatabaseError)?
             .ok_or(PeerManagerError::PeerNotFoundError)?;
+
         peer.addresses
             .mark_failed_connection_attempt(net_address)
             .map_err(PeerManagerError::NetAddressError)?;
@@ -556,6 +559,7 @@ where DS: KeyValueStore<PeerKey, Peer>
             .map_err(PeerManagerError::DatabaseError)?
             .ok_or(PeerManagerError::PeerNotFoundError)?;
         peer.addresses.reset_connection_attempts();
+
         self.peers
             .insert(peer_key, peer)
             .map_err(PeerManagerError::DatabaseError)

--- a/comms/src/test_utils/dialers.rs
+++ b/comms/src/test_utils/dialers.rs
@@ -87,4 +87,12 @@ impl<T> Connectivity for CountDialer<T> {
     fn disconnect_peer(&self, _: &NodeId) -> Result<Option<Arc<PeerConnection>>, ConnectionManagerError> {
         Ok(None)
     }
+
+    fn set_last_connection_failed(&self, _: &NodeId) -> Result<(), ConnectionManagerError> {
+        unimplemented!()
+    }
+
+    fn set_last_connection_succeeded(&self, _: &NodeId) -> Result<(), ConnectionManagerError> {
+        unimplemented!()
+    }
 }

--- a/comms/tests/connection_manager/actor.rs
+++ b/comms/tests/connection_manager/actor.rs
@@ -57,7 +57,6 @@ fn with_alice_and_bob(cb: impl FnOnce(CommsTestNode, CommsTestNode)) {
     let alice_identity = Arc::new(factories::node_identity::create().build().unwrap());
 
     //---------------------------------- Node B Setup --------------------------------------------//
-
     let bob_control_port_address = factories::net_address::create().build().unwrap();
     let bob_identity = Arc::new(
         factories::node_identity::create()

--- a/comms/tests/support/factories/peer.rs
+++ b/comms/tests/support/factories/peer.rs
@@ -30,6 +30,7 @@ use tari_comms::{
 
 use crate::support::makers::{comms_keys as ristretto_maker, node_id as node_id_maker};
 
+use chrono::Utc;
 use std::iter::repeat_with;
 use tari_comms::peer_manager::PeerFeatures;
 
@@ -94,6 +95,7 @@ impl TestFactory for PeerFactory {
             addresses: addresses.into(),
             features: self.peer_features,
             connection_stats: Default::default(),
+            added_at: Utc::now().naive_utc(),
         })
     }
 }

--- a/infrastructure/test_utils/src/streams/mod.rs
+++ b/infrastructure/test_utils/src/streams/mod.rs
@@ -41,14 +41,14 @@ where
 /// # use tokio::runtime::Runtime;
 /// # use futures::stream;
 /// # use std::time::Duration;
-/// # use tari_test_utils::stream_collect;
+/// # use tari_test_utils::collect_stream;
 ///
 /// let rt = Runtime::new().unwrap();
 /// let stream = stream::iter(1..10);
-/// assert_eq!(stream_collect!(rt, stream, take=3, timeout=Duration::from_secs(1)), vec![1,2,3]);
+/// assert_eq!(collect_stream!(rt, stream, take=3, timeout=Duration::from_secs(1)), vec![1,2,3]);
 /// ```
 #[macro_export]
-macro_rules! stream_collect {
+macro_rules! collect_stream {
     ($runtime:expr, $stream:expr, take=$take:expr, timeout=$timeout:expr $(,)?) => {{
         use futures::StreamExt as __FuturesStreamExt;
         use tokio::future::FutureExt as __TokioFuturesExt;
@@ -73,23 +73,23 @@ macro_rules! stream_collect {
 /// # use tokio::runtime::Runtime;
 /// # use futures::stream;
 /// # use std::time::Duration;
-/// # use tari_test_utils::stream_collect_count;
+/// # use tari_test_utils::collect_stream_count;
 ///
 /// let rt = Runtime::new().unwrap();
 /// let stream = stream::iter(vec![1,2,2,3,2]);
-/// assert_eq!(stream_collect_count!(rt, stream, timeout=Duration::from_secs(1)).get(&2), Some(&3));
+/// assert_eq!(collect_stream_count!(rt, stream, timeout=Duration::from_secs(1)).get(&2), Some(&3));
 /// ```
 #[macro_export]
-macro_rules! stream_collect_count {
+macro_rules! collect_stream_count {
     ($runtime:expr, $stream:expr, take=$take:expr, timeout=$timeout:expr$(,)?) => {{
         use std::collections::HashMap;
-        let items = $crate::stream_collect!($runtime, $stream, take = $take, timeout = $timeout);
+        let items = $crate::collect_stream!($runtime, $stream, take = $take, timeout = $timeout);
         $crate::streams::get_item_counts(items)
     }};
 
     ($runtime:expr, $stream:expr, timeout=$timeout:expr $(,)?) => {{
         use std::collections::HashMap;
-        let items = $crate::stream_collect!($runtime, $stream, timeout = $timeout);
+        let items = $crate::collect_stream!($runtime, $stream, timeout = $timeout);
         $crate::streams::get_item_counts(items)
     }};
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
- Allow a few attempts (configurable) to broadcast before entering a
  cooldown period for broadcasts (configurable) per peer
- ~~`PeerConnectionStats` replaced with `LastConnectionState`.
  `LastConnectionState` specifically deals with the last connection~~
- `PeerConnectionStats` includes details on the last connection  attempt 
and how many times a connection failed in a row.
- Test for select_peers in DHT
- Should fix flakiness for simultaneous connect test (e.g. https://app.circleci.com/jobs/github/tari-project/tari/7232)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
When using a 1:many broadcast strategy, peers which are not contactable should be temporarily excluded. This allows broadcasting to 'expand' (in terms of the distance metric) if a number of neighbouring nodes go offline. An attempt to contact nodes directly is still always attempted.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [x] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [x] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch
* [x] I ran `cargo-fmt --all` before pushing
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
