### PR TITLE
ConsensusManager refactor

### DIFF
--- a/applications/tari_base_node/src/builder.rs
+++ b/applications/tari_base_node/src/builder.rs
@@ -31,7 +31,7 @@ use std::{
     time::Duration,
 };
 use tari_broadcast_channel::Subscriber;
-use tari_common::{CommsTransport, DatabaseType, GlobalConfig, SocksAuthentication, TorControlAuthentication};
+use tari_common::{CommsTransport, DatabaseType, GlobalConfig, Network, SocksAuthentication, TorControlAuthentication};
 use tari_comms::{
     multiaddr::Multiaddr,
     peer_manager::{NodeId, NodeIdentity, Peer, PeerFeatures, PeerFlags},
@@ -58,7 +58,7 @@ use tari_core::{
         MemoryDatabase,
         Validators,
     },
-    consensus::ConsensusManager,
+    consensus::{ConsensusManager, ConsensusManagerBuilder, Network as NetworkType},
     mempool::{Mempool, MempoolConfig, MempoolValidators},
     mining::Miner,
     proof_of_work::DiffAdjManager,
@@ -132,10 +132,10 @@ impl NodeType {
         .await;
     }
 
-    pub fn get_state_change_event(&self) -> Subscriber<BaseNodeState> {
+    pub fn get_state_change_event_stream(&self) -> Subscriber<BaseNodeState> {
         match self {
-            NodeType::LMDB(n) => n.get_state_change_event(),
-            NodeType::Memory(n) => n.get_state_change_event(),
+            NodeType::LMDB(n) => n.get_state_change_event_stream(),
+            NodeType::Memory(n) => n.get_state_change_event_stream(),
         }
     }
 }
@@ -249,14 +249,18 @@ pub fn configure_and_initialize_node(
     let factories = CryptoFactories::default();
     let peers = assign_peers(&config.peer_seeds);
     let executor = rt.handle().clone();
+    let network = match &config.network {
+        Network::MainNet => NetworkType::MainNet,
+        Network::TestNet => NetworkType::Rincewind,
+    };
     let result = match &config.db_type {
         DatabaseType::Memory => {
-            let rules = ConsensusManager::default();
+            let rules = ConsensusManagerBuilder::new(network).build();
             let backend = MemoryDatabase::<HashDigest>::default();
-            let mut db = BlockchainDatabase::new(backend, &rules).map_err(|e| e.to_string())?;
+            let mut db = BlockchainDatabase::new(backend, rules.clone()).map_err(|e| e.to_string())?;
             let validators = Validators::new(
                 FullConsensusValidator::new(rules.clone(), factories.clone(), db.clone()),
-                StatelessValidator::new(),
+                StatelessValidator::new(&rules.consensus_constants()),
             );
             db.set_validators(validators);
             let mempool_validator = MempoolValidators::new(
@@ -264,7 +268,8 @@ pub fn configure_and_initialize_node(
                 TxInputAndMaturityValidator::new(db.clone()),
             );
             let mempool = Mempool::new(db.clone(), MempoolConfig::default(), mempool_validator);
-            let diff_adj_manager = DiffAdjManager::new(db.clone()).map_err(|e| e.to_string())?;
+            let diff_adj_manager =
+                DiffAdjManager::new(db.clone(), &rules.consensus_constants()).map_err(|e| e.to_string())?;
             rules.set_diff_manager(diff_adj_manager).map_err(|e| e.to_string())?;
             let (comms, handles) = setup_comms_services(
                 rt,
@@ -308,12 +313,12 @@ pub fn configure_and_initialize_node(
             (comms, node, miner, base_node_context)
         },
         DatabaseType::LMDB(p) => {
-            let rules = ConsensusManager::default();
+            let rules = ConsensusManagerBuilder::new(network).build();
             let backend = create_lmdb_database(&p, MmrCacheConfig::default()).map_err(|e| e.to_string())?;
-            let mut db = BlockchainDatabase::new(backend, &rules).map_err(|e| e.to_string())?;
+            let mut db = BlockchainDatabase::new(backend, rules.clone()).map_err(|e| e.to_string())?;
             let validators = Validators::new(
                 FullConsensusValidator::new(rules.clone(), factories.clone(), db.clone()),
-                StatelessValidator::new(),
+                StatelessValidator::new(&rules.consensus_constants()),
             );
             db.set_validators(validators);
             let mempool_validator = MempoolValidators::new(
@@ -321,7 +326,8 @@ pub fn configure_and_initialize_node(
                 TxInputAndMaturityValidator::new(db.clone()),
             );
             let mempool = Mempool::new(db.clone(), MempoolConfig::default(), mempool_validator);
-            let diff_adj_manager = DiffAdjManager::new(db.clone()).map_err(|e| e.to_string())?;
+            let diff_adj_manager =
+                DiffAdjManager::new(db.clone(), &rules.consensus_constants()).map_err(|e| e.to_string())?;
             rules.set_diff_manager(diff_adj_manager).map_err(|e| e.to_string())?;
             let (comms, handles) = setup_comms_services(
                 rt,

--- a/applications/tari_base_node/src/main.rs
+++ b/applications/tari_base_node/src/main.rs
@@ -149,7 +149,7 @@ fn main_inner() -> Result<(), ExitCodes> {
     // lets run the miner
     let miner_handle = if node_config.enable_mining {
         let mut rx = miner.get_utxo_receiver_channel();
-        let rx_events = node.get_state_change_event();
+        let mut rx_events = node.get_state_change_event_stream();
         miner.subscribe_to_state_change(rx_events);
         let mut wallet_output_handle = base_node_context.wallet_output_service.clone();
         rt.spawn(async move {

--- a/base_layer/core/src/base_node/base_node.rs
+++ b/base_layer/core/src/base_node/base_node.rs
@@ -29,6 +29,8 @@ use crate::{
     },
     chain_storage::{BlockchainBackend, BlockchainDatabase},
 };
+// use bitflags::_core::sync::atomic::AtomicBool;
+// use futures_util::sink::SinkExt;
 use futures::SinkExt;
 use log::*;
 use std::sync::{
@@ -135,7 +137,7 @@ impl<B: BlockchainBackend> BaseNodeStateMachine<B> {
     /// This clones the receiver end of the channel and gives out a copy to the caller
     /// This allows multiple subscribers to this channel by only keeping one channel and cloning the receiver for every
     /// caller.
-    pub fn get_state_change_event(&self) -> Subscriber<BaseNodeState> {
+    pub fn get_state_change_event_stream(&self) -> Subscriber<BaseNodeState> {
         self.event_receiver.clone()
     }
 

--- a/base_layer/core/src/base_node/comms_interface/inbound_handlers.rs
+++ b/base_layer/core/src/base_node/comms_interface/inbound_handlers.rs
@@ -34,7 +34,7 @@ use crate::{
         ChainStorageError,
         HistoricalBlock,
     },
-    consensus::{ConsensusConstants, ConsensusManager},
+    consensus::ConsensusManager,
     mempool::Mempool,
     transactions::transaction::{TransactionKernel, TransactionOutput},
 };
@@ -149,14 +149,18 @@ where T: BlockchainBackend + 'static
 
                 let transactions = self
                     .mempool
-                    .retrieve(ConsensusConstants::current().get_max_block_transaction_weight())
+                    .retrieve(
+                        self.consensus_manager
+                            .consensus_constants()
+                            .get_max_block_transaction_weight(),
+                    )
                     .map_err(|e| CommsInterfaceError::MempoolError(e.to_string()))?
                     .iter()
                     .map(|tx| (**tx).clone())
                     .collect();
 
                 let block_template = NewBlockTemplate::from(
-                    BlockBuilder::new()
+                    BlockBuilder::new(&self.consensus_manager.consensus_constants())
                         .with_header(header)
                         .with_transactions(transactions)
                         .build(),

--- a/base_layer/core/src/blocks/block.rs
+++ b/base_layer/core/src/blocks/block.rs
@@ -93,13 +93,12 @@ impl Block {
     /// 1. There is exactly ONE coinbase output
     /// 1. The output's maturity is correctly set
     /// NOTE this does not check the coinbase amount
-    pub fn check_coinbase_output(&self) -> Result<(), BlockValidationError> {
+    pub fn check_coinbase_output(&self, consensus_constants: &ConsensusConstants) -> Result<(), BlockValidationError> {
         let mut coinbase_counter = 0; // there should be exactly 1 coinbase
         for utxo in self.body.outputs() {
             if utxo.features.flags.contains(OutputFlags::COINBASE_OUTPUT) {
                 coinbase_counter += 1;
-                if utxo.features.maturity < (self.header.height + ConsensusConstants::current().coinbase_lock_height())
-                {
+                if utxo.features.maturity < (self.header.height + consensus_constants.coinbase_lock_height()) {
                     debug!(target: LOG_TARGET, "Coinbase found with maturity set to low");
                     return Err(BlockValidationError::InvalidCoinbase);
                 }
@@ -160,9 +159,9 @@ pub struct BlockBuilder {
 }
 
 impl BlockBuilder {
-    pub fn new() -> BlockBuilder {
+    pub fn new(consensus_constants: &ConsensusConstants) -> BlockBuilder {
         BlockBuilder {
-            header: BlockHeader::new(ConsensusConstants::current().blockchain_version()),
+            header: BlockHeader::new(consensus_constants.blockchain_version()),
             inputs: Vec::new(),
             outputs: Vec::new(),
             kernels: Vec::new(),

--- a/base_layer/core/src/chain_storage/blockchain_database.rs
+++ b/base_layer/core/src/chain_storage/blockchain_database.rs
@@ -199,15 +199,16 @@ macro_rules! fetch {
 /// ```
 /// use tari_core::{
 ///     chain_storage::{BlockchainDatabase, MemoryDatabase, Validators},
-///     consensus::ConsensusManager,
+///     consensus::{ConsensusManagerBuilder, Network},
 ///     transactions::types::HashDigest,
 ///     validation::{mocks::MockValidator, Validation},
 /// };
 /// let db_backend = MemoryDatabase::<HashDigest>::default();
 /// let validators = Validators::new(MockValidator::new(true), MockValidator::new(true));
 /// let db = MemoryDatabase::<HashDigest>::default();
-/// let rules = ConsensusManager::default();
-/// let mut db = BlockchainDatabase::new(db_backend, &rules).unwrap();
+/// let network = Network::LocalNet;
+/// let rules = ConsensusManagerBuilder::new(network).build();
+/// let mut db = BlockchainDatabase::new(db_backend, rules.clone()).unwrap();
 /// db.set_validators(validators);
 /// // Do stuff with db
 /// ```
@@ -217,21 +218,23 @@ where T: BlockchainBackend
     metadata: Arc<RwLock<ChainMetadata>>,
     db: Arc<T>,
     validators: Option<Validators<T>>,
+    consensus_manager: ConsensusManager<T>,
 }
 
 impl<T> BlockchainDatabase<T>
 where T: BlockchainBackend
 {
     /// Creates a new `BlockchainDatabase` using the provided backend.
-    pub fn new(db: T, consensus_manager: &ConsensusManager<T>) -> Result<Self, ChainStorageError> {
+    pub fn new(db: T, consensus_manager: ConsensusManager<T>) -> Result<Self, ChainStorageError> {
         let metadata = Self::read_metadata(&db)?;
         let blockchain_db = BlockchainDatabase {
             metadata: Arc::new(RwLock::new(metadata)),
             db: Arc::new(db),
             validators: None,
+            consensus_manager,
         };
         if let None = blockchain_db.get_height()? {
-            let genesis_block = consensus_manager.get_genesis_block();
+            let genesis_block = blockchain_db.consensus_manager.get_genesis_block();
             let genesis_block_hash = genesis_block.hash();
             blockchain_db.store_new_block(genesis_block)?;
             blockchain_db.update_metadata(0, genesis_block_hash)?;
@@ -553,7 +556,7 @@ where T: BlockchainBackend
         let (utxo_hashes, deleted_nodes) = utxo_cp.into_parts();
         let inputs = self.fetch_inputs(deleted_nodes)?;
         let (outputs, spent) = self.fetch_outputs(utxo_hashes)?;
-        let block = BlockBuilder::new()
+        let block = BlockBuilder::new(&self.consensus_manager.consensus_constants())
             .with_header(header)
             .add_inputs(inputs)
             .add_outputs(outputs)
@@ -962,6 +965,7 @@ where T: BlockchainBackend
             metadata: self.metadata.clone(),
             db: self.db.clone(),
             validators: self.validators.clone(),
+            consensus_manager: self.consensus_manager.clone(),
         }
     }
 }

--- a/base_layer/core/src/consensus/consensus_manager.rs
+++ b/base_layer/core/src/consensus/consensus_manager.rs
@@ -21,15 +21,23 @@
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 use crate::{
-    blocks::Block,
+    blocks::{
+        genesis_block::{
+            get_mainnet_block_hash,
+            get_mainnet_genesis_block,
+            get_rincewind_block_hash,
+            get_rincewind_genesis_block,
+        },
+        Block,
+    },
     chain_storage::{BlockchainBackend, ChainStorageError},
-    consensus::{emission::EmissionSchedule, ConsensusConstants},
+    consensus::{emission::EmissionSchedule, network::Network, ConsensusConstants},
     proof_of_work::{DiffAdjManager, DiffAdjManagerError, Difficulty, DifficultyAdjustmentError, PowAlgorithm},
     transactions::tari_amount::MicroTari,
 };
 use derive_error::Error;
 use std::sync::{Arc, RwLock, RwLockReadGuard};
-use tari_crypto::tari_utilities::epoch_time::EpochTime;
+use tari_crypto::tari_utilities::{epoch_time::EpochTime, hash::Hashable};
 
 #[derive(Debug, Error, Clone, PartialEq)]
 pub enum ConsensusManagerError {
@@ -60,15 +68,32 @@ where B: BlockchainBackend
 impl<B> ConsensusManager<B>
 where B: BlockchainBackend
 {
-    pub fn new(diff_adj_manager: Option<DiffAdjManager<B>>, consensus_constants: ConsensusConstants) -> Self {
-        Self {
-            inner: Arc::new(ConsensusManagerInner::new(diff_adj_manager, consensus_constants)),
+    /// Returns the genesis block for the selected network.
+    pub fn get_genesis_block(&self) -> Block {
+        match self.inner.network {
+            Network::MainNet => get_mainnet_genesis_block(),
+            Network::Rincewind => get_rincewind_genesis_block(),
+            Network::LocalNet => (self.inner.gen_block.clone().unwrap_or(get_rincewind_genesis_block())),
+        }
+    }
+
+    /// Returns the genesis block hash for the selected network.
+    pub fn get_genesis_block_hash(&self) -> Vec<u8> {
+        match self.inner.network {
+            Network::MainNet => get_mainnet_block_hash(),
+            Network::Rincewind => get_rincewind_block_hash(),
+            Network::LocalNet => (self.inner.gen_block.as_ref().unwrap_or(&get_rincewind_genesis_block())).hash(),
         }
     }
 
     /// Get a pointer to the emission schedule
     pub fn emission_schedule(&self) -> &EmissionSchedule {
-        &self.inner.consensus_constants.emission_schedule()
+        &self.inner.emission
+    }
+
+    /// Get a pointer to the consensus constants
+    pub fn consensus_constants(&self) -> &ConsensusConstants {
+        &self.inner.consensus_constants
     }
 
     /// This moves over a difficulty adjustment manager to the ConsensusManager to control.
@@ -150,24 +175,9 @@ where B: BlockchainBackend
             .map_err(|e| ConsensusManagerError::PoisonedAccess(e.to_string()))
     }
 
-    /// Returns the genesis block for the configured network.
-    pub fn get_genesis_block(&self) -> Block {
-        self.inner.consensus_constants.network().get_genesis_block()
-    }
-
-    /// Returns the genesis block hash for the configured network.
-    pub fn get_genesis_block_hash(&self) -> Vec<u8> {
-        self.inner.consensus_constants.network().get_genesis_block_hash()
-    }
-}
-
-impl<B> Default for ConsensusManager<B>
-where B: BlockchainBackend
-{
-    fn default() -> Self {
-        ConsensusManager {
-            inner: Arc::new(ConsensusManagerInner::default()),
-        }
+    /// This is the currently configured chain network.
+    pub fn network(&self) -> Network {
+        self.inner.network
     }
 }
 
@@ -189,23 +199,77 @@ where B: BlockchainBackend
     pub diff_adj_manager: RwLock<Option<DiffAdjManager<B>>>,
     /// This is the inner struct used to control all consensus values.
     pub consensus_constants: ConsensusConstants,
+
+    /// The configured chain network.
+    pub network: Network,
+    /// The configuration for the emission schedule.
+    pub emission: EmissionSchedule,
+    /// This allows the user to set a custom Genesis block
+    pub gen_block: Option<Block>,
 }
 
-impl<B> ConsensusManagerInner<B>
+/// Constructor for the consensus manager struct
+pub struct ConsensusManagerBuilder<B>
 where B: BlockchainBackend
 {
-    pub fn new(diff_adj_manager: Option<DiffAdjManager<B>>, consensus_constants: ConsensusConstants) -> Self {
-        Self {
-            diff_adj_manager: RwLock::new(diff_adj_manager),
-            consensus_constants,
+    /// Difficulty adjustment manager for the blockchain
+    pub diff_adj_manager: Option<DiffAdjManager<B>>,
+    /// This is the inner struct used to control all consensus values.
+    pub consensus_constants: Option<ConsensusConstants>,
+    /// The configured chain network.
+    pub network: Network,
+    /// This allows the user to set a custom Genesis block
+    pub gen_block: Option<Block>,
+}
+
+impl<B> ConsensusManagerBuilder<B>
+where B: BlockchainBackend
+{
+    /// Creates a new ConsensusManagerBuilder with the specified network
+    pub fn new(network: Network) -> Self {
+        ConsensusManagerBuilder {
+            diff_adj_manager: None,
+            consensus_constants: None,
+            network,
+            gen_block: None,
         }
     }
-}
 
-impl<B> Default for ConsensusManagerInner<B>
-where B: BlockchainBackend
-{
-    fn default() -> Self {
-        Self::new(None, ConsensusConstants::default())
+    /// Adds in a custom consensus constants to be used
+    pub fn with_consensus_constants(mut self, consensus_constants: ConsensusConstants) -> Self {
+        self.consensus_constants = Some(consensus_constants);
+        self
+    }
+
+    /// Adds in a difficulty adjustment manager to be used to be used
+    pub fn with_difficulty_adjustment_manager(mut self, difficulty_adj: DiffAdjManager<B>) -> Self {
+        self.diff_adj_manager = Some(difficulty_adj);
+        self
+    }
+
+    /// Adds in a custom block to be used. This will be overwritten if the network is anything else than localnet
+    pub fn with_block(mut self, block: Block) -> Self {
+        self.gen_block = Some(block);
+        self
+    }
+
+    /// Builds a consensus manager
+    pub fn build(self) -> ConsensusManager<B> {
+        let consensus_constants = self
+            .consensus_constants
+            .unwrap_or(self.network.create_consensus_constants());
+        let emission = EmissionSchedule::new(
+            consensus_constants.emission_initial,
+            consensus_constants.emission_decay,
+            consensus_constants.emission_tail,
+        );
+        let inner = ConsensusManagerInner {
+            diff_adj_manager: RwLock::new(self.diff_adj_manager),
+            consensus_constants,
+            network: self.network,
+            emission,
+            gen_block: self.gen_block,
+        };
+        ConsensusManager { inner: Arc::new(inner) }
     }
 }

--- a/base_layer/core/src/consensus/mod.rs
+++ b/base_layer/core/src/consensus/mod.rs
@@ -26,6 +26,6 @@ mod network;
 
 pub mod emission;
 
-pub use consensus_constants::ConsensusConstants;
-pub use consensus_manager::{ConsensusManager, ConsensusManagerError};
+pub use consensus_constants::{ConsensusConstants, ConsensusConstantsBuilder};
+pub use consensus_manager::{ConsensusManager, ConsensusManagerBuilder, ConsensusManagerError};
 pub use network::Network;

--- a/base_layer/core/src/consensus/network.rs
+++ b/base_layer/core/src/consensus/network.rs
@@ -20,18 +20,10 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use crate::blocks::{
-    genesis_block::{
-        get_mainnet_block_hash,
-        get_mainnet_genesis_block,
-        get_rincewind_block_hash,
-        get_rincewind_genesis_block,
-    },
-    Block,
-};
-use tari_crypto::tari_utilities::hash::Hashable;
+use super::consensus_constants::ConsensusConstants;
 
 /// Specifies the configured chain network.
+#[derive(Copy, Clone)]
 pub enum Network {
     /// Mainnet of Tari, currently should panic if network is set to this.
     MainNet,
@@ -39,25 +31,15 @@ pub enum Network {
     Rincewind,
     /// Local network constants used inside of unit and integration tests. Contains the genesis block to be used for
     /// that chain.
-    LocalNet(Box<Block>),
+    LocalNet,
 }
 
 impl Network {
-    /// Returns the genesis block for the selected network.
-    pub fn get_genesis_block(&self) -> Block {
+    pub fn create_consensus_constants(&self) -> ConsensusConstants {
         match self {
-            Network::MainNet => get_mainnet_genesis_block(),
-            Network::Rincewind => get_rincewind_genesis_block(),
-            Network::LocalNet(genesis_block) => (**genesis_block).clone(),
-        }
-    }
-
-    /// Returns the genesis block hash for the selected network.
-    pub fn get_genesis_block_hash(&self) -> Vec<u8> {
-        match self {
-            Network::MainNet => get_mainnet_block_hash(),
-            Network::Rincewind => get_rincewind_block_hash(),
-            Network::LocalNet(genesis_block) => (**genesis_block).hash(),
+            Network::MainNet => ConsensusConstants::mainnet(),
+            Network::Rincewind => ConsensusConstants::rincewind(),
+            Network::LocalNet => ConsensusConstants::localnet(),
         }
     }
 }

--- a/base_layer/core/src/mempool/orphan_pool/orphan_pool.rs
+++ b/base_layer/core/src/mempool/orphan_pool/orphan_pool.rs
@@ -152,7 +152,7 @@ where T: BlockchainBackend
 #[cfg(test)]
 mod test {
     use crate::{
-        consensus::Network,
+        consensus::{ConsensusManagerBuilder, Network},
         helpers::create_mem_db,
         mempool::orphan_pool::{OrphanPool, OrphanPoolConfig},
         transactions::tari_amount::MicroTari,
@@ -169,8 +169,9 @@ mod test {
         let tx4 = Arc::new(tx!(MicroTari(10_000), fee: MicroTari(200), lock: 1000, inputs: 2, outputs: 1).0);
         let tx5 = Arc::new(tx!(MicroTari(10_000), fee: MicroTari(500), lock: 2000, inputs: 2, outputs: 1).0);
         let tx6 = Arc::new(tx!(MicroTari(10_000), fee: MicroTari(600), lock: 5500, inputs: 2, outputs: 1).0);
-
-        let store = create_mem_db(Network::Rincewind);
+        let network = Network::LocalNet;
+        let consensus_manager = ConsensusManagerBuilder::new(network).build();
+        let store = create_mem_db(consensus_manager);
         let mempool_validator = Box::new(TxInputAndMaturityValidator::new(store.clone()));
         let orphan_pool = OrphanPool::new(
             OrphanPoolConfig {

--- a/base_layer/core/src/mempool/pending_pool/pending_pool.rs
+++ b/base_layer/core/src/mempool/pending_pool/pending_pool.rs
@@ -148,6 +148,7 @@ impl Clone for PendingPool {
 #[cfg(test)]
 mod test {
     use crate::{
+        consensus::Network,
         helpers::create_orphan_block,
         mempool::pending_pool::{PendingPool, PendingPoolConfig},
         transactions::tari_amount::MicroTari,
@@ -219,6 +220,8 @@ mod test {
 
     #[test]
     fn test_remove_unlocked_and_discard_double_spends() {
+        let network = Network::LocalNet;
+        let consensus_constants = network.create_consensus_constants();
         let tx1 = Arc::new(tx!(MicroTari(10_000), fee: MicroTari(50), lock: 500, inputs: 2, outputs: 1).0);
         let tx2 =
             Arc::new(tx!(MicroTari(10_000), fee: MicroTari(20), lock: 0, inputs: 1, maturity: 2150, outputs: 2).0);
@@ -254,7 +257,7 @@ mod test {
         assert!(snapshot_txs.contains(&tx5));
         assert!(snapshot_txs.contains(&tx6));
 
-        let published_block = create_orphan_block(1500, vec![(*tx6).clone()]);
+        let published_block = create_orphan_block(1500, vec![(*tx6).clone()], &consensus_constants);
         let unlocked_txs = pending_pool
             .remove_unlocked_and_discard_double_spends(&published_block)
             .unwrap();

--- a/base_layer/core/src/mempool/reorg_pool/reorg_pool.rs
+++ b/base_layer/core/src/mempool/reorg_pool/reorg_pool.rs
@@ -132,7 +132,7 @@ impl Clone for ReorgPool {
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::{helpers::create_orphan_block, transactions::tari_amount::MicroTari, tx};
+    use crate::{consensus::Network, helpers::create_orphan_block, transactions::tari_amount::MicroTari, tx};
     use std::{thread, time::Duration};
 
     #[test]
@@ -221,6 +221,8 @@ mod test {
 
     #[test]
     fn remove_scan_for_and_remove_reorged_txs() {
+        let network = Network::LocalNet;
+        let consensus_constants = network.create_consensus_constants();
         let tx1 = Arc::new(tx!(MicroTari(10_000), fee: MicroTari(50), lock: 4000, inputs: 2, outputs: 1).0);
         let tx2 = Arc::new(tx!(MicroTari(10_000), fee: MicroTari(30), lock: 3000, inputs: 2, outputs: 1).0);
         let tx3 = Arc::new(tx!(MicroTari(10_000), fee: MicroTari(20), lock: 2500, inputs: 2, outputs: 1).0);
@@ -282,8 +284,8 @@ mod test {
         );
 
         let reorg_blocks = vec![
-            create_orphan_block(3000, vec![(*tx3).clone(), (*tx4).clone()]),
-            create_orphan_block(4000, vec![(*tx1).clone(), (*tx2).clone()]),
+            create_orphan_block(3000, vec![(*tx3).clone(), (*tx4).clone()], &consensus_constants),
+            create_orphan_block(4000, vec![(*tx1).clone(), (*tx2).clone()], &consensus_constants),
         ];
 
         let removed_txs = reorg_pool

--- a/base_layer/core/src/mempool/unconfirmed_pool/unconfirmed_pool.rs
+++ b/base_layer/core/src/mempool/unconfirmed_pool/unconfirmed_pool.rs
@@ -161,7 +161,7 @@ impl Clone for UnconfirmedPool {
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::{helpers::create_orphan_block, transactions::tari_amount::MicroTari, tx};
+    use crate::{consensus::Network, helpers::create_orphan_block, transactions::tari_amount::MicroTari, tx};
 
     #[test]
     fn test_insert_and_retrieve_highest_priority_txs() {
@@ -224,6 +224,8 @@ mod test {
 
     #[test]
     fn test_remove_published_txs() {
+        let network = Network::LocalNet;
+        let consensus_constants = network.create_consensus_constants();
         let tx1 = Arc::new(tx!(MicroTari(10_000), fee: MicroTari(50), inputs:2, outputs: 1).0);
         let tx2 = Arc::new(tx!(MicroTari(10_000), fee: MicroTari(20), inputs:3, outputs: 1).0);
         let tx3 = Arc::new(tx!(MicroTari(10_000), fee: MicroTari(100), inputs:2, outputs: 1).0);
@@ -249,7 +251,11 @@ mod test {
         assert!(snapshot_txs.contains(&tx4));
         assert!(snapshot_txs.contains(&tx5));
 
-        let published_block = create_orphan_block(0, vec![(*tx1).clone(), (*tx3).clone(), (*tx5).clone()]);
+        let published_block = create_orphan_block(
+            0,
+            vec![(*tx1).clone(), (*tx3).clone(), (*tx5).clone()],
+            &consensus_constants,
+        );
         let _ = unconfirmed_pool.remove_published_and_discard_double_spends(&published_block);
 
         assert_eq!(
@@ -294,6 +300,8 @@ mod test {
 
     #[test]
     fn test_discard_double_spend_txs() {
+        let network = Network::LocalNet;
+        let consensus_constants = network.create_consensus_constants();
         let tx1 = Arc::new(tx!(MicroTari(5_000), fee: MicroTari(50), inputs:2, outputs:1).0);
         let tx2 = Arc::new(tx!(MicroTari(5_000), fee: MicroTari(20), inputs:3, outputs:1).0);
         let tx3 = Arc::new(tx!(MicroTari(5_000), fee: MicroTari(100), inputs:2, outputs:1).0);
@@ -322,7 +330,11 @@ mod test {
             .unwrap();
 
         // The publishing of tx1 and tx3 will be double-spends and orphan tx5 and tx6
-        let published_block = create_orphan_block(0, vec![(*tx1).clone(), (*tx2).clone(), (*tx3).clone()]);
+        let published_block = create_orphan_block(
+            0,
+            vec![(*tx1).clone(), (*tx2).clone(), (*tx3).clone()],
+            &consensus_constants,
+        );
 
         let _ = unconfirmed_pool
             .remove_published_and_discard_double_spends(&published_block)

--- a/base_layer/core/src/mining/coinbase_builder.rs
+++ b/base_layer/core/src/mining/coinbase_builder.rs
@@ -23,7 +23,7 @@
 
 use crate::{
     chain_storage::BlockchainBackend,
-    consensus::{ConsensusConstants, ConsensusManager},
+    consensus::ConsensusManager,
     transactions::{
         tari_amount::{uT, MicroTari},
         transaction::{
@@ -125,7 +125,7 @@ impl CoinbaseBuilder {
         let public_nonce = PublicKey::from_secret_key(&nonce);
         let key = self.spend_key.ok_or_else(|| CoinbaseBuildError::MissingSpendKey)?;
         let output_features =
-            OutputFeatures::create_coinbase(height + ConsensusConstants::current().coinbase_lock_height());
+            OutputFeatures::create_coinbase(height + rules.consensus_constants().coinbase_lock_height());
         let excess = self.factories.commitment.commit_value(&key, 0);
         let kernel_features = KernelFeatures::create_coinbase();
         let metadata = TransactionMetadata::default();
@@ -161,7 +161,7 @@ impl CoinbaseBuilder {
 #[cfg(test)]
 mod test {
     use crate::{
-        consensus::ConsensusManager,
+        consensus::{ConsensusManager, ConsensusManagerBuilder, Network},
         helpers::MockBackend,
         mining::{coinbase_builder::CoinbaseBuildError, CoinbaseBuilder},
         transactions::{
@@ -174,7 +174,8 @@ mod test {
     use tari_crypto::commitment::HomomorphicCommitmentFactory;
 
     fn get_builder() -> (CoinbaseBuilder, ConsensusManager<MockBackend>, CryptoFactories) {
-        let rules = ConsensusManager::default();
+        let network = Network::LocalNet;
+        let rules = ConsensusManagerBuilder::new(network).build();
         let factories = CryptoFactories::default();
         (CoinbaseBuilder::new(factories.clone()), rules, factories)
     }

--- a/base_layer/core/src/mining/miner.rs
+++ b/base_layer/core/src/mining/miner.rs
@@ -104,8 +104,8 @@ impl<B: BlockchainBackend> Miner<B> {
 
     /// Async function to mine a block
     async fn mining(&mut self) -> Result<(), MinerError> {
-        debug!(target: LOG_TARGET, "start mining thread");
         // Lets make sure its set to mine
+        debug!(target: LOG_TARGET, "Start mining thread");
         while !self.kill_flag.load(Ordering::Relaxed) {
             while !self.received_new_block_flag.load(Ordering::Relaxed) {
                 tokio::time::delay_for(Duration::from_millis(100)).await; // wait for new block event
@@ -150,7 +150,11 @@ impl<B: BlockchainBackend> Miner<B> {
     pub async fn mine(mut self) {
         let flag = self.received_new_block_flag.clone();
         let block_event = self.node_interface.clone().get_block_event_stream_fused();
-        let state_event = self.state_change_event_rx.take().expect("todo").fuse();
+        let state_event = self
+            .state_change_event_rx
+            .take()
+            .expect("Miner does not have access to state event stream")
+            .fuse();
         let t_miner = self.mining().fuse();
 
         pin_mut!(block_event);

--- a/base_layer/core/src/proof_of_work/diff_adj_manager/diff_adj_manager.rs
+++ b/base_layer/core/src/proof_of_work/diff_adj_manager/diff_adj_manager.rs
@@ -22,6 +22,7 @@
 
 use crate::{
     chain_storage::{BlockchainBackend, BlockchainDatabase},
+    consensus::ConsensusConstants,
     proof_of_work::{
         diff_adj_manager::{diff_adj_storage::DiffAdjStorage, error::DiffAdjManagerError},
         Difficulty,
@@ -43,9 +44,13 @@ impl<T> DiffAdjManager<T>
 where T: BlockchainBackend
 {
     /// Constructs a new DiffAdjManager with access to the blockchain db.
-    pub fn new(blockchain_db: BlockchainDatabase<T>) -> Result<Self, DiffAdjManagerError> {
+    pub fn new(
+        blockchain_db: BlockchainDatabase<T>,
+        consensus_constants: &ConsensusConstants,
+    ) -> Result<Self, DiffAdjManagerError>
+    {
         Ok(Self {
-            diff_adj_storage: Arc::new(RwLock::new(DiffAdjStorage::new(blockchain_db))),
+            diff_adj_storage: Arc::new(RwLock::new(DiffAdjStorage::new(blockchain_db, consensus_constants))),
         })
     }
 

--- a/base_layer/core/src/proof_of_work/lwma_diff.rs
+++ b/base_layer/core/src/proof_of_work/lwma_diff.rs
@@ -6,12 +6,9 @@
 // https://github.com/zawy12/difficulty-algorithms/issues/3#issuecomment-442129791
 // https://github.com/zcash/zcash/issues/4021
 
-use crate::{
-    consensus::ConsensusConstants,
-    proof_of_work::{
-        difficulty::{Difficulty, DifficultyAdjustment},
-        error::DifficultyAdjustmentError,
-    },
+use crate::proof_of_work::{
+    difficulty::{Difficulty, DifficultyAdjustment},
+    error::DifficultyAdjustmentError,
 };
 use log::*;
 use std::{cmp, collections::VecDeque};
@@ -25,16 +22,6 @@ pub struct LinearWeightedMovingAverage {
     accumulated_difficulties: VecDeque<Difficulty>,
     block_window: usize,
     target_time: u64,
-}
-
-impl Default for LinearWeightedMovingAverage {
-    fn default() -> Self {
-        let consensus = ConsensusConstants::current();
-        LinearWeightedMovingAverage::new(
-            consensus.get_difficulty_block_window() as usize,
-            consensus.get_diff_target_block_interval(),
-        )
-    }
 }
 
 impl LinearWeightedMovingAverage {
@@ -140,13 +127,13 @@ mod test {
 
     #[test]
     fn lwma_zero_len() {
-        let dif = LinearWeightedMovingAverage::default();
+        let dif = LinearWeightedMovingAverage::new(90, 120);
         assert_eq!(dif.get_difficulty(), Difficulty::min());
     }
 
     #[test]
     fn lwma_add_non_increasing_diff() {
-        let mut dif = LinearWeightedMovingAverage::default();
+        let mut dif = LinearWeightedMovingAverage::new(90, 120);
         assert!(dif.add(100.into(), 100.into()).is_ok());
         assert!(dif.add(100.into(), 100.into()).is_err());
         assert!(dif.add(100.into(), 50.into()).is_err());
@@ -154,7 +141,7 @@ mod test {
 
     #[test]
     fn lwma_negative_solve_times() {
-        let mut dif = LinearWeightedMovingAverage::default();
+        let mut dif = LinearWeightedMovingAverage::new(90, 120);
         let mut timestamp = 60.into();
         let mut cum_diff = Difficulty::from(100);
         let _ = dif.add(timestamp, cum_diff);

--- a/base_layer/core/src/transactions/transaction.rs
+++ b/base_layer/core/src/transactions/transaction.rs
@@ -918,9 +918,6 @@ mod test {
     #[test]
     fn check_cut_through_() {
         let (tx, _, outputs) = create_tx(50000000.into(), 15.into(), 1, 2, 1, 2);
-        dbg!(&tx.body.outputs().len());
-        dbg!(&tx.body.inputs().len());
-        dbg!(&tx.body.kernels().len());
 
         assert_eq!(tx.body.inputs().len(), 2);
         assert_eq!(tx.body.outputs().len(), 2);

--- a/base_layer/core/src/validation/block_validators.rs
+++ b/base_layer/core/src/validation/block_validators.rs
@@ -41,12 +41,15 @@ use tari_crypto::tari_utilities::hash::Hashable;
 pub const LOG_TARGET: &str = "c::val::block_validators";
 
 /// This validator tests whether a candidate block is internally consistent
-#[derive(Default)]
-pub struct StatelessValidator {}
+pub struct StatelessValidator {
+    consensus_constants: ConsensusConstants,
+}
 
 impl StatelessValidator {
-    pub fn new() -> Self {
-        Self {}
+    pub fn new(consensus_constants: &ConsensusConstants) -> Self {
+        Self {
+            consensus_constants: consensus_constants.clone(),
+        }
     }
 }
 
@@ -56,7 +59,7 @@ impl<B: BlockchainBackend> Validation<Block, B> for StatelessValidator {
     /// 1. Is the accounting correct?
     /// 1. Are all inputs allowed to be spent (Are the feature flags satisfied)
     fn validate(&self, block: &Block) -> Result<(), ValidationError> {
-        check_coinbase_output(block)?;
+        check_coinbase_output(block, &self.consensus_constants)?;
         // Check that the inputs are are allowed to be spent
         block.check_stxo_rules().map_err(BlockValidationError::from)?;
         check_cut_through(block)?;
@@ -93,12 +96,12 @@ impl<B: BlockchainBackend> Validation<Block, B> for FullConsensusValidator<B> {
     /// 1. Is the Proof of Work valid?
     /// 1. Is the achieved difficulty of this block >= the target difficulty for this block?
     fn validate(&self, block: &Block) -> Result<(), ValidationError> {
-        check_coinbase_output(block)?;
+        check_coinbase_output(block, &self.rules.consensus_constants())?;
         check_cut_through(block)?;
         block.check_stxo_rules().map_err(BlockValidationError::from)?;
         check_accounting_balance(block, self.rules.clone(), &self.factories)?;
         check_inputs_are_utxos(block, self.db()?)?;
-        check_timestamp_ftl(&block.header)?;
+        check_timestamp_ftl(&block.header, &self.rules)?;
         check_median_timestamp_at_chain_tip(&block.header, self.db()?, self.rules.clone())?;
         check_achieved_difficulty_at_chain_tip(&block.header, self.db()?, self.rules.clone())?; // Update function signature once diff adjuster is complete
         Ok(())
@@ -120,8 +123,10 @@ fn check_accounting_balance<B: BlockchainBackend>(
         .map_err(ValidationError::TransactionError)
 }
 
-fn check_coinbase_output(block: &Block) -> Result<(), ValidationError> {
-    block.check_coinbase_output().map_err(ValidationError::from)
+fn check_coinbase_output(block: &Block, consensus_constants: &ConsensusConstants) -> Result<(), ValidationError> {
+    block
+        .check_coinbase_output(consensus_constants)
+        .map_err(ValidationError::from)
 }
 
 /// This function checks that all inputs in the blocks are valid UTXO's to be spend
@@ -145,8 +150,12 @@ fn check_inputs_are_utxos<B: BlockchainBackend>(
 }
 
 /// This function tests that the block timestamp is less than the ftl.
-fn check_timestamp_ftl(block_header: &BlockHeader) -> Result<(), ValidationError> {
-    if block_header.timestamp > ConsensusConstants::current().ftl() {
+fn check_timestamp_ftl<B: BlockchainBackend>(
+    block_header: &BlockHeader,
+    consensus_manager: &ConsensusManager<B>,
+) -> Result<(), ValidationError>
+{
+    if block_header.timestamp > consensus_manager.consensus_constants().ftl() {
         return Err(ValidationError::BlockHeaderError(
             BlockHeaderValidationError::InvalidTimestampFutureTimeLimit,
         ));

--- a/base_layer/core/tests/block_validation.rs
+++ b/base_layer/core/tests/block_validation.rs
@@ -22,7 +22,7 @@
 
 use tari_core::{
     chain_storage::{BlockchainDatabase, MemoryDatabase, Validators},
-    consensus::ConsensusManager,
+    consensus::{ConsensusManagerBuilder, Network},
     proof_of_work::DiffAdjManager,
     transactions::types::{CryptoFactories, HashDigest},
     validation::block_validators::{FullConsensusValidator, StatelessValidator},
@@ -31,15 +31,16 @@ use tari_core::{
 #[test]
 fn test_genesis_block() {
     let factories = CryptoFactories::default();
-    let rules = ConsensusManager::default();
+    let network = Network::LocalNet;
+    let rules = ConsensusManagerBuilder::new(network).build();
     let backend = MemoryDatabase::<HashDigest>::default();
-    let mut db = BlockchainDatabase::new(backend, &rules).unwrap();
+    let mut db = BlockchainDatabase::new(backend, rules.clone()).unwrap();
     let validators = Validators::new(
         FullConsensusValidator::new(rules.clone(), factories, db.clone()),
-        StatelessValidator::new(),
+        StatelessValidator::new(&rules.consensus_constants()),
     );
     db.set_validators(validators);
-    let diff_adj_manager = DiffAdjManager::new(db.clone()).unwrap();
+    let diff_adj_manager = DiffAdjManager::new(db.clone(), &rules.consensus_constants()).unwrap();
     rules.set_diff_manager(diff_adj_manager).unwrap();
     let block = rules.get_genesis_block();
     let result = db.add_block(block);

--- a/base_layer/core/tests/chain_storage_tests/chain_storage.rs
+++ b/base_layer/core/tests/chain_storage_tests/chain_storage.rs
@@ -40,7 +40,7 @@ use tari_core::{
         MmrTree,
         Validators,
     },
-    consensus::{ConsensusConstants, ConsensusManager, Network},
+    consensus::{ConsensusManagerBuilder, Network},
     helpers::{create_mem_db, create_orphan_block},
     proof_of_work::Difficulty,
     transactions::{
@@ -62,7 +62,9 @@ fn init_log() {
 
 #[test]
 fn fetch_nonexistent_kernel() {
-    let store = create_mem_db(Network::Rincewind);
+    let network = Network::LocalNet;
+    let consensus_manager = ConsensusManagerBuilder::new(network).build();
+    let store = create_mem_db(consensus_manager.clone());
     let h = vec![0u8; 32];
     assert_eq!(
         store.fetch_kernel(h.clone()),
@@ -72,7 +74,9 @@ fn fetch_nonexistent_kernel() {
 
 #[test]
 fn insert_and_fetch_kernel() {
-    let store = create_mem_db(Network::Rincewind);
+    let network = Network::LocalNet;
+    let consensus_manager = ConsensusManagerBuilder::new(network).build();
+    let store = create_mem_db(consensus_manager.clone());
     let kernel = create_test_kernel(5.into(), 0);
     let hash = kernel.hash();
 
@@ -84,7 +88,9 @@ fn insert_and_fetch_kernel() {
 
 #[test]
 fn fetch_nonexistent_header() {
-    let store = create_mem_db(Network::Rincewind);
+    let network = Network::LocalNet;
+    let consensus_manager = ConsensusManagerBuilder::new(network).build();
+    let store = create_mem_db(consensus_manager.clone());
     assert_eq!(
         store.fetch_header(1),
         Err(ChainStorageError::ValueNotFound(DbKey::BlockHeader(1)))
@@ -93,7 +99,9 @@ fn fetch_nonexistent_header() {
 
 #[test]
 fn insert_and_fetch_header() {
-    let store = create_mem_db(Network::Rincewind);
+    let network = Network::LocalNet;
+    let consensus_manager = ConsensusManagerBuilder::new(network).build();
+    let store = create_mem_db(consensus_manager.clone());
     let mut header = BlockHeader::new(0);
     header.height = 42;
 
@@ -111,7 +119,9 @@ fn insert_and_fetch_header() {
 #[test]
 fn insert_and_fetch_utxo() {
     let factories = CryptoFactories::default();
-    let store = create_mem_db(Network::Rincewind);
+    let network = Network::LocalNet;
+    let consensus_manager = ConsensusManagerBuilder::new(network).build();
+    let store = create_mem_db(consensus_manager.clone());
     let (utxo, _) = create_utxo(MicroTari(10_000), &factories, None);
     let hash = utxo.hash();
     assert_eq!(store.is_utxo(hash.clone()).unwrap(), false);
@@ -124,12 +134,14 @@ fn insert_and_fetch_utxo() {
 
 #[test]
 fn insert_and_fetch_orphan() {
-    let store = create_mem_db(Network::Rincewind);
+    let network = Network::LocalNet;
+    let consensus_manager = ConsensusManagerBuilder::new(network).build();
+    let store = create_mem_db(consensus_manager.clone());
     let txs = vec![
         (tx!(1000.into(), fee: 20.into(), inputs: 2, outputs: 1)).0,
         (tx!(2000.into(), fee: 30.into(), inputs: 1, outputs: 1)).0,
     ];
-    let orphan = create_orphan_block(10, txs);
+    let orphan = create_orphan_block(10, txs, &consensus_manager.consensus_constants());
     let orphan_hash = orphan.hash();
     let mut txn = DbTransaction::new();
     txn.insert_orphan(orphan.clone());
@@ -139,7 +151,9 @@ fn insert_and_fetch_orphan() {
 
 #[test]
 fn multiple_threads() {
-    let store = create_mem_db(Network::Rincewind);
+    let network = Network::LocalNet;
+    let consensus_manager = ConsensusManagerBuilder::new(network).build();
+    let store = create_mem_db(consensus_manager.clone());
     // Save a kernel in thread A
     let store_a = store.clone();
     let a = thread::spawn(move || {
@@ -171,7 +185,9 @@ fn multiple_threads() {
 
 #[test]
 fn utxo_and_rp_merkle_root() {
-    let store = create_mem_db(Network::Rincewind);
+    let network = Network::LocalNet;
+    let consensus_manager = ConsensusManagerBuilder::new(network).build();
+    let store = create_mem_db(consensus_manager.clone());
     let factories = CryptoFactories::default();
     let block0 = store.fetch_block(0).unwrap().block().clone();
 
@@ -203,7 +219,9 @@ fn utxo_and_rp_merkle_root() {
 
 #[test]
 fn kernel_merkle_root() {
-    let store = create_mem_db(Network::Rincewind);
+    let network = Network::LocalNet;
+    let consensus_manager = ConsensusManagerBuilder::new(network).build();
+    let store = create_mem_db(consensus_manager.clone());
     let block0 = store.fetch_block(0).unwrap().block().clone();
 
     let kernel1 = create_test_kernel(100.into(), 0);
@@ -229,7 +247,9 @@ fn kernel_merkle_root() {
 
 #[test]
 fn utxo_and_rp_future_merkle_root() {
-    let store = create_mem_db(Network::Rincewind);
+    let network = Network::LocalNet;
+    let consensus_manager = ConsensusManagerBuilder::new(network).build();
+    let store = create_mem_db(consensus_manager.clone());
     let factories = CryptoFactories::default();
 
     let (utxo1, _) = create_utxo(MicroTari(10_000), &factories, None);
@@ -268,7 +288,9 @@ fn utxo_and_rp_future_merkle_root() {
 
 #[test]
 fn kernel_future_merkle_root() {
-    let store = create_mem_db(Network::Rincewind);
+    let network = Network::LocalNet;
+    let consensus_manager = ConsensusManagerBuilder::new(network).build();
+    let store = create_mem_db(consensus_manager.clone());
 
     let kernel1 = create_test_kernel(100.into(), 0);
     let kernel2 = create_test_kernel(200.into(), 0);
@@ -293,7 +315,9 @@ fn kernel_future_merkle_root() {
 
 #[test]
 fn utxo_and_rp_mmr_proof() {
-    let store = create_mem_db(Network::Rincewind);
+    let network = Network::LocalNet;
+    let consensus_manager = ConsensusManagerBuilder::new(network).build();
+    let store = create_mem_db(consensus_manager.clone());
     let factories = CryptoFactories::default();
 
     let (utxo1, _) = create_utxo(MicroTari(5_000), &factories, None);
@@ -319,7 +343,9 @@ fn utxo_and_rp_mmr_proof() {
 
 #[test]
 fn kernel_mmr_proof() {
-    let store = create_mem_db(Network::Rincewind);
+    let network = Network::LocalNet;
+    let consensus_manager = ConsensusManagerBuilder::new(network).build();
+    let store = create_mem_db(consensus_manager.clone());
 
     let kernel1 = create_test_kernel(100.into(), 0);
     let kernel2 = create_test_kernel(200.into(), 1);
@@ -341,7 +367,7 @@ fn kernel_mmr_proof() {
 
 #[test]
 fn store_and_retrieve_block() {
-    let (db, blocks, _) = create_new_blockchain();
+    let (db, blocks, _, _) = create_new_blockchain(Network::LocalNet);
     let hash = blocks[0].hash();
     // Check the metadata
     let metadata = db.get_metadata().unwrap();
@@ -360,13 +386,15 @@ fn store_and_retrieve_block() {
 fn add_multiple_blocks() {
     init_log();
     // Create new database with genesis block
-    let store = create_mem_db(Network::Rincewind);
+    let network = Network::LocalNet;
+    let consensus_manager = ConsensusManagerBuilder::new(network).build();
+    let store = create_mem_db(consensus_manager.clone());
     let metadata = store.get_metadata().unwrap();
     assert_eq!(metadata.height_of_longest_chain, Some(0));
     let block0 = store.fetch_block(0).unwrap().block().clone();
     assert_eq!(metadata.best_block, Some(block0.hash()));
     // Add another block
-    let block1 = append_block(&store, &block0, vec![]).unwrap();
+    let block1 = append_block(&store, &block0, vec![], &consensus_manager.consensus_constants()).unwrap();
     let metadata = store.get_metadata().unwrap();
     let hash = block1.hash();
     assert_eq!(metadata.height_of_longest_chain, Some(1));
@@ -381,14 +409,15 @@ fn add_multiple_blocks() {
 
 #[test]
 fn test_checkpoints() {
-    let (db, blocks, outputs) = create_new_blockchain();
+    let network = Network::LocalNet;
+    let (db, blocks, outputs, consensus_manager) = create_new_blockchain(network);
 
     let txn = txn_schema!(
         from: vec![outputs[0][0].clone()],
         to: vec![MicroTari(5_000), MicroTari(6_000)]
     );
     let (txn, _, _) = spend_utxos(txn);
-    let block1 = append_block(&db, &blocks[0], vec![txn]).unwrap();
+    let block1 = append_block(&db, &blocks[0], vec![txn], &consensus_manager.consensus_constants()).unwrap();
     // Get the checkpoint
     let block_a = db.fetch_block(0).unwrap();
     assert_eq!(block_a.confirmations(), 2);
@@ -402,20 +431,42 @@ fn test_checkpoints() {
 
 #[test]
 fn rewind_to_height() {
-    let (mut db, mut blocks, mut outputs) = create_new_blockchain();
+    let network = Network::LocalNet;
+    let (mut db, mut blocks, mut outputs, consensus_manager) = create_new_blockchain(network);
 
     // Block 1
     let schema = vec![txn_schema!(from: vec![outputs[0][0].clone()], to: vec![6 * T, 3 * T])];
-    generate_new_block(&mut db, &mut blocks, &mut outputs, schema).unwrap();
+    generate_new_block(
+        &mut db,
+        &mut blocks,
+        &mut outputs,
+        schema,
+        &consensus_manager.consensus_constants(),
+    )
+    .unwrap();
     // Block 2
     let schema = vec![txn_schema!(from: vec![outputs[1][0].clone()], to: vec![3 * T, 1 * T])];
-    generate_new_block(&mut db, &mut blocks, &mut outputs, schema).unwrap();
+    generate_new_block(
+        &mut db,
+        &mut blocks,
+        &mut outputs,
+        schema,
+        &consensus_manager.consensus_constants(),
+    )
+    .unwrap();
     // Block 3
     let schema = vec![
         txn_schema!(from: vec![outputs[2][0].clone()], to: vec![2 * T, 500_000 * uT]),
         txn_schema!(from: vec![outputs[1][1].clone()], to: vec![500_000 * uT]),
     ];
-    generate_new_block(&mut db, &mut blocks, &mut outputs, schema).unwrap();
+    generate_new_block(
+        &mut db,
+        &mut blocks,
+        &mut outputs,
+        schema,
+        &consensus_manager.consensus_constants(),
+    )
+    .unwrap();
 
     assert!(db.rewind_to_height(3).is_ok());
     // Check MMRs are correct
@@ -451,7 +502,8 @@ fn handle_tip_reorg() {
     // reorged to GB->A1->B2
 
     // Create Main Chain
-    let (mut store, mut blocks, mut outputs) = create_new_blockchain();
+    let network = Network::LocalNet;
+    let (mut store, mut blocks, mut outputs, consensus_manager) = create_new_blockchain(network);
     // Block A1
     let txs = vec![txn_schema!(
         from: vec![outputs[0][0].clone()],
@@ -462,7 +514,8 @@ fn handle_tip_reorg() {
         &mut blocks,
         &mut outputs,
         txs,
-        Difficulty::from(1)
+        Difficulty::from(1),
+        &consensus_manager.consensus_constants()
     )
     .is_ok());
     // Block A2
@@ -472,12 +525,16 @@ fn handle_tip_reorg() {
         &mut blocks,
         &mut outputs,
         txs,
-        Difficulty::from(1)
+        Difficulty::from(1),
+        &consensus_manager.consensus_constants()
     )
     .is_ok());
 
     // Create Forked Chain
-    let mut orphan_store = create_mem_db(Network::LocalNet(Box::new(blocks[0].clone())));
+    let consensus_manager_fork = ConsensusManagerBuilder::new(network)
+        .with_block(blocks[0].clone())
+        .build();
+    let mut orphan_store = create_mem_db(consensus_manager_fork.clone());
     orphan_store.add_block(blocks[1].clone()).unwrap();
     let mut orphan_blocks = vec![blocks[0].clone(), blocks[1].clone()];
     let mut orphan_outputs = vec![outputs[0].clone(), outputs[1].clone()];
@@ -488,7 +545,8 @@ fn handle_tip_reorg() {
         &mut orphan_blocks,
         &mut orphan_outputs,
         txs,
-        Difficulty::from(2)
+        Difficulty::from(2),
+        &consensus_manager_fork.consensus_constants()
     )
     .is_ok());
 
@@ -514,7 +572,8 @@ fn handle_reorg() {
     // added to the blockchain then a reorg is triggered and the main chain is reorganized to GB->A1->B2->B3->C4.
 
     // Create Main Chain
-    let (mut store, mut blocks, mut outputs) = create_new_blockchain();
+    let network = Network::LocalNet;
+    let (mut store, mut blocks, mut outputs, consensus_manager) = create_new_blockchain(network);
     // Block A1
     let txs = vec![txn_schema!(
         from: vec![outputs[0][0].clone()],
@@ -525,7 +584,8 @@ fn handle_reorg() {
         &mut blocks,
         &mut outputs,
         txs,
-        Difficulty::from(1)
+        Difficulty::from(1),
+        &consensus_manager.consensus_constants()
     )
     .is_ok());
     // Block A2
@@ -535,7 +595,8 @@ fn handle_reorg() {
         &mut blocks,
         &mut outputs,
         txs,
-        Difficulty::from(3)
+        Difficulty::from(3),
+        &consensus_manager.consensus_constants()
     )
     .is_ok());
     // Block A3
@@ -545,7 +606,8 @@ fn handle_reorg() {
         &mut blocks,
         &mut outputs,
         txs,
-        Difficulty::from(1)
+        Difficulty::from(1),
+        &consensus_manager.consensus_constants()
     )
     .is_ok());
     // Block A4
@@ -555,12 +617,16 @@ fn handle_reorg() {
         &mut blocks,
         &mut outputs,
         txs,
-        Difficulty::from(1)
+        Difficulty::from(1),
+        &consensus_manager.consensus_constants()
     )
     .is_ok());
 
     // Create Forked Chain 1
-    let mut orphan1_store = create_mem_db(Network::LocalNet(Box::new(blocks[0].clone()))); // GB
+    let consensus_manager_fork = ConsensusManagerBuilder::new(network)
+        .with_block(blocks[0].clone())
+        .build();
+    let mut orphan1_store = create_mem_db(consensus_manager_fork); // GB
     orphan1_store.add_block(blocks[1].clone()).unwrap(); // A1
     let mut orphan1_blocks = vec![blocks[0].clone(), blocks[1].clone()];
     let mut orphan1_outputs = vec![outputs[0].clone(), outputs[1].clone()];
@@ -571,7 +637,8 @@ fn handle_reorg() {
         &mut orphan1_blocks,
         &mut orphan1_outputs,
         txs,
-        Difficulty::from(1)
+        Difficulty::from(1),
+        &consensus_manager.consensus_constants()
     )
     .is_ok());
     // Block B3
@@ -584,7 +651,8 @@ fn handle_reorg() {
         &mut orphan1_blocks,
         &mut orphan1_outputs,
         txs,
-        Difficulty::from(1)
+        Difficulty::from(1),
+        &consensus_manager.consensus_constants()
     )
     .is_ok());
     // Block B4
@@ -594,12 +662,16 @@ fn handle_reorg() {
         &mut orphan1_blocks,
         &mut orphan1_outputs,
         txs,
-        Difficulty::from(5)
+        Difficulty::from(5),
+        &consensus_manager.consensus_constants()
     )
     .is_ok());
 
     // Create Forked Chain 2
-    let mut orphan2_store = create_mem_db(Network::LocalNet(Box::new(blocks[0].clone()))); // GB
+    let consensus_manager_fork2 = ConsensusManagerBuilder::new(network)
+        .with_block(blocks[0].clone())
+        .build();
+    let mut orphan2_store = create_mem_db(consensus_manager_fork2); // GB
     orphan2_store.add_block(blocks[1].clone()).unwrap(); // A1
     orphan2_store.add_block(orphan1_blocks[2].clone()).unwrap(); // B2
     orphan2_store.add_block(orphan1_blocks[3].clone()).unwrap(); // B3
@@ -622,7 +694,8 @@ fn handle_reorg() {
         &mut orphan2_blocks,
         &mut orphan2_outputs,
         txs,
-        Difficulty::from(20)
+        Difficulty::from(20),
+        &consensus_manager.consensus_constants()
     )
     .is_ok());
 
@@ -648,19 +721,20 @@ fn handle_reorg() {
 fn store_and_retrieve_blocks() {
     let mmr_cache_config = MmrCacheConfig { rewind_hist_len: 2 };
     let validators = Validators::new(MockValidator::new(true), MockValidator::new(true));
-    let rules = ConsensusManager::default();
+    let network = Network::LocalNet;
+    let rules = ConsensusManagerBuilder::new(network).build();
     let db = MemoryDatabase::<HashDigest>::new(mmr_cache_config);
-    let mut store = BlockchainDatabase::new(db, &rules).unwrap();
+    let mut store = BlockchainDatabase::new(db, rules.clone()).unwrap();
     store.set_validators(validators);
 
     let block0 = store.fetch_block(0).unwrap().block().clone();
-    let block1 = append_block(&store, &block0, vec![]).unwrap();
-    let block2 = append_block(&store, &block1, vec![]).unwrap();
+    let block1 = append_block(&store, &block0, vec![], &rules.consensus_constants()).unwrap();
+    let block2 = append_block(&store, &block1, vec![], &rules.consensus_constants()).unwrap();
     assert_eq!(*store.fetch_block(0).unwrap().block(), block0);
     assert_eq!(*store.fetch_block(1).unwrap().block(), block1);
     assert_eq!(*store.fetch_block(2).unwrap().block(), block2);
 
-    let block3 = append_block(&store, &block2, vec![]).unwrap();
+    let block3 = append_block(&store, &block2, vec![], &rules.consensus_constants()).unwrap();
     assert_eq!(*store.fetch_block(0).unwrap().block(), block0);
     assert_eq!(*store.fetch_block(1).unwrap().block(), block1);
     assert_eq!(*store.fetch_block(2).unwrap().block(), block2);
@@ -669,7 +743,9 @@ fn store_and_retrieve_blocks() {
 
 #[test]
 fn total_kernel_excess() {
-    let store = create_mem_db(Network::Rincewind);
+    let network = Network::LocalNet;
+    let consensus_manager = ConsensusManagerBuilder::new(network).build();
+    let store = create_mem_db(consensus_manager.clone());
     let block0 = store.fetch_block(0).unwrap().block().clone();
 
     let kernel1 = create_test_kernel(100.into(), 0);
@@ -691,7 +767,9 @@ fn total_kernel_excess() {
 
 #[test]
 fn total_kernel_offset() {
-    let store = create_mem_db(Network::Rincewind);
+    let network = Network::LocalNet;
+    let consensus_manager = ConsensusManagerBuilder::new(network).build();
+    let store = create_mem_db(consensus_manager.clone());
     let block0 = store.fetch_block(0).unwrap().block().clone();
 
     let header2 = BlockHeader::from_previous(&block0.header);
@@ -711,7 +789,9 @@ fn total_kernel_offset() {
 #[test]
 fn total_utxo_commitment() {
     let factories = CryptoFactories::default();
-    let store = create_mem_db(Network::Rincewind);
+    let network = Network::LocalNet;
+    let consensus_manager = ConsensusManagerBuilder::new(network).build();
+    let store = create_mem_db(consensus_manager.clone());
     let block0 = store.fetch_block(0).unwrap().block().clone();
 
     let (utxo1, _) = create_utxo(MicroTari(10_000), &factories, None);
@@ -734,16 +814,17 @@ fn total_utxo_commitment() {
 #[test]
 fn restore_metadata() {
     let validators = Validators::new(MockValidator::new(true), MockValidator::new(true));
-    let rules = ConsensusManager::new(None, ConsensusConstants::current_with_network(Network::Rincewind));
+    let network = Network::LocalNet;
+    let rules = ConsensusManagerBuilder::new(network).build();
     let block_hash: BlockHash;
     let path = create_temporary_data_path();
     {
         let db = create_lmdb_database(&path, MmrCacheConfig::default()).unwrap();
-        let mut db = BlockchainDatabase::new(db, &rules).unwrap();
+        let mut db = BlockchainDatabase::new(db, rules.clone()).unwrap();
         db.set_validators(validators.clone());
 
         let block0 = db.fetch_block(0).unwrap().block().clone();
-        let block1 = append_block(&db, &block0, vec![]).unwrap();
+        let block1 = append_block(&db, &block0, vec![], &rules.consensus_constants()).unwrap();
         db.add_block(block1.clone()).unwrap();
         block_hash = block1.hash();
         let metadata = db.get_metadata().unwrap();
@@ -752,7 +833,7 @@ fn restore_metadata() {
     }
     // Restore blockchain db
     let db = create_lmdb_database(&path, MmrCacheConfig::default()).unwrap();
-    let mut db = BlockchainDatabase::new(db, &rules).unwrap();
+    let mut db = BlockchainDatabase::new(db, rules.clone()).unwrap();
     db.set_validators(validators);
 
     let metadata = db.get_metadata().unwrap();

--- a/base_layer/core/tests/helpers/nodes.rs
+++ b/base_layer/core/tests/helpers/nodes.rs
@@ -38,7 +38,7 @@ use tari_core::{
     },
     blocks::Block,
     chain_storage::{BlockchainDatabase, MemoryDatabase, Validators},
-    consensus::ConsensusManager,
+    consensus::{ConsensusManager, ConsensusManagerBuilder, Network},
     mempool::{
         Mempool,
         MempoolConfig,
@@ -89,11 +89,12 @@ pub struct BaseNodeBuilder {
     liveness_service_config: Option<LivenessConfig>,
     validators: Option<Validators<MemoryDatabase<HashDigest>>>,
     consensus_manager: Option<ConsensusManager<MemoryDatabase<HashDigest>>>,
+    network: Network,
 }
 
 impl BaseNodeBuilder {
     /// Create a new BaseNodeBuilder
-    pub fn new() -> Self {
+    pub fn new(network: Network) -> Self {
         Self {
             node_identity: None,
             peers: None,
@@ -104,6 +105,7 @@ impl BaseNodeBuilder {
             liveness_service_config: None,
             validators: None,
             consensus_manager: None,
+            network,
         }
     }
 
@@ -167,14 +169,21 @@ impl BaseNodeBuilder {
     }
 
     /// Build the test base node and start its services.
-    pub fn start(self, runtime: &mut Runtime, data_path: &str) -> NodeInterfaces {
+    pub fn start(
+        self,
+        runtime: &mut Runtime,
+        data_path: &str,
+    ) -> (NodeInterfaces, ConsensusManager<MemoryDatabase<HashDigest>>)
+    {
         let mmr_cache_config = self.mmr_cache_config.unwrap_or(MmrCacheConfig { rewind_hist_len: 10 });
         let validators = self
             .validators
             .unwrap_or(Validators::new(MockValidator::new(true), MockValidator::new(true)));
-        let consensus_manager = self.consensus_manager.unwrap_or(ConsensusManager::default());
+        let consensus_manager = self
+            .consensus_manager
+            .unwrap_or(ConsensusManagerBuilder::new(self.network).build());
         let db = MemoryDatabase::<HashDigest>::new(mmr_cache_config);
-        let mut blockchain_db = BlockchainDatabase::new(db, &consensus_manager).unwrap();
+        let mut blockchain_db = BlockchainDatabase::new(db, consensus_manager.clone()).unwrap();
         blockchain_db.set_validators(validators);
         let mempool_validator = MempoolValidators::new(
             TxInputAndMaturityValidator::new(blockchain_db.clone()),
@@ -185,7 +194,8 @@ impl BaseNodeBuilder {
             self.mempool_config.unwrap_or(MempoolConfig::default()),
             mempool_validator,
         );
-        let diff_adj_manager = DiffAdjManager::new(blockchain_db.clone()).unwrap();
+        let diff_adj_manager =
+            DiffAdjManager::new(blockchain_db.clone(), &consensus_manager.consensus_constants()).unwrap();
         consensus_manager.set_diff_manager(diff_adj_manager).unwrap();
         let node_identity = self.node_identity.unwrap_or(random_node_identity());
         let (outbound_nci, local_nci, outbound_mp_interface, outbound_message_service, chain_metadata_handle, comms) =
@@ -195,7 +205,7 @@ impl BaseNodeBuilder {
                 self.peers.unwrap_or(Vec::new()),
                 blockchain_db.clone(),
                 mempool.clone(),
-                consensus_manager,
+                consensus_manager.clone(),
                 self.base_node_service_config
                     .unwrap_or(BaseNodeServiceConfig::default()),
                 self.mempool_service_config.unwrap_or(MempoolServiceConfig::default()),
@@ -203,35 +213,48 @@ impl BaseNodeBuilder {
                 data_path,
             );
 
-        NodeInterfaces {
-            node_identity,
-            outbound_nci,
-            local_nci,
-            outbound_mp_interface,
-            outbound_message_service,
-            blockchain_db,
-            mempool,
-            chain_metadata_handle,
-            comms,
-        }
+        (
+            NodeInterfaces {
+                node_identity,
+                outbound_nci,
+                local_nci,
+                outbound_mp_interface,
+                outbound_message_service,
+                blockchain_db,
+                mempool,
+                chain_metadata_handle,
+                comms,
+            },
+            consensus_manager,
+        )
     }
 }
 
 // Creates a network with two Base Nodes where each node in the network knows the other nodes in the network.
-pub fn create_network_with_2_base_nodes(runtime: &mut Runtime, data_path: &str) -> (NodeInterfaces, NodeInterfaces) {
+pub fn create_network_with_2_base_nodes(
+    runtime: &mut Runtime,
+    data_path: &str,
+) -> (
+    NodeInterfaces,
+    NodeInterfaces,
+    ConsensusManager<MemoryDatabase<HashDigest>>,
+)
+{
     let alice_node_identity = random_node_identity();
     let bob_node_identity = random_node_identity();
 
-    let alice_node = BaseNodeBuilder::new()
+    let network = Network::LocalNet;
+    let (alice_node, consensus_manager) = BaseNodeBuilder::new(network)
         .with_node_identity(alice_node_identity.clone())
         .with_peers(vec![bob_node_identity.clone()])
         .start(runtime, data_path);
-    let bob_node = BaseNodeBuilder::new()
+    let (bob_node, consensus_manager) = BaseNodeBuilder::new(network)
         .with_node_identity(bob_node_identity)
         .with_peers(vec![alice_node_identity])
+        .with_consensus_manager(consensus_manager)
         .start(runtime, data_path);
 
-    (alice_node, bob_node)
+    (alice_node, bob_node, consensus_manager)
 }
 
 // Creates a network with two Base Nodes where each node in the network knows the other nodes in the network.
@@ -243,28 +266,32 @@ pub fn create_network_with_2_base_nodes_with_config(
     liveness_service_config: LivenessConfig,
     consensus_manager: ConsensusManager<MemoryDatabase<HashDigest>>,
     data_path: &str,
-) -> (NodeInterfaces, NodeInterfaces)
+) -> (
+    NodeInterfaces,
+    NodeInterfaces,
+    ConsensusManager<MemoryDatabase<HashDigest>>,
+)
 {
     let alice_node_identity = random_node_identity();
     let bob_node_identity = random_node_identity();
-
-    let alice_node = BaseNodeBuilder::new()
+    let network = Network::LocalNet;
+    let (alice_node, consensus_manager) = BaseNodeBuilder::new(network)
         .with_node_identity(alice_node_identity.clone())
         .with_peers(vec![bob_node_identity.clone()])
         .with_base_node_service_config(base_node_service_config)
         .with_mmr_cache_config(mmr_cache_config)
         .with_mempool_service_config(mempool_service_config)
         .with_liveness_service_config(liveness_service_config)
-        .with_consensus_manager(consensus_manager.clone())
+        .with_consensus_manager(consensus_manager)
         .start(runtime, data_path);
-    let bob_node = BaseNodeBuilder::new()
+    let (bob_node, consensus_manager) = BaseNodeBuilder::new(network)
         .with_node_identity(bob_node_identity)
         .with_peers(vec![alice_node_identity])
         .with_base_node_service_config(base_node_service_config)
         .with_mmr_cache_config(mmr_cache_config)
         .with_mempool_service_config(mempool_service_config)
         .with_liveness_service_config(liveness_service_config)
-        .with_consensus_manager(consensus_manager.clone())
+        .with_consensus_manager(consensus_manager)
         .start(runtime, data_path);
 
     runtime
@@ -276,15 +303,22 @@ pub fn create_network_with_2_base_nodes_with_config(
         )
         .unwrap();
 
-    (alice_node, bob_node)
+    (alice_node, bob_node, consensus_manager)
 }
 
 // Creates a network with three Base Nodes where each node in the network knows the other nodes in the network.
 pub fn create_network_with_3_base_nodes(
     runtime: &mut Runtime,
     data_path: &str,
-) -> (NodeInterfaces, NodeInterfaces, NodeInterfaces)
+) -> (
+    NodeInterfaces,
+    NodeInterfaces,
+    NodeInterfaces,
+    ConsensusManager<MemoryDatabase<HashDigest>>,
+)
 {
+    let network = Network::LocalNet;
+    let consensus_manager = ConsensusManagerBuilder::new(network).build();
     let mmr_cache_config = MmrCacheConfig { rewind_hist_len: 10 };
     create_network_with_3_base_nodes_with_config(
         runtime,
@@ -292,7 +326,7 @@ pub fn create_network_with_3_base_nodes(
         mmr_cache_config,
         MempoolServiceConfig::default(),
         LivenessConfig::default(),
-        ConsensusManager::default(),
+        consensus_manager,
         data_path,
     )
 }
@@ -306,31 +340,37 @@ pub fn create_network_with_3_base_nodes_with_config(
     liveness_service_config: LivenessConfig,
     consensus_manager: ConsensusManager<MemoryDatabase<HashDigest>>,
     data_path: &str,
-) -> (NodeInterfaces, NodeInterfaces, NodeInterfaces)
+) -> (
+    NodeInterfaces,
+    NodeInterfaces,
+    NodeInterfaces,
+    ConsensusManager<MemoryDatabase<HashDigest>>,
+)
 {
     let alice_node_identity = random_node_identity();
     let bob_node_identity = random_node_identity();
     let carol_node_identity = random_node_identity();
+    let network = Network::LocalNet;
 
-    let alice_node = BaseNodeBuilder::new()
+    let (alice_node, consensus_manager) = BaseNodeBuilder::new(network)
         .with_node_identity(alice_node_identity.clone())
         .with_peers(vec![bob_node_identity.clone(), carol_node_identity.clone()])
         .with_base_node_service_config(base_node_service_config)
         .with_mmr_cache_config(mmr_cache_config)
         .with_mempool_service_config(mempool_service_config)
         .with_liveness_service_config(liveness_service_config)
-        .with_consensus_manager(consensus_manager.clone())
+        .with_consensus_manager(consensus_manager)
         .start(runtime, data_path);
-    let bob_node = BaseNodeBuilder::new()
+    let (bob_node, consensus_manager) = BaseNodeBuilder::new(network)
         .with_node_identity(bob_node_identity.clone())
         .with_peers(vec![alice_node_identity.clone(), carol_node_identity.clone()])
         .with_base_node_service_config(base_node_service_config)
         .with_mmr_cache_config(mmr_cache_config)
         .with_mempool_service_config(mempool_service_config)
         .with_liveness_service_config(liveness_service_config)
-        .with_consensus_manager(consensus_manager.clone())
+        .with_consensus_manager(consensus_manager)
         .start(runtime, data_path);
-    let carol_node = BaseNodeBuilder::new()
+    let (carol_node, consensus_manager) = BaseNodeBuilder::new(network)
         .with_node_identity(carol_node_identity.clone())
         .with_peers(vec![alice_node_identity, bob_node_identity.clone()])
         .with_base_node_service_config(base_node_service_config)
@@ -362,7 +402,7 @@ pub fn create_network_with_3_base_nodes_with_config(
         // All node have an existing connection
     });
 
-    (alice_node, bob_node, carol_node)
+    (alice_node, bob_node, carol_node, consensus_manager)
 }
 
 fn random_string(len: usize) -> String {

--- a/base_layer/core/tests/mempool.rs
+++ b/base_layer/core/tests/mempool.rs
@@ -38,7 +38,7 @@ use std::{ops::Deref, sync::Arc, time::Duration};
 use tari_comms_dht::{domain_message::OutboundDomainMessage, outbound::OutboundEncryption};
 use tari_core::{
     base_node::service::BaseNodeServiceConfig,
-    consensus::{ConsensusConstants, ConsensusManager, Network},
+    consensus::{ConsensusConstantsBuilder, ConsensusManagerBuilder, Network},
     helpers::create_mem_db,
     mempool::{
         Mempool,
@@ -68,7 +68,8 @@ use tokio::runtime::Runtime;
 
 #[test]
 fn test_insert_and_process_published_block() {
-    let (mut store, mut blocks, mut outputs) = create_new_blockchain();
+    let network = Network::LocalNet;
+    let (mut store, mut blocks, mut outputs, consensus_manager) = create_new_blockchain(network);
     let mempool_validator = MempoolValidators::new(
         TxInputAndMaturityValidator::new(store.clone()),
         TxInputAndMaturityValidator::new(store.clone()),
@@ -79,7 +80,14 @@ fn test_insert_and_process_published_block() {
         from: vec![outputs[0][0].clone()],
         to: vec![2 * T, 2 * T, 2 * T, 2 * T]
     )];
-    generate_new_block(&mut store, &mut blocks, &mut outputs, txs).unwrap();
+    generate_new_block(
+        &mut store,
+        &mut blocks,
+        &mut outputs,
+        txs,
+        &consensus_manager.consensus_constants(),
+    )
+    .unwrap();
     // Create 6 new transactions to add to the mempool
     let (orphan, _, _) = tx!(1*T, fee: 100*uT);
     let orphan = Arc::new(orphan);
@@ -161,7 +169,13 @@ fn test_insert_and_process_published_block() {
     assert_eq!(stats.total_weight, 36);
 
     // Spend tx2, so it goes in Reorg pool, tx5 matures, so goes in Unconfirmed pool
-    generate_block(&mut store, &mut blocks, vec![tx2.deref().clone()]).unwrap();
+    generate_block(
+        &mut store,
+        &mut blocks,
+        vec![tx2.deref().clone()],
+        &consensus_manager.consensus_constants(),
+    )
+    .unwrap();
     mempool.process_published_block(&blocks[2]).unwrap();
 
     assert_eq!(
@@ -212,7 +226,8 @@ fn test_insert_and_process_published_block() {
 
 #[test]
 fn test_retrieve() {
-    let (mut store, mut blocks, mut outputs) = create_new_blockchain();
+    let network = Network::LocalNet;
+    let (mut store, mut blocks, mut outputs, consensus_manager) = create_new_blockchain(network);
     let mempool_validator = MempoolValidators::new(
         TxInputAndMaturityValidator::new(store.clone()),
         TxInputAndMaturityValidator::new(store.clone()),
@@ -223,7 +238,14 @@ fn test_retrieve() {
         to: vec![1 * T, 1 * T, 1 * T, 1 * T, 1 * T, 1 * T, 1 * T]
     )];
     // "Mine" Block 1
-    generate_new_block(&mut store, &mut blocks, &mut outputs, txs).unwrap();
+    generate_new_block(
+        &mut store,
+        &mut blocks,
+        &mut outputs,
+        txs,
+        &consensus_manager.consensus_constants(),
+    )
+    .unwrap();
     mempool.process_published_block(&blocks[1]).unwrap();
     // 1-Block, 8 UTXOs, empty mempool
     let txs = vec![
@@ -265,7 +287,13 @@ fn test_retrieve() {
         tx[7].deref().clone(),
     ];
     // "Mine" block 2
-    generate_block(&mut store, &mut blocks, block2_txns).unwrap();
+    generate_block(
+        &mut store,
+        &mut blocks,
+        block2_txns,
+        &consensus_manager.consensus_constants(),
+    )
+    .unwrap();
     println!("{}", blocks[2]);
     outputs.push(utxos);
     mempool.process_published_block(&blocks[2]).unwrap();
@@ -301,7 +329,8 @@ fn test_retrieve() {
 
 #[test]
 fn test_reorg() {
-    let (mut db, mut blocks, mut outputs) = create_new_blockchain();
+    let network = Network::LocalNet;
+    let (mut db, mut blocks, mut outputs, consensus_manager) = create_new_blockchain(network);
     let mempool_validator = MempoolValidators::new(
         TxInputAndMaturityValidator::new(db.clone()),
         TxInputAndMaturityValidator::new(db.clone()),
@@ -310,7 +339,14 @@ fn test_reorg() {
 
     // "Mine" Block 1
     let txs = vec![txn_schema!(from: vec![outputs[0][0].clone()], to: vec![1 * T, 1 * T])];
-    generate_new_block(&mut db, &mut blocks, &mut outputs, txs).unwrap();
+    generate_new_block(
+        &mut db,
+        &mut blocks,
+        &mut outputs,
+        txs,
+        &consensus_manager.consensus_constants(),
+    )
+    .unwrap();
     mempool.process_published_block(&blocks[1]).unwrap();
 
     // "Mine" block 2
@@ -327,7 +363,7 @@ fn test_reorg() {
     let stats = mempool.stats().unwrap();
     assert_eq!(stats.unconfirmed_txs, 3);
     let txns2 = txns2.iter().map(|t| t.deref().clone()).collect();
-    generate_block(&mut db, &mut blocks, txns2).unwrap();
+    generate_block(&mut db, &mut blocks, txns2, &consensus_manager.consensus_constants()).unwrap();
     mempool.process_published_block(&blocks[2]).unwrap();
 
     // "Mine" block 3
@@ -343,7 +379,13 @@ fn test_reorg() {
     });
     let txns3: Vec<Transaction> = txns3.iter().map(|t| t.deref().clone()).collect();
 
-    generate_block(&mut db, &mut blocks, vec![txns3[0].clone(), txns3[2].clone()]).unwrap();
+    generate_block(
+        &mut db,
+        &mut blocks,
+        vec![txns3[0].clone(), txns3[2].clone()],
+        &consensus_manager.consensus_constants(),
+    )
+    .unwrap();
     mempool.process_published_block(&blocks[3]).unwrap();
 
     let stats = mempool.stats().unwrap();
@@ -361,14 +403,22 @@ fn test_reorg() {
 
 #[test]
 fn test_orphaned_mempool_transactions() {
-    let (store, mut blocks, mut outputs) = create_new_blockchain();
+    let network = Network::LocalNet;
+    let (store, mut blocks, mut outputs, consensus_manager) = create_new_blockchain(network);
     // A parallel store that will "mine" the orphan chain
-    let mut miner = create_mem_db(Network::LocalNet(Box::new(blocks[0].clone())));
+    let mut miner = create_mem_db(consensus_manager.clone());
     let schemas = vec![txn_schema!(
         from: vec![outputs[0][0].clone()],
         to: vec![2 * T, 2 * T, 2 * T, 2 * T, 2 * T]
     )];
-    generate_new_block(&mut miner, &mut blocks, &mut outputs, schemas.clone()).unwrap();
+    generate_new_block(
+        &mut miner,
+        &mut blocks,
+        &mut outputs,
+        schemas.clone(),
+        &consensus_manager.consensus_constants(),
+    )
+    .unwrap();
     store.add_block(blocks[1].clone()).unwrap();
     let schemas = vec![
         txn_schema!(from: vec![outputs[1][0].clone(), outputs[1][1].clone()], to: vec![], fee: 500*uT, lock: 1100, OutputFeatures::default()),
@@ -376,7 +426,14 @@ fn test_orphaned_mempool_transactions() {
         txn_schema!(from: vec![outputs[1][3].clone()], to: vec![], fee: 100*uT),
     ];
     let (txns, _) = schema_to_transaction(&schemas.clone());
-    generate_new_block(&mut miner, &mut blocks, &mut outputs, schemas).unwrap();
+    generate_new_block(
+        &mut miner,
+        &mut blocks,
+        &mut outputs,
+        schemas,
+        &consensus_manager.consensus_constants(),
+    )
+    .unwrap();
     // tx3 and tx4 depend on tx0 and tx1
     let schemas = vec![
         txn_schema!(from: vec![outputs[2][0].clone()], to: vec![], fee: 200*uT),
@@ -384,7 +441,14 @@ fn test_orphaned_mempool_transactions() {
         txn_schema!(from: vec![outputs[1][4].clone()], to: vec![], fee: 600*uT, lock: 5200, OutputFeatures::default()),
     ];
     let (txns2, _) = schema_to_transaction(&schemas.clone());
-    generate_new_block(&mut miner, &mut blocks, &mut outputs, schemas).unwrap();
+    generate_new_block(
+        &mut miner,
+        &mut blocks,
+        &mut outputs,
+        schemas,
+        &consensus_manager.consensus_constants(),
+    )
+    .unwrap();
     let mempool_validator = MempoolValidators::new(
         TxInputAndMaturityValidator::new(store.clone()),
         TxInputAndMaturityValidator::new(store.clone()),
@@ -415,15 +479,23 @@ fn request_response_get_stats() {
     let factories = CryptoFactories::default();
     let mut runtime = Runtime::new().unwrap();
     let temp_dir = TempDir::new(string(8).as_str()).unwrap();
-    let (block0, utxo) = create_genesis_block(&factories);
-    let consensus_constants = ConsensusConstants::current_with_network(Network::LocalNet(Box::new(block0.clone())));
-    let (mut alice, bob) = create_network_with_2_base_nodes_with_config(
+    let network = Network::LocalNet;
+    let consensus_constants = ConsensusConstantsBuilder::new(network)
+        .with_coinbase_lockheight(100)
+        .with_emission_amounts(100_000_000.into(), 0.999, 100.into())
+        .build();
+    let (block0, utxo) = create_genesis_block(&factories, &consensus_constants);
+    let consensus_manager = ConsensusManagerBuilder::new(network)
+        .with_consensus_constants(consensus_constants)
+        .with_block(block0.clone())
+        .build();
+    let (mut alice, bob, _consensus_manager) = create_network_with_2_base_nodes_with_config(
         &mut runtime,
         BaseNodeServiceConfig::default(),
         MmrCacheConfig { rewind_hist_len: 10 },
         MempoolServiceConfig::default(),
         LivenessConfig::default(),
-        ConsensusManager::new(None, consensus_constants),
+        consensus_manager,
         temp_dir.path().to_str().unwrap(),
     );
 
@@ -469,15 +541,23 @@ fn request_response_get_tx_state_with_excess_sig() {
     let factories = CryptoFactories::default();
     let mut runtime = Runtime::new().unwrap();
     let temp_dir = TempDir::new(string(8).as_str()).unwrap();
-    let (block0, utxo) = create_genesis_block(&factories);
-    let consensus_constants = ConsensusConstants::current_with_network(Network::LocalNet(Box::new(block0.clone())));
-    let (mut alice_node, bob_node, carol_node) = create_network_with_3_base_nodes_with_config(
+    let network = Network::LocalNet;
+    let consensus_constants = ConsensusConstantsBuilder::new(network)
+        .with_coinbase_lockheight(100)
+        .with_emission_amounts(100_000_000.into(), 0.999, 100.into())
+        .build();
+    let (block0, utxo) = create_genesis_block(&factories, &consensus_constants);
+    let consensus_manager = ConsensusManagerBuilder::new(network)
+        .with_consensus_constants(consensus_constants)
+        .with_block(block0.clone())
+        .build();
+    let (mut alice_node, bob_node, carol_node, _consensus_manager) = create_network_with_3_base_nodes_with_config(
         &mut runtime,
         BaseNodeServiceConfig::default(),
         MmrCacheConfig { rewind_hist_len: 10 },
         MempoolServiceConfig::default(),
         LivenessConfig::default(),
-        ConsensusManager::new(None, consensus_constants),
+        consensus_manager,
         temp_dir.path().to_str().unwrap(),
     );
 
@@ -534,15 +614,23 @@ fn receive_and_propagate_transaction() {
     let factories = CryptoFactories::default();
     let mut runtime = Runtime::new().unwrap();
     let temp_dir = TempDir::new(string(8).as_str()).unwrap();
-    let (block0, utxo) = create_genesis_block(&factories);
-    let consensus_constants = ConsensusConstants::current_with_network(Network::LocalNet(Box::new(block0.clone())));
-    let (mut alice_node, bob_node, carol_node) = create_network_with_3_base_nodes_with_config(
+    let network = Network::LocalNet;
+    let consensus_constants = ConsensusConstantsBuilder::new(network)
+        .with_coinbase_lockheight(100)
+        .with_emission_amounts(100_000_000.into(), 0.999, 100.into())
+        .build();
+    let (block0, utxo) = create_genesis_block(&factories, &consensus_constants);
+    let consensus_manager = ConsensusManagerBuilder::new(network)
+        .with_consensus_constants(consensus_constants)
+        .with_block(block0.clone())
+        .build();
+    let (mut alice_node, bob_node, carol_node, _consensus_manager) = create_network_with_3_base_nodes_with_config(
         &mut runtime,
         BaseNodeServiceConfig::default(),
         MmrCacheConfig { rewind_hist_len: 10 },
         MempoolServiceConfig::default(),
         LivenessConfig::default(),
-        ConsensusManager::new(None, consensus_constants),
+        consensus_manager,
         temp_dir.path().to_str().unwrap(),
     );
 
@@ -607,18 +695,19 @@ fn receive_and_propagate_transaction() {
 #[test]
 fn service_request_timeout() {
     let mut runtime = Runtime::new().unwrap();
-
+    let network = Network::LocalNet;
+    let consensus_manager = ConsensusManagerBuilder::new(network).build();
     let mempool_service_config = MempoolServiceConfig {
         request_timeout: Duration::from_millis(1),
     };
     let temp_dir = TempDir::new(string(8).as_str()).unwrap();
-    let (mut alice_node, bob_node) = create_network_with_2_base_nodes_with_config(
+    let (mut alice_node, bob_node, _consensus_manager) = create_network_with_2_base_nodes_with_config(
         &mut runtime,
         BaseNodeServiceConfig::default(),
         MmrCacheConfig::default(),
         mempool_service_config,
         LivenessConfig::default(),
-        ConsensusManager::default(),
+        consensus_manager,
         temp_dir.path().to_str().unwrap(),
     );
 
@@ -636,17 +725,24 @@ fn service_request_timeout() {
 #[test]
 fn block_event_and_reorg_event_handling() {
     let factories = CryptoFactories::default();
+    let network = Network::LocalNet;
+    let consensus_constants = network.create_consensus_constants();
+
     let mut runtime = Runtime::new().unwrap();
     let temp_dir = TempDir::new(string(8).as_str()).unwrap();
-    let (block0, utxos0) = create_genesis_block_with_coinbase_value(&factories, 100_000_000.into(), 1);
-    let consensus_constants = ConsensusConstants::current_with_network(Network::LocalNet(Box::new(block0.clone())));
-    let (alice, mut bob) = create_network_with_2_base_nodes_with_config(
+    let (block0, utxos0) =
+        create_genesis_block_with_coinbase_value(&factories, 100_000_000.into(), &consensus_constants);
+    let consensus_manager = ConsensusManagerBuilder::new(network)
+        .with_consensus_constants(consensus_constants)
+        .with_block(block0.clone())
+        .build();
+    let (alice, mut bob, consensus_manager) = create_network_with_2_base_nodes_with_config(
         &mut runtime,
         BaseNodeServiceConfig::default(),
         MmrCacheConfig { rewind_hist_len: 10 },
         MempoolServiceConfig::default(),
         LivenessConfig::default(),
-        ConsensusManager::new(None, consensus_constants),
+        consensus_manager,
         temp_dir.path().to_str().unwrap(),
     );
 
@@ -685,19 +781,31 @@ fn block_event_and_reorg_event_handling() {
     // These blocks are manually constructed to allow the block event system to be used.
     let mut block1 = bob
         .blockchain_db
-        .calculate_mmr_roots(chain_block(&block0, vec![tx1]))
+        .calculate_mmr_roots(chain_block(
+            &block0,
+            vec![tx1],
+            &consensus_manager.consensus_constants(),
+        ))
         .unwrap();
     find_header_with_achieved_difficulty(&mut block1.header, Difficulty::from(1));
 
     let mut block2a = bob
         .blockchain_db
-        .calculate_mmr_roots(chain_block(&block1, vec![tx2, tx3]))
+        .calculate_mmr_roots(chain_block(
+            &block1,
+            vec![tx2, tx3],
+            &consensus_manager.consensus_constants(),
+        ))
         .unwrap();
     find_header_with_achieved_difficulty(&mut block2a.header, Difficulty::from(1));
     // Block2b also builds on Block1 but has a stronger PoW
     let mut block2b = bob
         .blockchain_db
-        .calculate_mmr_roots(chain_block(&block1, vec![tx4, tx5]))
+        .calculate_mmr_roots(chain_block(
+            &block1,
+            vec![tx4, tx5],
+            &consensus_manager.consensus_constants(),
+        ))
         .unwrap();
     find_header_with_achieved_difficulty(&mut block2b.header, Difficulty::from(10));
 

--- a/base_layer/core/tests/node_service.rs
+++ b/base_layer/core/tests/node_service.rs
@@ -49,7 +49,7 @@ use tari_core::{
     },
     blocks::BlockHeader,
     chain_storage::{BlockAddResult, DbTransaction},
-    consensus::{ConsensusConstants, ConsensusManager, Network},
+    consensus::{ConsensusConstantsBuilder, ConsensusManagerBuilder, Network},
     mempool::MempoolServiceConfig,
     proof_of_work::{Difficulty, PowAlgorithm},
     transactions::{
@@ -71,15 +71,22 @@ fn request_response_get_metadata() {
     let mut runtime = Runtime::new().unwrap();
     let factories = CryptoFactories::default();
     let temp_dir = TempDir::new(string(8).as_str()).unwrap();
-    let (block0, _) = create_genesis_block(&factories);
-    let consensus_constants = ConsensusConstants::current_with_network(Network::LocalNet(Box::new(block0.clone())));
-    let (mut alice_node, bob_node, carol_node) = create_network_with_3_base_nodes_with_config(
+    let network = Network::LocalNet;
+    let consensus_constants = ConsensusConstantsBuilder::new(network)
+        .with_emission_amounts(100_000_000.into(), 0.999, 100.into())
+        .build();
+    let (block0, _) = create_genesis_block(&factories, &consensus_constants);
+    let consensus_manager = ConsensusManagerBuilder::new(network)
+        .with_consensus_constants(consensus_constants)
+        .with_block(block0.clone())
+        .build();
+    let (mut alice_node, bob_node, carol_node, _consensus_manager) = create_network_with_3_base_nodes_with_config(
         &mut runtime,
         BaseNodeServiceConfig::default(),
         MmrCacheConfig { rewind_hist_len: 10 },
         MempoolServiceConfig::default(),
         LivenessConfig::default(),
-        ConsensusManager::new(None, consensus_constants),
+        consensus_manager,
         temp_dir.path().to_str().unwrap(),
     );
 
@@ -99,7 +106,7 @@ fn request_response_get_metadata() {
 fn request_and_response_fetch_headers() {
     let mut runtime = Runtime::new().unwrap();
     let temp_dir = TempDir::new(string(8).as_str()).unwrap();
-    let (mut alice_node, bob_node, carol_node) =
+    let (mut alice_node, bob_node, carol_node, _consensus_manager) =
         create_network_with_3_base_nodes(&mut runtime, temp_dir.path().to_str().unwrap());
 
     let mut headerb1 = BlockHeader::new(0);
@@ -143,7 +150,7 @@ fn request_and_response_fetch_headers() {
 fn request_and_response_fetch_kernels() {
     let mut runtime = Runtime::new().unwrap();
     let temp_dir = TempDir::new(string(8).as_str()).unwrap();
-    let (mut alice_node, bob_node, carol_node) =
+    let (mut alice_node, bob_node, carol_node, _consensus_manager) =
         create_network_with_3_base_nodes(&mut runtime, temp_dir.path().to_str().unwrap());
 
     let kernel1 = create_test_kernel(5.into(), 0);
@@ -185,7 +192,7 @@ fn request_and_response_fetch_utxos() {
     let mut runtime = Runtime::new().unwrap();
     let factories = CryptoFactories::default();
     let temp_dir = TempDir::new(string(8).as_str()).unwrap();
-    let (mut alice_node, bob_node, carol_node) =
+    let (mut alice_node, bob_node, carol_node, _consensus_manager) =
         create_network_with_3_base_nodes(&mut runtime, temp_dir.path().to_str().unwrap());
 
     let (utxo1, _) = create_utxo(MicroTari(10_000), &factories, None);
@@ -223,23 +230,30 @@ fn request_and_response_fetch_blocks() {
     let mut runtime = Runtime::new().unwrap();
     let factories = CryptoFactories::default();
     let temp_dir = TempDir::new(string(8).as_str()).unwrap();
-    let (block0, _) = create_genesis_block(&factories);
-    let consensus_constants = ConsensusConstants::current_with_network(Network::LocalNet(Box::new(block0.clone())));
-    let (mut alice_node, mut bob_node, carol_node) = create_network_with_3_base_nodes_with_config(
+    let network = Network::LocalNet;
+    let consensus_constants = ConsensusConstantsBuilder::new(network)
+        .with_emission_amounts(100_000_000.into(), 0.999, 100.into())
+        .build();
+    let (block0, _) = create_genesis_block(&factories, &consensus_constants);
+    let consensus_manager = ConsensusManagerBuilder::new(network)
+        .with_consensus_constants(consensus_constants)
+        .with_block(block0.clone())
+        .build();
+    let (mut alice_node, mut bob_node, carol_node, _) = create_network_with_3_base_nodes_with_config(
         &mut runtime,
         BaseNodeServiceConfig::default(),
         MmrCacheConfig { rewind_hist_len: 10 },
         MempoolServiceConfig::default(),
         LivenessConfig::default(),
-        ConsensusManager::new(None, consensus_constants),
+        consensus_manager.clone(),
         temp_dir.path().to_str().unwrap(),
     );
 
     let mut blocks = vec![block0];
     let db = &mut bob_node.blockchain_db;
-    generate_block(db, &mut blocks, vec![]).unwrap();
-    generate_block(db, &mut blocks, vec![]).unwrap();
-    generate_block(db, &mut blocks, vec![]).unwrap();
+    generate_block(db, &mut blocks, vec![], &consensus_manager.consensus_constants()).unwrap();
+    generate_block(db, &mut blocks, vec![], &consensus_manager.consensus_constants()).unwrap();
+    generate_block(db, &mut blocks, vec![], &consensus_manager.consensus_constants()).unwrap();
 
     carol_node.blockchain_db.add_block(blocks[1].clone()).unwrap();
     carol_node.blockchain_db.add_block(blocks[2].clone()).unwrap();
@@ -288,35 +302,41 @@ fn propagate_and_forward_valid_block() {
     let bob_node_identity = random_node_identity();
     let carol_node_identity = random_node_identity();
     let dan_node_identity = random_node_identity();
-    let (block0, _) = create_genesis_block(&factories);
-    let consensus_constants = ConsensusConstants::current_with_network(Network::LocalNet(Box::new(block0.clone())));
-    let rules = ConsensusManager::new(None, consensus_constants);
-    let mut alice_node = BaseNodeBuilder::new()
+    let network = Network::LocalNet;
+    let consensus_constants = ConsensusConstantsBuilder::new(network)
+        .with_emission_amounts(100_000_000.into(), 0.999, 100.into())
+        .build();
+    let (block0, _) = create_genesis_block(&factories, &consensus_constants);
+    let rules = ConsensusManagerBuilder::new(network)
+        .with_consensus_constants(consensus_constants)
+        .with_block(block0.clone())
+        .build();
+    let (mut alice_node, rules) = BaseNodeBuilder::new(network)
         .with_node_identity(alice_node_identity.clone())
         .with_peers(vec![bob_node_identity.clone()])
-        .with_consensus_manager(rules.clone())
+        .with_consensus_manager(rules)
         .start(&mut runtime, temp_dir.path().to_str().unwrap());
-    let bob_node = BaseNodeBuilder::new()
+    let (bob_node, rules) = BaseNodeBuilder::new(network)
         .with_node_identity(bob_node_identity.clone())
         .with_peers(vec![
             alice_node_identity,
             carol_node_identity.clone(),
             dan_node_identity.clone(),
         ])
-        .with_consensus_manager(rules.clone())
+        .with_consensus_manager(rules)
         .start(&mut runtime, temp_dir.path().to_str().unwrap());
-    let carol_node = BaseNodeBuilder::new()
+    let (carol_node, rules) = BaseNodeBuilder::new(network)
         .with_node_identity(carol_node_identity.clone())
         .with_peers(vec![bob_node_identity.clone(), dan_node_identity.clone()])
-        .with_consensus_manager(rules.clone())
+        .with_consensus_manager(rules)
         .start(&mut runtime, temp_dir.path().to_str().unwrap());
-    let dan_node = BaseNodeBuilder::new()
+    let (dan_node, rules) = BaseNodeBuilder::new(network)
         .with_node_identity(dan_node_identity)
         .with_peers(vec![bob_node_identity, carol_node_identity])
         .with_consensus_manager(rules)
         .start(&mut runtime, temp_dir.path().to_str().unwrap());
 
-    let block1 = append_block(&alice_node.blockchain_db, &block0, vec![]).unwrap();
+    let block1 = append_block(&alice_node.blockchain_db, &block0, vec![], &rules.consensus_constants()).unwrap();
     let block1_hash = block1.hash();
 
     runtime.block_on(async {
@@ -376,32 +396,38 @@ fn propagate_and_forward_invalid_block() {
     let bob_node_identity = random_node_identity();
     let carol_node_identity = random_node_identity();
     let dan_node_identity = random_node_identity();
-    let (block0, _) = create_genesis_block(&factories);
-    let consensus_constants = ConsensusConstants::current_with_network(Network::LocalNet(Box::new(block0.clone())));
-    let rules = ConsensusManager::new(None, consensus_constants);
-    let mut alice_node = BaseNodeBuilder::new()
+    let network = Network::LocalNet;
+    let consensus_constants = ConsensusConstantsBuilder::new(network)
+        .with_emission_amounts(100_000_000.into(), 0.999, 100.into())
+        .build();
+    let (block0, _) = create_genesis_block(&factories, &consensus_constants);
+    let rules = ConsensusManagerBuilder::new(network)
+        .with_consensus_constants(consensus_constants)
+        .with_block(block0.clone())
+        .build();
+    let (mut alice_node, rules) = BaseNodeBuilder::new(network)
         .with_node_identity(alice_node_identity.clone())
         .with_peers(vec![bob_node_identity.clone(), carol_node_identity.clone()])
-        .with_consensus_manager(rules.clone())
+        .with_consensus_manager(rules)
         .start(&mut runtime, temp_dir.path().to_str().unwrap());
-    let bob_node = BaseNodeBuilder::new()
+    let (bob_node, rules) = BaseNodeBuilder::new(network)
         .with_node_identity(bob_node_identity.clone())
         .with_peers(vec![alice_node_identity.clone(), dan_node_identity.clone()])
-        .with_consensus_manager(rules.clone())
+        .with_consensus_manager(rules)
         .start(&mut runtime, temp_dir.path().to_str().unwrap());
-    let carol_node = BaseNodeBuilder::new()
+    let (carol_node, rules) = BaseNodeBuilder::new(network)
         .with_node_identity(carol_node_identity.clone())
         .with_peers(vec![alice_node_identity, dan_node_identity.clone()])
-        .with_consensus_manager(rules.clone())
+        .with_consensus_manager(rules)
         .start(&mut runtime, temp_dir.path().to_str().unwrap());
-    let dan_node = BaseNodeBuilder::new()
+    let (dan_node, rules) = BaseNodeBuilder::new(network)
         .with_node_identity(dan_node_identity)
         .with_peers(vec![bob_node_identity, carol_node_identity])
         .with_consensus_manager(rules)
         .start(&mut runtime, temp_dir.path().to_str().unwrap());
 
     // Make block 1 invalid
-    let mut block1 = append_block(&alice_node.blockchain_db, &block0, vec![]).unwrap();
+    let mut block1 = append_block(&alice_node.blockchain_db, &block0, vec![], &rules.consensus_constants()).unwrap();
     block1.header.height = 0;
     let block1_hash = block1.hash();
     runtime.block_on(async {
@@ -443,18 +469,20 @@ fn propagate_and_forward_invalid_block() {
 #[test]
 fn service_request_timeout() {
     let mut runtime = Runtime::new().unwrap();
+    let network = Network::LocalNet;
+    let consensus_manager = ConsensusManagerBuilder::new(network).build();
     let base_node_service_config = BaseNodeServiceConfig {
         request_timeout: Duration::from_millis(1),
         desired_response_fraction: BASE_NODE_SERVICE_DESIRED_RESPONSE_FRACTION,
     };
     let temp_dir = TempDir::new(string(8).as_str()).unwrap();
-    let (mut alice_node, bob_node) = create_network_with_2_base_nodes_with_config(
+    let (mut alice_node, bob_node, _consensus_manager) = create_network_with_2_base_nodes_with_config(
         &mut runtime,
         base_node_service_config,
         MmrCacheConfig::default(),
         MempoolServiceConfig::default(),
         LivenessConfig::default(),
-        ConsensusManager::default(),
+        consensus_manager,
         temp_dir.path().to_str().unwrap(),
     );
 
@@ -473,11 +501,13 @@ fn service_request_timeout() {
 fn local_get_metadata() {
     let mut runtime = Runtime::new().unwrap();
     let temp_dir = TempDir::new(string(8).as_str()).unwrap();
-    let mut node = BaseNodeBuilder::new().start(&mut runtime, temp_dir.path().to_str().unwrap());
+    let network = Network::LocalNet;
+    let (mut node, consensus_manager) =
+        BaseNodeBuilder::new(network).start(&mut runtime, temp_dir.path().to_str().unwrap());
     let db = &node.blockchain_db;
     let block0 = db.fetch_block(0).unwrap().block().clone();
-    let block1 = append_block(db, &block0, vec![]).unwrap();
-    let block2 = append_block(db, &block1, vec![]).unwrap();
+    let block1 = append_block(db, &block0, vec![], &consensus_manager.consensus_constants()).unwrap();
+    let block2 = append_block(db, &block1, vec![], &consensus_manager.consensus_constants()).unwrap();
 
     runtime.block_on(async {
         let metadata = node.local_nci.get_metadata().await.unwrap();
@@ -493,10 +523,14 @@ fn local_get_new_block_template_and_get_new_block() {
     let factories = CryptoFactories::default();
     let mut runtime = Runtime::new().unwrap();
     let temp_dir = TempDir::new(string(8).as_str()).unwrap();
-    let (block0, outputs) = create_genesis_block_with_utxos(&factories, &[T, T]);
-    let consensus_constants = ConsensusConstants::current_with_network(Network::LocalNet(Box::new(block0)));
-    let rules = ConsensusManager::new(None, consensus_constants);
-    let mut node = BaseNodeBuilder::new()
+    let network = Network::LocalNet;
+    let consensus_constants = network.create_consensus_constants();
+    let (block0, outputs) = create_genesis_block_with_utxos(&factories, &[T, T], &consensus_constants);
+    let rules = ConsensusManagerBuilder::new(network)
+        .with_consensus_constants(consensus_constants)
+        .with_block(block0)
+        .build();
+    let (mut node, _rules) = BaseNodeBuilder::new(network)
         .with_consensus_manager(rules)
         .start(&mut runtime, temp_dir.path().to_str().unwrap());
 
@@ -526,9 +560,11 @@ fn local_get_new_block_template_and_get_new_block() {
 
 #[test]
 fn local_get_target_difficulty() {
+    let network = Network::LocalNet;
     let mut runtime = Runtime::new().unwrap();
     let temp_dir = TempDir::new(string(8).as_str()).unwrap();
-    let mut node = BaseNodeBuilder::new().start(&mut runtime, temp_dir.path().to_str().unwrap());
+    let (mut node, consensus_manager) =
+        BaseNodeBuilder::new(network).start(&mut runtime, temp_dir.path().to_str().unwrap());
 
     let db = &node.blockchain_db;
     let block0 = db.fetch_block(0).unwrap().block().clone();
@@ -544,12 +580,12 @@ fn local_get_target_difficulty() {
         assert_ne!(monero_target_difficulty1, Difficulty::from(0));
         assert_ne!(blake_target_difficulty1, Difficulty::from(0));
 
-        let block1 = chain_block(&block0, Vec::new());
+        let block1 = chain_block(&block0, Vec::new(), &consensus_manager.consensus_constants());
         let mut block1 = node.blockchain_db.calculate_mmr_roots(block1).unwrap();
         block1.header.timestamp = block0
             .header
             .timestamp
-            .increase(ConsensusConstants::current().get_target_block_interval());
+            .increase(consensus_manager.consensus_constants().get_target_block_interval());
         block1.header.pow.pow_algo = PowAlgorithm::Blake;
         node.blockchain_db.add_block(block1).unwrap();
         assert_eq!(node.blockchain_db.get_height(), Ok(Some(1)));
@@ -571,11 +607,15 @@ fn local_get_target_difficulty() {
 fn local_submit_block() {
     let mut runtime = Runtime::new().unwrap();
     let temp_dir = TempDir::new(string(8).as_str()).unwrap();
-    let mut node = BaseNodeBuilder::new().start(&mut runtime, temp_dir.path().to_str().unwrap());
+    let network = Network::LocalNet;
+    let (mut node, consensus_manager) =
+        BaseNodeBuilder::new(network).start(&mut runtime, temp_dir.path().to_str().unwrap());
 
     let db = &node.blockchain_db;
     let block0 = db.fetch_block(0).unwrap().block().clone();
-    let block1 = db.calculate_mmr_roots(chain_block(&block0, vec![])).unwrap();
+    let block1 = db
+        .calculate_mmr_roots(chain_block(&block0, vec![], &consensus_manager.consensus_constants()))
+        .unwrap();
     runtime.block_on(async {
         assert!(node.local_nci.submit_block(block1.clone()).await.is_ok());
 

--- a/base_layer/core/tests/node_state_machine.rs
+++ b/base_layer/core/tests/node_state_machine.rs
@@ -48,7 +48,7 @@ use tari_core::{
         BaseNodeStateMachine,
         BaseNodeStateMachineConfig,
     },
-    consensus::{ConsensusConstants, ConsensusManager, Network},
+    consensus::{ConsensusConstantsBuilder, ConsensusManagerBuilder, Network},
     mempool::MempoolServiceConfig,
     transactions::types::CryptoFactories,
 };
@@ -62,10 +62,17 @@ use tokio::runtime::Runtime;
 fn test_listening_lagging() {
     let mut runtime = Runtime::new().unwrap();
     let factories = CryptoFactories::default();
+    let network = Network::LocalNet;
     let temp_dir = TempDir::new(string(8).as_str()).unwrap();
-    let (mut prev_block, _) = create_genesis_block(&factories);
-    let consensus_constants = ConsensusConstants::current_with_network(Network::LocalNet(Box::new(prev_block.clone())));
-    let (alice_node, bob_node) = create_network_with_2_base_nodes_with_config(
+    let consensus_constants = ConsensusConstantsBuilder::new(network)
+        .with_emission_amounts(100_000_000.into(), 0.999, 100.into())
+        .build();
+    let (mut prev_block, _) = create_genesis_block(&factories, &consensus_constants);
+    let consensus_manager = ConsensusManagerBuilder::new(network)
+        .with_consensus_constants(consensus_constants)
+        .with_block(prev_block.clone())
+        .build();
+    let (alice_node, bob_node, consensus_manager) = create_network_with_2_base_nodes_with_config(
         &mut runtime,
         BaseNodeServiceConfig::default(),
         MmrCacheConfig::default(),
@@ -76,7 +83,7 @@ fn test_listening_lagging() {
             auto_ping_interval: Some(Duration::from_millis(100)),
             refresh_neighbours_interval: Duration::from_secs(60),
         },
-        ConsensusManager::new(None, consensus_constants),
+        consensus_manager,
         temp_dir.path().to_str().unwrap(),
     );
     let mut alice_state_machine = BaseNodeStateMachine::new(
@@ -92,9 +99,15 @@ fn test_listening_lagging() {
         let mut bob_local_nci = bob_node.local_nci;
 
         // Bob Block 1 - no block event
-        prev_block = append_block(&bob_db, &prev_block, vec![]).unwrap();
+        prev_block = append_block(&bob_db, &prev_block, vec![], &consensus_manager.consensus_constants()).unwrap();
         // Bob Block 2 - with block event and liveness service metadata update
-        let prev_block = bob_db.calculate_mmr_roots(chain_block(&prev_block, vec![])).unwrap();
+        let prev_block = bob_db
+            .calculate_mmr_roots(chain_block(
+                &prev_block,
+                vec![],
+                &consensus_manager.consensus_constants(),
+            ))
+            .unwrap();
         bob_local_nci.submit_block(prev_block.clone()).await.unwrap();
         assert_eq!(bob_db.get_height(), Ok(Some(2)));
 
@@ -111,9 +124,16 @@ fn test_event_channel() {
     let mut runtime = Runtime::new().unwrap();
     let factories = CryptoFactories::default();
     let temp_dir = TempDir::new(string(8).as_str()).unwrap();
-    let (mut prev_block, _) = create_genesis_block(&factories);
-    let consensus_constants = ConsensusConstants::current_with_network(Network::LocalNet(Box::new(prev_block.clone())));
-    let (alice_node, bob_node) = create_network_with_2_base_nodes_with_config(
+    let network = Network::LocalNet;
+    let consensus_constants = ConsensusConstantsBuilder::new(network)
+        .with_emission_amounts(100_000_000.into(), 0.999, 100.into())
+        .build();
+    let (mut prev_block, _) = create_genesis_block(&factories, &consensus_constants);
+    let consensus_manager = ConsensusManagerBuilder::new(network)
+        .with_consensus_constants(consensus_constants)
+        .with_block(prev_block.clone())
+        .build();
+    let (alice_node, bob_node, consensus_manager) = create_network_with_2_base_nodes_with_config(
         &mut runtime,
         BaseNodeServiceConfig::default(),
         MmrCacheConfig::default(),
@@ -124,7 +144,7 @@ fn test_event_channel() {
             auto_ping_interval: Some(Duration::from_millis(100)),
             refresh_neighbours_interval: Duration::from_secs(60),
         },
-        ConsensusManager::new(None, consensus_constants),
+        consensus_manager,
         temp_dir.path().to_str().unwrap(),
     );
     let alice_state_machine = BaseNodeStateMachine::new(
@@ -134,7 +154,7 @@ fn test_event_channel() {
         alice_node.chain_metadata_handle.get_event_stream(),
         BaseNodeStateMachineConfig::default(),
     );
-    let rx = alice_state_machine.get_state_change_event();
+    let rx = alice_state_machine.get_state_change_event_stream();
 
     runtime.spawn(async move {
         alice_state_machine.run().await;
@@ -145,9 +165,15 @@ fn test_event_channel() {
         let mut bob_local_nci = bob_node.local_nci;
 
         // Bob Block 1 - no block event
-        prev_block = append_block(&bob_db, &prev_block, vec![]).unwrap();
+        prev_block = append_block(&bob_db, &prev_block, vec![], &consensus_manager.consensus_constants()).unwrap();
         // Bob Block 2 - with block event and liveness service metadata update
-        let prev_block = bob_db.calculate_mmr_roots(chain_block(&prev_block, vec![])).unwrap();
+        let prev_block = bob_db
+            .calculate_mmr_roots(chain_block(
+                &prev_block,
+                vec![],
+                &consensus_manager.consensus_constants(),
+            ))
+            .unwrap();
         bob_local_nci.submit_block(prev_block.clone()).await.unwrap();
         assert_eq!(bob_db.get_height(), Ok(Some(2)));
         let state = rx.fuse().select_next_some().await;
@@ -165,7 +191,8 @@ fn test_event_channel() {
 fn test_listening_network_silence() {
     let mut runtime = Runtime::new().unwrap();
     let temp_dir = TempDir::new(string(8).as_str()).unwrap();
-    let (alice_node, bob_node) = create_network_with_2_base_nodes(&mut runtime, temp_dir.path().to_str().unwrap());
+    let (alice_node, bob_node, _consensus_manager) =
+        create_network_with_2_base_nodes(&mut runtime, temp_dir.path().to_str().unwrap());
     let state_machine_config = BaseNodeStateMachineConfig {
         block_sync_config: BlockSyncConfig::default(),
         listening_config: ListeningConfig {
@@ -194,15 +221,22 @@ fn test_block_sync() {
     let mut runtime = Runtime::new().unwrap();
     let factories = CryptoFactories::default();
     let temp_dir = TempDir::new(string(8).as_str()).unwrap();
-    let (mut prev_block, _) = create_genesis_block(&factories);
-    let consensus_constants = ConsensusConstants::current_with_network(Network::LocalNet(Box::new(prev_block.clone())));
-    let (alice_node, bob_node) = create_network_with_2_base_nodes_with_config(
+    let network = Network::LocalNet;
+    let consensus_constants = ConsensusConstantsBuilder::new(network)
+        .with_emission_amounts(100_000_000.into(), 0.999, 100.into())
+        .build();
+    let (mut prev_block, _) = create_genesis_block(&factories, &consensus_constants);
+    let consensus_manager = ConsensusManagerBuilder::new(network)
+        .with_consensus_constants(consensus_constants)
+        .with_block(prev_block.clone())
+        .build();
+    let (alice_node, bob_node, consensus_manager) = create_network_with_2_base_nodes_with_config(
         &mut runtime,
         BaseNodeServiceConfig::default(),
         MmrCacheConfig::default(),
         MempoolServiceConfig::default(),
         LivenessConfig::default(),
-        ConsensusManager::new(None, consensus_constants),
+        consensus_manager,
         temp_dir.path().to_str().unwrap(),
     );
     let state_machine_config = BaseNodeStateMachineConfig::default();
@@ -218,7 +252,7 @@ fn test_block_sync() {
         let adb = &alice_node.blockchain_db;
         let db = &bob_node.blockchain_db;
         for _ in 1..6 {
-            prev_block = append_block(db, &prev_block, vec![]).unwrap();
+            prev_block = append_block(db, &prev_block, vec![], &consensus_manager.consensus_constants()).unwrap();
         }
 
         // Sync Blocks from genesis block to tip
@@ -241,15 +275,22 @@ fn test_lagging_block_sync() {
     let mut runtime = Runtime::new().unwrap();
     let factories = CryptoFactories::default();
     let temp_dir = TempDir::new(string(8).as_str()).unwrap();
-    let (mut prev_block, _) = create_genesis_block(&factories);
-    let consensus_constants = ConsensusConstants::current_with_network(Network::LocalNet(Box::new(prev_block.clone())));
-    let (alice_node, bob_node) = create_network_with_2_base_nodes_with_config(
+    let network = Network::LocalNet;
+    let consensus_constants = ConsensusConstantsBuilder::new(network)
+        .with_emission_amounts(100_000_000.into(), 0.999, 100.into())
+        .build();
+    let (mut prev_block, _) = create_genesis_block(&factories, &consensus_constants);
+    let consensus_manager = ConsensusManagerBuilder::new(network)
+        .with_consensus_constants(consensus_constants)
+        .with_block(prev_block.clone())
+        .build();
+    let (alice_node, bob_node, consensus_manager) = create_network_with_2_base_nodes_with_config(
         &mut runtime,
         BaseNodeServiceConfig::default(),
         MmrCacheConfig::default(),
         MempoolServiceConfig::default(),
         LivenessConfig::default(),
-        ConsensusManager::new(None, consensus_constants),
+        consensus_manager,
         temp_dir.path().to_str().unwrap(),
     );
     let state_machine_config = BaseNodeStateMachineConfig::default();
@@ -263,11 +304,11 @@ fn test_lagging_block_sync() {
 
     let db = &bob_node.blockchain_db;
     for _ in 0..4 {
-        prev_block = append_block(db, &prev_block, vec![]).unwrap();
+        prev_block = append_block(db, &prev_block, vec![], &consensus_manager.consensus_constants()).unwrap();
         alice_node.blockchain_db.add_block(prev_block.clone()).unwrap();
     }
     for _ in 0..2 {
-        prev_block = append_block(db, &prev_block, vec![]).unwrap();
+        prev_block = append_block(db, &prev_block, vec![], &consensus_manager.consensus_constants()).unwrap();
     }
     assert_eq!(alice_node.blockchain_db.get_height(), Ok(Some(4)));
     assert_eq!(bob_node.blockchain_db.get_height(), Ok(Some(6)));
@@ -300,15 +341,22 @@ fn test_block_sync_recovery() {
     let mut runtime = Runtime::new().unwrap();
     let factories = CryptoFactories::default();
     let temp_dir = TempDir::new(string(8).as_str()).unwrap();
-    let (mut prev_block, _) = create_genesis_block(&factories);
-    let consensus_constants = ConsensusConstants::current_with_network(Network::LocalNet(Box::new(prev_block.clone())));
-    let (alice_node, bob_node, carol_node) = create_network_with_3_base_nodes_with_config(
+    let network = Network::LocalNet;
+    let consensus_constants = ConsensusConstantsBuilder::new(network)
+        .with_emission_amounts(100_000_000.into(), 0.999, 100.into())
+        .build();
+    let (mut prev_block, _) = create_genesis_block(&factories, &consensus_constants);
+    let consensus_manager = ConsensusManagerBuilder::new(network)
+        .with_consensus_constants(consensus_constants)
+        .with_block(prev_block.clone())
+        .build();
+    let (alice_node, bob_node, carol_node, _) = create_network_with_3_base_nodes_with_config(
         &mut runtime,
         BaseNodeServiceConfig::default(),
         MmrCacheConfig::default(),
         MempoolServiceConfig::default(),
         LivenessConfig::default(),
-        ConsensusManager::new(None, consensus_constants),
+        consensus_manager.clone(),
         temp_dir.path().to_str().unwrap(),
     );
     let state_machine_config = BaseNodeStateMachineConfig::default();
@@ -339,10 +387,10 @@ fn test_block_sync_recovery() {
         let bob_db = &bob_node.blockchain_db;
         let carol_db = &carol_node.blockchain_db;
         // Bob and Carol is ahead of Alice and Bob is ahead of Carol
-        prev_block = append_block(bob_db, &prev_block, vec![]).unwrap();
+        prev_block = append_block(bob_db, &prev_block, vec![], &consensus_manager.consensus_constants()).unwrap();
         carol_db.add_block(prev_block.clone()).unwrap();
         for _ in 0..2 {
-            prev_block = append_block(bob_db, &prev_block, vec![]).unwrap();
+            prev_block = append_block(bob_db, &prev_block, vec![], &consensus_manager.consensus_constants()).unwrap();
         }
 
         // Sync Blocks from genesis block to tip. Alice will notice that the chain tip is equivalent to Bobs tip and

--- a/common/src/configuration.rs
+++ b/common/src/configuration.rs
@@ -543,7 +543,7 @@ pub fn default_config() -> Config {
     cfg.set_default("base_node.testnet.grpc_enabled", false).unwrap();
     cfg.set_default("base_node.testnet.grpc_address", "tcp://127.0.0.1:18141")
         .unwrap();
-    cfg.set_default("base_node.testnet.enable_mining", true).unwrap();
+    cfg.set_default("base_node.testnet.enable_mining", false).unwrap();
 
     set_transport_defaults(&mut cfg);
 

--- a/comms/src/memsocket/mod.rs
+++ b/comms/src/memsocket/mod.rs
@@ -508,17 +508,19 @@ mod test {
 
     #[test]
     fn listener_bind() -> Result<()> {
-        let listener = MemoryListener::bind(42)?;
-        assert_eq!(listener.local_addr(), 42);
+        let port = acquire_next_memsocket_port().into();
+        let listener = MemoryListener::bind(port)?;
+        assert_eq!(listener.local_addr(), port);
 
         Ok(())
     }
 
     #[test]
     fn simple_connect() -> Result<()> {
-        let mut listener = MemoryListener::bind(10)?;
+        let port = acquire_next_memsocket_port().into();
+        let mut listener = MemoryListener::bind(port)?;
 
-        let mut dialer = MemorySocket::connect(10)?;
+        let mut dialer = MemorySocket::connect(port)?;
         let mut listener_socket = block_on(listener.incoming().next()).unwrap()?;
 
         block_on(dialer.write_all(b"foo"))?;
@@ -533,7 +535,8 @@ mod test {
 
     #[test]
     fn listen_on_port_zero() -> Result<()> {
-        let mut listener = MemoryListener::bind(0)?;
+        let port = acquire_next_memsocket_port().into();
+        let mut listener = MemoryListener::bind(port)?;
         let listener_addr = listener.local_addr();
 
         let mut dialer = MemorySocket::connect(listener_addr)?;
@@ -573,8 +576,9 @@ mod test {
             Ok(())
         }
 
-        connect_on_port(9)?;
-        connect_on_port(9)?;
+        let port = acquire_next_memsocket_port().into();
+        connect_on_port(port)?;
+        connect_on_port(port)?;
 
         Ok(())
     }


### PR DESCRIPTION
## Description
This PR refactors ConsensusManager. 
Network types moves to ConsensusManager.
Emission curve moves to ConsensusManager.
ConsensusConstants are being constructed depending on the network type. 

## Motivation and Context
ConcensusConstants should only be constants and not state, emission curve contains state. 
ConsensusManager Should be the single class that controls the state of all consensus rules. 

## How Has This Been Tested?
This should break no current unit test

## Types of changes
* [ ] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [x] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
* [x] I'm merging against the `development` branch
* [x] I ran `cargo-fmt --all` before pushing
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
