### PR TITLE
Mempool logs and handling of invalid transactions

### DIFF
--- a/base_layer/core/src/base_node/service/service.rs
+++ b/base_layer/core/src/base_node/service/service.rs
@@ -423,7 +423,7 @@ async fn handle_incoming_response(
         let _ = reply_tx.send(Ok(response).or_else(|resp| {
             warn!(
                 target: LOG_TARGET,
-                "Failed to send outbound request from Base Node: {}", resp
+                "Failed to finalize request (request key:{}): {:?}", &request_key, resp
             );
             Err(resp)
         }));
@@ -469,7 +469,7 @@ async fn handle_outbound_request(
                 .or_else(|resp| {
                     error!(
                         target: LOG_TARGET,
-                        "Failed to send outbound request from Base Node as no bootstrap nodes were configured"
+                        "Failed to send outbound request as no bootstrap nodes were configured"
                     );
                     Err(resp)
                 });
@@ -488,7 +488,7 @@ async fn handle_outbound_request(
                 .or_else(|resp| {
                     error!(
                         target: LOG_TARGET,
-                        "Failed to send outbound request from Base Node because DHT outbound broadcast failed"
+                        "Failed to send outbound request because DHT outbound broadcast failed"
                     );
                     Err(resp)
                 });
@@ -531,7 +531,7 @@ async fn handle_request_timeout(
         let _ = reply_tx.send(reply_msg.or_else(|resp| {
             error!(
                 target: LOG_TARGET,
-                "Failed to send outbound request (request key: {}) from Base Node: {:?}", &request_key, resp
+                "Failed to send outbound request (request key: {}): {:?}", &request_key, resp
             );
             Err(resp)
         }));

--- a/base_layer/core/src/base_node/states/block_sync.rs
+++ b/base_layer/core/src/base_node/states/block_sync.rs
@@ -144,7 +144,7 @@ impl BlockSyncInfo {
                 warn!(target: LOG_TARGET, "An empty network best block hash was received.",);
                 StateEvent::BlockSyncFailure
             },
-            Err(e) => StateEvent::FatalError(format!("Synchronizing blocks failed. {}", e)),
+            Err(e) => StateEvent::FatalError(format!("Synchronizing blocks failed. {:?}", e)),
         }
     }
 }

--- a/base_layer/core/src/mempool/async_mempool.rs
+++ b/base_layer/core/src/mempool/async_mempool.rs
@@ -62,7 +62,7 @@ macro_rules! make_async {
     };
 }
 
-make_async!(insert(tx: Arc<Transaction>) -> ());
+make_async!(insert(tx: Arc<Transaction>) -> TxStorageResponse);
 make_async!(process_published_block(published_block: Block) -> ());
 make_async!(process_reorg(removed_blocks: Vec<Block>, new_blocks: Vec<Block>) -> ());
 make_async!(snapshot() -> Vec<Arc<Transaction>>);

--- a/base_layer/core/src/mempool/mod.rs
+++ b/base_layer/core/src/mempool/mod.rs
@@ -57,6 +57,8 @@ pub use service::{MempoolServiceError, MempoolServiceInitializer, OutboundMempoo
 pub mod proto;
 #[cfg(any(feature = "base_node", feature = "mempool_proto"))]
 pub mod service;
+
+use core::fmt::{Display, Error, Formatter};
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
@@ -76,4 +78,17 @@ pub enum TxStorageResponse {
     PendingPool,
     ReorgPool,
     NotStored,
+}
+
+impl Display for TxStorageResponse {
+    fn fmt(&self, fmt: &mut Formatter<'_>) -> Result<(), Error> {
+        let storage = match self {
+            TxStorageResponse::UnconfirmedPool => "Unconfirmed pool",
+            TxStorageResponse::OrphanPool => "Orphan pool",
+            TxStorageResponse::PendingPool => "Pending pool",
+            TxStorageResponse::ReorgPool => "Reorg pool",
+            TxStorageResponse::NotStored => "Not stored",
+        };
+        fmt.write_str(&storage.to_string())
+    }
 }

--- a/base_layer/core/src/mempool/orphan_pool/orphan_pool_storage.rs
+++ b/base_layer/core/src/mempool/orphan_pool/orphan_pool_storage.rs
@@ -28,6 +28,7 @@ use crate::{
 };
 use log::*;
 use std::sync::Arc;
+use tari_crypto::tari_utilities::hex::Hex;
 use ttl_cache::TtlCache;
 
 pub const LOG_TARGET: &str = "c::mp::orphan_pool::orphan_pool_storage";
@@ -66,8 +67,13 @@ where T: BlockchainBackend
     /// Insert a new transaction into the OrphanPoolStorage. Orphaned transactions will have a limited Time-to-live and
     /// will be discarded if the UTXOs they require are not created before the Time-to-live threshold is reached.
     pub fn insert(&mut self, tx: Arc<Transaction>) {
-        trace!(target: LOG_TARGET, "Adding tx to orphan pool: {:?}", tx.clone());
         let tx_key = tx.body.kernels()[0].excess_sig.clone();
+        debug!(
+            target: LOG_TARGET,
+            "Inserting tx into orphan pool: {}",
+            tx_key.get_signature().to_hex()
+        );
+        trace!(target: LOG_TARGET, "Transaction inserted: {}", tx);
         let _ = self.txs_by_signature.insert(tx_key, tx, self.config.tx_ttl);
     }
 

--- a/base_layer/core/src/mempool/pending_pool/pending_pool_storage.rs
+++ b/base_layer/core/src/mempool/pending_pool/pending_pool_storage.rs
@@ -34,6 +34,7 @@ use std::{
     convert::TryFrom,
     sync::Arc,
 };
+use tari_crypto::tari_utilities::hex::Hex;
 
 pub const LOG_TARGET: &str = "c::mp::pending_pool::pending_pool_storage";
 
@@ -91,7 +92,12 @@ impl PendingPoolStorage {
     pub fn insert(&mut self, tx: Arc<Transaction>) -> Result<(), PendingPoolError> {
         let tx_key = tx.body.kernels()[0].excess_sig.clone();
         if !self.txs_by_signature.contains_key(&tx_key) {
-            trace!(target: LOG_TARGET, "Inserting tx into pending pool: {:?}", tx_key,);
+            debug!(
+                target: LOG_TARGET,
+                "Inserting tx into pending pool: {}",
+                tx_key.get_signature().to_hex()
+            );
+            trace!(target: LOG_TARGET, "Transaction inserted: {}", tx);
             let prioritized_tx = TimelockedTransaction::try_from((*tx).clone())?;
             if self.txs_by_signature.len() >= self.config.storage_capacity {
                 if prioritized_tx.fee_priority < *self.lowest_fee_priority() {

--- a/base_layer/core/src/mempool/reorg_pool/reorg_pool_storage.rs
+++ b/base_layer/core/src/mempool/reorg_pool/reorg_pool_storage.rs
@@ -27,7 +27,9 @@ use crate::{
 };
 use log::*;
 use std::sync::Arc;
+use tari_crypto::tari_utilities::hex::Hex;
 use ttl_cache::TtlCache;
+
 pub const LOG_TARGET: &str = "c::mp::reorg_pool::reorg_pool_storage";
 
 /// Reorg makes use of ReorgPoolStorage to provide thread save access to its TtlCache.
@@ -54,7 +56,12 @@ impl ReorgPoolStorage {
     /// the ReorgPoolStorage and will be discarded once the Time-to-live threshold has been reached.
     pub fn insert(&mut self, tx: Arc<Transaction>) {
         let tx_key = tx.body.kernels()[0].excess_sig.clone();
-        trace!(target: LOG_TARGET, "Inserting tx into reorg pool: {:?}", tx_key,);
+        trace!(
+            target: LOG_TARGET,
+            "Inserting tx into reorg pool: {}",
+            tx_key.get_signature().to_hex()
+        );
+        trace!(target: LOG_TARGET, "Transaction inserted: {}", tx);
         let _ = self.txs_by_signature.insert(tx_key, tx, self.config.tx_ttl);
     }
 

--- a/base_layer/core/src/mempool/service/request.rs
+++ b/base_layer/core/src/mempool/service/request.rs
@@ -21,13 +21,26 @@
 //  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 use crate::{base_node::RequestKey, transactions::types::Signature};
+use core::fmt::{Display, Error, Formatter};
 use serde::{Deserialize, Serialize};
+use tari_crypto::tari_utilities::hex::Hex;
 
 /// API Request enum for Mempool requests.
 #[derive(Debug, Serialize, Deserialize)]
 pub enum MempoolRequest {
     GetStats,
     GetTxStateWithExcessSig(Signature),
+}
+
+impl Display for MempoolRequest {
+    fn fmt(&self, f: &mut Formatter) -> Result<(), Error> {
+        match self {
+            MempoolRequest::GetStats => f.write_str("GetStats"),
+            MempoolRequest::GetTxStateWithExcessSig(sig) => {
+                f.write_str(&format!("GetTxStateWithExcessSig ({})", sig.get_signature().to_hex()))
+            },
+        }
+    }
 }
 
 /// Request type for a received MempoolService request.

--- a/base_layer/core/src/mempool/unconfirmed_pool/unconfirmed_pool_storage.rs
+++ b/base_layer/core/src/mempool/unconfirmed_pool/unconfirmed_pool_storage.rs
@@ -34,6 +34,8 @@ use std::{
     convert::TryFrom,
     sync::Arc,
 };
+use tari_crypto::tari_utilities::hex::Hex;
+
 pub const LOG_TARGET: &str = "c::mp::unconfirmed_pool::unconfirmed_pool_storage";
 
 /// UnconfirmedPool makes use of UnconfirmedPoolStorage to provide thread save access to its Hashmap and BTreeMap.
@@ -77,7 +79,12 @@ impl UnconfirmedPoolStorage {
     pub fn insert(&mut self, tx: Arc<Transaction>) -> Result<(), UnconfirmedPoolError> {
         let tx_key = tx.body.kernels()[0].excess_sig.clone();
         if !self.txs_by_signature.contains_key(&tx_key) {
-            trace!(target: LOG_TARGET, "Inserting tx into unconfirmed pool: {:?}", tx_key,);
+            debug!(
+                target: LOG_TARGET,
+                "Inserting tx into unconfirmed pool: {}",
+                tx_key.get_signature().to_hex()
+            );
+            trace!(target: LOG_TARGET, "Transaction inserted: {}", tx);
             let prioritized_tx = PrioritizedTransaction::try_from((*tx).clone())?;
             if self.txs_by_signature.len() >= self.config.storage_capacity {
                 if prioritized_tx.priority < *self.lowest_priority() {

--- a/base_layer/core/src/transactions/transaction.rs
+++ b/base_layer/core/src/transactions/transaction.rs
@@ -683,6 +683,16 @@ impl Add for Transaction {
     }
 }
 
+impl Display for Transaction {
+    fn fmt(&self, fmt: &mut Formatter<'_>) -> Result<(), std::fmt::Error> {
+        fmt.write_str("-------------- Transaction --------------\n")?;
+        fmt.write_str("--- Offset ---\n")?;
+        fmt.write_str(&format!("{}\n", self.offset.to_hex()))?;
+        fmt.write_str("---  Body  ---\n")?;
+        fmt.write_str(&format!("{}\n", self.body))
+    }
+}
+
 //----------------------------------------  Transaction Builder   ----------------------------------------------------//
 pub struct TransactionBuilder {
     body: AggregateBody,

--- a/base_layer/core/tests/mempool.rs
+++ b/base_layer/core/tests/mempool.rs
@@ -446,7 +446,9 @@ fn test_orphaned_mempool_transactions() {
     // There are 2 orphan txs
     vec![txns[2].clone(), txns2[0].clone(), txns2[1].clone(), txns2[2].clone()]
         .into_iter()
-        .for_each(|t| mempool.insert(t).unwrap());
+        .for_each(|t| {
+            let _ = mempool.insert(t).unwrap();
+        });
 
     let stats = mempool.stats().unwrap();
     assert_eq!(stats.total_txs, 4);

--- a/base_layer/core/tests/node_state_machine.rs
+++ b/base_layer/core/tests/node_state_machine.rs
@@ -41,7 +41,6 @@ use helpers::{
         BaseNodeBuilder,
     },
 };
-use log::debug;
 use rand::{rngs::OsRng, RngCore};
 use std::time::Duration;
 use tari_core::{


### PR DESCRIPTION
## Description
- Changed the handling of an incoming transaction in the mempool service so it only logs an error when a received transaction fails validation and does not return an error result.
- Added more detailed log messaging into mempool service, handlers, mempool and the different sub pools.
- Added display implementations for TxStorageResponse, MempoolRequest and Transaction.
- Modified mempool insert to return which pool a transaction has been inserted into, this will make the log messages more descriptive.

## Motivation and Context
These changes will make tracking of a transaction using logs simpler and will ensure the mempool service remains operational when an invalid transaction is received.

## How Has This Been Tested?
Existing tests cover changes.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch.
* [x] I ran `cargo-fmt --all` before pushing.
* [x] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
