### PR TITLE
Cleanup public key or emoji ID input

### DIFF
--- a/applications/tari_base_node/src/parser.rs
+++ b/applications/tari_base_node/src/parser.rs
@@ -680,7 +680,7 @@ impl Parser {
 }
 
 fn parse_emoji_id_or_public_key(key: &str) -> Option<CommsPublicKey> {
-    EmojiId::str_to_pubkey(key)
+    EmojiId::str_to_pubkey(&key.trim().replace('|', ""))
         .or_else(|_| CommsPublicKey::from_hex(key))
         .ok()
 }


### PR DESCRIPTION
The android app includes pipes in the copied Emoji ID - this may be
desirable for a visual check but creates extra work when pasting into
a base node. This PR ignores pipes pasted in commands taking public keys/emoji IDs.
