### PR TITLE
Update default log to include yamux into the network log

### DIFF
--- a/common/logging/log4rs-sample.yml
+++ b/common/logging/log4rs-sample.yml
@@ -93,6 +93,12 @@ loggers:
     appenders:
       - network
     additive: false
+    # Route log events sent to the "p2p" logger to the "network" appender
+  yamux:
+    level: trace
+    appenders:
+      - network
+    additive: false
  # Route log events sent to the "mio" logger to the "other" appender
   mio:
     level: trace


### PR DESCRIPTION
## Description
This PR updates the default log4rs settings file to include yamux logs into the network layer logs.

## Motivation and Context
Yamux logs does not belong in the base_layer logs



## Types of changes
* [ ] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
* [x] I'm merging against the `development` branch.
* [ ] I ran `cargo-fmt --all` before pushing.
* [ ] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
