### PR TITLE
Update wallet to monitor Tx recipient for liveness and to resend Tx

### DIFF
--- a/base_layer/p2p/examples/pingpong.rs
+++ b/base_layer/p2p/examples/pingpong.rs
@@ -292,7 +292,7 @@ mod pingpong {
         loop {
             ::futures::select! {
                 event = event_stream.select_next_some() => {
-                    match &*event {
+                    match &*(event.unwrap()) {
                         LivenessEvent::ReceivedPing => {
                             {
                                 let mut lock = UI_STATE.write().unwrap();

--- a/base_layer/wallet/Cargo.toml
+++ b/base_layer/wallet/Cargo.toml
@@ -50,6 +50,7 @@ default-features = false
 features = ["transactions", "mempool_proto", "base_node_proto"]
 
 [dev-dependencies]
+tari_p2p = {path = "../p2p", version = "^0.1", features=["test-mocks"]}
 tari_comms_dht = { path = "../../comms/dht", version = "^0.1", features=["test-mocks"]}
 tari_test_utils = { path = "../../infrastructure/test_utils", version = "^0.0"}
 lazy_static = "1.3.0"

--- a/base_layer/wallet/src/transaction_service/error.rs
+++ b/base_layer/wallet/src/transaction_service/error.rs
@@ -31,6 +31,7 @@ use serde_json::Error as SerdeJsonError;
 use tari_comms::peer_manager::node_id::NodeIdError;
 use tari_comms_dht::outbound::DhtOutboundError;
 use tari_core::transactions::{transaction::TransactionError, transaction_protocol::TransactionProtocolError};
+use tari_p2p::services::liveness::error::LivenessError;
 use tari_service_framework::reply_channel::TransportChannelError;
 use time::OutOfRangeError;
 use tokio::sync::broadcast::RecvError;
@@ -100,6 +101,7 @@ pub enum TransactionServiceError {
     NodeIdError(NodeIdError),
     BroadcastRecvError(RecvError),
     OneshotCancelled(Canceled),
+    LivenessError(LivenessError),
 }
 
 #[derive(Debug, Error)]

--- a/base_layer/wallet/src/transaction_service/mod.rs
+++ b/base_layer/wallet/src/transaction_service/mod.rs
@@ -49,7 +49,10 @@ use tari_core::{
 use tari_p2p::{
     comms_connector::PeerMessage,
     domain_message::DomainMessage,
-    services::utils::{map_decode, ok_or_skip_result},
+    services::{
+        liveness::LivenessHandle,
+        utils::{map_decode, ok_or_skip_result},
+    },
     tari_message::TariMessageType,
 };
 use tari_pubsub::TopicSubscriptionFactory;
@@ -175,6 +178,9 @@ where T: TransactionBackend + Clone + 'static
             let output_manager_service = handles
                 .get_handle::<OutputManagerHandle>()
                 .expect("Output Manager Service handle required for TransactionService");
+            let liveness_service = handles
+                .get_handle::<LivenessHandle>()
+                .expect("LivenessHandle handle required for Transaction Service");
 
             let service = TransactionService::new(
                 config,
@@ -187,6 +193,7 @@ where T: TransactionBackend + Clone + 'static
                 base_node_response_stream,
                 output_manager_service,
                 outbound_message_service,
+                liveness_service,
                 publisher,
                 node_identity,
                 factories,

--- a/base_layer/wallet/tests/transaction_service/storage.rs
+++ b/base_layer/wallet/tests/transaction_service/storage.rs
@@ -162,6 +162,20 @@ pub fn test_db_backend<T: TransactionBackend + 'static>(backend: T) {
         );
     }
 
+    let inbound_pub_key = runtime
+        .block_on(db.get_pending_transaction_counterparty_pub_key_by_tx_id(inbound_txs[0].tx_id))
+        .unwrap();
+    assert_eq!(inbound_pub_key, inbound_txs[0].source_public_key);
+
+    assert!(runtime
+        .block_on(db.get_pending_transaction_counterparty_pub_key_by_tx_id(100))
+        .is_err());
+
+    let outbound_pub_key = runtime
+        .block_on(db.get_pending_transaction_counterparty_pub_key_by_tx_id(outbound_txs[0].tx_id))
+        .unwrap();
+    assert_eq!(outbound_pub_key, outbound_txs[0].destination_public_key);
+
     let mut coinbases = Vec::new();
     for i in 0..messages.len() {
         coinbases.push(PendingCoinbaseTransaction {


### PR DESCRIPTION
## Description
Previously the transaction service would send a transaction once, directly and via store-and-forward, and then wait for a Reply from the Recipient. If the Transaction was lost it would never be resent and on the Sender’s side it would be a pending Tx until the client cancelled it 3 days later.

This PR updates the Transaction Send protocol in the Transaction service to use the Liveness Service to monitor the recipient for liveness with periodic pings. If the recipient replies with a Pong but has not sent the Transaction Reply message the Sender will resend the transaction to the Recipient in case the original send did not make it to them. Once the Send Transaction Protocol ends the Recipient will be removed from the Liveness service Nodes to monitor list.

Future PRs will apply this same strategy to the Recipient.

## How Has This Been Tested?
A test has been provided that send's a tx and then provides a Pong message and checks that a second tx is sent.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [x] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch.
* [x] I ran `cargo-fmt --all` before pushing.
* [ ] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
