### PR TITLE
Add FFI functions to get and read a wallets Seed Words

### DIFF
--- a/base_layer/wallet_ffi/Cargo.toml
+++ b/base_layer/wallet_ffi/Cargo.toml
@@ -38,3 +38,4 @@ crate-type = ["staticlib","cdylib"]
 tempdir = "0.3.7"
 lazy_static = "1.3.0"
 env_logger = "0.7.1"
+tari_key_manager = {path = "../key_manager", version = "^0.0"}

--- a/base_layer/wallet_ffi/wallet.h
+++ b/base_layer/wallet_ffi/wallet.h
@@ -71,6 +71,8 @@ struct TariPendingInboundTransaction;
 
 struct TariTransportType;
 
+struct TariSeedWords;
+
 /// -------------------------------- Transport Types ----------------------------------------------- ///
 
 // Creates a memory transport type
@@ -156,6 +158,16 @@ struct TariPrivateKey *private_key_from_hex(const char *hex,int* error_out);
 
 // Frees memory for a TariPrivateKey
 void private_key_destroy(struct TariPrivateKey *pk);
+
+/// -------------------------------- Seed Words  -------------------------------------------------- ///
+// Get the number of seed words in the provided collection
+unsigned int seed_words_get_length(struct TariSeedWords *seed_words, int* error_out);
+
+// Get a seed word from the provided collection at the specified position
+char *seed_words_get_at(struct TariSeedWords *seed_words, unsigned int position, int* error_out);
+
+// Frees the memory for a TariSeedWords collection
+void seed_words_destroy(truct TariSeedWords *seed_words);
 
 /// -------------------------------- Contact ------------------------------------------------------ ///
 
@@ -437,6 +449,9 @@ bool wallet_cancel_pending_transaction(struct TariWallet *wallet, unsigned long 
 
 /// Perform a coin split
 unsigned long long wallet_coin_split(struct TariWallet *wallet, unsigned long long amount, unsigned long long count, unsigned long long fee, const char* msg, unsigned long long lock_height, int* error_out);
+
+/// Get the seed words representing the seed private key of the provided TariWallet
+struct TariSeedWords *wallet_get_seed_words(struct TariWallet *wallet, int* error_out);
 
 // Frees memory for a TariWallet
 void wallet_destroy(struct TariWallet *wallet);


### PR DESCRIPTION
## Description
This PR adds the FFI functions to get the seed words that represent the seed private key of the key manager that wallet is using. This PR also provides the FFI functions used to restructure the collection of seed words and free the memory when you are done with it.

## How Has This Been Tested?
Test provided that exercises all these functions.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [x] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch.
* [x] I ran `cargo-fmt --all` before pushing.
* [ ] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
