### PR TITLE
Emit cargo:rerun-if-changed directives automatically for protobuf builds

### DIFF
--- a/base_layer/core/build.rs
+++ b/base_layer/core/build.rs
@@ -29,6 +29,7 @@ fn main() {
             "src/base_node/proto",
             "src/transactions/transaction_protocol/proto",
         ])
+        .emit_rerun_if_changed_directives()
         .compile()
         .unwrap();
 }

--- a/base_layer/core/src/base_node/proto/mod.rs
+++ b/base_layer/core/src/base_node/proto/mod.rs
@@ -20,6 +20,7 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+#[cfg(feature = "base_node_proto")]
 pub use crate::proto::generated::base_node;
 
 #[cfg(feature = "base_node")]

--- a/base_layer/core/src/proto/generated/mod.rs
+++ b/base_layer/core/src/proto/generated/mod.rs
@@ -22,7 +22,7 @@
 
 //! Imports of rust files generated from protos
 
-#[cfg(feature = "base_node")]
+#[cfg(feature = "base_node_proto")]
 #[path = "tari.base_node.rs"]
 pub mod base_node;
 #[path = "tari.core.rs"]

--- a/base_layer/p2p/build.rs
+++ b/base_layer/p2p/build.rs
@@ -24,8 +24,7 @@ fn main() {
     tari_common::protobuf_build::ProtoCompiler::new()
         .proto_paths(&["src/proto"])
         .out_dir("src/proto")
+        .emit_rerun_if_changed_directives()
         .compile()
         .unwrap();
-    println!("cargo:rerun-if-changed=src/proto/liveness.proto");
-    println!("cargo:rerun-if-changed=src/proto/message_type.proto");
 }

--- a/comms/build.rs
+++ b/comms/build.rs
@@ -24,6 +24,7 @@ fn main() {
     tari_common::protobuf_build::ProtoCompiler::new()
         .proto_paths(&["src/proto"])
         .out_dir("src/proto")
+        .emit_rerun_if_changed_directives()
         .compile()
         .unwrap();
 }

--- a/comms/dht/build.rs
+++ b/comms/dht/build.rs
@@ -24,10 +24,7 @@ fn main() {
     tari_common::protobuf_build::ProtoCompiler::new()
         .proto_paths(&["src/proto"])
         .out_dir("src/proto")
+        .emit_rerun_if_changed_directives()
         .compile()
         .unwrap();
-    println!("cargo:rerun-if-changed=src/proto/dht.proto");
-    println!("cargo:rerun-if-changed=src/proto/envelope.proto");
-    println!("cargo:rerun-if-changed=src/proto/message_header.proto");
-    println!("cargo:rerun-if-changed=src/proto/store_forward.proto");
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Add a builder option to enable emitting `rerun-if-changed` cargo build
directives for all proto files. This removes the need to manually maintain
a list or proto files in build.rs.

Also fixed compile issues for wallet FFI libs