### PR TITLE
Request store and forward on connect

### DIFF
--- a/applications/tari_base_node/src/builder.rs
+++ b/applications/tari_base_node/src/builder.rs
@@ -1107,7 +1107,6 @@ where
             LivenessConfig {
                 auto_ping_interval: Some(Duration::from_secs(30)),
                 enable_auto_join: true,
-                enable_auto_stored_message_request: false,
                 refresh_neighbours_interval: Duration::from_secs(3 * 60),
             },
             subscription_factory,
@@ -1143,7 +1142,6 @@ async fn register_wallet_services(
             LivenessConfig{
                 auto_ping_interval: None,
                 enable_auto_join: true,
-                enable_auto_stored_message_request: true,
                 ..Default::default()
             },
             subscription_factory.clone(),

--- a/base_layer/core/tests/node_state_machine.rs
+++ b/base_layer/core/tests/node_state_machine.rs
@@ -96,7 +96,6 @@ fn test_listening_lagging() {
         MempoolServiceConfig::default(),
         LivenessConfig {
             enable_auto_join: false,
-            enable_auto_stored_message_request: false,
             auto_ping_interval: Some(Duration::from_millis(100)),
             refresh_neighbours_interval: Duration::from_secs(60),
         },

--- a/base_layer/p2p/examples/pingpong.rs
+++ b/base_layer/p2p/examples/pingpong.rs
@@ -202,7 +202,6 @@ mod pingpong {
                     .add_initializer(LivenessInitializer::new(
                         LivenessConfig {
                             auto_ping_interval: None, // Some(Duration::from_secs(5)),
-                            enable_auto_stored_message_request: false,
                             enable_auto_join: true,
                             ..Default::default()
                         },

--- a/base_layer/p2p/src/initialization.rs
+++ b/base_layer/p2p/src/initialization.rs
@@ -41,7 +41,7 @@ use tari_comms::{
     CommsBuilderError,
     CommsNode,
 };
-use tari_comms_dht::{Dht, DhtBuilder, DhtConfig};
+use tari_comms_dht::{Dht, DhtBuilder, DhtConfig, DhtInitializationError};
 use tari_storage::{lmdb_store::LMDBBuilder, LMDBWrapper};
 use tower::ServiceBuilder;
 
@@ -50,6 +50,7 @@ const LOG_TARGET: &str = "b::p2p::initialization";
 #[derive(Debug, Error)]
 pub enum CommsInitializationError {
     CommsBuilderError(CommsBuilderError),
+    DhtInitializationError(DhtInitializationError),
     HiddenServiceBuilderError(tor::HiddenServiceBuilderError),
     #[error(non_std, no_from, msg_embedded)]
     InvalidLivenessCidrs(String),
@@ -136,7 +137,8 @@ where
     )
     .local_test()
     .with_discovery_timeout(discovery_request_timeout)
-    .finish();
+    .finish()
+    .await?;
 
     let dht_outbound_layer = dht.outbound_middleware_layer();
 
@@ -297,7 +299,8 @@ where
         comms.shutdown_signal(),
     )
     .with_config(config.dht)
-    .finish();
+    .finish()
+    .await?;
 
     let dht_outbound_layer = dht.outbound_middleware_layer();
 

--- a/base_layer/p2p/src/services/liveness/config.rs
+++ b/base_layer/p2p/src/services/liveness/config.rs
@@ -29,8 +29,6 @@ pub struct LivenessConfig {
     pub auto_ping_interval: Option<Duration>,
     /// Set to true to enable automatically joining the network on node startup (default: false)
     pub enable_auto_join: bool,
-    /// Set to true to enable a request for stored messages on node startup (default: false)
-    pub enable_auto_stored_message_request: bool,
     /// The length of time between querying peer manager for closest neighbours. (default: 1 minute)
     pub refresh_neighbours_interval: Duration,
 }
@@ -40,7 +38,6 @@ impl Default for LivenessConfig {
         Self {
             auto_ping_interval: None,
             enable_auto_join: false,
-            enable_auto_stored_message_request: false,
             refresh_neighbours_interval: Duration::from_secs(60),
         }
     }

--- a/base_layer/p2p/src/services/liveness/mod.rs
+++ b/base_layer/p2p/src/services/liveness/mod.rs
@@ -165,25 +165,6 @@ impl ServiceInitializer for LivenessInitializer {
                 }
             }
 
-            if config.enable_auto_stored_message_request {
-                // TODO: Record when store message request was last requested
-                //       and request messages from after that time
-                match dht_requester.send_request_stored_messages().await {
-                    Ok(_) => {
-                        trace!(
-                            target: LOG_TARGET,
-                            "Stored message request has been sent to closest peers",
-                        );
-                    },
-                    Err(err) => {
-                        error!(
-                            target: LOG_TARGET,
-                            "Failed to send stored message on startup because '{}'", err
-                        );
-                    },
-                }
-            }
-
             let state = LivenessState::new();
 
             let service = LivenessService::new(

--- a/base_layer/p2p/tests/services/liveness.rs
+++ b/base_layer/p2p/tests/services/liveness.rs
@@ -57,7 +57,6 @@ pub async fn setup_liveness_service(
         .add_initializer(LivenessInitializer::new(
             LivenessConfig {
                 enable_auto_join: false,
-                enable_auto_stored_message_request: false,
                 auto_ping_interval: None,
                 refresh_neighbours_interval: Duration::from_secs(60),
             },

--- a/base_layer/wallet/src/wallet.rs
+++ b/base_layer/wallet/src/wallet.rs
@@ -141,7 +141,6 @@ where
                 LivenessConfig {
                     auto_ping_interval: Some(Duration::from_secs(30)),
                     enable_auto_join: true,
-                    enable_auto_stored_message_request: true,
                     refresh_neighbours_interval: Default::default(),
                 },
                 Arc::clone(&subscription_factory),

--- a/comms/dht/Cargo.toml
+++ b/comms/dht/Cargo.toml
@@ -15,6 +15,7 @@ test-mocks = []
 [dependencies]
 tari_comms = { version = "^0.0", path = "../"}
 tari_crypto = { version = "^0.3" }
+tari_utilities = { version = "^0.1" }
 tari_shutdown = { version = "^0.0", path = "../../infrastructure/shutdown"}
 tari_storage = { version = "^0.0", path = "../../infrastructure/storage"}
 

--- a/comms/dht/migrations/2020-04-20-082924_rename_settings_to_metadata/down.sql
+++ b/comms/dht/migrations/2020-04-20-082924_rename_settings_to_metadata/down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE dht_metadata RENAME TO dht_settings;

--- a/comms/dht/migrations/2020-04-20-082924_rename_settings_to_metadata/up.sql
+++ b/comms/dht/migrations/2020-04-20-082924_rename_settings_to_metadata/up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE dht_settings RENAME TO dht_metadata;

--- a/comms/dht/src/config.rs
+++ b/comms/dht/src/config.rs
@@ -59,6 +59,8 @@ pub struct DhtConfig {
     pub saf_high_priority_msg_storage_ttl: Duration,
     /// The limit on the message size to store in SAF storage in bytes. Default 500 KiB
     pub saf_max_message_size: usize,
+    /// When true, store and forward messages are requested from peers on connect (Default: true)
+    pub saf_auto_request: bool,
     /// The max capacity of the message hash cache
     /// Default: 10000
     pub msg_hash_cache_capacity: usize,
@@ -97,6 +99,7 @@ impl DhtConfig {
         Self {
             network: Network::LocalTest,
             database_url: DbConnectionUrl::Memory,
+            saf_auto_request: false,
             ..Default::default()
         }
     }
@@ -112,6 +115,7 @@ impl Default for DhtConfig {
             saf_msg_cache_storage_capacity: SAF_MSG_CACHE_STORAGE_CAPACITY,
             saf_low_priority_msg_storage_ttl: SAF_LOW_PRIORITY_MSG_STORAGE_TTL,
             saf_high_priority_msg_storage_ttl: SAF_HIGH_PRIORITY_MSG_STORAGE_TTL,
+            saf_auto_request: true,
             saf_max_message_size: 512 * 1024, // 500 KiB
             msg_hash_cache_capacity: 10_000,
             msg_hash_cache_ttl: Duration::from_secs(5 * 60),

--- a/comms/dht/src/crypt.rs
+++ b/comms/dht/src/crypt.rs
@@ -48,7 +48,7 @@ pub fn encrypt(cipher_key: &CommsPublicKey, plain_text: &[u8]) -> Result<Vec<u8>
 #[cfg(test)]
 mod test {
     use super::*;
-    use tari_crypto::tari_utilities::hex::from_hex;
+    use tari_utilities::hex::from_hex;
 
     #[test]
     fn encrypt_decrypt() {

--- a/comms/dht/src/dedup.rs
+++ b/comms/dht/src/dedup.rs
@@ -26,7 +26,7 @@ use futures::{task::Context, Future};
 use log::*;
 use std::task::Poll;
 use tari_comms::{pipeline::PipelineError, types::Challenge};
-use tari_crypto::tari_utilities::hex::Hex;
+use tari_utilities::hex::Hex;
 use tower::{layer::Layer, Service, ServiceExt};
 
 const LOG_TARGET: &str = "comms::dht::dedup";

--- a/comms/dht/src/envelope.rs
+++ b/comms/dht/src/envelope.rs
@@ -29,7 +29,7 @@ use std::{
     fmt::Display,
 };
 use tari_comms::{peer_manager::NodeId, types::CommsPublicKey};
-use tari_crypto::tari_utilities::{ByteArray, ByteArrayError};
+use tari_utilities::{ByteArray, ByteArrayError};
 
 // Re-export applicable protos
 pub use crate::proto::envelope::{dht_header::Destination, DhtEnvelope, DhtHeader, DhtMessageType, Network};

--- a/comms/dht/src/inbound/decryption.rs
+++ b/comms/dht/src/inbound/decryption.rs
@@ -38,7 +38,7 @@ use tari_comms::{
     types::CommsPublicKey,
     utils::signature,
 };
-use tari_crypto::tari_utilities::ByteArray;
+use tari_utilities::ByteArray;
 use tower::{layer::Layer, Service, ServiceExt};
 
 const LOG_TARGET: &str = "comms::middleware::decryption";

--- a/comms/dht/src/inbound/dht_handler/task.rs
+++ b/comms/dht/src/inbound/dht_handler/task.rs
@@ -40,7 +40,7 @@ use tari_comms::{
     pipeline::PipelineError,
     types::CommsPublicKey,
 };
-use tari_crypto::tari_utilities::{hex::Hex, ByteArray};
+use tari_utilities::{hex::Hex, ByteArray};
 use tower::{Service, ServiceExt};
 
 const LOG_TARGET: &str = "comms::dht::dht_handler";
@@ -177,6 +177,7 @@ where S: Service<DecryptedDhtMessage, Response = (), Error = PipelineError>
             dht_header,
             source_peer,
             authenticated_origin,
+            is_saf_message,
             ..
         } = message;
 
@@ -251,6 +252,14 @@ where S: Service<DecryptedDhtMessage, Response = (), Error = PipelineError>
             );
 
             self.send_join_direct(origin_peer.public_key).await?;
+        }
+
+        if is_saf_message {
+            debug!(
+                target: LOG_TARGET,
+                "Not re-propagating join message received from store and forward"
+            );
+            return Ok(());
         }
 
         debug!(

--- a/comms/dht/src/inbound/message.rs
+++ b/comms/dht/src/inbound/message.rs
@@ -81,6 +81,7 @@ pub struct DecryptedDhtMessage {
     pub source_peer: Arc<Peer>,
     pub authenticated_origin: Option<CommsPublicKey>,
     pub dht_header: DhtMessageHeader,
+    pub is_saf_message: bool,
     pub decryption_result: Result<EnvelopeBody, Vec<u8>>,
 }
 
@@ -97,6 +98,7 @@ impl DecryptedDhtMessage {
             source_peer: message.source_peer,
             authenticated_origin,
             dht_header: message.dht_header,
+            is_saf_message: message.is_saf_message,
             decryption_result: Ok(message_body),
         }
     }
@@ -108,6 +110,7 @@ impl DecryptedDhtMessage {
             source_peer: message.source_peer,
             authenticated_origin: None,
             dht_header: message.dht_header,
+            is_saf_message: message.is_saf_message,
             decryption_result: Err(message.body),
         }
     }

--- a/comms/dht/src/lib.rs
+++ b/comms/dht/src/lib.rs
@@ -132,7 +132,7 @@ mod consts;
 mod crypt;
 
 mod dht;
-pub use dht::Dht;
+pub use dht::{Dht, DhtInitializationError};
 
 mod discovery;
 pub use discovery::DhtDiscoveryRequester;

--- a/comms/dht/src/outbound/message.rs
+++ b/comms/dht/src/outbound/message.rs
@@ -32,7 +32,7 @@ use tari_comms::{
     peer_manager::Peer,
     types::CommsPublicKey,
 };
-use tari_crypto::tari_utilities::hex::Hex;
+use tari_utilities::hex::Hex;
 
 /// Determines if an outbound message should be Encrypted and, if so, for which public key
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/comms/dht/src/outbound/serialize.rs
+++ b/comms/dht/src/outbound/serialize.rs
@@ -33,7 +33,7 @@ use tari_comms::{
     pipeline::PipelineError,
     Bytes,
 };
-use tari_crypto::tari_utilities::ByteArray;
+use tari_utilities::ByteArray;
 use tower::{layer::Layer, Service, ServiceExt};
 
 const LOG_TARGET: &str = "comms::dht::serialize";

--- a/comms/dht/src/proto/mod.rs
+++ b/comms/dht/src/proto/mod.rs
@@ -22,7 +22,7 @@
 
 use crate::proto::envelope::Network;
 use std::fmt;
-use tari_crypto::tari_utilities::hex::Hex;
+use tari_utilities::hex::Hex;
 
 #[path = "tari.dht.envelope.rs"]
 pub mod envelope;

--- a/comms/dht/src/schema.rs
+++ b/comms/dht/src/schema.rs
@@ -1,5 +1,5 @@
 table! {
-    dht_settings (id) {
+    dht_metadata (id) {
         id -> Integer,
         key -> Text,
         value -> Binary,
@@ -22,4 +22,4 @@ table! {
     }
 }
 
-allow_tables_to_appear_in_same_query!(dht_settings, stored_messages,);
+allow_tables_to_appear_in_same_query!(dht_metadata, stored_messages,);

--- a/comms/dht/src/storage/dht_setting_entry.rs
+++ b/comms/dht/src/storage/dht_setting_entry.rs
@@ -20,31 +20,31 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use crate::schema::dht_settings;
+use crate::schema::dht_metadata;
 use std::fmt;
 
 #[derive(Debug, Clone, Copy)]
-pub enum DhtSettingKey {
-    /// The timestamp of the last time this node made a SAF request
-    SafLastRequestTimestamp,
+pub enum DhtMetadataKey {
+    /// Timestamp each time the DHT is shut down
+    OfflineTimestamp,
 }
 
-impl fmt::Display for DhtSettingKey {
+impl fmt::Display for DhtMetadataKey {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{:?}", self)
     }
 }
 
 #[derive(Clone, Debug, Insertable)]
-#[table_name = "dht_settings"]
-pub struct NewDhtSettingEntry {
+#[table_name = "dht_metadata"]
+pub struct NewDhtMetadataEntry {
     pub key: String,
     pub value: Vec<u8>,
 }
 
 #[derive(Clone, Debug, Queryable, Identifiable)]
-#[table_name = "dht_settings"]
-pub struct DhtSettingsEntry {
+#[table_name = "dht_metadata"]
+pub struct DhtMetadataEntry {
     pub id: i32,
     pub key: String,
     pub value: Vec<u8>,

--- a/comms/dht/src/storage/error.rs
+++ b/comms/dht/src/storage/error.rs
@@ -21,7 +21,7 @@
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 use derive_error::Error;
-use tari_crypto::tari_utilities::message_format::MessageFormatError;
+use tari_utilities::message_format::MessageFormatError;
 use tokio::task;
 
 #[derive(Debug, Error)]

--- a/comms/dht/src/storage/mod.rs
+++ b/comms/dht/src/storage/mod.rs
@@ -27,7 +27,7 @@ mod error;
 pub use error::StorageError;
 
 mod dht_setting_entry;
-pub use dht_setting_entry::{DhtSettingKey, DhtSettingsEntry};
+pub use dht_setting_entry::{DhtMetadataEntry, DhtMetadataKey};
 
 mod database;
 pub use database::DhtDatabase;

--- a/comms/dht/src/store_forward/database/stored_message.rs
+++ b/comms/dht/src/store_forward/database/stored_message.rs
@@ -29,7 +29,7 @@ use crate::{
 use chrono::NaiveDateTime;
 use std::convert::TryInto;
 use tari_comms::message::MessageExt;
-use tari_crypto::tari_utilities::hex::Hex;
+use tari_utilities::hex::Hex;
 
 #[derive(Clone, Debug, Insertable, Default)]
 #[table_name = "stored_messages"]

--- a/comms/dht/src/store_forward/error.rs
+++ b/comms/dht/src/store_forward/error.rs
@@ -25,7 +25,7 @@ use derive_error::Error;
 use prost::DecodeError;
 use std::io;
 use tari_comms::{message::MessageError, peer_manager::PeerManagerError};
-use tari_crypto::tari_utilities::{byte_array::ByteArrayError, ciphers::cipher::CipherError};
+use tari_utilities::{byte_array::ByteArrayError, ciphers::cipher::CipherError};
 
 #[derive(Debug, Error)]
 pub enum StoreAndForwardError {
@@ -75,4 +75,7 @@ pub enum StoreAndForwardError {
     InvalidNodeDistanceThreshold,
     /// DHT message type should not have been forwarded
     InvalidDhtMessageType,
+    /// Failed to send request for store and forward messages
+    #[error(no_from)]
+    RequestMessagesFailed(DhtOutboundError),
 }

--- a/comms/dht/src/store_forward/message.rs
+++ b/comms/dht/src/store_forward/message.rs
@@ -59,6 +59,7 @@ impl StoredMessagesRequest {
         }
     }
 
+    #[allow(unused)]
     pub fn since(since: DateTime<Utc>) -> Self {
         Self {
             since: Some(datetime_to_timestamp(since)),

--- a/comms/dht/src/test_utils/dht_actor_mock.rs
+++ b/comms/dht/src/test_utils/dht_actor_mock.rs
@@ -19,10 +19,11 @@
 // SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#![allow(dead_code)]
 
 use crate::{
     actor::{DhtRequest, DhtRequester},
-    storage::DhtSettingKey,
+    storage::DhtMetadataKey,
 };
 use futures::{channel::mpsc, stream::Fuse, StreamExt};
 use std::{
@@ -72,7 +73,7 @@ impl DhtMockState {
         self.call_count.fetch_add(1, Ordering::SeqCst);
     }
 
-    pub fn get_setting(&self, key: &DhtSettingKey) -> Option<Vec<u8>> {
+    pub fn get_setting(&self, key: &DhtMetadataKey) -> Option<Vec<u8>> {
         self.settings.read().unwrap().get(&key.to_string()).map(Clone::clone)
     }
 }
@@ -113,8 +114,7 @@ impl DhtActorMock {
                 let lock = self.state.select_peers.read().unwrap();
                 reply_tx.send(lock.clone()).unwrap();
             },
-            SendRequestStoredMessages => {},
-            GetSetting(key, reply_tx) => {
+            GetMetadata(key, reply_tx) => {
                 let _ = reply_tx.send(Ok(self
                     .state
                     .settings
@@ -123,7 +123,7 @@ impl DhtActorMock {
                     .get(&key.to_string())
                     .map(Clone::clone)));
             },
-            SetSetting(key, value) => {
+            SetMetadata(key, value) => {
                 self.state.settings.write().unwrap().insert(key.to_string(), value);
             },
         }

--- a/comms/dht/src/test_utils/store_and_forward_mock.rs
+++ b/comms/dht/src/test_utils/store_and_forward_mock.rs
@@ -129,6 +129,7 @@ impl StoreAndForwardMock {
                 priority: msg.priority,
                 stored_at: Utc::now().naive_utc(),
             }),
+            SendStoreForwardRequestToPeer(_) => {},
         }
     }
 }

--- a/comms/src/peer_manager/manager.rs
+++ b/comms/src/peer_manager/manager.rs
@@ -296,6 +296,12 @@ impl PeerManager {
             .await
             .get_region_stats(region_node_id, n, features)
     }
+
+    pub async fn get_peer_features(&self, node_id: &NodeId) -> Result<PeerFeatures, PeerManagerError> {
+        // TODO: #sqliterefactor fetch the features with a sql query
+        let peer = self.find_by_node_id(node_id).await?;
+        Ok(peer.features)
+    }
 }
 
 #[cfg(test)]

--- a/comms/src/peer_manager/node_id.rs
+++ b/comms/src/peer_manager/node_id.rs
@@ -116,7 +116,7 @@ impl fmt::Display for NodeDistance {
 }
 
 /// A Node Identity is used as a unique identifier for a node in the Tari communications network.
-#[derive(Clone, Debug, Eq, Deserialize, Serialize, Default)]
+#[derive(Clone, Eq, Deserialize, Serialize, Default)]
 pub struct NodeId(NodeIdArray);
 
 impl NodeId {
@@ -266,6 +266,12 @@ impl AsRef<[u8]> for NodeId {
 impl fmt::Display for NodeId {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", to_hex(&self.0))
+    }
+}
+
+impl fmt::Debug for NodeId {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "NodeId({})", to_hex(&self.0))
     }
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
- SAF messages requested on each connection. A request-response interaction is kept (although
  not strictly necessary) because it allows the requesting node to
  tailor the messages they may be interested in and reduce the number of
  messages returned (messages _since_ X, messages within my network
  region etc).
- Base nodes also request store and forward messages
- Nodes will accept and return SAF messages regardless of the requester's
  XOR distance from the responder
- Store messages as low priority if the peer is unknown (rather than not storing it)
- Remove auto SAF request from liveness in favour of "on connect" SAF
  request
- DHT initialization improvements. This fixes some test race conditions.
- Only call `migrate()` on the database once and use a single
  connection.
- Some improvements/fixes for sending join from SAF (Joins are not currently sent but
  could prove useful for generally improving network connectivity)
- Don't propagate joins if coming from SAF
- _memorynet_ more info and stats on connectivity, reduced output clutter
- Many logging improvements

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Allow peers to request SAF messages from any node to increase the possibility that a stored message will reach the requester

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Existing SAF and DHT tests modified where applicable. Existing higher level tests involving store and forward pass. Some race conditions eliminated.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [x] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch.
* [x] I ran `cargo-fmt --all` before pushing.
* [x] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
