### PR TITLE
Remove requested store and forward messages

### DIFF
--- a/comms/dht/src/test_utils/store_and_forward_mock.rs
+++ b/comms/dht/src/test_utils/store_and_forward_mock.rs
@@ -129,6 +129,11 @@ impl StoreAndForwardMock {
                 priority: msg.priority,
                 stored_at: Utc::now().naive_utc(),
             }),
+            RemoveMessages(message_ids) => {
+                for id in message_ids {
+                    self.state.stored_messages.write().await.retain(|msg| msg.id != id);
+                }
+            },
             SendStoreForwardRequestToPeer(_) => {},
             SendStoreForwardRequestNeighbours => {},
         }


### PR DESCRIPTION
## Description
- These changes remove the store and forward messages from a local node after a destination node has requested these messages and the response message has been queued or sent.
- Added remove_message function to store and forward db.
- Added RemoveMessages store and forward request and provided implementations for the StoreAndForwardRequester and StoreAndForwardMock handle_request.

## Motivation and Context
These changes will remove old store and forward messages from the db after it has been provided or queued to be sent to the destination node.

## How Has This Been Tested?
Added a remove_messages test for the store and forward db.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [x] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch.
* [x] I ran `cargo-fmt --all` before pushing.
* [x] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
