### PR TITLE
Quick clean up of message logging layer, reject msg log

### DIFF
--- a/comms/dht/src/dht.rs
+++ b/comms/dht/src/dht.rs
@@ -170,7 +170,7 @@ impl Dht {
             ))
             .layer(inbound::DedupLayer::new(self.dht_requester()))
             .layer(tower_filter::FilterLayer::new(self.unsupported_saf_messages_filter()))
-            .layer(MessageLoggingLayer::new())
+            .layer(MessageLoggingLayer::new("Inbound message: "))
             .layer(inbound::DecryptionLayer::new(Arc::clone(&self.node_identity)))
             .layer(store_forward::ForwardLayer::new(
                 Arc::clone(&self.peer_manager),
@@ -231,7 +231,7 @@ impl Dht {
                 self.discovery_service_requester(),
                 self.config.network,
             ))
-            .layer(MessageLoggingLayer::new())
+            .layer(MessageLoggingLayer::new("Outbound message: "))
             .layer(outbound::EncryptionLayer::new(Arc::clone(&self.node_identity)))
             .layer(outbound::SerializeLayer::new(Arc::clone(&self.node_identity)))
             .into_inner()

--- a/comms/dht/src/logging_middleware.rs
+++ b/comms/dht/src/logging_middleware.rs
@@ -20,51 +20,62 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use crate::{crypt, inbound::DhtInboundMessage, outbound::message::DhtOutboundMessage, PipelineError};
 use futures::{task::Context, Future};
 use log::*;
-use std::{sync::Arc, task::Poll};
-use tari_comms::peer_manager::NodeIdentity;
+use std::{fmt::Display, marker::PhantomData, task::Poll};
 use tower::{layer::Layer, Service, ServiceExt};
 
 const LOG_TARGET: &str = "comms::middleware::message_logging";
 
-/// This layer is responsible for logging messages for debugging. It should not be used in
-/// production
-pub struct MessageLoggingLayer {}
+/// This layer is responsible for logging messages for debugging.
+pub struct MessageLoggingLayer<R> {
+    prefix_msg: &'static str,
+    _r: PhantomData<R>,
+}
 
-impl MessageLoggingLayer {
-    pub fn new() -> Self {
-        Self {}
+impl<R> MessageLoggingLayer<R> {
+    pub fn new(prefix_msg: &'static str) -> Self {
+        Self {
+            prefix_msg,
+            _r: PhantomData,
+        }
     }
 }
 
-impl<S> Layer<S> for MessageLoggingLayer {
+impl<S, R> Layer<S> for MessageLoggingLayer<R>
+where
+    S: Service<R>,
+    R: Display,
+{
     type Service = MessageLoggingService<S>;
 
     fn layer(&self, service: S) -> Self::Service {
-        MessageLoggingService::new(service)
+        MessageLoggingService::new(self.prefix_msg, service)
     }
 }
 
 #[derive(Clone)]
 pub struct MessageLoggingService<S> {
+    prefix_msg: &'static str,
     inner: S,
 }
 
 impl<S> MessageLoggingService<S> {
-    pub fn new(service: S) -> Self {
-        Self { inner: service }
+    pub fn new(prefix_msg: &'static str, service: S) -> Self {
+        Self {
+            inner: service,
+            prefix_msg,
+        }
     }
 }
 
-impl<S> Service<DhtOutboundMessage> for MessageLoggingService<S>
+impl<S, R> Service<R> for MessageLoggingService<S>
 where
-    S: Service<DhtOutboundMessage, Response = ()> + Clone,
-    S::Error: Into<PipelineError>,
+    S: Service<R> + Clone,
+    R: Display,
 {
-    type Error = PipelineError;
-    type Response = ();
+    type Error = S::Error;
+    type Response = S::Response;
 
     type Future = impl Future<Output = Result<Self::Response, Self::Error>>;
 
@@ -72,51 +83,12 @@ where
         Poll::Ready(Ok(()))
     }
 
-    fn call(&mut self, msg: DhtOutboundMessage) -> Self::Future {
-        Self::handle_message(self.inner.clone(), msg)
-    }
-}
-
-impl<S> MessageLoggingService<S>
-where
-    S: Service<DhtOutboundMessage, Response = ()>,
-    S::Error: Into<PipelineError>,
-{
-    async fn handle_message(mut next_service: S, mut message: DhtOutboundMessage) -> Result<(), PipelineError> {
-        trace!(target: LOG_TARGET, "Outbound message: {}", message);
-
-        next_service.oneshot(message).await.map_err(Into::into)
-    }
-}
-
-impl<S> Service<DhtInboundMessage> for MessageLoggingService<S>
-where
-    S: Service<DhtInboundMessage, Response = ()> + Clone,
-    S::Error: Into<PipelineError>,
-{
-    type Error = PipelineError;
-    type Response = ();
-
-    type Future = impl Future<Output = Result<Self::Response, Self::Error>>;
-
-    fn poll_ready(&mut self, _: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
-        Poll::Ready(Ok(()))
-    }
-
-    fn call(&mut self, msg: DhtInboundMessage) -> Self::Future {
-        Self::handle_message_inbound(self.inner.clone(), msg)
-    }
-}
-
-impl<S> MessageLoggingService<S>
-where
-    S: Service<DhtInboundMessage, Response = ()>,
-    S::Error: Into<PipelineError>,
-{
-    async fn handle_message_inbound(mut next_service: S, mut message: DhtInboundMessage) -> Result<(), PipelineError> {
-        trace!(target: LOG_TARGET, "Inbound message: {}", message);
-
-        next_service.ready().await.map_err(Into::into)?;
-        next_service.call(message).await.map_err(Into::into)
+    fn call(&mut self, msg: R) -> Self::Future {
+        trace!(target: LOG_TARGET, "{}{}", self.prefix_msg, msg);
+        let mut inner = self.inner.clone();
+        async move {
+            inner.ready().await?;
+            inner.call(msg).await
+        }
     }
 }

--- a/comms/dht/src/proto/mod.rs
+++ b/comms/dht/src/proto/mod.rs
@@ -21,6 +21,7 @@
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 use crate::proto::envelope::Network;
+use std::fmt;
 
 #[path = "tari.dht.envelope.rs"]
 pub mod envelope;
@@ -56,5 +57,13 @@ impl envelope::Network {
             Network::LocalTest => true,
             _ => false,
         }
+    }
+}
+
+//---------------------------------- RejectMessage --------------------------------------------//
+
+impl fmt::Display for dht::RejectMessage {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "RejectMessage(Reason = {})", self.reason)
     }
 }


### PR DESCRIPTION
- Shorter code in the logging layer. Unfortunately, could not avoid the
  service clone (cheap anyway).
- Added better log for explicit rejection of messages.
- Fixed up some code warnings