### PR TITLE
DB model update

### DIFF
--- a/base_layer/core/src/chain_storage/postgres_db/migrations/2020-04-07-14-49_tx_outputs/up.sql
+++ b/base_layer/core/src/chain_storage/postgres_db/migrations/2020-04-07-14-49_tx_outputs/up.sql
@@ -4,8 +4,6 @@ create table  if not exists  tx_outputs(
     features_maturity BIGINT NOT NULL,
     commitment TEXT NOT NULL,
     proof BYTEA NULL,
-    created_in_block TEXT NOT NULL REFERENCES block_headers(hash),
-    spent TEXT NULL REFERENCES block_headers(hash)
 );
 
 create index index_tx_outputs_hash on tx_outputs(hash);

--- a/base_layer/core/src/chain_storage/postgres_db/migrations/2020-04-28-15-51_outputs/up.sql
+++ b/base_layer/core/src/chain_storage/postgres_db/migrations/2020-04-28-15-51_outputs/up.sql
@@ -1,0 +1,9 @@
+create table  if not exists  outputs(
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+    created_in_block TEXT NOT NULL REFERENCES block_headers(hash),
+    tx_output TEXT NOT NULL REFERENCES tx_outputs(hash)
+);
+
+create index index_outputs_id on outputs(id);
+create index index_outputs_created_in_block on outputs(created_in_block);
+create index index_outputs_tx_output on outputs(tx_output);

--- a/base_layer/core/src/chain_storage/postgres_db/migrations/2020-04-28-15-51_spent/up.sql
+++ b/base_layer/core/src/chain_storage/postgres_db/migrations/2020-04-28-15-51_spent/up.sql
@@ -1,0 +1,9 @@
+create table  if not exists  spends(
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+    spent_in_block TEXT NOT NULL REFERENCES block_headers(hash),
+    tx_output TEXT NOT NULL REFERENCES tx_outputs(hash)
+);
+
+create index index_spends_id on spends(id);
+create index index_spends_spent_in_block on spends(spent_in_block);
+create index index_spends_tx_output on spends(tx_output);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Proposes some DB table changes

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Currently the postgres tables have only one link per transactional output for created in a block and spent in a block. While this is fine for when an output only occurs in the main chain as an output can only be created once and spent once. But we have orphan blocks which means that a transactional output can be in more than one orphan block or in a orphan block and the main chain. This means that a transactional output can be in more in than one block if looked from the database's tables. This also means that the current table layout will not work for all cases. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [ ] I'm merging against the `development` branch.
* [ ] I ran `cargo-fmt --all` before pushing.
* [ ] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
