### PR TITLE
Network fork

### DIFF
--- a/comms/dht/src/store_forward/saf_handler/task.rs
+++ b/comms/dht/src/store_forward/saf_handler/task.rs
@@ -196,8 +196,8 @@ where S: Service<DecryptedDhtMessage, Response = (), Error = PipelineError>
 
         let response_types = vec![
             SafResponseType::ForMe,
-            SafResponseType::InRegion,
-            SafResponseType::Discovery,
+            /* SafResponseType::InRegion,
+             * SafResponseType::Discovery, */
         ];
 
         for resp_type in response_types {

--- a/comms/src/connection_manager/wire_mode.rs
+++ b/comms/src/connection_manager/wire_mode.rs
@@ -23,7 +23,7 @@
 use std::convert::TryFrom;
 
 pub enum WireMode {
-    Comms = 0x01,
+    Comms = 0x02,
     Liveness = 0x45, // E
 }
 
@@ -32,7 +32,7 @@ impl TryFrom<u8> for WireMode {
 
     fn try_from(value: u8) -> Result<Self, Self::Error> {
         match value {
-            0x01 => Ok(WireMode::Comms),
+            0x02 => Ok(WireMode::Comms),
             0x45 => Ok(WireMode::Liveness),
             _ => Err(()),
         }


### PR DESCRIPTION
- Fork network to prevent old nodes from spamming
- Don't send discovery back from S&F
