### PR TITLE
Handle discovery "error" when sending a transaction

### DIFF
--- a/applications/tari_base_node/src/main.rs
+++ b/applications/tari_base_node/src/main.rs
@@ -31,6 +31,7 @@ mod consts;
 mod miner;
 /// Parser module used to control user commands
 mod parser;
+mod utils;
 
 use crate::builder::{create_new_base_node_identity, load_identity};
 use log::*;

--- a/applications/tari_base_node/src/parser.rs
+++ b/applications/tari_base_node/src/parser.rs
@@ -21,7 +21,7 @@
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 use super::LOG_TARGET;
-use crate::builder::NodeContainer;
+use crate::{builder::NodeContainer, utils};
 use log::*;
 use rustyline::{
     completion::Completer,
@@ -38,6 +38,7 @@ use std::{
         atomic::{AtomicBool, Ordering},
         Arc,
     },
+    time::{Duration, Instant},
 };
 use strum::IntoEnumIterator;
 use strum_macros::{Display, EnumIter, EnumString};
@@ -54,10 +55,10 @@ use tari_core::{
 };
 use tari_wallet::{
     output_manager_service::handle::OutputManagerHandle,
-    transaction_service::handle::TransactionServiceHandle,
+    transaction_service::{error::TransactionServiceError, handle::TransactionServiceHandle},
     util::emoji::EmojiId,
 };
-use tokio::runtime;
+use tokio::{runtime, time};
 
 /// Enum representing commands used by the basenode
 #[derive(Clone, PartialEq, Debug, Display, EnumIter, EnumString)]
@@ -436,7 +437,7 @@ impl Parser {
     fn process_send_tari<'a, I: Iterator<Item = &'a str>>(&mut self, mut args: I) {
         let amount = args.next().and_then(|v| v.parse::<u64>().ok());
         if amount.is_none() {
-            println!("please enter a valid amount of tari");
+            println!("Please enter a valid amount of tari");
             return;
         }
         let amount: MicroTari = amount.unwrap().into();
@@ -453,22 +454,74 @@ impl Parser {
         let dest_pubkey = match EmojiId::str_to_pubkey(&key).or_else(|_| CommsPublicKey::from_hex(&key)) {
             Ok(v) => v,
             _ => {
-                println!("please enter a valid destination public key or emoji id");
+                println!("Please enter a valid destination public key or emoji id");
                 return;
             },
         };
         let fee_per_gram = 25 * uT;
-        let mut handler = self.wallet_transaction_service.clone();
+        let mut txn_service = self.wallet_transaction_service.clone();
         self.executor.spawn(async move {
-            match handler
+            let event_stream = txn_service.get_event_stream_fused();
+            match txn_service
                 .send_transaction(
                     dest_pubkey.clone(),
                     amount,
                     fee_per_gram,
-                    "coinbase reward from mining".into(),
+                    "Coinbase reward from mining".into(),
                 )
                 .await
             {
+                Err(TransactionServiceError::OutboundSendDiscoveryInProgress(tx_id)) => {
+                    println!(
+                        "No peer found matching that public key. Attempting to discover the peer on the network. 🌎"
+                    );
+                    let start = Instant::now();
+                    match time::timeout(
+                        Duration::from_secs(120),
+                        utils::wait_for_discovery_transaction_event(event_stream, tx_id),
+                    )
+                    .await
+                    {
+                        Ok(true) => {
+                            let end = Instant::now();
+                            println!(
+                                "Discovery succeeded for peer {} after {}ms",
+                                dest_pubkey,
+                                (end - start).as_millis()
+                            );
+                            debug!(
+                                target: LOG_TARGET,
+                                "Discovery succeeded for peer {} after {}ms",
+                                dest_pubkey,
+                                (end - start).as_millis()
+                            );
+                        },
+                        Ok(false) => {
+                            let end = Instant::now();
+                            println!(
+                                "Discovery failed for peer {} after {}ms",
+                                dest_pubkey,
+                                (end - start).as_millis()
+                            );
+                            println!("The peer may be offline. Please try again later.");
+
+                            debug!(
+                                target: LOG_TARGET,
+                                "Discovery failed for peer {} after {}ms",
+                                dest_pubkey,
+                                (end - start).as_millis()
+                            );
+                        },
+                        Err(_) => {
+                            debug!(
+                                target: LOG_TARGET,
+                                "Discovery timed out before the node was discovered."
+                            );
+                            println!("Discovery timed out before the node was discovered.");
+                            println!("The peer may be offline. Please try again later.");
+                        },
+                    }
+                },
                 Err(e) => {
                     println!("Something went wrong sending funds");
                     println!("{:?}", e);

--- a/applications/tari_base_node/src/utils.rs
+++ b/applications/tari_base_node/src/utils.rs
@@ -1,0 +1,43 @@
+// Copyright 2020, The Tari Project
+//
+// Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+// following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+// disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+// following disclaimer in the documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+// products derived from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+// INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+// WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+// USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+use futures::{Stream, StreamExt};
+use std::sync::Arc;
+use tari_wallet::transaction_service::handle::TransactionEvent;
+
+pub async fn wait_for_discovery_transaction_event<S>(mut event_stream: S, expected_tx_id: u64) -> bool
+where S: Stream<Item = Arc<TransactionEvent>> + Unpin {
+    loop {
+        match event_stream.next().await {
+            Some(event) => {
+                if let TransactionEvent::TransactionSendDiscoveryComplete(tx_id, is_success) = &*event {
+                    if *tx_id == expected_tx_id {
+                        break *is_success;
+                    }
+                }
+            },
+            None => {
+                break false;
+            },
+        }
+    }
+}

--- a/base_layer/wallet/src/transaction_service/handle.rs
+++ b/base_layer/wallet/src/transaction_service/handle.rs
@@ -131,8 +131,6 @@ pub enum TransactionEvent {
     TransactionSendDiscoveryComplete(TxId, bool),
     TransactionBroadcast(TxId),
     TransactionMined(TxId),
-    TransactionSendDiscoverySuccess(TxId),
-    TransactionSendDiscoveryFailure(TxId),
     TransactionMinedRequestTimedOut(TxId),
     Error(String),
 }

--- a/config/tari_config_sample.toml
+++ b/config/tari_config_sample.toml
@@ -197,8 +197,11 @@ peer_seeds = []
 # Use TCP to connect to the Tari network. This transport can only communicate with TCP/IP addresses, so peers with
 # e.g. tor onion addresses will not be contactable.
 #transport = "tcp"
-# # The address and port to listen for peer connections over TCP.
+# The address and port to listen for peer connections over TCP.
 #tcp_listener_address = "/ip4/0.0.0.0/tcp/18189"
+# Address of the SOCK5 service to use to resolve tor addresses
+# tcp_tor_socks_address # disabled by default
+# tcp_tor_socks_auth = "none"
 
 # Configures the node to run over a tor hidden service using the Tor proxy. This transport recognises ip/tcp,
 # onion v2, onion v3 and dns addresses.


### PR DESCRIPTION
The PR notifies the user when a discovery is initiated and
completes (success/fail) when using the `send-tari` command.
 Before this would be treated as an error.