### PR TITLE
Add callback to FFI for Base Node Sync process completion

### DIFF
--- a/base_layer/wallet/src/output_manager_service/config.rs
+++ b/base_layer/wallet/src/output_manager_service/config.rs
@@ -20,15 +20,17 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+use std::time::Duration;
+
 #[derive(Clone)]
 pub struct OutputManagerServiceConfig {
-    pub base_node_query_timeout_in_secs: u64,
+    pub base_node_query_timeout: Duration,
 }
 
 impl Default for OutputManagerServiceConfig {
     fn default() -> Self {
         Self {
-            base_node_query_timeout_in_secs: 30,
+            base_node_query_timeout: Duration::from_secs(30),
         }
     }
 }

--- a/base_layer/wallet/src/output_manager_service/handle.rs
+++ b/base_layer/wallet/src/output_manager_service/handle.rs
@@ -98,7 +98,7 @@ pub enum OutputManagerResponse {
     InvalidOutputs(Vec<UnblindedOutput>),
     SeedWords(Vec<String>),
     BaseNodePublicKeySet,
-    StartedBaseNodeSync,
+    StartedBaseNodeSync(u64),
 }
 
 /// Events that can be published on the Text Message Service Event Stream
@@ -289,9 +289,9 @@ impl OutputManagerHandle {
         }
     }
 
-    pub async fn sync_with_base_node(&mut self) -> Result<(), OutputManagerError> {
+    pub async fn sync_with_base_node(&mut self) -> Result<u64, OutputManagerError> {
         match self.handle.call(OutputManagerRequest::SyncWithBaseNode).await?? {
-            OutputManagerResponse::StartedBaseNodeSync => Ok(()),
+            OutputManagerResponse::StartedBaseNodeSync(request_key) => Ok(request_key),
             _ => Err(OutputManagerError::UnexpectedApiResponse),
         }
     }

--- a/base_layer/wallet/src/output_manager_service/storage/memory_db.rs
+++ b/base_layer/wallet/src/output_manager_service/storage/memory_db.rs
@@ -64,7 +64,7 @@ impl InnerDatabase {
     }
 }
 
-#[derive(Clone)]
+#[derive(Clone, Default)]
 pub struct OutputManagerMemoryDatabase {
     db: Arc<RwLock<InnerDatabase>>,
 }

--- a/base_layer/wallet/src/output_manager_service/storage/sqlite_db.rs
+++ b/base_layer/wallet/src/output_manager_service/storage/sqlite_db.rs
@@ -148,19 +148,19 @@ impl OutputManagerBackend for OutputManagerSqliteDatabase {
         match op {
             WriteOperation::Insert(kvp) => match kvp {
                 DbKeyValuePair::SpentOutput(k, o) => {
-                    if let Ok(_) = OutputSql::find(&k.to_vec(), &(*conn)) {
+                    if OutputSql::find(&k.to_vec(), &(*conn)).is_ok() {
                         return Err(OutputManagerStorageError::DuplicateOutput);
                     }
                     OutputSql::new(*o, OutputStatus::Spent, None).commit(&(*conn))?
                 },
                 DbKeyValuePair::UnspentOutput(k, o) => {
-                    if let Ok(_) = OutputSql::find(&k.to_vec(), &(*conn)) {
+                    if OutputSql::find(&k.to_vec(), &(*conn)).is_ok() {
                         return Err(OutputManagerStorageError::DuplicateOutput);
                     }
                     OutputSql::new(*o, OutputStatus::Unspent, None).commit(&(*conn))?
                 },
                 DbKeyValuePair::PendingTransactionOutputs(tx_id, p) => {
-                    if let Ok(_) = PendingTransactionOutputSql::find(tx_id, &(*conn)) {
+                    if PendingTransactionOutputSql::find(tx_id, &(*conn)).is_ok() {
                         return Err(OutputManagerStorageError::DuplicateOutput);
                     }
                     PendingTransactionOutputSql::new(p.tx_id, p.timestamp).commit(&(*conn))?;

--- a/base_layer/wallet/src/storage/memory_db.rs
+++ b/base_layer/wallet/src/storage/memory_db.rs
@@ -27,6 +27,7 @@ use crate::{
 use std::sync::{Arc, RwLock};
 use tari_comms::peer_manager::Peer;
 
+#[derive(Default)]
 pub struct InnerDatabase {
     peers: Vec<Peer>,
 }

--- a/base_layer/wallet/src/transaction_service/service.rs
+++ b/base_layer/wallet/src/transaction_service/service.rs
@@ -1101,7 +1101,7 @@ where
                     )
                     .await?;
                 // Start Timeout
-                let state_timeout = StateDelay::new(self.config.mempool_broadcast_timeout.clone(), completed_tx.tx_id);
+                let state_timeout = StateDelay::new(self.config.mempool_broadcast_timeout, completed_tx.tx_id);
 
                 broadcast_timeout_futures.push(state_timeout.delay().boxed());
             },
@@ -1245,8 +1245,7 @@ where
                     )
                     .await?;
                 // Start Timeout
-                let state_timeout =
-                    StateDelay::new(self.config.base_node_mined_timeout.clone(), completed_tx.tx_id.clone());
+                let state_timeout = StateDelay::new(self.config.base_node_mined_timeout, completed_tx.tx_id);
 
                 mined_request_timeout_futures.push(state_timeout.delay().boxed());
             },
@@ -1623,7 +1622,7 @@ async fn transaction_send_discovery_process_completion(
                     "Send Discovery process for TX_ID: {} was unsuccessful and no message was sent", tx_id
                 ),
                 1 => {
-                    message_tag = Some(tags[0].clone());
+                    message_tag = Some(tags[0]);
 
                     info!(
                         target: LOG_TARGET,
@@ -1654,7 +1653,7 @@ async fn transaction_send_discovery_process_completion(
         },
     }
 
-    return if let Some(mt) = message_tag {
+    if let Some(mt) = message_tag {
         let updated_outbound_tx = OutboundTransaction {
             timestamp: Utc::now().naive_utc(),
             ..outbound_tx.clone()
@@ -1662,5 +1661,5 @@ async fn transaction_send_discovery_process_completion(
         Ok((mt, updated_outbound_tx))
     } else {
         Err(TransactionServiceError::DiscoveryProcessFailed(tx_id))
-    };
+    }
 }

--- a/base_layer/wallet/src/transaction_service/storage/sqlite_db.rs
+++ b/base_layer/wallet/src/transaction_service/storage/sqlite_db.rs
@@ -165,25 +165,25 @@ impl TransactionBackend for TransactionServiceSqliteDatabase {
         match op {
             WriteOperation::Insert(kvp) => match kvp {
                 DbKeyValuePair::PendingOutboundTransaction(k, v) => {
-                    if let Ok(_) = OutboundTransactionSql::find(k, &(*conn)) {
+                    if OutboundTransactionSql::find(k, &(*conn)).is_ok() {
                         return Err(TransactionStorageError::DuplicateOutput);
                     }
                     OutboundTransactionSql::try_from(*v)?.commit(&(*conn))?;
                 },
                 DbKeyValuePair::PendingInboundTransaction(k, v) => {
-                    if let Ok(_) = InboundTransactionSql::find(k, &(*conn)) {
+                    if InboundTransactionSql::find(k, &(*conn)).is_ok() {
                         return Err(TransactionStorageError::DuplicateOutput);
                     }
                     InboundTransactionSql::try_from(*v)?.commit(&(*conn))?;
                 },
                 DbKeyValuePair::PendingCoinbaseTransaction(k, v) => {
-                    if let Ok(_) = PendingCoinbaseTransactionSql::find(k, &(*conn)) {
+                    if PendingCoinbaseTransactionSql::find(k, &(*conn)).is_ok() {
                         return Err(TransactionStorageError::DuplicateOutput);
                     }
                     PendingCoinbaseTransactionSql::from(*v).commit(&(*conn))?;
                 },
                 DbKeyValuePair::CompletedTransaction(k, v) => {
-                    if let Ok(_) = CompletedTransactionSql::find(k, &(*conn)) {
+                    if CompletedTransactionSql::find(k, &(*conn)).is_ok() {
                         return Err(TransactionStorageError::DuplicateOutput);
                     }
                     CompletedTransactionSql::try_from(*v)?.commit(&(*conn))?;

--- a/base_layer/wallet/src/wallet.rs
+++ b/base_layer/wallet/src/wallet.rs
@@ -154,9 +154,7 @@ where
                 factories.clone(),
             ))
             .add_initializer(TransactionServiceInitializer::new(
-                config
-                    .transaction_service_config
-                    .unwrap_or(TransactionServiceConfig::default()),
+                config.transaction_service_config.unwrap_or_default(),
                 subscription_factory.clone(),
                 comms.subscribe_messaging_events(),
                 transaction_backend,
@@ -236,10 +234,8 @@ where
             self.transaction_service
                 .set_base_node_public_key(peer.public_key.clone()),
         )?;
-        self.runtime.block_on(
-            self.output_manager_service
-                .set_base_node_public_key(peer.public_key.clone()),
-        )?;
+        self.runtime
+            .block_on(self.output_manager_service.set_base_node_public_key(peer.public_key))?;
 
         Ok(())
     }
@@ -304,9 +300,10 @@ where
 
     /// Have all the wallet components that need to start a sync process with the set base node to confirm the wallets
     /// state is accurately reflected on the blockchain
-    pub fn sync_with_base_node(&mut self) -> Result<(), WalletError> {
-        self.runtime
+    pub fn sync_with_base_node(&mut self) -> Result<u64, WalletError> {
+        let request_key = self
+            .runtime
             .block_on(self.output_manager_service.sync_with_base_node())?;
-        Ok(())
+        Ok(request_key)
     }
 }

--- a/base_layer/wallet/tests/output_manager_service/service.rs
+++ b/base_layer/wallet/tests/output_manager_service/service.rs
@@ -98,7 +98,7 @@ pub fn setup_output_manager_service<T: OutputManagerBackend + 'static>(
     let output_manager_service = runtime
         .block_on(OutputManagerService::new(
             OutputManagerServiceConfig {
-                base_node_query_timeout_in_secs: 3,
+                base_node_query_timeout: Duration::from_secs(3),
             },
             outbound_message_requester.clone(),
             oms_request_receiver,

--- a/base_layer/wallet_ffi/wallet.h
+++ b/base_layer/wallet_ffi/wallet.h
@@ -340,6 +340,7 @@ struct TariWallet *wallet_create(struct TariWalletConfig *config,
                                     void (*callback_transaction_broadcast)(struct TariCompletedTransaction*),
                                     void (*callback_transaction_mined)(struct TariCompletedTransaction*),
                                     void (*callback_discovery_process_complete)(unsigned long long, bool),
+                                    void (*callback_base_node_sync_complete)(unsigned long long, bool),
                                     int* error_out);
 
 // Signs a message
@@ -408,7 +409,7 @@ bool wallet_is_completed_transaction_outbound(struct TariWallet *wallet, struct 
 unsigned long long wallet_import_utxo(struct TariWallet *wallet, unsigned long long amount, struct TariPrivateKey *spending_key, struct TariPublicKey *source_public_key, const char *message, int* error_out);
 
 // This function will tell the wallet to query the set base node to confirm the status of wallet data.
-bool wallet_sync_with_base_node(struct TariWallet *wallet, int* error_out);
+unsigned long long wallet_sync_with_base_node(struct TariWallet *wallet, int* error_out);
 
 // Simulates the completion of a broadcasted TariPendingInboundTransaction
 bool wallet_test_broadcast_transaction(struct TariWallet *wallet, unsigned long long tx, int* error_out);


### PR DESCRIPTION
## Description
This PR adds in a new callback to the FFI that is called when the Base Node Sync process for the Output Manager service completes.

fn wallet_sync_with_base_node(...) now returns a u64 which is the request key used to identify the callback associated with this request.

## How Has This Been Tested?
Existing tests updated 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch.
* [x] I ran `cargo-fmt --all` before pushing.
* [ ] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
