### PR TITLE
runtime usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,19 +67,10 @@ A successful build should output something as follows
     Finished release [optimized] target(s) in 12m 24s
 ```
 
-#### Run
+Alternatively, cargo can build and install the executable into `~/.cargo/bin`, so it will be executable from anywhere 
+on your system.
 
-The executable is currently inside your `target/release` folder. You can run it from that folder if you like, but you'll
-more likely want to copy it somewhere more convenient. You can simply run
-
-    cargo install -p tari_base_node
-
-and cargo will copy the executable into `~/.cargo/bin`. This folder was added to your path in a previous step, so it
-will be executable from anywhere on your system.
-
-Alternatively, you can run the node from your source folder with the command
-
-    cargo run -p tari_base_node
+    cargo install tari_base_node
 
 ### Building from source (Windows 10)
 
@@ -172,21 +163,39 @@ A successful build should output something as follows
     Finished release [optimized] target(s) in 12m 24s
 ```
 
-Alternatively, cargo can build and install the executable into `%USERPROFILE%\.cargo\bin`:
+Alternatively, cargo can build and install the executable into `%USERPROFILE%\.cargo\bin`, so it will be executable from 
+anywhere on your system.
 
     cargo install tari_base_node
 
-#### Run
+### Running the base node
 
-The executable will either be inside your `%USERPROFILE%\Code\tari\target\release` or the `%USERPROFILE%\.cargo\bin` 
-folder, depending on the build choice above. If the former build method was used, you can run it from that folder, 
-or you more likely want to copy it somewhere more convenient. Using the latter method,  it will be executable from 
-anywhere on your system, as `%USERPROFILE%\.cargo\bin` was added to your path in a previous step.
+The executable will either be inside your `~/tari/target/release` (on Linux) or `%USERPROFILE%\Code\tari\target\release` 
+(on Windows) folder, or alternatively, inside your `~/.cargo/bin` (on Linux) `%USERPROFILE%\.cargo\bin` (on Windows)
+folder, depending on the build choice above, and must be run from the command line. If the former build method was used, 
+you can run it from that folder, or you more likely want to copy it somewhere more convenient.
 
-Alternatively, you can run the node from your source folder with the command
+To run from any folder of your choice, where the executable is visible in the path (first time use):
 
-    cargo run --bin tari_base_node
+    tari_base_node --init --create-id
+    tari_base_node
 
+Consecutive runs:
+
+    tari_base_node
+
+Alternatively, you can run the node from your source folder using `cargo` (first time use):
+
+    cargo run --bin tari_base_node --release --  --init --create-id
+    cargo run --bin tari_base_node --release
+
+Consecutive runs:
+
+    cargo run --bin tari_base_node --release
+
+Using all the default options, the blockchain database, wallet database, log files and all configuration files will be 
+created in the `~/.tari` (on Linux) or `%USERPROFILE%\.tari` (on Windows) folder. Alternatively, by specifying 
+`--base-path <base-path>` on the command line as well, all of this will be created in that folder.  
 
 ### Building a docker image
 
@@ -209,8 +218,6 @@ Test your image
 ### Advanced build configurations
 
 * [Building with Vagrant](https://github.com/tari-project/tari/issues/1407)
-
-
 
 # Project documentation
 
@@ -256,36 +263,6 @@ and other Tari-related discussions.
 the first to know about important updates and announcements about the project.
 
 Most of the technical conversation about Tari development happens on [#FreeNode IRC](https://freenode.net/) in the #tari-dev room.
-
-
-and cargo will copy the executable into `~/.cargo/bin`. This folder was added to your path in a previous step, so it
-will be executable from anywhere on your system.
-
-Alternatively, you can run the node from your source folder with the command
-
-    cargo run -p tari_base_node
-
-### Building a docker image
-
-If you don't want to use the docker images provided by the community, you can roll your own!
-
-First, clone the Tari repo
-```bash
-git clone git@github.com:tari-project/tari.git
-```
-
-Then build the image using the dockerfile in `buildtools`. The base node docker file build the application and then
-places the binary inside a small container, keeping the executable binary to a minimum.
-
-    docker build -t tari_base_node:latest -f ./buildtools/base_node.Dockerfile .
-
-Test your image
-
-    docker run tari_base_node tari_base_node --help
-
-### Advanced build configurations
-
-Our community has contr
 
 # Project documentation
 

--- a/applications/tari_base_node/src/cli.rs
+++ b/applications/tari_base_node/src/cli.rs
@@ -21,9 +21,6 @@
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 //
 
-use structopt::StructOpt;
-use tari_common::ConfigBootstrap;
-
 // Import the auto-generated const values from the Manifest and Git
 include!(concat!(env!("OUT_DIR"), "/consts.rs"));
 
@@ -171,14 +168,4 @@ pub fn print_banner(commands: Vec<String>, chunk_size: i32) {
         println!("{}", row);
     }
     println!("{}", box_line(target_line_length, false));
-}
-
-/// The reference Tari cryptocurrency base node implementation
-#[derive(StructOpt)]
-pub struct Arguments {
-    /// Create and save new node identity if one doesn't exist
-    #[structopt(long)]
-    pub create_id: bool,
-    #[structopt(flatten)]
-    pub bootstrap: ConfigBootstrap,
 }

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -22,6 +22,7 @@ log4rs = "0.8.3"
 multiaddr={package="parity-multiaddr", version = "0.7.2"}
 prost-build = "0.6.1"
 sha2 = "0.8.0"
+path-clean = "0.1.0"
 
 [dev-dependencies]
 tempdir = "0.3.7"

--- a/common/config/tari_config_sample.toml
+++ b/common/config/tari_config_sample.toml
@@ -13,7 +13,7 @@
 # section holds configuration options that are common to all sections.
 
 # A note about Logging - The logger is initialised before the configuration file is loaded. For this reason, logging
-# is not configured here, but in `~/.tari/log4rs.yml` (*nix / OsX) or `%HOME%/.tari/log4rs.yml` (Windows) by
+# is not configured here, but in `~/.tari/log4rs.yml` (*nix / OsX) or `%USERPROFILE%\.tari\log4rs.yml` (Windows) by
 # default, or the location specified in the TARI_LOGFILE environment variable.
 
 [common]
@@ -27,7 +27,7 @@
 #message_cache_ttl = 1440
 
 # The peer database list is stored in a database file at this location
-#peer_database = "~/.tari/peers"
+#peer_database = "~/.tari/peers" # or "%USERPROFILE%\\.tari\peers"
 
 # If peer nodes spam you with messages, or are otherwise badly behaved, they will be added to your blacklist and banned
 # You can set a time limit to release that ban (in minutes), or otherwise ban them for life (-1). The default is to
@@ -58,10 +58,10 @@
 # Valid values here are IPv4 and IPv6 TCP sockets, local unix sockets (e.g. "ipc://base-node-gprc.sock.100")
 #grpc_address = "tcp://127.0.0.1:80400"
 
-# The folder to store your local key data and transaction history. DO NOT EVER DELETE THIS FILE unless you
+# The relative folder to store your local key data and transaction history. DO NOT EVER DELETE THIS FILE unless you
 #  a) have backed up your seed phrase and
 #  b) know what you are doing!
-#wallet_file = "~/.tari/wallet/wallet.dat"
+#wallet_file = "wallet/wallet.dat" # or "wallet\\wallet.dat"
 
 #[base_node.transport.tor]
 #control_address = "/ip4/127.0.0.1/tcp/9051"
@@ -83,18 +83,21 @@
 
 # Select the network to connect to. Valid options are:
 #   mainnet - the "real" Tari network (default)
-#   testnet - the Tari test net
+#   rincewind - the Tari test net
 #network = "mainnet"
 
 
 # Configuration options for testnet
-[base_node.testnet]
+[base_node.rincewind]
 # The type of database backend to use. Currently supported options are "memory" and "lmdb". LMDB is recommnded for
 # almost all use cases.
 #db_type = "lmdb"
 
-# The path to store persistent data
-#data_dir = "~/.tari/testnet/"
+# Enable if this node must be a mining node
+#enable_mining = true
+
+# The relative path to store persistent data
+data_dir = "rincewind"
 
 # When first logging onto the Tari network, you need to find a few peers to bootstrap the process. In the absence of
 # any servers, this is a little more challenging than usual. Our best strategy is just to try and connect to the peers
@@ -102,8 +105,28 @@
 # where this whitelist comes in. It's a list of known Tari nodes that are likely to be around for a long time and that
 # new nodes can use to introduce themselves to the network.
 # peer_seeds = ["public_key1::address1", "public_key2::address2",... ]
-peer_seeds = []
+peer_seeds = [
+    #t-tbn-nvir
+    "06e98e9c5eb52bd504836edec1878eccf12eb9f26a5fe5ec0e279423156e657a::/onion3/bsmuof2cn4y2ysz253gzsvg3s72fcgh4f3qcm3hdlxdtcwe6al2dicyd:18141",
 
+    #t-tbn-ncal
+    "3a5081a0c9ff72b2d5cf52f8d78cc5a206d643259cdeb7d934512f519e090e6c::/onion3/gfynjxfm7rcxcekhu6jwuhvyyfdjvmruvvehurmlte565v74oinv2lad:18141",
+
+    #t-tbn-oregon
+    "e6f3c83dc592af45ede5424974f52c776e9e6859e530066e57c1b0dd59d9b61c::/onion3/ixihtmcbvr2q53bj23bsla5hi7ek37odnsxzkapr7znyfneqxzhq7zad:18141",
+
+    #t-tbn-london
+    "ce2254825d0e0294d31a86c6aac18f83c9a7b3d01d9cdb6866b4b2af8fd3fd17::/onion3/gm7kxmr4cyjg5fhcw4onav2ofa3flscrocfxiiohdcys3kshdhcjeuyd:18141",
+
+    #t-tbn-stockholm
+    "461d4d7be657521969896f90e3f611f0c4e902ca33d3b808c03357ad86fd7801::/onion3/4me2aw6auq2ucql34uuvsegtjxmvsmcyk55qprtrpqxvu3whxajvb5ad:18141",
+
+    #t-tbn-seoul
+    "d440b328e69b20dd8ee6c4a61aeb18888939f0f67cf96668840b7f72055d834c::/onion3/j5x7xkcxnrich5lcwibwszd5kylclbf6a5unert5sy6ykio2kphnopad:18141",
+
+    #t-tbn-sydney
+    "b81b4071f72418cc410166d9baf0c6ef7a8c309e64671fafbbed88f7e1ee7709::/onion3/lwwcv4nq7epgem5vdcawom4mquqsw2odbwfcjzv3j6sksx4gr24e52ad:18141",
+]
 
 # Determines the method of syncing blocks when the node is lagging. If you are not struggling with syncing, then
 # it is recommended to leave this setting as it. Available values are ViaBestChainMetadata and ViaRandomPeer.
@@ -131,31 +154,34 @@ peer_seeds = []
 #grpc_address = "tcp://127.0.0.1:18141"
 
 # A path to the file that stores your node identity and secret key
-#identity_file = "~/.tari/testnet/node_id.json"
+identity_file = "./node_id.json" # or ".\\node_id.json"
+
+# A path to the file that stores your wallet's node identity and secret key
+wallet_identity_file = "./wallet-identity.json" # or ".\\wallet-identity.json"
 
 # -------------- Transport configuration --------------
 # Use TCP to connect to the Tari network. This transport can only communicate with TCP/IP addresses, so peers with
 # e.g. tor onion addresses will not be contactable.
-transport = "tcp"
-# # The address and port to listen for peer connections over TCP.
-tcp_listener_address = "/ip4/0.0.0.0/tcp/18189"
+#transport = "tcp"
+# The address and port to listen for peer connections over TCP.
+#tcp_listener_address = "/ip4/0.0.0.0/tcp/18189"
 # Configures a tor proxy used to connect to onion addresses. All other traffic uses direct TCP connections.
 # This setting is optional however, if it is not specified, this node will not be able to connect to nodes that
 # only advertise an onion address.
-tcp_tor_socks_address = "/ip4/127.0.0.1/tcp/36050"
-tcp_tor_socks_auth = "none"
+#tcp_tor_socks_address = "/ip4/127.0.0.1/tcp/36050"
+#tcp_tor_socks_auth = "none"
 
 # Configures the node to run over a tor hidden service using the Tor proxy. This transport recognises ip/tcp,
 # onion v2, onion v3 and dns addresses.
-#transport = "tor"
+transport = "tor"
 # Address of the tor control server
-#tor_control_address = "/ip4/127.0.0.1/tcp/9051"
+tor_control_address = "/ip4/127.0.0.1/tcp/9051"
 # Authentication to use for the tor control server
-#tor_control_auth = "none" # or "password=xxxxxx"
+tor_control_auth = "none" # or "password=xxxxxx"
 # The onion port to use.
-#tor_onion_port = 18141
+tor_onion_port = 18141
 # The address to which traffic on the node's onion address will be forwarded
-#tor_forward_address = "/ip4/127.0.0.1/tcp/18141"
+tor_forward_address = "/ip4/127.0.0.1/tcp/18141"
 # Instead of attemping to get the SOCKS5 address from the tor control port, use this one. The default is to
 # use the first address returned by the tor control port (GETINFO /net/listeners/socks).
 #tor_socks_address_override=
@@ -169,21 +195,25 @@ tcp_tor_socks_auth = "none"
 #socks5_auth = "none" # or "username_password=username:xxxxxxx"
 
 # A path to the file that stores the tor hidden service private key, if using the tor transport.
-# tor_identity_file = "~/.tari/testnet/tor.key"
+tor_identity_file = "./tor.json" # or ".\\tor.json"
+
+# A path to the file that stores the wallet's tor hidden service private key, if using the tor transport.
+wallet_tor_identity_file = "./wallet-tor.json" # or ".\\wallet-tor.json"
 
 [base_node.mainnet]
 # The type of database backend to use. Currently supported options are "memory" and "lmdb". LMDB is recommnded for
 # almost all use cases.
 #db_type = "lmdb"
 
-# The path to store persistent data
-#data_dir = "~/.tari/mainnet/"
+# The relative path to store persistent data
+#data_dir = "mainnet"
 
 # When first logging onto the Tari network, you need to find a few peers to bootstrap the process. In the absence of
 # any servers, this is a little more challenging than usual. Our best strategy is just to try and connect to the peers
 # you knew about last time you ran the software. But what about when you run the software for the first time? That's
 # where this whitelist comes in. It's a list of known Tari nodes that are likely to be around for a long time and that
 # new nodes can use to introduce themselves to the network.
+# peer_seeds = ["public_key1::address1", "public_key2::address2",... ]
 peer_seeds = []
 
 # Configure the number of threads to spawn for long-running tasks, like block and transaction validation. A good choice
@@ -202,7 +232,10 @@ peer_seeds = []
 #grpc_address = "tcp://127.0.0.1:18041"
 
 # A path to the file that stores your node identity and secret key
-#identity_file = "~/.tari/mainnet/node_id.json"
+#identity_file = "./node_id.json" # or ".\\node_id.json"
+
+# A path to the file that stores your wallet's node identity and secret key
+#wallet_identity_file = "./wallet-identity.json" # or ".\\wallet-identity.json"
 
 # -------------- Transport configuration --------------
 # Use TCP to connect to the Tari network. This transport can only communicate with TCP/IP addresses, so peers with
@@ -237,8 +270,11 @@ peer_seeds = []
 #socks5_listener_address = "/ip4/127.0.0.1/tcp/18189"
 #socks5_auth = "none" # or "username_password=username:xxxxxxx"
 
-# A path to the file that stores the tor hidden service private key, if using the tor transport
-# tor_identity_file = "~/.tari/mainnet/tor.key"
+# A path to the file that stores the tor hidden service private key, if using the tor transport.
+#tor_identity_file = "./tor.json" # or ".\\tor.json"
+
+# A path to the file that stores the wallet's tor hidden service private key, if using the tor transport.
+#wallet_tor_identity_file = "./wallet-tor.json" # or ".\\wallet-tor.json"
 
 ########################################################################################################################
 #                                                                                                                      #
@@ -361,3 +397,4 @@ peer_seeds = []
 # The socket to expose for the gRPC base node server. This value is ignored if grpc_enabled is false.
 # Valid values here are IPv4 and IPv6 TCP sockets, local unix sockets (e.g. "ipc://base-node-gprc.sock.100")
 #grpc_address = "tcp://127.0.0.1:18042"
+ 

--- a/common/src/configuration/bootstrap.rs
+++ b/common/src/configuration/bootstrap.rs
@@ -4,7 +4,7 @@
 //! [`ConfigBootstrap`] struct. ConfigBootstrap implements [`structopt::StructOpt`] trait, all CLI options
 //! required for initializing configs can be embedded in any StructOpt derived struct.
 //!
-//! After loading ConfigBootstrap parameters it is necessary to call [`ConfigBootstrap::init_dirs()`] call
+//! After loading ConfigBootstrap parameters it is necessary to call [`ConfigBootstrap::init_dirs()`]
 //! which would create necessary configuration files based on input parameters. This usually followed by:
 //! - [`ConfigBootstrap::initialize_logging()`] would initialize log4rs logging.
 //! - [`ConfigBootstrap::load_configuration()`] which would load [config::Config] from .tari config file.
@@ -12,30 +12,18 @@
 //! ## Example - CLI which is loading and deserializing the global config file
 //!
 //! ```ignore
-//! # use tempdir::TempDir;
 //! use tari_common::ConfigBootstrap;
-//! use structopt::StructOpt;
 //!
-//! #[derive(StructOpt)]
-//! /// The reference Tari cryptocurrency base node implementation
-//! struct Arguments {
-//!     /// Create and save new node identity if one doesn't exist
-//!     #[structopt(long)]
-//!     id: bool,
-//!     #[structopt(flatten)]
-//!     bootstrap: ConfigBootstrap,
-//! }
-//!
-//! let mut args = Arguments::from_args();
-//! # let temp_dir = TempDir::new(string(8).as_str()).unwrap();
-//! # args.bootstrap.base_path = temp_dir.path().to_path_buf();
-//! # args.bootstrap.init = true;
-//! args.bootstrap.init_dirs();
-//! args.bootstrap.initialize_logging();
-//! let config = args.bootstrap.load_configuration();
+//! // Parse and validate command-line arguments
+//! let mut bootstrap = ConfigBootstrap::from_args();
+//! // Check and initialize configuration files
+//! bootstrap.init_dirs()?;
+//! // Load and apply configuration file
+//! let config = bootstrap.load_configuration()?;
+//! // Initialise the logger
+//! bootstrap.initialize_logging()?;
 //! assert_eq!(config.network, Network::MainNet);
 //! assert_eq!(config.blocking_threads, 4);
-//! # std::fs::remove_dir_all(&dir_utils::default_subdir("", Some(dir))).unwrap();
 //! ```
 //!
 //! ```shell
@@ -48,7 +36,7 @@
 //!
 //! FLAGS:
 //!     -h, --help       Prints help information
-//!         --create     Create and save new node identity if one doesn't exist
+//!         --create-id  Create and save new node identity if one doesn't exist
 //!         --init       Create a default configuration file if it doesn't exist
 //!     -V, --version    Prints version information
 //!
@@ -68,12 +56,20 @@ use std::{
     io,
     path::{Path, PathBuf},
 };
-use structopt::{clap::ArgMatches, StructOpt};
+use structopt::StructOpt;
 
 #[derive(StructOpt, Debug)]
 pub struct ConfigBootstrap {
     /// A path to a directory to store your files
-    #[structopt(short, long, alias("base_dir"), hide_default_value(true), default_value = "")]
+    #[structopt(
+        short,
+        long,
+        alias("base_path"),
+        alias("base_dir"),
+        alias("base-dir"),
+        hide_default_value(true),
+        default_value = ""
+    )]
     pub base_path: PathBuf,
     /// A path to the configuration file to use (config.toml)
     #[structopt(short, long, hide_default_value(true), default_value = "")]
@@ -91,6 +87,9 @@ pub struct ConfigBootstrap {
     /// Create a default configuration file if it doesn't exist
     #[structopt(long)]
     pub init: bool,
+    /// Create and save new node identity if one doesn't exist
+    #[structopt(long, alias("create_id"))]
+    pub create_id: bool,
 }
 
 impl Default for ConfigBootstrap {
@@ -100,13 +99,12 @@ impl Default for ConfigBootstrap {
             config: dir_utils::default_path(DEFAULT_CONFIG, None),
             log_config: dir_utils::default_path(DEFAULT_LOG_CONFIG, None),
             init: false,
+            create_id: false,
         }
     }
 }
 
 impl ConfigBootstrap {
-    const ARGS: &'static [&'static str] = &["base-path", "base_dir", "config", "init", "log-config", "log_config"];
-
     /// Initialize configuration and directories based on ConfigBootstrap options.
     ///
     /// If not present it will create base directory (default ~/.tari/, depending on OS).
@@ -117,6 +115,8 @@ impl ConfigBootstrap {
     pub fn init_dirs(&mut self) -> Result<(), ConfigError> {
         if self.base_path.to_str() == Some("") {
             self.base_path = dir_utils::default_path("", None);
+        } else {
+            self.base_path = dir_utils::absolute_path(&self.base_path);
         }
 
         // Create the tari data directory
@@ -131,12 +131,9 @@ impl ConfigBootstrap {
             self.config = dir_utils::default_path(DEFAULT_CONFIG, Some(&self.base_path));
         }
 
-        let log_config = if self.log_config.to_str() == Some("") {
-            None
-        } else {
-            Some(self.log_config.clone())
-        };
-        self.log_config = logging::get_log_configuration_path(log_config);
+        if self.log_config.to_str() == Some("") {
+            self.log_config = dir_utils::default_path(DEFAULT_LOG_CONFIG, Some(&self.base_path));
+        }
 
         if !self.config.exists() {
             let install = if !self.init {
@@ -173,80 +170,38 @@ impl ConfigBootstrap {
         Ok(())
     }
 
-    /// Fill in ConfigBootstrap from clap ArgMatches.
-    ///
-    /// ## Example:
-    /// ```edition2018
-    /// # use structopt::clap::clap_app;
-    /// # use tari_common::*;
-    /// let matches = clap_app!(myapp =>
-    ///     (@arg base_path: -b --("base-path") +takes_value "A path to a directory to store your files")
-    ///     (@arg config: -c --config +takes_value "A path to the configuration file to use (config.toml)")
-    ///     (@arg log_config: -l --("log-config") +takes_value "A path to the logfile configuration (log4rs.yml))")
-    ///     (@arg init: -i --init "Create a default configuration file if it doesn't exist")
-    /// ).get_matches();
-    /// let bootstrap = ConfigBootstrap::from_matches(&matches);
-    /// ```
-    pub fn from_matches(matches: &ArgMatches) -> Result<Self, ConfigError> {
-        let iter = matches
-            .args
-            .keys()
-            .flat_map(|arg| match Self::ARGS.binary_search(arg) {
-                Ok(_) => vec![
-                    Some(std::ffi::OsString::from(format!("--{}", arg))),
-                    matches.value_of_os(arg).map(|s| s.to_os_string()),
-                ],
-                _ => vec![],
-            })
-            .filter_map(|arg| arg);
-
-        let mut vals: Vec<std::ffi::OsString> = iter.collect();
-        vals.insert(0, "".into());
-        Ok(ConfigBootstrap::from_iter_safe(vals.iter())?)
-    }
-
     /// Set up application-level logging using the Log4rs configuration file
     /// based on supplied CLI arguments
     pub fn initialize_logging(&self) -> Result<(), ConfigError> {
-        match initialize_logging(&self.log_config) {
-            true => Ok(()),
-            false => Err(ConfigError::new("failed to initalize logging", None)),
-        }
+        let current_dir = std::env::current_dir().unwrap_or_default();
+        if current_dir != self.base_path && std::env::set_current_dir(&self.base_path).is_err() {
+            println!(
+                "Logging initialized in {}, could not initialize in {}.",
+                &current_dir.display(),
+                &self.base_path.display()
+            );
+        };
+        let result = if initialize_logging(&self.log_config) {
+            Ok(())
+        } else {
+            Err(ConfigError::new("failed to initalize logging", None))
+        };
+        if current_dir != std::env::current_dir().unwrap_or_default() &&
+            std::env::set_current_dir(&current_dir).is_err()
+        {
+            println!(
+                "Working directory could not be changed back to {} after logging has been initialized. New working \
+                 directory is {}",
+                &current_dir.display(),
+                &std::env::current_dir().unwrap_or_default().display()
+            );
+        };
+        result
     }
 
     /// Load configuration from files located based on supplied CLI arguments
     pub fn load_configuration(&self) -> Result<config::Config, ConfigError> {
         load_configuration(self).map_err(|source| ConfigError::new("failed to load configuration", Some(source)))
-    }
-}
-
-/// Fill in ConfigBootstrap from clap ArgMatches
-///
-/// ```rust
-/// # use structopt::clap::clap_app;
-/// # use tari_common::*;
-/// let matches = clap_app!(myapp =>
-///     (version: "0.0.10")
-///     (author: "The Tari Community")
-///     (about: "The reference Tari cryptocurrency base node implementation")
-///     (@arg base_path: -b --("base-path") +takes_value "A path to a directory to store your files")
-///     (@arg config: -c --config +takes_value "A path to the configuration file to use (config.toml)")
-///     (@arg log_config: -l --("log-config") +takes_value "A path to the logfile configuration (log4rs.yml))")
-///     (@arg init: -i --init "Create a default configuration file if it doesn't exist")
-///     (@arg create_id: --("create-id") "Create and save new node identity if one doesn't exist ")
-/// ).get_matches();
-/// let bootstrap = bootstrap_config_from_cli(&matches);
-/// ```
-/// ## Caveats
-/// It will exit with code 1 if no base dir and fails to create one
-pub fn bootstrap_config_from_cli(matches: &ArgMatches) -> ConfigBootstrap {
-    let mut bootstrap = ConfigBootstrap::from_matches(matches).expect("failed to extract matches");
-    match bootstrap.init_dirs() {
-        Err(err) => {
-            println!("{}", err);
-            std::process::exit(1);
-        },
-        Ok(_) => bootstrap,
     }
 }
 
@@ -271,151 +226,129 @@ where F: Fn(&Path) -> Result<(), std::io::Error> {
 
 #[cfg(test)]
 mod test {
-    use super::ConfigBootstrap;
-    use crate::{bootstrap_config_from_cli, dir_utils, dir_utils::default_subdir, load_configuration};
+    use crate::{
+        dir_utils,
+        dir_utils::default_subdir,
+        load_configuration,
+        ConfigBootstrap,
+        DEFAULT_CONFIG,
+        DEFAULT_LOG_CONFIG,
+    };
+    use std::path::PathBuf;
     use structopt::{clap::clap_app, StructOpt};
     use tari_test_utils::random::string;
     use tempdir::TempDir;
 
     #[test]
-    fn test_bootstrap_from_matches() {
-        // Create command line test data
-        let app = clap_app!(myapp =>
-            (@arg base_dir: -b --base_dir +takes_value "A path to a directory to store your files")
-            (@arg config: -c --config +takes_value "A path to the configuration file to use (config.toml)")
-            (@arg log_config: -l--log_config +takes_value "A path to the logfile configuration (log4rs.yml))")
-            (@arg init: --init "Create a default configuration file if it doesn't exist")
-        );
-        let matches = app.clone().get_matches_from(vec![
+    fn test_bootstrap_args_from_iter_safe() {
+        // Test command line arguments
+        let bootstrap = ConfigBootstrap::from_iter_safe(vec![
             "",
-            "--log_config",
-            "no-file-created",
-            "--config",
-            "no-file-created",
-            "--base_dir",
-            "no-dir-created",
             "--init",
-        ]);
-        let bootstrap = ConfigBootstrap::from_matches(&matches).expect("failed to extract matches");
-        assert!(bootstrap.init);
-        assert_eq!(bootstrap.base_path.to_str(), Some("no-dir-created"));
-        assert_eq!(bootstrap.log_config.to_str(), Some("no-file-created"));
-        assert_eq!(bootstrap.config.to_str(), Some("no-file-created"));
-
-        // Check aliases too
-        let app = clap_app!(myapp =>
-            (@arg ("base-path"): -b --("base-path") +takes_value "A path to a directory to store your files")
-            (@arg config: -c --config +takes_value "A path to the configuration file to use (config.toml)")
-            (@arg ("log-config"): -l --("log-config") +takes_value "A path to the logfile configuration (log4rs.yml))")
-            (@arg init: --init "Create a default configuration file if it doesn't exist")
-        );
-        let matches = app.get_matches_from(vec![
-            "",
-            "--log-config",
-            "no-file-created",
+            "--create-id",
             "--base-path",
-            "no-dir-created",
-        ]);
-        let bootstrap = ConfigBootstrap::from_matches(&matches).expect("failed to extract matches");
-        assert!(!bootstrap.init);
-        assert_eq!(bootstrap.base_path.to_str(), Some("no-dir-created"));
-        assert_eq!(bootstrap.log_config.to_str(), Some("no-file-created"));
-        assert_eq!(bootstrap.config.to_str(), Some(""));
+            "no-temp-path-created",
+            "--log-config",
+            "no-log-config-file-created",
+            "--config",
+            "no-config-file-created",
+        ])
+        .expect("failed to process arguments");
+        assert!(bootstrap.init);
+        assert!(bootstrap.create_id);
+        assert_eq!(bootstrap.base_path.to_str(), Some("no-temp-path-created"));
+        assert_eq!(bootstrap.log_config.to_str(), Some("no-log-config-file-created"));
+        assert_eq!(bootstrap.config.to_str(), Some("no-config-file-created"));
+
+        // Test command line argument aliases
+        let bootstrap = ConfigBootstrap::from_iter_safe(vec![
+            "",
+            "--base_path",
+            "no-temp-path-created",
+            "--log_config",
+            "no-log-config-file-created",
+        ])
+        .expect("failed to process arguments");
+        assert_eq!(bootstrap.base_path.to_str(), Some("no-temp-path-created"));
+        assert_eq!(bootstrap.log_config.to_str(), Some("no-log-config-file-created"));
+        let bootstrap = ConfigBootstrap::from_iter_safe(vec!["", "--base-dir", "no-temp-path-created"])
+            .expect("failed to process arguments");
+        assert_eq!(bootstrap.base_path.to_str(), Some("no-temp-path-created"));
+        let bootstrap = ConfigBootstrap::from_iter_safe(vec!["", "--base_dir", "no-temp-path-created"])
+            .expect("failed to process arguments");
+        assert_eq!(bootstrap.base_path.to_str(), Some("no-temp-path-created"));
+
+        // Test from environment variable
+        std::env::set_var("TARI_LOG_CONFIGURATION", "~/fake-example");
+        let bootstrap = ConfigBootstrap::from_iter_safe(vec![""]).expect("failed to process arguments");
+        assert_eq!(bootstrap.log_config.to_str(), Some("~/fake-example"));
+        assert_ne!(bootstrap.config.to_str(), Some("~/fake-example"));
+        std::env::set_var("TARI_LOG_CONFIGURATION", "");
     }
 
     #[test]
-    fn test_bootstrap_config_from_cli_and_load_configuration() {
+    fn test_bootstrap_and_load_configuration() {
         let temp_dir = TempDir::new(string(8).as_str()).unwrap();
-        let dir = &temp_dir.path().to_path_buf();
-        // Create test folder
-        dir_utils::create_data_directory(Some(dir)).unwrap();
+        let dir = &PathBuf::from(temp_dir.path().to_path_buf().display().to_string().to_owned() + "/01/02/");
+        let data_path = default_subdir("", Some(dir));
 
         // Create command line test data
-        let matches = clap_app!(myapp =>
-            (version: "0.0.10")
-            (author: "The Tari Community")
-            (about: "The reference Tari cryptocurrency base node implementation")
-            (@arg base_dir: -b --base_dir +takes_value "A path to a directory to store your files")
-            (@arg config: -c --config +takes_value "A path to the configuration file to use (config.toml)")
-            (@arg log_config: -l --log_config +takes_value "A path to the logfile configuration (log4rs.yml))")
-            (@arg init: --init "Create a default configuration file if it doesn't exist")
-            (@arg create_id: --create_id "Create and save new node identity if one doesn't exist ")
-        )
-        .get_matches_from(vec![
-            "",
-            "--base_dir",
-            default_subdir("", Some(dir)).as_str(),
-            "--init",
-            "--create_id",
-        ]);
+        let mut bootstrap =
+            ConfigBootstrap::from_iter_safe(vec!["", "--base_dir", &data_path.as_str(), "--init", "--create_id"])
+                .expect("failed to process arguments");
 
-        let bootstrap = ConfigBootstrap::from_matches(&matches).expect("failed to extract matches");
-        assert!(bootstrap.init);
-        assert_eq!(&bootstrap.base_path, dir);
-
-        // Load bootstrap via former API
-        let bootstrap = bootstrap_config_from_cli(&matches);
+        // Initialize bootstrap dirs
+        bootstrap.init_dirs().expect("failed to initialize dirs");
         let config_exists = std::path::Path::new(&bootstrap.config).exists();
         let log_config_exists = std::path::Path::new(&bootstrap.log_config).exists();
         // Load and apply configuration file
         let cfg = load_configuration(&bootstrap);
 
+        // Initialize logging
+        let logging_initialized = match bootstrap.initialize_logging() {
+            Ok(Result) => true,
+            _ => false,
+        };
+        let log_network_file_exists = std::path::Path::new(&bootstrap.base_path)
+            .join("log/network.log")
+            .exists();
+        let log_base_layer_file_exists = std::path::Path::new(&bootstrap.base_path)
+            .join("log/base_layer.log")
+            .exists();
+        let log_other_file_exists = std::path::Path::new(&bootstrap.base_path)
+            .join("log/other.log")
+            .exists();
+
         // Cleanup test data
-        if std::path::Path::new(&dir_utils::default_subdir("", Some(dir))).exists() {
-            std::fs::remove_dir_all(&dir_utils::default_subdir("", Some(dir))).expect("failed to cleanup dirs");
+        if std::path::Path::new(&data_path.as_str()).exists() {
+            std::fs::remove_dir_all(&data_path.as_str()).unwrap();
         }
 
-        // Assert results
+        // Assert bootstrap results
+        assert_eq!(bootstrap.base_path, PathBuf::from(&data_path));
+        assert!(bootstrap.init);
+        assert!(bootstrap.create_id);
+        assert!(&cfg.is_ok());
         assert!(config_exists);
+        assert_eq!(
+            &bootstrap.config,
+            &PathBuf::from(data_path.to_owned() + &DEFAULT_CONFIG.to_string())
+        );
         assert!(log_config_exists);
-        assert!(&cfg.is_ok());
-    }
+        assert_eq!(
+            &bootstrap.log_config,
+            &PathBuf::from(data_path.to_owned() + &DEFAULT_LOG_CONFIG.to_string())
+        );
 
-    #[test]
-    fn test_bootstrap_config_from_structopt_derive() {
-        let temp_dir = TempDir::new(string(8).as_str()).unwrap();
-        let dir = &temp_dir.path().to_path_buf();
-        // Create test folder
-        dir_utils::create_data_directory(Some(dir)).unwrap();
-
-        #[derive(StructOpt)]
-        /// The reference Tari cryptocurrency base node implementation
-        struct Arguments {
-            /// Create and save new node identity if one doesn't exist
-            #[structopt(long = "create_id")]
-            create_id: bool,
-            #[structopt(flatten)]
-            bootstrap: super::ConfigBootstrap,
-        }
-
-        // Create command line test data
-        let mut args = Arguments::from_iter_safe(vec![
-            "",
-            "--base_dir",
-            default_subdir("", Some(dir)).as_str(),
-            "--init",
-            "--create_id",
-        ])
-        .expect("failed to process arguments");
-        // Init bootstrap dirs
-        args.bootstrap.init_dirs().expect("failed to initialize dirs");
-        // Load and apply configuration file
-        let cfg = load_configuration(&args.bootstrap);
-
-        // Cleanup test data
-        if std::path::Path::new(&dir_utils::default_subdir("", Some(dir))).exists() {
-            std::fs::remove_dir_all(&dir_utils::default_subdir("", Some(dir))).unwrap();
-        }
-
-        // Assert results
-        assert!(args.bootstrap.init);
-        assert!(args.create_id);
-        assert!(&cfg.is_ok());
+        // Assert logging results
+        assert!(logging_initialized);
+        assert!(log_network_file_exists);
+        assert!(log_base_layer_file_exists);
+        assert!(log_other_file_exists);
     }
 
     #[test]
     fn check_homedir_is_used_by_default() {
-        dir_utils::create_data_directory(None).unwrap();
         assert_eq!(
             dirs::home_dir().unwrap().join(".tari"),
             dir_utils::default_path("", None)

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -78,7 +78,7 @@ pub use configuration::error::ConfigError;
 
 pub mod dir_utils;
 pub use configuration::{
-    bootstrap::{bootstrap_config_from_cli, install_configuration, ConfigBootstrap},
+    bootstrap::{install_configuration, ConfigBootstrap},
     global::{CommsTransport, DatabaseType, GlobalConfig, Network, SocksAuthentication, TorControlAuthentication},
     loader::{ConfigExtractor, ConfigLoader, ConfigPath, ConfigurationError, DefaultConfigLoader, NetworkConfigPath},
     utils::{default_config, install_default_config_file, load_configuration},

--- a/common/src/logging.rs
+++ b/common/src/logging.rs
@@ -21,34 +21,7 @@
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 //
 
-use std::{
-    env,
-    fs,
-    path::{Path, PathBuf},
-};
-
-/// Determine the path to a log configuration file using the following precedence rules:
-/// 1. Use the provided path (usually pulled from a CLI argument)
-/// 2. Use the value in the `TARI_LOG_CONFIGURATION` envar
-/// 3. The default path (OS-dependent), "~/.tari/log4rs.toml`
-/// 4. The current directory
-pub fn get_log_configuration_path(cli_path: Option<PathBuf>) -> PathBuf {
-    cli_path
-        .or_else(|| {
-            env::var_os("TARI_LOG_CONFIGURATION")
-                .filter(|s| !s.is_empty())
-                .map(PathBuf::from)
-        })
-        .or_else(|| dirs::home_dir().map(|path| path.join(".tari/log4rs.yml")))
-        .or_else(|| {
-            Some(env::current_dir().expect(
-                "Could find a suitable path to the log configuration file. Consider setting the \
-                 TARI_LOG_CONFIGURATION envar, or check that the current directory exists and that you have \
-                 permission to read it",
-            ))
-        })
-        .unwrap()
-}
+use std::{fs, path::Path};
 
 /// Set up application-level logging using the Log4rs configuration file specified in
 pub fn initialize_logging(config_file: &Path) -> bool {
@@ -124,39 +97,6 @@ macro_rules! log_if_error_fmt {
 
 #[cfg(test)]
 mod test {
-    #[cfg(target_os = "windows")]
-    pub const PATH_SEPARATOR: &str = "\\";
-    #[cfg(not(target_os = "windows"))]
-    pub const PATH_SEPARATOR: &str = "/";
-
-    use crate::{dir_utils, logging::get_log_configuration_path};
-    use std::{env, path::PathBuf};
-
-    #[test]
-    fn get_log_configuration_path_cli() {
-        let path = get_log_configuration_path(Some(PathBuf::from("~/my-tari")));
-        assert_eq!(path.to_str().unwrap(), "~/my-tari");
-    }
-
-    #[test]
-    fn get_log_configuration_path_default() {
-        let path = get_log_configuration_path(Some(PathBuf::from(
-            &dir_utils::default_subdir("", None).trim_end_matches(PATH_SEPARATOR),
-        )));
-        assert_eq!(
-            path.to_str().unwrap(),
-            dir_utils::default_subdir("", None).trim_end_matches(PATH_SEPARATOR)
-        );
-    }
-
-    #[test]
-    fn get_log_configuration_path_by_env_var() {
-        env::set_var("TARI_LOG_CONFIGURATION", "~/fake-example");
-        let path = get_log_configuration_path(None);
-        assert_eq!(path.to_str().unwrap(), "~/fake-example");
-        env::set_var("TARI_LOG_CONFIGURATION", "");
-    }
-
     #[test]
     fn log_if_error() {
         let err = Result::<(), _>::Err("What a shame");


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- Main `README.md` updated to better guide first-time users to run the base node.
- `wallet_identity_file` and `wallet_tor_identity_file` parameters added to `tari_config_sample.toml`
- All aliases for command-line arguments are now consistently supported across platforms; `--create-id` & `--create_id`, `--base-path` & `--base_path`, `base-dir` & `base_dir`, `log-config` & `log_config`.
- `--base-path` can now be specified as a relative path, previously an absolute path was required.
- `--base-path` can now be created multiple levels deep, previously only one new sub-level could be accommodated.
- Deprecated command-line args from matches methods and associated tests removed
- Tests expanded and added to cover all use cases.

Bug fixes:
- Consistent command-line arguments for Windows and Linux can now be applied, previously `--create-id` & `--create_id` was required respectively.
- Log config file was not created in the `--base-path` directory when the latter was specified.
- The log folder was not created in the `--base-path` directory when specified, but in the current working directory instead.

## Motivation and Context
- `README.md` did not give proper runtime guidance.
- Consistent command-line use between Windows and Linux is a requirement.
-  `tari_config_sample.toml` did not explain the wallet identities, with the result that uninformed users would not have unique base-node wallet identities if multiple base nodes were run on the same computer.

## How Has This Been Tested?
Tested on Windows and Linux

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [X] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [X] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [X] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [X] I'm merging against the `development` branch.
* [X] I ran `cargo-fmt --all` before pushing.
* [X] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [X] I have added tests to cover my changes.
