### PR TITLE
Make wallet db calls properly async and use spawn_blocking()

### DIFF
--- a/base_layer/wallet/Cargo.toml
+++ b/base_layer/wallet/Cargo.toml
@@ -35,7 +35,7 @@ diesel_migrations =  "1.4"
 diesel = {version="1.4", features = ["sqlite", "serde_json", "chrono", "r2d2"]}
 rand = "0.5.5"
 futures =  { version = "^0.3.1", features =["compat", "std"]}
-tokio = "0.2.10"
+tokio = { version = "0.2.10", features = ["blocking"]}
 tower = "0.3.0-alpha.2"
 tempdir = "0.3.7"
 tari_test_utils = { path = "../../infrastructure/test_utils", version = "^0.0", optional = true}

--- a/base_layer/wallet/src/contacts_service/error.rs
+++ b/base_layer/wallet/src/contacts_service/error.rs
@@ -54,4 +54,6 @@ pub enum ContactsServiceStorageError {
     DieselConnectionError(diesel::ConnectionError),
     #[error(msg_embedded, no_from, non_std)]
     DatabaseMigrationError(String),
+    #[error(msg_embedded, non_std, no_from)]
+    BlockingTaskSpawnError(String),
 }

--- a/base_layer/wallet/src/contacts_service/storage/memory_db.rs
+++ b/base_layer/wallet/src/contacts_service/storage/memory_db.rs
@@ -63,7 +63,7 @@ impl ContactsBackend for ContactsServiceMemoryDatabase {
         Ok(result)
     }
 
-    fn write(&mut self, op: WriteOperation) -> Result<Option<DbValue>, ContactsServiceStorageError> {
+    fn write(&self, op: WriteOperation) -> Result<Option<DbValue>, ContactsServiceStorageError> {
         let mut db = acquire_write_lock!(self.db);
         match op {
             WriteOperation::Insert(kvp) => match kvp {

--- a/base_layer/wallet/src/contacts_service/storage/sqlite_db.rs
+++ b/base_layer/wallet/src/contacts_service/storage/sqlite_db.rs
@@ -96,7 +96,7 @@ impl ContactsBackend for ContactsServiceSqliteDatabase {
         Ok(result)
     }
 
-    fn write(&mut self, op: WriteOperation) -> Result<Option<DbValue>, ContactsServiceStorageError> {
+    fn write(&self, op: WriteOperation) -> Result<Option<DbValue>, ContactsServiceStorageError> {
         let conn = self
             .database_connection_pool
             .clone()

--- a/base_layer/wallet/src/error.rs
+++ b/base_layer/wallet/src/error.rs
@@ -66,4 +66,6 @@ pub enum WalletStorageError {
     ValueNotFound(DbKey),
     #[error(msg_embedded, non_std, no_from)]
     UnexpectedResult(String),
+    #[error(msg_embedded, non_std, no_from)]
+    BlockingTaskSpawnError(String),
 }

--- a/base_layer/wallet/src/output_manager_service/error.rs
+++ b/base_layer/wallet/src/output_manager_service/error.rs
@@ -82,4 +82,6 @@ pub enum OutputManagerStorageError {
     DieselConnectionError(diesel::ConnectionError),
     #[error(msg_embedded, no_from, non_std)]
     DatabaseMigrationError(String),
+    #[error(msg_embedded, non_std, no_from)]
+    BlockingTaskSpawnError(String),
 }

--- a/base_layer/wallet/src/output_manager_service/mod.rs
+++ b/base_layer/wallet/src/output_manager_service/mod.rs
@@ -37,6 +37,7 @@ use tokio::runtime;
 
 pub mod error;
 pub mod handle;
+#[allow(unused_assignments)]
 pub mod service;
 pub mod storage;
 
@@ -88,6 +89,7 @@ where T: OutputManagerBackend + 'static
         let factories = self.factories.clone();
         executor.spawn(async move {
             let service = OutputManagerService::new(receiver, OutputManagerDatabase::new(backend), factories)
+                .await
                 .expect("Could not initialize Output Manager Service")
                 .start();
 

--- a/base_layer/wallet/src/output_manager_service/storage/memory_db.rs
+++ b/base_layer/wallet/src/output_manager_service/storage/memory_db.rs
@@ -106,7 +106,7 @@ impl OutputManagerBackend for OutputManagerMemoryDatabase {
         Ok(result)
     }
 
-    fn write(&mut self, op: WriteOperation) -> Result<Option<DbValue>, OutputManagerStorageError> {
+    fn write(&self, op: WriteOperation) -> Result<Option<DbValue>, OutputManagerStorageError> {
         let mut db = acquire_write_lock!(self.db);
         match op {
             WriteOperation::Insert(kvp) => match kvp {
@@ -162,7 +162,7 @@ impl OutputManagerBackend for OutputManagerMemoryDatabase {
         Ok(None)
     }
 
-    fn confirm_transaction(&mut self, tx_id: TxId) -> Result<(), OutputManagerStorageError> {
+    fn confirm_transaction(&self, tx_id: TxId) -> Result<(), OutputManagerStorageError> {
         let mut db = acquire_write_lock!(self.db);
         let mut pending_tx = db
             .pending_transactions
@@ -185,7 +185,7 @@ impl OutputManagerBackend for OutputManagerMemoryDatabase {
     }
 
     fn encumber_outputs(
-        &mut self,
+        &self,
         tx_id: TxId,
         outputs_to_send: &Vec<UnblindedOutput>,
         change_output: Option<UnblindedOutput>,
@@ -217,7 +217,7 @@ impl OutputManagerBackend for OutputManagerMemoryDatabase {
         Ok(())
     }
 
-    fn cancel_pending_transaction(&mut self, tx_id: TxId) -> Result<(), OutputManagerStorageError> {
+    fn cancel_pending_transaction(&self, tx_id: TxId) -> Result<(), OutputManagerStorageError> {
         let mut db = acquire_write_lock!(self.db);
         let mut pending_tx = db
             .pending_transactions
@@ -232,7 +232,7 @@ impl OutputManagerBackend for OutputManagerMemoryDatabase {
         Ok(())
     }
 
-    fn timeout_pending_transactions(&mut self, period: Duration) -> Result<(), OutputManagerStorageError> {
+    fn timeout_pending_transactions(&self, period: Duration) -> Result<(), OutputManagerStorageError> {
         let db = acquire_write_lock!(self.db);
         let mut transactions_to_be_cancelled = Vec::new();
         for (tx_id, pt) in db.pending_transactions.iter() {
@@ -248,7 +248,7 @@ impl OutputManagerBackend for OutputManagerMemoryDatabase {
         Ok(())
     }
 
-    fn increment_key_index(&mut self) -> Result<(), OutputManagerStorageError> {
+    fn increment_key_index(&self) -> Result<(), OutputManagerStorageError> {
         let mut db = acquire_write_lock!(self.db);
 
         if db.key_manager_state.is_none() {

--- a/base_layer/wallet/src/output_manager_service/storage/sqlite_db.rs
+++ b/base_layer/wallet/src/output_manager_service/storage/sqlite_db.rs
@@ -166,7 +166,7 @@ impl OutputManagerBackend for OutputManagerSqliteDatabase {
         Ok(result)
     }
 
-    fn write(&mut self, op: WriteOperation) -> Result<Option<DbValue>, OutputManagerStorageError> {
+    fn write(&self, op: WriteOperation) -> Result<Option<DbValue>, OutputManagerStorageError> {
         let conn = self
             .database_connection_pool
             .clone()
@@ -255,7 +255,7 @@ impl OutputManagerBackend for OutputManagerSqliteDatabase {
         Ok(None)
     }
 
-    fn confirm_transaction(&mut self, tx_id: u64) -> Result<(), OutputManagerStorageError> {
+    fn confirm_transaction(&self, tx_id: u64) -> Result<(), OutputManagerStorageError> {
         let conn = self
             .database_connection_pool
             .clone()
@@ -304,7 +304,7 @@ impl OutputManagerBackend for OutputManagerSqliteDatabase {
     }
 
     fn encumber_outputs(
-        &mut self,
+        &self,
         tx_id: u64,
         outputs_to_send: &Vec<UnblindedOutput>,
         change_output: Option<UnblindedOutput>,
@@ -346,7 +346,7 @@ impl OutputManagerBackend for OutputManagerSqliteDatabase {
         Ok(())
     }
 
-    fn cancel_pending_transaction(&mut self, tx_id: u64) -> Result<(), OutputManagerStorageError> {
+    fn cancel_pending_transaction(&self, tx_id: u64) -> Result<(), OutputManagerStorageError> {
         let conn = self
             .database_connection_pool
             .clone()
@@ -391,7 +391,7 @@ impl OutputManagerBackend for OutputManagerSqliteDatabase {
         Ok(())
     }
 
-    fn timeout_pending_transactions(&mut self, period: Duration) -> Result<(), OutputManagerStorageError> {
+    fn timeout_pending_transactions(&self, period: Duration) -> Result<(), OutputManagerStorageError> {
         let conn = self
             .database_connection_pool
             .clone()
@@ -409,7 +409,7 @@ impl OutputManagerBackend for OutputManagerSqliteDatabase {
         Ok(())
     }
 
-    fn increment_key_index(&mut self) -> Result<(), OutputManagerStorageError> {
+    fn increment_key_index(&self) -> Result<(), OutputManagerStorageError> {
         let conn = self
             .database_connection_pool
             .clone()

--- a/base_layer/wallet/src/storage/memory_db.rs
+++ b/base_layer/wallet/src/storage/memory_db.rs
@@ -64,7 +64,7 @@ impl WalletBackend for WalletMemoryDatabase {
         Ok(result)
     }
 
-    fn write(&mut self, op: WriteOperation) -> Result<Option<DbValue>, WalletStorageError> {
+    fn write(&self, op: WriteOperation) -> Result<Option<DbValue>, WalletStorageError> {
         let mut db = acquire_write_lock!(self.db);
         match op {
             WriteOperation::Insert(kvp) => match kvp {

--- a/base_layer/wallet/src/storage/sqlite_db.rs
+++ b/base_layer/wallet/src/storage/sqlite_db.rs
@@ -94,7 +94,7 @@ impl WalletBackend for WalletSqliteDatabase {
         Ok(result)
     }
 
-    fn write(&mut self, op: WriteOperation) -> Result<Option<DbValue>, WalletStorageError> {
+    fn write(&self, op: WriteOperation) -> Result<Option<DbValue>, WalletStorageError> {
         let conn = self
             .database_connection_pool
             .clone()

--- a/base_layer/wallet/src/testnet_utils.rs
+++ b/base_layer/wallet/src/testnet_utils.rs
@@ -164,7 +164,7 @@ pub fn generate_wallet_test_data<
 >(
     wallet: &mut Wallet<T, U, V, W>,
     data_path: &str,
-    mut transaction_service_backend: U,
+    transaction_service_backend: U,
 ) -> Result<(), WalletError>
 {
     let mut rng = rand::OsRng::new().unwrap();

--- a/base_layer/wallet/src/transaction_service/error.rs
+++ b/base_layer/wallet/src/transaction_service/error.rs
@@ -105,4 +105,6 @@ pub enum TransactionStorageError {
     DieselConnectionError(diesel::ConnectionError),
     #[error(msg_embedded, no_from, non_std)]
     DatabaseMigrationError(String),
+    #[error(msg_embedded, non_std, no_from)]
+    BlockingTaskSpawnError(String),
 }

--- a/base_layer/wallet/src/transaction_service/service.rs
+++ b/base_layer/wallet/src/transaction_service/service.rs
@@ -113,7 +113,6 @@ where TBackend: TransactionBackend + Clone + 'static
     event_publisher: Publisher<TransactionEvent>,
     node_identity: Arc<NodeIdentity>,
     factories: CryptoFactories,
-    discovery_process_futures: FuturesUnordered<BoxFuture<'static, Result<TxId, TransactionServiceError>>>,
 }
 
 impl<TTxStream, TTxReplyStream, TTxFinalizedStream, TBackend>
@@ -151,7 +150,6 @@ where
             event_publisher,
             node_identity,
             factories,
-            discovery_process_futures: FuturesUnordered::new(),
         }
     }
 
@@ -182,12 +180,15 @@ where
             .fuse();
         pin_mut!(transaction_finalized_stream);
 
+        let mut discovery_process_futures: FuturesUnordered<BoxFuture<'static, Result<TxId, TransactionServiceError>>> =
+            FuturesUnordered::new();
+
         loop {
             futures::select! {
                 //Incoming request
                 request_context = request_stream.select_next_some() => {
                     let (request, reply_tx) = request_context.split();
-                    let _ = reply_tx.send(self.handle_request(request).await.or_else(|resp| {
+                    let _ = reply_tx.send(self.handle_request(request, &mut discovery_process_futures).await.or_else(|resp| {
                         error!(target: LOG_TARGET, "Error handling request: {:?}", resp);
                         Err(resp)
                     })).or_else(|resp| {
@@ -240,25 +241,25 @@ where
                                 .await;
                     }
                 },
-                response = self.discovery_process_futures.select_next_some() => {
-                    match response {
-                        Ok(tx_id) => {
-                            let _ = self.event_publisher
-                                .send(TransactionEvent::TransactionSendDiscoveryComplete(tx_id, true))
-                                .await;
-                        },
-                        Err(TransactionServiceError::DiscoveryProcessFailed(tx_id)) => {
-                            if let Err(e) = self.output_manager_service.cancel_transaction(tx_id).await {
-                                error!(target: LOG_TARGET, "Failed to Cancel TX_ID: {} after failed sending attempt", tx_id);
-                            }
-                            error!(target: LOG_TARGET, "Discovery and Send failed for TX_ID: {}", tx_id);
-                            let _ = self.event_publisher
-                                .send(TransactionEvent::TransactionSendDiscoveryComplete(tx_id, false))
-                                .await;
-                        }
-                        Err(e) => error!(target: LOG_TARGET, "Discovery and Send failed with Error: {:?}", e),
-                    }
-                },
+                            response = discovery_process_futures.select_next_some() => {
+                                match response {
+                                    Ok(tx_id) => {
+                                        let _ = self.event_publisher
+                                            .send(TransactionEvent::TransactionSendDiscoveryComplete(tx_id, true))
+                                            .await;
+                                    },
+                                    Err(TransactionServiceError::DiscoveryProcessFailed(tx_id)) => {
+                                        if let Err(e) = self.output_manager_service.cancel_transaction(tx_id).await {
+                                            error!(target: LOG_TARGET, "Failed to Cancel TX_ID: {} after failed sending attempt", tx_id);
+                                        }
+                                        error!(target: LOG_TARGET, "Discovery and Send failed for TX_ID: {}", tx_id);
+                                        let _ = self.event_publisher
+                                            .send(TransactionEvent::TransactionSendDiscoveryComplete(tx_id, false))
+                                            .await;
+                                    }
+                                    Err(e) => error!(target: LOG_TARGET, "Discovery and Send failed with Error: {:?}", e),
+                                }
+                            },
 
                 complete => {
                     info!(target: LOG_TARGET, "Text message service shutting down");
@@ -273,27 +274,31 @@ where
     async fn handle_request(
         &mut self,
         request: TransactionServiceRequest,
+        discovery_process_futures: &mut FuturesUnordered<BoxFuture<'static, Result<TxId, TransactionServiceError>>>,
     ) -> Result<TransactionServiceResponse, TransactionServiceError>
     {
         match request {
             TransactionServiceRequest::SendTransaction((dest_pubkey, amount, fee_per_gram, message)) => self
-                .send_transaction(dest_pubkey, amount, fee_per_gram, message)
+                .send_transaction(dest_pubkey, amount, fee_per_gram, message, discovery_process_futures)
                 .await
                 .map(|_| TransactionServiceResponse::TransactionSent),
             TransactionServiceRequest::GetPendingInboundTransactions => Ok(
-                TransactionServiceResponse::PendingInboundTransactions(self.get_pending_inbound_transactions()?),
+                TransactionServiceResponse::PendingInboundTransactions(self.get_pending_inbound_transactions().await?),
             ),
-            TransactionServiceRequest::GetPendingOutboundTransactions => Ok(
-                TransactionServiceResponse::PendingOutboundTransactions(self.get_pending_outbound_transactions()?),
-            ),
+            TransactionServiceRequest::GetPendingOutboundTransactions => {
+                Ok(TransactionServiceResponse::PendingOutboundTransactions(
+                    self.get_pending_outbound_transactions().await?,
+                ))
+            },
             TransactionServiceRequest::GetCompletedTransactions => Ok(
-                TransactionServiceResponse::CompletedTransactions(self.get_completed_transactions()?),
+                TransactionServiceResponse::CompletedTransactions(self.get_completed_transactions().await?),
             ),
             TransactionServiceRequest::RequestCoinbaseSpendingKey((amount, maturity_height)) => Ok(
                 TransactionServiceResponse::CoinbaseKey(self.request_coinbase_key(amount, maturity_height).await?),
             ),
             TransactionServiceRequest::CompleteCoinbaseTransaction((tx_id, completed_transaction)) => {
-                self.submit_completed_coinbase_transaction(tx_id, completed_transaction)?;
+                self.submit_completed_coinbase_transaction(tx_id, completed_transaction)
+                    .await?;
                 Ok(TransactionServiceResponse::CompletedCoinbaseTransactionReceived)
             },
             TransactionServiceRequest::CancelPendingCoinbaseTransaction(tx_id) => {
@@ -340,6 +345,7 @@ where
         amount: MicroTari,
         fee_per_gram: MicroTari,
         message: String,
+        discovery_process_futures: &mut FuturesUnordered<BoxFuture<'static, Result<TxId, TransactionServiceError>>>,
     ) -> Result<(), TransactionServiceError>
     {
         let mut sender_protocol = self
@@ -384,20 +390,22 @@ where
                 let discovery_future = async move {
                     transaction_send_discovery_process_completion(r, db_clone, tx_id_clone, outbound_tx_clone).await
                 };
-                self.discovery_process_futures.push(discovery_future.boxed());
+                discovery_process_futures.push(discovery_future.boxed());
                 return Err(TransactionServiceError::OutboundSendDiscoveryInProgress(tx_id.clone()));
             },
         }
 
-        self.db.add_pending_outbound_transaction(tx_id, OutboundTransaction {
-            tx_id,
-            destination_public_key: dest_pubkey.clone(),
-            amount,
-            fee: sender_protocol.get_fee_amount()?,
-            sender_protocol,
-            message,
-            timestamp: Utc::now().naive_utc(),
-        })?;
+        self.db
+            .add_pending_outbound_transaction(tx_id, OutboundTransaction {
+                tx_id,
+                destination_public_key: dest_pubkey.clone(),
+                amount,
+                fee: sender_protocol.get_fee_amount()?,
+                sender_protocol,
+                message,
+                timestamp: Utc::now().naive_utc(),
+            })
+            .await?;
 
         info!(
             target: LOG_TARGET,
@@ -422,7 +430,8 @@ where
 
         let mut outbound_tx = self
             .db
-            .get_pending_outbound_transaction(recipient_reply.tx_id.clone())?;
+            .get_pending_outbound_transaction(recipient_reply.tx_id.clone())
+            .await?;
 
         let tx_id = recipient_reply.tx_id.clone();
         if !outbound_tx.sender_protocol.check_tx_id(tx_id.clone()) ||
@@ -452,7 +461,8 @@ where
             timestamp: Utc::now().naive_utc(),
         };
         self.db
-            .complete_outbound_transaction(tx_id.clone(), completed_transaction.clone())?;
+            .complete_outbound_transaction(tx_id.clone(), completed_transaction.clone())
+            .await?;
         info!(
             target: LOG_TARGET,
             "Transaction Recipient Reply for TX_ID = {} received", tx_id,
@@ -515,7 +525,7 @@ where
 
             // Check this is not a repeat message i.e. tx_id doesn't already exist in our pending or completed
             // transactions
-            if self.db.transaction_exists(&recipient_reply.tx_id)? {
+            if self.db.transaction_exists(&recipient_reply.tx_id).await? {
                 return Err(TransactionServiceError::RepeatedMessageError);
             }
 
@@ -539,7 +549,8 @@ where
                 timestamp: Utc::now().naive_utc(),
             };
             self.db
-                .add_pending_inbound_transaction(tx_id, inbound_transaction.clone())?;
+                .add_pending_inbound_transaction(tx_id, inbound_transaction.clone())
+                .await?;
 
             info!(
                 target: LOG_TARGET,
@@ -586,13 +597,17 @@ where
             source_pubkey.clone()
         );
 
-        let inbound_tx = self.db.get_pending_inbound_transaction(tx_id.clone()).map_err(|e| {
-            error!(
-                target: LOG_TARGET,
-                "Finalized transaction TxId does not exist in Pending Inbound Transactions"
-            );
-            e
-        })?;
+        let inbound_tx = self
+            .db
+            .get_pending_inbound_transaction(tx_id.clone())
+            .await
+            .map_err(|e| {
+                error!(
+                    target: LOG_TARGET,
+                    "Finalized transaction TxId does not exist in Pending Inbound Transactions"
+                );
+                e
+            })?;
 
         if inbound_tx.source_public_key != source_pubkey {
             error!(
@@ -630,7 +645,8 @@ where
         };
 
         self.db
-            .complete_inbound_transaction(tx_id.clone(), completed_transaction.clone())?;
+            .complete_inbound_transaction(tx_id.clone(), completed_transaction.clone())
+            .await?;
 
         // TODO Actually Broadcast this Transaction to a base node
 
@@ -673,26 +689,31 @@ where
                     .commitment
                     .commit_value(&spending_key, u64::from(amount.clone())),
                 timestamp: Utc::now().naive_utc(),
-            })?;
+            })
+            .await?;
 
         Ok(PendingCoinbaseSpendingKey { tx_id, spending_key })
     }
 
     /// Once the miner has constructed the completed Coinbase transaction they will submit it to the Transaction Service
     /// which will monitor the chain to see when it has been mined.
-    pub fn submit_completed_coinbase_transaction(
+    pub async fn submit_completed_coinbase_transaction(
         &mut self,
         tx_id: TxId,
         completed_transaction: Transaction,
     ) -> Result<(), TransactionServiceError>
     {
-        let coinbase_tx = self.db.get_pending_coinbase_transaction(tx_id.clone()).map_err(|e| {
-            error!(
-                target: LOG_TARGET,
-                "Finalized coinbase transaction TxId does not exist in Pending Inbound Transactions"
-            );
-            e
-        })?;
+        let coinbase_tx = self
+            .db
+            .get_pending_coinbase_transaction(tx_id.clone())
+            .await
+            .map_err(|e| {
+                error!(
+                    target: LOG_TARGET,
+                    "Finalized coinbase transaction TxId does not exist in Pending Inbound Transactions"
+                );
+                e
+            })?;
 
         if completed_transaction.body.inputs().len() != 0 ||
             completed_transaction.body.outputs().len() != 1 ||
@@ -717,52 +738,60 @@ where
             return Err(TransactionServiceError::InvalidCompletedTransaction);
         }
 
-        self.db.complete_coinbase_transaction(tx_id, CompletedTransaction {
-            tx_id,
-            source_public_key: self.node_identity.public_key().clone(),
-            destination_public_key: self.node_identity.public_key().clone(),
-            amount: coinbase_tx.amount,
-            fee: MicroTari::from(0),
-            transaction: completed_transaction,
-            status: TransactionStatus::Completed,
-            message: "Coinbase Transaction".to_string(),
-            timestamp: Utc::now().naive_utc(),
-        })?;
+        self.db
+            .complete_coinbase_transaction(tx_id, CompletedTransaction {
+                tx_id,
+                source_public_key: self.node_identity.public_key().clone(),
+                destination_public_key: self.node_identity.public_key().clone(),
+                amount: coinbase_tx.amount,
+                fee: MicroTari::from(0),
+                transaction: completed_transaction,
+                status: TransactionStatus::Completed,
+                message: "Coinbase Transaction".to_string(),
+                timestamp: Utc::now().naive_utc(),
+            })
+            .await?;
 
         Ok(())
     }
 
     /// If a specific coinbase transaction will not be mined then the Miner can cancel it
     pub async fn cancel_pending_coinbase_transaction(&mut self, tx_id: TxId) -> Result<(), TransactionServiceError> {
-        let _ = self.db.get_pending_coinbase_transaction(tx_id.clone()).map_err(|e| {
-            error!(
-                target: LOG_TARGET,
-                "Finalized coinbase transaction TxId does not exist in Pending Inbound Transactions"
-            );
-            e
-        })?;
+        let _ = self
+            .db
+            .get_pending_coinbase_transaction(tx_id.clone())
+            .await
+            .map_err(|e| {
+                error!(
+                    target: LOG_TARGET,
+                    "Finalized coinbase transaction TxId does not exist in Pending Inbound Transactions"
+                );
+                e
+            })?;
 
         self.output_manager_service.cancel_transaction(tx_id).await?;
 
-        self.db.cancel_coinbase_transaction(tx_id)?;
+        self.db.cancel_coinbase_transaction(tx_id).await?;
 
         Ok(())
     }
 
-    pub fn get_pending_inbound_transactions(
+    pub async fn get_pending_inbound_transactions(
         &self,
     ) -> Result<HashMap<u64, InboundTransaction>, TransactionServiceError> {
-        Ok(self.db.get_pending_inbound_transactions()?)
+        Ok(self.db.get_pending_inbound_transactions().await?)
     }
 
-    pub fn get_pending_outbound_transactions(
+    pub async fn get_pending_outbound_transactions(
         &self,
     ) -> Result<HashMap<u64, OutboundTransaction>, TransactionServiceError> {
-        Ok(self.db.get_pending_outbound_transactions()?)
+        Ok(self.db.get_pending_outbound_transactions().await?)
     }
 
-    pub fn get_completed_transactions(&self) -> Result<HashMap<u64, CompletedTransaction>, TransactionServiceError> {
-        Ok(self.db.get_completed_transactions()?)
+    pub async fn get_completed_transactions(
+        &self,
+    ) -> Result<HashMap<u64, CompletedTransaction>, TransactionServiceError> {
+        Ok(self.db.get_completed_transactions().await?)
     }
 
     /// This function is only available for testing by the client of LibWallet. It simulates a receiver accepting and
@@ -775,7 +804,8 @@ where
     ) -> Result<(), TransactionServiceError>
     {
         self.db
-            .complete_outbound_transaction(completed_tx.tx_id.clone(), completed_tx.clone())?;
+            .complete_outbound_transaction(completed_tx.tx_id.clone(), completed_tx.clone())
+            .await?;
         Ok(())
     }
 
@@ -784,14 +814,14 @@ where
     /// the completed transaction.
     #[cfg(feature = "test_harness")]
     pub async fn broadcast_transaction(&mut self, tx_id: TxId) -> Result<(), TransactionServiceError> {
-        let completed_txs = self.db.get_completed_transactions()?;
+        let completed_txs = self.db.get_completed_transactions().await?;
         let _found_tx = completed_txs
             .get(&tx_id.clone())
             .ok_or(TransactionServiceError::TestHarnessError(
                 "Could not find Completed TX to broadcast.".to_string(),
             ))?;
 
-        self.db.broadcast_completed_transaction(tx_id)?;
+        self.db.broadcast_completed_transaction(tx_id).await?;
 
         self.event_publisher
             .send(TransactionEvent::TransactionBroadcast(tx_id))
@@ -809,7 +839,7 @@ where
     pub async fn mine_transaction(&mut self, tx_id: TxId) -> Result<(), TransactionServiceError> {
         use tari_core::transactions::transaction::TransactionOutput;
 
-        let completed_txs = self.db.get_completed_transactions()?;
+        let completed_txs = self.db.get_completed_transactions().await?;
         let _found_tx = completed_txs
             .get(&tx_id.clone())
             .ok_or(TransactionServiceError::TestHarnessError(
@@ -841,7 +871,7 @@ where
             .confirm_sent_transaction(tx_id.clone(), outputs_to_be_spent, outputs_to_be_received)
             .await?;
 
-        self.db.mine_completed_transaction(tx_id)?;
+        self.db.mine_completed_transaction(tx_id).await?;
 
         self.event_publisher
             .send(TransactionEvent::TransactionMined(tx_id))
@@ -873,14 +903,17 @@ where
             receiver,
             OutputManagerDatabase::new(OutputManagerMemoryDatabase::new()),
             self.factories.clone(),
-        )?;
+        )
+        .await?;
 
         use crate::testnet_utils::make_input;
         let (_ti, uo) = make_input(&mut rng.clone(), amount + 1 * T, &self.factories);
 
-        fake_oms.add_output(uo)?;
+        fake_oms.add_output(uo).await?;
 
-        let mut stp = fake_oms.prepare_transaction_to_send(amount, MicroTari::from(100), None, "".to_string())?;
+        let mut stp = fake_oms
+            .prepare_transaction_to_send(amount, MicroTari::from(100), None, "".to_string())
+            .await?;
 
         let msg = stp.build_single_round_message()?;
         let proto_msg = proto::TransactionSenderMessage::single(msg.into());
@@ -911,7 +944,8 @@ where
         };
 
         self.db
-            .add_pending_inbound_transaction(tx_id.clone(), inbound_transaction.clone())?;
+            .add_pending_inbound_transaction(tx_id.clone(), inbound_transaction.clone())
+            .await?;
 
         self.event_publisher
             .send(TransactionEvent::ReceivedTransaction(tx_id))
@@ -925,7 +959,7 @@ where
     /// wallet sending a transaction to this wallet which will become a PendingInboundTransaction
     #[cfg(feature = "test_harness")]
     pub async fn finalize_received_test_transaction(&mut self, tx_id: TxId) -> Result<(), TransactionServiceError> {
-        let inbound_txs = self.db.get_pending_inbound_transactions()?;
+        let inbound_txs = self.db.get_pending_inbound_transactions().await?;
 
         let found_tx = inbound_txs
             .get(&tx_id.clone())
@@ -946,7 +980,8 @@ where
         };
 
         self.db
-            .complete_inbound_transaction(tx_id.clone(), completed_transaction.clone())?;
+            .complete_inbound_transaction(tx_id.clone(), completed_transaction.clone())
+            .await?;
         self.event_publisher
             .send(TransactionEvent::ReceivedFinalizedTransaction(tx_id))
             .await
@@ -957,7 +992,7 @@ where
 
 async fn transaction_send_discovery_process_completion<TBackend: TransactionBackend + Clone + 'static>(
     response_channel: oneshot::Receiver<SendMessageResponse>,
-    mut db: TransactionDatabase<TBackend>,
+    db: TransactionDatabase<TBackend>,
     tx_id: TxId,
     outbound_tx: OutboundTransaction,
 ) -> Result<TxId, TransactionServiceError>
@@ -1001,7 +1036,10 @@ async fn transaction_send_discovery_process_completion<TBackend: TransactionBack
             timestamp: Utc::now().naive_utc(),
             ..outbound_tx
         };
-        if let Err(_) = db.add_pending_outbound_transaction(tx_id, updated_outbound_tx.clone()) {
+        if let Err(_) = db
+            .add_pending_outbound_transaction(tx_id, updated_outbound_tx.clone())
+            .await
+        {
             success = false;
         }
         info!(

--- a/base_layer/wallet/src/wallet.rs
+++ b/base_layer/wallet/src/wallet.rs
@@ -80,7 +80,7 @@ pub struct WalletConfig {
 /// the services and provide the APIs that applications will use to interact with the services
 pub struct Wallet<T, U, V, W>
 where
-    T: WalletBackend,
+    T: WalletBackend + 'static,
     U: TransactionBackend + Clone + 'static,
     V: OutputManagerBackend + 'static,
     W: ContactsBackend + 'static,
@@ -103,7 +103,7 @@ where
 
 impl<T, U, V, W> Wallet<T, U, V, W>
 where
-    T: WalletBackend,
+    T: WalletBackend + 'static,
     U: TransactionBackend + Clone + 'static,
     V: OutputManagerBackend + 'static,
     W: ContactsBackend + 'static,
@@ -246,7 +246,7 @@ where
 
         self.comms.peer_manager().add_peer(peer.clone())?;
 
-        self.db.save_peer(peer)?;
+        self.runtime.block_on(self.db.save_peer(peer))?;
 
         Ok(())
     }

--- a/base_layer/wallet/tests/wallet/mod.rs
+++ b/base_layer/wallet/tests/wallet/mod.rs
@@ -323,6 +323,7 @@ impl CallbackState {
         }
     }
 
+    #[allow(dead_code)]
     fn reset(&mut self) {
         self.received_tx_callback_called = false;
         self.received_tx_reply_callback_called = false;


### PR DESCRIPTION
## Description
All the database calls in the wallet were synchronous and I suspect the deadlocks we were seeing in constrained environments was due to this fact. The PR makes all the wallet database calls proper async blocking tasks.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch
* [x] I ran `cargo-fmt --all` before pushing
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
