### PR TITLE
Enable switching between XOR metric and Hamming distance for testing

### DIFF
--- a/comms/src/peer_manager/manager.rs
+++ b/comms/src/peer_manager/manager.rs
@@ -448,7 +448,7 @@ mod test {
             let selected_dist = unmanaged_peer.node_id.distance(&peer_identity.node_id);
             for unused_peer in &unused_peers {
                 let unused_dist = unmanaged_peer.node_id.distance(&unused_peer.node_id);
-                assert!(unused_dist > selected_dist);
+                assert!(unused_dist >= selected_dist);
             }
         }
 
@@ -475,7 +475,7 @@ mod test {
             let selected_dist = unmanaged_peer.node_id.distance(&peer_identity.node_id);
             for unused_peer in &unused_peers {
                 let unused_dist = unmanaged_peer.node_id.distance(&unused_peer.node_id);
-                assert!(unused_dist > selected_dist);
+                assert!(unused_dist >= selected_dist);
             }
             assert!(!excluded_peers.contains(&peer_identity.public_key));
         }
@@ -527,7 +527,7 @@ mod test {
             .filter(|p| p.features == PeerFeatures::COMMUNICATION_NODE)
             .skip(n)
         {
-            assert!(peer.node_id.distance(&network_region_node_id) > node_region_threshold);
+            assert!(peer.node_id.distance(&network_region_node_id) >= node_region_threshold);
         }
 
         let node_region_threshold = peer_manager
@@ -550,7 +550,7 @@ mod test {
             .filter(|p| p.features == PeerFeatures::COMMUNICATION_CLIENT)
             .skip(5)
         {
-            assert!(peer.node_id.distance(&network_region_node_id) > node_region_threshold);
+            assert!(peer.node_id.distance(&network_region_node_id) >= node_region_threshold);
         }
     }
 


### PR DESCRIPTION
## Description
- These changes allow the the distance metric used to determine the distance between nodes to be switched between the XOR metric and the Hamming distance. The default is still the XOR metric.
- The Hamming distance seems to produce more uniform connections between different nodes, reducing the clustering of nodes that are not able to communicate with each other.

## Motivation and Context
The XOR metric seems to cause clustering of nodes that are not able to communicate. Hamming distance seems to improve the clustering issue. This PR allows the switching between the two distance algorithms so that the Hamming distance can be tested.

## How Has This Been Tested?
Existing tests were updated to remain functional with changes to the distance algorithm. Some tests that could not be changed have the results of both distance algorithms.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [x] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch.
* [x] I ran `cargo-fmt --all` before pushing.
* [x] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
