### PR TITLE
Added additional FFI methods

### DIFF
--- a/base_layer/wallet_ffi/wallet.h
+++ b/base_layer/wallet_ffi/wallet.h
@@ -205,6 +205,9 @@ struct TariPublicKey *pending_outbound_transaction_get_destination_public_key(st
 // Gets the amount of a TariPendingOutboundTransaction
 unsigned long long pending_outbound_transaction_get_amount(struct TariPendingOutboundTransaction *transaction,int* error_out);
 
+// Gets the fee of a TariPendingOutboundTransaction
+unsigned long long pending_outbound_transaction_get_fee(struct TariPendingOutboundTransaction *transaction,int* error_out);
+
 // Gets the message of a TariPendingOutboundTransaction
 const char *pending_outbound_transaction_get_message(struct TariPendingOutboundTransaction *transaction,int* error_out);
 
@@ -331,6 +334,10 @@ struct TariPendingInboundTransaction *wallet_get_pending_inbound_transaction_by_
 
 // Simulates completion of a TariPendingOutboundTransaction
 bool wallet_test_complete_sent_transaction(struct TariWallet *wallet, struct TariPendingOutboundTransaction *tx,int* error_out);
+
+// Checks if a TariCompletedTransaction was originally a TariPendingOutboundTransaction,
+// i.e the transaction was originally sent from the wallet
+bool wallet_is_completed_transaction_outbound(struct TariWallet *wallet, struct TariCompletedTransaction *tx,int* error_out);
 
 // Simulates the completion of a broadcasted TariPendingInboundTransaction
 bool wallet_test_broadcast_transaction(struct TariWallet *wallet, struct TariCompletedTransaction *tx, int* error_out);


### PR DESCRIPTION
PR to add two additional methods to wallet_ffi

1) wallet_check_originating_completed_transaction -> determines if a completed transaction was originally sent from the wallet.
2) pending_outbound_transaction_get_fee -> returns the fee of an outbound transaction.

## Description

## Motivation and Context
Requested by mobile developers

## How Has This Been Tested?
cargo test --all --all-features

## Types of changes
* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [x] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch
* [x] I ran `cargo-fmt --all` before pushing
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
