### PR TITLE
Simplified outbound message interface

### DIFF
--- a/base_layer/core/tests/mempool.rs
+++ b/base_layer/core/tests/mempool.rs
@@ -36,7 +36,7 @@ use helpers::{
     sample_blockchains::create_new_blockchain,
 };
 use std::{ops::Deref, sync::Arc, time::Duration};
-use tari_comms_dht::{domain_message::OutboundDomainMessage, outbound::OutboundEncryption};
+use tari_comms_dht::domain_message::OutboundDomainMessage;
 use tari_core::{
     base_node::{comms_interface::Broadcast, service::BaseNodeServiceConfig},
     consensus::{ConsensusConstantsBuilder, ConsensusManagerBuilder, Network},
@@ -642,7 +642,6 @@ fn receive_and_propagate_transaction() {
             .outbound_message_service
             .send_direct(
                 bob_node.node_identity.public_key().clone(),
-                OutboundEncryption::None,
                 OutboundDomainMessage::new(TariMessageType::NewTransaction, proto::types::Transaction::from(tx)),
             )
             .await
@@ -651,7 +650,6 @@ fn receive_and_propagate_transaction() {
             .outbound_message_service
             .send_direct(
                 carol_node.node_identity.public_key().clone(),
-                OutboundEncryption::None,
                 OutboundDomainMessage::new(TariMessageType::NewTransaction, proto::types::Transaction::from(orphan)),
             )
             .await

--- a/base_layer/core/tests/mining.rs
+++ b/base_layer/core/tests/mining.rs
@@ -31,7 +31,7 @@ use helpers::{
 };
 use std::{sync::atomic::Ordering, time::Duration};
 use tari_broadcast_channel::{bounded, Publisher, Subscriber};
-use tari_comms_dht::{domain_message::OutboundDomainMessage, outbound::OutboundEncryption};
+use tari_comms_dht::domain_message::OutboundDomainMessage;
 use tari_core::{
     base_node::{service::BaseNodeServiceConfig, states::StateEvent},
     consensus::{ConsensusManagerBuilder, Network},
@@ -80,7 +80,6 @@ fn mining() {
             .outbound_message_service
             .send_direct(
                 alice_node.node_identity.public_key().clone(),
-                OutboundEncryption::None,
                 OutboundDomainMessage::new(
                     TariMessageType::NewTransaction,
                     proto::types::Transaction::from(tx1.clone()),

--- a/base_layer/wallet/src/transaction_service/protocols/transaction_broadcast_protocol.rs
+++ b/base_layer/wallet/src/transaction_service/protocols/transaction_broadcast_protocol.rs
@@ -30,7 +30,7 @@ use futures::{channel::mpsc::Receiver, FutureExt, StreamExt};
 use log::*;
 use std::{convert::TryFrom, sync::Arc, time::Duration};
 use tari_comms::types::CommsPublicKey;
-use tari_comms_dht::{domain_message::OutboundDomainMessage, outbound::OutboundEncryption};
+use tari_comms_dht::domain_message::OutboundDomainMessage;
 use tari_core::{
     base_node::proto::{
         base_node as BaseNodeProto,
@@ -154,7 +154,6 @@ where TBackend: TransactionBackend + Clone + 'static
                 .outbound_message_service
                 .send_direct(
                     self.base_node_public_key.clone(),
-                    OutboundEncryption::None,
                     OutboundDomainMessage::new(TariMessageType::MempoolRequest, mempool_request.clone()),
                 )
                 .await
@@ -175,7 +174,6 @@ where TBackend: TransactionBackend + Clone + 'static
                 .outbound_message_service
                 .send_direct(
                     self.base_node_public_key.clone(),
-                    OutboundEncryption::None,
                     OutboundDomainMessage::new(TariMessageType::BaseNodeRequest, service_request),
                 )
                 .await

--- a/base_layer/wallet/src/transaction_service/protocols/transaction_chain_monitoring_protocol.rs
+++ b/base_layer/wallet/src/transaction_service/protocols/transaction_chain_monitoring_protocol.rs
@@ -33,7 +33,7 @@ use futures::{channel::mpsc::Receiver, FutureExt, StreamExt};
 use log::*;
 use std::{convert::TryFrom, sync::Arc, time::Duration};
 use tari_comms::types::CommsPublicKey;
-use tari_comms_dht::{domain_message::OutboundDomainMessage, outbound::OutboundEncryption};
+use tari_comms_dht::domain_message::OutboundDomainMessage;
 use tari_core::{
     base_node::proto::{
         base_node as BaseNodeProto,
@@ -177,7 +177,6 @@ where TBackend: TransactionBackend + Clone + 'static
                 .outbound_message_service
                 .send_direct(
                     self.base_node_public_key.clone(),
-                    OutboundEncryption::None,
                     OutboundDomainMessage::new(TariMessageType::MempoolRequest, mempool_request.clone()),
                 )
                 .await
@@ -193,7 +192,6 @@ where TBackend: TransactionBackend + Clone + 'static
                 .outbound_message_service
                 .send_direct(
                     self.base_node_public_key.clone(),
-                    OutboundEncryption::None,
                     OutboundDomainMessage::new(TariMessageType::BaseNodeRequest, service_request),
                 )
                 .await

--- a/base_layer/wallet/src/transaction_service/protocols/transaction_receive_protocol.rs
+++ b/base_layer/wallet/src/transaction_service/protocols/transaction_receive_protocol.rs
@@ -171,7 +171,6 @@ where TBackend: TransactionBackend + Clone + 'static
                 .outbound_message_service
                 .send_direct(
                     self.source_pubkey.clone(),
-                    OutboundEncryption::None,
                     OutboundDomainMessage::new(TariMessageType::ReceiverPartialTransactionReply, proto_message.clone()),
                 )
                 .await
@@ -191,10 +190,10 @@ where TBackend: TransactionBackend + Clone + 'static
                                 .map_err(|e| TransactionServiceProtocolError::new(self.id, e))?;
                         }
                     },
-                    SendMessageResponse::Failed => {
+                    SendMessageResponse::Failed(err) => {
                         error!(
                             target: LOG_TARGET,
-                            "Transaction Reply Send Direct for TxID: {} failed", self.id
+                            "Transaction Reply Send Direct for TxID {} failed: {}", self.id, err
                         );
                         store_and_forward_send_result = self
                             .send_transaction_reply_store_and_forward(
@@ -304,30 +303,14 @@ where TBackend: TransactionBackend + Clone + 'static
             )
             .await
         {
-            Ok(result) => match result.resolve_ok().await {
-                None => {
-                    error!(
-                        target: LOG_TARGET,
-                        "Sending Transaction Reply (TxId: {}) to neighbours for Store and Forward failed", tx_id,
-                    );
-                },
-                Some(tags) if !tags.is_empty() => {
-                    info!(
-                        target: LOG_TARGET,
-                        "Sending Transaction Reply (TxId: {}) to Neighbours for Store and Forward successful with \
-                         Message Tags: {:?}",
-                        tx_id,
-                        tags,
-                    );
-                },
-                Some(_) => {
-                    error!(
-                        target: LOG_TARGET,
-                        "Sending Transaction Reply to Neighbours for Store and Forward for TX_ID: {} was unsuccessful \
-                         and no messages were sent.",
-                        tx_id,
-                    );
-                },
+            Ok(send_states) => {
+                info!(
+                    target: LOG_TARGET,
+                    "Sending Transaction Reply (TxId: {}) to Neighbours for Store and Forward successful with Message \
+                     Tags: {:?}",
+                    tx_id,
+                    send_states.to_tags(),
+                );
             },
             Err(e) => {
                 error!(

--- a/comms/dht/examples/memorynet.rs
+++ b/comms/dht/examples/memorynet.rs
@@ -471,7 +471,7 @@ async fn do_network_wide_propagation(nodes: &mut [TestNode]) {
                             .unwrap();
                         println!("📬 {} got public message '{}'", node_name, public_msg);
                         is_success = true;
-                        let sent_state = outbound_req
+                        let send_states = outbound_req
                             .propagate(
                                 NodeDestination::Unknown,
                                 OutboundEncryption::None,
@@ -480,8 +480,7 @@ async fn do_network_wide_propagation(nodes: &mut [TestNode]) {
                             )
                             .await
                             .unwrap();
-                        let states = sent_state.resolve_ok().await.unwrap();
-                        println!("🦠 {} propagated to {} peer(s)", node_name, states.len());
+                        println!("🦠 {} propagated to {} peer(s)", node_name, send_states.len());
                     },
                     Err(_) | Ok(None) => {
                         banner!(

--- a/comms/dht/src/actor.rs
+++ b/comms/dht/src/actor.rs
@@ -109,7 +109,7 @@ pub enum DhtRequest {
     /// Fetch selected peers according to the broadcast strategy
     SelectPeers(BroadcastStrategy, oneshot::Sender<Vec<NodeId>>),
     GetMetadata(DhtMetadataKey, oneshot::Sender<Result<Option<Vec<u8>>, DhtActorError>>),
-    SetMetadata(DhtMetadataKey, Vec<u8>),
+    SetMetadata(DhtMetadataKey, Vec<u8>, oneshot::Sender<Result<(), DhtActorError>>),
 }
 
 impl Display for DhtRequest {
@@ -119,8 +119,10 @@ impl Display for DhtRequest {
             SendJoin => f.write_str("SendJoin"),
             MsgHashCacheInsert(_, _) => f.write_str("MsgHashCacheInsert"),
             SelectPeers(s, _) => f.write_str(&format!("SelectPeers (Strategy={})", s)),
-            GetMetadata(key, _) => f.write_str(&format!("GetSetting (key={})", key)),
-            SetMetadata(key, value) => f.write_str(&format!("SetSetting (key={}, value={} bytes)", key, value.len())),
+            GetMetadata(key, _) => f.write_str(&format!("GetMetadata (key={})", key)),
+            SetMetadata(key, value, _) => {
+                f.write_str(&format!("SetMetadata (key={}, value={} bytes)", key, value.len()))
+            },
         }
     }
 }
@@ -168,9 +170,10 @@ impl DhtRequester {
     }
 
     pub async fn set_metadata<T: MessageFormat>(&mut self, key: DhtMetadataKey, value: T) -> Result<(), DhtActorError> {
+        let (reply_tx, reply_rx) = oneshot::channel();
         let bytes = value.to_binary().map_err(DhtActorError::FailedToSerializeValue)?;
-        self.sender.send(DhtRequest::SetMetadata(key, bytes)).await?;
-        Ok(())
+        self.sender.send(DhtRequest::SetMetadata(key, bytes, reply_tx)).await?;
+        reply_rx.await.map_err(|_| DhtActorError::ReplyCanceled)?
     }
 }
 
@@ -317,15 +320,17 @@ impl DhtActor {
                     Ok(())
                 })
             },
-            SetMetadata(key, value) => {
+            SetMetadata(key, value, reply_tx) => {
                 let db = self.database.clone();
                 Box::pin(async move {
                     match db.set_metadata_value_bytes(key, value).await {
                         Ok(_) => {
-                            debug!(target: LOG_TARGET, "Dht setting '{}' set", key);
+                            debug!(target: LOG_TARGET, "Dht metadata '{}' set", key);
+                            let _ = reply_tx.send(Ok(()));
                         },
                         Err(err) => {
-                            warn!(target: LOG_TARGET, "set_setting failed because {:?}", err);
+                            warn!(target: LOG_TARGET, "Unable to set metadata because {:?}", err);
+                            let _ = reply_tx.send(Err(err.into()));
                         },
                     }
                     Ok(())

--- a/comms/dht/src/discovery/error.rs
+++ b/comms/dht/src/discovery/error.rs
@@ -20,7 +20,7 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use crate::outbound::DhtOutboundError;
+use crate::outbound::{message::SendFailure, DhtOutboundError};
 use futures::channel::mpsc::SendError;
 use tari_comms::{connection_manager::ConnectionManagerError, peer_manager::PeerManagerError};
 use thiserror::Error;
@@ -41,8 +41,8 @@ pub enum DhtDiscoveryError {
     SendBufferFull,
     #[error("The discovery request timed out")]
     DiscoveryTimeout,
-    #[error("Failed to send discovery message")]
-    DiscoverySendFailed,
+    #[error("Failed to send discovery message: {0}")]
+    DiscoverySendFailed(SendFailure),
     #[error("PeerManagerError: {0}")]
     PeerManagerError(#[from] PeerManagerError),
     #[error("InvalidPeerMultiaddr: {0}")]

--- a/comms/dht/src/discovery/service.rs
+++ b/comms/dht/src/discovery/service.rs
@@ -352,9 +352,9 @@ impl DhtDiscoveryService {
                 discover_msg,
             )
             .await?
-            .resolve_ok()
+            .resolve()
             .await
-            .ok_or_else(|| DhtDiscoveryError::DiscoverySendFailed)?;
+            .map_err(DhtDiscoveryError::DiscoverySendFailed)?;
 
         // Spawn a task to log how the sending of discovery went
         task::spawn(async move {

--- a/comms/dht/src/outbound/error.rs
+++ b/comms/dht/src/outbound/error.rs
@@ -20,6 +20,7 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+use crate::outbound::message::SendFailure;
 use futures::channel::mpsc::SendError;
 use tari_comms::message::MessageError;
 use tari_crypto::{
@@ -54,4 +55,17 @@ pub enum DhtOutboundError {
     DiscoveryFailed,
     #[error("Failed to insert message hash")]
     FailedToInsertMessageHash,
+    #[error("Failed to send message: {0}")]
+    SendMessageFailed(SendFailure),
+    #[error("No messages were queued for sending")]
+    NoMessagesQueued,
+}
+
+impl From<SendFailure> for DhtOutboundError {
+    fn from(err: SendFailure) -> Self {
+        match err {
+            SendFailure::NoMessagesQueued => DhtOutboundError::NoMessagesQueued,
+            err => Self::SendMessageFailed(err),
+        }
+    }
 }

--- a/comms/dht/src/outbound/message.rs
+++ b/comms/dht/src/outbound/message.rs
@@ -33,6 +33,7 @@ use tari_comms::{
     types::CommsPublicKey,
 };
 use tari_utilities::hex::Hex;
+use thiserror::Error;
 
 /// Determines if an outbound message should be Encrypted and, if so, for which public key
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -77,13 +78,29 @@ impl Default for OutboundEncryption {
     }
 }
 
+#[derive(Debug, Error)]
+pub enum SendFailure {
+    #[error("Attempt to send message to ourselves")]
+    SendToOurselves,
+    #[error("Discovery reply channel cancelled")]
+    SenderCancelled,
+    #[error("Failure when sending: {0}")]
+    General(String),
+    #[error("Discovery failed")]
+    DiscoveryFailed,
+    #[error("Failure when generating messages: {0}")]
+    FailedToGenerateMessages(String),
+    #[error("No messages were queued for sending")]
+    NoMessagesQueued,
+}
+
 #[derive(Debug)]
 pub enum SendMessageResponse {
     /// Returns the message tags which are queued for sending. These tags will be used in a subsequent OutboundEvent to
     /// indicate if the message succeeded/failed to send
     Queued(MessageSendStates),
     /// A failure occurred when sending
-    Failed,
+    Failed(SendFailure),
     /// DHT Discovery has been initiated. The caller may wait on the receiver
     /// to find out of the message was sent.
     /// _NOTE: DHT discovery could take minutes (determined by `DhtConfig::discovery_request_timeout)_
@@ -92,24 +109,26 @@ pub enum SendMessageResponse {
 
 impl SendMessageResponse {
     /// Returns the result of a send message request.
-    /// A `SendMessageResponse::Queued(n)` will resolve immediately returning `Some(n)`.
-    /// A `SendMessageResponse::Failed` will resolve immediately returning a `None`.
-    /// If DHT discovery is initiated, this will resolve once discovery has completed, either
-    /// succeeding (`Some(n)`) or failing (`None`).
-    pub async fn resolve_ok(self) -> Option<MessageSendStates> {
+    /// A `SendMessageResponse::Queued(n)` will resolve immediately returning `Ok(n)` or
+    /// `Err(SendFailure::NoMessagesSent)`. A `SendMessageResponse::Failed` will resolve immediately returning a
+    /// `Err(SendFailure)`. If DHT discovery is initiated, this will resolve once discovery has completed, either
+    /// succeeding or failing.
+    pub async fn resolve(self) -> Result<MessageSendStates, SendFailure> {
         use SendMessageResponse::*;
         match self {
-            Queued(send_states) => Some(send_states),
-            Failed => None,
-            PendingDiscovery(rx) => rx.await.ok()?.queued_or_failed(),
+            Queued(send_states) if !send_states.is_empty() => Ok(send_states),
+            Queued(_) => Err(SendFailure::NoMessagesQueued),
+            Failed(err) => Err(err),
+            PendingDiscovery(rx) => rx.await.map_err(|_| SendFailure::SenderCancelled)?.queued_or_failed(),
         }
     }
 
-    fn queued_or_failed(self) -> Option<MessageSendStates> {
+    fn queued_or_failed(self) -> Result<MessageSendStates, SendFailure> {
         use SendMessageResponse::*;
         match self {
-            Queued(send_states) => Some(send_states),
-            Failed => None,
+            Queued(send_states) if !send_states.is_empty() => Ok(send_states),
+            Queued(_) => Err(SendFailure::NoMessagesQueued),
+            Failed(err) => Err(err),
             PendingDiscovery(_) => panic!("ok_or_failed() called on PendingDiscovery"),
         }
     }

--- a/comms/dht/src/outbound/message_params.rs
+++ b/comms/dht/src/outbound/message_params.rs
@@ -77,7 +77,7 @@ impl Default for FinalSendMessageParams {
             dht_message_type: Default::default(),
             dht_message_flags: Default::default(),
             force_origin: false,
-            is_discovery_enabled: true,
+            is_discovery_enabled: false,
             dht_header: None,
         }
     }

--- a/comms/dht/src/outbound/message_send_state.rs
+++ b/comms/dht/src/outbound/message_send_state.rs
@@ -42,6 +42,10 @@ impl MessageSendState {
     pub fn new(tag: MessageTag, reply_rx: MessagingReplyRx) -> Self {
         Self { tag, reply_rx }
     }
+
+    pub fn wait_for_result(self) -> MessagingReplyRx {
+        self.reply_rx
+    }
 }
 
 #[derive(Debug)]
@@ -213,6 +217,14 @@ impl MessageSendStates {
         });
 
         unordered
+    }
+
+    pub fn into_inner(self) -> Vec<MessageSendState> {
+        self.inner
+    }
+
+    pub fn to_tags(&self) -> Vec<MessageTag> {
+        self.inner.iter().map(|s| s.tag).collect()
     }
 }
 

--- a/comms/dht/src/outbound/mod.rs
+++ b/comms/dht/src/outbound/mod.rs
@@ -33,7 +33,7 @@ mod message_params;
 pub use message_params::SendMessageParams;
 
 mod message_send_state;
-pub use message_send_state::MessageSendStates;
+pub use message_send_state::{MessageSendState, MessageSendStates};
 
 mod requester;
 pub use requester::OutboundMessageRequester;

--- a/comms/dht/src/store_forward/saf_handler/task.rs
+++ b/comms/dht/src/store_forward/saf_handler/task.rs
@@ -239,10 +239,10 @@ where S: Service<DecryptedDhtMessage, Response = (), Error = PipelineError>
                     stored_messages,
                 )
                 .await?
-                .resolve_ok()
+                .resolve()
                 .await
             {
-                Some(_) => {
+                Ok(_) => {
                     debug!(
                         target: LOG_TARGET,
                         "Removing {:?} stored messages for peer '{}'",
@@ -252,11 +252,12 @@ where S: Service<DecryptedDhtMessage, Response = (), Error = PipelineError>
                     trace!(target: LOG_TARGET, "Removing stored messages: {:?}", message_ids,);
                     self.saf_requester.remove_messages(message_ids).await?;
                 },
-                None => {
+                Err(err) => {
                     error!(
                         target: LOG_TARGET,
-                        "Failed to send stored messages to peer '{}'",
-                        message.source_peer.node_id.short_str()
+                        "Failed to send stored messages to peer '{}': {}",
+                        message.source_peer.node_id.short_str(),
+                        err
                     );
                 },
             }

--- a/comms/dht/src/test_utils/dht_actor_mock.rs
+++ b/comms/dht/src/test_utils/dht_actor_mock.rs
@@ -130,8 +130,9 @@ impl DhtActorMock {
                     .get(&key.to_string())
                     .map(Clone::clone)));
             },
-            SetMetadata(key, value) => {
+            SetMetadata(key, value, reply_tx) => {
                 self.state.settings.write().unwrap().insert(key.to_string(), value);
+                reply_tx.send(Ok(())).unwrap();
             },
         }
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
- Failed message send state now has details about the error
- All calls apart from `send_direct` do not do discovery. API changed to
  reflect this.
- Direct send by NodeId always returns a single MessageSendState if
  queuing is successful.
- Direct message send always uses `OutboundEncryption::None`, because all p2p
  comms is already encrypted over the wire.
- If no messages are queued, an error is returned. This means that
  callers do not need to check if `send_states.is_empty()`.
- Updated code in wallet and base node

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Every call to send message could choose to handle the case where discovery is possible, however discovery is only possible on `send_direct` using the public key. The API change reflects the fact that they don't do discovery making domain layer code cleaner. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Existing tests updated

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [x] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch.
* [x] I ran `cargo-fmt --all` before pushing.
* [x] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
