### PR TITLE
Reinitialize peer pools if node transitions to offline

### DIFF
--- a/base_layer/core/src/base_node/states/block_sync.rs
+++ b/base_layer/core/src/base_node/states/block_sync.rs
@@ -719,7 +719,7 @@ async fn exclude_sync_peer(sync_peers: &mut Vec<NodeId>, sync_peer: NodeId) -> R
     Ok(())
 }
 
-// Ban and disconnect the provided sync peer.
+// Ban and disconnect the provided sync peer if this node is online
 async fn ban_sync_peer_if_online<B: BlockchainBackend + 'static>(
     shared: &mut BaseNodeStateMachine<B>,
     sync_peers: &mut Vec<NodeId>,
@@ -746,7 +746,6 @@ async fn ban_sync_peer<B: BlockchainBackend + 'static>(
 ) -> Result<(), BlockSyncError>
 {
     info!(target: LOG_TARGET, "Banning peer {} from local node.", sync_peer);
-    sync_peers.retain(|p| *p != sync_peer);
     shared.connectivity.ban_peer(sync_peer.clone(), ban_duration).await?;
     exclude_sync_peer(sync_peers, sync_peer).await
 }

--- a/comms/dht/src/connectivity/mod.rs
+++ b/comms/dht/src/connectivity/mod.rs
@@ -176,6 +176,22 @@ impl DhtConnectivity {
         Ok(())
     }
 
+    async fn reinitialize_pools(&mut self) -> Result<(), DhtConnectivityError> {
+        info!(
+            target: LOG_TARGET,
+            "Reinitializing neighbour pool. Draining neighbour list (len={})",
+            self.neighbours.len(),
+        );
+        for neighbour in self.neighbours.drain(..) {
+            self.connectivity.remove_peer(neighbour).await?;
+        }
+
+        self.initialize_neighbours().await?;
+        self.refresh_random_pool().await?;
+
+        Ok(())
+    }
+
     async fn handle_connectivity_event(&mut self, event: &ConnectivityEvent) -> Result<(), DhtConnectivityError> {
         use ConnectivityEvent::*;
         match event {
@@ -201,6 +217,9 @@ impl DhtConnectivity {
                     }
                 }
             },
+            ConnectivityStateOffline => {
+                self.reinitialize_pools().await?;
+            },
             _ => {},
         }
 
@@ -208,52 +227,53 @@ impl DhtConnectivity {
     }
 
     async fn refresh_random_pool_if_required(&mut self) -> Result<(), DhtConnectivityError> {
-        if self.should_refresh_random_pool() {
-            let mut random_peers = self
-                .fetch_random_peers(self.config.num_random_nodes, &self.neighbours)
-                .await?;
-            if random_peers.is_empty() {
-                warn!(
-                    target: LOG_TARGET,
-                    "Unable to refresh random peer pool because there are insufficient known peers",
-                );
-            } else {
-                let (keep, to_remove) = self
-                    .random_pool
-                    .iter()
-                    .partition::<Vec<_>, _>(|n| random_peers.contains(n));
-                // Remove the peers that we want to keep from the `random_peers` to be added
-                random_peers.retain(|n| !keep.contains(&n));
-                debug!(
-                    target: LOG_TARGET,
-                    "Adding new peers to random peer pool (#new = {}, #keeping = {}, #removing = {})",
-                    random_peers.len(),
-                    keep.len(),
-                    to_remove.len()
-                );
-                trace!(
-                    target: LOG_TARGET,
-                    "Random peers: Adding = {:?}, Removing = {:?}",
-                    random_peers,
-                    to_remove
-                );
-                self.connectivity.add_managed_peers(random_peers).await?;
-                for n in to_remove {
-                    self.connectivity.remove_peer(n.clone()).await?;
-                }
-            }
-            self.random_pool_last_refresh = Some(Instant::now());
+        let should_refresh = self.config.num_random_nodes > 0 &&
+            self.random_pool_last_refresh
+                .map(|instant| instant.elapsed() >= self.config.connectivity_random_pool_refresh)
+                .unwrap_or(true);
+        if should_refresh {
+            self.refresh_random_pool().await?;
         }
 
         Ok(())
     }
 
-    #[inline]
-    fn should_refresh_random_pool(&self) -> bool {
-        self.config.num_random_nodes > 0 &&
-            self.random_pool_last_refresh
-                .map(|instant| instant.elapsed() >= self.config.connectivity_random_pool_refresh)
-                .unwrap_or(true)
+    async fn refresh_random_pool(&mut self) -> Result<(), DhtConnectivityError> {
+        let mut random_peers = self
+            .fetch_random_peers(self.config.num_random_nodes, &self.neighbours)
+            .await?;
+        if random_peers.is_empty() {
+            warn!(
+                target: LOG_TARGET,
+                "Unable to refresh random peer pool because there are insufficient known peers",
+            );
+        } else {
+            let (keep, to_remove) = self
+                .random_pool
+                .iter()
+                .partition::<Vec<_>, _>(|n| random_peers.contains(n));
+            // Remove the peers that we want to keep from the `random_peers` to be added
+            random_peers.retain(|n| !keep.contains(&n));
+            debug!(
+                target: LOG_TARGET,
+                "Adding new peers to random peer pool (#new = {}, #keeping = {}, #removing = {})",
+                random_peers.len(),
+                keep.len(),
+                to_remove.len()
+            );
+            trace!(
+                target: LOG_TARGET,
+                "Random peers: Adding = {:?}, Removing = {:?}",
+                random_peers,
+                to_remove
+            );
+            self.connectivity.add_managed_peers(random_peers).await?;
+            for n in to_remove {
+                self.connectivity.remove_peer(n.clone()).await?;
+            }
+        }
+        self.random_pool_last_refresh = Some(Instant::now());
+        Ok(())
     }
 
     async fn handle_new_peer_connected(&mut self, conn: &PeerConnection) -> Result<(), DhtConnectivityError> {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
 Fetch a fresh neighbour pool and random pool if node transitions to offline.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
I've observed base node sync stall caused by the liveness service to have no peers left to ping. This seems to be due to banning of peers, which removes them from ping rounds and the DHT connectivity not being able to replace them with new peers while the node has a low visibility into the network. Fetching a new set of available neighbours and random peers should allow the node to continue syncing

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
New functional test

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [x] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [x] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch.
* [x] I ran `cargo-fmt --all` before pushing.
* [x] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
