### PR TITLE
Update logging level for double spend error and transaction send

### DIFF
--- a/base_layer/core/src/validation/transaction_validators.rs
+++ b/base_layer/core/src/validation/transaction_validators.rs
@@ -138,10 +138,9 @@ fn verify_inputs<B: BlockchainBackend>(tx: &Transaction, db: &B) -> Result<(), V
     for input in tx.body.inputs() {
         if is_stxo(db, input.hash()).map_err(|e| ValidationError::CustomError(e.to_string()))? {
             // we dont want to log this as a node or wallet might retransmit a transaction
-            trace!(
+            debug!(
                 target: LOG_TARGET,
-                "Transaction validation failed due to already spent input: {}",
-                input
+                "Transaction validation failed due to already spent input: {}", input
             );
             return Err(ValidationError::ContainsSTxO);
         }

--- a/base_layer/wallet/src/transaction_service/protocols/transaction_send_protocol.rs
+++ b/base_layer/wallet/src/transaction_service/protocols/transaction_send_protocol.rs
@@ -96,10 +96,9 @@ where TBackend: TransactionBackend + Clone + 'static
 
     /// Execute the Transaction Send Protocol as an async task.
     pub async fn execute(mut self) -> Result<u64, TransactionServiceProtocolError> {
-        trace!(
+        info!(
             "Starting Transaction Send protocol for TxId: {} at Stage {:?}",
-            self.id,
-            self.stage
+            self.id, self.stage
         );
 
         // Only Send the transaction of the protocol stage is Initial. If the protocol is started in a later stage


### PR DESCRIPTION
## Description
Just push the log message that record when a double spend is attempted to debug level so that we can see when this happens on the Faucet node.

Also push the log message about starting and resuming the Send Transaction protocol to debug for easier debugging.
