### PR TITLE
Bitmap init

### DIFF
--- a/base_layer/core/src/chain_storage/lmdb_db/mod.rs
+++ b/base_layer/core/src/chain_storage/lmdb_db/mod.rs
@@ -42,3 +42,5 @@ pub const LMDB_DB_KERNEL_MMR_BASE_BACKEND: &str = "kernel_mmr_base_backend";
 pub const LMDB_DB_KERNEL_MMR_CP_BACKEND: &str = "kernel_mmr_cp_backend";
 pub const LMDB_DB_RANGE_PROOF_MMR_BASE_BACKEND: &str = "range_proof_mmr_base_backend";
 pub const LMDB_DB_RANGE_PROOF_MMR_CP_BACKEND: &str = "range_proof_mmr_cp_backend";
+pub const LMDB_DB_MMR_BITMAPS: &str = "mmr_bitmaps";
+pub const LMDB_UTXO_BITMAP_KEY: u16 = 1;

--- a/base_layer/core/src/chain_storage/memory_db.rs
+++ b/base_layer/core/src/chain_storage/memory_db.rs
@@ -30,6 +30,7 @@ use crate::{
         error::ChainStorageError,
     },
 };
+use croaring::Bitmap;
 use digest::Digest;
 use std::{
     collections::HashMap,
@@ -91,11 +92,14 @@ where D: Digest
 {
     pub fn new(mct_config: MerkleChangeTrackerConfig) -> Self {
         let utxo_mmr =
-            MerkleChangeTracker::<D, _, _>::new(MutableMmr::new(Vec::new()), Vec::new(), mct_config).unwrap();
+            MerkleChangeTracker::<D, _, _>::new(MutableMmr::new(Vec::new(), Bitmap::create()), Vec::new(), mct_config)
+                .unwrap();
         let kernel_mmr =
-            MerkleChangeTracker::<D, _, _>::new(MutableMmr::new(Vec::new()), Vec::new(), mct_config).unwrap();
+            MerkleChangeTracker::<D, _, _>::new(MutableMmr::new(Vec::new(), Bitmap::create()), Vec::new(), mct_config)
+                .unwrap();
         let range_proof_mmr =
-            MerkleChangeTracker::<D, _, _>::new(MutableMmr::new(Vec::new()), Vec::new(), mct_config).unwrap();
+            MerkleChangeTracker::<D, _, _>::new(MutableMmr::new(Vec::new(), Bitmap::create()), Vec::new(), mct_config)
+                .unwrap();
         Self {
             db: Arc::new(RwLock::new(InnerDatabase {
                 metadata: HashMap::default(),
@@ -494,11 +498,14 @@ where D: Digest
             max_history_len: 1000,
         };
         let utxo_mmr =
-            MerkleChangeTracker::<D, _, _>::new(MutableMmr::new(Vec::new()), Vec::new(), mct_config).unwrap();
+            MerkleChangeTracker::<D, _, _>::new(MutableMmr::new(Vec::new(), Bitmap::create()), Vec::new(), mct_config)
+                .unwrap();
         let kernel_mmr =
-            MerkleChangeTracker::<D, _, _>::new(MutableMmr::new(Vec::new()), Vec::new(), mct_config).unwrap();
+            MerkleChangeTracker::<D, _, _>::new(MutableMmr::new(Vec::new(), Bitmap::create()), Vec::new(), mct_config)
+                .unwrap();
         let range_proof_mmr =
-            MerkleChangeTracker::<D, _, _>::new(MutableMmr::new(Vec::new()), Vec::new(), mct_config).unwrap();
+            MerkleChangeTracker::<D, _, _>::new(MutableMmr::new(Vec::new(), Bitmap::create()), Vec::new(), mct_config)
+                .unwrap();
         Self {
             metadata: HashMap::default(),
             headers: HashMap::default(),
@@ -569,7 +576,7 @@ mod test {
         deleted.add(3);
         let state = MutableMmrLeafNodes::new(hashes, deleted);
         // Create a local version of the MMR
-        let mut mmr = MutableMmr::<HashDigest, _>::new(Vec::new());
+        let mut mmr = MutableMmr::<HashDigest, _>::new(Vec::new(), Bitmap::create());
         // Assign the state to the DB backend and compare roots
         mmr.assign(state.clone()).unwrap();
         let root = mmr.get_merkle_root().unwrap();

--- a/base_layer/core/tests/chain_storage_tests/chain_backend.rs
+++ b/base_layer/core/tests/chain_storage_tests/chain_backend.rs
@@ -20,6 +20,7 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+use croaring::Bitmap;
 use tari_core::{
     blocks::BlockHeader,
     chain_storage::{
@@ -387,7 +388,7 @@ fn fetch_mmr_root_and_proof_for_utxo_and_rp<T: BlockchainBackend>(db: T) {
     txn.insert_utxo(utxo3.clone(), true);
     assert!(db.write(txn).is_ok());
 
-    let mut utxo_mmr_check = MutableMmr::<HashDigest, _>::new(Vec::new());
+    let mut utxo_mmr_check = MutableMmr::<HashDigest, _>::new(Vec::new(), Bitmap::create());
     assert!(utxo_mmr_check.push(&utxo_hash1).is_ok());
     assert!(utxo_mmr_check.push(&utxo_hash2).is_ok());
     assert!(utxo_mmr_check.push(&utxo_hash3).is_ok());
@@ -404,7 +405,7 @@ fn fetch_mmr_root_and_proof_for_utxo_and_rp<T: BlockchainBackend>(db: T) {
     assert!(proof2.verify_leaf::<HashDigest>(&mmr_only_root, &utxo_hash2, 1).is_ok());
     assert!(proof3.verify_leaf::<HashDigest>(&mmr_only_root, &utxo_hash3, 2).is_ok());
 
-    let mut rp_mmr_check = MutableMmr::<HashDigest, _>::new(Vec::new());
+    let mut rp_mmr_check = MutableMmr::<HashDigest, _>::new(Vec::new(), Bitmap::create());
     assert_eq!(rp_mmr_check.push(&rp_hash1), Ok(1));
     assert_eq!(rp_mmr_check.push(&rp_hash2), Ok(2));
     assert_eq!(rp_mmr_check.push(&rp_hash3), Ok(3));
@@ -458,7 +459,7 @@ fn fetch_mmr_root_and_proof_for_kernel<T: BlockchainBackend>(db: T) {
     txn.insert_kernel(kernel3, true);
     assert!(db.write(txn).is_ok());
 
-    let mut kernel_mmr_check = MutableMmr::<HashDigest, _>::new(Vec::new());
+    let mut kernel_mmr_check = MutableMmr::<HashDigest, _>::new(Vec::new(), Bitmap::create());
     assert!(kernel_mmr_check.push(&hash1).is_ok());
     assert!(kernel_mmr_check.push(&hash2).is_ok());
     assert!(kernel_mmr_check.push(&hash3).is_ok());

--- a/base_layer/core/tests/chain_storage_tests/chain_storage.rs
+++ b/base_layer/core/tests/chain_storage_tests/chain_storage.rs
@@ -24,6 +24,7 @@ use crate::helpers::{
     block_builders::{append_block, create_genesis_block, create_genesis_block_with_utxos, generate_new_block},
     sample_blockchains::create_new_blockchain,
 };
+use croaring::Bitmap;
 use env_logger;
 use std::thread;
 use tari_core::{
@@ -178,7 +179,7 @@ fn utxo_and_rp_merkle_root() {
     let hash1 = utxo1.hash();
     let hash2 = utxo2.hash();
     // Calculate the Range proof MMR root as a check
-    let mut rp_mmr_check = MutableMmr::<HashDigest, _>::new(Vec::new());
+    let mut rp_mmr_check = MutableMmr::<HashDigest, _>::new(Vec::new(), Bitmap::create());
     assert_eq!(rp_mmr_check.push(&utxo1.proof.hash()).unwrap(), 1);
     assert_eq!(rp_mmr_check.push(&utxo2.proof.hash()).unwrap(), 2);
     // Store the UTXOs
@@ -188,7 +189,7 @@ fn utxo_and_rp_merkle_root() {
     assert!(store.commit(txn).is_ok());
     let root = store.fetch_mmr_root(MmrTree::Utxo).unwrap();
     let rp_root = store.fetch_mmr_root(MmrTree::RangeProof).unwrap();
-    let mut mmr_check = MutableMmr::<HashDigest, _>::new(Vec::new());
+    let mut mmr_check = MutableMmr::<HashDigest, _>::new(Vec::new(), Bitmap::create());
     assert!(mmr_check.push(&hash1).is_ok());
     assert!(mmr_check.push(&hash2).is_ok());
     assert_eq!(root.to_hex(), mmr_check.get_merkle_root().unwrap().to_hex());
@@ -216,7 +217,7 @@ fn kernel_merkle_root() {
     txn.insert_kernel(kernel3, true);
     assert!(store.commit(txn).is_ok());
     let root = store.fetch_mmr_root(MmrTree::Kernel).unwrap();
-    let mut mmr_check = MutableMmr::<HashDigest, _>::new(Vec::new());
+    let mut mmr_check = MutableMmr::<HashDigest, _>::new(Vec::new(), Bitmap::create());
     assert!(mmr_check.push(&hash1).is_ok());
     assert!(mmr_check.push(&hash2).is_ok());
     assert!(mmr_check.push(&hash3).is_ok());

--- a/base_layer/mmr/src/change_tracker.rs
+++ b/base_layer/mmr/src/change_tracker.rs
@@ -42,7 +42,7 @@ pub struct MerkleChangeTrackerConfig {
     /// When the max_history_len is reached then the number of checkpoints upto the min_history_len is committed to the
     /// base MMR.
     pub min_history_len: usize,
-    /// The max_history_len specifies the point in history upto where the MMR can be rewinded.
+    /// The max_history_len specifies the point in history upto where the MMR can be rewound.
     pub max_history_len: usize,
 }
 

--- a/base_layer/mmr/src/mutable_mmr.rs
+++ b/base_layer/mmr/src/mutable_mmr.rs
@@ -58,13 +58,9 @@ where
     B: ArrayLike<Value = Hash>,
 {
     /// Create a new mutable MMR using the backend provided
-    pub fn new(mmr_backend: B) -> MutableMmr<D, B> {
+    pub fn new(mmr_backend: B, deleted: Bitmap) -> MutableMmr<D, B> {
         let mmr = MerkleMountainRange::new(mmr_backend);
-        MutableMmr {
-            mmr,
-            deleted: Bitmap::create(),
-            size: 0,
-        }
+        MutableMmr { mmr, deleted, size: 0 }
     }
 
     /// Clear the MutableMmr and assign the MMR state from the set of leaf_hashes and deleted nodes given in `state`.
@@ -245,6 +241,11 @@ where
     /// Expose the MerkleMountainRange for verifying proofs
     pub fn mmr(&self) -> &MerkleMountainRange<D, B> {
         &self.mmr
+    }
+
+    /// Return a reference to the bitmap of deleted nodes
+    pub fn deleted(&self) -> &Bitmap {
+        &self.deleted
     }
 }
 

--- a/base_layer/mmr/tests/change_tracker.rs
+++ b/base_layer/mmr/tests/change_tracker.rs
@@ -37,7 +37,7 @@ use tari_utilities::hex::Hex;
 
 #[test]
 fn change_tracker() {
-    let mmr = MutableMmr::<Hasher, _>::new(Vec::default());
+    let mmr = MutableMmr::<Hasher, _>::new(Vec::default(), Bitmap::create());
     let config = MerkleChangeTrackerConfig {
         min_history_len: 15,
         max_history_len: 20,
@@ -51,7 +51,7 @@ fn change_tracker() {
 /// Test the same MMR structure as the test in mutable_mmr, but add in rewinding and restoring of state
 fn checkpoints() {
     //----------- Construct and populate the initial MMR --------------------------
-    let base = MutableMmr::<Hasher, _>::new(Vec::default());
+    let base = MutableMmr::<Hasher, _>::new(Vec::default(), Bitmap::create());
     let config = MerkleChangeTrackerConfig {
         min_history_len: 15,
         max_history_len: 20,
@@ -185,7 +185,7 @@ fn serialize_and_deserialize_merklecheckpoint() {
 
 #[test]
 fn update_of_base_mmr_with_history_bounds() {
-    let base = MutableMmr::<Hasher, _>::new(Vec::default());
+    let base = MutableMmr::<Hasher, _>::new(Vec::default(), Bitmap::create());
     let config = MerkleChangeTrackerConfig {
         min_history_len: 3,
         max_history_len: 5,
@@ -218,7 +218,7 @@ fn update_of_base_mmr_with_history_bounds() {
 
 #[test]
 fn find_leaf_index() {
-    let base = MutableMmr::<Hasher, _>::new(Vec::default());
+    let base = MutableMmr::<Hasher, _>::new(Vec::default(), Bitmap::create());
     let config = MerkleChangeTrackerConfig {
         min_history_len: 2,
         max_history_len: 3,
@@ -255,7 +255,7 @@ fn find_leaf_index() {
 #[ignore] // TODO: this test demonstrate bug #1132, where the pruned MMR doesn't remove the leaf hashes that have been committed
           // to the base MMR.
 fn check_pruning_of_pruned_mmr() {
-    let base = MutableMmr::<Hasher, _>::new(Vec::default());
+    let base = MutableMmr::<Hasher, _>::new(Vec::default(), Bitmap::create());
     let config = MerkleChangeTrackerConfig {
         min_history_len: 2,
         max_history_len: 3,

--- a/base_layer/mmr/tests/mutable_mmr.rs
+++ b/base_layer/mmr/tests/mutable_mmr.rs
@@ -37,7 +37,7 @@ fn hash_with_bitmap(hash: &HashSlice, bitmap: &mut Bitmap) -> Hash {
 /// MMRs with no elements should provide sane defaults. The merkle root must be the hash of an empty string, b"".
 #[test]
 fn zero_length_mmr() {
-    let mmr = MutableMmr::<Hasher, _>::new(Vec::default());
+    let mmr = MutableMmr::<Hasher, _>::new(Vec::default(), Bitmap::create());
     assert_eq!(mmr.len(), 0);
     assert_eq!(mmr.is_empty(), Ok(true));
     let empty_hash = Hasher::digest(b"").to_vec();
@@ -50,7 +50,7 @@ fn zero_length_mmr() {
 #[test]
 // Note the hardcoded hashes are only valid when using Blake256 as the Hasher
 fn delete() {
-    let mut mmr = MutableMmr::<Hasher, _>::new(Vec::default());
+    let mut mmr = MutableMmr::<Hasher, _>::new(Vec::default(), Bitmap::create());
     assert_eq!(mmr.is_empty(), Ok(true));
     for i in 0..5 {
         assert!(mmr.push(&int_to_hash(i)).is_ok());
@@ -108,7 +108,7 @@ fn build_mmr() {
     assert_eq!(mmr_check.len(), Ok(8));
     let mut bitmap = Bitmap::create();
     // Create a small mutable MMR
-    let mut mmr = MutableMmr::<Hasher, _>::new(Vec::default());
+    let mut mmr = MutableMmr::<Hasher, _>::new(Vec::default(), Bitmap::create());
     for i in 0..5 {
         assert!(mmr.push(&int_to_hash(i)).is_ok());
     }
@@ -126,8 +126,8 @@ fn build_mmr() {
 
 #[test]
 fn equality_check() {
-    let mut ma = MutableMmr::<Hasher, _>::new(Vec::default());
-    let mut mb = MutableMmr::<Hasher, _>::new(Vec::default());
+    let mut ma = MutableMmr::<Hasher, _>::new(Vec::default(), Bitmap::create());
+    let mut mb = MutableMmr::<Hasher, _>::new(Vec::default(), Bitmap::create());
     assert!(ma == mb);
     assert!(ma.push(&int_to_hash(1)).is_ok());
     assert!(ma != mb);
@@ -148,7 +148,7 @@ fn equality_check() {
 
 #[test]
 fn restore_from_leaf_nodes() {
-    let mut mmr = MutableMmr::<Hasher, _>::new(Vec::default());
+    let mut mmr = MutableMmr::<Hasher, _>::new(Vec::default(), Bitmap::create());
     for i in 0..12 {
         assert!(mmr.push(&int_to_hash(i)).is_ok());
     }

--- a/base_layer/mmr/tests/support/mod.rs
+++ b/base_layer/mmr/tests/support/mod.rs
@@ -21,6 +21,7 @@
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 //
 
+use croaring::Bitmap;
 use digest::Digest;
 use tari_crypto::common::Blake256;
 use tari_mmr::{Hash, HashSlice, MerkleMountainRange, MutableMmr};
@@ -37,7 +38,7 @@ pub fn create_mmr(size: usize) -> MerkleMountainRange<Hasher, Vec<Hash>> {
 }
 
 pub fn create_mutable_mmr(size: usize) -> MutableMmr<Hasher, Vec<Hash>> {
-    let mut mmr = MutableMmr::<Hasher, _>::new(Vec::default());
+    let mut mmr = MutableMmr::<Hasher, _>::new(Vec::default(), Bitmap::create());
     for i in 0..size {
         let hash = int_to_hash(i);
         assert!(mmr.push(&hash).is_ok());


### PR DESCRIPTION
1. Add bitmap to MutableMMR constructor
    
    One should be able to provide a set of nodes that are marked as deleted
    when creating a MutableMmr.

2. Modify MutableMmr calls to use new constructor
    
    All uses of MutableMmr have been updated to include a
    Bitmap in the constructor.
    
    The LMDB_DB constructor can now load the deleted UTXO state
    from the backend and populate the UTXO Mmr instance. This
    is Step 1 of making the UTXO state persist which UTXOs have
    been spent.
    
    The next step (not done here) is to write the UTXO bitmap to
    the backend when it changes.

