### PR TITLE
Add rustfmt to github action dependencies

### DIFF
--- a/.github/workflows/clippy-check.yml
+++ b/.github/workflows/clippy-check.yml
@@ -8,7 +8,7 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: nightly
-          components: clippy
+          components: clippy, rustfmt
           override: true
       - name: Install dependencies
         run: |


### PR DESCRIPTION
Some crates require rustfmt to compile