### PR TITLE
Chain metadata service not updating metadata on reorgs

### DIFF
--- a/base_layer/core/src/base_node/chain_metadata_service/service.rs
+++ b/base_layer/core/src/base_node/chain_metadata_service/service.rs
@@ -24,7 +24,7 @@ use super::{error::ChainMetadataSyncError, LOG_TARGET};
 use crate::{
     base_node::{
         chain_metadata_service::handle::{ChainMetadataEvent, PeerChainMetadata},
-        comms_interface::{BlockEvent, Broadcast, LocalNodeCommsInterface},
+        comms_interface::{BlockEvent, LocalNodeCommsInterface},
         proto,
     },
     chain_storage::BlockAddResult,
@@ -109,9 +109,9 @@ impl ChainMetadataService {
 
     /// Handle BlockEvents
     async fn handle_block_event(&mut self, event: &BlockEvent) -> Result<(), ChainMetadataSyncError> {
-        let _broadcast = Broadcast::from(true);
         match event {
-            BlockEvent::Verified((_, BlockAddResult::Ok, _broadcast)) => {
+            BlockEvent::Verified((_, BlockAddResult::Ok, _)) |
+            BlockEvent::Verified((_, BlockAddResult::ChainReorg(_), _)) => {
                 self.update_liveness_chain_metadata().await?;
             },
             BlockEvent::Verified(_) | BlockEvent::Invalid(_) => {},

--- a/comms/src/builder/consts.rs
+++ b/comms/src/builder/consts.rs
@@ -42,4 +42,4 @@ pub const MESSAGING_EVENTS_BUFFER_SIZE: usize = 100;
 pub const MESSAGING_REQUEST_BUFFER_SIZE: usize = 50;
 /// The default maximum number of times to retry sending a failed message before publishing a SendMessageFailed event.
 /// This can be low because dialing a peer is already attempted a number of times.
-pub const MESSAGING_MAX_SEND_RETRIES: usize = 2;
+pub const MESSAGING_MAX_SEND_RETRIES: usize = 1;


### PR DESCRIPTION
## Description
- Fixed an issue with the chain metadata service where it was not updating its copy of the chain metadata on reorg events. This could have resulted in some nodes on the network reporting outdated chain metadata.
- The chain metadata service will look for both block add and reorg events to determine if the blockchain db state was updated and the latest chain metadata needs to be retrieved.
 -Also, chained the max send retries used by the Message protocol to 1.

## Motivation and Context
The chain metadata service keeps an internal copy of the chain metadata that it distributes to remote nodes. It should keep this copy uptodate with the blockchain db based on received BlockEvents. It only updated the metadata on block add events and not reorg events, this could have resulted in outdated metadata being shared on the network.

## How Has This Been Tested?
Existing tests remain functioning.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch.
* [x] I ran `cargo-fmt --all` before pushing.
* [x] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
