### PR TITLE
Remove R2D2 for Sqlite from Wallet

### DIFF
--- a/applications/tari_base_node/src/builder.rs
+++ b/applications/tari_base_node/src/builder.rs
@@ -90,7 +90,7 @@ use tari_wallet::{
         storage::sqlite_db::OutputManagerSqliteDatabase,
         OutputManagerServiceInitializer,
     },
-    storage::connection_manager::{run_migration_and_create_connection_pool, WalletConnection},
+    storage::connection_manager::{run_migration_and_create_sqlite_connection, WalletConnection},
     transaction_service::{
         config::TransactionServiceConfig,
         handle::TransactionServiceHandle,
@@ -364,7 +364,7 @@ where
     }
     add_peers_to_comms(&comms, assign_peers(&config.peer_seeds)).await?;
     create_wallet_folder(&config.wallet_file)?;
-    let wallet_conn = run_migration_and_create_connection_pool(&config.wallet_file)
+    let wallet_conn = run_migration_and_create_sqlite_connection(&config.wallet_file)
         .map_err(|e| format!("Could not create wallet: {:?}", e))?;
     debug!(target: LOG_TARGET, "Registering base node services");
     let handles = register_services(

--- a/base_layer/core/tests/wallet.rs
+++ b/base_layer/core/tests/wallet.rs
@@ -135,7 +135,6 @@ fn wallet_base_node_integration_test() {
     };
     let alice_wallet_config = WalletConfig {
         comms_config: alice_comms_config,
-        logging_path: None,
         factories: factories.clone(),
         transaction_service_config: Some(TransactionServiceConfig {
             mempool_broadcast_timeout: Duration::from_secs(10),
@@ -183,7 +182,6 @@ fn wallet_base_node_integration_test() {
     };
     let bob_wallet_config = WalletConfig {
         comms_config: bob_comms_config,
-        logging_path: None,
         factories: factories.clone(),
         transaction_service_config: None,
     };

--- a/base_layer/wallet/Cargo.toml
+++ b/base_layer/wallet/Cargo.toml
@@ -35,7 +35,7 @@ log = "0.4.6"
 log4rs = {version = "0.8.3", features = ["console_appender", "file_appender", "file", "yaml_format"]}
 lmdb-zero = "0.4.4"
 diesel_migrations =  "1.4"
-diesel = {version="1.4", features = ["sqlite", "serde_json", "chrono", "r2d2"]}
+diesel = {version="1.4", features = ["sqlite", "serde_json", "chrono"]}
 rand = "0.7.2"
 futures =  { version = "^0.3.1", features =["compat", "std"]}
 tokio = { version = "0.2.10", features = ["blocking", "sync"]}

--- a/base_layer/wallet/migrations/2019-10-30-084148_output_manager_service/up.sql
+++ b/base_layer/wallet/migrations/2019-10-30-084148_output_manager_service/up.sql
@@ -4,8 +4,7 @@ CREATE TABLE outputs (
     flags INTEGER NOT NULL,
     maturity INTEGER NOT NULL,
     status INTEGER NOT NULL,
-    tx_id INTEGER NULL,
-    FOREIGN KEY(tx_id) REFERENCES pending_transaction_outputs(tx_id)
+    tx_id INTEGER NULL
 );
 
 CREATE TABLE pending_transaction_outputs (

--- a/base_layer/wallet/src/contacts_service/service.rs
+++ b/base_layer/wallet/src/contacts_service/service.rs
@@ -65,7 +65,7 @@ where T: ContactsBackend + 'static
             .fuse();
         pin_mut!(request_stream);
 
-        info!("Contacts Service started");
+        info!(target: LOG_TARGET, "Contacts Service started");
         loop {
             futures::select! {
                 request_context = request_stream.select_next_some() => {
@@ -84,7 +84,7 @@ where T: ContactsBackend + 'static
                 }
             }
         }
-        info!("Contacts Service ended");
+        info!(target: LOG_TARGET, "Contacts Service ended");
         Ok(())
     }
 

--- a/base_layer/wallet/src/contacts_service/storage/sqlite_db.rs
+++ b/base_layer/wallet/src/contacts_service/storage/sqlite_db.rs
@@ -27,38 +27,30 @@ use crate::{
     },
     schema::contacts,
 };
-use diesel::{
-    prelude::*,
-    r2d2::{ConnectionManager, Pool, PooledConnection},
-    result::Error as DieselError,
-    SqliteConnection,
+use diesel::{prelude::*, result::Error as DieselError, SqliteConnection};
+use std::{
+    convert::TryFrom,
+    sync::{Arc, Mutex},
 };
-use std::convert::TryFrom;
 use tari_core::transactions::types::PublicKey;
 use tari_crypto::tari_utilities::ByteArray;
 
 /// A Sqlite backend for the Output Manager Service. The Backend is accessed via a connection pool to the Sqlite file.
 pub struct ContactsServiceSqliteDatabase {
-    database_connection_pool: Pool<ConnectionManager<SqliteConnection>>,
+    database_connection: Arc<Mutex<SqliteConnection>>,
 }
 impl ContactsServiceSqliteDatabase {
-    pub fn new(database_connection_pool: Pool<ConnectionManager<SqliteConnection>>) -> Self {
-        Self {
-            database_connection_pool,
-        }
+    pub fn new(database_connection: Arc<Mutex<SqliteConnection>>) -> Self {
+        Self { database_connection }
     }
 }
 
 impl ContactsBackend for ContactsServiceSqliteDatabase {
     fn fetch(&self, key: &DbKey) -> Result<Option<DbValue>, ContactsServiceStorageError> {
-        let conn = self
-            .database_connection_pool
-            .clone()
-            .get()
-            .map_err(|_| ContactsServiceStorageError::R2d2Error)?;
+        let conn = acquire_lock!(self.database_connection);
 
         let result = match key {
-            DbKey::Contact(pk) => match ContactSql::find(&pk.to_vec(), &conn) {
+            DbKey::Contact(pk) => match ContactSql::find(&pk.to_vec(), &(*conn)) {
                 Ok(c) => Some(DbValue::Contact(Box::new(Contact::try_from(c)?))),
                 Err(ContactsServiceStorageError::DieselError(DieselError::NotFound)) => None,
                 Err(e) => return Err(e),
@@ -75,17 +67,13 @@ impl ContactsBackend for ContactsServiceSqliteDatabase {
     }
 
     fn write(&self, op: WriteOperation) -> Result<Option<DbValue>, ContactsServiceStorageError> {
-        let conn = self
-            .database_connection_pool
-            .clone()
-            .get()
-            .map_err(|_| ContactsServiceStorageError::R2d2Error)?;
+        let conn = acquire_lock!(self.database_connection);
 
         match op {
             WriteOperation::Upsert(kvp) => match kvp {
-                DbKeyValuePair::Contact(k, c) => match ContactSql::find(&k.to_vec(), &conn) {
+                DbKeyValuePair::Contact(k, c) => match ContactSql::find(&k.to_vec(), &(*conn)) {
                     Ok(found_c) => {
-                        let _ = found_c.update(UpdateContact { alias: Some(c.alias) }, &conn)?;
+                        let _ = found_c.update(UpdateContact { alias: Some(c.alias) }, &(*conn))?;
                     },
                     Err(_) => {
                         ContactSql::from(c).commit(&conn)?;
@@ -93,7 +81,7 @@ impl ContactsBackend for ContactsServiceSqliteDatabase {
                 },
             },
             WriteOperation::Remove(k) => match k {
-                DbKey::Contact(k) => match ContactSql::find(&k.to_vec(), &conn) {
+                DbKey::Contact(k) => match ContactSql::find(&k.to_vec(), &(*conn)) {
                     Ok(c) => {
                         c.clone().delete(&conn)?;
                         return Ok(Some(DbValue::Contact(Box::new(Contact::try_from(c)?))));
@@ -119,11 +107,7 @@ struct ContactSql {
 
 impl ContactSql {
     /// Write this struct to the database
-    pub fn commit(
-        &self,
-        conn: &PooledConnection<ConnectionManager<SqliteConnection>>,
-    ) -> Result<(), ContactsServiceStorageError>
-    {
+    pub fn commit(&self, conn: &SqliteConnection) -> Result<(), ContactsServiceStorageError> {
         diesel::insert_into(contacts::table)
             .values(self.clone())
             .execute(conn)?;
@@ -131,28 +115,18 @@ impl ContactSql {
     }
 
     /// Return all contacts
-    pub fn index(
-        conn: &PooledConnection<ConnectionManager<SqliteConnection>>,
-    ) -> Result<Vec<ContactSql>, ContactsServiceStorageError> {
+    pub fn index(conn: &SqliteConnection) -> Result<Vec<ContactSql>, ContactsServiceStorageError> {
         Ok(contacts::table.load::<ContactSql>(conn)?)
     }
 
     /// Find a particular Contact, if it exists
-    pub fn find(
-        public_key: &[u8],
-        conn: &PooledConnection<ConnectionManager<SqliteConnection>>,
-    ) -> Result<ContactSql, ContactsServiceStorageError>
-    {
+    pub fn find(public_key: &[u8], conn: &SqliteConnection) -> Result<ContactSql, ContactsServiceStorageError> {
         Ok(contacts::table
             .filter(contacts::public_key.eq(public_key))
             .first::<ContactSql>(conn)?)
     }
 
-    pub fn delete(
-        &self,
-        conn: &PooledConnection<ConnectionManager<SqliteConnection>>,
-    ) -> Result<(), ContactsServiceStorageError>
-    {
+    pub fn delete(&self, conn: &SqliteConnection) -> Result<(), ContactsServiceStorageError> {
         let num_deleted =
             diesel::delete(contacts::table.filter(contacts::public_key.eq(&self.public_key))).execute(conn)?;
 
@@ -166,7 +140,7 @@ impl ContactSql {
     pub fn update(
         &self,
         updated_contact: UpdateContact,
-        conn: &PooledConnection<ConnectionManager<SqliteConnection>>,
+        conn: &SqliteConnection,
     ) -> Result<ContactSql, ContactsServiceStorageError>
     {
         let num_updated = diesel::update(contacts::table.filter(contacts::public_key.eq(&self.public_key)))
@@ -217,7 +191,7 @@ mod test {
         database::Contact,
         sqlite_db::{ContactSql, UpdateContact},
     };
-    use diesel::{r2d2::ConnectionManager, Connection, SqliteConnection};
+    use diesel::{Connection, SqliteConnection};
     use rand::rngs::OsRng;
     use std::convert::TryFrom;
     use tari_core::transactions::types::{PrivateKey, PublicKey};
@@ -239,10 +213,6 @@ mod test {
 
             embedded_migrations::run_with_output(&conn, &mut std::io::stdout()).expect("Migration failed");
 
-            let manager = ConnectionManager::<SqliteConnection>::new(db_path);
-            let pool = diesel::r2d2::Pool::builder().max_size(1).build(manager).unwrap();
-
-            let conn = pool.get().unwrap();
             conn.execute("PRAGMA foreign_keys = ON").unwrap();
 
             let names = ["Alice".to_string(), "Bob".to_string(), "Carol".to_string()];

--- a/base_layer/wallet/src/error.rs
+++ b/base_layer/wallet/src/error.rs
@@ -56,6 +56,8 @@ pub enum WalletStorageError {
     ConversionError,
     /// Could not find all values specified for batch operation
     ValuesNotFound,
+    /// Db Path does not exist
+    DbPathDoesNotExist,
     SerdeJsonError(SerdeJsonError),
     R2d2Error,
     DieselError(DieselError),

--- a/base_layer/wallet/src/output_manager_service/service.rs
+++ b/base_layer/wallet/src/output_manager_service/service.rs
@@ -160,7 +160,7 @@ where
 
         let mut utxo_query_timeout_futures: FuturesUnordered<BoxFuture<'static, u64>> = FuturesUnordered::new();
 
-        info!("Output Manager Service started");
+        info!(target: LOG_TARGET, "Output Manager Service started");
         loop {
             futures::select! {
                 request_context = request_stream.select_next_some() => {
@@ -201,7 +201,7 @@ where
                 }
             }
         }
-        info!("Output Manager Service ended");
+        info!(target: LOG_TARGET, "Output Manager Service ended");
         Ok(())
     }
 

--- a/base_layer/wallet/src/output_manager_service/storage/sqlite_db.rs
+++ b/base_layer/wallet/src/output_manager_service/storage/sqlite_db.rs
@@ -39,41 +39,36 @@ use crate::{
 use chrono::{Duration as ChronoDuration, NaiveDateTime, Utc};
 #[cfg(test)]
 use diesel::expression::dsl::not;
-use diesel::{
-    prelude::*,
-    r2d2::{ConnectionManager, Pool, PooledConnection},
-    result::Error as DieselError,
-    SqliteConnection,
+use diesel::{prelude::*, result::Error as DieselError, SqliteConnection};
+use std::{
+    collections::HashMap,
+    convert::TryFrom,
+    sync::{Arc, Mutex},
+    time::Duration,
 };
-use std::{collections::HashMap, convert::TryFrom, time::Duration};
 use tari_core::transactions::{
     tari_amount::MicroTari,
     transaction::{OutputFeatures, OutputFlags, UnblindedOutput},
     types::PrivateKey,
 };
 use tari_crypto::tari_utilities::ByteArray;
+
 /// A Sqlite backend for the Output Manager Service. The Backend is accessed via a connection pool to the Sqlite file.
 #[derive(Clone)]
 pub struct OutputManagerSqliteDatabase {
-    database_connection_pool: Pool<ConnectionManager<SqliteConnection>>,
+    database_connection: Arc<Mutex<SqliteConnection>>,
 }
 impl OutputManagerSqliteDatabase {
-    pub fn new(database_connection_pool: Pool<ConnectionManager<SqliteConnection>>) -> Self {
-        Self {
-            database_connection_pool,
-        }
+    pub fn new(database_connection: Arc<Mutex<SqliteConnection>>) -> Self {
+        Self { database_connection }
     }
 }
 impl OutputManagerBackend for OutputManagerSqliteDatabase {
     fn fetch(&self, key: &DbKey) -> Result<Option<DbValue>, OutputManagerStorageError> {
-        let conn = self
-            .database_connection_pool
-            .clone()
-            .get()
-            .map_err(|_| OutputManagerStorageError::R2d2Error)?;
+        let conn = acquire_lock!(self.database_connection);
 
         let result = match key {
-            DbKey::SpentOutput(k) => match OutputSql::find_status(&k.to_vec(), OutputStatus::Spent, &conn) {
+            DbKey::SpentOutput(k) => match OutputSql::find_status(&k.to_vec(), OutputStatus::Spent, &(*conn)) {
                 Ok(o) => Some(DbValue::SpentOutput(Box::new(UnblindedOutput::try_from(o)?))),
                 Err(e) => {
                     match e {
@@ -83,7 +78,7 @@ impl OutputManagerBackend for OutputManagerSqliteDatabase {
                     None
                 },
             },
-            DbKey::UnspentOutput(k) => match OutputSql::find_status(&k.to_vec(), OutputStatus::Unspent, &conn) {
+            DbKey::UnspentOutput(k) => match OutputSql::find_status(&k.to_vec(), OutputStatus::Unspent, &(*conn)) {
                 Ok(o) => Some(DbValue::UnspentOutput(Box::new(UnblindedOutput::try_from(o)?))),
                 Err(e) => {
                     match e {
@@ -93,9 +88,9 @@ impl OutputManagerBackend for OutputManagerSqliteDatabase {
                     None
                 },
             },
-            DbKey::PendingTransactionOutputs(tx_id) => match PendingTransactionOutputSql::find(*tx_id, &conn) {
+            DbKey::PendingTransactionOutputs(tx_id) => match PendingTransactionOutputSql::find(*tx_id, &(*conn)) {
                 Ok(p) => {
-                    let outputs = OutputSql::find_by_tx_id_and_encumbered(*tx_id, &conn)?;
+                    let outputs = OutputSql::find_by_tx_id_and_encumbered(*tx_id, &(*conn))?;
                     Some(DbValue::PendingTransactionOutputs(Box::new(
                         pending_transaction_outputs_from_sql_outputs(p.tx_id as u64, &p.timestamp, outputs)?,
                     )))
@@ -109,22 +104,22 @@ impl OutputManagerBackend for OutputManagerSqliteDatabase {
                 },
             },
             DbKey::UnspentOutputs => Some(DbValue::UnspentOutputs(
-                OutputSql::index_status(OutputStatus::Unspent, &conn)?
+                OutputSql::index_status(OutputStatus::Unspent, &(*conn))?
                     .iter()
                     .map(|o| UnblindedOutput::try_from(o.clone()))
                     .collect::<Result<Vec<_>, _>>()?,
             )),
             DbKey::SpentOutputs => Some(DbValue::SpentOutputs(
-                OutputSql::index_status(OutputStatus::Spent, &conn)?
+                OutputSql::index_status(OutputStatus::Spent, &(*conn))?
                     .iter()
                     .map(|o| UnblindedOutput::try_from(o.clone()))
                     .collect::<Result<Vec<_>, _>>()?,
             )),
             DbKey::AllPendingTransactionOutputs => {
-                let pending_sql_txs = PendingTransactionOutputSql::index(&conn)?;
+                let pending_sql_txs = PendingTransactionOutputSql::index(&(*conn))?;
                 let mut pending_txs = HashMap::new();
                 for p_tx in pending_sql_txs {
-                    let outputs = OutputSql::find_by_tx_id_and_encumbered(p_tx.tx_id as u64, &conn)?;
+                    let outputs = OutputSql::find_by_tx_id_and_encumbered(p_tx.tx_id as u64, &(*conn))?;
                     pending_txs.insert(
                         p_tx.tx_id as u64,
                         pending_transaction_outputs_from_sql_outputs(p_tx.tx_id as u64, &p_tx.timestamp, outputs)?,
@@ -132,12 +127,12 @@ impl OutputManagerBackend for OutputManagerSqliteDatabase {
                 }
                 Some(DbValue::AllPendingTransactionOutputs(pending_txs))
             },
-            DbKey::KeyManagerState => match KeyManagerStateSql::get_state(&conn).ok() {
+            DbKey::KeyManagerState => match KeyManagerStateSql::get_state(&(*conn)).ok() {
                 None => None,
                 Some(km) => Some(DbValue::KeyManagerState(KeyManagerState::try_from(km)?)),
             },
             DbKey::InvalidOutputs => Some(DbValue::InvalidOutputs(
-                OutputSql::index_status(OutputStatus::Invalid, &conn)?
+                OutputSql::index_status(OutputStatus::Invalid, &(*conn))?
                     .iter()
                     .map(|o| UnblindedOutput::try_from(o.clone()))
                     .collect::<Result<Vec<_>, _>>()?,
@@ -148,44 +143,41 @@ impl OutputManagerBackend for OutputManagerSqliteDatabase {
     }
 
     fn write(&self, op: WriteOperation) -> Result<Option<DbValue>, OutputManagerStorageError> {
-        let conn = self
-            .database_connection_pool
-            .clone()
-            .get()
-            .map_err(|_| OutputManagerStorageError::R2d2Error)?;
+        let conn = acquire_lock!(self.database_connection);
 
         match op {
             WriteOperation::Insert(kvp) => match kvp {
                 DbKeyValuePair::SpentOutput(k, o) => {
-                    if let Ok(_) = OutputSql::find(&k.to_vec(), &conn) {
+                    if let Ok(_) = OutputSql::find(&k.to_vec(), &(*conn)) {
                         return Err(OutputManagerStorageError::DuplicateOutput);
                     }
-                    OutputSql::new(*o, OutputStatus::Spent, None).commit(&conn)?
+                    OutputSql::new(*o, OutputStatus::Spent, None).commit(&(*conn))?
                 },
                 DbKeyValuePair::UnspentOutput(k, o) => {
-                    if let Ok(_) = OutputSql::find(&k.to_vec(), &conn) {
+                    if let Ok(_) = OutputSql::find(&k.to_vec(), &(*conn)) {
                         return Err(OutputManagerStorageError::DuplicateOutput);
                     }
-                    OutputSql::new(*o, OutputStatus::Unspent, None).commit(&conn)?
+                    OutputSql::new(*o, OutputStatus::Unspent, None).commit(&(*conn))?
                 },
                 DbKeyValuePair::PendingTransactionOutputs(tx_id, p) => {
-                    if let Ok(_) = PendingTransactionOutputSql::find(tx_id, &conn) {
+                    if let Ok(_) = PendingTransactionOutputSql::find(tx_id, &(*conn)) {
                         return Err(OutputManagerStorageError::DuplicateOutput);
                     }
-                    PendingTransactionOutputSql::new(p.tx_id, p.timestamp).commit(&conn)?;
+                    PendingTransactionOutputSql::new(p.tx_id, p.timestamp).commit(&(*conn))?;
                     for o in p.outputs_to_be_spent {
-                        OutputSql::new(o.clone(), OutputStatus::EncumberedToBeSpent, Some(p.tx_id)).commit(&conn)?;
+                        OutputSql::new(o.clone(), OutputStatus::EncumberedToBeSpent, Some(p.tx_id)).commit(&(*conn))?;
                     }
                     for o in p.outputs_to_be_received {
-                        OutputSql::new(o.clone(), OutputStatus::EncumberedToBeReceived, Some(p.tx_id)).commit(&conn)?;
+                        OutputSql::new(o.clone(), OutputStatus::EncumberedToBeReceived, Some(p.tx_id))
+                            .commit(&(*conn))?;
                     }
                 },
-                DbKeyValuePair::KeyManagerState(km) => KeyManagerStateSql::set_state(km, &conn)?,
+                DbKeyValuePair::KeyManagerState(km) => KeyManagerStateSql::set_state(km, &(*conn))?,
             },
             WriteOperation::Remove(k) => match k {
-                DbKey::SpentOutput(s) => match OutputSql::find_status(&s.to_vec(), OutputStatus::Spent, &conn) {
+                DbKey::SpentOutput(s) => match OutputSql::find_status(&s.to_vec(), OutputStatus::Spent, &(*conn)) {
                     Ok(o) => {
-                        o.clone().delete(&conn)?;
+                        o.clone().delete(&(*conn))?;
                         return Ok(Some(DbValue::SpentOutput(Box::new(UnblindedOutput::try_from(o)?))));
                     },
                     Err(e) => {
@@ -195,9 +187,9 @@ impl OutputManagerBackend for OutputManagerSqliteDatabase {
                         };
                     },
                 },
-                DbKey::UnspentOutput(k) => match OutputSql::find_status(&k.to_vec(), OutputStatus::Unspent, &conn) {
+                DbKey::UnspentOutput(k) => match OutputSql::find_status(&k.to_vec(), OutputStatus::Unspent, &(*conn)) {
                     Ok(o) => {
-                        o.clone().delete(&conn)?;
+                        o.clone().delete(&(*conn))?;
                         return Ok(Some(DbValue::UnspentOutput(Box::new(UnblindedOutput::try_from(o)?))));
                     },
                     Err(e) => {
@@ -207,10 +199,10 @@ impl OutputManagerBackend for OutputManagerSqliteDatabase {
                         };
                     },
                 },
-                DbKey::PendingTransactionOutputs(tx_id) => match PendingTransactionOutputSql::find(tx_id, &conn) {
+                DbKey::PendingTransactionOutputs(tx_id) => match PendingTransactionOutputSql::find(tx_id, &(*conn)) {
                     Ok(p) => {
-                        let outputs = OutputSql::find_by_tx_id_and_encumbered(p.tx_id as u64, &conn)?;
-                        p.clone().delete(&conn)?;
+                        let outputs = OutputSql::find_by_tx_id_and_encumbered(p.tx_id as u64, &(*conn))?;
+                        p.clone().delete(&(*conn))?;
                         return Ok(Some(DbValue::PendingTransactionOutputs(Box::new(
                             pending_transaction_outputs_from_sql_outputs(p.tx_id as u64, &p.timestamp, outputs)?,
                         ))));
@@ -234,15 +226,11 @@ impl OutputManagerBackend for OutputManagerSqliteDatabase {
     }
 
     fn confirm_transaction(&self, tx_id: u64) -> Result<(), OutputManagerStorageError> {
-        let conn = self
-            .database_connection_pool
-            .clone()
-            .get()
-            .map_err(|_| OutputManagerStorageError::R2d2Error)?;
+        let conn = acquire_lock!(self.database_connection);
 
-        match PendingTransactionOutputSql::find(tx_id, &conn) {
+        match PendingTransactionOutputSql::find(tx_id, &(*conn)) {
             Ok(p) => {
-                let outputs = OutputSql::find_by_tx_id_and_encumbered(tx_id, &conn)?;
+                let outputs = OutputSql::find_by_tx_id_and_encumbered(tx_id, &(*conn))?;
 
                 for o in outputs {
                     if o.status == (OutputStatus::EncumberedToBeReceived as i32) {
@@ -251,7 +239,7 @@ impl OutputManagerBackend for OutputManagerSqliteDatabase {
                                 status: Some(OutputStatus::Unspent),
                                 tx_id: None,
                             },
-                            &conn,
+                            &(*conn),
                         )?;
                     } else if o.status == (OutputStatus::EncumberedToBeSpent as i32) {
                         o.update(
@@ -259,12 +247,12 @@ impl OutputManagerBackend for OutputManagerSqliteDatabase {
                                 status: Some(OutputStatus::Spent),
                                 tx_id: None,
                             },
-                            &conn,
+                            &(*conn),
                         )?;
                     }
                 }
 
-                p.delete(&conn)?;
+                p.delete(&(*conn))?;
             },
             Err(e) => {
                 match e {
@@ -284,22 +272,18 @@ impl OutputManagerBackend for OutputManagerSqliteDatabase {
         change_output: Option<UnblindedOutput>,
     ) -> Result<(), OutputManagerStorageError>
     {
-        let conn = self
-            .database_connection_pool
-            .clone()
-            .get()
-            .map_err(|_| OutputManagerStorageError::R2d2Error)?;
+        let conn = acquire_lock!(self.database_connection);
 
         let mut outputs_to_be_spent = Vec::new();
         for i in outputs_to_send {
-            let output = OutputSql::find(&i.spending_key.to_vec(), &conn)?;
+            let output = OutputSql::find(&i.spending_key.to_vec(), &(*conn))?;
             if output.status == (OutputStatus::Spent as i32) {
                 return Err(OutputManagerStorageError::OutputAlreadySpent);
             }
             outputs_to_be_spent.push(output);
         }
 
-        PendingTransactionOutputSql::new(tx_id, Utc::now().naive_utc()).commit(&conn)?;
+        PendingTransactionOutputSql::new(tx_id, Utc::now().naive_utc()).commit(&(*conn))?;
 
         for o in outputs_to_be_spent {
             o.update(
@@ -307,44 +291,40 @@ impl OutputManagerBackend for OutputManagerSqliteDatabase {
                     status: Some(OutputStatus::EncumberedToBeSpent),
                     tx_id: Some(tx_id),
                 },
-                &conn,
+                &(*conn),
             )?;
         }
 
         if let Some(co) = change_output {
-            OutputSql::new(co, OutputStatus::EncumberedToBeReceived, Some(tx_id)).commit(&conn)?;
+            OutputSql::new(co, OutputStatus::EncumberedToBeReceived, Some(tx_id)).commit(&(*conn))?;
         }
 
         Ok(())
     }
 
     fn cancel_pending_transaction(&self, tx_id: u64) -> Result<(), OutputManagerStorageError> {
-        let conn = self
-            .database_connection_pool
-            .clone()
-            .get()
-            .map_err(|_| OutputManagerStorageError::R2d2Error)?;
+        let conn = acquire_lock!(self.database_connection);
 
-        match PendingTransactionOutputSql::find(tx_id, &conn) {
+        match PendingTransactionOutputSql::find(tx_id, &(*conn)) {
             Ok(p) => {
-                let outputs = OutputSql::find_by_tx_id_and_encumbered(tx_id, &conn)?;
+                let outputs = OutputSql::find_by_tx_id_and_encumbered(tx_id, &(*conn))?;
 
                 for o in outputs {
                     if o.status == (OutputStatus::EncumberedToBeReceived as i32) {
-                        o.delete(&conn)?;
+                        o.delete(&(*conn))?;
                     } else if o.status == (OutputStatus::EncumberedToBeSpent as i32) {
                         o.update(
                             UpdateOutput {
                                 status: Some(OutputStatus::Unspent),
                                 tx_id: None,
                             },
-                            &conn,
+                            &(*conn),
                         )?;
-                        o.update_null(NullOutputSql { tx_id: None }, &conn)?;
+                        o.update_null(NullOutputSql { tx_id: None }, &(*conn))?;
                     }
                 }
 
-                p.delete(&conn)?;
+                p.delete(&(*conn))?;
             },
             Err(e) => {
                 match e {
@@ -362,15 +342,11 @@ impl OutputManagerBackend for OutputManagerSqliteDatabase {
     }
 
     fn timeout_pending_transactions(&self, period: Duration) -> Result<(), OutputManagerStorageError> {
-        let conn = self
-            .database_connection_pool
-            .clone()
-            .get()
-            .map_err(|_| OutputManagerStorageError::R2d2Error)?;
+        let conn = acquire_lock!(self.database_connection);
 
         let older_pending_txs = PendingTransactionOutputSql::index_older(
             Utc::now().naive_utc() - ChronoDuration::from_std(period)?,
-            &conn,
+            &(*conn),
         )?;
         drop(conn);
         for ptx in older_pending_txs {
@@ -380,31 +356,22 @@ impl OutputManagerBackend for OutputManagerSqliteDatabase {
     }
 
     fn increment_key_index(&self) -> Result<(), OutputManagerStorageError> {
-        let conn = self
-            .database_connection_pool
-            .clone()
-            .get()
-            .map_err(|_| OutputManagerStorageError::R2d2Error)?;
+        let conn = acquire_lock!(self.database_connection);
 
-        KeyManagerStateSql::increment_index(&conn)?;
+        KeyManagerStateSql::increment_index(&(*conn))?;
 
         Ok(())
     }
 
     fn invalidate_unspent_output(&self, output: &UnblindedOutput) -> Result<(), OutputManagerStorageError> {
-        let conn = self
-            .database_connection_pool
-            .get()
-            .map_err(|_| OutputManagerStorageError::R2d2Error)?;
-
+        let conn = acquire_lock!(self.database_connection);
         let output = OutputSql::find(&output.spending_key.to_vec(), &conn)?;
-
         let _ = output.update(
             UpdateOutput {
                 status: Some(OutputStatus::Invalid),
                 tx_id: None,
             },
-            &conn,
+            &(*conn),
         )?;
 
         Ok(())
@@ -487,20 +454,14 @@ impl OutputSql {
     }
 
     /// Write this struct to the database
-    pub fn commit(
-        &self,
-        conn: &PooledConnection<ConnectionManager<SqliteConnection>>,
-    ) -> Result<(), OutputManagerStorageError>
-    {
+    pub fn commit(&self, conn: &SqliteConnection) -> Result<(), OutputManagerStorageError> {
         diesel::insert_into(outputs::table).values(self.clone()).execute(conn)?;
         Ok(())
     }
 
     /// Return all unencumbered outputs
     #[cfg(test)]
-    pub fn index(
-        conn: &PooledConnection<ConnectionManager<SqliteConnection>>,
-    ) -> Result<Vec<OutputSql>, OutputManagerStorageError> {
+    pub fn index(conn: &SqliteConnection) -> Result<Vec<OutputSql>, OutputManagerStorageError> {
         Ok(outputs::table
             .filter(not(outputs::status.eq(OutputStatus::EncumberedToBeReceived as i32)))
             .filter(not(outputs::status.eq(OutputStatus::EncumberedToBeSpent as i32)))
@@ -510,18 +471,14 @@ impl OutputSql {
     /// Return all outputs with a given status
     pub fn index_status(
         status: OutputStatus,
-        conn: &PooledConnection<ConnectionManager<SqliteConnection>>,
+        conn: &SqliteConnection,
     ) -> Result<Vec<OutputSql>, OutputManagerStorageError>
     {
         Ok(outputs::table.filter(outputs::status.eq(status as i32)).load(conn)?)
     }
 
     /// Find a particular Output, if it exists
-    pub fn find(
-        spending_key: &[u8],
-        conn: &PooledConnection<ConnectionManager<SqliteConnection>>,
-    ) -> Result<OutputSql, OutputManagerStorageError>
-    {
+    pub fn find(spending_key: &[u8], conn: &SqliteConnection) -> Result<OutputSql, OutputManagerStorageError> {
         Ok(outputs::table
             .filter(outputs::spending_key.eq(spending_key))
             .first::<OutputSql>(conn)?)
@@ -530,7 +487,7 @@ impl OutputSql {
     /// Find outputs via tx_id that are encumbered. Any outputs that are encumbered cannot be marked as spent.
     pub fn find_by_tx_id_and_encumbered(
         tx_id: TxId,
-        conn: &PooledConnection<ConnectionManager<SqliteConnection>>,
+        conn: &SqliteConnection,
     ) -> Result<Vec<OutputSql>, OutputManagerStorageError>
     {
         Ok(outputs::table
@@ -547,7 +504,7 @@ impl OutputSql {
     pub fn find_status(
         spending_key: &[u8],
         status: OutputStatus,
-        conn: &PooledConnection<ConnectionManager<SqliteConnection>>,
+        conn: &SqliteConnection,
     ) -> Result<OutputSql, OutputManagerStorageError>
     {
         Ok(outputs::table
@@ -556,11 +513,7 @@ impl OutputSql {
             .first::<OutputSql>(conn)?)
     }
 
-    pub fn delete(
-        &self,
-        conn: &PooledConnection<ConnectionManager<SqliteConnection>>,
-    ) -> Result<(), OutputManagerStorageError>
-    {
+    pub fn delete(&self, conn: &SqliteConnection) -> Result<(), OutputManagerStorageError> {
         let num_deleted =
             diesel::delete(outputs::table.filter(outputs::spending_key.eq(&self.spending_key))).execute(conn)?;
 
@@ -574,7 +527,7 @@ impl OutputSql {
     pub fn update(
         &self,
         updated_output: UpdateOutput,
-        conn: &PooledConnection<ConnectionManager<SqliteConnection>>,
+        conn: &SqliteConnection,
     ) -> Result<OutputSql, OutputManagerStorageError>
     {
         let num_updated = diesel::update(outputs::table.filter(outputs::spending_key.eq(&self.spending_key)))
@@ -594,7 +547,7 @@ impl OutputSql {
     pub fn update_null(
         &self,
         updated_null: NullOutputSql,
-        conn: &PooledConnection<ConnectionManager<SqliteConnection>>,
+        conn: &SqliteConnection,
     ) -> Result<OutputSql, OutputManagerStorageError>
     {
         let num_updated = diesel::update(outputs::table.filter(outputs::spending_key.eq(&self.spending_key)))
@@ -676,11 +629,7 @@ impl PendingTransactionOutputSql {
         }
     }
 
-    pub fn commit(
-        &self,
-        conn: &PooledConnection<ConnectionManager<SqliteConnection>>,
-    ) -> Result<(), OutputManagerStorageError>
-    {
+    pub fn commit(&self, conn: &SqliteConnection) -> Result<(), OutputManagerStorageError> {
         diesel::insert_into(pending_transaction_outputs::table)
             .values(self.clone())
             .execute(conn)?;
@@ -689,7 +638,7 @@ impl PendingTransactionOutputSql {
 
     pub fn find(
         tx_id: TxId,
-        conn: &PooledConnection<ConnectionManager<SqliteConnection>>,
+        conn: &SqliteConnection,
     ) -> Result<PendingTransactionOutputSql, OutputManagerStorageError>
     {
         Ok(pending_transaction_outputs::table
@@ -697,15 +646,13 @@ impl PendingTransactionOutputSql {
             .first::<PendingTransactionOutputSql>(conn)?)
     }
 
-    pub fn index(
-        conn: &PooledConnection<ConnectionManager<SqliteConnection>>,
-    ) -> Result<Vec<PendingTransactionOutputSql>, OutputManagerStorageError> {
+    pub fn index(conn: &SqliteConnection) -> Result<Vec<PendingTransactionOutputSql>, OutputManagerStorageError> {
         Ok(pending_transaction_outputs::table.load::<PendingTransactionOutputSql>(conn)?)
     }
 
     pub fn index_older(
         timestamp: NaiveDateTime,
-        conn: &PooledConnection<ConnectionManager<SqliteConnection>>,
+        conn: &SqliteConnection,
     ) -> Result<Vec<PendingTransactionOutputSql>, OutputManagerStorageError>
     {
         Ok(pending_transaction_outputs::table
@@ -713,11 +660,7 @@ impl PendingTransactionOutputSql {
             .load::<PendingTransactionOutputSql>(conn)?)
     }
 
-    pub fn delete(
-        &self,
-        conn: &PooledConnection<ConnectionManager<SqliteConnection>>,
-    ) -> Result<(), OutputManagerStorageError>
-    {
+    pub fn delete(&self, conn: &SqliteConnection) -> Result<(), OutputManagerStorageError> {
         let num_deleted = diesel::delete(
             pending_transaction_outputs::table.filter(pending_transaction_outputs::tx_id.eq(&self.tx_id)),
         )
@@ -727,9 +670,9 @@ impl PendingTransactionOutputSql {
             return Err(OutputManagerStorageError::ValuesNotFound);
         }
 
-        let outputs = OutputSql::find_by_tx_id_and_encumbered(self.tx_id as u64, &conn)?;
+        let outputs = OutputSql::find_by_tx_id_and_encumbered(self.tx_id as u64, &(*conn))?;
         for o in outputs {
-            o.delete(&conn)?;
+            o.delete(&(*conn))?;
         }
 
         Ok(())
@@ -772,20 +715,14 @@ impl TryFrom<KeyManagerStateSql> for KeyManagerState {
 }
 
 impl KeyManagerStateSql {
-    fn commit(
-        &self,
-        conn: &PooledConnection<ConnectionManager<SqliteConnection>>,
-    ) -> Result<(), OutputManagerStorageError>
-    {
+    fn commit(&self, conn: &SqliteConnection) -> Result<(), OutputManagerStorageError> {
         diesel::insert_into(key_manager_states::table)
             .values(self.clone())
             .execute(conn)?;
         Ok(())
     }
 
-    pub fn get_state(
-        conn: &PooledConnection<ConnectionManager<SqliteConnection>>,
-    ) -> Result<KeyManagerStateSql, OutputManagerStorageError> {
+    pub fn get_state(conn: &SqliteConnection) -> Result<KeyManagerStateSql, OutputManagerStorageError> {
         Ok(key_manager_states::table
             .first::<KeyManagerStateSql>(conn)
             .map_err(|_| OutputManagerStorageError::KeyManagerNotInitialized)?)
@@ -793,7 +730,7 @@ impl KeyManagerStateSql {
 
     pub fn set_state(
         key_manager_state: KeyManagerState,
-        conn: &PooledConnection<ConnectionManager<SqliteConnection>>,
+        conn: &SqliteConnection,
     ) -> Result<(), OutputManagerStorageError>
     {
         match KeyManagerStateSql::get_state(conn) {
@@ -818,9 +755,7 @@ impl KeyManagerStateSql {
         Ok(())
     }
 
-    pub fn increment_index(
-        conn: &PooledConnection<ConnectionManager<SqliteConnection>>,
-    ) -> Result<usize, OutputManagerStorageError> {
+    pub fn increment_index(conn: &SqliteConnection) -> Result<usize, OutputManagerStorageError> {
         Ok(match KeyManagerStateSql::get_state(conn) {
             Ok(km) => {
                 let current_index = (km.primary_key_index + 1) as usize;
@@ -875,7 +810,7 @@ mod test {
         sqlite_db::{KeyManagerStateSql, OutputSql, OutputStatus, PendingTransactionOutputSql, UpdateOutput},
     };
     use chrono::{Duration as ChronoDuration, Utc};
-    use diesel::{r2d2::ConnectionManager, Connection, SqliteConnection};
+    use diesel::{Connection, SqliteConnection};
     use rand::{distributions::Alphanumeric, rngs::OsRng, CryptoRng, Rng, RngCore};
     use std::{convert::TryFrom, iter, time::Duration};
     use tari_core::transactions::{
@@ -910,10 +845,6 @@ mod test {
 
         embedded_migrations::run_with_output(&conn, &mut std::io::stdout()).expect("Migration failed");
 
-        let manager = ConnectionManager::<SqliteConnection>::new(db_path);
-        let pool = diesel::r2d2::Pool::builder().max_size(1).build(manager).unwrap();
-
-        let conn = pool.get().unwrap();
         conn.execute("PRAGMA foreign_keys = ON").unwrap();
 
         let mut outputs = Vec::new();
@@ -965,17 +896,6 @@ mod test {
         assert_eq!(OutputSql::index(&conn).unwrap().len(), 4);
 
         let tx_id = 44u64;
-
-        assert!(OutputSql::find(&outputs[0].spending_key, &conn)
-            .unwrap()
-            .update(
-                UpdateOutput {
-                    status: None,
-                    tx_id: Some(tx_id),
-                },
-                &conn,
-            )
-            .is_err());
 
         PendingTransactionOutputSql::new(tx_id, Utc::now().naive_utc())
             .commit(&conn)
@@ -1049,10 +969,6 @@ mod test {
 
         embedded_migrations::run_with_output(&conn, &mut std::io::stdout()).expect("Migration failed");
 
-        let manager = ConnectionManager::<SqliteConnection>::new(db_path);
-        let pool = diesel::r2d2::Pool::builder().max_size(1).build(manager).unwrap();
-
-        let conn = pool.get().unwrap();
         conn.execute("PRAGMA foreign_keys = ON").unwrap();
 
         assert!(KeyManagerStateSql::get_state(&conn).is_err());

--- a/base_layer/wallet/src/storage/database.rs
+++ b/base_layer/wallet/src/storage/database.rs
@@ -183,7 +183,7 @@ mod test {
     use crate::{
         error::WalletStorageError,
         storage::{
-            connection_manager::run_migration_and_create_connection_pool,
+            connection_manager::run_migration_and_create_sqlite_connection,
             database::{DbKey, WalletBackend, WalletDatabase},
             memory_db::WalletMemoryDatabase,
             sqlite_db::WalletSqliteDatabase,
@@ -267,8 +267,8 @@ mod test {
             .to_str()
             .unwrap()
             .to_string();
-        let connection_pool = run_migration_and_create_connection_pool(&format!("{}{}", db_folder, db_name)).unwrap();
+        let connection = run_migration_and_create_sqlite_connection(&format!("{}{}", db_folder, db_name)).unwrap();
 
-        test_database_crud(WalletSqliteDatabase::new(connection_pool));
+        test_database_crud(WalletSqliteDatabase::new(connection));
     }
 }

--- a/base_layer/wallet/src/storage/sqlite_db.rs
+++ b/base_layer/wallet/src/storage/sqlite_db.rs
@@ -25,38 +25,30 @@ use crate::{
     schema::peers,
     storage::database::{DbKey, DbKeyValuePair, DbValue, WalletBackend, WriteOperation},
 };
-use diesel::{
-    prelude::*,
-    r2d2::{ConnectionManager, Pool, PooledConnection},
-    result::Error as DieselError,
-    SqliteConnection,
+use diesel::{prelude::*, result::Error as DieselError, SqliteConnection};
+use std::{
+    convert::TryFrom,
+    sync::{Arc, Mutex},
 };
-use std::convert::TryFrom;
 use tari_comms::peer_manager::Peer;
 use tari_crypto::tari_utilities::ByteArray;
 
 /// A Sqlite backend for the Output Manager Service. The Backend is accessed via a connection pool to the Sqlite file.
 pub struct WalletSqliteDatabase {
-    database_connection_pool: Pool<ConnectionManager<SqliteConnection>>,
+    database_connection: Arc<Mutex<SqliteConnection>>,
 }
 impl WalletSqliteDatabase {
-    pub fn new(database_connection_pool: Pool<ConnectionManager<SqliteConnection>>) -> Self {
-        Self {
-            database_connection_pool,
-        }
+    pub fn new(database_connection: Arc<Mutex<SqliteConnection>>) -> Self {
+        Self { database_connection }
     }
 }
 
 impl WalletBackend for WalletSqliteDatabase {
     fn fetch(&self, key: &DbKey) -> Result<Option<DbValue>, WalletStorageError> {
-        let conn = self
-            .database_connection_pool
-            .clone()
-            .get()
-            .map_err(|_| WalletStorageError::R2d2Error)?;
+        let conn = acquire_lock!(self.database_connection);
 
         let result = match key {
-            DbKey::Peer(pk) => match PeerSql::find(&pk.to_vec(), &conn) {
+            DbKey::Peer(pk) => match PeerSql::find(&pk.to_vec(), &(*conn)) {
                 Ok(c) => Some(DbValue::Peer(Box::new(Peer::try_from(c)?))),
                 Err(WalletStorageError::DieselError(DieselError::NotFound)) => None,
                 Err(e) => return Err(e),
@@ -73,23 +65,19 @@ impl WalletBackend for WalletSqliteDatabase {
     }
 
     fn write(&self, op: WriteOperation) -> Result<Option<DbValue>, WalletStorageError> {
-        let conn = self
-            .database_connection_pool
-            .clone()
-            .get()
-            .map_err(|_| WalletStorageError::R2d2Error)?;
+        let conn = acquire_lock!(self.database_connection);
 
         match op {
             WriteOperation::Insert(kvp) => match kvp {
                 DbKeyValuePair::Peer(k, p) => {
-                    if let Ok(_) = PeerSql::find(&k.to_vec(), &conn) {
+                    if let Ok(_) = PeerSql::find(&k.to_vec(), &(*conn)) {
                         return Err(WalletStorageError::DuplicateContact);
                     }
                     PeerSql::try_from(p)?.commit(&conn)?;
                 },
             },
             WriteOperation::Remove(k) => match k {
-                DbKey::Peer(k) => match PeerSql::find(&k.to_vec(), &conn) {
+                DbKey::Peer(k) => match PeerSql::find(&k.to_vec(), &(*conn)) {
                     Ok(p) => {
                         p.clone().delete(&conn)?;
                         return Ok(Some(DbValue::Peer(Box::new(Peer::try_from(p)?))));
@@ -115,38 +103,24 @@ struct PeerSql {
 
 impl PeerSql {
     /// Write this struct to the database
-    pub fn commit(
-        &self,
-        conn: &PooledConnection<ConnectionManager<SqliteConnection>>,
-    ) -> Result<(), WalletStorageError>
-    {
+    pub fn commit(&self, conn: &SqliteConnection) -> Result<(), WalletStorageError> {
         diesel::insert_into(peers::table).values(self.clone()).execute(conn)?;
         Ok(())
     }
 
     /// Return all peers
-    pub fn index(
-        conn: &PooledConnection<ConnectionManager<SqliteConnection>>,
-    ) -> Result<Vec<PeerSql>, WalletStorageError> {
+    pub fn index(conn: &SqliteConnection) -> Result<Vec<PeerSql>, WalletStorageError> {
         Ok(peers::table.load::<PeerSql>(conn)?)
     }
 
     /// Find a particular Peer, if it exists
-    pub fn find(
-        public_key: &[u8],
-        conn: &PooledConnection<ConnectionManager<SqliteConnection>>,
-    ) -> Result<PeerSql, WalletStorageError>
-    {
+    pub fn find(public_key: &[u8], conn: &SqliteConnection) -> Result<PeerSql, WalletStorageError> {
         Ok(peers::table
             .filter(peers::public_key.eq(public_key))
             .first::<PeerSql>(conn)?)
     }
 
-    pub fn delete(
-        &self,
-        conn: &PooledConnection<ConnectionManager<SqliteConnection>>,
-    ) -> Result<(), WalletStorageError>
-    {
+    pub fn delete(&self, conn: &SqliteConnection) -> Result<(), WalletStorageError> {
         let num_deleted = diesel::delete(peers::table.filter(peers::public_key.eq(&self.public_key))).execute(conn)?;
 
         if num_deleted == 0 {

--- a/base_layer/wallet/src/testnet_utils.rs
+++ b/base_layer/wallet/src/testnet_utils.rs
@@ -136,7 +136,6 @@ pub fn create_wallet(
 
     let config = WalletConfig {
         comms_config,
-        logging_path: None,
         factories,
         transaction_service_config: None,
     };

--- a/base_layer/wallet/src/transaction_service/service.rs
+++ b/base_layer/wallet/src/transaction_service/service.rs
@@ -1351,7 +1351,10 @@ where
                         .await
                         .map_err(|_| TransactionServiceError::EventStreamError)?;
 
-                    info!("Transaction (TxId: {:?}) detected as mined on the Base Layer", tx_id);
+                    info!(
+                        target: LOG_TARGET,
+                        "Transaction (TxId: {:?}) detected as mined on the Base Layer", tx_id
+                    );
                 }
             }
         } else {

--- a/base_layer/wallet/src/transaction_service/storage/sqlite_db.rs
+++ b/base_layer/wallet/src/transaction_service/storage/sqlite_db.rs
@@ -40,13 +40,12 @@ use crate::{
     },
 };
 use chrono::NaiveDateTime;
-use diesel::{
-    prelude::*,
-    r2d2::{ConnectionManager, Pool, PooledConnection},
-    result::Error as DieselError,
-    SqliteConnection,
+use diesel::{prelude::*, result::Error as DieselError, SqliteConnection};
+use std::{
+    collections::HashMap,
+    convert::TryFrom,
+    sync::{Arc, Mutex},
 };
-use std::{collections::HashMap, convert::TryFrom};
 use tari_core::transactions::{
     tari_amount::MicroTari,
     types::{Commitment, PublicKey},
@@ -56,40 +55,34 @@ use tari_crypto::tari_utilities::ByteArray;
 /// A Sqlite backend for the Transaction Service. The Backend is accessed via a connection pool to the Sqlite file.
 #[derive(Clone)]
 pub struct TransactionServiceSqliteDatabase {
-    database_connection_pool: Pool<ConnectionManager<SqliteConnection>>,
+    database_connection: Arc<Mutex<SqliteConnection>>,
 }
 impl TransactionServiceSqliteDatabase {
-    pub fn new(database_connection_pool: Pool<ConnectionManager<SqliteConnection>>) -> Self {
-        Self {
-            database_connection_pool,
-        }
+    pub fn new(database_connection: Arc<Mutex<SqliteConnection>>) -> Self {
+        Self { database_connection }
     }
 }
 
 impl TransactionBackend for TransactionServiceSqliteDatabase {
     fn fetch(&self, key: &DbKey) -> Result<Option<DbValue>, TransactionStorageError> {
-        let conn = self
-            .database_connection_pool
-            .clone()
-            .get()
-            .map_err(|_| TransactionStorageError::R2d2Error)?;
+        let conn = acquire_lock!(self.database_connection);
 
         let result = match key {
-            DbKey::PendingOutboundTransaction(t) => match OutboundTransactionSql::find(*t, &conn) {
+            DbKey::PendingOutboundTransaction(t) => match OutboundTransactionSql::find(*t, &(*conn)) {
                 Ok(o) => Some(DbValue::PendingOutboundTransaction(Box::new(
                     OutboundTransaction::try_from(o)?,
                 ))),
                 Err(TransactionStorageError::DieselError(DieselError::NotFound)) => None,
                 Err(e) => return Err(e),
             },
-            DbKey::PendingInboundTransaction(t) => match InboundTransactionSql::find(*t, &conn) {
+            DbKey::PendingInboundTransaction(t) => match InboundTransactionSql::find(*t, &(*conn)) {
                 Ok(o) => Some(DbValue::PendingInboundTransaction(Box::new(
                     InboundTransaction::try_from(o)?,
                 ))),
                 Err(TransactionStorageError::DieselError(DieselError::NotFound)) => None,
                 Err(e) => return Err(e),
             },
-            DbKey::PendingCoinbaseTransaction(t) => match PendingCoinbaseTransactionSql::find(*t, &conn) {
+            DbKey::PendingCoinbaseTransaction(t) => match PendingCoinbaseTransactionSql::find(*t, &(*conn)) {
                 Ok(o) => Some(DbValue::PendingCoinbaseTransaction(Box::new(
                     PendingCoinbaseTransaction::try_from(o)?,
                 ))),
@@ -97,7 +90,7 @@ impl TransactionBackend for TransactionServiceSqliteDatabase {
                 Err(e) => return Err(e),
             },
 
-            DbKey::CompletedTransaction(t) => match CompletedTransactionSql::find(*t, &conn) {
+            DbKey::CompletedTransaction(t) => match CompletedTransactionSql::find(*t, &(*conn)) {
                 Ok(o) => Some(DbValue::CompletedTransaction(Box::new(CompletedTransaction::try_from(
                     o,
                 )?))),
@@ -105,7 +98,7 @@ impl TransactionBackend for TransactionServiceSqliteDatabase {
                 Err(e) => return Err(e),
             },
             DbKey::PendingOutboundTransactions => Some(DbValue::PendingOutboundTransactions(
-                OutboundTransactionSql::index(&conn)?
+                OutboundTransactionSql::index(&(*conn))?
                     .iter()
                     .fold(HashMap::new(), |mut acc, x| {
                         if let Ok(v) = OutboundTransaction::try_from((*x).clone()) {
@@ -115,7 +108,7 @@ impl TransactionBackend for TransactionServiceSqliteDatabase {
                     }),
             )),
             DbKey::PendingInboundTransactions => Some(DbValue::PendingInboundTransactions(
-                InboundTransactionSql::index(&conn)?
+                InboundTransactionSql::index(&(*conn))?
                     .iter()
                     .fold(HashMap::new(), |mut acc, x| {
                         if let Ok(v) = InboundTransaction::try_from((*x).clone()) {
@@ -125,7 +118,7 @@ impl TransactionBackend for TransactionServiceSqliteDatabase {
                     }),
             )),
             DbKey::PendingCoinbaseTransactions => Some(DbValue::PendingCoinbaseTransactions(
-                PendingCoinbaseTransactionSql::index(&conn)?
+                PendingCoinbaseTransactionSql::index(&(*conn))?
                     .iter()
                     .fold(HashMap::new(), |mut acc, x| {
                         if let Ok(v) = PendingCoinbaseTransaction::try_from((*x).clone()) {
@@ -135,7 +128,7 @@ impl TransactionBackend for TransactionServiceSqliteDatabase {
                     }),
             )),
             DbKey::CompletedTransactions => Some(DbValue::CompletedTransactions(
-                CompletedTransactionSql::index(&conn)?
+                CompletedTransactionSql::index(&(*conn))?
                     .iter()
                     .fold(HashMap::new(), |mut acc, x| {
                         if let Ok(v) = CompletedTransaction::try_from((*x).clone()) {
@@ -150,17 +143,13 @@ impl TransactionBackend for TransactionServiceSqliteDatabase {
     }
 
     fn contains(&self, key: &DbKey) -> Result<bool, TransactionStorageError> {
-        let conn = self
-            .database_connection_pool
-            .clone()
-            .get()
-            .map_err(|_| TransactionStorageError::R2d2Error)?;
+        let conn = acquire_lock!(self.database_connection);
 
         let result = match key {
-            DbKey::PendingOutboundTransaction(k) => OutboundTransactionSql::find(*k, &conn).is_ok(),
-            DbKey::PendingInboundTransaction(k) => InboundTransactionSql::find(*k, &conn).is_ok(),
-            DbKey::PendingCoinbaseTransaction(k) => PendingCoinbaseTransactionSql::find(*k, &conn).is_ok(),
-            DbKey::CompletedTransaction(k) => CompletedTransactionSql::find(*k, &conn).is_ok(),
+            DbKey::PendingOutboundTransaction(k) => OutboundTransactionSql::find(*k, &(*conn)).is_ok(),
+            DbKey::PendingInboundTransaction(k) => InboundTransactionSql::find(*k, &(*conn)).is_ok(),
+            DbKey::PendingCoinbaseTransaction(k) => PendingCoinbaseTransactionSql::find(*k, &(*conn)).is_ok(),
+            DbKey::CompletedTransaction(k) => CompletedTransactionSql::find(*k, &(*conn)).is_ok(),
             DbKey::PendingOutboundTransactions => false,
             DbKey::PendingInboundTransactions => false,
             DbKey::CompletedTransactions => false,
@@ -171,43 +160,39 @@ impl TransactionBackend for TransactionServiceSqliteDatabase {
     }
 
     fn write(&self, op: WriteOperation) -> Result<Option<DbValue>, TransactionStorageError> {
-        let conn = self
-            .database_connection_pool
-            .clone()
-            .get()
-            .map_err(|_| TransactionStorageError::R2d2Error)?;
+        let conn = acquire_lock!(self.database_connection);
 
         match op {
             WriteOperation::Insert(kvp) => match kvp {
                 DbKeyValuePair::PendingOutboundTransaction(k, v) => {
-                    if let Ok(_) = OutboundTransactionSql::find(k, &conn) {
+                    if let Ok(_) = OutboundTransactionSql::find(k, &(*conn)) {
                         return Err(TransactionStorageError::DuplicateOutput);
                     }
-                    OutboundTransactionSql::try_from(*v)?.commit(&conn)?;
+                    OutboundTransactionSql::try_from(*v)?.commit(&(*conn))?;
                 },
                 DbKeyValuePair::PendingInboundTransaction(k, v) => {
-                    if let Ok(_) = InboundTransactionSql::find(k, &conn) {
+                    if let Ok(_) = InboundTransactionSql::find(k, &(*conn)) {
                         return Err(TransactionStorageError::DuplicateOutput);
                     }
-                    InboundTransactionSql::try_from(*v)?.commit(&conn)?;
+                    InboundTransactionSql::try_from(*v)?.commit(&(*conn))?;
                 },
                 DbKeyValuePair::PendingCoinbaseTransaction(k, v) => {
-                    if let Ok(_) = PendingCoinbaseTransactionSql::find(k, &conn) {
+                    if let Ok(_) = PendingCoinbaseTransactionSql::find(k, &(*conn)) {
                         return Err(TransactionStorageError::DuplicateOutput);
                     }
-                    PendingCoinbaseTransactionSql::from(*v).commit(&conn)?;
+                    PendingCoinbaseTransactionSql::from(*v).commit(&(*conn))?;
                 },
                 DbKeyValuePair::CompletedTransaction(k, v) => {
-                    if let Ok(_) = CompletedTransactionSql::find(k, &conn) {
+                    if let Ok(_) = CompletedTransactionSql::find(k, &(*conn)) {
                         return Err(TransactionStorageError::DuplicateOutput);
                     }
-                    CompletedTransactionSql::try_from(*v)?.commit(&conn)?;
+                    CompletedTransactionSql::try_from(*v)?.commit(&(*conn))?;
                 },
             },
             WriteOperation::Remove(kvp) => match kvp {
-                DbKey::PendingOutboundTransaction(k) => match OutboundTransactionSql::find(k, &conn) {
+                DbKey::PendingOutboundTransaction(k) => match OutboundTransactionSql::find(k, &(*conn)) {
                     Ok(v) => {
-                        v.delete(&conn)?;
+                        v.delete(&(*conn))?;
                         return Ok(Some(DbValue::PendingOutboundTransaction(Box::new(
                             OutboundTransaction::try_from(v)?,
                         ))));
@@ -219,9 +204,9 @@ impl TransactionBackend for TransactionServiceSqliteDatabase {
                     },
                     Err(e) => return Err(e),
                 },
-                DbKey::PendingInboundTransaction(k) => match InboundTransactionSql::find(k, &conn) {
+                DbKey::PendingInboundTransaction(k) => match InboundTransactionSql::find(k, &(*conn)) {
                     Ok(v) => {
-                        v.delete(&conn)?;
+                        v.delete(&(*conn))?;
                         return Ok(Some(DbValue::PendingInboundTransaction(Box::new(
                             InboundTransaction::try_from(v)?,
                         ))));
@@ -233,9 +218,9 @@ impl TransactionBackend for TransactionServiceSqliteDatabase {
                     },
                     Err(e) => return Err(e),
                 },
-                DbKey::PendingCoinbaseTransaction(k) => match PendingCoinbaseTransactionSql::find(k, &conn) {
+                DbKey::PendingCoinbaseTransaction(k) => match PendingCoinbaseTransactionSql::find(k, &(*conn)) {
                     Ok(v) => {
-                        v.delete(&conn)?;
+                        v.delete(&(*conn))?;
                         return Ok(Some(DbValue::PendingCoinbaseTransaction(Box::new(
                             PendingCoinbaseTransaction::try_from(v)?,
                         ))));
@@ -247,9 +232,9 @@ impl TransactionBackend for TransactionServiceSqliteDatabase {
                     },
                     Err(e) => return Err(e),
                 },
-                DbKey::CompletedTransaction(k) => match CompletedTransactionSql::find(k, &conn) {
+                DbKey::CompletedTransaction(k) => match CompletedTransactionSql::find(k, &(*conn)) {
                     Ok(v) => {
-                        v.delete(&conn)?;
+                        v.delete(&(*conn))?;
                         return Ok(Some(DbValue::CompletedTransaction(Box::new(
                             CompletedTransaction::try_from(v)?,
                         ))));
@@ -269,16 +254,12 @@ impl TransactionBackend for TransactionServiceSqliteDatabase {
     }
 
     fn transaction_exists(&self, tx_id: u64) -> Result<bool, TransactionStorageError> {
-        let conn = self
-            .database_connection_pool
-            .clone()
-            .get()
-            .map_err(|_| TransactionStorageError::R2d2Error)?;
+        let conn = acquire_lock!(self.database_connection);
 
-        Ok(OutboundTransactionSql::find(tx_id, &conn).is_ok() ||
-            InboundTransactionSql::find(tx_id, &conn).is_ok() ||
-            PendingCoinbaseTransactionSql::find(tx_id, &conn).is_ok() ||
-            CompletedTransactionSql::find(tx_id, &conn).is_ok())
+        Ok(OutboundTransactionSql::find(tx_id, &(*conn)).is_ok() ||
+            InboundTransactionSql::find(tx_id, &(*conn)).is_ok() ||
+            PendingCoinbaseTransactionSql::find(tx_id, &(*conn)).is_ok() ||
+            CompletedTransactionSql::find(tx_id, &(*conn)).is_ok())
     }
 
     fn complete_outbound_transaction(
@@ -287,21 +268,17 @@ impl TransactionBackend for TransactionServiceSqliteDatabase {
         completed_transaction: CompletedTransaction,
     ) -> Result<(), TransactionStorageError>
     {
-        let conn = self
-            .database_connection_pool
-            .clone()
-            .get()
-            .map_err(|_| TransactionStorageError::R2d2Error)?;
+        let conn = acquire_lock!(self.database_connection);
 
-        if CompletedTransactionSql::find(tx_id, &conn).is_ok() {
+        if CompletedTransactionSql::find(tx_id, &(*conn)).is_ok() {
             return Err(TransactionStorageError::TransactionAlreadyExists);
         }
 
-        match OutboundTransactionSql::find(tx_id, &conn) {
+        match OutboundTransactionSql::find(tx_id, &(*conn)) {
             Ok(v) => {
                 let completed_tx_sql = CompletedTransactionSql::try_from(completed_transaction)?;
-                v.delete(&conn)?;
-                completed_tx_sql.commit(&conn)?;
+                v.delete(&(*conn))?;
+                completed_tx_sql.commit(&(*conn))?;
             },
             Err(TransactionStorageError::DieselError(DieselError::NotFound)) => {
                 return Err(TransactionStorageError::ValueNotFound(
@@ -319,21 +296,17 @@ impl TransactionBackend for TransactionServiceSqliteDatabase {
         completed_transaction: CompletedTransaction,
     ) -> Result<(), TransactionStorageError>
     {
-        let conn = self
-            .database_connection_pool
-            .clone()
-            .get()
-            .map_err(|_| TransactionStorageError::R2d2Error)?;
+        let conn = acquire_lock!(self.database_connection);
 
-        if CompletedTransactionSql::find(tx_id, &conn).is_ok() {
+        if CompletedTransactionSql::find(tx_id, &(*conn)).is_ok() {
             return Err(TransactionStorageError::TransactionAlreadyExists);
         }
 
-        match InboundTransactionSql::find(tx_id, &conn) {
+        match InboundTransactionSql::find(tx_id, &(*conn)) {
             Ok(v) => {
                 let completed_tx_sql = CompletedTransactionSql::try_from(completed_transaction)?;
-                v.delete(&conn)?;
-                completed_tx_sql.commit(&conn)?;
+                v.delete(&(*conn))?;
+                completed_tx_sql.commit(&(*conn))?;
             },
             Err(TransactionStorageError::DieselError(DieselError::NotFound)) => {
                 return Err(TransactionStorageError::ValueNotFound(
@@ -351,21 +324,17 @@ impl TransactionBackend for TransactionServiceSqliteDatabase {
         completed_transaction: CompletedTransaction,
     ) -> Result<(), TransactionStorageError>
     {
-        let conn = self
-            .database_connection_pool
-            .clone()
-            .get()
-            .map_err(|_| TransactionStorageError::R2d2Error)?;
+        let conn = acquire_lock!(self.database_connection);
 
-        if CompletedTransactionSql::find(tx_id, &conn).is_ok() {
+        if CompletedTransactionSql::find(tx_id, &(*conn)).is_ok() {
             return Err(TransactionStorageError::TransactionAlreadyExists);
         }
 
-        match PendingCoinbaseTransactionSql::find(tx_id, &conn) {
+        match PendingCoinbaseTransactionSql::find(tx_id, &(*conn)) {
             Ok(v) => {
                 let completed_tx_sql = CompletedTransactionSql::try_from(completed_transaction)?;
-                v.delete(&conn)?;
-                completed_tx_sql.commit(&conn)?;
+                v.delete(&(*conn))?;
+                completed_tx_sql.commit(&(*conn))?;
             },
             Err(TransactionStorageError::DieselError(DieselError::NotFound)) => {
                 return Err(TransactionStorageError::ValueNotFound(
@@ -378,13 +347,9 @@ impl TransactionBackend for TransactionServiceSqliteDatabase {
     }
 
     fn broadcast_completed_transaction(&self, tx_id: u64) -> Result<(), TransactionStorageError> {
-        let conn = self
-            .database_connection_pool
-            .clone()
-            .get()
-            .map_err(|_| TransactionStorageError::R2d2Error)?;
+        let conn = acquire_lock!(self.database_connection);
 
-        match CompletedTransactionSql::find(tx_id, &conn) {
+        match CompletedTransactionSql::find(tx_id, &(*conn)) {
             Ok(v) => {
                 if TransactionStatus::try_from(v.status)? == TransactionStatus::Completed {
                     let _ = v.update(
@@ -392,7 +357,7 @@ impl TransactionBackend for TransactionServiceSqliteDatabase {
                             status: Some(TransactionStatus::Broadcast),
                             timestamp: None,
                         },
-                        &conn,
+                        &(*conn),
                     )?;
                 }
             },
@@ -407,20 +372,16 @@ impl TransactionBackend for TransactionServiceSqliteDatabase {
     }
 
     fn mine_completed_transaction(&self, tx_id: u64) -> Result<(), TransactionStorageError> {
-        let conn = self
-            .database_connection_pool
-            .clone()
-            .get()
-            .map_err(|_| TransactionStorageError::R2d2Error)?;
+        let conn = acquire_lock!(self.database_connection);
 
-        match CompletedTransactionSql::find(tx_id, &conn) {
+        match CompletedTransactionSql::find(tx_id, &(*conn)) {
             Ok(v) => {
                 let _ = v.update(
                     UpdateCompletedTransaction {
                         status: Some(TransactionStatus::Mined),
                         timestamp: None,
                     },
-                    &conn,
+                    &(*conn),
                 )?;
             },
             Err(TransactionStorageError::DieselError(DieselError::NotFound)) => {
@@ -440,19 +401,15 @@ impl TransactionBackend for TransactionServiceSqliteDatabase {
         timestamp: NaiveDateTime,
     ) -> Result<(), TransactionStorageError>
     {
-        let conn = self
-            .database_connection_pool
-            .clone()
-            .get()
-            .map_err(|_| TransactionStorageError::R2d2Error)?;
+        let conn = acquire_lock!(self.database_connection);
 
-        if let Ok(tx) = CompletedTransactionSql::find(tx_id, &conn) {
+        if let Ok(tx) = CompletedTransactionSql::find(tx_id, &(*conn)) {
             let _ = tx.update(
                 UpdateCompletedTransaction {
                     status: None,
                     timestamp: Some(timestamp),
                 },
-                &conn,
+                &(*conn),
             );
         }
 
@@ -472,38 +429,24 @@ struct InboundTransactionSql {
 }
 
 impl InboundTransactionSql {
-    pub fn commit(
-        &self,
-        conn: &PooledConnection<ConnectionManager<SqliteConnection>>,
-    ) -> Result<(), TransactionStorageError>
-    {
+    pub fn commit(&self, conn: &SqliteConnection) -> Result<(), TransactionStorageError> {
         diesel::insert_into(inbound_transactions::table)
             .values(self.clone())
             .execute(conn)?;
         Ok(())
     }
 
-    pub fn index(
-        conn: &PooledConnection<ConnectionManager<SqliteConnection>>,
-    ) -> Result<Vec<InboundTransactionSql>, TransactionStorageError> {
+    pub fn index(conn: &SqliteConnection) -> Result<Vec<InboundTransactionSql>, TransactionStorageError> {
         Ok(inbound_transactions::table.load::<InboundTransactionSql>(conn)?)
     }
 
-    pub fn find(
-        tx_id: TxId,
-        conn: &PooledConnection<ConnectionManager<SqliteConnection>>,
-    ) -> Result<InboundTransactionSql, TransactionStorageError>
-    {
+    pub fn find(tx_id: TxId, conn: &SqliteConnection) -> Result<InboundTransactionSql, TransactionStorageError> {
         Ok(inbound_transactions::table
             .filter(inbound_transactions::tx_id.eq(tx_id as i64))
             .first::<InboundTransactionSql>(conn)?)
     }
 
-    pub fn delete(
-        &self,
-        conn: &PooledConnection<ConnectionManager<SqliteConnection>>,
-    ) -> Result<(), TransactionStorageError>
-    {
+    pub fn delete(&self, conn: &SqliteConnection) -> Result<(), TransactionStorageError> {
         let num_deleted =
             diesel::delete(inbound_transactions::table.filter(inbound_transactions::tx_id.eq(&self.tx_id)))
                 .execute(conn)?;
@@ -562,38 +505,24 @@ struct OutboundTransactionSql {
 }
 
 impl OutboundTransactionSql {
-    pub fn commit(
-        &self,
-        conn: &PooledConnection<ConnectionManager<SqliteConnection>>,
-    ) -> Result<(), TransactionStorageError>
-    {
+    pub fn commit(&self, conn: &SqliteConnection) -> Result<(), TransactionStorageError> {
         diesel::insert_into(outbound_transactions::table)
             .values(self.clone())
             .execute(conn)?;
         Ok(())
     }
 
-    pub fn index(
-        conn: &PooledConnection<ConnectionManager<SqliteConnection>>,
-    ) -> Result<Vec<OutboundTransactionSql>, TransactionStorageError> {
+    pub fn index(conn: &SqliteConnection) -> Result<Vec<OutboundTransactionSql>, TransactionStorageError> {
         Ok(outbound_transactions::table.load::<OutboundTransactionSql>(conn)?)
     }
 
-    pub fn find(
-        tx_id: TxId,
-        conn: &PooledConnection<ConnectionManager<SqliteConnection>>,
-    ) -> Result<OutboundTransactionSql, TransactionStorageError>
-    {
+    pub fn find(tx_id: TxId, conn: &SqliteConnection) -> Result<OutboundTransactionSql, TransactionStorageError> {
         Ok(outbound_transactions::table
             .filter(outbound_transactions::tx_id.eq(tx_id as i64))
             .first::<OutboundTransactionSql>(conn)?)
     }
 
-    pub fn delete(
-        &self,
-        conn: &PooledConnection<ConnectionManager<SqliteConnection>>,
-    ) -> Result<(), TransactionStorageError>
-    {
+    pub fn delete(&self, conn: &SqliteConnection) -> Result<(), TransactionStorageError> {
         let num_deleted =
             diesel::delete(outbound_transactions::table.filter(outbound_transactions::tx_id.eq(&self.tx_id)))
                 .execute(conn)?;
@@ -650,26 +579,20 @@ struct PendingCoinbaseTransactionSql {
 }
 
 impl PendingCoinbaseTransactionSql {
-    pub fn commit(
-        &self,
-        conn: &PooledConnection<ConnectionManager<SqliteConnection>>,
-    ) -> Result<(), TransactionStorageError>
-    {
+    pub fn commit(&self, conn: &SqliteConnection) -> Result<(), TransactionStorageError> {
         diesel::insert_into(coinbase_transactions::table)
             .values(self.clone())
             .execute(conn)?;
         Ok(())
     }
 
-    pub fn index(
-        conn: &PooledConnection<ConnectionManager<SqliteConnection>>,
-    ) -> Result<Vec<PendingCoinbaseTransactionSql>, TransactionStorageError> {
+    pub fn index(conn: &SqliteConnection) -> Result<Vec<PendingCoinbaseTransactionSql>, TransactionStorageError> {
         Ok(coinbase_transactions::table.load::<PendingCoinbaseTransactionSql>(conn)?)
     }
 
     pub fn find(
         tx_id: TxId,
-        conn: &PooledConnection<ConnectionManager<SqliteConnection>>,
+        conn: &SqliteConnection,
     ) -> Result<PendingCoinbaseTransactionSql, TransactionStorageError>
     {
         Ok(coinbase_transactions::table
@@ -677,11 +600,7 @@ impl PendingCoinbaseTransactionSql {
             .first::<PendingCoinbaseTransactionSql>(conn)?)
     }
 
-    pub fn delete(
-        &self,
-        conn: &PooledConnection<ConnectionManager<SqliteConnection>>,
-    ) -> Result<(), TransactionStorageError>
-    {
+    pub fn delete(&self, conn: &SqliteConnection) -> Result<(), TransactionStorageError> {
         let num_deleted =
             diesel::delete(coinbase_transactions::table.filter(coinbase_transactions::tx_id.eq(&self.tx_id)))
                 .execute(conn)?;
@@ -734,38 +653,24 @@ struct CompletedTransactionSql {
 }
 
 impl CompletedTransactionSql {
-    pub fn commit(
-        &self,
-        conn: &PooledConnection<ConnectionManager<SqliteConnection>>,
-    ) -> Result<(), TransactionStorageError>
-    {
+    pub fn commit(&self, conn: &SqliteConnection) -> Result<(), TransactionStorageError> {
         diesel::insert_into(completed_transactions::table)
             .values(self.clone())
             .execute(conn)?;
         Ok(())
     }
 
-    pub fn index(
-        conn: &PooledConnection<ConnectionManager<SqliteConnection>>,
-    ) -> Result<Vec<CompletedTransactionSql>, TransactionStorageError> {
+    pub fn index(conn: &SqliteConnection) -> Result<Vec<CompletedTransactionSql>, TransactionStorageError> {
         Ok(completed_transactions::table.load::<CompletedTransactionSql>(conn)?)
     }
 
-    pub fn find(
-        tx_id: TxId,
-        conn: &PooledConnection<ConnectionManager<SqliteConnection>>,
-    ) -> Result<CompletedTransactionSql, TransactionStorageError>
-    {
+    pub fn find(tx_id: TxId, conn: &SqliteConnection) -> Result<CompletedTransactionSql, TransactionStorageError> {
         Ok(completed_transactions::table
             .filter(completed_transactions::tx_id.eq(tx_id as i64))
             .first::<CompletedTransactionSql>(conn)?)
     }
 
-    pub fn delete(
-        &self,
-        conn: &PooledConnection<ConnectionManager<SqliteConnection>>,
-    ) -> Result<(), TransactionStorageError>
-    {
+    pub fn delete(&self, conn: &SqliteConnection) -> Result<(), TransactionStorageError> {
         let num_deleted =
             diesel::delete(completed_transactions::table.filter(completed_transactions::tx_id.eq(&self.tx_id)))
                 .execute(conn)?;
@@ -780,7 +685,7 @@ impl CompletedTransactionSql {
     pub fn update(
         &self,
         updated_tx: UpdateCompletedTransaction,
-        conn: &PooledConnection<ConnectionManager<SqliteConnection>>,
+        conn: &SqliteConnection,
     ) -> Result<CompletedTransactionSql, TransactionStorageError>
     {
         let num_updated =
@@ -879,7 +784,7 @@ mod test {
         },
     };
     use chrono::Utc;
-    use diesel::{r2d2::ConnectionManager, Connection, SqliteConnection};
+    use diesel::{Connection, SqliteConnection};
     use rand::rngs::OsRng;
     use std::convert::TryFrom;
     use tari_core::transactions::{
@@ -910,10 +815,6 @@ mod test {
 
         embedded_migrations::run_with_output(&conn, &mut std::io::stdout()).expect("Migration failed");
 
-        let manager = ConnectionManager::<SqliteConnection>::new(db_path);
-        let pool = diesel::r2d2::Pool::builder().max_size(1).build(manager).unwrap();
-
-        let conn = pool.get().unwrap();
         conn.execute("PRAGMA foreign_keys = ON").unwrap();
 
         let mut builder = SenderTransactionProtocol::builder(1);

--- a/base_layer/wallet/tests/contacts_service/mod.rs
+++ b/base_layer/wallet/tests/contacts_service/mod.rs
@@ -37,7 +37,7 @@ use tari_wallet::{
         },
         ContactsServiceInitializer,
     },
-    storage::connection_manager::run_migration_and_create_connection_pool,
+    storage::connection_manager::run_migration_and_create_sqlite_connection,
 };
 use tempdir::TempDir;
 use tokio::runtime::Runtime;
@@ -182,6 +182,7 @@ fn contacts_service_sqlite_db() {
     let db_name = format!("{}.sqlite3", random_string(8).as_str());
     let temp_dir = TempDir::new(random_string(8).as_str()).unwrap();
     let db_folder = temp_dir.path().to_str().unwrap().to_string();
-    let connection_pool = run_migration_and_create_connection_pool(&format!("{}/{}", db_folder, db_name)).unwrap();
-    test_contacts_service(ContactsServiceSqliteDatabase::new(connection_pool));
+    let db_path = format!("{}/{}", db_folder, db_name);
+    let connection = run_migration_and_create_sqlite_connection(&db_path).unwrap();
+    test_contacts_service(ContactsServiceSqliteDatabase::new(connection));
 }

--- a/base_layer/wallet/tests/output_manager_service/service.rs
+++ b/base_layer/wallet/tests/output_manager_service/service.rs
@@ -72,7 +72,7 @@ use tari_wallet::{
             sqlite_db::OutputManagerSqliteDatabase,
         },
     },
-    storage::connection_manager::run_migration_and_create_connection_pool,
+    storage::connection_manager::run_migration_and_create_sqlite_connection,
 };
 use tempdir::TempDir;
 use tokio::runtime::Runtime;
@@ -214,9 +214,9 @@ fn sending_transaction_and_confirmation_sqlite_db() {
     let db_tempdir = TempDir::new(random_string(8).as_str()).unwrap();
     let db_folder = db_tempdir.path().to_str().unwrap().to_string();
     let db_path = format!("{}/{}", db_folder, db_name);
-    let connection_pool = run_migration_and_create_connection_pool(&db_path).unwrap();
+    let connection = run_migration_and_create_sqlite_connection(&db_path).unwrap();
 
-    sending_transaction_and_confirmation(OutputManagerSqliteDatabase::new(connection_pool));
+    sending_transaction_and_confirmation(OutputManagerSqliteDatabase::new(connection));
 }
 
 fn send_not_enough_funds<T: OutputManagerBackend + 'static>(backend: T) {
@@ -257,9 +257,9 @@ fn send_not_enough_funds_sqlite_db() {
     let db_tempdir = TempDir::new(random_string(8).as_str()).unwrap();
     let db_folder = db_tempdir.path().to_str().unwrap().to_string();
     let db_path = format!("{}/{}", db_folder, db_name);
-    let connection_pool = run_migration_and_create_connection_pool(&db_path).unwrap();
+    let connection = run_migration_and_create_sqlite_connection(&db_path).unwrap();
 
-    send_not_enough_funds(OutputManagerSqliteDatabase::new(connection_pool));
+    send_not_enough_funds(OutputManagerSqliteDatabase::new(connection));
 }
 
 fn send_no_change<T: OutputManagerBackend + 'static>(backend: T) {
@@ -333,9 +333,9 @@ fn send_no_change_sqlite_db() {
     let db_tempdir = TempDir::new(random_string(8).as_str()).unwrap();
     let db_folder = db_tempdir.path().to_str().unwrap().to_string();
     let db_path = format!("{}/{}", db_folder, db_name);
-    let connection_pool = run_migration_and_create_connection_pool(&db_path).unwrap();
+    let connection = run_migration_and_create_sqlite_connection(&db_path).unwrap();
 
-    send_no_change(OutputManagerSqliteDatabase::new(connection_pool));
+    send_no_change(OutputManagerSqliteDatabase::new(connection));
 }
 
 fn send_not_enough_for_change<T: OutputManagerBackend + 'static>(backend: T) {
@@ -378,9 +378,9 @@ fn send_not_enough_for_change_sqlite_db() {
     let db_tempdir = TempDir::new(random_string(8).as_str()).unwrap();
     let db_folder = db_tempdir.path().to_str().unwrap().to_string();
     let db_path = format!("{}/{}", db_folder, db_name);
-    let connection_pool = run_migration_and_create_connection_pool(&db_path).unwrap();
+    let connection = run_migration_and_create_sqlite_connection(&db_path).unwrap();
 
-    send_not_enough_for_change(OutputManagerSqliteDatabase::new(connection_pool));
+    send_not_enough_for_change(OutputManagerSqliteDatabase::new(connection));
 }
 
 fn receiving_and_confirmation<T: OutputManagerBackend + 'static>(backend: T) {
@@ -422,9 +422,9 @@ fn receiving_and_confirmation_sqlite_db() {
     let db_tempdir = TempDir::new(random_string(8).as_str()).unwrap();
     let db_folder = db_tempdir.path().to_str().unwrap().to_string();
     let db_path = format!("{}/{}", db_folder, db_name);
-    let connection_pool = run_migration_and_create_connection_pool(&db_path).unwrap();
+    let connection = run_migration_and_create_sqlite_connection(&db_path).unwrap();
 
-    receiving_and_confirmation(OutputManagerSqliteDatabase::new(connection_pool));
+    receiving_and_confirmation(OutputManagerSqliteDatabase::new(connection));
 }
 
 fn cancel_transaction<T: OutputManagerBackend + 'static>(backend: T) {
@@ -472,8 +472,9 @@ fn cancel_transaction_sqlite_db() {
     let db_tempdir = TempDir::new(random_string(8).as_str()).unwrap();
     let db_folder = db_tempdir.path().to_str().unwrap().to_string();
     let db_path = format!("{}/{}", db_folder, db_name);
-    let connection_pool = run_migration_and_create_connection_pool(&db_path).unwrap();
-    cancel_transaction(OutputManagerSqliteDatabase::new(connection_pool));
+    let connection = run_migration_and_create_sqlite_connection(&db_path).unwrap();
+
+    cancel_transaction(OutputManagerSqliteDatabase::new(connection));
 }
 
 fn timeout_transaction<T: OutputManagerBackend + 'static>(backend: T) {
@@ -526,8 +527,9 @@ fn timeout_transaction_sqlite_db() {
     let db_tempdir = TempDir::new(random_string(8).as_str()).unwrap();
     let db_folder = db_tempdir.path().to_str().unwrap().to_string();
     let db_path = format!("{}/{}", db_folder, db_name);
-    let connection_pool = run_migration_and_create_connection_pool(&db_path).unwrap();
-    timeout_transaction(OutputManagerSqliteDatabase::new(connection_pool));
+    let connection = run_migration_and_create_sqlite_connection(&db_path).unwrap();
+
+    timeout_transaction(OutputManagerSqliteDatabase::new(connection));
 }
 
 fn test_get_balance<T: OutputManagerBackend + 'static>(backend: T) {
@@ -578,8 +580,9 @@ fn test_get_balance_sqlite_db() {
     let db_tempdir = TempDir::new(random_string(8).as_str()).unwrap();
     let db_folder = db_tempdir.path().to_str().unwrap().to_string();
     let db_path = format!("{}/{}", db_folder, db_name);
-    let connection_pool = run_migration_and_create_connection_pool(&db_path).unwrap();
-    test_get_balance(OutputManagerSqliteDatabase::new(connection_pool));
+    let connection = run_migration_and_create_sqlite_connection(&db_path).unwrap();
+
+    test_get_balance(OutputManagerSqliteDatabase::new(connection));
 }
 
 fn test_confirming_received_output<T: OutputManagerBackend + 'static>(backend: T) {
@@ -616,8 +619,9 @@ fn test_confirming_received_output_sqlite_db() {
     let db_tempdir = TempDir::new(random_string(8).as_str()).unwrap();
     let db_folder = db_tempdir.path().to_str().unwrap().to_string();
     let db_path = format!("{}/{}", db_folder, db_name);
-    let connection_pool = run_migration_and_create_connection_pool(&db_path).unwrap();
-    test_confirming_received_output(OutputManagerSqliteDatabase::new(connection_pool));
+    let connection = run_migration_and_create_sqlite_connection(&db_path).unwrap();
+
+    test_confirming_received_output(OutputManagerSqliteDatabase::new(connection));
 }
 
 #[test]

--- a/base_layer/wallet/tests/output_manager_service/storage.rs
+++ b/base_layer/wallet/tests/output_manager_service/storage.rs
@@ -39,7 +39,7 @@ use tari_wallet::{
             sqlite_db::OutputManagerSqliteDatabase,
         },
     },
-    storage::connection_manager::run_migration_and_create_connection_pool,
+    storage::connection_manager::run_migration_and_create_sqlite_connection,
 };
 use tempdir::TempDir;
 use tokio::runtime::Runtime;
@@ -293,8 +293,9 @@ pub fn test_output_manager_sqlite_db() {
     let db_name = format!("{}.sqlite3", random_string(8).as_str());
     let temp_dir = TempDir::new(random_string(8).as_str()).unwrap();
     let db_folder = temp_dir.path().to_str().unwrap().to_string();
-    let connection_pool = run_migration_and_create_connection_pool(&format!("{}/{}", db_folder, db_name)).unwrap();
-    test_db_backend(OutputManagerSqliteDatabase::new(connection_pool));
+    let connection = run_migration_and_create_sqlite_connection(&format!("{}/{}", db_folder, db_name)).unwrap();
+
+    test_db_backend(OutputManagerSqliteDatabase::new(connection));
 }
 
 pub fn test_key_manager_crud<T: OutputManagerBackend + 'static>(backend: T) {
@@ -343,6 +344,7 @@ pub fn test_key_manager_crud_sqlite_db() {
     let db_name = format!("{}.sqlite3", random_string(8).as_str());
     let temp_dir = TempDir::new(random_string(8).as_str()).unwrap();
     let db_folder = temp_dir.path().to_str().unwrap().to_string();
-    let connection_pool = run_migration_and_create_connection_pool(&format!("{}/{}", db_folder, db_name)).unwrap();
-    test_key_manager_crud(OutputManagerSqliteDatabase::new(connection_pool));
+    let connection = run_migration_and_create_sqlite_connection(&format!("{}/{}", db_folder, db_name)).unwrap();
+
+    test_key_manager_crud(OutputManagerSqliteDatabase::new(connection));
 }

--- a/base_layer/wallet/tests/transaction_service/service.rs
+++ b/base_layer/wallet/tests/transaction_service/service.rs
@@ -84,7 +84,7 @@ use tari_wallet::{
         storage::{database::OutputManagerDatabase, memory_db::OutputManagerMemoryDatabase},
         OutputManagerServiceInitializer,
     },
-    storage::connection_manager::run_migration_and_create_connection_pool,
+    storage::connection_manager::run_migration_and_create_sqlite_connection,
     transaction_service::{
         config::TransactionServiceConfig,
         error::TransactionServiceError,
@@ -404,12 +404,12 @@ fn manage_single_transaction_sqlite_db() {
     let alice_db_path = format!("{}/{}", temp_dir.path().to_str().unwrap(), alice_db_name);
     let bob_db_name = format!("{}.sqlite3", random_string(8).as_str());
     let bob_db_path = format!("{}/{}", temp_dir.path().to_str().unwrap(), bob_db_name);
-    let connection_pool_alice = run_migration_and_create_connection_pool(&alice_db_path).unwrap();
-    let connection_pool_bob = run_migration_and_create_connection_pool(&bob_db_path).unwrap();
+    let connection_alice = run_migration_and_create_sqlite_connection(&alice_db_path).unwrap();
+    let connection_bob = run_migration_and_create_sqlite_connection(&bob_db_path).unwrap();
 
     manage_single_transaction(
-        TransactionServiceSqliteDatabase::new(connection_pool_alice),
-        TransactionServiceSqliteDatabase::new(connection_pool_bob),
+        TransactionServiceSqliteDatabase::new(connection_alice),
+        TransactionServiceSqliteDatabase::new(connection_bob),
         temp_dir.path().to_str().unwrap().to_string(),
     );
 }
@@ -585,13 +585,13 @@ fn manage_multiple_transactions_sqlite_db() {
     let bob_db_path = format!("{}/{}", path_string, bob_db_name);
     let carol_db_name = format!("{}.sqlite3", random_string(8).as_str());
     let carol_db_path = format!("{}/{}", path_string, carol_db_name);
-    let connection_pool_alice = run_migration_and_create_connection_pool(&alice_db_path).unwrap();
-    let connection_pool_bob = run_migration_and_create_connection_pool(&bob_db_path).unwrap();
-    let connection_pool_carol = run_migration_and_create_connection_pool(&carol_db_path).unwrap();
+    let connection_alice = run_migration_and_create_sqlite_connection(&alice_db_path).unwrap();
+    let connection_bob = run_migration_and_create_sqlite_connection(&bob_db_path).unwrap();
+    let connection_carol = run_migration_and_create_sqlite_connection(&carol_db_path).unwrap();
     manage_multiple_transactions(
-        TransactionServiceSqliteDatabase::new(connection_pool_alice),
-        TransactionServiceSqliteDatabase::new(connection_pool_bob),
-        TransactionServiceSqliteDatabase::new(connection_pool_carol),
+        TransactionServiceSqliteDatabase::new(connection_alice),
+        TransactionServiceSqliteDatabase::new(connection_bob),
+        TransactionServiceSqliteDatabase::new(connection_carol),
         path_string,
     );
 }
@@ -682,11 +682,11 @@ fn test_sending_repeated_tx_ids_sqlite_db() {
         let alice_db_path = format!("{}/{}", path_string, alice_db_name);
         let bob_db_name = format!("{}.sqlite3", random_string(8).as_str());
         let bob_db_path = format!("{}/{}", path_string, bob_db_name);
-        let connection_pool_alice = run_migration_and_create_connection_pool(&alice_db_path).unwrap();
-        let connection_pool_bob = run_migration_and_create_connection_pool(&bob_db_path).unwrap();
+        let connection_alice = run_migration_and_create_sqlite_connection(&alice_db_path).unwrap();
+        let connection_bob = run_migration_and_create_sqlite_connection(&bob_db_path).unwrap();
         test_sending_repeated_tx_ids(
-            TransactionServiceSqliteDatabase::new(connection_pool_alice),
-            TransactionServiceSqliteDatabase::new(connection_pool_bob),
+            TransactionServiceSqliteDatabase::new(connection_alice),
+            TransactionServiceSqliteDatabase::new(connection_bob),
         );
     });
 }
@@ -781,8 +781,8 @@ fn test_accepting_unknown_tx_id_and_malformed_reply_sqlite_db() {
         let path_string = dir_path.to_str().unwrap().to_string();
         let alice_db_name = format!("{}.sqlite3", random_string(8).as_str());
         let alice_db_path = format!("{}/{}", path_string, alice_db_name);
-        let connection_pool_alice = run_migration_and_create_connection_pool(&alice_db_path).unwrap();
-        test_accepting_unknown_tx_id_and_malformed_reply(TransactionServiceSqliteDatabase::new(connection_pool_alice));
+        let connection_alice = run_migration_and_create_sqlite_connection(&alice_db_path).unwrap();
+        test_accepting_unknown_tx_id_and_malformed_reply(TransactionServiceSqliteDatabase::new(connection_alice));
     });
 }
 
@@ -838,9 +838,9 @@ fn finalize_tx_with_nonexistent_txid_sqlite_db() {
         let path_string = dir_path.to_str().unwrap().to_string();
         let alice_db_name = format!("{}.sqlite3", random_string(8).as_str());
         let alice_db_path = format!("{}/{}", path_string, alice_db_name);
-        let connection_pool_alice = run_migration_and_create_connection_pool(&alice_db_path).unwrap();
+        let connection_alice = run_migration_and_create_sqlite_connection(&alice_db_path).unwrap();
 
-        finalize_tx_with_nonexistent_txid(TransactionServiceSqliteDatabase::new(connection_pool_alice));
+        finalize_tx_with_nonexistent_txid(TransactionServiceSqliteDatabase::new(connection_alice));
     });
 }
 
@@ -939,11 +939,11 @@ fn finalize_tx_with_incorrect_pubkey_sqlite_db() {
         let alice_db_path = format!("{}/{}", path_string, alice_db_name);
         let bob_db_name = format!("{}.sqlite3", random_string(8).as_str());
         let bob_db_path = format!("{}/{}", path_string, bob_db_name);
-        let connection_pool_alice = run_migration_and_create_connection_pool(&alice_db_path).unwrap();
-        let connection_pool_bob = run_migration_and_create_connection_pool(&bob_db_path).unwrap();
+        let connection_alice = run_migration_and_create_sqlite_connection(&alice_db_path).unwrap();
+        let connection_bob = run_migration_and_create_sqlite_connection(&bob_db_path).unwrap();
         finalize_tx_with_incorrect_pubkey(
-            TransactionServiceSqliteDatabase::new(connection_pool_alice),
-            TransactionServiceSqliteDatabase::new(connection_pool_bob),
+            TransactionServiceSqliteDatabase::new(connection_alice),
+            TransactionServiceSqliteDatabase::new(connection_bob),
         );
     });
 }
@@ -1042,11 +1042,11 @@ fn finalize_tx_with_missing_output_sqlite_db() {
         let alice_db_path = format!("{}/{}", path_string, alice_db_name);
         let bob_db_name = format!("{}.sqlite3", random_string(8).as_str());
         let bob_db_path = format!("{}/{}", path_string, bob_db_name);
-        let connection_pool_alice = run_migration_and_create_connection_pool(&alice_db_path).unwrap();
-        let connection_pool_bob = run_migration_and_create_connection_pool(&bob_db_path).unwrap();
+        let connection_alice = run_migration_and_create_sqlite_connection(&alice_db_path).unwrap();
+        let connection_bob = run_migration_and_create_sqlite_connection(&bob_db_path).unwrap();
         finalize_tx_with_missing_output(
-            TransactionServiceSqliteDatabase::new(connection_pool_alice),
-            TransactionServiceSqliteDatabase::new(connection_pool_bob),
+            TransactionServiceSqliteDatabase::new(connection_alice),
+            TransactionServiceSqliteDatabase::new(connection_bob),
         );
     });
 }
@@ -1324,9 +1324,9 @@ fn test_coinbase_sqlite_db() {
         let path_string = dir_path.to_str().unwrap().to_string();
         let alice_db_name = format!("{}.sqlite3", random_string(8).as_str());
         let alice_db_path = format!("{}/{}", path_string, alice_db_name);
-        let connection_pool_alice = run_migration_and_create_connection_pool(&alice_db_path).unwrap();
+        let connection_alice = run_migration_and_create_sqlite_connection(&alice_db_path).unwrap();
 
-        test_coinbase(TransactionServiceSqliteDatabase::new(connection_pool_alice));
+        test_coinbase(TransactionServiceSqliteDatabase::new(connection_alice));
     });
 }
 

--- a/base_layer/wallet/tests/transaction_service/storage.rs
+++ b/base_layer/wallet/tests/transaction_service/storage.rs
@@ -36,7 +36,7 @@ use tari_crypto::{
     keys::{PublicKey as PublicKeyTrait, SecretKey as SecretKeyTrait},
 };
 use tari_wallet::{
-    storage::connection_manager::run_migration_and_create_connection_pool,
+    storage::connection_manager::run_migration_and_create_sqlite_connection,
     transaction_service::storage::{
         database::{
             CompletedTransaction,
@@ -305,6 +305,7 @@ pub fn test_transaction_service_sqlite_db() {
     let db_tempdir = TempDir::new(random_string(8).as_str()).unwrap();
     let db_folder = db_tempdir.path().to_str().unwrap().to_string();
     let db_path = format!("{}/{}", db_folder, db_name);
-    let connection_pool = run_migration_and_create_connection_pool(&db_path).unwrap();
-    test_db_backend(TransactionServiceSqliteDatabase::new(connection_pool));
+    let connection = run_migration_and_create_sqlite_connection(&db_path).unwrap();
+
+    test_db_backend(TransactionServiceSqliteDatabase::new(connection));
 }

--- a/base_layer/wallet/tests/wallet/mod.rs
+++ b/base_layer/wallet/tests/wallet/mod.rs
@@ -113,13 +113,11 @@ fn test_wallet() {
         };
         let config1 = WalletConfig {
             comms_config: comms_config1,
-            logging_path: None,
             factories: factories.clone(),
             transaction_service_config: None,
         };
         let config2 = WalletConfig {
             comms_config: comms_config2,
-            logging_path: None,
             factories: factories.clone(),
             transaction_service_config: None,
         };
@@ -247,7 +245,6 @@ fn test_import_utxo() {
     };
     let config = WalletConfig {
         comms_config,
-        logging_path: None,
         factories: factories.clone(),
         transaction_service_config: None,
     };
@@ -318,7 +315,6 @@ fn test_data_generation() {
     let config = WalletConfig {
         comms_config,
         factories,
-        logging_path: None,
         transaction_service_config: None,
     };
 

--- a/base_layer/wallet_ffi/Cargo.toml
+++ b/base_layer/wallet_ffi/Cargo.toml
@@ -23,6 +23,7 @@ chrono = { version = "0.4.6", features = ["serde"]}
 tari_broadcast_channel = "^0.1"
 derive-error = "0.0.4"
 log = "0.4.6"
+log4rs = {version = "0.8.3", features = ["console_appender", "file_appender", "file", "yaml_format"]}
 
 [dependencies.tari_core]
 path = "../../base_layer/core"


### PR DESCRIPTION
## Description
R2D2 was added to provide thread safety for the Async wallet services with the thought that in the future we might require a pool of connections but after testing we are having problems with Segmentation Faults on Android coming from the R2D2 thread pool.

So this PR removes the threadpool in favour of a single SqliteConnection maintained behind a Arc<Mutex<>>. This is a much simpler arrangement and will hopefully be more stable on mobile platforms.

I also moved the wallet logging to being initialized in the Wallet FFI so that logging starts as early as possible.

## How Has This Been Tested?
Updated existing tests

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [x] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [x] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch.
* [x] I ran `cargo-fmt --all` before pushing.
* [ ] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
