### PR TITLE
Mining refactor and multi thread support

### DIFF
--- a/applications/tari_base_node/src/builder.rs
+++ b/applications/tari_base_node/src/builder.rs
@@ -427,6 +427,7 @@ where
             node.get_interrupt_flag(),
             event_stream,
             rules,
+            config.num_mining_threads,
         ))
     } else {
         debug!(

--- a/applications/tari_base_node/src/miner.rs
+++ b/applications/tari_base_node/src/miner.rs
@@ -32,16 +32,17 @@ use tari_core::{
 };
 use tari_service_framework::handles::ServiceHandles;
 
-pub fn build_miner<B: BlockchainBackend, H: AsRef<ServiceHandles>>(
+pub fn build_miner<B: BlockchainBackend + 'static, H: AsRef<ServiceHandles>>(
     handles: H,
     stop_flag: Arc<AtomicBool>,
     event_stream: Subscriber<BaseNodeState>,
     consensus_manager: ConsensusManager<B>,
+    num_threads: usize,
 ) -> Miner<B>
 {
     let handles = handles.as_ref();
     let node_local_interface = handles.get_handle::<LocalNodeCommsInterface>().unwrap();
-    let mut miner = Miner::new(stop_flag, consensus_manager, &node_local_interface);
+    let mut miner = Miner::new(stop_flag, consensus_manager, &node_local_interface, num_threads);
     miner.subscribe_to_state_change(event_stream);
     miner
 }

--- a/base_layer/core/src/mining/blake_miner.rs
+++ b/base_layer/core/src/mining/blake_miner.rs
@@ -52,7 +52,6 @@ impl CpuBlakePow {
         target_difficulty: Difficulty,
         mut header: BlockHeader,
         stop_flag: Arc<AtomicBool>,
-        kill_flag: Arc<AtomicBool>,
     ) -> Option<BlockHeader>
     {
         let mut start = Instant::now();
@@ -72,11 +71,11 @@ impl CpuBlakePow {
                     std::u64::MAX - last_measured_nonce + nonce
                 };
                 let hash_rate = hashes as f64 / start.elapsed().as_micros() as f64;
-                info!(target: LOG_TARGET, "Mining hash rate: {:.6} MH/s", hash_rate);
+                info!(target: LOG_TARGET, "Mining hash rate per thread: {:.6} MH/s", hash_rate);
                 last_measured_nonce = nonce;
                 start = Instant::now();
             }
-            if stop_flag.load(Ordering::Relaxed) || kill_flag.load(Ordering::Relaxed) {
+            if stop_flag.load(Ordering::Relaxed) {
                 info!(target: LOG_TARGET, "Mining stopped via flag");
                 return None;
             }

--- a/base_layer/core/tests/mining.rs
+++ b/base_layer/core/tests/mining.rs
@@ -103,7 +103,7 @@ fn mining() {
     });
     // Setup and start the miner
     let stop_flag = Arc::new(AtomicBool::new(false));
-    let mut miner = Miner::new(stop_flag, consensus_manager, &alice_node.local_nci);
+    let mut miner = Miner::new(stop_flag, consensus_manager, &alice_node.local_nci, 1);
     let (mut state_event_sender, state_event_receiver): (Publisher<BaseNodeState>, Subscriber<BaseNodeState>) =
         bounded(1);
     miner.subscribe_to_state_change(state_event_receiver);

--- a/base_layer/core/tests/wallet.rs
+++ b/base_layer/core/tests/wallet.rs
@@ -290,7 +290,7 @@ fn wallet_base_node_integration_test() {
 
     // Setup and start the miner
     let stop_flag = Arc::new(AtomicBool::new(false));
-    let mut miner = Miner::new(stop_flag, consensus_manager, &base_node.local_nci);
+    let mut miner = Miner::new(stop_flag, consensus_manager, &base_node.local_nci, 1);
     let (mut state_event_sender, state_event_receiver): (Publisher<BaseNodeState>, Subscriber<BaseNodeState>) =
         bounded(1);
     miner.subscribe_to_state_change(state_event_receiver);

--- a/common/src/configuration.rs
+++ b/common/src/configuration.rs
@@ -266,6 +266,7 @@ pub struct GlobalConfig {
     pub peer_seeds: Vec<String>,
     pub peer_db_path: String,
     pub enable_mining: bool,
+    pub num_mining_threads: usize,
     pub wallet_file: String,
     pub tor_identity_file: String,
 }
@@ -365,6 +366,11 @@ fn convert_node_config(network: Network, cfg: Config) -> Result<GlobalConfig, Co
         .get_bool(&key)
         .map_err(|e| ConfigurationError::new(&key, &e.to_string()))? as bool;
 
+    let key = config_string(&net_str, "num_mining_threads");
+    let num_mining_threads = cfg
+        .get_int(&key)
+        .map_err(|e| ConfigurationError::new(&key, &e.to_string()))? as usize;
+
     // set wallet_file
     let key = "wallet.wallet_file".to_string();
     let wallet_file = cfg
@@ -383,6 +389,7 @@ fn convert_node_config(network: Network, cfg: Config) -> Result<GlobalConfig, Co
         peer_seeds,
         peer_db_path,
         enable_mining,
+        num_mining_threads,
         wallet_file,
         tor_identity_file,
     })
@@ -537,6 +544,7 @@ pub fn default_config() -> Config {
     cfg.set_default("base_node.mainnet.grpc_address", "tcp://127.0.0.1:18041")
         .unwrap();
     cfg.set_default("base_node.mainnet.enable_mining", false).unwrap();
+    cfg.set_default("base_node.mainnet.num_mining_threads", 1).unwrap();
 
     // Rincewind base node defaults
     cfg.set_default("base_node.rincewind.db_type", "lmdb").unwrap();
@@ -565,6 +573,7 @@ pub fn default_config() -> Config {
     cfg.set_default("base_node.rincewind.grpc_address", "tcp://127.0.0.1:18141")
         .unwrap();
     cfg.set_default("base_node.rincewind.enable_mining", false).unwrap();
+    cfg.set_default("base_node.rincewind.num_mining_threads", 1).unwrap();
 
     set_transport_defaults(&mut cfg);
 


### PR DESCRIPTION
## Description
This PR refactors the mining of the base node to more clearly separate goals. It also includes multi thread support. 
This PR also fixes a bug that allowed the miner to mine when the BN is behind. 

## Motivation and Context
The mining module was very difficult to follow what goes on and how it functions. This PR some what cleans it up. It also makes it easier to support shutdown via channels via a future PR. 
The miner will now stop mining when the BN falls behind and exits listening state.
The miner can now mine multi threaded as well to better support multi core cpu's


## Types of changes
* [ ] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [x] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
* [x] I'm merging against the `development` branch.
* [x] I ran `cargo-fmt --all` before pushing.
* [x] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
