### PR TITLE
Added monero_merge_mining feature flag

### DIFF
--- a/applications/tari_base_node/src/grpc.rs
+++ b/applications/tari_base_node/src/grpc.rs
@@ -309,9 +309,12 @@ impl From<BlockHeader> for base_node_grpc::BlockHeader {
             total_kernel_offset: Vec::from(h.total_kernel_offset.as_bytes()),
             nonce: h.nonce,
             pow: Some(base_node_grpc::ProofOfWork {
+                #[allow(dead_code)]
                 pow_algo: match h.pow.pow_algo {
+                    #[cfg(feature = "monero_merge_mining")]
                     PowAlgorithm::Monero => 0,
                     PowAlgorithm::Blake => 1,
+                    _ => 99, // build fails otherwise due to feature flag
                 },
                 accumulated_monero_difficulty: h.pow.accumulated_monero_difficulty.into(),
                 accumulated_blake_difficulty: h.pow.accumulated_blake_difficulty.into(),

--- a/base_layer/core/Cargo.toml
+++ b/base_layer/core/Cargo.toml
@@ -10,7 +10,8 @@ version = "0.1.0"
 edition = "2018"
 
 [features]
-default = ["croaring", "tari_mmr", "transactions", "base_node", "mempool_proto", "monero", "randomx-rs", "base_node_proto"]
+default = ["croaring", "tari_mmr", "transactions", "base_node", "mempool_proto", "base_node_proto"]
+monero_merge_mining = ["croaring", "tari_mmr", "transactions", "base_node", "mempool_proto", "base_node_proto", "monero", "randomx-rs"]
 transactions = []
 mempool_proto = []
 base_node = []
@@ -30,8 +31,7 @@ tari_broadcast_channel = "^0.1"
 tari_pubsub = "^0.1"
 tari_shutdown = { version = "^0.0", path = "../../infrastructure/shutdown" }
 tari_mmr = { version = "^0.1", path = "../../base_layer/mmr", optional = true }
-
-randomx-rs = { version = "0.2.0", optional = true }
+randomx-rs = { version = "0.2.1", optional = true }
 monero = { version = "0.5", features= ["serde_support"], optional = true }
 bitflags = "1.0.4"
 chrono = { version = "0.4.6", features = ["serde"]}

--- a/base_layer/core/src/consensus/consensus_constants.rs
+++ b/base_layer/core/src/consensus/consensus_constants.rs
@@ -134,6 +134,7 @@ impl ConsensusConstants {
     // This is the min initial difficulty that can be requested for the pow
     pub fn min_pow_difficulty(&self, pow_algo: PowAlgorithm) -> Difficulty {
         match pow_algo {
+            #[cfg(feature = "monero_merge_mining")]
             PowAlgorithm::Monero => self.min_pow_difficulty.0,
             PowAlgorithm::Blake => self.min_pow_difficulty.1,
         }

--- a/base_layer/core/src/proof_of_work/mod.rs
+++ b/base_layer/core/src/proof_of_work/mod.rs
@@ -25,6 +25,7 @@ mod difficulty;
 mod error;
 mod median_timestamp;
 #[allow(clippy::enum_variant_names)]
+#[cfg(feature = "monero_merge_mining")]
 mod monero_rx;
 #[allow(clippy::module_inception)]
 mod proof_of_work;
@@ -39,6 +40,7 @@ pub use blake_pow::{blake_difficulty, blake_difficulty_with_hash};
 pub use difficulty::{Difficulty, DifficultyAdjustment};
 pub use error::{DifficultyAdjustmentError, PowError};
 pub use median_timestamp::get_median_timestamp;
+#[cfg(feature = "monero_merge_mining")]
 pub use monero_rx::monero_difficulty;
 pub use proof_of_work::{PowAlgorithm, ProofOfWork};
 pub use target_difficulty::get_target_difficulty;

--- a/base_layer/core/tests/chain_storage_tests/chain_backend.rs
+++ b/base_layer/core/tests/chain_storage_tests/chain_backend.rs
@@ -1377,7 +1377,72 @@ fn lmdb_fetch_last_header() {
     }
 }
 
+#[cfg(not(feature = "monero_merge_mining"))]
 fn fetch_target_difficulties<T: BlockchainBackend>(mut db: T) {
+    let mut header0 = BlockHeader::new(0);
+    header0.pow.pow_algo = PowAlgorithm::Blake;
+    header0.pow.target_difficulty = Difficulty::from(100);
+    let mut header1 = BlockHeader::from_previous(&header0);
+    header1.pow.pow_algo = PowAlgorithm::Blake;
+    header1.pow.target_difficulty = Difficulty::from(1000);
+    let mut header2 = BlockHeader::from_previous(&header1);
+    header2.pow.pow_algo = PowAlgorithm::Blake;
+    header2.pow.target_difficulty = Difficulty::from(2000);
+    let mut header3 = BlockHeader::from_previous(&header2);
+    header3.pow.pow_algo = PowAlgorithm::Blake;
+    header3.pow.target_difficulty = Difficulty::from(3000);
+    let mut header4 = BlockHeader::from_previous(&header3);
+    header4.pow.pow_algo = PowAlgorithm::Blake;
+    header4.pow.target_difficulty = Difficulty::from(4000);
+    let mut header5 = BlockHeader::from_previous(&header4);
+    header5.pow.pow_algo = PowAlgorithm::Blake;
+    header5.pow.target_difficulty = Difficulty::from(5000);
+    assert!(db.fetch_target_difficulties(PowAlgorithm::Blake, 5, 100).is_err());
+
+    let mut txn = DbTransaction::new();
+    txn.insert_header(header0.clone());
+    txn.insert_header(header1.clone());
+    txn.insert_header(header2.clone());
+    txn.insert_header(header3.clone());
+    txn.insert_header(header4.clone());
+    txn.insert_header(header5.clone());
+    txn.insert(DbKeyValuePair::Metadata(
+        MetadataKey::ChainHeight,
+        MetadataValue::ChainHeight(Some(header5.height)),
+    ));
+    assert!(db.write(txn).is_ok());
+
+    // Check block window constraint
+    let desired_targets: Vec<(EpochTime, Difficulty)> = vec![
+        (header2.timestamp, header2.pow.target_difficulty),
+        (header3.timestamp, header3.pow.target_difficulty),
+        (header4.timestamp, header4.pow.target_difficulty),
+    ];
+    assert_eq!(
+        db.fetch_target_difficulties(PowAlgorithm::Blake, header4.height, 3),
+        Ok(desired_targets)
+    );
+    let desired_targets: Vec<(EpochTime, Difficulty)> = vec![
+        (header1.timestamp, header1.pow.target_difficulty),
+        (header4.timestamp, header4.pow.target_difficulty),
+    ];
+    // Check search from tip to genesis block
+    let desired_targets: Vec<(EpochTime, Difficulty)> = vec![
+        (header0.timestamp, header0.pow.target_difficulty),
+        (header1.timestamp, header1.pow.target_difficulty),
+        (header2.timestamp, header2.pow.target_difficulty),
+        (header3.timestamp, header3.pow.target_difficulty),
+        (header4.timestamp, header4.pow.target_difficulty),
+        (header5.timestamp, header5.pow.target_difficulty),
+    ];
+    assert_eq!(
+        db.fetch_target_difficulties(PowAlgorithm::Blake, header5.height, 100),
+        Ok(desired_targets)
+    );
+}
+
+#[cfg(feature = "monero_merge_mining")]
+fn fetch_target_difficulties_merge_mine<T: BlockchainBackend>(mut db: T) {
     let mut header0 = BlockHeader::new(0);
     header0.pow.pow_algo = PowAlgorithm::Blake;
     header0.pow.target_difficulty = Difficulty::from(100);
@@ -1453,6 +1518,9 @@ fn fetch_target_difficulties<T: BlockchainBackend>(mut db: T) {
 #[test]
 fn memory_fetch_target_difficulties() {
     let db = MemoryDatabase::<HashDigest>::default();
+    #[cfg(feature = "monero_merge_mining")]
+    fetch_target_difficulties_merge_mine(db);
+    #[cfg(not(feature = "monero_merge_mining"))]
     fetch_target_difficulties(db);
 }
 
@@ -1464,6 +1532,9 @@ fn lmdb_fetch_target_difficulties() {
     // Perform test
     {
         let db = create_lmdb_database(&temp_path, MmrCacheConfig::default()).unwrap();
+        #[cfg(feature = "monero_merge_mining")]
+        fetch_target_difficulties_merge_mine(db);
+        #[cfg(not(feature = "monero_merge_mining"))]
         fetch_target_difficulties(db);
     }
 

--- a/base_layer/core/tests/median_timestamp.rs
+++ b/base_layer/core/tests/median_timestamp.rs
@@ -50,13 +50,27 @@ fn test_median_timestamp_with_height() {
     let network = Network::LocalNet;
     let consensus_manager = ConsensusManagerBuilder::new(network).build();
     let store = create_mem_db(&consensus_manager);
-    let pow_algos = vec![
-        PowAlgorithm::Blake, // GB default
-        PowAlgorithm::Monero,
-        PowAlgorithm::Blake,
-        PowAlgorithm::Monero,
-        PowAlgorithm::Blake,
-    ];
+    let pow_algos: Vec<PowAlgorithm>;
+    #[cfg(feature = "monero_merge_mining")]
+    {
+        pow_algos = vec![
+            PowAlgorithm::Blake, // GB default
+            PowAlgorithm::Monero,
+            PowAlgorithm::Blake,
+            PowAlgorithm::Monero,
+            PowAlgorithm::Blake,
+        ];
+    }
+    #[cfg(not(feature = "monero_merge_mining"))]
+    {
+        pow_algos = vec![
+            PowAlgorithm::Blake, // GB default
+            PowAlgorithm::Blake,
+            PowAlgorithm::Blake,
+            PowAlgorithm::Blake,
+            PowAlgorithm::Blake,
+        ];
+    }
     create_test_pow_blockchain(&store, pow_algos, &consensus_manager);
     let timestamp_count = 10;
 

--- a/base_layer/core/tests/node_service.rs
+++ b/base_layer/core/tests/node_service.rs
@@ -699,12 +699,14 @@ fn local_get_target_difficulty() {
     assert_eq!(node.blockchain_db.get_height(), Ok(Some(0)));
 
     runtime.block_on(async {
+        #[cfg(feature = "monero_merge_mining")]
         let monero_target_difficulty1 = node
             .local_nci
             .get_target_difficulty(PowAlgorithm::Monero)
             .await
             .unwrap();
         let blake_target_difficulty1 = node.local_nci.get_target_difficulty(PowAlgorithm::Blake).await.unwrap();
+        #[cfg(feature = "monero_merge_mining")]
         assert_ne!(monero_target_difficulty1, Difficulty::from(0));
         assert_ne!(blake_target_difficulty1, Difficulty::from(0));
 
@@ -717,13 +719,14 @@ fn local_get_target_difficulty() {
         block1.header.pow.pow_algo = PowAlgorithm::Blake;
         node.blockchain_db.add_block(block1).unwrap();
         assert_eq!(node.blockchain_db.get_height(), Ok(Some(1)));
-
+        #[cfg(feature = "monero_merge_mining")]
         let monero_target_difficulty2 = node
             .local_nci
             .get_target_difficulty(PowAlgorithm::Monero)
             .await
             .unwrap();
         let blake_target_difficulty2 = node.local_nci.get_target_difficulty(PowAlgorithm::Blake).await.unwrap();
+        #[cfg(feature = "monero_merge_mining")]
         assert!(monero_target_difficulty1 <= monero_target_difficulty2);
         assert!(blake_target_difficulty1 <= blake_target_difficulty2);
 


### PR DESCRIPTION
RandomX and Monero has been moved to the merge_mining_monero feature flag.
Updated randomx-rs version.

## Description
Modified tari_base_node:
grpc.rs

Modified base_layer:
Cargo.toml
consensus/consensus_constants.rs
proof_of_work/mod.rs
proof_of_work/monero_rx.rs
proof_of_work/proof_of_work.rs
chain_storage_tests/chain_backend.rs
tests/median_timestamp.rs
tests/node_service.rs
tests/target_difficulty.rs

## Motivation and Context

## How Has This Been Tested?
cargo test --all

## Types of changes
* [ ] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [x] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
* [x] I'm merging against the `development` branch.
* [x] I ran `cargo-fmt --all` before pushing.
* [x] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
