### PR TITLE
Perform reorgs only on stronger tip accumulated difficulties

### DIFF
--- a/applications/tari_base_node/src/builder.rs
+++ b/applications/tari_base_node/src/builder.rs
@@ -82,6 +82,7 @@ use tari_core::{
         types::{CryptoFactories, HashDigest, PrivateKey, PublicKey},
     },
     validation::{
+        accum_difficulty_validators::AccumDifficultyValidator,
         block_validators::{FullConsensusValidator, StatelessBlockValidator},
         transaction_validators::{FullTxValidator, TxInputAndMaturityValidator},
     },
@@ -462,6 +463,7 @@ where
     let validators = Validators::new(
         FullConsensusValidator::new(rules.clone(), factories.clone()),
         StatelessBlockValidator::new(&rules.consensus_constants()),
+        AccumDifficultyValidator {},
     );
     // TODO - make BlockchainDatabaseConfig configurable
     let db = BlockchainDatabase::new(backend, &rules, validators, BlockchainDatabaseConfig::default())

--- a/base_layer/core/src/helpers/mod.rs
+++ b/base_layer/core/src/helpers/mod.rs
@@ -30,7 +30,7 @@ use crate::{
     chain_storage::{BlockchainDatabase, BlockchainDatabaseConfig, MemoryDatabase, Validators},
     consensus::{ConsensusConstants, ConsensusManager},
     transactions::{transaction::Transaction, types::HashDigest},
-    validation::mocks::MockValidator,
+    validation::{accum_difficulty_validators::MockAccumDifficultyValidator, mocks::MockValidator},
 };
 
 pub use mock_backend::MockBackend;
@@ -49,7 +49,11 @@ pub fn create_orphan_block(
 }
 
 pub fn create_mem_db(consensus_manager: &ConsensusManager) -> BlockchainDatabase<MemoryDatabase<HashDigest>> {
-    let validators = Validators::new(MockValidator::new(true), MockValidator::new(true));
+    let validators = Validators::new(
+        MockValidator::new(true),
+        MockValidator::new(true),
+        MockAccumDifficultyValidator {},
+    );
     let db = MemoryDatabase::<HashDigest>::default();
     BlockchainDatabase::new(db, consensus_manager, validators, BlockchainDatabaseConfig::default()).unwrap()
 }

--- a/base_layer/core/src/validation/accum_difficulty_validators.rs
+++ b/base_layer/core/src/validation/accum_difficulty_validators.rs
@@ -1,0 +1,63 @@
+// Copyright 2019. The Tari Project
+//
+// Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+// following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+// disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+// following disclaimer in the documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+// products derived from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+// INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+// WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+// USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+use crate::{
+    chain_storage::BlockchainBackend,
+    proof_of_work::Difficulty,
+    validation::{Validation, ValidationError},
+};
+
+/// This validator will check if a provided accumulated difficulty is stronger than the chain tip.
+#[derive(Clone)]
+pub struct AccumDifficultyValidator {}
+
+impl<B: BlockchainBackend> Validation<Difficulty, B> for AccumDifficultyValidator {
+    fn validate(&self, accum_difficulty: &Difficulty, db: &B) -> Result<(), ValidationError> {
+        let tip_header = db
+            .fetch_last_header()
+            .map_err(|e| ValidationError::CustomError(e.to_string()))?
+            .ok_or_else(|| ValidationError::CustomError("Cannot retrieve tip header. Blockchain DB is empty".into()))?;
+        if *accum_difficulty <= tip_header.total_accumulated_difficulty_inclusive() {
+            return Err(ValidationError::WeakerAccumulatedDifficulty);
+        }
+        Ok(())
+    }
+}
+
+/// This a mock validator that can be used for testing, it will check if a provided accumulated difficulty is equal or
+/// stronger than the chain tip. This will simplify testing where small testing blockchains need to be constructed as
+/// the accumulated difficulty of preceding blocks don't have to have an increasing accumulated difficulty.
+#[derive(Clone)]
+pub struct MockAccumDifficultyValidator {}
+
+impl<B: BlockchainBackend> Validation<Difficulty, B> for MockAccumDifficultyValidator {
+    fn validate(&self, accum_difficulty: &Difficulty, db: &B) -> Result<(), ValidationError> {
+        let tip_header = db
+            .fetch_last_header()
+            .map_err(|e| ValidationError::CustomError(e.to_string()))?
+            .ok_or_else(|| ValidationError::CustomError("Cannot retrieve tip header. Blockchain DB is empty".into()))?;
+        if *accum_difficulty < tip_header.total_accumulated_difficulty_inclusive() {
+            return Err(ValidationError::WeakerAccumulatedDifficulty);
+        }
+        Ok(())
+    }
+}

--- a/base_layer/core/src/validation/error.rs
+++ b/base_layer/core/src/validation/error.rs
@@ -46,4 +46,6 @@ pub enum ValidationError {
     InvalidAccountingBalance,
     // Transaction contains already spent inputs
     ContainsSTxO,
+    // The recorded chain accumulated difficulty was stronger
+    WeakerAccumulatedDifficulty,
 }

--- a/base_layer/core/src/validation/mod.rs
+++ b/base_layer/core/src/validation/mod.rs
@@ -35,4 +35,5 @@ pub mod block_validators;
 pub mod mocks;
 pub use error::ValidationError;
 pub use traits::{StatelessValidation, StatelessValidator, Validation, Validator};
+pub mod accum_difficulty_validators;
 pub mod transaction_validators;

--- a/base_layer/core/tests/block_validation.rs
+++ b/base_layer/core/tests/block_validation.rs
@@ -25,7 +25,10 @@ use tari_core::{
     consensus::{ConsensusManagerBuilder, Network},
     proof_of_work::DiffAdjManager,
     transactions::types::{CryptoFactories, HashDigest},
-    validation::block_validators::{FullConsensusValidator, StatelessBlockValidator},
+    validation::{
+        accum_difficulty_validators::AccumDifficultyValidator,
+        block_validators::{FullConsensusValidator, StatelessBlockValidator},
+    },
 };
 
 #[test]
@@ -37,6 +40,7 @@ fn test_genesis_block() {
     let validators = Validators::new(
         FullConsensusValidator::new(rules.clone(), factories),
         StatelessBlockValidator::new(&rules.consensus_constants()),
+        AccumDifficultyValidator {},
     );
     let db = BlockchainDatabase::new(backend, &rules, validators, BlockchainDatabaseConfig::default()).unwrap();
     let diff_adj_manager = DiffAdjManager::new(&rules.consensus_constants()).unwrap();

--- a/base_layer/core/tests/chain_storage_tests/chain_storage.rs
+++ b/base_layer/core/tests/chain_storage_tests/chain_storage.rs
@@ -58,7 +58,11 @@ use tari_core::{
     },
     tx,
     txn_schema,
-    validation::{block_validators::StatelessBlockValidator, mocks::MockValidator},
+    validation::{
+        accum_difficulty_validators::MockAccumDifficultyValidator,
+        block_validators::StatelessBlockValidator,
+        mocks::MockValidator,
+    },
 };
 use tari_crypto::tari_utilities::{hex::Hex, Hashable};
 use tari_mmr::{MmrCacheConfig, MutableMmr};
@@ -755,7 +759,11 @@ fn handle_reorg() {
 #[test]
 fn store_and_retrieve_blocks() {
     let mmr_cache_config = MmrCacheConfig { rewind_hist_len: 2 };
-    let validators = Validators::new(MockValidator::new(true), MockValidator::new(true));
+    let validators = Validators::new(
+        MockValidator::new(true),
+        MockValidator::new(true),
+        MockAccumDifficultyValidator {},
+    );
     let network = Network::LocalNet;
     let rules = ConsensusManagerBuilder::new(network).build();
     let db = MemoryDatabase::<HashDigest>::new(mmr_cache_config);
@@ -778,7 +786,11 @@ fn store_and_retrieve_blocks() {
 #[test]
 fn store_and_retrieve_chain_and_orphan_blocks_with_hashes() {
     let mmr_cache_config = MmrCacheConfig { rewind_hist_len: 2 };
-    let validators = Validators::new(MockValidator::new(true), MockValidator::new(true));
+    let validators = Validators::new(
+        MockValidator::new(true),
+        MockValidator::new(true),
+        MockAccumDifficultyValidator {},
+    );
     let network = Network::LocalNet;
     let rules = ConsensusManagerBuilder::new(network).build();
     let db = MemoryDatabase::<HashDigest>::new(mmr_cache_config);
@@ -805,7 +817,11 @@ fn restore_metadata() {
 
     // Perform test
     {
-        let validators = Validators::new(MockValidator::new(true), MockValidator::new(true));
+        let validators = Validators::new(
+            MockValidator::new(true),
+            MockValidator::new(true),
+            MockAccumDifficultyValidator {},
+        );
         let network = Network::LocalNet;
         let rules = ConsensusManagerBuilder::new(network).build();
         let block_hash: BlockHash;
@@ -854,6 +870,7 @@ fn invalid_block() {
         let validators = Validators::new(
             MockValidator::new(true),
             StatelessBlockValidator::new(&consensus_manager.consensus_constants()),
+            MockAccumDifficultyValidator {},
         );
         let db = create_lmdb_database(&temp_path, MmrCacheConfig::default()).unwrap();
         let mut store =
@@ -971,7 +988,11 @@ fn invalid_block() {
 fn orphan_cleanup_on_block_add() {
     let network = Network::LocalNet;
     let consensus_manager = ConsensusManagerBuilder::new(network).build();
-    let validators = Validators::new(MockValidator::new(true), MockValidator::new(true));
+    let validators = Validators::new(
+        MockValidator::new(true),
+        MockValidator::new(true),
+        MockAccumDifficultyValidator {},
+    );
     let db = MemoryDatabase::<HashDigest>::default();
     let config = BlockchainDatabaseConfig {
         orphan_storage_capacity: 3,
@@ -1021,7 +1042,11 @@ fn orphan_cleanup_on_reorg() {
         .with_consensus_constants(consensus_constants)
         .with_block(block0.clone())
         .build();
-    let validators = Validators::new(MockValidator::new(true), MockValidator::new(true));
+    let validators = Validators::new(
+        MockValidator::new(true),
+        MockValidator::new(true),
+        MockAccumDifficultyValidator {},
+    );
     let db = MemoryDatabase::<HashDigest>::default();
     let config = BlockchainDatabaseConfig {
         orphan_storage_capacity: 3,

--- a/base_layer/core/tests/node_service.rs
+++ b/base_layer/core/tests/node_service.rs
@@ -60,7 +60,11 @@ use tari_core::{
         types::CryptoFactories,
     },
     txn_schema,
-    validation::{block_validators::StatelessBlockValidator, mocks::MockValidator},
+    validation::{
+        accum_difficulty_validators::MockAccumDifficultyValidator,
+        block_validators::StatelessBlockValidator,
+        mocks::MockValidator,
+    },
 };
 use tari_crypto::tari_utilities::hash::Hashable;
 use tari_mmr::MmrCacheConfig;
@@ -504,6 +508,7 @@ fn propagate_and_forward_invalid_block() {
         .build();
     let stateless_block_validator = StatelessBlockValidator::new(&rules.consensus_constants());
     let mock_validator = MockValidator::new(true);
+    let mock_accum_difficulty_validator = MockAccumDifficultyValidator {};
     let (mut alice_node, rules) = BaseNodeBuilder::new(network)
         .with_node_identity(alice_node_identity.clone())
         .with_peers(vec![bob_node_identity.clone(), carol_node_identity.clone()])
@@ -513,13 +518,21 @@ fn propagate_and_forward_invalid_block() {
         .with_node_identity(bob_node_identity.clone())
         .with_peers(vec![alice_node_identity.clone(), dan_node_identity.clone()])
         .with_consensus_manager(rules)
-        .with_validators(mock_validator.clone(), stateless_block_validator.clone())
+        .with_validators(
+            mock_validator.clone(),
+            stateless_block_validator.clone(),
+            mock_accum_difficulty_validator.clone(),
+        )
         .start(&mut runtime, temp_dir.path().to_str().unwrap());
     let (carol_node, rules) = BaseNodeBuilder::new(network)
         .with_node_identity(carol_node_identity.clone())
         .with_peers(vec![alice_node_identity, dan_node_identity.clone()])
         .with_consensus_manager(rules)
-        .with_validators(mock_validator.clone(), stateless_block_validator)
+        .with_validators(
+            mock_validator.clone(),
+            stateless_block_validator,
+            mock_accum_difficulty_validator.clone(),
+        )
         .start(&mut runtime, temp_dir.path().to_str().unwrap());
     let (dan_node, rules) = BaseNodeBuilder::new(network)
         .with_node_identity(dan_node_identity)

--- a/base_layer/core/tests/node_state_machine.rs
+++ b/base_layer/core/tests/node_state_machine.rs
@@ -62,7 +62,11 @@ use tari_core::{
     helpers::create_mem_db,
     mempool::MempoolServiceConfig,
     transactions::types::CryptoFactories,
-    validation::{block_validators::StatelessBlockValidator, mocks::MockValidator},
+    validation::{
+        accum_difficulty_validators::MockAccumDifficultyValidator,
+        block_validators::StatelessBlockValidator,
+        mocks::MockValidator,
+    },
 };
 use tari_mmr::MmrCacheConfig;
 use tari_p2p::services::liveness::LivenessConfig;
@@ -611,7 +615,11 @@ fn test_sync_peer_banning() {
         .with_mempool_service_config(mempool_service_config)
         .with_liveness_service_config(liveness_service_config)
         .with_consensus_manager(consensus_manager)
-        .with_validators(mock_validator, stateless_block_validator)
+        .with_validators(
+            mock_validator,
+            stateless_block_validator,
+            MockAccumDifficultyValidator {},
+        )
         .start(&mut runtime, data_path);
     let (bob_node, consensus_manager) = BaseNodeBuilder::new(network)
         .with_node_identity(bob_node_identity)


### PR DESCRIPTION
## Description
- These changes will allow the accumulated difficulty to be checked using validators. The accumulated difficulty check was also updated that chain reorgs should only occur when the fork chain has a higher accumulated difficulty.
- When competing chain tip blocks are encountered with similar accumulated difficulty then the local chain will wait for the next block to determine which of the two chains are the dominant chain.
- A mock accumulated difficulty validator was also introduced that can be used for generating simpler test blockchains where the accumulated difficulty for each preceding block does not have to increase.

## Motivation and Context
Introduced accumulated difficulty validators to allow different rules for testing and running running a base node.

## How Has This Been Tested?
Covered by existing tests.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [x] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch.
* [x] I ran `cargo-fmt --all` before pushing.
* [x] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
