### PR TITLE
Base node peers - fix feature flag

### DIFF
--- a/applications/tari_base_node/src/builder.rs
+++ b/applications/tari_base_node/src/builder.rs
@@ -415,7 +415,7 @@ fn assign_peers(seeds: &[String]) -> Vec<Peer> {
             node_id,
             addr.into(),
             PeerFlags::default(),
-            PeerFeatures::empty(),
+            PeerFeatures::COMMUNICATION_NODE,
         );
         result.push(peer);
     }


### PR DESCRIPTION
Whitelisted peer nodes in the base node app were being excluded because
the MESSAGE_PROPAGATION flag was not set in their peer records,
resulting in them not being discoverable on the network.

This change set the peer feature flag to COMMNuICATION_NODE by default
so that peers are selected.

