### PR TITLE
Added some DHT discovery logging + peer offline bug

### DIFF
--- a/comms/dht/src/discovery/error.rs
+++ b/comms/dht/src/discovery/error.rs
@@ -30,8 +30,6 @@ pub enum DhtDiscoveryError {
     /// The reply channel was canceled
     ReplyCanceled,
     DhtOutboundError(DhtOutboundError),
-    /// Received a discovery response which did not match an inflight discovery request
-    InflightDiscoveryRequestNotFound,
     /// Received public key in peer discovery response which does not match the requested public key
     DiscoveredPeerMismatch,
     /// Received an invalid `NodeId`

--- a/comms/dht/src/discovery/requester.rs
+++ b/comms/dht/src/discovery/requester.rs
@@ -82,7 +82,9 @@ impl Display for DhtDiscoveryRequest {
         use DhtDiscoveryRequest::*;
         match self {
             DiscoverPeer(boxed) => write!(f, "DiscoverPeer({})", boxed.0),
-            NotifyDiscoveryResponseReceived(boxed) => write!(f, "NotifyDiscoveryResponseReceived({:#?})", *boxed),
+            NotifyDiscoveryResponseReceived(discovery_resp) => {
+                write!(f, "NotifyDiscoveryResponseReceived({:#?})", discovery_resp)
+            },
         }
     }
 }

--- a/comms/src/connection_manager/common.rs
+++ b/comms/src/connection_manager/common.rs
@@ -144,6 +144,7 @@ pub async fn validate_and_add_peer_from_peer_identity(
                     Some(supported_protocols),
                 )
                 .await?;
+            peer_manager.set_offline(&authenticated_public_key, false).await?;
         },
         None => {
             debug!(


### PR DESCRIPTION
- Added timestamp to in-flight discovery state to increase visibility of
discovery.
- More logging for different edge cases for discovery response
- Ensure that a peer is unmarked as offline when peer connects.
