### PR TITLE
Removed chain metadata from blockchain db.

### DIFF
--- a/base_layer/core/src/base_node/comms_interface/inbound_handlers.rs
+++ b/base_layer/core/src/base_node/comms_interface/inbound_handlers.rs
@@ -234,10 +234,9 @@ where T: BlockchainBackend + 'static
                 Ok(NodeCommsResponse::NewBlock(block))
             },
             NodeCommsRequest::GetTargetDifficulty(pow_algo) => {
-                let (db, metadata) = &self.blockchain_db.db_and_metadata_read_access()?;
+                let db = &self.blockchain_db.db_read_access()?;
                 Ok(NodeCommsResponse::TargetDifficulty(
-                    self.consensus_manager
-                        .get_target_difficulty(metadata, &**db, *pow_algo)?,
+                    self.consensus_manager.get_target_difficulty(&**db, *pow_algo)?,
                 ))
             },
         }

--- a/base_layer/core/src/chain_storage/lmdb_db/lmdb_db.rs
+++ b/base_layer/core/src/chain_storage/lmdb_db/lmdb_db.rs
@@ -21,10 +21,22 @@
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 use crate::{
-    blocks::{blockheader::BlockHeader, Block},
+    blocks::{
+        blockheader::{BlockHash, BlockHeader},
+        Block,
+    },
     chain_storage::{
         blockchain_database::BlockchainBackend,
-        db_transaction::{DbKey, DbKeyValuePair, DbTransaction, DbValue, MetadataValue, MmrTree, WriteOperation},
+        db_transaction::{
+            DbKey,
+            DbKeyValuePair,
+            DbTransaction,
+            DbValue,
+            MetadataKey,
+            MetadataValue,
+            MmrTree,
+            WriteOperation,
+        },
         error::ChainStorageError,
         lmdb_db::{
             lmdb::{lmdb_delete, lmdb_exists, lmdb_for_each, lmdb_get, lmdb_insert, lmdb_len, lmdb_replace},
@@ -42,7 +54,9 @@ use crate::{
             LMDB_DB_UTXO_MMR_CP_BACKEND,
         },
         memory_db::MemDbVec,
+        ChainMetadata,
     },
+    proof_of_work::Difficulty,
     transactions::{
         transaction::{TransactionKernel, TransactionOutput},
         types::{HashDigest, HashOutput},
@@ -76,6 +90,7 @@ where D: Digest
 {
     env: Arc<Environment>,
     metadata_db: DatabaseRef,
+    mem_metadata: ChainMetadata, // Memory copy of stored metadata
     headers_db: DatabaseRef,
     block_hashes_db: DatabaseRef,
     utxos_db: DatabaseRef,
@@ -122,12 +137,23 @@ where D: Digest + Send + Sync
                 .db()
                 .clone(),
         );
+        // Restore memory metadata
+        let env = store.env();
+        let metadata_db = store
+            .get_handle(LMDB_DB_METADATA)
+            .ok_or_else(|| ChainStorageError::CriticalError)?
+            .db()
+            .clone();
+        let metadata = ChainMetadata {
+            height_of_longest_chain: fetch_chain_height(&env, &metadata_db)?,
+            best_block: fetch_best_block(&env, &metadata_db)?,
+            pruning_horizon: fetch_pruning_horizon(&env, &metadata_db)?,
+            accumulated_difficulty: fetch_accumulated_work(&env, &metadata_db)?,
+        };
+
         Ok(Self {
-            metadata_db: store
-                .get_handle(LMDB_DB_METADATA)
-                .ok_or_else(|| ChainStorageError::CriticalError)?
-                .db()
-                .clone(),
+            metadata_db,
+            mem_metadata: metadata,
             headers_db: store
                 .get_handle(LMDB_DB_HEADERS)
                 .ok_or_else(|| ChainStorageError::CriticalError)?
@@ -172,7 +198,7 @@ where D: Digest + Send + Sync
             range_proof_mmr: MmrCache::new(MemDbVec::new(), range_proof_checkpoints.clone(), mmr_cache_config)?,
             range_proof_checkpoints,
             curr_range_proof_checkpoint: MerkleCheckPoint::new(Vec::new(), Bitmap::create()),
-            env: store.env(),
+            env,
         })
     }
 
@@ -276,6 +302,7 @@ where D: Digest + Send + Sync
     // changes committed to the backend databases. CreateMmrCheckpoint and RewindMmr txns will be performed after these
     // txns have been successfully applied.
     fn apply_mmr_and_storage_txs(&mut self, tx: &DbTransaction) -> Result<(), ChainStorageError> {
+        let mut update_mem_metadata = false;
         let txn = WriteTransaction::new(self.env.clone()).map_err(|e| ChainStorageError::AccessError(e.to_string()))?;
         {
             for op in tx.operations.iter() {
@@ -283,6 +310,7 @@ where D: Digest + Send + Sync
                     WriteOperation::Insert(insert) => match insert {
                         DbKeyValuePair::Metadata(k, v) => {
                             lmdb_replace(&txn, &self.metadata_db, &(k.clone() as u32), &v)?;
+                            update_mem_metadata = true;
                         },
                         DbKeyValuePair::BlockHeader(k, v) => {
                             if lmdb_exists(&self.env, &self.headers_db, &k)? {
@@ -389,7 +417,18 @@ where D: Digest + Send + Sync
                 }
             }
         }
-        txn.commit().map_err(|e| ChainStorageError::AccessError(e.to_string()))
+        txn.commit()
+            .map_err(|e| ChainStorageError::AccessError(e.to_string()))?;
+
+        if update_mem_metadata {
+            self.mem_metadata = ChainMetadata {
+                height_of_longest_chain: fetch_chain_height(&self.env, &self.metadata_db)?,
+                best_block: fetch_best_block(&self.env, &self.metadata_db)?,
+                pruning_horizon: fetch_pruning_horizon(&self.env, &self.metadata_db)?,
+                accumulated_difficulty: fetch_accumulated_work(&self.env, &self.metadata_db)?,
+            };
+        }
+        Ok(())
     }
 
     // Returns the leaf index of the hash. If the hash is in the newly added hashes it returns the future MMR index for
@@ -645,6 +684,67 @@ where D: Digest + Send + Sync
             Ok(None)
         }
     }
+
+    /// Returns the metadata of the chain.
+    fn fetch_metadata(&self) -> Result<ChainMetadata, ChainStorageError> {
+        Ok(self.mem_metadata.clone())
+    }
+}
+
+// Fetches the chain height from the provided metadata db.
+fn fetch_chain_height(env: &Environment, db: &Database) -> Result<Option<u64>, ChainStorageError> {
+    let k = MetadataKey::ChainHeight;
+    let val: Option<MetadataValue> = lmdb_get(&env, &db, &(k as u32))?;
+    let val: Option<DbValue> = val.map(DbValue::Metadata);
+    Ok(
+        if let Some(DbValue::Metadata(MetadataValue::ChainHeight(height))) = val {
+            height
+        } else {
+            None
+        },
+    )
+}
+
+// Fetches the best block hash from the provided metadata db.
+fn fetch_best_block(env: &Environment, db: &Database) -> Result<Option<BlockHash>, ChainStorageError> {
+    let k = MetadataKey::BestBlock;
+    let val: Option<MetadataValue> = lmdb_get(&env, &db, &(k as u32))?;
+    let val: Option<DbValue> = val.map(DbValue::Metadata);
+    Ok(
+        if let Some(DbValue::Metadata(MetadataValue::BestBlock(best_block))) = val {
+            best_block
+        } else {
+            None
+        },
+    )
+}
+
+// Fetches the accumulated work from the provided metadata db.
+fn fetch_accumulated_work(env: &Environment, db: &Database) -> Result<Option<Difficulty>, ChainStorageError> {
+    let k = MetadataKey::AccumulatedWork;
+    let val: Option<MetadataValue> = lmdb_get(&env, &db, &(k as u32))?;
+    let val: Option<DbValue> = val.map(DbValue::Metadata);
+    Ok(
+        if let Some(DbValue::Metadata(MetadataValue::AccumulatedWork(accumulated_work))) = val {
+            accumulated_work
+        } else {
+            None
+        },
+    )
+}
+
+// Fetches the pruning horizon from the provided metadata db.
+fn fetch_pruning_horizon(env: &Environment, db: &Database) -> Result<u64, ChainStorageError> {
+    let k = MetadataKey::PruningHorizon;
+    let val: Option<MetadataValue> = lmdb_get(&env, &db, &(k as u32))?;
+    let val: Option<DbValue> = val.map(DbValue::Metadata);
+    Ok(
+        if let Some(DbValue::Metadata(MetadataValue::PruningHorizon(pruning_horizon))) = val {
+            pruning_horizon
+        } else {
+            2880
+        },
+    )
 }
 
 // Calculated the new checkpoint count after rewinding a set number of steps back.

--- a/base_layer/core/src/consensus/consensus_manager.rs
+++ b/base_layer/core/src/consensus/consensus_manager.rs
@@ -30,7 +30,7 @@ use crate::{
         },
         Block,
     },
-    chain_storage::{BlockchainBackend, ChainMetadata, ChainStorageError},
+    chain_storage::{BlockchainBackend, ChainStorageError},
     consensus::{emission::EmissionSchedule, network::Network, ConsensusConstants},
     proof_of_work::{DiffAdjManager, DiffAdjManagerError, Difficulty, DifficultyAdjustmentError, PowAlgorithm},
     transactions::tari_amount::MicroTari,
@@ -115,14 +115,13 @@ impl ConsensusManager {
     /// Returns the estimated target difficulty for the specified PoW algorithm at the chain tip.
     pub fn get_target_difficulty<B: BlockchainBackend>(
         &self,
-        metadata: &ChainMetadata,
         db: &B,
         pow_algo: PowAlgorithm,
     ) -> Result<Difficulty, ConsensusManagerError>
     {
         match self.access_diff_adj()?.as_ref() {
             Some(v) => v
-                .get_target_difficulty(metadata, db, pow_algo)
+                .get_target_difficulty(db, pow_algo)
                 .map_err(ConsensusManagerError::DifficultyAdjustmentManagerError),
             None => Err(ConsensusManagerError::MissingDifficultyAdjustmentManager),
         }
@@ -145,15 +144,10 @@ impl ConsensusManager {
     }
 
     /// Returns the median timestamp of the past 11 blocks at the chain tip.
-    pub fn get_median_timestamp<B: BlockchainBackend>(
-        &self,
-        metadata: &ChainMetadata,
-        db: &B,
-    ) -> Result<EpochTime, ConsensusManagerError>
-    {
+    pub fn get_median_timestamp<B: BlockchainBackend>(&self, db: &B) -> Result<EpochTime, ConsensusManagerError> {
         match self.access_diff_adj()?.as_ref() {
             Some(v) => v
-                .get_median_timestamp(metadata, db)
+                .get_median_timestamp(db)
                 .map_err(ConsensusManagerError::DifficultyAdjustmentManagerError),
             None => Err(ConsensusManagerError::MissingDifficultyAdjustmentManager),
         }

--- a/base_layer/core/src/helpers/mock_backend.rs
+++ b/base_layer/core/src/helpers/mock_backend.rs
@@ -19,11 +19,10 @@
 // SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-//
 
 use crate::{
     blocks::{Block, BlockHeader},
-    chain_storage::{BlockchainBackend, ChainStorageError, DbKey, DbTransaction, DbValue, MmrTree},
+    chain_storage::{BlockchainBackend, ChainMetadata, ChainStorageError, DbKey, DbTransaction, DbValue, MmrTree},
     transactions::{
         transaction::{TransactionKernel, TransactionOutput},
         types::HashOutput,
@@ -111,6 +110,10 @@ impl BlockchainBackend for MockBackend {
     }
 
     fn fetch_last_header(&self) -> Result<Option<BlockHeader>, ChainStorageError> {
+        unimplemented!()
+    }
+
+    fn fetch_metadata(&self) -> Result<ChainMetadata, ChainStorageError> {
         unimplemented!()
     }
 }

--- a/base_layer/core/src/mempool/mempool_storage.rs
+++ b/base_layer/core/src/mempool/mempool_storage.rs
@@ -83,9 +83,9 @@ where T: BlockchainBackend
             tx.body.kernels()[0].excess_sig.get_signature().to_hex()
         );
         // The transaction is already internally consistent
-        let (db, metadata) = self.blockchain_db.db_and_metadata_read_access()?;
+        let db = self.blockchain_db.db_read_access()?;
 
-        match self.validator.validate(&tx, &db, &metadata) {
+        match self.validator.validate(&tx, &db) {
             Ok(()) => {
                 self.unconfirmed_pool.insert(tx)?;
                 Ok(TxStorageResponse::UnconfirmedPool)

--- a/base_layer/core/src/mempool/orphan_pool/orphan_pool_storage.rs
+++ b/base_layer/core/src/mempool/orphan_pool/orphan_pool_storage.rs
@@ -102,9 +102,9 @@ where T: BlockchainBackend
         // We dont care about tx's that appeared in valid blocks. Those tx's will time out in orphan pool and remove
         // them selves.
         for (tx_key, tx) in self.txs_by_signature.iter() {
-            let (db, metadata) = self.blockchain_db.db_and_metadata_read_access()?;
+            let db = self.blockchain_db.db_read_access()?;
 
-            match self.validator.validate(&tx, &db, &metadata) {
+            match self.validator.validate(&tx, &db) {
                 Ok(()) => {
                     trace!(
                         target: LOG_TARGET,

--- a/base_layer/core/src/proof_of_work/diff_adj_manager/diff_adj_manager.rs
+++ b/base_layer/core/src/proof_of_work/diff_adj_manager/diff_adj_manager.rs
@@ -21,7 +21,7 @@
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 use crate::{
-    chain_storage::{BlockchainBackend, ChainMetadata},
+    chain_storage::BlockchainBackend,
     consensus::ConsensusConstants,
     proof_of_work::{
         diff_adj_manager::{diff_adj_storage::DiffAdjStorage, error::DiffAdjManagerError},
@@ -49,7 +49,6 @@ impl DiffAdjManager {
     /// Returns the estimated target difficulty for the specified PoW algorithm at the chain tip.
     pub fn get_target_difficulty<B: BlockchainBackend>(
         &self,
-        metadata: &ChainMetadata,
         db: &B,
         pow_algo: PowAlgorithm,
     ) -> Result<Difficulty, DiffAdjManagerError>
@@ -57,7 +56,7 @@ impl DiffAdjManager {
         self.diff_adj_storage
             .write()
             .map_err(|_| DiffAdjManagerError::PoisonedAccess)?
-            .get_target_difficulty(metadata, db, pow_algo)
+            .get_target_difficulty(db, pow_algo)
     }
 
     /// Returns the estimated target difficulty for the specified PoW algorithm and provided height.
@@ -75,16 +74,11 @@ impl DiffAdjManager {
     }
 
     /// Returns the median timestamp of the past 11 blocks at the chain tip.
-    pub fn get_median_timestamp<B: BlockchainBackend>(
-        &self,
-        metadata: &ChainMetadata,
-        db: &B,
-    ) -> Result<EpochTime, DiffAdjManagerError>
-    {
+    pub fn get_median_timestamp<B: BlockchainBackend>(&self, db: &B) -> Result<EpochTime, DiffAdjManagerError> {
         self.diff_adj_storage
             .write()
             .map_err(|_| DiffAdjManagerError::PoisonedAccess)?
-            .get_median_timestamp(metadata, db)
+            .get_median_timestamp(db)
     }
 
     /// Returns the median timestamp of the past 11 blocks at the provided height.

--- a/base_layer/core/src/validation/mocks.rs
+++ b/base_layer/core/src/validation/mocks.rs
@@ -21,10 +21,7 @@
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 use super::{StatelessValidation, Validation};
-use crate::{
-    chain_storage::{BlockchainBackend, ChainMetadata},
-    validation::error::ValidationError,
-};
+use crate::{chain_storage::BlockchainBackend, validation::error::ValidationError};
 
 #[derive(Clone)]
 pub struct MockValidator {
@@ -38,7 +35,7 @@ impl MockValidator {
 }
 
 impl<T, B: BlockchainBackend> Validation<T, B> for MockValidator {
-    fn validate(&self, _item: &T, _db: &B, _metadata: &ChainMetadata) -> Result<(), ValidationError> {
+    fn validate(&self, _item: &T, _db: &B) -> Result<(), ValidationError> {
         if self.result {
             Ok(())
         } else {

--- a/base_layer/core/src/validation/traits.rs
+++ b/base_layer/core/src/validation/traits.rs
@@ -20,10 +20,7 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use crate::{
-    chain_storage::{BlockchainBackend, ChainMetadata},
-    validation::error::ValidationError,
-};
+use crate::{chain_storage::BlockchainBackend, validation::error::ValidationError};
 
 pub type Validator<T, B> = Box<dyn Validation<T, B>>;
 pub type StatelessValidator<T> = Box<dyn StatelessValidation<T>>;
@@ -35,7 +32,7 @@ pub trait Validation<T, B>: Send + Sync
 where B: BlockchainBackend
 {
     /// General validation code that can run independent of external state
-    fn validate(&self, item: &T, db: &B, metadata: &ChainMetadata) -> Result<(), ValidationError>;
+    fn validate(&self, item: &T, db: &B) -> Result<(), ValidationError>;
 }
 
 /// Stateless version of the core validation trait.

--- a/base_layer/core/tests/diff_adj_manager.rs
+++ b/base_layer/core/tests/diff_adj_manager.rs
@@ -114,11 +114,7 @@ fn test_initial_sync() {
     let diff_adj_manager = DiffAdjManager::new(&consensus_manager.consensus_constants()).unwrap();
 
     assert_eq!(
-        diff_adj_manager.get_target_difficulty(
-            &store.metadata_read_access().unwrap(),
-            &*store.db_and_metadata_read_access().unwrap().0,
-            PowAlgorithm::Monero
-        ),
+        diff_adj_manager.get_target_difficulty(&*store.db_read_access().unwrap(), PowAlgorithm::Monero),
         Ok(calculate_accumulated_difficulty(
             &store,
             vec![2, 5, 6],
@@ -126,11 +122,7 @@ fn test_initial_sync() {
         ))
     );
     assert_eq!(
-        diff_adj_manager.get_target_difficulty(
-            &store.metadata_read_access().unwrap(),
-            &*store.db_and_metadata_read_access().unwrap().0,
-            PowAlgorithm::Blake
-        ),
+        diff_adj_manager.get_target_difficulty(&*store.db_read_access().unwrap(), PowAlgorithm::Blake),
         Ok(calculate_accumulated_difficulty(
             &store,
             vec![0, 1, 3, 4, 7],
@@ -158,11 +150,7 @@ fn test_sync_to_chain_tip() {
     create_test_pow_blockchain(&store, pow_algos, &consensus_manager.consensus_constants());
     assert_eq!(store.get_height(), Ok(Some(5)));
     assert_eq!(
-        consensus_manager.get_target_difficulty(
-            &store.metadata_read_access().unwrap(),
-            &*store.db_and_metadata_read_access().unwrap().0,
-            PowAlgorithm::Monero
-        ),
+        consensus_manager.get_target_difficulty(&*store.db_read_access().unwrap(), PowAlgorithm::Monero),
         Ok(calculate_accumulated_difficulty(
             &store,
             vec![1, 4],
@@ -170,11 +158,7 @@ fn test_sync_to_chain_tip() {
         ))
     );
     assert_eq!(
-        consensus_manager.get_target_difficulty(
-            &store.metadata_read_access().unwrap(),
-            &*store.db_and_metadata_read_access().unwrap().0,
-            PowAlgorithm::Blake
-        ),
+        consensus_manager.get_target_difficulty(&*store.db_read_access().unwrap(), PowAlgorithm::Blake),
         Ok(calculate_accumulated_difficulty(
             &store,
             vec![0, 2, 3, 5],
@@ -192,11 +176,7 @@ fn test_sync_to_chain_tip() {
     append_to_pow_blockchain(&store, tip, pow_algos, &consensus_manager.consensus_constants());
     assert_eq!(store.get_height(), Ok(Some(9)));
     assert_eq!(
-        consensus_manager.get_target_difficulty(
-            &store.metadata_read_access().unwrap(),
-            &*store.db_and_metadata_read_access().unwrap().0,
-            PowAlgorithm::Monero
-        ),
+        consensus_manager.get_target_difficulty(&*store.db_read_access().unwrap(), PowAlgorithm::Monero),
         Ok(calculate_accumulated_difficulty(
             &store,
             vec![1, 4, 7, 9],
@@ -204,11 +184,7 @@ fn test_sync_to_chain_tip() {
         ))
     );
     assert_eq!(
-        consensus_manager.get_target_difficulty(
-            &store.metadata_read_access().unwrap(),
-            &*store.db_and_metadata_read_access().unwrap().0,
-            PowAlgorithm::Blake
-        ),
+        consensus_manager.get_target_difficulty(&*store.db_read_access().unwrap(), PowAlgorithm::Blake),
         Ok(calculate_accumulated_difficulty(
             &store,
             vec![0, 2, 3, 5, 6, 8],
@@ -225,14 +201,10 @@ fn test_target_difficulty_with_height() {
     let diff_adj_manager = DiffAdjManager::new(&consensus_manager.consensus_constants()).unwrap();
     let _ = consensus_manager.set_diff_manager(diff_adj_manager);
     assert!(consensus_manager
-        .get_target_difficulty_with_height(
-            &*store.db_and_metadata_read_access().unwrap().0,
-            PowAlgorithm::Monero,
-            5
-        )
+        .get_target_difficulty_with_height(&*store.db_read_access().unwrap(), PowAlgorithm::Monero, 5)
         .is_err());
     assert!(consensus_manager
-        .get_target_difficulty_with_height(&*store.db_and_metadata_read_access().unwrap().0, PowAlgorithm::Blake, 5)
+        .get_target_difficulty_with_height(&*store.db_read_access().unwrap(), PowAlgorithm::Blake, 5)
         .is_err());
 
     let pow_algos = vec![
@@ -248,11 +220,7 @@ fn test_target_difficulty_with_height() {
     let _ = consensus_manager.set_diff_manager(diff_adj_manager);
 
     assert_eq!(
-        consensus_manager.get_target_difficulty_with_height(
-            &*store.db_and_metadata_read_access().unwrap().0,
-            PowAlgorithm::Monero,
-            5
-        ),
+        consensus_manager.get_target_difficulty_with_height(&*store.db_read_access().unwrap(), PowAlgorithm::Monero, 5),
         Ok(calculate_accumulated_difficulty(
             &store,
             vec![1, 4],
@@ -260,11 +228,7 @@ fn test_target_difficulty_with_height() {
         ))
     );
     assert_eq!(
-        consensus_manager.get_target_difficulty_with_height(
-            &*store.db_and_metadata_read_access().unwrap().0,
-            PowAlgorithm::Blake,
-            5
-        ),
+        consensus_manager.get_target_difficulty_with_height(&*store.db_read_access().unwrap(), PowAlgorithm::Blake, 5),
         Ok(calculate_accumulated_difficulty(
             &store,
             vec![0, 2, 3, 5],
@@ -273,11 +237,7 @@ fn test_target_difficulty_with_height() {
     );
 
     assert_eq!(
-        consensus_manager.get_target_difficulty_with_height(
-            &*store.db_and_metadata_read_access().unwrap().0,
-            PowAlgorithm::Monero,
-            2
-        ),
+        consensus_manager.get_target_difficulty_with_height(&*store.db_read_access().unwrap(), PowAlgorithm::Monero, 2),
         Ok(calculate_accumulated_difficulty(
             &store,
             vec![1],
@@ -285,11 +245,7 @@ fn test_target_difficulty_with_height() {
         ))
     );
     assert_eq!(
-        consensus_manager.get_target_difficulty_with_height(
-            &*store.db_and_metadata_read_access().unwrap().0,
-            PowAlgorithm::Blake,
-            2
-        ),
+        consensus_manager.get_target_difficulty_with_height(&*store.db_read_access().unwrap(), PowAlgorithm::Blake, 2),
         Ok(calculate_accumulated_difficulty(
             &store,
             vec![0, 2],
@@ -298,11 +254,7 @@ fn test_target_difficulty_with_height() {
     );
 
     assert_eq!(
-        consensus_manager.get_target_difficulty_with_height(
-            &*store.db_and_metadata_read_access().unwrap().0,
-            PowAlgorithm::Monero,
-            3
-        ),
+        consensus_manager.get_target_difficulty_with_height(&*store.db_read_access().unwrap(), PowAlgorithm::Monero, 3),
         Ok(calculate_accumulated_difficulty(
             &store,
             vec![1],
@@ -310,11 +262,7 @@ fn test_target_difficulty_with_height() {
         ))
     );
     assert_eq!(
-        consensus_manager.get_target_difficulty_with_height(
-            &*store.db_and_metadata_read_access().unwrap().0,
-            PowAlgorithm::Blake,
-            3
-        ),
+        consensus_manager.get_target_difficulty_with_height(&*store.db_read_access().unwrap(), PowAlgorithm::Blake, 3),
         Ok(calculate_accumulated_difficulty(
             &store,
             vec![0, 2, 3],
@@ -341,19 +289,11 @@ fn test_full_sync_on_reorg() {
     create_test_pow_blockchain(&store, pow_algos, &consensus_manager.consensus_constants());
     assert_eq!(store.get_height(), Ok(Some(4)));
     assert_eq!(
-        diff_adj_manager.get_target_difficulty(
-            &store.metadata_read_access().unwrap(),
-            &*store.db_and_metadata_read_access().unwrap().0,
-            PowAlgorithm::Monero
-        ),
+        diff_adj_manager.get_target_difficulty(&*store.db_read_access().unwrap(), PowAlgorithm::Monero),
         Ok(Difficulty::from(1))
     );
     assert_eq!(
-        diff_adj_manager.get_target_difficulty(
-            &store.metadata_read_access().unwrap(),
-            &*store.db_and_metadata_read_access().unwrap().0,
-            PowAlgorithm::Blake
-        ),
+        diff_adj_manager.get_target_difficulty(&*store.db_read_access().unwrap(), PowAlgorithm::Blake),
         Ok(Difficulty::from(18))
     );
 
@@ -371,19 +311,11 @@ fn test_full_sync_on_reorg() {
     let tip = store.fetch_block(8).unwrap().block;
     append_to_pow_blockchain(&store, tip, pow_algos, &consensus_manager.consensus_constants());
     assert_eq!(
-        diff_adj_manager.get_target_difficulty(
-            &store.metadata_read_access().unwrap(),
-            &*store.db_and_metadata_read_access().unwrap().0,
-            PowAlgorithm::Monero
-        ),
+        diff_adj_manager.get_target_difficulty(&*store.db_read_access().unwrap(), PowAlgorithm::Monero),
         Ok(Difficulty::from(2))
     );
     assert_eq!(
-        diff_adj_manager.get_target_difficulty(
-            &store.metadata_read_access().unwrap(),
-            &*store.db_and_metadata_read_access().unwrap().0,
-            PowAlgorithm::Blake
-        ),
+        diff_adj_manager.get_target_difficulty(&*store.db_read_access().unwrap(), PowAlgorithm::Blake),
         Ok(Difficulty::from(9))
     );
 }
@@ -398,10 +330,7 @@ fn test_median_timestamp() {
     create_test_pow_blockchain(&store, pow_algos, &consensus_manager.consensus_constants());
     let start_timestamp = store.fetch_block(0).unwrap().block().header.timestamp.clone();
     let mut timestamp = diff_adj_manager
-        .get_median_timestamp(
-            &store.metadata_read_access().unwrap(),
-            &*store.db_and_metadata_read_access().unwrap().0,
-        )
+        .get_median_timestamp(&*store.db_read_access().unwrap())
         .expect("median returned an error");
     assert_eq!(timestamp, start_timestamp);
 
@@ -412,10 +341,7 @@ fn test_median_timestamp() {
     let mut prev_timestamp: EpochTime =
         start_timestamp.increase(consensus_manager.consensus_constants().get_target_block_interval());
     timestamp = diff_adj_manager
-        .get_median_timestamp(
-            &store.metadata_read_access().unwrap(),
-            &*store.db_and_metadata_read_access().unwrap().0,
-        )
+        .get_median_timestamp(&*store.db_read_access().unwrap())
         .expect("median returned an error");
     assert_eq!(timestamp, prev_timestamp);
     // lets add 1
@@ -423,10 +349,7 @@ fn test_median_timestamp() {
     append_to_pow_blockchain(&store, tip, pow_algos.clone(), &consensus_manager.consensus_constants());
     prev_timestamp = start_timestamp.increase(consensus_manager.consensus_constants().get_target_block_interval());
     timestamp = diff_adj_manager
-        .get_median_timestamp(
-            &store.metadata_read_access().unwrap(),
-            &*store.db_and_metadata_read_access().unwrap().0,
-        )
+        .get_median_timestamp(&*store.db_read_access().unwrap())
         .expect("median returned an error");
     assert_eq!(timestamp, prev_timestamp);
 
@@ -437,10 +360,7 @@ fn test_median_timestamp() {
         prev_timestamp =
             start_timestamp.increase(consensus_manager.consensus_constants().get_target_block_interval() * (i / 2));
         timestamp = diff_adj_manager
-            .get_median_timestamp(
-                &store.metadata_read_access().unwrap(),
-                &*store.db_and_metadata_read_access().unwrap().0,
-            )
+            .get_median_timestamp(&*store.db_read_access().unwrap())
             .expect("median returned an error");
         assert_eq!(timestamp, prev_timestamp);
     }
@@ -451,10 +371,7 @@ fn test_median_timestamp() {
         append_to_pow_blockchain(&store, tip, pow_algos.clone(), &consensus_manager.consensus_constants());
         prev_timestamp = prev_timestamp.increase(consensus_manager.consensus_constants().get_target_block_interval());
         timestamp = diff_adj_manager
-            .get_median_timestamp(
-                &store.metadata_read_access().unwrap(),
-                &*store.db_and_metadata_read_access().unwrap().0,
-            )
+            .get_median_timestamp(&*store.db_read_access().unwrap())
             .expect("median returned an error");
         assert_eq!(timestamp, prev_timestamp);
     }
@@ -480,22 +397,22 @@ fn test_median_timestamp_with_height() {
     let header2_timestamp = store.fetch_header(2).unwrap().timestamp;
 
     let timestamp = diff_adj_manager
-        .get_median_timestamp_at_height(&*store.db_and_metadata_read_access().unwrap().0, 0)
+        .get_median_timestamp_at_height(&*store.db_read_access().unwrap(), 0)
         .expect("median returned an error");
     assert_eq!(timestamp, header0_timestamp);
 
     let timestamp = diff_adj_manager
-        .get_median_timestamp_at_height(&*store.db_and_metadata_read_access().unwrap().0, 3)
+        .get_median_timestamp_at_height(&*store.db_read_access().unwrap(), 3)
         .expect("median returned an error");
     assert_eq!(timestamp, header2_timestamp);
 
     let timestamp = diff_adj_manager
-        .get_median_timestamp_at_height(&*store.db_and_metadata_read_access().unwrap().0, 2)
+        .get_median_timestamp_at_height(&*store.db_read_access().unwrap(), 2)
         .expect("median returned an error");
     assert_eq!(timestamp, header1_timestamp);
 
     let timestamp = diff_adj_manager
-        .get_median_timestamp_at_height(&*store.db_and_metadata_read_access().unwrap().0, 4)
+        .get_median_timestamp_at_height(&*store.db_read_access().unwrap(), 4)
         .expect("median returned an error");
     assert_eq!(timestamp, header2_timestamp);
 }
@@ -510,10 +427,7 @@ fn test_median_timestamp_odd_order() {
     create_test_pow_blockchain(&store, pow_algos, &consensus_manager.consensus_constants());
     let start_timestamp = store.fetch_block(0).unwrap().block().header.timestamp.clone();
     let mut timestamp = diff_adj_manager
-        .get_median_timestamp(
-            &store.metadata_read_access().unwrap(),
-            &*store.db_and_metadata_read_access().unwrap().0,
-        )
+        .get_median_timestamp(&*store.db_read_access().unwrap())
         .expect("median returned an error");
     assert_eq!(timestamp, start_timestamp);
     let pow_algos = vec![PowAlgorithm::Blake];
@@ -523,10 +437,7 @@ fn test_median_timestamp_odd_order() {
     let mut prev_timestamp: EpochTime =
         start_timestamp.increase(consensus_manager.consensus_constants().get_target_block_interval());
     timestamp = diff_adj_manager
-        .get_median_timestamp(
-            &store.metadata_read_access().unwrap(),
-            &*store.db_and_metadata_read_access().unwrap().0,
-        )
+        .get_median_timestamp(&*store.db_read_access().unwrap())
         .expect("median returned an error");
     assert_eq!(timestamp, prev_timestamp);
 
@@ -542,10 +453,7 @@ fn test_median_timestamp_odd_order() {
 
     prev_timestamp = start_timestamp.increase(consensus_manager.consensus_constants().get_target_block_interval() / 2);
     timestamp = diff_adj_manager
-        .get_median_timestamp(
-            &store.metadata_read_access().unwrap(),
-            &*store.db_and_metadata_read_access().unwrap().0,
-        )
+        .get_median_timestamp(&*store.db_read_access().unwrap())
         .expect("median returned an error");
     // Median timestamp should be block 3 and not block 2
     assert_eq!(timestamp, prev_timestamp);


### PR DESCRIPTION
## Description
- Removed the memory copy of metadata from the blockchain db and made the backend responsible for providing fast access to the chain metadata.
- A memory copy of the metadata was added to lmdb_db, and the backend was made responsible for restoring the memory copy and keeping it in sync with the persistent stored version.
- Removed all unused memory chain metadata functions and parameters from the blockchain db, mempool, consensus manager and difficulty adjustment manager.
- The validation train, block validators and transaction validators were updated to not need access to the chain metadata as it can be obtained from the blockchain backend.
- Modified the rewind_to_height function to update the metadata with the set of rewind db transactions ensuring it does not get updated when the db transaction fails.
- Added fetch_metadata to blockchain backend trait and provided implementations for lmdb_db, memory_db and mock_db.

## Motivation and Context
These changes will make it easier to keep the memory and persistent stored versions of the chain metadata in sync.

## How Has This Been Tested?
Covered by existing tests.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [x] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch.
* [x] I ran `cargo-fmt --all` before pushing.
* [x] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
