### PR TITLE
Ensure liveness service correctly indicates pong from neighbour

### DIFF
--- a/base_layer/core/tests/node_state_machine.rs
+++ b/base_layer/core/tests/node_state_machine.rs
@@ -80,7 +80,7 @@ fn test_listening_lagging() {
         LivenessConfig {
             enable_auto_join: false,
             enable_auto_stored_message_request: false,
-            auto_ping_interval: Some(Duration::from_millis(500)),
+            auto_ping_interval: Some(Duration::from_millis(100)),
             refresh_neighbours_interval: Duration::from_secs(60),
         },
         consensus_manager,

--- a/base_layer/p2p/src/services/liveness/neighbours.rs
+++ b/base_layer/p2p/src/services/liveness/neighbours.rs
@@ -22,7 +22,7 @@
 
 use chrono::{NaiveDateTime, Utc};
 use std::time::Duration;
-use tari_comms::peer_manager::Peer;
+use tari_comms::peer_manager::{NodeId, Peer};
 
 pub struct Neighbours {
     last_updated: Option<NaiveDateTime>,
@@ -58,5 +58,9 @@ impl Neighbours {
 
     pub fn peers(&self) -> &[Peer] {
         &self.peers
+    }
+
+    pub fn contains(&self, node_id: &NodeId) -> bool {
+        self.peers.iter().map(|p| &p.node_id).any(|n| n == node_id)
     }
 }

--- a/base_layer/p2p/src/services/liveness/service.rs
+++ b/base_layer/p2p/src/services/liveness/service.rs
@@ -168,7 +168,7 @@ where
             PingPong::Pong => {
                 let maybe_latency = self.state.record_pong(inner_msg.nonce);
                 trace!(target: LOG_TARGET, "Recorded latency: {:?}", maybe_latency);
-                let is_neighbour = self.neighbours.peers().contains(&msg.source_peer);
+                let is_neighbour = self.neighbours.contains(&msg.source_peer.node_id);
                 let is_monitored = self.state.is_monitored_node_id(&msg.source_peer.node_id);
                 let pong_event = PongEvent::new(
                     msg.source_peer.node_id.clone(),


### PR DESCRIPTION
Changed equality check for neighbour list to only use the node id.

This seems to fix the issue with `test_listening_lagging`
