### PR TITLE
Nodes should only send as many blocks as they want

### DIFF
--- a/applications/tari_base_node/src/builder.rs
+++ b/applications/tari_base_node/src/builder.rs
@@ -38,6 +38,7 @@ use tari_core::{
         service::{BaseNodeServiceConfig, BaseNodeServiceInitializer},
         BaseNodeStateMachine,
         BaseNodeStateMachineConfig,
+        InboundNodeCommsHandlersConfig,
         OutboundNodeCommsInterface,
     },
     chain_storage::{
@@ -291,6 +292,7 @@ where
     T: BlockchainBackend + 'static,
 {
     let node_config = BaseNodeServiceConfig::default(); // TODO - make this configurable
+    let inbound_node_comms_handlers_config = InboundNodeCommsHandlersConfig::default(); // TODO - make this configurable
     let (publisher, subscription_factory) = pubsub_connector(rt.executor(), 100);
     let subscription_factory = Arc::new(subscription_factory);
     let comms_config = CommsConfig {
@@ -327,6 +329,7 @@ where
             mempool,
             consensus_manager,
             node_config,
+            inbound_node_comms_handlers_config,
         ))
         .finish();
 

--- a/base_layer/core/src/base_node/comms_interface/mod.rs
+++ b/base_layer/core/src/base_node/comms_interface/mod.rs
@@ -31,6 +31,6 @@ mod outbound_interface;
 pub use comms_request::{MmrStateRequest, NodeCommsRequest, NodeCommsRequestType};
 pub use comms_response::NodeCommsResponse;
 pub use error::CommsInterfaceError;
-pub use inbound_handlers::{BlockEvent, InboundNodeCommsHandlers};
+pub use inbound_handlers::{BlockEvent, InboundNodeCommsHandlers, InboundNodeCommsHandlersConfig};
 pub use local_interface::LocalNodeCommsInterface;
 pub use outbound_interface::OutboundNodeCommsInterface;

--- a/base_layer/core/src/base_node/mod.rs
+++ b/base_layer/core/src/base_node/mod.rs
@@ -46,4 +46,4 @@ pub mod states;
 // Public re-exports
 pub use backoff::BackOff;
 pub use base_node::{BaseNodeStateMachine, BaseNodeStateMachineConfig};
-pub use comms_interface::{LocalNodeCommsInterface, OutboundNodeCommsInterface};
+pub use comms_interface::{InboundNodeCommsHandlersConfig, LocalNodeCommsInterface, OutboundNodeCommsInterface};

--- a/base_layer/core/src/base_node/states/block_sync.rs
+++ b/base_layer/core/src/base_node/states/block_sync.rs
@@ -28,22 +28,24 @@ use crate::{
     chain_storage::{BlockchainBackend, ChainMetadata},
 };
 use log::*;
+use std::cmp::min;
 
 const LOG_TARGET: &str = "base_node::block_sync";
 
-// The number of Blocks that can be requested in a single query from remote nodes.
-const BLOCK_SYNC_CHUNK_SIZE: usize = 2;
+// The number of Blocks that will be requested in a single query from remote nodes. Note that the remote node might not
+// be willing to provided this many blocks in a single response.
+const MAX_BLOCK_REQUEST_BATCH_SIZE: usize = 2;
 
 /// Configuration for the Block Synchronization.
 #[derive(Clone, Copy)]
 pub struct BlockSyncConfig {
-    pub block_sync_chunk_size: usize,
+    pub max_block_request_batch_size: usize,
 }
 
 impl Default for BlockSyncConfig {
     fn default() -> Self {
         Self {
-            block_sync_chunk_size: BLOCK_SYNC_CHUNK_SIZE,
+            max_block_request_batch_size: MAX_BLOCK_REQUEST_BATCH_SIZE,
         }
     }
 }
@@ -104,19 +106,25 @@ async fn network_chain_tip<B: BlockchainBackend>(shared: &mut BaseNodeStateMachi
 }
 
 async fn synchronize_blocks<B: BlockchainBackend>(shared: &mut BaseNodeStateMachine<B>) -> Result<(), String> {
-    let start_height = match shared.db.get_height().map_err(|e| e.to_string())? {
+    let mut start_height = match shared.db.get_height().map_err(|e| e.to_string())? {
         Some(height) => height + 1,
         None => 0u64,
     };
     let network_tip_height = network_chain_tip(shared).await?;
 
-    let height_indices = (start_height..=network_tip_height).collect::<Vec<u64>>();
-    for block_nums in height_indices.chunks(shared.config.block_sync_config.block_sync_chunk_size) {
+    while start_height <= network_tip_height {
+        let end_height = min(
+            start_height + shared.config.block_sync_config.max_block_request_batch_size as u64,
+            network_tip_height + 1,
+        );
+        let block_nums = (start_height..end_height).collect::<Vec<u64>>();
+
         let hist_blocks = shared
             .comms
             .fetch_blocks(block_nums.to_vec())
             .await
             .map_err(|e| e.to_string())?;
+        start_height += hist_blocks.len() as u64;
 
         for hist_block in hist_blocks {
             shared.db.add_block(hist_block.block).map_err(|e| e.to_string())?;

--- a/base_layer/core/src/base_node/test/comms_interface.rs
+++ b/base_layer/core/src/base_node/test/comms_interface.rs
@@ -24,6 +24,7 @@ use crate::{
     base_node::comms_interface::{
         CommsInterfaceError,
         InboundNodeCommsHandlers,
+        InboundNodeCommsHandlersConfig,
         MmrStateRequest,
         NodeCommsRequest,
         NodeCommsRequestType,
@@ -112,8 +113,14 @@ fn inbound_get_metadata() {
     let (request_sender, _) = reply_channel::unbounded();
     let (block_sender, _) = futures_mpsc_channel_unbounded();
     let outbound_nci = OutboundNodeCommsInterface::new(request_sender, block_sender.clone());
-    let inbound_nch =
-        InboundNodeCommsHandlers::new(block_event_publisher, store, mempool, consensus_manager, outbound_nci);
+    let inbound_nch = InboundNodeCommsHandlers::new(
+        block_event_publisher,
+        store,
+        mempool,
+        consensus_manager,
+        outbound_nci,
+        InboundNodeCommsHandlersConfig::default(),
+    );
 
     test_async(move |rt| {
         rt.spawn(async move {
@@ -166,6 +173,7 @@ fn inbound_fetch_kernels() {
         mempool,
         consensus_manager,
         outbound_nci,
+        InboundNodeCommsHandlersConfig::default(),
     );
 
     let kernel = create_test_kernel(5.into(), 0);
@@ -225,6 +233,7 @@ fn inbound_fetch_headers() {
         mempool,
         consensus_manager,
         outbound_nci,
+        InboundNodeCommsHandlersConfig::default(),
     );
 
     let mut header = BlockHeader::new(0);
@@ -286,6 +295,7 @@ fn inbound_fetch_utxos() {
         mempool,
         consensus_manager,
         outbound_nci,
+        InboundNodeCommsHandlersConfig::default(),
     );
 
     let (utxo, _) = create_utxo(MicroTari(10_000), &factories);
@@ -344,6 +354,7 @@ fn inbound_fetch_blocks() {
         mempool,
         consensus_manager,
         outbound_nci,
+        InboundNodeCommsHandlersConfig::default(),
     );
 
     let block = add_block_and_update_header(&store, get_genesis_block());
@@ -394,8 +405,14 @@ fn inbound_fetch_mmr_state() {
     let (request_sender, _) = reply_channel::unbounded();
     let (block_sender, _) = futures_mpsc_channel_unbounded();
     let outbound_nci = OutboundNodeCommsInterface::new(request_sender, block_sender);
-    let inbound_nch =
-        InboundNodeCommsHandlers::new(block_event_publisher, store, mempool, consensus_manager, outbound_nci);
+    let inbound_nch = InboundNodeCommsHandlers::new(
+        block_event_publisher,
+        store,
+        mempool,
+        consensus_manager,
+        outbound_nci,
+        InboundNodeCommsHandlersConfig::default(),
+    );
 
     test_async(move |rt| {
         rt.spawn(async move {

--- a/base_layer/core/src/base_node/test/state_machine.rs
+++ b/base_layer/core/src/base_node/test/state_machine.rs
@@ -26,6 +26,7 @@ use crate::{
         states::{BlockSyncConfig, BlockSyncInfo, HorizonInfo, HorizonSyncConfig, StateEvent},
         BaseNodeStateMachine,
         BaseNodeStateMachineConfig,
+        InboundNodeCommsHandlersConfig,
     },
     blocks::genesis_block::get_genesis_block,
     chain_storage::{DbTransaction, MmrTree},
@@ -54,6 +55,7 @@ fn test_horizon_state_sync() {
     let (alice_node, bob_node) = create_network_with_2_base_nodes_with_config(
         &runtime,
         BaseNodeServiceConfig::default(),
+        InboundNodeCommsHandlersConfig::default(),
         mct_config,
         MempoolServiceConfig::default(),
         temp_dir.path().to_str().unwrap(),
@@ -162,14 +164,23 @@ fn test_block_sync_from_horizon() {
         min_history_len: 2,
         max_history_len: 4,
     };
+    let inbound_handlers_config = InboundNodeCommsHandlersConfig {
+        max_block_response_batch_size: 2,
+    };
     let (alice_node, bob_node) = create_network_with_2_base_nodes_with_config(
         &runtime,
         BaseNodeServiceConfig::default(),
+        inbound_handlers_config,
         mct_config,
         MempoolServiceConfig::default(),
         temp_dir.path().to_str().unwrap(),
     );
-    let state_machine_config = BaseNodeStateMachineConfig::default();
+    let state_machine_config = BaseNodeStateMachineConfig {
+        horizon_sync_config: HorizonSyncConfig::default(),
+        block_sync_config: BlockSyncConfig {
+            max_block_request_batch_size: 3,
+        },
+    };
     let mut alice_state_machine = BaseNodeStateMachine::new(
         &alice_node.blockchain_db,
         &alice_node.outbound_nci,
@@ -252,14 +263,23 @@ fn test_lagging_block_sync() {
         min_history_len: 10,
         max_history_len: 20,
     };
+    let inbound_handlers_config = InboundNodeCommsHandlersConfig {
+        max_block_response_batch_size: 1,
+    };
     let (alice_node, bob_node) = create_network_with_2_base_nodes_with_config(
         &runtime,
         BaseNodeServiceConfig::default(),
+        inbound_handlers_config,
         mct_config,
         MempoolServiceConfig::default(),
         temp_dir.path().to_str().unwrap(),
     );
-    let state_machine_config = BaseNodeStateMachineConfig::default();
+    let state_machine_config = BaseNodeStateMachineConfig {
+        horizon_sync_config: HorizonSyncConfig::default(),
+        block_sync_config: BlockSyncConfig {
+            max_block_request_batch_size: 2,
+        },
+    };
     let mut alice_state_machine = BaseNodeStateMachine::new(
         &alice_node.blockchain_db,
         &alice_node.outbound_nci,

--- a/base_layer/core/src/mempool/test/service.rs
+++ b/base_layer/core/src/mempool/test/service.rs
@@ -21,7 +21,7 @@
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 use crate::{
-    base_node::service::BaseNodeServiceConfig,
+    base_node::{service::BaseNodeServiceConfig, InboundNodeCommsHandlersConfig},
     mempool::{
         service::{MempoolServiceConfig, MempoolServiceError},
         TxStorageResponse,
@@ -229,6 +229,7 @@ fn service_request_timeout() {
     let (mut alice_node, bob_node) = create_network_with_2_base_nodes_with_config(
         &runtime,
         BaseNodeServiceConfig::default(),
+        InboundNodeCommsHandlersConfig::default(),
         mct_config,
         mempool_service_config,
         temp_dir.path().to_str().unwrap(),

--- a/base_layer/core/src/test_utils/node.rs
+++ b/base_layer/core/src/test_utils/node.rs
@@ -23,6 +23,7 @@
 use crate::{
     base_node::{
         service::{BaseNodeServiceConfig, BaseNodeServiceInitializer},
+        InboundNodeCommsHandlersConfig,
         LocalNodeCommsInterface,
         OutboundNodeCommsInterface,
     },
@@ -77,6 +78,7 @@ pub struct BaseNodeBuilder {
     node_identity: Option<Arc<NodeIdentity>>,
     peers: Option<Vec<Arc<NodeIdentity>>>,
     base_node_service_config: Option<BaseNodeServiceConfig>,
+    inbound_node_comms_handlers_config: Option<InboundNodeCommsHandlersConfig>,
     mct_config: Option<MerkleChangeTrackerConfig>,
     mempool_config: Option<MempoolConfig>,
     mempool_service_config: Option<MempoolServiceConfig>,
@@ -90,6 +92,7 @@ impl BaseNodeBuilder {
             node_identity: None,
             peers: None,
             base_node_service_config: None,
+            inbound_node_comms_handlers_config: None,
             mct_config: None,
             mempool_config: None,
             mempool_service_config: None,
@@ -112,6 +115,12 @@ impl BaseNodeBuilder {
     /// Set the configuration of the Base Node Service
     pub fn with_base_node_service_config(mut self, config: BaseNodeServiceConfig) -> Self {
         self.base_node_service_config = Some(config);
+        self
+    }
+
+    /// Set the configuration of the inbound node comms handlers.
+    pub fn with_inbound_node_comms_handlers_config(mut self, config: InboundNodeCommsHandlersConfig) -> Self {
+        self.inbound_node_comms_handlers_config = Some(config);
         self
     }
 
@@ -173,6 +182,8 @@ impl BaseNodeBuilder {
                 consensus_manager,
                 self.base_node_service_config
                     .unwrap_or(BaseNodeServiceConfig::default()),
+                self.inbound_node_comms_handlers_config
+                    .unwrap_or(InboundNodeCommsHandlersConfig::default()),
                 self.mempool_service_config.unwrap_or(MempoolServiceConfig::default()),
                 data_path,
             );
@@ -211,6 +222,7 @@ pub fn create_network_with_2_base_nodes(runtime: &Runtime, data_path: &str) -> (
 pub fn create_network_with_2_base_nodes_with_config(
     runtime: &Runtime,
     base_node_service_config: BaseNodeServiceConfig,
+    inbound_node_comms_handlers_config: InboundNodeCommsHandlersConfig,
     mct_config: MerkleChangeTrackerConfig,
     mempool_service_config: MempoolServiceConfig,
     data_path: &str,
@@ -223,6 +235,7 @@ pub fn create_network_with_2_base_nodes_with_config(
         .with_node_identity(alice_node_identity.clone())
         .with_peers(vec![bob_node_identity.clone()])
         .with_base_node_service_config(base_node_service_config)
+        .with_inbound_node_comms_handlers_config(inbound_node_comms_handlers_config)
         .with_merkle_change_tracker_config(mct_config)
         .with_mempool_service_config(mempool_service_config)
         .start(&runtime, data_path);
@@ -230,6 +243,7 @@ pub fn create_network_with_2_base_nodes_with_config(
         .with_node_identity(bob_node_identity)
         .with_peers(vec![alice_node_identity])
         .with_base_node_service_config(base_node_service_config)
+        .with_inbound_node_comms_handlers_config(inbound_node_comms_handlers_config)
         .with_merkle_change_tracker_config(mct_config)
         .with_mempool_service_config(mempool_service_config)
         .start(&runtime, data_path);
@@ -250,6 +264,7 @@ pub fn create_network_with_3_base_nodes(
     create_network_with_3_base_nodes_with_config(
         runtime,
         BaseNodeServiceConfig::default(),
+        InboundNodeCommsHandlersConfig::default(),
         mct_config,
         MempoolServiceConfig::default(),
         data_path,
@@ -260,6 +275,7 @@ pub fn create_network_with_3_base_nodes(
 pub fn create_network_with_3_base_nodes_with_config(
     runtime: &Runtime,
     base_node_service_config: BaseNodeServiceConfig,
+    inbound_node_comms_handlers_config: InboundNodeCommsHandlersConfig,
     mct_config: MerkleChangeTrackerConfig,
     mempool_service_config: MempoolServiceConfig,
     data_path: &str,
@@ -273,6 +289,7 @@ pub fn create_network_with_3_base_nodes_with_config(
         .with_node_identity(alice_node_identity.clone())
         .with_peers(vec![bob_node_identity.clone(), carol_node_identity.clone()])
         .with_base_node_service_config(base_node_service_config)
+        .with_inbound_node_comms_handlers_config(inbound_node_comms_handlers_config)
         .with_merkle_change_tracker_config(mct_config)
         .with_mempool_service_config(mempool_service_config)
         .start(&runtime, data_path);
@@ -280,6 +297,7 @@ pub fn create_network_with_3_base_nodes_with_config(
         .with_node_identity(bob_node_identity.clone())
         .with_peers(vec![alice_node_identity.clone(), carol_node_identity.clone()])
         .with_base_node_service_config(base_node_service_config)
+        .with_inbound_node_comms_handlers_config(inbound_node_comms_handlers_config)
         .with_merkle_change_tracker_config(mct_config)
         .with_mempool_service_config(mempool_service_config)
         .start(&runtime, data_path);
@@ -287,6 +305,7 @@ pub fn create_network_with_3_base_nodes_with_config(
         .with_node_identity(carol_node_identity.clone())
         .with_peers(vec![alice_node_identity, bob_node_identity.clone()])
         .with_base_node_service_config(base_node_service_config)
+        .with_inbound_node_comms_handlers_config(inbound_node_comms_handlers_config)
         .with_merkle_change_tracker_config(mct_config)
         .with_mempool_service_config(mempool_service_config)
         .start(&runtime, data_path);
@@ -370,6 +389,7 @@ fn setup_base_node_services(
     mempool: Mempool<MemoryDatabase<HashDigest>>,
     consensus_manager: ConsensusManager<MemoryDatabase<HashDigest>>,
     base_node_service_config: BaseNodeServiceConfig,
+    inbound_node_comms_handlers_config: InboundNodeCommsHandlersConfig,
     mempool_service_config: MempoolServiceConfig,
     data_path: &str,
 ) -> (
@@ -392,6 +412,7 @@ fn setup_base_node_services(
             mempool.clone(),
             consensus_manager,
             base_node_service_config,
+            inbound_node_comms_handlers_config,
         ))
         .add_initializer(MempoolServiceInitializer::new(
             subscription_factory,


### PR DESCRIPTION
## Description
- Implemented the ability for a base node to limit the number of blocks that it will provided in response to fetch block requests.
- Added configuration to the inbound node comms handlers, allowing the maximum block response batch size to be specified.
- Changed the block synchronisation logic so that it doesn’t assume that all requested blocks were provided, the request batches are updated depending on what block responses were received.

## Motivation and Context
This improvement is required to limit a potential DOS attack for the fetch block mechanism. 

## How Has This Been Tested?
- Extended the service request_and_response_fetch_blocks test to also test for a mismatch between the number of request and response block limits.
- Modified the state_machine tests (test_block_sync_from_horizon, test_lagging_block_sync) to check that syncing remain functional when block request and response limits are different.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch
* [x] I ran `cargo-fmt --all` before pushing
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
