### PR TITLE
Add FFI function to return list of cancelled transactions

### DIFF
--- a/base_layer/wallet/migrations/2020-05-05-122254_add_canceled_flag/down.sql
+++ b/base_layer/wallet/migrations/2020-05-05-122254_add_canceled_flag/down.sql
@@ -1,0 +1,12 @@
+UPDATE completed_transactions
+SET status = 5
+WHERE cancelled = 1;
+
+ALTER TABLE completed_transactions
+    DROP COLUMN cancelled;
+
+ALTER TABLE inbound_transactions
+    DROP COLUMN cancelled;
+
+ALTER TABLE outbound_transactions
+    DROP COLUMN cancelled;

--- a/base_layer/wallet/migrations/2020-05-05-122254_add_canceled_flag/up.sql
+++ b/base_layer/wallet/migrations/2020-05-05-122254_add_canceled_flag/up.sql
@@ -1,0 +1,12 @@
+ALTER TABLE completed_transactions
+    ADD COLUMN cancelled INTEGER NOT NULL DEFAULT 0;
+
+ALTER TABLE inbound_transactions
+    ADD COLUMN cancelled INTEGER NOT NULL DEFAULT 0;
+
+ALTER TABLE outbound_transactions
+    ADD COLUMN cancelled INTEGER NOT NULL DEFAULT 0;
+
+UPDATE completed_transactions
+SET cancelled = 1, status = 1
+WHERE status = 5;

--- a/base_layer/wallet/src/output_manager_service/service.rs
+++ b/base_layer/wallet/src/output_manager_service/service.rs
@@ -104,6 +104,7 @@ where
     TBackend: OutputManagerBackend,
     BNResponseStream: Stream<Item = DomainMessage<BaseNodeProto::BaseNodeServiceResponse>>,
 {
+    #[allow(clippy::too_many_arguments)]
     pub async fn new(
         config: OutputManagerServiceConfig,
         outbound_message_service: OutboundMessageRequester,
@@ -697,7 +698,8 @@ where
     pub async fn cancel_transaction(&mut self, tx_id: u64) -> Result<(), OutputManagerError> {
         trace!(
             target: LOG_TARGET,
-            "Cancelling pending transaction outputs for TxId: tx_id"
+            "Cancelling pending transaction outputs for TxId: {}",
+            tx_id
         );
         Ok(self.db.cancel_pending_transaction_outputs(tx_id).await?)
     }

--- a/base_layer/wallet/src/output_manager_service/storage/memory_db.rs
+++ b/base_layer/wallet/src/output_manager_service/storage/memory_db.rs
@@ -347,9 +347,9 @@ impl OutputManagerBackend for OutputManagerMemoryDatabase {
             Some(pos) => {
                 let output = db.unspent_outputs.remove(pos);
                 db.invalid_outputs.push(output.clone());
-                return Ok(output.tx_id);
+                Ok(output.tx_id)
             },
-            None => return Err(OutputManagerStorageError::ValuesNotFound),
+            None => Err(OutputManagerStorageError::ValuesNotFound),
         }
     }
 }

--- a/base_layer/wallet/src/schema.rs
+++ b/base_layer/wallet/src/schema.rs
@@ -18,6 +18,7 @@ table! {
         status -> Integer,
         message -> Text,
         timestamp -> Timestamp,
+        cancelled -> Integer,
     }
 }
 
@@ -36,6 +37,7 @@ table! {
         receiver_protocol -> Text,
         message -> Text,
         timestamp -> Timestamp,
+        cancelled -> Integer,
     }
 }
 
@@ -58,6 +60,7 @@ table! {
         sender_protocol -> Text,
         message -> Text,
         timestamp -> Timestamp,
+        cancelled -> Integer,
     }
 }
 

--- a/base_layer/wallet/src/storage/connection_manager.rs
+++ b/base_layer/wallet/src/storage/connection_manager.rs
@@ -33,7 +33,6 @@ pub type WalletDbConnection = Arc<Mutex<SqliteConnection>>;
 pub fn run_migration_and_create_sqlite_connection<P: AsRef<Path>>(
     db_path: P,
 ) -> Result<WalletDbConnection, WalletStorageError> {
-    let db_exists = db_path.as_ref().exists();
     let path_str = db_path
         .as_ref()
         .to_str()
@@ -41,11 +40,9 @@ pub fn run_migration_and_create_sqlite_connection<P: AsRef<Path>>(
     let connection = SqliteConnection::establish(path_str)?;
     connection.execute("PRAGMA foreign_keys = ON; PRAGMA busy_timeout = 60000;")?;
 
-    if !db_exists {
-        embed_migrations!("./migrations");
-        embedded_migrations::run_with_output(&connection, &mut io::stdout())
-            .map_err(|err| WalletStorageError::DatabaseMigrationError(format!("Database migration failed {}", err)))?;
-    }
+    embed_migrations!("./migrations");
+    embedded_migrations::run_with_output(&connection, &mut io::stdout())
+        .map_err(|err| WalletStorageError::DatabaseMigrationError(format!("Database migration failed {}", err)))?;
 
     Ok(Arc::new(Mutex::new(connection)))
 }

--- a/base_layer/wallet/src/testnet_utils.rs
+++ b/base_layer/wallet/src/testnet_utils.rs
@@ -703,17 +703,17 @@ pub fn complete_sent_transaction<
         .block_on(wallet.transaction_service.get_pending_outbound_transactions())?;
     match pending_outbound_tx.get(&tx_id) {
         Some(p) => {
-            let completed_tx: CompletedTransaction = CompletedTransaction {
-                tx_id: p.tx_id,
-                source_public_key: wallet.comms.node_identity().public_key().clone(),
-                destination_public_key: p.destination_public_key.clone(),
-                amount: p.amount,
-                fee: p.fee,
-                transaction: Transaction::new(Vec::new(), Vec::new(), Vec::new(), BlindingFactor::default()),
-                message: p.message.clone(),
-                status: TransactionStatus::Completed,
-                timestamp: Utc::now().naive_utc(),
-            };
+            let completed_tx: CompletedTransaction = CompletedTransaction::new(
+                p.tx_id,
+                wallet.comms.node_identity().public_key().clone(),
+                p.destination_public_key.clone(),
+                p.amount,
+                p.fee,
+                Transaction::new(Vec::new(), Vec::new(), Vec::new(), BlindingFactor::default()),
+                TransactionStatus::Completed,
+                p.message.clone(),
+                Utc::now().naive_utc(),
+            );
             wallet.runtime.block_on(
                 wallet
                     .transaction_service

--- a/base_layer/wallet/src/transaction_service/handle.rs
+++ b/base_layer/wallet/src/transaction_service/handle.rs
@@ -41,6 +41,9 @@ pub enum TransactionServiceRequest {
     GetPendingInboundTransactions,
     GetPendingOutboundTransactions,
     GetCompletedTransactions,
+    GetCancelledPendingInboundTransactions,
+    GetCancelledPendingOutboundTransactions,
+    GetCancelledCompletedTransactions,
     GetCompletedTransaction(TxId),
     SetBaseNodePublicKey(CommsPublicKey),
     SendTransaction((CommsPublicKey, MicroTari, MicroTari, String)),
@@ -68,6 +71,9 @@ impl fmt::Display for TransactionServiceRequest {
             Self::GetPendingInboundTransactions => f.write_str("GetPendingInboundTransactions"),
             Self::GetPendingOutboundTransactions => f.write_str("GetPendingOutboundTransactions"),
             Self::GetCompletedTransactions => f.write_str("GetCompletedTransactions"),
+            Self::GetCancelledPendingInboundTransactions => f.write_str("GetCancelledPendingInboundTransactions"),
+            Self::GetCancelledPendingOutboundTransactions => f.write_str("GetCancelledPendingOutboundTransactions"),
+            Self::GetCancelledCompletedTransactions => f.write_str("GetCancelledCompletedTransactions"),
             Self::GetCompletedTransaction(t) => f.write_str(&format!("GetCompletedTransaction({})", t)),
             Self::SetBaseNodePublicKey(k) => f.write_str(&format!("SetBaseNodePublicKey ({})", k)),
             Self::SendTransaction((k, v, _, msg)) => {
@@ -217,6 +223,19 @@ impl TransactionServiceHandle {
         }
     }
 
+    pub async fn get_cancelled_pending_inbound_transactions(
+        &mut self,
+    ) -> Result<HashMap<u64, InboundTransaction>, TransactionServiceError> {
+        match self
+            .handle
+            .call(TransactionServiceRequest::GetCancelledPendingInboundTransactions)
+            .await??
+        {
+            TransactionServiceResponse::PendingInboundTransactions(p) => Ok(p),
+            _ => Err(TransactionServiceError::UnexpectedApiResponse),
+        }
+    }
+
     pub async fn get_pending_outbound_transactions(
         &mut self,
     ) -> Result<HashMap<u64, OutboundTransaction>, TransactionServiceError> {
@@ -230,12 +249,38 @@ impl TransactionServiceHandle {
         }
     }
 
+    pub async fn get_cancelled_pending_outbound_transactions(
+        &mut self,
+    ) -> Result<HashMap<u64, OutboundTransaction>, TransactionServiceError> {
+        match self
+            .handle
+            .call(TransactionServiceRequest::GetCancelledPendingOutboundTransactions)
+            .await??
+        {
+            TransactionServiceResponse::PendingOutboundTransactions(p) => Ok(p),
+            _ => Err(TransactionServiceError::UnexpectedApiResponse),
+        }
+    }
+
     pub async fn get_completed_transactions(
         &mut self,
     ) -> Result<HashMap<u64, CompletedTransaction>, TransactionServiceError> {
         match self
             .handle
             .call(TransactionServiceRequest::GetCompletedTransactions)
+            .await??
+        {
+            TransactionServiceResponse::CompletedTransactions(c) => Ok(c),
+            _ => Err(TransactionServiceError::UnexpectedApiResponse),
+        }
+    }
+
+    pub async fn get_cancelled_completed_transactions(
+        &mut self,
+    ) -> Result<HashMap<u64, CompletedTransaction>, TransactionServiceError> {
+        match self
+            .handle
+            .call(TransactionServiceRequest::GetCancelledCompletedTransactions)
             .await??
         {
             TransactionServiceResponse::CompletedTransactions(c) => Ok(c),

--- a/base_layer/wallet/tests/output_manager_service/service.rs
+++ b/base_layer/wallet/tests/output_manager_service/service.rs
@@ -197,14 +197,20 @@ fn sending_transaction_and_confirmation<T: Clone + OutputManagerBackend + 'stati
         .block_on(oms.confirm_transaction(sender_tx_id, tx.body.inputs().clone(), tx.body.outputs().clone()))
         .unwrap();
 
-    assert_eq!(runtime.block_on(oms.get_pending_transactions()).unwrap().len(), 0);
+    assert_eq!(
+        runtime.block_on(oms.get_pending_transactions()).unwrap().len(),
+        0,
+        "Should have no pending tx"
+    );
     assert_eq!(
         runtime.block_on(oms.get_spent_outputs()).unwrap().len(),
-        tx.body.inputs().len()
+        tx.body.inputs().len(),
+        "# Outputs should equal number of sent inputs"
     );
     assert_eq!(
         runtime.block_on(oms.get_unspent_outputs()).unwrap().len(),
-        num_outputs + 1 - runtime.block_on(oms.get_spent_outputs()).unwrap().len() + tx.body.outputs().len() - 1
+        num_outputs + 1 - runtime.block_on(oms.get_spent_outputs()).unwrap().len() + tx.body.outputs().len() - 1,
+        "Unspent outputs"
     );
 
     if let DbValue::KeyManagerState(km) = backend.fetch(&DbKey::KeyManagerState).unwrap().unwrap() {

--- a/base_layer/wallet/tests/transaction_service/service.rs
+++ b/base_layer/wallet/tests/transaction_service/service.rs
@@ -1823,6 +1823,7 @@ fn broadcast_all_completed_transactions_on_startup() {
         status: TransactionStatus::Completed,
         message: "Yo!".to_string(),
         timestamp: Utc::now().naive_utc(),
+        cancelled: false,
     };
 
     let completed_tx2 = CompletedTransaction {
@@ -2333,6 +2334,7 @@ fn query_all_completed_transactions_on_startup() {
         status: TransactionStatus::Broadcast,
         message: "Yo!".to_string(),
         timestamp: Utc::now().naive_utc(),
+        cancelled: false,
     };
 
     let completed_tx2 = CompletedTransaction {

--- a/base_layer/wallet_ffi/wallet.h
+++ b/base_layer/wallet_ffi/wallet.h
@@ -391,6 +391,9 @@ struct TariPublicKey *wallet_get_public_key(struct TariWallet *wallet,int* error
 // Get the TariPendingInboundTransactions from a TariWallet
 struct TariPendingInboundTransactions *wallet_get_pending_inbound_transactions(struct TariWallet *wallet,int* error_out);
 
+// Get all cancelled transactions from a TariWallet
+struct TariCompletedTransactions *wallet_get_cancelled_transactions(struct TariWallet *wallet,int* error_out);
+
 // Get the TariCompletedTransaction from a TariWallet by its TransactionId
 struct TariCompletedTransaction *wallet_get_completed_transaction_by_id(struct TariWallet *wallet, unsigned long long transaction_id,int* error_out);
 


### PR DESCRIPTION
## Description
This PR adds a new FFI function to return all cancelled transactions. This list includes cancelled Pending Inbound and Outbound transactions that are converted to CompletedTransaction structs for the final collection so that all three transaction types can live in the same list.

To facilitate this the database is updated to use a separate flag to indicate if a transaction (inbound, outbound and completed) is cancelled while maintaining the original status of the transactions. 

## How Has This Been Tested?
Tests have been updated to exercise new methods.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch.
* [x] I ran `cargo-fmt --all` before pushing.
* [ ] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
