### PR TITLE
Update transaction_send_protocol to apply timeout on DirectSend attempts

### DIFF
--- a/base_layer/wallet/src/transaction_service/config.rs
+++ b/base_layer/wallet/src/transaction_service/config.rs
@@ -24,21 +24,19 @@ use std::time::Duration;
 
 #[derive(Clone)]
 pub struct TransactionServiceConfig {
-    // This is the timeout of the first broadcast which should be short
-    pub initial_mempool_broadcast_timeout: Duration,
-    // Subsequent timeouts should be longer
     pub mempool_broadcast_timeout: Duration,
-    pub initial_base_node_mined_timeout: Duration,
     pub base_node_mined_timeout: Duration,
+    pub direct_send_timeout: Duration,
+    pub broadcast_send_timeout: Duration,
 }
 
 impl Default for TransactionServiceConfig {
     fn default() -> Self {
         Self {
-            initial_mempool_broadcast_timeout: Duration::from_secs(5),
             mempool_broadcast_timeout: Duration::from_secs(30),
-            initial_base_node_mined_timeout: Duration::from_secs(5),
             base_node_mined_timeout: Duration::from_secs(30),
+            direct_send_timeout: Duration::from_secs(20),
+            broadcast_send_timeout: Duration::from_secs(30),
         }
     }
 }

--- a/base_layer/wallet/src/transaction_service/service.rs
+++ b/base_layer/wallet/src/transaction_service/service.rs
@@ -182,6 +182,7 @@ where
             event_publisher: event_publisher.clone(),
             node_identity: node_identity.clone(),
             factories: factories.clone(),
+            config: config.clone(),
         };
         TransactionService {
             config,
@@ -1696,4 +1697,5 @@ where TBackend: TransactionBackend + Clone + 'static
     pub event_publisher: TransactionEventSender,
     pub node_identity: Arc<NodeIdentity>,
     pub factories: CryptoFactories,
+    pub config: TransactionServiceConfig,
 }

--- a/base_layer/wallet/tests/transaction_service/service.rs
+++ b/base_layer/wallet/tests/transaction_service/service.rs
@@ -262,7 +262,8 @@ pub fn setup_transaction_service_no_comms<T: TransactionBackend + Clone + 'stati
         TransactionServiceConfig {
             mempool_broadcast_timeout: Duration::from_secs(5),
             base_node_mined_timeout: mined_request_timeout.unwrap_or(Duration::from_secs(5)),
-            ..Default::default()
+            direct_send_timeout: Duration::from_secs(5),
+            broadcast_send_timeout: Duration::from_secs(5),
         },
         TransactionDatabase::new(backend),
         ts_request_receiver,
@@ -3197,4 +3198,212 @@ fn test_direct_vs_saf_send_of_tx_reply_and_finalize() {
 
     // Should be 2 messages sent, Direct and SAF
     let _ = alice_outbound_service.wait_call_count(2, Duration::from_secs(60));
+}
+
+#[test]
+fn test_tx_direct_send_behaviour() {
+    let factories = CryptoFactories::default();
+    let mut runtime = Runtime::new().unwrap();
+
+    let bob_node_identity =
+        NodeIdentity::random(&mut OsRng, get_next_memory_address(), PeerFeatures::COMMUNICATION_NODE).unwrap();
+
+    let (
+        mut alice_ts,
+        mut alice_output_manager,
+        alice_outbound_service,
+        mut _alice_tx_sender,
+        mut _alice_tx_ack_sender,
+        _,
+        _,
+        _,
+        _,
+        _,
+        _,
+    ) = setup_transaction_service_no_comms(
+        &mut runtime,
+        factories.clone(),
+        TransactionMemoryDatabase::new(),
+        Some(Duration::from_secs(5)),
+    );
+    let mut alice_event_stream = alice_ts.get_event_stream_fused();
+
+    let (_utxo, uo) = make_input(&mut OsRng, 1000000 * uT, &factories.commitment);
+    runtime.block_on(alice_output_manager.add_output(uo)).unwrap();
+    let (_utxo, uo) = make_input(&mut OsRng, 1000000 * uT, &factories.commitment);
+    runtime.block_on(alice_output_manager.add_output(uo)).unwrap();
+    let (_utxo, uo) = make_input(&mut OsRng, 1000000 * uT, &factories.commitment);
+    runtime.block_on(alice_output_manager.add_output(uo)).unwrap();
+    let (_utxo, uo) = make_input(&mut OsRng, 1000000 * uT, &factories.commitment);
+    runtime.block_on(alice_output_manager.add_output(uo)).unwrap();
+
+    let amount_sent = 10000 * uT;
+
+    alice_outbound_service.set_behaviour(MockBehaviour {
+        direct: ResponseType::Failed,
+        broadcast: ResponseType::Failed,
+    });
+
+    let _tx_id = runtime
+        .block_on(alice_ts.send_transaction(
+            bob_node_identity.public_key().clone(),
+            amount_sent,
+            100 * uT,
+            "Testing Message1".to_string(),
+        ))
+        .unwrap();
+
+    runtime.block_on(async {
+        let mut delay = delay_for(Duration::from_secs(60)).fuse();
+        let mut direct_count = 0;
+        let mut saf_count = 0;
+        loop {
+            futures::select! {
+                event = alice_event_stream.select_next_some() => {
+                    match &*event.unwrap() {
+                        TransactionEvent::TransactionDirectSendResult(_, result) => if (!result) { direct_count+=1 },
+                        TransactionEvent::TransactionStoreForwardSendResult(_, result) => if (!result) { saf_count+=1 },
+                        _ => (),
+                    }
+
+                    if direct_count == 1 && saf_count == 1 {
+                        break;
+                    }
+                },
+                () = delay => {
+                    break;
+                },
+            }
+        }
+        assert_eq!(direct_count, 1, "Should be 1 failed direct");
+        assert_eq!(saf_count, 1, "Should be 1 failed saf");
+    });
+
+    alice_outbound_service.set_behaviour(MockBehaviour {
+        direct: ResponseType::QueuedFail,
+        broadcast: ResponseType::Queued,
+    });
+
+    let _tx_id = runtime
+        .block_on(alice_ts.send_transaction(
+            bob_node_identity.public_key().clone(),
+            amount_sent,
+            100 * uT,
+            "Testing Message2".to_string(),
+        ))
+        .unwrap();
+
+    alice_outbound_service
+        .wait_call_count(1, Duration::from_secs(60))
+        .unwrap();
+
+    runtime.block_on(async {
+        let mut delay = delay_for(Duration::from_secs(60)).fuse();
+        let mut direct_count = 0;
+        let mut saf_count = 0;
+        loop {
+            futures::select! {
+                event = alice_event_stream.select_next_some() => {
+                    match &*event.unwrap() {
+                        TransactionEvent::TransactionDirectSendResult(_, result) => if (!result) { direct_count+=1 },
+                        TransactionEvent::TransactionStoreForwardSendResult(_, result) => if *result { saf_count+=1 },
+                        _ => (),
+                    }
+
+                    if direct_count == 1 && saf_count == 1 {
+                        break;
+                    }
+                },
+                () = delay => {
+                    break;
+                },
+            }
+        }
+        assert_eq!(direct_count, 1, "Should be 1 failed direct");
+        assert_eq!(saf_count, 1, "Should be 1 succeeded saf");
+    });
+
+    alice_outbound_service.set_behaviour(MockBehaviour {
+        direct: ResponseType::QueuedSuccessDelay(Duration::from_secs(1)),
+        broadcast: ResponseType::Queued,
+    });
+
+    let _tx_id = runtime
+        .block_on(alice_ts.send_transaction(
+            bob_node_identity.public_key().clone(),
+            amount_sent,
+            100 * uT,
+            "Testing Message3".to_string(),
+        ))
+        .unwrap();
+
+    alice_outbound_service
+        .wait_call_count(1, Duration::from_secs(60))
+        .unwrap();
+
+    runtime.block_on(async {
+        let mut delay = delay_for(Duration::from_secs(60)).fuse();
+        let mut direct_count = 0;
+        loop {
+            futures::select! {
+                event = alice_event_stream.select_next_some() => {
+                    match &*event.unwrap() {
+                        TransactionEvent::TransactionDirectSendResult(_, result) => if *result { direct_count+=1 },
+                        TransactionEvent::TransactionStoreForwardSendResult(_, _) => assert!(false, "Should be no SAF messages"),
+                        _ => (),
+                    }
+
+                    if direct_count >= 1  {
+                        break;
+                    }
+                },
+                () = delay => {
+                    break;
+                },
+            }
+        }
+        assert_eq!(direct_count, 1, "Should be 1 succeeded direct");
+    });
+
+    alice_outbound_service.set_behaviour(MockBehaviour {
+        direct: ResponseType::QueuedSuccessDelay(Duration::from_secs(30)),
+        broadcast: ResponseType::Queued,
+    });
+
+    let _tx_id = runtime
+        .block_on(alice_ts.send_transaction(
+            bob_node_identity.public_key().clone(),
+            amount_sent,
+            100 * uT,
+            "Testing Message4".to_string(),
+        ))
+        .unwrap();
+
+    alice_outbound_service
+        .wait_call_count(1, Duration::from_secs(60))
+        .unwrap();
+
+    runtime.block_on(async {
+        let mut delay = delay_for(Duration::from_secs(60)).fuse();
+        let mut saf_count = 0;
+        loop {
+            futures::select! {
+                event = alice_event_stream.select_next_some() => {
+                    match &*event.unwrap() {
+                        TransactionEvent::TransactionStoreForwardSendResult(_, result) => if *result { saf_count+=1 },
+                        TransactionEvent::TransactionDirectSendResult(_, result) => if *result { assert!(false, "Should be no direct messages") },
+                        _ => (),
+                    }
+
+                    if saf_count >= 1  {
+                        break;
+                    }
+                },
+                () = delay => {
+                    break;
+                },
+            }
+        }
+        assert_eq!(saf_count, 1, "Should be 1 succeeded saf");
+    });
 }

--- a/base_layer/wallet_ffi/src/lib.rs
+++ b/base_layer/wallet_ffi/src/lib.rs
@@ -165,6 +165,7 @@ use tari_wallet::{
         receive_test_transaction,
     },
     transaction_service::{
+        config::TransactionServiceConfig,
         error::TransactionServiceError,
         storage::{
             database::{
@@ -2368,7 +2369,10 @@ pub unsafe extern "C" fn wallet_create(
                 WalletConfig {
                     comms_config: (*config).clone(),
                     factories,
-                    transaction_service_config: None,
+                    transaction_service_config: Some(TransactionServiceConfig {
+                        direct_send_timeout: (*config).dht.discovery_request_timeout.clone(),
+                        ..Default::default()
+                    }),
                 },
                 runtime,
                 wallet_backend,


### PR DESCRIPTION
## Description
Previously the transaction service would rely on the timeouts within the comms stack to timeout direct send attempts. However it was found that occasionally Tor would take up to 2 minutes to decide that a discovered host was actually unreachable. 2 Minutes over 3 attempts by the Messaging protocol was too long to be tolerated by the Mobile Clients.

This PR adds a timeout to all attempts to SendDirect within the Transaction_Send_Protocol. Now when a peer is discovery and the message is queued to be sent the Transaction Service will wait the same time as the provided `Discovery Request Timout` before it will fire the event to tell the mobile clients the direct send has failed and it will now attempt a Store and Forward send. 

This timeout does not actually stop the direct send which might still potentially go through. Whether the direct or SAF message is the one that makes it to the Recipient does not matter to the Transaction Service.

## How Has This Been Tested?
The Mock outbound requester was updated to allow it to react in all the ways that the real comms outbound requester could react: Queued and then success, Queued and the fail, Fail and then Queued and long delay before success.
Test was written that tests the reaction to all 4 these cases.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [x] New Tests
* [x] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch.
* [x] I ran `cargo-fmt --all` before pushing.
* [ ] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
