### PR TITLE
Include random peers in all propagation messages

### DIFF
--- a/base_layer/core/src/base_node/comms_interface/inbound_handlers.rs
+++ b/base_layer/core/src/base_node/comms_interface/inbound_handlers.rs
@@ -44,7 +44,7 @@ use log::*;
 use std::sync::Arc;
 use strum_macros::Display;
 use tari_broadcast_channel::Publisher;
-use tari_comms::types::CommsPublicKey;
+use tari_comms::peer_manager::NodeId;
 use tari_crypto::tari_utilities::{hash::Hashable, hex::Hex};
 use tokio::sync::RwLock;
 
@@ -247,7 +247,7 @@ where T: BlockchainBackend + 'static
     pub async fn handle_block(
         &mut self,
         block: &Block,
-        source_peer: Option<CommsPublicKey>,
+        source_peer: Option<NodeId>,
     ) -> Result<(), CommsInterfaceError>
     {
         debug!(

--- a/base_layer/core/src/base_node/comms_interface/outbound_interface.rs
+++ b/base_layer/core/src/base_node/comms_interface/outbound_interface.rs
@@ -31,7 +31,7 @@ use crate::{
 };
 use futures::channel::mpsc::UnboundedSender;
 use log::*;
-use tari_comms::{peer_manager::NodeId, types::CommsPublicKey};
+use tari_comms::peer_manager::NodeId;
 use tari_service_framework::reply_channel::SenderService;
 use tower_service::Service;
 
@@ -41,7 +41,7 @@ pub const LOG_TARGET: &str = "c::bn::comms_interface::outbound_interface";
 #[derive(Clone)]
 pub struct OutboundNodeCommsInterface {
     request_sender: SenderService<(NodeCommsRequest, Option<NodeId>), Result<NodeCommsResponse, CommsInterfaceError>>,
-    block_sender: UnboundedSender<(Block, Vec<CommsPublicKey>)>,
+    block_sender: UnboundedSender<(Block, Vec<NodeId>)>,
 }
 
 impl OutboundNodeCommsInterface {
@@ -51,7 +51,7 @@ impl OutboundNodeCommsInterface {
             (NodeCommsRequest, Option<NodeId>),
             Result<NodeCommsResponse, CommsInterfaceError>,
         >,
-        block_sender: UnboundedSender<(Block, Vec<CommsPublicKey>)>,
+        block_sender: UnboundedSender<(Block, Vec<NodeId>)>,
     ) -> Self
     {
         Self {
@@ -270,7 +270,7 @@ impl OutboundNodeCommsInterface {
     pub async fn propagate_block(
         &mut self,
         block: Block,
-        exclude_peers: Vec<CommsPublicKey>,
+        exclude_peers: Vec<NodeId>,
     ) -> Result<(), CommsInterfaceError>
     {
         self.block_sender

--- a/base_layer/core/src/mempool/service/inbound_handlers.rs
+++ b/base_layer/core/src/mempool/service/inbound_handlers.rs
@@ -33,7 +33,7 @@ use crate::{
 };
 use log::*;
 use std::sync::Arc;
-use tari_comms::types::CommsPublicKey;
+use tari_comms::peer_manager::NodeId;
 use tari_crypto::tari_utilities::hex::Hex;
 
 pub const LOG_TARGET: &str = "c::mp::service::inbound_handlers";
@@ -83,7 +83,7 @@ where T: BlockchainBackend + 'static
     pub async fn handle_transaction(
         &mut self,
         tx: &Transaction,
-        source_peer: Option<CommsPublicKey>,
+        source_peer: Option<NodeId>,
     ) -> Result<(), MempoolServiceError>
     {
         debug!(
@@ -103,7 +103,7 @@ where T: BlockchainBackend + 'static
     async fn submit_transaction(
         &mut self,
         tx: &Transaction,
-        exclude_peers: Vec<CommsPublicKey>,
+        exclude_peers: Vec<NodeId>,
     ) -> Result<TxStorageResponse, MempoolServiceError>
     {
         trace!(target: LOG_TARGET, "Transaction: {}.", tx);

--- a/base_layer/core/src/mempool/service/outbound_interface.rs
+++ b/base_layer/core/src/mempool/service/outbound_interface.rs
@@ -30,7 +30,7 @@ use crate::{
 };
 use futures::channel::mpsc::UnboundedSender;
 use log::*;
-use tari_comms::types::CommsPublicKey;
+use tari_comms::peer_manager::NodeId;
 use tari_service_framework::reply_channel::SenderService;
 use tower_service::Service;
 pub const LOG_TARGET: &str = "c::mp::service::outbound_interface";
@@ -40,14 +40,14 @@ pub const LOG_TARGET: &str = "c::mp::service::outbound_interface";
 #[derive(Clone)]
 pub struct OutboundMempoolServiceInterface {
     request_sender: SenderService<MempoolRequest, Result<MempoolResponse, MempoolServiceError>>,
-    tx_sender: UnboundedSender<(Transaction, Vec<CommsPublicKey>)>,
+    tx_sender: UnboundedSender<(Transaction, Vec<NodeId>)>,
 }
 
 impl OutboundMempoolServiceInterface {
     /// Construct a new OutboundMempoolServiceInterface with the specified SenderService.
     pub fn new(
         request_sender: SenderService<MempoolRequest, Result<MempoolResponse, MempoolServiceError>>,
-        tx_sender: UnboundedSender<(Transaction, Vec<CommsPublicKey>)>,
+        tx_sender: UnboundedSender<(Transaction, Vec<NodeId>)>,
     ) -> Self
     {
         Self {
@@ -70,7 +70,7 @@ impl OutboundMempoolServiceInterface {
     pub async fn propagate_tx(
         &mut self,
         transaction: Transaction,
-        exclude_peers: Vec<CommsPublicKey>,
+        exclude_peers: Vec<NodeId>,
     ) -> Result<(), MempoolServiceError>
     {
         self.tx_sender

--- a/comms/dht/examples/memorynet.rs
+++ b/comms/dht/examples/memorynet.rs
@@ -36,7 +36,7 @@
 //! `RUST_BACKTRACE=1 RUST_LOG=trace cargo run --example memorynet 2> /tmp/debug.log`
 
 // Size of network
-const NUM_NODES: usize = 39;
+const NUM_NODES: usize = 45;
 // Must be at least 2
 const NUM_WALLETS: usize = 8;
 const QUIET_MODE: bool = true;

--- a/comms/dht/src/broadcast_strategy.rs
+++ b/comms/dht/src/broadcast_strategy.rs
@@ -31,7 +31,7 @@ pub struct BroadcastClosestRequest {
     pub n: usize,
     pub node_id: NodeId,
     pub peer_features: PeerFeatures,
-    pub excluded_peers: Vec<CommsPublicKey>,
+    pub excluded_peers: Vec<NodeId>,
 }
 
 #[derive(Debug, Clone)]
@@ -49,7 +49,9 @@ pub enum BroadcastStrategy {
     /// A convenient strategy which behaves the same as the `Closest` strategy with the `NodeId` set
     /// to this node. Element 0 in the tuple is a public key exclusion list. If element 1 is set to true, all
     /// neighbouring client peers are also included in addition to node peers.
-    Neighbours(Vec<CommsPublicKey>, bool),
+    Neighbours(Vec<NodeId>, bool),
+    /// Propagate to a set of closest neighbours and random peers
+    Propagate(Vec<NodeId>),
 }
 
 impl fmt::Display for BroadcastStrategy {
@@ -67,6 +69,7 @@ impl fmt::Display for BroadcastStrategy {
                 excluded.len(),
                 if *include_clients { ", Include all clients" } else { "" }
             ),
+            Propagate(excluded) => write!(f, "Propagate({} excluded)", excluded.len()),
         }
     }
 }
@@ -75,7 +78,7 @@ impl BroadcastStrategy {
     pub fn is_broadcast(&self) -> bool {
         use BroadcastStrategy::*;
         match self {
-            Closest(_) | Flood | Neighbours(_, _) | Random(_, _) => true,
+            Closest(_) | Flood | Neighbours(_, _) | Random(_, _) | Propagate(_) => true,
             _ => false,
         }
     }

--- a/comms/dht/src/config.rs
+++ b/comms/dht/src/config.rs
@@ -31,6 +31,8 @@ pub const SAF_LOW_PRIORITY_MSG_STORAGE_TTL: Duration = Duration::from_secs(6 * 6
 pub const SAF_HIGH_PRIORITY_MSG_STORAGE_TTL: Duration = Duration::from_secs(3 * 24 * 60 * 60); // 3 days
 /// The default number of peer nodes that a message has to be closer to, to be considered a neighbour
 pub const DEFAULT_NUM_NEIGHBOURING_NODES: usize = 10;
+/// The default number of randomly-selected peer nodes to be included in propagation messages
+pub const DEFAULT_NUM_RANDOM_PROPAGATION_NODES: usize = 2;
 
 #[derive(Debug, Clone)]
 pub struct DhtConfig {
@@ -42,6 +44,10 @@ pub struct DhtConfig {
     /// The maximum number of peer nodes that a message has to be closer to, to be considered a neighbour
     /// Default: 10
     pub num_neighbouring_nodes: usize,
+    /// The maximum number of randomly-selected peer nodes that will be included in propagation
+    /// messages. Only applies to `BroadcastStrategy::Propagate`.
+    /// Default: 2
+    pub num_random_propagation_nodes: usize,
     /// A request to retrieve stored messages will be ignored if the requesting node is
     /// not within one of this nodes _n_ closest nodes.
     /// Default 8
@@ -109,6 +115,7 @@ impl Default for DhtConfig {
     fn default() -> Self {
         Self {
             num_neighbouring_nodes: DEFAULT_NUM_NEIGHBOURING_NODES,
+            num_random_propagation_nodes: DEFAULT_NUM_RANDOM_PROPAGATION_NODES,
             saf_num_closest_nodes: 10,
             saf_max_returned_messages: 50,
             outbound_buffer_size: 20,

--- a/comms/dht/src/inbound/dht_handler/task.rs
+++ b/comms/dht/src/inbound/dht_handler/task.rs
@@ -188,6 +188,8 @@ where S: Service<DecryptedDhtMessage, Response = (), Error = PipelineError>
             return Ok(());
         }
 
+        let origin_node_id = origin_peer.node_id;
+
         // Send a join request back to the origin peer of the join request if:
         // - this join request was not sent directly from the origin peer but was forwarded (from the source peer), and
         // - that peer is from the same region of network.
@@ -197,7 +199,7 @@ where S: Service<DecryptedDhtMessage, Response = (), Error = PipelineError>
         if source_peer.public_key != origin_peer.public_key &&
             self.peer_manager
                 .in_network_region(
-                    &origin_peer.node_id,
+                    &origin_node_id,
                     self.node_identity.node_id(),
                     self.config.num_neighbouring_nodes,
                 )
@@ -236,9 +238,9 @@ where S: Service<DecryptedDhtMessage, Response = (), Error = PipelineError>
                 .send_raw(
                     SendMessageParams::new()
                         .closest(
-                            origin_peer.node_id,
+                            origin_node_id.clone(),
                             self.config.num_neighbouring_nodes,
-                            vec![authenticated_pk, source_peer.public_key.clone()],
+                            vec![origin_node_id, source_peer.node_id.clone()],
                             PeerFeatures::MESSAGE_PROPAGATION,
                         )
                         .with_dht_header(dht_header)

--- a/comms/dht/src/outbound/message_params.rs
+++ b/comms/dht/src/outbound/message_params.rs
@@ -119,7 +119,7 @@ impl SendMessageParams {
         &mut self,
         node_id: NodeId,
         n: usize,
-        excluded_peers: Vec<CommsPublicKey>,
+        excluded_peers: Vec<NodeId>,
         peer_features: PeerFeatures,
     ) -> &mut Self
     {
@@ -134,13 +134,18 @@ impl SendMessageParams {
 
     /// Set broadcast_strategy to Neighbours. `excluded_peers` are excluded. Only Peers that have
     /// `PeerFeatures::MESSAGE_PROPAGATION` are included.
-    pub fn neighbours(&mut self, excluded_peers: Vec<CommsPublicKey>) -> &mut Self {
+    pub fn neighbours(&mut self, excluded_peers: Vec<NodeId>) -> &mut Self {
         self.params_mut().broadcast_strategy = BroadcastStrategy::Neighbours(excluded_peers, false);
         self
     }
 
-    pub fn neighbours_include_clients(&mut self, excluded_peers: Vec<CommsPublicKey>) -> &mut Self {
+    pub fn neighbours_include_clients(&mut self, excluded_peers: Vec<NodeId>) -> &mut Self {
         self.params_mut().broadcast_strategy = BroadcastStrategy::Neighbours(excluded_peers, true);
+        self
+    }
+
+    pub fn propagate(&mut self, excluded_peers: Vec<NodeId>) -> &mut Self {
+        self.params_mut().broadcast_strategy = BroadcastStrategy::Propagate(excluded_peers);
         self
     }
 

--- a/comms/dht/src/outbound/requester.rs
+++ b/comms/dht/src/outbound/requester.rs
@@ -97,7 +97,7 @@ impl OutboundMessageRequester {
     pub async fn send_direct_neighbours<T>(
         &mut self,
         encryption: OutboundEncryption,
-        exclude_peers: Vec<CommsPublicKey>,
+        exclude_peers: Vec<NodeId>,
         message: OutboundDomainMessage<T>,
     ) -> Result<SendMessageResponse, DhtOutboundError>
     where
@@ -115,7 +115,7 @@ impl OutboundMessageRequester {
         &mut self,
         destination: NodeDestination,
         encryption: OutboundEncryption,
-        exclude_peers: Vec<CommsPublicKey>,
+        exclude_peers: Vec<NodeId>,
         message: OutboundDomainMessage<T>,
     ) -> Result<SendMessageResponse, DhtOutboundError>
     where
@@ -123,7 +123,7 @@ impl OutboundMessageRequester {
     {
         self.send_message(
             SendMessageParams::new()
-                .neighbours(exclude_peers)
+                .propagate(exclude_peers)
                 .with_encryption(encryption)
                 .with_destination(destination)
                 .finish(),

--- a/comms/src/peer_manager/manager.rs
+++ b/comms/src/peer_manager/manager.rs
@@ -254,7 +254,7 @@ impl PeerManager {
     }
 
     /// Fetch n random peers
-    pub async fn random_peers(&self, n: usize, excluded: Vec<NodeId>) -> Result<Vec<Peer>, PeerManagerError> {
+    pub async fn random_peers(&self, n: usize, excluded: &[NodeId]) -> Result<Vec<Peer>, PeerManagerError> {
         // Send to a random set of peers of size n that are Communication Nodes
         self.peer_storage.read().await.random_peers(n, excluded)
     }
@@ -481,8 +481,8 @@ mod test {
         }
 
         // Test Random
-        let identities1 = peer_manager.random_peers(10, vec![]).await.unwrap();
-        let identities2 = peer_manager.random_peers(10, vec![]).await.unwrap();
+        let identities1 = peer_manager.random_peers(10, &[]).await.unwrap();
+        let identities2 = peer_manager.random_peers(10, &[]).await.unwrap();
         assert_ne!(identities1, identities2);
     }
 

--- a/comms/src/peer_manager/peer_storage.rs
+++ b/comms/src/peer_manager/peer_storage.rs
@@ -350,7 +350,7 @@ where DS: KeyValueStore<PeerId, Peer>
     }
 
     /// Compile a random list of communication node peers of size _n_ that are not banned or offline
-    pub fn random_peers(&self, n: usize, exclude_peers: Vec<NodeId>) -> Result<Vec<Peer>, PeerManagerError> {
+    pub fn random_peers(&self, n: usize, exclude_peers: &[NodeId]) -> Result<Vec<Peer>, PeerManagerError> {
         let mut peer_keys = self
             .peer_db
             .filter(|(_, peer)| {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
**Please test on current testnet network before merging**
Include a configured number (default: 2) of randomly-selected peers in all
propagation messages.

- Added `BroadcastStrategy::Propagate` that adds randomly-selected peers
  to the neighbouring peer set
- Use `NodeId` instead of `CommsPublicKey` for excluded peer list (for
  conistency and it has a much smaller memory footprint)
- Removed propagation of all discovery messages to wallets. This is pointless if the discovery destination is not set to the wallet. Messages will still reach the wallet if the peer already knows the wallet.

This is a quick way to improve network propagation connectivity although
it is not optimal (i.e. does not scale) and much less robust than the `ConnectivityManager`
solution to follow.


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Nodes currently propagate within their neighbourhood. Including random peers in propagation spreads messages outside of the region allows those messages to 'bloom' from those random locations.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
memorynet (which tests discovery propagation) succeeds 100% of the time without a inordinate increase in messages sent.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [x] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch.
* [x] I ran `cargo-fmt --all` before pushing.
* [x] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
