### PR TITLE
Remove global crypto factories

### DIFF
--- a/base_layer/core/src/blocks/block.rs
+++ b/base_layer/core/src/blocks/block.rs
@@ -31,7 +31,7 @@ use tari_transactions::{
     consensus::ConsensusRules,
     tari_amount::MicroTari,
     transaction::{OutputFlags, Transaction, TransactionError, TransactionInput, TransactionKernel, TransactionOutput},
-    types::{COMMITMENT_FACTORY, PROVER},
+    types::CryptoFactories,
 };
 use tari_utilities::Hashable;
 
@@ -62,11 +62,16 @@ impl Block {
     /// This function will check the block to ensure that all UTXO's are validly constructed and that all signatures are
     /// valid. It does _not_ check that the inputs exist in the current UTXO set;
     /// nor does it check that the PoW is the largest accumulated PoW value.
-    pub fn check_internal_consistency(&self, rules: &ConsensusRules) -> Result<(), BlockValidationError> {
+    pub fn check_internal_consistency(
+        &self,
+        rules: &ConsensusRules,
+        factories: &CryptoFactories,
+    ) -> Result<(), BlockValidationError>
+    {
         let offset = &self.header.total_kernel_offset;
         let total_coinbase = self.calculate_coinbase_and_fees(rules);
         self.body
-            .validate_internal_consistency(&offset, total_coinbase, &PROVER, &COMMITMENT_FACTORY)?;
+            .validate_internal_consistency(&offset, total_coinbase, factories)?;
         self.check_stxo_rules()?;
         self.check_utxo_rules(rules)?;
         self.check_pow()

--- a/base_layer/core/src/mempool/mempool.rs
+++ b/base_layer/core/src/mempool/mempool.rs
@@ -32,10 +32,7 @@ use crate::{
     },
 };
 use std::sync::Arc;
-use tari_transactions::{
-    transaction::Transaction,
-    types::{Signature, COMMITMENT_FACTORY, PROVER},
-};
+use tari_transactions::{transaction::Transaction, types::Signature};
 use tari_utilities::hash::Hashable;
 
 #[derive(Debug, PartialEq)]
@@ -123,10 +120,10 @@ where T: BlockchainBackend
         }
     }
 
-    /// Insert an unconfirmed transaction into the Mempool.
+    /// Insert an unconfirmed transaction into the Mempool. The transaction *MUST* have passed through the validation
+    /// pipeline already and will thus always be internally consistent by this stage
     pub fn insert(&self, tx: Arc<Transaction>) -> Result<(), MempoolError> {
-        tx.validate_internal_consistency(&PROVER, &COMMITMENT_FACTORY)?;
-
+        // The transaction is already internally consistent
         if self.check_input_utxos(&tx)? {
             if self.check_timelocks(&tx)? {
                 self.pending_pool.insert(tx)?;

--- a/base_layer/core/src/test_utils/sample_blockchains.rs
+++ b/base_layer/core/src/test_utils/sample_blockchains.rs
@@ -35,7 +35,7 @@ use crate::{
 use tari_transactions::{
     tari_amount::{uT, T},
     transaction::{Transaction, UnblindedOutput},
-    types::HashDigest,
+    types::{CryptoFactories, HashDigest},
 };
 
 /// Create a simple 6 block memory-backed database.
@@ -124,11 +124,12 @@ pub fn create_new_blockchain() -> (
     Vec<Block>,
     Vec<Vec<UnblindedOutput>>,
 ) {
+    let factories = CryptoFactories::default();
     let db = BlockchainDatabase::new(MemoryDatabase::<HashDigest>::default()).unwrap();
     let mut outputs = Vec::new();
     let mut blocks = Vec::new();
     // Genesis Block
-    let (mut block0, utxo) = create_genesis_block();
+    let (mut block0, utxo) = create_genesis_block(&factories);
     block0 = add_block_and_update_header(&db, block0);
     blocks.push(block0);
     outputs.push(vec![utxo]);

--- a/base_layer/core/src/test_utils/test_common.rs
+++ b/base_layer/core/src/test_utils/test_common.rs
@@ -30,7 +30,7 @@ use tari_crypto::{
 use tari_transactions::{
     tari_amount::*,
     transaction::{OutputFeatures, TransactionInput, UnblindedOutput},
-    types::{PrivateKey, PublicKey, COMMITMENT_FACTORY},
+    types::{CommitmentFactory, PrivateKey, PublicKey},
 };
 
 pub struct TestParams {
@@ -54,10 +54,15 @@ impl TestParams {
     }
 }
 
-pub fn make_input<R: Rng + CryptoRng>(rng: &mut R, val: MicroTari) -> (TransactionInput, UnblindedOutput) {
+pub fn make_input<R: Rng + CryptoRng>(
+    rng: &mut R,
+    val: MicroTari,
+    factory: &CommitmentFactory,
+) -> (TransactionInput, UnblindedOutput)
+{
     let key = PrivateKey::random(rng);
     let v = PrivateKey::from(val);
-    let commitment = COMMITMENT_FACTORY.commit(&key, &v);
+    let commitment = factory.commit(&key, &v);
     let input = TransactionInput::new(OutputFeatures::default(), commitment);
     (input, UnblindedOutput::new(val, key, None))
 }

--- a/base_layer/transactions/src/aggregated_body.rs
+++ b/base_layer/transactions/src/aggregated_body.rs
@@ -23,7 +23,7 @@
 use crate::{
     tari_amount::*,
     transaction::*,
-    types::{BlindingFactor, Commitment, CommitmentFactory, PrivateKey, RangeProofService, COMMITMENT_FACTORY},
+    types::{BlindingFactor, Commitment, CommitmentFactory, CryptoFactories, PrivateKey, RangeProofService},
 };
 use serde::{Deserialize, Serialize};
 use std::fmt::{Display, Error, Formatter};
@@ -161,14 +161,13 @@ impl AggregateBody {
         &self,
         offset: &BlindingFactor,
         reward: MicroTari,
-        prover: &RangeProofService,
-        factory: &CommitmentFactory,
+        factories: &CryptoFactories,
     ) -> Result<(), TransactionError>
     {
-        let total_offset = COMMITMENT_FACTORY.commit_value(&offset, reward.0);
+        let total_offset = factories.commitment.commit_value(&offset, reward.0);
         self.verify_kernel_signatures()?;
-        self.validate_kernel_sum(total_offset, factory)?;
-        self.validate_range_proofs(prover)
+        self.validate_kernel_sum(total_offset, &factories.commitment)?;
+        self.validate_range_proofs(&factories.range_proof)
     }
 
     pub fn dissolve(self) -> (Vec<TransactionInput>, Vec<TransactionOutput>, Vec<TransactionKernel>) {

--- a/base_layer/transactions/src/transaction_protocol/test_common.rs
+++ b/base_layer/transactions/src/transaction_protocol/test_common.rs
@@ -25,7 +25,7 @@
 use crate::{
     tari_amount::*,
     transaction::{OutputFeatures, TransactionInput, UnblindedOutput},
-    types::{PrivateKey, PublicKey, COMMITMENT_FACTORY},
+    types::{CommitmentFactory, PrivateKey, PublicKey},
 };
 use rand::{CryptoRng, Rng};
 use tari_crypto::{
@@ -54,10 +54,15 @@ impl TestParams {
     }
 }
 
-pub fn make_input<R: Rng + CryptoRng>(rng: &mut R, val: MicroTari) -> (TransactionInput, UnblindedOutput) {
+pub fn make_input<R: Rng + CryptoRng>(
+    rng: &mut R,
+    val: MicroTari,
+    factory: &CommitmentFactory,
+) -> (TransactionInput, UnblindedOutput)
+{
     let key = PrivateKey::random(rng);
     let v = PrivateKey::from(val);
-    let commitment = COMMITMENT_FACTORY.commit(&key, &v);
+    let commitment = factory.commit(&key, &v);
     let input = TransactionInput::new(OutputFeatures::default(), commitment);
     (input, UnblindedOutput::new(val, key, None))
 }

--- a/base_layer/transactions/src/types.rs
+++ b/base_layer/transactions/src/types.rs
@@ -21,6 +21,7 @@
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 use crate::bullet_rangeproofs::BulletRangeProof;
+use std::sync::Arc;
 use tari_crypto::{
     common::Blake256,
     ristretto::{
@@ -68,13 +69,36 @@ pub type RangeProof = BulletRangeProof;
 /// Define the data type that is used to store results of `HashDigest`
 pub type HashOutput = Vec<u8>;
 
-#[cfg(test)]
-pub const MAX_RANGE_PROOF_RANGE: usize = 32; // 2^32 This is the only way to produce failing range proofs for the tests
-#[cfg(not(test))]
 pub const MAX_RANGE_PROOF_RANGE: usize = 64; // 2^64
 
-lazy_static! {
-    pub static ref COMMITMENT_FACTORY: CommitmentFactory = CommitmentFactory::default();
-    pub static ref PROVER: RangeProofService =
-        RangeProofService::new(MAX_RANGE_PROOF_RANGE, &COMMITMENT_FACTORY).unwrap();
+/// A convenience struct wrapping cryptographic factories that are used through-out the rest of the code base
+#[derive(Clone)]
+pub struct CryptoFactories {
+    pub commitment: Arc<CommitmentFactory>,
+    pub range_proof: Arc<RangeProofService>,
+}
+
+impl Default for CryptoFactories {
+    /// Return a default set of crypto factories based on Pedersen commitments with G and H defined in
+    /// [pedersen.rs](/infrastructure/crypto/src/ristretto/pedersen.rs), and an associated range proof factory with a
+    /// range of `[0; 2^64)`.
+    fn default() -> Self {
+        CryptoFactories::new(MAX_RANGE_PROOF_RANGE)
+    }
+}
+
+impl CryptoFactories {
+    /// Create a new set of crypto factories.
+    ///
+    /// ## Parameters
+    ///
+    /// * `max_proof_range`: Sets the the maximum value in range proofs, where `max = 2^max_proof_range`
+    pub fn new(max_proof_range: usize) -> Self {
+        let commitment = Arc::new(CommitmentFactory::default());
+        let range_proof = Arc::new(RangeProofService::new(max_proof_range, &commitment).unwrap());
+        Self {
+            commitment,
+            range_proof,
+        }
+    }
 }

--- a/base_layer/wallet/src/output_manager_service/storage/sqlite_db.rs
+++ b/base_layer/wallet/src/output_manager_service/storage/sqlite_db.rs
@@ -723,7 +723,7 @@ mod test {
     use tari_transactions::{
         tari_amount::MicroTari,
         transaction::{OutputFeatures, TransactionInput, UnblindedOutput},
-        types::{PrivateKey, COMMITMENT_FACTORY},
+        types::{CommitmentFactory, PrivateKey},
     };
     use tempdir::TempDir;
 
@@ -734,7 +734,8 @@ mod test {
 
     pub fn make_input<R: Rng + CryptoRng>(rng: &mut R, val: MicroTari) -> (TransactionInput, UnblindedOutput) {
         let key = PrivateKey::random(rng);
-        let commitment = COMMITMENT_FACTORY.commit_value(&key, val.into());
+        let factory = CommitmentFactory::default();
+        let commitment = factory.commit_value(&key, val.into());
         let input = TransactionInput::new(OutputFeatures::default(), commitment);
         (input, UnblindedOutput::new(val, key, None))
     }

--- a/base_layer/wallet/src/wallet.rs
+++ b/base_layer/wallet/src/wallet.rs
@@ -62,11 +62,13 @@ use tari_p2p::{
     },
 };
 use tari_service_framework::StackBuilder;
+use tari_transactions::types::CryptoFactories;
 use tokio::runtime::Runtime;
 
 #[derive(Clone)]
 pub struct WalletConfig {
     pub comms_config: CommsConfig,
+    pub factories: CryptoFactories,
 }
 
 /// A structure containing the config and services that a Wallet application will require. This struct will start up all
@@ -99,7 +101,7 @@ where T: WalletBackend
             branch_seed: "".to_string(),
             primary_key_index: 0,
         };
-
+        let factories = config.factories;
         let (publisher, subscription_factory) =
             pubsub_connector(runtime.executor(), config.comms_config.inbound_buffer_size);
         let subscription_factory = Arc::new(subscription_factory);
@@ -116,11 +118,13 @@ where T: WalletBackend
             .add_initializer(OutputManagerServiceInitializer::new(
                 oms_config,
                 OutputManagerMemoryDatabase::new(),
+                factories.clone(),
             ))
             .add_initializer(TransactionServiceInitializer::new(
                 subscription_factory.clone(),
                 TransactionMemoryDatabase::new(),
                 comms.node_identity().clone(),
+                factories.clone(),
             ))
             .add_initializer(ContactsServiceInitializer::new(ContactsServiceMemoryDatabase::new()))
             .finish();

--- a/base_layer/wallet/tests/support/utils.rs
+++ b/base_layer/wallet/tests/support/utils.rs
@@ -37,7 +37,7 @@ use tari_crypto::{
 use tari_transactions::{
     tari_amount::MicroTari,
     transaction::{OutputFeatures, TransactionInput, UnblindedOutput},
-    types::{PrivateKey, PublicKey, COMMITMENT_FACTORY},
+    types::{CommitmentFactory, PrivateKey, PublicKey},
 };
 
 pub fn assert_change<F, T>(mut func: F, to: T, poll_count: usize)
@@ -117,9 +117,14 @@ impl TestParams {
         }
     }
 }
-pub fn make_input<R: Rng + CryptoRng>(rng: &mut R, val: MicroTari) -> (TransactionInput, UnblindedOutput) {
+pub fn make_input<R: Rng + CryptoRng>(
+    rng: &mut R,
+    val: MicroTari,
+    factory: &CommitmentFactory,
+) -> (TransactionInput, UnblindedOutput)
+{
     let key = PrivateKey::random(rng);
-    let commitment = COMMITMENT_FACTORY.commit_value(&key, val.into());
+    let commitment = factory.commit_value(&key, val.into());
     let input = TransactionInput::new(OutputFeatures::default(), commitment);
     (input, UnblindedOutput::new(val, key, None))
 }

--- a/base_layer/wallet_ffi/src/lib.rs
+++ b/base_layer/wallet_ffi/src/lib.rs
@@ -118,6 +118,7 @@ use core::ptr;
 use std::{sync::Arc, time::Duration};
 use tari_comms::{connection::NetAddress, control_service::ControlServiceConfig, peer_manager::PeerFeatures};
 use tari_crypto::keys::PublicKey;
+use tari_transactions::types::CryptoFactories;
 use tari_utilities::hex::Hex;
 use tari_wallet::{
     contacts_service::storage::database::Contact,
@@ -1261,12 +1262,14 @@ pub unsafe extern "C" fn wallet_create(config: *mut TariCommsConfig) -> *mut Tar
     }
     // TODO Gracefully handle the case where these expects would fail
     let runtime = Runtime::new();
+    let factories = CryptoFactories::default();
     let w;
     match runtime {
         Ok(runtime) => {
             w = TariWallet::new(
                 WalletConfig {
                     comms_config: (*config).clone(),
+                    factories,
                 },
                 WalletMemoryDatabase::new(),
                 runtime,


### PR DESCRIPTION
PROVER and COMMITMENT_FACTORY are two ugly global variables sitting
in the `types` module.

## Motivation and Context

It would be better to have applications construct a set of factories
(in Arcs, so they can be added to structs where necessary) that
gets passed around. Tests can then use the defaults and tweak the
factories where required to e.g. test range proof bounds.

This PR does just that. `CryptoFactories` is a single container struct that ships 
the commonly used crypto factories around the codebase.

This will also help smooth out the Validation pipeline process.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->


<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Existing tests were updated to use `CryptoFactories`

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [x] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch
* [x] I ran `cargo-fmt --all` before pushing
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
