### PR TITLE
Buffer dropped messages logs for `pub_sub` channels

### DIFF
--- a/applications/tari_base_node/Cargo.toml
+++ b/applications/tari_base_node/Cargo.toml
@@ -19,7 +19,7 @@ tari_service_framework = { version = "^0.0", path = "../../base_layer/service_fr
 tari_shutdown = { path = "../../infrastructure/shutdown", version = "^0.0" }
 tari_mmr = { path = "../../base_layer/mmr", version = "^0.1" }
 tari_wallet = { path = "../../base_layer/wallet", version = "^0.1" }
-tari_broadcast_channel = "^0.1"
+tari_broadcast_channel = "^0.2"
 tari_crypto = { version = "^0.3" }
 
 structopt = { version = "0.3.13", default_features = false }

--- a/applications/tari_base_node/src/builder.rs
+++ b/applications/tari_base_node/src/builder.rs
@@ -492,7 +492,7 @@ where
 
     //---------------------------------- Base Node --------------------------------------------//
 
-    let (publisher, base_node_subscriptions) = pubsub_connector(handle.clone(), 100);
+    let (publisher, base_node_subscriptions) = pubsub_connector(handle.clone(), 100, 1);
     let base_node_subscriptions = Arc::new(base_node_subscriptions);
     create_peer_db_folder(&config.peer_db_path)?;
     let (base_node_comms, base_node_dht) = setup_base_node_comms(base_node_identity, config, publisher).await?;
@@ -515,7 +515,7 @@ where
     debug!(target: LOG_TARGET, "Base node service registration complete.");
 
     //---------------------------------- Wallet --------------------------------------------//
-    let (publisher, wallet_subscriptions) = pubsub_connector(handle.clone(), 100);
+    let (publisher, wallet_subscriptions) = pubsub_connector(handle.clone(), 100, 2);
     let wallet_subscriptions = Arc::new(wallet_subscriptions);
     create_peer_db_folder(&config.wallet_peer_db_path)?;
     let (wallet_comms, wallet_dht) = setup_wallet_comms(

--- a/base_layer/core/Cargo.toml
+++ b/base_layer/core/Cargo.toml
@@ -27,8 +27,8 @@ tari_common = { version= "^0.1", path = "../../common"}
 tari_service_framework = { version = "^0.0", path = "../service_framework"}
 tari_p2p = { version = "^0.1", path = "../../base_layer/p2p" }
 tari_comms_dht = { version = "^0.1", path = "../../comms/dht"}
-tari_broadcast_channel = "^0.1"
-tari_pubsub = "^0.1"
+tari_broadcast_channel = "^0.2"
+tari_pubsub = "^0.2"
 tari_shutdown = { version = "^0.0", path = "../../infrastructure/shutdown" }
 tari_mmr = { version = "^0.1", path = "../../base_layer/mmr", optional = true }
 randomx-rs = { version = "0.2.1", optional = true }

--- a/base_layer/core/src/base_node/chain_metadata_service/initializer.rs
+++ b/base_layer/core/src/base_node/chain_metadata_service/initializer.rs
@@ -46,7 +46,7 @@ impl ServiceInitializer for ChainMetadataServiceInitializer {
         shutdown: ShutdownSignal,
     ) -> Self::Future
     {
-        let (publisher, subscriber) = broadcast_channel::bounded(BROADCAST_EVENT_BUFFER_SIZE);
+        let (publisher, subscriber) = broadcast_channel::bounded(BROADCAST_EVENT_BUFFER_SIZE, 5);
         let handle = ChainMetadataHandle::new(subscriber);
         handles_fut.register(handle);
 

--- a/base_layer/core/src/base_node/chain_metadata_service/service.rs
+++ b/base_layer/core/src/base_node/chain_metadata_service/service.rs
@@ -303,7 +303,7 @@ mod test {
 
             let (base_node, mut base_node_receiver) = create_base_node_nci();
 
-            let (publisher, _subscriber) = broadcast_channel::bounded(1);
+            let (publisher, _subscriber) = broadcast_channel::bounded(1, 106);
             let mut service = ChainMetadataService::new(liveness_handle, base_node, publisher);
 
             let mut proto_chain_metadata = create_sample_proto_chain_metadata();
@@ -347,7 +347,7 @@ mod test {
 
         let (base_node, _) = create_base_node_nci();
 
-        let (publisher, _subscriber) = broadcast_channel::bounded(1);
+        let (publisher, _subscriber) = broadcast_channel::bounded(1, 107);
         let mut service = ChainMetadataService::new(liveness_handle, base_node, publisher);
 
         // To prevent the chain metadata buffer being flushed after receiving a single pong event,
@@ -377,7 +377,7 @@ mod test {
         };
 
         let (base_node, _) = create_base_node_nci();
-        let (publisher, _subscriber) = broadcast_channel::bounded(1);
+        let (publisher, _subscriber) = broadcast_channel::bounded(1, 108);
         let mut service = ChainMetadataService::new(liveness_handle, base_node, publisher);
 
         let sample_event = LivenessEvent::ReceivedPong(Box::new(pong_event));
@@ -400,7 +400,7 @@ mod test {
         };
 
         let (base_node, _) = create_base_node_nci();
-        let (publisher, _subscriber) = broadcast_channel::bounded(1);
+        let (publisher, _subscriber) = broadcast_channel::bounded(1, 109);
         let mut service = ChainMetadataService::new(liveness_handle, base_node, publisher);
 
         let sample_event = LivenessEvent::ReceivedPong(Box::new(pong_event));

--- a/base_layer/core/src/base_node/state_machine.rs
+++ b/base_layer/core/src/base_node/state_machine.rs
@@ -87,8 +87,8 @@ impl<B: BlockchainBackend + 'static> BaseNodeStateMachine<B> {
         shutdown_signal: ShutdownSignal,
     ) -> Self
     {
-        let (event_sender, event_receiver): (Publisher<_>, Subscriber<_>) = bounded(10);
-        let (status_event_publisher, status_event_subscriber): (Publisher<_>, Subscriber<_>) = bounded(1); // only latest update is important
+        let (event_sender, event_receiver): (Publisher<_>, Subscriber<_>) = bounded(10, 3);
+        let (status_event_publisher, status_event_subscriber): (Publisher<_>, Subscriber<_>) = bounded(1, 4); // only latest update is important
         Self {
             db: db.clone(),
             local_node_interface: local_node_interface.clone(),

--- a/base_layer/core/src/mempool/service/initializer.rs
+++ b/base_layer/core/src/mempool/service/initializer.rs
@@ -160,7 +160,7 @@ where T: BlockchainBackend + 'static
         let (outbound_tx_sender_service, outbound_tx_stream) = futures_mpsc_channel_unbounded();
         let (outbound_request_sender_service, outbound_request_stream) = reply_channel::unbounded();
         let (local_request_sender_service, local_request_stream) = reply_channel::unbounded();
-        let (mempool_state_event_publisher, mempool_state_event_subscriber) = bounded(100);
+        let (mempool_state_event_publisher, mempool_state_event_subscriber) = bounded(100, 6);
         let outbound_mp_interface =
             OutboundMempoolServiceInterface::new(outbound_request_sender_service, outbound_tx_sender_service);
         let local_mp_interface = LocalMempoolService::new(local_request_sender_service, mempool_state_event_subscriber);

--- a/base_layer/core/src/mempool/service/local_service.rs
+++ b/base_layer/core/src/mempool/service/local_service.rs
@@ -129,7 +129,7 @@ mod test {
 
     #[tokio_macros::test]
     async fn mempool_stats() {
-        let (_, event_subscriber) = bounded(100);
+        let (_, event_subscriber) = bounded(100, 110);
         let (tx, rx) = unbounded();
         let mut service = LocalMempoolService::new(tx, event_subscriber);
         task::spawn(mock_handler(rx));
@@ -140,7 +140,7 @@ mod test {
 
     #[tokio_macros::test]
     async fn mempool_stats_from_multiple() {
-        let (_, event_subscriber) = bounded(100);
+        let (_, event_subscriber) = bounded(100, 111);
         let (tx, rx) = unbounded();
         let mut service = LocalMempoolService::new(tx, event_subscriber);
         let mut service2 = service.clone();

--- a/base_layer/core/tests/helpers/chain_metadata.rs
+++ b/base_layer/core/tests/helpers/chain_metadata.rs
@@ -42,7 +42,7 @@ pub struct MockChainMetadata {
 
 impl MockChainMetadata {
     pub fn new() -> Self {
-        let (publisher, subscriber) = bounded(10);
+        let (publisher, subscriber) = bounded(10, 114);
         Self { publisher, subscriber }
     }
 

--- a/base_layer/core/tests/helpers/nodes.rs
+++ b/base_layer/core/tests/helpers/nodes.rs
@@ -448,7 +448,7 @@ fn setup_base_node_services(
     CommsNode,
 )
 {
-    let (publisher, subscription_factory) = pubsub_connector(runtime.handle().clone(), 100);
+    let (publisher, subscription_factory) = pubsub_connector(runtime.handle().clone(), 100, 104);
     let subscription_factory = Arc::new(subscription_factory);
     let (comms, dht) = runtime.block_on(setup_comms_services(node_identity, peers, publisher, data_path));
 

--- a/base_layer/core/tests/mining.rs
+++ b/base_layer/core/tests/mining.rs
@@ -102,7 +102,7 @@ fn mining() {
     let shutdown = Shutdown::new();
     let mut miner = Miner::new(shutdown.to_signal(), consensus_manager, &alice_node.local_nci, 1);
     miner.enable_mining_flag().store(true, Ordering::Relaxed);
-    let (mut state_event_sender, state_event_receiver): (Publisher<_>, Subscriber<_>) = bounded(1);
+    let (mut state_event_sender, state_event_receiver): (Publisher<_>, Subscriber<_>) = bounded(1, 112);
     miner.subscribe_to_node_state_events(state_event_receiver);
     miner.subscribe_to_mempool_state_events(alice_node.local_mp_interface.get_mempool_state_event_stream());
     let miner_utxo_stream = miner.get_utxo_receiver_channel().fuse();

--- a/base_layer/core/tests/wallet.rs
+++ b/base_layer/core/tests/wallet.rs
@@ -301,7 +301,7 @@ fn wallet_base_node_integration_test() {
     let mut shutdown = Shutdown::new();
     let mut miner = Miner::new(shutdown.to_signal(), consensus_manager, &base_node.local_nci, 1);
     miner.enable_mining_flag().store(true, Ordering::Relaxed);
-    let (mut state_event_sender, state_event_receiver): (Publisher<_>, Subscriber<_>) = bounded(1);
+    let (mut state_event_sender, state_event_receiver): (Publisher<_>, Subscriber<_>) = bounded(1, 113);
     miner.subscribe_to_node_state_events(state_event_receiver);
     miner.subscribe_to_mempool_state_events(base_node.local_mp_interface.get_mempool_state_event_stream());
     let miner_utxo_stream = miner.get_utxo_receiver_channel().fuse();

--- a/base_layer/p2p/Cargo.toml
+++ b/base_layer/p2p/Cargo.toml
@@ -13,11 +13,11 @@ edition = "2018"
 test-mocks = []
 
 [dependencies]
-tari_broadcast_channel = "^0.1"
+tari_broadcast_channel = "^0.2"
 tari_comms = { version = "^0.1", path = "../../comms"}
 tari_comms_dht = { version = "^0.1", path = "../../comms/dht"}
 tari_crypto = { version = "^0.3" }
-tari_pubsub = "^0.1"
+tari_pubsub = "^0.2"
 tari_service_framework = { version = "^0.0", path = "../service_framework"}
 tari_shutdown = { version = "^0.0", path="../../infrastructure/shutdown" }
 tari_storage = {version = "^0.1", path = "../../infrastructure/storage"}

--- a/base_layer/p2p/examples/pingpong.rs
+++ b/base_layer/p2p/examples/pingpong.rs
@@ -143,7 +143,7 @@ mod pingpong {
 
         let datastore_path = TempDir::new(random_string(8).as_str()).unwrap();
 
-        let (publisher, subscription_factory) = pubsub_connector(rt.handle().clone(), 100);
+        let (publisher, subscription_factory) = pubsub_connector(rt.handle().clone(), 100, 105);
         let subscription_factory = Arc::new(subscription_factory);
 
         let transport_type = if is_tor_enabled {

--- a/base_layer/p2p/src/comms_connector/pubsub.rs
+++ b/base_layer/p2p/src/comms_connector/pubsub.rs
@@ -25,7 +25,7 @@ use crate::{comms_connector::InboundDomainConnector, tari_message::TariMessageTy
 use futures::{channel::mpsc, FutureExt, SinkExt, StreamExt};
 use log::*;
 use std::sync::Arc;
-use tari_pubsub::{pubsub_channel, TopicPayload, TopicSubscriptionFactory};
+use tari_pubsub::{pubsub_channel_with_id, TopicPayload, TopicSubscriptionFactory};
 use tokio::runtime::Handle;
 
 const LOG_TARGET: &str = "comms::middleware::pubsub";
@@ -35,8 +35,13 @@ pub type PubsubDomainConnector = InboundDomainConnector<mpsc::Sender<Arc<PeerMes
 pub type SubscriptionFactory = TopicSubscriptionFactory<TariMessageType, Arc<PeerMessage>>;
 
 /// Connects `InboundDomainConnector` to a `tari_pubsub::TopicPublisher` through a buffered channel
-pub fn pubsub_connector(executor: Handle, buf_size: usize) -> (PubsubDomainConnector, SubscriptionFactory) {
-    let (publisher, subscription_factory) = pubsub_channel(buf_size);
+pub fn pubsub_connector(
+    executor: Handle,
+    buf_size: usize,
+    buf_id: usize,
+) -> (PubsubDomainConnector, SubscriptionFactory)
+{
+    let (publisher, subscription_factory) = pubsub_channel_with_id(buf_size, buf_id);
     let (sender, receiver) = mpsc::channel(buf_size);
 
     // Spawn a task which forwards messages from the pubsub service to the TopicPublisher

--- a/base_layer/p2p/tests/services/liveness.rs
+++ b/base_layer/p2p/tests/services/liveness.rs
@@ -48,7 +48,7 @@ pub async fn setup_liveness_service(
 ) -> (LivenessHandle, CommsNode, Dht)
 {
     let rt_handle = runtime::Handle::current();
-    let (publisher, subscription_factory) = pubsub_connector(rt_handle.clone(), 100);
+    let (publisher, subscription_factory) = pubsub_connector(rt_handle.clone(), 100, 101);
     let subscription_factory = Arc::new(subscription_factory);
     let (comms, dht) = setup_comms_services(node_identity.clone(), peers, publisher, data_path).await;
 

--- a/base_layer/wallet/Cargo.toml
+++ b/base_layer/wallet/Cargo.toml
@@ -11,13 +11,13 @@ test_harness = ["tari_test_utils"]
 c_integration = []
 
 [dependencies]
-tari_broadcast_channel = "^0.1"
+tari_broadcast_channel = "^0.2"
 tari_comms = { path = "../../comms", version = "^0.1"}
 tari_comms_dht = { path = "../../comms/dht", version = "^0.1"}
 tari_crypto = { version = "^0.3" }
 tari_key_manager = {path = "../key_manager", version = "^0.0"}
 tari_p2p = {path = "../p2p", version = "^0.1"}
-tari_pubsub = "^0.1"
+tari_pubsub = "^0.2"
 tari_service_framework = { version = "^0.0", path = "../service_framework"}
 tari_shutdown = { path = "../../infrastructure/shutdown", version = "^0.0"}
 tari_storage = { version = "^0.1", path = "../../infrastructure/storage"}

--- a/base_layer/wallet/src/output_manager_service/mod.rs
+++ b/base_layer/wallet/src/output_manager_service/mod.rs
@@ -112,7 +112,7 @@ where T: OutputManagerBackend + 'static
         let base_node_response_stream = self.base_node_response_stream();
 
         let (sender, receiver) = reply_channel::unbounded();
-        let (publisher, subscriber) = bounded(100);
+        let (publisher, subscriber) = bounded(100, 7);
 
         let oms_handle = OutputManagerHandle::new(sender, subscriber);
 

--- a/base_layer/wallet/src/text_message_service/mod.rs
+++ b/base_layer/wallet/src/text_message_service/mod.rs
@@ -104,7 +104,7 @@ impl ServiceInitializer for TextMessageServiceInitializer {
             .expect("text message service initializer already called");
 
         let (sender, receiver) = reply_channel::unbounded();
-        let (publisher, subscriber) = bounded(100);
+        let (publisher, subscriber) = bounded(100, 117);
 
         let text_message_stream = self.text_message_stream();
         let text_message_ack_stream = self.text_message_ack_stream();

--- a/base_layer/wallet/src/transaction_service/service.rs
+++ b/base_layer/wallet/src/transaction_service/service.rs
@@ -1575,7 +1575,7 @@ where
 
         let (_sender, receiver) = reply_channel::unbounded();
         let (tx, _rx) = mpsc::channel(20);
-        let (oms_event_publisher, _oms_event_subscriber) = bounded(100);
+        let (oms_event_publisher, _oms_event_subscriber) = bounded(100, 118);
         let (ts_request_sender, _ts_request_receiver) = reply_channel::unbounded();
         let (event_publisher, _) = broadcast::channel(100);
         let ts_handle = TransactionServiceHandle::new(ts_request_sender, event_publisher.clone());

--- a/base_layer/wallet/src/wallet.rs
+++ b/base_layer/wallet/src/wallet.rs
@@ -131,6 +131,7 @@ where
         let (publisher, subscription_factory) = pubsub_connector(
             runtime.handle().clone(),
             config.comms_config.max_concurrent_inbound_tasks,
+            4,
         );
         let subscription_factory = Arc::new(subscription_factory);
 

--- a/base_layer/wallet/tests/output_manager_service/service.rs
+++ b/base_layer/wallet/tests/output_manager_service/service.rs
@@ -98,7 +98,7 @@ pub fn setup_output_manager_service<T: OutputManagerBackend + 'static>(
     let (outbound_message_requester, mock_outbound_service) = create_outbound_service_mock(20);
     let (oms_request_sender, oms_request_receiver) = reply_channel::unbounded();
     let (base_node_response_sender, base_node_response_receiver) = mpsc::channel(20);
-    let (oms_event_publisher, oms_event_subscriber) = bounded(100);
+    let (oms_event_publisher, oms_event_subscriber) = bounded(100, 115);
 
     let (ts_request_sender, _ts_request_receiver) = reply_channel::unbounded();
     let (event_publisher, _) = channel(100);

--- a/base_layer/wallet/tests/text_message_service/mod.rs
+++ b/base_layer/wallet/tests/text_message_service/mod.rs
@@ -46,7 +46,7 @@ pub fn setup_text_message_service(
     database_path: String,
 ) -> (TextMessageHandle, CommsNode, Dht)
 {
-    let (publisher, subscription_factory) = pubsub_connector(runtime.executor(), 100);
+    let (publisher, subscription_factory) = pubsub_connector(runtime.executor(), 100, 102);
     let subscription_factory = Arc::new(subscription_factory);
     let (comms, dht) = setup_comms_services(runtime.executor(), Arc::new(node_identity.clone()), peers, publisher);
 

--- a/base_layer/wallet/tests/transaction_service/service.rs
+++ b/base_layer/wallet/tests/transaction_service/service.rs
@@ -151,7 +151,7 @@ pub fn setup_transaction_service<T: TransactionBackend + Clone + 'static>(
     discovery_request_timeout: Duration,
 ) -> (TransactionServiceHandle, OutputManagerHandle, CommsNode)
 {
-    let (publisher, subscription_factory) = pubsub_connector(runtime.handle().clone(), 100);
+    let (publisher, subscription_factory) = pubsub_connector(runtime.handle().clone(), 100, 103);
     let subscription_factory = Arc::new(subscription_factory);
     let (comms, dht) = runtime.block_on(setup_comms_services(
         node_identity,
@@ -224,7 +224,7 @@ pub fn setup_transaction_service_no_comms<T: TransactionBackend + Clone + 'stati
 {
     let (oms_request_sender, oms_request_receiver) = reply_channel::unbounded();
 
-    let (oms_event_publisher, oms_event_subscriber) = bounded(100);
+    let (oms_event_publisher, oms_event_subscriber) = bounded(100, 116);
     let (outbound_message_requester, mock_outbound_service) = create_outbound_service_mock(100);
 
     let (liveness_handle, liveness_mock, liveness_event_sender) = create_p2p_liveness_mock(50);

--- a/base_layer/wallet_ffi/Cargo.toml
+++ b/base_layer/wallet_ffi/Cargo.toml
@@ -20,7 +20,7 @@ tokio = "0.2.10"
 libc = "0.2.65"
 rand = "0.7.2"
 chrono = { version = "0.4.6", features = ["serde"]}
-tari_broadcast_channel = "^0.1"
+tari_broadcast_channel = "^0.2"
 derive-error = "0.0.4"
 log = "0.4.6"
 log4rs = {version = "0.8.3", features = ["console_appender", "file_appender", "file", "yaml_format"]}

--- a/common/logging/log4rs-debug-sample.yml
+++ b/common/logging/log4rs-debug-sample.yml
@@ -123,3 +123,9 @@ loggers:
     appenders:
       - other
     additive: false
+  # Route log events sent to the "pub_sub" logger to the "other" appender
+  tari_broadcast_channel:
+    level: debug
+    appenders:
+      - other
+    additive: false

--- a/common/logging/log4rs-sample.yml
+++ b/common/logging/log4rs-sample.yml
@@ -122,3 +122,9 @@ loggers:
     appenders:
       - other
     additive: false
+  # Route log events sent to the "pub_sub" logger to the "other" appender
+  tari_broadcast_channel:
+    level: debug
+    appenders:
+      - other
+    additive: false


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- Added buffer dropped messages logs with unique subscriber ID seed values for `pub_sub` channels.
- Updated `log4rs*.yml` to include logging of the `pub_sub` logger.
- Dependent on linked PR in https://github.com/tari-project/pubsub/pull/2 and crate to be released, using the new `pubsub_channel_with_id` interface (Previous linked PRs: https://github.com/tari-project/broadcast_channel/pull/2 and https://github.com/tari-project/pubsub/pull/1).

The following unique subscriber seed values have been assigned to `pub_sub` users for base node runtime:
```
applications\tari_base_node\src\builder.rs:
  let (publisher, base_node_subscriptions) = pubsub_connector(handle.clone(), 100, 1);
  let (publisher, wallet_subscriptions) = pubsub_connector(handle.clone(), 100, 2);

base_layer\core\src\base_node\state_machine.rs:
  let (event_sender, event_receiver): (Publisher<_>, Subscriber<_>) = bounded(10, 3);
  let (status_event_publisher, status_event_subscriber): (Publisher<_>, Subscriber<_>) = bounded(1, 4);

base_layer\core\src\base_node\chain_metadata_service\initializer.rs:
  let (publisher, subscriber) = broadcast_channel::bounded(BROADCAST_EVENT_BUFFER_SIZE, 5);

base_layer\core\src\mempool\service\initializer.rs:
  let (mempool_state_event_publisher, mempool_state_event_subscriber) = bounded(100, 6);

base_layer\wallet\src\output_manager_service\mod.rs:
  let (publisher, subscriber) = bounded(100, 7);
```

Sample log file extract of a base node startup with a large wallet, showing 67 (by design) messages dropped in the `ServiceInitializer for ChainMetadataServiceInitializer`:
```
2020-05-27 15:54:05.106470800 [pub_sub] TRACE Subscrber with ID '20003', receive error: 'receiving on an empty channel'
2020-05-27 15:54:05.227469300 [pub_sub] TRACE Subscrber with ID '20002', receive error: 'receiving on an empty channel'
2020-05-27 15:54:05.227469300 [pub_sub] TRACE Subscrber with ID '50000' was cloned, new subscription.
2020-05-27 15:54:05.227469300 [pub_sub] TRACE Subscrber with ID '50001' was cloned, new subscription.
2020-05-27 15:54:05.227469300 [pub_sub] DEBUG Buffer created with ID '30000' (3) and size 10, consecutive subscriptions add 1 to the ID.
2020-05-27 15:54:05.227469300 [pub_sub] DEBUG Buffer created with ID '40000' (4) and size 1, consecutive subscriptions add 1 to the ID.
2020-05-27 15:54:05.227469300 [pub_sub] TRACE Subscrber with ID '60000' was cloned, new subscription.
2020-05-27 15:54:05.227469300 [pub_sub] TRACE Subscrber with ID '30000' was cloned, new subscription.
2020-05-27 15:54:05.227469300 [pub_sub] TRACE Subscrber with ID '60001' was cloned, new subscription.
2020-05-27 15:54:05.227469300 [pub_sub] TRACE Subscrber with ID '70000' was cloned, new subscription.
2020-05-27 15:54:05.227469300 [pub_sub] TRACE Subscrber with ID '60000' was cloned, new subscription.
2020-05-27 15:54:05.227469300 [pub_sub] TRACE Subscrber with ID '40000' was cloned, new subscription.
2020-05-27 15:54:06.071470400 [pub_sub] TRACE Subscrber with ID '70000' was cloned, new subscription.
2020-05-27 15:54:06.071470400 [pub_sub] ERROR Subscrber with ID '50003' has 67 buffer messages dropped.
2020-05-27 15:54:06.071470400 [pub_sub] TRACE Subscrber with ID '10003', receive error: 'receiving on an empty channel'
2020-05-27 15:54:06.071470400 [pub_sub] TRACE Subscrber with ID '10002', receive error: 'receiving on an empty channel'
2020-05-27 15:54:06.071470400 [pub_sub] TRACE Subscrber with ID '10001', receive error: 'receiving on an empty channel'
```

## Motivation and Context
Monitoring is needed for dropped messages in the pub_sub subscription channels. See linked PRs.

## How Has This Been Tested?
Performed a system-level test on Windows as part of a Tari base node executable.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [X] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [X] I'm merging against the `development` branch.
* [X] I ran `cargo-fmt --all` before pushing.
* [X] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
