### PR TITLE
Blockchain backend fetch MMR nodes

### DIFF
--- a/base_layer/core/src/chain_storage/blockchain_database.rs
+++ b/base_layer/core/src/chain_storage/blockchain_database.rs
@@ -155,8 +155,13 @@ pub trait BlockchainBackend: Send + Sync {
     /// Fetches the checkpoint corresponding to the provided height, the checkpoint consist of the list of nodes
     /// added & deleted for the given Merkle tree.
     fn fetch_checkpoint(&self, tree: MmrTree, height: u64) -> Result<MerkleCheckPoint, ChainStorageError>;
+    /// Fetches the total merkle mountain range node count upto the specified height.
+    fn fetch_mmr_node_count(&self, tree: MmrTree, height: u64) -> Result<u32, ChainStorageError>;
     /// Fetches the leaf node hash and its deletion status for the nth leaf node in the given MMR tree.
     fn fetch_mmr_node(&self, tree: MmrTree, pos: u32) -> Result<(Hash, bool), ChainStorageError>;
+    /// Fetches the set of leaf node hashes and their deletion status' for the nth to nth+count leaf node index in the
+    /// given MMR tree.
+    fn fetch_mmr_nodes(&self, tree: MmrTree, pos: u32, count: u32) -> Result<Vec<(Hash, bool)>, ChainStorageError>;
     /// Performs the function F for each orphan block in the orphan pool.
     fn for_each_orphan<F>(&self, f: F) -> Result<(), ChainStorageError>
     where
@@ -271,7 +276,6 @@ where T: BlockchainBackend
             );
             blockchain_db.store_pruning_horizon(config.pruning_horizon)?;
         }
-
         Ok(blockchain_db)
     }
 

--- a/base_layer/core/src/chain_storage/memory_db/memory_db.rs
+++ b/base_layer/core/src/chain_storage/memory_db/memory_db.rs
@@ -49,6 +49,7 @@ use crate::{
 use croaring::Bitmap;
 use digest::Digest;
 use std::{
+    cmp::min,
     collections::{HashMap, VecDeque},
     sync::{Arc, RwLock, RwLockReadGuard, RwLockWriteGuard},
 };
@@ -454,6 +455,15 @@ where D: Digest + Send + Sync
         .ok_or_else(|| ChainStorageError::OutOfRange)
     }
 
+    fn fetch_mmr_node_count(&self, tree: MmrTree, height: u64) -> Result<u32, ChainStorageError> {
+        let db = self.db_access()?;
+        match tree {
+            MmrTree::Kernel => count_mmr_nodes_added(&db.kernel_checkpoints, height),
+            MmrTree::Utxo => count_mmr_nodes_added(&db.utxo_checkpoints, height),
+            MmrTree::RangeProof => count_mmr_nodes_added(&db.range_proof_checkpoints, height),
+        }
+    }
+
     fn fetch_mmr_node(&self, tree: MmrTree, pos: u32) -> Result<(Vec<u8>, bool), ChainStorageError> {
         let db = self.db_access()?;
         let (hash, deleted) = match tree {
@@ -465,6 +475,14 @@ where D: Digest + Send + Sync
             ChainStorageError::UnexpectedResult(format!("A leaf node hash in the {} MMR tree was not found", tree))
         })?;
         Ok((hash, deleted))
+    }
+
+    fn fetch_mmr_nodes(&self, tree: MmrTree, pos: u32, count: u32) -> Result<Vec<(Vec<u8>, bool)>, ChainStorageError> {
+        let mut lead_nodes = Vec::<(Vec<u8>, bool)>::with_capacity(count as usize);
+        for pos in pos..pos + count {
+            lead_nodes.push(self.fetch_mmr_node(tree.clone(), pos)?);
+        }
+        Ok(lead_nodes)
     }
 
     /// Iterate over all the stored orphan blocks and execute the function `f` for each block.
@@ -712,4 +730,19 @@ fn rewind_checkpoint_index(cp_count: usize, steps_back: usize) -> usize {
     } else {
         1
     }
+}
+
+// Calculate the total leaf node count upto a specified height.
+fn count_mmr_nodes_added(checkpoints: &MemDbVec<MerkleCheckPoint>, height: u64) -> Result<u32, ChainStorageError> {
+    let mut node_count: u32 = 0;
+    let last_index = min(checkpoints.len()?, (height + 1) as usize);
+    for cp_index in 0..last_index {
+        if let Some(cp) = checkpoints
+            .get(cp_index)
+            .map_err(|e| ChainStorageError::AccessError(format!("Checkpoint error: {}", e.to_string())))?
+        {
+            node_count += cp.nodes_added().len() as u32;
+        }
+    }
+    Ok(node_count)
 }

--- a/base_layer/core/src/chain_storage/mod.rs
+++ b/base_layer/core/src/chain_storage/mod.rs
@@ -53,7 +53,16 @@ pub use blockchain_database::{
     MutableMmrState,
     Validators,
 };
-pub use db_transaction::{DbKey, DbKeyValuePair, DbTransaction, DbValue, MetadataKey, MetadataValue, MmrTree};
+pub use db_transaction::{
+    DbKey,
+    DbKeyValuePair,
+    DbTransaction,
+    DbValue,
+    MetadataKey,
+    MetadataValue,
+    MmrTree,
+    WriteOperation,
+};
 pub use error::ChainStorageError;
 pub use historical_block::HistoricalBlock;
 pub use lmdb_db::{

--- a/base_layer/core/src/helpers/mock_backend.rs
+++ b/base_layer/core/src/helpers/mock_backend.rs
@@ -75,7 +75,21 @@ impl BlockchainBackend for MockBackend {
         unimplemented!()
     }
 
+    fn fetch_mmr_node_count(&self, _tree: MmrTree, _height: u64) -> Result<u32, ChainStorageError> {
+        unimplemented!()
+    }
+
     fn fetch_mmr_node(&self, _tree: MmrTree, _pos: u32) -> Result<(Hash, bool), ChainStorageError> {
+        unimplemented!()
+    }
+
+    fn fetch_mmr_nodes(
+        &self,
+        _tree: MmrTree,
+        _pos: u32,
+        _count: u32,
+    ) -> Result<Vec<(Vec<u8>, bool)>, ChainStorageError>
+    {
         unimplemented!()
     }
 

--- a/base_layer/mmr/src/merkle_mountain_range.rs
+++ b/base_layer/mmr/src/merkle_mountain_range.rs
@@ -27,7 +27,6 @@ use crate::{
     Hash,
 };
 use digest::Digest;
-use log::*;
 use std::{
     cmp::{max, min},
     marker::PhantomData,


### PR DESCRIPTION
## Description
Added fetch_mmr_nodes and fetch_mmr_node_count to the blockchain backends to enable downloading of the Kernel, UTXO and Range Proof MMRs when syncing using Pruned mode.

## Motivation and Context
The MMR state should be retrievable to allow sharing between nodes that are running in pruned mode.

## How Has This Been Tested?
- Added chain backend tests for testing the lmdb and memory backend implementations of the fetch_mmr_nodes and fetch_mmr_node_count functions for the Kernel, UTXO and Range Proof MMRs.
- Added a pruned mode test for downloading of blocks when the node is running in pruned mode.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [x] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch.
* [x] I ran `cargo-fmt --all` before pushing.
* [x] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
