### PR TITLE
Make sure there are enough blocking threads to do mining

### DIFF
--- a/applications/tari_base_node/src/main.rs
+++ b/applications/tari_base_node/src/main.rs
@@ -168,17 +168,19 @@ fn main_inner() -> Result<(), ExitCodes> {
 fn setup_runtime(config: &GlobalConfig) -> Result<Runtime, String> {
     let num_core_threads = config.core_threads;
     let num_blocking_threads = config.blocking_threads;
+    let num_mining_threads = config.num_mining_threads;
 
     debug!(
         target: LOG_TARGET,
-        "Configuring the node to run on {} core threads and {} blocking worker threads.",
+        "Configuring the node to run on {} core threads, {} blocking worker threads and {} mining threads.",
         num_core_threads,
-        num_blocking_threads
+        num_blocking_threads,
+        num_mining_threads
     );
     tokio::runtime::Builder::new()
         .threaded_scheduler()
         .enable_all()
-        .max_threads(num_core_threads + num_blocking_threads)
+        .max_threads(num_core_threads + num_blocking_threads + num_mining_threads)
         .core_threads(num_core_threads)
         .build()
         .map_err(|e| format!("There was an error while building the node runtime. {}", e.to_string()))


### PR DESCRIPTION
If mining threads are set higher than the blocking threads the node
stops responding, mainly due to the async db not being able to schedule
work while mining uses all available blocking threads.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation
