### PR TITLE
Set the peer id when replacing

### DIFF
--- a/comms/src/peer_manager/peer_storage.rs
+++ b/comms/src/peer_manager/peer_storage.rs
@@ -88,6 +88,7 @@ where DS: KeyValueStore<PeerId, Peer>
             Some(peer_key) => {
                 trace!(target: LOG_TARGET, "Replacing peer that has NodeId '{}'", peer.node_id,);
                 // Replace existing entry
+                peer.set_id(peer_key);
                 self.peer_db
                     .insert(peer_key, peer)
                     .map_err(PeerManagerError::DatabaseError)?;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Peer IDs were stored as None when they are replaced using `add_peer`. This is a problem when they are retrieved later.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch
* [x] I ran `cargo-fmt --all` before pushing
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
