### PR TITLE
Updated wallet wording and formatting

### DIFF
--- a/applications/tari_base_node/src/parser.rs
+++ b/applications/tari_base_node/src/parser.rs
@@ -123,10 +123,7 @@ impl Parser {
         let commands: Vec<&str> = command_str.split(' ').collect();
         let command = BaseNodeCommand::from_str(commands[0]);
         if command.is_err() {
-            println!(
-                "{} is not a valid command, please enter a valid command",
-                command_str
-            );
+            println!("{} is not a valid command, please enter a valid command", command_str);
             println!("Enter help or press tab for available commands");
             return;
         }

--- a/applications/tari_base_node/src/parser.rs
+++ b/applications/tari_base_node/src/parser.rs
@@ -124,7 +124,7 @@ impl Parser {
         let command = BaseNodeCommand::from_str(commands[0]);
         if command.is_err() {
             println!(
-                "Received: {}, this is not a valid command, please enter a valid command",
+                "{} is not a valid command, please enter a valid command",
                 command_str
             );
             println!("Enter help or press tab for available commands");
@@ -200,7 +200,7 @@ impl Parser {
                     warn!(target: LOG_TARGET, "Error communicating with wallet: {}", e.to_string(),);
                     return;
                 },
-                Ok(data) => println!("Current balance is: {}", data),
+                Ok(data) => println!("Balances:\n{}", data),
             };
         });
     }
@@ -227,7 +227,7 @@ impl Parser {
     // Function to process  the send transaction function
     fn process_send_tari(&mut self, command_arg: Vec<&str>) {
         if command_arg.len() != 3 {
-            println!("Command entered wrong, please enter in the following format: ");
+            println!("Command entered incorrectly, please use the following format: ");
             println!("send_tari [amount of tari to send] [public key to send to]");
             return;
         }

--- a/base_layer/wallet/src/output_manager_service/service.rs
+++ b/base_layer/wallet/src/output_manager_service/service.rs
@@ -713,10 +713,9 @@ pub struct Balance {
 
 impl fmt::Display for Balance {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "You current balance is:\n")?;
-        write!(f, "Available balance: {} \n", self.available_balance)?;
-        write!(f, "Pending incoming balance: {}\n", self.pending_incoming_balance)?;
-        write!(f, "Pending outgoing balance: {}\n", self.pending_outgoing_balance)?;
+        writeln!(f, "Available balance: {}", self.available_balance)?;
+        writeln!(f, "Pending incoming balance: {}", self.pending_incoming_balance)?;
+        write!(f, "Pending outgoing balance: {}", self.pending_outgoing_balance)?;
         Ok(())
     }
 }


### PR DESCRIPTION
## Description
Changed the wording for invalid commands to be slightly friendlier. Also formatted the wallet balances as well as slightly changing the wording of the balances.

## Motivation and Context
The wallet balances were all on one line.

## How Has This Been Tested?
Manually, as well as running `cargo test`

## Types of changes
* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch
* [x] I ran `cargo-fmt --all` before pushing
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
