### PR TITLE
Manage a node's connectivity to the network

### DIFF
--- a/applications/tari_base_node/src/builder.rs
+++ b/applications/tari_base_node/src/builder.rs
@@ -584,7 +584,7 @@ where
         &node_local_interface,
         &outbound_interface,
         base_node_comms.peer_manager(),
-        base_node_comms.connection_manager(),
+        base_node_comms.connectivity(),
         chain_metadata_service.get_event_stream(),
         state_machine_config,
         interrupt_signal,
@@ -986,6 +986,7 @@ async fn setup_base_node_comms(
         // TODO - make this configurable
         dht: DhtConfig {
             database_url: DbConnectionUrl::File(config.data_dir.join("dht.db")),
+            auto_join: true,
             ..Default::default()
         },
         // TODO: This should be false unless testing locally - make this configurable
@@ -993,7 +994,9 @@ async fn setup_base_node_comms(
         listener_liveness_whitelist_cidrs: config.listener_liveness_whitelist_cidrs.clone(),
         listener_liveness_max_sessions: config.listnener_liveness_max_sessions,
     };
-    let (comms, dht) = initialize_comms(comms_config, publisher)
+
+    let seed_peers = parse_peer_seeds(&config.peer_seeds);
+    let (comms, dht) = initialize_comms(comms_config, publisher, seed_peers)
         .await
         .map_err(|e| e.to_friendly_string())?;
 
@@ -1005,8 +1008,6 @@ async fn setup_base_node_comms(
         save_as_json(&config.tor_identity_file, hs.tor_identity())
             .map_err(|e| format!("Failed to save tor identity: {:?}", e))?;
     }
-
-    add_peers_to_comms(&comms, parse_peer_seeds(&config.peer_seeds)).await?;
 
     Ok((comms, dht))
 }
@@ -1037,6 +1038,7 @@ async fn setup_wallet_comms(
         // TODO - make this configurable
         dht: DhtConfig {
             database_url: DbConnectionUrl::File(config.data_dir.join("dht-wallet.db")),
+            auto_join: true,
             ..Default::default()
         },
         // TODO: This should be false unless testing locally - make this configurable
@@ -1044,7 +1046,10 @@ async fn setup_wallet_comms(
         listener_liveness_whitelist_cidrs: Vec::new(),
         listener_liveness_max_sessions: 0,
     };
-    let (comms, dht) = initialize_comms(comms_config, publisher)
+
+    let mut seed_peers = parse_peer_seeds(&config.peer_seeds);
+    seed_peers.push(base_node_peer);
+    let (comms, dht) = initialize_comms(comms_config, publisher, seed_peers)
         .await
         .map_err(|e| format!("Could not create comms layer: {:?}", e))?;
 
@@ -1057,38 +1062,7 @@ async fn setup_wallet_comms(
             .map_err(|e| format!("Failed to save tor identity: {:?}", e))?;
     }
 
-    add_peers_to_comms(&comms, vec![base_node_peer]).await?;
-
     Ok((comms, dht))
-}
-
-/// Adds a new peer to the base node
-/// ## Parameters
-/// `comms_node` - A reference to the comms node. This is the communications stack
-/// `peers` - A list of peers to be added to the comms node, the current node identity of the comms stack is excluded if
-/// found in the list.
-///
-/// ## Returns
-/// A Result to determine if the call was successful or not, string will indicate the reason on error
-async fn add_peers_to_comms(comms: &CommsNode, peers: Vec<Peer>) -> Result<(), String> {
-    for p in peers {
-        let peer_desc = p.to_string();
-        info!(target: LOG_TARGET, "Adding seed peer [{}]", peer_desc);
-
-        if &p.public_key == comms.node_identity().public_key() {
-            info!(
-                target: LOG_TARGET,
-                "Attempting to add yourself [{}] as a seed peer to comms layer, ignoring request", peer_desc
-            );
-            continue;
-        }
-        comms
-            .peer_manager()
-            .add_peer(p)
-            .await
-            .map_err(|e| format!("Could not add peer {} to comms layer: {}", peer_desc, e))?;
-    }
-    Ok(())
 }
 
 /// Asynchronously registers services of the base node
@@ -1134,7 +1108,6 @@ where
         .add_initializer(LivenessInitializer::new(
             LivenessConfig {
                 auto_ping_interval: Some(Duration::from_secs(30)),
-                enable_auto_join: true,
                 refresh_neighbours_interval: Duration::from_secs(3 * 60),
                 random_peer_selection_ratio: 0.4,
                 useragent: format!("tari\\basenode\\{}", env!("CARGO_PKG_VERSION")),
@@ -1142,7 +1115,6 @@ where
             },
             subscription_factory,
             dht.dht_requester(),
-            comms.connection_manager(),
         ))
         .add_initializer(ChainMetadataServiceInitializer)
         .finish()
@@ -1173,14 +1145,11 @@ async fn register_wallet_services(
         .add_initializer(LivenessInitializer::new(
             LivenessConfig{
                 auto_ping_interval: None,
-                enable_auto_join: true,
                 useragent: format!("tari\\wallet\\{}", env!("CARGO_PKG_VERSION")),
                 ..Default::default()
             },
             subscription_factory.clone(),
             wallet_dht.dht_requester(),
-    wallet_comms.connection_manager()
-
     ))
         // Wallet services
         .add_initializer(OutputManagerServiceInitializer::new(

--- a/base_layer/core/src/base_node/chain_metadata_service/service.rs
+++ b/base_layer/core/src/base_node/chain_metadata_service/service.rs
@@ -335,7 +335,6 @@ mod test {
 
         let node_id = NodeId::new();
         let pong_event = PingPongEvent {
-            is_neighbour: true,
             metadata,
             node_id: node_id.clone(),
             latency: None,
@@ -367,7 +366,6 @@ mod test {
         let metadata = Metadata::new();
         let node_id = NodeId::new();
         let pong_event = PingPongEvent {
-            is_neighbour: true,
             metadata,
             node_id,
             latency: None,
@@ -391,7 +389,6 @@ mod test {
         metadata.insert(MetadataKey::ChainMetadata, b"no-good".to_vec());
         let node_id = NodeId::new();
         let pong_event = PingPongEvent {
-            is_neighbour: true,
             metadata,
             node_id,
             latency: None,

--- a/base_layer/core/src/base_node/state_machine.rs
+++ b/base_layer/core/src/base_node/state_machine.rs
@@ -32,7 +32,7 @@ use futures::{future, future::Either, SinkExt};
 use log::*;
 use std::{future::Future, sync::Arc};
 use tari_broadcast_channel::{bounded, Publisher, Subscriber};
-use tari_comms::{connection_manager::ConnectionManagerRequester, PeerManager};
+use tari_comms::{connectivity::ConnectivityRequester, PeerManager};
 use tari_shutdown::ShutdownSignal;
 
 const LOG_TARGET: &str = "c::bn::base_node";
@@ -63,7 +63,7 @@ pub struct BaseNodeStateMachine<B: BlockchainBackend> {
     pub(super) local_node_interface: LocalNodeCommsInterface,
     pub(super) comms: OutboundNodeCommsInterface,
     pub(super) peer_manager: Arc<PeerManager>,
-    pub(super) connection_manager: ConnectionManagerRequester,
+    pub(super) connectivity: ConnectivityRequester,
     pub(super) metadata_event_stream: Subscriber<ChainMetadataEvent>,
     pub(super) config: BaseNodeStateMachineConfig,
     pub(super) info: StatusInfo,
@@ -81,7 +81,7 @@ impl<B: BlockchainBackend + 'static> BaseNodeStateMachine<B> {
         local_node_interface: &LocalNodeCommsInterface,
         comms: &OutboundNodeCommsInterface,
         peer_manager: Arc<PeerManager>,
-        connection_manager: ConnectionManagerRequester,
+        connectivity: ConnectivityRequester,
         metadata_event_stream: Subscriber<ChainMetadataEvent>,
         config: BaseNodeStateMachineConfig,
         shutdown_signal: ShutdownSignal,
@@ -94,7 +94,7 @@ impl<B: BlockchainBackend + 'static> BaseNodeStateMachine<B> {
             local_node_interface: local_node_interface.clone(),
             comms: comms.clone(),
             peer_manager,
-            connection_manager,
+            connectivity,
             metadata_event_stream,
             interrupt_signal: shutdown_signal,
             config,

--- a/base_layer/core/tests/mempool.rs
+++ b/base_layer/core/tests/mempool.rs
@@ -668,7 +668,9 @@ fn receive_and_propagate_transaction() {
                 .mempool
                 .has_tx_with_excess_sig(tx_excess_sig.clone())
                 .unwrap(),
-            expect = TxStorageResponse::PendingPool
+            expect = TxStorageResponse::PendingPool,
+            max_attempts = 10,
+            interval = Duration::from_millis(1000)
         );
         // Carol got sent the orphan tx directly, so it will be in her mempool
         async_assert_eventually!(

--- a/base_layer/core/tests/node_service.rs
+++ b/base_layer/core/tests/node_service.rs
@@ -22,8 +22,6 @@
 
 #[allow(dead_code)]
 mod helpers;
-use tari_core::base_node::comms_interface::Broadcast;
-
 use futures::join;
 use helpers::{
     block_builders::{
@@ -40,13 +38,14 @@ use helpers::{
         create_network_with_3_base_nodes,
         create_network_with_3_base_nodes_with_config,
         random_node_identity,
+        wait_until_online,
         BaseNodeBuilder,
     },
 };
 use std::time::Duration;
 use tari_core::{
     base_node::{
-        comms_interface::{BlockEvent, CommsInterfaceError},
+        comms_interface::{BlockEvent, Broadcast, CommsInterfaceError},
         consts::BASE_NODE_SERVICE_DESIRED_RESPONSE_FRACTION,
         service::BaseNodeServiceConfig,
     },
@@ -70,7 +69,7 @@ use tari_core::{
 use tari_crypto::tari_utilities::hash::Hashable;
 use tari_mmr::MmrCacheConfig;
 use tari_p2p::services::liveness::LivenessConfig;
-use tari_test_utils::random::string;
+use tari_test_utils::random;
 use tempdir::TempDir;
 use tokio::runtime::Runtime;
 
@@ -78,7 +77,7 @@ use tokio::runtime::Runtime;
 fn request_response_get_metadata() {
     let mut runtime = Runtime::new().unwrap();
     let factories = CryptoFactories::default();
-    let temp_dir = TempDir::new(string(8).as_str()).unwrap();
+    let temp_dir = TempDir::new(random::string(8).as_str()).unwrap();
     let network = Network::LocalNet;
     let consensus_constants = ConsensusConstantsBuilder::new(network)
         .with_emission_amounts(100_000_000.into(), 0.999, 100.into())
@@ -111,7 +110,7 @@ fn request_response_get_metadata() {
 #[test]
 fn request_and_response_fetch_headers() {
     let mut runtime = Runtime::new().unwrap();
-    let temp_dir = TempDir::new(string(8).as_str()).unwrap();
+    let temp_dir = TempDir::new(random::string(8).as_str()).unwrap();
     let (mut alice_node, bob_node, carol_node, _consensus_manager) =
         create_network_with_3_base_nodes(&mut runtime, temp_dir.path().to_str().unwrap());
 
@@ -155,7 +154,7 @@ fn request_and_response_fetch_headers() {
 #[test]
 fn request_and_response_fetch_headers_with_hashes() {
     let mut runtime = Runtime::new().unwrap();
-    let temp_dir = TempDir::new(string(8).as_str()).unwrap();
+    let temp_dir = TempDir::new(random::string(8).as_str()).unwrap();
     let (mut alice_node, bob_node, _consensus_manager) =
         create_network_with_2_base_nodes(&mut runtime, temp_dir.path().to_str().unwrap());
 
@@ -194,7 +193,7 @@ fn request_and_response_fetch_headers_with_hashes() {
 #[test]
 fn request_and_response_fetch_kernels() {
     let mut runtime = Runtime::new().unwrap();
-    let temp_dir = TempDir::new(string(8).as_str()).unwrap();
+    let temp_dir = TempDir::new(random::string(8).as_str()).unwrap();
     let (mut alice_node, bob_node, carol_node, _consensus_manager) =
         create_network_with_3_base_nodes(&mut runtime, temp_dir.path().to_str().unwrap());
 
@@ -236,7 +235,7 @@ fn request_and_response_fetch_kernels() {
 fn request_and_response_fetch_utxos() {
     let mut runtime = Runtime::new().unwrap();
     let factories = CryptoFactories::default();
-    let temp_dir = TempDir::new(string(8).as_str()).unwrap();
+    let temp_dir = TempDir::new(random::string(8).as_str()).unwrap();
     let (mut alice_node, bob_node, carol_node, _consensus_manager) =
         create_network_with_3_base_nodes(&mut runtime, temp_dir.path().to_str().unwrap());
 
@@ -274,7 +273,7 @@ fn request_and_response_fetch_utxos() {
 fn request_and_response_fetch_blocks() {
     let mut runtime = Runtime::new().unwrap();
     let factories = CryptoFactories::default();
-    let temp_dir = TempDir::new(string(8).as_str()).unwrap();
+    let temp_dir = TempDir::new(random::string(8).as_str()).unwrap();
     let network = Network::LocalNet;
     let consensus_constants = ConsensusConstantsBuilder::new(network)
         .with_emission_amounts(100_000_000.into(), 0.999, 100.into())
@@ -324,7 +323,7 @@ fn request_and_response_fetch_blocks() {
 fn request_and_response_fetch_blocks_with_hashes() {
     let mut runtime = Runtime::new().unwrap();
     let factories = CryptoFactories::default();
-    let temp_dir = TempDir::new(string(8).as_str()).unwrap();
+    let temp_dir = TempDir::new(random::string(8).as_str()).unwrap();
     let network = Network::LocalNet;
     let consensus_constants = ConsensusConstantsBuilder::new(network)
         .with_emission_amounts(100_000_000.into(), 0.999, 100.into())
@@ -383,7 +382,7 @@ fn request_and_response_fetch_blocks_with_hashes() {
 #[test]
 fn propagate_and_forward_valid_block() {
     let mut runtime = Runtime::new().unwrap();
-    let temp_dir = TempDir::new(string(8).as_str()).unwrap();
+    let temp_dir = TempDir::new(random::string(8).as_str()).unwrap();
     let factories = CryptoFactories::default();
     // Alice will propagate block to bob, bob will receive it, verify it and then propagate it to carol and dan. Dan and
     // Carol will also try to propagate the block to each other, as they dont know that bob sent it to the other node.
@@ -431,6 +430,12 @@ fn propagate_and_forward_valid_block() {
         .with_consensus_manager(rules)
         .start(&mut runtime, temp_dir.path().to_str().unwrap());
 
+    wait_until_online(&mut runtime, &[&alice_node, &bob_node, &carol_node, &dan_node]);
+
+    let bob_block_event_stream = bob_node.local_nci.get_block_event_stream_fused();
+    let carol_block_event_stream = carol_node.local_nci.get_block_event_stream_fused();
+    let dan_block_event_stream = dan_node.local_nci.get_block_event_stream_fused();
+
     let block1 = append_block(
         &alice_node.blockchain_db,
         &block0,
@@ -450,11 +455,8 @@ fn propagate_and_forward_valid_block() {
             .await
             .is_ok());
 
-        let bob_block_event_stream = bob_node.local_nci.get_block_event_stream_fused();
         let bob_block_event_fut = event_stream_next(bob_block_event_stream, Duration::from_millis(20000));
-        let carol_block_event_stream = carol_node.local_nci.get_block_event_stream_fused();
         let carol_block_event_fut = event_stream_next(carol_block_event_stream, Duration::from_millis(20000));
-        let dan_block_event_stream = dan_node.local_nci.get_block_event_stream_fused();
         let dan_block_event_fut = event_stream_next(dan_block_event_stream, Duration::from_millis(20000));
         let (bob_block_event, carol_block_event, dan_block_event) =
             join!(bob_block_event_fut, carol_block_event_fut, dan_block_event_fut);
@@ -485,7 +487,7 @@ fn propagate_and_forward_valid_block() {
 #[test]
 fn propagate_and_forward_invalid_block() {
     let mut runtime = Runtime::new().unwrap();
-    let temp_dir = TempDir::new(string(8).as_str()).unwrap();
+    let temp_dir = TempDir::new(random::string(8).as_str()).unwrap();
     let factories = CryptoFactories::default();
     // Alice will propagate an invalid block to Carol and Bob, they will check the received block and not propagate the
     // block to dan.
@@ -540,6 +542,8 @@ fn propagate_and_forward_invalid_block() {
         .with_peers(vec![bob_node_identity, carol_node_identity])
         .with_consensus_manager(rules)
         .start(&mut runtime, temp_dir.path().to_str().unwrap());
+
+    wait_until_online(&mut runtime, &[&alice_node, &bob_node, &carol_node, &dan_node]);
 
     // Make block 1 invalid
     let mut block1 = append_block(
@@ -597,7 +601,7 @@ fn service_request_timeout() {
         request_timeout: Duration::from_millis(1),
         desired_response_fraction: BASE_NODE_SERVICE_DESIRED_RESPONSE_FRACTION,
     };
-    let temp_dir = TempDir::new(string(8).as_str()).unwrap();
+    let temp_dir = TempDir::new(random::string(8).as_str()).unwrap();
     let (mut alice_node, bob_node, _consensus_manager) = create_network_with_2_base_nodes_with_config(
         &mut runtime,
         base_node_service_config,
@@ -624,7 +628,7 @@ fn service_request_timeout() {
 #[test]
 fn local_get_metadata() {
     let mut runtime = Runtime::new().unwrap();
-    let temp_dir = TempDir::new(string(8).as_str()).unwrap();
+    let temp_dir = TempDir::new(random::string(8).as_str()).unwrap();
     let network = Network::LocalNet;
     let (mut node, consensus_manager) =
         BaseNodeBuilder::new(network).start(&mut runtime, temp_dir.path().to_str().unwrap());
@@ -646,7 +650,7 @@ fn local_get_metadata() {
 fn local_get_new_block_template_and_get_new_block() {
     let factories = CryptoFactories::default();
     let mut runtime = Runtime::new().unwrap();
-    let temp_dir = TempDir::new(string(8).as_str()).unwrap();
+    let temp_dir = TempDir::new(random::string(8).as_str()).unwrap();
     let network = Network::LocalNet;
     let consensus_constants = network.create_consensus_constants();
     let (block0, outputs) = create_genesis_block_with_utxos(&factories, &[T, T], &consensus_constants);
@@ -690,7 +694,7 @@ fn local_get_new_block_template_and_get_new_block() {
 fn local_get_target_difficulty() {
     let network = Network::LocalNet;
     let mut runtime = Runtime::new().unwrap();
-    let temp_dir = TempDir::new(string(8).as_str()).unwrap();
+    let temp_dir = TempDir::new(random::string(8).as_str()).unwrap();
     let (mut node, consensus_manager) =
         BaseNodeBuilder::new(network).start(&mut runtime, temp_dir.path().to_str().unwrap());
 
@@ -733,7 +737,7 @@ fn local_get_target_difficulty() {
 #[test]
 fn local_submit_block() {
     let mut runtime = Runtime::new().unwrap();
-    let temp_dir = TempDir::new(string(8).as_str()).unwrap();
+    let temp_dir = TempDir::new(random::string(8).as_str()).unwrap();
     let network = Network::LocalNet;
     let (mut node, consensus_manager) =
         BaseNodeBuilder::new(network).start(&mut runtime, temp_dir.path().to_str().unwrap());

--- a/base_layer/core/tests/node_state_machine.rs
+++ b/base_layer/core/tests/node_state_machine.rs
@@ -38,6 +38,7 @@ use helpers::{
         create_network_with_2_base_nodes_with_config,
         create_network_with_3_base_nodes_with_config,
         random_node_identity,
+        wait_until_online,
         BaseNodeBuilder,
     },
 };
@@ -72,7 +73,7 @@ use tari_core::{
 use tari_mmr::MmrCacheConfig;
 use tari_p2p::services::liveness::LivenessConfig;
 use tari_shutdown::Shutdown;
-use tari_test_utils::{async_assert_eventually, random::string};
+use tari_test_utils::{collect_stream, random::string};
 use tempdir::TempDir;
 use tokio::{runtime::Runtime, time};
 
@@ -96,7 +97,6 @@ fn test_listening_lagging() {
         MmrCacheConfig::default(),
         MempoolServiceConfig::default(),
         LivenessConfig {
-            enable_auto_join: false,
             auto_ping_interval: Some(Duration::from_millis(100)),
             ..Default::default()
         },
@@ -109,11 +109,12 @@ fn test_listening_lagging() {
         &alice_node.local_nci,
         &alice_node.outbound_nci,
         alice_node.comms.peer_manager(),
-        alice_node.comms.connection_manager(),
+        alice_node.comms.connectivity(),
         alice_node.chain_metadata_handle.get_event_stream(),
         BaseNodeStateMachineConfig::default(),
         shutdown.to_signal(),
     );
+    wait_until_online(&mut runtime, &[&alice_node, &bob_node]);
 
     let await_event_task = runtime.spawn(async move { ListeningData.next_event(&mut alice_state_machine).await });
 
@@ -174,7 +175,7 @@ fn test_event_channel() {
         &node.local_nci,
         &node.outbound_nci,
         node.comms.peer_manager(),
-        node.comms.connection_manager(),
+        node.comms.connectivity(),
         mock.subscriber(),
         BaseNodeStateMachineConfig::default(),
         shutdown.to_signal(),
@@ -250,7 +251,7 @@ fn test_block_sync() {
         &alice_node.local_nci,
         &alice_node.outbound_nci,
         alice_node.comms.peer_manager(),
-        alice_node.comms.connection_manager(),
+        alice_node.comms.connectivity(),
         alice_node.chain_metadata_handle.get_event_stream(),
         state_machine_config,
         shutdown.to_signal(),
@@ -329,7 +330,7 @@ fn test_lagging_block_sync() {
         &alice_node.local_nci,
         &alice_node.outbound_nci,
         alice_node.comms.peer_manager(),
-        alice_node.comms.connection_manager(),
+        alice_node.comms.connectivity(),
         alice_node.chain_metadata_handle.get_event_stream(),
         state_machine_config,
         shutdown.to_signal(),
@@ -425,7 +426,7 @@ fn test_block_sync_recovery() {
         &alice_node.local_nci,
         &alice_node.outbound_nci,
         alice_node.comms.peer_manager(),
-        alice_node.comms.connection_manager(),
+        alice_node.comms.connectivity(),
         alice_node.chain_metadata_handle.get_event_stream(),
         state_machine_config,
         shutdown.to_signal(),
@@ -521,7 +522,7 @@ fn test_forked_block_sync() {
         &alice_node.local_nci,
         &alice_node.outbound_nci,
         alice_node.comms.peer_manager(),
-        alice_node.comms.connection_manager(),
+        alice_node.comms.connectivity(),
         alice_node.chain_metadata_handle.get_event_stream(),
         state_machine_config,
         shutdown.to_signal(),
@@ -638,24 +639,8 @@ fn test_sync_peer_banning() {
         .with_liveness_service_config(liveness_service_config.clone())
         .with_consensus_manager(consensus_manager)
         .start(&mut runtime, data_path);
-    // Wait for peers to connect
-    runtime.block_on(async {
-        let _ = alice_node
-            .comms
-            .connection_manager()
-            .dial_peer(bob_node.node_identity.node_id().clone())
-            .await;
-        async_assert_eventually!(
-            bob_node
-                .comms
-                .peer_manager()
-                .exists(alice_node.node_identity.public_key())
-                .await,
-            expect = true,
-            max_attempts = 20,
-            interval = Duration::from_millis(1000)
-        );
-    });
+
+    wait_until_online(&mut runtime, &[&alice_node, &bob_node]);
 
     let state_machine_config = BaseNodeStateMachineConfig {
         block_sync_config: BlockSyncConfig {
@@ -675,7 +660,7 @@ fn test_sync_peer_banning() {
         &alice_node.local_nci,
         &alice_node.outbound_nci,
         alice_node.comms.peer_manager(),
-        alice_node.comms.connection_manager(),
+        alice_node.comms.connectivity(),
         alice_node.chain_metadata_handle.get_event_stream(),
         state_machine_config,
         shutdown.to_signal(),
@@ -751,6 +736,7 @@ fn test_sync_peer_banning() {
         assert_eq!(alice_db.get_height(), Ok(Some(4)));
         assert_eq!(bob_db.get_height(), Ok(Some(6)));
 
+        let mut connectivity_events = alice_node.comms.connectivity().subscribe_event_stream();
         let network_tip = bob_db.get_metadata().unwrap();
         let mut sync_peers = vec![bob_node.node_identity.node_id().clone()];
         let state_event = BestChainMetadataBlockSyncInfo {}
@@ -759,6 +745,9 @@ fn test_sync_peer_banning() {
         assert_eq!(state_event, StateEvent::BlockSyncFailure);
 
         assert_eq!(alice_db.get_height(), Ok(Some(4)));
+
+        let _events = collect_stream!(connectivity_events, take = 1, timeout = Duration::from_secs(10));
+
         let peer = alice_peer_manager.find_by_public_key(bob_public_key).await.unwrap();
         assert_eq!(peer.is_banned(), true);
 

--- a/base_layer/core/tests/wallet.rs
+++ b/base_layer/core/tests/wallet.rs
@@ -115,6 +115,30 @@ fn wallet_base_node_integration_test() {
         base_node_identity.node_id().short_str()
     );
 
+    // Base Node Setup
+    let mut base_node_runtime = create_runtime();
+    let network = Network::LocalNet;
+    let consensus_constants = ConsensusConstantsBuilder::new(network)
+        .with_emission_amounts(100_000_000.into(), 0.999, 100.into())
+        .build();
+    let (block0, utxo0) =
+        create_genesis_block_with_coinbase_value(&factories, 100_000_000.into(), &consensus_constants);
+    let consensus_manager = ConsensusManagerBuilder::new(network)
+        .with_consensus_constants(consensus_constants)
+        .with_block(block0.clone())
+        .build();
+    let (base_node, _consensus_manager) = BaseNodeBuilder::new(network)
+        .with_node_identity(base_node_identity.clone())
+        .with_peers(vec![bob_node_identity.clone(), alice_node_identity.clone()])
+        .with_base_node_service_config(BaseNodeServiceConfig::default())
+        .with_mmr_cache_config(MmrCacheConfig { rewind_hist_len: 10 })
+        .with_mempool_service_config(MempoolServiceConfig::default())
+        .with_liveness_service_config(LivenessConfig::default())
+        .with_consensus_manager(consensus_manager.clone())
+        .start(&mut base_node_runtime, temp_dir.path().to_str().unwrap());
+
+    log::info!("Finished Starting Base Node");
+
     // Alice Wallet setup
     let alice_comms_config = CommsConfig {
         node_identity: alice_node_identity.clone(),
@@ -206,38 +230,23 @@ fn wallet_base_node_integration_test() {
 
     log::info!("Finished Starting Wallets");
 
-    // Base Node Setup
-    let mut base_node_runtime = create_runtime();
-    let network = Network::LocalNet;
-    let consensus_constants = ConsensusConstantsBuilder::new(network)
-        .with_emission_amounts(100_000_000.into(), 0.999, 100.into())
-        .build();
-    let (block0, utxo0) =
-        create_genesis_block_with_coinbase_value(&factories, 100_000_000.into(), &consensus_constants);
-    let consensus_manager = ConsensusManagerBuilder::new(network)
-        .with_consensus_constants(consensus_constants)
-        .with_block(block0.clone())
-        .build();
-    let (base_node, _consensus_manager) = BaseNodeBuilder::new(network)
-        .with_node_identity(base_node_identity.clone())
-        .with_peers(vec![bob_node_identity.clone(), alice_node_identity.clone()])
-        .with_base_node_service_config(BaseNodeServiceConfig::default())
-        .with_mmr_cache_config(MmrCacheConfig { rewind_hist_len: 10 })
-        .with_mempool_service_config(MempoolServiceConfig::default())
-        .with_liveness_service_config(LivenessConfig::default())
-        .with_consensus_manager(consensus_manager.clone())
-        .start(&mut base_node_runtime, temp_dir.path().to_str().unwrap());
-
-    log::info!("Finished Starting Base Node");
-
     // Transaction
     let mut runtime = create_runtime();
     alice_wallet
         .runtime
         .block_on(alice_wallet.output_manager_service.add_output(utxo0))
         .unwrap();
-    let value = MicroTari::from(1000);
+    alice_wallet
+        .runtime
+        .block_on(
+            alice_wallet
+                .comms
+                .connectivity()
+                .wait_for_connectivity(Duration::from_secs(10)),
+        )
+        .unwrap();
 
+    let value = MicroTari::from(1000);
     alice_wallet
         .runtime
         .block_on(alice_wallet.transaction_service.send_transaction(

--- a/base_layer/p2p/examples/pingpong.rs
+++ b/base_layer/p2p/examples/pingpong.rs
@@ -107,15 +107,6 @@ mod pingpong {
                     .required(true),
             )
             .arg(
-                Arg::with_name("log-config")
-                    .value_name("FILE")
-                    .long("log-config")
-                    .short("l")
-                    .help("The relative path of the log config file of the other node")
-                    .takes_value(true)
-                    .default_value("base_layer/p2p/examples/example-log-config.yml"),
-            )
-            .arg(
                 Arg::with_name("enable-tor")
                     .long("enable-tor")
                     .help("Set to enable tor"),
@@ -138,8 +129,6 @@ mod pingpong {
             .get_matches();
 
         let mut rt = Runtime::new().expect("Failed to initialize tokio runtime");
-
-        log4rs::init_file(matches.value_of("log-config").unwrap(), Default::default()).unwrap();
 
         let node_identity = Arc::new(load_file::<NodeIdentity>(matches.value_of("node-identity").unwrap()));
         let peer_identity = load_file::<NodeIdentity>(matches.value_of("peer-identity").unwrap());
@@ -187,7 +176,7 @@ mod pingpong {
             listener_liveness_max_sessions: 0,
         };
 
-        let (comms, dht) = rt.block_on(initialize_comms(comms_config, publisher)).unwrap();
+        let (comms, dht) = rt.block_on(initialize_comms(comms_config, publisher, vec![])).unwrap();
 
         println!("Comms listening on {}", comms.listening_address());
 
@@ -202,12 +191,10 @@ mod pingpong {
                     .add_initializer(LivenessInitializer::new(
                         LivenessConfig {
                             auto_ping_interval: None, // Some(Duration::from_secs(5)),
-                            enable_auto_join: true,
                             ..Default::default()
                         },
                         Arc::clone(&subscription_factory),
                         dht.dht_requester(),
-                        comms.connection_manager(),
                     ))
                     .finish(),
             )

--- a/base_layer/p2p/src/initialization.rs
+++ b/base_layer/p2p/src/initialization.rs
@@ -31,7 +31,7 @@ use rand::{distributions::Alphanumeric, thread_rng, Rng};
 use std::{error::Error, iter, path::PathBuf, sync::Arc, time::Duration};
 use tari_comms::{
     backoff::ConstantBackoff,
-    peer_manager::NodeIdentity,
+    peer_manager::{NodeIdentity, Peer, PeerManagerError},
     pipeline,
     pipeline::SinkService,
     tor,
@@ -40,6 +40,7 @@ use tari_comms::{
     CommsBuilder,
     CommsBuilderError,
     CommsNode,
+    PeerManager,
 };
 use tari_comms_dht::{Dht, DhtBuilder, DhtConfig, DhtInitializationError};
 use tari_storage::{lmdb_store::LMDBBuilder, LMDBWrapper};
@@ -54,6 +55,8 @@ pub enum CommsInitializationError {
     HiddenServiceBuilderError(tor::HiddenServiceBuilderError),
     #[error(non_std, no_from, msg_embedded)]
     InvalidLivenessCidrs(String),
+    /// Could not add seed peers to comms layer
+    FailedToAddSeedPeer(PeerManagerError),
 }
 
 impl CommsInitializationError {
@@ -109,6 +112,7 @@ pub async fn initialize_local_test_comms<TSink>(
     connector: InboundDomainConnector<TSink>,
     data_path: &str,
     discovery_request_timeout: Duration,
+    seed_peers: Vec<Peer>,
 ) -> Result<(CommsNode, Dht), CommsInitializationError>
 where
     TSink: Sink<Arc<PeerMessage>> + Unpin + Clone + Send + Sync + 'static,
@@ -141,7 +145,10 @@ where
         .with_node_identity(node_identity)
         .with_peer_storage(peer_database)
         .with_dial_backoff(ConstantBackoff::new(Duration::from_millis(500)))
+        .with_min_connectivity(1.0)
         .build()?;
+
+    add_peers_to_comms(&comms.peer_manager, &comms.node_identity, seed_peers).await?;
 
     // Create outbound channel
     let (outbound_tx, outbound_rx) = mpsc::channel(10);
@@ -150,7 +157,7 @@ where
         comms.node_identity(),
         comms.peer_manager(),
         outbound_tx,
-        comms.connection_manager_requester(),
+        comms.connectivity(),
         comms.shutdown_signal(),
     )
     .local_test()
@@ -185,6 +192,7 @@ where
 pub async fn initialize_comms<TSink>(
     config: CommsConfig,
     connector: InboundDomainConnector<TSink>,
+    seed_peers: Vec<Peer>,
 ) -> Result<(CommsNode, Dht), CommsInitializationError>
 where
     TSink: Sink<Arc<PeerMessage>> + Unpin + Clone + Send + Sync + 'static,
@@ -202,7 +210,7 @@ where
             let comms = builder
                 .with_transport(MemoryTransport)
                 .with_listener_address(listener_address.clone());
-            configure_comms_and_dht(comms, config, connector).await
+            configure_comms_and_dht(comms, config, connector, seed_peers).await
         },
         TransportType::Tcp {
             listener_address,
@@ -216,7 +224,7 @@ where
             let comms = builder
                 .with_transport(transport)
                 .with_listener_address(listener_address.clone());
-            configure_comms_and_dht(comms, config, connector).await
+            configure_comms_and_dht(comms, config, connector, seed_peers).await
         },
         TransportType::Tor(tor_config) => {
             debug!(
@@ -232,7 +240,7 @@ where
             let comms = builder.configure_from_hidden_service(hidden_service);
             debug!(target: LOG_TARGET, "Comms stack configured");
 
-            let (comms, dht) = configure_comms_and_dht(comms, config, connector).await?;
+            let (comms, dht) = configure_comms_and_dht(comms, config, connector, seed_peers).await?;
             debug!(target: LOG_TARGET, "DHT configured");
             // Set the public address to the onion address that comms is using
             comms
@@ -254,7 +262,7 @@ where
             let comms = builder
                 .with_transport(SocksTransport::new(socks_config.clone()))
                 .with_listener_address(listener_address.clone());
-            configure_comms_and_dht(comms, config, connector).await
+            configure_comms_and_dht(comms, config, connector, seed_peers).await
         },
     }
 }
@@ -279,6 +287,7 @@ async fn configure_comms_and_dht<TTransport, TSink>(
     builder: CommsBuilder<TTransport>,
     config: CommsConfig,
     connector: InboundDomainConnector<TSink>,
+    seed_peers: Vec<Peer>,
 ) -> Result<(CommsNode, Dht), CommsInitializationError>
 where
     TTransport: Transport + Unpin + Send + Sync + Clone + 'static,
@@ -306,6 +315,8 @@ where
         .with_peer_storage(peer_database)
         .build()?;
 
+    add_peers_to_comms(&comms.peer_manager, &comms.node_identity, seed_peers).await?;
+
     // Create outbound channel
     let (outbound_tx, outbound_rx) = mpsc::channel(config.outbound_buffer_size);
 
@@ -313,7 +324,7 @@ where
         comms.node_identity(),
         comms.peer_manager(),
         outbound_tx,
-        comms.connection_manager_requester(),
+        comms.connectivity(),
         comms.shutdown_signal(),
     )
     .with_config(config.dht)
@@ -341,4 +352,38 @@ where
         .await?;
 
     Ok((comms, dht))
+}
+
+/// Adds a new peer to the base node
+/// ## Parameters
+/// `comms_node` - A reference to the comms node. This is the communications stack
+/// `peers` - A list of peers to be added to the comms node, the current node identity of the comms stack is excluded if
+/// found in the list.
+///
+/// ## Returns
+/// A Result to determine if the call was successful or not, string will indicate the reason on error
+async fn add_peers_to_comms(
+    peer_manager: &PeerManager,
+    node_identity: &NodeIdentity,
+    peers: Vec<Peer>,
+) -> Result<(), CommsInitializationError>
+{
+    for peer in peers {
+        let peer_desc = peer.to_string();
+        info!(target: LOG_TARGET, "Adding seed peer [{}]", peer);
+
+        if &peer.public_key == node_identity.public_key() {
+            info!(
+                target: LOG_TARGET,
+                "Attempting to add yourself [{}] as a seed peer to comms layer, ignoring request", peer_desc
+            );
+            continue;
+        }
+
+        peer_manager
+            .add_peer(peer)
+            .await
+            .map_err(CommsInitializationError::FailedToAddSeedPeer)?;
+    }
+    Ok(())
 }

--- a/base_layer/p2p/src/services/liveness/config.rs
+++ b/base_layer/p2p/src/services/liveness/config.rs
@@ -27,8 +27,6 @@ use std::time::Duration;
 pub struct LivenessConfig {
     /// The interval to send Ping messages, or None to disable periodic pinging (default: None (disabled))
     pub auto_ping_interval: Option<Duration>,
-    /// Set to true to enable automatically joining the network on node startup (default: false)
-    pub enable_auto_join: bool,
     /// The length of time between querying peer manager for closest neighbours. (default: 2 minutes)
     pub refresh_neighbours_interval: Duration,
     /// The length of time between querying peer manager for random neighbours. (default: 2 hours)
@@ -43,7 +41,6 @@ impl Default for LivenessConfig {
     fn default() -> Self {
         Self {
             auto_ping_interval: None,
-            enable_auto_join: false,
             refresh_neighbours_interval: Duration::from_secs(2 * 60),
             refresh_random_pool_interval: Duration::from_secs(2 * 60 * 60),
             random_peer_selection_ratio: 0.0,

--- a/base_layer/p2p/src/services/liveness/handle.rs
+++ b/base_layer/p2p/src/services/liveness/handle.rs
@@ -93,26 +93,16 @@ pub struct PingPongEvent {
     pub latency: Option<u32>,
     /// Metadata of the corresponding node
     pub metadata: Metadata,
-    /// True if the ping/pong was from a neighbouring peer, otherwise false
-    pub is_neighbour: bool,
     /// True if the ping/pong was from a monitored node, otherwise false
     pub is_monitored: bool,
 }
 
 impl PingPongEvent {
-    pub fn new(
-        node_id: NodeId,
-        latency: Option<u32>,
-        metadata: Metadata,
-        is_neighbour: bool,
-        is_monitored: bool,
-    ) -> Self
-    {
+    pub fn new(node_id: NodeId, latency: Option<u32>, metadata: Metadata, is_monitored: bool) -> Self {
         Self {
             node_id,
             latency,
             metadata,
-            is_neighbour,
             is_monitored,
         }
     }

--- a/base_layer/p2p/src/services/liveness/state.rs
+++ b/base_layer/p2p/src/services/liveness/state.rs
@@ -109,10 +109,6 @@ impl LivenessState {
         self.pongs_received.load(Ordering::Relaxed)
     }
 
-    pub fn set_num_active_peers(&self, n: usize) {
-        self.num_active_peers.store(n, Ordering::Relaxed);
-    }
-
     #[cfg(test)]
     pub fn pings_sent(&self) -> usize {
         self.pings_sent.load(Ordering::Relaxed)

--- a/base_layer/p2p/src/test_utils.rs
+++ b/base_layer/p2p/src/test_utils.rs
@@ -25,14 +25,12 @@ use std::sync::Arc;
 use tari_comms::{
     message::MessageTag,
     multiaddr::Multiaddr,
-    peer_manager::{NodeId, NodeIdentity, Peer, PeerFeatures, PeerFlags},
-    types::CommsPublicKey,
+    peer_manager::{NodeIdentity, Peer, PeerFeatures, PeerFlags},
 };
 use tari_comms_dht::{
     envelope::{DhtMessageFlags, DhtMessageHeader, DhtMessageType, Network, NodeDestination},
     inbound::DhtInboundMessage,
 };
-use tari_crypto::keys::PublicKey;
 
 macro_rules! unwrap_oms_send_msg {
     ($var:expr, reply_value=$reply_value:expr) => {
@@ -49,11 +47,6 @@ macro_rules! unwrap_oms_send_msg {
             reply_value = tari_comms_dht::outbound::SendMessageResponse::Queued(vec![].into())
         );
     };
-}
-
-pub fn make_node_id() -> NodeId {
-    let (public_key, _) = CommsPublicKey::random_keypair(&mut OsRng);
-    NodeId::from_key(&public_key).unwrap()
 }
 
 pub fn make_node_identity() -> Arc<NodeIdentity> {

--- a/base_layer/p2p/tests/services/liveness.rs
+++ b/base_layer/p2p/tests/services/liveness.rs
@@ -21,11 +21,9 @@
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 use crate::support::comms_and_services::setup_comms_services;
-use futures::channel::mpsc;
 use rand::rngs::OsRng;
 use std::{sync::Arc, time::Duration};
 use tari_comms::{
-    connection_manager::ConnectionManagerRequester,
     peer_manager::{NodeIdentity, PeerFeatures},
     transports::MemoryTransport,
     CommsNode,
@@ -41,7 +39,7 @@ use tari_p2p::{
 use tari_service_framework::StackBuilder;
 use tari_test_utils::{collect_stream, random::string};
 use tempdir::TempDir;
-use tokio::{runtime, sync::broadcast};
+use tokio::runtime;
 
 pub async fn setup_liveness_service(
     node_identity: Arc<NodeIdentity>,
@@ -54,17 +52,12 @@ pub async fn setup_liveness_service(
     let subscription_factory = Arc::new(subscription_factory);
     let (comms, dht) = setup_comms_services(node_identity.clone(), peers, publisher, data_path).await;
 
-    let (tx, _) = mpsc::channel(0);
-    let (event_tx, _) = broadcast::channel(1);
-    let connection_manager = ConnectionManagerRequester::new(tx, event_tx);
-
     let handles = StackBuilder::new(rt_handle.clone(), comms.shutdown_signal())
         .add_initializer(CommsOutboundServiceInitializer::new(dht.outbound_requester()))
         .add_initializer(LivenessInitializer::new(
             Default::default(),
             Arc::clone(&subscription_factory),
             dht.dht_requester(),
-            connection_manager,
         ))
         .finish()
         .await
@@ -107,8 +100,8 @@ async fn end_to_end() {
     )
     .await;
 
-    let liveness1_event_stream = liveness1.get_event_stream_fused();
-    let liveness2_event_stream = liveness2.get_event_stream_fused();
+    let mut liveness1_event_stream = liveness1.get_event_stream_fused();
+    let mut liveness2_event_stream = liveness2.get_event_stream_fused();
 
     for _ in 0..5 {
         liveness2.send_ping(node_1_identity.node_id().clone()).await.unwrap();

--- a/base_layer/p2p/tests/support/comms_and_services.rs
+++ b/base_layer/p2p/tests/support/comms_and_services.rs
@@ -39,15 +39,10 @@ where
     TSink: Sink<Arc<PeerMessage>> + Clone + Unpin + Send + Sync + 'static,
     TSink::Error: Error + Send + Sync,
 {
-    let (comms, dht) = initialize_local_test_comms(node_identity, publisher, data_path, Duration::from_secs(1))
+    let peers = peers.into_iter().map(|ni| ni.to_peer()).collect();
+    let (comms, dht) = initialize_local_test_comms(node_identity, publisher, data_path, Duration::from_secs(1), peers)
         .await
         .unwrap();
-
-    let peer_manager = comms.peer_manager();
-
-    for p in peers {
-        peer_manager.add_peer(p.to_peer()).await.unwrap();
-    }
 
     (comms, dht)
 }

--- a/base_layer/wallet/src/error.rs
+++ b/base_layer/wallet/src/error.rs
@@ -30,7 +30,7 @@ use derive_error::Error;
 use diesel::result::Error as DieselError;
 use log::SetLoggerError;
 use serde_json::Error as SerdeJsonError;
-use tari_comms::{multiaddr, peer_manager::PeerManagerError};
+use tari_comms::{connectivity::ConnectivityError, multiaddr, peer_manager::PeerManagerError};
 use tari_comms_dht::store_forward::StoreAndForwardError;
 use tari_p2p::{initialization::CommsInitializationError, services::liveness::error::LivenessError};
 
@@ -46,6 +46,7 @@ pub enum WalletError {
     ContactsServiceError(ContactsServiceError),
     LivenessServiceError(LivenessError),
     StoreAndForwardError(StoreAndForwardError),
+    ConnectivityError(ConnectivityError),
 }
 
 #[derive(Debug, Error)]

--- a/base_layer/wallet/src/transaction_service/protocols/transaction_send_protocol.rs
+++ b/base_layer/wallet/src/transaction_service/protocols/transaction_send_protocol.rs
@@ -434,7 +434,7 @@ where TBackend: TransactionBackend + Clone + 'static
         {
             Ok(result) => match result {
                 SendMessageResponse::Queued(send_states) => {
-                    if self.wait_on_dail(send_states).await {
+                    if self.wait_on_dial(send_states).await {
                         direct_send_result = true;
                     } else {
                         store_and_forward_send_result = self.send_transaction_store_and_forward(msg.clone()).await?;
@@ -450,7 +450,7 @@ where TBackend: TransactionBackend + Clone + 'static
                         Ok(send_msg_response) => match send_msg_response {
                             SendMessageResponse::Queued(send_states) => {
                                 debug!("Discovery of {} completed for TxID: {}", self.dest_pubkey, self.id);
-                                direct_send_result = self.wait_on_dail(send_states).await;
+                                direct_send_result = self.wait_on_dial(send_states).await;
                             },
                             _ => (),
                         },
@@ -505,7 +505,7 @@ where TBackend: TransactionBackend + Clone + 'static
     }
 
     /// This function contains the logic to wait on a dial and send of a queued message
-    async fn wait_on_dail(&self, send_states: MessageSendStates) -> bool {
+    async fn wait_on_dial(&self, send_states: MessageSendStates) -> bool {
         if send_states.len() == 1 {
             debug!(
                 target: LOG_TARGET,
@@ -640,7 +640,7 @@ where TBackend: TransactionBackend + Clone + 'static
         {
             Ok(result) => match result.resolve_ok().await {
                 Some(send_states) if send_states.len() == 1 => {
-                    if self.wait_on_dail(send_states).await {
+                    if self.wait_on_dial(send_states).await {
                         if let Err(e) = self.resources.db.mark_direct_send_success(self.id).await {
                             error!(target: LOG_TARGET, "Error updating database: {:?}", e);
                         }

--- a/base_layer/wallet/tests/support/comms_and_services.rs
+++ b/base_layer/wallet/tests/support/comms_and_services.rs
@@ -56,13 +56,16 @@ where
     TSink: Sink<Arc<PeerMessage>> + Clone + Unpin + Send + Sync + 'static,
     TSink::Error: Error + Send + Sync,
 {
-    let (comms, dht) = initialize_local_test_comms(node_identity, publisher, &database_path, discovery_request_timeout)
-        .await
-        .unwrap();
-
-    for p in peers {
-        comms.peer_manager().add_peer(p.to_peer()).await.unwrap();
-    }
+    let peers = peers.into_iter().map(|ni| ni.to_peer()).collect();
+    let (comms, dht) = initialize_local_test_comms(
+        node_identity,
+        publisher,
+        &database_path,
+        discovery_request_timeout,
+        peers,
+    )
+    .await
+    .unwrap();
 
     (comms, dht)
 }

--- a/base_layer/wallet/tests/transaction_service/service.rs
+++ b/base_layer/wallet/tests/transaction_service/service.rs
@@ -183,7 +183,6 @@ pub fn setup_transaction_service<T: TransactionBackend + Clone + 'static>(
         .add_initializer(LivenessInitializer::new(
             LivenessConfig {
                 auto_ping_interval: Some(Duration::from_secs(10)),
-                enable_auto_join: false,
                 refresh_neighbours_interval: Default::default(),
                 refresh_random_pool_interval: Default::default(),
                 random_peer_selection_ratio: 0.0,
@@ -191,7 +190,6 @@ pub fn setup_transaction_service<T: TransactionBackend + Clone + 'static>(
             },
             Arc::clone(&subscription_factory),
             dht.dht_requester(),
-            comms.connection_manager(),
         ))
         .finish();
 
@@ -884,7 +882,7 @@ fn finalize_tx_with_incorrect_pubkey<T: TransactionBackend + Clone + 'static>(al
         _,
         _,
     ) = setup_transaction_service_no_comms(&mut runtime, factories.clone(), alice_backend, None);
-    let alice_event_stream = alice_ts.get_event_stream_fused();
+    let mut alice_event_stream = alice_ts.get_event_stream_fused();
 
     let bob_node_identity =
         NodeIdentity::random(&mut OsRng, get_next_memory_address(), PeerFeatures::COMMUNICATION_NODE).unwrap();
@@ -991,7 +989,7 @@ fn finalize_tx_with_missing_output<T: TransactionBackend + Clone + 'static>(alic
         _,
         _,
     ) = setup_transaction_service_no_comms(&mut runtime, factories.clone(), alice_backend, None);
-    let alice_event_stream = alice_ts.get_event_stream_fused();
+    let mut alice_event_stream = alice_ts.get_event_stream_fused();
 
     let bob_node_identity =
         NodeIdentity::random(&mut OsRng, get_next_memory_address(), PeerFeatures::COMMUNICATION_NODE).unwrap();
@@ -2850,7 +2848,6 @@ fn test_resend_of_tx_on_pong_event<T: TransactionBackend + Clone + 'static>(back
             None,
             Metadata::new(),
             true,
-            true,
         ))))) {
             Ok(_) => {
                 break;
@@ -2889,7 +2886,6 @@ fn test_resend_of_tx_on_pong_event<T: TransactionBackend + Clone + 'static>(back
             bob_node_identity.node_id().clone(),
             None,
             Metadata::new(),
-            true,
             true,
         )))))
         .unwrap();

--- a/comms/dht/examples/memorynet.rs
+++ b/comms/dht/examples/memorynet.rs
@@ -152,7 +152,7 @@ async fn main() {
 
     let (messaging_events_tx, mut messaging_events_rx) = mpsc::unbounded();
 
-    let mut seed_node = make_node(PeerFeatures::COMMUNICATION_NODE, None, messaging_events_tx.clone()).await;
+    let seed_node = make_node(PeerFeatures::COMMUNICATION_NODE, None, messaging_events_tx.clone()).await;
 
     let mut nodes = future::join_all(
         repeat_with(|| {
@@ -183,8 +183,13 @@ async fn main() {
             "Node '{}' is joining the network via the seed node '{}'",
             node, seed_node
         );
+        node.comms
+            .connectivity()
+            .wait_for_connectivity(Duration::from_secs(10))
+            .await
+            .unwrap();
+
         node.dht.dht_requester().send_join().await.unwrap();
-        seed_node.expect_peer_connection(&node.get_node_id()).await.unwrap();
     }
 
     take_a_break().await;
@@ -202,15 +207,13 @@ async fn main() {
             wallet,
             get_name(&wallet.seed_peer.as_ref().unwrap().node_id)
         );
-        wallet.dht.dht_requester().send_join().await.unwrap();
-        let seed_node_id = &wallet.seed_peer.as_ref().unwrap().node_id;
-        nodes
-            .iter_mut()
-            .find(|n| &n.get_node_id() == seed_node_id)
-            .expect("node must exist")
-            .expect_peer_connection(&wallet.get_node_id())
+        wallet
+            .comms
+            .connectivity()
+            .wait_for_connectivity(Duration::from_secs(10))
             .await
             .unwrap();
+        wallet.dht.dht_requester().send_join().await.unwrap();
     }
 
     let mut total_messages = 0;
@@ -222,8 +225,8 @@ async fn main() {
     network_connectivity_stats(&nodes, &wallets).await;
 
     {
-        let all_known_peers = seed_node.comms.peer_manager().all().await.unwrap();
-        println!("Seed node knows {} peers", all_known_peers.len());
+        let count = seed_node.comms.peer_manager().count().await;
+        println!("Seed node knows {} peers", count);
     }
 
     total_messages += discovery(&wallets, &mut messaging_events_rx).await;
@@ -368,7 +371,7 @@ async fn network_peer_list_stats(nodes: &[TestNode], wallets: &[TestNode]) {
             if node
                 .comms
                 .peer_manager()
-                .exists(wallet.node_identity().public_key())
+                .exists_node_id(wallet.node_identity().node_id())
                 .await
             {
                 num_known += 1;
@@ -557,7 +560,12 @@ async fn do_store_and_forward_message_propagation(
     let (tx, ims_rx) = mpsc::channel(1);
     let (comms, dht) = setup_comms_dht(node_identity, create_peer_storage(wallets_peers), tx).await;
     let mut wallet = TestNode::new(comms, dht, None, ims_rx, messaging_tx);
-    wallet.dht.dht_requester().send_join().await.unwrap();
+    wallet
+        .comms
+        .connectivity()
+        .wait_for_connectivity(Duration::from_secs(10))
+        .await
+        .unwrap();
     wallet
         .dht
         .store_and_forward_requester()
@@ -567,7 +575,7 @@ async fn do_store_and_forward_message_propagation(
 
     let mut num_msgs = 0;
     loop {
-        let result = time::timeout(Duration::from_secs(20), wallet.ims_rx.as_mut().unwrap().next()).await;
+        let result = time::timeout(Duration::from_secs(10), wallet.ims_rx.as_mut().unwrap().next()).await;
         num_msgs += 1;
         match result {
             Ok(msg) => {
@@ -623,6 +631,9 @@ async fn drain_messaging_events(messaging_rx: &mut MessagingEventRx, show_logs: 
                         node_id_buf.len(),
                         node_id_buf.drain(..).map(get_short_name).collect::<Vec<_>>().join(", ")
                     );
+
+                    last_from_node = Some(from_node);
+                    node_id_buf.push(to_node)
                 },
                 None => {
                     last_from_node = Some(from_node);
@@ -778,19 +789,18 @@ impl TestNode {
     }
 
     #[inline]
-    pub fn get_node_id(&self) -> NodeId {
-        self.node_identity().node_id().clone()
-    }
-
-    #[inline]
     pub fn to_peer(&self) -> Peer {
         self.comms.node_identity().to_peer()
     }
 
+    #[allow(dead_code)]
     pub async fn expect_peer_connection(&mut self, node_id: &NodeId) -> Option<PeerConnection> {
+        if let Some(conn) = self.comms.connectivity().get_connection(node_id.clone()).await.unwrap() {
+            return Some(conn);
+        }
         use ConnectionManagerEvent::*;
         loop {
-            let event = time::timeout(Duration::from_secs(10), self.conn_man_events_rx.next())
+            let event = time::timeout(Duration::from_secs(30), self.conn_man_events_rx.next())
                 .await
                 .ok()??;
 
@@ -870,6 +880,7 @@ async fn setup_comms_dht(
         .with_listener_address(node_identity.public_address())
         .with_transport(MemoryTransport)
         .with_node_identity(node_identity)
+        .with_min_connectivity(0.3)
         .with_peer_storage(storage)
         .with_dial_backoff(ConstantBackoff::new(Duration::from_millis(1000)))
         .build()
@@ -879,12 +890,14 @@ async fn setup_comms_dht(
         comms.node_identity(),
         comms.peer_manager(),
         outbound_tx,
-        comms.connection_manager_requester(),
+        comms.connectivity(),
         comms.shutdown_signal(),
     )
     .local_test()
+    .enable_auto_join()
     .with_discovery_timeout(Duration::from_secs(15))
     .with_num_neighbouring_nodes(8)
+    .with_propagation_factor(4)
     .finish()
     .await
     .unwrap();
@@ -915,5 +928,5 @@ async fn setup_comms_dht(
 
 async fn take_a_break() {
     banner!("Taking a break for a few seconds to let things settle...");
-    time::delay_for(Duration::from_millis(NUM_NODES as u64 * 100)).await;
+    time::delay_for(Duration::from_millis(NUM_NODES as u64 * 50)).await;
 }

--- a/comms/dht/src/actor.rs
+++ b/comms/dht/src/actor.rs
@@ -46,20 +46,11 @@ use futures::{
     StreamExt,
 };
 use log::*;
-use rand::{rngs::OsRng, seq::SliceRandom};
 use std::{fmt, fmt::Display, sync::Arc};
 use tari_comms::{
-    connection_manager::{ConnectionManagerError, ConnectionManagerRequester},
-    peer_manager::{
-        NodeId,
-        NodeIdentity,
-        Peer,
-        PeerFeatures,
-        PeerManager,
-        PeerManagerError,
-        PeerQuery,
-        PeerQuerySortBy,
-    },
+    connection_manager::ConnectionManagerError,
+    connectivity::{ConnectivityError, ConnectivityRequester, ConnectivitySelection},
+    peer_manager::{NodeId, NodeIdentity, PeerFeatures, PeerManager, PeerManagerError, PeerQuery, PeerQuerySortBy},
 };
 use tari_shutdown::ShutdownSignal;
 use tari_utilities::message_format::{MessageFormat, MessageFormatError};
@@ -87,6 +78,9 @@ pub enum DhtActorError {
     #[error(no_from)]
     FailedToSerializeValue(MessageFormatError),
     ConnectionManagerError(ConnectionManagerError),
+    ConnectivityError(ConnectivityError),
+    /// Connectivity event stream closed
+    ConnectivityEventStreamClosed,
 }
 
 impl From<SendError> for DhtActorError {
@@ -109,7 +103,7 @@ pub enum DhtRequest {
     /// which is true if the signature already exists in the cache, otherwise false
     MsgHashCacheInsert(Vec<u8>, oneshot::Sender<bool>),
     /// Fetch selected peers according to the broadcast strategy
-    SelectPeers(BroadcastStrategy, oneshot::Sender<Vec<Arc<Peer>>>),
+    SelectPeers(BroadcastStrategy, oneshot::Sender<Vec<NodeId>>),
     GetMetadata(DhtMetadataKey, oneshot::Sender<Result<Option<Vec<u8>>, DhtActorError>>),
     SetMetadata(DhtMetadataKey, Vec<u8>),
 }
@@ -141,11 +135,7 @@ impl DhtRequester {
         self.sender.send(DhtRequest::SendJoin).await.map_err(Into::into)
     }
 
-    pub async fn select_peers(
-        &mut self,
-        broadcast_strategy: BroadcastStrategy,
-    ) -> Result<Vec<Arc<Peer>>, DhtActorError>
-    {
+    pub async fn select_peers(&mut self, broadcast_strategy: BroadcastStrategy) -> Result<Vec<NodeId>, DhtActorError> {
         let (reply_tx, reply_rx) = oneshot::channel();
         self.sender
             .send(DhtRequest::SelectPeers(broadcast_strategy, reply_tx))
@@ -180,33 +170,25 @@ impl DhtRequester {
     }
 }
 
-pub struct DhtActor<'a> {
+pub struct DhtActor {
     node_identity: Arc<NodeIdentity>,
     peer_manager: Arc<PeerManager>,
     database: DhtDatabase,
     outbound_requester: OutboundMessageRequester,
-    connection_manager: ConnectionManagerRequester,
+    connectivity: ConnectivityRequester,
     config: DhtConfig,
     shutdown_signal: Option<ShutdownSignal>,
     request_rx: Fuse<mpsc::Receiver<DhtRequest>>,
     msg_hash_cache: TtlCache<Vec<u8>, ()>,
-    pending_jobs: FuturesUnordered<BoxFuture<'a, Result<(), DhtActorError>>>,
 }
 
-impl DhtActor<'static> {
-    pub async fn spawn(self) -> Result<(), DhtActorError> {
-        task::spawn(Self::run(self));
-        Ok(())
-    }
-}
-
-impl<'a> DhtActor<'a> {
+impl DhtActor {
     pub fn new(
         config: DhtConfig,
         conn: DbConnection,
         node_identity: Arc<NodeIdentity>,
         peer_manager: Arc<PeerManager>,
-        connection_manager: ConnectionManagerRequester,
+        connectivity: ConnectivityRequester,
         outbound_requester: OutboundMessageRequester,
         request_rx: mpsc::Receiver<DhtRequest>,
         shutdown_signal: ShutdownSignal,
@@ -218,15 +200,22 @@ impl<'a> DhtActor<'a> {
             database: DhtDatabase::new(conn),
             outbound_requester,
             peer_manager,
-            connection_manager,
+            connectivity,
             node_identity,
             shutdown_signal: Some(shutdown_signal),
             request_rx: request_rx.fuse(),
-            pending_jobs: FuturesUnordered::new(),
         }
     }
 
-    async fn run(mut self) {
+    pub fn spawn(self) {
+        task::spawn(async move {
+            if let Err(err) = self.run().await {
+                error!(target: LOG_TARGET, "DhtActor failed to start with error: {:?}", err);
+            }
+        });
+    }
+
+    async fn run(mut self) -> Result<(), DhtActorError> {
         let offline_ts = self
             .database
             .get_metadata_value::<DateTime<Utc>>(DhtMetadataKey::OfflineTimestamp)
@@ -241,6 +230,8 @@ impl<'a> DhtActor<'a> {
                 .unwrap_or_else(String::new)
         );
 
+        let mut pending_jobs = FuturesUnordered::new();
+
         let mut shutdown_signal = self
             .shutdown_signal
             .take()
@@ -250,33 +241,27 @@ impl<'a> DhtActor<'a> {
             futures::select! {
                 request = self.request_rx.select_next_some() => {
                     debug!(target: LOG_TARGET, "DhtActor received message: {}", request);
-                    let handler = self.request_handler(request);
-                    self.pending_jobs.push(handler);
+                    pending_jobs.push(self.request_handler(request));
                 },
 
-                result = self.pending_jobs.select_next_some() => {
-                    match result {
-                        Ok(_) => {
-                            trace!(target: LOG_TARGET, "DHT Actor request succeeded");
-                        },
-                        Err(err) => {
-                            error!(target: LOG_TARGET, "Error when handling DHT request message. {}", err);
-                        },
+                result = pending_jobs.select_next_some() => {
+                    if let Err(err) = result {
+                        error!(target: LOG_TARGET, "Error when handling DHT request message. {}", err);
                     }
                 },
 
                 _ = shutdown_signal => {
                     info!(target: LOG_TARGET, "DhtActor is shutting down because it received a shutdown signal.");
-                    // Called with reference to database otherwise DhtActor is not Send
-                    Self::mark_shutdown_time(&self.database).await;
-                    break;
+                    self.mark_shutdown_time().await;
+                    break Ok(());
                 },
             }
         }
     }
 
-    async fn mark_shutdown_time(db: &DhtDatabase) {
-        if let Err(err) = db
+    async fn mark_shutdown_time(&self) {
+        if let Err(err) = self
+            .database
             .set_metadata_value(DhtMetadataKey::OfflineTimestamp, Utc::now())
             .await
         {
@@ -284,17 +269,14 @@ impl<'a> DhtActor<'a> {
         }
     }
 
-    fn request_handler(&mut self, request: DhtRequest) -> BoxFuture<'a, Result<(), DhtActorError>> {
+    fn request_handler(&mut self, request: DhtRequest) -> BoxFuture<'static, Result<(), DhtActorError>> {
         use DhtRequest::*;
         match request {
             SendJoin => {
                 let node_identity = Arc::clone(&self.node_identity);
                 let outbound_requester = self.outbound_requester.clone();
-                Box::pin(Self::send_join(
-                    node_identity,
-                    outbound_requester,
-                    self.config.num_neighbouring_nodes,
-                ))
+                let config = self.config.clone();
+                Box::pin(Self::broadcast_join(config, node_identity, outbound_requester))
             },
             MsgHashCacheInsert(hash, reply_tx) => {
                 // No locks needed here. Downside is this isn't really async, however this should be
@@ -309,17 +291,11 @@ impl<'a> DhtActor<'a> {
             SelectPeers(broadcast_strategy, reply_tx) => {
                 let peer_manager = Arc::clone(&self.peer_manager);
                 let node_identity = Arc::clone(&self.node_identity);
-                let connection_manager = self.connection_manager.clone();
+                let connectivity = self.connectivity.clone();
                 let config = self.config.clone();
                 Box::pin(async move {
-                    match Self::select_peers(
-                        config,
-                        node_identity,
-                        peer_manager,
-                        connection_manager,
-                        broadcast_strategy,
-                    )
-                    .await
+                    match Self::select_peers(config, node_identity, peer_manager, connectivity, broadcast_strategy)
+                        .await
                     {
                         Ok(peers) => reply_tx.send(peers).map_err(|_| DhtActorError::ReplyCanceled),
                         Err(err) => {
@@ -353,23 +329,25 @@ impl<'a> DhtActor<'a> {
         }
     }
 
-    async fn send_join(
+    async fn broadcast_join(
+        config: DhtConfig,
         node_identity: Arc<NodeIdentity>,
         mut outbound_requester: OutboundMessageRequester,
-        num_neighbouring_nodes: usize,
     ) -> Result<(), DhtActorError>
     {
         let message = JoinMessage::from(&node_identity);
 
-        debug!(
-            target: LOG_TARGET,
-            "Sending Join message to (at most) {} closest peers", num_neighbouring_nodes
-        );
+        debug!(target: LOG_TARGET, "Sending Join message to closest peers");
 
         outbound_requester
             .send_message_no_header(
                 SendMessageParams::new()
-                    .broadcast(Vec::new())
+                    .closest(
+                        node_identity.node_id().clone(),
+                        config.num_neighbouring_nodes,
+                        vec![],
+                        PeerFeatures::MESSAGE_PROPAGATION,
+                    )
                     .with_dht_message_type(DhtMessageType::Join)
                     .force_origin()
                     .finish(),
@@ -385,9 +363,9 @@ impl<'a> DhtActor<'a> {
         config: DhtConfig,
         node_identity: Arc<NodeIdentity>,
         peer_manager: Arc<PeerManager>,
-        mut connection_manager: ConnectionManagerRequester,
+        mut connectivity: ConnectivityRequester,
         broadcast_strategy: BroadcastStrategy,
-    ) -> Result<Vec<Arc<Peer>>, DhtActorError>
+    ) -> Result<Vec<NodeId>, DhtActorError>
     {
         use BroadcastStrategy::*;
         match broadcast_strategy {
@@ -396,7 +374,7 @@ impl<'a> DhtActor<'a> {
                 peer_manager
                     .direct_identity_node_id(&node_id)
                     .await
-                    .map(|peer| peer.map(|p| vec![Arc::new(p)]).unwrap_or_default())
+                    .map(|peer| peer.map(|p| vec![p.node_id]).unwrap_or_default())
                     .map_err(Into::into)
             },
             DirectPublicKey(public_key) => {
@@ -404,18 +382,17 @@ impl<'a> DhtActor<'a> {
                 peer_manager
                     .direct_identity_public_key(&public_key)
                     .await
-                    .map(|peer| peer.map(|p| vec![Arc::new(p)]).unwrap_or_default())
+                    .map(|peer| peer.map(|p| vec![p.node_id]).unwrap_or_default())
                     .map_err(Into::into)
             },
             Flood => {
                 // Send to all known peers
                 // TODO: This should never be needed, remove
                 let peers = peer_manager.flood_peers().await?;
-                Ok(peers.into_iter().map(Arc::new).collect())
+                Ok(peers.into_iter().map(|p| p.node_id).collect())
             },
             Closest(closest_request) => {
                 Self::select_closest_peers_for_propagation(
-                    &config,
                     &peer_manager,
                     &closest_request.node_id,
                     closest_request.n,
@@ -430,28 +407,29 @@ impl<'a> DhtActor<'a> {
                     .random_peers(n, &excluded)
                     .await?
                     .into_iter()
-                    .map(Arc::new)
+                    .map(|p| p.node_id)
                     .collect())
             },
-            Neighbours(exclude) => {
-                let active_connections = connection_manager.get_active_connections().await?;
-                let (connected_nodes, connected_clients) = active_connections
-                    .into_iter()
-                    .map(|conn| conn.peer())
-                    .partition::<Vec<_>, _>(|peer| peer.features.contains(PeerFeatures::COMMUNICATION_NODE));
-                let mut candidates = Self::get_propagate_candidates(
-                    &config,
-                    &peer_manager,
-                    &connected_clients,
-                    &connected_nodes,
-                    &node_identity,
-                    node_identity.node_id().clone(),
-                    &exclude,
-                )
-                .await?;
+            Broadcast(exclude) => {
+                let connections = connectivity
+                    .select_connections(ConnectivitySelection::random_nodes(
+                        config.num_neighbouring_nodes,
+                        exclude.clone(),
+                    ))
+                    .await?;
 
-                candidates.truncate(config.num_neighbouring_nodes);
+                let candidates = connections
+                    .iter()
+                    .map(|c| c.peer_node_id())
+                    .cloned()
+                    .collect::<Vec<_>>();
 
+                if candidates.is_empty() {
+                    warn!(
+                        target: LOG_TARGET,
+                        "Broadcast requested but there are no node peer connections available"
+                    );
+                }
                 info!(
                     target: LOG_TARGET,
                     "{} candidate(s) selected for broadcast",
@@ -461,155 +439,88 @@ impl<'a> DhtActor<'a> {
                 Ok(candidates)
             },
             Propagate(destination, exclude) => {
-                let active_connections = connection_manager.get_active_connections().await?;
-                let (connected_nodes, connected_clients) = active_connections
-                    .into_iter()
-                    .map(|conn| conn.peer())
-                    .partition::<Vec<_>, _>(|peer| peer.features.contains(PeerFeatures::COMMUNICATION_NODE));
+                let dest_node_id = destination
+                    .node_id()
+                    .map(Clone::clone)
+                    .or_else(|| destination.public_key().and_then(|pk| NodeId::from_key(pk).ok()));
 
-                debug!(
+                let connections = match dest_node_id {
+                    Some(node_id) => {
+                        let dest_connection = connectivity.get_connection(node_id.clone()).await?;
+                        // If the peer was added to the exclude list, we don't want to send directly to the peer.
+                        // This handles an edge case for the the join message which has a destination to the peer that
+                        // sent it.
+                        let dest_connection = dest_connection.filter(|c| !exclude.contains(c.peer_node_id()));
+                        match dest_connection {
+                            Some(conn) => {
+                                // We're connected to the destination, so send the message directly
+                                vec![conn]
+                            },
+                            None => {
+                                // Select connections closer to the destination
+                                let mut connections = connectivity
+                                    .select_connections(ConnectivitySelection::closest_to(
+                                        node_identity.node_id().clone(),
+                                        config.num_neighbouring_nodes,
+                                        exclude.clone(),
+                                    ))
+                                    .await?;
+                                // Exclude candidates that are further away from the destination than this node
+                                // unless this node has not selected a big enough sample i.e. this node is not well
+                                // connected
+                                if connections.len() >= config.propagation_factor {
+                                    let dist_from_dest = node_identity.node_id().distance(&node_id);
+                                    let before_len = connections.len();
+                                    connections = connections
+                                        .into_iter()
+                                        .filter(|conn| conn.peer_node_id().distance(&node_id) < dist_from_dest)
+                                        .collect();
+
+                                    debug!(
+                                        target: LOG_TARGET,
+                                        "Filtered out {} node(s) that are further away than this node.",
+                                        before_len - connections.len()
+                                    );
+                                }
+
+                                connections
+                            },
+                        }
+                    },
+                    None => {
+                        connectivity
+                            .select_connections(ConnectivitySelection::random_nodes(
+                                config.num_neighbouring_nodes,
+                                exclude.clone(),
+                            ))
+                            .await?
+                    },
+                };
+
+                if connections.is_empty() {
+                    warn!(
+                        target: LOG_TARGET,
+                        "Propagation requested but there are no node peer connections available"
+                    );
+                }
+
+                let candidates = connections
+                    .iter()
+                    .take(config.propagation_factor)
+                    .map(|c| c.peer_node_id())
+                    .cloned()
+                    .collect::<Vec<_>>();
+
+                info!(
                     target: LOG_TARGET,
-                    "{} connected node(s), {} connected client(s)",
-                    connected_nodes.len(),
-                    connected_clients.len()
+                    "{} candidate(s) selected for propagation to {}",
+                    candidates.len(),
+                    destination
                 );
 
-                if destination.is_unknown() {
-                    // If the message has an unknown destination, propagate to random peers
-                    if connected_nodes.len() >= config.num_neighbouring_nodes {
-                        let candidates = connected_nodes
-                            .choose_multiple(&mut OsRng, config.num_propagation_nodes())
-                            .cloned()
-                            .collect();
-                        debug!(
-                            target: LOG_TARGET,
-                            "Selected {} candidates for propagation to undefined destination from a pool of {} active \
-                             connections",
-                            config.num_neighbouring_nodes,
-                            connected_nodes.len()
-                        );
-                        Ok(candidates)
-                    } else {
-                        let random_peers = peer_manager
-                            .random_peers(config.num_propagation_nodes(), &exclude)
-                            .await?
-                            .into_iter()
-                            .map(Arc::new)
-                            .collect::<Vec<_>>();
-                        debug!(
-                            target: LOG_TARGET,
-                            "Selected {} random candidates for propagation to undefined destination",
-                            random_peers.len(),
-                        );
-                        Ok(random_peers)
-                    }
-                } else {
-                    let dest_node_id = destination
-                        .node_id()
-                        .map(Clone::clone)
-                        .or_else(|| destination.public_key().and_then(|pk| NodeId::from_key(pk).ok()));
-
-                    let mut candidates = Self::get_propagate_candidates(
-                        &config,
-                        &peer_manager,
-                        &connected_clients,
-                        &connected_nodes,
-                        &node_identity,
-                        dest_node_id.clone().unwrap_or_else(|| node_identity.node_id().clone()),
-                        &exclude,
-                    )
-                    .await?;
-
-                    // Exclude candidates that are further away from the destination than this node
-                    // unless this node has not selected a big enough sample i.e. this node is not well connected
-                    if candidates.len() >= config.num_neighbouring_nodes {
-                        if let Some(node_id) = dest_node_id {
-                            let dist_from_dest = node_identity.node_id().distance(&node_id);
-                            let before_len = candidates.len();
-                            candidates = candidates
-                                .into_iter()
-                                .filter(|p| p.node_id.distance(&node_id) < dist_from_dest)
-                                .collect();
-
-                            debug!(
-                                target: LOG_TARGET,
-                                "Filtered out {} node(s) that are further away than this node.",
-                                before_len - candidates.len()
-                            );
-                        }
-                    }
-
-                    candidates.truncate(config.num_propagation_nodes());
-                    info!(
-                        target: LOG_TARGET,
-                        "{} candidate(s) selected for propagation to {}",
-                        candidates.len(),
-                        destination
-                    );
-
-                    Ok(candidates)
-                }
+                Ok(candidates)
             },
         }
-    }
-
-    async fn get_propagate_candidates(
-        config: &DhtConfig,
-        peer_manager: &PeerManager,
-        connected_clients: &[Arc<Peer>],
-        connected_nodes: &[Arc<Peer>],
-        node_identity: &NodeIdentity,
-        dest_node_id: NodeId,
-        exclude: &[NodeId],
-    ) -> Result<Vec<Arc<Peer>>, DhtActorError>
-    {
-        // If a connected wallet matches the destination, just send it to them
-        if let Some(client) = connected_clients.iter().find(|peer| peer.node_id == dest_node_id) {
-            // If we're excluding the client for this propagation (as is the case for join messages)
-            // do a normal propagation
-            if !exclude.contains(&client.node_id) {
-                debug!(
-                    target: LOG_TARGET,
-                    "Message destination is for the connected client '{}'. Sending to connected client only.",
-                    client.node_id
-                );
-                return Ok(vec![client.clone()]);
-            }
-        }
-
-        let mut candidates = Self::select_closest_peers_for_propagation(
-            config,
-            peer_manager,
-            // To prevent new connections being established, select neighbours
-            node_identity.node_id(),
-            config.num_neighbouring_nodes,
-            exclude,
-            PeerFeatures::MESSAGE_PROPAGATION,
-        )
-        .await?;
-
-        // Add any other communication nodes that are connected.
-        let connected_nodes = connected_nodes
-            .iter()
-            .filter(|peer| !candidates.contains(&peer))
-            .cloned()
-            .collect::<Vec<_>>();
-        candidates.extend(connected_nodes);
-
-        // Filter out excluded candidates that might have been included from active connections
-        let mut candidates = candidates
-            .into_iter()
-            .filter(|peer| !exclude.contains(&peer.node_id))
-            .collect::<Vec<_>>();
-
-        // Sort by closeness to destination
-        candidates.sort_by(|a, b| {
-            let node_a_dist = a.node_id.distance(&dest_node_id);
-            let node_b_dist = b.node_id.distance(&dest_node_id);
-            node_a_dist.cmp(&node_b_dist)
-        });
-
-        Ok(candidates)
     }
 
     /// Selects at least `n` MESSAGE_PROPAGATION peers (assuming that many are known) that are closest to `node_id` as
@@ -620,15 +531,13 @@ impl<'a> DhtActor<'a> {
     /// This ensures that peers are selected which are able to propagate the message further while still allowing
     /// clients to propagate to non-propagation nodes if required (e.g. Discovery messages)
     async fn select_closest_peers_for_propagation(
-        config: &DhtConfig,
         peer_manager: &PeerManager,
         node_id: &NodeId,
         n: usize,
         excluded_peers: &[NodeId],
         features: PeerFeatures,
-    ) -> Result<Vec<Arc<Peer>>, DhtActorError>
+    ) -> Result<Vec<NodeId>, DhtActorError>
     {
-        // TODO: This query is expensive. We can probably cache a list of neighbouring peers which are online
         // Fetch to all n nearest neighbour Communication Nodes
         // which are eligible for connection.
         // Currently that means:
@@ -659,17 +568,7 @@ impl<'a> DhtActor<'a> {
                     return false;
                 }
 
-                let is_connect_eligible = {
-                    !peer.is_offline() &&
-                        // Check this peer was recently connectable
-                        (peer.connection_stats.failed_attempts() <= config.broadcast_cooldown_max_attempts ||
-                        peer.connection_stats
-                            .time_since_last_failure()
-                            .map(|failed_since| failed_since >= config.broadcast_cooldown_period)
-                            .unwrap_or(true))
-                };
-
-                if !is_connect_eligible {
+                if peer.is_offline() {
                     trace!(
                         target: LOG_TARGET,
                         "[{}] suffered too many connection attempt failures or is offline",
@@ -709,7 +608,7 @@ impl<'a> DhtActor<'a> {
             );
         }
 
-        Ok(peers.into_iter().map(Arc::new).collect())
+        Ok(peers.into_iter().map(|p| p.node_id).collect())
     }
 }
 
@@ -723,7 +622,7 @@ mod test {
     use chrono::{DateTime, Utc};
     use tari_comms::{
         peer_manager::PeerFeatures,
-        test_utils::mocks::{create_connection_manager_mock, create_peer_connection_mock_pair},
+        test_utils::mocks::{create_connectivity_mock, create_peer_connection_mock_pair},
     };
     use tari_shutdown::Shutdown;
     use tari_test_utils::random;
@@ -739,7 +638,7 @@ mod test {
         let node_identity = make_node_identity();
         let peer_manager = make_peer_manager();
         let (out_tx, mut out_rx) = mpsc::channel(1);
-        let (connection_manager, mock) = create_connection_manager_mock();
+        let (connectivity_manager, mock) = create_connectivity_mock();
         mock.spawn();
         let (actor_tx, actor_rx) = mpsc::channel(1);
         let mut requester = DhtRequester::new(actor_tx);
@@ -750,13 +649,13 @@ mod test {
             db_connection().await,
             node_identity,
             peer_manager,
-            connection_manager,
+            connectivity_manager,
             outbound_requester,
             actor_rx,
             shutdown.to_signal(),
         );
 
-        actor.spawn().await.unwrap();
+        actor.spawn();
 
         requester.send_join().await.unwrap();
         let (params, _) = unwrap_oms_send_msg!(out_rx.next().await.unwrap());
@@ -767,7 +666,7 @@ mod test {
     async fn insert_message_signature() {
         let node_identity = make_node_identity();
         let peer_manager = make_peer_manager();
-        let (connection_manager, mock) = create_connection_manager_mock();
+        let (connectivity_manager, mock) = create_connectivity_mock();
         mock.spawn();
         let (out_tx, _) = mpsc::channel(1);
         let (actor_tx, actor_rx) = mpsc::channel(1);
@@ -779,13 +678,13 @@ mod test {
             db_connection().await,
             node_identity,
             peer_manager,
-            connection_manager,
+            connectivity_manager,
             outbound_requester,
             actor_rx,
             shutdown.to_signal(),
         );
 
-        actor.spawn().await.unwrap();
+        actor.spawn();
 
         let signature = vec![1u8, 2, 3];
         let is_dup = requester.insert_message_hash(signature.clone()).await.unwrap();
@@ -804,13 +703,13 @@ mod test {
         let client_node_identity = make_client_identity();
         peer_manager.add_peer(client_node_identity.to_peer()).await.unwrap();
 
-        let (connection_manager, mock) = create_connection_manager_mock();
-        let connection_manager_mock_state = mock.get_shared_state();
+        let (connectivity_manager, mock) = create_connectivity_mock();
+        let connectivity_manager_mock_state = mock.get_shared_state();
         mock.spawn();
 
-        let (conn_in, _, _conn_out, _) =
+        let (conn_in, _, conn_out, _) =
             create_peer_connection_mock_pair(1, client_node_identity.to_peer(), node_identity.to_peer()).await;
-        connection_manager_mock_state
+        connectivity_manager_mock_state
             .add_active_connection(node_identity.node_id().clone(), conn_in)
             .await;
 
@@ -826,19 +725,28 @@ mod test {
             db_connection().await,
             Arc::clone(&node_identity),
             peer_manager,
-            connection_manager,
+            connectivity_manager,
             outbound_requester,
             actor_rx,
             shutdown.to_signal(),
         );
 
-        actor.spawn().await.unwrap();
+        actor.spawn();
 
         let peers = requester
-            .select_peers(BroadcastStrategy::Neighbours(Vec::new()))
+            .select_peers(BroadcastStrategy::Broadcast(Vec::new()))
             .await
             .unwrap();
 
+        assert_eq!(peers.len(), 0);
+
+        connectivity_manager_mock_state
+            .set_selected_connections(vec![conn_out.clone()])
+            .await;
+        let peers = requester
+            .select_peers(BroadcastStrategy::Broadcast(Vec::new()))
+            .await
+            .unwrap();
         assert_eq!(peers.len(), 1);
 
         let send_request = Box::new(BroadcastClosestRequest {
@@ -869,7 +777,7 @@ mod test {
         let peer_manager = make_peer_manager();
         let (out_tx, _out_rx) = mpsc::channel(1);
         let (actor_tx, actor_rx) = mpsc::channel(1);
-        let (connection_manager, mock) = create_connection_manager_mock();
+        let (connectivity_manager, mock) = create_connectivity_mock();
         mock.spawn();
         let mut requester = DhtRequester::new(actor_tx);
         let outbound_requester = OutboundMessageRequester::new(out_tx);
@@ -879,13 +787,13 @@ mod test {
             db_connection().await,
             node_identity,
             peer_manager,
-            connection_manager,
+            connectivity_manager,
             outbound_requester,
             actor_rx,
             shutdown.to_signal(),
         );
 
-        actor.spawn().await.unwrap();
+        actor.spawn();
 
         assert!(requester
             .get_metadata::<DateTime<Utc>>(DhtMetadataKey::OfflineTimestamp)

--- a/comms/dht/src/broadcast_strategy.rs
+++ b/comms/dht/src/broadcast_strategy.rs
@@ -47,9 +47,7 @@ pub enum BroadcastStrategy {
     Random(usize, Vec<NodeId>),
     /// Send to all n nearest Communication Nodes according to the given BroadcastClosestRequest
     Closest(Box<BroadcastClosestRequest>),
-    /// A convenient strategy which behaves the same as the `Closest` strategy with the `NodeId` set
-    /// to this node. The given NodeIds are excluded from the selection.
-    Neighbours(Vec<NodeId>),
+    Broadcast(Vec<NodeId>),
     /// Propagate to a set of closest neighbours and random peers
     Propagate(NodeDestination, Vec<NodeId>),
 }
@@ -63,7 +61,7 @@ impl fmt::Display for BroadcastStrategy {
             Flood => write!(f, "Flood"),
             Closest(request) => write!(f, "Closest({})", request.n),
             Random(n, excluded) => write!(f, "Random({}, {} excluded)", n, excluded.len()),
-            Neighbours(excluded) => write!(f, "Neighbours({} excluded)", excluded.len()),
+            Broadcast(excluded) => write!(f, "Broadcast({} excluded)", excluded.len()),
             Propagate(destination, excluded) => write!(f, "Propagate({}, {} excluded)", destination, excluded.len(),),
         }
     }
@@ -73,7 +71,7 @@ impl BroadcastStrategy {
     pub fn is_broadcast(&self) -> bool {
         use BroadcastStrategy::*;
         match self {
-            Closest(_) | Flood | Neighbours(_) | Random(_, _) | Propagate(_, _) => true,
+            Closest(_) | Flood | Broadcast(_) | Random(_, _) | Propagate(_, _) => true,
             _ => false,
         }
     }
@@ -119,7 +117,7 @@ mod test {
     fn is_direct() {
         assert!(BroadcastStrategy::DirectPublicKey(Box::new(CommsPublicKey::default())).is_direct());
         assert!(BroadcastStrategy::DirectNodeId(Box::new(NodeId::default())).is_direct());
-        assert_eq!(BroadcastStrategy::Neighbours(Default::default()).is_direct(), false);
+        assert_eq!(BroadcastStrategy::Broadcast(Default::default()).is_direct(), false);
         assert_eq!(
             BroadcastStrategy::Propagate(Default::default(), Default::default()).is_direct(),
             false
@@ -146,7 +144,7 @@ mod test {
         assert!(BroadcastStrategy::DirectNodeId(Box::new(NodeId::default()))
             .direct_public_key()
             .is_none());
-        assert!(BroadcastStrategy::Neighbours(Default::default(),)
+        assert!(BroadcastStrategy::Broadcast(Default::default(),)
             .direct_public_key()
             .is_none());
         assert!(BroadcastStrategy::Flood.direct_public_key().is_none());
@@ -172,7 +170,7 @@ mod test {
         assert!(BroadcastStrategy::DirectNodeId(Box::new(NodeId::default()))
             .direct_node_id()
             .is_some());
-        assert!(BroadcastStrategy::Neighbours(Default::default(),)
+        assert!(BroadcastStrategy::Broadcast(Default::default(),)
             .direct_node_id()
             .is_none());
         assert!(BroadcastStrategy::Flood.direct_node_id().is_none());

--- a/comms/dht/src/builder.rs
+++ b/comms/dht/src/builder.rs
@@ -24,7 +24,7 @@ use crate::{dht::DhtInitializationError, outbound::DhtOutboundRequest, DbConnect
 use futures::channel::mpsc;
 use std::{sync::Arc, time::Duration};
 use tari_comms::{
-    connection_manager::ConnectionManagerRequester,
+    connectivity::ConnectivityRequester,
     peer_manager::{NodeIdentity, PeerManager},
 };
 use tari_shutdown::ShutdownSignal;
@@ -34,7 +34,7 @@ pub struct DhtBuilder {
     peer_manager: Arc<PeerManager>,
     config: DhtConfig,
     outbound_tx: mpsc::Sender<DhtOutboundRequest>,
-    connection_manager: ConnectionManagerRequester,
+    connectivity: ConnectivityRequester,
     shutdown_signal: ShutdownSignal,
 }
 
@@ -43,7 +43,7 @@ impl DhtBuilder {
         node_identity: Arc<NodeIdentity>,
         peer_manager: Arc<PeerManager>,
         outbound_tx: mpsc::Sender<DhtOutboundRequest>,
-        connection_manager: ConnectionManagerRequester,
+        connectivity: ConnectivityRequester,
         shutdown_signal: ShutdownSignal,
     ) -> Self
     {
@@ -55,7 +55,7 @@ impl DhtBuilder {
             node_identity,
             peer_manager,
             outbound_tx,
-            connection_manager,
+            connectivity,
             shutdown_signal,
         }
     }
@@ -105,8 +105,18 @@ impl DhtBuilder {
         self
     }
 
+    pub fn with_propagation_factor(mut self, propagation_factor: usize) -> Self {
+        self.config.propagation_factor = propagation_factor;
+        self
+    }
+
     pub fn with_discovery_timeout(mut self, timeout: Duration) -> Self {
         self.config.discovery_request_timeout = timeout;
+        self
+    }
+
+    pub fn enable_auto_join(mut self) -> Self {
+        self.config.auto_join = true;
         self
     }
 
@@ -119,7 +129,7 @@ impl DhtBuilder {
             self.node_identity,
             self.peer_manager,
             self.outbound_tx,
-            self.connection_manager,
+            self.connectivity,
             self.shutdown_signal,
         )
         .await

--- a/comms/dht/src/config.rs
+++ b/comms/dht/src/config.rs
@@ -29,8 +29,10 @@ pub const SAF_MSG_STORAGE_CAPACITY: usize = 10_000;
 pub const SAF_LOW_PRIORITY_MSG_STORAGE_TTL: Duration = Duration::from_secs(6 * 60 * 60); // 6 hours
 /// The default time-to-live duration used for storage of high priority messages by the Store-and-forward middleware
 pub const SAF_HIGH_PRIORITY_MSG_STORAGE_TTL: Duration = Duration::from_secs(3 * 24 * 60 * 60); // 3 days
-/// The default number of peer nodes that a message has to be closer to, to be considered a neighbour
+/// The default number of known peer nodes that are closest to this node
 pub const DEFAULT_NUM_NEIGHBOURING_NODES: usize = 8;
+/// The default number of randomly-selected peer nodes
+pub const DEFAULT_NUM_RANDOM_NODES: usize = 4;
 
 #[derive(Debug, Clone)]
 pub struct DhtConfig {
@@ -40,12 +42,14 @@ pub struct DhtConfig {
     /// Default: 20
     pub outbound_buffer_size: usize,
     /// The maximum number of peer nodes that a message has to be closer to, to be considered a neighbour
-    /// Default: 8
+    /// Default: [DEFAULT_NUM_NEIGHBOURING_NODES](self::DEFAULT_NUM_NEIGHBOURING_NODES)
     pub num_neighbouring_nodes: usize,
-    /// A number from 0 to 1 that determines the number of peers to propagate to as a factor of
-    /// `num_neighbouring_nodes`.
-    /// Default: 0.5
-    pub propagation_factor: f32,
+    /// Number of random peers to include
+    /// Default: [DEFAULT_NUM_RANDOM_NODES](self::DEFAULT_NUM_RANDOM_NODES)
+    pub num_random_nodes: usize,
+    /// For each message to propagate, propagate to this many peers
+    /// Default: 4
+    pub propagation_factor: usize,
     /// The maximum number of messages that can be stored using the Store-and-forward middleware. Default: 10_000
     pub saf_msg_storage_capacity: usize,
     /// A request to retrieve stored messages will be ignored if the requesting node is
@@ -71,18 +75,22 @@ pub struct DhtConfig {
     /// The time-to-live for items in the message hash cache
     /// Default: 300s (5 mins)
     pub msg_hash_cache_ttl: Duration,
-    /// Sets the number of failed attempts in-a-row to tolerate before temporarily excluding this peer from broadcast
-    /// messages.
-    /// Default: 3
-    pub broadcast_cooldown_max_attempts: usize,
-    /// Sets the period to wait before including this peer in broadcast messages after
-    /// `broadcast_cooldown_max_attempts` failed attempts. This helps prevent thrashing the comms layer
-    /// with connection attempts to a peer which is offline.
-    /// Default: 30 minutes
-    pub broadcast_cooldown_period: Duration,
     /// The duration to wait for a peer discovery to complete before giving up.
     /// Default: 2 minutes
     pub discovery_request_timeout: Duration,
+    /// Set to true to automatically broadcast a join message when ready, otherwise false. Default: false
+    pub auto_join: bool,
+    /// The minimum time between sending a Join message to the network. Joins are only sent when the node establishes
+    /// enough connections to the network as determined by comms ConnectivityManager. If a join was sent and then state
+    /// change happens again after this period, another join will be sent.
+    /// Default: 10 minutes
+    pub join_cooldown_interval: Duration,
+    /// The interval to update the neighbouring and random pools, if necessary.
+    /// Default: 2 minutes
+    pub connectivity_update_interval: Duration,
+    /// The interval to change the random pool peers.
+    /// Default: 2 hours
+    pub connectivity_random_pool_refresh: Duration,
     /// The active Network. Default: TestNet
     pub network: Network,
 }
@@ -104,14 +112,9 @@ impl DhtConfig {
             network: Network::LocalTest,
             database_url: DbConnectionUrl::Memory,
             saf_auto_request: false,
+            auto_join: false,
             ..Default::default()
         }
-    }
-
-    #[inline]
-    pub fn num_propagation_nodes(&self) -> usize {
-        let n = self.num_neighbouring_nodes as f32 * self.propagation_factor;
-        n.round() as usize
     }
 }
 
@@ -119,7 +122,8 @@ impl Default for DhtConfig {
     fn default() -> Self {
         Self {
             num_neighbouring_nodes: DEFAULT_NUM_NEIGHBOURING_NODES,
-            propagation_factor: 0.5,
+            num_random_nodes: DEFAULT_NUM_RANDOM_NODES,
+            propagation_factor: 4,
             saf_num_closest_nodes: 10,
             saf_max_returned_messages: 50,
             outbound_buffer_size: 20,
@@ -130,10 +134,12 @@ impl Default for DhtConfig {
             saf_max_message_size: 512 * 1024, // 500 KiB
             msg_hash_cache_capacity: 10_000,
             msg_hash_cache_ttl: Duration::from_secs(5 * 60),
-            broadcast_cooldown_max_attempts: 3,
             database_url: DbConnectionUrl::Memory,
-            broadcast_cooldown_period: Duration::from_secs(60 * 30),
             discovery_request_timeout: Duration::from_secs(2 * 60),
+            connectivity_update_interval: Duration::from_secs(2 * 60),
+            connectivity_random_pool_refresh: Duration::from_secs(2 * 60 * 60),
+            auto_join: false,
+            join_cooldown_interval: Duration::from_secs(10 * 60),
             network: Network::TestNet,
         }
     }

--- a/comms/dht/src/connectivity/mod.rs
+++ b/comms/dht/src/connectivity/mod.rs
@@ -1,0 +1,500 @@
+//  Copyright 2020, The Tari Project
+//
+//  Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+//  following conditions are met:
+//
+//  1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+//  disclaimer.
+//
+//  2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+//  following disclaimer in the documentation and/or other materials provided with the distribution.
+//
+//  3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+//  products derived from this software without specific prior written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+//  INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+//  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+//  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+//  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+//  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+//  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#[cfg(test)]
+mod test;
+
+use crate::{DhtActorError, DhtConfig, DhtRequester};
+use derive_error::Error;
+use futures::StreamExt;
+use log::*;
+use std::{sync::Arc, time::Instant};
+use tari_comms::{
+    connectivity::{ConnectivityError, ConnectivityEvent, ConnectivityEventRx, ConnectivityRequester},
+    peer_manager::{node_id::NodeDistance, NodeId, PeerManagerError, PeerQuery, PeerQuerySortBy},
+    NodeIdentity,
+    PeerConnection,
+    PeerManager,
+};
+use tari_shutdown::ShutdownSignal;
+use tokio::{task, task::JoinHandle, time};
+
+const LOG_TARGET: &str = "comms::dht::connectivity";
+
+#[derive(Debug, Error)]
+pub enum DhtConnectivityError {
+    ConnectivityError(ConnectivityError),
+    PeerManagerError(PeerManagerError),
+    /// Failed to send network Join message
+    #[error(no_from)]
+    SendJoinFailed(DhtActorError),
+}
+
+/// # DHT Connectivity Actor
+///
+/// Responsible for ensuring DHT network connectivity to a neighbouring and random peer set. This includes joining the
+/// network when the node has established some peer connections (e.g to seed peers). It maintains neighbouring and
+/// random peer pools and instructs the comms `ConnectivityManager` to establish those connections. Once a configured
+/// percentage of these peers is online, the node is established on the DHT network.
+///
+/// The DHT connectivity actor monitors the connectivity state (using `ConnectivityEvent`s) and attempts
+/// to maintain connectivity to the network as peers come and go.
+pub struct DhtConnectivity {
+    config: DhtConfig,
+    peer_manager: Arc<PeerManager>,
+    node_identity: Arc<NodeIdentity>,
+    connectivity: ConnectivityRequester,
+    dht_requester: DhtRequester,
+
+    /// List of neighbours managed by DhtConnectivity ordered by distance from this node
+    neighbours: Vec<NodeId>,
+    /// A randomly-selected set of peers, excluding neighbouring peers.
+    random_pool: Vec<NodeId>,
+    /// Used to track when the random peer pool was last refreshed
+    random_pool_last_refresh: Option<Instant>,
+    ///
+    stats: Stats,
+    shutdown_signal: Option<ShutdownSignal>,
+}
+
+impl DhtConnectivity {
+    pub fn new(
+        config: DhtConfig,
+        peer_manager: Arc<PeerManager>,
+        node_identity: Arc<NodeIdentity>,
+        connectivity: ConnectivityRequester,
+        dht_requester: DhtRequester,
+        shutdown_signal: ShutdownSignal,
+    ) -> Self
+    {
+        Self {
+            neighbours: Vec::with_capacity(config.num_neighbouring_nodes),
+            random_pool: Vec::with_capacity(config.num_random_nodes),
+            config,
+            peer_manager,
+            node_identity,
+            connectivity,
+            dht_requester,
+            random_pool_last_refresh: None,
+            stats: Stats::new(),
+            shutdown_signal: Some(shutdown_signal),
+        }
+    }
+
+    /// Spawn a DhtConnectivity actor. This will immediately subscribe to the connection manager event stream to
+    /// prevent unexpected missed events.
+    pub fn spawn(self) -> JoinHandle<Result<(), DhtConnectivityError>> {
+        let connectivity_events = self.connectivity.subscribe_event_stream();
+        task::spawn(async move {
+            match self.run(connectivity_events).await {
+                Ok(_) => Ok(()),
+                Err(err) => {
+                    error!(target: LOG_TARGET, "DhtConnectivity exited with error: {:?}", err);
+                    Err(err)
+                },
+            }
+        })
+    }
+
+    pub async fn run(mut self, connectivity_events: ConnectivityEventRx) -> Result<(), DhtConnectivityError> {
+        let mut connectivity_events = connectivity_events.fuse();
+        let mut shutdown_signal = self
+            .shutdown_signal
+            .take()
+            .expect("DhtConnectivity initialized without a shutdown_signal");
+
+        self.initialize_neighbours().await?;
+
+        let mut ticker = time::interval(self.config.connectivity_update_interval).fuse();
+
+        loop {
+            futures::select! {
+                event = connectivity_events.select_next_some() => {
+                    if let Ok(event) = event {
+                        if let Err(err) = self.handle_connectivity_event(&event).await {
+                            error!(target: LOG_TARGET, "Error handling connectivity event: {:?}", err);
+                        }
+                    }
+               },
+
+               _ = ticker.next() => {
+                    if let Err(err) = self.refresh_random_pool_if_required().await {
+                        error!(target: LOG_TARGET, "Error refreshing random peer pool: {:?}", err);
+                    }
+               },
+
+               _ = shutdown_signal => {
+                    info!(target: LOG_TARGET, "DhtConnectivity shutting down because the shutdown signal was received");
+                    break;
+               }
+            }
+        }
+
+        Ok(())
+    }
+
+    async fn initialize_neighbours(&mut self) -> Result<(), DhtConnectivityError> {
+        self.neighbours = self
+            .fetch_neighbouring_peers(self.config.num_neighbouring_nodes, &[])
+            .await?;
+        info!(
+            target: LOG_TARGET,
+            "Adding {} neighbouring peer(s)",
+            self.neighbours.len(),
+        );
+
+        self.connectivity.add_managed_peers(self.neighbours.clone()).await?;
+        Ok(())
+    }
+
+    async fn handle_connectivity_event(&mut self, event: &ConnectivityEvent) -> Result<(), DhtConnectivityError> {
+        use ConnectivityEvent::*;
+        match event {
+            PeerConnected(conn) => {
+                self.handle_new_peer_connected(conn).await?;
+            },
+            PeerConnectFailed(node_id) | PeerOffline(node_id) | PeerBanned(node_id) => {
+                self.replace_managed_peer(node_id).await?;
+            },
+            ConnectivityStateDegraded(_) | ConnectivityStateOnline(_) => {
+                if self.config.auto_join && self.can_send_join() {
+                    info!(target: LOG_TARGET, "Joining the network automatically");
+                    self.dht_requester
+                        .send_join()
+                        .await
+                        .map_err(DhtConnectivityError::SendJoinFailed)?;
+                    self.stats.mark_join_sent();
+                }
+            },
+            _ => {},
+        }
+
+        Ok(())
+    }
+
+    async fn refresh_random_pool_if_required(&mut self) -> Result<(), DhtConnectivityError> {
+        if self.should_refresh_random_pool() {
+            let mut random_peers = self
+                .fetch_random_peers(self.config.num_random_nodes, &self.neighbours)
+                .await?;
+            if random_peers.is_empty() {
+                warn!(
+                    target: LOG_TARGET,
+                    "Unable to refresh random peer pool because there are insufficient known peers",
+                );
+            } else {
+                let (keep, to_remove) = self
+                    .random_pool
+                    .iter()
+                    .partition::<Vec<_>, _>(|n| random_peers.contains(n));
+                // Remove the peers that we want to keep from the `random_peers` to be added
+                random_peers.retain(|n| !keep.contains(&n));
+                info!(
+                    target: LOG_TARGET,
+                    "Adding new peers to random peer pool (#new = {}, #keeping = {}, #removing = {})",
+                    random_peers.len(),
+                    keep.len(),
+                    to_remove.len()
+                );
+                self.connectivity.add_managed_peers(random_peers).await?;
+                for n in to_remove {
+                    self.connectivity.remove_peer(n.clone()).await?;
+                }
+            }
+            self.random_pool_last_refresh = Some(Instant::now());
+        }
+
+        Ok(())
+    }
+
+    #[inline]
+    fn should_refresh_random_pool(&self) -> bool {
+        self.config.num_random_nodes > 0 &&
+            self.random_pool_last_refresh
+                .map(|instant| instant.elapsed() >= self.config.connectivity_random_pool_refresh)
+                .unwrap_or(true)
+    }
+
+    async fn handle_new_peer_connected(&mut self, conn: &PeerConnection) -> Result<(), DhtConnectivityError> {
+        if conn.peer_features().is_client() {
+            debug!(
+                target: LOG_TARGET,
+                "Client node '{}' connected",
+                conn.peer_node_id().short_str()
+            );
+            return Ok(());
+        }
+
+        if self.is_managed(conn.peer_node_id()) {
+            debug!(
+                target: LOG_TARGET,
+                "Node {} connected that is already managed by DhtConnectivity",
+                conn.peer_node_id()
+            );
+            return Ok(());
+        }
+
+        let current_dist = conn.peer_node_id().distance(self.node_identity.node_id());
+        let neighbour_distance = self.get_neighbour_max_distance();
+        if current_dist < neighbour_distance {
+            info!(
+                target: LOG_TARGET,
+                "Peer '{}' connected that is closer than any current neighbour. Adding to neighbours.",
+                conn.peer_node_id().short_str()
+            );
+
+            if let Some(node_id) = self.insert_neighbour(conn.peer_node_id().clone()) {
+                // If we kicked a neighbour out of our neighbour pool but the random pool is not full.
+                // Add the neighbour to the random pool, otherwise remove it
+                if self.random_pool.len() < self.config.num_random_nodes {
+                    info!(
+                        target: LOG_TARGET,
+                        "Moving peer '{}' from neighbouring pool to random pool", node_id
+                    );
+                    self.random_pool.push(node_id);
+                } else {
+                    info!(target: LOG_TARGET, "Removing peer '{}' from neighbouring pool", node_id);
+                    self.connectivity.remove_peer(node_id).await?;
+                }
+            }
+            self.connectivity
+                .add_managed_peers(vec![conn.peer_node_id().clone()])
+                .await?;
+
+            return Ok(());
+        }
+
+        Ok(())
+    }
+
+    async fn replace_managed_peer(&mut self, current_peer: &NodeId) -> Result<(), DhtConnectivityError> {
+        if !self.is_managed(current_peer) {
+            return Ok(());
+        }
+
+        if self.random_pool.contains(current_peer) {
+            info!(
+                target: LOG_TARGET,
+                "Peer '{}' in random pool is offline. Adding a new random peer if possible", current_peer
+            );
+            let exclude = self.get_managed_peers();
+            match self.fetch_random_peers(1, &exclude).await?.pop() {
+                Some(node_id) => {
+                    if let Some(pos) = self.random_pool.iter().position(|n| n == current_peer) {
+                        self.random_pool.remove(pos);
+                    }
+                    self.random_pool.push(node_id.clone());
+                    self.connectivity.remove_peer(current_peer.clone()).await?;
+                    self.connectivity.add_managed_peers(vec![node_id]).await?;
+                },
+                None => {
+                    warn!(
+                        target: LOG_TARGET,
+                        "Unable to fetch new random peer to replace disconnected peer '{}' because not enough peers \
+                         are known. Random pool size is {}.",
+                        current_peer,
+                        self.random_pool.len()
+                    );
+                },
+            }
+        }
+
+        if self.neighbours.contains(current_peer) {
+            info!(
+                target: LOG_TARGET,
+                "Peer '{}' in neighbour pool is offline. Adding a new peer if possible", current_peer
+            );
+            let exclude = self.get_managed_peers();
+            match self.fetch_neighbouring_peers(1, &exclude).await?.pop() {
+                Some(node_id) => {
+                    if let Some(pos) = self.neighbours.iter().position(|n| n == current_peer) {
+                        self.neighbours.remove(pos);
+                    }
+                    self.insert_neighbour(node_id.clone());
+                    self.connectivity.remove_peer(current_peer.clone()).await?;
+                    self.connectivity.add_managed_peers(vec![node_id]).await?;
+                },
+                None => {
+                    warn!(
+                        target: LOG_TARGET,
+                        "Unable to fetch new neighbouring peer to replace disconnected peer '{}'. Neighbour pool size \
+                         is {}.",
+                        current_peer,
+                        self.neighbours.len()
+                    );
+                },
+            }
+        }
+
+        Ok(())
+    }
+
+    fn insert_neighbour(&mut self, node_id: NodeId) -> Option<NodeId> {
+        let dist = node_id.distance(self.node_identity.node_id());
+        let pos = self.neighbours.iter().position(|node_id| {
+            let d = node_id.distance(self.node_identity.node_id());
+            d > dist
+        });
+
+        let mut removed_peer = None;
+        if self.neighbours.len() + 1 > self.config.num_neighbouring_nodes {
+            removed_peer = self.neighbours.pop();
+        }
+
+        match pos {
+            Some(idx) => {
+                self.neighbours.insert(idx, node_id);
+            },
+            None => {
+                self.neighbours.push(node_id);
+            },
+        }
+
+        removed_peer
+    }
+
+    fn is_managed(&self, node_id: &NodeId) -> bool {
+        self.neighbours.contains(node_id) || self.random_pool.contains(node_id)
+    }
+
+    fn get_managed_peers(&self) -> Vec<NodeId> {
+        self.neighbours.iter().chain(self.random_pool.iter()).cloned().collect()
+    }
+
+    fn get_neighbour_max_distance(&self) -> NodeDistance {
+        assert!(
+            self.config.num_neighbouring_nodes > 0,
+            "DhtConfig::num_neighbouring_nodes must be greater than zero"
+        );
+
+        if self.neighbours.len() < self.config.num_neighbouring_nodes {
+            return NodeDistance::max_distance();
+        }
+
+        self.neighbours
+            .last()
+            .map(|node_id| node_id.distance(self.node_identity.node_id()))
+            .expect("already checked")
+    }
+
+    async fn fetch_neighbouring_peers(
+        &self,
+        n: usize,
+        excluded: &[NodeId],
+    ) -> Result<Vec<NodeId>, DhtConnectivityError>
+    {
+        let peer_manager = &self.peer_manager;
+        let node_id = self.node_identity.node_id();
+        // Fetch to all n nearest neighbour Communication Nodes
+        // which are eligible for connection.
+        // Currently that means:
+        // - The peer isn't banned,
+        // - it has the required features
+        // - it didn't recently fail to connect, and
+        // - it is not in the exclusion list in closest_request
+        let mut connect_ineligable_count = 0;
+        let mut banned_count = 0;
+        let mut excluded_count = 0;
+        let mut filtered_out_node_count = 0;
+        let query = PeerQuery::new()
+            .select_where(|peer| {
+                if peer.is_banned() {
+                    banned_count += 1;
+                    return false;
+                }
+
+                if peer.features.is_client() {
+                    filtered_out_node_count += 1;
+                    return false;
+                }
+
+                if peer.is_offline() {
+                    connect_ineligable_count += 1;
+                    return false;
+                }
+
+                let is_excluded = excluded.contains(&peer.node_id);
+                if is_excluded {
+                    excluded_count += 1;
+                    return false;
+                }
+
+                true
+            })
+            .sort_by(PeerQuerySortBy::DistanceFrom(&node_id))
+            .limit(n);
+
+        let peers = peer_manager.perform_query(query).await?;
+        let total_excluded = banned_count + connect_ineligable_count + excluded_count + filtered_out_node_count;
+        if total_excluded > 0 {
+            debug!(
+                target: LOG_TARGET,
+                "\n====================================\n Closest Peer Selection\n\n {num_peers} peer(s) selected\n \
+                 {total} peer(s) were not selected \n\n {banned} banned\n {filtered_out} not communication node\n \
+                 {not_connectable} are not connectable\n {excluded} explicitly excluded \
+                 \n====================================\n",
+                num_peers = peers.len(),
+                total = total_excluded,
+                banned = banned_count,
+                filtered_out = filtered_out_node_count,
+                not_connectable = connect_ineligable_count,
+                excluded = excluded_count
+            );
+        }
+
+        Ok(peers.into_iter().map(|p| p.node_id).collect())
+    }
+
+    async fn fetch_random_peers(&self, n: usize, excluded: &[NodeId]) -> Result<Vec<NodeId>, DhtConnectivityError> {
+        let peers = self.peer_manager.random_peers(n, excluded).await?;
+        Ok(peers.into_iter().map(|p| p.node_id).collect())
+    }
+
+    fn can_send_join(&self) -> bool {
+        let cooldown = self.config.join_cooldown_interval;
+        self.stats
+            .join_last_sent_at()
+            .map(|at| at.elapsed() > cooldown)
+            .unwrap_or(true)
+    }
+}
+
+/// Basic connectivity stats. Right now, it is only used to track the last time a join message was sent to prevent the
+/// node spamming the network if local connectivity changes.
+#[derive(Debug, Default)]
+struct Stats {
+    join_last_sent_at: Option<Instant>,
+}
+
+impl Stats {
+    pub fn new() -> Self {
+        Default::default()
+    }
+
+    pub fn join_last_sent_at(&self) -> Option<Instant> {
+        self.join_last_sent_at
+    }
+
+    pub fn mark_join_sent(&mut self) {
+        self.join_last_sent_at = Some(Instant::now());
+    }
+}

--- a/comms/dht/src/connectivity/test.rs
+++ b/comms/dht/src/connectivity/test.rs
@@ -1,0 +1,212 @@
+//  Copyright 2020, The Tari Project
+//
+//  Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+//  following conditions are met:
+//
+//  1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+//  disclaimer.
+//
+//  2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+//  following disclaimer in the documentation and/or other materials provided with the distribution.
+//
+//  3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+//  products derived from this software without specific prior written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+//  INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+//  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+//  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+//  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+//  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+//  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+use crate::{
+    connectivity::DhtConnectivity,
+    test_utils::{create_dht_actor_mock, make_node_identity, make_peer_manager, DhtMockState},
+    DhtConfig,
+};
+use rand::{rngs::OsRng, seq::SliceRandom};
+use std::{iter::repeat_with, sync::Arc, time::Duration};
+use tari_comms::{
+    connectivity::ConnectivityEvent,
+    peer_manager::{Peer, PeerFeatures},
+    test_utils::{
+        count_string_occurrences,
+        mocks::{create_connectivity_mock, create_dummy_peer_connection, ConnectivityManagerMockState},
+        node_identity::ordered_node_identities_by_distance,
+    },
+    NodeIdentity,
+    PeerManager,
+};
+use tari_shutdown::Shutdown;
+use tari_test_utils::async_assert;
+
+async fn setup(
+    config: DhtConfig,
+    node_identity: Arc<NodeIdentity>,
+    initial_peers: Vec<Peer>,
+) -> (
+    DhtConnectivity,
+    DhtMockState,
+    ConnectivityManagerMockState,
+    Arc<PeerManager>,
+    Arc<NodeIdentity>,
+    Shutdown,
+)
+{
+    let peer_manager = make_peer_manager();
+    for peer in initial_peers {
+        peer_manager.add_peer(peer).await.unwrap();
+    }
+
+    let shutdown = Shutdown::new();
+    let (connectivity, mock) = create_connectivity_mock();
+    let connectivity_state = mock.get_shared_state();
+    mock.spawn();
+    let (dht_requester, mock) = create_dht_actor_mock(1);
+    let dht_state = mock.get_shared_state();
+    mock.spawn();
+
+    let dht_connectivity = DhtConnectivity::new(
+        config,
+        peer_manager.clone(),
+        node_identity.clone(),
+        connectivity,
+        dht_requester,
+        shutdown.to_signal(),
+    );
+
+    (
+        dht_connectivity,
+        dht_state,
+        connectivity_state,
+        peer_manager,
+        node_identity,
+        shutdown,
+    )
+}
+
+#[tokio_macros::test_basic]
+async fn initialize() {
+    let config = DhtConfig {
+        num_neighbouring_nodes: 4,
+        num_random_nodes: 2,
+        ..Default::default()
+    };
+    let peers = repeat_with(|| make_node_identity().to_peer()).take(10).collect();
+    let (dht_connectivity, _, connectivity, peer_manager, node_identity, _shutdown) =
+        setup(config, make_node_identity(), peers).await;
+    dht_connectivity.spawn();
+    let neighbours = peer_manager
+        .closest_peers(node_identity.node_id(), 4, &[], Some(PeerFeatures::COMMUNICATION_NODE))
+        .await
+        .unwrap()
+        .into_iter()
+        .map(|p| p.node_id)
+        .collect::<Vec<_>>();
+
+    // Wait for calls to add peers
+    async_assert!(
+        connectivity.call_count() >= 2,
+        max_attempts = 20,
+        interval = Duration::from_millis(10),
+    );
+
+    let calls = connectivity.take_calls().await;
+    assert_eq!(count_string_occurrences(&calls, &["AddManagedPeers"]), 2);
+
+    // Check that neighbours are added
+    let mut managed = connectivity.get_managed_peers().await;
+    for neighbour in &neighbours {
+        let pos = managed.iter().position(|n| n == neighbour).unwrap();
+        managed.remove(pos);
+    }
+
+    // Check that random peers (excl neighbours) are added
+    assert_eq!(managed.len(), 2);
+    assert!(managed.iter().all(|n| !neighbours.contains(n)));
+}
+
+#[tokio_macros::test_basic]
+async fn added_neighbours() {
+    let node_identity = make_node_identity();
+    let mut node_identities =
+        ordered_node_identities_by_distance(node_identity.node_id(), 6, PeerFeatures::COMMUNICATION_NODE);
+    // Closest to this node
+    let closer_peer = node_identities.remove(0);
+    let peers = node_identities.iter().map(|ni| ni.to_peer()).collect::<Vec<_>>();
+
+    let config = DhtConfig {
+        num_neighbouring_nodes: 5,
+        num_random_nodes: 0,
+        ..Default::default()
+    };
+    let (dht_connectivity, _, connectivity, _, _, _shutdown) = setup(config, node_identity, peers).await;
+    dht_connectivity.spawn();
+
+    // Wait for calls to add peers
+    async_assert!(
+        connectivity.call_count() >= 1,
+        max_attempts = 20,
+        interval = Duration::from_millis(10),
+    );
+
+    let calls = connectivity.take_calls().await;
+    assert_eq!(count_string_occurrences(&calls, &["AddManagedPeers"]), 1);
+
+    let (conn, _) = create_dummy_peer_connection(closer_peer.node_id().clone());
+    connectivity.publish_event(ConnectivityEvent::PeerConnected(conn));
+
+    async_assert!(
+        connectivity.call_count() >= 2,
+        max_attempts = 20,
+        interval = Duration::from_millis(10),
+    );
+
+    let calls = connectivity.take_calls().await;
+    assert_eq!(count_string_occurrences(&calls, &["AddManagedPeers"]), 1);
+    assert_eq!(count_string_occurrences(&calls, &["RemovePeer"]), 1);
+
+    // Check that the closer neighbour was added to managed peers
+    let managed = connectivity.get_managed_peers().await;
+    assert_eq!(managed.len(), 5);
+    assert!(managed.contains(closer_peer.node_id()));
+}
+
+#[tokio_macros::test_basic]
+async fn insert_neighbour() {
+    let node_identity = make_node_identity();
+    let node_identities =
+        ordered_node_identities_by_distance(node_identity.node_id(), 10, PeerFeatures::COMMUNICATION_NODE);
+
+    let (mut dht_connectivity, _, _, _, _, _) = setup(Default::default(), node_identity.clone(), vec![]).await;
+    dht_connectivity.config.num_neighbouring_nodes = 8;
+
+    let shuffled = {
+        let mut v = node_identities.clone();
+        v.shuffle(&mut OsRng);
+        v
+    };
+
+    // First 8 inserts should not remove a peer (because num_neighbouring_nodes == 8)
+    for ni in shuffled.iter().take(8) {
+        assert!(dht_connectivity.insert_neighbour(ni.node_id().clone()).is_none());
+    }
+
+    // Next 2 inserts will always remove a node id
+    for ni in shuffled.iter().skip(8) {
+        assert!(dht_connectivity.insert_neighbour(ni.node_id().clone()).is_some())
+    }
+
+    // Check the first 7 node ids match our neighbours, the last element depends on distance and ordering of inserts
+    // (these are random). insert_neighbour only cares about inserting the element in the right order and preserving the
+    // length of the neighbour list. It doesnt care if it kicks out a closer peer (that is left for the calling
+    // code).
+    let ordered_node_ids = node_identities
+        .iter()
+        .take(7)
+        .map(|ni| ni.node_id())
+        .cloned()
+        .collect::<Vec<_>>();
+    assert_eq!(&dht_connectivity.neighbours[..7], ordered_node_ids.as_slice());
+}

--- a/comms/dht/src/dedup.rs
+++ b/comms/dht/src/dedup.rs
@@ -120,7 +120,7 @@ mod test {
     use super::*;
     use crate::{
         envelope::DhtMessageFlags,
-        test_utils::{create_dht_actor_mock, make_dht_inbound_message, make_node_identity, service_spy, DhtMockState},
+        test_utils::{create_dht_actor_mock, make_dht_inbound_message, make_node_identity, service_spy},
     };
     use tari_test_utils::panic_context;
     use tokio::runtime::Runtime;
@@ -130,10 +130,9 @@ mod test {
         let mut rt = Runtime::new().unwrap();
         let spy = service_spy();
 
-        let (dht_requester, mut mock) = create_dht_actor_mock(1);
-        let mock_state = DhtMockState::new();
+        let (dht_requester, mock) = create_dht_actor_mock(1);
+        let mock_state = mock.get_shared_state();
         mock_state.set_signature_cache_insert(false);
-        mock.set_shared_state(mock_state.clone());
         rt.spawn(mock.run());
 
         let mut dedup = DedupLayer::new(dht_requester).layer(spy.to_service::<PipelineError>());

--- a/comms/dht/src/discovery/service.rs
+++ b/comms/dht/src/discovery/service.rs
@@ -30,7 +30,6 @@ use crate::{
 use futures::{
     channel::{mpsc, oneshot},
     future::FutureExt,
-    stream::Fuse,
     StreamExt,
 };
 use log::*;
@@ -41,22 +40,16 @@ use std::{
     time::{Duration, Instant},
 };
 use tari_comms::{
-    connection_manager::{ConnectionManagerError, ConnectionManagerRequester},
     log_if_error,
     peer_manager::{NodeId, NodeIdentity, Peer, PeerFeatures, PeerManager},
     types::CommsPublicKey,
     validate_peer_addresses,
-    ConnectionManagerEvent,
 };
 use tari_shutdown::ShutdownSignal;
 use tari_utilities::{hex::Hex, ByteArray};
-use tokio::{sync::broadcast, task, time};
+use tokio::{task, time};
 
 const LOG_TARGET: &str = "comms::dht::discovery_service";
-
-/// The number of consecutive times that attempts to connect should
-/// fail before marking the peer as offline
-const MAX_FAILED_ATTEMPTS_MARK_PEER_OFFLINE: usize = 10;
 
 struct DiscoveryRequestState {
     reply_tx: oneshot::Sender<Result<Peer, DhtDiscoveryError>>,
@@ -78,7 +71,6 @@ pub struct DhtDiscoveryService {
     config: DhtConfig,
     node_identity: Arc<NodeIdentity>,
     outbound_requester: OutboundMessageRequester,
-    connection_manager: ConnectionManagerRequester,
     peer_manager: Arc<PeerManager>,
     request_rx: Option<mpsc::Receiver<DhtDiscoveryRequest>>,
     shutdown_signal: Option<ShutdownSignal>,
@@ -91,7 +83,6 @@ impl DhtDiscoveryService {
         node_identity: Arc<NodeIdentity>,
         peer_manager: Arc<PeerManager>,
         outbound_requester: OutboundMessageRequester,
-        connection_manager: ConnectionManagerRequester,
         request_rx: mpsc::Receiver<DhtDiscoveryRequest>,
         shutdown_signal: ShutdownSignal,
     ) -> Self
@@ -99,7 +90,6 @@ impl DhtDiscoveryService {
         Self {
             config,
             outbound_requester,
-            connection_manager,
             node_identity,
             peer_manager,
             shutdown_signal: Some(shutdown_signal),
@@ -109,12 +99,13 @@ impl DhtDiscoveryService {
     }
 
     pub fn spawn(self) {
-        let connection_events = self.connection_manager.get_event_subscription().fuse();
-        info!(target: LOG_TARGET, "Discovery service started");
-        task::spawn(async move { self.run(connection_events).await });
+        task::spawn(async move {
+            info!(target: LOG_TARGET, "Discovery service started");
+            self.run().await
+        });
     }
 
-    pub async fn run(mut self, mut connection_events: Fuse<broadcast::Receiver<Arc<ConnectionManagerEvent>>>) {
+    pub async fn run(mut self) {
         info!(target: LOG_TARGET, "Dht discovery service started");
         let mut shutdown_signal = self
             .shutdown_signal
@@ -133,15 +124,6 @@ impl DhtDiscoveryService {
                 request = request_rx.select_next_some() => {
                     trace!(target: LOG_TARGET, "Received request '{}'", request);
                     self.handle_request(request).await;
-                },
-
-                event = connection_events.select_next_some() => {
-                    if let Ok(event) = event {
-                        trace!(target: LOG_TARGET, "Received connection manager event '{}'", event);
-                        if let Err(err) = self.handle_connection_manager_event(&event).await {
-                            error!(target: LOG_TARGET, "Error handling connection manager event: {:?}", err);
-                        }
-                    }
                 },
 
                 _ = shutdown_signal => {
@@ -166,84 +148,6 @@ impl DhtDiscoveryService {
             NotifyDiscoveryResponseReceived(discovery_msg) => self.handle_discovery_response(discovery_msg).await,
         }
     }
-
-    async fn handle_connection_manager_event(
-        &mut self,
-        event: &ConnectionManagerEvent,
-    ) -> Result<(), DhtDiscoveryError>
-    {
-        use ConnectionManagerEvent::*;
-        // The connection manager could not dial the peer on any address
-        match event {
-            PeerConnectFailed(node_id, ConnectionManagerError::ConnectFailedMaximumAttemptsReached) => {
-                if self.connection_manager.get_num_active_connections().await? == 0 {
-                    info!(
-                        target: LOG_TARGET,
-                        "Unsure if we're online because we have no connections. Ignoring connection failed event for \
-                         peer '{}'.",
-                        node_id
-                    );
-                    return Ok(());
-                }
-                let peer = self.peer_manager.find_by_node_id(node_id).await?;
-                if peer.connection_stats.failed_attempts() > MAX_FAILED_ATTEMPTS_MARK_PEER_OFFLINE {
-                    debug!(
-                        target: LOG_TARGET,
-                        "Marking peer '{}' as offline because this node failed to connect to them {} times",
-                        peer.node_id.short_str(),
-                        MAX_FAILED_ATTEMPTS_MARK_PEER_OFFLINE
-                    );
-                    let neighbourhood_stats = self
-                        .peer_manager
-                        .get_region_stats(
-                            self.node_identity.node_id(),
-                            self.config.num_neighbouring_nodes,
-                            PeerFeatures::COMMUNICATION_NODE,
-                        )
-                        .await?;
-                    // If the node_id is not neighbouring or else if it is, the ratio of offline neighbouring peers
-                    // is below 30%, mark the peer as offline
-                    if !neighbourhood_stats.in_region(node_id) || neighbourhood_stats.offline_ratio() <= 0.3 {
-                        self.peer_manager.set_offline(&peer.public_key, true).await?;
-                    } else {
-                        debug!(
-                            target: LOG_TARGET,
-                            "Not marking neighbouring peer '{}' as offline ({})", node_id, neighbourhood_stats
-                        );
-                    }
-                } else {
-                    // if !self.has_inflight_discovery(&peer.public_key) {
-                    //     debug!(
-                    //         target: LOG_TARGET,
-                    //         "Attempting to discover peer '{}' because we failed to connect on all addresses for the
-                    // peer",
-                    //         peer.node_id.short_str()
-                    //     );
-                    //
-                    //     // Don't need to be notified for this discovery
-                    //     let (reply_tx, _) = oneshot::channel();
-                    //     // Send out a discovery for that peer without keeping track of it as an inflight discovery
-                    //     let dest_pubkey = Box::new(peer.public_key);
-                    //     self.initiate_peer_discovery(
-                    //         dest_pubkey.clone(),
-                    //         NodeDestination::PublicKey(dest_pubkey),
-                    //         reply_tx,
-                    //     )
-                    //     .await?;
-                    // }
-                }
-            },
-            _ => {},
-        }
-
-        Ok(())
-    }
-
-    // fn has_inflight_discovery(&self, public_key: &CommsPublicKey) -> bool {
-    //     self.inflight_discoveries
-    //         .values()
-    //         .all(|state| &*state.public_key != public_key)
-    // }
 
     fn collect_all_discovery_requests(&mut self, public_key: &CommsPublicKey) -> Vec<DiscoveryRequestState> {
         let mut requests = Vec::new();
@@ -491,7 +395,6 @@ mod test {
         test_utils::{make_node_identity, make_peer_manager},
     };
     use std::time::Duration;
-    use tari_comms::test_utils::mocks::create_connection_manager_mock;
     use tari_shutdown::Shutdown;
 
     #[tokio_macros::test_basic]
@@ -502,7 +405,6 @@ mod test {
         let oms_mock_state = outbound_mock.get_state();
         task::spawn(outbound_mock.run());
 
-        let (connection_manager, _) = create_connection_manager_mock();
         let (sender, receiver) = mpsc::channel(10);
         // Requester which timeout instantly
         let mut requester = DhtDiscoveryRequester::new(sender, Duration::from_millis(1));
@@ -513,7 +415,6 @@ mod test {
             node_identity,
             peer_manager,
             outbound_requester,
-            connection_manager,
             receiver,
             shutdown.to_signal(),
         )

--- a/comms/dht/src/inbound/dht_handler/task.rs
+++ b/comms/dht/src/inbound/dht_handler/task.rs
@@ -222,17 +222,17 @@ where S: Service<DecryptedDhtMessage, Response = (), Error = PipelineError>
             return Ok(());
         }
 
-        debug!(
-            target: LOG_TARGET,
-            "Propagating join message to at most {} peer(s)", self.config.num_neighbouring_nodes
-        );
-
         // Only propagate a join that was not directly sent to this node (presumably in response to a join this node
         // sent)
         // TODO: Join should have a response message type
         if dht_header.destination != self.node_identity.public_key() &&
             dht_header.destination != self.node_identity.node_id()
         {
+            info!(
+                target: LOG_TARGET,
+                "Propagating Join message from peer '{}'",
+                origin_node_id.short_str()
+            );
             // Propagate message to closer peers
             self.outbound_service
                 .send_raw(

--- a/comms/dht/src/lib.rs
+++ b/comms/dht/src/lib.rs
@@ -125,6 +125,8 @@ pub use actor::{DhtActorError, DhtRequest, DhtRequester};
 mod builder;
 pub use builder::DhtBuilder;
 
+mod connectivity;
+
 mod config;
 pub use config::DhtConfig;
 

--- a/comms/dht/src/outbound/broadcast.rs
+++ b/comms/dht/src/outbound/broadcast.rs
@@ -49,7 +49,7 @@ use rand::rngs::OsRng;
 use std::{sync::Arc, task::Poll};
 use tari_comms::{
     message::{MessageExt, MessageTag},
-    peer_manager::{NodeIdentity, Peer},
+    peer_manager::{NodeId, NodeIdentity, Peer},
     pipeline::PipelineError,
     types::{Challenge, CommsPublicKey},
     utils::signature,
@@ -289,7 +289,7 @@ where S: Service<DhtOutboundMessage, Response = (), Error = PipelineError>
                         Ok(Some(peer)) => {
                             // Set the reply_tx so that it can be used later
                             reply_tx = Some(discovery_reply_tx);
-                            peers = vec![Arc::new(peer)];
+                            peers = vec![peer.node_id];
                         },
                         Ok(None) => {
                             // Message sent to 0 peers
@@ -339,11 +339,7 @@ where S: Service<DhtOutboundMessage, Response = (), Error = PipelineError>
         }
     }
 
-    async fn select_peers(
-        &mut self,
-        broadcast_strategy: BroadcastStrategy,
-    ) -> Result<Vec<Arc<Peer>>, DhtOutboundError>
-    {
+    async fn select_peers(&mut self, broadcast_strategy: BroadcastStrategy) -> Result<Vec<NodeId>, DhtOutboundError> {
         self.dht_requester
             .select_peers(broadcast_strategy)
             .await
@@ -398,7 +394,7 @@ where S: Service<DhtOutboundMessage, Response = (), Error = PipelineError>
     #[allow(clippy::too_many_arguments)]
     async fn generate_send_messages(
         &mut self,
-        selected_peers: Vec<Arc<Peer>>,
+        selected_peers: Vec<NodeId>,
         destination: NodeDestination,
         dht_message_type: DhtMessageType,
         encryption: OutboundEncryption,
@@ -420,14 +416,14 @@ where S: Service<DhtOutboundMessage, Response = (), Error = PipelineError>
         // Construct a DhtOutboundMessage for each recipient
         let messages = selected_peers
             .into_iter()
-            .map(|peer| {
+            .map(|node_id| {
                 let (reply_tx, reply_rx) = oneshot::channel();
                 let tag = MessageTag::new();
                 let send_state = MessageSendState::new(tag, reply_rx);
                 (
                     DhtOutboundMessage {
                         tag,
-                        destination_peer: peer,
+                        destination_node_id: node_id,
                         destination: destination.clone(),
                         dht_message_type,
                         network: self.target_network,
@@ -516,14 +512,7 @@ mod test {
     use super::*;
     use crate::{
         outbound::SendMessageParams,
-        test_utils::{
-            create_dht_actor_mock,
-            create_dht_discovery_mock,
-            make_peer,
-            service_spy,
-            DhtDiscoveryMockState,
-            DhtMockState,
-        },
+        test_utils::{create_dht_actor_mock, create_dht_discovery_mock, make_peer, service_spy, DhtDiscoveryMockState},
     };
     use futures::channel::oneshot;
     use rand::rngs::OsRng;
@@ -568,12 +557,11 @@ mod test {
             .unwrap(),
         );
 
-        let (dht_requester, mut dht_mock) = create_dht_actor_mock(10);
+        let (dht_requester, dht_mock) = create_dht_actor_mock(10);
         let (dht_discover_requester, _) = create_dht_discovery_mock(10, Duration::from_secs(10));
 
-        let mock_state = DhtMockState::new();
+        let mock_state = dht_mock.get_shared_state();
         mock_state.set_select_peers_response(vec![example_peer.clone(), other_peer.clone()]);
-        dht_mock.set_shared_state(mock_state);
 
         rt.spawn(dht_mock.run());
 
@@ -599,10 +587,8 @@ mod test {
         let requests = spy.take_requests();
         assert!(requests
             .iter()
-            .any(|msg| msg.destination_peer.node_id == example_peer.node_id));
-        assert!(requests
-            .iter()
-            .any(|msg| msg.destination_peer.node_id == other_peer.node_id));
+            .any(|msg| msg.destination_node_id == example_peer.node_id));
+        assert!(requests.iter().any(|msg| msg.destination_node_id == other_peer.node_id));
     }
 
     #[test]

--- a/comms/dht/src/outbound/message.rs
+++ b/comms/dht/src/outbound/message.rs
@@ -29,7 +29,7 @@ use futures::channel::oneshot;
 use std::{fmt, fmt::Display, sync::Arc};
 use tari_comms::{
     message::{MessageTag, MessagingReplyTx},
-    peer_manager::Peer,
+    peer_manager::NodeId,
     types::CommsPublicKey,
 };
 use tari_utilities::hex::Hex;
@@ -168,7 +168,7 @@ impl Drop for WrappedReplyTx {
 #[derive(Debug)]
 pub struct DhtOutboundMessage {
     pub tag: MessageTag,
-    pub destination_peer: Arc<Peer>,
+    pub destination_node_id: NodeId,
     pub custom_header: Option<DhtMessageHeader>,
     pub body: Bytes,
     pub ephemeral_public_key: Option<Arc<CommsPublicKey>>,
@@ -198,7 +198,7 @@ impl fmt::Display for DhtOutboundMessage {
             "\n---- Outgoing message ---- \nSize: {} byte(s)\nType: {}\nPeer: {}\nHeader: {}\n{}\n----",
             self.body.len(),
             self.dht_message_type,
-            self.destination_peer,
+            self.destination_node_id,
             header_str,
             self.tag,
         )

--- a/comms/dht/src/outbound/message_params.rs
+++ b/comms/dht/src/outbound/message_params.rs
@@ -135,7 +135,7 @@ impl SendMessageParams {
     /// Set broadcast_strategy to Neighbours. `excluded_peers` are excluded. Only Peers that have
     /// `PeerFeatures::MESSAGE_PROPAGATION` are included.
     pub fn broadcast(&mut self, excluded_peers: Vec<NodeId>) -> &mut Self {
-        self.params_mut().broadcast_strategy = BroadcastStrategy::Neighbours(excluded_peers);
+        self.params_mut().broadcast_strategy = BroadcastStrategy::Broadcast(excluded_peers);
         self
     }
 

--- a/comms/dht/src/outbound/mock.rs
+++ b/comms/dht/src/outbound/mock.rs
@@ -168,7 +168,7 @@ impl OutboundServiceMock {
                         BroadcastStrategy::DirectPublicKey(_) => {
                             queued = behaviour.direct == ResponseType::Queued;
                         },
-                        BroadcastStrategy::Neighbours(_) => {
+                        BroadcastStrategy::Broadcast(_) => {
                             queued = behaviour.broadcast == ResponseType::Queued;
                         },
                         _ => (),

--- a/comms/dht/src/outbound/serialize.rs
+++ b/comms/dht/src/outbound/serialize.rs
@@ -68,7 +68,7 @@ where S: Service<OutboundMessage, Response = (), Error = PipelineError> + Clone 
 
             let DhtOutboundMessage {
                 tag,
-                destination_peer,
+                destination_node_id,
                 custom_header,
                 body,
                 ephemeral_public_key,
@@ -98,7 +98,7 @@ where S: Service<OutboundMessage, Response = (), Error = PipelineError> + Clone 
             next_service
                 .oneshot(OutboundMessage {
                     tag,
-                    peer_node_id: destination_peer.node_id.clone(),
+                    peer_node_id: destination_node_id,
                     reply_tx: reply_tx.into_inner(),
                     body,
                 })

--- a/comms/dht/src/store_forward/saf_handler/task.rs
+++ b/comms/dht/src/store_forward/saf_handler/task.rs
@@ -533,7 +533,6 @@ mod test {
             make_node_identity,
             make_peer_manager,
             service_spy,
-            DhtMockState,
         },
     };
     use chrono::Utc;
@@ -685,9 +684,7 @@ mod test {
         );
         message.dht_header.message_type = DhtMessageType::SafStoredMessages;
 
-        let (dht_requester, mut mock) = create_dht_actor_mock(1);
-        let mock_state = DhtMockState::new();
-        mock.set_shared_state(mock_state.clone());
+        let (dht_requester, mock) = create_dht_actor_mock(1);
         rt_handle.spawn(mock.run());
 
         let task = MessageHandlerTask::new(

--- a/comms/dht/src/store_forward/service.rs
+++ b/comms/dht/src/store_forward/service.rs
@@ -44,16 +44,15 @@ use futures::{
 use log::*;
 use std::{convert::TryFrom, sync::Arc, time::Duration};
 use tari_comms::{
-    connection_manager::ConnectionManagerRequester,
+    connectivity::{ConnectivityEvent, ConnectivityEventRx, ConnectivityRequester},
     peer_manager::{node_id::NodeDistance, NodeId, PeerFeatures},
     types::CommsPublicKey,
-    ConnectionManagerEvent,
     NodeIdentity,
     PeerManager,
 };
 use tari_shutdown::ShutdownSignal;
 use tari_utilities::ByteArray;
-use tokio::{sync::broadcast, task, time};
+use tokio::{task, time};
 
 const LOG_TARGET: &str = "comms::dht::storeforward::actor";
 /// The interval to initiate a database cleanup.
@@ -163,7 +162,7 @@ pub struct StoreAndForwardService {
     dht_requester: DhtRequester,
     database: StoreAndForwardDatabase,
     peer_manager: Arc<PeerManager>,
-    connection_events: Fuse<broadcast::Receiver<Arc<ConnectionManagerEvent>>>,
+    connection_events: Fuse<ConnectivityEventRx>,
     outbound_requester: OutboundMessageRequester,
     request_rx: Fuse<mpsc::Receiver<StoreAndForwardRequest>>,
     shutdown_signal: Option<ShutdownSignal>,
@@ -176,7 +175,7 @@ impl StoreAndForwardService {
         node_identity: Arc<NodeIdentity>,
         peer_manager: Arc<PeerManager>,
         dht_requester: DhtRequester,
-        connection_manager: ConnectionManagerRequester,
+        connectivity: ConnectivityRequester,
         outbound_requester: OutboundMessageRequester,
         request_rx: mpsc::Receiver<StoreAndForwardRequest>,
         shutdown_signal: ShutdownSignal,
@@ -189,16 +188,15 @@ impl StoreAndForwardService {
             peer_manager,
             dht_requester,
             request_rx: request_rx.fuse(),
-            connection_events: connection_manager.get_event_subscription().fuse(),
+            connection_events: connectivity.subscribe_event_stream().fuse(),
             outbound_requester,
             shutdown_signal: Some(shutdown_signal),
         }
     }
 
-    pub async fn spawn(self) -> SafResult<()> {
+    pub fn spawn(self) {
         info!(target: LOG_TARGET, "Store and forward service started");
         task::spawn(Self::run(self));
-        Ok(())
     }
 
     async fn run(mut self) {
@@ -217,7 +215,7 @@ impl StoreAndForwardService {
 
                event = self.connection_events.select_next_some() => {
                     if let Ok(event) = event {
-                         if let Err(err) = self.handle_connection_manager_event(&event).await {
+                         if let Err(err) = self.handle_connectivity_event(&event).await {
                             error!(target: LOG_TARGET, "Error handling connection manager event: {:?}", err);
                         }
                     }
@@ -290,8 +288,8 @@ impl StoreAndForwardService {
         }
     }
 
-    async fn handle_connection_manager_event(&mut self, event: &ConnectionManagerEvent) -> SafResult<()> {
-        use ConnectionManagerEvent::*;
+    async fn handle_connectivity_event(&mut self, event: &ConnectivityEvent) -> SafResult<()> {
+        use ConnectivityEvent::*;
         if !self.config.saf_auto_request {
             debug!(
                 target: LOG_TARGET,

--- a/comms/dht/src/test_utils/makers.rs
+++ b/comms/dht/src/test_utils/makers.rs
@@ -31,7 +31,6 @@ use std::{convert::TryInto, sync::Arc};
 use tari_comms::{
     message::{InboundMessage, MessageExt, MessageTag},
     multiaddr::Multiaddr,
-    net_address::MultiaddressesWithStats,
     peer_manager::{NodeId, NodeIdentity, Peer, PeerFeatures, PeerFlags, PeerManager},
     transports::MemoryTransport,
     types::{CommsDatabase, CommsPublicKey, CommsSecretKey},
@@ -194,14 +193,7 @@ pub fn create_outbound_message(body: &[u8]) -> DhtOutboundMessage {
     let msg_tag = MessageTag::new();
     DhtOutboundMessage {
         tag: msg_tag,
-        destination_peer: Arc::new(Peer::new(
-            CommsPublicKey::default(),
-            NodeId::default(),
-            MultiaddressesWithStats::new(vec![]),
-            PeerFlags::empty(),
-            PeerFeatures::COMMUNICATION_NODE,
-            &[],
-        )),
+        destination_node_id: NodeId::default(),
         destination: Default::default(),
         dht_message_type: Default::default(),
         network: Network::LocalTest,

--- a/comms/src/builder/consts.rs
+++ b/comms/src/builder/consts.rs
@@ -23,6 +23,10 @@
 /// Buffer size for inbound messages from _all_ peers. This should be large enough to buffer quite a few incoming
 /// messages before creating backpressure on peers speaking the messaging protocol.
 pub const INBOUND_MESSAGE_BUFFER_SIZE: usize = 100;
+/// Buffer size for actor requests to connectivity manager.
+pub const CONNECTIVITY_MANAGER_REQUEST_BUFFER_SIZE: usize = 10;
+/// Buffer size for connectivity events
+pub const CONNECTIVITY_MANAGER_EVENTS_BUFFER_SIZE: usize = 50;
 /// Buffer size for actor requests to connection manager. A lower value is ok because the connection manager shouldn't
 /// need to handle a ton of requests concurrently.
 pub const CONNECTION_MANAGER_REQUEST_BUFFER_SIZE: usize = 10;

--- a/comms/src/builder/tests.rs
+++ b/comms/src/builder/tests.rs
@@ -181,11 +181,11 @@ async fn peer_to_peer_custom_protocols() {
 async fn peer_to_peer_messaging() {
     const NUM_MSGS: usize = 100;
 
-    let (comms_node1, inbound_rx1, mut outbound_tx1) = spawn_node(Protocols::new()).await;
-    let (comms_node2, inbound_rx2, mut outbound_tx2) = spawn_node(Protocols::new()).await;
+    let (comms_node1, mut inbound_rx1, mut outbound_tx1) = spawn_node(Protocols::new()).await;
+    let (comms_node2, mut inbound_rx2, mut outbound_tx2) = spawn_node(Protocols::new()).await;
 
-    let messaging_events1 = comms_node1.subscribe_messaging_events();
-    let messaging_events2 = comms_node2.subscribe_messaging_events();
+    let mut messaging_events1 = comms_node1.subscribe_messaging_events();
+    let mut messaging_events2 = comms_node2.subscribe_messaging_events();
 
     let node_identity1 = comms_node1.node_identity();
     let node_identity2 = comms_node2.node_identity();
@@ -254,8 +254,8 @@ async fn peer_to_peer_messaging() {
 async fn peer_to_peer_messaging_simultaneous() {
     const NUM_MSGS: usize = 10;
 
-    let (comms_node1, inbound_rx1, mut outbound_tx1) = spawn_node(Protocols::new()).await;
-    let (comms_node2, inbound_rx2, mut outbound_tx2) = spawn_node(Protocols::new()).await;
+    let (comms_node1, mut inbound_rx1, mut outbound_tx1) = spawn_node(Protocols::new()).await;
+    let (comms_node2, mut inbound_rx2, mut outbound_tx2) = spawn_node(Protocols::new()).await;
 
     let o1 = outbound_tx1.clone();
     let o2 = outbound_tx2.clone();

--- a/comms/src/connection_manager/dialer.rs
+++ b/comms/src/connection_manager/dialer.rs
@@ -33,7 +33,7 @@ use crate::{
     multiaddr::Multiaddr,
     multiplexing::Yamux,
     noise::{NoiseConfig, NoiseSocket},
-    peer_manager::{NodeId, NodeIdentity, Peer, PeerManager},
+    peer_manager::{NodeId, NodeIdentity, Peer, PeerFeatures, PeerManager},
     protocol::ProtocolId,
     transports::Transport,
     types::CommsPublicKey,
@@ -217,12 +217,7 @@ where
             self.reply_to_pending_requests(&node_id, dial_result.clone());
         }
 
-        log_if_error_fmt!(
-            target: LOG_TARGET,
-            reply_tx.send(dial_result),
-            "Failed to send dial result reply for peer '{}'",
-            peer_id_short_str
-        );
+        let _ = reply_tx.send(dial_result);
     }
 
     pub async fn notify_connection_manager(&mut self, event: ConnectionManagerEvent) {
@@ -309,13 +304,17 @@ where
                         supported_protocols,
                         allow_test_addresses,
                     );
+
                     futures::pin_mut!(upgrade_fut);
                     let either = future::select(upgrade_fut, cancel_signal).await;
 
                     match either {
                         Either::Left((result, _)) => (dial_state, result),
-                        // Dial cancel was triggered
-                        Either::Right(_) => (dial_state, Err(ConnectionManagerError::DialCancelled)),
+                        //     Dial cancel was triggered
+                        Either::Right(_) => {
+                            info!(target: LOG_TARGET, "Dial was cancelled");
+                            (dial_state, Err(ConnectionManagerError::DialCancelled))
+                        },
                     }
                 },
                 Err(err) => (dial_state, Err(err)),
@@ -373,17 +372,19 @@ where
         )
         .await?;
 
+        let features = PeerFeatures::from_bits_truncate(peer_identity.features);
         debug!(
             target: LOG_TARGET,
-            "Peer identity exchange succeeded on Outbound connection for peer '{}'",
-            peer_identity.node_id.to_hex()
+            "Peer identity exchange succeeded on Outbound connection for peer '{}' (Features = {:?})",
+            peer_identity.node_id.to_hex(),
+            features
         );
         trace!(target: LOG_TARGET, "{:?}", peer_identity);
 
         // Check if we know the peer and if it is banned
         let known_peer = common::find_unbanned_peer(&peer_manager, &authenticated_public_key).await?;
 
-        let peer = common::validate_and_add_peer_from_peer_identity(
+        let peer_node_id = common::validate_and_add_peer_from_peer_identity(
             &peer_manager,
             known_peer,
             authenticated_public_key,
@@ -396,13 +397,14 @@ where
             target: LOG_TARGET,
             "[ThisNode={}] Peer '{}' added to peer list.",
             node_identity.node_id().short_str(),
-            peer.node_id.short_str()
+            peer_node_id.short_str()
         );
 
         peer_connection::create(
             muxer,
             dialed_addr,
-            peer,
+            peer_node_id,
+            features,
             CONNECTION_DIRECTION,
             conn_man_notifier,
             our_supported_protocols,

--- a/comms/src/connection_manager/manager.rs
+++ b/comms/src/connection_manager/manager.rs
@@ -319,12 +319,7 @@ where
             DialPeer(node_id, reply_tx) => match self.get_active_connection(&node_id) {
                 Some(conn) => {
                     debug!(target: LOG_TARGET, "[{}] Found existing active connection", conn);
-                    log_if_error_fmt!(
-                        target: LOG_TARGET,
-                        reply_tx.send(Ok(conn.clone())),
-                        "Failed to send reply for dial request for peer '{}'",
-                        node_id.short_str()
-                    );
+                    let _ = reply_tx.send(Ok(conn.clone()));
                 },
                 None => {
                     debug!(
@@ -336,6 +331,14 @@ where
                     );
                     self.dial_peer(node_id, reply_tx).await
                 },
+            },
+            CancelDial(node_id) => {
+                if let Err(err) = self.dialer_tx.send(DialerRequest::CancelPendingDial(node_id)).await {
+                    error!(
+                        target: LOG_TARGET,
+                        "Failed to send cancel dial request to dialer: {}", err
+                    );
+                }
             },
             NotifyListening(reply_tx) => match self.listener_address.as_ref() {
                 Some(addr) => {
@@ -365,13 +368,17 @@ where
                         .count(),
                 );
             },
-            DisconnectPeer(node_id, reply_tx) => match self.active_connections.remove(&node_id) {
-                Some(mut conn) => {
-                    let _ = reply_tx.send(conn.disconnect().await.map_err(Into::into));
-                },
-                None => {
-                    let _ = reply_tx.send(Ok(()));
-                },
+            DisconnectPeer(node_id) => {
+                if let Some(mut conn) = self.active_connections.remove(&node_id) {
+                    if let Err(err) = conn.disconnect().await {
+                        warn!(
+                            target: LOG_TARGET,
+                            "Error when disconnecting peer {}: {:?}",
+                            conn.peer_node_id(),
+                            err
+                        );
+                    }
+                }
             },
         }
     }
@@ -415,17 +422,6 @@ where
             },
             PeerConnected(new_conn) => {
                 let node_id = new_conn.peer_node_id().clone();
-
-                if let Err(err) = self.peer_manager.set_last_connect_success(&node_id).await {
-                    error!(
-                        target: LOG_TARGET,
-                        "set_last_connect_success failed because '{:?}'", err
-                    );
-                }
-
-                // If we're dialing this node, let's cancel it
-                self.send_dialer_request(DialerRequest::CancelPendingDial(node_id.clone()))
-                    .await;
 
                 match self.active_connections.get(&node_id) {
                     Some(existing_conn) => {
@@ -488,9 +484,6 @@ where
                 }
             },
             PeerConnectFailed(node_id, err) => {
-                if let Err(err) = self.peer_manager.set_last_connect_failed(&node_id).await {
-                    error!(target: LOG_TARGET, "set_peer_connect_failed failed because '{:?}'", err);
-                }
                 self.publish_event(PeerConnectFailed(node_id, err));
             },
             event => {
@@ -509,7 +502,7 @@ where
     #[inline]
     async fn send_dialer_request(&mut self, req: DialerRequest) {
         if let Err(err) = self.dialer_tx.send(req).await {
-            error!(target: LOG_TARGET, "Unable to send DialerRequest because '{}'", err);
+            error!(target: LOG_TARGET, "Failed to send request to dialer because '{}'", err);
         }
     }
 
@@ -568,14 +561,8 @@ where
     }
 
     fn publish_event(&self, event: ConnectionManagerEvent) {
-        let event = Arc::new(event);
-        if self.connection_manager_events_tx.send(event.clone()).is_err() {
-            trace!(
-                target: LOG_TARGET,
-                "Didn't send event '{}' because there are no subscribers",
-                event
-            );
-        }
+        // Error on no subscribers can be ignored
+        let _ = self.connection_manager_events_tx.send(Arc::new(event));
     }
 
     #[inline]
@@ -591,19 +578,12 @@ where
     {
         match self.peer_manager.find_by_node_id(&node_id).await {
             Ok(peer) => {
-                if let Err(err) = self.dialer_tx.send(DialerRequest::Dial(Box::new(peer), reply_tx)).await {
-                    error!(target: LOG_TARGET, "Failed to send request to dialer because '{}'", err);
-                }
+                self.send_dialer_request(DialerRequest::Dial(Box::new(peer), reply_tx))
+                    .await;
             },
             Err(err) => {
                 error!(target: LOG_TARGET, "Failed to fetch peer to dial because '{}'", err);
-                log_if_error_fmt!(
-                    level: warn,
-                    target: LOG_TARGET,
-                    reply_tx.send(Err(ConnectionManagerError::PeerManagerError(err))),
-                    "Failed to send error reply when dialing peer '{}'",
-                    node_id.short_str()
-                );
+                let _ = reply_tx.send(Err(ConnectionManagerError::PeerManagerError(err)));
             },
         }
     }

--- a/comms/src/connection_manager/peer_connection.rs
+++ b/comms/src/connection_manager/peer_connection.rs
@@ -26,8 +26,8 @@ use super::{
     types::ConnectionDirection,
 };
 use crate::{
-    multiplexing::{Control, IncomingSubstreams, Substream, Yamux},
-    peer_manager::{NodeId, Peer, PeerFeatures},
+    multiplexing::{Control, IncomingSubstreams, Substream, SubstreamCounter, Yamux},
+    peer_manager::{NodeId, PeerFeatures},
     protocol::{ProtocolId, ProtocolNegotiation},
     runtime,
 };
@@ -41,10 +41,7 @@ use log::*;
 use multiaddr::Multiaddr;
 use std::{
     fmt,
-    sync::{
-        atomic::{AtomicUsize, Ordering},
-        Arc,
-    },
+    sync::atomic::{AtomicUsize, Ordering},
     time::{Duration, Instant},
 };
 use tari_shutdown::Shutdown;
@@ -58,7 +55,8 @@ static ID_COUNTER: AtomicUsize = AtomicUsize::new(0);
 pub fn create(
     connection: Yamux,
     peer_addr: Multiaddr,
-    peer: Arc<Peer>,
+    peer_node_id: NodeId,
+    peer_features: PeerFeatures,
     direction: ConnectionDirection,
     event_notifier: mpsc::Sender<ConnectionManagerEvent>,
     our_supported_protocols: Vec<ProtocolId>,
@@ -67,14 +65,23 @@ pub fn create(
     trace!(
         target: LOG_TARGET,
         "(Peer={}) Socket successfully upgraded to multiplexed socket",
-        peer.node_id.short_str()
+        peer_node_id.short_str()
     );
     let (peer_tx, peer_rx) = mpsc::channel(PEER_REQUEST_BUFFER_SIZE);
     let id = ID_COUNTER.fetch_add(1, Ordering::Relaxed); // Monotonic
-    let peer_conn = PeerConnection::new(id, peer_tx, peer.clone(), peer_addr, direction);
+    let substream_counter = connection.substream_counter();
+    let peer_conn = PeerConnection::new(
+        id,
+        peer_tx,
+        peer_node_id.clone(),
+        peer_features,
+        peer_addr,
+        direction,
+        substream_counter,
+    );
     let peer_actor = PeerConnectionActor::new(
         id,
-        peer.node_id.clone(),
+        peer_node_id,
         direction,
         connection,
         peer_rx,
@@ -103,44 +110,44 @@ pub type ConnId = usize;
 #[derive(Clone, Debug)]
 pub struct PeerConnection {
     id: ConnId,
-    peer: Arc<Peer>,
+    peer_node_id: NodeId,
+    peer_features: PeerFeatures,
     request_tx: mpsc::Sender<PeerConnectionRequest>,
     address: Multiaddr,
     direction: ConnectionDirection,
     started_at: Instant,
+    substream_counter: SubstreamCounter,
 }
 
 impl PeerConnection {
     pub(crate) fn new(
         id: ConnId,
         request_tx: mpsc::Sender<PeerConnectionRequest>,
-        peer: Arc<Peer>,
+        peer_node_id: NodeId,
+        peer_features: PeerFeatures,
         address: Multiaddr,
         direction: ConnectionDirection,
+        substream_counter: SubstreamCounter,
     ) -> Self
     {
         Self {
             id,
             request_tx,
-            peer,
+            peer_node_id,
+            peer_features,
             address,
             direction,
             started_at: Instant::now(),
+            substream_counter,
         }
     }
 
-    /// Returns the peer associated with this peer connection.
-    /// WARNING: This is not kept in-sync with the peer database
-    pub fn peer(&self) -> Arc<Peer> {
-        self.peer.clone()
-    }
-
     pub fn peer_node_id(&self) -> &NodeId {
-        &self.peer.node_id
+        &self.peer_node_id
     }
 
     pub fn peer_features(&self) -> PeerFeatures {
-        self.peer.features
+        self.peer_features
     }
 
     pub fn direction(&self) -> ConnectionDirection {
@@ -159,8 +166,12 @@ impl PeerConnection {
         !self.request_tx.is_closed()
     }
 
-    pub fn connected_since(&self) -> Duration {
+    pub fn age(&self) -> Duration {
         self.started_at.elapsed()
+    }
+
+    pub fn substream_count(&self) -> usize {
+        self.substream_counter.get()
     }
 
     pub async fn open_substream(
@@ -177,6 +188,8 @@ impl PeerConnection {
             .map_err(|_| PeerConnectionError::InternalReplyCancelled)?
     }
 
+    /// Immediately disconnects the peer connection. This can only fail if the peer connection worker
+    /// is shut down (and the peer is already disconnected)
     pub async fn disconnect(&mut self) -> Result<(), PeerConnectionError> {
         let (reply_tx, reply_rx) = oneshot::channel();
         self.request_tx
@@ -202,11 +215,12 @@ impl fmt::Display for PeerConnection {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
         write!(
             f,
-            "Id = {}, Node ID = {}, Direction = {}, Peer Address = {}",
+            "Id = {}, Node ID = {}, Direction = {}, Peer Address = {}, Features = {:?}",
             self.id,
-            self.peer.node_id.short_str(),
-            self.direction.to_string(),
-            self.address.to_string()
+            self.peer_node_id.short_str(),
+            self.direction,
+            self.address,
+            self.peer_features,
         )
     }
 }

--- a/comms/src/connection_manager/requester.rs
+++ b/comms/src/connection_manager/requester.rs
@@ -33,9 +33,9 @@ use tokio::sync::broadcast;
 #[derive(Debug)]
 pub enum ConnectionManagerRequest {
     /// Dial a given peer by node id.
-    /// Parameters:
-    /// 1. Node Id to dial
     DialPeer(NodeId, oneshot::Sender<Result<PeerConnection, ConnectionManagerError>>),
+    /// Cancels a pending dial if one exists
+    CancelDial(NodeId),
     /// Register a oneshot to get triggered when the node is listening, or has failed to listen
     NotifyListening(oneshot::Sender<Multiaddr>),
     /// Retrieve an active connection for a given node id if one exists.
@@ -45,7 +45,7 @@ pub enum ConnectionManagerRequest {
     /// Retrieve the number of active connections
     GetNumActiveConnections(oneshot::Sender<usize>),
     /// Disconnect a peer
-    DisconnectPeer(NodeId, oneshot::Sender<Result<(), ConnectionManagerError>>),
+    DisconnectPeer(NodeId),
 }
 
 /// Responsible for constructing requests to the ConnectionManagerService
@@ -101,8 +101,6 @@ impl ConnectionManagerRequester {
 
     request_fn!(get_active_connection(node_id: NodeId) -> Option<PeerConnection>, request = ConnectionManagerRequest::GetActiveConnection);
 
-    request_fn!(disconnect_peer(node_id: NodeId) -> Result<(), ConnectionManagerError>, request = ConnectionManagerRequest::DisconnectPeer);
-
     /// Returns a ConnectionManagerEvent stream
     pub fn get_event_subscription(&self) -> broadcast::Receiver<Arc<ConnectionManagerEvent>> {
         self.event_tx.subscribe()
@@ -111,13 +109,49 @@ impl ConnectionManagerRequester {
     /// Attempt to connect to a remote peer
     pub async fn dial_peer(&mut self, node_id: NodeId) -> Result<PeerConnection, ConnectionManagerError> {
         let (reply_tx, reply_rx) = oneshot::channel();
+        self.send_dial_peer(node_id, reply_tx).await?;
+        reply_rx
+            .await
+            .map_err(|_| ConnectionManagerError::ActorRequestCanceled)?
+    }
+
+    /// Send instruction to ConnectionManager to dial a peer and return the result on the given oneshot
+    pub async fn cancel_dial(&mut self, node_id: NodeId) -> Result<(), ConnectionManagerError> {
+        self.sender
+            .send(ConnectionManagerRequest::CancelDial(node_id))
+            .await
+            .map_err(|_| ConnectionManagerError::SendToActorFailed)?;
+        Ok(())
+    }
+
+    /// Send instruction to ConnectionManager to dial a peer and return the result on the given oneshot
+    pub(crate) async fn send_dial_peer(
+        &mut self,
+        node_id: NodeId,
+        reply_tx: oneshot::Sender<Result<PeerConnection, ConnectionManagerError>>,
+    ) -> Result<(), ConnectionManagerError>
+    {
         self.sender
             .send(ConnectionManagerRequest::DialPeer(node_id, reply_tx))
             .await
             .map_err(|_| ConnectionManagerError::SendToActorFailed)?;
-        reply_rx
+        Ok(())
+    }
+
+    /// Send instruction to ConnectionManager to dial a peer without waiting for a result.
+    pub(crate) async fn send_dial_peer_no_reply(&mut self, node_id: NodeId) -> Result<(), ConnectionManagerError> {
+        let (reply_tx, _) = oneshot::channel();
+        self.send_dial_peer(node_id, reply_tx).await?;
+        Ok(())
+    }
+
+    /// Disconnect a peer. The peer will disconnect after a preconfigured linger time.
+    pub async fn disconnect_peer(&mut self, node_id: NodeId) -> Result<(), ConnectionManagerError> {
+        self.sender
+            .send(ConnectionManagerRequest::DisconnectPeer(node_id))
             .await
-            .map_err(|_| ConnectionManagerError::ActorRequestCanceled)?
+            .map_err(|_| ConnectionManagerError::SendToActorFailed)?;
+        Ok(())
     }
 
     /// Return the listening address of this node's listener. This will asynchronously block until the listener has

--- a/comms/src/connection_manager/tests/manager.rs
+++ b/comms/src/connection_manager/tests/manager.rs
@@ -33,6 +33,7 @@ use crate::{
     peer_manager::{NodeId, Peer, PeerFeatures, PeerFlags, PeerManagerError},
     protocol::{ProtocolEvent, ProtocolId, Protocols, IDENTITY_PROTOCOL},
     test_utils::{
+        count_string_occurrences,
         node_identity::{build_node_identity, ordered_node_identities},
         test_node::{build_connection_manager, build_peer_manager, TestNodeConfig},
     },
@@ -170,17 +171,6 @@ async fn dial_success() {
     let mut buf = [0u8; MSG.len()];
     substream_in.read_exact(&mut buf).await.unwrap();
     assert_eq!(buf, MSG);
-}
-
-fn count_string_occurrences<T, U>(events: &[T], expected: &[&str]) -> usize
-where
-    T: AsRef<U>,
-    U: ToString,
-{
-    events
-        .iter()
-        .filter(|event| expected.iter().any(|exp| event.as_ref().to_string().starts_with(exp)))
-        .count()
 }
 
 #[tokio_macros::test_basic]

--- a/comms/src/connectivity/config.rs
+++ b/comms/src/connectivity/config.rs
@@ -1,0 +1,51 @@
+//  Copyright 2020, The Tari Project
+//
+//  Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+//  following conditions are met:
+//
+//  1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+//  disclaimer.
+//
+//  2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+//  following disclaimer in the documentation and/or other materials provided with the distribution.
+//
+//  3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+//  products derived from this software without specific prior written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+//  INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+//  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+//  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+//  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+//  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+//  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+use std::time::Duration;
+
+#[derive(Debug, Clone, Copy)]
+pub struct ConnectivityConfig {
+    /// This factor is used to calculate the threshold to transition connectivity to an online state.
+    /// To change the status to ONLINE, this must be true: `num_connected >= num_peers * min_connectivity`
+    /// Default: 30%
+    pub min_connectivity: f32,
+    /// Interval to check the connection pool, including reaping inactive connections and retrying failed managed peer
+    /// connections. Default: 30s
+    pub connection_pool_refresh_interval: Duration,
+    /// The minimum age of the connection before it can be reaped. This prevents a connection that has just been
+    /// established from being reaped.
+    pub reaper_min_inactive_age: Duration,
+    /// The number of connection failures before a peer is considered offline
+    /// Default: 2
+    pub max_failures_mark_offline: usize,
+}
+
+impl Default for ConnectivityConfig {
+    fn default() -> Self {
+        Self {
+            min_connectivity: 0.3,
+            connection_pool_refresh_interval: Duration::from_secs(30),
+            reaper_min_inactive_age: Duration::from_secs(60),
+            max_failures_mark_offline: 2,
+        }
+    }
+}

--- a/comms/src/connectivity/connection_pool.rs
+++ b/comms/src/connectivity/connection_pool.rs
@@ -1,0 +1,257 @@
+//  Copyright 2020, The Tari Project
+//
+//  Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+//  following conditions are met:
+//
+//  1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+//  disclaimer.
+//
+//  2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+//  following disclaimer in the documentation and/or other materials provided with the distribution.
+//
+//  3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+//  products derived from this software without specific prior written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+//  INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+//  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+//  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+//  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+//  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+//  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+use crate::{peer_manager::NodeId, PeerConnection};
+use nom::lib::std::collections::hash_map::Entry;
+use std::{collections::HashMap, fmt, time::Duration};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ConnectionStatus {
+    NotConnected,
+    Connecting,
+    Connected,
+    Retrying,
+    Failed,
+    Disconnected,
+}
+
+impl fmt::Display for ConnectionStatus {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{:?}", self)
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct PeerConnectionState {
+    node_id: NodeId,
+    connection: Option<PeerConnection>,
+    status: ConnectionStatus,
+}
+
+impl PeerConnectionState {
+    #[inline]
+    pub fn connection(&self) -> Option<&PeerConnection> {
+        self.connection.as_ref()
+    }
+
+    #[inline]
+    pub fn connection_mut(&mut self) -> Option<&mut PeerConnection> {
+        self.connection.as_mut()
+    }
+
+    #[inline]
+    pub fn into_connection(self) -> Option<PeerConnection> {
+        self.connection
+    }
+
+    #[inline]
+    pub fn status(&self) -> ConnectionStatus {
+        self.status
+    }
+
+    #[inline]
+    pub fn node_id(&self) -> &NodeId {
+        &self.node_id
+    }
+
+    fn not_connected(node_id: NodeId) -> Self {
+        Self {
+            node_id,
+            connection: None,
+            status: ConnectionStatus::NotConnected,
+        }
+    }
+
+    fn connected(conn: PeerConnection) -> Self {
+        Self {
+            node_id: conn.peer_node_id().clone(),
+            connection: Some(conn),
+            status: ConnectionStatus::Connected,
+        }
+    }
+
+    fn set_connection(&mut self, conn: PeerConnection) {
+        self.connection = Some(conn);
+    }
+}
+
+impl fmt::Display for PeerConnectionState {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "{}, Status = {}",
+            self.connection()
+                .map(ToString::to_string)
+                .unwrap_or_else(|| self.node_id.to_string()),
+            self.status()
+        )
+    }
+}
+
+pub struct ConnectionPool {
+    connections: HashMap<NodeId, PeerConnectionState>,
+}
+
+impl ConnectionPool {
+    pub fn new() -> Self {
+        Self {
+            connections: HashMap::new(),
+        }
+    }
+
+    pub fn insert(&mut self, node_id: NodeId) -> ConnectionStatus {
+        match self.connections.entry(node_id) {
+            Entry::Occupied(entry) => entry.get().status(),
+            Entry::Vacant(entry) => {
+                let node_id = entry.key().clone();
+                entry.insert(PeerConnectionState::not_connected(node_id)).status()
+            },
+        }
+    }
+
+    pub fn contains(&mut self, node_id: &NodeId) -> bool {
+        self.connections.contains_key(node_id)
+    }
+
+    pub fn insert_connection(&mut self, conn: PeerConnection) {
+        match self.connections.entry(conn.peer_node_id().clone()) {
+            Entry::Occupied(mut entry) => {
+                let entry_mut = entry.get_mut();
+                entry_mut.status = if conn.is_connected() {
+                    ConnectionStatus::Connected
+                } else {
+                    ConnectionStatus::Disconnected
+                };
+                entry_mut.set_connection(conn);
+            },
+            Entry::Vacant(entry) => {
+                entry.insert(PeerConnectionState::connected(conn));
+            },
+        }
+    }
+
+    #[inline]
+    pub fn get(&self, node_id: &NodeId) -> Option<&PeerConnectionState> {
+        self.connections.get(node_id)
+    }
+
+    pub fn all(&self) -> Vec<&PeerConnectionState> {
+        self.connections.values().collect()
+    }
+
+    pub fn get_connection(&self, node_id: &NodeId) -> Option<&PeerConnection> {
+        self.get(node_id).and_then(|c| c.connection())
+    }
+
+    pub fn get_connection_status(&self, node_id: &NodeId) -> ConnectionStatus {
+        self.get(node_id)
+            .map(|c| c.status())
+            .unwrap_or(ConnectionStatus::NotConnected)
+    }
+
+    pub fn get_inactive_connections_mut(&mut self, min_age: Duration) -> Vec<&mut PeerConnection> {
+        self.filter_connections_mut(|conn| conn.age() > min_age && conn.substream_count() == 0)
+    }
+
+    pub(in crate::connectivity) fn filter_drain<P>(&mut self, mut predicate: P) -> Vec<PeerConnectionState>
+    where P: FnMut(&PeerConnectionState) -> bool {
+        let (keep, remove) = self
+            .connections
+            .drain()
+            .partition::<Vec<_>, _>(|(_, c)| !(predicate)(c));
+        self.connections = keep.into_iter().collect::<HashMap<_, _>>();
+        remove.into_iter().map(|(_, s)| s).collect()
+    }
+
+    pub(in crate::connectivity) fn filter_connection_states<P>(&self, mut predicate: P) -> Vec<&PeerConnection>
+    where P: FnMut(&PeerConnectionState) -> bool {
+        self.connections
+            .values()
+            .filter(|c| (predicate)(*c))
+            .filter_map(|c| c.connection())
+            .collect()
+    }
+
+    fn filter_connections_mut<P>(&mut self, mut predicate: P) -> Vec<&mut PeerConnection>
+    where P: FnMut(&PeerConnection) -> bool {
+        self.connections
+            .values_mut()
+            .filter_map(|c| c.connection_mut())
+            .filter(|c| (predicate)(*c))
+            .collect()
+    }
+
+    pub fn set_status(&mut self, node_id: &NodeId, status: ConnectionStatus) -> ConnectionStatus {
+        match self.connections.get_mut(node_id) {
+            Some(state) => {
+                let old_status = state.status();
+                state.status = status;
+                old_status
+            },
+            None => ConnectionStatus::NotConnected,
+        }
+    }
+
+    pub fn remove(&mut self, node_id: &NodeId) -> Option<PeerConnection> {
+        self.connections.remove(node_id).and_then(|c| c.into_connection())
+    }
+
+    pub fn count_connected_nodes(&self) -> usize {
+        self.connections
+            .values()
+            .filter(|c| {
+                c.status() == ConnectionStatus::Connected &&
+                    c.connection()
+                        .filter(|c| c.is_connected() && c.peer_features().is_node())
+                        .is_some()
+            })
+            .count()
+    }
+
+    pub fn count_connected_clients(&self) -> usize {
+        self.connections
+            .values()
+            .filter(|c| {
+                c.status() == ConnectionStatus::Connected &&
+                    c.connection()
+                        .filter(|c| c.is_connected() && c.peer_features().is_client())
+                        .is_some()
+            })
+            .count()
+    }
+
+    pub fn count_failed(&self) -> usize {
+        self.count_status(ConnectionStatus::Failed)
+    }
+
+    pub fn count_disconnected(&self) -> usize {
+        self.count_status(ConnectionStatus::Disconnected)
+    }
+
+    pub fn count_entries(&self) -> usize {
+        self.connections.len()
+    }
+
+    fn count_status(&self, status: ConnectionStatus) -> usize {
+        self.connections.values().filter(|c| c.status() == status).count()
+    }
+}

--- a/comms/src/connectivity/connection_stats.rs
+++ b/comms/src/connectivity/connection_stats.rs
@@ -1,0 +1,167 @@
+// Copyright 2019, The Tari Project
+//
+// Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+// following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+// disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+// following disclaimer in the documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+// products derived from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+// INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+// WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+// USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+use crate::utils::datetime::format_duration;
+use std::{
+    fmt,
+    fmt::{Display, Formatter},
+    time::Instant,
+};
+
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct PeerConnectionStats {
+    /// The last time a connection was successfully made or, None if a successful
+    /// connection has never been made.
+    pub last_connected_at: Option<Instant>,
+    /// Represents the last connection attempt
+    pub last_connection_attempt: LastConnectionAttempt,
+}
+
+impl PeerConnectionStats {
+    pub fn new() -> Self {
+        Default::default()
+    }
+
+    /// Sets the last connection as a success. `has_connected()` will return true from here on.
+    pub fn set_connection_success(&mut self) {
+        self.last_connected_at = Some(Instant::now());
+        self.last_connection_attempt = LastConnectionAttempt::Succeeded(Instant::now());
+    }
+
+    /// Sets the last connection as a failure
+    pub fn set_connection_failed(&mut self) {
+        self.last_connection_attempt = LastConnectionAttempt::Failed {
+            failed_at: Instant::now(),
+            num_attempts: self.failed_attempts() + 1,
+        };
+    }
+
+    /// Returns the number of failed attempts. 0 is returned if the `last_connection_attempt` is not `Failed`
+    pub fn failed_attempts(&self) -> usize {
+        match self.last_connection_attempt {
+            LastConnectionAttempt::Failed { num_attempts, .. } => num_attempts,
+            _ => 0,
+        }
+    }
+
+    /// Returns the date time (UTC) since the last failed connection occurred. None is returned if the
+    /// `last_connection_attempt` is not `Failed`
+    pub fn last_failed_at(&self) -> Option<Instant> {
+        match &self.last_connection_attempt {
+            LastConnectionAttempt::Failed { failed_at, .. } => Some(failed_at.clone()),
+            _ => None,
+        }
+    }
+}
+
+impl fmt::Display for PeerConnectionStats {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self.last_failed_at() {
+            Some(_) => {
+                write!(f, "{}", self.last_connection_attempt)?;
+            },
+            None => match self.last_connected_at.as_ref() {
+                Some(dt) => {
+                    write!(f, "Last connected {} ago", format_duration(dt.elapsed()))?;
+                },
+                None => {
+                    write!(f, "{}", self.last_connection_attempt)?;
+                },
+            },
+        }
+
+        Ok(())
+    }
+}
+
+/// Peer connection statistics
+#[derive(Debug, Clone, PartialOrd, PartialEq)]
+pub enum LastConnectionAttempt {
+    /// This node has never attempted to connect to this peer
+    Never,
+    /// The last connection attempt was successful
+    Succeeded(Instant),
+    /// The last connection attempt failed.
+    Failed {
+        /// Timestamp of the last failed attempt
+        failed_at: Instant,
+        /// Number of failed attempts in a row
+        num_attempts: usize,
+    },
+}
+
+impl Default for LastConnectionAttempt {
+    fn default() -> Self {
+        LastConnectionAttempt::Never
+    }
+}
+
+impl Display for LastConnectionAttempt {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), fmt::Error> {
+        use LastConnectionAttempt::*;
+        match self {
+            Never => write!(f, "Connection never attempted"),
+            Succeeded(succeeded_at) => write!(
+                f,
+                "Connection succeeded {} ago",
+                format_duration(succeeded_at.elapsed())
+            ),
+            Failed {
+                failed_at,
+                num_attempts,
+            } => write!(
+                f,
+                "Connection failed {} ago ({} attempt(s))",
+                format_duration(failed_at.elapsed()),
+                num_attempts
+            ),
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn peer_connection_stats() {
+        let state = PeerConnectionStats::new();
+        assert!(state.last_failed_at().is_none());
+        assert_eq!(state.failed_attempts(), 0);
+
+        let mut state = PeerConnectionStats::new();
+        state.set_connection_success();
+        assert!(state.last_failed_at().is_none());
+        assert_eq!(state.failed_attempts(), 0);
+
+        let mut state = PeerConnectionStats::new();
+        state.set_connection_failed();
+        state.set_connection_failed();
+        state.set_connection_failed();
+        assert!(state.last_failed_at().is_some());
+        assert_eq!(state.failed_attempts(), 3);
+
+        state.set_connection_success();
+        assert_eq!(state.failed_attempts(), 0);
+        assert!(state.last_failed_at().is_none());
+    }
+}

--- a/comms/src/connectivity/error.rs
+++ b/comms/src/connectivity/error.rs
@@ -1,0 +1,38 @@
+//  Copyright 2020, The Tari Project
+//
+//  Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+//  following conditions are met:
+//
+//  1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+//  disclaimer.
+//
+//  2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+//  following disclaimer in the documentation and/or other materials provided with the distribution.
+//
+//  3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+//  products derived from this software without specific prior written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+//  INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+//  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+//  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+//  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+//  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+//  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+use crate::{connection_manager::ConnectionManagerError, peer_manager::PeerManagerError};
+use derive_error::Error;
+
+#[derive(Debug, Error, Clone)]
+pub enum ConnectivityError {
+    /// Cannot send request because ConnectivityActor disconnected
+    ActorDisconnected,
+    /// Response was unexpectedly cancelled
+    ActorResponseCancelled,
+    PeerManagerError(PeerManagerError),
+    ConnectionFailed(ConnectionManagerError),
+    /// Connectivity event stream closed unexpectedly
+    ConnectivityEventStreamClosed,
+    /// Timeout while waiting for ONLINE connectivity
+    OnlineWaitTimeout,
+}

--- a/comms/src/connectivity/manager.rs
+++ b/comms/src/connectivity/manager.rs
@@ -1,0 +1,672 @@
+//  Copyright 2020, The Tari Project
+//
+//  Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+//  following conditions are met:
+//
+//  1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+//  disclaimer.
+//
+//  2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+//  following disclaimer in the documentation and/or other materials provided with the distribution.
+//
+//  3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+//  products derived from this software without specific prior written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+//  INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+//  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+//  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+//  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+//  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+//  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+use super::{
+    config::ConnectivityConfig,
+    connection_pool::{ConnectionPool, ConnectionStatus},
+    connection_stats::PeerConnectionStats,
+    error::ConnectivityError,
+    requester::{ConnectivityEvent, ConnectivityRequest},
+    selection,
+    selection::ConnectivitySelection,
+};
+use crate::{
+    connection_manager::{ConnectionManagerError, ConnectionManagerRequester},
+    peer_manager::NodeId,
+    utils::datetime::format_duration,
+    ConnectionManagerEvent,
+    PeerConnection,
+    PeerManager,
+};
+use futures::{channel::mpsc, stream::Fuse, StreamExt};
+use log::*;
+use nom::lib::std::collections::hash_map::Entry;
+use std::{
+    cmp,
+    collections::HashMap,
+    fmt,
+    sync::Arc,
+    time::{Duration, Instant},
+};
+use tari_shutdown::ShutdownSignal;
+use tokio::{sync::broadcast, task, task::JoinHandle, time};
+
+const LOG_TARGET: &str = "comms::connectivity::manager";
+
+/// # Connectivity Manager
+///
+/// The ConnectivityManager actor is responsible for tracking the state of all peer
+/// connections in the system and maintaining a _managed pool_ of peer connections.
+/// It provides a simple interface to fetch active peer connections.
+/// Selection includes selecting a single peer, random selection and selecting connections
+/// closer to a `NodeId`.
+///
+/// Additionally, set of managed peers can be provided. ConnectivityManager actor will
+/// attempt to ensure that all provided peers have active peer connections.
+/// It emits [ConnectivityEvent](crate::connectivity::ConnectivityEvent)s that can keep client components
+/// in the loop with the state of the node's connectivity.
+pub struct ConnectivityManager {
+    pub config: ConnectivityConfig,
+    pub request_rx: mpsc::Receiver<ConnectivityRequest>,
+    pub event_tx: broadcast::Sender<Arc<ConnectivityEvent>>,
+    pub connection_manager: ConnectionManagerRequester,
+    pub peer_manager: Arc<PeerManager>,
+    pub shutdown_signal: ShutdownSignal,
+}
+
+impl ConnectivityManager {
+    pub fn create(self) -> ConnectivityManagerActor {
+        ConnectivityManagerActor {
+            config: self.config,
+            status: ConnectivityStatus::Initializing,
+            request_rx: self.request_rx.fuse(),
+            connection_manager: self.connection_manager,
+            peer_manager: self.peer_manager.clone(),
+            event_tx: self.event_tx,
+            connection_stats: HashMap::new(),
+
+            managed_peers: Vec::new(),
+
+            shutdown_signal: Some(self.shutdown_signal),
+            pool: ConnectionPool::new(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ConnectivityStatus {
+    Initializing,
+    Online,
+    Degraded,
+    Offline,
+}
+
+macro_rules! is_fn {
+    ($name: ident, $($enum_key:ident)::+) => {
+        pub fn $name(&self) -> bool {
+            match self {
+                $($enum_key)::+ => true,
+                _ => false
+            }
+        }
+    }
+}
+
+impl ConnectivityStatus {
+    is_fn!(is_initializing, ConnectivityStatus::Initializing);
+
+    is_fn!(is_online, ConnectivityStatus::Online);
+
+    is_fn!(is_offline, ConnectivityStatus::Offline);
+
+    is_fn!(is_degraded, ConnectivityStatus::Degraded);
+}
+
+impl fmt::Display for ConnectivityStatus {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{:?}", self)
+    }
+}
+
+pub struct ConnectivityManagerActor {
+    config: ConnectivityConfig,
+    status: ConnectivityStatus,
+    request_rx: Fuse<mpsc::Receiver<ConnectivityRequest>>,
+    connection_manager: ConnectionManagerRequester,
+    shutdown_signal: Option<ShutdownSignal>,
+    peer_manager: Arc<PeerManager>,
+    event_tx: broadcast::Sender<Arc<ConnectivityEvent>>,
+    connection_stats: HashMap<NodeId, PeerConnectionStats>,
+
+    managed_peers: Vec<NodeId>,
+    pool: ConnectionPool,
+}
+
+impl ConnectivityManagerActor {
+    pub fn spawn(self) -> JoinHandle<()> {
+        task::spawn(Self::run(self))
+    }
+
+    pub async fn run(mut self) {
+        info!(target: LOG_TARGET, "ConnectivityManager started");
+        let mut shutdown_signal = self
+            .shutdown_signal
+            .take()
+            .expect("ConnectivityManager initialized without a shutdown_signal");
+
+        let mut connection_manager_events = self.connection_manager.get_event_subscription().fuse();
+
+        let interval = self.config.connection_pool_refresh_interval;
+        let mut ticker = time::interval_at(
+            Instant::now()
+                .checked_add(interval)
+                .expect("connection_pool_refresh_interval cause overflow")
+                .into(),
+            interval,
+        )
+        .fuse();
+
+        self.publish_event(ConnectivityEvent::ConnectivityStateInitialized);
+
+        loop {
+            futures::select! {
+                req = self.request_rx.select_next_some() => {
+                    self.handle_request(req).await;
+                },
+
+                event = connection_manager_events.select_next_some() => {
+                    if let Ok(event) = event {
+                        if let Err(err) = self.handle_connection_manager_event(&event).await {
+                            error!(target:LOG_TARGET, "Error handling connection manager event: {:?}", err);
+                        }
+                    }
+                },
+
+                _ = ticker.next() => {
+                    if let Err(err) = self.refresh_connection_pool().await {
+                        error!(target: LOG_TARGET, "Error when refreshing connection pools: {:?}", err);
+                    }
+                },
+
+                _ = shutdown_signal => {
+                    info!(target: LOG_TARGET, "ConnectivityManager is shutting down because it received the shutdown signal");
+                    break;
+                }
+            }
+        }
+    }
+
+    async fn handle_request(&mut self, req: ConnectivityRequest) {
+        use ConnectivityRequest::*;
+        trace!(target: LOG_TARGET, "Request: {:?}", req);
+        match req {
+            GetConnectivityStatus(reply_tx) => {
+                let _ = reply_tx.send(self.status);
+            },
+            DialPeer(node_id, reply_tx) => {
+                if let Err(err) = self.connection_manager.send_dial_peer(node_id, reply_tx).await {
+                    error!(
+                        target: LOG_TARGET,
+                        "Failed to send dial request to connection manager: {:?}", err
+                    );
+                }
+            },
+            AddManagedPeers(node_ids) => {
+                self.add_managed_peers(node_ids).await;
+            },
+            RemovePeer(node_id) => match self.remove_peer(&node_id).await {
+                Some(node_id) => {
+                    info!(target: LOG_TARGET, "Removed peer {} from managed pool", node_id);
+                },
+                None => {
+                    warn!(
+                        target: LOG_TARGET,
+                        "Request to remove peer {} that is not managed", node_id
+                    );
+                },
+            },
+            SelectConnections(selection, reply_tx) => {
+                let _ = reply_tx.send(self.select_connections(selection).await);
+            },
+            GetConnection(node_id, reply_tx) => {
+                let _ = reply_tx.send(
+                    self.pool
+                        .get(&node_id)
+                        .filter(|c| c.status() == ConnectionStatus::Connected)
+                        .and_then(|c| c.connection())
+                        .filter(|conn| conn.is_connected())
+                        .cloned(),
+                );
+            },
+            GetAllConnectionStates(reply_tx) => {
+                let _ = reply_tx.send(self.pool.all().into_iter().cloned().collect());
+            },
+            BanPeer(node_id, duration) => {
+                if let Err(err) = self.ban_peer(&node_id, duration).await {
+                    error!(target: LOG_TARGET, "Error when banning peer: {:?}", err);
+                }
+            },
+        }
+    }
+
+    async fn refresh_connection_pool(&mut self) -> Result<(), ConnectivityError> {
+        debug!(
+            target: LOG_TARGET,
+            "Performing connection pool cleanup/refresh. (#Peers = {}, #Connected={}, #Failed={}, #Disconnected={}, \
+             #Clients={})",
+            self.pool.count_entries(),
+            self.pool.count_connected_nodes(),
+            self.pool.count_failed(),
+            self.pool.count_disconnected(),
+            self.pool.count_connected_clients()
+        );
+        self.disconnect_inactive_connections().await;
+        // Attempt to connect all managed peers: Failed, Disconnected or NotConnection will be dialed
+        self.try_connect_managed_peers().await?;
+        // Remove disconnected/failed peers from the connection pool
+        self.clean_connection_pool();
+        self.update_connectivity_status();
+        Ok(())
+    }
+
+    async fn try_connect_managed_peers(&mut self) -> Result<(), ConnectivityError> {
+        for node_id in &self.managed_peers {
+            match self.pool.get_connection_status(node_id) {
+                ConnectionStatus::Failed => {
+                    let status = self.pool.set_status(node_id, ConnectionStatus::Retrying);
+                    info!(
+                        target: LOG_TARGET,
+                        "{} peer '{}' is managed. Retrying.", status, node_id
+                    );
+                    self.connection_manager.send_dial_peer_no_reply(node_id.clone()).await?;
+                },
+                ConnectionStatus::Disconnected => {
+                    let status = self.pool.set_status(node_id, ConnectionStatus::Retrying);
+                    info!(
+                        target: LOG_TARGET,
+                        "{} peer '{}' is managed. Retrying.", status, node_id
+                    );
+                    self.connection_manager.send_dial_peer_no_reply(node_id.clone()).await?;
+                    // self.send_dial_request(node_id.clone()).await?;
+                },
+                ConnectionStatus::NotConnected => {
+                    let status = self.pool.set_status(node_id, ConnectionStatus::Connecting);
+                    info!(
+                        target: LOG_TARGET,
+                        "{} peer '{}' is managed. Connecting.", status, node_id
+                    );
+                    self.connection_manager.send_dial_peer_no_reply(node_id.clone()).await?;
+                },
+                _ => {},
+            }
+        }
+
+        Ok(())
+    }
+
+    async fn disconnect_inactive_connections(&mut self) {
+        let connections = self
+            .pool
+            .get_inactive_connections_mut(self.config.reaper_min_inactive_age);
+        for conn in connections {
+            if !conn.is_connected() {
+                continue;
+            }
+
+            info!(
+                target: LOG_TARGET,
+                "Disconnecting '{}' because connection was inactive",
+                conn.peer_node_id().short_str()
+            );
+            if let Err(err) = conn.disconnect().await {
+                // Already disconnected
+                debug!(
+                    target: LOG_TARGET,
+                    "Peer '{}' already disconnected. Error: {:?}",
+                    conn.peer_node_id().short_str(),
+                    err
+                );
+            }
+        }
+    }
+
+    fn clean_connection_pool(&mut self) {
+        let managed_peers = self.managed_peers.clone();
+        let cleared_states = self.pool.filter_drain(|state| {
+            (state.status() == ConnectionStatus::Failed || state.status() == ConnectionStatus::Disconnected) &&
+                !managed_peers.contains(state.node_id())
+        });
+        if !cleared_states.is_empty() {
+            info!(
+                target: LOG_TARGET,
+                "Cleared {} disconnected/failed connection states",
+                cleared_states.len()
+            );
+            debug!(
+                target: LOG_TARGET,
+                "Cleared connection states:\n{}",
+                cleared_states
+                    .iter()
+                    .map(ToString::to_string)
+                    .collect::<Vec<_>>()
+                    .join("\n")
+            )
+        }
+    }
+
+    async fn select_connections(
+        &self,
+        selection: ConnectivitySelection,
+    ) -> Result<Vec<PeerConnection>, ConnectivityError>
+    {
+        use ConnectivitySelection::*;
+        debug!(target: LOG_TARGET, "Selection query: {:?}", selection);
+        debug!(
+            target: LOG_TARGET,
+            "Connected node peers = {}",
+            self.pool.count_connected_nodes()
+        );
+        let conns = match selection {
+            RandomNodes(n, exclude) => selection::select_random_nodes(&self.pool, n, &exclude),
+            ClosestTo(dest_node_id, n, exclude) => {
+                let mut connections = selection::select_closest(&self.pool, &dest_node_id, &exclude);
+                connections.truncate(n);
+                connections.to_vec()
+            },
+        };
+        debug!(target: LOG_TARGET, "Selected {} connections(s)", conns.len());
+
+        Ok(conns.into_iter().cloned().collect())
+    }
+
+    async fn add_managed_peers(&mut self, node_ids: Vec<NodeId>) {
+        let pool = &mut self.pool;
+        let mut should_update_connectivity = false;
+        for node_id in node_ids {
+            if !self.managed_peers.contains(&node_id) {
+                self.managed_peers.push(node_id.clone());
+                should_update_connectivity = true;
+            }
+
+            match pool.insert(node_id.clone()) {
+                ConnectionStatus::Failed => {
+                    info!(
+                        target: LOG_TARGET,
+                        "Retrying connection to failed managed peer '{}'", node_id
+                    );
+                    pool.set_status(&node_id, ConnectionStatus::Retrying);
+                    if let Err(err) = self.connection_manager.send_dial_peer_no_reply(node_id.clone()).await {
+                        error!(
+                            target: LOG_TARGET,
+                            "Failed to send dial request to connection manager: {:?}", err
+                        );
+                        // Remove from this pool, it may be re-added later by the periodic connection refresh
+                        pool.remove(&node_id);
+                    }
+                },
+                ConnectionStatus::NotConnected | ConnectionStatus::Disconnected => {
+                    info!(target: LOG_TARGET, "Dialing offline managed peer '{}'", node_id);
+                    pool.set_status(&node_id, ConnectionStatus::Connecting);
+                    if let Err(err) = self.connection_manager.send_dial_peer_no_reply(node_id.clone()).await {
+                        error!(
+                            target: LOG_TARGET,
+                            "Failed to send dial request to connection manager: {:?}", err
+                        );
+                    }
+                },
+                status => info!(
+                    target: LOG_TARGET,
+                    "Managed peer '{}' added with connection status {}", node_id, status
+                ),
+            }
+        }
+
+        if should_update_connectivity {
+            self.update_connectivity_status();
+        }
+    }
+
+    /// Removes a peer from the managed peers. This does not disconnect the peer, but the peer will be disconnected if
+    /// inactive as part of the connection pool refresh procedure
+    async fn remove_peer(&mut self, node_id: &NodeId) -> Option<NodeId> {
+        let pos = self.managed_peers.iter().position(|n| n == node_id)?;
+        let removed_peer = self.managed_peers.remove(pos);
+        self.update_connectivity_status();
+        Some(removed_peer)
+    }
+
+    fn get_connection_stat_mut(&mut self, node_id: NodeId) -> &mut PeerConnectionStats {
+        match self.connection_stats.entry(node_id) {
+            Entry::Occupied(entry) => entry.into_mut(),
+            Entry::Vacant(entry) => entry.insert(PeerConnectionStats::new()),
+        }
+    }
+
+    fn mark_peer_succeeded(&mut self, node_id: NodeId) {
+        let entry = self.get_connection_stat_mut(node_id);
+        entry.set_connection_success();
+    }
+
+    fn mark_peer_failed(&mut self, node_id: NodeId) -> usize {
+        let entry = self.get_connection_stat_mut(node_id);
+        entry.set_connection_failed();
+        entry.failed_attempts()
+    }
+
+    async fn handle_peer_connection_failure(&mut self, node_id: &NodeId) -> Result<(), ConnectivityError> {
+        if self.status.is_offline() {
+            info!(
+                target: LOG_TARGET,
+                "Node is offline. Ignoring connection failure event for peer '{}'.", node_id
+            );
+            return Ok(());
+        }
+
+        let num_failed = self.mark_peer_failed(node_id.clone());
+
+        if num_failed >= self.config.max_failures_mark_offline {
+            debug!(
+                target: LOG_TARGET,
+                "Marking peer '{}' as offline because this node failed to connect to them {} times",
+                node_id.short_str(),
+                num_failed
+            );
+            self.peer_manager.set_offline(node_id, true).await?;
+            self.connection_stats.remove(node_id);
+            self.publish_event(ConnectivityEvent::PeerOffline(node_id.clone()));
+        }
+
+        Ok(())
+    }
+
+    async fn handle_connection_manager_event(
+        &mut self,
+        event: &ConnectionManagerEvent,
+    ) -> Result<(), ConnectivityError>
+    {
+        use ConnectionManagerEvent::*;
+        let (node_id, new_status, connection) = match event {
+            PeerDisconnected(node_id) => {
+                self.connection_stats.remove(&node_id);
+                (&**node_id, ConnectionStatus::Disconnected, None)
+            },
+            PeerConnected(conn) => (conn.peer_node_id(), ConnectionStatus::Connected, Some(conn.clone())),
+
+            PeerConnectFailed(node_id, ConnectionManagerError::DialCancelled) => {
+                info!(
+                    target: LOG_TARGET,
+                    "Dial was cancelled before connection completed to peer '{}'", node_id
+                );
+                (&**node_id, ConnectionStatus::Failed, None)
+            },
+            PeerConnectFailed(node_id, err) => {
+                info!(
+                    target: LOG_TARGET,
+                    "Connection to peer '{}' failed because '{:?}'", node_id, err
+                );
+                self.handle_peer_connection_failure(node_id).await?;
+                (&**node_id, ConnectionStatus::Failed, None)
+            },
+            _ => return Ok(()),
+        };
+
+        let old_status = self.pool.set_status(node_id, new_status);
+        if let Some(conn) = connection {
+            self.pool.insert_connection(conn);
+        }
+        if old_status != new_status {
+            info!(
+                target: LOG_TARGET,
+                "Peer connection for node '{}' transitioned from {} to {}", node_id, old_status, new_status
+            );
+        }
+
+        let is_managed = self.managed_peers.contains(node_id);
+        let node_id = node_id.clone();
+
+        use ConnectionStatus::*;
+        match (old_status, new_status) {
+            (_, Connected) => {
+                self.mark_peer_succeeded(node_id.clone());
+                match self.pool.get_connection(&node_id).cloned() {
+                    Some(conn) => {
+                        self.publish_event(ConnectivityEvent::PeerConnected(conn));
+                    },
+                    None => unreachable!(
+                        "Connection transitioning to CONNECTED state must always have a connection set i.e. \
+                         ConnectionPool::get_connection is Some"
+                    ),
+                }
+            },
+            (Connected, Disconnected) => {
+                if is_managed {
+                    self.publish_event(ConnectivityEvent::ManagedPeerDisconnected(node_id));
+                } else {
+                    self.publish_event(ConnectivityEvent::PeerDisconnected(node_id));
+                }
+            },
+            // Was not connected so don't broadcast event
+            (_, Disconnected) => {},
+            (_, Failed) => {
+                if is_managed {
+                    self.publish_event(ConnectivityEvent::ManagedPeerConnectFailed(node_id));
+                } else {
+                    self.publish_event(ConnectivityEvent::PeerConnectFailed(node_id));
+                }
+            },
+            _ => {
+                error!(
+                    target: LOG_TARGET,
+                    "Unexpected connection status transition ({} to {}) for peer '{}'", old_status, new_status, node_id
+                );
+            },
+        }
+
+        self.update_connectivity_status();
+        Ok(())
+    }
+
+    fn update_connectivity_status(&mut self) {
+        // The contract we are making with online/degraded status transitions is as follows:
+        // - If no managed peers are set and a single peer is connected we MUST transition to ONLINE
+        // - Clients SHOULD tolerate entering a DEGRADED/OFFLINE status
+        // - If more managed peers are added, the status MAY transition to DEGRADED
+        // - Clients MUST NOT assume that all managed peers are connected when ONLINE
+        let min_peers = cmp::max(
+            (self.managed_peers.len() as f32 * self.config.min_connectivity).ceil() as usize,
+            1,
+        );
+        let num_connected = self.pool.count_connected_nodes();
+        debug!(
+            target: LOG_TARGET,
+            "#managed peers = {}, min_peers = {}, num_connected = {}",
+            self.managed_peers.len(),
+            min_peers,
+            num_connected
+        );
+
+        match num_connected {
+            n if n >= min_peers => {
+                self.transition(ConnectivityStatus::Online, n, min_peers);
+            },
+            n if n > 0 && n < min_peers => {
+                self.transition(ConnectivityStatus::Degraded, n, min_peers);
+            },
+            n if n == 0 => {
+                if self.pool.count_failed() > 0 {
+                    self.transition(ConnectivityStatus::Offline, n, min_peers);
+                }
+            },
+            _ => unreachable!("num_connected is unsigned and only negative pattern covered on this branch"),
+        }
+    }
+
+    fn transition(&mut self, next_status: ConnectivityStatus, num_peers: usize, required_num_peers: usize) {
+        use ConnectivityStatus::*;
+        if self.status != next_status {
+            debug!(
+                target: LOG_TARGET,
+                "Connectivity status transitioning from {} to {}", self.status, next_status
+            );
+        }
+
+        match (self.status, next_status) {
+            (Online, Online) => {},
+            (_, Online) => {
+                info!(
+                    target: LOG_TARGET,
+                    "Connectivity is ONLINE ({}/{} connections)", num_peers, required_num_peers
+                );
+                self.publish_event(ConnectivityEvent::ConnectivityStateOnline(num_peers));
+            },
+            (_, Degraded) => {
+                warn!(
+                    target: LOG_TARGET,
+                    "Connectivity is DEGRADED ({}/{} connections)", num_peers, required_num_peers
+                );
+                self.publish_event(ConnectivityEvent::ConnectivityStateDegraded(num_peers));
+            },
+            (Offline, Offline) => {},
+            (_, Offline) => {
+                warn!(
+                    target: LOG_TARGET,
+                    "Connectivity is OFFLINE (0/{} connections)", required_num_peers
+                );
+                self.publish_event(ConnectivityEvent::ConnectivityStateOffline);
+            },
+            (status, next_status) => unreachable!("Unexpected status transition ({} to {})", status, next_status),
+        }
+        self.status = next_status;
+    }
+
+    fn publish_event(&mut self, event: ConnectivityEvent) {
+        // A send operation can only fail if there are no subscribers, so it is safe to ignore the error
+        let _ = self.event_tx.send(Arc::new(event));
+    }
+
+    async fn ban_peer(&mut self, node_id: &NodeId, duration: Duration) -> Result<(), ConnectivityError> {
+        info!(
+            target: LOG_TARGET,
+            "Banning peer {} for {}",
+            node_id,
+            format_duration(duration)
+        );
+
+        if let Some(pos) = self.managed_peers.iter().position(|n| n == node_id) {
+            let node_id = self.managed_peers.remove(pos);
+            warn!(target: LOG_TARGET, "Banned managed peer '{}'", node_id);
+        }
+
+        self.peer_manager.ban_peer_by_node_id(node_id, duration).await?;
+
+        self.publish_event(ConnectivityEvent::PeerBanned(node_id.clone()));
+
+        if self.pool.contains(node_id) {
+            self.connection_manager.disconnect_peer(node_id.clone()).await?;
+            let old_status = self.pool.set_status(node_id, ConnectionStatus::Disconnected);
+            info!(
+                target: LOG_TARGET,
+                "Disconnecting banned peer {}. The peer connection status was {}", node_id, old_status
+            );
+        }
+        Ok(())
+    }
+}

--- a/comms/src/connectivity/mod.rs
+++ b/comms/src/connectivity/mod.rs
@@ -1,0 +1,45 @@
+//  Copyright 2020, The Tari Project
+//
+//  Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+//  following conditions are met:
+//
+//  1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+//  disclaimer.
+//
+//  2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+//  following disclaimer in the documentation and/or other materials provided with the distribution.
+//
+//  3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+//  products derived from this software without specific prior written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+//  INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+//  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+//  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+//  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+//  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+//  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+mod connection_stats;
+
+mod config;
+pub use config::ConnectivityConfig;
+
+mod connection_pool;
+
+mod error;
+pub use error::ConnectivityError;
+
+mod manager;
+pub(crate) use manager::ConnectivityManager;
+pub use manager::ConnectivityStatus;
+
+mod requester;
+pub(crate) use requester::ConnectivityRequest;
+pub use requester::{ConnectivityEvent, ConnectivityEventRx, ConnectivityRequester};
+
+mod selection;
+pub use selection::ConnectivitySelection;
+
+#[cfg(test)]
+mod test;

--- a/comms/src/connectivity/requester.rs
+++ b/comms/src/connectivity/requester.rs
@@ -1,0 +1,262 @@
+//  Copyright 2020, The Tari Project
+//
+//  Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+//  following conditions are met:
+//
+//  1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+//  disclaimer.
+//
+//  2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+//  following disclaimer in the documentation and/or other materials provided with the distribution.
+//
+//  3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+//  products derived from this software without specific prior written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+//  INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+//  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+//  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+//  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+//  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+//  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+use super::{
+    connection_pool::PeerConnectionState,
+    error::ConnectivityError,
+    manager::ConnectivityStatus,
+    ConnectivitySelection,
+};
+use crate::{connection_manager::ConnectionManagerError, peer_manager::NodeId, PeerConnection};
+use futures::{
+    channel::{mpsc, oneshot},
+    SinkExt,
+    StreamExt,
+};
+use log::*;
+use std::{
+    fmt,
+    sync::Arc,
+    time::{Duration, Instant},
+};
+use tokio::{sync::broadcast, time};
+
+const LOG_TARGET: &str = "comms::connectivity::requester";
+
+pub type ConnectivityEventRx = broadcast::Receiver<Arc<ConnectivityEvent>>;
+
+#[derive(Debug)]
+pub enum ConnectivityEvent {
+    PeerDisconnected(NodeId),
+    ManagedPeerDisconnected(NodeId),
+    PeerConnected(PeerConnection),
+    PeerConnectFailed(NodeId),
+    ManagedPeerConnectFailed(NodeId),
+    PeerBanned(NodeId),
+    PeerOffline(NodeId),
+
+    ConnectivityStateInitialized,
+    ConnectivityStateOnline(usize),
+    ConnectivityStateDegraded(usize),
+    ConnectivityStateOffline,
+}
+
+impl fmt::Display for ConnectivityEvent {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        use ConnectivityEvent::*;
+        match self {
+            PeerDisconnected(node_id) => write!(f, "PeerDisconnected({})", node_id),
+            ManagedPeerDisconnected(node_id) => write!(f, "ManagedPeerDisconnected({})", node_id),
+            PeerConnected(node_id) => write!(f, "PeerConnected({})", node_id),
+            PeerConnectFailed(node_id) => write!(f, "PeerConnectFailed({})", node_id),
+            ManagedPeerConnectFailed(node_id) => write!(f, "ManagedPeerConnectFailed({})", node_id),
+            PeerBanned(node_id) => write!(f, "PeerBanned({})", node_id),
+            PeerOffline(node_id) => write!(f, "PeerOffline({})", node_id),
+            ConnectivityStateInitialized => write!(f, "ConnectivityStateInitialized"),
+            ConnectivityStateOnline(n) => write!(f, "ConnectivityStateOnline({})", n),
+            ConnectivityStateDegraded(n) => write!(f, "ConnectivityStateDegraded({})", n),
+            ConnectivityStateOffline => write!(f, "ConnectivityStateOffline"),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub enum ConnectivityRequest {
+    DialPeer(NodeId, oneshot::Sender<Result<PeerConnection, ConnectionManagerError>>),
+    GetConnectivityStatus(oneshot::Sender<ConnectivityStatus>),
+    AddManagedPeers(Vec<NodeId>),
+    RemovePeer(NodeId),
+    SelectConnections(
+        ConnectivitySelection,
+        oneshot::Sender<Result<Vec<PeerConnection>, ConnectivityError>>,
+    ),
+    GetConnection(NodeId, oneshot::Sender<Option<PeerConnection>>),
+    GetAllConnectionStates(oneshot::Sender<Vec<PeerConnectionState>>),
+    BanPeer(NodeId, Duration),
+}
+
+impl ConnectivitySelection {
+    pub fn random_nodes(n: usize, exclude: Vec<NodeId>) -> Self {
+        ConnectivitySelection::RandomNodes(n, exclude)
+    }
+
+    /// Select `n` peer connections ordered by closeness to `node_id`
+    pub fn closest_to(node_id: NodeId, n: usize, exclude: Vec<NodeId>) -> Self {
+        ConnectivitySelection::ClosestTo(Box::new(node_id), n, exclude)
+    }
+}
+
+#[derive(Clone)]
+pub struct ConnectivityRequester {
+    sender: mpsc::Sender<ConnectivityRequest>,
+    event_tx: broadcast::Sender<Arc<ConnectivityEvent>>,
+}
+
+impl ConnectivityRequester {
+    pub fn new(sender: mpsc::Sender<ConnectivityRequest>, event_tx: broadcast::Sender<Arc<ConnectivityEvent>>) -> Self {
+        Self { sender, event_tx }
+    }
+
+    pub fn subscribe_event_stream(&self) -> ConnectivityEventRx {
+        self.event_tx.subscribe()
+    }
+
+    pub async fn dial_peer(&mut self, peer: NodeId) -> Result<PeerConnection, ConnectivityError> {
+        let (reply_tx, reply_rx) = oneshot::channel();
+        self.sender
+            .send(ConnectivityRequest::DialPeer(peer, reply_tx))
+            .await
+            .map_err(|_| ConnectivityError::ActorDisconnected)?;
+        reply_rx
+            .await
+            .map_err(|_| ConnectivityError::ActorResponseCancelled)?
+            .map_err(Into::into)
+    }
+
+    pub async fn add_managed_peers(&mut self, peers: Vec<NodeId>) -> Result<(), ConnectivityError> {
+        self.sender
+            .send(ConnectivityRequest::AddManagedPeers(peers))
+            .await
+            .map_err(|_| ConnectivityError::ActorDisconnected)?;
+        Ok(())
+    }
+
+    pub async fn remove_peer(&mut self, peer: NodeId) -> Result<(), ConnectivityError> {
+        self.sender
+            .send(ConnectivityRequest::RemovePeer(peer))
+            .await
+            .map_err(|_| ConnectivityError::ActorDisconnected)?;
+        Ok(())
+    }
+
+    pub async fn select_connections(
+        &mut self,
+        selection: ConnectivitySelection,
+    ) -> Result<Vec<PeerConnection>, ConnectivityError>
+    {
+        let (reply_tx, reply_rx) = oneshot::channel();
+        self.sender
+            .send(ConnectivityRequest::SelectConnections(selection, reply_tx))
+            .await
+            .map_err(|_| ConnectivityError::ActorDisconnected)?;
+        reply_rx.await.map_err(|_| ConnectivityError::ActorResponseCancelled)?
+    }
+
+    /// Get an active connection to the given node id if one exists. This will return None if the peer is not connected.
+    pub async fn get_connection(&mut self, node_id: NodeId) -> Result<Option<PeerConnection>, ConnectivityError> {
+        let (reply_tx, reply_rx) = oneshot::channel();
+        self.sender
+            .send(ConnectivityRequest::GetConnection(node_id, reply_tx))
+            .await
+            .map_err(|_| ConnectivityError::ActorDisconnected)?;
+        reply_rx.await.map_err(|_| ConnectivityError::ActorResponseCancelled)
+    }
+
+    pub async fn get_connectivity_status(&mut self) -> Result<ConnectivityStatus, ConnectivityError> {
+        let (reply_tx, reply_rx) = oneshot::channel();
+        self.sender
+            .send(ConnectivityRequest::GetConnectivityStatus(reply_tx))
+            .await
+            .map_err(|_| ConnectivityError::ActorDisconnected)?;
+        reply_rx.await.map_err(|_| ConnectivityError::ActorResponseCancelled)
+    }
+
+    pub async fn get_all_connection_states(&mut self) -> Result<Vec<PeerConnectionState>, ConnectivityError> {
+        let (reply_tx, reply_rx) = oneshot::channel();
+        self.sender
+            .send(ConnectivityRequest::GetAllConnectionStates(reply_tx))
+            .await
+            .map_err(|_| ConnectivityError::ActorDisconnected)?;
+        reply_rx.await.map_err(|_| ConnectivityError::ActorResponseCancelled)
+    }
+
+    pub async fn ban_peer(&mut self, node_id: NodeId, duration: Duration) -> Result<(), ConnectivityError> {
+        self.sender
+            .send(ConnectivityRequest::BanPeer(node_id, duration))
+            .await
+            .map_err(|_| ConnectivityError::ActorDisconnected)?;
+        Ok(())
+    }
+
+    /// Waits for the node to get at least one connection.
+    /// This is useful for testing and is not typically be needed in application code.
+    pub async fn wait_for_connectivity(&mut self, timeout: Duration) -> Result<(), ConnectivityError> {
+        let mut connectivity_events = self.subscribe_event_stream();
+        let status = self.get_connectivity_status().await?;
+        if status.is_online() {
+            return Ok(());
+        }
+        let start = Instant::now();
+        let mut remaining = timeout;
+
+        loop {
+            debug!(target: LOG_TARGET, "Waiting for connectivity event");
+            let recv_result = time::timeout(remaining, connectivity_events.next())
+                .await
+                .map_err(|_| ConnectivityError::OnlineWaitTimeout)?
+                .ok_or_else(|| ConnectivityError::ConnectivityEventStreamClosed)?;
+
+            remaining = timeout
+                .checked_sub(start.elapsed())
+                .ok_or_else(|| ConnectivityError::OnlineWaitTimeout)?;
+
+            match recv_result {
+                Ok(event) => match &*event {
+                    ConnectivityEvent::ConnectivityStateOnline(_) => {
+                        info!(target: LOG_TARGET, "Connectivity is ONLINE.");
+                        break Ok(());
+                    },
+                    ConnectivityEvent::ConnectivityStateDegraded(_) => {
+                        warn!(target: LOG_TARGET, "Connectivity is DEGRADED.");
+                    },
+                    ConnectivityEvent::ConnectivityStateOffline => {
+                        warn!(
+                            target: LOG_TARGET,
+                            "Connectivity is OFFLINE. Waiting for connections..."
+                        );
+                    },
+                    event => {
+                        debug!(
+                            target: LOG_TARGET,
+                            "Received event while waiting for connectivity: {:?}", event
+                        );
+                    },
+                },
+                Err(broadcast::RecvError::Closed) => {
+                    error!(
+                        target: LOG_TARGET,
+                        "Connectivity event stream closed unexpectedly. System may be shutting down."
+                    );
+                    break Err(ConnectivityError::ConnectivityEventStreamClosed);
+                },
+                Err(broadcast::RecvError::Lagged(n)) => {
+                    warn!(target: LOG_TARGET, "Lagging behind on {} connectivity event(s)", n);
+                    // We lagged, so could have missed the state change. Check it explicitly.
+                    let status = self.get_connectivity_status().await?;
+                    if status.is_online() {
+                        break Ok(());
+                    }
+                },
+            }
+        }
+    }
+}

--- a/comms/src/connectivity/selection.rs
+++ b/comms/src/connectivity/selection.rs
@@ -1,0 +1,120 @@
+//  Copyright 2020, The Tari Project
+//
+//  Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+//  following conditions are met:
+//
+//  1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+//  disclaimer.
+//
+//  2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+//  following disclaimer in the documentation and/or other materials provided with the distribution.
+//
+//  3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+//  products derived from this software without specific prior written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+//  INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+//  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+//  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+//  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+//  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+//  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+use super::connection_pool::ConnectionPool;
+use crate::{connectivity::connection_pool::ConnectionStatus, peer_manager::NodeId, PeerConnection};
+use rand::{rngs::OsRng, seq::SliceRandom};
+
+#[derive(Debug, Clone)]
+pub enum ConnectivitySelection {
+    RandomNodes(usize, Vec<NodeId>),
+    ClosestTo(Box<NodeId>, usize, Vec<NodeId>),
+}
+
+pub fn select_connected_nodes<'a>(pool: &'a ConnectionPool, exclude: &[NodeId]) -> Vec<&'a PeerConnection> {
+    pool.filter_connection_states(|state| {
+        if state.status() != ConnectionStatus::Connected {
+            return false;
+        }
+        let conn = state
+            .connection()
+            .expect("Connection does not exist in PeerConnectionState with status=Connected");
+        conn.is_connected() && conn.peer_features().is_node() && !exclude.contains(conn.peer_node_id())
+    })
+}
+
+pub fn select_closest<'a>(pool: &'a ConnectionPool, node_id: &NodeId, exclude: &[NodeId]) -> Vec<&'a PeerConnection> {
+    let mut nodes = select_connected_nodes(pool, exclude);
+
+    nodes.sort_by(|a, b| {
+        let dist_a = a.peer_node_id().distance(node_id);
+        let dist_b = b.peer_node_id().distance(node_id);
+        dist_a.cmp(&dist_b)
+    });
+
+    nodes
+}
+
+pub fn select_random_nodes<'a>(pool: &'a ConnectionPool, n: usize, exclude: &[NodeId]) -> Vec<&'a PeerConnection> {
+    let nodes = select_connected_nodes(pool, exclude);
+    nodes.choose_multiple(&mut OsRng, n).map(|c| *c).collect()
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::{
+        connection_manager::PeerConnectionRequest,
+        peer_manager::node_id::NodeDistance,
+        test_utils::{mocks::create_dummy_peer_connection, node_id, node_identity::build_node_identity},
+    };
+    use futures::channel::mpsc;
+    use std::iter::repeat_with;
+
+    fn create_pool_with_connections(n: usize) -> (ConnectionPool, Vec<mpsc::Receiver<PeerConnectionRequest>>) {
+        let mut pool = ConnectionPool::new();
+        let mut receivers = Vec::with_capacity(n);
+        repeat_with(|| create_dummy_peer_connection(node_id::random()))
+            .take(n)
+            .for_each(|(conn, rx)| {
+                receivers.push(rx);
+                assert!(conn.is_connected());
+                pool.insert_connection(conn);
+            });
+        (pool, receivers)
+    }
+
+    #[test]
+    fn select_random() {
+        let (pool, _receivers) = create_pool_with_connections(10);
+        let conns = select_random_nodes(&pool, 500, &[]);
+        assert_eq!(conns.len(), 10);
+
+        let first_node = conns.first().unwrap().peer_node_id().clone();
+        let conns = select_random_nodes(&pool, 10, &[first_node.clone()]);
+        assert_eq!(conns.len(), 9);
+        assert!(conns.iter().all(|c| c.peer_node_id() != &first_node));
+    }
+
+    #[test]
+    fn select_closest_ordering() {
+        let (pool, _receivers) = create_pool_with_connections(10);
+        let subject_node_identity = build_node_identity(Default::default());
+        let conns = select_closest(&pool, subject_node_identity.node_id(), &[]);
+        assert_eq!(conns.len(), 10);
+
+        let mut last_dist = NodeDistance::zero();
+        for (i, conn) in conns.into_iter().enumerate() {
+            let dist = conn.peer_node_id().distance(subject_node_identity.node_id());
+            assert!(dist > last_dist, "Ordering was incorrect on connection {}", i);
+            last_dist = dist;
+        }
+    }
+
+    #[test]
+    fn select_closest_empty() {
+        let pool = ConnectionPool::new();
+        let node_identity = build_node_identity(Default::default());
+        let conns = select_closest(&pool, node_identity.node_id(), &[]);
+        assert!(conns.is_empty());
+    }
+}

--- a/comms/src/connectivity/test.rs
+++ b/comms/src/connectivity/test.rs
@@ -1,0 +1,313 @@
+//  Copyright 2020, The Tari Project
+//
+//  Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+//  following conditions are met:
+//
+//  1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+//  disclaimer.
+//
+//  2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+//  following disclaimer in the documentation and/or other materials provided with the distribution.
+//
+//  3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+//  products derived from this software without specific prior written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+//  INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+//  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+//  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+//  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+//  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+//  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+use super::{
+    config::ConnectivityConfig,
+    connection_pool::ConnectionStatus,
+    manager::ConnectivityManager,
+    requester::{ConnectivityEvent, ConnectivityRequester},
+    selection::ConnectivitySelection,
+};
+use crate::{
+    connection_manager::ConnectionManagerError,
+    peer_manager::{Peer, PeerFeatures},
+    test_utils::{
+        mocks::{create_connection_manager_mock, create_peer_connection_mock_pair, ConnectionManagerMockState},
+        node_identity::{build_node_identity, ordered_node_identities},
+        test_node::build_peer_manager,
+    },
+    ConnectionManagerEvent,
+    NodeIdentity,
+    PeerManager,
+};
+use futures::{channel::mpsc, future};
+use std::{sync::Arc, time::Duration};
+use tari_shutdown::Shutdown;
+use tari_test_utils::{collect_stream, unpack_enum};
+use tokio::{sync::broadcast, task};
+
+fn setup_connectivity_manager(
+    config: ConnectivityConfig,
+) -> (
+    ConnectivityRequester,
+    broadcast::Receiver<Arc<ConnectivityEvent>>,
+    Arc<NodeIdentity>,
+    Arc<PeerManager>,
+    ConnectionManagerMockState,
+    Shutdown,
+) {
+    let peer_manager = build_peer_manager();
+    let node_identity = build_node_identity(PeerFeatures::COMMUNICATION_NODE);
+    let (cm_requester, mock) = create_connection_manager_mock();
+    let cm_mock_state = mock.get_shared_state();
+    task::spawn(mock.run());
+    let shutdown = Shutdown::new();
+
+    let (request_tx, request_rx) = mpsc::channel(1);
+    let (event_tx, event_rx) = broadcast::channel(10);
+    let requester = ConnectivityRequester::new(request_tx, event_tx.clone());
+    ConnectivityManager {
+        config,
+        event_tx,
+        request_rx,
+        connection_manager: cm_requester,
+        peer_manager: peer_manager.clone(),
+        shutdown_signal: shutdown.to_signal(),
+    }
+    .create()
+    .spawn();
+
+    (
+        requester,
+        event_rx,
+        node_identity,
+        peer_manager,
+        cm_mock_state,
+        shutdown,
+    )
+}
+
+async fn add_test_peers(peer_manager: &PeerManager, n: usize) -> Vec<Peer> {
+    let node_identities = ordered_node_identities(n, PeerFeatures::COMMUNICATION_NODE);
+    let peer_iter = node_identities.iter().map(|n| n.to_peer());
+
+    let mut peers = Vec::with_capacity(n);
+    for peer in peer_iter {
+        peers.push(peer.clone());
+        peer_manager.add_peer(peer).await.unwrap();
+    }
+    peers
+}
+
+#[tokio_macros::test_basic]
+async fn connecting_peers() {
+    let (mut connectivity, mut event_stream, node_identity, peer_manager, cm_mock_state, _shutdown) =
+        setup_connectivity_manager(Default::default());
+    let peers = add_test_peers(&peer_manager, 10).await;
+
+    let connections = future::join_all(
+        peers
+            .iter()
+            .cloned()
+            .map(|peer| create_peer_connection_mock_pair(1, peer, node_identity.to_peer())),
+    )
+    .await
+    .into_iter()
+    .map(|(conn, _, _, _)| conn)
+    .collect::<Vec<_>>();
+
+    let mut events = collect_stream!(event_stream, take = 1, timeout = Duration::from_secs(10));
+    unpack_enum!(ConnectivityEvent::ConnectivityStateInitialized = &*events.remove(0).unwrap());
+
+    // All connections succeeded
+    for conn in &connections {
+        cm_mock_state.publish_event(ConnectionManagerEvent::PeerConnected(conn.clone()));
+    }
+
+    let _events = collect_stream!(event_stream, take = 11, timeout = Duration::from_secs(10));
+
+    let connection_states = connectivity.get_all_connection_states().await.unwrap();
+    assert_eq!(connection_states.len(), 10);
+
+    for state in connection_states {
+        assert_eq!(state.status(), ConnectionStatus::Connected);
+    }
+}
+
+#[tokio_macros::test_basic]
+async fn add_many_managed_peers() {
+    let (mut connectivity, mut event_stream, node_identity, peer_manager, cm_mock_state, _shutdown) =
+        setup_connectivity_manager(Default::default());
+    let peers = add_test_peers(&peer_manager, 10).await;
+
+    let connections = future::join_all(
+        (0..5)
+            .map(|i| peers[i].clone())
+            .map(|peer| create_peer_connection_mock_pair(1, node_identity.to_peer(), peer)),
+    )
+    .await
+    .into_iter()
+    .map(|(_, _, conn, _)| conn)
+    .collect::<Vec<_>>();
+
+    connectivity
+        .add_managed_peers(peers.iter().map(|p| p.node_id.clone()).collect())
+        .await
+        .unwrap();
+
+    let mut events = collect_stream!(event_stream, take = 1, timeout = Duration::from_secs(10));
+    unpack_enum!(ConnectivityEvent::ConnectivityStateInitialized = &*events.remove(0).unwrap());
+
+    // First 5 succeeded
+    for conn in &connections {
+        cm_mock_state.publish_event(ConnectionManagerEvent::PeerConnected(conn.clone()));
+    }
+
+    // 7-10 have failed, the rest are still connecting
+    for i in 7..10 {
+        cm_mock_state.publish_event(ConnectionManagerEvent::PeerConnectFailed(
+            Box::new(peers[i].node_id.clone()),
+            ConnectionManagerError::ConnectFailedMaximumAttemptsReached,
+        ));
+    }
+
+    let events = collect_stream!(event_stream, take = 9, timeout = Duration::from_secs(10));
+    let n = events
+        .iter()
+        .find_map(|event| match &**event.as_ref().unwrap() {
+            ConnectivityEvent::ConnectivityStateOnline(n) => Some(n),
+            ConnectivityEvent::ConnectivityStateDegraded(_) => None,
+            ConnectivityEvent::PeerConnected(_) => None,
+            e => panic!("Unexpected ConnectivityEvent {:?}", e),
+        })
+        .unwrap();
+    assert!(*n > 1);
+
+    let connection_states = connectivity.get_all_connection_states().await.unwrap();
+    assert_eq!(connection_states.len(), 10);
+
+    for i in 0..5 {
+        let state = connection_states
+            .iter()
+            .find(|s| s.node_id() == &peers[i].node_id)
+            .unwrap();
+        assert_eq!(state.status(), ConnectionStatus::Connected);
+        // Check the connection matches the expected peer
+        assert_eq!(state.connection().unwrap().peer_node_id(), &peers[i].node_id);
+    }
+    for i in 5..6 {
+        let state = connection_states
+            .iter()
+            .find(|s| s.node_id() == &peers[i].node_id)
+            .unwrap();
+        assert_eq!(state.status(), ConnectionStatus::Connecting);
+        assert!(state.connection().is_none());
+    }
+    for i in 7..10 {
+        let state = connection_states
+            .iter()
+            .find(|s| s.node_id() == &peers[i].node_id)
+            .unwrap();
+        assert_eq!(state.status(), ConnectionStatus::Failed);
+        assert!(state.connection().is_none());
+    }
+}
+
+#[tokio_macros::test_basic]
+async fn ban_peer() {
+    let (mut connectivity, mut event_stream, node_identity, peer_manager, cm_mock_state, _shutdown) =
+        setup_connectivity_manager(Default::default());
+    let peer = add_test_peers(&peer_manager, 1).await.pop().unwrap();
+    let (_, _, conn, _) = create_peer_connection_mock_pair(1, node_identity.to_peer(), peer.clone()).await;
+
+    let mut events = collect_stream!(event_stream, take = 1, timeout = Duration::from_secs(10));
+    unpack_enum!(ConnectivityEvent::ConnectivityStateInitialized = &*events.remove(0).unwrap());
+
+    cm_mock_state.publish_event(ConnectionManagerEvent::PeerConnected(conn.clone()));
+    let mut events = collect_stream!(event_stream, take = 2, timeout = Duration::from_secs(10));
+    unpack_enum!(ConnectivityEvent::PeerConnected(_conn) = &*events.remove(0).unwrap());
+    unpack_enum!(ConnectivityEvent::ConnectivityStateOnline(_n) = &*events.remove(0).unwrap());
+
+    let conn = connectivity.get_connection(peer.node_id.clone()).await.unwrap();
+    assert!(conn.is_some());
+
+    connectivity
+        .ban_peer(peer.node_id.clone(), Duration::from_secs(3600))
+        .await
+        .unwrap();
+
+    // We can always expect a single PeerBanned because we do not publish a disconnected event from the connection
+    // manager In a real system, peer disconnect and peer banned events may happen in any order and should always be
+    // completely fine.
+    let event = collect_stream!(event_stream, take = 1, timeout = Duration::from_secs(10))
+        .pop()
+        .unwrap()
+        .unwrap();
+
+    unpack_enum!(ConnectivityEvent::PeerBanned(node_id) = &*event);
+    assert_eq!(node_id, &peer.node_id);
+
+    let peer = peer_manager.find_by_node_id(&peer.node_id).await.unwrap();
+    assert!(peer.is_banned());
+
+    let conn = connectivity.get_connection(peer.node_id.clone()).await.unwrap();
+    assert!(conn.is_none());
+}
+
+#[tokio_macros::test_basic]
+async fn peer_selection() {
+    let config = ConnectivityConfig {
+        min_connectivity: 1.0,
+        ..Default::default()
+    };
+    let (mut connectivity, mut event_stream, node_identity, peer_manager, cm_mock_state, _shutdown) =
+        setup_connectivity_manager(config);
+    let peers = add_test_peers(&peer_manager, 10).await;
+
+    let connections = future::join_all(
+        peers
+            .iter()
+            .cloned()
+            .map(|peer| create_peer_connection_mock_pair(1, peer, node_identity.to_peer())),
+    )
+    .await
+    .into_iter()
+    .map(|(conn, _, _, _)| conn)
+    .collect::<Vec<_>>();
+
+    connectivity
+        .add_managed_peers(peers.iter().take(5).map(|p| p.node_id.clone()).collect())
+        .await
+        .unwrap();
+
+    let mut events = collect_stream!(event_stream, take = 1, timeout = Duration::from_secs(10));
+    unpack_enum!(ConnectivityEvent::ConnectivityStateInitialized = &*events.remove(0).unwrap());
+    // 10 connections
+    for conn in &connections {
+        cm_mock_state.publish_event(ConnectionManagerEvent::PeerConnected(conn.clone()));
+    }
+
+    // Wait for all peers to be connected (i.e. for the connection manager events to be received)
+    let mut _events = collect_stream!(event_stream, take = 12, timeout = Duration::from_secs(10));
+
+    let conns = connectivity
+        .select_connections(ConnectivitySelection::random_nodes(10, vec![connections[0]
+            .peer_node_id()
+            .clone()]))
+        .await
+        .unwrap();
+    assert_eq!(conns.len(), 9);
+    assert!(conns.iter().all(|c| c.peer_node_id() != connections[0].peer_node_id()));
+
+    let mut conns = connectivity
+        .select_connections(ConnectivitySelection::closest_to(
+            connections.last().unwrap().peer_node_id().clone(),
+            5,
+            vec![],
+        ))
+        .await
+        .unwrap();
+    assert_eq!(conns.len(), 5);
+    for i in 9usize..=5 {
+        let c = conns.remove(0);
+        assert_eq!(c.peer_node_id(), connections[i].peer_node_id());
+    }
+}

--- a/comms/src/lib.rs
+++ b/comms/src/lib.rs
@@ -24,6 +24,8 @@ pub use connection_manager::{validate_peer_addresses, ConnectionManagerEvent, Pe
 pub mod peer_manager;
 pub use peer_manager::{NodeIdentity, PeerManager};
 
+pub mod connectivity;
+
 mod consts;
 mod multiplexing;
 mod noise;
@@ -47,6 +49,7 @@ pub mod types;
 pub mod utils;
 
 mod builder;
+
 pub use builder::{BuiltCommsNode, CommsBuilder, CommsBuilderError, CommsNode};
 
 // Re-exports

--- a/comms/src/multiplexing/mod.rs
+++ b/comms/src/multiplexing/mod.rs
@@ -21,4 +21,4 @@
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 mod yamux;
-pub use self::yamux::{ConnectionError, Control, IncomingSubstreams, Substream, Yamux};
+pub use self::yamux::{ConnectionError, Control, IncomingSubstreams, Substream, SubstreamCounter, Yamux};

--- a/comms/src/multiplexing/yamux.rs
+++ b/comms/src/multiplexing/yamux.rs
@@ -120,7 +120,12 @@ impl Yamux {
 
     /// Return the number of active substreams
     pub fn substream_count(&self) -> usize {
-        self.substream_counter.count()
+        self.substream_counter.get()
+    }
+
+    /// Return a SubstreamCounter for this connection
+    pub(crate) fn substream_counter(&self) -> SubstreamCounter {
+        self.substream_counter.clone()
     }
 
     pub fn is_terminated(&self) -> bool {
@@ -157,7 +162,11 @@ impl Control {
     }
 
     pub fn substream_count(&self) -> usize {
-        self.substream_counter.count()
+        self.substream_counter.get()
+    }
+
+    pub(crate) fn substream_counter(&self) -> SubstreamCounter {
+        self.substream_counter.clone()
     }
 }
 
@@ -177,7 +186,7 @@ impl IncomingSubstreams {
     }
 
     pub fn substream_count(&self) -> usize {
-        self.substream_counter.count()
+        self.substream_counter.get()
     }
 }
 
@@ -315,7 +324,7 @@ impl SubstreamCounter {
     }
 
     /// Get the substream count
-    pub fn count(&self) -> usize {
+    pub fn get(&self) -> usize {
         // Substract one to account for the initial CounterGuard reference
         Arc::strong_count(&*self.0) - 1
     }

--- a/comms/src/peer_manager/node_id.rs
+++ b/comms/src/peer_manager/node_id.rs
@@ -73,6 +73,11 @@ impl XorDistance {
     pub const fn max_distance() -> Self {
         Self([255; NODE_XOR_DISTANCE_ARRAY_SIZE])
     }
+
+    /// Returns a zero distance.
+    pub const fn zero() -> Self {
+        Self([0; NODE_XOR_DISTANCE_ARRAY_SIZE])
+    }
 }
 
 impl PartialEq for XorDistance {

--- a/comms/src/peer_manager/peer.rs
+++ b/comms/src/peer_manager/peer.rs
@@ -160,7 +160,6 @@ impl Peer {
 
     pub fn update(
         &mut self,
-        node_id: Option<NodeId>,
         net_addresses: Option<Vec<Multiaddr>>,
         flags: Option<PeerFlags>,
         #[allow(clippy::option_option)] banned_until: Option<Option<Duration>>,
@@ -170,9 +169,6 @@ impl Peer {
         supported_protocols: Option<Vec<ProtocolId>>,
     )
     {
-        if let Some(new_node_id) = node_id {
-            self.node_id = new_node_id
-        }
         if let Some(new_net_addresses) = net_addresses {
             self.addresses.update_net_addresses(new_net_addresses)
         }
@@ -319,20 +315,17 @@ mod test {
         let net_address1 = "/ip4/124.0.0.124/tcp/7000".parse::<Multiaddr>().unwrap();
         let mut peer: Peer = Peer::new(
             public_key1.clone(),
-            node_id,
+            node_id.clone(),
             MultiaddressesWithStats::from(net_address1.clone()),
             PeerFlags::default(),
             PeerFeatures::empty(),
             &[],
         );
 
-        let (_sk, public_key2) = RistrettoPublicKey::random_keypair(&mut rng);
-        let node_id2 = NodeId::from_key(&public_key2).unwrap();
         let net_address2 = "/ip4/125.0.0.125/tcp/8000".parse::<Multiaddr>().unwrap();
         let net_address3 = "/ip4/126.0.0.126/tcp/9000".parse::<Multiaddr>().unwrap();
 
         peer.update(
-            Some(node_id2.clone()),
             Some(vec![net_address2.clone(), net_address3.clone()]),
             None,
             Some(Some(Duration::from_secs(1000))),
@@ -343,7 +336,7 @@ mod test {
         );
 
         assert_eq!(peer.public_key, public_key1);
-        assert_eq!(peer.node_id, node_id2);
+        assert_eq!(peer.node_id, node_id);
         assert!(!peer
             .addresses
             .addresses

--- a/comms/src/peer_manager/peer_features.rs
+++ b/comms/src/peer_manager/peer_features.rs
@@ -36,6 +36,18 @@ bitflags! {
     }
 }
 
+impl PeerFeatures {
+    #[inline]
+    pub fn is_client(&self) -> bool {
+        self == &PeerFeatures::COMMUNICATION_CLIENT
+    }
+
+    #[inline]
+    pub fn is_node(&self) -> bool {
+        self == &PeerFeatures::COMMUNICATION_NODE
+    }
+}
+
 impl Default for PeerFeatures {
     fn default() -> Self {
         PeerFeatures::NONE

--- a/comms/src/pipeline/inbound.rs
+++ b/comms/src/pipeline/inbound.rs
@@ -97,7 +97,7 @@ mod test {
         let items = vec![1, 2, 3, 4, 5, 6];
         let stream = stream::iter(items.clone()).fuse();
 
-        let (mut out_tx, out_rx) = mpsc::channel(items.len());
+        let (mut out_tx, mut out_rx) = mpsc::channel(items.len());
 
         let executor = Handle::current();
         let shutdown = Shutdown::new();

--- a/comms/src/pipeline/outbound.rs
+++ b/comms/src/pipeline/outbound.rs
@@ -132,7 +132,7 @@ mod test {
             (0..NUM_ITEMS).map(|i| OutboundMessage::new(Default::default(), Bytes::copy_from_slice(&i.to_be_bytes())));
         let stream = stream::iter(items).fuse();
         let (out_tx, out_rx) = mpsc::channel(NUM_ITEMS);
-        let (msg_tx, msg_rx) = mpsc::channel(NUM_ITEMS);
+        let (msg_tx, mut msg_rx) = mpsc::channel(NUM_ITEMS);
         let executor = Handle::current();
 
         let pipeline = Outbound::new(

--- a/comms/src/protocol/messaging/outbound.rs
+++ b/comms/src/protocol/messaging/outbound.rs
@@ -125,9 +125,9 @@ impl OutboundMessaging {
     async fn start_forwarding_messages(mut self, substream: Substream) -> Result<(), MessagingProtocolError> {
         let mut framed = MessagingProtocol::framed(substream);
         while let Some(mut out_msg) = self.request_rx.next().await {
-            trace!(
+            debug!(
                 target: LOG_TARGET,
-                "Sending message ({} bytes) ({:?}) on outbound messaging substream",
+                "Sending message ({} bytes) ({}) on outbound messaging substream",
                 out_msg.body.len(),
                 out_msg.tag,
             );

--- a/comms/src/protocol/messaging/protocol.rs
+++ b/comms/src/protocol/messaging/protocol.rs
@@ -375,8 +375,8 @@ impl MessagingProtocol {
                 );
                 match self.peer_manager.find_by_node_id(&node_id).await {
                     Ok(peer) => {
-                        // For an inbound substream, read messages from the peer and forward on the incoming_messages
-                        // channel
+                        // For an inbound substream, read messages from the peer and forward on the
+                        // incoming_messages channel
                         self.spawn_inbound_handler(Arc::new(peer), substream).await;
                     },
                     Err(PeerManagerError::PeerNotFoundError) => {

--- a/comms/src/protocol/messaging/test.rs
+++ b/comms/src/protocol/messaging/test.rs
@@ -262,7 +262,7 @@ async fn send_message_substream_bulk_failure() {
 #[runtime::test_basic]
 async fn many_concurrent_send_message_requests() {
     const NUM_MSGS: usize = 100;
-    let (_, _, conn_man_mock, _, mut request_tx, _, events_rx, _shutdown) = spawn_messaging_protocol().await;
+    let (_, _, conn_man_mock, _, mut request_tx, _, mut events_rx, _shutdown) = spawn_messaging_protocol().await;
 
     let node_identity1 = build_node_identity(PeerFeatures::COMMUNICATION_NODE);
     let node_identity2 = build_node_identity(PeerFeatures::COMMUNICATION_NODE);
@@ -292,7 +292,7 @@ async fn many_concurrent_send_message_requests() {
 
     // Check that the node got the messages
     let stream = peer_conn_mock2.next_incoming_substream().await.unwrap();
-    let framed = MessagingProtocol::framed(stream);
+    let mut framed = MessagingProtocol::framed(stream);
     let messages = collect_stream!(framed, take = NUM_MSGS, timeout = Duration::from_secs(10));
     assert_eq!(messages.len(), NUM_MSGS);
 
@@ -319,7 +319,7 @@ async fn many_concurrent_send_message_requests() {
 #[runtime::test_basic]
 async fn many_concurrent_send_message_requests_that_fail() {
     const NUM_MSGS: usize = 100;
-    let (_, _, _, _, mut request_tx, _, events_rx, _shutdown) = spawn_messaging_protocol().await;
+    let (_, _, _, _, mut request_tx, _, mut events_rx, _shutdown) = spawn_messaging_protocol().await;
 
     let node_id2 = node_id::random();
 

--- a/comms/src/test_utils/mocks/connection_manager.rs
+++ b/comms/src/test_utils/mocks/connection_manager.rs
@@ -90,7 +90,7 @@ impl ConnectionManagerMockState {
     }
 
     #[allow(dead_code)]
-    pub fn publish_event(&mut self, event: ConnectionManagerEvent) {
+    pub fn publish_event(&self, event: ConnectionManagerEvent) {
         self.event_tx.send(Arc::new(event)).unwrap();
     }
 }
@@ -133,18 +133,17 @@ impl ConnectionManagerMock {
         match req {
             DialPeer(node_id, reply_tx) => {
                 // Send Ok(conn) if we have an active connection, otherwise Err(DialConnectFailedAllAddresses)
-                reply_tx
-                    .send(
-                        self.state
-                            .active_conns
-                            .lock()
-                            .await
-                            .get(&node_id)
-                            .map(Clone::clone)
-                            .ok_or_else(|| ConnectionManagerError::DialConnectFailedAllAddresses),
-                    )
-                    .unwrap();
+                let _ = reply_tx.send(
+                    self.state
+                        .active_conns
+                        .lock()
+                        .await
+                        .get(&node_id)
+                        .map(Clone::clone)
+                        .ok_or_else(|| ConnectionManagerError::DialConnectFailedAllAddresses),
+                );
             },
+            CancelDial(_) => {},
             NotifyListening(_reply_tx) => {},
             GetActiveConnection(node_id, reply_tx) => {
                 reply_tx
@@ -159,9 +158,8 @@ impl ConnectionManagerMock {
             GetNumActiveConnections(reply_tx) => {
                 reply_tx.send(self.state.active_conns.lock().await.len()).unwrap();
             },
-            DisconnectPeer(node_id, reply_tx) => {
+            DisconnectPeer(node_id) => {
                 let _ = self.state.active_conns.lock().await.remove(&node_id);
-                reply_tx.send(Ok(())).unwrap();
             },
         }
     }

--- a/comms/src/test_utils/mocks/connectivity_manager.rs
+++ b/comms/src/test_utils/mocks/connectivity_manager.rs
@@ -1,0 +1,183 @@
+// Copyright 2020, The Tari Project
+//
+// Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+// following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+// disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+// following disclaimer in the documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+// products derived from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+// INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+// WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+// USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+use crate::{
+    connection_manager::{ConnectionManagerError, PeerConnection},
+    connectivity::{ConnectivityEvent, ConnectivityRequest, ConnectivityRequester},
+    peer_manager::NodeId,
+};
+use futures::{channel::mpsc, lock::Mutex, stream::Fuse, StreamExt};
+use std::{
+    collections::HashMap,
+    sync::{
+        atomic::{AtomicUsize, Ordering},
+        Arc,
+    },
+};
+use tokio::{sync::broadcast, task};
+
+pub fn create_connectivity_mock() -> (ConnectivityRequester, ConnectivityManagerMock) {
+    let (tx, rx) = mpsc::channel(10);
+    let (event_tx, _) = broadcast::channel(10);
+    (
+        ConnectivityRequester::new(tx, event_tx.clone()),
+        ConnectivityManagerMock::new(rx.fuse(), event_tx),
+    )
+}
+
+#[derive(Debug, Clone)]
+pub struct ConnectivityManagerMockState {
+    call_count: Arc<AtomicUsize>,
+    calls: Arc<Mutex<Vec<String>>>,
+    active_conns: Arc<Mutex<HashMap<NodeId, PeerConnection>>>,
+    selected_connections: Arc<Mutex<Vec<PeerConnection>>>,
+    managed_peers: Arc<Mutex<Vec<NodeId>>>,
+    event_tx: broadcast::Sender<Arc<ConnectivityEvent>>,
+}
+
+impl ConnectivityManagerMockState {
+    pub fn new(event_tx: broadcast::Sender<Arc<ConnectivityEvent>>) -> Self {
+        Self {
+            call_count: Arc::new(AtomicUsize::new(0)),
+            calls: Arc::new(Mutex::new(Vec::new())),
+            event_tx,
+            selected_connections: Arc::new(Mutex::new(Vec::new())),
+            managed_peers: Arc::new(Mutex::new(Vec::new())),
+            active_conns: Arc::new(Mutex::new(HashMap::new())),
+        }
+    }
+
+    fn inc_call_count(&self) {
+        self.call_count.fetch_add(1, Ordering::SeqCst);
+    }
+
+    async fn add_call(&self, call_str: String) {
+        self.calls.lock().await.push(call_str);
+    }
+
+    pub async fn take_calls(&self) -> Vec<String> {
+        self.calls.lock().await.drain(..).collect()
+    }
+
+    pub async fn get_selected_connections(&self) -> Vec<PeerConnection> {
+        self.selected_connections.lock().await.clone()
+    }
+
+    pub async fn set_selected_connections(&self, conns: Vec<PeerConnection>) {
+        *self.selected_connections.lock().await = conns;
+    }
+
+    pub async fn get_managed_peers(&self) -> Vec<NodeId> {
+        self.managed_peers.lock().await.clone()
+    }
+
+    #[allow(dead_code)]
+    pub fn call_count(&self) -> usize {
+        self.call_count.load(Ordering::SeqCst)
+    }
+
+    #[allow(dead_code)]
+    pub async fn add_active_connection(&self, node_id: NodeId, conn: PeerConnection) {
+        self.active_conns.lock().await.insert(node_id, conn);
+    }
+
+    #[allow(dead_code)]
+    pub fn publish_event(&self, event: ConnectivityEvent) {
+        self.event_tx.send(Arc::new(event)).unwrap();
+    }
+}
+
+pub struct ConnectivityManagerMock {
+    receiver: Fuse<mpsc::Receiver<ConnectivityRequest>>,
+    state: ConnectivityManagerMockState,
+}
+
+impl ConnectivityManagerMock {
+    pub fn new(
+        receiver: Fuse<mpsc::Receiver<ConnectivityRequest>>,
+        event_tx: broadcast::Sender<Arc<ConnectivityEvent>>,
+    ) -> Self
+    {
+        Self {
+            receiver,
+            state: ConnectivityManagerMockState::new(event_tx),
+        }
+    }
+
+    pub fn get_shared_state(&self) -> ConnectivityManagerMockState {
+        self.state.clone()
+    }
+
+    pub fn spawn(self) {
+        task::spawn(Self::run(self));
+    }
+
+    pub async fn run(mut self) {
+        while let Some(req) = self.receiver.next().await {
+            self.handle_request(req).await;
+        }
+    }
+
+    async fn handle_request(&self, req: ConnectivityRequest) {
+        use ConnectivityRequest::*;
+        self.state.inc_call_count();
+        self.state.add_call(format!("{:?}", req)).await;
+        match req {
+            DialPeer(node_id, reply_tx) => {
+                // Send Ok(conn) if we have an active connection, otherwise Err(DialConnectFailedAllAddresses)
+                let _ = reply_tx.send(
+                    self.state
+                        .active_conns
+                        .lock()
+                        .await
+                        .get(&node_id)
+                        .map(Clone::clone)
+                        .ok_or_else(|| ConnectionManagerError::DialConnectFailedAllAddresses),
+                );
+            },
+            GetConnectivityStatus(_) => {},
+            AddManagedPeers(peers) => {
+                // TODO: we should not have to implement behaviour of the actor in the mock
+                //       but should rather have a _good_ way to check the call to the mock
+                //       was made with the correct arguments.
+                let mut lock = self.state.managed_peers.lock().await;
+                for peer in peers {
+                    if !lock.contains(&peer) {
+                        lock.push(peer.clone());
+                    }
+                }
+            },
+            RemovePeer(node_id) => {
+                let mut lock = self.state.managed_peers.lock().await;
+                if let Some(pos) = lock.iter().position(|n| n == &node_id) {
+                    lock.remove(pos);
+                }
+            },
+            SelectConnections(_, reply_tx) => {
+                let _ = reply_tx.send(Ok(self.state.get_selected_connections().await));
+            },
+            GetConnection(_, _) => {},
+            GetAllConnectionStates(_) => {},
+            BanPeer(_, _) => {},
+        }
+    }
+}

--- a/comms/src/test_utils/mocks/mod.rs
+++ b/comms/src/test_utils/mocks/mod.rs
@@ -23,5 +23,13 @@
 mod connection_manager;
 pub use connection_manager::{create_connection_manager_mock, ConnectionManagerMock, ConnectionManagerMockState};
 
+mod connectivity_manager;
+pub use connectivity_manager::{create_connectivity_mock, ConnectivityManagerMock, ConnectivityManagerMockState};
+
 mod peer_connection;
-pub use peer_connection::{create_peer_connection_mock_pair, PeerConnectionMock, PeerConnectionMockState};
+pub use peer_connection::{
+    create_dummy_peer_connection,
+    create_peer_connection_mock_pair,
+    PeerConnectionMock,
+    PeerConnectionMockState,
+};

--- a/comms/src/test_utils/mod.rs
+++ b/comms/src/test_utils/mod.rs
@@ -25,10 +25,22 @@
 pub mod factories;
 
 cfg_test! {
-    pub mod node_id;
-    pub mod node_identity;
     pub mod test_node;
 }
 
 pub mod mocks;
+pub mod node_id;
+pub mod node_identity;
 pub mod transport;
+
+pub fn count_string_occurrences<T, U>(items: T, expected: &[&str]) -> usize
+where
+    T: AsRef<[U]>,
+    U: ToString,
+{
+    items
+        .as_ref()
+        .iter()
+        .filter(|event| expected.iter().any(|exp| event.to_string().contains(exp)))
+        .count()
+}

--- a/comms/src/test_utils/node_identity.rs
+++ b/comms/src/test_utils/node_identity.rs
@@ -21,7 +21,7 @@
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 use crate::{
-    peer_manager::{NodeIdentity, PeerFeatures},
+    peer_manager::{NodeId, NodeIdentity, PeerFeatures},
     transports::MemoryTransport,
 };
 use rand::rngs::OsRng;
@@ -37,5 +37,16 @@ pub fn build_node_identity(features: PeerFeatures) -> Arc<NodeIdentity> {
 pub fn ordered_node_identities(n: usize, features: PeerFeatures) -> Vec<Arc<NodeIdentity>> {
     let mut ids = (0..n).map(|_| build_node_identity(features)).collect::<Vec<_>>();
     ids.sort_unstable_by(|a, b| a.node_id().cmp(b.node_id()));
+    ids
+}
+
+pub fn ordered_node_identities_by_distance(
+    node_id: &NodeId,
+    n: usize,
+    features: PeerFeatures,
+) -> Vec<Arc<NodeIdentity>>
+{
+    let mut ids = (0..n).map(|_| build_node_identity(features)).collect::<Vec<_>>();
+    ids.sort_unstable_by(|a, b| a.node_id().distance(node_id).cmp(&b.node_id().distance(node_id)));
     ids
 }

--- a/comms/src/utils/datetime.rs
+++ b/comms/src/utils/datetime.rs
@@ -31,3 +31,33 @@ pub fn safe_future_datetime_from_duration(duration: Duration) -> DateTime<Utc> {
             .expect("cannot fail")
     })
 }
+
+pub fn format_duration(duration: Duration) -> String {
+    let secs = duration.as_secs();
+    if secs > 60 {
+        let mins = secs / 60;
+        if mins > 60 {
+            let hours = mins / 60;
+            format!("{}h {}m {}s", hours, mins % 60, secs % 60)
+        } else {
+            format!("{}m {}s", mins, secs % 60)
+        }
+    } else {
+        format!("{}s", secs)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn formats_duration() {
+        let s = format_duration(Duration::from_secs(5));
+        assert_eq!(s, "5s");
+        let s = format_duration(Duration::from_secs(23 * 60 + 10));
+        assert_eq!(s, "23m 10s");
+        let s = format_duration(Duration::from_secs(9 * 60 * 60 + 35 * 60 + 45));
+        assert_eq!(s, "9h 35m 45s");
+    }
+}

--- a/infrastructure/test_utils/src/futures/async_assert_eventually.rs
+++ b/infrastructure/test_utils/src/futures/async_assert_eventually.rs
@@ -69,3 +69,20 @@ macro_rules! async_assert_eventually {
         );
     }};
 }
+
+#[macro_export]
+macro_rules! async_assert {
+    ($check_expr:expr, max_attempts = $max_attempts:expr, interval = $interval:expr $(,)?) => {{
+        let mut attempts = 0;
+        while !($check_expr) {
+            attempts += 1;
+            if attempts > $max_attempts {
+                panic!(
+                    "Assertion failed. Expression was not true after {} attempts.",
+                    $max_attempts
+                );
+            }
+            tokio::time::delay_for($interval).await;
+        }
+    }};
+}

--- a/infrastructure/test_utils/src/streams/mod.rs
+++ b/infrastructure/test_utils/src/streams/mod.rs
@@ -47,7 +47,7 @@ where
 /// # use tari_test_utils::collect_stream;
 ///
 /// let mut rt = Runtime::new().unwrap();
-/// let stream = stream::iter(1..10);
+/// let mut stream = stream::iter(1..10);
 /// assert_eq!(rt.block_on(async { collect_stream!(stream, take=3, timeout=Duration::from_secs(1)) }), vec![1,2,3]);
 /// ```
 #[macro_export]
@@ -57,7 +57,7 @@ macro_rules! collect_stream {
         use tokio::time;
 
         // Evaluate $stream once, NOT in the loop 🐛🚨
-        let mut stream = $stream;
+        let mut stream = &mut $stream;
 
         let mut items = Vec::new();
         loop {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR adds two connectivity modules to the comms and DHT stack and
integrates them with the rest of the stack where necessary.

**Comms Connectivity**

The ConnectivityManager actor is responsible for:
- Tracking the state of all peer connections in the system and maintaining a _managed pool_ of peer connections.
- It provides a simple interface to fetch active peer connections. Selection includes selecting a
  single peer, random selection and selecting connections closer to a `NodeId`.
- Periodic "reaping" of inactive connections
- Tracking peer connection failures and marking peers as offline
  (emitting a PeerOffline event)

Events for monitoring the state of individual connections as well as the
state of the network (i.e `Offline`, `Degraded`, `Online`) are emitted.

The DHT integrates with this to establish network connectivity.

**DHT connectivity**

Responsible for ensuring DHT network connectivity to a neighbouring and random peer set.
This includes joining the network when the node has established some
peer connections (e.g to seed peers).

It maintains neighbouring and random peer pools and instructs the
comms `ConnectivityManager` to establish those connections. Once
a configured percentage of these peers is online, the node is
established on the DHT network.

The DHT connectivity actor  monitors the connectivity state (using `ConnectivityEvent`)
and attempts to maintain connectivity to the network as peers come and
go.

- [dht] Integrate with the Propagate and Broadcast selectors in the DHT
  actor. This allows highly efficient selection of peers to pre-established
  and available connections. However, a node should be online before it
  requests to propagate or broadcast.
- [dht] Reduce memory footprint of peer selection, by only returning
  the NodeId rather than the whole peer
- [comms] Don't track failed/successful peer connections using peer
  manager (extra db writes, responsibility of connectivity manager)
- [base node] Only ban sync peers that time out if the node is online.
- [p2p] Remove peer pools from Liveness service. It simply asks the
  connectivity manager for a set of peers to interact with each round.
- [p2p] Liveness service is no-longer responsible for joining the DHT network.
- [p2p] Add seed peers to initialise functions so that seed peers are known
  before comms/dht start up.
- [tests] Remove clunky pre-connect code replaced with `wait_until_online`
- [examples] Update memorynet

Related TODO:
- Write some unit tests for DHT connectivity
- Implement closing of messaging substreams after period of inactivity to allow connectivity to reap unused connections
- NodeId can be a Copy type

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Comms connectivity actor has been tested, but could be improved. Dht connectivity must still get some tests (Next up). Existing tests updated and pass. memorynet passes.  

## Motivation and Context

Closes #1440 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [x] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [x] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch.
* [x] I ran `cargo-fmt --all` before pushing.
* [x] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [~] I have added tests to cover my changes.
