### PR TITLE
Dht and Store and forward fixes

### DIFF
--- a/applications/tari_base_node/src/builder.rs
+++ b/applications/tari_base_node/src/builder.rs
@@ -1005,7 +1005,10 @@ async fn setup_wallet_comms(
         max_concurrent_inbound_tasks: 100,
         outbound_buffer_size: 100,
         // TODO - make this configurable
-        dht: Default::default(),
+        dht: DhtConfig {
+            database_url: DbConnectionUrl::File(config.data_dir.join("dht-wallet.db")),
+            ..Default::default()
+        },
         // TODO: This should be false unless testing locally - make this configurable
         allow_test_addresses: true,
         listener_liveness_whitelist_cidrs: Vec::new(),

--- a/comms/dht/src/broadcast_strategy.rs
+++ b/comms/dht/src/broadcast_strategy.rs
@@ -72,6 +72,14 @@ impl fmt::Display for BroadcastStrategy {
 }
 
 impl BroadcastStrategy {
+    pub fn is_broadcast(&self) -> bool {
+        use BroadcastStrategy::*;
+        match self {
+            Closest(_) | Flood | Neighbours(_, _) | Random(_) => true,
+            _ => false,
+        }
+    }
+
     pub fn is_direct(&self) -> bool {
         use BroadcastStrategy::*;
         match self {

--- a/comms/dht/src/config.rs
+++ b/comms/dht/src/config.rs
@@ -107,7 +107,7 @@ impl Default for DhtConfig {
         Self {
             num_neighbouring_nodes: DEFAULT_NUM_NEIGHBOURING_NODES,
             saf_num_closest_nodes: 10,
-            saf_max_returned_messages: 100,
+            saf_max_returned_messages: 50,
             outbound_buffer_size: 20,
             saf_msg_cache_storage_capacity: SAF_MSG_CACHE_STORAGE_CAPACITY,
             saf_low_priority_msg_storage_ttl: SAF_LOW_PRIORITY_MSG_STORAGE_TTL,

--- a/comms/dht/src/discovery/service.rs
+++ b/comms/dht/src/discovery/service.rs
@@ -194,25 +194,25 @@ impl DhtDiscoveryService {
                         );
                     }
                 } else {
-                    if !self.has_inflight_discovery(&peer.public_key) {
-                        debug!(
-                            target: LOG_TARGET,
-                            "Attempting to discover peer '{}' because we failed to connect on all addresses for the
-                    peer",
-                            peer.node_id.short_str()
-                        );
-
-                        // Don't need to be notified for this discovery
-                        let (reply_tx, _) = oneshot::channel();
-                        // Send out a discovery for that peer without keeping track of it as an inflight discovery
-                        let dest_pubkey = Box::new(peer.public_key);
-                        self.initiate_peer_discovery(
-                            dest_pubkey.clone(),
-                            NodeDestination::PublicKey(dest_pubkey),
-                            reply_tx,
-                        )
-                        .await?;
-                    }
+                    // if !self.has_inflight_discovery(&peer.public_key) {
+                    //     debug!(
+                    //         target: LOG_TARGET,
+                    //         "Attempting to discover peer '{}' because we failed to connect on all addresses for the
+                    // peer",
+                    //         peer.node_id.short_str()
+                    //     );
+                    //
+                    //     // Don't need to be notified for this discovery
+                    //     let (reply_tx, _) = oneshot::channel();
+                    //     // Send out a discovery for that peer without keeping track of it as an inflight discovery
+                    //     let dest_pubkey = Box::new(peer.public_key);
+                    //     self.initiate_peer_discovery(
+                    //         dest_pubkey.clone(),
+                    //         NodeDestination::PublicKey(dest_pubkey),
+                    //         reply_tx,
+                    //     )
+                    //     .await?;
+                    // }
                 }
             },
             _ => {},
@@ -221,11 +221,11 @@ impl DhtDiscoveryService {
         Ok(())
     }
 
-    fn has_inflight_discovery(&self, public_key: &CommsPublicKey) -> bool {
-        self.inflight_discoveries
-            .values()
-            .all(|state| &*state.public_key != public_key)
-    }
+    // fn has_inflight_discovery(&self, public_key: &CommsPublicKey) -> bool {
+    //     self.inflight_discoveries
+    //         .values()
+    //         .all(|state| &*state.public_key != public_key)
+    // }
 
     fn collect_all_discovery_requests(&mut self, public_key: &CommsPublicKey) -> Vec<DiscoveryRequestState> {
         let mut requests = Vec::new();

--- a/comms/dht/src/inbound/mod.rs
+++ b/comms/dht/src/inbound/mod.rs
@@ -21,7 +21,6 @@
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 mod decryption;
-mod dedup;
 mod deserialize;
 mod dht_handler;
 mod error;
@@ -30,7 +29,6 @@ mod validate;
 
 pub use self::{
     decryption::DecryptionLayer,
-    dedup::DedupLayer,
     deserialize::DeserializeLayer,
     dht_handler::DhtHandlerLayer,
     message::{DecryptedDhtMessage, DhtInboundMessage},

--- a/comms/dht/src/lib.rs
+++ b/comms/dht/src/lib.rs
@@ -140,6 +140,9 @@ pub use discovery::DhtDiscoveryRequester;
 mod storage;
 pub use storage::DbConnectionUrl;
 
+mod dedup;
+pub use dedup::DedupLayer;
+
 mod logging_middleware;
 mod proto;
 mod tower_filter;

--- a/comms/dht/src/outbound/broadcast.rs
+++ b/comms/dht/src/outbound/broadcast.rs
@@ -261,6 +261,8 @@ where S: Service<DhtOutboundMessage, Response = (), Error = PipelineError>
                     is_discovery_enabled,
                 );
 
+                let is_broadcast = broadcast_strategy.is_broadcast();
+
                 // Discovery is required if:
                 //  - Discovery is enabled for this request
                 //  - There where no peers returned
@@ -301,6 +303,7 @@ where S: Service<DhtOutboundMessage, Response = (), Error = PipelineError>
                         dht_header,
                         dht_message_flags,
                         force_origin,
+                        is_broadcast,
                         body,
                     )
                     .await
@@ -389,6 +392,7 @@ where S: Service<DhtOutboundMessage, Response = (), Error = PipelineError>
         custom_header: Option<DhtMessageHeader>,
         extra_flags: DhtMessageFlags,
         force_origin: bool,
+        is_broadcast: bool,
         body: Bytes,
     ) -> Result<(Vec<DhtOutboundMessage>, Vec<MessageSendState>), DhtOutboundError>
     {
@@ -416,6 +420,7 @@ where S: Service<DhtOutboundMessage, Response = (), Error = PipelineError>
                         reply_tx: reply_tx.into(),
                         ephemeral_public_key: None,
                         origin_mac: None,
+                        is_broadcast,
                     },
                     send_state,
                 )

--- a/comms/dht/src/outbound/message.rs
+++ b/comms/dht/src/outbound/message.rs
@@ -180,6 +180,7 @@ pub struct DhtOutboundMessage {
     pub reply_tx: WrappedReplyTx,
     pub network: Network,
     pub dht_flags: DhtMessageFlags,
+    pub is_broadcast: bool,
 }
 
 impl DhtOutboundMessage {

--- a/comms/dht/src/store_forward/database/mod.rs
+++ b/comms/dht/src/store_forward/database/mod.rs
@@ -80,11 +80,11 @@ impl StoreAndForwardDatabase {
                     .into_boxed();
 
                 if let Some(since) = since {
-                    query = query.filter(stored_messages::stored_at.ge(since.naive_utc()));
+                    query = query.filter(stored_messages::stored_at.gt(since.naive_utc()));
                 }
 
                 query
-                    .order_by(stored_messages::stored_at.asc())
+                    .order_by(stored_messages::stored_at.desc())
                     .limit(limit)
                     .get_results(conn)
                     .map_err(Into::into)
@@ -112,11 +112,11 @@ impl StoreAndForwardDatabase {
                     .into_boxed();
 
                 if let Some(since) = since {
-                    query = query.filter(stored_messages::stored_at.ge(since.naive_utc()));
+                    query = query.filter(stored_messages::stored_at.gt(since.naive_utc()));
                 }
 
                 query
-                    .order_by(stored_messages::stored_at.asc())
+                    .order_by(stored_messages::stored_at.desc())
                     .limit(limit)
                     .get_results(conn)
                     .map_err(Into::into)
@@ -162,11 +162,11 @@ impl StoreAndForwardDatabase {
                     .into_boxed();
 
                 if let Some(since) = since {
-                    query = query.filter(stored_messages::stored_at.ge(since.naive_utc()));
+                    query = query.filter(stored_messages::stored_at.gt(since.naive_utc()));
                 }
 
                 query
-                    .order_by(stored_messages::stored_at.asc())
+                    .order_by(stored_messages::stored_at.desc())
                     .limit(limit)
                     .get_results(conn)
                     .map_err(Into::into)
@@ -192,11 +192,11 @@ impl StoreAndForwardDatabase {
                     .into_boxed();
 
                 if let Some(since) = since {
-                    query = query.filter(stored_messages::stored_at.ge(since.naive_utc()));
+                    query = query.filter(stored_messages::stored_at.gt(since.naive_utc()));
                 }
 
                 query
-                    .order_by(stored_messages::stored_at.asc())
+                    .order_by(stored_messages::stored_at.desc())
                     .limit(limit)
                     .get_results(conn)
                     .map_err(Into::into)

--- a/comms/dht/src/store_forward/message.rs
+++ b/comms/dht/src/store_forward/message.rs
@@ -40,7 +40,7 @@ use std::{
 pub(crate) fn datetime_to_timestamp(datetime: DateTime<Utc>) -> Timestamp {
     Timestamp {
         seconds: datetime.timestamp(),
-        nanos: datetime.timestamp_subsec_nanos() as i32,
+        nanos: datetime.timestamp_subsec_nanos().try_into().unwrap_or(std::i32::MAX),
     }
 }
 

--- a/comms/dht/src/store_forward/store.rs
+++ b/comms/dht/src/store_forward/store.rs
@@ -241,7 +241,7 @@ where S: Service<DecryptedDhtMessage, Response = (), Error = PipelineError>
             Some(_) => {
                 // If the message doesnt have an origin we wont store it
                 if !message.has_origin_mac() {
-                    log_not_eligible("it is encrypted and does not have an origin MAC");
+                    log_not_eligible("it is a cleartext message and does not have an origin MAC");
                     return Ok(None);
                 }
 

--- a/comms/dht/src/test_utils/makers.rs
+++ b/comms/dht/src/test_utils/makers.rs
@@ -221,5 +221,6 @@ pub fn create_outbound_message(body: &[u8]) -> DhtOutboundMessage {
         ephemeral_public_key: None,
         reply_tx: WrappedReplyTx::none(),
         origin_mac: None,
+        is_broadcast: false,
     }
 }

--- a/comms/src/peer_manager/peer.rs
+++ b/comms/src/peer_manager/peer.rs
@@ -226,6 +226,10 @@ impl Peer {
         self.banned_until = None;
     }
 
+    pub fn banned_until(&self) -> Option<&NaiveDateTime> {
+        self.banned_until.as_ref()
+    }
+
     /// Marks the peer as offline
     pub fn set_offline(&mut self, is_offline: bool) {
         if is_offline {
@@ -244,8 +248,20 @@ impl Display for Peer {
         } else {
             format!("{:?}", self.flags)
         };
+
+        let status_str = {
+            let mut s = Vec::new();
+            if let Some(offline_at) = self.offline_at.as_ref() {
+                s.push(format!("OFFLINE since {}", offline_at));
+            }
+
+            if let Some(dt) = self.banned_until() {
+                s.push(format!("BANNED until {}", dt));
+            }
+            s.join(", ")
+        };
         f.write_str(&format!(
-            "{}[{}] PK={} {} {:?} {}",
+            "{}[{}] PK={} ({}) {} {:?} {}",
             flags_str,
             self.node_id.short_str(),
             self.public_key,
@@ -255,6 +271,7 @@ impl Display for Peer {
                 .map(ToString::to_string)
                 .collect::<Vec<_>>()
                 .join(","),
+            status_str,
             match self.features {
                 PeerFeatures::COMMUNICATION_NODE => "BASE_NODE".to_string(),
                 PeerFeatures::COMMUNICATION_CLIENT => "WALLET".to_string(),

--- a/comms/src/protocol/messaging/protocol.rs
+++ b/comms/src/protocol/messaging/protocol.rs
@@ -84,7 +84,7 @@ impl fmt::Display for MessagingEvent {
             MessageReceived(node_id, tag) => write!(f, "MessageReceived({}, {})", node_id.short_str(), tag),
             InvalidMessageReceived(node_id) => write!(f, "InvalidMessageReceived({})", node_id.short_str()),
             SendMessageFailed(out_msg, reason) => write!(f, "SendMessageFailed({}, Reason = {})", out_msg, reason),
-            MessageSent(tag) => write!(f, "SendMessageSucceeded({})", tag),
+            MessageSent(tag) => write!(f, "MessageSent({})", tag),
         }
     }
 }


### PR DESCRIPTION
- [bug] BN wallet and BN shared same dht db
- [bug] accidently used `.gt` when comparing key strings
- [stopgap] return 50 store and forward messages instead of 100
- [spam] Don't do discovery if failing to connect to a peer
- [stopgap] return most recent messages rather than oldest that are stored (protocol needs to be extended to allow for something like paginated queries)
- [bug] response sends stored messages `>` requested timestamp, as `>=`  could result in duplicates being sent
- [test] integration test for propagation of messages and dedup
- [optimisation] Add outbound broadcast messages to dedup cache to
  prevent mistaken rebroadcasting

_No database or network breaking changes_