### PR TITLE
PeerConnection can open negotiated substreams

### DIFF
--- a/comms/src/connection_manager/error.rs
+++ b/comms/src/connection_manager/error.rs
@@ -20,7 +20,7 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use crate::peer_manager::PeerManagerError;
+use crate::{peer_manager::PeerManagerError, protocol::ProtocolError};
 use derive_error::Error;
 use futures::channel::mpsc;
 
@@ -63,4 +63,5 @@ pub enum PeerConnectionError {
     InternalReplyCancelled,
     /// Failed to send internal request
     InternalRequestSendFailed(mpsc::SendError),
+    ProtocolError(ProtocolError),
 }

--- a/comms/src/connection_manager/tests/listener_dialer.rs
+++ b/comms/src/connection_manager/tests/listener_dialer.rs
@@ -30,11 +30,14 @@ use crate::{
     },
     noise::NoiseConfig,
     peer_manager::{Peer, PeerFeatures, PeerFlags},
+    protocol::ProtocolId,
     test_utils::node_identity::build_node_identity,
     transports::MemoryTransport,
 };
 use futures::{
     channel::{mpsc, oneshot},
+    AsyncReadExt,
+    AsyncWriteExt,
     SinkExt,
     StreamExt,
 };
@@ -56,6 +59,7 @@ fn listen() -> Result<(), Box<dyn Error>> {
         MemoryTransport,
         noise_config.clone(),
         event_tx.clone(),
+        vec![],
         shutdown.to_signal(),
     );
 
@@ -76,26 +80,32 @@ fn listen() -> Result<(), Box<dyn Error>> {
 }
 
 #[test]
-fn smoke() -> Result<(), Box<dyn Error>> {
-    let mut rt = Runtime::new()?;
-    let (event_tx, mut event_rx) = mpsc::channel(100);
+fn smoke() {
+    // This test sets up Dialer and Listener components, uses the Dialer to dial the Listener,
+    // asserts the emitted events are correct, opens a substream, sends a small message over the substream,
+    // receives and checks the message and then disconnects and shuts down.
+    let mut rt = Runtime::new().unwrap();
+    let (event_tx, mut event_rx) = mpsc::channel(10);
     let mut shutdown = Shutdown::new();
 
     let node_identity1 = build_node_identity(PeerFeatures::COMMUNICATION_NODE);
     let noise_config1 = NoiseConfig::new(node_identity1.clone());
+    let expected_proto = ProtocolId::from_static(b"/tari/test-proto");
+    let supported_protocols = vec![expected_proto.clone()];
     let listener = PeerListener::new(
         rt.handle().clone(),
-        "/memory/0".parse()?,
+        "/memory/0".parse().unwrap(),
         MemoryTransport,
         noise_config1,
         event_tx.clone(),
+        supported_protocols.clone(),
         shutdown.to_signal(),
     );
 
     let listener_fut = rt.spawn(listener.run());
 
     let node_identity2 = build_node_identity(PeerFeatures::COMMUNICATION_NODE);
-    let noise_config2 = NoiseConfig::new(node_identity2);
+    let noise_config2 = NoiseConfig::new(node_identity2.clone());
     let (mut request_tx, request_rx) = mpsc::channel(1);
     let dialer = Dialer::new(
         rt.handle().clone(),
@@ -105,6 +115,7 @@ fn smoke() -> Result<(), Box<dyn Error>> {
         Arc::new(ConstantBackoff::new(Duration::from_millis(100))),
         request_rx,
         event_tx,
+        supported_protocols,
         shutdown.to_signal(),
     );
 
@@ -125,21 +136,42 @@ fn smoke() -> Result<(), Box<dyn Error>> {
         peer.set_id_for_test(1);
 
         let (reply_tx, reply_rx) = oneshot::channel();
-        request_tx.send(DialerRequest::Dial(Box::new(peer), reply_tx)).await?;
+        request_tx
+            .send(DialerRequest::Dial(Box::new(peer), reply_tx))
+            .await
+            .unwrap();
 
-        let mut _outbound_peer_conn = reply_rx.await.unwrap().unwrap();
-        // TODO: Test opening substream, basic comms and polite disconnect
-        //        let substream = outbound_peer_conn.open_substream("/tari/todo-proto").await?;
-        //        outbound_peer_conn.disconnect().await?;
+        let mut outbound_peer_conn = reply_rx.await.unwrap().unwrap();
 
+        // Open a substream
+        {
+            let mut out_stream = outbound_peer_conn.open_substream("/tari/test-proto").await.unwrap();
+            out_stream.stream.write_all(b"HELLO").await.unwrap();
+            out_stream.stream.flush().await.unwrap();
+        }
+
+        // Read PeerConnected events - we don't know which connection is which
+        unpack_enum!(ConnectionManagerEvent::PeerConnected(conn1) = event_rx.next().await.unwrap());
+        unpack_enum!(ConnectionManagerEvent::PeerConnected(conn2) = event_rx.next().await.unwrap());
+
+        // Next event should be a NewInboundSubstream has been received
         let listen_event = event_rx.next().await.unwrap();
-        unpack_enum!(ConnectionManagerEvent::PeerConnected(_inbound_peer_conn) = listen_event);
+        {
+            unpack_enum!(ConnectionManagerEvent::NewInboundSubstream(public_key, proto, in_stream) = listen_event);
+            assert_eq!(&*public_key, node_identity2.public_key());
+            assert_eq!(proto, expected_proto);
+
+            let mut buf = [0u8; 5];
+            in_stream.read_exact(&mut buf).await.unwrap();
+            assert_eq!(buf, *b"HELLO");
+        }
+
+        let _ = conn1.disconnect().await;
+        let _ = conn2.disconnect().await;
 
         shutdown.trigger().unwrap();
 
         timeout(Duration::from_secs(5), listener_fut).await.unwrap().unwrap();
         timeout(Duration::from_secs(5), dialer_fut).await.unwrap().unwrap();
-
-        Ok(())
-    })
+    });
 }

--- a/comms/src/lib.rs
+++ b/comms/src/lib.rs
@@ -37,9 +37,10 @@ pub mod types;
 cfg_next! {
     mod multiplexing;
     mod noise;
+    mod protocol;
     mod socks;
-    pub mod memsocket;
 
+    pub mod memsocket;
     pub mod transports;
 }
 

--- a/comms/src/macros.rs
+++ b/comms/src/macros.rs
@@ -96,9 +96,9 @@ macro_rules! acquire_read_lock {
 /// instead of writing `if let Err(err) = my_error_call() { error!(...) }`, you can write
 /// `log_if_error!(my_error_call())`
 ///
-/// ```edition2018
+/// ```edition2018,no_compile
 /// # use tari_common::log_if_error;
-/// let opt = log_if_error!(level: debug, target: "docs", "Error sending reply: {}", Result::<(), _>::Err("this will be logged"));
+/// let opt = log_if_error!(target: "docs", level: debug, Result::<(), _>::Err("this will be logged as 'error' tag"), "Error: {error}");
 /// assert_eq!(opt, None);
 /// ```
 #[macro_export]

--- a/comms/src/peer_manager/peer_id.rs
+++ b/comms/src/peer_manager/peer_id.rs
@@ -23,6 +23,7 @@
 use crate::consts::COMMS_RNG;
 use rand::RngCore;
 
+/// Represents a local peer id. This number is meaningless outside of this node.
 pub type PeerId = u64;
 
 pub fn generate_peer_key() -> PeerId {

--- a/comms/src/protocol/error.rs
+++ b/comms/src/protocol/error.rs
@@ -1,4 +1,4 @@
-// Copyright 2019, The Tari Project
+// Copyright 2020, The Tari Project
 //
 // Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
 // following conditions are met:
@@ -20,25 +20,20 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-pub mod deprecated;
+use derive_error::Error;
+use futures::channel::mpsc;
+use std::io;
 
-pub use deprecated::*;
-
-cfg_next! {
-    mod dial_state;
-    mod dialer;
-    mod error;
-    mod listener;
-    mod manager;
-    mod peer_connection;
-    mod requester;
-    mod utils;
-
-    pub mod next {
-        pub use super::manager::{ConnectionManager, ConnectionManagerConfig, ConnectionManagerEvent};
-        pub use super::requester::{ConnectionManagerRequester, ConnectionManagerRequest};
-    }
-
-    #[cfg(test)]
-    mod tests;
+#[derive(Debug, Error)]
+pub enum ProtocolError {
+    IoError(io::Error),
+    /// The ProtocolId was longer than 255
+    ProtocolIdTooLong,
+    /// Protocol negotiation failed because the peer did not accept any protocols
+    ProtocolOutboundNegotiationFailed,
+    /// Protocol negotiation terminated by peer
+    ProtocolNegotiationTerminatedByPeer,
+    /// Protocol was not registered
+    ProtocolNotRegistered,
+    SendError(mpsc::SendError),
 }

--- a/comms/src/protocol/mod.rs
+++ b/comms/src/protocol/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2019, The Tari Project
+// Copyright 2020, The Tari Project
 //
 // Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
 // following conditions are met:
@@ -20,25 +20,14 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-pub mod deprecated;
+mod error;
+mod negotiation;
+mod notifiers;
 
-pub use deprecated::*;
+/// Represents a protocol id string (e.g. /tari/transactions/1.0.0).
+/// This is atomically reference counted, so clones are shallow and cheap
+pub type ProtocolId = bytes::Bytes;
 
-cfg_next! {
-    mod dial_state;
-    mod dialer;
-    mod error;
-    mod listener;
-    mod manager;
-    mod peer_connection;
-    mod requester;
-    mod utils;
-
-    pub mod next {
-        pub use super::manager::{ConnectionManager, ConnectionManagerConfig, ConnectionManagerEvent};
-        pub use super::requester::{ConnectionManagerRequester, ConnectionManagerRequest};
-    }
-
-    #[cfg(test)]
-    mod tests;
-}
+pub use error::ProtocolError;
+pub use negotiation::ProtocolNegotiation;
+pub use notifiers::{ProtocolEvent, ProtocolNotifier};

--- a/comms/src/protocol/notifiers.rs
+++ b/comms/src/protocol/notifiers.rs
@@ -1,0 +1,145 @@
+// Copyright 2020, The Tari Project
+//
+// Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+// following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+// disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+// following disclaimer in the documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+// products derived from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+// INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+// WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+// USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+use crate::{
+    peer_manager::PeerId,
+    protocol::{ProtocolError, ProtocolId},
+};
+use futures::{channel::mpsc, SinkExt};
+use std::collections::HashMap;
+
+#[derive(Debug, Clone)]
+pub enum ProtocolEvent<TSubstream> {
+    NewSubstream(PeerId, TSubstream),
+}
+
+#[derive(Debug, Clone)]
+pub struct Notification<TSubstream> {
+    pub event: ProtocolEvent<TSubstream>,
+    pub protocol: ProtocolId,
+}
+
+impl<TSubstream> Notification<TSubstream> {
+    pub fn new(protocol: ProtocolId, event: ProtocolEvent<TSubstream>) -> Self {
+        Self { protocol, event }
+    }
+}
+
+#[derive(Clone)]
+pub struct ProtocolNotifier<TSubstream> {
+    notifiers: HashMap<ProtocolId, mpsc::Sender<Notification<TSubstream>>>,
+}
+
+impl<TSubstream> Default for ProtocolNotifier<TSubstream> {
+    fn default() -> Self {
+        Self {
+            notifiers: HashMap::default(),
+        }
+    }
+}
+
+impl<TSubstream> ProtocolNotifier<TSubstream> {
+    pub fn new() -> Self {
+        Default::default()
+    }
+
+    pub fn add(&mut self, protocols: &[ProtocolId], notifier: mpsc::Sender<Notification<TSubstream>>) {
+        self.notifiers
+            .extend(protocols.iter().map(|p| (p.clone(), notifier.clone())));
+    }
+
+    pub fn get_supported_protocols(&self) -> Vec<ProtocolId> {
+        self.notifiers.keys().cloned().collect()
+    }
+
+    pub async fn notify(
+        &mut self,
+        protocol: &ProtocolId,
+        event: ProtocolEvent<TSubstream>,
+    ) -> Result<(), ProtocolError>
+    {
+        match self.notifiers.get_mut(protocol) {
+            Some(sender) => {
+                sender.send(Notification::new(protocol.clone(), event)).await?;
+                Ok(())
+            },
+            None => Err(ProtocolError::ProtocolNotRegistered),
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use futures::StreamExt;
+    use tari_test_utils::unpack_enum;
+
+    #[test]
+    fn add() {
+        let mut notifiers = ProtocolNotifier::<()>::new();
+        let (tx, _) = mpsc::channel(1);
+        let protocols = &[
+            ProtocolId::from_static(b"/tari/test/1"),
+            ProtocolId::from_static(b"/tari/test/2"),
+        ];
+        notifiers.add(protocols, tx);
+
+        assert!(notifiers
+            .get_supported_protocols()
+            .contains(&&ProtocolId::from_static(b"/tari/test/2")))
+    }
+
+    #[tokio_macros::test_basic]
+    async fn notify() {
+        let mut notifiers = ProtocolNotifier::<()>::new();
+        let (tx, mut rx) = mpsc::channel(1);
+        let protocols = &[ProtocolId::from_static(b"/tari/test/1")];
+        notifiers.add(protocols, tx);
+
+        notifiers
+            .notify(
+                &ProtocolId::from_static(b"/tari/test/1"),
+                ProtocolEvent::NewSubstream(123, ()),
+            )
+            .await
+            .unwrap();
+
+        let notification = rx.next().await.unwrap();
+        unpack_enum!(ProtocolEvent::NewSubstream(peer_id, _s) = notification.event);
+        assert_eq!(peer_id, 123);
+    }
+
+    #[tokio_macros::test_basic]
+    async fn notify_fail_not_registered() {
+        let mut notifiers = ProtocolNotifier::<()>::new();
+
+        let err = notifiers
+            .notify(
+                &ProtocolId::from_static(b"/tari/test/0"),
+                ProtocolEvent::NewSubstream(123, ()),
+            )
+            .await
+            .unwrap_err();
+
+        unpack_enum!(ProtocolError::ProtocolNotRegistered = err);
+    }
+}

--- a/comms/src/test_utils/test_node.rs
+++ b/comms/src/test_utils/test_node.rs
@@ -27,6 +27,7 @@ use crate::{
     multiaddr::Multiaddr,
     noise::NoiseConfig,
     peer_manager::{NodeIdentity, PeerFeatures, PeerManager},
+    protocol::ProtocolNotifier,
     transports::TcpTransport,
 };
 use futures::channel::mpsc;
@@ -87,6 +88,7 @@ pub fn build_connection_manager(
         Arc::new(ConstantBackoff::new(config.dial_backoff_duration)),
         request_rx,
         peer_manager.into(),
+        ProtocolNotifier::new(),
         shutdown,
     );
 


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
- A peer connection can open substreams with a given protocol negotiated
- Implemented ProtocolNotifier, used to register mpsc senders given by
  domain-level components interested in speaking a particular protocol.
- Run Yamux Stream in it's own task, otherwise it doesn't work (bugfix)
- Extended dialer/listener test to include opening a substream and
  sending a message on that substream.


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #1158 and #1102 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Improved smoke test for listener and dialer

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [x] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [x] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [x] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch
* [x] I ran `cargo-fmt --all` before pushing
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
