### PR TITLE
Updated `list-utxos` command

### DIFF
--- a/applications/tari_base_node/Cargo.toml
+++ b/applications/tari_base_node/Cargo.toml
@@ -20,6 +20,7 @@ tari_shutdown = { path = "../../infrastructure/shutdown", version = "^0.0" }
 tari_mmr = { path = "../../base_layer/mmr", version = "^0.0" }
 tari_wallet = { path = "../../base_layer/wallet", version = "^0.0" }
 tari_broadcast_channel = "^0.1"
+tari_crypto = { version = "^0.3" }
 
 clap = "2.33.0"
 config = { version = "0.9.3" }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Updated `list-utxos` command -displaying the Pedersen commitment rather than the spending key when listing UTXOs.

## Motivation and Context
- When analyzing log files, Pedersen commitments can be traced, but not spending keys.
- The spending key should not be displayed in the console when UTXOs are listed, but kept private. 

## How Has This Been Tested?
Tested with runtime release versions of `tari_base_node` compiled with both Windows 10 and Ubuntu Linux.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [X] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [X] I'm merging against the `development` branch.
* [X] I ran `cargo-fmt --all` before pushing.
* [X] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
