### PR TITLE
sw cut through on blocks

### DIFF
--- a/base_layer/core/src/base_node/comms_interface/inbound_handlers.rs
+++ b/base_layer/core/src/base_node/comms_interface/inbound_handlers.rs
@@ -163,7 +163,6 @@ where T: BlockchainBackend + 'static
                         .with_transactions(transactions)
                         .build(),
                 );
-
                 Ok(NodeCommsResponse::NewBlockTemplate(block_template))
             },
             NodeCommsRequest::GetNewBlock(block_template) => {

--- a/base_layer/core/src/blocks/block.rs
+++ b/base_layer/core/src/blocks/block.rs
@@ -58,6 +58,8 @@ pub enum BlockValidationError {
     InvalidCoinbase,
     // Mismatched MMR roots
     MismatchedMmrRoots,
+    // The block contains transactions that should have been cut through.
+    NoCutThrough,
 }
 
 /// A Tari block. Blocks are linked together into a blockchain.
@@ -226,6 +228,7 @@ impl BlockBuilder {
             header: self.header,
             body: AggregateBody::new(self.inputs, self.outputs, self.kernels),
         };
+        block.body.do_cut_through();
         block.body.sort();
         block
     }


### PR DESCRIPTION
## Description
Did cut-through  on block
did cleanup of warnings of unused inputs

## Motivation and Context
RFC states that we need to implement cut-through on blocks. This implements cut-through.
Cut through still needs to be done on the mempool, see issue #1277 

## How Has This Been Tested?
Added unit tests

## Types of changes
* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [x] New Tests
* [ ] Documentation

## Checklist:
* [x] I'm merging against the `development` branch
* [x] I ran `cargo-fmt --all` before pushing
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
