### PR TITLE
Add UTXO selection strategy for large txs

### DIFF
--- a/base_layer/wallet/tests/output_manager_service/service.rs
+++ b/base_layer/wallet/tests/output_manager_service/service.rs
@@ -905,7 +905,7 @@ fn coin_split_with_change<T: Clone + OutputManagerBackend + 'static>(backend: T)
     assert_eq!(coin_split_tx.body.inputs().len(), 2);
     assert_eq!(coin_split_tx.body.outputs().len(), split_count + 1);
     assert_eq!(fee, Fee::calculate(fee_per_gram, 1, 2, split_count + 1));
-    assert_eq!(amount, val1 + val2);
+    assert_eq!(amount, val2 + val3);
 }
 
 #[test]


### PR DESCRIPTION
The default UTXO selection strategy is to use the smallest outputs
first. This works well most of the time, but for really large trans-
action amounts, we can run into the transaction input limits.

This PR adds a new strategy and a selection heuristic for selcring it.
`Largest` does what it says on the box. It's the inverse of `Smallest`.

If the total transaction amount > alpha * My largest UTXO, then we
select Largest (for now alpha = 1).

The coin_split strategy also uses Largest (since that makes the most
sense if you're trying to make more UTXOs)

