### PR TITLE
Base node not loading meta data correctly

### DIFF
--- a/base_layer/core/src/base_node/base_node.rs
+++ b/base_layer/core/src/base_node/base_node.rs
@@ -31,7 +31,7 @@ use crate::{
 };
 use bitflags::_core::sync::atomic::AtomicBool;
 // use futures_util::sink::SinkExt;
-use futures::{stream::Fuse, SinkExt, StreamExt};
+use futures::SinkExt;
 use log::*;
 use std::sync::{atomic::Ordering, Arc};
 use tari_broadcast_channel::{bounded, Publisher, Subscriber};

--- a/base_layer/core/src/chain_storage/lmdb_db/lmdb.rs
+++ b/base_layer/core/src/chain_storage/lmdb_db/lmdb.rs
@@ -75,6 +75,18 @@ where
         .map_err(|e| ChainStorageError::AccessError(e.to_string()))
 }
 
+pub fn lmdb_replace<K, V>(txn: &WriteTransaction, db: &Database, key: &K, val: &V) -> Result<(), ChainStorageError>
+where
+    K: Serialize,
+    V: Serialize,
+{
+    let key_buf = serialize(key)?;
+    let val_buf = serialize(val)?;
+    txn.access()
+        .put(&db, &key_buf, &val_buf, put::Flags::empty())
+        .map_err(|e| ChainStorageError::AccessError(e.to_string()))
+}
+
 pub fn lmdb_delete<K>(txn: &WriteTransaction, db: &Database, key: &K) -> Result<(), ChainStorageError>
 where K: Serialize {
     let key_buf = serialize(key)?;

--- a/base_layer/core/src/chain_storage/lmdb_db/lmdb_db.rs
+++ b/base_layer/core/src/chain_storage/lmdb_db/lmdb_db.rs
@@ -27,7 +27,7 @@ use crate::{
         db_transaction::{DbKey, DbKeyValuePair, DbTransaction, DbValue, MetadataValue, MmrTree, WriteOperation},
         error::ChainStorageError,
         lmdb_db::{
-            lmdb::{lmdb_delete, lmdb_exists, lmdb_for_each, lmdb_get, lmdb_insert, lmdb_len},
+            lmdb::{lmdb_delete, lmdb_exists, lmdb_for_each, lmdb_get, lmdb_insert, lmdb_len, lmdb_replace},
             LMDBVec,
             LMDB_DB_BLOCK_HASHES,
             LMDB_DB_HEADERS,
@@ -419,7 +419,7 @@ where D: Digest + Send + Sync
                 match op {
                     WriteOperation::Insert(insert) => match insert {
                         DbKeyValuePair::Metadata(k, v) => {
-                            lmdb_insert(&txn, &self.metadata_db, &(k.clone() as u32), &v)?;
+                            lmdb_replace(&txn, &self.metadata_db, &(k.clone() as u32), &v)?;
                         },
                         DbKeyValuePair::BlockHeader(k, v) => {
                             let hash = v.hash();

--- a/base_layer/core/src/chain_storage/memory_db/memory_db.rs
+++ b/base_layer/core/src/chain_storage/memory_db/memory_db.rs
@@ -150,9 +150,6 @@ where D: Digest + Send + Sync
                 WriteOperation::Insert(insert) => match insert {
                     DbKeyValuePair::Metadata(k, v) => {
                         let key = k as u32;
-                        if db.metadata.contains_key(&key) {
-                            return Err(ChainStorageError::InvalidOperation("Duplicate key".to_string()));
-                        }
                         db.metadata.insert(key, v);
                     },
                     DbKeyValuePair::BlockHeader(k, v) => {

--- a/base_layer/core/src/mining/miner.rs
+++ b/base_layer/core/src/mining/miner.rs
@@ -50,11 +50,9 @@ use log::*;
 use rand::rngs::OsRng;
 use std::{
     sync::{atomic::Ordering, Arc},
-    thread,
-    time,
     time::Duration,
 };
-use tari_broadcast_channel::{bounded, Publisher, Subscriber};
+use tari_broadcast_channel::Subscriber;
 use tari_crypto::keys::SecretKey;
 use tokio::task::spawn_blocking;
 

--- a/base_layer/core/tests/node_state_machine.rs
+++ b/base_layer/core/tests/node_state_machine.rs
@@ -127,14 +127,14 @@ fn test_event_channel() {
         ConsensusManager::new(None, consensus_constants),
         temp_dir.path().to_str().unwrap(),
     );
-    let mut alice_state_machine = BaseNodeStateMachine::new(
+    let alice_state_machine = BaseNodeStateMachine::new(
         &alice_node.blockchain_db,
         &alice_node.outbound_nci,
         runtime.handle().clone(),
         alice_node.chain_metadata_handle.get_event_stream(),
         BaseNodeStateMachineConfig::default(),
     );
-    let mut rx = alice_state_machine.get_state_change_event();
+    let rx = alice_state_machine.get_state_change_event();
 
     runtime.spawn(async move {
         alice_state_machine.run().await;

--- a/base_layer/wallet/src/util/emoji.rs
+++ b/base_layer/wallet/src/util/emoji.rs
@@ -27,7 +27,6 @@ use tari_core::transactions::types::PublicKey;
 use tari_crypto::tari_utilities::{
     hex::{Hex, HexError},
     ByteArray,
-    ByteArrayError,
 };
 
 #[derive(Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]


### PR DESCRIPTION
## Description
- Changed update_metadata to also update the storage metadata values in the backend.
- Changed the lmdb and memory backends to allow the metadata values to be replaced and updated.
- Added the lmdb_replace function to allow key values to be inserted and replaced if they already exist.
- Reverted the previous temporary fix from read_metadata.

## Motivation and Context
These changes will fix the blockchain db metadata restore issue.

## How Has This Been Tested?
Added a restore_metadata test to demonstrate that the backend metadata values were correctly updated.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [x] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch
* [x] I ran `cargo-fmt --all` before pushing
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
