### PR TITLE
Returns fixed difficulty for first 150 blocks of chain

### DIFF
--- a/base_layer/core/src/proof_of_work/lwma_diff.rs
+++ b/base_layer/core/src/proof_of_work/lwma_diff.rs
@@ -36,9 +36,10 @@ impl LinearWeightedMovingAverage {
 
     fn calculate(&self) -> Difficulty {
         let timestamps = &self.timestamps;
-        if timestamps.len() <= 1 {
+        if timestamps.len() <= 150 {
             // return INITIAL_DIFFICULTY;
-            return self.initial_difficulty.into();
+            // We return 10 times it, based it wat a intel mac 2017 cpu can roughly do, so we have 10 cpu's mining.
+            return (self.initial_difficulty * 10).into();
         }
 
         // Use the array length rather than block_window to include early cases where the no. of pts < block_window


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This returns a fixed difficulty for the first 150 blocks so that we can have a stable lwma difficulty adjustment. Assumption is made that the amount of mining power is 10 single thread intel mac 2017 cpu's. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The hash rate is very varying during testing. The LWMA also cannot work effectively with the varying hash rate and the very small block window. This forces the algorithm to chose a fixed amount until it can give out a proper estimation. This should only effect the first 150 blocks. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch.
* [x] I ran `cargo-fmt --all` before pushing.
* [x] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
