### PR TITLE
Add persistence for the Key Manager used in Output Manager Service

### DIFF
--- a/base_layer/wallet/migrations/2019-10-30-084148_output_manager_service/down.sql
+++ b/base_layer/wallet/migrations/2019-10-30-084148_output_manager_service/down.sql
@@ -1,2 +1,3 @@
 DROP TABLE IF EXISTS outputs;
 DROP TABLE IF EXISTS pending_transaction_outputs;
+DROP TABLE IF EXISTS key_manager_states;

--- a/base_layer/wallet/migrations/2019-10-30-084148_output_manager_service/up.sql
+++ b/base_layer/wallet/migrations/2019-10-30-084148_output_manager_service/up.sql
@@ -14,3 +14,11 @@ CREATE TABLE pending_transaction_outputs (
     tx_id INTEGER PRIMARY KEY NOT NULL,
     timestamp DATETIME NOT NULL
 );
+
+CREATE TABLE key_manager_states (
+    id INTEGER PRIMARY KEY,
+    master_seed BLOB NOT NULL,
+    branch_seed TEXT NOT NULL,
+    primary_key_index INTEGER NOT NULL,
+    timestamp DATETIME NOT NULL
+);

--- a/base_layer/wallet/src/output_manager_service/error.rs
+++ b/base_layer/wallet/src/output_manager_service/error.rs
@@ -74,6 +74,8 @@ pub enum OutputManagerStorageError {
     ConversionError,
     /// Output has already been spent
     OutputAlreadySpent,
+    /// Key Manager not initialized
+    KeyManagerNotInitialized,
     OutOfRangeError(OutOfRangeError),
     R2d2Error,
     DieselError(DieselError),

--- a/base_layer/wallet/src/schema.rs
+++ b/base_layer/wallet/src/schema.rs
@@ -31,6 +31,16 @@ table! {
 }
 
 table! {
+    key_manager_states (id) {
+        id -> Nullable<BigInt>,
+        master_seed -> Binary,
+        branch_seed -> Text,
+        primary_key_index -> BigInt,
+        timestamp -> Timestamp,
+    }
+}
+
+table! {
     outbound_transactions (tx_id) {
         tx_id -> BigInt,
         destination_public_key -> Binary,
@@ -75,6 +85,7 @@ allow_tables_to_appear_in_same_query!(
     completed_transactions,
     contacts,
     inbound_transactions,
+    key_manager_states,
     outbound_transactions,
     outputs,
     peers,

--- a/base_layer/wallet/src/transaction_service/service.rs
+++ b/base_layer/wallet/src/transaction_service/service.rs
@@ -59,6 +59,8 @@ use tari_p2p::{domain_message::DomainMessage, tari_message::TariMessageType};
 use tari_service_framework::{reply_channel, reply_channel::Receiver};
 #[cfg(feature = "test_harness")]
 use tari_transactions::tari_amount::T;
+#[cfg(feature = "test_harness")]
+use tari_transactions::types::BlindingFactor;
 use tari_transactions::{
     tari_amount::MicroTari,
     transaction::{KernelFeatures, OutputFeatures, Transaction},
@@ -67,7 +69,7 @@ use tari_transactions::{
         recipient::{RecipientSignedMessage, RecipientState},
         sender::TransactionSenderMessage,
     },
-    types::{BlindingFactor, CryptoFactories, PrivateKey},
+    types::{CryptoFactories, PrivateKey},
     ReceiverTransactionProtocol,
 };
 
@@ -744,22 +746,13 @@ where
         use crate::output_manager_service::{
             service::OutputManagerService,
             storage::{database::OutputManagerDatabase, memory_db::OutputManagerMemoryDatabase},
-            OutputManagerConfig,
         };
-        use tari_comms::types::CommsSecretKey;
-        use tari_crypto::keys::PublicKey;
 
         let (_sender, receiver) = reply_channel::unbounded();
         let mut rng = rand::OsRng::new().unwrap();
-        let (secret_key, _public_key): (CommsSecretKey, CommsPublicKey) = PublicKey::random_keypair(&mut rng);
 
         let mut fake_oms = OutputManagerService::new(
             receiver,
-            OutputManagerConfig {
-                master_seed: secret_key,
-                branch_seed: "".to_string(),
-                primary_key_index: 0,
-            },
             OutputManagerDatabase::new(OutputManagerMemoryDatabase::new()),
             self.factories.clone(),
         )?;

--- a/base_layer/wallet/src/transaction_service/storage/sqlite_db.rs
+++ b/base_layer/wallet/src/transaction_service/storage/sqlite_db.rs
@@ -688,14 +688,11 @@ impl From<UpdateCompletedTransaction> for UpdateCompletedTransactionSql {
 
 #[cfg(test)]
 mod test {
+    #[cfg(feature = "test_harness")]
+    use crate::transaction_service::storage::sqlite_db::UpdateCompletedTransaction;
     use crate::transaction_service::storage::{
         database::{CompletedTransaction, InboundTransaction, OutboundTransaction, TransactionStatus},
-        sqlite_db::{
-            CompletedTransactionSql,
-            InboundTransactionSql,
-            OutboundTransactionSql,
-            UpdateCompletedTransaction,
-        },
+        sqlite_db::{CompletedTransactionSql, InboundTransactionSql, OutboundTransactionSql},
     };
     use chrono::Utc;
     use diesel::{r2d2::ConnectionManager, Connection, SqliteConnection};

--- a/base_layer/wallet/tests/contacts_service/mod.rs
+++ b/base_layer/wallet/tests/contacts_service/mod.rs
@@ -20,7 +20,7 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use crate::support::{data::create_temporary_sqlite_path, utils::random_string};
+use crate::support::utils::random_string;
 use tari_crypto::keys::PublicKey as PublicKeyTrait;
 use tari_service_framework::StackBuilder;
 use tari_shutdown::Shutdown;
@@ -35,6 +35,7 @@ use tari_wallet::contacts_service::{
     },
     ContactsServiceInitializer,
 };
+use tempdir::TempDir;
 use tokio::runtime::Runtime;
 
 pub fn setup_contacts_service<T: ContactsBackend + 'static>(
@@ -164,5 +165,10 @@ fn contacts_service_memory_db() {
 
 #[test]
 fn contacts_service_sqlite_db() {
-    test_contacts_service(ContactsServiceSqliteDatabase::new(create_temporary_sqlite_path()).unwrap());
+    let db_name = format!("{}.sqlite3", random_string(8).as_str());
+    let temp_dir = TempDir::new(random_string(8).as_str()).unwrap();
+    let db_folder = temp_dir.path().to_str().unwrap().to_string();
+    test_contacts_service(
+        ContactsServiceSqliteDatabase::new(format!("{}/{}", db_folder, db_name).to_string()).unwrap(),
+    );
 }

--- a/base_layer/wallet/tests/support/data.rs
+++ b/base_layer/wallet/tests/support/data.rs
@@ -20,9 +20,7 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use crate::support::utils::random_string;
 use std::path::PathBuf;
-use tempdir::TempDir;
 
 pub fn get_path(name: Option<&str>) -> String {
     let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
@@ -41,15 +39,4 @@ pub fn init_sql_database(name: &str) {
     clean_up_sql_database(name);
     let path = get_path(None);
     let _ = std::fs::create_dir(&path).unwrap_or_default();
-}
-
-pub fn create_temporary_sqlite_path() -> String {
-    let db_name = format!("{}.sqlite3", random_string(8).as_str());
-    let db_folder = TempDir::new(random_string(8).as_str())
-        .unwrap()
-        .path()
-        .to_str()
-        .unwrap()
-        .to_string();
-    format!("{}{}", db_folder, db_name).to_string()
 }

--- a/base_layer/wallet/tests/transaction_service/callback_handler.rs
+++ b/base_layer/wallet/tests/transaction_service/callback_handler.rs
@@ -27,13 +27,9 @@ use crate::{
 use rand::OsRng;
 use std::{sync::Mutex, time::Duration};
 use tari_comms::peer_manager::{NodeIdentity, PeerFeatures};
-use tari_crypto::keys::SecretKey;
 use tari_shutdown::Shutdown;
 use tari_test_utils::collect_stream;
-use tari_transactions::{
-    tari_amount::MicroTari,
-    types::{CryptoFactories, PrivateKey},
-};
+use tari_transactions::{tari_amount::MicroTari, types::CryptoFactories};
 use tari_wallet::transaction_service::{
     callback_handler::CallbackHandler,
     handle::TransactionEvent,
@@ -132,7 +128,6 @@ fn test_callback_handler() {
     CALLBACK_STATE.lock().unwrap().reset();
 
     // Alice's parameters
-    let alice_seed = PrivateKey::random(&mut rng);
     let alice_node_identity = NodeIdentity::random(
         &mut rng,
         "/ip4/127.0.0.1/tcp/33101".parse().unwrap(),
@@ -141,7 +136,6 @@ fn test_callback_handler() {
     .unwrap();
 
     // Bob's parameters
-    let bob_seed = PrivateKey::random(&mut rng);
     let bob_node_identity = NodeIdentity::random(
         &mut rng,
         "/ip4/127.0.0.1/tcp/33102".parse().unwrap(),
@@ -150,7 +144,6 @@ fn test_callback_handler() {
     .unwrap();
 
     // Carols's parameters
-    let carol_seed = PrivateKey::random(&mut rng);
     let carol_node_identity = NodeIdentity::random(
         &mut rng,
         "/ip4/127.0.0.1/tcp/33103".parse().unwrap(),
@@ -163,7 +156,6 @@ fn test_callback_handler() {
     let alice_db = TransactionMemoryDatabase::new();
     let (mut alice_ts, mut alice_oms, _alice_comms) = setup_transaction_service(
         &runtime,
-        alice_seed,
         alice_node_identity.clone(),
         vec![bob_node_identity.clone()],
         factories.clone(),
@@ -188,7 +180,6 @@ fn test_callback_handler() {
 
     let (mut bob_ts, mut bob_oms, _bob_comms) = setup_transaction_service(
         &runtime,
-        bob_seed,
         bob_node_identity.clone(),
         vec![alice_node_identity.clone(), carol_node_identity.clone()],
         factories.clone(),
@@ -199,7 +190,6 @@ fn test_callback_handler() {
 
     let (_carol_ts, _carol_oms, _carol_comms) = setup_transaction_service(
         &runtime,
-        carol_seed,
         carol_node_identity.clone(),
         vec![bob_node_identity.clone()],
         factories.clone(),

--- a/base_layer/wallet/tests/wallet/mod.rs
+++ b/base_layer/wallet/tests/wallet/mod.rs
@@ -38,25 +38,23 @@ use tari_p2p::initialization::CommsConfig;
 use tari_test_utils::{collect_stream, paths::with_temp_dir};
 use tari_transactions::{tari_amount::MicroTari, types::CryptoFactories};
 #[cfg(feature = "test_harness")]
+use tari_wallet::testnet_utils::broadcast_transaction;
+#[cfg(feature = "test_harness")]
 use tari_wallet::testnet_utils::finalize_received_transaction;
+#[cfg(feature = "test_harness")]
+use tari_wallet::transaction_service::storage::database::{CompletedTransaction, InboundTransaction};
 use tari_wallet::{
     contacts_service::storage::{database::Contact, memory_db::ContactsServiceMemoryDatabase},
     output_manager_service::storage::memory_db::OutputManagerMemoryDatabase,
     storage::memory_db::WalletMemoryDatabase,
-    testnet_utils::broadcast_transaction,
-    transaction_service::{
-        handle::TransactionEvent,
-        storage::{
-            database::{CompletedTransaction, InboundTransaction},
-            memory_db::TransactionMemoryDatabase,
-        },
-    },
+    transaction_service::{handle::TransactionEvent, storage::memory_db::TransactionMemoryDatabase},
     wallet::WalletConfig,
     Wallet,
 };
 #[cfg(feature = "test_harness")]
 use tempdir::TempDir;
 use tokio::runtime::Runtime;
+
 fn create_peer(public_key: CommsPublicKey, net_address: Multiaddr) -> Peer {
     Peer::new(
         public_key.clone(),
@@ -334,26 +332,25 @@ impl CallbackState {
         self.discovery_send_callback_called = false;
     }
 }
-
 lazy_static! {
     static ref CALLBACK_STATE_HARNESS: Mutex<CallbackState> = {
         let c = Mutex::new(CallbackState::new());
         c
     };
 }
-
+#[cfg(feature = "test_harness")]
 unsafe extern "C" fn received_tx_callback(_tx: *mut InboundTransaction) {
     assert_eq!(_tx.is_null(), false);
     CALLBACK_STATE_HARNESS.lock().unwrap().received_tx_callback_called = true;
     Box::from_raw(_tx);
 }
-
+#[cfg(feature = "test_harness")]
 unsafe extern "C" fn received_tx_reply_callback(_tx: *mut CompletedTransaction) {
     assert_eq!(_tx.is_null(), false);
     CALLBACK_STATE_HARNESS.lock().unwrap().received_tx_reply_callback_called = true;
     Box::from_raw(_tx);
 }
-
+#[cfg(feature = "test_harness")]
 unsafe extern "C" fn received_finalized_tx_callback(_tx: *mut CompletedTransaction) {
     assert_eq!(_tx.is_null(), false);
     CALLBACK_STATE_HARNESS
@@ -362,19 +359,19 @@ unsafe extern "C" fn received_finalized_tx_callback(_tx: *mut CompletedTransacti
         .received_finalized_tx_callback_called = true;
     Box::from_raw(_tx);
 }
-
+#[cfg(feature = "test_harness")]
 unsafe extern "C" fn broadcast_tx_callback(_tx: *mut CompletedTransaction) {
     assert_eq!(_tx.is_null(), false);
     CALLBACK_STATE_HARNESS.lock().unwrap().broadcast_tx_callback_called = true;
     Box::from_raw(_tx);
 }
-
+#[cfg(feature = "test_harness")]
 unsafe extern "C" fn mined_tx_callback(_tx: *mut CompletedTransaction) {
     assert_eq!(_tx.is_null(), false);
     CALLBACK_STATE_HARNESS.lock().unwrap().mined_tx_callback_called = true;
     Box::from_raw(_tx);
 }
-
+#[cfg(feature = "test_harness")]
 unsafe extern "C" fn discovery_send_callback(_tx_id: u64, _result: bool) {
     CALLBACK_STATE_HARNESS.lock().unwrap().discovery_send_callback_called = true;
     assert!(true);


### PR DESCRIPTION
## Description
The Key Manager state used by the OMS was not being persisted, it will now automatically check if there is state in the DB and if there is not it will start a fresh key manager.

## Motivation and Context
Overlooked needing to persist this state

## How Has This Been Tested?
Tests provided

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [x] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch
* [x] I ran `cargo-fmt --all` before pushing
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
