### PR TITLE
Pruned mode sync peer selection

### DIFF
--- a/base_layer/core/src/base_node/states/block_sync.rs
+++ b/base_layer/core/src/base_node/states/block_sync.rs
@@ -30,7 +30,6 @@ use crate::{
 };
 use core::cmp::min;
 use derive_error::Error;
-use futures::SinkExt;
 use log::*;
 use rand::seq::SliceRandom;
 use std::{

--- a/base_layer/core/src/base_node/states/listening.rs
+++ b/base_layer/core/src/base_node/states/listening.rs
@@ -29,7 +29,7 @@ use crate::{
     chain_storage::{BlockchainBackend, ChainMetadata},
     proof_of_work::Difficulty,
 };
-use futures::{stream::StreamExt, SinkExt};
+use futures::stream::StreamExt;
 use log::*;
 use std::fmt::{Display, Formatter};
 use tari_comms::peer_manager::NodeId;
@@ -80,9 +80,10 @@ impl ListeningData {
                         };
                         // Find the best network metadata and set of sync peers with the best tip.
                         let best_metadata = best_metadata(peer_metadata_list.as_slice());
-                        let sync_peers = find_sync_peers(&best_metadata, &peer_metadata_list);
+                        let local_tip_height = local.height_of_longest_chain.unwrap_or(0);
+                        let sync_peers = select_sync_peers(local_tip_height, &best_metadata, &peer_metadata_list);
                         if let SyncStatus::Lagging(network_tip, sync_peers) =
-                            determine_sync_mode(&local, best_metadata, sync_peers, LOG_TARGET)
+                            determine_sync_mode(&local, best_metadata, sync_peers)
                         {
                             return StateEvent::FallenBehind(SyncStatus::Lagging(network_tip, sync_peers));
                         }
@@ -99,11 +100,21 @@ impl ListeningData {
     }
 }
 
-// Finds the set of sync peers that have the best tip on their main chain.
-fn find_sync_peers(best_metadata: &ChainMetadata, peer_metadata_list: &[PeerChainMetadata]) -> Vec<NodeId> {
+// Finds the set of sync peers that have the best tip on their main chain and have all the data required to update the
+// local node.
+fn select_sync_peers(
+    local_tip_height: u64,
+    best_metadata: &ChainMetadata,
+    peer_metadata_list: &[PeerChainMetadata],
+) -> Vec<NodeId>
+{
     let mut sync_peers = Vec::<NodeId>::new();
     for peer_metadata in peer_metadata_list {
-        if peer_metadata.chain_metadata == *best_metadata {
+        let peer_tip_height = peer_metadata.chain_metadata.height_of_longest_chain;
+        let peer_horizon_height = peer_metadata.chain_metadata.horizon_block(peer_tip_height.unwrap_or(0));
+        if (peer_horizon_height <= local_tip_height) &&
+            (peer_metadata.chain_metadata.best_block == best_metadata.best_block)
+        {
             sync_peers.push(peer_metadata.node_id.clone());
         }
     }
@@ -128,18 +139,12 @@ fn best_metadata(metadata_list: &[PeerChainMetadata]) -> ChainMetadata {
 }
 
 /// Given a local and the network chain state respectively, figure out what synchronisation state we should be in.
-fn determine_sync_mode(
-    local: &ChainMetadata,
-    network: ChainMetadata,
-    sync_peers: Vec<NodeId>,
-    log_target: &str,
-) -> SyncStatus
-{
+fn determine_sync_mode(local: &ChainMetadata, network: ChainMetadata, sync_peers: Vec<NodeId>) -> SyncStatus {
     use crate::base_node::states::SyncStatus::*;
     match network.accumulated_difficulty {
         None => {
             info!(
-                target: log_target,
+                target: LOG_TARGET,
                 "The rest of the network doesn't appear to have any up-to-date chain data, so we're going to assume \
                  we're at the tip"
             );
@@ -149,7 +154,7 @@ fn determine_sync_mode(
             let local_tip_accum_difficulty = local.accumulated_difficulty.unwrap_or_else(|| 0.into());
             if local_tip_accum_difficulty < network_tip_accum_difficulty {
                 info!(
-                    target: log_target,
+                    target: LOG_TARGET,
                     "Our local blockchain accumulated difficulty is a little behind that of the network. We're at \
                      block #{} with an accumulated difficulty of {}, and the network chain tip is at #{} with an \
                      accumulated difficulty of {}",
@@ -161,7 +166,7 @@ fn determine_sync_mode(
                 Lagging(network, sync_peers)
             } else {
                 info!(
-                    target: log_target,
+                    target: LOG_TARGET,
                     "Our blockchain is up-to-date. We're at block {} with an accumulated difficulty of {} and the \
                      network chain tip is at {} with an accumulated difficulty of {}",
                     local.height_of_longest_chain.unwrap_or(0),
@@ -172,5 +177,104 @@ fn determine_sync_mode(
                 UpToDate
             }
         },
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::blocks::BlockHash;
+    use rand::rngs::OsRng;
+    use tari_comms::types::CommsPublicKey;
+    use tari_crypto::keys::PublicKey;
+
+    fn random_node_id() -> NodeId {
+        let (_secret_key, public_key) = CommsPublicKey::random_keypair(&mut OsRng);
+        NodeId::from_key(&public_key).unwrap()
+    }
+
+    #[test]
+    fn sync_peer_selection() {
+        let local_tip_height: u64 = 4000;
+        let network_tip_height = 5000;
+        let block_hash1: BlockHash = vec![0, 1, 2, 3];
+        let block_hash2: BlockHash = vec![4, 5, 6, 7];
+        let accumulated_difficulty1 = Difficulty::from(200000);
+        let accumulated_difficulty2 = Difficulty::from(100000);
+
+        let mut peer_metadata_list = Vec::<PeerChainMetadata>::new();
+        let best_network_metadata = best_metadata(peer_metadata_list.as_slice());
+        assert_eq!(best_network_metadata, ChainMetadata::default());
+        let sync_peers = select_sync_peers(local_tip_height, &best_network_metadata, &peer_metadata_list);
+        assert_eq!(sync_peers.len(), 0);
+
+        let node_id1 = random_node_id();
+        let node_id2 = random_node_id();
+        let node_id3 = random_node_id();
+        let node_id4 = random_node_id();
+        let node_id5 = random_node_id();
+        let peer1 = PeerChainMetadata::new(
+            node_id1.clone(),
+            ChainMetadata::new(network_tip_height, block_hash1.clone(), 0, accumulated_difficulty1),
+        ); // Archival node
+        let peer2 = PeerChainMetadata::new(
+            node_id2,
+            ChainMetadata::new(network_tip_height, block_hash1.clone(), 500, accumulated_difficulty1),
+        ); // Pruning horizon is to short to sync from
+        let peer3 = PeerChainMetadata::new(
+            node_id3.clone(),
+            ChainMetadata::new(network_tip_height, block_hash1.clone(), 1440, accumulated_difficulty1),
+        );
+        let peer4 = PeerChainMetadata::new(
+            node_id4,
+            ChainMetadata::new(network_tip_height, block_hash2, 2880, accumulated_difficulty2),
+        ); // Node running a fork
+        let peer5 = PeerChainMetadata::new(
+            node_id5.clone(),
+            ChainMetadata::new(network_tip_height, block_hash1.clone(), 2880, accumulated_difficulty1),
+        );
+        peer_metadata_list.push(peer1);
+        peer_metadata_list.push(peer2);
+        peer_metadata_list.push(peer3);
+        peer_metadata_list.push(peer4);
+        peer_metadata_list.push(peer5);
+
+        let best_network_metadata = best_metadata(peer_metadata_list.as_slice());
+        assert_eq!(best_network_metadata.height_of_longest_chain, Some(network_tip_height));
+        assert_eq!(best_network_metadata.best_block, Some(block_hash1));
+        assert_eq!(
+            best_network_metadata.accumulated_difficulty,
+            Some(accumulated_difficulty1)
+        );
+        let sync_peers = select_sync_peers(local_tip_height, &best_network_metadata, &peer_metadata_list);
+        assert_eq!(sync_peers.len(), 3);
+        assert!(sync_peers.contains(&node_id1));
+        assert!(sync_peers.contains(&node_id3));
+        assert!(sync_peers.contains(&node_id5));
+    }
+
+    #[test]
+    fn sync_mode_selection() {
+        let mut local = ChainMetadata::default();
+        local.accumulated_difficulty = Some(Difficulty::from(500000));
+        let mut network1 = ChainMetadata::default();
+        network1.accumulated_difficulty = Some(Difficulty::from(499999));
+        let mut network2 = ChainMetadata::default();
+        network2.accumulated_difficulty = Some(Difficulty::from(500001));
+
+        match determine_sync_mode(&local, local.clone(), vec![]) {
+            SyncStatus::Lagging(_, _) => assert!(false),
+            SyncStatus::UpToDate => assert!(true),
+        }
+
+        match determine_sync_mode(&local, network1, vec![]) {
+            SyncStatus::Lagging(_, _) => assert!(false),
+            SyncStatus::UpToDate => assert!(true),
+        }
+
+        match determine_sync_mode(&local, network2.clone(), vec![]) {
+            SyncStatus::Lagging(network, _) => assert_eq!(network, network2),
+            SyncStatus::UpToDate => assert!(false),
+        }
     }
 }

--- a/base_layer/core/src/chain_storage/metadata.rs
+++ b/base_layer/core/src/chain_storage/metadata.rs
@@ -39,11 +39,17 @@ pub struct ChainMetadata {
 }
 
 impl ChainMetadata {
-    pub fn new(height: u64, hash: BlockHash, horizon: u64, accumulated_difficulty: Difficulty) -> ChainMetadata {
+    pub fn new(
+        height: u64,
+        hash: BlockHash,
+        pruning_horizon: u64,
+        accumulated_difficulty: Difficulty,
+    ) -> ChainMetadata
+    {
         ChainMetadata {
             height_of_longest_chain: Some(height),
             best_block: Some(hash),
-            pruning_horizon: horizon,
+            pruning_horizon,
             accumulated_difficulty: Some(accumulated_difficulty),
         }
     }

--- a/base_layer/core/tests/chain_storage_tests/chain_storage.rs
+++ b/base_layer/core/tests/chain_storage_tests/chain_storage.rs
@@ -60,7 +60,7 @@ use tari_core::{
     txn_schema,
     validation::{
         accum_difficulty_validators::MockAccumDifficultyValidator,
-        block_validators::{MockStatelessBlockValidator, StatelessBlockValidator},
+        block_validators::MockStatelessBlockValidator,
         mocks::MockValidator,
     },
 };

--- a/base_layer/core/tests/node_state_machine.rs
+++ b/base_layer/core/tests/node_state_machine.rs
@@ -65,7 +65,7 @@ use tari_core::{
     transactions::types::CryptoFactories,
     validation::{
         accum_difficulty_validators::MockAccumDifficultyValidator,
-        block_validators::{MockStatelessBlockValidator, StatelessBlockValidator},
+        block_validators::MockStatelessBlockValidator,
         mocks::MockValidator,
     },
 };


### PR DESCRIPTION
## Description
The sync peer selection mechanism was changed to allow the node listening state to only select sync peers with the entire range of data required by the current node. The pruning horizon and the current nodes tip height is used to determine if the network node has all the required chain data.

## Motivation and Context
These changes allow block syncing to function correctly when some nodes are running in archival mode. It will enable a lagging node to only select sync peers with all the chain data required for syncing by considering the reported tip height and pruning horizon of network nodes.

## How Has This Been Tested?
 Two tests were added for the node listening state to test sync peer selection and sync mode selection.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [x] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch.
* [x] I ran `cargo-fmt --all` before pushing.
* [x] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
