### PR TITLE
Moved exit for --create_id and --init arguments.

### DIFF
--- a/applications/tari_base_node/src/main.rs
+++ b/applications/tari_base_node/src/main.rs
@@ -128,15 +128,6 @@ fn main_inner() -> Result<(), ExitCodes> {
         },
     };
 
-    // Exit if create_id or init arguments were run
-    if arguments.create_id {
-        info!(target: LOG_TARGET, "Completed create_id, exiting");
-        return Ok(());
-    } else if arguments.init {
-        info!(target: LOG_TARGET, "Completed init, exiting");
-        return Ok(());
-    }
-
     // Set up the Tokio runtime
     let mut rt = match setup_runtime(&node_config) {
         Ok(rt) => rt,
@@ -155,6 +146,16 @@ fn main_inner() -> Result<(), ExitCodes> {
                 ExitCodes::UnknownError
             })
     })?;
+
+    // Exit if create_id or init arguments were run
+    if arguments.create_id {
+        info!(target: LOG_TARGET, "Completed create_id, exiting");
+        return Ok(());
+    } else if arguments.init {
+        info!(target: LOG_TARGET, "Completed init, exiting");
+        return Ok(());
+    }
+
     // Run, node, run!
     let parser = Parser::new(rt.handle().clone(), &ctx);
     let flag = ctx.interrupt_flag();


### PR DESCRIPTION

## Description
Fixes bug where writing of the configuration files wasn't being reached.

## Motivation and Context
Bug fix

## How Has This Been Tested?
```
cargo run -- --create_id
cargo run
```

## Types of changes
* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
* [x] I'm merging against the `development` branch.
* [x] I ran `cargo-fmt --all` before pushing.
* [x] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
