### PR TITLE
Close the socket if peer sends garbage on noise handshake

### DIFF
--- a/comms/dht/src/actor.rs
+++ b/comms/dht/src/actor.rs
@@ -255,7 +255,6 @@ impl<'a> DhtActor<'a> {
                 let node_identity = Arc::clone(&self.node_identity);
                 let config = self.config.clone();
                 Box::pin(async move {
-                    // task::spawn_blocking(move || {
                     match Self::select_peers(config, node_identity, peer_manager, broadcast_strategy).await {
                         Ok(peers) => reply_tx.send(peers).map_err(|_| DhtActorError::ReplyCanceled),
                         Err(err) => {
@@ -263,10 +262,7 @@ impl<'a> DhtActor<'a> {
                             reply_tx.send(Vec::new()).map_err(|_| DhtActorError::ReplyCanceled)
                         },
                     }
-                }
-                     // })
-                    // .map(hoist_nested_result),
-                )
+                })
             },
             SendRequestStoredMessages(maybe_since) => {
                 let node_identity = Arc::clone(&self.node_identity);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
The socket should immediately be closed if the noise protocol handshake
fails.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
When the noise protocol is not adhered to the node should immediately close the socket without flushing (buffer discarded).

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Used netcat to send garbage to the node. Before the socket would error but the socket would not close. With this change the socket closes and netcat returns a BrokenPipe error. 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch.
* [x] I ran `cargo-fmt --all` before pushing.
* [x] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
