### PR TITLE
Undo regression - make AggregateBody fields private

### DIFF
--- a/base_layer/core/src/proof_of_work/lwma_diff.rs
+++ b/base_layer/core/src/proof_of_work/lwma_diff.rs
@@ -58,9 +58,9 @@ impl LinearWeightedMovingAverage {
         // Loop through N most recent blocks.
         for i in 1..(n + 1) as usize {
             // 6*T limit prevents large drops in diff from long solve times which would cause oscillations.
-            // We cannot have if solvetime < 1 then solvetime = 1, this will greatly increase the next timestaamp
+            // We cannot have if solve_time < 1 then solve_time = 1, this will greatly increase the next timestamp
             // difficulty which will lower the difficulty
-            if (timestamps[i] > previous_timestamp) {
+            if timestamps[i] > previous_timestamp {
                 this_timestamp = timestamps[i];
             } else {
                 this_timestamp = previous_timestamp + 1;
@@ -140,7 +140,7 @@ mod test {
             timestamp += 60;
             let _ = dif.add(timestamp, cum_diff);
         }
-        // lets create chaos by having 60 blocks as negative solve times. This should never be allowed in practive by
+        // lets create chaos by having 60 blocks as negative solve times. This should never be allowed in practice by
         // having checks on the block times.
         for _i in 0..60 {
             cum_diff += Difficulty::from(100);

--- a/base_layer/transactions/src/aggregated_body.rs
+++ b/base_layer/transactions/src/aggregated_body.rs
@@ -33,13 +33,13 @@ use tari_crypto::{commitment::HomomorphicCommitmentFactory, ristretto::pedersen:
 /// cut-through means that blocks and transactions have the same structure.
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub struct AggregateBody {
-    pub sorted: bool,
+    sorted: bool,
     /// List of inputs spent by the transaction.
-    pub inputs: Vec<TransactionInput>,
+    inputs: Vec<TransactionInput>,
     /// List of outputs the transaction produces.
-    pub outputs: Vec<TransactionOutput>,
+    outputs: Vec<TransactionOutput>,
     /// Kernels contain the excesses and their signatures for transaction
-    pub kernels: Vec<TransactionKernel>,
+    kernels: Vec<TransactionKernel>,
 }
 
 impl AggregateBody {

--- a/base_layer/transactions/src/proto/transaction.proto
+++ b/base_layer/transactions/src/proto/transaction.proto
@@ -63,13 +63,13 @@ message OutputFeatures {
 }
 
 // The components of the block or transaction. The same struct can be used for either, since in Mimblewimble,
-// cut-through means that blocks and transactions have the same structure.
+// cut-through means that blocks and transactions have the same structure. The inputs, outputs and kernels should
+// be sorted by their Blake2b-256bit digest hash
 message AggregateBody {
-    bool sorted=  1;
     // List of inputs spent by the transaction.
-    repeated TransactionInput inputs = 2;
+    repeated TransactionInput inputs = 1;
     // List of outputs the transaction produces.
-    repeated TransactionOutput outputs = 3;
+    repeated TransactionOutput outputs = 2;
     // Kernels contain the excesses and their signatures for transaction
-    repeated TransactionKernel kernels = 4;
+    repeated TransactionKernel kernels = 3;
 }

--- a/base_layer/transactions/src/proto/transaction.rs
+++ b/base_layer/transactions/src/proto/transaction.rs
@@ -177,22 +177,22 @@ impl TryFrom<proto::AggregateBody> for AggregateBody {
     type Error = String;
 
     fn try_from(body: proto::AggregateBody) -> Result<Self, Self::Error> {
-        Ok(Self {
-            sorted: body.sorted,
-            inputs: try_convert_all(body.inputs)?,
-            outputs: try_convert_all(body.outputs)?,
-            kernels: try_convert_all(body.kernels)?,
-        })
+        let inputs = try_convert_all(body.inputs)?;
+        let outputs = try_convert_all(body.outputs)?;
+        let kernels = try_convert_all(body.kernels)?;
+        let mut body = AggregateBody::new(inputs, outputs, kernels);
+        body.sort();
+        Ok(body)
     }
 }
 
 impl From<AggregateBody> for proto::AggregateBody {
     fn from(body: AggregateBody) -> Self {
+        let (i, o, k) = body.dissolve();
         Self {
-            sorted: body.sorted,
-            inputs: body.inputs.into_iter().map(Into::into).collect(),
-            outputs: body.outputs.into_iter().map(Into::into).collect(),
-            kernels: body.kernels.into_iter().map(Into::into).collect(),
+            inputs: i.into_iter().map(Into::into).collect(),
+            outputs: o.into_iter().map(Into::into).collect(),
+            kernels: k.into_iter().map(Into::into).collect(),
         }
     }
 }

--- a/base_layer/transactions/src/proto/utils.rs
+++ b/base_layer/transactions/src/proto/utils.rs
@@ -23,15 +23,14 @@
 use std::convert::TryInto;
 
 /// Tries to convert a series of `T`s to `U`s, returning an error at the first failure
+#[inline]
 pub fn try_convert_all<T, U, I>(into_iter: I) -> Result<Vec<U>, T::Error>
 where
     I: IntoIterator<Item = T>,
     T: TryInto<U>,
 {
-    let iter = into_iter.into_iter();
-    let mut result = Vec::with_capacity(iter.size_hint().0);
-    for item in iter {
-        result.push(item.try_into()?);
-    }
-    Ok(result)
+    into_iter
+        .into_iter()
+        .map(TryInto::try_into)
+        .collect::<Result<Vec<U>, _>>()
 }


### PR DESCRIPTION
The `AggregateBody` fields should always be private.

Adding inputs and outputs have side-effects, and once built, an
AggregateBody should be considered immutable


