### PR TITLE
Small DHT propagate fix

### DIFF
--- a/comms/dht/examples/memory_net/drain_burst.rs
+++ b/comms/dht/examples/memory_net/drain_burst.rs
@@ -1,0 +1,87 @@
+// Copyright 2020, The Tari Project
+//
+// Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+// following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+// disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+// following disclaimer in the documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+// products derived from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+// INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+// WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+// USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+use futures::{Future, Stream, StreamExt};
+use std::{
+    pin::Pin,
+    task::{Context, Poll},
+};
+
+pub struct DrainBurst<'a, St>
+where St: Stream + ?Sized
+{
+    inner: &'a mut St,
+    collection: Vec<St::Item>,
+}
+
+impl<St: ?Sized + Unpin + Stream> Unpin for DrainBurst<'_, St> {}
+
+impl<'a, St> DrainBurst<'a, St>
+where St: ?Sized + Stream + Unpin
+{
+    pub fn new(stream: &'a mut St) -> Self {
+        let (lower_bound, upper_bound) = stream.size_hint();
+        Self {
+            inner: stream,
+            collection: Vec::with_capacity(upper_bound.or(Some(lower_bound)).unwrap()),
+        }
+    }
+}
+
+impl<St> Future for DrainBurst<'_, St>
+where St: ?Sized + Stream + Unpin
+{
+    type Output = Vec<St::Item>;
+
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        loop {
+            match self.inner.poll_next_unpin(cx) {
+                Poll::Ready(Some(item)) => {
+                    self.collection.push(item);
+                },
+                Poll::Ready(None) | Poll::Pending => {
+                    break Poll::Ready(self.collection.drain(..).collect());
+                },
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use futures::stream;
+
+    #[tokio_macros::test_basic]
+    async fn drain_terminating_stream() {
+        let mut stream = stream::iter(1..10u8);
+        let burst = DrainBurst::new(&mut stream).await;
+        assert_eq!(burst, (1..10u8).into_iter().collect::<Vec<_>>());
+    }
+
+    #[tokio_macros::test_basic]
+    async fn drain_stream_with_pending() {
+        let mut stream = stream::iter(1..10u8);
+        let burst = DrainBurst::new(&mut stream).await;
+        assert_eq!(burst, (1..10u8).into_iter().collect::<Vec<_>>());
+    }
+}

--- a/comms/dht/examples/memory_net/mod.rs
+++ b/comms/dht/examples/memory_net/mod.rs
@@ -1,0 +1,24 @@
+// Copyright 2020, The Tari Project
+//
+// Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+// following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+// disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+// following disclaimer in the documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+// products derived from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+// INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+// WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+// USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+mod drain_burst;
+pub use drain_burst::DrainBurst;

--- a/comms/dht/src/logging_middleware.rs
+++ b/comms/dht/src/logging_middleware.rs
@@ -86,7 +86,7 @@ where
     }
 
     fn call(&mut self, msg: R) -> Self::Future {
-        trace!(target: LOG_TARGET, "{}{}", self.prefix_msg, msg);
+        debug!(target: LOG_TARGET, "{}{}", self.prefix_msg, msg);
         let mut inner = self.inner.clone();
         async move {
             inner.ready().await?;

--- a/comms/src/peer_manager/manager.rs
+++ b/comms/src/peer_manager/manager.rs
@@ -147,6 +147,11 @@ impl PeerManager {
         self.peer_storage.read().await.exists_node_id(node_id)
     }
 
+    /// Returns all peers
+    pub async fn all(&self) -> Result<Vec<Peer>, PeerManagerError> {
+        self.peer_storage.read().await.all()
+    }
+
     /// Get a peer matching the given node ID
     pub async fn direct_identity_node_id(&self, node_id: &NodeId) -> Result<Option<Peer>, PeerManagerError> {
         match self.peer_storage.read().await.direct_identity_node_id(&node_id) {

--- a/comms/src/peer_manager/peer_storage.rs
+++ b/comms/src/peer_manager/peer_storage.rs
@@ -272,6 +272,16 @@ where DS: KeyValueStore<PeerId, Peer>
         query.executor(&self.peer_db).get_results()
     }
 
+    /// Return all peers
+    pub fn all(&self) -> Result<Vec<Peer>, PeerManagerError> {
+        let mut peers = Vec::with_capacity(self.peer_db.size()?);
+        self.peer_db.for_each_ok(|(_, peer)| {
+            peers.push(peer);
+            IterationResult::Continue
+        })?;
+        Ok(peers)
+    }
+
     /// Compile a list of all known peers
     pub fn flood_peers(&self) -> Result<Vec<Peer>, PeerManagerError> {
         self.peer_db


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
- Dht closest peer selection was not taking ClosestPeerRequest::features
  into account. This could lead to messages only being propagated to
  wallet nodes without being propagated to base nodes (which propagate
  messages further)
- Memorynet testing/demonstrating discovery with 3 different levels of
  privacy
