### PR TITLE
Fixed blockchain db rewind to height and reorg issue

### DIFF
--- a/base_layer/core/src/chain_storage/memory_db/memory_db.rs
+++ b/base_layer/core/src/chain_storage/memory_db/memory_db.rs
@@ -183,9 +183,6 @@ where D: Digest + Send + Sync
                         db.kernels.insert(k, *v);
                     },
                     DbKeyValuePair::OrphanBlock(k, v) => {
-                        if db.orphans.contains_key(&k) {
-                            return Err(ChainStorageError::InvalidOperation("Duplicate key".to_string()));
-                        }
                         db.orphans.insert(k, *v);
                     },
                 },

--- a/base_layer/core/tests/chain_storage_tests/chain_storage.rs
+++ b/base_layer/core/tests/chain_storage_tests/chain_storage.rs
@@ -460,39 +460,46 @@ fn rewind_to_height() {
 
     // Block 1
     let schema = vec![txn_schema!(from: vec![outputs[0][0].clone()], to: vec![6 * T, 3 * T])];
-    generate_new_block(
-        &mut db,
-        &mut blocks,
-        &mut outputs,
-        schema,
-        &consensus_manager.consensus_constants(),
-    )
-    .unwrap();
+    assert_eq!(
+        generate_new_block(
+            &mut db,
+            &mut blocks,
+            &mut outputs,
+            schema,
+            &consensus_manager.consensus_constants(),
+        ),
+        Ok(BlockAddResult::Ok)
+    );
     // Block 2
     let schema = vec![txn_schema!(from: vec![outputs[1][0].clone()], to: vec![3 * T, 1 * T])];
-    generate_new_block(
-        &mut db,
-        &mut blocks,
-        &mut outputs,
-        schema,
-        &consensus_manager.consensus_constants(),
-    )
-    .unwrap();
+    assert_eq!(
+        generate_new_block(
+            &mut db,
+            &mut blocks,
+            &mut outputs,
+            schema,
+            &consensus_manager.consensus_constants(),
+        ),
+        Ok(BlockAddResult::Ok)
+    );
     // Block 3
     let schema = vec![
         txn_schema!(from: vec![outputs[2][0].clone()], to: vec![2 * T, 500_000 * uT]),
         txn_schema!(from: vec![outputs[1][1].clone()], to: vec![500_000 * uT]),
     ];
-    generate_new_block(
-        &mut db,
-        &mut blocks,
-        &mut outputs,
-        schema,
-        &consensus_manager.consensus_constants(),
-    )
-    .unwrap();
+    assert_eq!(
+        generate_new_block(
+            &mut db,
+            &mut blocks,
+            &mut outputs,
+            schema,
+            &consensus_manager.consensus_constants(),
+        ),
+        Ok(BlockAddResult::Ok)
+    );
 
     assert!(db.rewind_to_height(3).is_ok());
+    assert_eq!(db.get_height(), Ok(Some(3)));
     // Check MMRs are correct
     let mmr_check = blocks[3].header.kernel_mr.clone();
     let mmr = db.fetch_mmr_root(MmrTree::Kernel).unwrap();
@@ -505,7 +512,9 @@ fn rewind_to_height() {
     assert_eq!(mmr, mmr_check);
     // Invalid rewind
     assert!(db.rewind_to_height(4).is_err());
+    assert_eq!(db.get_height(), Ok(Some(3)));
     assert!(db.rewind_to_height(1).is_ok());
+    assert_eq!(db.get_height(), Ok(Some(1)));
     // Check MMRs are correct
     let mmr_check = blocks[1].header.kernel_mr.clone();
     let mmr = db.fetch_mmr_root(MmrTree::Kernel).unwrap();

--- a/base_layer/core/tests/helpers/block_builders.rs
+++ b/base_layer/core/tests/helpers/block_builders.rs
@@ -24,7 +24,7 @@ use croaring::Bitmap;
 use rand::{rngs::OsRng, RngCore};
 use tari_core::{
     blocks::{Block, BlockHeader, NewBlockTemplate},
-    chain_storage::{BlockAddResult, BlockchainBackend, BlockchainDatabase, ChainStorageError, MemoryDatabase},
+    chain_storage::{BlockAddResult, BlockchainBackend, BlockchainDatabase, ChainStorageError},
     consensus::{ConsensusConstants, ConsensusManager, ConsensusManagerBuilder, Network},
     proof_of_work::Difficulty,
     transactions::{
@@ -233,8 +233,8 @@ pub fn append_block<B: BlockchainBackend>(
 
 /// Generate a new block using the given transaction schema and add it to the provided database.
 /// The blocks and UTXO vectors are also updated with the info from the new block.
-pub fn generate_new_block(
-    db: &mut BlockchainDatabase<MemoryDatabase<HashDigest>>,
+pub fn generate_new_block<B: BlockchainBackend>(
+    db: &BlockchainDatabase<B>,
     blocks: &mut Vec<Block>,
     outputs: &mut Vec<Vec<UnblindedOutput>>,
     schemas: Vec<TransactionSchema>,
@@ -314,8 +314,8 @@ pub fn find_header_with_achieved_difficulty(header: &mut BlockHeader, achieved_d
 /// correct MMR roots.
 /// This function is not able to determine the unblinded outputs of a transaction, so if you are mixing using this
 /// with [generate_new_block], you must update the unblinded UTXO vector  yourself.
-pub fn generate_block(
-    db: &mut BlockchainDatabase<MemoryDatabase<HashDigest>>,
+pub fn generate_block<B: BlockchainBackend>(
+    db: &BlockchainDatabase<B>,
     blocks: &mut Vec<Block>,
     transactions: Vec<Transaction>,
     consensus_constants: &ConsensusConstants,

--- a/base_layer/core/tests/node_state_machine.rs
+++ b/base_layer/core/tests/node_state_machine.rs
@@ -41,7 +41,7 @@ use helpers::{
         BaseNodeBuilder,
     },
 };
-use rand::{rngs::OsRng, thread_rng, RngCore};
+use rand::{rngs::OsRng, RngCore};
 use std::{thread, time::Duration};
 use tari_core::{
     base_node::{


### PR DESCRIPTION
## Description
- Fixed issue where the blockchain db with an LMDB backend was unable to rewind to the correct height and perform reorgs in some situations.
- Added checks for existing headers, utxos and kernels so it is similar to the memory db implementation.
- Removed the orphan duplicate check from the memory db as orphan blocks should be replaced without producing an error.
- Changed some of the block builder functions to make it easier to test with memory or lmdb backend.

## Motivation and Context
The rewind_to_height and handle_reorg tests failed when using an LMDB backend, these changes fixes this issue. 

## How Has This Been Tested?
No tests were added.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch.
* [x] I ran `cargo-fmt --all` before pushing.
* [x] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
