### PR TITLE
Refactor the BaseNodeService and MempoolService test helper functions

### DIFF
--- a/base_layer/core/src/base_node/mod.rs
+++ b/base_layer/core/src/base_node/mod.rs
@@ -46,4 +46,4 @@ pub mod states;
 // Public re-exports
 pub use backoff::BackOff;
 pub use base_node::BaseNodeStateMachine;
-pub use comms_interface::OutboundNodeCommsInterface;
+pub use comms_interface::{LocalNodeCommsInterface, OutboundNodeCommsInterface};

--- a/base_layer/core/src/chain_storage/blockchain_database.rs
+++ b/base_layer/core/src/chain_storage/blockchain_database.rs
@@ -754,7 +754,6 @@ where T: BlockchainBackend
     /// Each successful link is pushed to the front of the queue.
     fn try_construct_fork(&self, new_block: Block) -> Result<VecDeque<Block>, ChainStorageError> {
         let mut reorg_chain = VecDeque::new();
-        let _new_block_hash = new_block.hash();
         let mut hash = new_block.header.prev_hash.clone();
         let mut height = new_block.header.height;
         reorg_chain.push_front(new_block);

--- a/base_layer/core/src/mempool/mod.rs
+++ b/base_layer/core/src/mempool/mod.rs
@@ -35,3 +35,4 @@ mod unconfirmed_pool;
 // Public re-exports
 pub use error::MempoolError;
 pub use mempool::{Mempool, MempoolConfig, TxStorageResponse};
+pub use service::{MempoolServiceConfig, MempoolServiceInitializer, OutboundMempoolServiceInterface};

--- a/base_layer/core/src/mempool/test/service.rs
+++ b/base_layer/core/src/mempool/test/service.rs
@@ -21,277 +21,57 @@
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 use crate::{
-    chain_storage::{BlockchainDatabase, MemoryDatabase},
+    base_node::service::BaseNodeServiceConfig,
     mempool::{
-        service::{
-            MempoolServiceConfig,
-            MempoolServiceError,
-            MempoolServiceInitializer,
-            OutboundMempoolServiceInterface,
-        },
-        Mempool,
-        MempoolConfig,
+        service::{MempoolServiceConfig, MempoolServiceError},
         TxStorageResponse,
     },
-    test_utils::builders::{add_block_and_update_header, create_genesis_block, spend_utxos},
+    test_utils::{
+        builders::{add_block_and_update_header, create_genesis_block, spend_utxos},
+        node::{create_network_with_2_base_nodes_with_config, create_network_with_3_base_nodes},
+    },
     tx,
     txn_schema,
 };
-use futures::Sink;
-use rand::{distributions::Alphanumeric, rngs::OsRng, Rng};
 use std::{
-    error::Error,
-    iter,
     sync::Arc,
     time::{Duration, Instant},
 };
-use tari_comms::{
-    builder::CommsNode,
-    control_service::ControlServiceConfig,
-    peer_manager::{NodeIdentity, Peer, PeerFeatures, PeerFlags},
-};
-use tari_comms_dht::{
-    domain_message::OutboundDomainMessage,
-    outbound::{OutboundEncryption, OutboundMessageRequester},
-    Dht,
-};
-use tari_p2p::{
-    comms_connector::{pubsub_connector, InboundDomainConnector, PeerMessage},
-    initialization::{initialize_comms, CommsConfig},
-    services::comms_outbound::CommsOutboundServiceInitializer,
-    tari_message::TariMessageType,
-};
-use tari_service_framework::StackBuilder;
-use tari_test_utils::{address::get_next_local_address, async_assert_eventually};
+use tari_comms_dht::{domain_message::OutboundDomainMessage, outbound::OutboundEncryption};
+use tari_mmr::MerkleChangeTrackerConfig;
+use tari_p2p::tari_message::TariMessageType;
+use tari_test_utils::async_assert_eventually;
 use tari_transactions::{
     proto::types as proto,
     tari_amount::{uT, T},
-    types::{CryptoFactories, HashDigest},
+    types::CryptoFactories,
 };
-use tempdir::TempDir;
-use tokio::runtime::{Runtime, TaskExecutor};
-
-// Todo: Some of the helper test functions are the same or similar to the Base node service test functions, these should
-// be moved to the test_utils.
-
-fn random_string(len: usize) -> String {
-    let mut rng = OsRng::new().unwrap();
-    iter::repeat(()).map(|_| rng.sample(Alphanumeric)).take(len).collect()
-}
-
-fn setup_comms_services<TSink>(
-    executor: TaskExecutor,
-    node_identity: Arc<NodeIdentity>,
-    peers: Vec<NodeIdentity>,
-    publisher: InboundDomainConnector<TSink>,
-) -> (CommsNode, Dht)
-where
-    TSink: Sink<Arc<PeerMessage>> + Clone + Unpin + Send + Sync + 'static,
-    TSink::Error: Error + Send + Sync,
-{
-    let comms_config = CommsConfig {
-        node_identity: Arc::clone(&node_identity),
-        peer_connection_listening_address: "127.0.0.1:0".parse().unwrap(),
-        socks_proxy_address: None,
-        control_service: ControlServiceConfig {
-            listener_address: node_identity.control_service_address(),
-            socks_proxy_address: None,
-            requested_connection_timeout: Duration::from_millis(2000),
-        },
-        datastore_path: TempDir::new(random_string(8).as_str())
-            .unwrap()
-            .path()
-            .to_str()
-            .unwrap()
-            .to_string(),
-        establish_connection_timeout: Duration::from_secs(5),
-        peer_database_name: random_string(8),
-        inbound_buffer_size: 100,
-        outbound_buffer_size: 100,
-        dht: Default::default(),
-    };
-
-    let (comms, dht) = initialize_comms(executor, comms_config, publisher).unwrap();
-
-    for p in peers {
-        let addr = p.control_service_address();
-        comms
-            .peer_manager()
-            .add_peer(Peer::new(
-                p.public_key().clone(),
-                p.node_id().clone(),
-                addr.into(),
-                PeerFlags::empty(),
-                p.features().clone(),
-            ))
-            .unwrap();
-    }
-
-    (comms, dht)
-}
-
-struct NodeInterfaces {
-    pub node_identity: NodeIdentity,
-    pub outbound_mp_interface: OutboundMempoolServiceInterface,
-    pub outbound_message_service: OutboundMessageRequester,
-    pub blockchain_db: BlockchainDatabase<MemoryDatabase<HashDigest>>,
-    pub mempool: Mempool<MemoryDatabase<HashDigest>>,
-    pub comms: CommsNode,
-}
-
-impl NodeInterfaces {
-    fn new(
-        node_identity: NodeIdentity,
-        outbound_mp_interface: OutboundMempoolServiceInterface,
-        outbound_message_service: OutboundMessageRequester,
-        blockchain_db: BlockchainDatabase<MemoryDatabase<HashDigest>>,
-        mempool: Mempool<MemoryDatabase<HashDigest>>,
-        comms: CommsNode,
-    ) -> Self
-    {
-        Self {
-            node_identity,
-            outbound_mp_interface,
-            outbound_message_service,
-            blockchain_db,
-            mempool,
-            comms,
-        }
-    }
-}
-
-pub fn setup_mempool_service(
-    runtime: &Runtime,
-    node_identity: NodeIdentity,
-    peers: Vec<NodeIdentity>,
-    mempool: Mempool<MemoryDatabase<HashDigest>>,
-    config: MempoolServiceConfig,
-) -> (OutboundMempoolServiceInterface, OutboundMessageRequester, CommsNode)
-{
-    let (publisher, subscription_factory) = pubsub_connector(runtime.executor(), 100);
-    let subscription_factory = Arc::new(subscription_factory);
-    let (comms, dht) = setup_comms_services(runtime.executor(), Arc::new(node_identity), peers, publisher);
-
-    let fut = StackBuilder::new(runtime.executor(), comms.shutdown_signal())
-        .add_initializer(CommsOutboundServiceInitializer::new(dht.outbound_requester()))
-        .add_initializer(MempoolServiceInitializer::new(subscription_factory, mempool, config))
-        .finish();
-
-    let handles = runtime.block_on(fut).expect("Service initialization failed");
-
-    let outbound_mp_handle = handles.get_handle::<OutboundMempoolServiceInterface>().unwrap();
-    let outbound_message_service = handles.get_handle::<OutboundMessageRequester>().unwrap();
-
-    (outbound_mp_handle, outbound_message_service, comms)
-}
-
-fn create_network_with_3_mempools(
-    runtime: &Runtime,
-    config: MempoolServiceConfig,
-) -> (NodeInterfaces, NodeInterfaces, NodeInterfaces)
-{
-    let mut rng = OsRng::new().unwrap();
-    let alice_node_identity = NodeIdentity::random(
-        &mut rng,
-        get_next_local_address().parse().unwrap(),
-        PeerFeatures::COMMUNICATION_NODE,
-    )
-    .unwrap();
-    let alice_blockchain_db = BlockchainDatabase::new(MemoryDatabase::<HashDigest>::default()).unwrap();
-    let alice_mempool = Mempool::new(alice_blockchain_db.clone(), MempoolConfig::default());
-
-    let bob_node_identity = NodeIdentity::random(
-        &mut rng,
-        get_next_local_address().parse().unwrap(),
-        PeerFeatures::COMMUNICATION_NODE,
-    )
-    .unwrap();
-    let bob_blockchain_db = BlockchainDatabase::new(MemoryDatabase::<HashDigest>::default()).unwrap();
-    let bob_mempool = Mempool::new(bob_blockchain_db.clone(), MempoolConfig::default());
-
-    let carol_node_identity = NodeIdentity::random(
-        &mut rng,
-        get_next_local_address().parse().unwrap(),
-        PeerFeatures::COMMUNICATION_NODE,
-    )
-    .unwrap();
-    let carol_blockchain_db = BlockchainDatabase::new(MemoryDatabase::<HashDigest>::default()).unwrap();
-    let carol_mempool = Mempool::new(carol_blockchain_db.clone(), MempoolConfig::default());
-
-    let (alice_outbound_mp_interface, alice_outbound_message_service, alice_comms) = setup_mempool_service(
-        &runtime,
-        alice_node_identity.clone(),
-        vec![bob_node_identity.clone(), carol_node_identity.clone()],
-        alice_mempool.clone(),
-        config.clone(),
-    );
-    let (bob_outbound_mp_interface, bob_outbound_message_service, bob_comms) = setup_mempool_service(
-        &runtime,
-        bob_node_identity.clone(),
-        vec![alice_node_identity.clone(), carol_node_identity.clone()],
-        bob_mempool.clone(),
-        config.clone(),
-    );
-    let (carol_outbound_mp_interface, carol_outbound_message_service, carol_comms) = setup_mempool_service(
-        &runtime,
-        carol_node_identity.clone(),
-        vec![alice_node_identity.clone(), bob_node_identity.clone()],
-        carol_mempool.clone(),
-        config,
-    );
-    let alice_interfaces = NodeInterfaces::new(
-        alice_node_identity,
-        alice_outbound_mp_interface,
-        alice_outbound_message_service,
-        alice_blockchain_db,
-        alice_mempool,
-        alice_comms,
-    );
-    let bob_interfaces = NodeInterfaces::new(
-        bob_node_identity,
-        bob_outbound_mp_interface,
-        bob_outbound_message_service,
-        bob_blockchain_db,
-        bob_mempool,
-        bob_comms,
-    );
-    let carol_interfaces = NodeInterfaces::new(
-        carol_node_identity,
-        carol_outbound_mp_interface,
-        carol_outbound_message_service,
-        carol_blockchain_db,
-        carol_mempool,
-        carol_comms,
-    );
-    (alice_interfaces, bob_interfaces, carol_interfaces)
-}
+use tokio::runtime::Runtime;
 
 #[test]
 fn request_response_get_stats() {
     let factories = CryptoFactories::default();
     let runtime = Runtime::new().unwrap();
-
-    let (mut alice_interfaces, bob_interfaces, carol_interfaces) =
-        create_network_with_3_mempools(&runtime, MempoolServiceConfig::default());
+    let (mut alice_node, bob_node, carol_node) = create_network_with_3_base_nodes(&runtime);
 
     let (block0, utxo) = create_genesis_block(&factories);
-    add_block_and_update_header(&bob_interfaces.blockchain_db, block0.clone());
-    add_block_and_update_header(&carol_interfaces.blockchain_db, block0);
+    add_block_and_update_header(&bob_node.blockchain_db, block0.clone());
+    add_block_and_update_header(&carol_node.blockchain_db, block0);
     let (tx1, _, _) = spend_utxos(txn_schema!(from: vec![utxo], to: vec![2 * T, 2 * T, 2 * T]));
     let tx1 = Arc::new(tx1);
-    bob_interfaces.mempool.insert(tx1.clone()).unwrap();
-    carol_interfaces.mempool.insert(tx1).unwrap();
+    bob_node.mempool.insert(tx1.clone()).unwrap();
+    carol_node.mempool.insert(tx1).unwrap();
     let (orphan1, _, _) = tx!(1*T, fee: 100*uT);
     let orphan1 = Arc::new(orphan1);
-    bob_interfaces.mempool.insert(orphan1.clone()).unwrap();
-    carol_interfaces.mempool.insert(orphan1).unwrap();
+    bob_node.mempool.insert(orphan1.clone()).unwrap();
+    carol_node.mempool.insert(orphan1).unwrap();
     let (orphan2, _, _) = tx!(2*T, fee: 200*uT);
     let orphan2 = Arc::new(orphan2);
-    bob_interfaces.mempool.insert(orphan2.clone()).unwrap();
-    carol_interfaces.mempool.insert(orphan2).unwrap();
+    bob_node.mempool.insert(orphan2.clone()).unwrap();
+    carol_node.mempool.insert(orphan2).unwrap();
 
     runtime.block_on(async {
-        let received_stats = alice_interfaces.outbound_mp_interface.get_stats().await.unwrap();
+        let received_stats = alice_node.outbound_mp_interface.get_stats().await.unwrap();
         assert_eq!(received_stats.total_txs, 3);
         assert_eq!(received_stats.unconfirmed_txs, 1);
         assert_eq!(received_stats.orphan_txs, 2);
@@ -300,38 +80,36 @@ fn request_response_get_stats() {
         assert_eq!(received_stats.total_weight, 35);
     });
 
-    alice_interfaces.comms.shutdown().unwrap();
-    bob_interfaces.comms.shutdown().unwrap();
-    carol_interfaces.comms.shutdown().unwrap();
+    alice_node.comms.shutdown().unwrap();
+    bob_node.comms.shutdown().unwrap();
+    carol_node.comms.shutdown().unwrap();
 }
 
 #[test]
 fn request_response_get_tx_state_with_excess_sig() {
     let factories = CryptoFactories::default();
     let runtime = Runtime::new().unwrap();
-
-    let (mut alice_interfaces, bob_interfaces, carol_interfaces) =
-        create_network_with_3_mempools(&runtime, MempoolServiceConfig::default());
+    let (mut alice_node, bob_node, carol_node) = create_network_with_3_base_nodes(&runtime);
 
     let (block0, utxo) = create_genesis_block(&factories);
-    add_block_and_update_header(&bob_interfaces.blockchain_db, block0.clone());
-    add_block_and_update_header(&carol_interfaces.blockchain_db, block0);
+    add_block_and_update_header(&bob_node.blockchain_db, block0.clone());
+    add_block_and_update_header(&carol_node.blockchain_db, block0);
     let (tx, _, _) = spend_utxos(txn_schema!(from: vec![utxo.clone()], to: vec![2 * T, 2 * T, 2 * T]));
     let (unpublished_tx, _, _) = spend_utxos(txn_schema!(from: vec![utxo], to: vec![3 * T]));
     let (orphan_tx, _, _) = tx!(1*T, fee: 100*uT);
     let tx = Arc::new(tx);
     let orphan_tx = Arc::new(orphan_tx);
-    bob_interfaces.mempool.insert(tx.clone()).unwrap();
-    carol_interfaces.mempool.insert(tx.clone()).unwrap();
-    bob_interfaces.mempool.insert(orphan_tx.clone()).unwrap();
-    carol_interfaces.mempool.insert(orphan_tx.clone()).unwrap();
+    bob_node.mempool.insert(tx.clone()).unwrap();
+    carol_node.mempool.insert(tx.clone()).unwrap();
+    bob_node.mempool.insert(orphan_tx.clone()).unwrap();
+    carol_node.mempool.insert(orphan_tx.clone()).unwrap();
 
     runtime.block_on(async {
         let tx_excess_sig = tx.body.kernels()[0].excess_sig.clone();
         let unpublished_tx_excess_sig = unpublished_tx.body.kernels()[0].excess_sig.clone();
         let orphan_tx_excess_sig = orphan_tx.body.kernels()[0].excess_sig.clone();
         assert_eq!(
-            alice_interfaces
+            alice_node
                 .outbound_mp_interface
                 .get_tx_state_with_excess_sig(tx_excess_sig)
                 .await
@@ -339,7 +117,7 @@ fn request_response_get_tx_state_with_excess_sig() {
             TxStorageResponse::UnconfirmedPool
         );
         assert_eq!(
-            alice_interfaces
+            alice_node
                 .outbound_mp_interface
                 .get_tx_state_with_excess_sig(unpublished_tx_excess_sig)
                 .await
@@ -347,7 +125,7 @@ fn request_response_get_tx_state_with_excess_sig() {
             TxStorageResponse::NotStored
         );
         assert_eq!(
-            alice_interfaces
+            alice_node
                 .outbound_mp_interface
                 .get_tx_state_with_excess_sig(orphan_tx_excess_sig)
                 .await
@@ -356,44 +134,42 @@ fn request_response_get_tx_state_with_excess_sig() {
         );
     });
 
-    alice_interfaces.comms.shutdown().unwrap();
-    bob_interfaces.comms.shutdown().unwrap();
-    carol_interfaces.comms.shutdown().unwrap();
+    alice_node.comms.shutdown().unwrap();
+    bob_node.comms.shutdown().unwrap();
+    carol_node.comms.shutdown().unwrap();
 }
 
 #[test]
 fn receive_and_propagate_transaction() {
     let factories = CryptoFactories::default();
     let runtime = Runtime::new().unwrap();
-
-    let (mut alice_interfaces, bob_interfaces, carol_interfaces) =
-        create_network_with_3_mempools(&runtime, MempoolServiceConfig::default());
+    let (mut alice_node, bob_node, carol_node) = create_network_with_3_base_nodes(&runtime);
 
     let (block0, utxo) = create_genesis_block(&factories);
-    add_block_and_update_header(&alice_interfaces.blockchain_db, block0.clone());
-    add_block_and_update_header(&bob_interfaces.blockchain_db, block0.clone());
-    add_block_and_update_header(&carol_interfaces.blockchain_db, block0);
+    add_block_and_update_header(&alice_node.blockchain_db, block0.clone());
+    add_block_and_update_header(&bob_node.blockchain_db, block0.clone());
+    add_block_and_update_header(&carol_node.blockchain_db, block0);
     let (tx, _, _) = spend_utxos(txn_schema!(from: vec![utxo], to: vec![2 * T, 2 * T, 2 * T]));
     let (orphan, _, _) = tx!(1*T, fee: 100*uT);
     let tx_excess_sig = tx.body.kernels()[0].excess_sig.clone();
     let orphan_excess_sig = orphan.body.kernels()[0].excess_sig.clone();
-    assert!(alice_interfaces.mempool.insert(Arc::new(tx.clone())).is_ok());
-    assert!(alice_interfaces.mempool.insert(Arc::new(orphan.clone())).is_ok());
+    assert!(alice_node.mempool.insert(Arc::new(tx.clone())).is_ok());
+    assert!(alice_node.mempool.insert(Arc::new(orphan.clone())).is_ok());
 
     runtime.block_on(async {
-        alice_interfaces
+        alice_node
             .outbound_message_service
             .send_direct(
-                bob_interfaces.node_identity.public_key().clone(),
+                bob_node.node_identity.public_key().clone(),
                 OutboundEncryption::EncryptForPeer,
                 OutboundDomainMessage::new(TariMessageType::NewTransaction, proto::Transaction::from(tx)),
             )
             .await
             .unwrap();
-        alice_interfaces
+        alice_node
             .outbound_message_service
             .send_direct(
-                carol_interfaces.node_identity.public_key().clone(),
+                carol_node.node_identity.public_key().clone(),
                 OutboundEncryption::EncryptForPeer,
                 OutboundDomainMessage::new(TariMessageType::NewTransaction, proto::Transaction::from(orphan)),
             )
@@ -401,89 +177,61 @@ fn receive_and_propagate_transaction() {
             .unwrap();
 
         async_assert_eventually!(
-            bob_interfaces.mempool.has_tx_with_excess_sig(&tx_excess_sig).unwrap(),
+            bob_node.mempool.has_tx_with_excess_sig(&tx_excess_sig).unwrap(),
             expect = TxStorageResponse::UnconfirmedPool,
             max_attempts = 10,
             interval = Duration::from_millis(1000)
         );
         async_assert_eventually!(
-            bob_interfaces
-                .mempool
-                .has_tx_with_excess_sig(&orphan_excess_sig)
-                .unwrap(),
+            bob_node.mempool.has_tx_with_excess_sig(&orphan_excess_sig).unwrap(),
             expect = TxStorageResponse::OrphanPool,
             max_attempts = 10,
             interval = Duration::from_millis(1000)
         );
         async_assert_eventually!(
-            carol_interfaces.mempool.has_tx_with_excess_sig(&tx_excess_sig).unwrap(),
+            carol_node.mempool.has_tx_with_excess_sig(&tx_excess_sig).unwrap(),
             expect = TxStorageResponse::UnconfirmedPool,
             max_attempts = 10,
             interval = Duration::from_millis(1000)
         );
         async_assert_eventually!(
-            carol_interfaces
-                .mempool
-                .has_tx_with_excess_sig(&orphan_excess_sig)
-                .unwrap(),
+            carol_node.mempool.has_tx_with_excess_sig(&orphan_excess_sig).unwrap(),
             expect = TxStorageResponse::OrphanPool,
             max_attempts = 10,
             interval = Duration::from_millis(1000)
         );
     });
 
-    alice_interfaces.comms.shutdown().unwrap();
-    bob_interfaces.comms.shutdown().unwrap();
-    carol_interfaces.comms.shutdown().unwrap();
+    alice_node.comms.shutdown().unwrap();
+    bob_node.comms.shutdown().unwrap();
+    carol_node.comms.shutdown().unwrap();
 }
 
 #[test]
 fn service_request_timeout() {
-    let mut rng = OsRng::new().unwrap();
     let runtime = Runtime::new().unwrap();
+
     let mempool_service_config = MempoolServiceConfig {
         request_timeout: Duration::from_millis(1),
     };
-    let alice_node_identity = NodeIdentity::random(
-        &mut rng,
-        get_next_local_address().parse().unwrap(),
-        PeerFeatures::COMMUNICATION_NODE,
-    )
-    .unwrap();
-    let alice_blockchain_db = BlockchainDatabase::new(MemoryDatabase::<HashDigest>::default()).unwrap();
-    let alice_mempool = Mempool::new(alice_blockchain_db.clone(), MempoolConfig::default());
-
-    let bob_node_identity = NodeIdentity::random(
-        &mut rng,
-        get_next_local_address().parse().unwrap(),
-        PeerFeatures::COMMUNICATION_NODE,
-    )
-    .unwrap();
-    let bob_blockchain_db = BlockchainDatabase::new(MemoryDatabase::<HashDigest>::default()).unwrap();
-    let bob_mempool = Mempool::new(bob_blockchain_db.clone(), MempoolConfig::default());
-
-    let (mut alice_outbound_mp_interface, _, alice_comms) = setup_mempool_service(
+    let mct_config = MerkleChangeTrackerConfig {
+        min_history_len: 10,
+        max_history_len: 30,
+    };
+    let (mut alice_node, bob_node) = create_network_with_2_base_nodes_with_config(
         &runtime,
-        alice_node_identity.clone(),
-        vec![bob_node_identity.clone()],
-        alice_mempool.clone(),
-        mempool_service_config.clone(),
-    );
-    let (_, _, bob_comms) = setup_mempool_service(
-        &runtime,
-        bob_node_identity,
-        vec![alice_node_identity],
-        bob_mempool,
+        BaseNodeServiceConfig::default(),
+        mct_config,
         mempool_service_config,
     );
 
     runtime.block_on(async {
-        match alice_outbound_mp_interface.get_stats().await {
+        match alice_node.outbound_mp_interface.get_stats().await {
             Err(MempoolServiceError::RequestTimedOut) => assert!(true),
             _ => assert!(false),
         }
     });
 
-    alice_comms.shutdown().unwrap();
-    bob_comms.shutdown().unwrap();
+    alice_node.comms.shutdown().unwrap();
+    bob_node.comms.shutdown().unwrap();
 }

--- a/base_layer/core/src/test_utils/mod.rs
+++ b/base_layer/core/src/test_utils/mod.rs
@@ -25,6 +25,7 @@ pub mod primitives;
 /// Helper functions to simplify generated test blockchain data
 #[macro_use]
 pub mod builders;
+pub mod node;
 /// Hardcoded sample blockchain databases
 pub mod sample_blockchains;
 pub mod test_common;

--- a/base_layer/core/src/test_utils/node.rs
+++ b/base_layer/core/src/test_utils/node.rs
@@ -1,0 +1,385 @@
+// Copyright 2019. The Tari Project
+//
+// Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+// following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+// disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+// following disclaimer in the documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+// products derived from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+// INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+// WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+// USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+use crate::{
+    base_node::{
+        service::{BaseNodeServiceConfig, BaseNodeServiceInitializer},
+        LocalNodeCommsInterface,
+        OutboundNodeCommsInterface,
+    },
+    chain_storage::{BlockchainDatabase, MemoryDatabase},
+    mempool::{
+        Mempool,
+        MempoolConfig,
+        MempoolServiceConfig,
+        MempoolServiceInitializer,
+        OutboundMempoolServiceInterface,
+    },
+    proof_of_work::DiffAdjManager,
+};
+use futures::Sink;
+use rand::{distributions::Alphanumeric, rngs::OsRng, Rng};
+use std::{error::Error, iter, sync::Arc, time::Duration};
+use tari_comms::{
+    builder::CommsNode,
+    control_service::ControlServiceConfig,
+    peer_manager::{NodeIdentity, Peer, PeerFeatures, PeerFlags},
+};
+use tari_comms_dht::{outbound::OutboundMessageRequester, Dht};
+use tari_mmr::MerkleChangeTrackerConfig;
+use tari_p2p::{
+    comms_connector::{pubsub_connector, InboundDomainConnector, PeerMessage},
+    initialization::{initialize_comms, CommsConfig},
+    services::comms_outbound::CommsOutboundServiceInitializer,
+};
+use tari_service_framework::StackBuilder;
+use tari_test_utils::address::get_next_local_address;
+use tari_transactions::types::HashDigest;
+use tempdir::TempDir;
+use tokio::runtime::{Runtime, TaskExecutor};
+
+/// The NodeInterfaces is used as a container for providing access to all the services and interfaces of a single node.
+pub struct NodeInterfaces {
+    pub node_identity: Arc<NodeIdentity>,
+    pub outbound_nci: OutboundNodeCommsInterface,
+    pub local_nci: LocalNodeCommsInterface,
+    pub outbound_mp_interface: OutboundMempoolServiceInterface,
+    pub outbound_message_service: OutboundMessageRequester,
+    pub blockchain_db: BlockchainDatabase<MemoryDatabase<HashDigest>>,
+    pub mempool: Mempool<MemoryDatabase<HashDigest>>,
+    pub comms: CommsNode,
+}
+
+/// The BaseNodeBuilder can be used to construct a test Base Node with all its relevant services and interfaces for
+/// testing.
+pub struct BaseNodeBuilder {
+    node_identity: Option<Arc<NodeIdentity>>,
+    peers: Option<Vec<Arc<NodeIdentity>>>,
+    base_node_service_config: Option<BaseNodeServiceConfig>,
+    mct_config: Option<MerkleChangeTrackerConfig>,
+    mempool_config: Option<MempoolConfig>,
+    mempool_service_config: Option<MempoolServiceConfig>,
+}
+
+impl BaseNodeBuilder {
+    /// Create a new BaseNodeBuilder
+    pub fn new() -> Self {
+        Self {
+            node_identity: None,
+            peers: None,
+            base_node_service_config: None,
+            mct_config: None,
+            mempool_config: None,
+            mempool_service_config: None,
+        }
+    }
+
+    /// Set node identity that should be used for the Base Node. If not specified a random identity will be used.
+    pub fn with_node_identity(mut self, node_identity: Arc<NodeIdentity>) -> Self {
+        self.node_identity = Some(node_identity);
+        self
+    }
+
+    /// Set the initial peers that will be available in the peer manager.
+    pub fn with_peers(mut self, peers: Vec<Arc<NodeIdentity>>) -> Self {
+        self.peers = Some(peers);
+        self
+    }
+
+    /// Set the configuration of the Base Node Service
+    pub fn with_base_node_service_config(mut self, config: BaseNodeServiceConfig) -> Self {
+        self.base_node_service_config = Some(config);
+        self
+    }
+
+    /// Set the configuration of the MerkleChangeTracker of the Base Node Backend
+    pub fn with_merkle_change_tracker_config(mut self, config: MerkleChangeTrackerConfig) -> Self {
+        self.mct_config = Some(config);
+        self
+    }
+
+    /// Set the configuration of the Mempool
+    pub fn with_mempool_config(mut self, config: MempoolConfig) -> Self {
+        self.mempool_config = Some(config);
+        self
+    }
+
+    /// Set the configuration of the Mempool Service
+    pub fn with_mempool_service_config(mut self, config: MempoolServiceConfig) -> Self {
+        self.mempool_service_config = Some(config);
+        self
+    }
+
+    /// Build the test base node and start its services.
+    pub fn start(self, runtime: &Runtime) -> NodeInterfaces {
+        let mct_config = self.mct_config.unwrap_or(MerkleChangeTrackerConfig {
+            min_history_len: 10,
+            max_history_len: 20,
+        });
+        let blockchain_db = BlockchainDatabase::new(MemoryDatabase::<HashDigest>::new(mct_config)).unwrap();
+        let mempool = Mempool::new(
+            blockchain_db.clone(),
+            self.mempool_config.unwrap_or(MempoolConfig::default()),
+        );
+        let diff_adj_manager = DiffAdjManager::new(blockchain_db.clone()).unwrap();
+
+        let node_identity = self.node_identity.unwrap_or(random_node_identity());
+        let (outbound_nci, local_nci, outbound_mp_interface, outbound_message_service, comms) =
+            setup_base_node_services(
+                &runtime,
+                node_identity.clone(),
+                self.peers.unwrap_or(Vec::new()),
+                blockchain_db.clone(),
+                mempool.clone(),
+                diff_adj_manager,
+                self.base_node_service_config
+                    .unwrap_or(BaseNodeServiceConfig::default()),
+                self.mempool_service_config.unwrap_or(MempoolServiceConfig::default()),
+            );
+
+        NodeInterfaces {
+            node_identity,
+            outbound_nci,
+            local_nci,
+            outbound_mp_interface,
+            outbound_message_service,
+            blockchain_db,
+            mempool,
+            comms,
+        }
+    }
+}
+
+// Creates a network with two Base Nodes where each node in the network knows the other nodes in the network.
+pub fn create_network_with_2_base_nodes(runtime: &Runtime) -> (NodeInterfaces, NodeInterfaces) {
+    let alice_node_identity = random_node_identity();
+    let bob_node_identity = random_node_identity();
+
+    let alice_node = BaseNodeBuilder::new()
+        .with_node_identity(alice_node_identity.clone())
+        .with_peers(vec![bob_node_identity.clone()])
+        .start(&runtime);
+    let bob_node = BaseNodeBuilder::new()
+        .with_node_identity(bob_node_identity)
+        .with_peers(vec![alice_node_identity])
+        .start(&runtime);
+
+    (alice_node, bob_node)
+}
+
+// Creates a network with two Base Nodes where each node in the network knows the other nodes in the network.
+pub fn create_network_with_2_base_nodes_with_config(
+    runtime: &Runtime,
+    base_node_service_config: BaseNodeServiceConfig,
+    mct_config: MerkleChangeTrackerConfig,
+    mempool_service_config: MempoolServiceConfig,
+) -> (NodeInterfaces, NodeInterfaces)
+{
+    let alice_node_identity = random_node_identity();
+    let bob_node_identity = random_node_identity();
+
+    let alice_node = BaseNodeBuilder::new()
+        .with_node_identity(alice_node_identity.clone())
+        .with_peers(vec![bob_node_identity.clone()])
+        .with_base_node_service_config(base_node_service_config)
+        .with_merkle_change_tracker_config(mct_config)
+        .with_mempool_service_config(mempool_service_config)
+        .start(&runtime);
+    let bob_node = BaseNodeBuilder::new()
+        .with_node_identity(bob_node_identity)
+        .with_peers(vec![alice_node_identity])
+        .with_base_node_service_config(base_node_service_config)
+        .with_merkle_change_tracker_config(mct_config)
+        .with_mempool_service_config(mempool_service_config)
+        .start(&runtime);
+
+    (alice_node, bob_node)
+}
+
+// Creates a network with three Base Nodes where each node in the network knows the other nodes in the network.
+pub fn create_network_with_3_base_nodes(runtime: &Runtime) -> (NodeInterfaces, NodeInterfaces, NodeInterfaces) {
+    let mct_config = MerkleChangeTrackerConfig {
+        min_history_len: 10,
+        max_history_len: 20,
+    };
+    create_network_with_3_base_nodes_with_config(
+        runtime,
+        BaseNodeServiceConfig::default(),
+        mct_config,
+        MempoolServiceConfig::default(),
+    )
+}
+
+// Creates a network with three Base Nodes where each node in the network knows the other nodes in the network.
+pub fn create_network_with_3_base_nodes_with_config(
+    runtime: &Runtime,
+    base_node_service_config: BaseNodeServiceConfig,
+    mct_config: MerkleChangeTrackerConfig,
+    mempool_service_config: MempoolServiceConfig,
+) -> (NodeInterfaces, NodeInterfaces, NodeInterfaces)
+{
+    let alice_node_identity = random_node_identity();
+    let bob_node_identity = random_node_identity();
+    let carol_node_identity = random_node_identity();
+
+    let alice_node = BaseNodeBuilder::new()
+        .with_node_identity(alice_node_identity.clone())
+        .with_peers(vec![bob_node_identity.clone(), carol_node_identity.clone()])
+        .with_base_node_service_config(base_node_service_config)
+        .with_merkle_change_tracker_config(mct_config)
+        .with_mempool_service_config(mempool_service_config)
+        .start(&runtime);
+    let bob_node = BaseNodeBuilder::new()
+        .with_node_identity(bob_node_identity.clone())
+        .with_peers(vec![alice_node_identity.clone(), carol_node_identity.clone()])
+        .with_base_node_service_config(base_node_service_config)
+        .with_merkle_change_tracker_config(mct_config)
+        .with_mempool_service_config(mempool_service_config)
+        .start(&runtime);
+    let carol_node = BaseNodeBuilder::new()
+        .with_node_identity(carol_node_identity.clone())
+        .with_peers(vec![alice_node_identity, bob_node_identity.clone()])
+        .with_base_node_service_config(base_node_service_config)
+        .with_merkle_change_tracker_config(mct_config)
+        .with_mempool_service_config(mempool_service_config)
+        .start(&runtime);
+
+    (alice_node, bob_node, carol_node)
+}
+
+fn random_string(len: usize) -> String {
+    let mut rng = OsRng::new().unwrap();
+    iter::repeat(()).map(|_| rng.sample(Alphanumeric)).take(len).collect()
+}
+
+// Helper function for creating a random node indentity.
+fn random_node_identity() -> Arc<NodeIdentity> {
+    let mut rng = OsRng::new().unwrap();
+    Arc::new(
+        NodeIdentity::random(
+            &mut rng,
+            get_next_local_address().parse().unwrap(),
+            PeerFeatures::COMMUNICATION_NODE,
+        )
+        .unwrap(),
+    )
+}
+
+// Helper function for starting the comms stack.
+fn setup_comms_services<TSink>(
+    executor: TaskExecutor,
+    node_identity: Arc<NodeIdentity>,
+    peers: Vec<Arc<NodeIdentity>>,
+    publisher: InboundDomainConnector<TSink>,
+) -> (CommsNode, Dht)
+where
+    TSink: Sink<Arc<PeerMessage>> + Clone + Unpin + Send + Sync + 'static,
+    TSink::Error: Error + Send + Sync,
+{
+    let comms_config = CommsConfig {
+        node_identity: Arc::clone(&node_identity),
+        peer_connection_listening_address: "127.0.0.1:0".parse().unwrap(),
+        socks_proxy_address: None,
+        control_service: ControlServiceConfig {
+            listener_address: node_identity.control_service_address(),
+            socks_proxy_address: None,
+            requested_connection_timeout: Duration::from_millis(2000),
+        },
+        datastore_path: TempDir::new(random_string(8).as_str())
+            .unwrap()
+            .path()
+            .to_str()
+            .unwrap()
+            .to_string(),
+        establish_connection_timeout: Duration::from_secs(5),
+        peer_database_name: random_string(8),
+        inbound_buffer_size: 100,
+        outbound_buffer_size: 100,
+        dht: Default::default(),
+    };
+
+    let (comms, dht) = initialize_comms(executor, comms_config, publisher).unwrap();
+
+    for p in peers {
+        let addr = p.control_service_address();
+        comms
+            .peer_manager()
+            .add_peer(Peer::new(
+                p.public_key().clone(),
+                p.node_id().clone(),
+                addr.into(),
+                PeerFlags::empty(),
+                p.features().clone(),
+            ))
+            .unwrap();
+    }
+
+    (comms, dht)
+}
+
+// Helper function for starting the services of the Base node.
+fn setup_base_node_services(
+    runtime: &Runtime,
+    node_identity: Arc<NodeIdentity>,
+    peers: Vec<Arc<NodeIdentity>>,
+    blockchain_db: BlockchainDatabase<MemoryDatabase<HashDigest>>,
+    mempool: Mempool<MemoryDatabase<HashDigest>>,
+    diff_adj_manager: DiffAdjManager<MemoryDatabase<HashDigest>>,
+    base_node_service_config: BaseNodeServiceConfig,
+    mempool_service_config: MempoolServiceConfig,
+) -> (
+    OutboundNodeCommsInterface,
+    LocalNodeCommsInterface,
+    OutboundMempoolServiceInterface,
+    OutboundMessageRequester,
+    CommsNode,
+)
+{
+    let (publisher, subscription_factory) = pubsub_connector(runtime.executor(), 100);
+    let subscription_factory = Arc::new(subscription_factory);
+    let (comms, dht) = setup_comms_services(runtime.executor(), node_identity, peers, publisher);
+
+    let fut = StackBuilder::new(runtime.executor(), comms.shutdown_signal())
+        .add_initializer(CommsOutboundServiceInitializer::new(dht.outbound_requester()))
+        .add_initializer(BaseNodeServiceInitializer::new(
+            subscription_factory.clone(),
+            blockchain_db,
+            mempool.clone(),
+            diff_adj_manager,
+            base_node_service_config,
+        ))
+        .add_initializer(MempoolServiceInitializer::new(
+            subscription_factory,
+            mempool,
+            mempool_service_config,
+        ))
+        .finish();
+
+    let handles = runtime.block_on(fut).expect("Service initialization failed");
+    (
+        handles.get_handle::<OutboundNodeCommsInterface>().unwrap(),
+        handles.get_handle::<LocalNodeCommsInterface>().unwrap(),
+        handles.get_handle::<OutboundMempoolServiceInterface>().unwrap(),
+        handles.get_handle::<OutboundMessageRequester>().unwrap(),
+        comms,
+    )
+}


### PR DESCRIPTION
## Description
- Unified the service test utilities of the Mempool service and Base Node service into a test BaseNodeBuilder in test_utils.
- The test BaseNodeBuilder provides a simple interface for constructing and configuring the different components of the Base Node.
- Helper functions for creating a network with 2 nodes or 3 nodes were also added.
- Cleaned and changed the tests of MempoolService and BaseNodeService to make use of the new test utilities and BaseNodeBuilder.

## Motivation and Context
The BaseNodeBuilder provides a simpler and cleaner interface for constructing a test node.

## How Has This Been Tested?
Existing tests were modified to make use of the new test utilities.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [x] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch
* [x] I ran `cargo-fmt --all` before pushing
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
