### PR TITLE
Added list-connections command

### DIFF
--- a/applications/tari_base_node/Cargo.toml
+++ b/applications/tari_base_node/Cargo.toml
@@ -32,5 +32,5 @@ serde_json = "1.0"
 tokio = { version="0.2.10", features = ["signal"] }
 rustyline = "6.0"
 rustyline-derive = "0.3"
-strum = "0.17.1"
-strum_macros = "0.17.1"
+strum = "0.18.0"
+strum_macros = "0.18.0"

--- a/applications/tari_base_node/src/builder.rs
+++ b/applications/tari_base_node/src/builder.rs
@@ -32,7 +32,7 @@ use std::{
 use tari_common::{CommsTransport, DatabaseType, GlobalConfig, Network, SocksAuthentication, TorControlAuthentication};
 use tari_comms::{
     multiaddr::Multiaddr,
-    peer_manager::{NodeId, NodeIdentity, Peer, PeerFeatures, PeerFlags, PeerManager},
+    peer_manager::{NodeId, NodeIdentity, Peer, PeerFeatures, PeerFlags},
     socks,
     tor,
     tor::TorIdentity,
@@ -141,9 +141,9 @@ impl NodeContainer {
         using_backend!(self, ctx, ctx.local_node())
     }
 
-    /// Returns the PeerManager.
-    pub fn peer_manager(&self) -> Arc<PeerManager> {
-        using_backend!(self, ctx, ctx.comms.peer_manager())
+    /// Returns the CommsNode.
+    pub fn comms(&self) -> &CommsNode {
+        using_backend!(self, ctx, &ctx.comms)
     }
 
     /// Returns this node's identity.

--- a/comms/src/connection_manager/manager.rs
+++ b/comms/src/connection_manager/manager.rs
@@ -341,6 +341,9 @@ where
             GetActiveConnection(node_id, reply_tx) => {
                 let _ = reply_tx.send(self.active_connections.get(&node_id).map(Clone::clone));
             },
+            GetActiveConnections(reply_tx) => {
+                let _ = reply_tx.send(self.active_connections.values().cloned().collect());
+            },
         }
     }
 

--- a/comms/src/connection_manager/peer_connection.rs
+++ b/comms/src/connection_manager/peer_connection.rs
@@ -181,12 +181,14 @@ impl PeerConnection {
 
 impl fmt::Display for PeerConnection {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
-        f.debug_struct("PeerConnection")
-            .field("id", &self.id)
-            .field("peer_node_id", &self.peer_node_id.short_str())
-            .field("direction", &self.direction.to_string())
-            .field("address", &self.address.to_string())
-            .finish()
+        write!(
+            f,
+            "Id = {}, Node ID = {}, Direction = {}, Peer Address = {}",
+            self.id,
+            self.peer_node_id.short_str(),
+            self.direction.to_string(),
+            self.address.to_string()
+        )
     }
 }
 

--- a/comms/src/test_utils/connection_manager_mock.rs
+++ b/comms/src/test_utils/connection_manager_mock.rs
@@ -147,6 +147,11 @@ impl ConnectionManagerMock {
                     .send(self.state.active_conns.lock().await.get(&node_id).map(Clone::clone))
                     .unwrap();
             },
+            GetActiveConnections(reply_tx) => {
+                reply_tx
+                    .send(self.state.active_conns.lock().await.values().cloned().collect())
+                    .unwrap();
+            },
         }
     }
 }


### PR DESCRIPTION
- `list-connections` command will list the currently active connections
- Changed all commands to kebab-case
- `get-peers` to `list-peers`
- Tab completion moves to the end of the line

```
>> list-connections

Id = 10, Node ID = ee3db715400b5ad6, Direction = Outbound, Peer Address = /onion3/xxxxxxxx:18141
Id = 11, Node ID = fd728cb5b86eae64, Direction = Outbound, Peer Address = /onion3/xxxxxxxx:18141
```
