### PR TITLE
Format MicroTari as Tari when > 1e6

### DIFF
--- a/base_layer/core/src/transactions/tari_amount.rs
+++ b/base_layer/core/src/transactions/tari_amount.rs
@@ -82,7 +82,7 @@ impl MicroTari {
 impl Display for MicroTari {
     fn fmt(&self, f: &mut Formatter) -> Result<(), Error> {
         if *self < 1 * T {
-            f.write_fmt(format_args!("{} µT", self.0))
+            write!(f, "{} µT", self.0)
         } else {
             Tari::from(*self).fmt(f)
         }
@@ -135,7 +135,7 @@ newtype_ops! { [Tari] {mul div rem} {:=} Self f64 }
 
 impl Display for Tari {
     fn fmt(&self, f: &mut Formatter) -> Result<(), Error> {
-        f.write_fmt(format_args!("{:0.6} T", self.0))
+        write!(f, "{:0.6} T", self.0)
     }
 }
 

--- a/base_layer/core/src/transactions/tari_amount.rs
+++ b/base_layer/core/src/transactions/tari_amount.rs
@@ -81,7 +81,11 @@ impl MicroTari {
 
 impl Display for MicroTari {
     fn fmt(&self, f: &mut Formatter) -> Result<(), Error> {
-        f.write_fmt(format_args!("{} µT", self.0))
+        if *self < 1 * T {
+            f.write_fmt(format_args!("{} µT", self.0))
+        } else {
+            Tari::from(*self).fmt(f)
+        }
     }
 }
 
@@ -176,6 +180,8 @@ mod test {
     fn micro_tari_display() {
         let s = format!("{}", MicroTari::from(1234));
         assert_eq!(s, "1234 µT");
+        let s = format!("{}", MicroTari::from(1_000_000));
+        assert_eq!(s, "1.000000 T");
     }
 
     #[test]


### PR DESCRIPTION
## Description
When formatting `µT >= 1e6` rather format as `T`

## Motivation and Context
When formatting MicroTari that is greater than 1e6 rather display it as Tari.

## How Has This Been Tested?
Appended a unit test to display MicroTari > 1e6

## Types of changes
* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
* [x] I'm merging against the `development` branch
* [x] I ran `cargo-fmt --all` before pushing
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
