### PR TITLE
Add local pub key to the source and dest fields for cancelled txs from wallet_get_cancelled_transaction_by_id(...) FFI function

### DIFF
--- a/base_layer/wallet_ffi/src/lib.rs
+++ b/base_layer/wallet_ffi/src/lib.rs
@@ -3739,7 +3739,9 @@ pub unsafe extern "C" fn wallet_get_cancelled_transaction_by_id(
         };
 
         if let Some(tx) = outbound_transactions.remove(&transaction_id) {
-            transaction = Some(CompletedTransaction::from(tx));
+            let mut outbound_tx = CompletedTransaction::from(tx);
+            outbound_tx.source_public_key = (*wallet).comms.node_identity().public_key().clone();
+            transaction = Some(outbound_tx);
         } else {
             let mut inbound_transactions = match (*wallet).runtime.block_on(
                 (*wallet)
@@ -3754,7 +3756,9 @@ pub unsafe extern "C" fn wallet_get_cancelled_transaction_by_id(
                 },
             };
             if let Some(tx) = inbound_transactions.remove(&transaction_id) {
-                transaction = Some(CompletedTransaction::from(tx));
+                let mut inbound_tx = CompletedTransaction::from(tx);
+                inbound_tx.destination_public_key = (*wallet).comms.node_identity().public_key().clone();
+                transaction = Some(inbound_tx);
             }
         }
     }


### PR DESCRIPTION
## Description
The cancelled transactions returned by the `wallet_get_cancelled_transaction_by_id(…)` FFI function returns a CompletedTransaction of which some could be previous PendingInbound and PendingOutbound transactions. These previously pending transactions done have destination and source public keys in them because they are destined for or originate from the local node. In the conversion to a CompletedTransaction the respective pub key was zeroed.

This PR updated the  `wallet_get_cancelled_transaction_by_id(…)` function to include the local pub key in the respective fields.


## How Has This Been Tested?
Existing tests

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch.
* [x] I ran `cargo-fmt --all` before pushing.
* [ ] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
