### PR TITLE
Public Key from Emoji String

### DIFF
--- a/base_layer/wallet_ffi/src/error.rs
+++ b/base_layer/wallet_ffi/src/error.rs
@@ -53,6 +53,8 @@ pub enum InterfaceError {
     /// An error has occurred when attempting to deserialize input data
     #[error(non_std, no_from)]
     DeserializationError(String),
+    /// Emoji ID is invalid
+    InvalidEmojiId,
 }
 
 /// This struct is meant to hold an error for use by FFI client applications. The error has an integer code and string
@@ -85,6 +87,10 @@ impl From<InterfaceError> for LibWalletError {
             },
             InterfaceError::DeserializationError(_) => Self {
                 code: 5,
+                message: format!("{:?}", v),
+            },
+            InterfaceError::InvalidEmojiId => Self {
+                code: 6,
                 message: format!("{:?}", v),
             },
         }

--- a/base_layer/wallet_ffi/wallet.h
+++ b/base_layer/wallet_ffi/wallet.h
@@ -135,7 +135,10 @@ struct TariPublicKey *public_key_from_hex(const char *hex,int* error_out);
 void public_key_destroy(struct TariPublicKey *pk);
 
 //Converts a TariPublicKey to char array in emoji format
-char *public_key_to_emoji_node_id(struct TariPublicKey *pk, int* error_out);
+char *public_key_to_emoji_id(struct TariPublicKey *pk, int* error_out);
+
+// Converts a char array in emoji format to a public key
+struct TariPublicKey *emoji_id_to_public_key(const char *emoji,  int* error_out);
 
 /// -------------------------------- TariPrivateKey ----------------------------------------------- ///
 


### PR DESCRIPTION

## Description
Added method to FFI to convert an emoji string back into a public key.

## Motivation and Context
Needed to get public keys back from 33 char emoji_ids

## How Has This Been Tested?
cargo test --all --all-features

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch.
* [x] I ran `cargo-fmt --all` before pushing.
* [x] I have squashed my commits into a single commit.
* [x] My change requires a change to the documentation.
* [x] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
