### PR TITLE
Messaging protocol substreams close after a period of inactivity

### DIFF
--- a/applications/tari_base_node/src/builder.rs
+++ b/applications/tari_base_node/src/builder.rs
@@ -496,6 +496,11 @@ where
     let base_node_subscriptions = Arc::new(base_node_subscriptions);
     create_peer_db_folder(&config.peer_db_path)?;
     let (base_node_comms, base_node_dht) = setup_base_node_comms(base_node_identity, config, publisher).await?;
+    base_node_comms
+        .connectivity()
+        .add_managed_peers(vec![wallet_node_identity.node_id().clone()])
+        .await
+        .map_err(|err| err.to_string())?;
 
     debug!(target: LOG_TARGET, "Registering base node services");
     let base_node_handles = register_base_node_services(

--- a/comms/Cargo.toml
+++ b/comms/Cargo.toml
@@ -35,7 +35,7 @@ rand = "0.7.2"
 serde = "1.0.90"
 serde_derive = "1.0.90"
 snow = {version="=0.6.2", features=["default-resolver"]}
-tokio = {version="~0.2.19", features=["blocking", "tcp", "stream", "dns", "sync", "stream", "signal"]}
+tokio = {version="~0.2.19", features=["blocking", "time", "tcp", "dns", "sync", "stream", "signal"]}
 tokio-util = {version="0.2.0", features=["codec"]}
 tower= "0.3.1"
 yamux = "=0.4.5"

--- a/comms/src/builder/consts.rs
+++ b/comms/src/builder/consts.rs
@@ -44,6 +44,3 @@ pub const MESSAGING_EVENTS_BUFFER_SIZE: usize = 100;
 /// Buffer size for requests to the messaging protocol. All outbound messages will be sent along this channel. Some
 /// buffering may be required if the node needs to send many messages out at the same time.
 pub const MESSAGING_REQUEST_BUFFER_SIZE: usize = 50;
-/// The default maximum number of times to retry sending a failed message before publishing a SendMessageFailed event.
-/// This can be low because dialing a peer is already attempted a number of times.
-pub const MESSAGING_MAX_SEND_RETRIES: usize = 1;

--- a/comms/src/builder/mod.rs
+++ b/comms/src/builder/mod.rs
@@ -274,7 +274,6 @@ where
             messaging_request_rx,
             event_tx.clone(),
             inbound_message_tx,
-            consts::MESSAGING_MAX_SEND_RETRIES,
             self.shutdown.to_signal(),
         );
 

--- a/comms/src/connectivity/connection_pool.rs
+++ b/comms/src/connectivity/connection_pool.rs
@@ -132,7 +132,7 @@ impl ConnectionPool {
         self.connections.contains_key(node_id)
     }
 
-    pub fn insert_connection(&mut self, conn: PeerConnection) {
+    pub fn insert_connection(&mut self, conn: PeerConnection) -> ConnectionStatus {
         match self.connections.entry(conn.peer_node_id().clone()) {
             Entry::Occupied(mut entry) => {
                 let entry_mut = entry.get_mut();
@@ -142,10 +142,9 @@ impl ConnectionPool {
                     ConnectionStatus::Disconnected
                 };
                 entry_mut.set_connection(conn);
+                entry_mut.status
             },
-            Entry::Vacant(entry) => {
-                entry.insert(PeerConnectionState::connected(conn));
-            },
+            Entry::Vacant(entry) => entry.insert(PeerConnectionState::connected(conn)).status,
         }
     }
 

--- a/comms/src/runtime.rs
+++ b/comms/src/runtime.rs
@@ -22,6 +22,11 @@
 
 use tokio::runtime;
 
+// Re-export
+pub use tokio::task;
+#[cfg(test)]
+pub use tokio_macros::test_basic;
+
 /// Return the current tokio executor. Panics if the tokio runtime is not started.
 #[inline]
 pub fn current_executor() -> runtime::Handle {


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
- Inbound and outbound messaging protocol handlers are closed after a
  period of inactivity (5 mins)
- This allows connectivity manager to close connections if they are
  not on the managed peer list, and they have no open substreams.
- The base node wallet is added to managed peer list on startup. This is important because the base node/wallet should not disconnect if inactive. 
- Check that connections for managed peers are never reaped
- Use the correct event for managed peers connection
  fail/disconnect in DHT connectivity
- When a peer disconnects (as opposed to fails to connect), remove and replace with another peer if able. A connection to the peer may be retried at any point in the future and the peer will be free to reconnect at any time.
- Moved messaging related constants in the `messaging::protocol` module

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This brings the connectivity manager and substream counts features together to allow the connectivity manager to safely close/reap connections without cutting someone off. Messaging substreams can be reestablished later before the connection is reaped if needed. This cuts down on the number of idle pending tasks that the node has to keep in memory.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested inactivity timeout. Observing base node behaviour.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [x] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [x] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch.
* [x] I ran `cargo-fmt --all` before pushing.
* [x] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
