### PR TITLE
Resync UTXOs a period after a coinbase is imported

### DIFF
--- a/applications/tari_base_node/src/parser.rs
+++ b/applications/tari_base_node/src/parser.rs
@@ -318,9 +318,6 @@ impl Parser {
     fn process_get_balance(&mut self) {
         let mut handler = self.wallet_output_service.clone();
         self.executor.spawn(async move {
-            // TODO perform this function more intelligently in the Output Manager
-            let _ = handler.sync_with_base_node().await;
-
             match handler.get_balance().await {
                 Err(e) => {
                     println!("Something went wrong");
@@ -735,11 +732,7 @@ impl Parser {
 
         let fee_per_gram = 25 * uT;
         let mut txn_service = self.wallet_transaction_service.clone();
-        let mut oms_handle = self.wallet_output_service.clone();
         self.executor.spawn(async move {
-            // TODO perform this function more intelligently in the Output Manager
-            let _ = oms_handle.sync_with_base_node().await;
-
             let event_stream = txn_service.get_event_stream_fused();
             match txn_service
                 .send_transaction(dest_pubkey.clone(), amount, fee_per_gram, msg)


### PR DESCRIPTION
## Description
Instead of triggering a resync on Wallet operations from the tari_base_node CLI rather schedule a resync 4 minutes after a coinbase is imported into the wallet and do it in the background.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [x] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch.
* [x] I ran `cargo-fmt --all` before pushing.
* [ ] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
