### PR TITLE
Restrict access to reader lock on DB to prevent deadlocks

### DIFF
--- a/base_layer/core/src/base_node/comms_interface/inbound_handlers.rs
+++ b/base_layer/core/src/base_node/comms_interface/inbound_handlers.rs
@@ -233,13 +233,12 @@ where T: BlockchainBackend + 'static
                 let block = async_db::calculate_mmr_roots(self.blockchain_db.clone(), block_template.clone()).await?;
                 Ok(NodeCommsResponse::NewBlock(block))
             },
-            NodeCommsRequest::GetTargetDifficulty(pow_algo) => Ok(NodeCommsResponse::TargetDifficulty(
-                self.consensus_manager.get_target_difficulty(
-                    &self.blockchain_db.metadata_read_access()?,
-                    &self.blockchain_db.db_read_access()?,
-                    *pow_algo,
-                )?,
-            )),
+            NodeCommsRequest::GetTargetDifficulty(pow_algo) => {
+                let (db, metadata) = &self.blockchain_db.db_and_metadata_read_access()?;
+                Ok(NodeCommsResponse::TargetDifficulty(
+                    self.consensus_manager.get_target_difficulty(metadata, db, *pow_algo)?,
+                ))
+            },
         }
     }
 

--- a/base_layer/core/src/blocks/block.rs
+++ b/base_layer/core/src/blocks/block.rs
@@ -121,6 +121,11 @@ impl Block {
 
     /// This function will check all stxo to ensure that feature flags where followed
     pub fn check_stxo_rules(&self) -> Result<(), BlockValidationError> {
+        trace!(
+            target: LOG_TARGET,
+            "Checking maturity on inputs on block with hash {}",
+            self.hash().to_hex()
+        );
         for input in self.body.inputs() {
             if input.features.maturity > self.header.height {
                 warn!(

--- a/base_layer/core/src/mempool/mempool.rs
+++ b/base_layer/core/src/mempool/mempool.rs
@@ -104,11 +104,9 @@ where T: BlockchainBackend
             tx.body.kernels()[0].excess_sig.get_signature().to_hex()
         );
         // The transaction is already internally consistent
-        match self.validator.validate(
-            &tx,
-            &self.blockchain_db.db_read_access()?,
-            &self.blockchain_db.metadata_read_access()?,
-        ) {
+        let (db, metadata) = self.blockchain_db.db_and_metadata_read_access()?;
+
+        match self.validator.validate(&tx, &db, &metadata) {
             Ok(()) => {
                 self.unconfirmed_pool.insert(tx)?;
                 Ok(TxStorageResponse::UnconfirmedPool)

--- a/base_layer/core/src/mempool/orphan_pool/orphan_pool_storage.rs
+++ b/base_layer/core/src/mempool/orphan_pool/orphan_pool_storage.rs
@@ -102,11 +102,9 @@ where T: BlockchainBackend
         // We dont care about tx's that appeared in valid blocks. Those tx's will time out in orphan pool and remove
         // them selves.
         for (tx_key, tx) in self.txs_by_signature.iter() {
-            match self.validator.validate(
-                &tx,
-                &self.blockchain_db.db_read_access()?,
-                &self.blockchain_db.metadata_read_access()?,
-            ) {
+            let (db, metadata) = self.blockchain_db.db_and_metadata_read_access()?;
+
+            match self.validator.validate(&tx, &db, &metadata) {
                 Ok(()) => {
                     trace!(
                         target: LOG_TARGET,

--- a/base_layer/core/src/transactions/aggregated_body.rs
+++ b/base_layer/core/src/transactions/aggregated_body.rs
@@ -174,6 +174,7 @@ impl AggregateBody {
     /// Verify the signatures in all kernels contained in this aggregate body. Clients must provide an offset that
     /// will be added to the public key used in the signature verification.
     pub fn verify_kernel_signatures(&self) -> Result<(), TransactionError> {
+        trace!(target: LOG_TARGET, "Checking kernel signatures",);
         for kernel in self.kernels.iter() {
             kernel.verify_signature().or_else(|e| {
                 warn!(target: LOG_TARGET, "Kernel ({}) signature failed {:?}.", kernel, e);
@@ -206,6 +207,7 @@ impl AggregateBody {
     ) -> Result<(), TransactionError>
     {
         let total_offset = factories.commitment.commit_value(&offset, reward.0);
+
         self.verify_kernel_signatures()?;
         self.validate_kernel_sum(total_offset, &factories.commitment)?;
         self.validate_range_proofs(&factories.range_proof)
@@ -240,6 +242,7 @@ impl AggregateBody {
 
     /// Confirm that the (sum of the outputs) - (sum of inputs) = Kernel excess
     fn validate_kernel_sum(&self, offset: Commitment, factory: &CommitmentFactory) -> Result<(), TransactionError> {
+        trace!(target: LOG_TARGET, "Checking kernel total");
         let kernel_sum = self.sum_kernels(offset);
         let sum_io = self.sum_commitments(kernel_sum.fees.into(), factory);
 
@@ -253,6 +256,7 @@ impl AggregateBody {
     }
 
     fn validate_range_proofs(&self, range_proof_service: &RangeProofService) -> Result<(), TransactionError> {
+        trace!(target: LOG_TARGET, "Checking range proofs");
         for o in &self.outputs {
             if !o.verify_range_proof(&range_proof_service)? {
                 return Err(TransactionError::ValidationError(

--- a/base_layer/core/src/validation/helpers.rs
+++ b/base_layer/core/src/validation/helpers.rs
@@ -41,6 +41,7 @@ pub fn check_median_timestamp<B: BlockchainBackend>(
     rules: ConsensusManager,
 ) -> Result<(), ValidationError>
 {
+    trace!(target: LOG_TARGET, "Checking timestamp is not too far in the past",);
     if block_header.height == 0 || rules.get_genesis_block_hash() == block_header.hash() {
         return Ok(()); // Its the genesis block, so we dont have to check median
     }
@@ -75,6 +76,10 @@ pub fn check_achieved_difficulty<B: BlockchainBackend>(
     rules: ConsensusManager,
 ) -> Result<(), ValidationError>
 {
+    trace!(
+        target: LOG_TARGET,
+        "Checking block has acheived the required difficulty",
+    );
     let achieved = block_header.achieved_difficulty();
     let mut target = 1.into();
     if block_header.height > 0 || rules.get_genesis_block_hash() != block_header.hash() {

--- a/base_layer/core/tests/diff_adj_manager.rs
+++ b/base_layer/core/tests/diff_adj_manager.rs
@@ -116,7 +116,7 @@ fn test_initial_sync() {
     assert_eq!(
         diff_adj_manager.get_target_difficulty(
             &store.metadata_read_access().unwrap(),
-            &store.db_read_access().unwrap(),
+            &store.db_and_metadata_read_access().unwrap().0,
             PowAlgorithm::Monero
         ),
         Ok(calculate_accumulated_difficulty(
@@ -128,7 +128,7 @@ fn test_initial_sync() {
     assert_eq!(
         diff_adj_manager.get_target_difficulty(
             &store.metadata_read_access().unwrap(),
-            &store.db_read_access().unwrap(),
+            &store.db_and_metadata_read_access().unwrap().0,
             PowAlgorithm::Blake
         ),
         Ok(calculate_accumulated_difficulty(
@@ -160,7 +160,7 @@ fn test_sync_to_chain_tip() {
     assert_eq!(
         consensus_manager.get_target_difficulty(
             &store.metadata_read_access().unwrap(),
-            &store.db_read_access().unwrap(),
+            &store.db_and_metadata_read_access().unwrap().0,
             PowAlgorithm::Monero
         ),
         Ok(calculate_accumulated_difficulty(
@@ -172,7 +172,7 @@ fn test_sync_to_chain_tip() {
     assert_eq!(
         consensus_manager.get_target_difficulty(
             &store.metadata_read_access().unwrap(),
-            &store.db_read_access().unwrap(),
+            &store.db_and_metadata_read_access().unwrap().0,
             PowAlgorithm::Blake
         ),
         Ok(calculate_accumulated_difficulty(
@@ -194,7 +194,7 @@ fn test_sync_to_chain_tip() {
     assert_eq!(
         consensus_manager.get_target_difficulty(
             &store.metadata_read_access().unwrap(),
-            &store.db_read_access().unwrap(),
+            &store.db_and_metadata_read_access().unwrap().0,
             PowAlgorithm::Monero
         ),
         Ok(calculate_accumulated_difficulty(
@@ -206,7 +206,7 @@ fn test_sync_to_chain_tip() {
     assert_eq!(
         consensus_manager.get_target_difficulty(
             &store.metadata_read_access().unwrap(),
-            &store.db_read_access().unwrap(),
+            &store.db_and_metadata_read_access().unwrap().0,
             PowAlgorithm::Blake
         ),
         Ok(calculate_accumulated_difficulty(
@@ -225,10 +225,10 @@ fn test_target_difficulty_with_height() {
     let diff_adj_manager = DiffAdjManager::new(&consensus_manager.consensus_constants()).unwrap();
     let _ = consensus_manager.set_diff_manager(diff_adj_manager);
     assert!(consensus_manager
-        .get_target_difficulty_with_height(&store.db_read_access().unwrap(), PowAlgorithm::Monero, 5)
+        .get_target_difficulty_with_height(&store.db_and_metadata_read_access().unwrap().0, PowAlgorithm::Monero, 5)
         .is_err());
     assert!(consensus_manager
-        .get_target_difficulty_with_height(&store.db_read_access().unwrap(), PowAlgorithm::Blake, 5)
+        .get_target_difficulty_with_height(&store.db_and_metadata_read_access().unwrap().0, PowAlgorithm::Blake, 5)
         .is_err());
 
     let pow_algos = vec![
@@ -244,7 +244,11 @@ fn test_target_difficulty_with_height() {
     let _ = consensus_manager.set_diff_manager(diff_adj_manager);
 
     assert_eq!(
-        consensus_manager.get_target_difficulty_with_height(&store.db_read_access().unwrap(), PowAlgorithm::Monero, 5),
+        consensus_manager.get_target_difficulty_with_height(
+            &store.db_and_metadata_read_access().unwrap().0,
+            PowAlgorithm::Monero,
+            5
+        ),
         Ok(calculate_accumulated_difficulty(
             &store,
             vec![1, 4],
@@ -252,7 +256,11 @@ fn test_target_difficulty_with_height() {
         ))
     );
     assert_eq!(
-        consensus_manager.get_target_difficulty_with_height(&store.db_read_access().unwrap(), PowAlgorithm::Blake, 5),
+        consensus_manager.get_target_difficulty_with_height(
+            &store.db_and_metadata_read_access().unwrap().0,
+            PowAlgorithm::Blake,
+            5
+        ),
         Ok(calculate_accumulated_difficulty(
             &store,
             vec![0, 2, 3, 5],
@@ -261,7 +269,11 @@ fn test_target_difficulty_with_height() {
     );
 
     assert_eq!(
-        consensus_manager.get_target_difficulty_with_height(&store.db_read_access().unwrap(), PowAlgorithm::Monero, 2),
+        consensus_manager.get_target_difficulty_with_height(
+            &store.db_and_metadata_read_access().unwrap().0,
+            PowAlgorithm::Monero,
+            2
+        ),
         Ok(calculate_accumulated_difficulty(
             &store,
             vec![1],
@@ -269,7 +281,11 @@ fn test_target_difficulty_with_height() {
         ))
     );
     assert_eq!(
-        consensus_manager.get_target_difficulty_with_height(&store.db_read_access().unwrap(), PowAlgorithm::Blake, 2),
+        consensus_manager.get_target_difficulty_with_height(
+            &store.db_and_metadata_read_access().unwrap().0,
+            PowAlgorithm::Blake,
+            2
+        ),
         Ok(calculate_accumulated_difficulty(
             &store,
             vec![0, 2],
@@ -278,7 +294,11 @@ fn test_target_difficulty_with_height() {
     );
 
     assert_eq!(
-        consensus_manager.get_target_difficulty_with_height(&store.db_read_access().unwrap(), PowAlgorithm::Monero, 3),
+        consensus_manager.get_target_difficulty_with_height(
+            &store.db_and_metadata_read_access().unwrap().0,
+            PowAlgorithm::Monero,
+            3
+        ),
         Ok(calculate_accumulated_difficulty(
             &store,
             vec![1],
@@ -286,7 +306,11 @@ fn test_target_difficulty_with_height() {
         ))
     );
     assert_eq!(
-        consensus_manager.get_target_difficulty_with_height(&store.db_read_access().unwrap(), PowAlgorithm::Blake, 3),
+        consensus_manager.get_target_difficulty_with_height(
+            &store.db_and_metadata_read_access().unwrap().0,
+            PowAlgorithm::Blake,
+            3
+        ),
         Ok(calculate_accumulated_difficulty(
             &store,
             vec![0, 2, 3],
@@ -315,7 +339,7 @@ fn test_full_sync_on_reorg() {
     assert_eq!(
         diff_adj_manager.get_target_difficulty(
             &store.metadata_read_access().unwrap(),
-            &store.db_read_access().unwrap(),
+            &store.db_and_metadata_read_access().unwrap().0,
             PowAlgorithm::Monero
         ),
         Ok(Difficulty::from(1))
@@ -323,7 +347,7 @@ fn test_full_sync_on_reorg() {
     assert_eq!(
         diff_adj_manager.get_target_difficulty(
             &store.metadata_read_access().unwrap(),
-            &store.db_read_access().unwrap(),
+            &store.db_and_metadata_read_access().unwrap().0,
             PowAlgorithm::Blake
         ),
         Ok(Difficulty::from(18))
@@ -345,7 +369,7 @@ fn test_full_sync_on_reorg() {
     assert_eq!(
         diff_adj_manager.get_target_difficulty(
             &store.metadata_read_access().unwrap(),
-            &store.db_read_access().unwrap(),
+            &store.db_and_metadata_read_access().unwrap().0,
             PowAlgorithm::Monero
         ),
         Ok(Difficulty::from(2))
@@ -353,7 +377,7 @@ fn test_full_sync_on_reorg() {
     assert_eq!(
         diff_adj_manager.get_target_difficulty(
             &store.metadata_read_access().unwrap(),
-            &store.db_read_access().unwrap(),
+            &store.db_and_metadata_read_access().unwrap().0,
             PowAlgorithm::Blake
         ),
         Ok(Difficulty::from(9))
@@ -370,7 +394,10 @@ fn test_median_timestamp() {
     create_test_pow_blockchain(&store, pow_algos, &consensus_manager.consensus_constants());
     let start_timestamp = store.fetch_block(0).unwrap().block().header.timestamp.clone();
     let mut timestamp = diff_adj_manager
-        .get_median_timestamp(&store.metadata_read_access().unwrap(), &store.db_read_access().unwrap())
+        .get_median_timestamp(
+            &store.metadata_read_access().unwrap(),
+            &store.db_and_metadata_read_access().unwrap().0,
+        )
         .expect("median returned an error");
     assert_eq!(timestamp, start_timestamp);
 
@@ -381,7 +408,10 @@ fn test_median_timestamp() {
     let mut prev_timestamp: EpochTime =
         start_timestamp.increase(consensus_manager.consensus_constants().get_target_block_interval());
     timestamp = diff_adj_manager
-        .get_median_timestamp(&store.metadata_read_access().unwrap(), &store.db_read_access().unwrap())
+        .get_median_timestamp(
+            &store.metadata_read_access().unwrap(),
+            &store.db_and_metadata_read_access().unwrap().0,
+        )
         .expect("median returned an error");
     assert_eq!(timestamp, prev_timestamp);
     // lets add 1
@@ -389,7 +419,10 @@ fn test_median_timestamp() {
     append_to_pow_blockchain(&store, tip, pow_algos.clone(), &consensus_manager.consensus_constants());
     prev_timestamp = start_timestamp.increase(consensus_manager.consensus_constants().get_target_block_interval());
     timestamp = diff_adj_manager
-        .get_median_timestamp(&store.metadata_read_access().unwrap(), &store.db_read_access().unwrap())
+        .get_median_timestamp(
+            &store.metadata_read_access().unwrap(),
+            &store.db_and_metadata_read_access().unwrap().0,
+        )
         .expect("median returned an error");
     assert_eq!(timestamp, prev_timestamp);
 
@@ -400,7 +433,10 @@ fn test_median_timestamp() {
         prev_timestamp =
             start_timestamp.increase(consensus_manager.consensus_constants().get_target_block_interval() * (i / 2));
         timestamp = diff_adj_manager
-            .get_median_timestamp(&store.metadata_read_access().unwrap(), &store.db_read_access().unwrap())
+            .get_median_timestamp(
+                &store.metadata_read_access().unwrap(),
+                &store.db_and_metadata_read_access().unwrap().0,
+            )
             .expect("median returned an error");
         assert_eq!(timestamp, prev_timestamp);
     }
@@ -411,7 +447,10 @@ fn test_median_timestamp() {
         append_to_pow_blockchain(&store, tip, pow_algos.clone(), &consensus_manager.consensus_constants());
         prev_timestamp = prev_timestamp.increase(consensus_manager.consensus_constants().get_target_block_interval());
         timestamp = diff_adj_manager
-            .get_median_timestamp(&store.metadata_read_access().unwrap(), &store.db_read_access().unwrap())
+            .get_median_timestamp(
+                &store.metadata_read_access().unwrap(),
+                &store.db_and_metadata_read_access().unwrap().0,
+            )
             .expect("median returned an error");
         assert_eq!(timestamp, prev_timestamp);
     }
@@ -437,22 +476,22 @@ fn test_median_timestamp_with_height() {
     let header2_timestamp = store.fetch_header(2).unwrap().timestamp;
 
     let timestamp = diff_adj_manager
-        .get_median_timestamp_at_height(&store.db_read_access().unwrap(), 0)
+        .get_median_timestamp_at_height(&store.db_and_metadata_read_access().unwrap().0, 0)
         .expect("median returned an error");
     assert_eq!(timestamp, header0_timestamp);
 
     let timestamp = diff_adj_manager
-        .get_median_timestamp_at_height(&store.db_read_access().unwrap(), 3)
+        .get_median_timestamp_at_height(&store.db_and_metadata_read_access().unwrap().0, 3)
         .expect("median returned an error");
     assert_eq!(timestamp, header2_timestamp);
 
     let timestamp = diff_adj_manager
-        .get_median_timestamp_at_height(&store.db_read_access().unwrap(), 2)
+        .get_median_timestamp_at_height(&store.db_and_metadata_read_access().unwrap().0, 2)
         .expect("median returned an error");
     assert_eq!(timestamp, header1_timestamp);
 
     let timestamp = diff_adj_manager
-        .get_median_timestamp_at_height(&store.db_read_access().unwrap(), 4)
+        .get_median_timestamp_at_height(&store.db_and_metadata_read_access().unwrap().0, 4)
         .expect("median returned an error");
     assert_eq!(timestamp, header2_timestamp);
 }
@@ -467,7 +506,10 @@ fn test_median_timestamp_odd_order() {
     create_test_pow_blockchain(&store, pow_algos, &consensus_manager.consensus_constants());
     let start_timestamp = store.fetch_block(0).unwrap().block().header.timestamp.clone();
     let mut timestamp = diff_adj_manager
-        .get_median_timestamp(&store.metadata_read_access().unwrap(), &store.db_read_access().unwrap())
+        .get_median_timestamp(
+            &store.metadata_read_access().unwrap(),
+            &store.db_and_metadata_read_access().unwrap().0,
+        )
         .expect("median returned an error");
     assert_eq!(timestamp, start_timestamp);
     let pow_algos = vec![PowAlgorithm::Blake];
@@ -477,7 +519,10 @@ fn test_median_timestamp_odd_order() {
     let mut prev_timestamp: EpochTime =
         start_timestamp.increase(consensus_manager.consensus_constants().get_target_block_interval());
     timestamp = diff_adj_manager
-        .get_median_timestamp(&store.metadata_read_access().unwrap(), &store.db_read_access().unwrap())
+        .get_median_timestamp(
+            &store.metadata_read_access().unwrap(),
+            &store.db_and_metadata_read_access().unwrap().0,
+        )
         .expect("median returned an error");
     assert_eq!(timestamp, prev_timestamp);
 
@@ -493,7 +538,10 @@ fn test_median_timestamp_odd_order() {
 
     prev_timestamp = start_timestamp.increase(consensus_manager.consensus_constants().get_target_block_interval() / 2);
     timestamp = diff_adj_manager
-        .get_median_timestamp(&store.metadata_read_access().unwrap(), &store.db_read_access().unwrap())
+        .get_median_timestamp(
+            &store.metadata_read_access().unwrap(),
+            &store.db_and_metadata_read_access().unwrap().0,
+        )
         .expect("median returned an error");
     // Median timestamp should be block 3 and not block 2
     assert_eq!(timestamp, prev_timestamp);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR makes `db_read_access()` on the BlockchainDatabase private and exposes a new method that retrieves a read lock on the metadata as well. There were two instances in the mempool where the read lock on the DB was retrieved before the read lock on the metadata which is the reverse of most other operations. This would cause a deadlock. The new code makes it difficult for future developers to get the order incorrect.

I also added some logging to the validators for some extra tracing

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [ ] I'm merging against the `development` branch.
* [ ] I ran `cargo-fmt --all` before pushing.
* [ ] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
