### PR TITLE
Auto adjusting LMDB `mapsize` based on usage at startup, reduced rincewind LMDB environment size.

### DIFF
--- a/base_layer/core/src/chain_storage/lmdb_db/lmdb_db.rs
+++ b/base_layer/core/src/chain_storage/lmdb_db/lmdb_db.rs
@@ -507,7 +507,7 @@ pub fn create_lmdb_database(
     std::fs::create_dir_all(&path).unwrap_or_default();
     let lmdb_store = LMDBBuilder::new()
         .set_path(path.to_str().unwrap())
-        .set_environment_size(50000)
+        .set_environment_size(1_000)
         .set_max_number_of_databases(15)
         .add_database(LMDB_DB_METADATA, flags)
         .add_database(LMDB_DB_HEADERS, flags)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- Reduced rincewind lmdb size to 1 GB from 50 GB.
- Automatic resizing on create, test added.
- Added INFO log message about lmbd environment usage.

Example:
```
2020-05-06 10:33:15.262362700 [lmdb] DEBUG (rincewind\db) LMDB environment usage factor 99.99 %., size used 56 MB, increased by 40 MB.
2020-05-06 10:33:15.262362700 [lmdb] INFO  (rincewind\db) LMDB environment created with a capacity of 96 MB, 40 MB remaining.
```

## Motivation and Context
The pre-assigned Rincewind db usage at 50 GB on Windows is too severe. Current db size with ~5300 blocks are 44 MB. See related PR #1702 by @mikethetike.

## How Has This Been Tested?
The mdb `set_mapsize` function can be called anytime at startup or during runtime. It will increase a smaller sized db to a larger size, or reduce a db given that the usage level complies. When running a base node with reduced rincewind lmdb setup size of 1 GB on a prior 50 GB db on Windows, it shrinks the file size without any problems.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [X] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [X] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [X] I'm merging against the `development` branch.
* [X] I ran `cargo-fmt --all` before pushing.
* [X] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [X] I have added tests to cover my changes.
