### PR TITLE
Factor in blocks with the same timestamp

### DIFF
--- a/applications/tari_base_node/proto/base_node.proto
+++ b/applications/tari_base_node/proto/base_node.proto
@@ -44,7 +44,7 @@ service BaseNode {
     // Get Version
     rpc GetVersion(Empty) returns (StringValue);
     // Get coins in circulation
-    rpc GetTokensInCirculation(IntegerValue) returns (IntegerValue);
+    rpc GetTokensInCirculation(GetBlocksRequest) returns (stream ValueAtHeightResponse);
     // Get network difficulties
     rpc GetNetworkDifficulty(HeightRequest) returns (stream NetworkDifficultyResponse);
 }
@@ -57,6 +57,7 @@ message NetworkDifficultyResponse {
     uint64 difficulty = 1;
     uint64 estimated_hash_rate = 2;
     uint64 height = 3;
+    uint64 timestamp = 4;
 }
 
 // A generic single value response for a specific height

--- a/applications/tari_base_node/src/grpc/blocks.rs
+++ b/applications/tari_base_node/src/grpc/blocks.rs
@@ -44,7 +44,7 @@ pub async fn block_heights(
     from_tip: u64,
 ) -> Result<Vec<u64>, Status>
 {
-    let heights = if start_height > 0 && end_height > 0 {
+    let heights = if start_height >= 0 && end_height > 0 {
         Ok(BlockHeader::get_height_range(start_height, end_height))
     } else if from_tip > 0 {
         BlockHeader::get_heights_from_tip(handler, from_tip)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Two consecutive blocks may have the exact same timestamp, this just stops the u64 overflow as well as the divide by 0 error. The start_height is explicitly added in the if statement for understandability.
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes a possible overflow and divide by 0 error
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch.
* [x] I ran `cargo-fmt --all` before pushing.
* [x] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
