### PR TITLE
Fix few issues from install section of readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,11 +15,6 @@ You can check that the binaries match the hash by running
 
     sha256sum path/to/tari_base_node
 
-### Running a node in Docker
-
-If you have docker on your machine, you can run a prebuilt node using one of the docker images on
-[quay.io](https://quay.io/user/tarilabs).
-
 ### Building from source (Ubuntu 18.04)
 
 To build the Tari codebase from source, there are a few dependencies you need to have installed.
@@ -67,10 +62,14 @@ A successful build should output something as follows
     Finished release [optimized] target(s) in 12m 24s
 ```
 
+Compiled executable can be found by following path:
+
+    ./target/release/tari_base_node
+
 Alternatively, cargo can build and install the executable into `~/.cargo/bin`, so it will be executable from anywhere 
 on your system.
 
-    cargo install tari_base_node
+    cargo install --path=applications/tari_base_node --force
 
 ### Building from source (Windows 10)
 
@@ -163,10 +162,14 @@ A successful build should output something as follows
     Finished release [optimized] target(s) in 12m 24s
 ```
 
-Alternatively, cargo can build and install the executable into `%USERPROFILE%\.cargo\bin`, so it will be executable from 
+Compiled executable can be found by following path:
+
+    ./target/release/tari_base_node.exe
+
+Alternatively, cargo can build and install the executable into `%USERPROFILE%\.cargo\bin`, so it will be executable from
 anywhere on your system.
 
-    cargo install tari_base_node
+    cargo install --path=applications/tari_base_node --force
 
 ### Running the base node
 


### PR DESCRIPTION
## Description
- Docker image on quay.io is very old, hence I removed the section
- Specified where to look for compiled executable, for not rust folks
- Changed `cargo install` to install from the local path, rather than from crates. There is outdated version on crates.

## Motivation and Context
So that new people do not get trapped with same issues

## How Has This Been Tested?
New command line is working on OSX, same command line should be working on windows but I did not check that

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [X] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [X] I'm merging against the `development` branch.
* [ ] I ran `cargo-fmt --all` before pushing.
* [ ] I have squashed my commits into a single commit.
* [X] My change requires a change to the documentation.
* [X] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
