### PR TITLE
Blockchain db pruning horizon limits and orphan pool cleanup

### DIFF
--- a/base_layer/core/src/chain_storage/blockchain_database.rs
+++ b/base_layer/core/src/chain_storage/blockchain_database.rs
@@ -257,11 +257,21 @@ where T: BlockchainBackend
             validators,
             config,
         };
-        if blockchain_db.get_height()?.is_none() {
+        let metadata = blockchain_db.get_metadata()?;
+        if metadata.height_of_longest_chain.is_none() {
             let genesis_block = consensus_manager.get_genesis_block();
             blockchain_db.store_new_block(genesis_block)?;
             blockchain_db.store_pruning_horizon(config.pruning_horizon)?;
+        } else if (metadata.is_archival_node() && (config.pruning_horizon != metadata.pruning_horizon)) ||
+            (metadata.is_pruned_node() && (config.pruning_horizon < metadata.pruning_horizon))
+        {
+            debug!(
+                target: LOG_TARGET,
+                "Updating pruning horizon from {} to {}.", metadata.pruning_horizon, config.pruning_horizon,
+            );
+            blockchain_db.store_pruning_horizon(config.pruning_horizon)?;
         }
+
         Ok(blockchain_db)
     }
 
@@ -512,7 +522,7 @@ where T: BlockchainBackend
     ///
     /// The operation will fail if
     /// * The block height is in the future
-    /// * The block height is before pruning horizon
+    /// * The block height is before the horizon block height determined by the pruning horizon
     pub fn rewind_to_height(&self, height: u64) -> Result<Vec<Block>, ChainStorageError> {
         let mut db = self.db_write_access()?;
         rewind_to_height(&mut db, height)
@@ -642,10 +652,8 @@ fn add_block<T: BlockchainBackend>(
     let block_add_result = handle_possible_reorg(db, block_validator, accum_difficulty_validator, block)?;
     // Cleanup orphan block pool
     match block_add_result {
-        BlockAddResult::Ok => {},
-        BlockAddResult::BlockExists => {},
-        BlockAddResult::OrphanBlock => cleanup_orphans_single(db, orphan_storage_capacity)?,
-        BlockAddResult::ChainReorg(_) => cleanup_orphans_comprehensive(db, orphan_storage_capacity)?,
+        BlockAddResult::Ok | BlockAddResult::BlockExists => {},
+        BlockAddResult::OrphanBlock | BlockAddResult::ChainReorg(_) => cleanup_orphans(db, orphan_storage_capacity)?,
     }
     Ok(block_add_result)
 }
@@ -667,7 +675,7 @@ fn store_new_block<T: BlockchainBackend>(db: &mut RwLockWriteGuard<T>, block: Bl
     ));
     txn.insert(DbKeyValuePair::Metadata(
         MetadataKey::BestBlock,
-        MetadataValue::BestBlock(Some(best_block.clone())),
+        MetadataValue::BestBlock(Some(best_block)),
     ));
     txn.insert(DbKeyValuePair::Metadata(
         MetadataKey::AccumulatedWork,
@@ -730,11 +738,19 @@ fn fetch_block_with_hash<T: BlockchainBackend>(
 }
 
 fn check_for_valid_height<T: BlockchainBackend>(db: &T, height: u64) -> Result<u64, ChainStorageError> {
-    let db_height = db.fetch_metadata()?.height_of_longest_chain.unwrap_or(0);
+    let metadata = db.fetch_metadata()?;
+    let db_height = metadata.height_of_longest_chain.unwrap_or(0);
     if height > db_height {
         return Err(ChainStorageError::InvalidQuery(format!(
             "Cannot get block at height {}. Chain tip is at {}",
             height, db_height
+        )));
+    }
+    let horizon_height = metadata.horizon_block(db_height);
+    if height < horizon_height {
+        return Err(ChainStorageError::InvalidQuery(format!(
+            "Cannot get block at height {}. Horizon height is at {}",
+            height, horizon_height
         )));
     }
     Ok(db_height)
@@ -1248,67 +1264,39 @@ fn find_strongest_orphan_tip<T: BlockchainBackend>(
     Ok((best_accum_difficulty, best_tip_hash))
 }
 
-// Discards the orphan block with the minimum height from the block orphan pool to maintain the configured orphan pool
-// storage limit.
-fn cleanup_orphans_single<T: BlockchainBackend>(
-    db: &mut RwLockWriteGuard<T>,
-    orphan_storage_capacity: usize,
-) -> Result<(), ChainStorageError>
-{
-    if db.get_orphan_count()? > orphan_storage_capacity {
-        trace!(
-            target: LOG_TARGET,
-            "Orphan block storage limit reached, performing simple cleanup.",
-        );
-        let mut min_height: u64 = u64::max_value();
-        let mut remove_hash: Option<BlockHash> = None;
-        db.for_each_orphan(|pair| {
-            let (_, block) = pair.unwrap();
-            if block.header.height < min_height {
-                min_height = block.header.height;
-                remove_hash = Some(block.hash());
-            }
-        })
-        .expect("Unexpected result for database query");
-        if let Some(hash) = remove_hash {
-            trace!(target: LOG_TARGET, "Discarding orphan block ({}).", hash.to_hex());
-            remove_orphan(db, hash)?;
-        }
-    }
-    Ok(())
-}
-
 // Perform a comprehensive search to remove all the minimum height orphans to maintain the configured orphan pool
-// storage limit.
-fn cleanup_orphans_comprehensive<T: BlockchainBackend>(
+// storage limit. If the node is configured to run in pruned mode then orphan blocks with heights lower than the horizon
+// block height will also be discarded.
+fn cleanup_orphans<T: BlockchainBackend>(
     db: &mut RwLockWriteGuard<T>,
     orphan_storage_capacity: usize,
 ) -> Result<(), ChainStorageError>
 {
     let orphan_count = db.get_orphan_count()?;
-    if orphan_count > orphan_storage_capacity {
+    let num_over_limit = orphan_count.saturating_sub(orphan_storage_capacity);
+    if num_over_limit > 0 {
         trace!(
             target: LOG_TARGET,
-            "Orphan block storage limit reached, performing comprehensive cleanup.",
+            "Orphan block storage limit reached, performing cleanup.",
         );
-        let remove_count = orphan_count - orphan_storage_capacity;
 
         let mut orphans = Vec::<(u64, BlockHash)>::with_capacity(orphan_count);
         db.for_each_orphan(|pair| {
-            let (_, block) = pair.unwrap();
-            orphans.push((block.header.height, block.hash()));
+            let (block_hash, block) = pair.unwrap();
+            orphans.push((block.header.height, block_hash));
         })
         .expect("Unexpected result for database query");
         orphans.sort_by(|a, b| a.0.cmp(&b.0));
 
+        let metadata = db.fetch_metadata()?;
+        let horizon_height = metadata.horizon_block(metadata.height_of_longest_chain.unwrap_or(0));
         let mut txn = DbTransaction::new();
-        for i in 0..remove_count {
-            trace!(
-                target: LOG_TARGET,
-                "Discarding orphan block ({}).",
-                orphans[i].1.to_hex()
-            );
-            txn.delete(DbKey::OrphanBlock(orphans[i].1.clone()));
+        for (removed_count, (height, block_hash)) in orphans.into_iter().enumerate() {
+            if height > horizon_height && removed_count >= num_over_limit {
+                break;
+            }
+            trace!(target: LOG_TARGET, "Discarding orphan block ({}).", block_hash.to_hex());
+            txn.delete(DbKey::OrphanBlock(block_hash.clone()));
         }
         commit(db, txn)?;
     }
@@ -1332,7 +1320,7 @@ where T: BlockchainBackend
         BlockchainDatabase {
             db: self.db.clone(),
             validators: self.validators.clone(),
-            config: self.config.clone(),
+            config: self.config,
         }
     }
 }

--- a/base_layer/core/src/chain_storage/lmdb_db/lmdb_db.rs
+++ b/base_layer/core/src/chain_storage/lmdb_db/lmdb_db.rs
@@ -529,6 +529,9 @@ impl<D> BlockchainBackend for LMDBDatabase<D>
 where D: Digest + Send + Sync
 {
     fn write(&mut self, tx: DbTransaction) -> Result<(), ChainStorageError> {
+        if tx.operations.is_empty() {
+            return Ok(());
+        }
         match self.apply_mmr_and_storage_txs(&tx) {
             Ok(_) => self.commit_mmrs(tx),
             Err(e) => {

--- a/base_layer/core/src/chain_storage/memory_db/memory_db.rs
+++ b/base_layer/core/src/chain_storage/memory_db/memory_db.rs
@@ -202,6 +202,10 @@ impl<D> BlockchainBackend for MemoryDatabase<D>
 where D: Digest + Send + Sync
 {
     fn write(&mut self, tx: DbTransaction) -> Result<(), ChainStorageError> {
+        if tx.operations.is_empty() {
+            return Ok(());
+        }
+
         let mut db = self
             .db
             .write()

--- a/base_layer/core/src/chain_storage/metadata.rs
+++ b/base_layer/core/src/chain_storage/metadata.rs
@@ -77,6 +77,16 @@ impl ChainMetadata {
     pub fn pruned_mode(&mut self) {
         self.pruning_horizon = 2880;
     }
+
+    /// Check if the node is an archival node based on its pruning horizon.
+    pub fn is_archival_node(&self) -> bool {
+        self.pruning_horizon == 0
+    }
+
+    /// Check if the node is a pruned node based on its pruning horizon.
+    pub fn is_pruned_node(&self) -> bool {
+        self.pruning_horizon != 0
+    }
 }
 
 impl Default for ChainMetadata {

--- a/base_layer/core/tests/chain_storage_tests/chain_storage.rs
+++ b/base_layer/core/tests/chain_storage_tests/chain_storage.rs
@@ -534,6 +534,36 @@ fn rewind_to_height() {
 }
 
 #[test]
+fn rewind_past_horizon_height() {
+    let network = Network::LocalNet;
+    let consensus_manager = ConsensusManagerBuilder::new(network).build();
+    let consensus_constansts = consensus_manager.consensus_constants();
+    let validators = Validators::new(
+        MockValidator::new(true),
+        MockValidator::new(true),
+        MockAccumDifficultyValidator {},
+    );
+    let db = MemoryDatabase::<HashDigest>::default();
+    let config = BlockchainDatabaseConfig {
+        orphan_storage_capacity: 3,
+        pruning_horizon: 2,
+    };
+    let store = BlockchainDatabase::new(db, &consensus_manager, validators, config).unwrap();
+
+    let block0 = store.fetch_block(0).unwrap().block().clone();
+    let block1 = append_block(&store, &block0, vec![], &consensus_constansts, 1.into()).unwrap();
+    let block2 = append_block(&store, &block1, vec![], &consensus_constansts, 1.into()).unwrap();
+    let block3 = append_block(&store, &block2, vec![], &consensus_constansts, 1.into()).unwrap();
+    let _block4 = append_block(&store, &block3, vec![], &consensus_constansts, 1.into()).unwrap();
+
+    let metadata = store.get_metadata().unwrap();
+    let horizon_height = metadata.horizon_block(metadata.height_of_longest_chain.unwrap_or(0));
+    assert!(store.rewind_to_height(horizon_height - 1).is_err());
+    assert!(store.rewind_to_height(horizon_height).is_ok());
+    assert_eq!(store.get_height(), Ok(Some(horizon_height)));
+}
+
+#[test]
 fn handle_tip_reorg() {
     // GB --> A1 --> A2(Low PoW)      [Main Chain]
     //          \--> B2(Highest PoW)  [Forked Chain]
@@ -812,7 +842,7 @@ fn store_and_retrieve_chain_and_orphan_blocks_with_hashes() {
 }
 
 #[test]
-fn restore_metadata() {
+fn restore_metadata_and_pruning_horizon_update() {
     let path = create_temporary_data_path();
 
     // Perform test
@@ -824,12 +854,13 @@ fn restore_metadata() {
         );
         let network = Network::LocalNet;
         let rules = ConsensusManagerBuilder::new(network).build();
+        let mut config = BlockchainDatabaseConfig::default();
         let block_hash: BlockHash;
-        let pruning_horizon: u64 = 1000;
+        let pruning_horizon1: u64 = 1000;
+        let pruning_horizon2: u64 = 900;
         {
             let db = create_lmdb_database(&path, MmrCacheConfig::default()).unwrap();
-            let mut config = BlockchainDatabaseConfig::default();
-            config.pruning_horizon = pruning_horizon;
+            config.pruning_horizon = pruning_horizon1;
             let db = BlockchainDatabase::new(db, &rules, validators.clone(), config).unwrap();
 
             let block0 = db.fetch_block(0).unwrap().block().clone();
@@ -839,16 +870,30 @@ fn restore_metadata() {
             let metadata = db.get_metadata().unwrap();
             assert_eq!(metadata.height_of_longest_chain, Some(1));
             assert_eq!(metadata.best_block, Some(block_hash.clone()));
-            assert_eq!(metadata.pruning_horizon, pruning_horizon);
+            assert_eq!(metadata.pruning_horizon, pruning_horizon1);
         }
-        // Restore blockchain db
-        let db = create_lmdb_database(&path, MmrCacheConfig::default()).unwrap();
-        let db = BlockchainDatabase::new(db, &rules, validators, BlockchainDatabaseConfig::default()).unwrap();
+        // Restore blockchain db with invalid pruning horizon update
+        {
+            config.pruning_horizon = 2000;
+            let db = create_lmdb_database(&path, MmrCacheConfig::default()).unwrap();
+            let db = BlockchainDatabase::new(db, &rules, validators.clone(), config).unwrap();
 
-        let metadata = db.get_metadata().unwrap();
-        assert_eq!(metadata.height_of_longest_chain, Some(1));
-        assert_eq!(metadata.best_block, Some(block_hash));
-        assert_eq!(metadata.pruning_horizon, pruning_horizon);
+            let metadata = db.get_metadata().unwrap();
+            assert_eq!(metadata.height_of_longest_chain, Some(1));
+            assert_eq!(metadata.best_block, Some(block_hash.clone()));
+            assert_eq!(metadata.pruning_horizon, pruning_horizon1);
+        }
+        // Restore blockchain db with valid pruning horizon update
+        {
+            config.pruning_horizon = pruning_horizon2; // Invalid pruning horizon, keep original
+            let db = create_lmdb_database(&path, MmrCacheConfig::default()).unwrap();
+            let db = BlockchainDatabase::new(db, &rules, validators, config).unwrap();
+
+            let metadata = db.get_metadata().unwrap();
+            assert_eq!(metadata.height_of_longest_chain, Some(1));
+            assert_eq!(metadata.best_block, Some(block_hash));
+            assert_eq!(metadata.pruning_horizon, pruning_horizon2);
+        }
     }
 
     // Cleanup test data - in Windows the LMBD `set_mapsize` sets file size equals to map size; Linux use sparse files
@@ -1034,6 +1079,51 @@ fn orphan_cleanup_on_block_add() {
     assert!(store.fetch_orphan(orphan5_hash).is_err());
     assert!(store.fetch_orphan(orphan6_hash).is_err());
     assert_eq!(store.fetch_orphan(orphan7_hash), Ok(orphan7));
+}
+
+#[test]
+fn horizon_height_orphan_cleanup() {
+    let network = Network::LocalNet;
+    let consensus_manager = ConsensusManagerBuilder::new(network).build();
+    let consensus_constansts = consensus_manager.consensus_constants();
+    let validators = Validators::new(
+        MockValidator::new(true),
+        MockValidator::new(true),
+        MockAccumDifficultyValidator {},
+    );
+    let db = MemoryDatabase::<HashDigest>::default();
+    let config = BlockchainDatabaseConfig {
+        orphan_storage_capacity: 3,
+        pruning_horizon: 2,
+    };
+    let store = BlockchainDatabase::new(db, &consensus_manager, validators, config).unwrap();
+    let orphan1 = create_orphan_block(2, vec![], &consensus_constansts);
+    let orphan2 = create_orphan_block(3, vec![], &consensus_constansts);
+    let orphan3 = create_orphan_block(1, vec![], &consensus_constansts);
+    let orphan4 = create_orphan_block(4, vec![], &consensus_constansts);
+    let orphan1_hash = orphan1.hash();
+    let orphan2_hash = orphan2.hash();
+    let orphan3_hash = orphan3.hash();
+    let orphan4_hash = orphan4.hash();
+    assert_eq!(store.add_block(orphan1), Ok(BlockAddResult::OrphanBlock));
+    assert_eq!(store.add_block(orphan2.clone()), Ok(BlockAddResult::OrphanBlock));
+    assert_eq!(store.add_block(orphan3), Ok(BlockAddResult::OrphanBlock));
+    assert_eq!(store.db_read_access().unwrap().get_orphan_count(), Ok(3));
+
+    let block0 = store.fetch_block(0).unwrap().block().clone();
+    let block1 = append_block(&store, &block0, vec![], &consensus_constansts, 1.into()).unwrap();
+    let block2 = append_block(&store, &block1, vec![], &consensus_constansts, 1.into()).unwrap();
+    let block3 = append_block(&store, &block2, vec![], &consensus_constansts, 1.into()).unwrap();
+    let _block4 = append_block(&store, &block3, vec![], &consensus_constansts, 1.into()).unwrap();
+
+    // Adding another orphan block will trigger the orphan cleanup as the storage limit was reached
+    assert_eq!(store.add_block(orphan4.clone()), Ok(BlockAddResult::OrphanBlock));
+
+    assert_eq!(store.db_read_access().unwrap().get_orphan_count(), Ok(2));
+    assert!(store.fetch_orphan(orphan1_hash).is_err());
+    assert_eq!(store.fetch_orphan(orphan2_hash), Ok(orphan2));
+    assert!(store.fetch_orphan(orphan3_hash).is_err());
+    assert_eq!(store.fetch_orphan(orphan4_hash), Ok(orphan4));
 }
 
 #[test]


### PR DESCRIPTION
## Description
- When a node is loaded, it will check if a different pruning horizon was specified in the node config. If the node was previously running as an archival node then the node can be switched to a pruning node. If it was previously running in pruned mode then the pruning horizon can only be made lower. More advanced mechanisms can later be considered.
- The check_for_valid_heights function was modified to enforce checking of the pruning horizon to allow db queries and operations to be limited when the node is running in pruned mode.
- Orphan cleanup was modified to allow orphan blocks with block heights before the horizon block height to be discarded.
- Cleaning up of the orphan block pool was made more efficient by removing unnecessary hashing of orphan blocks.

## Motivation and Context
- Added a rewind_past_horizon_height test to check the behaviour when the node attempts to rewind the chain past the horizon block height.
- The restore_metadata test was updated to also test configuring of the pruning horizon.
- A horizon_height_orphan_cleanup test was also added to test the cleanup of orphan blocks with lower heights than the horizon block height.

## How Has This Been Tested?
These changes enable pruning horizon limits in the blockchain db and horizon height orphan pool cleanup.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [x] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch.
* [x] I ran `cargo-fmt --all` before pushing.
* [x] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
