### PR TITLE
Added a currency style formatter for T and µT

### DIFF
--- a/base_layer/core/src/transactions/helpers.rs
+++ b/base_layer/core/src/transactions/helpers.rs
@@ -372,3 +372,55 @@ pub fn schema_to_transaction(txns: &[TransactionSchema]) -> (Vec<Arc<Transaction
     });
     (tx, utxos)
 }
+
+/// Return a currency styled `String`
+/// # Examples
+///
+/// ```
+/// use tari_core::transactions::helpers::display_currency;
+/// assert_eq!(String::from("12,345.12"), display_currency(12345.12, 2, ","));
+/// assert_eq!(String::from("12,345"), display_currency(12345.12, 0, ","));
+/// ```
+pub fn display_currency(value: f64, precision: usize, separator: &str) -> String {
+    let whole = value as usize;
+    let decimal = ((value - whole as f64) * 10_f64.powf(precision as f64)).round() as usize;
+    let formatted_whole_value = whole
+        .to_string()
+        .chars()
+        .rev()
+        .enumerate()
+        .fold(String::new(), |acc, (i, c)| {
+            if i != 0 && i % 3 == 0 {
+                format!("{}{}{}", acc, separator, c)
+            } else {
+                format!("{}{}", acc, c)
+            }
+        })
+        .chars()
+        .rev()
+        .collect::<String>();
+
+    if precision > 0 {
+        format!("{}.{:0>2$}", formatted_whole_value, decimal, precision)
+    } else {
+        format!("{}", formatted_whole_value)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    #[test]
+    fn display_currency() {
+        assert_eq!(String::from("0.00"), super::display_currency(0.0f64, 2, ","));
+        assert_eq!(String::from("0.000000000000"), super::display_currency(0.0f64, 12, ","));
+        assert_eq!(
+            String::from("123,456.123456789"),
+            super::display_currency(123456.123456789012_f64, 9, ",")
+        );
+        assert_eq!(
+            String::from("123,456"),
+            super::display_currency(123456.123456789012_f64, 0, ",")
+        );
+        assert_eq!(String::from("1,234"), super::display_currency(1234.1f64, 0, ","));
+    }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
I have added a formatter to split values of T or µT every 3 places from the end of the whole number. The decimal places of T has been limited to 2.
![image](https://user-images.githubusercontent.com/41575888/80387143-9261fd00-88a8-11ea-8bb1-0e69368d67b8.png)
![image](https://user-images.githubusercontent.com/41575888/80387160-9857de00-88a8-11ea-9470-e3c1fd177be9.png)
![image](https://user-images.githubusercontent.com/41575888/80387577-174d1680-88a9-11ea-93ff-ae51507f56f9.png)

## Description
<!--- Describe your changes in detail -->
Refactored the `Display` implementation for `Tari` and `MicroTari` to use the new helper function `display_currency` 
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Distinguishing between millions or tens of millions of µT / T was getting painful.
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Updated the tests to include the new formatting as well as a few examples of the rounding.
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch.
* [x] I ran `cargo-fmt --all` before pushing.
* [x] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
