### PR TITLE
Exclude the Monero and Random-X deps from Core for Wallet

### DIFF
--- a/base_layer/core/Cargo.toml
+++ b/base_layer/core/Cargo.toml
@@ -10,7 +10,7 @@ version = "0.0.5"
 edition = "2018"
 
 [features]
-default = ["croaring", "tari_mmr", "transactions", "base_node", "mempool_proto"]
+default = ["croaring", "tari_mmr", "transactions", "base_node", "mempool_proto", "monero", "randomx-rs"]
 transactions = []
 mempool_proto = []
 base_node = []
@@ -30,8 +30,8 @@ tari_pubsub = { version = "^0.0", path = "../../infrastructure/pubsub"}
 tari_shutdown = { path = "../../infrastructure/shutdown", version = "^0.0"}
 tari_mmr = { path = "../../base_layer/mmr", version = "^0.0", optional = true }
 
-randomx-rs = "0.1.2"
-monero = { version = "0.5", features= ["serde_support"]}
+randomx-rs = { version = "0.1.2", optional = true }
+monero = { version = "0.5", features= ["serde_support"], optional = true }
 bitflags = "1.0.4"
 chrono = { version = "0.4.6", features = ["serde"]}
 digest = "0.8.0"


### PR DESCRIPTION
Exclude the Monero and Random-X deps from Core for Wallet

Plus some minor build script fixes
1) Fixed dependecy search path for android x86 when checking if dependency is already built
2) Fixed overwrite bug for logging for each android architecture build
3) Added output to android loop to indicate build for an architecture is complete
4) Fixed comparison of a variable for android build
5) Fixed missing path when dependencies are found

## Description

## Motivation and Context

## How Has This Been Tested?
cargo test --all --all-features
Ran build script

## Types of changes

* [ x] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
* [x] I'm merging against the `development` branch
* [x] I ran `cargo-fmt --all` before pushing
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
