### PR TITLE
Update zMQ v0.9.2

### DIFF
--- a/comms/Cargo.toml
+++ b/comms/Cargo.toml
@@ -15,6 +15,7 @@ tari_utilities = { version="^0.0",  path = "../infrastructure/tari_util" }
 tari_shutdown = { version="^0.0",  path = "../infrastructure/shutdown" }
 
 bitflags ="1.0.4"
+bytes = "0.4.12"
 chrono = { version = "0.4.6", features = ["serde"] }
 clear_on_drop = "0.2.3"
 derive-error = "0.0.4"
@@ -23,17 +24,16 @@ futures =  { version = "=0.3.0-alpha.19", package = "futures-preview", features 
 lazy_static = "1.3.0"
 lmdb-zero = "0.4.4"
 log = { version = "0.4.0", features = ["std"] }
+prost = "0.5.0"
 rand = "0.5.5"
 serde = "1.0.90"
 serde_derive = "1.0.90"
+serde_repr = "0.1.5"
 time = "0.1.42"
 tokio = "0.2.0-alpha.6"
 tokio-executor = { version ="^0.2.0-alpha.6", features = ["threadpool"] }
 ttl_cache = "0.5.1"
-zmq = "0.9.1"
-serde_repr = "0.1.5"
-prost = "0.5.0"
-bytes = "0.4.12"
+zmq = "0.9.2"
 
 [dev-dependencies]
 tari_test_utils = {path="../infrastructure/test_utils"}


### PR DESCRIPTION
Release notes here:
https://github.com/erickt/rust-zmq/blob/master/NEWS.md#092

Nothing that really effects this project but it's often a good idea to
stay up to date
