### PR TITLE
Removed base node service multi peer request system

### DIFF
--- a/base_layer/core/src/base_node/comms_interface/comms_request.rs
+++ b/base_layer/core/src/base_node/comms_interface/comms_request.rs
@@ -29,16 +29,6 @@ use crate::{
 use serde::{Deserialize, Serialize};
 use std::fmt::{Display, Error, Formatter};
 
-/// NodeCommsRequestType is used to specify the amount of peers that need to be queried before a request can be
-/// finalized.
-#[derive(Debug, Serialize, Deserialize)]
-pub enum NodeCommsRequestType {
-    /// Send the request to a single remote base node
-    Single,
-    /// Send the request to a number of remote base nodes and accumulate all the responses.
-    Many,
-}
-
 /// A container for the parameters required for a FetchMmrState request.
 #[derive(Debug, Serialize, Deserialize)]
 pub struct MmrStateRequest {

--- a/base_layer/core/src/base_node/comms_interface/mod.rs
+++ b/base_layer/core/src/base_node/comms_interface/mod.rs
@@ -28,7 +28,7 @@ mod local_interface;
 mod outbound_interface;
 
 // Public re-exports
-pub use comms_request::{MmrStateRequest, NodeCommsRequest, NodeCommsRequestType};
+pub use comms_request::{MmrStateRequest, NodeCommsRequest};
 pub use comms_response::NodeCommsResponse;
 pub use error::CommsInterfaceError;
 pub use inbound_handlers::{BlockEvent, InboundNodeCommsHandlers};

--- a/base_layer/core/src/base_node/mod.rs
+++ b/base_layer/core/src/base_node/mod.rs
@@ -56,4 +56,4 @@ pub mod proto;
 #[cfg(any(feature = "base_node", feature = "base_node_proto", feature = "mempool_proto"))]
 mod waiting_requests;
 #[cfg(any(feature = "base_node", feature = "base_node_proto", feature = "mempool_proto"))]
-pub use waiting_requests::{generate_request_key, RequestKey, WaitingRequest, WaitingRequestError, WaitingRequests};
+pub use waiting_requests::{generate_request_key, RequestKey, WaitingRequestError, WaitingRequests};

--- a/base_layer/core/tests/node_comms_interface.rs
+++ b/base_layer/core/tests/node_comms_interface.rs
@@ -27,13 +27,7 @@ use futures::{channel::mpsc::unbounded as futures_mpsc_channel_unbounded, execut
 use tari_broadcast_channel::bounded;
 use tari_core::{
     base_node::{
-        comms_interface::{
-            CommsInterfaceError,
-            InboundNodeCommsHandlers,
-            NodeCommsRequest,
-            NodeCommsRequestType,
-            NodeCommsResponse,
-        },
+        comms_interface::{CommsInterfaceError, InboundNodeCommsHandlers, NodeCommsRequest, NodeCommsResponse},
         OutboundNodeCommsInterface,
     },
     blocks::{BlockBuilder, BlockHeader},
@@ -54,11 +48,8 @@ use tari_service_framework::{reply_channel, reply_channel::Receiver};
 use tari_test_utils::runtime::test_async;
 
 async fn test_request_responder(
-    receiver: &mut Receiver<
-        (NodeCommsRequest, NodeCommsRequestType),
-        Result<Vec<NodeCommsResponse>, CommsInterfaceError>,
-    >,
-    response: Vec<NodeCommsResponse>,
+    receiver: &mut Receiver<NodeCommsRequest, Result<NodeCommsResponse, CommsInterfaceError>>,
+    response: NodeCommsResponse,
 )
 {
     let req_context = receiver.next().await.unwrap();
@@ -87,20 +78,13 @@ fn outbound_get_metadata() {
     let mut outbound_nci = OutboundNodeCommsInterface::new(request_sender, block_sender);
 
     block_on(async {
-        let metadata1 = ChainMetadata::new(5, vec![0u8], 3, 5.into());
-        let metadata2 = ChainMetadata::new(6, vec![1u8], 4, 6.into());
-        let metadata_response: Vec<NodeCommsResponse> = vec![
-            NodeCommsResponse::ChainMetadata(metadata1.clone()),
-            NodeCommsResponse::ChainMetadata(metadata2.clone()),
-        ];
+        let metadata = ChainMetadata::new(5, vec![0u8], 3, 5.into());
+        let metadata_response = NodeCommsResponse::ChainMetadata(metadata.clone());
         let (received_metadata, _) = futures::join!(
             outbound_nci.get_metadata(),
             test_request_responder(&mut request_receiver, metadata_response)
         );
-        let received_metadata = received_metadata.unwrap();
-        assert_eq!(received_metadata.len(), 2);
-        assert!(received_metadata.contains(&metadata1));
-        assert!(received_metadata.contains(&metadata2));
+        assert_eq!(received_metadata.unwrap(), metadata);
     });
 }
 
@@ -149,7 +133,7 @@ fn outbound_fetch_kernels() {
     block_on(async {
         let kernel = create_test_kernel(5.into(), 0);
         let hash = kernel.hash();
-        let kernel_response: Vec<NodeCommsResponse> = vec![NodeCommsResponse::TransactionKernels(vec![kernel.clone()])];
+        let kernel_response = NodeCommsResponse::TransactionKernels(vec![kernel.clone()]);
         let (received_kernels, _) = futures::join!(
             outbound_nci.fetch_kernels(vec![hash]),
             test_request_responder(&mut request_receiver, kernel_response)
@@ -209,7 +193,7 @@ fn outbound_fetch_headers() {
     block_on(async {
         let mut header = BlockHeader::new(0);
         header.height = 0;
-        let header_response: Vec<NodeCommsResponse> = vec![NodeCommsResponse::BlockHeaders(vec![header.clone()])];
+        let header_response = NodeCommsResponse::BlockHeaders(vec![header.clone()]);
         let (received_headers, _) = futures::join!(
             outbound_nci.fetch_headers(vec![0]),
             test_request_responder(&mut request_receiver, header_response)
@@ -268,7 +252,7 @@ fn outbound_fetch_utxos() {
     block_on(async {
         let (utxo, _) = create_utxo(MicroTari(10_000), &factories, None);
         let hash = utxo.hash();
-        let utxo_response: Vec<NodeCommsResponse> = vec![NodeCommsResponse::TransactionOutputs(vec![utxo.clone()])];
+        let utxo_response = NodeCommsResponse::TransactionOutputs(vec![utxo.clone()]);
         let (received_utxos, _) = futures::join!(
             outbound_nci.fetch_utxos(vec![hash]),
             test_request_responder(&mut request_receiver, utxo_response)
@@ -333,7 +317,7 @@ fn outbound_fetch_blocks() {
     block_on(async {
         let gb = BlockBuilder::new(consensus_constants.blockchain_version()).build();
         let block = HistoricalBlock::new(gb, 0, Vec::new());
-        let block_response: Vec<NodeCommsResponse> = vec![NodeCommsResponse::HistoricalBlocks(vec![block.clone()])];
+        let block_response = NodeCommsResponse::HistoricalBlocks(vec![block.clone()]);
         let (received_blocks, _) = futures::join!(
             outbound_nci.fetch_blocks(vec![0]),
             test_request_responder(&mut request_receiver, block_response)

--- a/base_layer/core/tests/node_service.rs
+++ b/base_layer/core/tests/node_service.rs
@@ -95,9 +95,7 @@ fn request_response_get_metadata() {
 
     runtime.block_on(async {
         let received_metadata = alice_node.outbound_nci.get_metadata().await.unwrap();
-        assert_eq!(received_metadata.len(), 2);
-        assert_eq!(received_metadata[0].height_of_longest_chain, Some(0));
-        assert_eq!(received_metadata[1].height_of_longest_chain, Some(0));
+        assert_eq!(received_metadata.height_of_longest_chain, Some(0));
 
         alice_node.comms.shutdown().await;
         bob_node.comms.shutdown().await;


### PR DESCRIPTION
## Description
- Simplified the base node service and mempool service request response system by removing the unused multi peer response system.
- Simplified the WaitingRequests system as multiple responses do not need to be tracked before resolving the waiting requests.
- Updated the inbound handlers of the mempool and base node service to use the simplified request system.
- Removed the unused NodeCommsRequestType.

## Motivation and Context
These changes remove the unused multi peers request response system, which simplifies the base node and mempool services.

## How Has This Been Tested?
Updated the base node service and mempool service tests to make use of only the single peer request system.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [x] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch.
* [x] I ran `cargo-fmt --all` before pushing.
* [x] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
