### PR TITLE
Sharing of chain metadata using ping and pong requests

### DIFF
--- a/base_layer/p2p/examples/pingpong.rs
+++ b/base_layer/p2p/examples/pingpong.rs
@@ -293,7 +293,7 @@ mod pingpong {
             ::futures::select! {
                 event = event_stream.select_next_some() => {
                     match &*(event.unwrap()) {
-                        LivenessEvent::ReceivedPing => {
+                        LivenessEvent::ReceivedPing(_) => {
                             {
                                 let mut lock = UI_STATE.write().unwrap();
                                  *lock = UiState {

--- a/base_layer/p2p/src/services/liveness/handle.rs
+++ b/base_layer/p2p/src/services/liveness/handle.rs
@@ -76,30 +76,30 @@ pub enum LivenessResponse {
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum LivenessEvent {
     /// A ping was received
-    ReceivedPing,
+    ReceivedPing(Box<PingPongEvent>),
     /// A pong was received. The latency to the peer (if available) and the metadata contained
     /// within the received pong message are included as part of the event
-    ReceivedPong(Box<PongEvent>),
+    ReceivedPong(Box<PingPongEvent>),
     BroadcastedNeighbourPings(usize),
     BroadcastedMonitoredNodeIdPings(usize),
 }
 
-/// Repressents a pong event
+/// Represents a ping or pong event
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub struct PongEvent {
-    /// The node id of the node which sent this pong
+pub struct PingPongEvent {
+    /// The node id of the node which sent this ping or pong
     pub node_id: NodeId,
-    /// Latency if available (i.e. a corresponding ping was sent within the Liveness state inflight ping TTL)
+    /// Latency if available (i.e. a corresponding event was sent within the Liveness state inflight ping TTL)
     pub latency: Option<u32>,
-    /// Pong metadata
+    /// Metadata of the corresponding node
     pub metadata: Metadata,
-    /// True if the pong was from a neighbouring peer, otherwise false
+    /// True if the ping/pong was from a neighbouring peer, otherwise false
     pub is_neighbour: bool,
-    /// True if the pong was from a monitored node, otherwise false
+    /// True if the ping/pong was from a monitored node, otherwise false
     pub is_monitored: bool,
 }
 
-impl PongEvent {
+impl PingPongEvent {
     pub fn new(
         node_id: NodeId,
         latency: Option<u32>,

--- a/base_layer/p2p/src/services/liveness/message.rs
+++ b/base_layer/p2p/src/services/liveness/message.rs
@@ -34,10 +34,10 @@ impl PingPongMessage {
         }
     }
 
-    /// Construct a ping message
-    pub fn ping() -> Self {
+    /// Construct a ping message with metadata
+    pub fn ping_with_metadata(metadata: Metadata) -> Self {
         let nonce = OsRng.next_u64();
-        Self::new(PingPong::Ping, nonce, Default::default())
+        Self::new(PingPong::Ping, nonce, metadata)
     }
 
     /// Construct a pong message with metadata

--- a/base_layer/p2p/src/services/liveness/mod.rs
+++ b/base_layer/p2p/src/services/liveness/mod.rs
@@ -70,7 +70,7 @@ pub mod mock;
 // Public exports
 pub use self::{
     config::LivenessConfig,
-    handle::{LivenessEvent, LivenessEventSender, LivenessHandle, LivenessRequest, LivenessResponse, PongEvent},
+    handle::{LivenessEvent, LivenessEventSender, LivenessHandle, LivenessRequest, LivenessResponse, PingPongEvent},
     state::Metadata,
 };
 pub use crate::proto::liveness::MetadataKey;

--- a/base_layer/p2p/src/services/liveness/state.rs
+++ b/base_layer/p2p/src/services/liveness/state.rs
@@ -76,7 +76,7 @@ pub struct LivenessState {
     pongs_sent: AtomicUsize,
     num_active_peers: AtomicUsize,
 
-    pong_metadata: Metadata,
+    local_metadata: Metadata,
     nodes_to_monitor: HashMap<NodeId, NodeStats>,
 }
 
@@ -123,14 +123,14 @@ impl LivenessState {
         self.pongs_sent.load(Ordering::Relaxed)
     }
 
-    /// Returns a reference to pong metadata
-    pub fn pong_metadata(&self) -> &Metadata {
-        &self.pong_metadata
+    /// Returns a reference to local metadata
+    pub fn metadata(&self) -> &Metadata {
+        &self.local_metadata
     }
 
-    /// Set a pong metadata entry. Duplicate entries are replaced.
-    pub fn set_pong_metadata_entry(&mut self, key: MetadataKey, value: Vec<u8>) {
-        self.pong_metadata.insert(key, value);
+    /// Set a metadata entry for the local node. Duplicate entries are replaced.
+    pub fn set_metadata_entry(&mut self, key: MetadataKey, value: Vec<u8>) {
+        self.local_metadata.insert(key, value);
     }
 
     /// Adds a ping to the inflight ping list, while noting the current time that a ping was sent.
@@ -383,13 +383,10 @@ mod test {
     }
 
     #[test]
-    fn set_pong_metadata_entry() {
+    fn set_metadata_entry() {
         let mut state = LivenessState::new();
-        state.set_pong_metadata_entry(MetadataKey::ChainMetadata, b"dummy-data".to_vec());
-        assert_eq!(
-            state.pong_metadata().get(MetadataKey::ChainMetadata).unwrap(),
-            b"dummy-data"
-        );
+        state.set_metadata_entry(MetadataKey::ChainMetadata, b"dummy-data".to_vec());
+        assert_eq!(state.metadata().get(MetadataKey::ChainMetadata).unwrap(), b"dummy-data");
     }
 
     #[test]

--- a/base_layer/p2p/tests/services/liveness.rs
+++ b/base_layer/p2p/tests/services/liveness.rs
@@ -131,7 +131,7 @@ async fn end_to_end() {
     let ping_count = events
         .iter()
         .filter(|event| match **(**event).as_ref().unwrap() {
-            LivenessEvent::ReceivedPing => true,
+            LivenessEvent::ReceivedPing(_) => true,
             _ => false,
         })
         .count();
@@ -153,7 +153,7 @@ async fn end_to_end() {
     let ping_count = events
         .iter()
         .filter(|event| match **(**event).as_ref().unwrap() {
-            LivenessEvent::ReceivedPing => true,
+            LivenessEvent::ReceivedPing(_) => true,
             _ => false,
         })
         .count();

--- a/base_layer/wallet/tests/transaction_service/service.rs
+++ b/base_layer/wallet/tests/transaction_service/service.rs
@@ -84,7 +84,7 @@ use tari_p2p::{
             LivenessInitializer,
             LivenessRequest,
             Metadata,
-            PongEvent,
+            PingPongEvent,
         },
     },
 };
@@ -2948,7 +2948,7 @@ fn test_resend_of_tx_on_pong_event<T: TransactionBackend + Clone + 'static>(back
 
     // Send the event but if the send protocol hasn't subscribed yet the send will error so wait a bit and try again.
     for _ in 0..12 {
-        match liveness_event_sender.send(Arc::new(LivenessEvent::ReceivedPong(Box::new(PongEvent::new(
+        match liveness_event_sender.send(Arc::new(LivenessEvent::ReceivedPong(Box::new(PingPongEvent::new(
             bob_node_identity.node_id().clone(),
             None,
             Metadata::new(),


### PR DESCRIPTION
## Description
- The Liveness service and Chain metadata service was updated to allow the processing of pings with chain metadata.
- The ReceivedPing from the LivenessEvent was changed to allow transfer of a PingPongEvent.
- Some functions previously only used for pongs were renamed, PongEvent was changed to PingPongEvent.

## Motivation and Context
These changes allow a remote node to send its chain metadata using the liveness ping request.

## How Has This Been Tested?
Liveness tests were updated to remain working with the new changes.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch.
* [x] I ran `cargo-fmt --all` before pushing.
* [x] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
