### PR TITLE
Add msg tag to the DHT header to enable traces across nodes.

### DIFF
--- a/base_layer/p2p/src/services/liveness/service.rs
+++ b/base_layer/p2p/src/services/liveness/service.rs
@@ -367,7 +367,7 @@ where
             let excluded = self
                 .neighbours
                 .node_ids()
-                .into_iter()
+                .iter()
                 .chain(vec![node_id])
                 .cloned()
                 .collect();
@@ -441,7 +441,7 @@ where
     }
 
     async fn refresh_random_peer_pool(&mut self) -> Result<(), LivenessError> {
-        let excluded = self.neighbours.node_ids().into_iter().cloned().collect();
+        let excluded = self.neighbours.node_ids().to_vec();
 
         // Select a pool of random peers the same length as neighbouring peers
         let random_peers = self
@@ -565,6 +565,7 @@ mod test {
     use rand::rngs::OsRng;
     use std::time::Duration;
     use tari_comms::{
+        message::MessageTag,
         multiaddr::Multiaddr,
         peer_manager::{NodeId, Peer, PeerFeatures, PeerFlags},
     };
@@ -694,6 +695,7 @@ mod test {
                 message_type: DhtMessageType::None,
                 network: Network::LocalTest,
                 flags: Default::default(),
+                message_tag: MessageTag::new(),
             },
             authenticated_origin: None,
             source_peer,

--- a/base_layer/p2p/src/test_utils.rs
+++ b/base_layer/p2p/src/test_utils.rs
@@ -67,7 +67,7 @@ pub fn make_node_identity() -> Arc<NodeIdentity> {
     )
 }
 
-pub fn make_dht_header() -> DhtMessageHeader {
+pub fn make_dht_header(trace: MessageTag) -> DhtMessageHeader {
     DhtMessageHeader {
         version: 0,
         destination: NodeDestination::Unknown,
@@ -76,13 +76,15 @@ pub fn make_dht_header() -> DhtMessageHeader {
         message_type: DhtMessageType::None,
         network: Network::LocalTest,
         flags: DhtMessageFlags::NONE,
+        message_tag: trace,
     }
 }
 
 pub fn make_dht_inbound_message(node_identity: &NodeIdentity, message: Vec<u8>) -> DhtInboundMessage {
+    let msg_tag = MessageTag::new();
     DhtInboundMessage::new(
-        MessageTag::new(),
-        make_dht_header(),
+        msg_tag,
+        make_dht_header(msg_tag),
         Arc::new(Peer::new(
             node_identity.public_key().clone(),
             node_identity.node_id().clone(),

--- a/base_layer/wallet/src/transaction_service/protocols/transaction_send_protocol.rs
+++ b/base_layer/wallet/src/transaction_service/protocols/transaction_send_protocol.rs
@@ -353,19 +353,21 @@ where TBackend: TransactionBackend + Clone + 'static
                 },
                 Some(send_states) => {
                     if send_states.len() == 1 {
+                        let msg_tag = send_states[0].tag;
                         debug!(
                             target: LOG_TARGET,
-                            "Transaction Finalized (TxId: {}) Direct Send to {} queued with Message Tag: {:?}",
+                            "Transaction Finalized (TxId: {}) Direct Send to {} queued with Message Tag: {}",
                             self.id,
                             self.dest_pubkey,
-                            send_states[0].tag,
+                            &msg_tag,
                         );
                         match send_states.wait_single().await {
                             true => {
                                 info!(
                                     target: LOG_TARGET,
-                                    "Direct Send of Transaction Finalized message for TX_ID: {} was successful",
-                                    self.id
+                                    "Direct Send of Transaction Finalized message for TX_ID: {} was successful ({})",
+                                    self.id,
+                                    msg_tag
                                 );
                             },
                             false => {
@@ -507,7 +509,7 @@ where TBackend: TransactionBackend + Clone + 'static
         if send_states.len() == 1 {
             debug!(
                 target: LOG_TARGET,
-                "Transaction (TxId: {}) Direct Send to {} queued with Message Tag: {:?}",
+                "Transaction (TxId: {}) Direct Send to {} queued with Message Tag: {}",
                 self.id,
                 self.dest_pubkey,
                 send_states[0].tag,

--- a/base_layer/wallet/tests/support/comms_and_services.rs
+++ b/base_layer/wallet/tests/support/comms_and_services.rs
@@ -23,6 +23,7 @@
 use futures::Sink;
 use std::{error::Error, sync::Arc, time::Duration};
 use tari_comms::{
+    message::MessageTag,
     multiaddr::Multiaddr,
     peer_manager::{NodeId, NodeIdentity, Peer, PeerFeatures, PeerFlags},
     transports::MemoryTransport,
@@ -84,6 +85,7 @@ pub fn create_dummy_message<T>(inner: T, public_key: &CommsPublicKey) -> DomainM
             flags: Default::default(),
             network: Network::LocalTest,
             destination: Default::default(),
+            message_tag: MessageTag::new(),
         },
         authenticated_origin: None,
         source_peer: peer_source,

--- a/comms/dht/src/envelope.rs
+++ b/comms/dht/src/envelope.rs
@@ -34,6 +34,7 @@ use tari_utilities::{ByteArray, ByteArrayError};
 // Re-export applicable protos
 pub use crate::proto::envelope::{dht_header::Destination, DhtEnvelope, DhtHeader, DhtMessageType, Network};
 use bytes::Bytes;
+use tari_comms::message::MessageTag;
 
 #[derive(Debug, Error)]
 pub enum DhtMessageError {
@@ -118,6 +119,7 @@ pub struct DhtMessageHeader {
     pub message_type: DhtMessageType,
     pub network: Network,
     pub flags: DhtMessageFlags,
+    pub message_tag: MessageTag,
 }
 
 impl DhtMessageHeader {
@@ -134,8 +136,8 @@ impl Display for DhtMessageHeader {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
         write!(
             f,
-            "DhtMessageHeader (Dest:{}, Type:{:?}, Network:{:?}, Flags:{:?})",
-            self.destination, self.message_type, self.network, self.flags
+            "DhtMessageHeader (Dest:{}, Type:{:?}, Network:{:?}, Flags:{:?}, Trace:{})",
+            self.destination, self.message_type, self.network, self.flags, self.message_tag
         )
     }
 }
@@ -169,6 +171,7 @@ impl TryFrom<DhtHeader> for DhtMessageHeader {
                 .ok_or_else(|| DhtMessageError::InvalidMessageType)?,
             network: Network::from_i32(header.network).ok_or_else(|| DhtMessageError::InvalidNetwork)?,
             flags: DhtMessageFlags::from_bits(header.flags).ok_or_else(|| DhtMessageError::InvalidMessageFlags)?,
+            message_tag: MessageTag::from(header.message_tag),
         })
     }
 }
@@ -198,6 +201,7 @@ impl From<DhtMessageHeader> for DhtHeader {
             message_type: header.message_type as i32,
             network: header.network as i32,
             flags: header.flags.bits(),
+            message_tag: header.message_tag.as_value(),
         }
     }
 }

--- a/comms/dht/src/outbound/message.rs
+++ b/comms/dht/src/outbound/message.rs
@@ -189,8 +189,8 @@ impl fmt::Display for DhtOutboundMessage {
             .map(|h| format!("{} (Propagated)", h))
             .unwrap_or_else(|| {
                 format!(
-                    "Network: {:?}, Flags: {:?}, Destination: {}",
-                    self.network, self.dht_flags, self.destination
+                    "Network: {:?}, Flags: {:?}, Destination: {}, Trace: {}",
+                    self.network, self.dht_flags, self.destination, self.tag,
                 )
             });
         write!(

--- a/comms/dht/src/outbound/serialize.rs
+++ b/comms/dht/src/outbound/serialize.rs
@@ -89,6 +89,7 @@ where S: Service<OutboundMessage, Response = (), Error = PipelineError> + Clone 
                 network: network as i32,
                 flags: dht_flags.bits(),
                 destination: Some(destination.into()),
+                message_tag: tag.as_value(),
             });
             let envelope = DhtEnvelope::new(dht_header, body);
 
@@ -106,6 +107,7 @@ where S: Service<OutboundMessage, Response = (), Error = PipelineError> + Clone 
     }
 }
 
+#[derive(Default)]
 pub struct SerializeLayer;
 
 impl SerializeLayer {

--- a/comms/dht/src/proto/envelope.proto
+++ b/comms/dht/src/proto/envelope.proto
@@ -42,6 +42,9 @@ message DhtHeader {
     // The network for which this message is intended (e.g. TestNet, MainNet etc.)
     Network network = 8;
     uint32 flags = 9;
+    // Message trace ID
+    // TODO: Remove for mainnet or when testing message traces is not required
+    uint64 message_tag = 10;
 }
 
 enum Network {

--- a/comms/dht/src/proto/tari.dht.envelope.rs
+++ b/comms/dht/src/proto/tari.dht.envelope.rs
@@ -19,6 +19,10 @@ pub struct DhtHeader {
     pub network: i32,
     #[prost(uint32, tag = "9")]
     pub flags: u32,
+    /// Message trace ID
+    /// TODO: Remove for mainnet or when testing message traces is not required
+    #[prost(uint64, tag = "10")]
+    pub message_tag: u64,
     #[prost(oneof = "dht_header::Destination", tags = "2, 3, 4")]
     pub destination: ::std::option::Option<dht_header::Destination>,
 }

--- a/comms/dht/src/store_forward/saf_handler/task.rs
+++ b/comms/dht/src/store_forward/saf_handler/task.rs
@@ -275,7 +275,7 @@ where S: Service<DecryptedDhtMessage, Response = (), Error = PipelineError>
             SafResponseType::from_i32(response.response_type)
                 .as_ref()
                 .map(|t| format!("{:?}", t))
-                .unwrap_or("<Invalid>".to_string()),
+                .unwrap_or_else(|| "<Invalid>".to_string()),
         );
 
         let tasks = response
@@ -577,7 +577,15 @@ mod test {
 
         // Recent message
         let (e_sk, e_pk) = make_keypair();
-        let dht_header = make_dht_header(&node_identity, &e_pk, &e_sk, &[], DhtMessageFlags::empty(), false);
+        let dht_header = make_dht_header(
+            &node_identity,
+            &e_pk,
+            &e_sk,
+            &[],
+            DhtMessageFlags::empty(),
+            false,
+            MessageTag::new(),
+        );
         mock_state
             .add_message(make_stored_message(&node_identity, dht_header))
             .await;

--- a/comms/src/message/tag.rs
+++ b/comms/src/message/tag.rs
@@ -31,6 +31,16 @@ impl MessageTag {
     pub fn new() -> Self {
         Self(OsRng.next_u64())
     }
+
+    pub fn as_value(self) -> u64 {
+        self.0
+    }
+}
+
+impl From<u64> for MessageTag {
+    fn from(v: u64) -> Self {
+        Self(v)
+    }
 }
 
 impl fmt::Display for MessageTag {

--- a/comms/src/protocol/messaging/inbound.rs
+++ b/comms/src/protocol/messaging/inbound.rs
@@ -59,21 +59,21 @@ impl InboundMessaging {
         while let Some(result) = framed_socket.next().await {
             match result {
                 Ok(raw_msg) => {
+                    let inbound_msg = InboundMessage::new(Arc::clone(&peer), raw_msg.clone().freeze());
                     trace!(
                         target: LOG_TARGET,
-                        "Received message from peer '{}' ({} bytes)",
+                        "Received message {} from peer '{}' ({} bytes)",
+                        inbound_msg.clone().tag,
                         peer.node_id.short_str(),
                         raw_msg.len()
                     );
 
-                    let inbound_msg = InboundMessage::new(Arc::clone(&peer), raw_msg.freeze());
-
                     let event = MessagingEvent::MessageReceived(
                         Box::new(inbound_msg.source_peer.node_id.clone()),
-                        inbound_msg.tag,
+                        inbound_msg.clone().tag,
                     );
 
-                    if let Err(err) = self.inbound_message_tx.send(inbound_msg).await {
+                    if let Err(err) = self.inbound_message_tx.send(inbound_msg.clone()).await {
                         warn!(
                             target: LOG_TARGET,
                             "Failed to send InboundMessage for peer '{}' because '{}'",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Enabling tracking of messages across nodes during testnet.

Example trace across nodes:
**Sender stage 1**
```
2020-05-20 10:51:38.181692300 [wallet::transaction_service::protocols::send_protocol] DEBUG Transaction (TxId: 17864096577764166221) Direct Send to 34ff4b3d9b20b76237becba4a839616a0b12441bb7a02152efdb08276e60e21e queued with Message Tag: MessageTag(9987700374622772089)
Header: Network: TestNet, Flags: NONE, Destination: Unknown, Trace: Tag#9987700374622772089
Tag#9987700374622772089
2020-05-20 10:51:38.181692300 [comms::dht::serialize] DEBUG Serializing outbound message MessageTag(9987700374622772089)
2020-05-20 10:51:45.683754200 [comms::protocol::messaging::outbound] TRACE Sending message (161 bytes) (MessageTag(9987700374622772089)) on outbound messaging substream
2020-05-20 10:51:45.684755600 [comms::protocol::messaging] TRACE Internal messaging event 'MessageSent(Tag#9987700374622772089)'
```
**Receiver stage 1**
```
2020-05-20 10:51:46.201902100 [comms::dht::deserialize] DEBUG Deserialization succeeded. Passing message Tag#8017475515622449727 onto next service (Trace: Tag#9987700374622772089)
Header: DhtMessageHeader (Dest:Unknown, Type:None, Network:TestNet, Flags:NONE, Trace:Tag#9987700374622772089)
2020-05-20 10:51:46.255901200 [wallet::transaction_service::service] TRACE Handling Transaction Message, Trace: Tag#9987700374622772089
2020-05-20 10:51:46.255901200 [wallet::transaction_service::service] TRACE Transaction (TxId: 17864096577764166221) received from 2609540b35ae89562ac985a7d5ba38e94ada5fd9dea3aa9781dd3c75eeb0cd5a, Trace: Tag#9987700374622772089
BUG Transaction Reply (TxId: 17864096577764166221) Direct Send to 2609540b35ae89562ac985a7d5ba38e94ada5fd9dea3aa9781dd3c75eeb0cd5a queued with Message Tag: MessageTag(9469085710403154976), Trace: Tag#9987700374622772089
2020-05-20 10:51:46.297899400 [wallet::transaction_service::service] INFO  Direct Send of Transaction Reply message for TX_ID: 17864096577764166221 was successful, Trace: Tag#9987700374622772089
2020-05-20 10:51:46.304898100 [wallet::transaction_service::service] INFO  Transaction with TX_ID = 17864096577764166221 received from 2609540b35ae89562ac985a7d5ba38e94ada5fd9dea3aa9781dd3c75eeb0cd5a, Trace: Tag#9987700374622772089. Reply Sent
2020-05-20 10:51:46.304898100 [wallet::transaction_service::service] INFO  Transaction (TX_ID: 17864096577764166221) - Amount: 9000 µT - Message: #Test direct Tx send 20200520_1050, Trace: Tag#9987700374622772089
```
**Receiver stage 2**
```
Header: Network: TestNet, Flags: NONE, Destination: Unknown, Trace: Tag#9469085710403154976
Tag#9469085710403154976
2020-05-20 10:51:46.296898000 [comms::dht::serialize] DEBUG Serializing outbound message MessageTag(9469085710403154976)
2020-05-20 10:51:46.297899400 [wallet::transaction_service::service] DEBUG Transaction Reply (TxId: 17864096577764166221) Direct Send to 2609540b35ae89562ac985a7d5ba38e94ada5fd9dea3aa9781dd3c75eeb0cd5a queued with Message Tag: MessageTag(9469085710403154976), Trace: Tag#9987700374622772089
2020-05-20 10:51:46.297899400 [comms::protocol::messaging::outbound] TRACE Sending message (869 bytes) (MessageTag5710403154976)) on outbound messaging substream
2020-05-20 10:51:46.297899400 [comms::protocol::messaging] TRACE Internal messaging event 'MessageSent(Tag#9469085710403154976)'
```
**Sender stage 2**
```
2020-05-20 10:51:46.804956900 [comms::dht::deserialize] DEBUG Deserialization succeeded. Passing message Tag#14698651695090578213 onto next service (Trace: Tag#9469085710403154976)
Header: DhtMessageHeader (Dest:Unknown, Type:None, Network:TestNet, Flags:NONE, Trace:Tag#9469085710403154976)
2020-05-20 10:51:46.805956400 [wallet::transaction_service::service] TRACE Handling Transaction Reply Message, Trace: Tag#9469085710403154976
```

## Motivation and Context
Sometimes messages disappear between nodes; this change to enable tracking messages across nodes during testnet by inserting the originating message tag into the DHT header.

## How Has This Been Tested?
Tested between 2x Windows and 1x Linux nodes.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [X] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [X] I'm merging against the `development` branch.
* [X] I ran `cargo-fmt --all` before pushing.
* [X] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [X] I have added tests to cover my changes.
