### PR TITLE
Integrate the Comms Event Bus feedback into the Wallet Send Transaction

### DIFF
--- a/applications/tari_base_node/src/builder.rs
+++ b/applications/tari_base_node/src/builder.rs
@@ -575,6 +575,7 @@ where
         .add_initializer(TransactionServiceInitializer::new(
             TransactionServiceConfig::default(),
             subscription_factory.clone(),
+            comms.subscribe_messaging_events(),
             TransactionServiceSqliteDatabase::new(connection_pool),
             id.clone(),
             factories,

--- a/base_layer/wallet/Cargo.toml
+++ b/base_layer/wallet/Cargo.toml
@@ -34,7 +34,7 @@ diesel_migrations =  "1.4"
 diesel = {version="1.4", features = ["sqlite", "serde_json", "chrono", "r2d2"]}
 rand = "0.7.2"
 futures =  { version = "^0.3.1", features =["compat", "std"]}
-tokio = { version = "0.2.10", features = ["blocking"]}
+tokio = { version = "0.2.10", features = ["blocking", "sync"]}
 tower = "0.3.0-alpha.2"
 tempdir = "0.3.7"
 tari_test_utils = { path = "../../infrastructure/test_utils", version = "^0.0", optional = true}

--- a/base_layer/wallet/src/contacts_service/storage/database.rs
+++ b/base_layer/wallet/src/contacts_service/storage/database.rs
@@ -111,8 +111,7 @@ where T: ContactsBackend + 'static
             Err(e) => log_error(DbKey::Contacts, e),
         })
         .await
-        .or_else(|err| Err(ContactsServiceStorageError::BlockingTaskSpawnError(err.to_string())))
-        .and_then(|inner_result| inner_result)?;
+        .or_else(|err| Err(ContactsServiceStorageError::BlockingTaskSpawnError(err.to_string())))??;
         Ok(c)
     }
 
@@ -126,8 +125,7 @@ where T: ContactsBackend + 'static
             )))
         })
         .await
-        .or_else(|err| Err(ContactsServiceStorageError::BlockingTaskSpawnError(err.to_string())))
-        .and_then(|inner_result| inner_result)?;
+        .or_else(|err| Err(ContactsServiceStorageError::BlockingTaskSpawnError(err.to_string())))??;
         Ok(())
     }
 

--- a/base_layer/wallet/src/output_manager_service/service.rs
+++ b/base_layer/wallet/src/output_manager_service/service.rs
@@ -310,7 +310,7 @@ where
 
         // If there are any remaining Unspent Outputs we will move them to the invalid collection
         for (_k, v) in output_hashes {
-            self.db.invalidate_output(v.clone()).await?;
+            self.db.invalidate_output(v).await?;
         }
 
         debug!(
@@ -352,7 +352,7 @@ where
         utxo_query_timeout_futures: &mut FuturesUnordered<BoxFuture<'static, u64>>,
     ) -> Result<(), OutputManagerError>
     {
-        match self.base_node_public_key.clone() {
+        match self.base_node_public_key.as_ref() {
             None => return Err(OutputManagerError::NoBaseNodeKeysProvided),
             Some(pk) => {
                 let unspent_outputs: Vec<UnblindedOutput> = self.db.get_unspent_outputs().await?;
@@ -554,7 +554,7 @@ where
     }
 
     /// Confirm that a received or sent transaction and its outputs have been detected on the base chain. The inputs and
-    /// outputs are checked to see that they match what the stored PendingTransaction contians. This will
+    /// outputs are checked to see that they match what the stored PendingTransaction contains. This will
     /// be called by the Transaction Service which monitors the base chain.
     pub async fn confirm_transaction(
         &mut self,

--- a/base_layer/wallet/src/output_manager_service/storage/database.rs
+++ b/base_layer/wallet/src/output_manager_service/storage/database.rs
@@ -172,8 +172,7 @@ where T: OutputManagerBackend + 'static
             db_clone.write(WriteOperation::Insert(DbKeyValuePair::KeyManagerState(state)))
         })
         .await
-        .or_else(|err| Err(OutputManagerStorageError::BlockingTaskSpawnError(err.to_string())))
-        .and_then(|inner_result| inner_result)?;
+        .or_else(|err| Err(OutputManagerStorageError::BlockingTaskSpawnError(err.to_string())))??;
 
         Ok(())
     }
@@ -182,8 +181,7 @@ where T: OutputManagerBackend + 'static
         let db_clone = self.db.clone();
         tokio::task::spawn_blocking(move || db_clone.increment_key_index())
             .await
-            .or_else(|err| Err(OutputManagerStorageError::BlockingTaskSpawnError(err.to_string())))
-            .and_then(|inner_result| inner_result)?;
+            .or_else(|err| Err(OutputManagerStorageError::BlockingTaskSpawnError(err.to_string())))??;
         Ok(())
     }
 
@@ -196,8 +194,7 @@ where T: OutputManagerBackend + 'static
             )))
         })
         .await
-        .or_else(|err| Err(OutputManagerStorageError::BlockingTaskSpawnError(err.to_string())))
-        .and_then(|inner_result| inner_result)?;
+        .or_else(|err| Err(OutputManagerStorageError::BlockingTaskSpawnError(err.to_string())))??;
 
         Ok(())
     }
@@ -214,8 +211,7 @@ where T: OutputManagerBackend + 'static
             })
         })
         .await
-        .or_else(|err| Err(OutputManagerStorageError::BlockingTaskSpawnError(err.to_string())))
-        .and_then(|inner_result| inner_result)?;
+        .or_else(|err| Err(OutputManagerStorageError::BlockingTaskSpawnError(err.to_string())))??;
 
         let unspent_outputs = tokio::task::spawn_blocking(move || {
             db_clone2.fetch(&DbKey::UnspentOutputs)?.ok_or_else(|| {
@@ -223,8 +219,7 @@ where T: OutputManagerBackend + 'static
             })
         })
         .await
-        .or_else(|err| Err(OutputManagerStorageError::BlockingTaskSpawnError(err.to_string())))
-        .and_then(|inner_result| inner_result)?;
+        .or_else(|err| Err(OutputManagerStorageError::BlockingTaskSpawnError(err.to_string())))??;
 
         if let DbValue::UnspentOutputs(uo) = unspent_outputs {
             if let DbValue::AllPendingTransactionOutputs(pto) = pending_txs {
@@ -269,8 +264,7 @@ where T: OutputManagerBackend + 'static
             )))
         })
         .await
-        .or_else(|err| Err(OutputManagerStorageError::BlockingTaskSpawnError(err.to_string())))
-        .and_then(|inner_result| inner_result)?;
+        .or_else(|err| Err(OutputManagerStorageError::BlockingTaskSpawnError(err.to_string())))??;
 
         Ok(())
     }
@@ -325,8 +319,7 @@ where T: OutputManagerBackend + 'static
             )))
         })
         .await
-        .or_else(|err| Err(OutputManagerStorageError::BlockingTaskSpawnError(err.to_string())))
-        .and_then(|inner_result| inner_result)?;
+        .or_else(|err| Err(OutputManagerStorageError::BlockingTaskSpawnError(err.to_string())))??;
         Ok(())
     }
 
@@ -379,8 +372,7 @@ where T: OutputManagerBackend + 'static
             Err(e) => log_error(DbKey::UnspentOutputs, e),
         })
         .await
-        .or_else(|err| Err(OutputManagerStorageError::BlockingTaskSpawnError(err.to_string())))
-        .and_then(|inner_result| inner_result)?;
+        .or_else(|err| Err(OutputManagerStorageError::BlockingTaskSpawnError(err.to_string())))??;
 
         uo.sort();
         Ok(uo)
@@ -399,8 +391,7 @@ where T: OutputManagerBackend + 'static
             Err(e) => log_error(DbKey::SpentOutputs, e),
         })
         .await
-        .or_else(|err| Err(OutputManagerStorageError::BlockingTaskSpawnError(err.to_string())))
-        .and_then(|inner_result| inner_result)?;
+        .or_else(|err| Err(OutputManagerStorageError::BlockingTaskSpawnError(err.to_string())))??;
         Ok(uo)
     }
 
@@ -421,8 +412,7 @@ where T: OutputManagerBackend + 'static
             Err(e) => log_error(DbKey::AllPendingTransactionOutputs, e),
         })
         .await
-        .or_else(|err| Err(OutputManagerStorageError::BlockingTaskSpawnError(err.to_string())))
-        .and_then(|inner_result| inner_result)?;
+        .or_else(|err| Err(OutputManagerStorageError::BlockingTaskSpawnError(err.to_string())))??;
         Ok(uo)
     }
 
@@ -439,8 +429,7 @@ where T: OutputManagerBackend + 'static
             Err(e) => log_error(DbKey::UnspentOutputs, e),
         })
         .await
-        .or_else(|err| Err(OutputManagerStorageError::BlockingTaskSpawnError(err.to_string())))
-        .and_then(|inner_result| inner_result)?;
+        .or_else(|err| Err(OutputManagerStorageError::BlockingTaskSpawnError(err.to_string())))??;
         Ok(uo)
     }
 
@@ -457,8 +446,7 @@ where T: OutputManagerBackend + 'static
             Err(e) => log_error(DbKey::InvalidOutputs, e),
         })
         .await
-        .or_else(|err| Err(OutputManagerStorageError::BlockingTaskSpawnError(err.to_string())))
-        .and_then(|inner_result| inner_result)?;
+        .or_else(|err| Err(OutputManagerStorageError::BlockingTaskSpawnError(err.to_string())))??;
         Ok(uo)
     }
 

--- a/base_layer/wallet/src/output_manager_service/storage/sqlite_db.rs
+++ b/base_layer/wallet/src/output_manager_service/storage/sqlite_db.rs
@@ -394,7 +394,6 @@ impl OutputManagerBackend for OutputManagerSqliteDatabase {
     fn invalidate_unspent_output(&self, output: &UnblindedOutput) -> Result<(), OutputManagerStorageError> {
         let conn = self
             .database_connection_pool
-            .clone()
             .get()
             .map_err(|_| OutputManagerStorageError::R2d2Error)?;
 

--- a/base_layer/wallet/src/storage/database.rs
+++ b/base_layer/wallet/src/storage/database.rs
@@ -106,8 +106,7 @@ where T: WalletBackend + 'static
             Err(e) => log_error(DbKey::Peers, e),
         })
         .await
-        .or_else(|err| Err(WalletStorageError::BlockingTaskSpawnError(err.to_string())))
-        .and_then(|inner_result| inner_result)?;
+        .or_else(|err| Err(WalletStorageError::BlockingTaskSpawnError(err.to_string())))??;
         Ok(c)
     }
 
@@ -121,8 +120,7 @@ where T: WalletBackend + 'static
             )))
         })
         .await
-        .or_else(|err| Err(WalletStorageError::BlockingTaskSpawnError(err.to_string())))
-        .and_then(|inner_result| inner_result)?;
+        .or_else(|err| Err(WalletStorageError::BlockingTaskSpawnError(err.to_string())))??;
         Ok(())
     }
 

--- a/base_layer/wallet/src/transaction_service/config.rs
+++ b/base_layer/wallet/src/transaction_service/config.rs
@@ -20,17 +20,19 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+use std::time::Duration;
+
 #[derive(Clone)]
 pub struct TransactionServiceConfig {
-    pub mempool_broadcast_timeout_in_secs: u64,
-    pub base_node_mined_timeout_in_secs: u64,
+    pub mempool_broadcast_timeout: Duration,
+    pub base_node_mined_timeout: Duration,
 }
 
 impl Default for TransactionServiceConfig {
     fn default() -> Self {
         Self {
-            mempool_broadcast_timeout_in_secs: 30,
-            base_node_mined_timeout_in_secs: 30,
+            mempool_broadcast_timeout: Duration::from_secs(30),
+            base_node_mined_timeout: Duration::from_secs(30),
         }
     }
 }

--- a/base_layer/wallet/src/transaction_service/error.rs
+++ b/base_layer/wallet/src/transaction_service/error.rs
@@ -27,6 +27,7 @@ use crate::{
 use derive_error::Error;
 use diesel::result::Error as DieselError;
 use serde_json::Error as SerdeJsonError;
+use tari_comms::peer_manager::node_id::NodeIdError;
 use tari_comms_dht::outbound::DhtOutboundError;
 use tari_core::transactions::{transaction::TransactionError, transaction_protocol::TransactionProtocolError};
 use tari_service_framework::reply_channel::TransportChannelError;
@@ -84,6 +85,7 @@ pub enum TransactionServiceError {
     TransactionError(TransactionError),
     #[error(msg_embedded, no_from, non_std)]
     ConversionError(String),
+    NodeIdError(NodeIdError),
 }
 
 #[derive(Debug, Error)]

--- a/base_layer/wallet/src/transaction_service/handle.rs
+++ b/base_layer/wallet/src/transaction_service/handle.rs
@@ -91,6 +91,7 @@ pub enum TransactionEvent {
     ReceivedTransaction(TxId),
     ReceivedTransactionReply(TxId),
     ReceivedFinalizedTransaction(TxId),
+    TransactionSendResult(TxId, bool),
     TransactionSendDiscoveryComplete(TxId, bool),
     TransactionBroadcast(TxId),
     TransactionMined(TxId),

--- a/base_layer/wallet/src/transaction_service/storage/database.rs
+++ b/base_layer/wallet/src/transaction_service/storage/database.rs
@@ -236,8 +236,7 @@ where T: TransactionBackend + 'static
             )))
         })
         .await
-        .or_else(|err| Err(TransactionStorageError::BlockingTaskSpawnError(err.to_string())))
-        .and_then(|inner_result| inner_result)?;
+        .or_else(|err| Err(TransactionStorageError::BlockingTaskSpawnError(err.to_string())))??;
 
         Ok(())
     }
@@ -256,8 +255,17 @@ where T: TransactionBackend + 'static
             )))
         })
         .await
-        .or_else(|err| Err(TransactionStorageError::BlockingTaskSpawnError(err.to_string())))
-        .and_then(|inner_result| inner_result)?;
+        .or_else(|err| Err(TransactionStorageError::BlockingTaskSpawnError(err.to_string())))??;
+        Ok(())
+    }
+
+    pub async fn remove_pending_outbound_transaction(&self, tx_id: TxId) -> Result<(), TransactionStorageError> {
+        let db_clone = self.db.clone();
+        tokio::task::spawn_blocking(move || {
+            db_clone.write(WriteOperation::Remove(DbKey::PendingOutboundTransaction(tx_id)))
+        })
+        .await
+        .or_else(|err| Err(TransactionStorageError::BlockingTaskSpawnError(err.to_string())))??;
         Ok(())
     }
 
@@ -275,8 +283,7 @@ where T: TransactionBackend + 'static
             )))
         })
         .await
-        .or_else(|err| Err(TransactionStorageError::BlockingTaskSpawnError(err.to_string())))
-        .and_then(|inner_result| inner_result)?;
+        .or_else(|err| Err(TransactionStorageError::BlockingTaskSpawnError(err.to_string())))??;
         Ok(())
     }
 
@@ -298,8 +305,7 @@ where T: TransactionBackend + 'static
         let db_clone = self.db.clone();
         let result = tokio::task::spawn_blocking(move || fetch!(db_clone, tx_id, PendingOutboundTransaction))
             .await
-            .or_else(|err| Err(TransactionStorageError::BlockingTaskSpawnError(err.to_string())))
-            .and_then(|inner_result| inner_result)?;
+            .or_else(|err| Err(TransactionStorageError::BlockingTaskSpawnError(err.to_string())))??;
         Ok(result)
     }
 
@@ -312,8 +318,7 @@ where T: TransactionBackend + 'static
 
         let result = tokio::task::spawn_blocking(move || fetch!(db_clone, tx_id, PendingInboundTransaction))
             .await
-            .or_else(|err| Err(TransactionStorageError::BlockingTaskSpawnError(err.to_string())))
-            .and_then(|inner_result| inner_result)?;
+            .or_else(|err| Err(TransactionStorageError::BlockingTaskSpawnError(err.to_string())))??;
 
         Ok(result)
     }
@@ -327,8 +332,7 @@ where T: TransactionBackend + 'static
 
         let result = tokio::task::spawn_blocking(move || fetch!(db_clone, tx_id, PendingCoinbaseTransaction))
             .await
-            .or_else(|err| Err(TransactionStorageError::BlockingTaskSpawnError(err.to_string())))
-            .and_then(|inner_result| inner_result)?;
+            .or_else(|err| Err(TransactionStorageError::BlockingTaskSpawnError(err.to_string())))??;
 
         Ok(result)
     }
@@ -342,8 +346,7 @@ where T: TransactionBackend + 'static
 
         let result = tokio::task::spawn_blocking(move || fetch!(db_clone, tx_id, CompletedTransaction))
             .await
-            .or_else(|err| Err(TransactionStorageError::BlockingTaskSpawnError(err.to_string())))
-            .and_then(|inner_result| inner_result)?;
+            .or_else(|err| Err(TransactionStorageError::BlockingTaskSpawnError(err.to_string())))??;
         Ok(result)
     }
 
@@ -364,8 +367,7 @@ where T: TransactionBackend + 'static
             Err(e) => log_error(DbKey::PendingInboundTransactions, e),
         })
         .await
-        .or_else(|err| Err(TransactionStorageError::BlockingTaskSpawnError(err.to_string())))
-        .and_then(|inner_result| inner_result)?;
+        .or_else(|err| Err(TransactionStorageError::BlockingTaskSpawnError(err.to_string())))??;
         Ok(t)
     }
 
@@ -386,8 +388,7 @@ where T: TransactionBackend + 'static
             Err(e) => log_error(DbKey::PendingOutboundTransactions, e),
         })
         .await
-        .or_else(|err| Err(TransactionStorageError::BlockingTaskSpawnError(err.to_string())))
-        .and_then(|inner_result| inner_result)?;
+        .or_else(|err| Err(TransactionStorageError::BlockingTaskSpawnError(err.to_string())))??;
         Ok(t)
     }
 
@@ -408,8 +409,7 @@ where T: TransactionBackend + 'static
             Err(e) => log_error(DbKey::PendingCoinbaseTransactions, e),
         })
         .await
-        .or_else(|err| Err(TransactionStorageError::BlockingTaskSpawnError(err.to_string())))
-        .and_then(|inner_result| inner_result)?;
+        .or_else(|err| Err(TransactionStorageError::BlockingTaskSpawnError(err.to_string())))??;
         Ok(t)
     }
 
@@ -428,8 +428,7 @@ where T: TransactionBackend + 'static
             Err(e) => log_error(DbKey::CompletedTransactions, e),
         })
         .await
-        .or_else(|err| Err(TransactionStorageError::BlockingTaskSpawnError(err.to_string())))
-        .and_then(|inner_result| inner_result)?;
+        .or_else(|err| Err(TransactionStorageError::BlockingTaskSpawnError(err.to_string())))??;
         Ok(t)
     }
 
@@ -485,8 +484,7 @@ where T: TransactionBackend + 'static
             db_clone.write(WriteOperation::Remove(DbKey::PendingCoinbaseTransaction(tx_id)))
         })
         .await
-        .or_else(|err| Err(TransactionStorageError::BlockingTaskSpawnError(err.to_string())))
-        .and_then(|inner_result| inner_result)?;
+        .or_else(|err| Err(TransactionStorageError::BlockingTaskSpawnError(err.to_string())))??;
         Ok(())
     }
 
@@ -540,8 +538,7 @@ where T: TransactionBackend + 'static
             )))
         })
         .await
-        .or_else(|err| Err(TransactionStorageError::BlockingTaskSpawnError(err.to_string())))
-        .and_then(|inner_result| inner_result)?;
+        .or_else(|err| Err(TransactionStorageError::BlockingTaskSpawnError(err.to_string())))??;
         Ok(())
     }
 }

--- a/base_layer/wallet/tests/wallet/mod.rs
+++ b/base_layer/wallet/tests/wallet/mod.rs
@@ -180,21 +180,22 @@ fn test_wallet() {
             ))
             .unwrap();
 
-        let received_transaction_reply_count = runtime
-            .block_on(async {
-                collect_stream!(
-                    alice_event_stream.map(|i| (*i).clone()),
-                    take = 1,
-                    timeout = Duration::from_secs(10)
-                )
-            })
-            .iter()
-            .fold(0, |acc, x| match x {
-                TransactionEvent::ReceivedTransactionReply(_) => acc + 1,
-                _ => acc,
-            });
+        let result_stream = runtime.block_on(async {
+            collect_stream!(
+                alice_event_stream.map(|i| (*i).clone()),
+                take = 2,
+                timeout = Duration::from_secs(10)
+            )
+        });
+        let received_transaction_reply_count = result_stream.iter().fold(0, |acc, x| match x {
+            TransactionEvent::ReceivedTransactionReply(_) => acc + 1,
+            _ => acc,
+        });
 
-        assert_eq!(received_transaction_reply_count, 1);
+        assert_eq!(
+            received_transaction_reply_count, 1,
+            "Did not received correct numebr of replies"
+        );
 
         let mut contacts = Vec::new();
         for i in 0..2 {

--- a/base_layer/wallet_ffi/src/callback_handler.rs
+++ b/base_layer/wallet_ffi/src/callback_handler.rs
@@ -124,13 +124,22 @@ where TBackend: TransactionBackend + 'static
                             self.receive_finalized_transaction_event(tx_id).await;
                         },
                         TransactionEvent::TransactionSendDiscoveryComplete(tx_id, result) => {
-                            self.receive_discovery_process_result(tx_id, result);
+                            // If this event result is false we will return that result via the callback as
+                            // no further action will be taken on this send attempt. However if it is true
+                            // then we must wait for a `TransactionSendResult` which
+                            // will tell us the final result of the send
+                            if !result {
+                                self.receive_discovery_process_result(tx_id, result);
+                            }
                         },
                         TransactionEvent::TransactionBroadcast(tx_id) => {
                             self.receive_transaction_broadcast_event(tx_id).await;
                         },
                         TransactionEvent::TransactionMined(tx_id) => {
                             self.receive_transaction_mined_event(tx_id).await;
+                        },
+                        TransactionEvent::TransactionSendResult(tx_id, result) => {
+                            self.receive_discovery_process_result(tx_id, result);
                         },
                         /// Only the above variants are mapped to callbacks
                         _ => (),

--- a/comms/dht/src/outbound/mock.rs
+++ b/comms/dht/src/outbound/mock.rs
@@ -31,6 +31,7 @@ use std::{
     sync::{Arc, Condvar, Mutex, RwLock},
     time::Duration,
 };
+use tari_comms::message::MessageTag;
 
 /// Creates a mock outbound request "handler" for testing purposes.
 ///
@@ -143,7 +144,7 @@ impl OutboundServiceMock {
                     let response = self
                         .mock_state
                         .take_next_response()
-                        .or_else(|| Some(SendMessageResponse::Queued(vec![])))
+                        .or_else(|| Some(SendMessageResponse::Queued(vec![MessageTag::new()])))
                         .expect("never none");
 
                     reply_tx.send(response).expect("Reply channel cancelled");

--- a/comms/src/lib.rs
+++ b/comms/src/lib.rs
@@ -21,7 +21,7 @@ mod consts;
 mod multiplexing;
 mod noise;
 mod proto;
-mod protocol;
+pub mod protocol;
 
 pub mod backoff;
 pub mod bounded_executor;

--- a/comms/src/protocol/messaging/messaging.rs
+++ b/comms/src/protocol/messaging/messaging.rs
@@ -60,7 +60,7 @@ pub enum MessagingRequest {
     SendMessage(OutboundMessage),
 }
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub enum MessagingEvent {
     MessageReceived(Box<NodeId>, MessageTag),
     InvalidMessageReceived(Box<NodeId>),

--- a/comms/src/protocol/messaging/outbound.rs
+++ b/comms/src/protocol/messaging/outbound.rs
@@ -128,8 +128,9 @@ impl OutboundMessaging {
                 Ok(body) => {
                     trace!(
                         target: LOG_TARGET,
-                        "Sending message ({} bytes) on outbound messaging substream",
-                        body.len()
+                        "Sending message ({} bytes) ({:?}) on outbound messaging substream",
+                        body.len(),
+                        out_msg.tag,
                     );
                     if let Err(err) = framed.send(body).await {
                         debug!(


### PR DESCRIPTION
## Description
The Comms stack now has an event bus that informs you when a message has been successfully sent where before you only knew it had been queued for sending after a discovery process has been successful.

This PR updates the Transaction Service to start monitoring the Messaging Events to wait for the confirmation that the message has sent or failed to send. If the message failed to send the client application will be informed via a Callback that the transaction Failed to send.

## Motivation and Context
Closes https://github.com/tari-project/tari/issues/1260

## How Has This Been Tested?
Tests updated and provided

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [x] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [x] New Tests
* [x] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch
* [x] I ran `cargo-fmt --all` before pushing
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
