### PR TITLE
Check and fix re-org logic 

### DIFF
--- a/base_layer/core/src/blocks/blockheader.rs
+++ b/base_layer/core/src/blocks/blockheader.rs
@@ -150,7 +150,15 @@ impl BlockHeader {
 
     /// Calculates and returns the achieved difficulty for this header and associated proof of work.
     pub fn achieved_difficulty(&self) -> Difficulty {
-        self.pow.achieved_difficulty(self)
+        ProofOfWork::achieved_difficulty(self)
+    }
+
+    /// Calculates the total accumulated difficulty for the blockchain from the genesis block up until (and including)
+    /// this block.
+    pub fn total_accumulated_difficulty_inclusive(&self) -> Difficulty {
+        let mut prev_pow = self.pow.clone();
+        prev_pow.add_difficulty(&self.pow, self.achieved_difficulty());
+        prev_pow.total_accumulated_difficulty()
     }
 }
 
@@ -271,11 +279,11 @@ mod test {
     #[test]
     fn from_previous() {
         let mut h1 = crate::proof_of_work::blake_test::get_header();
-        h1.nonce = 327; // Achieved difficulty is 1,034;
+        h1.nonce = 7600; // Achieved difficulty is 18,138;
         assert_eq!(h1.height, 0, "Default block height");
         let hash1 = h1.hash();
         let diff1 = h1.achieved_difficulty();
-        assert_eq!(diff1, 1_034.into());
+        assert_eq!(diff1, 18138.into());
         let h2 = BlockHeader::from_previous(&h1);
         assert_eq!(h2.height, h1.height + 1, "Incrementing block height");
         assert!(h2.timestamp > h1.timestamp, "Timestamp");

--- a/base_layer/core/src/mining/blake_miner.rs
+++ b/base_layer/core/src/mining/blake_miner.rs
@@ -20,7 +20,10 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use crate::{blocks::BlockHeader, proof_of_work::Difficulty};
+use crate::{
+    blocks::BlockHeader,
+    proof_of_work::{Difficulty, ProofOfWork},
+};
 use bigint::uint::U256;
 use rand::RngCore;
 use serde::{Deserialize, Serialize};
@@ -54,7 +57,7 @@ impl CpuBlakePow {
         let mut nonce: u64 = rng.next_u64();
         let start_nonce = nonce;
         // We're mining over here!
-        let difficulty = header.pow.achieved_difficulty(&header);
+        let difficulty = ProofOfWork::achieved_difficulty(&header);
         while difficulty < target_difficulty {
             if stop_flag.load(Ordering::Relaxed) || kill_flag.load(Ordering::Relaxed) {
                 return None;

--- a/base_layer/core/src/proof_of_work/blake_pow.rs
+++ b/base_layer/core/src/proof_of_work/blake_pow.rs
@@ -82,30 +82,30 @@ pub mod test {
     fn validate_max_target() {
         let mut header = get_header();
         header.nonce = 1;
-        assert_eq!(blake_difficulty(&header), Difficulty::from(1));
+        assert_eq!(blake_difficulty(&header), Difficulty::from(5));
     }
 
     #[test]
     fn difficulty_1000() {
         let mut header = get_header();
-        header.nonce = 327;
+        header.nonce = 2606;
         let (diff, hash) = blake_difficulty_with_hash(&header);
-        assert_eq!(diff, Difficulty::from(1_034));
+        assert_eq!(diff, Difficulty::from(1_385));
         assert_eq!(
             hash.to_hex(),
-            "003f54ee9fe7aac9972c2f774db06da5feba7a199b94b745572ec4ac8b331e8f"
+            "002f4dc46d5ac0f0207629095a479d6b0fa7d3db08a1ae1790e4d2078376948d"
         );
     }
 
     #[test]
     fn difficulty_1mil() {
         let mut header = get_header();
-        header.nonce = 1_753_044;
+        header.nonce = 7_945_536;
         let (diff, hash) = blake_difficulty_with_hash(&header);
-        assert_eq!(diff, Difficulty::from(3_039_691));
+        assert_eq!(diff, Difficulty::from(2_459_030));
         assert_eq!(
             hash.to_hex(),
-            "00000584f6336e855c6c881cb24a875e4ce353ddd0c38f47564bdb992f761e6a"
+            "000006d29c3fce2f73e2a96daa9071f3c5c65f0b9334513bca6a39d279c5faaf"
         );
     }
 }

--- a/base_layer/core/src/proof_of_work/difficulty.rs
+++ b/base_layer/core/src/proof_of_work/difficulty.rs
@@ -56,7 +56,7 @@ impl Difficulty {
 
 impl Default for Difficulty {
     fn default() -> Self {
-        Difficulty(0)
+        Difficulty::min()
     }
 }
 
@@ -114,7 +114,7 @@ mod test {
             Difficulty::from(1_000) + Difficulty::from(8_000),
             Difficulty::from(9_000)
         );
-        assert_eq!(Difficulty::default() + Difficulty::from(42), Difficulty::from(42));
+        assert_eq!(Difficulty::default() + Difficulty::from(42), Difficulty::from(43));
         assert_eq!(&Difficulty::from(15) + &Difficulty::from(5), Difficulty::from(20));
     }
 }

--- a/base_layer/core/src/proof_of_work/proof_of_work.rs
+++ b/base_layer/core/src/proof_of_work/proof_of_work.rs
@@ -111,9 +111,9 @@ impl ProofOfWork {
     /// (as a u256)
     ///
     /// If there are any problems with calculating a difficulty (e.g. an invalid header), then the function returns a
-    /// difficulty of zero.
-    pub fn achieved_difficulty(&self, header: &BlockHeader) -> Difficulty {
-        match self.pow_algo {
+    /// difficulty of one.
+    pub fn achieved_difficulty(header: &BlockHeader) -> Difficulty {
+        match header.pow.pow_algo {
             PowAlgorithm::Monero => monero_difficulty(header),
             PowAlgorithm::Blake => blake_difficulty(header),
         }
@@ -215,7 +215,7 @@ mod test {
         let pow = ProofOfWork::default();
         assert_eq!(
             &format!("{}", pow),
-            "Mining algorithm: Blake, \nTotal accumulated difficulty: \nMonero=0, Blake=0\nPow data: "
+            "Mining algorithm: Blake, \nTotal accumulated difficulty: \nMonero=1, Blake=1\nPow data: "
         );
     }
 

--- a/base_layer/core/tests/helpers/block_builders.rs
+++ b/base_layer/core/tests/helpers/block_builders.rs
@@ -24,6 +24,7 @@ use tari_core::{
     blocks::{Block, BlockBuilder, BlockHeader, NewBlockTemplate},
     chain_storage::{BlockAddResult, BlockchainBackend, BlockchainDatabase, ChainStorageError, MemoryDatabase},
     consensus::emission::EmissionSchedule,
+    proof_of_work::Difficulty,
     transactions::{
         helpers::{
             create_random_signature,
@@ -132,9 +133,10 @@ where
     B: BlockchainBackend,
 {
     let (block, output) = genesis_template(&factories, coinbase_value);
-    let block = db
+    let mut block = db
         .calculate_mmr_roots(block)
         .expect("Could not generate genesis block MMRs");
+    find_header_with_achieved_difficulty(&mut block.header, Difficulty::from(1));
     (block, output)
 }
 
@@ -155,9 +157,10 @@ where
         secrets.push(UnblindedOutput::new(v.clone(), k, None));
         secrets
     });
-    let block = db
+    let mut block = db
         .calculate_mmr_roots(template)
         .expect("Could not generate genesis block MMRs");
+    find_header_with_achieved_difficulty(&mut block.header, Difficulty::from(1));
     (block, outputs)
 }
 
@@ -226,6 +229,27 @@ pub fn generate_new_block(
     generate_block(db, blocks, txns)
 }
 
+pub fn generate_new_block_with_achieved_difficulty(
+    db: &mut BlockchainDatabase<MemoryDatabase<HashDigest>>,
+    blocks: &mut Vec<Block>,
+    outputs: &mut Vec<Vec<UnblindedOutput>>,
+    schemas: Vec<TransactionSchema>,
+    achieved_difficulty: Difficulty,
+) -> Result<BlockAddResult, ChainStorageError>
+{
+    let mut txns = Vec::new();
+    let mut block_utxos = Vec::new();
+    let mut keys = Vec::new();
+    for schema in schemas {
+        let (tx, mut utxos, param) = spend_utxos(schema);
+        txns.push(tx);
+        block_utxos.append(&mut utxos);
+        keys.push(param);
+    }
+    outputs.push(block_utxos);
+    generate_block_with_achieved_difficulty(db, blocks, txns, achieved_difficulty)
+}
+
 /// Generate a new block using the given transaction schema and coinbase value and add it to the provided database.
 /// The blocks and UTXO vectors are also updated with the info from the new block.
 pub fn generate_new_block_with_coinbase(
@@ -253,6 +277,12 @@ pub fn generate_new_block_with_coinbase(
     generate_block_with_coinbase(db, blocks, txns, coinbase_utxo, coinbase_kernel)
 }
 
+pub fn find_header_with_achieved_difficulty(header: &mut BlockHeader, achieved_difficulty: Difficulty) {
+    while header.achieved_difficulty() != achieved_difficulty {
+        header.nonce += 1;
+    }
+}
+
 /// Generate a block and add it to the database using the transactions provided. The header will be updated with the
 /// correct MMR roots.
 /// This function is not able to determine the unblinded outputs of a transaction, so if you are mixing using this
@@ -265,6 +295,23 @@ pub fn generate_block(
 {
     let template = chain_block(&blocks.last().unwrap(), transactions);
     let new_block = db.calculate_mmr_roots(template)?;
+    let result = db.add_block(new_block.clone());
+    if let Ok(BlockAddResult::Ok) = result {
+        blocks.push(new_block);
+    }
+    result
+}
+
+pub fn generate_block_with_achieved_difficulty(
+    db: &mut BlockchainDatabase<MemoryDatabase<HashDigest>>,
+    blocks: &mut Vec<Block>,
+    transactions: Vec<Transaction>,
+    achieved_difficulty: Difficulty,
+) -> Result<BlockAddResult, ChainStorageError>
+{
+    let template = chain_block(&blocks.last().unwrap(), transactions);
+    let mut new_block = db.calculate_mmr_roots(template)?;
+    find_header_with_achieved_difficulty(&mut new_block.header, achieved_difficulty);
     let result = db.add_block(new_block.clone());
     if let Ok(BlockAddResult::Ok) = result {
         blocks.push(new_block);

--- a/base_layer/core/tests/horizon_state_validators.rs
+++ b/base_layer/core/tests/horizon_state_validators.rs
@@ -26,6 +26,7 @@ mod helpers;
 use crate::helpers::block_builders::{
     create_genesis_block,
     create_genesis_block_with_coinbase_value,
+    find_header_with_achieved_difficulty,
     generate_new_block_with_coinbase,
 };
 use std::sync::Arc;
@@ -49,12 +50,6 @@ use tari_core::{
         ValidationError,
     },
 };
-
-fn find_header_with_achieved_difficulty(header: &mut BlockHeader, achieved_difficulty: Difficulty) {
-    while header.achieved_difficulty() != achieved_difficulty {
-        header.nonce += 1;
-    }
-}
 
 #[test]
 fn validate_header_sequence_and_chaining() {


### PR DESCRIPTION
## Description
- The handle_reorg function was updated to allow the construction of forked chains from newly received orphan blocks. The orphan chain tip with the highest accumulated difficulty that is linked to the new orphan block is found. A chain is then constructed from the tip to the new orphan block all the way to the main chain. When the total accumulated difficulty is higher than the tip of the main chain then a chain reorganisation is performed. 
- Added the total_accumulated_with_achieved_difficulty member function to BlockHeader, this allows the total accumulated difficulty for the blockchain at that height including the achieved difficulty to be determined.
- Changed the default difficulty to 1 as the geometric mean calculation fails when the difficulty is 0. Some tests had to be updated with new nonces to accommodate the change.
- Additional block builder helper functions were added to enable testing of blocks with specific achieved difficulties.

## Motivation and Context
The new reorg logic handles more special cases such as orphan blocks that are received out of order.

## How Has This Been Tested?
The handle_reorg test was updated to include a more comprehensive test and a handle_tip_reorg test was added to test the simpler case where the newly received block is the tip.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [x] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [x] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch
* [x] I ran `cargo-fmt --all` before pushing
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
