### PR TITLE
Update wallet to send a SAF request to neighbours on BN sync call

### DIFF
--- a/base_layer/wallet/src/error.rs
+++ b/base_layer/wallet/src/error.rs
@@ -31,6 +31,7 @@ use diesel::result::Error as DieselError;
 use log::SetLoggerError;
 use serde_json::Error as SerdeJsonError;
 use tari_comms::{multiaddr, peer_manager::PeerManagerError};
+use tari_comms_dht::store_forward::StoreAndForwardError;
 use tari_p2p::{initialization::CommsInitializationError, services::liveness::error::LivenessError};
 
 #[derive(Debug, Error)]
@@ -44,6 +45,7 @@ pub enum WalletError {
     SetLoggerError(SetLoggerError),
     ContactsServiceError(ContactsServiceError),
     LivenessServiceError(LivenessError),
+    StoreAndForwardError(StoreAndForwardError),
 }
 
 #[derive(Debug, Error)]

--- a/base_layer/wallet_ffi/src/error.rs
+++ b/base_layer/wallet_ffi/src/error.rs
@@ -208,6 +208,10 @@ impl From<WalletError> for LibWalletError {
                 code: 301,
                 message: format!("{:?}", w),
             },
+            WalletError::StoreAndForwardError(_) => Self {
+                code: 302,
+                message: format!("{:?}", w),
+            },
             WalletError::ContactsServiceError(ContactsServiceError::ContactNotFound) => Self {
                 code: 401,
                 message: format!("{:?}", w),

--- a/base_layer/wallet_ffi/src/lib.rs
+++ b/base_layer/wallet_ffi/src/lib.rs
@@ -3721,7 +3721,8 @@ pub unsafe extern "C" fn wallet_cancel_pending_transaction(
 }
 
 /// This function will tell the wallet to query the set base node to confirm the status of wallet data. For example this
-/// will check that Unspent Outputs stored in the wallet are still available as UTXO's on the blockchain
+/// will check that Unspent Outputs stored in the wallet are still available as UTXO's on the blockchain. This will also
+/// trigger a request for outstanding SAF messages to you neighbours
 ///
 /// ## Arguments
 /// `wallet` - The TariWallet pointer


### PR DESCRIPTION
## Description
The wallet has been updated to send a request for outstanding SAF message whenever the LibWallet client requests a Base Node sync. This is done to try improve SAF delivery reliability when an app returns from the background.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch.
* [x] I ran `cargo-fmt --all` before pushing.
* [ ] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
