### PR TITLE
Base node emits events rather than states

### DIFF
--- a/applications/tari_base_node/src/miner.rs
+++ b/applications/tari_base_node/src/miner.rs
@@ -23,7 +23,7 @@
 
 use tari_broadcast_channel::Subscriber;
 use tari_core::{
-    base_node::{states::BaseNodeState, LocalNodeCommsInterface},
+    base_node::{states::StateEvent, LocalNodeCommsInterface},
     consensus::ConsensusManager,
     mining::Miner,
 };
@@ -33,7 +33,7 @@ use tari_shutdown::ShutdownSignal;
 pub fn build_miner<H: AsRef<ServiceHandles>>(
     handles: H,
     kill_signal: ShutdownSignal,
-    event_stream: Subscriber<BaseNodeState>,
+    event_stream: Subscriber<StateEvent>,
     consensus_manager: ConsensusManager,
     num_threads: usize,
 ) -> Miner

--- a/base_layer/core/src/base_node/states/events_and_states.rs
+++ b/base_layer/core/src/base_node/states/events_and_states.rs
@@ -1,0 +1,105 @@
+// Copyright 2020. The Tari Project
+//
+// Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+// following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+// disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+// following disclaimer in the documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+// products derived from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+// INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+// WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+// USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+use crate::{
+    base_node::states::{BlockSyncInfo, ListeningInfo, Shutdown, Starting},
+    chain_storage::ChainMetadata,
+    proof_of_work::Difficulty,
+};
+use std::fmt::{Display, Error, Formatter};
+use tari_comms::peer_manager::NodeId;
+
+#[derive(Clone, Debug, PartialEq)]
+pub enum BaseNodeState {
+    Starting(Starting),
+    BlockSync(BlockSyncInfo, ChainMetadata, Vec<NodeId>),
+    // The best network chain metadata
+    Listening(ListeningInfo),
+    Shutdown(Shutdown),
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum StateEvent {
+    Initialized,
+    MetadataSynced(SyncStatus),
+    BlocksSynchronized,
+    BlockSyncFailure,
+    FallenBehind(SyncStatus),
+    NetworkSilence,
+    FatalError(String),
+    UserQuit,
+}
+
+/// Some state transition functions must return `SyncStatus`. The sync status indicates how far behind the network's
+/// blockchain the local node is. It can either be very far behind (`BehindHorizon`), in which case we will just
+/// synchronise against the pruning horizon; we're somewhat behind (`Lagging`) and need to download the missing
+/// blocks to catch up, or we are `UpToDate`.
+#[derive(Debug, Clone, PartialEq)]
+pub enum SyncStatus {
+    // We are behind the chain tip.
+    Lagging(ChainMetadata, Vec<NodeId>),
+    UpToDate,
+}
+
+impl Display for SyncStatus {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), Error> {
+        use SyncStatus::*;
+        match self {
+            Lagging(m, v) => write!(
+                f,
+                "Lagging behind {} peers (#{}, Difficulty: {})",
+                v.len(),
+                m.height_of_longest_chain.unwrap_or(0),
+                m.accumulated_difficulty.unwrap_or(Difficulty::min())
+            ),
+            UpToDate => f.write_str("UpToDate"),
+        }
+    }
+}
+
+impl Display for StateEvent {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), Error> {
+        use StateEvent::*;
+        match self {
+            Initialized => f.write_str("Initialized"),
+            MetadataSynced(s) => write!(f, "Synchronized metadata - {}", s),
+            BlocksSynchronized => f.write_str("Synchronised Blocks"),
+            BlockSyncFailure => f.write_str("Block Synchronization Failure"),
+            FallenBehind(s) => write!(f, "Fallen behind main chain - {}", s),
+            NetworkSilence => f.write_str("Network Silence"),
+            FatalError(e) => write!(f, "Fatal Error - {}", e),
+            UserQuit => f.write_str("User Termination"),
+        }
+    }
+}
+
+impl Display for BaseNodeState {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), Error> {
+        let s = match self {
+            Self::Starting(_) => "Initializing",
+            Self::BlockSync(_, _, _) => "Synchronizing blocks",
+            Self::Listening(_) => "Listening",
+            Self::Shutdown(_) => "Shutting down",
+        };
+        f.write_str(s)
+    }
+}

--- a/base_layer/core/src/base_node/states/mod.rs
+++ b/base_layer/core/src/base_node/states/mod.rs
@@ -20,97 +20,52 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use crate::chain_storage::ChainMetadata;
-use std::fmt::{Display, Error, Formatter};
-use tari_comms::peer_manager::NodeId;
-
-/// The base node state represents the FSM of the base node synchronisation process.
-///
-/// ## Starting state
-/// The node is in the `Starting`` state when it's first created. After basic internal setup and configuration, it will
-/// move to the `Listening` state.
-///
-/// ## Listening
-///
-/// In this state, we listen for chain tip updates from the network.
-///
-/// The liveness service will periodically poll peers to request the chain tip height. If we are more than one block
-/// behind the network chain tip, switch to `BlockSync` mode.
-///
-/// ## BlockSync
-///
-/// The BlockSync process first downloads the headers from the chain tip to the fork height on the local chain. The
-/// chain of headers are constructed by first downloading the tip header based on the received best chain metadata and
-/// then recursively downloading the previous header using the previous header hash recorded in the header until the
-/// current local chain is reached. The next step is to download the individual blocks corresponding to the previously
-/// downloaded headers, this is performed in a ascending order from the lowest height to the highest block height until
-/// the tip is reached.
-///
-/// After we have caught up on the chain, switch to `Listening`.
-///
-/// If errors occur, re-request the problematic header or block.
-///
-/// Give up after n failures and switch back to `Listening` (if a peer gave an erroneous chain tip and cannot provide
-/// the blocks it says it has, we can switch back to `Listening` and try receive blocks passively.
-///
-/// Full blocks received while in this state can be stored in the orphan pool until they are needed.
-///
-/// ## Shutdown
-///
-/// Reject all new requests with a `Shutdown` message, complete current validations / tasks, flush all state if
-/// required, and then shutdown.
-
-#[derive(Clone, Debug, PartialEq)]
-pub enum BaseNodeState {
-    Starting(Starting),
-    BlockSync(BlockSyncInfo, ChainMetadata, Vec<NodeId>), // The best network chain metadata
-    Listening(ListeningInfo),
-    Shutdown(Shutdown),
-}
-
-#[derive(Debug, PartialEq)]
-pub enum StateEvent {
-    Initialized,
-    MetadataSynced(SyncStatus),
-    BlocksSynchronized,
-    BlockSyncFailure,
-    FallenBehind(SyncStatus),
-    NetworkSilence,
-    FatalError(String),
-    UserQuit,
-}
-
-/// Some state transition functions must return `SyncStatus`. The sync status indicates how far behind the network's
-/// blockchain the local node is. It can either be very far behind (`BehindHorizon`), in which case we will just
-/// synchronise against the pruning horizon; we're somewhat behind (`Lagging`) and need to download the missing
-/// blocks to catch up, or we are `UpToDate`.
-#[derive(Debug, PartialEq)]
-pub enum SyncStatus {
-    // We are behind the chain tip.
-    Lagging(ChainMetadata, Vec<NodeId>),
-    UpToDate,
-}
-
-impl Display for BaseNodeState {
-    fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), Error> {
-        let s = match self {
-            Self::Starting(_) => "Initializing",
-            Self::BlockSync(_, _, _) => "Synchronizing blocks",
-            Self::Listening(_) => "Listening",
-            Self::Shutdown(_) => "Shutting down",
-        };
-        f.write_str(s)
-    }
-}
+//! The base node state represents the FSM of the base node synchronisation process.
+//!
+//! ## Starting state
+//! The node is in the `Starting`` state when it's first created. After basic internal setup and configuration, it will
+//! move to the `Listening` state.
+//!
+//! ## Listening
+//!
+//! In this state, we listen for chain tip updates from the network.
+//!
+//! The liveness service will periodically poll peers to request the chain tip height. If we are more than one block
+//! behind the network chain tip, switch to `BlockSync` mode.
+//!
+//! ## BlockSync
+//!
+//! The BlockSync process first downloads the headers from the chain tip to the fork height on the local chain. The
+//! chain of headers are constructed by first downloading the tip header based on the received best chain metadata and
+//! then recursively downloading the previous header using the previous header hash recorded in the header until the
+//! current local chain is reached. The next step is to download the individual blocks corresponding to the previously
+//! downloaded headers, this is performed in a ascending order from the lowest height to the highest block height until
+//! the tip is reached.
+//!
+//! After we have caught up on the chain, switch to `Listening`.
+//!
+//! If errors occur, re-request the problematic header or block.
+//!
+//! Give up after n failures and switch back to `Listening` (if a peer gave an erroneous chain tip and cannot provide
+//! the blocks it says it has, we can switch back to `Listening` and try receive blocks passively.
+//!
+//! Full blocks received while in this state can be stored in the orphan pool until they are needed.
+//!
+//! ## Shutdown
+//!
+//! Reject all new requests with a `Shutdown` message, complete current validations / tasks, flush all state if
+//! required, and then shutdown.
 
 mod block_sync;
 mod error;
+mod events_and_states;
 mod helpers;
 mod listening;
 mod shutdown_state;
 mod starting_state;
 
 pub use block_sync::{BlockSyncConfig, BlockSyncInfo};
+pub use events_and_states::{BaseNodeState, StateEvent, SyncStatus};
 pub use listening::ListeningInfo;
 pub use shutdown_state::Shutdown;
 pub use starting_state::Starting;

--- a/base_layer/core/tests/helpers/chain_metadata.rs
+++ b/base_layer/core/tests/helpers/chain_metadata.rs
@@ -1,0 +1,74 @@
+// Copyright 2020. The Tari Project
+//
+// Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+// following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+// disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+// following disclaimer in the documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+// products derived from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+// INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+// WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+// USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+use blake2::Digest;
+use futures::SinkExt;
+use tari_broadcast_channel::{bounded, Publisher, Subscriber};
+use tari_comms::peer_manager::NodeId;
+use tari_core::{
+    base_node::chain_metadata_service::{ChainMetadataEvent, ChainMetadataHandle, PeerChainMetadata},
+    chain_storage::ChainMetadata,
+    proof_of_work::Difficulty,
+};
+use tari_crypto::{common::Blake256, tari_utilities::ByteArray};
+
+/// Create a mock Chain Metadata stream.
+///
+/// This struct simulates the chain metadata input stream the base node uses to keep tabs on the blockchain progress
+/// in the rest of the network.
+pub struct MockChainMetadata {
+    publisher: Publisher<ChainMetadataEvent>,
+    subscriber: Subscriber<ChainMetadataEvent>,
+}
+
+impl MockChainMetadata {
+    pub fn new() -> Self {
+        let (publisher, subscriber) = bounded(10);
+        Self { publisher, subscriber }
+    }
+
+    pub fn chain_metadata_handle(&self) -> ChainMetadataHandle {
+        ChainMetadataHandle::new(self.subscriber.clone())
+    }
+
+    pub fn subscriber(&self) -> Subscriber<ChainMetadataEvent> {
+        self.subscriber.clone()
+    }
+
+    pub async fn publish_event(&mut self, event: ChainMetadataEvent) -> Result<(), ()> {
+        self.publisher.send(event).await.map_err(|_| ())
+    }
+
+    pub async fn publish_chain_metadata(&mut self, id: &NodeId, metadata: &ChainMetadata) -> Result<(), ()> {
+        let data = PeerChainMetadata::new(id.clone(), metadata.clone());
+        self.publish_event(ChainMetadataEvent::PeerChainMetadataReceived(vec![data]))
+            .await
+    }
+}
+
+pub fn random_peer_metadata(height: u64, difficulty: Difficulty) -> PeerChainMetadata {
+    let key: Vec<u8> = (0..13).map(|_| rand::random::<u8>()).collect();
+    let id = NodeId::from_key(&key).unwrap();
+    let block_hash = Blake256::digest(id.as_bytes()).to_vec();
+    let metadata = ChainMetadata::new(height, block_hash, 2800, difficulty);
+    PeerChainMetadata::new(id, metadata)
+}

--- a/base_layer/core/tests/helpers/mod.rs
+++ b/base_layer/core/tests/helpers/mod.rs
@@ -4,6 +4,7 @@
 //! through to functions that bootstrap entire blockchains in `sample_blockchains`.
 
 pub mod block_builders;
+pub mod chain_metadata;
 pub mod event_stream;
 pub mod nodes;
 pub mod sample_blockchains;

--- a/base_layer/core/tests/mining.rs
+++ b/base_layer/core/tests/mining.rs
@@ -33,10 +33,7 @@ use std::{sync::atomic::Ordering, time::Duration};
 use tari_broadcast_channel::{bounded, Publisher, Subscriber};
 use tari_comms_dht::{domain_message::OutboundDomainMessage, outbound::OutboundEncryption};
 use tari_core::{
-    base_node::{
-        service::BaseNodeServiceConfig,
-        states::{BaseNodeState, ListeningInfo},
-    },
+    base_node::{service::BaseNodeServiceConfig, states::StateEvent},
     consensus::{ConsensusManagerBuilder, Network},
     mempool::{MempoolServiceConfig, TxStorageResponse},
     mining::Miner,
@@ -105,18 +102,14 @@ fn mining() {
     let shutdown = Shutdown::new();
     let mut miner = Miner::new(shutdown.to_signal(), consensus_manager, &alice_node.local_nci, 1);
     miner.enable_mining_flag().store(true, Ordering::Relaxed);
-    let (mut state_event_sender, state_event_receiver): (Publisher<BaseNodeState>, Subscriber<BaseNodeState>) =
-        bounded(1);
+    let (mut state_event_sender, state_event_receiver): (Publisher<_>, Subscriber<_>) = bounded(1);
     miner.subscribe_to_state_change(state_event_receiver);
     let miner_utxo_stream = miner.get_utxo_receiver_channel().fuse();
     runtime.spawn(miner.mine());
 
     runtime.block_on(async {
-        // Force the base node state machine into listening state so the miner will start mining
-        assert!(state_event_sender
-            .send(BaseNodeState::Listening(ListeningInfo {}))
-            .await
-            .is_ok());
+        // Simulate the BlockSync event
+        assert!(state_event_sender.send(StateEvent::BlocksSynchronized).await.is_ok());
         // Wait for miner to finish mining block 1
         assert!(event_stream_next(miner_utxo_stream, Duration::from_secs(20))
             .await


### PR DESCRIPTION
The base node event stream currently emits state changes, rather than
events.

This is likely not what was intended, since other parts of the code typically
want to respond to events rather than state changes.

This is corroborated by the fact that the function in the miner code
that makes use of the stream was in fact called the "event stream".

Now that the miner code can respond to events we can pause mining when
the block chain lags behind the network and it can start mining
again when the blocks have synchronised.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch.
* [x] I ran `cargo-fmt --all` before pushing.
* [x] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [x] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
