### PR TITLE
MessageHeader::nonce set to constant (0) for propagation messages

### DIFF
--- a/base_layer/p2p/src/services/liveness/state.rs
+++ b/base_layer/p2p/src/services/liveness/state.rs
@@ -109,10 +109,6 @@ impl LivenessState {
         self.pongs_received.load(Ordering::Relaxed)
     }
 
-    pub fn num_active_peers(&self) -> usize {
-        self.num_active_peers.load(Ordering::Relaxed)
-    }
-
     pub fn set_num_active_peers(&self, n: usize) {
         self.num_active_peers.store(n, Ordering::Relaxed);
     }

--- a/comms/dht/examples/memorynet.rs
+++ b/comms/dht/examples/memorynet.rs
@@ -368,7 +368,7 @@ async fn network_peer_list_stats(nodes: &[TestNode], wallets: &[TestNode]) {
         );
     }
     println!(
-        "Average {}%",
+        "Average {:.2}%",
         avg.into_iter().sum::<f32>() / wallets.len() as f32 * 100.0
     );
 }
@@ -395,7 +395,11 @@ async fn network_connectivity_stats(nodes: &[TestNode], wallets: &[TestNode]) {
     let (t, a) = display(wallets).await;
     total += t;
     avg += a;
-    println!("{} total connections on the network. ({} average)", total, avg);
+    println!(
+        "{} total connections on the network. ({} per node on average)",
+        total,
+        avg / (wallets.len() + nodes.len())
+    );
 }
 
 async fn do_store_and_forward_discovery(

--- a/comms/dht/src/actor.rs
+++ b/comms/dht/src/actor.rs
@@ -62,10 +62,7 @@ use tari_comms::{
     types::CommsPublicKey,
 };
 use tari_shutdown::ShutdownSignal;
-use tari_utilities::{
-    message_format::{MessageFormat, MessageFormatError},
-    ByteArray,
-};
+use tari_utilities::message_format::{MessageFormat, MessageFormatError};
 use tokio::task;
 use ttl_cache::TtlCache;
 
@@ -345,11 +342,7 @@ impl<'a> DhtActor<'a> {
         num_neighbouring_nodes: usize,
     ) -> Result<(), DhtActorError>
     {
-        let message = JoinMessage {
-            node_id: node_identity.node_id().to_vec(),
-            addresses: vec![node_identity.public_address().to_string()],
-            peer_features: node_identity.features().bits(),
-        };
+        let message = JoinMessage::from(&node_identity);
 
         debug!(
             target: LOG_TARGET,
@@ -756,7 +749,7 @@ mod test {
         let (actor_tx, actor_rx) = mpsc::channel(1);
         let mut requester = DhtRequester::new(actor_tx);
         let outbound_requester = OutboundMessageRequester::new(out_tx);
-        let shutdown = Shutdown::new();
+        let mut shutdown = Shutdown::new();
         let actor = DhtActor::new(
             Default::default(),
             db_connection().await,
@@ -800,5 +793,7 @@ mod test {
             .unwrap()
             .unwrap();
         assert_eq!(got_ts, ts);
+
+        shutdown.trigger().unwrap();
     }
 }

--- a/comms/dht/src/outbound/requester.rs
+++ b/comms/dht/src/outbound/requester.rs
@@ -195,7 +195,12 @@ impl OutboundMessageRequester {
                 message
             );
         }
-        let body = wrap_in_envelope_body!(message.to_header(), message.into_inner()).to_encoded_bytes();
+        let header = if params.broadcast_strategy.is_direct() {
+            message.to_header()
+        } else {
+            message.to_propagation_header()
+        };
+        let body = wrap_in_envelope_body!(header, message.into_inner()).to_encoded_bytes();
         self.send_raw(params, body).await
     }
 

--- a/comms/dht/src/proto/dht.proto
+++ b/comms/dht/src/proto/dht.proto
@@ -12,6 +12,7 @@ message JoinMessage {
     bytes node_id = 1;
     repeated string addresses = 2;
     uint64 peer_features = 3;
+    uint64 nonce = 4;
 }
 
 // The DiscoverMessage stores the information required for a network discover request.

--- a/comms/dht/src/proto/mod.rs
+++ b/comms/dht/src/proto/mod.rs
@@ -20,9 +20,11 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use crate::proto::envelope::Network;
+use crate::proto::{dht::JoinMessage, envelope::Network};
+use rand::{rngs::OsRng, RngCore};
 use std::fmt;
-use tari_utilities::hex::Hex;
+use tari_comms::NodeIdentity;
+use tari_utilities::{hex::Hex, ByteArray};
 
 #[path = "tari.dht.envelope.rs"]
 pub mod envelope;
@@ -70,6 +72,18 @@ impl fmt::Display for dht::RejectMessage {
 }
 
 //---------------------------------- JoinMessage --------------------------------------------//
+
+impl<T: AsRef<NodeIdentity>> From<T> for JoinMessage {
+    fn from(identity: T) -> Self {
+        let node_identity = identity.as_ref();
+        Self {
+            node_id: node_identity.node_id().to_vec(),
+            addresses: vec![node_identity.public_address().to_string()],
+            peer_features: node_identity.features().bits(),
+            nonce: OsRng.next_u64(),
+        }
+    }
+}
 
 impl fmt::Display for dht::JoinMessage {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {

--- a/comms/dht/src/proto/tari.dht.rs
+++ b/comms/dht/src/proto/tari.dht.rs
@@ -12,6 +12,8 @@ pub struct JoinMessage {
     pub addresses: ::std::vec::Vec<std::string::String>,
     #[prost(uint64, tag = "3")]
     pub peer_features: u64,
+    #[prost(uint64, tag = "4")]
+    pub nonce: u64,
 }
 /// The DiscoverMessage stores the information required for a network discover request.
 ///

--- a/comms/dht/src/store_forward/forward.rs
+++ b/comms/dht/src/store_forward/forward.rs
@@ -117,7 +117,7 @@ where S: Service<DecryptedDhtMessage, Response = (), Error = PipelineError> + Cl
         let is_enabled = self.is_enabled;
         async move {
             if !is_enabled {
-                trace!(target: LOG_TARGET, "Passing message to next service (Not enabled)");
+                debug!(target: LOG_TARGET, "Passing message to next service (Not enabled)");
                 return next_service.oneshot(message).await;
             }
 
@@ -155,7 +155,7 @@ where S: Service<DecryptedDhtMessage, Response = (), Error = PipelineError>
         }
 
         // The message has been forwarded, but other middleware may be interested (i.e. StoreMiddleware)
-        trace!(target: LOG_TARGET, "Passing message to next service");
+        debug!(target: LOG_TARGET, "Passing message to next service");
         self.next_service.oneshot(message).await?;
         Ok(())
     }

--- a/comms/dht/src/store_forward/store.rs
+++ b/comms/dht/src/store_forward/store.rs
@@ -430,7 +430,7 @@ mod test {
     use std::time::Duration;
     use tari_comms::{message::MessageExt, wrap_in_envelope_body};
     use tari_test_utils::async_assert_eventually;
-    use tari_utilities::{hex::Hex, ByteArray};
+    use tari_utilities::hex::Hex;
 
     #[tokio_macros::test_basic]
     async fn cleartext_message_no_origin() {
@@ -459,12 +459,7 @@ mod test {
         let spy = service_spy();
         let peer_manager = make_peer_manager();
         let node_identity = make_node_identity();
-        let join_msg_bytes = JoinMessage {
-            node_id: node_identity.node_id().to_vec(),
-            addresses: vec![],
-            peer_features: 0,
-        }
-        .to_encoded_bytes();
+        let join_msg_bytes = JoinMessage::from(&node_identity).to_encoded_bytes();
 
         let mut service = StoreLayer::new(Default::default(), peer_manager, node_identity, requester)
             .layer(spy.to_service::<PipelineError>());


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
When re-propagating messages from the domain layer, a nonce is placed in the
header causing the message hash to change for every propagation causing
unique domain messages to be generated when propagating.
For propagation messages this has been changed to always be `0`. Direct messages will still generate a unique nonce to prevent purposefully duplicate messages from being rejected.   

Added nonce to Join message. Join messages have a nonce per non-propagation send because they will often contain duplicate data.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Can result in propagated domain messages spamming the network

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch.
* [x] I ran `cargo-fmt --all` before pushing.
* [x] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
