### PR TITLE
Miner wallet integration

### DIFF
--- a/applications/tari_base_node/src/builder.rs
+++ b/applications/tari_base_node/src/builder.rs
@@ -21,6 +21,10 @@
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 use crate::miner;
+use futures::channel::{
+    mpsc,
+    mpsc::{Receiver, Sender},
+};
 use log::*;
 use rand::rngs::OsRng;
 use std::{
@@ -56,6 +60,7 @@ use tari_core::{
     proof_of_work::DiffAdjManager,
     transactions::{
         crypto::keys::SecretKey as SK,
+        transaction::UnblindedOutput,
         types::{CryptoFactories, HashDigest, PrivateKey, PublicKey},
     },
     validation::{
@@ -141,6 +146,13 @@ impl MinerType {
             }
         }
         .await;
+    }
+
+    pub fn get_utxo_receiver_channel(&mut self) -> Receiver<UnblindedOutput> {
+        match self {
+            MinerType::LMDB(n) => n.get_utxo_receiver_channel(),
+            MinerType::Memory(n) => n.get_utxo_receiver_channel(),
+        }
     }
 }
 

--- a/base_layer/core/Cargo.toml
+++ b/base_layer/core/Cargo.toml
@@ -49,7 +49,7 @@ log = "0.4"
 blake2 = "^0.8.0"
 bigint = "^4.4.1"
 ttl_cache = "0.5.1"
-tokio = { version="^0.2" }
+tokio = { version="^0.2", features = ["blocking"] }
 futures = {version = "^0.3.1", features = ["async-await"] }
 lmdb-zero = "0.4.4"
 tower-service = { version="0.3.0-alpha.2" }


### PR DESCRIPTION
## Description
Miner wallet integration.
Cleanup the miner code and moved mining to a blocking thread.

## Motivation and Context
The miner needs to be able to submit a utxo to the wallet. The miner cannot contain a wallet as this will cause a cycle dependancy. The base node will act as a mediator between the two. The miner gives a channel out to the base node which will sit and listen for an unblindedUTXO which it will give to wallet

The miner code has also been moved to a blocking thread as spawning a task is not the most efficient use of blocking task. The mining task will wait for the blocking thread to return and does not use a thread anymore with channels to communicate internally. 

## Types of changes
* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [x] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
* [x] I'm merging against the `development` branch
* [x] I ran `cargo-fmt --all` before pushing
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
