### PR TITLE
Run clippy on pull requests

### DIFF
--- a/.github/workflows/clippy-check.yml
+++ b/.github/workflows/clippy-check.yml
@@ -1,4 +1,7 @@
-on: push
+on:
+  push:
+  pull_request:
+    types: [opened]
 name: Clippy
 jobs:
   clippy_check:


### PR DESCRIPTION
Pull requests from forked repos do not trigger the clippy action.

This PR adds a trigger for PRs to run the clippy action as well.

