### PR TITLE
Remove feature flag conditions for PowAlgorithm::Monero

### DIFF
--- a/applications/tari_base_node/src/grpc.rs
+++ b/applications/tari_base_node/src/grpc.rs
@@ -309,12 +309,9 @@ impl From<BlockHeader> for base_node_grpc::BlockHeader {
             total_kernel_offset: Vec::from(h.total_kernel_offset.as_bytes()),
             nonce: h.nonce,
             pow: Some(base_node_grpc::ProofOfWork {
-                #[allow(dead_code)]
                 pow_algo: match h.pow.pow_algo {
-                    #[cfg(feature = "monero_merge_mining")]
                     PowAlgorithm::Monero => 0,
                     PowAlgorithm::Blake => 1,
-                    _ => 99, // build fails otherwise due to feature flag
                 },
                 accumulated_monero_difficulty: h.pow.accumulated_monero_difficulty.into(),
                 accumulated_blake_difficulty: h.pow.accumulated_blake_difficulty.into(),

--- a/base_layer/core/src/base_node/states/block_sync.rs
+++ b/base_layer/core/src/base_node/states/block_sync.rs
@@ -219,7 +219,7 @@ impl BestChainMetadataBlockSyncInfo {
                 StateEvent::BlockSyncFailure
             },
             Err(BlockSyncError::CommsInterfaceError(e)) => {
-                warn!(target: LOG_TARGET, "Unable to perform network queries: {}", e);
+                warn!(target: LOG_TARGET, "Unable to perform network queries: {:?}", e);
                 StateEvent::BlockSyncFailure
             },
             Err(e) => StateEvent::FatalError(format!("Synchronizing blocks failed. {:?}", e)),

--- a/base_layer/core/src/consensus/consensus_constants.rs
+++ b/base_layer/core/src/consensus/consensus_constants.rs
@@ -134,7 +134,6 @@ impl ConsensusConstants {
     // This is the min initial difficulty that can be requested for the pow
     pub fn min_pow_difficulty(&self, pow_algo: PowAlgorithm) -> Difficulty {
         match pow_algo {
-            #[cfg(feature = "monero_merge_mining")]
             PowAlgorithm::Monero => self.min_pow_difficulty.0,
             PowAlgorithm::Blake => self.min_pow_difficulty.1,
         }

--- a/base_layer/core/src/proof_of_work/proof_of_work.rs
+++ b/base_layer/core/src/proof_of_work/proof_of_work.rs
@@ -39,7 +39,6 @@ pub trait AchievedDifficulty {}
 #[repr(u8)]
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq)]
 pub enum PowAlgorithm {
-    #[cfg(feature = "monero_merge_mining")]
     Monero = 0,
     Blake = 1,
 }
@@ -58,7 +57,6 @@ impl TryFrom<u64> for PowAlgorithm {
 
     fn try_from(v: u64) -> Result<Self, Self::Error> {
         match v {
-            #[cfg(feature = "monero_merge_mining")]
             0 => Ok(PowAlgorithm::Monero),
             1 => Ok(PowAlgorithm::Blake),
             _ => Err("Invalid PoWAlgorithm".into()),
@@ -124,6 +122,8 @@ impl ProofOfWork {
         match header.pow.pow_algo {
             #[cfg(feature = "monero_merge_mining")]
             PowAlgorithm::Monero => monero_difficulty(header),
+            #[cfg(not(feature = "monero_merge_mining"))]
+            PowAlgorithm::Monero => Difficulty(1),
             PowAlgorithm::Blake => blake_difficulty(header),
         }
     }
@@ -154,7 +154,6 @@ impl ProofOfWork {
     /// total cumulative difficulty and the provided `added_difficulty`.
     pub fn new_from_difficulty(pow: &ProofOfWork, added_difficulty: Difficulty) -> ProofOfWork {
         let (m, b) = match pow.pow_algo {
-            #[cfg(feature = "monero_merge_mining")]
             PowAlgorithm::Monero => (
                 pow.accumulated_monero_difficulty + added_difficulty,
                 pow.accumulated_blake_difficulty,
@@ -207,7 +206,6 @@ impl ProofOfWork {
 impl Display for PowAlgorithm {
     fn fmt(&self, fmt: &mut Formatter<'_>) -> Result<(), Error> {
         let algo = match self {
-            #[cfg(feature = "monero_merge_mining")]
             PowAlgorithm::Monero => "Monero",
             PowAlgorithm::Blake => "Blake",
         };

--- a/base_layer/core/tests/node_service.rs
+++ b/base_layer/core/tests/node_service.rs
@@ -706,7 +706,6 @@ fn local_get_target_difficulty() {
             .await
             .unwrap();
         let blake_target_difficulty1 = node.local_nci.get_target_difficulty(PowAlgorithm::Blake).await.unwrap();
-        #[cfg(feature = "monero_merge_mining")]
         assert_ne!(monero_target_difficulty1, Difficulty::from(0));
         assert_ne!(blake_target_difficulty1, Difficulty::from(0));
 
@@ -719,14 +718,12 @@ fn local_get_target_difficulty() {
         block1.header.pow.pow_algo = PowAlgorithm::Blake;
         node.blockchain_db.add_block(block1).unwrap();
         assert_eq!(node.blockchain_db.get_height(), Ok(Some(1)));
-        #[cfg(feature = "monero_merge_mining")]
         let monero_target_difficulty2 = node
             .local_nci
             .get_target_difficulty(PowAlgorithm::Monero)
             .await
             .unwrap();
         let blake_target_difficulty2 = node.local_nci.get_target_difficulty(PowAlgorithm::Blake).await.unwrap();
-        #[cfg(feature = "monero_merge_mining")]
         assert!(monero_target_difficulty1 <= monero_target_difficulty2);
         assert!(blake_target_difficulty1 <= blake_target_difficulty2);
 


### PR DESCRIPTION
Changing the PowAlgorithm enum is a DB breaking change.
Removed all feature flag conditions that removed the `Monero` enum
variant.
