### PR TITLE
Updated Dockerfile to be self contained

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,4 @@
+buildtools
 target
 .env
 

--- a/README.md
+++ b/README.md
@@ -229,7 +229,11 @@ places the binary inside a small container, keeping the executable binary to a m
 
 Test your image
 
-    docker run tari_base_node tari_base_node --help
+    docker run --rm -ti tari_base_node tari_base_node --help
+    
+Run the base node
+
+    docker run -ti -v /path/to/config/dir:/root/.tari tari_base_node
 
 ---
 

--- a/buildtools/base_node.Dockerfile
+++ b/buildtools/base_node.Dockerfile
@@ -19,14 +19,31 @@ RUN apt update && apt install \
     iputils-ping \
     less \
     telnet \
-    -y
+    gpg \
+    apt-transport-https \
+    ca-certificates \
+    -y && \
+    # Add Sources for the latest tor
+    printf "deb https://deb.torproject.org/torproject.org stretch main\ndeb-src https://deb.torproject.org/torproject.org stretch main" > /etc/apt/sources.list.d/tor.list && \
+    curl https://deb.torproject.org/torproject.org/A3C4F0F979CAA22CDBA8F512EE8CBC9E886DDD89.asc | gpg --import 1>&2 && \
+    gpg --export A3C4F0F979CAA22CDBA8F512EE8CBC9E886DDD89 | apt-key add - 1>&2 &&\
+    apt update 1>&2 && \
+    apt install -y tor deb.torproject.org-keyring 1>&2 && \
+    # Standard config for the tor client
+    printf "SocksPort 127.0.0.1:9050\nControlPort 127.0.0.1:9051\nCookieAuthentication 0\nClientOnly 1\nClientUseIPv6 1" > /etc/tor/torrc && \
+    # start.sh script to run tor, sleep 15 seconds and start the base node
+    printf "#!/bin/bash\ntor &\nsleep 15\nif [[ ! -f ~/.tari/config.toml ]]; then\n  tari_base_node --init --create-id\nfi\ntari_base_node" > /usr/bin/start.sh && \
+    chmod +x /usr/bin/start.sh
+
 
 # Now create a new image with only the essentials and throw everything else away
 FROM base
+
 COPY --from=builder /tari_base_node/target/release/tari_base_node /usr/bin/
-#COPY --from=builder /basenode/target/release/tari_base_node.d /etc/tari_base_node.d
-RUN mkdir /etc/tari_base_node.d
-COPY --from=builder /tari_base_node/common/config/tari_config_sample.toml /etc/tari_base_node.d/tari_config_sample.toml
+COPY --from=builder /tari_base_node/common/config/tari_config_sample.toml /root/.tari/tari_config_sample.toml
 COPY --from=builder /tari_base_node/common/logging/log4rs-sample.yml /root/.tari/log4rs.yml
 
-CMD ["tari_base_node"]
+# Keep the .tari directory in a volume by default
+VOLUME ["/root/.tari"]
+# Use start.sh to run tor then the base node or tari_base_node for the executable
+CMD ["start.sh"]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Having just the base node executable without a way to use it seemed less than optimal. 

The Dockerfile now includes the latest version of tor as well as a bundled `start.sh` script that starts tor, waits 15 seconds (i know this is hacky) for the bootstrapping to complete, then starts the base node. If checks for a config file on start and if it doesn't find one it runs `tari_base_node --init --create-id` then runs `tari_base_node`.

To run the base node `docker run -ti --rm tari_base_node:latest` to maintain your wallet you should bind a volume to `/root/tari`  e.g. `docker run -ti -v $(pwd)/tari:/root/.tari tari_base_node:latest`
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Trying to run the base node inside a Docker container was an incredibly complicated process that required multiple images, changes to the config file on the fly, authorization for the tor control port and more, by bundling tor into the image the process is simpler than running it on your host machine.
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Building and running the docker image successfully.
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch.
* [x] I ran `cargo-fmt --all` before pushing.
* [x] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [x] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
