### PR TITLE
Network genesis block refactor

### DIFF
--- a/applications/tari_base_node/src/builder.rs
+++ b/applications/tari_base_node/src/builder.rs
@@ -231,11 +231,11 @@ pub fn configure_and_initialize_node(
         DatabaseType::Memory => {
             let rules = ConsensusManager::default();
             let backend = MemoryDatabase::<HashDigest>::default();
-            let mut db = BlockchainDatabase::new(backend).map_err(|e| e.to_string())?;
+            let mut db = BlockchainDatabase::new(backend, &rules).map_err(|e| e.to_string())?;
             let validators = Validators::new(
                 FullConsensusValidator::new(rules.clone(), factories.clone(), db.clone()),
                 StatelessValidator::new(),
-                GenesisBlockValidator::new(),
+                GenesisBlockValidator::new(rules.clone()),
                 ChainTipValidator::new(rules.clone(), factories.clone(), db.clone()),
             );
             db.set_validators(validators);
@@ -291,11 +291,11 @@ pub fn configure_and_initialize_node(
         DatabaseType::LMDB(p) => {
             let rules = ConsensusManager::default();
             let backend = create_lmdb_database(&p, MmrCacheConfig::default()).map_err(|e| e.to_string())?;
-            let mut db = BlockchainDatabase::new(backend).map_err(|e| e.to_string())?;
+            let mut db = BlockchainDatabase::new(backend, &rules).map_err(|e| e.to_string())?;
             let validators = Validators::new(
                 FullConsensusValidator::new(rules.clone(), factories.clone(), db.clone()),
                 StatelessValidator::new(),
-                GenesisBlockValidator::new(),
+                GenesisBlockValidator::new(rules.clone()),
                 ChainTipValidator::new(rules.clone(), factories.clone(), db.clone()),
             );
             db.set_validators(validators);

--- a/base_layer/core/src/blocks/genesis_block.rs
+++ b/base_layer/core/src/blocks/genesis_block.rs
@@ -36,8 +36,21 @@ use crate::transactions::{
 use tari_crypto::tari_utilities::{hash::Hashable, hex::*};
 
 // TODO: see issue #1145
-// The values contain in this block is temporary. They should be replaced by the actual values before test net.
-pub fn get_genesis_block() -> Block {
+// The values contain in these blocks are temporary. They should be replaced by the actual values before test net.
+
+pub fn get_mainnet_genesis_block() -> Block {
+    unimplemented!()
+}
+
+pub fn get_mainnet_block_hash() -> Vec<u8> {
+    get_mainnet_genesis_block().hash()
+}
+
+pub fn get_mainnet_gen_header() -> BlockHeader {
+    get_mainnet_genesis_block().header
+}
+
+pub fn get_rincewind_genesis_block() -> Block {
     let sig = Signature::new(
         PublicKey::from_hex("82f5e603783cfe8b7d50ec1fefb7841398bffcadcb6102dae1f83b533f0aec41").unwrap(),
         PrivateKey::from_hex("05af349cb5618e636021ca66a3fd21067b6f9b159b75b7783985a534726fe509").unwrap(),
@@ -96,10 +109,10 @@ pub fn get_genesis_block() -> Block {
     }
 }
 
-pub fn get_gen_block_hash() -> Vec<u8> {
-    get_genesis_block().hash()
+pub fn get_rincewind_block_hash() -> Vec<u8> {
+    get_rincewind_genesis_block().hash()
 }
 
-pub fn get_gen_header() -> BlockHeader {
-    get_genesis_block().header
+pub fn get_rincewind_gen_header() -> BlockHeader {
+    get_rincewind_genesis_block().header
 }

--- a/base_layer/core/src/blocks/new_blockheader_template.rs
+++ b/base_layer/core/src/blocks/new_blockheader_template.rs
@@ -28,7 +28,6 @@ use crate::{
     proof_of_work::ProofOfWork,
     transactions::types::BlindingFactor,
 };
-use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use std::fmt::{Display, Error, Formatter};
 use tari_crypto::tari_utilities::hex::Hex;

--- a/base_layer/core/src/chain_storage/lmdb_db/lmdb_db.rs
+++ b/base_layer/core/src/chain_storage/lmdb_db/lmdb_db.rs
@@ -53,7 +53,6 @@ use digest::Digest;
 use lmdb_zero::{Database, Environment, WriteTransaction};
 use log::*;
 use std::{
-    fmt::Debug,
     path::Path,
     sync::{Arc, RwLock},
 };

--- a/base_layer/core/src/consensus/mod.rs
+++ b/base_layer/core/src/consensus/mod.rs
@@ -22,8 +22,10 @@
 
 mod consensus_constants;
 mod consensus_manager;
+mod network;
 
 pub mod emission;
 
 pub use consensus_constants::ConsensusConstants;
 pub use consensus_manager::{ConsensusManager, ConsensusManagerError};
+pub use network::Network;

--- a/base_layer/core/src/consensus/network.rs
+++ b/base_layer/core/src/consensus/network.rs
@@ -20,33 +20,44 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use tari_core::{
-    chain_storage::{BlockchainDatabase, MemoryDatabase, Validators},
-    consensus::ConsensusManager,
-    proof_of_work::DiffAdjManager,
-    transactions::types::{CryptoFactories, HashDigest},
-    validation::{
-        block_validators::{FullConsensusValidator, StatelessValidator},
-        mocks::MockValidator,
+use crate::blocks::{
+    genesis_block::{
+        get_mainnet_block_hash,
+        get_mainnet_genesis_block,
+        get_rincewind_block_hash,
+        get_rincewind_genesis_block,
     },
+    Block,
 };
+use tari_crypto::tari_utilities::hash::Hashable;
 
-#[test]
-fn test_genesis_block() {
-    let factories = CryptoFactories::default();
-    let rules = ConsensusManager::default();
-    let backend = MemoryDatabase::<HashDigest>::default();
-    let mut db = BlockchainDatabase::new(backend, &rules).unwrap();
-    let validators = Validators::new(
-        FullConsensusValidator::new(rules.clone(), factories, db.clone()),
-        StatelessValidator::new(),
-        MockValidator::new(true),
-        MockValidator::new(true),
-    );
-    db.set_validators(validators);
-    let diff_adj_manager = DiffAdjManager::new(db.clone()).unwrap();
-    rules.set_diff_manager(diff_adj_manager).unwrap();
-    let block = rules.get_genesis_block();
-    let result = db.add_block(block);
-    assert!(result.is_ok());
+/// Specifies the configured chain network.
+pub enum Network {
+    /// Mainnet of Tari, currently should panic if network is set to this.
+    MainNet,
+    /// Alpha net version
+    Rincewind,
+    /// Local network constants used inside of unit and integration tests. Contains the genesis block to be used for
+    /// that chain.
+    LocalNet(Box<Block>),
+}
+
+impl Network {
+    /// Returns the genesis block for the selected network.
+    pub fn get_genesis_block(&self) -> Block {
+        match self {
+            Network::MainNet => get_mainnet_genesis_block(),
+            Network::Rincewind => get_rincewind_genesis_block(),
+            Network::LocalNet(genesis_block) => (**genesis_block).clone(),
+        }
+    }
+
+    /// Returns the genesis block hash for the selected network.
+    pub fn get_genesis_block_hash(&self) -> Vec<u8> {
+        match self {
+            Network::MainNet => get_mainnet_block_hash(),
+            Network::Rincewind => get_rincewind_block_hash(),
+            Network::LocalNet(genesis_block) => (**genesis_block).hash(),
+        }
+    }
 }

--- a/base_layer/core/src/helpers/mod.rs
+++ b/base_layer/core/src/helpers/mod.rs
@@ -28,6 +28,7 @@ mod mock_backend;
 use crate::{
     blocks::{Block, BlockBuilder, BlockHeader},
     chain_storage::{BlockchainDatabase, MemoryDatabase, Validators},
+    consensus::{ConsensusConstants, ConsensusManager, Network},
     transactions::{transaction::Transaction, types::HashDigest},
     validation::mocks::MockValidator,
 };
@@ -45,15 +46,16 @@ pub fn create_orphan_block(block_height: u64, transactions: Vec<Transaction>) ->
         .build()
 }
 
-pub fn create_mem_db() -> BlockchainDatabase<MemoryDatabase<HashDigest>> {
+pub fn create_mem_db(network: Network) -> BlockchainDatabase<MemoryDatabase<HashDigest>> {
     let validators = Validators::new(
         MockValidator::new(true),
         MockValidator::new(true),
         MockValidator::new(true),
         MockValidator::new(true),
     );
+    let rules = ConsensusManager::new(None, ConsensusConstants::current_with_network(network));
     let db = MemoryDatabase::<HashDigest>::default();
-    let mut db = BlockchainDatabase::new(db).unwrap();
+    let mut db = BlockchainDatabase::new(db, &rules).unwrap();
     db.set_validators(validators);
     db
 }

--- a/base_layer/core/src/mempool/orphan_pool/orphan_pool.rs
+++ b/base_layer/core/src/mempool/orphan_pool/orphan_pool.rs
@@ -152,6 +152,7 @@ where T: BlockchainBackend
 #[cfg(test)]
 mod test {
     use crate::{
+        consensus::Network,
         helpers::create_mem_db,
         mempool::orphan_pool::{OrphanPool, OrphanPoolConfig},
         transactions::tari_amount::MicroTari,
@@ -169,7 +170,7 @@ mod test {
         let tx5 = Arc::new(tx!(MicroTari(10_000), fee: MicroTari(500), lock: 2000, inputs: 2, outputs: 1).0);
         let tx6 = Arc::new(tx!(MicroTari(10_000), fee: MicroTari(600), lock: 5500, inputs: 2, outputs: 1).0);
 
-        let store = create_mem_db();
+        let store = create_mem_db(Network::Rincewind);
         let mempool_validator = Box::new(TxInputAndMaturityValidator::new(store.clone()));
         let orphan_pool = OrphanPool::new(
             OrphanPoolConfig {

--- a/base_layer/core/src/validation/helpers.rs
+++ b/base_layer/core/src/validation/helpers.rs
@@ -21,10 +21,7 @@
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 use crate::{
-    blocks::{
-        blockheader::{BlockHeader, BlockHeaderValidationError},
-        genesis_block::get_gen_block_hash,
-    },
+    blocks::blockheader::{BlockHeader, BlockHeaderValidationError},
     chain_storage::{BlockchainBackend, BlockchainDatabase},
     consensus::ConsensusManager,
     proof_of_work::PowError,
@@ -60,7 +57,7 @@ pub fn check_median_timestamp<B: BlockchainBackend>(
     rules: ConsensusManager<B>,
 ) -> Result<(), ValidationError>
 {
-    if block_header.height == 0 || get_gen_block_hash() == block_header.hash() {
+    if block_header.height == 0 || rules.get_genesis_block_hash() == block_header.hash() {
         return Ok(()); // Its the genesis block, so we dont have to check median
     }
     let median_timestamp = rules
@@ -107,7 +104,7 @@ pub fn check_achieved_difficulty<B: BlockchainBackend>(
 {
     let achieved = block_header.achieved_difficulty();
     let mut target = 1.into();
-    if block_header.height > 0 || get_gen_block_hash() != block_header.hash() {
+    if block_header.height > 0 || rules.get_genesis_block_hash() != block_header.hash() {
         target = rules
             .get_target_difficulty_with_height(&block_header.pow.pow_algo, height)
             .or_else(|e| {

--- a/base_layer/core/tests/helpers/sample_blockchains.rs
+++ b/base_layer/core/tests/helpers/sample_blockchains.rs
@@ -25,14 +25,15 @@ use crate::helpers::block_builders::{create_genesis_block, generate_new_block};
 
 use tari_core::{
     blocks::Block,
-    chain_storage::{BlockchainDatabase, MemoryDatabase, Validators},
+    chain_storage::{BlockchainDatabase, MemoryDatabase},
+    consensus::Network,
+    helpers::create_mem_db,
     transactions::{
         tari_amount::{uT, T},
         transaction::UnblindedOutput,
         types::{CryptoFactories, HashDigest},
     },
     txn_schema,
-    validation::mocks::MockValidator,
 };
 
 /// Create a simple 6 block memory-backed database.
@@ -122,22 +123,7 @@ pub fn create_new_blockchain() -> (
     Vec<Vec<UnblindedOutput>>,
 ) {
     let factories = CryptoFactories::default();
-    // We may need move this to the parameters to provide more fine-grained validator control
-    let validators = Validators::new(
-        MockValidator::new(true),
-        MockValidator::new(true),
-        MockValidator::new(true),
-        MockValidator::new(true),
-    );
-    let db = MemoryDatabase::<HashDigest>::default();
-    let mut db = BlockchainDatabase::new(db).unwrap();
-    db.set_validators(validators);
-    let mut outputs = Vec::new();
-    let mut blocks = Vec::new();
-    // Genesis Block
-    let (block0, utxo) = create_genesis_block(&db, &factories);
-    db.add_block(block0.clone()).unwrap();
-    blocks.push(block0);
-    outputs.push(vec![utxo]);
-    (db, blocks, outputs)
+    let (block0, output) = create_genesis_block(&factories);
+    let db = create_mem_db(Network::LocalNet(Box::new(block0.clone())));
+    (db, vec![block0], vec![vec![output]])
 }


### PR DESCRIPTION
## Description
- When a blockchain db is created using a provided storage backend, it will check if the backend has a genesis block. If it doesn’t, it will use the Consensus manager to add the correct genesis block to the blockchain db depending on the configured network.
- Added a Network enum for configuring the chain network and retrieving the correct genesis block that should be used for that network.
- ConsensusConstants was added to the ConsensusManager and the network configuration was added to the ConsensusConstants with methods to access the configured network and retrieving the genesis block of the specified network.
- The dependency on the blockchain db was removed from the create genesis block functions to remove a circle dependency issue. An update_genesis_block_mmr_roots function was added to ensure that the MMR roots of the created genesis block header could still be correctly updated without access to the blockchain db.
- The test base node builder was updated to allow the configuration of the consensus manager.

## Motivation and Context
This PR will ensure that a base node always has a genesis block based on the configured chain network.

## How Has This Been Tested?
Updated the existing tests to make use if the new network genesis block functionality.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [x] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch
* [x] I ran `cargo-fmt --all` before pushing
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
