### PR TITLE
Pruned mode periodic checkpoint merging and horizon state cleanup

### DIFF
--- a/applications/tari_base_node/src/builder.rs
+++ b/applications/tari_base_node/src/builder.rs
@@ -483,6 +483,7 @@ where
     let db_config = BlockchainDatabaseConfig {
         orphan_storage_capacity: config.orphan_storage_capacity,
         pruning_horizon: config.pruning_horizon,
+        pruned_mode_cleanup_interval: config.pruned_mode_cleanup_interval,
     };
     let db = BlockchainDatabase::new(backend, &rules, validators, db_config).map_err(|e| e.to_string())?;
     let mempool_validator =

--- a/base_layer/core/src/chain_storage/consts.rs
+++ b/base_layer/core/src/chain_storage/consts.rs
@@ -24,3 +24,5 @@
 pub const BLOCKCHAIN_DATABASE_ORPHAN_STORAGE_CAPACITY: usize = 720;
 /// The pruning horizon that is set for a default configuration of the blockchain db.
 pub const BLOCKCHAIN_DATABASE_PRUNING_HORIZON: u64 = 0;
+/// The chain height interval used to determine when pruned mode cleanup should be performed.
+pub const BLOCKCHAIN_DATABASE_PRUNED_MODE_CLEANUP_INTERVAL: u64 = 50;

--- a/base_layer/core/src/chain_storage/db_transaction.rs
+++ b/base_layer/core/src/chain_storage/db_transaction.rs
@@ -170,6 +170,16 @@ impl DbTransaction {
         self.operations
             .push(WriteOperation::RewindMmr(MmrTree::RangeProof, steps_back));
     }
+
+    /// Merge checkpoints to ensure that only a specific number of checkpoints remain.
+    pub fn merge_checkpoints(&mut self, max_cp_count: usize) {
+        self.operations
+            .push(WriteOperation::MergeMmrCheckpoints(MmrTree::Kernel, max_cp_count));
+        self.operations
+            .push(WriteOperation::MergeMmrCheckpoints(MmrTree::Utxo, max_cp_count));
+        self.operations
+            .push(WriteOperation::MergeMmrCheckpoints(MmrTree::RangeProof, max_cp_count));
+    }
 }
 
 #[derive(Debug, Display)]
@@ -180,6 +190,7 @@ pub enum WriteOperation {
     UnSpend(DbKey),
     CreateMmrCheckpoint(MmrTree),
     RewindMmr(MmrTree, usize),
+    MergeMmrCheckpoints(MmrTree, usize),
 }
 
 /// A list of key-value pairs that are required for each insert operation

--- a/base_layer/core/tests/chain_storage_tests/chain_storage.rs
+++ b/base_layer/core/tests/chain_storage_tests/chain_storage.rs
@@ -536,7 +536,8 @@ fn rewind_to_height() {
 #[test]
 fn rewind_past_horizon_height() {
     let network = Network::LocalNet;
-    let consensus_manager = ConsensusManagerBuilder::new(network).build();
+    let block0 = genesis_block::get_rincewind_genesis_block_raw();
+    let consensus_manager = ConsensusManagerBuilder::new(network).with_block(block0.clone()).build();
     let consensus_constansts = consensus_manager.consensus_constants();
     let validators = Validators::new(
         MockValidator::new(true),
@@ -547,10 +548,10 @@ fn rewind_past_horizon_height() {
     let config = BlockchainDatabaseConfig {
         orphan_storage_capacity: 3,
         pruning_horizon: 2,
+        pruned_mode_cleanup_interval: 50,
     };
     let store = BlockchainDatabase::new(db, &consensus_manager, validators, config).unwrap();
 
-    let block0 = store.fetch_block(0).unwrap().block().clone();
     let block1 = append_block(&store, &block0, vec![], &consensus_constansts, 1.into()).unwrap();
     let block2 = append_block(&store, &block1, vec![], &consensus_constansts, 1.into()).unwrap();
     let block3 = append_block(&store, &block2, vec![], &consensus_constansts, 1.into()).unwrap();
@@ -853,7 +854,8 @@ fn restore_metadata_and_pruning_horizon_update() {
             MockAccumDifficultyValidator {},
         );
         let network = Network::LocalNet;
-        let rules = ConsensusManagerBuilder::new(network).build();
+        let block0 = genesis_block::get_rincewind_genesis_block_raw();
+        let rules = ConsensusManagerBuilder::new(network).with_block(block0.clone()).build();
         let mut config = BlockchainDatabaseConfig::default();
         let block_hash: BlockHash;
         let pruning_horizon1: u64 = 1000;
@@ -863,7 +865,6 @@ fn restore_metadata_and_pruning_horizon_update() {
             config.pruning_horizon = pruning_horizon1;
             let db = BlockchainDatabase::new(db, &rules, validators.clone(), config).unwrap();
 
-            let block0 = db.fetch_block(0).unwrap().block().clone();
             let block1 = append_block(&db, &block0, vec![], &rules.consensus_constants(), 1.into()).unwrap();
             db.add_block(block1.clone()).unwrap();
             block_hash = block1.hash();
@@ -1046,6 +1047,7 @@ fn orphan_cleanup_on_block_add() {
     let config = BlockchainDatabaseConfig {
         orphan_storage_capacity: 3,
         pruning_horizon: 0,
+        pruned_mode_cleanup_interval: 50,
     };
     let store = BlockchainDatabase::new(db, &consensus_manager, validators, config).unwrap();
 
@@ -1084,7 +1086,8 @@ fn orphan_cleanup_on_block_add() {
 #[test]
 fn horizon_height_orphan_cleanup() {
     let network = Network::LocalNet;
-    let consensus_manager = ConsensusManagerBuilder::new(network).build();
+    let block0 = genesis_block::get_rincewind_genesis_block_raw();
+    let consensus_manager = ConsensusManagerBuilder::new(network).with_block(block0.clone()).build();
     let consensus_constansts = consensus_manager.consensus_constants();
     let validators = Validators::new(
         MockValidator::new(true),
@@ -1095,6 +1098,7 @@ fn horizon_height_orphan_cleanup() {
     let config = BlockchainDatabaseConfig {
         orphan_storage_capacity: 3,
         pruning_horizon: 2,
+        pruned_mode_cleanup_interval: 50,
     };
     let store = BlockchainDatabase::new(db, &consensus_manager, validators, config).unwrap();
     let orphan1 = create_orphan_block(2, vec![], &consensus_constansts);
@@ -1110,7 +1114,6 @@ fn horizon_height_orphan_cleanup() {
     assert_eq!(store.add_block(orphan3), Ok(BlockAddResult::OrphanBlock));
     assert_eq!(store.db_read_access().unwrap().get_orphan_count(), Ok(3));
 
-    let block0 = store.fetch_block(0).unwrap().block().clone();
     let block1 = append_block(&store, &block0, vec![], &consensus_constansts, 1.into()).unwrap();
     let block2 = append_block(&store, &block1, vec![], &consensus_constansts, 1.into()).unwrap();
     let block3 = append_block(&store, &block2, vec![], &consensus_constansts, 1.into()).unwrap();
@@ -1146,6 +1149,7 @@ fn orphan_cleanup_on_reorg() {
     let config = BlockchainDatabaseConfig {
         orphan_storage_capacity: 3,
         pruning_horizon: 0,
+        pruned_mode_cleanup_interval: 50,
     };
     let mut store = BlockchainDatabase::new(db, &consensus_manager, validators, config).unwrap();
     let mut blocks = vec![block0];
@@ -1253,4 +1257,67 @@ fn orphan_cleanup_on_reorg() {
     assert_eq!(store.fetch_orphan(blocks[2].hash()), Ok(blocks[2].clone()));
     assert_eq!(store.fetch_orphan(blocks[3].hash()), Ok(blocks[3].clone()));
     assert_eq!(store.fetch_orphan(blocks[4].hash()), Ok(blocks[4].clone()));
+}
+
+#[test]
+fn pruned_mode_cleanup_and_fetch_block() {
+    let network = Network::LocalNet;
+    let block0 = genesis_block::get_rincewind_genesis_block_raw();
+    let consensus_manager = ConsensusManagerBuilder::new(network).with_block(block0.clone()).build();
+    let validators = Validators::new(
+        MockValidator::new(true),
+        MockValidator::new(true),
+        MockAccumDifficultyValidator {},
+    );
+    let db = MemoryDatabase::<HashDigest>::default();
+    let config = BlockchainDatabaseConfig {
+        orphan_storage_capacity: 3,
+        pruning_horizon: 2,
+        pruned_mode_cleanup_interval: 2,
+    };
+    let store = BlockchainDatabase::new(db, &consensus_manager, validators, config).unwrap();
+    let block1 = append_block(
+        &store,
+        &block0,
+        vec![],
+        &consensus_manager.consensus_constants(),
+        1.into(),
+    )
+    .unwrap();
+    let block2 = append_block(
+        &store,
+        &block1,
+        vec![],
+        &consensus_manager.consensus_constants(),
+        1.into(),
+    )
+    .unwrap();
+    let block3 = append_block(
+        &store,
+        &block2,
+        vec![],
+        &consensus_manager.consensus_constants(),
+        1.into(),
+    )
+    .unwrap();
+
+    assert!(store.fetch_block(0).is_err()); // Genesis block cant be retrieved in pruned mode
+    assert_eq!(store.fetch_block(1).unwrap().block, block1);
+    assert_eq!(store.fetch_block(2).unwrap().block, block2);
+
+    let block4 = append_block(
+        &store,
+        &block3,
+        vec![],
+        &consensus_manager.consensus_constants(),
+        1.into(),
+    )
+    .unwrap();
+
+    // Adding block 4 will trigger the pruned mode cleanup, first block after horizon block height is retrievable.
+    assert!(store.fetch_block(0).is_err());
+    assert!(store.fetch_block(1).is_err());
+    assert!(store.fetch_block(2).is_err());
+    assert_eq!(store.fetch_block(3).unwrap().block, block3);
+    assert_eq!(store.fetch_block(4).unwrap().block, block4);
 }

--- a/base_layer/core/tests/node_comms_interface.rs
+++ b/base_layer/core/tests/node_comms_interface.rs
@@ -31,7 +31,7 @@ use tari_core::{
         comms_interface::{CommsInterfaceError, InboundNodeCommsHandlers, NodeCommsRequest, NodeCommsResponse},
         OutboundNodeCommsInterface,
     },
-    blocks::{BlockBuilder, BlockHeader},
+    blocks::{genesis_block, BlockBuilder, BlockHeader},
     chain_storage::{
         BlockchainDatabase,
         BlockchainDatabaseConfig,
@@ -370,8 +370,10 @@ fn inbound_fetch_blocks() {
 fn inbound_fetch_blocks_before_horizon_height() {
     let network = Network::LocalNet;
     let consensus_constants = network.create_consensus_constants();
+    let block0 = genesis_block::get_rincewind_genesis_block_raw();
     let consensus_manager = ConsensusManagerBuilder::new(network)
         .with_consensus_constants(consensus_constants.clone())
+        .with_block(block0.clone())
         .build();
     let validators = Validators::new(
         MockValidator::new(true),
@@ -396,7 +398,6 @@ fn inbound_fetch_blocks_before_horizon_height() {
         outbound_nci,
     );
 
-    let block0 = store.fetch_block(0).unwrap().block().clone();
     let block1 = append_block(&store, &block0, vec![], &consensus_constants, 1.into()).unwrap();
     let block2 = append_block(&store, &block1, vec![], &consensus_constants, 1.into()).unwrap();
     let block3 = append_block(&store, &block2, vec![], &consensus_constants, 1.into()).unwrap();

--- a/common/src/configuration/global.rs
+++ b/common/src/configuration/global.rs
@@ -46,6 +46,7 @@ pub struct GlobalConfig {
     pub db_type: DatabaseType,
     pub orphan_storage_capacity: usize,
     pub pruning_horizon: u64,
+    pub pruned_mode_cleanup_interval: u64,
     pub core_threads: usize,
     pub blocking_threads: usize,
     pub identity_file: PathBuf,
@@ -110,6 +111,11 @@ fn convert_node_config(network: Network, cfg: Config) -> Result<GlobalConfig, Co
 
     let key = config_string(&net_str, "pruning_horizon");
     let pruning_horizon = cfg
+        .get_int(&key)
+        .map_err(|e| ConfigurationError::new(&key, &e.to_string()))? as u64;
+
+    let key = config_string(&net_str, "pruned_mode_cleanup_interval");
+    let pruned_mode_cleanup_interval = cfg
         .get_int(&key)
         .map_err(|e| ConfigurationError::new(&key, &e.to_string()))? as u64;
 
@@ -235,6 +241,7 @@ fn convert_node_config(network: Network, cfg: Config) -> Result<GlobalConfig, Co
         db_type,
         orphan_storage_capacity,
         pruning_horizon,
+        pruned_mode_cleanup_interval,
         core_threads,
         blocking_threads,
         identity_file,

--- a/common/src/configuration/utils.rs
+++ b/common/src/configuration/utils.rs
@@ -77,6 +77,8 @@ pub fn default_config(bootstrap: &ConfigBootstrap) -> Config {
     cfg.set_default("base_node.mainnet.orphan_storage_capacity", 720)
         .unwrap();
     cfg.set_default("base_node.mainnet.pruning_horizon", 0).unwrap();
+    cfg.set_default("base_node.mainnet.pruned_mode_cleanup_interval", 50)
+        .unwrap();
     cfg.set_default("base_node.mainnet.peer_seeds", Vec::<String>::new())
         .unwrap();
     cfg.set_default("base_node.mainnet.block_sync_strategy", "ViaBestChainMetadata")
@@ -125,6 +127,8 @@ pub fn default_config(bootstrap: &ConfigBootstrap) -> Config {
     cfg.set_default("base_node.rincewind.orphan_storage_capacity", 720)
         .unwrap();
     cfg.set_default("base_node.rincewind.pruning_horizon", 0).unwrap();
+    cfg.set_default("base_node.rincewind.pruned_mode_cleanup_interval", 50)
+        .unwrap();
     cfg.set_default("base_node.rincewind.peer_seeds", Vec::<String>::new())
         .unwrap();
     cfg.set_default("base_node.rincewind.block_sync_strategy", "ViaBestChainMetadata")


### PR DESCRIPTION
## Description
- Added periodic pruned mode cleanup into the blockchain db add_block function, allowing the blockchain backend checkpoints to be merged and STXOs from the horizon state to be discarded.
- Added a MergeMmrCheckpoints write operation to the db transactions and provided implementations for lmdb_db and memory_db. This can be used to merge old checkpoints into the horizon state and discard old STXOs.

## Motivation and Context
These changes enable a base node to run in pruned mode, allowing backend checkpoint merging to be performed and old horizon state STXOs to be discarded. Efficient pruned mode syncing will be introduced in follow up PRs.

## How Has This Been Tested?
- Modified broken tests that use pruned mode and attempt to fetch the genesis block.
- Added the configuration of the pruned mode cleanup interval to the base node application.
- Added the merging_and_fetch_checkpoints_and_stxo_discard blockchain backend test for testing the newly introduced checkpoint merging mechanism.
- Added the pruned_mode_cleanup_and_fetch_block test for checking the period pruned mode cleanup and reconstructing of blocks when running in pruned mode.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch.
* [x] I ran `cargo-fmt --all` before pushing.
* [x] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
