### PR TITLE
Added event channel to base node for event state streaming

### DIFF
--- a/base_layer/core/src/base_node/backoff.rs
+++ b/base_layer/core/src/base_node/backoff.rs
@@ -56,6 +56,7 @@ use tokio::time;
 /// };
 /// assert_eq!(backoff.attempts(), 4);
 /// ```
+#[derive(Clone, Debug, PartialEq)]
 pub struct BackOff {
     max_attempts: usize,
     current_attempts: usize,

--- a/base_layer/core/src/base_node/states/block_sync.rs
+++ b/base_layer/core/src/base_node/states/block_sync.rs
@@ -48,6 +48,7 @@ impl Default for BlockSyncConfig {
     }
 }
 
+#[derive(Clone, Debug, PartialEq)]
 pub struct BlockSyncInfo;
 
 impl BlockSyncInfo {

--- a/base_layer/core/src/base_node/states/initial_sync.rs
+++ b/base_layer/core/src/base_node/states/initial_sync.rs
@@ -43,6 +43,7 @@ const LOG_TARGET: &str = "c::bn::states::initial_sync";
 // The number of times we'll request the chain metadata before giving up
 const MAX_SYNC_ATTEMPTS: usize = 8;
 
+#[derive(Clone, Debug, PartialEq)]
 pub struct InitialSync {
     // keeps track of how many times we've tried to sync with the network
     backoff: BackOff,

--- a/base_layer/core/src/base_node/states/listening.rs
+++ b/base_layer/core/src/base_node/states/listening.rs
@@ -44,7 +44,7 @@ const LOG_TARGET: &str = "c::bn::states::listening";
 const LISTENING_SILENCE_TIMEOUT: Duration = Duration::from_secs(300); // 5 minutes
 
 /// Configuration for the Listening state.
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Debug)]
 pub struct ListeningConfig {
     pub listening_silence_timeout: Duration,
 }
@@ -61,6 +61,7 @@ impl Default for ListeningConfig {
 /// received metadata, if it detects that the current node is lagging behind the network it will switch to block sync
 /// state. If no metadata is received for a prolonged period of time it will transition to the initial sync state and
 /// request chain metadata from remote nodes.
+#[derive(Clone, Debug, PartialEq)]
 pub struct ListeningInfo;
 
 impl ListeningInfo {

--- a/base_layer/core/src/base_node/states/mod.rs
+++ b/base_layer/core/src/base_node/states/mod.rs
@@ -64,6 +64,7 @@ use std::fmt::{Display, Error, Formatter};
 ///
 /// Reject all new requests with a `Shutdown` message, complete current validations / tasks, flush all state if
 /// required, and then shutdown.
+#[derive(Clone, Debug, PartialEq)]
 pub enum BaseNodeState {
     Starting(Starting),
     InitialSync(InitialSync),

--- a/base_layer/core/src/base_node/states/shutdown_state.rs
+++ b/base_layer/core/src/base_node/states/shutdown_state.rs
@@ -23,6 +23,7 @@ use log::*;
 
 const LOG_TARGET: &str = "c::bn::states::shutdown_state";
 
+#[derive(Clone, Debug, PartialEq)]
 pub struct Shutdown {
     reason: String,
 }

--- a/base_layer/core/src/base_node/states/starting_state.rs
+++ b/base_layer/core/src/base_node/states/starting_state.rs
@@ -33,6 +33,7 @@ use std::ops::Deref;
 const LOG_TARGET: &str = "c::bn::states::starting_state";
 
 // The data structure handling Base Node Startup
+#[derive(Clone, Debug, PartialEq)]
 pub struct Starting;
 
 impl Starting {

--- a/base_layer/core/src/mining/miner.rs
+++ b/base_layer/core/src/mining/miner.rs
@@ -81,7 +81,7 @@ impl<B: BlockchainBackend> Miner<B> {
         }
     }
 
-    /// This function instanciates a new channel and returns the receiver so that the miner can send out a unblinded
+    /// This function instantiates a new channel and returns the receiver so that the miner can send out a unblinded
     /// output. This output is only sent if the miner successfully mines a block
     pub fn get_utxo_receiver_channel(&mut self) -> Receiver<UnblindedOutput> {
         let (sender, receiver): (Sender<UnblindedOutput>, Receiver<UnblindedOutput>) = mpsc::channel(1);


### PR DESCRIPTION
## Description
This PR adds in an event channel so that the state machine can publish its state when it changes. This uses `tari_broadcast_channel` as we have a single producer, multiple consumer. 

## Motivation and Context
We need to be able to notify  applications that the state machine changed state. The longer term solution to this would be to modify the state machine into a service. But because of and the simplicity of just adding a channel, for test net we only added a channel. 
The miner is one of the applications that require the use of the channel and it will require that the state machine notifies it when it goes into listing mode so that it can ask for a new block to start mining on.

## How Has This Been Tested?
I have added a integration test that confirms that the node publishes its state to the channel

## Types of changes
* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [x] New Tests
* [ ] Documentation

## Checklist:
* [x] I'm merging against the `development` branch
* [x] I ran `cargo-fmt --all` before pushing
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
