### PR TITLE
Implement wallet base node monitoring for broadcast transactions

### DIFF
--- a/base_layer/core/Cargo.toml
+++ b/base_layer/core/Cargo.toml
@@ -10,10 +10,11 @@ version = "0.0.5"
 edition = "2018"
 
 [features]
-default = ["croaring", "tari_mmr", "transactions", "base_node", "mempool_proto", "monero", "randomx-rs"]
+default = ["croaring", "tari_mmr", "transactions", "base_node", "mempool_proto", "monero", "randomx-rs", "base_node_proto"]
 transactions = []
 mempool_proto = []
 base_node = []
+base_node_proto = []
 
 [dependencies]
 tari_comms = { version = "^0.0", path = "../../comms"}

--- a/base_layer/core/src/base_node/mod.rs
+++ b/base_layer/core/src/base_node/mod.rs
@@ -32,17 +32,25 @@
 //! More details about the implementation are presented in
 //! [RFC-0111](https://rfc.tari.com/RFC-0111_BaseNodeArchitecture.html).
 
-mod backoff;
-mod base_node;
-mod chain_metadata_service;
-mod proto;
+cfg_if! {
+    if #[cfg(feature = "base_node")] {
+        mod backoff;
+        mod base_node;
+        mod chain_metadata_service;
 
-pub mod comms_interface;
-pub mod consts;
-pub mod service;
-pub mod states;
+        pub mod comms_interface;
+        pub mod consts;
+        pub mod service;
+        pub mod states;
+        // Public re-exports
+        pub use backoff::BackOff;
+        pub use base_node::{BaseNodeStateMachine, BaseNodeStateMachineConfig};
+        pub use comms_interface::{LocalNodeCommsInterface, OutboundNodeCommsInterface};
+    }
+}
 
-// Public re-exports
-pub use backoff::BackOff;
-pub use base_node::{BaseNodeStateMachine, BaseNodeStateMachineConfig};
-pub use comms_interface::{LocalNodeCommsInterface, OutboundNodeCommsInterface};
+cfg_if! {
+    if #[cfg(any(feature = "base_node", feature = "base_node_proto"))] {
+        pub mod proto;
+    }
+}

--- a/base_layer/core/src/base_node/proto/mod.rs
+++ b/base_layer/core/src/base_node/proto/mod.rs
@@ -23,17 +23,19 @@
 pub mod base_node {
     tari_utilities::include_proto_package!("tari.base_node");
 }
-
 use crate::proto::core;
 // Required for `super::types` used in generated files
 use crate::transactions::proto::types;
 
-pub mod chain_metadata;
-pub mod mmr_state_request;
-pub mod mmr_tree;
-pub mod mutable_mmr_leaf_nodes;
-pub mod mutable_mmr_state;
-pub mod request;
-pub mod response;
-
-pub use base_node::{BaseNodeServiceRequest, BaseNodeServiceResponse, ChainMetadata};
+cfg_if! {
+    if #[cfg(feature = "base_node")] {
+        pub mod chain_metadata;
+        pub mod mmr_state_request;
+        pub mod mmr_tree;
+        pub mod mutable_mmr_leaf_nodes;
+        pub mod mutable_mmr_state;
+        pub mod request;
+        pub mod response;
+        pub use base_node::{BaseNodeServiceRequest, BaseNodeServiceResponse, ChainMetadata};
+    }
+}

--- a/base_layer/core/src/lib.rs
+++ b/base_layer/core/src/lib.rs
@@ -35,15 +35,20 @@ extern crate cfg_if;
 
 cfg_if! {
     if #[cfg(feature = "base_node")] {
-        pub mod base_node;
         pub mod blocks;
         pub mod chain_storage;
         pub mod consensus;
         pub mod helpers;
         pub mod mining;
         pub mod proof_of_work;
-        pub mod proto;
         pub mod validation;
+    }
+}
+
+cfg_if! {
+    if #[cfg(any(feature = "base_node", feature = "base_node_proto"))] {
+        pub mod base_node;
+        pub mod proto;
     }
 }
 

--- a/base_layer/core/src/proto/mod.rs
+++ b/base_layer/core/src/proto/mod.rs
@@ -27,5 +27,9 @@ pub mod core {
     tari_utilities::include_proto_package!("tari.core");
 }
 
-mod block;
-pub mod utils;
+cfg_if! {
+    if #[cfg(feature = "base_node")] {
+        mod block;
+        pub mod utils;
+    }
+}

--- a/base_layer/core/src/transactions/aggregated_body.rs
+++ b/base_layer/core/src/transactions/aggregated_body.rs
@@ -28,7 +28,6 @@ use crate::transactions::{
 use serde::{Deserialize, Serialize};
 use std::fmt::{Display, Error, Formatter};
 use tari_crypto::{commitment::HomomorphicCommitmentFactory, ristretto::pedersen::PedersenCommitment};
-use tari_utilities::hash::Hashable;
 
 /// The components of the block or transaction. The same struct can be used for either, since in Mimblewimble,
 /// cut-through means that blocks and transactions have the same structure.

--- a/base_layer/core/tests/mempool.rs
+++ b/base_layer/core/tests/mempool.rs
@@ -285,7 +285,7 @@ fn test_retrieve() {
     let weight = tx[3].calculate_weight() + tx2[1].calculate_weight();
     let retrieved_txs = mempool.retrieve(weight).unwrap();
     let stats = mempool.stats().unwrap();
-    println!("{:?}", stats);
+
     assert_eq!(stats.unconfirmed_txs, 4);
     assert_eq!(stats.timelocked_txs, 1);
     assert_eq!(stats.published_txs, 5);

--- a/base_layer/wallet/Cargo.toml
+++ b/base_layer/wallet/Cargo.toml
@@ -50,4 +50,4 @@ prost = "0.6.1"
 path = "../../base_layer/core"
 version = "^0.0"
 default-features = false
-features = ["transactions", "mempool_proto"]
+features = ["transactions", "mempool_proto", "base_node_proto"]

--- a/base_layer/wallet/src/output_manager_service/handle.rs
+++ b/base_layer/wallet/src/output_manager_service/handle.rs
@@ -42,8 +42,7 @@ pub enum OutputManagerRequest {
     AddOutput(UnblindedOutput),
     GetRecipientKey((u64, MicroTari)),
     GetCoinbaseKey((u64, MicroTari, u64)),
-    ConfirmReceivedOutput((u64, TransactionOutput)),
-    ConfirmSentTransaction((u64, Vec<TransactionInput>, Vec<TransactionOutput>)),
+    ConfirmTransaction((u64, Vec<TransactionInput>, Vec<TransactionOutput>)),
     PrepareToSendTransaction((MicroTari, MicroTari, Option<u64>, String)),
     CancelTransaction(u64),
     TimeoutTransactions(Duration),
@@ -149,23 +148,7 @@ impl OutputManagerHandle {
         }
     }
 
-    pub async fn confirm_received_output(
-        &mut self,
-        tx_id: u64,
-        output: TransactionOutput,
-    ) -> Result<(), OutputManagerError>
-    {
-        match self
-            .handle
-            .call(OutputManagerRequest::ConfirmReceivedOutput((tx_id, output)))
-            .await??
-        {
-            OutputManagerResponse::OutputConfirmed => Ok(()),
-            _ => Err(OutputManagerError::UnexpectedApiResponse),
-        }
-    }
-
-    pub async fn confirm_sent_transaction(
+    pub async fn confirm_transaction(
         &mut self,
         tx_id: u64,
         spent_outputs: Vec<TransactionInput>,
@@ -174,7 +157,7 @@ impl OutputManagerHandle {
     {
         match self
             .handle
-            .call(OutputManagerRequest::ConfirmSentTransaction((
+            .call(OutputManagerRequest::ConfirmTransaction((
                 tx_id,
                 spent_outputs,
                 received_outputs,

--- a/base_layer/wallet/src/transaction_service/config.rs
+++ b/base_layer/wallet/src/transaction_service/config.rs
@@ -23,12 +23,14 @@
 #[derive(Clone)]
 pub struct TransactionServiceConfig {
     pub mempool_broadcast_timeout_in_secs: u64,
+    pub base_node_mined_timeout_in_secs: u64,
 }
 
 impl Default for TransactionServiceConfig {
     fn default() -> Self {
         Self {
             mempool_broadcast_timeout_in_secs: 30,
+            base_node_mined_timeout_in_secs: 30,
         }
     }
 }

--- a/base_layer/wallet/src/transaction_service/error.rs
+++ b/base_layer/wallet/src/transaction_service/error.rs
@@ -82,6 +82,8 @@ pub enum TransactionServiceError {
     #[error(msg_embedded, no_from, non_std)]
     TestHarnessError(String),
     TransactionError(TransactionError),
+    #[error(msg_embedded, no_from, non_std)]
+    ConversionError(String),
 }
 
 #[derive(Debug, Error)]

--- a/base_layer/wallet/src/transaction_service/handle.rs
+++ b/base_layer/wallet/src/transaction_service/handle.rs
@@ -94,6 +94,7 @@ pub enum TransactionEvent {
     TransactionMined(TxId),
     TransactionSendDiscoverySuccess(TxId),
     TransactionSendDiscoveryFailure(TxId),
+    TransactionMinedRequestTimedOut(TxId),
     Error(String),
 }
 

--- a/base_layer/wallet/src/transaction_service/storage/database.rs
+++ b/base_layer/wallet/src/transaction_service/storage/database.rs
@@ -78,7 +78,6 @@ pub trait TransactionBackend: Send + Sync {
     /// Indicated that a completed transaction has been broadcast to the mempools
     fn broadcast_completed_transaction(&self, tx_id: TxId) -> Result<(), TransactionStorageError>;
     /// Indicated that a completed transaction has been detected as mined on the base layer
-    #[cfg(feature = "test_harness")]
     fn mine_completed_transaction(&self, tx_id: TxId) -> Result<(), TransactionStorageError>;
     /// Update a completed transactions timestamp for use in test data generation
     #[cfg(feature = "test_harness")]
@@ -499,7 +498,6 @@ where T: TransactionBackend + 'static
     }
 
     /// Indicated that the specified completed transaction has been detected as mined on the base layer
-    #[cfg(feature = "test_harness")]
     pub async fn mine_completed_transaction(&mut self, tx_id: TxId) -> Result<(), TransactionStorageError> {
         let db_clone = self.db.clone();
 

--- a/base_layer/wallet/src/transaction_service/storage/memory_db.rs
+++ b/base_layer/wallet/src/transaction_service/storage/memory_db.rs
@@ -296,7 +296,6 @@ impl TransactionBackend for TransactionMemoryDatabase {
         Ok(())
     }
 
-    #[cfg(feature = "test_harness")]
     fn mine_completed_transaction(&self, tx_id: TxId) -> Result<(), TransactionStorageError> {
         let mut db = acquire_write_lock!(self.db);
 

--- a/base_layer/wallet/src/transaction_service/storage/sqlite_db.rs
+++ b/base_layer/wallet/src/transaction_service/storage/sqlite_db.rs
@@ -428,7 +428,6 @@ impl TransactionBackend for TransactionServiceSqliteDatabase {
         Ok(())
     }
 
-    #[cfg(feature = "test_harness")]
     fn mine_completed_transaction(&self, tx_id: u64) -> Result<(), TransactionStorageError> {
         let conn = self
             .database_connection_pool

--- a/base_layer/wallet/tests/output_manager_service/service.rs
+++ b/base_layer/wallet/tests/output_manager_service/service.rs
@@ -127,7 +127,7 @@ fn sending_transaction_and_confirmation<T: Clone + OutputManagerBackend + 'stati
     let tx = stp.get_transaction().unwrap();
 
     runtime
-        .block_on(oms.confirm_sent_transaction(sender_tx_id, tx.body.inputs().clone(), tx.body.outputs().clone()))
+        .block_on(oms.confirm_transaction(sender_tx_id, tx.body.inputs().clone(), tx.body.outputs().clone()))
         .unwrap();
 
     assert_eq!(runtime.block_on(oms.get_pending_transactions()).unwrap().len(), 0);
@@ -251,7 +251,7 @@ fn send_no_change<T: OutputManagerBackend + 'static>(backend: T) {
     let tx = stp.get_transaction().unwrap();
 
     runtime
-        .block_on(oms.confirm_sent_transaction(sender_tx_id, tx.body.inputs().clone(), tx.body.outputs().clone()))
+        .block_on(oms.confirm_transaction(sender_tx_id, tx.body.inputs().clone(), tx.body.outputs().clone()))
         .unwrap();
 
     assert_eq!(runtime.block_on(oms.get_pending_transactions()).unwrap().len(), 0);
@@ -339,7 +339,9 @@ fn receiving_and_confirmation<T: OutputManagerBackend + 'static>(backend: T) {
         RangeProof::from_bytes(&rr).unwrap(),
     );
 
-    runtime.block_on(oms.confirm_received_output(1, output)).unwrap();
+    runtime
+        .block_on(oms.confirm_transaction(1, vec![], vec![output]))
+        .unwrap();
 
     assert_eq!(runtime.block_on(oms.get_pending_transactions()).unwrap().len(), 0);
     assert_eq!(runtime.block_on(oms.get_unspent_outputs()).unwrap().len(), 1);
@@ -528,7 +530,9 @@ fn test_confirming_received_output<T: OutputManagerBackend + 'static>(backend: T
         commitment,
         RangeProof::from_bytes(&rr).unwrap(),
     );
-    runtime.block_on(oms.confirm_received_output(1, output)).unwrap();
+    runtime
+        .block_on(oms.confirm_transaction(1, vec![], vec![output]))
+        .unwrap();
     assert_eq!(runtime.block_on(oms.get_balance()).unwrap().available_balance, value);
 }
 


### PR DESCRIPTION
## Description

This PR implements base node monitoring for the Wallet to periodically ask a base_node if a pending CompletedTransaction has been mined yet.

When a Completed transaction is detected as broadcast to the mempool the Wallet will start querying the base_node for the outputs that have been mined.

When the wallet starts up it will go through stored completed transactions and check which have the broadcast state and start monitoring them for being mined

## Motivation and Context
Closes https://github.com/tari-project/tari/issues/640
Closes https://github.com/tari-project/tari/issues/888
Closes https://github.com/tari-project/tari/issues/887

## How Has This Been Tested?
Tests provided

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [x] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch
* [x] I ran `cargo-fmt --all` before pushing
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
