### PR TITLE
Perform header validation on synced blockchain horizon state

### DIFF
--- a/applications/tari_base_node/src/builder.rs
+++ b/applications/tari_base_node/src/builder.rs
@@ -51,7 +51,10 @@ use tari_core::{
     consensus::ConsensusManager,
     mempool::{Mempool, MempoolConfig},
     proof_of_work::DiffAdjManager,
-    validation::block_validators::{FullConsensusValidator, StatelessValidator},
+    validation::{
+        block_validators::{FullConsensusValidator, StatelessValidator},
+        horizon_state_validators::HorizonStateHeaderValidator,
+    },
 };
 use tari_mmr::MerkleChangeTrackerConfig;
 use tari_p2p::{
@@ -175,6 +178,7 @@ pub fn configure_and_initialize_node(
             let validators = Validators::new(
                 FullConsensusValidator::new(rules.clone(), factories.clone(), db.clone()),
                 StatelessValidator::new(factories.clone()),
+                HorizonStateHeaderValidator::new(rules.clone(), db.clone()),
             );
             db.set_validators(validators);
             let mempool = Mempool::new(db.clone(), MempoolConfig::default());
@@ -203,6 +207,7 @@ pub fn configure_and_initialize_node(
             let validators = Validators::new(
                 FullConsensusValidator::new(rules.clone(), factories.clone(), db.clone()),
                 StatelessValidator::new(factories.clone()),
+                HorizonStateHeaderValidator::new(rules.clone(), db.clone()),
             );
             db.set_validators(validators);
             let mempool = Mempool::new(db.clone(), MempoolConfig::default());

--- a/base_layer/core/src/blocks/block.rs
+++ b/base_layer/core/src/blocks/block.rs
@@ -22,11 +22,7 @@
 //
 // Portions of this file were originally copyrighted (c) 2018 The Grin Developers, issued under the Apache License,
 // Version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0.
-use crate::{
-    blocks::BlockHeader,
-    consensus::ConsensusConstants,
-    proof_of_work::{PowError, ProofOfWork},
-};
+use crate::{blocks::BlockHeader, consensus::ConsensusConstants, proof_of_work::ProofOfWork};
 use derive_error::Error;
 use serde::{Deserialize, Serialize};
 use std::fmt::{Display, Formatter};
@@ -41,8 +37,6 @@ use tari_utilities::Hashable;
 pub enum BlockValidationError {
     // A transaction in the block failed to validate
     TransactionError(TransactionError),
-    // Invalid Proof of work for the block
-    ProofOfWorkError(PowError),
     // Invalid kernel in block
     InvalidKernel,
     // Invalid input in block
@@ -53,8 +47,6 @@ pub enum BlockValidationError {
     InvalidCoinbase,
     // Mismatched MMR roots
     MismatchedMmrRoots,
-    // Invalid timestamp received on the block
-    InvalidTimestamp,
 }
 
 /// A Tari block. Blocks are linked together into a blockchain.

--- a/base_layer/core/src/blocks/blockheader.rs
+++ b/base_layer/core/src/blocks/blockheader.rs
@@ -39,9 +39,10 @@
 
 use crate::{
     blocks::NewBlockHeaderTemplate,
-    proof_of_work::{Difficulty, ProofOfWork},
+    proof_of_work::{Difficulty, PowError, ProofOfWork},
 };
 use chrono::{DateTime, Utc};
+use derive_error::Error;
 use digest::Digest;
 use serde::{
     de::{self, Visitor},
@@ -58,6 +59,20 @@ use tari_transactions::types::{BlindingFactor, HashDigest};
 use tari_utilities::{epoch_time::EpochTime, hex::Hex, ByteArray, Hashable};
 
 pub type BlockHash = Vec<u8>;
+
+#[derive(Clone, Debug, PartialEq, Error)]
+pub enum BlockHeaderValidationError {
+    // The Genesis block header is incorrectly chained
+    ChainedGenesisBlockHeader,
+    // Header does not form a valid chain
+    InvalidChaining,
+    // Invalid timestamp received on the header
+    InvalidTimestamp,
+    // Invalid timestamp future time limit received on the header
+    InvalidTimestampFutureTimeLimit,
+    // Invalid Proof of work for the header
+    ProofOfWorkError(PowError),
+}
 
 /// The BlockHeader contains all the metadata for the block, including proof of work, a link to the previous block
 /// and the transaction kernels.

--- a/base_layer/core/src/consensus/consensus_manager.rs
+++ b/base_layer/core/src/consensus/consensus_manager.rs
@@ -85,7 +85,7 @@ where B: BlockchainBackend
         }
     }
 
-    /// Returns the estimated target difficulty for the specified PoW algorithm.
+    /// Returns the estimated target difficulty for the specified PoW algorithm at the chain tip.
     pub fn get_target_difficulty(&self, pow_algo: &PowAlgorithm) -> Result<Difficulty, ConsensusManagerError> {
         match self.access_diff_adj()?.as_ref() {
             Some(v) => v
@@ -95,11 +95,36 @@ where B: BlockchainBackend
         }
     }
 
-    /// Returns the median timestamp of the past 11 blocks.
+    /// Returns the estimated target difficulty for the specified PoW algorithm and provided height.
+    pub fn get_target_difficulty_with_height(
+        &self,
+        pow_algo: &PowAlgorithm,
+        height: u64,
+    ) -> Result<Difficulty, ConsensusManagerError>
+    {
+        match self.access_diff_adj()?.as_ref() {
+            Some(v) => v
+                .get_target_difficulty_at_height(pow_algo, height)
+                .map_err(|e| ConsensusManagerError::DifficultyAdjustmentManagerError(e)),
+            None => Err(ConsensusManagerError::MissingDifficultyAdjustmentManager),
+        }
+    }
+
+    /// Returns the median timestamp of the past 11 blocks at the chain tip.
     pub fn get_median_timestamp(&self) -> Result<EpochTime, ConsensusManagerError> {
         match self.access_diff_adj()?.as_ref() {
             Some(v) => v
                 .get_median_timestamp()
+                .map_err(|e| ConsensusManagerError::DifficultyAdjustmentManagerError(e)),
+            None => Err(ConsensusManagerError::MissingDifficultyAdjustmentManager),
+        }
+    }
+
+    /// Returns the median timestamp of the past 11 blocks at the provided height.
+    pub fn get_median_timestamp_at_height(&self, height: u64) -> Result<EpochTime, ConsensusManagerError> {
+        match self.access_diff_adj()?.as_ref() {
+            Some(v) => v
+                .get_median_timestamp_at_height(height)
                 .map_err(|e| ConsensusManagerError::DifficultyAdjustmentManagerError(e)),
             None => Err(ConsensusManagerError::MissingDifficultyAdjustmentManager),
         }

--- a/base_layer/core/src/helpers/mod.rs
+++ b/base_layer/core/src/helpers/mod.rs
@@ -46,7 +46,11 @@ pub fn create_orphan_block(block_height: u64, transactions: Vec<Transaction>) ->
 }
 
 pub fn create_mem_db() -> BlockchainDatabase<MemoryDatabase<HashDigest>> {
-    let validators = Validators::new(MockValidator::new(true), MockValidator::new(true));
+    let validators = Validators::new(
+        MockValidator::new(true),
+        MockValidator::new(true),
+        MockValidator::new(true),
+    );
     let db = MemoryDatabase::<HashDigest>::default();
     let mut db = BlockchainDatabase::new(db).unwrap();
     db.set_validators(validators);

--- a/base_layer/core/src/proof_of_work/diff_adj_manager/diff_adj_manager.rs
+++ b/base_layer/core/src/proof_of_work/diff_adj_manager/diff_adj_manager.rs
@@ -58,7 +58,7 @@ where T: BlockchainBackend
     }
 
     /// Returns the estimated target difficulty for the specified PoW algorithm and provided height.
-    pub fn get_target_difficulty_with_height(
+    pub fn get_target_difficulty_at_height(
         &self,
         pow_algo: &PowAlgorithm,
         height: u64,
@@ -67,7 +67,7 @@ where T: BlockchainBackend
         self.diff_adj_storage
             .write()
             .map_err(|_| DiffAdjManagerError::PoisonedAccess)?
-            .get_target_difficulty_with_height(pow_algo, height)
+            .get_target_difficulty_at_height(pow_algo, height)
     }
 
     /// Returns the median timestamp of the past 11 blocks at the chain tip.
@@ -79,11 +79,11 @@ where T: BlockchainBackend
     }
 
     /// Returns the median timestamp of the past 11 blocks at the provided height.
-    pub fn get_median_timestamp_with_height(&mut self, height: u64) -> Result<EpochTime, DiffAdjManagerError> {
+    pub fn get_median_timestamp_at_height(&self, height: u64) -> Result<EpochTime, DiffAdjManagerError> {
         self.diff_adj_storage
             .write()
             .map_err(|_| DiffAdjManagerError::PoisonedAccess)?
-            .get_median_timestamp_with_height(height)
+            .get_median_timestamp_at_height(height)
     }
 }
 

--- a/base_layer/core/src/proof_of_work/diff_adj_manager/diff_adj_storage.rs
+++ b/base_layer/core/src/proof_of_work/diff_adj_manager/diff_adj_storage.rs
@@ -116,11 +116,11 @@ where T: BlockchainBackend
     /// Returns the estimated target difficulty for the specified PoW algorithm at the chain tip.
     pub fn get_target_difficulty(&mut self, pow_algo: &PowAlgorithm) -> Result<Difficulty, DiffAdjManagerError> {
         let height = self.get_height_of_longest_chain()?;
-        self.get_target_difficulty_with_height(pow_algo, height)
+        self.get_target_difficulty_at_height(pow_algo, height)
     }
 
     /// Returns the estimated target difficulty for the specified PoW algorithm and provided height.
-    pub fn get_target_difficulty_with_height(
+    pub fn get_target_difficulty_at_height(
         &mut self,
         pow_algo: &PowAlgorithm,
         height: u64,
@@ -136,11 +136,11 @@ where T: BlockchainBackend
     /// Returns the median timestamp of the past 11 blocks at the chain tip.
     pub fn get_median_timestamp(&mut self) -> Result<EpochTime, DiffAdjManagerError> {
         let height = self.get_height_of_longest_chain()?;
-        self.get_median_timestamp_with_height(height)
+        self.get_median_timestamp_at_height(height)
     }
 
     /// Returns the median timestamp of the past 11 blocks at the provided height.
-    pub fn get_median_timestamp_with_height(&mut self, height: u64) -> Result<EpochTime, DiffAdjManagerError> {
+    pub fn get_median_timestamp_at_height(&mut self, height: u64) -> Result<EpochTime, DiffAdjManagerError> {
         self.update(height)?;
         let mut length = self.timestamps.len();
         if length == 0 {

--- a/base_layer/core/src/validation/error.rs
+++ b/base_layer/core/src/validation/error.rs
@@ -20,12 +20,13 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use crate::blocks::BlockValidationError;
+use crate::blocks::{blockheader::BlockHeaderValidationError, BlockValidationError};
 use derive_error::Error;
 use tari_transactions::transaction::TransactionError;
 
 #[derive(Clone, Debug, PartialEq, Error)]
 pub enum ValidationError {
+    BlockHeaderError(BlockHeaderValidationError),
     BlockError(BlockValidationError),
     TransactionError(TransactionError),
     /// Custom error with string message

--- a/base_layer/core/src/validation/helpers.rs
+++ b/base_layer/core/src/validation/helpers.rs
@@ -1,0 +1,110 @@
+// Copyright 2019. The Tari Project
+//
+// Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+// following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+// disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+// following disclaimer in the documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+// products derived from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+// INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+// WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+// USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+use crate::{
+    blocks::{
+        blockheader::{BlockHeader, BlockHeaderValidationError},
+        genesis_block::get_gen_block_hash,
+    },
+    chain_storage::{BlockchainBackend, BlockchainDatabase},
+    consensus::ConsensusManager,
+    proof_of_work::PowError,
+    validation::ValidationError,
+};
+use tari_utilities::hash::Hashable;
+
+/// This function tests that the block timestamp is greater than the median timestamp at the chain tip.
+pub fn check_median_timestamp_at_chain_tip<B: BlockchainBackend>(
+    block_header: &BlockHeader,
+    db: BlockchainDatabase<B>,
+    rules: ConsensusManager<B>,
+) -> Result<(), ValidationError>
+{
+    let tip_height = db
+        .get_metadata()
+        .map_err(|e| ValidationError::CustomError(e.to_string()))?
+        .height_of_longest_chain
+        .unwrap_or(0);
+    check_median_timestamp(&block_header, tip_height, rules)
+}
+
+/// This function tests that the block timestamp is greater than the median timestamp at the specified height.
+pub fn check_median_timestamp<B: BlockchainBackend>(
+    block_header: &BlockHeader,
+    height: u64,
+    rules: ConsensusManager<B>,
+) -> Result<(), ValidationError>
+{
+    if block_header.height == 0 || get_gen_block_hash() == block_header.hash() {
+        return Ok(()); // Its the genesis block, so we dont have to check median
+    }
+    let median_timestamp = rules
+        .get_median_timestamp_at_height(height)
+        .map_err(|_| ValidationError::BlockHeaderError(BlockHeaderValidationError::InvalidTimestamp))?;
+    if block_header.timestamp < median_timestamp {
+        return Err(ValidationError::BlockHeaderError(
+            BlockHeaderValidationError::InvalidTimestamp,
+        ));
+    }
+    Ok(())
+}
+
+/// Calculates the achieved and target difficulties at the chain tip and compares them.
+pub fn check_achieved_difficulty_at_chain_tip<B: BlockchainBackend>(
+    block_header: &BlockHeader,
+    db: BlockchainDatabase<B>,
+    rules: ConsensusManager<B>,
+) -> Result<(), ValidationError>
+{
+    let tip_height = db
+        .get_metadata()
+        .map_err(|e| ValidationError::CustomError(e.to_string()))?
+        .height_of_longest_chain
+        .unwrap_or(0);
+    check_achieved_difficulty(&block_header, tip_height, rules)
+}
+
+/// Calculates the achieved and target difficulties at the specified height and compares them.
+pub fn check_achieved_difficulty<B: BlockchainBackend>(
+    block_header: &BlockHeader,
+    height: u64,
+    rules: ConsensusManager<B>,
+) -> Result<(), ValidationError>
+{
+    let achieved = block_header.achieved_difficulty();
+    let mut target = 1.into();
+    if block_header.height > 0 || get_gen_block_hash() != block_header.hash() {
+        target = rules
+            .get_target_difficulty_with_height(&block_header.pow.pow_algo, height)
+            .map_err(|_| {
+                ValidationError::BlockHeaderError(BlockHeaderValidationError::ProofOfWorkError(
+                    PowError::InvalidProofOfWork,
+                ))
+            })?;
+    }
+    if achieved < target {
+        return Err(ValidationError::BlockHeaderError(
+            BlockHeaderValidationError::ProofOfWorkError(PowError::AchievedDifficultyTooLow),
+        ));
+    }
+    Ok(())
+}

--- a/base_layer/core/src/validation/horizon_state_validators.rs
+++ b/base_layer/core/src/validation/horizon_state_validators.rs
@@ -1,0 +1,98 @@
+// Copyright 2019. The Tari Project
+//
+// Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+// following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+// disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+// following disclaimer in the documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+// products derived from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+// INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+// WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+// USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+pub use crate::consensus::ConsensusManager;
+use crate::{
+    blocks::blockheader::{BlockHeader, BlockHeaderValidationError},
+    chain_storage::{BlockchainBackend, BlockchainDatabase},
+    validation::{
+        error::ValidationError,
+        helpers::{check_achieved_difficulty, check_median_timestamp},
+        traits::Validation,
+    },
+};
+
+/// This validator check that the synced horizon state headers satisfies *all* consensus rules.
+pub struct HorizonStateHeaderValidator<B: BlockchainBackend> {
+    rules: ConsensusManager<B>,
+    db: BlockchainDatabase<B>,
+}
+
+impl<B: BlockchainBackend> HorizonStateHeaderValidator<B>
+where B: BlockchainBackend
+{
+    pub fn new(rules: ConsensusManager<B>, db: BlockchainDatabase<B>) -> Self {
+        Self { rules, db }
+    }
+
+    fn db(&self) -> Result<BlockchainDatabase<B>, ValidationError> {
+        Ok(self.db.clone())
+    }
+}
+
+impl<B: BlockchainBackend> Validation<BlockHeader, B> for HorizonStateHeaderValidator<B> {
+    /// The consensus checks that are done (in order of cheapest to verify to most expensive):
+    /// 1. Do the headers form a valid sequence and are they correctly chained?
+    /// 1. Is the block header timestamp greater than the median timestamp?
+    /// 1. Is the Proof of Work valid and is the achieved difficulty of this block >= the target difficulty for this
+    /// block?
+    fn validate(&self, block_header: &BlockHeader) -> Result<(), ValidationError> {
+        check_header_sequence_and_chaining(block_header, self.db()?)?;
+        check_median_timestamp(&block_header, block_header.height, self.rules.clone())?;
+        check_achieved_difficulty(&block_header, block_header.height, self.rules.clone())?;
+
+        Ok(())
+    }
+}
+
+/// Check that the headers form a valid sequence and that the headers are correctly chained.
+fn check_header_sequence_and_chaining<B: BlockchainBackend>(
+    block_header: &BlockHeader,
+    db: BlockchainDatabase<B>,
+) -> Result<(), ValidationError>
+{
+    if block_header.height == 0 {
+        if block_header.prev_hash != vec![0; 32] {
+            return Err(ValidationError::BlockHeaderError(
+                BlockHeaderValidationError::ChainedGenesisBlockHeader,
+            ));
+        }
+        return Ok(());
+    }
+
+    match db.fetch_header_with_block_hash(block_header.prev_hash.clone()) {
+        Ok(prev_block_header) => {
+            if block_header.height != prev_block_header.height + 1 {
+                return Err(ValidationError::BlockHeaderError(
+                    BlockHeaderValidationError::InvalidChaining,
+                ));
+            }
+        },
+        Err(_) => {
+            return Err(ValidationError::BlockHeaderError(
+                BlockHeaderValidationError::InvalidChaining,
+            ));
+        },
+    }
+
+    Ok(())
+}

--- a/base_layer/core/src/validation/mod.rs
+++ b/base_layer/core/src/validation/mod.rs
@@ -28,9 +28,11 @@
 //! without having to bring in all sorts of blockchain and communications paraphernalia.
 
 mod error;
+mod helpers;
 mod traits;
 
 pub mod block_validators;
+pub mod horizon_state_validators;
 pub mod mocks;
 pub use error::ValidationError;
 pub use traits::{Validation, Validator};

--- a/base_layer/core/src/validation/traits.rs
+++ b/base_layer/core/src/validation/traits.rs
@@ -20,10 +20,7 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use crate::{
-    chain_storage::{BlockchainBackend, BlockchainDatabase},
-    validation::error::ValidationError,
-};
+use crate::{chain_storage::BlockchainBackend, validation::error::ValidationError};
 
 pub type Validator<T, B> = Box<dyn Validation<T, B>>;
 
@@ -35,8 +32,4 @@ where B: BlockchainBackend
 {
     /// General validation code that can run independent of external state
     fn validate(&self, item: &T) -> Result<(), ValidationError>;
-    #[allow(unused_variables)]
-    fn set_db(&mut self, db: BlockchainDatabase<B>) {
-        // noop
-    }
 }

--- a/base_layer/core/tests/block_validation.rs
+++ b/base_layer/core/tests/block_validation.rs
@@ -26,7 +26,10 @@ use tari_core::{
     chain_storage::{BlockchainDatabase, MemoryDatabase, Validators},
     consensus::ConsensusManager,
     proof_of_work::DiffAdjManager,
-    validation::block_validators::{FullConsensusValidator, StatelessValidator},
+    validation::{
+        block_validators::{FullConsensusValidator, StatelessValidator},
+        mocks::MockValidator,
+    },
 };
 use tari_transactions::types::{CryptoFactories, HashDigest};
 
@@ -39,6 +42,7 @@ fn test_genesis_block() {
     let validators = Validators::new(
         FullConsensusValidator::new(rules.clone(), factories.clone(), db.clone()),
         StatelessValidator::new(factories.clone()),
+        MockValidator::new(true),
     );
     db.set_validators(validators);
     let diff_adj_manager = DiffAdjManager::new(db.clone()).unwrap();

--- a/base_layer/core/tests/chain_storage_tests/chain_storage.rs
+++ b/base_layer/core/tests/chain_storage_tests/chain_storage.rs
@@ -510,7 +510,11 @@ fn store_and_retrieve_block_with_mmr_pruning_horizon() {
         min_history_len: 2,
         max_history_len: 3,
     };
-    let validators = Validators::new(MockValidator::new(true), MockValidator::new(true));
+    let validators = Validators::new(
+        MockValidator::new(true),
+        MockValidator::new(true),
+        MockValidator::new(true),
+    );
     let db = MemoryDatabase::<HashDigest>::new(mct_config);
     let mut store = BlockchainDatabase::new(db).unwrap();
     store.set_validators(validators);
@@ -533,5 +537,3 @@ fn store_and_retrieve_block_with_mmr_pruning_horizon() {
     assert_eq!(*store.fetch_block(2).unwrap().block(), block2);
     assert_eq!(*store.fetch_block(3).unwrap().block(), block3);
 }
-
-// TODO: add validate_horizon_state test

--- a/base_layer/core/tests/diff_adj_manager.rs
+++ b/base_layer/core/tests/diff_adj_manager.rs
@@ -168,10 +168,10 @@ fn test_target_difficulty_with_height() {
     let store = create_mem_db();
     let diff_adj_manager = DiffAdjManager::new(store.clone()).unwrap();
     assert!(diff_adj_manager
-        .get_target_difficulty_with_height(&PowAlgorithm::Monero, 5)
+        .get_target_difficulty_at_height(&PowAlgorithm::Monero, 5)
         .is_err());
     assert!(diff_adj_manager
-        .get_target_difficulty_with_height(&PowAlgorithm::Blake, 5)
+        .get_target_difficulty_at_height(&PowAlgorithm::Blake, 5)
         .is_err());
 
     let pow_algos = vec![
@@ -186,29 +186,29 @@ fn test_target_difficulty_with_height() {
     let diff_adj_manager = DiffAdjManager::new(store.clone()).unwrap();
 
     assert_eq!(
-        diff_adj_manager.get_target_difficulty_with_height(&PowAlgorithm::Monero, 5),
+        diff_adj_manager.get_target_difficulty_at_height(&PowAlgorithm::Monero, 5),
         Ok(calculate_accumulated_difficulty(&store, vec![1, 4]))
     );
     assert_eq!(
-        diff_adj_manager.get_target_difficulty_with_height(&PowAlgorithm::Blake, 5),
+        diff_adj_manager.get_target_difficulty_at_height(&PowAlgorithm::Blake, 5),
         Ok(calculate_accumulated_difficulty(&store, vec![0, 2, 3, 5]))
     );
 
     assert_eq!(
-        diff_adj_manager.get_target_difficulty_with_height(&PowAlgorithm::Monero, 2),
+        diff_adj_manager.get_target_difficulty_at_height(&PowAlgorithm::Monero, 2),
         Ok(calculate_accumulated_difficulty(&store, vec![1]))
     );
     assert_eq!(
-        diff_adj_manager.get_target_difficulty_with_height(&PowAlgorithm::Blake, 2),
+        diff_adj_manager.get_target_difficulty_at_height(&PowAlgorithm::Blake, 2),
         Ok(calculate_accumulated_difficulty(&store, vec![0, 2]))
     );
 
     assert_eq!(
-        diff_adj_manager.get_target_difficulty_with_height(&PowAlgorithm::Monero, 3),
+        diff_adj_manager.get_target_difficulty_at_height(&PowAlgorithm::Monero, 3),
         Ok(calculate_accumulated_difficulty(&store, vec![1]))
     );
     assert_eq!(
-        diff_adj_manager.get_target_difficulty_with_height(&PowAlgorithm::Blake, 3),
+        diff_adj_manager.get_target_difficulty_at_height(&PowAlgorithm::Blake, 3),
         Ok(calculate_accumulated_difficulty(&store, vec![0, 2, 3]))
     );
 }
@@ -319,7 +319,7 @@ fn test_median_timestamp() {
 #[test]
 fn test_median_timestamp_with_height() {
     let store = create_mem_db();
-    let mut diff_adj_manager = DiffAdjManager::new(store.clone()).unwrap();
+    let diff_adj_manager = DiffAdjManager::new(store.clone()).unwrap();
     let pow_algos = vec![
         PowAlgorithm::Blake, // GB default
         PowAlgorithm::Monero,
@@ -334,22 +334,22 @@ fn test_median_timestamp_with_height() {
     let header2_timestamp = store.fetch_header(2).unwrap().timestamp;
 
     let timestamp = diff_adj_manager
-        .get_median_timestamp_with_height(0)
+        .get_median_timestamp_at_height(0)
         .expect("median returned an error");
     assert_eq!(timestamp, header0_timestamp);
 
     let timestamp = diff_adj_manager
-        .get_median_timestamp_with_height(3)
+        .get_median_timestamp_at_height(3)
         .expect("median returned an error");
     assert_eq!(timestamp, header2_timestamp);
 
     let timestamp = diff_adj_manager
-        .get_median_timestamp_with_height(2)
+        .get_median_timestamp_at_height(2)
         .expect("median returned an error");
     assert_eq!(timestamp, header1_timestamp);
 
     let timestamp = diff_adj_manager
-        .get_median_timestamp_with_height(4)
+        .get_median_timestamp_at_height(4)
         .expect("median returned an error");
     assert_eq!(timestamp, header2_timestamp);
 }

--- a/base_layer/core/tests/helpers/block_builders.rs
+++ b/base_layer/core/tests/helpers/block_builders.rs
@@ -22,16 +22,8 @@
 
 use tari_core::{
     blocks::{Block, BlockBuilder, BlockHeader, NewBlockTemplate},
-    chain_storage::{
-        BlockAddResult,
-        BlockchainBackend,
-        BlockchainDatabase,
-        ChainStorageError,
-        MemoryDatabase,
-        Validators,
-    },
+    chain_storage::{BlockAddResult, BlockchainBackend, BlockchainDatabase, ChainStorageError, MemoryDatabase},
     consensus::emission::EmissionSchedule,
-    validation::mocks::MockValidator,
 };
 use tari_transactions::{
     helpers::{

--- a/base_layer/core/tests/helpers/nodes.rs
+++ b/base_layer/core/tests/helpers/nodes.rs
@@ -35,7 +35,7 @@ use tari_core::{
         LocalNodeCommsInterface,
         OutboundNodeCommsInterface,
     },
-    blocks::Block,
+    blocks::{Block, BlockHeader},
     chain_storage::{BlockchainDatabase, MemoryDatabase, Validators},
     consensus::ConsensusManager,
     mempool::{
@@ -137,9 +137,10 @@ impl BaseNodeBuilder {
         mut self,
         block: impl Validation<Block, MemoryDatabase<HashDigest>> + 'static,
         orphan: impl Validation<Block, MemoryDatabase<HashDigest>> + 'static,
+        horizon_state_header: impl Validation<BlockHeader, MemoryDatabase<HashDigest>> + 'static,
     ) -> Self
     {
-        let validators = Validators::new(block, orphan);
+        let validators = Validators::new(block, orphan, horizon_state_header);
         self.validators = Some(validators);
         self
     }
@@ -150,9 +151,11 @@ impl BaseNodeBuilder {
             min_history_len: 10,
             max_history_len: 20,
         });
-        let validators = self
-            .validators
-            .unwrap_or(Validators::new(MockValidator::new(true), MockValidator::new(true)));
+        let validators = self.validators.unwrap_or(Validators::new(
+            MockValidator::new(true),
+            MockValidator::new(true),
+            MockValidator::new(true),
+        ));
         let db = MemoryDatabase::<HashDigest>::new(mct_config);
         let mut blockchain_db = BlockchainDatabase::new(db).unwrap();
         blockchain_db.set_validators(validators);

--- a/base_layer/core/tests/helpers/sample_blockchains.rs
+++ b/base_layer/core/tests/helpers/sample_blockchains.rs
@@ -122,7 +122,11 @@ pub fn create_new_blockchain() -> (
 ) {
     let factories = CryptoFactories::default();
     // We may need move this to the parameters to provide more fine-grained validator control
-    let validators = Validators::new(MockValidator::new(true), MockValidator::new(true));
+    let validators = Validators::new(
+        MockValidator::new(true),
+        MockValidator::new(true),
+        MockValidator::new(true),
+    );
     let db = MemoryDatabase::<HashDigest>::default();
     let mut db = BlockchainDatabase::new(db).unwrap();
     db.set_validators(validators);

--- a/base_layer/core/tests/horizon_state_validators.rs
+++ b/base_layer/core/tests/horizon_state_validators.rs
@@ -1,0 +1,143 @@
+// Copyright 2019. The Tari Project
+//
+// Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+// following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+// disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+// following disclaimer in the documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+// products derived from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+// INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+// WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+// USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+use tari_core::{
+    blocks::BlockHeader,
+    chain_storage::{BlockchainDatabase, DbTransaction, MemoryDatabase, Validators},
+    consensus::{ConsensusConstants, ConsensusManager},
+    proof_of_work::{DiffAdjManager, Difficulty},
+    validation::{horizon_state_validators::HorizonStateHeaderValidator, mocks::MockValidator},
+};
+use tari_transactions::types::HashDigest;
+
+fn find_header_with_achieved_difficulty(header: &mut BlockHeader, achieved_difficulty: Difficulty) {
+    while header.achieved_difficulty() != achieved_difficulty {
+        header.nonce += 1;
+    }
+}
+
+#[test]
+fn validate_header_sequence_and_chaining() {
+    let db = MemoryDatabase::<HashDigest>::default();
+    let mut store = BlockchainDatabase::new(db).unwrap();
+    let rules = ConsensusManager::default();
+    let validators = Validators::new(
+        MockValidator::new(true),
+        MockValidator::new(true),
+        HorizonStateHeaderValidator::new(rules, store.clone()),
+    );
+    store.set_validators(validators);
+
+    let header0 = BlockHeader::new(0);
+    let header1 = BlockHeader::from_previous(&header0);
+    let mut header2 = BlockHeader::from_previous(&header1);
+    header2.prev_hash = header0.prev_hash.clone(); // Change to incorrect hash chain
+
+    let mut txn = DbTransaction::new();
+    txn.insert_header(header0);
+    txn.insert_header(header1);
+    txn.insert_header(header2);
+    assert!(store.commit(txn).is_ok());
+    assert!(store.validate_horizon_state().is_err());
+}
+
+#[test]
+fn validate_median_timestamp() {
+    let db = MemoryDatabase::<HashDigest>::default();
+    let mut store = BlockchainDatabase::new(db).unwrap();
+    let consensus = ConsensusConstants::current();
+    let rules = ConsensusManager::default();
+    rules
+        .set_diff_manager(DiffAdjManager::new(store.clone()).unwrap())
+        .unwrap();
+    let validators = Validators::new(
+        MockValidator::new(true),
+        MockValidator::new(true),
+        HorizonStateHeaderValidator::new(rules, store.clone()),
+    );
+    store.set_validators(validators);
+
+    let mut header0 = BlockHeader::new(0);
+    find_header_with_achieved_difficulty(&mut header0, Difficulty::from(1));
+    let mut header1 = BlockHeader::from_previous(&header0);
+    header1.timestamp = header0.timestamp.increase(consensus.get_diff_target_block_interval());
+    find_header_with_achieved_difficulty(&mut header1, Difficulty::from(1));
+    let mut header2 = BlockHeader::from_previous(&header1);
+    header2.timestamp = header1.timestamp.increase(consensus.get_diff_target_block_interval());
+    find_header_with_achieved_difficulty(&mut header2, Difficulty::from(1));
+    let mut header3 = BlockHeader::from_previous(&header2);
+    header3.timestamp = header0.timestamp;
+    find_header_with_achieved_difficulty(&mut header3, Difficulty::from(1));
+
+    let mut txn = DbTransaction::new();
+    txn.insert_header(header0);
+    txn.insert_header(header1);
+    txn.insert_header(header2);
+    assert!(store.commit(txn).is_ok());
+    assert!(store.validate_horizon_state().is_ok());
+
+    let mut txn = DbTransaction::new();
+    txn.insert_header(header3);
+    assert!(store.commit(txn).is_ok());
+    assert!(store.validate_horizon_state().is_err());
+}
+
+#[test]
+fn validate_achieved_difficulty() {
+    let db = MemoryDatabase::<HashDigest>::default();
+    let mut store = BlockchainDatabase::new(db).unwrap();
+    let consensus = ConsensusConstants::current();
+    let rules = ConsensusManager::default();
+    rules
+        .set_diff_manager(DiffAdjManager::new(store.clone()).unwrap())
+        .unwrap();
+    let validators = Validators::new(
+        MockValidator::new(true),
+        MockValidator::new(true),
+        HorizonStateHeaderValidator::new(rules, store.clone()),
+    );
+    store.set_validators(validators);
+
+    let mut header0 = BlockHeader::new(0);
+    find_header_with_achieved_difficulty(&mut header0, Difficulty::from(1));
+    let mut header1 = BlockHeader::from_previous(&header0);
+    header1.timestamp = header0.timestamp.increase(consensus.get_diff_target_block_interval());
+    find_header_with_achieved_difficulty(&mut header1, Difficulty::from(1));
+    let mut header2 = BlockHeader::from_previous(&header1);
+    header2.timestamp = header1.timestamp.increase(consensus.get_diff_target_block_interval());
+    find_header_with_achieved_difficulty(&mut header2, Difficulty::from(4));
+    let mut header3 = BlockHeader::from_previous(&header2);
+    header3.timestamp = header3.timestamp.increase(consensus.get_diff_target_block_interval());
+    find_header_with_achieved_difficulty(&mut header3, Difficulty::from(2));
+
+    let mut txn = DbTransaction::new();
+    txn.insert_header(header0);
+    txn.insert_header(header1);
+    txn.insert_header(header2);
+    assert!(store.commit(txn).is_ok());
+    assert!(store.validate_horizon_state().is_ok());
+
+    let mut txn = DbTransaction::new();
+    txn.insert_header(header3);
+    assert!(store.commit(txn).is_ok());
+    assert!(store.validate_horizon_state().is_err());
+}


### PR DESCRIPTION
## Description
- Added the HorizonStateHeaderValidator for checking chaining, PoW and timestamps of the synced headers. 
- Added the horizon state header validator to the validators of the blockchain database and implemented the validate_horizon state function.
- Created a BlockHeaderValidationError and moved some of the header specific errors from BlockValidationError to the new error type.
- Exposed the get_target_difficulty_with_height and get_median_timestamp_with_height functions in the consensus manager.
- Split the timestamp FTL and median timestamp check into two separate checks to allow the median timestamp check code to be reused by the horizon state validator.
- Moved the common validation check functions to a helpers file.
- Removed the unused set_db function from the Validation trait.

## Motivation and Context
Horizon state validation is required to ensure that the synced blockchain state is valid.

## How Has This Been Tested?
Added tests for checking valid and invalid header sequences and header hash chaining, validating median timestamps and validating the achieved difficulty of the synced headers.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [x] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [x] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch
* [x] I ran `cargo-fmt --all` before pushing
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
