### PR TITLE
Added `discover-peer` command

### DIFF
--- a/applications/tari_base_node/src/builder.rs
+++ b/applications/tari_base_node/src/builder.rs
@@ -158,6 +158,11 @@ impl NodeContainer {
         using_backend!(self, ctx, ctx.base_node_comms.node_identity())
     }
 
+    /// Returns the base node DHT
+    pub fn base_node_dht(&self) -> &Dht {
+        using_backend!(self, ctx, &ctx.base_node_dht)
+    }
+
     /// Returns this node's wallet identity.
     pub fn wallet_node_identity(&self) -> Arc<NodeIdentity> {
         using_backend!(self, ctx, ctx.wallet_comms.node_identity())

--- a/comms/dht/src/lib.rs
+++ b/comms/dht/src/lib.rs
@@ -130,6 +130,8 @@ mod dht;
 pub use dht::Dht;
 
 mod discovery;
+pub use discovery::DhtDiscoveryRequester;
+
 mod logging_middleware;
 mod proto;
 mod tower_filter;

--- a/comms/src/peer_manager/peer.rs
+++ b/comms/src/peer_manager/peer.rs
@@ -204,10 +204,19 @@ impl Peer {
 impl Display for Peer {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         f.write_str(&format!(
-            "[{}] PK={} Features={:?} {}",
+            "[{}] PK={} {} {:?} {}",
             self.node_id.short_str(),
             self.public_key,
-            self.features,
+            self.addresses
+                .address_iter()
+                .next()
+                .map(ToString::to_string)
+                .unwrap_or_else(|| "<none>".to_string()),
+            match self.features {
+                PeerFeatures::COMMUNICATION_NODE => "BASE_NODE".to_string(),
+                PeerFeatures::COMMUNICATION_CLIENT => "WALLET".to_string(),
+                f => format!("{:?}", f),
+            },
             self.connection_stats,
         ))
     }


### PR DESCRIPTION
```
>> discover-peer c85bb4933d2e9e9e924e47530c00b987072da14c3a2a36b86e
🌎 Peer discovery started.
⚡️ Discovery succeeded in 1293ms!
This peer was found:
[ac414ecc153977fa] PK=c85bb4933d2e9e9e924e47530c00b987072da14c3a2a36b86e20cf6xxxxxxx /onion3/[redacted]:18021 "WALLET" Last connected at '2020-03-20 15:14:01.734128'.
```

- `discover-peer [emoji id]` works
- `list-peers` also lists wallets.
- `list-peers basenode` lists base nodes only (`list-peers bn` for short) 
- `list-peers wallet` lists wallets only (`list-peers w` for short)