### PR TITLE
Change FFI completed_transaction_get_status representation from c_char to c_int

### DIFF
--- a/base_layer/wallet_ffi/src/lib.rs
+++ b/base_layer/wallet_ffi/src/lib.rs
@@ -836,7 +836,7 @@ pub unsafe extern "C" fn completed_transaction_get_source_public_key(
 /// `transaction` - The pointer to a TariCompletedTransaction
 ///
 /// ## Returns
-/// `c_char` - Returns the status which corresponds to:
+/// `c_int` - Returns the status which corresponds to:
 /// | Value | Interpretation |
 /// |---|---|
 /// |  -1 | TxNullError |
@@ -844,12 +844,12 @@ pub unsafe extern "C" fn completed_transaction_get_source_public_key(
 /// |   1 | Broadcast |
 /// |   2 | Mined |
 #[no_mangle]
-pub unsafe extern "C" fn completed_transaction_get_status(transaction: *mut TariCompletedTransaction) -> c_char {
+pub unsafe extern "C" fn completed_transaction_get_status(transaction: *mut TariCompletedTransaction) -> c_int {
     if transaction.is_null() {
-        return -1 as c_char;
+        return -1;
     }
     let status = (*transaction).status.clone();
-    status as c_char
+    status as c_int
 }
 
 /// Gets the amount of a TariCompletedTransaction

--- a/base_layer/wallet_ffi/wallet.h
+++ b/base_layer/wallet_ffi/wallet.h
@@ -174,7 +174,7 @@ const char *completed_transaction_get_message(struct TariCompletedTransaction *t
 // |   0 | Completed |
 // |   1 | Broadcast |
 // |   2 | Mined |
-char completed_transaction_get_status(struct TariCompletedTransaction *transaction);
+int completed_transaction_get_status(struct TariCompletedTransaction *transaction);
 
 // Gets the TransactionID of a TariCompletedTransaction
 unsigned long long completed_transaction_get_transaction_id(struct TariCompletedTransaction *transaction);


### PR DESCRIPTION
The method completed_transaction_get_status, for the iOS build c_char is interpreted as i8, for the Android build it is interpreted as u8, which results in an error. Changing the return to c_int resolves the problem.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch
* [x] I ran `cargo-fmt --all` before pushing
* [x] My change requires a change to the documentation.
* [x] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
