### PR TITLE
Added cli mempool queries for state and stats

### DIFF
--- a/applications/tari_base_node/src/builder.rs
+++ b/applications/tari_base_node/src/builder.rs
@@ -65,7 +65,14 @@ use tari_core::{
         Validators,
     },
     consensus::{ConsensusManager, ConsensusManagerBuilder, Network as NetworkType},
-    mempool::{Mempool, MempoolConfig, MempoolServiceConfig, MempoolServiceInitializer, MempoolValidators},
+    mempool::{
+        service::LocalMempoolService,
+        Mempool,
+        MempoolConfig,
+        MempoolServiceConfig,
+        MempoolServiceInitializer,
+        MempoolValidators,
+    },
     mining::Miner,
     proof_of_work::DiffAdjManager,
     tari_utilities::{hex::Hex, message_format::MessageFormat},
@@ -143,6 +150,12 @@ impl NodeContainer {
     /// with the comms service
     pub fn local_node(&self) -> LocalNodeCommsInterface {
         using_backend!(self, ctx, ctx.local_node())
+    }
+
+    /// Returns a handle to the local mempool service. This function panics if it has not been registered
+    /// with the comms service
+    pub fn local_mempool(&self) -> LocalMempoolService {
+        using_backend!(self, ctx, ctx.local_mempool())
     }
 
     /// Returns the CommsNode.
@@ -231,7 +244,13 @@ impl<B: BlockchainBackend> BaseNodeContext<B> {
     pub fn local_node(&self) -> LocalNodeCommsInterface {
         self.base_node_handles
             .get_handle::<LocalNodeCommsInterface>()
-            .expect("Could not get local comms interface handle")
+            .expect("Could not get local node interface handle")
+    }
+
+    pub fn local_mempool(&self) -> LocalMempoolService {
+        self.base_node_handles
+            .get_handle::<LocalMempoolService>()
+            .expect("Could not get local mempool interface handle")
     }
 
     pub fn wallet_transaction_service(&self) -> TransactionServiceHandle {

--- a/base_layer/core/src/mempool/async_mempool.rs
+++ b/base_layer/core/src/mempool/async_mempool.rs
@@ -23,7 +23,7 @@
 use crate::{
     blocks::Block,
     chain_storage::BlockchainBackend,
-    mempool::{error::MempoolError, Mempool, StatsResponse, TxStorageResponse},
+    mempool::{error::MempoolError, Mempool, StateResponse, StatsResponse, TxStorageResponse},
     transactions::{transaction::Transaction, types::Signature},
 };
 use std::sync::Arc;
@@ -69,3 +69,4 @@ make_async!(snapshot() -> Vec<Arc<Transaction>>);
 make_async!(retrieve(total_weight: u64) -> Vec<Arc<Transaction>>);
 make_async!(has_tx_with_excess_sig(excess_sig: Signature) -> TxStorageResponse);
 make_async!(stats() -> StatsResponse);
+make_async!(state() -> StateResponse);

--- a/base_layer/core/src/mempool/mempool.rs
+++ b/base_layer/core/src/mempool/mempool.rs
@@ -30,6 +30,7 @@ use crate::{
         reorg_pool::ReorgPool,
         unconfirmed_pool::UnconfirmedPool,
         MempoolConfig,
+        StateResponse,
         StatsResponse,
         TxStorageResponse,
     },
@@ -249,6 +250,40 @@ where T: BlockchainBackend
             timelocked_txs: self.pending_pool.len()?,
             published_txs: self.reorg_pool.len()?,
             total_weight: self.calculate_weight()?,
+        })
+    }
+
+    /// Gathers and returns a breakdown of all the transaction in the Mempool.
+    pub fn state(&self) -> Result<StateResponse, MempoolError> {
+        let unconfirmed_pool = self
+            .unconfirmed_pool
+            .snapshot()?
+            .iter()
+            .map(|tx| tx.body.kernels()[0].excess_sig.clone())
+            .collect::<Vec<_>>();
+        let orphan_pool = self
+            .orphan_pool
+            .snapshot()?
+            .iter()
+            .map(|tx| tx.body.kernels()[0].excess_sig.clone())
+            .collect::<Vec<_>>();
+        let pending_pool = self
+            .pending_pool
+            .snapshot()?
+            .iter()
+            .map(|tx| tx.body.kernels()[0].excess_sig.clone())
+            .collect::<Vec<_>>();
+        let reorg_pool = self
+            .reorg_pool
+            .snapshot()?
+            .iter()
+            .map(|tx| tx.body.kernels()[0].excess_sig.clone())
+            .collect::<Vec<_>>();
+        Ok(StateResponse {
+            unconfirmed_pool,
+            orphan_pool,
+            pending_pool,
+            reorg_pool,
         })
     }
 }

--- a/base_layer/core/src/mempool/mod.rs
+++ b/base_layer/core/src/mempool/mod.rs
@@ -58,8 +58,10 @@ pub mod proto;
 #[cfg(any(feature = "base_node", feature = "mempool_proto"))]
 pub mod service;
 
+use crate::transactions::types::Signature;
 use core::fmt::{Display, Error, Formatter};
 use serde::{Deserialize, Serialize};
+use tari_crypto::tari_utilities::hex::Hex;
 
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
 pub struct StatsResponse {
@@ -84,6 +86,37 @@ impl Display for StatsResponse {
             self.published_txs,
             self.total_weight
         )
+    }
+}
+
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
+pub struct StateResponse {
+    pub unconfirmed_pool: Vec<Signature>,
+    pub orphan_pool: Vec<Signature>,
+    pub pending_pool: Vec<Signature>,
+    pub reorg_pool: Vec<Signature>,
+}
+
+impl Display for StateResponse {
+    fn fmt(&self, fmt: &mut Formatter<'_>) -> Result<(), Error> {
+        fmt.write_str("----------------- Mempool -----------------\n")?;
+        fmt.write_str("--- Unconfirmed Pool ---\n")?;
+        for excess_sig in &self.unconfirmed_pool {
+            fmt.write_str(&format!("    {}\n", excess_sig.get_signature().to_hex()))?;
+        }
+        fmt.write_str("--- Orphan Pool ---\n")?;
+        for excess_sig in &self.orphan_pool {
+            fmt.write_str(&format!("    {}\n", excess_sig.get_signature().to_hex()))?;
+        }
+        fmt.write_str("--- Pending Pool ---\n")?;
+        for excess_sig in &self.pending_pool {
+            fmt.write_str(&format!("    {}\n", excess_sig.get_signature().to_hex()))?;
+        }
+        fmt.write_str("--- Reorg Pool ---\n")?;
+        for excess_sig in &self.reorg_pool {
+            fmt.write_str(&format!("    {}\n", excess_sig.get_signature().to_hex()))?;
+        }
+        Ok(())
     }
 }
 

--- a/base_layer/core/src/mempool/proto/mempool_request.rs
+++ b/base_layer/core/src/mempool/proto/mempool_request.rs
@@ -36,6 +36,7 @@ impl TryInto<MempoolRequest> for ProtoMempoolRequest {
         let request = match self {
             // Field was not specified
             GetStats(_) => MempoolRequest::GetStats,
+            GetState(_) => MempoolRequest::GetState,
             GetTxStateWithExcessSig(excess_sig) => MempoolRequest::GetTxStateWithExcessSig(
                 excess_sig.try_into().map_err(|err: ByteArrayError| err.to_string())?,
             ),
@@ -50,6 +51,7 @@ impl From<MempoolRequest> for ProtoMempoolRequest {
         use MempoolRequest::*;
         match request {
             GetStats => ProtoMempoolRequest::GetStats(true),
+            GetState => ProtoMempoolRequest::GetState(true),
             GetTxStateWithExcessSig(excess_sig) => ProtoMempoolRequest::GetTxStateWithExcessSig(excess_sig.into()),
             SubmitTransaction(tx) => ProtoMempoolRequest::SubmitTransaction(tx.into()),
         }

--- a/base_layer/core/src/mempool/proto/mempool_response.rs
+++ b/base_layer/core/src/mempool/proto/mempool_response.rs
@@ -37,6 +37,7 @@ impl TryInto<MempoolResponse> for ProtoMempoolResponse {
         use ProtoMempoolResponse::*;
         let response = match self {
             Stats(stats_response) => MempoolResponse::Stats(stats_response.try_into()?),
+            State(state_response) => MempoolResponse::State(state_response.try_into()?),
             TxStorage(tx_storage_response) => {
                 let tx_storage_response = ProtoTxStorageResponse::from_i32(tx_storage_response)
                     .ok_or_else(|| "Invalid or unrecognised `TxStorageResponse` enum".to_string())?;
@@ -66,6 +67,7 @@ impl From<MempoolResponse> for ProtoMempoolResponse {
         use MempoolResponse::*;
         match response {
             Stats(stats_response) => ProtoMempoolResponse::Stats(stats_response.into()),
+            State(state_response) => ProtoMempoolResponse::State(state_response.into()),
             TxStorage(tx_storage_response) => {
                 let tx_storage_response: ProtoTxStorageResponse = tx_storage_response.into();
                 ProtoMempoolResponse::TxStorage(tx_storage_response.into())

--- a/base_layer/core/src/mempool/proto/mod.rs
+++ b/base_layer/core/src/mempool/proto/mod.rs
@@ -29,6 +29,7 @@ pub mod mempool {
 
 pub mod mempool_request;
 pub mod mempool_response;
+pub mod state_response;
 pub mod stats_response;
 pub mod tx_storage_response;
 pub use mempool::{MempoolServiceRequest, MempoolServiceResponse};

--- a/base_layer/core/src/mempool/proto/service_request.proto
+++ b/base_layer/core/src/mempool/proto/service_request.proto
@@ -11,9 +11,11 @@ message MempoolServiceRequest {
     oneof request {
         // Indicates a GetStats request. The value of the bool should be ignored.
         bool get_stats = 2;
+        // Indicates a GetState request. The value of the bool should be ignored.
+        bool get_state = 3;
         // Indicates a GetTxStateWithExcessSig request.
-        tari.types.Signature get_tx_state_with_excess_sig = 3;
+        tari.types.Signature get_tx_state_with_excess_sig = 4;
         // Indicates a SubmitTransaction request.
-        tari.types.Transaction submit_transaction = 4;
+        tari.types.Transaction submit_transaction = 5;
     }
 }

--- a/base_layer/core/src/mempool/proto/service_response.proto
+++ b/base_layer/core/src/mempool/proto/service_response.proto
@@ -1,6 +1,7 @@
 syntax = "proto3";
 
 import "stats_response.proto";
+import "state_response.proto";
 import "tx_storage_response.proto";
 
 package tari.mempool;
@@ -10,7 +11,8 @@ message MempoolServiceResponse {
     uint64 request_key = 1;
     oneof response {
         StatsResponse stats = 2;
-        TxStorageResponse tx_storage = 3;
+        StateResponse state = 3;
+        TxStorageResponse tx_storage = 4;
     }
 }
 

--- a/base_layer/core/src/mempool/proto/state_response.proto
+++ b/base_layer/core/src/mempool/proto/state_response.proto
@@ -1,0 +1,22 @@
+syntax = "proto3";
+
+package tari.mempool;
+
+// TODO: Remove duplicate Signature, transaction also has a Signature.
+// Define the explicit Signature implementation for the Tari base layer. A different signature scheme can be
+// employed by redefining this type.
+message Signature {
+    bytes public_nonce = 1;
+    bytes signature = 2;
+}
+
+message StateResponse {
+    // List of transactions in unconfirmed pool.
+    repeated Signature unconfirmed_pool = 1;
+    // List of transactions in orphan pool.
+    repeated Signature orphan_pool = 2;
+    // List of transactions in pending pool.
+    repeated Signature pending_pool = 3;
+    // List of transactions in reorg pool.
+    repeated Signature reorg_pool = 4;
+}

--- a/base_layer/core/src/mempool/proto/state_response.rs
+++ b/base_layer/core/src/mempool/proto/state_response.rs
@@ -1,0 +1,98 @@
+// Copyright 2019, The Tari Project
+//
+// Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+// following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+// disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+// following disclaimer in the documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+// products derived from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+// INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+// WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+// USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+use crate::mempool::{proto::mempool::StateResponse as ProtoStateResponse, StateResponse};
+use std::convert::{TryFrom, TryInto};
+// use crate::transactions::proto::types::Signature as ProtoSignature;
+use crate::{
+    mempool::proto::mempool::Signature as ProtoSignature,
+    transactions::types::{PrivateKey, PublicKey, Signature},
+};
+use tari_crypto::tari_utilities::{ByteArray, ByteArrayError};
+
+//---------------------------------- Signature --------------------------------------------//
+// TODO: Remove duplicate Signature, transaction also has a Signature.
+impl TryFrom<ProtoSignature> for Signature {
+    type Error = ByteArrayError;
+
+    fn try_from(sig: ProtoSignature) -> Result<Self, Self::Error> {
+        let public_nonce = PublicKey::from_bytes(&sig.public_nonce)?;
+        let signature = PrivateKey::from_bytes(&sig.signature)?;
+
+        Ok(Self::new(public_nonce, signature))
+    }
+}
+
+impl From<Signature> for ProtoSignature {
+    fn from(sig: Signature) -> Self {
+        Self {
+            public_nonce: sig.get_public_nonce().to_vec(),
+            signature: sig.get_signature().to_vec(),
+        }
+    }
+}
+
+//--------------------------------- StateResponse -------------------------------------------//
+
+impl TryFrom<ProtoStateResponse> for StateResponse {
+    type Error = String;
+
+    fn try_from(state: ProtoStateResponse) -> Result<Self, Self::Error> {
+        Ok(Self {
+            unconfirmed_pool: state
+                .unconfirmed_pool
+                .into_iter()
+                .map(TryInto::try_into)
+                .collect::<Result<Vec<_>, _>>()
+                .map_err(|err: ByteArrayError| err.to_string())?,
+            orphan_pool: state
+                .orphan_pool
+                .into_iter()
+                .map(TryInto::try_into)
+                .collect::<Result<Vec<_>, _>>()
+                .map_err(|err: ByteArrayError| err.to_string())?,
+            pending_pool: state
+                .pending_pool
+                .into_iter()
+                .map(TryInto::try_into)
+                .collect::<Result<Vec<_>, _>>()
+                .map_err(|err: ByteArrayError| err.to_string())?,
+            reorg_pool: state
+                .reorg_pool
+                .into_iter()
+                .map(TryInto::try_into)
+                .collect::<Result<Vec<_>, _>>()
+                .map_err(|err: ByteArrayError| err.to_string())?,
+        })
+    }
+}
+
+impl From<StateResponse> for ProtoStateResponse {
+    fn from(state: StateResponse) -> Self {
+        Self {
+            unconfirmed_pool: state.unconfirmed_pool.into_iter().map(Into::into).collect(),
+            orphan_pool: state.orphan_pool.into_iter().map(Into::into).collect(),
+            pending_pool: state.pending_pool.into_iter().map(Into::into).collect(),
+            reorg_pool: state.reorg_pool.into_iter().map(Into::into).collect(),
+        }
+    }
+}

--- a/base_layer/core/src/mempool/reorg_pool/reorg_pool.rs
+++ b/base_layer/core/src/mempool/reorg_pool/reorg_pool.rs
@@ -111,6 +111,15 @@ impl ReorgPool {
             .len())
     }
 
+    /// Returns all transaction stored in the ReorgPool.
+    pub fn snapshot(&self) -> Result<Vec<Arc<Transaction>>, ReorgPoolError> {
+        Ok(self
+            .pool_storage
+            .write()
+            .map_err(|e| ReorgPoolError::BackendError(e.to_string()))?
+            .snapshot())
+    }
+
     /// Returns the total weight of all transactions stored in the pool.
     pub fn calculate_weight(&self) -> Result<u64, ReorgPoolError> {
         Ok(self

--- a/base_layer/core/src/mempool/reorg_pool/reorg_pool_storage.rs
+++ b/base_layer/core/src/mempool/reorg_pool/reorg_pool_storage.rs
@@ -125,6 +125,11 @@ impl ReorgPoolStorage {
         self.txs_by_signature.iter().count()
     }
 
+    /// Returns all transaction stored in the ReorgPoolStorage.
+    pub fn snapshot(&mut self) -> Vec<Arc<Transaction>> {
+        self.txs_by_signature.iter().map(|(_, tx)| tx).cloned().collect()
+    }
+
     /// Returns the total weight of all transactions stored in the pool.
     pub fn calculate_weight(&mut self) -> u64 {
         self.txs_by_signature

--- a/base_layer/core/src/mempool/service/inbound_handlers.rs
+++ b/base_layer/core/src/mempool/service/inbound_handlers.rs
@@ -62,6 +62,9 @@ where T: BlockchainBackend + 'static
             MempoolRequest::GetStats => Ok(MempoolResponse::Stats(
                 async_mempool::stats(self.mempool.clone()).await?,
             )),
+            MempoolRequest::GetState => Ok(MempoolResponse::State(
+                async_mempool::state(self.mempool.clone()).await?,
+            )),
             MempoolRequest::GetTxStateWithExcessSig(excess_sig) => Ok(MempoolResponse::TxStorage(
                 async_mempool::has_tx_with_excess_sig(self.mempool.clone(), excess_sig.clone()).await?,
             )),

--- a/base_layer/core/src/mempool/service/initializer.rs
+++ b/base_layer/core/src/mempool/service/initializer.rs
@@ -28,6 +28,7 @@ use crate::{
         proto,
         service::{
             inbound_handlers::MempoolInboundHandlers,
+            local_service::LocalMempoolService,
             outbound_interface::OutboundMempoolServiceInterface,
             service::{MempoolService, MempoolStreams},
         },
@@ -157,13 +158,17 @@ where T: BlockchainBackend + 'static
         // Connect MempoolOutboundServiceHandle to MempoolService
         let (outbound_tx_sender_service, outbound_tx_stream) = futures_mpsc_channel_unbounded();
         let (outbound_request_sender_service, outbound_request_stream) = reply_channel::unbounded();
+        let (local_request_sender_service, local_request_stream) = reply_channel::unbounded();
         let outbound_mp_interface =
             OutboundMempoolServiceInterface::new(outbound_request_sender_service, outbound_tx_sender_service);
+        let local_mp_interface = LocalMempoolService::new(local_request_sender_service);
         let config = self.config;
         let mempool = self.mempool.clone();
         let inbound_handlers = MempoolInboundHandlers::new(mempool, outbound_mp_interface.clone());
+
         // Register handle to OutboundMempoolServiceInterface before waiting for handles to be ready
         handles_fut.register(outbound_mp_interface);
+        handles_fut.register(local_mp_interface);
 
         executor.spawn(async move {
             let handles = handles_fut.await;
@@ -182,6 +187,7 @@ where T: BlockchainBackend + 'static
                 inbound_request_stream,
                 inbound_response_stream,
                 inbound_transaction_stream,
+                local_request_stream,
                 base_node.get_block_event_stream(),
             );
             let service = MempoolService::new(outbound_message_service, inbound_handlers, config).start(streams);

--- a/base_layer/core/src/mempool/service/local_service.rs
+++ b/base_layer/core/src/mempool/service/local_service.rs
@@ -21,8 +21,8 @@
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 use crate::mempool::{
-    service::{MempoolRequest, MempoolResponse},
-    MempoolServiceError,
+    service::{MempoolRequest, MempoolResponse, MempoolServiceError},
+    StateResponse,
     StatsResponse,
 };
 use tari_service_framework::reply_channel::{Receiver, SenderService};
@@ -58,6 +58,13 @@ impl LocalMempoolService {
     pub async fn get_mempool_stats(&mut self) -> Result<StatsResponse, MempoolServiceError> {
         match self.request_sender.call(MempoolRequest::GetStats).await?? {
             MempoolResponse::Stats(s) => Ok(s),
+            _ => Err(MempoolServiceError::UnexpectedApiResponse),
+        }
+    }
+
+    pub async fn get_mempool_state(&mut self) -> Result<StateResponse, MempoolServiceError> {
+        match self.request_sender.call(MempoolRequest::GetState).await?? {
+            MempoolResponse::State(s) => Ok(s),
             _ => Err(MempoolServiceError::UnexpectedApiResponse),
         }
     }

--- a/base_layer/core/src/mempool/service/mod.rs
+++ b/base_layer/core/src/mempool/service/mod.rs
@@ -39,6 +39,8 @@ pub use error::MempoolServiceError;
 #[cfg(feature = "base_node")]
 pub use initializer::MempoolServiceInitializer;
 #[cfg(feature = "base_node")]
+pub use local_service::LocalMempoolService;
+#[cfg(feature = "base_node")]
 pub use outbound_interface::OutboundMempoolServiceInterface;
 #[cfg(feature = "base_node")]
 pub use service::MempoolService;

--- a/base_layer/core/src/mempool/service/request.rs
+++ b/base_layer/core/src/mempool/service/request.rs
@@ -32,6 +32,7 @@ use tari_crypto::tari_utilities::hex::Hex;
 #[derive(Debug, Serialize, Deserialize)]
 pub enum MempoolRequest {
     GetStats,
+    GetState,
     GetTxStateWithExcessSig(Signature),
     SubmitTransaction(Transaction),
 }
@@ -40,6 +41,7 @@ impl Display for MempoolRequest {
     fn fmt(&self, f: &mut Formatter) -> Result<(), Error> {
         match self {
             MempoolRequest::GetStats => f.write_str("GetStats"),
+            MempoolRequest::GetState => f.write_str("GetState"),
             MempoolRequest::GetTxStateWithExcessSig(sig) => {
                 f.write_str(&format!("GetTxStateWithExcessSig ({})", sig.get_signature().to_hex()))
             },

--- a/base_layer/core/src/mempool/service/response.rs
+++ b/base_layer/core/src/mempool/service/response.rs
@@ -22,7 +22,7 @@
 
 use crate::{
     base_node::RequestKey,
-    mempool::{StatsResponse, TxStorageResponse},
+    mempool::{StateResponse, StatsResponse, TxStorageResponse},
 };
 use serde::{Deserialize, Serialize};
 
@@ -30,6 +30,7 @@ use serde::{Deserialize, Serialize};
 #[derive(Debug, Serialize, Deserialize)]
 pub enum MempoolResponse {
     Stats(StatsResponse),
+    State(StateResponse),
     TxStorage(TxStorageResponse),
 }
 

--- a/base_layer/core/src/mempool/service/service.rs
+++ b/base_layer/core/src/mempool/service/service.rs
@@ -63,21 +63,23 @@ use tokio::task;
 const LOG_TARGET: &str = "c::mempool::service::service";
 
 /// A convenience struct to hold all the Mempool service streams
-pub struct MempoolStreams<SOutReq, SInReq, SInRes, STxIn> {
+pub struct MempoolStreams<SOutReq, SInReq, SInRes, STxIn, SLocalReq> {
     outbound_request_stream: SOutReq,
     outbound_tx_stream: UnboundedReceiver<(Transaction, Vec<CommsPublicKey>)>,
     inbound_request_stream: SInReq,
     inbound_response_stream: SInRes,
     inbound_transaction_stream: STxIn,
+    local_request_stream: SLocalReq,
     block_event_stream: Subscriber<BlockEvent>,
 }
 
-impl<SOutReq, SInReq, SInRes, STxIn> MempoolStreams<SOutReq, SInReq, SInRes, STxIn>
+impl<SOutReq, SInReq, SInRes, STxIn, SLocalReq> MempoolStreams<SOutReq, SInReq, SInRes, STxIn, SLocalReq>
 where
     SOutReq: Stream<Item = RequestContext<MempoolRequest, Result<MempoolResponse, MempoolServiceError>>>,
     SInReq: Stream<Item = DomainMessage<proto::MempoolServiceRequest>>,
     SInRes: Stream<Item = DomainMessage<proto::MempoolServiceResponse>>,
     STxIn: Stream<Item = DomainMessage<Transaction>>,
+    SLocalReq: Stream<Item = RequestContext<MempoolRequest, Result<MempoolResponse, MempoolServiceError>>>,
 {
     pub fn new(
         outbound_request_stream: SOutReq,
@@ -85,6 +87,7 @@ where
         inbound_request_stream: SInReq,
         inbound_response_stream: SInRes,
         inbound_transaction_stream: STxIn,
+        local_request_stream: SLocalReq,
         block_event_stream: Subscriber<BlockEvent>,
     ) -> Self
     {
@@ -94,6 +97,7 @@ where
             inbound_request_stream,
             inbound_response_stream,
             inbound_transaction_stream,
+            local_request_stream,
             block_event_stream,
         }
     }
@@ -130,15 +134,16 @@ where B: BlockchainBackend + 'static
         }
     }
 
-    pub async fn start<SOutReq, SInReq, SInRes, STxIn>(
+    pub async fn start<SOutReq, SInReq, SInRes, STxIn, SLocalReq>(
         mut self,
-        streams: MempoolStreams<SOutReq, SInReq, SInRes, STxIn>,
+        streams: MempoolStreams<SOutReq, SInReq, SInRes, STxIn, SLocalReq>,
     ) -> Result<(), MempoolServiceError>
     where
         SOutReq: Stream<Item = RequestContext<MempoolRequest, Result<MempoolResponse, MempoolServiceError>>>,
         SInReq: Stream<Item = DomainMessage<proto::MempoolServiceRequest>>,
         SInRes: Stream<Item = DomainMessage<proto::MempoolServiceResponse>>,
         STxIn: Stream<Item = DomainMessage<Transaction>>,
+        SLocalReq: Stream<Item = RequestContext<MempoolRequest, Result<MempoolResponse, MempoolServiceError>>>,
     {
         let outbound_request_stream = streams.outbound_request_stream.fuse();
         pin_mut!(outbound_request_stream);
@@ -150,6 +155,8 @@ where B: BlockchainBackend + 'static
         pin_mut!(inbound_response_stream);
         let inbound_transaction_stream = streams.inbound_transaction_stream.fuse();
         pin_mut!(inbound_transaction_stream);
+        let local_request_stream = streams.local_request_stream.fuse();
+        pin_mut!(local_request_stream);
         let block_event_stream = streams.block_event_stream.fuse();
         pin_mut!(block_event_stream);
         let timeout_receiver_stream = self
@@ -184,6 +191,11 @@ where B: BlockchainBackend + 'static
                 transaction_msg = inbound_transaction_stream.select_next_some() => {
                     self.spawn_handle_incoming_tx(transaction_msg);
                 }
+
+                // Incoming local request messages from the LocalMempoolServiceInterface and other local services
+                local_request_context = local_request_stream.select_next_some() => {
+                    self.spawn_handle_local_request(local_request_context);
+                },
 
                 // Block events from local Base Node.
                 block_event = block_event_stream.select_next_some() => {
@@ -288,6 +300,26 @@ where B: BlockchainBackend + 'static
                 );
                 Err(err)
             });
+        });
+    }
+
+    fn spawn_handle_local_request(
+        &self,
+        request_context: RequestContext<MempoolRequest, Result<MempoolResponse, MempoolServiceError>>,
+    )
+    {
+        let mut inbound_handlers = self.inbound_handlers.clone();
+        task::spawn(async move {
+            let (request, reply_tx) = request_context.split();
+            let _ = reply_tx
+                .send(inbound_handlers.handle_request(&request).await)
+                .or_else(|err| {
+                    error!(
+                        target: LOG_TARGET,
+                        "MempoolService failed to send reply to local request {:?}", err
+                    );
+                    Err(err)
+                });
         });
     }
 

--- a/base_layer/wallet/src/transaction_service/service.rs
+++ b/base_layer/wallet/src/transaction_service/service.rs
@@ -1219,6 +1219,11 @@ where
                     "Mempool Response of invalid type".to_string(),
                 ))
             },
+            MempoolResponse::State(_) => {
+                return Err(TransactionServiceError::InvalidMessageError(
+                    "Mempool Response of invalid type".to_string(),
+                ))
+            },
             MempoolResponse::TxStorage(ts) => {
                 let completed_tx = self.db.get_completed_transaction(response.request_key.clone()).await?;
 

--- a/base_layer/wallet/tests/transaction_service/service.rs
+++ b/base_layer/wallet/tests/transaction_service/service.rs
@@ -1577,6 +1577,7 @@ fn transaction_mempool_broadcast() {
 
     match mempool_service_request.request {
         MempoolRequest::GetStats => assert!(false, "Invalid Mempool Service Request variant"),
+        MempoolRequest::GetState => assert!(false, "Invalid Mempool Service Request variant"),
         MempoolRequest::GetTxStateWithExcessSig(_) => assert!(false, "Invalid Mempool Service Request variant"),
         MempoolRequest::SubmitTransaction(tx) => assert_eq!(tx, alice_completed_tx.transaction),
     }


### PR DESCRIPTION
## Description
- Added two cli functions to enable the mempool stats and state of the local node to be queried.
- Added a state function and state response to the mempool that returns a list of transaction excess signatures for each pool in the mempool.
- Added proto conversions for StateResponse and Signature. Duplicate Signature conversions exist and the one copy should be removed at a later point.

## Motivation and Context
These changes allow the mempool to be inspected to see which transactions are in the local pools.

## How Has This Been Tested?
No tests were added.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch.
* [x] I ran `cargo-fmt --all` before pushing.
* [x] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
