### PR TITLE
Fixed config and log creation when not running base node from source

### DIFF
--- a/common/src/configuration.rs
+++ b/common/src/configuration.rs
@@ -27,9 +27,9 @@ use log::*;
 use multiaddr::{Multiaddr, Protocol};
 use std::{
     convert::TryFrom,
-    env,
     error::Error,
     fmt::{Display, Formatter, Result as FormatResult},
+    fs,
     net::IpAddr,
     num::NonZeroU16,
     path::{Path, PathBuf},
@@ -66,11 +66,9 @@ pub fn load_configuration(bootstrap: &ConfigBootstrap) -> Result<Config, String>
 }
 
 /// Installs a new configuration file template, copied from `tari_config_sample.toml` to the given path.
-/// When bundled as a binary, the config sample file must be bundled in `./config`.
-pub fn install_default_config_file(path: &Path) -> Result<u64, std::io::Error> {
-    let mut source = env::current_dir()?;
-    source.push(Path::new("config/tari_config_sample.toml"));
-    std::fs::copy(source, path)
+pub fn install_default_config_file(path: &Path) -> Result<(), std::io::Error> {
+    let source = include_str!("../../config/tari_config_sample.toml");
+    fs::write(path, source)
 }
 
 //---------------------------------------------       Network type        ------------------------------------------//

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -141,7 +141,7 @@ fn prompt(question: &str) -> bool {
 }
 
 pub fn install_configuration<F>(path: &Path, installer: F)
-where F: Fn(&Path) -> Result<u64, std::io::Error> {
+where F: Fn(&Path) -> Result<(), std::io::Error> {
     if let Err(e) = installer(path) {
         println!(
             "We could not install a new configuration file in {}: {}",

--- a/common/src/logging.rs
+++ b/common/src/logging.rs
@@ -23,6 +23,7 @@
 
 use std::{
     env,
+    fs,
     path::{Path, PathBuf},
 };
 
@@ -63,11 +64,9 @@ pub fn initialize_logging(config_file: &Path) -> bool {
 }
 
 /// Installs a new default logfile configuration, copied from `log4rs-sample.yml` to the given path.
-/// When bundled as a binary, the config sample file must be bundled in `common/config`.
-pub fn install_default_logfile_config(path: &Path) -> Result<u64, std::io::Error> {
-    let mut source = env::current_dir()?;
-    source.push(Path::new("common/logging/log4rs-sample.yml"));
-    std::fs::copy(source, path)
+pub fn install_default_logfile_config(path: &Path) -> Result<(), std::io::Error> {
+    let source = include_str!("../logging/log4rs-sample.yml");
+    fs::write(path, source)
 }
 
 /// Log an error if an `Err` is returned from the `$expr`. If the given expression is `Ok(v)`,


### PR DESCRIPTION
Default log and configs files are now compiled into the binary so that
they don't have to exist in deployments
