### PR TITLE
Fixed Discovery Timeout and make wallet test data deterministic

### DIFF
--- a/base_layer/p2p/src/initialization.rs
+++ b/base_layer/p2p/src/initialization.rs
@@ -121,7 +121,7 @@ where
 
     // Create a channel for outbound requests
     let mut dht = comms_dht::DhtBuilder::from_comms(&mut comms)
-        .with_config(comms_dht::DhtConfig::default())
+        .with_config(config.dht.clone())
         .finish();
 
     //---------------------------------- Inbound Pipeline --------------------------------------------//

--- a/base_layer/wallet/tests/wallet/mod.rs
+++ b/base_layer/wallet/tests/wallet/mod.rs
@@ -28,6 +28,7 @@ use tari_comms::{
     peer_manager::{peer::PeerFlags, NodeId, NodeIdentity, Peer, PeerFeatures},
     types::CommsPublicKey,
 };
+use tari_comms_dht::DhtConfig;
 use tari_crypto::keys::PublicKey;
 use tari_p2p::initialization::CommsConfig;
 use tari_transactions::tari_amount::MicroTari;
@@ -195,7 +196,8 @@ fn test_data_generation() {
         PeerFeatures::COMMUNICATION_NODE,
     )
     .unwrap();
-
+    let mut dht_config: DhtConfig = Default::default();
+    dht_config.discovery_request_timeout = Duration::from_millis(500);
     let comms_config = CommsConfig {
         node_identity: Arc::new(node_id.clone()),
         peer_connection_listening_address: "127.0.0.1".parse().unwrap(),
@@ -215,7 +217,7 @@ fn test_data_generation() {
         peer_database_name: random_string(8),
         inbound_buffer_size: 100,
         outbound_buffer_size: 100,
-        dht: Default::default(),
+        dht: dht_config,
     };
 
     let config = WalletConfig { comms_config };
@@ -277,6 +279,8 @@ fn test_test_harness() {
     )
     .unwrap();
 
+    let mut dht_config: DhtConfig = Default::default();
+    dht_config.discovery_request_timeout = Duration::from_millis(500);
     let comms_config1 = CommsConfig {
         node_identity: Arc::new(alice_identity.clone()),
         peer_connection_listening_address: "127.0.0.1".parse().unwrap(),
@@ -296,7 +300,7 @@ fn test_test_harness() {
         peer_database_name: random_string(8),
         inbound_buffer_size: 100,
         outbound_buffer_size: 100,
-        dht: Default::default(),
+        dht: dht_config,
     };
     let config1 = WalletConfig {
         comms_config: comms_config1,


### PR DESCRIPTION
## Description

The Comms stack was not using the provided Discovery Timeout which was causing some trouble in a couple tests.

Also made the contacts keys and amounts of the generated wallet test data consistent between runs.

## Motivation and Context
Closes https://github.com/tari-project/tari/issues/1023

## How Has This Been Tested?
tests updated

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch
* [x] I ran `cargo-fmt --all` before pushing
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
