### PR TITLE
Reduce the Discovery timeout in the Wallet

### DIFF
--- a/base_layer/core/src/consts.rs
+++ b/base_layer/core/src/consts.rs
@@ -47,6 +47,6 @@ thread_local! {
     pub(crate) static BASE_NODE_RNG: RefCell<BaseNodeRng> = RefCell::new(BaseNodeRng::new().expect("Failed to initialize BaseNodeRng"));
 }
 /// The allocated waiting time for a request waiting for service responses from remote base nodes.
-pub const BASE_NODE_SERVICE_REQUEST_TIMEOUT: Duration = Duration::from_secs(5);
+pub const BASE_NODE_SERVICE_REQUEST_TIMEOUT: Duration = Duration::from_secs(60);
 /// The fraction of responses that need to be received for a corresponding service request to be finalize.
 pub const BASE_NODE_SERVICE_DESIRED_RESPONSE_FRACTION: f32 = 0.6;

--- a/base_layer/wallet/src/testnet_utils.rs
+++ b/base_layer/wallet/src/testnet_utils.rs
@@ -100,8 +100,6 @@ pub fn create_wallet(secret_key: CommsSecretKey, net_address: String) -> Wallet<
         PeerFeatures::COMMUNICATION_NODE,
     )
     .expect("Could not construct Node Id");
-    let mut dht_config: DhtConfig = Default::default();
-    dht_config.discovery_request_timeout = Duration::from_millis(500);
     let comms_config = CommsConfig {
         node_identity: Arc::new(node_id.clone()),
         peer_connection_listening_address: "127.0.0.1:0".parse().unwrap(),
@@ -121,7 +119,10 @@ pub fn create_wallet(secret_key: CommsSecretKey, net_address: String) -> Wallet<
         peer_database_name: random_string(8),
         inbound_buffer_size: 100,
         outbound_buffer_size: 100,
-        dht: dht_config,
+        dht: DhtConfig {
+            discovery_request_timeout: Duration::from_millis(500),
+            ..Default::default()
+        },
     };
 
     let config = WalletConfig {

--- a/base_layer/wallet/tests/wallet/mod.rs
+++ b/base_layer/wallet/tests/wallet/mod.rs
@@ -203,8 +203,6 @@ fn test_data_generation() {
         PeerFeatures::COMMUNICATION_NODE,
     )
     .unwrap();
-    let mut dht_config: DhtConfig = Default::default();
-    dht_config.discovery_request_timeout = Duration::from_millis(500);
     let comms_config = CommsConfig {
         node_identity: Arc::new(node_id.clone()),
         peer_connection_listening_address: "127.0.0.1:0".parse().unwrap(),
@@ -224,7 +222,10 @@ fn test_data_generation() {
         peer_database_name: random_string(8),
         inbound_buffer_size: 100,
         outbound_buffer_size: 100,
-        dht: dht_config,
+        dht: DhtConfig {
+            discovery_request_timeout: Duration::from_millis(500),
+            ..Default::default()
+        },
     };
 
     let config = WalletConfig {
@@ -291,8 +292,6 @@ fn test_test_harness() {
     )
     .unwrap();
 
-    let mut dht_config: DhtConfig = Default::default();
-    dht_config.discovery_request_timeout = Duration::from_millis(500);
     let comms_config1 = CommsConfig {
         node_identity: Arc::new(alice_identity.clone()),
         peer_connection_listening_address: "127.0.0.1:0".parse().unwrap(),
@@ -312,7 +311,10 @@ fn test_test_harness() {
         peer_database_name: random_string(8),
         inbound_buffer_size: 100,
         outbound_buffer_size: 100,
-        dht: dht_config,
+        dht: DhtConfig {
+            discovery_request_timeout: Duration::from_millis(500),
+            ..Default::default()
+        },
     };
     let config1 = WalletConfig {
         comms_config: comms_config1,

--- a/base_layer/wallet_ffi/src/lib.rs
+++ b/base_layer/wallet_ffi/src/lib.rs
@@ -117,6 +117,7 @@ use tari_wallet::wallet::WalletConfig;
 use core::ptr;
 use std::{sync::Arc, time::Duration};
 use tari_comms::{connection::NetAddress, control_service::ControlServiceConfig, peer_manager::PeerFeatures};
+use tari_comms_dht::DhtConfig;
 use tari_crypto::keys::PublicKey;
 use tari_transactions::types::CryptoFactories;
 use tari_utilities::hex::Hex;
@@ -1233,7 +1234,10 @@ pub unsafe extern "C" fn comms_config_create(
                             peer_database_name: database_name_string,
                             inbound_buffer_size: 100,
                             outbound_buffer_size: 100,
-                            dht: Default::default(),
+                            dht: DhtConfig {
+                                discovery_request_timeout: Duration::from_millis(1000),
+                                ..Default::default()
+                            },
                         };
 
                         Box::into_raw(Box::new(config))


### PR DESCRIPTION
## Description
Currently when you send a message via the wallet to a peer that has yet to be discovered the comms stack doesn't return while it waits for the the discovery process to complete or timeout. We are working on a solution with more detailed async feedback but for now just reducing this timeout.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch
* [x] I ran `cargo-fmt --all` before pushing
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
