### PR TITLE
Median timestamp refactor

### DIFF
--- a/base_layer/core/src/consensus/consensus_manager.rs
+++ b/base_layer/core/src/consensus/consensus_manager.rs
@@ -30,14 +30,14 @@ use crate::{
         },
         Block,
     },
-    chain_storage::{fetch_headers, BlockchainBackend, ChainStorageError},
+    chain_storage::ChainStorageError,
     consensus::{emission::EmissionSchedule, network::Network, ConsensusConstants},
-    proof_of_work::{get_median_timestamp, DifficultyAdjustmentError},
+    proof_of_work::DifficultyAdjustmentError,
     transactions::tari_amount::MicroTari,
 };
 use derive_error::Error;
 use std::sync::Arc;
-use tari_crypto::tari_utilities::{epoch_time::EpochTime, hash::Hashable};
+use tari_crypto::tari_utilities::hash::Hashable;
 
 #[derive(Debug, Error, Clone, PartialEq)]
 pub enum ConsensusManagerError {
@@ -88,33 +88,6 @@ impl ConsensusManager {
     /// Get a pointer to the consensus constants
     pub fn consensus_constants(&self) -> &ConsensusConstants {
         &self.inner.consensus_constants
-    }
-
-    /// Returns the median timestamp of the past 11 blocks at the chain tip.
-    pub fn get_median_timestamp<B: BlockchainBackend>(&self, db: &B) -> Result<EpochTime, ConsensusManagerError> {
-        let height = db
-            .fetch_metadata()?
-            .height_of_longest_chain
-            .ok_or_else(|| ConsensusManagerError::EmptyBlockchain)?;
-        self.get_median_timestamp_at_height(db, height)
-    }
-
-    /// Returns the median timestamp of the past 11 blocks at the provided height.
-    pub fn get_median_timestamp_at_height<B: BlockchainBackend>(
-        &self,
-        db: &B,
-        height: u64,
-    ) -> Result<EpochTime, ConsensusManagerError>
-    {
-        let median_timestamp_count = self.inner.consensus_constants.get_median_timestamp_count();
-        let min_height = if height > median_timestamp_count as u64 {
-            height - median_timestamp_count as u64
-        } else {
-            0
-        };
-        let block_nums = (min_height..=height).collect();
-        let headers = fetch_headers(db, block_nums)?;
-        get_median_timestamp(headers).ok_or_else(|| ConsensusManagerError::EmptyBlockchain)
     }
 
     /// Creates a total_coinbase offset containing all fees for the validation from block

--- a/base_layer/core/src/proof_of_work/median_timestamp.rs
+++ b/base_layer/core/src/proof_of_work/median_timestamp.rs
@@ -20,32 +20,24 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use crate::blocks::blockheader::BlockHeader;
 use log::*;
 use tari_crypto::tari_utilities::epoch_time::EpochTime;
 
 pub const LOG_TARGET: &str = "c::pow::median_timestamp";
 
 /// Returns the median timestamp for the provided header set.
-pub fn get_median_timestamp(headers: Vec<BlockHeader>) -> Option<EpochTime> {
-    if headers.is_empty() {
+pub fn get_median_timestamp(mut timestamps: Vec<EpochTime>) -> Option<EpochTime> {
+    if timestamps.is_empty() {
         return None;
     }
-    let height = headers.last().expect("Header set should not be empty").height;
-    debug!(target: LOG_TARGET, "Calculating median timestamp to height:{}", height);
-    let mut timestamps = headers.iter().map(|h| h.timestamp).collect::<Vec<_>>();
     timestamps.sort();
     trace!(target: LOG_TARGET, "Sorted median timestamps: {:?}", timestamps);
-    // Calculate median timestamp
     let mid_index = timestamps.len() / 2;
-    // let median_timestamp=if timestamps.len()%2==0 {
-    // (timestamps[mid_index-1]+timestamps[mid_index])/2
-    // }
-    // else { timestamps[mid_index] };
-    let median_timestamp = timestamps[mid_index];
-    debug!(
-        target: LOG_TARGET,
-        "Median timestamp:{} at height:{}", median_timestamp, height
-    );
+    let median_timestamp = if timestamps.len() % 2 == 0 {
+        (timestamps[mid_index - 1] + timestamps[mid_index]) / 2
+    } else {
+        timestamps[mid_index]
+    };
+    trace!(target: LOG_TARGET, "Median timestamp:{}", median_timestamp);
     Some(median_timestamp)
 }

--- a/base_layer/core/tests/median_timestamp.rs
+++ b/base_layer/core/tests/median_timestamp.rs
@@ -28,66 +28,21 @@ use helpers::{
     pow_blockchain::{append_to_pow_blockchain, create_test_pow_blockchain},
 };
 use tari_core::{
+    chain_storage::{fetch_headers, BlockchainBackend},
     consensus::{ConsensusManagerBuilder, Network},
     helpers::create_mem_db,
-    proof_of_work::PowAlgorithm,
+    proof_of_work::{get_median_timestamp, PowAlgorithm},
 };
 use tari_crypto::tari_utilities::epoch_time::EpochTime;
 
-#[test]
-fn test_median_timestamp() {
-    let network = Network::LocalNet;
-    let consensus_manager = ConsensusManagerBuilder::new(network).build();
-    let store = create_mem_db(&consensus_manager);
-    let pow_algos = vec![PowAlgorithm::Blake]; // GB default
-    create_test_pow_blockchain(&store, pow_algos, &consensus_manager);
-    let start_timestamp = store.fetch_block(0).unwrap().block().header.timestamp.clone();
-    let mut timestamp = consensus_manager
-        .get_median_timestamp(&*store.db_read_access().unwrap())
-        .expect("median returned an error");
-    assert_eq!(timestamp, start_timestamp);
-
-    let pow_algos = vec![PowAlgorithm::Blake];
-    // lets add 1
-    let tip = store.fetch_block(store.get_height().unwrap().unwrap()).unwrap().block;
-    append_to_pow_blockchain(&store, tip, pow_algos.clone(), &consensus_manager);
-    let mut prev_timestamp: EpochTime =
-        start_timestamp.increase(consensus_manager.consensus_constants().get_target_block_interval());
-    timestamp = consensus_manager
-        .get_median_timestamp(&*store.db_read_access().unwrap())
-        .expect("median returned an error");
-    assert_eq!(timestamp, prev_timestamp);
-    // lets add 1
-    let tip = store.fetch_block(store.get_height().unwrap().unwrap()).unwrap().block;
-    append_to_pow_blockchain(&store, tip, pow_algos.clone(), &consensus_manager);
-    prev_timestamp = start_timestamp.increase(consensus_manager.consensus_constants().get_target_block_interval());
-    timestamp = consensus_manager
-        .get_median_timestamp(&*store.db_read_access().unwrap())
-        .expect("median returned an error");
-    assert_eq!(timestamp, prev_timestamp);
-
-    // lets build up 11 blocks
-    for i in 4..12 {
-        let tip = store.fetch_block(store.get_height().unwrap().unwrap()).unwrap().block;
-        append_to_pow_blockchain(&store, tip, pow_algos.clone(), &consensus_manager);
-        prev_timestamp =
-            start_timestamp.increase(consensus_manager.consensus_constants().get_target_block_interval() * (i / 2));
-        timestamp = consensus_manager
-            .get_median_timestamp(&*store.db_read_access().unwrap())
-            .expect("median returned an error");
-        assert_eq!(timestamp, prev_timestamp);
-    }
-
-    // lets add many1 blocks
-    for _i in 1..20 {
-        let tip = store.fetch_block(store.get_height().unwrap().unwrap()).unwrap().block;
-        append_to_pow_blockchain(&store, tip, pow_algos.clone(), &consensus_manager);
-        prev_timestamp = prev_timestamp.increase(consensus_manager.consensus_constants().get_target_block_interval());
-        timestamp = consensus_manager
-            .get_median_timestamp(&*store.db_read_access().unwrap())
-            .expect("median returned an error");
-        assert_eq!(timestamp, prev_timestamp);
-    }
+pub fn get_header_timestamps<B: BlockchainBackend>(db: &B, height: u64, timestamp_count: u64) -> Vec<EpochTime> {
+    let min_height = height.checked_sub(timestamp_count).unwrap_or(0);
+    let block_nums = (min_height..=height).collect();
+    fetch_headers(db, block_nums)
+        .unwrap()
+        .iter()
+        .map(|h| h.timestamp)
+        .collect::<Vec<_>>()
 }
 
 #[test]
@@ -103,69 +58,79 @@ fn test_median_timestamp_with_height() {
         PowAlgorithm::Blake,
     ];
     create_test_pow_blockchain(&store, pow_algos, &consensus_manager);
+    let timestamp_count = 10;
 
     let header0_timestamp = store.fetch_header(0).unwrap().timestamp;
     let header1_timestamp = store.fetch_header(1).unwrap().timestamp;
     let header2_timestamp = store.fetch_header(2).unwrap().timestamp;
 
-    let timestamp = consensus_manager
-        .get_median_timestamp_at_height(&*store.db_read_access().unwrap(), 0)
-        .expect("median returned an error");
-    assert_eq!(timestamp, header0_timestamp);
+    let db = &*store.db_read_access().unwrap();
+    let median_timestamp =
+        get_median_timestamp(get_header_timestamps(db, 0, timestamp_count)).expect("median returned an error");
+    assert_eq!(median_timestamp, header0_timestamp);
 
-    let timestamp = consensus_manager
-        .get_median_timestamp_at_height(&*store.db_read_access().unwrap(), 3)
-        .expect("median returned an error");
-    assert_eq!(timestamp, header2_timestamp);
+    let median_timestamp =
+        get_median_timestamp(get_header_timestamps(db, 3, timestamp_count)).expect("median returned an error");
+    assert_eq!(median_timestamp, (header1_timestamp + header2_timestamp) / 2);
 
-    let timestamp = consensus_manager
-        .get_median_timestamp_at_height(&*store.db_read_access().unwrap(), 2)
-        .expect("median returned an error");
-    assert_eq!(timestamp, header1_timestamp);
+    let median_timestamp =
+        get_median_timestamp(get_header_timestamps(db, 2, timestamp_count)).expect("median returned an error");
+    assert_eq!(median_timestamp, header1_timestamp);
 
-    let timestamp = consensus_manager
-        .get_median_timestamp_at_height(&*store.db_read_access().unwrap(), 4)
-        .expect("median returned an error");
-    assert_eq!(timestamp, header2_timestamp);
+    let median_timestamp =
+        get_median_timestamp(get_header_timestamps(db, 4, timestamp_count)).expect("median returned an error");
+    assert_eq!(median_timestamp, header2_timestamp);
 }
 
 #[test]
 fn test_median_timestamp_odd_order() {
     let network = Network::LocalNet;
     let consensus_manager = ConsensusManagerBuilder::new(network).build();
+    let timestamp_count = consensus_manager.consensus_constants().get_median_timestamp_count() as u64;
     let store = create_mem_db(&consensus_manager);
     let pow_algos = vec![PowAlgorithm::Blake]; // GB default
     create_test_pow_blockchain(&store, pow_algos, &consensus_manager);
-    let start_timestamp = store.fetch_block(0).unwrap().block().header.timestamp.clone();
-    let mut timestamp = consensus_manager
-        .get_median_timestamp(&*store.db_read_access().unwrap())
-        .expect("median returned an error");
-    assert_eq!(timestamp, start_timestamp);
+    let mut timestamps = vec![store.fetch_block(0).unwrap().block().header.timestamp.clone()];
+    let height = store.get_metadata().unwrap().height_of_longest_chain.unwrap();
+    let mut median_timestamp = get_median_timestamp(get_header_timestamps(
+        &*store.db_read_access().unwrap(),
+        height,
+        timestamp_count,
+    ))
+    .expect("median returned an error");
+    assert_eq!(median_timestamp, timestamps[0]);
     let pow_algos = vec![PowAlgorithm::Blake];
     // lets add 1
     let tip = store.fetch_block(store.get_height().unwrap().unwrap()).unwrap().block;
     append_to_pow_blockchain(&store, tip, pow_algos.clone(), &consensus_manager);
-    let mut prev_timestamp: EpochTime =
-        start_timestamp.increase(consensus_manager.consensus_constants().get_target_block_interval());
-    timestamp = consensus_manager
-        .get_median_timestamp(&*store.db_read_access().unwrap())
-        .expect("median returned an error");
-    assert_eq!(timestamp, prev_timestamp);
+    timestamps.push(timestamps[0].increase(consensus_manager.consensus_constants().get_target_block_interval()));
+    let height = store.get_metadata().unwrap().height_of_longest_chain.unwrap();
+    median_timestamp = get_median_timestamp(get_header_timestamps(
+        &*store.db_read_access().unwrap(),
+        height,
+        timestamp_count,
+    ))
+    .expect("median returned an error");
+    assert_eq!(median_timestamp, (timestamps[0] + timestamps[1]) / 2);
 
     // lets add 1 that's further back then
     let append_height = store.get_height().unwrap().unwrap();
     let prev_block = store.fetch_block(append_height).unwrap().block().clone();
     let new_block = chain_block(&prev_block, Vec::new(), &consensus_manager.consensus_constants());
     let mut new_block = store.calculate_mmr_roots(new_block).unwrap();
-    new_block.header.timestamp =
-        start_timestamp.increase(&consensus_manager.consensus_constants().get_target_block_interval() / 2);
+    timestamps.push(timestamps[0].increase(&consensus_manager.consensus_constants().get_target_block_interval() / 2));
+    new_block.header.timestamp = timestamps[2];
     new_block.header.pow.pow_algo = PowAlgorithm::Blake;
     store.add_block(new_block).unwrap();
 
-    prev_timestamp = start_timestamp.increase(consensus_manager.consensus_constants().get_target_block_interval() / 2);
-    timestamp = consensus_manager
-        .get_median_timestamp(&*store.db_read_access().unwrap())
-        .expect("median returned an error");
+    timestamps.push(timestamps[2].increase(consensus_manager.consensus_constants().get_target_block_interval() / 2));
+    let height = store.get_metadata().unwrap().height_of_longest_chain.unwrap();
+    median_timestamp = get_median_timestamp(get_header_timestamps(
+        &*store.db_read_access().unwrap(),
+        height,
+        timestamp_count,
+    ))
+    .expect("median returned an error");
     // Median timestamp should be block 3 and not block 2
-    assert_eq!(timestamp, prev_timestamp);
+    assert_eq!(median_timestamp, timestamps[2]);
 }


### PR DESCRIPTION
## Description
- Decoupled the median timestamp calculation from the ConsensusManger by removing the get_median_timestamp and get_median_timestamp_at_height functions.
- Changed the get_median_timestamp function to calculate the median from a set of timestamps and not a set of headers.
- Changed the median calculation to use the correct median formula.

## Motivation and Context
These changes decouple the median timestamp calculation from the blockchain backend and ConsensusManger. Also, the median calculation was changed to perform a true median and not an approximation. 

## How Has This Been Tested?
Updated the median timestamp tests and discarded the test_median_timestamp test that was testing similar mechanisms to the other median timestamp tests.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [x] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch.
* [x] I ran `cargo-fmt --all` before pushing.
* [x] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
