### PR TITLE
Allow multiple simultaneous inbound connections (bounded)

### DIFF
--- a/comms/src/connection_manager/listener.rs
+++ b/comms/src/connection_manager/listener.rs
@@ -22,10 +22,11 @@
 
 use super::error::ConnectionManagerError;
 use crate::{
+    bounded_executor::BoundedExecutor,
     connection::ConnectionDirection,
     connection_manager::{
         common,
-        next::ConnectionManagerEvent,
+        next::{ConnectionManagerConfig, ConnectionManagerEvent},
         peer_connection::{self, PeerConnection},
     },
     multiaddr::Multiaddr,
@@ -46,6 +47,7 @@ const LOG_TARGET: &str = "comms::connection_manager::listener";
 pub struct PeerListener<TTransport> {
     listen_address: Multiaddr,
     executor: runtime::Handle,
+    bounded_executor: BoundedExecutor,
     conn_man_notifier: mpsc::Sender<ConnectionManagerEvent>,
     shutdown_signal: Option<ShutdownSignal>,
     transport: TTransport,
@@ -63,7 +65,7 @@ where
 {
     pub fn new(
         executor: runtime::Handle,
-        listen_address: Multiaddr,
+        config: ConnectionManagerConfig,
         transport: TTransport,
         noise_config: NoiseConfig,
         conn_man_notifier: mpsc::Sender<ConnectionManagerEvent>,
@@ -74,8 +76,8 @@ where
     ) -> Self
     {
         Self {
-            executor,
-            listen_address,
+            executor: executor.clone(),
+            listen_address: config.listener_address,
             transport,
             noise_config,
             conn_man_notifier,
@@ -84,6 +86,7 @@ where
             shutdown_signal: Some(shutdown_signal),
             listening_address: None,
             our_supported_protocols: supported_protocols,
+            bounded_executor: BoundedExecutor::new(executor, config.max_simultaneous_inbound_connects),
         }
     }
 
@@ -107,9 +110,8 @@ where
                     futures::select! {
                         inbound_result = inbound.select_next_some() => {
                             if let Some((inbound_future, peer_addr)) = log_if_error!(target: LOG_TARGET, inbound_result, "Inbound connection failed because '{error}'",) {
-                                // TODO: Add inbound_future to FuturesUnordered stream to allow multiple peers to connect simultaneously
                                 if let Some(socket) = log_if_error!(target: LOG_TARGET, inbound_future.await,  "Inbound connection failed because '{error}'",) {
-                                    self.handle_inbound_connection(socket, peer_addr).await;
+                                    self.spawn_listen_task(socket, peer_addr).await;
                                 }
                             }
                         },
@@ -127,6 +129,54 @@ where
         }
     }
 
+    async fn spawn_listen_task(&self, socket: TTransport::Output, peer_addr: Multiaddr) {
+        let executor = self.executor.clone();
+        let node_identity = self.node_identity.clone();
+        let peer_manager = self.peer_manager.clone();
+        let mut conn_man_notifier = self.conn_man_notifier.clone();
+        let noise_config = self.noise_config.clone();
+        let our_supported_protocols = self.our_supported_protocols.clone();
+
+        // This will block (asynchronously) if we have reached the maximum simultaneous connections, creating
+        // back-pressure on nodes connecting to this node
+        self.bounded_executor
+            .spawn(async move {
+                let result = Self::perform_socket_upgrade_procedure(
+                    executor,
+                    node_identity,
+                    peer_manager,
+                    noise_config,
+                    conn_man_notifier.clone(),
+                    socket,
+                    peer_addr,
+                    our_supported_protocols,
+                )
+                .await;
+
+                match result {
+                    Ok(peer_conn) => {
+                        log_if_error!(
+                            target: LOG_TARGET,
+                            conn_man_notifier
+                                .send(ConnectionManagerEvent::PeerConnected(Box::new(peer_conn)))
+                                .await,
+                            "Failed to publish event because '{error}'",
+                        );
+                    },
+                    Err(err) => {
+                        log_if_error!(
+                            target: LOG_TARGET,
+                            conn_man_notifier
+                                .send(ConnectionManagerEvent::PeerInboundConnectFailed(err))
+                                .await,
+                            "Failed to publish event because '{error}'",
+                        );
+                    },
+                }
+            })
+            .await;
+    }
+
     async fn send_event(&mut self, event: ConnectionManagerEvent) {
         log_if_error_fmt!(
             target: LOG_TARGET,
@@ -135,23 +185,15 @@ where
         );
     }
 
-    async fn handle_inbound_connection(&mut self, socket: TTransport::Output, peer_addr: Multiaddr) {
-        match self.perform_socket_upgrade_procedure(socket, peer_addr).await {
-            Ok(peer_conn) => {
-                self.notify_connection_manager(ConnectionManagerEvent::PeerConnected(Box::new(peer_conn)))
-                    .await;
-            },
-            Err(err) => {
-                self.notify_connection_manager(ConnectionManagerEvent::PeerInboundConnectFailed(err))
-                    .await
-            },
-        }
-    }
-
     async fn perform_socket_upgrade_procedure(
-        &mut self,
+        executor: runtime::Handle,
+        node_identity: Arc<NodeIdentity>,
+        peer_manager: AsyncPeerManager,
+        noise_config: NoiseConfig,
+        conn_man_notifier: mpsc::Sender<ConnectionManagerEvent>,
         socket: TTransport::Output,
         peer_addr: Multiaddr,
+        our_supported_protocols: Vec<ProtocolId>,
     ) -> Result<PeerConnection, ConnectionManagerError>
     {
         static CONNECTION_DIRECTION: ConnectionDirection = ConnectionDirection::Inbound;
@@ -160,8 +202,7 @@ where
             "Starting noise protocol upgrade for peer at address '{}'", peer_addr
         );
 
-        let noise_socket = self
-            .noise_config
+        let noise_socket = noise_config
             .upgrade_socket(socket, CONNECTION_DIRECTION)
             .await
             .map_err(|err| ConnectionManagerError::NoiseError(err.to_string()))?;
@@ -170,7 +211,7 @@ where
             .get_remote_public_key()
             .ok_or(ConnectionManagerError::InvalidStaticPublicKey)?;
 
-        let mut muxer = Yamux::upgrade_connection(self.executor.clone(), noise_socket, CONNECTION_DIRECTION)
+        let mut muxer = Yamux::upgrade_connection(executor.clone(), noise_socket, CONNECTION_DIRECTION)
             .await
             .map_err(|err| ConnectionManagerError::YamuxUpgradeFailure(err.to_string()))?;
 
@@ -179,25 +220,20 @@ where
             "Starting peer identity exchange for peer with public key '{}'",
             authenticated_public_key
         );
-        let peer_identity =
-            common::perform_identity_exchange(&mut muxer, Arc::clone(&self.node_identity), CONNECTION_DIRECTION)
+        let peer_identity = common::perform_identity_exchange(&mut muxer, node_identity, CONNECTION_DIRECTION).await?;
+
+        let peer_node_id =
+            common::validate_and_add_peer_from_peer_identity(&peer_manager, authenticated_public_key, peer_identity)
                 .await?;
 
-        let peer_node_id = common::validate_and_add_peer_from_peer_identity(
-            &self.peer_manager,
-            authenticated_public_key,
-            peer_identity,
-        )
-        .await?;
-
         peer_connection::create(
-            self.executor.clone(),
+            executor,
             muxer,
             peer_addr,
             peer_node_id,
             CONNECTION_DIRECTION,
-            self.conn_man_notifier.clone(),
-            self.our_supported_protocols.clone(),
+            conn_man_notifier,
+            our_supported_protocols,
         )
     }
 
@@ -206,13 +242,5 @@ where
             .listen(self.listen_address.clone())
             .await
             .map_err(|err| ConnectionManagerError::TransportError(err.to_string()))
-    }
-
-    pub async fn notify_connection_manager(&mut self, event: ConnectionManagerEvent) {
-        log_if_error!(
-            target: LOG_TARGET,
-            self.conn_man_notifier.send(event).await,
-            "Failed to publish event because '{error}'",
-        );
     }
 }

--- a/comms/src/connection_manager/manager.rs
+++ b/comms/src/connection_manager/manager.rs
@@ -73,9 +73,13 @@ pub enum ConnectionManagerEvent {
 #[derive(Debug, Clone)]
 pub struct ConnectionManagerConfig {
     /// The address to listen on for incoming connections. This address must be supported by the transport.
+    /// Default: DEFAULT_LISTENER_ADDRESS constant
     pub listener_address: Multiaddr,
-    /// The number of dial attempts to make before giving up
+    /// The number of dial attempts to make before giving up. Default: 3
     pub max_dial_attempts: usize,
+    /// The maximum number of connection tasks that will be spawned at the same time. Once this limit is reached, peers
+    /// attempting to connect will have to wait for another connection attempt to complete. Default: 20
+    pub max_simultaneous_inbound_connects: usize,
 }
 
 impl Default for ConnectionManagerConfig {
@@ -85,6 +89,7 @@ impl Default for ConnectionManagerConfig {
                 .parse()
                 .expect("DEFAULT_LISTENER_ADDRESS is malformed"),
             max_dial_attempts: 3,
+            max_simultaneous_inbound_connects: 20,
         }
     }
 }
@@ -129,7 +134,7 @@ where
 
         let listener = PeerListener::new(
             executor.clone(),
-            config.listener_address.clone(),
+            config.clone(),
             transport.clone(),
             noise_config.clone(),
             event_tx.clone(),


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
The peer listener now can accept and upgrade multiple peer
connections simultaneously. Each inbound connection spawns it's own
"connection upgrade" task using the bounded executor (see PR #1257).

A configuration field was added to set maximum simultaneous inbound
connections. Once this threshold is reached, any new inbound connections
will have to wait for other connection to complete their upgrade
procedure.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #1151 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Concurrent inbound connections needs to be tested, leaving that for a later PR

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [x] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch
* [x] I ran `cargo-fmt --all` before pushing
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
