### PR TITLE
Removed env var that was set by test.

### DIFF
--- a/common/src/configuration/bootstrap.rs
+++ b/common/src/configuration/bootstrap.rs
@@ -283,7 +283,7 @@ mod test {
         let bootstrap = ConfigBootstrap::from_iter_safe(vec![""]).expect("failed to process arguments");
         assert_eq!(bootstrap.log_config.to_str(), Some("~/fake-example"));
         assert_ne!(bootstrap.config.to_str(), Some("~/fake-example"));
-        std::env::set_var("TARI_LOG_CONFIGURATION", "");
+        std::env::remove_var("TARI_LOG_CONFIGURATION");
     }
 
     #[test]


### PR DESCRIPTION
## Description
Env var set in test test_bootstrap_args_from_iter_safe caused an issue for test test_bootstrap_and_load_configuration.


## Motivation and Context
Env var set in one test caused another test to sometimes fail.

## How Has This Been Tested?
cargo test --all

## Types of changes
* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
* [x] I'm merging against the `development` branch.
* [x] I ran `cargo-fmt --all` before pushing.
* [x] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
