### PR TITLE
Add Coinbase Transaction Builder

### DIFF
--- a/applications/tari_testnet_miner/src/miner.rs
+++ b/applications/tari_testnet_miner/src/miner.rs
@@ -94,33 +94,7 @@ impl Miner {
 
     /// Temp code, this needs to come from the wallet.
     fn create_coinbase_tx(&self, coinbase_value: MicroTari, block: &Block) -> (TransactionOutput, TransactionKernel) {
-        let mut rng = rand::OsRng::new().unwrap();
-        let coinbase_key = PrivateKey::random(&mut rng);
-        let new_commitment = self.factories.commitment.commit(&coinbase_key, &coinbase_value.into());
-        let rr = self
-            .factories
-            .range_proof
-            .construct_proof(&coinbase_key, coinbase_value.into())
-            .unwrap();
-        let coinbase = TransactionOutput {
-            commitment: new_commitment,
-            features: OutputFeatures::create_coinbase(block.header.height, &self.rules),
-            proof: RangeProof::from_bytes(&rr).unwrap(),
-        };
-        let excess = self.factories.commitment.commit(&coinbase_key, &(MicroTari(0)).into());
-        let nonce = PrivateKey::random(&mut rng);
-        let challenge = Miner::get_challenge(&PublicKey::from_secret_key(&nonce));
-        let sig = Signature::sign(coinbase_key, nonce, &challenge).unwrap();
-        let kernel = TransactionKernel {
-            features: KernelFeatures::empty(),
-            fee: 0.into(),
-            lock_height: 0,
-            excess,
-            excess_sig: sig,
-            meta_info: None,
-            linked_kernel: None,
-        };
-        (coinbase, kernel)
+        unimplemented!()
     }
 
     async fn mining(
@@ -181,15 +155,5 @@ impl Miner {
             return None;
         };
         std::mem::replace(&mut self.block, None)
-    }
-
-    /// This constructs a challenge for the coinbase tx
-    fn get_challenge(nonce: &PublicKey) -> MessageHash {
-        Challenge::new()
-            .chain(nonce.as_bytes())
-            .chain(&(0 as u64).to_le_bytes())
-            .chain(&(0 as u64).to_le_bytes())
-            .result()
-            .to_vec()
     }
 }

--- a/base_layer/transactions/src/coinbase_builder.rs
+++ b/base_layer/transactions/src/coinbase_builder.rs
@@ -1,0 +1,195 @@
+// Copyright 2019. The Tari Project
+//
+// Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+// following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+// disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+// following disclaimer in the documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+// products derived from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+// INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+// WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+// USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+
+use crate::{
+    consensus::ConsensusRules,
+    tari_amount::{uT, MicroTari},
+    transaction::{KernelBuilder, KernelFeatures, OutputFeatures, Transaction, TransactionBuilder, UnblindedOutput},
+    transaction_protocol::{build_challenge, TransactionMetadata},
+    types::{BlindingFactor, CryptoFactories, PrivateKey, PublicKey, Signature},
+};
+use derive_error::Error;
+use std::sync::Arc;
+use tari_crypto::{commitment::HomomorphicCommitmentFactory, keys::PublicKey as PK};
+
+#[derive(Debug, Clone, Error, PartialEq)]
+pub enum CoinbaseBuildError {
+    /// The block height for this coinbase transaction wasn't provided
+    MissingBlockHeight,
+    /// The value for the coinbase transaction is missing
+    MissingFees,
+    /// The private nonce for this coinbase transaction wasn't provided
+    MissingNonce,
+    /// The spend key for this coinbase transaction wasn't provided
+    MissingSpendKey,
+    /// An error ocurred building the final transaction
+    #[error(msg_embedded, no_from, non_std)]
+    BuildError(String),
+    /// Some inconsistent data was given to the builder. This transaction is not valid
+    InvalidTransaction,
+}
+
+pub struct CoinbaseBuilder {
+    rules: Arc<ConsensusRules>,
+    factories: Arc<CryptoFactories>,
+    block_height: Option<u64>,
+    fees: Option<MicroTari>,
+    spend_key: Option<PrivateKey>,
+    private_nonce: Option<PrivateKey>,
+}
+
+impl CoinbaseBuilder {
+    /// Start building a new Coinbase transaction. From here you can build the transaction piecemeal with the builder
+    /// methods, or pass in a block to `using_block` to determine most of the coinbase parameters automatically.
+    pub fn new(rules: Arc<ConsensusRules>, factories: Arc<CryptoFactories>) -> Self {
+        CoinbaseBuilder {
+            rules,
+            factories,
+            block_height: None,
+            fees: None,
+            spend_key: None,
+            private_nonce: None,
+        }
+    }
+
+    /// Assign the block height. This is used to determine the lock height of the transaction. Not required if
+    /// `using_block` is used.
+    pub fn with_block_height(mut self, height: u64) -> Self {
+        self.block_height = Some(height);
+        self
+    }
+
+    pub fn with_fees(mut self, value: MicroTari) -> Self {
+        self.fees = Some(value);
+        self
+    }
+
+    pub fn with_spend_key(mut self, key: PrivateKey) -> Self {
+        self.spend_key = Some(key);
+        self
+    }
+
+    pub fn with_nonce(mut self, nonce: PrivateKey) -> Self {
+        self.private_nonce = Some(nonce);
+        self
+    }
+
+    pub fn build(self) -> Result<Transaction, CoinbaseBuildError> {
+        let height = self.block_height.ok_or(CoinbaseBuildError::MissingBlockHeight)?;
+        let reward =
+            self.rules.emission_schedule().block_reward(height) + self.fees.ok_or(CoinbaseBuildError::MissingFees)?;
+        let nonce = self.private_nonce.ok_or(CoinbaseBuildError::MissingNonce)?;
+        let public_nonce = PublicKey::from_secret_key(&nonce);
+        let key = self.spend_key.ok_or(CoinbaseBuildError::MissingSpendKey)?;
+        let output_features = OutputFeatures::create_coinbase(height, &self.rules);
+        let excess = self.factories.commitment.commit_value(&key, 0);
+        let kernel_features = KernelFeatures::create_coinbase();
+        let metadata = TransactionMetadata::default();
+        let challenge = build_challenge(&public_nonce, &metadata);
+        let sig = Signature::sign(key.clone(), nonce, &challenge)
+            .map_err(|_| CoinbaseBuildError::BuildError("Challenge could not be represented as a scalar".into()))?;
+        let output = UnblindedOutput::new(reward, key, Some(output_features));
+        let output = output
+            .as_transaction_output(&self.factories)
+            .map_err(|e| CoinbaseBuildError::BuildError(e.to_string()))?;
+        let kernel = KernelBuilder::new()
+            .with_fee(0 * uT)
+            .with_features(kernel_features)
+            .with_lock_height(0)
+            .with_excess(&excess)
+            .with_signature(&sig)
+            .build()
+            .map_err(|e| CoinbaseBuildError::BuildError(e.to_string()))?;
+
+        let mut builder = TransactionBuilder::new();
+        builder
+            .add_output(output)
+            .add_offset(BlindingFactor::default())
+            .with_reward(reward)
+            .with_kernel(kernel);
+        builder
+            .build(&self.factories)
+            .map_err(|e| CoinbaseBuildError::BuildError(e.to_string()))
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::{
+        coinbase_builder::CoinbaseBuildError,
+        consensus::ConsensusRules,
+        tari_amount::uT,
+        test_utils::primitives::TestParams,
+        transaction::OutputFlags,
+        types::CryptoFactories,
+        CoinbaseBuilder,
+    };
+    use std::sync::Arc;
+    use tari_crypto::commitment::HomomorphicCommitmentFactory;
+
+    fn get_builder() -> (CoinbaseBuilder, Arc<ConsensusRules>, Arc<CryptoFactories>) {
+        let rules = Arc::new(ConsensusRules::current());
+        let factories = Arc::new(CryptoFactories::default());
+        (CoinbaseBuilder::new(rules.clone(), factories.clone()), rules, factories)
+    }
+
+    #[test]
+    fn missing_height() {
+        let (builder, _, _) = get_builder();
+        assert_eq!(builder.build().unwrap_err(), CoinbaseBuildError::MissingBlockHeight);
+    }
+
+    #[test]
+    fn missing_fees() {
+        let (builder, _, _) = get_builder();
+        let builder = builder.with_block_height(42);
+        assert_eq!(builder.build().unwrap_err(), CoinbaseBuildError::MissingFees);
+    }
+
+    #[test]
+    fn missing_spend_key() {
+        let p = TestParams::new();
+        let (builder, _, _) = get_builder();
+        let builder = builder.with_block_height(42).with_fees(0 * uT).with_nonce(p.nonce);
+        assert_eq!(builder.build().unwrap_err(), CoinbaseBuildError::MissingSpendKey);
+    }
+
+    #[test]
+    fn valid_coinbase() {
+        let p = TestParams::new();
+        let (builder, rules, factories) = get_builder();
+        let builder = builder
+            .with_block_height(42)
+            .with_fees(145 * uT)
+            .with_nonce(p.nonce.clone())
+            .with_spend_key(p.spend_key.clone());
+        let tx = builder.build().unwrap();
+        let utxo = &tx.body.outputs()[0];
+        let block_reward = rules.emission_schedule().block_reward(42) + 145 * uT;
+        assert!(factories
+            .commitment
+            .open_value(&p.spend_key, block_reward.into(), utxo.commitment()));
+        assert!(utxo.verify_range_proof(&factories.range_proof).unwrap());
+        assert!(utxo.features.flags.contains(OutputFlags::COINBASE_OUTPUT));
+    }
+}

--- a/base_layer/transactions/src/coinbase_builder.rs
+++ b/base_layer/transactions/src/coinbase_builder.rs
@@ -72,28 +72,37 @@ impl CoinbaseBuilder {
         }
     }
 
-    /// Assign the block height. This is used to determine the lock height of the transaction. Not required if
-    /// `using_block` is used.
+    /// Assign the block height. This is used to determine the lock height of the transaction.
     pub fn with_block_height(mut self, height: u64) -> Self {
         self.block_height = Some(height);
         self
     }
 
+    /// Indicates the sum total of all fees that the coinbase transaction earns, over and above the block reward
     pub fn with_fees(mut self, value: MicroTari) -> Self {
         self.fees = Some(value);
         self
     }
 
+    /// Provides the private spend key for this transaction. This will usually be provided by a miner's wallet instance.
     pub fn with_spend_key(mut self, key: PrivateKey) -> Self {
         self.spend_key = Some(key);
         self
     }
 
+    /// The nonce to be used for this transaction. This will usually be provided by a miner's wallet instance.
     pub fn with_nonce(mut self, nonce: PrivateKey) -> Self {
         self.private_nonce = Some(nonce);
         self
     }
 
+    /// Try and construct a Coinbase Transaction. The block reward is taken from the emission curve for the current
+    /// block height. The other parameters (keys, nonces etc.) are provided by the caller. Other data is
+    /// automatically set: Coinbase transactions have an offset of zero, no fees, the `COINBASE_OUTPUT` flags are set
+    /// on the output and kernel, and the maturity schedule is set from the consensus rules.
+    ///
+    /// After `build` is called, the struct is destroyed and the private keys stored are dropped and the memory zeroed
+    /// out (by virtue of the zero_on_drop crate).
     pub fn build(self) -> Result<Transaction, CoinbaseBuildError> {
         let height = self.block_height.ok_or(CoinbaseBuildError::MissingBlockHeight)?;
         let reward =

--- a/base_layer/transactions/src/lib.rs
+++ b/base_layer/transactions/src/lib.rs
@@ -6,6 +6,8 @@ extern crate bitflags;
 #[cfg(test)]
 mod test_utils;
 
+mod coinbase_builder;
+
 pub mod aggregated_body;
 pub mod bullet_rangeproofs;
 pub mod consensus;
@@ -17,8 +19,8 @@ pub mod transaction;
 #[allow(clippy::op_ref)]
 pub mod transaction_protocol;
 pub mod types;
-
 // Re-export commonly used structs
 pub use transaction_protocol::{recipient::ReceiverTransactionProtocol, sender::SenderTransactionProtocol};
 // Re-export the crypto crate to make exposing traits etc easier for clients of this crate
+pub use coinbase_builder::CoinbaseBuilder;
 pub use tari_crypto as crypto;

--- a/base_layer/transactions/src/test_utils/mod.rs
+++ b/base_layer/transactions/src/test_utils/mod.rs
@@ -23,3 +23,4 @@
 /// Helper functions to simplify generated test blockchain data
 #[macro_use]
 pub mod builders;
+pub mod primitives;

--- a/base_layer/transactions/src/test_utils/primitives.rs
+++ b/base_layer/transactions/src/test_utils/primitives.rs
@@ -20,18 +20,8 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-// Used in tests only
-
-use crate::{
-    tari_amount::*,
-    transaction::{OutputFeatures, TransactionInput, UnblindedOutput},
-    types::{CommitmentFactory, PrivateKey, PublicKey},
-};
-use rand::{CryptoRng, Rng};
-use tari_crypto::{
-    commitment::HomomorphicCommitmentFactory,
-    keys::{PublicKey as PK, SecretKey},
-};
+use crate::types::{PrivateKey, PublicKey};
+use tari_crypto::keys::{PublicKey as PK, SecretKey as SK};
 
 pub struct TestParams {
     pub spend_key: PrivateKey,
@@ -42,27 +32,15 @@ pub struct TestParams {
 }
 
 impl TestParams {
-    pub fn new<R: Rng + CryptoRng>(rng: &mut R) -> TestParams {
-        let r = PrivateKey::random(rng);
+    pub fn new() -> TestParams {
+        let mut rng = rand::OsRng::new().unwrap();
+        let r = PrivateKey::random(&mut rng);
         TestParams {
-            spend_key: PrivateKey::random(rng),
-            change_key: PrivateKey::random(rng),
-            offset: PrivateKey::random(rng),
+            spend_key: PrivateKey::random(&mut rng),
+            change_key: PrivateKey::random(&mut rng),
+            offset: PrivateKey::random(&mut rng),
             public_nonce: PublicKey::from_secret_key(&r),
             nonce: r,
         }
     }
-}
-
-pub fn make_input<R: Rng + CryptoRng>(
-    rng: &mut R,
-    val: MicroTari,
-    factory: &CommitmentFactory,
-) -> (TransactionInput, UnblindedOutput)
-{
-    let key = PrivateKey::random(rng);
-    let v = PrivateKey::from(val);
-    let commitment = factory.commit(&key, &v);
-    let input = TransactionInput::new(OutputFeatures::default(), commitment);
-    (input, UnblindedOutput::new(val, key, None))
 }

--- a/base_layer/transactions/src/transaction_protocol/mod.rs
+++ b/base_layer/transactions/src/transaction_protocol/mod.rs
@@ -49,9 +49,6 @@
 //!   end
 //! </div>
 
-#[cfg(test)]
-pub mod test_common;
-
 pub mod proto;
 pub mod recipient;
 pub mod sender;

--- a/base_layer/transactions/src/transaction_protocol/recipient.rs
+++ b/base_layer/transactions/src/transaction_protocol/recipient.rs
@@ -160,24 +160,22 @@ impl ReceiverTransactionProtocol {
 mod test {
     use crate::{
         tari_amount::*,
+        test_utils::primitives::TestParams,
         transaction::OutputFeatures,
         transaction_protocol::{
             build_challenge,
             sender::{SingleRoundSenderData, TransactionSenderMessage},
-            test_common::TestParams,
             TransactionMetadata,
         },
         types::{CryptoFactories, PublicKey, Signature},
         ReceiverTransactionProtocol,
     };
-    use rand::OsRng;
     use tari_crypto::{commitment::HomomorphicCommitmentFactory, keys::PublicKey as PK};
 
     #[test]
     fn single_round_recipient() {
-        let mut rng = OsRng::new().unwrap();
         let factories = CryptoFactories::default();
-        let p = TestParams::new(&mut rng);
+        let p = TestParams::new();
         let m = TransactionMetadata {
             fee: MicroTari(125),
             lock_height: 0,

--- a/base_layer/transactions/src/transaction_protocol/transaction_initializer.rs
+++ b/base_layer/transactions/src/transaction_protocol/transaction_initializer.rs
@@ -317,10 +317,10 @@ mod test {
     use crate::{
         fee::{Fee, BASE_COST, WEIGHT_PER_INPUT, WEIGHT_PER_OUTPUT},
         tari_amount::*,
+        test_utils::{builders::make_input, primitives::TestParams},
         transaction::{UnblindedOutput, MAX_TRANSACTION_INPUTS},
         transaction_protocol::{
             sender::SenderState,
-            test_common::{make_input, TestParams},
             transaction_initializer::SenderTransactionInitializer,
             TransactionProtocolError,
         },
@@ -335,7 +335,7 @@ mod test {
         // Create some inputs
         let mut rng = OsRng::new().unwrap();
         let factories = CryptoFactories::default();
-        let p = TestParams::new(&mut rng);
+        let p = TestParams::new();
         // Start the builder
         let builder = SenderTransactionInitializer::new(0);
         let err = builder.build::<Blake256>(&factories).unwrap_err();
@@ -382,7 +382,7 @@ mod test {
         // Create some inputs
         let mut rng = OsRng::new().unwrap();
         let factories = CryptoFactories::default();
-        let p = TestParams::new(&mut rng);
+        let p = TestParams::new();
         let (utxo, input) = make_input(&mut rng, MicroTari(500), &factories.commitment);
         let expected_fee = Fee::calculate(MicroTari(20), 1, 1);
         let output = UnblindedOutput::new(MicroTari(500) - expected_fee, p.spend_key, None);
@@ -417,7 +417,7 @@ mod test {
         // Create some inputs
         let mut rng = OsRng::new().unwrap();
         let factories = CryptoFactories::default();
-        let p = TestParams::new(&mut rng);
+        let p = TestParams::new();
         let (utxo, input) = make_input(&mut rng, MicroTari(500), &factories.commitment);
         let expected_fee = MicroTari::from(BASE_COST + (WEIGHT_PER_INPUT + 1 * WEIGHT_PER_OUTPUT) * 20); // 101, output = 80
                                                                                                          // Pay out so that I should get change, but not enough to pay for the output
@@ -452,7 +452,7 @@ mod test {
         // Create some inputs
         let mut rng = OsRng::new().unwrap();
         let factories = CryptoFactories::default();
-        let p = TestParams::new(&mut rng);
+        let p = TestParams::new();
         let output = UnblindedOutput::new(MicroTari(500), p.spend_key, None);
         // Start the builder
         let mut builder = SenderTransactionInitializer::new(0);
@@ -475,7 +475,7 @@ mod test {
         // Create some inputs
         let mut rng = OsRng::new().unwrap();
         let factories = CryptoFactories::default();
-        let p = TestParams::new(&mut rng);
+        let p = TestParams::new();
         let (utxo, input) = make_input(&mut rng, MicroTari(500), &factories.commitment);
         let output = UnblindedOutput::new(MicroTari(400), p.spend_key, None);
         // Start the builder
@@ -497,7 +497,7 @@ mod test {
         // Create some inputs
         let mut rng = OsRng::new().unwrap();
         let factories = CryptoFactories::default();
-        let p = TestParams::new(&mut rng);
+        let p = TestParams::new();
         let (utxo, input) = make_input(&mut rng, MicroTari(400), &factories.commitment);
         let output = UnblindedOutput::new(MicroTari(400), p.spend_key, None);
         // Start the builder
@@ -519,7 +519,7 @@ mod test {
         // Create some inputs
         let mut rng = OsRng::new().unwrap();
         let factories = CryptoFactories::default();
-        let p = TestParams::new(&mut rng);
+        let p = TestParams::new();
         let (utxo, input) = make_input(&mut rng, MicroTari(1000), &factories.commitment);
         let output = UnblindedOutput::new(MicroTari(150), p.spend_key, None);
         // Start the builder
@@ -548,7 +548,7 @@ mod test {
         // Create some inputs
         let mut rng = OsRng::new().unwrap();
         let factories = CryptoFactories::default();
-        let p = TestParams::new(&mut rng);
+        let p = TestParams::new();
         let (utxo1, input1) = make_input(&mut rng, MicroTari(2000), &factories.commitment);
         let (utxo2, input2) = make_input(&mut rng, MicroTari(3000), &factories.commitment);
         let weight = MicroTari(30);
@@ -587,7 +587,7 @@ mod test {
         // Create some inputs
         let mut rng = OsRng::new().unwrap();
         let factories = CryptoFactories::new(32);
-        let p = TestParams::new(&mut rng);
+        let p = TestParams::new();
         let (utxo1, input1) = make_input(&mut rng, (2u64.pow(32) + 10000u64).into(), &factories.commitment);
         let weight = MicroTari(30);
         let output = UnblindedOutput::new((1u64.pow(32) + 1u64).into(), p.spend_key, None);


### PR DESCRIPTION
The coinbase transaction hasn't been properly addressed until now.
There were several pieces of code that provided CB TXs in various
places in the codebase.

The CB TX is a simple but non-trivial implementation and so a builder
pattern is used.

The builder unifies all the code for generating a CB TX in one place.

The builder lives in the `transactions` crate and so does not know
about a block. Another PR will provide a `from_block` type function
in `tari_core` that will make use of the builder to ergonomically
construct a CB TX from information in a block.

Also brought the `TestParams` test utility into the common utils module to be more widely accessible 