### PR TITLE
Add `calculate_mmr_root` utility functions

### DIFF
--- a/base_layer/core/src/chain_storage/lmdb_db/lmdb_db.rs
+++ b/base_layer/core/src/chain_storage/lmdb_db/lmdb_db.rs
@@ -55,7 +55,7 @@ use std::{
     sync::{Arc, RwLock},
 };
 use tari_mmr::{
-    pruned_mmr::prune_mutable_mmr,
+    functions::prune_mutable_mmr,
     Hash as MmrHash,
     MerkleChangeTracker,
     MerkleChangeTrackerConfig,

--- a/base_layer/core/src/chain_storage/memory_db.rs
+++ b/base_layer/core/src/chain_storage/memory_db.rs
@@ -45,7 +45,7 @@ use std::{
     sync::{Arc, RwLock, RwLockReadGuard, RwLockWriteGuard},
 };
 use tari_mmr::{
-    pruned_mmr::prune_mutable_mmr,
+    functions::prune_mutable_mmr,
     Hash as MmrHash,
     MerkleChangeTracker,
     MerkleChangeTrackerConfig,

--- a/base_layer/mmr/src/change_tracker.rs
+++ b/base_layer/mmr/src/change_tracker.rs
@@ -23,8 +23,8 @@
 use crate::{
     backend::{ArrayLike, ArrayLikeExt},
     error::MerkleMountainRangeError,
+    functions::{prune_mutable_mmr, PrunedMutableMmr},
     mutable_mmr_leaf_nodes::MutableMmrLeafNodes,
-    pruned_mmr::{prune_mutable_mmr, PrunedMutableMmr},
     Hash,
     MutableMmr,
 };

--- a/base_layer/mmr/src/lib.rs
+++ b/base_layer/mmr/src/lib.rs
@@ -146,9 +146,9 @@ mod serde_support;
 // Less commonly used exports
 pub mod common;
 pub mod error;
+pub mod functions;
 /// A function for snapshotting and pruning a Merkle Mountain Range
 pub mod pruned_hashset;
-pub mod pruned_mmr;
 
 // Commonly used exports
 /// A vector-based backend for [MerkleMountainRange]

--- a/base_layer/mmr/tests/support/mod.rs
+++ b/base_layer/mmr/tests/support/mod.rs
@@ -23,12 +23,21 @@
 
 use digest::Digest;
 use tari_crypto::common::Blake256;
-use tari_mmr::{Hash, HashSlice, MerkleMountainRange};
+use tari_mmr::{Hash, HashSlice, MerkleMountainRange, MutableMmr};
 
 pub type Hasher = Blake256;
 
 pub fn create_mmr(size: usize) -> MerkleMountainRange<Hasher, Vec<Hash>> {
     let mut mmr = MerkleMountainRange::<Hasher, _>::new(Vec::default());
+    for i in 0..size {
+        let hash = int_to_hash(i);
+        assert!(mmr.push(&hash).is_ok());
+    }
+    mmr
+}
+
+pub fn create_mutable_mmr(size: usize) -> MutableMmr<Hasher, Vec<Hash>> {
+    let mut mmr = MutableMmr::<Hasher, _>::new(Vec::default());
     for i in 0..size {
         let hash = int_to_hash(i);
         assert!(mmr.push(&hash).is_ok());


### PR DESCRIPTION
A useful feature is to be able to relatively cheaply calculate a new MMR
root by simulating changes to a MMR without changing the MMR itself.

This PR adds two new functions that provide this functionality.


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [x] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch
* [x] I ran `cargo-fmt --all` before pushing
* [ ] My change requires a change to the documentation.
* [x] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
