### PR TITLE
Emoji encoding and decoding

### DIFF
--- a/RFC/src/RFC-0152_EmojiId.md
+++ b/RFC/src/RFC-0152_EmojiId.md
@@ -136,7 +136,7 @@ One can extract the node id from an emoji ID as follows:
    return with an error. if any emoji character is not in the emoji map, return an error.
 2. Extract the version number:
    3. Do a reverse lookup of emoji`[10]` to find its index. Store this u64 value in `I`.
-   4. The Version number is `(I && 0x3F) >> 2`. This can be used to set the Emoji map accordingly (and may have to be
+   4. The Version number is `(I & 0x3F) >> 2`. This can be used to set the Emoji map accordingly (and may have to be
       done iteratively, since the version is encoded into the emoji string).
 3. Set `CURSOR = 0`.
 4. Set `B = []`, and empty byte array
@@ -157,7 +157,7 @@ will usually cause incompatible versions of the emoji ID to be detected. However
 
 The last 6 bits of the 11th emoji encodes the version; this means that the first 4 bits are part of the node ID. On a
 reverse mapping, there is a chance that the reverse mapping would offer a valid, but incorrect version number if the new
-mapping are not chosen carefully.
+mapping is not chosen carefully.
 
 ##### Example.
 

--- a/base_layer/wallet/src/util/emoji.rs
+++ b/base_layer/wallet/src/util/emoji.rs
@@ -20,104 +20,348 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+use crate::util::{luhn, luhn::checksum};
+use core::convert::TryFrom;
+use derive_error::Error;
 use serde::export::{fmt::Error, Formatter};
 use std::fmt::Display;
-use tari_core::transactions::types::PublicKey;
+use tari_comms::peer_manager::{NodeId, NODE_ID_ARRAY_SIZE};
 use tari_crypto::tari_utilities::{
-    hex::{Hex, HexError},
+    bit::{bits_to_bytes, uint_to_bits},
     ByteArray,
-    ByteArrayError,
 };
 
+/// The number of emoji in the dictionary.
+const EMOJI_ID_DICTIONARY_LEN: usize = 1024;
+/// The Dictionary version encoded into EmojiIds created from NodeIds.
+const NODE_ID_TO_EMOJI_ID_VERSION: u8 = 1;
+/// The Dictionary version bit count encoded into EmojiIds created from NodeIds.
+const NODE_ID_TO_EMOJI_ID_VERSION_BIT_COUNT: u8 = 6;
+
+/// The total set of emoji that can be used for emoji id generation.
+// TODO: This is a test dictionary and should be replaced.
+const EMOJI: [char; EMOJI_ID_DICTIONARY_LEN] = [
+    '😀', '😃', '😄', '😁', '😆', '😅', '🤣', '😂', '🙂', '🙃', '😉', '😊', '😇', '🥰', '😍', '🤩', '😘', '😗', '😚',
+    '😙', '😋', '😛', '😜', '🤪', '😝', '🤑', '🤗', '🤭', '🤫', '🤔', '🤐', '🤨', '😐', '😑', '😶', '😏', '😒', '🙄',
+    '😬', '🤥', '😌', '😔', '😪', '🤤', '😴', '😷', '🤒', '🤕', '🤢', '🤮', '🤧', '🥵', '🥶', '🥴', '😵', '🤯', '🤠', '🥳',
+    '😎', '🤓', '🧐', '😕', '😟', '🙁', '😮', '😲', '😳', '🥺', '😦', '😧', '😨', '😰', '😥', '😢', '😭', '😱', '😖',
+    '😣', '😞', '😓', '😩', '😫', '🥱', '😤', '😡', '😠', '🤬', '😈', '👿', '💀', '💩', '🤡', '👹', '👺', '👻', '👽',
+    '👾', '🤖', '😺', '😸', '😹', '😻', '😼', '😽', '🙀', '😿', '😾', '🙈', '🙉', '🙊', '💋', '💌', '💘', '💝', '💞',
+    '💕', '💔', '💯', '💢', '💥', '💫', '💦', '💨', '🕳', '💣', '💬', '🗨', '🗯', '💭', '💤', '👋', '🤚', '🖐', '✋', '🖖',
+    '👌', '🤏', '🤞', '🤟', '🤘', '🤙', '👈', '👉', '👆', '🖕', '👇', '👍', '👎', '✊', '👊', '🤛', '🤜', '👏', '🙌',
+    '👐', '🤲', '🤝', '🙏', '💅', '🤳', '💪', '🦾', '🦿', '🦵', '🦶', '👂', '👃', '🧠', '🦷', '🦴', '👀', '👁', '👅', '👄',
+    '👶', '🧒', '👦', '👧', '🧑', '👱', '👨', '🧔', '👩', '👵', '🙍', '🙅', '🙆', '💁', '🙋', '🧏', '🙇', '🤦', '🤷',
+    '👮', '🕵', '💂', '👷', '🤴', '👸', '👳', '👲', '🧕', '👰', '🤰', '🤱', '👼', '🎅', '🤶', '🦸', '🦹', '🧙', '🧚',
+    '🧛', '🧜', '🧝', '🧞', '🧟', '💆', '💇', '🚶', '🧍', '🧎', '🏃', '💃', '🕺', '🕴', '👯', '🧖', '🧗', '🤺', '🏇', '⛷',
+    '🏂', '🏌', '🏄', '🚣', '🏊', '⛹', '🏋', '🚴', '🚵', '🤸', '🤼', '🤽', '🤾', '🤹', '🧘', '🛀', '🛌', '💏', '👪', '🗣',
+    '👤', '👥', '👣', '🐵', '🐒', '🦍', '🦧', '🐶', '🐕', '🦮', '🐩', '🐺', '🦊', '🦝', '🐱', '🐈', '🦁', '🐯', '🐅',
+    '🐆', '🐴', '🐎', '🦄', '🦓', '🦌', '🐮', '🐂', '🐃', '🐄', '🐷', '🐖', '🐗', '🐽', '🐏', '🐑', '🐐', '🐪', '🐫',
+    '🦙', '🦒', '🐘', '🦏', '🦛', '🐭', '🐁', '🐀', '🐹', '🐰', '🐇', '🐿', '🦔', '🦇', '🐻', '🐨', '🐼', '🦥', '🦦', '🦨',
+    '🦘', '🦡', '🐾', '🦃', '🐔', '🐓', '🐣', '🐤', '🐥', '🐦', '🐧', '🕊', '🦅', '🦆', '🦢', '🦉', '🦩', '🦚', '🦜', '🐸',
+    '🐊', '🐢', '🦎', '🐍', '🐲', '🐉', '🦕', '🦖', '🐳', '🐋', '🐬', '🐟', '🐠', '🐡', '🦈', '🐙', '🐚', '🐌', '🦋',
+    '🐛', '🐜', '🐝', '🐞', '🦗', '🕷', '🕸', '🦂', '🦟', '🦠', '💐', '🌸', '💮', '🏵', '🌹', '🥀', '🌺', '🌻', '🌼', '🌷',
+    '🌱', '🌲', '🌳', '🌴', '🌵', '🌾', '🌿', '🍀', '🍁', '🍂', '🍃', '🍇', '🍈', '🍉', '🍊', '🍋', '🍌', '🍍', '🥭',
+    '🍎', '🍏', '🍐', '🍑', '🍒', '🍓', '🥝', '🍅', '🥥', '🥑', '🍆', '🥔', '🥕', '🌽', '🌶', '🥒', '🥬', '🥦', '🧄', '🧅',
+    '🍄', '🥜', '🌰', '🍞', '🥐', '🥖', '🥨', '🥯', '🥞', '🧇', '🧀', '🍖', '🍗', '🥩', '🥓', '🍔', '🍟', '🍕', '🌭',
+    '🥪', '🌮', '🌯', '🥙', '🧆', '🥚', '🍳', '🥘', '🍲', '🥣', '🥗', '🍿', '🧈', '🧂', '🥫', '🍱', '🍘', '🍙', '🍚',
+    '🍛', '🍜', '🍝', '🍠', '🍢', '🍣', '🍤', '🍥', '🥮', '🍡', '🥟', '🥠', '🥡', '🦀', '🦞', '🦐', '🦑', '🦪', '🍦',
+    '🍧', '🍨', '🍩', '🍪', '🎂', '🍰', '🧁', '🥧', '🍫', '🍬', '🍭', '🍮', '🍯', '🍼', '🥛', '🍶', '🍾', '🍷', '🍸',
+    '🍹', '🍺', '🍻', '🥂', '🥃', '🥤', '🧃', '🧉', '🧊', '🥢', '🍽', '🍴', '🥄', '🔪', '🏺', '🌍', '🗺', '🧭', '🏔', '🌋',
+    '🏕', '🏖', '🏜', '🏝', '🏟', '🏛', '🏗', '🧱', '🏘', '🏚', '🏠', '🏡', '🏢', '🏣', '🏤', '🏥', '🏦', '🏨', '🏩', '🏪', '🏫',
+    '🏬', '🏭', '🏯', '🏰', '💒', '🗼', '🗽', '⛪', '🕌', '🛕', '🕍', '⛩', '🕋', '⛲', '⛺', '🌁', '🌃', '🏙', '🌄',
+    '🌅', '🌆', '🌉', '🎠', '🎡', '🎢', '💈', '🎪', '🚂', '🚄', '🚋', '🚌', '🚐', '🚑', '🚒', '🚓', '🚕', '🚗', '🚙',
+    '🚚', '🚜', '🏎', '🏍', '🛵', '🦼', '🛺', '🚲', '🛴', '🛹', '🚏', '🛣', '🛤', '🛢', '⛽', '🚨', '🚦', '🛑', '🚧', '⛵',
+    '🛶', '🚤', '🛳', '🛥', '🛩', '🪂', '💺', '🚁', '🚠', '🛰', '🚀', '🛸', '🛎', '🧳', '⌛', '⌚', '⏰', '⏲', '🕰', '🕛',
+    '🕧', '🕐', '🕜', '🕑', '🕝', '🕒', '🕞', '🕓', '🕟', '🕔', '🕠', '🕕', '🕡', '🕖', '🕢', '🕗', '🕣', '🕘', '🕤',
+    '🕙', '🕥', '🕚', '🕦', '🌑', '🌒', '🌓', '🌔', '🌕', '🌖', '🌗', '🌘', '🌙', '🌚', '🌛', '🌡', '🌝', '🌞', '🪐',
+    '⭐', '🌠', '🌌', '⛅', '⛈', '🌨', '🌪', '🌫', '🌬', '🌀', '🌈', '🌂', '⛱', '🔥', '💧', '🌊', '🎃', '🎄', '🎇', '🧨',
+    '✨', '🎈', '🎉', '🎊', '🎋', '🎍', '🎎', '🎏', '🎐', '🎑', '🧧', '🎀', '🎁', '🎗', '🎟', '🎖', '🏆', '🥇', '🥈', '🥉',
+    '⚽', '⚾', '🥎', '🏀', '🏐', '🏈', '🏉', '🎾', '🥏', '🎳', '🏏', '🏑', '🏒', '🥍', '🏓', '🏸', '🥊', '🥋', '🥅',
+    '⛳', '⛸', '🎣', '🤿', '🎽', '🎿', '🛷', '🥌', '🎯', '🪀', '🪁', '🎱', '🔮', '🧿', '🎮', '🕹', '🎰', '🎲', '🧩', '🧸',
+    '♠', '♥', '♦', '♣', '🃏', '🀄', '🎴', '🎭', '🖼', '🎨', '🧵', '🧶', '👓', '🕶', '🥽', '🥼', '🦺', '👔', '👕', '👖', '🧣',
+    '🧤', '🧥', '🧦', '👗', '👘', '🥻', '🩱', '🩲', '🩳', '👙', '👚', '👛', '👜', '👝', '🛍', '🎒', '👞', '👟', '🥾', '🥿',
+    '👠', '👡', '🩰', '👢', '👑', '👒', '🎩', '🎓', '🧢', '⛑', '📿', '💄', '💍', '💎', '🔈', '📣', '📯', '🔔', '🎼',
+    '🎵', '🎶', '🎛', '🎤', '🎧', '📻', '🎷', '🎸', '🎹', '🎺', '🎻', '🪕', '🥁', '📱', '📞', '📟', '📠', '🔋', '🔌',
+    '💻', '🖥', '🖨', '🖱', '💽', '💾', '🧮', '🎥', '🎞', '📽', '🎬', '📺', '📷', '📹', '📼', '🔍', '🕯', '💡', '🔦', '🏮',
+    '🪔', '📕', '📖', '📚', '📰', '🏷', '💰', '💳', '📦', '📫', '📮', '🗳', '🖍', '💼', '📅', '📈', '📉', '📊', '📋', '📌',
+    '📎', '🖇', '📏', '📐', '🗄', '🗑', '🔒', '🔑', '🗝', '🔨', '🪓', '⛏', '🛠', '🗡', '🔫', '🏹', '🛡', '🔧', '🔩', '🗜', '🦯',
+    '🔗', '⛓', '🧰', '🧲', '🧪', '🧫', '🧬', '🔬', '🔭', '📡', '💉', '🩸', '💊', '🩹', '🩺', '🚪', '🛏', '🛋', '🪑', '🚽', '🚿',
+    '🛁', '🪒', '🧴', '🧷', '🧹', '🧺', '🧻', '🧼', '🧽', '🧯', '🛒', '🚬', '🗿', '🏁', '!', '"', '#', '$', '%', '&', '(', ')',
+    '*', '+', ',', '-', '.', '/', '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', ':', ';', '<', '=', '>', '?', '@',
+    'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M', 'N', 'O', 'P', 'Q', 'R', 'S', 'S', 'U', 'V', 'W',
+    'X', 'Y', 'Z', '[', ']', '^', '_', '`', 'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm', 'n', 'o',
+    'p', 'q', 'r', 's', 't', 'u', 'v', 'w', 'x', 'u', 'z', '{', '|', '}', '€', '‚', 'ƒ', '…', '†', '‡', 'ˆ', '‰', 'Š',
+    '‹', 'Œ', 'Ž', '•', '˜', '™', 'š', '›', 'œ', 'ž', 'Ÿ', '¢', '£', '¤', '¥', '¦', '§', '©', 'ª', '«', '¬', '®', '¯',
+    '°', '±', '²', '³', 'µ', '¶',
+];
+
+#[derive(Debug, Clone, Error, PartialEq)]
+pub enum EmojiIdError {
+    // The provided Emoji could not be found in the Emoji set.
+    Notfound,
+    // The checksum of the EmojiId was invalid.
+    InvalidChecksum,
+    // Emoji index out of bounds.
+    IndexOutOfBounds,
+    // Could not converting from a different format
+    #[error(msg_embedded, non_std, no_from)]
+    ConversionError(String),
+}
+
+/// The EmojiId can encode and decode a set of bytes into emoji, and back again. It contains also includes a version and
+/// checksum for the encoded information.
 #[derive(Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
-pub struct EmojiId(String);
+pub struct EmojiId(Vec<u8>);
 
 impl EmojiId {
-    pub fn from_pubkey(key: &PublicKey) -> Self {
-        // Temp hacky approach - full spec coming shortly
-        let bytes = key.as_bytes();
-        let id = bytes.iter().map(|b| EMOJI[*b as usize]).collect();
-        Self(id)
+    /// Create a new EmojiID from a set of unchecked bytes, a version and checksum for the provided bytes will be
+    /// included in the EmojiId. Only the first bits upto the specified bit_count will be considered.
+    pub fn new(unchecked_bytes: Vec<u8>, bit_count: usize) -> Result<Self, EmojiIdError> {
+        let unchecked_indices = bytes_to_indices(unchecked_bytes, bit_count);
+        EmojiId::new_from_indices(unchecked_indices)
     }
 
-    pub fn from_hex(hex_key: &str) -> Result<Self, HexError> {
-        let key = PublicKey::from_hex(hex_key)?;
-        Ok(EmojiId::from_pubkey(&key))
+    /// Create a new EmojiID from a set of unchecked emoji dictionary indices, a version and checksum or the provided
+    /// emoji dictionary indices will be included in the EmojiId.
+    pub fn new_from_indices(mut unchecked_indices: Vec<usize>) -> Result<Self, EmojiIdError> {
+        check_valid_indices(&unchecked_indices)?;
+        unchecked_indices.push(checksum(&unchecked_indices, EMOJI_ID_DICTIONARY_LEN));
+        Ok(Self(indices_to_bytes(&unchecked_indices)))
     }
 
-    /// Given a emoji string in `value` returns true if this is a representable as a public key
-    pub fn is_valid(value: &str) -> bool {
-        EmojiId::try_convert_to_pubkey(value).is_ok()
+    // Returns the number of bits used for indices.
+    fn num_indice_bits(&self) -> usize {
+        let num_indices = (self.0.len() * 8) / 10;
+        num_indices * 10
     }
+}
 
-    pub fn as_str(&self) -> &str {
-        &self.0
+/// Create an EmojiId from a set of bytes, these bytes should include a version and checksum.
+impl TryFrom<Vec<u8>> for EmojiId {
+    type Error = EmojiIdError;
+
+    fn try_from(key_bytes: Vec<u8>) -> Result<Self, Self::Error> {
+        let num_indices = (key_bytes.len() * 8) / 10;
+        let bitcount = num_indices * 10;
+        let indices = bytes_to_indices(key_bytes.clone(), bitcount);
+        check_valid_indices(&indices)?;
+        if !luhn::is_valid(&indices, EMOJI_ID_DICTIONARY_LEN) {
+            return Err(EmojiIdError::InvalidChecksum);
+        }
+        Ok(Self(key_bytes))
     }
+}
 
-    /// Convert an emoji id to a pubic key
-    pub fn try_convert_to_pubkey(value: &str) -> Result<PublicKey, ByteArrayError> {
-        let bytes: Vec<u8> = value
-            .chars()
-            .filter_map(|c| EMOJI.iter().position(|e| *e == c))
-            .map(|v| v as u8)
-            .collect();
-        PublicKey::from_bytes(&bytes)
+/// Create an EmojiId from a emoji string, this string should include a version and checksum.
+impl TryFrom<&str> for EmojiId {
+    type Error = EmojiIdError;
+
+    fn try_from(emoji_set: &str) -> Result<Self, Self::Error> {
+        let indices = emoji_set_to_indices(emoji_set)?;
+        EmojiId::try_from(indices_to_bytes(&indices))
+    }
+}
+
+impl TryFrom<NodeId> for EmojiId {
+    type Error = EmojiIdError;
+
+    fn try_from(node_id: NodeId) -> Result<Self, Self::Error> {
+        let mut unchecked_bytes = node_id.as_bytes().to_vec();
+        let bit_count = unchecked_bytes.len() * 8 + NODE_ID_TO_EMOJI_ID_VERSION_BIT_COUNT as usize;
+        unchecked_bytes.push(NODE_ID_TO_EMOJI_ID_VERSION);
+        EmojiId::new(unchecked_bytes, bit_count)
+    }
+}
+
+// Decode the NodeId and dictionary version from a EmojiId that encoded a NodeId.
+fn emoji_id_to_node_id(emoji_id: EmojiId) -> Result<(NodeId, u8), EmojiIdError> {
+    let emoji_id_bytes = emoji_id.0.as_bytes();
+    if emoji_id_bytes.len() <= NODE_ID_ARRAY_SIZE {
+        // NodeID + Version
+        return Err(EmojiIdError::ConversionError("Insufficient bytes".into()));
+    }
+    let node_id = NodeId::from_bytes(&emoji_id_bytes[0..NODE_ID_ARRAY_SIZE])
+        .map_err(|err| EmojiIdError::ConversionError(format!("{:?}", err)))?;
+    let version = emoji_id_bytes[NODE_ID_ARRAY_SIZE] << 2 >> 2; // Erase unused bits
+    Ok((node_id, version))
+}
+
+/// An Iterator for traversing a set of bytes by grouping 10 bits at a time that can be used as the index in the emoji
+/// dictionary. It will apply zero padding when needed.
+pub struct EmojiIterator {
+    cursor: usize,
+    bit_count: usize,
+    key: Vec<u8>,
+}
+
+impl EmojiIterator {
+    /// Construct a new EmojiIterator from a set of bytes. The bit count limits the number of bits that will be used
+    /// from the byte set.
+    pub fn new(key: Vec<u8>, bit_count: usize) -> Self {
+        Self {
+            cursor: 0,
+            bit_count,
+            key,
+        }
+    }
+}
+
+impl Iterator for EmojiIterator {
+    type Item = usize;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.cursor < self.bit_count {
+            let index = self.cursor / 8;
+            if index < self.key.len() {
+                let offset = (self.cursor % 8) as u16;
+                let key2 = if index + 1 < self.key.len() {
+                    self.key[index + 1] as u16
+                } else {
+                    0u16
+                };
+                let bit_set = self.key[index] as u16 + (key2 << 8);
+                let index = (bit_set >> offset) & 1023;
+                self.cursor += 10;
+                return Some(index as usize);
+            }
+        }
+        None
     }
 }
 
 impl Display for EmojiId {
     fn fmt(&self, fmt: &mut Formatter<'_>) -> Result<(), Error> {
-        fmt.write_str(self.as_str())
+        fmt.write_str(
+            &EmojiIterator::new(self.0.clone(), self.num_indice_bits())
+                .map(|index| EMOJI[index as usize])
+                .collect::<String>(),
+        )
     }
 }
+// Converts a set of indices to bytes.
+fn indices_to_bytes(indices: &Vec<usize>) -> Vec<u8> {
+    let mut bits = Vec::<bool>::new();
+    for index in indices {
+        bits.append(&mut uint_to_bits(*index, 10));
+    }
+    // Zero padding
+    let byte_aligment = bits.len() % 8;
+    if byte_aligment > 0 {
+        (0..(8 - byte_aligment)).for_each(|_| bits.push(false));
+    }
+    bits_to_bytes(&bits)
+}
 
-const EMOJI: [char; 256] = [
-    '😀', '😃', '😄', '😁', '😆', '😅', '🤣', '😂', '🙂', '🙃', '😉', '😊', '😇', '🥰', '😍', '🤩', '😘', '😗', '😚',
-    '😙', '😋', '😛', '😜', '🤪', '😝', '🐠', '🤗', '🤭', '🤫', '🤔', '🤐', '🤨', '😐', '😑', '😶', '😏', '😒', '🙄',
-    '😬', '🤥', '😌', '😔', '😪', '🤤', '😴', '😷', '🤒', '🤕', '🤢', '🤮', '🤧', '🥵', '🥶', '🥴', '😵', '🤯', '🤠', '🥳',
-    '😎', '🤓', '🧐', '😕', '😟', '🙁', '😮', '😯', '😲', '😳', '🥺', '😦', '😧', '😨', '😰', '😥', '😢', '😭', '😱',
-    '😖', '😣', '😞', '😓', '😩', '😫', '😤', '😡', '😠', '🤬', '😈', '👿', '💀', '🐟', '💩', '🤡', '👹', '👺', '👻',
-    '👽', '👾', '🤖', '😺', '😹', '😻', '😼', '😽', '🙀', '😿', '😾', '💋', '👋', '🤚', '🖐', '✋', '🖖', '👌', '🤞',
-    '🤟', '🤘', '🤙', '👈', '👉', '👆', '🖕', '👇', '👍', '👎', '✊', '👊', '🤛', '🤜', '👏', '🙌', '👐', '🤲', '🤝',
-    '🙏', '💅', '🤳', '💪', '🦵', '🦶', '👂', '👃', '🧠', '🦷', '🦴', '👀', '👁', '👅', '👄', '🚶', '👣', '🧳', '🌂', '☂',
-    '🧵', '🧶', '👓', '🕶', '🥽', '🥼', '👔', '👕', '👖', '🧣', '🧤', '🧥', '🧦', '👗', '👘', '👙', '👚', '👛', '👜', '👝',
-    '🎒', '👞', '👟', '🥾', '🥿', '👠', '👡', '👢', '👑', '👒', '🎩', '🎓', '🧢', '⛑', '💄', '💍', '💼', '🙈', '🙉',
-    '🙊', '💥', '💫', '💦', '💨', '🐵', '🐒', '🦍', '🐶', '🐕', '🐩', '🐺', '🦊', '🦝', '🐱', '🐈', '🦁', '🐯', '🐅',
-    '🐆', '🐴', '🐎', '🦄', '🦓', '🦌', '🐮', '🐂', '🐃', '🐄', '🐷', '🐖', '🐗', '🐽', '🐏', '🐑', '🐐', '🐪', '🐫',
-    '🦙', '🦒', '🐘', '🦏', '🦛', '🐭', '🐁', '🐀', '🐹', '🐰', '🐇', '🐿', '🦔', '🦇', '🐻', '🐨', '🐼', '🦘', '🦡', '🐾',
-    '🦃', '🐓', '🐣', '🐋', '🐬',
-];
+// Converts a set of bytes to emoji indices, only the bits upto the specified bit count will be considered.
+fn bytes_to_indices(key_bytes: Vec<u8>, bit_count: usize) -> Vec<usize> {
+    EmojiIterator::new(key_bytes, bit_count).collect::<Vec<usize>>()
+}
+
+// Finds the index of the specified emoji in the dictionary.
+fn emoji_to_index(emoji: char) -> Result<usize, EmojiIdError> {
+    for i in 0..EMOJI.len() {
+        if emoji == EMOJI[i] {
+            return Ok(i);
+        }
+    }
+    Err(EmojiIdError::Notfound)
+}
+
+// Converts a set of emoji, provided in a string, to a list of dictionary indices.
+fn emoji_set_to_indices(emoji_set: &str) -> Result<Vec<usize>, EmojiIdError> {
+    let mut indices = Vec::<usize>::new();
+    for emoji in emoji_set.chars() {
+        indices.push(emoji_to_index(emoji)?);
+    }
+    Ok(indices)
+}
+
+// Checks that the provided indices exist in the emoji dictionary.
+fn check_valid_indices(key_indices: &Vec<usize>) -> Result<(), EmojiIdError> {
+    if key_indices.iter().any(|index| *index >= EMOJI_ID_DICTIONARY_LEN) {
+        return Err(EmojiIdError::IndexOutOfBounds);
+    }
+    Ok(())
+}
 
 #[cfg(test)]
 mod test {
-    use crate::util::emoji::EmojiId;
-    use tari_core::transactions::types::PublicKey;
-    use tari_crypto::tari_utilities::hex::Hex;
+    use crate::util::emoji::{emoji_id_to_node_id, EmojiId, EmojiIdError, NODE_ID_TO_EMOJI_ID_VERSION};
+    use std::convert::TryFrom;
+    use tari_comms::peer_manager::NodeId;
+    use tari_crypto::{keys::PublicKey, ristretto::RistrettoPublicKey, tari_utilities::byte_array::ByteArray};
 
     #[test]
-    fn convert_key() {
-        let key = PublicKey::from_hex("70350e09c474809209824c6e6888707b7dd09959aa227343b5106382b856f73a").unwrap();
-        let eid = EmojiId::from_pubkey(&key);
-        assert_eq!(
-            eid.as_str(),
-            "🖖🥴😍🙃💦🤘🤜👁🙃🙌😱🖐🙀🤳🖖👍✊🐈☂💀👚😶🤟😳👢😘😺🙌🎩🤬🐼😎"
-        );
-        let h_eid = EmojiId::from_hex("70350e09c474809209824c6e6888707b7dd09959aa227343b5106382b856f73a").unwrap();
-        assert_eq!(eid, h_eid);
+    fn id_from_bytes() {
+        let unchecked_bytes = [
+            64, 28, 98, 64, 28, 197, 216, 115, 9, 25, 41, 76, 147, 195, 53, 207, 0, 145, 5, 55, 235, 244, 160, 195, 48,
+            48, 144, 160, 71, 15, 241, 52,
+        ];
+        let desired_emoji_set = "😮👌🤣💝🤴🧘🤜😹😔🧚🥳🧞🤶😮💀🧍🚣😕😎💂🤢😒💨😕🤸🥰🦊";
+
+        let emoji_id = EmojiId::new(unchecked_bytes.to_vec(), unchecked_bytes.len() * 8).unwrap();
+        let emoji_set = emoji_id.to_string();
+        assert_eq!(emoji_set, desired_emoji_set);
+        let emoji_id = EmojiId::try_from(emoji_set.as_str()).unwrap();
+        assert_eq!(emoji_id.to_string(), desired_emoji_set);
+
+        let checked_bytes = [
+            64, 28, 98, 64, 28, 197, 216, 115, 9, 25, 41, 76, 147, 195, 53, 207, 0, 145, 5, 55, 235, 244, 160, 195, 48,
+            48, 144, 160, 71, 15, 241, 52, 128, 16,
+        ];
+        let emoji_id = EmojiId::try_from(checked_bytes.to_vec()).unwrap();
+        assert_eq!(emoji_id.to_string(), desired_emoji_set);
+
+        // Valid emoji set with invalid checksum
+        let emoji_id = EmojiId::try_from("😮👌🤣💝🤴🧘🤜😹😔🧚🥳🧞🤶😮💀🧍🚣😕😎💂🤢😒💨😕🤸🥰💣");
+        assert_eq!(emoji_id, Err(EmojiIdError::InvalidChecksum));
+
+        // Invalid emoji set with valid checksum
+        let emoji_id = EmojiId::try_from("😮👌🤣💝🤴💣🤜😹😔🧚🥳🧞🤶😮💀🧍🚣😕😎💂🤢😒💨😕🤸🥰🦊");
+        assert_eq!(emoji_id, Err(EmojiIdError::InvalidChecksum));
     }
 
     #[test]
-    fn is_valid() {
-        let key =
-            EmojiId::try_convert_to_pubkey("🖖🥴😍🙃💦🤘🤜👁🙃🙌😱🖐🙀🤳🖖👍✊🐈☂💀👚😶🤟😳👢😘😺🙌🎩🤬🐼😎").unwrap();
+    fn id_from_indices() {
+        let key_indices = vec![0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20];
+        let desired_emoji_set = "😀😃😄😁😆😅🤣😂🙂🙃😉😊😇🥰😍🤩😘😗😚😙😋🎽";
+
+        let emoji_id = EmojiId::new_from_indices(key_indices).unwrap();
+        let emoji_set = emoji_id.to_string();
+        assert_eq!(emoji_set, desired_emoji_set);
+        let emoji_id = EmojiId::try_from(emoji_set.as_str()).unwrap();
+        assert_eq!(emoji_id.to_string(), desired_emoji_set);
+
+        // Invalid Indices
+        let key_indices = vec![0, 1, 2, 3, 4, 1025, 5000];
         assert_eq!(
-            key.to_hex(),
-            "70350e09c474809209824c6e6888707b7dd09959aa227343b5106382b856f73a"
+            EmojiId::new_from_indices(key_indices),
+            Err(EmojiIdError::IndexOutOfBounds)
         );
-        assert!(EmojiId::is_valid(
-            "🖖🥴😍🙃💦🤘🤜👁🙃🙌😱🖐🙀🤳🖖👍✊🐈☂💀👚😶🤟😳👢😘😺🙌🎩🤬🐼😎"
-        ));
-        assert_eq!(EmojiId::is_valid("😂"), false);
-        assert_eq!(EmojiId::is_valid("Hi"), false);
+
+        // Valid emoji set with invalid checksum
+        let emoji_id = EmojiId::try_from("😀😃😄😁😆😅🤣😂🙂🙃😉😊😇🥰😍🤩😘😗😚😙😋💣");
+        assert_eq!(emoji_id, Err(EmojiIdError::InvalidChecksum));
+
+        // Invalid emoji set with valid checksum
+        let emoji_id = EmojiId::try_from("😀😃😄😁😆😅🤣😂🙂🙃😉😊😇🥰😍🤩💣😗😚😙😋🎽");
+        assert_eq!(emoji_id, Err(EmojiIdError::InvalidChecksum));
+    }
+
+    #[test]
+    fn id_from_node_id() {
+        let node_id = NodeId::new();
+        let desired_emoji_set = "😀😀😀😀😀😀😀😀😀😀😘ˆ";
+        let emoji_id = EmojiId::try_from(node_id.clone()).unwrap();
+        assert_eq!(emoji_id.to_string(), desired_emoji_set);
+
+        let mut rng = rand::rngs::OsRng;
+        let (_sk, pk) = RistrettoPublicKey::random_keypair(&mut rng);
+        let desired_node_id = NodeId::from_key(&pk).unwrap();
+        let emoji_id = EmojiId::try_from(desired_node_id.clone()).unwrap();
+
+        let (node_id, version) = emoji_id_to_node_id(emoji_id).unwrap();
+        assert_eq!(node_id, desired_node_id);
+        assert_eq!(version, NODE_ID_TO_EMOJI_ID_VERSION);
     }
 }

--- a/base_layer/wallet/tests/output_manager_service/service.rs
+++ b/base_layer/wallet/tests/output_manager_service/service.rs
@@ -71,7 +71,6 @@ use tari_wallet::{
             memory_db::OutputManagerMemoryDatabase,
             sqlite_db::OutputManagerSqliteDatabase,
         },
-        OutputManagerServiceInitializer,
     },
     storage::connection_manager::run_migration_and_create_connection_pool,
 };

--- a/base_layer/wallet_ffi/src/lib.rs
+++ b/base_layer/wallet_ffi/src/lib.rs
@@ -157,6 +157,8 @@ use tari_wallet::{
     wallet::WalletConfig,
 };
 use tokio::runtime::Runtime;
+use std::convert::TryFrom;
+use tari_comms::peer_manager::NodeId;
 
 pub type TariWallet = tari_wallet::wallet::Wallet<
     WalletSqliteDatabase,
@@ -437,39 +439,6 @@ pub unsafe extern "C" fn public_key_from_hex(key: *const c_char, error_out: *mut
     }
 }
 
-/// Creates a TariPublicKey from an EmojiID string
-///
-/// ## Arguments
-/// `emoji` - The pointer to a char array which is emoji encoded
-/// `error_out` - Pointer to an int which will be modified to an error code should one occur, may not be null. Functions
-/// as an out parameter.
-///
-/// ## Returns
-/// `*mut TariPublicKey` - Returns a pointer to a TariPublicKey. Note that it returns ptr::null_mut()
-/// if emoji is null or if there was an error creating the TariPublicKey from key
-#[no_mangle]
-pub unsafe extern "C" fn public_key_from_emoji(emoji: *const c_char, error_out: *mut c_int) -> *mut TariPublicKey {
-    let mut error = 0;
-    let emoji_str;
-    ptr::swap(error_out, &mut error as *mut c_int);
-    if emoji.is_null() {
-        error = LibWalletError::from(InterfaceError::NullError("key".to_string())).code;
-        ptr::swap(error_out, &mut error as *mut c_int);
-        return ptr::null_mut();
-    } else {
-        emoji_str = CStr::from_ptr(emoji).to_str().unwrap().to_owned();
-    }
-    let public_key = EmojiId::try_convert_to_pubkey(&emoji_str);
-    match public_key {
-        Ok(public_key) => Box::into_raw(Box::new(public_key)),
-        Err(e) => {
-            error = LibWalletError::from(e).code;
-            ptr::swap(error_out, &mut error as *mut c_int);
-            ptr::null_mut()
-        },
-    }
-}
-
 /// Creates a char array from a TariPublicKey in emoji format
 ///
 /// ## Arguments
@@ -481,7 +450,7 @@ pub unsafe extern "C" fn public_key_from_emoji(emoji: *const c_char, error_out: 
 /// `*mut c_char` - Returns a pointer to a char array. Note that it returns empty
 /// if emoji is null or if there was an error creating the emoji string from TariPublicKey
 #[no_mangle]
-pub unsafe extern "C" fn public_key_to_emoji(pk: *mut TariPublicKey, error_out: *mut c_int) -> *mut c_char {
+pub unsafe extern "C" fn public_key_to_emoji_node_id(pk: *mut TariPublicKey, error_out: *mut c_int) -> *mut c_char {
     let mut error = 0;
     let mut result = CString::new("").unwrap();
     ptr::swap(error_out, &mut error as *mut c_int);
@@ -491,8 +460,9 @@ pub unsafe extern "C" fn public_key_to_emoji(pk: *mut TariPublicKey, error_out: 
         return CString::into_raw(result);
     }
 
-    let emoji = EmojiId::from_pubkey(&(*pk));
-    result = CString::new(emoji.as_str()).unwrap();
+    let node_id = NodeId::from_key(&(*pk)).unwrap();
+    let emoji = EmojiId::try_from(node_id).unwrap();
+    result = CString::new(emoji.to_string()).unwrap();
     CString::into_raw(result)
 }
 /// -------------------------------------------------------------------------------------------- ///
@@ -3241,18 +3211,12 @@ mod test {
             assert_eq!(private_key_length, 32);
             assert_eq!(public_key_length, 32);
             assert_ne!((*private_bytes), (*public_bytes));
-            let emoji = public_key_to_emoji(public_key, error_ptr) as *mut c_char;
+            let emoji = public_key_to_emoji_node_id(public_key, error_ptr) as *mut c_char;
             let emoji_str = CStr::from_ptr(emoji).to_str().unwrap().to_owned();
-            assert_eq!(EmojiId::is_valid(&emoji_str), true);
-            let emoji_key = public_key_from_emoji(emoji, error_ptr);
-            let emoji_bytes = public_key_get_bytes(public_key, error_ptr);
-            assert_eq!((*emoji_bytes), (*public_bytes));
             private_key_destroy(private_key);
             public_key_destroy(public_key);
-            public_key_destroy(emoji_key);
             byte_vector_destroy(public_bytes);
             byte_vector_destroy(private_bytes);
-            byte_vector_destroy(emoji_bytes);
         }
     }
 

--- a/base_layer/wallet_ffi/wallet.h
+++ b/base_layer/wallet_ffi/wallet.h
@@ -107,10 +107,7 @@ struct TariPublicKey *public_key_from_hex(const char *hex,int* error_out);
 void public_key_destroy(struct TariPublicKey *pk);
 
 //Converts a TariPublicKey to char array in emoji format
-char *public_key_to_emoji(struct TariPublicKey *pk, int* error_out);
-
-//Converts a char array in emoji format to a TariPublicKey
-struct TariPublicKey *public_key_from_emoji(const char* emoji, int* error_out);
+char *public_key_to_emoji_node_id(struct TariPublicKey *pk, int* error_out);
 
 /// -------------------------------- TariPrivateKey ----------------------------------------------- ///
 

--- a/comms/src/peer_manager/mod.rs
+++ b/comms/src/peer_manager/mod.rs
@@ -81,7 +81,7 @@ cfg_next! {
 
 pub use self::{
     error::PeerManagerError,
-    node_id::NodeId,
+    node_id::{NodeId,NODE_ID_ARRAY_SIZE},
     node_identity::NodeIdentity,
     peer::{Peer, PeerFlags},
     peer_features::PeerFeatures,

--- a/comms/src/peer_manager/node_id.rs
+++ b/comms/src/peer_manager/node_id.rs
@@ -40,7 +40,7 @@ use tari_crypto::tari_utilities::{
     ByteArrayError,
 };
 
-const NODE_ID_ARRAY_SIZE: usize = 13; // 104-bit as per RFC-0151
+pub const NODE_ID_ARRAY_SIZE: usize = 13; // 104-bit as per RFC-0151
 type NodeIdArray = [u8; NODE_ID_ARRAY_SIZE];
 
 #[derive(Debug, Error, Clone)]


### PR DESCRIPTION
## Description
- Updated the EmojiId encoding and decoding to include the creation and checking of checksums.
- Added the ability to create a new EmojiId from a NodeID, string, dictionary indices and unchecked bytes. 
- A previously generated EmojiId can be restored from a string or a byte set, these should include a valid checksum.
- An EmojiId that was created from a NodeId, can be destructed to obtain the encoded NodeId and version.
- Added a EmojiIterator that allows a byte set to be traversed in 10bit increments to simplify the construction of the EmojiId.
- Added a test emoji dictionary with 1024 emoji, for some of the dictionary elements only ascii characters were used. This emoji dictionary should be updated in the future.

## Motivation and Context
These changes provide a generic system to encode and decode EmojiIds, it also provide the ability to encode NodeIds as EmojiIds with dictionary versions.

## How Has This Been Tested?
The id_from_bytes, id_from_indices, id_from_node_id tests were added to demonstrate the different methods of EmojiId encoding and decoding. 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [x] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch
* [x] I ran `cargo-fmt --all` before pushing
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
