### PR TITLE
Fetch MMR checkpoints using height

### DIFF
--- a/base_layer/core/src/chain_storage/blockchain_database.rs
+++ b/base_layer/core/src/chain_storage/blockchain_database.rs
@@ -124,11 +124,12 @@ pub trait BlockchainBackend: Send + Sync {
     ) -> Result<HashOutput, ChainStorageError>;
     /// Constructs a merkle proof for the specified merkle mountain range and the given leaf position.
     fn fetch_mmr_proof(&self, tree: MmrTree, pos: usize) -> Result<MerkleProof, ChainStorageError>;
-    /// The nth MMR checkpoint (the list of nodes added & deleted) for the given Merkle tree. The index is the n-th
-    /// checkpoint (block) from the pruning horizon block.
+    /// Fetches the MMR checkpoint corresponding to the provided height, the checkpoint consist of the list of nodes
+    /// added & deleted for the given Merkle tree. When a height is provided that is less than the pruning horizon, then
+    /// a BeyondPruningHorizon error will be produced.
     // TODO: Fix conflicting definitions for fetch_mmr_checkpoint where some functions require checkpoint offset, and
     // the others take block height.
-    fn fetch_mmr_checkpoint(&self, tree: MmrTree, index: u64) -> Result<MerkleCheckPoint, ChainStorageError>;
+    fn fetch_mmr_checkpoint(&self, tree: MmrTree, height: u64) -> Result<MerkleCheckPoint, ChainStorageError>;
     /// Fetches the leaf node hash and its deletion status for the nth leaf node in the given MMR tree.
     fn fetch_mmr_node(&self, tree: MmrTree, pos: u32) -> Result<(Hash, bool), ChainStorageError>;
     /// Fetches the MMR base state of the specified tree. The MMR base state consists of the state from the genesis
@@ -149,6 +150,8 @@ pub trait BlockchainBackend: Send + Sync {
     where
         Self: Sized,
         F: FnMut(Result<(HashOutput, Block), ChainStorageError>);
+    /// Returns the height of the pruning horizon.
+    fn fetch_pruning_horizon(&self) -> Result<u64, ChainStorageError>;
 }
 
 // Private macro that pulls out all the boiler plate of extracting a DB query result from its variants

--- a/base_layer/core/src/proof_of_work/diff_adj_manager/diff_adj_manager.rs
+++ b/base_layer/core/src/proof_of_work/diff_adj_manager/diff_adj_manager.rs
@@ -289,7 +289,7 @@ pub mod test {
         }
 
         // lets add many1 blocks
-        for i in 1..20 {
+        for _ in 1..20 {
             let append_height = store.get_height().unwrap().unwrap();
             append_to_pow_blockchain(&store, append_height, pow_algos.clone());
             prev_timestamp = prev_timestamp.increase(consensus.get_target_block_interval());
@@ -329,7 +329,7 @@ pub mod test {
         let mut new_block = chain_block(&prev_block, Vec::new());
         new_block.header.timestamp = EpochTime::from(1575018842).increase(consensus.get_target_block_interval() / 2);
         new_block.header.pow.pow_algo = PowAlgorithm::Blake;
-        prev_block = add_block_and_update_header(&store, new_block);
+        add_block_and_update_header(&store, new_block);
 
         prev_timestamp = 1575018842.into();
         prev_timestamp = prev_timestamp.increase(consensus.get_target_block_interval() / 2);


### PR DESCRIPTION
## Description
- Changed the fetch_mmr_checkpoint blockchain backend function to rather use height instead of index. Internally, the provided height is converted to the checkpoint index.
- This will fix the fetch_block issue when the change tracker committed checkpoints to the base MMR, a test was provided to demonstrate the fix.
- Added fetch_pruning_horizon function to the blockchain backend, memory_db and lmdb_db. This allows the pruning horizon of the MMR change trackers to be retrieved.

## Motivation and Context
Fetch block uses height as the checkpoint index, which is not valid when the change tracker has committed some of the checkpoint to the base mmr. This PR will fix this issue.

## How Has This Been Tested?
Two tests were added to test the fetch_block and testing the fetch_mmr_checkpoint with changing pruning horizons.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [x] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [x] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch
* [x] I ran `cargo-fmt --all` before pushing
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
