### PR TITLE
Don't redial peer for a while if they cannot be contacted

### DIFF
--- a/base_layer/core/tests/helpers/nodes.rs
+++ b/base_layer/core/tests/helpers/nodes.rs
@@ -294,14 +294,12 @@ pub fn create_network_with_2_base_nodes_with_config(
         .with_consensus_manager(consensus_manager)
         .start(runtime, data_path);
 
-    runtime
-        .block_on(
-            alice_node
-                .comms
-                .connection_manager()
-                .dial_peer(bob_node.node_identity.node_id().clone()),
-        )
-        .unwrap();
+    let _ = runtime.block_on(
+        alice_node
+            .comms
+            .connection_manager()
+            .dial_peer(bob_node.node_identity.node_id().clone()),
+    );
 
     (alice_node, bob_node, consensus_manager)
 }
@@ -383,21 +381,12 @@ pub fn create_network_with_3_base_nodes_with_config(
     runtime.block_on(async {
         // Alice (pre)connects to bob and carol
         let mut conn_man = alice_node.comms.connection_manager();
-        conn_man
-            .dial_peer(bob_node.node_identity.node_id().clone())
-            .await
-            .unwrap();
-        conn_man
-            .dial_peer(carol_node.node_identity.node_id().clone())
-            .await
-            .unwrap();
+        let _ = conn_man.dial_peer(bob_node.node_identity.node_id().clone()).await;
+        let _ = conn_man.dial_peer(carol_node.node_identity.node_id().clone()).await;
 
         // Bob (pre)connects to carol
         let mut conn_man = bob_node.comms.connection_manager();
-        conn_man
-            .dial_peer(carol_node.node_identity.node_id().clone())
-            .await
-            .unwrap();
+        let _ = conn_man.dial_peer(carol_node.node_identity.node_id().clone()).await;
 
         // All node have an existing connection
     });

--- a/base_layer/core/tests/node_state_machine.rs
+++ b/base_layer/core/tests/node_state_machine.rs
@@ -80,7 +80,7 @@ fn test_listening_lagging() {
         LivenessConfig {
             enable_auto_join: false,
             enable_auto_stored_message_request: false,
-            auto_ping_interval: Some(Duration::from_millis(100)),
+            auto_ping_interval: Some(Duration::from_millis(500)),
             refresh_neighbours_interval: Duration::from_secs(60),
         },
         consensus_manager,

--- a/base_layer/p2p/src/services/liveness/service.rs
+++ b/base_layer/p2p/src/services/liveness/service.rs
@@ -305,12 +305,12 @@ where
                 "Sending liveness ping to {} monitored nodes",
                 num_nodes,
             );
-            for k in self.state.get_monitored_node_ids() {
+            for node_id in self.state.get_monitored_node_ids() {
                 let msg = PingPongMessage::ping();
-                self.state.add_inflight_ping(msg.nonce, &k);
+                self.state.add_inflight_ping(msg.nonce, &node_id);
                 self.oms_handle
                     .send_direct_node_id(
-                        k,
+                        node_id,
                         OutboundEncryption::None,
                         OutboundDomainMessage::new(TariMessageType::PingPong, msg),
                     )

--- a/base_layer/p2p/src/services/liveness/state.rs
+++ b/base_layer/p2p/src/services/liveness/state.rs
@@ -204,7 +204,7 @@ impl LivenessState {
     }
 
     pub fn get_monitored_node_ids(&self) -> Vec<NodeId> {
-        self.nodes_to_monitor.keys().map(|n| (*n).clone()).collect()
+        self.nodes_to_monitor.keys().cloned().collect()
     }
 
     pub fn is_monitored_node_id(&self, node_id: &NodeId) -> bool {

--- a/base_layer/wallet/src/transaction_service/service.rs
+++ b/base_layer/wallet/src/transaction_service/service.rs
@@ -465,7 +465,7 @@ where
     async fn handle_message_event(&mut self, message_event: MessagingEvent) -> Result<(), TransactionServiceError> {
         let (message_tag, result) = match message_event {
             MessagingEvent::MessageSent(message_tag) => (message_tag, true),
-            MessagingEvent::SendMessageFailed(outbound_message) => (outbound_message.tag, false),
+            MessagingEvent::SendMessageFailed(outbound_message, _reason) => (outbound_message.tag, false),
             _ => return Ok(()),
         };
         match self.pending_outbound_message_results.remove(&message_tag) {

--- a/comms/src/builder/builder.rs
+++ b/comms/src/builder/builder.rs
@@ -312,7 +312,7 @@ where
             .protocols
             .take()
             .or_else(|| Some(Protocols::new()))
-            .map(move |protocols| protocols.add(&[messaging::MESSAGING_PROTOCOL], messaging_proto_tx))
+            .map(move |protocols| protocols.add([messaging::MESSAGING_PROTOCOL], messaging_proto_tx))
             .expect("cannot fail");
 
         //---------------------------------- ConnectionManager --------------------------------------------//

--- a/comms/src/connection_manager/common.rs
+++ b/comms/src/connection_manager/common.rs
@@ -24,7 +24,7 @@ use super::types::ConnectionDirection;
 use crate::{
     connection_manager::error::ConnectionManagerError,
     multiplexing::Yamux,
-    peer_manager::{NodeId, NodeIdentity, Peer, PeerFeatures, PeerFlags, PeerManager},
+    peer_manager::{AsyncPeerManager, NodeId, NodeIdentity, Peer, PeerFeatures, PeerFlags},
     proto::identity::PeerIdentityMsg,
     protocol,
     types::CommsPublicKey,
@@ -74,11 +74,12 @@ pub fn is_valid_base_node_node_id(node_id: &NodeId, public_key: &CommsPublicKey)
 /// 1. Check that the offered addresses are valid
 /// 1. Update or add the peer, returning it's NodeId
 pub fn validate_and_add_peer_from_peer_identity(
-    peer_manager: &PeerManager,
+    peer_manager: &AsyncPeerManager,
     authenticated_public_key: CommsPublicKey,
     peer_identity: PeerIdentityMsg,
 ) -> Result<NodeId, ConnectionManagerError>
 {
+    let peer_manager = peer_manager.inner();
     // Validate the given node id for base nodes
     // TODO: This is technically a domain-level rule
     let peer_node_id =

--- a/comms/src/connection_manager/dialer.rs
+++ b/comms/src/connection_manager/dialer.rs
@@ -383,11 +383,8 @@ where
         );
         trace!(target: LOG_TARGET, "{:?}", peer_identity);
 
-        let peer_node_id = common::validate_and_add_peer_from_peer_identity(
-            peer_manager.inner(),
-            authenticated_public_key,
-            peer_identity,
-        )?;
+        let peer_node_id =
+            common::validate_and_add_peer_from_peer_identity(&peer_manager, authenticated_public_key, peer_identity)?;
 
         debug!(
             target: LOG_TARGET,

--- a/comms/src/connection_manager/error.rs
+++ b/comms/src/connection_manager/error.rs
@@ -71,6 +71,8 @@ pub enum ConnectionManagerError {
     IdentityProtocolError(IdentityProtocolError),
     /// The dial was cancelled
     DialCancelled,
+    /// The peer is offline and will not be dialed
+    PeerOffline,
 }
 
 impl From<yamux::ConnectionError> for ConnectionManagerError {

--- a/comms/src/connection_manager/listener.rs
+++ b/comms/src/connection_manager/listener.rs
@@ -238,11 +238,8 @@ where
         );
         trace!(target: LOG_TARGET, "{:?}", peer_identity);
 
-        let peer_node_id = common::validate_and_add_peer_from_peer_identity(
-            peer_manager.inner(),
-            authenticated_public_key,
-            peer_identity,
-        )?;
+        let peer_node_id =
+            common::validate_and_add_peer_from_peer_identity(&peer_manager, authenticated_public_key, peer_identity)?;
 
         debug!(
             target: LOG_TARGET,

--- a/comms/src/connection_manager/requester.rs
+++ b/comms/src/connection_manager/requester.rs
@@ -32,7 +32,16 @@ use tokio::sync::broadcast;
 /// Requests which are handled by the ConnectionManagerService
 #[derive(Debug)]
 pub enum ConnectionManagerRequest {
-    DialPeer(NodeId, oneshot::Sender<Result<PeerConnection, ConnectionManagerError>>),
+    /// Dial a given peer by node id.
+    /// Parameters:
+    /// 1. Node Id to dial
+    /// 1. If true, attempt to dial the peer even if we recently failed to dial them and they are considered offline
+    DialPeer(
+        NodeId,
+        bool,
+        oneshot::Sender<Result<PeerConnection, ConnectionManagerError>>,
+    ),
+    /// Register a oneshot to get triggered when the node is listening, or has failed to listen
     NotifyListening(oneshot::Sender<Multiaddr>),
     GetActiveConnection(NodeId, oneshot::Sender<Option<PeerConnection>>),
 }
@@ -63,9 +72,23 @@ impl ConnectionManagerRequester {
 
     /// Attempt to connect to a remote peer
     pub async fn dial_peer(&mut self, node_id: NodeId) -> Result<PeerConnection, ConnectionManagerError> {
+        self.send_dial_peer(node_id, false).await
+    }
+
+    /// Attempt to connect to a remote peer, even if we failed to contact the peer recently
+    pub async fn dial_peer_forced(&mut self, node_id: NodeId) -> Result<PeerConnection, ConnectionManagerError> {
+        self.send_dial_peer(node_id, true).await
+    }
+
+    async fn send_dial_peer(
+        &mut self,
+        node_id: NodeId,
+        is_forced: bool,
+    ) -> Result<PeerConnection, ConnectionManagerError>
+    {
         let (reply_tx, reply_rx) = oneshot::channel();
         self.sender
-            .send(ConnectionManagerRequest::DialPeer(node_id, reply_tx))
+            .send(ConnectionManagerRequest::DialPeer(node_id, is_forced, reply_tx))
             .await
             .map_err(|_| ConnectionManagerError::SendToActorFailed)?;
         reply_rx

--- a/comms/src/connection_manager/tests/manager.rs
+++ b/comms/src/connection_manager/tests/manager.rs
@@ -27,17 +27,18 @@ use crate::{
         manager::ConnectionManagerEvent,
         ConnectionManager,
         ConnectionManagerRequester,
+        PeerConnectionError,
     },
     noise::NoiseConfig,
     peer_manager::{NodeId, Peer, PeerFeatures, PeerFlags, PeerManagerError},
-    protocol::Protocols,
+    protocol::{ProtocolEvent, ProtocolId, Protocols},
     test_utils::{
         node_identity::{build_node_identity, ordered_node_identities},
         test_node::{build_connection_manager, build_peer_manager, TestNodeConfig},
     },
     transports::MemoryTransport,
 };
-use futures::{channel::mpsc, future, StreamExt};
+use futures::{channel::mpsc, future, AsyncReadExt, AsyncWriteExt, StreamExt};
 use std::time::Duration;
 use tari_shutdown::Shutdown;
 use tari_test_utils::{collect_stream, unpack_enum};
@@ -47,7 +48,7 @@ use tokio_macros as r#async;
 #[r#async::test_basic]
 async fn connect_to_nonexistent_peer() {
     let rt_handle = Handle::current();
-    let node_identity = build_node_identity(PeerFeatures::COMMUNICATION_NODE);
+    let node_identity = build_node_identity(PeerFeatures::empty());
     let noise_config = NoiseConfig::new(node_identity.clone());
     let (request_tx, request_rx) = mpsc::channel(1);
     let (event_tx, _) = broadcast::channel(1);
@@ -86,6 +87,155 @@ async fn connect_to_nonexistent_peer() {
 }
 
 #[r#async::test_basic]
+async fn dial_success() {
+    const TEST_PROTO: ProtocolId = ProtocolId::from_static(b"/test/valid");
+    let rt_handle = Handle::current();
+    let shutdown = Shutdown::new();
+
+    let node_identity1 = build_node_identity(PeerFeatures::empty());
+    let node_identity2 = build_node_identity(PeerFeatures::empty());
+
+    let (proto_tx1, _) = mpsc::channel(1);
+    let (proto_tx2, mut proto_rx2) = mpsc::channel(1);
+
+    // Setup connection manager 1
+    let peer_manager1 = build_peer_manager();
+    let mut conn_man1 = build_connection_manager(
+        rt_handle.clone(),
+        TestNodeConfig {
+            node_identity: node_identity1.clone(),
+            ..Default::default()
+        },
+        peer_manager1.clone(),
+        Protocols::new().add([TEST_PROTO], proto_tx1),
+        shutdown.to_signal(),
+    );
+
+    let public_address1 = conn_man1.wait_until_listening().await.unwrap();
+
+    let peer_manager2 = build_peer_manager();
+    let mut conn_man2 = build_connection_manager(
+        rt_handle,
+        TestNodeConfig {
+            node_identity: node_identity2.clone(),
+            ..Default::default()
+        },
+        peer_manager2.clone(),
+        Protocols::new().add([TEST_PROTO], proto_tx2),
+        shutdown.to_signal(),
+    );
+    let mut subscription2 = conn_man2.get_event_subscription();
+    let public_address2 = conn_man2.wait_until_listening().await.unwrap();
+
+    peer_manager1
+        .add_peer(Peer::new(
+            node_identity2.public_key().clone(),
+            node_identity2.node_id().clone(),
+            vec![public_address2].into(),
+            PeerFlags::empty(),
+            PeerFeatures::COMMUNICATION_CLIENT,
+        ))
+        .unwrap();
+
+    peer_manager2
+        .add_peer(Peer::new(
+            node_identity1.public_key().clone(),
+            node_identity1.node_id().clone(),
+            vec![public_address1].into(),
+            PeerFlags::empty(),
+            PeerFeatures::COMMUNICATION_CLIENT,
+        ))
+        .unwrap();
+
+    // Dial at the same time
+    let mut conn_out = conn_man1.dial_peer(node_identity2.node_id().clone()).await.unwrap();
+    assert_eq!(conn_out.peer_node_id(), node_identity2.node_id());
+
+    let event = subscription2.next().await.unwrap().unwrap();
+    unpack_enum!(ConnectionManagerEvent::Listening(_addr) = &*event);
+
+    let event = subscription2.next().await.unwrap().unwrap();
+    unpack_enum!(ConnectionManagerEvent::PeerConnected(conn_in) = &*event);
+    assert_eq!(conn_in.peer_node_id(), node_identity1.node_id());
+
+    let err = conn_out.open_substream("/tari/invalid").await.unwrap_err();
+    unpack_enum!(PeerConnectionError::ProtocolError(_err) = err);
+
+    let mut substream_out = conn_out.open_substream(TEST_PROTO).await.unwrap();
+    assert_eq!(substream_out.protocol, TEST_PROTO);
+
+    const MSG: &[u8] = b"Welease Woger!";
+    substream_out.stream.write_all(MSG).await.unwrap();
+
+    let protocol_in = proto_rx2.next().await.unwrap();
+    assert_eq!(protocol_in.protocol, &TEST_PROTO);
+    unpack_enum!(ProtocolEvent::NewInboundSubstream(node_id, substream_in) = protocol_in.event);
+    assert_eq!(&*node_id, node_identity1.node_id());
+
+    let mut buf = [0u8; MSG.len()];
+    substream_in.read_exact(&mut buf).await.unwrap();
+    assert_eq!(buf, MSG);
+}
+
+fn count_string_occurrences<T, U>(events: &[T], expected: &[&str]) -> usize
+where
+    T: AsRef<U>,
+    U: ToString,
+{
+    events
+        .iter()
+        .filter(|event| expected.iter().any(|exp| event.as_ref().to_string().starts_with(exp)))
+        .count()
+}
+
+#[r#async::test_basic]
+async fn dial_offline_peer() {
+    let rt_handle = Handle::current();
+    let shutdown = Shutdown::new();
+
+    let node_identity = build_node_identity(PeerFeatures::empty());
+
+    let peer_manager = build_peer_manager();
+    let mut conn_man = build_connection_manager(
+        rt_handle.clone(),
+        TestNodeConfig {
+            node_identity: node_identity.clone(),
+            ..Default::default()
+        },
+        peer_manager.clone(),
+        Protocols::new(),
+        shutdown.to_signal(),
+    );
+
+    let public_address = conn_man.wait_until_listening().await.unwrap();
+    let mut subscription = conn_man.get_event_subscription();
+
+    let mut peer = Peer::new(
+        node_identity.public_key().clone(),
+        node_identity.node_id().clone(),
+        vec![public_address].into(),
+        PeerFlags::empty(),
+        PeerFeatures::COMMUNICATION_CLIENT,
+    );
+
+    peer.connection_stats.set_connection_failed();
+    assert_eq!(peer.is_offline(), false);
+    peer.connection_stats.set_connection_failed();
+    assert_eq!(peer.is_offline(), true);
+
+    peer_manager.add_peer(peer).unwrap();
+
+    let err = conn_man.dial_peer(node_identity.node_id().clone()).await.unwrap_err();
+    unpack_enum!(ConnectionManagerError::PeerOffline = err);
+
+    let event = subscription.next().await.unwrap().unwrap();
+
+    unpack_enum!(ConnectionManagerEvent::PeerConnectFailed(node_id, err) = &*event);
+    assert_eq!(&**node_id, node_identity.node_id());
+    unpack_enum!(ConnectionManagerError::PeerOffline = err);
+}
+
+#[r#async::test_basic]
 async fn simultaneous_dial_events() {
     let rt_handle = Handle::current();
     let mut shutdown = Shutdown::new();
@@ -101,6 +251,7 @@ async fn simultaneous_dial_events() {
             ..Default::default()
         },
         peer_manager1.clone(),
+        Protocols::new(),
         shutdown.to_signal(),
     );
 
@@ -115,6 +266,7 @@ async fn simultaneous_dial_events() {
             ..Default::default()
         },
         peer_manager2.clone(),
+        Protocols::new(),
         shutdown.to_signal(),
     );
     let mut subscription2 = conn_man2.get_event_subscription();
@@ -160,7 +312,7 @@ async fn simultaneous_dial_events() {
     unpack_enum!(ConnectionManagerEvent::Listening(_addr) = &*event);
 
     let event = subscription2.next().await.unwrap().unwrap();
-    assert!(count_events(&[event], &["PeerConnected", "PeerInboundConnectFailed"]) >= 1);
+    assert!(count_string_occurrences(&[event], &["PeerConnected", "PeerInboundConnectFailed"]) >= 1);
 
     shutdown.trigger().unwrap();
     drop(conn_man1);
@@ -177,14 +329,6 @@ async fn simultaneous_dial_events() {
         .collect::<Vec<_>>();
 
     // TODO: Investigate why two PeerDisconnected events are sometimes received
-    assert!(count_events(&events1, &["PeerDisconnected", "PeerConnectWillClose"]) >= 1);
-    assert!(count_events(&events2, &["PeerDisconnected", "PeerConnectWillClose"]) >= 1);
-}
-
-fn count_events<T>(events: &[T], expected: &[&str]) -> usize
-where T: AsRef<ConnectionManagerEvent> {
-    events
-        .iter()
-        .filter(|event| expected.iter().any(|exp| event.as_ref().to_string().starts_with(exp)))
-        .count()
+    assert!(count_string_occurrences(&events1, &["PeerDisconnected", "PeerConnectWillClose"]) >= 1);
+    assert!(count_string_occurrences(&events2, &["PeerDisconnected", "PeerConnectWillClose"]) >= 1);
 }

--- a/comms/src/consts.rs
+++ b/comms/src/consts.rs
@@ -20,8 +20,14 @@
 //  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 //  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+use std::time::Duration;
+
 /// The maximum number of peers to return from the flood_identities method in peer manager
 pub const PEER_MANAGER_MAX_FLOOD_PEERS: usize = 1000;
+
+/// The amount of time to consider a peer to be offline (i.e. dial to peer will fail without trying) after a failed
+/// connection attempt
+pub const PEER_OFFLINE_COOLDOWN_PERIOD: Duration = Duration::from_secs(60);
 
 /// The envelope version. This should be increased any time a change is made to the
 /// envelope proto files.

--- a/comms/src/net_address/multiaddr_with_stats.rs
+++ b/comms/src/net_address/multiaddr_with_stats.rs
@@ -212,7 +212,7 @@ mod test {
         net_address_with_stats.mark_message_rejected();
         net_address_with_stats.mark_message_rejected();
         assert_eq!(net_address_with_stats.rejected_message_count, 2);
-        assert!(last_seen < net_address_with_stats.last_seen.unwrap());
+        assert!(last_seen <= net_address_with_stats.last_seen.unwrap());
     }
 
     #[test]

--- a/comms/src/peer_manager/async_peer_manager.rs
+++ b/comms/src/peer_manager/async_peer_manager.rs
@@ -65,7 +65,6 @@ impl AsyncPeerManager {
     }
 
     pub async fn find_by_public_key(&self, public_key: &CommsPublicKey) -> Result<Peer, PeerManagerError> {
-        // TODO: When tokio block_in_place is more stable, this clone may not be necessary
         let public_key = public_key.clone();
         self.blocking_call(move |pm| pm.find_by_public_key(&public_key)).await?
     }
@@ -75,8 +74,22 @@ impl AsyncPeerManager {
         self.blocking_call(move |pm| Ok(pm.exists(&public_key))).await?
     }
 
-    pub fn inner(&self) -> &PeerManager {
-        &self.peer_manager
+    /// Set the last connection to this peer as a success
+    pub async fn set_last_connect_success(&self, node_id: &NodeId) -> Result<(), PeerManagerError> {
+        let node_id = node_id.clone();
+        self.blocking_call(move |pm| pm.set_last_connect_success(&node_id))
+            .await?
+    }
+
+    /// Set the last connection to this peer as a failure
+    pub async fn set_last_connect_failed(&self, node_id: &NodeId) -> Result<(), PeerManagerError> {
+        let node_id = node_id.clone();
+        self.blocking_call(move |pm| pm.set_last_connect_failed(&node_id))
+            .await?
+    }
+
+    pub fn inner(&self) -> Arc<PeerManager> {
+        self.peer_manager.clone()
     }
 
     /// Updates fields for a peer. Any fields set to Some(xx) will be updated. All None

--- a/comms/src/peer_manager/connection_stats.rs
+++ b/comms/src/peer_manager/connection_stats.rs
@@ -71,7 +71,7 @@ impl PeerConnectionStats {
 
     /// Returns the date time (UTC) since the last failed connection occurred. None is returned if the
     /// `last_connection_attempt` is not `Failed`
-    pub fn failed_at(&self) -> Option<&NaiveDateTime> {
+    pub fn last_failed_at(&self) -> Option<&NaiveDateTime> {
         match &self.last_connection_attempt {
             LastConnectionAttempt::Failed { failed_at, .. } => Some(failed_at),
             _ => None,
@@ -81,7 +81,7 @@ impl PeerConnectionStats {
     /// Returns the Duration since the last failed connection occurred. None is returned if the
     /// `last_connection_attempt` is not `Failed`
     pub fn time_since_last_failure(&self) -> Option<Duration> {
-        self.failed_at()
+        self.last_failed_at()
             .map(|failed_at| Utc::now().naive_utc() - *failed_at)
             .map(convert_to_std_duration)
     }
@@ -140,14 +140,14 @@ mod test {
     #[test]
     fn peer_connection_stats() {
         let state = PeerConnectionStats::new();
-        assert!(state.failed_at().is_none());
+        assert!(state.last_failed_at().is_none());
         assert_eq!(state.failed_attempts(), 0);
         assert!(state.time_since_last_failure().is_none());
         assert_eq!(state.has_ever_connected(), false);
 
         let mut state = PeerConnectionStats::new();
         state.set_connection_success();
-        assert!(state.failed_at().is_none());
+        assert!(state.last_failed_at().is_none());
         assert_eq!(state.failed_attempts(), 0);
         assert!(state.time_since_last_failure().is_none());
         assert_eq!(state.has_ever_connected(), true);
@@ -156,7 +156,7 @@ mod test {
         state.set_connection_failed();
         state.set_connection_failed();
         state.set_connection_failed();
-        assert!(state.failed_at().is_some());
+        assert!(state.last_failed_at().is_some());
         assert_eq!(state.failed_attempts(), 3);
         assert!(state.time_since_last_failure().unwrap().as_millis() < 100);
 

--- a/comms/src/peer_manager/peer_manager.rs
+++ b/comms/src/peer_manager/peer_manager.rs
@@ -80,7 +80,7 @@ impl PeerManager {
     }
 
     /// Set the last connection to this peer as a success
-    pub fn set_success_connection_state(&self, node_id: &NodeId) -> Result<(), PeerManagerError> {
+    pub fn set_last_connect_success(&self, node_id: &NodeId) -> Result<(), PeerManagerError> {
         let mut storage = self.peer_storage.write()?;
         let mut peer = storage.find_by_node_id(node_id)?;
         peer.connection_stats.set_connection_success();
@@ -88,7 +88,7 @@ impl PeerManager {
     }
 
     /// Set the last connection to this peer as a failure
-    pub fn set_failed_connection_state(&self, node_id: &NodeId) -> Result<(), PeerManagerError> {
+    pub fn set_last_connect_failed(&self, node_id: &NodeId) -> Result<(), PeerManagerError> {
         let mut storage = self.peer_storage.write()?;
         let mut peer = storage.find_by_node_id(node_id)?;
         peer.connection_stats.set_connection_failed();

--- a/comms/src/protocol/messaging/mod.rs
+++ b/comms/src/protocol/messaging/mod.rs
@@ -31,6 +31,7 @@ pub use messaging::{
     MessagingEventSender,
     MessagingProtocol,
     MessagingRequest,
+    SendFailReason,
     MESSAGING_PROTOCOL,
 };
 

--- a/comms/src/test_utils/connection_manager_mock.rs
+++ b/comms/src/test_utils/connection_manager_mock.rs
@@ -127,7 +127,7 @@ impl ConnectionManagerMock {
         self.state.inc_call_count();
         self.state.add_call(format!("{:?}", req)).await;
         match req {
-            DialPeer(node_id, reply_tx) => {
+            DialPeer(node_id, _, reply_tx) => {
                 // Send Ok(conn) if we have an active connection, otherwise Err(DialConnectFailedAllAddresses)
                 reply_tx
                     .send(

--- a/comms/src/test_utils/test_node.rs
+++ b/comms/src/test_utils/test_node.rs
@@ -70,6 +70,7 @@ pub fn build_connection_manager(
     executor: runtime::Handle,
     config: TestNodeConfig,
     peer_manager: Arc<PeerManager>,
+    protocols: Protocols<yamux::Stream>,
     shutdown: ShutdownSignal,
 ) -> ConnectionManagerRequester
 {
@@ -88,7 +89,7 @@ pub fn build_connection_manager(
         request_rx,
         config.node_identity,
         peer_manager.into(),
-        Protocols::new(),
+        protocols,
         event_tx,
         shutdown,
     );

--- a/comms/src/transports/socks.rs
+++ b/comms/src/transports/socks.rs
@@ -29,6 +29,9 @@ use crate::{
 use futures::{Future, FutureExt};
 use std::{io, time::Duration};
 
+/// SO_KEEPALIVE setting for the SOCKS TCP connection
+const SOCKS_SO_KEEPALIVE: Duration = Duration::from_millis(1500);
+
 #[derive(Clone, Debug)]
 struct SocksConfig {
     proxy_address: Multiaddr,
@@ -45,7 +48,7 @@ impl SocksTransport {
     pub fn new(proxy_address: Multiaddr, authentication: socks::Authentication) -> Self {
         let mut tcp_transport = TcpTransport::new();
         tcp_transport.set_nodelay(true);
-        tcp_transport.set_keepalive(Some(Duration::from_millis(600)));
+        tcp_transport.set_keepalive(Some(SOCKS_SO_KEEPALIVE));
 
         Self {
             socks_config: SocksConfig {


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Currently, if we cannot send to a peer the user of `MessagingProtocol`
has no way to know if the peer is not contactable.

This PR notifies the requester if they attempting to dial a peer which was not
contactable within a cooldown period (1 minute) so that they have some
way to handle that (give up, retry later etc).

The messaging protocol provides the following reasons as to why a message
failed to send:
```rust
pub enum SendFailReason {
    /// Dial was not attempted because the peer is offline
    PeerOffline,
    /// Dial was attempted, but failed
    PeerDialFailed,
    /// Outbound message envelope failed to serialize
    EnvelopeFailedToSerialize,
    /// Failed to open a messaging substream to peer
    SubstreamOpenFailed,
    /// Failed to send on substream channel
    SubstreamSendFailed,
}
```


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #1371 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested `ConnectionManager` and `MessagingProtocol` emit correct events and errors (Peer offline etc) . 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [x] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [x] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch
* [x] I ran `cargo-fmt --all` before pushing
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
