### PR TITLE
Builder dry

### DIFF
--- a/base_layer/core/src/blocks/genesis_block.rs
+++ b/base_layer/core/src/blocks/genesis_block.rs
@@ -33,11 +33,6 @@ use crate::transactions::{
     transaction::{KernelFeatures, OutputFeatures, OutputFlags, TransactionKernel, TransactionOutput},
     types::{Commitment, PrivateKey, PublicKey, Signature},
 };
-use serde::Deserialize;
-use std::{
-    fs::File,
-    io::{BufRead, BufReader, Error, Write},
-};
 use tari_crypto::tari_utilities::{hash::Hashable, hex::*};
 
 // TODO: see issue #1145

--- a/base_layer/core/src/proof_of_work/lwma_diff.rs
+++ b/base_layer/core/src/proof_of_work/lwma_diff.rs
@@ -73,6 +73,22 @@ impl LinearWeightedMovingAverage {
         // k is the sum of weights (1+2+..+n) * target_time
         let k = n * (n + 1) * self.target_time / 2;
         let target = ave_difficulty * k as f64 / weighted_times as f64;
+        trace!(
+            target: LOG_TARGET,
+            "DiffCalc; t={}; bw={}; n={}; ts[0]={}; ts[n]={}; weighted_ts={}; k={}; diff[0]={}; diff[n]={}; \
+             ave_difficulty={}; target={}",
+            self.target_time,
+            self.block_window,
+            n,
+            timestamps[0],
+            timestamps[n as usize],
+            weighted_times,
+            k,
+            self.accumulated_difficulties[0],
+            self.accumulated_difficulties[n as usize],
+            ave_difficulty,
+            target
+        );
         if target > std::u64::MAX as f64 {
             error!(
                 target: LOG_TARGET,
@@ -81,7 +97,7 @@ impl LinearWeightedMovingAverage {
             panic!("Difficulty target has overflowed");
         }
         let target = target.ceil() as u64; // difficulty difference of 1 should not matter much, but difficulty should never be below 1, ceil(0.9) = 1
-        trace!(target: LOG_TARGET, "New difficultly requested: {:?}", target);
+        debug!(target: LOG_TARGET, "New target difficulty: {}", target);
         target.into()
     }
 }

--- a/base_layer/p2p/src/comms_connector/mod.rs
+++ b/base_layer/p2p/src/comms_connector/mod.rs
@@ -24,4 +24,8 @@ mod inbound_connector;
 mod peer_message;
 mod pubsub;
 
-pub use self::{inbound_connector::InboundDomainConnector, peer_message::PeerMessage, pubsub::pubsub_connector};
+pub use self::{
+    inbound_connector::InboundDomainConnector,
+    peer_message::PeerMessage,
+    pubsub::{pubsub_connector, PubsubDomainConnector, SubscriptionFactory},
+};

--- a/base_layer/p2p/src/comms_connector/pubsub.rs
+++ b/base_layer/p2p/src/comms_connector/pubsub.rs
@@ -26,22 +26,16 @@ use futures::{channel::mpsc, FutureExt, SinkExt, StreamExt};
 use log::*;
 use std::sync::Arc;
 use tari_pubsub::{pubsub_channel, TopicPayload, TopicSubscriptionFactory};
-use tokio::runtime;
+use tokio::runtime::Handle;
 
 const LOG_TARGET: &str = "comms::middleware::pubsub";
 
 /// Alias for a pubsub-type domain connector
 pub type PubsubDomainConnector = InboundDomainConnector<mpsc::Sender<Arc<PeerMessage>>>;
+pub type SubscriptionFactory = TopicSubscriptionFactory<TariMessageType, Arc<PeerMessage>>;
 
 /// Connects `InboundDomainConnector` to a `tari_pubsub::TopicPublisher` through a buffered channel
-pub fn pubsub_connector(
-    executor: runtime::Handle,
-    buf_size: usize,
-) -> (
-    PubsubDomainConnector,
-    TopicSubscriptionFactory<TariMessageType, Arc<PeerMessage>>,
-)
-{
+pub fn pubsub_connector(executor: Handle, buf_size: usize) -> (PubsubDomainConnector, SubscriptionFactory) {
     let (publisher, subscription_factory) = pubsub_channel(buf_size);
     let (sender, receiver) = mpsc::channel(buf_size);
 

--- a/common/src/configuration.rs
+++ b/common/src/configuration.rs
@@ -77,7 +77,7 @@ pub fn install_default_config_file(path: &Path) -> Result<u64, std::io::Error> {
 #[derive(Clone, Debug, PartialEq)]
 pub enum Network {
     MainNet,
-    TestNet,
+    Rincewind,
 }
 
 impl TryFrom<String> for Network {
@@ -85,8 +85,8 @@ impl TryFrom<String> for Network {
 
     fn try_from(value: String) -> Result<Self, Self::Error> {
         let val = value.to_lowercase();
-        if &val == "testnet" {
-            Ok(Self::TestNet)
+        if &val == "rincewind" {
+            Ok(Self::Rincewind)
         } else if &val == "mainnet" {
             Ok(Self::MainNet)
         } else {
@@ -102,7 +102,7 @@ impl Display for Network {
     fn fmt(&self, f: &mut Formatter) -> FormatResult {
         let msg = match self {
             Self::MainNet => "mainnet",
-            Self::TestNet => "testnet",
+            Self::Rincewind => "rincewind",
         };
         f.write_str(msg)
     }
@@ -131,7 +131,7 @@ impl Display for Network {
 ///     fn extract_configuration(cfg: &Config, network: Network) -> Result<Self, ConfigurationError> {
 ///         let key = match network {
 ///             Network::MainNet => "main.foo",
-///             Network::TestNet => "test.foo",
+///             Network::Rincewind => "test.foo",
 ///         };
 ///         let foo = cfg.get_int(key).map_err(|e| ConfigurationError::new(&key, &e.to_string()))? as usize;
 ///         Ok(MyConf { foo })
@@ -517,33 +517,33 @@ pub fn default_config() -> Config {
         .unwrap();
     cfg.set_default("base_node.mainnet.enable_mining", false).unwrap();
 
-    // Testnet base node defaults
-    cfg.set_default("base_node.testnet.db_type", "lmdb").unwrap();
-    cfg.set_default("base_node.testnet.peer_seeds", Vec::<String>::new())
+    // Rincewind base node defaults
+    cfg.set_default("base_node.rincewind.db_type", "lmdb").unwrap();
+    cfg.set_default("base_node.rincewind.peer_seeds", Vec::<String>::new())
         .unwrap();
-    cfg.set_default("base_node.testnet.blocking_threads", 4).unwrap();
-    cfg.set_default("base_node.testnet.core_threads", 4).unwrap();
-    cfg.set_default("base_node.testnet.data_dir", default_subdir("testnet/"))
+    cfg.set_default("base_node.rincewind.blocking_threads", 4).unwrap();
+    cfg.set_default("base_node.rincewind.core_threads", 4).unwrap();
+    cfg.set_default("base_node.rincewind.data_dir", default_subdir("rincewind/"))
         .unwrap();
     cfg.set_default(
-        "base_node.testnet.tor_identity_file",
-        default_subdir("testnet/tor.json"),
+        "base_node.rincewind.tor_identity_file",
+        default_subdir("rincewind/tor.json"),
     )
     .unwrap();
     cfg.set_default(
-        "base_node.testnet.identity_file",
-        default_subdir("testnet/node_id.json"),
+        "base_node.rincewind.identity_file",
+        default_subdir("rincewind/node_id.json"),
     )
     .unwrap();
     cfg.set_default(
-        "base_node.testnet.public_address",
+        "base_node.rincewind.public_address",
         format!("{}/tcp/18141", local_ip_addr),
     )
     .unwrap();
-    cfg.set_default("base_node.testnet.grpc_enabled", false).unwrap();
-    cfg.set_default("base_node.testnet.grpc_address", "tcp://127.0.0.1:18141")
+    cfg.set_default("base_node.rincewind.grpc_enabled", false).unwrap();
+    cfg.set_default("base_node.rincewind.grpc_address", "tcp://127.0.0.1:18141")
         .unwrap();
-    cfg.set_default("base_node.testnet.enable_mining", false).unwrap();
+    cfg.set_default("base_node.rincewind.enable_mining", false).unwrap();
 
     set_transport_defaults(&mut cfg);
 
@@ -569,23 +569,23 @@ fn set_transport_defaults(cfg: &mut Config) {
         .unwrap();
     cfg.set_default("base_node.mainnet.socks5_auth", "none").unwrap();
 
-    // Testnet
-    // Default transport for testnet is tcp
-    cfg.set_default("base_node.testnet.transport", "tcp").unwrap();
-    cfg.set_default("base_node.testnet.tcp_listener_address", "/ip4/0.0.0.0/tcp/18189")
+    // rincewind
+    // Default transport for rincewind is tcp
+    cfg.set_default("base_node.rincewind.transport", "tcp").unwrap();
+    cfg.set_default("base_node.rincewind.tcp_listener_address", "/ip4/0.0.0.0/tcp/18189")
         .unwrap();
 
-    cfg.set_default("base_node.testnet.tor_control_address", "/ip4/127.0.0.1/tcp/9051")
+    cfg.set_default("base_node.rincewind.tor_control_address", "/ip4/127.0.0.1/tcp/9051")
         .unwrap();
-    cfg.set_default("base_node.testnet.tor_control_auth", "none").unwrap();
-    cfg.set_default("base_node.testnet.tor_forward_address", "/ip4/127.0.0.1/tcp/18041")
+    cfg.set_default("base_node.rincewind.tor_control_auth", "none").unwrap();
+    cfg.set_default("base_node.rincewind.tor_forward_address", "/ip4/127.0.0.1/tcp/18041")
         .unwrap();
 
-    cfg.set_default("base_node.testnet.socks5_proxy_address", "/ip4/0.0.0.0/tcp/9150")
+    cfg.set_default("base_node.rincewind.socks5_proxy_address", "/ip4/0.0.0.0/tcp/9150")
         .unwrap();
-    cfg.set_default("base_node.testnet.socks5_listener_address", "/ip4/0.0.0.0/tcp/18199")
+    cfg.set_default("base_node.rincewind.socks5_listener_address", "/ip4/0.0.0.0/tcp/18199")
         .unwrap();
-    cfg.set_default("base_node.testnet.socks5_auth", "none").unwrap();
+    cfg.set_default("base_node.rincewind.socks5_auth", "none").unwrap();
 }
 
 fn get_local_ip() -> Option<Multiaddr> {

--- a/comms/src/peer_manager/peer.rs
+++ b/comms/src/peer_manager/peer.rs
@@ -30,6 +30,7 @@ use bitflags::bitflags;
 use chrono::{DateTime, NaiveDateTime, Utc};
 use multiaddr::Multiaddr;
 use serde::{Deserialize, Serialize};
+use std::fmt::Display;
 use tari_crypto::tari_utilities::hex::serialize_to_hex;
 
 bitflags! {
@@ -152,6 +153,17 @@ impl Peer {
     /// Changes the ban flag bit of the peer
     pub fn set_banned(&mut self, ban_flag: bool) {
         self.flags.set(PeerFlags::BANNED, ban_flag);
+    }
+}
+
+/// Display Peer as `[peer_id]: <pubkey>`
+impl Display for Peer {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str(&format!(
+            "[{}]: {}",
+            self.id.map(|v| v.to_string()).unwrap_or("NoID".to_string()),
+            self.public_key,
+        ))
     }
 }
 


### PR DESCRIPTION
## DRY up node builder
    
* The node builder has been cleaned up significantly.
* The `BlockchainBackend` has been abstracted away behind a  `NodeContainer` enum that exposes a set of methods that   are backend-agnostic.
* This lets us remove all the duplicated code in the builder logic.
* All the functions in the builder have been refactored to have a *single responsibility*.
    
## Other changes
* The miner builder code has been collected up and grouped together.
* A hash rate calculator hash been added to `blake_miner`.
    
    Every minute, if a block hasn't been found, it'll log the hashrate to
    the logs (in MH/s).


* Many log messages have been added to the code, the mining code in
    particular.
    
## Please check
_Please check_: The miner did not start because the `new_block_found`
 flag was initially set to false, which put the mining thread in a
 perpetual loop; and it never got to ask for a template. The thing is, I
 don't know how mining ever worked before with this code, so I'd love to
 know if there's anything I've broken.
