### PR TITLE
Improves broadcast and propagation strategies

### DIFF
--- a/base_layer/core/src/base_node/comms_interface/inbound_handlers.rs
+++ b/base_layer/core/src/base_node/comms_interface/inbound_handlers.rs
@@ -47,7 +47,7 @@ use std::{
 };
 use strum_macros::Display;
 use tari_broadcast_channel::Publisher;
-use tari_comms::types::CommsPublicKey;
+use tari_comms::peer_manager::NodeId;
 use tari_crypto::tari_utilities::{hash::Hashable, hex::Hex};
 use tokio::sync::RwLock;
 
@@ -274,7 +274,7 @@ where T: BlockchainBackend + 'static
     pub async fn handle_block(
         &mut self,
         block_context: &(Block, Broadcast),
-        source_peer: Option<CommsPublicKey>,
+        source_peer: Option<NodeId>,
     ) -> Result<(), CommsInterfaceError>
     {
         let (block, broadcast) = block_context;

--- a/base_layer/core/src/base_node/comms_interface/outbound_interface.rs
+++ b/base_layer/core/src/base_node/comms_interface/outbound_interface.rs
@@ -31,7 +31,7 @@ use crate::{
 };
 use futures::channel::mpsc::UnboundedSender;
 use log::*;
-use tari_comms::{peer_manager::NodeId, types::CommsPublicKey};
+use tari_comms::peer_manager::NodeId;
 use tari_service_framework::reply_channel::SenderService;
 use tower_service::Service;
 
@@ -41,7 +41,7 @@ pub const LOG_TARGET: &str = "c::bn::comms_interface::outbound_interface";
 #[derive(Clone)]
 pub struct OutboundNodeCommsInterface {
     request_sender: SenderService<(NodeCommsRequest, Option<NodeId>), Result<NodeCommsResponse, CommsInterfaceError>>,
-    block_sender: UnboundedSender<(Block, Vec<CommsPublicKey>)>,
+    block_sender: UnboundedSender<(Block, Vec<NodeId>)>,
 }
 
 impl OutboundNodeCommsInterface {
@@ -51,7 +51,7 @@ impl OutboundNodeCommsInterface {
             (NodeCommsRequest, Option<NodeId>),
             Result<NodeCommsResponse, CommsInterfaceError>,
         >,
-        block_sender: UnboundedSender<(Block, Vec<CommsPublicKey>)>,
+        block_sender: UnboundedSender<(Block, Vec<NodeId>)>,
     ) -> Self
     {
         Self {
@@ -270,7 +270,7 @@ impl OutboundNodeCommsInterface {
     pub async fn propagate_block(
         &mut self,
         block: Block,
-        exclude_peers: Vec<CommsPublicKey>,
+        exclude_peers: Vec<NodeId>,
     ) -> Result<(), CommsInterfaceError>
     {
         self.block_sender

--- a/base_layer/core/src/base_node/service/service.rs
+++ b/base_layer/core/src/base_node/service/service.rs
@@ -53,16 +53,13 @@ use futures::{
 use log::*;
 use rand::rngs::OsRng;
 use std::{convert::TryInto, time::Duration};
-use tari_comms::{peer_manager::NodeId, types::CommsPublicKey};
+use tari_comms::peer_manager::NodeId;
 use tari_comms_dht::{
     domain_message::OutboundDomainMessage,
     envelope::NodeDestination,
     outbound::{OutboundEncryption, OutboundMessageRequester, SendMessageParams},
 };
-use tari_crypto::{
-    ristretto::RistrettoPublicKey,
-    tari_utilities::{hex::Hex, Hashable},
-};
+use tari_crypto::tari_utilities::{hex::Hex, Hashable};
 use tari_p2p::{domain_message::DomainMessage, tari_message::TariMessageType};
 use tari_service_framework::RequestContext;
 use tokio::task;
@@ -90,7 +87,7 @@ impl Default for BaseNodeServiceConfig {
 /// A convenience struct to hold all the BaseNode streams
 pub struct BaseNodeStreams<SOutReq, SInReq, SInRes, SBlockIn, SLocalReq, SLocalBlock> {
     outbound_request_stream: SOutReq,
-    outbound_block_stream: UnboundedReceiver<(Block, Vec<CommsPublicKey>)>,
+    outbound_block_stream: UnboundedReceiver<(Block, Vec<NodeId>)>,
     inbound_request_stream: SInReq,
     inbound_response_stream: SInRes,
     inbound_block_stream: SBlockIn,
@@ -112,7 +109,7 @@ where
 {
     pub fn new(
         outbound_request_stream: SOutReq,
-        outbound_block_stream: UnboundedReceiver<(Block, Vec<CommsPublicKey>)>,
+        outbound_block_stream: UnboundedReceiver<(Block, Vec<NodeId>)>,
         inbound_request_stream: SInReq,
         inbound_response_stream: SInRes,
         inbound_block_stream: SBlockIn,
@@ -205,8 +202,8 @@ where B: BlockchainBackend + 'static
                 },
 
                 // Outbound block messages from the OutboundNodeCommsInterface
-                outbound_block_context = outbound_block_stream.select_next_some() => {
-                    self.spawn_handle_outbound_block(outbound_block_context);
+                (block, excluded_peers) = outbound_block_stream.select_next_some() => {
+                    self.spawn_handle_outbound_block(block, excluded_peers);
                 },
 
                 // Incoming request messages from the Comms layer
@@ -282,10 +279,9 @@ where B: BlockchainBackend + 'static
         });
     }
 
-    fn spawn_handle_outbound_block(&self, block_context: (Block, Vec<RistrettoPublicKey>)) {
+    fn spawn_handle_outbound_block(&self, block: Block, excluded_peers: Vec<NodeId>) {
         let outbound_message_service = self.outbound_message_service.clone();
         task::spawn(async move {
-            let (block, excluded_peers) = block_context;
             let _ = handle_outbound_block(outbound_message_service, block, excluded_peers)
                 .await
                 .or_else(|err| {
@@ -513,7 +509,7 @@ async fn handle_outbound_request(
 async fn handle_outbound_block(
     mut outbound_message_service: OutboundMessageRequester,
     block: Block,
-    exclude_peers: Vec<CommsPublicKey>,
+    exclude_peers: Vec<NodeId>,
 ) -> Result<(), CommsInterfaceError>
 {
     outbound_message_service
@@ -579,7 +575,7 @@ async fn handle_incoming_block<B: BlockchainBackend + 'static>(
         source_peer.public_key
     );
     inbound_nch
-        .handle_block(&(inner, true.into()), Some(source_peer.public_key))
+        .handle_block(&(inner, true.into()), Some(source_peer.node_id))
         .await?;
 
     // TODO - retain peer info for stats and potential banning for sending invalid blocks

--- a/base_layer/core/src/mempool/service/inbound_handlers.rs
+++ b/base_layer/core/src/mempool/service/inbound_handlers.rs
@@ -36,7 +36,7 @@ use futures::SinkExt;
 use log::*;
 use std::sync::Arc;
 use tari_broadcast_channel::Publisher;
-use tari_comms::types::CommsPublicKey;
+use tari_comms::peer_manager::NodeId;
 use tari_crypto::tari_utilities::hex::Hex;
 use tokio::sync::RwLock;
 
@@ -97,7 +97,7 @@ where T: BlockchainBackend + 'static
     pub async fn handle_transaction(
         &mut self,
         tx: &Transaction,
-        source_peer: Option<CommsPublicKey>,
+        source_peer: Option<NodeId>,
     ) -> Result<(), MempoolServiceError>
     {
         debug!(
@@ -117,7 +117,7 @@ where T: BlockchainBackend + 'static
     async fn submit_transaction(
         &mut self,
         tx: &Transaction,
-        exclude_peers: Vec<CommsPublicKey>,
+        exclude_peers: Vec<NodeId>,
     ) -> Result<TxStorageResponse, MempoolServiceError>
     {
         trace!(target: LOG_TARGET, "Transaction: {}.", tx);

--- a/base_layer/core/src/mempool/service/outbound_interface.rs
+++ b/base_layer/core/src/mempool/service/outbound_interface.rs
@@ -30,7 +30,7 @@ use crate::{
 };
 use futures::channel::mpsc::UnboundedSender;
 use log::*;
-use tari_comms::types::CommsPublicKey;
+use tari_comms::peer_manager::NodeId;
 use tari_service_framework::reply_channel::SenderService;
 use tower_service::Service;
 pub const LOG_TARGET: &str = "c::mp::service::outbound_interface";
@@ -40,14 +40,14 @@ pub const LOG_TARGET: &str = "c::mp::service::outbound_interface";
 #[derive(Clone)]
 pub struct OutboundMempoolServiceInterface {
     request_sender: SenderService<MempoolRequest, Result<MempoolResponse, MempoolServiceError>>,
-    tx_sender: UnboundedSender<(Transaction, Vec<CommsPublicKey>)>,
+    tx_sender: UnboundedSender<(Transaction, Vec<NodeId>)>,
 }
 
 impl OutboundMempoolServiceInterface {
     /// Construct a new OutboundMempoolServiceInterface with the specified SenderService.
     pub fn new(
         request_sender: SenderService<MempoolRequest, Result<MempoolResponse, MempoolServiceError>>,
-        tx_sender: UnboundedSender<(Transaction, Vec<CommsPublicKey>)>,
+        tx_sender: UnboundedSender<(Transaction, Vec<NodeId>)>,
     ) -> Self
     {
         Self {
@@ -70,7 +70,7 @@ impl OutboundMempoolServiceInterface {
     pub async fn propagate_tx(
         &mut self,
         transaction: Transaction,
-        exclude_peers: Vec<CommsPublicKey>,
+        exclude_peers: Vec<NodeId>,
     ) -> Result<(), MempoolServiceError>
     {
         self.tx_sender

--- a/base_layer/core/src/mempool/service/service.rs
+++ b/base_layer/core/src/mempool/service/service.rs
@@ -49,13 +49,13 @@ use log::*;
 use rand::rngs::OsRng;
 use std::{convert::TryInto, sync::Arc, time::Duration};
 use tari_broadcast_channel::Subscriber;
-use tari_comms::types::CommsPublicKey;
+use tari_comms::peer_manager::NodeId;
 use tari_comms_dht::{
     domain_message::OutboundDomainMessage,
     envelope::NodeDestination,
     outbound::{OutboundEncryption, OutboundMessageRequester},
 };
-use tari_crypto::{ristretto::RistrettoPublicKey, tari_utilities::hex::Hex};
+use tari_crypto::tari_utilities::hex::Hex;
 use tari_p2p::{domain_message::DomainMessage, tari_message::TariMessageType};
 use tari_service_framework::RequestContext;
 use tokio::task;
@@ -65,7 +65,7 @@ const LOG_TARGET: &str = "c::mempool::service::service";
 /// A convenience struct to hold all the Mempool service streams
 pub struct MempoolStreams<SOutReq, SInReq, SInRes, STxIn, SLocalReq> {
     outbound_request_stream: SOutReq,
-    outbound_tx_stream: UnboundedReceiver<(Transaction, Vec<CommsPublicKey>)>,
+    outbound_tx_stream: UnboundedReceiver<(Transaction, Vec<NodeId>)>,
     inbound_request_stream: SInReq,
     inbound_response_stream: SInRes,
     inbound_transaction_stream: STxIn,
@@ -83,7 +83,7 @@ where
 {
     pub fn new(
         outbound_request_stream: SOutReq,
-        outbound_tx_stream: UnboundedReceiver<(Transaction, Vec<CommsPublicKey>)>,
+        outbound_tx_stream: UnboundedReceiver<(Transaction, Vec<NodeId>)>,
         inbound_request_stream: SInReq,
         inbound_response_stream: SInRes,
         inbound_transaction_stream: STxIn,
@@ -173,8 +173,8 @@ where B: BlockchainBackend + 'static
                 },
 
                 // Outbound tx messages from the OutboundMempoolServiceInterface
-                outbound_tx_context = outbound_tx_stream.select_next_some() => {
-                    self.spawn_handle_outbound_tx(outbound_tx_context);
+                (txn, excluded_peers) = outbound_tx_stream.select_next_some() => {
+                    self.spawn_handle_outbound_tx(txn, excluded_peers);
                 },
 
                 // Incoming request messages from the Comms layer
@@ -246,10 +246,9 @@ where B: BlockchainBackend + 'static
         });
     }
 
-    fn spawn_handle_outbound_tx(&self, tx_context: (Transaction, Vec<RistrettoPublicKey>)) {
+    fn spawn_handle_outbound_tx(&self, tx: Transaction, excluded_peers: Vec<NodeId>) {
         let outbound_message_service = self.outbound_message_service.clone();
         task::spawn(async move {
-            let (tx, excluded_peers) = tx_context;
             let _ = handle_outbound_tx(outbound_message_service, tx, excluded_peers)
                 .await
                 .or_else(|err| {
@@ -482,7 +481,7 @@ async fn handle_incoming_tx<B: BlockchainBackend + 'static>(
         source_peer.public_key
     );
     inbound_handlers
-        .handle_transaction(&inner, Some(source_peer.public_key))
+        .handle_transaction(&inner, Some(source_peer.node_id))
         .await?;
 
     Ok(())
@@ -510,7 +509,7 @@ async fn handle_request_timeout(
 async fn handle_outbound_tx(
     mut outbound_message_service: OutboundMessageRequester,
     tx: Transaction,
-    exclude_peers: Vec<CommsPublicKey>,
+    exclude_peers: Vec<NodeId>,
 ) -> Result<(), MempoolServiceError>
 {
     outbound_message_service
@@ -535,7 +534,6 @@ async fn handle_block_event<B: BlockchainBackend + 'static>(
 ) -> Result<(), MempoolServiceError>
 {
     inbound_handlers.handle_block_event(block_event).await?;
-
     Ok(())
 }
 

--- a/base_layer/p2p/src/services/liveness/service.rs
+++ b/base_layer/p2p/src/services/liveness/service.rs
@@ -362,7 +362,7 @@ where
                 .pop()
             {
                 self.random_peers.remove(node_id);
-                self.random_peers.push(peer.node_id)
+                self.random_peers.push(peer.node_id.clone())
             }
         }
 
@@ -435,7 +435,7 @@ where
         if random_peers.is_empty() {
             warn!(target: LOG_TARGET, "No random peers selected for this round of pings");
         }
-        let new_node_ids = random_peers.into_iter().map(|p| p.node_id).collect::<Vec<_>>();
+        let new_node_ids = random_peers.into_iter().map(|p| p.node_id.clone()).collect::<Vec<_>>();
         let removed = new_node_ids
             .iter()
             .filter(|n| self.random_peers.contains(*n))
@@ -455,7 +455,7 @@ where
     async fn refresh_neighbour_pool(&mut self) -> Result<(), LivenessError> {
         let neighbours = self
             .dht_requester
-            .select_peers(BroadcastStrategy::Neighbours(Vec::new(), false))
+            .select_peers(BroadcastStrategy::Neighbours(Vec::new()))
             .await?;
 
         debug!(
@@ -464,7 +464,7 @@ where
             neighbours.len()
         );
         self.neighbours
-            .set_node_ids(neighbours.into_iter().map(|p| p.node_id).collect());
+            .set_node_ids(neighbours.into_iter().map(|p| p.node_id.clone()).collect());
 
         Ok(())
     }
@@ -749,7 +749,7 @@ mod test {
             while let Some(req) = dht_rx.next().await {
                 match req {
                     SelectPeers(_, reply_tx) => {
-                        reply_tx.send(vec![peer.clone()]).unwrap();
+                        reply_tx.send(vec![Arc::new(peer.clone())]).unwrap();
                     },
                     _ => panic!("unexpected request {:?}", req),
                 }

--- a/base_layer/wallet/src/transaction_service/protocols/transaction_send_protocol.rs
+++ b/base_layer/wallet/src/transaction_service/protocols/transaction_send_protocol.rs
@@ -325,7 +325,7 @@ where TBackend: TransactionBackend + Clone + 'static
         match self
             .resources
             .outbound_message_service
-            .propagate(
+            .broadcast(
                 NodeDestination::NodeId(Box::new(NodeId::from_key(&self.dest_pubkey).map_err(|e| {
                     TransactionServiceProtocolError::new(self.id, TransactionServiceError::from(e))
                 })?)),
@@ -461,7 +461,7 @@ where TBackend: TransactionBackend + Clone + 'static
         match self
             .resources
             .outbound_message_service
-            .propagate(
+            .broadcast(
                 NodeDestination::NodeId(Box::new(NodeId::from_key(&self.dest_pubkey).map_err(|e| {
                     TransactionServiceProtocolError::new(self.id, TransactionServiceError::from(e))
                 })?)),

--- a/base_layer/wallet/src/transaction_service/service.rs
+++ b/base_layer/wallet/src/transaction_service/service.rs
@@ -750,7 +750,7 @@ where
                 .await?;
 
             self.outbound_message_service
-                .propagate(
+                .broadcast(
                     NodeDestination::NodeId(Box::new(NodeId::from_key(&source_pubkey)?)),
                     OutboundEncryption::EncryptFor(Box::new(source_pubkey.clone())),
                     vec![],

--- a/comms/dht/src/config.rs
+++ b/comms/dht/src/config.rs
@@ -31,6 +31,8 @@ pub const SAF_LOW_PRIORITY_MSG_STORAGE_TTL: Duration = Duration::from_secs(6 * 6
 pub const SAF_HIGH_PRIORITY_MSG_STORAGE_TTL: Duration = Duration::from_secs(3 * 24 * 60 * 60); // 3 days
 /// The default number of peer nodes that a message has to be closer to, to be considered a neighbour
 pub const DEFAULT_NUM_NEIGHBOURING_NODES: usize = 10;
+/// The default number of randomly-selected peer nodes to be included in propagation messages
+pub const DEFAULT_NUM_RANDOM_PROPAGATION_NODES: usize = 2;
 
 #[derive(Debug, Clone)]
 pub struct DhtConfig {
@@ -42,6 +44,10 @@ pub struct DhtConfig {
     /// The maximum number of peer nodes that a message has to be closer to, to be considered a neighbour
     /// Default: 10
     pub num_neighbouring_nodes: usize,
+    /// The maximum number of randomly-selected peer nodes that will be included in propagation
+    /// messages. Only applies to `BroadcastStrategy::Propagate`.
+    /// Default: 2
+    pub num_random_propagation_nodes: usize,
     /// A request to retrieve stored messages will be ignored if the requesting node is
     /// not within one of this nodes _n_ closest nodes.
     /// Default 8
@@ -109,6 +115,7 @@ impl Default for DhtConfig {
     fn default() -> Self {
         Self {
             num_neighbouring_nodes: DEFAULT_NUM_NEIGHBOURING_NODES,
+            num_random_propagation_nodes: DEFAULT_NUM_RANDOM_PROPAGATION_NODES,
             saf_num_closest_nodes: 10,
             saf_max_returned_messages: 50,
             outbound_buffer_size: 20,

--- a/comms/dht/src/dht.rs
+++ b/comms/dht/src/dht.rs
@@ -139,6 +139,7 @@ impl Dht {
             conn,
             Arc::clone(&self.node_identity),
             Arc::clone(&self.peer_manager),
+            self.connection_manager.clone(),
             self.outbound_requester(),
             request_receiver,
             shutdown_signal,
@@ -234,7 +235,6 @@ impl Dht {
             )))
             .layer(inbound::DecryptionLayer::new(Arc::clone(&self.node_identity)))
             .layer(store_forward::ForwardLayer::new(
-                Arc::clone(&self.peer_manager),
                 self.outbound_requester(),
                 self.node_identity.features().contains(PeerFeatures::DHT_STORE_FORWARD),
             ))
@@ -358,7 +358,7 @@ mod test {
     async fn stack_unencrypted() {
         let node_identity = make_node_identity();
         let peer_manager = make_peer_manager();
-        let (connection_manager, _) = create_connection_manager_mock(1);
+        let (connection_manager, _) = create_connection_manager_mock();
 
         // Dummy out channel, we are not testing outbound here.
         let (out_tx, _) = mpsc::channel(10);
@@ -400,7 +400,7 @@ mod test {
     async fn stack_encrypted() {
         let node_identity = make_node_identity();
         let peer_manager = make_peer_manager();
-        let (connection_manager, _) = create_connection_manager_mock(1);
+        let (connection_manager, _) = create_connection_manager_mock();
 
         // Dummy out channel, we are not testing outbound here.
         let (out_tx, _out_rx) = mpsc::channel(10);
@@ -445,7 +445,7 @@ mod test {
 
         let shutdown = Shutdown::new();
 
-        let (connection_manager, _) = create_connection_manager_mock(1);
+        let (connection_manager, _) = create_connection_manager_mock();
         let (next_service_tx, mut next_service_rx) = mpsc::channel(10);
         let (oms_requester, oms_mock) = create_outbound_service_mock(1);
 
@@ -493,7 +493,7 @@ mod test {
     async fn stack_filter_saf_message() {
         let node_identity = make_client_identity();
         let peer_manager = make_peer_manager();
-        let (connection_manager, _) = create_connection_manager_mock(1);
+        let (connection_manager, _) = create_connection_manager_mock();
 
         // Dummy out channel, we are not testing outbound here.
         let (out_tx, _) = mpsc::channel(10);

--- a/comms/dht/src/discovery/service.rs
+++ b/comms/dht/src/discovery/service.rs
@@ -440,7 +440,7 @@ impl DhtDiscoveryService {
             .outbound_requester
             .send_message_no_header(
                 SendMessageParams::new()
-                    .neighbours_include_clients(Vec::new())
+                    .broadcast(Vec::new())
                     .with_destination(destination)
                     .with_encryption(OutboundEncryption::EncryptFor(dest_public_key))
                     .with_dht_message_type(DhtMessageType::Discovery)
@@ -502,7 +502,7 @@ mod test {
         let oms_mock_state = outbound_mock.get_state();
         task::spawn(outbound_mock.run());
 
-        let (connection_manager, _) = create_connection_manager_mock(1);
+        let (connection_manager, _) = create_connection_manager_mock();
         let (sender, receiver) = mpsc::channel(10);
         // Requester which timeout instantly
         let mut requester = DhtDiscoveryRequester::new(sender, Duration::from_millis(1));

--- a/comms/dht/src/inbound/dht_handler/task.rs
+++ b/comms/dht/src/inbound/dht_handler/task.rs
@@ -188,6 +188,8 @@ where S: Service<DecryptedDhtMessage, Response = (), Error = PipelineError>
             return Ok(());
         }
 
+        let origin_node_id = origin_peer.node_id;
+
         // Send a join request back to the origin peer of the join request if:
         // - this join request was not sent directly from the origin peer but was forwarded (from the source peer), and
         // - that peer is from the same region of network.
@@ -197,7 +199,7 @@ where S: Service<DecryptedDhtMessage, Response = (), Error = PipelineError>
         if source_peer.public_key != origin_peer.public_key &&
             self.peer_manager
                 .in_network_region(
-                    &origin_peer.node_id,
+                    &origin_node_id,
                     self.node_identity.node_id(),
                     self.config.num_neighbouring_nodes,
                 )
@@ -236,9 +238,9 @@ where S: Service<DecryptedDhtMessage, Response = (), Error = PipelineError>
                 .send_raw(
                     SendMessageParams::new()
                         .closest(
-                            origin_peer.node_id,
+                            origin_node_id.clone(),
                             self.config.num_neighbouring_nodes,
-                            vec![authenticated_pk, source_peer.public_key.clone()],
+                            vec![origin_node_id, source_peer.node_id.clone()],
                             PeerFeatures::MESSAGE_PROPAGATION,
                         )
                         .with_dht_header(dht_header)

--- a/comms/dht/src/outbound/broadcast.rs
+++ b/comms/dht/src/outbound/broadcast.rs
@@ -287,7 +287,7 @@ where S: Service<DhtOutboundMessage, Response = (), Error = PipelineError>
                         Ok(Some(peer)) => {
                             // Set the reply_tx so that it can be used later
                             reply_tx = Some(discovery_reply_tx);
-                            peers = vec![peer];
+                            peers = vec![Arc::new(peer)];
                         },
                         Ok(None) => {
                             // Message sent to 0 peers
@@ -337,7 +337,11 @@ where S: Service<DhtOutboundMessage, Response = (), Error = PipelineError>
         }
     }
 
-    async fn select_peers(&mut self, broadcast_strategy: BroadcastStrategy) -> Result<Vec<Peer>, DhtOutboundError> {
+    async fn select_peers(
+        &mut self,
+        broadcast_strategy: BroadcastStrategy,
+    ) -> Result<Vec<Arc<Peer>>, DhtOutboundError>
+    {
         self.dht_requester
             .select_peers(broadcast_strategy)
             .await
@@ -392,7 +396,7 @@ where S: Service<DhtOutboundMessage, Response = (), Error = PipelineError>
     #[allow(clippy::too_many_arguments)]
     async fn generate_send_messages(
         &mut self,
-        selected_peers: Vec<Peer>,
+        selected_peers: Vec<Arc<Peer>>,
         destination: NodeDestination,
         dht_message_type: DhtMessageType,
         encryption: OutboundEncryption,

--- a/comms/dht/src/outbound/message.rs
+++ b/comms/dht/src/outbound/message.rs
@@ -168,7 +168,7 @@ impl Drop for WrappedReplyTx {
 #[derive(Debug)]
 pub struct DhtOutboundMessage {
     pub tag: MessageTag,
-    pub destination_peer: Peer,
+    pub destination_peer: Arc<Peer>,
     pub custom_header: Option<DhtMessageHeader>,
     pub body: Bytes,
     pub ephemeral_public_key: Option<Arc<CommsPublicKey>>,

--- a/comms/dht/src/outbound/message_params.rs
+++ b/comms/dht/src/outbound/message_params.rs
@@ -119,7 +119,7 @@ impl SendMessageParams {
         &mut self,
         node_id: NodeId,
         n: usize,
-        excluded_peers: Vec<CommsPublicKey>,
+        excluded_peers: Vec<NodeId>,
         peer_features: PeerFeatures,
     ) -> &mut Self
     {
@@ -134,13 +134,13 @@ impl SendMessageParams {
 
     /// Set broadcast_strategy to Neighbours. `excluded_peers` are excluded. Only Peers that have
     /// `PeerFeatures::MESSAGE_PROPAGATION` are included.
-    pub fn neighbours(&mut self, excluded_peers: Vec<CommsPublicKey>) -> &mut Self {
-        self.params_mut().broadcast_strategy = BroadcastStrategy::Neighbours(excluded_peers, false);
+    pub fn broadcast(&mut self, excluded_peers: Vec<NodeId>) -> &mut Self {
+        self.params_mut().broadcast_strategy = BroadcastStrategy::Neighbours(excluded_peers);
         self
     }
 
-    pub fn neighbours_include_clients(&mut self, excluded_peers: Vec<CommsPublicKey>) -> &mut Self {
-        self.params_mut().broadcast_strategy = BroadcastStrategy::Neighbours(excluded_peers, true);
+    pub fn propagate(&mut self, destination: NodeDestination, excluded_peers: Vec<NodeId>) -> &mut Self {
+        self.params_mut().broadcast_strategy = BroadcastStrategy::Propagate(destination, excluded_peers);
         self
     }
 

--- a/comms/dht/src/outbound/serialize.rs
+++ b/comms/dht/src/outbound/serialize.rs
@@ -97,7 +97,7 @@ where S: Service<OutboundMessage, Response = (), Error = PipelineError> + Clone 
             next_service
                 .oneshot(OutboundMessage {
                     tag,
-                    peer_node_id: destination_peer.node_id,
+                    peer_node_id: destination_peer.node_id.clone(),
                     reply_tx: reply_tx.into_inner(),
                     body,
                 })

--- a/comms/dht/src/store_forward/service.rs
+++ b/comms/dht/src/store_forward/service.rs
@@ -336,7 +336,7 @@ impl StoreAndForwardService {
         self.outbound_requester
             .send_message_no_header(
                 SendMessageParams::new()
-                    .neighbours(vec![])
+                    .broadcast(vec![])
                     .with_dht_message_type(DhtMessageType::SafRequestMessages)
                     .finish(),
                 request,

--- a/comms/dht/src/test_utils/dht_actor_mock.rs
+++ b/comms/dht/src/test_utils/dht_actor_mock.rs
@@ -112,7 +112,7 @@ impl DhtActorMock {
             },
             SelectPeers(_, reply_tx) => {
                 let lock = self.state.select_peers.read().unwrap();
-                reply_tx.send(lock.clone()).unwrap();
+                reply_tx.send(lock.iter().cloned().map(Arc::new).collect()).unwrap();
             },
             GetMetadata(key, reply_tx) => {
                 let _ = reply_tx.send(Ok(self

--- a/comms/src/connection_manager/common.rs
+++ b/comms/src/connection_manager/common.rs
@@ -34,6 +34,7 @@ use crate::{
 };
 use futures::StreamExt;
 use log::*;
+use std::sync::Arc;
 use tari_crypto::tari_utilities::ByteArray;
 
 const LOG_TARGET: &str = "comms::connection_manager::common";
@@ -85,7 +86,7 @@ pub async fn validate_and_add_peer_from_peer_identity(
     authenticated_public_key: CommsPublicKey,
     peer_identity: PeerIdentityMsg,
     allow_test_addrs: bool,
-) -> Result<NodeId, ConnectionManagerError>
+) -> Result<Arc<Peer>, ConnectionManagerError>
 {
     // let peer_manager = peer_manager.inner();
     // Validate the given node id for base nodes
@@ -166,7 +167,9 @@ pub async fn validate_and_add_peer_from_peer_identity(
         },
     }
 
-    Ok(peer_node_id)
+    let peer = Arc::new(peer_manager.find_by_node_id(&peer_node_id).await?);
+
+    Ok(peer)
 }
 
 pub fn validate_peer_addresses<A: AsRef<[Multiaddr]>>(

--- a/comms/src/connection_manager/dialer.rs
+++ b/comms/src/connection_manager/dialer.rs
@@ -379,7 +379,7 @@ where
         );
         trace!(target: LOG_TARGET, "{:?}", peer_identity);
 
-        let peer_node_id = common::validate_and_add_peer_from_peer_identity(
+        let peer = common::validate_and_add_peer_from_peer_identity(
             &peer_manager,
             authenticated_public_key,
             peer_identity,
@@ -391,13 +391,13 @@ where
             target: LOG_TARGET,
             "[ThisNode={}] Peer '{}' added to peer list.",
             node_identity.node_id().short_str(),
-            peer_node_id.short_str()
+            peer.node_id.short_str()
         );
 
         peer_connection::create(
             muxer,
             dialed_addr,
-            peer_node_id,
+            peer,
             CONNECTION_DIRECTION,
             conn_man_notifier,
             our_supported_protocols,

--- a/comms/src/connection_manager/listener.rs
+++ b/comms/src/connection_manager/listener.rs
@@ -330,7 +330,7 @@ where
         );
         trace!(target: LOG_TARGET, "{:?}", peer_identity);
 
-        let peer_node_id = common::validate_and_add_peer_from_peer_identity(
+        let peer = common::validate_and_add_peer_from_peer_identity(
             &peer_manager,
             authenticated_public_key,
             peer_identity,
@@ -342,13 +342,13 @@ where
             target: LOG_TARGET,
             "[ThisNode={}] Peer '{}' added to peer list.",
             node_identity.node_id().short_str(),
-            peer_node_id.short_str()
+            peer.node_id.short_str()
         );
 
         peer_connection::create(
             muxer,
             peer_addr,
-            peer_node_id,
+            peer,
             CONNECTION_DIRECTION,
             conn_man_notifier,
             our_supported_protocols,

--- a/comms/src/peer_manager/manager.rs
+++ b/comms/src/peer_manager/manager.rs
@@ -254,7 +254,7 @@ impl PeerManager {
     }
 
     /// Fetch n random peers
-    pub async fn random_peers(&self, n: usize, excluded: Vec<NodeId>) -> Result<Vec<Peer>, PeerManagerError> {
+    pub async fn random_peers(&self, n: usize, excluded: &[NodeId]) -> Result<Vec<Peer>, PeerManagerError> {
         // Send to a random set of peers of size n that are Communication Nodes
         self.peer_storage.read().await.random_peers(n, excluded)
     }
@@ -481,8 +481,8 @@ mod test {
         }
 
         // Test Random
-        let identities1 = peer_manager.random_peers(10, vec![]).await.unwrap();
-        let identities2 = peer_manager.random_peers(10, vec![]).await.unwrap();
+        let identities1 = peer_manager.random_peers(10, &[]).await.unwrap();
+        let identities2 = peer_manager.random_peers(10, &[]).await.unwrap();
         assert_ne!(identities1, identities2);
     }
 

--- a/comms/src/peer_manager/peer.rs
+++ b/comms/src/peer_manager/peer.rs
@@ -56,7 +56,7 @@ pub struct PeerIdentity {
 /// A Peer represents a communication peer that is identified by a Public Key and NodeId. The Peer struct maintains a
 /// collection of the NetAddressesWithStats that this Peer can be reached by. The struct also maintains a set of flags
 /// describing the status of the Peer.
-#[derive(Debug, Clone, Deserialize, Serialize, PartialEq)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct Peer {
     /// The local id of the peer. If this is None, the peer has never been persisted
     id: Option<PeerId>,
@@ -277,6 +277,12 @@ impl Display for Peer {
             },
             self.connection_stats,
         ))
+    }
+}
+
+impl PartialEq for Peer {
+    fn eq(&self, other: &Self) -> bool {
+        self.public_key == other.public_key
     }
 }
 

--- a/comms/src/peer_manager/peer_storage.rs
+++ b/comms/src/peer_manager/peer_storage.rs
@@ -350,7 +350,7 @@ where DS: KeyValueStore<PeerId, Peer>
     }
 
     /// Compile a random list of communication node peers of size _n_ that are not banned or offline
-    pub fn random_peers(&self, n: usize, exclude_peers: Vec<NodeId>) -> Result<Vec<Peer>, PeerManagerError> {
+    pub fn random_peers(&self, n: usize, exclude_peers: &[NodeId]) -> Result<Vec<Peer>, PeerManagerError> {
         let mut peer_keys = self
             .peer_db
             .filter(|(_, peer)| {

--- a/comms/src/test_utils/mocks/connection_manager.rs
+++ b/comms/src/test_utils/mocks/connection_manager.rs
@@ -38,11 +38,11 @@ use std::{
         Arc,
     },
 };
-use tokio::sync::broadcast;
+use tokio::{sync::broadcast, task};
 
-pub fn create_connection_manager_mock(buf_size: usize) -> (ConnectionManagerRequester, ConnectionManagerMock) {
-    let (tx, rx) = mpsc::channel(buf_size);
-    let (event_tx, _) = broadcast::channel(buf_size);
+pub fn create_connection_manager_mock() -> (ConnectionManagerRequester, ConnectionManagerMock) {
+    let (tx, rx) = mpsc::channel(10);
+    let (event_tx, _) = broadcast::channel(10);
     (
         ConnectionManagerRequester::new(tx, event_tx.clone()),
         ConnectionManagerMock::new(rx.fuse(), event_tx),
@@ -114,6 +114,10 @@ impl ConnectionManagerMock {
 
     pub fn get_shared_state(&self) -> ConnectionManagerMockState {
         self.state.clone()
+    }
+
+    pub fn spawn(self) {
+        task::spawn(Self::run(self));
     }
 
     pub async fn run(mut self) {

--- a/comms/src/test_utils/mocks/peer_connection.rs
+++ b/comms/src/test_utils/mocks/peer_connection.rs
@@ -30,7 +30,7 @@ use crate::{
     },
     multiplexing,
     multiplexing::{IncomingSubstreams, Yamux},
-    peer_manager::NodeId,
+    peer_manager::Peer,
     test_utils::transport,
 };
 use futures::{channel::mpsc, lock::Mutex, stream::Fuse, StreamExt};
@@ -42,8 +42,8 @@ use tokio::runtime::Handle;
 
 pub async fn create_peer_connection_mock_pair(
     buf_size: usize,
-    node_id_in: NodeId,
-    node_id_out: NodeId,
+    peer_in: Peer,
+    peer_out: Peer,
 ) -> (
     PeerConnection,
     PeerConnectionMockState,
@@ -65,9 +65,15 @@ pub async fn create_peer_connection_mock_pair(
     rt_handle.spawn(mock.run());
 
     (
-        PeerConnection::new(1, tx1, node_id_in, listen_addr.clone(), ConnectionDirection::Inbound),
+        PeerConnection::new(
+            1,
+            tx1,
+            Arc::new(peer_in),
+            listen_addr.clone(),
+            ConnectionDirection::Inbound,
+        ),
         mock_state_in,
-        PeerConnection::new(2, tx2, node_id_out, listen_addr, ConnectionDirection::Outbound),
+        PeerConnection::new(2, tx2, Arc::new(peer_out), listen_addr, ConnectionDirection::Outbound),
         mock_state_out,
     )
 }


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Propagation didn't include connected peers in propagation.
This could cause messages to stay within their neighbourhood cluster in
the XOR metric space.
This PR includes all connected peers as propagation candidates, then
selects a subset of peers that are closer to the message destination.
If no closer peers can be found (and the node is well connected),
the propagation ends.

A distinction is made between propagating a message along and
broadcasting a new message. Broadcasted messages are sent to neighbours
for propagation. Propagated messages are forwarded closer to the
message destination. If a destination is not provided, the message is
broadcast to a subset of connected nodes and neighbours.

- Added `BroadcastStrategy::Propagate` that adds connected nodes to the
  propagation set for consideration
- Propagation selects a subset peers that are closer to the destination
- Renamed `neighbours` to `broadcast` in the outbound requester
  interface
- Use `NodeId` instead of `CommsPublicKey` for excluded peer list (for conistency
  and it has a much smaller memory footprint)
- Updated memorynet example to test domain-level message propagation

Number of established connections should remain similar to what is currently observed. 
Connection reaping will be implemented soon™️ .

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Block and transaction propagation get stuck in network clusters.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
All tests pass, tests updated where necessary. Memorynet has 100% pass rate on a number of runs.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [x] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch.
* [x] I ran `cargo-fmt --all` before pushing.
* [x] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
