### PR TITLE
Bump tari_utilities minor version

### DIFF
--- a/applications/console_text_messenger/Cargo.toml
+++ b/applications/console_text_messenger/Cargo.toml
@@ -11,7 +11,7 @@ tari_common = {path = "../../common", version= "^0.0"}
 tari_comms = { path = "../../comms", version = "^0.0"}
 tari_crypto = { path = "../../infrastructure/crypto", version = "^0.0"}
 tari_p2p = {path = "../../base_layer/p2p", version = "^0.0"}
-tari_utilities = { path = "../../infrastructure/tari_util", version = "^0.0"}
+tari_utilities = { path = "../../infrastructure/tari_util", version = "^0.1"}
 tari_wallet = {path = "../../base_layer/wallet", version="^0.0"}
 
 chrono = { version = "0.4.6", features = ["serde"]}

--- a/applications/grpc_wallet/Cargo.toml
+++ b/applications/grpc_wallet/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 [dependencies]
 tari_wallet = {path = "../../base_layer/wallet", version="^0.0"}
 tari_common = {path = "../../common", version= "^0.0"}
-tari_utilities = { path = "../../infrastructure/tari_util", version = "^0.0"}
+tari_utilities = { path = "../../infrastructure/tari_util", version = "^0.1"}
 tari_comms = { path = "../../comms", version = "^0.0"}
 tari_p2p = {path = "../../base_layer/p2p", version = "^0.0"}
 tari_crypto = { path = "../../infrastructure/crypto"}

--- a/applications/tari_base_node/Cargo.toml
+++ b/applications/tari_base_node/Cargo.toml
@@ -14,7 +14,7 @@ tari_core = {path = "../../base_layer/core", version= "^0.0"}
 tari_p2p = {path = "../../base_layer/p2p", version= "^0.0"}
 tari_service_framework = { version = "^0.0", path = "../../base_layer/service_framework"}
 tari_shutdown = { path = "../../infrastructure/shutdown", version = "^0.0" }
-tari_utilities = { version = "^0.0", path = "../../infrastructure/tari_util"}
+tari_utilities = { version = "^0.1", path = "../../infrastructure/tari_util"}
 tari_mmr = { path = "../../base_layer/mmr", version = "^0.0" }
 tari_wallet = { path = "../../base_layer/wallet", version = "^0.0" }
 

--- a/base_layer/core/Cargo.toml
+++ b/base_layer/core/Cargo.toml
@@ -18,7 +18,7 @@ base_node_proto = []
 
 [dependencies]
 tari_comms = { version = "^0.0", path = "../../comms"}
-tari_utilities = { path = "../../infrastructure/tari_util", version = "^0.0"}
+tari_utilities = { path = "../../infrastructure/tari_util", version = "^0.1"}
 tari_infra_derive = { path = "../../infrastructure/derive", version = "^0.0" }
 tari_crypto = { path = "../../infrastructure/crypto", version = "^0.0" }
 tari_storage = { path = "../../infrastructure/storage", version = "^0.0" }

--- a/base_layer/key_manager/Cargo.toml
+++ b/base_layer/key_manager/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2018"
 
 [dependencies]
 tari_crypto = { path = "../../infrastructure/crypto", version = "^0.0" }
-tari_utilities = { path = "../../infrastructure/tari_util", version = "^0.0" }
+tari_utilities = { path = "../../infrastructure/tari_util", version = "^0.1" }
 rand = "0.7.2"
 digest = "0.8.0"
 sha2 = "0.8.0"

--- a/base_layer/mmr/Cargo.toml
+++ b/base_layer/mmr/Cargo.toml
@@ -8,7 +8,7 @@ version = "0.0.5"
 edition = "2018"
 
 [dependencies]
-tari_utilities = { path = "../../infrastructure/tari_util", version = "^0.0" }
+tari_utilities = { path = "../../infrastructure/tari_util", version = "^0.1" }
 derive-error = "0.0.4"
 digest = "0.8.0"
 log = "0.4"

--- a/base_layer/p2p/Cargo.toml
+++ b/base_layer/p2p/Cargo.toml
@@ -20,7 +20,7 @@ tari_pubsub = { version = "^0.0", path = "../../infrastructure/pubsub"}
 tari_service_framework = { version = "^0.0", path = "../service_framework"}
 tari_shutdown = { version = "^0.0", path="../../infrastructure/shutdown" }
 tari_storage = {version = "^0.0", path = "../../infrastructure/storage"}
-tari_utilities = { version = "^0.0", path = "../../infrastructure/tari_util"}
+tari_utilities = {version = "^0.1", path = "../../infrastructure/tari_util"}
 
 bytes = "0.4.12"
 chrono = { version = "0.4.6", features = ["serde"]}

--- a/base_layer/wallet/Cargo.toml
+++ b/base_layer/wallet/Cargo.toml
@@ -18,7 +18,7 @@ tari_pubsub = {path = "../../infrastructure/pubsub", version = "^0.0"}
 tari_service_framework = { version = "^0.0", path = "../service_framework"}
 tari_shutdown = { path = "../../infrastructure/shutdown", version = "^0.0"}
 tari_storage = { version = "^0.0", path = "../../infrastructure/storage"}
-tari_utilities = { path = "../../infrastructure/tari_util", version = "^0.0"}
+tari_utilities = { path = "../../infrastructure/tari_util", version = "^0.1"}
 
 chrono = { version = "0.4.6", features = ["serde"]}
 time = {version = "0.1.39"}

--- a/base_layer/wallet_ffi/Cargo.toml
+++ b/base_layer/wallet_ffi/Cargo.toml
@@ -8,7 +8,7 @@ tari_comms = { path = "../../comms", version = "^0.0"}
 tari_comms_dht = { path = "../../comms/dht", version = "^0.0"}
 tari_crypto = { path = "../../infrastructure/crypto", version = "^0.0" }
 tari_p2p = {path = "../p2p", version = "^0.0"}
-tari_utilities = { path = "../../infrastructure/tari_util", version = "^0.0"}
+tari_utilities = { path = "../../infrastructure/tari_util", version = "^0.1"}
 tari_wallet = { path = "../wallet", version = "^0.0", features = ["test_harness", "c_integration"]}
 tari_shutdown = { path = "../../infrastructure/shutdown", version = "^0.0"}
 

--- a/comms/Cargo.toml
+++ b/comms/Cargo.toml
@@ -14,7 +14,7 @@ next = ["yamux", "snow"]
 [dependencies]
 tari_crypto = { version="^0.0",  path = "../infrastructure/crypto" }
 tari_storage = { version="^0.0", path = "../infrastructure/storage" }
-tari_utilities = { version="^0.0",  path = "../infrastructure/tari_util" }
+tari_utilities = { version="^0.1",  path = "../infrastructure/tari_util" }
 tari_shutdown = { version="^0.0",  path = "../infrastructure/shutdown" }
 
 bitflags = "1.0.4"

--- a/comms/dht/Cargo.toml
+++ b/comms/dht/Cargo.toml
@@ -16,7 +16,7 @@ test-mocks = []
 tari_comms = { version = "^0.0", path = "../"}
 tari_crypto = { version = "^0.0", path = "../../infrastructure/crypto"}
 tari_shutdown = { version = "^0.0", path = "../../infrastructure/shutdown"}
-tari_utilities = { version = "^0.0", path = "../../infrastructure/tari_util"}
+tari_utilities = { version = "^0.1", path = "../../infrastructure/tari_util"}
 
 bitflags = "1.2.0"
 bytes = "0.4.12"

--- a/infrastructure/crypto/Cargo.toml
+++ b/infrastructure/crypto/Cargo.toml
@@ -11,7 +11,7 @@ version = "0.0.5"
 edition = "2018"
 
 [dependencies]
-tari_utilities = { path = "../tari_util", version = "^0.0" }
+tari_utilities = { path = "../tari_util", version = "^0.1" }
 base64 = "0.10.1"
 digest = "0.8.0"
 rand = "0.7.2"

--- a/infrastructure/storage/Cargo.toml
+++ b/infrastructure/storage/Cargo.toml
@@ -18,7 +18,7 @@ rmp = "0.8.7"
 rmp-serde = "0.13.7"
 serde = "1.0.80"
 serde_derive = "1.0.80"
-tari_utilities = { path = "../tari_util", version = "^0.0" }
+tari_utilities = { path = "../tari_util", version = "^0.1" }
 bytes = "0.4.12"
 
 [dev-dependencies]

--- a/infrastructure/tari_util/Cargo.toml
+++ b/infrastructure/tari_util/Cargo.toml
@@ -6,7 +6,7 @@ repository = "https://github.com/tari-project/tari"
 homepage = "https://tari.com"
 readme = "README.md"
 license = "BSD-3-Clause"
-version = "0.0.5"
+version = "0.1.0"
 edition = "2018"
 
 [dependencies]


### PR DESCRIPTION
Bumping tari_utilities to v0.1.0

"External" crates, inc tari_crypto depend on tari_utilies.
Therefore it should keep to semver conventions.
To keep with semver conventions, breaking changes must
increase the minor version.

Since moving to rand v0.7 introduced breaking changes, we bump the minor
version.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [ ] I'm merging against the `development` branch
* [ ] I ran `cargo-fmt --all` before pushing
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
