### PR TITLE
Make OMS broadcast buffer size configurable

### DIFF
--- a/comms/src/builder/builder.rs
+++ b/comms/src/builder/builder.rs
@@ -295,10 +295,11 @@ where
     {
         let outbound_stream = self.outbound_stream.take().expect("outbound_stream cannot be None");
         let oms_backoff = self.oms_backoff.take().expect("oms_backoff was None");
-        let (event_tx, _) = broadcast::channel(10);
+        let config = self.outbound_service_config.take().unwrap_or_default();
+        let (event_tx, _) = broadcast::channel(config.broadcast_channel_buf_size);
         (
             OutboundMessageService::with_backoff(
-                self.outbound_service_config.take().unwrap_or_default(),
+                config,
                 outbound_stream,
                 node_identity,
                 connection_manager_requester,

--- a/comms/src/outbound_message_service/mod.rs
+++ b/comms/src/outbound_message_service/mod.rs
@@ -39,6 +39,8 @@ pub struct OutboundServiceConfig {
     pub max_cached_connections: usize,
     /// Maximum attempts to send a message before discarding it. Default: 5
     pub max_attempts: usize,
+    /// The size of the broadcast buffer. Default: 100
+    pub broadcast_channel_buf_size: usize,
 }
 
 impl Default for OutboundServiceConfig {
@@ -46,6 +48,7 @@ impl Default for OutboundServiceConfig {
         Self {
             max_attempts: 5,
             max_cached_connections: 20,
+            broadcast_channel_buf_size: 100,
         }
     }
 }


### PR DESCRIPTION
Was hardcoded to 10. Made it configurable and default to 100
