### PR TITLE
Enable mining in CLI

### DIFF
--- a/base_layer/core/tests/mining.rs
+++ b/base_layer/core/tests/mining.rs
@@ -30,7 +30,10 @@ use helpers::{
     event_stream::event_stream_next,
     nodes::create_network_with_2_base_nodes_with_config,
 };
-use std::{sync::Arc, time::Duration};
+use std::{
+    sync::{atomic::Ordering, Arc},
+    time::Duration,
+};
 use tari_broadcast_channel::{bounded, Publisher, Subscriber};
 use tari_comms_dht::{domain_message::OutboundDomainMessage, outbound::OutboundEncryption};
 use tari_core::{
@@ -104,6 +107,7 @@ fn mining() {
     // Setup and start the miner
     let stop_flag = Arc::new(AtomicBool::new(false));
     let mut miner = Miner::new(stop_flag, consensus_manager, &alice_node.local_nci, 1);
+    miner.enable_mining_flag().store(true, Ordering::Relaxed);
     let (mut state_event_sender, state_event_receiver): (Publisher<BaseNodeState>, Subscriber<BaseNodeState>) =
         bounded(1);
     miner.subscribe_to_state_change(state_event_receiver);

--- a/base_layer/core/tests/wallet.rs
+++ b/base_layer/core/tests/wallet.rs
@@ -33,7 +33,10 @@ use core::iter;
 use futures::{FutureExt, SinkExt, StreamExt};
 use rand::{distributions::Alphanumeric, rngs::OsRng, Rng};
 use std::{
-    sync::{atomic::AtomicBool, Arc},
+    sync::{
+        atomic::{AtomicBool, Ordering},
+        Arc,
+    },
     time::Duration,
 };
 use tari_broadcast_channel::{bounded, Publisher, Subscriber};
@@ -291,6 +294,7 @@ fn wallet_base_node_integration_test() {
     // Setup and start the miner
     let stop_flag = Arc::new(AtomicBool::new(false));
     let mut miner = Miner::new(stop_flag, consensus_manager, &base_node.local_nci, 1);
+    miner.enable_mining_flag().store(true, Ordering::Relaxed);
     let (mut state_event_sender, state_event_receiver): (Publisher<BaseNodeState>, Subscriber<BaseNodeState>) =
         bounded(1);
     miner.subscribe_to_state_change(state_event_receiver);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This allows the user to enable and disable mining in the CLI via a command

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
We want the user to be able to enable mining in the UI without the user needing to restart the node and set it in the config


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch.
* [x] I ran `cargo-fmt --all` before pushing.
* [x] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
