### PR TITLE
Find the MMR leaf index for a hash in the MerkleChangeTracker

### DIFF
--- a/base_layer/core/src/base_node/test/comms_interface.rs
+++ b/base_layer/core/src/base_node/test/comms_interface.rs
@@ -108,7 +108,7 @@ fn inbound_get_metadata() {
     let diff_adj_manager = DiffAdjManager::new(store.clone()).unwrap();
     let (block_event_publisher, _block_event_subscriber) = bounded(100);
     let consensus_manager = ConsensusManager::default();
-    consensus_manager.set_diff_manager(diff_adj_manager);
+    assert!(consensus_manager.set_diff_manager(diff_adj_manager).is_ok());
     let inbound_nch = InboundNodeCommsHandlers::new(block_event_publisher, store, mempool, consensus_manager);
 
     test_async(move |rt| {
@@ -152,7 +152,7 @@ fn inbound_fetch_kernels() {
     let diff_adj_manager = DiffAdjManager::new(store.clone()).unwrap();
     let (block_event_publisher, _block_event_subscriber) = bounded(100);
     let consensus_manager = ConsensusManager::default();
-    consensus_manager.set_diff_manager(diff_adj_manager);
+    assert!(consensus_manager.set_diff_manager(diff_adj_manager).is_ok());
     let inbound_nch = InboundNodeCommsHandlers::new(block_event_publisher, store.clone(), mempool, consensus_manager);
 
     let kernel = create_test_kernel(5.into(), 0);
@@ -202,7 +202,7 @@ fn inbound_fetch_headers() {
     let diff_adj_manager = DiffAdjManager::new(store.clone()).unwrap();
     let (block_event_publisher, _block_event_subscriber) = bounded(100);
     let consensus_manager = ConsensusManager::default();
-    consensus_manager.set_diff_manager(diff_adj_manager);
+    assert!(consensus_manager.set_diff_manager(diff_adj_manager).is_ok());
     let inbound_nch = InboundNodeCommsHandlers::new(block_event_publisher, store.clone(), mempool, consensus_manager);
 
     let mut header = BlockHeader::new(0);
@@ -254,7 +254,7 @@ fn inbound_fetch_utxos() {
     let (block_event_publisher, _block_event_subscriber) = bounded(100);
     let diff_adj_manager = DiffAdjManager::new(store.clone()).unwrap();
     let consensus_manager = ConsensusManager::default();
-    consensus_manager.set_diff_manager(diff_adj_manager);
+    assert!(consensus_manager.set_diff_manager(diff_adj_manager).is_ok());
     let inbound_nch = InboundNodeCommsHandlers::new(block_event_publisher, store.clone(), mempool, consensus_manager);
 
     let (utxo, _) = create_utxo(MicroTari(10_000), &factories);
@@ -303,7 +303,7 @@ fn inbound_fetch_blocks() {
     let diff_adj_manager = DiffAdjManager::new(store.clone()).unwrap();
     let (block_event_publisher, _block_event_subscriber) = bounded(100);
     let consensus_manager = ConsensusManager::default();
-    consensus_manager.set_diff_manager(diff_adj_manager);
+    assert!(consensus_manager.set_diff_manager(diff_adj_manager).is_ok());
     let inbound_nch = InboundNodeCommsHandlers::new(block_event_publisher, store.clone(), mempool, consensus_manager);
 
     let block = add_block_and_update_header(&store, get_genesis_block());
@@ -350,7 +350,7 @@ fn inbound_fetch_mmr_state() {
     let diff_adj_manager = DiffAdjManager::new(store.clone()).unwrap();
     let (block_event_publisher, _block_event_subscriber) = bounded(100);
     let consensus_manager = ConsensusManager::default();
-    consensus_manager.set_diff_manager(diff_adj_manager);
+    let _ = consensus_manager.set_diff_manager(diff_adj_manager);
     let inbound_nch = InboundNodeCommsHandlers::new(block_event_publisher, store, mempool, consensus_manager);
 
     test_async(move |rt| {

--- a/base_layer/core/src/chain_storage/lmdb_db/lmdb_db.rs
+++ b/base_layer/core/src/chain_storage/lmdb_db/lmdb_db.rs
@@ -424,7 +424,7 @@ where D: Digest + Send + Sync
                                 .range_proof_mmr
                                 .read()
                                 .map_err(|e| ChainStorageError::AccessError(e.to_string()))?
-                                .index(&proof_hash)
+                                .find_leaf_index(&proof_hash)?
                             {
                                 lmdb_insert(&txn, &self.utxos_db, &k, &v)?;
                                 lmdb_insert(&txn, &self.txos_hash_to_index_db, &k, &index)?;

--- a/base_layer/core/src/chain_storage/memory_db.rs
+++ b/base_layer/core/src/chain_storage/memory_db.rs
@@ -149,7 +149,7 @@ where D: Digest + Send + Sync
                         db.utxo_mmr.push(&k)?;
                         let proof_hash = v.proof().hash();
                         db.range_proof_mmr.push(&proof_hash)?;
-                        if let Some(index) = db.range_proof_mmr.index(&proof_hash) {
+                        if let Some(index) = db.range_proof_mmr.find_leaf_index(&proof_hash)? {
                             let v = MerkleNode { index, value: *v };
                             db.utxos.insert(k, v);
                         }

--- a/base_layer/core/src/proof_of_work/diff_adj_manager/diff_adj_manager.rs
+++ b/base_layer/core/src/proof_of_work/diff_adj_manager/diff_adj_manager.rs
@@ -325,7 +325,7 @@ pub mod test {
 
         // lets add 1 thats further back then
         let append_height = store.get_height().unwrap().unwrap();
-        let mut prev_block = store.fetch_block(append_height).unwrap().block().clone();
+        let prev_block = store.fetch_block(append_height).unwrap().block().clone();
         let mut new_block = chain_block(&prev_block, Vec::new());
         new_block.header.timestamp = EpochTime::from(1575018842).increase(consensus.get_target_block_interval() / 2);
         new_block.header.pow.pow_algo = PowAlgorithm::Blake;

--- a/base_layer/core/src/test_utils/node.rs
+++ b/base_layer/core/src/test_utils/node.rs
@@ -161,7 +161,7 @@ impl BaseNodeBuilder {
         );
         let diff_adj_manager = DiffAdjManager::new(blockchain_db.clone()).unwrap();
         let consensus_manager = ConsensusManager::default();
-        consensus_manager.set_diff_manager(diff_adj_manager);
+        consensus_manager.set_diff_manager(diff_adj_manager).unwrap();
         let node_identity = self.node_identity.unwrap_or(random_node_identity());
         let (outbound_nci, local_nci, outbound_mp_interface, outbound_message_service, comms) =
             setup_base_node_services(

--- a/base_layer/core/src/test_utils/test_common.rs
+++ b/base_layer/core/src/test_utils/test_common.rs
@@ -77,23 +77,23 @@ pub fn make_input<R: Rng + CryptoRng>(
 pub struct MockBackend;
 
 impl BlockchainBackend for MockBackend {
-    fn write(&self, tx: DbTransaction) -> Result<(), ChainStorageError> {
+    fn write(&self, _tx: DbTransaction) -> Result<(), ChainStorageError> {
         unimplemented!()
     }
 
-    fn fetch(&self, key: &DbKey) -> Result<Option<DbValue>, ChainStorageError> {
+    fn fetch(&self, _key: &DbKey) -> Result<Option<DbValue>, ChainStorageError> {
         unimplemented!()
     }
 
-    fn contains(&self, key: &DbKey) -> Result<bool, ChainStorageError> {
+    fn contains(&self, _key: &DbKey) -> Result<bool, ChainStorageError> {
         unimplemented!()
     }
 
-    fn fetch_mmr_root(&self, tree: MmrTree) -> Result<HashOutput, ChainStorageError> {
+    fn fetch_mmr_root(&self, _tree: MmrTree) -> Result<HashOutput, ChainStorageError> {
         unimplemented!()
     }
 
-    fn fetch_mmr_only_root(&self, tree: MmrTree) -> Result<HashOutput, ChainStorageError> {
+    fn fetch_mmr_only_root(&self, _tree: MmrTree) -> Result<HashOutput, ChainStorageError> {
         unimplemented!()
     }
 
@@ -103,45 +103,45 @@ impl BlockchainBackend for MockBackend {
 
     fn calculate_mmr_root(
         &self,
-        tree: MmrTree,
-        additions: Vec<HashOutput>,
-        deletions: Vec<HashOutput>,
+        _tree: MmrTree,
+        _additions: Vec<HashOutput>,
+        _deletions: Vec<HashOutput>,
     ) -> Result<HashOutput, ChainStorageError>
     {
         unimplemented!()
     }
 
-    fn fetch_mmr_proof(&self, tree: MmrTree, pos: usize) -> Result<MerkleProof, ChainStorageError> {
+    fn fetch_mmr_proof(&self, _tree: MmrTree, _pos: usize) -> Result<MerkleProof, ChainStorageError> {
         unimplemented!()
     }
 
-    fn fetch_mmr_checkpoint(&self, tree: MmrTree, index: u64) -> Result<MerkleCheckPoint, ChainStorageError> {
+    fn fetch_mmr_checkpoint(&self, _tree: MmrTree, _index: u64) -> Result<MerkleCheckPoint, ChainStorageError> {
         unimplemented!()
     }
 
-    fn fetch_mmr_node(&self, tree: MmrTree, pos: u32) -> Result<(Hash, bool), ChainStorageError> {
+    fn fetch_mmr_node(&self, _tree: MmrTree, _pos: u32) -> Result<(Hash, bool), ChainStorageError> {
         unimplemented!()
     }
 
     fn fetch_mmr_base_leaf_nodes(
         &self,
-        tree: MmrTree,
-        index: usize,
-        count: usize,
+        _tree: MmrTree,
+        _index: usize,
+        _count: usize,
     ) -> Result<MutableMmrState, ChainStorageError>
     {
         unimplemented!()
     }
 
-    fn fetch_mmr_base_leaf_node_count(&self, tree: MmrTree) -> Result<usize, ChainStorageError> {
+    fn fetch_mmr_base_leaf_node_count(&self, _tree: MmrTree) -> Result<usize, ChainStorageError> {
         unimplemented!()
     }
 
-    fn restore_mmr(&self, tree: MmrTree, base_state: MutableMmrLeafNodes) -> Result<(), ChainStorageError> {
+    fn restore_mmr(&self, _tree: MmrTree, _base_state: MutableMmrLeafNodes) -> Result<(), ChainStorageError> {
         unimplemented!()
     }
 
-    fn for_each_orphan<F>(&self, f: F) -> Result<(), ChainStorageError>
+    fn for_each_orphan<F>(&self, _f: F) -> Result<(), ChainStorageError>
     where
         Self: Sized,
         F: FnMut(Result<(HashOutput, Block), ChainStorageError>),

--- a/base_layer/mmr/src/common.rs
+++ b/base_layer/mmr/src/common.rs
@@ -28,12 +28,12 @@ use digest::Digest;
 
 const ALL_ONES: usize = std::usize::MAX;
 
-/// Returns the MMR index of the nth leaf node
-pub fn leaf_index(n: usize) -> usize {
-    if n == 0 {
+/// Returns the MMR node index derived from the leaf index.
+pub fn node_index(leaf_index: usize) -> usize {
+    if leaf_index == 0 {
         return 0;
     }
-    2 * n - n.count_ones() as usize
+    2 * leaf_index - leaf_index.count_ones() as usize
 }
 
 /// Is this position a leaf in the MMR?
@@ -191,15 +191,15 @@ mod test {
     use super::*;
 
     #[test]
-    fn leaf_indices() {
-        assert_eq!(leaf_index(0), 0);
-        assert_eq!(leaf_index(1), 1);
-        assert_eq!(leaf_index(2), 3);
-        assert_eq!(leaf_index(3), 4);
-        assert_eq!(leaf_index(5), 8);
-        assert_eq!(leaf_index(6), 10);
-        assert_eq!(leaf_index(7), 11);
-        assert_eq!(leaf_index(8), 15);
+    fn leaf_to_node_indices() {
+        assert_eq!(node_index(0), 0);
+        assert_eq!(node_index(1), 1);
+        assert_eq!(node_index(2), 3);
+        assert_eq!(node_index(3), 4);
+        assert_eq!(node_index(5), 8);
+        assert_eq!(node_index(6), 10);
+        assert_eq!(node_index(7), 11);
+        assert_eq!(node_index(8), 15);
     }
 
     #[test]

--- a/base_layer/mmr/src/merkle_proof.rs
+++ b/base_layer/mmr/src/merkle_proof.rs
@@ -25,7 +25,7 @@
 
 use crate::{
     backend::ArrayLike,
-    common::{family, family_branch, find_peaks, hash_together, is_leaf, is_left_sibling, leaf_index},
+    common::{family, family_branch, find_peaks, hash_together, is_leaf, is_left_sibling, node_index},
     error::MerkleMountainRangeError,
     serde_support,
     Hash,
@@ -88,13 +88,13 @@ impl MerkleProof {
     /// See [MerkleProof::for_node] for more details on how the proof is constructed.
     pub fn for_leaf_node<D, B>(
         mmr: &MerkleMountainRange<D, B>,
-        leaf_pos: usize,
+        leaf_index: usize,
     ) -> Result<MerkleProof, MerkleProofError>
     where
         D: Digest,
         B: ArrayLike<Value = Hash>,
     {
-        let pos = leaf_index(leaf_pos);
+        let pos = node_index(leaf_index);
         MerkleProof::generate_proof(mmr, pos)
     }
 
@@ -169,10 +169,10 @@ impl MerkleProof {
         &self,
         root: &HashSlice,
         hash: &HashSlice,
-        leaf_pos: usize,
+        leaf_index: usize,
     ) -> Result<(), MerkleProofError>
     {
-        let pos = leaf_index(leaf_pos);
+        let pos = node_index(leaf_index);
         self.verify::<D>(root, hash, pos)
     }
 

--- a/base_layer/mmr/src/mutable_mmr_leaf_nodes.rs
+++ b/base_layer/mmr/src/mutable_mmr_leaf_nodes.rs
@@ -52,6 +52,15 @@ impl MutableMmrLeafNodes {
     }
 }
 
+impl From<Vec<Hash>> for MutableMmrLeafNodes {
+    fn from(leaf_hashes: Vec<Hash>) -> Self {
+        Self {
+            leaf_hashes,
+            deleted: Bitmap::create(),
+        }
+    }
+}
+
 impl Serialize for MutableMmrLeafNodes {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where S: Serializer {

--- a/base_layer/mmr/tests/merkle_proof.rs
+++ b/base_layer/mmr/tests/merkle_proof.rs
@@ -25,7 +25,7 @@ mod support;
 
 use support::{create_mmr, int_to_hash, Hasher};
 use tari_mmr::{
-    common::{is_leaf, leaf_index},
+    common::{is_leaf, node_index},
     MerkleProof,
     MerkleProofError,
 };
@@ -66,7 +66,7 @@ fn med_mmr() {
     let mmr = create_mmr(size);
     let root = mmr.get_merkle_root().unwrap();
     let i = 499;
-    let pos = leaf_index(i);
+    let pos = node_index(i);
     let hash = int_to_hash(i);
     let proof = MerkleProof::for_node(&mmr, pos).unwrap();
     assert!(proof.verify::<Hasher>(&root, &hash, pos).is_ok());
@@ -76,7 +76,7 @@ fn med_mmr() {
 fn a_big_proof() {
     let mmr = create_mmr(100_000);
     let leaf_pos = 28_543;
-    let mmr_index = leaf_index(leaf_pos);
+    let mmr_index = node_index(leaf_pos);
     let root = mmr.get_merkle_root().unwrap();
     let hash = int_to_hash(leaf_pos);
     let proof = MerkleProof::for_node(&mmr, mmr_index).unwrap();


### PR DESCRIPTION
## Description
- Modified the MerkleChangeTracker function to find the leaf index of previously committed hashes and uncommitted hashes. This change is required to enable MMR updates to be enabled or disabled in the blockchain backends. 
- Fixed the MerkleChangeTracker restore function so it correctly reverts the pruned MMR back to the newly restored base MMR.
- Added a find_leaf_index function that returns the leaf index of a given hash, and renamed the find_leaf_node function to find_node_index. 
- Changed the naming of the two types of indices used in the MMRs to leaf_index and node_index to make it more intuitive, less error prone and more descriptive of what index is required by the different functions. The leaf index refers to the leaf number and the node_index is the position in the MMR.
- Also, removed some of the warnings.

## Motivation and Context
This change is required to enable MMR updates to be enabled or disabled in the blockchain backends. 

## How Has This Been Tested?
- Added a test for testing the find_leaf_index function. 
- Added a test for demonstrating bug #1132, where the pruned MMR doesn't remove the leaf hashes that have been committed to the base MMR.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [x] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [x] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch
* [ ] I ran `cargo-fmt --all` before pushing
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
