### PR TITLE
Windows runtime and installer for `tari_base_node 0.2.1-23677a7-release`

### DIFF
--- a/applications/tari_base_node/windows/README.md
+++ b/applications/tari_base_node/windows/README.md
@@ -1,54 +1,44 @@
 # Tari Base Node and Wallet Runtime Instructions
 
+This `README` file, in the installation folder, contains important instructions 
+before running `tari_base_node.exe` the first time.  
+
 ## Pre-requisites 
 
 - SQLite:
-  - Download 32bit/64bit Precompiled Binaries for Windows for [SQL Lite](https://www.sqlite.org/index.html). 
+  - Download 32bit/64bit Precompiled Binaries for Windows for 
+    [SQL Lite](https://www.sqlite.org/index.html). 
   - Extract to local path, e.g. `%USERPROFILE%\.sqlite`.
-  - Ensure folder containing `sqlite3.dll`, e.g. `%USERPROFILE%\.sqlite`, is in the user or system path environment 
-    variable (hint: type `path` in a command console to verify).
+  - Ensure folder containing `sqlite3.dll`, e.g. `%USERPROFILE%\.sqlite`, is in 
+    the user or system path environment variable (hint: type `path` in a command 
+    console to verify).
 
 - Tor
-  - Donwload [Tor Windows Expert Bundle](https://www.torproject.org/download/tor/).
+  - Donwload 
+    [Tor Windows Expert Bundle](https://www.torproject.org/download/tor/).
   - Extract to local path, e.g. `C:\Program Files (x86)\Tor Services`.
-  - Ensure folder containing the Tor executable, e.g. `C:\Program Files (x86)\Tor Services\Tor`, is in the user or 
-    system path environment variable (hint: type `path` in a command console to verify).
+  - Ensure folder containing the Tor executable, e.g. 
+    `C:\Program Files (x86)\Tor Services\Tor`, is in the user or system path 
+    environment variable (hint: type `path` in a command console to verify).
 
-- Microsoft Visual C++ [Redistributable for Visual Studio 2019](https://support.microsoft.com/en-us/help/2977003/the-latest-supported-visual-c-downloads)
+- Microsoft Visual C++ 
+  [Redistributable for Visual Studio 2019](https://support.microsoft.com/en-us/help/2977003/the-latest-supported-visual-c-downloads)
   - Download and install `x86: vc_redist.x86.exe`, or
   - Download and install `x64: vc_redist.x64.exe`
 
- # Automatic Installation
-
-- Download the latest Windows installation file (and SHA-256 CRC) from <https://tari.com/downloads/>.
-- Run the installation file.
-
-## Manual Installation
-
-- Folder Structure
-  All references to folders from here on are relative to `applications\tari_base_node\windows`, within the Tari project 
-  source code folder structure.
-
-- Tari Base Node Executable
-  - Build `tari_base_node.exe` according to 
-    [Building from source (Windows 10)](https://github.com/tari-project/tari#building-from-source-windows-10).
-  - Copy `tari_base_node.exe` to `.`, `.\runtime` or other local path.
-  - If not extracted to `.` or `.\runtime`, ensure the folder containing `tari_base_node.exe` is in the path.
-
-- Tari Base Node Runtime Configuration File
- - Copy  `..\..\common\config\presets\windows.toml` to `.\config`
- 
 ## Runtime
 
-- Tor needs to be running before the base node can run, so execute the `.\start_tor` shortcut and wait till the console 
-  outputs `[notice] Bootstrapped 100% (done): Done`
-- Execute the `.\start_tari_basenode` shortcut
+- Execute the `.\start_tari_basenode` shortcut; this will also start the Tor 
+  services that needs to be running before the base node can run (do not close 
+  the Tor console).
+- The Tor the console will output `[notice] Bootstrapped 100% (done): Done` 
+  when the Tor services have fully started.
 - Runtime artefacts:
   - The blockchain will be created in the `.\rincewind` folder.
   - The wallet will be created in the `.\wallet` folfder.
   - All log files will be created in the `.\log` folder.
-  - The following configuration files will be created in the `.\config` folder if runtime configuration
-    `..\..\common\config\presets\windows.toml` was used:
+  - The following configuration files will be created in the `.\config` folder if 
+    runtime configuration `..\..\common\config\presets\windows.toml` was used:
     - `wallet-identity.json`
     - `wallet-tor.json`
     - `node_id.json`
@@ -59,4 +49,31 @@
 
 - To delete log files, delete the `.\log` folder.
 - To re-sync the blockchain, delete the `.\rincewind` folder.1
-- To destroy your wallet and loose all your hard-earned Tari coins, delete the `.\wallet` folder.
+- To destroy your wallet and loose all your hard-earned Tari coins, delete the 
+  `.\wallet` folder.
+
+# Installation Options
+
+## Automatic Installation
+
+- Download the latest Windows installation file (and SHA-256 CRC) from 
+  <https://tari.com/downloads/>.
+- Run the installation file.
+
+## Manual Installation
+
+- Folder Structure
+  All references to folders from here on are relative to 
+  `applications\tari_base_node\windows`, within the Tari project source code 
+  folder structure.
+
+- Tari Base Node Executable
+  - Build `tari_base_node.exe` according to 
+    [Building from source (Windows 10)](https://github.com/tari-project/tari#building-from-source-windows-10).
+  - Copy `tari_base_node.exe` to `.`, `.\runtime` or other local path.
+  - If not extracted to `.` or `.\runtime`, ensure the folder containing 
+    `tari_base_node.exe` is in the path.
+
+- Tari Base Node Runtime Configuration File
+  - Copy  `..\..\common\config\presets\windows.toml` to `.\config`
+ 

--- a/applications/tari_base_node/windows/runtime/start_tari_basenode.bat
+++ b/applications/tari_base_node/windows/runtime/start_tari_basenode.bat
@@ -19,6 +19,12 @@
 @echo base_path=%base_path%
 
 @echo.
+@echo Start Tor Services
+@echo ----------------------------
+@call %my_exe_path%\start_tor.bat
+@if [%errorlevel%]==[10101] goto :END
+
+@echo.
 @echo Run the base node
 @echo -----------------
 @call %my_exe_path%\run_the_base_node.bat

--- a/applications/tari_base_node/windows/runtime/start_tor.bat
+++ b/applications/tari_base_node/windows/runtime/start_tor.bat
@@ -1,3 +1,57 @@
-@taskkill /im tor.exe /f > nul
-@tor --allow-missing-torrc --ignore-missing-torrc --clientonly 1 --socksport 9050 --controlport 127.0.0.1:9051 --clientuseipv6 1 --log "notice stdout"
-@pause
+@set file_1=%TEMP%\tor1.txt
+@set file_2=%TEMP%\tor2.txt
+@set file_3=%TEMP%\tor3.txt
+
+@call :QUERY_TOR_SERVICE
+@if not defined TOR_RUNNING (
+    @start tor --allow-missing-torrc --ignore-missing-torrc --clientonly 1 --socksport 9050 --controlport 127.0.0.1:9051 --clientuseipv6 1 --log "notice stdout"
+    @echo Tor service started on ports 9050 and 9051.
+    @ping -n 10 localhost>nul
+) else (
+    @goto :END
+)
+
+@if not defined TOR_RUNNING (
+    @call :QUERY_TOR_SERVICE
+    @if not defined TOR_RUNNING (
+        @echo Problem starting Tor services. Check if Tor is in the path.
+        @pause
+        @exit /b 10101
+    )
+)
+@goto :END
+
+:QUERY_TOR_SERVICE
+@if exist %file_1% (
+    del %file_1% /f/q
+)
+@if exist %file_2% (
+    del %file_2% /f/q
+)
+@for /f "tokens=1,2,3,4,5*" %%i in ('netstat -aon ^| findstr ":9050" ^| findstr /i listening') do @echo %j %l & @tasklist | findstr %%m > %file_1%
+@for /f "tokens=1,2,3,4,5*" %%i in ('netstat -aon ^| findstr ":9051" ^| findstr /i listening') do @echo %j %l & @tasklist | findstr %%m > %file_2%
+@if exist %file_1% (
+    @if exist %file_2% (
+        @echo Found tor service listening on ports 9050 and 9051. Good.
+        @set TOR_RUNNING=1
+    ) else (
+        @taskkill /im tor.exe /f > nul
+        @set TOR_RUNNING=
+    )
+)
+@goto :eof
+
+:QUERY_TOR_STARTED
+@if exist %file_3% (
+    del %file_3% /f/q
+)
+@tasklist /fi "imagename eq tor.exe" > %file_3%
+@if exist %file_3% (
+    @set TOR_RUNNING=1
+) else (
+    @set TOR_RUNNING=
+) 
+@goto :eof
+
+:END
+@echo.

--- a/buildtools/windows_inno_installer.iss
+++ b/buildtools/windows_inno_installer.iss
@@ -3,7 +3,7 @@
 
 #define MyOrgName "Tari"
 #define MyAppName "Base Node"
-#define MyAppVersion "0.2.1-3435d4c-release"
+#define MyAppVersion "0.2.1-23677a7-release"
 #define MyAppPublisher "The Tari Development Community"
 #define MyAppURL "https://github.com/tari-project/tari"
 #define MyAppSupp "Tari Website"
@@ -11,6 +11,7 @@
 #define MyAppExeName "start_tari_basenode.bat"
 #define TorServicesName "Tor Services"
 #define TorServicesExeName "start_tor.bat"
+#define ReadmeName "README.txt"
 
 [Setup]
 ; NOTE: The value of AppId uniquely identifies this application.
@@ -35,6 +36,7 @@ SolidCompression=yes
 MinVersion=0,6.1
 VersionInfoCompany=The Tari Developer Community
 VersionInfoProductName=tari_base_node
+InfoAfterFile="..\applications\tari_base_node\windows\README.md"
 
 [CustomMessages]
 TariGit=Tari on GitHub
@@ -49,7 +51,9 @@ Name: "quicklaunchicon"; Description: "{cm:CreateQuickLaunchIcon}"; GroupDescrip
 
 [Files]
 Source: "..\LICENSE"; DestDir: "{app}"; DestName: "LICENSE.md"; Flags: ignoreversion
+Source: "..\LICENSE"; DestDir: "{app}"; DestName: "LICENSE.txt"; Flags: ignoreversion
 Source: "..\applications\tari_base_node\windows\README.md"; DestDir: "{app}"; Flags: ignoreversion
+Source: "..\applications\tari_base_node\windows\README.md"; DestDir: "{app}"; DestName: "README.txt"; Flags: ignoreversion
 Source: "..\applications\tari_base_node\windows\start_tari_basenode.lnk"; DestDir: "{app}"; Flags: ignoreversion
 Source: "..\applications\tari_base_node\windows\start_tor.lnk"; DestDir: "{app}"; Flags: ignoreversion
 Source: "..\target\release\tari_base_node.exe"; DestDir: "{app}\runtime"; Flags: ignoreversion
@@ -63,6 +67,7 @@ Source: "tor.ico"; DestDir: "{userdocs}\..\temp\tari_icons"; Flags: ignoreversio
 [Icons]
 Name: "{group}\{#MyAppName}"; Filename: "{app}\runtime\{#MyAppExeName}"; WorkingDir: "{app}"
 Name: "{group}\{#TorServicesName}"; Filename: "{app}\runtime\{#TorServicesExeName}"; WorkingDir: "{app}"
+Name: "{group}\{#ReadmeName}"; Filename: "{app}\{#ReadmeName}"; WorkingDir: "{app}"
 Name: "{group}\{cm:ProgramOnTheWeb,{#MyAppName}}"; Filename: "{#MyAppURL}"
 Name: "{group}\{cm:TariWeb,{#MyAppSupp}}"; Filename: "{#MyAppSuppURL}"
 Name: "{group}\{cm:UninstallProgram,{#MyOrgName} {#MyAppName} - Testnet}"; Filename: "{uninstallexe}"

--- a/common/config/presets/windows.toml
+++ b/common/config/presets/windows.toml
@@ -34,6 +34,11 @@
 # ban them for 10 days.
 #blacklist_ban_period = 1440
 
+# The number of liveness sessions to allow. Liveness sessions can be established by liveness monitors over TCP by
+# sending a 0x50 (P) as the first byte. Any messages sent must be followed by newline message no longer than
+# 50 characters. That message will be echoed back.
+# liveness_max_sessions = 0
+# liveness_whitelist_cidrs = ["127.0.0.1/32"]
 
 ########################################################################################################################
 #                                                                                                                      #
@@ -88,6 +93,7 @@ db_type = "lmdb"
 
 # Enable if this node must be a mining node
 enable_mining = true
+num_mining_threads = 1
 
 # The path to store persistent data
 data_dir="rincewind"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Updated runtime environment and installer for `tari_base_node 0.2.1-23677a7-release`
- Updated `README`
- `README` displayed just before installation finishes
- `README` added to the menu when installed

   ![image](https://user-images.githubusercontent.com/39146854/80683321-530ff800-8ac4-11ea-9c65-f9a295f97516.png)

- `README` and `LICENSE` also now installed as `*.txt` files

   ![image](https://user-images.githubusercontent.com/39146854/80683973-47710100-8ac5-11ea-9e0f-8f96582838ca.png)

- Automated and more intelligent starting of the Tor services when the base node is started

TODO: 
- Code signing
- Automated installation for the pre-requisites

## Motivation and Context
The previous `tari_base_node` version - `0.2.1-3435d4c-release` - was broken as it did not communicate to the network properly. This version has been tested to run successfully since 2020-04-29 @ 15:40. Also some UX improvements in installation and runtime.

## How Has This Been Tested?
Installation and runtime tested on different Windows 10 platforms.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [X] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [X] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [X] I'm merging against the `development` branch.
* [X] I ran `cargo-fmt --all` before pushing.
* [X] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
