### PR TITLE
Add FromStr for MicroTari

### DIFF
--- a/applications/tari_base_node/src/parser.rs
+++ b/applications/tari_base_node/src/parser.rs
@@ -1237,12 +1237,12 @@ impl Parser {
 
     /// Function to process the send transaction command
     fn process_send_tari<'a, I: Iterator<Item = &'a str>>(&mut self, mut args: I) {
-        let amount = args.next().and_then(|v| v.parse::<u64>().ok());
+        let amount = args.next().and_then(|v| MicroTari::from_str(v).ok());
         if amount.is_none() {
             println!("Please enter a valid amount of tari");
             return;
         }
-        let amount: MicroTari = amount.unwrap().into();
+        let amount: MicroTari = amount.unwrap();
 
         let key = match args.next() {
             Some(k) => k.to_string(),

--- a/base_layer/core/src/transactions/tari_amount.rs
+++ b/base_layer/core/src/transactions/tari_amount.rs
@@ -30,6 +30,7 @@ use std::{
     ops::{Add, Mul},
 };
 use tari_crypto::ristretto::RistrettoSecretKey;
+use thiserror::Error as ThisError;
 
 /// All calculations using Tari amounts should use these newtypes to prevent bugs related to rounding errors, unit
 /// conversion errors etc.
@@ -44,6 +45,11 @@ use tari_crypto::ristretto::RistrettoSecretKey;
 #[derive(Copy, Default, Clone, Debug, Eq, Hash, PartialEq, PartialOrd, Ord, Serialize, Deserialize)]
 pub struct MicroTari(pub u64);
 
+#[derive(Debug, Clone, ThisError, PartialEq)]
+pub enum MicroTariError {
+    #[error("Failed to parse value:{0}")]
+    ParseError(String),
+}
 /// A convenience constant that makes it easier to define Tari amounts.
 /// ```edition2018
 ///   use tari_core::transactions::tari_amount::{MicroTari, uT, T};
@@ -98,6 +104,48 @@ impl Display for MicroTari {
 impl From<MicroTari> for u64 {
     fn from(v: MicroTari) -> Self {
         v.0
+    }
+}
+
+impl std::str::FromStr for MicroTari {
+    type Err = MicroTariError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        // Is this Tari or MicroTari
+        let processed = s.replace(",", "").replace(" ", "").to_ascii_lowercase();
+        let is_micro_tari = if processed.ends_with("ut") || processed.ends_with("µt") {
+            true
+        } else if processed.ends_with("t") {
+            false
+        } else {
+            true
+        };
+
+        // Avoid using f64 if we an
+        let processed = processed.replace("ut", "").replace("µt", "").replace("t", "");
+        if is_micro_tari {
+            processed
+                .parse::<u64>()
+                .map(|v| MicroTari::from(v.max(0)))
+                .map_err(|e| MicroTariError::ParseError(e.to_string()))
+        } else {
+            processed
+                .parse::<f64>()
+                .map_err(|e| MicroTariError::ParseError(e.to_string()))
+                .map(|v| {
+                    if v < 0.0 {
+                        Err(MicroTariError::ParseError("value cannot be negative".to_string()))
+                    } else {
+                        Ok(MicroTari::from(Tari::from(v.max(0.0))))
+                    }
+                })?
+        }
+    }
+}
+
+impl From<Tari> for MicroTari {
+    fn from(v: Tari) -> Self {
+        MicroTari((v.0 * 1e6) as u64)
     }
 }
 
@@ -201,8 +249,8 @@ impl From<MicroTari> for Tari {
 
 #[cfg(test)]
 mod test {
-    use crate::transactions::tari_amount::{MicroTari, Tari};
-
+    use super::{MicroTari, Tari};
+    use std::str::FromStr;
     #[test]
     fn micro_tari_arithmetic() {
         let mut a = MicroTari::from(500);
@@ -232,6 +280,24 @@ mod test {
         assert_eq!(s, "99,100,000 µT");
         let s = format!("{}", MicroTari::from(1_000_000_000).formatted());
         assert_eq!(s, "1,000,000,000 µT");
+    }
+
+    #[test]
+    fn micro_tari_from_string() {
+        let micro_tari = MicroTari::from(99_100_000);
+        let s = format!("{}", micro_tari.formatted());
+        assert_eq!(micro_tari, MicroTari::from_str(s.as_str()).unwrap());
+        let tari = Tari::from(1.12);
+        let s = format!("{}", tari.formatted());
+        assert_eq!(MicroTari::from(tari), MicroTari::from_str(s.as_str()).unwrap());
+        assert_eq!(MicroTari::from(5_000_000), MicroTari::from_str("5000000").unwrap());
+        assert_eq!(MicroTari::from(5_000_000), MicroTari::from_str("5,000,000").unwrap());
+        assert_eq!(MicroTari::from(5_000_000), MicroTari::from_str("5,000,000 uT").unwrap());
+        assert_eq!(MicroTari::from(5_000_000), MicroTari::from_str("5000000 uT").unwrap());
+        assert_eq!(MicroTari::from(5_000_000), MicroTari::from_str("5 T").unwrap());
+        assert!(MicroTari::from_str("-5 T").is_err());
+        assert!(MicroTari::from_str("-5 uT").is_err());
+        assert!(MicroTari::from_str("5garbage T").is_err());
     }
 
     #[test]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
** I Haven't been able to send any actual tXTR because I don't have any **
## Description
<!--- Describe your changes in detail -->
When sending tXTR using the `send-tari` command it's unintuitive to have to send `uT` when your balance is rendered in `T`.
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This allows the `send-tari` command to accept a string of tXTR value and will attempt to parse it to `MicroTari` valid strings include:
```
5000000
5,000,000
5,000,000 µT
5,000,000 uT
5 T
5,000,000ut
5t
```
Any negative number will error for `T` and `uT`
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I have added unit tests for the conversion
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch.
* [x] I ran `cargo-fmt --all` before pushing.
* [x] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
