### PR TITLE
Add block weight constants to grpc endpoint

### DIFF
--- a/applications/tari_base_node/proto/base_node.proto
+++ b/applications/tari_base_node/proto/base_node.proto
@@ -144,6 +144,12 @@ message ConsensusConstants {
     uint64 emission_tail = 12;
     /// This is the initial min difficulty for the difficulty adjustment
     uint64 min_blake_pow_difficulty = 13;
+    /// Block weight for inputs
+    uint64 block_weight_inputs = 14;
+    /// Block weight for output
+    uint64 block_weight_outputs = 15;
+    /// Block weight for kernels
+    uint64 block_weight_kernels = 16;
 }
 
 // The return type of the rpc GetCalcTiming

--- a/applications/tari_base_node/src/grpc/server.rs
+++ b/applications/tari_base_node/src/grpc/server.rs
@@ -34,6 +34,7 @@ use tari_core::{
     chain_storage::HistoricalBlock,
     consensus::{emission::EmissionSchedule, ConsensusConstants, Network},
     proof_of_work::PowAlgorithm,
+    transactions::fee::{KERNEL_WEIGHT, WEIGHT_PER_INPUT, WEIGHT_PER_OUTPUT},
 };
 use tari_crypto::tari_utilities::{epoch_time::EpochTime, ByteArray, Hashable};
 use tokio::{runtime, sync::mpsc};
@@ -570,6 +571,9 @@ impl From<ConsensusConstants> for base_node_grpc::ConsensusConstants {
             emission_decay: emission_decay.into(),
             emission_tail: emission_tail.into(),
             min_blake_pow_difficulty: cc.min_pow_difficulty(PowAlgorithm::Blake).into(),
+            block_weight_inputs: WEIGHT_PER_INPUT,
+            block_weight_outputs: WEIGHT_PER_OUTPUT,
+            block_weight_kernels: KERNEL_WEIGHT,
         }
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Added the block weight constants to the constants grpc endpoint so that the block explorer api / frontend could calculate block sizes.
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
I didn't want to hard code weights into other projects when I could extract the source of truth.
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [x] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch.
* [x] I ran `cargo-fmt --all` before pushing.
* [x] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
