### PR TITLE
MempoolService: handle add block and reorg events

### DIFF
--- a/base_layer/core/src/chain_storage/async_db.rs
+++ b/base_layer/core/src/chain_storage/async_db.rs
@@ -78,5 +78,5 @@ make_async!(calculate_mmr_roots(template: NewBlockTemplate) -> Block);
 
 // make_async!(is_new_best_block(block: &Block) -> bool);
 make_async!(fetch_block(height: u64) -> HistoricalBlock);
-make_async!(rewind_to_height(height: u64) -> ());
+make_async!(rewind_to_height(height: u64) -> Vec<Block>);
 make_async!(fetch_mmr_proof(tree: MmrTree, pos: usize) -> MerkleProof);

--- a/base_layer/core/src/mempool/mempool.rs
+++ b/base_layer/core/src/mempool/mempool.rs
@@ -162,7 +162,11 @@ where T: BlockchainBackend
                 block
             );
         }
-        self.insert_txs(self.reorg_pool.scan_for_and_remove_reorged_txs(removed_blocks)?)?;
+
+        self.insert_txs(
+            self.reorg_pool
+                .remove_reorged_txs_and_discard_double_spends(removed_blocks, &new_blocks)?,
+        )?;
         self.process_published_blocks(&new_blocks)?;
         Ok(())
     }

--- a/base_layer/core/src/mempool/orphan_pool/error.rs
+++ b/base_layer/core/src/mempool/orphan_pool/error.rs
@@ -25,8 +25,9 @@ use derive_error::Error;
 
 #[derive(Debug, Error)]
 pub enum OrphanPoolError {
-    /// The Thread Safety has been breached and the data access has become poisoned
-    PoisonedAccess,
+    /// A problem has been encountered with the storage backend.
+    #[error(non_std, no_from)]
+    BackendError(String),
     ChainStorageError(ChainStorageError),
     /// The Blockchain height is undefined
     ChainHeightUndefined,

--- a/base_layer/core/src/mempool/orphan_pool/orphan_pool.rs
+++ b/base_layer/core/src/mempool/orphan_pool/orphan_pool.rs
@@ -76,7 +76,7 @@ where T: BlockchainBackend
     pub fn insert(&self, transaction: Arc<Transaction>) -> Result<(), OrphanPoolError> {
         self.pool_storage
             .write()
-            .map_err(|_| OrphanPoolError::PoisonedAccess)?
+            .map_err(|e| OrphanPoolError::BackendError(e.to_string()))?
             .insert(transaction);
         Ok(())
     }
@@ -86,7 +86,7 @@ where T: BlockchainBackend
     pub fn insert_txs(&self, transactions: Vec<Arc<Transaction>>) -> Result<(), OrphanPoolError> {
         self.pool_storage
             .write()
-            .map_err(|_| OrphanPoolError::PoisonedAccess)?
+            .map_err(|e| OrphanPoolError::BackendError(e.to_string()))?
             .insert_txs(transactions);
         Ok(())
     }
@@ -96,7 +96,7 @@ where T: BlockchainBackend
         Ok(self
             .pool_storage
             .read()
-            .map_err(|_| OrphanPoolError::PoisonedAccess)?
+            .map_err(|e| OrphanPoolError::BackendError(e.to_string()))?
             .has_tx_with_excess_sig(excess_sig))
     }
 
@@ -107,7 +107,7 @@ where T: BlockchainBackend
     ) -> Result<(Vec<Arc<Transaction>>, Vec<Arc<Transaction>>), OrphanPoolError> {
         self.pool_storage
             .write()
-            .map_err(|_| OrphanPoolError::PoisonedAccess)?
+            .map_err(|e| OrphanPoolError::BackendError(e.to_string()))?
             .scan_for_and_remove_unorphaned_txs()
     }
 
@@ -116,7 +116,7 @@ where T: BlockchainBackend
         Ok(self
             .pool_storage
             .write()
-            .map_err(|_| OrphanPoolError::PoisonedAccess)?
+            .map_err(|e| OrphanPoolError::BackendError(e.to_string()))?
             .len())
     }
 
@@ -125,7 +125,7 @@ where T: BlockchainBackend
         Ok(self
             .pool_storage
             .write()
-            .map_err(|_| OrphanPoolError::PoisonedAccess)?
+            .map_err(|e| OrphanPoolError::BackendError(e.to_string()))?
             .snapshot())
     }
 
@@ -134,7 +134,7 @@ where T: BlockchainBackend
         Ok(self
             .pool_storage
             .write()
-            .map_err(|_| OrphanPoolError::PoisonedAccess)?
+            .map_err(|e| OrphanPoolError::BackendError(e.to_string()))?
             .calculate_weight())
     }
 }

--- a/base_layer/core/src/mempool/pending_pool/error.rs
+++ b/base_layer/core/src/mempool/pending_pool/error.rs
@@ -27,7 +27,8 @@ use derive_error::Error;
 pub enum PendingPoolError {
     /// The HashMap and BTreeMap are out of sync
     StorageOutofSync,
-    /// The Thread Safety has been breached and the data access has become poisoned
-    PoisonedAccess,
+    /// A problem has been encountered with the storage backend.
+    #[error(non_std, no_from)]
+    BackendError(String),
     PriorityError(PriorityError),
 }

--- a/base_layer/core/src/mempool/pending_pool/pending_pool.rs
+++ b/base_layer/core/src/mempool/pending_pool/pending_pool.rs
@@ -65,7 +65,7 @@ impl PendingPool {
     pub fn insert(&self, transaction: Arc<Transaction>) -> Result<(), PendingPoolError> {
         self.pool_storage
             .write()
-            .map_err(|_| PendingPoolError::PoisonedAccess)?
+            .map_err(|e| PendingPoolError::BackendError(e.to_string()))?
             .insert(transaction)
     }
 
@@ -73,7 +73,7 @@ impl PendingPool {
     pub fn insert_txs(&self, transactions: Vec<Arc<Transaction>>) -> Result<(), PendingPoolError> {
         self.pool_storage
             .write()
-            .map_err(|_| PendingPoolError::PoisonedAccess)?
+            .map_err(|e| PendingPoolError::BackendError(e.to_string()))?
             .insert_txs(transactions)
     }
 
@@ -82,7 +82,7 @@ impl PendingPool {
         Ok(self
             .pool_storage
             .read()
-            .map_err(|_| PendingPoolError::PoisonedAccess)?
+            .map_err(|e| PendingPoolError::BackendError(e.to_string()))?
             .has_tx_with_excess_sig(excess_sig))
     }
 
@@ -95,7 +95,7 @@ impl PendingPool {
     {
         self.pool_storage
             .write()
-            .map_err(|_| PendingPoolError::PoisonedAccess)?
+            .map_err(|e| PendingPoolError::BackendError(e.to_string()))?
             .remove_unlocked_and_discard_double_spends(published_block)
     }
 
@@ -104,7 +104,7 @@ impl PendingPool {
         Ok(self
             .pool_storage
             .read()
-            .map_err(|_| PendingPoolError::PoisonedAccess)?
+            .map_err(|e| PendingPoolError::BackendError(e.to_string()))?
             .len())
     }
 
@@ -113,7 +113,7 @@ impl PendingPool {
         Ok(self
             .pool_storage
             .read()
-            .map_err(|_| PendingPoolError::PoisonedAccess)?
+            .map_err(|e| PendingPoolError::BackendError(e.to_string()))?
             .snapshot())
     }
 
@@ -122,7 +122,7 @@ impl PendingPool {
         Ok(self
             .pool_storage
             .read()
-            .map_err(|_| PendingPoolError::PoisonedAccess)?
+            .map_err(|e| PendingPoolError::BackendError(e.to_string()))?
             .calculate_weight())
     }
 
@@ -132,7 +132,7 @@ impl PendingPool {
         Ok(self
             .pool_storage
             .read()
-            .map_err(|_| PendingPoolError::PoisonedAccess)?
+            .map_err(|e| PendingPoolError::BackendError(e.to_string()))?
             .check_status())
     }
 }

--- a/base_layer/core/src/mempool/reorg_pool/error.rs
+++ b/base_layer/core/src/mempool/reorg_pool/error.rs
@@ -24,6 +24,7 @@ use derive_error::Error;
 
 #[derive(Debug, Error)]
 pub enum ReorgPoolError {
-    /// The Thread Safety has been breached and the data access has become poisoned
-    PoisonedAccess,
+    /// A problem has been encountered with the storage backend.
+    #[error(non_std, no_from)]
+    BackendError(String),
 }

--- a/base_layer/core/src/mempool/service/initializer.rs
+++ b/base_layer/core/src/mempool/service/initializer.rs
@@ -21,6 +21,7 @@
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 use crate::{
+    base_node::comms_interface::LocalNodeCommsInterface,
     chain_storage::BlockchainBackend,
     mempool::{
         mempool::Mempool,
@@ -172,12 +173,17 @@ where T: BlockchainBackend + 'static
                 .get_handle::<OutboundMessageRequester>()
                 .expect("OutboundMessageRequester handle required for MempoolService");
 
+            let base_node = handles
+                .get_handle::<LocalNodeCommsInterface>()
+                .expect("LocalNodeCommsInterface required to initialize ChainStateSyncService");
+
             let streams = MempoolStreams::new(
                 outbound_request_stream,
                 outbound_tx_stream,
                 inbound_request_stream,
                 inbound_response_stream,
                 inbound_transaction_stream,
+                base_node.get_block_event_stream(),
             );
             let service =
                 MempoolService::new(executer_clone, outbound_message_service, inbound_handlers, config).start(streams);

--- a/base_layer/core/src/mempool/unconfirmed_pool/error.rs
+++ b/base_layer/core/src/mempool/unconfirmed_pool/error.rs
@@ -27,7 +27,8 @@ use derive_error::Error;
 pub enum UnconfirmedPoolError {
     /// The HashMap and BTreeMap are out of sync
     StorageOutofSync,
-    /// The Thread Safety has been breached and the data access has become poisoned
-    PoisonedAccess,
+    /// A problem has been encountered with the storage backend.
+    #[error(non_std, no_from)]
+    BackendError(String),
     PriorityError(PriorityError),
 }

--- a/base_layer/core/src/mempool/unconfirmed_pool/unconfirmed_pool.rs
+++ b/base_layer/core/src/mempool/unconfirmed_pool/unconfirmed_pool.rs
@@ -69,7 +69,7 @@ impl UnconfirmedPool {
     pub fn insert(&self, transaction: Arc<Transaction>) -> Result<(), UnconfirmedPoolError> {
         self.pool_storage
             .write()
-            .map_err(|_| UnconfirmedPoolError::PoisonedAccess)?
+            .map_err(|e| UnconfirmedPoolError::BackendError(e.to_string()))?
             .insert(transaction)
     }
 
@@ -77,7 +77,7 @@ impl UnconfirmedPool {
     pub fn insert_txs(&self, transactions: Vec<Arc<Transaction>>) -> Result<(), UnconfirmedPoolError> {
         self.pool_storage
             .write()
-            .map_err(|_| UnconfirmedPoolError::PoisonedAccess)?
+            .map_err(|e| UnconfirmedPoolError::BackendError(e.to_string()))?
             .insert_txs(transactions)
     }
 
@@ -86,7 +86,7 @@ impl UnconfirmedPool {
         Ok(self
             .pool_storage
             .read()
-            .map_err(|_| UnconfirmedPoolError::PoisonedAccess)?
+            .map_err(|e| UnconfirmedPoolError::BackendError(e.to_string()))?
             .has_tx_with_excess_sig(excess_sig))
     }
 
@@ -94,7 +94,7 @@ impl UnconfirmedPool {
     pub fn highest_priority_txs(&self, total_weight: u64) -> Result<Vec<Arc<Transaction>>, UnconfirmedPoolError> {
         self.pool_storage
             .read()
-            .map_err(|_| UnconfirmedPoolError::PoisonedAccess)?
+            .map_err(|e| UnconfirmedPoolError::BackendError(e.to_string()))?
             .highest_priority_txs(total_weight)
     }
 
@@ -108,7 +108,7 @@ impl UnconfirmedPool {
         Ok(self
             .pool_storage
             .write()
-            .map_err(|_| UnconfirmedPoolError::PoisonedAccess)?
+            .map_err(|e| UnconfirmedPoolError::BackendError(e.to_string()))?
             .remove_published_and_discard_double_spends(published_block))
     }
 
@@ -117,7 +117,7 @@ impl UnconfirmedPool {
         Ok(self
             .pool_storage
             .read()
-            .map_err(|_| UnconfirmedPoolError::PoisonedAccess)?
+            .map_err(|e| UnconfirmedPoolError::BackendError(e.to_string()))?
             .len())
     }
 
@@ -126,7 +126,7 @@ impl UnconfirmedPool {
         Ok(self
             .pool_storage
             .read()
-            .map_err(|_| UnconfirmedPoolError::PoisonedAccess)?
+            .map_err(|e| UnconfirmedPoolError::BackendError(e.to_string()))?
             .snapshot())
     }
 
@@ -135,7 +135,7 @@ impl UnconfirmedPool {
         Ok(self
             .pool_storage
             .read()
-            .map_err(|_| UnconfirmedPoolError::PoisonedAccess)?
+            .map_err(|e| UnconfirmedPoolError::BackendError(e.to_string()))?
             .calculate_weight())
     }
 
@@ -145,7 +145,7 @@ impl UnconfirmedPool {
         Ok(self
             .pool_storage
             .read()
-            .map_err(|_| UnconfirmedPoolError::PoisonedAccess)?
+            .map_err(|e| UnconfirmedPoolError::BackendError(e.to_string()))?
             .check_status())
     }
 }

--- a/base_layer/core/tests/chain_storage_tests/chain_storage.rs
+++ b/base_layer/core/tests/chain_storage_tests/chain_storage.rs
@@ -493,10 +493,11 @@ fn handle_tip_reorg() {
     .is_ok());
 
     // Adding B2 to the main chain will produce a reorg to GB->A1->B2.
-    assert_eq!(
-        store.add_block(orphan_blocks[2].clone()),
-        Ok(BlockAddResult::ChainReorg)
-    );
+    if let Ok(BlockAddResult::ChainReorg(_)) = store.add_block(orphan_blocks[2].clone()) {
+        assert!(true);
+    } else {
+        assert!(false);
+    }
     assert_eq!(store.fetch_tip_header(), Ok(orphan_blocks[2].header.clone()));
 
     // Check that B2 was removed from the block orphans and A2 has been orphaned.

--- a/base_layer/core/tests/node_state_machine.rs
+++ b/base_layer/core/tests/node_state_machine.rs
@@ -351,7 +351,6 @@ fn test_block_sync_recovery() {
         // have been reached.
         let state_event = BlockSyncInfo.next_event(&mut alice_state_machine).await;
         assert_eq!(state_event, StateEvent::BlocksSynchronized);
-        println!("state_event={:?}", state_event);
 
         let bob_tip_height = bob_db.get_height().unwrap().unwrap();
         for height in 1..=bob_tip_height {


### PR DESCRIPTION
## Description
- Changed the mempool service so that it listens to block events from the base node, a block event handler was added to allow the mempool to react to add block events and chain re-org events.
- Changed the inbound block handler of the base node to allow the network propagation of received blocks that produced a re-org of the local chain.
- Modified the blockchain database rewind_to_height and reorganize_chain functions so they return the blocks that were removed, these removed blocks are required to process a re-org in the mempool.
- The BlockAddResult ChainReorg event was changed to allow the mempool service event handler to obtain the set of added and removed blocks. 
- Replaced the PoisonedAccess error type with a BackendError in the OrphanPoolError, PendingPoolError, ReorgPoolError and UnconfirmedPoolError.
- Changed some of the test block builder functions to allow the creation of coinbases with configurable maturity.

## Motivation and Context
These changes are required to allow the mempool state to be updated when new blocks were added to the blockchain or a chain re-organisation was performed.

## How Has This Been Tested?
Added the mempool test block_event_and_reorg_event_handling for checking that the mempool service is correctly reacting to add block events and chain re-org events. 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [x] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch
* [x] I ran `cargo-fmt --all` before pushing
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
