### PR TITLE
Request target difficulty and median timestamp with height

### DIFF
--- a/base_layer/core/src/proof_of_work/diff_adj_manager/diff_adj_manager.rs
+++ b/base_layer/core/src/proof_of_work/diff_adj_manager/diff_adj_manager.rs
@@ -49,7 +49,7 @@ where T: BlockchainBackend
         })
     }
 
-    /// Returns the estimated target difficulty for the specified PoW algorithm.
+    /// Returns the estimated target difficulty for the specified PoW algorithm at the chain tip.
     pub fn get_target_difficulty(&self, pow_algo: &PowAlgorithm) -> Result<Difficulty, DiffAdjManagerError> {
         self.diff_adj_storage
             .write()
@@ -57,12 +57,33 @@ where T: BlockchainBackend
             .get_target_difficulty(pow_algo)
     }
 
-    /// Returns the median timestamp of the past 11 blocks.
+    /// Returns the estimated target difficulty for the specified PoW algorithm and provided height.
+    pub fn get_target_difficulty_with_height(
+        &self,
+        pow_algo: &PowAlgorithm,
+        height: u64,
+    ) -> Result<Difficulty, DiffAdjManagerError>
+    {
+        self.diff_adj_storage
+            .write()
+            .map_err(|_| DiffAdjManagerError::PoisonedAccess)?
+            .get_target_difficulty_with_height(pow_algo, height)
+    }
+
+    /// Returns the median timestamp of the past 11 blocks at the chain tip.
     pub fn get_median_timestamp(&self) -> Result<EpochTime, DiffAdjManagerError> {
         self.diff_adj_storage
             .write()
             .map_err(|_| DiffAdjManagerError::PoisonedAccess)?
             .get_median_timestamp()
+    }
+
+    /// Returns the median timestamp of the past 11 blocks at the provided height.
+    pub fn get_median_timestamp_with_height(&mut self, height: u64) -> Result<EpochTime, DiffAdjManagerError> {
+        self.diff_adj_storage
+            .write()
+            .map_err(|_| DiffAdjManagerError::PoisonedAccess)?
+            .get_median_timestamp_with_height(height)
     }
 }
 

--- a/base_layer/core/src/proof_of_work/mod.rs
+++ b/base_layer/core/src/proof_of_work/mod.rs
@@ -34,7 +34,7 @@ pub mod lwma_diff;
 
 pub use blake_pow::{blake_difficulty, blake_difficulty_with_hash};
 pub use diff_adj_manager::{DiffAdjManager, DiffAdjManagerError};
-pub use difficulty::Difficulty;
+pub use difficulty::{Difficulty, DifficultyAdjustment};
 pub use error::{DifficultyAdjustmentError, PowError};
 pub use monero_rx::monero_difficulty;
 pub use proof_of_work::{PowAlgorithm, ProofOfWork};


### PR DESCRIPTION
## Description
- Added get_target_difficulty_with_height and get_median_timestamp_with_height function to the diff_adj_manager to enable the calculation of the target difficulty and median timestamp for any height in the chain and not only the tip. 
- Fixed an issue where the VecDeque of timestamps was not properly reset before full syncs with the blockchain db.
- Modified the diff_adj_manager tests to be less reliant on the calculated difficulties provided by lwma_diff, but rather test that the correct blocks were used in the calculation of the target difficulty and median timestamps.

## Motivation and Context
This change was required to check the PoW and timestamps of the synced horizon state.

## How Has This Been Tested?
Added test_target_difficulty_with_height and test_median_timestamp_with_height tests.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [x] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch
* [x] I ran `cargo-fmt --all` before pushing
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
