### PR TITLE
Add a status field to Pending Inbound and Outbound transactions

### DIFF
--- a/base_layer/wallet/src/transaction_service/service.rs
+++ b/base_layer/wallet/src/transaction_service/service.rs
@@ -557,6 +557,7 @@ where
                         amount,
                         fee: sender_protocol.get_fee_amount()?,
                         sender_protocol,
+                        status: TransactionStatus::Pending,
                         message,
                         timestamp: Utc::now().naive_utc(),
                     };
@@ -585,6 +586,7 @@ where
                     amount,
                     fee: sender_protocol.get_fee_amount()?,
                     sender_protocol: sender_protocol.clone(),
+                    status: TransactionStatus::Pending,
                     message: message.clone(),
                     timestamp: Utc::now().naive_utc(),
                 };
@@ -742,6 +744,7 @@ where
                 source_public_key: source_pubkey.clone(),
                 amount,
                 receiver_protocol: rtp.clone(),
+                status: TransactionStatus::Pending,
                 message: data.message,
                 timestamp: Utc::now().naive_utc(),
             };
@@ -1537,6 +1540,7 @@ where
             source_public_key,
             amount,
             receiver_protocol: rtp,
+            status: TransactionStatus::Pending,
             message: "".to_string(),
             timestamp: Utc::now().naive_utc(),
         };

--- a/base_layer/wallet/src/transaction_service/storage/database.rs
+++ b/base_layer/wallet/src/transaction_service/storage/database.rs
@@ -99,6 +99,8 @@ pub enum TransactionStatus {
     Mined,
     /// This transaction was generated as part of importing a spendable UTXO
     Imported,
+    /// This transaction is still being negotiated by the parties
+    Pending,
 }
 
 impl TryFrom<i32> for TransactionStatus {
@@ -110,8 +112,15 @@ impl TryFrom<i32> for TransactionStatus {
             1 => Ok(TransactionStatus::Broadcast),
             2 => Ok(TransactionStatus::Mined),
             3 => Ok(TransactionStatus::Imported),
+            4 => Ok(TransactionStatus::Pending),
             _ => Err(TransactionStorageError::ConversionError),
         }
+    }
+}
+
+impl Default for TransactionStatus {
+    fn default() -> Self {
+        TransactionStatus::Pending
     }
 }
 
@@ -121,6 +130,7 @@ pub struct InboundTransaction {
     pub source_public_key: CommsPublicKey,
     pub amount: MicroTari,
     pub receiver_protocol: ReceiverTransactionProtocol,
+    pub status: TransactionStatus,
     pub message: String,
     pub timestamp: NaiveDateTime,
 }
@@ -132,6 +142,7 @@ pub struct OutboundTransaction {
     pub amount: MicroTari,
     pub fee: MicroTari,
     pub sender_protocol: SenderTransactionProtocol,
+    pub status: TransactionStatus,
     pub message: String,
     pub timestamp: NaiveDateTime,
 }
@@ -200,6 +211,7 @@ impl From<CompletedTransaction> for InboundTransaction {
             source_public_key: ct.source_public_key,
             amount: ct.amount,
             receiver_protocol: ReceiverTransactionProtocol::new_placeholder(),
+            status: ct.status,
             message: ct.message,
             timestamp: ct.timestamp,
         }
@@ -214,6 +226,7 @@ impl From<CompletedTransaction> for OutboundTransaction {
             amount: ct.amount,
             fee: ct.fee,
             sender_protocol: SenderTransactionProtocol::new_placeholder(),
+            status: ct.status,
             message: ct.message,
             timestamp: ct.timestamp,
         }

--- a/base_layer/wallet/src/transaction_service/storage/sqlite_db.rs
+++ b/base_layer/wallet/src/transaction_service/storage/sqlite_db.rs
@@ -541,6 +541,7 @@ impl TryFrom<InboundTransactionSql> for InboundTransaction {
                 .map_err(|_| TransactionStorageError::ConversionError)?,
             amount: MicroTari::from(i.amount as u64),
             receiver_protocol: serde_json::from_str(&i.receiver_protocol)?,
+            status: TransactionStatus::Pending,
             message: i.message,
             timestamp: i.timestamp,
         })
@@ -632,6 +633,7 @@ impl TryFrom<OutboundTransactionSql> for OutboundTransaction {
             amount: MicroTari::from(i.amount as u64),
             fee: MicroTari::from(i.fee as u64),
             sender_protocol: serde_json::from_str(&i.sender_protocol)?,
+            status: TransactionStatus::Pending,
             message: i.message,
             timestamp: i.timestamp,
         })
@@ -938,6 +940,7 @@ mod test {
             amount,
             fee: stp.clone().get_fee_amount().unwrap(),
             sender_protocol: stp.clone(),
+            status: TransactionStatus::Pending,
             message: "Yo!".to_string(),
             timestamp: Utc::now().naive_utc(),
         };
@@ -948,6 +951,8 @@ mod test {
             amount,
             fee: stp.clone().get_fee_amount().unwrap(),
             sender_protocol: stp.clone(),
+            status: TransactionStatus::Pending,
+
             message: "Hey!".to_string(),
             timestamp: Utc::now().naive_utc(),
         })
@@ -983,6 +988,7 @@ mod test {
             source_public_key: PublicKey::from_secret_key(&PrivateKey::random(&mut OsRng)),
             amount,
             receiver_protocol: rtp.clone(),
+            status: TransactionStatus::Pending,
             message: "Yo!".to_string(),
             timestamp: Utc::now().naive_utc(),
         };
@@ -991,6 +997,7 @@ mod test {
             source_public_key: PublicKey::from_secret_key(&PrivateKey::random(&mut OsRng)),
             amount,
             receiver_protocol: rtp.clone(),
+            status: TransactionStatus::Pending,
             message: "Hey!".to_string(),
             timestamp: Utc::now().naive_utc(),
         };

--- a/base_layer/wallet/tests/transaction_service/storage.rs
+++ b/base_layer/wallet/tests/transaction_service/storage.rs
@@ -88,6 +88,7 @@ pub fn test_db_backend<T: TransactionBackend + 'static>(backend: T) {
             amount: amounts[i].clone(),
             fee: stp.clone().get_fee_amount().unwrap(),
             sender_protocol: stp.clone(),
+            status: TransactionStatus::Pending,
             message: messages[i].clone(),
             timestamp: Utc::now().naive_utc(),
         });
@@ -135,6 +136,7 @@ pub fn test_db_backend<T: TransactionBackend + 'static>(backend: T) {
             source_public_key: PublicKey::from_secret_key(&PrivateKey::random(&mut OsRng)),
             amount: amounts[i].clone(),
             receiver_protocol: rtp.clone(),
+            status: TransactionStatus::Pending,
             message: messages[i].clone(),
             timestamp: Utc::now().naive_utc(),
         });

--- a/base_layer/wallet_ffi/wallet.h
+++ b/base_layer/wallet_ffi/wallet.h
@@ -200,9 +200,11 @@ const char *completed_transaction_get_message(struct TariCompletedTransaction *t
 // | Value | Interpretation |
 // |---|---|
 // |  -1 | TxNullError |
-// |   0 | Completed |
-// |   1 | Broadcast |
-// |   2 | Mined |
+// |   0 | Completed   |
+// |   1 | Broadcast   |
+// |   2 | Mined       |
+// |   3 | Imported    |
+// |   4 | Pending     |
 int completed_transaction_get_status(struct TariCompletedTransaction *transaction,int* error_out);
 
 // Gets the TransactionID of a TariCompletedTransaction
@@ -245,6 +247,17 @@ const char *pending_outbound_transaction_get_message(struct TariPendingOutboundT
 // Gets the timestamp of a TariPendingOutboundTransaction
 unsigned long long pending_outbound_transaction_get_timestamp(struct TariPendingOutboundTransaction *transaction,int* error_out);
 
+// Gets the status of a TariPendingOutboundTransaction
+// | Value | Interpretation |
+// |---|---|
+// |  -1 | TxNullError |
+// |   0 | Completed   |
+// |   1 | Broadcast   |
+// |   2 | Mined       |
+// |   3 | Imported    |
+// |   4 | Pending     |
+int pending_outbound_transaction_get_status(struct TariPendingOutboundTransaction *transaction,int* error_out);
+
 // Frees memory for a TariPendingOutboundTactions
 void pending_outbound_transaction_destroy(struct TariPendingOutboundTransaction *transaction);
 
@@ -275,6 +288,17 @@ unsigned long long pending_inbound_transaction_get_amount(struct TariPendingInbo
 
 // Gets the timestamp of a TariPendingInboundTransaction
 unsigned long long pending_inbound_transaction_get_timestamp(struct TariPendingInboundTransaction *transaction,int* error_out);
+
+// Gets the status of a TariPendingInboundTransaction
+// | Value | Interpretation |
+// |---|---|
+// |  -1 | TxNullError |
+// |   0 | Completed   |
+// |   1 | Broadcast   |
+// |   2 | Mined       |
+// |   3 | Imported    |
+// |   4 | Pending     |
+int pending_Inbound_transaction_get_status(struct TariPendingInboundTransaction *transaction,int* error_out);
 
 // Frees memory for a TariPendingInboundTransaction
 void pending_inbound_transaction_destroy(struct TariPendingInboundTransaction *transaction);


### PR DESCRIPTION
## Description
Now that Completed transaction can appear in the pending lists until they are mined it will be useful to find the status of these pending transaction via the FFI

## How Has This Been Tested?
Updated the wallet_ffi integration test to check it works.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch
* [x] I ran `cargo-fmt --all` before pushing
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
