### PR TITLE
Request Tx state from Mempool Service

### DIFF
--- a/base_layer/core/src/base_node/test/service.rs
+++ b/base_layer/core/src/base_node/test/service.rs
@@ -742,7 +742,7 @@ fn service_request_timeout() {
     let runtime = Runtime::new().unwrap();
     let mut rng = OsRng::new().unwrap();
     let base_node_service_config = BaseNodeServiceConfig {
-        request_timeout: Duration::from_millis(10),
+        request_timeout: Duration::from_millis(1),
         desired_response_fraction: BASE_NODE_SERVICE_DESIRED_RESPONSE_FRACTION,
     };
 

--- a/base_layer/core/src/mempool/mempool.rs
+++ b/base_layer/core/src/mempool/mempool.rs
@@ -36,7 +36,7 @@ use std::sync::Arc;
 use tari_transactions::{transaction::Transaction, types::Signature};
 use tari_utilities::hash::Hashable;
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
 pub enum TxStorageResponse {
     UnconfirmedPool,
     OrphanPool,

--- a/base_layer/core/src/mempool/proto/mempool_request.rs
+++ b/base_layer/core/src/mempool/proto/mempool_request.rs
@@ -23,6 +23,7 @@
 use super::mempool::mempool_service_request::Request as ProtoMempoolRequest;
 use crate::mempool::service::MempoolRequest;
 use std::convert::TryInto;
+use tari_utilities::ByteArrayError;
 
 impl TryInto<MempoolRequest> for ProtoMempoolRequest {
     type Error = String;
@@ -32,6 +33,9 @@ impl TryInto<MempoolRequest> for ProtoMempoolRequest {
         let request = match self {
             // Field was not specified
             GetStats(_) => MempoolRequest::GetStats,
+            GetTxStateWithExcessSig(excess_sig) => MempoolRequest::GetTxStateWithExcessSig(
+                excess_sig.try_into().map_err(|err: ByteArrayError| err.to_string())?,
+            ),
         };
         Ok(request)
     }
@@ -42,6 +46,7 @@ impl From<MempoolRequest> for ProtoMempoolRequest {
         use MempoolRequest::*;
         match request {
             GetStats => ProtoMempoolRequest::GetStats(true),
+            GetTxStateWithExcessSig(excess_sig) => ProtoMempoolRequest::GetTxStateWithExcessSig(excess_sig.into()),
         }
     }
 }

--- a/base_layer/core/src/mempool/proto/mempool_response.rs
+++ b/base_layer/core/src/mempool/proto/mempool_response.rs
@@ -21,7 +21,7 @@
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 use super::mempool::mempool_service_response::Response as ProtoMempoolResponse;
-use crate::mempool::service::MempoolResponse;
+use crate::mempool::{proto::mempool::TxStorageResponse as ProtoTxStorageResponse, service::MempoolResponse};
 use std::convert::TryInto;
 
 impl TryInto<MempoolResponse> for ProtoMempoolResponse {
@@ -31,6 +31,11 @@ impl TryInto<MempoolResponse> for ProtoMempoolResponse {
         use ProtoMempoolResponse::*;
         let response = match self {
             Stats(stats_response) => MempoolResponse::Stats(stats_response.try_into()?),
+            TxStorage(tx_storage_response) => {
+                let tx_storage_response = ProtoTxStorageResponse::from_i32(tx_storage_response)
+                    .ok_or("Invalid or unrecognised `TxStorageResponse` enum".to_string())?;
+                MempoolResponse::TxStorage(tx_storage_response.try_into()?)
+            },
         };
         Ok(response)
     }
@@ -41,6 +46,10 @@ impl From<MempoolResponse> for ProtoMempoolResponse {
         use MempoolResponse::*;
         match response {
             Stats(stats_response) => ProtoMempoolResponse::Stats(stats_response.into()),
+            TxStorage(tx_storage_response) => {
+                let tx_storage_response: ProtoTxStorageResponse = tx_storage_response.into();
+                ProtoMempoolResponse::TxStorage(tx_storage_response.into())
+            },
         }
     }
 }

--- a/base_layer/core/src/mempool/proto/mod.rs
+++ b/base_layer/core/src/mempool/proto/mod.rs
@@ -20,6 +20,9 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+// Required for `super::types` used in generated files
+use tari_transactions::proto::types;
+
 pub mod mempool {
     tari_utilities::include_proto_package!("tari.mempool");
 }
@@ -27,5 +30,6 @@ pub mod mempool {
 pub mod mempool_request;
 pub mod mempool_response;
 pub mod stats_response;
+pub mod tx_storage_response;
 
 pub use mempool::{MempoolServiceRequest, MempoolServiceResponse};

--- a/base_layer/core/src/mempool/proto/service_request.proto
+++ b/base_layer/core/src/mempool/proto/service_request.proto
@@ -1,12 +1,16 @@
 syntax = "proto3";
 
+import "types.proto";
+
 package tari.mempool;
 
 // Request type for a received MempoolService request.
 message MempoolServiceRequest {
     uint64 request_key = 1;
     oneof request {
-        // Indicates a Stats request. The value of the bool should be ignored.
+        // Indicates a GetStats request. The value of the bool should be ignored.
         bool get_stats = 2;
+        // Indicates a GetTxStateWithExcessSig request.
+        tari.types.Signature get_tx_state_with_excess_sig = 3;
     }
 }

--- a/base_layer/core/src/mempool/proto/service_response.proto
+++ b/base_layer/core/src/mempool/proto/service_response.proto
@@ -1,6 +1,7 @@
 syntax = "proto3";
 
 import "stats_response.proto";
+import "tx_storage_response.proto";
 
 package tari.mempool;
 
@@ -9,6 +10,7 @@ message MempoolServiceResponse {
     uint64 request_key = 1;
     oneof response {
         StatsResponse stats = 2;
+        TxStorageResponse tx_storage = 3;
     }
 }
 

--- a/base_layer/core/src/mempool/proto/tx_storage_response.proto
+++ b/base_layer/core/src/mempool/proto/tx_storage_response.proto
@@ -1,0 +1,14 @@
+syntax = "proto3";
+
+import "google/protobuf/wrappers.proto";
+
+package tari.mempool;
+
+enum TxStorageResponse {
+    TxStorageResponseNone = 0;
+    TxStorageResponseUnconfirmedPool = 1;
+    TxStorageResponseOrphanPool = 2;
+    TxStorageResponsePendingPool = 3;
+    TxStorageResponseReorgPool = 4;
+    TxStorageResponseNotStored = 5;
+}

--- a/base_layer/core/src/mempool/proto/tx_storage_response.rs
+++ b/base_layer/core/src/mempool/proto/tx_storage_response.rs
@@ -1,4 +1,4 @@
-// Copyright 2019 The Tari Project
+// Copyright 2019, The Tari Project
 //
 // Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
 // following conditions are met:
@@ -20,22 +20,34 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use crate::mempool::{
-    mempool::{StatsResponse, TxStorageResponse},
-    service::RequestKey,
-};
-use serde::{Deserialize, Serialize};
+use crate::mempool::{mempool::TxStorageResponse, proto::mempool::TxStorageResponse as ProtoTxStorageResponse};
+use std::convert::TryFrom;
 
-/// API Response enum for Mempool responses.
-#[derive(Debug, Serialize, Deserialize)]
-pub enum MempoolResponse {
-    Stats(StatsResponse),
-    TxStorage(TxStorageResponse),
+impl TryFrom<ProtoTxStorageResponse> for TxStorageResponse {
+    type Error = String;
+
+    fn try_from(tx_storage: ProtoTxStorageResponse) -> Result<Self, Self::Error> {
+        use ProtoTxStorageResponse::*;
+        Ok(match tx_storage {
+            None => return Err("TxStorageResponse not provided".to_string()),
+            UnconfirmedPool => TxStorageResponse::UnconfirmedPool,
+            OrphanPool => TxStorageResponse::OrphanPool,
+            PendingPool => TxStorageResponse::PendingPool,
+            ReorgPool => TxStorageResponse::ReorgPool,
+            NotStored => TxStorageResponse::NotStored,
+        })
+    }
 }
 
-/// Response type for a received MempoolService requests
-#[derive(Debug, Serialize, Deserialize)]
-pub struct MempoolServiceResponse {
-    pub request_key: RequestKey,
-    pub response: MempoolResponse,
+impl From<TxStorageResponse> for ProtoTxStorageResponse {
+    fn from(tree: TxStorageResponse) -> Self {
+        use TxStorageResponse::*;
+        match tree {
+            UnconfirmedPool => ProtoTxStorageResponse::UnconfirmedPool,
+            OrphanPool => ProtoTxStorageResponse::OrphanPool,
+            PendingPool => ProtoTxStorageResponse::PendingPool,
+            ReorgPool => ProtoTxStorageResponse::ReorgPool,
+            NotStored => ProtoTxStorageResponse::NotStored,
+        }
+    }
 }

--- a/base_layer/core/src/mempool/service/inbound_handlers.rs
+++ b/base_layer/core/src/mempool/service/inbound_handlers.rs
@@ -48,9 +48,12 @@ where T: BlockchainBackend
 
     /// Handle inbound Mempool service requests from remote nodes and local services.
     pub async fn handle_request(&self, request: &MempoolRequest) -> Result<MempoolResponse, MempoolServiceError> {
+        // TODO: make mempool calls async
         match request {
-            MempoolRequest::GetStats => Ok(MempoolResponse::Stats(self.mempool.stats()?)), /* TODO: make mempool
-                                                                                            * calls async */
+            MempoolRequest::GetStats => Ok(MempoolResponse::Stats(self.mempool.stats()?)),
+            MempoolRequest::GetTxStateWithExcessSig(excess_sig) => Ok(MempoolResponse::TxStorage(
+                self.mempool.has_tx_with_excess_sig(excess_sig)?,
+            )),
         }
     }
 

--- a/base_layer/core/src/mempool/service/outbound_interface.rs
+++ b/base_layer/core/src/mempool/service/outbound_interface.rs
@@ -21,10 +21,11 @@
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 use crate::mempool::{
-    mempool::StatsResponse,
+    mempool::{StatsResponse, TxStorageResponse},
     service::{MempoolRequest, MempoolResponse, MempoolServiceError},
 };
 use tari_service_framework::reply_channel::SenderService;
+use tari_transactions::types::Signature;
 use tower_service::Service;
 
 /// The OutboundMempoolServiceInterface provides an interface to request information from the Mempools of remote Base
@@ -44,6 +45,23 @@ impl OutboundMempoolServiceInterface {
     pub async fn get_stats(&mut self) -> Result<StatsResponse, MempoolServiceError> {
         if let MempoolResponse::Stats(stats) = self.request_sender.call(MempoolRequest::GetStats).await?? {
             Ok(stats)
+        } else {
+            Err(MempoolServiceError::UnexpectedApiResponse)
+        }
+    }
+
+    /// Check if the specified transaction is stored in the mempool of a remote base node.
+    pub async fn get_tx_state_with_excess_sig(
+        &mut self,
+        excess_sig: Signature,
+    ) -> Result<TxStorageResponse, MempoolServiceError>
+    {
+        if let MempoolResponse::TxStorage(tx_storage_response) = self
+            .request_sender
+            .call(MempoolRequest::GetTxStateWithExcessSig(excess_sig))
+            .await??
+        {
+            Ok(tx_storage_response)
         } else {
             Err(MempoolServiceError::UnexpectedApiResponse)
         }

--- a/base_layer/core/src/mempool/service/request.rs
+++ b/base_layer/core/src/mempool/service/request.rs
@@ -22,6 +22,7 @@
 
 use rand::RngCore;
 use serde::{Deserialize, Serialize};
+use tari_transactions::types::Signature;
 
 pub type RequestKey = u64; // TODO: BaseNodeService and MempoolService uses RequestKey
 
@@ -35,6 +36,7 @@ where R: RngCore {
 #[derive(Debug, Serialize, Deserialize)]
 pub enum MempoolRequest {
     GetStats,
+    GetTxStateWithExcessSig(Signature),
 }
 
 /// Request type for a received MempoolService request.


### PR DESCRIPTION
## Description
- Added ability to request from the MempoolService if a transaction is stored in the Mempool and where in the Mempool the transaction is located.
- The transactions excess signature is used to uniquely identify the transaction.
- The TxStorageResponse proto enum was added with conversions.

## Motivation and Context
This PR allows remote nodes to query if a transaction is in the Mempool and in which subpool the transaction is located.

## How Has This Been Tested?
A test was added to test the get transaction using excess sig request and a test for service request timeouts. 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [x] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch
* [x] I ran `cargo-fmt --all` before pushing
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
