### PR TITLE
RwLockReadGuards and RwLockWriteGuards refactor

### DIFF
--- a/applications/tari_base_node/src/parser.rs
+++ b/applications/tari_base_node/src/parser.rs
@@ -558,7 +558,7 @@ impl Parser {
             println!("list-headers [amount of headers from top]");
             return;
         }
-        let mut handler = self.node_service.clone();
+        let handler = self.node_service.clone();
         self.executor.spawn(async move {
             let headers = Parser::get_headers(handler, command_arg).await;
             for header in headers {
@@ -632,7 +632,7 @@ impl Parser {
             return;
         }
 
-        let mut handler = self.node_service.clone();
+        let handler = self.node_service.clone();
         self.executor.spawn(async move {
             let headers = Parser::get_headers(handler, command_arg).await;
             let mut total = 0;

--- a/base_layer/core/src/base_node/comms_interface/inbound_handlers.rs
+++ b/base_layer/core/src/base_node/comms_interface/inbound_handlers.rs
@@ -236,7 +236,8 @@ where T: BlockchainBackend + 'static
             NodeCommsRequest::GetTargetDifficulty(pow_algo) => {
                 let (db, metadata) = &self.blockchain_db.db_and_metadata_read_access()?;
                 Ok(NodeCommsResponse::TargetDifficulty(
-                    self.consensus_manager.get_target_difficulty(metadata, db, *pow_algo)?,
+                    self.consensus_manager
+                        .get_target_difficulty(metadata, &**db, *pow_algo)?,
                 ))
             },
         }

--- a/base_layer/core/src/chain_storage/mod.rs
+++ b/base_layer/core/src/chain_storage/mod.rs
@@ -40,11 +40,8 @@ pub mod async_db;
 // Public API exports
 pub use blockchain_database::{
     calculate_mmr_roots,
-    calculate_mmr_roots_writeguard,
     fetch_header,
-    fetch_header_writeguard,
     is_utxo,
-    is_utxo_writeguard,
     BlockAddResult,
     BlockchainBackend,
     BlockchainDatabase,

--- a/base_layer/core/src/proof_of_work/diff_adj_manager/diff_adj_manager.rs
+++ b/base_layer/core/src/proof_of_work/diff_adj_manager/diff_adj_manager.rs
@@ -29,7 +29,7 @@ use crate::{
         PowAlgorithm,
     },
 };
-use std::sync::{Arc, RwLock, RwLockReadGuard, RwLockWriteGuard};
+use std::sync::{Arc, RwLock};
 use tari_crypto::tari_utilities::epoch_time::EpochTime;
 
 /// The DiffAdjManager is used to calculate the current target difficulty based on PoW recorded in the latest blocks of
@@ -49,8 +49,8 @@ impl DiffAdjManager {
     /// Returns the estimated target difficulty for the specified PoW algorithm at the chain tip.
     pub fn get_target_difficulty<B: BlockchainBackend>(
         &self,
-        metadata: &RwLockReadGuard<ChainMetadata>,
-        db: &RwLockReadGuard<B>,
+        metadata: &ChainMetadata,
+        db: &B,
         pow_algo: PowAlgorithm,
     ) -> Result<Difficulty, DiffAdjManagerError>
     {
@@ -63,7 +63,7 @@ impl DiffAdjManager {
     /// Returns the estimated target difficulty for the specified PoW algorithm and provided height.
     pub fn get_target_difficulty_at_height<B: BlockchainBackend>(
         &self,
-        db: &RwLockReadGuard<B>,
+        db: &B,
         pow_algo: PowAlgorithm,
         height: u64,
     ) -> Result<Difficulty, DiffAdjManagerError>
@@ -74,25 +74,11 @@ impl DiffAdjManager {
             .get_target_difficulty_at_height(db, pow_algo, height)
     }
 
-    /// Returns the estimated target difficulty for the specified PoW algorithm and provided height.
-    pub fn get_target_difficulty_at_height_writeguard<B: BlockchainBackend>(
-        &self,
-        db: &RwLockWriteGuard<B>,
-        pow_algo: PowAlgorithm,
-        height: u64,
-    ) -> Result<Difficulty, DiffAdjManagerError>
-    {
-        self.diff_adj_storage
-            .write()
-            .map_err(|_| DiffAdjManagerError::PoisonedAccess)?
-            .get_target_difficulty_at_height_writeguard(db, pow_algo, height)
-    }
-
     /// Returns the median timestamp of the past 11 blocks at the chain tip.
     pub fn get_median_timestamp<B: BlockchainBackend>(
         &self,
-        metadata: &RwLockReadGuard<ChainMetadata>,
-        db: &RwLockReadGuard<B>,
+        metadata: &ChainMetadata,
+        db: &B,
     ) -> Result<EpochTime, DiffAdjManagerError>
     {
         self.diff_adj_storage
@@ -104,7 +90,7 @@ impl DiffAdjManager {
     /// Returns the median timestamp of the past 11 blocks at the provided height.
     pub fn get_median_timestamp_at_height<B: BlockchainBackend>(
         &self,
-        db: &RwLockReadGuard<B>,
+        db: &B,
         height: u64,
     ) -> Result<EpochTime, DiffAdjManagerError>
     {
@@ -112,19 +98,6 @@ impl DiffAdjManager {
             .write()
             .map_err(|_| DiffAdjManagerError::PoisonedAccess)?
             .get_median_timestamp_at_height(db, height)
-    }
-
-    /// Returns the median timestamp of the past 11 blocks at the provided height.
-    pub fn get_median_timestamp_at_height_writeguard<B: BlockchainBackend>(
-        &self,
-        db: &RwLockWriteGuard<B>,
-        height: u64,
-    ) -> Result<EpochTime, DiffAdjManagerError>
-    {
-        self.diff_adj_storage
-            .write()
-            .map_err(|_| DiffAdjManagerError::PoisonedAccess)?
-            .get_median_timestamp_at_height_writeguard(db, height)
     }
 }
 

--- a/base_layer/core/src/validation/helpers.rs
+++ b/base_layer/core/src/validation/helpers.rs
@@ -30,12 +30,11 @@ use crate::{
 use log::*;
 use tari_crypto::tari_utilities::hash::Hashable;
 pub const LOG_TARGET: &str = "c::val::helpers";
-use std::sync::RwLockWriteGuard;
 use tari_crypto::tari_utilities::hex::Hex;
 
 /// This function tests that the block timestamp is greater than the median timestamp at the specified height.
 pub fn check_median_timestamp<B: BlockchainBackend>(
-    db: &RwLockWriteGuard<B>,
+    db: &B,
     block_header: &BlockHeader,
     height: u64,
     rules: ConsensusManager,
@@ -46,7 +45,7 @@ pub fn check_median_timestamp<B: BlockchainBackend>(
         return Ok(()); // Its the genesis block, so we dont have to check median
     }
     let median_timestamp = rules
-        .get_median_timestamp_at_height_writeguard(db, height)
+        .get_median_timestamp_at_height(db, height)
         .or_else(|e| {
             error!(target: LOG_TARGET, "Validation could not get median timestamp");
 
@@ -70,7 +69,7 @@ pub fn check_median_timestamp<B: BlockchainBackend>(
 
 /// Calculates the achieved and target difficulties at the specified height and compares them.
 pub fn check_achieved_difficulty<B: BlockchainBackend>(
-    db: &RwLockWriteGuard<B>,
+    db: &B,
     block_header: &BlockHeader,
     height: u64,
     rules: ConsensusManager,
@@ -84,7 +83,7 @@ pub fn check_achieved_difficulty<B: BlockchainBackend>(
     let mut target = 1.into();
     if block_header.height > 0 || rules.get_genesis_block_hash() != block_header.hash() {
         target = rules
-            .get_target_difficulty_with_height_writeguard(db, block_header.pow.pow_algo, height)
+            .get_target_difficulty_with_height(db, block_header.pow.pow_algo, height)
             .or_else(|e| {
                 error!(target: LOG_TARGET, "Validation could not get achieved difficulty");
                 Err(e)

--- a/base_layer/core/src/validation/mocks.rs
+++ b/base_layer/core/src/validation/mocks.rs
@@ -20,12 +20,11 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use super::{StatelessValidation, Validation, ValidationWriteGuard};
+use super::{StatelessValidation, Validation};
 use crate::{
     chain_storage::{BlockchainBackend, ChainMetadata},
     validation::error::ValidationError,
 };
-use std::sync::{RwLockReadGuard, RwLockWriteGuard};
 
 #[derive(Clone)]
 pub struct MockValidator {
@@ -39,31 +38,7 @@ impl MockValidator {
 }
 
 impl<T, B: BlockchainBackend> Validation<T, B> for MockValidator {
-    fn validate(
-        &self,
-        _item: &T,
-        _db: &RwLockReadGuard<B>,
-        _metadata: &RwLockReadGuard<ChainMetadata>,
-    ) -> Result<(), ValidationError>
-    {
-        if self.result {
-            Ok(())
-        } else {
-            Err(ValidationError::CustomError(
-                "This mock validator always returns an error".into(),
-            ))
-        }
-    }
-}
-
-impl<T, B: BlockchainBackend> ValidationWriteGuard<T, B> for MockValidator {
-    fn validate(
-        &self,
-        _item: &T,
-        _db: &RwLockWriteGuard<B>,
-        _metadata: &RwLockWriteGuard<ChainMetadata>,
-    ) -> Result<(), ValidationError>
-    {
+    fn validate(&self, _item: &T, _db: &B, _metadata: &ChainMetadata) -> Result<(), ValidationError> {
         if self.result {
             Ok(())
         } else {

--- a/base_layer/core/src/validation/mod.rs
+++ b/base_layer/core/src/validation/mod.rs
@@ -34,12 +34,5 @@ mod traits;
 pub mod block_validators;
 pub mod mocks;
 pub use error::ValidationError;
-pub use traits::{
-    StatelessValidation,
-    StatelessValidator,
-    Validation,
-    ValidationWriteGuard,
-    Validator,
-    ValidatorWriteGuard,
-};
+pub use traits::{StatelessValidation, StatelessValidator, Validation, Validator};
 pub mod transaction_validators;

--- a/base_layer/core/src/validation/traits.rs
+++ b/base_layer/core/src/validation/traits.rs
@@ -24,10 +24,8 @@ use crate::{
     chain_storage::{BlockchainBackend, ChainMetadata},
     validation::error::ValidationError,
 };
-use std::sync::{RwLockReadGuard, RwLockWriteGuard};
 
 pub type Validator<T, B> = Box<dyn Validation<T, B>>;
-pub type ValidatorWriteGuard<T, B> = Box<dyn ValidationWriteGuard<T, B>>;
 pub type StatelessValidator<T> = Box<dyn StatelessValidation<T>>;
 
 /// The core validation trait. Multiple `Validation` implementors can be chained together in a [ValidatorPipeline] to
@@ -37,25 +35,7 @@ pub trait Validation<T, B>: Send + Sync
 where B: BlockchainBackend
 {
     /// General validation code that can run independent of external state
-    fn validate(
-        &self,
-        item: &T,
-        db: &RwLockReadGuard<B>,
-        metadata: &RwLockReadGuard<ChainMetadata>,
-    ) -> Result<(), ValidationError>;
-}
-
-/// A write guard version of the core validation trait that allows access to the db backend using a lock write guard.
-pub trait ValidationWriteGuard<T, B>: Send + Sync
-where B: BlockchainBackend
-{
-    /// General validation code that can run independent of external state
-    fn validate(
-        &self,
-        item: &T,
-        db: &RwLockWriteGuard<B>,
-        metadata: &RwLockWriteGuard<ChainMetadata>,
-    ) -> Result<(), ValidationError>;
+    fn validate(&self, item: &T, db: &B, metadata: &ChainMetadata) -> Result<(), ValidationError>;
 }
 
 /// Stateless version of the core validation trait.

--- a/base_layer/core/tests/diff_adj_manager.rs
+++ b/base_layer/core/tests/diff_adj_manager.rs
@@ -116,7 +116,7 @@ fn test_initial_sync() {
     assert_eq!(
         diff_adj_manager.get_target_difficulty(
             &store.metadata_read_access().unwrap(),
-            &store.db_and_metadata_read_access().unwrap().0,
+            &*store.db_and_metadata_read_access().unwrap().0,
             PowAlgorithm::Monero
         ),
         Ok(calculate_accumulated_difficulty(
@@ -128,7 +128,7 @@ fn test_initial_sync() {
     assert_eq!(
         diff_adj_manager.get_target_difficulty(
             &store.metadata_read_access().unwrap(),
-            &store.db_and_metadata_read_access().unwrap().0,
+            &*store.db_and_metadata_read_access().unwrap().0,
             PowAlgorithm::Blake
         ),
         Ok(calculate_accumulated_difficulty(
@@ -160,7 +160,7 @@ fn test_sync_to_chain_tip() {
     assert_eq!(
         consensus_manager.get_target_difficulty(
             &store.metadata_read_access().unwrap(),
-            &store.db_and_metadata_read_access().unwrap().0,
+            &*store.db_and_metadata_read_access().unwrap().0,
             PowAlgorithm::Monero
         ),
         Ok(calculate_accumulated_difficulty(
@@ -172,7 +172,7 @@ fn test_sync_to_chain_tip() {
     assert_eq!(
         consensus_manager.get_target_difficulty(
             &store.metadata_read_access().unwrap(),
-            &store.db_and_metadata_read_access().unwrap().0,
+            &*store.db_and_metadata_read_access().unwrap().0,
             PowAlgorithm::Blake
         ),
         Ok(calculate_accumulated_difficulty(
@@ -194,7 +194,7 @@ fn test_sync_to_chain_tip() {
     assert_eq!(
         consensus_manager.get_target_difficulty(
             &store.metadata_read_access().unwrap(),
-            &store.db_and_metadata_read_access().unwrap().0,
+            &*store.db_and_metadata_read_access().unwrap().0,
             PowAlgorithm::Monero
         ),
         Ok(calculate_accumulated_difficulty(
@@ -206,7 +206,7 @@ fn test_sync_to_chain_tip() {
     assert_eq!(
         consensus_manager.get_target_difficulty(
             &store.metadata_read_access().unwrap(),
-            &store.db_and_metadata_read_access().unwrap().0,
+            &*store.db_and_metadata_read_access().unwrap().0,
             PowAlgorithm::Blake
         ),
         Ok(calculate_accumulated_difficulty(
@@ -225,10 +225,14 @@ fn test_target_difficulty_with_height() {
     let diff_adj_manager = DiffAdjManager::new(&consensus_manager.consensus_constants()).unwrap();
     let _ = consensus_manager.set_diff_manager(diff_adj_manager);
     assert!(consensus_manager
-        .get_target_difficulty_with_height(&store.db_and_metadata_read_access().unwrap().0, PowAlgorithm::Monero, 5)
+        .get_target_difficulty_with_height(
+            &*store.db_and_metadata_read_access().unwrap().0,
+            PowAlgorithm::Monero,
+            5
+        )
         .is_err());
     assert!(consensus_manager
-        .get_target_difficulty_with_height(&store.db_and_metadata_read_access().unwrap().0, PowAlgorithm::Blake, 5)
+        .get_target_difficulty_with_height(&*store.db_and_metadata_read_access().unwrap().0, PowAlgorithm::Blake, 5)
         .is_err());
 
     let pow_algos = vec![
@@ -245,7 +249,7 @@ fn test_target_difficulty_with_height() {
 
     assert_eq!(
         consensus_manager.get_target_difficulty_with_height(
-            &store.db_and_metadata_read_access().unwrap().0,
+            &*store.db_and_metadata_read_access().unwrap().0,
             PowAlgorithm::Monero,
             5
         ),
@@ -257,7 +261,7 @@ fn test_target_difficulty_with_height() {
     );
     assert_eq!(
         consensus_manager.get_target_difficulty_with_height(
-            &store.db_and_metadata_read_access().unwrap().0,
+            &*store.db_and_metadata_read_access().unwrap().0,
             PowAlgorithm::Blake,
             5
         ),
@@ -270,7 +274,7 @@ fn test_target_difficulty_with_height() {
 
     assert_eq!(
         consensus_manager.get_target_difficulty_with_height(
-            &store.db_and_metadata_read_access().unwrap().0,
+            &*store.db_and_metadata_read_access().unwrap().0,
             PowAlgorithm::Monero,
             2
         ),
@@ -282,7 +286,7 @@ fn test_target_difficulty_with_height() {
     );
     assert_eq!(
         consensus_manager.get_target_difficulty_with_height(
-            &store.db_and_metadata_read_access().unwrap().0,
+            &*store.db_and_metadata_read_access().unwrap().0,
             PowAlgorithm::Blake,
             2
         ),
@@ -295,7 +299,7 @@ fn test_target_difficulty_with_height() {
 
     assert_eq!(
         consensus_manager.get_target_difficulty_with_height(
-            &store.db_and_metadata_read_access().unwrap().0,
+            &*store.db_and_metadata_read_access().unwrap().0,
             PowAlgorithm::Monero,
             3
         ),
@@ -307,7 +311,7 @@ fn test_target_difficulty_with_height() {
     );
     assert_eq!(
         consensus_manager.get_target_difficulty_with_height(
-            &store.db_and_metadata_read_access().unwrap().0,
+            &*store.db_and_metadata_read_access().unwrap().0,
             PowAlgorithm::Blake,
             3
         ),
@@ -339,7 +343,7 @@ fn test_full_sync_on_reorg() {
     assert_eq!(
         diff_adj_manager.get_target_difficulty(
             &store.metadata_read_access().unwrap(),
-            &store.db_and_metadata_read_access().unwrap().0,
+            &*store.db_and_metadata_read_access().unwrap().0,
             PowAlgorithm::Monero
         ),
         Ok(Difficulty::from(1))
@@ -347,7 +351,7 @@ fn test_full_sync_on_reorg() {
     assert_eq!(
         diff_adj_manager.get_target_difficulty(
             &store.metadata_read_access().unwrap(),
-            &store.db_and_metadata_read_access().unwrap().0,
+            &*store.db_and_metadata_read_access().unwrap().0,
             PowAlgorithm::Blake
         ),
         Ok(Difficulty::from(18))
@@ -369,7 +373,7 @@ fn test_full_sync_on_reorg() {
     assert_eq!(
         diff_adj_manager.get_target_difficulty(
             &store.metadata_read_access().unwrap(),
-            &store.db_and_metadata_read_access().unwrap().0,
+            &*store.db_and_metadata_read_access().unwrap().0,
             PowAlgorithm::Monero
         ),
         Ok(Difficulty::from(2))
@@ -377,7 +381,7 @@ fn test_full_sync_on_reorg() {
     assert_eq!(
         diff_adj_manager.get_target_difficulty(
             &store.metadata_read_access().unwrap(),
-            &store.db_and_metadata_read_access().unwrap().0,
+            &*store.db_and_metadata_read_access().unwrap().0,
             PowAlgorithm::Blake
         ),
         Ok(Difficulty::from(9))
@@ -396,7 +400,7 @@ fn test_median_timestamp() {
     let mut timestamp = diff_adj_manager
         .get_median_timestamp(
             &store.metadata_read_access().unwrap(),
-            &store.db_and_metadata_read_access().unwrap().0,
+            &*store.db_and_metadata_read_access().unwrap().0,
         )
         .expect("median returned an error");
     assert_eq!(timestamp, start_timestamp);
@@ -410,7 +414,7 @@ fn test_median_timestamp() {
     timestamp = diff_adj_manager
         .get_median_timestamp(
             &store.metadata_read_access().unwrap(),
-            &store.db_and_metadata_read_access().unwrap().0,
+            &*store.db_and_metadata_read_access().unwrap().0,
         )
         .expect("median returned an error");
     assert_eq!(timestamp, prev_timestamp);
@@ -421,7 +425,7 @@ fn test_median_timestamp() {
     timestamp = diff_adj_manager
         .get_median_timestamp(
             &store.metadata_read_access().unwrap(),
-            &store.db_and_metadata_read_access().unwrap().0,
+            &*store.db_and_metadata_read_access().unwrap().0,
         )
         .expect("median returned an error");
     assert_eq!(timestamp, prev_timestamp);
@@ -435,7 +439,7 @@ fn test_median_timestamp() {
         timestamp = diff_adj_manager
             .get_median_timestamp(
                 &store.metadata_read_access().unwrap(),
-                &store.db_and_metadata_read_access().unwrap().0,
+                &*store.db_and_metadata_read_access().unwrap().0,
             )
             .expect("median returned an error");
         assert_eq!(timestamp, prev_timestamp);
@@ -449,7 +453,7 @@ fn test_median_timestamp() {
         timestamp = diff_adj_manager
             .get_median_timestamp(
                 &store.metadata_read_access().unwrap(),
-                &store.db_and_metadata_read_access().unwrap().0,
+                &*store.db_and_metadata_read_access().unwrap().0,
             )
             .expect("median returned an error");
         assert_eq!(timestamp, prev_timestamp);
@@ -476,22 +480,22 @@ fn test_median_timestamp_with_height() {
     let header2_timestamp = store.fetch_header(2).unwrap().timestamp;
 
     let timestamp = diff_adj_manager
-        .get_median_timestamp_at_height(&store.db_and_metadata_read_access().unwrap().0, 0)
+        .get_median_timestamp_at_height(&*store.db_and_metadata_read_access().unwrap().0, 0)
         .expect("median returned an error");
     assert_eq!(timestamp, header0_timestamp);
 
     let timestamp = diff_adj_manager
-        .get_median_timestamp_at_height(&store.db_and_metadata_read_access().unwrap().0, 3)
+        .get_median_timestamp_at_height(&*store.db_and_metadata_read_access().unwrap().0, 3)
         .expect("median returned an error");
     assert_eq!(timestamp, header2_timestamp);
 
     let timestamp = diff_adj_manager
-        .get_median_timestamp_at_height(&store.db_and_metadata_read_access().unwrap().0, 2)
+        .get_median_timestamp_at_height(&*store.db_and_metadata_read_access().unwrap().0, 2)
         .expect("median returned an error");
     assert_eq!(timestamp, header1_timestamp);
 
     let timestamp = diff_adj_manager
-        .get_median_timestamp_at_height(&store.db_and_metadata_read_access().unwrap().0, 4)
+        .get_median_timestamp_at_height(&*store.db_and_metadata_read_access().unwrap().0, 4)
         .expect("median returned an error");
     assert_eq!(timestamp, header2_timestamp);
 }
@@ -508,7 +512,7 @@ fn test_median_timestamp_odd_order() {
     let mut timestamp = diff_adj_manager
         .get_median_timestamp(
             &store.metadata_read_access().unwrap(),
-            &store.db_and_metadata_read_access().unwrap().0,
+            &*store.db_and_metadata_read_access().unwrap().0,
         )
         .expect("median returned an error");
     assert_eq!(timestamp, start_timestamp);
@@ -521,7 +525,7 @@ fn test_median_timestamp_odd_order() {
     timestamp = diff_adj_manager
         .get_median_timestamp(
             &store.metadata_read_access().unwrap(),
-            &store.db_and_metadata_read_access().unwrap().0,
+            &*store.db_and_metadata_read_access().unwrap().0,
         )
         .expect("median returned an error");
     assert_eq!(timestamp, prev_timestamp);
@@ -540,7 +544,7 @@ fn test_median_timestamp_odd_order() {
     timestamp = diff_adj_manager
         .get_median_timestamp(
             &store.metadata_read_access().unwrap(),
-            &store.db_and_metadata_read_access().unwrap().0,
+            &*store.db_and_metadata_read_access().unwrap().0,
         )
         .expect("median returned an error");
     // Median timestamp should be block 3 and not block 2

--- a/base_layer/core/tests/helpers/nodes.rs
+++ b/base_layer/core/tests/helpers/nodes.rs
@@ -53,7 +53,7 @@ use tari_core::{
         mocks::MockValidator,
         transaction_validators::TxInputAndMaturityValidator,
         StatelessValidation,
-        ValidationWriteGuard,
+        Validation,
     },
 };
 use tari_mmr::MmrCacheConfig;
@@ -159,7 +159,7 @@ impl BaseNodeBuilder {
 
     pub fn with_validators(
         mut self,
-        block: impl ValidationWriteGuard<Block, MemoryDatabase<HashDigest>> + 'static,
+        block: impl Validation<Block, MemoryDatabase<HashDigest>> + 'static,
         orphan: impl StatelessValidation<Block> + 'static,
     ) -> Self
     {


### PR DESCRIPTION
## Description
- Cleaned up duplicate code from the Blockchain db, consensus manager, difficulty adjustment manager by removing unnecessary RwLockReadGuards and RwLockWriteGuards.
- Removed the ValidationWriteGuard trait and changed the block and transaction validators to use the simplified version.

## Motivation and Context
These changes simplifies the blockchain db, consensus manager and difficulty adjustment manager calls where a RwLockReadGuards or RwLockWriteGuards could be used. It makes that only 2 validator traits are needed and not 3.

## How Has This Been Tested?
Covered by existing tests.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [x] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch.
* [x] I ran `cargo-fmt --all` before pushing.
* [x] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
