### PR TITLE
Restricted usage of monero_merge_mining_flag to monero_rx

### DIFF
--- a/applications/tari_base_node/src/grpc.rs
+++ b/applications/tari_base_node/src/grpc.rs
@@ -309,12 +309,9 @@ impl From<BlockHeader> for base_node_grpc::BlockHeader {
             total_kernel_offset: Vec::from(h.total_kernel_offset.as_bytes()),
             nonce: h.nonce,
             pow: Some(base_node_grpc::ProofOfWork {
-                #[allow(dead_code)]
                 pow_algo: match h.pow.pow_algo {
-                    #[cfg(feature = "monero_merge_mining")]
                     PowAlgorithm::Monero => 0,
                     PowAlgorithm::Blake => 1,
-                    _ => 99, // build fails otherwise due to feature flag
                 },
                 accumulated_monero_difficulty: h.pow.accumulated_monero_difficulty.into(),
                 accumulated_blake_difficulty: h.pow.accumulated_blake_difficulty.into(),

--- a/base_layer/core/Cargo.toml
+++ b/base_layer/core/Cargo.toml
@@ -10,7 +10,7 @@ version = "0.1.0"
 edition = "2018"
 
 [features]
-default = ["croaring", "tari_mmr", "transactions", "base_node", "mempool_proto", "base_node_proto"]
+default = ["croaring", "tari_mmr", "transactions", "base_node", "mempool_proto", "base_node_proto", "monero"]
 monero_merge_mining = ["croaring", "tari_mmr", "transactions", "base_node", "mempool_proto", "base_node_proto", "monero", "randomx-rs"]
 transactions = []
 mempool_proto = []

--- a/base_layer/core/src/consensus/consensus_constants.rs
+++ b/base_layer/core/src/consensus/consensus_constants.rs
@@ -134,7 +134,6 @@ impl ConsensusConstants {
     // This is the min initial difficulty that can be requested for the pow
     pub fn min_pow_difficulty(&self, pow_algo: PowAlgorithm) -> Difficulty {
         match pow_algo {
-            #[cfg(feature = "monero_merge_mining")]
             PowAlgorithm::Monero => self.min_pow_difficulty.0,
             PowAlgorithm::Blake => self.min_pow_difficulty.1,
         }

--- a/base_layer/core/src/proof_of_work/mod.rs
+++ b/base_layer/core/src/proof_of_work/mod.rs
@@ -25,7 +25,6 @@ mod difficulty;
 mod error;
 mod median_timestamp;
 #[allow(clippy::enum_variant_names)]
-#[cfg(feature = "monero_merge_mining")]
 mod monero_rx;
 #[allow(clippy::module_inception)]
 mod proof_of_work;
@@ -40,7 +39,6 @@ pub use blake_pow::{blake_difficulty, blake_difficulty_with_hash};
 pub use difficulty::{Difficulty, DifficultyAdjustment};
 pub use error::{DifficultyAdjustmentError, PowError};
 pub use median_timestamp::get_median_timestamp;
-#[cfg(feature = "monero_merge_mining")]
 pub use monero_rx::monero_difficulty;
 pub use proof_of_work::{PowAlgorithm, ProofOfWork};
 pub use target_difficulty::get_target_difficulty;

--- a/base_layer/core/src/proof_of_work/proof_of_work.rs
+++ b/base_layer/core/src/proof_of_work/proof_of_work.rs
@@ -20,11 +20,9 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-#[cfg(feature = "monero_merge_mining")]
-use crate::proof_of_work::monero_rx::monero_difficulty;
 use crate::{
     blocks::BlockHeader,
-    proof_of_work::{blake_pow::blake_difficulty, Difficulty},
+    proof_of_work::{blake_pow::blake_difficulty, monero_rx::monero_difficulty, Difficulty},
 };
 use bytes::{self, BufMut};
 use serde::{Deserialize, Serialize};
@@ -39,7 +37,6 @@ pub trait AchievedDifficulty {}
 #[repr(u8)]
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq)]
 pub enum PowAlgorithm {
-    #[cfg(feature = "monero_merge_mining")]
     Monero = 0,
     Blake = 1,
 }
@@ -58,7 +55,6 @@ impl TryFrom<u64> for PowAlgorithm {
 
     fn try_from(v: u64) -> Result<Self, Self::Error> {
         match v {
-            #[cfg(feature = "monero_merge_mining")]
             0 => Ok(PowAlgorithm::Monero),
             1 => Ok(PowAlgorithm::Blake),
             _ => Err("Invalid PoWAlgorithm".into()),
@@ -122,7 +118,6 @@ impl ProofOfWork {
     /// difficulty of one.
     pub fn achieved_difficulty(header: &BlockHeader) -> Difficulty {
         match header.pow.pow_algo {
-            #[cfg(feature = "monero_merge_mining")]
             PowAlgorithm::Monero => monero_difficulty(header),
             PowAlgorithm::Blake => blake_difficulty(header),
         }
@@ -154,7 +149,6 @@ impl ProofOfWork {
     /// total cumulative difficulty and the provided `added_difficulty`.
     pub fn new_from_difficulty(pow: &ProofOfWork, added_difficulty: Difficulty) -> ProofOfWork {
         let (m, b) = match pow.pow_algo {
-            #[cfg(feature = "monero_merge_mining")]
             PowAlgorithm::Monero => (
                 pow.accumulated_monero_difficulty + added_difficulty,
                 pow.accumulated_blake_difficulty,
@@ -207,7 +201,6 @@ impl ProofOfWork {
 impl Display for PowAlgorithm {
     fn fmt(&self, fmt: &mut Formatter<'_>) -> Result<(), Error> {
         let algo = match self {
-            #[cfg(feature = "monero_merge_mining")]
             PowAlgorithm::Monero => "Monero",
             PowAlgorithm::Blake => "Blake",
         };
@@ -277,20 +270,7 @@ mod test {
     }
 
     #[test]
-    #[cfg(not(feature = "monero_merge_mining"))]
     fn add_difficulty() {
-        let mut pow = ProofOfWork::new(PowAlgorithm::Blake);
-        pow.accumulated_blake_difficulty = Difficulty::from(42);
-        pow.accumulated_monero_difficulty = Difficulty::from(420);
-        let mut pow2 = ProofOfWork::default();
-        pow2.add_difficulty(&pow, Difficulty::from(80));
-        assert_eq!(pow2.accumulated_blake_difficulty, Difficulty::from(122));
-        assert_eq!(pow2.accumulated_monero_difficulty, Difficulty::from(420));
-    }
-
-    #[test]
-    #[cfg(feature = "monero_merge_mining")]
-    fn add_difficulty_merge_mining() {
         let mut pow = ProofOfWork::new(PowAlgorithm::Monero);
         pow.accumulated_blake_difficulty = Difficulty::from(42);
         pow.accumulated_monero_difficulty = Difficulty::from(420);

--- a/base_layer/core/tests/median_timestamp.rs
+++ b/base_layer/core/tests/median_timestamp.rs
@@ -51,26 +51,13 @@ fn test_median_timestamp_with_height() {
     let consensus_manager = ConsensusManagerBuilder::new(network).build();
     let store = create_mem_db(&consensus_manager);
     let pow_algos: Vec<PowAlgorithm>;
-    #[cfg(feature = "monero_merge_mining")]
-    {
-        pow_algos = vec![
-            PowAlgorithm::Blake, // GB default
-            PowAlgorithm::Monero,
-            PowAlgorithm::Blake,
-            PowAlgorithm::Monero,
-            PowAlgorithm::Blake,
-        ];
-    }
-    #[cfg(not(feature = "monero_merge_mining"))]
-    {
-        pow_algos = vec![
-            PowAlgorithm::Blake, // GB default
-            PowAlgorithm::Blake,
-            PowAlgorithm::Blake,
-            PowAlgorithm::Blake,
-            PowAlgorithm::Blake,
-        ];
-    }
+    pow_algos = vec![
+        PowAlgorithm::Blake, // GB default
+        PowAlgorithm::Monero,
+        PowAlgorithm::Blake,
+        PowAlgorithm::Monero,
+        PowAlgorithm::Blake,
+    ];
     create_test_pow_blockchain(&store, pow_algos, &consensus_manager);
     let timestamp_count = 10;
 

--- a/base_layer/core/tests/node_service.rs
+++ b/base_layer/core/tests/node_service.rs
@@ -699,14 +699,12 @@ fn local_get_target_difficulty() {
     assert_eq!(node.blockchain_db.get_height(), Ok(Some(0)));
 
     runtime.block_on(async {
-        #[cfg(feature = "monero_merge_mining")]
         let monero_target_difficulty1 = node
             .local_nci
             .get_target_difficulty(PowAlgorithm::Monero)
             .await
             .unwrap();
         let blake_target_difficulty1 = node.local_nci.get_target_difficulty(PowAlgorithm::Blake).await.unwrap();
-        #[cfg(feature = "monero_merge_mining")]
         assert_ne!(monero_target_difficulty1, Difficulty::from(0));
         assert_ne!(blake_target_difficulty1, Difficulty::from(0));
 
@@ -719,14 +717,12 @@ fn local_get_target_difficulty() {
         block1.header.pow.pow_algo = PowAlgorithm::Blake;
         node.blockchain_db.add_block(block1).unwrap();
         assert_eq!(node.blockchain_db.get_height(), Ok(Some(1)));
-        #[cfg(feature = "monero_merge_mining")]
         let monero_target_difficulty2 = node
             .local_nci
             .get_target_difficulty(PowAlgorithm::Monero)
             .await
             .unwrap();
         let blake_target_difficulty2 = node.local_nci.get_target_difficulty(PowAlgorithm::Blake).await.unwrap();
-        #[cfg(feature = "monero_merge_mining")]
         assert!(monero_target_difficulty1 <= monero_target_difficulty2);
         assert!(blake_target_difficulty1 <= blake_target_difficulty2);
 

--- a/base_layer/core/tests/target_difficulty.rs
+++ b/base_layer/core/tests/target_difficulty.rs
@@ -31,53 +31,7 @@ use tari_core::{
 };
 
 #[test]
-#[cfg(not(feature = "monero_merge_mining"))]
 fn test_target_difficulty_at_tip() {
-    let network = Network::LocalNet;
-    let consensus_manager = ConsensusManagerBuilder::new(network).build();
-    let constants = consensus_manager.consensus_constants();
-    let block_window = constants.get_difficulty_block_window() as usize;
-    let target_time = constants.get_diff_target_block_interval();
-    let max_block_time = constants.get_difficulty_max_block_interval();
-    let store = create_mem_db(&consensus_manager);
-
-    let pow_algos = vec![
-        PowAlgorithm::Blake, //  GB default
-        PowAlgorithm::Blake,
-        PowAlgorithm::Blake,
-        PowAlgorithm::Blake,
-        PowAlgorithm::Blake,
-        PowAlgorithm::Blake,
-        PowAlgorithm::Blake,
-        PowAlgorithm::Blake,
-        PowAlgorithm::Blake,
-        PowAlgorithm::Blake,
-    ];
-    create_test_pow_blockchain(&store, pow_algos.clone(), &consensus_manager);
-    let height = store.get_metadata().unwrap().height_of_longest_chain.unwrap();
-
-    let pow_algo = PowAlgorithm::Blake;
-    let target_difficulties = store.fetch_target_difficulties(pow_algo, height, block_window).unwrap();
-    assert_eq!(
-        get_target_difficulty(
-            target_difficulties,
-            block_window,
-            target_time,
-            constants.min_pow_difficulty(pow_algo),
-            max_block_time
-        ),
-        Ok(calculate_accumulated_difficulty(
-            &store,
-            pow_algo,
-            vec![0, 1, 2, 3, 4, 5, 6, 7, 8, 9],
-            &constants
-        ))
-    );
-}
-
-#[test]
-#[cfg(feature = "monero_merge_mining")]
-fn test_target_difficulty_at_tip_merge_mine() {
     let network = Network::LocalNet;
     let consensus_manager = ConsensusManagerBuilder::new(network).build();
     let constants = consensus_manager.consensus_constants();
@@ -139,81 +93,7 @@ fn test_target_difficulty_at_tip_merge_mine() {
 }
 
 #[test]
-#[cfg(not(feature = "monero_merge_mining"))]
 fn test_target_difficulty_with_height() {
-    let network = Network::LocalNet;
-    let consensus_manager = ConsensusManagerBuilder::new(network).build();
-    let constants = consensus_manager.consensus_constants();
-    let block_window = constants.get_difficulty_block_window() as usize;
-    let target_time = constants.get_diff_target_block_interval();
-    let max_block_time = constants.get_difficulty_max_block_interval();
-    let store = create_mem_db(&consensus_manager);
-
-    let pow_algos = vec![
-        PowAlgorithm::Blake, // GB default
-        PowAlgorithm::Blake,
-        PowAlgorithm::Blake,
-        PowAlgorithm::Blake,
-        PowAlgorithm::Blake,
-        PowAlgorithm::Blake,
-    ];
-    create_test_pow_blockchain(&store, pow_algos, &consensus_manager);
-
-    let pow_algo = PowAlgorithm::Blake;
-    assert_eq!(
-        get_target_difficulty(
-            store.fetch_target_difficulties(pow_algo, 5, block_window).unwrap(),
-            block_window,
-            target_time,
-            constants.min_pow_difficulty(pow_algo),
-            max_block_time
-        ),
-        Ok(calculate_accumulated_difficulty(
-            &store,
-            pow_algo,
-            vec![0, 1, 2, 3, 4, 5],
-            &constants
-        ))
-    );
-
-    let pow_algo = PowAlgorithm::Blake;
-    assert_eq!(
-        get_target_difficulty(
-            store.fetch_target_difficulties(pow_algo, 2, block_window).unwrap(),
-            block_window,
-            target_time,
-            constants.min_pow_difficulty(pow_algo),
-            max_block_time
-        ),
-        Ok(calculate_accumulated_difficulty(
-            &store,
-            pow_algo,
-            vec![0, 1, 2],
-            &constants
-        ))
-    );
-
-    let pow_algo = PowAlgorithm::Blake;
-    assert_eq!(
-        get_target_difficulty(
-            store.fetch_target_difficulties(pow_algo, 3, block_window).unwrap(),
-            block_window,
-            target_time,
-            constants.min_pow_difficulty(pow_algo),
-            max_block_time
-        ),
-        Ok(calculate_accumulated_difficulty(
-            &store,
-            pow_algo,
-            vec![0, 1, 2, 3],
-            &constants
-        ))
-    );
-}
-
-#[test]
-#[cfg(feature = "monero_merge_mining")]
-fn test_target_difficulty_with_height_merge_mine() {
     let network = Network::LocalNet;
     let consensus_manager = ConsensusManagerBuilder::new(network).build();
     let constants = consensus_manager.consensus_constants();


### PR DESCRIPTION
## Description
Restricted usage of monero_merge_mining flag to monero_rx

## Motivation and Context
Existing base nodes encountered a problem `[c::cs::database] ERROR Database access error on request: Block hash` from the previous PR for this.

This should reset the changes to pre-flag code with the exception of the flag being used in monero_rx.

## How Has This Been Tested
cargo test --all

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch.
* [x] I ran `cargo-fmt --all` before pushing.
* [x] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
