### PR TITLE
Validator reuse of backend lock guards

### DIFF
--- a/applications/tari_base_node/src/miner.rs
+++ b/applications/tari_base_node/src/miner.rs
@@ -26,19 +26,18 @@ use std::sync::Arc;
 use tari_broadcast_channel::Subscriber;
 use tari_core::{
     base_node::{states::BaseNodeState, LocalNodeCommsInterface},
-    chain_storage::BlockchainBackend,
     consensus::ConsensusManager,
     mining::Miner,
 };
 use tari_service_framework::handles::ServiceHandles;
 
-pub fn build_miner<B: BlockchainBackend + 'static, H: AsRef<ServiceHandles>>(
+pub fn build_miner<H: AsRef<ServiceHandles>>(
     handles: H,
     stop_flag: Arc<AtomicBool>,
     event_stream: Subscriber<BaseNodeState>,
-    consensus_manager: ConsensusManager<B>,
+    consensus_manager: ConsensusManager,
     num_threads: usize,
-) -> Miner<B>
+) -> Miner
 {
     let handles = handles.as_ref();
     let node_local_interface = handles.get_handle::<LocalNodeCommsInterface>().unwrap();

--- a/base_layer/core/src/base_node/comms_interface/inbound_handlers.rs
+++ b/base_layer/core/src/base_node/comms_interface/inbound_handlers.rs
@@ -63,7 +63,7 @@ where T: BlockchainBackend + 'static
     event_publisher: Arc<RwLock<Publisher<BlockEvent>>>,
     blockchain_db: BlockchainDatabase<T>,
     mempool: Mempool<T>,
-    consensus_manager: ConsensusManager<T>,
+    consensus_manager: ConsensusManager,
     outbound_nci: OutboundNodeCommsInterface,
 }
 
@@ -75,7 +75,7 @@ where T: BlockchainBackend + 'static
         event_publisher: Publisher<BlockEvent>,
         blockchain_db: BlockchainDatabase<T>,
         mempool: Mempool<T>,
-        consensus_manager: ConsensusManager<T>,
+        consensus_manager: ConsensusManager,
         outbound_nci: OutboundNodeCommsInterface,
     ) -> Self
     {
@@ -206,7 +206,11 @@ where T: BlockchainBackend + 'static
                 Ok(NodeCommsResponse::NewBlock(block))
             },
             NodeCommsRequest::GetTargetDifficulty(pow_algo) => Ok(NodeCommsResponse::TargetDifficulty(
-                self.consensus_manager.get_target_difficulty(*pow_algo)?,
+                self.consensus_manager.get_target_difficulty(
+                    &self.blockchain_db.metadata_read_access()?,
+                    &self.blockchain_db.db_read_access()?,
+                    *pow_algo,
+                )?,
             )),
         }
     }

--- a/base_layer/core/src/base_node/service/initializer.rs
+++ b/base_layer/core/src/base_node/service/initializer.rs
@@ -62,7 +62,7 @@ where T: BlockchainBackend
     inbound_message_subscription_factory: Arc<TopicSubscriptionFactory<TariMessageType, Arc<PeerMessage>>>,
     blockchain_db: BlockchainDatabase<T>,
     mempool: Mempool<T>,
-    consensus_manager: ConsensusManager<T>,
+    consensus_manager: ConsensusManager,
     config: BaseNodeServiceConfig,
 }
 
@@ -74,7 +74,7 @@ where T: BlockchainBackend
         inbound_message_subscription_factory: Arc<TopicSubscriptionFactory<TariMessageType, Arc<PeerMessage>>>,
         blockchain_db: BlockchainDatabase<T>,
         mempool: Mempool<T>,
-        consensus_manager: ConsensusManager<T>,
+        consensus_manager: ConsensusManager,
         config: BaseNodeServiceConfig,
     ) -> Self
     {

--- a/base_layer/core/src/chain_storage/metadata.rs
+++ b/base_layer/core/src/chain_storage/metadata.rs
@@ -87,7 +87,7 @@ impl Display for ChainMetadata {
             .clone()
             .map(|b| b.to_hex())
             .unwrap_or_else(|| "Empty Database".into());
-        let accumulated_difficulty = self.accumulated_difficulty.unwrap_or(0.into());
+        let accumulated_difficulty = self.accumulated_difficulty.unwrap_or_else(|| 0.into());
         fmt.write_str(&format!("Height of longest chain : {}\n", height))?;
         fmt.write_str(&format!(
             "Geometric mean of longest chain : {}\n",

--- a/base_layer/core/src/chain_storage/mod.rs
+++ b/base_layer/core/src/chain_storage/mod.rs
@@ -38,7 +38,19 @@ mod metadata;
 pub mod async_db;
 
 // Public API exports
-pub use blockchain_database::{BlockAddResult, BlockchainBackend, BlockchainDatabase, MutableMmrState, Validators};
+pub use blockchain_database::{
+    calculate_mmr_roots,
+    calculate_mmr_roots_writeguard,
+    fetch_header,
+    fetch_header_writeguard,
+    is_utxo,
+    is_utxo_writeguard,
+    BlockAddResult,
+    BlockchainBackend,
+    BlockchainDatabase,
+    MutableMmrState,
+    Validators,
+};
 pub use db_transaction::{DbKey, DbKeyValuePair, DbTransaction, DbValue, MetadataKey, MetadataValue, MmrTree};
 pub use error::ChainStorageError;
 pub use historical_block::HistoricalBlock;

--- a/base_layer/core/src/helpers/mod.rs
+++ b/base_layer/core/src/helpers/mod.rs
@@ -48,12 +48,8 @@ pub fn create_orphan_block(
     header.into_builder().with_transactions(transactions).build()
 }
 
-pub fn create_mem_db(
-    consensus_manager: &ConsensusManager<MemoryDatabase<HashDigest>>,
-) -> BlockchainDatabase<MemoryDatabase<HashDigest>> {
+pub fn create_mem_db(consensus_manager: &ConsensusManager) -> BlockchainDatabase<MemoryDatabase<HashDigest>> {
     let validators = Validators::new(MockValidator::new(true), MockValidator::new(true));
     let db = MemoryDatabase::<HashDigest>::default();
-    let mut db = BlockchainDatabase::new(db, consensus_manager).unwrap();
-    db.set_validators(validators);
-    db
+    BlockchainDatabase::new(db, consensus_manager, validators).unwrap()
 }

--- a/base_layer/core/src/mempool/orphan_pool/orphan_pool.rs
+++ b/base_layer/core/src/mempool/orphan_pool/orphan_pool.rs
@@ -21,7 +21,7 @@
 //  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 use crate::{
-    chain_storage::BlockchainBackend,
+    chain_storage::{BlockchainBackend, BlockchainDatabase},
     mempool::{
         consts::{MEMPOOL_ORPHAN_POOL_CACHE_TTL, MEMPOOL_ORPHAN_POOL_STORAGE_CAPACITY},
         orphan_pool::{error::OrphanPoolError, orphan_pool_storage::OrphanPoolStorage},
@@ -65,9 +65,14 @@ impl<T> OrphanPool<T>
 where T: BlockchainBackend
 {
     /// Create a new OrphanPool with the specified configuration
-    pub fn new(config: OrphanPoolConfig, validator: Validator<Transaction, T>) -> Self {
+    pub fn new(
+        config: OrphanPoolConfig,
+        validator: Validator<Transaction, T>,
+        blockchain_db: BlockchainDatabase<T>,
+    ) -> Self
+    {
         Self {
-            pool_storage: Arc::new(RwLock::new(OrphanPoolStorage::new(config, validator))),
+            pool_storage: Arc::new(RwLock::new(OrphanPoolStorage::new(config, validator, blockchain_db))),
         }
     }
 
@@ -172,13 +177,14 @@ mod test {
         let network = Network::LocalNet;
         let consensus_manager = ConsensusManagerBuilder::new(network).build();
         let store = create_mem_db(&consensus_manager);
-        let mempool_validator = Box::new(TxInputAndMaturityValidator::new(store.clone()));
+        let mempool_validator = Box::new(TxInputAndMaturityValidator {});
         let orphan_pool = OrphanPool::new(
             OrphanPoolConfig {
                 storage_capacity: 3,
                 tx_ttl: Duration::from_millis(50),
             },
             mempool_validator,
+            store.clone(),
         );
         orphan_pool
             .insert_txs(vec![tx1.clone(), tx2.clone(), tx3.clone(), tx4.clone()])

--- a/base_layer/core/src/mempool/orphan_pool/orphan_pool_storage.rs
+++ b/base_layer/core/src/mempool/orphan_pool/orphan_pool_storage.rs
@@ -21,7 +21,7 @@
 //  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 use crate::{
-    chain_storage::BlockchainBackend,
+    chain_storage::{BlockchainBackend, BlockchainDatabase},
     mempool::orphan_pool::{error::OrphanPoolError, orphan_pool::OrphanPoolConfig},
     transactions::{transaction::Transaction, types::Signature},
     validation::{ValidationError, Validator},
@@ -42,17 +42,24 @@ where T: BlockchainBackend
     config: OrphanPoolConfig,
     txs_by_signature: TtlCache<Signature, Arc<Transaction>>,
     validator: Validator<Transaction, T>,
+    blockchain_db: BlockchainDatabase<T>,
 }
 
 impl<T> OrphanPoolStorage<T>
 where T: BlockchainBackend
 {
     /// Create a new OrphanPoolStorage with the specified configuration
-    pub fn new(config: OrphanPoolConfig, validator: Validator<Transaction, T>) -> Self {
+    pub fn new(
+        config: OrphanPoolConfig,
+        validator: Validator<Transaction, T>,
+        blockchain_db: BlockchainDatabase<T>,
+    ) -> Self
+    {
         Self {
             config,
             txs_by_signature: TtlCache::new(config.storage_capacity),
             validator,
+            blockchain_db,
         }
     }
 
@@ -89,7 +96,11 @@ where T: BlockchainBackend
         // We dont care about tx's that appeared in valid blocks. Those tx's will time out in orphan pool and remove
         // them selves.
         for (tx_key, tx) in self.txs_by_signature.iter() {
-            match self.validator.validate(&tx) {
+            match self.validator.validate(
+                &tx,
+                &self.blockchain_db.db_read_access()?,
+                &self.blockchain_db.metadata_read_access()?,
+            ) {
                 Ok(()) => {
                     trace!(
                         target: LOG_TARGET,

--- a/base_layer/core/src/mining/coinbase_builder.rs
+++ b/base_layer/core/src/mining/coinbase_builder.rs
@@ -22,7 +22,6 @@
 //
 
 use crate::{
-    chain_storage::BlockchainBackend,
     consensus::ConsensusManager,
     transactions::{
         tari_amount::{uT, MicroTari},
@@ -111,11 +110,7 @@ impl CoinbaseBuilder {
     /// After `build` is called, the struct is destroyed and the private keys stored are dropped and the memory zeroed
     /// out (by virtue of the zero_on_drop crate).
     #[allow(clippy::erasing_op)] // This is for 0 * uT
-    pub fn build<B: BlockchainBackend>(
-        self,
-        rules: ConsensusManager<B>,
-    ) -> Result<(Transaction, UnblindedOutput), CoinbaseBuildError>
-    {
+    pub fn build(self, rules: ConsensusManager) -> Result<(Transaction, UnblindedOutput), CoinbaseBuildError> {
         let height = self
             .block_height
             .ok_or_else(|| CoinbaseBuildError::MissingBlockHeight)?;
@@ -162,7 +157,6 @@ impl CoinbaseBuilder {
 mod test {
     use crate::{
         consensus::{ConsensusManager, ConsensusManagerBuilder, Network},
-        helpers::MockBackend,
         mining::{coinbase_builder::CoinbaseBuildError, CoinbaseBuilder},
         transactions::{
             helpers::TestParams,
@@ -173,7 +167,7 @@ mod test {
     };
     use tari_crypto::commitment::HomomorphicCommitmentFactory;
 
-    fn get_builder() -> (CoinbaseBuilder, ConsensusManager<MockBackend>, CryptoFactories) {
+    fn get_builder() -> (CoinbaseBuilder, ConsensusManager, CryptoFactories) {
         let network = Network::LocalNet;
         let rules = ConsensusManagerBuilder::new(network).build();
         let factories = CryptoFactories::default();

--- a/base_layer/core/src/validation/block_validators.rs
+++ b/base_layer/core/src/validation/block_validators.rs
@@ -27,26 +27,29 @@ use crate::{
         BlockValidationError,
         NewBlockTemplate,
     },
-    chain_storage::{BlockchainBackend, BlockchainDatabase},
+    chain_storage::{calculate_mmr_roots_writeguard, is_utxo_writeguard, BlockchainBackend, ChainMetadata},
     consensus::{ConsensusConstants, ConsensusManager},
     transactions::{transaction::OutputFlags, types::CryptoFactories},
     validation::{
-        helpers::{check_achieved_difficulty_at_chain_tip, check_median_timestamp_at_chain_tip},
-        Validation,
+        helpers::{check_achieved_difficulty, check_median_timestamp},
+        StatelessValidation,
         ValidationError,
+        ValidationWriteGuard,
     },
 };
 use log::*;
+use std::sync::RwLockWriteGuard;
 use tari_crypto::tari_utilities::hash::Hashable;
+
 pub const LOG_TARGET: &str = "c::val::block_validators";
 
 /// This validator tests whether a candidate block is internally consistent
 #[derive(Clone)]
-pub struct StatelessValidator {
+pub struct StatelessBlockValidator {
     consensus_constants: ConsensusConstants,
 }
 
-impl StatelessValidator {
+impl StatelessBlockValidator {
     pub fn new(consensus_constants: &ConsensusConstants) -> Self {
         Self {
             consensus_constants: consensus_constants.clone(),
@@ -54,7 +57,7 @@ impl StatelessValidator {
     }
 }
 
-impl<B: BlockchainBackend> Validation<Block, B> for StatelessValidator {
+impl StatelessValidation<Block> for StatelessBlockValidator {
     /// The consensus checks that are done (in order of cheapest to verify to most expensive):
     /// 1. Is there precisely one Coinbase output and is it correctly defined?
     /// 1. Is the accounting correct?
@@ -70,25 +73,18 @@ impl<B: BlockchainBackend> Validation<Block, B> for StatelessValidator {
 
 /// This block checks whether a block satisfies *all* consensus rules. If a block passes this validator, it is the
 /// next block on the blockchain.
-pub struct FullConsensusValidator<B: BlockchainBackend> {
-    rules: ConsensusManager<B>,
+pub struct FullConsensusValidator {
+    rules: ConsensusManager,
     factories: CryptoFactories,
-    db: BlockchainDatabase<B>,
 }
 
-impl<B: BlockchainBackend> FullConsensusValidator<B>
-where B: BlockchainBackend
-{
-    pub fn new(rules: ConsensusManager<B>, factories: CryptoFactories, db: BlockchainDatabase<B>) -> Self {
-        Self { rules, factories, db }
-    }
-
-    fn db(&self) -> Result<BlockchainDatabase<B>, ValidationError> {
-        Ok(self.db.clone())
+impl FullConsensusValidator {
+    pub fn new(rules: ConsensusManager, factories: CryptoFactories) -> Self {
+        Self { rules, factories }
     }
 }
 
-impl<B: BlockchainBackend> Validation<Block, B> for FullConsensusValidator<B> {
+impl<B: BlockchainBackend> ValidationWriteGuard<Block, B> for FullConsensusValidator {
     /// The consensus checks that are done (in order of cheapest to verify to most expensive):
     /// 1. Does the block satisfy the stateless checks?
     /// 1. Are all inputs currently in the UTXO set?
@@ -96,23 +92,31 @@ impl<B: BlockchainBackend> Validation<Block, B> for FullConsensusValidator<B> {
     /// 1. Is the block header timestamp greater than the median timestamp?
     /// 1. Is the Proof of Work valid?
     /// 1. Is the achieved difficulty of this block >= the target difficulty for this block?
-    fn validate(&self, block: &Block) -> Result<(), ValidationError> {
+    fn validate(
+        &self,
+        block: &Block,
+        db: &RwLockWriteGuard<B>,
+        metadata: &RwLockWriteGuard<ChainMetadata>,
+    ) -> Result<(), ValidationError>
+    {
         check_coinbase_output(block, &self.rules.consensus_constants())?;
         check_cut_through(block)?;
         block.check_stxo_rules().map_err(BlockValidationError::from)?;
         check_accounting_balance(block, self.rules.clone(), &self.factories)?;
-        check_inputs_are_utxos(block, self.db()?)?;
+        check_inputs_are_utxos(block, &db)?;
+        check_mmr_roots(block, &db)?;
         check_timestamp_ftl(&block.header, &self.rules)?;
-        check_median_timestamp_at_chain_tip(&block.header, self.db()?, self.rules.clone())?;
-        check_achieved_difficulty_at_chain_tip(&block.header, self.db()?, self.rules.clone())?; // Update function signature once diff adjuster is complete
+        let tip_height = metadata.height_of_longest_chain.unwrap_or(0);
+        check_median_timestamp(db, &block.header, tip_height, self.rules.clone())?;
+        check_achieved_difficulty(db, &block.header, tip_height, self.rules.clone())?;
         Ok(())
     }
 }
 
 //-------------------------------------     Block validator helper functions     -------------------------------------//
-fn check_accounting_balance<B: BlockchainBackend>(
+fn check_accounting_balance(
     block: &Block,
-    rules: ConsensusManager<B>,
+    rules: ConsensusManager,
     factories: &CryptoFactories,
 ) -> Result<(), ValidationError>
 {
@@ -133,12 +137,12 @@ fn check_coinbase_output(block: &Block, consensus_constants: &ConsensusConstants
 /// This function checks that all inputs in the blocks are valid UTXO's to be spend
 fn check_inputs_are_utxos<B: BlockchainBackend>(
     block: &Block,
-    db: BlockchainDatabase<B>,
+    db: &RwLockWriteGuard<B>,
 ) -> Result<(), ValidationError>
 {
     for utxo in block.body.inputs() {
         if !(utxo.features.flags.contains(OutputFlags::COINBASE_OUTPUT)) &&
-            !(db.is_utxo(utxo.hash())).map_err(|e| ValidationError::CustomError(e.to_string()))?
+            !(is_utxo_writeguard(db, utxo.hash())).map_err(|e| ValidationError::CustomError(e.to_string()))?
         {
             warn!(
                 target: LOG_TARGET,
@@ -151,9 +155,9 @@ fn check_inputs_are_utxos<B: BlockchainBackend>(
 }
 
 /// This function tests that the block timestamp is less than the ftl.
-fn check_timestamp_ftl<B: BlockchainBackend>(
+fn check_timestamp_ftl(
     block_header: &BlockHeader,
-    consensus_manager: &ConsensusManager<B>,
+    consensus_manager: &ConsensusManager,
 ) -> Result<(), ValidationError>
 {
     if block_header.timestamp > consensus_manager.consensus_constants().ftl() {
@@ -164,11 +168,10 @@ fn check_timestamp_ftl<B: BlockchainBackend>(
     Ok(())
 }
 
-fn check_mmr_roots<B: BlockchainBackend>(block: &Block, db: BlockchainDatabase<B>) -> Result<(), ValidationError> {
+fn check_mmr_roots<B: BlockchainBackend>(block: &Block, db: &RwLockWriteGuard<B>) -> Result<(), ValidationError> {
     let template = NewBlockTemplate::from(block.clone());
-    let tmp_block = db
-        .calculate_mmr_roots(template)
-        .map_err(|e| ValidationError::CustomError(e.to_string()))?;
+    let tmp_block =
+        calculate_mmr_roots_writeguard(db, template).map_err(|e| ValidationError::CustomError(e.to_string()))?;
     let tmp_header = &tmp_block.header;
     let header = &block.header;
     if header.kernel_mr != tmp_header.kernel_mr ||

--- a/base_layer/core/src/validation/helpers.rs
+++ b/base_layer/core/src/validation/helpers.rs
@@ -22,7 +22,7 @@
 
 use crate::{
     blocks::blockheader::{BlockHeader, BlockHeaderValidationError},
-    chain_storage::{BlockchainBackend, BlockchainDatabase},
+    chain_storage::BlockchainBackend,
     consensus::ConsensusManager,
     proof_of_work::PowError,
     validation::ValidationError,
@@ -30,38 +30,21 @@ use crate::{
 use log::*;
 use tari_crypto::tari_utilities::hash::Hashable;
 pub const LOG_TARGET: &str = "c::val::helpers";
-
-/// This function tests that the block timestamp is greater than the median timestamp at the chain tip.
-pub fn check_median_timestamp_at_chain_tip<B: BlockchainBackend>(
-    block_header: &BlockHeader,
-    db: BlockchainDatabase<B>,
-    rules: ConsensusManager<B>,
-) -> Result<(), ValidationError>
-{
-    let tip_height = db
-        .get_metadata()
-        .or_else(|e| {
-            error!(target: LOG_TARGET, "validation failed to get metadata {:?}.", e);
-            Err(e)
-        })
-        .map_err(|e| ValidationError::CustomError(e.to_string()))?
-        .height_of_longest_chain
-        .unwrap_or(0);
-    check_median_timestamp(&block_header, tip_height, rules)
-}
+use std::sync::RwLockWriteGuard;
 
 /// This function tests that the block timestamp is greater than the median timestamp at the specified height.
 pub fn check_median_timestamp<B: BlockchainBackend>(
+    db: &RwLockWriteGuard<B>,
     block_header: &BlockHeader,
     height: u64,
-    rules: ConsensusManager<B>,
+    rules: ConsensusManager,
 ) -> Result<(), ValidationError>
 {
     if block_header.height == 0 || rules.get_genesis_block_hash() == block_header.hash() {
         return Ok(()); // Its the genesis block, so we dont have to check median
     }
     let median_timestamp = rules
-        .get_median_timestamp_at_height(height)
+        .get_median_timestamp_at_height_writeguard(db, height)
         .or_else(|e| {
             error!(target: LOG_TARGET, "Validation could not get median timestamp");
 
@@ -76,37 +59,19 @@ pub fn check_median_timestamp<B: BlockchainBackend>(
     Ok(())
 }
 
-/// Calculates the achieved and target difficulties at the chain tip and compares them.
-pub fn check_achieved_difficulty_at_chain_tip<B: BlockchainBackend>(
-    block_header: &BlockHeader,
-    db: BlockchainDatabase<B>,
-    rules: ConsensusManager<B>,
-) -> Result<(), ValidationError>
-{
-    let tip_height = db
-        .get_metadata()
-        .or_else(|e| {
-            error!(target: LOG_TARGET, "Validation could not get achieved difficultly");
-            Err(e)
-        })
-        .map_err(|e| ValidationError::CustomError(e.to_string()))?
-        .height_of_longest_chain
-        .unwrap_or(0);
-    check_achieved_difficulty(&block_header, tip_height, rules)
-}
-
 /// Calculates the achieved and target difficulties at the specified height and compares them.
 pub fn check_achieved_difficulty<B: BlockchainBackend>(
+    db: &RwLockWriteGuard<B>,
     block_header: &BlockHeader,
     height: u64,
-    rules: ConsensusManager<B>,
+    rules: ConsensusManager,
 ) -> Result<(), ValidationError>
 {
     let achieved = block_header.achieved_difficulty();
     let mut target = 1.into();
     if block_header.height > 0 || rules.get_genesis_block_hash() != block_header.hash() {
         target = rules
-            .get_target_difficulty_with_height(block_header.pow.pow_algo, height)
+            .get_target_difficulty_with_height_writeguard(db, block_header.pow.pow_algo, height)
             .or_else(|e| {
                 error!(target: LOG_TARGET, "Validation could not get achieved difficulty");
                 Err(e)

--- a/base_layer/core/src/validation/mod.rs
+++ b/base_layer/core/src/validation/mod.rs
@@ -34,5 +34,12 @@ mod traits;
 pub mod block_validators;
 pub mod mocks;
 pub use error::ValidationError;
-pub use traits::{Validation, Validator};
+pub use traits::{
+    StatelessValidation,
+    StatelessValidator,
+    Validation,
+    ValidationWriteGuard,
+    Validator,
+    ValidatorWriteGuard,
+};
 pub mod transaction_validators;

--- a/base_layer/core/src/validation/traits.rs
+++ b/base_layer/core/src/validation/traits.rs
@@ -20,9 +20,15 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use crate::{chain_storage::BlockchainBackend, validation::error::ValidationError};
+use crate::{
+    chain_storage::{BlockchainBackend, ChainMetadata},
+    validation::error::ValidationError,
+};
+use std::sync::{RwLockReadGuard, RwLockWriteGuard};
 
 pub type Validator<T, B> = Box<dyn Validation<T, B>>;
+pub type ValidatorWriteGuard<T, B> = Box<dyn ValidationWriteGuard<T, B>>;
+pub type StatelessValidator<T> = Box<dyn StatelessValidation<T>>;
 
 /// The core validation trait. Multiple `Validation` implementors can be chained together in a [ValidatorPipeline] to
 /// provide consensus validation for blocks, transactions, or DAN instructions. Implementors only need to implement
@@ -30,6 +36,30 @@ pub type Validator<T, B> = Box<dyn Validation<T, B>>;
 pub trait Validation<T, B>: Send + Sync
 where B: BlockchainBackend
 {
+    /// General validation code that can run independent of external state
+    fn validate(
+        &self,
+        item: &T,
+        db: &RwLockReadGuard<B>,
+        metadata: &RwLockReadGuard<ChainMetadata>,
+    ) -> Result<(), ValidationError>;
+}
+
+/// A write guard version of the core validation trait that allows access to the db backend using a lock write guard.
+pub trait ValidationWriteGuard<T, B>: Send + Sync
+where B: BlockchainBackend
+{
+    /// General validation code that can run independent of external state
+    fn validate(
+        &self,
+        item: &T,
+        db: &RwLockWriteGuard<B>,
+        metadata: &RwLockWriteGuard<ChainMetadata>,
+    ) -> Result<(), ValidationError>;
+}
+
+/// Stateless version of the core validation trait.
+pub trait StatelessValidation<T>: Send + Sync {
     /// General validation code that can run independent of external state
     fn validate(&self, item: &T) -> Result<(), ValidationError>;
 }

--- a/base_layer/core/tests/async_db.rs
+++ b/base_layer/core/tests/async_db.rs
@@ -33,7 +33,7 @@ use tari_core::{
     blocks::Block,
     chain_storage::{async_db, BlockAddResult, MmrTree},
     consensus::{ConsensusManager, ConsensusManagerBuilder, Network},
-    helpers::{create_orphan_block, MockBackend},
+    helpers::create_orphan_block,
     transactions::{
         helpers::schema_to_transaction,
         tari_amount::T,
@@ -224,7 +224,7 @@ fn fetch_async_mmr_roots() {
 fn async_add_block_fetch_orphan() {
     env_logger::init();
     let network = Network::LocalNet;
-    let consensus: ConsensusManager<MockBackend> = ConsensusManagerBuilder::new(network).build();
+    let consensus: ConsensusManager = ConsensusManagerBuilder::new(network).build();
     let (db, _, _, _) = create_blockchain_db_no_cut_through();
     let orphan = create_orphan_block(7, vec![], &consensus.consensus_constants());
     let block_hash = orphan.hash();

--- a/base_layer/core/tests/block_validation.rs
+++ b/base_layer/core/tests/block_validation.rs
@@ -25,7 +25,7 @@ use tari_core::{
     consensus::{ConsensusManagerBuilder, Network},
     proof_of_work::DiffAdjManager,
     transactions::types::{CryptoFactories, HashDigest},
-    validation::block_validators::{FullConsensusValidator, StatelessValidator},
+    validation::block_validators::{FullConsensusValidator, StatelessBlockValidator},
 };
 
 #[test]
@@ -34,13 +34,12 @@ fn test_genesis_block() {
     let network = Network::LocalNet;
     let rules = ConsensusManagerBuilder::new(network).build();
     let backend = MemoryDatabase::<HashDigest>::default();
-    let mut db = BlockchainDatabase::new(backend, &rules).unwrap();
     let validators = Validators::new(
-        FullConsensusValidator::new(rules.clone(), factories, db.clone()),
-        StatelessValidator::new(&rules.consensus_constants()),
+        FullConsensusValidator::new(rules.clone(), factories),
+        StatelessBlockValidator::new(&rules.consensus_constants()),
     );
-    db.set_validators(validators);
-    let diff_adj_manager = DiffAdjManager::new(db.clone(), &rules.consensus_constants()).unwrap();
+    let db = BlockchainDatabase::new(backend, &rules, validators).unwrap();
+    let diff_adj_manager = DiffAdjManager::new(&rules.consensus_constants()).unwrap();
     rules.set_diff_manager(diff_adj_manager).unwrap();
     let block = rules.get_genesis_block();
     let result = db.add_block(block);

--- a/base_layer/core/tests/chain_storage_tests/chain_storage.rs
+++ b/base_layer/core/tests/chain_storage_tests/chain_storage.rs
@@ -742,8 +742,7 @@ fn store_and_retrieve_blocks() {
     let network = Network::LocalNet;
     let rules = ConsensusManagerBuilder::new(network).build();
     let db = MemoryDatabase::<HashDigest>::new(mmr_cache_config);
-    let mut store = BlockchainDatabase::new(db, &rules).unwrap();
-    store.set_validators(validators);
+    let store = BlockchainDatabase::new(db, &rules, validators).unwrap();
 
     let block0 = store.fetch_block(0).unwrap().block().clone();
     let block1 = append_block(&store, &block0, vec![], &rules.consensus_constants(), 1.into()).unwrap();
@@ -766,8 +765,7 @@ fn store_and_retrieve_chain_and_orphan_blocks_with_hashes() {
     let network = Network::LocalNet;
     let rules = ConsensusManagerBuilder::new(network).build();
     let db = MemoryDatabase::<HashDigest>::new(mmr_cache_config);
-    let mut store = BlockchainDatabase::new(db, &rules).unwrap();
-    store.set_validators(validators);
+    let store = BlockchainDatabase::new(db, &rules, validators).unwrap();
 
     let block0 = store.fetch_block(0).unwrap().block().clone();
     let block1 = append_block(&store, &block0, vec![], &rules.consensus_constants(), 1.into()).unwrap();
@@ -864,8 +862,7 @@ fn restore_metadata() {
     let path = create_temporary_data_path();
     {
         let db = create_lmdb_database(&path, MmrCacheConfig::default()).unwrap();
-        let mut db = BlockchainDatabase::new(db, &rules).unwrap();
-        db.set_validators(validators.clone());
+        let db = BlockchainDatabase::new(db, &rules, validators.clone()).unwrap();
 
         let block0 = db.fetch_block(0).unwrap().block().clone();
         let block1 = append_block(&db, &block0, vec![], &rules.consensus_constants(), 1.into()).unwrap();
@@ -877,8 +874,7 @@ fn restore_metadata() {
     }
     // Restore blockchain db
     let db = create_lmdb_database(&path, MmrCacheConfig::default()).unwrap();
-    let mut db = BlockchainDatabase::new(db, &rules).unwrap();
-    db.set_validators(validators);
+    let db = BlockchainDatabase::new(db, &rules, validators).unwrap();
 
     let metadata = db.get_metadata().unwrap();
     assert_eq!(metadata.height_of_longest_chain, Some(1));

--- a/base_layer/core/tests/helpers/block_builders.rs
+++ b/base_layer/core/tests/helpers/block_builders.rs
@@ -26,7 +26,6 @@ use tari_core::{
     blocks::{Block, BlockHeader, NewBlockTemplate},
     chain_storage::{BlockAddResult, BlockchainBackend, BlockchainDatabase, ChainStorageError, MemoryDatabase},
     consensus::{ConsensusConstants, ConsensusManager, ConsensusManagerBuilder, Network},
-    helpers::MockBackend,
     proof_of_work::Difficulty,
     transactions::{
         helpers::{
@@ -93,7 +92,7 @@ fn genesis_template(
 // This is a helper function to generate and print out a block that can be used as the genesis block.
 pub fn create_act_gen_block() {
     let network = MAINNET;
-    let consensus_manager: ConsensusManager<MockBackend> = ConsensusManagerBuilder::new(network).build();
+    let consensus_manager: ConsensusManager = ConsensusManagerBuilder::new(network).build();
     let factories = CryptoFactories::default();
     let mut header = BlockHeader::new(consensus_manager.consensus_constants().blockchain_version());
     let value = consensus_manager.emission_schedule().supply_at_block(0);

--- a/base_layer/core/tests/helpers/sample_blockchains.rs
+++ b/base_layer/core/tests/helpers/sample_blockchains.rs
@@ -77,7 +77,7 @@ pub fn create_blockchain_db_no_cut_through() -> (
     BlockchainDatabase<MemoryDatabase<HashDigest>>,
     Vec<Block>,
     Vec<Vec<UnblindedOutput>>,
-    ConsensusManager<MemoryDatabase<HashDigest>>,
+    ConsensusManager,
 ) {
     let network = Network::LocalNet;
     let (mut db, mut blocks, mut outputs, consensus_manager) = create_new_blockchain(network);
@@ -160,7 +160,7 @@ pub fn create_new_blockchain(
     BlockchainDatabase<MemoryDatabase<HashDigest>>,
     Vec<Block>,
     Vec<Vec<UnblindedOutput>>,
-    ConsensusManager<MemoryDatabase<HashDigest>>,
+    ConsensusManager,
 ) {
     let factories = CryptoFactories::default();
     let consensus_constants = ConsensusConstantsBuilder::new(network)

--- a/base_layer/core/tests/mempool.rs
+++ b/base_layer/core/tests/mempool.rs
@@ -71,10 +71,7 @@ use tokio::runtime::Runtime;
 fn test_insert_and_process_published_block() {
     let network = Network::LocalNet;
     let (mut store, mut blocks, mut outputs, consensus_manager) = create_new_blockchain(network);
-    let mempool_validator = MempoolValidators::new(
-        TxInputAndMaturityValidator::new(store.clone()),
-        TxInputAndMaturityValidator::new(store.clone()),
-    );
+    let mempool_validator = MempoolValidators::new(TxInputAndMaturityValidator {}, TxInputAndMaturityValidator {});
     let mempool = Mempool::new(store.clone(), MempoolConfig::default(), mempool_validator);
     // Create a block with 4 outputs
     let txs = vec![txn_schema!(
@@ -229,10 +226,7 @@ fn test_insert_and_process_published_block() {
 fn test_retrieve() {
     let network = Network::LocalNet;
     let (mut store, mut blocks, mut outputs, consensus_manager) = create_new_blockchain(network);
-    let mempool_validator = MempoolValidators::new(
-        TxInputAndMaturityValidator::new(store.clone()),
-        TxInputAndMaturityValidator::new(store.clone()),
-    );
+    let mempool_validator = MempoolValidators::new(TxInputAndMaturityValidator {}, TxInputAndMaturityValidator {});
     let mempool = Mempool::new(store.clone(), MempoolConfig::default(), mempool_validator);
     let txs = vec![txn_schema!(
         from: vec![outputs[0][0].clone()],
@@ -332,10 +326,7 @@ fn test_retrieve() {
 fn test_reorg() {
     let network = Network::LocalNet;
     let (mut db, mut blocks, mut outputs, consensus_manager) = create_new_blockchain(network);
-    let mempool_validator = MempoolValidators::new(
-        TxInputAndMaturityValidator::new(db.clone()),
-        TxInputAndMaturityValidator::new(db.clone()),
-    );
+    let mempool_validator = MempoolValidators::new(TxInputAndMaturityValidator {}, TxInputAndMaturityValidator {});
     let mempool = Mempool::new(db.clone(), MempoolConfig::default(), mempool_validator);
 
     // "Mine" Block 1
@@ -450,10 +441,7 @@ fn test_orphaned_mempool_transactions() {
         &consensus_manager.consensus_constants(),
     )
     .unwrap();
-    let mempool_validator = MempoolValidators::new(
-        TxInputAndMaturityValidator::new(store.clone()),
-        TxInputAndMaturityValidator::new(store.clone()),
-    );
+    let mempool_validator = MempoolValidators::new(TxInputAndMaturityValidator {}, TxInputAndMaturityValidator {});
     let mempool = Mempool::new(store.clone(), MempoolConfig::default(), mempool_validator);
     // There are 2 orphan txs
     vec![txns[2].clone(), txns2[0].clone(), txns2[1].clone(), txns2[2].clone()]

--- a/base_layer/core/tests/node_comms_interface.rs
+++ b/base_layer/core/tests/node_comms_interface.rs
@@ -64,10 +64,7 @@ fn new_mempool() -> (
     let network = Network::LocalNet;
     let consensus_manager = ConsensusManagerBuilder::new(network).build();
     let store = create_mem_db(&consensus_manager);
-    let mempool_validator = MempoolValidators::new(
-        TxInputAndMaturityValidator::new(store.clone()),
-        TxInputAndMaturityValidator::new(store.clone()),
-    );
+    let mempool_validator = MempoolValidators::new(TxInputAndMaturityValidator {}, TxInputAndMaturityValidator {});
     let mempool = Mempool::new(store.clone(), MempoolConfig::default(), mempool_validator);
     (mempool, store)
 }
@@ -95,7 +92,7 @@ fn inbound_get_metadata() {
 
     let network = Network::LocalNet;
     let consensus_manager = ConsensusManagerBuilder::new(network).build();
-    let diff_adj_manager = DiffAdjManager::new(store.clone(), &consensus_manager.consensus_constants()).unwrap();
+    let diff_adj_manager = DiffAdjManager::new(&consensus_manager.consensus_constants()).unwrap();
     let (block_event_publisher, _block_event_subscriber) = bounded(100);
     assert!(consensus_manager.set_diff_manager(diff_adj_manager).is_ok());
     let (request_sender, _) = reply_channel::unbounded();
@@ -150,7 +147,7 @@ fn inbound_fetch_kernels() {
     let (mempool, store) = new_mempool();
     let network = Network::LocalNet;
     let consensus_manager = ConsensusManagerBuilder::new(network).build();
-    let diff_adj_manager = DiffAdjManager::new(store.clone(), &consensus_manager.consensus_constants()).unwrap();
+    let diff_adj_manager = DiffAdjManager::new(&consensus_manager.consensus_constants()).unwrap();
     let (block_event_publisher, _block_event_subscriber) = bounded(100);
     assert!(consensus_manager.set_diff_manager(diff_adj_manager).is_ok());
     let (request_sender, _) = reply_channel::unbounded();
@@ -213,7 +210,7 @@ fn inbound_fetch_headers() {
     let consensus_manager = ConsensusManagerBuilder::new(network)
         .with_consensus_constants(consensus_constants)
         .build();
-    let diff_adj_manager = DiffAdjManager::new(store.clone(), &consensus_manager.consensus_constants()).unwrap();
+    let diff_adj_manager = DiffAdjManager::new(&consensus_manager.consensus_constants()).unwrap();
     let (block_event_publisher, _block_event_subscriber) = bounded(100);
     assert!(consensus_manager.set_diff_manager(diff_adj_manager).is_ok());
     let (request_sender, _) = reply_channel::unbounded();
@@ -274,7 +271,7 @@ fn inbound_fetch_utxos() {
     let consensus_manager = ConsensusManagerBuilder::new(network)
         .with_consensus_constants(consensus_constants)
         .build();
-    let diff_adj_manager = DiffAdjManager::new(store.clone(), &consensus_manager.consensus_constants()).unwrap();
+    let diff_adj_manager = DiffAdjManager::new(&consensus_manager.consensus_constants()).unwrap();
     assert!(consensus_manager.set_diff_manager(diff_adj_manager).is_ok());
     let (request_sender, _) = reply_channel::unbounded();
     let (block_sender, _) = futures_mpsc_channel_unbounded();
@@ -338,7 +335,7 @@ fn inbound_fetch_blocks() {
     let consensus_manager = ConsensusManagerBuilder::new(network)
         .with_consensus_constants(consensus_constants)
         .build();
-    let diff_adj_manager = DiffAdjManager::new(store.clone(), &consensus_manager.consensus_constants()).unwrap();
+    let diff_adj_manager = DiffAdjManager::new(&consensus_manager.consensus_constants()).unwrap();
     assert!(consensus_manager.set_diff_manager(diff_adj_manager).is_ok());
     let (request_sender, _) = reply_channel::unbounded();
     let (block_sender, _) = futures_mpsc_channel_unbounded();

--- a/base_layer/core/tests/node_service.rs
+++ b/base_layer/core/tests/node_service.rs
@@ -60,7 +60,7 @@ use tari_core::{
         types::CryptoFactories,
     },
     txn_schema,
-    validation::block_validators::StatelessValidator,
+    validation::{block_validators::StatelessBlockValidator, mocks::MockValidator},
 };
 use tari_crypto::tari_utilities::hash::Hashable;
 use tari_mmr::MmrCacheConfig;
@@ -502,7 +502,8 @@ fn propagate_and_forward_invalid_block() {
         .with_consensus_constants(consensus_constants)
         .with_block(block0.clone())
         .build();
-    let stateless_validator = StatelessValidator::new(&rules.consensus_constants());
+    let stateless_block_validator = StatelessBlockValidator::new(&rules.consensus_constants());
+    let mock_validator = MockValidator::new(true);
     let (mut alice_node, rules) = BaseNodeBuilder::new(network)
         .with_node_identity(alice_node_identity.clone())
         .with_peers(vec![bob_node_identity.clone(), carol_node_identity.clone()])
@@ -512,13 +513,13 @@ fn propagate_and_forward_invalid_block() {
         .with_node_identity(bob_node_identity.clone())
         .with_peers(vec![alice_node_identity.clone(), dan_node_identity.clone()])
         .with_consensus_manager(rules)
-        .with_validators(stateless_validator.clone(), stateless_validator.clone())
+        .with_validators(mock_validator.clone(), stateless_block_validator.clone())
         .start(&mut runtime, temp_dir.path().to_str().unwrap());
     let (carol_node, rules) = BaseNodeBuilder::new(network)
         .with_node_identity(carol_node_identity.clone())
         .with_peers(vec![alice_node_identity, dan_node_identity.clone()])
         .with_consensus_manager(rules)
-        .with_validators(stateless_validator.clone(), stateless_validator)
+        .with_validators(mock_validator.clone(), stateless_block_validator)
         .start(&mut runtime, temp_dir.path().to_str().unwrap());
     let (dan_node, rules) = BaseNodeBuilder::new(network)
         .with_node_identity(dan_node_identity)

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -155,7 +155,7 @@ where F: Fn(&Path) -> Result<(), std::io::Error> {
 
 #[cfg(test)]
 mod test {
-    use crate::{bootstrap_config_from_cli, dir_utils, load_configuration, DEFAULT_CONFIG, DEFAULT_LOG_CONFIG};
+    use crate::{bootstrap_config_from_cli, dir_utils, load_configuration};
     use clap::clap_app;
 
     #[test]


### PR DESCRIPTION
## Description
- All block validation was restored in the blockchain db and the validators were changed to reuse blockchain backend lock guards to query the information from the blockchain db.
- The Validators can now be provided to the Blockchain database on construction as they will be provided with a read or write lock guard when validation is performed. Validators no longer require a copy of the blockchain db.
- The previously unused check_mmr_roots was added to the full state block validator.
- The consensus manager and difficulty adjustment manager was changed to rather reuse the read or write lock guard provided when calling their member functions, this allowed the blockchain backend to be removed and ensured that it did not attempt to obtain a read lock in a write lock producing a panic.
- Some duplication of code was introduced in the difficulty adjustment manager to allow queries using a read and write lock guard, this should be cleaned up at a later stage.
- Three validators were introduced: Validator, ValidatorWriteGuard, StatelessValidator. Validator uses a read lock guard on validation. ValidatorWriteGuard use a write lock guard on validation and  the StatelessValidator is stateless and require no lock guards,
- All current validators from the blockchain db and mempool were updated to use these new validator types depending on their blockchain backend usage.
- Implements for all three validator types were provided for the mock validators.
- Removed the unused blockchain backend generic from the Consensus Manger, Miner and difficulty adjustment manager.

## Motivation and Context
These changes will ensure that validators reuse read and write lock guards from the blockchain db, full block validation was also restored.

## How Has This Been Tested?
Existing tests cover changes.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [x] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch.
* [x] I ran `cargo-fmt --all` before pushing.
* [x] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
