### PR TITLE
Emoji encoding and decoding

### DIFF
--- a/RFC/src/RFC-0152_EmojiId.md
+++ b/RFC/src/RFC-0152_EmojiId.md
@@ -136,7 +136,7 @@ One can extract the node id from an emoji ID as follows:
    return with an error. if any emoji character is not in the emoji map, return an error.
 2. Extract the version number:
    3. Do a reverse lookup of emoji`[10]` to find its index. Store this u64 value in `I`.
-   4. The Version number is `(I && 0x3F) >> 2`. This can be used to set the Emoji map accordingly (and may have to be
+   4. The Version number is `(I & 0x3F) >> 2`. This can be used to set the Emoji map accordingly (and may have to be
       done iteratively, since the version is encoded into the emoji string).
 3. Set `CURSOR = 0`.
 4. Set `B = []`, and empty byte array
@@ -157,7 +157,7 @@ will usually cause incompatible versions of the emoji ID to be detected. However
 
 The last 6 bits of the 11th emoji encodes the version; this means that the first 4 bits are part of the node ID. On a
 reverse mapping, there is a chance that the reverse mapping would offer a valid, but incorrect version number if the new
-mapping are not chosen carefully.
+mapping is not chosen carefully.
 
 ##### Example.
 

--- a/applications/tari_base_node/src/builder.rs
+++ b/applications/tari_base_node/src/builder.rs
@@ -21,7 +21,7 @@
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 use crate::miner;
-use futures::{channel::mpsc::Receiver, stream};
+use futures::channel::mpsc::Receiver;
 use log::*;
 use rand::rngs::OsRng;
 use std::{
@@ -77,7 +77,6 @@ use tari_p2p::{
     },
 };
 
-use futures::stream::Fuse;
 use tari_service_framework::{handles::ServiceHandles, StackBuilder};
 use tokio::runtime::Runtime;
 

--- a/applications/tari_base_node/src/main.rs
+++ b/applications/tari_base_node/src/main.rs
@@ -140,7 +140,7 @@ fn main() {
     // lets run the miner
     let miner_handle = if node_config.enable_mining {
         let mut rx = miner.get_utxo_receiver_channel();
-        let mut rx_events = node.get_state_change_event();
+        let rx_events = node.get_state_change_event();
         miner.subscribe_to_state_change(rx_events);
         let mut wallet_output_handle = base_node_context.wallet_output_service.clone();
         rt.spawn(async move {

--- a/base_layer/core/src/base_node/base_node.rs
+++ b/base_layer/core/src/base_node/base_node.rs
@@ -30,8 +30,8 @@ use crate::{
     chain_storage::{BlockchainBackend, BlockchainDatabase},
 };
 use bitflags::_core::sync::atomic::AtomicBool;
-// use futures_util::sink::SinkExt;
-use futures::{stream::Fuse, SinkExt, StreamExt};
+
+use futures::SinkExt;
 use log::*;
 use std::sync::{atomic::Ordering, Arc};
 use tari_broadcast_channel::{bounded, Publisher, Subscriber};

--- a/base_layer/core/src/chain_storage/blockchain_database.rs
+++ b/base_layer/core/src/chain_storage/blockchain_database.rs
@@ -23,7 +23,7 @@
 use crate::{
     blocks::{blockheader::BlockHash, Block, BlockBuilder, BlockHeader, NewBlockTemplate},
     chain_storage::{
-        db_transaction::{DbKey, DbTransaction, DbValue, MetadataKey, MetadataValue, MmrTree},
+        db_transaction::{DbKey, DbTransaction, DbValue, MmrTree},
         error::ChainStorageError,
         ChainMetadata,
         HistoricalBlock,

--- a/base_layer/core/src/mining/miner.rs
+++ b/base_layer/core/src/mining/miner.rs
@@ -50,11 +50,9 @@ use log::*;
 use rand::rngs::OsRng;
 use std::{
     sync::{atomic::Ordering, Arc},
-    thread,
-    time,
     time::Duration,
 };
-use tari_broadcast_channel::{bounded, Publisher, Subscriber};
+use tari_broadcast_channel::Subscriber;
 use tari_crypto::keys::SecretKey;
 use tokio::task::spawn_blocking;
 

--- a/base_layer/core/tests/node_state_machine.rs
+++ b/base_layer/core/tests/node_state_machine.rs
@@ -127,14 +127,14 @@ fn test_event_channel() {
         ConsensusManager::new(None, consensus_constants),
         temp_dir.path().to_str().unwrap(),
     );
-    let mut alice_state_machine = BaseNodeStateMachine::new(
+    let alice_state_machine = BaseNodeStateMachine::new(
         &alice_node.blockchain_db,
         &alice_node.outbound_nci,
         runtime.handle().clone(),
         alice_node.chain_metadata_handle.get_event_stream(),
         BaseNodeStateMachineConfig::default(),
     );
-    let mut rx = alice_state_machine.get_state_change_event();
+    let rx = alice_state_machine.get_state_change_event();
 
     runtime.spawn(async move {
         alice_state_machine.run().await;

--- a/base_layer/wallet/src/util/emoji.rs
+++ b/base_layer/wallet/src/util/emoji.rs
@@ -20,88 +20,176 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+use core::convert::TryFrom;
+use derive_error::Error;
 use serde::export::{fmt::Error, Formatter};
 use std::fmt::Display;
-use tari_comms::peer_manager::NodeId;
-use tari_core::transactions::types::PublicKey;
-use tari_crypto::tari_utilities::{
-    hex::{Hex, HexError},
-    ByteArray,
-    ByteArrayError,
-};
+use tari_comms::peer_manager::{NodeId, NODE_ID_ARRAY_SIZE};
+use tari_crypto::tari_utilities::ByteArray;
 
+/// The number of emoji in the emoji id dictionary.
+const EMOJI_ID_DICTIONARY_LEN: usize = 256;
+/// The byte size of an EmojiId.
+pub const EMOJI_ID_ARRAY_SIZE: usize = 1 + NODE_ID_ARRAY_SIZE; // Version + NodeId
+/// The Dictionary version used for creating an EmojiId.
+pub const EMOJI_ID_VERSION: u8 = 0;
+
+/// The total set of emoji that can be used for emoji id generation.
+// TODO: This is a test dictionary and should be replaced.
+const EMOJI: [char; EMOJI_ID_DICTIONARY_LEN] = [
+    '💫', '😀', '😁', '😆', '😅', '🤣', '🙃', '😉', '😊', '😇', '🥰', '😍', '🤩', '😘', '😋', '🤪', '🤑', '🤗', '🤭',
+    '🤫', '🤔', '🤐', '🤨', '😶', '😏', '😒', '🙄', '😬', '🤥', '😌', '🤤', '😴', '😷', '🤒', '🤢', '🤮', '🥵', '🥶',
+    '🥴', '😵', '🤯', '🤠', '🥳', '😎', '🤓', '🧐', '😕', '😳', '🥺', '😰', '😥', '😭', '😱', '😖', '😡', '👻', '👽',
+    '👾', '🤖', '🙈', '🙉', '🙊', '💋', '💌', '💘', '💝', '💕', '💯', '💢', '💥', '💣', '💤', '👌', '🤞', '🤟', '🤙',
+    '👍', '👎', '✊', '👊', '👏', '🤝', '💪', '🦶', '👂', '🧠', '🦷', '🦴', '👀', '👄', '🤦', '🤷', '🦸', '🦹', '🧙', '🧚',
+    '🧛', '🧜', '🧞', '🧟', '💃', '🕺', '🧗', '🏇', '⛷', '🏂', '🏌', '🏄', '🚣', '🏊', '⛹', '🏋', '🚴', '🤸', '🤼', '🤽',
+    '🤾', '🤹', '👣', '🛀', '🛌', '🦍', '🐶', '🦊', '🐱', '🦁', '🐯', '🦄', '🐮', '🐷', '🦒', '🐘', '🦏', '🐹', '🐰',
+    '🐨', '🐼', '🦨', '🦘', '🐾', '🐓', '🐣', '🐧', '🕊', '🦅', '🦢', '🦩', '🐸', '🦎', '🦖', '🐳', '🐬', '🐟', '🐙', '🐚',
+    '🐌', '🦋', '🐛', '🐜', '🐝', '🐞', '💐', '🌹', '🌴', '🌵', '🍀', '🍇', '🍉', '🍌', '🍍', '🍎', '🍒', '🍓', '🥥',
+    '🥑', '🥕', '🌽', '🌶', '🧅', '🍄', '🥨', '🧀', '🍔', '🍟', '🍕', '🌭', '🥪', '🍿', '🧂', '🦀', '🦑', '🍦', '🍧',
+    '🍩', '🍪', '🎂', '🍫', '🍬', '🍭', '🍯', '🌍', '🏰', '🎪', '🚂', '🚒', '🚓', '🏎', '🛹', '⛵', '🪂', '🚁', '🚀',
+    '🛸', '⌛', '⏰', '🌡', '⭐', '🌈', '🔥', '💧', '🧨', '🎈', '🎉', '🎀', '🎁', '🏆', '⚽', '🎳', '🥊', '🎱', '🕹',
+    '🎲', '🧸', '🎨', '🕶', '👠', '👑', '🎩', '🧢', '💄', '💎', '🔈', '🔔', '🎵', '🎧', '🎷', '🎸', '🎹', '🎺', '🎻',
+    '📱', '🔋', '🎬', '💰', '🖍', '🔫',
+];
+
+#[derive(Debug, Clone, Error, PartialEq)]
+pub enum EmojiIdError {
+    // The provided Emoji could not be found in the Emoji set.
+    Notfound,
+    // Could not create an EmojiId from the provided bytes.
+    IncorrectByteCount,
+    // Unsupported emoji dictionary version.
+    UnsupportedVersion,
+    // Could not convert from an EmojiId to a NodeId.
+    #[error(msg_embedded, non_std, no_from)]
+    ConversionError(String),
+}
+
+/// EmojiId can encode and decode a NodeId and dictionary version into a Emoji string set.
 #[derive(Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
-pub struct EmojiId(String);
+pub struct EmojiId([u8; EMOJI_ID_ARRAY_SIZE]);
 
 impl EmojiId {
-    pub fn from_pubkey(key: &PublicKey) -> Self {
-        // Temp hacky approach - full spec coming shortly
-        let node_id = NodeId::from_key(key).unwrap();
-        let bytes = node_id.as_bytes();
-        let id = bytes.iter().map(|b| EMOJI[*b as usize]).collect();
-        Self(id)
+    /// The dictionary version used by the EmojiId.
+    pub fn version(&self) -> u8 {
+        self.0[0]
     }
 
-    pub fn from_hex(hex_key: &str) -> Result<Self, HexError> {
-        let key = PublicKey::from_hex(hex_key)?;
-        Ok(EmojiId::from_pubkey(&key))
+    /// Extract and return the encoded NodeId from the EmojiId.
+    pub fn node_id(&self) -> Result<NodeId, EmojiIdError> {
+        NodeId::from_bytes(&self.0[1..=NODE_ID_ARRAY_SIZE])
+            .map_err(|err| EmojiIdError::ConversionError(format!("{:?}", err)))
     }
 
-    /// Given a emoji string in `value` returns true if this is a representable as a public key
-    pub fn is_valid(emoji: &str, key: &PublicKey) -> bool {
-        let eid = EmojiId::from_pubkey(&key);
-        eid.as_str() == emoji
+    // Encode the internal bytes to a Emoji string set.
+    fn to_emoji_string(&self) -> String {
+        self.0.iter().map(|index| EMOJI[*index as usize]).collect::<String>()
     }
+}
 
-    pub fn as_str(&self) -> &str {
-        &self.0
+/// Create an EmojiId from a set of bytes, these bytes should include a dictionary version and NodeId.
+impl TryFrom<Vec<u8>> for EmojiId {
+    type Error = EmojiIdError;
+
+    fn try_from(id_bytes: Vec<u8>) -> Result<Self, Self::Error> {
+        if id_bytes.len() != EMOJI_ID_ARRAY_SIZE {
+            return Err(EmojiIdError::IncorrectByteCount);
+        }
+
+        let mut id_byte_slice = [0u8; EMOJI_ID_ARRAY_SIZE];
+        id_byte_slice.copy_from_slice(id_bytes.as_slice());
+
+        let emoji_id = Self(id_byte_slice);
+        if emoji_id.version() != EMOJI_ID_VERSION {
+            return Err(EmojiIdError::UnsupportedVersion);
+        }
+        Ok(emoji_id)
+    }
+}
+
+/// Create an EmojiId from an emoji string set.
+impl TryFrom<&str> for EmojiId {
+    type Error = EmojiIdError;
+
+    fn try_from(emoji_set: &str) -> Result<Self, Self::Error> {
+        let mut id_bytes = Vec::<u8>::with_capacity(EMOJI_ID_ARRAY_SIZE);
+        for emoji in emoji_set.chars() {
+            id_bytes.push(emoji_to_index(emoji)?);
+        }
+        EmojiId::try_from(id_bytes)
+    }
+}
+
+/// Create an EmojiId from a NodeId.
+impl TryFrom<NodeId> for EmojiId {
+    type Error = EmojiIdError;
+
+    fn try_from(node_id: NodeId) -> Result<Self, Self::Error> {
+        let mut id_bytes: Vec<u8> = vec![EMOJI_ID_VERSION];
+        id_bytes.append(&mut node_id.as_bytes().to_vec());
+        EmojiId::try_from(id_bytes)
     }
 }
 
 impl Display for EmojiId {
     fn fmt(&self, fmt: &mut Formatter<'_>) -> Result<(), Error> {
-        fmt.write_str(self.as_str())
+        fmt.write_str(&self.to_emoji_string())
     }
 }
 
-const EMOJI: [char; 256] = [
-    '😀', '😃', '😄', '😁', '😆', '😅', '🤣', '😂', '🙂', '🙃', '😉', '😊', '😇', '🥰', '😍', '🤩', '😘', '😗', '😚',
-    '😙', '😋', '😛', '😜', '🤪', '😝', '🐠', '🤗', '🤭', '🤫', '🤔', '🤐', '🤨', '😐', '😑', '😶', '😏', '😒', '🙄',
-    '😬', '🤥', '😌', '😔', '😪', '🤤', '😴', '😷', '🤒', '🤕', '🤢', '🤮', '🤧', '🥵', '🥶', '🥴', '😵', '🤯', '🤠', '🥳',
-    '😎', '🤓', '🧐', '😕', '😟', '🙁', '😮', '😯', '😲', '😳', '🥺', '😦', '😧', '😨', '😰', '😥', '😢', '😭', '😱',
-    '😖', '😣', '😞', '😓', '😩', '😫', '😤', '😡', '😠', '🤬', '😈', '👿', '💀', '🐟', '💩', '🤡', '👹', '👺', '👻',
-    '👽', '👾', '🤖', '😺', '😹', '😻', '😼', '😽', '🙀', '😿', '😾', '💋', '👋', '🤚', '🖐', '✋', '🖖', '👌', '🤞',
-    '🤟', '🤘', '🤙', '👈', '👉', '👆', '🖕', '👇', '👍', '👎', '✊', '👊', '🤛', '🤜', '👏', '🙌', '👐', '🤲', '🤝',
-    '🙏', '💅', '🤳', '💪', '🦵', '🦶', '👂', '👃', '🧠', '🦷', '🦴', '👀', '👁', '👅', '👄', '🚶', '👣', '🧳', '🌂', '☂',
-    '🧵', '🧶', '👓', '🕶', '🥽', '🥼', '👔', '👕', '👖', '🧣', '🧤', '🧥', '🧦', '👗', '👘', '👙', '👚', '👛', '👜', '👝',
-    '🎒', '👞', '👟', '🥾', '🥿', '👠', '👡', '👢', '👑', '👒', '🎩', '🎓', '🧢', '⛑', '💄', '💍', '💼', '🙈', '🙉',
-    '🙊', '💥', '💫', '💦', '💨', '🐵', '🐒', '🦍', '🐶', '🐕', '🐩', '🐺', '🦊', '🦝', '🐱', '🐈', '🦁', '🐯', '🐅',
-    '🐆', '🐴', '🐎', '🦄', '🦓', '🦌', '🐮', '🐂', '🐃', '🐄', '🐷', '🐖', '🐗', '🐽', '🐏', '🐑', '🐐', '🐪', '🐫',
-    '🦙', '🦒', '🐘', '🦏', '🦛', '🐭', '🐁', '🐀', '🐹', '🐰', '🐇', '🐿', '🦔', '🦇', '🐻', '🐨', '🐼', '🦘', '🦡', '🐾',
-    '🦃', '🐓', '🐣', '🐋', '🐬',
-];
+// Finds the index of the specified emoji in the dictionary.
+fn emoji_to_index(emoji: char) -> Result<u8, EmojiIdError> {
+    for i in 0..EMOJI.len() {
+        if emoji == EMOJI[i] {
+            return Ok(i as u8);
+        }
+    }
+    Err(EmojiIdError::Notfound)
+}
 
 #[cfg(test)]
 mod test {
-    use crate::util::emoji::EmojiId;
-    use tari_core::transactions::types::PublicKey;
-    use tari_crypto::tari_utilities::hex::Hex;
+    use crate::util::emoji::{EmojiId, EmojiIdError, EMOJI_ID_VERSION};
+    use std::convert::TryFrom;
+    use tari_comms::peer_manager::NodeId;
+    use tari_crypto::{keys::PublicKey, ristretto::RistrettoPublicKey};
 
     #[test]
-    fn convert_key() {
-        let key = PublicKey::from_hex("70350e09c474809209824c6e6888707b7dd09959aa227343b5106382b856f73a").unwrap();
-        let eid = EmojiId::from_pubkey(&key);
-        assert_eq!(eid.as_str(), "🤟🥳🤢🧶🖕💦🦒👟👔🤞🤜🐱👠");
-        let h_eid = EmojiId::from_hex("70350e09c474809209824c6e6888707b7dd09959aa227343b5106382b856f73a").unwrap();
-        assert_eq!(eid, h_eid);
+    fn id_from_byte_slice() {
+        let key_bytes = [64, 28, 98, 64, 28, 197, 216, 115, 9, 25, 41, 76];
+        let desired_emoji_set = "💘🤥🧞💘🤥🍬⭐🤽😇😒🤠👍".to_string();
+        assert_eq!(EmojiId(key_bytes).to_string(), desired_emoji_set);
     }
 
     #[test]
-    fn is_valid() {
-        let key = PublicKey::from_hex("70350e09c474809209824c6e6888707b7dd09959aa227343b5106382b856f73a").unwrap();
-        let eid = EmojiId::from_pubkey(&key);
-        assert!(EmojiId::is_valid(eid.as_str(), &key));
-        assert_eq!(EmojiId::is_valid("😂", &key), false);
-        assert_eq!(EmojiId::is_valid("Hi", &key), false);
+    fn id_from_string() {
+        let desired_emoji_set = "💫🎀🐼🍫🚣🦅🍩🤤🎲🤭🍭🐓".to_string();
+        let emoji_id = EmojiId::try_from(desired_emoji_set.as_str()).unwrap();
+        assert_eq!(emoji_id.to_string(), desired_emoji_set);
+    }
+
+    #[test]
+    fn id_from_node_id() {
+        let node_id = NodeId::new();
+        let desired_emoji_set = "💫💫💫💫💫💫💫💫💫💫💫💫".to_string();
+        let emoji_id = EmojiId::try_from(node_id.clone()).unwrap();
+        assert_eq!(emoji_id.to_string(), desired_emoji_set);
+
+        let mut rng = rand::rngs::OsRng;
+        let (_sk, pk) = RistrettoPublicKey::random_keypair(&mut rng);
+        let node_id = NodeId::from_key(&pk).unwrap();
+        let emoji_id = EmojiId::try_from(node_id.clone()).unwrap();
+        assert_eq!(emoji_id.node_id().unwrap(), node_id);
+        assert_eq!(emoji_id.version(), EMOJI_ID_VERSION);
+    }
+
+    #[test]
+    fn check_id_version() {
+        let emoji_set = "💣👾🧞💘🦋🍬⭐🤽🐣😒🤠🌭".to_string();
+        assert_eq!(
+            EmojiId::try_from(emoji_set.as_str()),
+            Err(EmojiIdError::UnsupportedVersion)
+        );
     }
 }

--- a/base_layer/wallet/tests/output_manager_service/service.rs
+++ b/base_layer/wallet/tests/output_manager_service/service.rs
@@ -71,7 +71,6 @@ use tari_wallet::{
             memory_db::OutputManagerMemoryDatabase,
             sqlite_db::OutputManagerSqliteDatabase,
         },
-        OutputManagerServiceInitializer,
     },
     storage::connection_manager::run_migration_and_create_connection_pool,
 };

--- a/comms/src/peer_manager/mod.rs
+++ b/comms/src/peer_manager/mod.rs
@@ -81,7 +81,7 @@ cfg_next! {
 
 pub use self::{
     error::PeerManagerError,
-    node_id::NodeId,
+    node_id::{NodeId, NODE_ID_ARRAY_SIZE},
     node_identity::NodeIdentity,
     peer::{Peer, PeerFlags},
     peer_features::PeerFeatures,

--- a/comms/src/peer_manager/node_id.rs
+++ b/comms/src/peer_manager/node_id.rs
@@ -40,7 +40,7 @@ use tari_crypto::tari_utilities::{
     ByteArrayError,
 };
 
-const NODE_ID_ARRAY_SIZE: usize = 13; // 104-bit as per RFC-0151
+pub const NODE_ID_ARRAY_SIZE: usize = 11; // 88-bit as per RFC-0152
 type NodeIdArray = [u8; NODE_ID_ARRAY_SIZE];
 
 #[derive(Debug, Error, Clone)]
@@ -280,7 +280,7 @@ mod test {
             NodeId::try_from(&[144u8, 28, 106, 112, 220, 197, 216, 119, 9, 217, 42, 77, 159, 211, 53][..]).unwrap();
 
         let result = format!("{}", node_id);
-        assert_eq!("901c6a70dcc5d87709d92a4d9f", result);
+        assert_eq!("901c6a70dcc5d87709d92a", result);
     }
 
     #[test]
@@ -350,32 +350,26 @@ mod test {
     #[test]
     fn test_closest() {
         let mut node_ids: Vec<NodeId> = Vec::new();
-        node_ids.push(NodeId::try_from(&[144, 28, 106, 112, 220, 197, 216, 119, 9, 217, 42, 77, 159][..]).unwrap());
-        node_ids.push(NodeId::try_from(&[75, 249, 102, 1, 2, 166, 155, 37, 22, 54, 84, 98, 56][..]).unwrap());
-        node_ids.push(NodeId::try_from(&[60, 32, 246, 39, 108, 201, 214, 91, 30, 230, 3, 126, 31][..]).unwrap());
-        node_ids.push(NodeId::try_from(&[134, 116, 78, 53, 246, 206, 200, 147, 126, 96, 54, 113, 67][..]).unwrap());
-        node_ids.push(NodeId::try_from(&[75, 146, 162, 130, 22, 63, 247, 182, 156, 103, 174, 32, 134][..]).unwrap());
-        node_ids.push(NodeId::try_from(&[186, 43, 62, 14, 60, 214, 9, 180, 145, 122, 55, 160, 83][..]).unwrap());
-        node_ids.push(NodeId::try_from(&[143, 189, 32, 210, 30, 231, 82, 5, 86, 85, 28, 82, 154][..]).unwrap());
-        node_ids.push(NodeId::try_from(&[155, 210, 214, 160, 153, 70, 172, 234, 177, 178, 62, 82, 166][..]).unwrap());
-        node_ids.push(NodeId::try_from(&[173, 218, 34, 188, 211, 173, 235, 82, 18, 159, 55, 47, 242][..]).unwrap());
+        node_ids.push(NodeId::try_from(&[144, 28, 106, 112, 220, 197, 216, 119, 9, 217, 42][..]).unwrap());
+        node_ids.push(NodeId::try_from(&[75, 249, 102, 1, 2, 166, 155, 37, 22, 54, 84][..]).unwrap());
+        node_ids.push(NodeId::try_from(&[60, 32, 246, 39, 108, 201, 214, 91, 30, 230, 3][..]).unwrap());
+        node_ids.push(NodeId::try_from(&[134, 116, 78, 53, 246, 206, 200, 147, 126, 96, 54][..]).unwrap());
+        node_ids.push(NodeId::try_from(&[75, 146, 162, 130, 22, 63, 247, 182, 156, 103, 174][..]).unwrap());
+        node_ids.push(NodeId::try_from(&[186, 43, 62, 14, 60, 214, 9, 180, 145, 122, 55][..]).unwrap());
+        node_ids.push(NodeId::try_from(&[143, 189, 32, 210, 30, 231, 82, 5, 86, 85, 28][..]).unwrap());
+        node_ids.push(NodeId::try_from(&[155, 210, 214, 160, 153, 70, 172, 234, 177, 178, 62][..]).unwrap());
+        node_ids.push(NodeId::try_from(&[173, 218, 34, 188, 211, 173, 235, 82, 18, 159, 55][..]).unwrap());
 
-        let node_id = NodeId::try_from(&[169, 125, 200, 137, 210, 73, 241, 238, 25, 108, 8, 48, 66][..]).unwrap();
+        let node_id = NodeId::try_from(&[169, 125, 200, 137, 210, 73, 241, 238, 25, 108, 8][..]).unwrap();
 
         let k = 3;
         match node_id.closest(&node_ids, k) {
             Ok(knn_node_ids) => {
                 println!(" KNN = {:?}", knn_node_ids);
                 assert_eq!(knn_node_ids.len(), k);
-                assert_eq!(knn_node_ids[0].0, [
-                    173, 218, 34, 188, 211, 173, 235, 82, 18, 159, 55, 47, 242
-                ]);
-                assert_eq!(knn_node_ids[1].0, [
-                    186, 43, 62, 14, 60, 214, 9, 180, 145, 122, 55, 160, 83
-                ]);
-                assert_eq!(knn_node_ids[2].0, [
-                    143, 189, 32, 210, 30, 231, 82, 5, 86, 85, 28, 82, 154
-                ]);
+                assert_eq!(knn_node_ids[0].0, [173, 218, 34, 188, 211, 173, 235, 82, 18, 159, 55,]);
+                assert_eq!(knn_node_ids[1].0, [186, 43, 62, 14, 60, 214, 9, 180, 145, 122, 55,]);
+                assert_eq!(knn_node_ids[2].0, [143, 189, 32, 210, 30, 231, 82, 5, 86, 85, 28,]);
             },
             Err(_e) => assert!(false),
         };

--- a/comms/src/peer_manager/peer.rs
+++ b/comms/src/peer_manager/peer.rs
@@ -231,7 +231,7 @@ mod test {
     #[test]
     fn json_ser_der() {
         let expected_pk_hex = "02622ace8f7303a31cafc63f8fc48fdc16e1c8c8d234b2f0d6685282a9076031";
-        let expected_nodeid_hex = "c1a7552e5d9e9b257c4008b965";
+        let expected_nodeid_hex = "61e0d155fe7f4bdc2b63de";
         let pk = CommsPublicKey::from_hex(expected_pk_hex).unwrap();
         let node_id = NodeId::from_key(&pk).unwrap();
         let peer = Peer::new(


### PR DESCRIPTION
## Description
-  The EmojiId encoding and decoding from emoji string sets and NodeIds were updated, now the EmojiId also includes an emoji dictionary version.
- The NodeId byte size was reduced to 11 bytes(88-bit) to ensure that the EmojiId produced 12 emoji when it is represented as a string.
- Updated the wallet ffi to make use of the changed EmojiId and fixed a few warnings.
- Updated the emoji dictionary set to include more objects and less faces.

## Motivation and Context
These changes will allow the version of an EmojiId to be determined and make use of only an emoji dictionary with 256 unique emoji.

## How Has This Been Tested?
EmojiId tests were added: id_from_byte_slice, id_from_string, id_from_node_id and check_id_version.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [x] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [x] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch
* [x] I ran `cargo-fmt --all` before pushing
* [x] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
