### PR TITLE
Persistent store and forward

### DIFF
--- a/applications/tari_base_node/src/builder.rs
+++ b/applications/tari_base_node/src/builder.rs
@@ -46,7 +46,7 @@ use tari_comms::{
     ConnectionManagerEvent,
     PeerManager,
 };
-use tari_comms_dht::Dht;
+use tari_comms_dht::{DbConnectionUrl, Dht, DhtConfig};
 use tari_core::{
     base_node::{
         chain_metadata_service::{ChainMetadataHandle, ChainMetadataServiceInitializer},
@@ -841,7 +841,10 @@ async fn setup_base_node_comms(
         max_concurrent_inbound_tasks: 100,
         outbound_buffer_size: 100,
         // TODO - make this configurable
-        dht: Default::default(),
+        dht: DhtConfig {
+            database_url: DbConnectionUrl::File(config.data_dir.join("dht.db")),
+            ..Default::default()
+        },
         // TODO: This should be false unless testing locally - make this configurable
         allow_test_addresses: true,
         listener_liveness_whitelist_cidrs: config.listener_liveness_whitelist_cidrs.clone(),

--- a/comms/dht/Cargo.toml
+++ b/comms/dht/Cargo.toml
@@ -22,6 +22,8 @@ bitflags = "1.2.0"
 bytes = "0.4.12"
 chrono = "0.4.9"
 derive-error = "0.0.4"
+diesel = {version="1.4", features = ["sqlite", "serde_json", "chrono"]}
+diesel_migrations =  "1.4"
 digest = "0.8.1"
 futures= {version= "^0.3.1"}
 log = "0.4.8"
@@ -34,6 +36,7 @@ serde_repr = "0.1.5"
 tokio = {version="0.2.10", features=["rt-threaded", "blocking"]}
 tower= "0.3.0"
 ttl_cache = "0.5.1"
+
 # tower-filter dependencies
 pin-project = "0.4"
 

--- a/comms/dht/diesel.toml
+++ b/comms/dht/diesel.toml
@@ -1,0 +1,5 @@
+# For documentation on how to configure this file,
+# see diesel.rs/guides/configuring-diesel-cli
+
+[print_schema]
+file = "src/schema.rs"

--- a/comms/dht/examples/memorynet.rs
+++ b/comms/dht/examples/memorynet.rs
@@ -403,7 +403,7 @@ async fn do_store_and_forward_discovery(
     println!("Waiting a few seconds for discovery to propagate around the network...");
     time::delay_for(Duration::from_secs(8)).await;
 
-    let mut total_messages = drain_messaging_events(messaging_rx, true).await;
+    let mut total_messages = drain_messaging_events(messaging_rx, false).await;
 
     banner!("🤓 {} is coming back online", get_name(node_identity.node_id()));
     let (tx, ims_rx) = mpsc::channel(1);

--- a/comms/dht/migrations/2020-04-01-095825_initial/down.sql
+++ b/comms/dht/migrations/2020-04-01-095825_initial/down.sql
@@ -1,0 +1,2 @@
+DROP TABLE IF EXISTS stored_messages;
+DROP TABLE IF EXISTS dht_settings;

--- a/comms/dht/migrations/2020-04-01-095825_initial/up.sql
+++ b/comms/dht/migrations/2020-04-01-095825_initial/up.sql
@@ -1,0 +1,27 @@
+CREATE TABLE stored_messages (
+   id INTEGER NOT NULL PRIMARY KEY,
+   version INT NOT NULL,
+   origin_pubkey TEXT NOT NULL,
+   origin_signature TEXT NOT NULL,
+   message_type INT NOT NULL,
+   destination_pubkey TEXT,
+   destination_node_id TEXT,
+   header BLOB  NOT NULL,
+   body BLOB  NOT NULL,
+   is_encrypted BOOLEAN NOT NULL CHECK (is_encrypted IN (0,1)),
+   priority INT NOT NULL,
+   stored_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX idx_stored_messages_destination_pubkey ON stored_messages (destination_pubkey);
+CREATE INDEX idx_stored_messages_destination_node_id ON stored_messages (destination_node_id);
+CREATE INDEX idx_stored_messages_stored_at ON stored_messages (stored_at);
+CREATE INDEX idx_stored_messages_priority ON stored_messages (priority);
+
+CREATE TABLE dht_settings (
+    id INTEGER PRIMARY KEY NOT NULL,
+    key TEXT NOT NULL,
+    value BLOB NOT NULL
+);
+
+CREATE UNIQUE INDEX idx_dht_settings_key ON dht_settings (key);

--- a/comms/dht/src/builder.rs
+++ b/comms/dht/src/builder.rs
@@ -20,7 +20,7 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use crate::{outbound::DhtOutboundRequest, Dht, DhtConfig};
+use crate::{outbound::DhtOutboundRequest, DbConnectionUrl, Dht, DhtConfig};
 use futures::channel::mpsc;
 use std::{sync::Arc, time::Duration};
 use tari_comms::{
@@ -77,6 +77,11 @@ impl DhtBuilder {
 
     pub fn mainnet(mut self) -> Self {
         self.config = DhtConfig::default_mainnet();
+        self
+    }
+
+    pub fn with_database_url(mut self, database_url: DbConnectionUrl) -> Self {
+        self.config.database_url = database_url;
         self
     }
 

--- a/comms/dht/src/config.rs
+++ b/comms/dht/src/config.rs
@@ -20,20 +20,22 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use crate::envelope::Network;
+use crate::{envelope::Network, storage::DbConnectionUrl};
 use std::time::Duration;
 
 /// The default maximum number of messages that can be stored using the Store-and-forward middleware
 pub const SAF_MSG_CACHE_STORAGE_CAPACITY: usize = 10_000;
 /// The default time-to-live duration used for storage of low priority messages by the Store-and-forward middleware
-pub const SAF_LOW_PRIORITY_MSG_STORAGE_TTL: Duration = Duration::from_secs(6 * 60 * 60);
+pub const SAF_LOW_PRIORITY_MSG_STORAGE_TTL: Duration = Duration::from_secs(6 * 60 * 60); // 6 hours
 /// The default time-to-live duration used for storage of high priority messages by the Store-and-forward middleware
-pub const SAF_HIGH_PRIORITY_MSG_STORAGE_TTL: Duration = Duration::from_secs(24 * 60 * 60);
+pub const SAF_HIGH_PRIORITY_MSG_STORAGE_TTL: Duration = Duration::from_secs(2 * 24 * 60 * 60); // 2 days
 /// The default number of peer nodes that a message has to be closer to, to be considered a neighbour
 pub const DEFAULT_NUM_NEIGHBOURING_NODES: usize = 10;
 
 #[derive(Debug, Clone)]
 pub struct DhtConfig {
+    /// The `DbConnectionUrl` for the Dht database. Default: In-memory database
+    pub database_url: DbConnectionUrl,
     /// The size of the buffer (channel) which holds pending outbound message requests.
     /// Default: 20
     pub outbound_buffer_size: usize,
@@ -53,8 +55,10 @@ pub struct DhtConfig {
     /// Default: 6 hours
     pub saf_low_priority_msg_storage_ttl: Duration,
     /// The time-to-live duration used for storage of high priority messages by the Store-and-forward middleware.
-    /// Default: 24 hours
+    /// Default: 2 days
     pub saf_high_priority_msg_storage_ttl: Duration,
+    /// The limit on the message size to store in SAF storage in bytes. Default 500kb
+    pub saf_max_message_size: usize,
     /// The max capacity of the message hash cache
     /// Default: 1000
     pub msg_hash_cache_capacity: usize,
@@ -92,6 +96,7 @@ impl DhtConfig {
     pub fn default_local_test() -> Self {
         Self {
             network: Network::LocalTest,
+            database_url: DbConnectionUrl::Memory,
             ..Default::default()
         }
     }
@@ -102,14 +107,16 @@ impl Default for DhtConfig {
         Self {
             num_neighbouring_nodes: DEFAULT_NUM_NEIGHBOURING_NODES,
             saf_num_closest_nodes: 10,
-            saf_max_returned_messages: 1000,
+            saf_max_returned_messages: 100,
             outbound_buffer_size: 20,
             saf_msg_cache_storage_capacity: SAF_MSG_CACHE_STORAGE_CAPACITY,
             saf_low_priority_msg_storage_ttl: SAF_LOW_PRIORITY_MSG_STORAGE_TTL,
             saf_high_priority_msg_storage_ttl: SAF_HIGH_PRIORITY_MSG_STORAGE_TTL,
+            saf_max_message_size: 512 * 1024, // 512 kb
             msg_hash_cache_capacity: 10_000,
             msg_hash_cache_ttl: Duration::from_secs(300),
             broadcast_cooldown_max_attempts: 3,
+            database_url: DbConnectionUrl::Memory,
             broadcast_cooldown_period: Duration::from_secs(60 * 30),
             discovery_request_timeout: Duration::from_secs(2 * 60),
             network: Network::TestNet,

--- a/comms/dht/src/envelope.rs
+++ b/comms/dht/src/envelope.rs
@@ -69,11 +69,36 @@ bitflags! {
     }
 }
 
+impl DhtMessageFlags {
+    pub fn is_encrypted(self) -> bool {
+        self.contains(Self::ENCRYPTED)
+    }
+}
+
 impl DhtMessageType {
     pub fn is_dht_message(self) -> bool {
+        self.is_dht_discovery() || self.is_dht_join()
+    }
+
+    pub fn is_dht_discovery(self) -> bool {
         match self {
-            DhtMessageType::None => false,
-            _ => true,
+            DhtMessageType::Discovery => true,
+            _ => false,
+        }
+    }
+
+    pub fn is_dht_join(self) -> bool {
+        match self {
+            DhtMessageType::Join => true,
+            _ => false,
+        }
+    }
+
+    pub fn is_saf_message(self) -> bool {
+        use DhtMessageType::*;
+        match self {
+            SafRequestMessages | SafStoredMessages => true,
+            _ => false,
         }
     }
 }

--- a/comms/dht/src/inbound/error.rs
+++ b/comms/dht/src/inbound/error.rs
@@ -28,7 +28,6 @@ use tari_comms::{message::MessageError, peer_manager::PeerManagerError};
 #[derive(Debug, Error)]
 pub enum DhtInboundError {
     MessageError(MessageError),
-    //    MessageFormatError(MessageFormatError),
     PeerManagerError(PeerManagerError),
     DhtOutboundError(DhtOutboundError),
     /// Failed to decode message
@@ -39,8 +38,6 @@ pub enum DhtInboundError {
     InvalidNodeId,
     /// All given addresses were invalid
     InvalidAddresses,
-    /// One or more NetAddress in the join message were invalid
-    InvalidJoinNetAddresses,
     DhtDiscoveryError(DhtDiscoveryError),
     #[error(msg_embedded, no_from, non_std)]
     OriginRequired(String),

--- a/comms/dht/src/inbound/message.rs
+++ b/comms/dht/src/inbound/message.rs
@@ -20,7 +20,10 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use crate::{consts::DHT_ENVELOPE_HEADER_VERSION, envelope::DhtMessageHeader};
+use crate::{
+    consts::DHT_ENVELOPE_HEADER_VERSION,
+    envelope::{DhtMessageFlags, DhtMessageHeader},
+};
 use std::{
     fmt::{Display, Error, Formatter},
     sync::Arc,
@@ -118,5 +121,21 @@ impl DecryptedDhtMessage {
             .as_ref()
             .map(|o| &o.public_key)
             .unwrap_or(&self.source_peer.public_key)
+    }
+
+    /// Returns true if the message is or was encrypted by
+    pub fn is_encrypted(&self) -> bool {
+        self.dht_header.flags.contains(DhtMessageFlags::ENCRYPTED)
+    }
+
+    pub fn has_origin(&self) -> bool {
+        self.dht_header.origin.is_some()
+    }
+
+    pub fn body_size(&self) -> usize {
+        match self.decryption_result.as_ref() {
+            Ok(b) => b.total_size(),
+            Err(b) => b.len(),
+        }
     }
 }

--- a/comms/dht/src/lib.rs
+++ b/comms/dht/src/lib.rs
@@ -108,6 +108,11 @@
 #![feature(type_alias_impl_trait)]
 
 #[macro_use]
+extern crate diesel;
+#[macro_use]
+extern crate diesel_migrations;
+
+#[macro_use]
 mod macros;
 
 #[cfg(test)]
@@ -132,9 +137,15 @@ pub use dht::Dht;
 mod discovery;
 pub use discovery::DhtDiscoveryRequester;
 
+mod storage;
+pub use storage::DbConnectionUrl;
+
 mod logging_middleware;
 mod proto;
 mod tower_filter;
+mod utils;
+
+mod schema;
 
 pub mod broadcast_strategy;
 pub mod domain_message;

--- a/comms/dht/src/outbound/serialize.rs
+++ b/comms/dht/src/outbound/serialize.rs
@@ -32,7 +32,7 @@ use tari_comms::{
     utils::signature,
     Bytes,
 };
-use tari_crypto::tari_utilities::{hex::Hex, message_format::MessageFormat};
+use tari_crypto::tari_utilities::message_format::MessageFormat;
 use tower::{layer::Layer, Service, ServiceExt};
 
 const LOG_TARGET: &str = "comms::dht::serialize";
@@ -97,10 +97,9 @@ where S: Service<OutboundMessage, Response = (), Error = PipelineError>
 
         // If forwarding the message, the DhtHeader already has a signature that should not change
         if is_forwarded {
-            trace!(
+            debug!(
                 target: LOG_TARGET,
-                "Forwarded message {:?}. Message will not be signed",
-                message.tag
+                "Message ({}) is being forwarded so this node will NOT signed it", message.tag
             );
         } else {
             // Sign the body if the origin public key was previously specified.
@@ -108,12 +107,6 @@ where S: Service<OutboundMessage, Response = (), Error = PipelineError>
                 let signature = signature::sign(&mut OsRng, node_identity.secret_key().clone(), &body)
                     .map_err(PipelineError::from_debug)?;
                 origin.signature = signature.to_binary().map_err(PipelineError::from_debug)?;
-                trace!(
-                    target: LOG_TARGET,
-                    "Signed message {:?}: {}",
-                    message.tag,
-                    origin.signature.to_hex()
-                );
             }
         }
 

--- a/comms/dht/src/proto/store_forward.proto
+++ b/comms/dht/src/proto/store_forward.proto
@@ -11,6 +11,7 @@ package tari.dht.store_forward;
 // will be sent.
 message StoredMessagesRequest {
     google.protobuf.Timestamp since = 1;
+    uint32 request_id = 2;
 }
 
 // Storage for a single message envelope, including the date and time when the element was stored
@@ -18,10 +19,22 @@ message StoredMessage {
     google.protobuf.Timestamp stored_at = 1;
     uint32 version = 2;
     tari.dht.envelope.DhtHeader dht_header = 3;
-    bytes encrypted_body = 4;
+    bytes body = 4;
 }
 
 // The StoredMessages contains the set of applicable messages retrieved from a neighbouring peer node.
 message StoredMessagesResponse {
     repeated StoredMessage messages = 1;
+    uint32 request_id = 2;
+    enum SafResponseType {
+        // All applicable messages
+        General = 0;
+        // Send messages explicitly addressed to the requesting node or within the requesting node's region
+        ExplicitlyAddressed = 1;
+        // Send Discovery messages that could be for the requester
+        Discovery = 2;
+        // Send Join messages that the requester could be interested in
+        Join = 3;
+    }
+    SafResponseType response_type = 3;
 }

--- a/comms/dht/src/proto/tari.dht.store_forward.rs
+++ b/comms/dht/src/proto/tari.dht.store_forward.rs
@@ -5,6 +5,8 @@
 pub struct StoredMessagesRequest {
     #[prost(message, optional, tag = "1")]
     pub since: ::std::option::Option<::prost_types::Timestamp>,
+    #[prost(uint32, tag = "2")]
+    pub request_id: u32,
 }
 /// Storage for a single message envelope, including the date and time when the element was stored
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -16,11 +18,29 @@ pub struct StoredMessage {
     #[prost(message, optional, tag = "3")]
     pub dht_header: ::std::option::Option<super::envelope::DhtHeader>,
     #[prost(bytes, tag = "4")]
-    pub encrypted_body: std::vec::Vec<u8>,
+    pub body: std::vec::Vec<u8>,
 }
 /// The StoredMessages contains the set of applicable messages retrieved from a neighbouring peer node.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct StoredMessagesResponse {
     #[prost(message, repeated, tag = "1")]
     pub messages: ::std::vec::Vec<StoredMessage>,
+    #[prost(uint32, tag = "2")]
+    pub request_id: u32,
+    #[prost(enumeration = "stored_messages_response::SafResponseType", tag = "3")]
+    pub response_type: i32,
+}
+pub mod stored_messages_response {
+    #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
+    #[repr(i32)]
+    pub enum SafResponseType {
+        /// All applicable messages
+        General = 0,
+        /// Send messages explicitly addressed to the requesting node or within the requesting node's region
+        ExplicitlyAddressed = 1,
+        /// Send Discovery messages that could be for the requester
+        Discovery = 2,
+        /// Send Join messages that the requester could be interested in
+        Join = 3,
+    }
 }

--- a/comms/dht/src/schema.rs
+++ b/comms/dht/src/schema.rs
@@ -1,0 +1,26 @@
+table! {
+    dht_settings (id) {
+        id -> Integer,
+        key -> Text,
+        value -> Binary,
+    }
+}
+
+table! {
+    stored_messages (id) {
+        id -> Integer,
+        version -> Integer,
+        origin_pubkey -> Text,
+        origin_signature -> Text,
+        message_type -> Integer,
+        destination_pubkey -> Nullable<Text>,
+        destination_node_id -> Nullable<Text>,
+        header -> Binary,
+        body -> Binary,
+        is_encrypted -> Bool,
+        priority -> Integer,
+        stored_at -> Timestamp,
+    }
+}
+
+allow_tables_to_appear_in_same_query!(dht_settings, stored_messages,);

--- a/comms/dht/src/storage/connection.rs
+++ b/comms/dht/src/storage/connection.rs
@@ -1,0 +1,122 @@
+// Copyright 2020. The Tari Project
+//
+// Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+// following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+// disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+// following disclaimer in the documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+// products derived from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+// INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+// WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+// USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+use crate::storage::error::StorageError;
+use diesel::{Connection, SqliteConnection};
+use std::{
+    io,
+    path::PathBuf,
+    sync::{Arc, Mutex},
+};
+use tokio::task;
+
+#[derive(Clone, Debug)]
+pub enum DbConnectionUrl {
+    /// In-memory database. Each connection has it's own database
+    Memory,
+    /// In-memory database shared with more than one in-process connection according to the given identifier
+    MemoryShared(String),
+    /// Database persisted on disk
+    File(PathBuf),
+}
+
+impl DbConnectionUrl {
+    pub fn to_url_string(&self) -> String {
+        use DbConnectionUrl::*;
+        match self {
+            Memory => ":memory:".to_owned(),
+            MemoryShared(identifier) => format!("file:{}?mode=memory&cache=shared", identifier),
+            File(path) => path
+                .to_str()
+                .expect("Invalid non-UTF8 character in database path")
+                .to_owned(),
+        }
+    }
+}
+
+#[derive(Clone)]
+pub struct DbConnection {
+    inner: Arc<Mutex<SqliteConnection>>,
+}
+
+impl DbConnection {
+    #[cfg(test)]
+    pub async fn connect_memory(name: String) -> Result<Self, StorageError> {
+        Self::connect_url(DbConnectionUrl::MemoryShared(name)).await
+    }
+
+    pub async fn connect_url(db_url: DbConnectionUrl) -> Result<Self, StorageError> {
+        let conn = task::spawn_blocking(move || {
+            let conn = SqliteConnection::establish(&db_url.to_url_string())?;
+            conn.execute("PRAGMA foreign_keys = ON; PRAGMA busy_timeout = 60000;")?;
+            Result::<_, StorageError>::Ok(conn)
+        })
+        .await??;
+
+        Ok(Self::new(conn))
+    }
+
+    fn new(conn: SqliteConnection) -> Self {
+        Self {
+            inner: Arc::new(Mutex::new(conn)),
+        }
+    }
+
+    pub async fn migrate(&self) -> Result<String, StorageError> {
+        embed_migrations!("./migrations");
+
+        self.with_connection_async(|conn| {
+            let mut buf = io::Cursor::new(Vec::new());
+            embedded_migrations::run_with_output(conn, &mut buf)
+                .map_err(|err| StorageError::DatabaseMigrationFailed(format!("Database migration failed {}", err)))?;
+            Ok(String::from_utf8_lossy(&buf.into_inner()).to_string())
+        })
+        .await
+    }
+
+    pub async fn with_connection_async<F, R>(&self, f: F) -> Result<R, StorageError>
+    where
+        F: FnOnce(&SqliteConnection) -> Result<R, StorageError> + Send + 'static,
+        R: Send + 'static,
+    {
+        let conn_mutex = self.inner.clone();
+        let ret = task::spawn_blocking(move || {
+            let lock = acquire_lock!(conn_mutex);
+            f(&*lock)
+        })
+        .await??;
+        Ok(ret)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use tari_test_utils::random;
+
+    #[tokio_macros::test_basic]
+    async fn connect_and_migrate() {
+        let conn = DbConnection::connect_memory(random::string(8)).await.unwrap();
+        let output = conn.migrate().await.unwrap();
+        assert!(output.starts_with("Running migration"));
+    }
+}

--- a/comms/dht/src/storage/database.rs
+++ b/comms/dht/src/storage/database.rs
@@ -1,0 +1,77 @@
+// Copyright 2020, The Tari Project
+//
+// Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+// following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+// disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+// following disclaimer in the documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+// products derived from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+// INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+// WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+// USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+use super::{dht_setting_entry::DhtSettingsEntry, DbConnection, StorageError};
+use crate::{
+    schema::dht_settings,
+    storage::{dht_setting_entry::NewDhtSettingEntry, DhtSettingKey},
+};
+use diesel::{ExpressionMethods, QueryDsl, RunQueryDsl};
+use tari_crypto::tari_utilities::message_format::MessageFormat;
+
+#[derive(Clone)]
+pub struct DhtDatabase {
+    connection: DbConnection,
+}
+
+impl DhtDatabase {
+    pub fn new(connection: DbConnection) -> Self {
+        Self { connection }
+    }
+
+    pub async fn get_value<T: MessageFormat>(&self, key: DhtSettingKey) -> Result<Option<T>, StorageError> {
+        match self.get_value_bytes(key).await? {
+            Some(bytes) => T::from_binary(&bytes).map(Some).map_err(Into::into),
+            None => Ok(None),
+        }
+    }
+
+    pub async fn get_value_bytes(&self, key: DhtSettingKey) -> Result<Option<Vec<u8>>, StorageError> {
+        self.connection
+            .with_connection_async(move |conn| {
+                dht_settings::table
+                    .filter(dht_settings::key.eq(key.to_string()))
+                    .first(conn)
+                    .map(|rec: DhtSettingsEntry| Some(rec.value))
+                    .or_else(|err| match err {
+                        diesel::result::Error::NotFound => Ok(None),
+                        err => Err(err.into()),
+                    })
+            })
+            .await
+    }
+
+    pub async fn set_value(&self, key: DhtSettingKey, value: Vec<u8>) -> Result<(), StorageError> {
+        self.connection
+            .with_connection_async(move |conn| {
+                diesel::replace_into(dht_settings::table)
+                    .values(NewDhtSettingEntry {
+                        key: key.to_string(),
+                        value,
+                    })
+                    .execute(conn)
+                    .map(|_| ())
+                    .map_err(Into::into)
+            })
+            .await
+    }
+}

--- a/comms/dht/src/storage/dht_setting_entry.rs
+++ b/comms/dht/src/storage/dht_setting_entry.rs
@@ -1,4 +1,4 @@
-// Copyright 2019, The Tari Project
+// Copyright 2020, The Tari Project
 //
 // Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
 // following conditions are met:
@@ -20,34 +20,32 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-macro_rules! unwrap_oms_send_msg {
-    ($var:expr, reply_value=$reply_value:expr) => {
-        match $var {
-            crate::outbound::DhtOutboundRequest::SendMessage(boxed, body, reply_tx) => {
-                let _ = reply_tx.send($reply_value);
-                (*boxed, body)
-            },
-        }
-    };
-    ($var:expr) => {
-        unwrap_oms_send_msg!(
-            $var,
-            reply_value = $crate::outbound::SendMessageResponse::Queued(vec![])
-        );
-    };
+use crate::schema::dht_settings;
+use std::fmt;
+
+#[derive(Debug, Clone, Copy)]
+pub enum DhtSettingKey {
+    /// The timestamp of the last time this node made a SAF request
+    SafLastRequestTimestamp,
 }
 
-mod dht_actor_mock;
-pub use dht_actor_mock::{create_dht_actor_mock, DhtMockState};
+impl fmt::Display for DhtSettingKey {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{:?}", self)
+    }
+}
 
-mod dht_discovery_mock;
-pub use dht_discovery_mock::{create_dht_discovery_mock, DhtDiscoveryMockState};
+#[derive(Clone, Debug, Insertable)]
+#[table_name = "dht_settings"]
+pub struct NewDhtSettingEntry {
+    pub key: String,
+    pub value: Vec<u8>,
+}
 
-mod makers;
-pub use makers::*;
-
-mod service;
-pub use service::{service_fn, service_spy};
-
-mod store_and_forward_mock;
-pub use store_and_forward_mock::{create_store_and_forward_mock, StoreAndForwardMockState};
+#[derive(Clone, Debug, Queryable, Identifiable)]
+#[table_name = "dht_settings"]
+pub struct DhtSettingsEntry {
+    pub id: i32,
+    pub key: String,
+    pub value: Vec<u8>,
+}

--- a/comms/dht/src/storage/mod.rs
+++ b/comms/dht/src/storage/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2019, The Tari Project
+// Copyright 2019. The Tari Project
 //
 // Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
 // following conditions are met:
@@ -20,34 +20,14 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-macro_rules! unwrap_oms_send_msg {
-    ($var:expr, reply_value=$reply_value:expr) => {
-        match $var {
-            crate::outbound::DhtOutboundRequest::SendMessage(boxed, body, reply_tx) => {
-                let _ = reply_tx.send($reply_value);
-                (*boxed, body)
-            },
-        }
-    };
-    ($var:expr) => {
-        unwrap_oms_send_msg!(
-            $var,
-            reply_value = $crate::outbound::SendMessageResponse::Queued(vec![])
-        );
-    };
-}
+mod connection;
+pub use connection::{DbConnection, DbConnectionUrl};
 
-mod dht_actor_mock;
-pub use dht_actor_mock::{create_dht_actor_mock, DhtMockState};
+mod error;
+pub use error::StorageError;
 
-mod dht_discovery_mock;
-pub use dht_discovery_mock::{create_dht_discovery_mock, DhtDiscoveryMockState};
+mod dht_setting_entry;
+pub use dht_setting_entry::{DhtSettingKey, DhtSettingsEntry};
 
-mod makers;
-pub use makers::*;
-
-mod service;
-pub use service::{service_fn, service_spy};
-
-mod store_and_forward_mock;
-pub use store_and_forward_mock::{create_store_and_forward_mock, StoreAndForwardMockState};
+mod database;
+pub use database::DhtDatabase;

--- a/comms/dht/src/store_forward/database/mod.rs
+++ b/comms/dht/src/store_forward/database/mod.rs
@@ -1,0 +1,165 @@
+// Copyright 2020, The Tari Project
+//
+// Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+// following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+// disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+// following disclaimer in the documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+// products derived from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+// INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+// WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+// USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+mod stored_message;
+pub use stored_message::{NewStoredMessage, StoredMessage};
+
+use crate::{
+    envelope::DhtMessageType,
+    schema::stored_messages,
+    storage::{DbConnection, StorageError},
+    store_forward::message::StoredMessagePriority,
+};
+use chrono::{DateTime, NaiveDateTime, Utc};
+use diesel::{BoolExpressionMethods, ExpressionMethods, QueryDsl, RunQueryDsl};
+use tari_comms::types::CommsPublicKey;
+use tari_crypto::tari_utilities::hex::Hex;
+
+pub struct StoreAndForwardDatabase {
+    connection: DbConnection,
+}
+
+impl StoreAndForwardDatabase {
+    pub fn new(connection: DbConnection) -> Self {
+        Self { connection }
+    }
+
+    pub async fn insert_message(&self, message: NewStoredMessage) -> Result<(), StorageError> {
+        self.connection
+            .with_connection_async(|conn| {
+                diesel::insert_into(stored_messages::table)
+                    .values(message)
+                    .execute(conn)?;
+                Ok(())
+            })
+            .await
+    }
+
+    pub async fn find_messages_for_public_key(
+        &self,
+        public_key: &CommsPublicKey,
+        since: Option<DateTime<Utc>>,
+        limit: i64,
+    ) -> Result<Vec<StoredMessage>, StorageError>
+    {
+        let pk_hex = public_key.to_hex();
+        self.connection
+            .with_connection_async(move |conn| {
+                let mut query = stored_messages::table
+                    .select(stored_messages::all_columns)
+                    .filter(stored_messages::destination_pubkey.eq(pk_hex))
+                    .filter(stored_messages::message_type.eq(DhtMessageType::None as i32))
+                    .into_boxed();
+
+                if let Some(since) = since {
+                    query = query.filter(stored_messages::stored_at.ge(since.naive_utc()));
+                }
+
+                query
+                    .order_by(stored_messages::stored_at.desc())
+                    .limit(limit)
+                    .get_results(conn)
+                    .map_err(Into::into)
+            })
+            .await
+    }
+
+    pub async fn find_messages_of_type_for_pubkey(
+        &self,
+        public_key: &CommsPublicKey,
+        message_type: DhtMessageType,
+        since: Option<DateTime<Utc>>,
+        limit: i64,
+    ) -> Result<Vec<StoredMessage>, StorageError>
+    {
+        let pk_hex = public_key.to_hex();
+        self.connection
+            .with_connection_async(move |conn| {
+                let mut query = stored_messages::table
+                    .select(stored_messages::all_columns)
+                    .filter(
+                        stored_messages::destination_pubkey
+                            .eq(pk_hex)
+                            .or(stored_messages::destination_pubkey.is_null()),
+                    )
+                    .filter(stored_messages::message_type.eq(message_type as i32))
+                    .into_boxed();
+
+                if let Some(since) = since {
+                    query = query.filter(stored_messages::stored_at.ge(since.naive_utc()));
+                }
+
+                query
+                    .order_by(stored_messages::stored_at.desc())
+                    .limit(limit)
+                    .get_results(conn)
+                    .map_err(Into::into)
+            })
+            .await
+    }
+
+    #[cfg(test)]
+    pub(crate) async fn get_all_messages(&self) -> Result<Vec<StoredMessage>, StorageError> {
+        self.connection
+            .with_connection_async(|conn| {
+                stored_messages::table
+                    .select(stored_messages::all_columns)
+                    .get_results(conn)
+                    .map_err(Into::into)
+            })
+            .await
+    }
+
+    pub(crate) async fn delete_messages_with_priority_older_than(
+        &self,
+        priority: StoredMessagePriority,
+        since: NaiveDateTime,
+    ) -> Result<usize, StorageError>
+    {
+        self.connection
+            .with_connection_async(move |conn| {
+                diesel::delete(stored_messages::table)
+                    .filter(stored_messages::stored_at.lt(since))
+                    .filter(stored_messages::priority.eq(priority as i32))
+                    .execute(conn)
+                    .map_err(Into::into)
+            })
+            .await
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use tari_test_utils::random;
+
+    #[tokio_macros::test_basic]
+    async fn insert_messages() {
+        let conn = DbConnection::connect_memory(random::string(8)).await.unwrap();
+        // let conn = DbConnection::connect_path("/tmp/tmp.db").await.unwrap();
+        conn.migrate().await.unwrap();
+        let db = StoreAndForwardDatabase::new(conn);
+        db.insert_message(Default::default()).await.unwrap();
+        let messages = db.get_all_messages().await.unwrap();
+        assert_eq!(messages.len(), 1);
+    }
+}

--- a/comms/dht/src/store_forward/database/stored_message.rs
+++ b/comms/dht/src/store_forward/database/stored_message.rs
@@ -1,0 +1,89 @@
+// Copyright 2020, The Tari Project
+//
+// Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+// following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+// disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+// following disclaimer in the documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+// products derived from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+// INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+// WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+// USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+use crate::{
+    envelope::DhtMessageHeader,
+    proto::envelope::DhtHeader,
+    schema::stored_messages,
+    store_forward::message::StoredMessagePriority,
+};
+use chrono::NaiveDateTime;
+use std::convert::TryInto;
+use tari_comms::message::MessageExt;
+use tari_crypto::tari_utilities::hex::Hex;
+
+#[derive(Clone, Debug, Insertable, Default)]
+#[table_name = "stored_messages"]
+pub struct NewStoredMessage {
+    pub version: i32,
+    pub origin_pubkey: String,
+    pub origin_signature: String,
+    pub message_type: i32,
+    pub destination_pubkey: Option<String>,
+    pub destination_node_id: Option<String>,
+    pub header: Vec<u8>,
+    pub body: Vec<u8>,
+    pub is_encrypted: bool,
+    pub priority: i32,
+}
+
+impl NewStoredMessage {
+    pub fn try_construct(
+        version: u32,
+        dht_header: DhtMessageHeader,
+        priority: StoredMessagePriority,
+        body: Vec<u8>,
+    ) -> Option<Self>
+    {
+        Some(Self {
+            version: version.try_into().ok()?,
+            origin_pubkey: dht_header.origin.as_ref().map(|o| o.public_key.to_hex())?,
+            origin_signature: dht_header.origin.as_ref().map(|o| o.signature.to_hex())?,
+            message_type: dht_header.message_type as i32,
+            destination_pubkey: dht_header.destination.public_key().map(|pk| pk.to_hex()),
+            destination_node_id: dht_header.destination.node_id().map(|node_id| node_id.to_hex()),
+            body,
+            is_encrypted: dht_header.flags.is_encrypted(),
+            priority: priority as i32,
+            header: {
+                let dht_header: DhtHeader = dht_header.into();
+                dht_header.to_encoded_bytes().ok()?
+            },
+        })
+    }
+}
+
+#[derive(Clone, Debug, Queryable, Identifiable)]
+pub struct StoredMessage {
+    pub id: i32,
+    pub version: i32,
+    pub origin_pubkey: String,
+    pub origin_signature: String,
+    pub message_type: i32,
+    pub destination_pubkey: Option<String>,
+    pub destination_node_id: Option<String>,
+    pub header: Vec<u8>,
+    pub body: Vec<u8>,
+    pub is_encrypted: bool,
+    pub priority: i32,
+    pub stored_at: NaiveDateTime,
+}

--- a/comms/dht/src/store_forward/error.rs
+++ b/comms/dht/src/store_forward/error.rs
@@ -20,12 +20,12 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use crate::{actor::DhtActorError, envelope::DhtMessageError, outbound::DhtOutboundError};
+use crate::{actor::DhtActorError, envelope::DhtMessageError, outbound::DhtOutboundError, storage::StorageError};
 use derive_error::Error;
 use prost::DecodeError;
 use std::io;
 use tari_comms::{message::MessageError, peer_manager::PeerManagerError};
-use tari_crypto::tari_utilities::ciphers::cipher::CipherError;
+use tari_crypto::tari_utilities::{byte_array::ByteArrayError, ciphers::cipher::CipherError};
 
 #[derive(Debug, Error)]
 pub enum StoreAndForwardError {
@@ -58,4 +58,15 @@ pub enum StoreAndForwardError {
     MessageOriginRequired,
     /// The message was malformed
     MalformedMessage,
+
+    StorageError(StorageError),
+    /// The store and forward service requester channel closed
+    RequesterChannelClosed,
+    /// The request was cancelled by the store and forward service
+    RequestCancelled,
+    /// The message was not valid for store and forward
+    InvalidStoreMessage,
+    /// The envelope version is invalid
+    InvalidEnvelopeVersion,
+    MalformedNodeId(ByteArrayError),
 }

--- a/comms/dht/src/store_forward/mod.rs
+++ b/comms/dht/src/store_forward/mod.rs
@@ -20,17 +20,24 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-mod error;
-mod forward;
-mod message;
-mod saf_handler;
-mod state;
-mod store;
+type SafResult<T> = Result<T, StoreAndForwardError>;
 
-pub use self::{
-    error::StoreAndForwardError,
-    forward::ForwardLayer,
-    saf_handler::MessageHandlerLayer,
-    state::SafStorage,
-    store::StoreLayer,
-};
+mod service;
+pub use service::{StoreAndForwardRequest, StoreAndForwardRequester, StoreAndForwardService};
+
+mod database;
+pub use database::StoredMessage;
+
+mod error;
+pub use error::StoreAndForwardError;
+
+mod forward;
+pub use forward::ForwardLayer;
+
+mod message;
+
+mod saf_handler;
+pub use saf_handler::MessageHandlerLayer;
+
+mod store;
+pub use store::StoreLayer;

--- a/comms/dht/src/store_forward/service.rs
+++ b/comms/dht/src/store_forward/service.rs
@@ -1,0 +1,274 @@
+// Copyright 2020, The Tari Project
+//
+// Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+// following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+// disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+// following disclaimer in the documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+// products derived from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+// INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+// WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+// USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+use super::{
+    database::{NewStoredMessage, StoreAndForwardDatabase, StoredMessage},
+    message::StoredMessagePriority,
+    SafResult,
+    StoreAndForwardError,
+};
+use crate::{
+    envelope::DhtMessageType,
+    proto::store_forward::stored_messages_response::SafResponseType,
+    storage::DbConnection,
+    DhtConfig,
+};
+use chrono::{DateTime, NaiveDateTime, Utc};
+use futures::{
+    channel::{mpsc, oneshot},
+    stream::Fuse,
+    SinkExt,
+    StreamExt,
+};
+use log::*;
+use std::{convert::TryFrom, time::Duration};
+use tari_comms::types::CommsPublicKey;
+use tari_shutdown::ShutdownSignal;
+use tokio::time;
+
+const LOG_TARGET: &str = "comms::dht::store_forward::actor";
+/// The interval to initiate a database cleanup.
+/// This involves cleaning up messages which have been stored too long according to their priority
+const CLEANUP_INTERVAL: Duration = Duration::from_secs(10 * 60); // 10 mins
+
+#[derive(Debug, Clone)]
+pub struct FetchStoredMessageQuery {
+    public_key: Box<CommsPublicKey>,
+    since: Option<DateTime<Utc>>,
+    response_type: SafResponseType,
+}
+
+impl FetchStoredMessageQuery {
+    pub fn new(public_key: Box<CommsPublicKey>) -> Self {
+        Self {
+            public_key,
+            since: None,
+            response_type: SafResponseType::General,
+        }
+    }
+
+    pub fn since(&mut self, since: DateTime<Utc>) -> &mut Self {
+        self.since = Some(since);
+        self
+    }
+
+    pub fn with_response_type(&mut self, response_type: SafResponseType) -> &mut Self {
+        self.response_type = response_type;
+        self
+    }
+}
+
+#[derive(Debug)]
+pub enum StoreAndForwardRequest {
+    FetchMessages(FetchStoredMessageQuery, oneshot::Sender<SafResult<Vec<StoredMessage>>>),
+    InsertMessage(NewStoredMessage),
+}
+
+#[derive(Clone)]
+pub struct StoreAndForwardRequester {
+    sender: mpsc::Sender<StoreAndForwardRequest>,
+}
+
+impl StoreAndForwardRequester {
+    pub fn new(sender: mpsc::Sender<StoreAndForwardRequest>) -> Self {
+        Self { sender }
+    }
+
+    pub async fn fetch_messages(
+        &mut self,
+        request: FetchStoredMessageQuery,
+    ) -> Result<Vec<StoredMessage>, StoreAndForwardError>
+    {
+        let (reply_tx, reply_rx) = oneshot::channel();
+        self.sender
+            .send(StoreAndForwardRequest::FetchMessages(request, reply_tx))
+            .await
+            .map_err(|_| StoreAndForwardError::RequesterChannelClosed)?;
+        reply_rx.await.map_err(|_| StoreAndForwardError::RequestCancelled)?
+    }
+
+    pub async fn insert_message(&mut self, message: NewStoredMessage) -> Result<(), StoreAndForwardError> {
+        self.sender
+            .send(StoreAndForwardRequest::InsertMessage(message))
+            .await
+            .map_err(|_| StoreAndForwardError::RequesterChannelClosed)?;
+        Ok(())
+    }
+}
+
+pub struct StoreAndForwardService {
+    config: DhtConfig,
+    request_rx: Fuse<mpsc::Receiver<StoreAndForwardRequest>>,
+    shutdown_signal: Option<ShutdownSignal>,
+}
+
+impl StoreAndForwardService {
+    pub fn new(
+        config: DhtConfig,
+        request_rx: mpsc::Receiver<StoreAndForwardRequest>,
+        shutdown_signal: ShutdownSignal,
+    ) -> Self
+    {
+        Self {
+            config,
+            request_rx: request_rx.fuse(),
+            shutdown_signal: Some(shutdown_signal),
+        }
+    }
+
+    pub(crate) async fn connect_database(&self) -> SafResult<StoreAndForwardDatabase> {
+        let conn = DbConnection::connect_url(self.config.database_url.clone()).await?;
+        let output = conn.migrate().await?;
+        info!(target: LOG_TARGET, "Store and forward database migration:\n{}", output);
+        Ok(StoreAndForwardDatabase::new(conn))
+    }
+
+    pub async fn run(mut self) -> SafResult<()> {
+        let db = self.connect_database().await?;
+        let mut shutdown_signal = self
+            .shutdown_signal
+            .take()
+            .expect("StoreAndForwardActor initialized without shutdown_signal");
+
+        let mut cleanup_ticker = time::interval(CLEANUP_INTERVAL).fuse();
+
+        // Do initial cleanup to account for time passed since being offline
+        if let Err(err) = self.cleanup(&db).await {
+            error!(
+                target: LOG_TARGET,
+                "Error when performing store and forward cleanup: {:?}", err
+            );
+        }
+
+        loop {
+            futures::select! {
+                request = self.request_rx.select_next_some() => {
+                    self.handle_request(&db, request).await;
+                },
+
+                _ = cleanup_ticker.next() => {
+                    if let Err(err) = self.cleanup(&db).await {
+                        error!(target: LOG_TARGET, "Error when performing store and forward cleanup: {:?}", err);
+                    }
+                },
+
+                _ = shutdown_signal => {
+                    info!(target: LOG_TARGET, "StoreAndForwardActor is shutting down because the shutdown signal was triggered");
+                    break;
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    async fn handle_request(&self, db: &StoreAndForwardDatabase, request: StoreAndForwardRequest) {
+        use StoreAndForwardRequest::*;
+        match request {
+            FetchMessages(query, reply_tx) => match self.handle_fetch_message_query(db, query).await {
+                Ok(messages) => {
+                    let _ = reply_tx.send(Ok(messages));
+                },
+                Err(err) => {
+                    error!(
+                        target: LOG_TARGET,
+                        "find_messages_by_public_key failed because '{:?}'", err
+                    );
+                    let _ = reply_tx.send(Err(err));
+                },
+            },
+            InsertMessage(msg) => {
+                let public_key = msg.destination_pubkey.clone();
+                match db.insert_message(msg).await {
+                    Ok(_) => info!(
+                        target: LOG_TARGET,
+                        "Store and forward message stored for public key '{}'",
+                        public_key.unwrap_or_else(|| "<None>".to_string())
+                    ),
+                    Err(err) => {
+                        error!(target: LOG_TARGET, "insert_message failed because '{:?}'", err);
+                    },
+                }
+            },
+        }
+    }
+
+    async fn handle_fetch_message_query(
+        &self,
+        db: &StoreAndForwardDatabase,
+        query: FetchStoredMessageQuery,
+    ) -> SafResult<Vec<StoredMessage>>
+    {
+        let limit = i64::try_from(self.config.saf_max_returned_messages)
+            .ok()
+            .or(Some(std::i64::MAX))
+            .unwrap();
+        let messages = match query.response_type {
+            SafResponseType::General => {
+                db.find_messages_for_public_key(&query.public_key, query.since, limit)
+                    .await?
+            },
+            SafResponseType::Join => {
+                db.find_messages_of_type_for_pubkey(&query.public_key, DhtMessageType::Join, query.since, limit)
+                    .await?
+            },
+            SafResponseType::Discovery => {
+                db.find_messages_of_type_for_pubkey(&query.public_key, DhtMessageType::Discovery, query.since, limit)
+                    .await?
+            },
+            SafResponseType::ExplicitlyAddressed => {
+                db.find_messages_for_public_key(&query.public_key, query.since, limit)
+                    .await?
+            },
+        };
+
+        Ok(messages)
+    }
+
+    async fn cleanup(&self, db: &StoreAndForwardDatabase) -> SafResult<()> {
+        let num_removed = db
+            .delete_messages_with_priority_older_than(
+                StoredMessagePriority::Low,
+                since(self.config.saf_low_priority_msg_storage_ttl),
+            )
+            .await?;
+        info!(target: LOG_TARGET, "Cleaned {} old low priority messages", num_removed);
+
+        let num_removed = db
+            .delete_messages_with_priority_older_than(
+                StoredMessagePriority::High,
+                since(self.config.saf_high_priority_msg_storage_ttl),
+            )
+            .await?;
+        info!(target: LOG_TARGET, "Cleaned {} old high priority messages", num_removed);
+        Ok(())
+    }
+}
+
+fn since(period: Duration) -> NaiveDateTime {
+    use chrono::Duration as OldDuration;
+    let period = OldDuration::from_std(period).expect("period was out of range for chrono::Duration");
+    Utc::now()
+        .naive_utc()
+        .checked_sub_signed(period)
+        .expect("period overflowed when used with checked_sub_signed")
+}

--- a/comms/dht/src/test_utils/makers.rs
+++ b/comms/dht/src/test_utils/makers.rs
@@ -91,7 +91,7 @@ pub fn make_comms_inbound_message(node_identity: &NodeIdentity, message: Bytes, 
     )
 }
 
-pub fn make_dht_header(node_identity: &NodeIdentity, message: &Vec<u8>, flags: DhtMessageFlags) -> DhtMessageHeader {
+pub fn make_dht_header(node_identity: &NodeIdentity, message: &[u8], flags: DhtMessageFlags) -> DhtMessageHeader {
     DhtMessageHeader {
         version: 0,
         destination: NodeDestination::Unknown,

--- a/comms/dht/src/test_utils/store_and_forward_mock.rs
+++ b/comms/dht/src/test_utils/store_and_forward_mock.rs
@@ -1,0 +1,135 @@
+// Copyright 2019, The Tari Project
+//
+// Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+// following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+// disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+// following disclaimer in the documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+// products derived from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+// INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+// WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+// USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+use crate::store_forward::{StoreAndForwardRequest, StoreAndForwardRequester, StoredMessage};
+use chrono::Utc;
+use futures::{channel::mpsc, stream::Fuse, StreamExt};
+use log::*;
+use rand::{rngs::OsRng, RngCore};
+use std::sync::{
+    atomic::{AtomicUsize, Ordering},
+    Arc,
+};
+use tokio::{runtime, sync::RwLock};
+
+const LOG_TARGET: &str = "comms::dht::discovery_mock";
+
+pub fn create_store_and_forward_mock() -> (StoreAndForwardRequester, StoreAndForwardMockState) {
+    let (tx, rx) = mpsc::channel(10);
+
+    let mock = StoreAndForwardMock::new(rx.fuse());
+    let state = mock.get_shared_state();
+    runtime::Handle::current().spawn(mock.run());
+    (StoreAndForwardRequester::new(tx), state)
+}
+
+#[derive(Debug, Clone)]
+pub struct StoreAndForwardMockState {
+    call_count: Arc<AtomicUsize>,
+    stored_messages: Arc<RwLock<Vec<StoredMessage>>>,
+    calls: Arc<RwLock<Vec<String>>>,
+}
+
+impl StoreAndForwardMockState {
+    pub fn new() -> Self {
+        Self {
+            call_count: Arc::new(AtomicUsize::new(0)),
+            stored_messages: Arc::new(RwLock::new(Vec::new())),
+            calls: Arc::new(RwLock::new(Vec::new())),
+        }
+    }
+
+    pub fn inc_call_count(&self) {
+        self.call_count.fetch_add(1, Ordering::SeqCst);
+    }
+
+    pub async fn add_call(&self, call: &StoreAndForwardRequest) {
+        self.inc_call_count();
+        self.calls.write().await.push(format!("{:?}", call));
+    }
+
+    pub fn call_count(&self) -> usize {
+        self.call_count.load(Ordering::SeqCst)
+    }
+
+    pub async fn get_messages(&self) -> Vec<StoredMessage> {
+        self.stored_messages.read().await.clone()
+    }
+
+    pub async fn add_message(&self, message: StoredMessage) {
+        self.stored_messages.write().await.push(message)
+    }
+
+    pub async fn take_calls(&self) -> Vec<String> {
+        self.calls.write().await.drain(..).collect()
+    }
+}
+
+pub struct StoreAndForwardMock {
+    receiver: Fuse<mpsc::Receiver<StoreAndForwardRequest>>,
+    state: StoreAndForwardMockState,
+}
+
+impl StoreAndForwardMock {
+    pub fn new(receiver: Fuse<mpsc::Receiver<StoreAndForwardRequest>>) -> Self {
+        Self {
+            receiver,
+            state: StoreAndForwardMockState::new(),
+        }
+    }
+
+    pub fn get_shared_state(&self) -> StoreAndForwardMockState {
+        self.state.clone()
+    }
+
+    pub async fn run(mut self) {
+        while let Some(req) = self.receiver.next().await {
+            self.handle_request(req).await;
+        }
+    }
+
+    async fn handle_request(&self, req: StoreAndForwardRequest) {
+        use StoreAndForwardRequest::*;
+        trace!(target: LOG_TARGET, "StoreAndForwardMock received request {:?}", req);
+        self.state.add_call(&req).await;
+        match req {
+            FetchMessages(_, reply_tx) => {
+                let msgs = self.state.stored_messages.read().await;
+                let _ = reply_tx.send(Ok(msgs.clone()));
+            },
+            InsertMessage(msg) => self.state.stored_messages.write().await.push(StoredMessage {
+                id: OsRng.next_u32() as i32,
+                version: msg.version,
+                origin_pubkey: msg.origin_pubkey,
+                origin_signature: msg.origin_signature,
+                message_type: msg.message_type,
+                destination_pubkey: msg.destination_pubkey,
+                destination_node_id: msg.destination_node_id,
+                header: msg.header,
+                body: msg.body,
+                is_encrypted: msg.is_encrypted,
+                priority: msg.priority,
+                stored_at: Utc::now().naive_utc(),
+            }),
+        }
+    }
+}

--- a/comms/src/message/envelope.rs
+++ b/comms/src/message/envelope.rs
@@ -151,6 +151,10 @@ impl EnvelopeBody {
         self.parts.len()
     }
 
+    pub fn total_size(&self) -> usize {
+        self.parts.iter().fold(0, |acc, b| acc + b.len())
+    }
+
     pub fn is_empty(&self) -> bool {
         self.parts.is_empty()
     }

--- a/infrastructure/storage/src/lmdb_store/store.rs
+++ b/infrastructure/storage/src/lmdb_store/store.rs
@@ -622,7 +622,7 @@ mod test {
 
     #[test]
     fn test_lmdb_builder() {
-        let mut store = LMDBBuilder::new()
+        let store = LMDBBuilder::new()
             .set_path(env::temp_dir())
             .set_environment_size(500)
             .set_max_number_of_databases(10)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
- Implemented sqlite persistence for store and forward (SAF).
- Nodes keep track of a timestamp that they last requested messages for
- Nodes use that timestamp when requesting messages to reduce the number
  of duplicate messages requested
- Request for SAF messages is broken up into 3 responses: Discovery, Join
  and ExplicitlyAddressed - respectively, discovery messages, join messages and
  messages that are explicitly addressed to this node.
- DB migrations run on node startup
- Sqlite operations run on tokio blocking threads
- Sqlite connection interface that allows usage of sqlite's in-memory
  database connection in addition to the file-system database

TODO: 
- Verify that the node requested the store and forward messages before accepting them using the nonce already included in the request and response messages.  
- Clean out stored messages when they have been delivered 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
In order for store and forward to be reliable it will need to be persistent between node restarts and be able to store and fetch thousands of messages. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Some unit testing, _memorynet_ store and forward test works. _memorynet_ takes a wallet offline before another peer attempts to discover it, waits a while for the discovery message to propagate through the network, brings the peer online before the discovery times out, requests SAF messages and see if discovery succeeds.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [~] Breaking change (fix or feature that would cause existing functionality to change)
* [x] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [x] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch.
* [x] I ran `cargo-fmt --all` before pushing.
* [x] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
