### PR TITLE
Refactor Transaction Send protocol in Wallet

### DIFF
--- a/base_layer/p2p/src/services/liveness/state.rs
+++ b/base_layer/p2p/src/services/liveness/state.rs
@@ -192,15 +192,30 @@ impl LivenessState {
         self.peer_latency.get(node_id).map(|latency| latency.calc_average())
     }
 
+    /// Add a NodeId to be monitored. If the NodeID already exists then increment the count of how many requests for
+    /// monitoring have occured.
     pub fn add_node_id(&mut self, node_id: &NodeId) {
-        if self.nodes_to_monitor.contains_key(node_id) {
-            return;
+        if let Some(n) = self.nodes_to_monitor.get_mut(node_id) {
+            n.number_of_monitor_requests += 1;
+        } else {
+            let _ = self.nodes_to_monitor.insert(node_id.clone(), NodeStats::new());
         }
-        let _ = self.nodes_to_monitor.insert(node_id.clone(), NodeStats::new());
     }
 
+    /// Reduce the count of how many request has been received to monitor NodeId, if this would reduce the count to zero
+    /// then remove the NodeId
     pub fn remove_node_id(&mut self, node_id: &NodeId) {
-        let _ = self.nodes_to_monitor.remove(node_id);
+        let mut remove_block = false;
+        if let Some(n) = self.nodes_to_monitor.get_mut(node_id) {
+            if n.number_of_monitor_requests > 1 {
+                n.number_of_monitor_requests -= 1;
+            } else {
+                remove_block = true;
+            }
+        }
+        if remove_block {
+            let _ = self.nodes_to_monitor.remove(node_id);
+        }
     }
 
     pub fn get_num_monitored_nodes(&self) -> usize {
@@ -302,6 +317,7 @@ pub struct NodeStats {
     last_ping_sent: Option<NaiveDateTime>,
     last_pong_received: Option<NaiveDateTime>,
     average_latency: AverageLatency,
+    number_of_monitor_requests: u32,
 }
 
 impl NodeStats {
@@ -310,6 +326,7 @@ impl NodeStats {
             last_ping_sent: None,
             last_pong_received: None,
             average_latency: AverageLatency::new(LATENCY_SAMPLE_WINDOW_SIZE),
+            number_of_monitor_requests: 1,
         }
     }
 }
@@ -415,6 +432,16 @@ mod test {
         assert_eq!(stats.average_latency.calc_average(), latency);
 
         state.add_node_id(&node_id2);
+        state.add_node_id(&node_id2);
+        assert_eq!(
+            state
+                .nodes_to_monitor
+                .get(&node_id2)
+                .unwrap()
+                .number_of_monitor_requests,
+            2
+        );
+
         assert_eq!(state.get_num_monitored_nodes(), 2);
         state.add_inflight_ping(1, &node_id2);
         let _ = state.record_pong(1).unwrap();
@@ -428,5 +455,17 @@ mod test {
 
         state.remove_node_id(&node_id);
         assert_eq!(state.get_num_monitored_nodes(), 1);
+        state.remove_node_id(&node_id2);
+        assert_eq!(state.get_num_monitored_nodes(), 1);
+        assert_eq!(
+            state
+                .nodes_to_monitor
+                .get(&node_id2)
+                .unwrap()
+                .number_of_monitor_requests,
+            1
+        );
+        state.remove_node_id(&node_id2);
+        assert_eq!(state.get_num_monitored_nodes(), 0);
     }
 }

--- a/base_layer/wallet/migrations/2020-05-12-142154_add_direct_send_success_column_to_pending_tx/down.sql
+++ b/base_layer/wallet/migrations/2020-05-12-142154_add_direct_send_success_column_to_pending_tx/down.sql
@@ -1,0 +1,5 @@
+ALTER TABLE outbound_transactions
+    DROP COLUMN cancelled;
+
+ALTER TABLE outbound_transactions
+    DROP COLUMN cancelled;

--- a/base_layer/wallet/migrations/2020-05-12-142154_add_direct_send_success_column_to_pending_tx/up.sql
+++ b/base_layer/wallet/migrations/2020-05-12-142154_add_direct_send_success_column_to_pending_tx/up.sql
@@ -1,0 +1,5 @@
+ALTER TABLE outbound_transactions
+    ADD COLUMN direct_send_success INTEGER NOT NULL DEFAULT 0;
+
+ALTER TABLE inbound_transactions
+    ADD COLUMN direct_send_success INTEGER NOT NULL DEFAULT 0;

--- a/base_layer/wallet/src/schema.rs
+++ b/base_layer/wallet/src/schema.rs
@@ -29,6 +29,7 @@ table! {
         message -> Text,
         timestamp -> Timestamp,
         cancelled -> Integer,
+        direct_send_success -> Integer,
     }
 }
 
@@ -52,6 +53,7 @@ table! {
         message -> Text,
         timestamp -> Timestamp,
         cancelled -> Integer,
+        direct_send_success -> Integer,
     }
 }
 

--- a/base_layer/wallet/src/transaction_service/storage/memory_db.rs
+++ b/base_layer/wallet/src/transaction_service/storage/memory_db.rs
@@ -383,6 +383,23 @@ impl TransactionBackend for TransactionMemoryDatabase {
         Ok(())
     }
 
+    fn mark_direct_send_success(&self, tx_id: u64) -> Result<(), TransactionStorageError> {
+        let mut db = acquire_write_lock!(self.db);
+
+        if db.pending_inbound_transactions.contains_key(&tx_id) {
+            if let Some(inbound) = db.pending_inbound_transactions.get_mut(&tx_id) {
+                inbound.direct_send_success = true;
+            }
+        } else if db.pending_outbound_transactions.contains_key(&tx_id) {
+            if let Some(outbound) = db.pending_outbound_transactions.get_mut(&tx_id) {
+                outbound.direct_send_success = true;
+            }
+        } else {
+            return Err(TransactionStorageError::ValuesNotFound);
+        }
+        Ok(())
+    }
+
     #[cfg(feature = "test_harness")]
     fn update_completed_transaction_timestamp(
         &self,

--- a/comms/dht/src/outbound/mod.rs
+++ b/comms/dht/src/outbound/mod.rs
@@ -33,6 +33,7 @@ mod message_params;
 pub use message_params::SendMessageParams;
 
 mod message_send_state;
+pub use message_send_state::MessageSendStates;
 
 mod requester;
 pub use requester::OutboundMessageRequester;


### PR DESCRIPTION
## Description
This PR updates the Transaction send protocol in order to reduce unnecessary	SAF messages and to repeat less. The changes are as follows:
1. First a Direct send is attempted (previously the direct and SAF were both sent at the same time)
2. A SAF message is only sent if a Discovery needs to be done or the Direct messages fails
3. A record is made in the DB if a direct send occurs because then we know the recipient DEFINITELY got the message and no repeat or SAF should be sent
4. If only a SAF message was sent then the Recipient is registered for monitoring by the Liveness service
5. If a PONG is received then only a Direct send is attempted as a repeat sending of the transaction (so SAF is sent on repeats)
6. As soon as a Direct send is successful no further repeats will be sent.

To test this functionality the Outbound Service Mock was updated to allow it to be set to respond to Direct and Broadcast messages in different ways.


## How Has This Been Tested?
Tests updated in Liveness service and for Transaction Service

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [x] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch.
* [x] I ran `cargo-fmt --all` before pushing.
* [ ] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
