### PR TITLE
Quick optimisation of insert into dedup cache

### DIFF
--- a/comms/dht/src/dedup.rs
+++ b/comms/dht/src/dedup.rs
@@ -20,7 +20,7 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use crate::{actor::DhtRequester, inbound::DhtInboundMessage, outbound::message::DhtOutboundMessage};
+use crate::{actor::DhtRequester, inbound::DhtInboundMessage};
 use digest::Input;
 use futures::{task::Context, Future};
 use log::*;
@@ -33,10 +33,6 @@ const LOG_TARGET: &str = "comms::dht::dedup";
 
 fn hash_inbound_message(message: &DhtInboundMessage) -> Vec<u8> {
     Challenge::new().chain(&message.body).result().to_vec()
-}
-
-fn hash_outbound_message(message: &DhtOutboundMessage) -> Vec<u8> {
-    Challenge::new().chain(&message.body.to_vec()).result().to_vec()
 }
 
 /// # DHT Deduplication middleware
@@ -101,50 +97,6 @@ where S: Service<DhtInboundMessage, Response = (), Error = PipelineError> + Clon
     }
 }
 
-impl<S> Service<DhtOutboundMessage> for DedupMiddleware<S>
-where S: Service<DhtOutboundMessage, Response = (), Error = PipelineError> + Clone
-{
-    type Error = PipelineError;
-    type Response = ();
-
-    type Future = impl Future<Output = Result<Self::Response, Self::Error>>;
-
-    fn poll_ready(&mut self, _: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
-        Poll::Ready(Ok(()))
-    }
-
-    fn call(&mut self, message: DhtOutboundMessage) -> Self::Future {
-        let next_service = self.next_service.clone();
-        let mut dht_requester = self.dht_requester.clone();
-        async move {
-            if message.is_broadcast {
-                let hash = hash_outbound_message(&message);
-                debug!(
-                    target: LOG_TARGET,
-                    "Dedup added message hash {} to cache for message {}",
-                    hash.to_hex(),
-                    message.tag
-                );
-                if dht_requester
-                    .insert_message_hash(hash)
-                    .await
-                    .map_err(PipelineError::from_debug)?
-                {
-                    info!(
-                        target: LOG_TARGET,
-                        "Outgoing message is already in the cache ({}, next peer = {})",
-                        message.tag,
-                        message.destination_peer.node_id.short_str()
-                    );
-                }
-            }
-
-            trace!(target: LOG_TARGET, "Passing message onto next service");
-            next_service.oneshot(message).await
-        }
-    }
-}
-
 pub struct DedupLayer {
     dht_requester: DhtRequester,
 }
@@ -168,14 +120,7 @@ mod test {
     use super::*;
     use crate::{
         envelope::DhtMessageFlags,
-        test_utils::{
-            create_dht_actor_mock,
-            create_outbound_message,
-            make_dht_inbound_message,
-            make_node_identity,
-            service_spy,
-            DhtMockState,
-        },
+        test_utils::{create_dht_actor_mock, make_dht_inbound_message, make_node_identity, service_spy, DhtMockState},
     };
     use tari_test_utils::panic_context;
     use tokio::runtime::Runtime;
@@ -216,17 +161,13 @@ mod test {
         let node_identity = make_node_identity();
         let msg = make_dht_inbound_message(&node_identity, TEST_MSG.to_vec(), DhtMessageFlags::empty(), false);
         let hash1 = hash_inbound_message(&msg);
-        let msg = create_outbound_message(&TEST_MSG);
-        let hash_out1 = hash_outbound_message(&msg);
 
         let node_identity = make_node_identity();
         let msg = make_dht_inbound_message(&node_identity, TEST_MSG.to_vec(), DhtMessageFlags::empty(), false);
         let hash2 = hash_inbound_message(&msg);
-        let msg = create_outbound_message(&TEST_MSG);
-        let hash_out2 = hash_outbound_message(&msg);
 
         assert_eq!(hash1, hash2);
-        let subjects = &[hash1, hash_out1, hash2, hash_out2];
+        let subjects = &[hash1, hash2];
         assert!(subjects.into_iter().all(|h| h.to_hex() == EXPECTED_HASH));
     }
 }

--- a/comms/dht/src/dht.rs
+++ b/comms/dht/src/dht.rs
@@ -287,7 +287,6 @@ impl Dht {
                 self.discovery_service_requester(),
                 self.config.network,
             ))
-            .layer(DedupLayer::new(self.dht_requester()))
             .layer(MessageLoggingLayer::new(format!(
                 "Outbound [{}]",
                 self.node_identity.node_id().short_str()

--- a/comms/dht/src/logging_middleware.rs
+++ b/comms/dht/src/logging_middleware.rs
@@ -86,7 +86,7 @@ where
     }
 
     fn call(&mut self, msg: R) -> Self::Future {
-        debug!(target: LOG_TARGET, "{}{}", self.prefix_msg, msg);
+        info!(target: LOG_TARGET, "{}{}", self.prefix_msg, msg);
         let mut inner = self.inner.clone();
         async move { inner.ready_and().and_then(|s| s.call(msg)).await.map_err(Into::into) }
     }

--- a/comms/dht/src/outbound/error.rs
+++ b/comms/dht/src/outbound/error.rs
@@ -47,4 +47,6 @@ pub enum DhtOutboundError {
     SendToOurselves,
     /// Discovery process failed
     DiscoveryFailed,
+    /// Failed to insert message hash
+    FailedToInsertMessageHash,
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Since `OutboundEncryption::EncryptForPeer` was removed, the hash for
a group of outbound broadcast messages is the same and so can
be added once (instead of adding the same one `n` times) in the
broadcast layer.


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Easy optimisation - reduces the logs repeating that the outbound message is already in the cache.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Not explicitly tested, but memorynet and existing tests pass 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [x] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch.
* [x] I ran `cargo-fmt --all` before pushing.
* [x] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
