### PR TITLE
Base node horizon synchronisation

### DIFF
--- a/applications/tari_base_node/src/builder.rs
+++ b/applications/tari_base_node/src/builder.rs
@@ -37,6 +37,7 @@ use tari_core::{
     base_node::{
         service::{BaseNodeServiceConfig, BaseNodeServiceInitializer},
         BaseNodeStateMachine,
+        BaseNodeStateMachineConfig,
         OutboundNodeCommsInterface,
     },
     chain_storage::{
@@ -189,7 +190,11 @@ pub fn configure_and_initialize_node(
             let outbound_interface = handles.get_handle::<OutboundNodeCommsInterface>().unwrap();
             (
                 comms,
-                NodeType::Memory(BaseNodeStateMachine::new(&db, &outbound_interface)),
+                NodeType::Memory(BaseNodeStateMachine::new(
+                    &db,
+                    &outbound_interface,
+                    BaseNodeStateMachineConfig::default(),
+                )),
             )
         },
         DatabaseType::LMDB(p) => {
@@ -217,7 +222,11 @@ pub fn configure_and_initialize_node(
             let outbound_interface = handles.get_handle::<OutboundNodeCommsInterface>().unwrap();
             (
                 comms,
-                NodeType::LMDB(BaseNodeStateMachine::new(&db, &outbound_interface)),
+                NodeType::LMDB(BaseNodeStateMachine::new(
+                    &db,
+                    &outbound_interface,
+                    BaseNodeStateMachineConfig::default(),
+                )),
             )
         },
     };

--- a/base_layer/core/src/base_node/base_node.rs
+++ b/base_layer/core/src/base_node/base_node.rs
@@ -24,7 +24,7 @@ use crate::{
     base_node::{
         comms_interface::OutboundNodeCommsInterface,
         states,
-        states::{BaseNodeState, HorizonInfo, ListeningInfo, StateEvent},
+        states::{BaseNodeState, HorizonInfo, HorizonSyncConfig, ListeningInfo, StateEvent},
     },
     chain_storage::{BlockchainBackend, BlockchainDatabase},
 };
@@ -33,6 +33,20 @@ use log::*;
 use std::sync::{atomic::Ordering, Arc};
 
 const LOG_TARGET: &str = "core::base_node";
+
+/// Configuration for the BaseNodeStateMachine.
+#[derive(Clone, Copy)]
+pub struct BaseNodeStateMachineConfig {
+    pub horizon_sync_config: HorizonSyncConfig,
+}
+
+impl Default for BaseNodeStateMachineConfig {
+    fn default() -> Self {
+        Self {
+            horizon_sync_config: HorizonSyncConfig::default(),
+        }
+    }
+}
 
 /// A Tari full node, aka Base Node.
 ///
@@ -45,15 +59,22 @@ pub struct BaseNodeStateMachine<B: BlockchainBackend> {
     pub(super) db: BlockchainDatabase<B>,
     pub(super) comms: OutboundNodeCommsInterface,
     pub(super) user_stopped: Arc<AtomicBool>,
+    pub(super) config: BaseNodeStateMachineConfig,
 }
 
 impl<B: BlockchainBackend> BaseNodeStateMachine<B> {
     /// Instantiate a new Base Node.
-    pub fn new(db: &BlockchainDatabase<B>, comms: &OutboundNodeCommsInterface) -> Self {
+    pub fn new(
+        db: &BlockchainDatabase<B>,
+        comms: &OutboundNodeCommsInterface,
+        config: BaseNodeStateMachineConfig,
+    ) -> Self
+    {
         Self {
             db: db.clone(),
             comms: comms.clone(),
             user_stopped: Arc::new(AtomicBool::new(false)),
+            config,
         }
     }
 

--- a/base_layer/core/src/base_node/mod.rs
+++ b/base_layer/core/src/base_node/mod.rs
@@ -45,5 +45,5 @@ pub mod states;
 
 // Public re-exports
 pub use backoff::BackOff;
-pub use base_node::BaseNodeStateMachine;
+pub use base_node::{BaseNodeStateMachine, BaseNodeStateMachineConfig};
 pub use comms_interface::{LocalNodeCommsInterface, OutboundNodeCommsInterface};

--- a/base_layer/core/src/base_node/states/fetching_horizon_state.rs
+++ b/base_layer/core/src/base_node/states/fetching_horizon_state.rs
@@ -22,11 +22,44 @@
 
 use crate::{
     base_node::{states::StateEvent, BaseNodeStateMachine},
-    chain_storage::BlockchainBackend,
+    chain_storage::{BlockchainBackend, DbTransaction, MmrTree, MutableMmrState},
 };
+use croaring::Bitmap;
 use log::*;
+use tari_mmr::MutableMmrLeafNodes;
+use tari_transactions::types::HashOutput;
 
 const LOG_TARGET: &str = "base_node::fetching_horizon_state";
+
+// TODO: Find better chunk sizes to limit the maximum size of the response messages
+// The number of MMR leaf nodes that can be requested in a single query from remote nodes.
+const HORIZON_SYNC_CHUNK_SIZE_LEAF_NODES: usize = 1000;
+// The number of headers that can be requested in a single query from remote nodes.
+const HORIZON_SYNC_CHUNK_SIZE_HEADERS: usize = 1000;
+// The number of kernels that can be requested in a single query from remote nodes.
+const HORIZON_SYNC_CHUNK_SIZE_KERNELS: usize = 1000;
+// The number of utxos that can be requested in a single query from remote nodes.
+const HORIZON_SYNC_CHUNK_SIZE_UTXOS: usize = 1000;
+
+/// Configuration for the Horizon Synchronization.
+#[derive(Clone, Copy)]
+pub struct HorizonSyncConfig {
+    pub leaf_nodes_sync_chunk_size: usize,
+    pub headers_sync_chunk_size: usize,
+    pub kernels_sync_chunk_size: usize,
+    pub utxos_sync_chunk_size: usize,
+}
+
+impl Default for HorizonSyncConfig {
+    fn default() -> Self {
+        Self {
+            leaf_nodes_sync_chunk_size: HORIZON_SYNC_CHUNK_SIZE_LEAF_NODES,
+            headers_sync_chunk_size: HORIZON_SYNC_CHUNK_SIZE_HEADERS,
+            kernels_sync_chunk_size: HORIZON_SYNC_CHUNK_SIZE_KERNELS,
+            utxos_sync_chunk_size: HORIZON_SYNC_CHUNK_SIZE_UTXOS,
+        }
+    }
+}
 
 /// Local state used when synchronizing the node to the pruning horizon.
 pub struct HorizonInfo {
@@ -39,7 +72,7 @@ impl HorizonInfo {
         HorizonInfo { horizon_block }
     }
 
-    pub async fn next_event<B: BlockchainBackend>(&mut self, _shared: &mut BaseNodeStateMachine<B>) -> StateEvent {
+    pub async fn next_event<B: BlockchainBackend>(&mut self, shared: &mut BaseNodeStateMachine<B>) -> StateEvent {
         debug!(
             target: LOG_TARGET,
             "Starting horizon synchronisation at block {}", self.horizon_block
@@ -49,32 +82,32 @@ impl HorizonInfo {
             target: LOG_TARGET,
             "Synchronising kernel merkle mountain range to pruning horizon."
         );
-        if let Err(e) = self.synchronize_kernel_mmr().await {
+        if let Err(e) = self.synchronize_kernel_mmr(shared).await {
             return StateEvent::FatalError(format!("Synchronizing kernel MMR failed. {}", e));
         }
 
         info!(target: LOG_TARGET, "Synchronising range proof MMR to pruning horizon.");
-        if let Err(e) = self.synchronize_range_proof_mmr().await {
+        if let Err(e) = self.synchronize_range_proof_mmr(shared).await {
             return StateEvent::FatalError(format!("Synchronizing range proof MMR failed. {}", e));
         }
 
         info!(target: LOG_TARGET, "Synchronising TXO MMR to pruning horizon.");
-        if let Err(e) = self.synchronize_output_mmr().await {
+        if let Err(e) = self.synchronize_output_mmr(shared).await {
             return StateEvent::FatalError(format!("Synchronizing output MMR failed. {}", e));
         }
 
         info!(target: LOG_TARGET, "Synchronising headers to pruning horizon.");
-        if let Err(e) = self.synchronize_headers().await {
+        if let Err(e) = self.synchronize_headers(shared).await {
             return StateEvent::FatalError(format!("Synchronizing block headers failed. {}", e));
         }
 
         info!(target: LOG_TARGET, "Synchronising kernels to pruning horizon.");
-        if let Err(e) = self.synchronize_kernels().await {
+        if let Err(e) = self.synchronize_kernels(shared).await {
             return StateEvent::FatalError(format!("Synchronizing kernels failed. {}", e));
         }
 
         info!(target: LOG_TARGET, "Synchronising UTXO set at pruning horizon.");
-        if let Err(e) = self.synchronize_utxo_set().await {
+        if let Err(e) = self.synchronize_utxo_set(shared).await {
             return StateEvent::FatalError(format!("Synchronizing UTXO set failed. {}", e));
         }
 
@@ -82,27 +115,153 @@ impl HorizonInfo {
         StateEvent::HorizonStateFetched
     }
 
-    async fn synchronize_headers(&mut self) -> Result<(), String> {
-        Err("unimplemented".into())
+    // Retrieve the full base mmr state for the specified MmrTree by performing multiple queries and reassembling the
+    // full state from the received chunks.
+    async fn download_mmr_base_state<B: BlockchainBackend>(
+        &mut self,
+        shared: &mut BaseNodeStateMachine<B>,
+        tree: MmrTree,
+    ) -> Result<MutableMmrLeafNodes, String>
+    {
+        let leaf_nodes_sync_chunk_size = shared.config.horizon_sync_config.leaf_nodes_sync_chunk_size as u64;
+        let mut index = 0;
+        let mut complete_leaf_count = leaf_nodes_sync_chunk_size;
+        let mut base_state = MutableMmrLeafNodes::new(Vec::new(), Bitmap::create());
+        while index < complete_leaf_count {
+            let MutableMmrState {
+                total_leaf_count,
+                leaf_nodes,
+            } = shared
+                .comms
+                .fetch_mmr_state(tree.clone(), index, leaf_nodes_sync_chunk_size)
+                .await
+                .map_err(|e| e.to_string())?;
+            base_state.combine(leaf_nodes);
+            complete_leaf_count = total_leaf_count as u64;
+            index += leaf_nodes_sync_chunk_size;
+        }
+        Ok(base_state)
     }
 
-    async fn synchronize_kernels(&mut self) -> Result<(), String> {
-        Err("unimplemented".into())
+    async fn synchronize_headers<B: BlockchainBackend>(
+        &mut self,
+        shared: &mut BaseNodeStateMachine<B>,
+    ) -> Result<(), String>
+    {
+        let height_indices = (0..self.horizon_block).collect::<Vec<u64>>();
+        for block_nums in height_indices.chunks(shared.config.horizon_sync_config.headers_sync_chunk_size) {
+            let headers = shared
+                .comms
+                .fetch_headers(block_nums.to_vec())
+                .await
+                .map_err(|e| e.to_string())?;
+
+            let mut txn = DbTransaction::new();
+            headers.into_iter().for_each(|header| txn.insert_header(header));
+            shared.db.commit(txn).map_err(|e| e.to_string())?;
+        }
+        Ok(())
     }
 
-    async fn synchronize_utxo_set(&mut self) -> Result<(), String> {
-        Err("unimplemented".into())
+    async fn synchronize_kernels<B: BlockchainBackend>(
+        &mut self,
+        shared: &mut BaseNodeStateMachine<B>,
+    ) -> Result<(), String>
+    {
+        let mmr_state = shared
+            .db
+            .fetch_mmr_base_leaf_nodes(MmrTree::Kernel, 0, 1)
+            .map_err(|e| e.to_string())?;
+        let kernel_hashes = shared
+            .db
+            .fetch_mmr_base_leaf_nodes(MmrTree::Kernel, 0, mmr_state.total_leaf_count)
+            .map_err(|e| e.to_string())?
+            .leaf_nodes
+            .leaf_hashes;
+
+        for hashes in kernel_hashes.chunks(shared.config.horizon_sync_config.kernels_sync_chunk_size) {
+            let kernels = shared
+                .comms
+                .fetch_kernels(hashes.to_vec())
+                .await
+                .map_err(|e| e.to_string())?;
+
+            let mut txn = DbTransaction::new();
+            kernels.into_iter().for_each(|kernel| txn.insert_kernel(kernel));
+            shared.db.commit(txn).map_err(|e| e.to_string())?;
+        }
+        Ok(())
     }
 
-    async fn synchronize_kernel_mmr(&mut self) -> Result<(), String> {
-        Err("unimplemented".into())
+    async fn synchronize_utxo_set<B: BlockchainBackend>(
+        &mut self,
+        shared: &mut BaseNodeStateMachine<B>,
+    ) -> Result<(), String>
+    {
+        let total_leaf_count = shared
+            .db
+            .fetch_mmr_base_leaf_node_count(MmrTree::Utxo)
+            .map_err(|e| e.to_string())?;
+
+        for index in (0..total_leaf_count).step_by(shared.config.horizon_sync_config.utxos_sync_chunk_size) {
+            let MutableMmrLeafNodes { leaf_hashes, deleted } = shared
+                .db
+                .fetch_mmr_base_leaf_nodes(
+                    MmrTree::Utxo,
+                    index,
+                    shared.config.horizon_sync_config.utxos_sync_chunk_size,
+                )
+                .map_err(|e| e.to_string())?
+                .leaf_nodes;
+            let leaf_hashes: Vec<HashOutput> = leaf_hashes
+                .into_iter()
+                .enumerate()
+                .filter(|(local_index, _h)| !deleted.contains((*local_index + index) as u32))
+                .map(|(_, h)| h)
+                .collect();
+
+            let utxos = shared.comms.fetch_utxos(leaf_hashes).await.map_err(|e| e.to_string())?;
+
+            let mut txn = DbTransaction::new();
+            utxos.into_iter().for_each(|utxo| txn.insert_utxo(utxo));
+            shared.db.commit(txn).map_err(|e| e.to_string())?;
+        }
+        Ok(())
     }
 
-    async fn synchronize_range_proof_mmr(&mut self) -> Result<(), String> {
-        Err("unimplemented".into())
+    async fn synchronize_kernel_mmr<B: BlockchainBackend>(
+        &mut self,
+        shared: &mut BaseNodeStateMachine<B>,
+    ) -> Result<(), String>
+    {
+        let base_state = self.download_mmr_base_state(shared, MmrTree::Kernel).await?;
+        shared
+            .db
+            .restore_mmr(MmrTree::Kernel, base_state)
+            .map_err(|e| e.to_string())
     }
 
-    async fn synchronize_output_mmr(&mut self) -> Result<(), String> {
-        Err("unimplemented".into())
+    async fn synchronize_range_proof_mmr<B: BlockchainBackend>(
+        &mut self,
+        shared: &mut BaseNodeStateMachine<B>,
+    ) -> Result<(), String>
+    {
+        let base_state = self.download_mmr_base_state(shared, MmrTree::RangeProof).await?;
+        shared
+            .db
+            .restore_mmr(MmrTree::RangeProof, base_state)
+            .map_err(|e| e.to_string())
+    }
+
+    async fn synchronize_output_mmr<B: BlockchainBackend>(
+        &mut self,
+        shared: &mut BaseNodeStateMachine<B>,
+    ) -> Result<(), String>
+    {
+        let base_state = self.download_mmr_base_state(shared, MmrTree::Utxo).await?;
+        shared
+            .db
+            .restore_mmr(MmrTree::Utxo, base_state)
+            .map_err(|e| e.to_string())
     }
 }

--- a/base_layer/core/src/base_node/states/initial_sync.rs
+++ b/base_layer/core/src/base_node/states/initial_sync.rs
@@ -165,7 +165,7 @@ impl InitialSync {
                 if local_tip < network_tip {
                     info!(
                         target: LOG_TARGET,
-                        "Our local blockchain history is a little behind that of the network.We're at block #{}, and \
+                        "Our local blockchain history is a little behind that of the network. We're at block #{}, and \
                          the chain tip is at #{}",
                         local_tip,
                         network_tip

--- a/base_layer/core/src/base_node/states/mod.rs
+++ b/base_layer/core/src/base_node/states/mod.rs
@@ -96,7 +96,7 @@ pub enum BaseNodeState {
     Shutdown(Shutdown),
 }
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 pub enum StateEvent {
     Initialized,
     MetadataSynced(SyncStatus),
@@ -111,7 +111,7 @@ pub enum StateEvent {
 /// blockchain the local node is. It can either be very far behind (`BehindHorizon`), in which case we will just
 /// synchronise against the pruning horizon; we're somewhat behind (`Lagging`) and need to download the missing
 /// blocks to catch up, or we are `UpToDate`.
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 pub enum SyncStatus {
     // We are behind the pruning horizon. The u64 parameter indicates the block height at the horizon.
     BehindHorizon(u64),
@@ -143,7 +143,7 @@ mod shutdown_state;
 mod starting_state;
 
 pub use block_sync::BlockSyncInfo;
-pub use fetching_horizon_state::HorizonInfo;
+pub use fetching_horizon_state::{HorizonInfo, HorizonSyncConfig};
 pub use initial_sync::InitialSync;
 pub use listening::ListeningInfo;
 pub use shutdown_state::Shutdown;

--- a/base_layer/core/src/base_node/test/mod.rs
+++ b/base_layer/core/src/base_node/test/mod.rs
@@ -22,3 +22,4 @@
 
 mod comms_interface;
 mod service;
+mod state_machine;

--- a/base_layer/core/src/base_node/test/state_machine.rs
+++ b/base_layer/core/src/base_node/test/state_machine.rs
@@ -1,0 +1,152 @@
+// Copyright 2019. The Tari Project
+//
+// Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+// following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+// disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+// following disclaimer in the documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+// products derived from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+// INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+// WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+// USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+use crate::{
+    base_node::{
+        service::BaseNodeServiceConfig,
+        states::{HorizonInfo, HorizonSyncConfig, StateEvent},
+        BaseNodeStateMachine,
+        BaseNodeStateMachineConfig,
+    },
+    blocks::genesis_block::get_genesis_block,
+    chain_storage::{DbTransaction, MmrTree},
+    mempool::MempoolServiceConfig,
+    test_utils::{
+        builders::{add_block_and_update_header, chain_block},
+        node::create_network_with_2_base_nodes_with_config,
+    },
+    tx,
+};
+use tari_mmr::MerkleChangeTrackerConfig;
+use tari_test_utils::random::string;
+use tari_transactions::{tari_amount::uT, types::CryptoFactories};
+use tempdir::TempDir;
+use tokio::runtime::Runtime;
+
+#[test]
+fn test_horizon_state_sync() {
+    let runtime = Runtime::new().unwrap();
+    let factories = CryptoFactories::default();
+    let temp_dir = TempDir::new(string(8).as_str()).unwrap();
+    let mct_config = MerkleChangeTrackerConfig {
+        min_history_len: 2,
+        max_history_len: 4,
+    };
+    let (alice_node, bob_node) = create_network_with_2_base_nodes_with_config(
+        &runtime,
+        BaseNodeServiceConfig::default(),
+        mct_config,
+        MempoolServiceConfig::default(),
+        temp_dir.path().to_str().unwrap(),
+    );
+    let state_machine_config = BaseNodeStateMachineConfig {
+        horizon_sync_config: HorizonSyncConfig {
+            leaf_nodes_sync_chunk_size: 5,
+            headers_sync_chunk_size: 5,
+            kernels_sync_chunk_size: 5,
+            utxos_sync_chunk_size: 5,
+        },
+    };
+    let mut alice_state_machine = BaseNodeStateMachine::new(
+        &alice_node.blockchain_db,
+        &alice_node.outbound_nci,
+        state_machine_config,
+    );
+
+    let mut prev_block = add_block_and_update_header(&bob_node.blockchain_db, get_genesis_block());
+    for _ in 0..12 {
+        let (tx, inputs, _) = tx!(10_000*uT, fee: 50*uT, inputs: 1, outputs: 1);
+        let mut txn = DbTransaction::new();
+        txn.insert_utxo(inputs[0].as_transaction_output(&factories).unwrap());
+        assert!(bob_node.blockchain_db.commit(txn).is_ok());
+
+        let next_block = chain_block(&prev_block, vec![tx.clone()]);
+        prev_block = add_block_and_update_header(&bob_node.blockchain_db, next_block);
+    }
+
+    let bob_utxo_mmr_state = bob_node
+        .blockchain_db
+        .fetch_mmr_base_leaf_nodes(MmrTree::Utxo, 0, 1000)
+        .unwrap();
+    let bob_kernel_mmr_state = bob_node
+        .blockchain_db
+        .fetch_mmr_base_leaf_nodes(MmrTree::Kernel, 0, 1000)
+        .unwrap();
+    let bob_rp_mmr_state = bob_node
+        .blockchain_db
+        .fetch_mmr_base_leaf_nodes(MmrTree::RangeProof, 0, 1000)
+        .unwrap();
+
+    runtime.block_on(async {
+        // TODO: This is a temporary fix. Currently, there is a disconnect between the Metadata Horizon block height and
+        // the MMR changetracker horizon height.
+        // let metadata=bob_node.blockchain_db.get_metadata().unwrap();
+        // let horizon_block: u64 = metadata.horizon_block(metadata.height_of_longest_chain.unwrap());
+        let horizon_block = bob_node
+            .blockchain_db
+            .fetch_mmr_base_leaf_node_count(MmrTree::Header)
+            .unwrap() as u64;
+
+        let mut horizon_info = HorizonInfo::new(horizon_block);
+        let state_event = horizon_info.next_event(&mut alice_state_machine).await;
+        assert_eq!(state_event, StateEvent::HorizonStateFetched);
+
+        let alice_utxo_mmr_state = alice_node
+            .blockchain_db
+            .fetch_mmr_base_leaf_nodes(MmrTree::Utxo, 0, 1000)
+            .unwrap();
+        let alice_kernel_mmr_state = alice_node
+            .blockchain_db
+            .fetch_mmr_base_leaf_nodes(MmrTree::Kernel, 0, 1000)
+            .unwrap();
+        let alice_rp_mmr_state = alice_node
+            .blockchain_db
+            .fetch_mmr_base_leaf_nodes(MmrTree::RangeProof, 0, 1000)
+            .unwrap();
+        assert_eq!(alice_utxo_mmr_state, bob_utxo_mmr_state);
+        assert_eq!(alice_kernel_mmr_state, bob_kernel_mmr_state);
+        assert_eq!(alice_rp_mmr_state, bob_rp_mmr_state);
+
+        for height in 0..horizon_block {
+            assert_eq!(
+                alice_node.blockchain_db.fetch_header(height),
+                bob_node.blockchain_db.fetch_header(height)
+            );
+        }
+
+        for hash in bob_kernel_mmr_state.leaf_nodes.leaf_hashes {
+            assert_eq!(
+                alice_node.blockchain_db.fetch_kernel(hash.clone()),
+                bob_node.blockchain_db.fetch_kernel(hash)
+            );
+        }
+
+        for hash in bob_utxo_mmr_state.leaf_nodes.leaf_hashes {
+            if let Ok(utxo) = bob_node.blockchain_db.fetch_utxo(hash.clone()) {
+                assert_eq!(alice_node.blockchain_db.fetch_utxo(hash).unwrap(), utxo);
+            }
+        }
+    });
+
+    alice_node.comms.shutdown().unwrap();
+    bob_node.comms.shutdown().unwrap();
+}

--- a/base_layer/core/src/chain_storage/blockchain_database.rs
+++ b/base_layer/core/src/chain_storage/blockchain_database.rs
@@ -131,13 +131,17 @@ pub trait BlockchainBackend: Send + Sync {
     fn fetch_mmr_checkpoint(&self, tree: MmrTree, index: u64) -> Result<MerkleCheckPoint, ChainStorageError>;
     /// Fetches the leaf node hash and its deletion status for the nth leaf node in the given MMR tree.
     fn fetch_mmr_node(&self, tree: MmrTree, pos: u32) -> Result<(Hash, bool), ChainStorageError>;
-    /// Fetches the MMR base state of the specified tree.
+    /// Fetches the MMR base state of the specified tree. The MMR base state consists of the state from the genesis
+    /// block to the horizon block. The index is the n-th leaf node in the MMR. The count specifies the maximum number
+    /// of leaf nodes that can be returned, starting with the node at the provided index.
     fn fetch_mmr_base_leaf_nodes(
         &self,
         tree: MmrTree,
         index: usize,
         count: usize,
     ) -> Result<MutableMmrState, ChainStorageError>;
+    /// Returns the number of leaf nodes in the base MMR of the specified tree.
+    fn fetch_mmr_base_leaf_node_count(&self, tree: MmrTree) -> Result<usize, ChainStorageError>;
     /// Resets and restores the state of the specified MMR tree using a set of leaf nodes.
     fn restore_mmr(&self, tree: MmrTree, base_state: MutableMmrLeafNodes) -> Result<(), ChainStorageError>;
     /// Performs the function F for each orphan block in the orphan pool.
@@ -376,7 +380,9 @@ where T: BlockchainBackend
         self.db.fetch_mmr_proof(tree, pos)
     }
 
-    /// Fetches the MMR base state of the specified tree
+    /// Fetches the MMR base state of the specified tree. The MMR base state consists of the state from the genesis
+    /// block to the horizon block. The index is the n-th leaf node in the MMR. The count specifies the maximum number
+    /// of leaf nodes that can be returned, starting with the node at the provided index.
     pub fn fetch_mmr_base_leaf_nodes(
         &self,
         tree: MmrTree,
@@ -385,6 +391,11 @@ where T: BlockchainBackend
     ) -> Result<MutableMmrState, ChainStorageError>
     {
         self.db.fetch_mmr_base_leaf_nodes(tree, index, count)
+    }
+
+    /// Returns the number of leaf nodes in the base MMR of the specified tree.
+    pub fn fetch_mmr_base_leaf_node_count(&self, tree: MmrTree) -> Result<usize, ChainStorageError> {
+        self.db.fetch_mmr_base_leaf_node_count(tree)
     }
 
     /// Resets the specified MMR and restores it with the provided state.

--- a/base_layer/core/src/chain_storage/lmdb_db/lmdb_db.rs
+++ b/base_layer/core/src/chain_storage/lmdb_db/lmdb_db.rs
@@ -880,6 +880,32 @@ where D: Digest + Send + Sync
         Ok(mmr_state)
     }
 
+    fn fetch_mmr_base_leaf_node_count(&self, tree: MmrTree) -> Result<usize, ChainStorageError> {
+        let mmr_state = match tree {
+            MmrTree::Kernel => self
+                .kernel_mmr
+                .read()
+                .map_err(|e| ChainStorageError::AccessError(e.to_string()))?
+                .get_base_leaf_count(),
+            MmrTree::Header => self
+                .header_mmr
+                .read()
+                .map_err(|e| ChainStorageError::AccessError(e.to_string()))?
+                .get_base_leaf_count(),
+            MmrTree::Utxo => self
+                .utxo_mmr
+                .read()
+                .map_err(|e| ChainStorageError::AccessError(e.to_string()))?
+                .get_base_leaf_count(),
+            MmrTree::RangeProof => self
+                .range_proof_mmr
+                .read()
+                .map_err(|e| ChainStorageError::AccessError(e.to_string()))?
+                .get_base_leaf_count(),
+        };
+        Ok(mmr_state)
+    }
+
     fn restore_mmr(&self, tree: MmrTree, base_state: MutableMmrLeafNodes) -> Result<(), ChainStorageError> {
         match tree {
             MmrTree::Kernel => self

--- a/base_layer/core/src/chain_storage/memory_db.rs
+++ b/base_layer/core/src/chain_storage/memory_db.rs
@@ -431,6 +431,17 @@ where D: Digest + Send + Sync
         Ok(mmr_state)
     }
 
+    fn fetch_mmr_base_leaf_node_count(&self, tree: MmrTree) -> Result<usize, ChainStorageError> {
+        let db = self.db_access()?;
+        let mmr_state = match tree {
+            MmrTree::Kernel => db.kernel_mmr.get_base_leaf_count(),
+            MmrTree::Header => db.header_mmr.get_base_leaf_count(),
+            MmrTree::Utxo => db.utxo_mmr.get_base_leaf_count(),
+            MmrTree::RangeProof => db.range_proof_mmr.get_base_leaf_count(),
+        };
+        Ok(mmr_state)
+    }
+
     fn restore_mmr(&self, tree: MmrTree, base_state: MutableMmrLeafNodes) -> Result<(), ChainStorageError> {
         let mut db = self
             .db

--- a/base_layer/core/src/proof_of_work/monero_rx.rs
+++ b/base_layer/core/src/proof_of_work/monero_rx.rs
@@ -23,19 +23,10 @@
 use crate::{blocks::BlockHeader, proof_of_work::Difficulty};
 use bigint::uint::U256;
 use derive_error::Error;
-use digest::Digest;
-use monero::{
-    blockdata::{
-        block::BlockHeader as MoneroBlockHeader,
-        Transaction as MoneroTransaction,
-        TransactionPrefix as MoneroTransactionPrefix,
-    },
-    consensus::encode::VarInt,
-    cryptonote::hash::Hash as MoneroHash,
-};
+use monero::blockdata::{block::BlockHeader as MoneroBlockHeader, Transaction as MoneroTransaction};
 use randomx_rs::{RandomXCache, RandomXError, RandomXFlag, RandomXVM};
 use serde::{Deserialize, Serialize};
-use tari_mmr::{Hash, HashSlice, MerkleMountainRange, MerkleProof};
+use tari_mmr::MerkleProof;
 
 const MAX_TARGET: U256 = U256::MAX;
 
@@ -71,8 +62,8 @@ pub struct MoneroData {
 }
 
 impl MoneroData {
-    fn new(TariHeader: &BlockHeader) -> Result<MoneroData, MergeMineError> {
-        bincode::deserialize(&TariHeader.pow.pow_data).map_err(|_| MergeMineError::DeserializeError)
+    fn new(tari_header: &BlockHeader) -> Result<MoneroData, MergeMineError> {
+        bincode::deserialize(&tari_header.pow.pow_data).map_err(|_| MergeMineError::DeserializeError)
     }
 }
 
@@ -109,7 +100,7 @@ fn create_input_blob(_data: &MoneroData) -> Result<String, MergeMineError> {
     Err(MergeMineError::HashingError)
 }
 
-fn verify_header(header: &BlockHeader, monero_data: &MoneroData) -> Result<(), MergeMineError> {
+fn verify_header(_header: &BlockHeader, _monero_data: &MoneroData) -> Result<(), MergeMineError> {
     // todo
     // verify that our header is in coinbase
     // todo


### PR DESCRIPTION
## Description
- Implemented the initial base node horizon synchronisation of the kernel mmr, range proof mmr, output mmr, headers, kernels and utxo set.
- Added fetch_mmr_base_leaf_node_count blockchain_db, memory_db and lmdb_db function to retrieve the total base mmr node count.
- Added Configuration for BaseNodeStateMachine and Horizon syncing, to allow the configuration of request chunk sizes.

## Motivation and Context
Enables the initial sync process of a Base node, allowing the blockchain to be synced from genesis block to pruning horizon.

## How Has This Been Tested?
Added a test for testing the horizon syncing mechanism and state transition.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [x] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch
* [x] I ran `cargo-fmt --all` before pushing
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
