### PR TITLE
Implement Base Node Syncing for Wallet Output Manager Service

### DIFF
--- a/applications/tari_base_node/src/builder.rs
+++ b/applications/tari_base_node/src/builder.rs
@@ -21,7 +21,7 @@
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 use crate::miner;
-use futures::channel::mpsc::Receiver;
+use futures::{channel::mpsc::Receiver, stream};
 use log::*;
 use rand::rngs::OsRng;
 use std::{
@@ -80,6 +80,7 @@ use tokio::runtime::Runtime;
 use tari_core::tari_utilities::{hex::Hex, message_format::MessageFormat};
 use tari_wallet::{
     output_manager_service::{
+        config::OutputManagerServiceConfig,
         handle::OutputManagerHandle,
         storage::sqlite_db::OutputManagerSqliteDatabase,
         OutputManagerServiceInitializer,
@@ -470,6 +471,8 @@ where
             node_config,
         ))
         .add_initializer(OutputManagerServiceInitializer::new(
+            OutputManagerServiceConfig::default(),
+            subscription_factory.clone(),
             OutputManagerSqliteDatabase::new(connection_pool.clone()),
             factories.clone(),
         ))

--- a/base_layer/wallet/migrations/2019-10-30-084148_output_manager_service/up.sql
+++ b/base_layer/wallet/migrations/2019-10-30-084148_output_manager_service/up.sql
@@ -3,9 +3,7 @@ CREATE TABLE outputs (
     value INTEGER NOT NULL,
     flags INTEGER NOT NULL,
     maturity INTEGER NOT NULL,
-    spent INTEGER NOT NULL DEFAULT 0,
-    to_be_received INTEGER NOT NULL DEFAULT 0,
-    encumbered INTEGER NOT NULL DEFAULT 0,
+    status INTEGER NOT NULL,
     tx_id INTEGER NULL,
     FOREIGN KEY(tx_id) REFERENCES pending_transaction_outputs(tx_id)
 );

--- a/base_layer/wallet/src/output_manager_service/config.rs
+++ b/base_layer/wallet/src/output_manager_service/config.rs
@@ -1,0 +1,34 @@
+// Copyright 2020. The Tari Project
+//
+// Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+// following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+// disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+// following disclaimer in the documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+// products derived from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+// INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+// WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+// USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#[derive(Clone)]
+pub struct OutputManagerServiceConfig {
+    pub base_node_query_timeout_in_secs: u64,
+}
+
+impl Default for OutputManagerServiceConfig {
+    fn default() -> Self {
+        Self {
+            base_node_query_timeout_in_secs: 30,
+        }
+    }
+}

--- a/base_layer/wallet/src/output_manager_service/error.rs
+++ b/base_layer/wallet/src/output_manager_service/error.rs
@@ -23,13 +23,14 @@
 use crate::output_manager_service::storage::database::DbKey;
 use derive_error::Error;
 use diesel::result::Error as DieselError;
-use tari_core::transactions::transaction_protocol::TransactionProtocolError;
+use tari_comms_dht::outbound::DhtOutboundError;
+use tari_core::transactions::{transaction::TransactionError, transaction_protocol::TransactionProtocolError};
 use tari_crypto::tari_utilities::ByteArrayError;
 use tari_key_manager::{key_manager::KeyManagerError, mnemonic::MnemonicError};
 use tari_service_framework::reply_channel::TransportChannelError;
 use time::OutOfRangeError;
 
-#[derive(Debug, Error, PartialEq)]
+#[derive(Debug, Error)]
 pub enum OutputManagerError {
     #[error(msg_embedded, no_from, non_std)]
     BuildError(String),
@@ -40,6 +41,10 @@ pub enum OutputManagerError {
     OutputManagerStorageError(OutputManagerStorageError),
     MnemonicError(MnemonicError),
     KeyManagerError(KeyManagerError),
+    TransactionError(TransactionError),
+    DhtOutboundError(DhtOutboundError),
+    #[error(msg_embedded, no_from, non_std)]
+    ConversionError(String),
     /// Not all the transaction inputs and outputs are present to be confirmed
     IncompleteTransaction,
     /// Not enough funds to fulfil transaction
@@ -54,6 +59,12 @@ pub enum OutputManagerError {
     UnexpectedApiResponse,
     /// Invalid config provided to Output Manager
     InvalidConfig,
+    /// The response received from another service is an incorrect variant
+    InvalidResponseError,
+    /// No Base Node public key has been provided for this service to use for contacting a base node
+    NoBaseNodeKeysProvided,
+    /// An error occured sending an event out on the event stream
+    EventStreamError,
 }
 
 #[derive(Debug, Error, PartialEq)]

--- a/base_layer/wallet/src/schema.rs
+++ b/base_layer/wallet/src/schema.rs
@@ -67,9 +67,7 @@ table! {
         value -> BigInt,
         flags -> Integer,
         maturity -> BigInt,
-        spent -> Integer,
-        to_be_received -> Integer,
-        encumbered -> Integer,
+        status -> Integer,
         tx_id -> Nullable<BigInt>,
     }
 }

--- a/base_layer/wallet/tests/output_manager_service/storage.rs
+++ b/base_layer/wallet/tests/output_manager_service/storage.rs
@@ -270,6 +270,17 @@ pub fn test_db_backend<T: OutputManagerBackend + 'static>(backend: T) {
         .block_on(db.fetch_all_pending_transaction_outputs())
         .unwrap()
         .contains_key(&pending_txs[2].tx_id));
+
+    // Test invalidating an output
+    let invalid_outputs = runtime.block_on(db.get_invalid_outputs()).unwrap();
+    assert_eq!(invalid_outputs.len(), 0);
+    let unspent_outputs = runtime.block_on(db.get_unspent_outputs()).unwrap();
+    runtime
+        .block_on(db.invalidate_output(unspent_outputs[0].clone()))
+        .unwrap();
+    let invalid_outputs = runtime.block_on(db.get_invalid_outputs()).unwrap();
+    assert_eq!(invalid_outputs.len(), 1);
+    assert_eq!(invalid_outputs[0], unspent_outputs[0]);
 }
 
 #[test]

--- a/base_layer/wallet_ffi/src/error.rs
+++ b/base_layer/wallet_ffi/src/error.rs
@@ -133,6 +133,10 @@ impl From<WalletError> for LibWalletError {
                 code: 108,
                 message: format!("{:?}", w),
             },
+            WalletError::OutputManagerError(OutputManagerError::NoBaseNodeKeysProvided) => Self {
+                code: 109,
+                message: format!("{:?}", w),
+            },
             // Transaction Service Errors
             WalletError::TransactionServiceError(TransactionServiceError::InvalidStateError) => Self {
                 code: 201,

--- a/base_layer/wallet_ffi/wallet.h
+++ b/base_layer/wallet_ffi/wallet.h
@@ -355,6 +355,9 @@ bool wallet_is_completed_transaction_outbound(struct TariWallet *wallet, struct 
 // event.
 unsigned long long wallet_import_utxo(struct TariWallet *wallet, unsigned long long amount, struct TariPrivateKey *spending_key, struct TariPublicKey *source_public_key, const char *message, int* error_out);
 
+// This function will tell the wallet to query the set base node to confirm the status of wallet data.
+bool wallet_sync_with_base_node(struct TariWallet *wallet, int* error_out);
+
 // Simulates the completion of a broadcasted TariPendingInboundTransaction
 bool wallet_test_broadcast_transaction(struct TariWallet *wallet, struct TariCompletedTransaction *tx, int* error_out);
 


### PR DESCRIPTION
## Description

This PR implements the functionality for the Output Manager to query the base node to confirm the status of stored Unspent Outputs as UTXO’s that exist on the blockchain. If the UTXOs do not exist then the Unspent Outputs and moved to the Invalid Outputs collection.

This sync function is called when the Base Node Public Key is first set and an FFI API call is provided for the frontend to call the function whenever it feels it is required.

An event bus is also added to the Output Manager Service.

## Motivation and Context
This functionality is meant to help a wallet make sure its state is consistent with that is on the blockchain. If a wallet is copied and the other copy spends some of the outputs when the first wallet starts up it will have an incorrect balance so this will allow the first wallet to sync its state by querying the base node.

## How Has This Been Tested?
Tests provided that exercise the comms stack queries.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [x] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch
* [x] I ran `cargo-fmt --all` before pushing
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
