### PR TITLE
Don't require a network for create-id and init

### DIFF
--- a/applications/tari_base_node/src/main.rs
+++ b/applications/tari_base_node/src/main.rs
@@ -168,20 +168,6 @@ fn main_inner() -> Result<(), ExitCodes> {
         PeerFeatures::COMMUNICATION_NODE,
     )?;
 
-    // Build, node, build!
-    let shutdown = Shutdown::new();
-    let ctx = rt
-        .block_on(builder::configure_and_initialize_node(
-            &node_config,
-            node_identity,
-            wallet_identity,
-            shutdown.to_signal(),
-        ))
-        .map_err(|err| {
-            error!(target: LOG_TARGET, "{}", err);
-            ExitCodes::UnknownError
-        })?;
-
     // Exit if create_id or init arguments were run
     if bootstrap.create_id {
         info!(
@@ -196,6 +182,20 @@ fn main_inner() -> Result<(), ExitCodes> {
         info!(target: LOG_TARGET, "Default configuration created. Done.");
         return Ok(());
     }
+
+    // Build, node, build!
+    let shutdown = Shutdown::new();
+    let ctx = rt
+        .block_on(builder::configure_and_initialize_node(
+            &node_config,
+            node_identity,
+            wallet_identity,
+            shutdown.to_signal(),
+        ))
+        .map_err(|err| {
+            error!(target: LOG_TARGET, "{}", err);
+            ExitCodes::UnknownError
+        })?;
 
     // Run, node, run!
     let parser = Parser::new(rt.handle().clone(), &ctx, &node_config);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
You cannot run `tari_base_node --create-id --init` without tor running, even though there is no requirement for the network to be live.
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
When automating the docker creation process I kept requiring tor just to set up the config files etc.
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Ran `cargo test`
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [x] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch.
* [x] I ran `cargo-fmt --all` before pushing.
* [x] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
