### PR TITLE
Switched to tokio broadcast for inbound pubsub

### DIFF
--- a/applications/tari_base_node/src/builder.rs
+++ b/applications/tari_base_node/src/builder.rs
@@ -492,7 +492,7 @@ where
 
     //---------------------------------- Base Node --------------------------------------------//
 
-    let (publisher, base_node_subscriptions) = pubsub_connector(handle.clone(), 100, 1);
+    let (publisher, base_node_subscriptions) = pubsub_connector(handle.clone(), 100);
     let base_node_subscriptions = Arc::new(base_node_subscriptions);
     create_peer_db_folder(&config.peer_db_path)?;
     let (base_node_comms, base_node_dht) = setup_base_node_comms(base_node_identity, config, publisher).await?;
@@ -515,7 +515,7 @@ where
     debug!(target: LOG_TARGET, "Base node service registration complete.");
 
     //---------------------------------- Wallet --------------------------------------------//
-    let (publisher, wallet_subscriptions) = pubsub_connector(handle.clone(), 1000, 2);
+    let (publisher, wallet_subscriptions) = pubsub_connector(handle.clone(), 1000);
     let wallet_subscriptions = Arc::new(wallet_subscriptions);
     create_peer_db_folder(&config.wallet_peer_db_path)?;
     let (wallet_comms, wallet_dht) = setup_wallet_comms(

--- a/base_layer/core/Cargo.toml
+++ b/base_layer/core/Cargo.toml
@@ -28,7 +28,6 @@ tari_service_framework = { version = "^0.0", path = "../service_framework"}
 tari_p2p = { version = "^0.1", path = "../../base_layer/p2p" }
 tari_comms_dht = { version = "^0.1", path = "../../comms/dht"}
 tari_broadcast_channel = "^0.2"
-tari_pubsub = "^0.2"
 tari_shutdown = { version = "^0.0", path = "../../infrastructure/shutdown" }
 tari_mmr = { version = "^0.1", path = "../../base_layer/mmr", optional = true }
 randomx-rs = { version = "0.2.1", optional = true }

--- a/base_layer/core/tests/helpers/nodes.rs
+++ b/base_layer/core/tests/helpers/nodes.rs
@@ -445,7 +445,7 @@ fn setup_base_node_services(
     CommsNode,
 )
 {
-    let (publisher, subscription_factory) = pubsub_connector(runtime.handle().clone(), 100, 104);
+    let (publisher, subscription_factory) = pubsub_connector(runtime.handle().clone(), 100);
     let subscription_factory = Arc::new(subscription_factory);
     let (comms, dht) = runtime.block_on(setup_comms_services(node_identity, peers, publisher, data_path));
 

--- a/base_layer/p2p/Cargo.toml
+++ b/base_layer/p2p/Cargo.toml
@@ -17,7 +17,6 @@ tari_broadcast_channel = "^0.2"
 tari_comms = { version = "^0.1", path = "../../comms"}
 tari_comms_dht = { version = "^0.1", path = "../../comms/dht"}
 tari_crypto = { version = "^0.3" }
-tari_pubsub = "^0.2"
 tari_service_framework = { version = "^0.0", path = "../service_framework"}
 tari_shutdown = { version = "^0.0", path="../../infrastructure/shutdown" }
 tari_storage = {version = "^0.1", path = "../../infrastructure/storage"}

--- a/base_layer/p2p/examples/pingpong.rs
+++ b/base_layer/p2p/examples/pingpong.rs
@@ -143,7 +143,7 @@ mod pingpong {
 
         let datastore_path = TempDir::new(random_string(8).as_str()).unwrap();
 
-        let (publisher, subscription_factory) = pubsub_connector(rt.handle().clone(), 100, 105);
+        let (publisher, subscription_factory) = pubsub_connector(rt.handle().clone(), 100);
         let subscription_factory = Arc::new(subscription_factory);
 
         let transport_type = if is_tor_enabled {

--- a/base_layer/p2p/src/comms_connector/inbound_connector.rs
+++ b/base_layer/p2p/src/comms_connector/inbound_connector.rs
@@ -61,7 +61,7 @@ where
     fn call(&mut self, msg: DecryptedDhtMessage) -> Self::Future {
         let mut sink = self.sink.clone();
         async move {
-            let peer_message = Self::do_peer_message(msg)?;
+            let peer_message = Self::construct_peer_message(msg)?;
             // If this fails there is something wrong with the sink and the pubsub middleware should not
             // continue
             sink.send(Arc::new(peer_message))
@@ -74,7 +74,7 @@ where
 }
 
 impl<TSink> InboundDomainConnector<TSink> {
-    fn do_peer_message(mut inbound_message: DecryptedDhtMessage) -> Result<PeerMessage, PipelineError> {
+    fn construct_peer_message(mut inbound_message: DecryptedDhtMessage) -> Result<PeerMessage, PipelineError> {
         let envelope_body = inbound_message
             .success_mut()
             .ok_or_else(|| "Message failed to decrypt")?;
@@ -125,7 +125,7 @@ where
     }
 
     fn start_send(mut self: Pin<&mut Self>, item: DecryptedDhtMessage) -> Result<(), Self::Error> {
-        let item = Self::do_peer_message(item)?;
+        let item = Self::construct_peer_message(item)?;
         Pin::new(&mut self.sink)
             .start_send(Arc::new(item))
             .map_err(PipelineError::from_debug)

--- a/base_layer/p2p/src/comms_connector/mod.rs
+++ b/base_layer/p2p/src/comms_connector/mod.rs
@@ -21,11 +21,10 @@
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 mod inbound_connector;
-mod peer_message;
-mod pubsub;
+pub use inbound_connector::InboundDomainConnector;
 
-pub use self::{
-    inbound_connector::InboundDomainConnector,
-    peer_message::PeerMessage,
-    pubsub::{pubsub_connector, PubsubDomainConnector, SubscriptionFactory},
-};
+mod peer_message;
+pub use peer_message::PeerMessage;
+
+mod pubsub;
+pub use pubsub::{pubsub_connector, PubsubDomainConnector, SubscriptionFactory, TopicSubscriptionFactory};

--- a/base_layer/p2p/src/comms_connector/pubsub.rs
+++ b/base_layer/p2p/src/comms_connector/pubsub.rs
@@ -22,11 +22,10 @@
 
 use super::peer_message::PeerMessage;
 use crate::{comms_connector::InboundDomainConnector, tari_message::TariMessageType};
-use futures::{channel::mpsc, FutureExt, SinkExt, StreamExt};
+use futures::{channel::mpsc, future, stream::Fuse, Stream, StreamExt};
 use log::*;
-use std::sync::Arc;
-use tari_pubsub::{pubsub_channel_with_id, TopicPayload, TopicSubscriptionFactory};
-use tokio::runtime::Handle;
+use std::{fmt::Debug, sync::Arc};
+use tokio::{runtime::Handle, sync::broadcast};
 
 const LOG_TARGET: &str = "comms::middleware::pubsub";
 
@@ -34,22 +33,17 @@ const LOG_TARGET: &str = "comms::middleware::pubsub";
 pub type PubsubDomainConnector = InboundDomainConnector<mpsc::Sender<Arc<PeerMessage>>>;
 pub type SubscriptionFactory = TopicSubscriptionFactory<TariMessageType, Arc<PeerMessage>>;
 
-/// Connects `InboundDomainConnector` to a `tari_pubsub::TopicPublisher` through a buffered channel
-pub fn pubsub_connector(
-    executor: Handle,
-    buf_size: usize,
-    buf_id: usize,
-) -> (PubsubDomainConnector, SubscriptionFactory)
-{
-    let (publisher, subscription_factory) = pubsub_channel_with_id(buf_size, buf_id);
+/// Connects `InboundDomainConnector` to a `tari_pubsub::TopicPublisher` through a buffered broadcast channel
+pub fn pubsub_connector(executor: Handle, buf_size: usize) -> (PubsubDomainConnector, SubscriptionFactory) {
+    let (publisher, subscription_factory) = pubsub_channel(buf_size);
     let (sender, receiver) = mpsc::channel(buf_size);
 
     // Spawn a task which forwards messages from the pubsub service to the TopicPublisher
     let forwarder = receiver
         // Map DomainMessage into a TopicPayload
-        .map(|msg: Arc<PeerMessage>| {
-            TariMessageType::from_i32(msg.message_header.message_type)
-                .map(|msg_type| {
+        .filter_map(|msg: Arc<PeerMessage>| {
+            let opt = match TariMessageType::from_i32(msg.message_header.message_type) {
+                Some(msg_type) => {
                     let message_tag_trace = msg.dht_header.message_tag;
                     let payload = TopicPayload::new(msg_type, msg);
                     trace!(
@@ -57,22 +51,215 @@ pub fn pubsub_connector(
                         "Created topic payload message {:?}, Trace: {}",
                         &payload.topic(), message_tag_trace
                     );
-                    payload
-                })
-                .ok_or_else(|| "Invalid or unrecognised Tari message type".to_string())
+                    Some(payload)
+                }
+                None => {
+                    warn!(target: LOG_TARGET, "Invalid or unrecognised Tari message type '{}'", msg.message_header.message_type);
+                    None
+                }
+            };
+            future::ready(opt)
         })
         // Forward TopicPayloads to the publisher
-        .forward(publisher.sink_map_err(|err| err.to_string()))
-        // Log error and return unit
-        .map(|result| {
-            if let Err(err) = result {
+        .for_each(move |item| {
+            if let Err(err) = publisher.send(item).map_err(|_| "No subscribers when sending message".to_string())
+            {
                 warn!(
                     target: LOG_TARGET,
                     "Error forwarding pubsub messages to publisher: {}", err
                 );
             }
+            future::ready(())
         });
+
     executor.spawn(forwarder);
 
     (InboundDomainConnector::new(sender), subscription_factory)
+}
+
+/// Create a topic-based pub-sub channel
+fn pubsub_channel<T, M>(size: usize) -> (TopicPublisher<T, M>, TopicSubscriptionFactory<T, M>)
+where
+    T: Clone + Debug + Send + Eq,
+    M: Send + Clone,
+{
+    let (publisher, _) = broadcast::channel(size);
+    (publisher.clone(), TopicSubscriptionFactory::new(publisher))
+}
+
+/// The container for a message that is passed along the pub-sub channel that contains a Topic to define the type of
+/// message and the message itself.
+#[derive(Debug, Clone)]
+pub struct TopicPayload<T, M> {
+    topic: T,
+    message: M,
+}
+
+impl<T, M> TopicPayload<T, M> {
+    pub fn new(topic: T, message: M) -> Self {
+        Self { topic, message }
+    }
+
+    pub fn topic(&self) -> &T {
+        &self.topic
+    }
+
+    pub fn message(&self) -> &M {
+        &self.message
+    }
+}
+
+pub type TopicPublisher<T, M> = broadcast::Sender<TopicPayload<T, M>>;
+
+/// This structure is used to create subscriptions to particular topics.
+/// Note that subscriptions obtained after messages are published will miss messages.
+#[derive(Clone)]
+pub struct TopicSubscriptionFactory<T, M> {
+    sender: broadcast::Sender<TopicPayload<T, M>>,
+}
+
+impl<T, M> TopicSubscriptionFactory<T, M>
+where
+    T: Clone + Eq + Debug + Send,
+    M: Clone + Send,
+{
+    pub fn new(sender: broadcast::Sender<TopicPayload<T, M>>) -> Self {
+        TopicSubscriptionFactory { sender }
+    }
+
+    /// Create a subscription stream to a particular topic. The provided label is used to identify which consumer is
+    /// lagging.
+    pub fn get_subscription(&self, topic: T, label: &'static str) -> impl Stream<Item = M> {
+        self.sender
+            .subscribe()
+            .filter_map({
+                let topic = topic.clone();
+                move |result| {
+                    let opt = match result {
+                        Ok(payload) => Some(payload),
+                        Err(broadcast::RecvError::Closed) => None,
+                        Err(broadcast::RecvError::Lagged(n)) => {
+                            warn!(
+                                target: LOG_TARGET,
+                                "Subscription '{}' for topic '{:?}' lagged. {} message(s) dropped.", label, topic, n
+                            );
+                            None
+                        },
+                    };
+                    future::ready(opt)
+                }
+            })
+            .filter_map(move |item| {
+                let opt = if item.topic() == &topic {
+                    Some(item.message)
+                } else {
+                    None
+                };
+                future::ready(opt)
+            })
+    }
+
+    /// Convenience function that returns a fused (`stream::Fuse`) version of the subscription stream.
+    pub fn get_subscription_fused(&self, topic: T, label: &'static str) -> Fuse<impl Stream<Item = M>> {
+        self.get_subscription(topic, label).fuse()
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use futures::stream;
+    use std::time::Duration;
+    use tari_test_utils::collect_stream;
+
+    #[tokio_macros::test_basic]
+    async fn topic_pub_sub() {
+        let (publisher, subscriber_factory) = pubsub_channel(10);
+
+        #[derive(Debug, Clone)]
+        struct Dummy {
+            a: u32,
+            b: String,
+        }
+
+        let messages = vec![
+            TopicPayload::new("Topic1", Dummy {
+                a: 1u32,
+                b: "one".to_string(),
+            }),
+            TopicPayload::new("Topic2", Dummy {
+                a: 2u32,
+                b: "two".to_string(),
+            }),
+            TopicPayload::new("Topic1", Dummy {
+                a: 3u32,
+                b: "three".to_string(),
+            }),
+            TopicPayload::new("Topic2", Dummy {
+                a: 4u32,
+                b: "four".to_string(),
+            }),
+            TopicPayload::new("Topic1", Dummy {
+                a: 5u32,
+                b: "five".to_string(),
+            }),
+            TopicPayload::new("Topic2", Dummy {
+                a: 6u32,
+                b: "size".to_string(),
+            }),
+            TopicPayload::new("Topic1", Dummy {
+                a: 7u32,
+                b: "seven".to_string(),
+            }),
+        ];
+
+        let mut sub1 = subscriber_factory.get_subscription("Topic1", "Test").fuse();
+        let mut sub2 = subscriber_factory.get_subscription("Topic2", "Test");
+        drop(subscriber_factory);
+
+        for m in messages {
+            publisher.send(m).unwrap();
+        }
+
+        let topic1a = collect_stream!(sub1, take = 4, timeout = Duration::from_secs(10));
+
+        assert_eq!(topic1a[0].a, 1);
+        assert_eq!(topic1a[1].a, 3);
+        assert_eq!(topic1a[2].a, 5);
+        assert_eq!(topic1a[3].a, 7);
+
+        let messages2 = vec![
+            TopicPayload::new("Topic1", Dummy {
+                a: 11u32,
+                b: "one one".to_string(),
+            }),
+            TopicPayload::new("Topic2", Dummy {
+                a: 22u32,
+                b: "two two".to_string(),
+            }),
+            TopicPayload::new("Topic1", Dummy {
+                a: 33u32,
+                b: "three three".to_string(),
+            }),
+        ];
+
+        stream::iter(messages2)
+            .for_each(|msg| {
+                publisher.send(msg).unwrap();
+                future::ready(())
+            })
+            .await;
+
+        let topic1b = collect_stream!(sub1, take = 2, timeout = Duration::from_secs(10));
+
+        assert_eq!(topic1b[0].a, 11);
+        assert_eq!(topic1b[1].a, 33);
+
+        let topic2 = collect_stream!(sub2, take = 4, timeout = Duration::from_secs(10));
+
+        assert_eq!(topic2[0].a, 2);
+        assert_eq!(topic2[1].a, 4);
+        assert_eq!(topic2[2].a, 6);
+        assert_eq!(topic2[3].a, 22);
+    }
 }

--- a/base_layer/p2p/src/services/liveness/mod.rs
+++ b/base_layer/p2p/src/services/liveness/mod.rs
@@ -53,7 +53,6 @@ use futures::{future, Future, Stream, StreamExt};
 use log::*;
 use std::sync::Arc;
 use tari_comms_dht::{outbound::OutboundMessageRequester, DhtRequester};
-use tari_pubsub::TopicSubscriptionFactory;
 use tari_service_framework::{
     handles::ServiceHandlesFuture,
     reply_channel,
@@ -72,6 +71,7 @@ pub use self::{
     handle::{LivenessEvent, LivenessEventSender, LivenessHandle, LivenessRequest, LivenessResponse, PingPongEvent},
     state::Metadata,
 };
+use crate::comms_connector::TopicSubscriptionFactory;
 pub use crate::proto::liveness::MetadataKey;
 use tokio::sync::broadcast;
 
@@ -102,7 +102,7 @@ impl LivenessInitializer {
     /// Get a stream of inbound PingPong messages
     fn ping_stream(&self) -> impl Stream<Item = DomainMessage<PingPongMessage>> {
         self.inbound_message_subscription_factory
-            .get_subscription(TariMessageType::PingPong)
+            .get_subscription(TariMessageType::PingPong, "Liveness")
             .map(map_decode::<PingPongMessage>)
             .filter_map(ok_or_skip_result)
     }

--- a/base_layer/p2p/tests/services/liveness.rs
+++ b/base_layer/p2p/tests/services/liveness.rs
@@ -48,7 +48,7 @@ pub async fn setup_liveness_service(
 ) -> (LivenessHandle, CommsNode, Dht)
 {
     let rt_handle = runtime::Handle::current();
-    let (publisher, subscription_factory) = pubsub_connector(rt_handle.clone(), 100, 101);
+    let (publisher, subscription_factory) = pubsub_connector(rt_handle.clone(), 100);
     let subscription_factory = Arc::new(subscription_factory);
     let (comms, dht) = setup_comms_services(node_identity.clone(), peers, publisher, data_path).await;
 

--- a/base_layer/wallet/Cargo.toml
+++ b/base_layer/wallet/Cargo.toml
@@ -17,7 +17,6 @@ tari_comms_dht = { path = "../../comms/dht", version = "^0.1"}
 tari_crypto = { version = "^0.3" }
 tari_key_manager = {path = "../key_manager", version = "^0.0"}
 tari_p2p = {path = "../p2p", version = "^0.1"}
-tari_pubsub = "^0.2"
 tari_service_framework = { version = "^0.0", path = "../service_framework"}
 tari_shutdown = { path = "../../infrastructure/shutdown", version = "^0.0"}
 tari_storage = { version = "^0.1", path = "../../infrastructure/storage"}

--- a/base_layer/wallet/src/wallet.rs
+++ b/base_layer/wallet/src/wallet.rs
@@ -128,11 +128,7 @@ where
         let transaction_backend_handle = transaction_backend.clone();
 
         let factories = config.factories;
-        let (publisher, subscription_factory) = pubsub_connector(
-            runtime.handle().clone(),
-            config.comms_config.max_concurrent_inbound_tasks,
-            4,
-        );
+        let (publisher, subscription_factory) = pubsub_connector(runtime.handle().clone(), 100);
         let subscription_factory = Arc::new(subscription_factory);
 
         // Wallet should join the network

--- a/base_layer/wallet/tests/transaction_service/service.rs
+++ b/base_layer/wallet/tests/transaction_service/service.rs
@@ -152,7 +152,7 @@ pub fn setup_transaction_service<T: TransactionBackend + Clone + 'static, P: AsR
     discovery_request_timeout: Duration,
 ) -> (TransactionServiceHandle, OutputManagerHandle, CommsNode)
 {
-    let (publisher, subscription_factory) = pubsub_connector(runtime.handle().clone(), 100, 103);
+    let (publisher, subscription_factory) = pubsub_connector(runtime.handle().clone(), 100);
     let subscription_factory = Arc::new(subscription_factory);
     let (comms, dht) = runtime.block_on(setup_comms_services(
         node_identity,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR switches to the tokio broadcast channel for inbound message
pubsub. The main benefit of this vs tari_broadcast_channel is that the
each item in the buffer is dropped once all subscribers have read it instead
of living in memory until overwritten.
The tokio channel also lets a subscriber know that it has missed messages.

Removes the "channel IDs" from pubsub as the topic is already logged
when the subscriber is lagging, which should give a good indication of
which component is slow to read.

~~If we need more fine-grained logging, I suggest a string label be implemented 
as a get_subscription_labelled. However, I suspect logging of lagged topics 
would be enough.~~

Added a string label so that the consumer of the subscription will be clearly logged 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Memory usage should be lower

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Included unit test from tari_pubsub and many existing tests use the inbound pipeline

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [x] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [x] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch.
* [x] I ran `cargo-fmt --all` before pushing.
* [x] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
