### PR TITLE
Orphan block duplicate key issue

### DIFF
--- a/base_layer/core/src/chain_storage/lmdb_db/lmdb_db.rs
+++ b/base_layer/core/src/chain_storage/lmdb_db/lmdb_db.rs
@@ -341,7 +341,7 @@ where D: Digest + Send + Sync
                             lmdb_insert(&txn, &self.kernels_db, &k, &v)?;
                         },
                         DbKeyValuePair::OrphanBlock(k, v) => {
-                            lmdb_insert(&txn, &self.orphans_db, &k, &v)?;
+                            lmdb_replace(&txn, &self.orphans_db, &k, &v)?;
                         },
                     },
                     WriteOperation::Delete(delete) => match delete {


### PR DESCRIPTION
## Description
This change allows an existing orphan block to be replaced instead of causing a panic.

## Motivation and Context
Fixes a duplicate key issue when inserting the same orphan block.

## How Has This Been Tested?
Covered by existing tests

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch.
* [x] I ran `cargo-fmt --all` before pushing.
* [x] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
