### PR TITLE
Add a final stage to the wallet Transaction Protocol

### DIFF
--- a/base_layer/p2p/src/proto/message_type.proto
+++ b/base_layer/p2p/src/proto/message_type.proto
@@ -21,7 +21,7 @@ enum TariMessageType {
     TariMessageTypeBaseNodeResponse = 70;
     TariMessageTypeMempoolRequest= 71;
     TariMessageTypeMempoolResponse = 72;
-
+    TariMessageTypeTransactionFinalized = 73;
     // -- DAN Messages --
 
     // -- Extended --

--- a/base_layer/transactions/src/transaction_protocol/proto/transaction_finalized.proto
+++ b/base_layer/transactions/src/transaction_protocol/proto/transaction_finalized.proto
@@ -1,0 +1,13 @@
+syntax = "proto3";
+
+import "transaction.proto";
+
+package tari.transaction_protocol;
+
+message TransactionFinalizedMessage {
+    // The transaction id for the recipient
+    uint64 tx_id = 1;
+   // The actual transaction;
+    tari.types.Transaction transaction = 2;
+}
+

--- a/base_layer/wallet/src/lib.rs
+++ b/base_layer/wallet/src/lib.rs
@@ -1,4 +1,4 @@
-#![recursion_limit = "256"]
+#![recursion_limit = "512"]
 #![feature(drain_filter)]
 #![feature(type_alias_impl_trait)]
 

--- a/base_layer/wallet/src/transaction_service/error.rs
+++ b/base_layer/wallet/src/transaction_service/error.rs
@@ -31,15 +31,15 @@ use time::OutOfRangeError;
 
 #[derive(Debug, Error)]
 pub enum TransactionServiceError {
-    // Transaction protocol is not in the correct state for this operation
+    /// Transaction protocol is not in the correct state for this operation
     InvalidStateError,
-    // Transaction Protocol Error
+    /// Transaction Protocol Error
     TransactionProtocolError(TransactionProtocolError),
-    // The message being process is not recognized by the Transaction Manager
+    /// The message being process is not recognized by the Transaction Manager
     InvalidMessageTypeError,
-    // A message for a specific tx_id has been repeated
+    /// A message for a specific tx_id has been repeated
     RepeatedMessageError,
-    // A recipient reply was received for a non-existent tx_id
+    /// A recipient reply was received for a non-existent tx_id
     TransactionDoesNotExistError,
     /// The Outbound Message Service is not initialized
     OutboundMessageServiceNotInitialized,
@@ -51,6 +51,11 @@ pub enum TransactionServiceError {
     ApiReceiveFailed,
     /// An error has occurred reading or writing the event subscriber stream
     EventStreamError,
+    /// The Source Public Key on the received transaction does not match the transaction with the same TX_ID in the
+    /// database
+    InvalidSourcePublicKey,
+    /// The transaction does not contain the receivers output
+    ReceiverOutputNotFound,
     OutboundError(DhtOutboundError),
     OutputManagerError(OutputManagerError),
     TransportChannelError(TransportChannelError),

--- a/base_layer/wallet/src/transaction_service/mod.rs
+++ b/base_layer/wallet/src/transaction_service/mod.rs
@@ -98,6 +98,13 @@ where T: TransactionBackend
             .map(map_decode::<proto::RecipientSignedMessage>)
             .filter_map(ok_or_skip_result)
     }
+
+    fn transaction_finalized_stream(&self) -> impl Stream<Item = DomainMessage<proto::TransactionFinalizedMessage>> {
+        self.subscription_factory
+            .get_subscription(TariMessageType::TransactionFinalized)
+            .map(map_decode::<proto::TransactionFinalizedMessage>)
+            .filter_map(ok_or_skip_result)
+    }
 }
 
 impl<T> ServiceInitializer for TransactionServiceInitializer<T>
@@ -115,6 +122,7 @@ where T: TransactionBackend + 'static
         let (sender, receiver) = reply_channel::unbounded();
         let transaction_stream = self.transaction_stream();
         let transaction_reply_stream = self.transaction_reply_stream();
+        let transaction_finalized_stream = self.transaction_finalized_stream();
 
         let (publisher, subscriber) = bounded(100);
 
@@ -145,6 +153,7 @@ where T: TransactionBackend + 'static
                 receiver,
                 transaction_stream,
                 transaction_reply_stream,
+                transaction_finalized_stream,
                 output_manager_service,
                 outbound_message_service,
                 publisher,

--- a/base_layer/wallet/src/transaction_service/storage/database.rs
+++ b/base_layer/wallet/src/transaction_service/storage/database.rs
@@ -216,6 +216,11 @@ where T: TransactionBackend
         Ok(result)
     }
 
+    pub fn get_pending_inbound_transaction(&self, tx_id: TxId) -> Result<InboundTransaction, TransactionStorageError> {
+        let result = fetch!(self, tx_id, PendingInboundTransaction)?;
+        Ok(result)
+    }
+
     pub fn get_pending_inbound_transactions(
         &self,
     ) -> Result<HashMap<TxId, InboundTransaction>, TransactionStorageError> {

--- a/base_layer/wallet/src/transaction_service/storage/memory_db.rs
+++ b/base_layer/wallet/src/transaction_service/storage/memory_db.rs
@@ -206,16 +206,14 @@ impl TransactionBackend for TransactionMemoryDatabase {
         if db.completed_transactions.contains_key(&tx_id) {
             return Err(TransactionStorageError::TransactionAlreadyExists);
         }
-
         let _ = db
             .pending_inbound_transactions
             .remove(&tx_id)
             .ok_or(TransactionStorageError::ValueNotFound(
-                DbKey::PendingOutboundTransaction(tx_id.clone()),
+                DbKey::PendingInboundTransaction(tx_id.clone()),
             ))?;
 
         db.completed_transactions.insert(tx_id, transaction);
-
         Ok(())
     }
 

--- a/base_layer/wallet/src/wallet.rs
+++ b/base_layer/wallet/src/wallet.rs
@@ -19,11 +19,7 @@
 // SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-#[cfg(feature = "c_integration")]
-use crate::transaction_service::{
-    error::TransactionServiceError,
-    storage::database::{CompletedTransaction, InboundTransaction},
-};
+
 use crate::{
     contacts_service::{
         handle::ContactsServiceHandle,
@@ -182,52 +178,6 @@ where T: WalletBackend
             runtime,
             log_handle,
         })
-    }
-
-    #[cfg(feature = "c_integration")]
-    pub async fn register_callback_received_transaction(
-        &mut self,
-        call: unsafe extern "C" fn(*mut InboundTransaction),
-    ) -> Result<(), TransactionServiceError>
-    {
-        self.transaction_service
-            .register_callback_received_transaction(call)
-            .await?;
-        Ok(())
-    }
-
-    #[cfg(feature = "c_integration")]
-    pub async fn register_callback_received_transaction_reply(
-        &mut self,
-        call: unsafe extern "C" fn(*mut CompletedTransaction),
-    ) -> Result<(), TransactionServiceError>
-    {
-        self.transaction_service
-            .register_callback_received_transaction_reply(call)
-            .await?;
-        Ok(())
-    }
-
-    #[cfg(feature = "c_integration")]
-    pub async fn register_callback_mined(
-        &mut self,
-        call: unsafe extern "C" fn(*mut CompletedTransaction),
-    ) -> Result<(), TransactionServiceError>
-    {
-        self.transaction_service.register_callback_mined(call).await?;
-        Ok(())
-    }
-
-    #[cfg(feature = "c_integration")]
-    pub async fn register_callback_transaction_broadcast(
-        &mut self,
-        call: unsafe extern "C" fn(*mut CompletedTransaction),
-    ) -> Result<(), TransactionServiceError>
-    {
-        self.transaction_service
-            .register_callback_transaction_broadcast(call)
-            .await?;
-        Ok(())
     }
 
     /// This method consumes the wallet so that the handles are dropped which will result in the services async loops

--- a/base_layer/wallet/tests/output_manager_service/service.rs
+++ b/base_layer/wallet/tests/output_manager_service/service.rs
@@ -22,7 +22,7 @@
 
 use crate::support::{
     data::create_temporary_sqlite_path,
-    utils::{make_input, random_string, TestParams},
+    utils::{make_input, TestParams},
 };
 use rand::RngCore;
 use std::{thread, time::Duration};
@@ -53,7 +53,6 @@ use tari_wallet::output_manager_service::{
     OutputManagerConfig,
     OutputManagerServiceInitializer,
 };
-use tempdir::TempDir;
 use tokio::runtime::Runtime;
 
 pub fn setup_output_manager_service<T: OutputManagerBackend + 'static>(

--- a/base_layer/wallet/tests/output_manager_service/storage.rs
+++ b/base_layer/wallet/tests/output_manager_service/storage.rs
@@ -20,10 +20,7 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use crate::support::{
-    data::create_temporary_sqlite_path,
-    utils::{make_input, random_string},
-};
+use crate::support::{data::create_temporary_sqlite_path, utils::make_input};
 use chrono::{Duration as ChronoDuration, Utc};
 use rand::RngCore;
 use std::time::Duration;
@@ -36,7 +33,6 @@ use tari_wallet::output_manager_service::{
         sqlite_db::OutputManagerSqliteDatabase,
     },
 };
-use tempdir::TempDir;
 
 pub fn test_db_backend<T: OutputManagerBackend>(backend: T) {
     let mut db = OutputManagerDatabase::new(backend);

--- a/base_layer/wallet/tests/support/comms_and_services.rs
+++ b/base_layer/wallet/tests/support/comms_and_services.rs
@@ -22,7 +22,6 @@
 
 use crate::support::utils::random_string;
 use futures::Sink;
-use rand::rngs::OsRng;
 use std::{error::Error, sync::Arc, time::Duration};
 use tari_comms::{
     builder::CommsNode,
@@ -32,7 +31,6 @@ use tari_comms::{
     types::CommsPublicKey,
 };
 use tari_comms_dht::{envelope::DhtMessageHeader, Dht};
-use tari_crypto::keys::PublicKey;
 use tari_p2p::{
     comms_connector::{InboundDomainConnector, PeerMessage},
     domain_message::DomainMessage,
@@ -93,12 +91,10 @@ where
     (comms, dht)
 }
 
-pub fn create_dummy_message<T>(inner: T) -> DomainMessage<T> {
-    let mut rng = OsRng::new().unwrap();
-    let (_, pk) = CommsPublicKey::random_keypair(&mut rng);
+pub fn create_dummy_message<T>(inner: T, public_key: &CommsPublicKey) -> DomainMessage<T> {
     let peer_source = Peer::new(
-        pk.clone(),
-        NodeId::from_key(&pk).unwrap(),
+        public_key.clone(),
+        NodeId::from_key(public_key).unwrap(),
         Vec::<NetAddress>::new().into(),
         PeerFlags::empty(),
         PeerFeatures::COMMUNICATION_NODE,

--- a/base_layer/wallet/tests/support/data.rs
+++ b/base_layer/wallet/tests/support/data.rs
@@ -22,7 +22,6 @@
 
 use crate::support::utils::random_string;
 use std::path::PathBuf;
-use tari_test_utils::random::string;
 use tempdir::TempDir;
 
 pub fn get_path(name: Option<&str>) -> String {

--- a/base_layer/wallet/tests/wallet/mod.rs
+++ b/base_layer/wallet/tests/wallet/mod.rs
@@ -254,12 +254,6 @@ fn test_data_generation() {
         .unwrap();
     assert!(outbound_tx.len() > 0);
 
-    let inbound_tx = wallet
-        .runtime
-        .block_on(wallet.transaction_service.get_pending_inbound_transactions())
-        .unwrap();
-    assert!(inbound_tx.len() > 0);
-
     let completed_tx = wallet
         .runtime
         .block_on(wallet.transaction_service.get_completed_transactions())

--- a/base_layer/wallet_ffi/src/lib.rs
+++ b/base_layer/wallet_ffi/src/lib.rs
@@ -1918,9 +1918,11 @@ pub unsafe extern "C" fn wallet_callback_register_received_transaction(
     call: unsafe extern "C" fn(*mut TariPendingInboundTransaction),
 ) -> bool
 {
-    let result = (*wallet)
-        .runtime
-        .block_on((*wallet).register_callback_received_transaction(call));
+    let result = (*wallet).runtime.block_on(
+        (*wallet)
+            .transaction_service
+            .register_callback_received_transaction(call),
+    );
     match result {
         Ok(_) => true,
         Err(_) => false,
@@ -1941,9 +1943,36 @@ pub unsafe extern "C" fn wallet_callback_register_received_transaction_reply(
     call: unsafe extern "C" fn(*mut TariCompletedTransaction),
 ) -> bool
 {
-    let result = (*wallet)
-        .runtime
-        .block_on((*wallet).register_callback_received_transaction_reply(call));
+    let result = (*wallet).runtime.block_on(
+        (*wallet)
+            .transaction_service
+            .register_callback_received_transaction_reply(call),
+    );
+    match result {
+        Ok(_) => true,
+        Err(_) => false,
+    }
+}
+
+/// Registers a callback function for when a Receiver receives a finalized transaction from a sender
+///
+/// ## Arguments
+/// `wallet` - The TariWallet pointer
+/// `call` - The callback function pointer matching the function signature
+///
+/// ## Returns
+/// `bool` - Returns if successful or not
+#[no_mangle]
+pub unsafe extern "C" fn wallet_callback_register_received_finalized_transaction(
+    wallet: *mut TariWallet,
+    call: unsafe extern "C" fn(*mut TariCompletedTransaction),
+) -> bool
+{
+    let result = (*wallet).runtime.block_on(
+        (*wallet)
+            .transaction_service
+            .register_callback_received_finalized_transaction(call),
+    );
     match result {
         Ok(_) => true,
         Err(_) => false,
@@ -1964,7 +1993,9 @@ pub unsafe extern "C" fn wallet_callback_register_mined(
     call: unsafe extern "C" fn(*mut TariCompletedTransaction),
 ) -> bool
 {
-    let result = (*wallet).runtime.block_on((*wallet).register_callback_mined(call));
+    let result = (*wallet)
+        .runtime
+        .block_on((*wallet).transaction_service.register_callback_mined(call));
     match result {
         Ok(_) => true,
         Err(_) => false,
@@ -1985,9 +2016,11 @@ pub unsafe extern "C" fn wallet_callback_register_transaction_broadcast(
     call: unsafe extern "C" fn(*mut TariCompletedTransaction),
 ) -> bool
 {
-    let result = (*wallet)
-        .runtime
-        .block_on((*wallet).register_callback_transaction_broadcast(call));
+    let result = (*wallet).runtime.block_on(
+        (*wallet)
+            .transaction_service
+            .register_callback_transaction_broadcast(call),
+    );
     match result {
         Ok(_) => true,
         Err(_) => false,

--- a/base_layer/wallet_ffi/wallet.h
+++ b/base_layer/wallet_ffi/wallet.h
@@ -353,6 +353,10 @@ bool wallet_callback_register_received_transaction(struct TariWallet *wallet, vo
 // Registers a callback function for when a reply is received for a TariPendingOutboundTransaction
 bool wallet_callback_register_received_transaction_reply(struct TariWallet *wallet, void (*call)(struct TariCompletedTransaction*));
 
+// Registers a callback function for when a Receiver receives a finalized transaction from a sender
+bool wallet_callback_register_received_finalized_transaction(struct TariWallet *wallet, void (*call)(struct TariCompletedTransaction*));
+
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
## Description
Currently the transaction protocol between a Sender and Receiver wallet involves 2 stages. 

1. Sender send Partial Tx to Receiver
2. Receiver Signs Tx and sends partial Tx to Sender

The Sender then completes the Tx and broadcasts it. This means the Receiver is only aware of the finalised transaction once they spot it in the mempool.

It was decided to add one more message to the protocol where the Sender will send the Finalised transaction back to the Receiver so that they have a copy of it before it appears in the mempool. This makes it easier for the Receiver to spot the Tx in the mempool OR if the sender does not broadcast it the Receiver can potentially broadcast it.

This PR adds this sending of the finalised transaction and adds a FFI callback for receiving this message and a number of tests.

## Motivation and Context
Closes https://github.com/tari-project/tari/issues/1076

## How Has This Been Tested?
Tests provided

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [x] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch
* [x] I ran `cargo-fmt --all` before pushing
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
