### PR TITLE
Implemented PublicKey to NodeID Emoji

### DIFF
--- a/base_layer/wallet_ffi/wallet.h
+++ b/base_layer/wallet_ffi/wallet.h
@@ -107,10 +107,7 @@ struct TariPublicKey *public_key_from_hex(const char *hex,int* error_out);
 void public_key_destroy(struct TariPublicKey *pk);
 
 //Converts a TariPublicKey to char array in emoji format
-char *public_key_to_emoji(struct TariPublicKey *pk, int* error_out);
-
-//Converts a char array in emoji format to a TariPublicKey
-struct TariPublicKey *public_key_from_emoji(const char* emoji, int* error_out);
+char *public_key_to_emoji_node_id(struct TariPublicKey *pk, int* error_out);
 
 /// -------------------------------- TariPrivateKey ----------------------------------------------- ///
 


### PR DESCRIPTION
Modified EmojiID to return node_id in emoji format.
Removed method to create PublicKey form emoji.

## Description

## Motivation and Context

## How Has This Been Tested?
cargo test --all --all-features

## Types of changes
* [ ] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [x] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
* [x] I'm merging against the `development` branch
* [x] I ran `cargo-fmt --all` before pushing
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
