### PR TITLE
Async message handling in mempool service

### DIFF
--- a/base_layer/core/src/base_node/service/error.rs
+++ b/base_layer/core/src/base_node/service/error.rs
@@ -20,7 +20,7 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use crate::base_node::{comms_interface::CommsInterfaceError, service::service_request::WaitingRequestError};
+use crate::{base_node::comms_interface::CommsInterfaceError, helpers::WaitingRequestError};
 use derive_error::Error;
 use tari_comms_dht::outbound::DhtOutboundError;
 

--- a/base_layer/core/src/base_node/service/mod.rs
+++ b/base_layer/core/src/base_node/service/mod.rs
@@ -29,5 +29,5 @@ mod service_response;
 // Public re-exports
 pub use initializer::BaseNodeServiceInitializer;
 pub use service::{BaseNodeService, BaseNodeServiceConfig};
-pub use service_request::{BaseNodeServiceRequest, RequestKey};
+pub use service_request::BaseNodeServiceRequest;
 pub use service_response::BaseNodeServiceResponse;

--- a/base_layer/core/src/base_node/service/service_request.rs
+++ b/base_layer/core/src/base_node/service/service_request.rs
@@ -20,99 +20,12 @@
 //  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 //  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use crate::base_node::comms_interface::{CommsInterfaceError, NodeCommsRequest, NodeCommsResponse};
-use derive_error::Error;
-use futures::channel::oneshot::Sender as OneshotSender;
-use rand::RngCore;
+use crate::{base_node::comms_interface::NodeCommsRequest, helpers::RequestKey};
 use serde::{Deserialize, Serialize};
-use std::{
-    collections::HashMap,
-    sync::{Arc, RwLock},
-};
-
-pub type RequestKey = u64;
-
-/// Generate a new random request key to uniquely identify a request and its corresponding responses.
-pub fn generate_request_key<R>(rng: &mut R) -> RequestKey
-where R: RngCore {
-    rng.next_u64()
-}
-
-/// The WaitingRequest is used to link incoming responses to the original sent request. When enough responses have been
-/// received or the request timeout has been received then the received responses are returned on the reply_tx.
-#[derive(Debug)]
-pub struct WaitingRequest {
-    pub(crate) reply_tx: Option<OneshotSender<Result<Vec<NodeCommsResponse>, CommsInterfaceError>>>,
-    pub(crate) received_responses: Vec<NodeCommsResponse>,
-    pub(crate) desired_resp_count: usize,
-}
 
 /// Request type for a received BaseNodeService request.
 #[derive(Debug, Serialize, Deserialize)]
 pub struct BaseNodeServiceRequest {
     pub request_key: RequestKey,
     pub request: NodeCommsRequest,
-}
-
-#[derive(Debug, Error)]
-pub enum WaitingRequestError {
-    /// A problem has been encountered with the storage backend.
-    #[error(non_std, no_from)]
-    BackendError(String),
-}
-
-/// WaitingRequests is used to keep track of a set of WaitingRequests.
-#[derive(Clone)]
-pub struct WaitingRequests {
-    requests: Arc<RwLock<HashMap<RequestKey, WaitingRequest>>>,
-}
-
-impl WaitingRequests {
-    /// Create a new set of waiting requests.
-    pub fn new() -> Self {
-        Self {
-            requests: Arc::new(RwLock::new(HashMap::new())),
-        }
-    }
-
-    /// Insert a new waiting request.
-    pub fn insert(&self, key: RequestKey, waiting_request: WaitingRequest) -> Result<(), WaitingRequestError> {
-        self.requests
-            .write()
-            .map_err(|e| WaitingRequestError::BackendError(e.to_string()))?
-            .insert(key, waiting_request);
-        Ok(())
-    }
-
-    /// Remove the waiting request corresponding to the provided key.
-    pub fn remove(&self, key: RequestKey) -> Result<Option<WaitingRequest>, WaitingRequestError> {
-        Ok(self
-            .requests
-            .write()
-            .map_err(|e| WaitingRequestError::BackendError(e.to_string()))?
-            .remove(&key))
-    }
-
-    /// Check if a sufficient number of responses have been received to complete the waiting request. Also, add the
-    /// newly received response to the specified waiting request.
-    pub fn check_complete(
-        &self,
-        key: RequestKey,
-        response: NodeCommsResponse,
-    ) -> Result<Option<WaitingRequest>, WaitingRequestError>
-    {
-        let mut lock = self
-            .requests
-            .write()
-            .map_err(|e| WaitingRequestError::BackendError(e.to_string()))?;
-        let mut finalize_request = false;
-        if let Some(waiting_request) = lock.get_mut(&key) {
-            waiting_request.received_responses.push(response);
-            finalize_request = waiting_request.received_responses.len() >= waiting_request.desired_resp_count;
-        }
-        if finalize_request {
-            return Ok(lock.remove(&key));
-        }
-        Ok(None)
-    }
 }

--- a/base_layer/core/src/base_node/service/service_response.rs
+++ b/base_layer/core/src/base_node/service/service_response.rs
@@ -20,7 +20,7 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use crate::base_node::{comms_interface::NodeCommsResponse, service::service_request::RequestKey};
+use crate::{base_node::comms_interface::NodeCommsResponse, helpers::RequestKey};
 use serde::{Deserialize, Serialize};
 
 /// Response type for a received BaseNodeService requests

--- a/base_layer/core/src/helpers/mod.rs
+++ b/base_layer/core/src/helpers/mod.rs
@@ -24,6 +24,7 @@
 //! integration test folder.
 
 mod mock_backend;
+mod waiting_requests;
 
 use crate::{
     blocks::{Block, BlockBuilder, BlockHeader},
@@ -34,6 +35,7 @@ use crate::{
 };
 
 pub use mock_backend::MockBackend;
+pub use waiting_requests::{generate_request_key, RequestKey, WaitingRequest, WaitingRequestError, WaitingRequests};
 
 /// Create a partially constructed block using the provided set of transactions
 /// is chain_block, or rename it to `create_orphan_block` and drop the prev_block argument

--- a/base_layer/core/src/helpers/waiting_requests.rs
+++ b/base_layer/core/src/helpers/waiting_requests.rs
@@ -1,0 +1,122 @@
+//  Copyright 2019 The Tari Project
+//
+//  Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+//  following conditions are met:
+//
+//  1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+//  disclaimer.
+//
+//  2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+//  following disclaimer in the documentation and/or other materials provided with the distribution.
+//
+//  3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+//  products derived from this software without specific prior written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+//  INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+//  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+//  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+//  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+//  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+//  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+use derive_error::Error;
+use futures::channel::oneshot::Sender as OneshotSender;
+use rand::RngCore;
+use std::{
+    collections::HashMap,
+    sync::{Arc, RwLock},
+};
+
+pub type RequestKey = u64;
+
+/// Generate a new random request key to uniquely identify a request and its corresponding responses.
+pub fn generate_request_key<R>(rng: &mut R) -> RequestKey
+where R: RngCore {
+    rng.next_u64()
+}
+
+/// The WaitingRequest is used to link incoming responses to the original sent request. When enough responses have been
+/// received or the request timeout has been received then the received responses are returned on the reply_tx.
+#[derive(Debug)]
+pub struct WaitingRequest<T, R> {
+    pub(crate) reply_tx: Option<OneshotSender<T>>,
+    pub(crate) received_responses: Vec<R>,
+    pub(crate) desired_resp_count: usize,
+}
+
+#[derive(Debug, Error)]
+pub enum WaitingRequestError {
+    /// A problem has been encountered with the storage backend.
+    #[error(non_std, no_from)]
+    BackendError(String),
+}
+
+/// WaitingRequests is used to keep track of a set of WaitingRequests.
+pub struct WaitingRequests<T, R> {
+    requests: Arc<RwLock<HashMap<RequestKey, WaitingRequest<T, R>>>>,
+}
+
+impl<T, R> WaitingRequests<T, R> {
+    /// Create a new set of waiting requests.
+    pub fn new() -> Self {
+        Self {
+            requests: Arc::new(RwLock::new(HashMap::new())),
+        }
+    }
+
+    /// Insert a new waiting request.
+    pub fn insert(&self, key: RequestKey, waiting_request: WaitingRequest<T, R>) -> Result<(), WaitingRequestError> {
+        self.requests
+            .write()
+            .map_err(|e| WaitingRequestError::BackendError(e.to_string()))?
+            .insert(key, waiting_request);
+        Ok(())
+    }
+
+    /// Remove the waiting request corresponding to the provided key.
+    pub fn remove(&self, key: RequestKey) -> Result<Option<WaitingRequest<T, R>>, WaitingRequestError> {
+        Ok(self
+            .requests
+            .write()
+            .map_err(|e| WaitingRequestError::BackendError(e.to_string()))?
+            .remove(&key))
+    }
+
+    /// Check if a sufficient number of responses have been received to complete the waiting request. Also, add the
+    /// newly received response to the specified waiting request.
+    pub fn check_complete(
+        &self,
+        key: RequestKey,
+        response: R,
+    ) -> Result<Option<WaitingRequest<T, R>>, WaitingRequestError>
+    {
+        let mut lock = self
+            .requests
+            .write()
+            .map_err(|e| WaitingRequestError::BackendError(e.to_string()))?;
+        let mut finalize_request = false;
+        if let Some(waiting_request) = lock.get_mut(&key) {
+            waiting_request.received_responses.push(response);
+            finalize_request = waiting_request.received_responses.len() >= waiting_request.desired_resp_count;
+        }
+        if finalize_request {
+            return Ok(lock.remove(&key));
+        }
+        Ok(None)
+    }
+}
+
+impl<T, R> Clone for WaitingRequests<T, R> {
+    fn clone(&self) -> Self {
+        Self {
+            requests: self.requests.clone(),
+        }
+    }
+}
+
+impl<T, R> Default for WaitingRequests<T, R> {
+    fn default() -> Self {
+        WaitingRequests::new()
+    }
+}

--- a/base_layer/core/src/mempool/service/error.rs
+++ b/base_layer/core/src/mempool/service/error.rs
@@ -20,7 +20,7 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use crate::mempool::MempoolError;
+use crate::{helpers::WaitingRequestError, mempool::MempoolError};
 use derive_error::Error;
 use tari_comms_dht::outbound::DhtOutboundError;
 use tari_service_framework::reply_channel::TransportChannelError;
@@ -41,4 +41,5 @@ pub enum MempoolServiceError {
     TransportChannelError(TransportChannelError),
     /// Failed to send broadcast message
     BroadcastFailed,
+    WaitingRequestError(WaitingRequestError),
 }

--- a/base_layer/core/src/mempool/service/inbound_handlers.rs
+++ b/base_layer/core/src/mempool/service/inbound_handlers.rs
@@ -100,3 +100,15 @@ where T: BlockchainBackend + 'static
         Ok(())
     }
 }
+
+impl<T> Clone for MempoolInboundHandlers<T>
+where T: BlockchainBackend + 'static
+{
+    fn clone(&self) -> Self {
+        // All members use Arc's internally so calling clone should be cheap.
+        Self {
+            mempool: self.mempool.clone(),
+            outbound_nmi: self.outbound_nmi.clone(),
+        }
+    }
+}

--- a/base_layer/core/src/mempool/service/initializer.rs
+++ b/base_layer/core/src/mempool/service/initializer.rs
@@ -159,7 +159,6 @@ where T: BlockchainBackend + 'static
         let (outbound_request_sender_service, outbound_request_stream) = reply_channel::unbounded();
         let outbound_mp_interface =
             OutboundMempoolServiceInterface::new(outbound_request_sender_service, outbound_tx_sender_service);
-        let executer_clone = executor.clone(); // Give MempoolService access to the executor
         let config = self.config;
         let mempool = self.mempool.clone();
         let inbound_handlers = MempoolInboundHandlers::new(mempool, outbound_mp_interface.clone());
@@ -185,8 +184,7 @@ where T: BlockchainBackend + 'static
                 inbound_transaction_stream,
                 base_node.get_block_event_stream(),
             );
-            let service =
-                MempoolService::new(executer_clone, outbound_message_service, inbound_handlers, config).start(streams);
+            let service = MempoolService::new(outbound_message_service, inbound_handlers, config).start(streams);
             futures::pin_mut!(service);
             future::select(service, shutdown).await;
             info!(target: LOG_TARGET, "Mempool Service shutdown");

--- a/base_layer/core/src/mempool/service/mod.rs
+++ b/base_layer/core/src/mempool/service/mod.rs
@@ -44,5 +44,5 @@ pub use service::MempoolService;
 mod request;
 mod response;
 
-pub use request::{MempoolRequest, MempoolServiceRequest, RequestKey};
+pub use request::{MempoolRequest, MempoolServiceRequest};
 pub use response::{MempoolResponse, MempoolServiceResponse};

--- a/base_layer/core/src/mempool/service/request.rs
+++ b/base_layer/core/src/mempool/service/request.rs
@@ -20,18 +20,8 @@
 //  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 //  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use crate::transactions::types::Signature;
-use rand::RngCore;
+use crate::{helpers::RequestKey, transactions::types::Signature};
 use serde::{Deserialize, Serialize};
-
-pub type RequestKey = u64; // TODO: BaseNodeService and MempoolService uses RequestKey
-
-/// Generate a new random request key to uniquely identify a request and its corresponding responses.
-#[cfg(feature = "mempool_proto")]
-pub fn generate_request_key<R>(rng: &mut R) -> RequestKey
-where R: RngCore {
-    rng.next_u64()
-}
 
 /// API Request enum for Mempool requests.
 #[derive(Debug, Serialize, Deserialize)]

--- a/base_layer/core/src/mempool/service/response.rs
+++ b/base_layer/core/src/mempool/service/response.rs
@@ -20,7 +20,10 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use crate::mempool::{service::RequestKey, StatsResponse, TxStorageResponse};
+use crate::{
+    helpers::RequestKey,
+    mempool::{StatsResponse, TxStorageResponse},
+};
 use serde::{Deserialize, Serialize};
 
 /// API Response enum for Mempool responses.

--- a/base_layer/core/src/mempool/service/service.rs
+++ b/base_layer/core/src/mempool/service/service.rs
@@ -23,12 +23,12 @@
 use crate::{
     base_node::comms_interface::BlockEvent,
     chain_storage::BlockchainBackend,
+    helpers::{generate_request_key, RequestKey, WaitingRequest, WaitingRequests},
     mempool::{
         proto,
         service::{
             error::MempoolServiceError,
             inbound_handlers::MempoolInboundHandlers,
-            request::{generate_request_key, RequestKey},
             MempoolRequest,
             MempoolResponse,
         },
@@ -48,7 +48,7 @@ use futures::{
 };
 use log::*;
 use rand::rngs::OsRng;
-use std::{collections::HashMap, convert::TryInto, time::Duration};
+use std::{convert::TryInto, sync::Arc, time::Duration};
 use tari_broadcast_channel::Subscriber;
 use tari_comms::types::CommsPublicKey;
 use tari_comms_dht::{
@@ -56,9 +56,10 @@ use tari_comms_dht::{
     envelope::NodeDestination,
     outbound::{OutboundEncryption, OutboundMessageRequester},
 };
+use tari_crypto::ristretto::RistrettoPublicKey;
 use tari_p2p::{domain_message::DomainMessage, tari_message::TariMessageType};
 use tari_service_framework::RequestContext;
-use tokio::runtime;
+use tokio::task;
 
 const LOG_TARGET: &str = "c::mempool::service::service";
 
@@ -102,10 +103,9 @@ where
 /// The Mempool Service is responsible for handling inbound requests and responses and for sending new requests to the
 /// Mempools of remote Base nodes.
 pub struct MempoolService<B: BlockchainBackend + 'static> {
-    executor: runtime::Handle,
     outbound_message_service: OutboundMessageRequester,
     inbound_handlers: MempoolInboundHandlers<B>,
-    waiting_requests: HashMap<RequestKey, Option<OneshotSender<Result<MempoolResponse, MempoolServiceError>>>>,
+    waiting_requests: WaitingRequests<Result<MempoolResponse, MempoolServiceError>, MempoolResponse>,
     timeout_sender: Sender<RequestKey>,
     timeout_receiver_stream: Option<Receiver<RequestKey>>,
     config: MempoolServiceConfig,
@@ -115,7 +115,6 @@ impl<B> MempoolService<B>
 where B: BlockchainBackend + 'static
 {
     pub fn new(
-        executor: runtime::Handle,
         outbound_message_service: OutboundMessageRequester,
         inbound_handlers: MempoolInboundHandlers<B>,
         config: MempoolServiceConfig,
@@ -123,10 +122,9 @@ where B: BlockchainBackend + 'static
     {
         let (timeout_sender, timeout_receiver) = channel(100);
         Self {
-            executor,
             outbound_message_service,
             inbound_handlers,
-            waiting_requests: HashMap::new(),
+            waiting_requests: WaitingRequests::new(),
             timeout_sender,
             timeout_receiver_stream: Some(timeout_receiver),
             config,
@@ -165,60 +163,37 @@ where B: BlockchainBackend + 'static
             futures::select! {
                 // Outbound request messages from the OutboundMempoolServiceInterface
                 outbound_request_context = outbound_request_stream.select_next_some() => {
-                    let (request, reply_tx) = outbound_request_context.split();
-                    let _ = self.handle_outbound_request(reply_tx,request).await.or_else(|err| {
-                        error!(target: LOG_TARGET, "Failed to handle outbound request message: {:?}", err);
-                        Err(err)
-                    });
+                    self.spawn_handle_outbound_request(outbound_request_context);
                 },
 
                 // Outbound tx messages from the OutboundMempoolServiceInterface
                 outbound_tx_context = outbound_tx_stream.select_next_some() => {
-                    let (tx, excluded_peers) = outbound_tx_context;
-                    let _ = self.handle_outbound_tx(tx,excluded_peers).await.or_else(|err| {
-                        error!(target: LOG_TARGET, "Failed to handle outbound tx message {:?}",err);
-                        Err(err)
-                    });
+                    self.spawn_handle_outbound_tx(outbound_tx_context);
                 },
 
                 // Incoming request messages from the Comms layer
                 domain_msg = inbound_request_stream.select_next_some() => {
-                    let _ = self.handle_incoming_request(domain_msg).await.or_else(|err| {
-                        error!(target: LOG_TARGET, "Failed to handle incoming request message: {:?}", err);
-                        Err(err)
-                    });
+                    self.spawn_handle_incoming_request(domain_msg);
                 },
 
                 // Incoming response messages from the Comms layer
                 domain_msg = inbound_response_stream.select_next_some() => {
-                    let _ = self.handle_incoming_response(domain_msg.into_inner()).await.or_else(|err| {
-                        error!(target: LOG_TARGET, "Failed to handle incoming response message: {:?}", err);
-                        Err(err)
-                    });
+                    self.spawn_handle_incoming_response(domain_msg);
                 },
 
                 // Incoming transaction messages from the Comms layer
                 transaction_msg = inbound_transaction_stream.select_next_some() => {
-                    let _ = self.handle_incoming_transaction(transaction_msg).await.or_else(|err| {
-                        error!(target: LOG_TARGET, "Failed to handle incoming transaction message: {:?}", err);
-                        Err(err)
-                    });
+                    self.spawn_handle_incoming_tx(transaction_msg);
                 }
 
                 // Block events from local Base Node.
                 block_event = block_event_stream.select_next_some() => {
-                    let _ = self.handle_block_event(&block_event).await.or_else(|err| {
-                        error!(target: LOG_TARGET, "Failed to handle base node block event: {:?}", err);
-                        Err(err)
-                    });
+                    self.spawn_handle_block_event(block_event);
                 },
 
                 // Timeout events for waiting requests
                 timeout_request_key = timeout_receiver_stream.select_next_some() => {
-                    let _ =self.handle_request_timeout(timeout_request_key).await.or_else(|err| {
-                        error!(target: LOG_TARGET, "Failed to handle request timeout event: {:?}", err);
-                        Err(err)
-                    });
+                    self.spawn_handle_request_timeout(timeout_request_key);
                 },
 
                 complete => {
@@ -230,195 +205,318 @@ where B: BlockchainBackend + 'static
         Ok(())
     }
 
-    async fn handle_incoming_request(
-        &mut self,
-        domain_request_msg: DomainMessage<proto::MempoolServiceRequest>,
-    ) -> Result<(), MempoolServiceError>
+    fn spawn_handle_outbound_request(
+        &self,
+        request_context: RequestContext<MempoolRequest, Result<MempoolResponse, MempoolServiceError>>,
+    )
     {
-        let (origin_public_key, inner_msg) = domain_request_msg.into_origin_and_inner();
-
-        // Convert proto::MempoolServiceRequest to a MempoolServiceRequest
-        let request = inner_msg.request.ok_or_else(|| {
-            MempoolServiceError::InvalidRequest("Received invalid mempool service request".to_string())
-        })?;
-
-        let response = self
-            .inbound_handlers
-            .handle_request(&request.try_into().map_err(MempoolServiceError::InvalidRequest)?)
-            .await?;
-
-        let message = proto::MempoolServiceResponse {
-            request_key: inner_msg.request_key,
-            response: Some(response.into()),
-        };
-
-        self.outbound_message_service
-            .send_direct(
-                origin_public_key,
-                OutboundEncryption::EncryptForPeer,
-                OutboundDomainMessage::new(TariMessageType::MempoolResponse, message),
-            )
-            .await?;
-
-        Ok(())
-    }
-
-    async fn handle_incoming_response(
-        &mut self,
-        incoming_response: proto::MempoolServiceResponse,
-    ) -> Result<(), MempoolServiceError>
-    {
-        let proto::MempoolServiceResponse { request_key, response } = incoming_response;
-
-        match self.waiting_requests.remove(&request_key) {
-            Some(mut reply_tx) => {
-                if let Some(reply_tx) = reply_tx.take() {
-                    let response = response.and_then(|r| r.try_into().ok()).ok_or_else(|| {
-                        MempoolServiceError::InvalidResponse("Received an invalid Mempool response".to_string())
-                    })?;
-                    let _ = reply_tx.send(Ok(response).or_else(|resp| {
-                        error!(
-                            target: LOG_TARGET,
-                            "Failed to send outbound request (request key:{})  from Mempool service: {:?}",
-                            &request_key,
-                            resp
-                        );
-                        Err(resp)
-                    }));
-                }
-            },
-            None => {
-                info!(target: LOG_TARGET, "Discard incoming unmatched response");
-            },
-        }
-
-        Ok(())
-    }
-
-    async fn handle_outbound_request(
-        &mut self,
-        reply_tx: OneshotSender<Result<MempoolResponse, MempoolServiceError>>,
-        request: MempoolRequest,
-    ) -> Result<(), MempoolServiceError>
-    {
-        let request_key = generate_request_key(&mut OsRng);
-        let service_request = proto::MempoolServiceRequest {
-            request_key,
-            request: Some(request.into()),
-        };
-
-        let send_result = self
-            .outbound_message_service
-            .send_random(
-                1,
-                NodeDestination::Unknown,
-                OutboundEncryption::EncryptForPeer,
-                OutboundDomainMessage::new(TariMessageType::MempoolRequest, service_request),
+        let outbound_message_service = self.outbound_message_service.clone();
+        let waiting_requests = self.waiting_requests.clone();
+        let timeout_sender = self.timeout_sender.clone();
+        let config = self.config;
+        task::spawn(async move {
+            let (request, reply_tx) = request_context.split();
+            let _ = handle_outbound_request(
+                outbound_message_service,
+                waiting_requests,
+                timeout_sender,
+                reply_tx,
+                request,
+                config,
             )
             .await
-            .or_else(|e| {
-                error!(target: LOG_TARGET, "mempool outbound request failure. {:?}", e);
-                Err(e)
-            })
-            .map_err(|e| MempoolServiceError::OutboundMessageService(e.to_string()))?;
+            .or_else(|err| {
+                error!(
+                    target: LOG_TARGET,
+                    "Failed to handle outbound request message: {:?}", err
+                );
+                Err(err)
+            });
+        });
+    }
 
-        match send_result.resolve_ok().await {
-            Some(tags) if !tags.is_empty() => {
-                // Spawn timeout and wait for matching response to arrive
-                self.waiting_requests.insert(request_key, Some(reply_tx));
-                self.spawn_request_timeout(request_key, self.config.request_timeout)
-                    .await;
-            },
-            Some(_) => {
-                let _ = reply_tx.send(Err(MempoolServiceError::NoBootstrapNodesConfigured).or_else(|resp| {
+    fn spawn_handle_outbound_tx(&self, tx_context: (Transaction, Vec<RistrettoPublicKey>)) {
+        let outbound_message_service = self.outbound_message_service.clone();
+        task::spawn(async move {
+            let (tx, excluded_peers) = tx_context;
+            let _ = handle_outbound_tx(outbound_message_service, tx, excluded_peers)
+                .await
+                .or_else(|err| {
+                    error!(target: LOG_TARGET, "Failed to handle outbound tx message {:?}", err);
+                    Err(err)
+                });
+        });
+    }
+
+    fn spawn_handle_incoming_request(&self, domain_msg: DomainMessage<proto::mempool::MempoolServiceRequest>) {
+        let inbound_handlers = self.inbound_handlers.clone();
+        let outbound_message_service = self.outbound_message_service.clone();
+        task::spawn(async move {
+            let _ = handle_incoming_request(inbound_handlers, outbound_message_service, domain_msg)
+                .await
+                .or_else(|err| {
                     error!(
                         target: LOG_TARGET,
-                        "Failed to send outbound request from Mempool service as no bootstrap nodes were configured"
+                        "Failed to handle incoming request message: {:?}", err
                     );
-                    Err(resp)
-                }));
-            },
-            None => {
-                let _ = reply_tx
-                    .send(Err(MempoolServiceError::BroadcastFailed))
-                    .or_else(|resp| {
-                        error!(
-                            target: LOG_TARGET,
-                            "Failed to send outbound request from Mempool service because of a failure in DHT \
-                             broadcast"
-                        );
-                        Err(resp)
-                    });
-            },
-        }
-
-        Ok(())
+                    Err(err)
+                });
+        });
     }
 
-    async fn handle_incoming_transaction(
-        &mut self,
-        domain_transaction_msg: DomainMessage<Transaction>,
-    ) -> Result<(), MempoolServiceError>
-    {
-        let DomainMessage::<_> { source_peer, inner, .. } = domain_transaction_msg;
-
-        self.inbound_handlers
-            .handle_transaction(&inner, Some(source_peer.public_key))
-            .await?;
-
-        Ok(())
-    }
-
-    async fn handle_request_timeout(&mut self, request_key: RequestKey) -> Result<(), MempoolServiceError> {
-        if let Some(mut waiting_request) = self.waiting_requests.remove(&request_key) {
-            if let Some(reply_tx) = waiting_request.take() {
-                let reply_msg = Err(MempoolServiceError::RequestTimedOut);
-                let _ = reply_tx.send(reply_msg.or_else(|resp| {
+    fn spawn_handle_incoming_response(&self, domain_msg: DomainMessage<proto::mempool::MempoolServiceResponse>) {
+        let waiting_requests = self.waiting_requests.clone();
+        task::spawn(async move {
+            let _ = handle_incoming_response(waiting_requests, domain_msg.into_inner())
+                .await
+                .or_else(|err| {
                     error!(
                         target: LOG_TARGET,
-                        "Failed to send outbound request from Mempool service"
+                        "Failed to handle incoming response message: {:?}", err
+                    );
+                    Err(err)
+                });
+        });
+    }
+
+    fn spawn_handle_incoming_tx(&self, tx_msg: DomainMessage<Transaction>) {
+        let inbound_handlers = self.inbound_handlers.clone();
+        task::spawn(async move {
+            let _ = handle_incoming_tx(inbound_handlers, tx_msg).await.or_else(|err| {
+                error!(
+                    target: LOG_TARGET,
+                    "Failed to handle incoming transaction message: {:?}", err
+                );
+                Err(err)
+            });
+        });
+    }
+
+    fn spawn_handle_block_event(&self, block_event: Arc<BlockEvent>) {
+        let inbound_handlers = self.inbound_handlers.clone();
+        task::spawn(async move {
+            let _ = handle_block_event(inbound_handlers, &block_event).await.or_else(|err| {
+                error!(target: LOG_TARGET, "Failed to handle base node block event: {:?}", err);
+                Err(err)
+            });
+        });
+    }
+
+    fn spawn_handle_request_timeout(&self, timeout_request_key: u64) {
+        let waiting_requests = self.waiting_requests.clone();
+        task::spawn(async move {
+            let _ = handle_request_timeout(waiting_requests, timeout_request_key)
+                .await
+                .or_else(|err| {
+                    error!(target: LOG_TARGET, "Failed to handle request timeout event: {:?}", err);
+                    Err(err)
+                });
+        });
+    }
+}
+
+async fn handle_incoming_request<B: BlockchainBackend + 'static>(
+    inbound_handlers: MempoolInboundHandlers<B>,
+    mut outbound_message_service: OutboundMessageRequester,
+    domain_request_msg: DomainMessage<proto::MempoolServiceRequest>,
+) -> Result<(), MempoolServiceError>
+{
+    let (origin_public_key, inner_msg) = domain_request_msg.into_origin_and_inner();
+
+    // Convert proto::MempoolServiceRequest to a MempoolServiceRequest
+    let request = inner_msg
+        .request
+        .ok_or_else(|| MempoolServiceError::InvalidRequest("Received invalid mempool service request".to_string()))?;
+
+    let response = inbound_handlers
+        .handle_request(&request.try_into().map_err(MempoolServiceError::InvalidRequest)?)
+        .await?;
+
+    let message = proto::MempoolServiceResponse {
+        request_key: inner_msg.request_key,
+        response: Some(response.into()),
+    };
+
+    outbound_message_service
+        .send_direct(
+            origin_public_key,
+            OutboundEncryption::EncryptForPeer,
+            OutboundDomainMessage::new(TariMessageType::MempoolResponse, message),
+        )
+        .await?;
+
+    Ok(())
+}
+
+async fn handle_incoming_response(
+    waiting_requests: WaitingRequests<Result<MempoolResponse, MempoolServiceError>, MempoolResponse>,
+    incoming_response: proto::MempoolServiceResponse,
+) -> Result<(), MempoolServiceError>
+{
+    let proto::MempoolServiceResponse { request_key, response } = incoming_response;
+    let response = response
+        .and_then(|r| r.try_into().ok())
+        .ok_or_else(|| MempoolServiceError::InvalidResponse("Received an invalid Mempool response".to_string()))?;
+
+    if let Some(waiting_request) = waiting_requests.check_complete(request_key, response)? {
+        let WaitingRequest {
+            mut reply_tx,
+            received_responses,
+            ..
+        } = waiting_request;
+        if let Some(reply_tx) = reply_tx.take() {
+            if let Some(received_response) = received_responses.into_iter().next() {
+                let _ = reply_tx.send(Ok(received_response).or_else(|resp| {
+                    warn!(
+                        target: LOG_TARGET,
+                        "Failed to send outbound request (request key:{})  from Mempool service: {:?}",
+                        &request_key,
+                        resp
                     );
                     Err(resp)
                 }));
             }
         }
-        Ok(())
     }
 
-    async fn handle_outbound_tx(
-        &mut self,
-        tx: Transaction,
-        exclude_peers: Vec<CommsPublicKey>,
-    ) -> Result<(), MempoolServiceError>
-    {
-        self.outbound_message_service
-            .propagate(
-                NodeDestination::Unknown,
-                OutboundEncryption::EncryptForPeer,
-                exclude_peers,
-                OutboundDomainMessage::new(TariMessageType::NewTransaction, ProtoTransaction::from(tx)),
-            )
-            .await
-            .or_else(|e| {
-                error!(target: LOG_TARGET, "Handle outbound tx failure. {:?}", e);
-                Err(e)
-            })
-            .map_err(|e| MempoolServiceError::OutboundMessageService(e.to_string()))
-            .map(|_| ())
+    Ok(())
+}
+
+async fn handle_outbound_request(
+    mut outbound_message_service: OutboundMessageRequester,
+    waiting_requests: WaitingRequests<Result<MempoolResponse, MempoolServiceError>, MempoolResponse>,
+    timeout_sender: Sender<RequestKey>,
+    reply_tx: OneshotSender<Result<MempoolResponse, MempoolServiceError>>,
+    request: MempoolRequest,
+    config: MempoolServiceConfig,
+) -> Result<(), MempoolServiceError>
+{
+    let request_key = generate_request_key(&mut OsRng);
+    let service_request = proto::MempoolServiceRequest {
+        request_key,
+        request: Some(request.into()),
+    };
+
+    let send_result = outbound_message_service
+        .send_random(
+            1,
+            NodeDestination::Unknown,
+            OutboundEncryption::EncryptForPeer,
+            OutboundDomainMessage::new(TariMessageType::MempoolRequest, service_request),
+        )
+        .await
+        .or_else(|e| {
+            error!(target: LOG_TARGET, "mempool outbound request failure. {:?}", e);
+            Err(e)
+        })
+        .map_err(|e| MempoolServiceError::OutboundMessageService(e.to_string()))?;
+
+    match send_result.resolve_ok().await {
+        Some(tags) if !tags.is_empty() => {
+            // Spawn timeout and wait for matching response to arrive
+            waiting_requests.insert(request_key, WaitingRequest {
+                reply_tx: Some(reply_tx),
+                received_responses: Vec::new(),
+                desired_resp_count: 1,
+            })?;
+            // Spawn timeout for waiting_request
+            spawn_request_timeout(timeout_sender, request_key, config.request_timeout);
+        },
+        Some(_) => {
+            let _ = reply_tx.send(Err(MempoolServiceError::NoBootstrapNodesConfigured).or_else(|resp| {
+                error!(
+                    target: LOG_TARGET,
+                    "Failed to send outbound request from Mempool service as no bootstrap nodes were configured"
+                );
+                Err(resp)
+            }));
+        },
+        None => {
+            let _ = reply_tx
+                .send(Err(MempoolServiceError::BroadcastFailed))
+                .or_else(|resp| {
+                    error!(
+                        target: LOG_TARGET,
+                        "Failed to send outbound request from Mempool service because of a failure in DHT broadcast"
+                    );
+                    Err(resp)
+                });
+        },
     }
 
-    /// Handle block events from local base node service.
-    async fn handle_block_event(&mut self, block_event: &BlockEvent) -> Result<(), MempoolServiceError> {
-        self.inbound_handlers.handle_block_event(block_event).await?;
+    Ok(())
+}
 
-        Ok(())
+async fn handle_incoming_tx<B: BlockchainBackend + 'static>(
+    mut inbound_handlers: MempoolInboundHandlers<B>,
+    domain_transaction_msg: DomainMessage<Transaction>,
+) -> Result<(), MempoolServiceError>
+{
+    let DomainMessage::<_> { source_peer, inner, .. } = domain_transaction_msg;
+
+    inbound_handlers
+        .handle_transaction(&inner, Some(source_peer.public_key))
+        .await?;
+
+    Ok(())
+}
+
+async fn handle_request_timeout(
+    waiting_requests: WaitingRequests<Result<MempoolResponse, MempoolServiceError>, MempoolResponse>,
+    request_key: RequestKey,
+) -> Result<(), MempoolServiceError>
+{
+    if let Some(mut waiting_request) = waiting_requests.remove(request_key)? {
+        if let Some(reply_tx) = waiting_request.reply_tx.take() {
+            let reply_msg = Err(MempoolServiceError::RequestTimedOut);
+            let _ = reply_tx.send(reply_msg.or_else(|resp| {
+                error!(
+                    target: LOG_TARGET,
+                    "Failed to send outbound request from Mempool service"
+                );
+                Err(resp)
+            }));
+        }
     }
 
-    async fn spawn_request_timeout(&self, request_key: RequestKey, timeout: Duration) {
-        let mut timeout_sender = self.timeout_sender.clone();
-        self.executor.spawn(async move {
-            tokio::time::delay_for(timeout).await;
-            let _ = timeout_sender.send(request_key).await;
-        });
-    }
+    Ok(())
+}
+
+async fn handle_outbound_tx(
+    mut outbound_message_service: OutboundMessageRequester,
+    tx: Transaction,
+    exclude_peers: Vec<CommsPublicKey>,
+) -> Result<(), MempoolServiceError>
+{
+    outbound_message_service
+        .propagate(
+            NodeDestination::Unknown,
+            OutboundEncryption::EncryptForPeer,
+            exclude_peers,
+            OutboundDomainMessage::new(TariMessageType::NewTransaction, ProtoTransaction::from(tx)),
+        )
+        .await
+        .or_else(|e| {
+            error!(target: LOG_TARGET, "Handle outbound tx failure. {:?}", e);
+            Err(e)
+        })
+        .map_err(|e| MempoolServiceError::OutboundMessageService(e.to_string()))
+        .map(|_| ())
+}
+
+async fn handle_block_event<B: BlockchainBackend + 'static>(
+    mut inbound_handlers: MempoolInboundHandlers<B>,
+    block_event: &BlockEvent,
+) -> Result<(), MempoolServiceError>
+{
+    inbound_handlers.handle_block_event(block_event).await?;
+
+    Ok(())
+}
+
+fn spawn_request_timeout(mut timeout_sender: Sender<RequestKey>, request_key: RequestKey, timeout: Duration) {
+    task::spawn(async move {
+        tokio::time::delay_for(timeout).await;
+        let _ = timeout_sender.send(request_key).await;
+    });
 }


### PR DESCRIPTION
## Description
- The mempool service was updated to limit the blocking behaviour when messages are being processed. A task will be spawned for every request, response and received transaction, allowing the tasks to be completed independently and not cause the mempool service to block while messages are being processed.
- WaitingRequests was moved to helpers and was modified to allow the base node service and mempool service to use it. 
- An implementation of clone was provided to allow the mempool service to be shared between tasks.
- The unused executor was removed from the mempool service.

## Motivation and Context
These changes allow the mempool service to handle all received messages as independent tasks, limiting blocking while listening for new messages.

## How Has This Been Tested?
None, current tests remain functioning.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [x] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch.
* [x] I ran `cargo-fmt --all` before pushing.
* [x] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
