### PR TITLE
Initial sync compare pow

### DIFF
--- a/base_layer/core/src/base_node/states/block_sync.rs
+++ b/base_layer/core/src/base_node/states/block_sync.rs
@@ -102,7 +102,7 @@ async fn network_tip_metadata<B: BlockchainBackend>(
     Ok(metadata_list
         .into_iter()
         .fold(ChainMetadata::default(), |best, current| {
-            if current.height_of_longest_chain.unwrap_or(0) >= best.height_of_longest_chain.unwrap_or(0) {
+            if current.accumulated_difficulty.unwrap_or(0.into()) >= best.accumulated_difficulty.unwrap_or(0.into()) {
                 current
             } else {
                 best

--- a/base_layer/core/src/base_node/states/initial_sync.rs
+++ b/base_layer/core/src/base_node/states/initial_sync.rs
@@ -137,7 +137,7 @@ impl InitialSync {
         // TODO: Use heuristics to weed out outliers / dishonest nodes.
         // Right now, we a simple strategy of returning the max height
         let result = data.into_iter().fold(ChainMetadata::default(), |best, current| {
-            if current.height_of_longest_chain.unwrap_or(0) >= best.height_of_longest_chain.unwrap_or(0) {
+            if current.accumulated_difficulty.unwrap_or(0.into()) >= best.accumulated_difficulty.unwrap_or(0.into()) {
                 current
             } else {
                 best


### PR DESCRIPTION
## Description
Change the intial sync so that it compres the total accumulated proof of work and not the longest chain when comparing two chain tips.

## Motivation and Context
Reorg is done on the geometric mean of the proof of work of the chain tip. The intial sync only looks at the total height of the chain when deciding to enter sync mode or not. This causes the node te enter sync mode prematurely. If it encounters a chain tip further ahead of it but with lower proof if work, it will get stuck as it will keep on entering sync state and failing to reorg as it already has a greater proof of work chain. This causes the base node to get stuck. 


## Types of changes
* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
* [x] I'm merging against the `development` branch
* [x] I ran `cargo-fmt --all` before pushing
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
