### PR TITLE
Prevent adding yourself as a peer

### DIFF
--- a/applications/tari_base_node/src/builder.rs
+++ b/applications/tari_base_node/src/builder.rs
@@ -908,6 +908,14 @@ async fn add_peers_to_comms(comms: &CommsNode, peers: Vec<Peer>) -> Result<(), S
     for p in peers {
         let peer_desc = p.to_string();
         info!(target: LOG_TARGET, "Adding seed peer [{}]", peer_desc);
+
+        if &p.public_key == comms.node_identity().public_key() {
+            info!(
+                target: LOG_TARGET,
+                "Attempting to add yourself [{}] as a seed peer to comms layer, ignoring request", peer_desc
+            );
+            continue;
+        }
         comms
             .peer_manager()
             .add_peer(p)


### PR DESCRIPTION
## Description
Updated add_peers_to_comms to prevent adding yourself as a peer

## Motivation and Context
To be able to use a single configuration file for all base nodes

## How Has This Been Tested?
cargo test --all --all-features

## Types of changes
* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
* [x] I'm merging against the `development` branch.
* [x] I ran `cargo-fmt --all` before pushing.
* [x] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
