### PR TITLE
Ban sync peers that provide invalid blocks and responses

### DIFF
--- a/applications/tari_base_node/src/builder.rs
+++ b/applications/tari_base_node/src/builder.rs
@@ -465,6 +465,8 @@ where
     let node = BaseNodeStateMachine::new(
         &db,
         &outbound_interface,
+        base_node_comms.peer_manager(),
+        base_node_comms.connection_manager(),
         chain_metadata_service.get_event_stream(),
         BaseNodeStateMachineConfig::default(),
         interrupt_signal,

--- a/base_layer/core/src/base_node/states/listening.rs
+++ b/base_layer/core/src/base_node/states/listening.rs
@@ -35,27 +35,9 @@ use crate::{
 };
 use futures::stream::StreamExt;
 use log::*;
-use std::collections::VecDeque;
 use tari_comms::peer_manager::NodeId;
 
 const LOG_TARGET: &str = "c::bn::states::listening";
-
-// The number of liveness rounds that need to be included when determining the best network tip.
-const METADATA_LIVENESS_ROUNDS: usize = 1;
-
-/// Configuration for the Listening state.
-#[derive(Clone, Copy, Debug)]
-pub struct ListeningConfig {
-    pub metadata_liveness_rounds: usize,
-}
-
-impl Default for ListeningConfig {
-    fn default() -> Self {
-        Self {
-            metadata_liveness_rounds: METADATA_LIVENESS_ROUNDS,
-        }
-    }
-}
 
 /// This state listens for chain metadata events received from the liveness and chain metadata service. Based on the
 /// received metadata, if it detects that the current node is lagging behind the network it will switch to block sync
@@ -67,41 +49,30 @@ impl ListeningInfo {
     pub async fn next_event<B: BlockchainBackend>(&mut self, shared: &mut BaseNodeStateMachine<B>) -> StateEvent {
         info!(target: LOG_TARGET, "Listening for chain metadata updates");
 
-        let mut metadata_rounds = VecDeque::<Vec<PeerChainMetadata>>::new();
         let mut metadata_event_stream = shared.metadata_event_stream.clone().fuse();
-
         while let Some(metadata_event) = metadata_event_stream.next().await {
             match &*metadata_event {
-                ChainMetadataEvent::PeerChainMetadataReceived(chain_metadata_list) => {
-                    if !chain_metadata_list.is_empty() {
-                        // Update the metadata queue
-                        if metadata_rounds.len() >= shared.config.listening_config.metadata_liveness_rounds {
-                            metadata_rounds.pop_front();
-                        }
-                        metadata_rounds.push_back(chain_metadata_list.clone());
-
-                        if metadata_rounds.len() == shared.config.listening_config.metadata_liveness_rounds {
-                            info!(target: LOG_TARGET, "Loading local blockchain metadata.");
-                            let local = match shared.db.get_metadata() {
-                                Ok(m) => m,
-                                Err(e) => {
-                                    let msg = format!("Could not get local blockchain metadata. {}", e.to_string());
-                                    return FatalError(msg);
-                                },
-                            };
-                            // Find the best network metadata and set of sync peers with the best tip.
-                            let metadata_list = metadata_rounds
-                                .iter()
-                                .flatten()
-                                .map(|peer_metadata| peer_metadata.chain_metadata.clone())
-                                .collect::<Vec<_>>();
-                            let best_metadata = best_metadata(metadata_list);
-                            let sync_peers = find_sync_peers(&best_metadata, &metadata_rounds);
-                            if let SyncStatus::Lagging(network_tip, sync_peers) =
-                                determine_sync_mode(&local, best_metadata, sync_peers, LOG_TARGET)
-                            {
-                                return StateEvent::FallenBehind(SyncStatus::Lagging(network_tip, sync_peers));
-                            }
+                ChainMetadataEvent::PeerChainMetadataReceived(peer_metadata_list) => {
+                    if !peer_metadata_list.is_empty() {
+                        info!(target: LOG_TARGET, "Loading local blockchain metadata.");
+                        let local = match shared.db.get_metadata() {
+                            Ok(m) => m,
+                            Err(e) => {
+                                let msg = format!("Could not get local blockchain metadata. {}", e.to_string());
+                                return FatalError(msg);
+                            },
+                        };
+                        // Find the best network metadata and set of sync peers with the best tip.
+                        let metadata_list = peer_metadata_list
+                            .iter()
+                            .map(|peer_metadata| peer_metadata.chain_metadata.clone())
+                            .collect::<Vec<_>>();
+                        let best_metadata = best_metadata(metadata_list);
+                        let sync_peers = find_sync_peers(&best_metadata, &peer_metadata_list);
+                        if let SyncStatus::Lagging(network_tip, sync_peers) =
+                            determine_sync_mode(&local, best_metadata, sync_peers, LOG_TARGET)
+                        {
+                            return StateEvent::FallenBehind(SyncStatus::Lagging(network_tip, sync_peers));
                         }
                     }
                 },
@@ -112,14 +83,14 @@ impl ListeningInfo {
             target: LOG_TARGET,
             "Event listener is complete because liveness metadata and timeout streams were closed"
         );
-        return StateEvent::UserQuit;
+        StateEvent::UserQuit
     }
 }
 
 // Finds the set of sync peers that have the best tip on their main chain.
-fn find_sync_peers(best_metadata: &ChainMetadata, metadata_rounds: &VecDeque<Vec<PeerChainMetadata>>) -> Vec<NodeId> {
+fn find_sync_peers(best_metadata: &ChainMetadata, peer_metadata_list: &Vec<PeerChainMetadata>) -> Vec<NodeId> {
     let mut sync_peers = Vec::<NodeId>::new();
-    for peer_metadata in metadata_rounds.iter().flatten() {
+    for peer_metadata in peer_metadata_list {
         if peer_metadata.chain_metadata == *best_metadata {
             sync_peers.push(peer_metadata.node_id.clone());
         }

--- a/base_layer/core/src/base_node/states/mod.rs
+++ b/base_layer/core/src/base_node/states/mod.rs
@@ -111,6 +111,6 @@ mod shutdown_state;
 mod starting_state;
 
 pub use block_sync::{BlockSyncConfig, BlockSyncInfo};
-pub use listening::{ListeningConfig, ListeningInfo};
+pub use listening::ListeningInfo;
 pub use shutdown_state::Shutdown;
 pub use starting_state::Starting;

--- a/base_layer/core/tests/helpers/block_builders.rs
+++ b/base_layer/core/tests/helpers/block_builders.rs
@@ -56,7 +56,7 @@ use tari_mmr::MutableMmr;
 
 const MAINNET: Network = Network::MainNet;
 
-fn create_coinbase(
+pub fn create_coinbase(
     factories: &CryptoFactories,
     value: MicroTari,
     maturity_height: u64,


### PR DESCRIPTION
## Description
- Modified block syncing to keep track of sync peers during requests and ban bad nodes when they provide invalid blocks or respond incorrectly.
- The ban will ensure that they wont be able to establish connections in the future and wont be able to influence the local nodes block syncing.
- Removed the accumulation of the different metadata rounds as some of these peers might have been banned in later rounds.
- Removed the unused ListeningConfig.

## Motivation and Context
This will enable nodes to detect bad nodes and exclude them from their local network.

## How Has This Been Tested?
A test was added to demonstrate the banning of sync peers: test_sync_peer_banning.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [x] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [x] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch.
* [x] I ran `cargo-fmt --all` before pushing.
* [x] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
