### PR TITLE
Add generic debug log function to FFI

### DIFF
--- a/base_layer/wallet_ffi/src/lib.rs
+++ b/base_layer/wallet_ffi/src/lib.rs
@@ -3772,6 +3772,22 @@ pub unsafe extern "C" fn wallet_destroy(wallet: *mut TariWallet) {
     }
 }
 
+/// This function will log the provided string at debug level. To be used to have a client log messages to the LibWallet
+/// logs.
+///
+/// ## Arguments
+/// `msg` - A string that will be logged at the debug level. If msg is null nothing will be done.
+///
+/// # Safety
+/// None
+#[no_mangle]
+pub unsafe extern "C" fn log_debug_message(msg: *const c_char) {
+    if !msg.is_null() {
+        let message = CStr::from_ptr(msg).to_str().unwrap().to_owned();
+        debug!(target: LOG_TARGET, "{}", message);
+    }
+}
+
 #[cfg(test)]
 mod test {
     extern crate libc;

--- a/base_layer/wallet_ffi/wallet.h
+++ b/base_layer/wallet_ffi/wallet.h
@@ -432,6 +432,9 @@ bool wallet_cancel_pending_transaction(struct TariWallet *wallet, unsigned long 
 // Frees memory for a TariWallet
 void wallet_destroy(struct TariWallet *wallet);
 
+/// This function will log the provided string at debug level. To be used to have a client log messages to the LibWallet
+void log_debug_message(const char* msg);
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
Added a basic FFI function that will log a string at debug level. This will be used to get some logging of info from the LibWallet clients in the logs.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch.
* [x] I ran `cargo-fmt --all` before pushing.
* [ ] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
