### PR TITLE
Provide async callback for when Transaction service needs to perform peer discovery

### DIFF
--- a/base_layer/wallet/src/testnet_utils.rs
+++ b/base_layer/wallet/src/testnet_utils.rs
@@ -156,7 +156,7 @@ pub fn create_wallet(
 /// This function will generate a set of test data for the supplied wallet. Takes a few seconds to complete
 pub fn generate_wallet_test_data<
     T: WalletBackend,
-    U: TransactionBackend,
+    U: TransactionBackend + Clone,
     V: OutputManagerBackend,
     W: ContactsBackend,
 >(
@@ -315,7 +315,7 @@ pub fn generate_wallet_test_data<
 /// CompletedTransaction with the Broadcast status indicating it is in a base node Mempool but not yet mined
 pub fn complete_sent_transaction<
     T: WalletBackend,
-    U: TransactionBackend,
+    U: TransactionBackend + Clone,
     V: OutputManagerBackend,
     W: ContactsBackend,
 >(
@@ -359,7 +359,7 @@ pub fn complete_sent_transaction<
 /// wallet sending a transaction to this wallet which will become a PendingInboundTransaction
 pub fn receive_test_transaction<
     T: WalletBackend,
-    U: TransactionBackend,
+    U: TransactionBackend + Clone,
     V: OutputManagerBackend,
     W: ContactsBackend,
 >(
@@ -379,7 +379,12 @@ pub fn receive_test_transaction<
     Ok(())
 }
 
-pub fn broadcast_transaction<T: WalletBackend, U: TransactionBackend, V: OutputManagerBackend, W: ContactsBackend>(
+pub fn broadcast_transaction<
+    T: WalletBackend,
+    U: TransactionBackend + Clone,
+    V: OutputManagerBackend,
+    W: ContactsBackend,
+>(
     wallet: &mut Wallet<T, U, V, W>,
     tx_id: TxId,
 ) -> Result<(), WalletError>
@@ -395,7 +400,12 @@ pub fn broadcast_transaction<T: WalletBackend, U: TransactionBackend, V: OutputM
 /// the event when a CompletedTransaction that is in the Broadcast status, is in a mempool but not mined, beocmes
 /// mined/confirmed. After this function is called the status of the CompletedTransaction becomes `Mined` and the funds
 /// that were pending become spent and available respectively.
-pub fn mine_transaction<T: WalletBackend, U: TransactionBackend, V: OutputManagerBackend, W: ContactsBackend>(
+pub fn mine_transaction<
+    T: WalletBackend,
+    U: TransactionBackend + Clone,
+    V: OutputManagerBackend,
+    W: ContactsBackend,
+>(
     wallet: &mut Wallet<T, U, V, W>,
     tx_id: TxId,
 ) -> Result<(), WalletError>

--- a/base_layer/wallet/src/transaction_service/error.rs
+++ b/base_layer/wallet/src/transaction_service/error.rs
@@ -20,7 +20,10 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use crate::{output_manager_service::error::OutputManagerError, transaction_service::storage::database::DbKey};
+use crate::{
+    output_manager_service::{error::OutputManagerError, TxId},
+    transaction_service::storage::database::DbKey,
+};
 use derive_error::Error;
 use diesel::result::Error as DieselError;
 use serde_json::Error as SerdeJsonError;
@@ -56,7 +59,16 @@ pub enum TransactionServiceError {
     InvalidSourcePublicKey,
     /// The transaction does not contain the receivers output
     ReceiverOutputNotFound,
-    OutboundError(DhtOutboundError),
+    /// Outbound Service send failed
+    OutboundSendFailure,
+    /// Outbound Service Discovery process needed to be conducted before message could be sent. The result of the
+    /// process will be communicated via the callback at some time in the future (could be minutes)
+    #[error(no_from, non_std)]
+    OutboundSendDiscoveryInProgress(TxId),
+    /// Discovery process failed to return a result
+    #[error(no_from, non_std)]
+    DiscoveryProcessFailed(TxId),
+    DhtOutboundError(DhtOutboundError),
     OutputManagerError(OutputManagerError),
     TransportChannelError(TransportChannelError),
     TransactionStorageError(TransactionStorageError),

--- a/base_layer/wallet/src/transaction_service/handle.rs
+++ b/base_layer/wallet/src/transaction_service/handle.rs
@@ -20,11 +20,12 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-#[cfg(feature = "test_harness")]
-use crate::output_manager_service::TxId;
-use crate::transaction_service::{
-    error::TransactionServiceError,
-    storage::database::{CompletedTransaction, InboundTransaction, OutboundTransaction},
+use crate::{
+    output_manager_service::TxId,
+    transaction_service::{
+        error::TransactionServiceError,
+        storage::database::{CompletedTransaction, InboundTransaction, OutboundTransaction},
+    },
 };
 use futures::{stream::Fuse, StreamExt};
 use std::collections::HashMap;
@@ -86,6 +87,8 @@ pub enum TransactionEvent {
     ReceivedTransaction,
     ReceivedTransactionReply,
     ReceivedFinalizedTransaction,
+    TransactionSendDiscoverySuccess(TxId),
+    TransactionSendDiscoveryFailure(TxId),
     Error(String),
 }
 

--- a/base_layer/wallet/src/transaction_service/mod.rs
+++ b/base_layer/wallet/src/transaction_service/mod.rs
@@ -108,7 +108,7 @@ where T: TransactionBackend
 }
 
 impl<T> ServiceInitializer for TransactionServiceInitializer<T>
-where T: TransactionBackend + 'static
+where T: TransactionBackend + Clone + 'static
 {
     type Future = impl Future<Output = Result<(), ServiceInitializationError>>;
 

--- a/base_layer/wallet/src/transaction_service/storage/database.rs
+++ b/base_layer/wallet/src/transaction_service/storage/database.rs
@@ -159,6 +159,7 @@ macro_rules! fetch {
 
 /// This structure holds an inner type that implements the `TransactionBackend` trait and contains the more complex
 /// data access logic required by the module built onto the functionality defined by the trait
+#[derive(Clone)]
 pub struct TransactionDatabase<T>
 where T: TransactionBackend
 {

--- a/base_layer/wallet/src/transaction_service/storage/memory_db.rs
+++ b/base_layer/wallet/src/transaction_service/storage/memory_db.rs
@@ -59,6 +59,7 @@ impl InnerDatabase {
     }
 }
 
+#[derive(Clone)]
 pub struct TransactionMemoryDatabase {
     db: Arc<RwLock<InnerDatabase>>,
 }

--- a/base_layer/wallet/src/transaction_service/storage/sqlite_db.rs
+++ b/base_layer/wallet/src/transaction_service/storage/sqlite_db.rs
@@ -52,6 +52,7 @@ use tari_utilities::ByteArray;
 const DATABASE_CONNECTION_TIMEOUT_MS: u64 = 2000;
 
 /// A Sqlite backend for the Transaction Service. The Backend is accessed via a connection pool to the Sqlite file.
+#[derive(Clone)]
 pub struct TransactionServiceSqliteDatabase {
     database_connection_pool: Pool<ConnectionManager<SqliteConnection>>,
 }

--- a/base_layer/wallet/src/wallet.rs
+++ b/base_layer/wallet/src/wallet.rs
@@ -76,7 +76,7 @@ pub struct WalletConfig {
 pub struct Wallet<T, U, V, W>
 where
     T: WalletBackend,
-    U: TransactionBackend + 'static,
+    U: TransactionBackend + Clone + 'static,
     V: OutputManagerBackend + 'static,
     W: ContactsBackend + 'static,
 {
@@ -97,7 +97,7 @@ where
 impl<T, U, V, W> Wallet<T, U, V, W>
 where
     T: WalletBackend,
-    U: TransactionBackend + 'static,
+    U: TransactionBackend + Clone + 'static,
     V: OutputManagerBackend + 'static,
     W: ContactsBackend + 'static,
 {

--- a/base_layer/wallet/tests/output_manager_service/service.rs
+++ b/base_layer/wallet/tests/output_manager_service/service.rs
@@ -20,10 +20,7 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use crate::support::{
-    data::create_temporary_sqlite_path,
-    utils::{make_input, TestParams},
-};
+use crate::support::utils::{make_input, random_string, TestParams};
 use rand::RngCore;
 use std::{thread, time::Duration};
 use tari_crypto::{
@@ -52,6 +49,7 @@ use tari_wallet::output_manager_service::{
     OutputManagerConfig,
     OutputManagerServiceInitializer,
 };
+use tempdir::TempDir;
 use tokio::runtime::Runtime;
 
 pub fn setup_output_manager_service<T: OutputManagerBackend + 'static>(
@@ -166,7 +164,11 @@ fn sending_transaction_and_confirmation_memory_db() {
 
 #[test]
 fn sending_transaction_and_confirmation_sqlite_db() {
-    sending_transaction_and_confirmation(OutputManagerSqliteDatabase::new(create_temporary_sqlite_path()).unwrap());
+    let db_name = format!("{}.sqlite3", random_string(8).as_str());
+    let db_tempdir = TempDir::new(random_string(8).as_str()).unwrap();
+    let db_folder = db_tempdir.path().to_str().unwrap().to_string();
+    let db_path = format!("{}/{}", db_folder, db_name);
+    sending_transaction_and_confirmation(OutputManagerSqliteDatabase::new(db_path).unwrap());
 }
 
 fn send_not_enough_funds<T: OutputManagerBackend + 'static>(backend: T) {
@@ -213,7 +215,11 @@ fn send_not_enough_funds_memory_db() {
 
 #[test]
 fn send_not_enough_funds_sqlite_db() {
-    send_not_enough_funds(OutputManagerSqliteDatabase::new(create_temporary_sqlite_path()).unwrap());
+    let db_name = format!("{}.sqlite3", random_string(8).as_str());
+    let db_tempdir = TempDir::new(random_string(8).as_str()).unwrap();
+    let db_folder = db_tempdir.path().to_str().unwrap().to_string();
+    let db_path = format!("{}/{}", db_folder, db_name);
+    send_not_enough_funds(OutputManagerSqliteDatabase::new(db_path).unwrap());
 }
 
 fn send_no_change<T: OutputManagerBackend + 'static>(backend: T) {
@@ -293,7 +299,11 @@ fn send_no_change_memory_db() {
 
 #[test]
 fn send_no_change_sqlite_db() {
-    send_no_change(OutputManagerSqliteDatabase::new(create_temporary_sqlite_path()).unwrap());
+    let db_name = format!("{}.sqlite3", random_string(8).as_str());
+    let db_tempdir = TempDir::new(random_string(8).as_str()).unwrap();
+    let db_folder = db_tempdir.path().to_str().unwrap().to_string();
+    let db_path = format!("{}/{}", db_folder, db_name);
+    send_no_change(OutputManagerSqliteDatabase::new(db_path).unwrap());
 }
 
 fn send_not_enough_for_change<T: OutputManagerBackend + 'static>(backend: T) {
@@ -343,7 +353,11 @@ fn send_not_enough_for_change_memory_db() {
 
 #[test]
 fn send_not_enough_for_change_sqlite_db() {
-    send_not_enough_for_change(OutputManagerSqliteDatabase::new(create_temporary_sqlite_path()).unwrap());
+    let db_name = format!("{}.sqlite3", random_string(8).as_str());
+    let db_tempdir = TempDir::new(random_string(8).as_str()).unwrap();
+    let db_folder = db_tempdir.path().to_str().unwrap().to_string();
+    let db_path = format!("{}/{}", db_folder, db_name);
+    send_not_enough_for_change(OutputManagerSqliteDatabase::new(db_path).unwrap());
 }
 
 fn receiving_and_confirmation<T: OutputManagerBackend + 'static>(backend: T) {
@@ -389,7 +403,11 @@ fn receiving_and_confirmation_memory_db() {
 
 #[test]
 fn receiving_and_confirmation_sqlite_db() {
-    receiving_and_confirmation(OutputManagerSqliteDatabase::new(create_temporary_sqlite_path()).unwrap());
+    let db_name = format!("{}.sqlite3", random_string(8).as_str());
+    let db_tempdir = TempDir::new(random_string(8).as_str()).unwrap();
+    let db_folder = db_tempdir.path().to_str().unwrap().to_string();
+    let db_path = format!("{}/{}", db_folder, db_name);
+    receiving_and_confirmation(OutputManagerSqliteDatabase::new(db_path).unwrap());
 }
 
 fn cancel_transaction<T: OutputManagerBackend + 'static>(backend: T) {
@@ -443,7 +461,11 @@ fn cancel_transaction_memory_db() {
 
 #[test]
 fn cancel_transaction_sqlite_db() {
-    cancel_transaction(OutputManagerSqliteDatabase::new(create_temporary_sqlite_path()).unwrap());
+    let db_name = format!("{}.sqlite3", random_string(8).as_str());
+    let db_tempdir = TempDir::new(random_string(8).as_str()).unwrap();
+    let db_folder = db_tempdir.path().to_str().unwrap().to_string();
+    let db_path = format!("{}/{}", db_folder, db_name);
+    cancel_transaction(OutputManagerSqliteDatabase::new(db_path).unwrap());
 }
 
 fn timeout_transaction<T: OutputManagerBackend + 'static>(backend: T) {
@@ -502,7 +524,11 @@ fn timeout_transaction_memory_db() {
 
 #[test]
 fn timeout_transaction_sqlite_db() {
-    timeout_transaction(OutputManagerSqliteDatabase::new(create_temporary_sqlite_path()).unwrap());
+    let db_name = format!("{}.sqlite3", random_string(8).as_str());
+    let db_tempdir = TempDir::new(random_string(8).as_str()).unwrap();
+    let db_folder = db_tempdir.path().to_str().unwrap().to_string();
+    let db_path = format!("{}/{}", db_folder, db_name);
+    timeout_transaction(OutputManagerSqliteDatabase::new(db_path).unwrap());
 }
 
 fn test_get_balance<T: OutputManagerBackend + 'static>(backend: T) {
@@ -560,7 +586,11 @@ fn test_get_balance_memory_db() {
 
 #[test]
 fn test_get_balance_sqlite_db() {
-    test_get_balance(OutputManagerSqliteDatabase::new(create_temporary_sqlite_path()).unwrap());
+    let db_name = format!("{}.sqlite3", random_string(8).as_str());
+    let db_tempdir = TempDir::new(random_string(8).as_str()).unwrap();
+    let db_folder = db_tempdir.path().to_str().unwrap().to_string();
+    let db_path = format!("{}/{}", db_folder, db_name);
+    test_get_balance(OutputManagerSqliteDatabase::new(db_path).unwrap());
 }
 
 fn test_confirming_received_output<T: OutputManagerBackend + 'static>(backend: T) {
@@ -601,5 +631,9 @@ fn test_confirming_received_output_memory_db() {
 
 #[test]
 fn test_confirming_received_output_sqlite_db() {
-    test_confirming_received_output(OutputManagerSqliteDatabase::new(create_temporary_sqlite_path()).unwrap());
+    let db_name = format!("{}.sqlite3", random_string(8).as_str());
+    let db_tempdir = TempDir::new(random_string(8).as_str()).unwrap();
+    let db_folder = db_tempdir.path().to_str().unwrap().to_string();
+    let db_path = format!("{}/{}", db_folder, db_name);
+    test_confirming_received_output(OutputManagerSqliteDatabase::new(db_path).unwrap());
 }

--- a/base_layer/wallet/tests/support/comms_and_services.rs
+++ b/base_layer/wallet/tests/support/comms_and_services.rs
@@ -58,7 +58,7 @@ where
                 p.node_id().clone(),
                 addr.into(),
                 PeerFlags::empty(),
-                PeerFeatures::empty(),
+                PeerFeatures::COMMUNICATION_NODE,
             ))
             .unwrap();
     }

--- a/base_layer/wallet/tests/transaction_service/storage.rs
+++ b/base_layer/wallet/tests/transaction_service/storage.rs
@@ -211,12 +211,8 @@ pub fn test_transaction_service_memory_db() {
 #[test]
 pub fn test_transaction_service_sqlite_db() {
     let db_name = format!("{}.sqlite3", random_string(8).as_str());
-    let db_folder = TempDir::new(random_string(8).as_str())
-        .unwrap()
-        .path()
-        .to_str()
-        .unwrap()
-        .to_string();
-    let db_path = format!("{}{}", db_folder, db_name);
+    let db_tempdir = TempDir::new(random_string(8).as_str()).unwrap();
+    let db_folder = db_tempdir.path().to_str().unwrap().to_string();
+    let db_path = format!("{}/{}", db_folder, db_name);
     test_db_backend(TransactionServiceSqliteDatabase::new(db_path).unwrap());
 }

--- a/base_layer/wallet/tests/wallet/mod.rs
+++ b/base_layer/wallet/tests/wallet/mod.rs
@@ -340,6 +340,15 @@ fn test_test_harness() {
     )
     .unwrap();
 
+    alice_wallet
+        .comms
+        .peer_manager()
+        .add_peer(create_peer(
+            bob_identity.public_key().clone(),
+            bob_identity.control_service_address(),
+        ))
+        .unwrap();
+
     let value = MicroTari::from(1000);
     let (_utxo, uo1) = make_input(&mut rng, MicroTari(2500), &factories.commitment);
 

--- a/base_layer/wallet_ffi/src/lib.rs
+++ b/base_layer/wallet_ffi/src/lib.rs
@@ -1594,10 +1594,7 @@ pub unsafe extern "C" fn comms_config_create(
                             peer_database_name: database_name_string,
                             inbound_buffer_size: 100,
                             outbound_buffer_size: 100,
-                            dht: DhtConfig {
-                                discovery_request_timeout: Duration::from_millis(1000),
-                                ..Default::default()
-                            },
+                            dht: DhtConfig::default(),
                         };
 
                         Box::into_raw(Box::new(config))


### PR DESCRIPTION
## Description
When a transaction is sent to a peer that is not known the comms stack will perform a Discovery process which can take minutes. Do not block the client using the wallet library we now return immediately telling the client that the Discovery process is underway and then when it is completed we will use a call-back and event bus to let the client know that the Discovery has been completed (successfully or not) asynchronously.

If the discovery was unsuccessful the pending transaction is cancelled.

## Motivation and Context
Closes https://github.com/tari-project/tari/issues/1065

## How Has This Been Tested?
Test provided

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [x] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [x] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch
* [x] I ran `cargo-fmt --all` before pushing
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
