### PR TITLE
Remove cfg_if for better IDE integration

### DIFF
--- a/base_layer/core/src/base_node/mod.rs
+++ b/base_layer/core/src/base_node/mod.rs
@@ -32,25 +32,27 @@
 //! More details about the implementation are presented in
 //! [RFC-0111](https://rfc.tari.com/RFC-0111_BaseNodeArchitecture.html).
 
-cfg_if! {
-    if #[cfg(feature = "base_node")] {
-        mod backoff;
-        mod base_node;
+#[cfg(feature = "base_node")]
+mod backoff;
+#[cfg(feature = "base_node")]
+mod base_node;
+#[cfg(feature = "base_node")]
+pub mod chain_metadata_service;
+#[cfg(feature = "base_node")]
+pub mod comms_interface;
+#[cfg(feature = "base_node")]
+pub mod consts;
+#[cfg(feature = "base_node")]
+pub mod service;
+#[cfg(feature = "base_node")]
+pub mod states;
+// Public re-exports
+#[cfg(feature = "base_node")]
+pub use backoff::BackOff;
+#[cfg(feature = "base_node")]
+pub use base_node::{BaseNodeStateMachine, BaseNodeStateMachineConfig};
+#[cfg(feature = "base_node")]
+pub use comms_interface::{LocalNodeCommsInterface, OutboundNodeCommsInterface};
 
-        pub mod comms_interface;
-        pub mod consts;
-        pub mod service;
-        pub mod chain_metadata_service;
-        pub mod states;
-        // Public re-exports
-        pub use backoff::BackOff;
-        pub use base_node::{BaseNodeStateMachine, BaseNodeStateMachineConfig};
-        pub use comms_interface::{LocalNodeCommsInterface, OutboundNodeCommsInterface};
-    }
-}
-
-cfg_if! {
-    if #[cfg(any(feature = "base_node", feature = "base_node_proto"))] {
-        pub mod proto;
-    }
-}
+#[cfg(any(feature = "base_node", feature = "base_node_proto"))]
+pub mod proto;

--- a/base_layer/core/src/base_node/proto/mod.rs
+++ b/base_layer/core/src/base_node/proto/mod.rs
@@ -27,12 +27,13 @@ use crate::proto::core;
 // Required for `super::types` used in generated files
 use crate::transactions::proto::types;
 
-cfg_if! {
-    if #[cfg(feature = "base_node")] {
-        pub mod chain_metadata;
-        pub mod mmr_tree;
-        pub mod request;
-        pub mod response;
-        pub use base_node::{BaseNodeServiceRequest, BaseNodeServiceResponse, ChainMetadata};
-    }
-}
+#[cfg(feature = "base_node")]
+pub mod chain_metadata;
+#[cfg(feature = "base_node")]
+pub mod mmr_tree;
+#[cfg(feature = "base_node")]
+pub mod request;
+#[cfg(feature = "base_node")]
+pub mod response;
+#[cfg(feature = "base_node")]
+pub use base_node::{BaseNodeServiceRequest, BaseNodeServiceResponse, ChainMetadata};

--- a/base_layer/core/src/lib.rs
+++ b/base_layer/core/src/lib.rs
@@ -30,27 +30,26 @@
 
 #[macro_use]
 extern crate bitflags;
-#[macro_use]
-extern crate cfg_if;
 
-cfg_if! {
-    if #[cfg(feature = "base_node")] {
-        pub mod blocks;
-        pub mod chain_storage;
-        pub mod consensus;
-        pub mod helpers;
-        pub mod mining;
-        pub mod proof_of_work;
-        pub mod validation;
-    }
-}
+#[cfg(feature = "base_node")]
+pub mod blocks;
+#[cfg(feature = "base_node")]
+pub mod chain_storage;
+#[cfg(feature = "base_node")]
+pub mod consensus;
+#[cfg(feature = "base_node")]
+pub mod helpers;
+#[cfg(feature = "base_node")]
+pub mod mining;
+#[cfg(feature = "base_node")]
+pub mod proof_of_work;
+#[cfg(feature = "base_node")]
+pub mod validation;
 
-cfg_if! {
-    if #[cfg(any(feature = "base_node", feature = "base_node_proto"))] {
-        pub mod base_node;
-        pub mod proto;
-    }
-}
+#[cfg(any(feature = "base_node", feature = "base_node_proto"))]
+pub mod base_node;
+#[cfg(any(feature = "base_node", feature = "base_node_proto"))]
+pub mod proto;
 
 #[cfg(any(feature = "base_node", feature = "mempool_proto"))]
 pub mod mempool;

--- a/base_layer/core/src/mempool/mod.rs
+++ b/base_layer/core/src/mempool/mod.rs
@@ -20,31 +20,38 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-cfg_if! {
-    if #[cfg(feature = "base_node")] {
-        mod config;
-        mod consts;
-        mod error;
-        mod mempool;
-        mod orphan_pool;
-        mod pending_pool;
-        mod priority;
-        mod reorg_pool;
-        mod unconfirmed_pool;
-        // Public re-exports
-        pub use self::config::{MempoolConfig, MempoolServiceConfig};
-        pub use error::MempoolError;
-        pub use mempool::{Mempool, MempoolValidators};
-        pub use service::{MempoolServiceError, MempoolServiceInitializer, OutboundMempoolServiceInterface};
-    }
-}
+#[cfg(feature = "base_node")]
+mod config;
+#[cfg(feature = "base_node")]
+mod consts;
+#[cfg(feature = "base_node")]
+mod error;
+#[cfg(feature = "base_node")]
+mod mempool;
+#[cfg(feature = "base_node")]
+mod orphan_pool;
+#[cfg(feature = "base_node")]
+mod pending_pool;
+#[cfg(feature = "base_node")]
+mod priority;
+#[cfg(feature = "base_node")]
+mod reorg_pool;
+#[cfg(feature = "base_node")]
+mod unconfirmed_pool;
+// Public re-exports
+#[cfg(feature = "base_node")]
+pub use self::config::{MempoolConfig, MempoolServiceConfig};
+#[cfg(feature = "base_node")]
+pub use error::MempoolError;
+#[cfg(feature = "base_node")]
+pub use mempool::{Mempool, MempoolValidators};
+#[cfg(feature = "base_node")]
+pub use service::{MempoolServiceError, MempoolServiceInitializer, OutboundMempoolServiceInterface};
 
-cfg_if! {
-    if #[cfg(any(feature = "base_node", feature = "mempool_proto"))] {
-        pub mod proto;
-        pub mod service;
-     }
-}
+#[cfg(any(feature = "base_node", feature = "mempool_proto"))]
+pub mod proto;
+#[cfg(any(feature = "base_node", feature = "mempool_proto"))]
+pub mod service;
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, PartialEq, Serialize, Deserialize)]

--- a/base_layer/core/src/mempool/service/mod.rs
+++ b/base_layer/core/src/mempool/service/mod.rs
@@ -20,20 +20,26 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-cfg_if! {
-    if #[cfg(feature = "base_node")] {
+#[cfg(feature = "base_node")]
 mod error;
+#[cfg(feature = "base_node")]
 mod inbound_handlers;
+#[cfg(feature = "base_node")]
 mod initializer;
+#[cfg(feature = "base_node")]
 mod outbound_interface;
+#[cfg(feature = "base_node")]
 mod service;
+#[cfg(feature = "base_node")]
 // Public re-exports
+#[cfg(feature = "base_node")]
 pub use error::MempoolServiceError;
+#[cfg(feature = "base_node")]
 pub use initializer::MempoolServiceInitializer;
+#[cfg(feature = "base_node")]
 pub use outbound_interface::OutboundMempoolServiceInterface;
+#[cfg(feature = "base_node")]
 pub use service::MempoolService;
-    }
-}
 
 mod request;
 mod response;

--- a/base_layer/core/src/proto/mod.rs
+++ b/base_layer/core/src/proto/mod.rs
@@ -27,9 +27,7 @@ pub mod core {
     include!(concat!(env!("OUT_DIR"), "/", "tari.core.rs"));
 }
 
-cfg_if! {
-    if #[cfg(feature = "base_node")] {
-        mod block;
-        pub mod utils;
-    }
-}
+#[cfg(feature = "base_node")]
+mod block;
+#[cfg(feature = "base_node")]
+pub mod utils;


### PR DESCRIPTION
Using cfg_if! doesn't integrate well with CLion and makes navigating the code with features like "Go to definition" not work. This isn't a necessary change, but makes it easier to work with the project
