### PR TITLE
Fix for mempool not clearning

### DIFF
--- a/applications/tari_base_node/src/builder.rs
+++ b/applications/tari_base_node/src/builder.rs
@@ -563,9 +563,12 @@ where
         .block_sync_strategy
         .parse()
         .expect("Problem reading block sync strategy from config");
-
+    let node_local_interface = base_node_handles
+        .get_handle::<LocalNodeCommsInterface>()
+        .expect("Problem getting node local interface handle.");
     let node = BaseNodeStateMachine::new(
         &db,
+        &node_local_interface,
         &outbound_interface,
         base_node_comms.peer_manager(),
         base_node_comms.connection_manager(),

--- a/base_layer/core/src/base_node/chain_metadata_service/service.rs
+++ b/base_layer/core/src/base_node/chain_metadata_service/service.rs
@@ -24,7 +24,7 @@ use super::{error::ChainMetadataSyncError, LOG_TARGET};
 use crate::{
     base_node::{
         chain_metadata_service::handle::{ChainMetadataEvent, PeerChainMetadata},
-        comms_interface::{BlockEvent, LocalNodeCommsInterface},
+        comms_interface::{BlockEvent, Broadcast, LocalNodeCommsInterface},
         proto,
     },
     chain_storage::BlockAddResult,
@@ -109,8 +109,9 @@ impl ChainMetadataService {
 
     /// Handle BlockEvents
     async fn handle_block_event(&mut self, event: &BlockEvent) -> Result<(), ChainMetadataSyncError> {
+        let _broadcast = Broadcast::from(true);
         match event {
-            BlockEvent::Verified((_, BlockAddResult::Ok)) => {
+            BlockEvent::Verified((_, BlockAddResult::Ok, _broadcast)) => {
                 self.update_liveness_chain_metadata().await?;
             },
             BlockEvent::Verified(_) | BlockEvent::Invalid(_) => {},

--- a/base_layer/core/src/base_node/comms_interface/mod.rs
+++ b/base_layer/core/src/base_node/comms_interface/mod.rs
@@ -31,6 +31,6 @@ mod outbound_interface;
 pub use comms_request::{MmrStateRequest, NodeCommsRequest};
 pub use comms_response::NodeCommsResponse;
 pub use error::CommsInterfaceError;
-pub use inbound_handlers::{BlockEvent, InboundNodeCommsHandlers};
+pub use inbound_handlers::{BlockEvent, Broadcast, InboundNodeCommsHandlers};
 pub use local_interface::LocalNodeCommsInterface;
 pub use outbound_interface::OutboundNodeCommsInterface;

--- a/base_layer/core/src/base_node/state_machine.rs
+++ b/base_layer/core/src/base_node/state_machine.rs
@@ -19,11 +19,10 @@
 // SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
 use crate::{
     base_node::{
         chain_metadata_service::ChainMetadataEvent,
-        comms_interface::OutboundNodeCommsInterface,
+        comms_interface::{LocalNodeCommsInterface, OutboundNodeCommsInterface},
         states,
         states::{BaseNodeState, BlockSyncConfig, StateEvent},
     },
@@ -61,6 +60,7 @@ impl Default for BaseNodeStateMachineConfig {
 /// database and hooks to the p2p network
 pub struct BaseNodeStateMachine<B: BlockchainBackend> {
     pub(super) db: BlockchainDatabase<B>,
+    pub(super) local_node_interface: LocalNodeCommsInterface,
     pub(super) comms: OutboundNodeCommsInterface,
     pub(super) peer_manager: Arc<PeerManager>,
     pub(super) connection_manager: ConnectionManagerRequester,
@@ -75,6 +75,7 @@ impl<B: BlockchainBackend + 'static> BaseNodeStateMachine<B> {
     /// Instantiate a new Base Node.
     pub fn new(
         db: &BlockchainDatabase<B>,
+        local_node_interface: &LocalNodeCommsInterface,
         comms: &OutboundNodeCommsInterface,
         peer_manager: Arc<PeerManager>,
         connection_manager: ConnectionManagerRequester,
@@ -86,6 +87,7 @@ impl<B: BlockchainBackend + 'static> BaseNodeStateMachine<B> {
         let (event_sender, event_receiver): (Publisher<_>, Subscriber<_>) = bounded(10);
         Self {
             db: db.clone(),
+            local_node_interface: local_node_interface.clone(),
             comms: comms.clone(),
             peer_manager,
             connection_manager,

--- a/base_layer/core/src/base_node/states/block_sync.rs
+++ b/base_layer/core/src/base_node/states/block_sync.rs
@@ -22,7 +22,7 @@
 
 use crate::{
     base_node::{
-        comms_interface::CommsInterfaceError,
+        comms_interface::{Broadcast, CommsInterfaceError},
         state_machine::BaseNodeStateMachine,
         states::{ForwardBlockSyncInfo, ListeningInfo, StateEvent},
     },
@@ -359,7 +359,11 @@ async fn request_and_add_blocks<B: BlockchainBackend + 'static>(
         let (blocks, sync_peer) = request_blocks(shared, sync_peers, block_nums.clone()).await?;
         for block in blocks {
             let block_hash = block.hash();
-            match shared.db.add_block(block.clone()) {
+            match shared
+                .local_node_interface
+                .submit_block(block.clone(), Broadcast::from(false))
+                .await
+            {
                 Ok(_) => {
                     info!(
                         target: LOG_TARGET,
@@ -370,7 +374,7 @@ async fn request_and_add_blocks<B: BlockchainBackend + 'static>(
                     trace!(target: LOG_TARGET, "Block added to database: {}", block,);
                     block_nums.remove(0);
                 },
-                Err(ChainStorageError::InvalidBlock) => {
+                Err(CommsInterfaceError::ChainStorageError(ChainStorageError::InvalidBlock)) => {
                     warn!(
                         target: LOG_TARGET,
                         "Invalid block {} received from peer. Retrying",
@@ -383,7 +387,7 @@ async fn request_and_add_blocks<B: BlockchainBackend + 'static>(
                     ban_sync_peer(shared, sync_peers, sync_peer.clone()).await?;
                     break;
                 },
-                Err(ChainStorageError::ValidationError { source }) => {
+                Err(CommsInterfaceError::ChainStorageError(ChainStorageError::ValidationError { source })) => {
                     warn!(
                         target: LOG_TARGET,
                         "Validation on block {} from peer failed due to: {:?}. Retrying",
@@ -397,7 +401,7 @@ async fn request_and_add_blocks<B: BlockchainBackend + 'static>(
                     ban_sync_peer(shared, sync_peers, sync_peer.clone()).await?;
                     break;
                 },
-                Err(e) => return Err(BlockSyncError::ChainStorageError(e)),
+                Err(e) => return Err(BlockSyncError::CommsInterfaceError(e)),
             }
         }
         if block_nums.is_empty() {

--- a/base_layer/core/tests/mempool.rs
+++ b/base_layer/core/tests/mempool.rs
@@ -38,7 +38,7 @@ use helpers::{
 use std::{ops::Deref, sync::Arc, time::Duration};
 use tari_comms_dht::{domain_message::OutboundDomainMessage, outbound::OutboundEncryption};
 use tari_core::{
-    base_node::service::BaseNodeServiceConfig,
+    base_node::{comms_interface::Broadcast, service::BaseNodeServiceConfig},
     consensus::{ConsensusConstantsBuilder, ConsensusManagerBuilder, Network},
     helpers::create_mem_db,
     mempool::{
@@ -817,7 +817,11 @@ fn block_event_and_reorg_event_handling() {
 
     runtime.block_on(async {
         // Add Block1 - tx1 will be moved to the ReorgPool.
-        assert!(bob.local_nci.submit_block(block1.clone()).await.is_ok());
+        assert!(bob
+            .local_nci
+            .submit_block(block1.clone(), Broadcast::from(true))
+            .await
+            .is_ok());
         async_assert_eventually!(
             alice.mempool.has_tx_with_excess_sig(tx1_excess_sig.clone()).unwrap(),
             expect = TxStorageResponse::ReorgPool,
@@ -826,7 +830,11 @@ fn block_event_and_reorg_event_handling() {
         );
 
         // Add Block2a - tx4 and tx5 will be discarded as double spends.
-        assert!(bob.local_nci.submit_block(block2a.clone()).await.is_ok());
+        assert!(bob
+            .local_nci
+            .submit_block(block2a.clone(), Broadcast::from(true))
+            .await
+            .is_ok());
         async_assert_eventually!(
             alice.mempool.has_tx_with_excess_sig(tx2_excess_sig.clone()).unwrap(),
             expect = TxStorageResponse::ReorgPool,
@@ -847,7 +855,11 @@ fn block_event_and_reorg_event_handling() {
         );
 
         // Reorg chain by adding Block2b - tx2 and tx3 will be discarded as double spends.
-        assert!(bob.local_nci.submit_block(block2b.clone()).await.is_ok());
+        assert!(bob
+            .local_nci
+            .submit_block(block2b.clone(), Broadcast::from(true))
+            .await
+            .is_ok());
         async_assert_eventually!(
             alice.mempool.has_tx_with_excess_sig(tx2_excess_sig.clone()).unwrap(),
             expect = TxStorageResponse::NotStored,

--- a/base_layer/core/tests/node_state_machine.rs
+++ b/base_layer/core/tests/node_state_machine.rs
@@ -46,6 +46,7 @@ use std::{thread, time::Duration};
 use tari_core::{
     base_node::{
         chain_metadata_service::PeerChainMetadata,
+        comms_interface::Broadcast,
         service::BaseNodeServiceConfig,
         states::{
             BestChainMetadataBlockSyncInfo,
@@ -105,6 +106,7 @@ fn test_listening_lagging() {
     let shutdown = Shutdown::new();
     let mut alice_state_machine = BaseNodeStateMachine::new(
         &alice_node.blockchain_db,
+        &alice_node.local_nci,
         &alice_node.outbound_nci,
         alice_node.comms.peer_manager(),
         alice_node.comms.connection_manager(),
@@ -136,7 +138,10 @@ fn test_listening_lagging() {
                 &consensus_manager.consensus_constants(),
             ))
             .unwrap();
-        bob_local_nci.submit_block(prev_block).await.unwrap();
+        bob_local_nci
+            .submit_block(prev_block, Broadcast::from(true))
+            .await
+            .unwrap();
         assert_eq!(bob_db.get_height(), Ok(Some(2)));
 
         let next_event = time::timeout(Duration::from_secs(10), await_event_task)
@@ -166,6 +171,7 @@ fn test_event_channel() {
     let mut mock = MockChainMetadata::new();
     let state_machine = BaseNodeStateMachine::new(
         &db,
+        &node.local_nci,
         &node.outbound_nci,
         node.comms.peer_manager(),
         node.comms.connection_manager(),
@@ -241,6 +247,7 @@ fn test_block_sync() {
     let shutdown = Shutdown::new();
     let mut alice_state_machine = BaseNodeStateMachine::new(
         &alice_node.blockchain_db,
+        &alice_node.local_nci,
         &alice_node.outbound_nci,
         alice_node.comms.peer_manager(),
         alice_node.comms.connection_manager(),
@@ -319,6 +326,7 @@ fn test_lagging_block_sync() {
     let shutdown = Shutdown::new();
     let mut alice_state_machine = BaseNodeStateMachine::new(
         &alice_node.blockchain_db,
+        &alice_node.local_nci,
         &alice_node.outbound_nci,
         alice_node.comms.peer_manager(),
         alice_node.comms.connection_manager(),
@@ -414,6 +422,7 @@ fn test_block_sync_recovery() {
     let shutdown = Shutdown::new();
     let mut alice_state_machine = BaseNodeStateMachine::new(
         &alice_node.blockchain_db,
+        &alice_node.local_nci,
         &alice_node.outbound_nci,
         alice_node.comms.peer_manager(),
         alice_node.comms.connection_manager(),
@@ -509,6 +518,7 @@ fn test_forked_block_sync() {
     let shutdown = Shutdown::new();
     let mut alice_state_machine = BaseNodeStateMachine::new(
         &alice_node.blockchain_db,
+        &alice_node.local_nci,
         &alice_node.outbound_nci,
         alice_node.comms.peer_manager(),
         alice_node.comms.connection_manager(),
@@ -662,6 +672,7 @@ fn test_sync_peer_banning() {
     let shutdown = Shutdown::new();
     let mut alice_state_machine = BaseNodeStateMachine::new(
         &alice_node.blockchain_db,
+        &alice_node.local_nci,
         &alice_node.outbound_nci,
         alice_node.comms.peer_manager(),
         alice_node.comms.connection_manager(),

--- a/infrastructure/storage/tests/lmdb.rs
+++ b/infrastructure/storage/tests/lmdb.rs
@@ -283,7 +283,7 @@ fn lmbd_resize_on_create() {
     {
         let path = get_path(&db_env_name);
         std::fs::create_dir(&path).unwrap_or_default();
-        let mut size_used_round_1: usize;
+        let size_used_round_1: usize;
         const PRESET_SIZE: usize = 1;
         let db_name = "test";
         {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Changes the syncing service to use the local node interface to submit blocks rather than just adding it. 
Submit block now requires you to say if it should propagate the block or not. 
Submit block also returns the result of the add_block to db_backend. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Currently if the statemachine syncs blocks, the mempool is not given the blocks to clear its pool. The mempool only listens for the addblock event to trigger its "cleansing". But because there is a bug in block propagation, nodes sync rather than get new blocks via propagation. This causes that the node's mempool is never cleared of all transactions. 



## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch.
* [x] I ran `cargo-fmt --all` before pushing.
* [x] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
