### PR TITLE
Do a UTXO sync during get_balance and send_tari CLI commands

### DIFF
--- a/applications/tari_base_node/src/parser.rs
+++ b/applications/tari_base_node/src/parser.rs
@@ -318,6 +318,9 @@ impl Parser {
     fn process_get_balance(&mut self) {
         let mut handler = self.wallet_output_service.clone();
         self.executor.spawn(async move {
+            // TODO perform this function more intelligently in the Output Manager
+            let _ = handler.sync_with_base_node().await;
+
             match handler.get_balance().await {
                 Err(e) => {
                     println!("Something went wrong");
@@ -762,7 +765,11 @@ impl Parser {
 
         let fee_per_gram = 25 * uT;
         let mut txn_service = self.wallet_transaction_service.clone();
+        let mut oms_handle = self.wallet_output_service.clone();
         self.executor.spawn(async move {
+            // TODO perform this function more intelligently in the Output Manager
+            let _ = oms_handle.sync_with_base_node().await;
+
             let event_stream = txn_service.get_event_stream_fused();
             match txn_service
                 .send_transaction(dest_pubkey.clone(), amount, fee_per_gram, msg)


### PR DESCRIPTION
To have the base node wallet perform this check more often we will just trigger it to start whenever the user interacts with the wallet aspect of the base node application.

In the near future we will do away with this and have the Output Manager manage this in a more proactive manner.