### PR TITLE
Validate peer addresses before adding them to peer list

### DIFF
--- a/applications/tari_base_node/src/builder.rs
+++ b/applications/tari_base_node/src/builder.rs
@@ -337,6 +337,8 @@ where
         outbound_buffer_size: 100,
         // TODO - make this configurable
         dht: Default::default(),
+        // TODO: This should be false unless testing locally - make this configurable
+        allow_test_addresses: true,
     };
     let (comms, dht) = setup_comms_services(comms_config, publisher).await?;
     // Save final node identity after comms has initialized. This is required because the public_address can be changed

--- a/base_layer/p2p/examples/pingpong.rs
+++ b/base_layer/p2p/examples/pingpong.rs
@@ -171,6 +171,7 @@ fn main() {
         max_concurrent_inbound_tasks: 10,
         outbound_buffer_size: 10,
         dht: Default::default(),
+        allow_test_addresses: true,
     };
 
     let (comms, dht) = rt.block_on(initialize_comms(comms_config, publisher)).unwrap();

--- a/base_layer/wallet/src/testnet_utils.rs
+++ b/base_layer/wallet/src/testnet_utils.rs
@@ -128,6 +128,7 @@ pub fn create_wallet(
             discovery_request_timeout: Duration::from_millis(500),
             ..Default::default()
         },
+        allow_test_addresses: true,
     };
 
     let config = WalletConfig {

--- a/base_layer/wallet/tests/wallet/mod.rs
+++ b/base_layer/wallet/tests/wallet/mod.rs
@@ -94,6 +94,7 @@ fn test_wallet() {
             max_concurrent_inbound_tasks: 100,
             outbound_buffer_size: 100,
             dht: Default::default(),
+            allow_test_addresses: true,
         };
         let comms_config2 = CommsConfig {
             node_identity: Arc::new(bob_identity.clone()),
@@ -105,6 +106,7 @@ fn test_wallet() {
             max_concurrent_inbound_tasks: 100,
             outbound_buffer_size: 100,
             dht: Default::default(),
+            allow_test_addresses: true,
         };
         let config1 = WalletConfig {
             comms_config: comms_config1,
@@ -242,6 +244,7 @@ fn test_import_utxo() {
         max_concurrent_inbound_tasks: 100,
         outbound_buffer_size: 100,
         dht: Default::default(),
+        allow_test_addresses: true,
     };
     let config = WalletConfig {
         comms_config,
@@ -309,6 +312,7 @@ fn test_data_generation() {
             discovery_request_timeout: Duration::from_millis(500),
             ..Default::default()
         },
+        allow_test_addresses: true,
     };
 
     let config = WalletConfig {

--- a/base_layer/wallet_ffi/src/lib.rs
+++ b/base_layer/wallet_ffi/src/lib.rs
@@ -1860,6 +1860,9 @@ pub unsafe extern "C" fn comms_config_create(
                         max_concurrent_inbound_tasks: 100,
                         outbound_buffer_size: 100,
                         dht: DhtConfig::default(),
+                        // TODO: This should be set to false for non-test wallets. See the `allow_test_addresses` field
+                        //       docstring for more info.
+                        allow_test_addresses: true,
                     };
 
                     Box::into_raw(Box::new(config))
@@ -3597,6 +3600,7 @@ mod test {
                 secret_key_alice,
                 error_ptr,
             );
+            (*alice_config).allow_test_addresses = true;
             let alice_wallet = wallet_create(
                 alice_config,
                 ptr::null(),

--- a/comms/dht/src/discovery/error.rs
+++ b/comms/dht/src/discovery/error.rs
@@ -43,6 +43,8 @@ pub enum DhtDiscoveryError {
     /// The discovery request timed out
     DiscoveryTimeout,
     PeerManagerError(PeerManagerError),
+    #[error(msg_embedded, non_std, no_from)]
+    InvalidPeerMultiaddr(String),
 }
 
 impl DhtDiscoveryError {

--- a/comms/dht/src/discovery/service.rs
+++ b/comms/dht/src/discovery/service.rs
@@ -43,6 +43,7 @@ use tari_comms::{
     multiaddr::Multiaddr,
     peer_manager::{NodeId, NodeIdentity, Peer, PeerFeatures, PeerFlags, PeerManager},
     types::CommsPublicKey,
+    validate_peer_addresses,
 };
 use tari_crypto::tari_utilities::{hex::Hex, ByteArray};
 use tari_shutdown::ShutdownSignal;
@@ -195,6 +196,9 @@ impl DhtDiscoveryService {
             .into_iter()
             .filter_map(|addr| addr.parse().ok())
             .collect::<Vec<_>>();
+
+        validate_peer_addresses(&addresses, self.config.network.is_localtest())
+            .map_err(|err| DhtDiscoveryError::InvalidPeerMultiaddr(err.to_string()))?;
 
         let peer = self.add_or_update_peer(
             &public_key,

--- a/comms/dht/src/proto/mod.rs
+++ b/comms/dht/src/proto/mod.rs
@@ -20,6 +20,8 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+use crate::proto::envelope::Network;
+
 #[path = "tari.dht.envelope.rs"]
 pub mod envelope;
 
@@ -31,3 +33,28 @@ pub mod store_forward;
 
 #[path = "tari.dht.message_header.rs"]
 pub mod message_header;
+
+//---------------------------------- Network impl --------------------------------------------//
+
+impl envelope::Network {
+    pub fn is_mainnet(&self) -> bool {
+        match self {
+            Network::MainNet => true,
+            _ => false,
+        }
+    }
+
+    pub fn is_testnet(&self) -> bool {
+        match self {
+            Network::TestNet => true,
+            _ => false,
+        }
+    }
+
+    pub fn is_localtest(&self) -> bool {
+        match self {
+            Network::LocalTest => true,
+            _ => false,
+        }
+    }
+}

--- a/comms/dht/tests/dht.rs
+++ b/comms/dht/tests/dht.rs
@@ -78,6 +78,7 @@ async fn setup_comms_dht(
     let (outbound_tx, outbound_rx) = mpsc::channel(10);
 
     let comms = CommsBuilder::new()
+        .allow_test_addresses()
         // In this case the listener address and the public address are the same (/memory/...)
         .with_listener_address(node_identity.public_address())
         .with_transport(MemoryTransport)

--- a/comms/src/builder/builder.rs
+++ b/comms/src/builder/builder.rs
@@ -96,6 +96,7 @@ impl CommsBuilder<TcpTransport> {
             protocols: None,
             hidden_service: None,
             connection_manager_config: ConnectionManagerConfig::default(),
+
             shutdown: Shutdown::new(),
         }
     }
@@ -124,6 +125,17 @@ where
     /// [OutboundMessagePool]: ../../outbound_message_service/index.html#outbound-message-pool
     pub fn with_node_identity(mut self, node_identity: Arc<NodeIdentity>) -> Self {
         self.node_identity = Some(node_identity);
+        self
+    }
+
+    /// Allow test addresses (memory addresses, local loopback etc). This should only be activated for tests.
+    pub fn allow_test_addresses(mut self) -> Self {
+        #[cfg(not(debug_assertions))]
+        warn!(
+            target: LOG_TARGET,
+            "Test addresses are enabled! This is invalid and potentially insecure when running a production node."
+        );
+        self.connection_manager_config.allow_test_addresses = true;
         self
     }
 

--- a/comms/src/connection_manager/error.rs
+++ b/comms/src/connection_manager/error.rs
@@ -73,6 +73,8 @@ pub enum ConnectionManagerError {
     DialCancelled,
     /// The peer is offline and will not be dialed
     PeerOffline,
+    #[error(msg_embedded, no_from, non_std)]
+    InvalidMultiaddr(String),
 }
 
 impl From<yamux::ConnectionError> for ConnectionManagerError {

--- a/comms/src/connection_manager/manager.rs
+++ b/comms/src/connection_manager/manager.rs
@@ -112,6 +112,9 @@ pub struct ConnectionManagerConfig {
     pub max_simultaneous_inbound_connects: usize,
     /// The period of time to keep the peer connection around before disconnecting. Default: 3s
     pub disconnect_linger: Duration,
+    /// Set to true to allow peers to send loopback, local-link and other addresses normally not considered valid for
+    /// peer-to-peer comms. Default: false
+    pub allow_test_addresses: bool,
 }
 
 impl Default for ConnectionManagerConfig {
@@ -123,6 +126,11 @@ impl Default for ConnectionManagerConfig {
             max_dial_attempts: 3,
             max_simultaneous_inbound_connects: 20,
             disconnect_linger: Duration::from_secs(3),
+            #[cfg(not(test))]
+            allow_test_addresses: false,
+            // This must always be true for internal crate tests
+            #[cfg(test)]
+            allow_test_addresses: true,
         }
     }
 }

--- a/comms/src/connection_manager/mod.rs
+++ b/comms/src/connection_manager/mod.rs
@@ -20,10 +20,12 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-mod common;
 mod dial_state;
 mod dialer;
 mod listener;
+
+mod common;
+pub use common::validate_peer_addresses;
 
 mod types;
 pub use types::ConnectionDirection;

--- a/comms/src/lib.rs
+++ b/comms/src/lib.rs
@@ -9,6 +9,8 @@
 #![recursion_limit = "512"]
 // Allow `type Future = impl Future`
 #![feature(type_alias_impl_trait)]
+// Required to use `Ip4Addr::is_global`. Stabilisation imminent https://github.com/rust-lang/rust/issues/27709
+#![feature(ip)]
 
 #[macro_use]
 extern crate lazy_static;
@@ -17,6 +19,8 @@ extern crate lazy_static;
 mod macros;
 
 mod connection_manager;
+pub use connection_manager::validate_peer_addresses;
+
 mod consts;
 mod multiplexing;
 mod noise;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Potentially malicious addresses were previously trusted by nodes. As an
example, an infected node accepts a loopback address from a malicious peer
and causes it to connect locally to some malware.

Addresses given by peers are now checked before being added to the
peer list.

Some test environments require the ability to use /memory and/or localhost addresses,
so a configuration item was added to comms to explicitly enable "test addresses".
Currently, the wallet and base node have these enabled to prevent
disruption to development on these applications. Once non-local addresses are used
for testnet environments, "test addresses" should be disallowed.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #1315 - not validated against the transport, but the transport will reject addresses it doesn't support. This PR stops misuse of a node by foreign nodes.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Unit tested validation function and existing tests pass

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [x] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [x] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch
* [x] I ran `cargo-fmt --all` before pushing
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
