### PR TITLE
Trace log double-spend or invalid inputs

### DIFF
--- a/applications/tari_base_node/windows/README.md
+++ b/applications/tari_base_node/windows/README.md
@@ -14,7 +14,7 @@ installed automatically if selected:
 Notes: 
 - Minimum Windows 7 64bit with Windows Powershell 3.0 required, 
   Windows 10 64bit recommended.
-- Minimum 60GB free disk space required at the initial runtime. 
+- Minimum 1.2 GB free disk space required at the initial runtime. 
 
 ## Runtime
 

--- a/base_layer/core/src/mempool/service/inbound_handlers.rs
+++ b/base_layer/core/src/mempool/service/inbound_handlers.rs
@@ -135,7 +135,20 @@ where T: BlockchainBackend + 'static
                     );
                     let propagate = match tx_storage {
                         TxStorageResponse::UnconfirmedPool => true,
-                        TxStorageResponse::OrphanPool => false,
+                        TxStorageResponse::OrphanPool => {
+                            trace!(
+                                target: LOG_TARGET,
+                                "Transaction `{}` received from nodeID `{}` is bad: double spend or non-existent \
+                                 input.",
+                                tx.body.kernels()[0].excess_sig.get_signature().to_hex(),
+                                exclude_peers
+                                    .first()
+                                    .as_ref()
+                                    .map(|p| format!("{}", p))
+                                    .unwrap_or_else(|| "local services".to_string())
+                            );
+                            false
+                        },
                         TxStorageResponse::PendingPool => true,
                         TxStorageResponse::ReorgPool => false,
                         TxStorageResponse::NotStored => false,

--- a/comms/dht/src/dedup.rs
+++ b/comms/dht/src/dedup.rs
@@ -130,7 +130,7 @@ where S: Service<DhtOutboundMessage, Response = (), Error = PipelineError> + Clo
                     .await
                     .map_err(PipelineError::from_debug)?
                 {
-                    info!(
+                    debug!(
                         target: LOG_TARGET,
                         "Outgoing message is already in the cache ({}, next peer = {})",
                         message.tag,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- Added trace log entry for Txs with double-spend or using invalid inputs, also identifying which node sent it.
- Updated Windows installation README.
- Reduced the log level of one of the dedup log messages from info to debug.

_**TODO**: Protect self against receiving invalid Txs by banning such nodes for a period of time. As an example, 4731 messages with invalid inputs have been sent by 8 peers to a single node from `09:43:34` till `13:08:28`._

## Motivation and Context
We need more insight into nodes that are spamming the network with invalid Txs, either from double-spend or using invalid inputs.

## How Has This Been Tested?
Tested running `tari_base_node.exe`

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [X] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [X] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [X] I'm merging against the `development` branch.
* [X] I ran `cargo-fmt --all` before pushing.
* [X] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
