### PR TITLE
Initiate Discovery when direct public key strategy used on unknown peer

### DIFF
--- a/comms/dht/build.rs
+++ b/comms/dht/build.rs
@@ -22,7 +22,6 @@
 
 fn main() {
     tari_protobuf_build::ProtoCompiler::new()
-        .add_type_attribute(".tari.comms.control_service.RejectReason", "#[derive(Error)]")
         .proto_paths(&["src/proto"])
         .out_dir("src/proto")
         .compile()

--- a/comms/dht/src/actor.rs
+++ b/comms/dht/src/actor.rs
@@ -29,13 +29,10 @@
 
 use crate::{
     broadcast_strategy::{BroadcastClosestRequest, BroadcastStrategy},
+    discovery::DhtDiscoveryError,
     envelope::NodeDestination,
     outbound::{OutboundEncryption, OutboundMessageRequester},
-    proto::{
-        dht::{DiscoverMessage, JoinMessage},
-        envelope::DhtMessageType,
-        store_forward::StoredMessagesRequest,
-    },
+    proto::{dht::JoinMessage, envelope::DhtMessageType, store_forward::StoredMessagesRequest},
     DhtConfig,
 };
 use chrono::{DateTime, Utc};
@@ -82,6 +79,7 @@ pub enum DhtActorError {
     PeerManagerError(PeerManagerError),
     #[error(msg_embedded, no_from, non_std)]
     SendFailed(String),
+    DiscoveryError(DhtDiscoveryError),
 }
 
 impl From<SendError> for DhtActorError {
@@ -100,12 +98,6 @@ impl From<SendError> for DhtActorError {
 pub enum DhtRequest {
     /// Send a Join request to the network
     SendJoin,
-    /// Send a discover request for a network region or node
-    SendDiscover {
-        dest_public_key: CommsPublicKey,
-        dest_node_id: Option<NodeId>,
-        destination: NodeDestination,
-    },
     /// Send a request for stored messages, optionally specifying a date time that the foreign node should
     /// use to filter the returned messages.
     SendRequestStoredMessages(Option<DateTime<Utc>>),
@@ -136,23 +128,6 @@ impl DhtRequester {
             .send(DhtRequest::SelectPeers(broadcast_strategy, reply_tx))
             .await?;
         reply_rx.await.map_err(|_| DhtActorError::ReplyCanceled)
-    }
-
-    pub async fn send_discover(
-        &mut self,
-        dest_public_key: CommsPublicKey,
-        dest_node_id: Option<NodeId>,
-        destination: NodeDestination,
-    ) -> Result<(), DhtActorError>
-    {
-        self.sender
-            .send(DhtRequest::SendDiscover {
-                dest_public_key,
-                dest_node_id,
-                destination,
-            })
-            .await
-            .map_err(Into::into)
     }
 
     pub async fn insert_message_signature(&mut self, signature: Vec<u8>) -> Result<bool, DhtActorError> {
@@ -205,7 +180,7 @@ impl<'a> DhtActor<'a> {
         }
     }
 
-    pub async fn start(mut self) {
+    pub async fn run(mut self) {
         let mut shutdown_signal = self
             .shutdown_signal
             .take()
@@ -231,7 +206,7 @@ impl<'a> DhtActor<'a> {
                     }
                 },
 
-                _guard = shutdown_signal => {
+                _ = shutdown_signal => {
                     info!(target: LOG_TARGET, "DhtActor is shutting down because it received a shutdown signal.");
                     break;
                 },
@@ -255,23 +230,6 @@ impl<'a> DhtActor<'a> {
                     self.config.num_neighbouring_nodes,
                 ))
             },
-            SendDiscover {
-                destination,
-                dest_node_id,
-                dest_public_key,
-            } => {
-                let node_identity = Arc::clone(&self.node_identity);
-                let outbound_requester = self.outbound_requester.clone();
-                Box::pin(Self::send_discover(
-                    node_identity,
-                    outbound_requester,
-                    self.config.num_neighbouring_nodes,
-                    dest_public_key,
-                    dest_node_id,
-                    destination,
-                ))
-            },
-
             SignatureCacheInsert(signature, reply_tx) => {
                 // No locks needed here. Downside is this isn't really async, however this should be
                 // fine as it is very quick
@@ -279,8 +237,8 @@ impl<'a> DhtActor<'a> {
                     .signature_cache
                     .insert(signature, (), self.config.signature_cache_ttl)
                     .is_some();
-                let _ = reply_tx.send(already_exists);
-                Box::pin(future::ready(Ok(())))
+                let result = reply_tx.send(already_exists).map_err(|_| DhtActorError::ReplyCanceled);
+                Box::pin(future::ready(result))
             },
             SelectPeers(broadcast_strategy, reply_tx) => {
                 let peer_manager = Arc::clone(&self.peer_manager);
@@ -288,13 +246,10 @@ impl<'a> DhtActor<'a> {
                 let config = self.config.clone();
                 Box::pin(blocking::run(move || {
                     match Self::select_peers(config, node_identity, peer_manager, broadcast_strategy) {
-                        Ok(peers) => {
-                            let _ = reply_tx.send(peers);
-                            Ok(())
-                        },
+                        Ok(peers) => reply_tx.send(peers).map_err(|_| DhtActorError::ReplyCanceled),
                         Err(err) => {
-                            let _ = reply_tx.send(Vec::new());
-                            Err(err)
+                            error!(target: LOG_TARGET, "Peer selection failed: {}", err);
+                            reply_tx.send(Vec::new()).map_err(|_| DhtActorError::ReplyCanceled)
                         },
                     }
                 }))
@@ -343,53 +298,6 @@ impl<'a> DhtActor<'a> {
             )
             .await
             .map_err(|err| DhtActorError::SendFailed(format!("Failed to send join message: {}", err)))?;
-
-        Ok(())
-    }
-
-    async fn send_discover(
-        node_identity: Arc<NodeIdentity>,
-        mut outbound_requester: OutboundMessageRequester,
-        num_neighbouring_nodes: usize,
-        dest_public_key: CommsPublicKey,
-        dest_node_id: Option<NodeId>,
-        destination: NodeDestination,
-    ) -> Result<(), DhtActorError>
-    {
-        let discover_msg = DiscoverMessage {
-            node_id: node_identity.node_id().to_vec(),
-            addresses: vec![node_identity.control_service_address().to_string()],
-            peer_features: node_identity.features().bits(),
-        };
-        debug!(
-            target: LOG_TARGET,
-            "Sending Discover message to (at most) {} closest peers", num_neighbouring_nodes
-        );
-
-        // If the destination node is is known, send to the closest peers we know. Otherwise...
-        let network_location_node_id = dest_node_id.unwrap_or(match &destination {
-            // ... if the destination is undisclosed or a public key, send discover to our closest peers
-            NodeDestination::Unknown | NodeDestination::PublicKey(_) => node_identity.node_id().clone(),
-            // otherwise, send it to the closest peers to the given NodeId destination we know
-            NodeDestination::NodeId(node_id) => node_id.clone(),
-        });
-
-        let broadcast_strategy = BroadcastStrategy::Closest(Box::new(BroadcastClosestRequest {
-            n: num_neighbouring_nodes,
-            node_id: network_location_node_id,
-            excluded_peers: Vec::new(),
-        }));
-
-        outbound_requester
-            .send_dht_message(
-                broadcast_strategy,
-                destination,
-                OutboundEncryption::EncryptFor(dest_public_key),
-                DhtMessageType::Discover,
-                discover_msg,
-            )
-            .await
-            .map_err(|err| DhtActorError::SendFailed(format!("Failed to send discovery message: {}", err)))?;
 
         Ok(())
     }
@@ -540,9 +448,10 @@ impl<'a> DhtActor<'a> {
         if total > 0 {
             debug!(
                 target: LOG_TARGET,
-                "\n====================================\n {total} peer(s) were excluded from closest query\n {banned} \
-                 banned\n{not_propagation_node} not communication node\n {not_connectable} are not connectable\n \
-                 {excluded} excluded\n====================================\n",
+                "\n====================================\n Closest Peer Selection\n\n {num_peers} peer(s) selected\n \
+                 {total} peer(s) were excluded \n {banned} banned\n {not_propagation_node} not communication node\n \
+                 {not_connectable} are not connectable\n {excluded} excluded\n====================================\n",
+                num_peers = peers.len(),
                 total = total,
                 banned = banned_count,
                 not_propagation_node = not_propagation_node_count,
@@ -585,7 +494,7 @@ mod test {
                 shutdown.to_signal(),
             );
 
-            rt.spawn(actor.start());
+            rt.spawn(actor.run());
 
             rt.block_on(async move {
                 requester.send_join().await.unwrap();
@@ -595,37 +504,37 @@ mod test {
         });
     }
 
-    #[test]
-    fn send_discover_request() {
-        runtime::test_async(|rt| {
-            let node_identity = make_node_identity();
-            let peer_manager = make_peer_manager();
-            let (out_tx, mut out_rx) = mpsc::channel(1);
-            let (actor_tx, actor_rx) = mpsc::channel(1);
-            let mut requester = DhtRequester::new(actor_tx);
-            let outbound_requester = OutboundMessageRequester::new(out_tx);
-            let shutdown = Shutdown::new();
-            let actor = DhtActor::new(
-                Default::default(),
-                node_identity,
-                peer_manager,
-                outbound_requester,
-                actor_rx,
-                shutdown.to_signal(),
-            );
-
-            rt.spawn(actor.start());
-
-            rt.block_on(async move {
-                requester
-                    .send_discover(CommsPublicKey::default(), None, NodeDestination::Unknown)
-                    .await
-                    .unwrap();
-                let request = unwrap_oms_send_msg!(out_rx.next().await.unwrap());
-                assert_eq!(request.dht_message_type, DhtMessageType::Discover);
-            });
-        });
-    }
+    //    #[test]
+    //    fn send_discover_request() {
+    //        runtime::test_async(|rt| {
+    //            let node_identity = make_node_identity();
+    //            let peer_manager = make_peer_manager();
+    //            let (out_tx, mut out_rx) = mpsc::channel(1);
+    //            let (actor_tx, actor_rx) = mpsc::channel(1);
+    //            let mut requester = DhtRequester::new(actor_tx);
+    //            let outbound_requester = OutboundMessageRequester::new(out_tx);
+    //            let shutdown = Shutdown::new();
+    //            let actor = DhtActor::new(
+    //                Default::default(),
+    //                node_identity,
+    //                peer_manager,
+    //                outbound_requester,
+    //                actor_rx,
+    //                shutdown.to_signal(),
+    //            );
+    //
+    //            rt.spawn(actor.run());
+    //
+    //            rt.block_on(async move {
+    //                requester
+    //                    .send_discover(CommsPublicKey::default(), None, NodeDestination::Unknown)
+    //                    .await
+    //                    .unwrap();
+    //                let request = unwrap_oms_send_msg!(out_rx.next().await.unwrap());
+    //                assert_eq!(request.dht_message_type, DhtMessageType::Discovery);
+    //            });
+    //        });
+    //    }
 
     #[test]
     fn insert_message_signature() {
@@ -646,7 +555,7 @@ mod test {
                 shutdown.to_signal(),
             );
 
-            rt.spawn(actor.start());
+            rt.spawn(actor.run());
 
             rt.block_on(async move {
                 let signature = vec![1u8, 2, 3];
@@ -688,7 +597,7 @@ mod test {
                 shutdown.to_signal(),
             );
 
-            rt.spawn(actor.start());
+            rt.spawn(actor.run());
 
             rt.block_on(async move {
                 let peers = requester

--- a/comms/dht/src/builder.rs
+++ b/comms/dht/src/builder.rs
@@ -83,6 +83,11 @@ impl DhtBuilder {
         self
     }
 
+    pub fn with_discovery_timeout(mut self, timeout: Duration) -> Self {
+        self.config.discovery_request_timeout = timeout;
+        self
+    }
+
     pub fn finish(self) -> Dht {
         Dht::new(
             self.config,

--- a/comms/dht/src/config.rs
+++ b/comms/dht/src/config.rs
@@ -69,6 +69,9 @@ pub struct DhtConfig {
     /// with connection attempts to a peer which is offline.
     /// Default: 30 minutes
     pub broadcast_cooldown_period: Duration,
+    /// The duration to wait for a peer discovery to complete before giving up.
+    /// Default: 2 minutes
+    pub discovery_request_timeout: Duration,
 }
 
 impl Default for DhtConfig {
@@ -85,6 +88,7 @@ impl Default for DhtConfig {
             signature_cache_ttl: Duration::from_secs(300),
             broadcast_cooldown_max_attempts: 3,
             broadcast_cooldown_period: Duration::from_secs(60 * 30),
+            discovery_request_timeout: Duration::from_secs(2 * 60),
         }
     }
 }

--- a/comms/dht/src/discovery/mod.rs
+++ b/comms/dht/src/discovery/mod.rs
@@ -20,26 +20,10 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use crate::{discovery::DhtDiscoveryError, outbound::DhtOutboundError};
-use derive_error::Error;
-use prost::DecodeError;
-use tari_comms::{message::MessageError, peer_manager::PeerManagerError};
+mod error;
+mod requester;
+mod service;
 
-#[derive(Debug, Error)]
-pub enum DhtInboundError {
-    MessageError(MessageError),
-    //    MessageFormatError(MessageFormatError),
-    PeerManagerError(PeerManagerError),
-    DhtOutboundError(DhtOutboundError),
-    /// Failed to decode message
-    DecodeError(DecodeError),
-    /// Message body invalid
-    InvalidMessageBody,
-    /// Node ID is invalid
-    InvalidNodeId,
-    /// All given addresses were invalid
-    InvalidAddresses,
-    /// One or more NetAddress in the join message were invalid
-    InvalidJoinNetAddresses,
-    DhtDiscoveryError(DhtDiscoveryError),
-}
+pub(crate) use self::requester::DhtDiscoveryRequest;
+
+pub use self::{error::DhtDiscoveryError, requester::DhtDiscoveryRequester, service::DhtDiscoveryService};

--- a/comms/dht/src/discovery/requester.rs
+++ b/comms/dht/src/discovery/requester.rs
@@ -1,0 +1,141 @@
+// Copyright 2019, The Tari Project
+//
+// Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+// following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+// disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+// following disclaimer in the documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+// products derived from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+// INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+// WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+// USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+use crate::{discovery::DhtDiscoveryError, envelope::NodeDestination, proto::dht::DiscoveryResponseMessage};
+use futures::{
+    channel::{mpsc, oneshot},
+    SinkExt,
+};
+use std::{
+    fmt::{Display, Error, Formatter},
+    time::Duration,
+};
+use tari_comms::{
+    peer_manager::{NodeId, Peer},
+    types::CommsPublicKey,
+};
+use tokio::future::FutureExt;
+
+#[derive(Debug)]
+pub struct DiscoverPeerRequest {
+    /// The public key of the peer to be discovered. The message will be encrypted with a DH shared
+    /// secret using this public key.
+    pub dest_public_key: CommsPublicKey,
+    /// The node id of the peer to be discovered, if it is known. Providing the `NodeId` allows
+    /// discovery requests to reach their destination more quickly.
+    pub dest_node_id: Option<NodeId>,
+    /// The destination to include in the comms header.
+    /// `Undisclosed` will require nodes to propagate the message across the network, presumably eventually
+    /// reaching the destination node (the node which can decrypt the message). This will happen without
+    /// any intermediary nodes knowing who is being searched for.
+    /// `NodeId` will direct the discovery request closer to the destination or network region.
+    /// `PublicKey` will be propagated across the network. If any node knows the peer, the request can be
+    /// forwarded to them immediately. However, more nodes will know that this node is being searched for
+    /// which may slightly compromise privacy.
+    pub destination: NodeDestination,
+}
+
+impl Display for DiscoverPeerRequest {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), Error> {
+        f.debug_struct("DiscoverPeerRequest")
+            .field("dest_public_key", &format!("{}", self.dest_public_key))
+            .field(
+                "dest_node_id",
+                &self
+                    .dest_node_id
+                    .as_ref()
+                    .map(|node_id| format!("{}", node_id))
+                    .unwrap_or("None".to_string()),
+            )
+            .field("destination", &format!("{}", self.destination))
+            .finish()
+    }
+}
+
+#[derive(Debug)]
+pub enum DhtDiscoveryRequest {
+    DiscoverPeer(Box<(DiscoverPeerRequest, oneshot::Sender<Result<Peer, DhtDiscoveryError>>)>),
+    NotifyDiscoveryResponseReceived(Box<DiscoveryResponseMessage>),
+}
+
+impl Display for DhtDiscoveryRequest {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), Error> {
+        use DhtDiscoveryRequest::*;
+        match self {
+            DiscoverPeer(boxed) => write!(f, "DiscoverPeer({})", boxed.0),
+            NotifyDiscoveryResponseReceived(boxed) => write!(f, "NotifyDiscoveryResponseReceived({:#?})", *boxed),
+        }
+    }
+}
+
+#[derive(Clone)]
+pub struct DhtDiscoveryRequester {
+    sender: mpsc::Sender<DhtDiscoveryRequest>,
+    discovery_timeout: Duration,
+}
+
+impl DhtDiscoveryRequester {
+    pub fn new(sender: mpsc::Sender<DhtDiscoveryRequest>, discovery_timeout: Duration) -> Self {
+        Self {
+            sender,
+            discovery_timeout,
+        }
+    }
+
+    pub async fn discover_peer(
+        &mut self,
+        dest_public_key: CommsPublicKey,
+        dest_node_id: Option<NodeId>,
+        destination: NodeDestination,
+    ) -> Result<Peer, DhtDiscoveryError>
+    {
+        let (reply_tx, reply_rx) = oneshot::channel();
+        let request = DiscoverPeerRequest {
+            dest_public_key,
+            dest_node_id,
+            destination,
+        };
+        self.sender
+            .send(DhtDiscoveryRequest::DiscoverPeer(Box::new((request, reply_tx))))
+            .await?;
+
+        reply_rx
+            .timeout(self.discovery_timeout)
+            .await
+            // Timeout?
+            .map_err(|_| DhtDiscoveryError::DiscoveryTimeout)?
+            // Channel error?
+            .map_err(|_| DhtDiscoveryError::ReplyCanceled)?
+    }
+
+    pub async fn notify_discovery_response_received(
+        &mut self,
+        response: DiscoveryResponseMessage,
+    ) -> Result<(), DhtDiscoveryError>
+    {
+        self.sender
+            .send(DhtDiscoveryRequest::NotifyDiscoveryResponseReceived(Box::new(response)))
+            .await?;
+
+        Ok(())
+    }
+}

--- a/comms/dht/src/discovery/service.rs
+++ b/comms/dht/src/discovery/service.rs
@@ -1,0 +1,404 @@
+// Copyright 2019, The Tari Project
+//
+// Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+// following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+// disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+// following disclaimer in the documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+// products derived from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+// INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+// WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+// USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+use crate::{
+    broadcast_strategy::{BroadcastClosestRequest, BroadcastStrategy},
+    consts::DHT_RNG,
+    discovery::{
+        requester::{DhtDiscoveryRequest, DiscoverPeerRequest},
+        DhtDiscoveryError,
+    },
+    envelope::{DhtMessageType, NodeDestination},
+    outbound::{OutboundEncryption, OutboundMessageRequester},
+    proto::dht::{DiscoveryMessage, DiscoveryResponseMessage},
+    DhtConfig,
+};
+use futures::{
+    channel::{mpsc, oneshot},
+    future::FutureExt,
+    StreamExt,
+};
+use log::*;
+use rand::RngCore;
+use std::{collections::HashMap, sync::Arc};
+use tari_comms::{
+    connection::NetAddress,
+    log_if_error,
+    peer_manager::{NodeId, NodeIdentity, Peer, PeerFeatures, PeerFlags, PeerManager},
+    types::CommsPublicKey,
+};
+use tari_shutdown::ShutdownSignal;
+use tari_utilities::{hex::Hex, ByteArray};
+
+const LOG_TARGET: &str = "comms::dht::discovery_service";
+
+struct DiscoveryRequestState {
+    reply_tx: oneshot::Sender<Result<Peer, DhtDiscoveryError>>,
+    public_key: CommsPublicKey,
+}
+
+pub struct DhtDiscoveryService {
+    config: DhtConfig,
+    node_identity: Arc<NodeIdentity>,
+    outbound_requester: OutboundMessageRequester,
+    peer_manager: Arc<PeerManager>,
+    request_rx: Option<mpsc::Receiver<DhtDiscoveryRequest>>,
+    shutdown_signal: Option<ShutdownSignal>,
+    inflight_discoveries: HashMap<u64, DiscoveryRequestState>,
+}
+
+impl DhtDiscoveryService {
+    pub fn new(
+        config: DhtConfig,
+        node_identity: Arc<NodeIdentity>,
+        peer_manager: Arc<PeerManager>,
+        outbound_requester: OutboundMessageRequester,
+        request_rx: mpsc::Receiver<DhtDiscoveryRequest>,
+        shutdown_signal: ShutdownSignal,
+    ) -> Self
+    {
+        Self {
+            config,
+            outbound_requester,
+            node_identity,
+            peer_manager,
+            shutdown_signal: Some(shutdown_signal),
+            request_rx: Some(request_rx),
+            inflight_discoveries: HashMap::new(),
+        }
+    }
+
+    pub async fn run(mut self) {
+        let mut shutdown_signal = self
+            .shutdown_signal
+            .take()
+            .expect("DiscoveryService initialized without shutdown_signal")
+            .fuse();
+
+        let mut request_rx = self
+            .request_rx
+            .take()
+            .expect("DiscoveryService initialized without request_rx")
+            .fuse();
+
+        loop {
+            futures::select! {
+                request = request_rx.select_next_some() => {
+                    trace!(target: LOG_TARGET, "Received request '{}'", request);
+                    self.handle_request(request).await;
+                },
+
+                _ = shutdown_signal => {
+                    info!(target: LOG_TARGET, "Discovery service is shutting down because the shutdown signal was received");
+                    break;
+                }
+            }
+        }
+    }
+
+    async fn handle_request(&mut self, request: DhtDiscoveryRequest) {
+        use DhtDiscoveryRequest::*;
+        match request {
+            DiscoverPeer(boxed) => {
+                let (request, reply_tx) = *boxed;
+                log_if_error!(
+                    target: LOG_TARGET,
+                    "Failed to initiate a discovery request because '{}'",
+                    self.initiate_peer_discovery(request, reply_tx).await
+                );
+            },
+
+            NotifyDiscoveryResponseReceived(discovery_msg) => self.handle_discovery_response(*discovery_msg),
+        }
+    }
+
+    fn collect_all_discovery_requests(&mut self, public_key: &CommsPublicKey) -> Vec<DiscoveryRequestState> {
+        let mut requests = Vec::new();
+        let mut remaining_requests = HashMap::new();
+        for (nonce, request) in self.inflight_discoveries.drain() {
+            // Exclude canceled requests
+            if request.reply_tx.is_canceled() {
+                continue;
+            }
+
+            // Requests for this public key are collected
+            if &request.public_key == public_key {
+                requests.push(request);
+                continue;
+            }
+
+            // Everything else is put back in inflight_discoveries
+            remaining_requests.insert(nonce, request);
+        }
+
+        self.inflight_discoveries = remaining_requests;
+        requests
+    }
+
+    fn handle_discovery_response(&mut self, discovery_msg: DiscoveryResponseMessage) {
+        trace!(
+            target: LOG_TARGET,
+            "Received discovery response message from {}",
+            discovery_msg.node_id.to_hex()
+        );
+        if let Some(request) = log_if_error!(
+            target: LOG_TARGET,
+            "{}",
+            self.inflight_discoveries
+                .remove(&discovery_msg.nonce)
+                .ok_or(DhtDiscoveryError::InflightDiscoveryRequestNotFound)
+        ) {
+            let DiscoveryRequestState { public_key, reply_tx } = request;
+
+            let result = self.validate_then_add_peer(&public_key, discovery_msg);
+
+            // Resolve any other pending discover requests if the peer was found
+            if let Ok(peer) = &result {
+                for request in self.collect_all_discovery_requests(&public_key) {
+                    let _ = request.reply_tx.send(Ok(peer.clone()));
+                }
+            }
+
+            trace!(target: LOG_TARGET, "Discovery request is recognised and valid");
+
+            let _ = reply_tx.send(result);
+        }
+    }
+
+    fn validate_then_add_peer(
+        &mut self,
+        public_key: &CommsPublicKey,
+        discovery_msg: DiscoveryResponseMessage,
+    ) -> Result<Peer, DhtDiscoveryError>
+    {
+        let node_id = self.validate_raw_node_id(&public_key, &discovery_msg.node_id)?;
+
+        let addresses = discovery_msg
+            .addresses
+            .into_iter()
+            .filter_map(|addr| addr.parse().ok())
+            .collect::<Vec<_>>();
+
+        let peer = self.add_or_update_peer(
+            &public_key,
+            node_id,
+            addresses,
+            PeerFeatures::from_bits_truncate(discovery_msg.peer_features),
+        )?;
+
+        Ok(peer)
+    }
+
+    fn validate_raw_node_id(
+        &self,
+        public_key: &CommsPublicKey,
+        raw_node_id: &[u8],
+    ) -> Result<NodeId, DhtDiscoveryError>
+    {
+        // The reason that we check the given node id against what we expect instead of just using the given node id
+        // is in future the NodeId may not necessarily be derived from the public key (i.e. DAN node is registered on
+        // the base layer)
+        let expected_node_id = NodeId::from_key(public_key).map_err(|_| DhtDiscoveryError::InvalidNodeId)?;
+        let node_id = NodeId::from_bytes(raw_node_id).map_err(|_| DhtDiscoveryError::InvalidNodeId)?;
+        if expected_node_id == node_id {
+            Ok(expected_node_id)
+        } else {
+            // TODO: Misbehaviour
+            Err(DhtDiscoveryError::InvalidNodeId)
+        }
+    }
+
+    fn add_or_update_peer(
+        &self,
+        pubkey: &CommsPublicKey,
+        node_id: NodeId,
+        net_addresses: Vec<NetAddress>,
+        peer_features: PeerFeatures,
+    ) -> Result<Peer, DhtDiscoveryError>
+    {
+        let peer_manager = &self.peer_manager;
+        if peer_manager.exists(pubkey) {
+            peer_manager.update_peer(
+                pubkey,
+                Some(node_id),
+                Some(net_addresses),
+                None,
+                Some(peer_features),
+                None,
+            )?;
+        } else {
+            peer_manager.add_peer(Peer::new(
+                pubkey.clone(),
+                node_id,
+                net_addresses.into(),
+                PeerFlags::default(),
+                peer_features,
+            ))?;
+        }
+
+        let peer = peer_manager.find_by_public_key(&pubkey)?;
+
+        Ok(peer)
+    }
+
+    async fn initiate_peer_discovery(
+        &mut self,
+        discovery_request: DiscoverPeerRequest,
+        reply_tx: oneshot::Sender<Result<Peer, DhtDiscoveryError>>,
+    ) -> Result<(), DhtDiscoveryError>
+    {
+        let nonce = DHT_RNG.with(|rng| rng.borrow_mut().next_u64());
+        let public_key = discovery_request.dest_public_key.clone();
+        self.send_discover(nonce, discovery_request).await?;
+
+        let inflight_count = self.inflight_discoveries.len();
+
+        // Take this opportunity to clear cancelled discovery requests (e.g if the caller has timed out the request)
+        self.inflight_discoveries = self
+            .inflight_discoveries
+            .drain()
+            .filter(|(_, state)| !state.reply_tx.is_canceled())
+            .collect();
+
+        trace!(
+            target: LOG_TARGET,
+            "{} inflight request(s) cleared",
+            inflight_count - self.inflight_discoveries.len()
+        );
+
+        // Add the new inflight request.
+        let key_exists = self
+            .inflight_discoveries
+            .insert(nonce, DiscoveryRequestState { reply_tx, public_key })
+            .is_some();
+        // The nonce should never be chosen more than once
+        debug_assert!(!key_exists);
+
+        trace!(
+            target: LOG_TARGET,
+            "Number of inflight discoveries = {}",
+            self.inflight_discoveries.len()
+        );
+
+        Ok(())
+    }
+
+    async fn send_discover(
+        &mut self,
+        nonce: u64,
+        discovery_request: DiscoverPeerRequest,
+    ) -> Result<(), DhtDiscoveryError>
+    {
+        let DiscoverPeerRequest {
+            dest_node_id,
+            dest_public_key,
+            destination,
+        } = discovery_request;
+
+        // If the destination node is is known, send to the closest peers we know. Otherwise...
+        let network_location_node_id = dest_node_id
+            .or_else(|| match &destination {
+                // ... if the destination is undisclosed or a public key, send discover to our closest peers
+                NodeDestination::Unknown | NodeDestination::PublicKey(_) => Some(self.node_identity.node_id().clone()),
+                // otherwise, send it to the closest peers to the given NodeId destination we know
+                NodeDestination::NodeId(node_id) => Some(node_id.clone()),
+            })
+            .expect("cannot fail");
+
+        let broadcast_strategy = BroadcastStrategy::Closest(Box::new(BroadcastClosestRequest {
+            n: self.config.num_neighbouring_nodes,
+            node_id: network_location_node_id,
+            excluded_peers: Vec::new(),
+        }));
+
+        let discover_msg = DiscoveryMessage {
+            node_id: self.node_identity.node_id().to_vec(),
+            addresses: vec![self.node_identity.control_service_address().to_string()],
+            peer_features: self.node_identity.features().bits(),
+            nonce,
+        };
+        debug!(
+            target: LOG_TARGET,
+            "Sending Discover message to (at most) {} closest peers", self.config.num_neighbouring_nodes
+        );
+
+        self.outbound_requester
+            .send_dht_message(
+                broadcast_strategy,
+                destination,
+                OutboundEncryption::EncryptFor(dest_public_key),
+                DhtMessageType::Discovery,
+                discover_msg,
+            )
+            .await?;
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::{
+        discovery::DhtDiscoveryRequester,
+        outbound::mock::create_mock_outbound_service,
+        test_utils::{make_node_identity, make_peer_manager},
+    };
+    use std::time::Duration;
+    use tari_shutdown::Shutdown;
+    use tari_test_utils::runtime;
+
+    #[test]
+    fn send_discovery() {
+        runtime::test_async(|rt| {
+            let node_identity = make_node_identity();
+            let peer_manager = make_peer_manager();
+            let (outbound_requester, mut outbound_mock) = create_mock_outbound_service(10);
+            let (sender, receiver) = mpsc::channel(10);
+            // Requester which timeout instantly
+            let mut requester = DhtDiscoveryRequester::new(sender, Duration::from_millis(1));
+            let mut shutdown = Shutdown::new();
+
+            let service = DhtDiscoveryService::new(
+                DhtConfig::default(),
+                node_identity,
+                peer_manager,
+                outbound_requester,
+                receiver,
+                shutdown.to_signal(),
+            );
+
+            rt.spawn(service.run());
+
+            let dest_public_key = CommsPublicKey::default();
+            let result = rt.block_on(requester.discover_peer(dest_public_key.clone(), None, NodeDestination::Unknown));
+
+            assert!(result.unwrap_err().is_timeout());
+
+            let msg = rt.block_on(outbound_mock.handle_next(Duration::from_millis(5000), 1));
+            assert_eq!(msg.dht_message_type, DhtMessageType::Discovery);
+            assert_eq!(msg.encryption, OutboundEncryption::EncryptFor(dest_public_key));
+
+            shutdown.trigger().unwrap();
+        })
+    }
+}

--- a/comms/dht/src/inbound/dht_handler/layer.rs
+++ b/comms/dht/src/inbound/dht_handler/layer.rs
@@ -21,7 +21,7 @@
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 use super::middleware::DhtHandlerMiddleware;
-use crate::{config::DhtConfig, outbound::OutboundMessageRequester};
+use crate::{config::DhtConfig, discovery::DhtDiscoveryRequester, outbound::OutboundMessageRequester};
 use std::sync::Arc;
 use tari_comms::peer_manager::{NodeIdentity, PeerManager};
 use tower::layer::Layer;
@@ -31,6 +31,7 @@ pub struct DhtHandlerLayer {
     peer_manager: Arc<PeerManager>,
     node_identity: Arc<NodeIdentity>,
     outbound_service: OutboundMessageRequester,
+    discovery_requester: DhtDiscoveryRequester,
 }
 
 impl DhtHandlerLayer {
@@ -38,6 +39,7 @@ impl DhtHandlerLayer {
         config: DhtConfig,
         node_identity: Arc<NodeIdentity>,
         peer_manager: Arc<PeerManager>,
+        discovery_requester: DhtDiscoveryRequester,
         outbound_service: OutboundMessageRequester,
     ) -> Self
     {
@@ -45,6 +47,7 @@ impl DhtHandlerLayer {
             config,
             node_identity,
             peer_manager,
+            discovery_requester,
             outbound_service,
         }
     }
@@ -60,6 +63,7 @@ impl<S> Layer<S> for DhtHandlerLayer {
             Arc::clone(&self.node_identity),
             Arc::clone(&self.peer_manager),
             self.outbound_service.clone(),
+            self.discovery_requester.clone(),
         )
     }
 }

--- a/comms/dht/src/inbound/dht_handler/middleware.rs
+++ b/comms/dht/src/inbound/dht_handler/middleware.rs
@@ -21,7 +21,12 @@
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 use super::task::ProcessDhtMessage;
-use crate::{config::DhtConfig, inbound::DecryptedDhtMessage, outbound::OutboundMessageRequester};
+use crate::{
+    config::DhtConfig,
+    discovery::DhtDiscoveryRequester,
+    inbound::DecryptedDhtMessage,
+    outbound::OutboundMessageRequester,
+};
 use futures::{task::Context, Future, Poll};
 use std::sync::Arc;
 use tari_comms::peer_manager::{NodeIdentity, PeerManager};
@@ -35,6 +40,7 @@ pub struct DhtHandlerMiddleware<S> {
     peer_manager: Arc<PeerManager>,
     node_identity: Arc<NodeIdentity>,
     outbound_service: OutboundMessageRequester,
+    discovery_requester: DhtDiscoveryRequester,
 }
 
 impl<S> DhtHandlerMiddleware<S> {
@@ -44,6 +50,8 @@ impl<S> DhtHandlerMiddleware<S> {
         node_identity: Arc<NodeIdentity>,
         peer_manager: Arc<PeerManager>,
         outbound_service: OutboundMessageRequester,
+
+        discovery_requester: DhtDiscoveryRequester,
     ) -> Self
     {
         Self {
@@ -52,6 +60,7 @@ impl<S> DhtHandlerMiddleware<S> {
             node_identity,
             peer_manager,
             outbound_service,
+            discovery_requester,
         }
     }
 }
@@ -77,6 +86,7 @@ where
             Arc::clone(&self.peer_manager),
             self.outbound_service.clone(),
             Arc::clone(&self.node_identity),
+            self.discovery_requester.clone(),
             message,
         )
         .run()

--- a/comms/dht/src/lib.rs
+++ b/comms/dht/src/lib.rs
@@ -119,6 +119,7 @@ mod builder;
 mod config;
 mod consts;
 mod dht;
+mod discovery;
 mod proto;
 
 pub mod broadcast_strategy;

--- a/comms/dht/src/outbound/encryption.rs
+++ b/comms/dht/src/outbound/encryption.rs
@@ -112,7 +112,7 @@ where
                 message.body = crypt::encrypt(&shared_secret, &message.body)?
             },
             OutboundEncryption::None => {
-                debug!(target: LOG_TARGET, "Encryption not set for message",);
+                debug!(target: LOG_TARGET, "Encryption not requested for message");
             },
         };
 

--- a/comms/dht/src/outbound/error.rs
+++ b/comms/dht/src/outbound/error.rs
@@ -20,7 +20,6 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use crate::actor::DhtActorError;
 use derive_error::Error;
 use futures::channel::mpsc::SendError;
 use tari_comms::{connection::ConnectionError, message::MessageError};
@@ -32,8 +31,10 @@ pub enum DhtOutboundError {
     SendError(SendError),
     MessageSerializationError(MessageError),
     MessageFormatError(MessageFormatError),
-    DhtActorError(DhtActorError),
     ConnectionError(ConnectionError),
     SignatureError(SchnorrSignatureError),
+    /// Requester reply channel closed before response was received
     RequesterReplyChannelClosed,
+    /// Peer selection failed
+    PeerSelectionFailed,
 }

--- a/comms/dht/src/proto/dht.proto
+++ b/comms/dht/src/proto/dht.proto
@@ -17,10 +17,18 @@ message JoinMessage {
 // The DiscoverMessage stores the information required for a network discover request.
 //
 // When this message is received and can be decrypted, this node verifies the information
-// provided and, if everything checks out, a Join request is sent to the origin of this
+// provided and, if everything checks out, a DiscoveryResponse is sent to the origin of this
 // Discovery request so that the source node knows about this node.
-message DiscoverMessage {
+message DiscoveryMessage {
     bytes node_id = 1;
     repeated string addresses = 2;
     uint64 peer_features = 3;
+    uint64 nonce = 4;
+}
+
+message DiscoveryResponseMessage {
+    bytes node_id = 1;
+    repeated string addresses = 2;
+    uint64 peer_features = 3;
+    uint64 nonce = 4;
 }

--- a/comms/dht/src/proto/envelope.proto
+++ b/comms/dht/src/proto/envelope.proto
@@ -2,45 +2,39 @@ syntax = "proto3";
 
 package tari.dht.envelope;
 
-// Represents the ways a destination node can be represented.
-enum NodeDestinationType {
-    // The sender has chosen not to disclose the message destination, or the destination is
-    // the peer being sent to.
-    NodeDestinationTypeUnknown = 0;
-    /// Destined for a particular public key
-    NodeDestinationTypePublicKey = 1;
-    /// Destined for a particular node id, or network region
-    NodeDestinationTypeNodeId = 2;
-}
-
 enum DhtMessageType {
     // Indicated this message is not a DHT message
     DhtMessageTypeNone = 0;
     // Join Request
     DhtMessageTypeJoin = 1;
-    // Discover Request
-    DhtMessageTypeDiscover = 2;
+    // Discovery request
+    DhtMessageTypeDiscovery = 2;
+    // Response to a discovery request
+    DhtMessageTypeDiscoveryResponse = 3;
     // Request stored messages from a node
-    DhtMessageTypeSafRequestMessages = 3;
+    DhtMessageTypeSafRequestMessages = 20;
     // Stored messages response
-    DhtMessageTypeSafStoredMessages = 4;
+    DhtMessageTypeSafStoredMessages = 21;
 }
 
 message DhtHeader {
     uint32 version = 1;
-    NodeDestinationType destination_type = 2;
-    // Data related to the specified destination.
-    // Unknown - empty bytes (default)
-    // PublicKey - public key bytes
-    // NodeId - NodeId bytes
-    bytes destination_data = 3;
+    oneof destination {
+        // The sender has chosen not to disclose the message destination, or the destination is
+        // the peer being sent to.
+        bool unknown = 2;
+        /// Destined for a particular public key
+        bytes public_key = 3;
+        /// Destined for a particular node id, or network region
+        bytes node_id = 4;
+    }
 
     // Origin public key of the message. This can be the same peer that sent the message
     // or another peer if the message should be forwarded.
-    bytes origin_public_key = 4;
-    bytes origin_signature = 5;
-    DhtMessageType message_type = 6;
-    uint32 flags = 7;
+    bytes origin_public_key = 5;
+    bytes origin_signature = 6;
+    DhtMessageType message_type = 7;
+    uint32 flags = 8;
 }
 
 message DhtEnvelope {

--- a/comms/dht/src/test_utils/makers.rs
+++ b/comms/dht/src/test_utils/makers.rs
@@ -49,6 +49,17 @@ pub fn make_node_identity() -> Arc<NodeIdentity> {
     )
 }
 
+pub fn make_peer() -> Peer {
+    let node_identity = make_node_identity();
+    Peer::new(
+        node_identity.public_key().clone(),
+        node_identity.node_id().clone(),
+        vec![node_identity.control_service_address()].into(),
+        PeerFlags::empty(),
+        PeerFeatures::COMMUNICATION_NODE,
+    )
+}
+
 pub fn make_client_identity() -> Arc<NodeIdentity> {
     Arc::new(
         NodeIdentity::random(

--- a/comms/dht/src/test_utils/mod.rs
+++ b/comms/dht/src/test_utils/mod.rs
@@ -35,10 +35,18 @@ macro_rules! unwrap_oms_send_msg {
     };
 }
 
+macro_rules! acquire_read_lock {
+    ($e:expr) => {
+        acquire_lock!($e, read)
+    };
+}
+
 mod dht_actor_mock;
+mod dht_discovery_mock;
 mod makers;
 mod service;
 
 pub use dht_actor_mock::{create_dht_actor_mock, DhtMockState};
+pub use dht_discovery_mock::{create_dht_discovery_mock, DhtDiscoveryMockState};
 pub use makers::*;
 pub use service::{service_fn, service_spy};

--- a/comms/src/connection/net_address/mod.rs
+++ b/comms/src/connection/net_address/mod.rs
@@ -36,7 +36,7 @@ use std::{fmt, str::FromStr};
 
 pub use self::{net_address_with_stats::NetAddressWithStats, net_addresses::NetAddressesWithStats};
 
-#[derive(Debug, Error, PartialEq)]
+#[derive(Debug, Error, Clone, PartialEq)]
 pub enum NetAddressError {
     /// Failed to parse address
     ParseFailed,

--- a/comms/src/outbound_message_service/service.rs
+++ b/comms/src/outbound_message_service/service.rs
@@ -99,14 +99,6 @@ impl DialState {
     }
 }
 
-macro_rules! log_if_error {
-    (target: $target:expr, $msg:expr, $expr:expr) => {{
-        if let Err(err) = $expr {
-            log::error!(target: $target, $msg, err);
-        }
-    }};
-}
-
 /// Responsible for dialing peers and sending queued messages
 pub struct OutboundMessageService<TMsgStream> {
     config: OutboundServiceConfig,

--- a/comms/src/peer_manager/error.rs
+++ b/comms/src/peer_manager/error.rs
@@ -23,14 +23,11 @@
 use crate::{connection::NetAddressError, peer_manager::node_id::NodeIdError};
 use derive_error::Error;
 use tari_storage::KeyValStoreError;
-use tari_utilities::message_format::MessageFormatError;
 
-#[derive(Debug, Error)]
+#[derive(Debug, Error, Clone)]
 pub enum PeerManagerError {
     /// The requested peer does not exist or could not be located
     PeerNotFoundError,
-    // A problem occurred during the serialization of the keys or data
-    SerializationError(MessageFormatError),
     /// A problem occurred converting the serialized data into peers
     DeserializationError,
     /// The index doesn't relate to an existing peer

--- a/comms/src/peer_manager/node_id.rs
+++ b/comms/src/peer_manager/node_id.rs
@@ -40,7 +40,7 @@ use tari_utilities::{
 const NODE_ID_ARRAY_SIZE: usize = 32;
 type NodeIdArray = [u8; NODE_ID_ARRAY_SIZE];
 
-#[derive(Debug, Error)]
+#[derive(Debug, Error, Clone)]
 pub enum NodeIdError {
     IncorrectByteCount,
     OutOfBounds,

--- a/infrastructure/storage/src/key_val_store/error.rs
+++ b/infrastructure/storage/src/key_val_store/error.rs
@@ -22,7 +22,7 @@
 
 use derive_error::Error;
 
-#[derive(Debug, Error)]
+#[derive(Debug, Error, Clone)]
 pub enum KeyValStoreError {
     /// The Thread Safety has been breached and the data access has become poisoned
     PoisonedAccess,


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
When  `BroadcastStrategy::DirectPubkey` is used and the peer is not
known, a discovery request is automatically sent.

- Added `DiscoveryResponseMessage` which SHOULD be sent on receipt of a
  valid `DiscoveryMessage`.
- Added a nonce identifier for each Discovery request to aid in tracking
  requests.
- DhtEnvelope using `oneof`
- Unit and integration tests

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #1002 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Unit and integration tests

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [x] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [x] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch
* [x] I ran `cargo-fmt --all` before pushing
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
