### PR TITLE
Allow nodes to use TCP transport and connect to onion addresses

### DIFF
--- a/applications/tari_base_node/src/main.rs
+++ b/applications/tari_base_node/src/main.rs
@@ -98,7 +98,10 @@ fn main_inner() -> Result<(), ExitCodes> {
 
     // Load or create the Node identity
     let node_identity = match load_identity(&node_config.identity_file) {
-        Ok(id) => id,
+        Ok(id) => {
+            id.set_public_address(node_config.public_address.clone()).unwrap();
+            id
+        },
         Err(e) => {
             if !arguments.create_id {
                 error!(

--- a/applications/tari_base_node/src/parser.rs
+++ b/applications/tari_base_node/src/parser.rs
@@ -260,12 +260,15 @@ impl Parser {
         self.executor.spawn(async move {
             match peer_manager.flood_peers().await {
                 Ok(peers) => {
+                    let num_peers = peers.len();
                     println!(
                         "{}",
                         peers
                             .into_iter()
                             .fold(String::new(), |acc, p| { format!("{}\n{}", acc, p) })
                     );
+
+                    println!("{} peer(s) known by this node", num_peers);
                 },
                 Err(e) => {
                     error!(target: LOG_TARGET, "Could not read peers: {}", e.to_string());
@@ -283,12 +286,14 @@ impl Parser {
                     println!("No active peer connections.");
                 },
                 Ok(conns) => {
+                    let num_connections = conns.len();
                     println!(
                         "{}",
                         conns
                             .into_iter()
                             .fold(String::new(), |acc, p| { format!("{}\n{}", acc, p) })
                     );
+                    println!("{} active connection(s)", num_connections);
                 },
                 Err(e) => {
                     error!(target: LOG_TARGET, "Could not list connections: {}", e.to_string());

--- a/base_layer/p2p/examples/pingpong.rs
+++ b/base_layer/p2p/examples/pingpong.rs
@@ -170,6 +170,7 @@ mod pingpong {
         } else {
             TransportType::Tcp {
                 listener_address: node_identity.public_address(),
+                tor_socks_config: None,
             }
         };
 

--- a/base_layer/p2p/src/services/liveness/service.rs
+++ b/base_layer/p2p/src/services/liveness/service.rs
@@ -131,11 +131,11 @@ where
 
                 _ = ping_tick.select_next_some() => {
                         let _ = self.ping_neighbours().await.or_else(|err| {
-                            error!(target: LOG_TARGET, "Error when pinging neighbours: {}", err);
+                            error!(target: LOG_TARGET, "Error when pinging neighbours: {:?}", err);
                             Err(err)
                         });
                         let _ = self.ping_monitored_node_ids().await.or_else(|err| {
-                            error!(target: LOG_TARGET, "Error when pinging monitored nodes: {}", err);
+                            error!(target: LOG_TARGET, "Error when pinging monitored nodes: {:?}", err);
                             Err(err)
                         });
                 },

--- a/base_layer/p2p/src/transport.rs
+++ b/base_layer/p2p/src/transport.rs
@@ -20,22 +20,25 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use tari_comms::{multiaddr::Multiaddr, socks, tor};
+use tari_comms::{multiaddr::Multiaddr, socks, tor, transports::SocksConfig};
 
 #[derive(Debug, Clone)]
 pub enum TransportType {
     /// Use a memory transport. This transport recognises /memory addresses primarily used for local testing.
     Memory { listener_address: Multiaddr },
     /// Use a TcpTransport. This transport recognises /ip{4|6}/.../tcp/xxxx addresses.
-    Tcp { listener_address: Multiaddr },
+    Tcp {
+        listener_address: Multiaddr,
+        /// The optional SOCKS proxy to use when connecting to Tor onion addresses
+        tor_socks_config: Option<SocksConfig>,
+    },
     /// This does not directly map to a transport, but will configure comms to run over a tor hidden service using the
     /// Tor proxy. This transport recognises ip/tcp, onion v2, onion v3 and dns addresses.
     Tor(TorConfig),
     /// Use a SOCKS5 proxy transport. This transport recognises ip/tcp and dns addresses.
     Socks {
-        proxy_address: Multiaddr,
+        socks_config: SocksConfig,
         listener_address: Multiaddr,
-        authentication: socks::Authentication,
     },
 }
 

--- a/base_layer/wallet/tests/wallet/mod.rs
+++ b/base_layer/wallet/tests/wallet/mod.rs
@@ -89,6 +89,7 @@ fn test_wallet() {
             node_identity: Arc::new(alice_identity.clone()),
             transport_type: TransportType::Tcp {
                 listener_address: alice_identity.public_address(),
+                tor_socks_config: None,
             },
             datastore_path: dir_path.to_str().unwrap().to_string(),
             peer_database_name: random_string(8),
@@ -101,6 +102,7 @@ fn test_wallet() {
             node_identity: Arc::new(bob_identity.clone()),
             transport_type: TransportType::Tcp {
                 listener_address: bob_identity.public_address(),
+                tor_socks_config: None,
             },
             datastore_path: dir_path.to_str().unwrap().to_string(),
             peer_database_name: random_string(8),
@@ -234,6 +236,7 @@ fn test_import_utxo() {
         node_identity: Arc::new(alice_identity.clone()),
         transport_type: TransportType::Tcp {
             listener_address: "/ip4/127.0.0.1/tcp/0".parse().unwrap(),
+            tor_socks_config: None,
         },
         datastore_path: temp_dir.path().to_str().unwrap().to_string(),
         peer_database_name: random_string(8),

--- a/base_layer/wallet_ffi/src/lib.rs
+++ b/base_layer/wallet_ffi/src/lib.rs
@@ -1853,6 +1853,7 @@ pub unsafe extern "C" fn transport_tcp_create(
     }
     let transport = TariTransportType::Tcp {
         listener_address: listener_address_str.parse::<Multiaddr>().unwrap(),
+        tor_socks_config: None,
     };
     Box::into_raw(Box::new(transport))
 }

--- a/comms/src/builder/error.rs
+++ b/comms/src/builder/error.rs
@@ -1,0 +1,43 @@
+// Copyright 2020, The Tari Project
+//
+// Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+// following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+// disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+// following disclaimer in the documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+// products derived from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+// INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+// WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+// USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+use crate::{connection_manager::ConnectionManagerError, peer_manager::PeerManagerError};
+use derive_error::Error;
+
+#[derive(Debug, Error)]
+pub enum CommsBuilderError {
+    PeerManagerError(PeerManagerError),
+    ConnectionManagerError(ConnectionManagerError),
+    /// Node identity not set. Call `with_node_identity(node_identity)` on [CommsBuilder]
+    NodeIdentityNotSet,
+    /// The PeerStorage was not provided to the CommsBuilder. Use `with_peer_storage` to set it.
+    PeerStorageNotProvided,
+    /// The messaging pipeline was not provided to the CommsBuilder. Use `with_messaging_pipeline` to set it.
+    /// pipeline.
+    MessagingPiplineNotProvided,
+    /// Unable to receive a ConnectionManagerEvent within timeout
+    ConnectionManagerEventStreamTimeout,
+    /// ConnectionManagerEvent stream unexpectedly closed
+    ConnectionManagerEventStreamClosed,
+    /// Receiving on ConnectionManagerEvent stream lagged unexpectedly
+    ConnectionManagerEventStreamLagged,
+}

--- a/comms/src/peer_manager/connection_stats.rs
+++ b/comms/src/peer_manager/connection_stats.rs
@@ -87,6 +87,26 @@ impl PeerConnectionStats {
     }
 }
 
+impl fmt::Display for PeerConnectionStats {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self.last_connected_at.as_ref() {
+            Some(dt) => {
+                write!(f, "Last connected at '{}'.", dt)?;
+
+                if self.last_failed_at().is_some() {
+                    write!(f, " {}", self.last_connection_attempt)?;
+                }
+            },
+            None => {
+                write!(f, "Never connected to this peer.")?;
+                write!(f, " {}", self.last_connection_attempt)?;
+            },
+        }
+
+        Ok(())
+    }
+}
+
 /// Peer connection statistics
 #[derive(Debug, Clone, Deserialize, Serialize, PartialOrd, PartialEq)]
 pub enum LastConnectionAttempt {
@@ -116,7 +136,6 @@ impl Default for LastConnectionAttempt {
 
 impl Display for LastConnectionAttempt {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), fmt::Error> {
-        writeln!(f, "Last connection to peer")?;
         use LastConnectionAttempt::*;
         match self {
             Never => write!(f, "Connection never attempted"),

--- a/comms/src/peer_manager/peer.rs
+++ b/comms/src/peer_manager/peer.rs
@@ -199,10 +199,11 @@ impl Peer {
 impl Display for Peer {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         f.write_str(&format!(
-            "[{}] PK={} Features={:?}",
+            "[{}] PK={} Features={:?} {}",
             self.node_id.short_str(),
             self.public_key,
-            self.features
+            self.features,
+            self.connection_stats,
         ))
     }
 }

--- a/comms/src/tor/hidden_service/mod.rs
+++ b/comms/src/tor/hidden_service/mod.rs
@@ -27,7 +27,7 @@ use crate::{
     multiaddr::Multiaddr,
     socks,
     tor::{PrivateKey, TorClientError, TorControlPortClient},
-    transports::{SocksTransport, TcpTransport, Transport},
+    transports::{SocksConfig, SocksTransport, TcpTransport, Transport},
 };
 use serde_derive::{Deserialize, Serialize};
 
@@ -76,7 +76,10 @@ impl HiddenService {
     }
 
     pub fn get_transport(&self) -> SocksTransport {
-        SocksTransport::new(self.socks_addr.clone(), self.socks_auth.clone())
+        SocksTransport::new(SocksConfig {
+            proxy_address: self.socks_addr.clone(),
+            authentication: self.socks_auth.clone(),
+        })
     }
 
     pub fn get_tor_identity(&self) -> TorIdentity {

--- a/comms/src/transports/mod.rs
+++ b/comms/src/transports/mod.rs
@@ -28,12 +28,16 @@ use futures::{Future, Stream};
 use multiaddr::Multiaddr;
 
 mod memory;
-mod socks;
-mod tcp;
-
 pub use memory::MemoryTransport;
-pub use socks::SocksTransport;
+
+mod socks;
+pub use socks::{SocksConfig, SocksTransport};
+
+mod tcp;
 pub use tcp::{TcpSocket, TcpTransport};
+
+mod tcp_with_tor;
+pub use tcp_with_tor::TcpWithTorTransport;
 
 pub trait Transport {
     /// The output of the transport after a connection is established

--- a/comms/src/transports/socks.rs
+++ b/comms/src/transports/socks.rs
@@ -33,9 +33,9 @@ use std::{io, time::Duration};
 const SOCKS_SO_KEEPALIVE: Duration = Duration::from_millis(1500);
 
 #[derive(Clone, Debug)]
-struct SocksConfig {
-    proxy_address: Multiaddr,
-    authentication: socks::Authentication,
+pub struct SocksConfig {
+    pub proxy_address: Multiaddr,
+    pub authentication: socks::Authentication,
 }
 
 #[derive(Clone, Debug)]
@@ -45,16 +45,13 @@ pub struct SocksTransport {
 }
 
 impl SocksTransport {
-    pub fn new(proxy_address: Multiaddr, authentication: socks::Authentication) -> Self {
+    pub fn new(socks_config: SocksConfig) -> Self {
         let mut tcp_transport = TcpTransport::new();
         tcp_transport.set_nodelay(true);
         tcp_transport.set_keepalive(Some(SOCKS_SO_KEEPALIVE));
 
         Self {
-            socks_config: SocksConfig {
-                proxy_address,
-                authentication,
-            },
+            socks_config,
             tcp_transport,
         }
     }
@@ -107,7 +104,10 @@ mod test {
     #[test]
     fn new() {
         let proxy_address = "/ip4/127.0.0.1/tcp/1234".parse::<Multiaddr>().unwrap();
-        let transport = SocksTransport::new(proxy_address.clone(), Default::default());
+        let transport = SocksTransport::new(SocksConfig {
+            proxy_address: proxy_address.clone(),
+            authentication: Default::default(),
+        });
 
         assert_eq!(transport.socks_config.proxy_address, proxy_address);
         assert_eq!(transport.socks_config.authentication, Authentication::None);

--- a/comms/src/transports/tcp_with_tor.rs
+++ b/comms/src/transports/tcp_with_tor.rs
@@ -1,0 +1,123 @@
+// Copyright 2019, The Tari Project
+//
+// Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+// following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+// disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+// following disclaimer in the documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+// products derived from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+// INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+// WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+// USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+use super::Transport;
+use crate::{
+    multiaddr::Protocol,
+    transports::{SocksConfig, SocksTransport, TcpSocket, TcpTransport},
+};
+use futures::{Future, FutureExt};
+use multiaddr::Multiaddr;
+use std::io;
+
+/// Transport implementation for TCP with Tor support
+#[derive(Debug, Clone, Default)]
+pub struct TcpWithTorTransport {
+    socks_transport: Option<SocksTransport>,
+    tcp_transport: TcpTransport,
+}
+
+impl TcpWithTorTransport {
+    /// Sets the SOCKS proxy to use for onion addresses
+    pub fn set_tor_socks_proxy(&mut self, socks_config: SocksConfig) -> &mut Self {
+        self.socks_transport = Some(SocksTransport::new(socks_config));
+        self
+    }
+
+    /// Create a new TcpTransport
+    pub fn new() -> Self {
+        Default::default()
+    }
+
+    pub fn tcp_transport_mut(&mut self) -> &mut TcpTransport {
+        &mut self.tcp_transport
+    }
+
+    fn is_onion_address(addr: &Multiaddr) -> io::Result<bool> {
+        let protocol = addr
+            .iter()
+            .next()
+            .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidInput, format!("Invalid address '{}'", addr)))?;
+
+        match protocol {
+            Protocol::Onion(_, _) | Protocol::Onion3(_) => Ok(true),
+            _ => Ok(false),
+        }
+    }
+}
+
+impl Transport for TcpWithTorTransport {
+    type Error = io::Error;
+    type Inbound = <TcpTransport as Transport>::Inbound;
+    type ListenFuture = <TcpTransport as Transport>::ListenFuture;
+    type Listener = <TcpTransport as Transport>::Listener;
+    type Output = TcpSocket;
+
+    type DialFuture = impl Future<Output = io::Result<Self::Output>>;
+
+    fn listen(&self, addr: Multiaddr) -> Result<Self::ListenFuture, Self::Error> {
+        self.tcp_transport.listen(addr)
+    }
+
+    fn dial(&self, addr: Multiaddr) -> Result<Self::DialFuture, Self::Error> {
+        if Self::is_onion_address(&addr)? {
+            match self.socks_transport {
+                Some(ref transport) => {
+                    let dial_fut = transport.dial(addr)?;
+                    Ok(dial_fut.boxed())
+                },
+                None => Err(io::Error::new(
+                    io::ErrorKind::Other,
+                    format!("Tor SOCKS proxy is not set for TCP transport. Cannot dial peer with onion addresses."),
+                )),
+            }
+        } else {
+            let dial_fut = self.tcp_transport.dial(addr)?;
+            Ok(dial_fut.boxed())
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn is_onion_address() {
+        let expect_true = [
+            "/onion/aaimaq4ygg2iegci:1234",
+            "/onion3/vww6ybal4bd7szmgncyruucpgfkqahzddi37ktceo3ah7ngmcopnpyyd:1234",
+        ];
+
+        let expect_false = ["/dns4/mikes-node-nook.com:80", "/ip4/1.2.3.4/tcp/1234"];
+
+        expect_true.iter().for_each(|addr| {
+            let addr = addr.parse().unwrap();
+            assert!(TcpWithTorTransport::is_onion_address(&addr).unwrap());
+        });
+
+        expect_false.iter().for_each(|addr| {
+            let addr = addr.parse().unwrap();
+            assert_eq!(TcpWithTorTransport::is_onion_address(&addr).unwrap(), false);
+        });
+    }
+}

--- a/config/tari_config_sample.toml
+++ b/config/tari_config_sample.toml
@@ -125,9 +125,14 @@ peer_seeds = []
 # -------------- Transport configuration --------------
 # Use TCP to connect to the Tari network. This transport can only communicate with TCP/IP addresses, so peers with
 # e.g. tor onion addresses will not be contactable.
-#transport = "tcp"
+transport = "tcp"
 # # The address and port to listen for peer connections over TCP.
-#tcp_listener_address = "/ip4/0.0.0.0/tcp/18189"
+tcp_listener_address = "/ip4/0.0.0.0/tcp/18189"
+# Configures a tor proxy used to connect to onion addresses. All other traffic uses direct TCP connections.
+# This setting is optional however, if it is not specified, this node will not be able to connect to nodes that
+# only advertise an onion address.
+tcp_tor_socks_address = "/ip4/127.0.0.1/tcp/36050"
+tcp_tor_socks_auth = "none"
 
 # Configures the node to run over a tor hidden service using the Tor proxy. This transport recognises ip/tcp,
 # onion v2, onion v3 and dns addresses.


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
- Added optional setting to tcp transport that allows the node to use a direct connection
  to the internet for all traffic _AND_ use Tor for peers which
  advertise a tor address.
- `list-peers` displays last connection info


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #1350 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Base node works and joins network with "tcp with tor" transport.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch.
* [x] I ran `cargo-fmt --all` before pushing.
* [x] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
