### PR TITLE
refactor diff manager

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ members = [
     "infrastructure/shutdown",
     "infrastructure/storage",
     "infrastructure/test_utils",
-    "applications/tari_testnet_miner",
+    #"applications/tari_testnet_miner",
     "applications/tari_base_node",
     #Needs to be updated to make its calls using an Tokio runtime block_on function.
     #"ffi"

--- a/base_layer/core/src/base_node/comms_interface/error.rs
+++ b/base_layer/core/src/base_node/comms_interface/error.rs
@@ -20,7 +20,7 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use crate::{chain_storage::ChainStorageError, proof_of_work::DiffAdjManagerError};
+use crate::{chain_storage::ChainStorageError, consensus::ConsensusManagerError};
 use derive_error::Error;
 use tari_service_framework::reply_channel::TransportChannelError;
 
@@ -39,5 +39,5 @@ pub enum CommsInterfaceError {
     MempoolError(String),
     /// Failure in broadcast DHT middleware
     BroadcastFailed,
-    DifficultyAdjustmentManagerError(DiffAdjManagerError),
+    DifficultyAdjustmentManagerError(ConsensusManagerError),
 }

--- a/base_layer/core/src/base_node/comms_interface/inbound_handlers.rs
+++ b/base_layer/core/src/base_node/comms_interface/inbound_handlers.rs
@@ -32,9 +32,8 @@ use crate::{
         HistoricalBlock,
         MmrTree,
     },
-    consensus::ConsensusConstants,
+    consensus::{ConsensusConstants, ConsensusManager},
     mempool::Mempool,
-    proof_of_work::DiffAdjManager,
 };
 use futures::SinkExt;
 use tari_broadcast_channel::Publisher;
@@ -58,7 +57,7 @@ where T: BlockchainBackend
     event_publisher: Publisher<BlockEvent>,
     blockchain_db: BlockchainDatabase<T>,
     mempool: Mempool<T>,
-    diff_adj_manager: DiffAdjManager<T>,
+    consensus_manager: ConsensusManager<T>,
 }
 
 impl<T> InboundNodeCommsHandlers<T>
@@ -69,14 +68,14 @@ where T: BlockchainBackend
         event_publisher: Publisher<BlockEvent>,
         blockchain_db: BlockchainDatabase<T>,
         mempool: Mempool<T>,
-        diff_adj_manager: DiffAdjManager<T>,
+        consensus_manager: ConsensusManager<T>,
     ) -> Self
     {
         Self {
             event_publisher,
             blockchain_db,
             mempool,
-            diff_adj_manager,
+            consensus_manager,
         }
     }
 
@@ -185,7 +184,7 @@ where T: BlockchainBackend
                 Ok(NodeCommsResponse::NewBlock(Block { header, body }))
             },
             NodeCommsRequest::GetTargetDifficulty(pow_algo) => Ok(NodeCommsResponse::TargetDifficulty(
-                self.diff_adj_manager.get_target_difficulty(pow_algo)?,
+                self.consensus_manager.get_target_difficulty(pow_algo)?,
             )),
         }
     }

--- a/base_layer/core/src/base_node/service/initializer.rs
+++ b/base_layer/core/src/base_node/service/initializer.rs
@@ -28,8 +28,8 @@ use crate::{
     },
     blocks::Block,
     chain_storage::{BlockchainBackend, BlockchainDatabase},
+    consensus::ConsensusManager,
     mempool::Mempool,
-    proof_of_work::DiffAdjManager,
     proto as shared_protos,
 };
 use futures::{future, Future, Stream, StreamExt};
@@ -62,7 +62,7 @@ where T: BlockchainBackend
     inbound_message_subscription_factory: Arc<TopicSubscriptionFactory<TariMessageType, Arc<PeerMessage>>>,
     blockchain_db: BlockchainDatabase<T>,
     mempool: Mempool<T>,
-    diff_adj_manager: DiffAdjManager<T>,
+    consensus_manager: ConsensusManager<T>,
     config: BaseNodeServiceConfig,
 }
 
@@ -74,7 +74,7 @@ where T: BlockchainBackend
         inbound_message_subscription_factory: Arc<TopicSubscriptionFactory<TariMessageType, Arc<PeerMessage>>>,
         blockchain_db: BlockchainDatabase<T>,
         mempool: Mempool<T>,
-        diff_adj_manager: DiffAdjManager<T>,
+        consensus_manager: ConsensusManager<T>,
         config: BaseNodeServiceConfig,
     ) -> Self
     {
@@ -82,7 +82,7 @@ where T: BlockchainBackend
             inbound_message_subscription_factory,
             blockchain_db,
             mempool,
-            diff_adj_manager,
+            consensus_manager,
             config,
         }
     }
@@ -175,7 +175,7 @@ where T: BlockchainBackend + 'static
             block_event_publisher,
             self.blockchain_db.clone(),
             self.mempool.clone(),
-            self.diff_adj_manager.clone(),
+            self.consensus_manager.clone(),
         );
         let executer_clone = executor.clone(); // Give BaseNodeService access to the executor
         let config = self.config.clone();

--- a/base_layer/core/src/base_node/test/comms_interface.rs
+++ b/base_layer/core/src/base_node/test/comms_interface.rs
@@ -40,6 +40,7 @@ use crate::{
         MmrTree,
         MutableMmrState,
     },
+    consensus::ConsensusManager,
     mempool::{Mempool, MempoolConfig},
     proof_of_work::DiffAdjManager,
     test_utils::builders::{add_block_and_update_header, create_default_db, create_test_kernel, create_utxo},
@@ -106,7 +107,9 @@ fn inbound_get_metadata() {
     let (mempool, store) = new_mempool();
     let diff_adj_manager = DiffAdjManager::new(store.clone()).unwrap();
     let (block_event_publisher, _block_event_subscriber) = bounded(100);
-    let inbound_nch = InboundNodeCommsHandlers::new(block_event_publisher, store, mempool, diff_adj_manager);
+    let consensus_manager = ConsensusManager::default();
+    consensus_manager.set_diff_manager(diff_adj_manager);
+    let inbound_nch = InboundNodeCommsHandlers::new(block_event_publisher, store, mempool, consensus_manager);
 
     test_async(move |rt| {
         rt.spawn(async move {
@@ -148,7 +151,9 @@ fn inbound_fetch_kernels() {
     let (mempool, store) = new_mempool();
     let diff_adj_manager = DiffAdjManager::new(store.clone()).unwrap();
     let (block_event_publisher, _block_event_subscriber) = bounded(100);
-    let inbound_nch = InboundNodeCommsHandlers::new(block_event_publisher, store.clone(), mempool, diff_adj_manager);
+    let consensus_manager = ConsensusManager::default();
+    consensus_manager.set_diff_manager(diff_adj_manager);
+    let inbound_nch = InboundNodeCommsHandlers::new(block_event_publisher, store.clone(), mempool, consensus_manager);
 
     let kernel = create_test_kernel(5.into(), 0);
     let hash = kernel.hash();
@@ -196,7 +201,9 @@ fn inbound_fetch_headers() {
     let (mempool, store) = new_mempool();
     let diff_adj_manager = DiffAdjManager::new(store.clone()).unwrap();
     let (block_event_publisher, _block_event_subscriber) = bounded(100);
-    let inbound_nch = InboundNodeCommsHandlers::new(block_event_publisher, store.clone(), mempool, diff_adj_manager);
+    let consensus_manager = ConsensusManager::default();
+    consensus_manager.set_diff_manager(diff_adj_manager);
+    let inbound_nch = InboundNodeCommsHandlers::new(block_event_publisher, store.clone(), mempool, consensus_manager);
 
     let mut header = BlockHeader::new(0);
     header.height = 0;
@@ -246,7 +253,9 @@ fn inbound_fetch_utxos() {
     let (mempool, store) = new_mempool();
     let (block_event_publisher, _block_event_subscriber) = bounded(100);
     let diff_adj_manager = DiffAdjManager::new(store.clone()).unwrap();
-    let inbound_nch = InboundNodeCommsHandlers::new(block_event_publisher, store.clone(), mempool, diff_adj_manager);
+    let consensus_manager = ConsensusManager::default();
+    consensus_manager.set_diff_manager(diff_adj_manager);
+    let inbound_nch = InboundNodeCommsHandlers::new(block_event_publisher, store.clone(), mempool, consensus_manager);
 
     let (utxo, _) = create_utxo(MicroTari(10_000), &factories);
     let hash = utxo.hash();
@@ -293,7 +302,9 @@ fn inbound_fetch_blocks() {
     let (mempool, store) = new_mempool();
     let diff_adj_manager = DiffAdjManager::new(store.clone()).unwrap();
     let (block_event_publisher, _block_event_subscriber) = bounded(100);
-    let inbound_nch = InboundNodeCommsHandlers::new(block_event_publisher, store.clone(), mempool, diff_adj_manager);
+    let consensus_manager = ConsensusManager::default();
+    consensus_manager.set_diff_manager(diff_adj_manager);
+    let inbound_nch = InboundNodeCommsHandlers::new(block_event_publisher, store.clone(), mempool, consensus_manager);
 
     let block = add_block_and_update_header(&store, get_genesis_block());
 
@@ -338,7 +349,9 @@ fn inbound_fetch_mmr_state() {
     let (mempool, store) = new_mempool();
     let diff_adj_manager = DiffAdjManager::new(store.clone()).unwrap();
     let (block_event_publisher, _block_event_subscriber) = bounded(100);
-    let inbound_nch = InboundNodeCommsHandlers::new(block_event_publisher, store, mempool, diff_adj_manager);
+    let consensus_manager = ConsensusManager::default();
+    consensus_manager.set_diff_manager(diff_adj_manager);
+    let inbound_nch = InboundNodeCommsHandlers::new(block_event_publisher, store, mempool, consensus_manager);
 
     test_async(move |rt| {
         rt.spawn(async move {

--- a/base_layer/core/src/blocks/block.rs
+++ b/base_layer/core/src/blocks/block.rs
@@ -24,7 +24,7 @@
 // Version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0.
 use crate::{
     blocks::BlockHeader,
-    consensus::{ConsensusConstants, ConsensusManager},
+    consensus::ConsensusConstants,
     proof_of_work::{PowError, ProofOfWork},
 };
 use derive_error::Error;
@@ -61,13 +61,9 @@ pub struct Block {
 }
 
 impl Block {
-    // create a total_coinbase offset containing all fees for the validation
-    pub fn calculate_coinbase_and_fees(&self, rules: &ConsensusManager) -> MicroTari {
-        let mut coinbase = rules.emission_schedule().block_reward(self.header.height);
-        for kernel in self.body.kernels() {
-            coinbase += kernel.fee;
-        }
-        coinbase
+    /// This function will calculate the total fees contained in a block
+    pub fn calculate_fees(&self) -> MicroTari {
+        self.body.kernels().iter().fold(0.into(), |sum, x| sum + x.fee)
     }
 
     /// This function will check spent kernel rules like tx lock height etc

--- a/base_layer/core/src/chain_storage/mod.rs
+++ b/base_layer/core/src/chain_storage/mod.rs
@@ -41,7 +41,7 @@ pub mod async_db;
 
 // Public API exports
 pub use blockchain_database::{BlockAddResult, BlockchainBackend, BlockchainDatabase, MutableMmrState, Validators};
-pub use db_transaction::{DbTransaction, MmrTree};
+pub use db_transaction::{DbKey, DbTransaction, DbValue, MmrTree};
 pub use error::ChainStorageError;
 pub use historical_block::HistoricalBlock;
 pub use lmdb_db::{

--- a/base_layer/core/src/consensus/consensus_manager.rs
+++ b/base_layer/core/src/consensus/consensus_manager.rs
@@ -20,36 +20,143 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use crate::consensus::emission::EmissionSchedule;
+use crate::{
+    blocks::Block,
+    chain_storage::{BlockchainBackend, ChainStorageError},
+    consensus::emission::EmissionSchedule,
+    proof_of_work::{DiffAdjManager, DiffAdjManagerError, Difficulty, DifficultyAdjustmentError, PowAlgorithm},
+};
+use derive_error::Error;
+use std::sync::{Arc, RwLock, RwLockReadGuard};
+use tari_transactions::tari_amount::MicroTari;
+use tari_utilities::epoch_time::EpochTime;
 
-/// This is the used to control all consensus values.
-pub struct ConsensusManager {
-    /// The emission schedule to use for coinbase rewards
-    emission_schedule: EmissionSchedule,
+#[derive(Debug, Error, Clone, PartialEq)]
+pub enum ConsensusManagerError {
+    /// Difficulty adjustment encountered an error
+    DifficultyAdjustmentError(DifficultyAdjustmentError),
+    /// Difficulty adjustment manager encountered an error
+    DifficultyAdjustmentManagerError(DiffAdjManagerError),
+    /// Problem with the DB backend storage
+    ChainStorageError(ChainStorageError),
+    /// There is no blockchain to query
+    EmptyBlockchain,
+    /// RwLock access broken.
+    #[error(non_std, no_from)]
+    PoisonedAccess(String),
+    /// No Diffuclty adjustment manager present
+    MissingDifficultyAdjustmentManager,
 }
 
-impl ConsensusManager {
-    pub fn new() -> Self {
-        ConsensusManager::default()
-    }
+/// This is the consensus manager struct. This manages all state-full consensus code.
+/// The inside is wrapped inside of an ARC so that it can safely and cheaply be cloned.
+/// The code is multi-thread safe and so only one instance is required. Inner objects are wrapped inside of RwLocks.
+pub struct ConsensusManager<B>
+where B: BlockchainBackend
+{
+    inner: Arc<ConsensusManagerInner<B>>,
+}
 
+impl<B> ConsensusManager<B>
+where B: BlockchainBackend
+{
+    /// Get a pointer to the emission schedule
     pub fn emission_schedule(&self) -> &EmissionSchedule {
-        &self.emission_schedule
+        &self.inner.emission_schedule
+    }
+
+    /// This moves over a difficulty adjustment manager to the ConsensusManager to control.
+    pub fn set_diff_manager(&self, diff_manager: DiffAdjManager<B>) -> Result<(), ConsensusManagerError> {
+        let mut lock = self
+            .inner
+            .diff_adj_manager
+            .write()
+            .map_err(|e| ConsensusManagerError::PoisonedAccess(e.to_string()))?;
+        *lock = Some(diff_manager);
+        Ok(())
+    }
+
+    /// This returns the difficulty adjustment manager back. This can safely be cloned as the Difficulty adjustment
+    /// manager wraps an ARC in side of it.
+    pub fn get_diff_manager(&self) -> Result<DiffAdjManager<B>, ConsensusManagerError> {
+        match self.access_diff_adj()?.as_ref() {
+            Some(v) => Ok(v.clone()),
+            None => Err(ConsensusManagerError::MissingDifficultyAdjustmentManager),
+        }
+    }
+
+    /// Returns the estimated target difficulty for the specified PoW algorithm.
+    pub fn get_target_difficulty(&self, pow_algo: &PowAlgorithm) -> Result<Difficulty, ConsensusManagerError> {
+        match self.access_diff_adj()?.as_ref() {
+            Some(v) => v
+                .get_target_difficulty(pow_algo)
+                .map_err(|e| ConsensusManagerError::DifficultyAdjustmentManagerError(e)),
+            None => Err(ConsensusManagerError::MissingDifficultyAdjustmentManager),
+        }
+    }
+
+    /// Returns the median timestamp of the past 11 blocks.
+    pub fn get_median_timestamp(&self) -> Result<EpochTime, ConsensusManagerError> {
+        match self.access_diff_adj()?.as_ref() {
+            Some(v) => v
+                .get_median_timestamp()
+                .map_err(|e| ConsensusManagerError::DifficultyAdjustmentManagerError(e)),
+            None => Err(ConsensusManagerError::MissingDifficultyAdjustmentManager),
+        }
+    }
+
+    /// Creates a total_coinbase offset containing all fees for the validation from block
+    pub fn calculate_coinbase_and_fees(&self, block: &Block) -> MicroTari {
+        let coinbase = self.emission_schedule().block_reward(block.header.height);
+        coinbase + block.calculate_fees()
+    }
+
+    // Inner helper function to access to the difficulty adjustment manager
+    fn access_diff_adj(&self) -> Result<RwLockReadGuard<Option<DiffAdjManager<B>>>, ConsensusManagerError> {
+        self.inner
+            .diff_adj_manager
+            .read()
+            .map_err(|e| ConsensusManagerError::PoisonedAccess(e.to_string()))
     }
 }
 
-impl Default for ConsensusManager {
+impl<B> Default for ConsensusManager<B>
+where B: BlockchainBackend
+{
     fn default() -> Self {
         ConsensusManager {
-            emission_schedule: EmissionSchedule::new(10_000_000.into(), 0.999, 100.into()),
+            inner: Arc::new(ConsensusManagerInner::default()),
         }
     }
 }
 
-impl Clone for ConsensusManager {
+impl<B> Clone for ConsensusManager<B>
+where B: BlockchainBackend
+{
     fn clone(&self) -> Self {
         Self {
-            emission_schedule: self.emission_schedule.clone(),
+            inner: self.inner.clone(),
+        }
+    }
+}
+
+/// This is the used to control all consensus values.
+struct ConsensusManagerInner<B>
+where B: BlockchainBackend
+{
+    /// The emission schedule to use for coinbase rewards
+    pub emission_schedule: EmissionSchedule,
+    /// Difficulty adjustment manager for the blockchain
+    pub diff_adj_manager: RwLock<Option<DiffAdjManager<B>>>,
+}
+
+impl<B> Default for ConsensusManagerInner<B>
+where B: BlockchainBackend
+{
+    fn default() -> Self {
+        ConsensusManagerInner {
+            emission_schedule: EmissionSchedule::new(10_000_000.into(), 0.999, 100.into()),
+            diff_adj_manager: RwLock::new(None),
         }
     }
 }

--- a/base_layer/core/src/consensus/mod.rs
+++ b/base_layer/core/src/consensus/mod.rs
@@ -26,4 +26,4 @@ mod consensus_manager;
 pub mod emission;
 
 pub use consensus_constants::ConsensusConstants;
-pub use consensus_manager::ConsensusManager;
+pub use consensus_manager::{ConsensusManager, ConsensusManagerError};

--- a/base_layer/core/src/proof_of_work/diff_adj_manager/diff_adj_manager.rs
+++ b/base_layer/core/src/proof_of_work/diff_adj_manager/diff_adj_manager.rs
@@ -289,7 +289,7 @@ pub mod test {
         }
 
         // lets add many1 blocks
-        for _ in 1..20 {
+        for _i in 1..20 {
             let append_height = store.get_height().unwrap().unwrap();
             append_to_pow_blockchain(&store, append_height, pow_algos.clone());
             prev_timestamp = prev_timestamp.increase(consensus.get_target_block_interval());

--- a/base_layer/core/src/proof_of_work/mod.rs
+++ b/base_layer/core/src/proof_of_work/mod.rs
@@ -35,6 +35,6 @@ pub mod lwma_diff;
 pub use blake_pow::{blake_difficulty, blake_difficulty_with_hash};
 pub use diff_adj_manager::{DiffAdjManager, DiffAdjManagerError};
 pub use difficulty::Difficulty;
-pub use error::PowError;
+pub use error::{DifficultyAdjustmentError, PowError};
 pub use monero_rx::monero_difficulty;
 pub use proof_of_work::{PowAlgorithm, ProofOfWork};

--- a/base_layer/core/src/test_utils/test_common.rs
+++ b/base_layer/core/src/test_utils/test_common.rs
@@ -22,15 +22,20 @@
 
 // Used in tests only
 
+use crate::{
+    blocks::Block,
+    chain_storage::{BlockchainBackend, ChainStorageError, DbKey, DbTransaction, DbValue, MmrTree, MutableMmrState},
+};
 use rand::{CryptoRng, Rng};
 use tari_crypto::{
     commitment::HomomorphicCommitmentFactory,
     keys::{PublicKey as PK, SecretKey},
 };
+use tari_mmr::{Hash, MerkleCheckPoint, MerkleProof, MutableMmrLeafNodes};
 use tari_transactions::{
     tari_amount::*,
     transaction::{OutputFeatures, TransactionInput, UnblindedOutput},
-    types::{CommitmentFactory, PrivateKey, PublicKey},
+    types::{CommitmentFactory, HashOutput, PrivateKey, PublicKey},
 };
 
 pub struct TestParams {
@@ -65,4 +70,82 @@ pub fn make_input<R: Rng + CryptoRng>(
     let commitment = factory.commit(&key, &v);
     let input = TransactionInput::new(OutputFeatures::default(), commitment);
     (input, UnblindedOutput::new(val, key, None))
+}
+
+// This is a test backend. This is used so that the ConsensusManager can be called without actually having a backend.
+// Calling this backend will result in a panic.
+pub struct MockBackend;
+
+impl BlockchainBackend for MockBackend {
+    fn write(&self, tx: DbTransaction) -> Result<(), ChainStorageError> {
+        unimplemented!()
+    }
+
+    fn fetch(&self, key: &DbKey) -> Result<Option<DbValue>, ChainStorageError> {
+        unimplemented!()
+    }
+
+    fn contains(&self, key: &DbKey) -> Result<bool, ChainStorageError> {
+        unimplemented!()
+    }
+
+    fn fetch_mmr_root(&self, tree: MmrTree) -> Result<HashOutput, ChainStorageError> {
+        unimplemented!()
+    }
+
+    fn fetch_mmr_only_root(&self, tree: MmrTree) -> Result<HashOutput, ChainStorageError> {
+        unimplemented!()
+    }
+
+    fn fetch_pruning_horizon(&self) -> Result<u64, ChainStorageError> {
+        unimplemented!()
+    }
+
+    fn calculate_mmr_root(
+        &self,
+        tree: MmrTree,
+        additions: Vec<HashOutput>,
+        deletions: Vec<HashOutput>,
+    ) -> Result<HashOutput, ChainStorageError>
+    {
+        unimplemented!()
+    }
+
+    fn fetch_mmr_proof(&self, tree: MmrTree, pos: usize) -> Result<MerkleProof, ChainStorageError> {
+        unimplemented!()
+    }
+
+    fn fetch_mmr_checkpoint(&self, tree: MmrTree, index: u64) -> Result<MerkleCheckPoint, ChainStorageError> {
+        unimplemented!()
+    }
+
+    fn fetch_mmr_node(&self, tree: MmrTree, pos: u32) -> Result<(Hash, bool), ChainStorageError> {
+        unimplemented!()
+    }
+
+    fn fetch_mmr_base_leaf_nodes(
+        &self,
+        tree: MmrTree,
+        index: usize,
+        count: usize,
+    ) -> Result<MutableMmrState, ChainStorageError>
+    {
+        unimplemented!()
+    }
+
+    fn fetch_mmr_base_leaf_node_count(&self, tree: MmrTree) -> Result<usize, ChainStorageError> {
+        unimplemented!()
+    }
+
+    fn restore_mmr(&self, tree: MmrTree, base_state: MutableMmrLeafNodes) -> Result<(), ChainStorageError> {
+        unimplemented!()
+    }
+
+    fn for_each_orphan<F>(&self, f: F) -> Result<(), ChainStorageError>
+    where
+        Self: Sized,
+        F: FnMut(Result<(HashOutput, Block), ChainStorageError>),
+    {
+        unimplemented!()
+    }
 }


### PR DESCRIPTION
## Description
The is the second refactor of consensus and difficulty adjustment manager. This adds difficulty manager to the consensus manager.

## Motivation and Context
This refactor allows the code to only keep track of `ConsensusManager` which now keeps all state-full consensus objects inside of it. This is wrapped inside of an ARC and RwLocks. This allows the data to change while allowing multiple reads. The `ConsensusManager` can  safely be clone as we only clone the arc inside of it. 

This changes will also make the validation pipeline testing easier as it already has access to the consensus manager. It will now have access to all state-full checking objects

## How Has This Been Tested?
All existing test stil pass. 

## Types of changes
* [ ] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [x] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
* [x] I'm merging against the `development` branch
* [x] I ran `cargo-fmt --all` before pushing
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
