### PR TITLE
Added oneshot reply to outbound messaging

### DIFF
--- a/base_layer/core/src/base_node/service/service.rs
+++ b/base_layer/core/src/base_node/service/service.rs
@@ -463,7 +463,7 @@ async fn handle_outbound_request(
         .map_err(|e| CommsInterfaceError::OutboundMessageService(e.to_string()))?;
 
     match send_result.resolve_ok().await {
-        Some(tags) if tags.is_empty() => {
+        Some(send_states) if send_states.is_empty() => {
             let _ = reply_tx
                 .send(Err(CommsInterfaceError::NoBootstrapNodesConfigured))
                 .or_else(|resp| {

--- a/base_layer/core/src/mempool/service/service.rs
+++ b/base_layer/core/src/mempool/service/service.rs
@@ -432,7 +432,7 @@ async fn handle_outbound_request(
         .map_err(|e| MempoolServiceError::OutboundMessageService(e.to_string()))?;
 
     match send_result.resolve_ok().await {
-        Some(tags) if !tags.is_empty() => {
+        Some(send_states) if !send_states.is_empty() => {
             // Spawn timeout and wait for matching response to arrive
             waiting_requests.insert(request_key, Some(reply_tx))?;
             // Spawn timeout for waiting_request

--- a/base_layer/p2p/src/services/liveness/service.rs
+++ b/base_layer/p2p/src/services/liveness/service.rs
@@ -494,7 +494,7 @@ mod test {
         task::spawn(async move {
             match outbound_rx.select_next_some().await {
                 DhtOutboundRequest::SendMessage(_, _, reply_tx) => {
-                    reply_tx.send(SendMessageResponse::Queued(vec![])).unwrap();
+                    reply_tx.send(SendMessageResponse::Queued(vec![].into())).unwrap();
                 },
             }
         });

--- a/base_layer/p2p/src/test_utils.rs
+++ b/base_layer/p2p/src/test_utils.rs
@@ -43,7 +43,7 @@ macro_rules! unwrap_oms_send_msg {
     ($var:expr) => {
         unwrap_oms_send_msg!(
             $var,
-            reply_value = tari_comms_dht::outbound::SendMessageResponse::Queued(vec![])
+            reply_value = tari_comms_dht::outbound::SendMessageResponse::Queued(vec![].into())
         );
     };
 }

--- a/base_layer/wallet/src/transaction_service/protocols/transaction_send_protocol.rs
+++ b/base_layer/wallet/src/transaction_service/protocols/transaction_send_protocol.rs
@@ -292,16 +292,16 @@ where TBackend: TransactionBackend + Clone + 'static
                         .send(Arc::new(TransactionEvent::TransactionDirectSendResult(tx_id, false)));
                     error!(target: LOG_TARGET, "Transaction Send directly to recipient failed");
                 },
-                Some(tags) if tags.len() == 1 => {
+                Some(send_states) if send_states.len() == 1 => {
                     info!(
                         target: LOG_TARGET,
                         "Transaction (TxId: {}) Direct Send to {} successful with Message Tag: {:?}",
                         tx_id,
                         self.dest_pubkey,
-                        tags[0],
+                        send_states[0].tag,
                     );
                     direct_send_success = true;
-                    let message_tag = tags[0];
+                    let message_tag = send_states[0].tag;
                     let event_publisher = self.resources.event_publisher.clone();
                     // Launch a task to monitor if the message gets sent
                     if let Some(mut message_event_receiver) = self.message_send_event_receiver.take() {

--- a/comms/dht/src/discovery/error.rs
+++ b/comms/dht/src/discovery/error.rs
@@ -40,6 +40,8 @@ pub enum DhtDiscoveryError {
     SendBufferFull,
     /// The discovery request timed out
     DiscoveryTimeout,
+    /// Failed to send discovery message
+    DiscoverySendFailed,
     PeerManagerError(PeerManagerError),
     #[error(msg_embedded, non_std, no_from)]
     InvalidPeerMultiaddr(String),

--- a/comms/dht/src/outbound/message_send_state.rs
+++ b/comms/dht/src/outbound/message_send_state.rs
@@ -1,0 +1,230 @@
+// Copyright 2020, The Tari Project
+//
+// Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+// following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+// disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+// following disclaimer in the documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+// products derived from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+// INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+// WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+// USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+use futures::{stream::FuturesUnordered, Future, StreamExt};
+use std::ops::Index;
+use tari_comms::message::{MessageTag, MessagingReplyRx};
+
+#[derive(Debug)]
+pub struct MessageSendState {
+    pub tag: MessageTag,
+    reply_rx: MessagingReplyRx,
+}
+impl MessageSendState {
+    pub fn new(tag: MessageTag, reply_rx: MessagingReplyRx) -> Self {
+        Self { tag, reply_rx }
+    }
+}
+
+#[derive(Debug)]
+pub struct MessageSendStates {
+    inner: Vec<MessageSendState>,
+}
+
+impl MessageSendStates {
+    /// The number of `MessageSendState`s held in this container
+    #[inline]
+    pub fn len(&self) -> usize {
+        self.inner.len()
+    }
+
+    /// Returns true if there are no send states held in this container, otherwise false
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    /// Wait for all send results to return. The return value contains the successful messages sent and the failed
+    /// messages respectively
+    pub async fn wait_all(self) -> (Vec<MessageTag>, Vec<MessageTag>) {
+        let mut succeeded = Vec::new();
+        let mut failed = Vec::new();
+        let mut unordered = self.into_futures_unordered();
+        while let Some((tag, result)) = unordered.next().await {
+            match result {
+                Ok(_) => {
+                    succeeded.push(tag);
+                },
+                Err(_) => {
+                    failed.push(tag);
+                },
+            }
+        }
+
+        (succeeded, failed)
+    }
+
+    /// Wait for a certain percentage of successful sends
+    pub async fn wait_percentage_success(self, threshold_perc: f32) -> (Vec<MessageTag>, Vec<MessageTag>) {
+        if self.is_empty() {
+            return (Vec::new(), Vec::new());
+        }
+        let total = self.len();
+        let mut count = 0;
+
+        let mut unordered = self.into_futures_unordered();
+        let mut succeeded = Vec::new();
+        let mut failed = Vec::new();
+        loop {
+            match unordered.next().await {
+                Some((tag, result)) => {
+                    match result {
+                        Ok(_) => {
+                            count += 1;
+                            succeeded.push(tag);
+                        },
+                        Err(_) => {
+                            failed.push(tag);
+                        },
+                    }
+                    if (count as f32) / (total as f32) >= threshold_perc {
+                        break;
+                    }
+                },
+                None => {
+                    break;
+                },
+            }
+        }
+
+        (succeeded, failed)
+    }
+
+    /// Wait for the result of a single send. This should not be used when this container contains multiple send states.
+    ///
+    /// ## Panics
+    ///
+    /// This function expects there to be exactly one MessageSendState contained in this object and will
+    /// panic in debug mode if this expectation is not met. It will panic for release builds if called
+    /// when empty.
+    pub async fn wait_single(mut self) -> bool {
+        let state = self
+            .inner
+            .pop()
+            .expect("wait_single called when MessageSendStates::len() is 0");
+
+        debug_assert!(
+            self.is_empty(),
+            "MessageSendStates::wait_single called with multiple message send states"
+        );
+
+        state
+            .reply_rx
+            .await
+            .expect("oneshot should never be canceled before sending")
+            .is_ok()
+    }
+
+    pub fn into_futures_unordered(self) -> FuturesUnordered<impl Future<Output = (MessageTag, Result<(), ()>)>> {
+        let unordered = FuturesUnordered::new();
+        self.inner.into_iter().for_each(|state| {
+            unordered.push(async move {
+                match state.reply_rx.await {
+                    Ok(result) => (state.tag, result),
+                    // Somewhere the reply sender was dropped without first sending a reply
+                    // This should never happen because we if the wrapped oneshot is dropped it sends an Err(())
+                    Err(_) => unreachable!(),
+                }
+            });
+        });
+
+        unordered
+    }
+}
+
+impl From<Vec<MessageSendState>> for MessageSendStates {
+    fn from(inner: Vec<MessageSendState>) -> Self {
+        Self { inner }
+    }
+}
+
+impl Index<usize> for MessageSendStates {
+    type Output = MessageSendState;
+
+    fn index(&self, index: usize) -> &Self::Output {
+        &self.inner[index]
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use bitflags::_core::iter::repeat_with;
+    use futures::channel::oneshot;
+    use tari_comms::message::MessagingReplyTx;
+
+    fn create_send_state() -> (MessageSendState, MessagingReplyTx) {
+        let (reply_tx, reply_rx) = oneshot::channel();
+        let state = MessageSendState::new(MessageTag::new(), reply_rx);
+        (state, reply_tx)
+    }
+
+    #[test]
+    fn is_empty() {
+        let states = MessageSendStates::from(vec![]);
+        assert!(states.is_empty());
+        let (state, _) = create_send_state();
+        let states = MessageSendStates::from(vec![state]);
+        assert_eq!(states.is_empty(), false);
+    }
+
+    #[tokio_macros::test_basic]
+    async fn wait_single() {
+        let (state, reply_tx) = create_send_state();
+        let states = MessageSendStates::from(vec![state]);
+        reply_tx.send(Ok(())).unwrap();
+        assert_eq!(states.len(), 1);
+        assert_eq!(states.wait_single().await, true);
+
+        let (state, reply_tx) = create_send_state();
+        let states = MessageSendStates::from(vec![state]);
+        reply_tx.send(Err(())).unwrap();
+        assert_eq!(states.len(), 1);
+        assert_eq!(states.wait_single().await, false);
+    }
+
+    #[tokio_macros::test_basic]
+    async fn wait_percentage_success() {
+        let states = repeat_with(|| create_send_state()).take(10).collect::<Vec<_>>();
+        let (states, mut reply_txs) = states.into_iter().unzip::<_, _, Vec<_>, Vec<_>>();
+        let states = MessageSendStates::from(states);
+        reply_txs.drain(..4).for_each(|tx| tx.send(Err(())).unwrap());
+        reply_txs.drain(..).for_each(|tx| tx.send(Ok(())).unwrap());
+
+        let (success, failed) = states.wait_percentage_success(0.3).await;
+        assert_eq!(success.len(), 3);
+        assert_eq!(failed.len(), 4);
+    }
+
+    #[tokio_macros::test_basic]
+    async fn wait_all() {
+        let states = repeat_with(|| create_send_state()).take(10).collect::<Vec<_>>();
+        let (states, mut reply_txs) = states.into_iter().unzip::<_, _, Vec<_>, Vec<_>>();
+        let states = MessageSendStates::from(states);
+        reply_txs.drain(..4).for_each(|tx| tx.send(Err(())).unwrap());
+        reply_txs.drain(..).for_each(|tx| tx.send(Ok(())).unwrap());
+
+        let (success, failed) = states.wait_all().await;
+        assert_eq!(success.len(), 6);
+        assert_eq!(failed.len(), 4);
+    }
+}

--- a/comms/dht/src/outbound/mod.rs
+++ b/comms/dht/src/outbound/mod.rs
@@ -35,6 +35,8 @@ pub use message::{DhtOutboundRequest, OutboundEncryption, SendMessageResponse};
 mod message_params;
 pub use message_params::SendMessageParams;
 
+mod message_send_state;
+
 mod requester;
 pub use requester::OutboundMessageRequester;
 

--- a/comms/dht/src/outbound/serialize.rs
+++ b/comms/dht/src/outbound/serialize.rs
@@ -77,6 +77,7 @@ where S: Service<OutboundMessage, Response = (), Error = PipelineError> + Clone 
                 network,
                 dht_flags,
                 origin_mac,
+                reply_tx,
                 ..
             } = message;
 
@@ -95,7 +96,12 @@ where S: Service<OutboundMessage, Response = (), Error = PipelineError> + Clone 
             let body = Bytes::from(envelope.to_encoded_bytes());
 
             next_service
-                .oneshot(OutboundMessage::with_tag(tag, destination_peer.node_id, body))
+                .oneshot(OutboundMessage {
+                    tag,
+                    peer_node_id: destination_peer.node_id,
+                    reply_tx: reply_tx.into_inner(),
+                    body,
+                })
                 .await
         }
     }

--- a/comms/dht/src/store_forward/saf_handler/task.rs
+++ b/comms/dht/src/store_forward/saf_handler/task.rs
@@ -61,7 +61,7 @@ use tari_comms::{
 use tari_crypto::tari_utilities::ByteArray;
 use tower::{Service, ServiceExt};
 
-const LOG_TARGET: &str = "comms::dht::store_forward";
+const LOG_TARGET: &str = "comms::dht::store_forward::handler";
 
 pub struct MessageHandlerTask<S> {
     config: DhtConfig,

--- a/comms/dht/src/store_forward/store.rs
+++ b/comms/dht/src/store_forward/store.rs
@@ -43,7 +43,7 @@ use tari_comms::{
 use tari_crypto::tari_utilities::ByteArray;
 use tower::{layer::Layer, Service, ServiceExt};
 
-const LOG_TARGET: &str = "comms::middleware::forward";
+const LOG_TARGET: &str = "comms::dht::storeforward::store";
 
 /// This layer is responsible for storing messages which have failed to decrypt
 pub struct StoreLayer {

--- a/comms/dht/src/test_utils/makers.rs
+++ b/comms/dht/src/test_utils/makers.rs
@@ -23,7 +23,7 @@ use crate::{
     crypt,
     envelope::{DhtMessageFlags, DhtMessageHeader, NodeDestination},
     inbound::DhtInboundMessage,
-    outbound::message::DhtOutboundMessage,
+    outbound::message::{DhtOutboundMessage, WrappedReplyTx},
     proto::envelope::{DhtEnvelope, DhtMessageType, Network, OriginMac},
 };
 use rand::rngs::OsRng;
@@ -219,6 +219,7 @@ pub fn create_outbound_message(body: &[u8]) -> DhtOutboundMessage {
         encryption: Default::default(),
         body: body.to_vec().into(),
         ephemeral_public_key: None,
+        reply_tx: WrappedReplyTx::none(),
         origin_mac: None,
     }
 }

--- a/comms/dht/src/test_utils/mod.rs
+++ b/comms/dht/src/test_utils/mod.rs
@@ -32,7 +32,7 @@ macro_rules! unwrap_oms_send_msg {
     ($var:expr) => {
         unwrap_oms_send_msg!(
             $var,
-            reply_value = $crate::outbound::SendMessageResponse::Queued(vec![])
+            reply_value = $crate::outbound::SendMessageResponse::Queued(vec![].into())
         );
     };
 }

--- a/comms/src/message/mod.rs
+++ b/comms/src/message/mod.rs
@@ -71,7 +71,7 @@ mod inbound;
 pub use inbound::InboundMessage;
 
 mod outbound;
-pub use outbound::OutboundMessage;
+pub use outbound::{MessagingReplyRx, MessagingReplyTx, OutboundMessage};
 
 mod tag;
 pub use tag::MessageTag;

--- a/comms/src/protocol/messaging/error.rs
+++ b/comms/src/protocol/messaging/error.rs
@@ -22,7 +22,7 @@
 
 use crate::{
     connection_manager::PeerConnectionError,
-    message::{MessageError, OutboundMessage},
+    message::MessageError,
     peer_manager::PeerManagerError,
     protocol::ProtocolError,
 };
@@ -39,7 +39,7 @@ pub enum InboundMessagingError {
 pub enum MessagingProtocolError {
     /// Failed to send message
     #[error(no_from, non_std)]
-    MessageSendFailed(OutboundMessage), // Msg returned to sender
+    MessageSendFailed,
     ProtocolError(ProtocolError),
     PeerConnectionError(PeerConnectionError),
     /// Failed to dial peer


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Each message sent using outbound messaging now has a oneshot attached.
A success or failure result is guaranteed to be sent back on the oneshot
for every message sent.

Convenience functions were added to allow callers to easily know the
state of each message sent.

```rust
let send_states =
outbound_messaging_requester.propagate(...).await?.reolve_ok().await?;

let num_queued = send_states.len();
println!("{} message queued for sending", num_queued);
let (success, failed) = send_states.wait_percentage_success(0.51).await;
println!("Message sent to a majority of nodes ({} succeeded, {} failed)",succeeded.len(), failed.len())
// or (wait_* consumes send_states)
let (success, failed) = send_states.wait_all().await;
println!("Result of the propagation: {} succeeded, {} failed", succeeded.len(), failed.len())
```

This was implemented with minimal breaking changes to the public
outbound messaging api.

- Fixed bug where a repeated failure to connect to a peer did not
  result in the peer being marked as offline.
- Limited the number of client peers propagated to when sending inital
  discovery to those within this node's region.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The only way to know that a message was actually sent or not was to listen on the messaging event stream and sift through until you find your message tags. This change provides a way to know if a message was sent or not with a MessageSendStates struct returned from the send call. To limit breaking changes, the api may not be as ergonomic as it could be. This is a TODO.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Unit tested MessageSendStates and updated some existing tests that test the messaging protocol.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [x] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [x] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch.
* [x] I ran `cargo-fmt --all` before pushing.
* [x] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
