### PR TITLE
ArrayLikeExt push_front and efficient db array shift

### DIFF
--- a/base_layer/core/src/base_node/comms_interface/local_interface.rs
+++ b/base_layer/core/src/base_node/comms_interface/local_interface.rs
@@ -31,7 +31,6 @@ use crate::{
     blocks::{Block, BlockHeader, NewBlockTemplate},
     chain_storage::{ChainMetadata, HistoricalBlock},
     proof_of_work::{Difficulty, PowAlgorithm},
-    transactions::types::HashOutput,
 };
 use futures::{stream::Fuse, StreamExt};
 use std::sync::Arc;

--- a/base_layer/mmr/src/backend.rs
+++ b/base_layer/mmr/src/backend.rs
@@ -57,6 +57,9 @@ pub trait ArrayLikeExt {
     /// Shift the array, by discarding the first n elements from the front.
     fn shift(&mut self, n: usize) -> Result<(), MerkleMountainRangeError>;
 
+    /// Store a new item first in the array, previous items will be shifted up to make room.
+    fn push_front(&mut self, item: Self::Value) -> Result<(), MerkleMountainRangeError>;
+
     /// Execute the given closure for each value in the array
     fn for_each<F>(&self, f: F) -> Result<(), MerkleMountainRangeError>
     where F: FnMut(Result<Self::Value, MerkleMountainRangeError>);
@@ -104,6 +107,11 @@ impl<T: Clone> ArrayLikeExt for Vec<T> {
     fn shift(&mut self, n: usize) -> Result<(), MerkleMountainRangeError> {
         let drain_n = min(n, self.len());
         self.drain(0..drain_n);
+        Ok(())
+    }
+
+    fn push_front(&mut self, item: Self::Value) -> Result<(), MerkleMountainRangeError> {
+        self.insert(0, item);
         Ok(())
     }
 

--- a/base_layer/mmr/src/mem_backend_vec.rs
+++ b/base_layer/mmr/src/mem_backend_vec.rs
@@ -117,6 +117,13 @@ impl<T: Clone> ArrayLikeExt for MemBackendVec<T> {
         Ok(())
     }
 
+    fn push_front(&mut self, item: Self::Value) -> Result<(), MerkleMountainRangeError> {
+        self.db
+            .write()
+            .map_err(|e| MerkleMountainRangeError::BackendError(e.to_string()))?
+            .push_front(item)
+    }
+
     fn for_each<F>(&self, f: F) -> Result<(), MerkleMountainRangeError>
     where F: FnMut(Result<Self::Value, MerkleMountainRangeError>) {
         self.db


### PR DESCRIPTION
## Description
- Added push_front to ArrayLikeExt trait and provided implementations for the memory and lmdb implementations.
- The lmdb implementation was updated to keep track of an offset index to allow the shift operation to be efficiently processed without updating the keys of preceding elements.
- The add index offset also allows elements to be efficiently inserted at the front of the array.

**I tested these changes on an existing base node blockchain db and it seems to function without breaking the DB. I would still recommend resyncing the base node from scratch.**

## Motivation and Context
These changes add extra functions to the ArrayLikeExt and make existing functions such as shift more efficient to enable the implementation of checkpoint merging in the db backend for pruned mode.

## How Has This Been Tested?
Existing tests for MemDbVec and LmdbVec were updated to test the push_front functionality.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch.
* [x] I ran `cargo-fmt --all` before pushing.
* [x] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
