### PR TITLE
Detect failure and reestablish tor control connection + tor events

### DIFF
--- a/applications/tari_base_node/src/builder.rs
+++ b/applications/tari_base_node/src/builder.rs
@@ -359,7 +359,7 @@ where
     save_as_json(&config.identity_file, &*comms.node_identity())
         .map_err(|e| format!("Failed to save node identity: {:?}", e))?;
     if let Some(hs) = comms.hidden_service() {
-        save_as_json(&config.tor_identity_file, &hs.get_tor_identity())
+        save_as_json(&config.tor_identity_file, hs.tor_identity())
             .map_err(|e| format!("Failed to save tor identity: {:?}", e))?;
     }
     add_peers_to_comms(&comms, assign_peers(&config.peer_seeds)).await?;

--- a/base_layer/p2p/examples/gen_tor_identity.rs
+++ b/base_layer/p2p/examples/gen_tor_identity.rs
@@ -92,7 +92,7 @@ async fn main() {
         .await
         .unwrap();
 
-    let json = hidden_service.get_tor_identity().to_json().unwrap();
+    let json = hidden_service.tor_identity().to_json().unwrap();
     let out_path = to_abs_path(matches.value_of("output").unwrap());
     fs::write(out_path, json).unwrap();
 }

--- a/base_layer/p2p/src/services/liveness/service.rs
+++ b/base_layer/p2p/src/services/liveness/service.rs
@@ -182,9 +182,7 @@ where
                     target: LOG_TARGET,
                     "Received pong from peer '{}'. {} {} {}",
                     node_id.short_str(),
-                    maybe_latency
-                        .map(|ms| format!("Latency: {}ms", ms))
-                        .unwrap_or(String::new()),
+                    maybe_latency.map(|ms| format!("Latency: {}ms", ms)).unwrap_or_default(),
                     if is_neighbour { "(neighbouring)" } else { "" },
                     if is_monitored { "(monitored)" } else { "" },
                 );

--- a/base_layer/wallet_ffi/src/lib.rs
+++ b/base_layer/wallet_ffi/src/lib.rs
@@ -2005,7 +2005,7 @@ pub unsafe extern "C" fn wallet_get_tor_identity(wallet: *const TariWallet, erro
         let service = (*wallet).comms.hidden_service();
         match service {
             Some(s) => {
-                let tor_identity = s.get_tor_identity();
+                let tor_identity = s.tor_identity();
                 identity_bytes = tor_identity.to_binary().unwrap();
             },
             None => {

--- a/comms/Cargo.toml
+++ b/comms/Cargo.toml
@@ -36,7 +36,7 @@ snow = {version="0.6.2", features=["default-resolver"]}
 tokio = {version="^0.2", features=["blocking", "tcp", "stream", "dns", "sync", "stream", "signal"]}
 tokio-util = {version="0.2.0", features=["codec"]}
 tower= "0.3.1"
-yamux = {version="0.4.3"}
+yamux = {version="0.4.4"}
 
 [dev-dependencies]
 tari_test_utils = {version="0.0.9", path="../infrastructure/test_utils"}

--- a/comms/src/builder/mod.rs
+++ b/comms/src/builder/mod.rs
@@ -242,7 +242,7 @@ where
         let messaging = MessagingProtocol::new(
             executor,
             conn_man_requester,
-            peer_manager.into(),
+            peer_manager,
             node_identity,
             proto_rx,
             messaging_request_rx,
@@ -287,7 +287,7 @@ where
             backoff,
             request_rx,
             node_identity,
-            peer_manager.into(),
+            peer_manager,
             protocols,
             connection_manager_events_tx,
             self.shutdown.to_signal(),

--- a/comms/src/peer_manager/peer_storage.rs
+++ b/comms/src/peer_manager/peer_storage.rs
@@ -164,7 +164,7 @@ where DS: KeyValueStore<PeerId, Peer>
                 if must_update_node_id {
                     trace!(target: LOG_TARGET, "Must update node id for peer '{}'", node_id);
                     self.remove_index_links(peer_key);
-                    self.add_index_links(peer_key, public_key, node_id.clone());
+                    self.add_index_links(peer_key, public_key, node_id);
                 }
 
                 Ok(())

--- a/comms/src/tor/control_client/commands/add_onion.rs
+++ b/comms/src/tor/control_client/commands/add_onion.rs
@@ -117,13 +117,13 @@ impl TorCommand for AddOnion<'_> {
         Ok(s)
     }
 
-    fn parse_responses(&self, mut responses: Vec<ResponseLine<'_>>) -> Result<Self::Output, Self::Error> {
+    fn parse_responses(&self, mut responses: Vec<ResponseLine>) -> Result<Self::Output, Self::Error> {
         let last_response = responses.pop().ok_or_else(|| TorClientError::UnexpectedEof)?;
         if let Some(err) = last_response.err() {
             if err.contains("Onion address collision") {
                 return Err(TorClientError::OnionAddressCollision);
             }
-            return Err(TorClientError::TorCommandFailed(err.into_owned()));
+            return Err(TorClientError::TorCommandFailed(err.to_owned()));
         }
 
         let mut service_id = None;

--- a/comms/src/tor/control_client/commands/del_onion.rs
+++ b/comms/src/tor/control_client/commands/del_onion.rs
@@ -44,10 +44,10 @@ impl<'a> TorCommand for DelOnion<'a> {
         Ok(format!("DEL_ONION {}", self.service_id))
     }
 
-    fn parse_responses(&self, mut responses: Vec<ResponseLine<'_>>) -> Result<Self::Output, Self::Error> {
+    fn parse_responses(&self, mut responses: Vec<ResponseLine>) -> Result<Self::Output, Self::Error> {
         let last_response = responses.pop().ok_or_else(|| TorClientError::UnexpectedEof)?;
         if let Some(err) = last_response.err() {
-            return Err(TorClientError::TorCommandFailed(err.into_owned()));
+            return Err(TorClientError::TorCommandFailed(err.to_owned()));
         }
 
         Ok(())

--- a/comms/src/tor/control_client/commands/key_value.rs
+++ b/comms/src/tor/control_client/commands/key_value.rs
@@ -37,6 +37,13 @@ pub fn get_info(key_name: &str) -> KeyValueCommand<'_, '_> {
     KeyValueCommand::new("GETINFO", &[key_name])
 }
 
+/// The SETEVENTS command.
+///
+/// This command is used to set the events that tor will emit
+pub fn set_events<'b>(event_types: &[&'b str]) -> KeyValueCommand<'static, 'b> {
+    KeyValueCommand::new("SETEVENTS", event_types)
+}
+
 pub struct KeyValueCommand<'a, 'b> {
     command: &'a str,
     args: Vec<&'b str>,
@@ -61,7 +68,7 @@ impl<'a, 'b> TorCommand for KeyValueCommand<'a, 'b> {
         Ok(format!("{} {}", self.command, self.args.join(" ")))
     }
 
-    fn parse_responses(&self, mut responses: Vec<ResponseLine<'_>>) -> Result<Self::Output, Self::Error> {
+    fn parse_responses(&self, mut responses: Vec<ResponseLine>) -> Result<Self::Output, Self::Error> {
         if let Some(resp) = responses.iter().find(|v| v.is_err()) {
             return Err(TorClientError::TorCommandFailed(resp.value.to_string()));
         }

--- a/comms/src/tor/control_client/commands/mod.rs
+++ b/comms/src/tor/control_client/commands/mod.rs
@@ -28,7 +28,7 @@ mod key_value;
 
 pub use add_onion::{AddOnion, AddOnionFlag, AddOnionResponse};
 pub use del_onion::DelOnion;
-pub use key_value::{get_conf, get_info, KeyValueCommand};
+pub use key_value::{get_conf, get_info, set_events, KeyValueCommand};
 
 pub trait TorCommand {
     type Output;
@@ -36,5 +36,5 @@ pub trait TorCommand {
 
     fn to_command_string(&self) -> Result<String, Self::Error>;
 
-    fn parse_responses(&self, responses: Vec<ResponseLine<'_>>) -> Result<Self::Output, Self::Error>;
+    fn parse_responses(&self, responses: Vec<ResponseLine>) -> Result<Self::Output, Self::Error>;
 }

--- a/comms/src/tor/control_client/mod.rs
+++ b/comms/src/tor/control_client/mod.rs
@@ -28,6 +28,10 @@ pub use error::TorClientError;
 
 pub mod commands;
 
+mod event;
+pub use event::TorControlEvent;
+
+mod monitor;
 mod parsers;
 mod response;
 
@@ -36,3 +40,5 @@ pub use types::{KeyBlob, KeyType, PortMapping, PrivateKey};
 
 #[cfg(test)]
 mod test_server;
+
+const LOG_TARGET: &str = "comms::tor::control_client";

--- a/comms/src/tor/control_client/monitor.rs
+++ b/comms/src/tor/control_client/monitor.rs
@@ -1,0 +1,150 @@
+// Copyright 2020, The Tari Project
+//
+// Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+// following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+// disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+// following disclaimer in the documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+// products derived from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+// INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+// WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+// USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+use super::{event::TorControlEvent, parsers, response::ResponseLine, LOG_TARGET};
+use crate::compat::IoCompat;
+use futures::{channel::mpsc, future, future::Either, AsyncRead, AsyncWrite, SinkExt, Stream, StreamExt};
+use log::*;
+use std::fmt;
+use tokio::{sync::broadcast, task};
+use tokio_util::codec::{Framed, LinesCodec};
+
+pub fn spawn_monitor<TSocket>(
+    mut cmd_rx: mpsc::Receiver<String>,
+    socket: TSocket,
+    event_tx: broadcast::Sender<TorControlEvent>,
+) -> mpsc::Receiver<ResponseLine>
+where
+    TSocket: AsyncRead + AsyncWrite + Unpin + Send + 'static,
+{
+    let (mut responses_tx, responses_rx) = mpsc::channel(100);
+
+    task::spawn(async move {
+        let framed = Framed::new(IoCompat::new(socket), LinesCodec::new());
+        let (mut sink, mut stream) = framed.split();
+        loop {
+            let either = future::select(cmd_rx.next(), stream.next()).await;
+            match either {
+                // Received a command to send to the control server
+                Either::Left((Some(line), _)) => {
+                    trace!(target: LOG_TARGET, "Writing command of length '{}'", line.len());
+                    if let Err(err) = sink.send(line).await {
+                        error!(
+                            target: LOG_TARGET,
+                            "Error when sending to Tor control server: {:?}. Monitor is shutting down.", err
+                        );
+                        break;
+                    }
+                },
+                // Command stream ended
+                Either::Left((None, _)) => {
+                    debug!(
+                        target: LOG_TARGET,
+                        "Tor control server command receiver closed. Monitor is exiting."
+                    );
+                    break;
+                },
+
+                // Received a line from the control server
+                Either::Right((Some(Ok(line)), _)) => {
+                    trace!(target: LOG_TARGET, "Read line of length '{}'", line.len());
+                    match parsers::response_line(&line) {
+                        Ok(mut line) => {
+                            if line.is_multiline {
+                                let lines = read_until(&mut stream, ".").await;
+                                line.value = format!("{}\n{}", line.value, lines.join("\n"));
+                            }
+
+                            if line.is_event() {
+                                match TorControlEvent::try_from_response(line) {
+                                    Ok(event) => {
+                                        let _ = event_tx.send(event);
+                                    },
+                                    Err(err) => {
+                                        log_server_response_error(err);
+                                    },
+                                }
+                            } else if let Err(err) = responses_tx.send(line).await {
+                                warn!(
+                                    target: LOG_TARGET,
+                                    "Failed to send response on internal channel: {:?}", err
+                                );
+                            }
+                        },
+                        Err(err) => log_server_response_error(err),
+                    }
+                },
+
+                // Error receiving a line from the control server
+                Either::Right((Some(Err(err)), _)) => {
+                    error!(
+                        target: LOG_TARGET,
+                        "Line framing error when reading from tor control server: '{:?}'", err
+                    );
+                },
+                // The control server disconnected
+                Either::Right((None, _)) => {
+                    cmd_rx.close();
+                    debug!(
+                        target: LOG_TARGET,
+                        "Connection to tor control port closed. Monitor is exiting."
+                    );
+                    let _ = event_tx.send(TorControlEvent::TorControlDisconnected);
+                    break;
+                },
+            }
+        }
+    });
+
+    responses_rx
+}
+
+async fn read_until<E: fmt::Debug, S: Stream<Item = Result<String, E>> + Unpin>(
+    stream: &mut S,
+    pat: &str,
+) -> Vec<String>
+{
+    let mut items = Vec::new();
+    loop {
+        match stream.next().await {
+            Some(Ok(item)) => {
+                if item.trim() == pat {
+                    break items;
+                }
+                items.push(item);
+            },
+            Some(Err(err)) => {
+                error!(target: LOG_TARGET, "read_until: {:?}", err);
+            },
+            None => {
+                break items;
+            },
+        }
+    }
+}
+
+fn log_server_response_error<E: fmt::Debug>(err: E) {
+    error!(
+        target: LOG_TARGET,
+        "Error processing response from tor control server: '{:?}'", err
+    );
+}

--- a/comms/src/tor/control_client/parsers.rs
+++ b/comms/src/tor/control_client/parsers.rs
@@ -48,7 +48,7 @@ impl fmt::Display for ParseError {
     }
 }
 
-pub fn response_line(line: &str) -> Result<ResponseLine<'_>, ParseError> {
+pub fn response_line(line: &str) -> Result<ResponseLine, ParseError> {
     let parser = map_res(digit1, |code: &str| code.parse::<u16>());
     let (rest, code) = parser(line)?;
     let (rest, ch) = anychar(rest)?;
@@ -63,7 +63,7 @@ pub fn response_line(line: &str) -> Result<ResponseLine<'_>, ParseError> {
         has_more: ['-', '+'].contains(&ch),
         is_multiline: ch == '+',
         code,
-        value: rest.into(),
+        value: rest.to_owned(),
     })
 }
 

--- a/comms/src/tor/control_client/response.rs
+++ b/comms/src/tor/control_client/response.rs
@@ -20,21 +20,19 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use std::borrow::Cow;
-
 const OK_CODE: u16 = 250;
 pub const EVENT_CODE: u16 = 650;
 
 /// Represents a single response line from the server.
 #[derive(Debug)]
-pub struct ResponseLine<'a> {
-    pub(super) value: Cow<'a, str>,
+pub struct ResponseLine {
+    pub(super) value: String,
     pub(super) code: u16,
     pub(super) has_more: bool,
     pub(super) is_multiline: bool,
 }
 
-impl<'a> ResponseLine<'a> {
+impl ResponseLine {
     pub fn is_ok(&self) -> bool {
         self.code == OK_CODE
     }
@@ -43,9 +41,13 @@ impl<'a> ResponseLine<'a> {
         self.has_more
     }
 
-    pub fn into_owned<'b>(self) -> ResponseLine<'b> {
+    pub fn is_event(&self) -> bool {
+        self.code == EVENT_CODE
+    }
+
+    pub fn into_owned(self) -> ResponseLine {
         ResponseLine {
-            value: Cow::Owned(self.value.into_owned()),
+            value: self.value,
             code: self.code,
             has_more: self.has_more,
             is_multiline: self.is_multiline,
@@ -56,9 +58,9 @@ impl<'a> ResponseLine<'a> {
         !self.is_ok()
     }
 
-    pub fn err(&self) -> Option<Cow<'a, str>> {
+    pub fn err(&self) -> Option<&str> {
         if self.is_err() {
-            Some(self.value.clone())
+            Some(&self.value)
         } else {
             None
         }

--- a/comms/src/tor/hidden_service/controller.rs
+++ b/comms/src/tor/hidden_service/controller.rs
@@ -1,0 +1,311 @@
+// Copyright 2020, The Tari Project
+//
+// Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+// following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+// disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+// following disclaimer in the documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+// products derived from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+// INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+// WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+// USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+use crate::{
+    multiaddr::Multiaddr,
+    socks,
+    tor::{
+        control_client::{
+            commands::{AddOnionFlag, AddOnionResponse},
+            TorControlEvent,
+        },
+        Authentication,
+        HiddenService,
+        HsFlags,
+        PortMapping,
+        TorClientError,
+        TorControlPortClient,
+        TorIdentity,
+    },
+    utils::multiaddr::socketaddr_to_multiaddr,
+};
+use derive_error::Error;
+use futures::{future, future::Either, pin_mut, StreamExt};
+use log::*;
+use std::{net::SocketAddr, time::Duration};
+use tari_shutdown::{Shutdown, ShutdownSignal};
+use tokio::{sync::broadcast, task, time};
+
+const LOG_TARGET: &str = "comms::tor::hidden_service_controller";
+
+#[derive(Debug, Error)]
+pub enum HiddenServiceControllerError {
+    /// Tor client is not connected
+    NotConnected,
+    /// Failed to parse SOCKS address returned by control port
+    FailedToParseSocksAddress,
+    TorClientError(TorClientError),
+    /// The given tor service id is not a valid detached service id
+    InvalidDetachedServiceId,
+    /// The shutdown signal interrupted the HiddenServiceController
+    ShutdownSignalInterrupt,
+}
+
+pub struct HiddenServiceController {
+    pub(super) client: Option<TorControlPortClient>,
+    pub(super) control_server_addr: Multiaddr,
+    pub(super) control_server_auth: Authentication,
+    pub(super) proxied_port_mapping: PortMapping,
+    pub(super) socks_address_override: Option<Multiaddr>,
+    pub(super) socks_auth: socks::Authentication,
+    pub(super) identity: Option<TorIdentity>,
+    pub(super) hs_flags: HsFlags,
+}
+
+impl HiddenServiceController {
+    pub async fn start_hidden_service(mut self) -> Result<HiddenService, HiddenServiceControllerError> {
+        self.connect().await?;
+        self.authenticate().await?;
+        self.set_events().await?;
+
+        let hidden_service = self.create_hidden_service().await?;
+        let mut shutdown_signal = hidden_service.shutdown.to_signal();
+        let mut event_stream = self.client.as_ref().unwrap().get_event_stream();
+
+        task::spawn({
+            async move {
+                loop {
+                    let either = future::select(&mut shutdown_signal, event_stream.next()).await;
+                    match either {
+                        Either::Left(_) => {
+                            debug!(
+                                target: LOG_TARGET,
+                                "Tor controller shut down because the shutdown signal was received"
+                            );
+                            break;
+                        },
+                        Either::Right((Some(Ok(TorControlEvent::TorControlDisconnected)), shutdown_signal)) => {
+                            let event_tx = self
+                                .client
+                                .as_ref()
+                                .map(|c| c.event_sender().clone())
+                                .expect("HiddenServiceController::client was None");
+                            warn!(
+                                target: LOG_TARGET,
+                                "Tor control server disconnected. Attempting to reestablish connection..."
+                            );
+                            if let Err(err) = self.reestablish_hidden_service(event_tx, shutdown_signal).await {
+                                error!(
+                                    target: LOG_TARGET,
+                                    "Failed to reestablish connection to tor control server because '{:?}'", err
+                                );
+                                break;
+                            }
+                        },
+                        Either::Right((Some(Ok(evt)), _)) => {
+                            trace!(target: LOG_TARGET, "Tor control event: {:?}", evt);
+                        },
+                        _ => {},
+                    }
+                }
+            }
+        });
+
+        Ok(hidden_service)
+    }
+
+    async fn reestablish_hidden_service(
+        &mut self,
+        event_tx: broadcast::Sender<TorControlEvent>,
+        shutdown_signal: &mut ShutdownSignal,
+    ) -> Result<(), HiddenServiceControllerError>
+    {
+        let mut signal = Some(shutdown_signal);
+        loop {
+            warn!(
+                target: LOG_TARGET,
+                "Attempting to reestablish control port connection at '{}'", self.control_server_addr
+            );
+            let connect_fut = TorControlPortClient::connect(self.control_server_addr.clone(), event_tx.clone());
+            pin_mut!(connect_fut);
+            let either = future::select(connect_fut, signal.take().expect("signal was None")).await;
+            match either {
+                Either::Left((Ok(client), _)) => {
+                    self.client = Some(client);
+                    self.authenticate().await?;
+                    self.set_events().await?;
+                    let _ = self.create_hidden_service().await;
+                    break Ok(());
+                },
+                Either::Left((Err(err), shutdown_signal)) => {
+                    signal = Some(shutdown_signal);
+                    warn!(
+                        target: LOG_TARGET,
+                        "Failed to reestablish connection with tor control server because '{:?}'", err
+                    );
+                    warn!(target: LOG_TARGET, "Will attempt again in 5 seconds...");
+                    time::delay_for(Duration::from_secs(5)).await;
+                },
+
+                Either::Right(_) => {
+                    break Err(HiddenServiceControllerError::ShutdownSignalInterrupt);
+                },
+            }
+        }
+    }
+
+    fn client_mut(&mut self) -> Result<&mut TorControlPortClient, HiddenServiceControllerError> {
+        self.client
+            .as_mut()
+            .filter(|c| c.is_connected())
+            .ok_or_else(|| HiddenServiceControllerError::NotConnected)
+    }
+
+    async fn connect(&mut self) -> Result<(), HiddenServiceControllerError> {
+        let (event_tx, _) = broadcast::channel(20);
+        let client = TorControlPortClient::connect(self.control_server_addr.clone(), event_tx).await?;
+        self.client = Some(client);
+        Ok(())
+    }
+
+    async fn authenticate(&mut self) -> Result<(), HiddenServiceControllerError> {
+        let auth = self.control_server_auth.clone();
+        self.client_mut()?.authenticate(&auth).await?;
+        Ok(())
+    }
+
+    async fn set_events(&mut self) -> Result<(), HiddenServiceControllerError> {
+        self.client_mut()?.set_events(&["NETWORK_LIVENESS"]).await?;
+        Ok(())
+    }
+
+    async fn get_socks_address(&mut self) -> Result<Multiaddr, HiddenServiceControllerError> {
+        match self.socks_address_override {
+            Some(ref addr) => {
+                debug!(
+                    target: LOG_TARGET,
+                    "Using SOCKS override '{}' for tor SOCKS proxy", addr
+                );
+                Ok(addr.clone())
+            },
+            None => {
+                // Get configured SOCK5 address from Tor
+                let socks_addrs = self.client_mut()?.get_info("net/listeners/socks").await?;
+
+                let addr = socks_addrs
+                    .iter()
+                    .map(|addr| addr.parse::<SocketAddr>())
+                    .filter_map(Result::ok)
+                    .map(|addr| socketaddr_to_multiaddr(&addr))
+                    .next()
+                    .ok_or_else(|| HiddenServiceControllerError::FailedToParseSocksAddress)?;
+
+                Ok(addr)
+            },
+        }
+    }
+
+    async fn create_hidden_service(&mut self) -> Result<HiddenService, HiddenServiceControllerError> {
+        let socks_addr = self.get_socks_address().await?;
+        debug!(target: LOG_TARGET, "Tor SOCKS address is '{}'", socks_addr);
+
+        // Initialize a onion hidden service - either from the given private key or by creating a new one
+        match self.identity.take() {
+            Some(identity) => {
+                let resp = self.create_or_reuse_onion(&identity).await?;
+                self.identity = Some(TorIdentity {
+                    onion_port: resp.onion_port,
+                    ..identity
+                });
+            },
+            None => {
+                let port_mapping = self.proxied_port_mapping.clone();
+                let resp = self.client_mut()?.add_onion(vec![], port_mapping, None).await?;
+                let private_key = resp
+                    .private_key
+                    .clone()
+                    .expect("Tor server MUST return private key according to spec");
+
+                self.identity = Some(TorIdentity {
+                    private_key,
+                    service_id: resp.service_id,
+                    onion_port: resp.onion_port,
+                });
+            },
+        };
+
+        let identity = self.identity.as_ref().map(Clone::clone).expect("already checked");
+        debug!(
+            target: LOG_TARGET,
+            "Added hidden service with service id '{}' on port '{}'", identity.service_id, identity.onion_port
+        );
+
+        let proxied_addr = socketaddr_to_multiaddr(self.proxied_port_mapping.proxied_address());
+
+        Ok(HiddenService {
+            socks_addr,
+            socks_auth: self.socks_auth.clone(),
+            identity,
+            proxied_addr,
+            shutdown: Shutdown::new(),
+        })
+    }
+
+    async fn create_or_reuse_onion(
+        &mut self,
+        identity: &TorIdentity,
+    ) -> Result<AddOnionResponse, HiddenServiceControllerError>
+    {
+        let mut flags = Vec::new();
+        if self.hs_flags.contains(HsFlags::DETACH) {
+            flags.push(AddOnionFlag::Detach);
+        }
+
+        let port_mapping = self.proxied_port_mapping.clone();
+
+        let client = self.client_mut()?;
+
+        let result = client
+            .add_onion_from_private_key(&identity.private_key, flags, port_mapping, None)
+            .await;
+
+        match result {
+            Ok(resp) => Ok(resp),
+            Err(TorClientError::OnionAddressCollision) => {
+                debug!(target: LOG_TARGET, "Onion address is already registered.");
+
+                let detached = client.get_info("onions/detached").await?;
+                debug!(
+                    target: LOG_TARGET,
+                    "Comparing active detached service IDs '{}' to expected service id '{}'",
+                    detached.join(", "),
+                    identity.service_id
+                );
+
+                if detached.iter().all(|svc_id| **svc_id != identity.service_id) {
+                    return Err(HiddenServiceControllerError::InvalidDetachedServiceId);
+                }
+
+                Ok(AddOnionResponse {
+                    // TODO(sdbondi): This could be a different ORPort than the one requested in port mapping, I was not
+                    //                able to find a way to find the port mapping for the service.
+                    //                Setting the onion_port to be the same as the original port may cause
+                    //                confusion/break "just works"(tm)
+                    onion_port: identity.onion_port,
+                    service_id: identity.service_id.clone(),
+                    private_key: Some(identity.private_key.clone()),
+                })
+            },
+            Err(err) => Err(err.into()),
+        }
+    }
+}

--- a/comms/src/transports/tcp_with_tor.rs
+++ b/comms/src/transports/tcp_with_tor.rs
@@ -87,7 +87,7 @@ impl Transport for TcpWithTorTransport {
                 },
                 None => Err(io::Error::new(
                     io::ErrorKind::Other,
-                    format!("Tor SOCKS proxy is not set for TCP transport. Cannot dial peer with onion addresses."),
+                    "Tor SOCKS proxy is not set for TCP transport. Cannot dial peer with onion addresses.".to_owned(),
                 )),
             }
         } else {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
If the tor server is restarted (for whatever reason), the hidden service
would cease to exist on the tor network making it impossible for clients
to connect into the node until the node is restarted.

This PR fixes this by adding a controller that is responsible for tor
hidden service reliability. If the tor control server disconnects, the 
controller will attempt to reconnect every 5 seconds until either 
it succeeds or is shut down. On success, clients will be able once 
more to connect to the node's hidden service.

Additionally, the TorControlClient now has the ability to subscribe to
events emitted by the tor control server and publish those on a tokio
broadcast channel. This could be useful down-the-line for determining
network availability/bandwidth usage etc.

This implementation required that:
1. The tor control connection is monitored in it's own task
1. Events and response text is split into seperate streams
1. The hidden service is immediately recovered once a connection is
   reestablished.
1. The event stream is preserved when reestablishing connections to tor
1. The SETEVENTS command is supported


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #1497 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
More extensive tests needed - existing control client tests pass, base node tor disconnect/reconnect works

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [x] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch.
* [x] I ran `cargo-fmt --all` before pushing.
* [x] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
