### PR TITLE
Mempool service skeleton

### DIFF
--- a/base_layer/core/build.rs
+++ b/base_layer/core/build.rs
@@ -23,7 +23,7 @@
 fn main() {
     tari_protobuf_build::ProtoCompiler::new()
         .include_paths(&["../transactions/src/proto", "src/proto"])
-        .proto_paths(&["src/base_node/proto"])
+        .proto_paths(&["src/mempool/proto", "src/base_node/proto"])
         .compile()
         .unwrap();
 }

--- a/base_layer/core/src/base_node/service/service.rs
+++ b/base_layer/core/src/base_node/service/service.rs
@@ -68,8 +68,6 @@ use tokio::runtime::TaskExecutor;
 
 const LOG_TARGET: &'static str = "tari_core::base_node::base_node_service::service";
 
-// TODO: Add streams for BlockchainMessage::NewBlock and BlockchainMessage::Transaction
-
 /// Configuration for the BaseNodeService.
 #[derive(Clone, Copy)]
 pub struct BaseNodeServiceConfig {
@@ -125,7 +123,7 @@ where
         local_block_stream: SLocalBlock,
     ) -> Self
     {
-        BaseNodeStreams {
+        Self {
             outbound_request_stream,
             outbound_block_stream,
             inbound_request_stream,
@@ -466,7 +464,9 @@ where B: BlockchainBackend
     ) -> Result<(), BaseNodeServiceError>
     {
         let DomainMessage::<_> {
-            origin_pubkey, inner, ..
+            // origin_pubkey,
+            inner,
+            ..
         } = domain_block_msg;
 
         info!("New candidate block received for height {}", inner.header.height);

--- a/base_layer/core/src/base_node/test/comms_interface.rs
+++ b/base_layer/core/src/base_node/test/comms_interface.rs
@@ -54,7 +54,7 @@ use tari_transactions::{
     tari_amount::MicroTari,
     types::{CryptoFactories, HashDigest},
 };
-use tari_utilities::{hash::Hashable, hex::Hex};
+use tari_utilities::hash::Hashable;
 
 async fn test_request_responder(
     receiver: &mut Receiver<

--- a/base_layer/core/src/blocks/blockheader.rs
+++ b/base_layer/core/src/blocks/blockheader.rs
@@ -38,7 +38,7 @@
 //! This hash is called the UTXO merkle root, and is used as the output_mr
 
 use crate::{proof_of_work::Difficulty, types::TariProofOfWork};
-use chrono::{DateTime, NaiveDateTime, Utc};
+use chrono::{DateTime, Utc};
 use digest::Digest;
 use serde::{
     de::{self, Visitor},

--- a/base_layer/core/src/consts.rs
+++ b/base_layer/core/src/consts.rs
@@ -50,3 +50,6 @@ thread_local! {
 pub const BASE_NODE_SERVICE_REQUEST_TIMEOUT: Duration = Duration::from_secs(5);
 /// The fraction of responses that need to be received for a corresponding service request to be finalize.
 pub const BASE_NODE_SERVICE_DESIRED_RESPONSE_FRACTION: f32 = 0.6;
+
+/// The allocated waiting time for a request waiting for service responses from the mempools of remote base nodes.
+pub const MEMPOOL_SERVICE_REQUEST_TIMEOUT: Duration = Duration::from_secs(5);

--- a/base_layer/core/src/mempool/mempool.rs
+++ b/base_layer/core/src/mempool/mempool.rs
@@ -31,6 +31,7 @@ use crate::{
         unconfirmed_pool::{UnconfirmedPool, UnconfirmedPoolConfig},
     },
 };
+use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 use tari_transactions::{transaction::Transaction, types::Signature};
 use tari_utilities::hash::Hashable;
@@ -44,7 +45,7 @@ pub enum TxStorageResponse {
     NotStored,
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
 pub struct StatsResponse {
     pub total_txs: usize,
     pub unconfirmed_txs: usize,

--- a/base_layer/core/src/mempool/proto/mempool_request.rs
+++ b/base_layer/core/src/mempool/proto/mempool_request.rs
@@ -1,4 +1,4 @@
-// Copyright 2019. The Tari Project
+// Copyright 2019, The Tari Project
 //
 // Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
 // following conditions are met:
@@ -20,18 +20,28 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-mod error;
-mod mempool;
-mod orphan_pool;
-mod pending_pool;
-mod priority;
-mod proto;
-mod reorg_pool;
-mod service;
-#[cfg(test)]
-mod test;
-mod unconfirmed_pool;
+use super::mempool::mempool_service_request::Request as ProtoMempoolRequest;
+use crate::mempool::service::MempoolRequest;
+use std::convert::TryInto;
 
-// Public re-exports
-pub use error::MempoolError;
-pub use mempool::{Mempool, MempoolConfig, TxStorageResponse};
+impl TryInto<MempoolRequest> for ProtoMempoolRequest {
+    type Error = String;
+
+    fn try_into(self) -> Result<MempoolRequest, Self::Error> {
+        use ProtoMempoolRequest::*;
+        let request = match self {
+            // Field was not specified
+            GetStats(_) => MempoolRequest::GetStats,
+        };
+        Ok(request)
+    }
+}
+
+impl From<MempoolRequest> for ProtoMempoolRequest {
+    fn from(request: MempoolRequest) -> Self {
+        use MempoolRequest::*;
+        match request {
+            GetStats => ProtoMempoolRequest::GetStats(true),
+        }
+    }
+}

--- a/base_layer/core/src/mempool/proto/mempool_response.rs
+++ b/base_layer/core/src/mempool/proto/mempool_response.rs
@@ -1,4 +1,4 @@
-// Copyright 2019. The Tari Project
+// Copyright 2019, The Tari Project
 //
 // Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
 // following conditions are met:
@@ -20,18 +20,27 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-mod error;
-mod mempool;
-mod orphan_pool;
-mod pending_pool;
-mod priority;
-mod proto;
-mod reorg_pool;
-mod service;
-#[cfg(test)]
-mod test;
-mod unconfirmed_pool;
+use super::mempool::mempool_service_response::Response as ProtoMempoolResponse;
+use crate::mempool::service::MempoolResponse;
+use std::convert::TryInto;
 
-// Public re-exports
-pub use error::MempoolError;
-pub use mempool::{Mempool, MempoolConfig, TxStorageResponse};
+impl TryInto<MempoolResponse> for ProtoMempoolResponse {
+    type Error = String;
+
+    fn try_into(self) -> Result<MempoolResponse, Self::Error> {
+        use ProtoMempoolResponse::*;
+        let response = match self {
+            Stats(stats_response) => MempoolResponse::Stats(stats_response.try_into()?),
+        };
+        Ok(response)
+    }
+}
+
+impl From<MempoolResponse> for ProtoMempoolResponse {
+    fn from(response: MempoolResponse) -> Self {
+        use MempoolResponse::*;
+        match response {
+            Stats(stats_response) => ProtoMempoolResponse::Stats(stats_response.into()),
+        }
+    }
+}

--- a/base_layer/core/src/mempool/proto/mod.rs
+++ b/base_layer/core/src/mempool/proto/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2019. The Tari Project
+// Copyright 2019, The Tari Project
 //
 // Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
 // following conditions are met:
@@ -20,18 +20,12 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-mod error;
-mod mempool;
-mod orphan_pool;
-mod pending_pool;
-mod priority;
-mod proto;
-mod reorg_pool;
-mod service;
-#[cfg(test)]
-mod test;
-mod unconfirmed_pool;
+pub mod mempool {
+    tari_utilities::include_proto_package!("tari.mempool");
+}
 
-// Public re-exports
-pub use error::MempoolError;
-pub use mempool::{Mempool, MempoolConfig, TxStorageResponse};
+pub mod mempool_request;
+pub mod mempool_response;
+pub mod stats_response;
+
+pub use mempool::{MempoolServiceRequest, MempoolServiceResponse};

--- a/base_layer/core/src/mempool/proto/service_request.proto
+++ b/base_layer/core/src/mempool/proto/service_request.proto
@@ -1,0 +1,12 @@
+syntax = "proto3";
+
+package tari.mempool;
+
+// Request type for a received MempoolService request.
+message MempoolServiceRequest {
+    uint64 request_key = 1;
+    oneof request {
+        // Indicates a Stats request. The value of the bool should be ignored.
+        bool get_stats = 2;
+    }
+}

--- a/base_layer/core/src/mempool/proto/service_response.proto
+++ b/base_layer/core/src/mempool/proto/service_response.proto
@@ -1,0 +1,14 @@
+syntax = "proto3";
+
+import "stats_response.proto";
+
+package tari.mempool;
+
+// Response type for a received MempoolService requests
+message MempoolServiceResponse {
+    uint64 request_key = 1;
+    oneof response {
+        StatsResponse stats = 2;
+    }
+}
+

--- a/base_layer/core/src/mempool/proto/stats_response.proto
+++ b/base_layer/core/src/mempool/proto/stats_response.proto
@@ -1,0 +1,12 @@
+syntax = "proto3";
+
+package tari.mempool;
+
+message StatsResponse {
+    uint64 total_txs = 1;
+    uint64 unconfirmed_txs = 2;
+    uint64 orphan_txs = 3;
+    uint64 timelocked_txs = 4;
+    uint64 published_txs = 5;
+    uint64 total_weight = 6;
+}

--- a/base_layer/core/src/mempool/proto/stats_response.rs
+++ b/base_layer/core/src/mempool/proto/stats_response.rs
@@ -1,4 +1,4 @@
-// Copyright 2019. The Tari Project
+// Copyright 2019, The Tari Project
 //
 // Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
 // following conditions are met:
@@ -20,18 +20,33 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-mod error;
-mod mempool;
-mod orphan_pool;
-mod pending_pool;
-mod priority;
-mod proto;
-mod reorg_pool;
-mod service;
-#[cfg(test)]
-mod test;
-mod unconfirmed_pool;
+use crate::mempool::{mempool::StatsResponse, proto::mempool::StatsResponse as ProtoStatsResponse};
+use std::convert::TryFrom;
 
-// Public re-exports
-pub use error::MempoolError;
-pub use mempool::{Mempool, MempoolConfig, TxStorageResponse};
+impl TryFrom<ProtoStatsResponse> for StatsResponse {
+    type Error = String;
+
+    fn try_from(stats: ProtoStatsResponse) -> Result<Self, Self::Error> {
+        Ok(Self {
+            total_txs: stats.total_txs as usize,
+            unconfirmed_txs: stats.unconfirmed_txs as usize,
+            orphan_txs: stats.orphan_txs as usize,
+            timelocked_txs: stats.timelocked_txs as usize,
+            published_txs: stats.published_txs as usize,
+            total_weight: stats.total_weight,
+        })
+    }
+}
+
+impl From<StatsResponse> for ProtoStatsResponse {
+    fn from(stats: StatsResponse) -> Self {
+        Self {
+            total_txs: stats.total_txs as u64,
+            unconfirmed_txs: stats.unconfirmed_txs as u64,
+            orphan_txs: stats.orphan_txs as u64,
+            timelocked_txs: stats.timelocked_txs as u64,
+            published_txs: stats.published_txs as u64,
+            total_weight: stats.total_weight,
+        }
+    }
+}

--- a/base_layer/core/src/mempool/service/error.rs
+++ b/base_layer/core/src/mempool/service/error.rs
@@ -1,4 +1,4 @@
-// Copyright 2019. The Tari Project
+// Copyright 2019 The Tari Project
 //
 // Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
 // following conditions are met:
@@ -20,18 +20,23 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-mod error;
-mod mempool;
-mod orphan_pool;
-mod pending_pool;
-mod priority;
-mod proto;
-mod reorg_pool;
-mod service;
-#[cfg(test)]
-mod test;
-mod unconfirmed_pool;
+use crate::mempool::MempoolError;
+use derive_error::Error;
+use tari_comms_dht::outbound::DhtOutboundError;
+use tari_service_framework::reply_channel::TransportChannelError;
 
-// Public re-exports
-pub use error::MempoolError;
-pub use mempool::{Mempool, MempoolConfig, TxStorageResponse};
+#[derive(Debug, Error)]
+pub enum MempoolServiceError {
+    DhtOutboundError(DhtOutboundError),
+    #[error(msg_embedded, no_from, non_std)]
+    InvalidRequest(String),
+    #[error(msg_embedded, no_from, non_std)]
+    InvalidResponse(String),
+    RequestTimedOut,
+    NoBootstrapNodesConfigured,
+    #[error(non_std, no_from)]
+    OutboundMessageService(String),
+    MempoolError(MempoolError),
+    UnexpectedApiResponse,
+    TransportChannelError(TransportChannelError),
+}

--- a/base_layer/core/src/mempool/service/initializer.rs
+++ b/base_layer/core/src/mempool/service/initializer.rs
@@ -1,0 +1,188 @@
+// Copyright 2019. The Tari Project
+//
+// Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+// following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+// disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+// following disclaimer in the documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+// products derived from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+// INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+// WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+// USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+use crate::{
+    chain_storage::BlockchainBackend,
+    mempool::{
+        mempool::Mempool,
+        proto,
+        service::{
+            inbound_handlers::MempoolInboundHandlers,
+            outbound_interface::OutboundMempoolServiceInterface,
+            service::{MempoolService, MempoolServiceConfig, MempoolStreams},
+        },
+    },
+};
+use futures::{future, Future, Stream, StreamExt};
+use log::*;
+use std::{convert::TryFrom, sync::Arc};
+use tari_comms_dht::outbound::OutboundMessageRequester;
+use tari_p2p::{
+    comms_connector::PeerMessage,
+    domain_message::DomainMessage,
+    services::utils::{map_decode, ok_or_skip_result},
+    tari_message::TariMessageType,
+};
+use tari_pubsub::TopicSubscriptionFactory;
+use tari_service_framework::{
+    handles::ServiceHandlesFuture,
+    reply_channel,
+    ServiceInitializationError,
+    ServiceInitializer,
+};
+use tari_shutdown::ShutdownSignal;
+use tari_transactions::{proto::types::Transaction as ProtoTransaction, transaction::Transaction};
+use tokio::runtime::TaskExecutor;
+
+const LOG_TARGET: &'static str = "base_node::mempool_service::initializer";
+
+/// Initializer for the Mempool service and service future.
+pub struct MempoolServiceInitializer<T>
+where T: BlockchainBackend
+{
+    inbound_message_subscription_factory: Arc<TopicSubscriptionFactory<TariMessageType, Arc<PeerMessage>>>,
+    mempool: Mempool<T>,
+    config: MempoolServiceConfig,
+}
+
+impl<T> MempoolServiceInitializer<T>
+where T: BlockchainBackend
+{
+    /// Create a new MempoolServiceInitializer from the inbound message subscriber.
+    pub fn new(
+        inbound_message_subscription_factory: Arc<TopicSubscriptionFactory<TariMessageType, Arc<PeerMessage>>>,
+        mempool: Mempool<T>,
+        config: MempoolServiceConfig,
+    ) -> Self
+    {
+        Self {
+            inbound_message_subscription_factory,
+            mempool,
+            config,
+        }
+    }
+
+    /// Get a stream for inbound Mempool service request messages
+    fn inbound_request_stream(&self) -> impl Stream<Item = DomainMessage<proto::MempoolServiceRequest>> {
+        self.inbound_message_subscription_factory
+            .get_subscription(TariMessageType::MempoolRequest)
+            .map(map_decode::<proto::MempoolServiceRequest>)
+            .filter_map(ok_or_skip_result)
+    }
+
+    /// Get a stream for inbound Mempool service response messages
+    fn inbound_response_stream(&self) -> impl Stream<Item = DomainMessage<proto::MempoolServiceResponse>> {
+        self.inbound_message_subscription_factory
+            .get_subscription(TariMessageType::MempoolResponse)
+            .map(map_decode::<proto::MempoolServiceResponse>)
+            .filter_map(ok_or_skip_result)
+    }
+
+    /// Create a stream of 'New Transaction` messages
+    fn inbound_transaction_stream(&self) -> impl Stream<Item = DomainMessage<Transaction>> {
+        self.inbound_message_subscription_factory
+            .get_subscription(TariMessageType::NewTransaction)
+            .filter_map(extract_transaction)
+    }
+}
+
+async fn extract_transaction(msg: Arc<PeerMessage>) -> Option<DomainMessage<Transaction>> {
+    match msg.decode_message::<ProtoTransaction>() {
+        Err(e) => {
+            warn!(
+                target: LOG_TARGET,
+                "Could not decode inbound transaction message. {}",
+                e.to_string()
+            );
+            None
+        },
+        Ok(tx) => {
+            let origin = msg.dht_header.origin_public_key.clone();
+            let tx = match Transaction::try_from(tx) {
+                Err(e) => {
+                    warn!(
+                        target: LOG_TARGET,
+                        "Inbound transaction message from {} was ill-formed. {}", origin, e
+                    );
+                    return None;
+                },
+                Ok(b) => b,
+            };
+            Some(DomainMessage {
+                source_peer: msg.source_peer.clone(),
+                origin_pubkey: origin,
+                inner: tx,
+            })
+        },
+    }
+}
+
+impl<T> ServiceInitializer for MempoolServiceInitializer<T>
+where T: BlockchainBackend + 'static
+{
+    type Future = impl Future<Output = Result<(), ServiceInitializationError>>;
+
+    fn initialize(
+        &mut self,
+        executor: TaskExecutor,
+        handles_fut: ServiceHandlesFuture,
+        shutdown: ShutdownSignal,
+    ) -> Self::Future
+    {
+        // Create streams for receiving Mempool service requests and response messages from comms
+        let inbound_request_stream = self.inbound_request_stream();
+        let inbound_response_stream = self.inbound_response_stream();
+        let inbound_transaction_stream = self.inbound_transaction_stream();
+        // Connect MempoolOutboundServiceHandle to MempoolService
+        let (outbound_request_sender_service, outbound_request_stream) = reply_channel::unbounded();
+        let outbound_mp_interface = OutboundMempoolServiceInterface::new(outbound_request_sender_service);
+
+        let inbound_handlers = MempoolInboundHandlers::new(self.mempool.clone());
+        let executer_clone = executor.clone(); // Give MempoolService access to the executor
+        let config = self.config.clone();
+
+        // Register handle to OutboundMempoolServiceInterface before waiting for handles to be ready
+        handles_fut.register(outbound_mp_interface);
+
+        executor.spawn(async move {
+            let handles = handles_fut.await;
+
+            let outbound_message_service = handles
+                .get_handle::<OutboundMessageRequester>()
+                .expect("OutboundMessageRequester handle required for MempoolService");
+
+            let streams = MempoolStreams::new(
+                outbound_request_stream,
+                inbound_request_stream,
+                inbound_response_stream,
+                inbound_transaction_stream,
+            );
+            let service =
+                MempoolService::new(executer_clone, outbound_message_service, inbound_handlers, config).start(streams);
+            futures::pin_mut!(service);
+            future::select(service, shutdown).await;
+            info!(target: LOG_TARGET, "Mempool Service shutdown");
+        });
+
+        future::ready(Ok(()))
+    }
+}

--- a/base_layer/core/src/mempool/service/mod.rs
+++ b/base_layer/core/src/mempool/service/mod.rs
@@ -21,17 +21,17 @@
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 mod error;
-mod mempool;
-mod orphan_pool;
-mod pending_pool;
-mod priority;
-mod proto;
-mod reorg_pool;
+mod inbound_handlers;
+mod initializer;
+mod outbound_interface;
+mod request;
+mod response;
 mod service;
-#[cfg(test)]
-mod test;
-mod unconfirmed_pool;
 
 // Public re-exports
-pub use error::MempoolError;
-pub use mempool::{Mempool, MempoolConfig, TxStorageResponse};
+pub use error::MempoolServiceError;
+pub use initializer::MempoolServiceInitializer;
+pub use outbound_interface::OutboundMempoolServiceInterface;
+pub use request::{MempoolRequest, MempoolServiceRequest, RequestKey};
+pub use response::{MempoolResponse, MempoolServiceResponse};
+pub use service::{MempoolService, MempoolServiceConfig};

--- a/base_layer/core/src/mempool/service/request.rs
+++ b/base_layer/core/src/mempool/service/request.rs
@@ -1,0 +1,45 @@
+//  Copyright 2019 The Tari Project
+//
+//  Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+//  following conditions are met:
+//
+//  1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+//  disclaimer.
+//
+//  2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+//  following disclaimer in the documentation and/or other materials provided with the distribution.
+//
+//  3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+//  products derived from this software without specific prior written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+//  INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+//  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+//  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+//  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+//  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+//  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+use rand::RngCore;
+use serde::{Deserialize, Serialize};
+
+pub type RequestKey = u64; // TODO: BaseNodeService and MempoolService uses RequestKey
+
+/// Generate a new random request key to uniquely identify a request and its corresponding responses.
+pub fn generate_request_key<R>(rng: &mut R) -> RequestKey
+where R: RngCore {
+    rng.next_u64()
+}
+
+/// API Request enum for Mempool requests.
+#[derive(Debug, Serialize, Deserialize)]
+pub enum MempoolRequest {
+    GetStats,
+}
+
+/// Request type for a received MempoolService request.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct MempoolServiceRequest {
+    pub request_key: RequestKey,
+    pub request: MempoolRequest,
+}

--- a/base_layer/core/src/mempool/service/response.rs
+++ b/base_layer/core/src/mempool/service/response.rs
@@ -1,4 +1,4 @@
-// Copyright 2019. The Tari Project
+// Copyright 2019 The Tari Project
 //
 // Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
 // following conditions are met:
@@ -20,18 +20,18 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-mod error;
-mod mempool;
-mod orphan_pool;
-mod pending_pool;
-mod priority;
-mod proto;
-mod reorg_pool;
-mod service;
-#[cfg(test)]
-mod test;
-mod unconfirmed_pool;
+use crate::mempool::{mempool::StatsResponse, service::RequestKey};
+use serde::{Deserialize, Serialize};
 
-// Public re-exports
-pub use error::MempoolError;
-pub use mempool::{Mempool, MempoolConfig, TxStorageResponse};
+/// API Response enum for Mempool responses.
+#[derive(Debug, Serialize, Deserialize)]
+pub enum MempoolResponse {
+    Stats(StatsResponse),
+}
+
+/// Response type for a received MempoolService requests
+#[derive(Debug, Serialize, Deserialize)]
+pub struct MempoolServiceResponse {
+    pub request_key: RequestKey,
+    pub response: MempoolResponse,
+}

--- a/base_layer/core/src/mempool/service/service.rs
+++ b/base_layer/core/src/mempool/service/service.rs
@@ -1,0 +1,375 @@
+// Copyright 2019 The Tari Project
+//
+// Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+// following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+// disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+// following disclaimer in the documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+// products derived from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+// INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+// WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+// USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+use crate::{
+    chain_storage::BlockchainBackend,
+    consts::{BASE_NODE_RNG, MEMPOOL_SERVICE_REQUEST_TIMEOUT},
+    mempool::{
+        proto,
+        service::{
+            error::MempoolServiceError,
+            inbound_handlers::MempoolInboundHandlers,
+            request::{generate_request_key, RequestKey},
+            MempoolRequest,
+            MempoolResponse,
+        },
+    },
+};
+use futures::{
+    channel::{
+        mpsc::{channel, Receiver, Sender},
+        oneshot::Sender as OneshotSender,
+    },
+    pin_mut,
+    stream::StreamExt,
+    SinkExt,
+    Stream,
+};
+use log::*;
+use std::{
+    collections::HashMap,
+    convert::TryInto,
+    time::{Duration, Instant},
+};
+use tari_comms_dht::{
+    broadcast_strategy::BroadcastStrategy,
+    domain_message::OutboundDomainMessage,
+    envelope::NodeDestination,
+    outbound::{OutboundEncryption, OutboundMessageRequester},
+};
+use tari_p2p::{domain_message::DomainMessage, tari_message::TariMessageType};
+use tari_service_framework::RequestContext;
+use tari_transactions::{proto::types::Transaction as ProtoTransaction, transaction::Transaction};
+use tokio::runtime::TaskExecutor;
+
+const LOG_TARGET: &'static str = "tari_core::base_node::mempool::service";
+
+/// Configuration for the MempoolService.
+#[derive(Clone, Copy)]
+pub struct MempoolServiceConfig {
+    /// The allocated waiting time for a request waiting for service responses from the Mempools of remote Base nodes.
+    pub request_timeout: Duration,
+}
+
+impl Default for MempoolServiceConfig {
+    fn default() -> Self {
+        Self {
+            request_timeout: MEMPOOL_SERVICE_REQUEST_TIMEOUT,
+        }
+    }
+}
+
+/// A convenience struct to hold all the Mempool service streams
+pub struct MempoolStreams<SOutReq, SInReq, SInRes, STxIn> {
+    outbound_request_stream: SOutReq,
+    inbound_request_stream: SInReq,
+    inbound_response_stream: SInRes,
+    inbound_transaction_stream: STxIn,
+}
+
+impl<SOutReq, SInReq, SInRes, STxIn> MempoolStreams<SOutReq, SInReq, SInRes, STxIn>
+where
+    SOutReq: Stream<Item = RequestContext<MempoolRequest, Result<MempoolResponse, MempoolServiceError>>>,
+    SInReq: Stream<Item = DomainMessage<proto::MempoolServiceRequest>>,
+    SInRes: Stream<Item = DomainMessage<proto::MempoolServiceResponse>>,
+    STxIn: Stream<Item = DomainMessage<Transaction>>,
+{
+    pub fn new(
+        outbound_request_stream: SOutReq,
+        inbound_request_stream: SInReq,
+        inbound_response_stream: SInRes,
+        inbound_transaction_stream: STxIn,
+    ) -> Self
+    {
+        Self {
+            outbound_request_stream,
+            inbound_request_stream,
+            inbound_response_stream,
+            inbound_transaction_stream,
+        }
+    }
+}
+
+/// The Mempool Service is responsible for handling inbound requests and responses and for sending new requests to the
+/// Mempools of remote Base nodes.
+pub struct MempoolService<B: BlockchainBackend> {
+    executor: TaskExecutor,
+    outbound_message_service: OutboundMessageRequester,
+    inbound_handlers: MempoolInboundHandlers<B>,
+    waiting_requests: HashMap<RequestKey, Option<OneshotSender<Result<MempoolResponse, MempoolServiceError>>>>,
+    timeout_sender: Sender<RequestKey>,
+    timeout_receiver_stream: Option<Receiver<RequestKey>>,
+    config: MempoolServiceConfig,
+}
+
+impl<B> MempoolService<B>
+where B: BlockchainBackend
+{
+    pub fn new(
+        executor: TaskExecutor,
+        outbound_message_service: OutboundMessageRequester,
+        inbound_handlers: MempoolInboundHandlers<B>,
+        config: MempoolServiceConfig,
+    ) -> Self
+    {
+        let (timeout_sender, timeout_receiver) = channel(100);
+        Self {
+            executor,
+            outbound_message_service,
+            inbound_handlers,
+            waiting_requests: HashMap::new(),
+            timeout_sender,
+            timeout_receiver_stream: Some(timeout_receiver),
+            config,
+        }
+    }
+
+    pub async fn start<SOutReq, SInReq, SInRes, STxIn>(
+        mut self,
+        streams: MempoolStreams<SOutReq, SInReq, SInRes, STxIn>,
+    ) -> Result<(), MempoolServiceError>
+    where
+        SOutReq: Stream<Item = RequestContext<MempoolRequest, Result<MempoolResponse, MempoolServiceError>>>,
+        SInReq: Stream<Item = DomainMessage<proto::MempoolServiceRequest>>,
+        SInRes: Stream<Item = DomainMessage<proto::MempoolServiceResponse>>,
+        STxIn: Stream<Item = DomainMessage<Transaction>>,
+    {
+        let outbound_request_stream = streams.outbound_request_stream.fuse();
+        pin_mut!(outbound_request_stream);
+        let inbound_request_stream = streams.inbound_request_stream.fuse();
+        pin_mut!(inbound_request_stream);
+        let inbound_response_stream = streams.inbound_response_stream.fuse();
+        pin_mut!(inbound_response_stream);
+        let inbound_transaction_stream = streams.inbound_transaction_stream.fuse();
+        pin_mut!(inbound_transaction_stream);
+        let timeout_receiver_stream = self
+            .timeout_receiver_stream
+            .take()
+            .expect("Mempool Service initialized without timeout_receiver_stream")
+            .fuse();
+        pin_mut!(timeout_receiver_stream);
+        loop {
+            futures::select! {
+                // Outbound request messages from the OutboundMempoolServiceInterface
+                outbound_request_context = outbound_request_stream.select_next_some() => {
+                    let (request, reply_tx) = outbound_request_context.split();
+                    let _ = self.handle_outbound_request(reply_tx,request).await.or_else(|err| {
+                        error!(target: LOG_TARGET, "Failed to handle outbound request message: {:?}", err);
+                        Err(err)
+                    });
+                },
+
+                // Incoming request messages from the Comms layer
+                domain_msg = inbound_request_stream.select_next_some() => {
+                    let _ = self.handle_incoming_request(domain_msg).await.or_else(|err| {
+                        error!(target: LOG_TARGET, "Failed to handle incoming request message: {:?}", err);
+                        Err(err)
+                    });
+                },
+
+                // Incoming response messages from the Comms layer
+                domain_msg = inbound_response_stream.select_next_some() => {
+                    let _ = self.handle_incoming_response(domain_msg.into_inner()).await.or_else(|err| {
+                        error!(target: LOG_TARGET, "Failed to handle incoming response message: {:?}", err);
+                        Err(err)
+                    });
+                },
+
+                // Incoming transaction messages from the Comms layer
+                transaction_msg = inbound_transaction_stream.select_next_some() => {
+                    let _ = self.handle_incoming_transaction(transaction_msg).await.or_else(|err| {
+                        error!(target: LOG_TARGET, "Failed to handle incoming transaction message: {:?}", err);
+                        Err(err)
+                    });
+                }
+
+                // Timeout events for waiting requests
+                timeout_request_key = timeout_receiver_stream.select_next_some() => {
+                    let _ =self.handle_request_timeout(timeout_request_key).await.or_else(|err| {
+                        error!(target: LOG_TARGET, "Failed to handle request timeout event: {:?}", err);
+                        Err(err)
+                    });
+                },
+
+                complete => {
+                    info!(target: LOG_TARGET, "Mempool service shutting down");
+                    break;
+                }
+            }
+        }
+        Ok(())
+    }
+
+    async fn handle_incoming_request(
+        &mut self,
+        domain_request_msg: DomainMessage<proto::MempoolServiceRequest>,
+    ) -> Result<(), MempoolServiceError>
+    {
+        let DomainMessage::<_> {
+            origin_pubkey, inner, ..
+        } = domain_request_msg;
+
+        // Convert proto::MempoolServiceRequest to a MempoolServiceRequest
+        let request = inner.request.ok_or(MempoolServiceError::InvalidRequest(
+            "Received invalid mempool service request".to_string(),
+        ))?;
+
+        let response = self
+            .inbound_handlers
+            .handle_request(&request.try_into().map_err(|e| MempoolServiceError::InvalidRequest(e))?)
+            .await?;
+
+        let message = proto::MempoolServiceResponse {
+            request_key: inner.request_key,
+            response: Some(response.into()),
+        };
+
+        self.outbound_message_service
+            .send_direct(
+                origin_pubkey,
+                OutboundEncryption::EncryptForDestination,
+                OutboundDomainMessage::new(TariMessageType::MempoolResponse, message),
+            )
+            .await?;
+
+        Ok(())
+    }
+
+    async fn handle_incoming_response(
+        &mut self,
+        incoming_response: proto::MempoolServiceResponse,
+    ) -> Result<(), MempoolServiceError>
+    {
+        let proto::MempoolServiceResponse { request_key, response } = incoming_response;
+
+        match self.waiting_requests.remove(&request_key) {
+            Some(mut reply_tx) => {
+                if let Some(reply_tx) = reply_tx.take() {
+                    let response =
+                        response
+                            .and_then(|r| r.try_into().ok())
+                            .ok_or(MempoolServiceError::InvalidResponse(
+                                "Received an invalid Mempool response".to_string(),
+                            ))?;
+                    let _ = reply_tx.send(Ok(response).or_else(|resp| {
+                        error!(
+                            target: LOG_TARGET,
+                            "Failed to send outbound request from Mempool service"
+                        );
+                        Err(resp)
+                    }));
+                }
+            },
+            None => {
+                info!(target: LOG_TARGET, "Discard incoming unmatched response");
+            },
+        }
+
+        Ok(())
+    }
+
+    async fn handle_outbound_request(
+        &mut self,
+        reply_tx: OneshotSender<Result<MempoolResponse, MempoolServiceError>>,
+        request: MempoolRequest,
+    ) -> Result<(), MempoolServiceError>
+    {
+        let request_key = BASE_NODE_RNG.with(|rng| generate_request_key(&mut *rng.borrow_mut()));
+        let service_request = proto::MempoolServiceRequest {
+            request_key,
+            request: Some(request.into()),
+        };
+
+        let dest_count = self
+            .outbound_message_service
+            .send_message(
+                BroadcastStrategy::Random(1),
+                NodeDestination::Unknown,
+                OutboundEncryption::EncryptForDestination,
+                OutboundDomainMessage::new(TariMessageType::MempoolRequest, service_request),
+            )
+            .await
+            .map_err(|e| MempoolServiceError::OutboundMessageService(e.to_string()))?;
+
+        if dest_count > 0 {
+            // Spawn timeout and wait for matching response to arrive
+            self.waiting_requests.insert(request_key, Some(reply_tx));
+            self.spawn_request_timeout(request_key, self.config.request_timeout)
+                .await;
+        } else {
+            let _ = reply_tx.send(Err(MempoolServiceError::NoBootstrapNodesConfigured).or_else(|resp| {
+                error!(
+                    target: LOG_TARGET,
+                    "Failed to send outbound request from Mempool service as no bootstrap nodes were configured"
+                );
+                Err(resp)
+            }));
+        }
+        Ok(())
+    }
+
+    async fn handle_incoming_transaction(
+        &mut self,
+        domain_transaction_msg: DomainMessage<Transaction>,
+    ) -> Result<(), MempoolServiceError>
+    {
+        let DomainMessage::<_> { source_peer, inner, .. } = domain_transaction_msg;
+
+        self.inbound_handlers.handle_transaction(&inner.clone().into()).await?;
+
+        self.outbound_message_service
+            .propagate(
+                NodeDestination::Unknown,
+                OutboundEncryption::None,
+                vec![source_peer.public_key],
+                OutboundDomainMessage::new(TariMessageType::NewTransaction, ProtoTransaction::from(inner)),
+            )
+            .await
+            .map_err(|e| MempoolServiceError::OutboundMessageService(e.to_string()))?;
+
+        Ok(())
+    }
+
+    async fn handle_request_timeout(&mut self, request_key: RequestKey) -> Result<(), MempoolServiceError> {
+        if let Some(mut waiting_request) = self.waiting_requests.remove(&request_key) {
+            if let Some(reply_tx) = waiting_request.take() {
+                let reply_msg = Err(MempoolServiceError::RequestTimedOut);
+                let _ = reply_tx.send(reply_msg.or_else(|resp| {
+                    error!(
+                        target: LOG_TARGET,
+                        "Failed to send outbound request from Mempool service"
+                    );
+                    Err(resp)
+                }));
+            }
+        }
+        Ok(())
+    }
+
+    async fn spawn_request_timeout(&self, request_key: RequestKey, timeout: Duration) {
+        let mut timeout_sender = self.timeout_sender.clone();
+        self.executor.spawn(async move {
+            tokio::timer::delay(Instant::now() + timeout).await;
+            let _ = timeout_sender.send(request_key).await;
+        });
+    }
+}

--- a/base_layer/core/src/mempool/test/mod.rs
+++ b/base_layer/core/src/mempool/test/mod.rs
@@ -20,18 +20,4 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-mod error;
-mod mempool;
-mod orphan_pool;
-mod pending_pool;
-mod priority;
-mod proto;
-mod reorg_pool;
 mod service;
-#[cfg(test)]
-mod test;
-mod unconfirmed_pool;
-
-// Public re-exports
-pub use error::MempoolError;
-pub use mempool::{Mempool, MempoolConfig, TxStorageResponse};

--- a/base_layer/core/src/mempool/test/service.rs
+++ b/base_layer/core/src/mempool/test/service.rs
@@ -1,0 +1,383 @@
+// Copyright 2019. The Tari Project
+//
+// Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+// following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+// disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+// following disclaimer in the documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+// products derived from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+// INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+// WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+// USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+use crate::{
+    chain_storage::{BlockchainDatabase, MemoryDatabase},
+    mempool::{
+        service::{MempoolServiceConfig, MempoolServiceInitializer, OutboundMempoolServiceInterface},
+        Mempool,
+        MempoolConfig,
+        TxStorageResponse,
+    },
+    test_utils::builders::{add_block_and_update_header, create_genesis_block, spend_utxos},
+    tx,
+    txn_schema,
+};
+use futures::Sink;
+use rand::{distributions::Alphanumeric, rngs::OsRng, Rng};
+use std::{
+    error::Error,
+    iter,
+    sync::Arc,
+    time::{Duration, Instant},
+};
+use tari_comms::{
+    builder::CommsNode,
+    control_service::ControlServiceConfig,
+    peer_manager::{NodeIdentity, Peer, PeerFeatures, PeerFlags},
+};
+use tari_comms_dht::{
+    broadcast_strategy::BroadcastStrategy,
+    domain_message::OutboundDomainMessage,
+    envelope::NodeDestination,
+    outbound::{OutboundEncryption, OutboundMessageRequester},
+    Dht,
+};
+use tari_p2p::{
+    comms_connector::{pubsub_connector, InboundDomainConnector, PeerMessage},
+    initialization::{initialize_comms, CommsConfig},
+    services::comms_outbound::CommsOutboundServiceInitializer,
+    tari_message::TariMessageType,
+};
+use tari_service_framework::StackBuilder;
+use tari_test_utils::{address::get_next_local_address, async_assert_eventually};
+use tari_transactions::{
+    proto::types as proto,
+    tari_amount::{uT, T},
+    types::{CryptoFactories, HashDigest},
+};
+use tempdir::TempDir;
+use tokio::runtime::{Runtime, TaskExecutor};
+
+// Todo: Some of the helper test functions are the same or similar to the Base node service test functions, these should
+// be moved to the test_utils.
+
+fn random_string(len: usize) -> String {
+    let mut rng = OsRng::new().unwrap();
+    iter::repeat(()).map(|_| rng.sample(Alphanumeric)).take(len).collect()
+}
+
+fn setup_comms_services<TSink>(
+    executor: TaskExecutor,
+    node_identity: Arc<NodeIdentity>,
+    peers: Vec<NodeIdentity>,
+    publisher: InboundDomainConnector<TSink>,
+) -> (CommsNode, Dht)
+where
+    TSink: Sink<Arc<PeerMessage>> + Clone + Unpin + Send + Sync + 'static,
+    TSink::Error: Error + Send + Sync,
+{
+    let comms_config = CommsConfig {
+        node_identity: Arc::clone(&node_identity),
+        peer_connection_listening_address: "127.0.0.1:0".parse().unwrap(),
+        socks_proxy_address: None,
+        control_service: ControlServiceConfig {
+            listener_address: node_identity.control_service_address(),
+            socks_proxy_address: None,
+            requested_connection_timeout: Duration::from_millis(2000),
+        },
+        datastore_path: TempDir::new(random_string(8).as_str())
+            .unwrap()
+            .path()
+            .to_str()
+            .unwrap()
+            .to_string(),
+        establish_connection_timeout: Duration::from_secs(5),
+        peer_database_name: random_string(8),
+        inbound_buffer_size: 100,
+        outbound_buffer_size: 100,
+        dht: Default::default(),
+    };
+
+    let (comms, dht) = initialize_comms(executor, comms_config, publisher).unwrap();
+
+    for p in peers {
+        let addr = p.control_service_address();
+        comms
+            .peer_manager()
+            .add_peer(Peer::new(
+                p.public_key().clone(),
+                p.node_id().clone(),
+                addr.into(),
+                PeerFlags::empty(),
+                p.features().clone(),
+            ))
+            .unwrap();
+    }
+
+    (comms, dht)
+}
+
+struct NodeInterfaces {
+    pub node_identity: NodeIdentity,
+    pub outbound_mp_interface: OutboundMempoolServiceInterface,
+    pub outbound_message_service: OutboundMessageRequester,
+    pub blockchain_db: BlockchainDatabase<MemoryDatabase<HashDigest>>,
+    pub mempool: Mempool<MemoryDatabase<HashDigest>>,
+    pub comms: CommsNode,
+}
+
+impl NodeInterfaces {
+    fn new(
+        node_identity: NodeIdentity,
+        outbound_mp_interface: OutboundMempoolServiceInterface,
+        outbound_message_service: OutboundMessageRequester,
+        blockchain_db: BlockchainDatabase<MemoryDatabase<HashDigest>>,
+        mempool: Mempool<MemoryDatabase<HashDigest>>,
+        comms: CommsNode,
+    ) -> Self
+    {
+        Self {
+            node_identity,
+            outbound_mp_interface,
+            outbound_message_service,
+            blockchain_db,
+            mempool,
+            comms,
+        }
+    }
+}
+
+pub fn setup_mempool_service(
+    runtime: &Runtime,
+    node_identity: NodeIdentity,
+    peers: Vec<NodeIdentity>,
+    mempool: Mempool<MemoryDatabase<HashDigest>>,
+    config: MempoolServiceConfig,
+) -> (OutboundMempoolServiceInterface, OutboundMessageRequester, CommsNode)
+{
+    let (publisher, subscription_factory) = pubsub_connector(runtime.executor(), 100);
+    let subscription_factory = Arc::new(subscription_factory);
+    let (comms, dht) = setup_comms_services(runtime.executor(), Arc::new(node_identity), peers, publisher);
+
+    let fut = StackBuilder::new(runtime.executor(), comms.shutdown_signal())
+        .add_initializer(CommsOutboundServiceInitializer::new(dht.outbound_requester()))
+        .add_initializer(MempoolServiceInitializer::new(subscription_factory, mempool, config))
+        .finish();
+
+    let handles = runtime.block_on(fut).expect("Service initialization failed");
+
+    let outbound_mp_handle = handles.get_handle::<OutboundMempoolServiceInterface>().unwrap();
+    let outbound_message_service = handles.get_handle::<OutboundMessageRequester>().unwrap();
+
+    (outbound_mp_handle, outbound_message_service, comms)
+}
+
+fn create_network_with_3_mempools(
+    runtime: &Runtime,
+    config: MempoolServiceConfig,
+) -> (NodeInterfaces, NodeInterfaces, NodeInterfaces)
+{
+    let mut rng = OsRng::new().unwrap();
+    let alice_node_identity = NodeIdentity::random(
+        &mut rng,
+        get_next_local_address().parse().unwrap(),
+        PeerFeatures::COMMUNICATION_NODE,
+    )
+    .unwrap();
+    let alice_blockchain_db = BlockchainDatabase::new(MemoryDatabase::<HashDigest>::default()).unwrap();
+    let alice_mempool = Mempool::new(alice_blockchain_db.clone(), MempoolConfig::default());
+
+    let bob_node_identity = NodeIdentity::random(
+        &mut rng,
+        get_next_local_address().parse().unwrap(),
+        PeerFeatures::COMMUNICATION_NODE,
+    )
+    .unwrap();
+    let bob_blockchain_db = BlockchainDatabase::new(MemoryDatabase::<HashDigest>::default()).unwrap();
+    let bob_mempool = Mempool::new(bob_blockchain_db.clone(), MempoolConfig::default());
+
+    let carol_node_identity = NodeIdentity::random(
+        &mut rng,
+        get_next_local_address().parse().unwrap(),
+        PeerFeatures::COMMUNICATION_NODE,
+    )
+    .unwrap();
+    let carol_blockchain_db = BlockchainDatabase::new(MemoryDatabase::<HashDigest>::default()).unwrap();
+    let carol_mempool = Mempool::new(carol_blockchain_db.clone(), MempoolConfig::default());
+
+    let (alice_outbound_mp_interface, alice_outbound_message_service, alice_comms) = setup_mempool_service(
+        &runtime,
+        alice_node_identity.clone(),
+        vec![bob_node_identity.clone(), carol_node_identity.clone()],
+        alice_mempool.clone(),
+        config.clone(),
+    );
+    let (bob_outbound_mp_interface, bob_outbound_message_service, bob_comms) = setup_mempool_service(
+        &runtime,
+        bob_node_identity.clone(),
+        vec![alice_node_identity.clone(), carol_node_identity.clone()],
+        bob_mempool.clone(),
+        config.clone(),
+    );
+    let (carol_outbound_mp_interface, carol_outbound_message_service, carol_comms) = setup_mempool_service(
+        &runtime,
+        carol_node_identity.clone(),
+        vec![alice_node_identity.clone(), bob_node_identity.clone()],
+        carol_mempool.clone(),
+        config,
+    );
+    let alice_interfaces = NodeInterfaces::new(
+        alice_node_identity,
+        alice_outbound_mp_interface,
+        alice_outbound_message_service,
+        alice_blockchain_db,
+        alice_mempool,
+        alice_comms,
+    );
+    let bob_interfaces = NodeInterfaces::new(
+        bob_node_identity,
+        bob_outbound_mp_interface,
+        bob_outbound_message_service,
+        bob_blockchain_db,
+        bob_mempool,
+        bob_comms,
+    );
+    let carol_interfaces = NodeInterfaces::new(
+        carol_node_identity,
+        carol_outbound_mp_interface,
+        carol_outbound_message_service,
+        carol_blockchain_db,
+        carol_mempool,
+        carol_comms,
+    );
+    (alice_interfaces, bob_interfaces, carol_interfaces)
+}
+
+#[test]
+fn request_response_get_stats() {
+    let factories = CryptoFactories::default();
+    let runtime = Runtime::new().unwrap();
+
+    let (mut alice_interfaces, bob_interfaces, carol_interfaces) =
+        create_network_with_3_mempools(&runtime, MempoolServiceConfig::default());
+
+    let (block0, utxo) = create_genesis_block(&factories);
+    add_block_and_update_header(&bob_interfaces.blockchain_db, block0.clone());
+    add_block_and_update_header(&carol_interfaces.blockchain_db, block0);
+    let (tx1, _, _) = spend_utxos(txn_schema!(from: vec![utxo], to: vec![2 * T, 2 * T, 2 * T]));
+    let tx1 = Arc::new(tx1);
+    bob_interfaces.mempool.insert(tx1.clone()).unwrap();
+    carol_interfaces.mempool.insert(tx1).unwrap();
+    let (orphan1, _, _) = tx!(1*T, fee: 100*uT);
+    let orphan1 = Arc::new(orphan1);
+    bob_interfaces.mempool.insert(orphan1.clone()).unwrap();
+    carol_interfaces.mempool.insert(orphan1).unwrap();
+    let (orphan2, _, _) = tx!(2*T, fee: 200*uT);
+    let orphan2 = Arc::new(orphan2);
+    bob_interfaces.mempool.insert(orphan2.clone()).unwrap();
+    carol_interfaces.mempool.insert(orphan2).unwrap();
+
+    runtime.block_on(async {
+        let received_stats = alice_interfaces.outbound_mp_interface.get_stats().await.unwrap();
+        assert_eq!(received_stats.total_txs, 3);
+        assert_eq!(received_stats.unconfirmed_txs, 1);
+        assert_eq!(received_stats.orphan_txs, 2);
+        assert_eq!(received_stats.timelocked_txs, 0);
+        assert_eq!(received_stats.published_txs, 0);
+        assert_eq!(received_stats.total_weight, 35);
+    });
+
+    alice_interfaces.comms.shutdown().unwrap();
+    bob_interfaces.comms.shutdown().unwrap();
+    carol_interfaces.comms.shutdown().unwrap();
+}
+
+#[test]
+fn receive_and_propagate_transaction() {
+    let factories = CryptoFactories::default();
+    let runtime = Runtime::new().unwrap();
+
+    let (mut alice_interfaces, mut bob_interfaces, mut carol_interfaces) =
+        create_network_with_3_mempools(&runtime, MempoolServiceConfig::default());
+
+    let (block0, utxo) = create_genesis_block(&factories);
+    add_block_and_update_header(&alice_interfaces.blockchain_db, block0.clone());
+    add_block_and_update_header(&bob_interfaces.blockchain_db, block0.clone());
+    add_block_and_update_header(&carol_interfaces.blockchain_db, block0);
+    let (tx, _, _) = spend_utxos(txn_schema!(from: vec![utxo], to: vec![2 * T, 2 * T, 2 * T]));
+    let (orphan, _, _) = tx!(1*T, fee: 100*uT);
+    let tx_excess_sig = tx.body.kernels()[0].excess_sig.clone();
+    let orphan_excess_sig = orphan.body.kernels()[0].excess_sig.clone();
+    assert!(alice_interfaces.mempool.insert(Arc::new(tx.clone())).is_ok());
+    assert!(alice_interfaces.mempool.insert(Arc::new(orphan.clone())).is_ok());
+
+    runtime.block_on(async {
+        alice_interfaces
+            .outbound_message_service
+            .send_message(
+                BroadcastStrategy::DirectPublicKey(bob_interfaces.node_identity.public_key().clone()),
+                NodeDestination::Unknown,
+                OutboundEncryption::EncryptForDestination,
+                OutboundDomainMessage::new(TariMessageType::NewTransaction, proto::Transaction::from(tx)),
+            )
+            .await
+            .unwrap();
+        alice_interfaces
+            .outbound_message_service
+            .send_message(
+                BroadcastStrategy::DirectPublicKey(carol_interfaces.node_identity.public_key().clone()),
+                NodeDestination::Unknown,
+                OutboundEncryption::EncryptForDestination,
+                OutboundDomainMessage::new(TariMessageType::NewTransaction, proto::Transaction::from(orphan)),
+            )
+            .await
+            .unwrap();
+
+        async_assert_eventually!(
+            bob_interfaces.mempool.has_tx_with_excess_sig(&tx_excess_sig).unwrap(),
+            expect = TxStorageResponse::UnconfirmedPool,
+            max_attempts = 10,
+            interval = Duration::from_millis(1000)
+        );
+        async_assert_eventually!(
+            bob_interfaces
+                .mempool
+                .has_tx_with_excess_sig(&orphan_excess_sig)
+                .unwrap(),
+            expect = TxStorageResponse::OrphanPool,
+            max_attempts = 10,
+            interval = Duration::from_millis(1000)
+        );
+        async_assert_eventually!(
+            carol_interfaces.mempool.has_tx_with_excess_sig(&tx_excess_sig).unwrap(),
+            expect = TxStorageResponse::UnconfirmedPool,
+            max_attempts = 10,
+            interval = Duration::from_millis(1000)
+        );
+        async_assert_eventually!(
+            carol_interfaces
+                .mempool
+                .has_tx_with_excess_sig(&orphan_excess_sig)
+                .unwrap(),
+            expect = TxStorageResponse::OrphanPool,
+            max_attempts = 10,
+            interval = Duration::from_millis(1000)
+        );
+    });
+
+    alice_interfaces.comms.shutdown().unwrap();
+    bob_interfaces.comms.shutdown().unwrap();
+    carol_interfaces.comms.shutdown().unwrap();
+}
+
+// TODO: add test for service_request_timeout

--- a/base_layer/core/src/proto/mod.rs
+++ b/base_layer/core/src/proto/mod.rs
@@ -28,6 +28,4 @@ pub mod core {
 }
 
 mod block;
-// mod types_impls;
-
 pub mod utils;

--- a/base_layer/p2p/src/proto/message_type.proto
+++ b/base_layer/p2p/src/proto/message_type.proto
@@ -13,11 +13,14 @@ enum TariMessageType {
 
     // -- Blockchain messages --
 
-    TariMessageTypeNewBlock = 65;
-    TariMessageTypeTransaction = 66;
-    TariMessageTypeTransactionReply = 67;
-    TariMessageTypeBaseNodeRequest = 68;
-    TariMessageTypeBaseNodeResponse = 69;
+    TariMessageTypeNewTransaction = 65;
+    TariMessageTypeNewBlock = 66;
+    TariMessageTypeSenderPartialTransaction = 67;
+    TariMessageTypeReceiverPartialTransactionReply = 68;
+    TariMessageTypeBaseNodeRequest = 69;
+    TariMessageTypeBaseNodeResponse = 70;
+    TariMessageTypeMempoolRequest= 71;
+    TariMessageTypeMempoolResponse = 72;
 
     // -- DAN Messages --
 

--- a/base_layer/transactions/src/proto/transaction.proto
+++ b/base_layer/transactions/src/proto/transaction.proto
@@ -73,3 +73,10 @@ message AggregateBody {
     // Kernels contain the excesses and their signatures for transaction
     repeated TransactionKernel kernels = 3;
 }
+
+// A transaction which consists of a kernel offset and an aggregate body made up of inputs, outputs and kernels.
+// This struct is used to describe single transactions only.
+message Transaction {
+    BlindingFactor offset = 1;
+    AggregateBody body = 2;
+}

--- a/base_layer/transactions/src/proto/types.proto
+++ b/base_layer/transactions/src/proto/types.proto
@@ -18,3 +18,8 @@ message Signature {
     bytes public_nonce = 1;
     bytes signature = 2;
 }
+
+// BlindingFactor wrapper
+message BlindingFactor {
+    bytes data = 1;
+}

--- a/base_layer/transactions/src/proto/types_impls.rs
+++ b/base_layer/transactions/src/proto/types_impls.rs
@@ -21,9 +21,8 @@
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 use super::types as proto;
-use crate::types::{Commitment, HashOutput, Signature};
+use crate::types::{BlindingFactor, Commitment, HashOutput, PrivateKey, PublicKey, Signature};
 use std::convert::TryFrom;
-use tari_crypto::ristretto::{RistrettoPublicKey, RistrettoSecretKey};
 use tari_utilities::{ByteArray, ByteArrayError};
 
 //---------------------------------- Commitment --------------------------------------------//
@@ -50,8 +49,8 @@ impl TryFrom<proto::Signature> for Signature {
     type Error = ByteArrayError;
 
     fn try_from(sig: proto::Signature) -> Result<Self, Self::Error> {
-        let public_nonce = RistrettoPublicKey::from_bytes(&sig.public_nonce)?;
-        let signature = RistrettoSecretKey::from_bytes(&sig.signature)?;
+        let public_nonce = PublicKey::from_bytes(&sig.public_nonce)?;
+        let signature = PrivateKey::from_bytes(&sig.signature)?;
 
         Ok(Self::new(public_nonce, signature))
     }
@@ -77,5 +76,21 @@ impl From<proto::HashOutput> for HashOutput {
 impl From<HashOutput> for proto::HashOutput {
     fn from(output: HashOutput) -> Self {
         Self { data: output }
+    }
+}
+
+//--------------------------------- BlindingFactor -----------------------------------------//
+
+impl TryFrom<proto::BlindingFactor> for BlindingFactor {
+    type Error = ByteArrayError;
+
+    fn try_from(offset: proto::BlindingFactor) -> Result<Self, Self::Error> {
+        Ok(BlindingFactor::from_bytes(&offset.data)?)
+    }
+}
+
+impl From<BlindingFactor> for proto::BlindingFactor {
+    fn from(offset: BlindingFactor) -> Self {
+        Self { data: offset.to_vec() }
     }
 }

--- a/base_layer/wallet/src/transaction_service/mod.rs
+++ b/base_layer/wallet/src/transaction_service/mod.rs
@@ -87,14 +87,14 @@ where T: TransactionBackend
     /// Get a stream of inbound Text messages
     fn transaction_stream(&self) -> impl Stream<Item = DomainMessage<proto::TransactionSenderMessage>> {
         self.subscription_factory
-            .get_subscription(TariMessageType::Transaction)
+            .get_subscription(TariMessageType::SenderPartialTransaction)
             .map(map_decode::<proto::TransactionSenderMessage>)
             .filter_map(ok_or_skip_result)
     }
 
     fn transaction_reply_stream(&self) -> impl Stream<Item = DomainMessage<proto::RecipientSignedMessage>> {
         self.subscription_factory
-            .get_subscription(TariMessageType::TransactionReply)
+            .get_subscription(TariMessageType::ReceiverPartialTransactionReply)
             .map(map_decode::<proto::RecipientSignedMessage>)
             .filter_map(ok_or_skip_result)
     }

--- a/base_layer/wallet/src/transaction_service/service.rs
+++ b/base_layer/wallet/src/transaction_service/service.rs
@@ -346,7 +346,7 @@ where
             .send_direct(
                 dest_pubkey.clone(),
                 OutboundEncryption::EncryptForDestination,
-                OutboundDomainMessage::new(TariMessageType::Transaction, proto_message),
+                OutboundDomainMessage::new(TariMessageType::SenderPartialTransaction, proto_message),
             )
             .await?;
 
@@ -482,7 +482,7 @@ where
                     BroadcastStrategy::DirectPublicKey(source_pubkey.clone()),
                     NodeDestination::Unknown,
                     OutboundEncryption::EncryptForDestination,
-                    OutboundDomainMessage::new(TariMessageType::TransactionReply, proto_message),
+                    OutboundDomainMessage::new(TariMessageType::ReceiverPartialTransactionReply, proto_message),
                 )
                 .await?;
 


### PR DESCRIPTION
## Description
- Added Mempool service skeleton with the ability to receive broadcasted transactions, propagate transactions and request the Mempool stats from remote nodes.
- The TariMessagesTypes were updated, Transaction was changed to SenderPartialTransaction, TransactionReply was changed to ReceiverPartialTransactionReply and a NewTransaction type was added.
- Added inbound handlers for handling Mempool service requests and handling received transactions.
- Added an outbound interface for the Mempool service that allows the querying of Mempool stats from remote nodes.
- Added proto files and conversions for Transaction, BlindingFactor, MempoolRequest, MempoolResponse, MempoolServiceRequest, MempoolServiceResponse, StatsResponse.

## Motivation and Context
The MempoolService will allow remote nodes and wallets to query the state of a nodes Mempool.

## How Has This Been Tested?
Added tests for testing the requesting and responding to get_stats requests and receiving and propagating transactions.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [x] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch
* [x] I ran `cargo-fmt --all` before pushing
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
