### PR TITLE
Fix Mutex dereference bug in the Contacts service

### DIFF
--- a/base_layer/wallet/src/contacts_service/storage/sqlite_db.rs
+++ b/base_layer/wallet/src/contacts_service/storage/sqlite_db.rs
@@ -56,7 +56,7 @@ impl ContactsBackend for ContactsServiceSqliteDatabase {
                 Err(e) => return Err(e),
             },
             DbKey::Contacts => Some(DbValue::Contacts(
-                ContactSql::index(&conn)?
+                ContactSql::index(&(*conn))?
                     .iter()
                     .map(|c| Contact::try_from(c.clone()))
                     .collect::<Result<Vec<_>, _>>()?,


### PR DESCRIPTION
Did not properly dereference a MutexGuard.