### PR TITLE
Update wallet to support sending Tx via Store and Forward

### DIFF
--- a/applications/tari_base_node/src/utils.rs
+++ b/applications/tari_base_node/src/utils.rs
@@ -40,7 +40,7 @@ where S: Stream<Item = Result<Arc<TransactionEvent>, RecvError>> + Unpin {
         match event_stream.next().await {
             Some(event_result) => match event_result {
                 Ok(event) => {
-                    if let TransactionEvent::TransactionSendDiscoveryComplete(tx_id, is_success) = &*event {
+                    if let TransactionEvent::TransactionDirectSendResult(tx_id, is_success) = &*event {
                         if *tx_id == expected_tx_id {
                             break *is_success;
                         }

--- a/base_layer/wallet/src/testnet_utils.rs
+++ b/base_layer/wallet/src/testnet_utils.rs
@@ -134,7 +134,7 @@ pub fn create_wallet(
         max_concurrent_inbound_tasks: 100,
         outbound_buffer_size: 100,
         dht: DhtConfig {
-            discovery_request_timeout: Duration::from_millis(500),
+            discovery_request_timeout: Duration::from_secs(30),
             ..Default::default()
         },
         allow_test_addresses: true,
@@ -288,6 +288,7 @@ pub fn generate_wallet_test_data<
     wallet
         .runtime
         .block_on(wallet.comms.peer_manager().add_peer(alice_peer))?;
+
     let bob_peer = wallet_bob.comms.node_identity().to_peer();
 
     wallet
@@ -449,7 +450,7 @@ pub fn generate_wallet_test_data<
             futures::select! {
                 event = wallet_event_stream.select_next_some() => {
                     match &*event.unwrap() {
-                        TransactionEvent::TransactionSendResult(_,_) => {
+                        TransactionEvent::TransactionDirectSendResult(_,_) => {
                             count+=1;
                             if count >= 10 {
                                 break;
@@ -495,7 +496,7 @@ pub fn generate_wallet_test_data<
         }
         assert!(count >= 8, "Event waiting timed out before receiving expected events 3");
     });
-
+    log::error!("Inbound Transactions starting");
     // Pending Inbound
     wallet_alice
         .runtime

--- a/base_layer/wallet/src/transaction_service/error.rs
+++ b/base_layer/wallet/src/transaction_service/error.rs
@@ -83,6 +83,8 @@ pub enum TransactionServiceError {
     UnexpectedMempoolResponse,
     /// Base Node response key does not match on that is expected
     UnexpectedBaseNodeResponse,
+    /// The current transaction has been cancelled
+    TransactionCancelled,
     DhtOutboundError(DhtOutboundError),
     OutputManagerError(OutputManagerError),
     TransportChannelError(TransportChannelError),

--- a/base_layer/wallet/src/transaction_service/protocols/transaction_broadcast_protocol.rs
+++ b/base_layer/wallet/src/transaction_service/protocols/transaction_broadcast_protocol.rs
@@ -297,9 +297,7 @@ where TBackend: TransactionBackend + Clone + 'static
                             let _ = self
                                 .resources
                                 .event_publisher
-                                .send(Arc::new(TransactionEvent::TransactionSendDiscoveryComplete(
-                                    self.id, false,
-                                )))
+                                .send(Arc::new(TransactionEvent::TransactionCancelled(self.id)))
                                 .map_err(|e| {
                                     trace!(
                                         target: LOG_TARGET,

--- a/base_layer/wallet/src/transaction_service/protocols/transaction_chain_monitoring_protocol.rs
+++ b/base_layer/wallet/src/transaction_service/protocols/transaction_chain_monitoring_protocol.rs
@@ -343,10 +343,7 @@ where TBackend: TransactionBackend + Clone + 'static
                             let _ = self
                                 .resources
                                 .event_publisher
-                                .send(Arc::new(TransactionEvent::TransactionSendDiscoveryComplete(
-                                    completed_tx.tx_id,
-                                    false,
-                                )))
+                                .send(Arc::new(TransactionEvent::TransactionCancelled(self.id)))
                                 .map_err(|e| {
                                     trace!(
                                         target: LOG_TARGET,

--- a/base_layer/wallet/tests/wallet/mod.rs
+++ b/base_layer/wallet/tests/wallet/mod.rs
@@ -28,14 +28,15 @@ use tari_comms::{
     peer_manager::{NodeId, NodeIdentity, Peer, PeerFeatures, PeerFlags},
     types::CommsPublicKey,
 };
-#[cfg(feature = "test_harness")]
 use tari_comms_dht::DhtConfig;
 use tari_core::transactions::{tari_amount::MicroTari, types::CryptoFactories};
 use tari_crypto::keys::PublicKey;
 use tari_p2p::initialization::CommsConfig;
-use tari_test_utils::{collect_stream, paths::with_temp_dir};
+use tari_test_utils::paths::with_temp_dir;
 
 use crate::support::comms_and_services::get_next_memory_address;
+use futures::{FutureExt, StreamExt};
+use std::path::Path;
 use tari_core::transactions::{tari_amount::uT, transaction::UnblindedOutput, types::PrivateKey};
 use tari_p2p::transport::TransportType;
 use tari_wallet::{
@@ -47,7 +48,7 @@ use tari_wallet::{
     Wallet,
 };
 use tempdir::TempDir;
-use tokio::runtime::Runtime;
+use tokio::{runtime::Runtime, time::delay_for};
 
 fn create_peer(public_key: CommsPublicKey, net_address: Multiaddr) -> Peer {
     Peer::new(
@@ -60,91 +61,62 @@ fn create_peer(public_key: CommsPublicKey, net_address: Multiaddr) -> Peer {
     )
 }
 
+fn create_wallet(
+    node_identity: NodeIdentity,
+    data_path: &Path,
+    factories: CryptoFactories,
+) -> Wallet<WalletMemoryDatabase, TransactionMemoryDatabase, OutputManagerMemoryDatabase, ContactsServiceMemoryDatabase>
+{
+    let comms_config = CommsConfig {
+        node_identity: Arc::new(node_identity.clone()),
+        transport_type: TransportType::Memory {
+            listener_address: node_identity.public_address(),
+        },
+        datastore_path: data_path.to_path_buf(),
+        peer_database_name: random_string(8),
+        max_concurrent_inbound_tasks: 100,
+        outbound_buffer_size: 100,
+        dht: DhtConfig {
+            discovery_request_timeout: Duration::from_secs(1),
+            ..Default::default()
+        },
+        allow_test_addresses: true,
+        listener_liveness_whitelist_cidrs: Vec::new(),
+        listener_liveness_max_sessions: 0,
+    };
+    let config = WalletConfig {
+        comms_config,
+        factories,
+        transaction_service_config: None,
+    };
+    let runtime_node = Runtime::new().unwrap();
+    let wallet = Wallet::new(
+        config,
+        runtime_node,
+        WalletMemoryDatabase::new(),
+        TransactionMemoryDatabase::new(),
+        OutputManagerMemoryDatabase::new(),
+        ContactsServiceMemoryDatabase::new(),
+    )
+    .unwrap();
+    wallet
+}
+
 #[test]
 fn test_wallet() {
     with_temp_dir(|dir_path| {
         let mut runtime = Runtime::new().unwrap();
         let factories = CryptoFactories::default();
-        let alice_identity = NodeIdentity::random(
-            &mut OsRng,
-            "/ip4/127.0.0.1/tcp/22523".parse().unwrap(),
-            PeerFeatures::COMMUNICATION_NODE,
-        )
-        .unwrap();
-        let bob_identity = NodeIdentity::random(
-            &mut OsRng,
-            "/ip4/127.0.0.1/tcp/22145".parse().unwrap(),
-            PeerFeatures::COMMUNICATION_NODE,
-        )
-        .unwrap();
+        let alice_identity =
+            NodeIdentity::random(&mut OsRng, get_next_memory_address(), PeerFeatures::COMMUNICATION_NODE).unwrap();
+        let bob_identity =
+            NodeIdentity::random(&mut OsRng, get_next_memory_address(), PeerFeatures::COMMUNICATION_NODE).unwrap();
 
-        let base_node_identity = NodeIdentity::random(
-            &mut OsRng,
-            "/ip4/127.0.0.1/tcp/54225".parse().unwrap(),
-            PeerFeatures::COMMUNICATION_NODE,
-        )
-        .unwrap();
+        let base_node_identity =
+            NodeIdentity::random(&mut OsRng, get_next_memory_address(), PeerFeatures::COMMUNICATION_NODE).unwrap();
 
-        let comms_config1 = CommsConfig {
-            node_identity: Arc::new(alice_identity.clone()),
-            transport_type: TransportType::Tcp {
-                listener_address: alice_identity.public_address(),
-                tor_socks_config: None,
-            },
-            datastore_path: dir_path.to_path_buf(),
-            peer_database_name: random_string(8),
-            max_concurrent_inbound_tasks: 100,
-            outbound_buffer_size: 100,
-            dht: Default::default(),
-            allow_test_addresses: true,
-            listener_liveness_whitelist_cidrs: Vec::new(),
-            listener_liveness_max_sessions: 0,
-        };
-        let comms_config2 = CommsConfig {
-            node_identity: Arc::new(bob_identity.clone()),
-            transport_type: TransportType::Tcp {
-                listener_address: bob_identity.public_address(),
-                tor_socks_config: None,
-            },
-            datastore_path: dir_path.to_path_buf(),
-            peer_database_name: random_string(8),
-            max_concurrent_inbound_tasks: 100,
-            outbound_buffer_size: 100,
-            dht: Default::default(),
-            allow_test_addresses: true,
-            listener_liveness_whitelist_cidrs: Vec::new(),
-            listener_liveness_max_sessions: 0,
-        };
-        let config1 = WalletConfig {
-            comms_config: comms_config1,
-            factories: factories.clone(),
-            transaction_service_config: None,
-        };
-        let config2 = WalletConfig {
-            comms_config: comms_config2,
-            factories: factories.clone(),
-            transaction_service_config: None,
-        };
-        let runtime_node1 = Runtime::new().unwrap();
-        let runtime_node2 = Runtime::new().unwrap();
-        let mut alice_wallet = Wallet::new(
-            config1,
-            runtime_node1,
-            WalletMemoryDatabase::new(),
-            TransactionMemoryDatabase::new(),
-            OutputManagerMemoryDatabase::new(),
-            ContactsServiceMemoryDatabase::new(),
-        )
-        .unwrap();
-        let mut bob_wallet = Wallet::new(
-            config2,
-            runtime_node2,
-            WalletMemoryDatabase::new(),
-            TransactionMemoryDatabase::new(),
-            OutputManagerMemoryDatabase::new(),
-            ContactsServiceMemoryDatabase::new(),
-        )
-        .unwrap();
+        let mut alice_wallet = create_wallet(alice_identity.clone(), dir_path, factories.clone());
+        let mut bob_wallet = create_wallet(bob_identity.clone(), dir_path, factories.clone());
 
         alice_wallet
             .runtime
@@ -169,7 +141,7 @@ fn test_wallet() {
             )
             .unwrap();
 
-        let alice_event_stream = alice_wallet.transaction_service.get_event_stream_fused();
+        let mut alice_event_stream = alice_wallet.transaction_service.get_event_stream_fused();
 
         let value = MicroTari::from(1000);
         let (_utxo, uo1) = make_input(&mut OsRng, MicroTari(2500), &factories.commitment);
@@ -187,17 +159,26 @@ fn test_wallet() {
             ))
             .unwrap();
 
-        let result_stream = runtime
-            .block_on(async { collect_stream!(alice_event_stream, take = 2, timeout = Duration::from_secs(10)) });
-        let received_transaction_reply_count = result_stream.iter().fold(0, |acc, x| match &**(*x).as_ref().unwrap() {
-            TransactionEvent::ReceivedTransactionReply(_) => acc + 1,
-            _ => acc,
-        });
+        runtime.block_on(async {
+            let mut delay = delay_for(Duration::from_secs(60)).fuse();
+            let mut reply_count = false;
+            loop {
+                futures::select! {
+                    event = alice_event_stream.select_next_some() => match &*event.unwrap() {
+                            TransactionEvent::ReceivedTransactionReply(_) => {
+                                reply_count = true;
+                                break;
+                            },
+                            _ => (),
+                        },
 
-        assert_eq!(
-            received_transaction_reply_count, 1,
-            "Did not received correct numebr of replies"
-        );
+                    () = delay => {
+                        break;
+                    },
+                }
+            }
+            assert!(reply_count);
+        });
 
         let mut contacts = Vec::new();
         for i in 0..2 {
@@ -216,6 +197,106 @@ fn test_wallet() {
         let got_contacts = runtime.block_on(alice_wallet.contacts_service.get_contacts()).unwrap();
         assert_eq!(contacts, got_contacts);
     });
+}
+
+#[test]
+fn test_store_and_forward_send_tx() {
+    let factories = CryptoFactories::default();
+    let db_tempdir = TempDir::new(random_string(8).as_str()).unwrap();
+
+    let alice_identity =
+        NodeIdentity::random(&mut OsRng, get_next_memory_address(), PeerFeatures::COMMUNICATION_NODE).unwrap();
+    let bob_identity =
+        NodeIdentity::random(&mut OsRng, get_next_memory_address(), PeerFeatures::COMMUNICATION_NODE).unwrap();
+    let carol_identity =
+        NodeIdentity::random(&mut OsRng, get_next_memory_address(), PeerFeatures::COMMUNICATION_NODE).unwrap();
+
+    let mut alice_wallet = create_wallet(alice_identity.clone(), &db_tempdir.path(), factories.clone());
+    let mut bob_wallet = create_wallet(bob_identity.clone(), &db_tempdir.path(), factories.clone());
+    let mut alice_event_stream = alice_wallet.transaction_service.get_event_stream_fused();
+
+    alice_wallet
+        .runtime
+        .block_on(alice_wallet.comms.peer_manager().add_peer(create_peer(
+            bob_identity.public_key().clone(),
+            bob_identity.public_address(),
+        )))
+        .unwrap();
+
+    bob_wallet
+        .runtime
+        .block_on(bob_wallet.comms.peer_manager().add_peer(create_peer(
+            alice_identity.public_key().clone(),
+            alice_identity.public_address(),
+        )))
+        .unwrap();
+
+    bob_wallet
+        .runtime
+        .block_on(bob_wallet.comms.peer_manager().add_peer(create_peer(
+            carol_identity.public_key().clone(),
+            carol_identity.public_address(),
+        )))
+        .unwrap();
+
+    let value = MicroTari::from(1000);
+    let (_utxo, uo1) = make_input(&mut OsRng, MicroTari(2500), &factories.commitment);
+
+    alice_wallet
+        .runtime
+        .block_on(alice_wallet.output_manager_service.add_output(uo1))
+        .unwrap();
+
+    alice_wallet
+        .runtime
+        .block_on(alice_wallet.transaction_service.send_transaction(
+            carol_identity.public_key().clone(),
+            value,
+            MicroTari::from(20),
+            "Store and Forward!".to_string(),
+        ))
+        .unwrap();
+
+    // Waiting here for a while to make sure the discovery retry is over
+    alice_wallet
+        .runtime
+        .block_on(async { delay_for(Duration::from_secs(10)).await });
+
+    let mut carol_wallet = create_wallet(carol_identity.clone(), &db_tempdir.path(), factories.clone());
+
+    carol_wallet
+        .runtime
+        .block_on(carol_wallet.comms.peer_manager().add_peer(create_peer(
+            bob_identity.public_key().clone(),
+            bob_identity.public_address(),
+        )))
+        .unwrap();
+
+    alice_wallet.runtime.block_on(async {
+        let mut delay = delay_for(Duration::from_secs(60)).fuse();
+        let mut tx_reply = 0;
+        loop {
+            futures::select! {
+                event = alice_event_stream.select_next_some() => {
+                    match &*event.unwrap() {
+                        TransactionEvent::ReceivedTransactionReply(_) => tx_reply+=1,
+                        _ => (),
+                    }
+                    if tx_reply == 1 {
+                        break;
+                    }
+                },
+                () = delay => {
+                    break;
+                },
+            }
+        }
+        assert_eq!(tx_reply, 1, "Must have received a reply from Carol");
+    });
+
+    alice_wallet.shutdown();
+    bob_wallet.shutdown();
+    carol_wallet.shutdown();
 }
 
 #[test]

--- a/base_layer/wallet_ffi/src/callback_handler.rs
+++ b/base_layer/wallet_ffi/src/callback_handler.rs
@@ -70,7 +70,9 @@ where TBackend: TransactionBackend + 'static
     callback_received_finalized_transaction: unsafe extern "C" fn(*mut CompletedTransaction),
     callback_transaction_broadcast: unsafe extern "C" fn(*mut CompletedTransaction),
     callback_transaction_mined: unsafe extern "C" fn(*mut CompletedTransaction),
-    callback_discovery_process_complete: unsafe extern "C" fn(TxId, bool),
+    callback_direct_send_result: unsafe extern "C" fn(TxId, bool),
+    callback_store_and_forward_send_result: unsafe extern "C" fn(TxId, bool),
+    callback_transaction_cancellation: unsafe extern "C" fn(TxId),
     callback_base_node_sync_complete: unsafe extern "C" fn(TxId, bool),
     db: TransactionDatabase<TBackend>,
     transaction_service_event_stream: Fuse<TransactionEventReceiver>,
@@ -92,7 +94,9 @@ where TBackend: TransactionBackend + 'static
         callback_received_finalized_transaction: unsafe extern "C" fn(*mut CompletedTransaction),
         callback_transaction_broadcast: unsafe extern "C" fn(*mut CompletedTransaction),
         callback_transaction_mined: unsafe extern "C" fn(*mut CompletedTransaction),
-        callback_discovery_process_complete: unsafe extern "C" fn(TxId, bool),
+        callback_direct_send_result: unsafe extern "C" fn(TxId, bool),
+        callback_store_and_forward_send_result: unsafe extern "C" fn(TxId, bool),
+        callback_transaction_cancellation: unsafe extern "C" fn(TxId),
         callback_base_node_sync_complete: unsafe extern "C" fn(u64, bool),
     ) -> Self
     {
@@ -118,7 +122,15 @@ where TBackend: TransactionBackend + 'static
         );
         info!(
             target: LOG_TARGET,
-            "DiscoveryProcessCompleteCallback -> Assigning Fn:  {:?}", callback_discovery_process_complete
+            "DirectSendResultCallback -> Assigning Fn:  {:?}", callback_direct_send_result
+        );
+        info!(
+            target: LOG_TARGET,
+            "StoreAndForwardSendResultCallback -> Assigning Fn:  {:?}", callback_store_and_forward_send_result
+        );
+        info!(
+            target: LOG_TARGET,
+            "TransactionCancellationCallback -> Assigning Fn:  {:?}", callback_transaction_cancellation
         );
         info!(
             target: LOG_TARGET,
@@ -131,7 +143,9 @@ where TBackend: TransactionBackend + 'static
             callback_received_finalized_transaction,
             callback_transaction_broadcast,
             callback_transaction_mined,
-            callback_discovery_process_complete,
+            callback_direct_send_result,
+            callback_store_and_forward_send_result,
+            callback_transaction_cancellation,
             callback_base_node_sync_complete,
             db,
             transaction_service_event_stream,
@@ -164,23 +178,20 @@ where TBackend: TransactionBackend + 'static
                                 TransactionEvent::ReceivedFinalizedTransaction(tx_id) => {
                                     self.receive_finalized_transaction_event(tx_id).await;
                                 },
-                                TransactionEvent::TransactionSendDiscoveryComplete(tx_id, result) => {
-                                    // If this event result is false we will return that result via the callback as
-                                    // no further action will be taken on this send attempt. However if it is true
-                                    // then we must wait for a `TransactionSendResult` which
-                                    // will tell us the final result of the send
-                                    if !result {
-                                        self.receive_discovery_process_result(tx_id, result);
-                                    }
+                                TransactionEvent::TransactionDirectSendResult(tx_id, result) => {
+                                    self.receive_direct_send_result(tx_id, result);
+                                },
+                                TransactionEvent::TransactionStoreForwardSendResult(tx_id, result) => {
+                                    self.receive_store_and_forward_send_result(tx_id, result);
+                                },
+                                 TransactionEvent::TransactionCancelled(tx_id) => {
+                                    self.receive_transaction_cancellation(tx_id);
                                 },
                                 TransactionEvent::TransactionBroadcast(tx_id) => {
                                     self.receive_transaction_broadcast_event(tx_id).await;
                                 },
                                 TransactionEvent::TransactionMined(tx_id) => {
                                     self.receive_transaction_mined_event(tx_id).await;
-                                },
-                                TransactionEvent::TransactionSendResult(tx_id, result) => {
-                                    self.receive_discovery_process_result(tx_id, result);
                                 },
                                 /// Only the above variants are mapped to callbacks
                                 _ => (),
@@ -265,13 +276,33 @@ where TBackend: TransactionBackend + 'static
         }
     }
 
-    fn receive_discovery_process_result(&mut self, tx_id: TxId, result: bool) {
+    fn receive_direct_send_result(&mut self, tx_id: TxId, result: bool) {
         debug!(
             target: LOG_TARGET,
-            "Calling Discovery Process Completed callback function for TxId: {} with result {}", tx_id, result
+            "Calling Direct Send Result callback function for TxId: {} with result {}", tx_id, result
         );
         unsafe {
-            (self.callback_discovery_process_complete)(tx_id, result);
+            (self.callback_direct_send_result)(tx_id, result);
+        }
+    }
+
+    fn receive_store_and_forward_send_result(&mut self, tx_id: TxId, result: bool) {
+        debug!(
+            target: LOG_TARGET,
+            "Calling Store and Forward Send Result callback function for TxId: {} with result {}", tx_id, result
+        );
+        unsafe {
+            (self.callback_store_and_forward_send_result)(tx_id, result);
+        }
+    }
+
+    fn receive_transaction_cancellation(&mut self, tx_id: TxId) {
+        debug!(
+            target: LOG_TARGET,
+            "Calling Transaction Cancellation callback function for TxId: {}", tx_id
+        );
+        unsafe {
+            (self.callback_transaction_cancellation)(tx_id);
         }
     }
 

--- a/base_layer/wallet_ffi/wallet.h
+++ b/base_layer/wallet_ffi/wallet.h
@@ -340,7 +340,9 @@ struct TariWallet *wallet_create(struct TariWalletConfig *config,
                                     void (*callback_received_finalized_transaction)(struct TariCompletedTransaction*),
                                     void (*callback_transaction_broadcast)(struct TariCompletedTransaction*),
                                     void (*callback_transaction_mined)(struct TariCompletedTransaction*),
-                                    void (*callback_discovery_process_complete)(unsigned long long, bool),
+                                    void (*callback_direct_send_result)(unsigned long long, bool),
+                                    void (*callback_store_and_forward_send_result)(unsigned long long, bool),
+                                    void (*callback_transaction_cancellation)(unsigned long long),
                                     void (*callback_base_node_sync_complete)(unsigned long long, bool),
                                     int* error_out);
 
@@ -423,6 +425,9 @@ bool wallet_test_mine_transaction(struct TariWallet *wallet, unsigned long long 
 
 // Simulates a TariPendingInboundtransaction being received
 bool wallet_test_receive_transaction(struct TariWallet *wallet,int* error_out);
+
+/// Cancel a Pending Outbound Transaction
+bool wallet_cancel_pending_transaction(struct TariWallet *wallet, unsigned long long transaction_id, int* error_out);
 
 // Frees memory for a TariWallet
 void wallet_destroy(struct TariWallet *wallet);


### PR DESCRIPTION
## Description
This PR adds support for sending transactions via Store and Forward to the Wallet.

When a transaction is sent it is now attempted to send a Direct message which includes a Discovery attempt but also sends the message to the network to be propagated so that the recipient will be able to receive it via Store and Forward when they come back online. The wallet is updated to tolerate receiving repeated messages in case both these messages arrive.

As long as a transaction was sent out in either channel (direct or via store and forward) the transaction will be considered a Pending Outbound Transaction and will start waiting for a Transaction Reply. It is possible for the Direct send to work and the Store and Forward send not to work if the wallet only other peer is a Wallet but as long as you add a Base Node peer it should always at least succeed at Store and Forward.

Because Store and Forward messaging is Fire-and-Forget this means that if too much time has passed the transaction will need to be *explicitly* cancelled. For this a new function is provided: `transaction_service.cancel_transaction(tx_id: TxId)`. This will cancel a specified Pending Outbound Transaction. An FFI interface function is provided for this functionality.

Two new callbacks are provided for FFI clients to interface with the new sending process:
- `callback_direct_send_result: unsafe extern "C" fn(TxId, bool)`: Will return the result of the attempt at a Direct send of a Tx
- `callback_store_and_forward_send_result: unsafe extern "C" fn(TxId, bool)`: Will return the result of trying to send a tx out via the network

One final change introduced in this PR is a new callback to indicate when a transaction has been cancelled due to a Blockchain Monitoring event or a manual cancel. For example if the mempool rejected the transaction.
- `callback_transaction_cancellation: unsafe extern "C" fn(TxId)`: Will be called when a transaction is cancelled (including when it is manually cancelled by the FFI client)

*The `callback_discovery_process_complete` is removed in this PR*

## Summary:
- Store and forward implemented
- callback_direct_send_result added
- callback_store_and_forward_send_result added
- callback_transaction_cancellation added
- callback_discovery_process_complete removed

## How Has This Been Tested?
Tests updated and provided

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [x] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [x] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch.
* [x] I ran `cargo-fmt --all` before pushing.
* [ ] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
