### PR TITLE
Handle block and block event stream

### DIFF
--- a/base_layer/core/src/base_node/comms_interface/error.rs
+++ b/base_layer/core/src/base_node/comms_interface/error.rs
@@ -34,4 +34,5 @@ pub enum CommsInterfaceError {
     ChainStorageError(ChainStorageError),
     #[error(non_std, no_from)]
     OutboundMessageService(String),
+    EventStreamError,
 }

--- a/base_layer/core/src/base_node/comms_interface/mod.rs
+++ b/base_layer/core/src/base_node/comms_interface/mod.rs
@@ -31,6 +31,6 @@ mod outbound_interface;
 pub use comms_request::{MmrStateRequest, NodeCommsRequest, NodeCommsRequestType};
 pub use comms_response::NodeCommsResponse;
 pub use error::CommsInterfaceError;
-pub use inbound_handlers::InboundNodeCommsHandlers;
+pub use inbound_handlers::{BlockEvent, InboundNodeCommsHandlers};
 pub use local_interface::LocalNodeCommsInterface;
 pub use outbound_interface::OutboundNodeCommsInterface;

--- a/base_layer/core/src/base_node/service/service.rs
+++ b/base_layer/core/src/base_node/service/service.rs
@@ -54,7 +54,6 @@ use log::*;
 use std::{
     collections::HashMap,
     convert::TryInto,
-    sync::Arc,
     time::{Duration, Instant},
 };
 use tari_comms_dht::{
@@ -143,7 +142,7 @@ where
 pub struct BaseNodeService<B: BlockchainBackend> {
     executor: TaskExecutor,
     outbound_message_service: OutboundMessageRequester,
-    inbound_nch: Arc<InboundNodeCommsHandlers<B>>,
+    inbound_nch: InboundNodeCommsHandlers<B>,
     waiting_requests: HashMap<RequestKey, WaitingRequest>,
     timeout_sender: Sender<RequestKey>,
     timeout_receiver_stream: Option<Receiver<RequestKey>>,
@@ -156,7 +155,7 @@ where B: BlockchainBackend
     pub fn new(
         executor: TaskExecutor,
         outbound_message_service: OutboundMessageRequester,
-        inbound_nch: Arc<InboundNodeCommsHandlers<B>>,
+        inbound_nch: InboundNodeCommsHandlers<B>,
         config: BaseNodeServiceConfig,
     ) -> Self
     {

--- a/base_layer/core/src/base_node/states/initial_sync.rs
+++ b/base_layer/core/src/base_node/states/initial_sync.rs
@@ -230,6 +230,10 @@ impl InitialSync {
                     msg
                 );
             },
+            CommsInterfaceError::EventStreamError => {
+                self.shutdown_votes += 1;
+                warn!(target: LOG_TARGET, "Problem sending event on EventStream. {}", msg);
+            },
         }
     }
 

--- a/base_layer/core/src/base_node/test/comms_interface.rs
+++ b/base_layer/core/src/base_node/test/comms_interface.rs
@@ -45,6 +45,7 @@ use crate::{
 };
 use croaring::Bitmap;
 use futures::{executor::block_on, StreamExt};
+use tari_broadcast_channel::bounded;
 use tari_mmr::MutableMmrLeafNodes;
 use tari_service_framework::{reply_channel, reply_channel::Receiver};
 use tari_test_utils::runtime::test_async;
@@ -90,7 +91,8 @@ fn outbound_get_metadata() {
 #[test]
 fn inbound_get_metadata() {
     let store = BlockchainDatabase::new(MemoryDatabase::<HashDigest>::default()).unwrap();
-    let inbound_nch = InboundNodeCommsHandlers::new(store);
+    let (block_event_publisher, _block_event_subscriber) = bounded(100);
+    let inbound_nch = InboundNodeCommsHandlers::new(block_event_publisher, store);
 
     test_async(move |rt| {
         rt.spawn(async move {
@@ -131,7 +133,8 @@ fn outbound_fetch_kernels() {
 #[test]
 fn inbound_fetch_kernels() {
     let store = BlockchainDatabase::new(MemoryDatabase::<HashDigest>::default()).unwrap();
-    let inbound_nch = InboundNodeCommsHandlers::new(store.clone());
+    let (block_event_publisher, _block_event_subscriber) = bounded(100);
+    let inbound_nch = InboundNodeCommsHandlers::new(block_event_publisher, store.clone());
 
     let kernel = create_test_kernel(5.into(), 0);
     let hash = kernel.hash();
@@ -177,7 +180,8 @@ fn outbound_fetch_headers() {
 #[test]
 fn inbound_fetch_headers() {
     let store = BlockchainDatabase::new(MemoryDatabase::<HashDigest>::default()).unwrap();
-    let inbound_nch = InboundNodeCommsHandlers::new(store.clone());
+    let (block_event_publisher, _block_event_subscriber) = bounded(100);
+    let inbound_nch = InboundNodeCommsHandlers::new(block_event_publisher, store.clone());
 
     let mut header = BlockHeader::new(0);
     header.height = 0;
@@ -223,7 +227,8 @@ fn outbound_fetch_utxos() {
 #[test]
 fn inbound_fetch_utxos() {
     let store = BlockchainDatabase::new(MemoryDatabase::<HashDigest>::default()).unwrap();
-    let inbound_nch = InboundNodeCommsHandlers::new(store.clone());
+    let (block_event_publisher, _block_event_subscriber) = bounded(100);
+    let inbound_nch = InboundNodeCommsHandlers::new(block_event_publisher, store.clone());
 
     let (utxo, _) = create_utxo(MicroTari(10_000));
     let hash = utxo.hash();
@@ -268,7 +273,8 @@ fn outbound_fetch_blocks() {
 #[test]
 fn inbound_fetch_blocks() {
     let store = BlockchainDatabase::new(MemoryDatabase::<HashDigest>::default()).unwrap();
-    let inbound_nch = InboundNodeCommsHandlers::new(store.clone());
+    let (block_event_publisher, _block_event_subscriber) = bounded(100);
+    let inbound_nch = InboundNodeCommsHandlers::new(block_event_publisher, store.clone());
 
     let block = add_block_and_update_header(&store, get_genesis_block());
 
@@ -311,7 +317,8 @@ fn outbound_fetch_mmr_state() {
 #[test]
 fn inbound_fetch_mmr_state() {
     let store = BlockchainDatabase::new(MemoryDatabase::<HashDigest>::default()).unwrap();
-    let inbound_nch = InboundNodeCommsHandlers::new(store);
+    let (block_event_publisher, _block_event_subscriber) = bounded(100);
+    let inbound_nch = InboundNodeCommsHandlers::new(block_event_publisher, store);
 
     test_async(move |rt| {
         rt.spawn(async move {


### PR DESCRIPTION
## Description
- Implemented handle_block by adding the received block to the blockchain db. A block event with the verification status is then created and sent on the block event stream.
- A block event and block event stream was added.
- The block event stream subscriber was added to the LocalNodeCommsInterface to allow other local services to obtain access to the block event stream.

## Motivation and Context
Newly received blocks are now handled by the base node service.

## How Has This Been Tested?
Added tests for propagation of valid and invalid blocks, and submitting a new block using the LocalNodeCommsInterface. 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [x] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch
* [x] I ran `cargo-fmt --all` before pushing
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
