### PR TITLE
windows_compatibility_tari_base_node

### DIFF
--- a/base_layer/wallet/README.md
+++ b/base_layer/wallet/README.md
@@ -1,1 +1,13 @@
 # Tari Wallet
+
+Foreign Function interface for the Tari Android and Tari iOS Wallets.
+
+This crate is part of the [Tari Cryptocurrency](https://tari.com) project.
+
+## Build setup (Mac)
+
+See README.md in wallet_ffi crate
+
+## Setup (Windows)
+
+See README.md in wallet_ffi crate

--- a/base_layer/wallet_ffi/README.md
+++ b/base_layer/wallet_ffi/README.md
@@ -114,3 +114,13 @@ sh mobile_build.sh
 
 The relevant libraries will then be built and placed in the appropriate directories of the Wallet-iOS and Wallet-Android repositories. 
 
+# Setup (Windows)
+
+## Test
+
+1. Download SQL Lite (https://www.sqlite.org/index.html - 64bit) and unzip
+2. `sqlite3.dll` must be accessible via the session path
+
+## Build
+
+ToDo -  Android only


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- Conditional compilation was added to exclude `store_forward` Tokio layer to be added for Windows builds. This removes  `store_forward` functionality from Windpows, but provides a temporary fix.
- Small refactoring for `fn load_users()` in `lmdb.rs`
- Windows build and run instructions where SQLite is a dependency

## Motivation and Context
The `tari_base_node` creates a stack overflow error when run in Windows. This has been traced to the implementation of multiple Tokio layers in `pub fn inbound_middleware_layer` (compliments due to @sdbondi). Excluding the 2x `store_forward` Tokio layers works for now. It seems this problem is related to the amount of layers added as well.

## How Has This Been Tested?
- The `tokio::runtime::Builder::new().thread_stack_size` has been increased from 2MB to 200MB but this did not solve the problem.
- Conditional compilation fully tested in Windows and Ubuntu Linux with `cargo test`

- `tari_base_node` was run and left to mine blocks on Windows and Ubuntu Linux; both mine successfully.

**Windows**
```
>> get_balance
>> Balances:
Available balance: 99716813707 µT
Pending incoming balance: 0 µT
Pending outgoing balance: 0 µT

 is not a valid command, please enter a valid command
Enter help or press tab for available commands
>> get_chain_metadata
Current meta data is is: Height of longest chain : 19
Best_block : a7cd45084c278fde1440c18784fa691d93f0de0c02b0708dda96fa308b291cb8
Pruning horizon : 2880
```

**Ubuntu Linux**
```
>> get_balance
Balances:
Available balance: 121875998510 µT
Pending incoming balance: 0 µT
Pending outgoing balance: 0 µT

>> get_chain_metadata
Current meta data is is: Height of longest chain : 22
Best_block : 73fad52710b809cf87badebd4a118183d936367fe4415d2023891fd8f5bbdc17
Pruning horizon : 2880
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [X] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [X] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [X] I'm merging against the `development` branch
* [X] I ran `cargo-fmt --all` before pushing
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
