### PR TITLE
Changed header timestamp to use u64 wrapper struct and not datetime

### DIFF
--- a/applications/tari_testnet_miner/src/miner.rs
+++ b/applications/tari_testnet_miner/src/miner.rs
@@ -140,7 +140,7 @@ impl Miner {
         if self.block.is_none() {
             return Err(MinerError::MissingBlock);
         }
-        let interval = self.block.as_ref().unwrap().header.timestamp.timestamp() - old_header.timestamp.timestamp();
+        let interval = self.block.as_ref().unwrap().header.timestamp - old_header.timestamp;
         let difficulty = Difficulty::min(); // replace with new function: Difficulty::calculate_req_difficulty(interval, self.difficulty);
 
         let (tx, mut rx): (Sender<BlockHeader>, Receiver<BlockHeader>) = mpsc::channel(1);

--- a/applications/tari_testnet_miner/src/t_blake_pow.rs
+++ b/applications/tari_testnet_miner/src/t_blake_pow.rs
@@ -67,7 +67,7 @@ impl TestBlakePow {
                 nonce += 1;
             }
             if nonce == start_nonce {
-                header.timestamp = header.timestamp.checked_add_signed(Duration::milliseconds(1)).unwrap();
+                header.timestamp = header.timestamp.increase(1);
             }
         }
         header

--- a/base_layer/core/Cargo.toml
+++ b/base_layer/core/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2018"
 [dependencies]
 tari_transactions = { path = "../../base_layer/transactions", version = "^0.0" }
 tari_comms = { version = "^0.0", path = "../../comms"}
-tari_utilities = { path = "../../infrastructure/tari_util", version = "^0.0", features = ["chrono_dt"]}
+tari_utilities = { path = "../../infrastructure/tari_util", version = "^0.0"}
 tari_infra_derive = { path = "../../infrastructure/derive", version = "^0.0" }
 tari_crypto = { path = "../../infrastructure/crypto", version = "^0.0" }
 tari_storage = { path = "../../infrastructure/storage", version = "^0.0" }

--- a/base_layer/core/src/proof_of_work/blake_pow.rs
+++ b/base_layer/core/src/proof_of_work/blake_pow.rs
@@ -107,7 +107,7 @@ mod test {
 
     fn get_header() -> BlockHeader {
         let mut header = BlockHeader::new(0);
-        header.timestamp = DateTime::<Utc>::from_utc(NaiveDate::from_ymd(2000, 1, 1).and_hms(1, 1, 1), Utc);
+        header.timestamp = DateTime::<Utc>::from_utc(NaiveDate::from_ymd(2000, 1, 1).and_hms(1, 1, 1), Utc).into();
         header
     }
     #[test]

--- a/base_layer/core/src/proof_of_work/difficulty.rs
+++ b/base_layer/core/src/proof_of_work/difficulty.rs
@@ -25,6 +25,7 @@ use bitflags::_core::ops::Div;
 use newtype_ops::newtype_ops;
 use serde::{Deserialize, Serialize};
 use std::fmt;
+use tari_utilities::epoch_time::EpochTime;
 
 /// Minimum difficulty, enforced in diff retargetting
 /// avoids getting stuck when trying to increase difficulty subject to dampening
@@ -93,7 +94,11 @@ impl From<u64> for Difficulty {
 pub trait DifficultyAdjustment {
     /// Adds the latest block timestamp (in seconds) and total accumulated difficulty. If the new data point violates
     /// some difficulty criteria, then `add` returns an error with the type of failure indicated
-    fn add(&mut self, timestamp: u64, accumulated_difficulty: Difficulty) -> Result<(), DifficultyAdjustmentError>;
+    fn add(
+        &mut self,
+        timestamp: EpochTime,
+        accumulated_difficulty: Difficulty,
+    ) -> Result<(), DifficultyAdjustmentError>;
 
     /// Return the calculated target difficulty for the next block.
     fn get_difficulty(&self) -> Difficulty;

--- a/base_layer/core/src/proof_of_work/lwma_diff.rs
+++ b/base_layer/core/src/proof_of_work/lwma_diff.rs
@@ -12,11 +12,12 @@ use crate::proof_of_work::{
 };
 use std::{cmp, collections::VecDeque};
 use tari_transactions::consensus::{DIFFICULTY_BLOCK_WINDOW, TARGET_BLOCK_INTERVAL};
+use tari_utilities::epoch_time::EpochTime;
 
 const INITIAL_DIFFICULTY: Difficulty = Difficulty::min();
 
 pub struct LinearWeightedMovingAverage {
-    timestamps: VecDeque<u64>,
+    timestamps: VecDeque<EpochTime>,
     accumulated_difficulties: VecDeque<Difficulty>,
     block_window: usize,
 }
@@ -54,18 +55,21 @@ impl LinearWeightedMovingAverage {
         let ave_difficulty = difficulty as f64 / n as f64;
 
         let mut previous_timestamp = timestamps[0];
-        let mut this_timestamp = 0;
+        let mut this_timestamp = 0.into();
         // Loop through N most recent blocks.
         for i in 1..(n + 1) as usize {
             // 6*T limit prevents large drops in diff from long solve times which would cause oscillations.
             // We cannot have if solvetime < 1 then solvetime = 1, this will greatly increase the next timestaamp
             // difficulty which will lower the difficulty
-            if (timestamps[i] > previous_timestamp) {
+            if timestamps[i] > previous_timestamp {
                 this_timestamp = timestamps[i];
             } else {
-                this_timestamp = previous_timestamp + 1;
+                this_timestamp = previous_timestamp.increase(1);
             }
-            let solve_time = cmp::min(this_timestamp - previous_timestamp, 6 * TARGET_BLOCK_INTERVAL);
+            let solve_time = cmp::min(
+                (this_timestamp - previous_timestamp).as_u64(),
+                6 * TARGET_BLOCK_INTERVAL,
+            );
             previous_timestamp = this_timestamp;
 
             // Give linearly higher weight to more recent solve times.
@@ -84,7 +88,12 @@ impl LinearWeightedMovingAverage {
 }
 
 impl DifficultyAdjustment for LinearWeightedMovingAverage {
-    fn add(&mut self, timestamp: u64, accumulated_difficulty: Difficulty) -> Result<(), DifficultyAdjustmentError> {
+    fn add(
+        &mut self,
+        timestamp: EpochTime,
+        accumulated_difficulty: Difficulty,
+    ) -> Result<(), DifficultyAdjustmentError>
+    {
         match self.accumulated_difficulties.back() {
             None => {},
             Some(v) => {
@@ -120,31 +129,31 @@ mod test {
     #[test]
     fn lwma_add_non_increasing_diff() {
         let mut dif = LinearWeightedMovingAverage::default();
-        assert!(dif.add(100, 100.into()).is_ok());
-        assert!(dif.add(100, 100.into()).is_err());
-        assert!(dif.add(100, 50.into()).is_err());
+        assert!(dif.add(100.into(), 100.into()).is_ok());
+        assert!(dif.add(100.into(), 100.into()).is_err());
+        assert!(dif.add(100.into(), 50.into()).is_err());
     }
 
     #[test]
     fn lwma_negative_solve_times() {
         let mut dif = LinearWeightedMovingAverage::default();
-        let mut timestamp = 60;
+        let mut timestamp = 60.into();
         let mut cum_diff = Difficulty::from(100);
         let _ = dif.add(timestamp, cum_diff);
-        timestamp += 60;
+        timestamp = timestamp.increase(60);
         cum_diff += Difficulty::from(100);
         let _ = dif.add(timestamp, cum_diff);
         // Lets create a history and populate the vecs
         for _i in 0..150 {
             cum_diff += Difficulty::from(100);
-            timestamp += 60;
+            timestamp = timestamp.increase(60);
             let _ = dif.add(timestamp, cum_diff);
         }
         // lets create chaos by having 60 blocks as negative solve times. This should never be allowed in practive by
         // having checks on the block times.
         for _i in 0..60 {
             cum_diff += Difficulty::from(100);
-            timestamp -= 1; // Only choosing -1 here since we are testing negative solve times and we cannot have 0 time
+            timestamp = (timestamp.as_u64() - 1).into(); // Only choosing -1 here since we are testing negative solve times and we cannot have 0 time
             let diff_before = dif.get_difficulty();
             let _ = dif.add(timestamp, cum_diff);
             let diff_after = dif.get_difficulty();
@@ -156,10 +165,10 @@ mod test {
     #[test]
     fn lwma_limit_difficulty_change() {
         let mut dif = LinearWeightedMovingAverage::new(5);
-        let _ = dif.add(60, 100.into());
-        let _ = dif.add(10_000_000, 200.into());
+        let _ = dif.add(60.into(), 100.into());
+        let _ = dif.add(10_000_000.into(), 200.into());
         assert_eq!(dif.get_difficulty(), 16.into());
-        let _ = dif.add(20_000_000, 216.into());
+        let _ = dif.add(20_000_000.into(), 216.into());
         assert_eq!(dif.get_difficulty(), 9.into());
     }
 
@@ -172,35 +181,35 @@ mod test {
     // Target:     1, 100, 100, 100, 100, 106, 135, 129, 119,  93,  35,  38,  46,  66, 174
     fn lwma_calculate() {
         let mut dif = LinearWeightedMovingAverage::new(5);
-        let _ = dif.add(60, 100.into());
+        let _ = dif.add(60.into(), 100.into());
         assert_eq!(dif.get_difficulty(), 1.into());
-        let _ = dif.add(120, 200.into());
+        let _ = dif.add(120.into(), 200.into());
         assert_eq!(dif.get_difficulty(), 100.into());
-        let _ = dif.add(180, 300.into());
+        let _ = dif.add(180.into(), 300.into());
         assert_eq!(dif.get_difficulty(), 100.into());
-        let _ = dif.add(240, 400.into());
+        let _ = dif.add(240.into(), 400.into());
         assert_eq!(dif.get_difficulty(), 100.into());
-        let _ = dif.add(300, 500.into());
+        let _ = dif.add(300.into(), 500.into());
         assert_eq!(dif.get_difficulty(), 100.into());
-        let _ = dif.add(350, 605.into());
+        let _ = dif.add(350.into(), 605.into());
         assert_eq!(dif.get_difficulty(), 106.into());
-        let _ = dif.add(380, 733.into());
+        let _ = dif.add(380.into(), 733.into());
         assert_eq!(dif.get_difficulty(), 135.into());
-        let _ = dif.add(445, 856.into());
+        let _ = dif.add(445.into(), 856.into());
         assert_eq!(dif.get_difficulty(), 129.into());
-        let _ = dif.add(515, 972.into());
+        let _ = dif.add(515.into(), 972.into());
         assert_eq!(dif.get_difficulty(), 119.into());
-        let _ = dif.add(615, 1066.into());
+        let _ = dif.add(615.into(), 1066.into());
         assert_eq!(dif.get_difficulty(), 93.into());
-        let _ = dif.add(975, 1105.into());
+        let _ = dif.add(975.into(), 1105.into());
         assert_eq!(dif.get_difficulty(), 35.into());
-        let _ = dif.add(976, 1151.into());
+        let _ = dif.add(976.into(), 1151.into());
         assert_eq!(dif.get_difficulty(), 38.into());
-        let _ = dif.add(977, 1206.into());
+        let _ = dif.add(977.into(), 1206.into());
         assert_eq!(dif.get_difficulty(), 46.into());
-        let _ = dif.add(978, 1281.into());
+        let _ = dif.add(978.into(), 1281.into());
         assert_eq!(dif.get_difficulty(), 66.into());
-        let _ = dif.add(979, 1429.into());
+        let _ = dif.add(979.into(), 1429.into());
         assert_eq!(dif.get_difficulty(), 174.into());
     }
 }

--- a/base_layer/core/src/proto/block.rs
+++ b/base_layer/core/src/proto/block.rs
@@ -26,23 +26,21 @@ use crate::{
     chain_storage::HistoricalBlock,
     proto::utils::try_convert_all,
 };
-use chrono::{DateTime, NaiveDateTime, Utc};
 use prost_types::Timestamp;
 use std::convert::{TryFrom, TryInto};
 use tari_transactions::types::BlindingFactor;
-use tari_utilities::{ByteArray, ByteArrayError};
+use tari_utilities::{epoch_time::EpochTime, ByteArray, ByteArrayError};
 
 /// Utility function that converts a `prost::Timestamp` to a `chrono::DateTime`
-pub(crate) fn timestamp_to_datetime(timestamp: Timestamp) -> DateTime<Utc> {
-    let dt = NaiveDateTime::from_timestamp(timestamp.seconds, timestamp.nanos as u32);
-    DateTime::<_>::from_utc(dt, Utc)
+pub(crate) fn timestamp_to_datetime(timestamp: Timestamp) -> EpochTime {
+    (timestamp.seconds as u64).into()
 }
 
 /// Utility function that converts a `chrono::DateTime` to a `prost::Timestamp`
-pub(crate) fn datetime_to_timestamp(datetime: DateTime<Utc>) -> Timestamp {
+pub(crate) fn datetime_to_timestamp(datetime: EpochTime) -> Timestamp {
     Timestamp {
-        seconds: datetime.timestamp(),
-        nanos: datetime.timestamp_subsec_nanos() as i32,
+        seconds: datetime.as_u64() as i64,
+        nanos: 0,
     }
 }
 

--- a/base_layer/transactions/Cargo.toml
+++ b/base_layer/transactions/Cargo.toml
@@ -13,7 +13,7 @@ edition = "2018"
 
 [dependencies]
 tari_crypto = { path = "../../infrastructure/crypto", version = "^0.0" }
-tari_utilities = { path = "../../infrastructure/tari_util", version = "^0.0", features = ["chrono_dt"]}
+tari_utilities = { path = "../../infrastructure/tari_util", version = "^0.0"}
 
 lazy_static = "1.3.0"
 serde = { version = "1.0.97", features = ["derive"] }

--- a/infrastructure/tari_util/Cargo.toml
+++ b/infrastructure/tari_util/Cargo.toml
@@ -12,14 +12,13 @@ edition = "2018"
 [dependencies]
 derive-error = "0.0.4"
 clear_on_drop = "0.2.3"
-chrono = {version = "0.4.6", optional = true}
+chrono = { version = "0.4.9", features = ["serde"]}
 bincode = "1.1.4"
 base64 = "0.10.1"
 serde_json = "1.0"
-serde = {version = "1.0.89", features = ["derive"] }
+serde = {version = "1.0.102", features = ["derive"] }
 rand = "0.5.5"
+newtype-ops = "0.1.4"
+bitflags = "1.2.1"
 
 [dev-dependencies]
-
-[features]
-chrono_dt = ["chrono"]

--- a/infrastructure/tari_util/src/epoch_time.rs
+++ b/infrastructure/tari_util/src/epoch_time.rs
@@ -1,0 +1,118 @@
+// Copyright 2019. The Tari Project
+//
+// Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+// following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+// disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+// following disclaimer in the documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+// products derived from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+// INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+// WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+// USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+use chrono::{DateTime, NaiveDateTime, Utc};
+use newtype_ops::newtype_ops;
+use serde::{Deserialize, Serialize};
+use std::{fmt, ops::Div};
+
+/// The timestamp, defined as the amount of seconds past from UNIX epoch.
+#[derive(Debug, Clone, Copy, PartialEq, PartialOrd, Eq, Ord, Deserialize, Serialize)]
+pub struct EpochTime(u64);
+
+impl EpochTime {
+    /// return UTC current as EpochTime
+    pub fn now() -> EpochTime {
+        EpochTime(Utc::now().timestamp() as u64)
+    }
+
+    /// Return the EpochTime as a u64
+    pub fn as_u64(&self) -> u64 {
+        self.0
+    }
+
+    /// This will return a new EpochTime increased by the amount of seconds given
+    /// This will panic if combined EpochTime and seconds are larger than U64::MAX
+    pub fn increase(&self, seconds: u64) -> EpochTime {
+        let num = seconds.checked_add(self.0);
+        let value = match num {
+            Some(v) => v,
+            _ => panic!("u64 overlfow in timestamp"),
+        };
+        EpochTime(value)
+    }
+
+    pub fn checked_sub(&self, other: EpochTime) -> Option<EpochTime> {
+        match self.0.checked_sub(other.0) {
+            None => None,
+            Some(v) => Some(EpochTime(v)),
+        }
+    }
+}
+
+impl Default for EpochTime {
+    fn default() -> Self {
+        EpochTime(Utc::now().timestamp() as u64)
+    }
+}
+
+// You can only add or subtract EpochTime from EpochTime
+newtype_ops! { [EpochTime] {add sub} {:=} Self Self }
+newtype_ops! { [EpochTime] {add sub} {:=} &Self &Self }
+newtype_ops! { [EpochTime] {add sub} {:=} Self &Self }
+
+// Multiplication and division of EpochTime by scalar is EpochTime
+newtype_ops! { [EpochTime] {mul div rem} {:=} Self u64 }
+
+// Division of EpochTime by EpochTime is a EpochTime ratio (scalar) (newtype_ops doesn't handle this case)
+impl Div for EpochTime {
+    type Output = u64;
+
+    fn div(self, rhs: Self) -> Self::Output {
+        self.0 / rhs.0
+    }
+}
+
+impl fmt::Display for EpochTime {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+impl From<u64> for EpochTime {
+    fn from(value: u64) -> Self {
+        EpochTime(value)
+    }
+}
+
+impl From<DateTime<Utc>> for EpochTime {
+    fn from(value: DateTime<Utc>) -> Self {
+        EpochTime(value.timestamp() as u64)
+    }
+}
+
+impl From<EpochTime> for DateTime<Utc> {
+    fn from(value: EpochTime) -> Self {
+        DateTime::<Utc>::from_utc(NaiveDateTime::from_timestamp(value.0 as i64, 0), Utc)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn add_epoch_time() {
+        assert_eq!(EpochTime::from(1_000) + EpochTime::from(8_000), EpochTime::from(9_000));
+        assert_eq!(&EpochTime::from(15) + &EpochTime::from(5), EpochTime::from(20));
+    }
+}

--- a/infrastructure/tari_util/src/extend_bytes.rs
+++ b/infrastructure/tari_util/src/extend_bytes.rs
@@ -20,7 +20,6 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-#[cfg(feature = "chrono_dt")]
 use chrono::{DateTime, Utc};
 
 /// this trait allows us to call append_raw_bytes and get the raw bytes of the type
@@ -131,7 +130,6 @@ impl ExtendBytes for bool {
     }
 }
 
-#[cfg(feature = "chrono_dt")]
 impl ExtendBytes for DateTime<Utc> {
     fn append_raw_bytes(&self, buf: &mut Vec<u8>) {
         let bytes = self.timestamp().to_le_bytes();

--- a/infrastructure/tari_util/src/lib.rs
+++ b/infrastructure/tari_util/src/lib.rs
@@ -27,6 +27,7 @@ pub mod protobuf;
 pub mod bit;
 pub mod byte_array;
 pub mod ciphers;
+pub mod epoch_time;
 pub mod extend_bytes;
 pub mod fixed_set;
 pub mod hash;


### PR DESCRIPTION
## Description
Changed the timestamp field of the header to be a u64 and not a datetime

## Motivation and Context
We currently have the timestamp as a chrono::datetime field. This adds a dependancy which is not really required and if this library is changed in the future it might give compatibility issues. 
Everywhere where we use the timestamp we need to convert it to a u64. We only use the timestamp as a u64 unix epoch including in wire transmission. 

The only exception to this is the display. This PR removes a dependancy and reduces the amount of conversions for the timestamp. 

## How Has This Been Tested?
This does not break any of the current unit tests

## Types of changes
* [ ] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [x] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
* [x] I'm merging against the `development` branch
* [x] I ran `cargo-fmt --all` before pushing
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
