### PR TITLE
Update transaction cancellation to use status rather than drop the data

### DIFF
--- a/base_layer/wallet/src/transaction_service/storage/sqlite_db.rs
+++ b/base_layer/wallet/src/transaction_service/storage/sqlite_db.rs
@@ -365,9 +365,9 @@ impl TransactionBackend for TransactionServiceSqliteDatabase {
                 }
             },
             Err(TransactionStorageError::DieselError(DieselError::NotFound)) => {
-                return Err(TransactionStorageError::ValueNotFound(
-                    DbKey::PendingInboundTransaction(tx_id),
-                ))
+                return Err(TransactionStorageError::ValueNotFound(DbKey::CompletedTransaction(
+                    tx_id,
+                )))
             },
             Err(e) => return Err(e),
         };
@@ -388,9 +388,25 @@ impl TransactionBackend for TransactionServiceSqliteDatabase {
                 )?;
             },
             Err(TransactionStorageError::DieselError(DieselError::NotFound)) => {
-                return Err(TransactionStorageError::ValueNotFound(
-                    DbKey::PendingInboundTransaction(tx_id),
-                ))
+                return Err(TransactionStorageError::ValueNotFound(DbKey::CompletedTransaction(
+                    tx_id,
+                )))
+            },
+            Err(e) => return Err(e),
+        };
+        Ok(())
+    }
+
+    fn cancel_completed_transaction(&self, tx_id: u64) -> Result<(), TransactionStorageError> {
+        let conn = acquire_lock!(self.database_connection);
+        match CompletedTransactionSql::find(tx_id, &(*conn)) {
+            Ok(v) => {
+                let _ = v.cancel(&(*conn))?;
+            },
+            Err(TransactionStorageError::DieselError(DieselError::NotFound)) => {
+                return Err(TransactionStorageError::ValueNotFound(DbKey::CompletedTransaction(
+                    tx_id,
+                )));
             },
             Err(e) => return Err(e),
         };
@@ -664,12 +680,15 @@ impl CompletedTransactionSql {
     }
 
     pub fn index(conn: &SqliteConnection) -> Result<Vec<CompletedTransactionSql>, TransactionStorageError> {
-        Ok(completed_transactions::table.load::<CompletedTransactionSql>(conn)?)
+        Ok(completed_transactions::table
+            .filter(completed_transactions::status.ne(TransactionStatus::Cancelled as i32))
+            .load::<CompletedTransactionSql>(conn)?)
     }
 
     pub fn find(tx_id: TxId, conn: &SqliteConnection) -> Result<CompletedTransactionSql, TransactionStorageError> {
         Ok(completed_transactions::table
             .filter(completed_transactions::tx_id.eq(tx_id as i64))
+            .filter(completed_transactions::status.ne(TransactionStatus::Cancelled as i32))
             .first::<CompletedTransactionSql>(conn)?)
     }
 
@@ -703,6 +722,24 @@ impl CompletedTransactionSql {
         }
 
         Ok(CompletedTransactionSql::find(self.tx_id as u64, conn)?)
+    }
+
+    pub fn cancel(&self, conn: &SqliteConnection) -> Result<(), TransactionStorageError> {
+        let num_updated =
+            diesel::update(completed_transactions::table.filter(completed_transactions::tx_id.eq(&self.tx_id)))
+                .set(UpdateCompletedTransactionSql {
+                    status: Some(TransactionStatus::Cancelled as i32),
+                    timestamp: None,
+                })
+                .execute(conn)?;
+
+        if num_updated == 0 {
+            return Err(TransactionStorageError::UnexpectedResult(
+                "Database update error".to_string(),
+            ));
+        }
+
+        Ok(())
     }
 }
 

--- a/base_layer/wallet/tests/transaction_service/storage.rs
+++ b/base_layer/wallet/tests/transaction_service/storage.rs
@@ -296,12 +296,19 @@ pub fn test_db_backend<T: TransactionBackend + 'static>(backend: T) {
     let completed_txs = runtime.block_on(db.get_completed_transactions()).unwrap();
     let num_completed_txs = completed_txs.len();
 
+    let cancelled_tx_id = completed_txs[&1].tx_id;
+    assert!(runtime.block_on(db.get_completed_transaction(cancelled_tx_id)).is_ok());
     runtime
-        .block_on(db.cancel_completed_transaction(completed_txs[&1].tx_id))
+        .block_on(db.cancel_completed_transaction(cancelled_tx_id))
         .unwrap();
-
     let completed_txs = runtime.block_on(db.get_completed_transactions()).unwrap();
     assert_eq!(completed_txs.len(), num_completed_txs - 1);
+
+    assert!(runtime.block_on(db.get_completed_transaction(cancelled_tx_id)).is_err());
+
+    assert!(runtime
+        .block_on(db.get_completed_transaction(completed_txs[&0].tx_id))
+        .is_ok());
 }
 
 #[test]

--- a/base_layer/wallet_ffi/src/lib.rs
+++ b/base_layer/wallet_ffi/src/lib.rs
@@ -2131,7 +2131,7 @@ pub unsafe extern "C" fn comms_config_create(
                         max_concurrent_inbound_tasks: 100,
                         outbound_buffer_size: 100,
                         dht: DhtConfig {
-                            discovery_request_timeout: Duration::from_secs(30),
+                            discovery_request_timeout: Duration::from_secs(60),
                             ..Default::default()
                         },
                         // TODO: This should be set to false for non-test wallets. See the `allow_test_addresses` field


### PR DESCRIPTION

## Description
This PR updates transaction cancellation to be done by changing the transaction status rather than dropping the data so that recovery is possible.

## How Has This Been Tested?
Tests updated

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [x] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch.
* [x] I ran `cargo-fmt --all` before pushing.
* [ ] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
