### PR TITLE
Transaction Service Refactor to use a protocol and broker pattern

### DIFF
--- a/applications/tari_base_node/src/builder.rs
+++ b/applications/tari_base_node/src/builder.rs
@@ -1150,7 +1150,7 @@ async fn register_wallet_services(
         .add_initializer(TransactionServiceInitializer::new(
             TransactionServiceConfig::default(),
             subscription_factory,
-            wallet_comms.subscribe_messaging_events(),
+            wallet_comms.message_event_sender(),
             TransactionServiceSqliteDatabase::new(wallet_db_conn.clone()),
             wallet_comms.node_identity(),
             factories,

--- a/base_layer/core/src/mempool/mod.rs
+++ b/base_layer/core/src/mempool/mod.rs
@@ -66,7 +66,7 @@ use core::fmt::{Display, Error, Formatter};
 use serde::{Deserialize, Serialize};
 use tari_crypto::tari_utilities::hex::Hex;
 
-#[derive(Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct StatsResponse {
     pub total_txs: usize,
     pub unconfirmed_txs: usize,
@@ -92,7 +92,7 @@ impl Display for StatsResponse {
     }
 }
 
-#[derive(Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct StateResponse {
     pub unconfirmed_pool: Vec<Signature>,
     pub orphan_pool: Vec<Signature>,
@@ -123,7 +123,7 @@ impl Display for StateResponse {
     }
 }
 
-#[derive(Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub enum TxStorageResponse {
     UnconfirmedPool,
     OrphanPool,

--- a/base_layer/core/tests/wallet.rs
+++ b/base_layer/core/tests/wallet.rs
@@ -149,6 +149,7 @@ fn wallet_base_node_integration_test() {
         ContactsServiceMemoryDatabase::new(),
     )
     .unwrap();
+    let mut alice_event_stream = alice_wallet.transaction_service.get_event_stream_fused();
 
     alice_wallet
         .set_base_node_peer(
@@ -247,14 +248,13 @@ fn wallet_base_node_integration_test() {
         ))
         .unwrap();
 
-    let mut alice_event_stream = alice_wallet.transaction_service.get_event_stream_fused();
     runtime.block_on(async {
-        let mut delay = delay_for(Duration::from_secs(30)).fuse();
+        let mut delay = delay_for(Duration::from_secs(60)).fuse();
         let mut broadcast = false;
         loop {
             futures::select! {
                 event = alice_event_stream.select_next_some() => {
-                    if let TransactionEvent::TransactionBroadcast(_e) = (*event).clone() {
+                    if let TransactionEvent::TransactionBroadcast(_e) = (*event.unwrap()).clone() {
                         broadcast = true;
                         break;
                     }
@@ -323,15 +323,13 @@ fn wallet_base_node_integration_test() {
         assert!(found_tx_outputs == transaction.body.outputs().len());
     });
 
-    let mut alice_event_stream = alice_wallet.transaction_service.get_event_stream_fused();
-
     runtime.block_on(async {
         let mut delay = delay_for(Duration::from_secs(30)).fuse();
         let mut mined = false;
         loop {
             futures::select! {
                 event = alice_event_stream.select_next_some() => {
-                    if let TransactionEvent::TransactionMined(_e) = (*event).clone() {
+                    if let TransactionEvent::TransactionMined(_e) = (*event.unwrap()).clone() {
                         mined = true;
                         break;
                     }

--- a/base_layer/wallet/src/testnet_utils.rs
+++ b/base_layer/wallet/src/testnet_utils.rs
@@ -41,6 +41,7 @@ use crate::{
     Wallet,
 };
 use chrono::{Duration as ChronoDuration, Utc};
+use futures::{FutureExt, StreamExt};
 use log::*;
 use rand::{distributions::Alphanumeric, rngs::OsRng, CryptoRng, Rng, RngCore};
 use std::{
@@ -68,8 +69,7 @@ use tari_crypto::{
     tari_utilities::hex::Hex,
 };
 use tari_p2p::{initialization::CommsConfig, transport::TransportType};
-use tari_test_utils::collect_stream;
-use tokio::runtime::Runtime;
+use tokio::{runtime::Runtime, time::delay_for};
 
 // Used to generate test wallet data
 
@@ -208,6 +208,8 @@ pub fn generate_wallet_test_data<
     .collect();
     let mut message_index = 0;
 
+    let mut wallet_event_stream = wallet.transaction_service.get_event_stream_fused();
+
     // Generate contacts
     let mut generated_contacts = Vec::new();
     for i in 0..names.len() {
@@ -247,7 +249,7 @@ pub fn generate_wallet_test_data<
         generated_contacts[0].1.clone(),
         alice_temp_dir.clone(),
     );
-
+    let mut alice_event_stream = wallet_alice.transaction_service.get_event_stream_fused();
     for i in 0..20 {
         let (_ti, uo) = make_input(&mut OsRng.clone(), MicroTari::from(1_500_000 + i * 530_500), &factories);
         wallet_alice
@@ -267,6 +269,8 @@ pub fn generate_wallet_test_data<
         generated_contacts[1].1.clone(),
         bob_temp_dir.clone(),
     );
+    let mut bob_event_stream = wallet_bob.transaction_service.get_event_stream_fused();
+
     for i in 0..20 {
         let (_ti, uo) = make_input(
             &mut OsRng.clone(),
@@ -310,35 +314,54 @@ pub fn generate_wallet_test_data<
         .unwrap();
     info!(target: LOG_TARGET, "Starting to execute test transactions");
 
+    // Grab the first 2 outbound tx_ids for later
+    let mut outbound_tx_ids = Vec::new();
+
     // Completed TX
-    wallet.runtime.block_on(wallet.transaction_service.send_transaction(
+    let tx_id = wallet.runtime.block_on(wallet.transaction_service.send_transaction(
         contacts[0].public_key.clone(),
         MicroTari::from(1_100_000),
         MicroTari::from(100),
         messages[message_index].clone(),
     ))?;
-
+    outbound_tx_ids.push(tx_id.clone());
     message_index = (message_index + 1) % messages.len();
-    wallet.runtime.block_on(wallet.transaction_service.send_transaction(
+
+    let tx_id = wallet.runtime.block_on(wallet.transaction_service.send_transaction(
         contacts[0].public_key.clone(),
         MicroTari::from(2_010_500),
         MicroTari::from(110),
         messages[message_index].clone(),
     ))?;
+    outbound_tx_ids.push(tx_id.clone());
     message_index = (message_index + 1) % messages.len();
 
-    // Grab the first 2 outbound tx_ids for later
-    let mut outbound_tx_ids = Vec::new();
-    let wallet_event_stream = wallet.transaction_service.get_event_stream_fused();
-    let wallet_stream = wallet
-        .runtime
-        .block_on(async { collect_stream!(wallet_event_stream, take = 4, timeout = Duration::from_secs(60)) });
-    for v in wallet_stream {
-        if let TransactionEvent::TransactionSendResult(tx_id, _) = &*v {
-            outbound_tx_ids.push(tx_id.clone());
+    wallet_alice.runtime.block_on(async {
+        let mut delay = delay_for(Duration::from_secs(60)).fuse();
+        let mut count = 0;
+        loop {
+            futures::select! {
+                event = alice_event_stream.select_next_some() => {
+                    match &*event.unwrap() {
+                        TransactionEvent::ReceivedTransaction(_) => {
+                            count +=1;
+                        },
+                        TransactionEvent::ReceivedFinalizedTransaction(_) => {
+                            count +=1;
+                        },
+                        _ => (),
+                    }
+                    if count >=4 {
+                        break;
+                    }
+                },
+                () = delay => {
+                    break;
+                },
+            }
         }
-    }
-    assert_eq!(outbound_tx_ids.len(), 2);
+        assert!(count >= 4, "Event waiting timed out before receiving expected events 1");
+    });
 
     wallet.runtime.block_on(wallet.transaction_service.send_transaction(
         contacts[0].public_key.clone(),
@@ -419,30 +442,59 @@ pub fn generate_wallet_test_data<
     ));
     message_index = (message_index + 1) % messages.len();
 
-    // Make sure that the messages have been received by the alice and bob wallets before they start sending messages so
-    // that they have the wallet in their peer_managers
-    let alice_event_stream = wallet_alice.transaction_service.get_event_stream_fused();
-    let bob_event_stream = wallet_bob.transaction_service.get_event_stream_fused();
+    wallet.runtime.block_on(async {
+        let mut delay = delay_for(Duration::from_secs(60)).fuse();
+        let mut count = 0;
+        loop {
+            futures::select! {
+                event = wallet_event_stream.select_next_some() => {
+                    match &*event.unwrap() {
+                        TransactionEvent::TransactionSendResult(_,_) => {
+                            count+=1;
+                            if count >= 10 {
+                                break;
+                            }
+                        },
+                        _ => (),
+                    }
+                },
+                () = delay => {
+                    break;
+                },
+            }
+        }
+        assert!(
+            count >= 10,
+            "Event waiting timed out before receiving expected events 2"
+        );
+    });
 
-    let _alice_stream = wallet_alice
-        .runtime
-        .block_on(async { collect_stream!(alice_event_stream, take = 12, timeout = Duration::from_secs(60)) });
-
-    let _bob_stream = wallet_bob
-        .runtime
-        .block_on(async { collect_stream!(bob_event_stream, take = 8, timeout = Duration::from_secs(60)) });
-    // Make sure that the messages have been received by the alice and bob wallets before they start sending messages so
-    // that they have the wallet in their peer_managers
-    let alice_event_stream = wallet_alice.transaction_service.get_event_stream_fused();
-    let bob_event_stream = wallet_bob.transaction_service.get_event_stream_fused();
-
-    let _alice_stream = wallet_bob
-        .runtime
-        .block_on(async { collect_stream!(alice_event_stream, take = 6, timeout = Duration::from_secs(60)) });
-
-    let _bob_stream = wallet_bob
-        .runtime
-        .block_on(async { collect_stream!(bob_event_stream, take = 2, timeout = Duration::from_secs(60)) });
+    wallet_bob.runtime.block_on(async {
+        let mut delay = delay_for(Duration::from_secs(60)).fuse();
+        let mut count = 0;
+        loop {
+            futures::select! {
+                event = bob_event_stream.select_next_some() => {
+                    match &*event.unwrap() {
+                        TransactionEvent::ReceivedTransaction(_) => {
+                            count+=1;
+                        },
+                        TransactionEvent::ReceivedFinalizedTransaction(_) => {
+                            count+=1;
+                        },
+                        _ => (),
+                    }
+                    if count >= 8 {
+                        break;
+                    }
+                },
+                () = delay => {
+                    break;
+                },
+            }
+        }
+        assert!(count >= 8, "Event waiting timed out before receiving expected events 3");
+    });
 
     // Pending Inbound
     wallet_alice
@@ -494,10 +546,30 @@ pub fn generate_wallet_test_data<
             messages[message_index].clone(),
         ))?;
 
-    let wallet_event_stream = wallet.transaction_service.get_event_stream_fused();
-    let _wallet_stream = wallet
-        .runtime
-        .block_on(async { collect_stream!(wallet_event_stream, take = 30, timeout = Duration::from_secs(120)) });
+    wallet.runtime.block_on(async {
+        let mut delay = delay_for(Duration::from_secs(60)).fuse();
+        let mut count = 0;
+        loop {
+            futures::select! {
+                event = wallet_event_stream.select_next_some() => {
+                    match &*event.unwrap() {
+                        TransactionEvent::ReceivedFinalizedTransaction(_) => {
+                            count+=1;
+                            if count >= 5 {
+                                break;
+                            }
+                        },
+                        _ => (),
+                    }
+                },
+                () = delay => {
+                    break;
+                },
+            }
+        }
+        assert!(count >= 5, "Event waiting timed out before receiving expected events 4");
+    });
+
     let txs = wallet
         .runtime
         .block_on(wallet.transaction_service.get_completed_transactions())

--- a/base_layer/wallet/src/transaction_service/error.rs
+++ b/base_layer/wallet/src/transaction_service/error.rs
@@ -26,12 +26,14 @@ use crate::{
 };
 use derive_error::Error;
 use diesel::result::Error as DieselError;
+use futures::channel::oneshot::Canceled;
 use serde_json::Error as SerdeJsonError;
 use tari_comms::peer_manager::node_id::NodeIdError;
 use tari_comms_dht::outbound::DhtOutboundError;
 use tari_core::transactions::{transaction::TransactionError, transaction_protocol::TransactionProtocolError};
 use tari_service_framework::reply_channel::TransportChannelError;
 use time::OutOfRangeError;
+use tokio::sync::broadcast::RecvError;
 
 #[derive(Debug, Error)]
 pub enum TransactionServiceError {
@@ -73,6 +75,14 @@ pub enum TransactionServiceError {
     InvalidCompletedTransaction,
     /// No Base Node public keys are provided for Base chain broadcast and monitoring
     NoBaseNodeKeysProvided,
+    /// Error sending data to Protocol via register channels
+    ProtocolChannelError,
+    /// Transaction detected as rejected by mempool
+    MempoolRejection,
+    /// Mempool response key does not match on that is expected
+    UnexpectedMempoolResponse,
+    /// Base Node response key does not match on that is expected
+    UnexpectedBaseNodeResponse,
     DhtOutboundError(DhtOutboundError),
     OutputManagerError(OutputManagerError),
     TransportChannelError(TransportChannelError),
@@ -86,6 +96,8 @@ pub enum TransactionServiceError {
     #[error(msg_embedded, no_from, non_std)]
     ConversionError(String),
     NodeIdError(NodeIdError),
+    BroadcastRecvError(RecvError),
+    OneshotCancelled(Canceled),
 }
 
 #[derive(Debug, Error)]
@@ -113,4 +125,24 @@ pub enum TransactionStorageError {
     DatabaseMigrationError(String),
     #[error(msg_embedded, non_std, no_from)]
     BlockingTaskSpawnError(String),
+}
+
+/// This error type is used to return TransactionServiceErrors from inside a Transaction Service protocol but also
+/// include the ID of the protocol
+#[derive(Debug)]
+pub struct TransactionServiceProtocolError {
+    pub id: u64,
+    pub error: TransactionServiceError,
+}
+
+impl TransactionServiceProtocolError {
+    pub fn new(id: u64, error: TransactionServiceError) -> Self {
+        Self { id, error }
+    }
+}
+
+impl From<TransactionServiceProtocolError> for TransactionServiceError {
+    fn from(tspe: TransactionServiceProtocolError) -> Self {
+        tspe.error
+    }
 }

--- a/base_layer/wallet/src/transaction_service/protocols/mod.rs
+++ b/base_layer/wallet/src/transaction_service/protocols/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2019 The Tari Project
+// Copyright 2020. The Tari Project
 //
 // Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
 // following conditions are met:
@@ -20,23 +20,7 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use crate::{
-    base_node::RequestKey,
-    mempool::{StateResponse, StatsResponse, TxStorageResponse},
-};
-use serde::{Deserialize, Serialize};
-
-/// API Response enum for Mempool responses.
-#[derive(Clone, Debug, Serialize, Deserialize)]
-pub enum MempoolResponse {
-    Stats(StatsResponse),
-    State(StateResponse),
-    TxStorage(TxStorageResponse),
-}
-
-/// Response type for a received MempoolService requests
-#[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct MempoolServiceResponse {
-    pub request_key: RequestKey,
-    pub response: MempoolResponse,
-}
+pub mod transaction_broadcast_protocol;
+pub mod transaction_chain_monitoring_protocol;
+pub mod transaction_receive_protocol;
+pub mod transaction_send_protocol;

--- a/base_layer/wallet/src/transaction_service/protocols/transaction_broadcast_protocol.rs
+++ b/base_layer/wallet/src/transaction_service/protocols/transaction_broadcast_protocol.rs
@@ -1,0 +1,462 @@
+// Copyright 2020. The Tari Project
+//
+// Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+// following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+// disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+// following disclaimer in the documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+// products derived from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+// INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+// WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+// USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+use crate::transaction_service::{
+    error::{TransactionServiceError, TransactionServiceProtocolError},
+    handle::TransactionEvent,
+    service::TransactionServiceResources,
+    storage::database::{TransactionBackend, TransactionStatus},
+};
+use futures::{channel::mpsc::Receiver, FutureExt, StreamExt};
+use log::*;
+use std::{convert::TryFrom, sync::Arc, time::Duration};
+use tari_comms::types::CommsPublicKey;
+use tari_comms_dht::{domain_message::OutboundDomainMessage, outbound::OutboundEncryption};
+use tari_core::{
+    base_node::proto::{
+        base_node as BaseNodeProto,
+        base_node::{
+            base_node_service_request::Request as BaseNodeRequestProto,
+            base_node_service_response::Response as BaseNodeResponseProto,
+        },
+    },
+    mempool::{
+        proto::mempool as MempoolProto,
+        service::{MempoolResponse, MempoolServiceResponse},
+        TxStorageResponse,
+    },
+    transactions::transaction::TransactionOutput,
+};
+use tari_crypto::tari_utilities::{hex::Hex, Hashable};
+use tari_p2p::tari_message::TariMessageType;
+use tokio::time::delay_for;
+
+const LOG_TARGET: &str = "wallet::transaction_service::protocols::broadcast_protocol";
+
+/// This protocol defines the process of monitoring a mempool and base node to detect when a Completed transaction is
+/// Broadcast to the mempool or potentially Mined
+pub struct TransactionBroadcastProtocol<TBackend>
+where TBackend: TransactionBackend + Clone + 'static
+{
+    id: u64,
+    resources: TransactionServiceResources<TBackend>,
+    timeout: Duration,
+    base_node_public_key: CommsPublicKey,
+    mempool_response_receiver: Option<Receiver<MempoolServiceResponse>>,
+    base_node_response_receiver: Option<Receiver<BaseNodeProto::BaseNodeServiceResponse>>,
+}
+
+impl<TBackend> TransactionBroadcastProtocol<TBackend>
+where TBackend: TransactionBackend + Clone + 'static
+{
+    pub fn new(
+        id: u64,
+        resources: TransactionServiceResources<TBackend>,
+        timeout: Duration,
+        base_node_public_key: CommsPublicKey,
+        mempool_response_receiver: Receiver<MempoolServiceResponse>,
+        base_node_response_receiver: Receiver<BaseNodeProto::BaseNodeServiceResponse>,
+    ) -> Self
+    {
+        Self {
+            id,
+            resources,
+            timeout,
+            base_node_public_key,
+            mempool_response_receiver: Some(mempool_response_receiver),
+            base_node_response_receiver: Some(base_node_response_receiver),
+        }
+    }
+
+    /// The task that defines the execution of the protocol.
+    pub async fn execute(mut self) -> Result<u64, TransactionServiceProtocolError> {
+        let mut mempool_response_receiver = self
+            .mempool_response_receiver
+            .take()
+            .ok_or_else(|| TransactionServiceProtocolError::new(self.id, TransactionServiceError::InvalidStateError))?;
+
+        let mut base_node_response_receiver = self
+            .base_node_response_receiver
+            .take()
+            .ok_or_else(|| TransactionServiceProtocolError::new(self.id, TransactionServiceError::InvalidStateError))?;
+
+        // This is the main loop of the protocol and following the following steps
+        // 1) Check transaction being monitored is still in the Completed state and needs to be monitored
+        // 2) Send a MempoolRequest::SubmitTransaction to Mempool and a Mined? Request to base node
+        // 3) Wait for a either a Mempool response, Base Node response for the correct Id OR a Timeout
+        //      a) A Mempool response for this Id is received >  update the Tx status and end the protocol
+        //      b) A Basenode response for this Id is received showing it is mined > Update Tx status and end protocol
+        //      c) Timeout is reached > Start again
+        loop {
+            let completed_tx = match self.resources.db.get_completed_transaction(self.id).await {
+                Ok(tx) => tx,
+                Err(e) => {
+                    error!(
+                        target: LOG_TARGET,
+                        "Cannot find Completed Transaction (TxId: {}) referred to by this Broadcast protocol: {:?}",
+                        self.id,
+                        e
+                    );
+                    return Err(TransactionServiceProtocolError::new(
+                        self.id,
+                        TransactionServiceError::TransactionDoesNotExistError,
+                    ));
+                },
+            };
+
+            if completed_tx.status != TransactionStatus::Completed {
+                debug!(
+                    target: LOG_TARGET,
+                    "Transaction (TxId: {}) no longer in Completed state and will stop being broadcast", self.id
+                );
+                return Ok(self.id);
+            }
+
+            info!(
+                target: LOG_TARGET,
+                "Attempting to Broadcast Transaction (TxId: {} and Kernel Signature: {}) to Mempool",
+                self.id,
+                completed_tx.transaction.body.kernels()[0]
+                    .excess_sig
+                    .get_signature()
+                    .to_hex()
+            );
+            trace!(target: LOG_TARGET, "{}", completed_tx.transaction);
+
+            // Send Mempool Request
+            let mempool_request = MempoolProto::MempoolServiceRequest {
+                request_key: completed_tx.tx_id,
+                request: Some(MempoolProto::mempool_service_request::Request::SubmitTransaction(
+                    completed_tx.transaction.clone().into(),
+                )),
+            };
+
+            self.resources
+                .outbound_message_service
+                .send_direct(
+                    self.base_node_public_key.clone(),
+                    OutboundEncryption::None,
+                    OutboundDomainMessage::new(TariMessageType::MempoolRequest, mempool_request.clone()),
+                )
+                .await
+                .map_err(|e| TransactionServiceProtocolError::new(self.id, TransactionServiceError::from(e)))?;
+
+            // Send Base Node query
+            let mut hashes = Vec::new();
+            for o in completed_tx.transaction.body.outputs() {
+                hashes.push(o.hash());
+            }
+
+            let request = BaseNodeRequestProto::FetchUtxos(BaseNodeProto::HashOutputs { outputs: hashes });
+            let service_request = BaseNodeProto::BaseNodeServiceRequest {
+                request_key: self.id,
+                request: Some(request),
+            };
+            self.resources
+                .outbound_message_service
+                .send_direct(
+                    self.base_node_public_key.clone(),
+                    OutboundEncryption::None,
+                    OutboundDomainMessage::new(TariMessageType::BaseNodeRequest, service_request),
+                )
+                .await
+                .map_err(|e| TransactionServiceProtocolError::new(self.id, TransactionServiceError::from(e)))?;
+
+            let mut delay = delay_for(self.timeout).fuse();
+            futures::select! {
+                mempool_response = mempool_response_receiver.select_next_some() => {
+                    if self.handle_mempool_response(mempool_response).await? {
+                        break;
+                    }
+                },
+                base_node_response = base_node_response_receiver.select_next_some() => {
+                    if self.handle_base_node_response(base_node_response).await? {
+                        break;
+                    }
+                },
+                () = delay => {
+                },
+            }
+
+            info!(
+                target: LOG_TARGET,
+                "Mempool broadcast timed out for Transaction with TX_ID: {}", self.id
+            );
+
+            let _ = self
+                .resources
+                .event_publisher
+                .send(Arc::new(TransactionEvent::MempoolBroadcastTimedOut(self.id)))
+                .map_err(|e| {
+                    trace!(
+                        target: LOG_TARGET,
+                        "Error sending event, usually because there are no subscribers: {:?}",
+                        e
+                    );
+                    e
+                });
+        }
+
+        Ok(self.id)
+    }
+
+    async fn handle_mempool_response(
+        &mut self,
+        response: MempoolServiceResponse,
+    ) -> Result<bool, TransactionServiceProtocolError>
+    {
+        if response.request_key != self.id {
+            trace!(
+                target: LOG_TARGET,
+                "Mempool response key does not match this Broadcast Protocol Id"
+            );
+            return Ok(false);
+        }
+
+        // Handle a receive Mempool Response
+        match response.response {
+            MempoolResponse::Stats(_) => {
+                error!(target: LOG_TARGET, "Invalid Mempool response variant");
+            },
+            MempoolResponse::State(_) => {
+                error!(target: LOG_TARGET, "Invalid Mempool response variant");
+            },
+            MempoolResponse::TxStorage(ts) => {
+                let completed_tx = match self
+                    .resources
+                    .db
+                    .get_completed_transaction(response.request_key.clone())
+                    .await
+                {
+                    Ok(tx) => tx,
+                    Err(e) => {
+                        error!(
+                            target: LOG_TARGET,
+                            "Cannot find Completed Transaction (TxId: {}) referred to by this Broadcast protocol: {:?}",
+                            self.id,
+                            e
+                        );
+                        return Err(TransactionServiceProtocolError::new(
+                            self.id,
+                            TransactionServiceError::TransactionDoesNotExistError,
+                        ));
+                    },
+                };
+                match completed_tx.status {
+                    TransactionStatus::Completed => match ts {
+                        // Getting this response means the Mempool Rejected this transaction so it will be
+                        // cancelled.
+                        TxStorageResponse::NotStored => {
+                            error!(
+                                target: LOG_TARGET,
+                                "Mempool response received for TxId: {:?}. Transaction was REJECTED. Cancelling \
+                                 transaction.",
+                                self.id
+                            );
+                            if let Err(e) = self
+                                .resources
+                                .output_manager_service
+                                .cancel_transaction(completed_tx.tx_id)
+                                .await
+                            {
+                                error!(
+                                    target: LOG_TARGET,
+                                    "Failed to Cancel outputs for TX_ID: {} after failed sending attempt with error \
+                                     {:?}",
+                                    completed_tx.tx_id,
+                                    e
+                                );
+                            }
+                            if let Err(e) = self.resources.db.cancel_completed_transaction(completed_tx.tx_id).await {
+                                error!(
+                                    target: LOG_TARGET,
+                                    "Failed to Cancel TX_ID: {} after failed sending attempt with error {:?}",
+                                    completed_tx.tx_id,
+                                    e
+                                );
+                            }
+                            let _ = self
+                                .resources
+                                .event_publisher
+                                .send(Arc::new(TransactionEvent::TransactionSendDiscoveryComplete(
+                                    self.id, false,
+                                )))
+                                .map_err(|e| {
+                                    trace!(
+                                        target: LOG_TARGET,
+                                        "Error sending event, usually because there are no subscribers: {:?}",
+                                        e
+                                    );
+                                    e
+                                });
+
+                            return Err(TransactionServiceProtocolError::new(
+                                self.id,
+                                TransactionServiceError::MempoolRejection,
+                            ));
+                        },
+                        // Any other variant of this enum means the transaction has been received by the
+                        // base_node and is in one of the various mempools
+                        _ => {
+                            // If this transaction is still in the Completed State it should be upgraded to the
+                            // Broadcast state
+                            info!(
+                                target: LOG_TARGET,
+                                "Completed Transaction (TxId: {} and Kernel Excess Sig: {}) detected as Broadcast to \
+                                 Base Node Mempool in {:?}",
+                                self.id,
+                                completed_tx.transaction.body.kernels()[0]
+                                    .excess_sig
+                                    .get_signature()
+                                    .to_hex(),
+                                ts
+                            );
+
+                            self.resources
+                                .db
+                                .broadcast_completed_transaction(self.id)
+                                .await
+                                .map_err(|e| {
+                                    TransactionServiceProtocolError::new(self.id, TransactionServiceError::from(e))
+                                })?;
+                            let _ = self
+                                .resources
+                                .event_publisher
+                                .send(Arc::new(TransactionEvent::TransactionBroadcast(self.id)))
+                                .map_err(|e| {
+                                    trace!(
+                                        target: LOG_TARGET,
+                                        "Error sending event, usually because there are no subscribers: {:?}",
+                                        e
+                                    );
+                                    e
+                                });
+                            return Ok(true);
+                        },
+                    },
+                    _ => (),
+                }
+            },
+        }
+
+        Ok(false)
+    }
+
+    async fn handle_base_node_response(
+        &mut self,
+        response: BaseNodeProto::BaseNodeServiceResponse,
+    ) -> Result<bool, TransactionServiceProtocolError>
+    {
+        if response.request_key != self.id {
+            trace!(
+                target: LOG_TARGET,
+                "Base Node response key does not match this Broadcast Protocol Id"
+            );
+            return Ok(false);
+        }
+
+        let response: Vec<tari_core::transactions::proto::types::TransactionOutput> = match response.response {
+            Some(BaseNodeResponseProto::TransactionOutputs(outputs)) => outputs.outputs,
+            _ => {
+                return Ok(false);
+            },
+        };
+
+        let completed_tx = match self.resources.db.get_completed_transaction(self.id).await {
+            Ok(tx) => tx,
+            Err(_) => {
+                error!(
+                    target: LOG_TARGET,
+                    "Cannot find Completed Transaction (TxId: {}) referred to by this Broadcast protocol", self.id
+                );
+                return Err(TransactionServiceProtocolError::new(
+                    self.id,
+                    TransactionServiceError::TransactionDoesNotExistError,
+                ));
+            },
+        };
+
+        if !response.is_empty() &&
+            (completed_tx.status == TransactionStatus::Broadcast ||
+                completed_tx.status == TransactionStatus::Completed)
+        {
+            let mut check = true;
+
+            for output in response.iter() {
+                let transaction_output = TransactionOutput::try_from(output.clone()).map_err(|_| {
+                    TransactionServiceProtocolError::new(
+                        self.id,
+                        TransactionServiceError::ConversionError("Could not convert Transaction Output".to_string()),
+                    )
+                })?;
+
+                check = check &&
+                    completed_tx
+                        .transaction
+                        .body
+                        .outputs()
+                        .iter()
+                        .any(|item| item == &transaction_output);
+            }
+            // If all outputs are present then mark this transaction as mined.
+            if check && !response.is_empty() {
+                self.resources
+                    .output_manager_service
+                    .confirm_transaction(
+                        self.id,
+                        completed_tx.transaction.body.inputs().clone(),
+                        completed_tx.transaction.body.outputs().clone(),
+                    )
+                    .await
+                    .map_err(|e| TransactionServiceProtocolError::new(self.id, TransactionServiceError::from(e)))?;
+
+                self.resources
+                    .db
+                    .mine_completed_transaction(self.id)
+                    .await
+                    .map_err(|e| TransactionServiceProtocolError::new(self.id, TransactionServiceError::from(e)))?;
+
+                let _ = self
+                    .resources
+                    .event_publisher
+                    .send(Arc::new(TransactionEvent::TransactionMined(self.id)))
+                    .map_err(|e| {
+                        trace!(
+                            target: LOG_TARGET,
+                            "Error sending event, usually because there are no subscribers: {:?}",
+                            e
+                        );
+                        e
+                    });
+
+                info!(
+                    target: LOG_TARGET,
+                    "Transaction (TxId: {:?}) detected as mined on the Base Layer", self.id
+                );
+
+                return Ok(true);
+            }
+        }
+
+        Ok(false)
+    }
+}

--- a/base_layer/wallet/src/transaction_service/protocols/transaction_chain_monitoring_protocol.rs
+++ b/base_layer/wallet/src/transaction_service/protocols/transaction_chain_monitoring_protocol.rs
@@ -1,0 +1,481 @@
+// Copyright 2020. The Tari Project
+//
+// Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+// following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+// disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+// following disclaimer in the documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+// products derived from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+// INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+// WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+// USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+use crate::{
+    output_manager_service::TxId,
+    transaction_service::{
+        error::{TransactionServiceError, TransactionServiceProtocolError},
+        handle::TransactionEvent,
+        service::TransactionServiceResources,
+        storage::database::{TransactionBackend, TransactionStatus},
+    },
+};
+use futures::{channel::mpsc::Receiver, FutureExt, StreamExt};
+use log::*;
+use std::{convert::TryFrom, sync::Arc, time::Duration};
+use tari_comms::types::CommsPublicKey;
+use tari_comms_dht::{domain_message::OutboundDomainMessage, outbound::OutboundEncryption};
+use tari_core::{
+    base_node::proto::{
+        base_node as BaseNodeProto,
+        base_node::{
+            base_node_service_request::Request as BaseNodeRequestProto,
+            base_node_service_response::Response as BaseNodeResponseProto,
+        },
+    },
+    mempool::{
+        proto::mempool as MempoolProto,
+        service::{MempoolResponse, MempoolServiceResponse},
+        TxStorageResponse,
+    },
+    transactions::transaction::TransactionOutput,
+};
+use tari_crypto::tari_utilities::{hex::Hex, Hashable};
+use tari_p2p::tari_message::TariMessageType;
+use tokio::time::delay_for;
+
+const LOG_TARGET: &str = "wallet::transaction_service::protocols::chain_monitoring_protocol";
+
+/// This protocol defines the process of monitoring a mempool and base node to detect when a Broadcast transaction is
+/// Mined or leaves the mempool in which case it should be cancelled
+pub struct TransactionChainMonitoringProtocol<TBackend>
+where TBackend: TransactionBackend + Clone + 'static
+{
+    id: u64,
+    tx_id: TxId,
+    resources: TransactionServiceResources<TBackend>,
+    timeout: Duration,
+    base_node_public_key: CommsPublicKey,
+    mempool_response_receiver: Option<Receiver<MempoolServiceResponse>>,
+    base_node_response_receiver: Option<Receiver<BaseNodeProto::BaseNodeServiceResponse>>,
+}
+
+impl<TBackend> TransactionChainMonitoringProtocol<TBackend>
+where TBackend: TransactionBackend + Clone + 'static
+{
+    pub fn new(
+        id: u64,
+        tx_id: TxId,
+        resources: TransactionServiceResources<TBackend>,
+        timeout: Duration,
+        base_node_public_key: CommsPublicKey,
+        mempool_response_receiver: Receiver<MempoolServiceResponse>,
+        base_node_response_receiver: Receiver<BaseNodeProto::BaseNodeServiceResponse>,
+    ) -> Self
+    {
+        Self {
+            id,
+            tx_id,
+            resources,
+            timeout,
+            base_node_public_key,
+            mempool_response_receiver: Some(mempool_response_receiver),
+            base_node_response_receiver: Some(base_node_response_receiver),
+        }
+    }
+
+    /// The task that defines the execution of the protocol.
+    pub async fn execute(mut self) -> Result<u64, TransactionServiceProtocolError> {
+        let mut mempool_response_receiver =
+            self.mempool_response_receiver
+                .take()
+                .ok_or(TransactionServiceProtocolError::new(
+                    self.id,
+                    TransactionServiceError::InvalidStateError,
+                ))?;
+
+        let mut base_node_response_receiver =
+            self.base_node_response_receiver
+                .take()
+                .ok_or(TransactionServiceProtocolError::new(
+                    self.id,
+                    TransactionServiceError::InvalidStateError,
+                ))?;
+
+        trace!(
+            target: LOG_TARGET,
+            "Starting chain monitoring protocol for TxId: {} with Protocol ID: {}",
+            self.tx_id,
+            self.id
+        );
+
+        // This is the main loop of the protocol and following the following steps
+        // 1) Check transaction being monitored is still in the Broadcast state and needs to be monitored
+        // 2) Send a MempoolRequest::GetTxStateWithExcessSig to Mempool and a Mined? Request to base node
+        // 3) Wait for both a Mempool response and Base Node response for the correct Id OR a Timeout
+        //      a) If the Tx is not in the mempool AND is not mined the protocol ends and Tx should be cancelled
+        //      b) If the Tx is in the mempool AND not mined > perform another iteration
+        //      c) If the Tx is in the mempool AND mined then update the status of the Tx and end the protocol
+        //      c) Timeout is reached > Start again
+        loop {
+            let completed_tx = match self.resources.db.get_completed_transaction(self.tx_id).await {
+                Ok(tx) => tx,
+                Err(e) => {
+                    error!(
+                        target: LOG_TARGET,
+                        "Cannot find Completed Transaction (TxId: {}) referred to by this Chain Monitoring Protocol: \
+                         {:?}",
+                        self.tx_id,
+                        e
+                    );
+                    return Err(TransactionServiceProtocolError::new(
+                        self.id,
+                        TransactionServiceError::TransactionDoesNotExistError,
+                    ));
+                },
+            };
+
+            if completed_tx.status != TransactionStatus::Broadcast {
+                debug!(
+                    target: LOG_TARGET,
+                    "Transaction (TxId: {}) no longer in Broadcast state and will stop being monitored for being Mined",
+                    self.tx_id
+                );
+                return Ok(self.id);
+            }
+
+            let mut hashes = Vec::new();
+            for o in completed_tx.transaction.body.outputs() {
+                hashes.push(o.hash());
+            }
+
+            info!(
+                target: LOG_TARGET,
+                "Sending Transaction Mined? request for TxId: {} and Kernel Signature {} to Base Node (Contains {} \
+                 outputs)",
+                completed_tx.tx_id,
+                completed_tx.transaction.body.kernels()[0]
+                    .excess_sig
+                    .get_signature()
+                    .to_hex(),
+                hashes.len(),
+            );
+
+            // Send Mempool query
+            let tx_excess_sig = completed_tx.transaction.body.kernels()[0].excess_sig.clone();
+            let mempool_request = MempoolProto::MempoolServiceRequest {
+                request_key: self.id,
+                request: Some(MempoolProto::mempool_service_request::Request::GetTxStateWithExcessSig(
+                    tx_excess_sig.into(),
+                )),
+            };
+
+            self.resources
+                .outbound_message_service
+                .send_direct(
+                    self.base_node_public_key.clone(),
+                    OutboundEncryption::None,
+                    OutboundDomainMessage::new(TariMessageType::MempoolRequest, mempool_request.clone()),
+                )
+                .await
+                .map_err(|e| TransactionServiceProtocolError::new(self.id, TransactionServiceError::from(e)))?;
+
+            // Send Base Node query
+            let request = BaseNodeRequestProto::FetchUtxos(BaseNodeProto::HashOutputs { outputs: hashes });
+            let service_request = BaseNodeProto::BaseNodeServiceRequest {
+                request_key: self.id,
+                request: Some(request),
+            };
+            self.resources
+                .outbound_message_service
+                .send_direct(
+                    self.base_node_public_key.clone(),
+                    OutboundEncryption::None,
+                    OutboundDomainMessage::new(TariMessageType::BaseNodeRequest, service_request),
+                )
+                .await
+                .map_err(|e| TransactionServiceProtocolError::new(self.id, TransactionServiceError::from(e)))?;
+
+            let mut delay = delay_for(self.timeout).fuse();
+            let mut received_mempool_response = false;
+            let mut received_base_node_response = false;
+            // Loop until both a Mempool response AND a Base node response is received OR the Timeout expires.
+            loop {
+                futures::select! {
+                    mempool_response = mempool_response_receiver.select_next_some() => {
+                        if !self
+                        .handle_mempool_response(completed_tx.tx_id, mempool_response)
+                        .await?
+                        {
+                            return Err(TransactionServiceProtocolError::new(
+                                self.id,
+                                TransactionServiceError::MempoolRejection,
+                            ));
+                        }
+                        received_mempool_response = true;
+
+                    },
+                    base_node_response = base_node_response_receiver.select_next_some() => {
+                        if self
+                        .handle_base_node_response(completed_tx.tx_id, base_node_response)
+                        .await?
+                        {
+                            // Tx is mined!
+                            return Ok(self.id);
+                        }
+                        received_base_node_response = true;
+                    },
+                    () = delay => {
+                        break;
+                    },
+                }
+
+                // If we have received both responses from this round we can stop waiting for more responses
+                if received_mempool_response && received_base_node_response {
+                    break;
+                }
+            }
+
+            if received_mempool_response && received_base_node_response {
+                info!(
+                    target: LOG_TARGET,
+                    "Base node and Mempool response received. TxId: {:?} not mined yet.", completed_tx.tx_id,
+                );
+                // Finish out the rest of this period before moving onto next round
+                delay.await;
+            }
+
+            info!(
+                target: LOG_TARGET,
+                "Chain monitoring process timed out for Transaction TX_ID: {}", completed_tx.tx_id
+            );
+
+            let _ = self
+                .resources
+                .event_publisher
+                .send(Arc::new(TransactionEvent::TransactionMinedRequestTimedOut(
+                    completed_tx.tx_id,
+                )))
+                .map_err(|e| {
+                    trace!(
+                        target: LOG_TARGET,
+                        "Error sending event, usually because there are no subscribers: {:?}",
+                        e
+                    );
+                    e
+                });
+        }
+    }
+
+    async fn handle_mempool_response(
+        &mut self,
+        tx_id: TxId,
+        response: MempoolServiceResponse,
+    ) -> Result<bool, TransactionServiceProtocolError>
+    {
+        // Handle a receive Mempool Response
+        match response.response {
+            MempoolResponse::Stats(_) => {
+                error!(target: LOG_TARGET, "Invalid Mempool response variant");
+            },
+            MempoolResponse::State(_) => {
+                error!(target: LOG_TARGET, "Invalid Mempool response variant");
+            },
+            MempoolResponse::TxStorage(ts) => {
+                let completed_tx = match self.resources.db.get_completed_transaction(tx_id).await {
+                    Ok(tx) => tx,
+                    Err(e) => {
+                        error!(
+                            target: LOG_TARGET,
+                            "Cannot find Completed Transaction (TxId: {}) referred to by this Chain Monitoring \
+                             Protocol: {:?}",
+                            self.tx_id,
+                            e
+                        );
+                        return Err(TransactionServiceProtocolError::new(
+                            self.id,
+                            TransactionServiceError::TransactionDoesNotExistError,
+                        ));
+                    },
+                };
+                match completed_tx.status {
+                    TransactionStatus::Broadcast => match ts {
+                        // Getting this response means the Mempool Rejected this transaction so it will be
+                        // cancelled.
+                        TxStorageResponse::NotStored => {
+                            error!(
+                                target: LOG_TARGET,
+                                "Mempool response received for TxId: {:?}. Transaction was REJECTED. Cancelling \
+                                 transaction.",
+                                tx_id
+                            );
+                            if let Err(e) = self
+                                .resources
+                                .output_manager_service
+                                .cancel_transaction(completed_tx.tx_id)
+                                .await
+                            {
+                                error!(
+                                    target: LOG_TARGET,
+                                    "Failed to Cancel outputs for TX_ID: {} after failed sending attempt with error \
+                                     {:?}",
+                                    completed_tx.tx_id,
+                                    e
+                                );
+                            }
+                            if let Err(e) = self.resources.db.cancel_completed_transaction(completed_tx.tx_id).await {
+                                error!(
+                                    target: LOG_TARGET,
+                                    "Failed to Cancel TX_ID: {} after failed sending attempt with error {:?}",
+                                    completed_tx.tx_id,
+                                    e
+                                );
+                            }
+                            let _ = self
+                                .resources
+                                .event_publisher
+                                .send(Arc::new(TransactionEvent::TransactionSendDiscoveryComplete(
+                                    completed_tx.tx_id,
+                                    false,
+                                )))
+                                .map_err(|e| {
+                                    trace!(
+                                        target: LOG_TARGET,
+                                        "Error sending event, usually because there are no subscribers: {:?}",
+                                        e
+                                    );
+                                    e
+                                });
+
+                            return Err(TransactionServiceProtocolError::new(
+                                self.id,
+                                TransactionServiceError::MempoolRejection,
+                            ));
+                        },
+                        // Any other variant of this enum means the transaction has been received by the
+                        // base_node and is in one of the various mempools
+                        _ => {
+                            // If this transaction is still in the Completed State it should be upgraded to the
+                            // Broadcast state
+                            info!(
+                                target: LOG_TARGET,
+                                "Completed Transaction (TxId: {} and Kernel Excess Sig: {}) detected in Base Node \
+                                 Mempool in {:?}",
+                                completed_tx.tx_id,
+                                completed_tx.transaction.body.kernels()[0]
+                                    .excess_sig
+                                    .get_signature()
+                                    .to_hex(),
+                                ts
+                            );
+                            return Ok(true);
+                        },
+                    },
+                    _ => (),
+                }
+            },
+        }
+
+        Ok(true)
+    }
+
+    async fn handle_base_node_response(
+        &mut self,
+        tx_id: TxId,
+        response: BaseNodeProto::BaseNodeServiceResponse,
+    ) -> Result<bool, TransactionServiceProtocolError>
+    {
+        let response: Vec<tari_core::transactions::proto::types::TransactionOutput> = match response.response {
+            Some(BaseNodeResponseProto::TransactionOutputs(outputs)) => outputs.outputs,
+            _ => {
+                return Ok(false);
+            },
+        };
+
+        let completed_tx = match self.resources.db.get_completed_transaction(tx_id).await {
+            Ok(tx) => tx,
+            Err(e) => {
+                error!(
+                    target: LOG_TARGET,
+                    "Cannot find Completed Transaction (TxId: {}) referred to by this Chain Monitoring Protocol: {:?}",
+                    self.tx_id,
+                    e
+                );
+                return Err(TransactionServiceProtocolError::new(
+                    self.id,
+                    TransactionServiceError::TransactionDoesNotExistError,
+                ));
+            },
+        };
+
+        if completed_tx.status == TransactionStatus::Broadcast {
+            let mut check = true;
+
+            for output in response.iter() {
+                let transaction_output = TransactionOutput::try_from(output.clone()).map_err(|_| {
+                    TransactionServiceProtocolError::new(
+                        self.id,
+                        TransactionServiceError::ConversionError("Could not convert Transaction Output".to_string()),
+                    )
+                })?;
+
+                check = check &&
+                    completed_tx
+                        .transaction
+                        .body
+                        .outputs()
+                        .iter()
+                        .any(|item| item == &transaction_output);
+            }
+            // If all outputs are present then mark this transaction as mined.
+            if check && !response.is_empty() {
+                self.resources
+                    .output_manager_service
+                    .confirm_transaction(
+                        completed_tx.tx_id,
+                        completed_tx.transaction.body.inputs().clone(),
+                        completed_tx.transaction.body.outputs().clone(),
+                    )
+                    .await
+                    .map_err(|e| TransactionServiceProtocolError::new(self.id, TransactionServiceError::from(e)))?;
+
+                self.resources
+                    .db
+                    .mine_completed_transaction(completed_tx.tx_id)
+                    .await
+                    .map_err(|e| TransactionServiceProtocolError::new(self.id, TransactionServiceError::from(e)))?;
+
+                let _ = self
+                    .resources
+                    .event_publisher
+                    .send(Arc::new(TransactionEvent::TransactionMined(completed_tx.tx_id)))
+                    .map_err(|e| {
+                        trace!(
+                            target: LOG_TARGET,
+                            "Error sending event, usually because there are no subscribers: {:?}",
+                            e
+                        );
+                        e
+                    });
+
+                info!(
+                    target: LOG_TARGET,
+                    "Transaction (TxId: {:?}) detected as mined on the Base Layer", completed_tx.tx_id
+                );
+
+                return Ok(true);
+            }
+        }
+
+        Ok(false)
+    }
+}

--- a/base_layer/wallet/src/transaction_service/protocols/transaction_receive_protocol.rs
+++ b/base_layer/wallet/src/transaction_service/protocols/transaction_receive_protocol.rs
@@ -1,4 +1,4 @@
-// Copyright 2019 The Tari Project
+// Copyright 2020. The Tari Project
 //
 // Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
 // following conditions are met:
@@ -20,23 +20,13 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use crate::{
-    base_node::RequestKey,
-    mempool::{StateResponse, StatsResponse, TxStorageResponse},
-};
-use serde::{Deserialize, Serialize};
-
-/// API Response enum for Mempool responses.
-#[derive(Clone, Debug, Serialize, Deserialize)]
-pub enum MempoolResponse {
-    Stats(StatsResponse),
-    State(StateResponse),
-    TxStorage(TxStorageResponse),
-}
-
-/// Response type for a received MempoolService requests
-#[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct MempoolServiceResponse {
-    pub request_key: RequestKey,
-    pub response: MempoolResponse,
-}
+// pub struct TransactionReceiveProtocol {
+//     id: u64,
+//     db: TransactionDatabase<TBackend>,
+//     output_manager_service: OutputManagerHandle,
+//     outbound_message_service: OutboundMessageRequester,
+//     event_publisher: Publisher<TransactionEvent>,
+//     node_identity: Arc<NodeIdentity>,
+//     factories: CryptoFactories,
+//     transaction_finalized_channel: Receiver<Transaction>,
+// }

--- a/base_layer/wallet/src/transaction_service/protocols/transaction_send_protocol.rs
+++ b/base_layer/wallet/src/transaction_service/protocols/transaction_send_protocol.rs
@@ -1,0 +1,402 @@
+// Copyright 2020. The Tari Project
+//
+// Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+// following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+// disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+// following disclaimer in the documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+// products derived from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+// INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+// WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+// USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+use std::sync::Arc;
+
+use chrono::Utc;
+use futures::{channel::mpsc::Receiver, StreamExt};
+use log::*;
+
+use crate::transaction_service::{
+    error::{TransactionServiceError, TransactionServiceProtocolError},
+    handle::TransactionEvent,
+    service::TransactionServiceResources,
+    storage::database::{CompletedTransaction, OutboundTransaction, TransactionBackend, TransactionStatus},
+};
+use tari_comms::{
+    protocol::messaging::{MessagingEvent, MessagingEventReceiver},
+    types::CommsPublicKey,
+};
+use tari_comms_dht::{domain_message::OutboundDomainMessage, outbound::OutboundEncryption};
+use tari_core::transactions::{
+    tari_amount::MicroTari,
+    transaction::{KernelFeatures, TransactionError},
+    transaction_protocol::{proto, recipient::RecipientSignedMessage},
+    SenderTransactionProtocol,
+};
+use tari_p2p::tari_message::TariMessageType;
+
+const LOG_TARGET: &str = "wallet::transaction_service::protocols::send_protocol";
+
+pub struct TransactionSendProtocol<TBackend>
+where TBackend: TransactionBackend + Clone + 'static
+{
+    id: u64,
+    resources: TransactionServiceResources<TBackend>,
+    transaction_reply_receiver: Option<Receiver<(CommsPublicKey, RecipientSignedMessage)>>,
+    message_send_event_receiver: MessagingEventReceiver,
+    dest_pubkey: CommsPublicKey,
+    amount: MicroTari,
+    message: String,
+    sender_protocol: SenderTransactionProtocol,
+}
+
+impl<TBackend> TransactionSendProtocol<TBackend>
+where TBackend: TransactionBackend + Clone + 'static
+{
+    pub fn new(
+        id: u64,
+        resources: TransactionServiceResources<TBackend>,
+        transaction_reply_receiver: Receiver<(CommsPublicKey, RecipientSignedMessage)>,
+        message_send_event_receiver: MessagingEventReceiver,
+        dest_pubkey: CommsPublicKey,
+        amount: MicroTari,
+        message: String,
+        sender_protocol: SenderTransactionProtocol,
+    ) -> Self
+    {
+        Self {
+            id,
+            resources,
+            transaction_reply_receiver: Some(transaction_reply_receiver),
+            message_send_event_receiver,
+            dest_pubkey,
+            amount,
+            message,
+            sender_protocol,
+        }
+    }
+
+    /// Execute the Transaction Send Protocol as an async task.
+    pub async fn execute(mut self) -> Result<u64, TransactionServiceProtocolError> {
+        if !self.sender_protocol.is_single_round_message_ready() {
+            error!(target: LOG_TARGET, "Sender Transaction Protocol is in an invalid state");
+            return Err(TransactionServiceProtocolError::new(
+                self.id,
+                TransactionServiceError::InvalidStateError,
+            ));
+        }
+
+        let msg = self
+            .sender_protocol
+            .build_single_round_message()
+            .map_err(|e| TransactionServiceProtocolError::new(self.id, TransactionServiceError::from(e)))?;
+        let tx_id = msg.tx_id;
+
+        if tx_id != self.id {
+            return Err(TransactionServiceProtocolError::new(
+                self.id,
+                TransactionServiceError::InvalidStateError,
+            ));
+        }
+
+        let proto_message = proto::TransactionSenderMessage::single(msg.into());
+
+        let message_tag = match self
+            .resources
+            .outbound_message_service
+            .send_direct(
+                self.dest_pubkey.clone(),
+                OutboundEncryption::None,
+                OutboundDomainMessage::new(TariMessageType::SenderPartialTransaction, proto_message),
+            )
+            .await
+        {
+            Ok(result) => match result.resolve_ok().await {
+                None => {
+                    let _ = self.resources.event_publisher.send(Arc::new(
+                        TransactionEvent::TransactionSendDiscoveryComplete(tx_id, false),
+                    ));
+                    error!(target: LOG_TARGET, "Transaction Send message failed to send");
+                    return Err(TransactionServiceProtocolError::new(
+                        self.id,
+                        TransactionServiceError::OutboundSendFailure,
+                    ));
+                },
+                Some(tags) if tags.len() == 1 => {
+                    info!(
+                        target: LOG_TARGET,
+                        "Transaction (TxId: {}) Send Discovery process successful with Message Tag: {:?}",
+                        tx_id,
+                        tags[0],
+                    );
+                    tags[0]
+                },
+                Some(_tags) => {
+                    error!(
+                        target: LOG_TARGET,
+                        "Send Discovery process for TX_ID: {} was unsuccessful and no message was sent", tx_id
+                    );
+                    let _ = self.resources.event_publisher.send(Arc::new(
+                        TransactionEvent::TransactionSendDiscoveryComplete(tx_id, false),
+                    ));
+                    if let Err(e) = self.resources.output_manager_service.cancel_transaction(tx_id).await {
+                        error!(
+                            target: LOG_TARGET,
+                            "Failed to Cancel TX_ID: {} after failed sending attempt with error {:?}", tx_id, e
+                        );
+                    };
+                    error!(target: LOG_TARGET, "Transaction Send message failed to send");
+                    return Err(TransactionServiceProtocolError::new(
+                        self.id,
+                        TransactionServiceError::OutboundSendFailure,
+                    ));
+                },
+            },
+            Err(e) => {
+                error!(target: LOG_TARGET, "Transaction Send failed: {:?}", e);
+                return Err(TransactionServiceProtocolError::new(
+                    self.id,
+                    TransactionServiceError::OutboundSendFailure,
+                ));
+            },
+        };
+
+        info!(
+            target: LOG_TARGET,
+            "Transaction with TX_ID = {} queued to be sent to {}", tx_id, self.dest_pubkey
+        );
+
+        // Wait for the Message Event to tell us this has been sent
+        loop {
+            let (received_tag, success) = match self.message_send_event_receiver.next().await {
+                Some(read_item) => match read_item {
+                    Ok(event) => match &*event {
+                        MessagingEvent::MessageSent(message_tag) => (message_tag.clone(), true),
+                        MessagingEvent::SendMessageFailed(outbound_message, _reason) => (outbound_message.tag, false),
+                        _ => continue,
+                    },
+                    Err(e) => {
+                        error!(
+                            target: LOG_TARGET,
+                            "Error reading from message send event stream: {:?}", e
+                        );
+                        return Err(TransactionServiceProtocolError::new(
+                            self.id,
+                            TransactionServiceError::from(e),
+                        ));
+                    },
+                },
+                None => {
+                    error!(target: LOG_TARGET, "Error reading from message send event stream");
+                    return Err(TransactionServiceProtocolError::new(
+                        self.id,
+                        TransactionServiceError::OutboundSendFailure,
+                    ));
+                },
+            };
+
+            if received_tag != message_tag {
+                continue;
+            }
+
+            if success {
+                self.resources
+                    .output_manager_service
+                    .confirm_pending_transaction(tx_id)
+                    .await
+                    .map_err(|e| TransactionServiceProtocolError::new(self.id, TransactionServiceError::from(e)))?;
+
+                let fee = self
+                    .sender_protocol
+                    .get_fee_amount()
+                    .map_err(|e| TransactionServiceProtocolError::new(self.id, TransactionServiceError::from(e)))?;
+                let outbound_tx = OutboundTransaction {
+                    tx_id,
+                    destination_public_key: self.dest_pubkey.clone(),
+                    amount: self.amount,
+                    fee,
+                    sender_protocol: self.sender_protocol.clone(),
+                    status: TransactionStatus::Pending,
+                    message: self.message.clone(),
+                    timestamp: Utc::now().naive_utc(),
+                };
+
+                self.resources
+                    .db
+                    .add_pending_outbound_transaction(outbound_tx.tx_id, outbound_tx)
+                    .await
+                    .map_err(|e| TransactionServiceProtocolError::new(self.id, TransactionServiceError::from(e)))?;
+
+                info!(
+                    target: LOG_TARGET,
+                    "Pending Outbound Transaction TxId: {:?} was successfully sent with Message Tag: {:?}",
+                    tx_id,
+                    message_tag
+                );
+            } else {
+                error!(
+                    target: LOG_TARGET,
+                    "Pending Outbound Transaction TxId: {:?} with Message Tag {:?} could not be sent",
+                    tx_id,
+                    message_tag,
+                );
+                if let Err(e) = self.resources.output_manager_service.cancel_transaction(tx_id).await {
+                    error!(
+                        target: LOG_TARGET,
+                        "Failed to Cancel TX_ID: {} after failed sending attempt with error {:?}", tx_id, e
+                    );
+                }
+            }
+
+            let _ = self
+                .resources
+                .event_publisher
+                .send(Arc::new(TransactionEvent::TransactionSendResult(tx_id, success)));
+
+            if !success {
+                return Err(TransactionServiceProtocolError::new(
+                    self.id,
+                    TransactionServiceError::OutboundSendFailure,
+                ));
+            }
+
+            break;
+        }
+
+        // Wait for Transaction Reply
+        let mut receiver = self
+            .transaction_reply_receiver
+            .take()
+            .ok_or_else(|| TransactionServiceProtocolError::new(self.id, TransactionServiceError::InvalidStateError))?;
+
+        let mut outbound_tx = self
+            .resources
+            .db
+            .get_pending_outbound_transaction(tx_id)
+            .await
+            .map_err(|e| TransactionServiceProtocolError::new(self.id, TransactionServiceError::from(e)))?;
+
+        if !outbound_tx.sender_protocol.is_collecting_single_signature() {
+            error!(target: LOG_TARGET, "Pending Transaction not in correct state");
+            return Err(TransactionServiceProtocolError::new(
+                self.id,
+                TransactionServiceError::InvalidStateError,
+            ));
+        }
+
+        let mut source_pubkey;
+        let mut recipient_reply;
+        loop {
+            match receiver.next().await {
+                Some((spk, rr)) => {
+                    source_pubkey = spk;
+                    recipient_reply = rr;
+                },
+                None => {
+                    error!(target: LOG_TARGET, "Transaction Reply Channel has closes");
+                    return Err(TransactionServiceProtocolError::new(
+                        self.id,
+                        TransactionServiceError::ProtocolChannelError,
+                    ));
+                },
+            }
+
+            if outbound_tx.destination_public_key != source_pubkey {
+                error!(
+                    target: LOG_TARGET,
+                    "Transaction Reply did not come from the expected Public Key"
+                );
+            } else if !outbound_tx.sender_protocol.check_tx_id(recipient_reply.tx_id.clone()) {
+                error!(target: LOG_TARGET, "Transaction Reply does not have the correct TxId");
+            } else {
+                break;
+            }
+        }
+
+        outbound_tx
+            .sender_protocol
+            .add_single_recipient_info(recipient_reply, &self.resources.factories.range_proof)
+            .map_err(|e| TransactionServiceProtocolError::new(self.id, TransactionServiceError::from(e)))?;
+
+        let finalize_result = outbound_tx
+            .sender_protocol
+            .finalize(KernelFeatures::empty(), &self.resources.factories)
+            .map_err(|e| TransactionServiceProtocolError::new(self.id, TransactionServiceError::from(e)))?;
+
+        if !finalize_result {
+            return Err(TransactionServiceProtocolError::new(
+                self.id,
+                TransactionServiceError::TransactionError(TransactionError::ValidationError(
+                    "Transaction could not be finalized".to_string(),
+                )),
+            ));
+        }
+
+        let tx = outbound_tx
+            .sender_protocol
+            .get_transaction()
+            .map_err(|e| TransactionServiceProtocolError::new(self.id, TransactionServiceError::from(e)))?;
+
+        let completed_transaction = CompletedTransaction {
+            tx_id,
+            source_public_key: self.resources.node_identity.public_key().clone(),
+            destination_public_key: outbound_tx.destination_public_key.clone(),
+            amount: outbound_tx.amount,
+            fee: outbound_tx.fee,
+            transaction: tx.clone(),
+            status: TransactionStatus::Completed,
+            message: outbound_tx.message.clone(),
+            timestamp: Utc::now().naive_utc(),
+        };
+
+        self.resources
+            .db
+            .complete_outbound_transaction(tx_id.clone(), completed_transaction.clone())
+            .await
+            .map_err(|e| TransactionServiceProtocolError::new(self.id, TransactionServiceError::from(e)))?;
+        info!(
+            target: LOG_TARGET,
+            "Transaction Recipient Reply for TX_ID = {} received", tx_id,
+        );
+
+        let finalized_transaction_message = proto::TransactionFinalizedMessage {
+            tx_id,
+            transaction: Some(tx.clone().into()),
+        };
+
+        let _ = self
+            .resources
+            .event_publisher
+            .send(Arc::new(TransactionEvent::ReceivedTransactionReply(tx_id)))
+            .map_err(|e| {
+                trace!(
+                    target: LOG_TARGET,
+                    "Error sending event, usually because there are no subscribers: {:?}",
+                    e
+                );
+                e
+            });
+
+        self.resources
+            .outbound_message_service
+            .send_direct(
+                outbound_tx.destination_public_key.clone(),
+                OutboundEncryption::None,
+                OutboundDomainMessage::new(TariMessageType::TransactionFinalized, finalized_transaction_message),
+            )
+            .await
+            .map_err(|e| TransactionServiceProtocolError::new(self.id, TransactionServiceError::from(e)))?;
+
+        Ok(self.id)
+    }
+}

--- a/base_layer/wallet/src/transaction_service/service.rs
+++ b/base_layer/wallet/src/transaction_service/service.rs
@@ -20,78 +20,17 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use std::{
-    collections::HashMap,
-    convert::{TryFrom, TryInto},
-    sync::Arc,
-    time::Duration,
-};
-
-use chrono::Utc;
-use futures::{
-    channel::oneshot,
-    future::{BoxFuture, FutureExt},
-    pin_mut,
-    stream::FuturesUnordered,
-    SinkExt,
-    Stream,
-    StreamExt,
-};
-use log::*;
-use rand::{rngs::OsRng, RngCore};
-use tari_broadcast_channel::Publisher;
-use tari_crypto::{
-    commitment::HomomorphicCommitmentFactory,
-    keys::SecretKey,
-    tari_utilities::{hash::Hashable, hex::Hex},
-};
-
-use tari_comms::{
-    message::MessageTag,
-    peer_manager::NodeIdentity,
-    protocol::messaging::{MessagingEvent, MessagingEventReceiver},
-    types::CommsPublicKey,
-};
-use tari_comms_dht::{
-    domain_message::OutboundDomainMessage,
-    outbound::{OutboundEncryption, OutboundMessageRequester, SendMessageResponse},
-};
-#[cfg(feature = "test_harness")]
-use tari_core::transactions::{tari_amount::uT, types::BlindingFactor};
-use tari_core::{
-    base_node::proto::{
-        base_node as BaseNodeProto,
-        base_node::{
-            base_node_service_request::Request as BaseNodeRequestProto,
-            base_node_service_response::Response as BaseNodeResponseProto,
-        },
-    },
-    mempool::{
-        proto::mempool as MempoolProto,
-        service::{MempoolResponse, MempoolServiceResponse},
-        TxStorageResponse,
-    },
-    transactions::{
-        tari_amount::MicroTari,
-        transaction::{KernelFeatures, OutputFeatures, OutputFlags, Transaction, TransactionOutput},
-        transaction_protocol::{
-            proto,
-            recipient::{RecipientSignedMessage, RecipientState},
-            sender::TransactionSenderMessage,
-        },
-        types::{CryptoFactories, PrivateKey},
-        ReceiverTransactionProtocol,
-    },
-};
-use tari_p2p::{domain_message::DomainMessage, tari_message::TariMessageType};
-use tari_service_framework::{reply_channel, reply_channel::Receiver};
-
 use crate::{
     output_manager_service::{handle::OutputManagerHandle, TxId},
     transaction_service::{
         config::TransactionServiceConfig,
-        error::TransactionServiceError,
-        handle::{TransactionEvent, TransactionServiceRequest, TransactionServiceResponse},
+        error::{TransactionServiceError, TransactionServiceProtocolError},
+        handle::{TransactionEvent, TransactionEventSender, TransactionServiceRequest, TransactionServiceResponse},
+        protocols::{
+            transaction_broadcast_protocol::TransactionBroadcastProtocol,
+            transaction_chain_monitoring_protocol::TransactionChainMonitoringProtocol,
+            transaction_send_protocol::TransactionSendProtocol,
+        },
         storage::database::{
             CompletedTransaction,
             InboundTransaction,
@@ -102,8 +41,49 @@ use crate::{
             TransactionStatus,
         },
     },
-    util::futures::StateDelay,
 };
+use chrono::Utc;
+use futures::{
+    channel::{mpsc, mpsc::Sender},
+    pin_mut,
+    stream::FuturesUnordered,
+    SinkExt,
+    Stream,
+    StreamExt,
+};
+use log::*;
+use rand::{rngs::OsRng, RngCore};
+use std::{
+    collections::HashMap,
+    convert::{TryFrom, TryInto},
+    sync::Arc,
+};
+use tari_comms::{peer_manager::NodeIdentity, protocol::messaging::MessagingEventSender, types::CommsPublicKey};
+use tari_comms_dht::{
+    domain_message::OutboundDomainMessage,
+    outbound::{OutboundEncryption, OutboundMessageRequester},
+};
+#[cfg(feature = "test_harness")]
+use tari_core::transactions::{tari_amount::uT, types::BlindingFactor};
+use tari_core::{
+    base_node::proto::base_node as BaseNodeProto,
+    mempool::{proto::mempool as MempoolProto, service::MempoolServiceResponse},
+    transactions::{
+        tari_amount::MicroTari,
+        transaction::{KernelFeatures, OutputFeatures, OutputFlags, Transaction},
+        transaction_protocol::{
+            proto,
+            recipient::{RecipientSignedMessage, RecipientState},
+            sender::TransactionSenderMessage,
+        },
+        types::{CryptoFactories, PrivateKey},
+        ReceiverTransactionProtocol,
+    },
+};
+use tari_crypto::{commitment::HomomorphicCommitmentFactory, keys::SecretKey};
+use tari_p2p::{domain_message::DomainMessage, tari_message::TariMessageType};
+use tari_service_framework::{reply_channel, reply_channel::Receiver};
+use tokio::task::JoinHandle;
 
 const LOG_TARGET: &str = "wallet::transaction_service::service";
 
@@ -136,7 +116,7 @@ where TBackend: TransactionBackend + Clone + 'static
     config: TransactionServiceConfig,
     db: TransactionDatabase<TBackend>,
     outbound_message_service: OutboundMessageRequester,
-    message_event_receiver: Option<MessagingEventReceiver>,
+    message_event_sender: MessagingEventSender,
     output_manager_service: OutputManagerHandle,
     transaction_stream: Option<TTxStream>,
     transaction_reply_stream: Option<TTxReplyStream>,
@@ -146,12 +126,14 @@ where TBackend: TransactionBackend + Clone + 'static
     request_stream: Option<
         reply_channel::Receiver<TransactionServiceRequest, Result<TransactionServiceResponse, TransactionServiceError>>,
     >,
-    event_publisher: Publisher<TransactionEvent>,
+    event_publisher: TransactionEventSender,
     node_identity: Arc<NodeIdentity>,
     factories: CryptoFactories,
     base_node_public_key: Option<CommsPublicKey>,
-    pending_outbound_message_results: HashMap<MessageTag, OutboundTransaction>,
-    pending_transaction_mined_queries: HashMap<TxId, TransactionMinedRequestResult>,
+    service_resources: TransactionServiceResources<TBackend>,
+    pending_transaction_reply_senders: HashMap<TxId, Sender<(CommsPublicKey, RecipientSignedMessage)>>,
+    mempool_response_senders: HashMap<u64, Sender<MempoolServiceResponse>>,
+    base_node_response_senders: HashMap<u64, Sender<BaseNodeProto::BaseNodeServiceResponse>>,
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -179,17 +161,27 @@ where
         base_node_response_stream: BNResponseStream,
         output_manager_service: OutputManagerHandle,
         outbound_message_service: OutboundMessageRequester,
-        message_event_receiver: MessagingEventReceiver,
-        event_publisher: Publisher<TransactionEvent>,
+        message_event_sender: MessagingEventSender,
+        event_publisher: TransactionEventSender,
         node_identity: Arc<NodeIdentity>,
         factories: CryptoFactories,
     ) -> Self
     {
+        // Collect the resources that all protocols will need so that they can be neatly cloned as the protocols are
+        // spawned.
+        let service_resources = TransactionServiceResources {
+            db: db.clone(),
+            output_manager_service: output_manager_service.clone(),
+            outbound_message_service: outbound_message_service.clone(),
+            event_publisher: event_publisher.clone(),
+            node_identity: node_identity.clone(),
+            factories: factories.clone(),
+        };
         TransactionService {
             config,
             db,
             outbound_message_service,
-            message_event_receiver: Some(message_event_receiver),
+            message_event_sender,
             output_manager_service,
             transaction_stream: Some(transaction_stream),
             transaction_reply_stream: Some(transaction_reply_stream),
@@ -201,8 +193,10 @@ where
             node_identity,
             factories,
             base_node_public_key: None,
-            pending_outbound_message_results: HashMap::new(),
-            pending_transaction_mined_queries: HashMap::new(),
+            service_resources,
+            pending_transaction_reply_senders: HashMap::new(),
+            mempool_response_senders: HashMap::new(),
+            base_node_response_senders: HashMap::new(),
         }
     }
 
@@ -244,19 +238,18 @@ where
             .expect("Transaction Service initialized without base_node_response_stream")
             .fuse();
         pin_mut!(base_node_response_stream);
-        let message_event_receiver = self
-            .message_event_receiver
-            .take()
-            .expect("Transaction Service initialized without message_event_subscription")
-            .fuse();
-        pin_mut!(message_event_receiver);
 
-        let mut discovery_process_futures: FuturesUnordered<
-            BoxFuture<'static, Result<(MessageTag, OutboundTransaction), TransactionServiceError>>,
+        let mut send_transaction_protocol_handles: FuturesUnordered<
+            JoinHandle<Result<u64, TransactionServiceProtocolError>>,
         > = FuturesUnordered::new();
 
-        let mut broadcast_timeout_futures: FuturesUnordered<BoxFuture<'static, TxId>> = FuturesUnordered::new();
-        let mut mined_request_timeout_futures: FuturesUnordered<BoxFuture<'static, TxId>> = FuturesUnordered::new();
+        let mut transaction_broadcast_protocol_handles: FuturesUnordered<
+            JoinHandle<Result<u64, TransactionServiceProtocolError>>,
+        > = FuturesUnordered::new();
+
+        let mut transaction_chain_monitoring_protocol_handles: FuturesUnordered<
+            JoinHandle<Result<u64, TransactionServiceProtocolError>>,
+        > = FuturesUnordered::new();
 
         loop {
             futures::select! {
@@ -264,7 +257,7 @@ where
                 request_context = request_stream.select_next_some() => {
                     trace!(target: LOG_TARGET, "Handling Service API Request");
                     let (request, reply_tx) = request_context.split();
-                    let _ = reply_tx.send(self.handle_request(request, &mut discovery_process_futures, &mut  broadcast_timeout_futures, &mut  mined_request_timeout_futures).await.or_else(|resp| {
+                    let _ = reply_tx.send(self.handle_request(request, &mut send_transaction_protocol_handles,  &mut transaction_broadcast_protocol_handles, &mut transaction_chain_monitoring_protocol_handles).await.or_else(|resp| {
                         error!(target: LOG_TARGET, "Error handling request: {:?}", resp);
                         Err(resp)
                     })).or_else(|resp| {
@@ -282,52 +275,40 @@ where
                     });
 
                     if result.is_err() {
-                        let _ = self.event_publisher
-                                .send(TransactionEvent::Error(
-                                    "Error handling Transaction Sender message".to_string(),
-                                ))
-                                .await;
+                        let _ = self.event_publisher.send(Arc::new(TransactionEvent::Error("Error handling Transaction Sender message".to_string(),)));
                     }
                 },
                  // Incoming messages from the Comms layer
                 msg = transaction_reply_stream.select_next_some() => {
                     trace!(target: LOG_TARGET, "Handling Transaction Reply Message");
                     let (origin_public_key, inner_msg) = msg.into_origin_and_inner();
-                    let result = self.accept_recipient_reply(origin_public_key, inner_msg, &mut broadcast_timeout_futures).await.or_else(|err| {
+                    let result = self.accept_recipient_reply(origin_public_key, inner_msg).await.or_else(|err| {
                         error!(target: LOG_TARGET, "Failed to handle incoming Transaction Reply message: {:?} for NodeId: {}", err, self.node_identity.node_id().short_str());
                         Err(err)
                     });
 
                     if result.is_err() {
-                        let _ = self.event_publisher
-                                .send(TransactionEvent::Error(
-                                    "Error handling Transaction Recipient Reply message".to_string(),
-                                ))
-                                .await;
+                        let _ = self.event_publisher.send(Arc::new(TransactionEvent::Error("Error handling Transaction Recipient Reply message".to_string(),)));
                     }
                 },
                // Incoming messages from the Comms layer
                 msg = transaction_finalized_stream.select_next_some() => {
                     trace!(target: LOG_TARGET, "Handling Transaction Finalized Message");
                     let (origin_public_key, inner_msg) = msg.into_origin_and_inner();
-                    let result = self.accept_finalized_transaction(origin_public_key, inner_msg, &mut broadcast_timeout_futures).await.or_else(|err| {
+                    let result = self.accept_finalized_transaction(origin_public_key, inner_msg, &mut transaction_broadcast_protocol_handles).await.or_else(|err| {
                         error!(target: LOG_TARGET, "Failed to handle incoming Transaction Finalized message: {:?} for NodeID: {}", err , self.node_identity.node_id().short_str());
                         Err(err)
                     });
 
                     if result.is_err() {
-                        let _ = self.event_publisher
-                                .send(TransactionEvent::Error(
-                                    "Error handling Transaction Finalized message".to_string(),
-                                ))
-                                .await;
+                        let _ = self.event_publisher.send(Arc::new(TransactionEvent::Error("Error handling Transaction Finalized message".to_string(),)));
                     }
                 },
                 // Incoming messages from the Comms layer
                 msg = mempool_response_stream.select_next_some() => {
                     trace!(target: LOG_TARGET, "Handling Mempool Response");
                     let (origin_public_key, inner_msg) = msg.into_origin_and_inner();
-                    let _ = self.handle_mempool_response(inner_msg, &mut mined_request_timeout_futures).await.or_else(|resp| {
+                    let _ = self.handle_mempool_response(inner_msg).await.or_else(|resp| {
                         error!(target: LOG_TARGET, "Error handling mempool service response: {:?}", resp);
                         Err(resp)
                     });
@@ -341,57 +322,26 @@ where
                         Err(resp)
                     });
                 }
-                response = discovery_process_futures.select_next_some() => {
-                    trace!(target: LOG_TARGET, "Handling Discovery Process Completion");
-                    match response {
-                        Ok((message_tag, outbound_tx)) => {
-                            info!(
-                                target: LOG_TARGET,
-                                "Discovery process completed for TxId: {} with Message Tag: {} now waiting for MessageSent event",
-                                outbound_tx.tx_id,
-                                message_tag,
-                            );
-                            self.db
-                                .add_pending_outbound_transaction(outbound_tx.tx_id, outbound_tx.clone())
-                                .await?;
-                            self.pending_outbound_message_results.insert(message_tag.clone(), outbound_tx);
-                        },
-                        Err(TransactionServiceError::DiscoveryProcessFailed(tx_id)) => {
-                            if let Err(e) = self.output_manager_service.cancel_transaction(tx_id).await {
-                                error!(target: LOG_TARGET, "Failed to Cancel TX_ID: {} after failed sending attempt", tx_id);
-                            }
-                            error!(target: LOG_TARGET, "Discovery and Send failed for TX_ID: {}", tx_id);
-                            let _ = self.event_publisher
-                                .send(TransactionEvent::TransactionSendDiscoveryComplete(tx_id, false))
-                                .await;
-                        }
-                        Err(e) => error!(target: LOG_TARGET, "Discovery and Send failed with Error: {:?}", e),
-                    }
-                },
-                message_event = message_event_receiver.select_next_some() => {
-                   match message_event {
-                   Ok(event) => {
-                       let _ = self.handle_message_event((*event).clone()).await.or_else(|resp| {
-                            error!(target: LOG_TARGET, "Error handling outbound message event: {:?}", resp);
-                            Err(resp)
-                        });
-                    },
-                    Err(e) => error!(target: LOG_TARGET, "Error handling Outbound Message Event: {:?}", e),
-                   }
+                join_result = send_transaction_protocol_handles.select_next_some() => {
+                    trace!(target: LOG_TARGET, "Send Protocol for Transaction has ended with result {:?}", join_result);
+                    match join_result {
+                        Ok(join_result_inner) => self.complete_send_transaction_protocol(join_result_inner, &mut transaction_broadcast_protocol_handles).await,
+                        Err(e) => error!(target: LOG_TARGET, "Error resolving Join Handle: {:?}", e),
+                    };
                 }
-                tx_id = broadcast_timeout_futures.select_next_some() => {
-                    trace!(target: LOG_TARGET, "Handling Broadcast Timeout");
-                    let _ = self.handle_mempool_broadcast_timeout(tx_id, &mut  broadcast_timeout_futures).await.or_else(|resp| {
-                        error!(target: LOG_TARGET, "Error handling mempool broadcast timeout : {:?}", resp);
-                        Err(resp)
-                    });
+                join_result = transaction_broadcast_protocol_handles.select_next_some() => {
+                    trace!(target: LOG_TARGET, "Transaction Broadcast protocol has ended with result {:?}", join_result);
+                    match join_result {
+                        Ok(join_result_inner) => self.complete_transaction_broadcast_protocol(join_result_inner, &mut transaction_chain_monitoring_protocol_handles).await,
+                        Err(e) => error!(target: LOG_TARGET, "Error resolving Join Handle: {:?}", e),
+                    };
                 }
-                tx_id = mined_request_timeout_futures.select_next_some() => {
-                    trace!(target: LOG_TARGET, "Handling Mined Request Timeout");
-                    let _ = self.handle_transaction_mined_request_timeout(tx_id, &mut  mined_request_timeout_futures).await.or_else(|resp| {
-                        error!(target: LOG_TARGET, "Error handling transaction mined? request timeout : {:?}", resp);
-                        Err(resp)
-                    });
+                join_result = transaction_chain_monitoring_protocol_handles.select_next_some() => {
+                    trace!(target: LOG_TARGET, "Transaction chain monitoring protocol has ended with result {:?}", join_result);
+                    match join_result {
+                        Ok(join_result_inner) => self.complete_transaction_chain_monitoring_protocol(join_result_inner),
+                        Err(e) => error!(target: LOG_TARGET, "Error resolving Join Handle: {:?}", e),
+                    };
                 }
                 complete => {
                     info!(target: LOG_TARGET, "Transaction service shutting down");
@@ -406,19 +356,25 @@ where
     async fn handle_request(
         &mut self,
         request: TransactionServiceRequest,
-        discovery_process_futures: &mut FuturesUnordered<
-            BoxFuture<'static, Result<(MessageTag, OutboundTransaction), TransactionServiceError>>,
+        send_transaction_join_handles: &mut FuturesUnordered<JoinHandle<Result<u64, TransactionServiceProtocolError>>>,
+        transaction_broadcast_join_handles: &mut FuturesUnordered<
+            JoinHandle<Result<u64, TransactionServiceProtocolError>>,
         >,
-        broadcast_timeout_futures: &mut FuturesUnordered<BoxFuture<'static, TxId>>,
-        mined_request_timeout_futures: &mut FuturesUnordered<BoxFuture<'static, TxId>>,
+        chain_monitoring_join_handles: &mut FuturesUnordered<JoinHandle<Result<u64, TransactionServiceProtocolError>>>,
     ) -> Result<TransactionServiceResponse, TransactionServiceError>
     {
         trace!(target: LOG_TARGET, "Handling Service Request: {}", request);
         match request {
             TransactionServiceRequest::SendTransaction((dest_pubkey, amount, fee_per_gram, message)) => self
-                .send_transaction(dest_pubkey, amount, fee_per_gram, message, discovery_process_futures)
+                .send_transaction(
+                    dest_pubkey,
+                    amount,
+                    fee_per_gram,
+                    message,
+                    send_transaction_join_handles,
+                )
                 .await
-                .map(|_| TransactionServiceResponse::TransactionSent),
+                .map(TransactionServiceResponse::TransactionSent),
             TransactionServiceRequest::GetPendingInboundTransactions => Ok(
                 TransactionServiceResponse::PendingInboundTransactions(self.get_pending_inbound_transactions().await?),
             ),
@@ -443,7 +399,11 @@ where
                 Ok(TransactionServiceResponse::CoinbaseTransactionCancelled)
             },
             TransactionServiceRequest::SetBaseNodePublicKey(public_key) => self
-                .set_base_node_public_key(public_key, broadcast_timeout_futures, mined_request_timeout_futures)
+                .set_base_node_public_key(
+                    public_key,
+                    transaction_broadcast_join_handles,
+                    chain_monitoring_join_handles,
+                )
                 .await
                 .map(|_| TransactionServiceResponse::BaseNodePublicKeySet),
             TransactionServiceRequest::ImportUtxo(value, source_public_key, message) => self
@@ -479,62 +439,6 @@ where
         }
     }
 
-    async fn handle_message_event(&mut self, message_event: MessagingEvent) -> Result<(), TransactionServiceError> {
-        let (message_tag, result) = match message_event {
-            MessagingEvent::MessageSent(message_tag) => (message_tag, true),
-            MessagingEvent::SendMessageFailed(outbound_message, _reason) => (outbound_message.tag, false),
-            _ => return Ok(()),
-        };
-        match self.pending_outbound_message_results.remove(&message_tag) {
-            None => (),
-            Some(outbound_tx) => {
-                // If the message was successfully sent then add it to the pending transaction list
-                if result {
-                    self.output_manager_service
-                        .confirm_pending_transaction(outbound_tx.tx_id)
-                        .await?;
-                    info!(
-                        target: LOG_TARGET,
-                        "Pending Outbound Transaction TxId: {:?} was successfully sent with Message Tag: {:?}",
-                        outbound_tx.tx_id,
-                        message_tag
-                    );
-                } else {
-                    error!(
-                        target: LOG_TARGET,
-                        "Pending Outbound Transaction TxId: {:?} with Message Tag {:?} could not be sent",
-                        outbound_tx.tx_id,
-                        message_tag,
-                    );
-                    if let Err(e) = self.db.remove_pending_outbound_transaction(outbound_tx.tx_id).await {
-                        error!(
-                            target: LOG_TARGET,
-                            "Failed to remove pending transaction TX_ID: {} after failed sending attempt with error \
-                             {:?}",
-                            outbound_tx.tx_id,
-                            e
-                        );
-                    }
-                    if let Err(e) = self.output_manager_service.cancel_transaction(outbound_tx.tx_id).await {
-                        error!(
-                            target: LOG_TARGET,
-                            "Failed to Cancel TX_ID: {} after failed sending attempt with error {:?}",
-                            outbound_tx.tx_id,
-                            e
-                        );
-                    }
-                }
-
-                let _ = self
-                    .event_publisher
-                    .send(TransactionEvent::TransactionSendResult(outbound_tx.tx_id, result))
-                    .await;
-            },
-        }
-
-        Ok(())
-    }
-
     /// Sends a new transaction to a recipient
     /// # Arguments
     /// 'dest_pubkey': The Comms pubkey of the recipient node
@@ -546,107 +450,33 @@ where
         amount: MicroTari,
         fee_per_gram: MicroTari,
         message: String,
-        discovery_process_futures: &mut FuturesUnordered<
-            BoxFuture<'static, Result<(MessageTag, OutboundTransaction), TransactionServiceError>>,
-        >,
-    ) -> Result<(), TransactionServiceError>
+        join_handles: &mut FuturesUnordered<JoinHandle<Result<u64, TransactionServiceProtocolError>>>,
+    ) -> Result<TxId, TransactionServiceError>
     {
-        let mut sender_protocol = self
+        let sender_protocol = self
             .output_manager_service
             .prepare_transaction_to_send(amount, fee_per_gram, None, message.clone())
             .await?;
 
-        if !sender_protocol.is_single_round_message_ready() {
-            return Err(TransactionServiceError::InvalidStateError);
-        }
+        let tx_id = sender_protocol.get_tx_id()?;
 
-        let msg = sender_protocol.build_single_round_message()?;
-        let tx_id = msg.tx_id;
-        let proto_message = proto::TransactionSenderMessage::single(msg.into());
-
-        match self
-            .outbound_message_service
-            .send_direct(
-                dest_pubkey.clone(),
-                OutboundEncryption::None,
-                OutboundDomainMessage::new(TariMessageType::SenderPartialTransaction, proto_message),
-            )
-            .await?
-        {
-            SendMessageResponse::Queued(tags) => match tags.len() {
-                0 => error!(
-                    target: LOG_TARGET,
-                    "Queuing Transaction TX_ID: {} for send was unsuccessful and no message was sent", tx_id
-                ),
-                1 => {
-                    info!(
-                        target: LOG_TARGET,
-                        "Transaction (TxId: {}) Send successfully queued for send with Message Tag: {:?}",
-                        tx_id,
-                        tags[0],
-                    );
-
-                    let outbound_tx = OutboundTransaction {
-                        tx_id,
-                        destination_public_key: dest_pubkey.clone(),
-                        amount,
-                        fee: sender_protocol.get_fee_amount()?,
-                        sender_protocol,
-                        status: TransactionStatus::Pending,
-                        message,
-                        timestamp: Utc::now().naive_utc(),
-                    };
-                    self.db
-                        .add_pending_outbound_transaction(outbound_tx.tx_id, outbound_tx.clone())
-                        .await?;
-                    self.pending_outbound_message_results
-                        .insert(tags[0].clone(), outbound_tx);
-                },
-                _ => error!(
-                    target: LOG_TARGET,
-                    "Send process for TX_ID: {} was unsuccessful due to more than 1 MessageTag being returned", tx_id
-                ),
-            },
-            SendMessageResponse::Failed => return Err(TransactionServiceError::OutboundSendFailure),
-            SendMessageResponse::PendingDiscovery(r) => {
-                // The sending of the message resulted in a long running Discovery process being performed by the Comms
-                // layer. This can take minutes so we will spawn a task to wait for the result and then act
-                // appropriately on it
-                let tx_id_clone = tx_id;
-                let outbound_tx_clone = OutboundTransaction {
-                    tx_id,
-                    destination_public_key: dest_pubkey.clone(),
-                    amount,
-                    fee: sender_protocol.get_fee_amount()?,
-                    sender_protocol: sender_protocol.clone(),
-                    status: TransactionStatus::Pending,
-                    message: message.clone(),
-                    timestamp: Utc::now().naive_utc(),
-                };
-
-                info!(
-                    target: LOG_TARGET,
-                    "Send Transaction request for TxID: {:?} to recipient with public_key {} requires that a \
-                     Discovery Process be conducted",
-                    tx_id,
-                    dest_pubkey
-                );
-
-                let discovery_future = async move {
-                    transaction_send_discovery_process_completion(r, tx_id_clone, outbound_tx_clone).await
-                };
-                discovery_process_futures.push(discovery_future.boxed());
-
-                return Err(TransactionServiceError::OutboundSendDiscoveryInProgress(tx_id));
-            },
-        }
-
-        info!(
-            target: LOG_TARGET,
-            "Transaction with TX_ID = {} queued to be sent to {}", tx_id, dest_pubkey
+        let (tx_reply_sender, tx_reply_receiver) = mpsc::channel(100);
+        self.pending_transaction_reply_senders.insert(tx_id, tx_reply_sender);
+        let protocol = TransactionSendProtocol::new(
+            tx_id,
+            self.service_resources.clone(),
+            tx_reply_receiver,
+            self.message_event_sender.subscribe(),
+            dest_pubkey,
+            amount,
+            message,
+            sender_protocol,
         );
 
-        Ok(())
+        let join_handle = tokio::spawn(protocol.execute());
+        join_handles.push(join_handle);
+
+        Ok(tx_id)
     }
 
     /// Accept the public reply from a recipient and apply the reply to the relevant transaction protocol
@@ -656,84 +486,66 @@ where
         &mut self,
         source_pubkey: CommsPublicKey,
         recipient_reply: proto::RecipientSignedMessage,
-        broadcast_timeout_futures: &mut FuturesUnordered<BoxFuture<'static, TxId>>,
     ) -> Result<(), TransactionServiceError>
     {
         let recipient_reply: RecipientSignedMessage = recipient_reply
             .try_into()
             .map_err(TransactionServiceError::InvalidMessageError)?;
 
-        let mut outbound_tx = self.db.get_pending_outbound_transaction(recipient_reply.tx_id).await?;
-
         let tx_id = recipient_reply.tx_id;
-        if !outbound_tx.sender_protocol.check_tx_id(tx_id.clone()) ||
-            !outbound_tx.sender_protocol.is_collecting_single_signature()
-        {
-            return Err(TransactionServiceError::InvalidStateError);
-        }
 
-        outbound_tx
-            .sender_protocol
-            .add_single_recipient_info(recipient_reply, &self.factories.range_proof)?;
-        outbound_tx
-            .sender_protocol
-            .finalize(KernelFeatures::empty(), &self.factories)?;
-        let tx = outbound_tx.sender_protocol.get_transaction()?;
-
-        let completed_transaction = CompletedTransaction {
-            tx_id,
-            source_public_key: self.node_identity.public_key().clone(),
-            destination_public_key: outbound_tx.destination_public_key,
-            amount: outbound_tx.amount,
-            fee: outbound_tx.fee,
-            transaction: tx.clone(),
-            status: TransactionStatus::Completed,
-            message: outbound_tx.message.clone(),
-            timestamp: Utc::now().naive_utc(),
-        };
-        self.db
-            .complete_outbound_transaction(tx_id.clone(), completed_transaction.clone())
-            .await?;
-        info!(
-            target: LOG_TARGET,
-            "Transaction Recipient Reply for TX_ID = {} received", tx_id,
-        );
-
-        let finalized_transaction_message = proto::TransactionFinalizedMessage {
-            tx_id,
-            transaction: Some(tx.clone().into()),
+        let sender = match self.pending_transaction_reply_senders.get_mut(&tx_id) {
+            None => return Err(TransactionServiceError::TransactionDoesNotExistError),
+            Some(s) => s,
         };
 
-        self.outbound_message_service
-            .send_direct(
-                source_pubkey.clone(),
-                OutboundEncryption::None,
-                OutboundDomainMessage::new(TariMessageType::TransactionFinalized, finalized_transaction_message),
-            )
-            .await?;
-
-        // Logging this error here instead of propogating it up to the select! catchall which generates the Error Event.
-        let _ = self
-            .broadcast_completed_transaction_to_mempool(
-                tx_id,
-                self.config.initial_mempool_broadcast_timeout,
-                broadcast_timeout_futures,
-            )
+        sender
+            .send((source_pubkey, recipient_reply))
             .await
-            .map_err(|e| {
-                error!(
-                    target: LOG_TARGET,
-                    "Error broadcasting completed transaction to mempool: {:?}", e
-                );
-                e
-            });
-
-        self.event_publisher
-            .send(TransactionEvent::ReceivedTransactionReply(tx_id))
-            .await
-            .map_err(|_| TransactionServiceError::EventStreamError)?;
+            .map_err(|_| TransactionServiceError::ProtocolChannelError)?;
 
         Ok(())
+    }
+
+    /// Handle the final clean up after a Send Transaction protocol completes
+    async fn complete_send_transaction_protocol(
+        &mut self,
+        join_result: Result<u64, TransactionServiceProtocolError>,
+        transaction_broadcast_join_handles: &mut FuturesUnordered<
+            JoinHandle<Result<u64, TransactionServiceProtocolError>>,
+        >,
+    )
+    {
+        match join_result {
+            Ok(id) => {
+                let _ = self.pending_transaction_reply_senders.remove(&id);
+                let _ = self
+                    .broadcast_completed_transaction_to_mempool(id, transaction_broadcast_join_handles)
+                    .await
+                    .or_else(|resp| {
+                        error!(
+                            target: LOG_TARGET,
+                            "Error starting Broadcast Protocol after completed Send Transaction Protocol : {:?}", resp
+                        );
+                        Err(resp)
+                    });
+                trace!(
+                    target: LOG_TARGET,
+                    "Send Transaction Protocol for TxId: {} completed successfully",
+                    id
+                );
+            },
+            Err(TransactionServiceProtocolError { id, error }) => {
+                let _ = self.pending_transaction_reply_senders.remove(&id);
+                error!(
+                    target: LOG_TARGET,
+                    "Error completing Send Transaction Protocol (Id: {}): {:?}", id, error
+                );
+                let _ = self
+                    .event_publisher
+                    .send(Arc::new(TransactionEvent::Error(format!("{:?}", error).to_string())));
+            },
+        }
     }
 
     /// Accept a new transaction from a sender by handling a public SenderMessage. The reply is generated and sent.
@@ -808,10 +620,17 @@ where
                 "Transaction (TX_ID: {}) - Amount: {} - Message: {}", tx_id, amount, data.message
             );
 
-            self.event_publisher
-                .send(TransactionEvent::ReceivedTransaction(tx_id))
-                .await
-                .map_err(|_| TransactionServiceError::EventStreamError)?;
+            let _ = self
+                .event_publisher
+                .send(Arc::new(TransactionEvent::ReceivedTransaction(tx_id)))
+                .map_err(|e| {
+                    trace!(
+                        target: LOG_TARGET,
+                        "Error sending event, usually because there are no subscribers: {:?}",
+                        e
+                    );
+                    e
+                });
         }
         Ok(())
     }
@@ -824,7 +643,9 @@ where
         &mut self,
         source_pubkey: CommsPublicKey,
         finalized_transaction: proto::TransactionFinalizedMessage,
-        broadcast_timeout_futures: &mut FuturesUnordered<BoxFuture<'static, TxId>>,
+        transaction_broadcast_join_handles: &mut FuturesUnordered<
+            JoinHandle<Result<u64, TransactionServiceProtocolError>>,
+        >,
     ) -> Result<(), TransactionServiceError>
     {
         let tx_id = finalized_transaction.tx_id;
@@ -899,11 +720,6 @@ where
             .complete_inbound_transaction(tx_id.clone(), completed_transaction.clone())
             .await?;
 
-        self.event_publisher
-            .send(TransactionEvent::ReceivedFinalizedTransaction(tx_id))
-            .await
-            .map_err(|_| TransactionServiceError::EventStreamError)?;
-
         info!(
             target: LOG_TARGET,
             "Inbound Transaction with TX_ID = {} from {} moved to Completed Transactions",
@@ -913,16 +729,24 @@ where
 
         // Logging this error here instead of propogating it up to the select! catchall which generates the Error Event.
         let _ = self
-            .broadcast_completed_transaction_to_mempool(
-                tx_id,
-                self.config.initial_mempool_broadcast_timeout,
-                broadcast_timeout_futures,
-            )
+            .broadcast_completed_transaction_to_mempool(tx_id, transaction_broadcast_join_handles)
             .await
             .map_err(|e| {
                 error!(
                     target: LOG_TARGET,
                     "Error broadcasting completed transaction to mempool: {:?}", e
+                );
+                e
+            });
+
+        let _ = self
+            .event_publisher
+            .send(Arc::new(TransactionEvent::ReceivedFinalizedTransaction(tx_id)))
+            .map_err(|e| {
+                trace!(
+                    target: LOG_TARGET,
+                    "Error sending event, usually because there are no subscribers: {:?}",
+                    e
                 );
                 e
             });
@@ -1061,8 +885,8 @@ where
     async fn set_base_node_public_key(
         &mut self,
         base_node_public_key: CommsPublicKey,
-        broadcast_timeout_futures: &mut FuturesUnordered<BoxFuture<'static, TxId>>,
-        mined_request_timeout_futures: &mut FuturesUnordered<BoxFuture<'static, TxId>>,
+        broadcast_join_handles: &mut FuturesUnordered<JoinHandle<Result<u64, TransactionServiceProtocolError>>>,
+        chain_monitoring_join_handles: &mut FuturesUnordered<JoinHandle<Result<u64, TransactionServiceProtocolError>>>,
     ) -> Result<(), TransactionServiceError>
     {
         let startup_broadcast = self.base_node_public_key.is_none();
@@ -1071,7 +895,7 @@ where
 
         if startup_broadcast {
             let _ = self
-                .broadcast_all_completed_transactions_to_mempool(broadcast_timeout_futures)
+                .broadcast_all_completed_transactions_to_mempool(broadcast_join_handles)
                 .await
                 .or_else(|resp| {
                     error!(
@@ -1082,7 +906,7 @@ where
                 });
 
             let _ = self
-                .monitor_all_completed_transactions_for_mining(mined_request_timeout_futures)
+                .start_chain_monitoring_for_all_broadcast_transactions(chain_monitoring_join_handles)
                 .await
                 .or_else(|resp| {
                     error!(
@@ -1101,8 +925,7 @@ where
     pub async fn broadcast_completed_transaction_to_mempool(
         &mut self,
         tx_id: TxId,
-        timeout: Duration,
-        broadcast_timeout_futures: &mut FuturesUnordered<BoxFuture<'static, TxId>>,
+        join_handles: &mut FuturesUnordered<JoinHandle<Result<u64, TransactionServiceProtocolError>>>,
     ) -> Result<(), TransactionServiceError>
     {
         let completed_tx = self.db.get_completed_transaction(tx_id.clone()).await?;
@@ -1113,35 +936,20 @@ where
         match self.base_node_public_key.clone() {
             None => return Err(TransactionServiceError::NoBaseNodeKeysProvided),
             Some(pk) => {
-                info!(
-                    target: LOG_TARGET,
-                    "Attempting to Broadcast Transaction (TxId: {} and Kernel Signature: {}) to Mempool",
-                    completed_tx.tx_id,
-                    completed_tx.transaction.body.kernels()[0]
-                        .excess_sig
-                        .get_signature()
-                        .to_hex()
+                let (mempool_response_sender, mempool_response_receiver) = mpsc::channel(100);
+                let (base_node_response_sender, base_node_response_receiver) = mpsc::channel(100);
+                self.mempool_response_senders.insert(tx_id, mempool_response_sender);
+                self.base_node_response_senders.insert(tx_id, base_node_response_sender);
+                let protocol = TransactionBroadcastProtocol::new(
+                    tx_id,
+                    self.service_resources.clone(),
+                    self.config.mempool_broadcast_timeout.clone(),
+                    pk.clone(),
+                    mempool_response_receiver,
+                    base_node_response_receiver,
                 );
-                trace!(target: LOG_TARGET, "{}", completed_tx.transaction);
-
-                // Send  Mempool Request
-                let mempool_request = MempoolProto::MempoolServiceRequest {
-                    request_key: completed_tx.tx_id,
-                    request: Some(MempoolProto::mempool_service_request::Request::SubmitTransaction(
-                        completed_tx.transaction.into(),
-                    )),
-                };
-                self.outbound_message_service
-                    .send_direct(
-                        pk.clone(),
-                        OutboundEncryption::None,
-                        OutboundDomainMessage::new(TariMessageType::MempoolRequest, mempool_request),
-                    )
-                    .await?;
-                // Start Timeout
-                let state_timeout = StateDelay::new(timeout, completed_tx.tx_id);
-
-                broadcast_timeout_futures.push(state_timeout.delay().boxed());
+                let join_handle = tokio::spawn(protocol.execute());
+                join_handles.push(join_handle);
             },
         }
 
@@ -1152,53 +960,18 @@ where
     /// node followed by mempool requests to confirm that they have been received
     async fn broadcast_all_completed_transactions_to_mempool(
         &mut self,
-        broadcast_timeout_futures: &mut FuturesUnordered<BoxFuture<'static, TxId>>,
+        join_handles: &mut FuturesUnordered<JoinHandle<Result<u64, TransactionServiceProtocolError>>>,
     ) -> Result<(), TransactionServiceError>
     {
-        trace!(target: LOG_TARGET, "Querying Broadcast? for all completed Transactions");
+        trace!(target: LOG_TARGET, "Attempting to Broadcast all Completed Transactions");
         let completed_txs = self.db.get_completed_transactions().await?;
         for completed_tx in completed_txs.values() {
             if completed_tx.status == TransactionStatus::Completed {
-                self.broadcast_completed_transaction_to_mempool(
-                    completed_tx.tx_id.clone(),
-                    self.config.initial_mempool_broadcast_timeout,
-                    broadcast_timeout_futures,
-                )
-                .await?;
+                if !self.mempool_response_senders.contains_key(&completed_tx.tx_id) {
+                    self.broadcast_completed_transaction_to_mempool(completed_tx.tx_id, join_handles)
+                        .await?;
+                }
             }
-        }
-
-        Ok(())
-    }
-
-    /// Handle the timeout of a pending transaction broadcast request. This will check if the transaction's status has
-    /// been updated by received MempoolRepsonse during the course of this timeout. If it has not been updated the
-    /// transaction is broadcast again
-    pub async fn handle_mempool_broadcast_timeout(
-        &mut self,
-        tx_id: TxId,
-        broadcast_timeout_futures: &mut FuturesUnordered<BoxFuture<'static, TxId>>,
-    ) -> Result<(), TransactionServiceError>
-    {
-        let completed_tx = self.db.get_completed_transaction(tx_id.clone()).await?;
-
-        if completed_tx.status == TransactionStatus::Completed {
-            info!(
-                target: LOG_TARGET,
-                "Mempool broadcast timed out for Transaction with TX_ID: {}", tx_id
-            );
-
-            self.broadcast_completed_transaction_to_mempool(
-                tx_id,
-                self.config.mempool_broadcast_timeout,
-                broadcast_timeout_futures,
-            )
-            .await?;
-
-            self.event_publisher
-                .send(TransactionEvent::MempoolBroadcastTimedOut(tx_id))
-                .await
-                .map_err(|_| TransactionServiceError::EventStreamError)?;
         }
 
         Ok(())
@@ -1208,252 +981,146 @@ where
     pub async fn handle_mempool_response(
         &mut self,
         response: MempoolProto::MempoolServiceResponse,
-        mined_request_timeout_futures: &mut FuturesUnordered<BoxFuture<'static, TxId>>,
     ) -> Result<(), TransactionServiceError>
     {
         let response = MempoolServiceResponse::try_from(response).unwrap();
+        trace!(target: LOG_TARGET, "Received Mempool Response: {:?}", response);
+
         let tx_id = response.request_key;
-        match response.response {
-            MempoolResponse::Stats(_) => {
-                return Err(TransactionServiceError::InvalidMessageError(
-                    "Mempool Response of invalid type".to_string(),
-                ))
-            },
-            MempoolResponse::State(_) => {
-                return Err(TransactionServiceError::InvalidMessageError(
-                    "Mempool Response of invalid type".to_string(),
-                ))
-            },
-            MempoolResponse::TxStorage(ts) => {
-                let completed_tx = self.db.get_completed_transaction(response.request_key.clone()).await?;
 
-                match completed_tx.status {
-                    TransactionStatus::Completed => match ts {
-                        // Getting this response means the Mempool Rejected this transaction so it will be cancelled.
-                        TxStorageResponse::NotStored => {
-                            // If this transaction is still in the Completed State it should be upgraded to the
-                            // Broadcast state
-                            error!(
+        let sender = match self.mempool_response_senders.get_mut(&tx_id) {
+            None => return Err(TransactionServiceError::UnexpectedMempoolResponse),
+            Some(s) => s,
+        };
+        sender
+            .send(response)
+            .await
+            .map_err(|_| TransactionServiceError::ProtocolChannelError)?;
+
+        Ok(())
+    }
+
+    /// Handle the final clean up after a Transaction Broadcast protocol completes
+    async fn complete_transaction_broadcast_protocol(
+        &mut self,
+        join_result: Result<u64, TransactionServiceProtocolError>,
+        transaction_chain_monitoring_join_handles: &mut FuturesUnordered<
+            JoinHandle<Result<u64, TransactionServiceProtocolError>>,
+        >,
+    )
+    {
+        match join_result {
+            Ok(id) => {
+                // Cleanup any registered senders
+                let _ = self.mempool_response_senders.remove(&id);
+                let _ = self.base_node_response_senders.remove(&id);
+                trace!(
+                    target: LOG_TARGET,
+                    "Transaction Broadcast Protocol for TxId: {} completed successfully",
+                    id
+                );
+                let _ = self
+                    .start_transaction_chain_monitoring_protocol(id, transaction_chain_monitoring_join_handles)
+                    .await
+                    .or_else(|resp| {
+                        match resp {
+                            TransactionServiceError::InvalidCompletedTransaction => trace!(
                                 target: LOG_TARGET,
-                                "Mempool response received for TxId: {:?}. Transaction was REJECTED. Cancelling \
-                                 transaction.",
-                                tx_id
-                            );
-                            if let Err(e) = self.output_manager_service.cancel_transaction(completed_tx.tx_id).await {
-                                error!(
-                                    target: LOG_TARGET,
-                                    "Failed to Cancel outputs for TX_ID: {} after failed sending attempt with error \
-                                     {:?}",
-                                    completed_tx.tx_id,
-                                    e
-                                );
-                            }
-                            if let Err(e) = self.db.cancel_completed_transaction(completed_tx.tx_id).await {
-                                error!(
-                                    target: LOG_TARGET,
-                                    "Failed to Cancel TX_ID: {} after failed sending attempt with error {:?}",
-                                    completed_tx.tx_id,
-                                    e
-                                );
-                            }
-                            self.event_publisher
-                                .send(TransactionEvent::TransactionSendDiscoveryComplete(tx_id, false))
-                                .await
-                                .map_err(|_| TransactionServiceError::EventStreamError)?;
-                        },
-                        // Any other variant of this enum means the transaction has been received by the base_node and
-                        // is in one of the various mempools
-                        _ => {
-                            // If this transaction is still in the Completed State it should be upgraded to the
-                            // Broadcast state
-
-                            info!(
+                                "Not starting Chain monitoring protocol as transaction cannot be found, either \
+                                 cancelled or already mined."
+                            ),
+                            _ => error!(
                                 target: LOG_TARGET,
-                                "Completed Transaction (TxId: {} and Kernel Excess Sig: {}) detected as Broadcast to \
-                                 Base Node Mempool",
-                                tx_id,
-                                completed_tx.transaction.body.kernels()[0]
-                                    .excess_sig
-                                    .get_signature()
-                                    .to_hex()
-                            );
-                            self.db.broadcast_completed_transaction(tx_id.clone()).await?;
-                            // Start monitoring the base node to see if this Tx has been mined
-                            self.send_transaction_mined_request(
-                                tx_id.clone(),
-                                self.config.base_node_mined_timeout,
-                                mined_request_timeout_futures,
-                            )
-                            .await?;
-
-                            self.event_publisher
-                                .send(TransactionEvent::TransactionBroadcast(tx_id))
-                                .await
-                                .map_err(|_| TransactionServiceError::EventStreamError)?;
-                        },
-                    },
-                    TransactionStatus::Broadcast => {
-                        info!(
-                            target: LOG_TARGET,
-                            "Mempool query for transaction Tx_ID: {} returned {:?}", completed_tx.tx_id, ts
-                        );
-                        if let Some(result) = self.pending_transaction_mined_queries.get_mut(&completed_tx.tx_id) {
-                            match ts {
-                                TxStorageResponse::NotStored => result.mempool_response = Some(false),
-                                _ => result.mempool_response = Some(true),
-                            }
-                            debug!(target: LOG_TARGET, "Current Mempool/Mined state {:?}", result);
-                            if result.is_complete() {
-                                self.handle_transaction_mined_request_result(completed_tx.tx_id).await;
-                            }
+                                "Error starting Chain Monitoring Protocol after completed Broadcast Protocol : {:?}",
+                                resp
+                            ),
                         }
-                    },
-                    _ => (),
-                }
+                        Err(resp)
+                    });
+            },
+            Err(TransactionServiceProtocolError { id, error }) => {
+                let _ = self.mempool_response_senders.remove(&id);
+                let _ = self.base_node_response_senders.remove(&id);
+                error!(
+                    target: LOG_TARGET,
+                    "Error completing Transaction Broadcast Protocol (Id: {}): {:?}", id, error
+                );
+                let _ = self
+                    .event_publisher
+                    .send(Arc::new(TransactionEvent::Error(format!("{:?}", error).to_string())));
             },
         }
-        Ok(())
     }
 
     /// Send a request to the Base Node to see if the specified transaction has been mined yet. This function will send
     /// the request and store a timeout future to check in on the status of the transaction in the future.
-    async fn send_transaction_mined_request(
+    async fn start_transaction_chain_monitoring_protocol(
         &mut self,
         tx_id: TxId,
-        timeout: Duration,
-        mined_request_timeout_futures: &mut FuturesUnordered<BoxFuture<'static, TxId>>,
+        join_handles: &mut FuturesUnordered<JoinHandle<Result<u64, TransactionServiceProtocolError>>>,
     ) -> Result<(), TransactionServiceError>
     {
         let completed_tx = self.db.get_completed_transaction(tx_id.clone()).await?;
 
-        if (completed_tx.status != TransactionStatus::Broadcast && completed_tx.status != TransactionStatus::Completed) ||
-            completed_tx.transaction.body.kernels().is_empty()
-        {
+        if completed_tx.status != TransactionStatus::Broadcast || completed_tx.transaction.body.kernels().is_empty() {
             return Err(TransactionServiceError::InvalidCompletedTransaction);
         }
 
         match self.base_node_public_key.clone() {
             None => return Err(TransactionServiceError::NoBaseNodeKeysProvided),
             Some(pk) => {
-                let mut hashes = Vec::new();
-                for o in completed_tx.transaction.body.outputs() {
-                    hashes.push(o.hash());
-                }
+                let protocol_id = OsRng.next_u64();
 
-                info!(
-                    target: LOG_TARGET,
-                    "Sending Transaction Mined? request for TxId: {} to Base Node with {} outputs",
-                    tx_id,
-                    hashes.len(),
+                let (mempool_response_sender, mempool_response_receiver) = mpsc::channel(100);
+                let (base_node_response_sender, base_node_response_receiver) = mpsc::channel(100);
+                self.mempool_response_senders
+                    .insert(protocol_id, mempool_response_sender);
+                self.base_node_response_senders
+                    .insert(protocol_id, base_node_response_sender);
+                let protocol = TransactionChainMonitoringProtocol::new(
+                    protocol_id,
+                    completed_tx.tx_id,
+                    self.service_resources.clone(),
+                    self.config.base_node_mined_timeout.clone(),
+                    pk.clone(),
+                    mempool_response_receiver,
+                    base_node_response_receiver,
                 );
-
-                // Send a request to the mempool to find the state of the Tx there
-                let tx_excess_sig = completed_tx.transaction.body.kernels()[0].excess_sig.clone();
-                let mempool_request = MempoolProto::MempoolServiceRequest {
-                    request_key: completed_tx.tx_id,
-                    request: Some(MempoolProto::mempool_service_request::Request::GetTxStateWithExcessSig(
-                        tx_excess_sig.into(),
-                    )),
-                };
-                self.outbound_message_service
-                    .send_direct(
-                        pk.clone(),
-                        OutboundEncryption::None,
-                        OutboundDomainMessage::new(TariMessageType::MempoolRequest, mempool_request),
-                    )
-                    .await?;
-
-                // Ask the base node if the outputs are in the chain
-                let request = BaseNodeRequestProto::FetchUtxos(BaseNodeProto::HashOutputs { outputs: hashes });
-                let service_request = BaseNodeProto::BaseNodeServiceRequest {
-                    request_key: tx_id,
-                    request: Some(request),
-                };
-                self.outbound_message_service
-                    .send_direct(
-                        pk.clone(),
-                        OutboundEncryption::None,
-                        OutboundDomainMessage::new(TariMessageType::BaseNodeRequest, service_request),
-                    )
-                    .await?;
-                // Start Timeout
-                let state_timeout = StateDelay::new(timeout, completed_tx.tx_id);
-                let _ = self
-                    .pending_transaction_mined_queries
-                    .insert(tx_id, TransactionMinedRequestResult::default());
-                mined_request_timeout_futures.push(state_timeout.delay().boxed());
+                let join_handle = tokio::spawn(protocol.execute());
+                join_handles.push(join_handle);
             },
         }
         Ok(())
     }
 
-    /// Handle the timeout of a pending transaction mined? request. This will check if the transaction's status has
-    /// been updated by received BaseNodeRepsonse during the course of this timeout. If it has not been updated the
-    /// transaction is broadcast again
-    pub async fn handle_transaction_mined_request_timeout(
+    /// Handle the final clean up after a Transaction Chain Monitoring protocol completes
+    fn complete_transaction_chain_monitoring_protocol(
         &mut self,
-        tx_id: TxId,
-        mined_request_timeout_futures: &mut FuturesUnordered<BoxFuture<'static, TxId>>,
-    ) -> Result<(), TransactionServiceError>
+        join_result: Result<u64, TransactionServiceProtocolError>,
+    )
     {
-        let completed_tx = self.db.get_completed_transaction(tx_id.clone()).await?;
-
-        if completed_tx.status == TransactionStatus::Broadcast || completed_tx.status == TransactionStatus::Completed {
-            info!(
-                target: LOG_TARGET,
-                "Transaction Mined? request timed out for TX_ID: {}", tx_id
-            );
-
-            self.send_transaction_mined_request(
-                tx_id,
-                self.config.base_node_mined_timeout,
-                mined_request_timeout_futures,
-            )
-            .await?;
-
-            self.event_publisher
-                .send(TransactionEvent::TransactionMinedRequestTimedOut(tx_id))
-                .await
-                .map_err(|_| TransactionServiceError::EventStreamError)?;
-        }
-
-        Ok(())
-    }
-
-    /// Handle the result of receiving all the stages needed to complete a Transaction Mined request
-    pub async fn handle_transaction_mined_request_result(&mut self, tx_id: TxId) {
-        if let Some(result) = self.pending_transaction_mined_queries.remove(&tx_id) {
-            // If the transaction is not in mempool AND not mined then the Tx was reorged out and will never appear
-            // in the chain and should be cancelled
-            if result.mempool_response == Some(false) && result.chain_response == Some(false) {
+        match join_result {
+            Ok(id) => {
+                // Cleanup any registered senders
+                let _ = self.mempool_response_senders.remove(&id);
+                let _ = self.base_node_response_senders.remove(&id);
+                trace!(
+                    target: LOG_TARGET,
+                    "Transaction chain monitoring Protocol for TxId: {} completed successfully",
+                    id
+                );
+            },
+            Err(TransactionServiceProtocolError { id, error }) => {
+                let _ = self.mempool_response_senders.remove(&id);
+                let _ = self.base_node_response_senders.remove(&id);
                 error!(
                     target: LOG_TARGET,
-                    "Transaction (TxId: {}) has left the Mempool while not being Mined. It will be cancelled.", tx_id,
+                    "Error completing Transaction chain monitoring Protocol (Id: {}): {:?}", id, error
                 );
                 let _ = self
-                    .output_manager_service
-                    .cancel_transaction(tx_id)
-                    .await
-                    .map_err(|e| {
-                        error!(
-                            target: LOG_TARGET,
-                            "Failed to Cancel outputs for TX_ID: {} after failed sending attempt with error {:?}",
-                            tx_id,
-                            e
-                        );
-                    });
-                let _ = self.db.cancel_completed_transaction(tx_id).await.map_err(|e| {
-                    error!(
-                        target: LOG_TARGET,
-                        "Failed to Cancel TX_ID: {} after failed sending attempt with error {:?}", tx_id, e
-                    );
-                });
-                let _ = self
                     .event_publisher
-                    .send(TransactionEvent::TransactionSendDiscoveryComplete(tx_id, false))
-                    .await
-                    .map_err(|e| error!(target: LOG_TARGET, "Failed send event {:?}", e));
-            }
+                    .send(Arc::new(TransactionEvent::Error(format!("{:?}", error).to_string())));
+            },
         }
     }
 
@@ -1463,115 +1130,42 @@ where
         response: BaseNodeProto::BaseNodeServiceResponse,
     ) -> Result<(), TransactionServiceError>
     {
-        let tx_id = response.request_key;
-        let response: Vec<tari_core::transactions::proto::types::TransactionOutput> = match response.response {
-            Some(BaseNodeResponseProto::TransactionOutputs(outputs)) => outputs.outputs,
-            _ => {
-                return Ok(());
-            },
-        };
-
-        let completed_tx = match self.db.get_completed_transaction(tx_id.clone()).await {
-            Ok(tx) => tx,
-            Err(_) => {
-                debug!(
+        trace!(target: LOG_TARGET, "Received Base Node Response: {:?}", response);
+        let sender = match self.base_node_response_senders.get_mut(&response.request_key) {
+            None => {
+                trace!(
                     target: LOG_TARGET,
-                    "Base Node Response received with unexpected key {:?}", tx_id
+                    "Received Base Node response with unexpected key: {}. Not for this service",
+                    response.request_key
                 );
                 return Ok(());
             },
+            Some(s) => s,
         };
-        // If this transaction is still in the Broadcast or Completed State it should be upgraded to the Mined state
-        if completed_tx.status == TransactionStatus::Broadcast || completed_tx.status == TransactionStatus::Completed {
-            // Confirm that all outputs were reported as mined for the transaction
-            if response.len() != completed_tx.transaction.body.outputs().len() {
-                info!(
-                    target: LOG_TARGET,
-                    "Base node response received. TxId: {:?} not mined yet. ({} outputs requested but {} returned)",
-                    tx_id,
-                    completed_tx.transaction.body.outputs().len(),
-                    response.len(),
-                );
-
-                if completed_tx.status == TransactionStatus::Broadcast {
-                    if let Some(result) = self.pending_transaction_mined_queries.get_mut(&completed_tx.tx_id) {
-                        result.chain_response = Some(false);
-                        debug!(target: LOG_TARGET, "Current Mempool/Mined state {:?}", result);
-                        if result.is_complete() {
-                            self.handle_transaction_mined_request_result(completed_tx.tx_id).await;
-                        }
-                    }
-                }
-            } else {
-                let mut check = true;
-
-                for output in response.iter() {
-                    let transaction_output = TransactionOutput::try_from(output.clone())
-                        .map_err(TransactionServiceError::ConversionError)?;
-
-                    check = check &&
-                        completed_tx
-                            .transaction
-                            .body
-                            .outputs()
-                            .iter()
-                            .any(|item| item == &transaction_output);
-                }
-                // If all outputs are present then mark this transaction as mined.
-                if check {
-                    self.output_manager_service
-                        .confirm_transaction(
-                            tx_id.clone(),
-                            completed_tx.transaction.body.inputs().clone(),
-                            completed_tx.transaction.body.outputs().clone(),
-                        )
-                        .await?;
-
-                    self.db.mine_completed_transaction(tx_id).await?;
-
-                    self.event_publisher
-                        .send(TransactionEvent::TransactionMined(tx_id))
-                        .await
-                        .map_err(|_| TransactionServiceError::EventStreamError)?;
-
-                    info!(
-                        target: LOG_TARGET,
-                        "Transaction (TxId: {:?}) detected as mined on the Base Layer", tx_id
-                    );
-                }
-            }
-        } else {
-            debug!(
-                target: LOG_TARGET,
-                "Base node response received for TxId: {:?} but this transaction is not in the Broadcast state", tx_id
-            );
-        }
+        sender
+            .send(response.clone())
+            .await
+            .map_err(|_| TransactionServiceError::ProtocolChannelError)?;
 
         Ok(())
     }
 
-    /// Go through all completed transactions that have  been broadcast and start querying the base_node to see if they
+    /// Go through all completed transactions that have been broadcast and start querying the base_node to see if they
     /// have been mined
-    async fn monitor_all_completed_transactions_for_mining(
+    async fn start_chain_monitoring_for_all_broadcast_transactions(
         &mut self,
-        mined_request_timeout_futures: &mut FuturesUnordered<BoxFuture<'static, TxId>>,
+        join_handles: &mut FuturesUnordered<JoinHandle<Result<u64, TransactionServiceProtocolError>>>,
     ) -> Result<(), TransactionServiceError>
     {
         trace!(
             target: LOG_TARGET,
-            "Querying Transaction Mined? for all Broadcast Transactions"
+            "Starting Chain monitoring for all Broadcast Transactions"
         );
         let completed_txs = self.db.get_completed_transactions().await?;
         for completed_tx in completed_txs.values() {
-            if completed_tx.status == TransactionStatus::Broadcast ||
-                completed_tx.status == TransactionStatus::Completed
-            {
-                self.send_transaction_mined_request(
-                    completed_tx.tx_id.clone(),
-                    self.config.initial_base_node_mined_timeout,
-                    mined_request_timeout_futures,
-                )
-                .await?;
+            if completed_tx.status == TransactionStatus::Broadcast {
+                self.start_transaction_chain_monitoring_protocol(completed_tx.tx_id.clone(), join_handles)
+                    .await?;
             }
         }
 
@@ -1626,10 +1220,17 @@ where
 
         self.db.broadcast_completed_transaction(tx_id).await?;
 
-        self.event_publisher
-            .send(TransactionEvent::TransactionBroadcast(tx_id))
-            .await
-            .map_err(|_| TransactionServiceError::EventStreamError)?;
+        let _ = self
+            .event_publisher
+            .send(Arc::new(TransactionEvent::TransactionBroadcast(tx_id)))
+            .map_err(|e| {
+                trace!(
+                    target: LOG_TARGET,
+                    "Error sending event, usually because there are no subscribers: {:?}",
+                    e
+                );
+                e
+            });
 
         Ok(())
     }
@@ -1671,10 +1272,17 @@ where
 
         self.db.mine_completed_transaction(tx_id).await?;
 
-        self.event_publisher
-            .send(TransactionEvent::TransactionMined(tx_id))
-            .await
-            .map_err(|_| TransactionServiceError::EventStreamError)?;
+        let _ = self
+            .event_publisher
+            .send(Arc::new(TransactionEvent::TransactionMined(tx_id)))
+            .map_err(|e| {
+                trace!(
+                    target: LOG_TARGET,
+                    "Error sending event, usually because there are no subscribers: {:?}",
+                    e
+                );
+                e
+            });
 
         Ok(())
     }
@@ -1694,7 +1302,7 @@ where
             service::OutputManagerService,
             storage::{database::OutputManagerDatabase, memory_db::OutputManagerMemoryDatabase},
         };
-        use futures::{channel::mpsc, stream};
+        use futures::stream;
         use tari_broadcast_channel::bounded;
 
         let (_sender, receiver) = reply_channel::unbounded();
@@ -1754,10 +1362,17 @@ where
             .add_pending_inbound_transaction(tx_id.clone(), inbound_transaction.clone())
             .await?;
 
-        self.event_publisher
-            .send(TransactionEvent::ReceivedTransaction(tx_id))
-            .await
-            .map_err(|_| TransactionServiceError::EventStreamError)?;
+        let _ = self
+            .event_publisher
+            .send(Arc::new(TransactionEvent::ReceivedTransaction(tx_id)))
+            .map_err(|e| {
+                trace!(
+                    target: LOG_TARGET,
+                    "Error sending event, usually because there are no subscribers: {:?}",
+                    e
+                );
+                e
+            });
 
         Ok(())
     }
@@ -1787,83 +1402,30 @@ where
         self.db
             .complete_inbound_transaction(tx_id.clone(), completed_transaction.clone())
             .await?;
-        self.event_publisher
-            .send(TransactionEvent::ReceivedFinalizedTransaction(tx_id))
-            .await
-            .map_err(|_| TransactionServiceError::EventStreamError)?;
+        let _ = self
+            .event_publisher
+            .send(Arc::new(TransactionEvent::ReceivedFinalizedTransaction(tx_id)))
+            .map_err(|e| {
+                trace!(
+                    target: LOG_TARGET,
+                    "Error sending event, usually because there are no subscribers: {:?}",
+                    e
+                );
+                e
+            });
         Ok(())
     }
 }
 
-// Asynchronous Tasks
-
-async fn transaction_send_discovery_process_completion(
-    response_channel: oneshot::Receiver<SendMessageResponse>,
-    tx_id: TxId,
-    outbound_tx: OutboundTransaction,
-) -> Result<(MessageTag, OutboundTransaction), TransactionServiceError>
+/// This struct is a collection of the common resources that a protocol in the service requires.
+#[derive(Clone)]
+pub struct TransactionServiceResources<TBackend>
+where TBackend: TransactionBackend + Clone + 'static
 {
-    let mut message_tag: Option<MessageTag> = None;
-    match response_channel.await {
-        Ok(response) => match response {
-            SendMessageResponse::Queued(tags) => match tags.len() {
-                0 => error!(
-                    target: LOG_TARGET,
-                    "Send Discovery process for TX_ID: {} was unsuccessful and no message was sent", tx_id
-                ),
-                1 => {
-                    message_tag = Some(tags[0]);
-
-                    info!(
-                        target: LOG_TARGET,
-                        "Transaction (TxId: {}) Send Discovery process successful with Message Tag: {:?}",
-                        tx_id,
-                        message_tag,
-                    );
-                },
-                _ => error!(
-                    target: LOG_TARGET,
-                    "Send Discovery process for TX_ID: {} was unsuccessful due to more than 1 MessageTag being \
-                     returned",
-                    tx_id
-                ),
-            },
-            _ => {
-                error!(
-                    target: LOG_TARGET,
-                    "Transaction (TxId: {}) Send Discovery process failed", tx_id
-                );
-            },
-        },
-        Err(_) => {
-            error!(
-                target: LOG_TARGET,
-                "Transaction (TxId: {}) Send Response One-shot channel dropped", tx_id
-            );
-        },
-    }
-
-    if let Some(mt) = message_tag {
-        let updated_outbound_tx = OutboundTransaction {
-            timestamp: Utc::now().naive_utc(),
-            ..outbound_tx.clone()
-        };
-        Ok((mt, updated_outbound_tx))
-    } else {
-        Err(TransactionServiceError::DiscoveryProcessFailed(tx_id))
-    }
-}
-
-/// This struct holds the responses of a multistage base node monitoring request to see if a Transaction has been mined.
-/// This is used to keep track of the status of the transaction in both the mempool and chain.
-#[derive(Debug, Default)]
-struct TransactionMinedRequestResult {
-    mempool_response: Option<bool>,
-    chain_response: Option<bool>,
-}
-
-impl TransactionMinedRequestResult {
-    fn is_complete(&self) -> bool {
-        self.mempool_response.is_some() && self.chain_response.is_some()
-    }
+    pub db: TransactionDatabase<TBackend>,
+    pub output_manager_service: OutputManagerHandle,
+    pub outbound_message_service: OutboundMessageRequester,
+    pub event_publisher: TransactionEventSender,
+    pub node_identity: Arc<NodeIdentity>,
+    pub factories: CryptoFactories,
 }

--- a/base_layer/wallet/src/wallet.rs
+++ b/base_layer/wallet/src/wallet.rs
@@ -156,7 +156,7 @@ where
             .add_initializer(TransactionServiceInitializer::new(
                 config.transaction_service_config.unwrap_or_default(),
                 subscription_factory.clone(),
-                comms.subscribe_messaging_events(),
+                comms.message_event_sender(),
                 transaction_backend,
                 comms.node_identity(),
                 factories.clone(),

--- a/base_layer/wallet/tests/output_manager_service/service.rs
+++ b/base_layer/wallet/tests/output_manager_service/service.rs
@@ -680,7 +680,7 @@ fn test_startup_utxo_scan() {
     let output3 = UnblindedOutput::new(MicroTari::from(value3), key3, None);
     runtime.block_on(oms.add_output(output3.clone())).unwrap();
 
-    let (_, body) = outbound_service.pop_call().unwrap();
+    let (_, body, _) = outbound_service.pop_call().unwrap();
     let envelope_body = EnvelopeBody::decode(body.to_vec().as_slice()).unwrap();
     let bn_request: BaseNodeProto::BaseNodeServiceRequest = envelope_body
         .decode_part::<BaseNodeProto::BaseNodeServiceRequest>(1)
@@ -755,7 +755,7 @@ fn test_startup_utxo_scan() {
 
     runtime.block_on(oms.sync_with_base_node()).unwrap();
 
-    let (_, body) = outbound_service.pop_call().unwrap();
+    let (_, body, _) = outbound_service.pop_call().unwrap();
     let envelope_body = EnvelopeBody::decode(body.to_vec().as_slice()).unwrap();
     let bn_request: BaseNodeProto::BaseNodeServiceRequest = envelope_body
         .decode_part::<BaseNodeProto::BaseNodeServiceRequest>(1)

--- a/base_layer/wallet/tests/wallet/mod.rs
+++ b/base_layer/wallet/tests/wallet/mod.rs
@@ -189,7 +189,7 @@ fn test_wallet() {
 
         let result_stream = runtime
             .block_on(async { collect_stream!(alice_event_stream, take = 2, timeout = Duration::from_secs(10)) });
-        let received_transaction_reply_count = result_stream.iter().fold(0, |acc, x| match &**x {
+        let received_transaction_reply_count = result_stream.iter().fold(0, |acc, x| match &**(*x).as_ref().unwrap() {
             TransactionEvent::ReceivedTransactionReply(_) => acc + 1,
             _ => acc,
         });

--- a/base_layer/wallet_ffi/src/lib.rs
+++ b/base_layer/wallet_ffi/src/lib.rs
@@ -3101,7 +3101,7 @@ pub unsafe extern "C" fn wallet_get_pending_outgoing_balance(
 /// as an out parameter.
 ///
 /// ## Returns
-/// `bool` - Returns if successful or not
+/// `unsigned long long` - Returns 0 if unsuccessful or the TxId of the sent transaction if successful
 ///
 /// # Safety
 /// None
@@ -3113,20 +3113,20 @@ pub unsafe extern "C" fn wallet_send_transaction(
     fee_per_gram: c_ulonglong,
     message: *const c_char,
     error_out: *mut c_int,
-) -> bool
+) -> c_ulonglong
 {
     let mut error = 0;
     ptr::swap(error_out, &mut error as *mut c_int);
     if wallet.is_null() {
         error = LibWalletError::from(InterfaceError::NullError("wallet".to_string())).code;
         ptr::swap(error_out, &mut error as *mut c_int);
-        return false;
+        return 0;
     }
 
     if dest_public_key.is_null() {
         error = LibWalletError::from(InterfaceError::NullError("dest_public_key".to_string())).code;
         ptr::swap(error_out, &mut error as *mut c_int);
-        return false;
+        return 0;
     }
 
     let message_string = if !message.is_null() {
@@ -3145,11 +3145,11 @@ pub unsafe extern "C" fn wallet_send_transaction(
             MicroTari::from(fee_per_gram),
             message_string,
         )) {
-        Ok(_) => true,
+        Ok(tx_id) => tx_id,
         Err(e) => {
             error = LibWalletError::from(WalletError::TransactionServiceError(e)).code;
             ptr::swap(error_out, &mut error as *mut c_int);
-            false
+            0
         },
     }
 }

--- a/base_layer/wallet_ffi/wallet.h
+++ b/base_layer/wallet_ffi/wallet.h
@@ -372,7 +372,7 @@ unsigned long long wallet_get_pending_incoming_balance(struct TariWallet *wallet
 unsigned long long wallet_get_pending_outgoing_balance(struct TariWallet *wallet,int* error_out);
 
 // Sends a TariPendingOutboundTransaction
-bool wallet_send_transaction(struct TariWallet *wallet, struct TariPublicKey *destination, unsigned long long amount, unsigned long long fee_per_gram,const char *message,int* error_out);
+unsigned long long wallet_send_transaction(struct TariWallet *wallet, struct TariPublicKey *destination, unsigned long long amount, unsigned long long fee_per_gram,const char *message,int* error_out);
 
 // Get the TariContacts from a TariWallet
 struct TariContacts *wallet_get_contacts(struct TariWallet *wallet,int* error_out);

--- a/comms/dht/src/dht.rs
+++ b/comms/dht/src/dht.rs
@@ -441,7 +441,7 @@ mod test {
         service.call(inbound_message).await.unwrap();
 
         assert_eq!(oms_mock_state.call_count(), 1);
-        let (params, _) = oms_mock_state.pop_call().unwrap();
+        let (params, _, _) = oms_mock_state.pop_call().unwrap();
 
         // Check that OMS got a request to forward with the original Dht Header
         assert_eq!(params.dht_header.unwrap().origin_mac, origin_mac);

--- a/comms/dht/src/discovery/service.rs
+++ b/comms/dht/src/discovery/service.rs
@@ -483,7 +483,7 @@ mod test {
             assert!(result.unwrap_err().is_timeout());
 
             oms_mock_state.wait_call_count(1, Duration::from_secs(5)).unwrap();
-            let (params, _) = oms_mock_state.pop_call().unwrap();
+            let (params, _, _) = oms_mock_state.pop_call().unwrap();
             assert_eq!(params.dht_message_type, DhtMessageType::Discovery);
             assert_eq!(params.encryption, OutboundEncryption::EncryptFor(dest_public_key));
 

--- a/comms/dht/src/store_forward/forward.rs
+++ b/comms/dht/src/store_forward/forward.rs
@@ -302,7 +302,7 @@ mod test {
         assert!(spy.is_called());
 
         assert_eq!(oms_mock_state.call_count(), 1);
-        let (params, _) = oms_mock_state.pop_call().unwrap();
+        let (params, _, _) = oms_mock_state.pop_call().unwrap();
 
         assert!(params.dht_header.is_some());
     }

--- a/comms/src/builder/comms_node.rs
+++ b/comms/src/builder/comms_node.rs
@@ -275,6 +275,11 @@ impl CommsNode {
         self.messaging_event_tx.subscribe()
     }
 
+    /// Return a clone of the of the messaging event Sender to allow for other services to create subscriptions
+    pub fn message_event_sender(&self) -> messaging::MessagingEventSender {
+        self.messaging_event_tx.clone()
+    }
+
     /// Return an owned copy of a ConnectionManagerRequester. Used to initiate connections to peers.
     pub fn connection_manager(&self) -> ConnectionManagerRequester {
         self.connection_manager_requester.clone()


### PR DESCRIPTION
## Description
This PR refactors the 3 most complex long running processes in the Transaction service. The Sending protocol, Broadcast protocol and the Chain monitoring protocol.

These protocols all have multiple complex asynchronous stages and they were all handled in the main service code making them difficult to trace and maintain. The refactor introduces the idea of a “protocol” which is a struct and the logic to execute a long running task that requires complex asynchronous input and processing. The protocol is spawned as an async task and to receive input when it is created it registers channels with the Service task along which the required data will be sent when it arrives at the service.

The main service task still acts as a broker where all input streams (Event stream, comms stack message subscriptions, Service API calls etc) are read and when such an event/message is received if a Protocol has registered interest in the event it will be sent along the channel to the Protocol task.

This refactor makes the writing, reading and maintenance of a complex asynchronous protocol much easier as it can all be written as a single flow of logic. Giving a protocol its own task is also much neater in terms of managing where it awaits.

## Motivation and Context
The async task handling in the Tx service had gotten to complex to easily maintain and update.

## How Has This Been Tested?
Tests have been updated

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [x] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [x] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch.
* [x] I ran `cargo-fmt --all` before pushing.
* [ ] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
