### PR TITLE
Various S&F improvements and Peer offline handling

### DIFF
--- a/base_layer/p2p/src/services/liveness/config.rs
+++ b/base_layer/p2p/src/services/liveness/config.rs
@@ -31,7 +31,7 @@ pub struct LivenessConfig {
     pub enable_auto_join: bool,
     /// Set to true to enable a request for stored messages on node startup (default: false)
     pub enable_auto_stored_message_request: bool,
-    /// The length of time between querying peer manager for closest neighbours. (default: 5mins)
+    /// The length of time between querying peer manager for closest neighbours. (default: 1 minute)
     pub refresh_neighbours_interval: Duration,
 }
 
@@ -41,7 +41,7 @@ impl Default for LivenessConfig {
             auto_ping_interval: None,
             enable_auto_join: false,
             enable_auto_stored_message_request: false,
-            refresh_neighbours_interval: Duration::from_secs(3 * 60),
+            refresh_neighbours_interval: Duration::from_secs(60),
         }
     }
 }

--- a/comms/dht/migrations/2020-04-16-165626_clear_stored_messages/down.sql
+++ b/comms/dht/migrations/2020-04-16-165626_clear_stored_messages/down.sql
@@ -1,0 +1,1 @@
+-- This file should undo anything in `up.sql`

--- a/comms/dht/migrations/2020-04-16-165626_clear_stored_messages/up.sql
+++ b/comms/dht/migrations/2020-04-16-165626_clear_stored_messages/up.sql
@@ -1,0 +1,1 @@
+DELETE FROM stored_messages;

--- a/comms/dht/src/broadcast_strategy.rs
+++ b/comms/dht/src/broadcast_strategy.rs
@@ -47,8 +47,8 @@ pub enum BroadcastStrategy {
     /// Send to all n nearest Communication Nodes according to the given BroadcastClosestRequest
     Closest(Box<BroadcastClosestRequest>),
     /// A convenient strategy which behaves the same as the `Closest` strategy with the `NodeId` set
-    /// to this node and a pre-configured number of neighbours that have all the matching PeerFeatures flags.
-    /// This strategy excludes the given public keys.
+    /// to this node. Element 0 in the tuple is a public key exclusion list. If element 1 is set to true, all
+    /// neighbouring client peers are also included in addition to node peers.
     Neighbours(Vec<CommsPublicKey>, bool),
 }
 

--- a/comms/dht/src/outbound/broadcast.rs
+++ b/comms/dht/src/outbound/broadcast.rs
@@ -349,7 +349,11 @@ where S: Service<DhtOutboundMessage, Response = (), Error = PipelineError>
         );
 
         // Peer not found, let's try and discover it
-        match self.dht_discovery_requester.discover_peer(dest_public_key).await {
+        match self
+            .dht_discovery_requester
+            .discover_peer(dest_public_key.clone(), NodeDestination::PublicKey(dest_public_key))
+            .await
+        {
             // Peer found!
             Ok(peer) => {
                 if peer.is_banned() {

--- a/comms/dht/src/proto/mod.rs
+++ b/comms/dht/src/proto/mod.rs
@@ -22,6 +22,7 @@
 
 use crate::proto::envelope::Network;
 use std::fmt;
+use tari_crypto::tari_utilities::hex::Hex;
 
 #[path = "tari.dht.envelope.rs"]
 pub mod envelope;
@@ -65,5 +66,19 @@ impl envelope::Network {
 impl fmt::Display for dht::RejectMessage {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "RejectMessage(Reason = {})", self.reason)
+    }
+}
+
+//---------------------------------- JoinMessage --------------------------------------------//
+
+impl fmt::Display for dht::JoinMessage {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "JoinMessage(NodeId = {}, Addresses = {:?}, Features = {:?})",
+            self.node_id.to_hex(),
+            self.addresses,
+            self.peer_features
+        )
     }
 }

--- a/comms/dht/src/store_forward/database/mod.rs
+++ b/comms/dht/src/store_forward/database/mod.rs
@@ -186,11 +186,7 @@ impl StoreAndForwardDatabase {
             .with_connection_async(move |conn| {
                 let mut query = stored_messages::table
                     .select(stored_messages::all_columns)
-                    .filter(
-                        stored_messages::destination_pubkey
-                            .eq(pk_hex)
-                            .or(stored_messages::destination_pubkey.is_null()),
-                    )
+                    .filter(stored_messages::destination_pubkey.eq(pk_hex))
                     .filter(stored_messages::message_type.eq(message_type as i32))
                     .into_boxed();
 

--- a/comms/dht/src/store_forward/saf_handler/task.rs
+++ b/comms/dht/src/store_forward/saf_handler/task.rs
@@ -61,7 +61,7 @@ use tari_comms::{
 use tari_crypto::tari_utilities::ByteArray;
 use tower::{Service, ServiceExt};
 
-const LOG_TARGET: &str = "comms::dht::store_forward::handler";
+const LOG_TARGET: &str = "comms::dht::storeforward::handler";
 
 pub struct MessageHandlerTask<S> {
     config: DhtConfig,
@@ -193,7 +193,6 @@ where S: Service<DecryptedDhtMessage, Response = (), Error = PipelineError>
             SafResponseType::Anonymous,
             SafResponseType::InRegion,
             SafResponseType::Discovery,
-            SafResponseType::Join,
         ];
 
         for resp_type in response_types {
@@ -251,7 +250,7 @@ where S: Service<DecryptedDhtMessage, Response = (), Error = PipelineError>
             .ok_or_else(|| StoreAndForwardError::InvalidEnvelopeBody)?;
         let source_peer = Arc::new(message.source_peer);
 
-        debug!(
+        info!(
             target: LOG_TARGET,
             "Received {} stored messages of type {} from peer",
             response.messages().len(),

--- a/comms/dht/src/test_utils/dht_discovery_mock.rs
+++ b/comms/dht/src/test_utils/dht_discovery_mock.rs
@@ -102,7 +102,7 @@ impl DhtDiscoveryMock {
         trace!(target: LOG_TARGET, "DhtDiscoveryMock received request {:?}", req);
         self.state.inc_call_count();
         match req {
-            DiscoverPeer(_, reply_tx) => {
+            DiscoverPeer(_, _, reply_tx) => {
                 let lock = self.state.discover_peer.read().unwrap();
                 reply_tx.send(Ok(lock.clone())).unwrap();
             },

--- a/comms/dht/tests/dht.rs
+++ b/comms/dht/tests/dht.rs
@@ -225,7 +225,10 @@ async fn dht_discover_propagation() {
     node_A
         .dht
         .discovery_service_requester()
-        .discover_peer(Box::new(node_D.node_identity().public_key().clone()))
+        .discover_peer(
+            Box::new(node_D.node_identity().public_key().clone()),
+            NodeDestination::Unknown,
+        )
         .await
         .unwrap();
 

--- a/comms/src/connection_manager/common.rs
+++ b/comms/src/connection_manager/common.rs
@@ -138,13 +138,14 @@ pub async fn validate_and_add_peer_from_peer_identity(
                     &authenticated_public_key,
                     Some(peer_node_id.clone()),
                     Some(addresses),
-                    None,
+                    // Clear all flags (this is ok because we only have BANNED and OFFLINE flags)
+                    // TODO: Change the way banned and offline states are represented
+                    Some(PeerFlags::empty()),
                     Some(PeerFeatures::from_bits_truncate(peer_identity.features)),
                     Some(conn_stats),
                     Some(supported_protocols),
                 )
                 .await?;
-            peer_manager.set_offline(&authenticated_public_key, false).await?;
         },
         None => {
             debug!(

--- a/comms/src/connection_manager/error.rs
+++ b/comms/src/connection_manager/error.rs
@@ -74,8 +74,6 @@ pub enum ConnectionManagerError {
     IdentityProtocolError(IdentityProtocolError),
     /// The dial was cancelled
     DialCancelled,
-    /// The peer is offline and will not be dialed
-    PeerOffline,
     #[error(msg_embedded, no_from, non_std)]
     InvalidMultiaddr(String),
     /// Failed to send wire format byte

--- a/comms/src/connection_manager/requester.rs
+++ b/comms/src/connection_manager/requester.rs
@@ -35,12 +35,7 @@ pub enum ConnectionManagerRequest {
     /// Dial a given peer by node id.
     /// Parameters:
     /// 1. Node Id to dial
-    /// 1. If true, attempt to dial the peer even if we recently failed to dial them and they are considered offline
-    DialPeer(
-        NodeId,
-        bool,
-        oneshot::Sender<Result<PeerConnection, ConnectionManagerError>>,
-    ),
+    DialPeer(NodeId, oneshot::Sender<Result<PeerConnection, ConnectionManagerError>>),
     /// Register a oneshot to get triggered when the node is listening, or has failed to listen
     NotifyListening(oneshot::Sender<Multiaddr>),
     /// Retrieve an active connection for a given node id if one exists.
@@ -111,23 +106,9 @@ impl ConnectionManagerRequester {
 
     /// Attempt to connect to a remote peer
     pub async fn dial_peer(&mut self, node_id: NodeId) -> Result<PeerConnection, ConnectionManagerError> {
-        self.send_dial_peer(node_id, false).await
-    }
-
-    /// Attempt to connect to a remote peer, even if we failed to contact the peer recently
-    pub async fn dial_peer_forced(&mut self, node_id: NodeId) -> Result<PeerConnection, ConnectionManagerError> {
-        self.send_dial_peer(node_id, true).await
-    }
-
-    async fn send_dial_peer(
-        &mut self,
-        node_id: NodeId,
-        is_forced: bool,
-    ) -> Result<PeerConnection, ConnectionManagerError>
-    {
         let (reply_tx, reply_rx) = oneshot::channel();
         self.sender
-            .send(ConnectionManagerRequest::DialPeer(node_id, is_forced, reply_tx))
+            .send(ConnectionManagerRequest::DialPeer(node_id, reply_tx))
             .await
             .map_err(|_| ConnectionManagerError::SendToActorFailed)?;
         reply_rx

--- a/comms/src/peer_manager/peer.rs
+++ b/comms/src/peer_manager/peer.rs
@@ -68,7 +68,7 @@ pub struct Peer {
     pub node_id: NodeId,
     /// Peer's addresses
     pub addresses: MultiaddressesWithStats,
-    /// Flags for the peer. Indicates if the peer is banned.
+    /// Flags for the peer.
     pub flags: PeerFlags,
     /// Features supported by the peer
     pub features: PeerFeatures,

--- a/comms/src/protocol/messaging/outbound.rs
+++ b/comms/src/protocol/messaging/outbound.rs
@@ -86,17 +86,6 @@ impl OutboundMessaging {
                     );
                     continue;
                 },
-                Err(err @ ConnectionManagerError::PeerOffline) => {
-                    error!(
-                        target: LOG_TARGET,
-                        "MessagingProtocol failed to dial peer '{}' because '{:?}'",
-                        self.peer_node_id.short_str(),
-                        err
-                    );
-                    self.flush_all_messages_to_failed_event(SendFailReason::PeerOffline)
-                        .await;
-                    break Err(MessagingProtocolError::PeerDialFailed);
-                },
                 Err(err) => {
                     error!(
                         target: LOG_TARGET,

--- a/comms/src/protocol/messaging/protocol.rs
+++ b/comms/src/protocol/messaging/protocol.rs
@@ -61,8 +61,6 @@ pub enum MessagingRequest {
 /// occurred
 #[derive(Debug, Error, Copy, Clone)]
 pub enum SendFailReason {
-    /// Dial was not attempted because the peer is offline
-    PeerOffline,
     /// Dial was attempted, but failed
     PeerDialFailed,
     /// Failed to open a messaging substream to peer

--- a/comms/src/test_utils/mocks/connection_manager.rs
+++ b/comms/src/test_utils/mocks/connection_manager.rs
@@ -127,7 +127,7 @@ impl ConnectionManagerMock {
         self.state.inc_call_count();
         self.state.add_call(format!("{:?}", req)).await;
         match req {
-            DialPeer(node_id, _, reply_tx) => {
+            DialPeer(node_id, reply_tx) => {
                 // Send Ok(conn) if we have an active connection, otherwise Err(DialConnectFailedAllAddresses)
                 reply_tx
                     .send(


### PR DESCRIPTION
This is really 2 PRs that follow after each other:

## PR 1 - Changes to peer offline handling
The current offline handling is a too aggressive and needs to be
considered a bit more carefully.

This change removes the check in ConnectionManager to immediately fail
dials if the peer is marked as offline. This did not belong in the
connection manager anyway, and more intelligent handling of this case
will live higher up in the stack.

Nodes will still not broadcast to offline peers however direct send
messages will still attempt to dial. This should solve the issue on
mobile where the phone does not attempt to connect to a base node it
cannot talk to.

Nodes will no longer mark all their base node neighbours as offline. If
a certain percentage (30%) of neighbouring nodes are already marked as
offline, no further nodes will be marked as offline.

Added `reset-offline-peers` command

A more sophisticated solutions may involve:
- Somehow tell comms that transport-level connectivity has been lost
  (might help if the OS could tell comms about the state of internet connectivity)
- A node should ask neighbours and come to a consensus on the state of
  their neighbouring peer list.

## PR 2 - Various S&F improvements and fixes
- Added destination to discovery
- Only store and forward discovery messages with a destination
- Do not store DHT join messages
- Ensure that a message that fails decryption is not erronously
  discarded if the bad decryption happens to decode to valid protobuf.
- Disable store and forward middleware for nodes without the DHT_STORE_FORWARD feature