### PR TITLE
Fix the usage of TempDir

### DIFF
--- a/applications/grpc_wallet/tests/wallet_grpc_server/wallet_grpc_server.rs
+++ b/applications/grpc_wallet/tests/wallet_grpc_server/wallet_grpc_server.rs
@@ -518,6 +518,7 @@ fn test_rpc_text_message_service() {
     let node_identity1 = NodeIdentity::new(secret_key1, listener_address1.clone())
         .map(Arc::new)
         .unwrap();
+    let temp_dir1 = TempDir::new(random_string(8).as_str()).unwrap();
     let config1 = WalletConfig {
         comms: CommsConfig {
             control_service: ControlServiceConfig {
@@ -528,12 +529,7 @@ fn test_rpc_text_message_service() {
             socks_proxy_address: None,
             host: "127.0.0.1".parse().unwrap(),
             node_identity: node_identity1,
-            datastore_path: TempDir::new(random_string(8).as_str())
-                .unwrap()
-                .path()
-                .to_str()
-                .unwrap()
-                .to_string(),
+            datastore_path: temp_dir1.path().to_str().unwrap().to_string(),
             peer_database_name: random_string(8),
             // TODO: configureable
             inbound_buffer_size: 30,
@@ -548,6 +544,7 @@ fn test_rpc_text_message_service() {
     let node_identity2 = NodeIdentity::new(secret_key2, listener_address2.clone())
         .map(Arc::new)
         .unwrap();
+    let temp_dir2 = TempDir::new(random_string(8).as_str()).unwrap();
     let config2 = WalletConfig {
         comms: CommsConfig {
             control_service: ControlServiceConfig {
@@ -558,12 +555,7 @@ fn test_rpc_text_message_service() {
             socks_proxy_address: None,
             host: "127.0.0.1".parse().unwrap(),
             node_identity: node_identity2,
-            datastore_path: TempDir::new(random_string(8).as_str())
-                .unwrap()
-                .path()
-                .to_str()
-                .unwrap()
-                .to_string(),
+            datastore_path: temp_dir2.path().to_str().unwrap().to_string(),
             peer_database_name: random_string(8),
             // TODO: configureable
             inbound_buffer_size: 30,

--- a/base_layer/core/src/mempool/test/service.rs
+++ b/base_layer/core/src/mempool/test/service.rs
@@ -40,19 +40,22 @@ use std::{
 use tari_comms_dht::{domain_message::OutboundDomainMessage, outbound::OutboundEncryption};
 use tari_mmr::MerkleChangeTrackerConfig;
 use tari_p2p::tari_message::TariMessageType;
-use tari_test_utils::async_assert_eventually;
+use tari_test_utils::{async_assert_eventually, random::string};
 use tari_transactions::{
     proto::types as proto,
     tari_amount::{uT, T},
     types::CryptoFactories,
 };
+use tempdir::TempDir;
 use tokio::runtime::Runtime;
 
 #[test]
 fn request_response_get_stats() {
     let factories = CryptoFactories::default();
     let runtime = Runtime::new().unwrap();
-    let (mut alice_node, bob_node, carol_node) = create_network_with_3_base_nodes(&runtime);
+    let temp_dir = TempDir::new(string(8).as_str()).unwrap();
+    let (mut alice_node, bob_node, carol_node) =
+        create_network_with_3_base_nodes(&runtime, temp_dir.path().to_str().unwrap());
 
     let (block0, utxo) = create_genesis_block(&factories);
     add_block_and_update_header(&bob_node.blockchain_db, block0.clone());
@@ -89,7 +92,9 @@ fn request_response_get_stats() {
 fn request_response_get_tx_state_with_excess_sig() {
     let factories = CryptoFactories::default();
     let runtime = Runtime::new().unwrap();
-    let (mut alice_node, bob_node, carol_node) = create_network_with_3_base_nodes(&runtime);
+    let temp_dir = TempDir::new(string(8).as_str()).unwrap();
+    let (mut alice_node, bob_node, carol_node) =
+        create_network_with_3_base_nodes(&runtime, temp_dir.path().to_str().unwrap());
 
     let (block0, utxo) = create_genesis_block(&factories);
     add_block_and_update_header(&bob_node.blockchain_db, block0.clone());
@@ -143,7 +148,9 @@ fn request_response_get_tx_state_with_excess_sig() {
 fn receive_and_propagate_transaction() {
     let factories = CryptoFactories::default();
     let runtime = Runtime::new().unwrap();
-    let (mut alice_node, bob_node, carol_node) = create_network_with_3_base_nodes(&runtime);
+    let temp_dir = TempDir::new(string(8).as_str()).unwrap();
+    let (mut alice_node, bob_node, carol_node) =
+        create_network_with_3_base_nodes(&runtime, temp_dir.path().to_str().unwrap());
 
     let (block0, utxo) = create_genesis_block(&factories);
     add_block_and_update_header(&alice_node.blockchain_db, block0.clone());
@@ -218,11 +225,13 @@ fn service_request_timeout() {
         min_history_len: 10,
         max_history_len: 30,
     };
+    let temp_dir = TempDir::new(string(8).as_str()).unwrap();
     let (mut alice_node, bob_node) = create_network_with_2_base_nodes_with_config(
         &runtime,
         BaseNodeServiceConfig::default(),
         mct_config,
         mempool_service_config,
+        temp_dir.path().to_str().unwrap(),
     );
 
     runtime.block_on(async {

--- a/base_layer/p2p/src/initialization.rs
+++ b/base_layer/p2p/src/initialization.rs
@@ -85,7 +85,6 @@ where
     TSink: Sink<Arc<PeerMessage>> + Unpin + Clone + Send + Sync + 'static,
     TSink::Error: Error + Send + Sync,
 {
-    let _ = std::fs::create_dir(&config.datastore_path).unwrap_or_default();
     let datastore = LMDBBuilder::new()
         .set_path(&config.datastore_path)
         .set_environment_size(10)

--- a/base_layer/p2p/tests/support/comms_and_services.rs
+++ b/base_layer/p2p/tests/support/comms_and_services.rs
@@ -33,7 +33,6 @@ use tari_p2p::{
     initialization::{initialize_comms, CommsConfig},
 };
 use tari_test_utils::random;
-use tempdir::TempDir;
 use tokio::runtime::TaskExecutor;
 
 pub fn setup_comms_services<TSink>(
@@ -41,6 +40,7 @@ pub fn setup_comms_services<TSink>(
     node_identity: Arc<NodeIdentity>,
     peers: Vec<NodeIdentity>,
     publisher: InboundDomainConnector<TSink>,
+    data_path: &str,
 ) -> (Arc<CommsNode>, Dht)
 where
     TSink: Sink<Arc<PeerMessage>> + Clone + Unpin + Send + Sync + 'static,
@@ -55,12 +55,7 @@ where
             socks_proxy_address: None,
             requested_connection_timeout: Duration::from_millis(2000),
         },
-        datastore_path: TempDir::new(random::string(8).as_str())
-            .unwrap()
-            .path()
-            .to_str()
-            .unwrap()
-            .to_string(),
+        datastore_path: data_path.to_string(),
         establish_connection_timeout: Duration::from_secs(5),
         peer_database_name: random::string(8),
         inbound_buffer_size: 10,

--- a/base_layer/wallet/src/testnet_utils.rs
+++ b/base_layer/wallet/src/testnet_utils.rs
@@ -101,6 +101,7 @@ pub fn random_string(len: usize) -> String {
 pub fn create_wallet(
     secret_key: CommsSecretKey,
     net_address: String,
+    data_path: String,
 ) -> Wallet<WalletMemoryDatabase, TransactionMemoryDatabase, OutputManagerMemoryDatabase, ContactsServiceMemoryDatabase>
 {
     let runtime = Runtime::new().unwrap();
@@ -122,12 +123,7 @@ pub fn create_wallet(
             requested_connection_timeout: Duration::from_millis(500),
         },
         establish_connection_timeout: Duration::from_secs(2),
-        datastore_path: TempDir::new(random_string(8).as_str())
-            .unwrap()
-            .path()
-            .to_str()
-            .unwrap()
-            .to_string(),
+        datastore_path: data_path,
         peer_database_name: random_string(8),
         inbound_buffer_size: 100,
         outbound_buffer_size: 100,
@@ -206,7 +202,12 @@ pub fn generate_wallet_test_data<
     }
 
     // Generate some Tx history
-    let mut wallet_alice = create_wallet(generated_contacts[0].0.clone(), generated_contacts[0].1.clone());
+    let alice_temp_dir = TempDir::new(random_string(8).as_str()).unwrap();
+    let mut wallet_alice = create_wallet(
+        generated_contacts[0].0.clone(),
+        generated_contacts[0].1.clone(),
+        alice_temp_dir.path().to_str().unwrap().to_string(),
+    );
     for i in 0..20 {
         let (_ti, uo) = make_input(&mut rng.clone(), MicroTari::from(1_500_000 + i * 530_500), &factories);
         wallet_alice
@@ -214,8 +215,12 @@ pub fn generate_wallet_test_data<
             .block_on(wallet_alice.output_manager_service.add_output(uo))
             .unwrap();
     }
-
-    let mut wallet_bob = create_wallet(generated_contacts[1].0.clone(), generated_contacts[1].1.clone());
+    let bob_temp_dir = TempDir::new(random_string(8).as_str()).unwrap();
+    let mut wallet_bob = create_wallet(
+        generated_contacts[1].0.clone(),
+        generated_contacts[1].1.clone(),
+        bob_temp_dir.path().to_str().unwrap().to_string(),
+    );
     for i in 0..20 {
         let (_ti, uo) = make_input(
             &mut rng.clone(),

--- a/base_layer/wallet/tests/support/comms_and_services.rs
+++ b/base_layer/wallet/tests/support/comms_and_services.rs
@@ -36,7 +36,6 @@ use tari_p2p::{
     domain_message::DomainMessage,
     initialization::{initialize_comms, CommsConfig},
 };
-use tempdir::TempDir;
 use tokio::runtime::TaskExecutor;
 
 pub fn setup_comms_services<TSink>(
@@ -45,6 +44,7 @@ pub fn setup_comms_services<TSink>(
     listening_address: NetAddress,
     peers: Vec<NodeIdentity>,
     publisher: InboundDomainConnector<TSink>,
+    database_path: String,
 ) -> (CommsNode, Dht)
 where
     TSink: Sink<Arc<PeerMessage>> + Clone + Unpin + Send + Sync + 'static,
@@ -59,12 +59,7 @@ where
             socks_proxy_address: None,
             requested_connection_timeout: Duration::from_millis(2000),
         },
-        datastore_path: TempDir::new(random_string(8).as_str())
-            .unwrap()
-            .path()
-            .to_str()
-            .unwrap()
-            .to_string(),
+        datastore_path: database_path,
         establish_connection_timeout: Duration::from_secs(3),
         peer_database_name: random_string(8),
         inbound_buffer_size: 100,


### PR DESCRIPTION
## Description
We were using TempDir incorrectly. We were essentially using it to generate a random path for us, the letting it delete that directory but then remake the directly ourselves but never clean it up.

There was a line in the comms_setup that did this with a silent error which I have removed and then fixed all the usages of tempdir to be used correctly so the resulting directory is cleaned at the end of the test.

## Motivation and Context
Properly cleanup temporary files in tests

## How Has This Been Tested?
Updated tests

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [x] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [x] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch
* [x] I ran `cargo-fmt --all` before pushing
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
