### PR TITLE
Only write generated proto structs if necessary

### DIFF
--- a/infrastructure/protobuf_build/Cargo.toml
+++ b/infrastructure/protobuf_build/Cargo.toml
@@ -13,3 +13,4 @@ edition = "2018"
 
 [dependencies]
 prost-build = "0.5.0"
+sha2 = "0.8.0"


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Generated protobuf structs were written on every build, which causes
rust to rebuild the crate.
This PR only writes a generated rust protobuf struct if necessary i.e.
if the hash of the files contents are different, and so prevents
unnecessary rebuilds.
