### PR TITLE
Added helpful message if tor is not started

### DIFF
--- a/applications/tari_base_node/src/builder.rs
+++ b/applications/tari_base_node/src/builder.rs
@@ -982,7 +982,7 @@ async fn setup_base_node_comms(
     };
     let (comms, dht) = initialize_comms(comms_config, publisher)
         .await
-        .map_err(|e| format!("Could not create comms layer: {:?}", e))?;
+        .map_err(|e| e.to_friendly_string())?;
 
     // Save final node identity after comms has initialized. This is required because the public_address can be changed
     // by comms during initialization when using tor.

--- a/base_layer/p2p/src/initialization.rs
+++ b/base_layer/p2p/src/initialization.rs
@@ -56,6 +56,24 @@ pub enum CommsInitializationError {
     InvalidLivenessCidrs(String),
 }
 
+impl CommsInitializationError {
+    pub fn to_friendly_string(&self) -> String {
+        // Add any helpful user-facing messages here
+        match self {
+            CommsInitializationError::HiddenServiceBuilderError(
+                tor::HiddenServiceBuilderError::HiddenServiceControllerError(
+                    tor::HiddenServiceControllerError::TorControlPortOffline,
+                ),
+            ) => r#"Unable to connect to the Tor control port. 
+Please check that you have the Tor proxy running and that access to the Tor control port is turned on.
+If you are unsure of what to do, use the following command to start the Tor proxy:
+tor --allow-missing-torrc --ignore-missing-torrc --clientonly 1 --socksport 9050 --controlport 127.0.0.1:9051 --log "notice stdout" --clientuseipv6 1"#
+                .to_string(),
+            err => format!("Failed to initialize comms: {:?}", err),
+        }
+    }
+}
+
 /// Configuration for a comms node
 #[derive(Clone)]
 pub struct CommsConfig {

--- a/comms/src/tor/hidden_service/mod.rs
+++ b/comms/src/tor/hidden_service/mod.rs
@@ -24,6 +24,7 @@ mod builder;
 pub use builder::{HiddenServiceBuilder, HiddenServiceBuilderError, HsFlags};
 
 mod controller;
+pub use controller::HiddenServiceControllerError;
 
 use crate::{
     multiaddr::Multiaddr,

--- a/comms/src/tor/mod.rs
+++ b/comms/src/tor/mod.rs
@@ -42,4 +42,11 @@ pub use control_client::{
 };
 
 mod hidden_service;
-pub use hidden_service::{HiddenService, HiddenServiceBuilder, HiddenServiceBuilderError, HsFlags, TorIdentity};
+pub use hidden_service::{
+    HiddenService,
+    HiddenServiceBuilder,
+    HiddenServiceBuilderError,
+    HiddenServiceControllerError,
+    HsFlags,
+    TorIdentity,
+};


### PR DESCRIPTION
```
 Unable to connect to the Tor control port.
 Please check that you have the Tor proxy running and that access to the
 Tor control port is turned on.
 If you are unsure of what to do, use the following command to start the
 Tor proxy:
 tor --allow-missing-torrc --ignore-missing-torrc --clientonly 1 --socksport 9050 --controlport 127.0.0.1:9051 --log "notice stdout" --clientuseipv6 1
```
