### PR TITLE
Fixed issue where a bad orphan block can stop a valid reorg

### DIFF
--- a/base_layer/core/src/base_node/states/listening.rs
+++ b/base_layer/core/src/base_node/states/listening.rs
@@ -140,8 +140,8 @@ fn determine_sync_mode(
             } else {
                 info!(
                     target: log_target,
-                    "Our local blockchain is up-to-date. We're at block #{} with an accumulated difficulty of {} and \
-                     the network chain tip is at #{} with an accumulated difficulty of {}",
+                    "Our blockchain is up-to-date. We're at block {} with an accumulated difficulty of {} and the \
+                     network chain tip is at {} with an accumulated difficulty of {}",
                     local.height_of_longest_chain.unwrap_or(0),
                     local_tip_accum_difficulty,
                     network.height_of_longest_chain.unwrap_or(0),

--- a/base_layer/core/src/validation/block_validators.rs
+++ b/base_layer/core/src/validation/block_validators.rs
@@ -228,7 +228,7 @@ fn check_mmr_roots<B: BlockchainBackend>(block: &Block, db: &RwLockWriteGuard<B>
 fn check_cut_through(block: &Block) -> Result<(), ValidationError> {
     trace!(
         target: LOG_TARGET,
-        "Checking coinbase output on block with hash {}",
+        "Checking cut through on block with hash {}",
         block.hash().to_hex()
     );
     if !block.body.cut_through_check() {


### PR DESCRIPTION
## Description
- Updated the try_construct_fork function to check every new block that is added to the fork chain if it is connected to the main chain. This will fix a potential issue where a bad orphan block was added to the beginning of the fork chain that is already linked to the main chain causing the fork chain to fail validation.
- Some log messages were corrected and updated with better descriptions.

## Motivation and Context
Fixes an issue where a bad orphan block can stop a valid reorg.

## How Has This Been Tested?
Existing tests remain functioning.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch.
* [x] I ran `cargo-fmt --all` before pushing.
* [x] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
