### PR TITLE
Fix for flaky propagation tests

### DIFF
--- a/base_layer/core/tests/helpers/nodes.rs
+++ b/base_layer/core/tests/helpers/nodes.rs
@@ -196,7 +196,12 @@ impl BaseNodeBuilder {
                 self.base_node_service_config
                     .unwrap_or(BaseNodeServiceConfig::default()),
                 self.mempool_service_config.unwrap_or(MempoolServiceConfig::default()),
-                self.liveness_service_config.unwrap_or(LivenessConfig::default()),
+                self.liveness_service_config.unwrap_or(LivenessConfig {
+                    auto_ping_interval: None,
+                    enable_auto_join: false,
+                    enable_auto_stored_message_request: true,
+                    refresh_neighbours_interval: Duration::from_secs(3 * 60),
+                }),
                 data_path,
             );
 


### PR DESCRIPTION
## Description
Disabled auto network join for all network based tests, there seems to be a connection collision.

## Motivation and Context
This PR is required to ensure the liveness service doesn't auto join the network resulting in the tests failing.

## How Has This Been Tested?
Tests were modified.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch
* [x] I ran `cargo-fmt --all` before pushing
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
