### PR TITLE
clippy-check github action to locked toolchain version

### DIFF
--- a/.github/workflows/clippy-check.yml
+++ b/.github/workflows/clippy-check.yml
@@ -7,7 +7,7 @@ jobs:
       - uses: actions/checkout@v1
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: nightly
+          toolchain: nightly-2020-01-08
           components: clippy, rustfmt
           override: true
       - name: Install dependencies


### PR DESCRIPTION
Set the toolchain version to the one set in `rust-toolchain`.
`asm!` is no longer supported and this breaks `clear-on-drop`.
