### PR TITLE
ASCII table output for list-peers and list-connections

### DIFF
--- a/applications/tari_base_node/src/main.rs
+++ b/applications/tari_base_node/src/main.rs
@@ -73,6 +73,10 @@
 /// `quit` - Exits the Base Node
 /// `exit` - Same as quit
 
+/// Used to display tabulated data
+#[macro_use]
+mod table;
+
 /// Utilities and helpers for building the base node instance
 mod builder;
 /// The command line interface definition and configuration

--- a/applications/tari_base_node/src/table.rs
+++ b/applications/tari_base_node/src/table.rs
@@ -1,0 +1,147 @@
+// Copyright 2020, The Tari Project
+//
+// Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+// following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+// disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+// following disclaimer in the documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+// products derived from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+// INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+// WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+// USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+use std::{cmp, io, io::Write};
+
+/// Basic ASCII table implementation that is easy to put in a spreadsheet.
+pub struct Table<'t, 's> {
+    titles: Option<Vec<&'t str>>,
+    rows: Vec<Vec<String>>,
+    delim_str: &'s str,
+}
+
+impl<'t, 's> Table<'t, 's> {
+    pub fn new() -> Self {
+        Self {
+            titles: None,
+            rows: Vec::new(),
+            delim_str: "|",
+        }
+    }
+
+    pub fn set_titles(&mut self, titles: Vec<&'t str>) {
+        self.titles = Some(titles);
+    }
+
+    pub fn add_row(&mut self, row: Vec<String>) {
+        self.rows.push(row);
+    }
+
+    pub fn render<T: Write>(&self, out: &mut T) -> io::Result<()> {
+        self.render_titles(out)?;
+        if self.rows.len() > 0 {
+            out.write_all(b"\n")?;
+            self.render_rows(out)?;
+            out.write_all(b"\n")?;
+        }
+        Ok(())
+    }
+
+    pub fn print_std(&self) {
+        self.render(&mut io::stdout()).unwrap();
+    }
+
+    fn col_width(&self, idx: usize) -> usize {
+        let title_width = self.titles.as_ref().map(|titles| titles[idx].len()).unwrap_or(0);
+        let rows_width = self.rows.iter().fold(0, |max, r| {
+            if idx < r.len() {
+                cmp::max(max, r[idx].len())
+            } else {
+                max
+            }
+        });
+        cmp::max(title_width, rows_width)
+    }
+
+    fn render_titles<T: Write>(&self, out: &mut T) -> io::Result<()> {
+        if let Some(titles) = self.titles.as_ref() {
+            self.render_row(titles, out)?;
+        }
+        Ok(())
+    }
+
+    fn render_rows<T: Write>(&self, out: &mut T) -> io::Result<()> {
+        let rows_len = self.rows.len();
+        for (i, row) in self.rows.iter().enumerate() {
+            self.render_row(row, out)?;
+            if i < rows_len - 1 {
+                out.write_all(b"\n")?;
+            }
+        }
+        Ok(())
+    }
+
+    fn render_row<T: Write, I: AsRef<[S]>, S: ToString>(&self, row: I, out: &mut T) -> io::Result<()> {
+        let row_len = row.as_ref().len();
+        for (i, string) in row.as_ref().iter().enumerate() {
+            let s = string.to_string();
+            let width = self.col_width(i);
+            let pad_left = if i == 0 { "" } else { " " };
+            let pad_right = " ".repeat(width - s.len() + 1);
+            out.write_all(pad_left.as_bytes())?;
+            out.write_all(s.as_bytes())?;
+            out.write_all(pad_right.as_bytes())?;
+            if i < row_len - 1 {
+                out.write_all(self.delim_str.as_bytes())?;
+            }
+        }
+        Ok(())
+    }
+}
+
+macro_rules! row {
+    ($($s:expr),*$(,)?) => {
+        vec![$($s.to_string()),*]
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn renders_titles() {
+        let mut table = Table::new();
+        table.set_titles(vec!["Hello", "World", "Bonjour", "Le", "Monde"]);
+        let mut buf = io::Cursor::new(Vec::new());
+        table.render(&mut buf).unwrap();
+        assert_eq!(
+            String::from_utf8_lossy(&buf.into_inner()),
+            "Hello | World | Bonjour | Le | Monde "
+        );
+    }
+
+    #[test]
+    fn renders_rows_with_titles() {
+        let mut table = Table::new();
+        table.set_titles(vec!["Name", "Age", "Telephone Number", "Favourite Headwear"]);
+        table.add_row(row!["Trevor", 132, "+123 12323223", "Pith Helmet"]);
+        table.add_row(row![]);
+        table.add_row(row!["Hatless", 2]);
+        let mut buf = io::Cursor::new(Vec::new());
+        table.render(&mut buf).unwrap();
+        assert_eq!(
+            String::from_utf8_lossy(&buf.into_inner()),
+            "Name    | Age | Telephone Number | Favourite Headwear \nTrevor  | 132 | +123 12323223    | Pith Helmet        \n\nHatless | 2   \n"
+        );
+    }
+}

--- a/applications/tari_base_node/src/utils.rs
+++ b/applications/tari_base_node/src/utils.rs
@@ -21,7 +21,7 @@
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 use futures::{Stream, StreamExt};
-use std::sync::Arc;
+use std::{sync::Arc, time::Duration};
 use tari_wallet::transaction_service::handle::TransactionEvent;
 use tokio::sync::broadcast::RecvError;
 
@@ -55,5 +55,35 @@ where S: Stream<Item = Result<Arc<TransactionEvent>, RecvError>> + Unpin {
                 break false;
             },
         }
+    }
+}
+
+pub fn format_duration_basic(duration: Duration) -> String {
+    let secs = duration.as_secs();
+    if secs > 60 {
+        let mins = secs / 60;
+        if mins > 60 {
+            let hours = mins / 60;
+            format!("{}h {}m {}s", hours, mins % 60, secs % 60)
+        } else {
+            format!("{}m {}s", mins, secs % 60)
+        }
+    } else {
+        format!("{}s", secs)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn formats_duration() {
+        let s = format_duration_basic(Duration::from_secs(5));
+        assert_eq!(s, "5s");
+        let s = format_duration_basic(Duration::from_secs(23 * 60 + 10));
+        assert_eq!(s, "23m 10s");
+        let s = format_duration_basic(Duration::from_secs(9 * 60 * 60 + 35 * 60 + 45));
+        assert_eq!(s, "9h 35m 45s");
     }
 }

--- a/base_layer/core/src/chain_storage/async_db.rs
+++ b/base_layer/core/src/chain_storage/async_db.rs
@@ -54,12 +54,11 @@ where F: FnOnce() -> R {
         trace_id
     );
     let ret = f();
-    let end = Instant::now();
     trace!(
         target: LOG_TARGET,
         "[{}] Exited blocking thread after {}ms. trace_id: '{}'",
         name,
-        (end - start).as_millis(),
+        start.elapsed().as_millis(),
         trace_id
     );
     ret

--- a/comms/dht/examples/memorynet.rs
+++ b/comms/dht/examples/memorynet.rs
@@ -258,18 +258,16 @@ async fn discovery(wallets: &[TestNode], messaging_events_rx: &mut MessagingEven
             )
             .await;
 
-        let end = Instant::now();
-
         match discovery_result {
             Ok(peer) => {
                 successes += 1;
-                total_time += end - start;
+                total_time += start.elapsed();
                 banner!(
                     "⚡️🎉😎 '{}' discovered peer '{}' ({}) in {}ms",
                     wallet1,
                     get_name(&peer.node_id),
                     peer,
-                    (end - start).as_millis()
+                    start.elapsed().as_millis()
                 );
 
                 time::delay_for(Duration::from_secs(5)).await;
@@ -280,7 +278,7 @@ async fn discovery(wallets: &[TestNode], messaging_events_rx: &mut MessagingEven
                     "💩 '{}' failed to discover '{}' after {}ms because '{:?}'",
                     wallet1,
                     wallet2,
-                    (end - start).as_millis(),
+                    start.elapsed().as_millis(),
                     err
                 );
 
@@ -381,8 +379,7 @@ async fn do_store_and_forward_discovery(
 
     total_messages += match discovery_task.await.unwrap() {
         Ok(peer) => {
-            let end = Instant::now();
-            banner!("🎉 Discovered peer {} in {}ms", peer, (end - start).as_millis());
+            banner!("🎉 Discovered peer {} in {}ms", peer, start.elapsed().as_millis());
             drain_messaging_events(messaging_rx, false).await
         },
         Err(err) => {

--- a/comms/dht/src/macros.rs
+++ b/comms/dht/src/macros.rs
@@ -28,18 +28,12 @@ macro_rules! acquire_lock {
         match $e.$m() {
             Ok(lock) => lock,
             Err(poisoned) => {
-                log::warn!(target: "dht", "Lock has been POISONED and will be silently recovered");
+                log::warn!(target: "comms::dht", "Lock has been POISONED and will be silently recovered");
                 poisoned.into_inner()
             },
         }
     };
     ($e:expr) => {
         acquire_lock!($e, lock)
-    };
-}
-
-macro_rules! acquire_write_lock {
-    ($e:expr) => {
-        acquire_lock!($e, write)
     };
 }

--- a/comms/dht/src/outbound/mock.rs
+++ b/comms/dht/src/outbound/mock.rs
@@ -109,7 +109,7 @@ impl OutboundServiceMockState {
     }
 
     pub fn take_next_response(&self) -> Option<SendMessageResponse> {
-        acquire_write_lock!(self.next_response).take()
+        self.next_response.write().unwrap().take()
     }
 
     pub fn add_call(&self, req: (FinalSendMessageParams, Bytes)) {

--- a/comms/dht/src/test_utils/dht_actor_mock.rs
+++ b/comms/dht/src/test_utils/dht_actor_mock.rs
@@ -64,7 +64,7 @@ impl DhtMockState {
     }
 
     pub fn set_select_peers_response(&self, peers: Vec<Peer>) -> &Self {
-        *acquire_write_lock!(self.select_peers) = peers;
+        *self.select_peers.write().unwrap() = peers;
         self
     }
 

--- a/comms/dht/src/test_utils/dht_discovery_mock.rs
+++ b/comms/dht/src/test_utils/dht_discovery_mock.rs
@@ -61,7 +61,7 @@ impl DhtDiscoveryMockState {
     }
 
     pub fn set_discover_peer_response(&self, peer: Peer) -> &Self {
-        *acquire_write_lock!(self.discover_peer) = peer;
+        *self.discover_peer.write().unwrap() = peer;
         self
     }
 

--- a/comms/src/connection_manager/peer_connection.rs
+++ b/comms/src/connection_manager/peer_connection.rs
@@ -46,6 +46,7 @@ use std::{
         atomic::{AtomicUsize, Ordering},
         Arc,
     },
+    time::{Duration, Instant},
 };
 use tari_shutdown::Shutdown;
 
@@ -107,6 +108,7 @@ pub struct PeerConnection {
     request_tx: mpsc::Sender<PeerConnectionRequest>,
     address: Multiaddr,
     direction: ConnectionDirection,
+    started_at: Instant,
 }
 
 impl PeerConnection {
@@ -124,6 +126,7 @@ impl PeerConnection {
             peer_node_id: Arc::new(peer_node_id),
             address,
             direction,
+            started_at: Instant::now(),
         }
     }
 
@@ -135,12 +138,20 @@ impl PeerConnection {
         self.direction
     }
 
+    pub fn address(&self) -> &Multiaddr {
+        &self.address
+    }
+
     pub fn id(&self) -> ConnId {
         self.id
     }
 
     pub fn is_connected(&self) -> bool {
         !self.request_tx.is_closed()
+    }
+
+    pub fn connected_since(&self) -> Duration {
+        self.started_at.elapsed()
     }
 
     pub fn reference_count(&self) -> usize {

--- a/comms/src/peer_manager/connection_stats.rs
+++ b/comms/src/peer_manager/connection_stats.rs
@@ -89,17 +89,17 @@ impl PeerConnectionStats {
 
 impl fmt::Display for PeerConnectionStats {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self.last_connected_at.as_ref() {
-            Some(dt) => {
-                write!(f, "Last connected at '{}'.", dt)?;
-
-                if self.last_failed_at().is_some() {
-                    write!(f, " {}", self.last_connection_attempt)?;
-                }
+        match self.last_failed_at() {
+            Some(_) => {
+                write!(f, "{}", self.last_connection_attempt)?;
             },
-            None => {
-                write!(f, "Never connected to this peer.")?;
-                write!(f, " {}", self.last_connection_attempt)?;
+            None => match self.last_connected_at.as_ref() {
+                Some(dt) => {
+                    write!(f, "Last connected at {}", dt.format("%Y-%m-%d %H:%M:%S"))?;
+                },
+                None => {
+                    write!(f, "{}", self.last_connection_attempt)?;
+                },
             },
         }
 
@@ -145,8 +145,9 @@ impl Display for LastConnectionAttempt {
                 num_attempts,
             } => write!(
                 f,
-                "Connection failed at {} after {} attempt(s)",
-                failed_at, num_attempts
+                "Connection failed at {} ({} attempt(s))",
+                failed_at.format("%Y-%m-%d %H:%M:%S"),
+                num_attempts
             ),
         }
     }

--- a/comms/src/peer_manager/peer_features.rs
+++ b/comms/src/peer_manager/peer_features.rs
@@ -22,6 +22,7 @@
 
 use bitflags::bitflags;
 use serde::{Deserialize, Serialize};
+use std::fmt;
 
 bitflags! {
     #[derive(Serialize, Deserialize)]
@@ -38,5 +39,11 @@ bitflags! {
 impl Default for PeerFeatures {
     fn default() -> Self {
         PeerFeatures::NONE
+    }
+}
+
+impl fmt::Display for PeerFeatures {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{:?}", self)
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
- Added basic ASCII table implementation that is easy to copy into a
      spreadsheet
    - `list-peers` and `list-connections` use table implementation
    - `list-connections` shows peer data and duration of connection

```
NodeId           | Public Key                                                       | Address                                                                | Direction | Uptime  | Role
75cfb63f1e967a5d | 2e93c460df49d8cfbbf7a06dd9004c25a84f92584f7d0ac5e30bd8e0beee9a43 | /ip4/127.0.0.1/tcp/60187                                               | Inbound   | 13m 38s | Base node
9fc307fd4c4874fd | b81b4071f72418cc410166d9baf0c6ef7a8c309e64671fafbbed88f7e1ee7709 | /ip4/127.0.0.1/tcp/60176                                               | Inbound   | 13m 39s | Base node
099fc6fc362f07b5 | 3a5081a0c9ff72b2d5cf52f8d78cc5a206d643259cdeb7d934512f519e090e6c | /ip4/127.0.0.1/tcp/60169                                               | Inbound   | 13m 41s | Base node
609e2f8272a22c76 | ee445a2a74b1acd85c69af2880c2341ece651ac3b7ca36370df695f6faf62b4e | /onion3/zkai65rsht26si35xgezkc2kh3dkr72v2723efpy444ds45kr62imaid:18141 | Outbound  | 13m 35s | Base node
4 active connection(s)
```

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Ugly hard-to-read output for `list-peers` and `list-connections`. `list-connections` only displayed the peer node ID which made it difficult to determine which peers are connected.

~~New dependency on tari_base_node: `prettytable-rs`~~