### PR TITLE
Calculate total kernel excess, kernel offset and utxo commitment for chain

### DIFF
--- a/base_layer/core/src/blocks/blockheader.rs
+++ b/base_layer/core/src/blocks/blockheader.rs
@@ -97,8 +97,7 @@ pub struct BlockHeader {
     /// This is the MMR root of the kernels
     #[serde(with = "hash_serializer")]
     pub kernel_mr: BlockHash,
-    /// Total accumulated sum of kernel offsets since genesis block. We can derive the kernel offset sum for *this*
-    /// block from the total kernel offset of the previous block header.
+    /// Sum of kernel offsets for all kernels in this block.
     pub total_kernel_offset: BlindingFactor,
     /// Nonce increment used to mine this block.
     pub nonce: u64,

--- a/base_layer/core/src/chain_storage/lmdb_db/lmdb_db.rs
+++ b/base_layer/core/src/chain_storage/lmdb_db/lmdb_db.rs
@@ -853,6 +853,24 @@ where D: Digest + Send + Sync
         lmdb_for_each::<F, HashOutput, Block>(&self.env, &self.orphans_db, f)
     }
 
+    /// Iterate over all the stored transaction kernels and execute the function `f` for each kernel.
+    fn for_each_kernel<F>(&self, f: F) -> Result<(), ChainStorageError>
+    where F: FnMut(Result<(HashOutput, TransactionKernel), ChainStorageError>) {
+        lmdb_for_each::<F, HashOutput, TransactionKernel>(&self.env, &self.kernels_db, f)
+    }
+
+    /// Iterate over all the stored block headers and execute the function `f` for each header.
+    fn for_each_header<F>(&self, f: F) -> Result<(), ChainStorageError>
+    where F: FnMut(Result<(u64, BlockHeader), ChainStorageError>) {
+        lmdb_for_each::<F, u64, BlockHeader>(&self.env, &self.headers_db, f)
+    }
+
+    /// Iterate over all the stored transaction kernels and execute the function `f` for each kernel.
+    fn for_each_utxo<F>(&self, f: F) -> Result<(), ChainStorageError>
+    where F: FnMut(Result<(HashOutput, TransactionOutput), ChainStorageError>) {
+        lmdb_for_each::<F, HashOutput, TransactionOutput>(&self.env, &self.utxos_db, f)
+    }
+
     fn fetch_horizon_block_height(&self) -> Result<u64, ChainStorageError> {
         let tip_height = lmdb_len(&self.env, &self.headers_db)?;
         let checkpoint_count = self

--- a/base_layer/core/src/chain_storage/memory_db.rs
+++ b/base_layer/core/src/chain_storage/memory_db.rs
@@ -461,6 +461,36 @@ where D: Digest + Send + Sync
         Ok(())
     }
 
+    /// Iterate over all the stored transaction kernels and execute the function `f` for each kernel.
+    fn for_each_kernel<F>(&self, mut f: F) -> Result<(), ChainStorageError>
+    where F: FnMut(Result<(HashOutput, TransactionKernel), ChainStorageError>) {
+        let db = self.db_access()?;
+        for (key, val) in db.kernels.iter() {
+            f(Ok((key.clone(), val.clone())));
+        }
+        Ok(())
+    }
+
+    /// Iterate over all the stored block headers and execute the function `f` for each header.
+    fn for_each_header<F>(&self, mut f: F) -> Result<(), ChainStorageError>
+    where F: FnMut(Result<(u64, BlockHeader), ChainStorageError>) {
+        let db = self.db_access()?;
+        for (key, val) in db.headers.iter() {
+            f(Ok((key.clone(), val.clone())));
+        }
+        Ok(())
+    }
+
+    /// Iterate over all the stored unspent transaction outputs and execute the function `f` for each UTXO.
+    fn for_each_utxo<F>(&self, mut f: F) -> Result<(), ChainStorageError>
+    where F: FnMut(Result<(HashOutput, TransactionOutput), ChainStorageError>) {
+        let db = self.db_access()?;
+        for (key, val) in db.utxos.iter() {
+            f(Ok((key.clone(), val.value.clone())));
+        }
+        Ok(())
+    }
+
     /// The horizon block is the earliest block that we can return all data to reconstruct a full block
     fn fetch_horizon_block_height(&self) -> Result<u64, ChainStorageError> {
         let db = self.db_access()?;

--- a/base_layer/core/src/helpers/mock_backend.rs
+++ b/base_layer/core/src/helpers/mock_backend.rs
@@ -26,7 +26,10 @@ use crate::{
     chain_storage::{BlockchainBackend, ChainStorageError, DbKey, DbTransaction, DbValue, MmrTree, MutableMmrState},
 };
 use tari_mmr::{Hash, MerkleCheckPoint, MerkleProof, MutableMmrLeafNodes};
-use tari_transactions::types::HashOutput;
+use tari_transactions::{
+    transaction::{TransactionKernel, TransactionOutput},
+    types::HashOutput,
+};
 
 // This is a test backend. This is used so that the ConsensusManager can be called without actually having a backend.
 // Calling this backend will result in a panic.
@@ -101,6 +104,30 @@ impl BlockchainBackend for MockBackend {
     where
         Self: Sized,
         F: FnMut(Result<(HashOutput, Block), ChainStorageError>),
+    {
+        unimplemented!()
+    }
+
+    fn for_each_kernel<F>(&self, _f: F) -> Result<(), ChainStorageError>
+    where
+        Self: Sized,
+        F: FnMut(Result<(HashOutput, TransactionKernel), ChainStorageError>),
+    {
+        unimplemented!()
+    }
+
+    fn for_each_header<F>(&self, _f: F) -> Result<(), ChainStorageError>
+    where
+        Self: Sized,
+        F: FnMut(Result<(u64, BlockHeader), ChainStorageError>),
+    {
+        unimplemented!()
+    }
+
+    fn for_each_utxo<F>(&self, _f: F) -> Result<(), ChainStorageError>
+    where
+        Self: Sized,
+        F: FnMut(Result<(HashOutput, TransactionOutput), ChainStorageError>),
     {
         unimplemented!()
     }


### PR DESCRIPTION
## Description
- Added total_kernel_excess function to Blockchain_db. Total_kernel_excess can be used to calculate the total kernel excess for all kernels in the chain.
- Added total_kernel_offset function to Blockchain_db, used to calculate the total kernel offset for all the kernel offsets recorded in the headers of the chain.
 - Added total_utxo_commitment function to Blockchain_db, that calculates the total sum of all the UTXO commitments in the chain.
- Added for_each_kernel, for_each_header and for_each_utxo to the BlockchainBackend trait to provide access to all stored kernels, header and utxos.
- Implement these new functions for Lmdb_db, Memory_db and Mock_backend.

## Motivation and Context
These changes are required to validate the synced horizon state.

## How Has This Been Tested?
Added new chain storage and backend tests for these new functions.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [x] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch
* [x] I ran `cargo-fmt --all` before pushing
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
