### PR TITLE
Update to tari_utils 0.1.2 and send_tari arg parsing

### DIFF
--- a/applications/test_faucet/Cargo.toml
+++ b/applications/test_faucet/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-tari_utilities = "0.1.1"
+tari_utilities = "^0.1"
 serde = { version = "1.0.97", features = ["derive"] }
 serde_json = "1.0"
 rand = "0.7.2"

--- a/base_layer/wallet/src/util/emoji.rs
+++ b/base_layer/wallet/src/util/emoji.rs
@@ -190,6 +190,11 @@ mod test {
         assert!(EmojiId::is_valid(eid.as_str()));
         assert_eq!(EmojiId::is_valid("😂"), false, "Emoji ID too short");
         assert_eq!(
+            EmojiId::is_valid("🖖🥴😍🙃💦🤘🤜👁🙃🙌😱🖐🙀🤳🖖👍✊🐈☂💀👚😶🤟😳👢😘😺🙌🎩🤬🐼"),
+            false,
+            "Emoji ID too short"
+        );
+        assert_eq!(
             EmojiId::is_valid("70350e09c474809209824c6e6888707b7dd09959aa227343b5106382b856f73a"),
             false,
             "Not emoji string"

--- a/base_layer/wallet_ffi/Cargo.toml
+++ b/base_layer/wallet_ffi/Cargo.toml
@@ -13,7 +13,7 @@ tari_crypto = { version = "^0.3" }
 tari_p2p = {path = "../p2p", version = "^0.0"}
 tari_wallet = { path = "../wallet", version = "^0.0", features = ["test_harness", "c_integration"]}
 tari_shutdown = { path = "../../infrastructure/shutdown", version = "^0.0"}
-tari_utilities = "0.1.1"
+tari_utilities = "^0.1"
 
 futures =  { version = "^0.3.1", features =["compat", "std"]}
 tokio = "0.2.10"


### PR DESCRIPTION
The send_tari command was causing a thread panic if an emoji id was
used. In refactoring the parsing logic, it was discovered that the
problem lay with `from_hex` in the tari_utilities crate.

The crate was patched with a fix and bumped to 0.1.2.

The send_tari command now works with both hex and emoji pubkeys.


