### PR TITLE
Neaten up log messages

### DIFF
--- a/applications/tari_base_node/src/builder.rs
+++ b/applications/tari_base_node/src/builder.rs
@@ -99,7 +99,7 @@ use tari_wallet::{
 };
 use tokio::{runtime, stream::StreamExt};
 
-const LOG_TARGET: &str = "base_node::initialization";
+const LOG_TARGET: &str = "c::bn::initialization";
 
 #[macro_export]
 macro_rules! using_backend {

--- a/base_layer/core/src/base_node/service/initializer.rs
+++ b/base_layer/core/src/base_node/service/initializer.rs
@@ -53,7 +53,7 @@ use tari_service_framework::{
 use tari_shutdown::ShutdownSignal;
 use tokio::runtime;
 
-const LOG_TARGET: &str = "base_node::service::initializer";
+const LOG_TARGET: &str = "c::bn::service::initializer";
 
 /// Initializer for the Base Node service handle and service future.
 pub struct BaseNodeServiceInitializer<T>

--- a/base_layer/core/src/mempool/service/initializer.rs
+++ b/base_layer/core/src/mempool/service/initializer.rs
@@ -55,7 +55,7 @@ use tari_service_framework::{
 use tari_shutdown::ShutdownSignal;
 use tokio::runtime;
 
-const LOG_TARGET: &str = "base_node::mempool_service::initializer";
+const LOG_TARGET: &str = "c::bn::mempool_service::initializer";
 
 /// Initializer for the Mempool service and service future.
 pub struct MempoolServiceInitializer<T>

--- a/base_layer/p2p/src/services/liveness/mock.rs
+++ b/base_layer/p2p/src/services/liveness/mock.rs
@@ -40,7 +40,7 @@ use tari_broadcast_channel::{Publisher, SendError};
 use tari_crypto::tari_utilities::acquire_write_lock;
 use tari_service_framework::{reply_channel, RequestContext};
 
-const LOG_TARGET: &str = "base_layer::p2p::liveness_mock";
+const LOG_TARGET: &str = "p2p::liveness_mock";
 
 pub fn create_p2p_liveness_mock(buf_size: usize) -> (LivenessHandle, LivenessMock) {
     let (sender, receiver) = reply_channel::unbounded();

--- a/base_layer/p2p/src/services/utils.rs
+++ b/base_layer/p2p/src/services/utils.rs
@@ -24,7 +24,7 @@ use crate::{comms_connector::PeerMessage, domain_message::DomainMessage};
 use log::*;
 use std::{fmt::Debug, sync::Arc};
 
-const LOG_TARGET: &str = "base_layer::p2p::services";
+const LOG_TARGET: &str = "p2p::services";
 
 /// For use with `StreamExt::filter_map`. Log and filter any errors.
 pub async fn ok_or_skip_result<T, E>(res: Result<T, E>) -> Option<T>

--- a/base_layer/wallet/src/contacts_service/mod.rs
+++ b/base_layer/wallet/src/contacts_service/mod.rs
@@ -41,7 +41,7 @@ pub mod handle;
 pub mod service;
 pub mod storage;
 
-const LOG_TARGET: &str = "base_layer::wallet::contacts_service::initializer";
+const LOG_TARGET: &str = "wallet::contacts_service::initializer";
 
 pub struct ContactsServiceInitializer<T>
 where T: ContactsBackend

--- a/base_layer/wallet/src/contacts_service/service.rs
+++ b/base_layer/wallet/src/contacts_service/service.rs
@@ -29,7 +29,7 @@ use futures::{pin_mut, StreamExt};
 use log::*;
 use tari_service_framework::reply_channel;
 
-const LOG_TARGET: &str = "base_layer::wallet:contacts_service";
+const LOG_TARGET: &str = "wallet:contacts_service";
 
 pub struct ContactsService<T>
 where T: ContactsBackend + 'static

--- a/base_layer/wallet/src/output_manager_service/handle.rs
+++ b/base_layer/wallet/src/output_manager_service/handle.rs
@@ -26,7 +26,7 @@ use crate::output_manager_service::{
     storage::database::PendingTransactionOutputs,
 };
 use futures::{stream::Fuse, StreamExt};
-use std::{collections::HashMap, time::Duration};
+use std::{collections::HashMap, fmt, time::Duration};
 use tari_broadcast_channel::Subscriber;
 use tari_comms::types::CommsPublicKey;
 use tari_core::transactions::{
@@ -56,6 +56,30 @@ pub enum OutputManagerRequest {
     GetSeedWords,
     SetBaseNodePublicKey(CommsPublicKey),
     SyncWithBaseNode,
+}
+
+impl fmt::Display for OutputManagerRequest {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::GetBalance => f.write_str("GetBalance"),
+            Self::AddOutput(v) => f.write_str(&format!("AddOutput ({})", v.value)),
+            Self::GetRecipientKey(v) => f.write_str(&format!("GetRecipientKey ({})", v.0)),
+            Self::GetCoinbaseKey(v) => f.write_str(&format!("GetCoinbaseKey ({})", v.0)),
+            Self::ConfirmTransaction(v) => f.write_str(&format!("ConfirmTransaction ({})", v.0)),
+            Self::PrepareToSendTransaction((_, _, _, msg)) => {
+                f.write_str(&format!("PrepareToSendTransaction ({})", msg))
+            },
+            Self::CancelTransaction(v) => f.write_str(&format!("CancelTransaction ({})", v)),
+            Self::TimeoutTransactions(d) => f.write_str(&format!("TimeoutTransactions ({}s)", d.as_secs())),
+            Self::GetPendingTransactions => f.write_str("GetPendingTransactions"),
+            Self::GetSpentOutputs => f.write_str("GetSpentOutputs"),
+            Self::GetUnspentOutputs => f.write_str("GetUnspentOutputs"),
+            Self::GetInvalidOutputs => f.write_str("GetInvalidOutputs"),
+            Self::GetSeedWords => f.write_str("GetSeedWords"),
+            Self::SetBaseNodePublicKey(k) => f.write_str(&format!("SetBaseNodePublicKey ({})", k)),
+            Self::SyncWithBaseNode => f.write_str("SyncWithBaseNode"),
+        }
+    }
 }
 
 /// API Reply enum

--- a/base_layer/wallet/src/output_manager_service/service.rs
+++ b/base_layer/wallet/src/output_manager_service/service.rs
@@ -71,7 +71,7 @@ use tari_key_manager::{
 use tari_p2p::{domain_message::DomainMessage, tari_message::TariMessageType};
 use tari_service_framework::reply_channel;
 
-const LOG_TARGET: &str = "base_layer::wallet::output_manager_service";
+const LOG_TARGET: &str = "wallet::output_manager_service";
 
 /// This service will manage a wallet's available outputs and the key manager that produces the keys for these outputs.
 /// The service will assemble transactions to be sent from the wallets available outputs and provide keys to receive
@@ -212,7 +212,7 @@ where
         utxo_query_timeout_futures: &mut FuturesUnordered<BoxFuture<'static, u64>>,
     ) -> Result<OutputManagerResponse, OutputManagerError>
     {
-        trace!(target: LOG_TARGET, "Handling Service Request: {:?}", request);
+        trace!(target: LOG_TARGET, "Handling Service Request: {}", request);
         match request {
             OutputManagerRequest::AddOutput(uo) => {
                 self.add_output(uo).await.map(|_| OutputManagerResponse::OutputAdded)

--- a/base_layer/wallet/src/text_message_service/service.rs
+++ b/base_layer/wallet/src/text_message_service/service.rs
@@ -50,7 +50,7 @@ use tari_p2p::{
 use tari_service_framework::reply_channel;
 use tokio_executor::threadpool::blocking;
 
-const LOG_TARGET: &str = "base_layer::wallet::text_messsage_service";
+const LOG_TARGET: &str = "wallet::text_messsage_service";
 
 /// Represents an Acknowledgement of receiving a Text Message
 #[derive(Clone, Debug, Serialize, Deserialize)]

--- a/base_layer/wallet/src/transaction_service/handle.rs
+++ b/base_layer/wallet/src/transaction_service/handle.rs
@@ -29,7 +29,7 @@ use crate::{
     },
 };
 use futures::{stream::Fuse, StreamExt};
-use std::collections::HashMap;
+use std::{collections::HashMap, fmt};
 use tari_broadcast_channel::Subscriber;
 use tari_comms::types::CommsPublicKey;
 use tari_core::transactions::{tari_amount::MicroTari, transaction::Transaction};
@@ -58,6 +58,42 @@ pub enum TransactionServiceRequest {
     MineTransaction(TxId),
     #[cfg(feature = "test_harness")]
     BroadcastTransaction(TxId),
+}
+
+impl fmt::Display for TransactionServiceRequest {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::GetPendingInboundTransactions => f.write_str("GetPendingInboundTransactions"),
+            Self::GetPendingOutboundTransactions => f.write_str("GetPendingOutboundTransactions"),
+            Self::GetCompletedTransactions => f.write_str("GetCompletedTransactions"),
+            Self::SetBaseNodePublicKey(k) => f.write_str(&format!("SetBaseNodePublicKey ({})", k)),
+            Self::SendTransaction((k, v, _, msg)) => {
+                f.write_str(&format!("SendTransaction (to {}, {}, {})", k, v, msg))
+            },
+            Self::RequestCoinbaseSpendingKey((v, h)) => {
+                f.write_str(&format!("RequestCoinbaseSpendingKey ({}, maturity={})", v, h))
+            },
+            Self::CompleteCoinbaseTransaction((id, _)) => f.write_str(&format!("CompleteCoinbaseTransaction ({})", id)),
+            Self::CancelPendingCoinbaseTransaction(id) => {
+                f.write_str(&format!("CancelPendingCoinbaseTransaction ({}) ", id))
+            },
+            Self::ImportUtxo(v, k, msg) => f.write_str(&format!("ImportUtxo (from {}, {}, {})", k, v, msg)),
+            #[cfg(feature = "test_harness")]
+            Self::CompletePendingOutboundTransaction(tx) => {
+                f.write_str(&format!("CompletePendingOutboundTransaction ({})", tx.tx_id))
+            },
+            #[cfg(feature = "test_harness")]
+            Self::FinalizePendingInboundTransaction(id) => {
+                f.write_str(&format!("FinalizePendingInboundTransaction ({})", id))
+            },
+            #[cfg(feature = "test_harness")]
+            Self::AcceptTestTransaction((id, _, _)) => f.write_str(&format!("AcceptTestTransaction ({})", id)),
+            #[cfg(feature = "test_harness")]
+            Self::MineTransaction(id) => f.write_str(&format!("MineTransaction ({})", id)),
+            #[cfg(feature = "test_harness")]
+            Self::BroadcastTransaction(id) => f.write_str(&format!("BroadcastTransaction ({})", id)),
+        }
+    }
 }
 
 /// API Response enum

--- a/base_layer/wallet/src/transaction_service/mod.rs
+++ b/base_layer/wallet/src/transaction_service/mod.rs
@@ -62,7 +62,7 @@ use tari_service_framework::{
 use tari_shutdown::ShutdownSignal;
 use tokio::runtime;
 
-const LOG_TARGET: &str = "base_layer::wallet::transaction_service";
+const LOG_TARGET: &str = "wallet::transaction_service";
 
 pub struct TransactionServiceInitializer<T>
 where T: TransactionBackend

--- a/base_layer/wallet/src/transaction_service/service.rs
+++ b/base_layer/wallet/src/transaction_service/service.rs
@@ -98,7 +98,7 @@ use tari_crypto::{commitment::HomomorphicCommitmentFactory, keys::SecretKey, tar
 use tari_p2p::{domain_message::DomainMessage, tari_message::TariMessageType};
 use tari_service_framework::{reply_channel, reply_channel::Receiver};
 
-const LOG_TARGET: &str = "base_layer::wallet::transaction_service::service";
+const LOG_TARGET: &str = "wallet::transaction_service::service";
 
 /// Contains the generated TxId and SpendingKey for a Pending Coinbase transaction
 #[derive(Debug)]
@@ -397,7 +397,7 @@ where
         mined_request_timeout_futures: &mut FuturesUnordered<BoxFuture<'static, TxId>>,
     ) -> Result<TransactionServiceResponse, TransactionServiceError>
     {
-        trace!(target: LOG_TARGET, "Handling Service Request: {:?}", request);
+        trace!(target: LOG_TARGET, "Handling Service Request: {}", request);
         match request {
             TransactionServiceRequest::SendTransaction((dest_pubkey, amount, fee_per_gram, message)) => self
                 .send_transaction(dest_pubkey, amount, fee_per_gram, message, discovery_process_futures)

--- a/base_layer/wallet/src/wallet.rs
+++ b/base_layer/wallet/src/wallet.rs
@@ -76,7 +76,7 @@ use tari_p2p::{
 use tari_service_framework::StackBuilder;
 use tokio::runtime::Runtime;
 
-const LOG_TARGET: &str = "base_layer::wallet";
+const LOG_TARGET: &str = "wallet";
 
 #[derive(Clone)]
 pub struct WalletConfig {

--- a/base_layer/wallet_ffi/src/callback_handler.rs
+++ b/base_layer/wallet_ffi/src/callback_handler.rs
@@ -32,7 +32,7 @@ use tari_wallet::{
     },
 };
 
-const LOG_TARGET: &str = "base_layer::wallet::transaction_service::callback_handler";
+const LOG_TARGET: &str = "wallet::transaction_service::callback_handler";
 
 pub struct CallbackHandler<TBackend>
 where TBackend: TransactionBackend + 'static

--- a/comms/dht/src/inbound/dht_handler/task.rs
+++ b/comms/dht/src/inbound/dht_handler/task.rs
@@ -376,7 +376,7 @@ where
             peer_features: self.node_identity.features().bits(),
         };
 
-        trace!("Sending direct join request to {}", dest_public_key);
+        trace!(target: LOG_TARGET, "Sending direct join request to {}", dest_public_key);
         self.outbound_service
             .send_message_no_header(
                 SendMessageParams::new()
@@ -407,7 +407,7 @@ where
             nonce,
         };
 
-        trace!("Sending discovery response to {}", dest_public_key);
+        trace!(target: LOG_TARGET, "Sending discovery response to {}", dest_public_key);
         self.outbound_service
             .send_message_no_header(
                 SendMessageParams::new()


### PR DESCRIPTION
* Wallet request messages that printed a lot of debug information now
prints a human-friendly summary
* Normalise LOG_TARGET strings:
  * to `c::bn`, short for `core::base_node`
  * drop the leading `base_layer`
* Add target: LOG_TARGET in a few spots that were missing it

