### PR TITLE
[Store and forward] Private message storage and retrieval

### DIFF
--- a/comms/dht/src/config.rs
+++ b/comms/dht/src/config.rs
@@ -28,7 +28,7 @@ pub const SAF_MSG_CACHE_STORAGE_CAPACITY: usize = 10_000;
 /// The default time-to-live duration used for storage of low priority messages by the Store-and-forward middleware
 pub const SAF_LOW_PRIORITY_MSG_STORAGE_TTL: Duration = Duration::from_secs(6 * 60 * 60); // 6 hours
 /// The default time-to-live duration used for storage of high priority messages by the Store-and-forward middleware
-pub const SAF_HIGH_PRIORITY_MSG_STORAGE_TTL: Duration = Duration::from_secs(2 * 24 * 60 * 60); // 2 days
+pub const SAF_HIGH_PRIORITY_MSG_STORAGE_TTL: Duration = Duration::from_secs(3 * 24 * 60 * 60); // 3 days
 /// The default number of peer nodes that a message has to be closer to, to be considered a neighbour
 pub const DEFAULT_NUM_NEIGHBOURING_NODES: usize = 10;
 
@@ -55,9 +55,9 @@ pub struct DhtConfig {
     /// Default: 6 hours
     pub saf_low_priority_msg_storage_ttl: Duration,
     /// The time-to-live duration used for storage of high priority messages by the Store-and-forward middleware.
-    /// Default: 2 days
+    /// Default: 3 days
     pub saf_high_priority_msg_storage_ttl: Duration,
-    /// The limit on the message size to store in SAF storage in bytes. Default 500kb
+    /// The limit on the message size to store in SAF storage in bytes. Default 500 KiB
     pub saf_max_message_size: usize,
     /// The max capacity of the message hash cache
     /// Default: 1000
@@ -112,7 +112,7 @@ impl Default for DhtConfig {
             saf_msg_cache_storage_capacity: SAF_MSG_CACHE_STORAGE_CAPACITY,
             saf_low_priority_msg_storage_ttl: SAF_LOW_PRIORITY_MSG_STORAGE_TTL,
             saf_high_priority_msg_storage_ttl: SAF_HIGH_PRIORITY_MSG_STORAGE_TTL,
-            saf_max_message_size: 512 * 1024, // 512 kb
+            saf_max_message_size: 512 * 1024, // 500 KiB
             msg_hash_cache_capacity: 10_000,
             msg_hash_cache_ttl: Duration::from_secs(300),
             broadcast_cooldown_max_attempts: 3,

--- a/comms/dht/src/inbound/message.rs
+++ b/comms/dht/src/inbound/message.rs
@@ -52,7 +52,7 @@ impl Display for DhtInboundMessage {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), Error> {
         write!(
             f,
-            "\n---- DhtInboundMessage ---- \nSize: {} byte(s)\nType: {}\nPeer: {}\nHeader: {}\n----",
+            "\n---- Inbound Message ---- \nSize: {} byte(s)\nType: {}\nPeer: {}\nHeader: {}\n----",
             self.body.len(),
             self.dht_header.message_type,
             self.source_peer,

--- a/comms/dht/src/outbound/broadcast.rs
+++ b/comms/dht/src/outbound/broadcast.rs
@@ -222,6 +222,7 @@ where S: Service<DhtOutboundMessage, Response = (), Error = PipelineError>
         reply_tx: oneshot::Sender<SendMessageResponse>,
     ) -> Result<Vec<DhtOutboundMessage>, DhtOutboundError>
     {
+        trace!(target: LOG_TARGET, "Send params: {:?}", params);
         if params
             .broadcast_strategy
             .direct_public_key()

--- a/comms/dht/src/outbound/message.rs
+++ b/comms/dht/src/outbound/message.rs
@@ -168,7 +168,7 @@ impl fmt::Display for DhtOutboundMessage {
         let header_str = self
             .custom_header
             .as_ref()
-            .and_then(|h| Some(format!("{} (Propagated)", h)))
+            .map(|h| format!("{} (Propagated)", h))
             .unwrap_or_else(|| {
                 format!(
                     "Network: {:?}, Flags: {:?}, Destination: {}",

--- a/comms/dht/src/proto/store_forward.proto
+++ b/comms/dht/src/proto/store_forward.proto
@@ -12,6 +12,7 @@ package tari.dht.store_forward;
 message StoredMessagesRequest {
     google.protobuf.Timestamp since = 1;
     uint32 request_id = 2;
+    bytes dist_threshold = 3;
 }
 
 // Storage for a single message envelope, including the date and time when the element was stored
@@ -27,14 +28,16 @@ message StoredMessagesResponse {
     repeated StoredMessage messages = 1;
     uint32 request_id = 2;
     enum SafResponseType {
-        // All applicable messages
-        General = 0;
-        // Send messages explicitly addressed to the requesting node or within the requesting node's region
-        ExplicitlyAddressed = 1;
-        // Send Discovery messages that could be for the requester
-        Discovery = 2;
-        // Send Join messages that the requester could be interested in
-        Join = 3;
+        // Messages for the requested public key or node ID
+        ForMe = 0;
+        // Discovery messages that could be for the requester
+        Discovery = 1;
+        // Join messages that the requester could be interested in
+        Join = 2;
+        // Messages without an explicit destination and with an unidentified encrypted source
+        Anonymous = 3;
+        // Messages within the requesting node's region
+        InRegion = 4;
     }
     SafResponseType response_type = 3;
 }

--- a/comms/dht/src/proto/tari.dht.store_forward.rs
+++ b/comms/dht/src/proto/tari.dht.store_forward.rs
@@ -7,6 +7,8 @@ pub struct StoredMessagesRequest {
     pub since: ::std::option::Option<::prost_types::Timestamp>,
     #[prost(uint32, tag = "2")]
     pub request_id: u32,
+    #[prost(bytes, tag = "3")]
+    pub dist_threshold: std::vec::Vec<u8>,
 }
 /// Storage for a single message envelope, including the date and time when the element was stored
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -34,13 +36,15 @@ pub mod stored_messages_response {
     #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
     #[repr(i32)]
     pub enum SafResponseType {
-        /// All applicable messages
-        General = 0,
-        /// Send messages explicitly addressed to the requesting node or within the requesting node's region
-        ExplicitlyAddressed = 1,
-        /// Send Discovery messages that could be for the requester
-        Discovery = 2,
-        /// Send Join messages that the requester could be interested in
-        Join = 3,
+        /// Messages for the requested public key or node ID
+        ForMe = 0,
+        /// Discovery messages that could be for the requester
+        Discovery = 1,
+        /// Join messages that the requester could be interested in
+        Join = 2,
+        /// Messages without an explicit destination and with an unidentified encrypted source
+        Anonymous = 3,
+        /// Messages within the requesting node's region
+        InRegion = 4,
     }
 }

--- a/comms/dht/src/store_forward/database/mod.rs
+++ b/comms/dht/src/store_forward/database/mod.rs
@@ -31,7 +31,10 @@ use crate::{
 };
 use chrono::{DateTime, NaiveDateTime, Utc};
 use diesel::{BoolExpressionMethods, ExpressionMethods, QueryDsl, RunQueryDsl};
-use tari_comms::types::CommsPublicKey;
+use tari_comms::{
+    peer_manager::{node_id::NodeDistance, NodeId},
+    types::CommsPublicKey,
+};
 use tari_crypto::tari_utilities::hex::Hex;
 
 pub struct StoreAndForwardDatabase {
@@ -54,19 +57,56 @@ impl StoreAndForwardDatabase {
             .await
     }
 
-    pub async fn find_messages_for_public_key(
+    pub async fn find_messages_for_peer(
         &self,
         public_key: &CommsPublicKey,
+        node_id: &NodeId,
         since: Option<DateTime<Utc>>,
         limit: i64,
     ) -> Result<Vec<StoredMessage>, StorageError>
     {
         let pk_hex = public_key.to_hex();
+        let node_id_hex = node_id.to_hex();
         self.connection
-            .with_connection_async(move |conn| {
+            .with_connection_async::<_, Vec<StoredMessage>>(move |conn| {
                 let mut query = stored_messages::table
                     .select(stored_messages::all_columns)
-                    .filter(stored_messages::destination_pubkey.eq(pk_hex))
+                    .filter(
+                        stored_messages::destination_pubkey
+                            .eq(pk_hex)
+                            .or(stored_messages::destination_node_id.eq(node_id_hex)),
+                    )
+                    .into_boxed();
+
+                if let Some(since) = since {
+                    query = query.filter(stored_messages::stored_at.ge(since.naive_utc()));
+                }
+
+                query
+                    .order_by(stored_messages::stored_at.asc())
+                    .limit(limit)
+                    .get_results(conn)
+                    .map_err(Into::into)
+            })
+            .await
+    }
+
+    pub async fn find_regional_messages(
+        &self,
+        node_id: &NodeId,
+        dist_threshold: Option<Box<NodeDistance>>,
+        since: Option<DateTime<Utc>>,
+        limit: i64,
+    ) -> Result<Vec<StoredMessage>, StorageError>
+    {
+        let node_id_hex = node_id.to_hex();
+        let results = self
+            .connection
+            .with_connection_async::<_, Vec<StoredMessage>>(move |conn| {
+                let mut query = stored_messages::table
+                    .select(stored_messages::all_columns)
+                    .filter(stored_messages::destination_node_id.ne(node_id_hex))
+                    .filter(stored_messages::destination_node_id.is_not_null())
                     .filter(stored_messages::message_type.eq(DhtMessageType::None as i32))
                     .into_boxed();
 
@@ -75,7 +115,57 @@ impl StoreAndForwardDatabase {
                 }
 
                 query
-                    .order_by(stored_messages::stored_at.desc())
+                    .order_by(stored_messages::stored_at.asc())
+                    .limit(limit)
+                    .get_results(conn)
+                    .map_err(Into::into)
+            })
+            .await?;
+
+        match dist_threshold {
+            Some(dist_threshold) => {
+                // Filter node ids that are within the distance threshold from the source node id
+                let results = results
+                    .into_iter()
+                    // TODO: Investigate if we could do this in sqlite using XOR (^)
+                    .filter(|message| match message.destination_node_id {
+                        Some(ref dest_node_id) => match NodeId::from_hex(dest_node_id).ok() {
+                            Some(dest_node_id) => {
+                                &dest_node_id == node_id || &dest_node_id.distance(node_id) <= &*dist_threshold
+                            },
+                            None => false,
+                        },
+                        None => true,
+                    })
+                    .collect();
+                Ok(results)
+            },
+            None => Ok(results),
+        }
+    }
+
+    pub async fn find_anonymous_messages(
+        &self,
+        since: Option<DateTime<Utc>>,
+        limit: i64,
+    ) -> Result<Vec<StoredMessage>, StorageError>
+    {
+        self.connection
+            .with_connection_async(move |conn| {
+                let mut query = stored_messages::table
+                    .select(stored_messages::all_columns)
+                    .filter(stored_messages::origin_pubkey.is_null())
+                    .filter(stored_messages::destination_pubkey.is_null())
+                    .filter(stored_messages::is_encrypted.eq(true))
+                    .filter(stored_messages::message_type.eq(DhtMessageType::None as i32))
+                    .into_boxed();
+
+                if let Some(since) = since {
+                    query = query.filter(stored_messages::stored_at.ge(since.naive_utc()));
+                }
+
+                query
+                    .order_by(stored_messages::stored_at.asc())
                     .limit(limit)
                     .get_results(conn)
                     .map_err(Into::into)
@@ -109,7 +199,7 @@ impl StoreAndForwardDatabase {
                 }
 
                 query
-                    .order_by(stored_messages::stored_at.desc())
+                    .order_by(stored_messages::stored_at.asc())
                     .limit(limit)
                     .get_results(conn)
                     .map_err(Into::into)

--- a/comms/dht/src/store_forward/error.rs
+++ b/comms/dht/src/store_forward/error.rs
@@ -71,4 +71,6 @@ pub enum StoreAndForwardError {
     /// The envelope version is invalid
     InvalidEnvelopeVersion,
     MalformedNodeId(ByteArrayError),
+    /// NodeDistance threshold was invalid
+    InvalidNodeDistanceThreshold,
 }

--- a/comms/dht/src/store_forward/message.rs
+++ b/comms/dht/src/store_forward/message.rs
@@ -55,6 +55,7 @@ impl StoredMessagesRequest {
         Self {
             since: None,
             request_id: OsRng.next_u32(),
+            dist_threshold: Vec::new(),
         }
     }
 
@@ -62,6 +63,7 @@ impl StoredMessagesRequest {
         Self {
             since: Some(datetime_to_timestamp(since)),
             request_id: OsRng.next_u32(),
+            dist_threshold: Vec::new(),
         }
     }
 }

--- a/comms/dht/tests/dht.rs
+++ b/comms/dht/tests/dht.rs
@@ -20,28 +20,37 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use futures::channel::mpsc;
+use futures::{channel::mpsc, StreamExt};
 use rand::rngs::OsRng;
 use std::{sync::Arc, time::Duration};
 use tari_comms::{
     backoff::ConstantBackoff,
+    message::MessageExt,
     peer_manager::{NodeIdentity, Peer, PeerFeatures, PeerStorage},
     pipeline,
     pipeline::SinkService,
     transports::MemoryTransport,
     types::CommsDatabase,
+    wrap_in_envelope_body,
     CommsBuilder,
     CommsNode,
 };
-use tari_comms_dht::{inbound::DecryptedDhtMessage, Dht, DhtBuilder};
+use tari_comms_dht::{
+    envelope::NodeDestination,
+    inbound::DecryptedDhtMessage,
+    outbound::{OutboundEncryption, SendMessageParams},
+    Dht,
+    DhtBuilder,
+};
 use tari_storage::{lmdb_store::LMDBBuilder, LMDBWrapper};
 use tari_test_utils::{async_assert_eventually, paths::create_temporary_data_path, random};
+use tokio::time;
 use tower::ServiceBuilder;
 
 struct TestNode {
     comms: CommsNode,
     dht: Dht,
-    _ims_rx: mpsc::Receiver<DecryptedDhtMessage>,
+    ims_rx: mpsc::Receiver<DecryptedDhtMessage>,
 }
 
 impl TestNode {
@@ -51,6 +60,10 @@ impl TestNode {
 
     pub fn to_peer(&self) -> Peer {
         self.comms.node_identity().to_peer()
+    }
+
+    pub async fn next_inbound_message(&mut self, timeout: Duration) -> Option<DecryptedDhtMessage> {
+        time::timeout(timeout, self.ims_rx.next()).await.ok()?
     }
 }
 
@@ -81,15 +94,14 @@ fn create_peer_storage(peers: Vec<Peer>) -> CommsDatabase {
 
 async fn make_node(features: PeerFeatures, seed_peer: Option<Peer>) -> TestNode {
     let node_identity = make_node_identity(features);
+    make_node_with_node_identity(node_identity, seed_peer).await
+}
 
+async fn make_node_with_node_identity(node_identity: Arc<NodeIdentity>, seed_peer: Option<Peer>) -> TestNode {
     let (tx, ims_rx) = mpsc::channel(1);
     let (comms, dht) = setup_comms_dht(node_identity, create_peer_storage(seed_peer.into_iter().collect()), tx).await;
 
-    TestNode {
-        comms,
-        dht,
-        _ims_rx: ims_rx,
-    }
+    TestNode { comms, dht, ims_rx }
 }
 
 async fn setup_comms_dht(
@@ -233,4 +245,69 @@ async fn dht_discover_propagation() {
     node_B.comms.shutdown().await;
     node_C.comms.shutdown().await;
     node_D.comms.shutdown().await;
+}
+
+#[tokio_macros::test]
+#[allow(non_snake_case)]
+async fn dht_store_forward() {
+    let node_C_node_identity = make_node_identity(PeerFeatures::COMMUNICATION_NODE);
+    // Node B knows about Node C
+    let node_B = make_node(PeerFeatures::COMMUNICATION_NODE, None).await;
+    // Node A knows about Node B
+    let node_A = make_node(PeerFeatures::COMMUNICATION_NODE, Some(node_B.to_peer())).await;
+
+    let params = SendMessageParams::new()
+        .neighbours(vec![])
+        .with_encryption(OutboundEncryption::EncryptFor(Box::new(
+            node_C_node_identity.public_key().clone(),
+        )))
+        .with_destination(NodeDestination::Unknown)
+        .finish();
+
+    let secret_msg1 = b"NCZW VUSX PNYM INHZ XMQX SFWX WLKJ AHSH";
+    let secret_msg2 = b"NMCO CCAK UQPM KCSM HKSE INJU SBLK";
+
+    let mut node_B_msg_events = node_B.comms.subscribe_messaging_events();
+    node_A
+        .dht
+        .outbound_requester()
+        .send_raw(
+            params.clone(),
+            wrap_in_envelope_body!(secret_msg1.to_vec()).to_encoded_bytes(),
+        )
+        .await
+        .unwrap();
+    node_A
+        .dht
+        .outbound_requester()
+        .send_raw(params, wrap_in_envelope_body!(secret_msg2.to_vec()).to_encoded_bytes())
+        .await
+        .unwrap();
+
+    // Wait for node B to receive the 2 propagation messages
+    node_B_msg_events.next().await.unwrap().unwrap();
+    node_B_msg_events.next().await.unwrap().unwrap();
+
+    let mut node_C = make_node_with_node_identity(node_C_node_identity, None).await;
+    node_C.comms.peer_manager().add_peer(node_B.to_peer()).await.unwrap();
+    node_C.dht.dht_requester().send_request_stored_messages().await.unwrap();
+
+    let msg = node_C.next_inbound_message(Duration::from_secs(5)).await.unwrap();
+    assert_eq!(
+        msg.authenticated_origin.as_ref().unwrap(),
+        node_A.comms.node_identity().public_key()
+    );
+    let secret = msg.success().unwrap().decode_part::<Vec<u8>>(0).unwrap().unwrap();
+    assert_eq!(secret, secret_msg1.to_vec());
+    let msg = node_C.next_inbound_message(Duration::from_secs(5)).await.unwrap();
+    assert_eq!(
+        msg.authenticated_origin.as_ref().unwrap(),
+        node_A.comms.node_identity().public_key()
+    );
+    let secret = msg.success().unwrap().decode_part::<Vec<u8>>(0).unwrap().unwrap();
+    assert_eq!(secret, secret_msg2.to_vec());
+
+    node_A.comms.shutdown().await;
+    node_B.comms.shutdown().await;
+    node_C.comms.shutdown().await;
 }

--- a/comms/src/peer_manager/node_id.rs
+++ b/comms/src/peer_manager/node_id.rs
@@ -94,6 +94,21 @@ impl TryFrom<&[u8]> for NodeDistance {
     }
 }
 
+impl ByteArray for NodeDistance {
+    /// Try and convert the given byte array to a NodeDistance. Any failures (incorrect array length,
+    /// implementation-specific checks, etc) return a [ByteArrayError](enum.ByteArrayError.html).
+    fn from_bytes(bytes: &[u8]) -> Result<Self, ByteArrayError> {
+        bytes
+            .try_into()
+            .map_err(|err| ByteArrayError::ConversionError(format!("{:?}", err)))
+    }
+
+    /// Return the NodeDistance as a byte array
+    fn as_bytes(&self) -> &[u8] {
+        self.0.as_ref()
+    }
+}
+
 impl fmt::Display for NodeDistance {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", to_hex(&self.0))


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Storage and retreival of messages without an origin (PR #1686)
All private/anonymous messages are stored as low priority (short TTL)
messages.

- New response type `Anonymous` for store and forward query responses
- Added some more logging
- DHT store and forward integration test
- SAF messages can never be stored in store and forward


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Since messages can be completely private (no known source or destination) SAF needs to store and relay these messages.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Added a store and forward integration test

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [x] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [x] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch.
* [x] I ran `cargo-fmt --all` before pushing.
* [x] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
