### PR TITLE
Fix bug with hanging test bootstrap_config on some envs

### DIFF
--- a/base_layer/wallet_ffi/wallet.h
+++ b/base_layer/wallet_ffi/wallet.h
@@ -334,7 +334,7 @@ void comms_config_destroy(struct TariCommsConfig *wc);
 
 // Creates a TariWallet
 struct TariWallet *wallet_create(struct TariWalletConfig *config,
-                                    char *log_path,
+                                    const char *log_path,
                                     void (*callback_received_transaction)(struct TariPendingInboundTransaction*),
                                     void (*callback_received_transaction_reply)(struct TariCompletedTransaction*),
                                     void (*callback_received_finalized_transaction)(struct TariCompletedTransaction*),


### PR DESCRIPTION
## Description
With adding StructOpt support for BootstrapConfig back - support for clap ArgMatches appeared broken, while test `test_bootstrap_config_from_cli_and_load_configuration` was not showing a problem as it appeared worked fine with no arguments provided on env where there was default config in default dir, while hanging with prompt on envs without default setting.

This PR fixing the bug, so clap options are back supported again, also adding test that validates ArgMatches with possible combinations including aliases.

## Motivation and Context
As reported by @sdbondi in nomatter:

> Anyone else finding the test_bootstrap_config_from_cli_and_load_configuration test is hanging locally? @dunnock I think the problem lies in ConfigBootstrap::from_matches because init is not  set to true even through the --init flag is present - not sure why ci doesnt hang?

## How Has This Been Tested?
Add unit tests covering `BootstrapConfig::from_matches` where bug appeared.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [X] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [X] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [X] I'm merging against the `development` branch.
* [X] I ran `cargo-fmt --all` before pushing.
* [X] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [X] I have added tests to cover my changes.
