### PR TITLE
Async Mempool

### DIFF
--- a/base_layer/core/src/mempool/async_mempool.rs
+++ b/base_layer/core/src/mempool/async_mempool.rs
@@ -1,0 +1,71 @@
+// Copyright 2019. The Tari Project
+//
+// Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+// following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+// disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+// following disclaimer in the documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+// products derived from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+// INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+// WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+// USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+use crate::{
+    blocks::Block,
+    chain_storage::BlockchainBackend,
+    mempool::{error::MempoolError, Mempool, StatsResponse, TxStorageResponse},
+    transactions::{transaction::Transaction, types::Signature},
+};
+use std::sync::Arc;
+
+macro_rules! make_async {
+    ($fn:ident($($param1:ident:$ptype1:ty,$param2:ident:$ptype2:ty),+) -> $rtype:ty) => {
+        pub async fn $fn<T>(mp: Mempool<T>, $($param1: $ptype1, $param2: $ptype2),+) -> Result<$rtype, MempoolError>
+        where T: BlockchainBackend + 'static {
+            tokio::task::spawn_blocking(move || mp.$fn($($param1,$param2),+))
+                .await
+                .or_else(|err| Err(MempoolError::BlockingTaskSpawnError(err.to_string())))
+                .and_then(|inner_result| inner_result)
+        }
+    };
+
+    ($fn:ident($($param:ident:$ptype:ty),+) -> $rtype:ty) => {
+        pub async fn $fn<T>(mp: Mempool<T>, $($param: $ptype),+) -> Result<$rtype, MempoolError>
+        where T: BlockchainBackend + 'static {
+            tokio::task::spawn_blocking(move || mp.$fn($($param),+))
+                .await
+                .or_else(|err| Err(MempoolError::BlockingTaskSpawnError(err.to_string())))
+                .and_then(|inner_result| inner_result)
+        }
+    };
+
+    ($fn:ident() -> $rtype:ty) => {
+        pub async fn $fn<T>(mp: Mempool<T>) -> Result<$rtype, MempoolError>
+        where T: BlockchainBackend + 'static {
+            tokio::task::spawn_blocking(move || {
+                mp.$fn()
+            })
+            .await
+            .or_else(|err| Err(MempoolError::BlockingTaskSpawnError(err.to_string())))
+            .and_then(|inner_result| inner_result)
+        }
+    };
+}
+
+make_async!(insert(tx: Arc<Transaction>) -> ());
+make_async!(process_published_block(published_block: Block) -> ());
+make_async!(process_reorg(removed_blocks: Vec<Block>, new_blocks: Vec<Block>) -> ());
+make_async!(snapshot() -> Vec<Arc<Transaction>>);
+make_async!(retrieve(total_weight: u64) -> Vec<Arc<Transaction>>);
+make_async!(has_tx_with_excess_sig(excess_sig: Signature) -> TxStorageResponse);
+make_async!(stats() -> StatsResponse);

--- a/base_layer/core/src/mempool/error.rs
+++ b/base_layer/core/src/mempool/error.rs
@@ -43,4 +43,6 @@ pub enum MempoolError {
     /// The Blockchain height is undefined
     ChainHeightUndefined,
     ValidationError,
+    #[error(msg_embedded, non_std, no_from)]
+    BlockingTaskSpawnError(String),
 }

--- a/base_layer/core/src/mempool/mod.rs
+++ b/base_layer/core/src/mempool/mod.rs
@@ -38,6 +38,11 @@ mod priority;
 mod reorg_pool;
 #[cfg(feature = "base_node")]
 mod unconfirmed_pool;
+
+// public modules
+#[cfg(feature = "base_node")]
+pub mod async_mempool;
+
 // Public re-exports
 #[cfg(feature = "base_node")]
 pub use self::config::{MempoolConfig, MempoolServiceConfig};

--- a/base_layer/core/src/mempool/service/service.rs
+++ b/base_layer/core/src/mempool/service/service.rs
@@ -101,7 +101,7 @@ where
 
 /// The Mempool Service is responsible for handling inbound requests and responses and for sending new requests to the
 /// Mempools of remote Base nodes.
-pub struct MempoolService<B: BlockchainBackend> {
+pub struct MempoolService<B: BlockchainBackend + 'static> {
     executor: runtime::Handle,
     outbound_message_service: OutboundMessageRequester,
     inbound_handlers: MempoolInboundHandlers<B>,
@@ -112,7 +112,7 @@ pub struct MempoolService<B: BlockchainBackend> {
 }
 
 impl<B> MempoolService<B>
-where B: BlockchainBackend
+where B: BlockchainBackend + 'static
 {
     pub fn new(
         executor: runtime::Handle,

--- a/base_layer/core/tests/mining.rs
+++ b/base_layer/core/tests/mining.rs
@@ -92,7 +92,10 @@ fn mining() {
             .await
             .unwrap();
         async_assert_eventually!(
-            alice_node.mempool.has_tx_with_excess_sig(&tx1_excess_sig).unwrap(),
+            alice_node
+                .mempool
+                .has_tx_with_excess_sig(tx1_excess_sig.clone())
+                .unwrap(),
             expect = TxStorageResponse::UnconfirmedPool,
             max_attempts = 20,
             interval = Duration::from_millis(1000)
@@ -135,7 +138,7 @@ fn mining() {
         }
         assert!(found_tx_outputs == tx1.body.outputs().len());
         assert_eq!(
-            alice_node.mempool.has_tx_with_excess_sig(&tx1_excess_sig).unwrap(),
+            alice_node.mempool.has_tx_with_excess_sig(tx1_excess_sig).unwrap(),
             TxStorageResponse::ReorgPool
         );
 

--- a/base_layer/core/tests/wallet.rs
+++ b/base_layer/core/tests/wallet.rs
@@ -282,7 +282,7 @@ fn wallet_base_node_integration_test() {
         let tx_excess_sig = tx.transaction.body.kernels()[0].excess_sig.clone();
         runtime.block_on(async {
             async_assert_eventually!(
-                base_node.mempool.has_tx_with_excess_sig(&tx_excess_sig).unwrap(),
+                base_node.mempool.has_tx_with_excess_sig(tx_excess_sig.clone()).unwrap(),
                 expect = TxStorageResponse::UnconfirmedPool,
                 max_attempts = 20,
                 interval = Duration::from_millis(1000)

--- a/base_layer/wallet_ffi/src/lib.rs
+++ b/base_layer/wallet_ffi/src/lib.rs
@@ -132,7 +132,6 @@ use tari_comms::{
     peer_manager::{NodeIdentity, PeerFeatures},
     socks,
     tor,
-    tor::TorIdentity,
 };
 use tari_comms_dht::DhtConfig;
 use tari_core::transactions::{tari_amount::MicroTari, types::CryptoFactories};
@@ -140,15 +139,8 @@ use tari_crypto::{
     keys::{PublicKey, SecretKey},
     tari_utilities::ByteArray,
 };
-use tari_p2p::{
-    initialization::CommsInitializationError,
-    transport::{TorConfig, TransportType},
-};
-use tari_utilities::{
-    hex,
-    hex::Hex,
-    message_format::{MessageFormat, MessageFormatError},
-};
+use tari_p2p::transport::{TorConfig, TransportType};
+use tari_utilities::{hex, hex::Hex, message_format::MessageFormat};
 use tari_wallet::{
     contacts_service::storage::{database::Contact, sqlite_db::ContactsServiceSqliteDatabase},
     error::WalletError,


### PR DESCRIPTION
## Description
- Added async_mempool for spawning blocking threads for the mempool functions.
- All Mempool calls in the mempool service inbound handlers were changed to the async alternatives.
- The base node inbound handlers were also updated to make use of the async versions.
- The mempool process_published_block/s and has_tx_with_excess_sig functions were changed to take as input owned copies of the signature and block to allow the async calls to be constructed.
- A static lifetime constraint was added to the blockchain backend generic of the mempool service and inbound handlers to enable async mempool calls. 

## Motivation and Context
Making the mempool functions async might resolve some of the blocking behaviour experienced in the base node application.

## How Has This Been Tested?
None, existing tests are still functioning.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [x] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch
* [x] I ran `cargo-fmt --all` before pushing
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
