### PR TITLE
Add dns4 to the MultiAddr to SocketAddr resolver

### DIFF
--- a/config/tari_config_sample.toml
+++ b/config/tari_config_sample.toml
@@ -104,7 +104,7 @@ peer_seeds = []
 
 # Configure the number of threads for the overall node work-stealing scheduler. A good value here is between 3 and
 # n - blocking_threads, where n is the number of cores on your machine, and blocking_thread is set above.
- #core_threads = 4
+#core_threads = 4
 
 # The node's publicly-accessible hostname. This is the host name that is advertised on the network so that
 # peers can find you.
@@ -173,7 +173,7 @@ peer_seeds = []
 
 # Configure the number of threads for the overall node work-stealing scheduler. A good value here is between 3 and
 # n - blocking_threads, where n is the number of cores on your machine, and blocking_thread is set above.
- #core_threads = 6
+#core_threads = 6
 
 # Enable the gRPC server for the base node. Set this to true if you want to enable third-party wallet software
 #grpc_enabled = false


### PR DESCRIPTION
Added a Dns4 match for the MultiAddr to SocketAddr resolver. This allows for dns based tor_control_addresses in the config.

## Description
The Dns4 match attempts to resolve the dns address using `std::net::ToSocketAddrs` it will then use the first result it finds as the ip address.

I also removed 2 whitespaces before some comments in the sample config file. It just allows for a cleaner parsing when generating a succinct config with `cat config/tari_config_sample.toml | grep -v '^#' | grep -v '^$' > clean_config.toml` 

## Motivation and Context
This allows use of /dns4 multiaddresses
Fixes tari-project/tari#1426

## How Has This Been Tested?
Ran `cargo test`
Included 2 tests to test for successful resolution as well as a failed resolution

## Types of changes
* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [x] New Tests
* [ ] Documentation

## Checklist:
* [x] I'm merging against the `development` branch
* [x] I ran `cargo-fmt --all` before pushing
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
