### PR TITLE
Periodically share chain metadata

### DIFF
--- a/base_layer/core/Cargo.toml
+++ b/base_layer/core/Cargo.toml
@@ -54,8 +54,10 @@ bytes = "0.4.12"
 prost-types = "0.5.0"
 
 [dev-dependencies]
-env_logger = "0.7.0"
+tari_p2p = {path = "../../base_layer/p2p", version = "^0.0", features=["test-mocks"]}
 tari_test_utils = { path = "../../infrastructure/test_utils", version = "^0.0" }
+
+env_logger = "0.7.0"
 tempdir = "0.3.7"
 
 [build-dependencies]

--- a/base_layer/core/src/base_node/chain_metadata_service/error.rs
+++ b/base_layer/core/src/base_node/chain_metadata_service/error.rs
@@ -20,28 +20,21 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use std::time::Duration;
+use crate::base_node::comms_interface::CommsInterfaceError;
+use derive_error::Error;
+use prost::DecodeError;
+use tari_comms::message::MessageError;
+use tari_p2p::services::liveness::error::LivenessError;
 
-/// Configuration for liveness service
-#[derive(Debug, Clone)]
-pub struct LivenessConfig {
-    /// The interval to send Ping messages, or None to disable periodic pinging (default: None (disabled))
-    pub auto_ping_interval: Option<Duration>,
-    /// Set to true to enable automatically joining the network on node startup (default: true)
-    pub enable_auto_join: bool,
-    /// Set to true to enable a request for stored messages on node startup (default: true)
-    pub enable_auto_stored_message_request: bool,
-    /// The length of time between querying peer manager for closest neighbours. (default: 5mins)
-    pub refresh_neighbours_interval: Duration,
-}
-
-impl Default for LivenessConfig {
-    fn default() -> Self {
-        Self {
-            auto_ping_interval: None,
-            enable_auto_join: true,
-            enable_auto_stored_message_request: true,
-            refresh_neighbours_interval: Duration::from_secs(5 * 60),
-        }
-    }
+#[derive(Debug, Error)]
+pub enum ChainMetadataSyncError {
+    /// Failed to decode chain metadata
+    DecodeError(DecodeError),
+    /// Peer did not send any chain metadata
+    NoChainMetadata,
+    LivenessError(LivenessError),
+    CommsInterfaceError(CommsInterfaceError),
+    MessageError(MessageError),
+    /// Failed to publish `ChainMetadataEvent`
+    EventPublishFailed,
 }

--- a/base_layer/core/src/base_node/chain_metadata_service/handle.rs
+++ b/base_layer/core/src/base_node/chain_metadata_service/handle.rs
@@ -20,28 +20,24 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use std::time::Duration;
+use crate::chain_storage::ChainMetadata;
+use futures::{stream::Fuse, StreamExt};
+use tari_broadcast_channel::Subscriber;
 
-/// Configuration for liveness service
-#[derive(Debug, Clone)]
-pub struct LivenessConfig {
-    /// The interval to send Ping messages, or None to disable periodic pinging (default: None (disabled))
-    pub auto_ping_interval: Option<Duration>,
-    /// Set to true to enable automatically joining the network on node startup (default: true)
-    pub enable_auto_join: bool,
-    /// Set to true to enable a request for stored messages on node startup (default: true)
-    pub enable_auto_stored_message_request: bool,
-    /// The length of time between querying peer manager for closest neighbours. (default: 5mins)
-    pub refresh_neighbours_interval: Duration,
+pub enum ChainMetadataEvent {
+    PeerChainMetadataReceived(Vec<ChainMetadata>),
 }
 
-impl Default for LivenessConfig {
-    fn default() -> Self {
-        Self {
-            auto_ping_interval: None,
-            enable_auto_join: true,
-            enable_auto_stored_message_request: true,
-            refresh_neighbours_interval: Duration::from_secs(5 * 60),
-        }
+pub struct ChainMetadataHandle {
+    event_stream: Subscriber<ChainMetadataEvent>,
+}
+
+impl ChainMetadataHandle {
+    pub fn new(event_stream: Subscriber<ChainMetadataEvent>) -> Self {
+        Self { event_stream }
+    }
+
+    pub fn get_event_stream(&self) -> Fuse<Subscriber<ChainMetadataEvent>> {
+        self.event_stream.clone().fuse()
     }
 }

--- a/base_layer/core/src/base_node/chain_metadata_service/initializer.rs
+++ b/base_layer/core/src/base_node/chain_metadata_service/initializer.rs
@@ -1,0 +1,71 @@
+// Copyright 2019, The Tari Project
+//
+// Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+// following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+// disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+// following disclaimer in the documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+// products derived from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+// INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+// WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+// USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+use super::{service::ChainMetadataService, LOG_TARGET};
+use crate::base_node::{chain_metadata_service::handle::ChainMetadataHandle, comms_interface::LocalNodeCommsInterface};
+use futures::{future, future::select, pin_mut};
+use log::*;
+use std::future::Future;
+use tari_broadcast_channel as broadcast_channel;
+use tari_p2p::services::liveness::LivenessHandle;
+use tari_service_framework::{handles::ServiceHandlesFuture, ServiceInitializationError, ServiceInitializer};
+use tari_shutdown::ShutdownSignal;
+use tokio::runtime::TaskExecutor;
+
+const BROADCAST_EVENT_BUFFER_SIZE: usize = 10;
+
+pub struct ChainMetadataServiceInitializer;
+
+impl ServiceInitializer for ChainMetadataServiceInitializer {
+    type Future = impl Future<Output = Result<(), ServiceInitializationError>>;
+
+    fn initialize(
+        &mut self,
+        executor: TaskExecutor,
+        handles_fut: ServiceHandlesFuture,
+        shutdown: ShutdownSignal,
+    ) -> Self::Future
+    {
+        let (publisher, subscriber) = broadcast_channel::bounded(BROADCAST_EVENT_BUFFER_SIZE);
+        let handle = ChainMetadataHandle::new(subscriber);
+        handles_fut.register(handle);
+
+        executor.spawn(async move {
+            let handles = handles_fut.await;
+
+            let liveness = handles
+                .get_handle::<LivenessHandle>()
+                .expect("Liveness service required to initialize ChainStateSyncService");
+
+            let base_node = handles
+                .get_handle::<LocalNodeCommsInterface>()
+                .expect("LocalNodeCommsInterface required to initialize ChainStateSyncService");
+
+            let service_run = ChainMetadataService::new(liveness, base_node, publisher).run();
+            pin_mut!(service_run);
+            select(service_run, shutdown).await;
+            info!(target: LOG_TARGET, "ChainMetadataService has shut down");
+        });
+
+        future::ready(Ok(()))
+    }
+}

--- a/base_layer/core/src/base_node/chain_metadata_service/mod.rs
+++ b/base_layer/core/src/base_node/chain_metadata_service/mod.rs
@@ -20,28 +20,9 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use std::time::Duration;
+const LOG_TARGET: &str = "tari_core::base_node::chain_state_sync_service";
 
-/// Configuration for liveness service
-#[derive(Debug, Clone)]
-pub struct LivenessConfig {
-    /// The interval to send Ping messages, or None to disable periodic pinging (default: None (disabled))
-    pub auto_ping_interval: Option<Duration>,
-    /// Set to true to enable automatically joining the network on node startup (default: true)
-    pub enable_auto_join: bool,
-    /// Set to true to enable a request for stored messages on node startup (default: true)
-    pub enable_auto_stored_message_request: bool,
-    /// The length of time between querying peer manager for closest neighbours. (default: 5mins)
-    pub refresh_neighbours_interval: Duration,
-}
-
-impl Default for LivenessConfig {
-    fn default() -> Self {
-        Self {
-            auto_ping_interval: None,
-            enable_auto_join: true,
-            enable_auto_stored_message_request: true,
-            refresh_neighbours_interval: Duration::from_secs(5 * 60),
-        }
-    }
-}
+mod error;
+mod handle;
+mod initializer;
+mod service;

--- a/base_layer/core/src/base_node/chain_metadata_service/service.rs
+++ b/base_layer/core/src/base_node/chain_metadata_service/service.rs
@@ -1,0 +1,411 @@
+// Copyright 2019, The Tari Project
+//
+// Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+// following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+// disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+// following disclaimer in the documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+// products derived from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+// INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+// WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+// USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+use super::{error::ChainMetadataSyncError, LOG_TARGET};
+use crate::{
+    base_node::{
+        chain_metadata_service::handle::ChainMetadataEvent,
+        comms_interface::{BlockEvent, LocalNodeCommsInterface},
+        proto,
+    },
+    chain_storage::{BlockAddResult, ChainMetadata},
+};
+use chrono::{NaiveDateTime, Utc};
+use futures::{stream::StreamExt, SinkExt};
+use log::*;
+use prost::Message;
+use tari_broadcast_channel::Publisher;
+use tari_common::log_if_error;
+use tari_comms::{message::MessageExt, peer_manager::NodeId};
+use tari_p2p::services::liveness::{LivenessEvent, LivenessHandle, Metadata, MetadataKey};
+
+pub(super) struct ChainMetadataService {
+    liveness: LivenessHandle,
+    base_node: LocalNodeCommsInterface,
+    peer_chain_metadata: Vec<PeerChainMetadata>,
+    last_chainstate_flushed_at: NaiveDateTime,
+    event_publisher: Publisher<ChainMetadataEvent>,
+}
+
+impl ChainMetadataService {
+    /// Create a new ChainMetadataService
+    ///
+    /// ## Arguments
+    /// `liveness` - the liveness service handle
+    /// `base_node` - the base node service handle
+    pub fn new(
+        liveness: LivenessHandle,
+        base_node: LocalNodeCommsInterface,
+        event_publisher: Publisher<ChainMetadataEvent>,
+    ) -> Self
+    {
+        Self {
+            liveness,
+            base_node,
+            peer_chain_metadata: Vec::new(),
+            last_chainstate_flushed_at: Utc::now().naive_utc(),
+            event_publisher,
+        }
+    }
+
+    /// Run the service
+    pub async fn run(mut self) {
+        let mut liveness_event_stream = self.liveness.get_event_stream_fused();
+        let mut base_node_event_stream = self.base_node.get_block_event_stream_fused();
+
+        log_if_error!(
+            target: LOG_TARGET,
+            "Error when updating liveness chain metadata: '{}'",
+            self.update_liveness_chain_metadata().await
+        );
+
+        loop {
+            futures::select! {
+                event = base_node_event_stream.select_next_some() => {
+                    log_if_error!(
+                        level: debug,
+                        target: LOG_TARGET,
+                        "Failed to handle base node event because '{}'",
+                        self.handle_block_event(&event).await
+                    );
+                },
+
+                liveness_event = liveness_event_stream.select_next_some() => {
+                    log_if_error!(
+                        target: LOG_TARGET,
+                        "Failed to handle liveness event because '{}'",
+                        self.handle_liveness_event(&liveness_event).await
+                    );
+                },
+
+                complete => {
+                    info!(target: LOG_TARGET, "ChainStateSyncService is exiting because all tasks have completed");
+                    break;
+                }
+            }
+        }
+    }
+
+    /// Handle BlockEvents
+    async fn handle_block_event(&mut self, event: &BlockEvent) -> Result<(), ChainMetadataSyncError> {
+        match event {
+            BlockEvent::Verified((_, BlockAddResult::Ok(_))) => {
+                self.update_liveness_chain_metadata().await?;
+            },
+            BlockEvent::Verified(_) | BlockEvent::Invalid(_) => {},
+        }
+
+        Ok(())
+    }
+
+    /// Send this node's metadata to
+    async fn update_liveness_chain_metadata(&mut self) -> Result<(), ChainMetadataSyncError> {
+        let chain_metadata = self.base_node.get_metadata().await?;
+        let bytes = proto::ChainMetadata::from(chain_metadata).to_encoded_bytes()?;
+        self.liveness
+            .set_pong_metadata_entry(MetadataKey::ChainMetadata, bytes)
+            .await?;
+        Ok(())
+    }
+
+    async fn handle_liveness_event(&mut self, event: &LivenessEvent) -> Result<(), ChainMetadataSyncError> {
+        match event {
+            // Received a pong, check if our neighbour sent it and it contains ChainMetadata
+            LivenessEvent::ReceivedPong(event) => {
+                if event.is_neighbour {
+                    self.collect_chain_state_from_pong(&event.node_id, &event.metadata)?;
+
+                    // All peers have responded in this round, send the chain metadata to the base node service
+                    if self.peer_chain_metadata.len() == self.peer_chain_metadata.capacity() {
+                        self.flush_chain_metadata_to_event_publisher().await?;
+                    }
+                } else {
+                    debug!(
+                        target: LOG_TARGET,
+                        "Received pong from non-neighbouring node '{}'. Pong ignored...", event.node_id
+                    )
+                }
+            },
+            // New ping round has begun
+            LivenessEvent::BroadcastedPings(num_peers) => {
+                // If we have chain metadata to send to the base node service, send them now
+                // because the next round of pings is happening.
+                // TODO: It's pretty easy for this service to require either a percentage of peers
+                //       to respond or, a time limit before assuming some peers will never respond
+                //       between rounds (even if this time limit is larger than one or more ping rounds)
+                //       before publishing the chain metadata event.
+                //       The following will send the chain metadata at the start of a new round if at
+                //       least one node has responded.
+                if self.peer_chain_metadata.len() > 0 {
+                    self.flush_chain_metadata_to_event_publisher().await?;
+                }
+                // Ensure that we're waiting for the correct amount of peers to respond
+                // and have allocated space for their replies
+                self.resize_chainstate_buffer(*num_peers);
+            },
+            _ => {},
+        }
+
+        Ok(())
+    }
+
+    async fn flush_chain_metadata_to_event_publisher(&mut self) -> Result<(), ChainMetadataSyncError> {
+        let chain_metadata = self
+            .peer_chain_metadata
+            .drain(..)
+            .map(|peer_metadata| peer_metadata.chain_metadata)
+            .collect::<Vec<_>>();
+
+        self.event_publisher
+            .send(ChainMetadataEvent::PeerChainMetadataReceived(chain_metadata))
+            .await
+            .map_err(|_| ChainMetadataSyncError::EventPublishFailed)?;
+
+        self.last_chainstate_flushed_at = Utc::now().naive_utc();
+
+        Ok(())
+    }
+
+    fn resize_chainstate_buffer(&mut self, n: usize) {
+        match self.peer_chain_metadata.capacity() {
+            cap if n > cap => {
+                let additional = n - self.peer_chain_metadata.len();
+                self.peer_chain_metadata.reserve_exact(additional);
+            },
+            cap if n < cap => {
+                self.peer_chain_metadata.shrink_to(cap);
+            },
+            _ => {},
+        }
+    }
+
+    fn collect_chain_state_from_pong(
+        &mut self,
+        node_id: &NodeId,
+        metadata: &Metadata,
+    ) -> Result<(), ChainMetadataSyncError>
+    {
+        let chain_metadata_bytes = metadata
+            .get(&MetadataKey::ChainMetadata)
+            .ok_or(ChainMetadataSyncError::NoChainMetadata)?;
+
+        debug!(target: LOG_TARGET, "Received chain metadata from NodeId '{}'", node_id);
+        let chain_metadata = proto::ChainMetadata::decode(chain_metadata_bytes)?.into();
+
+        if let Some(pos) = self
+            .peer_chain_metadata
+            .iter()
+            .position(|peer_chainstate| &peer_chainstate.node_id == node_id)
+        {
+            self.peer_chain_metadata.remove(pos);
+        }
+
+        self.peer_chain_metadata
+            .push(PeerChainMetadata::new(node_id.clone(), chain_metadata));
+
+        Ok(())
+    }
+}
+
+struct PeerChainMetadata {
+    node_id: NodeId,
+    chain_metadata: ChainMetadata,
+}
+
+impl PeerChainMetadata {
+    fn new(node_id: NodeId, chain_metadata: ChainMetadata) -> Self {
+        Self {
+            node_id,
+            chain_metadata,
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::base_node::comms_interface::{CommsInterfaceError, NodeCommsRequest, NodeCommsResponse};
+    use std::convert::TryInto;
+    use tari_broadcast_channel as broadcast_channel;
+    use tari_p2p::services::liveness::{mock::create_p2p_liveness_mock, LivenessRequest, PongEvent};
+    use tari_service_framework::reply_channel;
+    use tari_test_utils::{runtime, unpack_enum};
+
+    fn create_base_node_nci() -> (
+        LocalNodeCommsInterface,
+        reply_channel::Receiver<NodeCommsRequest, Result<NodeCommsResponse, CommsInterfaceError>>,
+    ) {
+        let (base_node_sender, base_node_receiver) = reply_channel::unbounded();
+        let (block_sender, _block_receiver) = reply_channel::unbounded();
+        let (_base_node_publisher, subscriber) = broadcast_channel::bounded(1);
+        let base_node = LocalNodeCommsInterface::new(base_node_sender, block_sender, subscriber);
+
+        (base_node, base_node_receiver)
+    }
+
+    fn create_sample_proto_chain_metadata() -> proto::ChainMetadata {
+        proto::ChainMetadata {
+            height_of_longest_chain: Some(1),
+            best_block: Some(vec![]),
+            pruning_horizon: 64,
+        }
+    }
+
+    #[test]
+    fn update_liveness_chain_metadata() {
+        runtime::test_async(|rt| {
+            let (liveness_handle, liveness_mock) = create_p2p_liveness_mock(1);
+            let liveness_mock_state = liveness_mock.get_mock_state();
+            rt.spawn(liveness_mock.run());
+
+            let (base_node, mut base_node_receiver) = create_base_node_nci();
+
+            let (publisher, _subscriber) = broadcast_channel::bounded(1);
+            let mut service = ChainMetadataService::new(liveness_handle, base_node, publisher);
+
+            let mut proto_chain_metadata = create_sample_proto_chain_metadata();
+            proto_chain_metadata.height_of_longest_chain = Some(123);
+            let chain_metadata = proto_chain_metadata.clone().try_into().unwrap();
+
+            rt.spawn(async move {
+                let base_node_req = base_node_receiver.select_next_some().await;
+                let (_req, reply_tx) = base_node_req.split();
+                reply_tx
+                    .send(Ok(NodeCommsResponse::ChainMetadata(chain_metadata)))
+                    .unwrap();
+            });
+
+            rt.block_on(service.update_liveness_chain_metadata()).unwrap();
+
+            assert_eq!(liveness_mock_state.call_count(), 1);
+
+            let last_call = liveness_mock_state.take_calls().remove(0);
+            unpack_enum!(LivenessRequest::SetPongMetadata(metadata_key, data) = last_call);
+            assert_eq!(metadata_key, MetadataKey::ChainMetadata);
+            let chain_metadata = proto::ChainMetadata::decode(&data).unwrap();
+            assert_eq!(chain_metadata.height_of_longest_chain, Some(123));
+        });
+    }
+
+    #[tokio::test]
+    async fn handle_liveness_event_ok() {
+        let (liveness_handle, _) = create_p2p_liveness_mock(1);
+        let mut metadata = Metadata::new();
+        let proto_chain_metadata = create_sample_proto_chain_metadata();
+        metadata.insert(
+            MetadataKey::ChainMetadata,
+            proto_chain_metadata.to_encoded_bytes().unwrap(),
+        );
+
+        let node_id = NodeId::new();
+        let pong_event = PongEvent {
+            is_neighbour: true,
+            metadata,
+            node_id: node_id.clone(),
+            latency: None,
+        };
+
+        let (base_node, _) = create_base_node_nci();
+
+        let (publisher, _subscriber) = broadcast_channel::bounded(1);
+        let mut service = ChainMetadataService::new(liveness_handle, base_node, publisher);
+
+        // To prevent the chain metadata buffer being flushed after receiving a single pong event,
+        // extend it's capacity to 2
+        service.peer_chain_metadata.reserve_exact(2);
+        let sample_event = LivenessEvent::ReceivedPong(Box::new(pong_event));
+        service.handle_liveness_event(&sample_event).await.unwrap();
+        assert_eq!(service.peer_chain_metadata.len(), 1);
+        let metadata = service.peer_chain_metadata.remove(0);
+        assert_eq!(metadata.node_id, node_id);
+        assert_eq!(
+            metadata.chain_metadata.height_of_longest_chain,
+            proto_chain_metadata.height_of_longest_chain
+        );
+    }
+
+    #[tokio::test]
+    async fn handle_liveness_event_no_metadata() {
+        let (liveness_handle, _) = create_p2p_liveness_mock(1);
+        let metadata = Metadata::new();
+        let node_id = NodeId::new();
+        let pong_event = PongEvent {
+            is_neighbour: true,
+            metadata,
+            node_id,
+            latency: None,
+        };
+
+        let (base_node, _) = create_base_node_nci();
+        let (publisher, _subscriber) = broadcast_channel::bounded(1);
+        let mut service = ChainMetadataService::new(liveness_handle, base_node, publisher);
+
+        let sample_event = LivenessEvent::ReceivedPong(Box::new(pong_event));
+        let err = service.handle_liveness_event(&sample_event).await.unwrap_err();
+        unpack_enum!(ChainMetadataSyncError::NoChainMetadata = err);
+        assert_eq!(service.peer_chain_metadata.len(), 0);
+    }
+
+    #[tokio::test]
+    async fn handle_liveness_event_not_neighbour() {
+        let (liveness_handle, _) = create_p2p_liveness_mock(1);
+        let metadata = Metadata::new();
+        let node_id = NodeId::new();
+        let pong_event = PongEvent {
+            is_neighbour: false,
+            metadata,
+            node_id,
+            latency: None,
+        };
+
+        let (base_node, _) = create_base_node_nci();
+        let (publisher, _subscriber) = broadcast_channel::bounded(1);
+        let mut service = ChainMetadataService::new(liveness_handle, base_node, publisher);
+
+        let sample_event = LivenessEvent::ReceivedPong(Box::new(pong_event));
+        service.handle_liveness_event(&sample_event).await.unwrap();
+        assert_eq!(service.peer_chain_metadata.len(), 0);
+    }
+
+    #[tokio::test]
+    async fn handle_liveness_event_bad_metadata() {
+        let (liveness_handle, _) = create_p2p_liveness_mock(1);
+        let mut metadata = Metadata::new();
+        metadata.insert(MetadataKey::ChainMetadata, b"no-good".to_vec());
+        let node_id = NodeId::new();
+        let pong_event = PongEvent {
+            is_neighbour: true,
+            metadata,
+            node_id,
+            latency: None,
+        };
+
+        let (base_node, _) = create_base_node_nci();
+        let (publisher, _subscriber) = broadcast_channel::bounded(1);
+        let mut service = ChainMetadataService::new(liveness_handle, base_node, publisher);
+
+        let sample_event = LivenessEvent::ReceivedPong(Box::new(pong_event));
+        let err = service.handle_liveness_event(&sample_event).await.unwrap_err();
+        unpack_enum!(ChainMetadataSyncError::DecodeError(_err) = err);
+        assert_eq!(service.peer_chain_metadata.len(), 0);
+    }
+}

--- a/base_layer/core/src/base_node/mod.rs
+++ b/base_layer/core/src/base_node/mod.rs
@@ -34,6 +34,7 @@
 
 mod backoff;
 mod base_node;
+mod chain_metadata_service;
 mod comms_interface;
 mod proto;
 #[cfg(test)]

--- a/base_layer/core/src/base_node/proto/mod.rs
+++ b/base_layer/core/src/base_node/proto/mod.rs
@@ -36,4 +36,4 @@ pub mod mutable_mmr_state;
 pub mod request;
 pub mod response;
 
-pub use base_node::{BaseNodeServiceRequest, BaseNodeServiceResponse};
+pub use base_node::{BaseNodeServiceRequest, BaseNodeServiceResponse, ChainMetadata};

--- a/base_layer/core/src/lib.rs
+++ b/base_layer/core/src/lib.rs
@@ -25,6 +25,8 @@
 // Used to eliminate the need for boxing futures in many cases.
 // Tracking issue: https://github.com/rust-lang/rust/issues/63063
 #![feature(type_alias_impl_trait)]
+// Enable usage of Vec::shrink_to
+#![feature(shrink_to)]
 
 #[cfg(test)]
 pub mod test_utils;

--- a/base_layer/p2p/Cargo.toml
+++ b/base_layer/p2p/Cargo.toml
@@ -8,6 +8,9 @@ readme = "README.md"
 license = "BSD-3-Clause"
 edition = "2018"
 
+[features]
+test-mocks = []
+
 [dependencies]
 tari_broadcast_channel = { version="^0.0",  path = "../../infrastructure/broadcast_channel" }
 tari_comms = { version = "^0.0", path = "../../comms"}

--- a/base_layer/p2p/examples/pingpong.rs
+++ b/base_layer/p2p/examples/pingpong.rs
@@ -59,11 +59,7 @@ use tari_p2p::{
     initialization::{initialize_comms, CommsConfig},
     services::{
         comms_outbound::CommsOutboundServiceInitializer,
-        liveness::{
-            handle::{LivenessEvent, LivenessHandle},
-            LivenessConfig,
-            LivenessInitializer,
-        },
+        liveness::{LivenessConfig, LivenessEvent, LivenessHandle, LivenessInitializer},
     },
 };
 use tari_service_framework::StackBuilder;
@@ -327,6 +323,8 @@ async fn update_ui(update_sink: CursiveSignal, mut liveness_handle: LivenessHand
                                 avg_latency: lock.avg_latency,
                             };
                         }
+
+                        let _ = update_sink.send(Box::new(update_count));
                     },
                     LivenessEvent::ReceivedPong(event) => {
                         {
@@ -338,10 +336,12 @@ async fn update_ui(update_sink: CursiveSignal, mut liveness_handle: LivenessHand
                                 avg_latency: event.latency.unwrap_or(0),
                             };
                         }
+
+                        let _ = update_sink.send(Box::new(update_count));
                     },
+                    _ => {},
                 }
 
-                let _ = update_sink.send(Box::new(update_count));
             },
             _ = shutdown =>  {
                 log::debug!("Ping pong example UI exiting");

--- a/base_layer/p2p/src/proto/liveness.proto
+++ b/base_layer/p2p/src/proto/liveness.proto
@@ -12,8 +12,10 @@ enum PingPong {
 message PingPongMessage {
     // Indicates if this message is a ping or pong
     PingPong ping_pong = 1;
+    // The nonce of the ping. Pong messages MUST use the nonce from a corresponding ping
+    uint64 nonce = 2;
     // Metadata attached to the message. The int32 key SHOULD always be one of the keys in `MetadataKey`.
-    map<int32, bytes> metadata = 2;
+    map<int32, bytes> metadata = 3;
 }
 
 // This enum represents all the possible metadata keys that can be used with a ping/pong message.

--- a/base_layer/p2p/src/services/liveness/message.rs
+++ b/base_layer/p2p/src/services/liveness/message.rs
@@ -23,23 +23,27 @@
 use crate::services::liveness::state::Metadata;
 
 pub use crate::proto::liveness::{PingPong, PingPongMessage};
+use crate::THREAD_RNG;
+use rand::RngCore;
 
 impl PingPongMessage {
-    pub fn new(ping_pong: PingPong, metadata: Metadata) -> Self {
+    pub fn new(ping_pong: PingPong, nonce: u64, metadata: Metadata) -> Self {
         PingPongMessage {
             ping_pong: ping_pong as i32,
+            nonce,
             metadata: metadata.into(),
         }
     }
 
     /// Construct a ping message
     pub fn ping() -> Self {
-        Self::new(PingPong::Ping, Default::default())
+        let nonce = THREAD_RNG.with(|rng| rng.borrow_mut().next_u64());
+        Self::new(PingPong::Ping, nonce, Default::default())
     }
 
     /// Construct a pong message with metadata
-    pub fn pong_with_metadata(metadata: Metadata) -> Self {
-        Self::new(PingPong::Pong, metadata)
+    pub fn pong_with_metadata(nonce: u64, metadata: Metadata) -> Self {
+        Self::new(PingPong::Pong, nonce, metadata)
     }
 
     /// Return the kind of PingPong message. Either a ping or pong.

--- a/base_layer/p2p/src/services/liveness/mock.rs
+++ b/base_layer/p2p/src/services/liveness/mock.rs
@@ -1,0 +1,142 @@
+// Copyright 2019, The Tari Project
+//
+// Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+// following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+// disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+// following disclaimer in the documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+// products derived from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+// INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+// WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+// USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+use crate::services::liveness::{
+    error::LivenessError,
+    LivenessEvent,
+    LivenessHandle,
+    LivenessRequest,
+    LivenessResponse,
+};
+use futures::{SinkExt, StreamExt};
+use log::*;
+use std::sync::{
+    atomic::{AtomicUsize, Ordering},
+    Arc,
+    RwLock,
+};
+use tari_broadcast_channel as broadcast_channel;
+use tari_broadcast_channel::{Publisher, SendError};
+use tari_service_framework::{reply_channel, RequestContext};
+use tari_utilities::acquire_write_lock;
+
+const LOG_TARGET: &str = "base_layer::p2p::liveness_mock";
+
+pub fn create_p2p_liveness_mock(buf_size: usize) -> (LivenessHandle, LivenessMock) {
+    let (sender, receiver) = reply_channel::unbounded();
+    let (publisher, subscriber) = broadcast_channel::bounded(buf_size);
+    (
+        LivenessHandle::new(sender, subscriber),
+        LivenessMock::new(receiver, LivenessMockState::new(publisher)),
+    )
+}
+
+#[derive(Debug, Clone)]
+pub struct LivenessMockState {
+    call_count: Arc<AtomicUsize>,
+    event_publisher: Arc<RwLock<Publisher<LivenessEvent>>>,
+    calls: Arc<RwLock<Vec<LivenessRequest>>>,
+}
+
+impl LivenessMockState {
+    pub fn new(event_publisher: Publisher<LivenessEvent>) -> Self {
+        Self {
+            call_count: Arc::new(AtomicUsize::new(0)),
+            event_publisher: Arc::new(RwLock::new(event_publisher)),
+            calls: Arc::new(RwLock::new(Vec::new())),
+        }
+    }
+
+    pub async fn publish_event(&self, event: LivenessEvent) -> Result<(), SendError<LivenessEvent>> {
+        acquire_write_lock!(self.event_publisher).send(event).await
+    }
+
+    pub fn add_request_call(&self, req: LivenessRequest) {
+        self.call_count.fetch_add(1, Ordering::SeqCst);
+        acquire_write_lock!(self.calls).push(req);
+    }
+
+    pub fn take_calls(&self) -> Vec<LivenessRequest> {
+        acquire_write_lock!(self.calls).drain(..).collect()
+    }
+
+    pub fn call_count(&self) -> usize {
+        self.call_count.load(Ordering::SeqCst)
+    }
+}
+
+pub struct LivenessMock {
+    receiver: reply_channel::Receiver<LivenessRequest, Result<LivenessResponse, LivenessError>>,
+    mock_state: LivenessMockState,
+}
+
+impl LivenessMock {
+    pub fn new(
+        receiver: reply_channel::Receiver<LivenessRequest, Result<LivenessResponse, LivenessError>>,
+        mock_state: LivenessMockState,
+    ) -> Self
+    {
+        Self { receiver, mock_state }
+    }
+
+    pub fn get_mock_state(&self) -> LivenessMockState {
+        self.mock_state.clone()
+    }
+
+    pub fn set_mock_state(&mut self, mock_state: LivenessMockState) {
+        self.mock_state = mock_state;
+    }
+
+    pub async fn run(mut self) {
+        while let Some(req) = self.receiver.next().await {
+            self.handle_request(req).await;
+        }
+    }
+
+    async fn handle_request(&self, req: RequestContext<LivenessRequest, Result<LivenessResponse, LivenessError>>) {
+        use LivenessRequest::*;
+        let (req, reply_tx) = req.split();
+        trace!(target: LOG_TARGET, "LivenessMock received request {:?}", req);
+        self.mock_state.add_request_call(req.clone());
+        // TODO: Make these responses configurable
+        match req {
+            SendPing(_) => {
+                reply_tx.send(Ok(LivenessResponse::Ok)).unwrap();
+            },
+            GetPingCount => {
+                reply_tx.send(Ok(LivenessResponse::Count(1))).unwrap();
+            },
+            GetPongCount => {
+                reply_tx.send(Ok(LivenessResponse::Count(1))).unwrap();
+            },
+            GetAvgLatency(_) => {
+                reply_tx.send(Ok(LivenessResponse::AvgLatency(None))).unwrap();
+            },
+            SetPongMetadata(_, _) => {
+                reply_tx.send(Ok(LivenessResponse::Ok)).unwrap();
+            },
+            GetNumActiveNeighbours => {
+                reply_tx.send(Ok(LivenessResponse::NumActiveNeighbours(8))).unwrap();
+            },
+        }
+    }
+}

--- a/base_layer/p2p/tests/services/liveness.rs
+++ b/base_layer/p2p/tests/services/liveness.rs
@@ -31,11 +31,7 @@ use tari_p2p::{
     comms_connector::pubsub_connector,
     services::{
         comms_outbound::CommsOutboundServiceInitializer,
-        liveness::{
-            handle::{LivenessEvent, LivenessHandle},
-            LivenessConfig,
-            LivenessInitializer,
-        },
+        liveness::{LivenessConfig, LivenessEvent, LivenessHandle, LivenessInitializer},
     },
 };
 use tari_service_framework::StackBuilder;
@@ -59,6 +55,7 @@ pub fn setup_liveness_service(
                 enable_auto_join: false,
                 enable_auto_stored_message_request: false,
                 auto_ping_interval: None,
+                refresh_neighbours_interval: Duration::from_secs(60),
             },
             Arc::clone(&subscription_factory),
             dht.dht_requester(),

--- a/base_layer/wallet/src/wallet.rs
+++ b/base_layer/wallet/src/wallet.rs
@@ -65,7 +65,7 @@ use tari_p2p::{
     initialization::{initialize_comms, CommsConfig},
     services::{
         comms_outbound::CommsOutboundServiceInitializer,
-        liveness::{handle::LivenessHandle, LivenessInitializer},
+        liveness::{LivenessHandle, LivenessInitializer},
     },
 };
 use tari_service_framework::StackBuilder;

--- a/comms/dht/src/actor.rs
+++ b/comms/dht/src/actor.rs
@@ -417,6 +417,11 @@ impl<'a> DhtActor<'a> {
                     return false;
                 }
 
+                if !peer.has_features(PeerFeatures::MESSAGE_PROPAGATION) {
+                    not_propagation_node_count += 1;
+                    return false;
+                }
+
                 let is_connect_eligible = {
                     // Check this peer was recently connectable
                     peer.connection_stats.failed_attempts() <= config.broadcast_cooldown_max_attempts ||

--- a/infrastructure/broadcast_channel/src/channel.rs
+++ b/infrastructure/broadcast_channel/src/channel.rs
@@ -1,14 +1,15 @@
 use crate::atomic_counter::AtomicCounter;
 use arc_swap::ArcSwapOption;
 use std::{
+    fmt::Debug,
     iter::Iterator,
     sync::{
         atomic::{AtomicBool, Ordering},
         Arc,
     },
 };
+
 // Use std mpsc's error types as our own
-use std::fmt::Debug;
 pub use std::sync::mpsc::{RecvError, RecvTimeoutError, SendError, TryRecvError};
 
 /// Function used to create and initialise a (Sender, Receiver) tuple.

--- a/infrastructure/broadcast_channel/src/lib.rs
+++ b/infrastructure/broadcast_channel/src/lib.rs
@@ -94,4 +94,4 @@ pub(crate) mod atomic_counter;
 mod channel;
 
 pub use async_channel::{bounded, Publisher, Subscriber};
-pub use channel::bounded as raw_bounded;
+pub use channel::{bounded as raw_bounded, SendError};

--- a/infrastructure/tari_util/src/lib.rs
+++ b/infrastructure/tari_util/src/lib.rs
@@ -32,6 +32,8 @@ pub mod extend_bytes;
 pub mod fixed_set;
 pub mod hash;
 pub mod hex;
+#[macro_use]
+pub mod locks;
 pub mod message_format;
 pub mod thread_join;
 

--- a/infrastructure/test_utils/src/enums.rs
+++ b/infrastructure/test_utils/src/enums.rs
@@ -1,0 +1,72 @@
+// Copyright 2019, The Tari Project
+//
+// Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+// following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+// disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+// following disclaimer in the documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+// products derived from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+// INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+// WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+// USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+/// Unpack the tuple or struct variant variables from an enum.
+///
+/// ```edition2018
+/// # use tari_test_utils::unpack_enum;
+///
+/// #[derive(Debug)]
+/// enum AnyEnum<'a> {
+///     Tuple(u8, &'a str),
+///     Struct { name: &'a str, age: u8 },
+///     SingleVariant,
+/// }
+///
+/// let e = AnyEnum::Tuple(123, "Hubert etc.");
+/// unpack_enum!(AnyEnum::Tuple(age, name) = e);
+/// assert_eq!(age, 123);
+/// assert_eq!(name, "Hubert etc.");
+///
+/// let e = AnyEnum::Struct{age: 123, name: "Hubert etc."};
+/// unpack_enum!(AnyEnum::Struct{ age, name } = e);
+/// assert_eq!(age, 123);
+/// assert_eq!(name, "Hubert etc.");
+///
+/// let e = AnyEnum::SingleVariant;
+/// unpack_enum!(AnyEnum::SingleVariant = e);
+///
+/// // Will panic
+/// // let e = AnyEnum::Tuple(123, "Hubert etc.");
+/// // unpack_enum!(AnyEnum::SingleVariant = e);
+/// ```
+#[macro_export]
+macro_rules! unpack_enum {
+    ($($enum_key:ident)::+ { $($idents:tt),* } = $enum:expr) => {
+        let ($($idents),+) =  match $enum {
+            $($enum_key)::+{$($idents),+} => ($($idents),+),
+            _ => panic!("Unexpected enum variant given to unpack_enum"),
+        };
+    };
+    ($($enum_key:ident)::+ ( $($idents:tt),* ) = $enum:expr) => {
+        let ($($idents),+) =  match $enum {
+            $($enum_key)::+($($idents),+) => ($($idents),+),
+            _ => panic!("Unexpected enum variant given to unpack_enum"),
+        };
+    };
+    ($($enum_key:ident)::+ = $enum:expr) => {
+        match $enum {
+            $($enum_key)::+ => {},
+            _ => panic!("Unexpected enum variant given to unpack_enum"),
+        };
+    };
+}

--- a/infrastructure/test_utils/src/lib.rs
+++ b/infrastructure/test_utils/src/lib.rs
@@ -12,6 +12,8 @@
 extern crate lazy_static;
 
 pub mod address;
+#[macro_use]
+pub mod enums;
 pub mod futures;
 pub mod paths;
 pub mod random;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This iteration does not send aggregated chain metadata to the base node
service as that is TBD, but is complete enough for a review.

- Liveness service sends pings at a configurable interval
- Metadata can be tacked onto the reply pongs
- The chain metadata service is responsible for:
  - Keeping the metadata sent up to date by updating the metadata the
    liveness service sends after each block that is added to the
    blockchain
  - Collecting the metadata from each neighbouring peer between rounds
    of pings
  - Sending that data to the basenode once all peers have responded or
    before the next round of pings has started (sending to base node
    service is TBD)

TODO:
- If base node enters synching state, chain metadata service needs to be notified and should stop sending chain metadata to peers until listening state is restored
- ~~Discuss how best to send the chain metadata from peers to the base node service.~~ Chain metadata service publishes peer chain metadata on an event stream.  

Extras:
- Added `tari_test_utils::unpack_enum!` macro to to used whenever an enum needs to be 'unpacked' in tests
e.g.
```rust
unpack_enum!(LivenessRequest::SetPongMetadata(metadata_key, data) = last_call);
assert_eq!(metadata_key, MetadataKey::ChainMetadata);
```

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #947 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Unit tests. Added a liveness service mock for testing available behind `test-mocks` feature flag on `tari_p2p`.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [x] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch
* [x] I ran `cargo-fmt --all` before pushing
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
