### PR TITLE
Only store unique store and forward messages

### DIFF
--- a/comms/dht/migrations/2020-05-14-103121_add_body_hash/down.sql
+++ b/comms/dht/migrations/2020-05-14-103121_add_body_hash/down.sql
@@ -1,0 +1,4 @@
+DROP INDEX uidx_stored_messages_body_hash;
+
+ALTER TABLE stored_messages
+    DROP COLUMN body_hash;

--- a/comms/dht/migrations/2020-05-14-103121_add_body_hash/up.sql
+++ b/comms/dht/migrations/2020-05-14-103121_add_body_hash/up.sql
@@ -1,0 +1,4 @@
+ALTER TABLE stored_messages
+    ADD body_hash TEXT;
+
+CREATE UNIQUE INDEX uidx_stored_messages_body_hash ON stored_messages (body_hash);

--- a/comms/dht/src/schema.rs
+++ b/comms/dht/src/schema.rs
@@ -19,6 +19,7 @@ table! {
         is_encrypted -> Bool,
         priority -> Integer,
         stored_at -> Timestamp,
+        body_hash -> Text,
     }
 }
 

--- a/comms/dht/src/store_forward/database/stored_message.rs
+++ b/comms/dht/src/store_forward/database/stored_message.rs
@@ -27,8 +27,9 @@ use crate::{
     store_forward::message::StoredMessagePriority,
 };
 use chrono::NaiveDateTime;
+use digest::Input;
 use std::convert::TryInto;
-use tari_comms::message::MessageExt;
+use tari_comms::{message::MessageExt, types::Challenge};
 use tari_utilities::hex::Hex;
 
 #[derive(Clone, Debug, Insertable, Default)]
@@ -43,6 +44,7 @@ pub struct NewStoredMessage {
     pub body: Vec<u8>,
     pub is_encrypted: bool,
     pub priority: i32,
+    pub body_hash: String,
 }
 
 impl NewStoredMessage {
@@ -72,6 +74,7 @@ impl NewStoredMessage {
                 let dht_header: DhtHeader = dht_header.into();
                 dht_header.to_encoded_bytes()
             },
+            body_hash: Challenge::new().chain(body.clone()).result().to_vec().to_hex(),
             body,
         })
     }
@@ -90,4 +93,5 @@ pub struct StoredMessage {
     pub is_encrypted: bool,
     pub priority: i32,
     pub stored_at: NaiveDateTime,
+    pub body_hash: String,
 }

--- a/comms/dht/src/store_forward/saf_handler/task.rs
+++ b/comms/dht/src/store_forward/saf_handler/task.rs
@@ -546,6 +546,8 @@ mod test {
     // TODO: unit tests for static functions (check_signature, etc)
 
     fn make_stored_message(node_identity: &NodeIdentity, dht_header: DhtMessageHeader) -> StoredMessage {
+        let body = b"A".to_vec();
+        let body_hash = Challenge::new().chain(body.clone()).result().to_vec().to_hex();
         StoredMessage {
             id: 1,
             version: 0,
@@ -554,10 +556,11 @@ mod test {
             destination_pubkey: None,
             destination_node_id: None,
             header: DhtHeader::from(dht_header).to_encoded_bytes(),
-            body: b"A".to_vec(),
+            body,
             is_encrypted: false,
             priority: StoredMessagePriority::High as i32,
             stored_at: Utc::now().naive_utc(),
+            body_hash,
         }
     }
 

--- a/comms/dht/src/store_forward/service.rs
+++ b/comms/dht/src/store_forward/service.rs
@@ -256,7 +256,7 @@ impl StoreAndForwardService {
             InsertMessage(msg) => {
                 let public_key = msg.destination_pubkey.clone();
                 let node_id = msg.destination_node_id.clone();
-                match self.database.insert_message(msg).await {
+                match self.database.insert_message_if_unique(msg).await {
                     Ok(_) => info!(
                         target: LOG_TARGET,
                         "Stored message for {}",

--- a/comms/dht/src/test_utils/store_and_forward_mock.rs
+++ b/comms/dht/src/test_utils/store_and_forward_mock.rs
@@ -22,6 +22,7 @@
 
 use crate::store_forward::{StoreAndForwardRequest, StoreAndForwardRequester, StoredMessage};
 use chrono::Utc;
+use digest::Input;
 use futures::{channel::mpsc, stream::Fuse, StreamExt};
 use log::*;
 use rand::{rngs::OsRng, RngCore};
@@ -29,6 +30,8 @@ use std::sync::{
     atomic::{AtomicUsize, Ordering},
     Arc,
 };
+use tari_comms::types::Challenge;
+use tari_utilities::hex::Hex;
 use tokio::{runtime, sync::RwLock};
 
 const LOG_TARGET: &str = "comms::dht::discovery_mock";
@@ -124,10 +127,11 @@ impl StoreAndForwardMock {
                 destination_pubkey: msg.destination_pubkey,
                 destination_node_id: msg.destination_node_id,
                 header: msg.header,
-                body: msg.body,
+                body: msg.body.clone(),
                 is_encrypted: msg.is_encrypted,
                 priority: msg.priority,
                 stored_at: Utc::now().naive_utc(),
+                body_hash: Challenge::new().chain(msg.body).result().to_vec().to_hex(),
             }),
             RemoveMessages(message_ids) => {
                 for id in message_ids {


### PR DESCRIPTION
## Description
- These changes allow only unique messages to be stored by the store and forward system.
- This is achieved by comparing the body hash of a new message to the hashes of the currently stored set of messages. Only if the body content is unique is the message stored by the store and forward database.

## Motivation and Context
Limit unnecessary storage of messages with duplicate content.

## How Has This Been Tested?
Modified the store and forward database insert_message test to also test the behaviour when a duplicate message is inserted.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [x] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch.
* [x] I ran `cargo-fmt --all` before pushing.
* [x] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
