### PR TITLE
Fix for mempool not clearing

### DIFF
--- a/applications/tari_base_node/src/builder.rs
+++ b/applications/tari_base_node/src/builder.rs
@@ -563,9 +563,12 @@ where
         .block_sync_strategy
         .parse()
         .expect("Problem reading block sync strategy from config");
-
+    let node_local_interface = base_node_handles
+        .get_handle::<LocalNodeCommsInterface>()
+        .expect("Problem getting node local interface handle.");
     let node = BaseNodeStateMachine::new(
         &db,
+        &node_local_interface,
         &outbound_interface,
         base_node_comms.peer_manager(),
         base_node_comms.connection_manager(),

--- a/base_layer/core/src/base_node/chain_metadata_service/service.rs
+++ b/base_layer/core/src/base_node/chain_metadata_service/service.rs
@@ -110,7 +110,7 @@ impl ChainMetadataService {
     /// Handle BlockEvents
     async fn handle_block_event(&mut self, event: &BlockEvent) -> Result<(), ChainMetadataSyncError> {
         match event {
-            BlockEvent::Verified((_, BlockAddResult::Ok)) => {
+            BlockEvent::Verified((_, BlockAddResult::Ok, true)) => {
                 self.update_liveness_chain_metadata().await?;
             },
             BlockEvent::Verified(_) | BlockEvent::Invalid(_) => {},

--- a/base_layer/core/src/base_node/comms_interface/local_interface.rs
+++ b/base_layer/core/src/base_node/comms_interface/local_interface.rs
@@ -36,7 +36,7 @@ use tower_service::Service;
 #[derive(Clone)]
 pub struct LocalNodeCommsInterface {
     request_sender: SenderService<NodeCommsRequest, Result<NodeCommsResponse, CommsInterfaceError>>,
-    block_sender: SenderService<Block, Result<(), CommsInterfaceError>>,
+    block_sender: SenderService<(Block, bool), Result<(), CommsInterfaceError>>,
     block_event_stream: Subscriber<BlockEvent>,
 }
 
@@ -44,7 +44,7 @@ impl LocalNodeCommsInterface {
     /// Construct a new LocalNodeCommsInterface with the specified SenderService.
     pub fn new(
         request_sender: SenderService<NodeCommsRequest, Result<NodeCommsResponse, CommsInterfaceError>>,
-        block_sender: SenderService<Block, Result<(), CommsInterfaceError>>,
+        block_sender: SenderService<(Block, bool), Result<(), CommsInterfaceError>>,
         block_event_stream: Subscriber<BlockEvent>,
     ) -> Self
     {
@@ -139,8 +139,8 @@ impl LocalNodeCommsInterface {
         }
     }
 
-    /// Submit a block to the base node service.
-    pub async fn submit_block(&mut self, block: Block) -> Result<(), CommsInterfaceError> {
-        self.block_sender.call(block).await?
+    /// Submit a block to the base node service. Internal_only flag will prevent propagation.
+    pub async fn submit_block(&mut self, block: Block, propagate: bool) -> Result<(), CommsInterfaceError> {
+        self.block_sender.call((block, propagate)).await?
     }
 }

--- a/base_layer/core/src/base_node/service/service.rs
+++ b/base_layer/core/src/base_node/service/service.rs
@@ -102,7 +102,7 @@ where
     SInRes: Stream<Item = DomainMessage<proto::BaseNodeServiceResponse>>,
     SBlockIn: Stream<Item = DomainMessage<Block>>,
     SLocalReq: Stream<Item = RequestContext<NodeCommsRequest, Result<NodeCommsResponse, CommsInterfaceError>>>,
-    SLocalBlock: Stream<Item = RequestContext<Block, Result<(), CommsInterfaceError>>>,
+    SLocalBlock: Stream<Item = RequestContext<(Block, bool), Result<(), CommsInterfaceError>>>,
 {
     pub fn new(
         outbound_request_stream: SOutReq,
@@ -169,7 +169,7 @@ where B: BlockchainBackend + 'static
         SInRes: Stream<Item = DomainMessage<proto::BaseNodeServiceResponse>>,
         SBlockIn: Stream<Item = DomainMessage<Block>>,
         SLocalReq: Stream<Item = RequestContext<NodeCommsRequest, Result<NodeCommsResponse, CommsInterfaceError>>>,
-        SLocalBlock: Stream<Item = RequestContext<Block, Result<(), CommsInterfaceError>>>,
+        SLocalBlock: Stream<Item = RequestContext<(Block, bool), Result<(), CommsInterfaceError>>>,
     {
         let outbound_request_stream = streams.outbound_request_stream.fuse();
         pin_mut!(outbound_request_stream);
@@ -362,7 +362,7 @@ where B: BlockchainBackend + 'static
         });
     }
 
-    fn spawn_handle_local_block(&self, block_context: RequestContext<Block, Result<(), CommsInterfaceError>>) {
+    fn spawn_handle_local_block(&self, block_context: RequestContext<(Block, bool), Result<(), CommsInterfaceError>>) {
         let mut inbound_nch = self.inbound_nch.clone();
         task::spawn(async move {
             let (block, reply_tx) = block_context.split();
@@ -568,7 +568,9 @@ async fn handle_incoming_block<B: BlockchainBackend + 'static>(
         inner,
         source_peer.public_key
     );
-    inbound_nch.handle_block(&inner, Some(source_peer.public_key)).await?;
+    inbound_nch
+        .handle_block(&(inner, true), Some(source_peer.public_key))
+        .await?;
 
     // TODO - retain peer info for stats and potential banning for sending invalid blocks
 

--- a/base_layer/core/src/base_node/state_machine.rs
+++ b/base_layer/core/src/base_node/state_machine.rs
@@ -19,11 +19,10 @@
 // SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
 use crate::{
     base_node::{
         chain_metadata_service::ChainMetadataEvent,
-        comms_interface::OutboundNodeCommsInterface,
+        comms_interface::{LocalNodeCommsInterface, OutboundNodeCommsInterface},
         states,
         states::{BaseNodeState, BlockSyncConfig, StateEvent},
     },
@@ -61,6 +60,7 @@ impl Default for BaseNodeStateMachineConfig {
 /// database and hooks to the p2p network
 pub struct BaseNodeStateMachine<B: BlockchainBackend> {
     pub(super) db: BlockchainDatabase<B>,
+    pub(super) local_node_interface: LocalNodeCommsInterface,
     pub(super) comms: OutboundNodeCommsInterface,
     pub(super) peer_manager: Arc<PeerManager>,
     pub(super) connection_manager: ConnectionManagerRequester,
@@ -75,6 +75,7 @@ impl<B: BlockchainBackend + 'static> BaseNodeStateMachine<B> {
     /// Instantiate a new Base Node.
     pub fn new(
         db: &BlockchainDatabase<B>,
+        local_node_interface: &LocalNodeCommsInterface,
         comms: &OutboundNodeCommsInterface,
         peer_manager: Arc<PeerManager>,
         connection_manager: ConnectionManagerRequester,
@@ -86,6 +87,7 @@ impl<B: BlockchainBackend + 'static> BaseNodeStateMachine<B> {
         let (event_sender, event_receiver): (Publisher<_>, Subscriber<_>) = bounded(10);
         Self {
             db: db.clone(),
+            local_node_interface: local_node_interface.clone(),
             comms: comms.clone(),
             peer_manager,
             connection_manager,

--- a/base_layer/core/src/mempool/service/inbound_handlers.rs
+++ b/base_layer/core/src/mempool/service/inbound_handlers.rs
@@ -151,10 +151,10 @@ where T: BlockchainBackend + 'static
     /// Handle inbound block events from the local base node service.
     pub async fn handle_block_event(&mut self, block_event: &BlockEvent) -> Result<(), MempoolServiceError> {
         match block_event {
-            BlockEvent::Verified((block, BlockAddResult::Ok)) => {
+            BlockEvent::Verified((block, BlockAddResult::Ok, _)) => {
                 async_mempool::process_published_block(self.mempool.clone(), *block.clone()).await?;
             },
-            BlockEvent::Verified((_, BlockAddResult::ChainReorg((removed_blocks, added_blocks)))) => {
+            BlockEvent::Verified((_, BlockAddResult::ChainReorg((removed_blocks, added_blocks)), _)) => {
                 async_mempool::process_reorg(self.mempool.clone(), removed_blocks.to_vec(), added_blocks.to_vec())
                     .await?;
             },

--- a/base_layer/core/src/mining/miner.rs
+++ b/base_layer/core/src/mining/miner.rs
@@ -22,7 +22,7 @@
 
 use crate::{
     base_node::{
-        comms_interface::{BlockEvent, LocalNodeCommsInterface},
+        comms_interface::{BlockEvent, CommsInterfaceError, LocalNodeCommsInterface},
         states::{StateEvent, SyncStatus},
     },
     blocks::{Block, BlockHeader, NewBlockTemplate},
@@ -243,7 +243,7 @@ impl Miner {
                 futures::select! {
                 msg = block_event.select_next_some() => {
                     match *msg {
-                        BlockEvent::Verified((_, ref result)) => {
+                        BlockEvent::Verified((_, ref result, true)) => {
                             //Miner does not care if the chain reorg'ed or just added a new block. Both cases means a new chain tip, so it needs to restart.
                         match *result {
                             BlockAddResult::Ok | BlockAddResult::ChainReorg(_) => {
@@ -353,14 +353,20 @@ impl Miner {
     ///  function to send a block
     async fn send_block(&mut self, block: Block) -> Result<(), MinerError> {
         info!(target: LOG_TARGET, "Mined a block: {}", block);
-        self.node_interface
-            .submit_block(block)
-            .await
-            .or_else(|e| {
+        match self.node_interface.submit_block(block, true).await {
+            Ok(_) => {
+                trace!("Miner successfully submitted block");
+                Ok(())
+            },
+            Err(CommsInterfaceError::ChainStorageError(e)) => {
+                error!(target: LOG_TARGET, "Miner submitted invalid block. {:?}.", e);
+                // Miner does not care about an invalid block and wants the next block so we return an ok
+                Ok(())
+            },
+            Err(e) => {
                 error!(target: LOG_TARGET, "Could not send block to base node. {:?}.", e);
-                Err(e)
-            })
-            .map_err(|e| MinerError::CommunicationError(e.to_string()))?;
-        Ok(())
+                Err(MinerError::CommunicationError(e.to_string()))
+            },
+        }
     }
 }

--- a/base_layer/core/tests/mempool.rs
+++ b/base_layer/core/tests/mempool.rs
@@ -817,7 +817,7 @@ fn block_event_and_reorg_event_handling() {
 
     runtime.block_on(async {
         // Add Block1 - tx1 will be moved to the ReorgPool.
-        assert!(bob.local_nci.submit_block(block1.clone()).await.is_ok());
+        assert!(bob.local_nci.submit_block(block1.clone(), true).await.is_ok());
         async_assert_eventually!(
             alice.mempool.has_tx_with_excess_sig(tx1_excess_sig.clone()).unwrap(),
             expect = TxStorageResponse::ReorgPool,
@@ -826,7 +826,7 @@ fn block_event_and_reorg_event_handling() {
         );
 
         // Add Block2a - tx4 and tx5 will be discarded as double spends.
-        assert!(bob.local_nci.submit_block(block2a.clone()).await.is_ok());
+        assert!(bob.local_nci.submit_block(block2a.clone(), true).await.is_ok());
         async_assert_eventually!(
             alice.mempool.has_tx_with_excess_sig(tx2_excess_sig.clone()).unwrap(),
             expect = TxStorageResponse::ReorgPool,
@@ -847,7 +847,7 @@ fn block_event_and_reorg_event_handling() {
         );
 
         // Reorg chain by adding Block2b - tx2 and tx3 will be discarded as double spends.
-        assert!(bob.local_nci.submit_block(block2b.clone()).await.is_ok());
+        assert!(bob.local_nci.submit_block(block2b.clone(), true).await.is_ok());
         async_assert_eventually!(
             alice.mempool.has_tx_with_excess_sig(tx2_excess_sig.clone()).unwrap(),
             expect = TxStorageResponse::NotStored,

--- a/base_layer/core/tests/node_service.rs
+++ b/base_layer/core/tests/node_service.rs
@@ -458,17 +458,17 @@ fn propagate_and_forward_valid_block() {
         let (bob_block_event, carol_block_event, dan_block_event) =
             join!(bob_block_event_fut, carol_block_event_fut, dan_block_event_fut);
 
-        if let BlockEvent::Verified((received_block, _)) = &*bob_block_event.unwrap() {
+        if let BlockEvent::Verified((received_block, _, _)) = &*bob_block_event.unwrap() {
             assert_eq!(received_block.hash(), block1_hash);
         } else {
             panic!("Bob's node did not receive and validate the expected block");
         }
-        if let BlockEvent::Verified((received_block, _block_add_result)) = &*carol_block_event.unwrap() {
+        if let BlockEvent::Verified((received_block, _block_add_result, _)) = &*carol_block_event.unwrap() {
             assert_eq!(received_block.hash(), block1_hash);
         } else {
             panic!("Carol's node did not receive and validate the expected block");
         }
-        if let BlockEvent::Verified((received_block, _block_add_result)) = &*dan_block_event.unwrap() {
+        if let BlockEvent::Verified((received_block, _block_add_result, _)) = &*dan_block_event.unwrap() {
             assert_eq!(received_block.hash(), block1_hash);
         } else {
             panic!("Dan's node did not receive and validate the expected block");
@@ -568,12 +568,12 @@ fn propagate_and_forward_invalid_block() {
         let (bob_block_event, carol_block_event, dan_block_event) =
             join!(bob_block_event_fut, carol_block_event_fut, dan_block_event_fut);
 
-        if let BlockEvent::Invalid((received_block, _err)) = &*bob_block_event.unwrap() {
+        if let BlockEvent::Invalid((received_block, _err, _)) = &*bob_block_event.unwrap() {
             assert_eq!(received_block.hash(), block1_hash);
         } else {
             panic!("Bob's node should have detected an invalid block");
         }
-        if let BlockEvent::Invalid((received_block, _err)) = &*carol_block_event.unwrap() {
+        if let BlockEvent::Invalid((received_block, _err, _)) = &*carol_block_event.unwrap() {
             assert_eq!(received_block.hash(), block1_hash);
         } else {
             panic!("Carol's node should have detected an invalid block");
@@ -744,12 +744,12 @@ fn local_submit_block() {
         .calculate_mmr_roots(chain_block(&block0, vec![], &consensus_manager.consensus_constants()))
         .unwrap();
     runtime.block_on(async {
-        assert!(node.local_nci.submit_block(block1.clone()).await.is_ok());
+        assert!(node.local_nci.submit_block(block1.clone(), true).await.is_ok());
 
         let event_stream = node.local_nci.get_block_event_stream_fused();
         let event = event_stream_next(event_stream, Duration::from_millis(20000)).await;
 
-        if let BlockEvent::Verified((received_block, result)) = &*event.unwrap() {
+        if let BlockEvent::Verified((received_block, result, _)) = &*event.unwrap() {
             assert_eq!(received_block.hash(), block1.hash());
             assert_eq!(*result, BlockAddResult::Ok);
         } else {

--- a/base_layer/core/tests/node_state_machine.rs
+++ b/base_layer/core/tests/node_state_machine.rs
@@ -105,6 +105,7 @@ fn test_listening_lagging() {
     let shutdown = Shutdown::new();
     let mut alice_state_machine = BaseNodeStateMachine::new(
         &alice_node.blockchain_db,
+        &alice_node.local_nci,
         &alice_node.outbound_nci,
         alice_node.comms.peer_manager(),
         alice_node.comms.connection_manager(),
@@ -136,7 +137,7 @@ fn test_listening_lagging() {
                 &consensus_manager.consensus_constants(),
             ))
             .unwrap();
-        bob_local_nci.submit_block(prev_block).await.unwrap();
+        bob_local_nci.submit_block(prev_block, true).await.unwrap();
         assert_eq!(bob_db.get_height(), Ok(Some(2)));
 
         let next_event = time::timeout(Duration::from_secs(10), await_event_task)
@@ -166,6 +167,7 @@ fn test_event_channel() {
     let mut mock = MockChainMetadata::new();
     let state_machine = BaseNodeStateMachine::new(
         &db,
+        &node.local_nci,
         &node.outbound_nci,
         node.comms.peer_manager(),
         node.comms.connection_manager(),
@@ -241,6 +243,7 @@ fn test_block_sync() {
     let shutdown = Shutdown::new();
     let mut alice_state_machine = BaseNodeStateMachine::new(
         &alice_node.blockchain_db,
+        &alice_node.local_nci,
         &alice_node.outbound_nci,
         alice_node.comms.peer_manager(),
         alice_node.comms.connection_manager(),
@@ -319,6 +322,7 @@ fn test_lagging_block_sync() {
     let shutdown = Shutdown::new();
     let mut alice_state_machine = BaseNodeStateMachine::new(
         &alice_node.blockchain_db,
+        &alice_node.local_nci,
         &alice_node.outbound_nci,
         alice_node.comms.peer_manager(),
         alice_node.comms.connection_manager(),
@@ -414,6 +418,7 @@ fn test_block_sync_recovery() {
     let shutdown = Shutdown::new();
     let mut alice_state_machine = BaseNodeStateMachine::new(
         &alice_node.blockchain_db,
+        &alice_node.local_nci,
         &alice_node.outbound_nci,
         alice_node.comms.peer_manager(),
         alice_node.comms.connection_manager(),
@@ -509,6 +514,7 @@ fn test_forked_block_sync() {
     let shutdown = Shutdown::new();
     let mut alice_state_machine = BaseNodeStateMachine::new(
         &alice_node.blockchain_db,
+        &alice_node.local_nci,
         &alice_node.outbound_nci,
         alice_node.comms.peer_manager(),
         alice_node.comms.connection_manager(),
@@ -662,6 +668,7 @@ fn test_sync_peer_banning() {
     let shutdown = Shutdown::new();
     let mut alice_state_machine = BaseNodeStateMachine::new(
         &alice_node.blockchain_db,
+        &alice_node.local_nci,
         &alice_node.outbound_nci,
         alice_node.comms.peer_manager(),
         alice_node.comms.connection_manager(),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This gives the statemachine access to the mempool to give synced blocks to it. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Currently if the statemachine syncs blocks, the mempool is not given the blocks to clear its pool. The mempool only listens for the addblock event to trigger its "cleansing". But because there is a bug in block propagation, nodes sync rather than get new blocks via propagation. This causes that the node's mempool is never cleared of all transactions

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch.
* [x] I ran `cargo-fmt --all` before pushing.
* [x] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
