### PR TITLE
Update default logging settings

### DIFF
--- a/common/logging/log4rs-debug-sample.yml
+++ b/common/logging/log4rs-debug-sample.yml
@@ -68,23 +68,28 @@ appenders:
     encoder:
       pattern: "{d(%Y-%m-%d %H:%M:%S.%f)} [{t}] {l:5} {m}{n}"
 
-# Set the default logging level to "error" and attach the "stdout" appender to the root
+# Set the default logging level to "warn" and attach the "stdout" appender to the root
 root:
-  level: trace
+  level: warn
   appenders:
-    - base_layer
+    - stdout
 
 loggers:
-  # Set the maximum console output to "info"
-  base_node:
-    level: info
+  # Route log events sent to the "core" logger to the "base_layer" appender
+  c:
+    level: debug
     appenders:
-      - stdout
+      - base_layer
     additive: false
-
+  # Route log events sent to the "wallet" logger to the "base_layer" appender
+  wallet:
+    level: debug
+    appenders:
+      - base_layer
+    additive: false
   # Route log events sent to the "comms" logger to the "network" appender
   comms:
-    level: trace
+    level: debug
     appenders:
       - network
     additive: false

--- a/common/logging/log4rs-sample.yml
+++ b/common/logging/log4rs-sample.yml
@@ -68,27 +68,31 @@ appenders:
     encoder:
       pattern: "{d(%Y-%m-%d %H:%M:%S.%f)} [{t}] {l:5} {m}{n}"
 
-# Set the default logging level to "error" and attach the "stdout" appender to the root
+# Set the default logging level to "warn" and attach the "stdout" appender to the root
 root:
-  level: info
+  level: warn
   appenders:
-    - base_layer
+    - stdout
 
 loggers:
-  # Set the maximum console output to "info"
-  base_node:
+  # Route log events sent to the "core" logger to the "base_layer" appender
+  c:
     level: info
     appenders:
-      - stdout
+      - base_layer
     additive: false
-
+  # Route log events sent to the "wallet" logger to the "base_layer" appender
+  wallet:
+    level: info
+    appenders:
+      - base_layer
+    additive: false
   # Route log events sent to the "comms" logger to the "network" appender
   comms:
     level: info
     appenders:
       - network
     additive: false
-  # Route log events sent to the "p2p" logger to the "network" appender
   p2p:
     level: info
     appenders:


### PR DESCRIPTION
## Description
Update the default logging settings so only Warn ends up in std_out and base_node message end up in the base_layer appender. Also updated the comments.

## Motivation and Context
Default logging is stale as targets have changed.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch.
* [x] I ran `cargo-fmt --all` before pushing.
* [ ] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [x] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
