### PR TITLE
Make ConfigBootstrap CLI options reusable via StructOpt

### DIFF
--- a/applications/tari_base_node/Cargo.toml
+++ b/applications/tari_base_node/Cargo.toml
@@ -22,7 +22,7 @@ tari_wallet = { path = "../../base_layer/wallet", version = "^0.0" }
 tari_broadcast_channel = "^0.1"
 tari_crypto = { version = "^0.3" }
 
-clap = "2.33.0"
+structopt = { version = "0.3.13", default_features = false }
 config = { version = "0.9.3" }
 dirs = "2.0.2"
 futures = { version = "^0.3.1", default-features = false, features = ["alloc"]}

--- a/applications/tari_base_node/src/cli.rs
+++ b/applications/tari_base_node/src/cli.rs
@@ -22,8 +22,8 @@
 //
 
 use crate::consts;
-use clap::clap_app;
-use tari_common::{bootstrap_config_from_cli, ConfigBootstrap};
+use structopt::StructOpt;
+use tari_common::ConfigBootstrap;
 
 /// Prints a pretty banner on the console
 pub fn print_banner() {
@@ -36,34 +36,12 @@ pub fn print_banner() {
     );
 }
 
-/// Parsed command-line arguments
+/// The reference Tari cryptocurrency base node implementation
+#[derive(StructOpt)]
 pub struct Arguments {
-    pub bootstrap: ConfigBootstrap,
+    /// Create and save new node identity if one doesn't exist
+    #[structopt(long)]
     pub create_id: bool,
-    pub init: bool,
-}
-
-/// Parse the command-line args and populate the minimal bootstrap config object
-pub fn parse_cli_args() -> Arguments {
-    let matches = clap_app!(myapp =>
-        (version: consts::VERSION)
-        (author: consts::AUTHOR)
-        (about: "The reference Tari cryptocurrency base node implementation")
-        (@arg base_dir: -b --base_dir +takes_value "A path to a directory to store your files")
-        (@arg config: -c --config +takes_value "A path to the configuration file to use (config.toml)")
-        (@arg log_config: -l --log_config +takes_value "A path to the logfile configuration (log4rs.yml))")
-        (@arg init: --init "Create a default configuration file if it doesn't exist")
-        (@arg create_id: --create_id "Create and save new node identity if one doesn't exist ")
-    )
-    .get_matches();
-
-    let bootstrap = bootstrap_config_from_cli(&matches);
-    let create_id = matches.is_present("create_id");
-    let init = matches.is_present("init");
-
-    Arguments {
-        bootstrap,
-        create_id,
-        init,
-    }
+    #[structopt(flatten)]
+    pub bootstrap: ConfigBootstrap,
 }

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2018"
 
 
 [dependencies]
-clap = "2.33.0"
+structopt = { version = "0.3.13", default_features = false }
 config = { version = "0.9.3" }
 dirs = "2.0"
 get_if_addrs = "0.5.3"

--- a/common/examples/base_node_init.rs
+++ b/common/examples/base_node_init.rs
@@ -1,0 +1,19 @@
+use structopt::StructOpt;
+
+#[derive(StructOpt, Debug)]
+/// The reference Tari cryptocurrency base node implementation
+struct Arguments {
+    /// Custom application parameters might eb specified as usual
+    #[structopt(long, default_value = "any structopt options allowed")]
+    my_param: String,
+    #[structopt(flatten)]
+    bootstrap: tari_common::ConfigBootstrap,
+}
+
+fn main() {
+    Arguments::clap().print_help().expect("failed to print help");
+    let mut args = Arguments::from_args();
+    args.bootstrap.init_dirs().expect("failed to initialize configs");
+    println!("");
+    dbg!(args);
+}

--- a/common/src/error.rs
+++ b/common/src/error.rs
@@ -1,0 +1,35 @@
+use std::fmt;
+use structopt::clap::Error as ClapError;
+
+#[derive(Debug)]
+pub struct ConfigError {
+    pub(crate) cause: &'static str,
+    pub(crate) source: Option<String>,
+}
+
+impl ConfigError {
+    pub(crate) fn new(cause: &'static str, source: Option<String>) -> Self {
+        Self { cause, source }
+    }
+}
+
+impl std::error::Error for ConfigError {}
+impl fmt::Display for ConfigError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.cause)?;
+        if let Some(ref source) = self.source {
+            write!(f, ":\n{}", source)
+        } else {
+            Ok(())
+        }
+    }
+}
+
+impl From<ClapError> for ConfigError {
+    fn from(e: ClapError) -> Self {
+        Self {
+            cause: "Failed to process commandline parameters",
+            source: Some(e.to_string()),
+        }
+    }
+}

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -41,21 +41,57 @@
 //!
 //! ```edition2018
 //! # use tari_common::*;
-//! let bootstrap: ConfigBootstrap = ConfigBootstrap::default();
-//! let config = default_config(&bootstrap);
+//! use structopt::StructOpt;
+//!
+//! #[derive(StructOpt)]
+//! /// The reference Tari cryptocurrency base node implementation
+//! struct Arguments {
+//!     /// Create and save new node identity if one doesn't exist
+//!     #[structopt(long)]
+//!     id: bool,
+//!     #[structopt(flatten)]
+//!     bootstrap: ConfigBootstrap,
+//! }
+//!
+//! let mut args = Arguments::from_args();
+//! // args.bootstrap.init_dirs(); // will initalize directories
+//! let config = default_config(&args.bootstrap);
 //! let config = GlobalConfig::convert_from(config).unwrap();
 //! assert_eq!(config.network, Network::MainNet);
 //! assert_eq!(config.blocking_threads, 4);
 //! ```
+//!
+//! ```shell
+//! > main -h
+//! main 0.0.0
+//! The reference Tari cryptocurrency base node implementation
+//!
+//! USAGE:
+//!     main [FLAGS] [OPTIONS]
+//!
+//! FLAGS:
+//!     -h, --help       Prints help information
+//!         --id         Create and save new node identity if one doesn't exist
+//!         --init       Create a default configuration file if it doesn't exist
+//!     -V, --version    Prints version information
+//!
+//! OPTIONS:
+//!         --base-path <base-path>      A path to a directory to store your files
+//!         --config <config>            A path to the configuration file to use (config.toml)
+//!         --log-config <log-config>    The path to the log configuration file. It is set using the following precedence
+//!                                      set: [env: TARI_LOG_CONFIGURATION=]
+//! ```
 
-use clap::ArgMatches;
 use std::path::{Path, PathBuf};
+use structopt::clap::ArgMatches;
 
 mod configuration;
 #[macro_use]
 mod logging;
 
+mod error;
 pub mod protobuf_build;
+pub use error::ConfigError;
 
 pub mod dir_utils;
 pub use configuration::{
@@ -75,16 +111,29 @@ pub use logging::initialize_logging;
 use std::io;
 pub const DEFAULT_CONFIG: &str = "config.toml";
 pub const DEFAULT_LOG_CONFIG: &str = "log4rs.yml";
+use structopt::StructOpt;
 
-/// A minimal parsed configuration object that's used to bootstrap the main Configuration.
+#[derive(StructOpt, Debug)]
 pub struct ConfigBootstrap {
+    /// A path to a directory to store your files
+    #[structopt(short, long, alias("base_dir"), hide_default_value(true), default_value = "")]
     pub base_path: PathBuf,
+    /// A path to the configuration file to use (config.toml)
+    #[structopt(short, long, hide_default_value(true), default_value = "")]
     pub config: PathBuf,
-    /// The path to the log configuration file. It is set using the following precedence set:
-    ///   1. from the command-line parameter,
-    ///   2. from the `TARI_LOG_CONFIGURATION` environment variable,
-    ///   3. from a default value, usually `~/.tari/log4rs.yml` (or OS equivalent).
+    /// The path to the log configuration file. It is set using the following precedence set
+    #[structopt(
+        short,
+        long,
+        alias("log_config"),
+        env = "TARI_LOG_CONFIGURATION",
+        hide_default_value(true),
+        default_value = ""
+    )]
     pub log_config: PathBuf,
+    /// Create a default configuration file if it doesn't exist
+    #[structopt(long)]
+    pub init: bool,
 }
 
 impl Default for ConfigBootstrap {
@@ -93,69 +142,152 @@ impl Default for ConfigBootstrap {
             base_path: dir_utils::default_path("", None),
             config: dir_utils::default_path(DEFAULT_CONFIG, None),
             log_config: dir_utils::default_path(DEFAULT_LOG_CONFIG, None),
+            init: false,
         }
     }
 }
 
+impl ConfigBootstrap {
+    const ARGS: &'static [&'static str] = &["init", "base_dir", "base-path", "config", "log-config"];
+
+    /// Initialize configuration and directories based on ConfigBootstrap options.
+    ///
+    /// If not present it will create base directory (default ~/.tari/, depending on OS).
+    /// Log and tari configs will be initialized in the base directory too.
+    ///
+    /// Without `--init` flag provided configuration and directories will be created only
+    /// after user's confirmation.
+    pub fn init_dirs(&mut self) -> Result<(), ConfigError> {
+        if self.base_path.to_str() == Some("") {
+            self.base_path = dir_utils::default_path("", None);
+        }
+
+        // Create the tari data directory
+        dir_utils::create_data_directory(Some(&self.base_path)).map_err(|err| {
+            ConfigError::new(
+                "We couldn't create a default Tari data directory and have to quit now. This makes us sad :(",
+                Some(err.to_string()),
+            )
+        })?;
+
+        if self.config.to_str() == Some("") {
+            self.config = dir_utils::default_path(DEFAULT_CONFIG, Some(&self.base_path));
+        }
+
+        let log_config = if self.log_config.to_str() == Some("") {
+            None
+        } else {
+            Some(self.log_config.clone())
+        };
+        self.log_config = logging::get_log_configuration_path(log_config);
+
+        if !self.config.exists() {
+            let install = if !self.init {
+                prompt("Config file does not exist. We can create a default one for you now, or you can say 'no' here, \
+                and generate a customised one at https://config.tari.com.\n\
+                Would you like to try the default configuration (Y/n)?")
+            } else {
+                true
+            };
+
+            if install {
+                println!(
+                    "Installing new config file at {}",
+                    self.config.to_str().unwrap_or("[??]")
+                );
+                install_configuration(&self.config, configuration::install_default_config_file);
+            }
+        }
+
+        if !self.log_config.exists() {
+            let install = if !self.init {
+                prompt("Logging configuration file does not exist. Would you like to create a new one (Y/n)?")
+            } else {
+                true
+            };
+            if install {
+                println!(
+                    "Installing new logfile configuration at {}",
+                    self.log_config.to_str().unwrap_or("[??]")
+                );
+                install_configuration(&self.log_config, logging::install_default_logfile_config);
+            }
+        };
+        Ok(())
+    }
+
+    /// Fill in ConfigBootstrap from clap ArgMatches.
+    ///
+    /// ## Example:
+    /// ```rust
+    /// # use structopt::clap::clap_app;
+    /// # use tari_common::*;
+    /// let matches = clap_app!(myapp =>
+    ///     (@arg base_path: -b --("base-path") +takes_value "A path to a directory to store your files")
+    ///     (@arg config: -c --config +takes_value "A path to the configuration file to use (config.toml)")
+    ///     (@arg log_config: -l --("log-config") +takes_value "A path to the logfile configuration (log4rs.yml))")
+    ///     (@arg init: -i --init "Create a default configuration file if it doesn't exist")
+    /// ).get_matches();
+    /// let bootstrap = ConfigBootstrap::from_matches(&matches);
+    /// ```
+    pub fn from_matches(matches: &ArgMatches) -> Result<Self, ConfigError> {
+        let iter = matches
+            .args
+            .keys()
+            .flat_map(|arg| match Self::ARGS.binary_search(arg) {
+                Ok(_) => vec![
+                    Some(std::ffi::OsString::from(format!("--{}", arg))),
+                    matches.value_of_os(arg).map(|s| s.to_os_string()),
+                ],
+                _ => vec![],
+            })
+            .filter_map(|arg| arg);
+
+        Ok(ConfigBootstrap::from_iter_safe(iter)?)
+    }
+
+    /// Set up application-level logging using the Log4rs configuration file
+    /// based on supplied CLI arguments
+    pub fn initialize_logging(&self) -> Result<(), ConfigError> {
+        match initialize_logging(&self.log_config) {
+            true => Ok(()),
+            false => Err(ConfigError::new("failed to initalize logging", None)),
+        }
+    }
+
+    /// Load configuration from files located based on supplied CLI arguments
+    pub fn load_configuration(&self) -> Result<config::Config, ConfigError> {
+        load_configuration(self).map_err(|source| ConfigError::new("failed to load configuration", Some(source)))
+    }
+}
+
+/// Fill in ConfigBootstrap from clap ArgMatches
+///
+/// ```rust
+/// # use structopt::clap::clap_app;
+/// # use tari_common::*;
+/// let matches = clap_app!(myapp =>
+///     (version: "0.0.10")
+///     (author: "The Tari Community")
+///     (about: "The reference Tari cryptocurrency base node implementation")
+///     (@arg base_path: -b --("base-path") +takes_value "A path to a directory to store your files")
+///     (@arg config: -c --config +takes_value "A path to the configuration file to use (config.toml)")
+///     (@arg log_config: -l --("log-config") +takes_value "A path to the logfile configuration (log4rs.yml))")
+///     (@arg init: -i --init "Create a default configuration file if it doesn't exist")
+///     (@arg create_id: --("create-id") "Create and save new node identity if one doesn't exist ")
+/// ).get_matches();
+/// let bootstrap = bootstrap_config_from_cli(&matches);
+/// ```
+/// ## Caveats
+/// It will exit with code 1 if no base dir and fails to create one
 pub fn bootstrap_config_from_cli(matches: &ArgMatches) -> ConfigBootstrap {
-    let base_path = matches
-        .value_of("base_dir")
-        .map(PathBuf::from)
-        .unwrap_or_else(|| dir_utils::default_path("", None));
-
-    // Create the tari data directory
-    if let Err(e) = dir_utils::create_data_directory(Some(&base_path)) {
-        println!(
-            "We couldn't create a default Tari data directory and have to quit now. This makes us sad :(\n {}",
-            e.to_string()
-        );
-        std::process::exit(1);
-    }
-
-    let config = matches
-        .value_of("config")
-        .map(PathBuf::from)
-        .unwrap_or_else(|| dir_utils::default_path(DEFAULT_CONFIG, Some(&base_path)));
-
-    let log_config = matches
-        .value_of("log_config")
-        .map(PathBuf::from)
-        .or_else(|| Some(base_path.clone().join(DEFAULT_LOG_CONFIG)));
-    let log_config = logging::get_log_configuration_path(log_config);
-
-    if !config.exists() {
-        let install = if !matches.is_present("init") {
-            prompt("Config file does not exist. We can create a default one for you now, or you can say 'no' here, \
-            and generate a customised one at https://config.tari.com.\n\
-            Would you like to try the default configuration (Y/n)?")
-        } else {
-            true
-        };
-
-        if install {
-            println!("Installing new config file at {}", config.to_str().unwrap_or("[??]"));
-            install_configuration(&config, configuration::install_default_config_file);
-        }
-    }
-
-    if !log_config.exists() {
-        let install = if !matches.is_present("init") {
-            prompt("Logging configuration file does not exist. Would you like to create a new one (Y/n)?")
-        } else {
-            true
-        };
-        if install {
-            println!(
-                "Installing new logfile configuration at {}",
-                log_config.to_str().unwrap_or("[??]")
-            );
-            install_configuration(&log_config, logging::install_default_logfile_config);
-        }
-    }
-    ConfigBootstrap {
-        base_path,
-        config,
-        log_config,
+    let mut bootstrap = ConfigBootstrap::from_matches(matches).expect("failed to extract matches");
+    match bootstrap.init_dirs() {
+        Err(err) => {
+            println!("{}", err);
+            std::process::exit(1);
+        },
+        Ok(_) => bootstrap,
     }
 }
 
@@ -181,7 +313,7 @@ where F: Fn(&Path) -> Result<(), std::io::Error> {
 #[cfg(test)]
 mod test {
     use crate::{bootstrap_config_from_cli, dir_utils, dir_utils::default_subdir, load_configuration};
-    use clap::clap_app;
+    use structopt::{clap::clap_app, StructOpt};
     use tari_test_utils::random::string;
     use tempdir::TempDir;
 
@@ -220,12 +352,54 @@ mod test {
 
         // Cleanup test data
         if std::path::Path::new(&dir_utils::default_subdir("", Some(dir))).exists() {
-            std::fs::remove_dir_all(&dir_utils::default_subdir("", Some(dir))).unwrap();
+            std::fs::remove_dir_all(&dir_utils::default_subdir("", Some(dir))).expect("failed to cleanup dirs");
         }
 
         // Assert results
         assert!(config_exists);
         assert!(log_config_exists);
+        assert!(&cfg.is_ok());
+    }
+
+    #[test]
+    fn test_bootstrap_config_from_structopt_derive() {
+        let temp_dir = TempDir::new(string(8).as_str()).unwrap();
+        let dir = &temp_dir.path().to_path_buf();
+        // Create test folder
+        dir_utils::create_data_directory(Some(dir)).unwrap();
+
+        #[derive(StructOpt)]
+        /// The reference Tari cryptocurrency base node implementation
+        struct Arguments {
+            /// Create and save new node identity if one doesn't exist
+            #[structopt(long = "create_id")]
+            create_id: bool,
+            #[structopt(flatten)]
+            bootstrap: super::ConfigBootstrap,
+        }
+
+        // Create command line test data
+        let mut args = Arguments::from_iter_safe(vec![
+            "",
+            "--base_dir",
+            default_subdir("", Some(dir)).as_str(),
+            "--init",
+            "--create_id",
+        ])
+        .expect("failed to process arguments");
+        // Init bootstrap dirs
+        args.bootstrap.init_dirs().expect("failed to initialize dirs");
+        // Load and apply configuration file
+        let cfg = load_configuration(&args.bootstrap);
+
+        // Cleanup test data
+        if std::path::Path::new(&dir_utils::default_subdir("", Some(dir))).exists() {
+            std::fs::remove_dir_all(&dir_utils::default_subdir("", Some(dir))).unwrap();
+        }
+
+        // Assert results
+        assert!(args.bootstrap.init);
+        assert!(args.create_id);
         assert!(&cfg.is_ok());
     }
 


### PR DESCRIPTION
## Description
Allowing to reuse ConfigBootstrap CLI options via StructOpt would improve API ergonomics. StructOpt allows to define CLI arguments, description, default and validation in a regular Rust's struct, also allowing to embed that structure in client applications, so that CLI parametes will be reused. While providing StructOpt compatible configuration this change also preserves back compatibility with clap (StructOpt is using clap under the hood).

It also normalizes CLI arguments, e.g. no underscore, options correspond to struct parameters, e.g. `--base-path --log-config` accepted, as well as old aliases `--base_dir --log_config` accepted too.

Also adding `BoostrapConfig::init_dirs()` (similar to bootstrap_config_from_cli),`BoostrapConfig::initialize_logging()` and `BoostrapConfig::initialize_config()`  methods. All methods new normalized `ConfigError` type.

This allows to define CLI interface in a client app as:
```
/// The reference Tari cryptocurrency base node implementation
#[derive(StructOpt)]
pub struct Arguments {
    /// Create and save new node identity if one doesn't exist
    #[structopt(long)]
    pub create_id: bool,
    #[structopt(flatten)]
    pub bootstrap: ConfigBootstrap,
}

fn main() {
    let mut args = Arguments::from_args();
    args.bootstrap.init_dirs().unwrap();
    args.bootstrap.initialize_logging().unwrap();
    let config = args.bootstrap.initialize_config().unwrap();
}
```

This change is back compatible, so it will behave exactly as bootstrapping via clap directly:
```
fn main() {
        let matches = clap_app!(myapp =>
            (version: "0.0.10")
            (about: "The reference Tari cryptocurrency base node implementation")
            (@arg base_dir: -b --base_dir +takes_value "A path to a directory to store your files")
            (@arg config: -c --config +takes_value "A path to the configuration file to use (config.toml)")
            (@arg log_config: -l --log_config +takes_value "A path to the logfile configuration (log4rs.yml))")
            (@arg init: --init "Create a default configuration file if it doesn't exist")
            (@arg create_id: --create_id "Create and save new node identity if one doesn't exist ")
        ).get_matches();

        let bootstrap = bootstrap_config_from_cli(&matches);
        let create_id = matches.is_present("create_id");
        assert!(tari_common::initialize_logging(&bootstrap.log_config));
        load_configuration(&bootstrap).unwrap();
}
```

## Motivation and Context

When starting implementation of custom validation node from BigNeon I noticed that apart of configuration, bootstrap options also might be reusable. Also I liked to use high level StructOpt CLI definition.

This has additional benefit - making struct reusable CLI arguments required for BootstrapConfig will be encapsulated with bootstrapping code, which would allow extending BootstrapConfig and basic CLI arguments in the future directly from tari_commons crate.

## How Has This Been Tested?

This is additional feature, I have added couple of tests covering new feature, making sure same options as with clap approach are tested. Also added some doc tests to test back compatibility with `bootstrap_config_from_cli`.

On Mac OS X I have started tari_base_node successfully, then recreated new ID succefully, then reimplemented tari_base_node via StructOpt way and tested tari_base_node from scratch.

It is back compatible change, providing more ergonomic way of bootstrapping config.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [X] New Tests
* [x] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch.
* [x] I ran `cargo-fmt --all` before pushing.
* [x] I have squashed my commits into a single commit.
* [x] My change requires a change to the documentation.
* [x] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
