### PR TITLE
Use tempdir for wallet_ffi tests to avoid corrupted LMDB file in testing

### DIFF
--- a/base_layer/transactions/src/transaction_protocol/recipient.rs
+++ b/base_layer/transactions/src/transaction_protocol/recipient.rs
@@ -27,7 +27,7 @@ use crate::{
         single_receiver::SingleReceiverTransactionProtocol,
         TransactionProtocolError,
     },
-    types::{CryptoFactories, MessageHash, PrivateKey, PublicKey, RangeProofService, Signature},
+    types::{CryptoFactories, MessageHash, PrivateKey, PublicKey, Signature},
 };
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;

--- a/base_layer/transactions/src/transaction_protocol/sender.rs
+++ b/base_layer/transactions/src/transaction_protocol/sender.rs
@@ -23,7 +23,7 @@
 use crate::{
     tari_amount::*,
     transaction::{KernelFeatures, Transaction, TransactionBuilder, TransactionInput, TransactionOutput},
-    types::{BlindingFactor, CommitmentFactory, PrivateKey, PublicKey, RangeProofService, Signature},
+    types::{BlindingFactor, PrivateKey, PublicKey, RangeProofService, Signature},
 };
 
 use crate::{

--- a/base_layer/transactions/src/transaction_protocol/single_receiver.rs
+++ b/base_layer/transactions/src/transaction_protocol/single_receiver.rs
@@ -28,15 +28,7 @@ use crate::{
         sender::SingleRoundSenderData as SD,
         TransactionProtocolError as TPE,
     },
-    types::{
-        CommitmentFactory,
-        CryptoFactories,
-        PrivateKey as SK,
-        PublicKey,
-        RangeProof,
-        RangeProofService,
-        Signature,
-    },
+    types::{CryptoFactories, PrivateKey as SK, PublicKey, RangeProof, Signature},
 };
 use tari_crypto::{
     commitment::HomomorphicCommitmentFactory,

--- a/base_layer/transactions/src/transaction_protocol/transaction_initializer.rs
+++ b/base_layer/transactions/src/transaction_protocol/transaction_initializer.rs
@@ -35,7 +35,7 @@ use crate::{
         sender::{calculate_tx_id, RawTransactionInfo, SenderState, SenderTransactionProtocol},
         TransactionMetadata,
     },
-    types::{BlindingFactor, CommitmentFactory, CryptoFactories, PrivateKey, PublicKey, RangeProofService},
+    types::{BlindingFactor, CryptoFactories, PrivateKey, PublicKey},
 };
 use digest::Digest;
 use std::{

--- a/base_layer/wallet/src/testnet_utils.rs
+++ b/base_layer/wallet/src/testnet_utils.rs
@@ -134,7 +134,7 @@ pub fn create_wallet(secret_key: CommsSecretKey, net_address: String) -> Wallet<
 
 /// This function will generate a set of test data for the supplied wallet. Takes a few seconds to complete
 pub fn generate_wallet_test_data<T: WalletBackend>(wallet: &mut Wallet<T>) -> Result<(), WalletError> {
-    let mut rng = rand::OsRng::new().unwrap();
+    let rng = rand::OsRng::new().unwrap();
     let factories = CryptoFactories::default();
     let names = ["Alice", "Bob", "Carol", "Dave"];
     let private_keys = [

--- a/base_layer/wallet_ffi/Cargo.toml
+++ b/base_layer/wallet_ffi/Cargo.toml
@@ -17,10 +17,10 @@ tokio = "0.2.0-alpha.4"
 libc = "0.2.65"
 rand = "0.5.5"
 chrono = { version = "0.4.6", features = ["serde"]}
-tempdir = "0.3.7"
 tari_broadcast_channel = { version="^0.0",  path = "../../infrastructure/broadcast_channel" }
 
 [lib]
 crate-type = ["staticlib","cdylib"]
 
 [dev-dependencies]
+tempdir = "0.3.7"

--- a/base_layer/wallet_ffi/src/lib.rs
+++ b/base_layer/wallet_ffi/src/lib.rs
@@ -1980,6 +1980,8 @@ mod test {
     use crate::*;
     use libc::{c_char, c_uchar, c_uint};
     use std::ffi::CString;
+    use tari_wallet::testnet_utils::random_string;
+    use tempdir::TempDir;
 
     unsafe extern "C" fn completed_callback(tx: *mut TariCompletedTransaction) {
         assert_eq!(tx.is_null(), false);
@@ -2076,9 +2078,16 @@ mod test {
         unsafe {
             let secret_key_alice = private_key_generate();
             let public_key_alice = public_key_from_private_key(secret_key_alice.clone());
-            let db_name_alice = CString::new("ffi_test1_alice").unwrap();
+            let db_name_alice = CString::new(random_string(8).as_str()).unwrap();
             let db_name_alice_str: *const c_char = CString::into_raw(db_name_alice.clone()) as *const c_char;
-            let db_path_alice = CString::new("./data_alice").unwrap();
+            let db_path_alice = CString::new(
+                TempDir::new(random_string(8).as_str())
+                    .unwrap()
+                    .path()
+                    .to_str()
+                    .unwrap(),
+            )
+            .unwrap();
             let db_path_alice_str: *const c_char = CString::into_raw(db_path_alice.clone()) as *const c_char;
             let address_alice = CString::new("127.0.0.1:21443").unwrap();
             let address_alice_str: *const c_char = CString::into_raw(address_alice.clone()) as *const c_char;
@@ -2093,9 +2102,16 @@ mod test {
 
             let secret_key_bob = private_key_generate();
             let public_key_bob = public_key_from_private_key(secret_key_bob.clone());
-            let db_name_bob = CString::new("ffi_test1_bob").unwrap();
+            let db_name_bob = CString::new(random_string(8).as_str()).unwrap();
             let db_name_bob_str: *const c_char = CString::into_raw(db_name_bob.clone()) as *const c_char;
-            let db_path_bob = CString::new("./data_bob").unwrap();
+            let db_path_bob = CString::new(
+                TempDir::new(random_string(8).as_str())
+                    .unwrap()
+                    .path()
+                    .to_str()
+                    .unwrap(),
+            )
+            .unwrap();
             let db_path_bob_str: *const c_char = CString::into_raw(db_path_bob.clone()) as *const c_char;
             let address_bob = CString::new("127.0.0.1:21441").unwrap();
             let address_bob_str: *const c_char = CString::into_raw(address_bob.clone()) as *const c_char;


### PR DESCRIPTION
## Description
As above

## Motivation and Context
When the wallet_ffi test broke it would leave a corrupt LMDB file on the disk which caused future issues.


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch
* [x] I ran `cargo-fmt --all` before pushing
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
