### PR TITLE
Block sync from active peers with best chain

### DIFF
--- a/applications/tari_base_node/src/builder.rs
+++ b/applications/tari_base_node/src/builder.rs
@@ -689,7 +689,7 @@ where
         ))
         .add_initializer(LivenessInitializer::new(
             LivenessConfig {
-                auto_ping_interval: Some(Duration::from_secs(5)),
+                auto_ping_interval: Some(Duration::from_secs(30)),
                 enable_auto_join: true,
                 enable_auto_stored_message_request: true,
                 refresh_neighbours_interval: Duration::from_secs(3 * 60),

--- a/base_layer/core/src/base_node/chain_metadata_service/handle.rs
+++ b/base_layer/core/src/base_node/chain_metadata_service/handle.rs
@@ -23,10 +23,26 @@
 use crate::chain_storage::ChainMetadata;
 use futures::{stream::Fuse, StreamExt};
 use tari_broadcast_channel::Subscriber;
+use tari_comms::peer_manager::NodeId;
+
+#[derive(Debug, Clone)]
+pub struct PeerChainMetadata {
+    pub node_id: NodeId,
+    pub chain_metadata: ChainMetadata,
+}
+
+impl PeerChainMetadata {
+    pub fn new(node_id: NodeId, chain_metadata: ChainMetadata) -> Self {
+        Self {
+            node_id,
+            chain_metadata,
+        }
+    }
+}
 
 #[derive(Debug)]
 pub enum ChainMetadataEvent {
-    PeerChainMetadataReceived(Vec<ChainMetadata>),
+    PeerChainMetadataReceived(Vec<PeerChainMetadata>),
 }
 
 #[derive(Clone)]

--- a/base_layer/core/src/base_node/chain_metadata_service/mod.rs
+++ b/base_layer/core/src/base_node/chain_metadata_service/mod.rs
@@ -28,5 +28,5 @@ mod initializer;
 mod service;
 
 // Public re-exports
-pub use handle::{ChainMetadataEvent, ChainMetadataHandle};
+pub use handle::{ChainMetadataEvent, ChainMetadataHandle, PeerChainMetadata};
 pub use initializer::ChainMetadataServiceInitializer;

--- a/base_layer/core/src/base_node/chain_metadata_service/service.rs
+++ b/base_layer/core/src/base_node/chain_metadata_service/service.rs
@@ -23,11 +23,11 @@
 use super::{error::ChainMetadataSyncError, LOG_TARGET};
 use crate::{
     base_node::{
-        chain_metadata_service::handle::ChainMetadataEvent,
+        chain_metadata_service::handle::{ChainMetadataEvent, PeerChainMetadata},
         comms_interface::{BlockEvent, LocalNodeCommsInterface},
         proto,
     },
-    chain_storage::{BlockAddResult, ChainMetadata},
+    chain_storage::BlockAddResult,
 };
 use chrono::{NaiveDateTime, Utc};
 use futures::{stream::StreamExt, SinkExt};
@@ -174,11 +174,7 @@ impl ChainMetadataService {
     }
 
     async fn flush_chain_metadata_to_event_publisher(&mut self) -> Result<(), ChainMetadataSyncError> {
-        let chain_metadata = self
-            .peer_chain_metadata
-            .drain(..)
-            .map(|peer_metadata| peer_metadata.chain_metadata)
-            .collect::<Vec<_>>();
+        let chain_metadata = self.peer_chain_metadata.drain(..).collect::<Vec<_>>();
 
         self.event_publisher
             .send(ChainMetadataEvent::PeerChainMetadataReceived(chain_metadata))
@@ -229,20 +225,6 @@ impl ChainMetadataService {
             .push(PeerChainMetadata::new(node_id.clone(), chain_metadata));
 
         Ok(())
-    }
-}
-
-struct PeerChainMetadata {
-    node_id: NodeId,
-    chain_metadata: ChainMetadata,
-}
-
-impl PeerChainMetadata {
-    fn new(node_id: NodeId, chain_metadata: ChainMetadata) -> Self {
-        Self {
-            node_id,
-            chain_metadata,
-        }
     }
 }
 

--- a/base_layer/core/src/base_node/comms_interface/inbound_handlers.rs
+++ b/base_layer/core/src/base_node/comms_interface/inbound_handlers.rs
@@ -224,7 +224,7 @@ where T: BlockchainBackend + 'static
             source_peer
                 .as_ref()
                 .map(|p| format!("remote peer: {}", p))
-                .unwrap_or("local services".to_string())
+                .unwrap_or_else(|| "local services".to_string())
         );
         trace!(target: LOG_TARGET, "Block: {}", block);
         let add_block_result = async_db::add_block(self.blockchain_db.clone(), block.clone()).await;

--- a/base_layer/core/src/base_node/comms_interface/outbound_interface.rs
+++ b/base_layer/core/src/base_node/comms_interface/outbound_interface.rs
@@ -31,7 +31,7 @@ use crate::{
 };
 use futures::channel::mpsc::UnboundedSender;
 use log::*;
-use tari_comms::types::CommsPublicKey;
+use tari_comms::{peer_manager::NodeId, types::CommsPublicKey};
 use tari_service_framework::reply_channel::SenderService;
 use tower_service::Service;
 
@@ -40,14 +40,17 @@ pub const LOG_TARGET: &str = "c::bn::comms_interface::outbound_interface";
 /// The OutboundNodeCommsInterface provides an interface to request information from remove nodes.
 #[derive(Clone)]
 pub struct OutboundNodeCommsInterface {
-    request_sender: SenderService<NodeCommsRequest, Result<NodeCommsResponse, CommsInterfaceError>>,
+    request_sender: SenderService<(NodeCommsRequest, Option<NodeId>), Result<NodeCommsResponse, CommsInterfaceError>>,
     block_sender: UnboundedSender<(Block, Vec<CommsPublicKey>)>,
 }
 
 impl OutboundNodeCommsInterface {
     /// Construct a new OutboundNodeCommsInterface with the specified SenderService.
     pub fn new(
-        request_sender: SenderService<NodeCommsRequest, Result<NodeCommsResponse, CommsInterfaceError>>,
+        request_sender: SenderService<
+            (NodeCommsRequest, Option<NodeId>),
+            Result<NodeCommsResponse, CommsInterfaceError>,
+        >,
         block_sender: UnboundedSender<(Block, Vec<CommsPublicKey>)>,
     ) -> Self
     {
@@ -59,8 +62,20 @@ impl OutboundNodeCommsInterface {
 
     /// Request metadata from remote base nodes.
     pub async fn get_metadata(&mut self) -> Result<ChainMetadata, CommsInterfaceError> {
-        if let NodeCommsResponse::ChainMetadata(metadata) =
-            self.request_sender.call(NodeCommsRequest::GetChainMetadata).await??
+        self.request_metadata_from_peer(None).await
+    }
+
+    /// Request metadata from a specific base node, if None is provided as a node_id then a random base node will be
+    /// queried.
+    pub async fn request_metadata_from_peer(
+        &mut self,
+        node_id: Option<NodeId>,
+    ) -> Result<ChainMetadata, CommsInterfaceError>
+    {
+        if let NodeCommsResponse::ChainMetadata(metadata) = self
+            .request_sender
+            .call((NodeCommsRequest::GetChainMetadata, node_id))
+            .await??
         {
             trace!(target: LOG_TARGET, "Remote metadata requested: {:?}", metadata,);
             Ok(metadata)
@@ -76,12 +91,23 @@ impl OutboundNodeCommsInterface {
         hashes: Vec<HashOutput>,
     ) -> Result<Vec<TransactionKernel>, CommsInterfaceError>
     {
+        self.request_kernels_from_peer(hashes, None).await
+    }
+
+    /// Fetch the transaction kernels with the provided hashes from a specific base node, if None is provided as a
+    /// node_id then a random base node will be queried.
+    pub async fn request_kernels_from_peer(
+        &mut self,
+        hashes: Vec<HashOutput>,
+        node_id: Option<NodeId>,
+    ) -> Result<Vec<TransactionKernel>, CommsInterfaceError>
+    {
         if let NodeCommsResponse::TransactionKernels(kernels) = self
             .request_sender
-            .call(NodeCommsRequest::FetchKernels(hashes))
+            .call((NodeCommsRequest::FetchKernels(hashes), node_id))
             .await??
         {
-            Ok(kernels.clone())
+            Ok(kernels)
         } else {
             Err(CommsInterfaceError::UnexpectedApiResponse)
         }
@@ -89,12 +115,23 @@ impl OutboundNodeCommsInterface {
 
     /// Fetch the block headers corresponding to the provided block numbers from remote base nodes.
     pub async fn fetch_headers(&mut self, block_nums: Vec<u64>) -> Result<Vec<BlockHeader>, CommsInterfaceError> {
+        self.request_headers_from_peer(block_nums, None).await
+    }
+
+    /// Fetch the block headers corresponding to the provided block numbers from a specific base node, if None is
+    /// provided as a node_id then a random base node will be queried.
+    pub async fn request_headers_from_peer(
+        &mut self,
+        block_nums: Vec<u64>,
+        node_id: Option<NodeId>,
+    ) -> Result<Vec<BlockHeader>, CommsInterfaceError>
+    {
         if let NodeCommsResponse::BlockHeaders(headers) = self
             .request_sender
-            .call(NodeCommsRequest::FetchHeaders(block_nums))
+            .call((NodeCommsRequest::FetchHeaders(block_nums), node_id))
             .await??
         {
-            Ok(headers.clone())
+            Ok(headers)
         } else {
             Err(CommsInterfaceError::UnexpectedApiResponse)
         }
@@ -106,12 +143,23 @@ impl OutboundNodeCommsInterface {
         block_hashes: Vec<HashOutput>,
     ) -> Result<Vec<BlockHeader>, CommsInterfaceError>
     {
+        self.request_headers_with_hashes_from_peer(block_hashes, None).await
+    }
+
+    /// Fetch the Headers corresponding to the provided block hashes from a specific base node, if None is provided as a
+    /// node_id then a random base node will be queried.
+    pub async fn request_headers_with_hashes_from_peer(
+        &mut self,
+        block_hashes: Vec<HashOutput>,
+        node_id: Option<NodeId>,
+    ) -> Result<Vec<BlockHeader>, CommsInterfaceError>
+    {
         if let NodeCommsResponse::BlockHeaders(headers) = self
             .request_sender
-            .call(NodeCommsRequest::FetchHeadersWithHashes(block_hashes))
+            .call((NodeCommsRequest::FetchHeadersWithHashes(block_hashes), node_id))
             .await??
         {
-            Ok(headers.clone())
+            Ok(headers)
         } else {
             Err(CommsInterfaceError::UnexpectedApiResponse)
         }
@@ -123,10 +171,23 @@ impl OutboundNodeCommsInterface {
         hashes: Vec<HashOutput>,
     ) -> Result<Vec<TransactionOutput>, CommsInterfaceError>
     {
-        if let NodeCommsResponse::TransactionOutputs(utxos) =
-            self.request_sender.call(NodeCommsRequest::FetchUtxos(hashes)).await??
+        self.request_utxos_from_peer(hashes, None).await
+    }
+
+    /// Fetch the UTXOs with the provided hashes from a specific base node, if None is provided as a node_id then a
+    /// random base node will be queried.
+    pub async fn request_utxos_from_peer(
+        &mut self,
+        hashes: Vec<HashOutput>,
+        node_id: Option<NodeId>,
+    ) -> Result<Vec<TransactionOutput>, CommsInterfaceError>
+    {
+        if let NodeCommsResponse::TransactionOutputs(utxos) = self
+            .request_sender
+            .call((NodeCommsRequest::FetchUtxos(hashes), node_id))
+            .await??
         {
-            Ok(utxos.clone())
+            Ok(utxos)
         } else {
             Err(CommsInterfaceError::UnexpectedApiResponse)
         }
@@ -134,12 +195,23 @@ impl OutboundNodeCommsInterface {
 
     /// Fetch the Historical Blocks corresponding to the provided block numbers from remote base nodes.
     pub async fn fetch_blocks(&mut self, block_nums: Vec<u64>) -> Result<Vec<HistoricalBlock>, CommsInterfaceError> {
+        self.request_blocks_from_peer(block_nums, None).await
+    }
+
+    /// Fetch the Historical Blocks corresponding to the provided block numbers from a specific base node, if None is
+    /// provided as a node_id then a random base node will be queried.
+    pub async fn request_blocks_from_peer(
+        &mut self,
+        block_nums: Vec<u64>,
+        node_id: Option<NodeId>,
+    ) -> Result<Vec<HistoricalBlock>, CommsInterfaceError>
+    {
         if let NodeCommsResponse::HistoricalBlocks(blocks) = self
             .request_sender
-            .call(NodeCommsRequest::FetchBlocks(block_nums))
+            .call((NodeCommsRequest::FetchBlocks(block_nums), node_id))
             .await??
         {
-            Ok(blocks.clone())
+            Ok(blocks)
         } else {
             Err(CommsInterfaceError::UnexpectedApiResponse)
         }
@@ -152,12 +224,23 @@ impl OutboundNodeCommsInterface {
         block_hashes: Vec<HashOutput>,
     ) -> Result<Vec<HistoricalBlock>, CommsInterfaceError>
     {
+        self.request_blocks_with_hashes_from_peer(block_hashes, None).await
+    }
+
+    /// Fetch the Blocks corresponding to the provided block hashes from a specific base node. The requested blocks
+    /// could be chain blocks or orphan blocks.
+    pub async fn request_blocks_with_hashes_from_peer(
+        &mut self,
+        block_hashes: Vec<HashOutput>,
+        node_id: Option<NodeId>,
+    ) -> Result<Vec<HistoricalBlock>, CommsInterfaceError>
+    {
         if let NodeCommsResponse::HistoricalBlocks(blocks) = self
             .request_sender
-            .call(NodeCommsRequest::FetchBlocksWithHashes(block_hashes))
+            .call((NodeCommsRequest::FetchBlocksWithHashes(block_hashes), node_id))
             .await??
         {
-            Ok(blocks.clone())
+            Ok(blocks)
         } else {
             Err(CommsInterfaceError::UnexpectedApiResponse)
         }

--- a/base_layer/core/src/base_node/states/helpers.rs
+++ b/base_layer/core/src/base_node/states/helpers.rs
@@ -22,6 +22,7 @@
 
 use crate::{base_node::states::SyncStatus, chain_storage::ChainMetadata};
 use log::*;
+use tari_comms::peer_manager::NodeId;
 
 /// Determine the best metadata from a set of metadata received from the network.
 pub fn best_metadata(metadata_list: Vec<ChainMetadata>) -> ChainMetadata {
@@ -40,7 +41,13 @@ pub fn best_metadata(metadata_list: Vec<ChainMetadata>) -> ChainMetadata {
 }
 
 /// Given a local and the network chain state respectively, figure out what synchronisation state we should be in.
-pub fn determine_sync_mode(local: &ChainMetadata, network: &ChainMetadata, log_target: &str) -> SyncStatus {
+pub fn determine_sync_mode(
+    local: &ChainMetadata,
+    network: ChainMetadata,
+    sync_peers: Vec<NodeId>,
+    log_target: &str,
+) -> SyncStatus
+{
     use crate::base_node::states::SyncStatus::*;
     match network.accumulated_difficulty {
         None => {
@@ -64,7 +71,7 @@ pub fn determine_sync_mode(local: &ChainMetadata, network: &ChainMetadata, log_t
                     network.height_of_longest_chain.unwrap_or(0),
                     network_tip_accum_difficulty,
                 );
-                Lagging(network.clone())
+                Lagging(network, sync_peers)
             } else {
                 info!(
                     target: log_target,

--- a/base_layer/core/src/base_node/states/mod.rs
+++ b/base_layer/core/src/base_node/states/mod.rs
@@ -22,6 +22,7 @@
 
 use crate::chain_storage::ChainMetadata;
 use std::fmt::{Display, Error, Formatter};
+use tari_comms::peer_manager::NodeId;
 
 /// The base node state represents the FSM of the base node synchronisation process.
 ///
@@ -62,7 +63,7 @@ use std::fmt::{Display, Error, Formatter};
 #[derive(Clone, Debug, PartialEq)]
 pub enum BaseNodeState {
     Starting(Starting),
-    BlockSync(BlockSyncInfo, ChainMetadata), // The best network chain metadata
+    BlockSync(BlockSyncInfo, ChainMetadata, Vec<NodeId>), // The best network chain metadata
     Listening(ListeningInfo),
     Shutdown(Shutdown),
 }
@@ -86,7 +87,7 @@ pub enum StateEvent {
 #[derive(Debug, PartialEq)]
 pub enum SyncStatus {
     // We are behind the chain tip.
-    Lagging(ChainMetadata),
+    Lagging(ChainMetadata, Vec<NodeId>),
     UpToDate,
 }
 
@@ -94,7 +95,7 @@ impl Display for BaseNodeState {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), Error> {
         let s = match self {
             Self::Starting(_) => "Initializing",
-            Self::BlockSync(_, _) => "Synchronizing blocks",
+            Self::BlockSync(_, _, _) => "Synchronizing blocks",
             Self::Listening(_) => "Listening",
             Self::Shutdown(_) => "Shutting down",
         };

--- a/base_layer/core/tests/node_comms_interface.rs
+++ b/base_layer/core/tests/node_comms_interface.rs
@@ -25,6 +25,7 @@ mod helpers;
 
 use futures::{channel::mpsc::unbounded as futures_mpsc_channel_unbounded, executor::block_on, StreamExt};
 use tari_broadcast_channel::bounded;
+use tari_comms::peer_manager::NodeId;
 use tari_core::{
     base_node::{
         comms_interface::{CommsInterfaceError, InboundNodeCommsHandlers, NodeCommsRequest, NodeCommsResponse},
@@ -48,7 +49,7 @@ use tari_service_framework::{reply_channel, reply_channel::Receiver};
 use tari_test_utils::runtime::test_async;
 
 async fn test_request_responder(
-    receiver: &mut Receiver<NodeCommsRequest, Result<NodeCommsResponse, CommsInterfaceError>>,
+    receiver: &mut Receiver<(NodeCommsRequest, Option<NodeId>), Result<NodeCommsResponse, CommsInterfaceError>>,
     response: NodeCommsResponse,
 )
 {

--- a/base_layer/core/tests/node_service.rs
+++ b/base_layer/core/tests/node_service.rs
@@ -594,13 +594,15 @@ fn service_request_timeout() {
     );
 
     runtime.block_on(async {
+        // Bob should not be reachable
+        bob_node.comms.shutdown().await;
+
         assert_eq!(
             alice_node.outbound_nci.get_metadata().await,
             Err(CommsInterfaceError::RequestTimedOut)
         );
 
         alice_node.comms.shutdown().await;
-        bob_node.comms.shutdown().await;
     });
 }
 

--- a/base_layer/core/tests/node_state_machine.rs
+++ b/base_layer/core/tests/node_state_machine.rs
@@ -121,7 +121,7 @@ fn test_listening_lagging() {
             .unwrap();
 
         match next_event {
-            StateEvent::FallenBehind(Lagging(_)) => assert!(true),
+            StateEvent::FallenBehind(Lagging(_, _)) => assert!(true),
             _ => assert!(false),
         }
 
@@ -256,8 +256,9 @@ fn test_block_sync() {
 
         // Sync Blocks from genesis block to tip
         let network_tip = bob_db.get_metadata().unwrap();
+        let sync_peers = vec![bob_node.node_identity.node_id().clone()];
         let state_event = BlockSyncInfo {}
-            .next_event(&mut alice_state_machine, &network_tip)
+            .next_event(&mut alice_state_machine, &network_tip, &sync_peers)
             .await;
         assert_eq!(state_event, StateEvent::BlocksSynchronized);
         assert_eq!(alice_db.get_height(), bob_db.get_height());
@@ -337,8 +338,9 @@ fn test_lagging_block_sync() {
 
         // Lagging state beyond horizon, sync remaining Blocks to tip
         let network_tip = bob_db.get_metadata().unwrap();
+        let sync_peers = vec![bob_node.node_identity.node_id().clone()];
         let state_event = BlockSyncInfo {}
-            .next_event(&mut alice_state_machine, &network_tip)
+            .next_event(&mut alice_state_machine, &network_tip, &sync_peers)
             .await;
         assert_eq!(state_event, StateEvent::BlocksSynchronized);
 
@@ -423,7 +425,10 @@ fn test_block_sync_recovery() {
         // won't always have these blocks and Alice will have to request these blocks again until her maximum attempts
         // have been reached.
         let network_tip = bob_db.get_metadata().unwrap();
-        let state_event = BlockSyncInfo.next_event(&mut alice_state_machine, &network_tip).await;
+        let sync_peers = vec![bob_node.node_identity.node_id().clone()];
+        let state_event = BlockSyncInfo
+            .next_event(&mut alice_state_machine, &network_tip, &sync_peers)
+            .await;
         assert_eq!(state_event, StateEvent::BlocksSynchronized);
 
         for height in 1..=network_tip.height_of_longest_chain.unwrap() {
@@ -523,8 +528,9 @@ fn test_forked_block_sync() {
         assert_eq!(bob_db.get_height(), Ok(Some(9)));
 
         let network_tip = bob_db.get_metadata().unwrap();
+        let sync_peers = vec![bob_node.node_identity.node_id().clone()];
         let state_event = BlockSyncInfo {}
-            .next_event(&mut alice_state_machine, &network_tip)
+            .next_event(&mut alice_state_machine, &network_tip, &sync_peers)
             .await;
         assert_eq!(state_event, StateEvent::BlocksSynchronized);
 


### PR DESCRIPTION
## Description
- Modified the base node state system to allow the sharing of the current set of sync peers that have the current best network state.
- Modified the chain_metadata_service to share PeerChainMetadata on its events, this includes the node_id of the peer that provided the metadata.
- The base node service and outbound node interface was changed to allow requests to be sent to either a random base node or a specified peer.
- The service_request_timeout test was fixed where the one node should not be reachable for the test to function correctly.
The base node state machine tests were updated to make use of the new sync peers functionality.

## Motivation and Context
These changes will allow the block syncing to only request the missing headers and blocks from a subset of peer nodes that the local node has recently been in contact with and do have the best tip on their main chain. Previously, requests were sent to random peers that might not have had the desired headers and blocks, this resulted in poor block syncing reliability when the majority of the network was not on the best chain.

## How Has This Been Tested?
Changes covered by existing tests.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [x] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch.
* [x] I ran `cargo-fmt --all` before pushing.
* [x] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
