### PR TITLE
Move the coinbase builder to core so that consensus can move to core …

### DIFF
--- a/base_layer/core/src/mining/coinbase_builder.rs
+++ b/base_layer/core/src/mining/coinbase_builder.rs
@@ -21,16 +21,16 @@
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 //
 
-use crate::{
+use derive_error::Error;
+use std::sync::Arc;
+use tari_crypto::{commitment::HomomorphicCommitmentFactory, keys::PublicKey as PK};
+use tari_transactions::{
     consensus::ConsensusRules,
     tari_amount::{uT, MicroTari},
     transaction::{KernelBuilder, KernelFeatures, OutputFeatures, Transaction, TransactionBuilder, UnblindedOutput},
     transaction_protocol::{build_challenge, TransactionMetadata},
     types::{BlindingFactor, CryptoFactories, PrivateKey, PublicKey, Signature},
 };
-use derive_error::Error;
-use std::sync::Arc;
-use tari_crypto::{commitment::HomomorphicCommitmentFactory, keys::PublicKey as PK};
 
 #[derive(Debug, Clone, Error, PartialEq)]
 pub enum CoinbaseBuildError {
@@ -145,17 +145,17 @@ impl CoinbaseBuilder {
 #[cfg(test)]
 mod test {
     use crate::{
-        coinbase_builder::CoinbaseBuildError,
-        consensus::ConsensusRules,
-        tari_amount::uT,
+        mining::{coinbase_builder::CoinbaseBuildError, CoinbaseBuilder},
         test_utils::primitives::TestParams,
-        transaction::OutputFlags,
-        types::CryptoFactories,
-        CoinbaseBuilder,
     };
     use std::sync::Arc;
     use tari_crypto::commitment::HomomorphicCommitmentFactory;
-
+    use tari_transactions::{
+        consensus::ConsensusRules,
+        tari_amount::uT,
+        transaction::OutputFlags,
+        types::CryptoFactories,
+    };
     fn get_builder() -> (CoinbaseBuilder, Arc<ConsensusRules>, Arc<CryptoFactories>) {
         let rules = Arc::new(ConsensusRules::current());
         let factories = Arc::new(CryptoFactories::default());

--- a/base_layer/core/src/mining/mod.rs
+++ b/base_layer/core/src/mining/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2018 The Tari Project
+// Copyright 2019, The Tari Project
 //
 // Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
 // following conditions are met:
@@ -20,31 +20,6 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-// Needed to make futures::select! work
-#![recursion_limit = "512"]
-// Used to eliminate the need for boxing futures in many cases.
-// Tracking issue: https://github.com/rust-lang/rust/issues/63063
-#![feature(type_alias_impl_trait)]
-// Enable usage of Vec::shrink_to
-#![feature(shrink_to)]
-
-#[cfg(test)]
-pub mod test_utils;
-
-pub mod consts;
-pub mod mempool;
-pub mod proof_of_work;
-
-pub mod proto;
-pub mod types;
-
-pub mod base_node;
-pub mod blocks;
-
-pub mod chain_storage;
-pub mod validation;
-
-pub mod mining;
-
-// Re-export the crypto crate to make exposing traits etc easier for clients of this crate
-pub use tari_crypto as crypto;
+/// Helper functions to simplify generated test blockchain data
+mod coinbase_builder;
+pub use coinbase_builder::CoinbaseBuilder;

--- a/base_layer/core/src/test_utils/primitives.rs
+++ b/base_layer/core/src/test_utils/primitives.rs
@@ -60,3 +60,25 @@ pub fn create_random_signature(fee: MicroTari, lock_height: u64) -> (PublicKey, 
     let e = build_challenge(&PublicKey::from_secret_key(&r), &tx_meta);
     (p, Signature::sign(k, r, &e).unwrap())
 }
+
+pub struct TestParams {
+    pub spend_key: PrivateKey,
+    pub change_key: PrivateKey,
+    pub offset: PrivateKey,
+    pub nonce: PrivateKey,
+    pub public_nonce: PublicKey,
+}
+
+impl TestParams {
+    pub fn new() -> TestParams {
+        let mut rng = rand::OsRng::new().unwrap();
+        let r = PrivateKey::random(&mut rng);
+        TestParams {
+            spend_key: PrivateKey::random(&mut rng),
+            change_key: PrivateKey::random(&mut rng),
+            offset: PrivateKey::random(&mut rng),
+            public_nonce: PublicKey::from_secret_key(&r),
+            nonce: r,
+        }
+    }
+}

--- a/base_layer/transactions/src/lib.rs
+++ b/base_layer/transactions/src/lib.rs
@@ -6,8 +6,6 @@ extern crate bitflags;
 #[cfg(test)]
 mod test_utils;
 
-mod coinbase_builder;
-
 pub mod aggregated_body;
 pub mod bullet_rangeproofs;
 pub mod consensus;
@@ -22,5 +20,4 @@ pub mod types;
 // Re-export commonly used structs
 pub use transaction_protocol::{recipient::ReceiverTransactionProtocol, sender::SenderTransactionProtocol};
 // Re-export the crypto crate to make exposing traits etc easier for clients of this crate
-pub use coinbase_builder::CoinbaseBuilder;
 pub use tari_crypto as crypto;


### PR DESCRIPTION
## Description
Move the coinbase builder to core so that consensus can move to core as well. 

## Motivation and Context
Currently consensus is stuck in transactions, which stops a future refactor of consensus. This PR is to move this over so we can refactor consensus. 

## Types of changes
* [ ] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [x] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
* [x] I'm merging against the `development` branch
* [x] I ran `cargo-fmt --all` before pushing
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
