### PR TITLE
removed arc from crypto factories

### DIFF
--- a/applications/tari_base_node/src/builder.rs
+++ b/applications/tari_base_node/src/builder.rs
@@ -189,7 +189,7 @@ pub fn configure_and_initialize_node(
 ) -> Result<(CommsNode, NodeType, MinerType), String>
 {
     let id = Arc::new(id);
-    let factories = Arc::new(CryptoFactories::default());
+    let factories = CryptoFactories::default();
     let peers = assign_peers(&config.peer_seeds);
     let executor = rt.handle().clone();
     let result = match &config.db_type {

--- a/base_layer/core/src/mining/coinbase_builder.rs
+++ b/base_layer/core/src/mining/coinbase_builder.rs
@@ -60,7 +60,7 @@ pub enum CoinbaseBuildError {
 }
 
 pub struct CoinbaseBuilder {
-    factories: Arc<CryptoFactories>,
+    factories: CryptoFactories,
     block_height: Option<u64>,
     fees: Option<MicroTari>,
     spend_key: Option<PrivateKey>,
@@ -70,7 +70,7 @@ pub struct CoinbaseBuilder {
 impl CoinbaseBuilder {
     /// Start building a new Coinbase transaction. From here you can build the transaction piecemeal with the builder
     /// methods, or pass in a block to `using_block` to determine most of the coinbase parameters automatically.
-    pub fn new(factories: Arc<CryptoFactories>) -> Self {
+    pub fn new(factories: CryptoFactories) -> Self {
         CoinbaseBuilder {
             factories,
             block_height: None,
@@ -162,9 +162,9 @@ mod test {
     use std::sync::Arc;
     use tari_crypto::commitment::HomomorphicCommitmentFactory;
 
-    fn get_builder() -> (CoinbaseBuilder, ConsensusManager<MockBackend>, Arc<CryptoFactories>) {
+    fn get_builder() -> (CoinbaseBuilder, ConsensusManager<MockBackend>, CryptoFactories) {
         let rules = ConsensusManager::default();
-        let factories = Arc::new(CryptoFactories::default());
+        let factories = CryptoFactories::default();
         (CoinbaseBuilder::new(factories.clone()), rules, factories)
     }
 

--- a/base_layer/core/src/mining/miner.rs
+++ b/base_layer/core/src/mining/miner.rs
@@ -179,7 +179,7 @@ impl<B: BlockchainBackend> Miner<B> {
             fees + self.consensus.emission_schedule().block_reward(height),
             height + ConsensusConstants::current().coinbase_lock_height(),
         )?;
-        let factories = Arc::new(CryptoFactories::default());
+        let factories = CryptoFactories::default();
         let builder = CoinbaseBuilder::new(factories.clone());
         let builder = builder
             .with_block_height(block.header.height)

--- a/base_layer/core/src/transactions/types.rs
+++ b/base_layer/core/src/transactions/types.rs
@@ -72,7 +72,6 @@ pub type HashOutput = Vec<u8>;
 pub const MAX_RANGE_PROOF_RANGE: usize = 64; // 2^64
 
 /// A convenience struct wrapping cryptographic factories that are used through-out the rest of the code base
-#[derive(Clone)]
 pub struct CryptoFactories {
     pub commitment: Arc<CommitmentFactory>,
     pub range_proof: Arc<RangeProofService>,
@@ -99,6 +98,15 @@ impl CryptoFactories {
         Self {
             commitment,
             range_proof,
+        }
+    }
+}
+
+impl Clone for CryptoFactories {
+    fn clone(&self) -> Self {
+        Self {
+            commitment: self.commitment.clone(),
+            range_proof: self.range_proof.clone(),
         }
     }
 }

--- a/base_layer/core/src/transactions/types.rs
+++ b/base_layer/core/src/transactions/types.rs
@@ -72,7 +72,7 @@ pub type HashOutput = Vec<u8>;
 pub const MAX_RANGE_PROOF_RANGE: usize = 64; // 2^64
 
 /// A convenience struct wrapping cryptographic factories that are used through-out the rest of the code base
-/// Uses Arc's internally so calling clone on this is cheap, no need to wrap this in an Arc
+/// Uses Arcs internally so calling clone on this is cheap, no need to wrap this in an Arc
 pub struct CryptoFactories {
     pub commitment: Arc<CommitmentFactory>,
     pub range_proof: Arc<RangeProofService>,

--- a/base_layer/core/src/transactions/types.rs
+++ b/base_layer/core/src/transactions/types.rs
@@ -72,6 +72,7 @@ pub type HashOutput = Vec<u8>;
 pub const MAX_RANGE_PROOF_RANGE: usize = 64; // 2^64
 
 /// A convenience struct wrapping cryptographic factories that are used through-out the rest of the code base
+/// Uses Arc's internally so calling clone on this is cheap, no need to wrap this in an Arc
 pub struct CryptoFactories {
     pub commitment: Arc<CommitmentFactory>,
     pub range_proof: Arc<RangeProofService>,
@@ -102,6 +103,7 @@ impl CryptoFactories {
     }
 }
 
+/// Uses Arc's internally so calling clone on this is cheap, no need to wrap this in an Arc
 impl Clone for CryptoFactories {
     fn clone(&self) -> Self {
         Self {

--- a/base_layer/core/src/validation/block_validators.rs
+++ b/base_layer/core/src/validation/block_validators.rs
@@ -36,7 +36,6 @@ use crate::{
         ValidationError,
     },
 };
-use std::sync::Arc;
 use tari_utilities::hash::Hashable;
 
 /// This validator tests whether a candidate block is internally consistent
@@ -65,14 +64,14 @@ impl<B: BlockchainBackend> Validation<Block, B> for StatelessValidator {
 /// next block on the blockchain.
 pub struct FullConsensusValidator<B: BlockchainBackend> {
     rules: ConsensusManager<B>,
-    factories: Arc<CryptoFactories>,
+    factories: CryptoFactories,
     db: BlockchainDatabase<B>,
 }
 
 impl<B: BlockchainBackend> FullConsensusValidator<B>
 where B: BlockchainBackend
 {
-    pub fn new(rules: ConsensusManager<B>, factories: Arc<CryptoFactories>, db: BlockchainDatabase<B>) -> Self {
+    pub fn new(rules: ConsensusManager<B>, factories: CryptoFactories, db: BlockchainDatabase<B>) -> Self {
         Self { rules, factories, db }
     }
 

--- a/base_layer/core/src/validation/chain_validators.rs
+++ b/base_layer/core/src/validation/chain_validators.rs
@@ -30,7 +30,6 @@ use crate::{
     transactions::types::CryptoFactories,
     validation::{error::ValidationError, traits::Validation},
 };
-use std::sync::Arc;
 use tari_crypto::commitment::HomomorphicCommitmentFactory;
 use tari_utilities::hash::Hashable;
 
@@ -38,14 +37,14 @@ use tari_utilities::hash::Hashable;
 /// the chain tip header.
 pub struct ChainTipValidator<B: BlockchainBackend> {
     rules: ConsensusManager<B>,
-    factories: Arc<CryptoFactories>,
+    factories: CryptoFactories,
     db: BlockchainDatabase<B>,
 }
 
 impl<B: BlockchainBackend> ChainTipValidator<B>
 where B: BlockchainBackend
 {
-    pub fn new(rules: ConsensusManager<B>, factories: Arc<CryptoFactories>, db: BlockchainDatabase<B>) -> Self {
+    pub fn new(rules: ConsensusManager<B>, factories: CryptoFactories, db: BlockchainDatabase<B>) -> Self {
         Self { rules, factories, db }
     }
 

--- a/base_layer/core/src/validation/transaction_validators.rs
+++ b/base_layer/core/src/validation/transaction_validators.rs
@@ -30,11 +30,11 @@ use tari_utilities::hash::Hashable;
 
 /// This validator will only check that a transaction is internally consistent. It requires no state information.
 pub struct StatelessTxValidator {
-    factories: Arc<CryptoFactories>,
+    factories: CryptoFactories,
 }
 
 impl StatelessTxValidator {
-    pub fn new(factories: Arc<CryptoFactories>) -> Self {
+    pub fn new(factories: CryptoFactories) -> Self {
         Self { factories }
     }
 }
@@ -50,14 +50,14 @@ impl<B: BlockchainBackend> Validation<Transaction, B> for StatelessTxValidator {
 /// Transaction integrity, All inputs exist in the backend, All timelocks (kernel lock heights and output maturities)
 /// have passed
 pub struct FullTxValidator<B: BlockchainBackend> {
-    factories: Arc<CryptoFactories>,
+    factories: CryptoFactories,
     db: BlockchainDatabase<B>,
 }
 
 impl<B: BlockchainBackend> FullTxValidator<B>
 where B: BlockchainBackend
 {
-    pub fn new(factories: Arc<CryptoFactories>, db: BlockchainDatabase<B>) -> Self {
+    pub fn new(factories: CryptoFactories, db: BlockchainDatabase<B>) -> Self {
         Self { factories, db }
     }
 }

--- a/base_layer/core/tests/block_validation.rs
+++ b/base_layer/core/tests/block_validation.rs
@@ -35,7 +35,7 @@ use tari_core::{
 
 #[test]
 fn test_genesis_block() {
-    let factories = Arc::new(CryptoFactories::default());
+    let factories = CryptoFactories::default();
     let rules = ConsensusManager::default();
     let backend = MemoryDatabase::<HashDigest>::default();
     let mut db = BlockchainDatabase::new(backend).unwrap();

--- a/base_layer/core/tests/horizon_state_validators.rs
+++ b/base_layer/core/tests/horizon_state_validators.rs
@@ -173,7 +173,7 @@ fn validate_chain_genesis_block() {
         GenesisBlockValidator::new(),
         MockValidator::new(true),
     );
-    let factories = Arc::new(CryptoFactories::default());
+    let factories = CryptoFactories::default();
 
     let db = MemoryDatabase::<HashDigest>::default();
     let mut store = BlockchainDatabase::new(db).unwrap();
@@ -231,7 +231,7 @@ fn create_test_blockchain_with_emission(
 fn validate_accounting_balance() {
     let db = MemoryDatabase::<HashDigest>::default();
     let mut store = BlockchainDatabase::new(db).unwrap();
-    let factories = Arc::new(CryptoFactories::default());
+    let factories = CryptoFactories::default();
     let rules = ConsensusManager::default();
     rules
         .set_diff_manager(DiffAdjManager::new(store.clone()).unwrap())
@@ -277,7 +277,7 @@ fn validate_accounting_balance() {
 fn validate_kernel_mmr_roots() {
     let db = MemoryDatabase::<HashDigest>::default();
     let mut store = BlockchainDatabase::new(db).unwrap();
-    let factories = Arc::new(CryptoFactories::default());
+    let factories = CryptoFactories::default();
     let rules = ConsensusManager::default();
     rules
         .set_diff_manager(DiffAdjManager::new(store.clone()).unwrap())
@@ -310,7 +310,7 @@ fn validate_kernel_mmr_roots() {
 fn validate_output_and_rp_mmr_roots() {
     let db = MemoryDatabase::<HashDigest>::default();
     let mut store = BlockchainDatabase::new(db).unwrap();
-    let factories = Arc::new(CryptoFactories::default());
+    let factories = CryptoFactories::default();
     let rules = ConsensusManager::default();
     rules
         .set_diff_manager(DiffAdjManager::new(store.clone()).unwrap())


### PR DESCRIPTION
## Description
Removed the use of all Arc's from cryptofactories.

## Motivation and Context
Cryptofactories already wraps its internals inside of ARC's so its no need to wrap it in an arc as well. You can just clone it.

## Types of changes
* [ ] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [x] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
* [x] I'm merging against the `development` branch
* [x] I ran `cargo-fmt --all` before pushing
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
