### PR TITLE
Fixes check_db to check for the actual block

### DIFF
--- a/base_layer/core/src/base_node/comms_interface/inbound_handlers.rs
+++ b/base_layer/core/src/base_node/comms_interface/inbound_handlers.rs
@@ -195,6 +195,8 @@ where T: BlockchainBackend + 'static
                     debug!(target: LOG_TARGET, "A peer has requested block {}", block_num);
                     match async_db::fetch_block(self.blockchain_db.clone(), *block_num).await {
                         Ok(block) => blocks.push(block),
+                        // We need to suppress the error as another node might ask for a block we dont have, so we
+                        // return ok([])
                         Err(e) => info!(
                             target: LOG_TARGET,
                             "Could not provide requested block {} to peer because: {}",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This fixes the check_db command to ensure that the actual block can be found.
Also adds a block so it doesnt look for a blocks older than the pruning horizon. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Currently the check_db only checks that the get_blocks return OK, but this will always happen as we cant return an error to another node. This checks that the function actually returns the block as the block we ask for needs to be in the db. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch.
* [x] I ran `cargo-fmt --all` before pushing.
* [x] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
