### PR TITLE
Add tor COOKIE auth support

### DIFF
--- a/base_layer/wallet_ffi/README.md
+++ b/base_layer/wallet_ffi/README.md
@@ -85,21 +85,22 @@ Which will present you with the file contents as follows
 ```text
 BUILD_ANDROID=1
 BUILD_IOS=1
+CARGO_CLEAN=1
 SQLITE_SOURCE=https://www.sqlite.org/snapshot/sqlite-snapshot-201911192122.tar.gz
-NDK_PATH=/Users/user/Desktop/android-ndk-r20
-PKG_PATH=/usr/local/Cellar/zeromq/4.3.2/lib/pkgconfig
-
-ANDROID_WALLET_PATH=/Users/user/Desktop/wallet-android
-IOS_WALLET_PATH=/Users/user/Desktop/wallet-ios
-TARI_REPO_PATH=/Users/user/Desktop/tari-main
+NDK_PATH=$HOME/android-ndk-r20
+PKG_PATH=
+ANDROID_WALLET_PATH=$HOME/wallet-android
+IOS_WALLET_PATH=$HOME/wallet-ios
+TARI_REPO_PATH=$HOME/tari-main
 ```
 The following changes need to be made to the file
 1. ```NDK_PATH``` needs to be changed to the directory of the Android NDK Bundle.
-2. ```ANDROID_WALLET``` needs to be changed to the path of the Android-Wallet repository
-3. ```IOS_WALLET_PATH``` needs to be changed to the path of the Wallet-iOS repository
-4. ```TARI_REPO_PATH``` needs to be changed to the path of the Tari repository
-5. ```BUILD_ANDROID``` can be set to ```0``` to disable Android library build
-6. ```BUILD_IOS``` can be set to ```0``` to disable iOS library build
+1. ```ANDROID_WALLET``` needs to be changed to the path of the Android-Wallet repository
+1. ```IOS_WALLET_PATH``` needs to be changed to the path of the Wallet-iOS repository
+1. ```CARGO_CLEAN``` if set to 1, the cargo clean command will be run before the build
+1. ```TARI_REPO_PATH``` needs to be changed to the path of the Tari repository (Optional - defaults to current repo)
+1. ```BUILD_ANDROID``` can be set to ```0``` to disable Android library build
+1. ```BUILD_IOS``` can be set to ```0``` to disable iOS library build
 
 Save the file and rename it to ```build.config```
 

--- a/base_layer/wallet_ffi/build.sample.config
+++ b/base_layer/wallet_ffi/build.sample.config
@@ -2,7 +2,9 @@ BUILD_ANDROID=1
 BUILD_IOS=1
 SQLITE_SOURCE=https://www.sqlite.org/snapshot/sqlite-snapshot-201911192122.tar.gz
 NDK_PATH=/Users/user/Desktop/android-ndk-r20
-PKG_PATH=/usr/local/Cellar/zeromq/4.3.2/lib/pkgconfig
-ANDROID_WALLET_PATH=/Users/user/Desktop/wallet-android
-IOS_WALLET_PATH=/Users/user/Desktop/wallet-ios
-TARI_REPO_PATH=/Users/user/Desktop/tari-main
+PKG_PATH=
+ANDROID_WALLET_PATH=$HOME/Desktop/wallet-android
+IOS_WALLET_PATH=$HOME/Desktop/wallet-ios
+TARI_REPO_PATH=$HOME/Desktop/tari-main
+# Run cargo clean before the build starts
+CARGO_CLEAN=1

--- a/base_layer/wallet_ffi/mobile_build.sh
+++ b/base_layer/wallet_ffi/mobile_build.sh
@@ -12,18 +12,16 @@ YELLOW='\033[1;33m'
 NC='\033[0m' # No Color
 
 source build.config
+TARI_REPO_PATH=${TARI_REPO_PATH:-`git rev-parse --show-toplevel`}
 CURRENT_DIR=${TARI_REPO_PATH}/base_layer/wallet_ffi
 cd ${CURRENT_DIR} || exit
-timestamp=$(date +%s)
 mkdir -p logs
 cd logs || exit
-mkdir -p ${timestamp}
-cd ${timestamp} || exit
 mkdir -p ios
 mkdir -p android
 cd ../..
-IOS_LOG_PATH=${CURRENT_DIR}/logs/${timestamp}/ios
-ANDROID_LOG_PATH=${CURRENT_DIR}/logs/${timestamp}/android
+IOS_LOG_PATH=${CURRENT_DIR}/logs/ios
+ANDROID_LOG_PATH=${CURRENT_DIR}/logs/android
 SQLITE_FOLDER=sqlite
 cd ../../..
 
@@ -52,7 +50,7 @@ fi
 DEPENDENCIES=${IOS_WALLET_PATH}
 # PKG_PATH, BUILD_IOS is defined in build.config
 # shellcheck disable=SC2153
-if [ -n "${DEPENDENCIES}" ] && [ -n "${PKG_PATH}" ] && [ "${BUILD_IOS}" -eq 1 ] && [ "${MACHINE}" == "Mac" ]; then
+if [ -n "${DEPENDENCIES}" ] && [ "${BUILD_IOS}" -eq 1 ] && [ "${MACHINE}" == "Mac" ]; then
   echo "${GREEN}Commencing iOS build${NC}"
   echo "${YELLOW}Build logs can be found at ${IOS_LOG_PATH}${NC}"
   echo "\t${CYAN}Configuring Rust${NC}"
@@ -66,7 +64,9 @@ if [ -n "${DEPENDENCIES}" ] && [ -n "${PKG_PATH}" ] && [ "${BUILD_IOS}" -eq 1 ] 
   BUILD_ROOT=$PWD
   cd ..
   cd ${CURRENT_DIR} || exit
-  cargo clean
+  if [ "${CARGO_CLEAN}" -eq "1" ]; then
+      cargo clean >> ${IOS_LOG_PATH}/cargo.txt 2>&1
+  fi
   cp wallet.h "${DEPENDENCIES}/MobileWallet/TariLib/"
   export PKG_CONFIG_PATH=${PKG_PATH}
   echo "\t${CYAN}Building Wallet FFI${NC}"
@@ -89,7 +89,7 @@ fi
 DEPENDENCIES=$ANDROID_WALLET_PATH
 # PKG_PATH, BUILD_ANDROID, NDK_PATH is defined in build.config
 # shellcheck disable=SC2153
-if [ -n "${DEPENDENCIES}" ] && [ -n "${NDK_PATH}" ] && [ -n "${PKG_PATH}" ] && [ "${BUILD_ANDROID}" -eq 1 ]; then
+if [ -n "${DEPENDENCIES}" ] && [ -n "${NDK_PATH}" ] && [ "${BUILD_ANDROID}" -eq 1 ]; then
   echo "${GREEN}Commencing Android build${NC}"
   echo "${YELLOW}Build logs can be found at ${ANDROID_LOG_PATH}${NC}"
   echo "\t${CYAN}Configuring Rust${NC}"
@@ -231,7 +231,9 @@ if [ -n "${DEPENDENCIES}" ] && [ -n "${NDK_PATH}" ] && [ -n "${PKG_PATH}" ] && [
 
       echo "\t${CYAN}Configuring Cargo${NC}"
       cd ${CURRENT_DIR} || exit
-      cargo clean >> ${ANDROID_LOG_PATH}/cargo.txt 2>&1
+      if [ "${CARGO_CLEAN}" -eq "1" ]; then
+        cargo clean >> ${ANDROID_LOG_PATH}/cargo.txt 2>&1
+      fi
       mkdir -p .cargo
       cd .cargo || exit
       if [ "${MACHINE}" == "Mac" ]; then

--- a/base_layer/wallet_ffi/wallet.h
+++ b/base_layer/wallet_ffi/wallet.h
@@ -82,7 +82,7 @@ struct TariTransportType *transport_tcp_create(const char *listener_address,int*
 // Creates a tor transport type
 struct TariTransportType *transport_tor_create(
     const char *control_server_address,
-    const char *tor_password,
+    struct ByteVector *tor_cookie,
     struct ByteVector *tor_identity,
     unsigned short tor_port,
     const char *socks_username,


### PR DESCRIPTION
Add COOKIE authentication support to tor control client.
This is needed for Tor.Framework.

mobile_build.sh changes

- Added ability to disable cargo clean when doing mobile builds
- Updated mobile build readme