### PR TITLE
Interleaved add block fix

### DIFF
--- a/base_layer/core/src/chain_storage/blockchain_database.rs
+++ b/base_layer/core/src/chain_storage/blockchain_database.rs
@@ -446,6 +446,7 @@ where T: BlockchainBackend
     ///
     /// If an error does occur while writing the new block parts, all changes are reverted before returning.
     pub fn add_block(&self, block: Block) -> Result<BlockAddResult, ChainStorageError> {
+        let mut db = self.db_write_access()?;
         // Perform orphan block validation.
         if let Err(e) = self.validators.orphan.validate(&block) {
             warn!(
@@ -458,7 +459,6 @@ where T: BlockchainBackend
             return Err(e.into());
         }
 
-        let mut db = self.db_write_access()?;
         add_block(
             &mut db,
             &self.validators.block,


### PR DESCRIPTION
## Description
Moved the write lock to ensure that add block operations do not interleave and cause the validation status to change. 

## Motivation and Context
The validation status of a newly added block might change if two different async add block operations are interleaved.

## How Has This Been Tested?
Existing tests remain functioning.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch.
* [x] I ran `cargo-fmt --all` before pushing.
* [x] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
