### PR TITLE
Upgraded yamux 0.4.5

### DIFF
--- a/comms/Cargo.toml
+++ b/comms/Cargo.toml
@@ -36,7 +36,7 @@ snow = {version="0.6.2", features=["default-resolver"]}
 tokio = {version="^0.2", features=["blocking", "tcp", "stream", "dns", "sync", "stream", "signal"]}
 tokio-util = {version="0.2.0", features=["codec"]}
 tower= "0.3.1"
-yamux = {version="0.4.4"}
+yamux = "0.4.5"
 
 [dev-dependencies]
 tari_test_utils = {version="0.0.9", path="../infrastructure/test_utils"}

--- a/comms/src/connection_manager/common.rs
+++ b/comms/src/connection_manager/common.rs
@@ -51,7 +51,7 @@ pub async fn perform_identity_exchange<'p, P: IntoIterator<Item = &'p ProtocolId
             .incoming_mut()
             .next()
             .await
-            .ok_or_else(|| ConnectionManagerError::IncomingListenerStreamClosed)??,
+            .ok_or_else(|| ConnectionManagerError::IncomingListenerStreamClosed)?,
         ConnectionDirection::Outbound => control.open_stream().await?,
     };
 

--- a/comms/src/connection_manager/peer_connection.rs
+++ b/comms/src/connection_manager/peer_connection.rs
@@ -238,7 +238,7 @@ impl PeerConnectionActor {
 
                 maybe_substream = self.incoming_substreams.next() => {
                     match maybe_substream {
-                        Some(Ok(substream)) => {
+                        Some(substream) => {
                             if let Err(err) = self.handle_incoming_substream(substream).await {
                                 error!(
                                     target: LOG_TARGET,
@@ -248,10 +248,6 @@ impl PeerConnectionActor {
                                     error = err
                                 )
                             }
-                        },
-                        Some(Err(err)) => {
-                            warn!(target: LOG_TARGET, "[{}] Incoming substream error '{}'. Closing connection for peer '{}'", self, err, self.peer_node_id.short_str());
-                            self.disconnect(false).await;
                         },
                         None => {
                             debug!(target: LOG_TARGET, "[{}] Peer '{}' closed the connection", self, self.peer_node_id.short_str());

--- a/comms/src/protocol/messaging/test.rs
+++ b/comms/src/protocol/messaging/test.rs
@@ -137,7 +137,7 @@ async fn new_inbound_substream_handling() {
         .await
         .unwrap();
 
-    let stream_theirs = muxer_theirs.incoming_mut().next().await.unwrap().unwrap();
+    let stream_theirs = muxer_theirs.incoming_mut().next().await.unwrap();
     let mut framed_theirs = MessagingProtocol::framed(stream_theirs);
 
     let envelope = Envelope::construct_signed(&sk, &pk, TEST_MSG1, MessageFlags::empty()).unwrap();

--- a/comms/src/test_utils/mocks/peer_connection.rs
+++ b/comms/src/test_utils/mocks/peer_connection.rs
@@ -101,7 +101,7 @@ impl PeerConnectionMockState {
     }
 
     pub async fn next_incoming_substream(&self) -> Option<yamux::Stream> {
-        self.mux_incoming.lock().await.next().await.map(Result::unwrap)
+        self.mux_incoming.lock().await.next().await
     }
 
     pub async fn disconnect(&self) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
0.4.5 includes yamux PR 80. This PR closes the stream after an error is
received. This is expected behaviour for streams.

There is no need to send a Result out of inbound substreams, so that
simplified the code a bit.


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Removed the need to handle error edge cases in the yamux worker. yamux#80 removed the possibility of the endless loop log flooding issue.  

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Existing tests do a decent job at testing for this.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [x] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch.
* [x] I ran `cargo-fmt --all` before pushing.
* [x] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
