### PR TITLE
add faucet for alphanet

### DIFF
--- a/base_layer/core/tests/chain_storage_tests/chain_storage.rs
+++ b/base_layer/core/tests/chain_storage_tests/chain_storage.rs
@@ -28,7 +28,7 @@ use croaring::Bitmap;
 use env_logger;
 use std::thread;
 use tari_core::{
-    blocks::{Block, BlockHash, BlockHeader},
+    blocks::{genesis_block, Block, BlockHash, BlockHeader},
     chain_storage::{
         create_lmdb_database,
         BlockAddResult,
@@ -186,7 +186,8 @@ fn multiple_threads() {
 #[test]
 fn utxo_and_rp_merkle_root() {
     let network = Network::LocalNet;
-    let consensus_manager = ConsensusManagerBuilder::new(network).build();
+    let gen_block = genesis_block::get_rincewind_genesis_block_raw();
+    let consensus_manager = ConsensusManagerBuilder::new(network).with_block(gen_block).build();
     let store = create_mem_db(consensus_manager.clone());
     let factories = CryptoFactories::default();
     let block0 = store.fetch_block(0).unwrap().block().clone();
@@ -248,7 +249,8 @@ fn kernel_merkle_root() {
 #[test]
 fn utxo_and_rp_future_merkle_root() {
     let network = Network::LocalNet;
-    let consensus_manager = ConsensusManagerBuilder::new(network).build();
+    let gen_block = genesis_block::get_rincewind_genesis_block_raw();
+    let consensus_manager = ConsensusManagerBuilder::new(network).with_block(gen_block).build();
     let store = create_mem_db(consensus_manager.clone());
     let factories = CryptoFactories::default();
 
@@ -289,7 +291,8 @@ fn utxo_and_rp_future_merkle_root() {
 #[test]
 fn kernel_future_merkle_root() {
     let network = Network::LocalNet;
-    let consensus_manager = ConsensusManagerBuilder::new(network).build();
+    let gen_block = genesis_block::get_rincewind_genesis_block_raw();
+    let consensus_manager = ConsensusManagerBuilder::new(network).with_block(gen_block).build();
     let store = create_mem_db(consensus_manager.clone());
 
     let kernel1 = create_test_kernel(100.into(), 0);
@@ -316,7 +319,8 @@ fn kernel_future_merkle_root() {
 #[test]
 fn utxo_and_rp_mmr_proof() {
     let network = Network::LocalNet;
-    let consensus_manager = ConsensusManagerBuilder::new(network).build();
+    let gen_block = genesis_block::get_rincewind_genesis_block_raw();
+    let consensus_manager = ConsensusManagerBuilder::new(network).with_block(gen_block).build();
     let store = create_mem_db(consensus_manager.clone());
     let factories = CryptoFactories::default();
 
@@ -790,7 +794,8 @@ fn total_kernel_offset() {
 fn total_utxo_commitment() {
     let factories = CryptoFactories::default();
     let network = Network::LocalNet;
-    let consensus_manager = ConsensusManagerBuilder::new(network).build();
+    let gen_block = genesis_block::get_rincewind_genesis_block_raw();
+    let consensus_manager = ConsensusManagerBuilder::new(network).with_block(gen_block).build();
     let store = create_mem_db(consensus_manager.clone());
     let block0 = store.fetch_block(0).unwrap().block().clone();
 


### PR DESCRIPTION
## Description
This PR adds in the faucet utxo's for the testnet launch

## Motivation and Context
We need to include the faucets for the testnet launch into the genesis block. This adds that

## How Has This Been Tested?
Unit test that loads the genesis block for rincewind and ensures its 4001 blocks

## Types of changes
* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [x] New Tests
* [ ] Documentation

## Checklist:
* [x] I'm merging against the `development` branch
* [x] I ran `cargo-fmt --all` before pushing
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
