### PR TITLE
Normalise log message levels

### DIFF
--- a/applications/tari_base_node/src/main.rs
+++ b/applications/tari_base_node/src/main.rs
@@ -144,7 +144,7 @@ fn main_inner() -> Result<(), ExitCodes> {
         ExitCodes::ConfigError
     })?;
 
-    trace!(target: LOG_TARGET, "Using configuration: {:?}", node_config);
+    debug!(target: LOG_TARGET, "Using configuration: {:?}", node_config);
 
     // Set up the Tokio runtime
     let mut rt = setup_runtime(&node_config).map_err(|err| {
@@ -248,7 +248,7 @@ fn setup_runtime(config: &GlobalConfig) -> Result<Runtime, String> {
     let num_blocking_threads = config.blocking_threads;
     let num_mining_threads = config.num_mining_threads;
 
-    debug!(
+    info!(
         target: LOG_TARGET,
         "Configuring the node to run on {} core threads, {} blocking worker threads and {} mining threads.",
         num_core_threads,

--- a/applications/tari_base_node/src/utils.rs
+++ b/applications/tari_base_node/src/utils.rs
@@ -48,7 +48,7 @@ where S: Stream<Item = Result<Arc<TransactionEvent>, RecvError>> + Unpin {
                     }
                 },
                 Err(e) => {
-                    log::error!(target: LOG_TARGET, "Error reading from event broadcast channel {:?}", e);
+                    log::warn!(target: LOG_TARGET, "Error reading from event broadcast channel {:?}", e);
                     break false;
                 },
             },

--- a/base_layer/core/src/base_node/chain_metadata_service/service.rs
+++ b/base_layer/core/src/base_node/chain_metadata_service/service.rs
@@ -27,7 +27,7 @@ use crate::{
         comms_interface::{BlockEvent, LocalNodeCommsInterface},
         proto,
     },
-    chain_storage::BlockAddResult,
+    chain_storage::{BlockAddResult, ChainMetadata},
 };
 use chrono::{NaiveDateTime, Utc};
 use futures::{stream::StreamExt, SinkExt};
@@ -211,9 +211,11 @@ impl ChainMetadataService {
     ) -> Result<(), ChainMetadataSyncError>
     {
         if let Some(chain_metadata_bytes) = metadata.get(MetadataKey::ChainMetadata) {
-            let chain_metadata = proto::ChainMetadata::decode(chain_metadata_bytes.as_slice())?.into();
-            debug!(target: LOG_TARGET, "Received chain metadata from NodeId '{}'", node_id);
-            trace!(target: LOG_TARGET, "{}", chain_metadata);
+            let chain_metadata: ChainMetadata = proto::ChainMetadata::decode(chain_metadata_bytes.as_slice())?.into();
+            debug!(
+                target: LOG_TARGET,
+                "Received chain metadata from NodeId '{}' - #{:?}", node_id, chain_metadata.height_of_longest_chain
+            );
 
             if let Some(pos) = self
                 .peer_chain_metadata
@@ -239,9 +241,11 @@ impl ChainMetadataService {
             .get(MetadataKey::ChainMetadata)
             .ok_or_else(|| ChainMetadataSyncError::NoChainMetadata)?;
 
-        let chain_metadata = proto::ChainMetadata::decode(chain_metadata_bytes.as_slice())?.into();
-        debug!(target: LOG_TARGET, "Received chain metadata from NodeId '{}'", node_id);
-        trace!(target: LOG_TARGET, "{}", chain_metadata);
+        let chain_metadata: ChainMetadata = proto::ChainMetadata::decode(chain_metadata_bytes.as_slice())?.into();
+        debug!(
+            target: LOG_TARGET,
+            "Received chain metadata from NodeId '{}' - #{:?}", node_id, chain_metadata.height_of_longest_chain
+        );
 
         if let Some(pos) = self
             .peer_chain_metadata

--- a/base_layer/core/src/base_node/service/service.rs
+++ b/base_layer/core/src/base_node/service/service.rs
@@ -562,7 +562,7 @@ async fn handle_incoming_block<B: BlockchainBackend + 'static>(
 {
     let DomainMessage::<_> { source_peer, inner, .. } = domain_block_msg;
 
-    info!(
+    debug!(
         "New candidate block #{} (accum_diff: {}, hash: ({})) received.",
         inner.header.height,
         inner.header.total_accumulated_difficulty_inclusive(),

--- a/base_layer/core/src/base_node/state_machine.rs
+++ b/base_layer/core/src/base_node/state_machine.rs
@@ -157,7 +157,7 @@ impl<B: BlockchainBackend + 'static> BaseNodeStateMachine<B> {
             if let Shutdown(reason) = &state {
                 debug!(
                     target: LOG_TARGET,
-                    "=== Base Node state machine is shutting down because {}", reason
+                    "Base Node state machine is shutting down because {}", reason
                 );
                 break;
             }
@@ -169,9 +169,11 @@ impl<B: BlockchainBackend + 'static> BaseNodeStateMachine<B> {
             let next_event = select_next_state_event(interrupt_signal, next_state_future).await;
             // Publish the event on the event bus
             let _ = self.event_sender.send(next_event.clone()).await;
-            debug!(
+            trace!(
                 target: LOG_TARGET,
-                "=== Base Node event in State [{}]:  {}", state, next_event
+                "Base Node event in State [{}]:  {}",
+                state,
+                next_event
             );
             state = self.transition(state, next_event);
         }

--- a/base_layer/core/src/base_node/states/forward_block_sync.rs
+++ b/base_layer/core/src/base_node/states/forward_block_sync.rs
@@ -113,7 +113,7 @@ async fn synchronize_blocks<B: BlockchainBackend + 'static>(
                             // than the headers we sent.
                             let oldest_header_sent = from_headers.last().unwrap();
                             if block.height == 0 && oldest_header_sent.height != 1 {
-                                info!(
+                                debug!(
                                     target: LOG_TARGET,
                                     "No headers from peer {} matched with the headers we sent. Retrying with older \
                                      headers",
@@ -122,7 +122,7 @@ async fn synchronize_blocks<B: BlockchainBackend + 'static>(
                                 from_headers = fetch_headers_to_send::<B>(oldest_header_sent, &shared.db);
                                 continue;
                             } else {
-                                info!(
+                                debug!(
                                     target: LOG_TARGET,
                                     "Chain split at height:{} according to sync peer:{}",
                                     block.height,
@@ -130,7 +130,7 @@ async fn synchronize_blocks<B: BlockchainBackend + 'static>(
                                 );
                             }
                         } else {
-                            info!(
+                            debug!(
                                 target: LOG_TARGET,
                                 "Still on the best chain according to sync peer:{}", sync_node_string
                             );
@@ -237,7 +237,7 @@ async fn download_blocks<B: BlockchainBackend + 'static>(
                         .await
                     {
                         Ok(result) => {
-                            info!(
+                            debug!(
                                 target: LOG_TARGET,
                                 "Added block {} during sync. Result:{:?}",
                                 header.to_hex(),

--- a/base_layer/core/src/base_node/states/listening.rs
+++ b/base_layer/core/src/base_node/states/listening.rs
@@ -70,7 +70,7 @@ impl ListeningData {
             match &*metadata_event {
                 ChainMetadataEvent::PeerChainMetadataReceived(ref peer_metadata_list) => {
                     if !peer_metadata_list.is_empty() {
-                        info!(target: LOG_TARGET, "Loading local blockchain metadata.");
+                        debug!(target: LOG_TARGET, "Loading local blockchain metadata.");
                         let local = match shared.db.get_metadata() {
                             Ok(m) => m,
                             Err(e) => {

--- a/base_layer/core/src/chain_storage/lmdb_db/lmdb_db.rs
+++ b/base_layer/core/src/chain_storage/lmdb_db/lmdb_db.rs
@@ -294,7 +294,7 @@ where D: Digest + Send + Sync
 
     // Reset any mmr txns that have been applied.
     fn reset_mmrs(&mut self) -> Result<(), ChainStorageError> {
-        debug!(target: LOG_TARGET, "Reset mmrs called");
+        trace!(target: LOG_TARGET, "Reset mmrs called");
         self.kernel_mmr.reset()?;
         self.utxo_mmr.reset()?;
         self.range_proof_mmr.reset()?;

--- a/base_layer/core/src/mempool/mempool_storage.rs
+++ b/base_layer/core/src/mempool/mempool_storage.rs
@@ -152,7 +152,7 @@ where T: BlockchainBackend
     pub fn process_reorg(&mut self, removed_blocks: Vec<Block>, new_blocks: Vec<Block>) -> Result<(), MempoolError> {
         debug!(target: LOG_TARGET, "Mempool processing reorg");
         for block in &removed_blocks {
-            trace!(
+            debug!(
                 target: LOG_TARGET,
                 "Mempool processing reorg removed block {} ({})",
                 block.header.height,
@@ -160,7 +160,7 @@ where T: BlockchainBackend
             );
         }
         for block in &new_blocks {
-            trace!(
+            debug!(
                 target: LOG_TARGET,
                 "Mempool processing reorg added new block {} ({})",
                 block.header.height,
@@ -185,7 +185,7 @@ where T: BlockchainBackend
         self.process_published_blocks(new_blocks)?;
 
         if new_tip_height < prev_tip_height {
-            trace!(
+            debug!(
                 target: LOG_TARGET,
                 "Checking for time locked transactions in unconfirmed pool as chain height was reduced from {} to {} \
                  during reorg.",

--- a/base_layer/core/src/mining/miner.rs
+++ b/base_layer/core/src/mining/miner.rs
@@ -137,7 +137,7 @@ impl Miner {
     ///     * or the loop is interrupted because a new block was found in the interim, or the miner is stopped
     async fn mining(mut self) -> Result<Miner, MinerError> {
         // Lets make sure its set to mine
-        debug!(target: LOG_TARGET, "Miner asking for new candidate block to mine.");
+        info!(target: LOG_TARGET, "Miner asking for new candidate block to mine.");
         let block_template = self.get_block_template().await;
         if block_template.is_err() {
             error!(

--- a/base_layer/core/src/validation/block_validators.rs
+++ b/base_layer/core/src/validation/block_validators.rs
@@ -80,7 +80,7 @@ impl StatelessValidation<Block> for StatelessBlockValidator {
         trace!(target: LOG_TARGET, "SV - Output constraints are ok for {} ", &block_id);
         check_cut_through(block)?;
         trace!(target: LOG_TARGET, "SV - Cut-through is ok for {} ", &block_id);
-        info!(
+        debug!(
             target: LOG_TARGET,
             "{} has PASSED stateless VALIDATION check.", &block_id
         );
@@ -116,21 +116,41 @@ impl<B: BlockchainBackend> Validation<Block, B> for FullConsensusValidator {
     fn validate(&self, block: &Block, db: &B) -> Result<(), ValidationError> {
         let block_id = format!("block #{} ({})", block.header.height, block.hash().to_hex());
         check_inputs_are_utxos(block, db)?;
-        trace!(target: LOG_TARGET, "FCV - All inputs are valid for {}", &block_id);
+        trace!(
+            target: LOG_TARGET,
+            "Block validation: All inputs are valid for {}",
+            &block_id
+        );
         check_mmr_roots(block, db)?;
-        trace!(target: LOG_TARGET, "FCV - MMR roots are valid for {}", &block_id);
+        trace!(
+            target: LOG_TARGET,
+            "Block validation: MMR roots are valid for {}",
+            &block_id
+        );
         check_timestamp_ftl(&block.header, &self.rules)?;
-        trace!(target: LOG_TARGET, "FCV - FTL timestamp is ok for {} ", &block_id);
+        trace!(
+            target: LOG_TARGET,
+            "Block validation: FTL timestamp is ok for {} ",
+            &block_id
+        );
         let tip_height = db
             .fetch_metadata()
             .map_err(|e| ValidationError::CustomError(e.to_string()))?
             .height_of_longest_chain
             .unwrap_or(0);
         check_median_timestamp(db, &block.header, tip_height, self.rules.clone())?;
-        trace!(target: LOG_TARGET, "FCV - Median timestamp is ok for {} ", &block_id);
+        trace!(
+            target: LOG_TARGET,
+            "Block validation: Median timestamp is ok for {} ",
+            &block_id
+        );
         check_achieved_and_target_difficulty(db, &block.header, tip_height, self.rules.clone())?;
-        trace!(target: LOG_TARGET, "FCV - Achieved difficulty is ok for {} ", &block_id);
-        info!(target: LOG_TARGET, "FCV - Block is VALID for {}", &block_id);
+        trace!(
+            target: LOG_TARGET,
+            "Block validation: Achieved difficulty is ok for {} ",
+            &block_id
+        );
+        debug!(target: LOG_TARGET, "Block validation: Block is VALID for {}", &block_id);
         Ok(())
     }
 }

--- a/base_layer/mmr/src/merkle_mountain_range.rs
+++ b/base_layer/mmr/src/merkle_mountain_range.rs
@@ -233,10 +233,9 @@ where
     }
 
     fn push_hash(&mut self, hash: Hash) -> Result<usize, MerkleMountainRangeError> {
-        self.hashes.push(hash).map_err(|e| {
-            error!(target: LOG_TARGET, "{:?}", e);
-            MerkleMountainRangeError::BackendError(e.to_string())
-        })
+        self.hashes
+            .push(hash)
+            .map_err(|e| MerkleMountainRangeError::BackendError(e.to_string()))
     }
 
     pub fn clear(&mut self) -> Result<(), MerkleMountainRangeError> {

--- a/base_layer/mmr/src/merkle_proof.rs
+++ b/base_layer/mmr/src/merkle_proof.rs
@@ -251,10 +251,6 @@ impl MerkleProof {
         let sibling = self.path.remove(0); // FIXME Compare perf vs using a VecDeque
         let (parent_pos, sibling_pos) = family(pos);
         if parent_pos > self.mmr_size {
-            error!(
-                "Found edge case. pos: {}, peaks: {:?}, mmr_size: {}, siblings: {:?}, peak_path: {:?}",
-                pos, peaks, self.mmr_size, &self.path, &self.peaks
-            );
             Err(MerkleProofError::Unexpected)
         } else {
             let parent = if is_left_sibling(sibling_pos) {

--- a/base_layer/p2p/src/comms_connector/pubsub.rs
+++ b/base_layer/p2p/src/comms_connector/pubsub.rs
@@ -52,7 +52,7 @@ pub fn pubsub_connector(executor: Handle, buf_size: usize) -> (PubsubDomainConne
         // Log error and return unit
         .map(|result| {
             if let Err(err) = result {
-                error!(
+                warn!(
                     target: LOG_TARGET,
                     "Error forwarding pubsub messages to publisher: {}", err
                 );

--- a/base_layer/p2p/src/initialization.rs
+++ b/base_layer/p2p/src/initialization.rs
@@ -370,10 +370,10 @@ async fn add_peers_to_comms(
 {
     for peer in peers {
         let peer_desc = peer.to_string();
-        info!(target: LOG_TARGET, "Adding seed peer [{}]", peer);
+        debug!(target: LOG_TARGET, "Adding seed peer [{}]", peer);
 
         if &peer.public_key == node_identity.public_key() {
-            info!(
+            debug!(
                 target: LOG_TARGET,
                 "Attempting to add yourself [{}] as a seed peer to comms layer, ignoring request", peer_desc
             );

--- a/base_layer/p2p/src/services/liveness/service.rs
+++ b/base_layer/p2p/src/services/liveness/service.rs
@@ -115,14 +115,14 @@ where
                 request_context = request_stream.select_next_some() => {
                     let (request, reply_tx) = request_context.split();
                     let _ = reply_tx.send(self.handle_request(request).await).or_else(|resp| {
-                        error!(target: LOG_TARGET, "Failed to send reply");
+                        warn!(target: LOG_TARGET, "Failed to send reply");
                         Err(resp)
                     });
                 },
 
                 _ = ping_tick.select_next_some() => {
                     let _ = self.ping_active_pool().await.or_else(|err| {
-                        error!(target: LOG_TARGET, "Error when pinging peers: {:?}", err);
+                        warn!(target: LOG_TARGET, "Error when pinging peers: {:?}", err);
                         Err(err)
                     });
                     let _ = self.ping_monitored_node_ids().await.or_else(|err| {
@@ -133,7 +133,7 @@ where
                 // Incoming messages from the Comms layer
                 msg = ping_stream.select_next_some() => {
                     let _ = self.handle_incoming_message(msg).await.or_else(|err| {
-                        error!(target: LOG_TARGET, "Failed to handle incoming PingPong message: {:?}", err);
+                        warn!(target: LOG_TARGET, "Failed to handle incoming PingPong message: {:?}", err);
                         Err(err)
                     });
                 },
@@ -311,7 +311,7 @@ where
         }
 
         let len_peers = broadcast_nodes.len();
-        info!(target: LOG_TARGET, "Sending liveness ping to {} peer(s)", len_peers);
+        debug!(target: LOG_TARGET, "Sending liveness ping to {} peer(s)", len_peers);
 
         for node_id in broadcast_nodes {
             let msg = PingPongMessage::ping_with_metadata(self.state.metadata().clone(), self.config.useragent.clone());

--- a/base_layer/p2p/src/services/utils.rs
+++ b/base_layer/p2p/src/services/utils.rs
@@ -32,7 +32,7 @@ where E: Debug {
     match res {
         Ok(t) => Some(t),
         Err(err) => {
-            error!(target: LOG_TARGET, "{:?}", err);
+            warn!(target: LOG_TARGET, "{:?}", err);
             None
         },
     }

--- a/common/src/logging.rs
+++ b/common/src/logging.rs
@@ -68,10 +68,10 @@ macro_rules! log_if_error {
         log_if_error!(level:$level, target: "$crate", $msg, $expr)
     }};
      (target: $target:expr, $msg:expr, $expr:expr $(,)*) => {{
-        log_if_error!(level:error, target: $target, $msg, $expr)
+        log_if_error!(level:warn, target: $target, $msg, $expr)
     }};
     ($msg:expr, $expr:expr $(,)*) => {{
-        log_if_error!(level:error, target: "$crate", $msg, $expr)
+        log_if_error!(level:warn, target: "$crate", $msg, $expr)
     }};
 }
 

--- a/comms/dht/src/actor.rs
+++ b/comms/dht/src/actor.rs
@@ -240,13 +240,13 @@ impl DhtActor {
         loop {
             futures::select! {
                 request = self.request_rx.select_next_some() => {
-                    debug!(target: LOG_TARGET, "DhtActor received message: {}", request);
+                    trace!(target: LOG_TARGET, "DhtActor received message: {}", request);
                     pending_jobs.push(self.request_handler(request));
                 },
 
                 result = pending_jobs.select_next_some() => {
                     if let Err(err) = result {
-                        error!(target: LOG_TARGET, "Error when handling DHT request message. {}", err);
+                        debug!(target: LOG_TARGET, "Error when handling DHT request message. {}", err);
                     }
                 },
 
@@ -265,7 +265,7 @@ impl DhtActor {
             .set_metadata_value(DhtMetadataKey::OfflineTimestamp, Utc::now())
             .await
         {
-            error!(target: LOG_TARGET, "Failed to mark offline time: {:?}", err);
+            warn!(target: LOG_TARGET, "Failed to mark offline time: {:?}", err);
         }
     }
 
@@ -299,7 +299,7 @@ impl DhtActor {
                     {
                         Ok(peers) => reply_tx.send(peers).map_err(|_| DhtActorError::ReplyCanceled),
                         Err(err) => {
-                            error!(target: LOG_TARGET, "Peer selection failed: {:?}", err);
+                            warn!(target: LOG_TARGET, "Peer selection failed: {:?}", err);
                             reply_tx.send(Vec::new()).map_err(|_| DhtActorError::ReplyCanceled)
                         },
                     }
@@ -317,10 +317,10 @@ impl DhtActor {
                 Box::pin(async move {
                     match db.set_metadata_value_bytes(key, value).await {
                         Ok(_) => {
-                            info!(target: LOG_TARGET, "Dht setting '{}' set", key);
+                            debug!(target: LOG_TARGET, "Dht setting '{}' set", key);
                         },
                         Err(err) => {
-                            error!(target: LOG_TARGET, "set_setting failed because {:?}", err);
+                            warn!(target: LOG_TARGET, "set_setting failed because {:?}", err);
                         },
                     }
                     Ok(())
@@ -430,7 +430,7 @@ impl DhtActor {
                         "Broadcast requested but there are no node peer connections available"
                     );
                 }
-                info!(
+                debug!(
                     target: LOG_TARGET,
                     "{} candidate(s) selected for broadcast",
                     candidates.len()
@@ -511,7 +511,7 @@ impl DhtActor {
                     .cloned()
                     .collect::<Vec<_>>();
 
-                info!(
+                debug!(
                     target: LOG_TARGET,
                     "{} candidate(s) selected for propagation to {}",
                     candidates.len(),
@@ -595,10 +595,9 @@ impl DhtActor {
         if total_excluded > 0 {
             debug!(
                 target: LOG_TARGET,
-                "\n====================================\n Closest Peer Selection\n\n {num_peers} peer(s) selected\n \
-                 {total} peer(s) were not selected \n\n {banned} banned\n {filtered_out} not communication node\n \
-                 {not_connectable} are not connectable\n {excluded} explicitly excluded \
-                 \n====================================\n",
+                "👨‍👧‍👦 Closest Peer Selection: {num_peers} peer(s) selected, {total} peer(s) not selected, {banned} \
+                 banned, {filtered_out} not communication node, {not_connectable} are not connectable, {excluded} \
+                 explicitly excluded",
                 num_peers = peers.len(),
                 total = total_excluded,
                 banned = banned_count,

--- a/comms/dht/src/connectivity/mod.rs
+++ b/comms/dht/src/connectivity/mod.rs
@@ -131,14 +131,14 @@ impl DhtConnectivity {
                 event = connectivity_events.select_next_some() => {
                     if let Ok(event) = event {
                         if let Err(err) = self.handle_connectivity_event(&event).await {
-                            error!(target: LOG_TARGET, "Error handling connectivity event: {:?}", err);
+                            debug!(target: LOG_TARGET, "Error handling connectivity event: {:?}", err);
                         }
                     }
                },
 
                _ = ticker.next() => {
                     if let Err(err) = self.refresh_random_pool_if_required().await {
-                        error!(target: LOG_TARGET, "Error refreshing random peer pool: {:?}", err);
+                        debug!(target: LOG_TARGET, "Error refreshing random peer pool: {:?}", err);
                     }
                },
 
@@ -208,7 +208,7 @@ impl DhtConnectivity {
                     .partition::<Vec<_>, _>(|n| random_peers.contains(n));
                 // Remove the peers that we want to keep from the `random_peers` to be added
                 random_peers.retain(|n| !keep.contains(&n));
-                info!(
+                debug!(
                     target: LOG_TARGET,
                     "Adding new peers to random peer pool (#new = {}, #keeping = {}, #removing = {})",
                     random_peers.len(),
@@ -256,7 +256,7 @@ impl DhtConnectivity {
         let current_dist = conn.peer_node_id().distance(self.node_identity.node_id());
         let neighbour_distance = self.get_neighbour_max_distance();
         if current_dist < neighbour_distance {
-            info!(
+            debug!(
                 target: LOG_TARGET,
                 "Peer '{}' connected that is closer than any current neighbour. Adding to neighbours.",
                 conn.peer_node_id().short_str()
@@ -266,13 +266,13 @@ impl DhtConnectivity {
                 // If we kicked a neighbour out of our neighbour pool but the random pool is not full.
                 // Add the neighbour to the random pool, otherwise remove it
                 if self.random_pool.len() < self.config.num_random_nodes {
-                    info!(
+                    debug!(
                         target: LOG_TARGET,
                         "Moving peer '{}' from neighbouring pool to random pool", node_id
                     );
                     self.random_pool.push(node_id);
                 } else {
-                    info!(target: LOG_TARGET, "Removing peer '{}' from neighbouring pool", node_id);
+                    debug!(target: LOG_TARGET, "Removing peer '{}' from neighbouring pool", node_id);
                     self.connectivity.remove_peer(node_id).await?;
                 }
             }
@@ -292,7 +292,7 @@ impl DhtConnectivity {
         }
 
         if self.random_pool.contains(current_peer) {
-            info!(
+            debug!(
                 target: LOG_TARGET,
                 "Peer '{}' in random pool is offline. Adding a new random peer if possible", current_peer
             );
@@ -319,7 +319,7 @@ impl DhtConnectivity {
         }
 
         if self.neighbours.contains(current_peer) {
-            info!(
+            debug!(
                 target: LOG_TARGET,
                 "Peer '{}' in neighbour pool is offline. Adding a new peer if possible", current_peer
             );

--- a/comms/dht/src/dedup.rs
+++ b/comms/dht/src/dedup.rs
@@ -83,7 +83,7 @@ where S: Service<DhtInboundMessage, Response = (), Error = PipelineError> + Clon
                 .await
                 .map_err(PipelineError::from_debug)?
             {
-                info!(
+                trace!(
                     target: LOG_TARGET,
                     "Received duplicate message {} from peer '{}' (Trace: {}). Message discarded.",
                     message.tag,
@@ -93,9 +93,11 @@ where S: Service<DhtInboundMessage, Response = (), Error = PipelineError> + Clon
                 return Ok(());
             }
 
-            debug!(
+            trace!(
                 target: LOG_TARGET,
-                "Passing message {} onto next service (Trace: {})", message.tag, message.dht_header.message_tag
+                "Passing message {} onto next service (Trace: {})",
+                message.tag,
+                message.dht_header.message_tag
             );
             next_service.oneshot(message).await
         }

--- a/comms/dht/src/dht.rs
+++ b/comms/dht/src/dht.rs
@@ -122,7 +122,7 @@ impl Dht {
         dht.actor(conn, dht_receiver, shutdown_signal.clone()).spawn();
         dht.discovery_service(discovery_receiver, shutdown_signal).spawn();
 
-        info!(target: LOG_TARGET, "Dht initialization complete.");
+        debug!(target: LOG_TARGET, "Dht initialization complete.");
 
         Ok(dht)
     }
@@ -321,7 +321,7 @@ impl Dht {
             match msg.dht_header.message_type {
                 DhtMessageType::SafRequestMessages => {
                     // TODO: #banheuristic This is an indication of node misbehaviour
-                    warn!(
+                    debug!(
                         "Received store and forward message from PublicKey={}. Store and forward feature is not \
                          supported by this node. Discarding message.",
                         msg.source_peer.public_key

--- a/comms/dht/src/discovery/service.rs
+++ b/comms/dht/src/discovery/service.rs
@@ -192,7 +192,7 @@ impl DhtDiscoveryService {
                 // Resolve any other pending discover requests if the peer was found
                 match &result {
                     Ok(peer) => {
-                        info!(
+                        debug!(
                             target: LOG_TARGET,
                             "Received discovery response from peer {}. Discovery completed in {}s",
                             peer.node_id,
@@ -212,7 +212,7 @@ impl DhtDiscoveryService {
                         );
                     },
                     Err(err) => {
-                        info!(
+                        debug!(
                             target: LOG_TARGET,
                             "Failed to validate and add peer from discovery response from peer. {:?} Discovery \
                              completed in {}s",
@@ -225,7 +225,7 @@ impl DhtDiscoveryService {
                 let _ = reply_tx.send(result);
             },
             None => {
-                info!(
+                debug!(
                     target: LOG_TARGET,
                     "Received a discovery response from peer '{}' that this node did not expect. It may have been \
                      cancelled earlier.",
@@ -335,7 +335,7 @@ impl DhtDiscoveryService {
             peer_features: self.node_identity.features().bits(),
             nonce,
         };
-        info!(
+        debug!(
             target: LOG_TARGET,
             "Sending Discovery message for peer public key '{}' with destination {}", dest_public_key, destination
         );
@@ -358,7 +358,7 @@ impl DhtDiscoveryService {
 
         // Spawn a task to log how the sending of discovery went
         task::spawn(async move {
-            info!(
+            debug!(
                 target: LOG_TARGET,
                 "Discovery sent to {} peer(s). Waiting to see how many got through.",
                 send_states.len()
@@ -369,7 +369,7 @@ impl DhtDiscoveryService {
                     let num_succeeded = succeeded.len();
                     let num_failed = failed.len();
 
-                    info!(
+                    debug!(
                         target: LOG_TARGET,
                         "Discovery sent to a majority of neighbouring peers ({} succeeded, {} failed)",
                         num_succeeded,

--- a/comms/dht/src/inbound/decryption.rs
+++ b/comms/dht/src/inbound/decryption.rs
@@ -150,7 +150,7 @@ where S: Service<DecryptedDhtMessage, Response = (), Error = PipelineError>
                 public_key
             },
             Err(err) => {
-                debug!(
+                trace!(
                     target: LOG_TARGET,
                     "Unable to decrypt message origin: {}, {} (Trace: {})",
                     err,
@@ -161,7 +161,7 @@ where S: Service<DecryptedDhtMessage, Response = (), Error = PipelineError>
             },
         };
 
-        debug!(
+        trace!(
             target: LOG_TARGET,
             "Attempting to decrypt message body from origin public key '{}', {} (Trace: {})",
             authenticated_origin,
@@ -270,7 +270,7 @@ where S: Service<DecryptedDhtMessage, Response = (), Error = PipelineError>
 
         match EnvelopeBody::decode(message.body.as_slice()) {
             Ok(deserialized) => {
-                debug!(
+                trace!(
                     target: LOG_TARGET,
                     "Message {} is not encrypted. Passing onto next service (Trace: {})",
                     message.tag,

--- a/comms/dht/src/inbound/deserialize.rs
+++ b/comms/dht/src/inbound/deserialize.rs
@@ -84,7 +84,7 @@ where S: Service<DhtInboundMessage, Response = (), Error = PipelineError> + Clon
                         source_peer,
                         dht_envelope.body,
                     );
-                    debug!(
+                    trace!(
                         target: LOG_TARGET,
                         "Deserialization succeeded. Passing message {} onto next service (Trace: {})",
                         tag,

--- a/comms/dht/src/inbound/dht_handler/task.rs
+++ b/comms/dht/src/inbound/dht_handler/task.rs
@@ -155,7 +155,7 @@ where S: Service<DecryptedDhtMessage, Response = (), Error = PipelineError>
         })?;
 
         if &authenticated_pk == self.node_identity.public_key() {
-            warn!(target: LOG_TARGET, "Received our own join message. Discarding it.");
+            debug!(target: LOG_TARGET, "Received our own join message. Discarding it.");
             return Ok(());
         }
 
@@ -164,7 +164,7 @@ where S: Service<DecryptedDhtMessage, Response = (), Error = PipelineError>
             .decode_part::<JoinMessage>(0)?
             .ok_or_else(|| DhtInboundError::InvalidMessageBody)?;
 
-        info!(
+        debug!(
             target: LOG_TARGET,
             "Received join Message from '{}' {}", authenticated_pk, join_msg
         );
@@ -193,7 +193,7 @@ where S: Service<DecryptedDhtMessage, Response = (), Error = PipelineError>
 
         // DO NOT propagate this peer if this node has banned them
         if origin_peer.is_banned() {
-            warn!(
+            debug!(
                 target: LOG_TARGET,
                 "Received Join request for banned peer. This join request will not be propagated."
             );
@@ -240,7 +240,7 @@ where S: Service<DecryptedDhtMessage, Response = (), Error = PipelineError>
         if dht_header.destination != self.node_identity.public_key() &&
             dht_header.destination != self.node_identity.node_id()
         {
-            info!(
+            debug!(
                 target: LOG_TARGET,
                 "Propagating Join message from peer '{}'",
                 origin_node_id.short_str()
@@ -323,7 +323,7 @@ where S: Service<DecryptedDhtMessage, Response = (), Error = PipelineError>
             DhtInboundError::OriginRequired("Origin header required for Discovery message".to_string())
         })?;
 
-        info!(
+        debug!(
             target: LOG_TARGET,
             "Received discovery message from '{}', forwarded by {}", authenticated_pk, message.source_peer
         );

--- a/comms/dht/src/inbound/validate.rs
+++ b/comms/dht/src/inbound/validate.rs
@@ -65,13 +65,15 @@ where S: Service<DhtInboundMessage, Response = (), Error = PipelineError> + Clon
         let target_network = self.target_network;
         async move {
             if message.dht_header.network == target_network && message.dht_header.is_valid() {
-                debug!(
+                trace!(
                     target: LOG_TARGET,
-                    "Passing message {} to next service (Trace: {})", message.tag, message.dht_header.message_tag
+                    "Passing message {} to next service (Trace: {})",
+                    message.tag,
+                    message.dht_header.message_tag
                 );
                 next_service.oneshot(message).await?;
             } else {
-                warn!(
+                debug!(
                     target: LOG_TARGET,
                     "Message is for another network (want = {:?} got = {:?}) or message header is invalid. Discarding \
                      the message (Trace: {}).",

--- a/comms/dht/src/logging_middleware.rs
+++ b/comms/dht/src/logging_middleware.rs
@@ -86,7 +86,7 @@ where
     }
 
     fn call(&mut self, msg: R) -> Self::Future {
-        info!(target: LOG_TARGET, "{}{}", self.prefix_msg, msg);
+        trace!(target: LOG_TARGET, "{}{}", self.prefix_msg, msg);
         let mut inner = self.inner.clone();
         async move { inner.ready_and().and_then(|s| s.call(msg)).await.map_err(Into::into) }
     }

--- a/comms/dht/src/outbound/serialize.rs
+++ b/comms/dht/src/outbound/serialize.rs
@@ -64,7 +64,7 @@ where S: Service<OutboundMessage, Response = (), Error = PipelineError> + Clone 
     fn call(&mut self, message: DhtOutboundMessage) -> Self::Future {
         let next_service = self.inner.clone();
         async move {
-            debug!(target: LOG_TARGET, "Serializing outbound message {:?}", message.tag);
+            trace!(target: LOG_TARGET, "Serializing outbound message {:?}", message.tag);
 
             let DhtOutboundMessage {
                 tag,

--- a/comms/dht/src/store_forward/forward.rs
+++ b/comms/dht/src/store_forward/forward.rs
@@ -100,7 +100,7 @@ where S: Service<DecryptedDhtMessage, Response = (), Error = PipelineError> + Cl
         let is_enabled = self.is_enabled;
         async move {
             if !is_enabled {
-                debug!(
+                trace!(
                     target: LOG_TARGET,
                     "Passing message {} to next service (Not enabled) (Trace: {})",
                     message.tag,
@@ -142,17 +142,21 @@ where S: Service<DecryptedDhtMessage, Response = (), Error = PipelineError>
 {
     async fn handle(mut self, message: DecryptedDhtMessage) -> Result<(), PipelineError> {
         if message.decryption_failed() {
-            debug!(
+            trace!(
                 target: LOG_TARGET,
-                "Decryption failed. Forwarding message {} (Trace: {})", message.tag, message.dht_header.message_tag
+                "Decryption failed. Forwarding message {} (Trace: {})",
+                message.tag,
+                message.dht_header.message_tag
             );
             self.forward(&message).await.map_err(PipelineError::from_debug)?;
         }
 
         // The message has been forwarded, but other middleware may be interested (i.e. StoreMiddleware)
-        debug!(
+        trace!(
             target: LOG_TARGET,
-            "Passing message {} to next service (Trace: {})", message.tag, message.dht_header.message_tag
+            "Passing message {} to next service (Trace: {})",
+            message.tag,
+            message.dht_header.message_tag
         );
         self.next_service.oneshot(message).await?;
         Ok(())
@@ -173,7 +177,7 @@ where S: Service<DecryptedDhtMessage, Response = (), Error = PipelineError>
             //       1. The source sent a message that the destination could not decrypt
             //       The authenticated source should be banned (malicious), and origin should be temporarily banned
             //       (bug?)
-            warn!(
+            debug!(
                 target: LOG_TARGET,
                 "Received message {} from peer '{}' that is destined for that peer. Discarding message (Trace: {})",
                 message.tag,

--- a/comms/dht/src/store_forward/saf_handler/task.rs
+++ b/comms/dht/src/store_forward/saf_handler/task.rs
@@ -126,7 +126,7 @@ where S: Service<DecryptedDhtMessage, Response = (), Error = PipelineError>
                 } else {
                     // TODO: #banheuristics - requester should not have requested store and forward messages from this
                     //       node
-                    info!(
+                    debug!(
                         target: LOG_TARGET,
                         "Received store and forward request {} from peer '{}' however, this node is not a store and \
                          forward node. Request ignored. (Trace: {})",
@@ -207,7 +207,7 @@ where S: Service<DecryptedDhtMessage, Response = (), Error = PipelineError>
             let messages = self.saf_requester.fetch_messages(query.clone()).await?;
 
             if messages.is_empty() {
-                info!(
+                debug!(
                     target: LOG_TARGET,
                     "No {:?} stored messages for peer '{}'",
                     resp_type,
@@ -223,7 +223,7 @@ where S: Service<DecryptedDhtMessage, Response = (), Error = PipelineError>
                 response_type: resp_type as i32,
             };
 
-            info!(
+            debug!(
                 target: LOG_TARGET,
                 "Responding to received message retrieval request with {} {:?} message(s)",
                 stored_messages.messages().len(),
@@ -281,7 +281,7 @@ where S: Service<DecryptedDhtMessage, Response = (), Error = PipelineError>
             .ok_or_else(|| StoreAndForwardError::InvalidEnvelopeBody)?;
         let source_peer = Arc::new(message.source_peer);
 
-        info!(
+        debug!(
             target: LOG_TARGET,
             "Received {} stored messages of type {} from peer",
             response.messages().len(),
@@ -396,7 +396,7 @@ where S: Service<DecryptedDhtMessage, Response = (), Error = PipelineError>
 
             if message_type.is_dht_message() {
                 if !message_type.is_dht_discovery() {
-                    warn!(
+                    debug!(
                         target: LOG_TARGET,
                         "Discarding {} message from peer '{}'",
                         message_type,
@@ -405,7 +405,7 @@ where S: Service<DecryptedDhtMessage, Response = (), Error = PipelineError>
                     return Err(StoreAndForwardError::InvalidDhtMessageType);
                 }
                 if dht_header.destination.is_unknown() {
-                    warn!(
+                    debug!(
                         target: LOG_TARGET,
                         "Discarding anonymous discovery message from peer '{}'",
                         source_peer.node_id.short_str()

--- a/comms/dht/src/store_forward/service.rs
+++ b/comms/dht/src/store_forward/service.rs
@@ -417,7 +417,7 @@ impl StoreAndForwardService {
                 since(self.config.saf_low_priority_msg_storage_ttl),
             )
             .await?;
-        info!(target: LOG_TARGET, "Cleaned {} old low priority messages", num_removed);
+        debug!(target: LOG_TARGET, "Cleaned {} old low priority messages", num_removed);
 
         let num_removed = self
             .database
@@ -426,14 +426,14 @@ impl StoreAndForwardService {
                 since(self.config.saf_high_priority_msg_storage_ttl),
             )
             .await?;
-        info!(target: LOG_TARGET, "Cleaned {} old high priority messages", num_removed);
+        debug!(target: LOG_TARGET, "Cleaned {} old high priority messages", num_removed);
 
         let num_removed = self
             .database
             .truncate_messages(self.config.saf_msg_storage_capacity)
             .await?;
         if num_removed > 0 {
-            info!(
+            debug!(
                 target: LOG_TARGET,
                 "Storage limits exceeded, removing {} oldest messages", num_removed
             );

--- a/comms/dht/src/store_forward/store.rs
+++ b/comms/dht/src/store_forward/store.rs
@@ -197,9 +197,11 @@ where S: Service<DecryptedDhtMessage, Response = (), Error = PipelineError>
                 .map_err(PipelineError::from_debug)?;
         }
 
-        debug!(
+        trace!(
             target: LOG_TARGET,
-            "Passing message {} to next service (Trace: {})", message.tag, message.dht_header.message_tag
+            "Passing message {} to next service (Trace: {})",
+            message.tag,
+            message.dht_header.message_tag
         );
         self.next_service.oneshot(message).await?;
 
@@ -280,7 +282,7 @@ where S: Service<DecryptedDhtMessage, Response = (), Error = PipelineError>
             None => {
                 if !message.has_origin_mac() {
                     // TODO: #banheuristic - the source peer should not have propagated this message
-                    warn!(
+                    debug!(
                         target: LOG_TARGET,
                         "Store task received an encrypted message with no origin MAC. This message {} is invalid and \
                          should not be stored or propagated. Dropping message. Sent by node '{}' (Trace: {})",

--- a/comms/src/connection_manager/dialer.rs
+++ b/comms/src/connection_manager/dialer.rs
@@ -312,7 +312,7 @@ where
                         Either::Left((result, _)) => (dial_state, result),
                         //     Dial cancel was triggered
                         Either::Right(_) => {
-                            info!(target: LOG_TARGET, "Dial was cancelled");
+                            debug!(target: LOG_TARGET, "Dial was cancelled");
                             (dial_state, Err(ConnectionManagerError::DialCancelled))
                         },
                     }
@@ -358,10 +358,9 @@ where
             .await
             .map_err(|err| ConnectionManagerError::YamuxUpgradeFailure(err.to_string()))?;
 
-        trace!(
+        debug!(
             target: LOG_TARGET,
-            "Starting peer identity exchange for peer with public key '{}'",
-            authenticated_public_key
+            "Starting peer identity exchange for peer with public key '{}'", authenticated_public_key
         );
 
         let peer_identity = common::perform_identity_exchange(
@@ -373,7 +372,7 @@ where
         .await?;
 
         let features = PeerFeatures::from_bits_truncate(peer_identity.features);
-        debug!(
+        trace!(
             target: LOG_TARGET,
             "Peer identity exchange succeeded on Outbound connection for peer '{}' (Features = {:?})",
             peer_identity.node_id.to_hex(),

--- a/comms/src/connection_manager/listener.rs
+++ b/comms/src/connection_manager/listener.rs
@@ -134,7 +134,7 @@ where
                 }
             },
             Err(err) => {
-                error!(target: LOG_TARGET, "PeerListener was unable to start because '{}'", err);
+                warn!(target: LOG_TARGET, "PeerListener was unable to start because '{}'", err);
                 self.send_event(ConnectionManagerEvent::ListenFailed(err)).await;
             },
         }
@@ -181,7 +181,7 @@ where
     {
         permit.fetch_sub(1, Ordering::SeqCst);
         let liveness = LivenessSession::new(socket);
-        info!(target: LOG_TARGET, "Started liveness session");
+        debug!(target: LOG_TARGET, "Started liveness session");
         runtime::current_executor().spawn(async move {
             future::select(liveness.run(), shutdown_signal).await;
             permit.fetch_add(1, Ordering::SeqCst);
@@ -246,13 +246,13 @@ where
                     if liveness_session_count.load(Ordering::SeqCst) > 0 &&
                         Self::is_address_in_liveness_cidr_range(&peer_addr, &config.liveness_cidr_whitelist)
                     {
-                        info!(
+                        debug!(
                             target: LOG_TARGET,
                             "Connection at address '{}' requested liveness session", peer_addr
                         );
                         Self::spawn_liveness_session(socket, liveness_session_count, shutdown_signal).await;
                     } else {
-                        warn!(
+                        debug!(
                             target: LOG_TARGET,
                             "No liveness sessions available or permitted for peer address '{}'", peer_addr
                         );

--- a/comms/src/connection_manager/manager.rs
+++ b/comms/src/connection_manager/manager.rs
@@ -553,7 +553,7 @@ where
                 match conn.disconnect_silent().await {
                     Ok(_) => {},
                     Err(err) => {
-                        error!(target: LOG_TARGET, "Failed to disconnect because '{:?}'", err);
+                        warn!(target: LOG_TARGET, "Failed to disconnect because '{:?}'", err);
                     },
                 }
             }
@@ -582,7 +582,7 @@ where
                     .await;
             },
             Err(err) => {
-                error!(target: LOG_TARGET, "Failed to fetch peer to dial because '{}'", err);
+                warn!(target: LOG_TARGET, "Failed to fetch peer to dial because '{}'", err);
                 let _ = reply_tx.send(Err(ConnectionManagerError::PeerManagerError(err)));
             },
         }

--- a/comms/src/connection_manager/peer_connection.rs
+++ b/comms/src/connection_manager/peer_connection.rs
@@ -374,7 +374,7 @@ impl PeerConnectionActor {
     ///
     /// # Arguments
     ///
-    /// silent - true to supress the PeerDisconnected event, false to publish the event
+    /// silent - true to suppress the PeerDisconnected event, false to publish the event
     async fn disconnect(&mut self, silent: bool) {
         if let Err(err) = self.control.close().await {
             warn!(
@@ -385,7 +385,7 @@ impl PeerConnectionActor {
                 err
             );
         }
-        trace!(target: LOG_TARGET, "Connection closed");
+        debug!(target: LOG_TARGET, "Connection closed");
 
         self.shutdown = true;
         // Shut down the incoming substream task

--- a/comms/src/macros.rs
+++ b/comms/src/macros.rs
@@ -110,13 +110,13 @@ macro_rules! log_if_error {
         }
     }};
     (target:$target:expr, $expr:expr, $msg:expr, $($args:tt),* $(,)*) => {{
-        log_if_error!(level:error, target:$target, $expr, $msg, $($args),*)
+        log_if_error!(level:warn, target:$target, $expr, $msg, $($args),*)
     }};
     (level:$level:ident, $expr:expr, $msg:expr, $($args:tt),* $(,)*) => {{
         log_if_error!(level:$level, target:"$crate", $expr, $msg, $($args),*)
     }};
     ($expr:expr, $msg:expr, $($args:tt)* $(,)*) => {{
-        log_if_error!(level:error, target:"$crate", $expr, $msg, $($args),*)
+        log_if_error!(level:warn, target:"$crate", $expr, $msg, $($args),*)
     }};
 }
 

--- a/comms/src/noise/socket.rs
+++ b/comms/src/noise/socket.rs
@@ -303,7 +303,7 @@ where TSocket: AsyncRead + Unpin
                                     };
                                 },
                                 Err(e) => {
-                                    error!(target: LOG_TARGET, "Decryption Error: {}", e);
+                                    warn!(target: LOG_TARGET, "Decryption Error: {}", e);
                                     self.read_state = ReadState::DecryptionError(e);
                                 },
                             }
@@ -411,7 +411,7 @@ where TSocket: AsyncWrite + Unpin
                                 };
                             },
                             Err(e) => {
-                                error!(target: LOG_TARGET, "Encryption Error: {}", e);
+                                warn!(target: LOG_TARGET, "Encryption Error: {}", e);
                                 let err = io::Error::new(io::ErrorKind::InvalidData, format!("EncryptionError: {}", e));
                                 self.write_state = WriteState::EncryptionError(e);
                                 return Poll::Ready(Err(err));

--- a/comms/src/pipeline/inbound.rs
+++ b/comms/src/pipeline/inbound.rs
@@ -74,7 +74,7 @@ where
             self.executor
                 .spawn(async move {
                     if let Err(err) = service.oneshot(item).await {
-                        error!(target: LOG_TARGET, "Inbound pipeline returned an error: '{:?}'", err);
+                        warn!(target: LOG_TARGET, "Inbound pipeline returned an error: '{:?}'", err);
                     }
                 })
                 .await;

--- a/comms/src/protocol/messaging/inbound.rs
+++ b/comms/src/protocol/messaging/inbound.rs
@@ -86,7 +86,7 @@ impl InboundMessaging {
                         }
                     }
 
-                    trace!(target: LOG_TARGET, "Inbound handler sending event '{}'", event);
+                    debug!(target: LOG_TARGET, "Inbound handler sending event '{}'", event);
                     if let Err(err) = self.messaging_events_tx.send(Arc::new(event)) {
                         trace!(
                             target: LOG_TARGET,

--- a/comms/src/protocol/messaging/outbound.rs
+++ b/comms/src/protocol/messaging/outbound.rs
@@ -78,7 +78,7 @@ impl OutboundMessaging {
             match self.conn_man_requester.dial_peer(self.peer_node_id.clone()).await {
                 Ok(conn) => break Ok(conn),
                 Err(ConnectionManagerError::DialCancelled) => {
-                    error!(
+                    debug!(
                         target: LOG_TARGET,
                         "Dial was cancelled for peer '{}'. This is probably because of connection tie-breaking. \
                          Retrying...",
@@ -87,7 +87,7 @@ impl OutboundMessaging {
                     continue;
                 },
                 Err(err) => {
-                    error!(
+                    warn!(
                         target: LOG_TARGET,
                         "MessagingProtocol failed to dial peer '{}' because '{:?}'",
                         self.peer_node_id.short_str(),

--- a/comms/src/protocol/messaging/protocol.rs
+++ b/comms/src/protocol/messaging/protocol.rs
@@ -210,7 +210,7 @@ impl MessagingProtocol {
             SendMessageFailed(out_msg, reason) => match self.attempts.entry(out_msg.tag) {
                 Entry::Occupied(mut entry) => match *entry.get() {
                     n if n >= self.max_attempts => {
-                        warn!(
+                        debug!(
                             target: LOG_TARGET,
                             "Failed to send message '{}' to peer '{}' because '{}'.",
                             out_msg.tag,
@@ -381,7 +381,7 @@ impl MessagingProtocol {
                     },
                     Err(PeerManagerError::PeerNotFoundError) => {
                         // This should never happen if everything is working correctly
-                        error!(
+                        warn!(
                             target: LOG_TARGET,
                             "[ThisNode={}] *** Could not find verified node_id '{}' in peer list. This should not \
                              happen ***",
@@ -391,7 +391,7 @@ impl MessagingProtocol {
                     },
                     Err(err) => {
                         // This should never happen if everything is working correctly
-                        error!(
+                        warn!(
                             target: LOG_TARGET,
                             "Peer manager error when handling protocol notification: '{:?}'", err
                         );

--- a/infrastructure/storage/src/lmdb_store/store.rs
+++ b/infrastructure/storage/src/lmdb_store/store.rs
@@ -297,9 +297,9 @@ pub struct LMDBStore {
 /// However, in that case `shutdown` returns an error.
 impl LMDBStore {
     pub fn flush(&self) -> Result<(), lmdb_zero::error::Error> {
-        debug!(target: LOG_TARGET, "Forcing flush of buffers to disk");
+        trace!(target: LOG_TARGET, "Forcing flush of buffers to disk");
         self.env.sync(true)?;
-        debug!(target: LOG_TARGET, "Buffers have been flushed");
+        debug!(target: LOG_TARGET, "LMDB Buffers have been flushed");
         Ok(())
     }
 
@@ -313,7 +313,7 @@ impl LMDBStore {
             ),
             Ok(info) => {
                 let size_mb = info.mapsize / 1024 / 1024;
-                info!(
+                debug!(
                     target: LOG_TARGET,
                     "LMDB Environment information ({}). Map Size={} MB. Last page no={}. Last tx id={}",
                     self.path,
@@ -332,7 +332,7 @@ impl LMDBStore {
             ),
             Ok(stats) => {
                 let page_size = stats.psize / 1024;
-                info!(
+                debug!(
                     target: LOG_TARGET,
                     "LMDB Environment statistics ({}). Page size={}kB. Tree depth={}. Branch pages={}. Leaf Pages={}, \
                      Overflow pages={}, Entries={}",
@@ -419,7 +419,7 @@ impl LMDBDatabase {
             ),
             Ok(stats) => {
                 let page_size = stats.psize / 1024;
-                info!(
+                debug!(
                     target: LOG_TARGET,
                     "LMDB Database statistics ({}). Page size={}kB. Tree depth={}. Branch pages={}. Leaf Pages={}, \
                      Overflow pages={}, Entries={}",


### PR DESCRIPTION
This is a first pass at normalising log messages.

The following principles were used to decide on the appropriate log level:
1. Severity - Catastrophic errors (money losing, data corrupting) are errors. Other errors are warning.
2. Relevance - Only messages casual users would be interested in are info or higher. Developers should be able to turn off all trace messages and still have enough info to hone in on areas of trouble. Developers running nodes should only have to turn on TRACE level messages when they really need to zoom into issues.
3. Length - Only trace messages are permitted to span more than one line.
4. Frequency - The deeper in the code; the lower the level. Messages inside loops are typically trace, unless their relevance suggests a higher level.

This PR did not refactor any wallet messages at this time -- since I'm
not sure whether the mobile apps rely on any messages bein at a specif
level.

