### PR TITLE
Add crate caching and parallel operation to circleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,6 +3,41 @@ version: 2.1
 defaults:
   rust_image: &rust_image quay.io/tarilabs/rust_tari-build-with-deps:nightly-2020-01-08
 
+commands:
+  test:
+    description: Run the tests
+    parameters:
+      release:
+        description: Set this to true to compile in release mode.
+        type: boolean
+        default: false
+    steps:
+      - run:
+          name: Calculate dependencies
+          command: |
+            rustc --version >rust-version
+            test -e Cargo.lock || cargo generate-lockfile
+      - restore_cache:
+          keys:
+            - v6-cargo-cache-{{arch}}-{{checksum "rust-version"}}-<<parameters.release>>-{{checksum "Cargo.lock"}}
+      - run:
+          name: Build the project
+          command: cargo build --all --all-features --jobs=3 <<#parameters.release>>--release<</parameters.release>>
+      - run:
+          name: Cargo fmt (ignored in release mode)
+          command: |
+            TOOLCHAIN=$(cat rust-toolchain)
+            <<#parameters.release>>#<</parameters.release>> rustup component add --toolchain $TOOLCHAIN rustfmt
+            <<#parameters.release>>#<</parameters.release>> cargo fmt --all -- --check
+      - run:
+          name: Run tests
+          command: cargo test --workspace --all-features --jobs=3 <<#parameters.release>>--release<</parameters.release>>
+      - save_cache:
+          paths:
+            - /usr/local/cargo/registry
+            - target
+          key: v6-cargo-cache-{{arch}}-{{checksum "rust-version"}}-<<parameters.release>>-{{checksum "Cargo.lock"}}
+
 jobs:
   test-docs:
     docker:
@@ -19,6 +54,24 @@ jobs:
       - persist_to_workspace:
           root: .
           paths: book
+
+  test-tari-debug:
+    docker:
+      - image: *rust_image
+    resource_class: medium
+    steps:
+      - checkout
+      - test:
+          release: false
+
+  test-tari-release:
+    docker:
+      - image: *rust_image
+    resource_class: medium
+    steps:
+      - checkout
+      - test:
+          release: true
 
   deploy-docs:
     docker:
@@ -62,22 +115,7 @@ jobs:
 
             echo "Published."
 
-  test-tari:
-    docker:
-      - image: *rust_image
-    resource_class: medium
-    steps:
-      - checkout
-      - run:
-          name: Tari source code
-          command: |
-            TOOLCHAIN=$(cat rust-toolchain)
-            NUM_JOBS=3
-            rustup component add --toolchain $TOOLCHAIN rustfmt
-            cargo build --jobs=$NUM_JOBS --all-features
-            cargo fmt --all -- --check
-            cargo test --workspace --all-features --jobs=$NUM_JOBS
-            cargo test --workspace --all-features --release --jobs=$NUM_JOBS
+
 
 workflows:
   version: 2
@@ -87,14 +125,17 @@ workflows:
           filters:
             branches:
               ignore: gh-pages
-      - test-tari:
-          filters:
-            branches:
-              ignore: gh-pages
       - deploy-docs:
           requires:
             - test-docs
           filters:
             branches:
               only: development
-
+      - test-tari-debug:
+          filters:
+            branches:
+              ignore: gh-pages
+      - test-tari-release:
+          filters:
+            branches:
+              ignore: gh-pages


### PR DESCRIPTION
 * Cache the target and crate registries so that subsequent pushes
      don't have to re-download and build the dependencies
 * Run debug and release tests in parallel pipelines to try and
      speed up overall builds

All builds prior to this were taking ±35min.

Cold builds (i.e. with dependency changes) should run about 5-7min quicker due to release and debug being in parallel.

Subsequent pushes may be up to 50% faster (depending on how far caching got). This PR took 16min to build from a hot start.