### PR TITLE
Libwallet build

### DIFF
--- a/.github/workflows/clippy-check.yml
+++ b/.github/workflows/clippy-check.yml
@@ -12,8 +12,8 @@ jobs:
           override: true
       - name: Install dependencies
         run: |
-          sudo apt update &&
-            sudo apt install libncurses5 libncurses5-dev openssl libssl-dev pkg-config libsqlite3-0 libsqlite3-dev clang git cmake libc++-dev libc++abi-dev
+           sudo apt update &&
+           sudo apt install libncurses5 libncurses5-dev openssl libssl-dev pkg-config libsqlite3-0 libsqlite3-dev clang git cmake libc++-dev libc++abi-dev
       - uses: actions-rs/clippy-check@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/libwallet.yml
+++ b/.github/workflows/libwallet.yml
@@ -1,0 +1,32 @@
+# Build a new set of libraries when a new tag containing 'libwallet' is pushed
+name: Build libwallet
+on:
+  push:
+    tags:
+      - "libwallet-*"
+jobs:
+  build_libs:
+    runs-on: ubuntu-latest
+    steps:
+      # Step 1: Checkout the code
+      - uses: actions/checkout@v2
+      # Step 2: Build and package the libraries
+      - name: Build libwallet
+        id: build-libwallet
+        uses: tari-project/action-buildlibs@v0.0.14
+        with:
+          platforms: "x86_64-linux-android;aarch64-linux-android;i686-linux-android;armv7-linux-androideabi"
+          level: "24"
+      # Step 3: Copy tarballs to S3
+      - name: Sync to S3
+        uses: jakejarvis/s3-sync-action@v0.5.1
+        with:
+          args: --acl public-read --follow-symlinks --delete
+        env:
+          AWS_S3_BUCKET: ${{ secrets.AWS_S3_BUCKET }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_REGION: 'us-east-1'   # optional: defaults to us-east-1
+          SOURCE_DIR: '$GITHUB_WORKSPACE/libwallet'
+          DEST_DIR: 'libwallet'
+


### PR DESCRIPTION
 Add Github action for building and deploying libwallet
 
 This PR adds a github action that
* triggers when a tag starting with `libwallet-` is pushed   
* Builds the FFI binaries for android for all specified platforms  
* Copies the libraries to an S3 bucket

The flow has been tested end-to-end
