### PR TITLE
Mempool service submit transaction request

### DIFF
--- a/base_layer/core/src/base_node/comms_interface/inbound_handlers.rs
+++ b/base_layer/core/src/base_node/comms_interface/inbound_handlers.rs
@@ -44,7 +44,7 @@ use std::sync::Arc;
 use strum_macros::Display;
 use tari_broadcast_channel::Publisher;
 use tari_comms::types::CommsPublicKey;
-use tari_crypto::tari_utilities::hex::Hex;
+use tari_crypto::tari_utilities::{hash::Hashable, hex::Hex};
 use tokio::sync::RwLock;
 
 const LOG_TARGET: &str = "c::bn::comms_interface::inbound_handler";
@@ -258,6 +258,11 @@ where T: BlockchainBackend + 'static
                 BlockAddResult::ChainReorg(_) => true,
             };
             if propagate {
+                debug!(
+                    target: LOG_TARGET,
+                    "Propagate block ({}) to network.",
+                    block.hash().to_hex()
+                );
                 let exclude_peers = source_peer.into_iter().collect();
                 self.outbound_nci.propagate_block(block.clone(), exclude_peers).await?;
             }

--- a/base_layer/core/src/mempool/error.rs
+++ b/base_layer/core/src/mempool/error.rs
@@ -42,7 +42,6 @@ pub enum MempoolError {
     ChainStorageError(ChainStorageError),
     /// The Blockchain height is undefined
     ChainHeightUndefined,
-    ValidationError,
     #[error(msg_embedded, non_std, no_from)]
     BlockingTaskSpawnError(String),
 }

--- a/base_layer/core/src/mempool/mempool.rs
+++ b/base_layer/core/src/mempool/mempool.rs
@@ -121,7 +121,7 @@ where T: BlockchainBackend
                 self.pending_pool.insert(tx)?;
                 Ok(TxStorageResponse::PendingPool)
             },
-            _ => Err(MempoolError::ValidationError),
+            _ => Ok(TxStorageResponse::NotStored),
         }
     }
 

--- a/base_layer/core/src/mempool/proto/mempool_request.rs
+++ b/base_layer/core/src/mempool/proto/mempool_request.rs
@@ -39,6 +39,7 @@ impl TryInto<MempoolRequest> for ProtoMempoolRequest {
             GetTxStateWithExcessSig(excess_sig) => MempoolRequest::GetTxStateWithExcessSig(
                 excess_sig.try_into().map_err(|err: ByteArrayError| err.to_string())?,
             ),
+            SubmitTransaction(tx) => MempoolRequest::SubmitTransaction(tx.try_into()?),
         };
         Ok(request)
     }
@@ -50,6 +51,7 @@ impl From<MempoolRequest> for ProtoMempoolRequest {
         match request {
             GetStats => ProtoMempoolRequest::GetStats(true),
             GetTxStateWithExcessSig(excess_sig) => ProtoMempoolRequest::GetTxStateWithExcessSig(excess_sig.into()),
+            SubmitTransaction(tx) => ProtoMempoolRequest::SubmitTransaction(tx.into()),
         }
     }
 }

--- a/base_layer/core/src/mempool/proto/service_request.proto
+++ b/base_layer/core/src/mempool/proto/service_request.proto
@@ -1,6 +1,7 @@
 syntax = "proto3";
 
 import "types.proto";
+import "transaction.proto";
 
 package tari.mempool;
 
@@ -12,5 +13,7 @@ message MempoolServiceRequest {
         bool get_stats = 2;
         // Indicates a GetTxStateWithExcessSig request.
         tari.types.Signature get_tx_state_with_excess_sig = 3;
+        // Indicates a SubmitTransaction request.
+        tari.types.Transaction submit_transaction = 4;
     }
 }

--- a/base_layer/core/src/mempool/service/request.rs
+++ b/base_layer/core/src/mempool/service/request.rs
@@ -20,7 +20,10 @@
 //  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 //  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use crate::{base_node::RequestKey, transactions::types::Signature};
+use crate::{
+    base_node::RequestKey,
+    transactions::{transaction::Transaction, types::Signature},
+};
 use core::fmt::{Display, Error, Formatter};
 use serde::{Deserialize, Serialize};
 use tari_crypto::tari_utilities::hex::Hex;
@@ -30,6 +33,7 @@ use tari_crypto::tari_utilities::hex::Hex;
 pub enum MempoolRequest {
     GetStats,
     GetTxStateWithExcessSig(Signature),
+    SubmitTransaction(Transaction),
 }
 
 impl Display for MempoolRequest {
@@ -39,6 +43,10 @@ impl Display for MempoolRequest {
             MempoolRequest::GetTxStateWithExcessSig(sig) => {
                 f.write_str(&format!("GetTxStateWithExcessSig ({})", sig.get_signature().to_hex()))
             },
+            MempoolRequest::SubmitTransaction(tx) => f.write_str(&format!(
+                "SubmitTransaction ({})",
+                tx.body.kernels()[0].excess_sig.get_signature().to_hex()
+            )),
         }
     }
 }

--- a/base_layer/core/src/mempool/service/service.rs
+++ b/base_layer/core/src/mempool/service/service.rs
@@ -315,7 +315,7 @@ where B: BlockchainBackend + 'static
 }
 
 async fn handle_incoming_request<B: BlockchainBackend + 'static>(
-    inbound_handlers: MempoolInboundHandlers<B>,
+    mut inbound_handlers: MempoolInboundHandlers<B>,
     mut outbound_message_service: OutboundMessageRequester,
     domain_request_msg: DomainMessage<proto::MempoolServiceRequest>,
 ) -> Result<(), MempoolServiceError>

--- a/base_layer/wallet/tests/transaction_service/service.rs
+++ b/base_layer/wallet/tests/transaction_service/service.rs
@@ -1516,6 +1516,7 @@ fn transaction_mempool_broadcast() {
     match mempool_service_request.request {
         MempoolRequest::GetStats => assert!(false, "Invalid Mempool Service Request variant"),
         MempoolRequest::GetTxStateWithExcessSig(excess_sig) => assert_eq!(excess_sig, kernel_sig),
+        MempoolRequest::SubmitTransaction(_) => assert!(false, "Invalid Mempool Service Request variant"),
     }
 
     let mempool_response = MempoolProto::MempoolServiceResponse {
@@ -1919,6 +1920,7 @@ fn transaction_base_node_monitoring() {
     match mempool_service_request.request {
         MempoolRequest::GetStats => assert!(false, "Invalid Mempool Service Request variant"),
         MempoolRequest::GetTxStateWithExcessSig(excess_sig) => assert_eq!(excess_sig, kernel_sig),
+        MempoolRequest::SubmitTransaction(_) => assert!(false, "Invalid Mempool Service Request variant"),
     }
 
     let mempool_response = MempoolProto::MempoolServiceResponse {


### PR DESCRIPTION
## Description
- Added a SubmitTransaction mempool request that allows wallets and other services to insert a transaction into the mempool and allow them to determine where a transaction was inserted and if it was discarded by the mempool.
- Modified the transaction propagation to only propagate transactions that have been accepted by specific mempool subpools.

## Motivation and Context
Enables wallets to insert a transaction using a mempool request that responds with the state of the insert instruction

## How Has This Been Tested?
No tests have been added.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch.
* [x] I ran `cargo-fmt --all` before pushing.
* [x] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
