### PR TITLE
Fix potential cause of frequent reorgs

### DIFF
--- a/base_layer/core/src/mining/miner.rs
+++ b/base_layer/core/src/mining/miner.rs
@@ -233,7 +233,7 @@ impl Miner {
             };
             // This flag will let the future select loop again if the miner has not been issued a shutdown command.
             let mut wait_for_miner = false;
-            'inner: while (!wait_for_miner) {
+            while !wait_for_miner {
                 futures::select! {
                 msg = block_event.select_next_some() => {
                     match *msg {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Changes the logic of the miner to loop the futures::select so that the miner can listen for more than one event before restarting. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The current miner code can cause that the miner can only listen once to an event. If the event does not change the miner state, the miner will continue to mine, but cant listen for future events until the miner finds a block. This causes lots of re-orgs to happen. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch.
* [x] I ran `cargo-fmt --all` before pushing.
* [x] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
