### PR TITLE
DhtOutboundRequester indicates to caller if discovery is in progress

### DIFF
--- a/base_layer/core/src/base_node/comms_interface/error.rs
+++ b/base_layer/core/src/base_node/comms_interface/error.rs
@@ -37,4 +37,6 @@ pub enum CommsInterfaceError {
     EventStreamError,
     #[error(non_std, no_from)]
     MempoolError(String),
+    /// Failure in broadcast DHT middleware
+    BroadcastFailed,
 }

--- a/base_layer/core/src/base_node/states/initial_sync.rs
+++ b/base_layer/core/src/base_node/states/initial_sync.rs
@@ -241,6 +241,14 @@ impl InitialSync {
                     "There was a problem accessing the mempool. {}. {}.", e, msg
                 );
             },
+            CommsInterfaceError::BroadcastFailed => {
+                self.shutdown_votes += 1;
+                error!(
+                    target: LOG_TARGET,
+                    "There was a problem sending with the DHT broadcast middleware. {}.",
+                    e.to_string(),
+                );
+            },
         }
     }
 

--- a/base_layer/core/src/mempool/service/error.rs
+++ b/base_layer/core/src/mempool/service/error.rs
@@ -39,4 +39,6 @@ pub enum MempoolServiceError {
     MempoolError(MempoolError),
     UnexpectedApiResponse,
     TransportChannelError(TransportChannelError),
+    /// Failed to send broadcast message
+    BroadcastFailed,
 }

--- a/base_layer/core/src/mempool/test/service.rs
+++ b/base_layer/core/src/mempool/test/service.rs
@@ -51,9 +51,7 @@ use tari_comms::{
     peer_manager::{NodeIdentity, Peer, PeerFeatures, PeerFlags},
 };
 use tari_comms_dht::{
-    broadcast_strategy::BroadcastStrategy,
     domain_message::OutboundDomainMessage,
-    envelope::NodeDestination,
     outbound::{OutboundEncryption, OutboundMessageRequester},
     Dht,
 };
@@ -385,20 +383,18 @@ fn receive_and_propagate_transaction() {
     runtime.block_on(async {
         alice_interfaces
             .outbound_message_service
-            .send_message(
-                BroadcastStrategy::DirectPublicKey(bob_interfaces.node_identity.public_key().clone()),
-                NodeDestination::Unknown,
-                OutboundEncryption::EncryptForDestination,
+            .send_direct(
+                bob_interfaces.node_identity.public_key().clone(),
+                OutboundEncryption::EncryptForPeer,
                 OutboundDomainMessage::new(TariMessageType::NewTransaction, proto::Transaction::from(tx)),
             )
             .await
             .unwrap();
         alice_interfaces
             .outbound_message_service
-            .send_message(
-                BroadcastStrategy::DirectPublicKey(carol_interfaces.node_identity.public_key().clone()),
-                NodeDestination::Unknown,
-                OutboundEncryption::EncryptForDestination,
+            .send_direct(
+                carol_interfaces.node_identity.public_key().clone(),
+                OutboundEncryption::EncryptForPeer,
                 OutboundDomainMessage::new(TariMessageType::NewTransaction, proto::Transaction::from(orphan)),
             )
             .await

--- a/base_layer/p2p/src/services/liveness/service.rs
+++ b/base_layer/p2p/src/services/liveness/service.rs
@@ -305,7 +305,7 @@ mod test {
         connection::NetAddress,
         peer_manager::{NodeId, Peer, PeerFeatures, PeerFlags},
     };
-    use tari_comms_dht::outbound::DhtOutboundRequest;
+    use tari_comms_dht::outbound::{DhtOutboundRequest, SendMessageResponse};
     use tari_crypto::keys::PublicKey;
     use tari_service_framework::reply_channel;
     use tari_shutdown::Shutdown;
@@ -395,8 +395,8 @@ mod test {
             // Receive outbound request
             rt.spawn(async move {
                 match outbound_rx.select_next_some().await {
-                    DhtOutboundRequest::SendMsg(_, reply_tx) => {
-                        reply_tx.send(0).unwrap();
+                    DhtOutboundRequest::SendMsg(_, _, reply_tx) => {
+                        reply_tx.send(SendMessageResponse::Ok(0)).unwrap();
                     },
                     _ => panic!("unexpected request"),
                 }

--- a/base_layer/p2p/src/test_utils.rs
+++ b/base_layer/p2p/src/test_utils.rs
@@ -36,15 +36,18 @@ use tari_utilities::message_format::MessageFormat;
 macro_rules! unwrap_oms_send_msg {
     ($var:expr, reply_value=$reply_value:expr) => {
         match $var {
-            tari_comms_dht::outbound::DhtOutboundRequest::SendMsg(boxed, reply_tx) => {
+            tari_comms_dht::outbound::DhtOutboundRequest::SendMsg(boxed, body, reply_tx) => {
                 let _ = reply_tx.send($reply_value);
-                *boxed
+                (*boxed, body)
             },
             _ => panic!("Unexpected DhtOutboundRequest"),
         }
     };
     ($var:expr) => {
-        unwrap_oms_send_msg!($var, reply_value = 0);
+        unwrap_oms_send_msg!(
+            $var,
+            reply_value = tari_comms_dht::outbound::SendMessageResponse::Ok(0)
+        );
     };
 }
 

--- a/base_layer/wallet/src/transaction_service/service.rs
+++ b/base_layer/wallet/src/transaction_service/service.rs
@@ -44,9 +44,7 @@ use std::{collections::HashMap, convert::TryInto, sync::Arc};
 use tari_broadcast_channel::Publisher;
 use tari_comms::{peer_manager::NodeIdentity, types::CommsPublicKey};
 use tari_comms_dht::{
-    broadcast_strategy::BroadcastStrategy,
     domain_message::OutboundDomainMessage,
-    envelope::NodeDestination,
     outbound::{OutboundEncryption, OutboundMessageRequester},
 };
 use tari_crypto::keys::SecretKey;
@@ -308,7 +306,7 @@ where
         self.outbound_message_service
             .send_direct(
                 dest_pubkey.clone(),
-                OutboundEncryption::EncryptForDestination,
+                OutboundEncryption::EncryptForPeer,
                 OutboundDomainMessage::new(TariMessageType::SenderPartialTransaction, proto_message),
             )
             .await?;
@@ -441,10 +439,9 @@ where
             let tx_id = recipient_reply.tx_id;
             let proto_message: proto::RecipientSignedMessage = recipient_reply.into();
             self.outbound_message_service
-                .send_message(
-                    BroadcastStrategy::DirectPublicKey(source_pubkey.clone()),
-                    NodeDestination::Unknown,
-                    OutboundEncryption::EncryptForDestination,
+                .send_direct(
+                    source_pubkey.clone(),
+                    OutboundEncryption::EncryptForPeer,
                     OutboundDomainMessage::new(TariMessageType::ReceiverPartialTransactionReply, proto_message),
                 )
                 .await?;

--- a/comms/dht/src/actor.rs
+++ b/comms/dht/src/actor.rs
@@ -28,10 +28,9 @@
 //! [DhtRequest]: ./enum.DhtRequest.html
 
 use crate::{
-    broadcast_strategy::{BroadcastClosestRequest, BroadcastStrategy},
+    broadcast_strategy::BroadcastStrategy,
     discovery::DhtDiscoveryError,
-    envelope::NodeDestination,
-    outbound::{OutboundEncryption, OutboundMessageRequester},
+    outbound::{OutboundMessageRequester, SendMessageParams},
     proto::{dht::JoinMessage, envelope::DhtMessageType, store_forward::StoredMessagesRequest},
     DhtConfig,
 };
@@ -285,15 +284,11 @@ impl<'a> DhtActor<'a> {
         );
 
         outbound_requester
-            .send_dht_message(
-                BroadcastStrategy::Closest(Box::new(BroadcastClosestRequest {
-                    n: num_neighbouring_nodes,
-                    node_id: node_identity.node_id().clone(),
-                    excluded_peers: Vec::new(),
-                })),
-                NodeDestination::Unknown,
-                OutboundEncryption::None,
-                DhtMessageType::Join,
+            .send_message_no_header(
+                SendMessageParams::new()
+                    .closest(node_identity.node_id().clone(), num_neighbouring_nodes, Vec::new())
+                    .with_dht_message_type(DhtMessageType::Join)
+                    .finish(),
                 message,
             )
             .await
@@ -309,18 +304,12 @@ impl<'a> DhtActor<'a> {
         maybe_since: Option<DateTime<Utc>>,
     ) -> Result<(), DhtActorError>
     {
-        let broadcast_strategy = BroadcastStrategy::Closest(Box::new(BroadcastClosestRequest {
-            n: num_neighbouring_nodes,
-            node_id: node_identity.node_id().clone(),
-            excluded_peers: Vec::new(),
-        }));
-
         outbound_requester
-            .send_dht_message(
-                broadcast_strategy,
-                NodeDestination::Unknown,
-                OutboundEncryption::EncryptForDestination,
-                DhtMessageType::SafRequestMessages,
+            .send_message_no_header(
+                SendMessageParams::new()
+                    .closest(node_identity.node_id().clone(), num_neighbouring_nodes, Vec::new())
+                    .with_dht_message_type(DhtMessageType::SafRequestMessages)
+                    .finish(),
                 maybe_since
                     .map(StoredMessagesRequest::since)
                     .unwrap_or(StoredMessagesRequest::new()),
@@ -498,43 +487,11 @@ mod test {
 
             rt.block_on(async move {
                 requester.send_join().await.unwrap();
-                let request = unwrap_oms_send_msg!(out_rx.next().await.unwrap());
-                assert_eq!(request.dht_message_type, DhtMessageType::Join);
+                let (params, _) = unwrap_oms_send_msg!(out_rx.next().await.unwrap());
+                assert_eq!(params.dht_message_type, DhtMessageType::Join);
             });
         });
     }
-
-    //    #[test]
-    //    fn send_discover_request() {
-    //        runtime::test_async(|rt| {
-    //            let node_identity = make_node_identity();
-    //            let peer_manager = make_peer_manager();
-    //            let (out_tx, mut out_rx) = mpsc::channel(1);
-    //            let (actor_tx, actor_rx) = mpsc::channel(1);
-    //            let mut requester = DhtRequester::new(actor_tx);
-    //            let outbound_requester = OutboundMessageRequester::new(out_tx);
-    //            let shutdown = Shutdown::new();
-    //            let actor = DhtActor::new(
-    //                Default::default(),
-    //                node_identity,
-    //                peer_manager,
-    //                outbound_requester,
-    //                actor_rx,
-    //                shutdown.to_signal(),
-    //            );
-    //
-    //            rt.spawn(actor.run());
-    //
-    //            rt.block_on(async move {
-    //                requester
-    //                    .send_discover(CommsPublicKey::default(), None, NodeDestination::Unknown)
-    //                    .await
-    //                    .unwrap();
-    //                let request = unwrap_oms_send_msg!(out_rx.next().await.unwrap());
-    //                assert_eq!(request.dht_message_type, DhtMessageType::Discovery);
-    //            });
-    //        });
-    //    }
 
     #[test]
     fn insert_message_signature() {

--- a/comms/dht/src/broadcast_strategy.rs
+++ b/comms/dht/src/broadcast_strategy.rs
@@ -86,7 +86,7 @@ impl BroadcastStrategy {
         }
     }
 
-    pub fn take_direct_public_key(self) -> Option<CommsPublicKey> {
+    pub fn into_direct_public_key(self) -> Option<CommsPublicKey> {
         use BroadcastStrategy::*;
         match self {
             DirectPublicKey(pk) => Some(pk),

--- a/comms/dht/src/inbound/dht_handler/task.rs
+++ b/comms/dht/src/inbound/dht_handler/task.rs
@@ -26,7 +26,7 @@ use crate::{
     discovery::DhtDiscoveryRequester,
     envelope::NodeDestination,
     inbound::{error::DhtInboundError, message::DecryptedDhtMessage},
-    outbound::{OutboundEncryption, OutboundMessageRequester},
+    outbound::{OutboundEncryption, OutboundMessageRequester, SendMessageParams},
     proto::{
         dht::{DiscoveryMessage, DiscoveryResponseMessage, JoinMessage},
         envelope::DhtMessageType,
@@ -324,11 +324,13 @@ where
 
         trace!("Sending direct join request to {}", dest_public_key);
         self.outbound_service
-            .send_dht_message(
-                BroadcastStrategy::DirectPublicKey(dest_public_key.clone()),
-                NodeDestination::PublicKey(dest_public_key),
-                OutboundEncryption::EncryptForDestination,
-                DhtMessageType::Join,
+            .send_message_no_header(
+                SendMessageParams::new()
+                    .direct_public_key(dest_public_key.clone())
+                    .with_destination(NodeDestination::PublicKey(dest_public_key))
+                    .with_encryption(OutboundEncryption::EncryptForPeer)
+                    .with_dht_message_type(DhtMessageType::Join)
+                    .finish(),
                 join_msg,
             )
             .await?;
@@ -353,11 +355,13 @@ where
 
         trace!("Sending discovery response to {}", dest_public_key);
         self.outbound_service
-            .send_dht_message(
-                BroadcastStrategy::DirectPublicKey(dest_public_key.clone()),
-                NodeDestination::PublicKey(dest_public_key),
-                OutboundEncryption::EncryptForDestination,
-                DhtMessageType::DiscoveryResponse,
+            .send_message_no_header(
+                SendMessageParams::new()
+                    .direct_public_key(dest_public_key.clone())
+                    .with_destination(NodeDestination::PublicKey(dest_public_key))
+                    .with_encryption(OutboundEncryption::EncryptForPeer)
+                    .with_dht_message_type(DhtMessageType::DiscoveryResponse)
+                    .finish(),
                 response,
             )
             .await?;

--- a/comms/dht/src/outbound/broadcast.rs
+++ b/comms/dht/src/outbound/broadcast.rs
@@ -26,9 +26,15 @@ use crate::{
     broadcast_strategy::BroadcastStrategy,
     discovery::DhtDiscoveryRequester,
     envelope::{DhtMessageHeader, NodeDestination},
-    outbound::message::{DhtOutboundMessage, ForwardRequest, OutboundEncryption, SendMessageRequest},
+    outbound::{
+        message::{DhtOutboundMessage, ForwardRequest, OutboundEncryption},
+        message_params::FinalSendMessageParams,
+        SendMessageResponse,
+    },
+    proto::envelope::DhtMessageType,
 };
 use futures::{
+    channel::oneshot,
     future,
     stream::{self, StreamExt},
     task::Context,
@@ -38,6 +44,7 @@ use futures::{
 use log::*;
 use std::sync::Arc;
 use tari_comms::{
+    message::MessageFlags,
     peer_manager::{NodeId, NodeIdentity, Peer, PeerFeatures},
     types::CommsPublicKey,
 };
@@ -188,19 +195,8 @@ where S: Service<DhtOutboundMessage, Response = (), Error = MiddlewareError>
     ) -> Result<Vec<DhtOutboundMessage>, DhtOutboundError>
     {
         match msg {
-            DhtOutboundRequest::SendMsg(request, reply_tx) => {
-                match self.generate_send_messages(*request).await {
-                    Ok(msgs) => {
-                        // Reply with the number of messages to be sent
-                        let _ = reply_tx.send(msgs.len());
-                        Ok(msgs)
-                    },
-                    Err(err) => {
-                        // Reply 0 messages sent
-                        let _ = reply_tx.send(0);
-                        Err(err)
-                    },
-                }
+            DhtOutboundRequest::SendMsg(params, body, reply_tx) => {
+                self.handle_send_message(*params, body, reply_tx).await
             },
             DhtOutboundRequest::Forward(request) => {
                 if self.node_identity.has_peer_features(PeerFeatures::MESSAGE_PROPAGATION) {
@@ -216,24 +212,108 @@ where S: Service<DhtOutboundMessage, Response = (), Error = MiddlewareError>
         }
     }
 
-    async fn select_or_discover_peer(
+    async fn handle_send_message(
         &mut self,
-        dest_public_key: CommsPublicKey,
-    ) -> Result<Option<Peer>, DhtOutboundError>
+        params: FinalSendMessageParams,
+        body: Vec<u8>,
+        reply_tx: oneshot::Sender<SendMessageResponse>,
+    ) -> Result<Vec<DhtOutboundMessage>, DhtOutboundError>
     {
-        let mut peers = self
-            .dht_requester
-            .select_peers(BroadcastStrategy::DirectPublicKey(dest_public_key.clone()))
+        let FinalSendMessageParams {
+            broadcast_strategy,
+            destination,
+            dht_message_type,
+            encryption,
+            is_discovery_enabled,
+        } = params;
+
+        match self.select_peers(broadcast_strategy.clone()).await {
+            Ok(mut peers) => {
+                if reply_tx.is_canceled() {
+                    return Err(DhtOutboundError::ReplyChannelCanceled);
+                }
+
+                let mut reply_tx = Some(reply_tx);
+
+                trace!(
+                    target: LOG_TARGET,
+                    "Number of peers selected = {}, is_discovery_enabled = {}",
+                    peers.len(),
+                    is_discovery_enabled,
+                );
+
+                // Discovery is required if:
+                //  - Discovery is enabled for this request
+                //  - There where no peers returned
+                //  - A direct public key broadcast strategy is used
+                if is_discovery_enabled && peers.len() == 0 && broadcast_strategy.direct_public_key().is_some() {
+                    let (discovery_reply_tx, discovery_reply_rx) = oneshot::channel();
+                    let target_public_key = broadcast_strategy.into_direct_public_key().expect("already checked");
+
+                    let _ = reply_tx
+                        .take()
+                        .expect("cannot fail")
+                        .send(SendMessageResponse::PendingDiscovery(discovery_reply_rx));
+
+                    match self.initiate_peer_discovery(target_public_key).await {
+                        Ok(Some(peer)) => {
+                            // Set the reply_tx so that it can be used later
+                            reply_tx = Some(discovery_reply_tx);
+                            peers = vec![peer];
+                        },
+                        Ok(None) => {
+                            // Message sent to 0 peers
+                            let _ = discovery_reply_tx.send(SendMessageResponse::Ok(0));
+                            return Ok(Vec::new());
+                        },
+                        Err(err) => {
+                            let _ = discovery_reply_tx.send(SendMessageResponse::Failed);
+                            return Err(err);
+                        },
+                    }
+                }
+
+                match self
+                    .generate_send_messages(peers, destination, dht_message_type, encryption, body)
+                    .await
+                {
+                    Ok(msgs) => {
+                        // Reply with the number of messages to be sent
+                        let _ = reply_tx
+                            .take()
+                            .expect("cannot fail")
+                            .send(SendMessageResponse::Ok(msgs.len()));
+                        Ok(msgs)
+                    },
+                    Err(err) => {
+                        // Reply 0 messages sent
+                        let _ = reply_tx.take().expect("cannot fail").send(SendMessageResponse::Failed);
+                        Err(err)
+                    },
+                }
+            },
+            Err(err) => {
+                let _ = reply_tx.send(SendMessageResponse::Failed);
+                Err(err)
+            },
+        }
+    }
+
+    async fn select_peers(&mut self, broadcast_strategy: BroadcastStrategy) -> Result<Vec<Peer>, DhtOutboundError> {
+        self.dht_requester
+            .select_peers(broadcast_strategy)
             .await
             .map_err(|err| {
                 error!(target: LOG_TARGET, "{}", err);
                 DhtOutboundError::PeerSelectionFailed
-            })?;
+            })
+    }
 
-        if peers.len() > 0 {
-            return Ok(Some(peers.remove(0)));
-        }
-
+    async fn initiate_peer_discovery(
+        &mut self,
+        dest_public_key: CommsPublicKey,
+    ) -> Result<Option<Peer>, DhtOutboundError>
+    {
         trace!(
             target: LOG_TARGET,
             "Initiating peer discovery for public key '{}'",
@@ -241,7 +321,7 @@ where S: Service<DhtOutboundMessage, Response = (), Error = MiddlewareError>
         );
 
         // TODO: This works because we know that all non-DAN node IDs are/should be derived from the public key.
-        //       Once the DAN launches, this may not be the case.
+        //       Once the DAN launches, this may not be the case and we'll need to query the blockchain for the node id
         let derived_node_id = NodeId::from_key(&dest_public_key).ok();
 
         // Peer not found, let's try and discover it
@@ -277,38 +357,14 @@ where S: Service<DhtOutboundMessage, Response = (), Error = MiddlewareError>
 
     async fn generate_send_messages(
         &mut self,
-        send_message_request: SendMessageRequest,
+        selected_peers: Vec<Peer>,
+        destination: NodeDestination,
+        dht_message_type: DhtMessageType,
+        encryption: OutboundEncryption,
+        body: Vec<u8>,
     ) -> Result<Vec<DhtOutboundMessage>, DhtOutboundError>
     {
-        let SendMessageRequest {
-            broadcast_strategy,
-            destination,
-            encryption,
-            comms_flags,
-            dht_flags,
-            dht_message_type,
-            body,
-        } = send_message_request;
-
-        // Use the BroadcastStrategy to select appropriate peer(s) from PeerManager and then construct and send a
-        // individually wrapped MessageEnvelope to each selected peer
-        // If the broadcast strategy is DirectPublicKey and the peer is not known, peer discovery will be initiated.
-        let selected_peers = match broadcast_strategy.direct_public_key() {
-            Some(_) => {
-                let dest_public_key = broadcast_strategy.take_direct_public_key().expect("already checked");
-                self.select_or_discover_peer(dest_public_key)
-                    .await
-                    .map(|peer| peer.map(|p| vec![p]).unwrap_or_default())?
-            },
-            None => self
-                .dht_requester
-                .select_peers(broadcast_strategy)
-                .await
-                .map_err(|err| {
-                    error!(target: LOG_TARGET, "{}", err);
-                    DhtOutboundError::PeerSelectionFailed
-                })?,
-        };
+        let dht_flags = encryption.flags();
 
         // Create a DHT header
         let dht_header = DhtMessageHeader::new(
@@ -326,7 +382,13 @@ where S: Service<DhtOutboundMessage, Response = (), Error = MiddlewareError>
         let messages = selected_peers
             .into_iter()
             .map(|peer| {
-                DhtOutboundMessage::new(peer, dht_header.clone(), encryption.clone(), comms_flags, body.clone())
+                DhtOutboundMessage::new(
+                    peer,
+                    dht_header.clone(),
+                    encryption.clone(),
+                    MessageFlags::NONE,
+                    body.clone(),
+                )
             })
             .collect::<Vec<_>>();
 
@@ -377,10 +439,7 @@ where S: Service<DhtOutboundMessage, Response = (), Error = MiddlewareError>
 mod test {
     use super::*;
     use crate::{
-        broadcast_strategy::BroadcastStrategy,
-        envelope::{DhtMessageFlags, NodeDestination},
-        outbound::message::OutboundEncryption,
-        proto::envelope::DhtMessageType,
+        outbound::SendMessageParams,
         test_utils::{
             create_dht_actor_mock,
             create_dht_discovery_mock,
@@ -395,7 +454,6 @@ mod test {
     use std::time::Duration;
     use tari_comms::{
         connection::NetAddress,
-        message::MessageFlags,
         peer_manager::{NodeId, Peer, PeerFeatures, PeerFlags},
         types::CommsPublicKey,
     };
@@ -448,15 +506,8 @@ mod test {
         let (reply_tx, _reply_rx) = oneshot::channel();
 
         rt.block_on(service.call(DhtOutboundRequest::SendMsg(
-            Box::new(SendMessageRequest {
-                broadcast_strategy: BroadcastStrategy::Flood,
-                comms_flags: MessageFlags::NONE,
-                destination: NodeDestination::Unknown,
-                encryption: OutboundEncryption::None,
-                dht_message_type: DhtMessageType::None,
-                dht_flags: DhtMessageFlags::NONE,
-                body: "custom_msg".as_bytes().to_vec(),
-            }),
+            Box::new(SendMessageParams::new().flood().finish()),
+            "custom_msg".as_bytes().to_vec(),
             reply_tx,
         )))
         .unwrap();
@@ -497,28 +548,33 @@ mod test {
         );
         let (reply_tx, reply_rx) = oneshot::channel();
 
-        rt.block_on(service.call(DhtOutboundRequest::SendMsg(
-            Box::new(SendMessageRequest {
-                broadcast_strategy: BroadcastStrategy::DirectPublicKey(pk),
-                comms_flags: MessageFlags::NONE,
-                destination: NodeDestination::Unknown,
-                encryption: OutboundEncryption::None,
-                dht_message_type: DhtMessageType::None,
-                dht_flags: DhtMessageFlags::NONE,
-                body: "custom_msg".as_bytes().to_vec(),
-            }),
-            reply_tx,
-        )))
+        rt.block_on(
+            service.call(DhtOutboundRequest::SendMsg(
+                Box::new(
+                    SendMessageParams::new()
+                        .direct_public_key(pk)
+                        .with_discovery(false)
+                        .finish(),
+                ),
+                "custom_msg".as_bytes().to_vec(),
+                reply_tx,
+            )),
+        )
         .unwrap();
 
-        let num_peers_selected = rt.block_on(reply_rx).unwrap();
-        assert_eq!(num_peers_selected, 0);
+        let send_message_response = rt.block_on(reply_rx).unwrap();
+        // TODO: use unpack_enum!
+        match send_message_response {
+            SendMessageResponse::Ok(0) => {},
+            _ => panic!("Unexpected SendMessageResponse variant"),
+        }
 
         assert_eq!(spy.call_count(), 0);
     }
 
     #[test]
     fn send_message_direct_dht_discovery() {
+        env_logger::init();
         let rt = Runtime::new().unwrap();
 
         let node_identity = NodeIdentity::random(
@@ -548,24 +604,32 @@ mod test {
         );
         let (reply_tx, reply_rx) = oneshot::channel();
 
-        rt.block_on(service.call(DhtOutboundRequest::SendMsg(
-            Box::new(SendMessageRequest {
-                broadcast_strategy: BroadcastStrategy::DirectPublicKey(peer_to_discover.public_key.clone()),
-                comms_flags: MessageFlags::NONE,
-                destination: NodeDestination::Unknown,
-                encryption: OutboundEncryption::None,
-                dht_message_type: DhtMessageType::None,
-                dht_flags: DhtMessageFlags::NONE,
-                body: "custom_msg".as_bytes().to_vec(),
-            }),
-            reply_tx,
-        )))
+        rt.block_on(
+            service.call(DhtOutboundRequest::SendMsg(
+                Box::new(
+                    SendMessageParams::new()
+                        .direct_public_key(peer_to_discover.public_key.clone())
+                        .finish(),
+                ),
+                "custom_msg".as_bytes().to_vec(),
+                reply_tx,
+            )),
+        )
         .unwrap();
 
-        let num_peers_selected = rt.block_on(reply_rx).unwrap();
-        assert_eq!(num_peers_selected, 1);
-        assert_eq!(dht_discovery_state.call_count(), 1);
+        let send_message_response = rt.block_on(reply_rx).unwrap();
+        match send_message_response {
+            SendMessageResponse::PendingDiscovery(await_discovery) => {
+                let discovery_reply = rt.block_on(await_discovery).unwrap();
+                assert_eq!(dht_discovery_state.call_count(), 1);
+                match discovery_reply {
+                    SendMessageResponse::Ok(1) => {},
+                    e => panic!("Unexpected SendMessageResponse variant: {:?}", e),
+                }
 
-        assert_eq!(spy.call_count(), 1);
+                assert_eq!(spy.call_count(), 1);
+            },
+            e => panic!("Unexpected SendMessageResponse variant: {:?}", e),
+        }
     }
 }

--- a/comms/dht/src/outbound/encryption.rs
+++ b/comms/dht/src/outbound/encryption.rs
@@ -102,7 +102,7 @@ where
                 let shared_secret = crypt::generate_ecdh_secret(node_identity.secret_key(), public_key);
                 message.body = crypt::encrypt(&shared_secret, &message.body)?;
             },
-            OutboundEncryption::EncryptForDestination => {
+            OutboundEncryption::EncryptForPeer => {
                 debug!(
                     target: LOG_TARGET,
                     "Encrypting message for peer with public key {}", message.destination_peer.public_key
@@ -188,7 +188,7 @@ mod test {
                 PeerFeatures::COMMUNICATION_NODE,
             ),
             make_dht_header(&node_identity, &body, DhtMessageFlags::ENCRYPTED),
-            OutboundEncryption::EncryptForDestination,
+            OutboundEncryption::EncryptForPeer,
             MessageFlags::empty(),
             body.clone(),
         );

--- a/comms/dht/src/outbound/error.rs
+++ b/comms/dht/src/outbound/error.rs
@@ -37,4 +37,8 @@ pub enum DhtOutboundError {
     RequesterReplyChannelClosed,
     /// Peer selection failed
     PeerSelectionFailed,
+    /// Failed to send broadcast message
+    BroadcastFailed,
+    /// Reply channel cancelled
+    ReplyChannelCanceled,
 }

--- a/comms/dht/src/outbound/message_params.rs
+++ b/comms/dht/src/outbound/message_params.rs
@@ -1,0 +1,142 @@
+// Copyright 2019, The Tari Project
+//
+// Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+// following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+// disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+// following disclaimer in the documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+// products derived from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+// INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+// WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+// USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+use crate::{
+    broadcast_strategy::{BroadcastClosestRequest, BroadcastStrategy},
+    envelope::NodeDestination,
+    outbound::OutboundEncryption,
+    proto::envelope::DhtMessageType,
+};
+use tari_comms::{peer_manager::NodeId, types::CommsPublicKey};
+
+/// Configuration for outbound messages.
+///
+/// ```edition2018
+/// # use tari_comms_dht::outbound::{SendMessageParams, OutboundEncryption};
+///
+/// // These params represent sending to 5 random peers, each encrypted for that peer
+/// let params = SendMessageParams::new()
+///   .random(5)
+///   .with_encryption(OutboundEncryption::EncryptForPeer)
+///   .finish();
+/// ```
+#[derive(Debug, Clone)]
+pub struct SendMessageParams {
+    params: Option<FinalSendMessageParams>,
+}
+
+impl Default for SendMessageParams {
+    fn default() -> Self {
+        Self {
+            params: Some(Default::default()),
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct FinalSendMessageParams {
+    pub broadcast_strategy: BroadcastStrategy,
+    pub destination: NodeDestination,
+    pub encryption: OutboundEncryption,
+    pub is_discovery_enabled: bool,
+    pub dht_message_type: DhtMessageType,
+}
+
+impl Default for FinalSendMessageParams {
+    fn default() -> Self {
+        Self {
+            broadcast_strategy: BroadcastStrategy::Flood,
+            destination: Default::default(),
+            encryption: Default::default(),
+            dht_message_type: Default::default(),
+            is_discovery_enabled: true,
+        }
+    }
+}
+
+impl SendMessageParams {
+    pub fn new() -> Self {
+        Default::default()
+    }
+
+    pub fn direct_public_key(&mut self, public_key: CommsPublicKey) -> &mut Self {
+        self.params_mut().broadcast_strategy = BroadcastStrategy::DirectPublicKey(public_key);
+        self
+    }
+
+    pub fn direct_node_id(&mut self, node_id: NodeId) -> &mut Self {
+        self.params_mut().broadcast_strategy = BroadcastStrategy::DirectNodeId(node_id);
+        self
+    }
+
+    pub fn closest(&mut self, node_id: NodeId, n: usize, excluded_peers: Vec<CommsPublicKey>) -> &mut Self {
+        self.params_mut().broadcast_strategy = BroadcastStrategy::Closest(Box::new(BroadcastClosestRequest {
+            excluded_peers,
+            node_id,
+            n,
+        }));
+        self
+    }
+
+    pub fn neighbours(&mut self, excluded_peers: Vec<CommsPublicKey>) -> &mut Self {
+        self.params_mut().broadcast_strategy = BroadcastStrategy::Neighbours(excluded_peers);
+        self
+    }
+
+    pub fn flood(&mut self) -> &mut Self {
+        self.params_mut().broadcast_strategy = BroadcastStrategy::Flood;
+        self
+    }
+
+    pub fn random(&mut self, n: usize) -> &mut Self {
+        self.params_mut().broadcast_strategy = BroadcastStrategy::Random(n);
+        self
+    }
+
+    pub fn with_destination(&mut self, destination: NodeDestination) -> &mut Self {
+        self.params_mut().destination = destination;
+        self
+    }
+
+    pub fn with_encryption(&mut self, encryption: OutboundEncryption) -> &mut Self {
+        self.params_mut().encryption = encryption;
+        self
+    }
+
+    pub fn with_discovery(&mut self, is_enabled: bool) -> &mut Self {
+        self.params_mut().is_discovery_enabled = is_enabled;
+        self
+    }
+
+    pub fn with_dht_message_type(&mut self, message_type: DhtMessageType) -> &mut Self {
+        self.params_mut().dht_message_type = message_type;
+        self
+    }
+
+    pub fn finish(&mut self) -> FinalSendMessageParams {
+        self.params.take().expect("cannot be None")
+    }
+
+    fn params_mut(&mut self) -> &mut FinalSendMessageParams {
+        self.params.as_mut().expect("cannot be None")
+    }
+}

--- a/comms/dht/src/outbound/mod.rs
+++ b/comms/dht/src/outbound/mod.rs
@@ -24,6 +24,7 @@ mod broadcast;
 mod encryption;
 mod error;
 mod message;
+mod message_params;
 mod requester;
 mod serialize;
 
@@ -33,7 +34,8 @@ pub use self::{
     broadcast::BroadcastLayer,
     encryption::EncryptionLayer,
     error::DhtOutboundError,
-    message::{DhtOutboundRequest, OutboundEncryption},
+    message::{DhtOutboundRequest, OutboundEncryption, SendMessageResponse},
+    message_params::SendMessageParams,
     requester::OutboundMessageRequester,
     serialize::SerializeLayer,
 };

--- a/comms/dht/src/test_utils/mod.rs
+++ b/comms/dht/src/test_utils/mod.rs
@@ -23,15 +23,15 @@
 macro_rules! unwrap_oms_send_msg {
     ($var:expr, reply_value=$reply_value:expr) => {
         match $var {
-            crate::outbound::DhtOutboundRequest::SendMsg(boxed, reply_tx) => {
+            crate::outbound::DhtOutboundRequest::SendMsg(boxed, body, reply_tx) => {
                 let _ = reply_tx.send($reply_value);
-                *boxed
+                (*boxed, body)
             },
             _ => panic!("Unexpected DhtOutboundRequest"),
         }
     };
     ($var:expr) => {
-        unwrap_oms_send_msg!($var, reply_value = 0);
+        unwrap_oms_send_msg!($var, reply_value = $crate::outbound::SendMessageResponse::Ok(0));
     };
 }
 

--- a/comms/src/connection/peer_connection/dialer.rs
+++ b/comms/src/connection/peer_connection/dialer.rs
@@ -301,7 +301,7 @@ impl PeerConnectionDialer {
                 self.set_state(&mut lock, PeerConnectionState::Disconnected);
             },
 
-            Connected => {
+            Connected | HandshakeSucceeded => {
                 self.retry_count = 0;
                 self.transition_connected()?;
             },
@@ -310,6 +310,10 @@ impl PeerConnectionDialer {
                     &mut acquire_lock!(self.connection_state),
                     PeerConnectionState::Failed(PeerConnectionError::ConnectFailed),
                 );
+            },
+
+            ConnectDelayed => {
+                trace!(target: LOG_TARGET, "Still connecting...");
             },
             ConnectRetried => {
                 let mut lock = acquire_lock!(self.connection_state);

--- a/comms/tests/control_service/service.rs
+++ b/comms/tests/control_service/service.rs
@@ -134,7 +134,7 @@ fn request_connection() {
         )
         .unwrap();
     let outcome = client
-        .receive_message::<RequestConnectionOutcome>(Duration::from_millis(3000))
+        .receive_message::<RequestConnectionOutcome>(Duration::from_millis(5000))
         .unwrap()
         .unwrap();
 
@@ -185,7 +185,7 @@ fn ping_pong() {
     let service = ControlService::new(context.clone(), Arc::clone(&node_identity), ControlServiceConfig {
         listener_address: listener_address.clone(),
         socks_proxy_address: None,
-        requested_connection_timeout: Duration::from_millis(2000),
+        requested_connection_timeout: Duration::from_millis(5000),
     })
     .serve(connection_manager)
     .unwrap();
@@ -200,7 +200,7 @@ fn ping_pong() {
         client_conn,
     );
 
-    client.ping_pong(Duration::from_millis(2000)).unwrap().unwrap();
+    client.ping_pong(Duration::from_millis(5000)).unwrap().unwrap();
 
     service.shutdown().unwrap();
     service.timeout_join(Duration::from_millis(3000)).unwrap();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

- When a peer discovery is required a
  `SendMessageResult::PendingDiscovery(discovery_notif)` is immediately returned with a
  oneshot that will resolve once the discovery process is complete.
- The caller can choose if they are interested in waiting for the
  discovery to resolve / can continue with other work in the meantime.
- Added SendMessageParam builder to encapsulate the options for sending messages. The 'preset' methods (such as propagate, neighbours etc) on the DhtOutboundRequester use this builder internally, and it can be used externally to use custom parameters when sending a message.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #1041

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Changed applicable tests

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [x] Breaking change (fix or feature that would cause existing functionality to change)
* [x] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch
* [x] I ran `cargo-fmt --all` before pushing
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
