### PR TITLE
Fixed metadata update and duplicate hash issue of horizon state sync

### DIFF
--- a/base_layer/core/src/base_node/test/comms_interface.rs
+++ b/base_layer/core/src/base_node/test/comms_interface.rs
@@ -158,7 +158,7 @@ fn inbound_fetch_kernels() {
     let kernel = create_test_kernel(5.into(), 0);
     let hash = kernel.hash();
     let mut txn = DbTransaction::new();
-    txn.insert_kernel(kernel.clone());
+    txn.insert_kernel(kernel.clone(), true);
     assert!(store.commit(txn).is_ok());
 
     test_async(move |rt| {
@@ -208,7 +208,7 @@ fn inbound_fetch_headers() {
     let mut header = BlockHeader::new(0);
     header.height = 0;
     let mut txn = DbTransaction::new();
-    txn.insert_header(header.clone());
+    txn.insert_header(header.clone(), true);
     assert!(store.commit(txn).is_ok());
 
     test_async(move |rt| {
@@ -260,7 +260,7 @@ fn inbound_fetch_utxos() {
     let (utxo, _) = create_utxo(MicroTari(10_000), &factories);
     let hash = utxo.hash();
     let mut txn = DbTransaction::new();
-    txn.insert_utxo(utxo.clone());
+    txn.insert_utxo(utxo.clone(), true);
     assert!(store.commit(txn).is_ok());
 
     test_async(move |rt| {

--- a/base_layer/core/src/base_node/test/service.rs
+++ b/base_layer/core/src/base_node/test/service.rs
@@ -97,8 +97,8 @@ fn request_and_response_fetch_headers() {
     let mut headerb2 = BlockHeader::new(0);
     headerb2.height = 2;
     let mut txn = DbTransaction::new();
-    txn.insert_header(headerb1.clone());
-    txn.insert_header(headerb2.clone());
+    txn.insert_header(headerb1.clone(), true);
+    txn.insert_header(headerb2.clone(), true);
     assert!(bob_node.blockchain_db.commit(txn).is_ok());
 
     let mut headerc1 = BlockHeader::new(0);
@@ -106,8 +106,8 @@ fn request_and_response_fetch_headers() {
     let mut headerc2 = BlockHeader::new(0);
     headerc2.height = 2;
     let mut txn = DbTransaction::new();
-    txn.insert_header(headerc1.clone());
-    txn.insert_header(headerc2.clone());
+    txn.insert_header(headerc1.clone(), true);
+    txn.insert_header(headerc2.clone(), true);
     assert!(carol_node.blockchain_db.commit(txn).is_ok());
 
     // The request is sent to a random remote base node so the returned headers can be from bob or carol
@@ -142,12 +142,12 @@ fn request_and_response_fetch_kernels() {
     let hash2 = kernel2.hash();
 
     let mut txn = DbTransaction::new();
-    txn.insert_kernel(kernel1.clone());
-    txn.insert_kernel(kernel2.clone());
+    txn.insert_kernel(kernel1.clone(), true);
+    txn.insert_kernel(kernel2.clone(), true);
     assert!(bob_node.blockchain_db.commit(txn).is_ok());
     let mut txn = DbTransaction::new();
-    txn.insert_kernel(kernel1.clone());
-    txn.insert_kernel(kernel2.clone());
+    txn.insert_kernel(kernel1.clone(), true);
+    txn.insert_kernel(kernel2.clone(), true);
     assert!(carol_node.blockchain_db.commit(txn).is_ok());
 
     runtime.block_on(async {
@@ -184,12 +184,12 @@ fn request_and_response_fetch_utxos() {
     let hash2 = utxo2.hash();
 
     let mut txn = DbTransaction::new();
-    txn.insert_utxo(utxo1.clone());
-    txn.insert_utxo(utxo2.clone());
+    txn.insert_utxo(utxo1.clone(), true);
+    txn.insert_utxo(utxo2.clone(), true);
     assert!(bob_node.blockchain_db.commit(txn).is_ok());
     let mut txn = DbTransaction::new();
-    txn.insert_utxo(utxo1.clone());
-    txn.insert_utxo(utxo2.clone());
+    txn.insert_utxo(utxo1.clone(), true);
+    txn.insert_utxo(utxo2.clone(), true);
     assert!(carol_node.blockchain_db.commit(txn).is_ok());
 
     runtime.block_on(async {
@@ -265,9 +265,9 @@ fn request_and_response_fetch_mmr_state() {
 
     let block0 = add_block_and_update_header(&bob_node.blockchain_db, get_genesis_block());
     let mut txn = DbTransaction::new();
-    txn.insert_utxo(inputs1[0].as_transaction_output(&factories).unwrap());
-    txn.insert_utxo(inputs2[0].as_transaction_output(&factories).unwrap());
-    txn.insert_utxo(inputs3[0].as_transaction_output(&factories).unwrap());
+    txn.insert_utxo(inputs1[0].as_transaction_output(&factories).unwrap(), true);
+    txn.insert_utxo(inputs2[0].as_transaction_output(&factories).unwrap(), true);
+    txn.insert_utxo(inputs3[0].as_transaction_output(&factories).unwrap(), true);
     assert!(bob_node.blockchain_db.commit(txn).is_ok());
     let mut block1 = chain_block(&block0, vec![tx1.clone()]);
     block1 = add_block_and_update_header(&bob_node.blockchain_db, block1);
@@ -278,9 +278,9 @@ fn request_and_response_fetch_mmr_state() {
 
     let block0 = add_block_and_update_header(&carol_node.blockchain_db, get_genesis_block());
     let mut txn = DbTransaction::new();
-    txn.insert_utxo(inputs1[0].as_transaction_output(&factories).unwrap());
-    txn.insert_utxo(inputs2[0].as_transaction_output(&factories).unwrap());
-    txn.insert_utxo(inputs3[0].as_transaction_output(&factories).unwrap());
+    txn.insert_utxo(inputs1[0].as_transaction_output(&factories).unwrap(), true);
+    txn.insert_utxo(inputs2[0].as_transaction_output(&factories).unwrap(), true);
+    txn.insert_utxo(inputs3[0].as_transaction_output(&factories).unwrap(), true);
     assert!(carol_node.blockchain_db.commit(txn).is_ok());
     let mut block1 = chain_block(&block0, vec![tx1.clone()]);
     block1 = add_block_and_update_header(&carol_node.blockchain_db, block1);
@@ -523,9 +523,9 @@ fn local_get_new_block_template_and_get_new_block() {
     let (tx2, inputs2, _) = tx!(10_000*uT, fee: 20*uT, inputs: 1, outputs: 1);
     let (tx3, inputs3, _) = tx!(10_000*uT, fee: 30*uT, inputs: 1, outputs: 1);
     let mut txn = DbTransaction::new();
-    txn.insert_utxo(inputs1[0].as_transaction_output(&factories).unwrap());
-    txn.insert_utxo(inputs2[0].as_transaction_output(&factories).unwrap());
-    txn.insert_utxo(inputs3[0].as_transaction_output(&factories).unwrap());
+    txn.insert_utxo(inputs1[0].as_transaction_output(&factories).unwrap(), true);
+    txn.insert_utxo(inputs2[0].as_transaction_output(&factories).unwrap(), true);
+    txn.insert_utxo(inputs3[0].as_transaction_output(&factories).unwrap(), true);
     assert!(node.blockchain_db.commit(txn).is_ok());
     assert!(node.mempool.insert(Arc::new(tx1)).is_ok());
     assert!(node.mempool.insert(Arc::new(tx2)).is_ok());

--- a/base_layer/core/src/base_node/test/state_machine.rs
+++ b/base_layer/core/src/base_node/test/state_machine.rs
@@ -76,7 +76,7 @@ fn test_horizon_state_sync() {
     for _ in 0..12 {
         let (tx, inputs, _) = tx!(10_000*uT, fee: 50*uT, inputs: 1, outputs: 1);
         let mut txn = DbTransaction::new();
-        txn.insert_utxo(inputs[0].as_transaction_output(&factories).unwrap());
+        txn.insert_utxo(inputs[0].as_transaction_output(&factories).unwrap(), true);
         assert!(bob_node.blockchain_db.commit(txn).is_ok());
 
         let next_block = chain_block(&prev_block, vec![tx.clone()]);
@@ -145,6 +145,8 @@ fn test_horizon_state_sync() {
                 assert_eq!(alice_node.blockchain_db.fetch_utxo(hash).unwrap(), utxo);
             }
         }
+
+        assert_eq!(alice_node.blockchain_db.get_height(), Ok(Some(8)));
     });
 
     alice_node.comms.shutdown().unwrap();

--- a/base_layer/core/src/chain_storage/db_transaction.rs
+++ b/base_layer/core/src/chain_storage/db_transaction.rs
@@ -61,21 +61,21 @@ impl DbTransaction {
     }
 
     /// Inserts a transaction kernel into the current transaction.
-    pub fn insert_kernel(&mut self, kernel: TransactionKernel) {
+    pub fn insert_kernel(&mut self, kernel: TransactionKernel, update_mmr: bool) {
         let hash = kernel.hash();
-        self.insert(DbKeyValuePair::TransactionKernel(hash, Box::new(kernel)));
+        self.insert(DbKeyValuePair::TransactionKernel(hash, Box::new(kernel), update_mmr));
     }
 
     /// Inserts a block header into the current transaction.
-    pub fn insert_header(&mut self, header: BlockHeader) {
+    pub fn insert_header(&mut self, header: BlockHeader, update_mmr: bool) {
         let height = header.height;
-        self.insert(DbKeyValuePair::BlockHeader(height, Box::new(header)));
+        self.insert(DbKeyValuePair::BlockHeader(height, Box::new(header), update_mmr));
     }
 
     /// Adds a UTXO into the current transaction and update the TXO MMR.
-    pub fn insert_utxo(&mut self, utxo: TransactionOutput) {
+    pub fn insert_utxo(&mut self, utxo: TransactionOutput, update_mmr: bool) {
         let hash = utxo.hash();
-        self.insert(DbKeyValuePair::UnspentOutput(hash, Box::new(utxo)));
+        self.insert(DbKeyValuePair::UnspentOutput(hash, Box::new(utxo), update_mmr));
     }
 
     /// Stores an orphan block. No checks are made as to whether this is actually an orphan. That responsibility lies
@@ -172,9 +172,9 @@ pub enum WriteOperation {
 #[derive(Debug)]
 pub enum DbKeyValuePair {
     Metadata(MetadataKey, MetadataValue),
-    BlockHeader(u64, Box<BlockHeader>),
-    UnspentOutput(HashOutput, Box<TransactionOutput>),
-    TransactionKernel(HashOutput, Box<TransactionKernel>),
+    BlockHeader(u64, Box<BlockHeader>, bool),
+    UnspentOutput(HashOutput, Box<TransactionOutput>, bool),
+    TransactionKernel(HashOutput, Box<TransactionKernel>, bool),
     OrphanBlock(HashOutput, Box<Block>),
 }
 

--- a/base_layer/core/src/chain_storage/test/chain_backend.rs
+++ b/base_layer/core/src/chain_storage/test/chain_backend.rs
@@ -50,7 +50,7 @@ fn insert_contains_delete_and_fetch_header<T: BlockchainBackend>(db: T) {
     assert_eq!(db.contains(&DbKey::BlockHash(hash.clone())), Ok(false));
 
     let mut txn = DbTransaction::new();
-    txn.insert_header(header.clone());
+    txn.insert_header(header.clone(), true);
     assert!(db.write(txn).is_ok());
     assert_eq!(db.contains(&DbKey::BlockHeader(header.height)), Ok(true));
     assert_eq!(db.contains(&DbKey::BlockHash(hash.clone())), Ok(true));
@@ -95,7 +95,7 @@ fn insert_contains_delete_and_fetch_utxo<T: BlockchainBackend>(db: T) {
     assert_eq!(db.contains(&DbKey::UnspentOutput(hash.clone())), Ok(false));
 
     let mut txn = DbTransaction::new();
-    txn.insert_utxo(utxo.clone());
+    txn.insert_utxo(utxo.clone(), true);
     assert!(db.write(txn).is_ok());
     assert_eq!(db.contains(&DbKey::UnspentOutput(hash.clone())), Ok(true));
     if let Some(DbValue::UnspentOutput(retrieved_utxo)) = db.fetch(&DbKey::UnspentOutput(hash.clone())).unwrap() {
@@ -132,7 +132,7 @@ fn insert_contains_delete_and_fetch_kernel<T: BlockchainBackend>(db: T) {
     assert_eq!(db.contains(&DbKey::TransactionKernel(hash.clone())), Ok(false));
 
     let mut txn = DbTransaction::new();
-    txn.insert_kernel(kernel.clone());
+    txn.insert_kernel(kernel.clone(), true);
     assert!(db.write(txn).is_ok());
     assert_eq!(db.contains(&DbKey::TransactionKernel(hash.clone())), Ok(true));
     if let Some(DbValue::TransactionKernel(retrieved_kernel)) =
@@ -215,8 +215,8 @@ fn spend_utxo_and_unspend_stxo<T: BlockchainBackend>(db: T) {
     let hash2 = utxo2.hash();
 
     let mut txn = DbTransaction::new();
-    txn.insert_utxo(utxo1.clone());
-    txn.insert_utxo(utxo2.clone());
+    txn.insert_utxo(utxo1.clone(), true);
+    txn.insert_utxo(utxo2.clone(), true);
     assert!(db.write(txn).is_ok());
 
     let mut txn = DbTransaction::new();
@@ -378,9 +378,9 @@ fn fetch_mmr_root_and_proof_for_utxo_and_rp<T: BlockchainBackend>(db: T) {
     let rp_hash3 = utxo3.proof.hash();
 
     let mut txn = DbTransaction::new();
-    txn.insert_utxo(utxo1.clone());
-    txn.insert_utxo(utxo2.clone());
-    txn.insert_utxo(utxo3.clone());
+    txn.insert_utxo(utxo1.clone(), true);
+    txn.insert_utxo(utxo2.clone(), true);
+    txn.insert_utxo(utxo3.clone(), true);
     assert!(db.write(txn).is_ok());
 
     let mut utxo_mmr_check = MutableMmr::<HashDigest, _>::new(Vec::new());
@@ -449,9 +449,9 @@ fn fetch_mmr_root_and_proof_for_kernel<T: BlockchainBackend>(db: T) {
     let hash3 = kernel3.hash();
 
     let mut txn = DbTransaction::new();
-    txn.insert_kernel(kernel1);
-    txn.insert_kernel(kernel2);
-    txn.insert_kernel(kernel3);
+    txn.insert_kernel(kernel1, true);
+    txn.insert_kernel(kernel2, true);
+    txn.insert_kernel(kernel3, true);
     assert!(db.write(txn).is_ok());
 
     let mut kernel_mmr_check = MutableMmr::<HashDigest, _>::new(Vec::new());
@@ -506,9 +506,9 @@ fn fetch_mmr_root_and_proof_for_header<T: BlockchainBackend>(db: T) {
     let hash3 = header3.hash();
 
     let mut txn = DbTransaction::new();
-    txn.insert_header(header1);
-    txn.insert_header(header2);
-    txn.insert_header(header3);
+    txn.insert_header(header1, true);
+    txn.insert_header(header2, true);
+    txn.insert_header(header3, true);
     assert!(db.write(txn).is_ok());
 
     let mut header_mmr_check = MutableMmr::<HashDigest, _>::new(Vec::new());
@@ -559,8 +559,8 @@ fn fetch_future_mmr_root_for_utxo_and_rp<T: BlockchainBackend>(db: T) {
     let rp_hash4 = utxo4.proof.hash();
 
     let mut txn = DbTransaction::new();
-    txn.insert_utxo(utxo1);
-    txn.insert_utxo(utxo2);
+    txn.insert_utxo(utxo1, true);
+    txn.insert_utxo(utxo2, true);
     assert!(db.write(txn).is_ok());
 
     let utxo_future_root = db
@@ -575,8 +575,8 @@ fn fetch_future_mmr_root_for_utxo_and_rp<T: BlockchainBackend>(db: T) {
     assert_ne!(rp_future_root, db.fetch_mmr_root(MmrTree::RangeProof).unwrap().to_hex());
 
     let mut txn = DbTransaction::new();
-    txn.insert_utxo(utxo3);
-    txn.insert_utxo(utxo4);
+    txn.insert_utxo(utxo3, true);
+    txn.insert_utxo(utxo4, true);
     txn.spend_utxo(utxo_hash1);
     assert!(db.write(txn).is_ok());
 
@@ -609,8 +609,8 @@ fn fetch_future_mmr_root_for_for_kernel<T: BlockchainBackend>(db: T) {
     let hash4 = kernel4.hash();
 
     let mut txn = DbTransaction::new();
-    txn.insert_kernel(kernel1);
-    txn.insert_kernel(kernel2);
+    txn.insert_kernel(kernel1, true);
+    txn.insert_kernel(kernel2, true);
     assert!(db.write(txn).is_ok());
 
     let future_root = db
@@ -620,8 +620,8 @@ fn fetch_future_mmr_root_for_for_kernel<T: BlockchainBackend>(db: T) {
     assert_ne!(future_root, db.fetch_mmr_root(MmrTree::Kernel).unwrap().to_hex());
 
     let mut txn = DbTransaction::new();
-    txn.insert_kernel(kernel3);
-    txn.insert_kernel(kernel4);
+    txn.insert_kernel(kernel3, true);
+    txn.insert_kernel(kernel4, true);
     assert!(db.write(txn).is_ok());
 
     assert_eq!(future_root, db.fetch_mmr_root(MmrTree::Kernel).unwrap().to_hex());
@@ -656,8 +656,8 @@ fn fetch_future_mmr_root_for_header<T: BlockchainBackend>(db: T) {
     let hash4 = header4.hash();
 
     let mut txn = DbTransaction::new();
-    txn.insert_header(header1);
-    txn.insert_header(header2);
+    txn.insert_header(header1, true);
+    txn.insert_header(header2, true);
     assert!(db.write(txn).is_ok());
 
     let future_root = db
@@ -667,8 +667,8 @@ fn fetch_future_mmr_root_for_header<T: BlockchainBackend>(db: T) {
     assert_ne!(future_root, db.fetch_mmr_root(MmrTree::Header).unwrap().to_hex());
 
     let mut txn = DbTransaction::new();
-    txn.insert_header(header3);
-    txn.insert_header(header4);
+    txn.insert_header(header3, true);
+    txn.insert_header(header4, true);
     assert!(db.write(txn).is_ok());
 
     assert_eq!(future_root, db.fetch_mmr_root(MmrTree::Header).unwrap().to_hex());
@@ -702,9 +702,9 @@ fn commit_block_and_create_fetch_checkpoint_and_rewind_mmr<T: BlockchainBackend>
     let header_hash1 = header1.hash();
 
     let mut txn = DbTransaction::new();
-    txn.insert_utxo(utxo1);
-    txn.insert_kernel(kernel1);
-    txn.insert_header(header1);
+    txn.insert_utxo(utxo1, true);
+    txn.insert_kernel(kernel1, true);
+    txn.insert_header(header1, true);
     txn.commit_block();
     assert!(db.write(txn).is_ok());
 
@@ -718,9 +718,9 @@ fn commit_block_and_create_fetch_checkpoint_and_rewind_mmr<T: BlockchainBackend>
     let header_hash2 = header2.hash();
 
     let mut txn = DbTransaction::new();
-    txn.insert_utxo(utxo2);
-    txn.insert_kernel(kernel2);
-    txn.insert_header(header2);
+    txn.insert_utxo(utxo2, true);
+    txn.insert_kernel(kernel2, true);
+    txn.insert_header(header2, true);
     txn.commit_block();
     assert!(db.write(txn).is_ok());
 
@@ -758,6 +758,7 @@ fn commit_block_and_create_fetch_checkpoint_and_rewind_mmr<T: BlockchainBackend>
     );
 
     let mut txn = DbTransaction::new();
+    txn.delete(DbKey::BlockHeader(2)); // Remove header to ensure height is calculated correctly
     txn.rewind_header_mmr(1);
     txn.rewind_kernel_mmr(1);
     txn.rewind_utxo_mmr(1);
@@ -888,10 +889,10 @@ fn lmdb_backend_restore() {
         let db = create_lmdb_database(&path, mct_config).unwrap();
         let mut txn = DbTransaction::new();
         txn.insert_orphan(orphan.clone());
-        txn.insert_utxo(utxo1);
-        txn.insert_utxo(utxo2);
-        txn.insert_kernel(kernel);
-        txn.insert_header(header.clone());
+        txn.insert_utxo(utxo1, true);
+        txn.insert_utxo(utxo2, true);
+        txn.insert_kernel(kernel, true);
+        txn.insert_header(header.clone(), true);
         txn.commit_block();
         assert!(db.write(txn).is_ok());
         let mut txn = DbTransaction::new();
@@ -938,9 +939,9 @@ fn lmdb_mmr_reset_and_commit() {
     let header_hash1 = header1.hash();
 
     let mut txn = DbTransaction::new();
-    txn.insert_utxo(utxo1);
-    txn.insert_kernel(kernel1);
-    txn.insert_header(header1);
+    txn.insert_utxo(utxo1, true);
+    txn.insert_kernel(kernel1, true);
+    txn.insert_header(header1, true);
     txn.commit_block();
     assert!(db.write(txn).is_ok());
 
@@ -1030,9 +1031,9 @@ fn fetch_mmr_base_leaf_nodes_and_restore<T: BlockchainBackend>(db: T) {
         let mut header = BlockHeader::new(0);
         header.height = height;
         let mut txn = DbTransaction::new();
-        txn.insert_utxo(utxo.clone());
-        txn.insert_kernel(kernel.clone());
-        txn.insert_header(header.clone());
+        txn.insert_utxo(utxo.clone(), true);
+        txn.insert_kernel(kernel.clone(), true);
+        txn.insert_header(header.clone(), true);
         txn.commit_block();
         assert!(db.write(txn).is_ok());
 
@@ -1070,9 +1071,9 @@ fn fetch_mmr_base_leaf_nodes_and_restore<T: BlockchainBackend>(db: T) {
     let mut header = BlockHeader::new(0);
     header.height = 10;
     let mut txn = DbTransaction::new();
-    txn.insert_utxo(utxo.clone());
-    txn.insert_kernel(kernel.clone());
-    txn.insert_header(header.clone());
+    txn.insert_utxo(utxo.clone(), true);
+    txn.insert_kernel(kernel.clone(), true);
+    txn.insert_header(header.clone(), true);
     txn.commit_block();
     assert!(db.write(txn).is_ok());
 
@@ -1156,9 +1157,9 @@ fn fetch_checkpoint_with_pruning_horizon<T: BlockchainBackend>(db: T) {
     let header_hash1 = header1.hash();
 
     let mut txn = DbTransaction::new();
-    txn.insert_utxo(utxo1);
-    txn.insert_kernel(kernel1);
-    txn.insert_header(header1.clone());
+    txn.insert_utxo(utxo1, true);
+    txn.insert_kernel(kernel1, true);
+    txn.insert_header(header1.clone(), true);
     txn.commit_block();
     assert!(db.write(txn).is_ok());
 
@@ -1171,9 +1172,9 @@ fn fetch_checkpoint_with_pruning_horizon<T: BlockchainBackend>(db: T) {
     let header_hash2 = header2.hash();
 
     let mut txn = DbTransaction::new();
-    txn.insert_utxo(utxo2);
-    txn.insert_kernel(kernel2);
-    txn.insert_header(header2.clone());
+    txn.insert_utxo(utxo2, true);
+    txn.insert_kernel(kernel2, true);
+    txn.insert_header(header2.clone(), true);
     txn.commit_block();
     assert!(db.write(txn).is_ok());
 
@@ -1203,9 +1204,9 @@ fn fetch_checkpoint_with_pruning_horizon<T: BlockchainBackend>(db: T) {
     let header_hash3 = header3.hash();
 
     let mut txn = DbTransaction::new();
-    txn.insert_utxo(utxo3);
-    txn.insert_kernel(kernel3);
-    txn.insert_header(header3);
+    txn.insert_utxo(utxo3, true);
+    txn.insert_kernel(kernel3, true);
+    txn.insert_header(header3, true);
     txn.commit_block();
     assert!(db.write(txn).is_ok());
 
@@ -1253,4 +1254,45 @@ fn lmdb_fetch_checkpoint_with_pruning_horizon() {
     };
     let db = create_lmdb_database(&create_temporary_data_path(), mct_config).unwrap();
     fetch_checkpoint_with_pruning_horizon(db);
+}
+
+fn fetch_last_header<T: BlockchainBackend>(db: T) {
+    let mut header0 = BlockHeader::new(0);
+    header0.height = 0;
+    let mut header1 = BlockHeader::new(0);
+    header1.height = 1;
+    let mut header2 = BlockHeader::new(0);
+    header2.height = 2;
+    assert_eq!(db.fetch_last_header(), Ok(None));
+
+    let mut txn = DbTransaction::new();
+    txn.insert_header(header0, true);
+    txn.insert_header(header1.clone(), true);
+    assert!(db.write(txn).is_ok());
+    assert_eq!(db.fetch_last_header(), Ok(Some(header1)));
+
+    let mut txn = DbTransaction::new();
+    txn.insert_header(header2.clone(), true);
+    assert!(db.write(txn).is_ok());
+    assert_eq!(db.fetch_last_header(), Ok(Some(header2)));
+}
+
+#[test]
+fn memory_fetch_last_header() {
+    let mct_config = MerkleChangeTrackerConfig {
+        min_history_len: 10,
+        max_history_len: 20,
+    };
+    let db = MemoryDatabase::<HashDigest>::new(mct_config);
+    fetch_last_header(db);
+}
+
+#[test]
+fn lmdb_fetch_last_header() {
+    let mct_config = MerkleChangeTrackerConfig {
+        min_history_len: 10,
+        max_history_len: 20,
+    };
+    let db = create_lmdb_database(&create_temporary_data_path(), mct_config).unwrap();
+    fetch_last_header(db);
 }

--- a/base_layer/core/src/test_utils/test_common.rs
+++ b/base_layer/core/src/test_utils/test_common.rs
@@ -23,7 +23,7 @@
 // Used in tests only
 
 use crate::{
-    blocks::Block,
+    blocks::{blockheader::BlockHeader, Block},
     chain_storage::{BlockchainBackend, ChainStorageError, DbKey, DbTransaction, DbValue, MmrTree, MutableMmrState},
 };
 use rand::{CryptoRng, Rng};
@@ -146,6 +146,10 @@ impl BlockchainBackend for MockBackend {
         Self: Sized,
         F: FnMut(Result<(HashOutput, Block), ChainStorageError>),
     {
+        unimplemented!()
+    }
+
+    fn fetch_last_header(&self) -> Result<Option<BlockHeader>, ChainStorageError> {
         unimplemented!()
     }
 }


### PR DESCRIPTION
##  Description
- Added validate horizon state step to the horizon sync process to allow the blockchain metadata to be updated and allow the future block sync process to build on the current horizon state.
- Modified the blockchain backend and db transactions to allow the enabling and disabling of MMR updates, this is useful to ensure that duplicate hashes are not inserted into the MMRs when the horizon state is synced.
- Modified the fetch_pruning_horizon function of the blockchain backends to calculate the number of checkpoints in the base MMR from the tip height and number of checkpoints in MerkleChangeTracker.
- Added the fetch_last_header blockchain backend function to allow easy retrieval of the tip header that can be used to update the blockchain metadata.

## Motivation and Context
Syncing the horizon state did not correctly update the blockchain metadata, breaking the ability to build onto the horizon state. The MMR sync process was broken as duplicate hashes were added to the MMRs.

## How Has This Been Tested?
Added a memory and lmdb test for testing the fetch_last_header method.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [x] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch
* [x] I ran `cargo-fmt --all` before pushing
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
