### PR TITLE
Allow transports to be configured for base node

### DIFF
--- a/base_layer/wallet_ffi/src/lib.rs
+++ b/base_layer/wallet_ffi/src/lib.rs
@@ -1636,10 +1636,7 @@ pub unsafe extern "C" fn transport_tor_create(
     if !socks_username.is_null() && !socks_password.is_null() {
         username_str = CStr::from_ptr(socks_username).to_str().unwrap().to_owned();
         password_str = CStr::from_ptr(socks_password).to_str().unwrap().to_owned();
-        authentication = socks::Authentication::Password {
-            username: username_str,
-            password: password_str,
-        }
+        authentication = socks::Authentication::Password(username_str, password_str);
     }
 
     let mut tor_authentication = tor::Authentication::None;

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -11,11 +11,13 @@ edition = "2018"
 
 
 [dependencies]
+clap = "2.33.0"
+config = { version = "0.9.3" }
 dirs = "2.0"
+get_if_addrs = "0.5.3"
 log = "0.4.8"
 log4rs = "0.8.3"
-config = { version = "0.9.3" }
-clap = "2.33.0"
+multiaddr={package="parity-multiaddr", version = "0.7.2"}
 
 [dev-dependencies]
 tempdir = "0.3.7"

--- a/common/src/configuration.rs
+++ b/common/src/configuration.rs
@@ -24,12 +24,16 @@
 use crate::{dir_utils::default_subdir, ConfigBootstrap};
 use config::{Config, Environment};
 use log::*;
+use multiaddr::{Multiaddr, Protocol};
 use std::{
     convert::TryFrom,
     env,
     error::Error,
     fmt::{Display, Formatter, Result as FormatResult},
+    net::IpAddr,
+    num::NonZeroU16,
     path::{Path, PathBuf},
+    str::FromStr,
 };
 
 const LOG_TARGET: &str = "common::config";
@@ -150,22 +154,117 @@ pub enum DatabaseType {
     Memory,
 }
 
+//---------------------------------------------     Network Transport     ------------------------------------------//
+#[derive(Debug, Clone)]
+pub enum TorControlAuthentication {
+    None,
+    Password(String),
+}
+
+fn parse_key_value(s: &str, split_chr: char) -> (String, Option<&str>) {
+    let mut parts = s.splitn(2, split_chr);
+    (
+        parts
+            .next()
+            .expect("splitn always emits at least one part")
+            .to_lowercase(),
+        parts.next(),
+    )
+}
+
+impl FromStr for TorControlAuthentication {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let (auth_type, maybe_value) = parse_key_value(s, '=');
+        match auth_type.as_str() {
+            "none" => Ok(TorControlAuthentication::None),
+            "password" => {
+                let password = maybe_value.ok_or_else(|| {
+                    "Invalid format for 'password' tor authentication type. It should be in the format \
+                     'password=xxxxxx'."
+                        .to_string()
+                })?;
+                Ok(TorControlAuthentication::Password(password.to_string()))
+            },
+            s => Err(format!("Invalid tor auth type '{}'", s)),
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub enum SocksAuthentication {
+    None,
+    UsernamePassword(String, String),
+}
+
+impl FromStr for SocksAuthentication {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let (auth_type, maybe_value) = parse_key_value(s, '=');
+        match auth_type.as_str() {
+            "none" => Ok(SocksAuthentication::None),
+            "username_password" => {
+                let (username, password) = maybe_value
+                    .and_then(|value| {
+                        let (un, pwd) = parse_key_value(value, ':');
+                        // If pwd is None, return None
+                        pwd.map(|p| (un, p))
+                    })
+                    .ok_or_else(|| {
+                        "Invalid format for 'username-password' socks authentication type. It should be in the format \
+                         'username_password=my_username:xxxxxx'."
+                            .to_string()
+                    })?;
+                Ok(SocksAuthentication::UsernamePassword(username, password.to_string()))
+            },
+            s => Err(format!("Invalid tor auth type '{}'", s)),
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub enum CommsTransport {
+    /// Use TCP to join the Tari network. This transport can only communicate with TCP/IP addresses, so peers with
+    /// e.g. tor onion addresses will not be contactable.
+    Tcp { listener_address: Multiaddr },
+    /// Configures the node to run over a tor hidden service using the Tor proxy. This transport recognises ip/tcp,
+    /// onion v2, onion v3 and dns addresses.
+    TorHiddenService {
+        /// The address of the control server
+        control_server_address: Multiaddr,
+        /// The address used to receive proxied traffic from the tor proxy to the Tari node. This port must be
+        /// available
+        forward_address: Multiaddr,
+        auth: TorControlAuthentication,
+        onion_port: NonZeroU16,
+    },
+    /// Use a SOCKS5 proxy transport. This transport recognises any addresses supported by the proxy.
+    Socks5 {
+        proxy_address: Multiaddr,
+        listener_address: Multiaddr,
+        auth: SocksAuthentication,
+    },
+}
+
 //-------------------------------------        Main Configuration Struct      --------------------------------------//
 
 #[derive(Debug)]
 pub struct GlobalConfig {
     pub network: Network,
+    pub comms_transport: CommsTransport,
     pub data_dir: PathBuf,
     pub db_type: DatabaseType,
     pub core_threads: usize,
     pub blocking_threads: usize,
     pub identity_file: PathBuf,
-    pub public_address: String,
-    pub listener_address: String,
+    pub public_address: Multiaddr,
     pub peer_seeds: Vec<String>,
     pub peer_db_path: String,
     pub enable_mining: bool,
     pub wallet_file: String,
+    pub tor_private_key_file: String,
 }
 
 impl GlobalConfig {
@@ -228,17 +327,24 @@ fn convert_node_config(network: Network, cfg: Config) -> Result<GlobalConfig, Co
         .map_err(|e| ConfigurationError::new(&key, &e.to_string()))?;
     let identity_file = PathBuf::from(identity_file);
 
-    // Public Address
-    let key = config_string(&net_str, "public_address");
-    let public_address = cfg
+    // Tor private key persistence
+    let key = config_string(&net_str, "tor_private_key_file");
+    let tor_private_key_file = cfg
         .get_str(&key)
         .map_err(|e| ConfigurationError::new(&key, &e.to_string()))?;
 
-    // Listener Address
-    let key = config_string(&net_str, "listener_address");
-    let listener_address = cfg
+    // Transport
+    let comms_transport = network_transport_config(&cfg, &net_str)?;
+
+    // Public address
+    let key = config_string(&net_str, "public_address");
+    let public_address = cfg
         .get_str(&key)
-        .map_err(|e| ConfigurationError::new(&key, &e.to_string()))?;
+        .map_err(|e| ConfigurationError::new(&key, &e.to_string()))
+        .and_then(|addr| {
+            addr.parse::<Multiaddr>()
+                .map_err(|e| ConfigurationError::new(&key, &e.to_string()))
+        })?;
 
     // Peer seeds
     let key = config_string(&net_str, "peer_seeds");
@@ -264,18 +370,92 @@ fn convert_node_config(network: Network, cfg: Config) -> Result<GlobalConfig, Co
 
     Ok(GlobalConfig {
         network,
+        comms_transport,
         data_dir,
         db_type,
         core_threads,
         blocking_threads,
         identity_file,
         public_address,
-        listener_address,
         peer_seeds,
         peer_db_path,
         enable_mining,
         wallet_file,
+        tor_private_key_file,
     })
+}
+
+fn network_transport_config(cfg: &Config, network: &str) -> Result<CommsTransport, ConfigurationError> {
+    let get_conf_str = |key| {
+        cfg.get_str(key)
+            .map_err(|err| ConfigurationError::new(key, &err.to_string()))
+    };
+
+    let get_conf_multiaddr = |key| {
+        let path_str = get_conf_str(key)?;
+        path_str
+            .parse::<Multiaddr>()
+            .map_err(|err| ConfigurationError::new(key, &err.to_string()))
+    };
+
+    let transport_key = config_string(network, "transport");
+    let transport = get_conf_str(&transport_key)?;
+
+    match transport.to_lowercase().as_str() {
+        "tcp" => {
+            let key = config_string(network, "tcp_listener_address");
+            let listener_address = get_conf_multiaddr(&key)?;
+
+            Ok(CommsTransport::Tcp { listener_address })
+        },
+        "tor" => {
+            let key = config_string(network, "tor_control_address");
+            let control_server_address = get_conf_multiaddr(&key)?;
+
+            let key = config_string(network, "tor_control_auth");
+            let auth_str = get_conf_str(&key)?;
+            let auth = auth_str
+                .parse()
+                .map_err(|err: String| ConfigurationError::new(&key, &err))?;
+
+            let key = config_string(network, "tor_forward_address");
+            let forward_address = get_conf_multiaddr(&key)?;
+            let key = config_string(network, "tor_onion_port");
+            let onion_port = cfg
+                .get::<NonZeroU16>(&key)
+                .map_err(|err| ConfigurationError::new(&key, &err.to_string()))?;
+
+            Ok(CommsTransport::TorHiddenService {
+                control_server_address,
+                auth,
+                forward_address,
+                onion_port,
+            })
+        },
+        "socks5" => {
+            let key = config_string(network, "socks5_proxy_address");
+            let proxy_address = get_conf_multiaddr(&key)?;
+
+            let key = config_string(network, "socks5_listener_address");
+            let auth_str = get_conf_str(&key)?;
+            let auth = auth_str
+                .parse()
+                .map_err(|err: String| ConfigurationError::new(&key, &err))?;
+
+            let key = config_string(network, "socks5_listener_address");
+            let listener_address = get_conf_multiaddr(&key)?;
+
+            Ok(CommsTransport::Socks5 {
+                proxy_address,
+                listener_address,
+                auth,
+            })
+        },
+        t => Err(ConfigurationError::new(
+            &transport_key,
+            &format!("Invalid transport type '{}'", t),
+        )),
+    }
 }
 
 fn config_string(network: &str, key: &str) -> String {
@@ -290,6 +470,8 @@ fn config_string(network: &str, key: &str) -> String {
 /// These will typically be overridden by userland settings in envars, the config file, or the command line.
 pub fn default_config() -> Config {
     let mut cfg = Config::new();
+    let local_ip_addr = get_local_ip().unwrap_or_else(|| "/ip4/1.2.3.4".parse().unwrap());
+
     // Common settings
     cfg.set_default("common.message_cache_size", 10).unwrap();
     cfg.set_default("common.message_cache_ttl", 1440).unwrap();
@@ -320,10 +502,16 @@ pub fn default_config() -> Config {
         default_subdir("mainnet/node_id.json"),
     )
     .unwrap();
-    cfg.set_default("base_node.mainnet.listener_address", "/ip4/0.0.0.0/tcp/18089")
-        .unwrap();
-    cfg.set_default("base_node.mainnet.public_address", "/ip4/0.0.0.0/tcp/18089")
-        .unwrap();
+    cfg.set_default(
+        "base_node.mainnet.tor_private_key_file",
+        default_subdir("mainnet/tor.json"),
+    )
+    .unwrap();
+    cfg.set_default(
+        "base_node.mainnet.public_address",
+        format!("{}/tcp/18041", local_ip_addr),
+    )
+    .unwrap();
     cfg.set_default("base_node.mainnet.grpc_enabled", false).unwrap();
     cfg.set_default("base_node.mainnet.grpc_address", "tcp://127.0.0.1:18041")
         .unwrap();
@@ -338,20 +526,86 @@ pub fn default_config() -> Config {
     cfg.set_default("base_node.testnet.data_dir", default_subdir("testnet/"))
         .unwrap();
     cfg.set_default(
+        "base_node.testnet.tor_private_key_file",
+        default_subdir("testnet/tor.json"),
+    )
+    .unwrap();
+    cfg.set_default(
         "base_node.testnet.identity_file",
         default_subdir("testnet/node_id.json"),
     )
     .unwrap();
-    cfg.set_default("base_node.testnet.public_address", "/ip4/0.0.0.0/tcp/18189")
-        .unwrap();
-    cfg.set_default("base_node.testnet.listener_address", "/ip4/0.0.0.0/tcp/18189")
-        .unwrap();
+    cfg.set_default(
+        "base_node.testnet.public_address",
+        format!("{}/tcp/18141", local_ip_addr),
+    )
+    .unwrap();
     cfg.set_default("base_node.testnet.grpc_enabled", false).unwrap();
     cfg.set_default("base_node.testnet.grpc_address", "tcp://127.0.0.1:18141")
         .unwrap();
     cfg.set_default("base_node.testnet.enable_mining", true).unwrap();
 
+    set_transport_defaults(&mut cfg);
+
     cfg
+}
+
+fn set_transport_defaults(cfg: &mut Config) {
+    // Mainnet
+    // Default transport for mainnet is tcp
+    cfg.set_default("base_node.mainnet.transport", "tcp").unwrap();
+    cfg.set_default("base_node.mainnet.tcp_listener_address", "/ip4/0.0.0.0/tcp/18089")
+        .unwrap();
+
+    cfg.set_default("base_node.mainnet.tor_control_address", "/ip4/127.0.0.1/tcp/9051")
+        .unwrap();
+    cfg.set_default("base_node.mainnet.tor_control_auth", "none").unwrap();
+    cfg.set_default("base_node.mainnet.tor_forward_address", "/ip4/127.0.0.1/tcp/18141")
+        .unwrap();
+
+    cfg.set_default("base_node.mainnet.socks5_proxy_address", "/ip4/0.0.0.0/tcp/9050")
+        .unwrap();
+    cfg.set_default("base_node.mainnet.socks5_listener_address", "/ip4/0.0.0.0/tcp/18099")
+        .unwrap();
+    cfg.set_default("base_node.mainnet.socks5_auth", "none").unwrap();
+
+    // Testnet
+    // Default transport for testnet is tcp
+    cfg.set_default("base_node.testnet.transport", "tcp").unwrap();
+    cfg.set_default("base_node.testnet.tcp_listener_address", "/ip4/0.0.0.0/tcp/18189")
+        .unwrap();
+
+    cfg.set_default("base_node.testnet.tor_control_address", "/ip4/127.0.0.1/tcp/9051")
+        .unwrap();
+    cfg.set_default("base_node.testnet.tor_control_auth", "none").unwrap();
+    cfg.set_default("base_node.testnet.tor_forward_address", "/ip4/127.0.0.1/tcp/18041")
+        .unwrap();
+
+    cfg.set_default("base_node.testnet.socks5_proxy_address", "/ip4/0.0.0.0/tcp/9150")
+        .unwrap();
+    cfg.set_default("base_node.testnet.socks5_listener_address", "/ip4/0.0.0.0/tcp/18199")
+        .unwrap();
+    cfg.set_default("base_node.testnet.socks5_auth", "none").unwrap();
+}
+
+fn get_local_ip() -> Option<Multiaddr> {
+    get_if_addrs::get_if_addrs().ok().and_then(|if_addrs| {
+        if_addrs
+            .into_iter()
+            .find(|if_addr| !if_addr.is_loopback())
+            .map(|if_addr| {
+                let mut addr = Multiaddr::empty();
+                match if_addr.ip() {
+                    IpAddr::V4(ip) => {
+                        addr.push(Protocol::Ip4(ip));
+                    },
+                    IpAddr::V6(ip) => {
+                        addr.push(Protocol::Ip6(ip));
+                    },
+                }
+                addr
+            })
+    })
 }
 
 //-------------------------------------      Configuration errors      --------------------------------------//

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -59,11 +59,14 @@ pub use configuration::{
     default_config,
     install_default_config_file,
     load_configuration,
+    CommsTransport,
     ConfigExtractor,
     ConfigurationError,
     DatabaseType,
     GlobalConfig,
     Network,
+    SocksAuthentication,
+    TorControlAuthentication,
 };
 pub use logging::initialize_logging;
 use std::io;

--- a/comms/src/socks/client.rs
+++ b/comms/src/socks/client.rs
@@ -34,14 +34,14 @@ pub type Result<T> = std::result::Result<T, SocksError>;
 /// Authentication methods
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Authentication {
-    Password { username: String, password: String },
     None,
+    Password(String, String),
 }
 
 impl Authentication {
     fn id(&self) -> u8 {
         match self {
-            Authentication::Password { .. } => 0x02,
+            Authentication::Password(_, _) => 0x02,
             Authentication::None => 0x00,
         }
     }
@@ -119,7 +119,8 @@ where TSocket: AsyncRead + AsyncWrite + Unpin
 
     fn validate_auth(auth: &Authentication) -> Result<()> {
         match auth {
-            Authentication::Password { username, password } => {
+            Authentication::None => {},
+            Authentication::Password(username, password) => {
                 let username_len = username.as_bytes().len();
                 if username_len < 1 || username_len > 255 {
                     Err(SocksError::InvalidAuthValues("username length should between 1 to 255"))?
@@ -129,7 +130,6 @@ where TSocket: AsyncRead + AsyncWrite + Unpin
                     Err(SocksError::InvalidAuthValues("password length should between 1 to 255"))?
                 }
             },
-            Authentication::None => {},
         }
         Ok(())
     }
@@ -314,7 +314,7 @@ where TSocket: AsyncRead + AsyncWrite + Unpin
 
     fn prepare_send_password_auth(&mut self) {
         match &self.authentication {
-            Authentication::Password { username, password } => {
+            Authentication::Password(username, password) => {
                 self.ptr = 0;
                 self.buf[0] = 0x01;
                 let username_bytes = username.as_bytes();

--- a/comms/src/tor/client/types.rs
+++ b/comms/src/tor/client/types.rs
@@ -114,7 +114,13 @@ impl PortMapping {
 
 impl From<u16> for PortMapping {
     fn from(onion_port: u16) -> Self {
-        Self::from_port(onion_port.into())
+        Self::from_port(onion_port)
+    }
+}
+
+impl<T: Into<u16>, U: Into<SocketAddr>> From<(T, U)> for PortMapping {
+    fn from((port, addr): (T, U)) -> Self {
+        Self(port.into(), addr.into())
     }
 }
 

--- a/config/tari_config_sample.toml
+++ b/config/tari_config_sample.toml
@@ -57,6 +57,12 @@
 #  b) know what you are doing!
 #wallet_file = "~/.tari/wallet/wallet.dat"
 
+#[base_node.transport.tor]
+#control_address = "/ip4/127.0.0.1/tcp/9051"
+#control_auth_type = "none" # or "password"
+# Required for control_auth_type = "password"
+#control_auth_password = "super-secure-password"
+
 ########################################################################################################################
 #                                                                                                                      #
 #                                          Base Node Configuration Options                                             #
@@ -73,6 +79,7 @@
 #   mainnet - the "real" Tari network (default)
 #   testnet - the Tari test net
 #network = "mainnet"
+
 
 # Configuration options for testnet
 [base_node.testnet]
@@ -99,12 +106,11 @@ peer_seeds = []
 # n - blocking_threads, where n is the number of cores on your machine, and blocking_thread is set above.
  #core_threads = 4
 
-# The node's publicly-accessible address. This is the address that is advertised on the network so that
+# The node's publicly-accessible hostname. This is the host name that is advertised on the network so that
 # peers can find you.
+# _NOTE_: If using the `tor` transport type, public_address will be ignored and an onion address will be
+# automatically configured
 #public_address = "/ip4/172.2.3.4/tcp/18189"
-
-# The address and port to listen for peer connections.
-#listener_address = "/ip4/172.2.3.4/tcp/18189"
 
 # Enable the gRPC server for the base node. Set this to true if you want to enable third-party wallet software
 #grpc_enabled = false
@@ -115,6 +121,36 @@ peer_seeds = []
 
 # A path to the file that stores your node identity and secret key
 #identity_file = "~/.tari/testnet/node_id.json"
+
+# -------------- Transport configuration --------------
+# Use TCP to connect to the Tari network. This transport can only communicate with TCP/IP addresses, so peers with
+# e.g. tor onion addresses will not be contactable.
+#transport = "tcp"
+# # The address and port to listen for peer connections over TCP.
+#tcp_listener_address = "/ip4/0.0.0.0/tcp/18189"
+
+# Configures the node to run over a tor hidden service using the Tor proxy. This transport recognises ip/tcp,
+# onion v2, onion v3 and dns addresses.
+#transport = "tor"
+# Address of the tor control server
+#tor_control_address = "/ip4/127.0.0.1/tcp/9051"
+# Authentication to use for the tor control server
+#tor_control_auth = "none" # or "password=xxxxxx"
+# The onion port to use.
+#tor_onion_port = 18141
+# The address to which traffic on the node's onion address will be forwarded
+#tor_forward_address = "/ip4/127.0.0.1/tcp/18141"
+
+# Use a SOCKS5 proxy transport. This transport recognises any addresses supported by the proxy.
+#transport = "socks5"
+# The address of the SOCKS5 proxy
+#socks5_proxy_address = "/ip4/127.0.0.1/tcp/9050"
+# The address to which traffic will be forwarded
+#socks5_listener_address = "/ip4/127.0.0.1/tcp/18189"
+#socks5_auth = "none" # or "username_password=username:xxxxxxx"
+
+# A path to the file that stores the tor hidden service private key, if using the tor transport.
+# tor_private_key_file = "~/.tari/testnet/tor.key"
 
 [base_node.mainnet]
 # The type of database backend to use. Currently supported options are "memory" and "lmdb". LMDB is recommnded for
@@ -139,10 +175,6 @@ peer_seeds = []
 # n - blocking_threads, where n is the number of cores on your machine, and blocking_thread is set above.
  #core_threads = 6
 
-# The address and port to listen for peer connections. This is the address that is advertised on the network so that
-# peers can find you. You may specify more than one address here
-#address = "tcp://0.0.0.0:18089"
-
 # Enable the gRPC server for the base node. Set this to true if you want to enable third-party wallet software
 #grpc_enabled = false
 
@@ -152,6 +184,36 @@ peer_seeds = []
 
 # A path to the file that stores your node identity and secret key
 #identity_file = "~/.tari/mainnet/node_id.json"
+
+# -------------- Transport configuration --------------
+# Use TCP to connect to the Tari network. This transport can only communicate with TCP/IP addresses, so peers with
+# e.g. tor onion addresses will not be contactable.
+#transport = "tcp"
+# # The address and port to listen for peer connections over TCP.
+#tcp_listener_address = "/ip4/0.0.0.0/tcp/18189"
+
+# Configures the node to run over a tor hidden service using the Tor proxy. This transport recognises ip/tcp,
+# onion v2, onion v3 and dns addresses.
+#transport = "tor"
+# Address of the tor control server
+#tor_control_address = "/ip4/127.0.0.1/tcp/9051"
+# Authentication to use for the tor control server
+#tor_control_auth = "none" # or "password=xxxxxx"
+# The onion port to use.
+#tor_onion_port = 18141
+# The address to which traffic on the node's onion address will be forwarded
+#tor_forward_address = "/ip4/127.0.0.1/tcp/18141"
+
+# Use a SOCKS5 proxy transport. This transport recognises any addresses supported by the proxy.
+#transport = "socks5"
+# The address of the SOCKS5 proxy
+#socks5_proxy_address = "/ip4/127.0.0.1/tcp/9050"
+# The address to which traffic will be forwarded
+#socks5_listener_address = "/ip4/127.0.0.1/tcp/18189"
+#socks5_auth = "none" # or "username_password=username:xxxxxxx"
+
+# A path to the file that stores the tor hidden service private key, if using the tor transport
+# tor_private_key_file = "~/.tari/mainnet/tor.key"
 
 ########################################################################################################################
 #                                                                                                                      #


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

The following keys now work in base_node.mainnet and base_node.testnet config sections:
```toml
// Select one transport
// TCP
transport = "tcp"
tcp_listener_address = "/ip4/0.0.0.0/tcp/18189"

// TOR
transport = "tor"
tor_control_address = "/ip4/127.0.0.1/tcp/9051"
tor_control_auth = "none" # or "password=xxxxxx"
tor_onion_port = 18141
tor_forward_address = "/ip4/127.0.0.1/tcp/18141"

// SOCKS
transport = "socks5"
socks5_proxy_address = "/ip4/127.0.0.1/tcp/9050"
socks5_listener_address = "/ip4/127.0.0.1/tcp/18189"
socks5_auth = "none" # or "username_password=username:xxxxxxx"

tor_private_key_file = "~/.tari/mainnet/tor.key"
```

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #1362 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Ran a base node over tor

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [x] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [ ] I'm merging against the `development` branch
* [ ] I ran `cargo-fmt --all` before pushing
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
