### PR TITLE
Add warns! when validation fails

### DIFF
--- a/base_layer/core/src/validation/helpers.rs
+++ b/base_layer/core/src/validation/helpers.rs
@@ -31,6 +31,7 @@ use log::*;
 use tari_crypto::tari_utilities::hash::Hashable;
 pub const LOG_TARGET: &str = "c::val::helpers";
 use std::sync::RwLockWriteGuard;
+use tari_crypto::tari_utilities::hex::Hex;
 
 /// This function tests that the block timestamp is greater than the median timestamp at the specified height.
 pub fn check_median_timestamp<B: BlockchainBackend>(
@@ -52,6 +53,13 @@ pub fn check_median_timestamp<B: BlockchainBackend>(
         })
         .map_err(|_| ValidationError::BlockHeaderError(BlockHeaderValidationError::InvalidTimestamp))?;
     if block_header.timestamp < median_timestamp {
+        warn!(
+            target: LOG_TARGET,
+            "Block header timestamp {} is less than median timestamp: {} for block:{}",
+            block_header.timestamp,
+            median_timestamp,
+            block_header.hash().to_hex()
+        );
         return Err(ValidationError::BlockHeaderError(
             BlockHeaderValidationError::InvalidTimestamp,
         ));
@@ -83,6 +91,13 @@ pub fn check_achieved_difficulty<B: BlockchainBackend>(
             })?;
     }
     if achieved < target {
+        warn!(
+            target: LOG_TARGET,
+            "Proof of work for {} was below the target difficulty. Achieved: {}, Target:{}",
+            block_header.hash().to_hex(),
+            achieved,
+            target
+        );
         return Err(ValidationError::BlockHeaderError(
             BlockHeaderValidationError::ProofOfWorkError(PowError::AchievedDifficultyTooLow),
         ));


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Added a few `warns!` and elevated some `debug!` to `warn!`s when validation fails. Sometimes validation would fail and the message would get lost in a `map_err`

Example:
```
2020-03-20 15:16:17.509604000 [c::cs::database] WARN  Validation failed on block:block error
2020-03-20 15:16:17.509901000 [c::bn::states::block_sync] WARN  Validation on block f40990379633be877af4018df8c8c9f5d820d91833b0fa7237c0ab750b453671 from peer failed:block error. Retrying
```

This is now:
```
[c::val::block_validators] WARN  Block header MMR roots in 6ba19de27caba88fd88bade649a1d588f31446d7d7b967af9915a40c3889e65f do not match calculated roots
```

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [ ] I'm merging against the `development` branch.
* [ ] I ran `cargo-fmt --all` before pushing.
* [ ] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
