### PR TITLE
Add testnet faucet generator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,5 @@ Cargo.lock
 base_layer/wallet_ffi/build.config
 /base_layer/wallet_ffi/logs/
 base_layer/wallet_ffi/.cargo/config
+
+keys.json

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ members = [
     "infrastructure/test_utils",
     #"applications/tari_testnet_miner",
     "applications/tari_base_node",
+    "applications/test_faucet",
     #Needs to be updated to make its calls using an Tokio runtime block_on function.
     #"ffi"
     #The wallet gRPC is based on the old Futures and not part of the Testnet scope

--- a/applications/test_faucet/Cargo.toml
+++ b/applications/test_faucet/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "test_faucet"
+version = "0.0.1"
+authors = ["The Tari Development Community"]
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+tari_utilities = "0.1.0"
+serde = { version = "1.0.97", features = ["derive"] }
+serde_json = "1.0"
+rand = "0.7.2"
+
+[dependencies.tari_core]
+version = "0.0.5"
+path = "../../base_layer/core/"
+default-features = false
+features = ["transactions", "avx2"]
+
+[dependencies.tokio]
+version = "^0.2.10"
+default-features = false
+features = ["fs", "blocking", "stream", "rt-threaded", "macros", "io-util", "sync"]

--- a/applications/test_faucet/src/main.rs
+++ b/applications/test_faucet/src/main.rs
@@ -1,0 +1,126 @@
+use rand::{self, Rng};
+use serde::Serialize;
+use tari_core::{
+    tari_utilities::hex::Hex,
+    transactions::{
+        helpers,
+        tari_amount::{MicroTari, T},
+        transaction::{OutputFeatures, TransactionOutput},
+        types::{CryptoFactories, PrivateKey},
+    },
+};
+
+use std::{fs::File, io::Write};
+use tokio::{sync::mpsc, task};
+
+const NUM_KEYS: usize = 10;
+
+#[derive(Serialize)]
+struct Key {
+    key: String,
+    value: u64,
+    commitment: String,
+    proof: String,
+}
+
+/// UTXO generation is pretty slow (esp range proofs), so we'll use async threads to speed things up.
+/// We'll use blocking thread tasks to do the CPU intensive utxo generation, and then push the results
+/// through a channel where a file-writer is waiting to persist the results to disk.
+#[tokio::main(core_threads = 2, max_threads = 10)]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let num_keys: usize = std::env::args()
+        .skip(1)
+        .take(1)
+        .fold(NUM_KEYS, |def, v| v.parse::<usize>().unwrap_or(def));
+
+    // Create a channel to give the file writer output as the utxos are generated
+    let (tx, rx) = mpsc::channel::<(TransactionOutput, PrivateKey, MicroTari)>(500);
+
+    println!("Setting up output");
+    let write_fut = task::spawn(write_keys(rx));
+
+    println!("Generating {} UTXOs..", num_keys);
+    let factories = CryptoFactories::default();
+    let values = Values;
+    let features = UTXOFeatures;
+    // Use Rust's awesome Iterator trait to produce a sequence of values and output features.
+    for (value, feature) in values.take(num_keys).zip(features.take(num_keys)) {
+        let fc = factories.clone();
+        let mut txc = tx.clone();
+        // Notice the `spawn(.. spawn_blocking)` nested call here. If we don't do this, we're basically queuing up
+        // blocking tasks, `await`ing them to finish, and then queueing up the next one. In effect we're running things
+        // synchronously.
+        // What this construction says is: Queue up this task, and move on. "this task" (the spawning of the blocking
+        // task and awaiting its result) is not run immediately, but pushed to the scheduler to execute when it's
+        // ready. Now, we will use all the available threads for generating the keys (and the output should print
+        // "Go!" before, or right the beginning of any key generation output.
+        task::spawn(async move {
+            let result = task::spawn_blocking(move || {
+                let (utxo, key) = helpers::create_utxo(value, &fc, Some(feature));
+                print!(".");
+                (utxo, key, value)
+            })
+            .await
+            .expect("Could not create key");
+            let _ = txc.send(result).await;
+        });
+    }
+    println!("Go!");
+    // Explicitly drop the tx side here, so that rx will end its input.
+    drop(tx);
+
+    let _res = write_fut.await;
+    Ok(())
+}
+
+async fn write_keys(mut rx: mpsc::Receiver<(TransactionOutput, PrivateKey, MicroTari)>) {
+    let mut utxo_file = File::create("utxos.json").expect("Could not create utxos.json");
+    let mut key_file = File::create("keys.json").expect("Could not create keys.json");
+    let mut written: u64 = 0;
+    // The receiver channel will patiently await results until the tx is dropped.
+    while let Some((utxo, key, value)) = rx.recv().await {
+        let key = Key {
+            key: key.to_hex(),
+            value: u64::from(value),
+            commitment: utxo.commitment.to_hex(),
+            proof: utxo.proof.to_hex(),
+        };
+        let key_str = format!("{}\n", serde_json::to_string(&key).unwrap());
+        let _ = key_file.write_all(key_str.as_bytes());
+
+        let utxo_s = serde_json::to_string(&utxo).unwrap();
+        match utxo_file.write_all(format!("{}\n", utxo_s).as_bytes()) {
+            Ok(_) => {
+                written += 1;
+                if written % 50 == 0 {
+                    println!("{} outputs written", written);
+                }
+            },
+            Err(e) => println!("{}", e.to_string()),
+        }
+    }
+    println!("Done.");
+}
+
+struct Values;
+
+impl Iterator for Values {
+    type Item = MicroTari;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let mut rng = rand::rngs::OsRng;
+        let extra = rng.gen_range(0, 25) * 10_000_000;
+        Some(5000 * T + MicroTari(extra))
+    }
+}
+
+struct UTXOFeatures;
+
+impl Iterator for UTXOFeatures {
+    type Item = OutputFeatures;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let f = OutputFeatures::with_maturity(0);
+        Some(f)
+    }
+}

--- a/base_layer/core/Cargo.toml
+++ b/base_layer/core/Cargo.toml
@@ -15,6 +15,7 @@ transactions = []
 mempool_proto = []
 base_node = []
 base_node_proto = []
+avx2 = ["tari_crypto/avx2"]
 
 [dependencies]
 tari_comms = { version = "^0.0", path = "../../comms"}

--- a/base_layer/core/src/lib.rs
+++ b/base_layer/core/src/lib.rs
@@ -60,3 +60,4 @@ pub mod transactions;
 
 // Re-export the crypto crate to make exposing traits etc easier for clients of this crate
 pub use tari_crypto as crypto;
+pub use tari_utilities;

--- a/base_layer/core/src/transactions/helpers.rs
+++ b/base_layer/core/src/transactions/helpers.rs
@@ -347,11 +347,17 @@ pub fn create_test_kernel(fee: MicroTari, lock_height: u64) -> TransactionKernel
 }
 
 /// Create a new UTXO for the specified value and return the output and spending key
-pub fn create_utxo(value: MicroTari, factories: &CryptoFactories) -> (TransactionOutput, PrivateKey) {
+pub fn create_utxo(
+    value: MicroTari,
+    factories: &CryptoFactories,
+    features: Option<OutputFeatures>,
+) -> (TransactionOutput, PrivateKey)
+{
     let keys = generate_keys();
+    let features = features.unwrap_or_default();
     let commitment = factories.commitment.commit_value(&keys.k, value.into());
     let proof = factories.range_proof.construct_proof(&keys.k, value.into()).unwrap();
-    let utxo = TransactionOutput::new(OutputFeatures::default(), commitment, proof.into());
+    let utxo = TransactionOutput::new(features, commitment, proof.into());
     (utxo, keys.k)
 }
 

--- a/base_layer/core/tests/chain_storage_tests/chain_backend.rs
+++ b/base_layer/core/tests/chain_storage_tests/chain_backend.rs
@@ -91,7 +91,7 @@ fn lmdb_insert_contains_delete_and_fetch_header() {
 
 fn insert_contains_delete_and_fetch_utxo<T: BlockchainBackend>(db: T) {
     let factories = CryptoFactories::default();
-    let (utxo, _) = create_utxo(MicroTari(10_000), &factories);
+    let (utxo, _) = create_utxo(MicroTari(10_000), &factories, None);
     let hash = utxo.hash();
     assert_eq!(db.contains(&DbKey::UnspentOutput(hash.clone())), Ok(false));
 
@@ -198,8 +198,8 @@ fn lmdb_insert_contains_delete_and_fetch_orphan() {
 
 fn spend_utxo_and_unspend_stxo<T: BlockchainBackend>(db: T) {
     let factories = CryptoFactories::default();
-    let (utxo1, _) = create_utxo(MicroTari(10_000), &factories);
-    let (utxo2, _) = create_utxo(MicroTari(15_000), &factories);
+    let (utxo1, _) = create_utxo(MicroTari(10_000), &factories, None);
+    let (utxo2, _) = create_utxo(MicroTari(15_000), &factories, None);
     let hash1 = utxo1.hash();
     let hash2 = utxo2.hash();
 
@@ -348,9 +348,9 @@ fn fetch_mmr_root_and_proof_for_utxo_and_rp<T: BlockchainBackend>(db: T) {
     );
     let factories = CryptoFactories::default();
 
-    let (utxo1, _) = create_utxo(MicroTari(10_000), &factories);
-    let (utxo2, _) = create_utxo(MicroTari(15_000), &factories);
-    let (utxo3, _) = create_utxo(MicroTari(20_000), &factories);
+    let (utxo1, _) = create_utxo(MicroTari(10_000), &factories, None);
+    let (utxo2, _) = create_utxo(MicroTari(15_000), &factories, None);
+    let (utxo3, _) = create_utxo(MicroTari(20_000), &factories, None);
     let utxo_hash1 = utxo1.hash();
     let utxo_hash2 = utxo2.hash();
     let utxo_hash3 = utxo3.hash();
@@ -464,10 +464,10 @@ fn lmdb_fetch_mmr_root_and_proof_for_kernel() {
 fn fetch_future_mmr_root_for_utxo_and_rp<T: BlockchainBackend>(db: T) {
     let factories = CryptoFactories::default();
 
-    let (utxo1, _) = create_utxo(MicroTari(10_000), &factories);
-    let (utxo2, _) = create_utxo(MicroTari(15_000), &factories);
-    let (utxo3, _) = create_utxo(MicroTari(20_000), &factories);
-    let (utxo4, _) = create_utxo(MicroTari(24_000), &factories);
+    let (utxo1, _) = create_utxo(MicroTari(10_000), &factories, None);
+    let (utxo2, _) = create_utxo(MicroTari(15_000), &factories, None);
+    let (utxo3, _) = create_utxo(MicroTari(20_000), &factories, None);
+    let (utxo4, _) = create_utxo(MicroTari(24_000), &factories, None);
     let utxo_hash1 = utxo1.hash();
     let utxo_hash3 = utxo3.hash();
     let utxo_hash4 = utxo4.hash();
@@ -553,7 +553,7 @@ fn lmdb_fetch_future_mmr_root_for_for_kernel() {
 
 fn commit_block_and_create_fetch_checkpoint_and_rewind_mmr<T: BlockchainBackend>(db: T) {
     let factories = CryptoFactories::default();
-    let (utxo1, _) = create_utxo(MicroTari(10_000), &factories);
+    let (utxo1, _) = create_utxo(MicroTari(10_000), &factories, None);
     let kernel1 = create_test_kernel(100.into(), 0);
     let header1 = BlockHeader::new(0);
     let utxo_hash1 = utxo1.hash();
@@ -567,7 +567,7 @@ fn commit_block_and_create_fetch_checkpoint_and_rewind_mmr<T: BlockchainBackend>
     txn.commit_block();
     assert!(db.write(txn).is_ok());
 
-    let (utxo2, _) = create_utxo(MicroTari(15_000), &factories);
+    let (utxo2, _) = create_utxo(MicroTari(15_000), &factories, None);
     let kernel2 = create_test_kernel(200.into(), 0);
     let header2 = BlockHeader::from_previous(&header1);
     let utxo_hash2 = utxo2.hash();
@@ -793,9 +793,9 @@ fn lmdb_for_each_header() {
 
 fn for_each_utxo<T: BlockchainBackend>(db: T) {
     let factories = CryptoFactories::default();
-    let (utxo1, _) = create_utxo(MicroTari(10_000), &factories);
-    let (utxo2, _) = create_utxo(MicroTari(15_000), &factories);
-    let (utxo3, _) = create_utxo(MicroTari(20_000), &factories);
+    let (utxo1, _) = create_utxo(MicroTari(10_000), &factories, None);
+    let (utxo2, _) = create_utxo(MicroTari(15_000), &factories, None);
+    let (utxo3, _) = create_utxo(MicroTari(20_000), &factories, None);
     let hash1 = utxo1.hash();
     let hash2 = utxo2.hash();
     let hash3 = utxo3.hash();
@@ -845,8 +845,8 @@ fn lmdb_backend_restore() {
 
     let txs = vec![(tx!(1000.into(), fee: 20.into(), inputs: 2, outputs: 1)).0];
     let orphan = create_orphan_block(10, txs);
-    let (utxo1, _) = create_utxo(MicroTari(10_000), &factories);
-    let (utxo2, _) = create_utxo(MicroTari(15_000), &factories);
+    let (utxo1, _) = create_utxo(MicroTari(10_000), &factories, None);
+    let (utxo2, _) = create_utxo(MicroTari(15_000), &factories, None);
     let kernel = create_test_kernel(100.into(), 0);
     let mut header = BlockHeader::new(0);
     header.height = 1;
@@ -894,8 +894,8 @@ fn lmdb_mmr_reset_and_commit() {
     let factories = CryptoFactories::default();
     let db = create_lmdb_database(&create_temporary_data_path(), MmrCacheConfig::default()).unwrap();
 
-    let (utxo1, _) = create_utxo(MicroTari(10_000), &factories);
-    let (utxo2, _) = create_utxo(MicroTari(15_000), &factories);
+    let (utxo1, _) = create_utxo(MicroTari(10_000), &factories, None);
+    let (utxo2, _) = create_utxo(MicroTari(15_000), &factories, None);
     let kernel1 = create_test_kernel(100.into(), 0);
     let kernel2 = create_test_kernel(200.into(), 0);
     let mut header1 = BlockHeader::new(0);
@@ -977,7 +977,7 @@ fn lmdb_mmr_reset_and_commit() {
 
 fn fetch_checkpoint<T: BlockchainBackend>(db: T) {
     let factories = CryptoFactories::default();
-    let (utxo1, _) = create_utxo(MicroTari(10_000), &factories);
+    let (utxo1, _) = create_utxo(MicroTari(10_000), &factories, None);
     let kernel1 = create_test_kernel(100.into(), 0);
     let mut header1 = BlockHeader::new(0);
     header1.height = 0;
@@ -992,7 +992,7 @@ fn fetch_checkpoint<T: BlockchainBackend>(db: T) {
     txn.commit_block();
     assert!(db.write(txn).is_ok());
 
-    let (utxo2, _) = create_utxo(MicroTari(15_000), &factories);
+    let (utxo2, _) = create_utxo(MicroTari(15_000), &factories, None);
     let kernel2 = create_test_kernel(200.into(), 0);
     let header2 = BlockHeader::from_previous(&header1);
     let utxo_hash2 = utxo2.hash();
@@ -1019,7 +1019,7 @@ fn fetch_checkpoint<T: BlockchainBackend>(db: T) {
     assert!(rp_cp0.unwrap().nodes_added().contains(&rp_hash1));
     assert!(rp_cp1.unwrap().nodes_added().contains(&rp_hash2));
 
-    let (utxo3, _) = create_utxo(MicroTari(20_000), &factories);
+    let (utxo3, _) = create_utxo(MicroTari(20_000), &factories, None);
     let kernel3 = create_test_kernel(300.into(), 0);
     let header3 = BlockHeader::from_previous(&header2);
     let utxo_hash3 = utxo3.hash();
@@ -1069,8 +1069,8 @@ fn lmdb_fetch_checkpoint() {
 
 fn duplicate_utxo<T: BlockchainBackend>(db: T) {
     let factories = CryptoFactories::default();
-    let (utxo1, _) = create_utxo(MicroTari(10_000), &factories);
-    let (utxo2, _) = create_utxo(MicroTari(15_000), &factories);
+    let (utxo1, _) = create_utxo(MicroTari(10_000), &factories, None);
+    let (utxo2, _) = create_utxo(MicroTari(15_000), &factories, None);
     let hash1 = utxo1.hash();
 
     let mut txn = DbTransaction::new();

--- a/base_layer/core/tests/chain_storage_tests/chain_storage.rs
+++ b/base_layer/core/tests/chain_storage_tests/chain_storage.rs
@@ -114,7 +114,7 @@ fn insert_and_fetch_header() {
 fn insert_and_fetch_utxo() {
     let factories = CryptoFactories::default();
     let store = create_mem_db();
-    let (utxo, _) = create_utxo(MicroTari(10_000), &factories);
+    let (utxo, _) = create_utxo(MicroTari(10_000), &factories, None);
     let hash = utxo.hash();
     assert_eq!(store.is_utxo(hash.clone()).unwrap(), false);
     let mut txn = DbTransaction::new();
@@ -181,8 +181,8 @@ fn utxo_and_rp_merkle_root() {
         &root.to_hex(),
         "26146a5435ef15e8cf7dc3354cb7268137e8be211794e93d04551576c6561565"
     );
-    let (utxo1, _) = create_utxo(MicroTari(10_000), &factories);
-    let (utxo2, _) = create_utxo(MicroTari(10_000), &factories);
+    let (utxo1, _) = create_utxo(MicroTari(10_000), &factories, None);
+    let (utxo2, _) = create_utxo(MicroTari(10_000), &factories, None);
     let hash1 = utxo1.hash();
     let hash2 = utxo2.hash();
     // Calculate the Range proof MMR root as a check
@@ -236,8 +236,8 @@ fn utxo_and_rp_future_merkle_root() {
     let store = create_mem_db();
     let factories = CryptoFactories::default();
 
-    let (utxo1, _) = create_utxo(MicroTari(10_000), &factories);
-    let (utxo2, _) = create_utxo(MicroTari(15_000), &factories);
+    let (utxo1, _) = create_utxo(MicroTari(10_000), &factories, None);
+    let (utxo2, _) = create_utxo(MicroTari(15_000), &factories, None);
     let utxo_hash2 = utxo2.hash();
     let rp_hash2 = utxo2.proof.hash();
 
@@ -300,9 +300,9 @@ fn utxo_and_rp_mmr_proof() {
     let store = create_mem_db();
     let factories = CryptoFactories::default();
 
-    let (utxo1, _) = create_utxo(MicroTari(5_000), &factories);
-    let (utxo2, _) = create_utxo(MicroTari(10_000), &factories);
-    let (utxo3, _) = create_utxo(MicroTari(15_000), &factories);
+    let (utxo1, _) = create_utxo(MicroTari(5_000), &factories, None);
+    let (utxo2, _) = create_utxo(MicroTari(10_000), &factories, None);
+    let (utxo3, _) = create_utxo(MicroTari(15_000), &factories, None);
     let mut txn = DbTransaction::new();
     txn.insert_utxo(utxo1.clone(), true);
     txn.insert_utxo(utxo2.clone(), true);
@@ -731,9 +731,9 @@ fn total_kernel_offset() {
 fn total_utxo_commitment() {
     let factories = CryptoFactories::default();
     let store = create_mem_db();
-    let (utxo1, _) = create_utxo(MicroTari(10_000), &factories);
-    let (utxo2, _) = create_utxo(MicroTari(15_000), &factories);
-    let (utxo3, _) = create_utxo(MicroTari(20_000), &factories);
+    let (utxo1, _) = create_utxo(MicroTari(10_000), &factories, None);
+    let (utxo2, _) = create_utxo(MicroTari(15_000), &factories, None);
+    let (utxo3, _) = create_utxo(MicroTari(20_000), &factories, None);
 
     let mut txn = DbTransaction::new();
     txn.insert_utxo(utxo1.clone(), true);

--- a/base_layer/core/tests/helpers/block_builders.rs
+++ b/base_layer/core/tests/helpers/block_builders.rs
@@ -55,7 +55,7 @@ fn create_coinbase(
 ) -> (TransactionOutput, TransactionKernel, UnblindedOutput)
 {
     let features = OutputFeatures::create_coinbase(100);
-    let (mut utxo, key) = create_utxo(value, &factories);
+    let (mut utxo, key) = create_utxo(value, &factories, None);
     utxo.features = features.clone();
     let excess = Commitment::from_public_key(&PublicKey::from_secret_key(&key));
     let (_pk, sig) = create_random_signature(0.into(), 0);
@@ -87,7 +87,7 @@ pub fn create_act_gen_block() {
     let mut header = BlockHeader::new(0);
     let emission_schedule = EmissionSchedule::new(10_000_000.into(), 0.999, 100.into());
     let value = emission_schedule.supply_at_block(0);
-    let (mut utxo, key) = create_utxo(value, &factories);
+    let (mut utxo, key) = create_utxo(value, &factories, None);
     utxo.features = OutputFeatures::create_coinbase(1);
     let (pk, sig) = create_random_signature_from_s_key(key.clone(), 0.into(), 0);
     let excess = Commitment::from_public_key(&pk);
@@ -152,7 +152,7 @@ where
 {
     let (mut template, coinbase) = genesis_template(&factories, 100_000_000.into());
     let outputs = values.iter().fold(vec![coinbase], |mut secrets, v| {
-        let (t, k) = create_utxo(*v, factories);
+        let (t, k) = create_utxo(*v, factories, None);
         template.body.add_output(t);
         secrets.push(UnblindedOutput::new(v.clone(), k, None));
         secrets

--- a/base_layer/core/tests/node_comms_interface.rs
+++ b/base_layer/core/tests/node_comms_interface.rs
@@ -256,7 +256,7 @@ fn outbound_fetch_utxos() {
     let mut outbound_nci = OutboundNodeCommsInterface::new(request_sender, block_sender);
 
     block_on(async {
-        let (utxo, _) = create_utxo(MicroTari(10_000), &factories);
+        let (utxo, _) = create_utxo(MicroTari(10_000), &factories, None);
         let hash = utxo.hash();
         let utxo_response: Vec<NodeCommsResponse> = vec![NodeCommsResponse::TransactionOutputs(vec![utxo.clone()])];
         let (received_utxos, _) = futures::join!(
@@ -288,7 +288,7 @@ fn inbound_fetch_utxos() {
         outbound_nci,
     );
 
-    let (utxo, _) = create_utxo(MicroTari(10_000), &factories);
+    let (utxo, _) = create_utxo(MicroTari(10_000), &factories, None);
     let hash = utxo.hash();
     let mut txn = DbTransaction::new();
     txn.insert_utxo(utxo.clone(), true);

--- a/base_layer/core/tests/node_service.rs
+++ b/base_layer/core/tests/node_service.rs
@@ -184,8 +184,8 @@ fn request_and_response_fetch_utxos() {
     let (mut alice_node, bob_node, carol_node) =
         create_network_with_3_base_nodes(&mut runtime, temp_dir.path().to_str().unwrap());
 
-    let (utxo1, _) = create_utxo(MicroTari(10_000), &factories);
-    let (utxo2, _) = create_utxo(MicroTari(15_000), &factories);
+    let (utxo1, _) = create_utxo(MicroTari(10_000), &factories, None);
+    let (utxo2, _) = create_utxo(MicroTari(15_000), &factories, None);
     let hash1 = utxo1.hash();
     let hash2 = utxo2.hash();
 


### PR DESCRIPTION
To help wallet users get some testnet Tari to play with, we're
adding some utxos to the genesis block that they can claim
from their mobile wallet apps.

This PR add a small application that generates the faucet UTXOs
and private keys.

The UTXOs will be added to the alpha-net genesis block.

The `create_utxo` helper function was extended to accept `OutputFeatures`

