### PR TITLE
Storage limits for store and forward messages

### DIFF
--- a/comms/dht/Cargo.toml
+++ b/comms/dht/Cargo.toml
@@ -23,7 +23,7 @@ bitflags = "1.2.0"
 bytes = "0.4.12"
 chrono = "0.4.9"
 derive-error = "0.0.4"
-diesel = {version="1.4", features = ["sqlite", "serde_json", "chrono"]}
+diesel = {version="1.4", features = ["sqlite", "serde_json", "chrono", "numeric"]}
 diesel_migrations =  "1.4"
 digest = "0.8.1"
 futures= {version= "^0.3.1"}

--- a/comms/dht/src/config.rs
+++ b/comms/dht/src/config.rs
@@ -24,7 +24,7 @@ use crate::{envelope::Network, storage::DbConnectionUrl};
 use std::time::Duration;
 
 /// The default maximum number of messages that can be stored using the Store-and-forward middleware
-pub const SAF_MSG_CACHE_STORAGE_CAPACITY: usize = 10_000;
+pub const SAF_MSG_STORAGE_CAPACITY: usize = 10_000;
 /// The default time-to-live duration used for storage of low priority messages by the Store-and-forward middleware
 pub const SAF_LOW_PRIORITY_MSG_STORAGE_TTL: Duration = Duration::from_secs(6 * 60 * 60); // 6 hours
 /// The default time-to-live duration used for storage of high priority messages by the Store-and-forward middleware
@@ -46,6 +46,8 @@ pub struct DhtConfig {
     /// `num_neighbouring_nodes`.
     /// Default: 0.5
     pub propagation_factor: f32,
+    /// The maximum number of messages that can be stored using the Store-and-forward middleware. Default: 10_000
+    pub saf_msg_storage_capacity: usize,
     /// A request to retrieve stored messages will be ignored if the requesting node is
     /// not within one of this nodes _n_ closest nodes.
     /// Default 8
@@ -53,8 +55,6 @@ pub struct DhtConfig {
     /// The maximum number of messages to return from a store and forward retrieval request.
     /// Default: 100
     pub saf_max_returned_messages: usize,
-    /// The maximum number of messages that can be stored using the Store-and-forward middleware. Default: 10_000
-    pub saf_msg_cache_storage_capacity: usize,
     /// The time-to-live duration used for storage of low priority messages by the Store-and-forward middleware.
     /// Default: 6 hours
     pub saf_low_priority_msg_storage_ttl: Duration,
@@ -123,7 +123,7 @@ impl Default for DhtConfig {
             saf_num_closest_nodes: 10,
             saf_max_returned_messages: 50,
             outbound_buffer_size: 20,
-            saf_msg_cache_storage_capacity: SAF_MSG_CACHE_STORAGE_CAPACITY,
+            saf_msg_storage_capacity: SAF_MSG_STORAGE_CAPACITY,
             saf_low_priority_msg_storage_ttl: SAF_LOW_PRIORITY_MSG_STORAGE_TTL,
             saf_high_priority_msg_storage_ttl: SAF_HIGH_PRIORITY_MSG_STORAGE_TTL,
             saf_auto_request: true,

--- a/comms/dht/src/store_forward/service.rs
+++ b/comms/dht/src/store_forward/service.rs
@@ -429,6 +429,18 @@ impl StoreAndForwardService {
             )
             .await?;
         info!(target: LOG_TARGET, "Cleaned {} old high priority messages", num_removed);
+
+        let num_removed = self
+            .database
+            .truncate_messages(self.config.saf_msg_storage_capacity)
+            .await?;
+        if num_removed > 0 {
+            info!(
+                target: LOG_TARGET,
+                "Storage limits exceeded, removing {} oldest messages", num_removed
+            );
+        }
+
         Ok(())
     }
 }


### PR DESCRIPTION
## Description
- These changes allow the storage capacity of the store and forward system to be configured and enforced. When the storage limit is reached then the oldest messages are discarded to preserve the configured storage limit.

## Motivation and Context
These changes ensure that the number of store and forward messages do not grow too large.

## How Has This Been Tested?
The truncate_message test was added to test the enforcement of the message storage limit.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch.
* [x] I ran `cargo-fmt --all` before pushing.
* [x] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
