### PR TITLE
Implemented optimistic protocol negotiation

### DIFF
--- a/comms/dht/examples/memorynet.rs
+++ b/comms/dht/examples/memorynet.rs
@@ -38,7 +38,7 @@
 // Size of network
 const NUM_NODES: usize = 15;
 // Must be at least 2
-const NUM_WALLETS: usize = 2;
+const NUM_WALLETS: usize = 8;
 
 use futures::{channel::mpsc, future, StreamExt};
 use lazy_static::lazy_static;
@@ -179,44 +179,48 @@ async fn main() {
         println!();
     }
 
-    let first_wallet = wallets.get(0).unwrap();
-    let last_wallet = wallets.last().unwrap();
+    take_a_break().await;
 
-    banner!("Now, '{}' is going to try discover '{}'.", first_wallet, last_wallet);
+    for i in 0..wallets.len() - 1 {
+        let wallet1 = wallets.get(i).unwrap();
+        let wallet2 = wallets.get(i + 1).unwrap();
 
-    let start = Instant::now();
-    let discovery_result = first_wallet
-        .dht
-        .discovery_service_requester()
-        .discover_peer(
-            Box::new(last_wallet.node_identity().public_key().clone()),
-            None,
-            NodeDestination::Unknown,
-        )
-        .await;
+        banner!("Now, '{}' is going to try discover '{}'.", wallet1, wallet2);
 
-    let end = Instant::now();
-    banner!("Discovery is done.");
+        let start = Instant::now();
+        let discovery_result = wallet1
+            .dht
+            .discovery_service_requester()
+            .discover_peer(
+                Box::new(wallet2.node_identity().public_key().clone()),
+                None,
+                NodeDestination::Unknown,
+            )
+            .await;
 
-    match discovery_result {
-        Ok(peer) => {
-            println!(
-                "⚡️🎉😎 '{}' discovered peer '{}' ({}) in {}ms",
-                first_wallet,
-                get_name(&peer.node_id),
-                peer,
-                (end - start).as_millis()
-            );
-        },
-        Err(err) => {
-            println!(
-                "💩 '{}' failed to discover '{}' after {}ms because '{:?}'",
-                first_wallet,
-                last_wallet,
-                (end - start).as_millis(),
-                err
-            );
-        },
+        let end = Instant::now();
+        banner!("Discovery is done.");
+
+        match discovery_result {
+            Ok(peer) => {
+                println!(
+                    "⚡️🎉😎 '{}' discovered peer '{}' ({}) in {}ms",
+                    wallet1,
+                    get_name(&peer.node_id),
+                    peer,
+                    (end - start).as_millis()
+                );
+            },
+            Err(err) => {
+                println!(
+                    "💩 '{}' failed to discover '{}' after {}ms because '{:?}'",
+                    wallet1,
+                    wallet2,
+                    (end - start).as_millis(),
+                    err
+                );
+            },
+        }
     }
 
     banner!("We're done here. Network is shutting down...");

--- a/comms/examples/tor.rs
+++ b/comms/examples/tor.rs
@@ -14,7 +14,6 @@ use tari_comms::{
     peer_manager::{NodeId, NodeIdentity, NodeIdentityError, Peer, PeerFeatures, PeerManagerError},
     pipeline,
     pipeline::SinkService,
-    protocol,
     tor,
     CommsBuilder,
     CommsBuilderError,
@@ -105,7 +104,7 @@ async fn run() -> Result<(), Error> {
             vec![node_identity2.public_address()].into(),
             Default::default(),
             PeerFeatures::COMMUNICATION_CLIENT,
-            &protocol::comms_protocols(),
+            &[],
         ))
         .await?;
 

--- a/comms/src/builder/mod.rs
+++ b/comms/src/builder/mod.rs
@@ -52,7 +52,6 @@ use crate::{
     multiaddr::Multiaddr,
     noise::NoiseConfig,
     peer_manager::{NodeIdentity, PeerManager, PeerManagerError},
-    protocol,
     protocol::{messaging, messaging::MessagingProtocol, ProtocolNotification, Protocols},
     tor,
     transports::{SocksTransport, TcpTransport, Transport},
@@ -346,7 +345,7 @@ where
             .protocols
             .take()
             .or_else(|| Some(Protocols::new()))
-            .map(move |protocols| protocols.add(protocol::comms_protocols(), messaging_proto_tx))
+            .map(move |protocols| protocols.add(&[messaging::MESSAGING_PROTOCOL.clone()], messaging_proto_tx))
             .expect("cannot fail");
 
         //---------------------------------- ConnectionManager --------------------------------------------//

--- a/comms/src/builder/tests.rs
+++ b/comms/src/builder/tests.rs
@@ -147,11 +147,11 @@ async fn peer_to_peer_custom_protocols() {
     unpack_enum!(ConnectionManagerEvent::PeerConnected(_conn) = &*next_event);
 
     // Let's speak both our test protocols
-    let mut negotiated_substream1 = conn1.open_substream(TEST_PROTOCOL).await.unwrap();
+    let mut negotiated_substream1 = conn1.open_substream(&TEST_PROTOCOL).await.unwrap();
     assert_eq!(negotiated_substream1.protocol, TEST_PROTOCOL);
     negotiated_substream1.stream.write_all(TEST_MSG).await.unwrap();
 
-    let mut negotiated_substream2 = conn2.open_substream(ANOTHER_TEST_PROTOCOL).await.unwrap();
+    let mut negotiated_substream2 = conn2.open_substream(&ANOTHER_TEST_PROTOCOL).await.unwrap();
     assert_eq!(negotiated_substream2.protocol, ANOTHER_TEST_PROTOCOL);
     negotiated_substream2.stream.write_all(ANOTHER_TEST_MSG).await.unwrap();
 

--- a/comms/src/connection_manager/tests/listener_dialer.rs
+++ b/comms/src/connection_manager/tests/listener_dialer.rs
@@ -159,7 +159,10 @@ async fn smoke() {
 
     // Open a substream
     {
-        let mut out_stream = outbound_peer_conn.open_substream("/tari/test-proto").await.unwrap();
+        let mut out_stream = outbound_peer_conn
+            .open_substream(&ProtocolId::from_static(b"/tari/test-proto"))
+            .await
+            .unwrap();
         out_stream.stream.write_all(b"HELLO").await.unwrap();
         out_stream.stream.flush().await.unwrap();
     }

--- a/comms/src/peer_manager/peer.rs
+++ b/comms/src/peer_manager/peer.rs
@@ -258,7 +258,7 @@ mod test {
             Some(PeerFlags::BANNED),
             Some(PeerFeatures::MESSAGE_PROPAGATION),
             Some(PeerConnectionStats::new()),
-            Some(protocol::comms_protocols().to_vec()),
+            Some(vec![protocol::IDENTITY_PROTOCOL.clone()]),
         );
 
         assert_eq!(peer.public_key, public_key1);
@@ -280,7 +280,7 @@ mod test {
             .any(|net_address_with_stats| net_address_with_stats.address == net_address3));
         assert_eq!(peer.flags, PeerFlags::BANNED);
         assert_eq!(peer.has_features(PeerFeatures::MESSAGE_PROPAGATION), true);
-        assert_eq!(peer.supported_protocols, protocol::comms_protocols());
+        assert_eq!(peer.supported_protocols, vec![protocol::IDENTITY_PROTOCOL.clone()]);
     }
 
     #[test]

--- a/comms/src/protocol/error.rs
+++ b/comms/src/protocol/error.rs
@@ -31,6 +31,10 @@ pub enum ProtocolError {
     ProtocolIdTooLong,
     /// Protocol negotiation failed because the peer did not accept any protocols
     ProtocolOutboundNegotiationFailed,
+    /// Protocol negotiation failed because the peer did not offer any protocols supported by this node
+    ProtocolInboundNegotiationFailed,
+    /// Optimistic protocol negotiation failed because the peer did not offer a protocol supported by this node
+    ProtocolOptimisticNegotiationFailed,
     /// Protocol negotiation terminated by peer
     ProtocolNegotiationTerminatedByPeer,
     /// Protocol was not registered

--- a/comms/src/protocol/identity.rs
+++ b/comms/src/protocol/identity.rs
@@ -58,7 +58,7 @@ where
                 node_identity.node_id().short_str()
             );
             negotiation
-                .negotiate_protocol_outbound(&[IDENTITY_PROTOCOL.clone()])
+                .negotiate_protocol_outbound_optimistic(&IDENTITY_PROTOCOL.clone())
                 .await?
         },
         ConnectionDirection::Inbound => {

--- a/comms/src/protocol/messaging/outbound.rs
+++ b/comms/src/protocol/messaging/outbound.rs
@@ -118,7 +118,7 @@ impl OutboundMessaging {
         mut conn: PeerConnection,
     ) -> Result<NegotiatedSubstream<CommsSubstream>, MessagingProtocolError>
     {
-        match conn.open_substream(MESSAGING_PROTOCOL.clone()).await {
+        match conn.open_substream(&MESSAGING_PROTOCOL).await {
             Ok(substream) => Ok(substream),
             Err(err) => {
                 error!(

--- a/comms/src/protocol/mod.rs
+++ b/comms/src/protocol/mod.rs
@@ -37,8 +37,3 @@ pub mod messaging;
 /// Represents a protocol id string (e.g. /tari/transactions/1.0.0).
 /// This is atomically reference counted, so clones are shallow and cheap
 pub type ProtocolId = bytes::Bytes;
-
-/// The protocols offered by comms. These will be added to the list of protocols supported by this node.
-pub fn comms_protocols() -> [ProtocolId; 1] {
-    [messaging::MESSAGING_PROTOCOL.clone()]
-}

--- a/comms/src/protocol/negotiation.rs
+++ b/comms/src/protocol/negotiation.rs
@@ -21,6 +21,7 @@
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 use super::{ProtocolError, ProtocolId};
+use bitflags::bitflags;
 use bytes::{Bytes, BytesMut};
 use futures::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
 use log::*;
@@ -28,14 +29,21 @@ use std::convert::TryInto;
 
 const LOG_TARGET: &str = "comms::connection_manager::protocol";
 
-const PROTOCOL_NOT_SUPPORTED: &[u8] = b"not-supported";
-const PROTOCOL_NEGOTIATION_TERMINATED: &[u8] = b"negotiation-terminated";
-const BUF_CAPACITY: usize = std::u8::MAX as usize + 1;
-const MAX_ROUNDS_ALLOWED: u8 = 10;
+const BUF_CAPACITY: usize = std::u8::MAX as usize;
+const MAX_ROUNDS_ALLOWED: u8 = 5;
 
 pub struct ProtocolNegotiation<'a, TSocket> {
     buf: BytesMut,
     socket: &'a mut TSocket,
+}
+
+bitflags! {
+    struct Flags: u8 {
+        const NONE = 0x00;
+        const OPTIMISTIC = 0x01;
+        const TERMINATE = 0x02;
+        const NOT_SUPPORTED = 0x04;
+    }
 }
 
 impl<'a, TSocket> ProtocolNegotiation<'a, TSocket>
@@ -60,14 +68,18 @@ where TSocket: AsyncRead + AsyncWrite + Unpin
     ) -> Result<ProtocolId, ProtocolError>
     {
         for protocol in selected_protocols {
-            self.write_frame_flush(protocol).await?;
+            self.write_frame_flush(protocol, Flags::NONE).await?;
 
-            let proto = self.read_frame().await?;
+            let (proto, flags) = self.read_frame().await?;
             // Friendly reply indicating that the maximum number of protocols in one 'session' has been reached
             // This reply cannot be relied upon, so protocol negotiation should be used with a timeout
-            if proto.as_ref() == PROTOCOL_NEGOTIATION_TERMINATED {
+            if flags.contains(Flags::TERMINATE) {
                 return Err(ProtocolError::ProtocolNegotiationTerminatedByPeer);
             }
+            if flags.contains(Flags::NOT_SUPPORTED) {
+                continue;
+            }
+
             if proto.as_ref() == protocol {
                 // Shallow copy
                 return Ok(protocol.clone());
@@ -75,9 +87,22 @@ where TSocket: AsyncRead + AsyncWrite + Unpin
         }
 
         // No more protocols to negotiate - let the peer know
-        self.write_frame_flush(&PROTOCOL_NEGOTIATION_TERMINATED.into()).await?;
+        self.write_frame_flush(&[], Flags::TERMINATE).await?;
 
         Err(ProtocolError::ProtocolOutboundNegotiationFailed)
+    }
+
+    /// Negotiate a protocol to speak. Since this node is initiating this interation, send each protocol this node
+    /// wishes to speak until the destination node agrees.
+    pub async fn negotiate_protocol_outbound_optimistic(
+        &mut self,
+        protocol: &ProtocolId,
+    ) -> Result<ProtocolId, ProtocolError>
+    {
+        self.write_frame_flush(protocol, Flags::OPTIMISTIC | Flags::TERMINATE)
+            .await?;
+
+        Ok(protocol.clone())
     }
 
     /// Negotiate a protocol to speak. Since this node is the responder, first we wait for a protocol to be sent and see
@@ -87,62 +112,83 @@ where TSocket: AsyncRead + AsyncWrite + Unpin
         supported_protocols: &[ProtocolId],
     ) -> Result<ProtocolId, ProtocolError>
     {
-        for _ in 0..MAX_ROUNDS_ALLOWED {
-            let proto = self.read_frame().await?;
+        let mut round = 0;
+        loop {
+            let (proto, flags) = self.read_frame().await?;
+
+            if flags.contains(Flags::OPTIMISTIC) {
+                return if supported_protocols.as_ref().iter().any(|p| proto == p) {
+                    Ok(proto.clone())
+                } else {
+                    Err(ProtocolError::ProtocolOptimisticNegotiationFailed)
+                };
+            }
 
             // Allow the peer to send a friendly reply saying that it has no more protocols to negotiate.
             // This reply cannot be relied upon, so protocol negotiation should be used with a timeout
-            if proto.as_ref() == PROTOCOL_NEGOTIATION_TERMINATED {
+            if flags.contains(Flags::TERMINATE) {
                 return Err(ProtocolError::ProtocolNegotiationTerminatedByPeer);
             }
 
             match supported_protocols.as_ref().iter().find(|p| proto == p) {
                 Some(proto) => {
-                    self.write_frame_flush(proto).await?;
+                    self.write_frame_flush(proto, Flags::NONE).await?;
                     // Shallow copy
                     return Ok(proto.clone());
                 },
                 None => {
-                    self.write_frame_flush(&PROTOCOL_NOT_SUPPORTED.into()).await?;
+                    let mut flags = Flags::NOT_SUPPORTED;
+                    let terminate = round == MAX_ROUNDS_ALLOWED - 1;
+                    if terminate {
+                        // Maximum rounds reached - send a friendly reply to let the peer know to give up
+                        flags |= Flags::TERMINATE;
+                    }
+                    self.write_frame_flush(&[], flags).await?;
+                    if terminate {
+                        break;
+                    }
                 },
             }
+
+            round += 1;
         }
 
-        // Maximum rounds reached - send a friendly reply to let the peer know to give up
-        self.write_frame_flush(&PROTOCOL_NEGOTIATION_TERMINATED.into()).await?;
-
-        Err(ProtocolError::ProtocolOutboundNegotiationFailed)
+        Err(ProtocolError::ProtocolInboundNegotiationFailed)
     }
 
-    async fn read_frame(&mut self) -> Result<Bytes, ProtocolError> {
-        self.socket.read_exact(&mut self.buf[..1]).await?;
-        // Len can never overrun the buffer because the buffer len is u8::MAX + 1 and the length delimiter
-        // is a u8. If that changes, then len should be checked here
+    async fn read_frame(&mut self) -> Result<(Bytes, Flags), ProtocolError> {
+        self.socket.read_exact(&mut self.buf[..2]).await?;
+        // Len can never overflow the buffer because the buffer len is u8::MAX and the length delimiter
+        // is a u8. If that changes, then len should be checked for overflow
         let len = u8::from_be_bytes([self.buf[0]]) as usize;
-        self.socket.read_exact(&mut self.buf[1..=len]).await?;
+        let flags = Flags::from_bits_truncate(u8::from_be_bytes([self.buf[1]]));
+        self.socket.read_exact(&mut self.buf[0..len]).await?;
         trace!(
             target: LOG_TARGET,
-            "Read frame '{}' ({} byte(s))",
-            String::from_utf8_lossy(&self.buf[1..=len]),
-            len
+            "Read frame '{}' ({} byte(s) Flags={:?})",
+            String::from_utf8_lossy(&self.buf[0..len]),
+            len,
+            flags,
         );
-        Ok(Bytes::copy_from_slice(&self.buf[1..=len]))
+        Ok((Bytes::copy_from_slice(&self.buf[0..len]), flags))
     }
 
-    async fn write_frame_flush(&mut self, protocol: &ProtocolId) -> Result<(), ProtocolError> {
+    async fn write_frame_flush(&mut self, protocol: &[u8], flags: Flags) -> Result<(), ProtocolError> {
         let len_byte = protocol
             .len()
             .try_into()
             .map(|v: u8| v.to_be_bytes())
             .map_err(|_| ProtocolError::ProtocolIdTooLong)?;
-        self.socket.write_all(&len_byte).await?;
+        self.socket.write(&len_byte).await?;
+        self.socket.write(&flags.bits().to_be_bytes()).await?;
         self.socket.write_all(&protocol).await?;
         self.socket.flush().await?;
         trace!(
             target: LOG_TARGET,
-            "Wrote frame '{}' ({} byte(s))",
+            "Wrote frame '{}' ({} byte(s) Flags={:?})",
             String::from_utf8_lossy(&protocol),
-            len_byte[0]
+            len_byte[0],
+            flags
         );
         Ok(())
     }
@@ -165,7 +211,7 @@ mod test {
             .into_iter()
             .map(|p| ProtocolId::from_static(p))
             .collect::<Vec<_>>();
-        let selected_protocols = vec![b"C", b"D", b"A"]
+        let selected_protocols = vec![b"C", b"D", b"E", b"F", b"A"]
             .into_iter()
             .map(|p| ProtocolId::from_static(p))
             .collect::<Vec<_>>();
@@ -203,5 +249,72 @@ mod test {
 
         unpack_enum!(ProtocolError::ProtocolNegotiationTerminatedByPeer = in_proto.unwrap_err());
         unpack_enum!(ProtocolError::ProtocolOutboundNegotiationFailed = out_proto.unwrap_err());
+    }
+
+    #[tokio_macros::test_basic]
+    async fn negotiate_fail_max_rounds() {
+        let (mut initiator, mut responder) = MemorySocket::new_pair();
+        let mut negotiate_out = ProtocolNegotiation::new(&mut initiator);
+        let mut negotiate_in = ProtocolNegotiation::new(&mut responder);
+
+        let supported_protocols = vec![b"A", b"B"]
+            .into_iter()
+            .map(|p| ProtocolId::from_static(p))
+            .collect::<Vec<_>>();
+        let selected_protocols = vec![b"C", b"D", b"E", b"F", b"G", b"A"]
+            .into_iter()
+            .map(|p| ProtocolId::from_static(p))
+            .collect::<Vec<_>>();
+
+        let (in_proto, out_proto) = future::join(
+            negotiate_in.negotiate_protocol_inbound(&supported_protocols),
+            negotiate_out.negotiate_protocol_outbound(&selected_protocols),
+        )
+        .await;
+
+        unpack_enum!(ProtocolError::ProtocolInboundNegotiationFailed = in_proto.unwrap_err());
+        unpack_enum!(ProtocolError::ProtocolNegotiationTerminatedByPeer = out_proto.unwrap_err());
+    }
+
+    #[tokio_macros::test_basic]
+    async fn negotiate_success_optimistic() {
+        let (mut initiator, mut responder) = MemorySocket::new_pair();
+        let mut negotiate_out = ProtocolNegotiation::new(&mut initiator);
+        let mut negotiate_in = ProtocolNegotiation::new(&mut responder);
+
+        let supported_protocols = vec![b"B", b"A"]
+            .into_iter()
+            .map(|p| ProtocolId::from_static(p))
+            .collect::<Vec<_>>();
+
+        let (in_proto, out_proto) = future::join(
+            negotiate_in.negotiate_protocol_inbound(&supported_protocols),
+            negotiate_out.negotiate_protocol_outbound_optimistic(&Bytes::from_static(b"A")),
+        )
+        .await;
+
+        assert_eq!(in_proto.unwrap(), ProtocolId::from_static(b"A"));
+        out_proto.unwrap();
+    }
+
+    #[tokio_macros::test_basic]
+    async fn negotiate_fail_optimistic() {
+        let (mut initiator, mut responder) = MemorySocket::new_pair();
+        let mut negotiate_out = ProtocolNegotiation::new(&mut initiator);
+        let mut negotiate_in = ProtocolNegotiation::new(&mut responder);
+
+        let supported_protocols = vec![b"A", b"B"]
+            .into_iter()
+            .map(|p| ProtocolId::from_static(p))
+            .collect::<Vec<_>>();
+
+        let (in_proto, out_proto) = future::join(
+            negotiate_in.negotiate_protocol_inbound(&supported_protocols),
+            negotiate_out.negotiate_protocol_outbound_optimistic(&Bytes::from_static(b"C")),
+        )
+        .await;
+
+        unpack_enum!(ProtocolError::ProtocolOptimisticNegotiationFailed = in_proto.unwrap_err());
+        out_proto.unwrap();
     }
 }

--- a/comms/src/protocol/protocols.rs
+++ b/comms/src/protocol/protocols.rs
@@ -22,7 +22,7 @@
 
 use crate::{
     peer_manager::NodeId,
-    protocol::{ProtocolError, ProtocolId},
+    protocol::{ProtocolError, ProtocolId, IDENTITY_PROTOCOL},
 };
 use futures::{channel::mpsc, SinkExt};
 use std::collections::HashMap;
@@ -81,7 +81,10 @@ impl<TSubstream> Protocols<TSubstream> {
     }
 
     pub fn get_supported_protocols(&self) -> Vec<ProtocolId> {
-        self.protocols.keys().cloned().collect()
+        let mut p = Vec::with_capacity(self.protocols.len() + 1);
+        p.push(IDENTITY_PROTOCOL.clone());
+        p.extend(self.protocols.keys().cloned());
+        p
     }
 
     pub async fn notify(
@@ -110,6 +113,7 @@ mod test {
     fn add() {
         let (tx, _) = mpsc::channel(1);
         let protos = [
+            IDENTITY_PROTOCOL.clone(),
             ProtocolId::from_static(b"/tari/test/1"),
             ProtocolId::from_static(b"/tari/test/2"),
         ];

--- a/comms/src/tor/control_client/commands/add_onion.rs
+++ b/comms/src/tor/control_client/commands/add_onion.rs
@@ -28,8 +28,9 @@ use crate::tor::control_client::{
     response::ResponseLine,
     types::{KeyBlob, KeyType, PortMapping, PrivateKey},
 };
-use std::{borrow::Cow, num::NonZeroU16};
+use std::{borrow::Cow, fmt, num::NonZeroU16};
 
+#[derive(Debug)]
 pub enum AddOnionFlag {
     /// The server should not include the newly generated private key as part of the response.
     DiscardPK,
@@ -44,15 +45,15 @@ pub enum AddOnionFlag {
     MaxStreamsCloseCircuit,
 }
 
-impl ToString for AddOnionFlag {
-    fn to_string(&self) -> String {
+impl fmt::Display for AddOnionFlag {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         use AddOnionFlag::*;
         match self {
-            DiscardPK => "DiscardPK".to_string(),
-            Detach => "Detach".to_string(),
-            BasicAuth => "BasicAuth".to_string(),
-            NonAnonymous => "NonAnonymous".to_string(),
-            MaxStreamsCloseCircuit => "MaxStreamsCloseCircuit".to_string(),
+            DiscardPK => write!(f, "DiscardPK"),
+            Detach => write!(f, "Detach"),
+            BasicAuth => write!(f, "BasicAuth"),
+            NonAnonymous => write!(f, "NonAnonymous"),
+            MaxStreamsCloseCircuit => write!(f, "MaxStreamsCloseCircuit"),
         }
     }
 }
@@ -172,6 +173,21 @@ impl TorCommand for AddOnion<'_> {
             private_key,
             onion_port: self.port_mapping.onion_port(),
         })
+    }
+}
+
+impl fmt::Display for AddOnion<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "ADD_ONION (KeyType={} KeyBlob={} Flags={} PortMapping={})",
+            self.key_type.as_tor_repr(),
+            self.key_blob,
+            self.flags
+                .iter()
+                .fold(String::new(), |acc, f| format!("{}, {}", acc, f)),
+            self.port_mapping
+        )
     }
 }
 

--- a/comms/src/tor/control_client/commands/del_onion.rs
+++ b/comms/src/tor/control_client/commands/del_onion.rs
@@ -21,6 +21,7 @@
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 use crate::tor::control_client::{commands::TorCommand, error::TorClientError, response::ResponseLine};
+use std::fmt;
 
 /// The DEL_ONION command.
 ///
@@ -50,6 +51,12 @@ impl<'a> TorCommand for DelOnion<'a> {
         }
 
         Ok(())
+    }
+}
+
+impl fmt::Display for DelOnion<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "DEL_ONION (ServiceId = {})", self.service_id)
     }
 }
 

--- a/comms/src/tor/control_client/commands/key_value.rs
+++ b/comms/src/tor/control_client/commands/key_value.rs
@@ -21,7 +21,7 @@
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 use crate::tor::control_client::{commands::TorCommand, error::TorClientError, parsers, response::ResponseLine};
-use std::{borrow::Cow, marker::PhantomData};
+use std::{borrow::Cow, fmt, marker::PhantomData};
 
 /// The GETCONF command.
 ///
@@ -89,6 +89,17 @@ impl<'a, 'b> TorCommand for KeyValueCommand<'a, 'b> {
             .map(|(_, values)| values.iter().map(|value| Cow::from(value.clone().into_owned())))
             .flatten()
             .collect())
+    }
+}
+
+impl fmt::Display for KeyValueCommand<'_, '_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "{} (Args = {})",
+            self.command,
+            self.args.iter().fold(String::new(), |acc, a| format!("{}, {}", acc, a))
+        )
     }
 }
 

--- a/comms/src/tor/control_client/response.rs
+++ b/comms/src/tor/control_client/response.rs
@@ -26,6 +26,7 @@ const OK_CODE: u16 = 250;
 pub const EVENT_CODE: u16 = 650;
 
 /// Represents a single response line from the server.
+#[derive(Debug)]
 pub struct ResponseLine<'a> {
     pub(super) value: Cow<'a, str>,
     pub(super) code: u16,

--- a/comms/src/tor/control_client/types.rs
+++ b/comms/src/tor/control_client/types.rs
@@ -65,6 +65,18 @@ impl KeyBlob<'_> {
     }
 }
 
+impl fmt::Display for KeyBlob<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        use KeyBlob::*;
+        match self {
+            Best => write!(f, "Best"),
+            Rsa1024 => write!(f, "Rsa1024"),
+            Ed25519V3 => write!(f, "Ed25519V3"),
+            String(_) => write!(f, "[redacted]"),
+        }
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub enum PrivateKey {
     /// The server should use the 1024 bit RSA key provided in as KeyBlob (v2).


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR removes a round of comms when negotiating protocols if the protocols supported
by the peer are known ahead of time (see #1404).

The "normal" negotiation protocol as follows (best case):
1. Initiator sends protocol candidate, and waits
1. Responder responds with TERMINATE flag and name of protocol to speak
1. Protocol begins

The "optimistic" negotiation is as follows:
1. Initiator sends protocol candidate with OPTIMISTIC flag (no waiting)
1. Protocol begins

Responder will receive the protocol name with the OPTIMISTIC flag and
either close the stream (if invalid) or accept and begin the protocol.

EXTRA: logs for tor control client

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #1381 - establishing connections should be as efficient as possible.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Unit tests + existing test pass 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [x] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch.
* [x] I ran `cargo-fmt --all` before pushing.
* [x] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
