### PR TITLE
Add proof of work to the chain meta data

### DIFF
--- a/base_layer/core/src/base_node/chain_metadata_service/service.rs
+++ b/base_layer/core/src/base_node/chain_metadata_service/service.rs
@@ -267,6 +267,7 @@ mod test {
             height_of_longest_chain: Some(1),
             best_block: Some(vec![]),
             pruning_horizon: 64,
+            accumulated_difficulty: 1.into(),
         }
     }
 

--- a/base_layer/core/src/base_node/proto/chain_metadata.proto
+++ b/base_layer/core/src/base_node/proto/chain_metadata.proto
@@ -12,4 +12,6 @@ message ChainMetadata {
     // The number of blocks back from the tip that this database tracks. A value of 0 indicates that all blocks are
     // tracked (i.e. the database is in full archival mode).
     uint64 pruning_horizon = 4;
+    // The current geometric mean of the pow of the chain tip, or `None` if there is no chain
+    google.protobuf.UInt64Value accumulated_difficulty = 5;
 }

--- a/base_layer/core/src/base_node/proto/chain_metadata.rs
+++ b/base_layer/core/src/base_node/proto/chain_metadata.rs
@@ -25,20 +25,30 @@ use crate::chain_storage::ChainMetadata;
 
 impl From<proto::ChainMetadata> for ChainMetadata {
     fn from(metadata: proto::ChainMetadata) -> Self {
+        let accumulated_difficulty = match metadata.accumulated_difficulty {
+            None => None,
+            Some(v) => Some(v.into()),
+        };
         Self {
             height_of_longest_chain: metadata.height_of_longest_chain,
             best_block: metadata.best_block,
             pruning_horizon: metadata.pruning_horizon,
+            accumulated_difficulty,
         }
     }
 }
 
 impl From<ChainMetadata> for proto::ChainMetadata {
     fn from(metadata: ChainMetadata) -> Self {
+        let accumulated_difficulty = match metadata.accumulated_difficulty {
+            None => None,
+            Some(v) => Some(v.into()),
+        };
         Self {
             height_of_longest_chain: metadata.height_of_longest_chain,
             best_block: metadata.best_block,
             pruning_horizon: metadata.pruning_horizon,
+            accumulated_difficulty,
         }
     }
 }

--- a/base_layer/core/src/blocks/genesis_block.rs
+++ b/base_layer/core/src/blocks/genesis_block.rs
@@ -23,7 +23,7 @@
 // This file is used to store the genesis block
 use crate::{
     blocks::{block::Block, BlockHeader},
-    proof_of_work::{Difficulty, PowAlgorithm, ProofOfWork},
+    proof_of_work::{PowAlgorithm, ProofOfWork},
 };
 
 use crate::transactions::{

--- a/base_layer/core/src/chain_storage/db_transaction.rs
+++ b/base_layer/core/src/chain_storage/db_transaction.rs
@@ -22,6 +22,7 @@
 
 use crate::{
     blocks::{blockheader::BlockHash, Block, BlockHeader},
+    proof_of_work::Difficulty,
     transactions::{
         transaction::{TransactionInput, TransactionKernel, TransactionOutput},
         types::HashOutput,
@@ -207,7 +208,7 @@ pub enum MetadataKey {
 pub enum MetadataValue {
     ChainHeight(Option<u64>),
     BestBlock(Option<BlockHash>),
-    AccumulatedWork(u64),
+    AccumulatedWork(Option<Difficulty>),
     PruningHorizon(u64),
 }
 

--- a/base_layer/core/src/proof_of_work/difficulty.rs
+++ b/base_layer/core/src/proof_of_work/difficulty.rs
@@ -89,6 +89,12 @@ impl From<u64> for Difficulty {
     }
 }
 
+impl From<Difficulty> for u64 {
+    fn from(value: Difficulty) -> Self {
+        value.0
+    }
+}
+
 /// General difficulty adjustment algorithm trait. The key method is `get_difficulty`, which returns the target
 /// difficulty given a set of historical achieved difficulties; supplied through the `add` method.
 pub trait DifficultyAdjustment {

--- a/base_layer/core/src/proof_of_work/proof_of_work.rs
+++ b/base_layer/core/src/proof_of_work/proof_of_work.rs
@@ -136,18 +136,30 @@ impl ProofOfWork {
     /// Replaces the `next` proof of work's difficulty with the sum of this proof of work's total cumulative
     /// difficulty and the provided `added_difficulty`.
     pub fn add_difficulty(&mut self, prev: &ProofOfWork, added_difficulty: Difficulty) {
-        let (m, b) = match prev.pow_algo {
+        let pow = ProofOfWork::new_from_difficulty(prev, added_difficulty);
+        self.accumulated_blake_difficulty = pow.accumulated_blake_difficulty;
+        self.accumulated_monero_difficulty = pow.accumulated_monero_difficulty;
+    }
+
+    /// Creates anew proof of work from the provided proof of work difficulty with the sum of this proof of work's total
+    /// cumulative difficulty and the provided `added_difficulty`.
+    pub fn new_from_difficulty(pow: &ProofOfWork, added_difficulty: Difficulty) -> ProofOfWork {
+        let (m, b) = match pow.pow_algo {
             PowAlgorithm::Monero => (
-                prev.accumulated_monero_difficulty + added_difficulty,
-                prev.accumulated_blake_difficulty,
+                pow.accumulated_monero_difficulty + added_difficulty,
+                pow.accumulated_blake_difficulty,
             ),
             PowAlgorithm::Blake => (
-                prev.accumulated_monero_difficulty,
-                prev.accumulated_blake_difficulty + added_difficulty,
+                pow.accumulated_monero_difficulty,
+                pow.accumulated_blake_difficulty + added_difficulty,
             ),
         };
-        self.accumulated_blake_difficulty = b;
-        self.accumulated_monero_difficulty = m;
+        ProofOfWork {
+            accumulated_monero_difficulty: m,
+            accumulated_blake_difficulty: b,
+            pow_algo: pow.pow_algo,
+            pow_data: pow.pow_data.clone(),
+        }
     }
 
     /// Compare the difficulties of this and another proof of work, without knowing anything about scaling factors.

--- a/base_layer/core/tests/chain_storage_tests/chain_backend.rs
+++ b/base_layer/core/tests/chain_storage_tests/chain_backend.rs
@@ -287,7 +287,7 @@ fn insert_fetch_metadata<T: BlockchainBackend>(db: T) {
     ));
     txn.insert(DbKeyValuePair::Metadata(
         MetadataKey::AccumulatedWork,
-        MetadataValue::AccumulatedWork(accumulated_work),
+        MetadataValue::AccumulatedWork(Some(accumulated_work.into())),
     ));
     txn.insert(DbKeyValuePair::Metadata(
         MetadataKey::PruningHorizon,
@@ -309,7 +309,7 @@ fn insert_fetch_metadata<T: BlockchainBackend>(db: T) {
     if let Some(DbValue::Metadata(MetadataValue::AccumulatedWork(retrieved_accumulated_work))) =
         db.fetch(&DbKey::Metadata(MetadataKey::AccumulatedWork)).unwrap()
     {
-        assert_eq!(retrieved_accumulated_work, accumulated_work);
+        assert_eq!(retrieved_accumulated_work, Some(accumulated_work.into()));
     } else {
         assert!(false);
     }

--- a/base_layer/core/tests/node_comms_interface.rs
+++ b/base_layer/core/tests/node_comms_interface.rs
@@ -87,8 +87,8 @@ fn outbound_get_metadata() {
     let mut outbound_nci = OutboundNodeCommsInterface::new(request_sender, block_sender);
 
     block_on(async {
-        let metadata1 = ChainMetadata::new(5, vec![0u8], 3);
-        let metadata2 = ChainMetadata::new(6, vec![1u8], 4);
+        let metadata1 = ChainMetadata::new(5, vec![0u8], 3, 5.into());
+        let metadata2 = ChainMetadata::new(6, vec![1u8], 4, 6.into());
         let metadata_response: Vec<NodeCommsResponse> = vec![
             NodeCommsResponse::ChainMetadata(metadata1.clone()),
             NodeCommsResponse::ChainMetadata(metadata2.clone()),


### PR DESCRIPTION
## Description
This PR adds the geometric mean of the pow of the chain tip to the chain meta data struct and messages

## Motivation and Context
We decide on reorgs based on the the Proof of work and not the chain length. The current metadata struct does not include this. We need to download the complete chain before we look at this.  With this PR we can just compare the pow and not only the length

## Types of changes
* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [x] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
* [x] I'm merging against the `development` branch
* [x] I ran `cargo-fmt --all` before pushing
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
