### PR TITLE
Additional Library Methods

### DIFF
--- a/base_layer/wallet_ffi/src/lib.rs
+++ b/base_layer/wallet_ffi/src/lib.rs
@@ -1292,6 +1292,31 @@ pub unsafe extern "C" fn pending_outbound_transaction_get_amount(
     c_ulonglong::from((*transaction).amount)
 }
 
+/// Gets the fee of a TariPendingOutboundTransaction
+///
+/// ## Arguments
+/// `transaction` - The pointer to a TariPendingOutboundTransaction
+/// `error_out` - Pointer to an int which will be modified to an error code should one occur, may not be null. Functions
+/// as an out parameter.
+///
+/// ## Returns
+/// `c_ulonglong` - Returns the fee, note that it will be zero if transaction is null
+#[no_mangle]
+pub unsafe extern "C" fn pending_outbound_transaction_get_fee(
+    transaction: *mut TariPendingOutboundTransaction,
+    error_out: *mut c_int,
+) -> c_ulonglong
+{
+    let mut error = 0;
+    ptr::swap(error_out, &mut error as *mut c_int);
+    if transaction.is_null() {
+        error = LibWalletError::from(InterfaceError::NullError("transaction".to_string())).code;
+        ptr::swap(error_out, &mut error as *mut c_int);
+        return 0;
+    }
+    c_ulonglong::from((*transaction).fee)
+}
+
 /// Gets the timestamp of a TariPendingOutboundTransaction
 ///
 /// ## Arguments
@@ -1874,6 +1899,43 @@ pub unsafe extern "C" fn wallet_test_complete_sent_transaction(
             false
         },
     }
+}
+
+/// This function checks to determine if a TariCompletedTransaction was originally a TariPendingOutboundTransaction
+///
+/// ## Arguments
+/// `wallet` - The TariWallet pointer
+/// `tx` - The TariCompletedTransaction
+/// `error_out` - Pointer to an int which will be modified to an error code should one occur, may not be null. Functions
+/// as an out parameter.
+///
+/// ## Returns
+/// `bool` - Returns if the transaction was originally sent from the wallet
+#[no_mangle]
+pub unsafe extern "C" fn wallet_is_completed_transaction_outbound(
+    wallet: *mut TariWallet,
+    tx: *mut TariCompletedTransaction,
+    error_out: *mut c_int,
+) -> bool
+{
+    let mut error = 0;
+    ptr::swap(error_out, &mut error as *mut c_int);
+    if wallet.is_null() {
+        error = LibWalletError::from(InterfaceError::NullError("wallet".to_string())).code;
+        ptr::swap(error_out, &mut error as *mut c_int);
+        return false;
+    }
+    if tx.is_null() {
+        error = LibWalletError::from(InterfaceError::NullError("tx".to_string())).code;
+        ptr::swap(error_out, &mut error as *mut c_int);
+        return false;
+    }
+
+    if (*tx).source_public_key == (*wallet).comms.node_identity().public_key().clone() {
+        return true;
+    }
+
+    return false;
 }
 
 /// This function will simulate the process when a completed transaction is broadcast to

--- a/base_layer/wallet_ffi/wallet.h
+++ b/base_layer/wallet_ffi/wallet.h
@@ -205,6 +205,9 @@ struct TariPublicKey *pending_outbound_transaction_get_destination_public_key(st
 // Gets the amount of a TariPendingOutboundTransaction
 unsigned long long pending_outbound_transaction_get_amount(struct TariPendingOutboundTransaction *transaction,int* error_out);
 
+// Gets the fee of a TariPendingOutboundTransaction
+unsigned long long pending_outbound_transaction_get_fee(struct TariPendingOutboundTransaction *transaction,int* error_out);
+
 // Gets the message of a TariPendingOutboundTransaction
 const char *pending_outbound_transaction_get_message(struct TariPendingOutboundTransaction *transaction,int* error_out);
 
@@ -331,6 +334,10 @@ struct TariPendingInboundTransaction *wallet_get_pending_inbound_transaction_by_
 
 // Simulates completion of a TariPendingOutboundTransaction
 bool wallet_test_complete_sent_transaction(struct TariWallet *wallet, struct TariPendingOutboundTransaction *tx,int* error_out);
+
+// Checks if a TariCompletedTransaction was originally a TariPendingOutboundTransaction,
+// i.e the transaction was originally sent from the wallet
+bool wallet_is_completed_transaction_outbound(struct TariWallet *wallet, struct TariCompletedTransaction *tx,int* error_out);
 
 // Simulates the completion of a broadcasted TariPendingInboundTransaction
 bool wallet_test_broadcast_transaction(struct TariWallet *wallet, struct TariCompletedTransaction *tx, int* error_out);


### PR DESCRIPTION
PR#1203 seems to have been overwritten by a merge, submitting again.

Adds two additional methods to wallet_ffi
1)  wallet_is_completed_transaction_outbound-> determines if a completed transaction was originally sent from the wallet.
2)  pending_outbound_transaction_get_fee -> returns the fee of an outbound transaction.

## Description

## Motivation and Context
Requested by mobile developers

## How Has This Been Tested?
cargo test --all --all-features

## Types of changes
* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [x] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch
* [x] I ran `cargo-fmt --all` before pushing
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
