### PR TITLE
Add support for managing coinbase transactions to Transaction Manager in wallet

### DIFF
--- a/base_layer/wallet/migrations/2019-11-20-090620_transaction_service/down.sql
+++ b/base_layer/wallet/migrations/2019-11-20-090620_transaction_service/down.sql
@@ -1,3 +1,4 @@
 DROP TABLE IF EXISTS pending_outbound_transactions;
 DROP TABLE IF EXISTS pending_inbound_transactions;
+DROP TABLE IF EXISTS pending_coinbase_transactions;
 DROP TABLE IF EXISTS completed_transactions;

--- a/base_layer/wallet/migrations/2019-11-20-090620_transaction_service/up.sql
+++ b/base_layer/wallet/migrations/2019-11-20-090620_transaction_service/up.sql
@@ -17,6 +17,13 @@ CREATE TABLE inbound_transactions (
     timestamp DATETIME NOT NULL
 );
 
+CREATE TABLE coinbase_transactions (
+    tx_id INTEGER PRIMARY KEY NOT NULL,
+    amount INTEGER NOT NULL,
+    commitment BLOB NOT NULL,
+    timestamp DATETIME NOT NULL
+);
+
 CREATE TABLE completed_transactions (
     tx_id INTEGER PRIMARY KEY NOT NULL,
     source_public_key BLOB NOT NULL,

--- a/base_layer/wallet/src/output_manager_service/handle.rs
+++ b/base_layer/wallet/src/output_manager_service/handle.rs
@@ -41,6 +41,7 @@ pub enum OutputManagerRequest {
     GetBalance,
     AddOutput(UnblindedOutput),
     GetRecipientKey((u64, MicroTari)),
+    GetCoinbaseKey((u64, MicroTari, u64)),
     ConfirmReceivedOutput((u64, TransactionOutput)),
     ConfirmSentTransaction((u64, Vec<TransactionInput>, Vec<TransactionOutput>)),
     PrepareToSendTransaction((MicroTari, MicroTari, Option<u64>, String)),
@@ -101,6 +102,23 @@ impl OutputManagerHandle {
         match self
             .handle
             .call(OutputManagerRequest::GetRecipientKey((tx_id, amount)))
+            .await??
+        {
+            OutputManagerResponse::RecipientKeyGenerated(k) => Ok(k),
+            _ => Err(OutputManagerError::UnexpectedApiResponse),
+        }
+    }
+
+    pub async fn get_coinbase_spending_key(
+        &mut self,
+        tx_id: u64,
+        amount: MicroTari,
+        maturity_height: u64,
+    ) -> Result<PrivateKey, OutputManagerError>
+    {
+        match self
+            .handle
+            .call(OutputManagerRequest::GetCoinbaseKey((tx_id, amount, maturity_height)))
             .await??
         {
             OutputManagerResponse::RecipientKeyGenerated(k) => Ok(k),

--- a/base_layer/wallet/src/output_manager_service/storage/database.rs
+++ b/base_layer/wallet/src/output_manager_service/storage/database.rs
@@ -258,6 +258,7 @@ where T: OutputManagerBackend
         tx_id: &TxId,
         amount: &MicroTari,
         spending_key: &PrivateKey,
+        output_features: OutputFeatures,
     ) -> Result<(), OutputManagerStorageError>
     {
         self.db
@@ -269,7 +270,7 @@ where T: OutputManagerBackend
                     outputs_to_be_received: vec![UnblindedOutput {
                         value: amount.clone(),
                         spending_key: spending_key.clone(),
-                        features: OutputFeatures::default(),
+                        features: output_features,
                     }],
                     timestamp: Utc::now().naive_utc(),
                 }),
@@ -313,7 +314,6 @@ where T: OutputManagerBackend
         }?;
 
         uo.sort();
-
         Ok(uo)
     }
 

--- a/base_layer/wallet/src/schema.rs
+++ b/base_layer/wallet/src/schema.rs
@@ -1,4 +1,13 @@
 table! {
+    coinbase_transactions (tx_id) {
+        tx_id -> BigInt,
+        amount -> BigInt,
+        commitment -> Binary,
+        timestamp -> Timestamp,
+    }
+}
+
+table! {
     completed_transactions (tx_id) {
         tx_id -> BigInt,
         source_public_key -> Binary,
@@ -82,6 +91,7 @@ table! {
 joinable!(outputs -> pending_transaction_outputs (tx_id));
 
 allow_tables_to_appear_in_same_query!(
+    coinbase_transactions,
     completed_transactions,
     contacts,
     inbound_transactions,

--- a/base_layer/wallet/src/transaction_service/error.rs
+++ b/base_layer/wallet/src/transaction_service/error.rs
@@ -68,6 +68,8 @@ pub enum TransactionServiceError {
     /// Discovery process failed to return a result
     #[error(no_from, non_std)]
     DiscoveryProcessFailed(TxId),
+    /// Invalid Completed Transaction provided
+    InvalidCompletedTransaction,
     DhtOutboundError(DhtOutboundError),
     OutputManagerError(OutputManagerError),
     TransportChannelError(TransportChannelError),

--- a/base_layer/wallet/tests/output_manager_service/storage.rs
+++ b/base_layer/wallet/tests/output_manager_service/storage.rs
@@ -27,6 +27,7 @@ use std::time::Duration;
 use tari_crypto::keys::SecretKey;
 use tari_transactions::{
     tari_amount::MicroTari,
+    transaction::OutputFeatures,
     types::{CryptoFactories, PrivateKey},
 };
 use tari_wallet::output_manager_service::{
@@ -183,8 +184,13 @@ pub fn test_db_backend<T: OutputManagerBackend>(backend: T) {
         MicroTari::from(100 + rng.next_u64() % 1000),
         &factories.commitment,
     );
-    db.accept_incoming_pending_transaction(&5, &uo_incoming.value, &uo_incoming.spending_key)
-        .unwrap();
+    db.accept_incoming_pending_transaction(
+        &5,
+        &uo_incoming.value,
+        &uo_incoming.spending_key,
+        OutputFeatures::default(),
+    )
+    .unwrap();
 
     pending_incoming_balance += uo_incoming.clone().value;
 


### PR DESCRIPTION
## Description
This PR add the functionality for a Miner to request the spending key for a coinable output that they want to mine. The key and amount of the coinbase is stored as a Pending Incoming Transaction and will reflect in the pending balance of the wallet.

If the mining is successful the Miner will supply the completed transaction to the Transaction Service. 

If mining was unsuccessful the coinbase transaction should be cancelled.

## Motivation and Context
Closes #1101 

## How Has This Been Tested?
Tests provided

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [x] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch
* [x] I ran `cargo-fmt --all` before pushing
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
