### PR TITLE
Disable reprocessing of old chain metadata events

### DIFF
--- a/base_layer/core/src/base_node/states/listening.rs
+++ b/base_layer/core/src/base_node/states/listening.rs
@@ -48,9 +48,7 @@ pub struct ListeningInfo;
 impl ListeningInfo {
     pub async fn next_event<B: BlockchainBackend>(&mut self, shared: &mut BaseNodeStateMachine<B>) -> StateEvent {
         info!(target: LOG_TARGET, "Listening for chain metadata updates");
-
-        let mut metadata_event_stream = shared.metadata_event_stream.clone().fuse();
-        while let Some(metadata_event) = metadata_event_stream.next().await {
+        while let Some(metadata_event) = shared.metadata_event_stream.next().await {
             match &*metadata_event {
                 ChainMetadataEvent::PeerChainMetadataReceived(peer_metadata_list) => {
                     if !peer_metadata_list.is_empty() {


### PR DESCRIPTION
## Description
- This change ensures that when the chain metadata is not updated on the metadata event stream then it wont reprocess the old chain metadata.

## Motivation and Context
When the chain metadata event stream is no longer updated, then this will ensure that the exist event does not get processed multiple times by the base node listening state.

## How Has This Been Tested?
No tests were added.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch.
* [x] I ran `cargo-fmt --all` before pushing.
* [x] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
