### PR TITLE
Add more detail to logs when an Output gets invalidated

### DIFF
--- a/base_layer/wallet/src/output_manager_service/mod.rs
+++ b/base_layer/wallet/src/output_manager_service/mod.rs
@@ -22,9 +22,12 @@
 
 use crate::output_manager_service::{handle::OutputManagerHandle, service::OutputManagerService};
 
-use crate::output_manager_service::{
-    config::OutputManagerServiceConfig,
-    storage::database::{OutputManagerBackend, OutputManagerDatabase},
+use crate::{
+    output_manager_service::{
+        config::OutputManagerServiceConfig,
+        storage::database::{OutputManagerBackend, OutputManagerDatabase},
+    },
+    transaction_service::handle::TransactionServiceHandle,
 };
 use futures::{future, Future, Stream, StreamExt};
 use log::*;
@@ -130,9 +133,14 @@ where T: OutputManagerBackend + 'static
                 .get_handle::<OutboundMessageRequester>()
                 .expect("OMS handle required for Output Manager Service");
 
+            let transaction_service = handles
+                .get_handle::<TransactionServiceHandle>()
+                .expect("Transaction Service handle required for Output Manager Service");
+
             let service = OutputManagerService::new(
                 config,
                 outbound_message_service,
+                transaction_service,
                 receiver,
                 base_node_response_stream,
                 OutputManagerDatabase::new(backend),

--- a/base_layer/wallet/src/output_manager_service/storage/database.rs
+++ b/base_layer/wallet/src/output_manager_service/storage/database.rs
@@ -76,8 +76,8 @@ pub trait OutputManagerBackend: Send + Sync {
     /// key is generated
     fn increment_key_index(&self) -> Result<(), OutputManagerStorageError>;
     /// If an unspent output is detected as invalid (i.e. not available on the blockchain) then it should be moved to
-    /// the invalid outputs collection
-    fn invalidate_unspent_output(&self, output: &UnblindedOutput) -> Result<(), OutputManagerStorageError>;
+    /// the invalid outputs collection. The function will return the last recorded TxId associated with this output.
+    fn invalidate_unspent_output(&self, output: &UnblindedOutput) -> Result<Option<TxId>, OutputManagerStorageError>;
 }
 
 /// Holds the outputs that have been selected for a given pending transaction waiting for confirmation
@@ -479,7 +479,7 @@ where T: OutputManagerBackend + 'static
         Ok(uo)
     }
 
-    pub async fn invalidate_output(&self, output: UnblindedOutput) -> Result<(), OutputManagerStorageError> {
+    pub async fn invalidate_output(&self, output: UnblindedOutput) -> Result<Option<TxId>, OutputManagerStorageError> {
         let db_clone = self.db.clone();
         tokio::task::spawn_blocking(move || db_clone.invalidate_unspent_output(&output))
             .await

--- a/base_layer/wallet/src/output_manager_service/storage/sqlite_db.rs
+++ b/base_layer/wallet/src/output_manager_service/storage/sqlite_db.rs
@@ -404,9 +404,10 @@ impl OutputManagerBackend for OutputManagerSqliteDatabase {
         Ok(())
     }
 
-    fn invalidate_unspent_output(&self, output: &UnblindedOutput) -> Result<(), OutputManagerStorageError> {
+    fn invalidate_unspent_output(&self, output: &UnblindedOutput) -> Result<Option<TxId>, OutputManagerStorageError> {
         let conn = acquire_lock!(self.database_connection);
         let output = OutputSql::find(&output.spending_key.to_vec(), &conn)?;
+        let tx_id = output.tx_id.clone().map(|id| id as u64);
         let _ = output.update(
             UpdateOutput {
                 status: Some(OutputStatus::Invalid),
@@ -415,7 +416,7 @@ impl OutputManagerBackend for OutputManagerSqliteDatabase {
             &(*conn),
         )?;
 
-        Ok(())
+        Ok(tx_id)
     }
 }
 

--- a/base_layer/wallet/tests/output_manager_service/storage.rs
+++ b/base_layer/wallet/tests/output_manager_service/storage.rs
@@ -276,12 +276,17 @@ pub fn test_db_backend<T: OutputManagerBackend + 'static>(backend: T) {
     let invalid_outputs = runtime.block_on(db.get_invalid_outputs()).unwrap();
     assert_eq!(invalid_outputs.len(), 0);
     let unspent_outputs = runtime.block_on(db.get_unspent_outputs()).unwrap();
-    runtime
+    let _ = runtime
         .block_on(db.invalidate_output(unspent_outputs[0].clone()))
         .unwrap();
     let invalid_outputs = runtime.block_on(db.get_invalid_outputs()).unwrap();
     assert_eq!(invalid_outputs.len(), 1);
     assert_eq!(invalid_outputs[0], unspent_outputs[0]);
+
+    let tx_id = runtime
+        .block_on(db.invalidate_output(pending_txs[0].outputs_to_be_received[0].clone()))
+        .unwrap();
+    assert_eq!(tx_id, Some(pending_txs[0].tx_id));
 }
 
 #[test]


### PR DESCRIPTION
## Description
This PR adds a Transaction Service Handle to the Output Manager Service so that when an output is invalidated due to a Base Node sync result that the OMS can request the associated transaction from the transaction service in order to provide some richer logs to help in tracing the reason for the invalidation in the Base node logs.

The OutputManagerMemoryDb backend had to be updated to provide the TxId

Added a new Service API request to Transaction Service to request just a single Completed Tx by tx_id.

## How Has This Been Tested?
The added infrastructure tested in updated tests.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [x] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch.
* [x] I ran `cargo-fmt --all` before pushing.
* [ ] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
