### PR TITLE
Removed redundant `EncryptForPeer` encryption option

### DIFF
--- a/base_layer/core/src/base_node/service/service.rs
+++ b/base_layer/core/src/base_node/service/service.rs
@@ -401,7 +401,7 @@ async fn handle_incoming_request<B: BlockchainBackend + 'static>(
     outbound_message_service
         .send_direct(
             origin_public_key,
-            OutboundEncryption::EncryptForPeer,
+            OutboundEncryption::None,
             OutboundDomainMessage::new(TariMessageType::BaseNodeResponse, message),
         )
         .await?;
@@ -506,7 +506,7 @@ async fn handle_outbound_block(
     outbound_message_service
         .propagate(
             NodeDestination::Unknown,
-            OutboundEncryption::EncryptForPeer,
+            OutboundEncryption::None,
             exclude_peers,
             OutboundDomainMessage::new(TariMessageType::NewBlock, ProtoBlock::from(block)),
         )

--- a/base_layer/core/src/mempool/service/service.rs
+++ b/base_layer/core/src/mempool/service/service.rs
@@ -371,7 +371,7 @@ async fn handle_incoming_request<B: BlockchainBackend + 'static>(
     outbound_message_service
         .send_direct(
             origin_public_key,
-            OutboundEncryption::EncryptForPeer,
+            OutboundEncryption::None,
             OutboundDomainMessage::new(TariMessageType::MempoolResponse, message),
         )
         .await?;
@@ -421,7 +421,7 @@ async fn handle_outbound_request(
         .send_random(
             1,
             NodeDestination::Unknown,
-            OutboundEncryption::EncryptForPeer,
+            OutboundEncryption::None,
             OutboundDomainMessage::new(TariMessageType::MempoolRequest, service_request),
         )
         .await
@@ -516,7 +516,7 @@ async fn handle_outbound_tx(
     outbound_message_service
         .propagate(
             NodeDestination::Unknown,
-            OutboundEncryption::EncryptForPeer,
+            OutboundEncryption::None,
             exclude_peers,
             OutboundDomainMessage::new(TariMessageType::NewTransaction, ProtoTransaction::from(tx)),
         )

--- a/base_layer/wallet/src/output_manager_service/service.rs
+++ b/base_layer/wallet/src/output_manager_service/service.rs
@@ -402,7 +402,7 @@ where
                 self.outbound_message_service
                     .send_direct(
                         pk.clone(),
-                        OutboundEncryption::EncryptForPeer,
+                        OutboundEncryption::None,
                         OutboundDomainMessage::new(TariMessageType::BaseNodeRequest, service_request),
                     )
                     .await?;

--- a/base_layer/wallet/src/transaction_service/service.rs
+++ b/base_layer/wallet/src/transaction_service/service.rs
@@ -568,7 +568,7 @@ where
             .outbound_message_service
             .send_direct(
                 dest_pubkey.clone(),
-                OutboundEncryption::EncryptForPeer,
+                OutboundEncryption::None,
                 OutboundDomainMessage::new(TariMessageType::SenderPartialTransaction, proto_message),
             )
             .await?
@@ -707,7 +707,7 @@ where
         self.outbound_message_service
             .send_direct(
                 source_pubkey.clone(),
-                OutboundEncryption::EncryptForPeer,
+                OutboundEncryption::None,
                 OutboundDomainMessage::new(TariMessageType::TransactionFinalized, finalized_transaction_message),
             )
             .await?;
@@ -780,7 +780,7 @@ where
             self.outbound_message_service
                 .send_direct(
                     source_pubkey.clone(),
-                    OutboundEncryption::EncryptForPeer,
+                    OutboundEncryption::None,
                     OutboundDomainMessage::new(TariMessageType::ReceiverPartialTransactionReply, proto_message),
                 )
                 .await?;
@@ -1134,7 +1134,7 @@ where
                 self.outbound_message_service
                     .send_direct(
                         pk.clone(),
-                        OutboundEncryption::EncryptForPeer,
+                        OutboundEncryption::None,
                         OutboundDomainMessage::new(TariMessageType::MempoolRequest, mempool_request),
                     )
                     .await?;
@@ -1358,7 +1358,7 @@ where
                 self.outbound_message_service
                     .send_direct(
                         pk.clone(),
-                        OutboundEncryption::EncryptForPeer,
+                        OutboundEncryption::None,
                         OutboundDomainMessage::new(TariMessageType::MempoolRequest, mempool_request),
                     )
                     .await?;
@@ -1372,7 +1372,7 @@ where
                 self.outbound_message_service
                     .send_direct(
                         pk.clone(),
-                        OutboundEncryption::EncryptForPeer,
+                        OutboundEncryption::None,
                         OutboundDomainMessage::new(TariMessageType::BaseNodeRequest, service_request),
                     )
                     .await?;

--- a/comms/dht/src/outbound/encryption.rs
+++ b/comms/dht/src/outbound/encryption.rs
@@ -100,15 +100,6 @@ where S: Service<DhtOutboundMessage, Response = (), Error = PipelineError>
                 let shared_secret = crypt::generate_ecdh_secret(node_identity.secret_key(), &**public_key);
                 message.body = crypt::encrypt(&shared_secret, &message.body).map_err(PipelineError::from_debug)?;
             },
-            OutboundEncryption::EncryptForPeer => {
-                debug!(
-                    target: LOG_TARGET,
-                    "Encrypting message for peer with public key {}", message.destination_peer.public_key
-                );
-                let shared_secret =
-                    crypt::generate_ecdh_secret(node_identity.secret_key(), &message.destination_peer.public_key);
-                message.body = crypt::encrypt(&shared_secret, &message.body).map_err(PipelineError::from_debug)?
-            },
             OutboundEncryption::None => {
                 debug!(target: LOG_TARGET, "Encryption not requested for message");
             },
@@ -185,7 +176,7 @@ mod test {
                 &[],
             ),
             make_dht_header(&node_identity, &body, DhtMessageFlags::ENCRYPTED),
-            OutboundEncryption::EncryptForPeer,
+            OutboundEncryption::EncryptFor(Box::new(CommsPublicKey::default())),
             MessageFlags::empty(),
             body.clone(),
         );

--- a/comms/dht/src/outbound/message.rs
+++ b/comms/dht/src/outbound/message.rs
@@ -40,18 +40,13 @@ pub enum OutboundEncryption {
     None,
     /// Message should be encrypted using a shared secret derived from the given public key
     EncryptFor(Box<CommsPublicKey>),
-    // TODO: Remove this option as it is redundant (message encryption only needed for forwarded private messages)
-    /// Message should be encrypted using a shared secret derived from the destination peer's
-    /// public key. Each message sent according to the broadcast strategy will be encrypted for
-    /// the destination peer.
-    EncryptForPeer,
 }
 
 impl OutboundEncryption {
     /// Return the correct DHT flags for the encryption setting
     pub fn flags(&self) -> DhtMessageFlags {
         match self {
-            OutboundEncryption::EncryptFor(_) | OutboundEncryption::EncryptForPeer => DhtMessageFlags::ENCRYPTED,
+            OutboundEncryption::EncryptFor(_) => DhtMessageFlags::ENCRYPTED,
             _ => DhtMessageFlags::NONE,
         }
     }
@@ -61,7 +56,7 @@ impl OutboundEncryption {
         use OutboundEncryption::*;
         match self {
             None => false,
-            EncryptFor(_) | EncryptForPeer => true,
+            EncryptFor(_) => true,
         }
     }
 }
@@ -71,7 +66,6 @@ impl Display for OutboundEncryption {
         match self {
             OutboundEncryption::None => write!(f, "None"),
             OutboundEncryption::EncryptFor(ref key) => write!(f, "EncryptFor:{}", key.to_hex()),
-            OutboundEncryption::EncryptForPeer => write!(f, "EncryptForPeer"),
         }
     }
 }

--- a/comms/dht/src/outbound/message_params.rs
+++ b/comms/dht/src/outbound/message_params.rs
@@ -36,11 +36,14 @@ use tari_comms::{
 ///
 /// ```edition2018
 /// # use tari_comms_dht::outbound::{SendMessageParams, OutboundEncryption};
+/// use tari_comms::types::CommsPublicKey;
 ///
-/// // These params represent sending to 5 random peers, each encrypted for that peer
+/// // These params represent sending to 5 random peers. The message will be able to be decrypted by
+/// // the peer with the corresponding secret key of `dest_public_key`.
+/// let dest_public_key = CommsPublicKey::default();
 /// let params = SendMessageParams::new()
 ///   .random(5)
-///   .with_encryption(OutboundEncryption::EncryptForPeer)
+///   .with_encryption(OutboundEncryption::EncryptFor(Box::new(dest_public_key)))
 ///   .finish();
 /// ```
 #[derive(Debug, Clone)]


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
`EncryptForPeer` was originally intended to provide an additional layer
of encryption security by encrypting the message using a shared ECDH key
for the _direct_ over-the-wire receiver the message when using zMQ.

This mode has become redundant with the introduction of the noise
protocol, which provides over-the-wire security (see IX protocol
[security properties]).

[security properties]: https://noiseprotocol.org/noise.html#payload-security-properties

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Removes redundant code and unnecessary computation. This is a non-breaking change because receivers do not require the message to have this additional encryption.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Existing tests updated where necessary.
