### PR TITLE
Bundler

### DIFF
--- a/applications/tari_base_node/install-osx.sh
+++ b/applications/tari_base_node/install-osx.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+
+# Installer script for Tari base node. This script is bundled with OSX and Linux versions of the Tari base node
+# binary distributions.
+
+function display_center() {
+    columns="$(tput cols)"
+    echo "$1" | while IFS= read -r line; do
+        printf "%*s\n" $(( (${#line} + columns) / 2)) "$line"
+    done
+}
+
+function banner() {
+  columns="$(tput cols)"
+  for (( c=1; c<=$columns; c++ )); do
+      echo -n "—"
+  done
+
+  display_center " ✨  $1 ✨ "
+  for (( c=1; c<=$columns; c++ )); do
+      echo -n "—"
+  done
+
+  echo
+}
+
+DATA_DIR=${1:-"$HOME/.tari"}
+NETWORK=rincewind
+
+banner Installing and setting up your Tari Base Node
+echo "Creating Tari data folder in $DATA_DIR"
+mkdir -p $DATA_DIR/$NETWORK
+echo "Copying configuraton files"
+cp rincewind-simple.toml $DATA_DIR/config.toml
+cp log4rs-sample.yml $DATA_DIR/log4rs.yml
+echo "Configuration complete."
+
+./install_tor.sh no-run
+# Start Tor
+osascript -e "tell application \"Terminal\" to do script \"sh ${PWD}/start_tor.sh\""
+echo "Waiting for Tor to start..."
+sleep 20
+echo "Ok"
+
+# Configure Base Node
+./tari_base_node --create_id
+
+banner Running Tari Base Node
+# Run Base Node
+./tari_base_node

--- a/config/presets/rincewind-simple.toml
+++ b/config/presets/rincewind-simple.toml
@@ -1,0 +1,17 @@
+# A simple set of sane defaults for connecting to the Ricnewind testnet
+[common]
+#peer_database = "~/.tari/peers"
+
+[base_node]
+network = "rincewind"
+
+[base_node.rincewind]
+db_type = "lmdb"
+transport = "tor"
+peer_seeds = [
+  "5edb022af1c21d644dfceeea2fcc7d3fac7a57ab44cf775b9a6f692cb75ed767::/onion3/vjkj44zpriqzrlve2qbiasrluaaxagrb6iuavzaascbujri6gw3rcmyd:18141",
+  "8c196e72cec4e8370c5a0caecc8a6cded4f86f43b1553564f653eceb159cec6f::/onion3/stjadvnac2rk45qc3o2bicrueqz6v2437c26gi7vi5cdhumym5wqulid:18145",
+  "2e93c460df49d8cfbbf7a06dd9004c25a84f92584f7d0ac5e30bd8e0beee9a43::/onion3/nuuq3e2olck22rudimovhmrdwkmjncxvwdgbvfxhz6myzcnx2j4rssyd:18141"
+]
+enable_mining = false
+tor_onion_port=9050

--- a/scripts/create_bundle.sh
+++ b/scripts/create_bundle.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+# This script creates a zip bundle for distribution
+# Right now, it only builds an OsX bundle
+
+print_usage () {
+  echo "Usage:
+  create_bundle [filename]
+"
+}
+
+OUTFILE=$1
+
+if [ "$OUTFILE" = "" ]; then
+  print_usage
+  exit
+fi
+
+BUNDLE='
+target/release/tari_base_node
+scripts/install_tor.sh
+config/presets/rincewind-simple.toml
+common/logging/log4rs-sample.yml
+applications/tari_base_node/install-osx.sh
+applications/tari_base_node/start_tor.sh
+'
+
+# Create a zip file, stripping out paths (-j)
+zip -j - $BUNDLE > $OUTFILE
+
+

--- a/scripts/install_tor.sh
+++ b/scripts/install_tor.sh
@@ -26,23 +26,6 @@ function banner() {
   echo
 }
 
-function run_tor() {
-  echo
-  banner "Running Tor"
-
-  tor --allow-missing-torrc --ignore-missing-torrc \
-     --clientonly 1 \
-     --socksport $SOCKSPORT \
-     --controlport $CONTROLPORT\
-     --log "notice stdout" \
-     --clientuseipv6 1
-}
-
-if hash tor 2>/dev/null; then
-  run_tor
-  exit
-fi
-
 function install_tor_linux_apt() {
   if [ "$EUID" -ne 0 ]; then
     echo "Please run as root"
@@ -67,7 +50,6 @@ EOF
    systemctl disable tor.service
    kill `ps -e | grep tor | cut -d " " -f1` 2>/dev/null || true
 
-   run_tor
 }
 
 function install_tor_mac() {
@@ -84,11 +66,11 @@ function install_tor_mac() {
     bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)"
     echo "Homebrew successfully installed"
   fi
-
+  # Install bottles
+  brew install pkgconfig 1>&2
+  brew install sqlite3 1>&2
   brew install tor 1>&2
   echo "Tor successfully installed"
-
-  run_tor
 }
 
 case "$(uname -s)" in
@@ -102,11 +84,6 @@ case "$(uname -s)" in
       install_tor_linux_apt
       ;;
     Darwin*)
-      if ! hash brew 2> /dev/null; then
-        echo "Homebrew is not installed. To install homebrew use:"
-        echo '/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)'
-        exit 1
-      fi
       install_tor_mac
       ;;
     CYGWIN*)


### PR DESCRIPTION
    Add quick and dirty OsX installer
    
    This PR is a minimal viable installer for OsX.
    
    The create_bundle script packages the release binary with working
    minimal config files.
    Then install-osx will install dependencies, create an id and run the
    node. It also runs Tor in a separate terminal.
    
    As I said, this is an MVP. There are lots of enhancements that can and
    should be made to this; but this is a start.