### PR TITLE
Fix missing Source and Destination Pubkeys in FFI callback Tx return

### DIFF
--- a/base_layer/wallet_ffi/src/lib.rs
+++ b/base_layer/wallet_ffi/src/lib.rs
@@ -2389,6 +2389,7 @@ pub unsafe extern "C" fn wallet_create(
                         w.transaction_service.get_event_stream_fused(),
                         w.output_manager_service.get_event_stream_fused(),
                         w.comms.shutdown_signal(),
+                        w.comms.node_identity().public_key().clone(),
                         callback_received_transaction,
                         callback_received_transaction_reply,
                         callback_received_finalized_transaction,


### PR DESCRIPTION
## Description
For the CompletedTransaction returned by the transaction cancellation callback it is possible that the transaction is a cancelled Pending Incoming or Pending Outgoing transaction which does not include the destination and source pub keys respectively. This PR adds in the code to add in the missing pub key to the returned CompletedTransaction.

@kukabi 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch.
* [x] I ran `cargo-fmt --all` before pushing.
* [ ] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
