### PR TITLE
Don't mark peers as offline if there are no existing connections

### DIFF
--- a/comms/dht/src/discovery/error.rs
+++ b/comms/dht/src/discovery/error.rs
@@ -23,7 +23,7 @@
 use crate::outbound::DhtOutboundError;
 use derive_error::Error;
 use futures::channel::mpsc::SendError;
-use tari_comms::peer_manager::PeerManagerError;
+use tari_comms::{connection_manager::ConnectionManagerError, peer_manager::PeerManagerError};
 
 #[derive(Debug, Error)]
 pub enum DhtDiscoveryError {
@@ -45,6 +45,7 @@ pub enum DhtDiscoveryError {
     PeerManagerError(PeerManagerError),
     #[error(msg_embedded, non_std, no_from)]
     InvalidPeerMultiaddr(String),
+    ConnectionManagerError(ConnectionManagerError),
 }
 
 impl DhtDiscoveryError {

--- a/comms/src/connection_manager/manager.rs
+++ b/comms/src/connection_manager/manager.rs
@@ -348,7 +348,21 @@ where
                 let _ = reply_tx.send(self.active_connections.get(&node_id).map(Clone::clone));
             },
             GetActiveConnections(reply_tx) => {
-                let _ = reply_tx.send(self.active_connections.values().cloned().collect());
+                let _ = reply_tx.send(
+                    self.active_connections
+                        .values()
+                        .filter(|conn| conn.is_connected())
+                        .cloned()
+                        .collect(),
+                );
+            },
+            GetNumActiveConnections(reply_tx) => {
+                let _ = reply_tx.send(
+                    self.active_connections
+                        .values()
+                        .filter(|conn| conn.is_connected())
+                        .count(),
+                );
             },
             DisconnectPeer(node_id, reply_tx) => match self.active_connections.remove(&node_id) {
                 Some(mut conn) => {

--- a/comms/src/connection_manager/requester.rs
+++ b/comms/src/connection_manager/requester.rs
@@ -42,6 +42,8 @@ pub enum ConnectionManagerRequest {
     GetActiveConnection(NodeId, oneshot::Sender<Option<PeerConnection>>),
     /// Retrieve all active connections
     GetActiveConnections(oneshot::Sender<Vec<PeerConnection>>),
+    /// Retrieve the number of active connections
+    GetNumActiveConnections(oneshot::Sender<usize>),
     /// Disconnect a peer
     DisconnectPeer(NodeId, oneshot::Sender<Result<(), ConnectionManagerError>>),
 }
@@ -94,6 +96,8 @@ macro_rules! request_fn {
 
 impl ConnectionManagerRequester {
     request_fn!(get_active_connections() -> Vec<PeerConnection>, request = ConnectionManagerRequest::GetActiveConnections);
+
+    request_fn!(get_num_active_connections() -> usize, request = ConnectionManagerRequest::GetNumActiveConnections);
 
     request_fn!(get_active_connection(node_id: NodeId) -> Option<PeerConnection>, request = ConnectionManagerRequest::GetActiveConnection);
 

--- a/comms/src/peer_manager/peer.rs
+++ b/comms/src/peer_manager/peer.rs
@@ -210,9 +210,7 @@ impl Peer {
 
     /// Returns the ban status of the peer
     pub fn is_banned(&self) -> bool {
-        self.banned_until
-            .map(|dt| dt >= Utc::now().naive_utc())
-            .unwrap_or(false)
+        self.banned_until().is_some()
     }
 
     /// Bans the peer for a specified duration
@@ -227,7 +225,7 @@ impl Peer {
     }
 
     pub fn banned_until(&self) -> Option<&NaiveDateTime> {
-        self.banned_until.as_ref()
+        self.banned_until.as_ref().filter(|dt| *dt >= &Utc::now().naive_utc())
     }
 
     /// Marks the peer as offline

--- a/comms/src/test_utils/mocks/connection_manager.rs
+++ b/comms/src/test_utils/mocks/connection_manager.rs
@@ -152,6 +152,9 @@ impl ConnectionManagerMock {
                     .send(self.state.active_conns.lock().await.values().cloned().collect())
                     .unwrap();
             },
+            GetNumActiveConnections(reply_tx) => {
+                reply_tx.send(self.state.active_conns.lock().await.len()).unwrap();
+            },
             DisconnectPeer(node_id, reply_tx) => {
                 let _ = self.state.active_conns.lock().await.remove(&node_id);
                 reply_tx.send(Ok(())).unwrap();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
- Adding a condition that will prevent peers from being marked as
  offline while there are no active connections, in which case, the node
  itself may have lost connection.
- To clarify the above: "Offline" means that a peer will not be chosen for the
  propagation of messages. Attempting to send a message directly will still
  be attempted. There is existing protection for marking more than 70%
  of neighbouring peers as offline, so this change is an additional
  protection from both sides considering each other offline.
- Bug fix where peers are displayed as offline in the `list-peers`
  command, even though logically they are not considered offline.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Nodes could mistakenly be marked as offline by a node experiencing loss of connection. This remedies that by requiring at least one active peer connection before marking any peer as offline.  Unfortunately, tor takes a while to drop socks connections once the internet is cut off, TODO: look for settings in tor to fine tune this.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
No unit/integration tests (TODO). Tested locally by starting a base node, switching off wifi and checking that no peers are marked as offline.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch.
* [x] I ran `cargo-fmt --all` before pushing.
* [x] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
