### PR TITLE
Update the transaction service base node monitoring heuristics

### DIFF
--- a/base_layer/core/tests/wallet.rs
+++ b/base_layer/core/tests/wallet.rs
@@ -285,7 +285,7 @@ fn wallet_base_node_integration_test() {
     let transaction = transaction.expect("Transaction must be present");
 
     // Setup and start the miner
-    let shutdown = Shutdown::new();
+    let mut shutdown = Shutdown::new();
     let mut miner = Miner::new(shutdown.to_signal(), consensus_manager, &base_node.local_nci, 1);
     miner.enable_mining_flag().store(true, Ordering::Relaxed);
     let (mut state_event_sender, state_event_receiver): (Publisher<_>, Subscriber<_>) = bounded(1);
@@ -342,5 +342,6 @@ fn wallet_base_node_integration_test() {
 
     alice_wallet.shutdown();
     bob_wallet.shutdown();
+    let _ = shutdown.trigger();
     runtime.block_on(base_node.comms.shutdown());
 }

--- a/base_layer/wallet/src/transaction_service/service.rs
+++ b/base_layer/wallet/src/transaction_service/service.rs
@@ -20,24 +20,13 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use crate::{
-    output_manager_service::{handle::OutputManagerHandle, TxId},
-    transaction_service::{
-        config::TransactionServiceConfig,
-        error::TransactionServiceError,
-        handle::{TransactionEvent, TransactionServiceRequest, TransactionServiceResponse},
-        storage::database::{
-            CompletedTransaction,
-            InboundTransaction,
-            OutboundTransaction,
-            PendingCoinbaseTransaction,
-            TransactionBackend,
-            TransactionDatabase,
-            TransactionStatus,
-        },
-    },
-    util::futures::StateDelay,
+use std::{
+    collections::HashMap,
+    convert::{TryFrom, TryInto},
+    sync::Arc,
+    time::Duration,
 };
+
 use chrono::Utc;
 use futures::{
     channel::oneshot,
@@ -50,13 +39,13 @@ use futures::{
 };
 use log::*;
 use rand::{rngs::OsRng, RngCore};
-use std::{
-    collections::HashMap,
-    convert::{TryFrom, TryInto},
-    sync::Arc,
-    time::Duration,
-};
 use tari_broadcast_channel::Publisher;
+use tari_crypto::{
+    commitment::HomomorphicCommitmentFactory,
+    keys::SecretKey,
+    tari_utilities::{hash::Hashable, hex::Hex},
+};
+
 use tari_comms::{
     message::MessageTag,
     peer_manager::NodeIdentity,
@@ -83,7 +72,6 @@ use tari_core::{
         TxStorageResponse,
     },
     transactions::{
-        proto as TransactionProto,
         tari_amount::MicroTari,
         transaction::{KernelFeatures, OutputFeatures, OutputFlags, Transaction, TransactionOutput},
         transaction_protocol::{
@@ -95,9 +83,27 @@ use tari_core::{
         ReceiverTransactionProtocol,
     },
 };
-use tari_crypto::{commitment::HomomorphicCommitmentFactory, keys::SecretKey, tari_utilities::hash::Hashable};
 use tari_p2p::{domain_message::DomainMessage, tari_message::TariMessageType};
 use tari_service_framework::{reply_channel, reply_channel::Receiver};
+
+use crate::{
+    output_manager_service::{handle::OutputManagerHandle, TxId},
+    transaction_service::{
+        config::TransactionServiceConfig,
+        error::TransactionServiceError,
+        handle::{TransactionEvent, TransactionServiceRequest, TransactionServiceResponse},
+        storage::database::{
+            CompletedTransaction,
+            InboundTransaction,
+            OutboundTransaction,
+            PendingCoinbaseTransaction,
+            TransactionBackend,
+            TransactionDatabase,
+            TransactionStatus,
+        },
+    },
+    util::futures::StateDelay,
+};
 
 const LOG_TARGET: &str = "wallet::transaction_service::service";
 
@@ -145,6 +151,7 @@ where TBackend: TransactionBackend + Clone + 'static
     factories: CryptoFactories,
     base_node_public_key: Option<CommsPublicKey>,
     pending_outbound_message_results: HashMap<MessageTag, OutboundTransaction>,
+    pending_transaction_mined_queries: HashMap<TxId, TransactionMinedRequestResult>,
 }
 
 impl<TTxStream, TTxReplyStream, TTxFinalizedStream, MReplyStream, BNResponseStream, TBackend>
@@ -194,6 +201,7 @@ where
             factories,
             base_node_public_key: None,
             pending_outbound_message_results: HashMap::new(),
+            pending_transaction_mined_queries: HashMap::new(),
         }
     }
 
@@ -1092,32 +1100,22 @@ where
         if completed_tx.status != TransactionStatus::Completed || completed_tx.transaction.body.kernels().is_empty() {
             return Err(TransactionServiceError::InvalidCompletedTransaction);
         }
-
         match self.base_node_public_key.clone() {
             None => return Err(TransactionServiceError::NoBaseNodeKeysProvided),
             Some(pk) => {
                 info!(
                     target: LOG_TARGET,
-                    "Attempting to Broadcast TxId: {} to Mempool", completed_tx.tx_id
+                    "Attempting to Broadcast Transaction (TxId: {} and Kernel Excess: {}) to Mempool",
+                    completed_tx.tx_id,
+                    completed_tx.transaction.body.kernels()[0].excess.to_hex()
                 );
-                // Broadcast Transaction
-                self.outbound_message_service
-                    .send_direct(
-                        pk.clone(),
-                        OutboundEncryption::EncryptForPeer,
-                        OutboundDomainMessage::new(
-                            TariMessageType::NewTransaction,
-                            TransactionProto::types::Transaction::from(completed_tx.transaction.clone()),
-                        ),
-                    )
-                    .await?;
+                trace!(target: LOG_TARGET, "{}", completed_tx.transaction);
 
                 // Send  Mempool Request
-                let tx_excess_sig = completed_tx.transaction.body.kernels()[0].excess_sig.clone();
                 let mempool_request = MempoolProto::MempoolServiceRequest {
                     request_key: completed_tx.tx_id,
-                    request: Some(MempoolProto::mempool_service_request::Request::GetTxStateWithExcessSig(
-                        tx_excess_sig.into(),
+                    request: Some(MempoolProto::mempool_service_request::Request::SubmitTransaction(
+                        completed_tx.transaction.into(),
                     )),
                 };
                 self.outbound_message_service
@@ -1172,7 +1170,10 @@ where
         let completed_tx = self.db.get_completed_transaction(tx_id.clone()).await?;
 
         if completed_tx.status == TransactionStatus::Completed {
-            info!(target: LOG_TARGET, "Mempool broadcast timed out for TX_ID: {}", tx_id);
+            info!(
+                target: LOG_TARGET,
+                "Mempool broadcast timed out for Transaction with TX_ID: {}", tx_id
+            );
 
             self.broadcast_completed_transaction_to_mempool(
                 tx_id,
@@ -1200,47 +1201,92 @@ where
         let response = MempoolServiceResponse::try_from(response).unwrap();
         let tx_id = response.request_key;
         match response.response {
-            MempoolResponse::Stats(_) => Err(TransactionServiceError::InvalidMessageError(
-                "Mempool Response of invalid type".to_string(),
-            )),
-            MempoolResponse::TxStorage(ts) => match ts {
-                TxStorageResponse::NotStored => {
-                    debug!(
-                        target: LOG_TARGET,
-                        "Mempool response received for TxId: {:?} but requested transaction was not found in mempool",
-                        tx_id
-                    );
-                    Ok(())
-                },
-                // Any other variant of this enum means the transaction has been received by the base_node and is in one
-                // of the various mempools
-                _ => {
-                    let completed_tx = self.db.get_completed_transaction(response.request_key.clone()).await?;
-                    // If this transaction is still in the Completed State it should be upgraded to the Broadcast state
-                    if completed_tx.status == TransactionStatus::Completed {
-                        info!(
-                            target: LOG_TARGET,
-                            "Completed Transaction with TxId: {} detected as Broadcast to Base Node Mempool", tx_id
-                        );
-                        self.db.broadcast_completed_transaction(tx_id.clone()).await?;
-                        // Start monitoring the base node to see if this Tx has been mined
-                        self.send_transaction_mined_request(
-                            tx_id.clone(),
-                            self.config.base_node_mined_timeout,
-                            mined_request_timeout_futures,
-                        )
-                        .await?;
+            MempoolResponse::Stats(_) => {
+                return Err(TransactionServiceError::InvalidMessageError(
+                    "Mempool Response of invalid type".to_string(),
+                ))
+            },
+            MempoolResponse::TxStorage(ts) => {
+                let completed_tx = self.db.get_completed_transaction(response.request_key.clone()).await?;
 
-                        self.event_publisher
-                            .send(TransactionEvent::TransactionBroadcast(tx_id))
-                            .await
-                            .map_err(|_| TransactionServiceError::EventStreamError)?;
-                    }
+                match completed_tx.status {
+                    TransactionStatus::Completed => match ts {
+                        // Getting this response means the Mempool Rejected this transaction so it will be cancelled.
+                        TxStorageResponse::NotStored => {
+                            // If this transaction is still in the Completed State it should be upgraded to the
+                            // Broadcast state
+                            error!(
+                                target: LOG_TARGET,
+                                "Mempool response received for TxId: {:?}. Transaction was REJECTED. Cancelling \
+                                 transaction.",
+                                tx_id
+                            );
+                            if let Err(e) = self.output_manager_service.cancel_transaction(completed_tx.tx_id).await {
+                                error!(
+                                    target: LOG_TARGET,
+                                    "Failed to Cancel outputs for TX_ID: {} after failed sending attempt with error \
+                                     {:?}",
+                                    completed_tx.tx_id,
+                                    e
+                                );
+                            }
+                            if let Err(e) = self.db.cancel_completed_transaction(completed_tx.tx_id).await {
+                                error!(
+                                    target: LOG_TARGET,
+                                    "Failed to Cancel TX_ID: {} after failed sending attempt with error {:?}",
+                                    completed_tx.tx_id,
+                                    e
+                                );
+                            }
+                            self.event_publisher
+                                .send(TransactionEvent::TransactionSendDiscoveryComplete(tx_id, false))
+                                .await
+                                .map_err(|_| TransactionServiceError::EventStreamError)?;
+                        },
+                        // Any other variant of this enum means the transaction has been received by the base_node and
+                        // is in one of the various mempools
+                        _ => {
+                            // If this transaction is still in the Completed State it should be upgraded to the
+                            // Broadcast state
 
-                    Ok(())
-                },
+                            info!(
+                                target: LOG_TARGET,
+                                "Completed Transaction (TxId: {} and Kernel Excess: {}) detected as Broadcast to Base \
+                                 Node Mempool",
+                                tx_id,
+                                completed_tx.transaction.body.kernels()[0].excess.to_hex()
+                            );
+                            self.db.broadcast_completed_transaction(tx_id.clone()).await?;
+                            // Start monitoring the base node to see if this Tx has been mined
+                            self.send_transaction_mined_request(
+                                tx_id.clone(),
+                                self.config.base_node_mined_timeout,
+                                mined_request_timeout_futures,
+                            )
+                            .await?;
+
+                            self.event_publisher
+                                .send(TransactionEvent::TransactionBroadcast(tx_id))
+                                .await
+                                .map_err(|_| TransactionServiceError::EventStreamError)?;
+                        },
+                    },
+                    TransactionStatus::Broadcast => {
+                        if let Some(result) = self.pending_transaction_mined_queries.get_mut(&completed_tx.tx_id) {
+                            match ts {
+                                TxStorageResponse::NotStored => result.mempool_response = Some(false),
+                                _ => result.mempool_response = Some(true),
+                            }
+                            if result.is_complete() {
+                                self.handle_transaction_mined_request_result(&completed_tx.tx_id).await;
+                            }
+                        }
+                    },
+                    _ => (),
+                }
             },
         }
+        Ok(())
     }
 
     /// Send a request to the Base Node to see if the specified transaction has been mined yet. This function will send
@@ -1275,6 +1321,23 @@ where
                     hashes.len(),
                 );
 
+                // Send a request to the mempool to find the state of the Tx there
+                let tx_excess_sig = completed_tx.transaction.body.kernels()[0].excess_sig.clone();
+                let mempool_request = MempoolProto::MempoolServiceRequest {
+                    request_key: completed_tx.tx_id,
+                    request: Some(MempoolProto::mempool_service_request::Request::GetTxStateWithExcessSig(
+                        tx_excess_sig.into(),
+                    )),
+                };
+                self.outbound_message_service
+                    .send_direct(
+                        pk.clone(),
+                        OutboundEncryption::EncryptForPeer,
+                        OutboundDomainMessage::new(TariMessageType::MempoolRequest, mempool_request),
+                    )
+                    .await?;
+
+                // Ask the base node if the outputs are in the chain
                 let request = BaseNodeRequestProto::FetchUtxos(BaseNodeProto::HashOutputs { outputs: hashes });
                 let service_request = BaseNodeProto::BaseNodeServiceRequest {
                     request_key: tx_id,
@@ -1289,7 +1352,9 @@ where
                     .await?;
                 // Start Timeout
                 let state_timeout = StateDelay::new(timeout, completed_tx.tx_id);
-
+                let _ = self
+                    .pending_transaction_mined_queries
+                    .insert(tx_id, TransactionMinedRequestResult::default());
                 mined_request_timeout_futures.push(state_timeout.delay().boxed());
             },
         }
@@ -1329,6 +1394,43 @@ where
         Ok(())
     }
 
+    /// Handle the result of receiving all the stages needed to complete a Transaction Mined request
+    pub async fn handle_transaction_mined_request_result(&mut self, tx_id: &TxId) {
+        if let Some(result) = self.pending_transaction_mined_queries.remove(tx_id) {
+            // If the transaction is not in mempool AND not mined then the Tx was reorged out and will never appear
+            // in the chain and should be cancelled
+            if result.mempool_response == Some(false) && result.chain_response == Some(false) {
+                error!(
+                    target: LOG_TARGET,
+                    "Transaction (TxId: {}) has left the Mempool while not being Mined. It will be cancelled.", tx_id,
+                );
+                let _ = self
+                    .output_manager_service
+                    .cancel_transaction(tx_id.clone())
+                    .await
+                    .map_err(|e| {
+                        error!(
+                            target: LOG_TARGET,
+                            "Failed to Cancel outputs for TX_ID: {} after failed sending attempt with error {:?}",
+                            tx_id,
+                            e
+                        );
+                    });
+                let _ = self.db.cancel_completed_transaction(tx_id.clone()).await.map_err(|e| {
+                    error!(
+                        target: LOG_TARGET,
+                        "Failed to Cancel TX_ID: {} after failed sending attempt with error {:?}", tx_id, e
+                    );
+                });
+                let _ = self
+                    .event_publisher
+                    .send(TransactionEvent::TransactionSendDiscoveryComplete(tx_id.clone(), false))
+                    .await
+                    .map_err(|e| error!(target: LOG_TARGET, "Failed send event {:?}", e));
+            }
+        }
+    }
+
     /// Handle an incoming basenode response message
     pub async fn handle_base_node_response(
         &mut self,
@@ -1364,6 +1466,16 @@ where
                     completed_tx.transaction.body.outputs().len(),
                     response.len(),
                 );
+
+                if completed_tx.status == TransactionStatus::Broadcast {
+                    if let Some(result) = self.pending_transaction_mined_queries.get_mut(&completed_tx.tx_id) {
+                        result.chain_response = Some(false);
+
+                        if result.is_complete() {
+                            self.handle_transaction_mined_request_result(&completed_tx.tx_id).await;
+                        }
+                    }
+                }
             } else {
                 let mut check = true;
 
@@ -1713,5 +1825,19 @@ async fn transaction_send_discovery_process_completion(
         Ok((mt, updated_outbound_tx))
     } else {
         Err(TransactionServiceError::DiscoveryProcessFailed(tx_id))
+    }
+}
+
+/// This struct holds the responses of a multistage base node monitoring request to see if a Transaction has been mined.
+/// This is used to keep track of the status of the transaction in both the mempool and chain.
+#[derive(Debug, Default)]
+struct TransactionMinedRequestResult {
+    mempool_response: Option<bool>,
+    chain_response: Option<bool>,
+}
+
+impl TransactionMinedRequestResult {
+    fn is_complete(&self) -> bool {
+        self.mempool_response.is_some() && self.chain_response.is_some()
     }
 }

--- a/base_layer/wallet/src/transaction_service/storage/database.rs
+++ b/base_layer/wallet/src/transaction_service/storage/database.rs
@@ -528,6 +528,14 @@ where T: TransactionBackend + 'static
         Ok(())
     }
 
+    pub async fn cancel_completed_transaction(&mut self, tx_id: TxId) -> Result<(), TransactionStorageError> {
+        let db_clone = self.db.clone();
+        tokio::task::spawn_blocking(move || db_clone.write(WriteOperation::Remove(DbKey::CompletedTransaction(tx_id))))
+            .await
+            .or_else(|err| Err(TransactionStorageError::BlockingTaskSpawnError(err.to_string())))??;
+        Ok(())
+    }
+
     /// Indicated that the specified completed transaction has been broadcast into the mempool
     pub async fn broadcast_completed_transaction(&mut self, tx_id: TxId) -> Result<(), TransactionStorageError> {
         let db_clone = self.db.clone();

--- a/base_layer/wallet/tests/transaction_service/service.rs
+++ b/base_layer/wallet/tests/transaction_service/service.rs
@@ -1493,24 +1493,29 @@ fn transaction_mempool_broadcast() {
         )))
         .unwrap();
 
-    let result_stream = runtime.block_on(async {
-        collect_stream!(
-            alice_ts.get_event_stream_fused().map(|i| (*i).clone()),
-            take = 3,
-            timeout = Duration::from_secs(60)
-        )
-    });
+    let mut alice_event_stream = alice_ts.get_event_stream_fused();
+    runtime.block_on(async {
+        let mut delay = delay_for(Duration::from_secs(60)).fuse();
+        let mut broadcast_timeout_count = 0;
+        loop {
+            futures::select! {
+                event = alice_event_stream.select_next_some() => {
+                     if let TransactionEvent::MempoolBroadcastTimedOut(_) = &*event{
+                        broadcast_timeout_count +=1;
+                        if broadcast_timeout_count >= 2 {
+                            break;
+                        }
 
-    assert_eq!(
-        2,
-        result_stream.iter().fold(0, |acc, item| {
-            if let TransactionEvent::MempoolBroadcastTimedOut(_) = item {
-                acc + 1
-            } else {
-                acc
+                    }
+                },
+                () = delay => {
+                log::error!("This select loop timed out");
+                    break;
+                },
             }
-        })
-    );
+        }
+        assert!(broadcast_timeout_count >= 2);
+    });
 
     let alice_completed_tx = runtime
         .block_on(alice_ts.get_completed_transactions())
@@ -1529,11 +1534,8 @@ fn transaction_mempool_broadcast() {
 
     let mempool_service_request = MempoolServiceRequest::try_from(msr.clone()).unwrap();
 
-    let _ = alice_outbound_service.pop_call().unwrap(); // burn a tx broadcast
     let _ = alice_outbound_service.pop_call().unwrap(); // burn a mempool request
-    let _ = alice_outbound_service.pop_call().unwrap(); // burn a tx broadcast
     let _ = alice_outbound_service.pop_call().unwrap(); // burn a mempool request
-    let _ = alice_outbound_service.pop_call().unwrap(); // burn a tx broadcast
     let call = alice_outbound_service.pop_call().unwrap(); // this should be the sending of the finalized tx to the receiver
 
     let envelope_body = EnvelopeBody::decode(&mut call.1.as_slice()).unwrap();
@@ -1546,63 +1548,37 @@ fn transaction_mempool_broadcast() {
         .block_on(bob_tx_finalized_sender.send(create_dummy_message(tx_finalized, alice_node_identity.public_key())))
         .unwrap();
 
-    let result_stream = runtime.block_on(async {
-        collect_stream!(
-            bob_ts.get_event_stream_fused().map(|i| (*i).clone()),
-            take = 3,
-            timeout = Duration::from_secs(60)
-        )
+    let mut alice_event_stream = alice_ts.get_event_stream_fused();
+    runtime.block_on(async {
+        let mut delay = delay_for(Duration::from_secs(60)).fuse();
+        let mut broadcast_timeout_count = 0;
+        loop {
+            futures::select! {
+                event = alice_event_stream.select_next_some() => {
+                     if let TransactionEvent::MempoolBroadcastTimedOut(_) = &*event{
+                        broadcast_timeout_count +=1;
+                        if broadcast_timeout_count >= 1 {
+                            break;
+                        }
+
+                    }
+                },
+                () = delay => {
+                log::error!("This select loop timed out");
+                    break;
+                },
+            }
+        }
+        assert!(broadcast_timeout_count >= 1);
     });
 
-    assert_eq!(
-        1,
-        result_stream.iter().fold(0, |acc, item| {
-            if let TransactionEvent::MempoolBroadcastTimedOut(_) = item {
-                acc + 1
-            } else {
-                acc
-            }
-        })
-    );
-
-    let kernel_sig = alice_completed_tx.transaction.body.kernels()[0].clone().excess_sig;
     assert_eq!(mempool_service_request.request_key, tx_id);
 
     match mempool_service_request.request {
         MempoolRequest::GetStats => assert!(false, "Invalid Mempool Service Request variant"),
-        MempoolRequest::GetTxStateWithExcessSig(excess_sig) => assert_eq!(excess_sig, kernel_sig),
-        MempoolRequest::SubmitTransaction(_) => assert!(false, "Invalid Mempool Service Request variant"),
+        MempoolRequest::GetTxStateWithExcessSig(_) => assert!(false, "Invalid Mempool Service Request variant"),
+        MempoolRequest::SubmitTransaction(tx) => assert_eq!(tx, alice_completed_tx.transaction),
     }
-
-    let mempool_response = MempoolProto::MempoolServiceResponse {
-        request_key: tx_id,
-        response: Some(MempoolResponse::TxStorage(TxStorageResponse::NotStored).into()),
-    };
-
-    runtime
-        .block_on(
-            alice_mempool_response_sender.send(create_dummy_message(mempool_response, base_node_identity.public_key())),
-        )
-        .unwrap();
-
-    let result_stream = runtime.block_on(async {
-        collect_stream!(
-            alice_ts.get_event_stream_fused().map(|i| (*i).clone()),
-            take = 4,
-            timeout = Duration::from_secs(60)
-        )
-    });
-
-    assert_eq!(
-        3,
-        result_stream.iter().fold(0, |acc, item| {
-            if let TransactionEvent::MempoolBroadcastTimedOut(_) = item {
-                acc + 1
-            } else {
-                acc
-            }
-        })
-    );
 
     let mempool_response = MempoolProto::MempoolServiceResponse {
         request_key: tx_id,
@@ -1615,35 +1591,27 @@ fn transaction_mempool_broadcast() {
         )
         .unwrap();
 
-    let result_stream = runtime.block_on(async {
-        collect_stream!(
-            alice_ts.get_event_stream_fused().map(|i| (*i).clone()),
-            take = 5,
-            timeout = Duration::from_secs(60)
-        )
+    let mut alice_event_stream = alice_ts.get_event_stream_fused();
+    runtime.block_on(async {
+        let mut delay = delay_for(Duration::from_secs(10)).fuse();
+        let mut broadcast = false;
+        loop {
+            futures::select! {
+                event = alice_event_stream.select_next_some() => {
+                     if let TransactionEvent::TransactionBroadcast(_) = &*event{
+                        broadcast = true;
+                        break;
+
+                    }
+                },
+                () = delay => {
+                log::error!("This select loop timed out");
+                    break;
+                },
+            }
+        }
+        assert!(broadcast);
     });
-
-    assert_eq!(
-        3,
-        result_stream.iter().fold(0, |acc, item| {
-            if let TransactionEvent::MempoolBroadcastTimedOut(_) = item {
-                acc + 1
-            } else {
-                acc
-            }
-        })
-    );
-
-    assert_eq!(
-        1,
-        result_stream.iter().fold(0, |acc, item| {
-            if let TransactionEvent::TransactionBroadcast(_) = item {
-                acc + 1
-            } else {
-                acc
-            }
-        })
-    );
 
     let alice_completed_tx = runtime
         .block_on(alice_ts.get_completed_transactions())
@@ -1940,8 +1908,7 @@ fn transaction_base_node_monitoring() {
         .block_on(alice_ts.set_base_node_public_key(base_node_identity.public_key().clone()))
         .unwrap();
 
-    let _ = alice_outbound_service.pop_call().unwrap(); // burn a Tx Mined? request
-    let _ = alice_outbound_service.pop_call().unwrap(); // burn a Tx Mined? request
+    let _ = alice_outbound_service.pop_call().unwrap(); // burn a base node request
 
     let call = alice_outbound_service.pop_call().unwrap();
     let envelope_body = EnvelopeBody::decode(&mut call.1.as_slice()).unwrap();
@@ -1952,9 +1919,6 @@ fn transaction_base_node_monitoring() {
 
     let mempool_service_request = MempoolServiceRequest::try_from(msr.clone()).unwrap();
 
-    let _ = alice_outbound_service.pop_call().unwrap(); // burn a tx broadcast
-    let _ = alice_outbound_service.pop_call().unwrap(); // burn a mempool request
-
     let broadcast_tx_id = mempool_service_request.request_key;
     let completed_tx_id = if tx_id == broadcast_tx_id { tx_id2 } else { tx_id };
 
@@ -1963,7 +1927,6 @@ fn transaction_base_node_monitoring() {
         .unwrap()
         .remove(&broadcast_tx_id)
         .expect("Transaction must be in collection");
-    let kernel_sig = broadcast_tx.transaction.body.kernels()[0].clone().excess_sig;
     let tx_outputs: Vec<TransactionOutputProto> = broadcast_tx
         .transaction
         .body
@@ -1974,8 +1937,7 @@ fn transaction_base_node_monitoring() {
 
     match mempool_service_request.request {
         MempoolRequest::GetStats => assert!(false, "Invalid Mempool Service Request variant"),
-        MempoolRequest::GetTxStateWithExcessSig(excess_sig) => assert_eq!(excess_sig, kernel_sig),
-        MempoolRequest::SubmitTransaction(_) => assert!(false, "Invalid Mempool Service Request variant"),
+        _ => (),
     }
 
     let mempool_response = MempoolProto::MempoolServiceResponse {
@@ -2234,7 +2196,6 @@ fn query_all_completed_transactions_on_startup() {
 
 #[test]
 fn test_failed_tx_send_timeout() {
-    let _ = env_logger::try_init();
     let temp_dir = TempDir::new(random_string(8).as_str()).unwrap();
     let mut runtime = create_runtime();
 
@@ -2295,7 +2256,6 @@ fn test_failed_tx_send_timeout() {
         .unwrap();
 
     runtime.block_on(bob_comms.shutdown());
-    runtime.block_on(async { delay_for(Duration::from_secs(10)).await });
 
     let balance = 2500 * uT;
     let value_sent = MicroTari::from(1000);
@@ -2339,4 +2299,262 @@ fn test_failed_tx_send_timeout() {
 
     let current_balance = runtime.block_on(alice_oms.get_balance()).unwrap();
     assert_eq!(current_balance.available_balance, balance);
+}
+
+#[test]
+fn transaction_cancellation_when_not_in_mempool() {
+    let factories = CryptoFactories::default();
+    let mut runtime = Runtime::new().unwrap();
+
+    let alice_node_identity =
+        NodeIdentity::random(&mut OsRng, get_next_memory_address(), PeerFeatures::COMMUNICATION_NODE).unwrap();
+
+    let bob_node_identity =
+        NodeIdentity::random(&mut OsRng, get_next_memory_address(), PeerFeatures::COMMUNICATION_NODE).unwrap();
+
+    let base_node_identity =
+        NodeIdentity::random(&mut OsRng, get_next_memory_address(), PeerFeatures::COMMUNICATION_NODE).unwrap();
+
+    let (
+        mut alice_ts,
+        mut alice_output_manager,
+        alice_outbound_service,
+        mut _alice_tx_sender,
+        mut alice_tx_ack_sender,
+        _,
+        mut alice_mempool_response_sender,
+        mut alice_base_node_response_sender,
+        _,
+    ) = setup_transaction_service_no_comms(&mut runtime, factories.clone(), TransactionMemoryDatabase::new());
+
+    let (mut bob_ts, _, bob_outbound_service, mut bob_tx_sender, _, _, _, _, _) =
+        setup_transaction_service_no_comms(&mut runtime, factories.clone(), TransactionMemoryDatabase::new());
+
+    runtime
+        .block_on(bob_ts.set_base_node_public_key(base_node_identity.public_key().clone()))
+        .unwrap();
+
+    let alice_total_available = 250000 * uT;
+    let (_utxo, uo) = make_input(&mut OsRng, alice_total_available, &factories.commitment);
+    runtime.block_on(alice_output_manager.add_output(uo)).unwrap();
+
+    let amount_sent = 10000 * uT;
+
+    runtime
+        .block_on(alice_ts.send_transaction(
+            bob_node_identity.public_key().clone(),
+            amount_sent,
+            100 * uT,
+            "Testing Message".to_string(),
+        ))
+        .unwrap();
+
+    let call = alice_outbound_service.pop_call().unwrap();
+    let envelope_body = EnvelopeBody::decode(&mut call.1.as_slice()).unwrap();
+    let tx_sender_msg: TransactionSenderMessage = envelope_body
+        .decode_part::<proto::TransactionSenderMessage>(1)
+        .unwrap()
+        .unwrap()
+        .try_into()
+        .unwrap();
+    let tx_id = match tx_sender_msg.clone() {
+        TransactionSenderMessage::Single(s) => s.tx_id,
+        _ => {
+            assert!(false, "Transaction is the not a single rounder sender variant");
+            0
+        },
+    };
+
+    runtime
+        .block_on(bob_tx_sender.send(create_dummy_message(
+            tx_sender_msg.into(),
+            alice_node_identity.public_key(),
+        )))
+        .unwrap();
+
+    let _result_stream = runtime.block_on(async {
+        collect_stream!(
+            bob_ts.get_event_stream_fused(),
+            take = 1,
+            timeout = Duration::from_secs(20)
+        )
+    });
+    let call = bob_outbound_service.pop_call().unwrap();
+    let envelope_body = EnvelopeBody::decode(&mut call.1.as_slice()).unwrap();
+    let tx_reply_msg: RecipientSignedMessage = envelope_body
+        .decode_part::<proto::RecipientSignedMessage>(1)
+        .unwrap()
+        .unwrap()
+        .try_into()
+        .unwrap();
+
+    runtime
+        .block_on(alice_tx_ack_sender.send(create_dummy_message(
+            tx_reply_msg.into(),
+            bob_node_identity.public_key(),
+        )))
+        .unwrap();
+
+    let _result_stream = runtime.block_on(async {
+        collect_stream!(
+            alice_ts.get_event_stream_fused().map(|i| (*i).clone()),
+            take = 1,
+            timeout = Duration::from_secs(60)
+        )
+    });
+    let alice_completed_tx = runtime
+        .block_on(alice_ts.get_completed_transactions())
+        .unwrap()
+        .remove(&tx_id)
+        .expect("Transaction must be in collection");
+
+    assert_eq!(alice_completed_tx.status, TransactionStatus::Completed);
+
+    runtime
+        .block_on(alice_ts.set_base_node_public_key(base_node_identity.public_key().clone()))
+        .unwrap();
+
+    let _ = alice_outbound_service.pop_call().unwrap(); // burn a base node request
+
+    let call = alice_outbound_service.pop_call().unwrap();
+    let envelope_body = EnvelopeBody::decode(&mut call.1.as_slice()).unwrap();
+    let msr = envelope_body
+        .decode_part::<MempoolProto::MempoolServiceRequest>(1)
+        .unwrap()
+        .unwrap();
+
+    let mempool_service_request = MempoolServiceRequest::try_from(msr.clone()).unwrap();
+
+    match mempool_service_request.request {
+        MempoolRequest::GetStats => assert!(false, "Invalid Mempool Service Request variant"),
+        _ => (),
+    }
+
+    let mempool_response = MempoolProto::MempoolServiceResponse {
+        request_key: tx_id,
+        response: Some(MempoolResponse::TxStorage(TxStorageResponse::UnconfirmedPool).into()),
+    };
+
+    runtime
+        .block_on(
+            alice_mempool_response_sender.send(create_dummy_message(mempool_response, base_node_identity.public_key())),
+        )
+        .unwrap();
+
+    let mut alice_event_stream = alice_ts.get_event_stream_fused();
+    runtime.block_on(async {
+        let mut delay = delay_for(Duration::from_secs(60)).fuse();
+        let mut timeouts = 0;
+        loop {
+            futures::select! {
+                event = alice_event_stream.select_next_some() => {
+                    if let TransactionEvent::TransactionMinedRequestTimedOut(_e) = &*event {
+                        timeouts+=1;
+                        if timeouts >= 1 {
+                            break;
+                        }
+                    }
+                },
+                () = delay => {
+                    break;
+                },
+            }
+        }
+        assert!(timeouts >= 1);
+    });
+
+    let base_node_response = BaseNodeProto::BaseNodeServiceResponse {
+        request_key: tx_id.clone(),
+        response: Some(BaseNodeResponseProto::TransactionOutputs(
+            BaseNodeProto::TransactionOutputs { outputs: vec![] },
+        )),
+    };
+    runtime
+        .block_on(alice_base_node_response_sender.send(create_dummy_message(
+            base_node_response,
+            base_node_identity.public_key(),
+        )))
+        .unwrap();
+
+    let mut alice_event_stream = alice_ts.get_event_stream_fused();
+    runtime.block_on(async {
+        let mut delay = delay_for(Duration::from_secs(60)).fuse();
+        let mut timeouts = 0;
+        loop {
+            futures::select! {
+                event = alice_event_stream.select_next_some() => {
+                    if let TransactionEvent::TransactionMinedRequestTimedOut(_e) = &*event {
+                        timeouts+=1;
+                        if timeouts >= 1 {
+                            break;
+                        }
+                    }
+                },
+                () = delay => {
+                    break;
+                },
+            }
+        }
+        assert!(timeouts >= 1);
+    });
+
+    let base_node_response = BaseNodeProto::BaseNodeServiceResponse {
+        request_key: tx_id.clone(),
+        response: Some(BaseNodeResponseProto::TransactionOutputs(
+            BaseNodeProto::TransactionOutputs { outputs: vec![] },
+        )),
+    };
+    runtime
+        .block_on(alice_base_node_response_sender.send(create_dummy_message(
+            base_node_response,
+            base_node_identity.public_key(),
+        )))
+        .unwrap();
+
+    let balance = runtime.block_on(alice_output_manager.get_balance()).unwrap();
+
+    assert_eq!(balance.available_balance, MicroTari(0));
+
+    let mempool_response = MempoolProto::MempoolServiceResponse {
+        request_key: tx_id,
+        response: Some(MempoolResponse::TxStorage(TxStorageResponse::NotStored).into()),
+    };
+
+    runtime
+        .block_on(
+            alice_mempool_response_sender.send(create_dummy_message(mempool_response, base_node_identity.public_key())),
+        )
+        .unwrap();
+
+    let mut alice_event_stream = alice_ts.get_event_stream_fused();
+    runtime.block_on(async {
+        let mut delay = delay_for(Duration::from_secs(20)).fuse();
+        let mut returned = false;
+        let mut result = true;
+        loop {
+            futures::select! {
+                event = alice_event_stream.select_next_some() => {
+                    if let TransactionEvent::TransactionSendDiscoveryComplete(_, success) = &*event {
+                        returned = true;
+                        result = success.clone();
+                    }
+                },
+                () = delay => {
+                    break;
+                },
+            }
+        }
+        assert!(returned, "Event should have occured");
+        assert!(!result, "Transaction should be cancelled");
+    });
+
+    let alice_completed_tx = runtime
+        .block_on(alice_ts.get_completed_transactions())
+        .unwrap()
+        .remove(&tx_id);
+    assert!(alice_completed_tx.is_none(), "Transaction must not be in collection");
+
+    let balance = runtime.block_on(alice_output_manager.get_balance()).unwrap();
+
+    assert_eq!(balance.available_balance, alice_total_available);
 }

--- a/base_layer/wallet/tests/transaction_service/storage.rs
+++ b/base_layer/wallet/tests/transaction_service/storage.rs
@@ -292,6 +292,16 @@ pub fn test_db_backend<T: TransactionBackend + 'static>(backend: T) {
             TransactionStatus::Mined
         );
     }
+
+    let completed_txs = runtime.block_on(db.get_completed_transactions()).unwrap();
+    let num_completed_txs = completed_txs.len();
+
+    runtime
+        .block_on(db.cancel_completed_transaction(completed_txs[&1].tx_id))
+        .unwrap();
+
+    let completed_txs = runtime.block_on(db.get_completed_transactions()).unwrap();
+    assert_eq!(completed_txs.len(), num_completed_txs - 1);
 }
 
 #[test]

--- a/base_layer/wallet_ffi/src/lib.rs
+++ b/base_layer/wallet_ffi/src/lib.rs
@@ -134,6 +134,7 @@ use std::{
     path::PathBuf,
     slice,
     sync::Arc,
+    time::Duration,
 };
 use tari_comms::{
     multiaddr::Multiaddr,
@@ -2129,7 +2130,10 @@ pub unsafe extern "C" fn comms_config_create(
                         peer_database_name: database_name_string,
                         max_concurrent_inbound_tasks: 100,
                         outbound_buffer_size: 100,
-                        dht: DhtConfig::default(),
+                        dht: DhtConfig {
+                            discovery_request_timeout: Duration::from_secs(30),
+                            ..Default::default()
+                        },
                         // TODO: This should be set to false for non-test wallets. See the `allow_test_addresses` field
                         //       docstring for more info.
                         allow_test_addresses: true,


### PR DESCRIPTION
## Description

This PR upgrades the transaction service’s base node monitoring for when its transactions are broadcast and then mined.

Things this PR does:
- Use the new MempoolRequest to submit a transaction that will produce an Ack from the mempool
- Once a Transaction is detected as broadcast it will be monitored in both the Mempool and in the blockchain
- If a transaction drops from the mempool BEFORE it appears in the blockchain it will be cancelled.

## How Has This Been Tested?
Tests provided

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [x] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [x] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch.
* [x] I ran `cargo-fmt --all` before pushing.
* [ ] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
