### PR TITLE
Temporary banning of non-responsive nodes.

### DIFF
--- a/base_layer/core/src/base_node/states/waiting.rs
+++ b/base_layer/core/src/base_node/states/waiting.rs
@@ -54,7 +54,7 @@ impl Waiting {
 impl From<BlockSyncStrategy> for Waiting {
     fn from(_: BlockSyncStrategy) -> Self {
         Waiting {
-            timeout: Duration::from_secs(5 * 60),
+            timeout: Duration::from_secs(1 * 60),
         }
     }
 }


### PR DESCRIPTION
## Description
- These changes will enable a temporary short term ban for peers that are providing chain metadata but do not respond to header and block requests. This will allow a local node to sync with remote nodes that are responding when a bad chain leader does not respond to requests.
- Also, fixed an issue where the incorrect local height is compared to the network chain tip when block syncing is determining if a the network chain has been extended.
- Added that peers will be banned that previously provided valid heights and then changed to invalid height.

## Motivation and Context
Allows a node to sync with responsive nodes when some tip leaders do not respond but provide chain metadata.

## How Has This Been Tested?
No tests were added.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [x] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch.
* [x] I ran `cargo-fmt --all` before pushing.
* [x] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
