### PR TITLE
Remove rust-multiaddr in favour of parity-multiaddr 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,10 +10,6 @@ jobs:
     steps:
       - checkout
       - run:
-          command: |
-            git submodule update --init --recursive
-          name: Init git submodule
-      - run:
           name: RFC documentation
           command: |
             # Workaround for bug https://github.com/rust-lang-nursery/mdBook/issues/855
@@ -29,10 +25,6 @@ jobs:
       - image: quay.io/tarilabs/git-ssh-client:0.2-alpine
     steps:
       - checkout
-      - run:
-          command: |
-            git submodule update --init --recursive
-          name: Init git submodule
       - attach_workspace:
           at: .
       - add_ssh_keys:
@@ -76,10 +68,6 @@ jobs:
     resource_class: medium
     steps:
       - checkout
-      - run:
-          command: |
-            git submodule update --init --recursive
-          name: Init git submodule
       - run:
           name: Tari source code
           command: |

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,8 +1,0 @@
-[submodule "comms/rust-multiaddr"]
-	path = comms/rust-multiaddr
-	url = https://github.com/tari-project/rust-multiaddr.git
-	branch = tari
-[submodule "comms/yamux"]
-	path = comms/yamux
-	url = https://github.com/tari-project/yamux.git
-	branch = futures-alpha

--- a/base_layer/p2p/Cargo.toml
+++ b/base_layer/p2p/Cargo.toml
@@ -46,10 +46,11 @@ cursive = "0.12.0"
 env_logger = "0.6.2"
 futures-test = { version = "0.3.0-alpha.19", package = "futures-test-preview" }
 futures-timer = "0.3.0"
+get_if_addrs = "0.5.3"
 lazy_static = "1.3.0"
+multiaddr = {version = "0.7.0", package = "parity-multiaddr"}
 stream-cancel = "0.4.4"
 tempdir = "0.3.7"
-get_if_addrs = "0.5.3"
 
 [dev-dependencies.log4rs]
 version ="0.8.3"

--- a/base_layer/p2p/examples/gen_node_identity.rs
+++ b/base_layer/p2p/examples/gen_node_identity.rs
@@ -34,6 +34,7 @@ use std::{
 use tari_comms::{
     multiaddr::Multiaddr,
     peer_manager::{NodeIdentity, PeerFeatures},
+    utils::multiaddr::socketaddr_to_multiaddr,
 };
 use tari_utilities::message_format::MessageFormat;
 
@@ -41,7 +42,7 @@ fn random_address() -> Multiaddr {
     let mut rng = OsRng::new().unwrap();
     let port = rng.gen_range(9000, std::u16::MAX);
     let socket_addr: SocketAddr = (Ipv4Addr::LOCALHOST, port).into();
-    socket_addr.into()
+    socketaddr_to_multiaddr(&socket_addr)
 }
 
 fn to_abs_path(path: &str) -> String {

--- a/base_layer/wallet_ffi/src/error.rs
+++ b/base_layer/wallet_ffi/src/error.rs
@@ -280,28 +280,36 @@ impl From<NodeIdentityError> for LibWalletError {
 }
 
 impl From<multiaddr::Error> for LibWalletError {
-    fn from(n: multiaddr::Error) -> Self {
-        error!(target: LOG_TARGET, "{}", format!("{:?}", n));
-        match n {
+    fn from(err: multiaddr::Error) -> Self {
+        error!(target: LOG_TARGET, "{}", format!("{:?}", err));
+        match err {
             multiaddr::Error::ParsingError(_) => Self {
                 code: 801,
-                message: format!("{:?}", n).to_string(),
+                message: format!("{:?}", err).to_string(),
             },
             multiaddr::Error::InvalidMultiaddr => Self {
                 code: 802,
-                message: format!("{:?}", n).to_string(),
+                message: format!("{:?}", err).to_string(),
             },
-            multiaddr::Error::MissingAddress => Self {
+            multiaddr::Error::DataLessThanLen => Self {
                 code: 803,
-                message: format!("{:?}", n).to_string(),
+                message: format!("{:?}", err).to_string(),
             },
-            multiaddr::Error::UnknownProtocol => Self {
+            multiaddr::Error::InvalidProtocolString => Self {
                 code: 804,
-                message: format!("{:?}", n).to_string(),
+                message: format!("{:?}", err).to_string(),
             },
-            multiaddr::Error::UnknownProtocolString => Self {
+            multiaddr::Error::UnknownProtocolString(_) => Self {
                 code: 805,
-                message: format!("{:?}", n).to_string(),
+                message: format!("{:?}", err).to_string(),
+            },
+            multiaddr::Error::InvalidUvar(_) => Self {
+                code: 806,
+                message: format!("{:?}", err).to_string(),
+            },
+            err => Self {
+                code: 810,
+                message: format!("Multiaddr error: {:?}", err).to_string(),
             },
         }
     }

--- a/comms/Cargo.toml
+++ b/comms/Cargo.toml
@@ -27,7 +27,7 @@ futures =  { version = "^0.3", features = ["async-await"]}
 lazy_static = "1.3.0"
 lmdb-zero = "0.4.4"
 log = { version = "0.4.0", features = ["std"] }
-multiaddr = {path="./rust-multiaddr", features = ["serde-support"]}
+multiaddr = {version = "0.7.0", package = "parity-multiaddr"}
 prost = "0.5.0"
 rand = "0.5.5"
 serde = "1.0.90"

--- a/comms/src/connection/connection.rs
+++ b/comms/src/connection/connection.rs
@@ -389,8 +389,8 @@ impl EstablishedConnection {
     /// the OS, (e.g. "127.0.0.1:0") which means that the actual port we're connecting to isn't known until the binding
     /// has been made. This function queries the socket for the connection info, and extracts the address & port if it
     /// was a TCP connection, returning None otherwise
-    pub fn get_connected_address(&self) -> &Option<SocketAddr> {
-        &self.connected_address
+    pub fn get_connected_address(&self) -> Option<&SocketAddr> {
+        self.connected_address.as_ref()
     }
 
     /// Read entire multipart message

--- a/comms/src/connection/peer_connection/dialer.rs
+++ b/comms/src/connection/peer_connection/dialer.rs
@@ -37,7 +37,7 @@ use crate::{
         InprocAddress,
     },
     message::FrameSet,
-    utils::multiaddr::multiaddr_to_socketaddr,
+    utils::multiaddr::{multiaddr_to_socketaddr, socketaddr_to_multiaddr},
 };
 use log::*;
 use std::{
@@ -180,7 +180,7 @@ impl PeerConnectionDialer {
 
         if let Some(addr) = addr {
             debug!(target: LOG_TARGET, "Starting peer connection worker thread on {}", addr);
-            self.context.peer_address = addr.clone().into();
+            self.context.peer_address = socketaddr_to_multiaddr(&addr);
         }
 
         loop {

--- a/comms/src/connection/peer_connection/listener.rs
+++ b/comms/src/connection/peer_connection/listener.rs
@@ -37,7 +37,7 @@ use crate::{
         InprocAddress,
     },
     message::{Frame, FrameSet},
-    utils::multiaddr::multiaddr_to_socketaddr,
+    utils::multiaddr::{multiaddr_to_socketaddr, socketaddr_to_multiaddr},
 };
 use log::*;
 use std::{
@@ -173,7 +173,7 @@ impl PeerConnectionListener {
 
         if let Some(addr) = addr {
             debug!(target: LOG_TARGET, "Starting peer connection worker thread on {}", addr);
-            self.context.peer_address = addr.clone().into();
+            self.context.peer_address = socketaddr_to_multiaddr(&addr);
         }
 
         loop {

--- a/comms/src/control_service/worker.rs
+++ b/comms/src/control_service/worker.rs
@@ -48,7 +48,7 @@ use crate::{
     message::{Envelope, EnvelopeBody, Frame, FrameSet, MessageEnvelopeHeader, MessageExt, MessageFlags},
     peer_manager::{NodeId, NodeIdentity, Peer, PeerFeatures, PeerFlags, PeerManagerError},
     types::CommsPublicKey,
-    utils::crypt,
+    utils::{crypt, multiaddr::socketaddr_to_multiaddr},
 };
 use log::*;
 use multiaddr::Multiaddr;
@@ -445,7 +445,7 @@ impl ControlServiceWorker {
                     .public_peer_address
                     .as_ref()
                     .map(Clone::clone)
-                    .or_else(|| inbound_conn.get_address().map(Into::into))
+                    .or_else(|| inbound_conn.get_address().as_ref().map(socketaddr_to_multiaddr))
                     .ok_or(ControlServiceError::ListenerAddressNotEstablished)?;
 
                 let permitted_identity = self.generate_random_identity();

--- a/comms/src/lib.rs
+++ b/comms/src/lib.rs
@@ -50,5 +50,5 @@ pub use self::builder::CommsBuilder;
 
 pub mod multiaddr {
     // Re-export so that client code does not have to have multiaddr as a dependency
-    pub use ::multiaddr::{AddrComponent, Error, Multiaddr, Protocol};
+    pub use ::multiaddr::{Error, Multiaddr, Protocol};
 }

--- a/comms/tests/connection/connection.rs
+++ b/comms/tests/connection/connection.rs
@@ -24,15 +24,17 @@ use crate::{
     support,
     support::factories::{self, TestFactory},
 };
-use multiaddr::Multiaddr;
 use std::time::Duration;
-use tari_comms::connection::{
-    connection::Connection,
-    error::ConnectionError,
-    types::{ConnectionDirection, Linger},
-    CurveEncryption,
-    InprocAddress,
-    ZmqContext,
+use tari_comms::{
+    connection::{
+        connection::Connection,
+        error::ConnectionError,
+        types::{ConnectionDirection, Linger},
+        CurveEncryption,
+        InprocAddress,
+        ZmqContext,
+    },
+    utils::multiaddr::socketaddr_to_multiaddr,
 };
 
 #[test]
@@ -107,7 +109,7 @@ fn inbound_recv_send_encrypted_tcp() {
         .establish(&addr)
         .unwrap();
 
-    let addr = Multiaddr::from(conn.get_connected_address().clone().unwrap());
+    let addr = conn.get_connected_address().map(socketaddr_to_multiaddr).unwrap();
 
     let signal = req_rep_pattern
         .set_endpoint(addr)

--- a/comms/tests/connection/monitor.rs
+++ b/comms/tests/connection/monitor.rs
@@ -21,14 +21,16 @@
 //  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 use crate::support::factories::{self, TestFactory};
-use multiaddr::Multiaddr;
 use std::{thread, time::Duration};
-use tari_comms::connection::{
-    connection::Connection,
-    monitor::{ConnectionMonitor, SocketEventType},
-    types::ConnectionDirection,
-    zmq::{ZmqContext, ZmqEndpoint},
-    InprocAddress,
+use tari_comms::{
+    connection::{
+        connection::Connection,
+        monitor::{ConnectionMonitor, SocketEventType},
+        types::ConnectionDirection,
+        zmq::{ZmqContext, ZmqEndpoint},
+        InprocAddress,
+    },
+    utils::multiaddr::socketaddr_to_multiaddr,
 };
 
 #[test]
@@ -43,7 +45,8 @@ fn recv_socket_events() {
         .set_monitor_addr(monitor_addr.clone())
         .establish(&address)
         .unwrap();
-    let connected_address = Multiaddr::from(conn_in.get_connected_address().clone().unwrap());
+
+    let connected_address = conn_in.get_connected_address().map(socketaddr_to_multiaddr).unwrap();
 
     {
         // Connect and disconnect

--- a/comms/tests/connection/peer_connection.rs
+++ b/comms/tests/connection/peer_connection.rs
@@ -38,6 +38,7 @@ use tari_comms::{
         ZmqContext,
     },
     message::FrameSet,
+    utils::multiaddr::socketaddr_to_multiaddr,
 };
 
 #[test]
@@ -234,7 +235,7 @@ fn connection_disconnect() {
         .establish(&addr)
         .unwrap();
 
-    let addr = sender.get_connected_address().clone().unwrap().into();
+    let addr = sender.get_connected_address().map(socketaddr_to_multiaddr).unwrap();
 
     // Initialize and start peer connection
     let identity = b"123".to_vec();

--- a/comms/tests/support/factories/net_address.rs
+++ b/comms/tests/support/factories/net_address.rs
@@ -21,7 +21,7 @@
 //  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 use super::{TestFactory, TestFactoryError};
-use multiaddr::{AddrComponent, Multiaddr};
+use multiaddr::{Multiaddr, Protocol};
 use std::iter::repeat_with;
 use tari_test_utils::address::get_next_local_port;
 
@@ -98,7 +98,7 @@ impl TestFactory for NetAddressFactory {
             .map_err(TestFactoryError::build_failed())?;
 
         let is_use_os_port = self.is_use_os_port;
-        addr.append(AddrComponent::TCP(self.port.unwrap_or_else(|| {
+        addr.push(Protocol::Tcp(self.port.unwrap_or_else(|| {
             if is_use_os_port {
                 0
             } else {

--- a/infrastructure/test_utils/src/runtime.rs
+++ b/infrastructure/test_utils/src/runtime.rs
@@ -29,8 +29,8 @@ pub fn create_runtime() -> Runtime {
         .threaded_scheduler()
         .enable_io()
         .enable_time()
-        .max_threads(4)
-        .core_threads(1)
+        .max_threads(8)
+        .core_threads(4)
         .build()
         .expect("Could not create runtime")
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

- Removed rust-multiaddr submodule
- Parity multiaddr is an actively developed fork of rust-multiaddr residing in rust-libp2p

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Ref #1186 
Only remaining issue is the `snow` git dependency

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Existing tests pass

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [x] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch
* [x] I ran `cargo-fmt --all` before pushing
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
