### PR TITLE
Fix chain monitoring bug in Transaction Service

### DIFF
--- a/base_layer/wallet/src/output_manager_service/storage/database.rs
+++ b/base_layer/wallet/src/output_manager_service/storage/database.rs
@@ -66,7 +66,8 @@ pub trait OutputManagerBackend: Send + Sync {
     /// transaction negotiation
     fn clear_short_term_encumberances(&self) -> Result<(), OutputManagerStorageError>;
     /// This method must take all the `outputs_to_be_spent` from the specified transaction and move them back into the
-    /// `UnspentOutputs` pool.
+    /// `UnspentOutputs` pool. The `outputs_to_be_received`'` will be marked as cancelled inbound outputs in case they
+    /// need to be recovered.
     fn cancel_pending_transaction(&self, tx_id: TxId) -> Result<(), OutputManagerStorageError>;
     /// This method must run through all the `PendingTransactionOutputs` and test if any have existed for longer that
     /// the specified duration. If they have they should be cancelled.

--- a/base_layer/wallet/src/output_manager_service/storage/sqlite_db.rs
+++ b/base_layer/wallet/src/output_manager_service/storage/sqlite_db.rs
@@ -346,7 +346,13 @@ impl OutputManagerBackend for OutputManagerSqliteDatabase {
 
                 for o in outputs {
                     if o.status == (OutputStatus::EncumberedToBeReceived as i32) {
-                        o.delete(&(*conn))?;
+                        o.update(
+                            UpdateOutput {
+                                status: Some(OutputStatus::CancelledInbound),
+                                tx_id: None,
+                            },
+                            &(*conn),
+                        )?;
                     } else if o.status == (OutputStatus::EncumberedToBeSpent as i32) {
                         o.update(
                             UpdateOutput {
@@ -446,6 +452,7 @@ enum OutputStatus {
     EncumberedToBeReceived,
     EncumberedToBeSpent,
     Invalid,
+    CancelledInbound,
 }
 
 impl TryFrom<i32> for OutputStatus {
@@ -458,6 +465,7 @@ impl TryFrom<i32> for OutputStatus {
             2 => Ok(OutputStatus::EncumberedToBeReceived),
             3 => Ok(OutputStatus::EncumberedToBeSpent),
             4 => Ok(OutputStatus::Invalid),
+            5 => Ok(OutputStatus::CancelledInbound),
             _ => Err(OutputManagerStorageError::ConversionError),
         }
     }

--- a/base_layer/wallet/tests/output_manager_service/storage.rs
+++ b/base_layer/wallet/tests/output_manager_service/storage.rs
@@ -387,6 +387,10 @@ pub async fn test_short_term_encumberance<T: OutputManagerBackend + 'static>(bac
     let balance = db.get_balance().await.unwrap();
     assert_eq!(available_balance, balance.available_balance);
 
+    pending_tx.outputs_to_be_received.clear();
+    let (_ti, uo) = make_input(&mut OsRng, MicroTari::from(50), &factories.commitment);
+    pending_tx.outputs_to_be_received.push(uo);
+
     db.encumber_outputs(pending_tx.tx_id, pending_tx.outputs_to_be_spent.clone(), vec![
         pending_tx.outputs_to_be_received[0].clone(),
     ])
@@ -398,6 +402,10 @@ pub async fn test_short_term_encumberance<T: OutputManagerBackend + 'static>(bac
 
     let balance = db.get_balance().await.unwrap();
     assert_eq!(balance.available_balance, MicroTari(0));
+
+    pending_tx.outputs_to_be_received.clear();
+    let (_ti, uo) = make_input(&mut OsRng, MicroTari::from(50), &factories.commitment);
+    pending_tx.outputs_to_be_received.push(uo);
 
     db.cancel_pending_transaction_outputs(pending_tx.tx_id).await.unwrap();
 


### PR DESCRIPTION
## Description
This PR fixes a bug where the Chain monitoring process in the Tx service was asleep for a long time and the pending Tx was mined and when they woke up they got the mempool response saying the Tx was no longer in the mempool BEFORE they get the Base Node response confirming its been mined. This used to result in the Pending Tx being cancelled. The Chain monitoring protocol was updated so that it will only cancel a pending tx in this way if it receives the mempool response AND the BN response and checks the BN response first.

The PR also stops completely deleting cancelled inbound UTXO’s and rather uses a status to mark them as deleted in case they need to be recovered.

## How Has This Been Tested?
Covered in existing tests

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch.
* [x] I ran `cargo-fmt --all` before pushing.
* [ ] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
