### PR TITLE
Remove Liveness and add a Low Power mode to the Wallet

### DIFF
--- a/base_layer/core/tests/wallet.rs
+++ b/base_layer/core/tests/wallet.rs
@@ -158,9 +158,10 @@ fn wallet_base_node_integration_test() {
         comms_config: alice_comms_config,
         factories: factories.clone(),
         transaction_service_config: Some(TransactionServiceConfig {
-            mempool_broadcast_timeout: Duration::from_secs(10),
-            base_node_mined_timeout: Duration::from_secs(1),
-            ..Default::default()
+            base_node_monitoring_timeout: Duration::from_secs(1),
+            direct_send_timeout: Default::default(),
+            broadcast_send_timeout: Default::default(),
+            low_power_polling_timeout: Duration::from_secs(10),
         }),
     };
     let alice_runtime = create_runtime();
@@ -294,7 +295,9 @@ fn wallet_base_node_integration_test() {
             );
         });
     }
-
+    runtime
+        .block_on(alice_wallet.transaction_service.set_low_power_mode())
+        .unwrap();
     let transaction = transaction.expect("Transaction must be present");
 
     // Setup and start the miner

--- a/base_layer/wallet/src/transaction_service/config.rs
+++ b/base_layer/wallet/src/transaction_service/config.rs
@@ -24,19 +24,20 @@ use std::time::Duration;
 
 #[derive(Clone)]
 pub struct TransactionServiceConfig {
-    pub mempool_broadcast_timeout: Duration,
-    pub base_node_mined_timeout: Duration,
+    pub base_node_monitoring_timeout: Duration,
     pub direct_send_timeout: Duration,
     pub broadcast_send_timeout: Duration,
+    pub low_power_polling_timeout: Duration, /* This is the timeout period that will be used when the wallet is in
+                                              * low_power mode */
 }
 
 impl Default for TransactionServiceConfig {
     fn default() -> Self {
         Self {
-            mempool_broadcast_timeout: Duration::from_secs(30),
-            base_node_mined_timeout: Duration::from_secs(30),
+            base_node_monitoring_timeout: Duration::from_secs(30),
             direct_send_timeout: Duration::from_secs(20),
             broadcast_send_timeout: Duration::from_secs(30),
+            low_power_polling_timeout: Duration::from_secs(300),
         }
     }
 }

--- a/base_layer/wallet/src/transaction_service/handle.rs
+++ b/base_layer/wallet/src/transaction_service/handle.rs
@@ -49,6 +49,8 @@ pub enum TransactionServiceRequest {
     CancelTransaction(TxId),
     ImportUtxo(MicroTari, CommsPublicKey, String),
     SubmitTransaction((TxId, Transaction, MicroTari, MicroTari, String)),
+    SetLowPowerMode,
+    SetNormalPowerMode,
     #[cfg(feature = "test_harness")]
     CompletePendingOutboundTransaction(CompletedTransaction),
     #[cfg(feature = "test_harness")]
@@ -78,6 +80,8 @@ impl fmt::Display for TransactionServiceRequest {
             Self::CancelTransaction(t) => f.write_str(&format!("CancelTransaction ({})", t)),
             Self::ImportUtxo(v, k, msg) => f.write_str(&format!("ImportUtxo (from {}, {}, {})", k, v, msg)),
             Self::SubmitTransaction((id, _, _, _, _)) => f.write_str(&format!("SubmitTransaction ({})", id)),
+            Self::SetLowPowerMode => f.write_str("SetLowPowerMode "),
+            Self::SetNormalPowerMode => f.write_str("SetNormalPowerMode"),
             #[cfg(feature = "test_harness")]
             Self::CompletePendingOutboundTransaction(tx) => {
                 f.write_str(&format!("CompletePendingOutboundTransaction ({})", tx.tx_id))
@@ -108,6 +112,8 @@ pub enum TransactionServiceResponse {
     BaseNodePublicKeySet,
     UtxoImported(TxId),
     TransactionSubmitted,
+    LowPowerModeSet,
+    NormalPowerModeSet,
     #[cfg(feature = "test_harness")]
     CompletedPendingTransaction,
     #[cfg(feature = "test_harness")]
@@ -342,6 +348,24 @@ impl TransactionServiceHandle {
             .await??
         {
             TransactionServiceResponse::TransactionSubmitted => Ok(()),
+            _ => Err(TransactionServiceError::UnexpectedApiResponse),
+        }
+    }
+
+    pub async fn set_low_power_mode(&mut self) -> Result<(), TransactionServiceError> {
+        match self.handle.call(TransactionServiceRequest::SetLowPowerMode).await?? {
+            TransactionServiceResponse::LowPowerModeSet => Ok(()),
+            _ => Err(TransactionServiceError::UnexpectedApiResponse),
+        }
+    }
+
+    pub async fn set_normal_power_mode(&mut self) -> Result<(), TransactionServiceError> {
+        match self
+            .handle
+            .call(TransactionServiceRequest::SetNormalPowerMode)
+            .await??
+        {
+            TransactionServiceResponse::NormalPowerModeSet => Ok(()),
             _ => Err(TransactionServiceError::UnexpectedApiResponse),
         }
     }

--- a/base_layer/wallet/src/transaction_service/protocols/transaction_broadcast_protocol.rs
+++ b/base_layer/wallet/src/transaction_service/protocols/transaction_broadcast_protocol.rs
@@ -48,7 +48,7 @@ use tari_core::{
 };
 use tari_crypto::tari_utilities::{hex::Hex, Hashable};
 use tari_p2p::tari_message::TariMessageType;
-use tokio::time::delay_for;
+use tokio::{sync::broadcast, time::delay_for};
 
 const LOG_TARGET: &str = "wallet::transaction_service::protocols::broadcast_protocol";
 
@@ -63,6 +63,7 @@ where TBackend: TransactionBackend + Clone + 'static
     base_node_public_key: CommsPublicKey,
     mempool_response_receiver: Option<Receiver<MempoolServiceResponse>>,
     base_node_response_receiver: Option<Receiver<BaseNodeProto::BaseNodeServiceResponse>>,
+    timeout_update_receiver: Option<broadcast::Receiver<Duration>>,
 }
 
 impl<TBackend> TransactionBroadcastProtocol<TBackend>
@@ -75,6 +76,7 @@ where TBackend: TransactionBackend + Clone + 'static
         base_node_public_key: CommsPublicKey,
         mempool_response_receiver: Receiver<MempoolServiceResponse>,
         base_node_response_receiver: Receiver<BaseNodeProto::BaseNodeServiceResponse>,
+        timeout_update_receiver: broadcast::Receiver<Duration>,
     ) -> Self
     {
         Self {
@@ -84,6 +86,7 @@ where TBackend: TransactionBackend + Clone + 'static
             base_node_public_key,
             mempool_response_receiver: Some(mempool_response_receiver),
             base_node_response_receiver: Some(base_node_response_receiver),
+            timeout_update_receiver: Some(timeout_update_receiver),
         }
     }
 
@@ -98,6 +101,12 @@ where TBackend: TransactionBackend + Clone + 'static
             .base_node_response_receiver
             .take()
             .ok_or_else(|| TransactionServiceProtocolError::new(self.id, TransactionServiceError::InvalidStateError))?;
+
+        let mut timeout_update_receiver = self
+            .timeout_update_receiver
+            .take()
+            .ok_or_else(|| TransactionServiceProtocolError::new(self.id, TransactionServiceError::InvalidStateError))?
+            .fuse();
 
         // This is the main loop of the protocol and following the following steps
         // 1) Check transaction being monitored is still in the Completed state and needs to be monitored
@@ -189,6 +198,15 @@ where TBackend: TransactionBackend + Clone + 'static
                 base_node_response = base_node_response_receiver.select_next_some() => {
                     if self.handle_base_node_response(base_node_response).await? {
                         break;
+                    }
+                },
+                updated_timeout = timeout_update_receiver.select_next_some() => {
+                    if let Ok(to) = updated_timeout {
+                        self.timeout = to;
+                        info!(
+                            target: LOG_TARGET,
+                            "Broadcast monitoring protocol (Id: {}) timeout updated to {:?}", self.id ,self.timeout
+                        );
                     }
                 },
                 () = delay => {

--- a/base_layer/wallet/src/wallet.rs
+++ b/base_layer/wallet/src/wallet.rs
@@ -40,7 +40,7 @@ use crate::{
 };
 use blake2::Digest;
 use log::*;
-use std::{marker::PhantomData, sync::Arc, time::Duration};
+use std::{marker::PhantomData, sync::Arc};
 use tari_comms::{
     multiaddr::Multiaddr,
     peer_manager::{NodeId, Peer, PeerFeatures, PeerFlags},
@@ -62,10 +62,7 @@ use tari_crypto::{
 use tari_p2p::{
     comms_connector::pubsub_connector,
     initialization::{initialize_comms, CommsConfig},
-    services::{
-        comms_outbound::CommsOutboundServiceInitializer,
-        liveness::{LivenessConfig, LivenessHandle, LivenessInitializer},
-    },
+    services::comms_outbound::CommsOutboundServiceInitializer,
 };
 use tari_service_framework::StackBuilder;
 use tokio::runtime::Runtime;
@@ -91,7 +88,6 @@ where
     pub comms: CommsNode,
     pub dht_service: Dht,
     pub store_and_forward_requester: StoreAndForwardRequester,
-    pub liveness_service: LivenessHandle,
     pub output_manager_service: OutputManagerHandle,
     pub transaction_service: TransactionServiceHandle,
     pub contacts_service: ContactsServiceHandle,
@@ -137,15 +133,6 @@ where
 
         let fut = StackBuilder::new(runtime.handle().clone(), comms.shutdown_signal())
             .add_initializer(CommsOutboundServiceInitializer::new(dht.outbound_requester()))
-            .add_initializer(LivenessInitializer::new(
-                LivenessConfig {
-                    auto_ping_interval: Some(Duration::from_secs(30)),
-                    useragent: format!("tari/wallet/{}", env!("CARGO_PKG_VERSION")),
-                    ..Default::default()
-                },
-                Arc::clone(&subscription_factory),
-                dht.dht_requester(),
-            ))
             .add_initializer(OutputManagerServiceInitializer::new(
                 OutputManagerServiceConfig::default(),
                 subscription_factory.clone(),
@@ -154,7 +141,7 @@ where
             ))
             .add_initializer(TransactionServiceInitializer::new(
                 config.transaction_service_config.unwrap_or_default(),
-                subscription_factory.clone(),
+                subscription_factory,
                 transaction_backend,
                 comms.node_identity(),
                 factories.clone(),
@@ -170,9 +157,6 @@ where
         let mut transaction_service_handle = handles
             .get_handle::<TransactionServiceHandle>()
             .expect("Could not get Transaction Service Handle");
-        let liveness_handle = handles
-            .get_handle::<LivenessHandle>()
-            .expect("Could not get Liveness Service Handle");
         let contacts_handle = handles
             .get_handle::<ContactsServiceHandle>()
             .expect("Could not get Contacts Service Handle");
@@ -188,7 +172,6 @@ where
             comms,
             dht_service: dht,
             store_and_forward_requester,
-            liveness_service: liveness_handle,
             output_manager_service: output_manager_handle,
             transaction_service: transaction_service_handle,
             contacts_service: contacts_handle,

--- a/base_layer/wallet_ffi/wallet.h
+++ b/base_layer/wallet_ffi/wallet.h
@@ -432,6 +432,12 @@ unsigned long long wallet_import_utxo(struct TariWallet *wallet, unsigned long l
 // This function will tell the wallet to query the set base node to confirm the status of wallet data.
 unsigned long long wallet_sync_with_base_node(struct TariWallet *wallet, int* error_out);
 
+// Set the power mode of the wallet to Low Power mode which will reduce the amount of network operations the wallet performs to conserve power
+void wallet_set_low_power_mode(struct TariWallet *wallet, int* error_out);
+
+// Set the power mode of the wallet to Normal Power mode which will then use the standard level of network traffic
+void wallet_set_normal_power_mode(struct TariWallet *wallet, int* error_out);
+
 // Simulates the completion of a broadcasted TariPendingInboundTransaction
 bool wallet_test_broadcast_transaction(struct TariWallet *wallet, unsigned long long tx, int* error_out);
 


### PR DESCRIPTION
## Description
In order to help reduce battery consumption this PR removes the Liveness service from the Wallet which is no longer required due to updates to the connectivity manager. 

This PR also adds two FFI functions to set Low power and Normal power modes. Currently these modes will change the Timeouts used by the two  base node monitoring protocols to poll the base node from 30 seconds to 5 minutes. The mobile client can switch to the low power mode when the app moves to the background when it doesn’t need to be as responsive and it will generate 10 times less network traffic and thus use less battery.

Closes https://github.com/tari-project/tari/issues/1963

@kukabi

## How Has This Been Tested?
Tests have been updated to exercise the new functions

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [x] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch.
* [x] I ran `cargo-fmt --all` before pushing.
* [ ] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
