### PR TITLE
Base node requests for fetching the MMR nodes and count

### DIFF
--- a/base_layer/core/src/base_node/comms_interface/comms_request.rs
+++ b/base_layer/core/src/base_node/comms_interface/comms_request.rs
@@ -51,6 +51,8 @@ pub enum NodeCommsRequest {
     GetNewBlockTemplate(PowAlgorithm),
     GetNewBlock(NewBlockTemplate),
     GetTargetDifficulty(PowAlgorithm),
+    FetchMmrNodeCount(MmrTree, u64),
+    FetchMmrNodes(MmrTree, u32, u32),
 }
 
 impl Display for NodeCommsRequest {
@@ -67,6 +69,13 @@ impl Display for NodeCommsRequest {
             NodeCommsRequest::GetNewBlockTemplate(algo) => f.write_str(&format!("GetNewBlockTemplate ({})", algo)),
             NodeCommsRequest::GetNewBlock(b) => f.write_str(&format!("GetNewBlock (Block Height={})", b.header.height)),
             NodeCommsRequest::GetTargetDifficulty(algo) => f.write_str(&format!("GetTargetDifficulty ({})", algo)),
+            NodeCommsRequest::FetchMmrNodeCount(tree, height) => {
+                f.write_str(&format!("FetchMmrNodeCount (tree={},Block Height={})", tree, height))
+            },
+            NodeCommsRequest::FetchMmrNodes(tree, pos, count) => f.write_str(&format!(
+                "FetchMmrNodeCount (tree={},pos={},count={})",
+                tree, pos, count
+            )),
         }
     }
 }

--- a/base_layer/core/src/base_node/comms_interface/comms_response.rs
+++ b/base_layer/core/src/base_node/comms_interface/comms_response.rs
@@ -24,7 +24,10 @@ use crate::{
     blocks::{blockheader::BlockHeader, Block, NewBlockTemplate},
     chain_storage::{ChainMetadata, HistoricalBlock},
     proof_of_work::Difficulty,
-    transactions::transaction::{TransactionKernel, TransactionOutput},
+    transactions::{
+        transaction::{TransactionKernel, TransactionOutput},
+        types::HashOutput,
+    },
 };
 use serde::{Deserialize, Serialize};
 
@@ -40,4 +43,6 @@ pub enum NodeCommsResponse {
     NewBlock(Block),
     TargetDifficulty(Difficulty),
     FetchHeadersAfterResponse(Vec<BlockHeader>),
+    MmrNodeCount(u32),
+    MmrNodes(Vec<HashOutput>, Vec<u8>),
 }

--- a/base_layer/core/src/base_node/proto/request.proto
+++ b/base_layer/core/src/base_node/proto/request.proto
@@ -1,6 +1,7 @@
 syntax = "proto3";
 
 import "block.proto";
+import "mmr_tree.proto";
 
 package tari.base_node;
 
@@ -30,6 +31,10 @@ message BaseNodeServiceRequest {
         uint64 get_target_difficulty = 11;
         // Get headers in best chain following any headers in this list
         FetchHeadersAfter fetch_headers_after = 12;
+        // Indicates a FetchMmrNodeCount request.
+        FetchMmrNodeCount fetch_mmr_node_count = 13;
+        // Indicates a FetchMmrNodes request.
+        FetchMmrNodes fetch_mmr_nodes = 14;
     }
 }
 
@@ -44,4 +49,15 @@ message HashOutputs {
 message FetchHeadersAfter {
     repeated bytes hashes = 1;
     bytes stopping_hash = 2;
+}
+
+message FetchMmrNodeCount {
+    MmrTree tree = 1;
+    uint64 height = 2;
+}
+
+message FetchMmrNodes{
+    MmrTree tree = 1;
+    uint32 pos = 2;
+    uint32 count = 3;
 }

--- a/base_layer/core/src/base_node/proto/request.rs
+++ b/base_layer/core/src/base_node/proto/request.rs
@@ -24,10 +24,12 @@ use super::base_node::{
     base_node_service_request::Request as ProtoNodeCommsRequest,
     BlockHeights,
     FetchHeadersAfter as ProtoFetchHeadersAfter,
+    FetchMmrNodeCount as ProtoFetchMmrNodeCount,
+    FetchMmrNodes as ProtoFetchMmrNodes,
     HashOutputs,
 };
 use crate::{base_node::comms_interface as ci, proof_of_work::PowAlgorithm, transactions::types::HashOutput};
-use std::convert::{TryFrom, TryInto};
+use std::convert::{From, TryFrom, TryInto};
 
 //---------------------------------- BaseNodeRequest --------------------------------------------//
 impl TryInto<ci::NodeCommsRequest> for ProtoNodeCommsRequest {
@@ -54,6 +56,12 @@ impl TryInto<ci::NodeCommsRequest> for ProtoNodeCommsRequest {
             GetTargetDifficulty(pow_algo) => {
                 ci::NodeCommsRequest::GetTargetDifficulty(PowAlgorithm::try_from(pow_algo)?)
             },
+            FetchMmrNodeCount(request) => {
+                ci::NodeCommsRequest::FetchMmrNodeCount(request.tree.try_into()?, request.height)
+            },
+            FetchMmrNodes(request) => {
+                ci::NodeCommsRequest::FetchMmrNodes(request.tree.try_into()?, request.pos, request.count)
+            },
         };
         Ok(request)
     }
@@ -76,6 +84,15 @@ impl From<ci::NodeCommsRequest> for ProtoNodeCommsRequest {
             GetNewBlockTemplate(pow_algo) => ProtoNodeCommsRequest::GetNewBlockTemplate(pow_algo as u64),
             GetNewBlock(block_template) => ProtoNodeCommsRequest::GetNewBlock(block_template.into()),
             GetTargetDifficulty(pow_algo) => ProtoNodeCommsRequest::GetTargetDifficulty(pow_algo as u64),
+            FetchMmrNodeCount(tree, height) => ProtoNodeCommsRequest::FetchMmrNodeCount(ProtoFetchMmrNodeCount {
+                tree: tree as i32,
+                height,
+            }),
+            FetchMmrNodes(tree, pos, count) => ProtoNodeCommsRequest::FetchMmrNodes(ProtoFetchMmrNodes {
+                tree: tree as i32,
+                pos,
+                count,
+            }),
         }
     }
 }

--- a/base_layer/core/src/base_node/proto/response.proto
+++ b/base_layer/core/src/base_node/proto/response.proto
@@ -28,6 +28,10 @@ message BaseNodeServiceResponse {
         uint64 target_difficulty = 9;
         // Block headers in range response
         BlockHeaders fetch_headers_after_response = 10;
+        // Indicates a MmrNodeCount response
+        uint32 MmrNodeCount = 11;
+        // Indicates a MmrNodes response
+        MmrNodes MmrNodes = 12;
     }
 }
 
@@ -45,5 +49,10 @@ message TransactionOutputs {
 
 message HistoricalBlocks {
     repeated tari.core.HistoricalBlock blocks = 1;
+}
+
+message MmrNodes {
+    repeated bytes added = 1;
+    bytes deleted = 2;
 }
 

--- a/base_layer/core/src/base_node/proto/response.rs
+++ b/base_layer/core/src/base_node/proto/response.rs
@@ -24,6 +24,7 @@ pub use super::base_node::base_node_service_response::Response as ProtoNodeComms
 use super::base_node::{
     BlockHeaders as ProtoBlockHeaders,
     HistoricalBlocks as ProtoHistoricalBlocks,
+    MmrNodes as ProtoMmrNodes,
     TransactionKernels as ProtoTransactionKernels,
     TransactionOutputs as ProtoTransactionOutputs,
 };
@@ -68,6 +69,8 @@ impl TryInto<ci::NodeCommsResponse> for ProtoNodeCommsResponse {
             NewBlockTemplate(block_template) => ci::NodeCommsResponse::NewBlockTemplate(block_template.try_into()?),
             NewBlock(block) => ci::NodeCommsResponse::NewBlock(block.try_into()?),
             TargetDifficulty(difficulty) => ci::NodeCommsResponse::TargetDifficulty(Difficulty::from(difficulty)),
+            MmrNodeCount(u64) => ci::NodeCommsResponse::MmrNodeCount(u64),
+            MmrNodes(response) => ci::NodeCommsResponse::MmrNodes(response.added, response.deleted),
         };
 
         Ok(response)
@@ -102,6 +105,8 @@ impl From<ci::NodeCommsResponse> for ProtoNodeCommsResponse {
             NewBlockTemplate(block_template) => ProtoNodeCommsResponse::NewBlockTemplate(block_template.into()),
             NewBlock(block) => ProtoNodeCommsResponse::NewBlock(block.into()),
             TargetDifficulty(difficulty) => ProtoNodeCommsResponse::TargetDifficulty(difficulty.as_u64()),
+            MmrNodeCount(node_count) => ProtoNodeCommsResponse::MmrNodeCount(node_count),
+            MmrNodes(added, deleted) => ProtoNodeCommsResponse::MmrNodes(ProtoMmrNodes { added, deleted }),
         }
     }
 }

--- a/base_layer/core/src/chain_storage/async_db.rs
+++ b/base_layer/core/src/chain_storage/async_db.rs
@@ -102,6 +102,8 @@ make_async!(is_stxo(hash: HashOutput) -> bool, "is_stxo");
 make_async!(fetch_mmr_root(tree: MmrTree) -> HashOutput, "fetch_mmr_root");
 make_async!(fetch_mmr_only_root(tree: MmrTree) -> HashOutput, "fetch_mmr_only_root");
 make_async!(calculate_mmr_root(tree: MmrTree,additions: Vec<HashOutput>,deletions: Vec<HashOutput>) -> HashOutput, "calculate_mmr_root");
+make_async!(fetch_mmr_node_count(tree: MmrTree, height: u64) -> u32, "fetch_mmr_node_count");
+make_async!(fetch_mmr_nodes(tree: MmrTree, pos: u32, count: u32) -> Vec<(Vec<u8>, bool)>, "fetch_mmr_nodes");
 make_async!(add_block(block: Block) -> BlockAddResult, "add_block");
 make_async!(calculate_mmr_roots(template: NewBlockTemplate) -> Block, "calculate_mmr_roots");
 

--- a/base_layer/core/src/chain_storage/db_transaction.rs
+++ b/base_layer/core/src/chain_storage/db_transaction.rs
@@ -29,7 +29,10 @@ use crate::{
     },
 };
 use serde::{Deserialize, Serialize};
-use std::fmt::{Display, Error, Formatter};
+use std::{
+    convert::TryFrom,
+    fmt::{Display, Error, Formatter},
+};
 use strum_macros::Display;
 use tari_crypto::tari_utilities::{hex::to_hex, Hashable};
 
@@ -274,6 +277,19 @@ impl Display for MmrTree {
             MmrTree::RangeProof => f.write_str("Range Proof"),
             MmrTree::Utxo => f.write_str("UTXO"),
             MmrTree::Kernel => f.write_str("Kernel"),
+        }
+    }
+}
+
+impl TryFrom<i32> for MmrTree {
+    type Error = String;
+
+    fn try_from(v: i32) -> Result<Self, Self::Error> {
+        match v {
+            0 => Ok(MmrTree::Utxo),
+            1 => Ok(MmrTree::Kernel),
+            2 => Ok(MmrTree::RangeProof),
+            _ => Err("Invalid MmrTree".into()),
         }
     }
 }

--- a/base_layer/core/src/chain_storage/lmdb_db/lmdb_db.rs
+++ b/base_layer/core/src/chain_storage/lmdb_db/lmdb_db.rs
@@ -666,11 +666,11 @@ where D: Digest + Send + Sync
     }
 
     fn fetch_mmr_nodes(&self, tree: MmrTree, pos: u32, count: u32) -> Result<Vec<(Vec<u8>, bool)>, ChainStorageError> {
-        let mut lead_nodes = Vec::<(Vec<u8>, bool)>::with_capacity(count as usize);
+        let mut leaf_nodes = Vec::<(Vec<u8>, bool)>::with_capacity(count as usize);
         for pos in pos..pos + count {
-            lead_nodes.push(self.fetch_mmr_node(tree.clone(), pos)?);
+            leaf_nodes.push(self.fetch_mmr_node(tree.clone(), pos)?);
         }
-        Ok(lead_nodes)
+        Ok(leaf_nodes)
     }
 
     /// Iterate over all the stored orphan blocks and execute the function `f` for each block.

--- a/base_layer/core/src/chain_storage/memory_db/memory_db.rs
+++ b/base_layer/core/src/chain_storage/memory_db/memory_db.rs
@@ -478,11 +478,11 @@ where D: Digest + Send + Sync
     }
 
     fn fetch_mmr_nodes(&self, tree: MmrTree, pos: u32, count: u32) -> Result<Vec<(Vec<u8>, bool)>, ChainStorageError> {
-        let mut lead_nodes = Vec::<(Vec<u8>, bool)>::with_capacity(count as usize);
+        let mut leaf_nodes = Vec::<(Vec<u8>, bool)>::with_capacity(count as usize);
         for pos in pos..pos + count {
-            lead_nodes.push(self.fetch_mmr_node(tree.clone(), pos)?);
+            leaf_nodes.push(self.fetch_mmr_node(tree.clone(), pos)?);
         }
-        Ok(lead_nodes)
+        Ok(leaf_nodes)
     }
 
     /// Iterate over all the stored orphan blocks and execute the function `f` for each block.


### PR DESCRIPTION
## Description
- Added the FetchMmrNodeCount and FetchMmrNodes base node requests. Also added the MmrNodeCount and MmrNodes responses that can be used to query the added and deleted mmr nodes from a base node.
- The inbound request handlers were also implemented with proto conversions.
- The db write lock from the blockchain db add_block method was moved to ensure a write lock does not need to be obtained for blocks that wont pass the orphan validation.

## Motivation and Context
Enables the base node request response system to sync the MMR leaf nodes for the Kernel, Utxo and Rangeproof MMRs.

## How Has This Been Tested?
The request_and_response_fetch_mmr_node_and_count test was added to test the base node FetchMmrNodeCount and FetchMmrNodes request system.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [x] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch.
* [x] I ran `cargo-fmt --all` before pushing.
* [x] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
