### PR TITLE
Adding additional GRPC endpoints for block explorer

### DIFF
--- a/applications/tari_base_node/proto/base_node.proto
+++ b/applications/tari_base_node/proto/base_node.proto
@@ -26,6 +26,7 @@ package tari.base_node;
 import "google/protobuf/wrappers.proto";
 import "google/protobuf/timestamp.proto";
 
+
 // The gRPC interface for interacting with the base node.
 service BaseNode {
     // Lists headers in the current best chain
@@ -33,19 +34,115 @@ service BaseNode {
     // Returns blocks in the current best chain. Currently only supports querying by height
     rpc GetBlocks(GetBlocksRequest) returns (stream HistoricalBlock);
     // Returns the calc timing for the chain heights
-    rpc GetCalcTiming(GetCalcTimingRequest) returns (CalcTimingResponse);
+    rpc GetCalcTiming(HeightRequest) returns (CalcTimingResponse);
+    // Returns the network Constants
+    rpc GetConstants(Empty) returns (ConsensusConstants);
+    // Returns Block Sizes
+    rpc GetBlockSize (BlockGroupRequest) returns (BlockGroupResponse);
+    // Returns Block Fees
+    rpc GetBlockFees (BlockGroupRequest) returns (BlockGroupResponse);
+    // Get Version
+    rpc GetVersion(Empty) returns (StringValue);
+    // Get coins in circulation
+    rpc GetTokensInCirculation(IntegerValue) returns (IntegerValue);
+    // Get network difficulties
+    rpc GetNetworkDifficulty(HeightRequest) returns (stream NetworkDifficultyResponse);
 }
 
+/// An Empty placeholder for endpoints without request parameters
+message Empty {}
 
-// The request used for querying the calc timing from the base node.
-// If start_height and end_height are set and > 0, they take precedence, otherwise from_tip is used
-message GetCalcTimingRequest {
+// Network difficulty response
+message NetworkDifficultyResponse {
+    uint64 difficulty = 1;
+    uint64 estimated_hash_rate = 2;
+    uint64 height = 3;
+}
+
+// A generic single value response for a specific height
+message ValueAtHeightResponse {
+    uint64 value= 1;
+    uint64 height = 2;
+}
+
+// A generic uint value
+message IntegerValue {
+    uint64 value = 1;
+}
+
+// A generic String value
+message StringValue {
+    string value = 1;
+}
+
+/// GetBlockSize / GetBlockFees Request
+/// Either the starting and ending heights OR the from_tip param must be specified
+message BlockGroupRequest {
     // The height from the chain tip (optional)
     uint64 from_tip = 1;
     // The starting height (optional)
     uint64 start_height = 2;
     // The ending height (optional)
     uint64 end_height = 3;
+    /// The type of calculation required (optional)
+    /// Defaults to median
+    /// median, mean, quartile, quantile
+    CalcType calc_type = 4;
+}
+
+/// GetBlockSize / GetBlockFees  Response
+message BlockGroupResponse {
+    repeated double value = 1;
+    CalcType calc_type = 2;
+}
+
+enum CalcType {
+    MEAN = 0;
+    MEDIAN = 1;
+    QUANTILE = 2;
+    QUARTILE = 3;
+}
+
+// The request used for querying a function that requires a height, either between 2 points or from the chain tip
+// If start_height and end_height are set and > 0, they take precedence, otherwise from_tip is used
+message HeightRequest {
+    // The height from the chain tip (optional)
+    uint64 from_tip = 1;
+    // The starting height (optional)
+    uint64 start_height = 2;
+    // The ending height (optional)
+    uint64 end_height = 3;
+}
+
+/// Consensus Constants response
+message ConsensusConstants {
+    /// The min height maturity a coinbase utxo must have
+    uint64 coinbase_lock_height = 1;
+    /// Current version of the blockchain
+    uint32 blockchain_version = 2;
+    /// The Future Time Limit (FTL) of the blockchain in seconds. This is the max allowable timestamp that is excepted.
+    /// We use TxN/20 where T = target time = 60 seconds, and N = block_window = 150
+    uint64 future_time_limit = 3;
+    /// This is the our target time in seconds between blocks
+    uint64 target_block_interval = 4;
+    /// When doing difficulty adjustments and FTL calculations this is the amount of blocks we look at
+    uint64 difficulty_block_window = 5;
+    /// When doing difficulty adjustments, this is the maximum block time allowed
+    uint64 difficulty_max_block_interval = 6;
+    /// Maximum transaction weight used for the construction of new blocks.
+    uint64 max_block_transaction_weight = 7;
+    /// The amount of PoW algorithms used by the Tari chain.
+    uint64 pow_algo_count = 8;
+    /// This is how many blocks we use to count towards the median timestamp to ensure the block chain moves forward
+    uint64 median_timestamp_count = 9;
+    /// This is the initial emission curve amount
+    uint64 emission_initial = 10;
+    /// This is the emission curve delay
+    double emission_decay = 11;
+    /// This is the emission curve tail amount
+    uint64 emission_tail = 12;
+    /// This is the initial min difficulty for the difficulty adjustment
+    uint64 min_blake_pow_difficulty = 13;
 }
 
 // The return type of the rpc GetCalcTiming

--- a/applications/tari_base_node/src/grpc/blocks.rs
+++ b/applications/tari_base_node/src/grpc/blocks.rs
@@ -1,0 +1,75 @@
+// Copyright 2019. The Tari Project
+//
+// Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+// following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+// disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+// following disclaimer in the documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+// products derived from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+// INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+// WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+// USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+use tari_core::{base_node::LocalNodeCommsInterface, blocks::BlockHeader, chain_storage::HistoricalBlock};
+use tonic::Status;
+
+// The maximum number of blocks that can be requested at a time. These will be streamed to the
+// client, so memory is not really a concern here, but a malicious client could request a large
+// number here to keep the node busy
+pub const GET_BLOCKS_MAX_HEIGHTS: usize = 1000;
+
+// The number of blocks to request from the base node at a time. This is to reduce the number of
+// requests to the base node, but if you'd like to stream directly, this can be set to 1.
+pub const GET_BLOCKS_PAGE_SIZE: usize = 10;
+
+/// Magic number for input and output sizes
+pub const BLOCK_INPUT_SIZE: u64 = 4;
+pub const BLOCK_OUTPUT_SIZE: u64 = 13;
+
+/// Returns the block heights based on the start and end heights or from_tip
+pub async fn block_heights(
+    handler: LocalNodeCommsInterface,
+    start_height: u64,
+    end_height: u64,
+    from_tip: u64,
+) -> Result<Vec<u64>, Status>
+{
+    let heights = if start_height > 0 && end_height > 0 {
+        Ok(BlockHeader::get_height_range(start_height, end_height))
+    } else if from_tip > 0 {
+        BlockHeader::get_heights_from_tip(handler, from_tip)
+            .await
+            .map_err(|e| Status::internal(e.to_string()))
+    } else {
+        return Err(Status::invalid_argument("Invalid arguments provided"));
+    };
+    heights
+}
+
+pub fn block_size(block: &HistoricalBlock) -> u64 {
+    let body = block.clone().block.body;
+
+    let input_size = body.inputs().len() as u64 * BLOCK_INPUT_SIZE;
+    let output_size = body.outputs().len() as u64 * BLOCK_OUTPUT_SIZE;
+    input_size + output_size
+}
+
+pub fn block_fees(block: &HistoricalBlock) -> u64 {
+    let body = block.clone().block.body;
+    body.kernels()
+        .iter()
+        .map(|k| k.fee.into())
+        .collect::<Vec<u64>>()
+        .iter()
+        .sum::<u64>()
+}

--- a/applications/tari_base_node/src/grpc/helpers.rs
+++ b/applications/tari_base_node/src/grpc/helpers.rs
@@ -20,35 +20,53 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use super::consensus_constants::ConsensusConstants;
-use tari_common::configuration::Network as GlobalNetwork;
-/// Specifies the configured chain network.
-#[derive(Copy, Clone)]
-pub enum Network {
-    /// Mainnet of Tari, currently should panic if network is set to this.
-    MainNet,
-    /// Alpha net version
-    Rincewind,
-    /// Local network constants used inside of unit and integration tests. Contains the genesis block to be used for
-    /// that chain.
-    LocalNet,
-}
-
-impl Network {
-    pub fn create_consensus_constants(self) -> ConsensusConstants {
-        match self {
-            Network::MainNet => ConsensusConstants::mainnet(),
-            Network::Rincewind => ConsensusConstants::rincewind(),
-            Network::LocalNet => ConsensusConstants::localnet(),
-        }
+pub fn median(mut list: Vec<u64>) -> Option<f64> {
+    if list.is_empty() {
+        return None;
     }
+    list.sort();
+    let mid_index = list.len() / 2;
+    let median = if list.len() % 2 == 0 {
+        (list[mid_index - 1] + list[mid_index]) as f64 / 2.0
+    } else {
+        list[mid_index] as f64
+    };
+    Some(median)
 }
 
-impl From<GlobalNetwork> for Network {
-    fn from(global_network: GlobalNetwork) -> Self {
-        match global_network {
-            GlobalNetwork::MainNet => Network::MainNet,
-            GlobalNetwork::Rincewind => Network::Rincewind,
-        }
+pub fn mean(list: Vec<u64>) -> Option<f64> {
+    if list.is_empty() {
+        return None;
+    }
+    let mut count = 0;
+    let total = list.iter().inspect(|_| count += 1).sum::<u64>();
+    Some(total as f64 / count as f64)
+}
+/// TODO Implement the function for grpc responsed
+pub fn quantile(_list: Vec<u64>) -> Option<f64> {
+    None
+}
+
+/// TODO Implement the function for grpc responsed
+pub fn quartile(_list: Vec<u64>) -> Option<f64> {
+    None
+}
+
+#[cfg(test)]
+pub mod test {
+    use super::*;
+
+    #[test]
+    fn median() {
+        let mut values = vec![1u64, 8u64, 3u64, 9u64];
+        let median_value = super::median(values);
+        assert_eq!(median_value, Some(5.5f64))
+    }
+
+    #[test]
+    fn mean() {
+        let values = vec![1u64, 8u64, 3u64, 9u64];
+        let mean_value = super::mean(values);
+        assert_eq!(mean_value, Some(5.25f64))
     }
 }

--- a/applications/tari_base_node/src/grpc/mod.rs
+++ b/applications/tari_base_node/src/grpc/mod.rs
@@ -1,0 +1,3 @@
+pub mod blocks;
+pub mod helpers;
+pub mod server;

--- a/applications/tari_base_node/src/main.rs
+++ b/applications/tari_base_node/src/main.rs
@@ -202,7 +202,8 @@ fn main_inner() -> Result<(), ExitCodes> {
 
     cli::print_banner(parser.get_commands(), 3);
     if node_config.grpc_enabled {
-        let grpc = crate::grpc::BaseNodeGrpcServer::new(rt.handle().clone(), ctx.local_node());
+        let grpc =
+            crate::grpc::server::BaseNodeGrpcServer::new(rt.handle().clone(), ctx.local_node(), node_config.clone());
 
         rt.spawn(run_grpc(grpc, node_config.grpc_address));
     }
@@ -225,11 +226,11 @@ fn main_inner() -> Result<(), ExitCodes> {
 }
 
 /// Runs the gRPC server
-async fn run_grpc(grpc: crate::grpc::BaseNodeGrpcServer, grpc_address: SocketAddr) -> Result<(), String> {
+async fn run_grpc(grpc: crate::grpc::server::BaseNodeGrpcServer, grpc_address: SocketAddr) -> Result<(), String> {
     info!(target: LOG_TARGET, "Starting GRPC on {}", grpc_address);
 
     Server::builder()
-        .add_service(crate::grpc::base_node_grpc::base_node_server::BaseNodeServer::new(grpc))
+        .add_service(crate::grpc::server::base_node_grpc::base_node_server::BaseNodeServer::new(grpc))
         .serve(grpc_address)
         .await
         .map_err(|e| format!("GRPC server returned error:{}", e))?;

--- a/base_layer/core/src/base_node/comms_interface/local_interface.rs
+++ b/base_layer/core/src/base_node/comms_interface/local_interface.rs
@@ -31,6 +31,7 @@ use crate::{
     blocks::{Block, BlockHeader, NewBlockTemplate},
     chain_storage::{ChainMetadata, HistoricalBlock},
     proof_of_work::{Difficulty, PowAlgorithm},
+    transactions::types::HashOutput,
 };
 use futures::{stream::Fuse, StreamExt};
 use std::sync::Arc;

--- a/base_layer/core/src/blocks/blockheader.rs
+++ b/base_layer/core/src/blocks/blockheader.rs
@@ -173,11 +173,13 @@ impl BlockHeader {
     {
         let metadata = handler.get_metadata().await?;
         let tip = metadata.height_of_longest_chain.unwrap_or(0);
-
-        let start = std::cmp::max(tip - height_from_tip, 1);
+        // Avoid overflow
+        let height_from_tip = std::cmp::min(tip, height_from_tip);
+        let start = std::cmp::max(tip - height_from_tip, 0);
         Ok(BlockHeader::get_height_range(start, tip))
     }
 
+    /// Returns a height range in descending order
     pub fn get_height_range(start: u64, end_inclusive: u64) -> Vec<u64> {
         let mut heights: Vec<u64> =
             (std::cmp::min(start, end_inclusive)..=std::cmp::max(start, end_inclusive)).collect();

--- a/common/src/configuration/global.rs
+++ b/common/src/configuration/global.rs
@@ -36,7 +36,7 @@ use std::{
 
 //-------------------------------------        Main Configuration Struct      --------------------------------------//
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct GlobalConfig {
     pub network: Network,
     pub comms_transport: CommsTransport,
@@ -350,7 +350,7 @@ fn config_string(network: &str, key: &str) -> String {
 }
 
 //---------------------------------------------       Network type        ------------------------------------------//
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Copy)]
 pub enum Network {
     MainNet,
     Rincewind,
@@ -382,7 +382,7 @@ impl Display for Network {
 }
 
 //---------------------------------------------      Database type        ------------------------------------------//
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub enum DatabaseType {
     LMDB(PathBuf),
     Memory,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
The following endpoints have been added to the GRPC service based on the core requirements. 
- GetConstants
- GetBlockSize
- GetBlockFees
- GetVersion
- GetTokensInCirculation
- GetNetworkDifficulty

I've used the standard local `LocalNodeCommsInterface` to extract all of the data used in these responses, it will probably be faster to use an instance of `async_db` and even faster once the `postgres_backend` branch is in to build more of these metrics directly into the db.

I wanted to get this up in the mean time, but GetBlockSize and GetBlockFees still need to have their quartile and quantile implementations created which is why their response type is an array of double.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
We required more stats from the base node for the block explorer.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
`cargo test`
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch.
* [x] I ran `cargo-fmt --all` before pushing.
* [x] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
