### PR TITLE
Make Tx service test less flaky

### DIFF
--- a/base_layer/wallet/src/transaction_service/service.rs
+++ b/base_layer/wallet/src/transaction_service/service.rs
@@ -369,7 +369,6 @@ where
                     }
                 },
                 message_event = message_event_receiver.select_next_some() => {
-                   trace!(target: LOG_TARGET, "Handling Message Event");
                    match message_event {
                    Ok(event) => {
                        let _ = self.handle_message_event((*event).clone()).await.or_else(|resp| {
@@ -399,7 +398,6 @@ where
                     break;
                 }
             }
-            trace!(target: LOG_TARGET, "Select Loop end");
         }
         Ok(())
     }


### PR DESCRIPTION
## Description

There was a chance that a timeout would fire before the second response is delivered so made the timeout longer and moved the two requests to be next to each other to make it most likely they arrive within the same Timeout period.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch.
* [x] I ran `cargo-fmt --all` before pushing.
* [ ] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
