### PR TITLE
Remove deprecated `to_description`

### DIFF
--- a/base_layer/transactions/src/transaction_protocol/transaction_initializer.rs
+++ b/base_layer/transactions/src/transaction_protocol/transaction_initializer.rs
@@ -40,7 +40,6 @@ use crate::{
 use digest::Digest;
 use std::{
     collections::HashMap,
-    error::Error as ErrorTrait,
     fmt::{Debug, Error, Formatter},
 };
 use tari_crypto::keys::PublicKey as PublicKeyTrait;
@@ -257,7 +256,7 @@ impl SenderTransactionInitializer {
         {
             Ok(o) => o,
             Err(e) => {
-                return self.build_err(e.description());
+                return self.build_err(&e.to_string());
             },
         };
 

--- a/infrastructure/tari_util/src/hex.rs
+++ b/infrastructure/tari_util/src/hex.rs
@@ -79,7 +79,6 @@ where
 #[cfg(test)]
 mod test {
     use super::*;
-    use std::error::Error;
 
     #[test]
     fn test_to_hex() {
@@ -109,7 +108,7 @@ mod test {
             _ => panic!(),
         }
         // Check that message is the doc message above
-        assert_eq!(err.description(), "Hex string lengths must be a multiple of 2");
+        assert_eq!(err.to_string(), "Hex string lengths must be a multiple of 2");
     }
 
     #[test]
@@ -121,7 +120,6 @@ mod test {
             HexError::InvalidCharacter(e) => println!("{:?}", e),
             _ => panic!(),
         }
-        // Check that message is inherited from ParseIntError
-        assert_eq!(err.description(), "invalid digit found in string");
+        assert_eq!(err.to_string(), "Only hexadecimal characters (0-9,a-f) are permitted");
     }
 }


### PR DESCRIPTION
`Error::description()` is deprecated. Instances have been replaced
with `to_string()`

