### PR TITLE
Added validators to the mempool so they can validate the transactions

### DIFF
--- a/applications/tari_base_node/src/builder.rs
+++ b/applications/tari_base_node/src/builder.rs
@@ -49,11 +49,12 @@ use tari_core::{
         Validators,
     },
     consensus::ConsensusManager,
-    mempool::{Mempool, MempoolConfig},
+    mempool::{Mempool, MempoolConfig, MempoolValidators},
     proof_of_work::DiffAdjManager,
     validation::{
         block_validators::{FullConsensusValidator, StatelessValidator},
         horizon_state_validators::HorizonStateHeaderValidator,
+        transaction_validators::{FullTxValidator, TxInputAndMaturityValidator},
     },
 };
 use tari_mmr::MerkleChangeTrackerConfig;
@@ -181,7 +182,11 @@ pub fn configure_and_initialize_node(
                 HorizonStateHeaderValidator::new(rules.clone(), db.clone()),
             );
             db.set_validators(validators);
-            let mempool = Mempool::new(db.clone(), MempoolConfig::default());
+            let mempool_validator = MempoolValidators::new(
+                FullTxValidator::new(factories.clone(), db.clone()),
+                TxInputAndMaturityValidator::new(db.clone()),
+            );
+            let mempool = Mempool::new(db.clone(), MempoolConfig::default(), mempool_validator);
             let diff_adj_manager = DiffAdjManager::new(db.clone()).map_err(|e| e.to_string())?;
             rules.set_diff_manager(diff_adj_manager).map_err(|e| e.to_string())?;
             let (comms, handles) =
@@ -210,7 +215,11 @@ pub fn configure_and_initialize_node(
                 HorizonStateHeaderValidator::new(rules.clone(), db.clone()),
             );
             db.set_validators(validators);
-            let mempool = Mempool::new(db.clone(), MempoolConfig::default());
+            let mempool_validator = MempoolValidators::new(
+                FullTxValidator::new(factories.clone(), db.clone()),
+                TxInputAndMaturityValidator::new(db.clone()),
+            );
+            let mempool = Mempool::new(db.clone(), MempoolConfig::default(), mempool_validator);
             let diff_adj_manager = DiffAdjManager::new(db.clone()).map_err(|e| e.to_string())?;
             rules.set_diff_manager(diff_adj_manager).map_err(|e| e.to_string())?;
             let (comms, handles) =

--- a/base_layer/core/src/mempool/error.rs
+++ b/base_layer/core/src/mempool/error.rs
@@ -42,4 +42,5 @@ pub enum MempoolError {
     ChainStorageError(ChainStorageError),
     /// The Blockchain height is undefined
     ChainHeightUndefined,
+    ValidationError,
 }

--- a/base_layer/core/src/mempool/mod.rs
+++ b/base_layer/core/src/mempool/mod.rs
@@ -32,7 +32,7 @@ mod unconfirmed_pool;
 
 // Public re-exports
 pub use error::MempoolError;
-pub use mempool::{Mempool, MempoolConfig, TxStorageResponse};
+pub use mempool::{Mempool, MempoolConfig, MempoolValidators, TxStorageResponse};
 pub use service::{
     MempoolServiceConfig,
     MempoolServiceError,

--- a/base_layer/core/tests/block_validation.rs
+++ b/base_layer/core/tests/block_validation.rs
@@ -49,6 +49,5 @@ fn test_genesis_block() {
     rules.set_diff_manager(diff_adj_manager).unwrap();
     let block = get_genesis_block();
     let result = db.add_block(block);
-    dbg!(&result);
     assert!(result.is_ok());
 }

--- a/base_layer/core/tests/node_comms_interface.rs
+++ b/base_layer/core/tests/node_comms_interface.rs
@@ -36,8 +36,9 @@ use tari_core::{
         MutableMmrState,
     },
     consensus::ConsensusManager,
-    mempool::{Mempool, MempoolConfig},
+    mempool::{Mempool, MempoolConfig, MempoolValidators},
     proof_of_work::DiffAdjManager,
+    validation::transaction_validators::TxInputAndMaturityValidator,
 };
 
 use croaring::Bitmap;
@@ -85,7 +86,11 @@ fn new_mempool() -> (
     BlockchainDatabase<MemoryDatabase<HashDigest>>,
 ) {
     let store = create_mem_db();
-    let mempool = Mempool::new(store.clone(), MempoolConfig::default());
+    let mempool_validator = MempoolValidators::new(
+        TxInputAndMaturityValidator::new(store.clone()),
+        TxInputAndMaturityValidator::new(store.clone()),
+    );
+    let mempool = Mempool::new(store.clone(), MempoolConfig::default(), mempool_validator);
     (mempool, store)
 }
 


### PR DESCRIPTION
## Description
Added validators to the mempool. How the mempool validates transactions can now be customised depending on the validators. 

## Motivation and Context
Mempool had hard locked ways of validating transactions. It also did not include any transaction verification. Using validators fixes this. This PR also fixes #1181 

## How Has This Been Tested?
Unit tests are all still passing. 

## Types of changes
* [ ] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [x] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
* [x] I'm merging against the `development` branch
* [x] I ran `cargo-fmt --all` before pushing
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
