### PR TITLE
Better max_block_transaction_weight estimate

### DIFF
--- a/base_layer/core/src/consensus/consensus_constants.rs
+++ b/base_layer/core/src/consensus/consensus_constants.rs
@@ -146,9 +146,7 @@ impl ConsensusConstants {
             target_block_interval,
             difficulty_block_window,
             difficulty_max_block_interval: target_block_interval * 60,
-            max_block_transaction_weight: 10000,
-            // TODO: a better weight estimate should be
-            // selected
+            max_block_transaction_weight: 6250,
             pow_algo_count: 1,
             median_timestamp_count: 11,
             emission_initial: 5_538_846_115 * uT,
@@ -168,7 +166,7 @@ impl ConsensusConstants {
             target_block_interval,
             difficulty_max_block_interval: target_block_interval * 6,
             difficulty_block_window,
-            max_block_transaction_weight: 10000, // TODO: a better weight estimate should be selected
+            max_block_transaction_weight: 6250,
             pow_algo_count: 2,
             median_timestamp_count: 11,
             emission_initial: 10_000_000.into(),
@@ -189,7 +187,7 @@ impl ConsensusConstants {
             target_block_interval,
             difficulty_max_block_interval: target_block_interval * 6,
             difficulty_block_window,
-            max_block_transaction_weight: 10000,
+            max_block_transaction_weight: 6250,
             pow_algo_count: 2,
             median_timestamp_count: 11,
             emission_initial: 10_000_000.into(),


### PR DESCRIPTION
## Description
- Changed the max_block_transaction_weight to an estimate that will produce blocks closer to 1MBytes. Byte sizes estimated using bincode conversions.

  | Bytes | Counts | Weights per gram | Total
-- | -- | -- | -- | --
header | 254 | 1 | 0 | 0
input | 57 | 625 | 1 | 625
output | 737 | 1250 | 4 | 5000
kernel | 147 | 625 | 1 | 625
  | Total MBytes: | 1.000408173 | Total Weights: | 6250

## Motivation and Context
Change will allow blocks to be produced that are closer to 1MBytes.

## How Has This Been Tested?
Only existing tests.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [x] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch.
* [x] I ran `cargo-fmt --all` before pushing.
* [x] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
