### PR TITLE
Check for reorg if adding a block already in the orphan pool

### DIFF
--- a/base_layer/core/src/chain_storage/blockchain_database.rs
+++ b/base_layer/core/src/chain_storage/blockchain_database.rs
@@ -775,7 +775,7 @@ fn add_block<T: BlockchainBackend>(
 ) -> Result<BlockAddResult, ChainStorageError>
 {
     let block_hash = block.hash();
-    if db.contains(&DbKey::BlockHash(block_hash.clone()))? || db.contains(&DbKey::OrphanBlock(block_hash))? {
+    if db.contains(&DbKey::BlockHash(block_hash.clone()))? {
         return Ok(BlockAddResult::BlockExists);
     }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
If a block is added that is already in the orphan pool it should be replaced and check for reorg. Sometimes blocks have come in before the db is at that height, and it'll be added to the orphan pool. When syncing, when trying to add that block, it should check for a reorg

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [ ] I'm merging against the `development` branch.
* [ ] I ran `cargo-fmt --all` before pushing.
* [ ] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
