### PR TITLE
Add basenode interface to miner for stub functions

### DIFF
--- a/applications/tari_base_node/src/builder.rs
+++ b/applications/tari_base_node/src/builder.rs
@@ -167,7 +167,7 @@ pub fn configure_and_initialize_node(
     config: &GlobalConfig,
     id: NodeIdentity,
     rt: &mut Runtime,
-) -> Result<(CommsNode, NodeType), String>
+) -> Result<(CommsNode, NodeType, Arc<ServiceHandles>), String>
 {
     let id = Arc::new(id);
     let factories = Arc::new(CryptoFactories::default());
@@ -202,6 +202,7 @@ pub fn configure_and_initialize_node(
                     &outbound_interface,
                     BaseNodeStateMachineConfig::default(),
                 )),
+                handles,
             )
         },
         DatabaseType::LMDB(p) => {
@@ -237,6 +238,7 @@ pub fn configure_and_initialize_node(
                     &outbound_interface,
                     BaseNodeStateMachineConfig::default(),
                 )),
+                handles,
             )
         },
     };

--- a/applications/tari_base_node/src/main.rs
+++ b/applications/tari_base_node/src/main.rs
@@ -27,6 +27,8 @@ mod builder;
 mod cli;
 /// Application-specific constants
 mod consts;
+/// Miner lib Todo hide behind feature flag
+mod miner;
 
 use crate::builder::{create_and_save_id, load_identity};
 use log::*;
@@ -119,7 +121,7 @@ fn main() {
     };
 
     // Build, node, build!
-    let (comms, node) = match builder::configure_and_initialize_node(&node_config, node_id, &mut rt) {
+    let (comms, node, _handles) = match builder::configure_and_initialize_node(&node_config, node_id, &mut rt) {
         Ok(n) => n,
         Err(e) => {
             error!(target: LOG_TARGET, "Could not instantiate node instance. {}", e);

--- a/applications/tari_base_node/src/miner.rs
+++ b/applications/tari_base_node/src/miner.rs
@@ -1,4 +1,4 @@
-// Copyright 2019, The Tari Project
+// Copyright 2019. The Tari Project
 //
 // Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
 // following conditions are met:
@@ -19,11 +19,46 @@
 // SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
 
-mod blake_miner;
-mod coinbase_builder;
-mod error;
-mod miner;
+use futures::channel::mpsc::{Receiver, Sender};
+use std::sync::Arc;
+use tari_core::{
+    base_node::{
+        service::{BaseNodeServiceConfig, BaseNodeServiceInitializer},
+        BaseNodeStateMachine,
+        BaseNodeStateMachineConfig,
+        LocalNodeCommsInterface,
+        OutboundNodeCommsInterface,
+    },
+    blocks::Block,
+    chain_storage::{
+        create_lmdb_database,
+        BlockchainBackend,
+        BlockchainDatabase,
+        LMDBDatabase,
+        MemoryDatabase,
+        Validators,
+    },
+    consensus::ConsensusManager,
+    mempool::{Mempool, MempoolConfig, MempoolValidators},
+    mining::Miner,
+    proof_of_work::DiffAdjManager,
+    transactions::{
+        crypto::keys::SecretKey as SK,
+        types::{CryptoFactories, HashDigest, PrivateKey, PublicKey},
+    },
+};
+use tari_service_framework::handles::ServiceHandles;
 
-pub use coinbase_builder::CoinbaseBuilder;
-pub use miner::Miner;
+pub fn build_miner<B: BlockchainBackend>(
+    handles: Arc<ServiceHandles>,
+    node: &BaseNodeStateMachine<B>,
+    consensus_manager: ConsensusManager<B>,
+) -> Miner<B>
+{
+    let stop_flag = node.get_interrupt_flag();
+    let node_local_interface = handles.get_handle::<LocalNodeCommsInterface>().unwrap();
+    let miner = Miner::new(stop_flag, consensus_manager, &node_local_interface);
+    miner
+}

--- a/applications/tari_base_node/src/miner.rs
+++ b/applications/tari_base_node/src/miner.rs
@@ -24,30 +24,10 @@
 use futures::channel::mpsc::{Receiver, Sender};
 use std::sync::Arc;
 use tari_core::{
-    base_node::{
-        service::{BaseNodeServiceConfig, BaseNodeServiceInitializer},
-        BaseNodeStateMachine,
-        BaseNodeStateMachineConfig,
-        LocalNodeCommsInterface,
-        OutboundNodeCommsInterface,
-    },
-    blocks::Block,
-    chain_storage::{
-        create_lmdb_database,
-        BlockchainBackend,
-        BlockchainDatabase,
-        LMDBDatabase,
-        MemoryDatabase,
-        Validators,
-    },
+    base_node::{BaseNodeStateMachine, LocalNodeCommsInterface},
+    chain_storage::BlockchainBackend,
     consensus::ConsensusManager,
-    mempool::{Mempool, MempoolConfig, MempoolValidators},
     mining::Miner,
-    proof_of_work::DiffAdjManager,
-    transactions::{
-        crypto::keys::SecretKey as SK,
-        types::{CryptoFactories, HashDigest, PrivateKey, PublicKey},
-    },
 };
 use tari_service_framework::handles::ServiceHandles;
 

--- a/base_layer/core/src/base_node/comms_interface/error.rs
+++ b/base_layer/core/src/base_node/comms_interface/error.rs
@@ -24,7 +24,7 @@ use crate::{chain_storage::ChainStorageError, consensus::ConsensusManagerError};
 use derive_error::Error;
 use tari_service_framework::reply_channel::TransportChannelError;
 
-#[derive(Debug, Error, PartialEq)]
+#[derive(Debug, Error, PartialEq, Clone)]
 pub enum CommsInterfaceError {
     /// Access to the underlying storage mechanism failed
     UnexpectedApiResponse,

--- a/base_layer/core/src/mining/blake_miner.rs
+++ b/base_layer/core/src/mining/blake_miner.rs
@@ -28,7 +28,7 @@ use std::sync::{
     atomic::{AtomicBool, Ordering},
     Arc,
 };
-use tari_utilities::{epoch_time::EpochTime, ByteArray, ByteArrayError, Hashable};
+use tari_utilities::epoch_time::EpochTime;
 
 const MAX_TARGET: U256 = U256::MAX;
 

--- a/base_layer/core/src/mining/error.rs
+++ b/base_layer/core/src/mining/error.rs
@@ -20,7 +20,6 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use crate::base_node::comms_interface::CommsInterfaceError;
 use derive_error::Error;
 
 #[derive(Clone, Debug, PartialEq, Error)]

--- a/base_layer/core/src/mining/error.rs
+++ b/base_layer/core/src/mining/error.rs
@@ -20,6 +20,7 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+use crate::base_node::comms_interface::CommsInterfaceError;
 use derive_error::Error;
 
 #[derive(Clone, Debug, PartialEq, Error)]
@@ -31,5 +32,6 @@ pub enum MinerError {
     // Config issue
     ConfigError,
     // Error communicating to base node or wallet
-    CommunicationError,
+    #[error(msg_embedded, non_std, no_from)]
+    CommunicationError(String),
 }

--- a/base_layer/core/src/mining/miner.rs
+++ b/base_layer/core/src/mining/miner.rs
@@ -34,7 +34,6 @@ use crate::{
     },
 };
 use core::sync::atomic::AtomicBool;
-use futures::executor::block_on;
 use std::{
     sync::{atomic::Ordering, Arc},
     thread,
@@ -90,7 +89,7 @@ impl<B: BlockchainBackend> Miner<B> {
             );
             if result.is_some() {
                 block.header = result.unwrap();
-                self.send_block(block).await;
+                self.send_block(block).await?;
             }
         }
         Ok(())
@@ -166,8 +165,8 @@ impl<B: BlockchainBackend> Miner<B> {
     /// stub function, get private key and tx_id from wallet
     pub fn get_spending_key(
         &self,
-        amount: MicroTari,
-        maturity_height: u64,
+        _amount: MicroTari,
+        _maturity_height: u64,
     ) -> Result<(u64, PrivateKey, PrivateKey), MinerError>
     {
         let mut rng = rand::OsRng::new().unwrap();
@@ -177,5 +176,5 @@ impl<B: BlockchainBackend> Miner<B> {
     }
 
     /// Stub function to let wallet know about potential tx
-    pub fn submit_tx_to_wallet(&self, tx: &Transaction, id: u64) {}
+    pub fn submit_tx_to_wallet(&self, _tx: &Transaction, _id: u64) {}
 }

--- a/base_layer/core/src/mining/miner.rs
+++ b/base_layer/core/src/mining/miner.rs
@@ -21,11 +21,12 @@
 
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 use crate::{
-    blocks::{genesis_block::get_genesis_block, Block, NewBlockTemplate},
+    base_node::comms_interface::LocalNodeCommsInterface,
+    blocks::{Block, NewBlockTemplate},
     chain_storage::BlockchainBackend,
     consensus::{ConsensusConstants, ConsensusManager},
     mining::{blake_miner::CpuBlakePow, error::MinerError, CoinbaseBuilder},
-    proof_of_work::Difficulty,
+    proof_of_work::{Difficulty, PowAlgorithm},
     transactions::{
         tari_amount::MicroTari,
         transaction::Transaction,
@@ -33,35 +34,39 @@ use crate::{
     },
 };
 use core::sync::atomic::AtomicBool;
-use futures::channel::mpsc::{Receiver, Sender};
+use futures::executor::block_on;
 use std::{
     sync::{atomic::Ordering, Arc},
     thread,
     time,
-    time::Duration,
 };
 use tari_crypto::keys::SecretKey;
 
-struct Miner<B: BlockchainBackend> {
+pub struct Miner<B: BlockchainBackend> {
     kill_flag: Arc<AtomicBool>,
     stop_mining_flag: Arc<AtomicBool>,
-    tx: Sender<Block>,
     consensus: ConsensusManager<B>,
+    node_interface: LocalNodeCommsInterface,
 }
 
 impl<B: BlockchainBackend> Miner<B> {
     /// Constructs a new miner
-    pub fn new(stop_flag: Arc<AtomicBool>, tx: Sender<Block>, consensus: ConsensusManager<B>) -> Miner<B> {
+    pub fn new(
+        stop_flag: Arc<AtomicBool>,
+        consensus: ConsensusManager<B>,
+        node_interface: &LocalNodeCommsInterface,
+    ) -> Miner<B>
+    {
         Miner {
-            kill_flag: Arc::new(AtomicBool::new(false)),
-            tx,
+            kill_flag: stop_flag,
             consensus,
-            stop_mining_flag: stop_flag,
+            stop_mining_flag: Arc::new(AtomicBool::new(false)),
+            node_interface: node_interface.clone(),
         }
     }
 
     /// Async function to mine a block
-    pub fn mine(&mut self) -> Result<(), MinerError> {
+    pub async fn mine(&mut self) -> Result<(), MinerError> {
         // Lets make sure its set to mine
         while !self.kill_flag.load(Ordering::Relaxed) {
             while !self.stop_mining_flag.load(Ordering::Relaxed) {
@@ -73,10 +78,10 @@ impl<B: BlockchainBackend> Miner<B> {
             let flag = self.stop_mining_flag.clone();
             flag.store(false, Ordering::Relaxed);
 
-            let mut block_template = self.get_block_template()?;
+            let mut block_template = self.get_block_template().await?;
             self.add_coinbase(&mut block_template)?;
-            let mut block = self.get_block(block_template)?;
-            let difficulty = self.get_req_difficulty()?;
+            let mut block = self.get_block(block_template).await?;
+            let difficulty = self.get_req_difficulty().await?;
             let result = CpuBlakePow::mine(
                 difficulty,
                 block.header,
@@ -85,28 +90,49 @@ impl<B: BlockchainBackend> Miner<B> {
             );
             if result.is_some() {
                 block.header = result.unwrap();
-                self.tx.try_send(block);
+                self.send_block(block).await;
             }
         }
         Ok(())
     }
 
-    /// Stub function, temp use genesis block as template
-    pub fn get_block_template(&self) -> Result<NewBlockTemplate, MinerError> {
-        Ok(NewBlockTemplate::from(get_genesis_block()))
+    /// function, temp use genesis block as template
+    pub async fn get_block_template(&mut self) -> Result<NewBlockTemplate, MinerError> {
+        Ok(self
+            .node_interface
+            .get_new_block_template()
+            .await
+            .map_err(|e| MinerError::CommunicationError(e.to_string()))?)
     }
 
-    /// Stub function, temp use genesis block as template
-    pub fn get_block(&self, block: NewBlockTemplate) -> Result<Block, MinerError> {
-        Ok(get_genesis_block())
+    ///  function send block
+    pub async fn send_block(&mut self, block: Block) -> Result<(), MinerError> {
+        self.node_interface
+            .submit_block(block)
+            .await
+            .map_err(|e| MinerError::CommunicationError(e.to_string()))?;
+        Ok(())
     }
 
-    /// Stub function
-    pub fn get_req_difficulty(&self) -> Result<Difficulty, MinerError> {
-        Ok(Difficulty::min())
+    /// function, temp use genesis block as template
+    pub async fn get_block(&mut self, block: NewBlockTemplate) -> Result<Block, MinerError> {
+        Ok(self
+            .node_interface
+            .get_new_block(block)
+            .await
+            .map_err(|e| MinerError::CommunicationError(e.to_string()))?)
     }
 
-    /// stub function, this function gets called when a new block event is triggered. It will ensure that the miner
+    /// function to get the required difficulty
+    pub async fn get_req_difficulty(&mut self) -> Result<Difficulty, MinerError> {
+        Ok(self
+            .node_interface
+            .get_target_difficulty(PowAlgorithm::Blake)
+            .await
+            .map_err(|e| MinerError::CommunicationError(e.to_string()))?)
+    }
+
+    /// function, this function gets called when a new block event is triggered. It will ensure that the miner
     /// restarts/starts to mine.
     pub fn new_block_event(&mut self) {
         let flag = self.stop_mining_flag.clone();

--- a/base_layer/service_framework/src/reply_channel.rs
+++ b/base_layer/service_framework/src/reply_channel.rs
@@ -95,7 +95,7 @@ impl<TReq, TRes> Service<TReq> for SenderService<TReq, TRes> {
     }
 }
 
-#[derive(Debug, Error, Eq, PartialEq)]
+#[derive(Debug, Error, Eq, PartialEq, Clone)]
 pub enum TransportChannelError {
     /// Error occurred when sending
     SendError(SendError),


### PR DESCRIPTION
## Description
This PR adds a basenode local interface to the miner to replace stub functions. 
This PR adds in a builder for the basenode for the miner. And links this to be build. 

## Motivation and Context
This is all for linking the miner to the basenode so that it can receive data form the basenode. 


## Types of changes
* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
* [x] I'm merging against the `development` branch
* [x] I ran `cargo-fmt --all` before pushing
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
