### PR TITLE
Base node listening state

### DIFF
--- a/applications/tari_base_node/src/builder.rs
+++ b/applications/tari_base_node/src/builder.rs
@@ -38,6 +38,7 @@ use tari_comms::{
 };
 use tari_core::{
     base_node::{
+        chain_metadata_service::ChainMetadataHandle,
         service::{BaseNodeServiceConfig, BaseNodeServiceInitializer},
         BaseNodeStateMachine,
         BaseNodeStateMachineConfig,
@@ -255,6 +256,9 @@ pub fn configure_and_initialize_node(
             let outbound_interface = handles
                 .get_handle::<OutboundNodeCommsInterface>()
                 .expect("Problem getting node interface handle");
+            let chain_metadata_service = handles
+                .get_handle::<ChainMetadataHandle>()
+                .expect("Problem getting chain metadata interface handle");
             let wallet_output_manager_service = handles
                 .get_handle::<OutputManagerHandle>()
                 .expect("Problem getting wallet interface handle");
@@ -267,6 +271,8 @@ pub fn configure_and_initialize_node(
             let node = NodeType::Memory(BaseNodeStateMachine::new(
                 &db,
                 &outbound_interface,
+                rt.handle().clone(),
+                chain_metadata_service.get_event_stream(),
                 BaseNodeStateMachineConfig::default(),
             ));
 
@@ -310,9 +316,14 @@ pub fn configure_and_initialize_node(
             let outbound_interface = handles
                 .get_handle::<OutboundNodeCommsInterface>()
                 .expect("Problem getting node interface handle");
+            let chain_metadata_service = handles
+                .get_handle::<ChainMetadataHandle>()
+                .expect("Problem getting chain metadata interface handle");
             let node = NodeType::LMDB(BaseNodeStateMachine::new(
                 &db,
                 &outbound_interface,
+                rt.handle().clone(),
+                chain_metadata_service.get_event_stream(),
                 BaseNodeStateMachineConfig::default(),
             ));
             let wallet_output_manager_service = handles

--- a/base_layer/core/src/base_node/chain_metadata_service/handle.rs
+++ b/base_layer/core/src/base_node/chain_metadata_service/handle.rs
@@ -24,10 +24,12 @@ use crate::chain_storage::ChainMetadata;
 use futures::{stream::Fuse, StreamExt};
 use tari_broadcast_channel::Subscriber;
 
+#[derive(Debug)]
 pub enum ChainMetadataEvent {
     PeerChainMetadataReceived(Vec<ChainMetadata>),
 }
 
+#[derive(Clone)]
 pub struct ChainMetadataHandle {
     event_stream: Subscriber<ChainMetadataEvent>,
 }
@@ -37,7 +39,11 @@ impl ChainMetadataHandle {
         Self { event_stream }
     }
 
-    pub fn get_event_stream(&self) -> Fuse<Subscriber<ChainMetadataEvent>> {
-        self.event_stream.clone().fuse()
+    pub fn get_event_stream(&self) -> Subscriber<ChainMetadataEvent> {
+        self.event_stream.clone()
+    }
+
+    pub fn get_event_stream_fused(&self) -> Fuse<Subscriber<ChainMetadataEvent>> {
+        self.get_event_stream().fuse()
     }
 }

--- a/base_layer/core/src/base_node/chain_metadata_service/mod.rs
+++ b/base_layer/core/src/base_node/chain_metadata_service/mod.rs
@@ -26,3 +26,7 @@ mod error;
 mod handle;
 mod initializer;
 mod service;
+
+// Public re-exports
+pub use handle::{ChainMetadataEvent, ChainMetadataHandle};
+pub use initializer::ChainMetadataServiceInitializer;

--- a/base_layer/core/src/base_node/comms_interface/local_interface.rs
+++ b/base_layer/core/src/base_node/comms_interface/local_interface.rs
@@ -55,8 +55,12 @@ impl LocalNodeCommsInterface {
         }
     }
 
+    pub fn get_block_event_stream(&self) -> Subscriber<BlockEvent> {
+        self.block_event_stream.clone()
+    }
+
     pub fn get_block_event_stream_fused(&self) -> Fuse<Subscriber<BlockEvent>> {
-        self.block_event_stream.clone().fuse()
+        self.get_block_event_stream().fuse()
     }
 
     /// Request metadata from the current local node.

--- a/base_layer/core/src/base_node/mod.rs
+++ b/base_layer/core/src/base_node/mod.rs
@@ -36,11 +36,11 @@ cfg_if! {
     if #[cfg(feature = "base_node")] {
         mod backoff;
         mod base_node;
-        mod chain_metadata_service;
 
         pub mod comms_interface;
         pub mod consts;
         pub mod service;
+        pub mod chain_metadata_service;
         pub mod states;
         // Public re-exports
         pub use backoff::BackOff;

--- a/base_layer/core/src/base_node/states/listening.rs
+++ b/base_layer/core/src/base_node/states/listening.rs
@@ -22,43 +22,109 @@
 
 use crate::{
     base_node::{
-        states::{StateEvent, StateEvent::UserQuit},
+        chain_metadata_service::ChainMetadataEvent,
+        states::{helpers::determine_sync_mode, StateEvent, StateEvent::FatalError, SyncStatus},
         BaseNodeStateMachine,
     },
-    blocks::Block,
-    chain_storage::{BlockchainBackend, ChainMetadata},
-    transactions::transaction::Transaction,
+    chain_storage::BlockchainBackend,
+};
+use futures::{
+    channel::mpsc::{channel, Sender},
+    stream::StreamExt,
+    SinkExt,
 };
 use log::*;
-use std::sync::atomic::Ordering;
+use std::time::{Duration, Instant};
+use tokio::runtime;
 
 const LOG_TARGET: &str = "base_node::listening";
 
-pub struct ListeningInfo;
+// The max duration that the listening state will wait between metadata events before it will start asking for metadata
+// from remote nodes.
+const LISTENING_SILENCE_TIMEOUT: Duration = Duration::from_secs(300); // 5 minutes
 
-enum ChainMessage {
-    Transaction(Box<Transaction>),
-    Block(Box<Block>),
-    Metadata(Box<ChainMetadata>),
+/// Configuration for the Listening state.
+#[derive(Clone, Copy)]
+pub struct ListeningConfig {
+    pub listening_silence_timeout: Duration,
 }
+
+impl Default for ListeningConfig {
+    fn default() -> Self {
+        Self {
+            listening_silence_timeout: LISTENING_SILENCE_TIMEOUT,
+        }
+    }
+}
+
+/// This state listens for chain metadata events received from the liveness and chain metadata service. Based on the
+/// received metadata, if it detects that the current node is lagging behind the network it will switch to block sync
+/// state. If no metadata is received for a prolonged period of time it will transition to the initial sync state and
+/// request chain metadata from remote nodes.
+pub struct ListeningInfo;
 
 impl ListeningInfo {
     pub async fn next_event<B: BlockchainBackend>(&mut self, shared: &mut BaseNodeStateMachine<B>) -> StateEvent {
-        info!(target: LOG_TARGET, "Listening for new blocks and transactions");
+        info!(target: LOG_TARGET, "Listening for chain metadata updates");
+
+        let mut metadata_event_stream = shared.metadata_event_stream.clone().fuse();
+        let (timeout_event_sender, timeout_event_receiver) = channel(100);
+        let mut timeout_event_receiver = timeout_event_receiver.fuse();
+
+        // Create the initial timeout event
+        spawn_timeout_event(
+            &shared.executor,
+            timeout_event_sender.clone(),
+            shared.config.listening_config.listening_silence_timeout,
+        )
+        .await;
+        let mut last_event_time = Instant::now();
+
         loop {
-            let message = self.wait_for_next_message().await;
-            match message {
-                ChainMessage::Transaction(_) => {},
-                ChainMessage::Block(_) => {},
-                ChainMessage::Metadata(_) => {},
-            }
-            if shared.user_stopped.load(Ordering::Relaxed) {
-                return UserQuit;
+            futures::select! {
+                metadata_event = metadata_event_stream.select_next_some() => {
+                    if let ChainMetadataEvent::PeerChainMetadataReceived(chain_metadata_list) = &*metadata_event {
+                        if let Some(network)=chain_metadata_list.first() {
+                            info!(target: LOG_TARGET, "Loading local blockchain metadata.");
+                            let local = match shared.db.get_metadata() {
+                                Ok(m) => m,
+                                Err(e) => {
+                                    let msg = format!("Could not get local blockchain metadata. {}", e.to_string());
+                                    return FatalError(msg);
+                                },
+                            };
+                            if let SyncStatus::Lagging(h)=determine_sync_mode(local,network.clone(),LOG_TARGET) {
+                                return StateEvent::FallenBehind(SyncStatus::Lagging(h));
+                            }
+                        }
+                        last_event_time=Instant::now();
+                    }
+                },
+
+                timeout_event= timeout_event_receiver.select_next_some() => {
+                    let timeout_time=Instant::now();
+                    let time_difference=timeout_time.duration_since(last_event_time);
+                    if time_difference>=shared.config.listening_config.listening_silence_timeout {
+                        return StateEvent::NetworkSilence;
+                    }
+                    else { // Timeout was early, spawn an updated timeout with correct delay
+                        let timeout_delay=shared.config.listening_config.listening_silence_timeout-time_difference;
+                        spawn_timeout_event(&shared.executor,timeout_event_sender.clone(),timeout_delay).await;
+                    }
+                },
+
+                complete => { // Shutting down as liveness metadata and timeout streams were closed
+                    return StateEvent::UserQuit;
+                }
             }
         }
     }
+}
 
-    async fn wait_for_next_message(&self) -> ChainMessage {
-        unimplemented!()
-    }
+// Spawn a timeout event that will respond on the timeout event sender once the specified time delay has been reached.
+async fn spawn_timeout_event(executor: &runtime::Handle, mut timeout_event_sender: Sender<bool>, timeout: Duration) {
+    executor.spawn(async move {
+        tokio::time::delay_for(timeout).await;
+        let _ = timeout_event_sender.send(true).await;
+    });
 }

--- a/base_layer/core/src/base_node/states/mod.rs
+++ b/base_layer/core/src/base_node/states/mod.rs
@@ -78,6 +78,7 @@ pub enum StateEvent {
     MetadataSynced(SyncStatus),
     BlocksSynchronized,
     FallenBehind(SyncStatus),
+    NetworkSilence,
     FatalError(String),
     UserQuit,
 }
@@ -108,6 +109,7 @@ impl Display for BaseNodeState {
 
 mod block_sync;
 mod error;
+mod helpers;
 mod initial_sync;
 mod listening;
 mod shutdown_state;
@@ -115,6 +117,6 @@ mod starting_state;
 
 pub use block_sync::{BlockSyncConfig, BlockSyncInfo};
 pub use initial_sync::InitialSync;
-pub use listening::ListeningInfo;
+pub use listening::{ListeningConfig, ListeningInfo};
 pub use shutdown_state::Shutdown;
 pub use starting_state::Starting;

--- a/base_layer/core/tests/mempool.rs
+++ b/base_layer/core/tests/mempool.rs
@@ -56,7 +56,7 @@ use tari_core::{
     validation::transaction_validators::TxInputAndMaturityValidator,
 };
 use tari_mmr::MmrCacheConfig;
-use tari_p2p::tari_message::TariMessageType;
+use tari_p2p::{services::liveness::LivenessConfig, tari_message::TariMessageType};
 use tari_test_utils::{async_assert_eventually, random::string};
 use tempdir::TempDir;
 use tokio::runtime::Runtime;
@@ -595,6 +595,7 @@ fn service_request_timeout() {
         BaseNodeServiceConfig::default(),
         MmrCacheConfig::default(),
         mempool_service_config,
+        LivenessConfig::default(),
         temp_dir.path().to_str().unwrap(),
     );
 

--- a/base_layer/core/tests/node_service.rs
+++ b/base_layer/core/tests/node_service.rs
@@ -59,6 +59,7 @@ use tari_core::{
     txn_schema,
 };
 use tari_mmr::MmrCacheConfig;
+use tari_p2p::services::liveness::LivenessConfig;
 use tari_test_utils::random::string;
 use tari_utilities::hash::Hashable;
 use tempdir::TempDir;
@@ -440,6 +441,7 @@ fn service_request_timeout() {
         base_node_service_config,
         MmrCacheConfig::default(),
         MempoolServiceConfig::default(),
+        LivenessConfig::default(),
         temp_dir.path().to_str().unwrap(),
     );
 

--- a/base_layer/core/tests/node_state_machine.rs
+++ b/base_layer/core/tests/node_state_machine.rs
@@ -24,13 +24,14 @@
 mod helpers;
 
 use helpers::{
-    block_builders::{append_block, create_genesis_block},
-    nodes::create_network_with_2_base_nodes_with_config,
+    block_builders::{append_block, chain_block, create_genesis_block},
+    nodes::{create_network_with_2_base_nodes, create_network_with_2_base_nodes_with_config},
 };
+use std::time::Duration;
 use tari_core::{
     base_node::{
         service::BaseNodeServiceConfig,
-        states::{BlockSyncInfo, StateEvent},
+        states::{BlockSyncConfig, BlockSyncInfo, ListeningConfig, ListeningInfo, StateEvent, SyncStatus::Lagging},
         BaseNodeStateMachine,
         BaseNodeStateMachineConfig,
     },
@@ -38,9 +39,87 @@ use tari_core::{
     transactions::types::CryptoFactories,
 };
 use tari_mmr::MmrCacheConfig;
+use tari_p2p::services::liveness::LivenessConfig;
 use tari_test_utils::random::string;
 use tempdir::TempDir;
 use tokio::runtime::Runtime;
+
+#[test]
+fn test_listening_lagging() {
+    let mut runtime = Runtime::new().unwrap();
+    let factories = CryptoFactories::default();
+    let temp_dir = TempDir::new(string(8).as_str()).unwrap();
+    let (alice_node, bob_node) = create_network_with_2_base_nodes_with_config(
+        &mut runtime,
+        BaseNodeServiceConfig::default(),
+        MmrCacheConfig::default(),
+        MempoolServiceConfig::default(),
+        LivenessConfig {
+            enable_auto_join: false,
+            enable_auto_stored_message_request: false,
+            auto_ping_interval: Some(Duration::from_millis(100)),
+            refresh_neighbours_interval: Duration::from_secs(60),
+        },
+        temp_dir.path().to_str().unwrap(),
+    );
+    let mut alice_state_machine = BaseNodeStateMachine::new(
+        &alice_node.blockchain_db,
+        &alice_node.outbound_nci,
+        runtime.handle().clone(),
+        alice_node.chain_metadata_handle.get_event_stream(),
+        BaseNodeStateMachineConfig::default(),
+    );
+
+    let alice_db = &alice_node.blockchain_db;
+    let bob_db = bob_node.blockchain_db;
+    let mut bob_local_nci = bob_node.local_nci;
+    let (mut prev_block, _) = create_genesis_block(alice_db, &factories);
+    alice_db.add_block(prev_block.clone()).unwrap();
+    bob_db.add_block(prev_block.clone()).unwrap();
+
+    runtime.block_on(async {
+        // Bob Block 1 - no block event
+        prev_block = append_block(&bob_db, &prev_block, vec![]).unwrap();
+        // Bob Block 2 - with block event and liveness service metadata update
+        let prev_block = bob_db.calculate_mmr_roots(chain_block(&prev_block, vec![])).unwrap();
+        bob_local_nci.submit_block(prev_block.clone()).await.unwrap();
+        assert_eq!(bob_db.get_height(), Ok(Some(2)));
+
+        let state_event = ListeningInfo {}.next_event(&mut alice_state_machine).await;
+        assert_eq!(state_event, StateEvent::FallenBehind(Lagging(2)));
+    });
+
+    alice_node.comms.shutdown().unwrap();
+    bob_node.comms.shutdown().unwrap();
+}
+
+#[test]
+fn test_listening_network_silence() {
+    let mut runtime = Runtime::new().unwrap();
+    let temp_dir = TempDir::new(string(8).as_str()).unwrap();
+    let (alice_node, bob_node) = create_network_with_2_base_nodes(&mut runtime, temp_dir.path().to_str().unwrap());
+    let state_machine_config = BaseNodeStateMachineConfig {
+        block_sync_config: BlockSyncConfig::default(),
+        listening_config: ListeningConfig {
+            listening_silence_timeout: Duration::from_millis(100),
+        },
+    };
+    let mut alice_state_machine = BaseNodeStateMachine::new(
+        &alice_node.blockchain_db,
+        &alice_node.outbound_nci,
+        runtime.handle().clone(),
+        alice_node.chain_metadata_handle.get_event_stream(),
+        state_machine_config,
+    );
+
+    runtime.block_on(async {
+        let state_event = ListeningInfo {}.next_event(&mut alice_state_machine).await;
+        assert_eq!(state_event, StateEvent::NetworkSilence);
+    });
+
+    alice_node.comms.shutdown().unwrap();
+    bob_node.comms.shutdown().unwrap();
+}
 
 #[test]
 fn test_block_sync() {
@@ -54,12 +133,15 @@ fn test_block_sync() {
         // mmr_cache_config,
         MmrCacheConfig::default(),
         MempoolServiceConfig::default(),
+        LivenessConfig::default(),
         temp_dir.path().to_str().unwrap(),
     );
     let state_machine_config = BaseNodeStateMachineConfig::default();
     let mut alice_state_machine = BaseNodeStateMachine::new(
         &alice_node.blockchain_db,
         &alice_node.outbound_nci,
+        runtime.handle().clone(),
+        alice_node.chain_metadata_handle.get_event_stream(),
         state_machine_config,
     );
 
@@ -99,12 +181,15 @@ fn test_lagging_block_sync() {
         BaseNodeServiceConfig::default(),
         MmrCacheConfig::default(),
         MempoolServiceConfig::default(),
+        LivenessConfig::default(),
         temp_dir.path().to_str().unwrap(),
     );
     let state_machine_config = BaseNodeStateMachineConfig::default();
     let mut alice_state_machine = BaseNodeStateMachine::new(
         &alice_node.blockchain_db,
         &alice_node.outbound_nci,
+        runtime.handle().clone(),
+        alice_node.chain_metadata_handle.get_event_stream(),
         state_machine_config,
     );
 


### PR DESCRIPTION
## Description
- Implemented the listening logic for the BaseNodeStateMachine. It listens for chain metadata events received from the liveness and chain metadata service. If it detects that the current node is lagging behind the network it will switch to the block sync state. When no metadata was received for a prolonged period of time it will transition to the initial sync state, where it will request chain metadata from remote nodes. 
- Modified the BaseNodeStateMachine to have access to the executor and metadata event stream.
- Also added an extra state transition in the BaseNodeStateMachine,allowing the node to transition from the listening state to the InitialSync state when network silence was detected.
- Moved the determine_sync_mode function to a helpers.rs file, to allow the listening state and initial sync to reuse the same function. 
- Added the ChainMetadataService handle to the construction of the base node in the base node builder.

## Motivation and Context
These changes will allow the BaseNodeStateMachine to react on the received chain metadata from remote nodes by performing a block sync when it detects that the current node is lagging. It will also detect prolonged periods of not receiving any chain metadata, allowing it to request chain metadata from its peers.

## How Has This Been Tested?
- Added the test_listening_lagging test that demonstrates the detection of a lagging state and the transition to the block sync state.
- Added the test_listening_network_silence test that demonstrates the internal timeout system for detecting prolonged network silence.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [x] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch
* [x] I ran `cargo-fmt --all` before pushing
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
