### PR TITLE
Close the connection earlier if a peer is banned

### DIFF
--- a/comms/src/connection_manager/dialer.rs
+++ b/comms/src/connection_manager/dialer.rs
@@ -364,6 +364,7 @@ where
             "Starting peer identity exchange for peer with public key '{}'",
             authenticated_public_key
         );
+
         let peer_identity = common::perform_identity_exchange(
             &mut muxer,
             &node_identity,
@@ -379,8 +380,12 @@ where
         );
         trace!(target: LOG_TARGET, "{:?}", peer_identity);
 
+        // Check if we know the peer and if it is banned
+        let known_peer = common::find_unbanned_peer(&peer_manager, &authenticated_public_key).await?;
+
         let peer = common::validate_and_add_peer_from_peer_identity(
             &peer_manager,
+            known_peer,
             authenticated_public_key,
             peer_identity,
             allow_test_addresses,

--- a/comms/src/multiplexing/yamux.rs
+++ b/comms/src/multiplexing/yamux.rs
@@ -26,6 +26,7 @@ use futures::{
     future,
     future::Either,
     io::{AsyncRead, AsyncWrite},
+    stream::FusedStream,
     task::Context,
     SinkExt,
     Stream,
@@ -105,6 +106,10 @@ impl Yamux {
     pub fn incoming(self) -> IncomingSubstreams {
         self.incoming
     }
+
+    pub fn is_terminated(&self) -> bool {
+        self.incoming.is_terminated()
+    }
 }
 
 pub struct IncomingSubstreams {
@@ -115,6 +120,12 @@ pub struct IncomingSubstreams {
 impl IncomingSubstreams {
     pub fn new(inner: IncomingRx, shutdown: Shutdown) -> Self {
         Self { inner, shutdown }
+    }
+}
+
+impl FusedStream for IncomingSubstreams {
+    fn is_terminated(&self) -> bool {
+        self.inner.is_terminated()
     }
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
If a peer was banned, the identity protocol would complete before the connection
was closed. This means that the peer connection of a dialing peer
would complete successfully before being immediately closed by the
listener. The banned dialing peer would retry indefinitely without
giving up.

This PR adds a check to the listener if the peer is banned _before_
beginning the peer identity protocol. This reduces the amount of wasted
work the listener has to do as well failing the dialer's peer connection.
The dialer will treat this as any other kind of failure and eventually mark the
peer as offline.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Reduces connection thrashing, by allowing a dialer to know that the connection has failed if they are banned.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Unit test added 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [x] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch.
* [x] I ran `cargo-fmt --all` before pushing.
* [x] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
