### PR TITLE
Simultaneous connection tie breaking

### DIFF
--- a/base_layer/p2p/tests/services/liveness.rs
+++ b/base_layer/p2p/tests/services/liveness.rs
@@ -135,12 +135,13 @@ fn end_to_end() {
             .unwrap();
     }
 
-    let events = collect_stream!(
-        runtime,
-        liveness1.get_event_stream_fused(),
-        take = 18,
-        timeout = Duration::from_secs(20),
-    );
+    let events = runtime.block_on(async {
+        collect_stream!(
+            liveness1.get_event_stream_fused(),
+            take = 18,
+            timeout = Duration::from_secs(20),
+        )
+    });
 
     let ping_count = events
         .iter()
@@ -162,12 +163,13 @@ fn end_to_end() {
 
     assert_eq!(pong_count, 8);
 
-    let events = collect_stream!(
-        runtime,
-        liveness2.get_event_stream_fused(),
-        take = 18,
-        timeout = Duration::from_secs(10),
-    );
+    let events = runtime.block_on(async {
+        collect_stream!(
+            liveness2.get_event_stream_fused(),
+            take = 18,
+            timeout = Duration::from_secs(10),
+        )
+    });
 
     let ping_count = events
         .iter()

--- a/base_layer/wallet/src/testnet_utils.rs
+++ b/base_layer/wallet/src/testnet_utils.rs
@@ -379,38 +379,42 @@ pub fn generate_wallet_test_data<
     let alice_event_stream = wallet_alice.transaction_service.get_event_stream_fused();
     let bob_event_stream = wallet_bob.transaction_service.get_event_stream_fused();
 
-    let _alice_stream = collect_stream!(
-        wallet_alice.runtime,
-        alice_event_stream.map(|i| (*i).clone()),
-        take = 12,
-        timeout = Duration::from_secs(60)
-    );
+    let _alice_stream = wallet_alice.runtime.block_on(async {
+        collect_stream!(
+            alice_event_stream.map(|i| (*i).clone()),
+            take = 12,
+            timeout = Duration::from_secs(60)
+        )
+    });
 
-    let _bob_stream = collect_stream!(
-        wallet_bob.runtime,
-        bob_event_stream.map(|i| (*i).clone()),
-        take = 8,
-        timeout = Duration::from_secs(60)
-    );
+    let _bob_stream = wallet_bob.runtime.block_on(async {
+        collect_stream!(
+            bob_event_stream.map(|i| (*i).clone()),
+            take = 8,
+            timeout = Duration::from_secs(60)
+        )
+    });
 
     // Make sure that the messages have been received by the alice and bob wallets before they start sending messages so
     // that they have the wallet in their peer_managers
     let alice_event_stream = wallet_alice.transaction_service.get_event_stream_fused();
     let bob_event_stream = wallet_bob.transaction_service.get_event_stream_fused();
 
-    let _alice_stream = collect_stream!(
-        wallet_alice.runtime,
-        alice_event_stream.map(|i| (*i).clone()),
-        take = 6,
-        timeout = Duration::from_secs(60)
-    );
+    let _alice_stream = wallet_bob.runtime.block_on(async {
+        collect_stream!(
+            alice_event_stream.map(|i| (*i).clone()),
+            take = 6,
+            timeout = Duration::from_secs(60)
+        )
+    });
 
-    let _bob_stream = collect_stream!(
-        wallet_bob.runtime,
-        bob_event_stream.map(|i| (*i).clone()),
-        take = 2,
-        timeout = Duration::from_secs(60)
-    );
+    let _bob_stream = wallet_bob.runtime.block_on(async {
+        collect_stream!(
+            bob_event_stream.map(|i| (*i).clone()),
+            take = 2,
+            timeout = Duration::from_secs(60)
+        )
+    });
 
     // Pending Inbound
     wallet_alice
@@ -463,12 +467,13 @@ pub fn generate_wallet_test_data<
         ))?;
 
     let wallet_event_stream = wallet.transaction_service.get_event_stream_fused();
-    let _wallet_stream = collect_stream!(
-        wallet.runtime,
-        wallet_event_stream.map(|i| (*i).clone()),
-        take = 20,
-        timeout = Duration::from_secs(60)
-    );
+    let _wallet_stream = wallet.runtime.block_on(async {
+        collect_stream!(
+            wallet_event_stream.map(|i| (*i).clone()),
+            take = 20,
+            timeout = Duration::from_secs(60)
+        )
+    });
 
     let txs = wallet
         .runtime

--- a/base_layer/wallet/tests/transaction_service/callback_handler.rs
+++ b/base_layer/wallet/tests/transaction_service/callback_handler.rs
@@ -230,12 +230,13 @@ fn test_callback_handler() {
 
     let alice_event_stream = alice_ts.get_event_stream_fused();
 
-    let alice_stream = collect_stream!(
-        runtime,
-        alice_event_stream.map(|i| (*i).clone()),
-        take = 4,
-        timeout = Duration::from_secs(10)
-    );
+    let alice_stream = runtime.block_on(async {
+        collect_stream!(
+            alice_event_stream.map(|i| (*i).clone()),
+            take = 4,
+            timeout = Duration::from_secs(10)
+        )
+    });
 
     let recv_tx = alice_stream.iter().find(|i| {
         if let TransactionEvent::ReceivedTransactionReply(_) = i {
@@ -252,12 +253,13 @@ fn test_callback_handler() {
     };
 
     let alice_event_stream = alice_ts.get_event_stream_fused();
-    let _ = collect_stream!(
-        runtime,
-        alice_event_stream.map(|i| (*i).clone()),
-        take = 5,
-        timeout = Duration::from_secs(10)
-    );
+    let _ = runtime.block_on(async {
+        collect_stream!(
+            alice_event_stream.map(|i| (*i).clone()),
+            take = 5,
+            timeout = Duration::from_secs(10)
+        )
+    });
 
     if let TransactionEvent::ReceivedTransactionReply(tx_id) = recv_tx.unwrap() {
         runtime
@@ -266,12 +268,13 @@ fn test_callback_handler() {
     };
 
     let alice_event_stream = alice_ts.get_event_stream_fused();
-    let _ = collect_stream!(
-        runtime,
-        alice_event_stream.map(|i| (*i).clone()),
-        take = 6,
-        timeout = Duration::from_secs(10)
-    );
+    let _ = runtime.block_on(async {
+        collect_stream!(
+            alice_event_stream.map(|i| (*i).clone()),
+            take = 6,
+            timeout = Duration::from_secs(10)
+        )
+    });
 
     let callback_state = CALLBACK_STATE.lock().unwrap();
     assert!(callback_state.received_tx_callback_called);

--- a/base_layer/wallet/tests/wallet/mod.rs
+++ b/base_layer/wallet/tests/wallet/mod.rs
@@ -185,17 +185,19 @@ fn test_wallet() {
             .unwrap();
 
         assert_eq!(
-            collect_stream!(
-                runtime,
-                alice_event_stream.map(|i| (*i).clone()),
-                take = 1,
-                timeout = Duration::from_secs(10)
-            )
-            .iter()
-            .fold(0, |acc, x| match x {
-                TransactionEvent::ReceivedTransactionReply(_) => acc + 1,
-                _ => acc,
-            }),
+            runtime
+                .block_on(async {
+                    collect_stream!(
+                        alice_event_stream.map(|i| (*i).clone()),
+                        take = 1,
+                        timeout = Duration::from_secs(10)
+                    )
+                })
+                .iter()
+                .fold(0, |acc, x| match x {
+                    TransactionEvent::ReceivedTransactionReply(_) => acc + 1,
+                    _ => acc,
+                }),
             1
         );
 

--- a/comms/Cargo.toml
+++ b/comms/Cargo.toml
@@ -33,7 +33,7 @@ rand = "0.7.2"
 serde = "1.0.90"
 serde_derive = "1.0.90"
 snow = {version="0.6.2", features=["default-resolver"], optional = true}
-tokio = {version="^0.2", features=["blocking", "tcp", "stream", "dns", "sync"]}
+tokio = {version="^0.2", features=["blocking", "tcp", "stream", "dns", "sync", "stream"]}
 tokio-util = {version="0.2.0", features=["codec"]}
 yamux = {version="0.4.0", optional = true}
 zmq = "0.9.2"

--- a/comms/src/connection_manager/listener.rs
+++ b/comms/src/connection_manager/listener.rs
@@ -63,7 +63,7 @@ where
     TTransport: Transport,
     TTransport::Output: AsyncRead + AsyncWrite + Send + Unpin + 'static,
 {
-    pub fn new(
+    pub(crate) fn new(
         executor: runtime::Handle,
         config: ConnectionManagerConfig,
         transport: TTransport,
@@ -158,7 +158,7 @@ where
                         log_if_error!(
                             target: LOG_TARGET,
                             conn_man_notifier
-                                .send(ConnectionManagerEvent::PeerConnected(Box::new(peer_conn)))
+                                .send(ConnectionManagerEvent::PeerConnected(peer_conn))
                                 .await,
                             "Failed to publish event because '{error}'",
                         );

--- a/comms/src/connection_manager/requester.rs
+++ b/comms/src/connection_manager/requester.rs
@@ -21,31 +21,44 @@
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 use super::{error::ConnectionManagerError, peer_connection::PeerConnection};
-use crate::peer_manager::NodeId;
+use crate::{connection_manager::manager::ConnectionManagerEvent, multiaddr::Multiaddr, peer_manager::NodeId};
 use futures::{
     channel::{mpsc, oneshot},
     SinkExt,
 };
+use std::sync::Arc;
+use tokio::sync::broadcast;
 
 /// Requests which are handled by the ConnectionManagerService
 pub enum ConnectionManagerRequest {
     DialPeer(NodeId, oneshot::Sender<Result<PeerConnection, ConnectionManagerError>>),
+    NotifyListening(oneshot::Sender<Multiaddr>),
 }
 
 /// Responsible for constructing requests to the ConnectionManagerService
 #[derive(Clone)]
 pub struct ConnectionManagerRequester {
     sender: mpsc::Sender<ConnectionManagerRequest>,
+    event_tx: broadcast::Sender<Arc<ConnectionManagerEvent>>,
 }
 
 impl ConnectionManagerRequester {
     /// Create a new ConnectionManagerRequester
-    pub fn new(sender: mpsc::Sender<ConnectionManagerRequest>) -> Self {
-        Self { sender }
+    pub fn new(
+        sender: mpsc::Sender<ConnectionManagerRequest>,
+        event_tx: broadcast::Sender<Arc<ConnectionManagerEvent>>,
+    ) -> Self
+    {
+        Self { sender, event_tx }
     }
 }
 
 impl ConnectionManagerRequester {
+    /// Returns a ConnectionManagerEvent stream
+    pub fn subscribe_events(&self) -> broadcast::Receiver<Arc<ConnectionManagerEvent>> {
+        self.event_tx.subscribe()
+    }
+
     /// Attempt to connect to a remote peer
     pub async fn dial_peer(&mut self, node_id: NodeId) -> Result<PeerConnection, ConnectionManagerError> {
         let (reply_tx, reply_rx) = oneshot::channel();
@@ -56,5 +69,15 @@ impl ConnectionManagerRequester {
         reply_rx
             .await
             .map_err(|_| ConnectionManagerError::ActorRequestCanceled)?
+    }
+
+    /// Attempt to connect to a remote peer
+    pub async fn wait_until_listening(&mut self) -> Result<Multiaddr, ConnectionManagerError> {
+        let (reply_tx, reply_rx) = oneshot::channel();
+        self.sender
+            .send(ConnectionManagerRequest::NotifyListening(reply_tx))
+            .await
+            .map_err(|_| ConnectionManagerError::SendToActorFailed)?;
+        reply_rx.await.map_err(|_| ConnectionManagerError::ActorRequestCanceled)
     }
 }

--- a/comms/src/connection_manager/tests/manager.rs
+++ b/comms/src/connection_manager/tests/manager.rs
@@ -1,0 +1,179 @@
+// Copyright 2020, The Tari Project
+//
+// Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+// following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+// disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+// following disclaimer in the documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+// products derived from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+// INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+// WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+// USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+use crate::{
+    backoff::ConstantBackoff,
+    connection_manager::{
+        error::ConnectionManagerError,
+        manager::ConnectionManagerEvent,
+        next::{ConnectionManager, ConnectionManagerRequester},
+    },
+    noise::NoiseConfig,
+    peer_manager::{NodeId, Peer, PeerFeatures, PeerFlags, PeerManagerError},
+    protocol::ProtocolNotifier,
+    test_utils::{
+        node_identity::{build_node_identity, ordered_node_identities},
+        test_node::{build_connection_manager, build_peer_manager, TestNodeConfig},
+    },
+    transports::MemoryTransport,
+};
+use futures::{channel::mpsc, future};
+use std::{sync::Arc, time::Duration};
+use tari_shutdown::Shutdown;
+use tari_test_utils::{collect_stream, unpack_enum};
+use tokio::{runtime::Handle, sync::broadcast};
+use tokio_macros as r#async;
+
+#[r#async::test_basic]
+async fn connect_to_nonexistent_peer() {
+    let rt_handle = Handle::current();
+    let node_identity = build_node_identity(PeerFeatures::COMMUNICATION_NODE);
+    let noise_config = NoiseConfig::new(node_identity.clone());
+    let (request_tx, request_rx) = mpsc::channel(1);
+    let (event_tx, _) = broadcast::channel(1);
+    let mut requester = ConnectionManagerRequester::new(request_tx, event_tx.clone());
+    let mut shutdown = Shutdown::new();
+
+    let peer_manager = build_peer_manager();
+
+    let connection_manager = ConnectionManager::new(
+        Default::default(),
+        rt_handle.clone(),
+        MemoryTransport,
+        noise_config,
+        Arc::new(ConstantBackoff::new(Duration::from_secs(1))),
+        request_rx,
+        node_identity,
+        peer_manager.into(),
+        ProtocolNotifier::new(),
+        event_tx,
+        shutdown.to_signal(),
+    );
+
+    rt_handle.spawn(connection_manager.run());
+
+    let result = requester.dial_peer(NodeId::default()).await;
+    unpack_enum!(Result::Err(err) = result);
+    match err {
+        ConnectionManagerError::PeerManagerError(PeerManagerError::PeerNotFoundError) => {},
+        _ => panic!(
+            "Unexpected error. Expected \
+             `ConnectionManagerError::PeerManagerError(PeerManagerError::PeerNotFoundError)`"
+        ),
+    }
+
+    shutdown.trigger().unwrap();
+}
+
+#[r#async::test_basic]
+async fn simultaneous_dial_events() {
+    let rt_handle = Handle::current();
+    let mut shutdown = Shutdown::new();
+
+    let node_identities = ordered_node_identities(2);
+
+    // Setup connection manager 1
+    let peer_manager1 = build_peer_manager();
+    let mut conn_man1 = build_connection_manager(
+        rt_handle.clone(),
+        TestNodeConfig {
+            node_identity: node_identities[0].clone(),
+            ..Default::default()
+        },
+        peer_manager1.clone(),
+        shutdown.to_signal(),
+    );
+
+    let subscription1 = conn_man1.subscribe_events();
+    let public_address1 = conn_man1.wait_until_listening().await.unwrap();
+
+    let peer_manager2 = build_peer_manager();
+    let mut conn_man2 = build_connection_manager(
+        rt_handle,
+        TestNodeConfig {
+            node_identity: node_identities[1].clone(),
+            ..Default::default()
+        },
+        peer_manager2.clone(),
+        shutdown.to_signal(),
+    );
+    let subscription2 = conn_man2.subscribe_events();
+    let public_address2 = conn_man2.wait_until_listening().await.unwrap();
+
+    peer_manager1
+        .add_peer(Peer::new(
+            node_identities[1].public_key().clone(),
+            node_identities[1].node_id().clone(),
+            vec![public_address2].into(),
+            PeerFlags::empty(),
+            PeerFeatures::COMMUNICATION_CLIENT,
+        ))
+        .unwrap();
+
+    peer_manager2
+        .add_peer(Peer::new(
+            node_identities[0].public_key().clone(),
+            node_identities[0].node_id().clone(),
+            vec![public_address1].into(),
+            PeerFlags::empty(),
+            PeerFeatures::COMMUNICATION_CLIENT,
+        ))
+        .unwrap();
+
+    // Dial at the same time
+    let (result1, result2) = future::join(
+        conn_man1.dial_peer(node_identities[1].node_id().clone()),
+        conn_man2.dial_peer(node_identities[0].node_id().clone()),
+    )
+    .await;
+
+    result1.unwrap();
+    result2.unwrap();
+
+    shutdown.trigger().unwrap();
+    drop(conn_man1);
+    drop(conn_man2);
+
+    let events1 = collect_stream!(subscription1, timeout = Duration::from_secs(5))
+        .into_iter()
+        .map(Result::unwrap)
+        .collect::<Vec<_>>();
+
+    let events2 = collect_stream!(subscription2, timeout = Duration::from_secs(5))
+        .into_iter()
+        .map(Result::unwrap)
+        .collect::<Vec<_>>();
+
+    let count_disconnected_events = |events: Vec<Arc<ConnectionManagerEvent>>| {
+        events
+            .iter()
+            .filter(|event| match &***event {
+                ConnectionManagerEvent::PeerDisconnected(_) => true,
+                _ => false,
+            })
+            .count()
+    };
+
+    // Check for only one disconnect event
+    assert_eq!(count_disconnected_events(events1), 1);
+    assert_eq!(count_disconnected_events(events2), 1);
+}

--- a/comms/src/connection_manager/tests/mod.rs
+++ b/comms/src/connection_manager/tests/mod.rs
@@ -21,3 +21,4 @@
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 mod listener_dialer;
+mod manager;

--- a/comms/src/outbound_message_service/service.rs
+++ b/comms/src/outbound_message_service/service.rs
@@ -641,7 +641,7 @@ mod test {
         assert_send_msg(msg, b"E");
 
         // Connection should be reused, so connection manager should not receive another request to connect.
-        let requests = collect_stream!(rt, conn_man_rx, take = 2, timeout = Duration::from_secs(3));
+        let requests = rt.block_on(async { collect_stream!(conn_man_rx, take = 2, timeout = Duration::from_secs(3)) });
         assert!(requests.iter().all(|req| {
             match req {
                 ConnectionManagerRequest::DialPeer(_) => false,

--- a/comms/src/peer_manager/node_id.rs
+++ b/comms/src/peer_manager/node_id.rs
@@ -187,6 +187,12 @@ impl PartialOrd<NodeId> for NodeId {
     }
 }
 
+impl Ord for NodeId {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.0.cmp(&other.0)
+    }
+}
+
 impl TryFrom<&[u8]> for NodeId {
     type Error = NodeIdError;
 

--- a/comms/src/peer_manager/node_identity.rs
+++ b/comms/src/peer_manager/node_identity.rs
@@ -86,7 +86,7 @@ impl NodeIdentity {
     /// Generates a new random NodeIdentity for CommsPublicKey
     pub fn random<R>(
         rng: &mut R,
-        control_service_address: Multiaddr,
+        public_address: Multiaddr,
         features: PeerFeatures,
     ) -> Result<Self, NodeIdentityError>
     where
@@ -101,7 +101,7 @@ impl NodeIdentity {
             public_key,
             features,
             secret_key,
-            public_address: RwLock::new(control_service_address),
+            public_address: RwLock::new(public_address),
         })
     }
 

--- a/comms/src/test_utils/node_identity.rs
+++ b/comms/src/test_utils/node_identity.rs
@@ -31,3 +31,11 @@ pub fn build_node_identity(features: PeerFeatures) -> Arc<NodeIdentity> {
     let public_addr = get_next_local_address().parse().unwrap();
     Arc::new(NodeIdentity::random(&mut OsRng, public_addr, features).unwrap())
 }
+
+pub fn ordered_node_identities(n: usize) -> Vec<Arc<NodeIdentity>> {
+    let mut ids = (0..n)
+        .map(|_| build_node_identity(PeerFeatures::default()))
+        .collect::<Vec<_>>();
+    ids.sort_unstable_by(|a, b| a.node_id().cmp(b.node_id()));
+    ids
+}

--- a/comms/src/test_utils/test_node.rs
+++ b/comms/src/test_utils/test_node.rs
@@ -22,39 +22,44 @@
 
 use crate::{
     backoff::ConstantBackoff,
-    connection_manager::next::{ConnectionManager, ConnectionManagerRequester},
-    multiaddr::Multiaddr,
+    connection_manager::next::{ConnectionManager, ConnectionManagerConfig, ConnectionManagerRequester},
     noise::NoiseConfig,
     peer_manager::{NodeIdentity, PeerFeatures, PeerManager},
     protocol::ProtocolNotifier,
-    transports::TcpTransport,
+    transports::MemoryTransport,
 };
 use futures::channel::mpsc;
+use rand::rngs::OsRng;
 use std::{sync::Arc, time::Duration};
 use tari_shutdown::ShutdownSignal;
 use tari_storage::HashmapDatabase;
-use tokio::runtime::Runtime;
-use rand::rngs::OsRng;
+use tokio::{runtime, sync::broadcast};
 
 #[derive(Clone, Debug)]
 pub struct TestNodeConfig {
-    listen_address: Multiaddr,
-    transport: TcpTransport,
-    dial_backoff_duration: Duration,
-    node_identity: Arc<NodeIdentity>,
+    pub transport: MemoryTransport,
+    pub dial_backoff_duration: Duration,
+    pub connection_manager_config: ConnectionManagerConfig,
+    pub node_identity: Arc<NodeIdentity>,
 }
 
 impl Default for TestNodeConfig {
     fn default() -> Self {
-        let node_identity = Arc::new(NodeIdentity::random(
-            &mut OsRng,
-            "/ip4/127.0.0.1/tcp/0".parse().unwrap(),
-            PeerFeatures::COMMUNICATION_NODE
-        ).unwrap());
+        let node_identity = Arc::new(
+            NodeIdentity::random(
+                &mut OsRng,
+                "/memory/0".parse().unwrap(),
+                PeerFeatures::COMMUNICATION_NODE,
+            )
+            .unwrap(),
+        );
 
         Self {
-            listen_address: "/ip4/127.0.0.1/tcp/0".parse().unwrap(),
-            transport: TcpTransport::default(),
+            transport: MemoryTransport,
+            connection_manager_config: ConnectionManagerConfig {
+                listener_address: "/memory/0".parse().unwrap(),
+                ..Default::default()
+            },
             dial_backoff_duration: Duration::from_millis(200),
             node_identity,
         }
@@ -62,33 +67,34 @@ impl Default for TestNodeConfig {
 }
 
 pub fn build_connection_manager(
-    runtime: Runtime,
+    executor: runtime::Handle,
     config: TestNodeConfig,
+    peer_manager: Arc<PeerManager>,
     shutdown: ShutdownSignal,
 ) -> ConnectionManagerRequester
 {
     // TODO: Once we have `comms::Builder@next` we can construct a whole "comms node" here for testing
     let noise_config = NoiseConfig::new(config.node_identity.clone());
-    let transport = TcpTransport::default();
     let (request_tx, request_rx) = mpsc::channel(10);
-    let requester = ConnectionManagerRequester::new(request_tx);
+    let (event_tx, _) = broadcast::channel(100);
 
-    let peer_manager = build_peer_manager();
+    let requester = ConnectionManagerRequester::new(request_tx, event_tx.clone());
 
     let connection_manager = ConnectionManager::new(
-        Default::default(),
-        runtime.handle().clone(),
-        transport,
+        config.connection_manager_config,
+        executor.clone(),
+        config.transport,
         noise_config,
         Arc::new(ConstantBackoff::new(config.dial_backoff_duration)),
         request_rx,
-        config.node_identity.clone(),
+        config.node_identity,
         peer_manager.into(),
         ProtocolNotifier::new(),
+        event_tx,
         shutdown,
     );
 
-    runtime.spawn(connection_manager.run());
+    executor.spawn(connection_manager.run());
 
     requester
 }

--- a/comms/tests/outbound_message_service/service.rs
+++ b/comms/tests/outbound_message_service/service.rs
@@ -323,7 +323,7 @@ fn test_outbound_message_pool_fail_and_retry() {
 
     shutdown.trigger().unwrap();
 
-    let events = collect_stream!(rt, event_subscription, timeout = Duration::from_secs(10));
+    let events = rt.block_on(async { collect_stream!(event_subscription, timeout = Duration::from_secs(10)) });
 
     // Check that the PeerDialSuccess event was emitted
     let dialed_node_id = events


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
If peers dial each other at the same time there must be a way for both
peers to deterministically choose which connection to keep and which to
disconnect.

This PR adds code to handle this situation by using the NodeID and
ConnectionDirection to enable both sides to agree on a connection to
close.

Extra: Since async tests are moving towards to running in an async context (through `#[tokio_macros::test]` - tests should probably change to use this) it no longer makes sense to use `tari_test_utils::runtime` and `Runtime::block_on` everywhere.  I changed `tari_test_utils::collect_stream!` to rather work in an async context. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #1153 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested by having two connection managers simultaneously dial each other and checking the events produced. Since the tie breaking is transparent to the outside api, it is not tested directly. More work needs to happen to make this easier to unit test.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [x] Breaking change (fix or feature that would cause existing functionality to change)
* [x] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [x] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch
* [x] I ran `cargo-fmt --all` before pushing
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
