### PR TITLE
Make Discovery timeout set by FFI client

### DIFF
--- a/base_layer/wallet_ffi/src/lib.rs
+++ b/base_layer/wallet_ffi/src/lib.rs
@@ -2151,6 +2151,7 @@ pub unsafe extern "C" fn comms_config_create(
     database_name: *const c_char,
     datastore_path: *const c_char,
     secret_key: *mut TariPrivateKey,
+    discovery_timeout_in_secs: c_ulonglong,
     error_out: *mut c_int,
 ) -> *mut TariCommsConfig
 {
@@ -2202,7 +2203,7 @@ pub unsafe extern "C" fn comms_config_create(
                         max_concurrent_inbound_tasks: 100,
                         outbound_buffer_size: 100,
                         dht: DhtConfig {
-                            discovery_request_timeout: Duration::from_secs(120),
+                            discovery_request_timeout: Duration::from_secs(discovery_timeout_in_secs),
                             ..Default::default()
                         },
                         // TODO: This should be set to false for non-test wallets. See the `allow_test_addresses` field
@@ -4173,6 +4174,7 @@ mod test {
                 db_name_alice_str,
                 db_path_alice_str,
                 secret_key_alice,
+                20,
                 error_ptr,
             );
             (*alice_config).allow_test_addresses = true;
@@ -4205,6 +4207,7 @@ mod test {
                 db_name_bob_str,
                 db_path_bob_str,
                 secret_key_bob,
+                20,
                 error_ptr,
             );
             let bob_wallet = wallet_create(

--- a/base_layer/wallet_ffi/wallet.h
+++ b/base_layer/wallet_ffi/wallet.h
@@ -324,6 +324,7 @@ struct TariCommsConfig *comms_config_create(char *public_address,
                                      char *database_name,
                                      char *datastore_path,
                                      struct TariPrivateKey *secret_key,
+                                     unsigned long long discovery_timeout_in_secs,
                                      int* error_out);
 
 // Frees memory for a TariCommsConfig


### PR DESCRIPTION
## Description
Update the `comms_config_create(...)` FFI function to add an argument to set the Discovery timeout.

@StriderDM @Jasonvdb This will require an update to the JNI and Swift wrappers

Towards @https://github.com/tari-project/tari/issues/1672

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [x] Breaking change (fix or feature that would cause existing functionality to change)
* [x] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch.
* [x] I ran `cargo-fmt --all` before pushing.
* [ ] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
