### PR TITLE
Force a network split

### DIFF
--- a/comms/src/connection_manager/wire_mode.rs
+++ b/comms/src/connection_manager/wire_mode.rs
@@ -22,9 +22,13 @@
 
 use std::convert::TryFrom;
 
+const COMMS_WIRE_MODE: u8 = 0x03;
+const LIVENESS_WIRE_MODE: u8 = 0x45; // E
+
+#[repr(u8)]
 pub enum WireMode {
-    Comms = 0x02,
-    Liveness = 0x45, // E
+    Comms = COMMS_WIRE_MODE,
+    Liveness = LIVENESS_WIRE_MODE,
 }
 
 impl TryFrom<u8> for WireMode {
@@ -32,8 +36,8 @@ impl TryFrom<u8> for WireMode {
 
     fn try_from(value: u8) -> Result<Self, Self::Error> {
         match value {
-            0x02 => Ok(WireMode::Comms),
-            0x45 => Ok(WireMode::Liveness),
+            COMMS_WIRE_MODE => Ok(WireMode::Comms),
+            LIVENESS_WIRE_MODE => Ok(WireMode::Liveness),
             _ => Err(()),
         }
     }


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Changed wiremode byte to `0x03`

This will cause a network split