### PR TITLE
Add median timestamp tracking

### DIFF
--- a/base_layer/transactions/src/consensus.rs
+++ b/base_layer/transactions/src/consensus.rs
@@ -36,6 +36,9 @@ pub const POW_ALGO_COUNT: u64 = 2;
 // algorithm count
 pub const DIFF_TARGET_BLOCK_INTERVAL: u64 = TARGET_BLOCK_INTERVAL * POW_ALGO_COUNT;
 
+// This is how many blocks we use to count towards the median timestamp to ensure the block chain moves forward
+pub const MEDIAN_TIMESTAMP_COUNT: usize = 11;
+
 /// This is used to control all consensus values.
 pub struct ConsensusRules {
     /// The min height maturity a coinbase utxo must have


### PR DESCRIPTION
## Description
This adds tracking of the timestamps for the median timestamp. This will allow the query of the median timestamp of the past 11 blocks.

## Motivation and Context
RFC 0120 specifies that we need to check that an incoming block's timestamp is greater than the median timestamp of the past 11 blocks. This requires that the past 11 bocks be kept track off. This uses the difficulty manager to keep track of the past 11 blocks as this already keeps track of the past 90 blocks for each difficulty. The median timestamp can now just be queried.

## How Has This Been Tested?
Added unit tests to ensure it keeps track of the correct blocks.

## Types of changes
* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [x] New Tests
* [ ] Documentation

## Checklist:
* [x] I'm merging against the `development` branch
* [x] I ran `cargo-fmt --all` before pushing
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
