### PR TITLE
Update Transaction Service to handle Discovery and failed sends properly

### DIFF
--- a/base_layer/wallet/migrations/2019-10-30-084148_output_manager_service/up.sql
+++ b/base_layer/wallet/migrations/2019-10-30-084148_output_manager_service/up.sql
@@ -9,6 +9,7 @@ CREATE TABLE outputs (
 
 CREATE TABLE pending_transaction_outputs (
     tx_id INTEGER PRIMARY KEY NOT NULL,
+    short_term INTEGER NOT NULL,
     timestamp DATETIME NOT NULL
 );
 

--- a/base_layer/wallet/src/output_manager_service/storage/memory_db.rs
+++ b/base_layer/wallet/src/output_manager_service/storage/memory_db.rs
@@ -49,6 +49,7 @@ pub struct InnerDatabase {
     spent_outputs: Vec<UnblindedOutput>,
     invalid_outputs: Vec<UnblindedOutput>,
     pending_transactions: HashMap<TxId, PendingTransactionOutputs>,
+    short_term_pending_transactions: HashMap<TxId, PendingTransactionOutputs>,
     key_manager_state: Option<KeyManagerState>,
 }
 
@@ -59,6 +60,7 @@ impl InnerDatabase {
             spent_outputs: Vec::new(),
             invalid_outputs: Vec::new(),
             pending_transactions: HashMap::new(),
+            short_term_pending_transactions: Default::default(),
             key_manager_state: None,
         }
     }
@@ -91,14 +93,21 @@ impl OutputManagerBackend for OutputManagerMemoryDatabase {
                 .iter()
                 .find(|v| &v.spending_key == k)
                 .map(|v| DbValue::UnspentOutput(Box::new(v.clone()))),
-            DbKey::PendingTransactionOutputs(tx_id) => db
-                .pending_transactions
-                .get(tx_id)
-                .map(|v| DbValue::PendingTransactionOutputs(Box::new(v.clone()))),
+            DbKey::PendingTransactionOutputs(tx_id) => {
+                let mut result = db.pending_transactions.get(tx_id);
+                if result.is_none() {
+                    result = db.short_term_pending_transactions.get(&tx_id);
+                }
+                result.map(|v| DbValue::PendingTransactionOutputs(Box::new(v.clone())))
+            },
             DbKey::UnspentOutputs => Some(DbValue::UnspentOutputs(db.unspent_outputs.clone())),
             DbKey::SpentOutputs => Some(DbValue::SpentOutputs(db.spent_outputs.clone())),
             DbKey::AllPendingTransactionOutputs => {
-                Some(DbValue::AllPendingTransactionOutputs(db.pending_transactions.clone()))
+                let mut pending_tx_outputs = db.pending_transactions.clone();
+                for (k, v) in db.short_term_pending_transactions.iter() {
+                    pending_tx_outputs.insert(k.clone(), v.clone());
+                }
+                Some(DbValue::AllPendingTransactionOutputs(pending_tx_outputs))
             },
             DbKey::KeyManagerState => db
                 .key_manager_state
@@ -169,9 +178,13 @@ impl OutputManagerBackend for OutputManagerMemoryDatabase {
 
     fn confirm_transaction(&self, tx_id: TxId) -> Result<(), OutputManagerStorageError> {
         let mut db = acquire_write_lock!(self.db);
-        let mut pending_tx = db
-            .pending_transactions
-            .remove(&tx_id)
+
+        let mut pending_tx = db.pending_transactions.remove(&tx_id);
+        if pending_tx.is_none() {
+            pending_tx = db.short_term_pending_transactions.remove(&tx_id);
+        }
+
+        let mut pending_tx = pending_tx
             .ok_or_else(|| OutputManagerStorageError::ValueNotFound(DbKey::PendingTransactionOutputs(tx_id)))?;
 
         // Add Spent outputs
@@ -187,7 +200,7 @@ impl OutputManagerBackend for OutputManagerMemoryDatabase {
         Ok(())
     }
 
-    fn encumber_outputs(
+    fn short_term_encumber_outputs(
         &self,
         tx_id: TxId,
         outputs_to_send: &[UnblindedOutput],
@@ -215,17 +228,48 @@ impl OutputManagerBackend for OutputManagerMemoryDatabase {
             pending_transaction.outputs_to_be_received.push(co);
         }
 
-        db.pending_transactions.insert(tx_id, pending_transaction);
+        db.short_term_pending_transactions.insert(tx_id, pending_transaction);
 
+        Ok(())
+    }
+
+    fn confirm_encumbered_outputs(&self, tx_id: u64) -> Result<(), OutputManagerStorageError> {
+        let mut db = acquire_write_lock!(self.db);
+
+        let pending_tx = db
+            .short_term_pending_transactions
+            .remove(&tx_id)
+            .ok_or_else(|| OutputManagerStorageError::ValueNotFound(DbKey::PendingTransactionOutputs(tx_id)))?;
+
+        let _ = db.pending_transactions.insert(pending_tx.tx_id, pending_tx);
+
+        Ok(())
+    }
+
+    fn clear_short_term_encumberances(&self) -> Result<(), OutputManagerStorageError> {
+        let db = acquire_write_lock!(self.db);
+
+        let short_term_encumberances = db.short_term_pending_transactions.clone();
+
+        drop(db);
+
+        for tx_id in short_term_encumberances.keys() {
+            self.cancel_pending_transaction(tx_id.clone())?;
+        }
         Ok(())
     }
 
     fn cancel_pending_transaction(&self, tx_id: TxId) -> Result<(), OutputManagerStorageError> {
         let mut db = acquire_write_lock!(self.db);
-        let mut pending_tx = db
-            .pending_transactions
-            .remove(&tx_id)
+        let mut pending_tx = db.pending_transactions.remove(&tx_id);
+
+        if pending_tx.is_none() {
+            pending_tx = db.short_term_pending_transactions.remove(&tx_id);
+        }
+
+        let mut pending_tx = pending_tx
             .ok_or_else(|| OutputManagerStorageError::ValueNotFound(DbKey::PendingTransactionOutputs(tx_id)))?;
+
         for o in pending_tx.outputs_to_be_spent.drain(..) {
             db.unspent_outputs.push(o);
         }
@@ -236,11 +280,18 @@ impl OutputManagerBackend for OutputManagerMemoryDatabase {
     fn timeout_pending_transactions(&self, period: Duration) -> Result<(), OutputManagerStorageError> {
         let db = acquire_write_lock!(self.db);
         let mut transactions_to_be_cancelled = Vec::new();
+
         for (tx_id, pt) in db.pending_transactions.iter() {
             if pt.timestamp + ChronoDuration::from_std(period)? < Utc::now().naive_utc() {
                 transactions_to_be_cancelled.push(tx_id.clone());
             }
         }
+        for (tx_id, pt) in db.short_term_pending_transactions.iter() {
+            if pt.timestamp + ChronoDuration::from_std(period)? < Utc::now().naive_utc() {
+                transactions_to_be_cancelled.push(tx_id.clone());
+            }
+        }
+
         drop(db);
         for t in transactions_to_be_cancelled {
             self.cancel_pending_transaction(t.clone())?;

--- a/base_layer/wallet/src/schema.rs
+++ b/base_layer/wallet/src/schema.rs
@@ -82,11 +82,10 @@ table! {
 table! {
     pending_transaction_outputs (tx_id) {
         tx_id -> BigInt,
+        short_term -> Integer,
         timestamp -> Timestamp,
     }
 }
-
-joinable!(outputs -> pending_transaction_outputs (tx_id));
 
 allow_tables_to_appear_in_same_query!(
     coinbase_transactions,

--- a/base_layer/wallet/src/wallet.rs
+++ b/base_layer/wallet/src/wallet.rs
@@ -140,8 +140,8 @@ where
             .add_initializer(LivenessInitializer::new(
                 LivenessConfig {
                     auto_ping_interval: Some(Duration::from_secs(30)),
-                    enable_auto_join: false,
-                    enable_auto_stored_message_request: false,
+                    enable_auto_join: true,
+                    enable_auto_stored_message_request: true,
                     refresh_neighbours_interval: Default::default(),
                 },
                 Arc::clone(&subscription_factory),

--- a/base_layer/wallet/tests/output_manager_service/storage.rs
+++ b/base_layer/wallet/tests/output_manager_service/storage.rs
@@ -178,6 +178,7 @@ pub fn test_db_backend<T: OutputManagerBackend + 'static>(backend: T) {
     runtime
         .block_on(db.encumber_outputs(2, outputs_to_encumber, Some(uo_change.clone())))
         .unwrap();
+    runtime.block_on(db.confirm_encumbered_outputs(2)).unwrap();
 
     available_balance -= total_encumbered;
     pending_incoming_balance += uo_change.clone().value;
@@ -347,4 +348,88 @@ pub fn test_key_manager_crud_sqlite_db() {
     let connection = run_migration_and_create_sqlite_connection(&format!("{}/{}", db_folder, db_name)).unwrap();
 
     test_key_manager_crud(OutputManagerSqliteDatabase::new(connection));
+}
+
+pub async fn test_short_term_encumberance<T: OutputManagerBackend + 'static>(backend: T) {
+    let factories = CryptoFactories::default();
+
+    let db = OutputManagerDatabase::new(backend);
+
+    // Add a pending tx
+    let mut available_balance = MicroTari(0);
+    let mut pending_tx = PendingTransactionOutputs {
+        tx_id: OsRng.next_u64(),
+        outputs_to_be_spent: vec![],
+        outputs_to_be_received: vec![],
+        timestamp: Utc::now().naive_utc() - ChronoDuration::from_std(Duration::from_millis(120_000_000)).unwrap(),
+    };
+    for i in 1..4 {
+        let (_ti, uo) = make_input(&mut OsRng, MicroTari::from(1000 * i), &factories.commitment);
+        available_balance += uo.value.clone();
+        db.add_unspent_output(uo.clone()).await.unwrap();
+        pending_tx.outputs_to_be_spent.push(uo);
+    }
+
+    let (_ti, uo) = make_input(&mut OsRng, MicroTari::from(50), &factories.commitment);
+    pending_tx.outputs_to_be_received.push(uo);
+
+    db.encumber_outputs(
+        pending_tx.tx_id,
+        pending_tx.outputs_to_be_spent.clone(),
+        Some(pending_tx.outputs_to_be_received[0].clone()),
+    )
+    .await
+    .unwrap();
+
+    let balance = db.get_balance().await.unwrap();
+    assert_eq!(balance.available_balance, MicroTari(0));
+
+    db.clear_short_term_encumberances().await.unwrap();
+
+    let balance = db.get_balance().await.unwrap();
+    assert_eq!(available_balance, balance.available_balance);
+
+    db.encumber_outputs(
+        pending_tx.tx_id,
+        pending_tx.outputs_to_be_spent.clone(),
+        Some(pending_tx.outputs_to_be_received[0].clone()),
+    )
+    .await
+    .unwrap();
+
+    db.confirm_encumbered_outputs(pending_tx.tx_id).await.unwrap();
+    db.clear_short_term_encumberances().await.unwrap();
+
+    let balance = db.get_balance().await.unwrap();
+    assert_eq!(balance.available_balance, MicroTari(0));
+
+    db.cancel_pending_transaction_outputs(pending_tx.tx_id).await.unwrap();
+
+    db.encumber_outputs(
+        pending_tx.tx_id,
+        pending_tx.outputs_to_be_spent.clone(),
+        Some(pending_tx.outputs_to_be_received[0].clone()),
+    )
+    .await
+    .unwrap();
+
+    db.confirm_pending_transaction_outputs(pending_tx.tx_id).await.unwrap();
+
+    let balance = db.get_balance().await.unwrap();
+    assert_eq!(balance.available_balance, pending_tx.outputs_to_be_received[0].value);
+}
+
+#[tokio_macros::test]
+pub async fn test_short_term_encumberance_memory_db() {
+    test_short_term_encumberance(OutputManagerMemoryDatabase::new()).await;
+}
+
+#[tokio_macros::test]
+pub async fn test_short_term_encumberance_sqlite_db() {
+    let db_name = format!("{}.sqlite3", random_string(8).as_str());
+    let temp_dir = TempDir::new(random_string(8).as_str()).unwrap();
+    let db_folder = temp_dir.path().to_str().unwrap().to_string();
+    let connection = run_migration_and_create_sqlite_connection(&format!("{}/{}", db_folder, db_name)).unwrap();
+
+    test_short_term_encumberance(OutputManagerSqliteDatabase::new(connection)).await;
 }


### PR DESCRIPTION
## Description
The behaviour in the transaction service when sending transaction where discovery failed or when discovery passed but the actually sending failed was wrong. It results in a pending transaction being added to the wallet that could never be completed as it was never sent and will never be resent. Another issue was that if during discovery the app was closed or crashed the encumbered UTXOs will never be released. The idea of short-term encumbrance was added to the Output Manager service to deal with this.

This PR implements the following:
- The handling of the flow of sending a transaction with the various permutation of discovery and send failure are now handled correctly
- Found a bug in the MessageEvent handling in the Comms layer that signals when a transaction was actually sent and now handles it correctly.
- Added a new short term encumbrance feature to the Output Manager Service to allow for emcumbering UTXO’s while discovery is in progress but if the app is turned off or crashes the encumbrance will be cleared on startup if the transaction did not complete.

## How Has This Been Tested?
Tests provided and updated

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [x] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [x] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch.
* [x] I ran `cargo-fmt --all` before pushing.
* [ ] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
