### PR TITLE
Multi stage mineable block construction

### DIFF
--- a/base_layer/core/src/base_node/comms_interface/comms_request.rs
+++ b/base_layer/core/src/base_node/comms_interface/comms_request.rs
@@ -20,7 +20,7 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use crate::chain_storage::MmrTree;
+use crate::{blocks::NewBlockTemplate, chain_storage::MmrTree};
 use serde::{Deserialize, Serialize};
 use tari_transactions::types::HashOutput;
 
@@ -52,4 +52,5 @@ pub enum NodeCommsRequest {
     FetchBlocks(Vec<u64>),
     FetchMmrState(MmrStateRequest),
     GetNewBlockTemplate,
+    GetNewBlock(NewBlockTemplate),
 }

--- a/base_layer/core/src/base_node/comms_interface/local_interface.rs
+++ b/base_layer/core/src/base_node/comms_interface/local_interface.rs
@@ -22,7 +22,7 @@
 
 use crate::{
     base_node::comms_interface::{error::CommsInterfaceError, BlockEvent, NodeCommsRequest, NodeCommsResponse},
-    blocks::Block,
+    blocks::{Block, NewBlockTemplate},
     chain_storage::ChainMetadata,
 };
 use futures::{stream::Fuse, StreamExt};
@@ -67,13 +67,25 @@ impl LocalNodeCommsInterface {
     }
 
     /// Request the construction of a new mineable block template from the base node service.
-    pub async fn get_new_block_template(&mut self) -> Result<Block, CommsInterfaceError> {
+    pub async fn get_new_block_template(&mut self) -> Result<NewBlockTemplate, CommsInterfaceError> {
         match self
             .request_sender
             .call(NodeCommsRequest::GetNewBlockTemplate)
             .await??
         {
-            NodeCommsResponse::NewBlockTemplate(block) => Ok(block),
+            NodeCommsResponse::NewBlockTemplate(new_block_template) => Ok(new_block_template),
+            _ => Err(CommsInterfaceError::UnexpectedApiResponse),
+        }
+    }
+
+    /// Request from base node service the construction of a block from a block template.
+    pub async fn get_new_block(&mut self, block_template: NewBlockTemplate) -> Result<Block, CommsInterfaceError> {
+        match self
+            .request_sender
+            .call(NodeCommsRequest::GetNewBlock(block_template))
+            .await??
+        {
+            NodeCommsResponse::NewBlock(block) => Ok(block),
             _ => Err(CommsInterfaceError::UnexpectedApiResponse),
         }
     }

--- a/base_layer/core/src/base_node/proto/request.proto
+++ b/base_layer/core/src/base_node/proto/request.proto
@@ -1,7 +1,9 @@
 syntax = "proto3";
 
-package tari.base_node;
 import "mmr_state_request.proto";
+import "block.proto";
+
+package tari.base_node;
 
 // Request type for a received BaseNodeService request.
 message BaseNodeServiceRequest {
@@ -21,6 +23,8 @@ message BaseNodeServiceRequest {
         MmrStateRequest fetch_mmr_state = 7;
         // Indicates a GetNewBlockTemplate request.
         bool get_new_block_template = 8;
+        // Indicates a GetNewBlock request.
+        tari.core.NewBlockTemplate get_new_block = 9;
     }
 }
 

--- a/base_layer/core/src/base_node/proto/request.rs
+++ b/base_layer/core/src/base_node/proto/request.rs
@@ -40,6 +40,7 @@ impl TryInto<ci::NodeCommsRequest> for ProtoNodeCommsRequest {
             FetchBlocks(block_heights) => ci::NodeCommsRequest::FetchBlocks(block_heights.heights),
             FetchMmrState(mmr_state_request) => ci::NodeCommsRequest::FetchMmrState(mmr_state_request.try_into()?),
             GetNewBlockTemplate(_) => ci::NodeCommsRequest::GetNewBlockTemplate,
+            GetNewBlock(block_template) => ci::NodeCommsRequest::GetNewBlock(block_template.try_into()?),
         };
         Ok(request)
     }
@@ -56,6 +57,7 @@ impl From<ci::NodeCommsRequest> for ProtoNodeCommsRequest {
             FetchBlocks(block_heights) => ProtoNodeCommsRequest::FetchBlocks(block_heights.into()),
             FetchMmrState(mmr_state_request) => ProtoNodeCommsRequest::FetchMmrState(mmr_state_request.into()),
             GetNewBlockTemplate => ProtoNodeCommsRequest::GetNewBlockTemplate(true),
+            GetNewBlock(block_template) => ProtoNodeCommsRequest::GetNewBlock(block_template.into()),
         }
     }
 }

--- a/base_layer/core/src/base_node/proto/response.proto
+++ b/base_layer/core/src/base_node/proto/response.proto
@@ -11,13 +11,22 @@ package tari.base_node;
 message BaseNodeServiceResponse {
     uint64 request_key = 1;
     oneof response {
+        // Indicates a ChainMetadata response.
         ChainMetadata chain_metadata = 2;
+        // Indicates a TransactionKernels response.
         TransactionKernels transaction_kernels = 3;
+        // Indicates a BlockHeaders response.
         BlockHeaders block_headers = 4;
+        // Indicates a TransactionOutputs response.
         TransactionOutputs transaction_outputs = 5;
+        // Indicates a HistoricalBlocks response.
         HistoricalBlocks historical_blocks = 6;
+        // Indicates a MmrState response.
         MutableMmrState mmr_state = 7;
-        tari.core.Block new_block_template = 8;
+        // Indicates a NewBlockTemplate response.
+        tari.core.NewBlockTemplate new_block_template = 8;
+        // Indicates a NewBlock response.
+        tari.core.Block new_block = 9;
     }
 }
 

--- a/base_layer/core/src/base_node/proto/response.rs
+++ b/base_layer/core/src/base_node/proto/response.rs
@@ -60,7 +60,8 @@ impl TryInto<ci::NodeCommsResponse> for ProtoNodeCommsResponse {
                 ci::NodeCommsResponse::HistoricalBlocks(blocks)
             },
             MmrState(state) => ci::NodeCommsResponse::MmrState(state.try_into()?),
-            NewBlockTemplate(block) => ci::NodeCommsResponse::NewBlockTemplate(block.try_into()?),
+            NewBlockTemplate(block_template) => ci::NodeCommsResponse::NewBlockTemplate(block_template.try_into()?),
+            NewBlock(block) => ci::NodeCommsResponse::NewBlock(block.try_into()?),
         };
 
         Ok(response)
@@ -89,7 +90,8 @@ impl From<ci::NodeCommsResponse> for ProtoNodeCommsResponse {
                 ProtoNodeCommsResponse::HistoricalBlocks(historical_blocks)
             },
             MmrState(state) => ProtoNodeCommsResponse::MmrState(state.into()),
-            NewBlockTemplate(block) => ProtoNodeCommsResponse::NewBlockTemplate(block.into()),
+            NewBlockTemplate(block_template) => ProtoNodeCommsResponse::NewBlockTemplate(block_template.into()),
+            NewBlock(block) => ProtoNodeCommsResponse::NewBlock(block.into()),
         }
     }
 }

--- a/base_layer/core/src/blocks/mod.rs
+++ b/base_layer/core/src/blocks/mod.rs
@@ -22,8 +22,12 @@
 
 mod block;
 pub(crate) mod blockheader;
+mod new_block_template;
+mod new_blockheader_template;
 
 pub mod genesis_block;
 
 pub use block::{Block, BlockBuilder, BlockValidationError};
-pub use blockheader::BlockHeader;
+pub use blockheader::{BlockHash, BlockHeader};
+pub use new_block_template::NewBlockTemplate;
+pub use new_blockheader_template::NewBlockHeaderTemplate;

--- a/base_layer/core/src/blocks/new_block_template.rs
+++ b/base_layer/core/src/blocks/new_block_template.rs
@@ -20,22 +20,24 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use crate::{
-    blocks::{blockheader::BlockHeader, Block, NewBlockTemplate},
-    chain_storage::{ChainMetadata, HistoricalBlock, MutableMmrState},
-};
+use crate::blocks::{new_blockheader_template::NewBlockHeaderTemplate, Block};
 use serde::{Deserialize, Serialize};
-use tari_transactions::transaction::{TransactionKernel, TransactionOutput};
+use tari_transactions::aggregated_body::AggregateBody;
 
-/// API Response enum
-#[derive(Debug, Serialize, Deserialize, Clone)]
-pub enum NodeCommsResponse {
-    ChainMetadata(ChainMetadata),
-    TransactionKernels(Vec<TransactionKernel>),
-    BlockHeaders(Vec<BlockHeader>),
-    TransactionOutputs(Vec<TransactionOutput>),
-    HistoricalBlocks(Vec<HistoricalBlock>),
-    MmrState(MutableMmrState),
-    NewBlockTemplate(NewBlockTemplate),
-    NewBlock(Block),
+/// The new block template is used constructing a new partial block, allowing a miner to added the coinbase utxo and as
+/// a final step the Base node to add the MMR roots to the header.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct NewBlockTemplate {
+    pub header: NewBlockHeaderTemplate,
+    pub body: AggregateBody,
+}
+
+impl From<Block> for NewBlockTemplate {
+    fn from(block: Block) -> Self {
+        let Block { header, body } = block;
+        Self {
+            header: header.into(),
+            body,
+        }
+    }
 }

--- a/base_layer/core/src/chain_storage/async_db.rs
+++ b/base_layer/core/src/chain_storage/async_db.rs
@@ -160,6 +160,7 @@ make_async!(fetch_orphan(hash: HashOutput) -> Block);
 make_async!(is_utxo(hash: HashOutput) -> bool);
 make_async!(fetch_mmr_root(tree: MmrTree) -> HashOutput);
 make_async!(fetch_mmr_only_root(tree: MmrTree) -> HashOutput);
+make_async!(calculate_mmr_root(tree: MmrTree,additions: Vec<HashOutput>,deletions: Vec<HashOutput>) -> HashOutput);
 make_async!(fetch_mmr_base_leaf_nodes(tree: MmrTree,index: usize, count:usize) -> MutableMmrState);
 make_async!(add_block(block: Block) -> BlockAddResult);
 #[cfg(test)]

--- a/base_layer/core/src/proof_of_work/proof_of_work.rs
+++ b/base_layer/core/src/proof_of_work/proof_of_work.rs
@@ -35,7 +35,7 @@ use tari_utilities::hex::Hex;
 pub trait AchievedDifficulty {}
 
 #[repr(u8)]
-#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq)]
 pub enum PowAlgorithm {
     Monero = 0,
     Blake = 1,
@@ -64,7 +64,7 @@ impl TryFrom<u64> for PowAlgorithm {
 
 /// The proof of work data structure that is included in the block header. There's some non-Rustlike redundancy here
 /// to make serialization more straightforward
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct ProofOfWork {
     /// The total accumulated difficulty for each proof of work algorithms for all blocks since Genesis,
     /// but not including this block, tracked separately.

--- a/base_layer/core/src/proto/block.proto
+++ b/base_layer/core/src/proto/block.proto
@@ -61,3 +61,25 @@ message HistoricalBlock {
     // The underlying block
     Block block = 3;
 }
+
+
+// The NewBlockHeaderTemplate is used for the construction of a new mineable block. It contains all the metadata for the block that the Base Node is able to complete on behalf of a Miner.
+message NewBlockHeaderTemplate {
+    // Version of the block
+    uint32 version = 1;
+    // Height of this block since the genesis block (height 0)
+    uint64 height = 2;
+    // Hash of the block previous to this in the chain.
+    bytes prev_hash = 3;
+    // Total accumulated sum of kernel offsets since genesis block. We can derive the kernel offset sum for *this*
+    // block from the total kernel offset of the previous block header.
+    bytes total_kernel_offset = 4;
+    // Proof of work metadata
+    ProofOfWork pow = 5;
+}
+
+// The new block template is used constructing a new partial block, allowing a miner to added the coinbase utxo and as a final step the Base node to add the MMR roots to the header.
+message NewBlockTemplate {
+    NewBlockHeaderTemplate header = 1;
+    tari.types.AggregateBody body = 2;
+}

--- a/base_layer/core/src/test_utils/builders.rs
+++ b/base_layer/core/src/test_utils/builders.rs
@@ -272,7 +272,7 @@ pub fn create_test_kernel(fee: MicroTari, lock_height: u64) -> TransactionKernel
 /// Right now this function does not use consensus rules to generate the block. The coinbase output has an arbitrary
 /// value, and the maturity is zero.
 pub fn create_genesis_block(factories: &CryptoFactories) -> (Block, UnblindedOutput) {
-    let mut header = BlockHeader::new(0);
+    let header = BlockHeader::new(0);
     let value = MicroTari::from(100_000_000);
     let excess = Commitment::from_public_key(&PublicKey::default());
     let (utxo, key) = create_utxo(value, &factories);
@@ -318,7 +318,7 @@ pub fn create_test_block(block_height: u64, prev_block: Option<Block>, transacti
 
 /// Create a new block using the provided transactions that adds to the blockchain given in `prev_block`
 pub fn chain_block(prev_block: &Block, transactions: Vec<Transaction>) -> Block {
-    let mut header = BlockHeader::from_previous(&prev_block.header);
+    let header = BlockHeader::from_previous(&prev_block.header);
     BlockBuilder::new()
         .with_header(header)
         .with_transactions(transactions)


### PR DESCRIPTION
## Description
- Added GetNewBlock Base node service request and modified the NewBlockTemplate response to return a block template.
- Block and header templates were introduced that can be used to construct new partial blocks.
- When a miner submits a block template, the base node will update the header with the correct MMR roots and return the block to the miner.
- Added proto requests and responses for GetNewBlock and NewBlock. Proto conversions for NewBlockTemplate and NewBlockHeaderTemplate were also added..
- Fetch_future_mmr_root was added to Blockchain_db, Memory_db and Lmdb_db. This allows the MMR roots to be calculated using the provided change set without altering the MMRs of the current longest chain. This functionality is required to construct a valid new mineable block.
- The RewindMmr write operation of Memory_db and Lmdb_db was altered to allow step_back of 0, when 0 is provided then the MMRs are reset and the current uncommitted changes are discarded. 

## Motivation and Context
A multi stage mineable block construction process is required to allow the Base Node to construct the initial block with transactions, allow the miner to add the coinbase and finally allow the Base node to update the MMR roots in the header.

## How Has This Been Tested?
Added a test to demonstrate the mineable block creation process and other tests for testing the calculation of future MMR roots.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [x] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch
* [x] I ran `cargo-fmt --all` before pushing
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
