### PR TITLE
Add the runtime for the miner

### DIFF
--- a/applications/tari_base_node/src/main.rs
+++ b/applications/tari_base_node/src/main.rs
@@ -121,7 +121,7 @@ fn main() {
     };
 
     // Build, node, build!
-    let (comms, node, _handles) = match builder::configure_and_initialize_node(&node_config, node_id, &mut rt) {
+    let (comms, node, miner) = match builder::configure_and_initialize_node(&node_config, node_id, &mut rt) {
         Ok(n) => n,
         Err(e) => {
             error!(target: LOG_TARGET, "Could not instantiate node instance. {}", e);
@@ -132,6 +132,16 @@ fn main() {
     // Configure the shutdown daemon to listen for CTRL-C
     let flag = node.get_flag();
     handle_ctrl_c(&rt, flag);
+
+    // lets run the miner
+    // Todo, enable this on config
+    if node_config.enable_mining {
+        rt.spawn(async move {
+            debug!(target: LOG_TARGET, "starting miner");
+            miner.mine().await;
+            debug!(target: LOG_TARGET, "Miner has shutdown");
+        });
+    };
 
     // Run, node, run!
     let main = async move {

--- a/applications/tari_base_node/src/miner.rs
+++ b/applications/tari_base_node/src/miner.rs
@@ -21,24 +21,25 @@
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 //
 
-use futures::channel::mpsc::{Receiver, Sender};
+use core::sync::atomic::AtomicBool;
 use std::sync::Arc;
 use tari_core::{
-    base_node::{BaseNodeStateMachine, LocalNodeCommsInterface},
+    base_node::LocalNodeCommsInterface,
     chain_storage::BlockchainBackend,
     consensus::ConsensusManager,
     mining::Miner,
 };
 use tari_service_framework::handles::ServiceHandles;
+use tokio::runtime;
 
 pub fn build_miner<B: BlockchainBackend>(
     handles: Arc<ServiceHandles>,
-    node: &BaseNodeStateMachine<B>,
+    stop_flag: Arc<AtomicBool>,
     consensus_manager: ConsensusManager<B>,
+    executor: runtime::Handle,
 ) -> Miner<B>
 {
-    let stop_flag = node.get_interrupt_flag();
     let node_local_interface = handles.get_handle::<LocalNodeCommsInterface>().unwrap();
-    let miner = Miner::new(stop_flag, consensus_manager, &node_local_interface);
+    let miner = Miner::new(stop_flag, consensus_manager, &node_local_interface, executor);
     miner
 }

--- a/base_layer/core/src/base_node/comms_interface/inbound_handlers.rs
+++ b/base_layer/core/src/base_node/comms_interface/inbound_handlers.rs
@@ -46,7 +46,7 @@ use tari_comms::types::CommsPublicKey;
 const LOG_TARGET: &str = "base_node::comms_interface::inbound_handler";
 
 /// Events that can be published on the Validated Block Event Stream
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub enum BlockEvent {
     Verified((Block, BlockAddResult)),
     Invalid((Block, ChainStorageError)),

--- a/common/src/configuration.rs
+++ b/common/src/configuration.rs
@@ -123,6 +123,7 @@ pub struct GlobalConfig {
     pub address: String,
     pub peer_seeds: Vec<String>,
     pub peer_db_path: String,
+    pub enable_mining: bool,
 }
 
 impl GlobalConfig {
@@ -200,6 +201,13 @@ fn convert_node_config(network: Network, cfg: Config) -> Result<GlobalConfig, Co
 
     // Peer DB path
     let peer_db_path = sub_dir(&data_dir, "peer_db")?;
+
+    // set base node mining
+    let key = config_string(&net_str, "enable_mining");
+    let enable_mining = cfg
+        .get_bool(&key)
+        .map_err(|e| ConfigurationError::new(&key, &e.to_string()))? as bool;
+
     Ok(GlobalConfig {
         network,
         data_dir,
@@ -210,6 +218,7 @@ fn convert_node_config(network: Network, cfg: Config) -> Result<GlobalConfig, Co
         address,
         peer_seeds,
         peer_db_path,
+        enable_mining,
     })
 }
 
@@ -260,6 +269,7 @@ pub fn default_config() -> Config {
     cfg.set_default("base_node.mainnet.grpc_enabled", false).unwrap();
     cfg.set_default("base_node.mainnet.grpc_address", "tcp://127.0.0.1:18041")
         .unwrap();
+    cfg.set_default("base_node.mainnet.enable_mining", false).unwrap();
 
     // Testnet base node defaults
     cfg.set_default("base_node.testnet.db_type", "lmdb").unwrap();
@@ -279,6 +289,7 @@ pub fn default_config() -> Config {
     cfg.set_default("base_node.testnet.grpc_enabled", false).unwrap();
     cfg.set_default("base_node.testnet.grpc_address", "tcp://127.0.0.1:18141")
         .unwrap();
+    cfg.set_default("base_node.testnet.enable_mining", true).unwrap();
 
     cfg
 }


### PR DESCRIPTION
## Description
This PR adds in the miner runtime as well as the miner base-node event stream.

## Motivation and Context
This allows the miner to run on its own thread, as well as listen to the base node when it receives a new block. When a valid new block has been received it will restart the miner on the new tip.


## Types of changes
* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
* [x] I'm merging against the `development` branch
* [x] I ran `cargo-fmt --all` before pushing
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
