### PR TITLE
Base node mining

### DIFF
--- a/applications/tari_base_node/Cargo.toml
+++ b/applications/tari_base_node/Cargo.toml
@@ -16,6 +16,7 @@ tari_service_framework = { version = "^0.0", path = "../../base_layer/service_fr
 tari_shutdown = { path = "../../infrastructure/shutdown", version = "^0.0" }
 tari_mmr = { path = "../../base_layer/mmr", version = "^0.0" }
 tari_wallet = { path = "../../base_layer/wallet", version = "^0.0" }
+tari_broadcast_channel = { version="^0.0",  path = "../../infrastructure/broadcast_channel" }
 
 clap = "2.33.0"
 config = { version = "0.9.3" }

--- a/applications/tari_base_node/src/builder.rs
+++ b/applications/tari_base_node/src/builder.rs
@@ -76,10 +76,16 @@ use tari_p2p::{
         liveness::{LivenessConfig, LivenessInitializer},
     },
 };
+
+use futures::stream::Fuse;
 use tari_service_framework::{handles::ServiceHandles, StackBuilder};
 use tokio::runtime::Runtime;
 
-use tari_core::tari_utilities::{hex::Hex, message_format::MessageFormat};
+use tari_broadcast_channel::Subscriber;
+use tari_core::{
+    base_node::states::BaseNodeState,
+    tari_utilities::{hex::Hex, message_format::MessageFormat},
+};
 use tari_wallet::{
     output_manager_service::{
         config::OutputManagerServiceConfig,
@@ -126,6 +132,13 @@ impl NodeType {
         }
         .await;
     }
+
+    pub fn get_state_change_event(&self) -> Subscriber<BaseNodeState> {
+        match self {
+            NodeType::LMDB(n) => n.get_state_change_event(),
+            NodeType::Memory(n) => n.get_state_change_event(),
+        }
+    }
 }
 
 pub enum MinerType {
@@ -148,6 +161,13 @@ impl MinerType {
         match self {
             MinerType::LMDB(n) => n.get_utxo_receiver_channel(),
             MinerType::Memory(n) => n.get_utxo_receiver_channel(),
+        }
+    }
+
+    pub fn subscribe_to_state_change(&mut self, state_change_event_rx: Subscriber<BaseNodeState>) {
+        match self {
+            MinerType::LMDB(n) => n.subscribe_to_state_change(state_change_event_rx),
+            MinerType::Memory(n) => n.subscribe_to_state_change(state_change_event_rx),
         }
     }
 }

--- a/applications/tari_base_node/src/main.rs
+++ b/applications/tari_base_node/src/main.rs
@@ -135,10 +135,11 @@ fn main() {
             },
         };
     let flag = node.get_flag();
-
     // lets run the miner
     let miner_handle = if node_config.enable_mining {
         let mut rx = miner.get_utxo_receiver_channel();
+        let mut rx_events = node.get_state_change_event();
+        miner.subscribe_to_state_change(rx_events);
         let mut wallet_output_handle = base_node_context.wallet_output_service.clone();
         rt.spawn(async move {
             while let Some(utxo) = rx.next().await {
@@ -146,7 +147,7 @@ fn main() {
             }
         });
         Some(rt.spawn(async move {
-            debug!(target: LOG_TARGET, "starting miner");
+            debug!(target: LOG_TARGET, "Starting miner");
             miner.mine().await;
             debug!(target: LOG_TARGET, "Miner has shutdown");
         }))

--- a/base_layer/core/Cargo.toml
+++ b/base_layer/core/Cargo.toml
@@ -50,7 +50,7 @@ log = "0.4"
 blake2 = "^0.8.0"
 bigint = "^4.4.1"
 ttl_cache = "0.5.1"
-tokio = { version="^0.2", features = ["blocking"] }
+tokio = { version="^0.2", features = ["blocking", "time"] }
 futures = {version = "^0.3.1", features = ["async-await"] }
 lmdb-zero = "0.4.4"
 tower-service = { version="0.3.0-alpha.2" }

--- a/base_layer/core/src/base_node/base_node.rs
+++ b/base_layer/core/src/base_node/base_node.rs
@@ -129,8 +129,8 @@ impl<B: BlockchainBackend> BaseNodeStateMachine<B> {
     /// This clones the receiver end of the channel and gives out a copy to the caller
     /// This allows multiple subscribers to this channel by only keeping one channel and cloning the receiver for every
     /// caller.
-    pub fn get_state_change_event(&self) -> Fuse<Subscriber<BaseNodeState>> {
-        self.event_receiver.clone().fuse()
+    pub fn get_state_change_event(&self) -> Subscriber<BaseNodeState> {
+        self.event_receiver.clone()
     }
 
     /// Start the base node runtime.

--- a/base_layer/core/tests/node_state_machine.rs
+++ b/base_layer/core/tests/node_state_machine.rs
@@ -149,7 +149,7 @@ fn test_event_channel() {
         let prev_block = bob_db.calculate_mmr_roots(chain_block(&prev_block, vec![])).unwrap();
         bob_local_nci.submit_block(prev_block.clone()).await.unwrap();
         assert_eq!(bob_db.get_height(), Ok(Some(2)));
-        let state = rx.select_next_some().await;
+        let state = rx.fuse().select_next_some().await;
         if let BaseNodeState::InitialSync(_) = *state {
             assert!(true);
         } else {


### PR DESCRIPTION
## Description
This PR adds in the ability for the base node to mine and run. This PR adds in the ability for the miner to listen to the state event change channel from the state machine. 

It also fixes a minor bug in the minor logic and temporary fix for metadata reading not working

## Motivation and Context
For testnet we require the basenodes to be able to mine for testnet using the blake pow. This adds in the ability

## How Has This Been Tested?
The basenode successfully increased difficulty and its chain. 

## Types of changes
* [x] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
* [x] I'm merging against the `development` branch
* [x] I ran `cargo-fmt --all` before pushing
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
