### PR TITLE
LMDB backend: adding of an invalid block issue

### DIFF
--- a/base_layer/core/tests/helpers/block_builders.rs
+++ b/base_layer/core/tests/helpers/block_builders.rs
@@ -254,8 +254,8 @@ pub fn generate_new_block(
     generate_block(db, blocks, txns, consensus_constants)
 }
 
-pub fn generate_new_block_with_achieved_difficulty(
-    db: &mut BlockchainDatabase<MemoryDatabase<HashDigest>>,
+pub fn generate_new_block_with_achieved_difficulty<B: BlockchainBackend>(
+    db: &mut BlockchainDatabase<B>,
     blocks: &mut Vec<Block>,
     outputs: &mut Vec<Vec<UnblindedOutput>>,
     schemas: Vec<TransactionSchema>,
@@ -278,8 +278,8 @@ pub fn generate_new_block_with_achieved_difficulty(
 
 /// Generate a new block using the given transaction schema and coinbase value and add it to the provided database.
 /// The blocks and UTXO vectors are also updated with the info from the new block.
-pub fn generate_new_block_with_coinbase(
-    db: &mut BlockchainDatabase<MemoryDatabase<HashDigest>>,
+pub fn generate_new_block_with_coinbase<B: BlockchainBackend>(
+    db: &mut BlockchainDatabase<B>,
     factories: &CryptoFactories,
     blocks: &mut Vec<Block>,
     outputs: &mut Vec<Vec<UnblindedOutput>>,
@@ -330,8 +330,8 @@ pub fn generate_block(
     result
 }
 
-pub fn generate_block_with_achieved_difficulty(
-    db: &mut BlockchainDatabase<MemoryDatabase<HashDigest>>,
+pub fn generate_block_with_achieved_difficulty<B: BlockchainBackend>(
+    db: &mut BlockchainDatabase<B>,
     blocks: &mut Vec<Block>,
     transactions: Vec<Transaction>,
     achieved_difficulty: Difficulty,
@@ -351,8 +351,8 @@ pub fn generate_block_with_achieved_difficulty(
 
 /// Generate a block and add it to the database using the provided transactions and coinbase. The header will be updated
 /// with the correct MMR roots.
-pub fn generate_block_with_coinbase(
-    db: &mut BlockchainDatabase<MemoryDatabase<HashDigest>>,
+pub fn generate_block_with_coinbase<B: BlockchainBackend>(
+    db: &mut BlockchainDatabase<B>,
     blocks: &mut Vec<Block>,
     transactions: Vec<Transaction>,
     coinbase_utxo: TransactionOutput,

--- a/base_layer/core/tests/mempool.rs
+++ b/base_layer/core/tests/mempool.rs
@@ -269,7 +269,6 @@ fn test_retrieve() {
     assert!(retrieved_txs.contains(&tx[2]));
     assert!(retrieved_txs.contains(&tx[3]));
     let stats = mempool.stats().unwrap();
-    println!("After block 1: {:?}", stats);
     assert_eq!(stats.unconfirmed_txs, 7);
     assert_eq!(stats.timelocked_txs, 1);
     assert_eq!(stats.published_txs, 0);


### PR DESCRIPTION
## Description
- Fixed an issue where a block that has been committed after an invalid block was added can’t be recovered. This was achieved by applying the MMR and storage transactions together and only committing them to the backend when they all succeeded.
- Fixed issue where fetch_block would not return blocks that are before the nodes pruning horizon.
- Modified some of the block builder functions to allow lmdb and memory backends to be used.

## Motivation and Context
The LMDB backend was left in an inconsistent state when an invalid block was added, these changes will help alleviate this issue.

## How Has This Been Tested?
Added the test invalid_block that checks that a valid block can be added after an invalid block was added, this test failed before these changes were applied.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [x] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [x] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch.
* [x] I ran `cargo-fmt --all` before pushing.
* [x] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
