### PR TITLE
Update the FFI Wallet container to use the Sqlite backends

### DIFF
--- a/base_layer/wallet/src/error.rs
+++ b/base_layer/wallet/src/error.rs
@@ -21,6 +21,7 @@
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 use crate::{
+    contacts_service::error::ContactsServiceError,
     output_manager_service::error::OutputManagerError,
     storage::database::DbKey,
     transaction_service::error::TransactionServiceError,
@@ -31,6 +32,7 @@ use log::SetLoggerError;
 use serde_json::Error as SerdeJsonError;
 use tari_comms::{builder::CommsError, connection::NetAddressError, peer_manager::PeerManagerError};
 use tari_p2p::initialization::CommsInitializationError;
+
 #[derive(Debug, Error)]
 pub enum WalletError {
     CommsInitializationError(CommsInitializationError),
@@ -41,6 +43,7 @@ pub enum WalletError {
     NetAddressError(NetAddressError),
     WalletStorageError(WalletStorageError),
     SetLoggerError(SetLoggerError),
+    ContactsServiceError(ContactsServiceError),
 }
 
 #[derive(Debug, Error)]

--- a/base_layer/wallet/tests/wallet/mod.rs
+++ b/base_layer/wallet/tests/wallet/mod.rs
@@ -36,9 +36,10 @@ use tari_transactions::{tari_amount::MicroTari, types::CryptoFactories};
 #[cfg(feature = "test_harness")]
 use tari_wallet::testnet_utils::broadcast_transaction;
 use tari_wallet::{
-    contacts_service::storage::database::Contact,
+    contacts_service::storage::{database::Contact, memory_db::ContactsServiceMemoryDatabase},
+    output_manager_service::storage::memory_db::OutputManagerMemoryDatabase,
     storage::memory_db::WalletMemoryDatabase,
-    transaction_service::handle::TransactionEvent,
+    transaction_service::{handle::TransactionEvent, storage::memory_db::TransactionMemoryDatabase},
     wallet::WalletConfig,
     Wallet,
 };
@@ -128,8 +129,24 @@ fn test_wallet() {
     };
     let runtime_node1 = Runtime::new().unwrap();
     let runtime_node2 = Runtime::new().unwrap();
-    let mut alice_wallet = Wallet::new(config1, WalletMemoryDatabase::new(), runtime_node1).unwrap();
-    let bob_wallet = Wallet::new(config2, WalletMemoryDatabase::new(), runtime_node2).unwrap();
+    let mut alice_wallet = Wallet::new(
+        config1,
+        runtime_node1,
+        WalletMemoryDatabase::new(),
+        TransactionMemoryDatabase::new(),
+        OutputManagerMemoryDatabase::new(),
+        ContactsServiceMemoryDatabase::new(),
+    )
+    .unwrap();
+    let bob_wallet = Wallet::new(
+        config2,
+        runtime_node2,
+        WalletMemoryDatabase::new(),
+        TransactionMemoryDatabase::new(),
+        OutputManagerMemoryDatabase::new(),
+        ContactsServiceMemoryDatabase::new(),
+    )
+    .unwrap();
 
     alice_wallet
         .comms
@@ -235,7 +252,15 @@ fn test_data_generation() {
         logging_path: None,
     };
 
-    let mut wallet = Wallet::new(config, WalletMemoryDatabase::new(), runtime).unwrap();
+    let mut wallet = Wallet::new(
+        config,
+        runtime,
+        WalletMemoryDatabase::new(),
+        TransactionMemoryDatabase::new(),
+        OutputManagerMemoryDatabase::new(),
+        ContactsServiceMemoryDatabase::new(),
+    )
+    .unwrap();
 
     generate_wallet_test_data(&mut wallet).unwrap();
 
@@ -318,7 +343,15 @@ fn test_test_harness() {
     };
 
     let runtime = Runtime::new().unwrap();
-    let mut alice_wallet = Wallet::new(config1, WalletMemoryDatabase::new(), runtime).unwrap();
+    let mut alice_wallet = Wallet::new(
+        config1,
+        runtime,
+        WalletMemoryDatabase::new(),
+        TransactionMemoryDatabase::new(),
+        OutputManagerMemoryDatabase::new(),
+        ContactsServiceMemoryDatabase::new(),
+    )
+    .unwrap();
 
     let value = MicroTari::from(1000);
     let (_utxo, uo1) = make_input(&mut rng, MicroTari(2500), &factories.commitment);


### PR DESCRIPTION
## Description
This PR Updates the wallet container to accept all 4 storage backends for the services it contains. This allows for the Wallet services that require storage to be constructed with either types of backend.

The Wallet FFI now builds the Wallet container using the Sqlite persistence backend.

## Motivation and Context
Closes #55 

## How Has This Been Tested?
Existing tests, test this

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch
* [x] I ran `cargo-fmt --all` before pushing
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
