### PR TITLE
Check if the  incoming tx contains STxO or not

### DIFF
--- a/base_layer/core/src/chain_storage/async_db.rs
+++ b/base_layer/core/src/chain_storage/async_db.rs
@@ -99,6 +99,7 @@ make_async!(fetch_utxo(hash: HashOutput) -> TransactionOutput, "fetch_utxo");
 make_async!(fetch_stxo(hash: HashOutput) -> TransactionOutput, "fetch_stxo");
 make_async!(fetch_orphan(hash: HashOutput) -> Block, "fetch_orphan");
 make_async!(is_utxo(hash: HashOutput) -> bool, "is_utxo");
+make_async!(is_stxo(hash: HashOutput) -> bool, "is_stxo");
 make_async!(fetch_mmr_root(tree: MmrTree) -> HashOutput, "fetch_mmr_root");
 make_async!(fetch_mmr_only_root(tree: MmrTree) -> HashOutput, "fetch_mmr_only_root");
 make_async!(calculate_mmr_root(tree: MmrTree,additions: Vec<HashOutput>,deletions: Vec<HashOutput>) -> HashOutput, "calculate_mmr_root");

--- a/base_layer/core/src/chain_storage/blockchain_database.rs
+++ b/base_layer/core/src/chain_storage/blockchain_database.rs
@@ -307,6 +307,12 @@ where T: BlockchainBackend
         fetch_stxo(&*db, hash)
     }
 
+    /// Returns the STXO with the given hash.
+    pub fn is_stxo(&self, hash: HashOutput) -> Result<bool, ChainStorageError> {
+        let db = self.db_read_access()?;
+        is_stxo(&*db, hash)
+    }
+
     /// Returns the orphan block with the given hash.
     pub fn fetch_orphan(&self, hash: HashOutput) -> Result<Block, ChainStorageError> {
         let db = self.db_read_access()?;
@@ -514,6 +520,11 @@ fn fetch_orphan<T: BlockchainBackend>(db: &T, hash: HashOutput) -> Result<Block,
 
 pub fn is_utxo<T: BlockchainBackend>(db: &T, hash: HashOutput) -> Result<bool, ChainStorageError> {
     let key = DbKey::UnspentOutput(hash);
+    db.contains(&key)
+}
+
+pub fn is_stxo<T: BlockchainBackend>(db: &T, hash: HashOutput) -> Result<bool, ChainStorageError> {
+    let key = DbKey::SpentOutput(hash);
     db.contains(&key)
 }
 

--- a/base_layer/core/src/chain_storage/mod.rs
+++ b/base_layer/core/src/chain_storage/mod.rs
@@ -41,6 +41,7 @@ pub mod async_db;
 pub use blockchain_database::{
     calculate_mmr_roots,
     fetch_header,
+    is_stxo,
     is_utxo,
     BlockAddResult,
     BlockchainBackend,

--- a/base_layer/core/src/mempool/mempool_storage.rs
+++ b/base_layer/core/src/mempool/mempool_storage.rs
@@ -94,6 +94,10 @@ where T: BlockchainBackend
                 self.orphan_pool.insert(tx)?;
                 Ok(TxStorageResponse::OrphanPool)
             },
+            Err(ValidationError::ContainsSTxO) => {
+                self.reorg_pool.insert(tx)?;
+                Ok(TxStorageResponse::ReorgPool)
+            },
             Err(ValidationError::MaturityError) => {
                 self.pending_pool.insert(tx)?;
                 Ok(TxStorageResponse::PendingPool)

--- a/base_layer/core/src/mempool/reorg_pool/reorg_pool.rs
+++ b/base_layer/core/src/mempool/reorg_pool/reorg_pool.rs
@@ -78,6 +78,16 @@ impl ReorgPool {
         Ok(())
     }
 
+    /// Insert a new transaction into the ReorgPool. Published transactions will have a limited Time-to-live in
+    /// the ReorgPool and will be discarded once the Time-to-live threshold has been reached.
+    pub fn insert(&self, transaction: Arc<Transaction>) -> Result<(), ReorgPoolError> {
+        self.pool_storage
+            .write()
+            .map_err(|e| ReorgPoolError::BackendError(e.to_string()))?
+            .insert(transaction);
+        Ok(())
+    }
+
     /// Check if a transaction is stored in the ReorgPool
     pub fn has_tx_with_excess_sig(&self, excess_sig: &Signature) -> Result<bool, ReorgPoolError> {
         Ok(self

--- a/base_layer/core/src/validation/error.rs
+++ b/base_layer/core/src/validation/error.rs
@@ -44,4 +44,6 @@ pub enum ValidationError {
     // The total expected supply plus the total accumulated (offset) excess does not equal the sum of all UTXO
     // commitments.
     InvalidAccountingBalance,
+    // Transaction contains already spent inputs
+    ContainsSTxO,
 }

--- a/base_layer/core/tests/async_db.rs
+++ b/base_layer/core/tests/async_db.rs
@@ -134,7 +134,7 @@ fn fetch_async_utxo() {
 }
 
 #[test]
-fn async_is_utxo() {
+fn async_is_utxo_stxo() {
     let (db, blocks, outputs, _) = create_blockchain_db_no_cut_through();
     let factory = CommitmentFactory::default();
     blocks.iter().for_each(|b| println!("{}", b));
@@ -144,6 +144,10 @@ fn async_is_utxo() {
     // Check using sync functions
     assert_eq!(db.is_utxo(utxo.hash()), Ok(true));
     assert_eq!(db.is_utxo(stxo.hash()), Ok(false));
+
+    assert_eq!(db.is_stxo(utxo.hash()), Ok(false));
+    assert_eq!(db.is_stxo(stxo.hash()), Ok(true));
+
     test_async(move |rt| {
         let db = db.clone();
         let db2 = db.clone();
@@ -151,10 +155,16 @@ fn async_is_utxo() {
         rt.spawn(async move {
             let is_utxo = async_db::is_utxo(db.clone(), utxo.hash()).await;
             assert_eq!(is_utxo, Ok(true));
+
+            let is_stxo = async_db::is_stxo(db.clone(), utxo.hash()).await;
+            assert_eq!(is_stxo, Ok(false));
         });
         rt.spawn(async move {
             let is_utxo = async_db::is_utxo(db2.clone(), stxo.hash()).await;
             assert_eq!(is_utxo, Ok(false));
+
+            let is_stxo = async_db::is_stxo(db2.clone(), stxo.hash()).await;
+            assert_eq!(is_stxo, Ok(true));
         });
     });
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR adds in a check for new transactions if they are contain STxO's or not.  If they contain STxO's they are moved to the reorg pool and not orphan pool. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Currently if a base node receives an old transaction it will flag as an orphan transaction and move it into the orphan pool because the inputs are not valid UTxO's. This will cause the base node to retransmit the transaction out to its peers. 

By checking the if the transaction contains STxO's, we can see if they contain spent outputs. We move the transaction to the reorg pool and we dont retransmit the transaction. This will reduce some network traffic as well as we dont re send transaction to peers. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Unit tests for check stxo's

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [x] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch.
* [x] I ran `cargo-fmt --all` before pushing.
* [x] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
