### PR TITLE
Validators will now check the weight of a block when doing validation

### DIFF
--- a/base_layer/core/src/blocks/block.rs
+++ b/base_layer/core/src/blocks/block.rs
@@ -63,6 +63,8 @@ pub enum BlockValidationError {
     MismatchedMmrRoots,
     // The block contains transactions that should have been cut through.
     NoCutThrough,
+    // The block weight is above the maximum
+    BlockTooLarge,
 }
 
 /// A Tari block. Blocks are linked together into a blockchain.

--- a/base_layer/core/src/transactions/aggregated_body.rs
+++ b/base_layer/core/src/transactions/aggregated_body.rs
@@ -21,6 +21,7 @@
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 use crate::transactions::{
+    fee::Fee,
     tari_amount::*,
     transaction::*,
     types::{BlindingFactor, Commitment, CommitmentFactory, CryptoFactories, PrivateKey, RangeProofService},
@@ -265,6 +266,11 @@ impl AggregateBody {
             }
         }
         Ok(())
+    }
+
+    /// Returns the byte size or weight of a body
+    pub fn calculate_weight(&self) -> u64 {
+        Fee::calculate_weight(self.inputs().len(), self.outputs().len())
     }
 }
 

--- a/base_layer/core/src/transactions/transaction.rs
+++ b/base_layer/core/src/transactions/transaction.rs
@@ -25,7 +25,6 @@
 
 use crate::transactions::{
     aggregated_body::AggregateBody,
-    fee::Fee,
     tari_amount::{uT, MicroTari},
     transaction_protocol::{build_challenge, TransactionMetadata},
     types::{
@@ -623,7 +622,7 @@ impl Transaction {
 
     /// Returns the byte size or weight of a transaction
     pub fn calculate_weight(&self) -> u64 {
-        Fee::calculate_weight(self.body.inputs().len(), self.body.outputs().len())
+        self.body.calculate_weight()
     }
 
     /// Returns the total fee allocated to each byte of the transaction


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Validators will now check the block weight when doing validation and return a weight error if its too large

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Blocks have a maximum size, this is represented in the consensus constants with the max weight field. By calculating the maximum weight of a block we can get a fairly accurate estimation of the maximum size of the block. This is to stop blocks getting too large. 


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch.
* [x] I ran `cargo-fmt --all` before pushing.
* [x] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
