### PR TITLE
Perform accounting balance and mmr state validation on synced blockchain horizon state

### DIFF
--- a/applications/tari_base_node/src/builder.rs
+++ b/applications/tari_base_node/src/builder.rs
@@ -53,6 +53,7 @@ use tari_core::{
     proof_of_work::DiffAdjManager,
     validation::{
         block_validators::{FullConsensusValidator, StatelessValidator},
+        chain_validators::{ChainTipValidator, GenesisBlockValidator},
         horizon_state_validators::HorizonStateHeaderValidator,
         transaction_validators::{FullTxValidator, TxInputAndMaturityValidator},
     },
@@ -178,8 +179,10 @@ pub fn configure_and_initialize_node(
             let mut db = BlockchainDatabase::new(backend).map_err(|e| e.to_string())?;
             let validators = Validators::new(
                 FullConsensusValidator::new(rules.clone(), factories.clone(), db.clone()),
-                StatelessValidator::new(factories.clone()),
+                StatelessValidator::new(),
                 HorizonStateHeaderValidator::new(rules.clone(), db.clone()),
+                GenesisBlockValidator::new(),
+                ChainTipValidator::new(rules.clone(), factories.clone(), db.clone()),
             );
             db.set_validators(validators);
             let mempool_validator = MempoolValidators::new(
@@ -211,8 +214,10 @@ pub fn configure_and_initialize_node(
             let mut db = BlockchainDatabase::new(backend).map_err(|e| e.to_string())?;
             let validators = Validators::new(
                 FullConsensusValidator::new(rules.clone(), factories.clone(), db.clone()),
-                StatelessValidator::new(factories.clone()),
+                StatelessValidator::new(),
                 HorizonStateHeaderValidator::new(rules.clone(), db.clone()),
+                GenesisBlockValidator::new(),
+                ChainTipValidator::new(rules.clone(), factories.clone(), db.clone()),
             );
             db.set_validators(validators);
             let mempool_validator = MempoolValidators::new(

--- a/base_layer/core/src/blocks/blockheader.rs
+++ b/base_layer/core/src/blocks/blockheader.rs
@@ -64,6 +64,8 @@ pub type BlockHash = Vec<u8>;
 pub enum BlockHeaderValidationError {
     // The Genesis block header is incorrectly chained
     ChainedGenesisBlockHeader,
+    // Incorrect Genesis block header,
+    IncorrectGenesisBlockHeader,
     // Header does not form a valid chain
     InvalidChaining,
     // Invalid timestamp received on the header
@@ -72,6 +74,8 @@ pub enum BlockHeaderValidationError {
     InvalidTimestampFutureTimeLimit,
     // Invalid Proof of work for the header
     ProofOfWorkError(PowError),
+    // Mismatched MMR roots
+    MismatchedMmrRoots,
 }
 
 /// The BlockHeader contains all the metadata for the block, including proof of work, a link to the previous block

--- a/base_layer/core/src/blocks/genesis_block.rs
+++ b/base_layer/core/src/blocks/genesis_block.rs
@@ -55,7 +55,7 @@ pub fn get_genesis_block() -> Block {
             commitment: Commitment::from_hex(
                 "feba9eeee21bb01aea86cfa52ea3c905647e3785040581dd9c1f6c89510e6548",
             )
-            .unwrap(),
+                .unwrap(),
             proof: BulletRangeProof::from_hex("9aadf23887b4bf69f2743c773aabfa0c70a270971d2fc9ad123340a1b6a1d015783012da766307c628a84bc2453f28f0157d64943e95a59ea3e4d892ef66bd70d85026432df39294a3000ed243c63e3e041c234498149962b447e3c8d234631bf036cd4f0649347957795b28a683e3b6190f1a42b51e5debbef7d2cee4941416ad15d8080ab498d7cfdee64d62a8a3701986aecede76894602689862d4465c0160fd23d97cc4379e857725905d757154f45b01803d8562bf03c25217e02ba600628c90e81f43cf94dd10b4ebd9acd3ee388ec99e659a06162af7ca3f34c84d0ef23dccbabc307af93fadad74c7c9df9e896f1c61b4340b55cf9a270218420c40ce8fec166f51e187fb9e53083e514047ff9970627b3d29dadcd8c4555e61ec2e8c09b99a9de4ac15c8583522a647960a1dd476992787f69cc9a2bf3a302fb0426ad6a121be5beb98a621e9171718901a1e6ff81e73dde7d5bbe32251ddf363423262293b81d2cb40354c41ed317b3c06f2fbddfdc1cf07547a854a50416b8d5f4adc39f021a189a5f032d1d445a19bf57c921e34d3f7d6ff8227490d50391765ccf24b84649c88f5a2aece1936c638c0b44eb21a2d9e1c159b96061d674600139e9e09d7e07ed7cc0f2c172da4104568e58ae3ef47b0ab5e7aafac7fdb05ef3a229812c4013d8fb19334f0b3488ce9bf0fc280c565ebde6197c9060740ae5d1a808de889dbb123e26fcf1dd99501f99ba6b6057aa0b0ffd07cfdf0690a2a9c79ecff61da6318c81e9066d3fb5fbc3b102b3e1d586a8933c653887c37f24c29257a7d123fa43f962f073c62e6cb0b318743b9bf9fc9043c0f56a9164eb0666174bf76e5e4b4264a35ab25edeae69af5388d7bec4690ce67304812a44df7af9909033a8234c2a777cf66b48c326de09fb2df8b23477a05d33cb59c0c4aa43ca60c").unwrap(),
         }],
         vec![TransactionKernel {
@@ -67,7 +67,7 @@ pub fn get_genesis_block() -> Block {
             excess: Commitment::from_hex(
                 "d811169b90cf749d056416121ba34bf8b435e1c1549c446433c233289fc1372c",
             )
-            .unwrap(),
+                .unwrap(),
             excess_sig: sig,
         }],
     );
@@ -104,5 +104,5 @@ pub fn get_gen_block_hash() -> Vec<u8> {
 }
 
 pub fn get_gen_header() -> BlockHeader {
-    BlockHeader::new(0)
+    get_genesis_block().header
 }

--- a/base_layer/core/src/blocks/mod.rs
+++ b/base_layer/core/src/blocks/mod.rs
@@ -28,6 +28,6 @@ mod new_blockheader_template;
 pub mod genesis_block;
 
 pub use block::{Block, BlockBuilder, BlockValidationError};
-pub use blockheader::{BlockHash, BlockHeader};
+pub use blockheader::{BlockHash, BlockHeader, BlockHeaderValidationError};
 pub use new_block_template::NewBlockTemplate;
 pub use new_blockheader_template::NewBlockHeaderTemplate;

--- a/base_layer/core/src/helpers/mod.rs
+++ b/base_layer/core/src/helpers/mod.rs
@@ -50,6 +50,8 @@ pub fn create_mem_db() -> BlockchainDatabase<MemoryDatabase<HashDigest>> {
         MockValidator::new(true),
         MockValidator::new(true),
         MockValidator::new(true),
+        MockValidator::new(true),
+        MockValidator::new(true),
     );
     let db = MemoryDatabase::<HashDigest>::default();
     let mut db = BlockchainDatabase::new(db).unwrap();

--- a/base_layer/core/src/mempool/mempool.rs
+++ b/base_layer/core/src/mempool/mempool.rs
@@ -120,7 +120,7 @@ where T: BlockchainBackend
         let (mempool_validator, orphan_validator) = validators.into_validators();
         Self {
             unconfirmed_pool: UnconfirmedPool::new(config.unconfirmed_pool_config),
-            orphan_pool: OrphanPool::new(blockchain_db.clone(), config.orphan_pool_config, orphan_validator),
+            orphan_pool: OrphanPool::new(config.orphan_pool_config, orphan_validator),
             pending_pool: PendingPool::new(config.pending_pool_config),
             reorg_pool: ReorgPool::new(config.reorg_pool_config),
             blockchain_db,

--- a/base_layer/core/src/mempool/orphan_pool/orphan_pool.rs
+++ b/base_layer/core/src/mempool/orphan_pool/orphan_pool.rs
@@ -21,7 +21,7 @@
 //  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 use crate::{
-    chain_storage::{BlockchainBackend, BlockchainDatabase},
+    chain_storage::BlockchainBackend,
     consts::{MEMPOOL_ORPHAN_POOL_CACHE_TTL, MEMPOOL_ORPHAN_POOL_STORAGE_CAPACITY},
     mempool::orphan_pool::{error::OrphanPoolError, orphan_pool_storage::OrphanPoolStorage},
     validation::Validator,
@@ -63,14 +63,9 @@ impl<T> OrphanPool<T>
 where T: BlockchainBackend
 {
     /// Create a new OrphanPool with the specified configuration
-    pub fn new(
-        blockchain_db: BlockchainDatabase<T>,
-        config: OrphanPoolConfig,
-        validator: Validator<Transaction, T>,
-    ) -> Self
-    {
+    pub fn new(config: OrphanPoolConfig, validator: Validator<Transaction, T>) -> Self {
         Self {
-            pool_storage: Arc::new(RwLock::new(OrphanPoolStorage::new(blockchain_db, config, validator))),
+            pool_storage: Arc::new(RwLock::new(OrphanPoolStorage::new(config, validator))),
         }
     }
 
@@ -174,7 +169,6 @@ mod test {
         let store = create_mem_db();
         let mempool_validator = Box::new(TxInputAndMaturityValidator::new(store.clone()));
         let orphan_pool = OrphanPool::new(
-            store,
             OrphanPoolConfig {
                 storage_capacity: 3,
                 tx_ttl: Duration::from_millis(50),

--- a/base_layer/core/src/validation/block_validators.rs
+++ b/base_layer/core/src/validation/block_validators.rs
@@ -40,13 +40,11 @@ use tari_transactions::{transaction::OutputFlags, types::CryptoFactories};
 use tari_utilities::hash::Hashable;
 
 /// This validator tests whether a candidate block is internally consistent
-pub struct StatelessValidator {
-    factories: Arc<CryptoFactories>,
-}
+pub struct StatelessValidator {}
 
 impl StatelessValidator {
-    pub fn new(factories: Arc<CryptoFactories>) -> Self {
-        Self { factories }
+    pub fn new() -> Self {
+        Self {}
     }
 }
 

--- a/base_layer/core/src/validation/chain_validators.rs
+++ b/base_layer/core/src/validation/chain_validators.rs
@@ -1,0 +1,149 @@
+// Copyright 2019. The Tari Project
+//
+// Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+// following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+// disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+// following disclaimer in the documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+// products derived from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+// INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+// WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+// USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+pub use crate::consensus::ConsensusManager;
+use crate::{
+    blocks::{
+        blockheader::{BlockHeader, BlockHeaderValidationError},
+        genesis_block::get_gen_block_hash,
+    },
+    chain_storage::{BlockchainBackend, BlockchainDatabase, MmrTree},
+    validation::{error::ValidationError, traits::Validation},
+};
+use std::sync::Arc;
+use tari_crypto::commitment::HomomorphicCommitmentFactory;
+use tari_transactions::types::CryptoFactories;
+use tari_utilities::hash::Hashable;
+
+/// This validator checks that the synced state satisfies *all* consensus rules and should only be performed on
+/// the chain tip header.
+pub struct ChainTipValidator<B: BlockchainBackend> {
+    rules: ConsensusManager<B>,
+    factories: Arc<CryptoFactories>,
+    db: BlockchainDatabase<B>,
+}
+
+impl<B: BlockchainBackend> ChainTipValidator<B>
+where B: BlockchainBackend
+{
+    pub fn new(rules: ConsensusManager<B>, factories: Arc<CryptoFactories>, db: BlockchainDatabase<B>) -> Self {
+        Self { rules, factories, db }
+    }
+
+    fn db(&self) -> Result<BlockchainDatabase<B>, ValidationError> {
+        Ok(self.db.clone())
+    }
+}
+
+impl<B: BlockchainBackend> Validation<BlockHeader, B> for ChainTipValidator<B> {
+    /// The consensus checks that are done (in order of cheapest to verify to most expensive):
+    /// 1. Does the MMR roots calculated from the chain state match that roots provided in the tip header?
+    /// 1. Is the full accounting balance of the current chain state valid?
+    fn validate(&self, block_header: &BlockHeader) -> Result<(), ValidationError> {
+        check_mmr_roots(block_header, self.db()?)?;
+        check_chain_accounting_balance(block_header, self.db()?, self.rules.clone(), &self.factories)?;
+
+        Ok(())
+    }
+}
+
+/// This validator checks that the synced chain builds on the correct genesis block and should only be performed on the
+/// genesis block header.
+pub struct GenesisBlockValidator {}
+
+impl GenesisBlockValidator {
+    pub fn new() -> Self {
+        Self {}
+    }
+}
+
+impl<B: BlockchainBackend> Validation<BlockHeader, B> for GenesisBlockValidator {
+    /// The consensus checks that are done (in order of cheapest to verify to most expensive):
+    /// Does the genesis block hash match the provided block hash?
+    fn validate(&self, block_header: &BlockHeader) -> Result<(), ValidationError> {
+        check_genesis_block_hash(block_header)?;
+
+        Ok(())
+    }
+}
+
+/// Check the full accounting balance of the current chain state. This check should only be performed on chain tip
+/// headers.
+fn check_chain_accounting_balance<B: BlockchainBackend>(
+    block_header: &BlockHeader,
+    db: BlockchainDatabase<B>,
+    rules: ConsensusManager<B>,
+    factories: &CryptoFactories,
+) -> Result<(), ValidationError>
+{
+    let total_coinbase = rules.emission_schedule().supply_at_block(block_header.height);
+    let total_kernel_excess = db
+        .total_kernel_excess()
+        .map_err(|e| ValidationError::CustomError(e.to_string()))?;
+    let total_kernel_offset = db
+        .total_kernel_offset()
+        .map_err(|e| ValidationError::CustomError(e.to_string()))?;
+    let kernel_offset_and_coinbase = factories
+        .commitment
+        .commit_value(&total_kernel_offset, total_coinbase.0);
+    let sum_utxo_commitments = db
+        .total_utxo_commitment()
+        .map_err(|e| ValidationError::CustomError(e.to_string()))?;
+    if sum_utxo_commitments != &total_kernel_excess + &kernel_offset_and_coinbase {
+        return Err(ValidationError::InvalidAccountingBalance);
+    }
+    Ok(())
+}
+
+/// This function checks that the MMR roots calculated from the chain state matches that MMR roots provided in the tip
+/// header.
+fn check_mmr_roots<B: BlockchainBackend>(
+    block_header: &BlockHeader,
+    db: BlockchainDatabase<B>,
+) -> Result<(), ValidationError>
+{
+    if (block_header.output_mr !=
+        db.fetch_mmr_root(MmrTree::Utxo)
+            .map_err(|e| ValidationError::CustomError(e.to_string()))?) ||
+        (block_header.range_proof_mr !=
+            db.fetch_mmr_root(MmrTree::RangeProof)
+                .map_err(|e| ValidationError::CustomError(e.to_string()))?) ||
+        (block_header.kernel_mr !=
+            db.fetch_mmr_root(MmrTree::Kernel)
+                .map_err(|e| ValidationError::CustomError(e.to_string()))?)
+    {
+        return Err(ValidationError::BlockHeaderError(
+            BlockHeaderValidationError::MismatchedMmrRoots,
+        ));
+    }
+    Ok(())
+}
+
+/// This function checks that the synced genesis block header is the correct block header.
+fn check_genesis_block_hash(block_header: &BlockHeader) -> Result<(), ValidationError> {
+    if block_header.hash() != get_gen_block_hash() {
+        return Err(ValidationError::BlockHeaderError(
+            BlockHeaderValidationError::IncorrectGenesisBlockHeader,
+        ));
+    }
+    Ok(())
+}

--- a/base_layer/core/src/validation/error.rs
+++ b/base_layer/core/src/validation/error.rs
@@ -39,4 +39,7 @@ pub enum ValidationError {
     CustomError(String),
     /// A database instance must be set for this validator
     NoDatabaseConfigured,
+    // The total expected supply plus the total accumulated (offset) excess does not equal the sum of all UTXO
+    // commitments.
+    InvalidAccountingBalance,
 }

--- a/base_layer/core/src/validation/mod.rs
+++ b/base_layer/core/src/validation/mod.rs
@@ -36,4 +36,5 @@ pub mod horizon_state_validators;
 pub mod mocks;
 pub use error::ValidationError;
 pub use traits::{Validation, Validator};
+pub mod chain_validators;
 pub mod transaction_validators;

--- a/base_layer/core/tests/block_validation.rs
+++ b/base_layer/core/tests/block_validation.rs
@@ -41,7 +41,9 @@ fn test_genesis_block() {
     let mut db = BlockchainDatabase::new(backend).unwrap();
     let validators = Validators::new(
         FullConsensusValidator::new(rules.clone(), factories.clone(), db.clone()),
-        StatelessValidator::new(factories.clone()),
+        StatelessValidator::new(),
+        MockValidator::new(true),
+        MockValidator::new(true),
         MockValidator::new(true),
     );
     db.set_validators(validators);

--- a/base_layer/core/tests/chain_storage_tests/chain_storage.rs
+++ b/base_layer/core/tests/chain_storage_tests/chain_storage.rs
@@ -514,6 +514,8 @@ fn store_and_retrieve_block_with_mmr_pruning_horizon() {
         MockValidator::new(true),
         MockValidator::new(true),
         MockValidator::new(true),
+        MockValidator::new(true),
+        MockValidator::new(true),
     );
     let db = MemoryDatabase::<HashDigest>::new(mct_config);
     let mut store = BlockchainDatabase::new(db).unwrap();

--- a/base_layer/core/tests/helpers/nodes.rs
+++ b/base_layer/core/tests/helpers/nodes.rs
@@ -139,9 +139,11 @@ impl BaseNodeBuilder {
         block: impl Validation<Block, MemoryDatabase<HashDigest>> + 'static,
         orphan: impl Validation<Block, MemoryDatabase<HashDigest>> + 'static,
         horizon_state_header: impl Validation<BlockHeader, MemoryDatabase<HashDigest>> + 'static,
+        chain_gb: impl Validation<BlockHeader, MemoryDatabase<HashDigest>> + 'static,
+        chain_tip: impl Validation<BlockHeader, MemoryDatabase<HashDigest>> + 'static,
     ) -> Self
     {
-        let validators = Validators::new(block, orphan, horizon_state_header);
+        let validators = Validators::new(block, orphan, horizon_state_header, chain_gb, chain_tip);
         self.validators = Some(validators);
         self
     }
@@ -153,6 +155,8 @@ impl BaseNodeBuilder {
             max_history_len: 20,
         });
         let validators = self.validators.unwrap_or(Validators::new(
+            MockValidator::new(true),
+            MockValidator::new(true),
             MockValidator::new(true),
             MockValidator::new(true),
             MockValidator::new(true),

--- a/base_layer/core/tests/helpers/sample_blockchains.rs
+++ b/base_layer/core/tests/helpers/sample_blockchains.rs
@@ -126,6 +126,8 @@ pub fn create_new_blockchain() -> (
         MockValidator::new(true),
         MockValidator::new(true),
         MockValidator::new(true),
+        MockValidator::new(true),
+        MockValidator::new(true),
     );
     let db = MemoryDatabase::<HashDigest>::default();
     let mut db = BlockchainDatabase::new(db).unwrap();


### PR DESCRIPTION
## Description
- Added GenesisBlockValidator. This validator processes the genesis block header and ensures that the synced chain builds on the correct genesis block.
- Added ChainTipValidator. This validator processes the tip header and checks that the accounting balance and MMR states of the synced chain state is valid.
- Removed the unused CryptoFactories from the StatelessValidator. 
- Removed the unused blockchain_db from the orphan_pool in the Mempool.

## Motivation and Context
These validators are required to ensure that the synced horizon state is valid.

## How Has This Been Tested?
Added tests for checking the genesis block, checking the accounting balance and checking the MMR roots of the kernel set, output set and range proof set. 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [x] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch
* [x] I ran `cargo-fmt --all` before pushing
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
