### PR TITLE
Increased redundancy for SAF messages

### DIFF
--- a/comms/dht/examples/memorynet.rs
+++ b/comms/dht/examples/memorynet.rs
@@ -234,17 +234,19 @@ async fn main() {
     take_a_break().await;
     total_messages += drain_messaging_events(&mut messaging_events_rx, false).await;
 
-    let random_wallet = wallets.remove(OsRng.gen_range(0, wallets.len() - 1));
-    let (num_msgs, random_wallet) = do_store_and_forward_message_propagation(
-        random_wallet,
-        &wallets,
-        messaging_events_tx,
-        &mut messaging_events_rx,
-    )
-    .await;
-    total_messages += num_msgs;
-    // Put the wallet back
-    wallets.push(random_wallet);
+    for _ in 0..5 {
+        let random_wallet = wallets.remove(OsRng.gen_range(0, wallets.len() - 1));
+        let (num_msgs, random_wallet) = do_store_and_forward_message_propagation(
+            random_wallet,
+            &wallets,
+            messaging_events_tx.clone(),
+            &mut messaging_events_rx,
+        )
+        .await;
+        total_messages += num_msgs;
+        // Put the wallet back
+        wallets.push(random_wallet);
+    }
 
     do_network_wide_propagation(&mut nodes).await;
 
@@ -896,7 +898,8 @@ async fn setup_comms_dht(
     .local_test()
     .enable_auto_join()
     .with_discovery_timeout(Duration::from_secs(15))
-    .with_num_neighbouring_nodes(8)
+    .with_num_neighbouring_nodes(10)
+    .with_num_random_nodes(5)
     .with_propagation_factor(4)
     .finish()
     .await

--- a/comms/dht/src/broadcast_strategy.rs
+++ b/comms/dht/src/broadcast_strategy.rs
@@ -22,17 +22,14 @@
 
 use crate::envelope::NodeDestination;
 use std::{fmt, fmt::Formatter};
-use tari_comms::{
-    peer_manager::{node_id::NodeId, PeerFeatures},
-    types::CommsPublicKey,
-};
+use tari_comms::{peer_manager::node_id::NodeId, types::CommsPublicKey};
 
 #[derive(Debug, Clone)]
 pub struct BroadcastClosestRequest {
     pub n: usize,
     pub node_id: NodeId,
-    pub peer_features: PeerFeatures,
     pub excluded_peers: Vec<NodeId>,
+    pub connected_only: bool,
 }
 
 #[derive(Debug, Clone)]
@@ -128,7 +125,7 @@ mod test {
                 node_id: NodeId::default(),
                 n: 0,
                 excluded_peers: Default::default(),
-                peer_features: Default::default()
+                connected_only: false
             }))
             .is_direct(),
             false
@@ -152,7 +149,7 @@ mod test {
             node_id: NodeId::default(),
             n: 0,
             excluded_peers: Default::default(),
-            peer_features: Default::default()
+            connected_only: false
         }))
         .direct_public_key()
         .is_none(),);
@@ -178,7 +175,7 @@ mod test {
             node_id: NodeId::default(),
             n: 0,
             excluded_peers: Default::default(),
-            peer_features: Default::default(),
+            connected_only: false
         }))
         .direct_node_id()
         .is_none(),);

--- a/comms/dht/src/builder.rs
+++ b/comms/dht/src/builder.rs
@@ -100,8 +100,13 @@ impl DhtBuilder {
         self
     }
 
-    pub fn with_num_neighbouring_nodes(mut self, num_neighbours: usize) -> Self {
-        self.config.num_neighbouring_nodes = num_neighbours;
+    pub fn with_num_random_nodes(mut self, n: usize) -> Self {
+        self.config.num_random_nodes = n;
+        self
+    }
+
+    pub fn with_num_neighbouring_nodes(mut self, n: usize) -> Self {
+        self.config.num_neighbouring_nodes = n;
         self
     }
 

--- a/comms/dht/src/dht.rs
+++ b/comms/dht/src/dht.rs
@@ -246,6 +246,7 @@ impl Dht {
             )))
             .layer(inbound::DecryptionLayer::new(Arc::clone(&self.node_identity)))
             .layer(store_forward::ForwardLayer::new(
+                self.config.clone(),
                 self.outbound_requester(),
                 self.node_identity.features().contains(PeerFeatures::DHT_STORE_FORWARD),
             ))

--- a/comms/dht/src/inbound/message.rs
+++ b/comms/dht/src/inbound/message.rs
@@ -82,6 +82,7 @@ pub struct DecryptedDhtMessage {
     pub authenticated_origin: Option<CommsPublicKey>,
     pub dht_header: DhtMessageHeader,
     pub is_saf_message: bool,
+    pub is_saf_stored: Option<bool>,
     pub decryption_result: Result<EnvelopeBody, Vec<u8>>,
 }
 
@@ -99,6 +100,7 @@ impl DecryptedDhtMessage {
             authenticated_origin,
             dht_header: message.dht_header,
             is_saf_message: message.is_saf_message,
+            is_saf_stored: None,
             decryption_result: Ok(message_body),
         }
     }
@@ -111,6 +113,7 @@ impl DecryptedDhtMessage {
             authenticated_origin: None,
             dht_header: message.dht_header,
             is_saf_message: message.is_saf_message,
+            is_saf_stored: None,
             decryption_result: Err(message.body),
         }
     }
@@ -157,5 +160,9 @@ impl DecryptedDhtMessage {
             Ok(b) => b.total_size(),
             Err(b) => b.len(),
         }
+    }
+
+    pub fn set_saf_stored(&mut self, is_stored: bool) {
+        self.is_saf_stored = Some(is_stored);
     }
 }

--- a/comms/dht/src/outbound/message_params.rs
+++ b/comms/dht/src/outbound/message_params.rs
@@ -27,10 +27,7 @@ use crate::{
     proto::envelope::DhtMessageType,
 };
 use std::{fmt, fmt::Display};
-use tari_comms::{
-    peer_manager::{NodeId, PeerFeatures},
-    types::CommsPublicKey,
-};
+use tari_comms::{peer_manager::NodeId, types::CommsPublicKey};
 
 /// Configuration for outbound messages.
 ///
@@ -115,19 +112,24 @@ impl SendMessageParams {
 
     /// Set broadcast_strategy to Closest.`excluded_peers` are excluded. Only Peers which have all `features` are
     /// included.
-    pub fn closest(
-        &mut self,
-        node_id: NodeId,
-        n: usize,
-        excluded_peers: Vec<NodeId>,
-        peer_features: PeerFeatures,
-    ) -> &mut Self
-    {
+    pub fn closest(&mut self, node_id: NodeId, n: usize, excluded_peers: Vec<NodeId>) -> &mut Self {
         self.params_mut().broadcast_strategy = BroadcastStrategy::Closest(Box::new(BroadcastClosestRequest {
             excluded_peers,
             node_id,
-            peer_features,
             n,
+            connected_only: false,
+        }));
+        self
+    }
+
+    /// Set broadcast_strategy to Closest.`excluded_peers` are excluded. Only Peers which have all `features` are
+    /// included.
+    pub fn closest_connected(&mut self, node_id: NodeId, n: usize, excluded_peers: Vec<NodeId>) -> &mut Self {
+        self.params_mut().broadcast_strategy = BroadcastStrategy::Closest(Box::new(BroadcastClosestRequest {
+            excluded_peers,
+            node_id,
+            n,
+            connected_only: true,
         }));
         self
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
When a message (with an explicit destination) is stored by a node,
broadcast `n` messages to connected peers that are close to the
destination to increase redundancy.

As a message is propagated closer to the destination, the message
will start to be stored for an offline peer once it reaches the
neighbourhood of the destination. Because propagation is more targeted,
it may miss some nodes that could be considered neighbours by the
wallet. This PR increases the number of nodes that see the message
as the message reaches the neighbourhood by broadcasting to a larger number 
of connected peers close to the destination.


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Increase SAF message redundancy in neighbourhood to increase SAF reliability

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
memorynet

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [x] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch.
* [x] I ran `cargo-fmt --all` before pushing.
* [x] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
