### PR TITLE
Fix bug when retrying message send in MessagingProtocol

### DIFF
--- a/comms/src/builder/consts.rs
+++ b/comms/src/builder/consts.rs
@@ -40,5 +40,6 @@ pub const MESSAGING_EVENTS_BUFFER_SIZE: usize = 100;
 /// Buffer size for requests to the messaging protocol. All outbound messages will be sent along this channel. Some
 /// buffering may be required if the node needs to send many messages out at the same time.
 pub const MESSAGING_REQUEST_BUFFER_SIZE: usize = 50;
-/// The default maximum number of times to retry sending a failed message before publishing a SendMessageFailed event
-pub const MESSAGING_MAX_SEND_RETRIES: usize = 3;
+/// The default maximum number of times to retry sending a failed message before publishing a SendMessageFailed event.
+/// This can be low because dialing a peer is already attempted a number of times.
+pub const MESSAGING_MAX_SEND_RETRIES: usize = 2;


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Messaging protocol makes a contract with clients that for every message
sent, you will either get back a MessageSent or SendMessageFailed event
for that (tagged) message.

Messaging protocol did not add the message to the retry queue after
one attempt. As a side effect of the bug, the above contract was broken.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
See description

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Changed existing unit test to attempt sending more than once and updated asserts to match expected results   

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch.
* [x] I ran `cargo-fmt --all` before pushing.
* [x] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
