### PR TITLE
Recovery mode if an error occurs during BlockSync

### DIFF
--- a/base_layer/core/src/base_node/base_node.rs
+++ b/base_layer/core/src/base_node/base_node.rs
@@ -98,6 +98,7 @@ impl<B: BlockchainBackend> BaseNodeStateMachine<B> {
             (InitialSync(s), MetadataSynced(Lagging(_))) => BlockSync(s.into()),
             (InitialSync(_s), MetadataSynced(UpToDate)) => Listening(ListeningInfo),
             (BlockSync(_s), BlocksSynchronized) => Listening(ListeningInfo),
+            (BlockSync(s), MaxRequestAttemptsReached) => InitialSync(s.into()),
             (Listening(s), FallenBehind(Lagging(_))) => BlockSync(s.into()),
             (Listening(s), NetworkSilence) => InitialSync(s.into()),
             (_, FatalError(s)) => Shutdown(states::Shutdown::with_reason(s)),

--- a/base_layer/core/src/base_node/states/initial_sync.rs
+++ b/base_layer/core/src/base_node/states/initial_sync.rs
@@ -35,7 +35,7 @@ use crate::{
     chain_storage::{BlockchainBackend, ChainMetadata},
 };
 
-use crate::base_node::states::{helpers::determine_sync_mode, listening::ListeningInfo};
+use crate::base_node::states::{block_sync::BlockSyncInfo, helpers::determine_sync_mode, listening::ListeningInfo};
 use log::*;
 use std::time::Duration;
 
@@ -242,6 +242,14 @@ impl From<Starting> for InitialSync {
 /// disconnected from the network.
 impl From<ListeningInfo> for InitialSync {
     fn from(_old: ListeningInfo) -> Self {
+        InitialSync::new()
+    }
+}
+
+/// State management for BlockSyncInfo -> InitialSync. This state change occurs when the block download requests
+/// repeatedly failed.
+impl From<BlockSyncInfo> for InitialSync {
+    fn from(_old: BlockSyncInfo) -> Self {
         InitialSync::new()
     }
 }

--- a/base_layer/core/src/base_node/states/mod.rs
+++ b/base_layer/core/src/base_node/states/mod.rs
@@ -77,6 +77,7 @@ pub enum StateEvent {
     Initialized,
     MetadataSynced(SyncStatus),
     BlocksSynchronized,
+    MaxRequestAttemptsReached,
     FallenBehind(SyncStatus),
     NetworkSilence,
     FatalError(String),


### PR DESCRIPTION
## Description
- Modified the block sync logic to enable redownloading missing blocks or received blocks that haven't passed block validation. Bad blocks will be ignored and requested again from the network.
- Block sync was also changed so that only one block is downloaded at a time, this simplified determining what blocks were received and which blocks should be requested again.
- The block_sync_chunk_size was removed from BlockSyncConfig and max_block_request_retry_attempts was added to specify how many times the current node should attempt to request the block at a specific height again from different peer nodes.
- The MaxRequestAttemptsReached state event was added to allow a node that has exceeded the maximum request attempts to transition to the InitialSync state and attempt to reestablish communication with the network.

## Motivation and Context
This change will make the block sync process more reliable as blocks can be requested again without switching to a different state machine state. 

## How Has This Been Tested?
A test_block_sync_recovery test was added that demonstrates that when a remote node responds with an empty response to a download request, the request will be repeated a limited number of times to other random nodes until the correct blocks could be retrieved.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [x] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [x] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch
* [x] I ran `cargo-fmt --all` before pushing
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
