### PR TITLE
Add `get_cancelled_transaction_by_id` to FFI & update cancel callback

### DIFF
--- a/base_layer/wallet_ffi/wallet.h
+++ b/base_layer/wallet_ffi/wallet.h
@@ -342,7 +342,7 @@ struct TariWallet *wallet_create(struct TariWalletConfig *config,
                                     void (*callback_transaction_mined)(struct TariCompletedTransaction*),
                                     void (*callback_direct_send_result)(unsigned long long, bool),
                                     void (*callback_store_and_forward_send_result)(unsigned long long, bool),
-                                    void (*callback_transaction_cancellation)(unsigned long long),
+                                    void (*callback_transaction_cancellation)(struct TariCompletedTransaction*),
                                     void (*callback_base_node_sync_complete)(unsigned long long, bool),
                                     int* error_out);
 
@@ -402,6 +402,9 @@ struct TariPendingOutboundTransaction *wallet_get_pending_outbound_transaction_b
 
 // Get the TariPendingInboundTransaction from a TariWallet by its TransactionId
 struct TariPendingInboundTransaction *wallet_get_pending_inbound_transaction_by_id(struct TariWallet *wallet, unsigned long long transaction_id,int* error_out);
+
+// Get a Cancelled transaction from a TariWallet by its TransactionId. Pending Inbound or Outbound transaction will be converted to a CompletedTransaction
+struct TariCompletedTransaction *wallet_get_cancelled_transaction_by_id(struct TariWallet *wallet, unsigned long long transaction_id, int* error_out);
 
 // Simulates completion of a TariPendingOutboundTransaction
 bool wallet_test_complete_sent_transaction(struct TariWallet *wallet, struct TariPendingOutboundTransaction *tx,int* error_out);


### PR DESCRIPTION
## Description
This PR add a `get_cancelled_transaction_by_id(…)` function to the FFI to request a single cancelled transaction. It also updates the `callback_transaction_cancellation(…)` callback in the FFI to return a pointer to the Transaction that was cancelled.

To facilitate this the Transaction service backend was updated to allow for queries of cancelled inbound, outbound and completed transactions.

@StriderDM This PR will require updates to the Swift and JNI interfaces
@kukabi and @Jasonvdb This PR will change the return type of the transaction_cancellation callback in addition to adding the new FFI function.

## Motivation and Context
Closes https://github.com/tari-project/tari/issues/1866

## How Has This Been Tested?
Tests have been updated to exercise all the additions.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [x] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch.
* [x] I ran `cargo-fmt --all` before pushing.
* [ ] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
