### PR TITLE
If tor socket has some kind of error, it shouldn't be read from again

### DIFF
--- a/comms/src/tor/control_client/monitor.rs
+++ b/comms/src/tor/control_client/monitor.rs
@@ -98,8 +98,9 @@ where
                 Either::Right((Some(Err(err)), _)) => {
                     error!(
                         target: LOG_TARGET,
-                        "Line framing error when reading from tor control server: '{:?}'", err
+                        "Line framing error when reading from tor control server: '{:?}'. Monitor is exiting.", err
                     );
+                    break;
                 },
                 // The control server disconnected
                 Either::Right((None, _)) => {

--- a/comms/src/tor/hidden_service/controller.rs
+++ b/comms/src/tor/hidden_service/controller.rs
@@ -152,8 +152,8 @@ impl HiddenServiceController {
                         target: LOG_TARGET,
                         "Failed to reestablish connection with tor control server because '{:?}'", err
                     );
-                    warn!(target: LOG_TARGET, "Will attempt again in 5 seconds...");
-                    time::delay_for(Duration::from_secs(5)).await;
+                    warn!(target: LOG_TARGET, "Will attempt again in 10 seconds...");
+                    time::delay_for(Duration::from_secs(10)).await;
                 },
 
                 Either::Right(_) => {


### PR DESCRIPTION
The contract for AsyncRead is generally that if there is an `Some(Err(_))`
or `Some(None)`, `poll_read` should never be called again. This fix
breaks the loop if a socket error is received. The tor controller will
attempt to reconnect on a "fresh" socket.

This prevents infinite looping of this log (confirmed on iOS app):
```
 [comms::tor::control_client] ERROR Line framing error when reading from tor control server: 'Io(Os { code: 57, kind: NotConnected, message: "Socket is not connected"  })'
```

The following is unclear:
1. The reason this happens in the first place (tor crash?)
1. If the connection can be reestablished (maybe tor crashed and
   restarted? If so then reconnect will work)
