### PR TITLE
Reject inbound SAF join messages, timelimit on peer bans, other fixes

### DIFF
--- a/applications/tari_base_node/src/builder.rs
+++ b/applications/tari_base_node/src/builder.rs
@@ -164,6 +164,11 @@ impl NodeContainer {
         using_backend!(self, ctx, &ctx.base_node_comms)
     }
 
+    /// Returns the wallet CommsNode.
+    pub fn wallet_comms(&self) -> &CommsNode {
+        using_backend!(self, ctx, &ctx.wallet_comms)
+    }
+
     /// Returns this node's identity.
     pub fn base_node_identity(&self) -> Arc<NodeIdentity> {
         using_backend!(self, ctx, ctx.base_node_comms.node_identity())
@@ -1097,7 +1102,7 @@ where
             LivenessConfig {
                 auto_ping_interval: Some(Duration::from_secs(30)),
                 enable_auto_join: true,
-                enable_auto_stored_message_request: true,
+                enable_auto_stored_message_request: false,
                 refresh_neighbours_interval: Duration::from_secs(3 * 60),
             },
             subscription_factory,

--- a/comms/dht/src/config.rs
+++ b/comms/dht/src/config.rs
@@ -60,7 +60,7 @@ pub struct DhtConfig {
     /// The limit on the message size to store in SAF storage in bytes. Default 500 KiB
     pub saf_max_message_size: usize,
     /// The max capacity of the message hash cache
-    /// Default: 1000
+    /// Default: 10000
     pub msg_hash_cache_capacity: usize,
     /// The time-to-live for items in the message hash cache
     /// Default: 300s

--- a/comms/dht/src/discovery/service.rs
+++ b/comms/dht/src/discovery/service.rs
@@ -194,27 +194,37 @@ impl DhtDiscoveryService {
                         );
                     }
                 } else {
-                    debug!(
-                        target: LOG_TARGET,
-                        "Attempting to discover peer '{}' because we failed to connect on all addresses for the peer",
-                        peer.node_id.short_str()
-                    );
-                    // Don't need to be notified for this discovery
-                    let (reply_tx, _) = oneshot::channel();
-                    // Send out a discovery for that peer without keeping track of it as an inflight discovery
-                    let dest_pubkey = Box::new(peer.public_key);
-                    self.initiate_peer_discovery(
-                        dest_pubkey.clone(),
-                        NodeDestination::PublicKey(dest_pubkey),
-                        reply_tx,
-                    )
-                    .await?;
+                    if !self.has_inflight_discovery(&peer.public_key) {
+                        debug!(
+                            target: LOG_TARGET,
+                            "Attempting to discover peer '{}' because we failed to connect on all addresses for the
+                    peer",
+                            peer.node_id.short_str()
+                        );
+
+                        // Don't need to be notified for this discovery
+                        let (reply_tx, _) = oneshot::channel();
+                        // Send out a discovery for that peer without keeping track of it as an inflight discovery
+                        let dest_pubkey = Box::new(peer.public_key);
+                        self.initiate_peer_discovery(
+                            dest_pubkey.clone(),
+                            NodeDestination::PublicKey(dest_pubkey),
+                            reply_tx,
+                        )
+                        .await?;
+                    }
                 }
             },
             _ => {},
         }
 
         Ok(())
+    }
+
+    fn has_inflight_discovery(&self, public_key: &CommsPublicKey) -> bool {
+        self.inflight_discoveries
+            .values()
+            .all(|state| &*state.public_key != public_key)
     }
 
     fn collect_all_discovery_requests(&mut self, public_key: &CommsPublicKey) -> Vec<DiscoveryRequestState> {
@@ -367,6 +377,8 @@ impl DhtDiscoveryService {
                     Some(node_id),
                     Some(net_addresses),
                     None,
+                    None,
+                    Some(false),
                     Some(peer_features),
                     None,
                     None,

--- a/comms/dht/src/envelope.rs
+++ b/comms/dht/src/envelope.rs
@@ -247,6 +247,13 @@ impl NodeDestination {
             NodeDestination::NodeId(node_id) => Some(node_id),
         }
     }
+
+    pub fn is_unknown(&self) -> bool {
+        match self {
+            NodeDestination::Unknown => true,
+            _ => false,
+        }
+    }
 }
 
 impl PartialEq<&CommsPublicKey> for NodeDestination {

--- a/comms/dht/src/inbound/dedup.rs
+++ b/comms/dht/src/inbound/dedup.rs
@@ -84,9 +84,10 @@ where S: Service<DhtInboundMessage, Response = (), Error = PipelineError>
             .await
             .map_err(PipelineError::from_debug)?
         {
-            warn!(
+            info!(
                 target: LOG_TARGET,
-                "Received duplicate message from peer {}. Message discarded.", message.source_peer.node_id,
+                "Received duplicate message from peer '{}'. Message discarded.",
+                message.source_peer.node_id.short_str(),
             );
             return Ok(());
         }

--- a/comms/dht/src/inbound/dht_handler/task.rs
+++ b/comms/dht/src/inbound/dht_handler/task.rs
@@ -131,9 +131,9 @@ where S: Service<DecryptedDhtMessage, Response = (), Error = PipelineError>
                     pubkey,
                     Some(node_id),
                     Some(net_addresses),
-                    // We've already checked this peer is not banned, so we aren't unsetting the ban flag
-                    // TODO: 🐞 If we use more than two flags we might inadvertently unset something we don't want to.
-                    Some(PeerFlags::empty()),
+                    None,
+                    None,
+                    Some(false),
                     Some(peer_features),
                     None,
                     None,
@@ -339,7 +339,7 @@ where S: Service<DecryptedDhtMessage, Response = (), Error = PipelineError>
 
         info!(
             target: LOG_TARGET,
-            "Received discovery message from '{}'", authenticated_pk
+            "Received discovery message from '{}', forwarded by {}", authenticated_pk, message.source_peer
         );
 
         let addresses = discover_msg
@@ -366,7 +366,7 @@ where S: Service<DecryptedDhtMessage, Response = (), Error = PipelineError>
         if origin_peer.is_banned() {
             warn!(
                 target: LOG_TARGET,
-                "Received Discovery request for banned peer. This request will be ignored."
+                "Received Discovery request for banned peer '{}'. This request will be ignored.", authenticated_pk
             );
             return Ok(());
         }

--- a/comms/dht/src/inbound/message.rs
+++ b/comms/dht/src/inbound/message.rs
@@ -35,6 +35,7 @@ pub struct DhtInboundMessage {
     pub version: u32,
     pub source_peer: Arc<Peer>,
     pub dht_header: DhtMessageHeader,
+    pub is_saf_message: bool,
     pub body: Vec<u8>,
 }
 impl DhtInboundMessage {
@@ -43,6 +44,7 @@ impl DhtInboundMessage {
             version: DHT_ENVELOPE_HEADER_VERSION,
             dht_header,
             source_peer,
+            is_saf_message: false,
             body,
         }
     }

--- a/comms/dht/src/store_forward/database/mod.rs
+++ b/comms/dht/src/store_forward/database/mod.rs
@@ -76,6 +76,7 @@ impl StoreAndForwardDatabase {
                             .eq(pk_hex)
                             .or(stored_messages::destination_node_id.eq(node_id_hex)),
                     )
+                    .filter(stored_messages::message_type.eq(DhtMessageType::None as i32))
                     .into_boxed();
 
                 if let Some(since) = since {

--- a/comms/dht/src/store_forward/error.rs
+++ b/comms/dht/src/store_forward/error.rs
@@ -73,4 +73,6 @@ pub enum StoreAndForwardError {
     MalformedNodeId(ByteArrayError),
     /// NodeDistance threshold was invalid
     InvalidNodeDistanceThreshold,
+    /// DHT message type should not have been forwarded
+    InvalidDhtMessageType,
 }

--- a/comms/dht/src/store_forward/store.rs
+++ b/comms/dht/src/store_forward/store.rs
@@ -348,7 +348,12 @@ where S: Service<DecryptedDhtMessage, Response = (), Error = PipelineError>
         match &message.dht_header.destination {
             Unknown => {
                 // No destination provided,
-                Ok(Some(StoredMessagePriority::Low))
+                if message.dht_header.message_type.is_dht_discovery() {
+                    log_not_eligible("it is an anonymous discovery message");
+                    Ok(None)
+                } else {
+                    Ok(Some(StoredMessagePriority::Low))
+                }
             },
             PublicKey(dest_public_key) => {
                 // If we know the destination peer, keep the message for them

--- a/comms/dht/tests/dht.rs
+++ b/comms/dht/tests/dht.rs
@@ -259,12 +259,13 @@ async fn dht_store_forward() {
     // Node A knows about Node B
     let node_A = make_node(PeerFeatures::COMMUNICATION_NODE, Some(node_B.to_peer())).await;
 
+    let dest_public_key = Box::new(node_C_node_identity.public_key().clone());
     let params = SendMessageParams::new()
         .neighbours(vec![])
-        .with_encryption(OutboundEncryption::EncryptFor(Box::new(
-            node_C_node_identity.public_key().clone(),
+        .with_encryption(OutboundEncryption::EncryptFor(dest_public_key))
+        .with_destination(NodeDestination::NodeId(Box::new(
+            node_C_node_identity.node_id().clone(),
         )))
-        .with_destination(NodeDestination::Unknown)
         .finish();
 
     let secret_msg1 = b"NCZW VUSX PNYM INHZ XMQX SFWX WLKJ AHSH";

--- a/comms/src/connection_manager/common.rs
+++ b/comms/src/connection_manager/common.rs
@@ -138,9 +138,9 @@ pub async fn validate_and_add_peer_from_peer_identity(
                     &authenticated_public_key,
                     Some(peer_node_id.clone()),
                     Some(addresses),
-                    // Clear all flags (this is ok because we only have BANNED and OFFLINE flags)
-                    // TODO: Change the way banned and offline states are represented
-                    Some(PeerFlags::empty()),
+                    None,
+                    None,
+                    Some(false),
                     Some(PeerFeatures::from_bits_truncate(peer_identity.features)),
                     Some(conn_stats),
                     Some(supported_protocols),

--- a/comms/src/peer_manager/peer_query.rs
+++ b/comms/src/peer_manager/peer_query.rs
@@ -218,7 +218,7 @@ mod test {
     };
     use multiaddr::Multiaddr;
     use rand::rngs::OsRng;
-    use std::iter::repeat_with;
+    use std::{iter::repeat_with, time::Duration};
     use tari_crypto::{keys::PublicKey, ristretto::RistrettoPublicKey};
     use tari_storage::HashmapDatabase;
 
@@ -234,7 +234,9 @@ mod test {
             PeerFeatures::MESSAGE_PROPAGATION,
             &[],
         );
-        peer.set_banned(ban_flag);
+        if ban_flag {
+            peer.ban_for(Duration::from_secs(1000));
+        }
         peer
     }
 

--- a/comms/src/utils/datetime.rs
+++ b/comms/src/utils/datetime.rs
@@ -1,4 +1,4 @@
-// Copyright 2019, The Tari Project
+// Copyright 2020, The Tari Project
 //
 // Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
 // following conditions are met:
@@ -20,7 +20,14 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-pub mod cidr;
-pub mod datetime;
-pub mod multiaddr;
-pub mod signature;
+use chrono::{DateTime, NaiveTime, Utc};
+use std::time::Duration;
+
+pub fn safe_future_datetime_from_duration(duration: Duration) -> DateTime<Utc> {
+    let old_duration = chrono::Duration::from_std(duration).unwrap_or_else(|_| chrono::Duration::max_value());
+    Utc::now().checked_add_signed(old_duration).unwrap_or_else(|| {
+        chrono::MAX_DATE
+            .and_time(NaiveTime::from_hms(0, 0, 0))
+            .expect("cannot fail")
+    })
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
- Inbound join messages sent form SAF are discarded
- Inbound anonymous discovery messages sent from SAF are discarded
- Base node no longer requests SAF message on start up (BN wallet still
  does)
- [BUG] `ForMe` messages only returns non-DHT messages
- (un)ban-peer command works on both the wallet and base node
- Sync peer ban set to 24 hours
- Only one discovery can be inflight at once
- Anonymous SAF response (sending back all anonymous messages) no longer happens

_NOTE: Wallet and base node peer databases will need to be deleted_
_RECOMMENDED: Delete your dht.db_
