### PR TITLE
Coin-split base node cli command

### DIFF
--- a/base_layer/wallet/src/output_manager_service/storage/database.rs
+++ b/base_layer/wallet/src/output_manager_service/storage/database.rs
@@ -57,7 +57,7 @@ pub trait OutputManagerBackend: Send + Sync {
         &self,
         tx_id: TxId,
         outputs_to_send: &[UnblindedOutput],
-        change_output: Option<UnblindedOutput>,
+        outputs_to_receive: &[UnblindedOutput],
     ) -> Result<(), OutputManagerStorageError>;
     /// This method confirms that a transaction negotiation is complete and outputs can be fully encumbered. This
     /// reserves these outputs until the transaction is confirmed or cancelled
@@ -335,12 +335,12 @@ where T: OutputManagerBackend + 'static
         &self,
         tx_id: TxId,
         outputs_to_send: Vec<UnblindedOutput>,
-        change_output: Option<UnblindedOutput>,
+        outputs_to_receive: Vec<UnblindedOutput>,
     ) -> Result<(), OutputManagerStorageError>
     {
         let db_clone = self.db.clone();
         tokio::task::spawn_blocking(move || {
-            db_clone.short_term_encumber_outputs(tx_id, &outputs_to_send, change_output)
+            db_clone.short_term_encumber_outputs(tx_id, &outputs_to_send, &outputs_to_receive)
         })
         .await
         .or_else(|err| Err(OutputManagerStorageError::BlockingTaskSpawnError(err.to_string())))

--- a/base_layer/wallet/src/output_manager_service/storage/memory_db.rs
+++ b/base_layer/wallet/src/output_manager_service/storage/memory_db.rs
@@ -204,7 +204,7 @@ impl OutputManagerBackend for OutputManagerMemoryDatabase {
         &self,
         tx_id: TxId,
         outputs_to_send: &[UnblindedOutput],
-        change_output: Option<UnblindedOutput>,
+        outputs_to_receive: &[UnblindedOutput],
     ) -> Result<(), OutputManagerStorageError>
     {
         let mut db = acquire_write_lock!(self.db);
@@ -224,8 +224,8 @@ impl OutputManagerBackend for OutputManagerMemoryDatabase {
             timestamp: Utc::now().naive_utc(),
         };
 
-        if let Some(co) = change_output {
-            pending_transaction.outputs_to_be_received.push(co);
+        for co in outputs_to_receive {
+            pending_transaction.outputs_to_be_received.push(co.clone());
         }
 
         db.short_term_pending_transactions.insert(tx_id, pending_transaction);

--- a/base_layer/wallet/src/output_manager_service/storage/sqlite_db.rs
+++ b/base_layer/wallet/src/output_manager_service/storage/sqlite_db.rs
@@ -269,7 +269,7 @@ impl OutputManagerBackend for OutputManagerSqliteDatabase {
         &self,
         tx_id: u64,
         outputs_to_send: &[UnblindedOutput],
-        change_output: Option<UnblindedOutput>,
+        outputs_to_receive: &[UnblindedOutput],
     ) -> Result<(), OutputManagerStorageError>
     {
         let conn = acquire_lock!(self.database_connection);
@@ -295,8 +295,8 @@ impl OutputManagerBackend for OutputManagerSqliteDatabase {
             )?;
         }
 
-        if let Some(co) = change_output {
-            OutputSql::new(co, OutputStatus::EncumberedToBeReceived, Some(tx_id)).commit(&(*conn))?;
+        for co in outputs_to_receive {
+            OutputSql::new(co.clone(), OutputStatus::EncumberedToBeReceived, Some(tx_id)).commit(&(*conn))?;
         }
 
         Ok(())

--- a/base_layer/wallet/tests/output_manager_service/storage.rs
+++ b/base_layer/wallet/tests/output_manager_service/storage.rs
@@ -176,7 +176,7 @@ pub fn test_db_backend<T: OutputManagerBackend + 'static>(backend: T) {
     let outputs_to_encumber = vec![outputs[0].clone(), outputs[1].clone()];
     let total_encumbered = outputs[0].clone().value + outputs[1].clone().value;
     runtime
-        .block_on(db.encumber_outputs(2, outputs_to_encumber, Some(uo_change.clone())))
+        .block_on(db.encumber_outputs(2, outputs_to_encumber, vec![uo_change.clone()]))
         .unwrap();
     runtime.block_on(db.confirm_encumbered_outputs(2)).unwrap();
 
@@ -373,11 +373,9 @@ pub async fn test_short_term_encumberance<T: OutputManagerBackend + 'static>(bac
     let (_ti, uo) = make_input(&mut OsRng, MicroTari::from(50), &factories.commitment);
     pending_tx.outputs_to_be_received.push(uo);
 
-    db.encumber_outputs(
-        pending_tx.tx_id,
-        pending_tx.outputs_to_be_spent.clone(),
-        Some(pending_tx.outputs_to_be_received[0].clone()),
-    )
+    db.encumber_outputs(pending_tx.tx_id, pending_tx.outputs_to_be_spent.clone(), vec![
+        pending_tx.outputs_to_be_received[0].clone(),
+    ])
     .await
     .unwrap();
 
@@ -389,11 +387,9 @@ pub async fn test_short_term_encumberance<T: OutputManagerBackend + 'static>(bac
     let balance = db.get_balance().await.unwrap();
     assert_eq!(available_balance, balance.available_balance);
 
-    db.encumber_outputs(
-        pending_tx.tx_id,
-        pending_tx.outputs_to_be_spent.clone(),
-        Some(pending_tx.outputs_to_be_received[0].clone()),
-    )
+    db.encumber_outputs(pending_tx.tx_id, pending_tx.outputs_to_be_spent.clone(), vec![
+        pending_tx.outputs_to_be_received[0].clone(),
+    ])
     .await
     .unwrap();
 
@@ -405,11 +401,9 @@ pub async fn test_short_term_encumberance<T: OutputManagerBackend + 'static>(bac
 
     db.cancel_pending_transaction_outputs(pending_tx.tx_id).await.unwrap();
 
-    db.encumber_outputs(
-        pending_tx.tx_id,
-        pending_tx.outputs_to_be_spent.clone(),
-        Some(pending_tx.outputs_to_be_received[0].clone()),
-    )
+    db.encumber_outputs(pending_tx.tx_id, pending_tx.outputs_to_be_spent.clone(), vec![
+        pending_tx.outputs_to_be_received[0].clone(),
+    ])
     .await
     .unwrap();
 


### PR DESCRIPTION
## Description
- Coin split functionality was added to the output manager service where a set of available UTXOs are found and the finalized transaction is constructed and the outputs are encumbered and tracked.
- The finalised transaction can then be submitted to the transaction service that propagates it and checks its status. Functionality to submit a transaction, that spends to self, was added to the transaction service.
- The ability to encumber more than one output to receive was added to the output manager db and the memory_db and sqlite_db was updated.
- The select_outputs method was renamed to select_utxos and was modified to allow the required number of outputs to be specified so that the fee can be correctly calculated for cases where more than one output is required. It will also now determine and return if a change output is required.
- The transaction initialiser from the transaction protocol was changed to allow transactions with 0 recipients (spending to self) to construct a transaction id for that transaction.

## Motivation and Context
These changes enable a coin split command in the base node application that can spend a few UTXOs to a large set of UTXOs.

## How Has This Been Tested?
Added two tests for creating a coin split with change and without, these tests will test both the output manager memory_db and sqlite_db implementations.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [x] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch.
* [x] I ran `cargo-fmt --all` before pushing.
* [x] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
