### PR TITLE
Introduce the validation pipeline

### DIFF
--- a/base_layer/core/src/consts.rs
+++ b/base_layer/core/src/consts.rs
@@ -52,4 +52,4 @@ pub const BASE_NODE_SERVICE_REQUEST_TIMEOUT: Duration = Duration::from_secs(60);
 pub const BASE_NODE_SERVICE_DESIRED_RESPONSE_FRACTION: f32 = 0.6;
 
 /// The allocated waiting time for a request waiting for service responses from the mempools of remote base nodes.
-pub const MEMPOOL_SERVICE_REQUEST_TIMEOUT: Duration = Duration::from_secs(5);
+pub const MEMPOOL_SERVICE_REQUEST_TIMEOUT: Duration = Duration::from_secs(60);

--- a/base_layer/core/src/lib.rs
+++ b/base_layer/core/src/lib.rs
@@ -42,6 +42,7 @@ pub mod base_node;
 pub mod blocks;
 
 pub mod chain_storage;
+pub mod validation;
 
 // Re-export the crypto crate to make exposing traits etc easier for clients of this crate
 pub use tari_crypto as crypto;

--- a/base_layer/core/src/validation/error.rs
+++ b/base_layer/core/src/validation/error.rs
@@ -20,4 +20,40 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-pub struct BlockValidationService;
+use derive_error::Error;
+use tari_transactions::transaction::TransactionError;
+
+#[derive(Clone, Debug, PartialEq, Error)]
+pub enum ValidationError {
+    BlockError(BlockValidationError),
+    BodyError(BodyValidationError),
+    /// Custom error with string message
+    InvalidRangeProof,
+    /// Custom error with string message
+    #[error(no_from, non_std, msg_embedded)]
+    CustomError(String),
+}
+
+#[derive(Clone, Debug, PartialEq, Error)]
+pub enum BlockValidationError {
+    /// A transaction in the block failed to validate
+    TransactionError(TransactionError),
+    /// Invalid Proof of work for the block
+    InvalidPow,
+    /// Invalid kernel in block
+    InvalidKernel,
+    /// Invalid input in block
+    InvalidInput,
+    /// Input maturity not reached
+    InputMaturity,
+    /// Invalid coinbase maturity in block or more than one coinbase
+    InvalidCoinbase,
+}
+
+#[derive(Clone, Debug, PartialEq, Error)]
+pub enum BodyValidationError {
+    /// The sum of the input and output commitments doesn't equal the sum of the kernel excesses
+    InconsistentCommitmentSum,
+    /// A kernel signature was invalid
+    InvalidKernelSignature,
+}

--- a/base_layer/core/src/validation/mocks.rs
+++ b/base_layer/core/src/validation/mocks.rs
@@ -1,0 +1,91 @@
+// Copyright 2019. The Tari Project
+//
+// Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+// following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+// disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+// following disclaimer in the documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+// products derived from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+// INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+// WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+// USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+use super::Validation;
+use crate::validation::{error::ValidationError, ValidationPipeline};
+use std::sync::Arc;
+
+pub struct MockValidator {
+    result: bool,
+}
+
+impl MockValidator {
+    pub fn new(is_valid: bool) -> MockValidator {
+        MockValidator { result: is_valid }
+    }
+}
+
+impl<T> Validation<T> for MockValidator {
+    fn validate(&mut self, _item: Arc<T>) -> Result<(), ValidationError> {
+        match self.result {
+            true => Ok(()),
+            false => Err(ValidationError::CustomError(
+                "This mock validator always returns an error".into(),
+            )),
+        }
+    }
+}
+
+/// Creates a [ValidationPipeline] that always validates
+pub fn new_valid_pipeline<T>() -> ValidationPipeline<T> {
+    ValidationPipeline::default()
+}
+
+/// Creates a [ValidationPipeline] that always returns an error
+pub fn new_invalid_pipeline<T>() -> ValidationPipeline<T> {
+    let mut pipeline = ValidationPipeline::default();
+    pipeline.push(MockValidator::new(false));
+    pipeline
+}
+
+#[cfg(test)]
+mod test {
+    use crate::validation::{
+        mocks::{new_invalid_pipeline, new_valid_pipeline, MockValidator},
+        Validation,
+    };
+    use std::sync::Arc;
+
+    #[test]
+    fn mock_is_valid() {
+        let mut validator = MockValidator::new(true);
+        assert!(validator.validate(Arc::new(())).is_ok());
+    }
+
+    #[test]
+    fn mock_is_invalid() {
+        let mut validator = MockValidator::new(false);
+        assert!(validator.validate(Arc::new(())).is_err());
+    }
+
+    #[test]
+    fn valid_pipeline() {
+        let mut pipeline = new_valid_pipeline();
+        assert!(pipeline.validate(Arc::new(())).is_ok());
+    }
+
+    #[test]
+    fn invalid_pipeline() {
+        let mut pipeline = new_invalid_pipeline();
+        assert!(pipeline.validate(Arc::new(())).is_err());
+    }
+}

--- a/base_layer/core/src/validation/mod.rs
+++ b/base_layer/core/src/validation/mod.rs
@@ -20,4 +20,26 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-pub struct TransactionValidationService;
+//! The validation module defines the [Validation] trait which describes all code that can perform block,
+//! transaction, or other validation tasks. Validators implement the [Validation] trait and can be chained together
+//! in a [ValidationPipeline] object to carry out complex validation routines.
+//!
+//! This module also defines a mock [MockValidator] that is useful for testing components that require validation
+//! without having to bring in all sorts of blockchain and communications paraphernalia.
+
+use error::ValidationError;
+use std::sync::Arc;
+
+/// The core validation trait. Multiple `Validation` implementors can be chained together in a [ValidatorPipeline] to
+/// provide consensus validation for blocks, transactions, or DAN instructions. Implementors only need to implement
+/// the methods that are relevant for the pipeline, since the default implementation always passes.
+pub trait Validation<T> {
+    /// General validation code that can run independent of external state
+    fn validate(&mut self, item: Arc<T>) -> Result<(), ValidationError>;
+}
+
+mod error;
+mod pipeline;
+
+pub mod mocks;
+pub use pipeline::ValidationPipeline;

--- a/base_layer/core/src/validation/pipeline.rs
+++ b/base_layer/core/src/validation/pipeline.rs
@@ -1,0 +1,110 @@
+// Copyright 2019. The Tari Project
+//
+// Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+// following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+// disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+// following disclaimer in the documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+// products derived from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+// INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+// WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+// USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+use super::Validation;
+use crate::validation::error::ValidationError;
+use std::sync::Arc;
+
+type Pipelined<T> = Box<dyn Validation<T>>;
+
+/// A validation pipeline. Multiple validators (structs that implement [Validation]) can be chained together to form a
+/// validation pipeline. `ValidationPipeline implements [Validation] itself, and the pipeline is valid _if and only
+/// if_ every validator it contains is valid.
+///
+/// # Example
+///
+/// ```edition2018
+///     use tari_core::validation::{mocks::MockValidator, Validation, ValidationPipeline};
+///     use tari_core::blocks::BlockBuilder;
+///     use std::sync::Arc;
+///
+///     let block = Arc::new(BlockBuilder::new().build());
+///     let mut pipeline = ValidationPipeline::new();
+///     pipeline.push(MockValidator::new(true));
+///     assert!(pipeline.validate(block).is_ok());
+/// ```
+
+pub struct ValidationPipeline<T> {
+    validators: Vec<Pipelined<T>>,
+}
+
+impl<T> Default for ValidationPipeline<T> {
+    fn default() -> Self {
+        ValidationPipeline { validators: Vec::new() }
+    }
+}
+
+impl<T> ValidationPipeline<T> {
+    /// Create a new empty validation pipeline.
+    pub fn new() -> Self {
+        ValidationPipeline::default()
+    }
+
+    /// Add a validator to the pipeline. Validators are executed in the order the are added.
+    pub fn push<V: 'static + Validation<T>>(&mut self, validator: V) {
+        self.validators.push(Box::new(validator))
+    }
+}
+
+impl<T> Validation<T> for ValidationPipeline<T> {
+    fn validate(&mut self, item: Arc<T>) -> Result<(), ValidationError> {
+        for v in &mut self.validators {
+            let _ = v.validate(Arc::clone(&item))?;
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::{
+        blocks::{Block, BlockBuilder},
+        validation::{mocks::MockValidator, Validation, ValidationPipeline},
+    };
+    use std::sync::Arc;
+
+    #[test]
+    fn empty_pipeline() {
+        let mut pipeline = ValidationPipeline::<()>::new();
+        assert!(pipeline.validate(Arc::new(())).is_ok());
+    }
+
+    #[test]
+    fn valid_pipeline() {
+        let block = Arc::new(BlockBuilder::new().build());
+        let mut pipeline = ValidationPipeline::<Block>::new();
+        pipeline.push(MockValidator::new(true));
+        pipeline.push(MockValidator::new(true));
+        pipeline.push(MockValidator::new(true));
+        assert!(pipeline.validate(block).is_ok());
+    }
+
+    #[test]
+    fn invalid_pipeline() {
+        let block = Arc::new(BlockBuilder::new().build());
+        let mut pipeline = ValidationPipeline::<Block>::new();
+        pipeline.push(MockValidator::new(true));
+        pipeline.push(MockValidator::new(false));
+        pipeline.push(MockValidator::new(true));
+        assert!(pipeline.validate(block).is_err());
+    }
+}

--- a/base_layer/core/src/validation/traits.rs
+++ b/base_layer/core/src/validation/traits.rs
@@ -20,17 +20,14 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-//! The validation module defines the [Validation] trait which describes all code that can perform block,
-//! transaction, or other validation tasks. Validators implement the [Validation] trait and can be chained together
-//! in a [ValidationPipeline] object to carry out complex validation routines.
-//!
-//! This module also defines a mock [MockValidator] that is useful for testing components that require validation
-//! without having to bring in all sorts of blockchain and communications paraphernalia.
+use crate::validation::error::ValidationError;
+use std::sync::Arc;
 
-mod error;
-mod traits;
-mod pipeline;
+/// The core validation trait. Multiple `Validation` implementors can be chained together in a [ValidatorPipeline] to
+/// provide consensus validation for blocks, transactions, or DAN instructions. Implementors only need to implement
+/// the methods that are relevant for the pipeline, since the default implementation always passes.
+pub trait Validation<T> {
+    /// General validation code that can run independent of external state
+    fn validate(&mut self, item: Arc<T>) -> Result<(), ValidationError>;
+}
 
-pub mod mocks;
-pub use traits::Validation;
-pub use pipeline::ValidationPipeline;

--- a/base_layer/wallet/Cargo.toml
+++ b/base_layer/wallet/Cargo.toml
@@ -23,7 +23,7 @@ time = {version = "0.1.39"}
 derive-error = "0.0.4"
 digest = "0.8.0"
 serde = {version = "1.0.89", features = ["derive"] }
-serde_json = "1.0"
+serde_json = "1.0.39"
 crossbeam-channel = "0.3.8"
 log = "0.4.6"
 log4rs = {version = "0.8.3", features = ["console_appender", "file_appender", "file", "yaml_format"]}
@@ -40,7 +40,7 @@ tempdir = "0.3.7"
 [dev-dependencies]
 env_logger = "0.6.2"
 prost = "0.5.0"
-tari_test_utils = {path="../../infrastructure/test_utils"}
+tari_test_utils = { path = "../../infrastructure/test_utils", version = "^0.0"}
 
 [features]
 test_harness = []

--- a/base_layer/wallet/migrations/2019-06-26-130555_initial/down.sql
+++ b/base_layer/wallet/migrations/2019-06-26-130555_initial/down.sql
@@ -1,4 +1,3 @@
-DROP TABLE IF EXISTS sent_messages;
-DROP TABLE IF EXISTS received_messages;
-DROP TABLE IF EXISTS contacts;
-DROP TABLE IF EXISTS settings;
+-- DROP TABLE IF EXISTS sent_messages;
+-- DROP TABLE IF EXISTS received_messages;
+-- DROP TABLE IF EXISTS settings;

--- a/base_layer/wallet/migrations/2019-06-26-130555_initial/up.sql
+++ b/base_layer/wallet/migrations/2019-06-26-130555_initial/up.sql
@@ -1,29 +1,25 @@
-CREATE TABLE sent_messages (
-   id TEXT PRIMARY KEY NOT NULL,
-   source_pub_key TEXT NOT NULL,
-   dest_pub_key TEXT NOT NULL,
-   message TEXT  NOT NULL,
-   timestamp DATETIME NOT NULL,
-   acknowledged INTEGER NOT NULL DEFAULT 0,
-   is_read INTEGER NOT NULL DEFAULT 0,
-   FOREIGN KEY(dest_pub_key) REFERENCES contacts(pub_key)
-);
+-- CREATE TABLE sent_messages (
+--    id TEXT PRIMARY KEY NOT NULL,
+--    source_pub_key TEXT NOT NULL,
+--    dest_pub_key TEXT NOT NULL,
+--    message TEXT  NOT NULL,
+--    timestamp DATETIME NOT NULL,
+--    acknowledged INTEGER NOT NULL DEFAULT 0,
+--    is_read INTEGER NOT NULL DEFAULT 0,
+--    FOREIGN KEY(dest_pub_key) REFERENCES contacts(pub_key)
+-- );
 
-CREATE TABLE received_messages (
-    id BLOB PRIMARY KEY NOT NULL,
-    source_pub_key TEXT NOT NULL,
-    dest_pub_key TEXT NOT NULL,
-    message TEXT  NOT NULL,
-    timestamp DATETIME NOT NULL
-);
+-- CREATE TABLE received_messages (
+--     id BLOB PRIMARY KEY NOT NULL,
+--     source_pub_key TEXT NOT NULL,
+--     dest_pub_key TEXT NOT NULL,
+--     message TEXT  NOT NULL,
+--     timestamp DATETIME NOT NULL
+-- );
 
-CREATE TABLE contacts (
-    pub_key TEXT PRIMARY KEY NOT NULL UNIQUE,
-    screen_name TEXT NOT NULL,
-    address TEXT NOT NULL
-);
+-- CREATE TABLE settings (
+--     pub_key TEXT PRIMARY KEY NOT NULL,
+--     screen_name TEXT NOT NULL
+-- )
 
-CREATE TABLE settings (
-    pub_key TEXT PRIMARY KEY NOT NULL,
-    screen_name TEXT NOT NULL
-)
+

--- a/base_layer/wallet/migrations/2019-11-26-105357_contacts/down.sql
+++ b/base_layer/wallet/migrations/2019-11-26-105357_contacts/down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS contacts;

--- a/base_layer/wallet/migrations/2019-11-26-105357_contacts/up.sql
+++ b/base_layer/wallet/migrations/2019-11-26-105357_contacts/up.sql
@@ -1,0 +1,4 @@
+CREATE TABLE contacts (
+    public_key BLOB PRIMARY KEY NOT NULL UNIQUE,
+    alias TEXT NOT NULL
+);

--- a/base_layer/wallet/migrations/2019-11-26-120903_peers/down.sql
+++ b/base_layer/wallet/migrations/2019-11-26-120903_peers/down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS peers;

--- a/base_layer/wallet/migrations/2019-11-26-120903_peers/up.sql
+++ b/base_layer/wallet/migrations/2019-11-26-120903_peers/up.sql
@@ -1,0 +1,4 @@
+CREATE TABLE peers (
+    public_key BLOB PRIMARY KEY NOT NULL UNIQUE,
+    peer TEXT NOT NULL
+);

--- a/base_layer/wallet/src/contacts_service/error.rs
+++ b/base_layer/wallet/src/contacts_service/error.rs
@@ -22,6 +22,7 @@
 
 use crate::contacts_service::storage::database::DbKey;
 use derive_error::Error;
+use diesel::result::Error as DieselError;
 use tari_service_framework::reply_channel::TransportChannelError;
 
 #[derive(Debug, Error, PartialEq)]
@@ -40,8 +41,17 @@ pub enum ContactsServiceStorageError {
     DuplicateContact,
     /// This write operation is not supported for provided DbKey
     OperationNotSupported,
+    /// Error converting a type
+    ConversionError,
+    /// Could not find all values specified for batch operation
+    ValuesNotFound,
     #[error(non_std, no_from)]
     ValueNotFound(DbKey),
     #[error(msg_embedded, non_std, no_from)]
     UnexpectedResult(String),
+    R2d2Error,
+    DieselError(DieselError),
+    DieselConnectionError(diesel::ConnectionError),
+    #[error(msg_embedded, no_from, non_std)]
+    DatabaseMigrationError(String),
 }

--- a/base_layer/wallet/src/contacts_service/storage/database.rs
+++ b/base_layer/wallet/src/contacts_service/storage/database.rs
@@ -48,7 +48,7 @@ pub enum DbKey {
 
 pub enum DbValue {
     Contact(Box<Contact>),
-    Contacts(Box<Vec<Contact>>),
+    Contacts(Vec<Contact>),
 }
 
 pub enum DbKeyValuePair {
@@ -96,7 +96,7 @@ where T: ContactsBackend
                 DbKey::Contacts,
                 ContactsServiceStorageError::UnexpectedResult("Could not retrieve contacts".to_string()),
             ),
-            Ok(Some(DbValue::Contacts(c))) => Ok(*c),
+            Ok(Some(DbValue::Contacts(c))) => Ok(c),
             Ok(Some(other)) => unexpected_result(DbKey::Contacts, other),
             Err(e) => log_error(DbKey::Contacts, e),
         }?;

--- a/base_layer/wallet/src/contacts_service/storage/memory_db.rs
+++ b/base_layer/wallet/src/contacts_service/storage/memory_db.rs
@@ -57,7 +57,7 @@ impl ContactsBackend for ContactsServiceMemoryDatabase {
                 .iter()
                 .find(|v| &v.public_key == pk)
                 .map(|c| DbValue::Contact(Box::new(c.clone()))),
-            DbKey::Contacts => Some(DbValue::Contacts(Box::new(db.contacts.clone()))),
+            DbKey::Contacts => Some(DbValue::Contacts(db.contacts.clone())),
         };
 
         Ok(result)

--- a/base_layer/wallet/src/contacts_service/storage/mod.rs
+++ b/base_layer/wallet/src/contacts_service/storage/mod.rs
@@ -22,3 +22,4 @@
 
 pub mod database;
 pub mod memory_db;
+pub mod sqlite_db;

--- a/base_layer/wallet/src/contacts_service/storage/sqlite_db.rs
+++ b/base_layer/wallet/src/contacts_service/storage/sqlite_db.rs
@@ -1,0 +1,281 @@
+// Copyright 2019. The Tari Project
+//
+// Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+// following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+// disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+// following disclaimer in the documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+// products derived from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+// INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+// WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+// USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+use crate::{
+    contacts_service::{
+        error::ContactsServiceStorageError,
+        storage::database::{Contact, ContactsBackend, DbKey, DbKeyValuePair, DbValue, WriteOperation},
+    },
+    schema::contacts,
+};
+use diesel::{
+    prelude::*,
+    r2d2::{ConnectionManager, Pool, PooledConnection},
+    result::Error as DieselError,
+    SqliteConnection,
+};
+use std::{convert::TryFrom, io, path::Path, time::Duration};
+use tari_transactions::types::PublicKey;
+use tari_utilities::ByteArray;
+
+const DATABASE_CONNECTION_TIMEOUT_MS: u64 = 2000;
+
+/// A Sqlite backend for the Output Manager Service. The Backend is accessed via a connection pool to the Sqlite file.
+pub struct ContactsServiceSqliteDatabase {
+    database_connection_pool: Pool<ConnectionManager<SqliteConnection>>,
+}
+impl ContactsServiceSqliteDatabase {
+    pub fn new(database_path: String) -> Result<Self, ContactsServiceStorageError> {
+        let db_exists = Path::new(&database_path).exists();
+
+        let connection = SqliteConnection::establish(&database_path)?;
+
+        connection.execute("PRAGMA foreign_keys = ON")?;
+        if !db_exists {
+            embed_migrations!("./migrations");
+            embedded_migrations::run_with_output(&connection, &mut io::stdout()).map_err(|err| {
+                ContactsServiceStorageError::DatabaseMigrationError(format!("Database migration failed {}", err))
+            })?;
+        }
+        drop(connection);
+
+        let manager = ConnectionManager::<SqliteConnection>::new(database_path);
+        let pool = diesel::r2d2::Pool::builder()
+            .connection_timeout(Duration::from_millis(DATABASE_CONNECTION_TIMEOUT_MS))
+            .idle_timeout(Some(Duration::from_millis(DATABASE_CONNECTION_TIMEOUT_MS)))
+            .build(manager)
+            .map_err(|_| ContactsServiceStorageError::R2d2Error)?;
+
+        Ok(Self {
+            database_connection_pool: pool,
+        })
+    }
+}
+
+impl ContactsBackend for ContactsServiceSqliteDatabase {
+    fn fetch(&self, key: &DbKey) -> Result<Option<DbValue>, ContactsServiceStorageError> {
+        let conn = self
+            .database_connection_pool
+            .clone()
+            .get()
+            .map_err(|_| ContactsServiceStorageError::R2d2Error)?;
+
+        let result = match key {
+            DbKey::Contact(pk) => match ContactSql::find(&pk.to_vec(), &conn) {
+                Ok(c) => Some(DbValue::Contact(Box::new(Contact::try_from(c)?))),
+                Err(ContactsServiceStorageError::DieselError(DieselError::NotFound)) => None,
+                Err(e) => return Err(e),
+            },
+            DbKey::Contacts => Some(DbValue::Contacts(
+                ContactSql::index(&conn)?
+                    .iter()
+                    .map(|c| Contact::try_from(c.clone()))
+                    .collect::<Result<Vec<_>, _>>()?,
+            )),
+        };
+
+        Ok(result)
+    }
+
+    fn write(&mut self, op: WriteOperation) -> Result<Option<DbValue>, ContactsServiceStorageError> {
+        let conn = self
+            .database_connection_pool
+            .clone()
+            .get()
+            .map_err(|_| ContactsServiceStorageError::R2d2Error)?;
+
+        match op {
+            WriteOperation::Insert(kvp) => match kvp {
+                DbKeyValuePair::Contact(k, c) => {
+                    if let Ok(_) = ContactSql::find(&k.to_vec(), &conn) {
+                        return Err(ContactsServiceStorageError::DuplicateContact);
+                    }
+
+                    ContactSql::from(c).commit(&conn)?;
+                },
+            },
+            WriteOperation::Remove(k) => match k {
+                DbKey::Contact(k) => match ContactSql::find(&k.to_vec(), &conn) {
+                    Ok(c) => {
+                        c.clone().delete(&conn)?;
+                        return Ok(Some(DbValue::Contact(Box::new(Contact::try_from(c)?))));
+                    },
+                    Err(ContactsServiceStorageError::DieselError(DieselError::NotFound)) => (),
+                    Err(e) => return Err(e),
+                },
+                DbKey::Contacts => return Err(ContactsServiceStorageError::OperationNotSupported),
+            },
+        }
+
+        Ok(None)
+    }
+}
+
+/// A Sql version of the Contact struct
+#[derive(Clone, Debug, Queryable, Insertable, PartialEq)]
+#[table_name = "contacts"]
+struct ContactSql {
+    public_key: Vec<u8>,
+    alias: String,
+}
+
+impl ContactSql {
+    /// Write this struct to the database
+    pub fn commit(
+        &self,
+        conn: &PooledConnection<ConnectionManager<SqliteConnection>>,
+    ) -> Result<(), ContactsServiceStorageError>
+    {
+        diesel::insert_into(contacts::table)
+            .values(self.clone())
+            .execute(conn)?;
+        Ok(())
+    }
+
+    /// Return all contacts
+    pub fn index(
+        conn: &PooledConnection<ConnectionManager<SqliteConnection>>,
+    ) -> Result<Vec<ContactSql>, ContactsServiceStorageError> {
+        Ok(contacts::table.load::<ContactSql>(conn)?)
+    }
+
+    /// Find a particular Contact, if it exists
+    pub fn find(
+        public_key: &Vec<u8>,
+        conn: &PooledConnection<ConnectionManager<SqliteConnection>>,
+    ) -> Result<ContactSql, ContactsServiceStorageError>
+    {
+        Ok(contacts::table
+            .filter(contacts::public_key.eq(public_key))
+            .first::<ContactSql>(conn)?)
+    }
+
+    pub fn delete(
+        &self,
+        conn: &PooledConnection<ConnectionManager<SqliteConnection>>,
+    ) -> Result<(), ContactsServiceStorageError>
+    {
+        let num_deleted =
+            diesel::delete(contacts::table.filter(contacts::public_key.eq(&self.public_key))).execute(conn)?;
+
+        if num_deleted == 0 {
+            return Err(ContactsServiceStorageError::ValuesNotFound);
+        }
+
+        Ok(())
+    }
+}
+
+/// Conversion from an Contact to the Sql datatype form
+impl TryFrom<ContactSql> for Contact {
+    type Error = ContactsServiceStorageError;
+
+    fn try_from(o: ContactSql) -> Result<Self, Self::Error> {
+        Ok(Self {
+            public_key: PublicKey::from_vec(&o.public_key).map_err(|_| ContactsServiceStorageError::ConversionError)?,
+            alias: o.alias,
+        })
+    }
+}
+
+/// Conversion from an Contact to the Sql datatype form
+impl From<Contact> for ContactSql {
+    fn from(o: Contact) -> Self {
+        Self {
+            public_key: o.public_key.to_vec(),
+            alias: o.alias,
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::contacts_service::storage::{database::Contact, sqlite_db::ContactSql};
+    use diesel::{r2d2::ConnectionManager, Connection, SqliteConnection};
+    use std::convert::TryFrom;
+    use tari_crypto::keys::{PublicKey as PublicKeyTrait, SecretKey as SecretKeyTrait};
+    use tari_test_utils::random::string;
+    use tari_transactions::types::{PrivateKey, PublicKey};
+    use tari_utilities::ByteArray;
+    use tempdir::TempDir;
+
+    #[test]
+    fn test_crud() {
+        let mut rng = rand::OsRng::new().unwrap();
+
+        let db_name = format!("{}.sqlite3", string(8).as_str());
+        let db_folder = TempDir::new(string(8).as_str())
+            .unwrap()
+            .path()
+            .to_str()
+            .unwrap()
+            .to_string();
+        let db_path = format!("{}{}", db_folder, db_name);
+
+        embed_migrations!("./migrations");
+        let conn = SqliteConnection::establish(&db_path).unwrap_or_else(|_| panic!("Error connecting to {}", db_path));
+
+        embedded_migrations::run_with_output(&conn, &mut std::io::stdout()).expect("Migration failed");
+
+        let manager = ConnectionManager::<SqliteConnection>::new(db_path);
+        let pool = diesel::r2d2::Pool::builder().max_size(1).build(manager).unwrap();
+
+        let conn = pool.get().unwrap();
+        conn.execute("PRAGMA foreign_keys = ON").unwrap();
+
+        let names = ["Alice".to_string(), "Bob".to_string(), "Carol".to_string()];
+
+        let mut contacts = Vec::new();
+        for i in 0..names.len() {
+            let pub_key = PublicKey::from_secret_key(&PrivateKey::random(&mut rng));
+            contacts.push(Contact {
+                alias: names[i].clone(),
+                public_key: pub_key,
+            });
+            ContactSql::from(contacts[i].clone()).commit(&conn).unwrap();
+        }
+
+        let retrieved_contacts = ContactSql::index(&conn).unwrap();
+
+        for i in 0..contacts.len() {
+            assert!(retrieved_contacts
+                .iter()
+                .find(|v| v == &&ContactSql::from(contacts[i].clone()))
+                .is_some());
+        }
+
+        assert_eq!(
+            contacts[1],
+            Contact::try_from(ContactSql::find(&contacts[1].public_key.to_vec(), &conn).unwrap()).unwrap()
+        );
+
+        ContactSql::from(contacts[0].clone()).delete(&conn).unwrap();
+
+        let retrieved_contacts = ContactSql::index(&conn).unwrap();
+        assert_eq!(retrieved_contacts.len(), 2);
+
+        assert!(retrieved_contacts
+            .iter()
+            .find(|v| v == &&ContactSql::from(contacts[0].clone()))
+            .is_none());
+    }
+}

--- a/base_layer/wallet/src/error.rs
+++ b/base_layer/wallet/src/error.rs
@@ -26,10 +26,11 @@ use crate::{
     transaction_service::error::TransactionServiceError,
 };
 use derive_error::Error;
+use diesel::result::Error as DieselError;
 use log::SetLoggerError;
+use serde_json::Error as SerdeJsonError;
 use tari_comms::{builder::CommsError, connection::NetAddressError, peer_manager::PeerManagerError};
 use tari_p2p::initialization::CommsInitializationError;
-
 #[derive(Debug, Error)]
 pub enum WalletError {
     CommsInitializationError(CommsInitializationError),
@@ -42,12 +43,22 @@ pub enum WalletError {
     SetLoggerError(SetLoggerError),
 }
 
-#[derive(Debug, Error, PartialEq)]
+#[derive(Debug, Error)]
 pub enum WalletStorageError {
     /// Tried to insert an output that already exists in the database
     DuplicateContact,
     /// This write operation is not supported for provided DbKey
     OperationNotSupported,
+    /// Error converting a type
+    ConversionError,
+    /// Could not find all values specified for batch operation
+    ValuesNotFound,
+    SerdeJsonError(SerdeJsonError),
+    R2d2Error,
+    DieselError(DieselError),
+    DieselConnectionError(diesel::ConnectionError),
+    #[error(msg_embedded, no_from, non_std)]
+    DatabaseMigrationError(String),
     #[error(non_std, no_from)]
     ValueNotFound(DbKey),
     #[error(msg_embedded, non_std, no_from)]

--- a/base_layer/wallet/src/schema.rs
+++ b/base_layer/wallet/src/schema.rs
@@ -13,10 +13,9 @@ table! {
 }
 
 table! {
-    contacts (pub_key) {
-        pub_key -> Text,
-        screen_name -> Text,
-        address -> Text,
+    contacts (public_key) {
+        public_key -> Binary,
+        alias -> Text,
     }
 }
 
@@ -57,43 +56,20 @@ table! {
 }
 
 table! {
+    peers (public_key) {
+        public_key -> Binary,
+        peer -> Text,
+    }
+}
+
+table! {
     pending_transaction_outputs (tx_id) {
         tx_id -> BigInt,
         timestamp -> Timestamp,
     }
 }
 
-table! {
-    received_messages (id) {
-        id -> Binary,
-        source_pub_key -> Text,
-        dest_pub_key -> Text,
-        message -> Text,
-        timestamp -> Timestamp,
-    }
-}
-
-table! {
-    sent_messages (id) {
-        id -> Text,
-        source_pub_key -> Text,
-        dest_pub_key -> Text,
-        message -> Text,
-        timestamp -> Timestamp,
-        acknowledged -> Integer,
-        is_read -> Integer,
-    }
-}
-
-table! {
-    settings (pub_key) {
-        pub_key -> Text,
-        screen_name -> Text,
-    }
-}
-
 joinable!(outputs -> pending_transaction_outputs (tx_id));
-joinable!(sent_messages -> contacts (dest_pub_key));
 
 allow_tables_to_appear_in_same_query!(
     completed_transactions,
@@ -101,8 +77,6 @@ allow_tables_to_appear_in_same_query!(
     inbound_transactions,
     outbound_transactions,
     outputs,
+    peers,
     pending_transaction_outputs,
-    received_messages,
-    sent_messages,
-    settings,
 );

--- a/base_layer/wallet/src/storage/mod.rs
+++ b/base_layer/wallet/src/storage/mod.rs
@@ -22,3 +22,4 @@
 
 pub mod database;
 pub mod memory_db;
+pub mod sqlite_db;

--- a/base_layer/wallet/src/storage/sqlite_db.rs
+++ b/base_layer/wallet/src/storage/sqlite_db.rs
@@ -1,0 +1,202 @@
+// Copyright 2019. The Tari Project
+//
+// Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+// following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+// disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+// following disclaimer in the documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+// products derived from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+// INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+// WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+// USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+use crate::{
+    error::WalletStorageError,
+    schema::peers,
+    storage::database::{DbKey, DbKeyValuePair, DbValue, WalletBackend, WriteOperation},
+};
+use diesel::{
+    prelude::*,
+    r2d2::{ConnectionManager, Pool, PooledConnection},
+    result::Error as DieselError,
+    SqliteConnection,
+};
+use std::{convert::TryFrom, io, path::Path, time::Duration};
+use tari_comms::peer_manager::Peer;
+use tari_utilities::ByteArray;
+
+const DATABASE_CONNECTION_TIMEOUT_MS: u64 = 2000;
+
+/// A Sqlite backend for the Output Manager Service. The Backend is accessed via a connection pool to the Sqlite file.
+pub struct WalletSqliteDatabase {
+    database_connection_pool: Pool<ConnectionManager<SqliteConnection>>,
+}
+impl WalletSqliteDatabase {
+    pub fn new(database_path: String) -> Result<Self, WalletStorageError> {
+        let db_exists = Path::new(&database_path).exists();
+
+        let connection = SqliteConnection::establish(&database_path)?;
+
+        connection.execute("PRAGMA foreign_keys = ON")?;
+        if !db_exists {
+            embed_migrations!("./migrations");
+            embedded_migrations::run_with_output(&connection, &mut io::stdout()).map_err(|err| {
+                WalletStorageError::DatabaseMigrationError(format!("Database migration failed {}", err))
+            })?;
+        }
+        drop(connection);
+
+        let manager = ConnectionManager::<SqliteConnection>::new(database_path);
+        let pool = diesel::r2d2::Pool::builder()
+            .connection_timeout(Duration::from_millis(DATABASE_CONNECTION_TIMEOUT_MS))
+            .idle_timeout(Some(Duration::from_millis(DATABASE_CONNECTION_TIMEOUT_MS)))
+            .build(manager)
+            .map_err(|_| WalletStorageError::R2d2Error)?;
+
+        Ok(Self {
+            database_connection_pool: pool,
+        })
+    }
+}
+
+impl WalletBackend for WalletSqliteDatabase {
+    fn fetch(&self, key: &DbKey) -> Result<Option<DbValue>, WalletStorageError> {
+        let conn = self
+            .database_connection_pool
+            .clone()
+            .get()
+            .map_err(|_| WalletStorageError::R2d2Error)?;
+
+        let result = match key {
+            DbKey::Peer(pk) => match PeerSql::find(&pk.to_vec(), &conn) {
+                Ok(c) => Some(DbValue::Peer(Box::new(Peer::try_from(c)?))),
+                Err(WalletStorageError::DieselError(DieselError::NotFound)) => None,
+                Err(e) => return Err(e),
+            },
+            DbKey::Peers => Some(DbValue::Peers(
+                PeerSql::index(&conn)?
+                    .iter()
+                    .map(|c| Peer::try_from(c.clone()))
+                    .collect::<Result<Vec<_>, _>>()?,
+            )),
+        };
+
+        Ok(result)
+    }
+
+    fn write(&mut self, op: WriteOperation) -> Result<Option<DbValue>, WalletStorageError> {
+        let conn = self
+            .database_connection_pool
+            .clone()
+            .get()
+            .map_err(|_| WalletStorageError::R2d2Error)?;
+
+        match op {
+            WriteOperation::Insert(kvp) => match kvp {
+                DbKeyValuePair::Peer(k, p) => {
+                    if let Ok(_) = PeerSql::find(&k.to_vec(), &conn) {
+                        return Err(WalletStorageError::DuplicateContact);
+                    }
+
+                    PeerSql::try_from(p)?.commit(&conn)?;
+                },
+            },
+            WriteOperation::Remove(k) => match k {
+                DbKey::Peer(k) => match PeerSql::find(&k.to_vec(), &conn) {
+                    Ok(p) => {
+                        p.clone().delete(&conn)?;
+                        return Ok(Some(DbValue::Peer(Box::new(Peer::try_from(p)?))));
+                    },
+                    Err(WalletStorageError::DieselError(DieselError::NotFound)) => (),
+                    Err(e) => return Err(e),
+                },
+                DbKey::Peers => return Err(WalletStorageError::OperationNotSupported),
+            },
+        }
+
+        Ok(None)
+    }
+}
+
+/// A Sql version of the Peer struct
+#[derive(Clone, Debug, Queryable, Insertable, PartialEq)]
+#[table_name = "peers"]
+struct PeerSql {
+    public_key: Vec<u8>,
+    peer: String,
+}
+
+impl PeerSql {
+    /// Write this struct to the database
+    pub fn commit(
+        &self,
+        conn: &PooledConnection<ConnectionManager<SqliteConnection>>,
+    ) -> Result<(), WalletStorageError>
+    {
+        diesel::insert_into(peers::table).values(self.clone()).execute(conn)?;
+        Ok(())
+    }
+
+    /// Return all peers
+    pub fn index(
+        conn: &PooledConnection<ConnectionManager<SqliteConnection>>,
+    ) -> Result<Vec<PeerSql>, WalletStorageError> {
+        Ok(peers::table.load::<PeerSql>(conn)?)
+    }
+
+    /// Find a particular Peer, if it exists
+    pub fn find(
+        public_key: &Vec<u8>,
+        conn: &PooledConnection<ConnectionManager<SqliteConnection>>,
+    ) -> Result<PeerSql, WalletStorageError>
+    {
+        Ok(peers::table
+            .filter(peers::public_key.eq(public_key))
+            .first::<PeerSql>(conn)?)
+    }
+
+    pub fn delete(
+        &self,
+        conn: &PooledConnection<ConnectionManager<SqliteConnection>>,
+    ) -> Result<(), WalletStorageError>
+    {
+        let num_deleted = diesel::delete(peers::table.filter(peers::public_key.eq(&self.public_key))).execute(conn)?;
+
+        if num_deleted == 0 {
+            return Err(WalletStorageError::ValuesNotFound);
+        }
+
+        Ok(())
+    }
+}
+
+/// Conversion from an Contact to the Sql datatype form
+impl TryFrom<PeerSql> for Peer {
+    type Error = WalletStorageError;
+
+    fn try_from(p: PeerSql) -> Result<Self, Self::Error> {
+        Ok(serde_json::from_str(&p.peer)?)
+    }
+}
+
+/// Conversion from an Contact to the Sql datatype form
+impl TryFrom<Peer> for PeerSql {
+    type Error = WalletStorageError;
+
+    fn try_from(p: Peer) -> Result<Self, Self::Error> {
+        Ok(Self {
+            public_key: p.public_key.to_vec(),
+            peer: serde_json::to_string(&p)?,
+        })
+    }
+}

--- a/base_layer/wallet/tests/support/data.rs
+++ b/base_layer/wallet/tests/support/data.rs
@@ -22,6 +22,7 @@
 
 use crate::support::utils::random_string;
 use std::path::PathBuf;
+use tari_test_utils::random::string;
 use tempdir::TempDir;
 
 pub fn get_path(name: Option<&str>) -> String {


### PR DESCRIPTION
The idea of ValidationPipeline is to provide a unified approach to
validation; and one that makes testing easier as we approach full
set of consensus rules.

A validation pipeline contains a set of validators that must all
pass before the pipeline passes.

The pipeline can maintain state (such as a BlockchainDB instance)
in order to help with validation.

There are also mock validators provided so that we can keep unit tests
of different parts of the consensus model separate, without
having to rewrite tests every time we add another consesnsus rule
in development.

This also lets us keep all validation in one place, making maintainability easier.

