### PR TITLE
Configurable pruning horizon

### DIFF
--- a/applications/tari_base_node/src/builder.rs
+++ b/applications/tari_base_node/src/builder.rs
@@ -464,9 +464,11 @@ where
         StatelessBlockValidator::new(&rules.consensus_constants()),
         AccumDifficultyValidator {},
     );
-    // TODO - make BlockchainDatabaseConfig configurable
-    let db = BlockchainDatabase::new(backend, &rules, validators, BlockchainDatabaseConfig::default())
-        .map_err(|e| e.to_string())?;
+    let db_config = BlockchainDatabaseConfig {
+        orphan_storage_capacity: config.orphan_storage_capacity,
+        pruning_horizon: config.pruning_horizon,
+    };
+    let db = BlockchainDatabase::new(backend, &rules, validators, db_config).map_err(|e| e.to_string())?;
     let mempool_validator =
         MempoolValidators::new(FullTxValidator::new(factories.clone()), TxInputAndMaturityValidator {});
     let mempool = Mempool::new(db.clone(), MempoolConfig::default(), mempool_validator);

--- a/base_layer/core/src/chain_storage/consts.rs
+++ b/base_layer/core/src/chain_storage/consts.rs
@@ -22,3 +22,5 @@
 
 /// The maximum number of orphans that can be stored in the Orphan block pool.
 pub const BLOCKCHAIN_DATABASE_ORPHAN_STORAGE_CAPACITY: usize = 720;
+/// The pruning horizon that is set for a default configuration of the blockchain db.
+pub const BLOCKCHAIN_DATABASE_PRUNING_HORIZON: u64 = 0;

--- a/base_layer/core/src/chain_storage/lmdb_db/lmdb_db.rs
+++ b/base_layer/core/src/chain_storage/lmdb_db/lmdb_db.rs
@@ -780,7 +780,7 @@ fn fetch_pruning_horizon(env: &Environment, db: &Database) -> Result<u64, ChainS
         if let Some(DbValue::Metadata(MetadataValue::PruningHorizon(pruning_horizon))) = val {
             pruning_horizon
         } else {
-            2880
+            0
         },
     )
 }

--- a/base_layer/core/src/chain_storage/memory_db/memory_db.rs
+++ b/base_layer/core/src/chain_storage/memory_db/memory_db.rs
@@ -192,7 +192,7 @@ where D: Digest + Send + Sync
             {
                 pruning_horizon
             } else {
-                2880
+                0
             },
         )
     }

--- a/base_layer/core/src/chain_storage/metadata.rs
+++ b/base_layer/core/src/chain_storage/metadata.rs
@@ -66,6 +66,11 @@ impl ChainMetadata {
     pub fn archival_mode(&mut self) {
         self.pruning_horizon = 0;
     }
+
+    /// Set the pruning horizon to indicate that the chain is in pruned mode (i.e. a pruning horizon of 2880)
+    pub fn pruned_mode(&mut self) {
+        self.pruning_horizon = 2880;
+    }
 }
 
 impl Default for ChainMetadata {
@@ -73,7 +78,7 @@ impl Default for ChainMetadata {
         ChainMetadata {
             height_of_longest_chain: None,
             best_block: None,
-            pruning_horizon: 2880,
+            pruning_horizon: 0,
             accumulated_difficulty: None,
         }
     }
@@ -109,8 +114,9 @@ mod test {
     }
 
     #[test]
-    fn horizon_block() {
-        let metadata = ChainMetadata::default();
+    fn pruned_mode() {
+        let mut metadata = ChainMetadata::default();
+        metadata.pruned_mode();
         assert_eq!(metadata.horizon_block(0), 0);
         assert_eq!(metadata.horizon_block(100), 0);
         assert_eq!(metadata.horizon_block(2880), 0);

--- a/base_layer/core/tests/node_comms_interface.rs
+++ b/base_layer/core/tests/node_comms_interface.rs
@@ -111,7 +111,7 @@ fn inbound_get_metadata() {
             {
                 assert_eq!(received_metadata.height_of_longest_chain, Some(0));
                 assert_eq!(received_metadata.best_block, Some(block.hash()));
-                assert_eq!(received_metadata.pruning_horizon, 2880);
+                assert_eq!(received_metadata.pruning_horizon, 0);
             } else {
                 assert!(false);
             }

--- a/common/src/configuration/global.rs
+++ b/common/src/configuration/global.rs
@@ -43,6 +43,8 @@ pub struct GlobalConfig {
     pub listener_liveness_whitelist_cidrs: Vec<String>,
     pub data_dir: PathBuf,
     pub db_type: DatabaseType,
+    pub orphan_storage_capacity: usize,
+    pub pruning_horizon: u64,
     pub core_threads: usize,
     pub blocking_threads: usize,
     pub identity_file: PathBuf,
@@ -97,6 +99,16 @@ fn convert_node_config(network: Network, cfg: Config) -> Result<GlobalConfig, Co
             &format!("Invalid option: {}", invalid_opt),
         )),
     }?;
+
+    let key = config_string(&net_str, "orphan_storage_capacity");
+    let orphan_storage_capacity = cfg
+        .get_int(&key)
+        .map_err(|e| ConfigurationError::new(&key, &e.to_string()))? as usize;
+
+    let key = config_string(&net_str, "pruning_horizon");
+    let pruning_horizon = cfg
+        .get_int(&key)
+        .map_err(|e| ConfigurationError::new(&key, &e.to_string()))? as u64;
 
     // Thread counts
     let key = config_string(&net_str, "core_threads");
@@ -203,6 +215,8 @@ fn convert_node_config(network: Network, cfg: Config) -> Result<GlobalConfig, Co
         listener_liveness_whitelist_cidrs: liveness_whitelist_cidrs,
         data_dir,
         db_type,
+        orphan_storage_capacity,
+        pruning_horizon,
         core_threads,
         blocking_threads,
         identity_file,

--- a/common/src/configuration/utils.rs
+++ b/common/src/configuration/utils.rs
@@ -74,6 +74,9 @@ pub fn default_config(bootstrap: &ConfigBootstrap) -> Config {
 
     // Mainnet base node defaults
     cfg.set_default("base_node.mainnet.db_type", "lmdb").unwrap();
+    cfg.set_default("base_node.mainnet.orphan_storage_capacity", 720)
+        .unwrap();
+    cfg.set_default("base_node.mainnet.pruning_horizon", 0).unwrap();
     cfg.set_default("base_node.mainnet.peer_seeds", Vec::<String>::new())
         .unwrap();
     cfg.set_default("base_node.mainnet.block_sync_strategy", "ViaBestChainMetadata")
@@ -119,6 +122,9 @@ pub fn default_config(bootstrap: &ConfigBootstrap) -> Config {
     //---------------------------------- Rincewind Defaults --------------------------------------------//
 
     cfg.set_default("base_node.rincewind.db_type", "lmdb").unwrap();
+    cfg.set_default("base_node.rincewind.orphan_storage_capacity", 720)
+        .unwrap();
+    cfg.set_default("base_node.rincewind.pruning_horizon", 0).unwrap();
     cfg.set_default("base_node.rincewind.peer_seeds", Vec::<String>::new())
         .unwrap();
     cfg.set_default("base_node.rincewind.block_sync_strategy", "ViaBestChainMetadata")


### PR DESCRIPTION
## Description
- Currently most nodes report their pruning horizon incorrectly using their chain metadata. To fix this without forcing nodes to add a pruning horizon setting to their config file, the default was changed to be an archival node.
- Made the BlockchainDatabaseConfig configurable using the base node application config file, allowing the orphan storage capacity and pruning horizon to be configured.
- Added the pruning horizon to the BlockchainDatabaseConfig and added functions to allow it to be stored using the blockchain backend.

## Motivation and Context
These changes allow the pruning horizon to be configured and changes the default operation to archival mode.

## How Has This Been Tested?
Existing tests were updated to ensure that the mode operation is correctly configured.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [x] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch.
* [x] I ran `cargo-fmt --all` before pushing.
* [x] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
