### PR TITLE
Added OutboundSendDiscoveryInProgress Error Code 

### DIFF
--- a/base_layer/wallet_ffi/src/error.rs
+++ b/base_layer/wallet_ffi/src/error.rs
@@ -173,6 +173,10 @@ impl From<WalletError> for LibWalletError {
                 code: 209,
                 message: format!("{:?}", w),
             },
+            WalletError::TransactionServiceError(TransactionServiceError::OutboundSendDiscoveryInProgress(_)) => Self {
+                code: 210,
+                message: format!("{:?}", w),
+            },
             // Comms Stack errors
             WalletError::MultiaddrError(_) => Self {
                 code: 301,


### PR DESCRIPTION
# Description
Small PR to add missing OutboundSendDiscoveryInProgress to WalletError

## Motivation and Context
Was being returned as the catch all error code (999) where it should be handled specifically by the client implementations

## How Has This Been Tested?
cargo test --all-features

## Types of changes
* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch
* [x] I ran `cargo-fmt --all` before pushing
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
