### PR TITLE
Update transaction service to monitor for completed tx’s being mined

### DIFF
--- a/base_layer/wallet/src/output_manager_service/service.rs
+++ b/base_layer/wallet/src/output_manager_service/service.rs
@@ -323,7 +323,7 @@ where
 
         // If there are any remaining Unspent Outputs we will move them to the invalid collection
         for (_k, v) in output_hashes {
-            debug!(
+            warn!(
                 target: LOG_TARGET,
                 "Output with value {} not returned from Base Node query and is thus being invalidated", v.value
             );


### PR DESCRIPTION
## Description
Currently the Transaction service monitors for CompletedTransactions being Broadcast and then after that transition for Broadcast transactions to change to being Mined. However if for some reason the Transaction service missed a transaction being broadcast and it moves straight to being mined the Transaction service wouldn’t note that. 

This PR updates the transaction service to also check if Completed Transactions are mined and not just broadcast to cater for this case.

## How Has This Been Tested?
Tests updated to cater for this change

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [x] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [x] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch.
* [x] I ran `cargo-fmt --all` before pushing.
* [ ] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
