### PR TITLE
Locked down some potentially network breaking deps

### DIFF
--- a/comms/Cargo.toml
+++ b/comms/Cargo.toml
@@ -27,17 +27,17 @@ futures =  { version = "^0.3", features = ["async-await"]}
 lazy_static = "1.3.0"
 lmdb-zero = "0.4.4"
 log = { version = "0.4.0", features = ["std"] }
-multiaddr = {version = "0.7.2", package = "parity-multiaddr"}
+multiaddr = {version = "=0.7.3", package = "parity-multiaddr"}
 nom = {version = "5.1.0", features=["std"], default-features=false}
-prost = "0.6.1"
+prost = "=0.6.1"
 rand = "0.7.2"
 serde = "1.0.90"
 serde_derive = "1.0.90"
-snow = {version="0.6.2", features=["default-resolver"]}
+snow = {version="=0.6.2", features=["default-resolver"]}
 tokio = {version="^0.2", features=["blocking", "tcp", "stream", "dns", "sync", "stream", "signal"]}
 tokio-util = {version="0.2.0", features=["codec"]}
 tower= "0.3.1"
-yamux = "0.4.5"
+yamux = "=0.4.5"
 
 [dev-dependencies]
 tari_test_utils = {version="^0.0", path="../infrastructure/test_utils"}

--- a/comms/dht/Cargo.toml
+++ b/comms/dht/Cargo.toml
@@ -28,14 +28,14 @@ diesel_migrations =  "1.4"
 digest = "0.8.1"
 futures= {version= "^0.3.1"}
 log = "0.4.8"
-prost = "0.6.1"
-prost-types = "0.6.1"
+prost = "=0.6.1"
+prost-types = "=0.6.1"
 rand = "0.7.2"
 serde = "1.0.90"
 serde_derive = "1.0.90"
 serde_repr = "0.1.5"
 tokio = {version="0.2.10", features=["rt-threaded", "blocking"]}
-tower= "0.3.0"
+tower= "0.3.1"
 ttl_cache = "0.5.1"
 
 # tower-filter dependencies


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
All dependencies that could cause network breaking changes should be
locked down even in the absence of a Cargo.lock.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
There was a network split on testnet launch caused by some windows nodes not being able to communicate to other nodes on the network. Although I cannot trace it to a version change in these crates, they should anyhow be locked to a precise version. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [x] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch.
* [ ] I ran `cargo-fmt --all` before pushing.
* [x] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
