### PR TITLE
Adding GetCalcTiming function to grpc service

### DIFF
--- a/applications/tari_base_node/proto/base_node.proto
+++ b/applications/tari_base_node/proto/base_node.proto
@@ -32,8 +32,28 @@ service BaseNode {
     rpc ListHeaders(ListHeadersRequest) returns (stream BlockHeader);
     // Returns blocks in the current best chain. Currently only supports querying by height
     rpc GetBlocks(GetBlocksRequest) returns (stream HistoricalBlock);
+    // Returns the calc timing for the chain heights
+    rpc GetCalcTiming(GetCalcTimingRequest) returns (CalcTimingResponse);
 }
 
+
+// The request used for querying the calc timing from the base node.
+// If start_height and end_height are set and > 0, they take precedence, otherwise from_tip is used
+message GetCalcTimingRequest {
+    // The height from the chain tip (optional)
+    uint64 from_tip = 1;
+    // The starting height (optional)
+    uint64 start_height = 2;
+    // The ending height (optional)
+    uint64 end_height = 3;
+}
+
+// The return type of the rpc GetCalcTiming
+message CalcTimingResponse {
+    uint64 max = 1;
+    uint64 min = 2;
+    double avg = 3;
+}
 // The request used for querying headers from the base node. The parameters `from_height` and `num_headers` can be used
 // to page through the current best chain.
 message ListHeadersRequest {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Added in the GetCalcTiming grpc endpoint. Part of doing that was decoupling some of the functionality from the `Parser` these were only small changes, as there is further work required there to fully de-couple the cli from the base node. The height lists and header responses were moved into the `BlockHeader`, there could be a better place for them, but it made sense in context.
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Getting more of the functionality ported to the GRPC interface is going to help with the block explorer requirements. This was some low hanging fruit to get started with.
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
`cargo test` 
No new tests have been written for the grpc endpoints yet.
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch.
* [x] I ran `cargo-fmt --all` before pushing.
* [x] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
