### PR TITLE
Peer manager fixes, custom oms backoff, flaky test fixes

### DIFF
--- a/applications/grpc_wallet/src/main.rs
+++ b/applications/grpc_wallet/src/main.rs
@@ -68,7 +68,7 @@ struct Peers {
 
 /// Entry point into the gRPC server binary
 pub fn main() {
-    let _ = env_logger::init();
+    let _ = env_logger::try_init();
     let matches = App::new("Tari Wallet gRPC server")
         .version("0.1")
         .arg(

--- a/applications/grpc_wallet/tests/wallet_grpc_server/wallet_grpc_server.rs
+++ b/applications/grpc_wallet/tests/wallet_grpc_server/wallet_grpc_server.rs
@@ -497,7 +497,6 @@ pub fn random_string(len: usize) -> String {
 
 #[test]
 fn test_rpc_text_message_service() {
-    env_logger::init();
     let mut rng = rand::OsRng::new().unwrap();
     let listener_address1: NetAddress = "127.0.0.1:32775".parse().unwrap();
     let secret_key1 = CommsSecretKey::random(&mut rng);

--- a/applications/tari_testnet_miner/src/main.rs
+++ b/applications/tari_testnet_miner/src/main.rs
@@ -54,7 +54,7 @@ struct Settings {
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let _ = env_logger::init();
+    let _ = env_logger::try_init();
 
     info!(target: LOG_TARGET, "Settings loaded");
 

--- a/base_layer/core/src/base_node/test/comms_interface.rs
+++ b/base_layer/core/src/base_node/test/comms_interface.rs
@@ -39,12 +39,10 @@ use crate::{
         MemoryDatabase,
         MmrTree,
         MutableMmrState,
-        Validators,
     },
     mempool::{Mempool, MempoolConfig},
     proof_of_work::DiffAdjManager,
     test_utils::builders::{add_block_and_update_header, create_default_db, create_test_kernel, create_utxo},
-    validation::mocks::MockValidator,
 };
 use croaring::Bitmap;
 use futures::{executor::block_on, StreamExt};

--- a/base_layer/core/src/mempool/test/service.rs
+++ b/base_layer/core/src/mempool/test/service.rs
@@ -186,7 +186,7 @@ fn receive_and_propagate_transaction() {
         async_assert_eventually!(
             bob_node.mempool.has_tx_with_excess_sig(&tx_excess_sig).unwrap(),
             expect = TxStorageResponse::UnconfirmedPool,
-            max_attempts = 10,
+            max_attempts = 20,
             interval = Duration::from_millis(1000)
         );
         async_assert_eventually!(

--- a/base_layer/core/src/test_utils/node.rs
+++ b/base_layer/core/src/test_utils/node.rs
@@ -56,7 +56,6 @@ use tari_p2p::{
 use tari_service_framework::StackBuilder;
 use tari_test_utils::address::get_next_local_address;
 use tari_transactions::types::HashDigest;
-use tempdir::TempDir;
 use tokio::runtime::{Runtime, TaskExecutor};
 
 /// The NodeInterfaces is used as a container for providing access to all the services and interfaces of a single node.

--- a/base_layer/p2p/examples/pingpong.rs
+++ b/base_layer/p2p/examples/pingpong.rs
@@ -172,6 +172,8 @@ fn main() {
         set_lan_address(&peer_identity);
     }
 
+    let datastore_path = TempDir::new(random_string(8).as_str()).unwrap();
+
     let comms_config = CommsConfig {
         node_identity: Arc::clone(&node_identity),
         peer_connection_listening_address: format!("0.0.0.0:{}", port).parse().unwrap(),
@@ -187,12 +189,7 @@ fn main() {
             requested_connection_timeout: Duration::from_millis(2000),
         },
         establish_connection_timeout: Duration::from_secs(10),
-        datastore_path: TempDir::new(random_string(8).as_str())
-            .unwrap()
-            .path()
-            .to_str()
-            .unwrap()
-            .to_string(),
+        datastore_path: datastore_path.path().to_str().unwrap().to_string(),
         peer_database_name: random_string(8),
         inbound_buffer_size: 10,
         outbound_buffer_size: 10,

--- a/base_layer/wallet/Cargo.toml
+++ b/base_layer/wallet/Cargo.toml
@@ -39,10 +39,10 @@ tempdir = "0.3.7"
 
 [dev-dependencies]
 tari_comms_dht = { path = "../../comms/dht", version = "^0.0", features=["test-mocks"]}
+tari_test_utils = { path = "../../infrastructure/test_utils", version = "^0.0"}
 
 env_logger = "0.6.2"
 prost = "0.5.0"
-tari_test_utils = { path = "../../infrastructure/test_utils", version = "^0.0"}
 
 [features]
 test_harness = []

--- a/base_layer/wallet/tests/mod.rs
+++ b/base_layer/wallet/tests/mod.rs
@@ -27,8 +27,3 @@ pub mod support;
 pub mod contacts_service;
 pub mod transaction_service;
 pub mod wallet;
-
-#[macro_use]
-extern crate diesel;
-#[macro_use]
-extern crate diesel_migrations;

--- a/base_layer/wallet/tests/wallet/mod.rs
+++ b/base_layer/wallet/tests/wallet/mod.rs
@@ -44,6 +44,7 @@ use tari_wallet::{
     wallet::WalletConfig,
     Wallet,
 };
+#[cfg(feature = "test_harness")]
 use tempdir::TempDir;
 use tokio::runtime::Runtime;
 

--- a/comms/dht/src/store_forward/store.rs
+++ b/comms/dht/src/store_forward/store.rs
@@ -212,12 +212,12 @@ where
                 }
             },
             NodeDestination::NodeId(dest_node_id) => {
-                if (peer_manager.exists_node_id(&dest_node_id)) |
-                    (peer_manager.in_network_region(
+                if peer_manager.exists_node_id(&dest_node_id) ||
+                    peer_manager.in_network_region(
                         &dest_node_id,
                         node_identity.node_id(),
                         self.config.num_neighbouring_nodes,
-                    )?)
+                    )?
                 {
                     self.storage.insert(
                         dht_header.origin_signature.clone(),

--- a/comms/dht/tests/dht.rs
+++ b/comms/dht/tests/dht.rs
@@ -137,7 +137,6 @@ fn setup_comms_dht(
 #[test]
 #[allow(non_snake_case)]
 fn dht_join_propagation() {
-    env_logger::init();
     runtime::test_async(|rt| {
         // Create 3 nodes where only Node B knows A and C, but A and C want to talk to each other
         let node_A_identity = new_node_identity("127.0.0.1:11113".parse().unwrap());

--- a/comms/src/connection_manager/deprecated/manager.rs
+++ b/comms/src/connection_manager/deprecated/manager.rs
@@ -115,7 +115,6 @@ impl ConnectionManager {
                 zmq_context,
                 Arc::clone(&node_identity),
                 config,
-                Arc::clone(&peer_manager),
                 message_sink_channel,
             ),
             node_identity,
@@ -414,10 +413,6 @@ impl ConnectionManager {
         );
 
         let protocol = PeerConnectionProtocol::new(&self.node_identity, &self.establisher);
-        self.peer_manager
-            .reset_connection_attempts(&peer.node_id)
-            .map_err(ConnectionManagerError::PeerManagerError)?;
-
         protocol
             .negotiate_peer_connection(peer)
             .and_then(|(new_conn, join_handle)| {

--- a/comms/src/control_service/worker.rs
+++ b/comms/src/control_service/worker.rs
@@ -253,9 +253,13 @@ impl ControlServiceWorker {
         }
 
         let decrypted_body = self.decrypt_body(&envelope.body, &envelope_header.public_key)?;
-        trace!(target: LOG_TARGET, "decrypted_body = {:?}", decrypted_body.to_hex());
+        debug!(
+            target: LOG_TARGET,
+            "decryption succeeded ({} bytes)",
+            decrypted_body.len()
+        );
 
-        let body = EnvelopeBody::decode(decrypted_body)?;
+        let body = EnvelopeBody::decode(&decrypted_body)?;
 
         debug!(target: LOG_TARGET, "Handling message");
         self.handle_message(envelope_header, identity_frame, body)

--- a/comms/src/outbound_message_service/backoff.rs
+++ b/comms/src/outbound_message_service/backoff.rs
@@ -1,0 +1,109 @@
+// Copyright 2019, The Tari Project
+//
+// Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+// following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+// disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+// following disclaimer in the documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+// products derived from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+// INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+// WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+// USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+use std::time::Duration;
+
+pub type BoxedBackoff = Box<dyn Backoff + Send + Sync>;
+
+pub trait Backoff {
+    fn calculate_backoff(&self, attempts: usize) -> Duration;
+}
+
+impl Backoff for BoxedBackoff {
+    fn calculate_backoff(&self, attempts: usize) -> Duration {
+        (**self).calculate_backoff(attempts)
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct ExponentialBackoff {
+    factor: f32,
+}
+
+impl ExponentialBackoff {
+    pub fn new(factor: f32) -> Self {
+        Self { factor }
+    }
+}
+
+impl Default for ExponentialBackoff {
+    fn default() -> Self {
+        Self::new(1.5)
+    }
+}
+
+impl Backoff for ExponentialBackoff {
+    fn calculate_backoff(&self, attempts: usize) -> Duration {
+        if attempts == 0 {
+            return Duration::from_secs(0);
+        }
+        let secs = (self.factor as f64) * (f64::powf(2.0, attempts as f64) - 1.0);
+        Duration::from_secs(secs.ceil() as u64)
+    }
+}
+
+#[derive(Clone)]
+pub struct ConstantBackoff(Duration);
+
+impl ConstantBackoff {
+    pub fn new(timeout: Duration) -> Self {
+        Self(timeout)
+    }
+}
+
+impl Backoff for ConstantBackoff {
+    fn calculate_backoff(&self, attempts: usize) -> Duration {
+        if attempts == 1 {
+            return Duration::from_secs(0);
+        }
+        self.0
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn default_backoff() {
+        let backoff = ExponentialBackoff::default();
+        assert_eq!(backoff.calculate_backoff(0).as_secs(), 0);
+        assert_eq!(backoff.calculate_backoff(1).as_secs(), 2);
+        assert_eq!(backoff.calculate_backoff(2).as_secs(), 5);
+        assert_eq!(backoff.calculate_backoff(3).as_secs(), 11);
+        assert_eq!(backoff.calculate_backoff(4).as_secs(), 23);
+        assert_eq!(backoff.calculate_backoff(5).as_secs(), 47);
+        assert_eq!(backoff.calculate_backoff(6).as_secs(), 95);
+        assert_eq!(backoff.calculate_backoff(7).as_secs(), 191);
+        assert_eq!(backoff.calculate_backoff(8).as_secs(), 383);
+        assert_eq!(backoff.calculate_backoff(9).as_secs(), 767);
+        assert_eq!(backoff.calculate_backoff(10).as_secs(), 1535);
+    }
+
+    #[test]
+    fn zero_backoff() {
+        let backoff = ExponentialBackoff::new(0.0);
+        assert_eq!(backoff.calculate_backoff(0).as_secs(), 0);
+        assert_eq!(backoff.calculate_backoff(1).as_secs(), 0);
+        assert_eq!(backoff.calculate_backoff(200).as_secs(), 0);
+    }
+}

--- a/comms/src/outbound_message_service/mod.rs
+++ b/comms/src/outbound_message_service/mod.rs
@@ -20,20 +20,25 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-// pub mod broadcast_strategy;
+mod backoff;
 mod error;
 mod messages;
 mod service;
 
-pub use self::{error::OutboundServiceError, messages::OutboundMessage, service::OutboundMessageService};
+pub use self::{
+    backoff::{Backoff, BoxedBackoff, ConstantBackoff, ExponentialBackoff},
+    error::OutboundServiceError,
+    messages::OutboundMessage,
+    service::OutboundMessageService,
+};
 
 /// Configuration for the OutboundService
 pub struct OutboundServiceConfig {
-    /// Maximum attempts to send a message before discarding it. Default: 5
-    pub max_attempts: usize,
     /// Maximum size of the recent connection cache. This cache keeps active connections
     /// for reuse with subsequent messages without querying the connection manager. Default: 20
     pub max_cached_connections: usize,
+    /// Maximum attempts to send a message before discarding it. Default: 5
+    pub max_attempts: usize,
 }
 
 impl Default for OutboundServiceConfig {

--- a/comms/src/peer_manager/error.rs
+++ b/comms/src/peer_manager/error.rs
@@ -20,7 +20,7 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE
 
-use crate::{connection::NetAddressError, peer_manager::node_id::NodeIdError};
+use crate::connection::NetAddressError;
 use derive_error::Error;
 use tari_storage::KeyValStoreError;
 
@@ -28,23 +28,12 @@ use tari_storage::KeyValStoreError;
 pub enum PeerManagerError {
     /// The requested peer does not exist or could not be located
     PeerNotFoundError,
-    /// A problem occurred converting the serialized data into peers
-    DeserializationError,
-    /// The index doesn't relate to an existing peer
-    IndexOutOfBounds,
-    /// The requested operation can only be performed if the PeerManager is linked to a DataStore
-    DatastoreUndefined,
-    /// An empty response was received from the Datastore
-    EmptyDatastoreQuery,
     // A NetAddressError occurred
     NetAddressError(NetAddressError),
     /// The peer has been banned
     BannedPeer,
-    /// Problem initializing the RNG
-    RngError,
     // An problem has been encountered with the database
     DatabaseError(KeyValStoreError),
-    NodeIdError(NodeIdError),
 }
 
 impl PeerManagerError {

--- a/comms/src/peer_manager/peer.rs
+++ b/comms/src/peer_manager/peer.rs
@@ -23,7 +23,7 @@
 use super::node_id::deserialize_node_id_from_hex;
 use crate::{
     connection::{net_address::net_addresses::NetAddressesWithStats, NetAddress},
-    peer_manager::{connection_stats::PeerConnectionStats, node_id::NodeId, PeerFeatures},
+    peer_manager::{connection_stats::PeerConnectionStats, node_id::NodeId, peer_key::PeerKey, PeerFeatures},
     types::CommsPublicKey,
 };
 use bitflags::bitflags;
@@ -43,6 +43,7 @@ bitflags! {
 /// describing the status of the Peer.
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq)]
 pub struct Peer {
+    id: Option<PeerKey>,
     pub public_key: CommsPublicKey,
     #[serde(serialize_with = "serialize_to_hex")]
     #[serde(deserialize_with = "deserialize_node_id_from_hex")]
@@ -65,6 +66,7 @@ impl Peer {
     ) -> Peer
     {
         Peer {
+            id: None,
             public_key,
             node_id,
             addresses,
@@ -73,6 +75,16 @@ impl Peer {
             connection_stats: Default::default(),
             added_at: Utc::now().naive_utc(),
         }
+    }
+
+    /// Returns the peers local id if this peer is persisted, otherwise None
+    pub fn id(&self) -> Option<PeerKey> {
+        self.id
+    }
+
+    pub(super) fn set_id(&mut self, id: PeerKey) {
+        debug_assert!(self.id.is_none());
+        self.id = Some(id);
     }
 
     pub fn update(

--- a/comms/src/peer_manager/peer_key.rs
+++ b/comms/src/peer_manager/peer_key.rs
@@ -20,11 +20,11 @@
 //  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 //  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+use crate::consts::COMMS_RNG;
 use rand::RngCore;
 
 pub type PeerKey = u64;
 
-pub fn generate_peer_key<R>(rng: &mut R) -> PeerKey
-where R: RngCore {
-    rng.next_u64()
+pub fn generate_peer_key() -> PeerKey {
+    COMMS_RNG.with(|rng| rng.borrow_mut().next_u64())
 }

--- a/comms/tests/inbound_message_service/mod.rs
+++ b/comms/tests/inbound_message_service/mod.rs
@@ -81,6 +81,7 @@ fn smoke_test() {
             .build()
             .unwrap(),
     );
+    let peer = peer_manager.find_by_node_id(&peer.node_id).unwrap();
 
     let (mut inbound_message_sink_tx, inbound_message_sink_rx) = mpsc::channel(100);
 

--- a/comms/tests/support/factories/peer.rs
+++ b/comms/tests/support/factories/peer.rs
@@ -21,18 +21,13 @@
 //  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 use super::{net_address::NetAddressesFactory, TestFactory, TestFactoryError};
-
+use crate::support::makers::{comms_keys as ristretto_maker, node_id as node_id_maker};
+use std::iter::repeat_with;
 use tari_comms::{
     connection::NetAddress,
-    peer_manager::{NodeId, Peer, PeerFlags},
+    peer_manager::{NodeId, Peer, PeerFeatures, PeerFlags},
     types::CommsPublicKey,
 };
-
-use crate::support::makers::{comms_keys as ristretto_maker, node_id as node_id_maker};
-
-use chrono::Utc;
-use std::iter::repeat_with;
-use tari_comms::peer_manager::PeerFeatures;
 
 pub fn create_many(n: usize) -> PeersFactory {
     PeersFactory::default().with_count(n)
@@ -88,15 +83,13 @@ impl TestFactory for PeerFactory {
                     "Failed to build net addresses for peer"
                 )))?;
 
-        Ok(Peer {
-            node_id,
-            flags,
+        Ok(Peer::new(
             public_key,
-            addresses: addresses.into(),
-            features: self.peer_features,
-            connection_stats: Default::default(),
-            added_at: Utc::now().naive_utc(),
-        })
+            node_id,
+            addresses.into(),
+            flags,
+            self.peer_features,
+        ))
     }
 }
 

--- a/infrastructure/test_utils/src/address.rs
+++ b/infrastructure/test_utils/src/address.rs
@@ -22,7 +22,7 @@
 
 use std::{cmp, ops::Range, sync::Mutex};
 
-const PORT_RANGE: Range<u16> = 40000..48000;
+const PORT_RANGE: Range<u16> = 20000..30000;
 const LOCAL_ADDRESS: &str = "127.0.0.1";
 
 lazy_static! {


### PR DESCRIPTION
- It should never be possible for peer manager index/hashmap links to be
  out of sync with the datastore. I've removed this possibility.
- Removed some unused but fairly complex features of the peer manager to
  reduce bug surface.
- Added `Backoff` trait and implemented ExponentialBackoff and
  ConstantBackoff (for tests).
- Added comms initializer function to be used with tests
- Fixed a race condition in `manage_multiple_transactions`