### PR TITLE
Calculate region threshold depending on PeerFeatures

### DIFF
--- a/comms/dht/examples/memorynet.rs
+++ b/comms/dht/examples/memorynet.rs
@@ -339,7 +339,7 @@ async fn peer_list_summary<'a, I: IntoIterator<Item = T>, T: AsRef<TestNode>>(ne
             .as_ref()
             .comms
             .peer_manager()
-            .closest_peers(node_identity.node_id(), 10, &[])
+            .closest_peers(node_identity.node_id(), 10, &[], None)
             .await
             .unwrap();
         let mut table = Table::new();

--- a/comms/src/connection_manager/tests/manager.rs
+++ b/comms/src/connection_manager/tests/manager.rs
@@ -234,7 +234,7 @@ async fn dial_offline_peer() {
 async fn simultaneous_dial_events() {
     let mut shutdown = Shutdown::new();
 
-    let node_identities = ordered_node_identities(2);
+    let node_identities = ordered_node_identities(2, Default::default());
 
     // Setup connection manager 1
     let peer_manager1 = build_peer_manager();

--- a/comms/src/peer_manager/node_id.rs
+++ b/comms/src/peer_manager/node_id.rs
@@ -68,7 +68,7 @@ impl NodeDistance {
         nd
     }
 
-    pub fn max_distance() -> NodeDistance {
+    pub const fn max_distance() -> NodeDistance {
         NodeDistance([255; NODE_ID_ARRAY_SIZE])
     }
 }
@@ -355,6 +355,12 @@ mod test {
         assert!(n1_to_n2_dist < n1_to_n3_dist);
         assert_eq!(n1_to_n2_dist, desired_n1_to_n2_dist);
         assert_eq!(n1_to_n3_dist, desired_n1_to_n3_dist);
+
+        // Commutative
+        let n1_to_n2_dist = node_id1.distance(&node_id2);
+        let n2_to_n1_dist = node_id2.distance(&node_id1);
+
+        assert_eq!(n1_to_n2_dist, n2_to_n1_dist);
     }
 
     #[test]

--- a/comms/src/test_utils/node_identity.rs
+++ b/comms/src/test_utils/node_identity.rs
@@ -34,10 +34,8 @@ pub fn build_node_identity(features: PeerFeatures) -> Arc<NodeIdentity> {
     Arc::new(NodeIdentity::random(&mut OsRng, public_addr, features).unwrap())
 }
 
-pub fn ordered_node_identities(n: usize) -> Vec<Arc<NodeIdentity>> {
-    let mut ids = (0..n)
-        .map(|_| build_node_identity(PeerFeatures::default()))
-        .collect::<Vec<_>>();
+pub fn ordered_node_identities(n: usize, features: PeerFeatures) -> Vec<Arc<NodeIdentity>> {
+    let mut ids = (0..n).map(|_| build_node_identity(features)).collect::<Vec<_>>();
     ids.sort_unstable_by(|a, b| a.node_id().cmp(b.node_id()));
     ids
 }


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
When a node is determining if a requesting node is in it's region, it takes
the closest `n` peers that it is aware of and if the node ID is within
that threshold it considers it a neighbouring node. Because there are
nodes on the network that do not perform some network functions (such as
message propagation and store and forward i.e. wallets), there is a
chance that a majority of neighbours are these non-propagating nodes and
'take up space' where propagation nodes could 'fit'.

When calculating the threshold for neighbouring nodes it must take the
features of the nodes it knows about into account.

This PR changes the peer manager to consider `COMMUNICATION_NODE`s and
`COMMUNICATION_CLIENT`s independently to ensure a minimum number of
propagation nodes are considered neighbouring.

TODO: PeerFeatures may be too fine-grained and adding unecessary complexity. It possibly should be replaced with `PeerRole::FullNode` and `PeerRole::Client` as part of the Sqlite refactor

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
It's likely that some messages are being ignored by nodes because they don't consider a peer within their network region.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Added tests for `calc_region_threshold`

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [x] Breaking change (fix or feature that would cause existing functionality to change)
* [x] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [x] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch.
* [x] I ran `cargo-fmt --all` before pushing.
* [x] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
