### PR TITLE
Library Build Script - Catalina Fix

### DIFF
--- a/base_layer/wallet_ffi/README.md
+++ b/base_layer/wallet_ffi/README.md
@@ -72,14 +72,6 @@ rustup toolchain add nightly-2019-10-04
 rustup default nightly-2019-10-04
 rustup component add rustfmt --toolchain nightly
 rustup component add clippy
-rustup target add x86_64-linux-android 
-rustup target add aarch64-linux-android 
-rustup target add armv7-linux-androideabi 
-rustup target add i686-linux-android arm-linux-androideabi
-rustup target add aarch64-apple-ios
-rustup target add x86_64-apple-ios
-cargo install cargo-ndk
-cargo install cargo-lipo
 ```
 
 ## Build Configuration
@@ -107,6 +99,8 @@ The following changes need to be made to the file
 2. ```ANDROID_WALLET``` needs to be changed to the path of the Android-Wallet repository
 3. ```IOS_WALLET_PATH``` needs to be changed to the path of the Wallet-iOS repository
 4. ```TARI_REPO_PATH``` needs to be changed to the path of the Tari repository
+5. ```BUILD_ANDROID``` can be set to ```0``` to disable Android library build
+6. ```BUILD_IOS``` can be set to ```0``` to disable iOS library build
 
 Save the file and rename it to ```build.config```
 

--- a/base_layer/wallet_ffi/mobile_build.sh
+++ b/base_layer/wallet_ffi/mobile_build.sh
@@ -1,11 +1,32 @@
 #!/bin/bash
+#
+# Script to build libraries for Tari Wallet
+#
+
+#Terminal colors
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+PURPLE='\033[0;35m'
+CYAN='\033[0;36m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
 source build.config
-CURRENT_DIR=$TARI_REPO_PATH/base_layer/wallet_ffi
+CURRENT_DIR=${TARI_REPO_PATH}/base_layer/wallet_ffi
+cd ${CURRENT_DIR} || exit
+timestamp=$(date +%s)
+mkdir -p logs
+cd logs || exit
+mkdir -p ${timestamp}
+cd ${timestamp} || exit
+mkdir -p ios
+mkdir -p android
+cd ../..
+IOS_LOG_PATH=${CURRENT_DIR}/logs/${timestamp}/ios
+ANDROID_LOG_PATH=${CURRENT_DIR}/logs/${timestamp}/android
 ZMQ_FOLDER=libzmq
 SQLITE_FOLDER=sqlite
-cd ..
-cd ..
-cd ..
+cd ../../..
 
 unameOut="$(uname -s)"
 case "${unameOut}" in
@@ -16,156 +37,270 @@ case "${unameOut}" in
     *)          MACHINE="UNKNOWN:${unameOut}"
 esac
 export PKG_CONFIG_ALLOW_CROSS=1
-DEPENDENCIES=$IOS_WALLET_PATH
-if [ ! -z "$DEPENDENCIES" ] && [ ! -z "$PKG_PATH" ] && [ "$BUILD_IOS" -eq 1 ] && [ "$MACHINE" == "Mac" ]; then
+
+# Fix for macOS Catalina failing to include correct headers for cross compilation
+if [ "${MACHINE}" == "Mac" ]; then
+  MAC_VERSION=$(sw_vers -productVersion)
+  MAC_SUB_VERSION=$(cut -d '.' -f2 <<<"${MAC_VERSION}")
+  if [ "${MAC_SUB_VERSION}" -ge 15 ]; then
+    unset CPATH
+    echo "${PURPLE}macOS 15+ Detected${NC}"
+  else
+     echo "${PURPLE}macOS 14 Detected${NC}"
+  fi
+fi
+
+DEPENDENCIES=${IOS_WALLET_PATH}
+# PKG_PATH, BUILD_IOS is defined in build.config
+# shellcheck disable=SC2153
+if [ -n "${DEPENDENCIES}" ] && [ -n "${PKG_PATH}" ] && [ "${BUILD_IOS}" -eq 1 ] && [ "${MACHINE}" == "Mac" ]; then
+  echo "${GREEN}Commencing iOS build${NC}"
+  echo "${YELLOW}Build logs can be found at ${IOS_LOG_PATH}${NC}"
+  echo "\t${CYAN}Configuring Rust${NC}"
+  rustup target add aarch64-apple-ios x86_64-apple-ios >> ${IOS_LOG_PATH}/rust.txt 2>&1
+  cargo install cargo-lipo >> ${IOS_LOG_PATH}/rust.txt 2>&1
+  echo "\t${CYAN}Configuring complete${NC}"
+  ZMQ_BUILD_FOUND=0
+  if [ -f ${DEPENDENCIES}/MobileWallet/TariLib/libzmq.a ]; then
+    ZMQ_BUILD_FOUND=1
+  fi
   #below line is temporary
   ZMQ_REPO_IOS="https://github.com/azawawi/libzmq-ios"
-  cd $DEPENDENCIES
+  cd ${DEPENDENCIES} || exit
   mkdir -p build
-  cd build
+  cd build || exit
   BUILD_ROOT=$PWD
   cd ..
-  if [ ! -d "${ZMQ_FOLDER}-ios" ]; then
-    git clone $ZMQ_REPO_IOS
-    cd ${ZMQ_FOLDER}-ios
+  if [ ${ZMQ_BUILD_FOUND} -eq 0 ]; then
+    echo "\t${CYAN}Fetching ZMQ source${NC}"
+    if [ ! -d "${ZMQ_FOLDER}-ios" ]; then
+      git clone ${ZMQ_REPO_IOS} > ${IOS_LOG_PATH}/zmq.txt 2>&1
+      cd ${ZMQ_FOLDER}-ios || exit
+    else
+      cd ${ZMQ_FOLDER}-ios || exit
+      git pull > ${IOS_LOG_PATH}/zmq.txt 2>&1
+    fi
+    echo "\t${CYAN}Source fetched${NC}"
+    # On macOS catalina, build for 32bit will throw linker error for unsupported architecture, can be safely ignored.
+    # Only libs we interested in from the below build script are for aarch64 and x86_64
+    echo "\t${CYAN}Building ZMQ${NC}"
+    ruby libzmq.rb >> ${IOS_LOG_PATH}/zmq.txt 2>&1
+    echo "\t${CYAN}ZMQ built${NC}"
+    cp "${PWD}/dist/ios/lib/libzmq.a" "${DEPENDENCIES}/MobileWallet/TariLib/"
   else
-    cd ${ZMQ_FOLDER}-ios
-    git pull
+    echo "\t${CYAN}ZMQ located${NC}"
   fi
-  ruby libzmq.rb
-  cp "${PWD}/dist/ios/lib/libzmq.a" "${DEPENDENCIES}/MobileWallet/TariLib/"
-  cd ${CURRENT_DIR}
+  cd ${CURRENT_DIR} || exit
   cargo clean
   cp wallet.h "${DEPENDENCIES}/MobileWallet/TariLib/"
   export PKG_CONFIG_PATH=${PKG_PATH}
-  cargo-lipo lipo --release
-  cd ..
-  cd ..
-  cd target
-  cd universal
-  cd release
+  echo "\t${CYAN}Building Wallet FFI${NC}"
+  cargo-lipo lipo --release > ${IOS_LOG_PATH}/cargo.txt 2>&1
+  cd ../..
+  cd target || exit
+  cd universal || exit
+  cd release || exit
   cp libwallet_ffi.a "${DEPENDENCIES}/MobileWallet/TariLib/"
-  cd ..
-  cd ..
-  cd ..
+  cd ../../.. || exit
   rm -rf target
-  cd ${DEPENDENCIES}
+  cd ${DEPENDENCIES} || exit
   rm -rf ${ZMQ_FOLDER}-ios
+  echo "${GREEN}iOS build completed${NC}"
 else
-  echo "Cannot configure iOS Wallet Library build"
+  if [ "${BUILD_IOS}" -eq 1 ]; then
+    echo "${RED}Cannot configure iOS Wallet Library build${NC}"
+  else
+    echo "${GREEN}iOS Wallet is configured not to build${NC}"
+  fi
 fi
 
 DEPENDENCIES=$ANDROID_WALLET_PATH
-if [ ! -z "$DEPENDENCIES" ] && [ ! -z "$NDK_PATH" ] && [ ! -z "$PKG_PATH" ] && [ "$BUILD_ANDROID" -eq 1 ]; then
-  DEPENDENCIES=$DEPENDENCIES/jniLibs
-  cd $DEPENDENCIES
-  mkdir -p build
-  cd build
-  BUILD_ROOT=$PWD
-  cd ..
-  if [ ! -d $ZMQ_FOLDER ]; then
-    git clone $ZMQ_REPO
-    cd $ZMQ_FOLDER
-  else
-    cd $ZMQ_FOLDER
-    git pull
+# PKG_PATH, BUILD_ANDROID, NDK_PATH is defined in build.config
+# shellcheck disable=SC2153
+if [ -n "${DEPENDENCIES}" ] && [ -n "${NDK_PATH}" ] && [ -n "${PKG_PATH}" ] && [ "${BUILD_ANDROID}" -eq 1 ]; then
+  echo "${GREEN}Commencing Android build${NC}"
+  echo "${YELLOW}Build logs can be found at ${ANDROID_LOG_PATH}${NC}"
+  echo "\t${CYAN}Configuring Rust${NC}"
+  rustup target add x86_64-linux-android aarch64-linux-android armv7-linux-androideabi i686-linux-android arm-linux-androideabi > ${ANDROID_LOG_PATH}/rust.txt 2>&1
+  if [ "${MAC_SUB_VERSION}" -lt 15 ]; then
+    cargo install cargo-ndk >> ${ANDROID_LOG_PATH}/rust.txt 2>&1
+  fi
+  echo "\t${CYAN}Configuring complete${NC}"
+  export NDK_HOME=${NDK_PATH}
+  export PKG_CONFIG_PATH=${PKG_PATH}
+  export NDK_TOOLCHAIN_VERSION=clang
+  DEPENDENCIES=${DEPENDENCIES}/jniLibs
+
+  ZMQ_BUILD_FOUND=0
+  if [ -f ${DEPENDENCIES}/i686/libzmq.a ] && [ -f ${DEPENDENCIES}/x86_64/libzmq.a ] && [ -f ${DEPENDENCIES}/armeabi-v7a/libzmq.a ] && [ -f ${DEPENDENCIES}/arm64-v8a/libzmq.a ]; then
+    ZMQ_BUILD_FOUND=1
   fi
 
-  export NDK_HOME=$NDK_PATH
-  export PKG_CONFIG_PATH=$PKG_PATH
-  export NDK_TOOLCHAIN_VERSION=clang
+  SQLITE_BUILD_FOUND=0
+  if [ -f ${DEPENDENCIES}/i686/libsqlite3.a ] && [ -f ${DEPENDENCIES}/x86_64/libsqlite3.a ] && [ -f ${DEPENDENCIES}/armeabi-v7a/libsqlite3.a ] && [ -f ${DEPENDENCIES}/arm64-v8a/libsqlite3.a ]; then
+    SQLITE_BUILD_FOUND=1
+  fi
 
-  for PLATFORMABI in "aarch64-linux-android" "i686-linux-android" "armv7-linux-androideabi" "x86_64-linux-android"
+  cd ${DEPENDENCIES} || exit
+  mkdir -p build
+  cd build || exit
+  BUILD_ROOT=${PWD}
+  if [ "${MACHINE}" == "Mac" ]; then
+    if [ "${MAC_SUB_VERSION}" -ge 15 ]; then
+      cd ${NDK_HOME}/sources/cxx-stl/llvm-libc++/include || exit
+      mkdir -p sys
+      #Fix for missing header, c code should reference limits.h instead of syslimits.h, happens with code that has been around for a long time.
+      cp "${NDK_HOME}/sources/cxx-stl/llvm-libc++/include/limits.h" "${NDK_HOME}/sources/cxx-stl/llvm-libc++/include/sys/syslimits.h"
+      cd ${BUILD_ROOT} || exit
+    fi
+  fi
+  cd ..
+  if [ ${ZMQ_BUILD_FOUND} -eq 0 ]; then
+    echo "\t${CYAN}Fetching ZMQ source${NC}"
+    if [ ! -d ${ZMQ_FOLDER} ]; then
+      git clone ${ZMQ_REPO} > ${ANDROID_LOG_PATH}/zmq.txt 2>&1
+      cd ${ZMQ_FOLDER} || exit
+    else
+      cd ${ZMQ_FOLDER} || exit
+      git pull > ${ANDROID_LOG_PATH}/zmq.txt 2>&1
+    fi
+    echo "\t${CYAN}Source fetched${NC}"
+  else
+    echo "\t${CYAN}ZMQ located${NC}"
+  fi
+  for PLATFORMABI in "aarch64-linux-android" "x86_64-linux-android" "i686-linux-android" "armv7-linux-androideabi"
   do
+    # Lint warning for loop only running once is acceptable here
+    # shellcheck disable=SC2043
     for LEVEL in 24
     #21 22 23 26 26 27 28 29 not included at present
     do
-      PLATFORM=$(cut -d'-' -f1 <<<"$PLATFORMABI")
+      PLATFORM=$(cut -d'-' -f1 <<<"${PLATFORMABI}")
 
       PLATFORM_OUTDIR=""
-      if [ "$PLATFORM" == "i686" ]; then
+      if [ "${PLATFORM}" == "i686" ]; then
         PLATFORM_OUTDIR="x86"
-        elif [ "$PLATFORM" == "x86_64" ]; then
+        elif [ "${PLATFORM}" == "x86_64" ]; then
           PLATFORM_OUTDIR="x86_64"
-        elif [ "$PLATFORM" == "armv7" ]; then
+        elif [ "${PLATFORM}" == "armv7" ]; then
           PLATFORM_OUTDIR="armeabi-v7a"
-        elif [ "$PLATFORM" == "aarch64" ]; then
+        elif [ "${PLATFORM}" == "aarch64" ]; then
           PLATFORM_OUTDIR="arm64-v8a"
         else
-          PLATFORM_OUTDIR=$PLATFORM
+          PLATFORM_OUTDIR=${PLATFORM}
       fi
-      cd $BUILD_ROOT
-      mkdir -p $PLATFORM_OUTDIR
-      OUTPUT_DIR=$BUILD_ROOT/$PLATFORM_OUTDIR
-      echo $OUTPUT_DIR
-      cd $DEPENDENCIES
+      cd ${BUILD_ROOT} || exit
+      mkdir -p ${PLATFORM_OUTDIR}
+      OUTPUT_DIR=${BUILD_ROOT}/${PLATFORM_OUTDIR}
+      cd ${DEPENDENCIES} || exit
 
-      PLATFORMABI_TOOLCHAIN=$PLATFORMABI
-      PLATFORMABI_COMPILER=$PLATFORMABI
-      if [ "$PLATFORMABI" == "armv7-linux-androideabi" ]; then
+      PLATFORMABI_TOOLCHAIN=${PLATFORMABI}
+      PLATFORMABI_COMPILER=${PLATFORMABI}
+      if [ "${PLATFORMABI}" == "armv7-linux-androideabi" ]; then
         PLATFORMABI_TOOLCHAIN="arm-linux-androideabi"
         PLATFORMABI_COMPILER="armv7a-linux-androideabi"
       fi
-
       # set toolchain path
-      export TOOLCHAIN=$NDK_HOME/toolchains/llvm/prebuilt/darwin-x86_64/$PLATFORMABI_TOOLCHAIN
+      export TOOLCHAIN=${NDK_HOME}/toolchains/llvm/prebuilt/darwin-x86_64/${PLATFORMABI_TOOLCHAIN}
 
       # set the archiver
-      export AR=$NDK_HOME/toolchains/llvm/prebuilt/darwin-x86_64/bin/${PLATFORMABI_TOOLCHAIN}\-ar
+      export AR=${NDK_HOME}/toolchains/llvm/prebuilt/darwin-x86_64/bin/${PLATFORMABI_TOOLCHAIN}$'-'ar
 
       # set the assembler
-      export AS=$NDK_HOME/toolchains/llvm/prebuilt/darwin-x86_64/bin/${PLATFORMABI_TOOLCHAIN}\-as
+      export AS=${NDK_HOME}/toolchains/llvm/prebuilt/darwin-x86_64/bin/${PLATFORMABI_TOOLCHAIN}$'-'as
 
       # set the c and c++ compiler
-      CC=$NDK_HOME/toolchains/llvm/prebuilt/darwin-x86_64/bin/$PLATFORMABI_COMPILER
-      export CC=${CC}${LEVEL}\-clang
+      CC=${NDK_HOME}/toolchains/llvm/prebuilt/darwin-x86_64/bin/${PLATFORMABI_COMPILER}
+      export CC=${CC}${LEVEL}$'-'clang
       export CXX=${CC}++
 
-      # set c++ (pre)compilation flags
-      export CXXFLAGS="-stdlib=libstdc++ -isystem $NDK_HOME/sources/cxx-stl/llvm-libc++/include"
-
+      export CXXFLAGS="-stdlib=libstdc++ -isystem ${NDK_HOME}/sources/cxx-stl/llvm-libc++/include"
       # set the linker
-      export LD=$NDK_HOME/toolchains/llvm/prebuilt/darwin-x86_64/bin/${PLATFORMABI_TOOLCHAIN}\-ld
+      export LD=${NDK_HOME}/toolchains/llvm/prebuilt/darwin-x86_64/bin/${PLATFORMABI_TOOLCHAIN}$'-'ld
 
       # set linker flags
-      export LDFLAGS="-L$NDK_HOME/toolchains/llvm/prebuilt/darwin-x86_64/sysroot/usr/lib/$PLATFORMABI_TOOLCHAIN/$LEVEL -L$OUTPUT_DIR/lib -lc++"
+      export LDFLAGS="-L${NDK_HOME}/toolchains/llvm/prebuilt/darwin-x86_64/sysroot/usr/lib/${PLATFORMABI_TOOLCHAIN}/${LEVEL} -L${OUTPUT_DIR}/lib -lc++"
 
       # set the archive index generator tool
-      export RANLIB=$NDK_HOME/toolchains/llvm/prebuilt/darwin-x86_64/bin/${PLATFORMABI_TOOLCHAIN}\-ranlib
+      export RANLIB=${NDK_HOME}/toolchains/llvm/prebuilt/darwin-x86_64/bin/${PLATFORMABI_TOOLCHAIN}$'-'ranlib
 
       # set the symbol stripping tool
-      export STRIP=$NDK_HOME/toolchains/llvm/prebuilt/darwin-x86_64/bin/${PLATFORMABI_TOOLCHAIN}\-strip
+      export STRIP=${NDK_HOME}/toolchains/llvm/prebuilt/darwin-x86_64/bin/${PLATFORMABI_TOOLCHAIN}$'-'strip
 
       # set c flags
-      export CFLAGS=-DMDB_USE_ROBUST=0
+      #note: Add -v to below to see compiler output, include paths, etc
+      export CFLAGS="-DMDB_USE_ROBUST=0"
 
       # set cpp flags
-      export CPPFLAGS="-fPIC -I$OUTPUT_DIR/include"
+      export CPPFLAGS="-fPIC -I${OUTPUT_DIR}/include"
 
-      mkdir -p $SQLITE_FOLDER
-      cd $SQLITE_FOLDER
-      curl -s $SQLITE_SOURCE | tar -xvf - -C $PWD
-      cd *
-      make clean
-      ./configure --host=$PLATFORMABI --prefix=$OUTPUT_DIR
-      make install
-      cd ..
-      cd ..
-      cd $ZMQ_FOLDER
+      mkdir -p ${SQLITE_FOLDER}
+      cd ${SQLITE_FOLDER} || exit
+      if [ ${SQLITE_BUILD_FOUND} -eq 0 ]; then
+        echo "\t${CYAN}Fetching Sqlite3 source${NC}"
+        curl -s ${SQLITE_SOURCE} | tar -xvf - -C ${PWD} > ${ANDROID_LOG_PATH}/sqlite.txt 2>&1
+        echo "\t${CYAN}Source fetched${NC}"
+        cd * || exit
+        echo "\t${CYAN}Building Sqlite3${NC}"
+        make clean >> ${ANDROID_LOG_PATH}/sqlite.txt 2>&1
+        ./configure --host=${PLATFORMABI} --prefix=${OUTPUT_DIR} >> ${ANDROID_LOG_PATH}/sqlite.txt 2>&1
+        make install >> ${ANDROID_LOG_PATH}/sqlite.txt 2>&1
+        echo "\t${CYAN}Sqlite3 built${NC}"
+      else
+        echo "\t${CYAN}Sqlite3 located${NC}"
+      fi
+      cd ../..
 
-      make clean
-      ./autogen.sh
-      ./configure --enable-static --disable-shared --host=$PLATFORMABI --prefix=$OUTPUT_DIR
-      make install
-      export LDFLAGS="-L$NDK_HOME/toolchains/llvm/prebuilt/darwin-x86_64/sysroot/usr/lib/${PLATFORMABI_TOOLCHAIN}/${LEVEL} -L${OUTPUT_DIR}/lib -lc++ -lzmq -lsqilte3"
-      cd $OUTPUT_DIR/lib
-      rm *.so
-      rm *.la
-      cd $CURRENT_DIR
-      cargo clean
+      cd ${ZMQ_FOLDER} || exit
+      if [ ${ZMQ_BUILD_FOUND} -eq 0 ]; then
+        echo "\t${CYAN}Building ZMQ${NC}"
+        make clean >> ${ANDROID_LOG_PATH}/zmq.txt 2>&1
+        ./autogen.sh >> ${ANDROID_LOG_PATH}/zmq.txt 2>&1
+        ./configure --enable-static --disable-shared --host=${PLATFORMABI} --prefix=${OUTPUT_DIR} --without-docs >> ${ANDROID_LOG_PATH}/zmq.txt >> ${ANDROID_LOG_PATH}/zmq.txt 2>&1
+        make install >> ${ANDROID_LOG_PATH}/zmq.txt 2>&1
+        echo "\t${CYAN}ZMQ built${NC}"
+      fi
+      if [ "${MACHINE}" == "Mac" ]; then
+        if [ "${MAC_SUB_VERSION}" -ge 15 ]; then
+          # Not ideal, however necesary for cargo to pass additional flags
+          export CFLAGS="${CFLAGS} -I${NDK_HOME}/sources/cxx-stl/llvm-libc++/include -I${NDK_HOME}/toolchains/llvm/prebuilt/darwin-x86_64/sysroot/usr/include -I${NDK_HOME}/sysroot/usr/include/${PLATFORMABI}"
+        fi
+      fi
+      export LDFLAGS="-L${NDK_HOME}/toolchains/llvm/prebuilt/darwin-x86_64/sysroot/usr/lib/${PLATFORMABI_TOOLCHAIN}/${LEVEL} -L${OUTPUT_DIR}/lib -lc++ -lzmq -lsqilte3"
+      cd ${OUTPUT_DIR}/lib || exit
+
+      if [ ${ZMQ_BUILD_FOUND} -eq 1 ]; then
+        rm *.so
+        rm *.la
+      else
+        cp ${DEPENDENCIES}/${PLATFORM_OUTDIR}/libzmq.a ${OUTPUT_DIR}/lib/libzmq.a
+      fi
+      if [ ${SQLITE_BUILD_FOUND} -eq 1 ]; then
+       cp ${DEPENDENCIES}/${PLATFORM_OUTDIR}/libsqlite3.a ${OUTPUT_DIR}/lib/libsqlite3.a
+      fi
+
+      echo "\t${CYAN}Configuring Cargo${NC}"
+      cd ${CURRENT_DIR} || exit
+      cargo clean > ${ANDROID_LOG_PATH}/cargo.txt 2>&1
       mkdir -p .cargo
-      cd .cargo
-      cat > config <<EOF
+      cd .cargo || exit
+      if [ "${MACHINE}" == "Mac" ]; then
+        if [ "${MAC_SUB_VERSION}" -ge 15 ]; then
+          cat > config <<EOF
+[build]
+target = "${PLATFORMABI}"
+
+[target.${PLATFORMABI}]
+ar = "${AR}"
+linker = "${CC}"
+rustflags = "-L${OUTPUT_DIR}/lib"
+
+[target.${PLATFORMABI}.zmq]
+rustc-flags = "-L${OUTPUT_DIR}/lib"
+EOF
+
+        else
+          cat > config <<EOF
 [target.${PLATFORMABI}]
 ar = "${AR}"
 linker = "${CC}"
@@ -173,31 +308,52 @@ linker = "${CC}"
 [target.${PLATFORMABI}.zmq]
 rustc-flags = "-L${OUTPUT_DIR}/lib"
 EOF
-      cd ..
-      cargo ndk --target $PLATFORMABI --android-platform $LEVEL -- build --release
-      cp wallet.h $DEPENDENCIES/
+
+        fi
+      fi
+      echo "\t${CYAN}Configuring complete${NC}"
+      cd .. || exit
+      echo "\t${CYAN}Building Wallet FFI${NC}"
+      #note: add -vv to below to see verbose and build script output
+      if [ "${MACHINE}" == "Mac" ]; then
+        if [ "${MAC_SUB_VERSION}" -ge 15 ]; then
+          cargo build --lib --release >> ${ANDROID_LOG_PATH}/cargo.txt 2>&1
+        else
+          cargo ndk --target ${PLATFORMABI} --android-platform ${LEVEL} -- build --release >> ${ANDROID_LOG_PATH}/cargo.txt 2>&1
+        fi
+      else
+        cargo ndk --target ${PLATFORMABI} --android-platform ${LEVEL} -- build --release >> ${ANDROID_LOG_PATH}/cargo.txt 2>&1
+      fi
+      cp wallet.h ${DEPENDENCIES}/
       rm -rf .cargo
-      cd ..
-      cd ..
-      cd target
-      cd $PLATFORMABI
-      cd release
-      cp libwallet_ffi.a $OUTPUT_DIR
-      cd ..
-      cd ..
+      cd ../..
+      cd target || exit
+      cd ${PLATFORMABI} || exit
+      cd release || exit
+      cp libwallet_ffi.a ${OUTPUT_DIR}
+      cd ../..
       rm -rf target
-      cd $DEPENDENCIES
-      mkdir -p $PLATFORM_OUTDIR
-      cd $PLATFORM_OUTDIR
-      cp ${OUTPUT_DIR}/lib/libsqlite3.a $PWD
-      cp ${OUTPUT_DIR}/libwallet_ffi.a $PWD
-      cp ${OUTPUT_DIR}/lib/libzmq.a $PWD
+      cd ${DEPENDENCIES} || exit
+      mkdir -p ${PLATFORM_OUTDIR}
+      cd ${PLATFORM_OUTDIR} || exit
+      if [ ${SQLITE_BUILD_FOUND} -eq 0 ]; then
+        cp ${OUTPUT_DIR}/lib/libsqlite3.a ${PWD}
+      fi
+      cp ${OUTPUT_DIR}/libwallet_ffi.a ${PWD}
+      if [ ${ZMQ_BUILD_FOUND} -eq 0 ]; then
+        cp ${OUTPUT_DIR}/lib/libzmq.a ${PWD}
+      fi
     done
   done
-  cd $DEPENDENCIES
+  cd ${DEPENDENCIES} || exit
   rm -rf build
-  rm -rf $ZMQ_FOLDER
-  rm -rf $SQLITE_FOLDER
+  rm -rf ${ZMQ_FOLDER}
+  rm -rf ${SQLITE_FOLDER}
+  echo "${GREEN}Android build completed${NC}"
 else
-  echo "Cannot configure Android Wallet Library build"
+  if [ "${BUILD_ANDROID}" -eq 1 ]; then
+    echo "${RED}Cannot configure Android Wallet Library build${NC}"
+  else
+    echo "${GREEN}Android Wallet is configured not to build${NC}"
+  fi
 fi


### PR DESCRIPTION
Catalina Fix

## Description
Fixed build for macOS Catalina
Redirected output to log files
Added colored messages for output to terminal
Fixed all lints above weak-warning level
Check to determine if ZMQ and Sqlite3 dependencies need to be rebuilt or not
Updated readme

## Motivation and Context
Script was broken in macOS Catalina

## How Has This Been Tested?
Manually run on macOS Catalina

## Types of changes
* [x] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [x] Documentation

## Checklist:
* [x] I'm merging against the `development` branch
* [x] I ran `cargo-fmt --all` before pushing
* [x] My change requires a change to the documentation.
* [x] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
