### PR TITLE
Allow external services to send SAF requests to neighbours

### DIFF
--- a/comms/dht/src/proto/tari.dht.envelope.rs
+++ b/comms/dht/src/proto/tari.dht.envelope.rs
@@ -25,8 +25,7 @@ pub struct DhtHeader {
 pub mod dht_header {
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Destination {
-        /// The sender has chosen not to disclose the message destination, or the destination is
-        /// the peer being sent to.
+        /// The sender has chosen not to disclose the message destination
         #[prost(bool, tag = "2")]
         Unknown(bool),
         /// Destined for a particular public key

--- a/comms/dht/src/test_utils/store_and_forward_mock.rs
+++ b/comms/dht/src/test_utils/store_and_forward_mock.rs
@@ -130,6 +130,7 @@ impl StoreAndForwardMock {
                 stored_at: Utc::now().naive_utc(),
             }),
             SendStoreForwardRequestToPeer(_) => {},
+            SendStoreForwardRequestNeighbours => {},
         }
     }
 }


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
- Added SendStoreForwardRequestNeighbours to SAF service

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Some delays experienced on iOS may be caused by the "on connect trigger" for SAF not triggering when the app is opened. External services can now send ad hoc SAF requests 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
implementation already tested, although this call has not been tested.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [x] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch.
* [x] I ran `cargo-fmt --all` before pushing.
* [x] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
