### PR TITLE
Added logs for async db enter and exit

### DIFF
--- a/base_layer/core/src/chain_storage/blockchain_database.rs
+++ b/base_layer/core/src/chain_storage/blockchain_database.rs
@@ -1208,6 +1208,11 @@ fn try_construct_fork<T: BlockchainBackend>(
     let mut height = new_block.header.height;
     fork_chain.push_front(new_block);
     while let Ok(b) = fetch_orphan(&**db, hash.clone()) {
+        trace!(
+            target: LOG_TARGET,
+            "Checking block #{} forms a sequence to main chain or is orphaned",
+            b.header.height
+        );
         if b.header.height + 1 != height {
             // Well now. The block heights don't form a sequence, which means that we should not only stop now,
             // but remove one or both of these orphans from the pool because the blockchain is broken at this point.

--- a/base_layer/core/src/proof_of_work/diff_adj_manager/diff_adj_storage.rs
+++ b/base_layer/core/src/proof_of_work/diff_adj_manager/diff_adj_storage.rs
@@ -195,7 +195,7 @@ impl DiffAdjStorage {
 
     // Retrieves the height of the longest chain from the blockchain db
     fn get_height_of_longest_chain(
-        &mut self,
+        &self,
         metadata: &RwLockReadGuard<ChainMetadata>,
     ) -> Result<u64, DiffAdjManagerError>
     {


### PR DESCRIPTION
Async db calls do not always return, these logs will be able to identify
when this happens.

```
DEBUG [add_block] Entered blocking thread. trace_id: '4067860168'
DEBUG [add_block] Exited blocking thread after 164ms. trace_id: '4067860168'
```
