### PR TITLE
Origin in DHT message is now optional, hash of message for dedup

### DIFF
--- a/base_layer/core/src/base_node/service/initializer.rs
+++ b/base_layer/core/src/base_node/service/initializer.rs
@@ -124,7 +124,7 @@ async fn extract_block(msg: Arc<PeerMessage>) -> Option<DomainMessage<Block>> {
         Ok(block) => {
             let block = match Block::try_from(block) {
                 Err(e) => {
-                    let origin = &msg.dht_header.origin_public_key;
+                    let origin = &msg.source_peer.public_key;
                     warn!(
                         target: LOG_TARGET,
                         "Inbound block message from {} was ill-formed. {}", origin, e

--- a/base_layer/core/src/chain_storage/async_db.rs
+++ b/base_layer/core/src/chain_storage/async_db.rs
@@ -43,25 +43,11 @@ macro_rules! make_async {
         pub async fn $fn<T>(db: BlockchainDatabase<T>) -> Result<$rtype, ChainStorageError>
         where T: BlockchainBackend + 'static {
             tokio::task::spawn_blocking(move || {
-                        db.$fn()
-                    })
-        //            poll_fn(move |_| {
-        //                match blocking(move || db.$fn()) {
-        //                    Poll::Pending => Poll::Pending,
-        //                     Map BlockingError -> ChainStorageError
-        //                    Poll::Ready(Err(e)) => Poll::Ready(Err(ChainStorageError::AccessError(format!(
-        //                        "Could not find a blocking thread to execute DB query. {}",
-        //                        e.to_string()
-        //                    )))),
-        //                     Unwrap and lift ChainStorageError
-        //                    Poll::Ready(Ok(Err(e))) => Poll::Ready(Err(e)),
-        //                     Unwrap and return result
-        //                    Poll::Ready(Ok(Ok(v))) => Poll::Ready(Ok(v)),
-        //                }
-        //            })
-                    .await
-                    .or_else(|err| Err(ChainStorageError::BlockingTaskSpawnError(err.to_string())))
-                    .and_then(|inner_result| inner_result)
+                db.$fn()
+            })
+            .await
+            .or_else(|err| Err(ChainStorageError::BlockingTaskSpawnError(err.to_string())))
+            .and_then(|inner_result| inner_result)
         }
     };
 
@@ -72,86 +58,8 @@ macro_rules! make_async {
                 .await
                 .or_else(|err| Err(ChainStorageError::BlockingTaskSpawnError(err.to_string())))
                 .and_then(|inner_result| inner_result)
-            //            poll_fn(move |_| {
-            //                let db = db.clone();
-            //                match blocking(move || db.$fn(hash)) {
-            //                    Poll::Pending => Poll::Pending,
-            //                    // Map BlockingError -> ChainStorageError
-            //                    Poll::Ready(Err(e)) => Poll::Ready(Err(ChainStorageError::AccessError(format!(
-            //                        "Could not find a blocking thread to execute DB query. {}",
-            //                        e.to_string()
-            //                    )))),
-            //                    // Unwrap and lift ChainStorageError
-            //                    Poll::Ready(Ok(Err(e))) => Poll::Ready(Err(e)),
-            //                    // Unwrap and return result
-            //                    Poll::Ready(Ok(Ok(v))) => Poll::Ready(Ok(v)),
-            //                }
-            //            })
-            //            .await
         }
     };
-
-//    ($fn:ident($param1:ident:$ptype1:ty,$param2:ident:$ptype2:ty) -> $rtype:ty) => {
-//        pub async fn $fn<T>(
-//            db: BlockchainDatabase<T>,
-//            $param1: $ptype1,
-//            $param2: $ptype2,
-//        ) -> Result<$rtype, ChainStorageError>
-//        where
-//            T: BlockchainBackend,
-//        {
-//            poll_fn(move |_| {
-//                let db = db.clone();
-//                let p1 = $param1.clone();
-//                let p2 = $param2.clone();
-//                match blocking(move || db.$fn(p1, p2)) {
-//                    Poll::Pending => Poll::Pending,
-//                    // Map BlockingError -> ChainStorageError
-//                    Poll::Ready(Err(e)) => Poll::Ready(Err(ChainStorageError::AccessError(format!(
-//                        "Could not find a blocking thread to execute DB query. {}",
-//                        e.to_string()
-//                    )))),
-//                    // Unwrap and lift ChainStorageError
-//                    Poll::Ready(Ok(Err(e))) => Poll::Ready(Err(e)),
-//                    // Unwrap and return result
-//                    Poll::Ready(Ok(Ok(v))) => Poll::Ready(Ok(v)),
-//                }
-//            })
-//            .await
-//        }
-//    };
-//
-//    ($fn:ident($param1:ident:$ptype1:ty,$param2:ident:$ptype2:ty,$param3:ident:$ptype3:ty) -> $rtype:ty) => {
-//        pub async fn $fn<T>(
-//            db: BlockchainDatabase<T>,
-//            $param1: $ptype1,
-//            $param2: $ptype2,
-//            $param3: $ptype3,
-//        ) -> Result<$rtype, ChainStorageError>
-//        where
-//            T: BlockchainBackend,
-//        {
-//            poll_fn(move |_| {
-//                let db = db.clone();
-//                let p1 = $param1.clone();
-//                let p2 = $param2.clone();
-//                let p3 = $param3.clone();
-//                match blocking(move || db.$fn(p1, p2, p3)) {
-//                    Poll::Pending => Poll::Pending,
-//                    // Map BlockingError -> ChainStorageError
-//                    Poll::Ready(Err(e)) => Poll::Ready(Err(ChainStorageError::AccessError(format!(
-//                        "Could not find a blocking thread to execute DB query. {}",
-//                        e.to_string()
-//                    )))),
-//                    // Unwrap and lift ChainStorageError
-//                    Poll::Ready(Ok(Err(e))) => Poll::Ready(Err(e)),
-//                    // Unwrap and return result
-//                    Poll::Ready(Ok(Ok(v))) => Poll::Ready(Ok(v)),
-//                }
-//            })
-//            .await
-//        }
-//    };
 }
 
 make_async!(get_metadata() -> ChainMetadata);

--- a/base_layer/core/src/mempool/service/initializer.rs
+++ b/base_layer/core/src/mempool/service/initializer.rs
@@ -118,7 +118,7 @@ async fn extract_transaction(msg: Arc<PeerMessage>) -> Option<DomainMessage<Tran
         Ok(tx) => {
             let tx = match Transaction::try_from(tx) {
                 Err(e) => {
-                    let origin = &msg.dht_header.origin_public_key;
+                    let origin = msg.origin_public_key();
                     warn!(
                         target: LOG_TARGET,
                         "Inbound transaction message from {} was ill-formed. {}", origin, e

--- a/base_layer/p2p/src/comms_connector/peer_message.rs
+++ b/base_layer/p2p/src/comms_connector/peer_message.rs
@@ -20,7 +20,7 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use tari_comms::peer_manager::Peer;
+use tari_comms::{peer_manager::Peer, types::CommsPublicKey};
 use tari_comms_dht::{domain_message::MessageHeader, envelope::DhtMessageHeader};
 
 /// A domain-level message
@@ -43,6 +43,14 @@ impl PeerMessage {
             dht_header,
             source_peer,
         }
+    }
+
+    pub fn origin_public_key(&self) -> &CommsPublicKey {
+        self.dht_header
+            .origin
+            .as_ref()
+            .map(|o| &o.public_key)
+            .unwrap_or(&self.source_peer.public_key)
     }
 
     pub fn decode_message<T>(&self) -> Result<T, prost::DecodeError>

--- a/base_layer/p2p/src/services/liveness/service.rs
+++ b/base_layer/p2p/src/services/liveness/service.rs
@@ -157,7 +157,7 @@ where
         match msg.inner().kind().ok_or(LivenessError::InvalidPingPongType)? {
             PingPong::Ping => {
                 self.state.inc_pings_received();
-                self.send_pong(msg.inner.nonce, msg.dht_header.origin_public_key)
+                self.send_pong(msg.inner.nonce, msg.source_peer.public_key)
                     .await
                     .unwrap();
                 self.state.inc_pongs_sent();
@@ -391,7 +391,7 @@ mod test {
         peer_manager::{NodeId, Peer, PeerFeatures, PeerFlags},
     };
     use tari_comms_dht::{
-        envelope::{DhtMessageHeader, Network},
+        envelope::{DhtMessageHeader, DhtMessageType, Network},
         outbound::{DhtOutboundRequest, SendMessageResponse},
     };
     use tari_crypto::keys::PublicKey;
@@ -505,21 +505,15 @@ mod test {
             PeerFeatures::COMMUNICATION_NODE,
         );
         DomainMessage {
-            dht_header: create_dummy_header(peer_source.public_key.clone()),
+            dht_header: DhtMessageHeader::new(
+                Default::default(),
+                DhtMessageType::None,
+                None,
+                Network::LocalTest,
+                Default::default(),
+            ),
             source_peer: peer_source,
             inner,
-        }
-    }
-
-    fn create_dummy_header(origin_public_key: CommsPublicKey) -> DhtMessageHeader {
-        DhtMessageHeader {
-            destination: Default::default(),
-            flags: Default::default(),
-            message_type: Default::default(),
-            origin_signature: Default::default(),
-            version: 0,
-            network: Network::LocalTest,
-            origin_public_key,
         }
     }
 

--- a/base_layer/p2p/src/test_utils.rs
+++ b/base_layer/p2p/src/test_utils.rs
@@ -28,7 +28,7 @@ use tari_comms::{
     utils::signature,
 };
 use tari_comms_dht::{
-    envelope::{DhtMessageFlags, DhtMessageHeader, DhtMessageType, Network, NodeDestination},
+    envelope::{DhtMessageFlags, DhtMessageHeader, DhtMessageOrigin, DhtMessageType, Network, NodeDestination},
     inbound::DhtInboundMessage,
 };
 use tari_utilities::message_format::MessageFormat;
@@ -65,11 +65,13 @@ pub fn make_dht_header(node_identity: &NodeIdentity, message: &Vec<u8>, flags: D
     DhtMessageHeader {
         version: 0,
         destination: NodeDestination::Unknown,
-        origin_public_key: node_identity.public_key().clone(),
-        origin_signature: signature::sign(&mut OsRng::new().unwrap(), node_identity.secret_key().clone(), message)
-            .unwrap()
-            .to_binary()
-            .unwrap(),
+        origin: Some(DhtMessageOrigin {
+            public_key: node_identity.public_key().clone(),
+            signature: signature::sign(&mut OsRng::new().unwrap(), node_identity.secret_key().clone(), message)
+                .unwrap()
+                .to_binary()
+                .unwrap(),
+        }),
         message_type: DhtMessageType::None,
         network: Network::LocalTest,
         flags,

--- a/base_layer/wallet/src/transaction_service/service.rs
+++ b/base_layer/wallet/src/transaction_service/service.rs
@@ -197,7 +197,8 @@ where
                 },
                 // Incoming messages from the Comms layer
                 msg = transaction_stream.select_next_some() => {
-                    let result  = self.accept_transaction(msg.dht_header.origin_public_key, msg.inner).await.or_else(|err| {
+                    let (origin_public_key, inner_msg) = msg.into_origin_and_inner();
+                    let result  = self.accept_transaction(origin_public_key, inner_msg).await.or_else(|err| {
                         error!(target: LOG_TARGET, "Failed to handle incoming message: {:?}", err);
                         Err(err)
                     });
@@ -212,7 +213,8 @@ where
                 },
                  // Incoming messages from the Comms layer
                 msg = transaction_reply_stream.select_next_some() => {
-                    let result = self.accept_recipient_reply(msg.dht_header.origin_public_key, msg.inner).await.or_else(|err| {
+                    let (origin_public_key, inner_msg) = msg.into_origin_and_inner();
+                    let result = self.accept_recipient_reply(origin_public_key, inner_msg).await.or_else(|err| {
                         error!(target: LOG_TARGET, "Failed to handle incoming message: {:?}", err);
                         Err(err)
                     });
@@ -227,7 +229,8 @@ where
                 },
                 // Incoming messages from the Comms layer
                 msg = transaction_finalized_stream.select_next_some() => {
-                    let result = self.accept_finalized_transaction(msg.dht_header.origin_public_key, msg.inner).await.or_else(|err| {
+                    let (origin_public_key, inner_msg) = msg.into_origin_and_inner();
+                    let result = self.accept_finalized_transaction(origin_public_key, inner_msg).await.or_else(|err| {
                         error!(target: LOG_TARGET, "Failed to handle incoming message: {:?}", err);
                         Err(err)
                     });
@@ -543,9 +546,7 @@ where
 
             info!(
                 target: LOG_TARGET,
-                "Transaction with TX_ID = {} received from {}. Reply Sent",
-                tx_id,
-                source_pubkey.clone()
+                "Transaction with TX_ID = {} received from {}. Reply Sent", tx_id, source_pubkey,
             );
 
             self.event_publisher

--- a/base_layer/wallet/tests/support/comms_and_services.rs
+++ b/base_layer/wallet/tests/support/comms_and_services.rs
@@ -87,8 +87,7 @@ pub fn create_dummy_message<T>(inner: T, public_key: &CommsPublicKey) -> DomainM
     );
     DomainMessage {
         dht_header: DhtMessageHeader {
-            origin_public_key: peer_source.public_key.clone(),
-            origin_signature: Default::default(),
+            origin: None,
             version: Default::default(),
             message_type: Default::default(),
             flags: Default::default(),

--- a/comms/dht/Cargo.toml
+++ b/comms/dht/Cargo.toml
@@ -32,7 +32,7 @@ rand = "0.5.5"
 serde = "1.0.90"
 serde_derive = "1.0.90"
 serde_repr = "0.1.5"
-tokio = "0.2.10"
+tokio = {version="0.2.10", features=["rt-threaded", "blocking"]}
 tower= "0.3.0"
 tower-filter = {version="0.3.0-alpha.2", path="../middleware/tower-filter"}
 ttl_cache = "0.5.1"
@@ -45,6 +45,7 @@ futures-test = { version = "0.3.0-alpha.19", package = "futures-test-preview" }
 lmdb-zero = "0.4.4"
 tempdir = "0.3.7"
 env_logger = "0.7.0"
+tokio-macros = "0.2.3"
 
 [build-dependencies]
 tari_protobuf_build = { version = "^0.0", path="../../infrastructure/protobuf_build"}

--- a/comms/dht/src/builder.rs
+++ b/comms/dht/src/builder.rs
@@ -87,12 +87,12 @@ impl DhtBuilder {
     }
 
     pub fn with_signature_cache_ttl(mut self, ttl: Duration) -> Self {
-        self.config.signature_cache_ttl = ttl;
+        self.config.msg_hash_cache_ttl = ttl;
         self
     }
 
     pub fn with_signature_cache_capacity(mut self, capacity: usize) -> Self {
-        self.config.signature_cache_capacity = capacity;
+        self.config.msg_hash_cache_capacity = capacity;
         self
     }
 

--- a/comms/dht/src/config.rs
+++ b/comms/dht/src/config.rs
@@ -55,12 +55,12 @@ pub struct DhtConfig {
     /// The time-to-live duration used for storage of high priority messages by the Store-and-forward middleware.
     /// Default: 24 hours
     pub saf_high_priority_msg_storage_ttl: Duration,
-    /// The max capacity of the signature cache
+    /// The max capacity of the message hash cache
     /// Default: 1000
-    pub signature_cache_capacity: usize,
-    /// The time-to-live for items in the signature cache
+    pub msg_hash_cache_capacity: usize,
+    /// The time-to-live for items in the message hash cache
     /// Default: 300s
-    pub signature_cache_ttl: Duration,
+    pub msg_hash_cache_ttl: Duration,
     /// Sets the number of failed attempts in-a-row to tolerate before temporarily excluding this peer from broadcast
     /// messages.
     /// Default: 3
@@ -107,8 +107,8 @@ impl Default for DhtConfig {
             saf_msg_cache_storage_capacity: SAF_MSG_CACHE_STORAGE_CAPACITY,
             saf_low_priority_msg_storage_ttl: SAF_LOW_PRIORITY_MSG_STORAGE_TTL,
             saf_high_priority_msg_storage_ttl: SAF_HIGH_PRIORITY_MSG_STORAGE_TTL,
-            signature_cache_capacity: 1000,
-            signature_cache_ttl: Duration::from_secs(300),
+            msg_hash_cache_capacity: 1000,
+            msg_hash_cache_ttl: Duration::from_secs(300),
             broadcast_cooldown_max_attempts: 3,
             broadcast_cooldown_period: Duration::from_secs(60 * 30),
             discovery_request_timeout: Duration::from_secs(2 * 60),

--- a/comms/dht/src/envelope.rs
+++ b/comms/dht/src/envelope.rs
@@ -20,7 +20,7 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use crate::consts::DHT_ENVELOPE_HEADER_VERSION;
+use crate::{consts::DHT_ENVELOPE_HEADER_VERSION, proto::envelope::DhtOrigin};
 use bitflags::bitflags;
 use derive_error::Error;
 use serde::{Deserialize, Serialize};
@@ -40,7 +40,7 @@ pub enum DhtMessageError {
     /// Invalid node destination
     InvalidDestination,
     /// Invalid origin public key
-    InvalidOriginPublicKey,
+    InvalidOrigin,
     /// Invalid or unrecognised DHT message type
     InvalidMessageType,
     /// Invalid or unrecognised network type
@@ -70,16 +70,50 @@ impl DhtMessageType {
     }
 }
 
+#[derive(Clone, PartialEq, Eq)]
+pub struct DhtMessageOrigin {
+    pub public_key: CommsPublicKey,
+    pub signature: Vec<u8>,
+}
+
+impl fmt::Debug for DhtMessageOrigin {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.debug_struct("DhtMessageOrigin")
+            .field("public_key", &self.public_key.to_hex())
+            .field("signature", &self.signature.to_hex())
+            .finish()
+    }
+}
+
+impl TryFrom<DhtOrigin> for DhtMessageOrigin {
+    type Error = DhtMessageError;
+
+    fn try_from(value: DhtOrigin) -> Result<Self, Self::Error> {
+        Ok(Self {
+            public_key: CommsPublicKey::from_bytes(&value.public_key).map_err(|_| DhtMessageError::InvalidOrigin)?,
+            signature: value.signature,
+        })
+    }
+}
+
+impl From<DhtMessageOrigin> for DhtOrigin {
+    fn from(value: DhtMessageOrigin) -> Self {
+        Self {
+            public_key: value.public_key.to_vec(),
+            signature: value.signature,
+        }
+    }
+}
+
 /// This struct mirrors the protobuf version of DhtHeader but is more ergonomic to work with.
 /// It is preferable to not to expose the generated prost structs publicly.
-#[derive(Clone, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct DhtMessageHeader {
     pub version: u32,
     pub destination: NodeDestination,
-    /// Origin public key of the message. This can be the same peer that sent the message
+    /// Origin of the message. This can refer to the same peer that sent the message
     /// or another peer if the message should be forwarded.
-    pub origin_public_key: CommsPublicKey,
-    pub origin_signature: Vec<u8>,
+    pub origin: Option<DhtMessageOrigin>,
     pub message_type: DhtMessageType,
     pub network: Network,
     pub flags: DhtMessageFlags,
@@ -88,9 +122,8 @@ pub struct DhtMessageHeader {
 impl DhtMessageHeader {
     pub fn new(
         destination: NodeDestination,
-        origin_pubkey: CommsPublicKey,
-        origin_signature: Vec<u8>,
         message_type: DhtMessageType,
+        origin: Option<DhtMessageOrigin>,
         network: Network,
         flags: DhtMessageFlags,
     ) -> Self
@@ -98,8 +131,7 @@ impl DhtMessageHeader {
         Self {
             version: DHT_ENVELOPE_HEADER_VERSION,
             destination: destination.into(),
-            origin_public_key: origin_pubkey,
-            origin_signature,
+            origin,
             message_type,
             network,
             flags,
@@ -107,37 +139,30 @@ impl DhtMessageHeader {
     }
 }
 
-impl fmt::Debug for DhtMessageHeader {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        f.debug_struct("DhtHeader")
-            .field("version", &self.version)
-            .field("destination", &self.destination)
-            .field("origin_public_key", &self.origin_public_key.to_hex())
-            .field("origin_signature", &self.origin_signature.to_hex())
-            .field("message_type", &self.message_type)
-            .field("flags", &self.flags)
-            .finish()
-    }
-}
-
 impl TryFrom<DhtHeader> for DhtMessageHeader {
     type Error = DhtMessageError;
 
     fn try_from(header: DhtHeader) -> Result<Self, Self::Error> {
-        Ok(Self::new(
-            header
-                .destination
-                .map(|destination| destination.try_into().ok())
-                .filter(Option::is_some)
-                .map(Option::unwrap)
-                .ok_or(DhtMessageError::InvalidDestination)?,
-            CommsPublicKey::from_bytes(&header.origin_public_key)
-                .map_err(|_| DhtMessageError::InvalidOriginPublicKey)?,
-            header.origin_signature,
-            DhtMessageType::from_i32(header.message_type).ok_or(DhtMessageError::InvalidMessageType)?,
-            Network::from_i32(header.network).ok_or(DhtMessageError::InvalidNetwork)?,
-            DhtMessageFlags::from_bits(header.flags).ok_or(DhtMessageError::InvalidMessageFlags)?,
-        ))
+        let destination = header
+            .destination
+            .map(|destination| destination.try_into().ok())
+            .filter(Option::is_some)
+            .map(Option::unwrap)
+            .ok_or(DhtMessageError::InvalidDestination)?;
+
+        let origin = match header.origin {
+            Some(origin) => Some(origin.try_into()?),
+            None => None,
+        };
+
+        Ok(Self {
+            version: header.version,
+            destination,
+            origin,
+            message_type: DhtMessageType::from_i32(header.message_type).ok_or(DhtMessageError::InvalidMessageType)?,
+            network: Network::from_i32(header.network).ok_or(DhtMessageError::InvalidNetwork)?,
+            flags: DhtMessageFlags::from_bits(header.flags).ok_or(DhtMessageError::InvalidMessageFlags)?,
+        })
     }
 }
 
@@ -156,8 +181,7 @@ impl From<DhtMessageHeader> for DhtHeader {
     fn from(header: DhtMessageHeader) -> Self {
         Self {
             version: header.version,
-            origin_public_key: header.origin_public_key.to_vec(),
-            origin_signature: header.origin_signature,
+            origin: header.origin.map(Into::into),
             destination: Some(header.destination.into()),
             message_type: header.message_type as i32,
             network: header.network as i32,
@@ -174,12 +198,26 @@ impl DhtEnvelope {
         }
     }
 
-    pub fn is_signature_valid(&self) -> bool {
+    /// Returns true if the header and origin are present, otherwise false
+    pub fn has_origin(&self) -> bool {
+        self.header.as_ref().map(|h| h.origin.is_some()).unwrap_or(false)
+    }
+
+    /// Verifies the origin signature and returns true if it is valid.
+    ///
+    /// This method panics if called on an envelope without an origin. This should be checked before calling this
+    /// function by using the `DhtEnvelope::has_origin` method
+    pub fn is_origin_signature_valid(&self) -> bool {
         self.header
             .as_ref()
             .and_then(|header| {
-                CommsPublicKey::from_bytes(&header.origin_public_key)
-                    .map(|pk| (pk, &header.origin_signature))
+                let origin = header
+                    .origin
+                    .as_ref()
+                    .expect("call is_origin_signature_valid on envelope without origin");
+
+                CommsPublicKey::from_bytes(&origin.public_key)
+                    .map(|pk| (pk, &origin.signature))
                     .ok()
             })
             .map(|(origin_public_key, origin_signature)| {

--- a/comms/dht/src/inbound/error.rs
+++ b/comms/dht/src/inbound/error.rs
@@ -42,4 +42,6 @@ pub enum DhtInboundError {
     /// One or more NetAddress in the join message were invalid
     InvalidJoinNetAddresses,
     DhtDiscoveryError(DhtDiscoveryError),
+    #[error(msg_embedded, no_from, non_std)]
+    OriginRequired(String),
 }

--- a/comms/dht/src/inbound/message.rs
+++ b/comms/dht/src/inbound/message.rs
@@ -21,7 +21,7 @@
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 use crate::{consts::DHT_ENVELOPE_HEADER_VERSION, envelope::DhtMessageHeader};
-use tari_comms::{message::EnvelopeBody, peer_manager::Peer};
+use tari_comms::{message::EnvelopeBody, peer_manager::Peer, types::CommsPublicKey};
 
 #[derive(Debug, Clone)]
 pub struct DhtInboundMessage {
@@ -93,5 +93,13 @@ impl DecryptedDhtMessage {
 
     pub fn decryption_failed(&self) -> bool {
         self.decryption_result.is_err()
+    }
+
+    pub fn origin_public_key(&self) -> &CommsPublicKey {
+        self.dht_header
+            .origin
+            .as_ref()
+            .map(|o| &o.public_key)
+            .unwrap_or(&self.source_peer.public_key)
     }
 }

--- a/comms/dht/src/inbound/validate.rs
+++ b/comms/dht/src/inbound/validate.rs
@@ -33,6 +33,7 @@ use log::*;
 use std::task::Poll;
 use tari_comms::message::MessageExt;
 use tari_comms_middleware::MiddlewareError;
+use tari_utilities::ByteArray;
 use tower::{layer::Layer, Service, ServiceExt};
 
 const LOG_TARGET: &'static str = "comms::dht::validate";
@@ -115,7 +116,11 @@ where
                         .with_dht_message_type(DhtMessageType::RejectMsg)
                         .finish(),
                     RejectMessage {
-                        signature: message.dht_header.origin_signature,
+                        signature: message
+                            .dht_header
+                            .origin
+                            .map(|o| o.public_key.to_vec())
+                            .unwrap_or_default(),
                         reason: RejectMessageReason::UnsupportedNetwork as i32,
                     }
                     .to_encoded_bytes()?,

--- a/comms/dht/src/outbound/message.rs
+++ b/comms/dht/src/outbound/message.rs
@@ -40,6 +40,7 @@ pub enum OutboundEncryption {
     None,
     /// Message should be encrypted using a shared secret derived from the given public key
     EncryptFor(CommsPublicKey),
+    // TODO: Remove this option as it is redundant (message encryption only needed for forwarded private messages)
     /// Message should be encrypted using a shared secret derived from the destination peer's
     /// public key. Each message sent according to the broadcast strategy will be encrypted for
     /// the destination peer.
@@ -52,6 +53,15 @@ impl OutboundEncryption {
         match self {
             OutboundEncryption::EncryptFor(_) | OutboundEncryption::EncryptForPeer => DhtMessageFlags::ENCRYPTED,
             _ => DhtMessageFlags::NONE,
+        }
+    }
+
+    /// Returns true if encryption is turned on, otherwise false
+    pub fn is_encrypt(&self) -> bool {
+        use OutboundEncryption::*;
+        match self {
+            None => false,
+            EncryptFor(_) | EncryptForPeer => true,
         }
     }
 }

--- a/comms/dht/src/outbound/message_params.rs
+++ b/comms/dht/src/outbound/message_params.rs
@@ -58,6 +58,7 @@ pub struct FinalSendMessageParams {
     pub destination: NodeDestination,
     pub encryption: OutboundEncryption,
     pub is_discovery_enabled: bool,
+    pub force_origin: bool,
     pub dht_message_type: DhtMessageType,
     pub dht_header: Option<DhtMessageHeader>,
 }
@@ -69,6 +70,7 @@ impl Default for FinalSendMessageParams {
             destination: Default::default(),
             encryption: Default::default(),
             dht_message_type: Default::default(),
+            force_origin: false,
             is_discovery_enabled: true,
             dht_header: None,
         }
@@ -80,16 +82,19 @@ impl SendMessageParams {
         Default::default()
     }
 
+    /// Set broadcast_strategy to DirectPublicKey
     pub fn direct_public_key(&mut self, public_key: CommsPublicKey) -> &mut Self {
         self.params_mut().broadcast_strategy = BroadcastStrategy::DirectPublicKey(public_key);
         self
     }
 
+    /// Set broadcast_strategy to DirectNodeId
     pub fn direct_node_id(&mut self, node_id: NodeId) -> &mut Self {
         self.params_mut().broadcast_strategy = BroadcastStrategy::DirectNodeId(node_id);
         self
     }
 
+    /// Set broadcast_strategy to Closest
     pub fn closest(&mut self, node_id: NodeId, n: usize, excluded_peers: Vec<CommsPublicKey>) -> &mut Self {
         self.params_mut().broadcast_strategy = BroadcastStrategy::Closest(Box::new(BroadcastClosestRequest {
             excluded_peers,
@@ -99,46 +104,62 @@ impl SendMessageParams {
         self
     }
 
+    /// Set broadcast_strategy to Neighbours
     pub fn neighbours(&mut self, excluded_peers: Vec<CommsPublicKey>) -> &mut Self {
         self.params_mut().broadcast_strategy = BroadcastStrategy::Neighbours(excluded_peers);
         self
     }
 
+    /// Set broadcast_strategy to Flood
     pub fn flood(&mut self) -> &mut Self {
         self.params_mut().broadcast_strategy = BroadcastStrategy::Flood;
         self
     }
 
+    /// Set broadcast_strategy to Random
     pub fn random(&mut self, n: usize) -> &mut Self {
         self.params_mut().broadcast_strategy = BroadcastStrategy::Random(n);
         self
     }
 
+    /// Set destination field in message header.
     pub fn with_destination(&mut self, destination: NodeDestination) -> &mut Self {
         self.params_mut().destination = destination;
         self
     }
 
+    /// Set encryption mode for message.
     pub fn with_encryption(&mut self, encryption: OutboundEncryption) -> &mut Self {
         self.params_mut().encryption = encryption;
         self
     }
 
+    /// Set to true to enable discovery, otherwise false
     pub fn with_discovery(&mut self, is_enabled: bool) -> &mut Self {
         self.params_mut().is_discovery_enabled = is_enabled;
         self
     }
 
+    /// Set the DHT message type
     pub fn with_dht_message_type(&mut self, message_type: DhtMessageType) -> &mut Self {
         self.params_mut().dht_message_type = message_type;
         self
     }
 
+    /// Override the DHtHeader of a message(s) with the given header
     pub fn with_dht_header(&mut self, dht_header: DhtMessageHeader) -> &mut Self {
         self.params_mut().dht_header = Some(dht_header);
         self
     }
 
+    /// Force the message origin to be included in the message. The origin is usually not included in messages without
+    /// encryption, however this setting will force the message origin and signature to be included.
+    pub fn force_origin(&mut self) -> &mut Self {
+        self.params_mut().force_origin = true;
+        self
+    }
+
+    /// Return the final SendMessageParams
     pub fn finish(&mut self) -> FinalSendMessageParams {
         self.params.take().expect("cannot be None")
     }

--- a/comms/dht/src/outbound/requester.rs
+++ b/comms/dht/src/outbound/requester.rs
@@ -193,7 +193,7 @@ impl OutboundMessageRequester {
         self.send_raw(params, body).await
     }
 
-    /// Send a DHT-level message
+    /// Send a message without a domain header part
     pub async fn send_message_no_header<T>(
         &mut self,
         params: FinalSendMessageParams,

--- a/comms/dht/src/proto/envelope.proto
+++ b/comms/dht/src/proto/envelope.proto
@@ -25,22 +25,21 @@ message DhtHeader {
         // The sender has chosen not to disclose the message destination, or the destination is
         // the peer being sent to.
         bool unknown = 2;
-        /// Destined for a particular public key
+        // Destined for a particular public key
         bytes public_key = 3;
-        /// Destined for a particular node id, or network region
+        // Destined for a particular node id, or network region
         bytes node_id = 4;
     }
 
     // Origin public key of the message. This can be the same peer that sent the message
-    // or another peer if the message should be forwarded.
-    bytes origin_public_key = 5;
-    // Signature of the message body that can be verified using the origin_public_key above
-    bytes origin_signature = 6;
+    // or another peer if the message should be forwarded. This is optional but must be specified
+    // if the ENCRYPTED flag is set.
+    DhtOrigin origin = 5;
     // The type of message
-    DhtMessageType message_type = 7;
+    DhtMessageType message_type = 6;
     // The network for which this message is intended (e.g. TestNet, MainNet etc.)
-    Network network = 8;
-    uint32 flags = 9;
+    Network network = 7;
+    uint32 flags = 8;
 }
 
 enum Network {
@@ -55,4 +54,9 @@ enum Network {
 message DhtEnvelope {
     DhtHeader header = 1;
     bytes body = 2;
+}
+
+message DhtOrigin {
+    bytes public_key = 1;
+    bytes signature = 2;
 }

--- a/comms/dht/src/proto/tari.dht.envelope.rs
+++ b/comms/dht/src/proto/tari.dht.envelope.rs
@@ -3,19 +3,17 @@ pub struct DhtHeader {
     #[prost(uint32, tag = "1")]
     pub version: u32,
     /// Origin public key of the message. This can be the same peer that sent the message
-    /// or another peer if the message should be forwarded.
-    #[prost(bytes, tag = "5")]
-    pub origin_public_key: std::vec::Vec<u8>,
-    /// Signature of the message body that can be verified using the origin_public_key above
-    #[prost(bytes, tag = "6")]
-    pub origin_signature: std::vec::Vec<u8>,
+    /// or another peer if the message should be forwarded. This is optional but must be specified
+    /// if the ENCRYPTED flag is set.
+    #[prost(message, optional, tag = "5")]
+    pub origin: ::std::option::Option<DhtOrigin>,
     /// The type of message
-    #[prost(enumeration = "DhtMessageType", tag = "7")]
+    #[prost(enumeration = "DhtMessageType", tag = "6")]
     pub message_type: i32,
     /// The network for which this message is intended (e.g. TestNet, MainNet etc.)
-    #[prost(enumeration = "Network", tag = "8")]
+    #[prost(enumeration = "Network", tag = "7")]
     pub network: i32,
-    #[prost(uint32, tag = "9")]
+    #[prost(uint32, tag = "8")]
     pub flags: u32,
     #[prost(oneof = "dht_header::Destination", tags = "2, 3, 4")]
     pub destination: ::std::option::Option<dht_header::Destination>,
@@ -27,10 +25,10 @@ pub mod dht_header {
         /// the peer being sent to.
         #[prost(bool, tag = "2")]
         Unknown(bool),
-        //// Destined for a particular public key
+        /// Destined for a particular public key
         #[prost(bytes, tag = "3")]
         PublicKey(std::vec::Vec<u8>),
-        //// Destined for a particular node id, or network region
+        /// Destined for a particular node id, or network region
         #[prost(bytes, tag = "4")]
         NodeId(std::vec::Vec<u8>),
     }
@@ -41,6 +39,13 @@ pub struct DhtEnvelope {
     pub header: ::std::option::Option<DhtHeader>,
     #[prost(bytes, tag = "2")]
     pub body: std::vec::Vec<u8>,
+}
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct DhtOrigin {
+    #[prost(bytes, tag = "1")]
+    pub public_key: std::vec::Vec<u8>,
+    #[prost(bytes, tag = "2")]
+    pub signature: std::vec::Vec<u8>,
 }
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
 #[repr(i32)]

--- a/comms/dht/src/store_forward/error.rs
+++ b/comms/dht/src/store_forward/error.rs
@@ -54,4 +54,8 @@ pub enum StoreAndForwardError {
     DhtHeaderNotProvided,
     /// Failed to spawn blocking task
     JoinError(tokio::task::JoinError),
+    /// Message origin is for all forwarded messages
+    MessageOriginRequired,
+    /// The message was malformed
+    MalformedMessage,
 }

--- a/comms/dht/src/store_forward/state.rs
+++ b/comms/dht/src/store_forward/state.rs
@@ -44,7 +44,7 @@ impl SafStorage {
         acquire_write_lock!(self.message_cache).insert(key, message, ttl)
     }
 
-    pub fn with_inner<F, T>(&self, f: F) -> T
+    pub fn with_lock<F, T>(&self, f: F) -> T
     where F: FnOnce(RwLockWriteGuard<TtlCache<SignatureBytes, StoredMessage>>) -> T {
         f(acquire_write_lock!(self.message_cache))
     }

--- a/comms/dht/src/test_utils/dht_actor_mock.rs
+++ b/comms/dht/src/test_utils/dht_actor_mock.rs
@@ -97,7 +97,7 @@ impl DhtActorMock {
         self.state.inc_call_count();
         match req {
             SendJoin => {},
-            SignatureCacheInsert(_, reply_tx) => {
+            MsgHashCacheInsert(_, reply_tx) => {
                 let v = self.state.signature_cache_insert.load(Ordering::SeqCst);
                 reply_tx.send(v).unwrap();
             },

--- a/comms/dht/src/test_utils/makers.rs
+++ b/comms/dht/src/test_utils/makers.rs
@@ -20,7 +20,7 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 use crate::{
-    envelope::{DhtMessageFlags, DhtMessageHeader, NodeDestination},
+    envelope::{DhtMessageFlags, DhtMessageHeader, DhtMessageOrigin, NodeDestination},
     inbound::DhtInboundMessage,
     proto::envelope::{DhtEnvelope, DhtMessageType, Network},
 };
@@ -97,11 +97,13 @@ pub fn make_dht_header(node_identity: &NodeIdentity, message: &Vec<u8>, flags: D
     DhtMessageHeader {
         version: 0,
         destination: NodeDestination::Unknown,
-        origin_public_key: node_identity.public_key().clone(),
-        origin_signature: signature::sign(&mut OsRng::new().unwrap(), node_identity.secret_key().clone(), message)
-            .unwrap()
-            .to_binary()
-            .unwrap(),
+        origin: Some(DhtMessageOrigin {
+            public_key: node_identity.public_key().clone(),
+            signature: signature::sign(&mut OsRng::new().unwrap(), node_identity.secret_key().clone(), message)
+                .unwrap()
+                .to_binary()
+                .unwrap(),
+        }),
         message_type: DhtMessageType::None,
         network: Network::LocalTest,
         flags,

--- a/comms/dht/tests/dht.rs
+++ b/comms/dht/tests/dht.rs
@@ -134,6 +134,7 @@ fn setup_comms_dht(
 #[test]
 #[allow(non_snake_case)]
 fn dht_join_propagation() {
+    env_logger::init();
     runtime::test_async(|rt| {
         // Create 3 nodes where only Node B knows A and C, but A and C want to talk to each other
         let node_A_identity = new_node_identity("/ip4/127.0.0.1/tcp/11113".parse::<Multiaddr>().unwrap());

--- a/comms/src/message/envelope.rs
+++ b/comms/src/message/envelope.rs
@@ -167,6 +167,8 @@ impl EnvelopeBody {
         self.parts
     }
 
+    /// Decodes a part of the message body and returns the result. If the part index is out of range Ok(None) is
+    /// returned
     pub fn decode_part<T>(&self, index: usize) -> Result<Option<T>, MessageError>
     where T: prost::Message + Default {
         match self.parts.get(index) {

--- a/comms/src/message/mod.rs
+++ b/comms/src/message/mod.rs
@@ -74,6 +74,7 @@ pub use self::{
 };
 
 pub trait MessageExt: prost::Message {
+    /// Encodes a message, allocating the buffer on the heap as necessary
     fn to_encoded_bytes(&self) -> Result<Vec<u8>, MessageError>
     where Self: Sized {
         let mut buf = Vec::new();

--- a/comms/src/utils/crypt.rs
+++ b/comms/src/utils/crypt.rs
@@ -33,7 +33,7 @@ where PK: PublicKey + DiffieHellmanSharedSecret<PK = PK> {
 }
 
 pub fn decrypt(cipher_key: &CommsPublicKey, cipher_text: &[u8]) -> Result<Vec<u8>, CipherError> {
-    CommsCipher::open_with_integral_nonce(cipher_text, &cipher_key.to_vec())
+    CommsCipher::open_with_integral_nonce(cipher_text, cipher_key.as_bytes())
 }
 
 pub fn encrypt(cipher_key: &CommsPublicKey, plain_text: &Vec<u8>) -> Result<Vec<u8>, CipherError> {


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
- Origin data (public key and signature) are optional to preserve
  privacy for appropriate messages (e.g. transactions, blocks)
- If the origin is omitted, the message is from the peer
  sending the message over a secure channel
- The deduping of messages uses a hash of the message contents, not the
   origin signature. This is to prevent a duplicate message signed by a
   different party from being let through.
- SAF storage keeps a copy of cleartext messages that have an origin
  specified
- Shared SAF storage access uses the blocking threadpool


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #1241 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Unit tests for new SAF behaviour.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [x] Breaking change (fix or feature that would cause existing functionality to change)
* [x] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [x] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch
* [x] I ran `cargo-fmt --all` before pushing
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
