### PR TITLE
BaseNodeService: local api interface and propagation of blocks

### DIFF
--- a/base_layer/core/src/base_node/comms_interface/comms_request.rs
+++ b/base_layer/core/src/base_node/comms_interface/comms_request.rs
@@ -51,4 +51,5 @@ pub enum NodeCommsRequest {
     FetchUtxos(Vec<HashOutput>),
     FetchBlocks(Vec<u64>),
     FetchMmrState(MmrStateRequest),
+    GetNewBlock,
 }

--- a/base_layer/core/src/base_node/comms_interface/comms_response.rs
+++ b/base_layer/core/src/base_node/comms_interface/comms_response.rs
@@ -21,7 +21,7 @@
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 use crate::{
-    blocks::blockheader::BlockHeader,
+    blocks::{blockheader::BlockHeader, Block},
     chain_storage::{ChainMetadata, HistoricalBlock, MutableMmrState},
 };
 use serde::{Deserialize, Serialize};
@@ -36,4 +36,5 @@ pub enum NodeCommsResponse {
     TransactionOutputs(Vec<TransactionOutput>),
     HistoricalBlocks(Vec<HistoricalBlock>),
     MmrState(MutableMmrState),
+    NewBlock(Block),
 }

--- a/base_layer/core/src/base_node/comms_interface/inbound_handlers.rs
+++ b/base_layer/core/src/base_node/comms_interface/inbound_handlers.rs
@@ -22,19 +22,19 @@
 
 use crate::{
     base_node::comms_interface::{error::CommsInterfaceError, NodeCommsRequest, NodeCommsResponse},
-    blocks::blockheader::BlockHeader,
+    blocks::{blockheader::BlockHeader, Block},
     chain_storage::{async_db, BlockchainBackend, BlockchainDatabase, HistoricalBlock},
 };
 use tari_transactions::transaction::{TransactionKernel, TransactionOutput};
 
 /// The InboundNodeCommsInterface is used to handle all received inbound requests from remote nodes.
-pub struct InboundNodeCommsInterface<T>
+pub struct InboundNodeCommsHandlers<T>
 where T: BlockchainBackend
 {
     blockchain_db: BlockchainDatabase<T>,
 }
 
-impl<T> InboundNodeCommsInterface<T>
+impl<T> InboundNodeCommsHandlers<T>
 where T: BlockchainBackend
 {
     /// Construct a new InboundNodeCommsInterface.
@@ -42,7 +42,7 @@ where T: BlockchainBackend
         Self { blockchain_db }
     }
 
-    /// Handle inbound node comms requests from remote nodes.
+    /// Handle inbound node comms requests from remote nodes and local services.
     pub async fn handle_request(&self, request: &NodeCommsRequest) -> Result<NodeCommsResponse, CommsInterfaceError> {
         match request {
             NodeCommsRequest::GetChainMetadata => Ok(NodeCommsResponse::ChainMetadata(
@@ -93,6 +93,18 @@ where T: BlockchainBackend
                 )
                 .await?,
             )),
+            NodeCommsRequest::GetNewBlock =>
+            // TODO: query blockchain_db and mempool to construct a new mineable block
+            {
+                unimplemented!()
+            },
         }
+    }
+
+    /// Handle inbound blocks from remote nodes and local services.
+    pub async fn handle_block(&self, block: &Block) -> Result<(), CommsInterfaceError> {
+        // TODO: Validate block and create event on block stream
+
+        Ok(())
     }
 }

--- a/base_layer/core/src/base_node/comms_interface/local_interface.rs
+++ b/base_layer/core/src/base_node/comms_interface/local_interface.rs
@@ -1,0 +1,72 @@
+// Copyright 2019. The Tari Project
+//
+// Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+// following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+// disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+// following disclaimer in the documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+// products derived from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+// INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+// WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+// USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+use crate::{
+    base_node::comms_interface::{error::CommsInterfaceError, NodeCommsRequest, NodeCommsResponse},
+    blocks::Block,
+    chain_storage::ChainMetadata,
+};
+use tari_service_framework::reply_channel::SenderService;
+use tower_service::Service;
+
+/// The InboundNodeCommsInterface provides an interface to request information from the current local node by other
+/// internal services.
+#[derive(Clone)]
+pub struct LocalNodeCommsInterface {
+    request_sender: SenderService<NodeCommsRequest, Result<NodeCommsResponse, CommsInterfaceError>>,
+    block_sender: SenderService<Block, Result<(), CommsInterfaceError>>,
+}
+
+impl LocalNodeCommsInterface {
+    /// Construct a new LocalNodeCommsInterface with the specified SenderService.
+    pub fn new(
+        request_sender: SenderService<NodeCommsRequest, Result<NodeCommsResponse, CommsInterfaceError>>,
+        block_sender: SenderService<Block, Result<(), CommsInterfaceError>>,
+    ) -> Self
+    {
+        Self {
+            request_sender,
+            block_sender,
+        }
+    }
+
+    /// Request metadata from the current local node.
+    pub async fn get_metadata(&mut self) -> Result<ChainMetadata, CommsInterfaceError> {
+        match self.request_sender.call(NodeCommsRequest::GetChainMetadata).await?? {
+            NodeCommsResponse::ChainMetadata(metadata) => Ok(metadata),
+            _ => Err(CommsInterfaceError::UnexpectedApiResponse),
+        }
+    }
+
+    /// Request the construction of a new block from the base node service.
+    pub async fn get_new_block(&mut self) -> Result<Block, CommsInterfaceError> {
+        match self.request_sender.call(NodeCommsRequest::GetNewBlock).await?? {
+            NodeCommsResponse::NewBlock(block) => Ok(block),
+            _ => Err(CommsInterfaceError::UnexpectedApiResponse),
+        }
+    }
+
+    /// Submit a block to the base node service.
+    pub async fn submit_block(&mut self, block: Block) -> Result<(), CommsInterfaceError> {
+        self.block_sender.call(block).await?
+    }
+}

--- a/base_layer/core/src/base_node/comms_interface/mod.rs
+++ b/base_layer/core/src/base_node/comms_interface/mod.rs
@@ -23,12 +23,14 @@
 mod comms_request;
 mod comms_response;
 mod error;
-mod inbound_interface;
+mod inbound_handlers;
+mod local_interface;
 mod outbound_interface;
 
 // Public re-exports
 pub use comms_request::{MmrStateRequest, NodeCommsRequest, NodeCommsRequestType};
 pub use comms_response::NodeCommsResponse;
 pub use error::CommsInterfaceError;
-pub use inbound_interface::InboundNodeCommsInterface;
+pub use inbound_handlers::InboundNodeCommsHandlers;
+pub use local_interface::LocalNodeCommsInterface;
 pub use outbound_interface::OutboundNodeCommsInterface;

--- a/base_layer/core/src/base_node/comms_interface/outbound_interface.rs
+++ b/base_layer/core/src/base_node/comms_interface/outbound_interface.rs
@@ -28,7 +28,7 @@ use crate::{
         NodeCommsRequestType,
         NodeCommsResponse,
     },
-    blocks::blockheader::BlockHeader,
+    blocks::{blockheader::BlockHeader, Block},
     chain_storage::{ChainMetadata, HistoricalBlock, MmrTree, MutableMmrState},
 };
 use tari_service_framework::reply_channel::SenderService;
@@ -41,26 +41,31 @@ use tower_service::Service;
 /// The OutboundNodeCommsInterface provides an interface to request information from remove nodes.
 #[derive(Clone)]
 pub struct OutboundNodeCommsInterface {
-    sender:
+    request_sender:
         SenderService<(NodeCommsRequest, NodeCommsRequestType), Result<Vec<NodeCommsResponse>, CommsInterfaceError>>,
+    block_sender: SenderService<Block, Result<(), CommsInterfaceError>>,
 }
 
 impl OutboundNodeCommsInterface {
     /// Construct a new OutboundNodeCommsInterface with the specified SenderService.
     pub fn new(
-        sender: SenderService<
+        request_sender: SenderService<
             (NodeCommsRequest, NodeCommsRequestType),
             Result<Vec<NodeCommsResponse>, CommsInterfaceError>,
         >,
+        block_sender: SenderService<Block, Result<(), CommsInterfaceError>>,
     ) -> Self
     {
-        Self { sender }
+        Self {
+            request_sender,
+            block_sender,
+        }
     }
 
     /// Request metadata from remote base nodes.
     pub async fn get_metadata(&mut self) -> Result<Vec<ChainMetadata>, CommsInterfaceError> {
         let mut responses = Vec::<ChainMetadata>::new();
-        self.sender
+        self.request_sender
             .call((NodeCommsRequest::GetChainMetadata, NodeCommsRequestType::Many))
             .await??
             .into_iter()
@@ -79,7 +84,7 @@ impl OutboundNodeCommsInterface {
     ) -> Result<Vec<TransactionKernel>, CommsInterfaceError>
     {
         if let Some(NodeCommsResponse::TransactionKernels(kernels)) = self
-            .sender
+            .request_sender
             .call((NodeCommsRequest::FetchKernels(hashes), NodeCommsRequestType::Single))
             .await??
             .first()
@@ -93,7 +98,7 @@ impl OutboundNodeCommsInterface {
     /// Fetch the block headers corresponding to the provided block numbers from remote base nodes.
     pub async fn fetch_headers(&mut self, block_nums: Vec<u64>) -> Result<Vec<BlockHeader>, CommsInterfaceError> {
         if let Some(NodeCommsResponse::BlockHeaders(headers)) = self
-            .sender
+            .request_sender
             .call((NodeCommsRequest::FetchHeaders(block_nums), NodeCommsRequestType::Single))
             .await??
             .first()
@@ -111,7 +116,7 @@ impl OutboundNodeCommsInterface {
     ) -> Result<Vec<TransactionOutput>, CommsInterfaceError>
     {
         if let Some(NodeCommsResponse::TransactionOutputs(utxos)) = self
-            .sender
+            .request_sender
             .call((NodeCommsRequest::FetchUtxos(hashes), NodeCommsRequestType::Single))
             .await??
             .first()
@@ -125,7 +130,7 @@ impl OutboundNodeCommsInterface {
     /// Fetch the Historical Blocks corresponding to the provided block numbers from remote base nodes.
     pub async fn fetch_blocks(&mut self, block_nums: Vec<u64>) -> Result<Vec<HistoricalBlock>, CommsInterfaceError> {
         if let Some(NodeCommsResponse::HistoricalBlocks(blocks)) = self
-            .sender
+            .request_sender
             .call((NodeCommsRequest::FetchBlocks(block_nums), NodeCommsRequestType::Single))
             .await??
             .first()
@@ -145,7 +150,7 @@ impl OutboundNodeCommsInterface {
     ) -> Result<MutableMmrState, CommsInterfaceError>
     {
         if let Some(NodeCommsResponse::MmrState(mmr_state)) = self
-            .sender
+            .request_sender
             .call((
                 NodeCommsRequest::FetchMmrState(MmrStateRequest { tree, index, count }),
                 NodeCommsRequestType::Single,
@@ -157,5 +162,10 @@ impl OutboundNodeCommsInterface {
         } else {
             Err(CommsInterfaceError::UnexpectedApiResponse)
         }
+    }
+
+    /// Transmit the a block to remote base nodes.
+    pub async fn propagate_block(&mut self, block: Block) -> Result<(), CommsInterfaceError> {
+        self.block_sender.call(block).await?
     }
 }

--- a/base_layer/core/src/base_node/proto/request.proto
+++ b/base_layer/core/src/base_node/proto/request.proto
@@ -19,6 +19,8 @@ message BaseNodeServiceRequest {
         BlockHeights fetch_blocks = 6;
         // Indicates a FetchMmrState request.
         MmrStateRequest fetch_mmr_state = 7;
+        // Indicates a GetNewBlock request.
+        bool get_new_block = 8;
     }
 }
 

--- a/base_layer/core/src/base_node/proto/request.rs
+++ b/base_layer/core/src/base_node/proto/request.rs
@@ -39,6 +39,7 @@ impl TryInto<ci::NodeCommsRequest> for ProtoNodeCommsRequest {
             FetchUtxos(hash_outputs) => ci::NodeCommsRequest::FetchUtxos(hash_outputs.outputs),
             FetchBlocks(block_heights) => ci::NodeCommsRequest::FetchBlocks(block_heights.heights),
             FetchMmrState(mmr_state_request) => ci::NodeCommsRequest::FetchMmrState(mmr_state_request.try_into()?),
+            GetNewBlock(_) => ci::NodeCommsRequest::GetNewBlock,
         };
         Ok(request)
     }
@@ -54,6 +55,7 @@ impl From<ci::NodeCommsRequest> for ProtoNodeCommsRequest {
             FetchUtxos(hash_outputs) => ProtoNodeCommsRequest::FetchUtxos(hash_outputs.into()),
             FetchBlocks(block_heights) => ProtoNodeCommsRequest::FetchBlocks(block_heights.into()),
             FetchMmrState(mmr_state_request) => ProtoNodeCommsRequest::FetchMmrState(mmr_state_request.into()),
+            GetNewBlock => ProtoNodeCommsRequest::GetNewBlock(true),
         }
     }
 }

--- a/base_layer/core/src/base_node/proto/response.proto
+++ b/base_layer/core/src/base_node/proto/response.proto
@@ -17,6 +17,7 @@ message BaseNodeServiceResponse {
         TransactionOutputs transaction_outputs = 5;
         HistoricalBlocks historical_blocks = 6;
         MutableMmrState mmr_state = 7;
+        tari.core.Block new_block = 8;
     }
 }
 

--- a/base_layer/core/src/base_node/proto/response.rs
+++ b/base_layer/core/src/base_node/proto/response.rs
@@ -60,6 +60,7 @@ impl TryInto<ci::NodeCommsResponse> for ProtoNodeCommsResponse {
                 ci::NodeCommsResponse::HistoricalBlocks(blocks)
             },
             MmrState(state) => ci::NodeCommsResponse::MmrState(state.try_into()?),
+            NewBlock(block) => ci::NodeCommsResponse::NewBlock(block.try_into()?),
         };
 
         Ok(response)
@@ -88,6 +89,7 @@ impl From<ci::NodeCommsResponse> for ProtoNodeCommsResponse {
                 ProtoNodeCommsResponse::HistoricalBlocks(historical_blocks)
             },
             MmrState(state) => ProtoNodeCommsResponse::MmrState(state.into()),
+            NewBlock(block) => ProtoNodeCommsResponse::NewBlock(block.into()),
         }
     }
 }

--- a/base_layer/core/src/base_node/test/service.rs
+++ b/base_layer/core/src/base_node/test/service.rs
@@ -22,7 +22,7 @@
 
 use crate::{
     base_node::{
-        comms_interface::{CommsInterfaceError, OutboundNodeCommsInterface},
+        comms_interface::{CommsInterfaceError, LocalNodeCommsInterface, OutboundNodeCommsInterface},
         service::{BaseNodeServiceConfig, BaseNodeServiceInitializer},
     },
     blocks::{genesis_block::get_genesis_block, BlockHeader},
@@ -118,13 +118,37 @@ where
     (comms, dht)
 }
 
+struct NodeInterfaces {
+    pub outbound_nci: OutboundNodeCommsInterface,
+    pub local_nci: LocalNodeCommsInterface,
+    pub blockchain_db: BlockchainDatabase<MemoryDatabase<HashDigest>>,
+    pub comms: CommsNode,
+}
+
+impl NodeInterfaces {
+    fn new(
+        outbound_nci: OutboundNodeCommsInterface,
+        local_nci: LocalNodeCommsInterface,
+        blockchain_db: BlockchainDatabase<MemoryDatabase<HashDigest>>,
+        comms: CommsNode,
+    ) -> Self
+    {
+        Self {
+            outbound_nci,
+            local_nci,
+            blockchain_db,
+            comms,
+        }
+    }
+}
+
 pub fn setup_base_node_service(
     runtime: &Runtime,
     node_identity: NodeIdentity,
     peers: Vec<NodeIdentity>,
     blockchain_db: BlockchainDatabase<MemoryDatabase<HashDigest>>,
     config: BaseNodeServiceConfig,
-) -> (OutboundNodeCommsInterface, CommsNode)
+) -> (OutboundNodeCommsInterface, LocalNodeCommsInterface, CommsNode)
 {
     let (publisher, subscription_factory) = pubsub_connector(runtime.executor(), 100);
     let subscription_factory = Arc::new(subscription_factory);
@@ -142,25 +166,46 @@ pub fn setup_base_node_service(
     let handles = runtime.block_on(fut).expect("Service initialization failed");
 
     let outbound_nci = handles.get_handle::<OutboundNodeCommsInterface>().unwrap();
+    let local_nci = handles.get_handle::<LocalNodeCommsInterface>().unwrap();
 
-    (outbound_nci, comms)
+    (outbound_nci, local_nci, comms)
+}
+
+fn create_base_node(
+    runtime: &Runtime,
+    config: BaseNodeServiceConfig,
+) -> (
+    OutboundNodeCommsInterface,
+    LocalNodeCommsInterface,
+    BlockchainDatabase<MemoryDatabase<HashDigest>>,
+    CommsNode,
+)
+{
+    let mut rng = OsRng::new().unwrap();
+    let node_identity = NodeIdentity::random(
+        &mut rng,
+        get_next_local_address().parse().unwrap(),
+        PeerFeatures::COMMUNICATION_NODE,
+    )
+    .unwrap();
+    let blockchain_db = BlockchainDatabase::new(MemoryDatabase::<HashDigest>::default()).unwrap();
+
+    let (outbound_nci, local_nci, comms) = setup_base_node_service(
+        &runtime,
+        node_identity.clone(),
+        Vec::new(),
+        blockchain_db.clone(),
+        config.clone(),
+    );
+
+    (outbound_nci, local_nci, blockchain_db, comms)
 }
 
 fn create_network_with_3_base_nodes(
     runtime: &Runtime,
     config: BaseNodeServiceConfig,
     mct_config: MerkleChangeTrackerConfig,
-) -> (
-    OutboundNodeCommsInterface,
-    OutboundNodeCommsInterface,
-    OutboundNodeCommsInterface,
-    BlockchainDatabase<MemoryDatabase<HashDigest>>,
-    BlockchainDatabase<MemoryDatabase<HashDigest>>,
-    BlockchainDatabase<MemoryDatabase<HashDigest>>,
-    CommsNode,
-    CommsNode,
-    CommsNode,
-)
+) -> (NodeInterfaces, NodeInterfaces, NodeInterfaces)
 {
     let mut rng = OsRng::new().unwrap();
     let alice_node_identity = NodeIdentity::random(
@@ -187,54 +232,47 @@ fn create_network_with_3_base_nodes(
     .unwrap();
     let carol_blockchain_db = BlockchainDatabase::new(MemoryDatabase::<HashDigest>::new(mct_config)).unwrap();
 
-    let (alice_outbound_nci, alice_comms) = setup_base_node_service(
+    let (alice_outbound_nci, alice_local_nci, alice_comms) = setup_base_node_service(
         &runtime,
         alice_node_identity.clone(),
         vec![bob_node_identity.clone(), carol_node_identity.clone()],
         alice_blockchain_db.clone(),
         config.clone(),
     );
-    let (bob_outbound_nci, bob_comms) = setup_base_node_service(
+    let (bob_outbound_nci, bob_local_nci, bob_comms) = setup_base_node_service(
         &runtime,
         bob_node_identity.clone(),
         vec![alice_node_identity.clone(), carol_node_identity.clone()],
         bob_blockchain_db.clone(),
         config.clone(),
     );
-    let (carol_outbound_nci, carol_comms) = setup_base_node_service(
+    let (carol_outbound_nci, carol_local_nci, carol_comms) = setup_base_node_service(
         &runtime,
         carol_node_identity,
         vec![alice_node_identity, bob_node_identity],
         carol_blockchain_db.clone(),
         config,
     );
-    (
-        alice_outbound_nci,
-        bob_outbound_nci,
-        carol_outbound_nci,
-        alice_blockchain_db,
-        bob_blockchain_db,
-        carol_blockchain_db,
-        alice_comms,
-        bob_comms,
-        carol_comms,
-    )
+    let alice_interfaces = NodeInterfaces::new(alice_outbound_nci, alice_local_nci, alice_blockchain_db, alice_comms);
+    let bob_interfaces = NodeInterfaces::new(bob_outbound_nci, bob_local_nci, bob_blockchain_db, bob_comms);
+    let carol_interfaces = NodeInterfaces::new(carol_outbound_nci, carol_local_nci, carol_blockchain_db, carol_comms);
+    (alice_interfaces, bob_interfaces, carol_interfaces)
 }
 
 #[test]
 fn request_response_get_metadata() {
     let runtime = Runtime::new().unwrap();
 
-    let (mut alice_outbound_nci, _, _, _, bob_blockchain_db, _, alice_comms, bob_comms, carol_comms) =
+    let (mut alice_interfaces, bob_interfaces, carol_interfaces) =
         create_network_with_3_base_nodes(&runtime, BaseNodeServiceConfig::default(), MerkleChangeTrackerConfig {
             min_history_len: 10,
             max_history_len: 20,
         });
 
-    add_block_and_update_header(&bob_blockchain_db, create_genesis_block().0);
+    add_block_and_update_header(&bob_interfaces.blockchain_db, create_genesis_block().0);
 
     runtime.block_on(async {
-        let received_metadata = alice_outbound_nci.get_metadata().await.unwrap();
+        let received_metadata = alice_interfaces.outbound_nci.get_metadata().await.unwrap();
         assert_eq!(received_metadata.len(), 2);
         assert!(
             (received_metadata[0].height_of_longest_chain == None) ||
@@ -246,16 +284,16 @@ fn request_response_get_metadata() {
         );
     });
 
-    alice_comms.shutdown().unwrap();
-    bob_comms.shutdown().unwrap();
-    carol_comms.shutdown().unwrap();
+    alice_interfaces.comms.shutdown().unwrap();
+    bob_interfaces.comms.shutdown().unwrap();
+    carol_interfaces.comms.shutdown().unwrap();
 }
 
 #[test]
 fn request_and_response_fetch_headers() {
     let runtime = Runtime::new().unwrap();
 
-    let (mut alice_outbound_nci, _, _, _, bob_blockchain_db, carol_blockchain_db, alice_comms, bob_comms, carol_comms) =
+    let (mut alice_interfaces, bob_interfaces, carol_interfaces) =
         create_network_with_3_base_nodes(&runtime, BaseNodeServiceConfig::default(), MerkleChangeTrackerConfig {
             min_history_len: 10,
             max_history_len: 20,
@@ -268,7 +306,7 @@ fn request_and_response_fetch_headers() {
     let mut txn = DbTransaction::new();
     txn.insert_header(headerb1.clone());
     txn.insert_header(headerb2.clone());
-    assert!(bob_blockchain_db.commit(txn).is_ok());
+    assert!(bob_interfaces.blockchain_db.commit(txn).is_ok());
 
     let mut headerc1 = BlockHeader::new(0);
     headerc1.height = 1;
@@ -277,15 +315,15 @@ fn request_and_response_fetch_headers() {
     let mut txn = DbTransaction::new();
     txn.insert_header(headerc1.clone());
     txn.insert_header(headerc2.clone());
-    assert!(carol_blockchain_db.commit(txn).is_ok());
+    assert!(carol_interfaces.blockchain_db.commit(txn).is_ok());
 
     // The request is sent to a random remote base node so the returned headers can be from bob or carol
     runtime.block_on(async {
-        let received_headers = alice_outbound_nci.fetch_headers(vec![1]).await.unwrap();
+        let received_headers = alice_interfaces.outbound_nci.fetch_headers(vec![1]).await.unwrap();
         assert_eq!(received_headers.len(), 1);
         assert!(received_headers.contains(&headerb1) || received_headers.contains(&headerc1));
 
-        let received_headers = alice_outbound_nci.fetch_headers(vec![1, 2]).await.unwrap();
+        let received_headers = alice_interfaces.outbound_nci.fetch_headers(vec![1, 2]).await.unwrap();
         assert_eq!(received_headers.len(), 2);
         assert!(
             (received_headers.contains(&headerb1) && (received_headers.contains(&headerb2))) ||
@@ -293,16 +331,16 @@ fn request_and_response_fetch_headers() {
         );
     });
 
-    alice_comms.shutdown().unwrap();
-    bob_comms.shutdown().unwrap();
-    carol_comms.shutdown().unwrap();
+    alice_interfaces.comms.shutdown().unwrap();
+    bob_interfaces.comms.shutdown().unwrap();
+    carol_interfaces.comms.shutdown().unwrap();
 }
 
 #[test]
 fn request_and_response_fetch_kernels() {
     let runtime = Runtime::new().unwrap();
 
-    let (mut alice_outbound_nci, _, _, _, bob_blockchain_db, carol_blockchain_db, alice_comms, bob_comms, carol_comms) =
+    let (mut alice_interfaces, bob_interfaces, carol_interfaces) =
         create_network_with_3_base_nodes(&runtime, BaseNodeServiceConfig::default(), MerkleChangeTrackerConfig {
             min_history_len: 10,
             max_history_len: 20,
@@ -316,33 +354,41 @@ fn request_and_response_fetch_kernels() {
     let mut txn = DbTransaction::new();
     txn.insert_kernel(kernel1.clone());
     txn.insert_kernel(kernel2.clone());
-    assert!(bob_blockchain_db.commit(txn).is_ok());
+    assert!(bob_interfaces.blockchain_db.commit(txn).is_ok());
     let mut txn = DbTransaction::new();
     txn.insert_kernel(kernel1.clone());
     txn.insert_kernel(kernel2.clone());
-    assert!(carol_blockchain_db.commit(txn).is_ok());
+    assert!(carol_interfaces.blockchain_db.commit(txn).is_ok());
 
     runtime.block_on(async {
-        let received_kernels = alice_outbound_nci.fetch_kernels(vec![hash1.clone()]).await.unwrap();
+        let received_kernels = alice_interfaces
+            .outbound_nci
+            .fetch_kernels(vec![hash1.clone()])
+            .await
+            .unwrap();
         assert_eq!(received_kernels.len(), 1);
         assert_eq!(received_kernels[0], kernel1);
 
-        let received_kernels = alice_outbound_nci.fetch_kernels(vec![hash1, hash2]).await.unwrap();
+        let received_kernels = alice_interfaces
+            .outbound_nci
+            .fetch_kernels(vec![hash1, hash2])
+            .await
+            .unwrap();
         assert_eq!(received_kernels.len(), 2);
         assert!(received_kernels.contains(&kernel1));
         assert!(received_kernels.contains(&kernel2));
     });
 
-    alice_comms.shutdown().unwrap();
-    bob_comms.shutdown().unwrap();
-    carol_comms.shutdown().unwrap();
+    alice_interfaces.comms.shutdown().unwrap();
+    bob_interfaces.comms.shutdown().unwrap();
+    carol_interfaces.comms.shutdown().unwrap();
 }
 
 #[test]
 fn request_and_response_fetch_utxos() {
     let runtime = Runtime::new().unwrap();
 
-    let (mut alice_outbound_nci, _, _, _, bob_blockchain_db, carol_blockchain_db, alice_comms, bob_comms, carol_comms) =
+    let (mut alice_interfaces, bob_interfaces, carol_interfaces) =
         create_network_with_3_base_nodes(&runtime, BaseNodeServiceConfig::default(), MerkleChangeTrackerConfig {
             min_history_len: 10,
             max_history_len: 20,
@@ -356,63 +402,71 @@ fn request_and_response_fetch_utxos() {
     let mut txn = DbTransaction::new();
     txn.insert_utxo(utxo1.clone());
     txn.insert_utxo(utxo2.clone());
-    assert!(bob_blockchain_db.commit(txn).is_ok());
+    assert!(bob_interfaces.blockchain_db.commit(txn).is_ok());
     let mut txn = DbTransaction::new();
     txn.insert_utxo(utxo1.clone());
     txn.insert_utxo(utxo2.clone());
-    assert!(carol_blockchain_db.commit(txn).is_ok());
+    assert!(carol_interfaces.blockchain_db.commit(txn).is_ok());
 
     runtime.block_on(async {
-        let received_utxos = alice_outbound_nci.fetch_utxos(vec![hash1.clone()]).await.unwrap();
+        let received_utxos = alice_interfaces
+            .outbound_nci
+            .fetch_utxos(vec![hash1.clone()])
+            .await
+            .unwrap();
         assert_eq!(received_utxos.len(), 1);
         assert_eq!(received_utxos[0], utxo1);
 
-        let received_utxos = alice_outbound_nci.fetch_utxos(vec![hash1, hash2]).await.unwrap();
+        let received_utxos = alice_interfaces
+            .outbound_nci
+            .fetch_utxos(vec![hash1, hash2])
+            .await
+            .unwrap();
         assert_eq!(received_utxos.len(), 2);
         assert!(received_utxos.contains(&utxo1));
         assert!(received_utxos.contains(&utxo2));
     });
 
-    alice_comms.shutdown().unwrap();
-    bob_comms.shutdown().unwrap();
-    carol_comms.shutdown().unwrap();
+    alice_interfaces.comms.shutdown().unwrap();
+    bob_interfaces.comms.shutdown().unwrap();
+    carol_interfaces.comms.shutdown().unwrap();
 }
 
 #[test]
 fn request_and_response_fetch_blocks() {
     let runtime = Runtime::new().unwrap();
 
-    let (mut alice_outbound_nci, _, _, _, bob_blockchain_db, carol_blockchain_db, alice_comms, bob_comms, carol_comms) =
+    let (mut alice_interfaces, bob_interfaces, carol_interfaces) =
         create_network_with_3_base_nodes(&runtime, BaseNodeServiceConfig::default(), MerkleChangeTrackerConfig {
             min_history_len: 10,
             max_history_len: 20,
         });
 
-    let block0 = add_block_and_update_header(&bob_blockchain_db, get_genesis_block());
+    let block0 = add_block_and_update_header(&bob_interfaces.blockchain_db, get_genesis_block());
     let mut block1 = chain_block(&block0, vec![]);
-    block1 = add_block_and_update_header(&bob_blockchain_db, block1);
+    block1 = add_block_and_update_header(&bob_interfaces.blockchain_db, block1);
     let mut block2 = chain_block(&block1, vec![]);
-    block2 = add_block_and_update_header(&bob_blockchain_db, block2);
+    block2 = add_block_and_update_header(&bob_interfaces.blockchain_db, block2);
 
-    carol_blockchain_db.add_new_block(block0.clone()).unwrap();
-    carol_blockchain_db.add_new_block(block1.clone()).unwrap();
-    carol_blockchain_db.add_new_block(block2.clone()).unwrap();
+    carol_interfaces.blockchain_db.add_new_block(block0.clone()).unwrap();
+    carol_interfaces.blockchain_db.add_new_block(block1.clone()).unwrap();
+    carol_interfaces.blockchain_db.add_new_block(block2.clone()).unwrap();
 
     runtime.block_on(async {
-        let received_blocks = alice_outbound_nci.fetch_blocks(vec![0]).await.unwrap();
+        let received_blocks = alice_interfaces.outbound_nci.fetch_blocks(vec![0]).await.unwrap();
         assert_eq!(received_blocks.len(), 1);
         assert_eq!(*received_blocks[0].block(), block0);
 
-        let received_blocks = alice_outbound_nci.fetch_blocks(vec![0, 1]).await.unwrap();
+        let received_blocks = alice_interfaces.outbound_nci.fetch_blocks(vec![0, 1]).await.unwrap();
         assert_eq!(received_blocks.len(), 2);
         assert_ne!(*received_blocks[0].block(), *received_blocks[1].block());
         assert!((*received_blocks[0].block() == block0) || (*received_blocks[1].block() == block0));
         assert!((*received_blocks[0].block() == block1) || (*received_blocks[1].block() == block1));
     });
 
-    alice_comms.shutdown().unwrap();
-    bob_comms.shutdown().unwrap();
-    carol_comms.shutdown().unwrap();
+    alice_interfaces.comms.shutdown().unwrap();
+    bob_interfaces.comms.shutdown().unwrap();
+    carol_interfaces.comms.shutdown().unwrap();
 }
 
 #[test]
@@ -423,80 +477,100 @@ fn request_and_response_fetch_mmr_state() {
         min_history_len: 1,
         max_history_len: 3,
     };
-    let (mut alice_outbound_nci, _, _, _, bob_blockchain_db, carol_blockchain_db, alice_comms, bob_comms, carol_comms) =
+    let (mut alice_interfaces, bob_interfaces, carol_interfaces) =
         create_network_with_3_base_nodes(&runtime, BaseNodeServiceConfig::default(), mct_config);
 
     let (tx1, inputs1, _) = tx!(10_000*uT, fee: 50*uT, inputs: 1, outputs: 1);
     let (tx2, inputs2, _) = tx!(10_000*uT, fee: 20*uT, inputs: 1, outputs: 1);
     let (_, inputs3, _) = tx!(10_000*uT, fee: 25*uT, inputs: 1, outputs: 1);
 
-    let block0 = add_block_and_update_header(&bob_blockchain_db, get_genesis_block());
+    let block0 = add_block_and_update_header(&bob_interfaces.blockchain_db, get_genesis_block());
     let mut txn = DbTransaction::new();
     txn.insert_utxo(inputs1[0].as_transaction_output(&PROVER, &COMMITMENT_FACTORY).unwrap());
     txn.insert_utxo(inputs2[0].as_transaction_output(&PROVER, &COMMITMENT_FACTORY).unwrap());
     txn.insert_utxo(inputs3[0].as_transaction_output(&PROVER, &COMMITMENT_FACTORY).unwrap());
-    assert!(bob_blockchain_db.commit(txn).is_ok());
+    assert!(bob_interfaces.blockchain_db.commit(txn).is_ok());
     let mut block1 = chain_block(&block0, vec![tx1.clone()]);
-    block1 = add_block_and_update_header(&bob_blockchain_db, block1);
+    block1 = add_block_and_update_header(&bob_interfaces.blockchain_db, block1);
     let mut block2 = chain_block(&block1, vec![]);
-    block2 = add_block_and_update_header(&bob_blockchain_db, block2);
+    block2 = add_block_and_update_header(&bob_interfaces.blockchain_db, block2);
     let block3 = chain_block(&block2, vec![tx2.clone()]);
-    bob_blockchain_db.add_new_block(block3.clone()).unwrap();
+    bob_interfaces.blockchain_db.add_new_block(block3.clone()).unwrap();
 
-    let block0 = add_block_and_update_header(&carol_blockchain_db, get_genesis_block());
+    let block0 = add_block_and_update_header(&carol_interfaces.blockchain_db, get_genesis_block());
     let mut txn = DbTransaction::new();
     txn.insert_utxo(inputs1[0].as_transaction_output(&PROVER, &COMMITMENT_FACTORY).unwrap());
     txn.insert_utxo(inputs2[0].as_transaction_output(&PROVER, &COMMITMENT_FACTORY).unwrap());
     txn.insert_utxo(inputs3[0].as_transaction_output(&PROVER, &COMMITMENT_FACTORY).unwrap());
-    assert!(carol_blockchain_db.commit(txn).is_ok());
+    assert!(carol_interfaces.blockchain_db.commit(txn).is_ok());
     let mut block1 = chain_block(&block0, vec![tx1.clone()]);
-    block1 = add_block_and_update_header(&carol_blockchain_db, block1);
+    block1 = add_block_and_update_header(&carol_interfaces.blockchain_db, block1);
     let mut block2 = chain_block(&block1, vec![]);
-    block2 = add_block_and_update_header(&carol_blockchain_db, block2);
+    block2 = add_block_and_update_header(&carol_interfaces.blockchain_db, block2);
     let block3 = chain_block(&block2, vec![tx2.clone()]);
-    carol_blockchain_db.add_new_block(block3.clone()).unwrap();
+    carol_interfaces.blockchain_db.add_new_block(block3.clone()).unwrap();
 
     runtime.block_on(async {
         // Partial queries
-        let received_mmr_state = alice_outbound_nci.fetch_mmr_state(MmrTree::Utxo, 1, 2).await.unwrap();
+        let received_mmr_state = alice_interfaces
+            .outbound_nci
+            .fetch_mmr_state(MmrTree::Utxo, 1, 2)
+            .await
+            .unwrap();
         assert_eq!(received_mmr_state.total_leaf_count, 4);
         assert_eq!(received_mmr_state.leaf_nodes.leaf_hashes.len(), 2);
 
-        let received_mmr_state = alice_outbound_nci.fetch_mmr_state(MmrTree::Kernel, 1, 2).await.unwrap();
+        let received_mmr_state = alice_interfaces
+            .outbound_nci
+            .fetch_mmr_state(MmrTree::Kernel, 1, 2)
+            .await
+            .unwrap();
         assert_eq!(received_mmr_state.total_leaf_count, 1);
         assert_eq!(received_mmr_state.leaf_nodes.leaf_hashes.len(), 0); // request out of range
 
-        let received_mmr_state = alice_outbound_nci
+        let received_mmr_state = alice_interfaces
+            .outbound_nci
             .fetch_mmr_state(MmrTree::RangeProof, 1, 2)
             .await
             .unwrap();
         assert_eq!(received_mmr_state.total_leaf_count, 4);
         assert_eq!(received_mmr_state.leaf_nodes.leaf_hashes.len(), 2);
 
-        let received_mmr_state = alice_outbound_nci.fetch_mmr_state(MmrTree::Header, 1, 2).await.unwrap();
+        let received_mmr_state = alice_interfaces
+            .outbound_nci
+            .fetch_mmr_state(MmrTree::Header, 1, 2)
+            .await
+            .unwrap();
         assert_eq!(received_mmr_state.total_leaf_count, 3);
         assert_eq!(received_mmr_state.leaf_nodes.leaf_hashes.len(), 2);
 
         // Comprehensive queries
-        let received_mmr_state = alice_outbound_nci.fetch_mmr_state(MmrTree::Utxo, 0, 100).await.unwrap();
+        let received_mmr_state = alice_interfaces
+            .outbound_nci
+            .fetch_mmr_state(MmrTree::Utxo, 0, 100)
+            .await
+            .unwrap();
         assert_eq!(received_mmr_state.total_leaf_count, 4);
         assert_eq!(received_mmr_state.leaf_nodes.leaf_hashes.len(), 4);
 
-        let received_mmr_state = alice_outbound_nci
+        let received_mmr_state = alice_interfaces
+            .outbound_nci
             .fetch_mmr_state(MmrTree::Kernel, 0, 100)
             .await
             .unwrap();
         assert_eq!(received_mmr_state.total_leaf_count, 1);
         assert_eq!(received_mmr_state.leaf_nodes.leaf_hashes.len(), 1);
 
-        let received_mmr_state = alice_outbound_nci
+        let received_mmr_state = alice_interfaces
+            .outbound_nci
             .fetch_mmr_state(MmrTree::RangeProof, 0, 100)
             .await
             .unwrap();
         assert_eq!(received_mmr_state.total_leaf_count, 4);
         assert_eq!(received_mmr_state.leaf_nodes.leaf_hashes.len(), 4);
 
-        let received_mmr_state = alice_outbound_nci
+        let received_mmr_state = alice_interfaces
+            .outbound_nci
             .fetch_mmr_state(MmrTree::Header, 0, 100)
             .await
             .unwrap();
@@ -504,10 +578,12 @@ fn request_and_response_fetch_mmr_state() {
         assert_eq!(received_mmr_state.leaf_nodes.leaf_hashes.len(), 3);
     });
 
-    alice_comms.shutdown().unwrap();
-    bob_comms.shutdown().unwrap();
-    carol_comms.shutdown().unwrap();
+    alice_interfaces.comms.shutdown().unwrap();
+    bob_interfaces.comms.shutdown().unwrap();
+    carol_interfaces.comms.shutdown().unwrap();
 }
+
+// TODO: propagate_block test
 
 #[test]
 fn service_request_timeout() {
@@ -534,14 +610,14 @@ fn service_request_timeout() {
     .unwrap();
     let bob_blockchain_db = BlockchainDatabase::new(MemoryDatabase::<HashDigest>::default()).unwrap();
 
-    let (mut alice_outbound_nci, alice_comms) = setup_base_node_service(
+    let (mut alice_outbound_nci, _, alice_comms) = setup_base_node_service(
         &runtime,
         alice_node_identity.clone(),
         vec![bob_node_identity.clone()],
         alice_blockchain_db,
         base_node_service_config.clone(),
     );
-    let (_bob_outbound_nci, bob_comms) = setup_base_node_service(
+    let (_, _, bob_comms) = setup_base_node_service(
         &runtime,
         bob_node_identity.clone(),
         vec![alice_node_identity.clone()],
@@ -559,3 +635,28 @@ fn service_request_timeout() {
     alice_comms.shutdown().unwrap();
     bob_comms.shutdown().unwrap();
 }
+
+#[test]
+fn local_get_metadata() {
+    let runtime = Runtime::new().unwrap();
+    let (outbound_nci, mut local_nci, blockchain_db, comms) =
+        create_base_node(&runtime, BaseNodeServiceConfig::default());
+
+    let block0 = add_block_and_update_header(&blockchain_db, get_genesis_block());
+    let mut block1 = chain_block(&block0, vec![]);
+    block1 = add_block_and_update_header(&blockchain_db, block1);
+    let mut block2 = chain_block(&block1, vec![]);
+    block2 = add_block_and_update_header(&blockchain_db, block2);
+
+    runtime.block_on(async {
+        let metadata = local_nci.get_metadata().await.unwrap();
+        assert_eq!(metadata.height_of_longest_chain, Some(2));
+        assert_eq!(metadata.best_block, Some(block2.hash()));
+    });
+
+    comms.shutdown().unwrap();
+}
+
+// TODO: local get_new_block test
+
+// TODO: local submit_block test


### PR DESCRIPTION
## Description
- Added the local base node service interface that allows the miner and other local services to request information from the base node service.
- Local services can use the local interface to request the metadata of the local base node service, the construction of a new block and submitting of blocks.
- The propagate_block function has been added to the OutboundNodeCommsInterface, to enable the broadcasting of validated blocks.
- The name of the InboundNodeCommsInterface has been changed to InboundNodeCommsHandlers.
- The logic of constructing a new block and handling of received blocks still need to be implemented.

## Motivation and Context
These additions allow the local miner to submit completed blocks and local services to propagate blocks to the network.

## How Has This Been Tested?
Added a test for testing the local interface for retrieving the metadata of the B
base node.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [x] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [x] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch
* [x] I ran `cargo-fmt --all` before pushing
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
