### PR TITLE
Resolve environment race condition for config tests

### DIFF
--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -29,3 +29,4 @@ tempdir = "0.3.7"
 tari_test_utils = { version = "^0.0", path = "../infrastructure/test_utils"}
 serde = { version = "1.0.106", features = ["derive"] }
 anyhow = "1.0"
+lazy_static = "1.4.0"


### PR DESCRIPTION
## Description
All the tests which change/read from environment affecting each other, this PR adds mutex to such config tests. This merge is to ho_loggin_int_dir branch for PR #1853

## Motivation and Context
Environment is shared resource between test threads, hence there is high chance of race condition.

## How Has This Been Tested?
This PR only improves automated tests

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [X] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [ ] I'm merging against the `development` branch.
* [ ] I ran `cargo-fmt --all` before pushing.
* [ ] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [X] I have added tests to cover my changes.
