### PR TITLE
Don't panic if the logger is initialized twice in Wallet FFI

### DIFF
--- a/base_layer/wallet_ffi/src/lib.rs
+++ b/base_layer/wallet_ffi/src/lib.rs
@@ -2330,8 +2330,13 @@ pub unsafe extern "C" fn wallet_create(
             .build(Root::builder().appender("logfile").build(LevelFilter::Debug))
             .unwrap();
 
-        log4rs::init_config(lconfig).expect("Should be able to start logging");
-        debug!(target: LOG_TARGET, "Logging started");
+        match log4rs::init_config(lconfig) {
+            Ok(_) => debug!(target: LOG_TARGET, "Logging started"),
+            Err(_) => error!(
+                target: LOG_TARGET,
+                "Could not start logging, logging was probably already started"
+            ),
+        }
     }
 
     let runtime = Runtime::new();

--- a/base_layer/wallet_ffi/src/lib.rs
+++ b/base_layer/wallet_ffi/src/lib.rs
@@ -2332,10 +2332,7 @@ pub unsafe extern "C" fn wallet_create(
 
         match log4rs::init_config(lconfig) {
             Ok(_) => debug!(target: LOG_TARGET, "Logging started"),
-            Err(_) => error!(
-                target: LOG_TARGET,
-                "Could not start logging, logging was probably already started"
-            ),
+            Err(_) => warn!(target: LOG_TARGET, "Logging has already been initialized"),
         }
     }
 


### PR DESCRIPTION
## Description
When the wallet FFI container is initialized the global Rust logger is started. It would panic if the global logger was already set which happened in the iOS environment. This PR stops that panic and just logs it as an error.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [x] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch.
* [x] I ran `cargo-fmt --all` before pushing.
* [ ] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
