### PR TITLE
Added multiplexed substream counts

### DIFF
--- a/comms/src/builder/mod.rs
+++ b/comms/src/builder/mod.rs
@@ -52,12 +52,13 @@ use crate::{
     },
     message::InboundMessage,
     multiaddr::Multiaddr,
+    multiplexing::Substream,
     noise::NoiseConfig,
     peer_manager::{NodeIdentity, PeerManager},
     protocol::{messaging, messaging::MessagingProtocol, ProtocolNotification, Protocols},
     tor,
     transports::{SocksTransport, TcpWithTorTransport, Transport},
-    types::{CommsDatabase, CommsSubstream},
+    types::CommsDatabase,
 };
 use futures::{channel::mpsc, AsyncRead, AsyncWrite};
 use log::*;
@@ -73,7 +74,7 @@ pub struct CommsBuilder<TTransport> {
     node_identity: Option<Arc<NodeIdentity>>,
     transport: Option<TTransport>,
     executor: Option<runtime::Handle>,
-    protocols: Option<Protocols<CommsSubstream>>,
+    protocols: Option<Protocols<Substream>>,
     dial_backoff: Option<BoxedBackoff>,
     hidden_service: Option<tor::HiddenService>,
     connection_manager_config: ConnectionManagerConfig,
@@ -220,7 +221,7 @@ where
         }
     }
 
-    pub fn with_protocols(mut self, protocols: Protocols<yamux::Stream>) -> Self {
+    pub fn with_protocols(mut self, protocols: Protocols<Substream>) -> Self {
         self.protocols = Some(protocols);
         self
     }
@@ -238,7 +239,7 @@ where
         node_identity: Arc<NodeIdentity>,
     ) -> (
         messaging::MessagingProtocol,
-        mpsc::Sender<ProtocolNotification<CommsSubstream>>,
+        mpsc::Sender<ProtocolNotification<Substream>>,
         mpsc::Sender<messaging::MessagingRequest>,
         mpsc::Receiver<InboundMessage>,
         messaging::MessagingEventSender,
@@ -277,7 +278,7 @@ where
         &mut self,
         node_identity: Arc<NodeIdentity>,
         peer_manager: Arc<PeerManager>,
-        protocols: Protocols<CommsSubstream>,
+        protocols: Protocols<Substream>,
         request_rx: mpsc::Receiver<ConnectionManagerRequest>,
         connection_manager_events_tx: broadcast::Sender<Arc<ConnectionManagerEvent>>,
     ) -> ConnectionManager<TTransport, BoxedBackoff>

--- a/comms/src/builder/tests.rs
+++ b/comms/src/builder/tests.rs
@@ -27,6 +27,7 @@ use crate::{
     memsocket,
     message::{InboundMessage, OutboundMessage},
     multiaddr::{Multiaddr, Protocol},
+    multiplexing::Substream,
     peer_manager::{Peer, PeerFeatures},
     pipeline,
     pipeline::SinkService,
@@ -34,7 +35,6 @@ use crate::{
     runtime,
     test_utils::node_identity::build_node_identity,
     transports::MemoryTransport,
-    types::CommsSubstream,
     CommsNode,
 };
 use bytes::Bytes;
@@ -44,7 +44,7 @@ use tari_storage::HashmapDatabase;
 use tari_test_utils::{collect_stream, unpack_enum};
 
 async fn spawn_node(
-    protocols: Protocols<CommsSubstream>,
+    protocols: Protocols<Substream>,
 ) -> (CommsNode, mpsc::Receiver<InboundMessage>, mpsc::Sender<OutboundMessage>) {
     let addr = format!("/memory/{}", memsocket::acquire_next_memsocket_port())
         .parse::<Multiaddr>()

--- a/comms/src/connection_manager/manager.rs
+++ b/comms/src/connection_manager/manager.rs
@@ -30,6 +30,7 @@ use super::{
 };
 use crate::{
     backoff::Backoff,
+    multiplexing::Substream,
     noise::NoiseConfig,
     peer_manager::{NodeId, NodeIdentity},
     protocol::{ProtocolEvent, ProtocolId, Protocols},
@@ -72,7 +73,7 @@ pub enum ConnectionManagerEvent {
     ListenFailed(ConnectionManagerError),
 
     // Substreams
-    NewInboundSubstream(Box<NodeId>, ProtocolId, yamux::Stream),
+    NewInboundSubstream(Box<NodeId>, ProtocolId, Substream),
 }
 
 impl fmt::Display for ConnectionManagerEvent {
@@ -157,7 +158,7 @@ pub struct ConnectionManager<TTransport, TBackoff> {
     node_identity: Arc<NodeIdentity>,
     active_connections: HashMap<NodeId, PeerConnection>,
     shutdown_signal: Option<ShutdownSignal>,
-    protocols: Protocols<yamux::Stream>,
+    protocols: Protocols<Substream>,
     listener_address: Option<Multiaddr>,
     listening_notifiers: Vec<oneshot::Sender<Multiaddr>>,
     connection_manager_events_tx: broadcast::Sender<Arc<ConnectionManagerEvent>>,
@@ -179,7 +180,7 @@ where
         request_rx: mpsc::Receiver<ConnectionManagerRequest>,
         node_identity: Arc<NodeIdentity>,
         peer_manager: Arc<PeerManager>,
-        protocols: Protocols<yamux::Stream>,
+        protocols: Protocols<Substream>,
         connection_manager_events_tx: broadcast::Sender<Arc<ConnectionManagerEvent>>,
         shutdown_signal: ShutdownSignal,
     ) -> Self

--- a/comms/src/multiplexing/mod.rs
+++ b/comms/src/multiplexing/mod.rs
@@ -21,4 +21,4 @@
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 mod yamux;
-pub use self::yamux::{Control, IncomingSubstreams, Yamux};
+pub use self::yamux::{ConnectionError, Control, IncomingSubstreams, Substream, Yamux};

--- a/comms/src/protocol/messaging/inbound.rs
+++ b/comms/src/protocol/messaging/inbound.rs
@@ -1,0 +1,118 @@
+//  Copyright 2020, The Tari Project
+//
+//  Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+//  following conditions are met:
+//
+//  1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+//  disclaimer.
+//
+//  2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+//  following disclaimer in the documentation and/or other materials provided with the distribution.
+//
+//  3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+//  products derived from this software without specific prior written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+//  INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+//  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+//  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+//  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+//  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+//  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+use crate::{
+    message::InboundMessage,
+    peer_manager::Peer,
+    protocol::messaging::{MessagingEvent, MessagingProtocol},
+};
+use futures::{channel::mpsc, AsyncRead, AsyncWrite, SinkExt, StreamExt};
+use log::*;
+use std::sync::Arc;
+use tokio::sync::broadcast;
+
+const LOG_TARGET: &str = "comms::protocol::messaging::inbound";
+
+pub struct InboundMessaging {
+    peer: Arc<Peer>,
+    inbound_message_tx: mpsc::Sender<InboundMessage>,
+    messaging_events_tx: broadcast::Sender<Arc<MessagingEvent>>,
+}
+
+impl InboundMessaging {
+    pub fn new(
+        peer: Arc<Peer>,
+        inbound_message_tx: mpsc::Sender<InboundMessage>,
+        messaging_events_tx: broadcast::Sender<Arc<MessagingEvent>>,
+    ) -> Self
+    {
+        Self {
+            peer,
+            inbound_message_tx,
+            messaging_events_tx,
+        }
+    }
+
+    pub async fn run<S>(mut self, socket: S)
+    where S: AsyncRead + AsyncWrite + Unpin {
+        let mut framed_socket = MessagingProtocol::framed(socket);
+        let peer = &self.peer;
+        while let Some(result) = framed_socket.next().await {
+            match result {
+                Ok(raw_msg) => {
+                    trace!(
+                        target: LOG_TARGET,
+                        "Received message from peer '{}' ({} bytes)",
+                        peer.node_id.short_str(),
+                        raw_msg.len()
+                    );
+
+                    let inbound_msg = InboundMessage::new(Arc::clone(&peer), raw_msg.freeze());
+
+                    let event = MessagingEvent::MessageReceived(
+                        Box::new(inbound_msg.source_peer.node_id.clone()),
+                        inbound_msg.tag,
+                    );
+
+                    if let Err(err) = self.inbound_message_tx.send(inbound_msg).await {
+                        warn!(
+                            target: LOG_TARGET,
+                            "Failed to send InboundMessage for peer '{}' because '{}'",
+                            peer.node_id.short_str(),
+                            err
+                        );
+
+                        if err.is_disconnected() {
+                            break;
+                        }
+                    }
+
+                    trace!(target: LOG_TARGET, "Inbound handler sending event '{}'", event);
+                    if let Err(err) = self.messaging_events_tx.send(Arc::new(event)) {
+                        trace!(
+                            target: LOG_TARGET,
+                            "Messaging event '{}' not sent for peer '{}' because there are no subscribers. \
+                             MessagingEvent dropped",
+                            err.0,
+                            peer.node_id.short_str(),
+                        );
+                    }
+                },
+                Err(err) => {
+                    error!(
+                        target: LOG_TARGET,
+                        "Failed to receive from peer '{}' because '{}'",
+                        peer.node_id.short_str(),
+                        err
+                    );
+                    break;
+                },
+            }
+        }
+
+        debug!(
+            target: LOG_TARGET,
+            "Inbound messaging handler for peer '{}' has stopped",
+            peer.node_id.short_str()
+        );
+    }
+}

--- a/comms/src/protocol/messaging/mod.rs
+++ b/comms/src/protocol/messaging/mod.rs
@@ -21,6 +21,7 @@
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 mod error;
+mod inbound;
 mod outbound;
 
 mod protocol;

--- a/comms/src/protocol/messaging/outbound.rs
+++ b/comms/src/protocol/messaging/outbound.rs
@@ -24,8 +24,8 @@ use super::{error::MessagingProtocolError, MessagingEvent, MessagingProtocol, Se
 use crate::{
     connection_manager::{ConnectionManagerError, ConnectionManagerRequester, NegotiatedSubstream, PeerConnection},
     message::OutboundMessage,
+    multiplexing::Substream,
     peer_manager::{NodeId, NodeIdentity},
-    types::CommsSubstream,
 };
 use futures::{channel::mpsc, SinkExt, StreamExt};
 use log::*;
@@ -104,7 +104,7 @@ impl OutboundMessaging {
     async fn try_open_substream(
         &mut self,
         mut conn: PeerConnection,
-    ) -> Result<NegotiatedSubstream<CommsSubstream>, MessagingProtocolError>
+    ) -> Result<NegotiatedSubstream<Substream>, MessagingProtocolError>
     {
         match conn.open_substream(&MESSAGING_PROTOCOL).await {
             Ok(substream) => Ok(substream),
@@ -122,7 +122,7 @@ impl OutboundMessaging {
         }
     }
 
-    async fn start_forwarding_messages(mut self, substream: CommsSubstream) -> Result<(), MessagingProtocolError> {
+    async fn start_forwarding_messages(mut self, substream: Substream) -> Result<(), MessagingProtocolError> {
         let mut framed = MessagingProtocol::framed(substream);
         while let Some(mut out_msg) = self.request_rx.next().await {
             trace!(

--- a/comms/src/protocol/messaging/test.rs
+++ b/comms/src/protocol/messaging/test.rs
@@ -29,6 +29,7 @@ use super::protocol::{
 };
 use crate::{
     message::{InboundMessage, MessageTag, OutboundMessage},
+    multiplexing::Substream,
     net_address::MultiaddressesWithStats,
     peer_manager::{NodeId, NodeIdentity, Peer, PeerFeatures, PeerFlags, PeerManager},
     protocol::{messaging::SendFailReason, ProtocolEvent, ProtocolNotification},
@@ -38,7 +39,7 @@ use crate::{
         node_identity::build_node_identity,
         transport,
     },
-    types::{CommsDatabase, CommsPublicKey, CommsSubstream},
+    types::{CommsDatabase, CommsPublicKey},
 };
 use bytes::Bytes;
 use futures::{
@@ -62,7 +63,7 @@ async fn spawn_messaging_protocol() -> (
     Arc<PeerManager>,
     Arc<NodeIdentity>,
     ConnectionManagerMockState,
-    mpsc::Sender<ProtocolNotification<CommsSubstream>>,
+    mpsc::Sender<ProtocolNotification<Substream>>,
     mpsc::Sender<MessagingRequest>,
     mpsc::Receiver<InboundMessage>,
     MessagingEventReceiver,

--- a/comms/src/test_utils/mocks/peer_connection.rs
+++ b/comms/src/test_utils/mocks/peer_connection.rs
@@ -29,7 +29,7 @@ use crate::{
         PeerConnectionRequest,
     },
     multiplexing,
-    multiplexing::{IncomingSubstreams, Yamux},
+    multiplexing::{IncomingSubstreams, Substream, Yamux},
     peer_manager::Peer,
     test_utils::transport,
 };
@@ -102,11 +102,11 @@ impl PeerConnectionMockState {
         self.call_count.load(Ordering::SeqCst)
     }
 
-    pub async fn open_substream(&self) -> Result<yamux::Stream, PeerConnectionError> {
+    pub async fn open_substream(&self) -> Result<Substream, PeerConnectionError> {
         self.mux_control.lock().await.open_stream().await.map_err(Into::into)
     }
 
-    pub async fn next_incoming_substream(&self) -> Option<yamux::Stream> {
+    pub async fn next_incoming_substream(&self) -> Option<Substream> {
         self.mux_incoming.lock().await.next().await
     }
 

--- a/comms/src/test_utils/test_node.rs
+++ b/comms/src/test_utils/test_node.rs
@@ -23,6 +23,7 @@
 use crate::{
     backoff::ConstantBackoff,
     connection_manager::{ConnectionManager, ConnectionManagerConfig, ConnectionManagerRequester},
+    multiplexing::Substream,
     noise::NoiseConfig,
     peer_manager::{NodeIdentity, PeerFeatures, PeerManager},
     protocol::Protocols,
@@ -70,7 +71,7 @@ impl Default for TestNodeConfig {
 pub fn build_connection_manager(
     config: TestNodeConfig,
     peer_manager: Arc<PeerManager>,
-    protocols: Protocols<yamux::Stream>,
+    protocols: Protocols<Substream>,
     shutdown: ShutdownSignal,
 ) -> ConnectionManagerRequester
 {

--- a/comms/src/types.rs
+++ b/comms/src/types.rs
@@ -49,5 +49,3 @@ pub type CommsDataStore = LMDBStore;
 pub type CommsDatabase = LMDBWrapper<PeerId, Peer>;
 #[cfg(test)]
 pub type CommsDatabase = HashmapDatabase<PeerId, Peer>;
-
-pub type CommsSubstream = yamux::Stream;


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Wrapped yamux structs to keep track of the number of substreams
that are currently being used. This will be used when doing connection
reaping. The connectivity manager will use this value to determine if it
can safely close connections.

TODO: The messaging protocol must close the peer's substream if there is
a long enough period of inactivity. The inbound messaging handler was
refactored into a separate module to keep it consistent with the
outbound handler.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Will allow connectivity manager to safely reap inactive connections  

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
New unit test

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [x] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch.
* [x] I ran `cargo-fmt --all` before pushing.
* [x] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
