### PR TITLE
Update FFI Tx listing functions for pending & completed transactions

### DIFF
--- a/base_layer/core/src/transactions/transaction_protocol/recipient.rs
+++ b/base_layer/core/src/transactions/transaction_protocol/recipient.rs
@@ -154,6 +154,16 @@ impl ReceiverTransactionProtocol {
             "Multiple recipients aren't supported yet".into(),
         ))
     }
+
+    /// Create an empty SenderTransactionProtocol that can be used as a placeholder in data structures that do not
+    /// require a well formed version
+    pub fn new_placeholder() -> Self {
+        ReceiverTransactionProtocol {
+            state: RecipientState::Failed(TransactionProtocolError::IncompleteStateError(
+                "This is a placeholder protocol".to_string(),
+            )),
+        }
+    }
 }
 
 #[cfg(test)]

--- a/base_layer/core/src/transactions/transaction_protocol/sender.rs
+++ b/base_layer/core/src/transactions/transaction_protocol/sender.rs
@@ -448,6 +448,14 @@ impl SenderTransactionProtocol {
             state: SenderState::CollectingSingleSignature(Box::new(raw_data)),
         })
     }
+
+    /// Create an empty SenderTransactionProtocol that can be used as a placeholder in data structures that do not
+    /// require a well formed version
+    pub fn new_placeholder() -> Self {
+        SenderTransactionProtocol {
+            state: SenderState::Failed(TPE::IncompleteStateError("This is a placeholder protocol".to_string())),
+        }
+    }
 }
 
 pub fn calculate_tx_id<D: Digest>(pub_nonce: &PublicKey, index: usize) -> u64 {

--- a/base_layer/wallet/src/transaction_service/storage/database.rs
+++ b/base_layer/wallet/src/transaction_service/storage/database.rs
@@ -193,6 +193,33 @@ pub enum WriteOperation {
     Remove(DbKey),
 }
 
+impl From<CompletedTransaction> for InboundTransaction {
+    fn from(ct: CompletedTransaction) -> Self {
+        Self {
+            tx_id: ct.tx_id,
+            source_public_key: ct.source_public_key,
+            amount: ct.amount,
+            receiver_protocol: ReceiverTransactionProtocol::new_placeholder(),
+            message: ct.message,
+            timestamp: ct.timestamp,
+        }
+    }
+}
+
+impl From<CompletedTransaction> for OutboundTransaction {
+    fn from(ct: CompletedTransaction) -> Self {
+        Self {
+            tx_id: ct.tx_id,
+            destination_public_key: ct.destination_public_key,
+            amount: ct.amount,
+            fee: ct.fee,
+            sender_protocol: SenderTransactionProtocol::new_placeholder(),
+            message: ct.message,
+            timestamp: ct.timestamp,
+        }
+    }
+}
+
 // Private macro that pulls out all the boiler plate of extracting a DB query result from its variants
 macro_rules! fetch {
     ($db:ident, $key_val:expr, $key_var:ident) => {{


### PR DESCRIPTION
## Description
The frontend considers a transaction as Completed only once it is mined. However the Transaction manager considers a CompletedTransaction to be one that have been completely negotiated between parties and is now ready to be Broadcast and Mined.

In order to present both truly pending and CompletedTransactions in the Completed and Broadcast states as Pending to the frontend this PR adds some logic to return them in the `wallet_get_pending_outbound_transactions(…)` and `wallet_get_pending_inbound_transactions(…)` FFI function calls. They are also excluded from the `wallet_get_completed_transactions(…)` function call which only include CompletedTransactions with the Mined status.

## How Has This Been Tested?
FFI tests updated to account for these changes

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [x] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [x] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch
* [x] I ran `cargo-fmt --all` before pushing
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
