### PR TITLE
Create only one R2D2 connection pool for the entire wallet

### DIFF
--- a/base_layer/wallet/src/contacts_service/storage/sqlite_db.rs
+++ b/base_layer/wallet/src/contacts_service/storage/sqlite_db.rs
@@ -33,42 +33,19 @@ use diesel::{
     result::Error as DieselError,
     SqliteConnection,
 };
-use std::{convert::TryFrom, io, path::Path, time::Duration};
+use std::convert::TryFrom;
 use tari_core::transactions::types::PublicKey;
 use tari_utilities::ByteArray;
-
-const DATABASE_CONNECTION_TIMEOUT_MS: u64 = 2000;
 
 /// A Sqlite backend for the Output Manager Service. The Backend is accessed via a connection pool to the Sqlite file.
 pub struct ContactsServiceSqliteDatabase {
     database_connection_pool: Pool<ConnectionManager<SqliteConnection>>,
 }
 impl ContactsServiceSqliteDatabase {
-    pub fn new(database_path: String) -> Result<Self, ContactsServiceStorageError> {
-        let db_exists = Path::new(&database_path).exists();
-
-        let connection = SqliteConnection::establish(&database_path)?;
-
-        connection.execute("PRAGMA foreign_keys = ON")?;
-        if !db_exists {
-            embed_migrations!("./migrations");
-            embedded_migrations::run_with_output(&connection, &mut io::stdout()).map_err(|err| {
-                ContactsServiceStorageError::DatabaseMigrationError(format!("Database migration failed {}", err))
-            })?;
+    pub fn new(database_connection_pool: Pool<ConnectionManager<SqliteConnection>>) -> Self {
+        Self {
+            database_connection_pool,
         }
-        drop(connection);
-
-        let manager = ConnectionManager::<SqliteConnection>::new(database_path);
-        let pool = diesel::r2d2::Pool::builder()
-            .connection_timeout(Duration::from_millis(DATABASE_CONNECTION_TIMEOUT_MS))
-            .idle_timeout(Some(Duration::from_millis(DATABASE_CONNECTION_TIMEOUT_MS)))
-            .max_size(1)
-            .build(manager)
-            .map_err(|_| ContactsServiceStorageError::R2d2Error)?;
-
-        Ok(Self {
-            database_connection_pool: pool,
-        })
     }
 }
 

--- a/base_layer/wallet/src/output_manager_service/storage/sqlite_db.rs
+++ b/base_layer/wallet/src/output_manager_service/storage/sqlite_db.rs
@@ -43,47 +43,23 @@ use diesel::{
     result::Error as DieselError,
     SqliteConnection,
 };
-use std::{collections::HashMap, convert::TryFrom, io, path::Path, time::Duration};
+use std::{collections::HashMap, convert::TryFrom, time::Duration};
 use tari_core::transactions::{
     tari_amount::MicroTari,
     transaction::{OutputFeatures, OutputFlags, UnblindedOutput},
     types::PrivateKey,
 };
 use tari_utilities::ByteArray;
-
-const DATABASE_CONNECTION_TIMEOUT_MS: u64 = 2000;
-
 /// A Sqlite backend for the Output Manager Service. The Backend is accessed via a connection pool to the Sqlite file.
 #[derive(Clone)]
 pub struct OutputManagerSqliteDatabase {
     database_connection_pool: Pool<ConnectionManager<SqliteConnection>>,
 }
 impl OutputManagerSqliteDatabase {
-    pub fn new(database_path: String) -> Result<Self, OutputManagerStorageError> {
-        let db_exists = Path::new(&database_path).exists();
-
-        let connection = SqliteConnection::establish(&database_path)?;
-
-        connection.execute("PRAGMA foreign_keys = ON")?;
-        if !db_exists {
-            embed_migrations!("./migrations");
-            embedded_migrations::run_with_output(&connection, &mut io::stdout()).map_err(|err| {
-                OutputManagerStorageError::DatabaseMigrationError(format!("Database migration failed {}", err))
-            })?;
+    pub fn new(database_connection_pool: Pool<ConnectionManager<SqliteConnection>>) -> Self {
+        Self {
+            database_connection_pool,
         }
-        drop(connection);
-
-        let manager = ConnectionManager::<SqliteConnection>::new(database_path);
-        let pool = diesel::r2d2::Pool::builder()
-            .connection_timeout(Duration::from_millis(DATABASE_CONNECTION_TIMEOUT_MS))
-            .idle_timeout(Some(Duration::from_millis(DATABASE_CONNECTION_TIMEOUT_MS)))
-            .max_size(1)
-            .build(manager)
-            .map_err(|_| OutputManagerStorageError::R2d2Error)?;
-
-        Ok(Self {
-            database_connection_pool: pool,
-        })
     }
 }
 impl OutputManagerBackend for OutputManagerSqliteDatabase {

--- a/base_layer/wallet/src/storage/connection_manager.rs
+++ b/base_layer/wallet/src/storage/connection_manager.rs
@@ -1,4 +1,4 @@
-// Copyright 2019. The Tari Project
+// Copyright 2020. The Tari Project
 //
 // Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
 // following conditions are met:
@@ -20,7 +20,36 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-pub mod connection_manager;
-pub mod database;
-pub mod memory_db;
-pub mod sqlite_db;
+use crate::error::WalletStorageError;
+use diesel::{
+    r2d2::{ConnectionManager, Pool},
+    Connection,
+    SqliteConnection,
+};
+use std::{io, path::Path, time::Duration};
+
+const DATABASE_CONNECTION_TIMEOUT_MS: u64 = 2000;
+
+pub fn run_migration_and_create_connection_pool(
+    database_path: String,
+) -> Result<Pool<ConnectionManager<SqliteConnection>>, WalletStorageError> {
+    let db_exists = Path::new(&database_path).exists();
+
+    let connection = SqliteConnection::establish(&database_path)?;
+
+    connection.execute("PRAGMA foreign_keys = ON; PRAGMA busy_timeout = 60000;")?;
+    if !db_exists {
+        embed_migrations!("./migrations");
+        embedded_migrations::run_with_output(&connection, &mut io::stdout())
+            .map_err(|err| WalletStorageError::DatabaseMigrationError(format!("Database migration failed {}", err)))?;
+    }
+    drop(connection);
+
+    let manager = ConnectionManager::<SqliteConnection>::new(database_path);
+    Ok(diesel::r2d2::Pool::builder()
+        .connection_timeout(Duration::from_millis(DATABASE_CONNECTION_TIMEOUT_MS))
+        .idle_timeout(Some(Duration::from_millis(DATABASE_CONNECTION_TIMEOUT_MS)))
+        .max_size(1)
+        .build(manager)
+        .map_err(|_| WalletStorageError::R2d2Error)?)
+}

--- a/base_layer/wallet/src/storage/database.rs
+++ b/base_layer/wallet/src/storage/database.rs
@@ -185,6 +185,7 @@ mod test {
     use crate::{
         error::WalletStorageError,
         storage::{
+            connection_manager::run_migration_and_create_connection_pool,
             database::{DbKey, WalletBackend, WalletDatabase},
             memory_db::WalletMemoryDatabase,
             sqlite_db::WalletSqliteDatabase,
@@ -267,7 +268,9 @@ mod test {
             .to_str()
             .unwrap()
             .to_string();
+        let connection_pool =
+            run_migration_and_create_connection_pool(format!("{}{}", db_folder, db_name).to_string()).unwrap();
 
-        test_database_crud(WalletSqliteDatabase::new(format!("{}{}", db_folder, db_name).to_string()).unwrap());
+        test_database_crud(WalletSqliteDatabase::new(connection_pool));
     }
 }

--- a/base_layer/wallet/src/storage/sqlite_db.rs
+++ b/base_layer/wallet/src/storage/sqlite_db.rs
@@ -31,42 +31,19 @@ use diesel::{
     result::Error as DieselError,
     SqliteConnection,
 };
-use std::{convert::TryFrom, io, path::Path, time::Duration};
+use std::convert::TryFrom;
 use tari_comms::peer_manager::Peer;
 use tari_utilities::ByteArray;
-
-const DATABASE_CONNECTION_TIMEOUT_MS: u64 = 2000;
 
 /// A Sqlite backend for the Output Manager Service. The Backend is accessed via a connection pool to the Sqlite file.
 pub struct WalletSqliteDatabase {
     database_connection_pool: Pool<ConnectionManager<SqliteConnection>>,
 }
 impl WalletSqliteDatabase {
-    pub fn new(database_path: String) -> Result<Self, WalletStorageError> {
-        let db_exists = Path::new(&database_path).exists();
-
-        let connection = SqliteConnection::establish(&database_path)?;
-
-        connection.execute("PRAGMA foreign_keys = ON")?;
-        if !db_exists {
-            embed_migrations!("./migrations");
-            embedded_migrations::run_with_output(&connection, &mut io::stdout()).map_err(|err| {
-                WalletStorageError::DatabaseMigrationError(format!("Database migration failed {}", err))
-            })?;
+    pub fn new(database_connection_pool: Pool<ConnectionManager<SqliteConnection>>) -> Self {
+        Self {
+            database_connection_pool,
         }
-        drop(connection);
-
-        let manager = ConnectionManager::<SqliteConnection>::new(database_path);
-        let pool = diesel::r2d2::Pool::builder()
-            .connection_timeout(Duration::from_millis(DATABASE_CONNECTION_TIMEOUT_MS))
-            .idle_timeout(Some(Duration::from_millis(DATABASE_CONNECTION_TIMEOUT_MS)))
-            .max_size(1)
-            .build(manager)
-            .map_err(|_| WalletStorageError::R2d2Error)?;
-
-        Ok(Self {
-            database_connection_pool: pool,
-        })
     }
 }
 

--- a/base_layer/wallet/tests/contacts_service/mod.rs
+++ b/base_layer/wallet/tests/contacts_service/mod.rs
@@ -26,15 +26,18 @@ use tari_core::transactions::types::PublicKey;
 use tari_crypto::keys::PublicKey as PublicKeyTrait;
 use tari_service_framework::StackBuilder;
 use tari_shutdown::Shutdown;
-use tari_wallet::contacts_service::{
-    error::{ContactsServiceError, ContactsServiceStorageError},
-    handle::ContactsServiceHandle,
-    storage::{
-        database::{Contact, ContactsBackend, ContactsDatabase, DbKey},
-        memory_db::ContactsServiceMemoryDatabase,
-        sqlite_db::ContactsServiceSqliteDatabase,
+use tari_wallet::{
+    contacts_service::{
+        error::{ContactsServiceError, ContactsServiceStorageError},
+        handle::ContactsServiceHandle,
+        storage::{
+            database::{Contact, ContactsBackend, ContactsDatabase, DbKey},
+            memory_db::ContactsServiceMemoryDatabase,
+            sqlite_db::ContactsServiceSqliteDatabase,
+        },
+        ContactsServiceInitializer,
     },
-    ContactsServiceInitializer,
+    storage::connection_manager::run_migration_and_create_connection_pool,
 };
 use tempdir::TempDir;
 use tokio::runtime::Runtime;
@@ -179,7 +182,7 @@ fn contacts_service_sqlite_db() {
     let db_name = format!("{}.sqlite3", random_string(8).as_str());
     let temp_dir = TempDir::new(random_string(8).as_str()).unwrap();
     let db_folder = temp_dir.path().to_str().unwrap().to_string();
-    test_contacts_service(
-        ContactsServiceSqliteDatabase::new(format!("{}/{}", db_folder, db_name).to_string()).unwrap(),
-    );
+    let connection_pool =
+        run_migration_and_create_connection_pool(format!("{}/{}", db_folder, db_name).to_string()).unwrap();
+    test_contacts_service(ContactsServiceSqliteDatabase::new(connection_pool));
 }

--- a/base_layer/wallet/tests/output_manager_service/service.rs
+++ b/base_layer/wallet/tests/output_manager_service/service.rs
@@ -34,15 +34,18 @@ use tari_crypto::{commitment::HomomorphicCommitmentFactory, keys::SecretKey, ran
 use tari_service_framework::StackBuilder;
 use tari_shutdown::Shutdown;
 use tari_utilities::ByteArray;
-use tari_wallet::output_manager_service::{
-    error::{OutputManagerError, OutputManagerStorageError},
-    handle::OutputManagerHandle,
-    storage::{
-        database::{DbKey, DbValue, OutputManagerBackend},
-        memory_db::OutputManagerMemoryDatabase,
-        sqlite_db::OutputManagerSqliteDatabase,
+use tari_wallet::{
+    output_manager_service::{
+        error::{OutputManagerError, OutputManagerStorageError},
+        handle::OutputManagerHandle,
+        storage::{
+            database::{DbKey, DbValue, OutputManagerBackend},
+            memory_db::OutputManagerMemoryDatabase,
+            sqlite_db::OutputManagerSqliteDatabase,
+        },
+        OutputManagerServiceInitializer,
     },
-    OutputManagerServiceInitializer,
+    storage::connection_manager::run_migration_and_create_connection_pool,
 };
 use tempdir::TempDir;
 use tokio::runtime::Runtime;
@@ -158,7 +161,9 @@ fn sending_transaction_and_confirmation_sqlite_db() {
     let db_tempdir = TempDir::new(random_string(8).as_str()).unwrap();
     let db_folder = db_tempdir.path().to_str().unwrap().to_string();
     let db_path = format!("{}/{}", db_folder, db_name);
-    sending_transaction_and_confirmation(OutputManagerSqliteDatabase::new(db_path).unwrap());
+    let connection_pool = run_migration_and_create_connection_pool(db_path).unwrap();
+
+    sending_transaction_and_confirmation(OutputManagerSqliteDatabase::new(connection_pool));
 }
 
 fn send_not_enough_funds<T: OutputManagerBackend + 'static>(backend: T) {
@@ -199,7 +204,9 @@ fn send_not_enough_funds_sqlite_db() {
     let db_tempdir = TempDir::new(random_string(8).as_str()).unwrap();
     let db_folder = db_tempdir.path().to_str().unwrap().to_string();
     let db_path = format!("{}/{}", db_folder, db_name);
-    send_not_enough_funds(OutputManagerSqliteDatabase::new(db_path).unwrap());
+    let connection_pool = run_migration_and_create_connection_pool(db_path).unwrap();
+
+    send_not_enough_funds(OutputManagerSqliteDatabase::new(connection_pool));
 }
 
 fn send_no_change<T: OutputManagerBackend + 'static>(backend: T) {
@@ -273,7 +280,9 @@ fn send_no_change_sqlite_db() {
     let db_tempdir = TempDir::new(random_string(8).as_str()).unwrap();
     let db_folder = db_tempdir.path().to_str().unwrap().to_string();
     let db_path = format!("{}/{}", db_folder, db_name);
-    send_no_change(OutputManagerSqliteDatabase::new(db_path).unwrap());
+    let connection_pool = run_migration_and_create_connection_pool(db_path).unwrap();
+
+    send_no_change(OutputManagerSqliteDatabase::new(connection_pool));
 }
 
 fn send_not_enough_for_change<T: OutputManagerBackend + 'static>(backend: T) {
@@ -316,7 +325,9 @@ fn send_not_enough_for_change_sqlite_db() {
     let db_tempdir = TempDir::new(random_string(8).as_str()).unwrap();
     let db_folder = db_tempdir.path().to_str().unwrap().to_string();
     let db_path = format!("{}/{}", db_folder, db_name);
-    send_not_enough_for_change(OutputManagerSqliteDatabase::new(db_path).unwrap());
+    let connection_pool = run_migration_and_create_connection_pool(db_path).unwrap();
+
+    send_not_enough_for_change(OutputManagerSqliteDatabase::new(connection_pool));
 }
 
 fn receiving_and_confirmation<T: OutputManagerBackend + 'static>(backend: T) {
@@ -358,7 +369,9 @@ fn receiving_and_confirmation_sqlite_db() {
     let db_tempdir = TempDir::new(random_string(8).as_str()).unwrap();
     let db_folder = db_tempdir.path().to_str().unwrap().to_string();
     let db_path = format!("{}/{}", db_folder, db_name);
-    receiving_and_confirmation(OutputManagerSqliteDatabase::new(db_path).unwrap());
+    let connection_pool = run_migration_and_create_connection_pool(db_path).unwrap();
+
+    receiving_and_confirmation(OutputManagerSqliteDatabase::new(connection_pool));
 }
 
 fn cancel_transaction<T: OutputManagerBackend + 'static>(backend: T) {
@@ -406,7 +419,8 @@ fn cancel_transaction_sqlite_db() {
     let db_tempdir = TempDir::new(random_string(8).as_str()).unwrap();
     let db_folder = db_tempdir.path().to_str().unwrap().to_string();
     let db_path = format!("{}/{}", db_folder, db_name);
-    cancel_transaction(OutputManagerSqliteDatabase::new(db_path).unwrap());
+    let connection_pool = run_migration_and_create_connection_pool(db_path).unwrap();
+    cancel_transaction(OutputManagerSqliteDatabase::new(connection_pool));
 }
 
 fn timeout_transaction<T: OutputManagerBackend + 'static>(backend: T) {
@@ -459,7 +473,8 @@ fn timeout_transaction_sqlite_db() {
     let db_tempdir = TempDir::new(random_string(8).as_str()).unwrap();
     let db_folder = db_tempdir.path().to_str().unwrap().to_string();
     let db_path = format!("{}/{}", db_folder, db_name);
-    timeout_transaction(OutputManagerSqliteDatabase::new(db_path).unwrap());
+    let connection_pool = run_migration_and_create_connection_pool(db_path).unwrap();
+    timeout_transaction(OutputManagerSqliteDatabase::new(connection_pool));
 }
 
 fn test_get_balance<T: OutputManagerBackend + 'static>(backend: T) {
@@ -510,7 +525,8 @@ fn test_get_balance_sqlite_db() {
     let db_tempdir = TempDir::new(random_string(8).as_str()).unwrap();
     let db_folder = db_tempdir.path().to_str().unwrap().to_string();
     let db_path = format!("{}/{}", db_folder, db_name);
-    test_get_balance(OutputManagerSqliteDatabase::new(db_path).unwrap());
+    let connection_pool = run_migration_and_create_connection_pool(db_path).unwrap();
+    test_get_balance(OutputManagerSqliteDatabase::new(connection_pool));
 }
 
 fn test_confirming_received_output<T: OutputManagerBackend + 'static>(backend: T) {
@@ -547,5 +563,6 @@ fn test_confirming_received_output_sqlite_db() {
     let db_tempdir = TempDir::new(random_string(8).as_str()).unwrap();
     let db_folder = db_tempdir.path().to_str().unwrap().to_string();
     let db_path = format!("{}/{}", db_folder, db_name);
-    test_confirming_received_output(OutputManagerSqliteDatabase::new(db_path).unwrap());
+    let connection_pool = run_migration_and_create_connection_pool(db_path).unwrap();
+    test_confirming_received_output(OutputManagerSqliteDatabase::new(connection_pool));
 }

--- a/base_layer/wallet/tests/transaction_service/storage.rs
+++ b/base_layer/wallet/tests/transaction_service/storage.rs
@@ -35,18 +35,21 @@ use tari_crypto::{
     commitment::HomomorphicCommitmentFactory,
     keys::{PublicKey as PublicKeyTrait, SecretKey as SecretKeyTrait},
 };
-use tari_wallet::transaction_service::storage::{
-    database::{
-        CompletedTransaction,
-        InboundTransaction,
-        OutboundTransaction,
-        PendingCoinbaseTransaction,
-        TransactionBackend,
-        TransactionDatabase,
-        TransactionStatus,
+use tari_wallet::{
+    storage::connection_manager::run_migration_and_create_connection_pool,
+    transaction_service::storage::{
+        database::{
+            CompletedTransaction,
+            InboundTransaction,
+            OutboundTransaction,
+            PendingCoinbaseTransaction,
+            TransactionBackend,
+            TransactionDatabase,
+            TransactionStatus,
+        },
+        memory_db::TransactionMemoryDatabase,
+        sqlite_db::TransactionServiceSqliteDatabase,
     },
-    memory_db::TransactionMemoryDatabase,
-    sqlite_db::TransactionServiceSqliteDatabase,
 };
 use tempdir::TempDir;
 use tokio::runtime::Runtime;
@@ -300,5 +303,6 @@ pub fn test_transaction_service_sqlite_db() {
     let db_tempdir = TempDir::new(random_string(8).as_str()).unwrap();
     let db_folder = db_tempdir.path().to_str().unwrap().to_string();
     let db_path = format!("{}/{}", db_folder, db_name);
-    test_db_backend(TransactionServiceSqliteDatabase::new(db_path).unwrap());
+    let connection_pool = run_migration_and_create_connection_pool(db_path).unwrap();
+    test_db_backend(TransactionServiceSqliteDatabase::new(connection_pool));
 }


### PR DESCRIPTION
## Description

This change is due to database lock errors occurring on CI and the mobile environments. This change means there is only a single connection pool that will only serve a single connection the Sqlite database at a time. This will hopefully eliminate any potential for locks.

## How Has This Been Tested?
Tests updated

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch
* [x] I ran `cargo-fmt --all` before pushing
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
