### PR TITLE
tari_comms minimum tokio version requirement

### DIFF
--- a/comms/Cargo.toml
+++ b/comms/Cargo.toml
@@ -35,7 +35,7 @@ rand = "0.7.2"
 serde = "1.0.90"
 serde_derive = "1.0.90"
 snow = {version="=0.6.2", features=["default-resolver"]}
-tokio = {version="^0.2", features=["blocking", "tcp", "stream", "dns", "sync", "stream", "signal"]}
+tokio = {version="~0.2.19", features=["blocking", "tcp", "stream", "dns", "sync", "stream", "signal"]}
 tokio-util = {version="0.2.0", features=["codec"]}
 tower= "0.3.1"
 yamux = "=0.4.5"


### PR DESCRIPTION
Tari comms requires `OwnedSemaphorePermit` available from `tokio@0.2.19`