### PR TITLE
Moved generated proto files into modules

### DIFF
--- a/base_layer/core/.gitignore
+++ b/base_layer/core/.gitignore
@@ -1,0 +1,2 @@
+src/proto/generated/*.rs
+!src/proto/generated/mod.rs

--- a/base_layer/core/build.rs
+++ b/base_layer/core/build.rs
@@ -22,6 +22,7 @@
 
 fn main() {
     tari_common::protobuf_build::ProtoCompiler::new()
+        .out_dir("src/proto/generated")
         .include_paths(&["src/transactions/proto", "src/proto"])
         .proto_paths(&[
             "src/mempool/proto",

--- a/base_layer/core/src/base_node/proto/mod.rs
+++ b/base_layer/core/src/base_node/proto/mod.rs
@@ -20,12 +20,7 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-pub mod base_node {
-    include!(concat!(env!("OUT_DIR"), "/", "tari.base_node.rs"));
-}
-use crate::proto::core;
-// Required for `super::types` used in generated files
-use crate::transactions::proto::types;
+pub use crate::proto::generated::base_node;
 
 #[cfg(feature = "base_node")]
 pub mod chain_metadata;

--- a/base_layer/core/src/mempool/proto/mod.rs
+++ b/base_layer/core/src/mempool/proto/mod.rs
@@ -20,12 +20,7 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-// Required for `super::types` used in generated files
-use crate::transactions::proto::types;
-
-pub mod mempool {
-    include!(concat!(env!("OUT_DIR"), "/", "tari.mempool.rs"));
-}
+pub use crate::proto::generated::mempool;
 
 pub mod mempool_request;
 pub mod mempool_response;

--- a/base_layer/core/src/proto/generated/mod.rs
+++ b/base_layer/core/src/proto/generated/mod.rs
@@ -1,0 +1,35 @@
+//  Copyright 2020, The Tari Project
+//
+//  Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+//  following conditions are met:
+//
+//  1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+//  disclaimer.
+//
+//  2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+//  following disclaimer in the documentation and/or other materials provided with the distribution.
+//
+//  3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+//  products derived from this software without specific prior written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+//  INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+//  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+//  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+//  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+//  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+//  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+//! Imports of rust files generated from protos
+
+#[cfg(feature = "base_node")]
+#[path = "tari.base_node.rs"]
+pub mod base_node;
+#[path = "tari.core.rs"]
+pub mod core;
+#[path = "tari.mempool.rs"]
+pub mod mempool;
+#[path = "tari.transaction_protocol.rs"]
+pub mod transaction_protocol;
+#[path = "tari.types.rs"]
+pub mod types;

--- a/base_layer/core/src/proto/mod.rs
+++ b/base_layer/core/src/proto/mod.rs
@@ -20,12 +20,8 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-// Required for `super::types` used in generated files
-use crate::transactions::proto::types;
-
-pub mod core {
-    include!(concat!(env!("OUT_DIR"), "/", "tari.core.rs"));
-}
+pub(crate) mod generated;
+pub use generated::core;
 
 #[cfg(feature = "base_node")]
 mod block;

--- a/base_layer/core/src/transactions/proto/mod.rs
+++ b/base_layer/core/src/transactions/proto/mod.rs
@@ -20,9 +20,7 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-pub mod types {
-    include!(concat!(env!("OUT_DIR"), "/", "tari.types.rs"));
-}
+pub use crate::proto::generated::types;
 
 mod transaction;
 mod types_impls;

--- a/base_layer/core/src/transactions/transaction_protocol/proto/mod.rs
+++ b/base_layer/core/src/transactions/transaction_protocol/proto/mod.rs
@@ -20,11 +20,7 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use crate::transactions::proto::types;
-
-pub mod protocol {
-    include!(concat!(env!("OUT_DIR"), "/", "tari.transaction_protocol.rs"));
-}
+pub use crate::proto::generated::transaction_protocol as protocol;
 
 pub mod recipient_signed_message;
 pub mod transaction_metadata;


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR improves the dev experience of using generated protobuf structs
in `tari_core` by adding them as a normal rust module rather than including from the
OUR_DIR.

Generated files are included in `src/proto/generated` and are
gitignored. From there, these structs can be imported in exactly the
same way as any other struct and an IDE can inspect them in the same way
as as any other struct.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Developer experience is poor when generated structs are not included as normal modules.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Existing tests pass

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [ ] I'm merging against the `development` branch.
* [ ] I ran `cargo-fmt --all` before pushing.
* [ ] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
