### PR TITLE
MmrCache rewind issue

### DIFF
--- a/base_layer/mmr/src/mmr_cache.rs
+++ b/base_layer/mmr/src/mmr_cache.rs
@@ -172,8 +172,9 @@ where
             .checkpoints
             .len()
             .map_err(|e| MerkleMountainRangeError::BackendError(e.to_string()))?;
-        if cp_count < self.base_cp_index {
-            // Checkpoint before the base MMR index, this will require a full reconstruction of the cache.
+        if cp_count <= self.base_cp_index {
+            // Checkpoint before or the same as the base MMR index, this will require a full reconstruction of the
+            // cache.
             self.create_base_mmr()?;
             self.create_curr_mmr()?;
         } else if cp_count < self.curr_cp_index {


### PR DESCRIPTION
## Description
 Fixes an issue where if a large reorg occurs that rewinds the chain to the same height as the MmrCache base index then the base and current MMRs are not correctly updated resulting in incorrect Merkle and Merklish roots being generated.

## Motivation and Context
Fixes an off by one error where the MmrCache is not correctly updated when a rewind occurs to the same index as the base index.

## How Has This Been Tested?
Added the multiple_rewinds tests that demonstrate this behaviour, this test fails when the fix is not applied.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch.
* [x] I ran `cargo-fmt --all` before pushing.
* [x] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
