### PR TITLE
Update Transaction Service error logs represent repeated SAF messages

### DIFF
--- a/base_layer/wallet/src/transaction_service/service.rs
+++ b/base_layer/wallet/src/transaction_service/service.rs
@@ -290,13 +290,17 @@ where
                 msg = transaction_reply_stream.select_next_some() => {
                     trace!(target: LOG_TARGET, "Handling Transaction Reply Message");
                     let (origin_public_key, inner_msg) = msg.into_origin_and_inner();
-                    let result = self.accept_recipient_reply(origin_public_key, inner_msg).await.or_else(|err| {
-                        error!(target: LOG_TARGET, "Failed to handle incoming Transaction Reply message: {:?} for NodeId: {}", err, self.node_identity.node_id().short_str());
-                        Err(err)
-                    });
+                    let result = self.accept_recipient_reply(origin_public_key, inner_msg).await;
 
-                    if result.is_err() {
-                        let _ = self.event_publisher.send(Arc::new(TransactionEvent::Error("Error handling Transaction Recipient Reply message".to_string(),)));
+                    match result {
+                        Err(TransactionServiceError::TransactionDoesNotExistError) => {
+                            debug!(target: LOG_TARGET, "Unable to handle incoming Transaction Reply message from NodeId: {} due to Transaction not Existing. This usually means the message was a repeated message from Store and Forward", self.node_identity.node_id().short_str());
+                        },
+                        Err(e) => {
+                            error!(target: LOG_TARGET, "Failed to handle incoming Transaction Reply message: {:?} for NodeId: {}", e, self.node_identity.node_id().short_str());
+                            let _ = self.event_publisher.send(Arc::new(TransactionEvent::Error("Error handling Transaction Recipient Reply message".to_string())));
+                        },
+                        Ok(_) => (),
                     }
                 },
                // Incoming messages from the Comms layer
@@ -773,14 +777,17 @@ where
                 )
             })?;
 
-        let inbound_tx = self.db.get_pending_inbound_transaction(tx_id).await.map_err(|e| {
-            error!(
-                target: LOG_TARGET,
-                "Finalized transaction TxId does not exist in Pending Inbound Transactions, could be a repeat Store \
-                 and Forward message"
-            );
-            e
-        })?;
+        let inbound_tx = match self.db.get_pending_inbound_transaction(tx_id).await {
+            Ok(tx) => tx,
+            Err(_e) => {
+                warn!(
+                    target: LOG_TARGET,
+                    "TxId for received Finalized Transaction does not exist in Pending Inbound Transactions, could be \
+                     a repeat Store and Forward message"
+                );
+                return Ok(());
+            },
+        };
 
         info!(
             target: LOG_TARGET,
@@ -1101,7 +1108,14 @@ where
         let tx_id = response.request_key;
 
         let sender = match self.mempool_response_senders.get_mut(&tx_id) {
-            None => return Err(TransactionServiceError::UnexpectedMempoolResponse),
+            None => {
+                trace!(
+                    target: LOG_TARGET,
+                    "Received Mempool response with unexpected key: {}. Not for this service",
+                    response.request_key
+                );
+                return Ok(());
+            },
             Some(s) => s,
         };
         sender


### PR DESCRIPTION
Store & Forward can result in the delivery of repeated messages. The Transaction Service can tolerate this but logged error messages in response. This PR just updates the Transaction Service logging to be friendlier to these types of errors and present that they are likely from repeated SAF message.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [x] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch.
* [x] I ran `cargo-fmt --all` before pushing.
* [ ] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
