### PR TITLE
Request PoW target difficulty for miner from the base node

### DIFF
--- a/base_layer/core/src/base_node/comms_interface/comms_request.rs
+++ b/base_layer/core/src/base_node/comms_interface/comms_request.rs
@@ -20,7 +20,7 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use crate::{blocks::NewBlockTemplate, chain_storage::MmrTree};
+use crate::{blocks::NewBlockTemplate, chain_storage::MmrTree, proof_of_work::PowAlgorithm};
 use serde::{Deserialize, Serialize};
 use tari_transactions::types::HashOutput;
 
@@ -53,4 +53,5 @@ pub enum NodeCommsRequest {
     FetchMmrState(MmrStateRequest),
     GetNewBlockTemplate,
     GetNewBlock(NewBlockTemplate),
+    GetTargetDifficulty(PowAlgorithm),
 }

--- a/base_layer/core/src/base_node/comms_interface/comms_response.rs
+++ b/base_layer/core/src/base_node/comms_interface/comms_response.rs
@@ -23,6 +23,7 @@
 use crate::{
     blocks::{blockheader::BlockHeader, Block, NewBlockTemplate},
     chain_storage::{ChainMetadata, HistoricalBlock, MutableMmrState},
+    proof_of_work::Difficulty,
 };
 use serde::{Deserialize, Serialize};
 use tari_transactions::transaction::{TransactionKernel, TransactionOutput};
@@ -38,4 +39,5 @@ pub enum NodeCommsResponse {
     MmrState(MutableMmrState),
     NewBlockTemplate(NewBlockTemplate),
     NewBlock(Block),
+    TargetDifficulty(Difficulty),
 }

--- a/base_layer/core/src/base_node/comms_interface/error.rs
+++ b/base_layer/core/src/base_node/comms_interface/error.rs
@@ -20,7 +20,7 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use crate::chain_storage::ChainStorageError;
+use crate::{chain_storage::ChainStorageError, proof_of_work::DiffAdjManagerError};
 use derive_error::Error;
 use tari_service_framework::reply_channel::TransportChannelError;
 
@@ -39,4 +39,5 @@ pub enum CommsInterfaceError {
     MempoolError(String),
     /// Failure in broadcast DHT middleware
     BroadcastFailed,
+    DifficultyAdjustmentManagerError(DiffAdjManagerError),
 }

--- a/base_layer/core/src/base_node/comms_interface/inbound_handlers.rs
+++ b/base_layer/core/src/base_node/comms_interface/inbound_handlers.rs
@@ -33,6 +33,7 @@ use crate::{
         MmrTree,
     },
     mempool::Mempool,
+    proof_of_work::DiffAdjManager,
 };
 use futures::SinkExt;
 use tari_broadcast_channel::Publisher;
@@ -57,6 +58,7 @@ where T: BlockchainBackend
     event_publisher: Publisher<BlockEvent>,
     blockchain_db: BlockchainDatabase<T>,
     mempool: Mempool<T>,
+    diff_adj_manager: DiffAdjManager<T>,
 }
 
 impl<T> InboundNodeCommsHandlers<T>
@@ -67,12 +69,14 @@ where T: BlockchainBackend
         event_publisher: Publisher<BlockEvent>,
         blockchain_db: BlockchainDatabase<T>,
         mempool: Mempool<T>,
+        diff_adj_manager: DiffAdjManager<T>,
     ) -> Self
     {
         Self {
             event_publisher,
             blockchain_db,
             mempool,
+            diff_adj_manager,
         }
     }
 
@@ -180,6 +184,9 @@ where T: BlockchainBackend
 
                 Ok(NodeCommsResponse::NewBlock(Block { header, body }))
             },
+            NodeCommsRequest::GetTargetDifficulty(pow_algo) => Ok(NodeCommsResponse::TargetDifficulty(
+                self.diff_adj_manager.get_target_difficulty(pow_algo)?,
+            )),
         }
     }
 

--- a/base_layer/core/src/base_node/comms_interface/local_interface.rs
+++ b/base_layer/core/src/base_node/comms_interface/local_interface.rs
@@ -24,6 +24,7 @@ use crate::{
     base_node::comms_interface::{error::CommsInterfaceError, BlockEvent, NodeCommsRequest, NodeCommsResponse},
     blocks::{Block, NewBlockTemplate},
     chain_storage::ChainMetadata,
+    proof_of_work::{Difficulty, PowAlgorithm},
 };
 use futures::{stream::Fuse, StreamExt};
 use tari_broadcast_channel::Subscriber;
@@ -86,6 +87,22 @@ impl LocalNodeCommsInterface {
             .await??
         {
             NodeCommsResponse::NewBlock(block) => Ok(block),
+            _ => Err(CommsInterfaceError::UnexpectedApiResponse),
+        }
+    }
+
+    /// Request the PoW target difficulty for mining on the main chain from the base node service.
+    pub async fn get_target_difficulty(
+        &mut self,
+        pow_algorithm: PowAlgorithm,
+    ) -> Result<Difficulty, CommsInterfaceError>
+    {
+        match self
+            .request_sender
+            .call(NodeCommsRequest::GetTargetDifficulty(pow_algorithm))
+            .await??
+        {
+            NodeCommsResponse::TargetDifficulty(difficulty) => Ok(difficulty),
             _ => Err(CommsInterfaceError::UnexpectedApiResponse),
         }
     }

--- a/base_layer/core/src/base_node/proto/request.proto
+++ b/base_layer/core/src/base_node/proto/request.proto
@@ -25,6 +25,8 @@ message BaseNodeServiceRequest {
         bool get_new_block_template = 8;
         // Indicates a GetNewBlock request.
         tari.core.NewBlockTemplate get_new_block = 9;
+        // Indicates a GetTargetDifficulty request.
+        uint64 get_target_difficulty = 10;
     }
 }
 

--- a/base_layer/core/src/base_node/proto/request.rs
+++ b/base_layer/core/src/base_node/proto/request.rs
@@ -21,8 +21,8 @@
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 use super::base_node::{base_node_service_request::Request as ProtoNodeCommsRequest, BlockHeights, HashOutputs};
-use crate::base_node::comms_interface as ci;
-use std::convert::TryInto;
+use crate::{base_node::comms_interface as ci, proof_of_work::PowAlgorithm};
+use std::convert::{TryFrom, TryInto};
 use tari_transactions::types::HashOutput;
 
 //---------------------------------- BaseNodeRequest --------------------------------------------//
@@ -41,6 +41,9 @@ impl TryInto<ci::NodeCommsRequest> for ProtoNodeCommsRequest {
             FetchMmrState(mmr_state_request) => ci::NodeCommsRequest::FetchMmrState(mmr_state_request.try_into()?),
             GetNewBlockTemplate(_) => ci::NodeCommsRequest::GetNewBlockTemplate,
             GetNewBlock(block_template) => ci::NodeCommsRequest::GetNewBlock(block_template.try_into()?),
+            GetTargetDifficulty(pow_algo) => {
+                ci::NodeCommsRequest::GetTargetDifficulty(PowAlgorithm::try_from(pow_algo)?)
+            },
         };
         Ok(request)
     }
@@ -58,6 +61,7 @@ impl From<ci::NodeCommsRequest> for ProtoNodeCommsRequest {
             FetchMmrState(mmr_state_request) => ProtoNodeCommsRequest::FetchMmrState(mmr_state_request.into()),
             GetNewBlockTemplate => ProtoNodeCommsRequest::GetNewBlockTemplate(true),
             GetNewBlock(block_template) => ProtoNodeCommsRequest::GetNewBlock(block_template.into()),
+            GetTargetDifficulty(pow_algo) => ProtoNodeCommsRequest::GetTargetDifficulty(*&pow_algo as u64),
         }
     }
 }

--- a/base_layer/core/src/base_node/proto/response.proto
+++ b/base_layer/core/src/base_node/proto/response.proto
@@ -27,6 +27,8 @@ message BaseNodeServiceResponse {
         tari.core.NewBlockTemplate new_block_template = 8;
         // Indicates a NewBlock response.
         tari.core.Block new_block = 9;
+        // Indicates a TargetDifficulty response.
+        uint64 target_difficulty = 10;
     }
 }
 

--- a/base_layer/core/src/base_node/proto/response.rs
+++ b/base_layer/core/src/base_node/proto/response.rs
@@ -20,21 +20,19 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+pub use super::base_node::base_node_service_response::Response as ProtoNodeCommsResponse;
 use super::base_node::{
     BlockHeaders as ProtoBlockHeaders,
     HistoricalBlocks as ProtoHistoricalBlocks,
     TransactionKernels as ProtoTransactionKernels,
     TransactionOutputs as ProtoTransactionOutputs,
 };
-use crate::{base_node::comms_interface as ci, proto::core as core_proto_types};
+use crate::{base_node::comms_interface as ci, proof_of_work::Difficulty, proto::core as core_proto_types};
 use std::{
     convert::TryInto,
     iter::{FromIterator, Iterator},
 };
-use tari_transactions::proto::types as transactions_proto;
-
-pub use super::base_node::base_node_service_response::Response as ProtoNodeCommsResponse;
-use tari_transactions::proto::utils::try_convert_all;
+use tari_transactions::proto::{types as transactions_proto, utils::try_convert_all};
 
 impl TryInto<ci::NodeCommsResponse> for ProtoNodeCommsResponse {
     type Error = String;
@@ -62,6 +60,7 @@ impl TryInto<ci::NodeCommsResponse> for ProtoNodeCommsResponse {
             MmrState(state) => ci::NodeCommsResponse::MmrState(state.try_into()?),
             NewBlockTemplate(block_template) => ci::NodeCommsResponse::NewBlockTemplate(block_template.try_into()?),
             NewBlock(block) => ci::NodeCommsResponse::NewBlock(block.try_into()?),
+            TargetDifficulty(difficulty) => ci::NodeCommsResponse::TargetDifficulty(Difficulty::from(difficulty)),
         };
 
         Ok(response)
@@ -92,6 +91,7 @@ impl From<ci::NodeCommsResponse> for ProtoNodeCommsResponse {
             MmrState(state) => ProtoNodeCommsResponse::MmrState(state.into()),
             NewBlockTemplate(block_template) => ProtoNodeCommsResponse::NewBlockTemplate(block_template.into()),
             NewBlock(block) => ProtoNodeCommsResponse::NewBlock(block.into()),
+            TargetDifficulty(difficulty) => ProtoNodeCommsResponse::TargetDifficulty(difficulty.as_u64()),
         }
     }
 }

--- a/base_layer/core/src/base_node/states/initial_sync.rs
+++ b/base_layer/core/src/base_node/states/initial_sync.rs
@@ -249,6 +249,13 @@ impl InitialSync {
                     e.to_string(),
                 );
             },
+            CommsInterfaceError::DifficultyAdjustmentManagerError(e) => {
+                self.shutdown_votes += 1;
+                error!(
+                    target: LOG_TARGET,
+                    "There was a problem accessing the difficulty adjustment manager. {}. {}.", e, msg
+                );
+            },
         }
     }
 

--- a/base_layer/core/src/base_node/test/comms_interface.rs
+++ b/base_layer/core/src/base_node/test/comms_interface.rs
@@ -41,6 +41,7 @@ use crate::{
         MutableMmrState,
     },
     mempool::{Mempool, MempoolConfig},
+    proof_of_work::DiffAdjManager,
     test_utils::builders::{add_block_and_update_header, create_test_kernel, create_utxo},
 };
 use croaring::Bitmap;
@@ -95,8 +96,9 @@ fn outbound_get_metadata() {
 fn inbound_get_metadata() {
     let store = BlockchainDatabase::new(MemoryDatabase::<HashDigest>::default()).unwrap();
     let mempool = Mempool::new(store.clone(), MempoolConfig::default());
+    let diff_adj_manager = DiffAdjManager::new(store.clone()).unwrap();
     let (block_event_publisher, _block_event_subscriber) = bounded(100);
-    let inbound_nch = InboundNodeCommsHandlers::new(block_event_publisher, store, mempool);
+    let inbound_nch = InboundNodeCommsHandlers::new(block_event_publisher, store, mempool, diff_adj_manager);
 
     test_async(move |rt| {
         rt.spawn(async move {
@@ -137,8 +139,9 @@ fn outbound_fetch_kernels() {
 fn inbound_fetch_kernels() {
     let store = BlockchainDatabase::new(MemoryDatabase::<HashDigest>::default()).unwrap();
     let mempool = Mempool::new(store.clone(), MempoolConfig::default());
+    let diff_adj_manager = DiffAdjManager::new(store.clone()).unwrap();
     let (block_event_publisher, _block_event_subscriber) = bounded(100);
-    let inbound_nch = InboundNodeCommsHandlers::new(block_event_publisher, store.clone(), mempool);
+    let inbound_nch = InboundNodeCommsHandlers::new(block_event_publisher, store.clone(), mempool, diff_adj_manager);
 
     let kernel = create_test_kernel(5.into(), 0);
     let hash = kernel.hash();
@@ -185,8 +188,9 @@ fn outbound_fetch_headers() {
 fn inbound_fetch_headers() {
     let store = BlockchainDatabase::new(MemoryDatabase::<HashDigest>::default()).unwrap();
     let mempool = Mempool::new(store.clone(), MempoolConfig::default());
+    let diff_adj_manager = DiffAdjManager::new(store.clone()).unwrap();
     let (block_event_publisher, _block_event_subscriber) = bounded(100);
-    let inbound_nch = InboundNodeCommsHandlers::new(block_event_publisher, store.clone(), mempool);
+    let inbound_nch = InboundNodeCommsHandlers::new(block_event_publisher, store.clone(), mempool, diff_adj_manager);
 
     let mut header = BlockHeader::new(0);
     header.height = 0;
@@ -236,7 +240,8 @@ fn inbound_fetch_utxos() {
     let store = BlockchainDatabase::new(MemoryDatabase::<HashDigest>::default()).unwrap();
     let mempool = Mempool::new(store.clone(), MempoolConfig::default());
     let (block_event_publisher, _block_event_subscriber) = bounded(100);
-    let inbound_nch = InboundNodeCommsHandlers::new(block_event_publisher, store.clone(), mempool);
+    let diff_adj_manager = DiffAdjManager::new(store.clone()).unwrap();
+    let inbound_nch = InboundNodeCommsHandlers::new(block_event_publisher, store.clone(), mempool, diff_adj_manager);
 
     let (utxo, _) = create_utxo(MicroTari(10_000), &factories);
     let hash = utxo.hash();
@@ -282,8 +287,9 @@ fn outbound_fetch_blocks() {
 fn inbound_fetch_blocks() {
     let store = BlockchainDatabase::new(MemoryDatabase::<HashDigest>::default()).unwrap();
     let mempool = Mempool::new(store.clone(), MempoolConfig::default());
+    let diff_adj_manager = DiffAdjManager::new(store.clone()).unwrap();
     let (block_event_publisher, _block_event_subscriber) = bounded(100);
-    let inbound_nch = InboundNodeCommsHandlers::new(block_event_publisher, store.clone(), mempool);
+    let inbound_nch = InboundNodeCommsHandlers::new(block_event_publisher, store.clone(), mempool, diff_adj_manager);
 
     let block = add_block_and_update_header(&store, get_genesis_block());
 
@@ -327,8 +333,9 @@ fn outbound_fetch_mmr_state() {
 fn inbound_fetch_mmr_state() {
     let store = BlockchainDatabase::new(MemoryDatabase::<HashDigest>::default()).unwrap();
     let mempool = Mempool::new(store.clone(), MempoolConfig::default());
+    let diff_adj_manager = DiffAdjManager::new(store.clone()).unwrap();
     let (block_event_publisher, _block_event_subscriber) = bounded(100);
-    let inbound_nch = InboundNodeCommsHandlers::new(block_event_publisher, store, mempool);
+    let inbound_nch = InboundNodeCommsHandlers::new(block_event_publisher, store, mempool, diff_adj_manager);
 
     test_async(move |rt| {
         rt.spawn(async move {

--- a/base_layer/core/src/chain_storage/test/chain_backend.rs
+++ b/base_layer/core/src/chain_storage/test/chain_backend.rs
@@ -544,11 +544,8 @@ fn fetch_future_mmr_root_for_utxo_and_rp<T: BlockchainBackend>(db: T) {
     let (utxo3, _) = create_utxo(MicroTari(20_000), &factories);
     let (utxo4, _) = create_utxo(MicroTari(24_000), &factories);
     let utxo_hash1 = utxo1.hash();
-    let utxo_hash2 = utxo2.hash();
     let utxo_hash3 = utxo3.hash();
     let utxo_hash4 = utxo4.hash();
-    let rp_hash1 = utxo1.proof.hash();
-    let rp_hash2 = utxo2.proof.hash();
     let rp_hash3 = utxo3.proof.hash();
     let rp_hash4 = utxo4.proof.hash();
 
@@ -599,8 +596,6 @@ fn fetch_future_mmr_root_for_for_kernel<T: BlockchainBackend>(db: T) {
     let kernel2 = create_test_kernel(200.into(), 1);
     let kernel3 = create_test_kernel(300.into(), 2);
     let kernel4 = create_test_kernel(400.into(), 3);
-    let hash1 = kernel1.hash();
-    let hash2 = kernel2.hash();
     let hash3 = kernel3.hash();
     let hash4 = kernel4.hash();
 
@@ -648,8 +643,6 @@ fn fetch_future_mmr_root_for_header<T: BlockchainBackend>(db: T) {
     header3.height = 3;
     let mut header4 = BlockHeader::new(0);
     header4.height = 4;
-    let hash1 = header1.hash();
-    let hash2 = header2.hash();
     let hash3 = header3.hash();
     let hash4 = header4.hash();
 

--- a/base_layer/core/src/chain_storage/test/chain_storage.rs
+++ b/base_layer/core/src/chain_storage/test/chain_storage.rs
@@ -260,9 +260,7 @@ fn utxo_and_rp_future_merkle_root() {
 
     let (utxo1, _) = create_utxo(MicroTari(10_000), &factories);
     let (utxo2, _) = create_utxo(MicroTari(15_000), &factories);
-    let utxo_hash1 = utxo1.hash();
     let utxo_hash2 = utxo2.hash();
-    let rp_hash1 = utxo1.proof.hash();
     let rp_hash2 = utxo2.proof.hash();
 
     let mut txn = DbTransaction::new();
@@ -301,7 +299,6 @@ fn header_future_merkle_root() {
     let header1 = BlockHeader::new(0);
     let mut header2 = BlockHeader::new(0);
     header2.height = 1;
-    let hash1 = header1.hash();
     let hash2 = header2.hash();
 
     let mut txn = DbTransaction::new();
@@ -327,7 +324,6 @@ fn kernel_future_merkle_root() {
 
     let kernel1 = create_test_kernel(100.into(), 0);
     let kernel2 = create_test_kernel(200.into(), 0);
-    let hash1 = kernel1.hash();
     let hash2 = kernel2.hash();
 
     let mut txn = DbTransaction::new();

--- a/base_layer/core/src/proof_of_work/diff_adj_manager/diff_adj_manager.rs
+++ b/base_layer/core/src/proof_of_work/diff_adj_manager/diff_adj_manager.rs
@@ -1,0 +1,228 @@
+// Copyright 2019. The Tari Project
+//
+// Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+// following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+// disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+// following disclaimer in the documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+// products derived from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+// INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+// WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+// USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+use crate::{
+    chain_storage::{BlockchainBackend, BlockchainDatabase},
+    proof_of_work::{
+        diff_adj_manager::{diff_adj_storage::DiffAdjStorage, error::DiffAdjManagerError},
+        Difficulty,
+        PowAlgorithm,
+    },
+};
+use std::sync::{Arc, RwLock};
+
+/// The DiffAdjManager is used to calculate the current target difficulty based on PoW recorded in the latest blocks of
+/// the current best chain.
+pub struct DiffAdjManager<T>
+where T: BlockchainBackend
+{
+    diff_adj_storage: Arc<RwLock<DiffAdjStorage<T>>>,
+}
+
+impl<T> DiffAdjManager<T>
+where T: BlockchainBackend
+{
+    /// Constructs a new DiffAdjManager with access to the blockchain db.
+    pub fn new(blockchain_db: BlockchainDatabase<T>) -> Result<Self, DiffAdjManagerError> {
+        Ok(Self {
+            diff_adj_storage: Arc::new(RwLock::new(DiffAdjStorage::new(blockchain_db))),
+        })
+    }
+
+    /// Returns the estimated target difficulty for the specified PoW algorithm.
+    pub fn get_target_difficulty(&self, pow_algo: &PowAlgorithm) -> Result<Difficulty, DiffAdjManagerError> {
+        self.diff_adj_storage
+            .write()
+            .map_err(|_| DiffAdjManagerError::PoisonedAccess)?
+            .get_target_difficulty(pow_algo)
+    }
+}
+
+impl<T> Clone for DiffAdjManager<T>
+where T: BlockchainBackend
+{
+    fn clone(&self) -> Self {
+        Self {
+            diff_adj_storage: self.diff_adj_storage.clone(),
+        }
+    }
+}
+
+#[cfg(test)]
+pub mod test {
+    use crate::{
+        blocks::genesis_block::get_genesis_block,
+        chain_storage::{BlockchainDatabase, MemoryDatabase},
+        proof_of_work::{DiffAdjManager, Difficulty, PowAlgorithm},
+        test_utils::builders::{add_block_and_update_header, chain_block},
+    };
+    use tari_transactions::{consensus::TARGET_BLOCK_INTERVAL, types::HashDigest};
+    use tari_utilities::epoch_time::EpochTime;
+
+    fn create_test_pow_blockchain(
+        store: &BlockchainDatabase<MemoryDatabase<HashDigest>>,
+        pow_algos: Vec<PowAlgorithm>,
+    )
+    {
+        let mut prev_block = get_genesis_block();
+        prev_block.header.timestamp = EpochTime::from(1575018842);
+        prev_block = add_block_and_update_header(&store, prev_block);
+
+        for pow_algo in pow_algos {
+            let mut new_block = chain_block(&prev_block, Vec::new());
+            new_block.header.timestamp = prev_block.header.timestamp.increase(TARGET_BLOCK_INTERVAL);
+            new_block.header.pow.pow_algo = pow_algo;
+            prev_block = add_block_and_update_header(&store, new_block);
+        }
+    }
+
+    fn append_to_pow_blockchain(
+        store: &BlockchainDatabase<MemoryDatabase<HashDigest>>,
+        append_height: u64,
+        pow_algos: Vec<PowAlgorithm>,
+    )
+    {
+        let mut prev_block = store.fetch_block(append_height).unwrap().block().clone();
+
+        for pow_algo in pow_algos {
+            let mut new_block = chain_block(&prev_block, Vec::new());
+            new_block.header.timestamp = prev_block.header.timestamp.increase(TARGET_BLOCK_INTERVAL);
+            new_block.header.pow.pow_algo = pow_algo;
+            prev_block = add_block_and_update_header(&store, new_block);
+        }
+    }
+
+    #[test]
+    fn test_initial_sync() {
+        let store = BlockchainDatabase::new(MemoryDatabase::<HashDigest>::default()).unwrap();
+        let diff_adj_manager = DiffAdjManager::new(store.clone()).unwrap();
+        assert!(diff_adj_manager.get_target_difficulty(&PowAlgorithm::Monero).is_err());
+        assert!(diff_adj_manager.get_target_difficulty(&PowAlgorithm::Blake).is_err());
+
+        let pow_algos = vec![
+            PowAlgorithm::Blake,
+            PowAlgorithm::Monero,
+            PowAlgorithm::Blake,
+            PowAlgorithm::Blake,
+            PowAlgorithm::Monero,
+            PowAlgorithm::Monero,
+            PowAlgorithm::Blake,
+        ];
+        create_test_pow_blockchain(&store, pow_algos);
+        let diff_adj_manager = DiffAdjManager::new(store.clone()).unwrap();
+        assert_eq!(
+            diff_adj_manager.get_target_difficulty(&PowAlgorithm::Monero),
+            Ok(Difficulty::from(2))
+        );
+        assert_eq!(
+            diff_adj_manager.get_target_difficulty(&PowAlgorithm::Blake),
+            Ok(Difficulty::from(8))
+        );
+    }
+
+    #[test]
+    fn test_sync_to_chain_tip() {
+        let store = BlockchainDatabase::new(MemoryDatabase::<HashDigest>::default()).unwrap();
+        let diff_adj_manager = DiffAdjManager::new(store.clone()).unwrap();
+
+        let pow_algos = vec![
+            PowAlgorithm::Monero,
+            PowAlgorithm::Blake,
+            PowAlgorithm::Blake,
+            PowAlgorithm::Monero,
+            PowAlgorithm::Blake,
+        ];
+        create_test_pow_blockchain(&store, pow_algos);
+        assert_eq!(store.get_height(), Ok(Some(5)));
+        assert_eq!(
+            diff_adj_manager.get_target_difficulty(&PowAlgorithm::Monero),
+            Ok(Difficulty::from(1))
+        );
+        assert_eq!(
+            diff_adj_manager.get_target_difficulty(&PowAlgorithm::Blake),
+            Ok(Difficulty::from(4))
+        );
+
+        let pow_algos = vec![
+            PowAlgorithm::Blake,
+            PowAlgorithm::Monero,
+            PowAlgorithm::Blake,
+            PowAlgorithm::Monero,
+        ];
+        let append_height = store.get_height().unwrap().unwrap();
+        append_to_pow_blockchain(&store, append_height, pow_algos);
+        assert_eq!(store.get_height(), Ok(Some(9)));
+        assert_eq!(
+            diff_adj_manager.get_target_difficulty(&PowAlgorithm::Monero),
+            Ok(Difficulty::from(1))
+        );
+        assert_eq!(
+            diff_adj_manager.get_target_difficulty(&PowAlgorithm::Blake),
+            Ok(Difficulty::from(5))
+        );
+    }
+
+    #[test]
+    #[ignore] // TODO Wait for reorg logic to be refactored
+    fn test_full_sync_on_reorg() {
+        let store = BlockchainDatabase::new(MemoryDatabase::<HashDigest>::default()).unwrap();
+        let diff_adj_manager = DiffAdjManager::new(store.clone()).unwrap();
+
+        let pow_algos = vec![
+            PowAlgorithm::Blake,
+            PowAlgorithm::Blake,
+            PowAlgorithm::Blake,
+            PowAlgorithm::Monero,
+        ];
+        create_test_pow_blockchain(&store, pow_algos);
+        assert_eq!(store.get_height(), Ok(Some(4)));
+        assert_eq!(
+            diff_adj_manager.get_target_difficulty(&PowAlgorithm::Monero),
+            Ok(Difficulty::from(1))
+        );
+        assert_eq!(
+            diff_adj_manager.get_target_difficulty(&PowAlgorithm::Blake),
+            Ok(Difficulty::from(18))
+        );
+
+        let pow_algos = vec![
+            PowAlgorithm::Blake,
+            PowAlgorithm::Blake,
+            PowAlgorithm::Monero,
+            PowAlgorithm::Monero,
+            PowAlgorithm::Blake,
+            PowAlgorithm::Monero,
+            PowAlgorithm::Blake,
+            PowAlgorithm::Monero,
+        ];
+        append_to_pow_blockchain(&store, 2, pow_algos);
+        assert_eq!(store.get_height(), Ok(Some(8)));
+        assert_eq!(
+            diff_adj_manager.get_target_difficulty(&PowAlgorithm::Monero),
+            Ok(Difficulty::from(2))
+        );
+        assert_eq!(
+            diff_adj_manager.get_target_difficulty(&PowAlgorithm::Blake),
+            Ok(Difficulty::from(9))
+        );
+    }
+}

--- a/base_layer/core/src/proof_of_work/diff_adj_manager/diff_adj_storage.rs
+++ b/base_layer/core/src/proof_of_work/diff_adj_manager/diff_adj_storage.rs
@@ -1,0 +1,208 @@
+//  Copyright 2019 The Tari Project
+//
+//  Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+//  following conditions are met:
+//
+//  1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+//  disclaimer.
+//
+//  2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+//  following disclaimer in the documentation and/or other materials provided with the distribution.
+//
+//  3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+//  products derived from this software without specific prior written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+//  INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+//  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+//  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+//  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+//  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+//  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+use crate::{
+    blocks::blockheader::BlockHash,
+    chain_storage::{BlockchainBackend, BlockchainDatabase},
+    proof_of_work::{
+        diff_adj_manager::error::DiffAdjManagerError,
+        difficulty::DifficultyAdjustment,
+        lwma_diff::LinearWeightedMovingAverage,
+        Difficulty,
+        PowAlgorithm,
+        ProofOfWork,
+    },
+};
+use tari_transactions::consensus::DIFFICULTY_BLOCK_WINDOW;
+use tari_utilities::{epoch_time::EpochTime, hash::Hashable};
+
+/// The UpdateState enum is used to specify what update operation should be performed to keep the difficulty adjustment
+/// system upto date with the blockchain db.
+enum UpdateState {
+    FullSync,
+    SyncToTip,
+    Synced,
+}
+
+/// DiffAdjManager makes use of DiffAdjStorage to provide thread save access to its LinearWeightedMovingAverages for
+/// each PoW algorithm.
+pub struct DiffAdjStorage<T>
+where T: BlockchainBackend
+{
+    blockchain_db: BlockchainDatabase<T>,
+    monero_lwma: LinearWeightedMovingAverage,
+    blake_lwma: LinearWeightedMovingAverage,
+    sync_data: Option<(u64, BlockHash)>,
+}
+
+impl<T> DiffAdjStorage<T>
+where T: BlockchainBackend
+{
+    /// Constructs a new DiffAdjStorage with access to the blockchain db.
+    pub fn new(blockchain_db: BlockchainDatabase<T>) -> Self {
+        Self {
+            blockchain_db,
+            monero_lwma: LinearWeightedMovingAverage::default(),
+            blake_lwma: LinearWeightedMovingAverage::default(),
+            sync_data: None,
+        }
+    }
+
+    // Check if the difficulty adjustment manager is in sync with the longest chain. It will also check if a full sync
+    // or update sync needs to be performed.
+    fn check_sync_state(&self, best_block: BlockHash) -> Result<UpdateState, DiffAdjManagerError> {
+        Ok(match &self.sync_data {
+            Some((sync_height, sync_block_hash)) => {
+                if *sync_block_hash != best_block {
+                    let header = self.blockchain_db.fetch_header(*sync_height)?;
+                    if *sync_block_hash == header.hash() {
+                        UpdateState::SyncToTip
+                    } else {
+                        UpdateState::FullSync
+                    }
+                } else {
+                    UpdateState::Synced
+                }
+            },
+            None => UpdateState::FullSync,
+        })
+    }
+
+    // Performs an update on the difficulty adjustment manager based on the detected sync state.
+    fn update(&mut self) -> Result<(), DiffAdjManagerError> {
+        let metadata = self.blockchain_db.get_metadata()?;
+        let height_of_longest_chain = metadata
+            .height_of_longest_chain
+            .ok_or(DiffAdjManagerError::EmptyBlockchain)?;
+        let best_block = metadata.best_block.ok_or(DiffAdjManagerError::EmptyBlockchain)?;
+        match self.check_sync_state(best_block.clone())? {
+            UpdateState::FullSync => self.sync_full_history(best_block, height_of_longest_chain)?,
+            UpdateState::SyncToTip => self.sync_to_chain_tip(best_block, height_of_longest_chain)?,
+            UpdateState::Synced => {},
+        };
+
+        Ok(())
+    }
+
+    /// Returns the estimated target difficulty for the specified PoW algorithm.
+    pub fn get_target_difficulty(&mut self, pow_algo: &PowAlgorithm) -> Result<Difficulty, DiffAdjManagerError> {
+        self.update()?;
+        Ok(match pow_algo {
+            PowAlgorithm::Monero => self.monero_lwma.get_difficulty(),
+            PowAlgorithm::Blake => self.blake_lwma.get_difficulty(),
+        })
+    }
+
+    // Resets the DiffAdjStorage.
+    fn reset(&mut self) {
+        self.monero_lwma = LinearWeightedMovingAverage::default();
+        self.blake_lwma = LinearWeightedMovingAverage::default();
+        self.sync_data = None;
+    }
+
+    // Adds the new PoW sample to the specific LinearWeightedMovingAverage specified by the PoW algorithm.
+    fn add(&mut self, timestamp: EpochTime, pow: ProofOfWork) -> Result<(), DiffAdjManagerError> {
+        match pow.pow_algo {
+            PowAlgorithm::Monero => self.monero_lwma.add(timestamp, pow.accumulated_monero_difficulty)?,
+            PowAlgorithm::Blake => self.blake_lwma.add(timestamp, pow.accumulated_blake_difficulty)?,
+        }
+        Ok(())
+    }
+
+    // Resets the DiffAdjStorage and perform a full sync using the blockchain db.
+    fn sync_full_history(
+        &mut self,
+        best_block: BlockHash,
+        height_of_longest_chain: u64,
+    ) -> Result<(), DiffAdjManagerError>
+    {
+        self.reset();
+
+        let mut monero_diff_list = Vec::<(EpochTime, Difficulty)>::with_capacity(DIFFICULTY_BLOCK_WINDOW as usize);
+        let mut blake_diff_list = Vec::<(EpochTime, Difficulty)>::with_capacity(DIFFICULTY_BLOCK_WINDOW as usize);
+        for height in (0..=height_of_longest_chain).rev() {
+            let header = self.blockchain_db.fetch_header(height)?;
+            match header.pow.pow_algo {
+                PowAlgorithm::Monero => {
+                    if (monero_diff_list.len() as u64) < DIFFICULTY_BLOCK_WINDOW {
+                        monero_diff_list.push((
+                            header.timestamp,
+                            header.pow.accumulated_monero_difficulty + header.achieved_difficulty(),
+                        ));
+                    }
+                },
+                PowAlgorithm::Blake => {
+                    if (blake_diff_list.len() as u64) < DIFFICULTY_BLOCK_WINDOW {
+                        blake_diff_list.push((
+                            header.timestamp,
+                            header.pow.accumulated_blake_difficulty + header.achieved_difficulty(),
+                        ));
+                    }
+                },
+            }
+            if ((monero_diff_list.len() as u64) >= DIFFICULTY_BLOCK_WINDOW) &&
+                ((blake_diff_list.len() as u64) >= DIFFICULTY_BLOCK_WINDOW)
+            {
+                break;
+            }
+        }
+        for (timestamp, accumulated_difficulty) in monero_diff_list.into_iter().rev() {
+            self.monero_lwma.add(timestamp, accumulated_difficulty)?
+        }
+        for (timestamp, accumulated_difficulty) in blake_diff_list.into_iter().rev() {
+            self.blake_lwma.add(timestamp, accumulated_difficulty)?
+        }
+        self.sync_data = Some((height_of_longest_chain, best_block));
+
+        Ok(())
+    }
+
+    // The difficulty adjustment manager has fallen behind, perform an update to the chain tip.
+    fn sync_to_chain_tip(
+        &mut self,
+        best_block: BlockHash,
+        height_of_longest_chain: u64,
+    ) -> Result<(), DiffAdjManagerError>
+    {
+        if let Some((sync_height, _)) = self.sync_data {
+            for height in (sync_height + 1)..=height_of_longest_chain {
+                let header = self.blockchain_db.fetch_header(height)?;
+                match header.pow.pow_algo {
+                    PowAlgorithm::Monero => {
+                        self.monero_lwma.add(
+                            header.timestamp,
+                            header.pow.accumulated_monero_difficulty + header.achieved_difficulty(),
+                        )?;
+                    },
+                    PowAlgorithm::Blake => {
+                        self.blake_lwma.add(
+                            header.timestamp,
+                            header.pow.accumulated_blake_difficulty + header.achieved_difficulty(),
+                        )?;
+                    },
+                }
+            }
+            self.sync_data = Some((height_of_longest_chain, best_block));
+        }
+        Ok(())
+    }
+}

--- a/base_layer/core/src/proof_of_work/diff_adj_manager/error.rs
+++ b/base_layer/core/src/proof_of_work/diff_adj_manager/error.rs
@@ -20,21 +20,13 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-mod blake_pow;
-mod diff_adj_manager;
-mod difficulty;
-mod error;
-mod monero;
-mod proof_of_work;
+use crate::{chain_storage::ChainStorageError, proof_of_work::error::DifficultyAdjustmentError};
+use derive_error::Error;
 
-#[cfg(test)]
-pub use blake_pow::test as blake_test;
-
-pub mod lwma_diff;
-
-pub use blake_pow::{blake_difficulty, blake_difficulty_with_hash};
-pub use diff_adj_manager::{DiffAdjManager, DiffAdjManagerError};
-pub use difficulty::Difficulty;
-pub use error::PowError;
-pub use monero::monero_difficulty;
-pub use proof_of_work::{PowAlgorithm, ProofOfWork};
+#[derive(Debug, Error, Clone, PartialEq)]
+pub enum DiffAdjManagerError {
+    DifficultyAdjustmentError(DifficultyAdjustmentError),
+    ChainStorageError(ChainStorageError),
+    EmptyBlockchain,
+    PoisonedAccess,
+}

--- a/base_layer/core/src/proof_of_work/diff_adj_manager/mod.rs
+++ b/base_layer/core/src/proof_of_work/diff_adj_manager/mod.rs
@@ -20,21 +20,9 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-mod blake_pow;
 mod diff_adj_manager;
-mod difficulty;
+mod diff_adj_storage;
 mod error;
-mod monero;
-mod proof_of_work;
 
-#[cfg(test)]
-pub use blake_pow::test as blake_test;
-
-pub mod lwma_diff;
-
-pub use blake_pow::{blake_difficulty, blake_difficulty_with_hash};
-pub use diff_adj_manager::{DiffAdjManager, DiffAdjManagerError};
-pub use difficulty::Difficulty;
-pub use error::PowError;
-pub use monero::monero_difficulty;
-pub use proof_of_work::{PowAlgorithm, ProofOfWork};
+pub use diff_adj_manager::DiffAdjManager;
+pub use error::DiffAdjManagerError;

--- a/base_layer/core/src/proof_of_work/error.rs
+++ b/base_layer/core/src/proof_of_work/error.rs
@@ -28,7 +28,7 @@ pub enum PowError {
     InvalidProofOfWork,
 }
 
-#[derive(Debug, Error, Clone)]
+#[derive(Debug, Error, Clone, PartialEq)]
 pub enum DifficultyAdjustmentError {
     // Accumulated difficulty values can only strictly increase
     DecreasingAccumulatedDifficulty,

--- a/base_layer/core/src/proto/block.proto
+++ b/base_layer/core/src/proto/block.proto
@@ -7,7 +7,7 @@ import "types.proto";
 
 package tari.core;
 
-// Metadata required for validating the PRoof of Work calculation
+// Metadata required for validating the Proof of Work calculation
 message ProofOfWork {
     // 0 = Monero
     // 1 = Blake

--- a/base_layer/transactions/src/consensus.rs
+++ b/base_layer/transactions/src/consensus.rs
@@ -25,11 +25,16 @@ use chrono::{DateTime, Duration, Utc};
 use std::ops::Add;
 
 // This is the our target time in seconds between blocks
-pub const TARGET_BLOCK_INTERVAL: u64 = 60;
+pub const TARGET_BLOCK_INTERVAL: u64 = 120;
 // When doing difficulty adjustments and FTL calculations this is the amount of blocks we look at
-pub const DIFFICULTY_BLOCK_WINDOW: u64 = 150;
+pub const DIFFICULTY_BLOCK_WINDOW: u64 = 90;
 // Maximum transaction weight used for the construction of new blocks.
 pub const MAX_BLOCK_TRANSACTION_WEIGHT: u64 = 10000; // TODO: a better weight estimate should be selected
+                                                     // The amount of PoW algorithms used by the Tari chain.
+pub const POW_ALGO_COUNT: u64 = 2;
+// The target time used by the difficulty adjustment algorithms, their target time is the target block interval * PoW
+// algorithm count
+pub const DIFF_TARGET_BLOCK_INTERVAL: u64 = TARGET_BLOCK_INTERVAL * POW_ALGO_COUNT;
 
 /// This is used to control all consensus values.
 pub struct ConsensusRules {


### PR DESCRIPTION
## Description
- Introduced the difficulty adjustment manager that keeps track of the chain state to calculate the target difficulty of the different PoW algorithms.
- Added the GetTargetDifficulty comms request and TargetDifficulty comms response to the BaseNodeService allowing miners to request the target difficulty from a Base node.
- Added proto conversions for the GetTargetDifficulty request and TargetDifficulty response.
- Added the difficulty adjustment manager to the tari base node and existing tests.
- Fixed 0 difficulty issue in Lwma_diff and change it to make use of the correct target time. Changed it to make the target time configurable.

## Motivation and Context
Enables miners to query a Base node to determine the target difficulty for a specified PoW algorithm.

## How Has This Been Tested?
Added a test for testing the the get target difficulty request and response system and tests for the DiffAdjManager system.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [x] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [x] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch
* [x] I ran `cargo-fmt --all` before pushing
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
