### PR TITLE
Use a single line to display the search height

### DIFF
--- a/applications/tari_base_node/src/parser.rs
+++ b/applications/tari_base_node/src/parser.rs
@@ -33,6 +33,7 @@ use rustyline::{
 };
 use rustyline_derive::{Helper, Highlighter, Validator};
 use std::{
+    io::{self, Write},
     str::FromStr,
     string::ToString,
     sync::{
@@ -630,21 +631,31 @@ impl Parser {
                 .pop()
                 .expect("Could not retrieve tip header from db");
             let mut missing_blocks = Vec::new();
+            let mut missing_headers = Vec::new();
+            print!("Searching for height: ");
             while height > 0 {
+                print!("{}", height);
+                io::stdout().flush().unwrap();
                 let block = node.get_blocks(vec![height]).await;
-                println!("searching for height: {}", height);
                 if block.is_err() {
                     // for some apparent reason this block is missing, means we have to ask for it again
-                    missing_blocks.push(current_header.hash());
-                    println!("missing block for height {}", height);
+                    missing_blocks.push((current_header.hash().to_hex(), height));
                 };
                 height -= 1;
                 let next_header = node.get_headers(vec![height]).await;
                 if next_header.is_err() {
                     // this header is missing, so we stop here and need to ask for this header
-                    println!("missing header for {}", height);
+                    missing_headers.push(height);
                 };
                 current_header = next_header.unwrap().pop().expect("Could not retrieve header from db");
+                print!("\x1B[{}D\x1B[K", (height + 1).to_string().chars().count());
+            }
+            println!("Complete");
+            for missing_block in missing_blocks {
+                println!("Missing block at height: {} {}", missing_block.1, missing_block.0);
+            }
+            for missing_header_height in missing_headers {
+                println!("Missing header at height: {}", missing_header_height)
             }
         });
     }


### PR DESCRIPTION

[![asciicast](https://asciinema.org/a/PDVDZWvzTijSMtG3WvtV4gQrL.png)](https://asciinema.org/a/PDVDZWvzTijSMtG3WvtV4gQrL)

## Description
<!--- Describe your changes in detail -->
Used escape sequences in the output to display the searching string on a single line and output the missing blocks / headers after the loop has run. 
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This will avoid lots of scrolling or missing blocks scrolling out of view before you can see them.
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch.
* [x] I ran `cargo-fmt --all` before pushing.
* [x] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
