### PR TITLE
Added log_if_error helper macro

### DIFF
--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -51,6 +51,7 @@ use clap::ArgMatches;
 use std::path::{Path, PathBuf};
 
 mod configuration;
+#[macro_use]
 mod logging;
 
 pub mod dir_utils;


### PR DESCRIPTION
A common pattern for asynchonous message passing components is to handle
errors by logging them and continuing.

```rust
futures::select! {
  event = read_an_event() => {
    match self.handle_event(event).await {
      Ok(_) => {},
      Err(err) => log::error!("An error happened {}", err);
    }
    // or ..

    let _ = self.handle_event(event).await.or_else(|err| {
      log::error!("An error happened {}", err);
      Err(err)
    })
  }
}
```

Now you can write

```rust
futures::select! {
  event = read_an_event() => {
    log_if_error!(
      target: LOG_TARGET,
      "An error happened {}",
      self.handle_event(event).await
    );
  }
}
```
