### PR TITLE
Update output manager service tests to use both storage backends

### DIFF
--- a/base_layer/wallet/src/output_manager_service/storage/sqlite_db.rs
+++ b/base_layer/wallet/src/output_manager_service/storage/sqlite_db.rs
@@ -370,7 +370,11 @@ impl OutputManagerBackend for OutputManagerSqliteDatabase {
             },
             Err(e) => {
                 match e {
-                    OutputManagerStorageError::DieselError(DieselError::NotFound) => (),
+                    OutputManagerStorageError::DieselError(DieselError::NotFound) => {
+                        return Err(OutputManagerStorageError::ValueNotFound(
+                            DbKey::PendingTransactionOutputs(tx_id.clone()),
+                        ))
+                    },
                     e => return Err(e),
                 };
             },

--- a/base_layer/wallet/tests/output_manager_service/storage.rs
+++ b/base_layer/wallet/tests/output_manager_service/storage.rs
@@ -20,7 +20,10 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use crate::support::utils::{make_input, random_string};
+use crate::support::{
+    data::create_temporary_sqlite_path,
+    utils::{make_input, random_string},
+};
 use chrono::{Duration as ChronoDuration, Utc};
 use rand::RngCore;
 use std::time::Duration;
@@ -247,13 +250,5 @@ pub fn test_output_manager_memory_db() {
 
 #[test]
 pub fn test_output_manager_sqlite_db() {
-    let db_name = format!("{}.sqlite3", random_string(8).as_str());
-    let db_folder = TempDir::new(random_string(8).as_str())
-        .unwrap()
-        .path()
-        .to_str()
-        .unwrap()
-        .to_string();
-    let db_path = format!("{}{}", db_folder, db_name);
-    test_db_backend(OutputManagerSqliteDatabase::new(db_path).unwrap());
+    test_db_backend(OutputManagerSqliteDatabase::new(create_temporary_sqlite_path()).unwrap());
 }

--- a/base_layer/wallet/tests/support/data.rs
+++ b/base_layer/wallet/tests/support/data.rs
@@ -20,7 +20,9 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+use crate::support::utils::random_string;
 use std::path::PathBuf;
+use tempdir::TempDir;
 
 pub fn get_path(name: Option<&str>) -> String {
     let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
@@ -39,4 +41,15 @@ pub fn init_sql_database(name: &str) {
     clean_up_sql_database(name);
     let path = get_path(None);
     let _ = std::fs::create_dir(&path).unwrap_or_default();
+}
+
+pub fn create_temporary_sqlite_path() -> String {
+    let db_name = format!("{}.sqlite3", random_string(8).as_str());
+    let db_folder = TempDir::new(random_string(8).as_str())
+        .unwrap()
+        .path()
+        .to_str()
+        .unwrap()
+        .to_string();
+    format!("{}{}", db_folder, db_name).to_string()
 }


### PR DESCRIPTION
## Description
The Output Manager service functional integration tests only used the MemoryDB storage backend, this PR has each test run on both the MemoryDB and Sqlite Backend

## How Has This Been Tested?
It is tests!

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [x] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch
* [x] I ran `cargo-fmt --all` before pushing
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
