### PR TITLE
Faster block syncing with basic header validation

### DIFF
--- a/base_layer/core/src/base_node/base_node.rs
+++ b/base_layer/core/src/base_node/base_node.rs
@@ -100,7 +100,7 @@ impl<B: BlockchainBackend + 'static> BaseNodeStateMachine<B> {
         match (state, event) {
             (Starting(s), Initialized) => Listening(s.into()),
             (BlockSync(s, _, _), BlocksSynchronized) => Listening(s.into()),
-            (BlockSync(s, _, _), MaxRequestAttemptsReached) => Listening(s.into()),
+            (BlockSync(s, _, _), BlockSyncFailure) => Listening(s.into()),
             (Listening(s), FallenBehind(Lagging(network_tip, sync_peers))) => {
                 BlockSync(s.into(), network_tip, sync_peers)
             },

--- a/base_layer/core/src/base_node/states/mod.rs
+++ b/base_layer/core/src/base_node/states/mod.rs
@@ -73,7 +73,7 @@ pub enum StateEvent {
     Initialized,
     MetadataSynced(SyncStatus),
     BlocksSynchronized,
-    MaxRequestAttemptsReached,
+    BlockSyncFailure,
     FallenBehind(SyncStatus),
     NetworkSilence,
     FatalError(String),

--- a/base_layer/core/src/validation/block_validators.rs
+++ b/base_layer/core/src/validation/block_validators.rs
@@ -71,7 +71,7 @@ impl StatelessValidation<Block> for StatelessBlockValidator {
     }
 }
 
-/// This block checks whether a block satisfies *all* consensus rules. If a block passes this validator, it is the
+/// This validator checks whether a block satisfies *all* consensus rules. If a block passes this validator, it is the
 /// next block on the blockchain.
 pub struct FullConsensusValidator {
     rules: ConsensusManager,
@@ -88,6 +88,7 @@ impl<B: BlockchainBackend> ValidationWriteGuard<Block, B> for FullConsensusValid
     /// The consensus checks that are done (in order of cheapest to verify to most expensive):
     /// 1. Does the block satisfy the stateless checks?
     /// 1. Are all inputs currently in the UTXO set?
+    /// 1. Are the block header MMR roots valid?
     /// 1. Is the block header timestamp less than the ftl?
     /// 1. Is the block header timestamp greater than the median timestamp?
     /// 1. Is the Proof of Work valid?

--- a/base_layer/core/tests/node_state_machine.rs
+++ b/base_layer/core/tests/node_state_machine.rs
@@ -228,8 +228,11 @@ fn test_block_sync() {
     );
     let state_machine_config = BaseNodeStateMachineConfig {
         block_sync_config: BlockSyncConfig {
+            random_sync_peer_with_chain: true,
             max_header_request_retry_attempts: 20,
             max_block_request_retry_attempts: 20,
+            max_add_block_retry_attempts: 3,
+            header_request_size: 5,
         },
         listening_config: ListeningConfig::default(),
     };
@@ -297,8 +300,11 @@ fn test_lagging_block_sync() {
     );
     let state_machine_config = BaseNodeStateMachineConfig {
         block_sync_config: BlockSyncConfig {
+            random_sync_peer_with_chain: true,
             max_header_request_retry_attempts: 20,
             max_block_request_retry_attempts: 20,
+            max_add_block_retry_attempts: 3,
+            header_request_size: 5,
         },
         listening_config: ListeningConfig::default(),
     };
@@ -383,8 +389,11 @@ fn test_block_sync_recovery() {
     );
     let state_machine_config = BaseNodeStateMachineConfig {
         block_sync_config: BlockSyncConfig {
+            random_sync_peer_with_chain: true,
             max_header_request_retry_attempts: 20,
             max_block_request_retry_attempts: 20,
+            max_add_block_retry_attempts: 3,
+            header_request_size: 5,
         },
         listening_config: ListeningConfig::default(),
     };
@@ -469,8 +478,11 @@ fn test_forked_block_sync() {
     );
     let state_machine_config = BaseNodeStateMachineConfig {
         block_sync_config: BlockSyncConfig {
+            random_sync_peer_with_chain: true,
             max_header_request_retry_attempts: 20,
             max_block_request_retry_attempts: 20,
+            max_add_block_retry_attempts: 3,
+            header_request_size: 5,
         },
         listening_config: ListeningConfig::default(),
     };


### PR DESCRIPTION
## Description
- The block sync logic was updated to be less reliant on syncing headers first allowing only basic header validation(sequence, hash chaining and linking to genesis block) to be performed during the block sync process.
- During block syncing it first attempts to determine if the local chain is on the best network chain. If it is, it can immediately start syncing blocks without first downloading the headers.
When it detects that a fork has occurred, it will attempt to find the split block height by downloading a set of headers from the minimum tip height to the genesis block. This can be done using only a few header bundle requests. Once the split height is determined syncing of blocks can be performed by requesting blocks by height from the split height to the network tip. Requesting blocks using hashes is no longer required as only the sync peers with the specific best chain are used for requesting blocks.
- The number of headers that is requested in a single query was made configurable. 
- Using a single sync peer or randomly requesting blocks from different sync peers that have the best chain was made configurable.

## Motivation and Context
These changes will result in faster syncing as the number of header requests are reduced for forked block syncs and eliminated for lagging block syncs. This approach requires only basic validation to be performed on the synced headers during the block sync process.

## How Has This Been Tested?
Existing tests cover changes.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [x] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch.
* [x] I ran `cargo-fmt --all` before pushing.
* [x] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
