### PR TITLE
Update Tx Service to one-shot response for SendDirect(..) and fix Output manager encumbrance bug

### DIFF
--- a/applications/tari_base_node/src/builder.rs
+++ b/applications/tari_base_node/src/builder.rs
@@ -1158,7 +1158,6 @@ async fn register_wallet_services(
         .add_initializer(TransactionServiceInitializer::new(
             TransactionServiceConfig::default(),
             subscription_factory,
-            wallet_comms.message_event_sender(),
             TransactionServiceSqliteDatabase::new(wallet_db_conn.clone()),
             wallet_comms.node_identity(),
             factories,

--- a/base_layer/wallet/src/output_manager_service/service.rs
+++ b/base_layer/wallet/src/output_manager_service/service.rs
@@ -465,6 +465,7 @@ where
             .accept_incoming_pending_transaction(tx_id, amount, key.clone(), OutputFeatures::default())
             .await?;
 
+        self.confirm_encumberance(tx_id).await?;
         Ok(key)
     }
 
@@ -654,6 +655,10 @@ where
 
     /// Cancel a pending transaction and place the encumbered outputs back into the unspent pool
     pub async fn cancel_transaction(&mut self, tx_id: u64) -> Result<(), OutputManagerError> {
+        trace!(
+            target: LOG_TARGET,
+            "Cancelling pending transaction outputs for TxId: tx_id"
+        );
         Ok(self.db.cancel_pending_transaction_outputs(tx_id).await?)
     }
 

--- a/base_layer/wallet/src/output_manager_service/storage/memory_db.rs
+++ b/base_layer/wallet/src/output_manager_service/storage/memory_db.rs
@@ -140,7 +140,7 @@ impl OutputManagerBackend for OutputManagerMemoryDatabase {
                     db.unspent_outputs.push(*o);
                 },
                 DbKeyValuePair::PendingTransactionOutputs(t, p) => {
-                    db.pending_transactions.insert(t, *p);
+                    db.short_term_pending_transactions.insert(t, *p);
                 },
                 DbKeyValuePair::KeyManagerState(km) => db.key_manager_state = Some(km),
             },

--- a/base_layer/wallet/src/output_manager_service/storage/sqlite_db.rs
+++ b/base_layer/wallet/src/output_manager_service/storage/sqlite_db.rs
@@ -650,7 +650,7 @@ impl From<UpdateOutput> for UpdateOutputSql {
 
 /// This struct represents a PendingTransactionOutputs  in the Sql database. A distinct struct is required to define the
 /// Sql friendly equivalent datatypes for the members.
-#[derive(Clone, Queryable, Insertable)]
+#[derive(Debug, Clone, Queryable, Insertable)]
 #[table_name = "pending_transaction_outputs"]
 struct PendingTransactionOutputSql {
     tx_id: i64,

--- a/base_layer/wallet/src/testnet_utils.rs
+++ b/base_layer/wallet/src/testnet_utils.rs
@@ -325,7 +325,7 @@ pub fn generate_wallet_test_data<
         MicroTari::from(100),
         messages[message_index].clone(),
     ))?;
-    outbound_tx_ids.push(tx_id.clone());
+    outbound_tx_ids.push(tx_id);
     message_index = (message_index + 1) % messages.len();
 
     let tx_id = wallet.runtime.block_on(wallet.transaction_service.send_transaction(
@@ -334,7 +334,7 @@ pub fn generate_wallet_test_data<
         MicroTari::from(110),
         messages[message_index].clone(),
     ))?;
-    outbound_tx_ids.push(tx_id.clone());
+    outbound_tx_ids.push(tx_id);
     message_index = (message_index + 1) % messages.len();
 
     wallet_alice.runtime.block_on(async {

--- a/base_layer/wallet/src/transaction_service/mod.rs
+++ b/base_layer/wallet/src/transaction_service/mod.rs
@@ -39,7 +39,7 @@ use crate::{
 use futures::{future, Future, Stream, StreamExt};
 use log::*;
 use std::sync::Arc;
-use tari_comms::{peer_manager::NodeIdentity, protocol::messaging::MessagingEventSender};
+use tari_comms::peer_manager::NodeIdentity;
 use tari_comms_dht::outbound::OutboundMessageRequester;
 use tari_core::{
     base_node::proto::base_node as BaseNodeProto,
@@ -69,7 +69,6 @@ where T: TransactionBackend
 {
     config: TransactionServiceConfig,
     subscription_factory: Arc<TopicSubscriptionFactory<TariMessageType, Arc<PeerMessage>>>,
-    message_event_receiver: Option<MessagingEventSender>,
     backend: Option<T>,
     node_identity: Arc<NodeIdentity>,
     factories: CryptoFactories,
@@ -81,7 +80,6 @@ where T: TransactionBackend
     pub fn new(
         config: TransactionServiceConfig,
         subscription_factory: Arc<TopicSubscriptionFactory<TariMessageType, Arc<PeerMessage>>>,
-        message_event_receiver: MessagingEventSender,
         backend: T,
         node_identity: Arc<NodeIdentity>,
         factories: CryptoFactories,
@@ -90,7 +88,6 @@ where T: TransactionBackend
         Self {
             config,
             subscription_factory,
-            message_event_receiver: Some(message_event_receiver),
             backend: Some(backend),
             node_identity,
             factories,
@@ -165,11 +162,6 @@ where T: TransactionBackend + Clone + 'static
             .take()
             .expect("Cannot start Transaction Service without providing a backend");
 
-        let message_event_receiver = self
-            .message_event_receiver
-            .take()
-            .expect("Cannot start Transaction Service without providing an Message Event Receiver");
-
         let node_identity = self.node_identity.clone();
         let factories = self.factories.clone();
         let config = self.config.clone();
@@ -195,7 +187,6 @@ where T: TransactionBackend + Clone + 'static
                 base_node_response_stream,
                 output_manager_service,
                 outbound_message_service,
-                message_event_receiver,
                 publisher,
                 node_identity,
                 factories,

--- a/base_layer/wallet/src/wallet.rs
+++ b/base_layer/wallet/src/wallet.rs
@@ -156,7 +156,6 @@ where
             .add_initializer(TransactionServiceInitializer::new(
                 config.transaction_service_config.unwrap_or_default(),
                 subscription_factory.clone(),
-                comms.message_event_sender(),
                 transaction_backend,
                 comms.node_identity(),
                 factories.clone(),

--- a/base_layer/wallet/tests/output_manager_service/service.rs
+++ b/base_layer/wallet/tests/output_manager_service/service.rs
@@ -680,7 +680,7 @@ fn test_startup_utxo_scan() {
     let output3 = UnblindedOutput::new(MicroTari::from(value3), key3, None);
     runtime.block_on(oms.add_output(output3.clone())).unwrap();
 
-    let (_, body, _) = outbound_service.pop_call().unwrap();
+    let (_, body) = outbound_service.pop_call().unwrap();
     let envelope_body = EnvelopeBody::decode(body.to_vec().as_slice()).unwrap();
     let bn_request: BaseNodeProto::BaseNodeServiceRequest = envelope_body
         .decode_part::<BaseNodeProto::BaseNodeServiceRequest>(1)
@@ -755,7 +755,7 @@ fn test_startup_utxo_scan() {
 
     runtime.block_on(oms.sync_with_base_node()).unwrap();
 
-    let (_, body, _) = outbound_service.pop_call().unwrap();
+    let (_, body) = outbound_service.pop_call().unwrap();
     let envelope_body = EnvelopeBody::decode(body.to_vec().as_slice()).unwrap();
     let bn_request: BaseNodeProto::BaseNodeServiceRequest = envelope_body
         .decode_part::<BaseNodeProto::BaseNodeServiceRequest>(1)

--- a/base_layer/wallet/tests/transaction_service/storage.rs
+++ b/base_layer/wallet/tests/transaction_service/storage.rs
@@ -270,7 +270,7 @@ pub fn test_db_backend<T: TransactionBackend + 'static>(backend: T) {
         );
         #[cfg(feature = "test_harness")]
         runtime
-            .block_on(db.broadcast_completed_transaction(completed_txs[0].tx_id.clone()))
+            .block_on(db.broadcast_completed_transaction(completed_txs[0].tx_id))
             .unwrap();
         let retrieved_completed_txs = runtime.block_on(db.get_completed_transactions()).unwrap();
 
@@ -282,7 +282,7 @@ pub fn test_db_backend<T: TransactionBackend + 'static>(backend: T) {
 
         #[cfg(feature = "test_harness")]
         runtime
-            .block_on(db.mine_completed_transaction(completed_txs[0].tx_id.clone()))
+            .block_on(db.mine_completed_transaction(completed_txs[0].tx_id))
             .unwrap();
         let retrieved_completed_txs = runtime.block_on(db.get_completed_transactions()).unwrap();
 

--- a/comms/dht/src/dht.rs
+++ b/comms/dht/src/dht.rs
@@ -447,7 +447,7 @@ mod test {
         service.call(inbound_message).await.unwrap();
 
         assert_eq!(oms_mock_state.call_count(), 1);
-        let (params, _, _) = oms_mock_state.pop_call().unwrap();
+        let (params, _) = oms_mock_state.pop_call().unwrap();
 
         // Check that OMS got a request to forward with the original Dht Header
         assert_eq!(params.dht_header.unwrap().origin_mac, origin_mac);

--- a/comms/dht/src/discovery/service.rs
+++ b/comms/dht/src/discovery/service.rs
@@ -550,7 +550,7 @@ mod test {
             assert!(result.unwrap_err().is_timeout());
 
             oms_mock_state.wait_call_count(1, Duration::from_secs(5)).unwrap();
-            let (params, _, _) = oms_mock_state.pop_call().unwrap();
+            let (params, _) = oms_mock_state.pop_call().unwrap();
             assert_eq!(params.dht_message_type, DhtMessageType::Discovery);
             assert_eq!(params.encryption, OutboundEncryption::EncryptFor(dest_public_key));
 

--- a/comms/dht/src/outbound/broadcast.rs
+++ b/comms/dht/src/outbound/broadcast.rs
@@ -384,7 +384,7 @@ where S: Service<DhtOutboundMessage, Response = (), Error = PipelineError>
             // Error during discovery
             Err(err) => {
                 debug!(target: LOG_TARGET, "Peer discovery failed because '{}'.", err);
-                Ok(None)
+                Err(DhtOutboundError::DiscoveryFailed)
             },
         }
     }

--- a/comms/dht/src/outbound/error.rs
+++ b/comms/dht/src/outbound/error.rs
@@ -45,4 +45,6 @@ pub enum DhtOutboundError {
     ReplyChannelCanceled,
     /// Attempted to send a message to ourselves
     SendToOurselves,
+    /// Discovery process failed
+    DiscoveryFailed,
 }

--- a/comms/dht/src/outbound/mock.rs
+++ b/comms/dht/src/outbound/mock.rs
@@ -50,7 +50,7 @@ pub fn create_outbound_service_mock(size: usize) -> (OutboundMessageRequester, O
 #[derive(Clone, Default)]
 pub struct OutboundServiceMockState {
     #[allow(clippy::type_complexity)]
-    calls: Arc<Mutex<Vec<(FinalSendMessageParams, Bytes, MessageTag)>>>,
+    calls: Arc<Mutex<Vec<(FinalSendMessageParams, Bytes)>>>,
     next_response: Arc<RwLock<Option<SendMessageResponse>>>,
     call_count_cond_var: Arc<Condvar>,
 }
@@ -94,7 +94,7 @@ impl OutboundServiceMockState {
     /// Wait for a call to be added or timeout.
     ///
     /// An error will be returned if the timeout expires.
-    pub fn wait_pop_call(&self, timeout: Duration) -> Result<(FinalSendMessageParams, Bytes, MessageTag), String> {
+    pub fn wait_pop_call(&self, timeout: Duration) -> Result<(FinalSendMessageParams, Bytes), String> {
         let call_guard = acquire_lock!(self.calls);
         let (mut call_guard, timeout) = self
             .call_count_cond_var
@@ -112,16 +112,16 @@ impl OutboundServiceMockState {
         acquire_write_lock!(self.next_response).take()
     }
 
-    pub fn add_call(&self, req: (FinalSendMessageParams, Bytes, MessageTag)) {
+    pub fn add_call(&self, req: (FinalSendMessageParams, Bytes)) {
         acquire_lock!(self.calls).push(req);
         self.call_count_cond_var.notify_all();
     }
 
-    pub fn take_calls(&self) -> Vec<(FinalSendMessageParams, Bytes, MessageTag)> {
+    pub fn take_calls(&self) -> Vec<(FinalSendMessageParams, Bytes)> {
         acquire_lock!(self.calls).drain(..).collect()
     }
 
-    pub fn pop_call(&self) -> Option<(FinalSendMessageParams, Bytes, MessageTag)> {
+    pub fn pop_call(&self) -> Option<(FinalSendMessageParams, Bytes)> {
         acquire_lock!(self.calls).pop()
     }
 }
@@ -147,8 +147,7 @@ impl OutboundServiceMock {
         while let Some(req) = self.receiver.next().await {
             match req {
                 DhtOutboundRequest::SendMessage(params, body, reply_tx) => {
-                    let tag = MessageTag::new();
-                    self.mock_state.add_call((*params, body, tag));
+                    self.mock_state.add_call((*params, body));
                     let (inner_reply_tx, inner_reply_rx) = oneshot::channel();
                     let response = self
                         .mock_state

--- a/comms/dht/src/store_forward/forward.rs
+++ b/comms/dht/src/store_forward/forward.rs
@@ -326,7 +326,7 @@ mod test {
         assert!(spy.is_called());
 
         assert_eq!(oms_mock_state.call_count(), 1);
-        let (params, body, _) = oms_mock_state.pop_call().unwrap();
+        let (params, body) = oms_mock_state.pop_call().unwrap();
 
         // Header and body are preserved when forwarding
         assert_eq!(&body.to_vec(), &sample_body);


### PR DESCRIPTION
## Description
This PR updates the Tx Service to use the embedded oneshot reply channel to determine if a Direct message was sent or not rather than relying on the MessagingEvent stream.

It also fixes a bug in the Output Manager service where an Inbound transaction output was not fully encumbered so if the app restarted it would be cleared as a short term encuberance.

Finally some Clippy cleanup.

## How Has This Been Tested?
Existing tests cover this

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [x] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch.
* [x] I ran `cargo-fmt --all` before pushing.
* [ ] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
