### PR TITLE
Use filesystem storage for dht.db on libwallet

### DIFF
--- a/comms/dht/src/actor.rs
+++ b/comms/dht/src/actor.rs
@@ -627,6 +627,7 @@ mod test {
     use crate::{
         broadcast_strategy::BroadcastClosestRequest,
         test_utils::{make_node_identity, make_peer_manager},
+        DbConnectionUrl,
     };
     use chrono::{DateTime, Utc};
     use tari_comms::{
@@ -634,6 +635,7 @@ mod test {
         peer_manager::{PeerFeatures, PeerFlags},
     };
     use tari_shutdown::Shutdown;
+    use tari_test_utils::random;
     use tokio::runtime;
 
     #[tokio_macros::test_basic]
@@ -781,7 +783,10 @@ mod test {
         let outbound_requester = OutboundMessageRequester::new(out_tx);
         let shutdown = Shutdown::new();
         let actor = DhtActor::new(
-            Default::default(),
+            DhtConfig {
+                database_url: DbConnectionUrl::MemoryShared(random::string(8)),
+                ..Default::default()
+            },
             node_identity,
             peer_manager,
             outbound_requester,


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
The DHT db was set to use an in-memory sqlite database on libwallet.
There is some DHT metadata that should be persisted. This change will
create a dht.db file in the datastore_path.

- Reused the datastore_path on `comms_config_create` ffi call
- Fixed flakey DHT test

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Some dht metadata should be persisted on mobile wallets

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Existing tests pass

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch.
* [x] I ran `cargo-fmt --all` before pushing.
* [x] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
