### PR TITLE
Update testnet consensus constants

### DIFF
--- a/base_layer/core/src/blocks/genesis_block.rs
+++ b/base_layer/core/src/blocks/genesis_block.rs
@@ -108,7 +108,7 @@ pub fn get_rincewind_genesis_block_raw() -> Block {
             prev_hash: vec![
                 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
             ],
-            timestamp: 1_585_476_000.into(), // Sunday, 29 March 2020 12:00:00 GMT+02:00
+            timestamp: 1_585_900_800.into(), // Friday, 3 April 2020 10:00:00 GMT+02:00
             output_mr: from_hex("fab84d9d797c272b33011caa78718f93c3d5fc44c7d35bbf138613440fca2c79").unwrap(),
             range_proof_mr: from_hex("63a36ba139a884434702dffccec348b02ba886d3851a19732d8d111a54e17d56").unwrap(),
             kernel_mr: from_hex("b097af173dc852862f48af67aa57f48c47d20bc608d77b46a3018999bffba911").unwrap(),

--- a/base_layer/core/src/consensus/consensus_constants.rs
+++ b/base_layer/core/src/consensus/consensus_constants.rs
@@ -138,7 +138,7 @@ impl ConsensusConstants {
 
     #[allow(clippy::identity_op)]
     pub fn rincewind() -> Self {
-        let target_block_interval = 60;
+        let target_block_interval = 120;
         let difficulty_block_window = 150;
         ConsensusConstants {
             coinbase_lock_height: 60,
@@ -147,13 +147,13 @@ impl ConsensusConstants {
             target_block_interval,
             difficulty_block_window,
             difficulty_max_block_interval: target_block_interval * 60,
-            max_block_transaction_weight: 6250,
+            max_block_transaction_weight: 19500,
             pow_algo_count: 1,
             median_timestamp_count: 11,
             emission_initial: 5_538_846_115 * uT,
             emission_decay: 0.999_999_560_409_038_5,
             emission_tail: 1 * T,
-            min_pow_difficulty: 6_000_000.into(),
+            min_pow_difficulty: 60_000_000.into(),
         }
     }
 
@@ -167,7 +167,7 @@ impl ConsensusConstants {
             target_block_interval,
             difficulty_max_block_interval: target_block_interval * 6,
             difficulty_block_window,
-            max_block_transaction_weight: 6250,
+            max_block_transaction_weight: 19500,
             pow_algo_count: 2,
             median_timestamp_count: 11,
             emission_initial: 10_000_000.into(),
@@ -188,7 +188,7 @@ impl ConsensusConstants {
             target_block_interval,
             difficulty_max_block_interval: target_block_interval * 6,
             difficulty_block_window,
-            max_block_transaction_weight: 6250,
+            max_block_transaction_weight: 19500,
             pow_algo_count: 2,
             median_timestamp_count: 11,
             emission_initial: 10_000_000.into(),

--- a/base_layer/core/src/consensus/consensus_constants.rs
+++ b/base_layer/core/src/consensus/consensus_constants.rs
@@ -139,7 +139,7 @@ impl ConsensusConstants {
     #[allow(clippy::identity_op)]
     pub fn rincewind() -> Self {
         let target_block_interval = 120;
-        let difficulty_block_window = 150;
+        let difficulty_block_window = 90;
         ConsensusConstants {
             coinbase_lock_height: 60,
             blockchain_version: 1,


### PR DESCRIPTION
This PR is in preparation for Rincewind testnet launch.

Block interval is increased to 120s. Testing at one minute intervals
produced many orphaned blocks. Transaction propagation over ToR is not
quite fast enough at this stage; this can be revisited in future if/when
tx propagation times improve.

Max block weight icreased to 19500: In line with the new transaction
weights, this limit keeps blocks at around 1MB.

Minimum difficulty increased to 60e6; about 2 minutes on a single
MAcbook Pro.

Genesis block timestamp updated.

