### PR TITLE
Added OMS events

### DIFF
--- a/base_layer/core/src/base_node/service/service.rs
+++ b/base_layer/core/src/base_node/service/service.rs
@@ -390,7 +390,7 @@ where B: BlockchainBackend + 'static
             .map_err(|e| CommsInterfaceError::OutboundMessageService(e.to_string()))?;
 
         match send_result.resolve_ok().await {
-            Some(0) => {
+            Some(tags) if tags.len() == 0 => {
                 let _ = reply_tx
                     .send(Err(CommsInterfaceError::NoBootstrapNodesConfigured))
                     .or_else(|resp| {
@@ -401,7 +401,8 @@ where B: BlockchainBackend + 'static
                         Err(resp)
                     });
             },
-            Some(dest_count) => {
+            Some(tags) => {
+                let dest_count = tags.len();
                 // Wait for matching responses to arrive
                 self.waiting_requests.insert(request_key, WaitingRequest {
                     reply_tx: Some(reply_tx),

--- a/base_layer/core/src/mempool/service/service.rs
+++ b/base_layer/core/src/mempool/service/service.rs
@@ -319,7 +319,7 @@ where B: BlockchainBackend
             .map_err(|e| MempoolServiceError::OutboundMessageService(e.to_string()))?;
 
         match send_result.resolve_ok().await {
-            Some(n) if n > 0 => {
+            Some(tags) if tags.len() > 0 => {
                 // Spawn timeout and wait for matching response to arrive
                 self.waiting_requests.insert(request_key, Some(reply_tx));
                 self.spawn_request_timeout(request_key, self.config.request_timeout)

--- a/base_layer/p2p/src/services/liveness/service.rs
+++ b/base_layer/p2p/src/services/liveness/service.rs
@@ -483,7 +483,7 @@ mod test {
             rt.spawn(async move {
                 match outbound_rx.select_next_some().await {
                     DhtOutboundRequest::SendMessage(_, _, reply_tx) => {
-                        reply_tx.send(SendMessageResponse::Ok(0)).unwrap();
+                        reply_tx.send(SendMessageResponse::Queued(vec![])).unwrap();
                     },
                 }
             });

--- a/base_layer/p2p/src/test_utils.rs
+++ b/base_layer/p2p/src/test_utils.rs
@@ -45,7 +45,7 @@ macro_rules! unwrap_oms_send_msg {
     ($var:expr) => {
         unwrap_oms_send_msg!(
             $var,
-            reply_value = tari_comms_dht::outbound::SendMessageResponse::Ok(0)
+            reply_value = tari_comms_dht::outbound::SendMessageResponse::Queued(vec![])
         );
     };
 }

--- a/base_layer/wallet/src/transaction_service/service.rs
+++ b/base_layer/wallet/src/transaction_service/service.rs
@@ -364,7 +364,7 @@ where
             )
             .await?
         {
-            SendMessageResponse::Ok(_) => (),
+            SendMessageResponse::Queued(_) => (),
             SendMessageResponse::Failed => return Err(TransactionServiceError::OutboundSendFailure),
             SendMessageResponse::PendingDiscovery(r) => {
                 // The sending of the message resulted in a long running Discovery process being performed by the Comms
@@ -965,8 +965,8 @@ async fn transaction_send_discovery_process_completion<TBackend: TransactionBack
     let mut success = false;
     match response_channel.await {
         Ok(response) => match response {
-            SendMessageResponse::Ok(n) => {
-                if n == 0 {
+            SendMessageResponse::Queued(tags) => {
+                if tags.len() == 0 {
                     error!(
                         target: LOG_TARGET,
                         "Send Discovery process for TX_ID: {} was unsuccessful and no message was sent", tx_id
@@ -974,7 +974,9 @@ async fn transaction_send_discovery_process_completion<TBackend: TransactionBack
                 } else {
                     info!(
                         target: LOG_TARGET,
-                        "Transaction (TxId: {}) Send Discovery process successful? {}", tx_id, n
+                        "Transaction (TxId: {}) Send Discovery process successful? {}",
+                        tx_id,
+                        tags.len()
                     );
                     success = true;
                 }

--- a/comms/Cargo.toml
+++ b/comms/Cargo.toml
@@ -35,7 +35,7 @@ serde_derive = "1.0.90"
 serde_repr = "0.1.5"
 snow = {version="0.6.2", features=["default-resolver"], optional = true}
 time = "0.1.42"
-tokio = {version="^0.2", features=["blocking", "tcp", "stream", "dns"]}
+tokio = {version="^0.2", features=["blocking", "tcp", "stream", "dns", "sync"]}
 ttl_cache = "0.5.1"
 yamux = {version="0.4.0", optional = true}
 zmq = "0.9.2"

--- a/comms/dht/Cargo.toml
+++ b/comms/dht/Cargo.toml
@@ -14,10 +14,10 @@ test-mocks = []
 
 [dependencies]
 tari_comms = { version = "^0.0", path = "../"}
-tari_crypto = { version = "^0.0", path = "../../infrastructure/crypto"}
-tari_utilities = { version = "^0.0", path = "../../infrastructure/tari_util"}
-tari_shutdown = { version = "^0.0", path = "../../infrastructure/shutdown"}
 tari_comms_middleware = { version = "^0.0", path = "../middleware"}
+tari_crypto = { version = "^0.0", path = "../../infrastructure/crypto"}
+tari_shutdown = { version = "^0.0", path = "../../infrastructure/shutdown"}
+tari_utilities = { version = "^0.0", path = "../../infrastructure/tari_util"}
 
 bitflags = "1.2.0"
 bytes = "0.4.12"

--- a/comms/dht/src/outbound/mock.rs
+++ b/comms/dht/src/outbound/mock.rs
@@ -144,7 +144,7 @@ impl OutboundServiceMock {
                     let response = self
                         .mock_state
                         .take_next_response()
-                        .or(Some(SendMessageResponse::Ok(0)))
+                        .or(Some(SendMessageResponse::Queued(vec![])))
                         .expect("never none");
 
                     reply_tx.send(response).expect("Reply channel cancelled");

--- a/comms/dht/src/test_utils/mod.rs
+++ b/comms/dht/src/test_utils/mod.rs
@@ -30,7 +30,10 @@ macro_rules! unwrap_oms_send_msg {
         }
     };
     ($var:expr) => {
-        unwrap_oms_send_msg!($var, reply_value = $crate::outbound::SendMessageResponse::Ok(0));
+        unwrap_oms_send_msg!(
+            $var,
+            reply_value = $crate::outbound::SendMessageResponse::Queued(vec![])
+        );
     };
 }
 

--- a/comms/src/outbound_message_service/event.rs
+++ b/comms/src/outbound_message_service/event.rs
@@ -1,4 +1,4 @@
-// Copyright 2019 The Tari Project
+// Copyright 2020, The Tari Project
 //
 // Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
 // following conditions are met:
@@ -20,32 +20,21 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-mod error;
-mod event;
-mod messages;
-mod service;
+use super::MessageTag;
+use crate::peer_manager::NodeId;
+use std::sync::Arc;
+use tokio::sync::broadcast;
 
-pub use self::{
-    error::OutboundServiceError,
-    event::{OutboundEvent, OutboundEventPublisher, OutboundEventSubscription},
-    messages::{MessageTag, OutboundMessage},
-    service::OutboundMessageService,
-};
+pub type OutboundEventSubscription = broadcast::Receiver<Arc<OutboundEvent>>;
+pub type OutboundEventPublisher = broadcast::Sender<Arc<OutboundEvent>>;
 
-/// Configuration for the OutboundService
-pub struct OutboundServiceConfig {
-    /// Maximum size of the recent connection cache. This cache keeps active connections
-    /// for reuse with subsequent messages without querying the connection manager. Default: 20
-    pub max_cached_connections: usize,
-    /// Maximum attempts to send a message before discarding it. Default: 5
-    pub max_attempts: usize,
-}
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum OutboundEvent {
+    PeerDialStart(NodeId),
+    PeerDialSuccess(NodeId),
+    PeerDialFail(NodeId),
+    PeerDialRetry(NodeId, usize),
 
-impl Default for OutboundServiceConfig {
-    fn default() -> Self {
-        Self {
-            max_attempts: 5,
-            max_cached_connections: 20,
-        }
-    }
+    MessageSendSuccess(MessageTag, NodeId),
+    MessageSendFail(MessageTag, NodeId),
 }


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Currently, there is no way for domain clients to tell if a message has
succeeded or failed to send to a peer.

The PR adds this ability.

When a call to the OMS is made each message is 'tagged' (i.e random `u64`)
so that it can be uniquely identified later. These tags are returned to the caller.
The caller can expect that the same tag will be part of an OMS event
indicating that the message has been (un)successfully sent.

The following events can be emitted by the OMS

```rust
pub enum OutboundEvent {
    PeerDialStart(NodeId),
    PeerDialSuccess(NodeId),
    PeerDialFail(NodeId),
    PeerDialRetry(NodeId, usize),

    MessageSendSuccess(MessageTag, NodeId),
    MessageSendFail(MessageTag, NodeId),
}
```

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #1238 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Emitted events tested in existing oms integration test

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [x] Breaking change (fix or feature that would cause existing functionality to change)
* [x] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [x] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch
* [x] I ran `cargo-fmt --all` before pushing
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
