### PR TITLE
Use async RwLock for WaitingRequests

### DIFF
--- a/base_layer/core/Cargo.toml
+++ b/base_layer/core/Cargo.toml
@@ -50,7 +50,7 @@ log = "0.4"
 blake2 = "^0.8.0"
 uint = { version = "0.8", default-features = false }
 ttl_cache = "0.5.1"
-tokio = { version="^0.2", features = ["blocking", "time"] }
+tokio = { version="^0.2", features = ["blocking", "time", "sync"] }
 futures = {version = "^0.3.1", features = ["async-await"] }
 lmdb-zero = "0.4.4"
 tower-service = { version="0.3.0-alpha.2" }

--- a/base_layer/core/src/base_node/mod.rs
+++ b/base_layer/core/src/base_node/mod.rs
@@ -56,4 +56,4 @@ pub mod proto;
 #[cfg(any(feature = "base_node", feature = "base_node_proto", feature = "mempool_proto"))]
 mod waiting_requests;
 #[cfg(any(feature = "base_node", feature = "base_node_proto", feature = "mempool_proto"))]
-pub use waiting_requests::{generate_request_key, RequestKey, WaitingRequestError, WaitingRequests};
+pub use waiting_requests::{generate_request_key, RequestKey, WaitingRequests};

--- a/base_layer/core/src/base_node/service/error.rs
+++ b/base_layer/core/src/base_node/service/error.rs
@@ -20,7 +20,7 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use crate::base_node::{comms_interface::CommsInterfaceError, WaitingRequestError};
+use crate::base_node::comms_interface::CommsInterfaceError;
 use derive_error::Error;
 use tari_comms_dht::outbound::DhtOutboundError;
 
@@ -32,5 +32,4 @@ pub enum BaseNodeServiceError {
     InvalidRequest(String),
     #[error(msg_embedded, no_from, non_std)]
     InvalidResponse(String),
-    WaitingRequestError(WaitingRequestError),
 }

--- a/base_layer/core/src/base_node/service/service.rs
+++ b/base_layer/core/src/base_node/service/service.rs
@@ -428,7 +428,7 @@ async fn handle_incoming_response(
         .and_then(|r| r.try_into().ok())
         .ok_or_else(|| BaseNodeServiceError::InvalidResponse("Received an invalid base node response".to_string()))?;
 
-    if let Some(reply_tx) = waiting_requests.remove(request_key)? {
+    if let Some(reply_tx) = waiting_requests.remove(request_key).await {
         let _ = reply_tx.send(Ok(response).or_else(|resp| {
             warn!(
                 target: LOG_TARGET,
@@ -485,9 +485,7 @@ async fn handle_outbound_request(
         },
         Some(_tags) => {
             // Wait for matching responses to arrive
-            waiting_requests
-                .insert(request_key, Some(reply_tx))
-                .map_err(|_| CommsInterfaceError::UnexpectedApiResponse)?;
+            waiting_requests.insert(request_key, Some(reply_tx)).await;
             // Spawn timeout for waiting_request
             spawn_request_timeout(timeout_sender, request_key, config.request_timeout);
         },
@@ -532,10 +530,7 @@ async fn handle_request_timeout(
     request_key: RequestKey,
 ) -> Result<(), CommsInterfaceError>
 {
-    if let Some(reply_tx) = waiting_requests
-        .remove(request_key)
-        .map_err(|_| CommsInterfaceError::UnexpectedApiResponse)?
-    {
+    if let Some(reply_tx) = waiting_requests.remove(request_key).await {
         let reply_msg = Err(CommsInterfaceError::RequestTimedOut);
         let _ = reply_tx.send(reply_msg.or_else(|resp| {
             error!(

--- a/base_layer/core/src/mempool/service/error.rs
+++ b/base_layer/core/src/mempool/service/error.rs
@@ -20,7 +20,7 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use crate::{base_node::WaitingRequestError, mempool::MempoolError};
+use crate::mempool::MempoolError;
 use derive_error::Error;
 use tari_comms_dht::outbound::DhtOutboundError;
 use tari_service_framework::reply_channel::TransportChannelError;
@@ -41,6 +41,5 @@ pub enum MempoolServiceError {
     TransportChannelError(TransportChannelError),
     /// Failed to send broadcast message
     BroadcastFailed,
-    WaitingRequestError(WaitingRequestError),
     EventStreamError,
 }


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR replaces the rust std `RwLock` with Tokio async `RwLock`
in the `WaitingRequests` struct. This allows Tokio to continue
scheduling tasks on its threads when there is contention on the lock.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Synchronous blocking within an async context is bad

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Existing tests pass

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch.
* [x] I ran `cargo-fmt --all` before pushing.
* [x] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
