### PR TITLE
Added missing const to header

### DIFF
--- a/base_layer/wallet_ffi/wallet.h
+++ b/base_layer/wallet_ffi/wallet.h
@@ -334,7 +334,7 @@ void comms_config_destroy(struct TariCommsConfig *wc);
 
 // Creates a TariWallet
 struct TariWallet *wallet_create(struct TariWalletConfig *config,
-                                    char *log_path,
+                                    const char *log_path,
                                     void (*callback_received_transaction)(struct TariPendingInboundTransaction*),
                                     void (*callback_received_transaction_reply)(struct TariCompletedTransaction*),
                                     void (*callback_received_finalized_transaction)(struct TariCompletedTransaction*),


### PR DESCRIPTION
## Description
Function definition is
```
pub unsafe extern "C" fn wallet_create(
    config: *mut TariCommsConfig,
    log_path: *const c_char,
    ...
}
```

Header has to match definition.

## Motivation and Context

## How Has This Been Tested?

## Types of changes
* [ ] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [x] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
* [x] I'm merging against the `development` branch.
* [x] I ran `cargo-fmt --all` before pushing.
* [x] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
