### PR TITLE
Implement `import_utxo(…)` for wallet

### DIFF
--- a/base_layer/wallet/src/contacts_service/storage/sqlite_db.rs
+++ b/base_layer/wallet/src/contacts_service/storage/sqlite_db.rs
@@ -62,6 +62,7 @@ impl ContactsServiceSqliteDatabase {
         let pool = diesel::r2d2::Pool::builder()
             .connection_timeout(Duration::from_millis(DATABASE_CONNECTION_TIMEOUT_MS))
             .idle_timeout(Some(Duration::from_millis(DATABASE_CONNECTION_TIMEOUT_MS)))
+            .max_size(1)
             .build(manager)
             .map_err(|_| ContactsServiceStorageError::R2d2Error)?;
 

--- a/base_layer/wallet/src/output_manager_service/storage/sqlite_db.rs
+++ b/base_layer/wallet/src/output_manager_service/storage/sqlite_db.rs
@@ -77,6 +77,7 @@ impl OutputManagerSqliteDatabase {
         let pool = diesel::r2d2::Pool::builder()
             .connection_timeout(Duration::from_millis(DATABASE_CONNECTION_TIMEOUT_MS))
             .idle_timeout(Some(Duration::from_millis(DATABASE_CONNECTION_TIMEOUT_MS)))
+            .max_size(1)
             .build(manager)
             .map_err(|_| OutputManagerStorageError::R2d2Error)?;
 

--- a/base_layer/wallet/src/storage/database.rs
+++ b/base_layer/wallet/src/storage/database.rs
@@ -28,7 +28,7 @@ use std::{
 };
 use tari_comms::{peer_manager::Peer, types::CommsPublicKey};
 
-const LOG_TARGET: &'static str = "wallet::contacts_service::database";
+const LOG_TARGET: &'static str = "wallet::database";
 
 /// This trait defines the functionality that a database backend need to provide for the Contacts Service
 pub trait WalletBackend: Send + Sync {

--- a/base_layer/wallet/src/storage/sqlite_db.rs
+++ b/base_layer/wallet/src/storage/sqlite_db.rs
@@ -60,6 +60,7 @@ impl WalletSqliteDatabase {
         let pool = diesel::r2d2::Pool::builder()
             .connection_timeout(Duration::from_millis(DATABASE_CONNECTION_TIMEOUT_MS))
             .idle_timeout(Some(Duration::from_millis(DATABASE_CONNECTION_TIMEOUT_MS)))
+            .max_size(1)
             .build(manager)
             .map_err(|_| WalletStorageError::R2d2Error)?;
 

--- a/base_layer/wallet/src/text_message_service/service.rs
+++ b/base_layer/wallet/src/text_message_service/service.rs
@@ -181,6 +181,7 @@ where
         let pool = diesel::r2d2::Pool::builder()
             .connection_timeout(Duration::from_millis(2000))
             .idle_timeout(Some(Duration::from_millis(2000)))
+            .max_size(1)
             .build(manager)
             .map_err(|_| TextMessageError::R2d2Error)?;
         Ok(pool)

--- a/base_layer/wallet/src/transaction_service/handle.rs
+++ b/base_layer/wallet/src/transaction_service/handle.rs
@@ -47,6 +47,7 @@ pub enum TransactionServiceRequest {
     RequestCoinbaseSpendingKey((MicroTari, u64)),
     CompleteCoinbaseTransaction((TxId, Transaction)),
     CancelPendingCoinbaseTransaction(TxId),
+    ImportUtxo(MicroTari, CommsPublicKey),
     #[cfg(feature = "test_harness")]
     CompletePendingOutboundTransaction(CompletedTransaction),
     #[cfg(feature = "test_harness")]
@@ -70,6 +71,7 @@ pub enum TransactionServiceResponse {
     CompletedCoinbaseTransactionReceived,
     CoinbaseTransactionCancelled,
     BaseNodePublicKeySet,
+    UtxoImported(TxId),
     #[cfg(feature = "test_harness")]
     CompletedPendingTransaction,
     #[cfg(feature = "test_harness")]
@@ -241,6 +243,22 @@ impl TransactionServiceHandle {
             .await??
         {
             TransactionServiceResponse::BaseNodePublicKeySet => Ok(()),
+            _ => Err(TransactionServiceError::UnexpectedApiResponse),
+        }
+    }
+
+    pub async fn import_utxo(
+        &mut self,
+        amount: MicroTari,
+        source_public_key: CommsPublicKey,
+    ) -> Result<TxId, TransactionServiceError>
+    {
+        match self
+            .handle
+            .call(TransactionServiceRequest::ImportUtxo(amount, source_public_key))
+            .await??
+        {
+            TransactionServiceResponse::UtxoImported(tx_id) => Ok(tx_id),
             _ => Err(TransactionServiceError::UnexpectedApiResponse),
         }
     }

--- a/base_layer/wallet/src/transaction_service/storage/sqlite_db.rs
+++ b/base_layer/wallet/src/transaction_service/storage/sqlite_db.rs
@@ -79,6 +79,7 @@ impl TransactionServiceSqliteDatabase {
         let pool = diesel::r2d2::Pool::builder()
             .connection_timeout(Duration::from_millis(DATABASE_CONNECTION_TIMEOUT_MS))
             .idle_timeout(Some(Duration::from_millis(DATABASE_CONNECTION_TIMEOUT_MS)))
+            .max_size(1)
             .build(manager)
             .map_err(|_| TransactionStorageError::R2d2Error)?;
 

--- a/base_layer/wallet/tests/transaction_service/service.rs
+++ b/base_layer/wallet/tests/transaction_service/service.rs
@@ -385,30 +385,28 @@ fn manage_single_transaction<T: TransactionBackend + Clone + 'static>(
 
 #[test]
 fn manage_single_transaction_memory_db() {
-    with_temp_dir(|dir_path| {
-        manage_single_transaction(
-            TransactionMemoryDatabase::new(),
-            TransactionMemoryDatabase::new(),
-            2,
-            dir_path.to_str().unwrap().to_string(),
-        );
-    });
+    let temp_dir = TempDir::new(random_string(8).as_str()).unwrap();
+    manage_single_transaction(
+        TransactionMemoryDatabase::new(),
+        TransactionMemoryDatabase::new(),
+        2,
+        temp_dir.path().to_str().unwrap().to_string(),
+    );
 }
 
 #[test]
 fn manage_single_transaction_sqlite_db() {
-    with_temp_dir(|dir_path| {
-        let alice_db_name = format!("{}.sqlite3", random_string(8).as_str());
-        let alice_db_path = format!("{}/{}", dir_path.to_str().unwrap(), alice_db_name);
-        let bob_db_name = format!("{}.sqlite3", random_string(8).as_str());
-        let bob_db_path = format!("{}/{}", dir_path.to_str().unwrap(), bob_db_name);
-        manage_single_transaction(
-            TransactionServiceSqliteDatabase::new(alice_db_path).unwrap(),
-            TransactionServiceSqliteDatabase::new(bob_db_path).unwrap(),
-            1,
-            dir_path.to_str().unwrap().to_string(),
-        );
-    });
+    let temp_dir = TempDir::new(random_string(8).as_str()).unwrap();
+    let alice_db_name = format!("{}.sqlite3", random_string(8).as_str());
+    let alice_db_path = format!("{}/{}", temp_dir.path().to_str().unwrap(), alice_db_name);
+    let bob_db_name = format!("{}.sqlite3", random_string(8).as_str());
+    let bob_db_path = format!("{}/{}", temp_dir.path().to_str().unwrap(), bob_db_name);
+    manage_single_transaction(
+        TransactionServiceSqliteDatabase::new(alice_db_path).unwrap(),
+        TransactionServiceSqliteDatabase::new(bob_db_path).unwrap(),
+        1,
+        temp_dir.path().to_str().unwrap().to_string(),
+    );
 }
 
 fn manage_multiple_transactions<T: TransactionBackend + Clone + 'static>(
@@ -593,35 +591,35 @@ fn manage_multiple_transactions<T: TransactionBackend + Clone + 'static>(
 
 #[test]
 fn manage_multiple_transactions_memory_db() {
-    with_temp_dir(|dir_path| {
-        manage_multiple_transactions(
-            TransactionMemoryDatabase::new(),
-            TransactionMemoryDatabase::new(),
-            TransactionMemoryDatabase::new(),
-            0,
-            dir_path.to_str().unwrap().to_string(),
-        );
-    });
+    let temp_dir = TempDir::new(random_string(8).as_str()).unwrap();
+
+    manage_multiple_transactions(
+        TransactionMemoryDatabase::new(),
+        TransactionMemoryDatabase::new(),
+        TransactionMemoryDatabase::new(),
+        0,
+        temp_dir.path().to_str().unwrap().to_string(),
+    );
 }
 
 #[test]
 fn manage_multiple_transactions_sqlite_db() {
-    with_temp_dir(|dir_path| {
-        let path_string = dir_path.to_str().unwrap().to_string();
-        let alice_db_name = format!("{}.sqlite3", random_string(8).as_str());
-        let alice_db_path = format!("{}/{}", path_string, alice_db_name);
-        let bob_db_name = format!("{}.sqlite3", random_string(8).as_str());
-        let bob_db_path = format!("{}/{}", path_string, bob_db_name);
-        let carol_db_name = format!("{}.sqlite3", random_string(8).as_str());
-        let carol_db_path = format!("{}/{}", path_string, carol_db_name);
-        manage_multiple_transactions(
-            TransactionServiceSqliteDatabase::new(alice_db_path).unwrap(),
-            TransactionServiceSqliteDatabase::new(bob_db_path).unwrap(),
-            TransactionServiceSqliteDatabase::new(carol_db_path).unwrap(),
-            1,
-            path_string,
-        );
-    });
+    let temp_dir = TempDir::new(random_string(8).as_str()).unwrap();
+
+    let path_string = temp_dir.path().to_str().unwrap().to_string();
+    let alice_db_name = format!("{}.sqlite3", random_string(8).as_str());
+    let alice_db_path = format!("{}/{}", path_string, alice_db_name);
+    let bob_db_name = format!("{}.sqlite3", random_string(8).as_str());
+    let bob_db_path = format!("{}/{}", path_string, bob_db_name);
+    let carol_db_name = format!("{}.sqlite3", random_string(8).as_str());
+    let carol_db_path = format!("{}/{}", path_string, carol_db_name);
+    manage_multiple_transactions(
+        TransactionServiceSqliteDatabase::new(alice_db_path).unwrap(),
+        TransactionServiceSqliteDatabase::new(bob_db_path).unwrap(),
+        TransactionServiceSqliteDatabase::new(carol_db_path).unwrap(),
+        1,
+        path_string,
+    );
 }
 
 fn test_sending_repeated_tx_ids<T: TransactionBackend + Clone + 'static>(alice_backend: T, bob_backend: T) {

--- a/base_layer/wallet_ffi/wallet.h
+++ b/base_layer/wallet_ffi/wallet.h
@@ -345,6 +345,10 @@ bool wallet_test_complete_sent_transaction(struct TariWallet *wallet, struct Tar
 // i.e the transaction was originally sent from the wallet
 bool wallet_is_completed_transaction_outbound(struct TariWallet *wallet, struct TariCompletedTransaction *tx,int* error_out);
 
+// Import a UTXO into the wallet. This will add a spendable UTXO and create a faux completed transaction to record the
+// event.
+unsigned long long wallet_import_utxo(struct TariWallet *wallet, unsigned long long amount, struct TariPrivateKey *spending_key, struct TariPublicKey *source_public_key, int* error_out);
+
 // Simulates the completion of a broadcasted TariPendingInboundTransaction
 bool wallet_test_broadcast_transaction(struct TariWallet *wallet, struct TariCompletedTransaction *tx, int* error_out);
 


### PR DESCRIPTION
## Description

This PR implements the ability to import a UTXO into the wallet by providing an amount and a private key. The UTXO will be added to your available balance and a faux CompletedTransaction will be created to record the event of adding the UTXO in the Transaction Service.

## Motivation and Context
Closes https://github.com/tari-project/tari/issues/1249

## How Has This Been Tested?
Test provided

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [x] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch
* [x] I ran `cargo-fmt --all` before pushing
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
