### PR TITLE
Comms shutdown callback

### DIFF
--- a/base_layer/wallet_ffi/src/lib.rs
+++ b/base_layer/wallet_ffi/src/lib.rs
@@ -2307,6 +2307,7 @@ pub unsafe extern "C" fn wallet_create(
     callback_store_and_forward_send_result: unsafe extern "C" fn(c_ulonglong, bool),
     callback_transaction_cancellation: unsafe extern "C" fn(*mut TariCompletedTransaction),
     callback_base_node_sync_complete: unsafe extern "C" fn(u64, bool),
+    callback_comms_shutdown_finished: unsafe extern "C" fn(),
     error_out: *mut c_int,
 ) -> *mut TariWallet
 {
@@ -2394,6 +2395,7 @@ pub unsafe extern "C" fn wallet_create(
                         callback_store_and_forward_send_result,
                         callback_transaction_cancellation,
                         callback_base_node_sync_complete,
+                        callback_comms_shutdown_finished,
                     );
 
                     w.runtime.spawn(callback_handler.start());
@@ -4126,6 +4128,10 @@ mod test {
         assert!(true);
     }
 
+    unsafe extern "C" fn comms_shutdown_finished_callback() {
+        assert!(true);
+    }
+
     unsafe extern "C" fn received_tx_callback_bob(tx: *mut TariPendingInboundTransaction) {
         assert_eq!(tx.is_null(), false);
         assert_eq!(
@@ -4470,6 +4476,7 @@ mod test {
                 store_and_forward_send_callback,
                 tx_cancellation_callback,
                 base_node_sync_process_complete_callback,
+                comms_shutdown_finished_callback,
                 error_ptr,
             );
             let secret_key_bob = private_key_generate();
@@ -4504,6 +4511,7 @@ mod test {
                 store_and_forward_send_callback_bob,
                 tx_cancellation_callback_bob,
                 base_node_sync_process_complete_callback_bob,
+                comms_shutdown_finished_callback,
                 error_ptr,
             );
 

--- a/base_layer/wallet_ffi/wallet.h
+++ b/base_layer/wallet_ffi/wallet.h
@@ -342,7 +342,7 @@ struct TariWallet *wallet_create(struct TariWalletConfig *config,
                                     void (*callback_transaction_mined)(struct TariCompletedTransaction*),
                                     void (*callback_direct_send_result)(unsigned long long, bool),
                                     void (*callback_store_and_forward_send_result)(unsigned long long, bool),
-                                    void (*callback_transaction_cancellation)(unsigned long long),
+                                    void (*callback_transaction_cancellation)(struct TariCompletedTransaction*),
                                     void (*callback_base_node_sync_complete)(unsigned long long, bool),
                                     int* error_out);
 
@@ -402,6 +402,9 @@ struct TariPendingOutboundTransaction *wallet_get_pending_outbound_transaction_b
 
 // Get the TariPendingInboundTransaction from a TariWallet by its TransactionId
 struct TariPendingInboundTransaction *wallet_get_pending_inbound_transaction_by_id(struct TariWallet *wallet, unsigned long long transaction_id,int* error_out);
+
+// Get a Cancelled transaction from a TariWallet by its TransactionId. Pending Inbound or Outbound transaction will be converted to a CompletedTransaction
+struct TariCompletedTransaction *wallet_get_cancelled_transaction_by_id(struct TariWallet *wallet, unsigned long long transaction_id, int* error_out);
 
 // Simulates completion of a TariPendingOutboundTransaction
 bool wallet_test_complete_sent_transaction(struct TariWallet *wallet, struct TariPendingOutboundTransaction *tx,int* error_out);

--- a/base_layer/wallet_ffi/wallet.h
+++ b/base_layer/wallet_ffi/wallet.h
@@ -344,6 +344,7 @@ struct TariWallet *wallet_create(struct TariWalletConfig *config,
                                     void (*callback_store_and_forward_send_result)(unsigned long long, bool),
                                     void (*callback_transaction_cancellation)(struct TariCompletedTransaction*),
                                     void (*callback_base_node_sync_complete)(unsigned long long, bool),
+                                    void (*callback_comms_shutdown_finished)(void),
                                     int* error_out);
 
 // Signs a message


### PR DESCRIPTION
## Description
Merge #1879 first.

Comms shutdown callback. Callback is triggered when the shutdown signal is received from Comms.

## Motivation and Context
closes #1877 

## How Has This Been Tested?
cargo test --lib

## Types of changes
* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
* [x] I'm merging against the `development` branch.
* [x] I ran `cargo-fmt --all` before pushing.
* [x] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
