### PR TITLE
Add balance trace log to OMS

### DIFF
--- a/base_layer/wallet/src/output_manager_service/service.rs
+++ b/base_layer/wallet/src/output_manager_service/service.rs
@@ -409,7 +409,9 @@ where
     }
 
     pub async fn get_balance(&self) -> Result<Balance, OutputManagerError> {
-        Ok(self.db.get_balance().await?)
+        let balance = self.db.get_balance().await?;
+        trace!(target: LOG_TARGET, "Balance: {:?}", balance);
+        Ok(balance)
     }
 
     /// Request a spending key to be used to accept a transaction from a sender.


### PR DESCRIPTION
Add a Trace level log to log the Balance of the Output manager service when it is requested via the Service API