### PR TITLE
Reset genesis block

### DIFF
--- a/base_layer/core/src/base_node/comms_interface/comms_request.rs
+++ b/base_layer/core/src/base_node/comms_interface/comms_request.rs
@@ -48,7 +48,7 @@ pub enum NodeCommsRequest {
     FetchUtxos(Vec<HashOutput>),
     FetchBlocks(Vec<u64>),
     FetchBlocksWithHashes(Vec<HashOutput>),
-    GetNewBlockTemplate,
+    GetNewBlockTemplate(PowAlgorithm),
     GetNewBlock(NewBlockTemplate),
     GetTargetDifficulty(PowAlgorithm),
 }
@@ -64,7 +64,7 @@ impl Display for NodeCommsRequest {
             NodeCommsRequest::FetchUtxos(v) => f.write_str(&format!("FetchUtxos (n={})", v.len())),
             NodeCommsRequest::FetchBlocks(v) => f.write_str(&format!("FetchBlocks (n={})", v.len())),
             NodeCommsRequest::FetchBlocksWithHashes(v) => f.write_str(&format!("FetchBlocks (n={})", v.len())),
-            NodeCommsRequest::GetNewBlockTemplate => f.write_str("GetNewBlockTemplate"),
+            NodeCommsRequest::GetNewBlockTemplate(algo) => f.write_str(&format!("GetNewBlockTemplate ({})", algo)),
             NodeCommsRequest::GetNewBlock(b) => f.write_str(&format!("GetNewBlock (Block Height={})", b.header.height)),
             NodeCommsRequest::GetTargetDifficulty(algo) => f.write_str(&format!("GetTargetDifficulty ({})", algo)),
         }

--- a/base_layer/core/src/base_node/comms_interface/inbound_handlers.rs
+++ b/base_layer/core/src/base_node/comms_interface/inbound_handlers.rs
@@ -36,6 +36,7 @@ use crate::{
     },
     consensus::ConsensusManager,
     mempool::{async_mempool, Mempool},
+    proof_of_work::{get_target_difficulty, Difficulty, PowAlgorithm},
     transactions::transaction::{TransactionKernel, TransactionOutput},
 };
 use futures::SinkExt;
@@ -202,15 +203,18 @@ where T: BlockchainBackend + 'static
                 }
                 Ok(NodeCommsResponse::HistoricalBlocks(blocks))
             },
-            NodeCommsRequest::GetNewBlockTemplate => {
+            NodeCommsRequest::GetNewBlockTemplate(pow_algo) => {
                 let metadata = async_db::get_metadata(self.blockchain_db.clone()).await?;
                 let best_block_hash = metadata
                     .best_block
                     .ok_or_else(|| CommsInterfaceError::UnexpectedApiResponse)?;
                 let best_block_header =
                     async_db::fetch_header_with_block_hash(self.blockchain_db.clone(), best_block_hash).await?;
+
+                let constants = self.consensus_manager.consensus_constants();
                 let mut header = BlockHeader::from_previous(&best_block_header);
-                header.version = self.consensus_manager.consensus_constants().blockchain_version();
+                header.version = constants.blockchain_version();
+                header.pow.target_difficulty = self.get_target_difficulty(*pow_algo).await?;
 
                 let transactions = async_mempool::retrieve(
                     self.mempool.clone(),
@@ -234,10 +238,29 @@ where T: BlockchainBackend + 'static
                 Ok(NodeCommsResponse::NewBlock(block))
             },
             NodeCommsRequest::GetTargetDifficulty(pow_algo) => {
-                let db = &self.blockchain_db.db_read_access()?;
-                Ok(NodeCommsResponse::TargetDifficulty(
-                    self.consensus_manager.get_target_difficulty(&**db, *pow_algo)?,
-                ))
+                /*let height_of_longest_chain = async_db::get_metadata(self.blockchain_db.clone())
+                    .await?
+                    .height_of_longest_chain
+                    .ok_or_else(|| CommsInterfaceError::UnexpectedApiResponse)?;
+                debug!(
+                    target: LOG_TARGET,
+                    "Calculating target difficulty at height:{} for PoW:{}", height_of_longest_chain, pow_algo
+                );
+                let constants = self.consensus_manager.consensus_constants();
+                let target_difficulties = self.blockchain_db.fetch_target_difficulties(
+                    *pow_algo,
+                    height_of_longest_chain,
+                    constants.get_difficulty_block_window() as usize,
+                )?;
+                let target = get_target_difficulty(
+                    target_difficulties,
+                    constants.get_difficulty_block_window() as usize,
+                    constants.get_diff_target_block_interval(),
+                    constants.min_pow_difficulty(*pow_algo),
+                    constants.get_difficulty_max_block_interval(),
+                )?;
+                debug!(target: LOG_TARGET, "Target difficulty:{} for PoW:{}", target, pow_algo);*/
+                Ok(NodeCommsResponse::TargetDifficulty(self.get_target_difficulty(*pow_algo).await?))
             },
         }
     }
@@ -295,6 +318,32 @@ where T: BlockchainBackend + 'static
             }
         }
         Ok(())
+    }
+
+    async fn get_target_difficulty(&self, pow_algo: PowAlgorithm) -> Result<Difficulty, CommsInterfaceError> {
+        let height_of_longest_chain = async_db::get_metadata(self.blockchain_db.clone())
+            .await?
+            .height_of_longest_chain
+            .ok_or_else(|| CommsInterfaceError::UnexpectedApiResponse)?;
+        debug!(
+            target: LOG_TARGET,
+            "Calculating target difficulty at height:{} for PoW:{}", height_of_longest_chain, pow_algo
+        );
+        let constants = self.consensus_manager.consensus_constants();
+        let target_difficulties = self.blockchain_db.fetch_target_difficulties(
+            pow_algo,
+            height_of_longest_chain,
+            constants.get_difficulty_block_window() as usize,
+        )?;
+        let target = get_target_difficulty(
+            target_difficulties,
+            constants.get_difficulty_block_window() as usize,
+            constants.get_diff_target_block_interval(),
+            constants.min_pow_difficulty(pow_algo),
+            constants.get_difficulty_max_block_interval(),
+        )?;
+        debug!(target: LOG_TARGET, "Target difficulty:{} for PoW:{}", target, pow_algo);
+        Ok(target)
     }
 }
 

--- a/base_layer/core/src/base_node/comms_interface/local_interface.rs
+++ b/base_layer/core/src/base_node/comms_interface/local_interface.rs
@@ -96,10 +96,14 @@ impl LocalNodeCommsInterface {
     }
 
     /// Request the construction of a new mineable block template from the base node service.
-    pub async fn get_new_block_template(&mut self) -> Result<NewBlockTemplate, CommsInterfaceError> {
+    pub async fn get_new_block_template(
+        &mut self,
+        pow_algorithm: PowAlgorithm,
+    ) -> Result<NewBlockTemplate, CommsInterfaceError>
+    {
         match self
             .request_sender
-            .call(NodeCommsRequest::GetNewBlockTemplate)
+            .call(NodeCommsRequest::GetNewBlockTemplate(pow_algorithm))
             .await??
         {
             NodeCommsResponse::NewBlockTemplate(new_block_template) => Ok(new_block_template),

--- a/base_layer/core/src/base_node/proto/request.proto
+++ b/base_layer/core/src/base_node/proto/request.proto
@@ -23,7 +23,7 @@ message BaseNodeServiceRequest {
         // Indicates a FetchBlocksWithHashes request.
         HashOutputs fetch_blocks_with_hashes = 8;
         // Indicates a GetNewBlockTemplate request.
-        bool get_new_block_template = 9;
+        uint64 get_new_block_template = 9;
         // Indicates a GetNewBlock request.
         tari.core.NewBlockTemplate get_new_block = 10;
         // Indicates a GetTargetDifficulty request.

--- a/base_layer/core/src/base_node/proto/request.rs
+++ b/base_layer/core/src/base_node/proto/request.rs
@@ -47,7 +47,9 @@ impl TryInto<ci::NodeCommsRequest> for ProtoNodeCommsRequest {
             FetchUtxos(hash_outputs) => ci::NodeCommsRequest::FetchUtxos(hash_outputs.outputs),
             FetchBlocks(block_heights) => ci::NodeCommsRequest::FetchBlocks(block_heights.heights),
             FetchBlocksWithHashes(block_hashes) => ci::NodeCommsRequest::FetchBlocksWithHashes(block_hashes.outputs),
-            GetNewBlockTemplate(_) => ci::NodeCommsRequest::GetNewBlockTemplate,
+            GetNewBlockTemplate(pow_algo) => {
+                ci::NodeCommsRequest::GetNewBlockTemplate(PowAlgorithm::try_from(pow_algo)?)
+            },
             GetNewBlock(block_template) => ci::NodeCommsRequest::GetNewBlock(block_template.try_into()?),
             GetTargetDifficulty(pow_algo) => {
                 ci::NodeCommsRequest::GetTargetDifficulty(PowAlgorithm::try_from(pow_algo)?)
@@ -71,7 +73,7 @@ impl From<ci::NodeCommsRequest> for ProtoNodeCommsRequest {
             FetchUtxos(hash_outputs) => ProtoNodeCommsRequest::FetchUtxos(hash_outputs.into()),
             FetchBlocks(block_heights) => ProtoNodeCommsRequest::FetchBlocks(block_heights.into()),
             FetchBlocksWithHashes(block_hashes) => ProtoNodeCommsRequest::FetchBlocksWithHashes(block_hashes.into()),
-            GetNewBlockTemplate => ProtoNodeCommsRequest::GetNewBlockTemplate(true),
+            GetNewBlockTemplate(pow_algo) => ProtoNodeCommsRequest::GetNewBlockTemplate(pow_algo as u64),
             GetNewBlock(block_template) => ProtoNodeCommsRequest::GetNewBlock(block_template.into()),
             GetTargetDifficulty(pow_algo) => ProtoNodeCommsRequest::GetTargetDifficulty(pow_algo as u64),
         }

--- a/base_layer/core/src/blocks/genesis_block.rs
+++ b/base_layer/core/src/blocks/genesis_block.rs
@@ -120,6 +120,7 @@ pub fn get_rincewind_genesis_block_raw() -> Block {
             pow: ProofOfWork {
                 accumulated_monero_difficulty: 1.into(),
                 accumulated_blake_difficulty: 1.into(),
+                target_difficulty: 1.into(),
                 pow_algo: PowAlgorithm::Blake,
                 pow_data: vec![],
             },

--- a/base_layer/core/src/blocks/genesis_block.rs
+++ b/base_layer/core/src/blocks/genesis_block.rs
@@ -108,7 +108,7 @@ pub fn get_rincewind_genesis_block_raw() -> Block {
             prev_hash: vec![
                 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
             ],
-            timestamp: 1_585_900_800.into(), // Friday, 3 April 2020 10:00:00 GMT+02:00
+            timestamp: 1_587_837_600.into(), // Saturday, 25 April 2020 18:00:00 GMT
             output_mr: from_hex("fab84d9d797c272b33011caa78718f93c3d5fc44c7d35bbf138613440fca2c79").unwrap(),
             range_proof_mr: from_hex("63a36ba139a884434702dffccec348b02ba886d3851a19732d8d111a54e17d56").unwrap(),
             kernel_mr: from_hex("b097af173dc852862f48af67aa57f48c47d20bc608d77b46a3018999bffba911").unwrap(),

--- a/base_layer/core/src/chain_storage/mod.rs
+++ b/base_layer/core/src/chain_storage/mod.rs
@@ -43,6 +43,7 @@ pub use blockchain_database::{
     calculate_mmr_roots,
     fetch_header,
     fetch_headers,
+    fetch_target_difficulties,
     is_stxo,
     is_utxo,
     BlockAddResult,

--- a/base_layer/core/src/consensus/consensus_constants.rs
+++ b/base_layer/core/src/consensus/consensus_constants.rs
@@ -22,7 +22,7 @@
 
 use crate::{
     consensus::network::Network,
-    proof_of_work::Difficulty,
+    proof_of_work::{Difficulty, PowAlgorithm},
     transactions::tari_amount::{uT, MicroTari, T},
 };
 use chrono::{DateTime, Duration, Utc};
@@ -58,7 +58,7 @@ pub struct ConsensusConstants {
     /// This is the emission curve tail amount
     pub(in crate::consensus) emission_tail: MicroTari,
     /// This is the initial min difficulty for the difficulty adjustment
-    min_pow_difficulty: Difficulty,
+    min_pow_difficulty: (Difficulty, Difficulty),
 }
 // The target time used by the difficulty adjustment algorithms, their target time is the target block interval * PoW
 // algorithm count
@@ -132,8 +132,11 @@ impl ConsensusConstants {
     }
 
     // This is the min initial difficulty that can be requested for the pow
-    pub fn min_pow_difficulty(&self) -> Difficulty {
-        self.min_pow_difficulty
+    pub fn min_pow_difficulty(&self, pow_algo: PowAlgorithm) -> Difficulty {
+        match pow_algo {
+            PowAlgorithm::Monero => self.min_pow_difficulty.0,
+            PowAlgorithm::Blake => self.min_pow_difficulty.1,
+        }
     }
 
     #[allow(clippy::identity_op)]
@@ -153,7 +156,7 @@ impl ConsensusConstants {
             emission_initial: 5_538_846_115 * uT,
             emission_decay: 0.999_999_560_409_038_5,
             emission_tail: 1 * T,
-            min_pow_difficulty: 60_000_000.into(),
+            min_pow_difficulty: (1.into(), 60_000_000.into()),
         }
     }
 
@@ -173,7 +176,7 @@ impl ConsensusConstants {
             emission_initial: 10_000_000.into(),
             emission_decay: 0.999,
             emission_tail: 100.into(),
-            min_pow_difficulty: 1.into(),
+            min_pow_difficulty: (1.into(), 1.into()),
         }
     }
 
@@ -194,7 +197,7 @@ impl ConsensusConstants {
             emission_initial: 10_000_000.into(),
             emission_decay: 0.999,
             emission_tail: 100.into(),
-            min_pow_difficulty: 500_000_000.into(),
+            min_pow_difficulty: (1.into(), 500_000_000.into()),
         }
     }
 }

--- a/base_layer/core/src/helpers/mock_backend.rs
+++ b/base_layer/core/src/helpers/mock_backend.rs
@@ -23,11 +23,13 @@
 use crate::{
     blocks::{Block, BlockHeader},
     chain_storage::{BlockchainBackend, ChainMetadata, ChainStorageError, DbKey, DbTransaction, DbValue, MmrTree},
+    proof_of_work::{Difficulty, PowAlgorithm},
     transactions::{
         transaction::{TransactionKernel, TransactionOutput},
         types::HashOutput,
     },
 };
+use tari_crypto::tari_utilities::epoch_time::EpochTime;
 use tari_mmr::{Hash, MerkleCheckPoint, MerkleProof};
 
 // This is a test backend. This is used so that the ConsensusManager can be called without actually having a backend.
@@ -118,6 +120,16 @@ impl BlockchainBackend for MockBackend {
     }
 
     fn fetch_metadata(&self) -> Result<ChainMetadata, ChainStorageError> {
+        unimplemented!()
+    }
+
+    fn fetch_target_difficulties(
+        &self,
+        _pow_algo: PowAlgorithm,
+        _height: u64,
+        _block_window: usize,
+    ) -> Result<Vec<(EpochTime, Difficulty)>, ChainStorageError>
+    {
         unimplemented!()
     }
 }

--- a/base_layer/core/src/mining/blake_miner.rs
+++ b/base_layer/core/src/mining/blake_miner.rs
@@ -20,10 +20,7 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use crate::{
-    blocks::BlockHeader,
-    proof_of_work::{Difficulty, ProofOfWork},
-};
+use crate::{blocks::BlockHeader, proof_of_work::ProofOfWork};
 use log::*;
 use rand::{rngs::OsRng, RngCore};
 use serde::{Deserialize, Serialize};
@@ -48,20 +45,18 @@ pub struct CpuBlakePow;
 impl CpuBlakePow {
     /// A simple miner. It starts with a random nonce and iterates until it finds a header hash that meets the desired
     /// target
-    pub fn mine(
-        target_difficulty: Difficulty,
-        mut header: BlockHeader,
-        stop_flag: Arc<AtomicBool>,
-    ) -> Option<BlockHeader>
-    {
+    pub fn mine(mut header: BlockHeader, stop_flag: Arc<AtomicBool>) -> Option<BlockHeader> {
         let mut start = Instant::now();
         let mut nonce: u64 = OsRng.next_u64();
         let mut last_measured_nonce = nonce;
         // We're mining over here!
         let mut difficulty = ProofOfWork::achieved_difficulty(&header);
         info!(target: LOG_TARGET, "Mining started.");
-        debug!(target: LOG_TARGET, "Mining for difficulty: {:?}", target_difficulty);
-        while difficulty < target_difficulty {
+        debug!(
+            target: LOG_TARGET,
+            "Mining for difficulty: {:?}", header.pow.target_difficulty
+        );
+        while difficulty < header.pow.target_difficulty {
             if start.elapsed() >= Duration::from_secs(60) {
                 // nonce might have wrapped around
                 let hashes = if nonce >= last_measured_nonce {

--- a/base_layer/core/src/proof_of_work/error.rs
+++ b/base_layer/core/src/proof_of_work/error.rs
@@ -28,6 +28,8 @@ pub enum PowError {
     InvalidProofOfWork,
     // Target difficulty not achieved
     AchievedDifficultyTooLow,
+    // Invalid target difficulty
+    InvalidTargetDifficulty,
 }
 
 #[derive(Debug, Error, Clone, PartialEq)]

--- a/base_layer/core/src/proof_of_work/proof_of_work.rs
+++ b/base_layer/core/src/proof_of_work/proof_of_work.rs
@@ -70,6 +70,8 @@ pub struct ProofOfWork {
     /// but not including this block, tracked separately.
     pub accumulated_monero_difficulty: Difficulty,
     pub accumulated_blake_difficulty: Difficulty,
+    /// The target difficulty for solving the current block using the specified proof of work algorithm.
+    pub target_difficulty: Difficulty,
     /// The algorithm used to mine this block
     pub pow_algo: PowAlgorithm,
     /// Supplemental proof of work data. For example for Blake, this would be empty (only the block header is
@@ -82,6 +84,7 @@ impl Default for ProofOfWork {
         Self {
             accumulated_monero_difficulty: Difficulty::default(),
             accumulated_blake_difficulty: Difficulty::default(),
+            target_difficulty: Difficulty::default(),
             pow_algo: PowAlgorithm::Blake,
             pow_data: vec![],
         }
@@ -96,6 +99,7 @@ impl ProofOfWork {
             pow_algo,
             accumulated_monero_difficulty: Difficulty::default(),
             accumulated_blake_difficulty: Difficulty::default(),
+            target_difficulty: Difficulty::default(),
             pow_data: vec![],
         }
     }
@@ -141,8 +145,8 @@ impl ProofOfWork {
         self.accumulated_monero_difficulty = pow.accumulated_monero_difficulty;
     }
 
-    /// Creates anew proof of work from the provided proof of work difficulty with the sum of this proof of work's total
-    /// cumulative difficulty and the provided `added_difficulty`.
+    /// Creates a new proof of work from the provided proof of work difficulty with the sum of this proof of work's
+    /// total cumulative difficulty and the provided `added_difficulty`.
     pub fn new_from_difficulty(pow: &ProofOfWork, added_difficulty: Difficulty) -> ProofOfWork {
         let (m, b) = match pow.pow_algo {
             PowAlgorithm::Monero => (
@@ -157,6 +161,7 @@ impl ProofOfWork {
         ProofOfWork {
             accumulated_monero_difficulty: m,
             accumulated_blake_difficulty: b,
+            target_difficulty: pow.target_difficulty,
             pow_algo: pow.pow_algo,
             pow_data: pow.pow_data.clone(),
         }

--- a/base_layer/core/src/proto/block.proto
+++ b/base_layer/core/src/proto/block.proto
@@ -15,6 +15,7 @@ message ProofOfWork {
     uint64 accumulated_monero_difficulty = 2;
     uint64 accumulated_blake_difficulty = 3;
     bytes pow_data = 4;
+    uint64 target_difficulty = 5;
 }
 
 // The BlockHeader contains all the metadata for the block, including proof of work, a link to the previous block

--- a/base_layer/core/src/proto/block.rs
+++ b/base_layer/core/src/proto/block.rs
@@ -134,6 +134,7 @@ impl TryFrom<proto::ProofOfWork> for ProofOfWork {
             pow_algo: PowAlgorithm::try_from(pow.pow_algo)?,
             accumulated_monero_difficulty: Difficulty::from(pow.accumulated_monero_difficulty),
             accumulated_blake_difficulty: Difficulty::from(pow.accumulated_blake_difficulty),
+            target_difficulty: Difficulty::from(pow.target_difficulty),
             pow_data: pow.pow_data,
         })
     }
@@ -145,6 +146,7 @@ impl From<ProofOfWork> for proto::ProofOfWork {
             pow_algo: pow.pow_algo as u64,
             accumulated_monero_difficulty: pow.accumulated_monero_difficulty.as_u64(),
             accumulated_blake_difficulty: pow.accumulated_blake_difficulty.as_u64(),
+            target_difficulty: pow.target_difficulty.as_u64(),
             pow_data: pow.pow_data,
         }
     }

--- a/base_layer/core/src/validation/block_validators.rs
+++ b/base_layer/core/src/validation/block_validators.rs
@@ -31,7 +31,7 @@ use crate::{
     consensus::{ConsensusConstants, ConsensusManager},
     transactions::{transaction::OutputFlags, types::CryptoFactories},
     validation::{
-        helpers::{check_achieved_difficulty, check_median_timestamp},
+        helpers::{check_achieved_and_target_difficulty, check_median_timestamp},
         StatelessValidation,
         Validation,
         ValidationError,
@@ -114,7 +114,7 @@ impl<B: BlockchainBackend> Validation<Block, B> for FullConsensusValidator {
             .height_of_longest_chain
             .unwrap_or(0);
         check_median_timestamp(db, &block.header, tip_height, self.rules.clone())?;
-        check_achieved_difficulty(db, &block.header, tip_height, self.rules.clone())?;
+        check_achieved_and_target_difficulty(db, &block.header, tip_height, self.rules.clone())?;
         Ok(())
     }
 }

--- a/base_layer/core/src/validation/helpers.rs
+++ b/base_layer/core/src/validation/helpers.rs
@@ -24,12 +24,13 @@ use crate::{
     blocks::blockheader::{BlockHeader, BlockHeaderValidationError},
     chain_storage::BlockchainBackend,
     consensus::ConsensusManager,
-    proof_of_work::PowError,
+    proof_of_work::{get_target_difficulty, PowError},
     validation::ValidationError,
 };
 use log::*;
 use tari_crypto::tari_utilities::hash::Hashable;
 pub const LOG_TARGET: &str = "c::val::helpers";
+use crate::chain_storage::fetch_target_difficulties;
 use tari_crypto::tari_utilities::hex::Hex;
 
 /// This function tests that the block timestamp is greater than the median timestamp at the specified height.
@@ -68,7 +69,7 @@ pub fn check_median_timestamp<B: BlockchainBackend>(
 }
 
 /// Calculates the achieved and target difficulties at the specified height and compares them.
-pub fn check_achieved_difficulty<B: BlockchainBackend>(
+pub fn check_achieved_and_target_difficulty<B: BlockchainBackend>(
     db: &B,
     block_header: &BlockHeader,
     height: u64,
@@ -80,19 +81,39 @@ pub fn check_achieved_difficulty<B: BlockchainBackend>(
         "Checking block has acheived the required difficulty",
     );
     let achieved = block_header.achieved_difficulty();
-    let mut target = 1.into();
-    if block_header.height > 0 || rules.get_genesis_block_hash() != block_header.hash() {
-        target = rules
-            .get_target_difficulty_with_height(db, block_header.pow.pow_algo, height)
-            .or_else(|e| {
-                error!(target: LOG_TARGET, "Validation could not get achieved difficulty");
-                Err(e)
-            })
-            .map_err(|_| {
-                ValidationError::BlockHeaderError(BlockHeaderValidationError::ProofOfWorkError(
-                    PowError::InvalidProofOfWork,
-                ))
-            })?;
+    let pow_algo = block_header.pow.pow_algo;
+    let target = if block_header.height > 0 || rules.get_genesis_block_hash() != block_header.hash() {
+        let constants = rules.consensus_constants();
+        let target_difficulties =
+            fetch_target_difficulties(db, pow_algo, height, constants.get_difficulty_block_window() as usize)
+                .map_err(|e| ValidationError::CustomError(e.to_string()))?;
+        get_target_difficulty(
+            target_difficulties,
+            constants.get_difficulty_block_window() as usize,
+            constants.get_diff_target_block_interval(),
+            constants.min_pow_difficulty(pow_algo),
+            constants.get_difficulty_max_block_interval(),
+        )
+        .or_else(|e| {
+            error!(target: LOG_TARGET, "Validation could not get target difficulty");
+            Err(e)
+        })
+        .map_err(|_| {
+            ValidationError::BlockHeaderError(BlockHeaderValidationError::ProofOfWorkError(
+                PowError::InvalidProofOfWork,
+            ))
+        })?
+    } else {
+        1.into()
+    };
+    if block_header.pow.target_difficulty != target {
+        warn!(
+            target: LOG_TARGET,
+            "Recorded header target difficulty {} was incorrect: {}", block_header.pow.target_difficulty, target
+        );
+        return Err(ValidationError::BlockHeaderError(
+            BlockHeaderValidationError::ProofOfWorkError(PowError::InvalidTargetDifficulty),
+        ));
     }
     if achieved < target {
         warn!(

--- a/base_layer/core/tests/median_timestamp.rs
+++ b/base_layer/core/tests/median_timestamp.rs
@@ -40,7 +40,7 @@ fn test_median_timestamp() {
     let consensus_manager = ConsensusManagerBuilder::new(network).build();
     let store = create_mem_db(&consensus_manager);
     let pow_algos = vec![PowAlgorithm::Blake]; // GB default
-    create_test_pow_blockchain(&store, pow_algos, &consensus_manager.consensus_constants());
+    create_test_pow_blockchain(&store, pow_algos, &consensus_manager);
     let start_timestamp = store.fetch_block(0).unwrap().block().header.timestamp.clone();
     let mut timestamp = consensus_manager
         .get_median_timestamp(&*store.db_read_access().unwrap())
@@ -50,7 +50,7 @@ fn test_median_timestamp() {
     let pow_algos = vec![PowAlgorithm::Blake];
     // lets add 1
     let tip = store.fetch_block(store.get_height().unwrap().unwrap()).unwrap().block;
-    append_to_pow_blockchain(&store, tip, pow_algos.clone(), &consensus_manager.consensus_constants());
+    append_to_pow_blockchain(&store, tip, pow_algos.clone(), &consensus_manager);
     let mut prev_timestamp: EpochTime =
         start_timestamp.increase(consensus_manager.consensus_constants().get_target_block_interval());
     timestamp = consensus_manager
@@ -59,7 +59,7 @@ fn test_median_timestamp() {
     assert_eq!(timestamp, prev_timestamp);
     // lets add 1
     let tip = store.fetch_block(store.get_height().unwrap().unwrap()).unwrap().block;
-    append_to_pow_blockchain(&store, tip, pow_algos.clone(), &consensus_manager.consensus_constants());
+    append_to_pow_blockchain(&store, tip, pow_algos.clone(), &consensus_manager);
     prev_timestamp = start_timestamp.increase(consensus_manager.consensus_constants().get_target_block_interval());
     timestamp = consensus_manager
         .get_median_timestamp(&*store.db_read_access().unwrap())
@@ -69,7 +69,7 @@ fn test_median_timestamp() {
     // lets build up 11 blocks
     for i in 4..12 {
         let tip = store.fetch_block(store.get_height().unwrap().unwrap()).unwrap().block;
-        append_to_pow_blockchain(&store, tip, pow_algos.clone(), &consensus_manager.consensus_constants());
+        append_to_pow_blockchain(&store, tip, pow_algos.clone(), &consensus_manager);
         prev_timestamp =
             start_timestamp.increase(consensus_manager.consensus_constants().get_target_block_interval() * (i / 2));
         timestamp = consensus_manager
@@ -81,7 +81,7 @@ fn test_median_timestamp() {
     // lets add many1 blocks
     for _i in 1..20 {
         let tip = store.fetch_block(store.get_height().unwrap().unwrap()).unwrap().block;
-        append_to_pow_blockchain(&store, tip, pow_algos.clone(), &consensus_manager.consensus_constants());
+        append_to_pow_blockchain(&store, tip, pow_algos.clone(), &consensus_manager);
         prev_timestamp = prev_timestamp.increase(consensus_manager.consensus_constants().get_target_block_interval());
         timestamp = consensus_manager
             .get_median_timestamp(&*store.db_read_access().unwrap())
@@ -102,7 +102,7 @@ fn test_median_timestamp_with_height() {
         PowAlgorithm::Monero,
         PowAlgorithm::Blake,
     ];
-    create_test_pow_blockchain(&store, pow_algos, &consensus_manager.consensus_constants());
+    create_test_pow_blockchain(&store, pow_algos, &consensus_manager);
 
     let header0_timestamp = store.fetch_header(0).unwrap().timestamp;
     let header1_timestamp = store.fetch_header(1).unwrap().timestamp;
@@ -135,7 +135,7 @@ fn test_median_timestamp_odd_order() {
     let consensus_manager = ConsensusManagerBuilder::new(network).build();
     let store = create_mem_db(&consensus_manager);
     let pow_algos = vec![PowAlgorithm::Blake]; // GB default
-    create_test_pow_blockchain(&store, pow_algos, &consensus_manager.consensus_constants());
+    create_test_pow_blockchain(&store, pow_algos, &consensus_manager);
     let start_timestamp = store.fetch_block(0).unwrap().block().header.timestamp.clone();
     let mut timestamp = consensus_manager
         .get_median_timestamp(&*store.db_read_access().unwrap())
@@ -144,7 +144,7 @@ fn test_median_timestamp_odd_order() {
     let pow_algos = vec![PowAlgorithm::Blake];
     // lets add 1
     let tip = store.fetch_block(store.get_height().unwrap().unwrap()).unwrap().block;
-    append_to_pow_blockchain(&store, tip, pow_algos.clone(), &consensus_manager.consensus_constants());
+    append_to_pow_blockchain(&store, tip, pow_algos.clone(), &consensus_manager);
     let mut prev_timestamp: EpochTime =
         start_timestamp.increase(consensus_manager.consensus_constants().get_target_block_interval());
     timestamp = consensus_manager

--- a/base_layer/core/tests/node_service.rs
+++ b/base_layer/core/tests/node_service.rs
@@ -666,7 +666,11 @@ fn local_get_new_block_template_and_get_new_block() {
     assert!(node.mempool.insert(txs[1].clone()).is_ok());
 
     runtime.block_on(async {
-        let block_template = node.local_nci.get_new_block_template().await.unwrap();
+        let block_template = node
+            .local_nci
+            .get_new_block_template(PowAlgorithm::Blake)
+            .await
+            .unwrap();
         assert_eq!(block_template.header.height, 1);
         assert_eq!(block_template.body.kernels().len(), 2);
 


### PR DESCRIPTION
The timestamp for the Genesis block is reset for 6pm GMT 25 April.

 This is a consensus-breaking change; and should be the last one  before Rincewind launches