### PR TITLE
Fix for incomplete chain sync issue

### DIFF
--- a/base_layer/core/src/proof_of_work/lwma_diff.rs
+++ b/base_layer/core/src/proof_of_work/lwma_diff.rs
@@ -144,7 +144,7 @@ mod test {
     fn lwma_negative_solve_times() {
         let mut dif = LinearWeightedMovingAverage::new(90, 120, 1.into(), 120 * 6);
         let mut timestamp = 60.into();
-        let mut cum_diff = Difficulty::from(100);
+        let cum_diff = Difficulty::from(100);
         let _ = dif.add(timestamp, cum_diff);
         timestamp = timestamp.increase(60);
         let _ = dif.add(timestamp, cum_diff);

--- a/base_layer/core/tests/node_state_machine.rs
+++ b/base_layer/core/tests/node_state_machine.rs
@@ -234,6 +234,7 @@ fn test_block_sync() {
     let state_machine_config = BaseNodeStateMachineConfig {
         block_sync_config: BlockSyncConfig {
             random_sync_peer_with_chain: true,
+            max_metadata_request_retry_attempts: 3,
             max_header_request_retry_attempts: 20,
             max_block_request_retry_attempts: 20,
             max_add_block_retry_attempts: 3,
@@ -308,6 +309,7 @@ fn test_lagging_block_sync() {
     let state_machine_config = BaseNodeStateMachineConfig {
         block_sync_config: BlockSyncConfig {
             random_sync_peer_with_chain: true,
+            max_metadata_request_retry_attempts: 3,
             max_header_request_retry_attempts: 20,
             max_block_request_retry_attempts: 20,
             max_add_block_retry_attempts: 3,
@@ -399,6 +401,7 @@ fn test_block_sync_recovery() {
     let state_machine_config = BaseNodeStateMachineConfig {
         block_sync_config: BlockSyncConfig {
             random_sync_peer_with_chain: true,
+            max_metadata_request_retry_attempts: 3,
             max_header_request_retry_attempts: 20,
             max_block_request_retry_attempts: 20,
             max_add_block_retry_attempts: 3,
@@ -490,6 +493,7 @@ fn test_forked_block_sync() {
     let state_machine_config = BaseNodeStateMachineConfig {
         block_sync_config: BlockSyncConfig {
             random_sync_peer_with_chain: true,
+            max_metadata_request_retry_attempts: 3,
             max_header_request_retry_attempts: 20,
             max_block_request_retry_attempts: 20,
             max_add_block_retry_attempts: 3,


### PR DESCRIPTION
## Description
- Modified block syncing to check if the chains of the sync peers have been extended.
- Block syncing will keep on downloading blocks and check if the sync peer chain has been extended until the tip is reached.

## Motivation and Context
These changes fixes an issue where the local chain is extended while a remote chain is being downloaded up to an old tip and the reorg is not successful as the local tip was updated and has a higher accumulated difficulty compared to the old tip that was synced.

## How Has This Been Tested?
Covered by existing tests.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch.
* [x] I ran `cargo-fmt --all` before pushing.
* [x] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
