### PR TITLE
Remove consensus manager field from DB

### DIFF
--- a/applications/tari_base_node/src/builder.rs
+++ b/applications/tari_base_node/src/builder.rs
@@ -317,7 +317,7 @@ where
     B: BlockchainBackend + 'static,
 {
     let rules = ConsensusManagerBuilder::new(network).build();
-    let mut db = BlockchainDatabase::new(backend, rules.clone()).map_err(|e| e.to_string())?;
+    let mut db = BlockchainDatabase::new(backend, &rules).map_err(|e| e.to_string())?;
     let factories = CryptoFactories::default();
     let validators = Validators::new(
         FullConsensusValidator::new(rules.clone(), factories.clone(), db.clone()),

--- a/base_layer/core/src/blocks/block.rs
+++ b/base_layer/core/src/blocks/block.rs
@@ -159,9 +159,9 @@ pub struct BlockBuilder {
 }
 
 impl BlockBuilder {
-    pub fn new(consensus_constants: &ConsensusConstants) -> BlockBuilder {
+    pub fn new(blockchain_version: u16) -> BlockBuilder {
         BlockBuilder {
-            header: BlockHeader::new(consensus_constants.blockchain_version()),
+            header: BlockHeader::new(blockchain_version),
             inputs: Vec::new(),
             outputs: Vec::new(),
             kernels: Vec::new(),

--- a/base_layer/core/src/blocks/blockheader.rs
+++ b/base_layer/core/src/blocks/blockheader.rs
@@ -38,7 +38,7 @@
 //! This hash is called the UTXO merkle root, and is used as the output_mr
 
 use crate::{
-    blocks::NewBlockHeaderTemplate,
+    blocks::{BlockBuilder, NewBlockHeaderTemplate},
     proof_of_work::{Difficulty, PowError, ProofOfWork},
     transactions::types::{BlindingFactor, HashDigest},
 };
@@ -159,6 +159,10 @@ impl BlockHeader {
         let mut prev_pow = self.pow.clone();
         prev_pow.add_difficulty(&self.pow, self.achieved_difficulty());
         prev_pow.total_accumulated_difficulty()
+    }
+
+    pub fn into_builder(self) -> BlockBuilder {
+        BlockBuilder::new(self.version).with_header(self)
     }
 }
 

--- a/base_layer/core/src/chain_storage/blockchain_database.rs
+++ b/base_layer/core/src/chain_storage/blockchain_database.rs
@@ -208,7 +208,7 @@ macro_rules! fetch {
 /// let db = MemoryDatabase::<HashDigest>::default();
 /// let network = Network::LocalNet;
 /// let rules = ConsensusManagerBuilder::new(network).build();
-/// let mut db = BlockchainDatabase::new(db_backend, rules.clone()).unwrap();
+/// let mut db = BlockchainDatabase::new(db_backend, &rules).unwrap();
 /// db.set_validators(validators);
 /// // Do stuff with db
 /// ```
@@ -218,23 +218,21 @@ where T: BlockchainBackend
     metadata: Arc<RwLock<ChainMetadata>>,
     db: Arc<T>,
     validators: Option<Validators<T>>,
-    consensus_manager: ConsensusManager<T>,
 }
 
 impl<T> BlockchainDatabase<T>
 where T: BlockchainBackend
 {
     /// Creates a new `BlockchainDatabase` using the provided backend.
-    pub fn new(db: T, consensus_manager: ConsensusManager<T>) -> Result<Self, ChainStorageError> {
+    pub fn new(db: T, consensus_manager: &ConsensusManager<T>) -> Result<Self, ChainStorageError> {
         let metadata = Self::read_metadata(&db)?;
         let blockchain_db = BlockchainDatabase {
             metadata: Arc::new(RwLock::new(metadata)),
             db: Arc::new(db),
             validators: None,
-            consensus_manager,
         };
         if let None = blockchain_db.get_height()? {
-            let genesis_block = blockchain_db.consensus_manager.get_genesis_block();
+            let genesis_block = consensus_manager.get_genesis_block();
             let genesis_block_hash = genesis_block.hash();
             let mut pow = genesis_block.header.pow.clone();
             pow.add_difficulty(
@@ -566,8 +564,8 @@ where T: BlockchainBackend
         let (utxo_hashes, deleted_nodes) = utxo_cp.into_parts();
         let inputs = self.fetch_inputs(deleted_nodes)?;
         let (outputs, spent) = self.fetch_outputs(utxo_hashes)?;
-        let block = BlockBuilder::new(&self.consensus_manager.consensus_constants())
-            .with_header(header)
+        let block = header
+            .into_builder()
             .add_inputs(inputs)
             .add_outputs(outputs)
             .add_kernels(kernels)
@@ -1005,7 +1003,6 @@ where T: BlockchainBackend
             metadata: self.metadata.clone(),
             db: self.db.clone(),
             validators: self.validators.clone(),
-            consensus_manager: self.consensus_manager.clone(),
         }
     }
 }

--- a/base_layer/core/src/helpers/mod.rs
+++ b/base_layer/core/src/helpers/mod.rs
@@ -45,16 +45,13 @@ pub fn create_orphan_block(
     consensus_constants: &ConsensusConstants,
 ) -> Block
 {
-    let mut header = BlockHeader::new(0);
+    let mut header = BlockHeader::new(consensus_constants.blockchain_version());
     header.height = block_height;
-    BlockBuilder::new(consensus_constants)
-        .with_header(header)
-        .with_transactions(transactions)
-        .build()
+    header.into_builder().with_transactions(transactions).build()
 }
 
 pub fn create_mem_db(
-    consensus_manager: ConsensusManager<MemoryDatabase<HashDigest>>,
+    consensus_manager: &ConsensusManager<MemoryDatabase<HashDigest>>,
 ) -> BlockchainDatabase<MemoryDatabase<HashDigest>> {
     let validators = Validators::new(MockValidator::new(true), MockValidator::new(true));
     let db = MemoryDatabase::<HashDigest>::default();

--- a/base_layer/core/src/mempool/orphan_pool/orphan_pool.rs
+++ b/base_layer/core/src/mempool/orphan_pool/orphan_pool.rs
@@ -171,7 +171,7 @@ mod test {
         let tx6 = Arc::new(tx!(MicroTari(10_000), fee: MicroTari(600), lock: 5500, inputs: 2, outputs: 1).0);
         let network = Network::LocalNet;
         let consensus_manager = ConsensusManagerBuilder::new(network).build();
-        let store = create_mem_db(consensus_manager);
+        let store = create_mem_db(&consensus_manager);
         let mempool_validator = Box::new(TxInputAndMaturityValidator::new(store.clone()));
         let orphan_pool = OrphanPool::new(
             OrphanPoolConfig {

--- a/base_layer/core/tests/block_validation.rs
+++ b/base_layer/core/tests/block_validation.rs
@@ -34,7 +34,7 @@ fn test_genesis_block() {
     let network = Network::LocalNet;
     let rules = ConsensusManagerBuilder::new(network).build();
     let backend = MemoryDatabase::<HashDigest>::default();
-    let mut db = BlockchainDatabase::new(backend, rules.clone()).unwrap();
+    let mut db = BlockchainDatabase::new(backend, &rules).unwrap();
     let validators = Validators::new(
         FullConsensusValidator::new(rules.clone(), factories, db.clone()),
         StatelessValidator::new(&rules.consensus_constants()),

--- a/base_layer/core/tests/chain_storage_tests/chain_storage.rs
+++ b/base_layer/core/tests/chain_storage_tests/chain_storage.rs
@@ -64,7 +64,7 @@ fn init_log() {
 fn fetch_nonexistent_kernel() {
     let network = Network::LocalNet;
     let consensus_manager = ConsensusManagerBuilder::new(network).build();
-    let store = create_mem_db(consensus_manager.clone());
+    let store = create_mem_db(&consensus_manager);
     let h = vec![0u8; 32];
     assert_eq!(
         store.fetch_kernel(h.clone()),
@@ -76,7 +76,7 @@ fn fetch_nonexistent_kernel() {
 fn insert_and_fetch_kernel() {
     let network = Network::LocalNet;
     let consensus_manager = ConsensusManagerBuilder::new(network).build();
-    let store = create_mem_db(consensus_manager.clone());
+    let store = create_mem_db(&consensus_manager);
     let kernel = create_test_kernel(5.into(), 0);
     let hash = kernel.hash();
 
@@ -90,7 +90,7 @@ fn insert_and_fetch_kernel() {
 fn fetch_nonexistent_header() {
     let network = Network::LocalNet;
     let consensus_manager = ConsensusManagerBuilder::new(network).build();
-    let store = create_mem_db(consensus_manager.clone());
+    let store = create_mem_db(&consensus_manager);
     assert_eq!(
         store.fetch_header(1),
         Err(ChainStorageError::ValueNotFound(DbKey::BlockHeader(1)))
@@ -101,7 +101,7 @@ fn fetch_nonexistent_header() {
 fn insert_and_fetch_header() {
     let network = Network::LocalNet;
     let consensus_manager = ConsensusManagerBuilder::new(network).build();
-    let store = create_mem_db(consensus_manager.clone());
+    let store = create_mem_db(&consensus_manager);
     let mut header = BlockHeader::new(0);
     header.height = 42;
 
@@ -121,7 +121,7 @@ fn insert_and_fetch_utxo() {
     let factories = CryptoFactories::default();
     let network = Network::LocalNet;
     let consensus_manager = ConsensusManagerBuilder::new(network).build();
-    let store = create_mem_db(consensus_manager.clone());
+    let store = create_mem_db(&consensus_manager);
     let (utxo, _) = create_utxo(MicroTari(10_000), &factories, None);
     let hash = utxo.hash();
     assert_eq!(store.is_utxo(hash.clone()).unwrap(), false);
@@ -136,7 +136,7 @@ fn insert_and_fetch_utxo() {
 fn insert_and_fetch_orphan() {
     let network = Network::LocalNet;
     let consensus_manager = ConsensusManagerBuilder::new(network).build();
-    let store = create_mem_db(consensus_manager.clone());
+    let store = create_mem_db(&consensus_manager);
     let txs = vec![
         (tx!(1000.into(), fee: 20.into(), inputs: 2, outputs: 1)).0,
         (tx!(2000.into(), fee: 30.into(), inputs: 1, outputs: 1)).0,
@@ -153,7 +153,7 @@ fn insert_and_fetch_orphan() {
 fn multiple_threads() {
     let network = Network::LocalNet;
     let consensus_manager = ConsensusManagerBuilder::new(network).build();
-    let store = create_mem_db(consensus_manager.clone());
+    let store = create_mem_db(&consensus_manager);
     // Save a kernel in thread A
     let store_a = store.clone();
     let a = thread::spawn(move || {
@@ -188,7 +188,7 @@ fn utxo_and_rp_merkle_root() {
     let network = Network::LocalNet;
     let gen_block = genesis_block::get_rincewind_genesis_block_raw();
     let consensus_manager = ConsensusManagerBuilder::new(network).with_block(gen_block).build();
-    let store = create_mem_db(consensus_manager.clone());
+    let store = create_mem_db(&consensus_manager);
     let factories = CryptoFactories::default();
     let block0 = store.fetch_block(0).unwrap().block().clone();
 
@@ -222,7 +222,7 @@ fn utxo_and_rp_merkle_root() {
 fn kernel_merkle_root() {
     let network = Network::LocalNet;
     let consensus_manager = ConsensusManagerBuilder::new(network).build();
-    let store = create_mem_db(consensus_manager.clone());
+    let store = create_mem_db(&consensus_manager);
     let block0 = store.fetch_block(0).unwrap().block().clone();
 
     let kernel1 = create_test_kernel(100.into(), 0);
@@ -251,7 +251,7 @@ fn utxo_and_rp_future_merkle_root() {
     let network = Network::LocalNet;
     let gen_block = genesis_block::get_rincewind_genesis_block_raw();
     let consensus_manager = ConsensusManagerBuilder::new(network).with_block(gen_block).build();
-    let store = create_mem_db(consensus_manager.clone());
+    let store = create_mem_db(&consensus_manager);
     let factories = CryptoFactories::default();
 
     let (utxo1, _) = create_utxo(MicroTari(10_000), &factories, None);
@@ -293,7 +293,7 @@ fn kernel_future_merkle_root() {
     let network = Network::LocalNet;
     let gen_block = genesis_block::get_rincewind_genesis_block_raw();
     let consensus_manager = ConsensusManagerBuilder::new(network).with_block(gen_block).build();
-    let store = create_mem_db(consensus_manager.clone());
+    let store = create_mem_db(&consensus_manager);
 
     let kernel1 = create_test_kernel(100.into(), 0);
     let kernel2 = create_test_kernel(200.into(), 0);
@@ -321,7 +321,7 @@ fn utxo_and_rp_mmr_proof() {
     let network = Network::LocalNet;
     let gen_block = genesis_block::get_rincewind_genesis_block_raw();
     let consensus_manager = ConsensusManagerBuilder::new(network).with_block(gen_block).build();
-    let store = create_mem_db(consensus_manager.clone());
+    let store = create_mem_db(&consensus_manager);
     let factories = CryptoFactories::default();
 
     let (utxo1, _) = create_utxo(MicroTari(5_000), &factories, None);
@@ -349,7 +349,7 @@ fn utxo_and_rp_mmr_proof() {
 fn kernel_mmr_proof() {
     let network = Network::LocalNet;
     let consensus_manager = ConsensusManagerBuilder::new(network).build();
-    let store = create_mem_db(consensus_manager.clone());
+    let store = create_mem_db(&consensus_manager);
 
     let kernel1 = create_test_kernel(100.into(), 0);
     let kernel2 = create_test_kernel(200.into(), 1);
@@ -392,7 +392,7 @@ fn add_multiple_blocks() {
     // Create new database with genesis block
     let network = Network::LocalNet;
     let consensus_manager = ConsensusManagerBuilder::new(network).build();
-    let store = create_mem_db(consensus_manager.clone());
+    let store = create_mem_db(&consensus_manager);
     let metadata = store.get_metadata().unwrap();
     assert_eq!(metadata.height_of_longest_chain, Some(0));
     let block0 = store.fetch_block(0).unwrap().block().clone();
@@ -552,7 +552,7 @@ fn handle_tip_reorg() {
     let consensus_manager_fork = ConsensusManagerBuilder::new(network)
         .with_block(blocks[0].clone())
         .build();
-    let mut orphan_store = create_mem_db(consensus_manager_fork.clone());
+    let mut orphan_store = create_mem_db(&consensus_manager_fork);
     orphan_store.add_block(blocks[1].clone()).unwrap();
     let mut orphan_blocks = vec![blocks[0].clone(), blocks[1].clone()];
     let mut orphan_outputs = vec![outputs[0].clone(), outputs[1].clone()];
@@ -644,7 +644,7 @@ fn handle_reorg() {
     let consensus_manager_fork = ConsensusManagerBuilder::new(network)
         .with_block(blocks[0].clone())
         .build();
-    let mut orphan1_store = create_mem_db(consensus_manager_fork); // GB
+    let mut orphan1_store = create_mem_db(&consensus_manager_fork); // GB
     orphan1_store.add_block(blocks[1].clone()).unwrap(); // A1
     let mut orphan1_blocks = vec![blocks[0].clone(), blocks[1].clone()];
     let mut orphan1_outputs = vec![outputs[0].clone(), outputs[1].clone()];
@@ -689,7 +689,7 @@ fn handle_reorg() {
     let consensus_manager_fork2 = ConsensusManagerBuilder::new(network)
         .with_block(blocks[0].clone())
         .build();
-    let mut orphan2_store = create_mem_db(consensus_manager_fork2); // GB
+    let mut orphan2_store = create_mem_db(&consensus_manager_fork2); // GB
     orphan2_store.add_block(blocks[1].clone()).unwrap(); // A1
     orphan2_store.add_block(orphan1_blocks[2].clone()).unwrap(); // B2
     orphan2_store.add_block(orphan1_blocks[3].clone()).unwrap(); // B3
@@ -742,7 +742,7 @@ fn store_and_retrieve_blocks() {
     let network = Network::LocalNet;
     let rules = ConsensusManagerBuilder::new(network).build();
     let db = MemoryDatabase::<HashDigest>::new(mmr_cache_config);
-    let mut store = BlockchainDatabase::new(db, rules.clone()).unwrap();
+    let mut store = BlockchainDatabase::new(db, &rules).unwrap();
     store.set_validators(validators);
 
     let block0 = store.fetch_block(0).unwrap().block().clone();
@@ -766,7 +766,7 @@ fn store_and_retrieve_chain_and_orphan_blocks_with_hashes() {
     let network = Network::LocalNet;
     let rules = ConsensusManagerBuilder::new(network).build();
     let db = MemoryDatabase::<HashDigest>::new(mmr_cache_config);
-    let mut store = BlockchainDatabase::new(db, rules.clone()).unwrap();
+    let mut store = BlockchainDatabase::new(db, &rules).unwrap();
     store.set_validators(validators);
 
     let block0 = store.fetch_block(0).unwrap().block().clone();
@@ -788,7 +788,7 @@ fn store_and_retrieve_chain_and_orphan_blocks_with_hashes() {
 fn total_kernel_excess() {
     let network = Network::LocalNet;
     let consensus_manager = ConsensusManagerBuilder::new(network).build();
-    let store = create_mem_db(consensus_manager.clone());
+    let store = create_mem_db(&consensus_manager);
     let block0 = store.fetch_block(0).unwrap().block().clone();
 
     let kernel1 = create_test_kernel(100.into(), 0);
@@ -812,7 +812,7 @@ fn total_kernel_excess() {
 fn total_kernel_offset() {
     let network = Network::LocalNet;
     let consensus_manager = ConsensusManagerBuilder::new(network).build();
-    let store = create_mem_db(consensus_manager.clone());
+    let store = create_mem_db(&consensus_manager);
     let block0 = store.fetch_block(0).unwrap().block().clone();
 
     let header2 = BlockHeader::from_previous(&block0.header);
@@ -835,7 +835,7 @@ fn total_utxo_commitment() {
     let network = Network::LocalNet;
     let gen_block = genesis_block::get_rincewind_genesis_block_raw();
     let consensus_manager = ConsensusManagerBuilder::new(network).with_block(gen_block).build();
-    let store = create_mem_db(consensus_manager.clone());
+    let store = create_mem_db(&consensus_manager);
     let block0 = store.fetch_block(0).unwrap().block().clone();
 
     let (utxo1, _) = create_utxo(MicroTari(10_000), &factories, None);
@@ -864,7 +864,7 @@ fn restore_metadata() {
     let path = create_temporary_data_path();
     {
         let db = create_lmdb_database(&path, MmrCacheConfig::default()).unwrap();
-        let mut db = BlockchainDatabase::new(db, rules.clone()).unwrap();
+        let mut db = BlockchainDatabase::new(db, &rules).unwrap();
         db.set_validators(validators.clone());
 
         let block0 = db.fetch_block(0).unwrap().block().clone();
@@ -877,7 +877,7 @@ fn restore_metadata() {
     }
     // Restore blockchain db
     let db = create_lmdb_database(&path, MmrCacheConfig::default()).unwrap();
-    let mut db = BlockchainDatabase::new(db, rules.clone()).unwrap();
+    let mut db = BlockchainDatabase::new(db, &rules).unwrap();
     db.set_validators(validators);
 
     let metadata = db.get_metadata().unwrap();

--- a/base_layer/core/tests/diff_adj_manager.rs
+++ b/base_layer/core/tests/diff_adj_manager.rs
@@ -100,7 +100,7 @@ fn calculate_accumulated_difficulty(
 fn test_initial_sync() {
     let network = Network::LocalNet;
     let consensus_manager = ConsensusManagerBuilder::new(network).build();
-    let store = create_mem_db(consensus_manager.clone());
+    let store = create_mem_db(&consensus_manager);
 
     let pow_algos = vec![
         PowAlgorithm::Blake, //  GB default
@@ -138,7 +138,7 @@ fn test_initial_sync() {
 fn test_sync_to_chain_tip() {
     let network = Network::LocalNet;
     let consensus_manager = ConsensusManagerBuilder::new(network).build();
-    let store = create_mem_db(consensus_manager.clone());
+    let store = create_mem_db(&consensus_manager);
     let diff_adj_manager = DiffAdjManager::new(store.clone(), &consensus_manager.consensus_constants()).unwrap();
     let _ = consensus_manager.set_diff_manager(diff_adj_manager);
 
@@ -200,7 +200,7 @@ fn test_sync_to_chain_tip() {
 fn test_target_difficulty_with_height() {
     let network = Network::LocalNet;
     let consensus_manager = ConsensusManagerBuilder::new(network).build();
-    let store = create_mem_db(consensus_manager.clone());
+    let store = create_mem_db(&consensus_manager);
     let diff_adj_manager = DiffAdjManager::new(store.clone(), &consensus_manager.consensus_constants()).unwrap();
     let _ = consensus_manager.set_diff_manager(diff_adj_manager);
     assert!(consensus_manager
@@ -279,7 +279,7 @@ fn test_target_difficulty_with_height() {
 fn test_full_sync_on_reorg() {
     let network = Network::LocalNet;
     let consensus_manager = ConsensusManagerBuilder::new(network).build();
-    let store = create_mem_db(consensus_manager.clone());
+    let store = create_mem_db(&consensus_manager);
     let diff_adj_manager = DiffAdjManager::new(store.clone(), &consensus_manager.consensus_constants()).unwrap();
 
     let pow_algos = vec![
@@ -327,7 +327,7 @@ fn test_full_sync_on_reorg() {
 fn test_median_timestamp() {
     let network = Network::LocalNet;
     let consensus_manager = ConsensusManagerBuilder::new(network).build();
-    let store = create_mem_db(consensus_manager.clone());
+    let store = create_mem_db(&consensus_manager);
     let diff_adj_manager = DiffAdjManager::new(store.clone(), &consensus_manager.consensus_constants()).unwrap();
     let pow_algos = vec![PowAlgorithm::Blake]; // GB default
     create_test_pow_blockchain(&store, pow_algos, &consensus_manager.consensus_constants());
@@ -384,7 +384,7 @@ fn test_median_timestamp() {
 fn test_median_timestamp_with_height() {
     let network = Network::LocalNet;
     let consensus_manager = ConsensusManagerBuilder::new(network).build();
-    let store = create_mem_db(consensus_manager.clone());
+    let store = create_mem_db(&consensus_manager);
     let diff_adj_manager = DiffAdjManager::new(store.clone(), &consensus_manager.consensus_constants()).unwrap();
     let pow_algos = vec![
         PowAlgorithm::Blake, // GB default
@@ -424,7 +424,7 @@ fn test_median_timestamp_with_height() {
 fn test_median_timestamp_odd_order() {
     let network = Network::LocalNet;
     let consensus_manager = ConsensusManagerBuilder::new(network).build();
-    let store = create_mem_db(consensus_manager.clone());
+    let store = create_mem_db(&consensus_manager);
     let diff_adj_manager = DiffAdjManager::new(store.clone(), &consensus_manager.consensus_constants()).unwrap();
     let pow_algos = vec![PowAlgorithm::Blake]; // GB default
     create_test_pow_blockchain(&store, pow_algos, &consensus_manager.consensus_constants());

--- a/base_layer/core/tests/helpers/nodes.rs
+++ b/base_layer/core/tests/helpers/nodes.rs
@@ -184,7 +184,7 @@ impl BaseNodeBuilder {
             .consensus_manager
             .unwrap_or(ConsensusManagerBuilder::new(self.network).build());
         let db = MemoryDatabase::<HashDigest>::new(mmr_cache_config);
-        let mut blockchain_db = BlockchainDatabase::new(db, consensus_manager.clone()).unwrap();
+        let mut blockchain_db = BlockchainDatabase::new(db, &consensus_manager).unwrap();
         blockchain_db.set_validators(validators);
         let mempool_validator = MempoolValidators::new(
             TxInputAndMaturityValidator::new(blockchain_db.clone()),

--- a/base_layer/core/tests/helpers/sample_blockchains.rs
+++ b/base_layer/core/tests/helpers/sample_blockchains.rs
@@ -171,6 +171,6 @@ pub fn create_new_blockchain(
         .with_consensus_constants(consensus_constants)
         .with_block(block0.clone())
         .build();
-    let db = create_mem_db(consensus_manager.clone());
+    let db = create_mem_db(&consensus_manager);
     (db, vec![block0], vec![vec![output]], consensus_manager)
 }

--- a/base_layer/core/tests/mempool.rs
+++ b/base_layer/core/tests/mempool.rs
@@ -407,7 +407,7 @@ fn test_orphaned_mempool_transactions() {
     let network = Network::LocalNet;
     let (store, mut blocks, mut outputs, consensus_manager) = create_new_blockchain(network);
     // A parallel store that will "mine" the orphan chain
-    let mut miner = create_mem_db(consensus_manager.clone());
+    let mut miner = create_mem_db(&consensus_manager);
     let schemas = vec![txn_schema!(
         from: vec![outputs[0][0].clone()],
         to: vec![2 * T, 2 * T, 2 * T, 2 * T, 2 * T]

--- a/base_layer/core/tests/node_comms_interface.rs
+++ b/base_layer/core/tests/node_comms_interface.rs
@@ -71,7 +71,7 @@ fn new_mempool() -> (
 ) {
     let network = Network::LocalNet;
     let consensus_manager = ConsensusManagerBuilder::new(network).build();
-    let store = create_mem_db(consensus_manager);
+    let store = create_mem_db(&consensus_manager);
     let mempool_validator = MempoolValidators::new(
         TxInputAndMaturityValidator::new(store.clone()),
         TxInputAndMaturityValidator::new(store.clone()),
@@ -331,7 +331,7 @@ fn outbound_fetch_blocks() {
     let network = Network::LocalNet;
     let consensus_constants = network.create_consensus_constants();
     block_on(async {
-        let gb = BlockBuilder::new(&consensus_constants).build();
+        let gb = BlockBuilder::new(consensus_constants.blockchain_version()).build();
         let block = HistoricalBlock::new(gb, 0, Vec::new());
         let block_response: Vec<NodeCommsResponse> = vec![NodeCommsResponse::HistoricalBlocks(vec![block.clone()])];
         let (received_blocks, _) = futures::join!(


### PR DESCRIPTION

## Description
<!--- Describe your changes in detail -->
Removed a bunch of clones on ConsensusManager and consolidated the version code for Blockheader. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The main aim was to remove the ConsensusManager field from the BlockchainDatabase because it is only used in the constructor. Furthermore, it is only used for the blockchain version which I saw in most places was set to 0 or a value that didn't make sense.

I tried to apply this logic:
1. When creating a new block, use the value in the consensus rules.
2. When retrieving an old block, use the value it has

In most cases using the BlockBuilder,  the version would be set and then replaced immediately with the `header()` method. I introduced the `BlockHeader.into_builder()` method to use the header instead

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [x] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch
* [x] I ran `cargo-fmt --all` before pushing
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
