### PR TITLE
Add db to FullStateValidator

### DIFF
--- a/applications/tari_base_node/src/builder.rs
+++ b/applications/tari_base_node/src/builder.rs
@@ -171,11 +171,12 @@ pub fn configure_and_initialize_node(
         DatabaseType::Memory => {
             let rules = ConsensusManager::default();
             let backend = MemoryDatabase::<HashDigest>::default();
+            let mut db = BlockchainDatabase::new(backend).map_err(|e| e.to_string())?;
             let validators = Validators::new(
-                FullConsensusValidator::new(rules.clone(), factories.clone()),
+                FullConsensusValidator::new(rules.clone(), factories.clone(), db.clone()),
                 StatelessValidator::new(factories.clone()),
             );
-            let db = BlockchainDatabase::new(backend, validators).map_err(|e| e.to_string())?;
+            db.add_validators(validators);
             let mempool = Mempool::new(db.clone(), MempoolConfig::default());
             let diff_adj_manager = DiffAdjManager::new(db.clone()).map_err(|e| e.to_string())?;
             rules.set_diff_manager(diff_adj_manager).map_err(|e| e.to_string())?;
@@ -198,11 +199,12 @@ pub fn configure_and_initialize_node(
                 max_history_len: 1000,
             };
             let backend = create_lmdb_database(&p, mct_config).map_err(|e| e.to_string())?;
+            let mut db = BlockchainDatabase::new(backend).map_err(|e| e.to_string())?;
             let validators = Validators::new(
-                FullConsensusValidator::new(rules.clone(), factories.clone()),
+                FullConsensusValidator::new(rules.clone(), factories.clone(), db.clone()),
                 StatelessValidator::new(factories.clone()),
             );
-            let db = BlockchainDatabase::new(backend, validators).map_err(|e| e.to_string())?;
+            db.add_validators(validators);
             let mempool = Mempool::new(db.clone(), MempoolConfig::default());
             let diff_adj_manager = DiffAdjManager::new(db.clone()).map_err(|e| e.to_string())?;
             rules.set_diff_manager(diff_adj_manager).map_err(|e| e.to_string())?;

--- a/base_layer/core/src/chain_storage/blockchain_database.rs
+++ b/base_layer/core/src/chain_storage/blockchain_database.rs
@@ -226,7 +226,7 @@ where T: BlockchainBackend
         })
     }
 
-    pub fn add_validators(&mut self, validators: Validators<T>) {
+    pub fn set_validators(&mut self, validators: Validators<T>) {
         self.validators = Some(validators);
     }
 

--- a/base_layer/core/src/helpers/mod.rs
+++ b/base_layer/core/src/helpers/mod.rs
@@ -48,5 +48,7 @@ pub fn create_orphan_block(block_height: u64, transactions: Vec<Transaction>) ->
 pub fn create_mem_db() -> BlockchainDatabase<MemoryDatabase<HashDigest>> {
     let validators = Validators::new(MockValidator::new(true), MockValidator::new(true));
     let db = MemoryDatabase::<HashDigest>::default();
-    BlockchainDatabase::new(db, validators).unwrap()
+    let mut db = BlockchainDatabase::new(db).unwrap();
+    db.add_validators(validators);
+    db
 }

--- a/base_layer/core/src/validation/block_validators.rs
+++ b/base_layer/core/src/validation/block_validators.rs
@@ -60,25 +60,18 @@ impl<B: BlockchainBackend> Validation<Block, B> for StatelessValidator {
 pub struct FullConsensusValidator<B: BlockchainBackend> {
     rules: ConsensusManager<B>,
     factories: Arc<CryptoFactories>,
-    db: Option<BlockchainDatabase<B>>,
+    db: BlockchainDatabase<B>,
 }
 
 impl<B: BlockchainBackend> FullConsensusValidator<B>
 where B: BlockchainBackend
 {
-    pub fn new(rules: ConsensusManager<B>, factories: Arc<CryptoFactories>) -> Self {
-        Self {
-            rules,
-            factories,
-            db: None,
-        }
+    pub fn new(rules: ConsensusManager<B>, factories: Arc<CryptoFactories>, db: BlockchainDatabase<B>) -> Self {
+        Self { rules, factories, db }
     }
 
     fn db(&self) -> Result<BlockchainDatabase<B>, ValidationError> {
-        match &self.db {
-            Some(db) => Ok(db.clone()),
-            None => Err(ValidationError::NoDatabaseConfigured),
-        }
+        Ok(self.db.clone())
     }
 }
 

--- a/base_layer/core/tests/chain_storage_tests/chain_storage.rs
+++ b/base_layer/core/tests/chain_storage_tests/chain_storage.rs
@@ -589,7 +589,8 @@ fn store_and_retrieve_block_with_mmr_pruning_horizon() {
     };
     let validators = Validators::new(MockValidator::new(true), MockValidator::new(true));
     let db = MemoryDatabase::<HashDigest>::new(mct_config);
-    let store = BlockchainDatabase::new(db, validators).unwrap();
+    let mut store = BlockchainDatabase::new(db).unwrap();
+    store.add_validators(validators);
 
     let (block0, _) = create_genesis_block(&store, &factories);
     store.add_block(block0.clone()).unwrap();

--- a/base_layer/core/tests/helpers/nodes.rs
+++ b/base_layer/core/tests/helpers/nodes.rs
@@ -154,7 +154,8 @@ impl BaseNodeBuilder {
             .validators
             .unwrap_or(Validators::new(MockValidator::new(true), MockValidator::new(true)));
         let db = MemoryDatabase::<HashDigest>::new(mct_config);
-        let blockchain_db = BlockchainDatabase::new(db, validators).unwrap();
+        let mut blockchain_db = BlockchainDatabase::new(db).unwrap();
+        blockchain_db.add_validators(validators);
         let mempool = Mempool::new(
             blockchain_db.clone(),
             self.mempool_config.unwrap_or(MempoolConfig::default()),

--- a/base_layer/core/tests/helpers/sample_blockchains.rs
+++ b/base_layer/core/tests/helpers/sample_blockchains.rs
@@ -124,7 +124,8 @@ pub fn create_new_blockchain() -> (
     // We may need move this to the parameters to provide more fine-grained validator control
     let validators = Validators::new(MockValidator::new(true), MockValidator::new(true));
     let db = MemoryDatabase::<HashDigest>::default();
-    let db = BlockchainDatabase::new(db, validators).unwrap();
+    let mut db = BlockchainDatabase::new(db).unwrap();
+    db.add_validators(validators);
     let mut outputs = Vec::new();
     let mut blocks = Vec::new();
     // Genesis Block


### PR DESCRIPTION
## Description
Refactored to the db to use an option<Validator>. This allows us to first construct the db. Then we can pass in the DB to the FullStateValidator which requires it to function. We then pass the validators in after construction of the db.  

## Motivation and Context
FullStateValidators require DB access

## How Has This Been Tested?
This is only a refactor and does not break any changes

## Types of changes
* [ ] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [x] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
* [x] I'm merging against the `development` branch
* [x] I ran `cargo-fmt --all` before pushing
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
