### PR TITLE
Fix for state system endless loop issue

### DIFF
--- a/base_layer/core/src/base_node/chain_metadata_service/initializer.rs
+++ b/base_layer/core/src/base_node/chain_metadata_service/initializer.rs
@@ -31,7 +31,8 @@ use tari_service_framework::{handles::ServiceHandlesFuture, ServiceInitializatio
 use tari_shutdown::ShutdownSignal;
 use tokio::runtime;
 
-const BROADCAST_EVENT_BUFFER_SIZE: usize = 10;
+// Must be set to 1 to ensure outdated chain metadata is discarded.
+const BROADCAST_EVENT_BUFFER_SIZE: usize = 1;
 
 pub struct ChainMetadataServiceInitializer;
 


### PR DESCRIPTION
## Description
 When the chain metadata service receives newer chain metadata it will replace the set of chain metadata on the channel instead of queuing it. 

## Motivation and Context
This change will ensure that old chain metadata will be discarded when a new set of chain metadata becomes available, fixing the issue where the state system enters an endless loop due to old chain metadata on the channel.

## How Has This Been Tested?
No tested.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch.
* [x] I ran `cargo-fmt --all` before pushing.
* [x] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
