### PR TITLE
Add an initially shorter timeout for Base Node queries from Tx service

### DIFF
--- a/base_layer/core/tests/wallet.rs
+++ b/base_layer/core/tests/wallet.rs
@@ -137,6 +137,7 @@ fn wallet_base_node_integration_test() {
         transaction_service_config: Some(TransactionServiceConfig {
             mempool_broadcast_timeout: Duration::from_secs(10),
             base_node_mined_timeout: Duration::from_secs(1),
+            ..Default::default()
         }),
     };
     let alice_runtime = create_runtime();

--- a/base_layer/wallet/src/output_manager_service/service.rs
+++ b/base_layer/wallet/src/output_manager_service/service.rs
@@ -296,7 +296,10 @@ where
             Some(qh) => qh,
         };
 
-        trace!(target: LOG_TARGET, "Handling a Base Node Response");
+        trace!(
+            target: LOG_TARGET,
+            "Handling a Base Node Response meant for this service"
+        );
 
         // Construct a HashMap of all the unspent outputs
         let unspent_outputs: Vec<UnblindedOutput> = self.db.get_unspent_outputs().await?;

--- a/base_layer/wallet/src/transaction_service/config.rs
+++ b/base_layer/wallet/src/transaction_service/config.rs
@@ -24,14 +24,20 @@ use std::time::Duration;
 
 #[derive(Clone)]
 pub struct TransactionServiceConfig {
+    // This is the timeout of the first broadcast which should be short
+    pub initial_mempool_broadcast_timeout: Duration,
+    // Subsequent timeouts should be longer
     pub mempool_broadcast_timeout: Duration,
+    pub initial_base_node_mined_timeout: Duration,
     pub base_node_mined_timeout: Duration,
 }
 
 impl Default for TransactionServiceConfig {
     fn default() -> Self {
         Self {
+            initial_mempool_broadcast_timeout: Duration::from_secs(5),
             mempool_broadcast_timeout: Duration::from_secs(30),
+            initial_base_node_mined_timeout: Duration::from_secs(5),
             base_node_mined_timeout: Duration::from_secs(30),
         }
     }

--- a/base_layer/wallet/tests/transaction_service/service.rs
+++ b/base_layer/wallet/tests/transaction_service/service.rs
@@ -153,6 +153,7 @@ pub fn setup_transaction_service<T: TransactionBackend + Clone + 'static>(
             TransactionServiceConfig {
                 mempool_broadcast_timeout: Duration::from_secs(5),
                 base_node_mined_timeout: Duration::from_secs(5),
+                ..Default::default()
             },
             subscription_factory,
             comms.subscribe_messaging_events(),
@@ -225,6 +226,7 @@ pub fn setup_transaction_service_no_comms<T: TransactionBackend + Clone + 'stati
         TransactionServiceConfig {
             mempool_broadcast_timeout: Duration::from_secs(5),
             base_node_mined_timeout: Duration::from_secs(5),
+            ..Default::default()
         },
         TransactionDatabase::new(backend),
         ts_request_receiver,


### PR DESCRIPTION
Add an initially shorter timeouts for Broadcast and Mined queries in Tx service to make them more responsive. Later timeouts should still be longer

Also some more logging.
