### PR TITLE
Fix for UTXO sync in output manager

### DIFF
--- a/config/presets/rincewind-simple.toml
+++ b/config/presets/rincewind-simple.toml
@@ -1,4 +1,4 @@
-# A simple set of sane defaults for connecting to the Ricnewind testnet
+# A simple set of sane defaults for connecting to the Rincewind testnet
 [common]
 #peer_database = "~/.tari/peers"
 


### PR DESCRIPTION
## Description
There was a bug in the Output Manager Service UTXO Sync process where if a UTXO was imported into the OMS after a Sync message was sent but before the response was received.

In this case the hash of the imported UTXO was not sent in the query and when the resposne came it does not include the new UTXO which was considered to be invalid.

This PR adds the list queries UTXO hashes to the list of pending sync queries and only hashes that are in that list and not in the response and invalidated.

## How Has This Been Tested?
Test was updated

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch.
* [x] I ran `cargo-fmt --all` before pushing.
* [ ] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
