### PR TITLE
Checking is_stxo using MMR

### DIFF
--- a/base_layer/core/src/chain_storage/lmdb_db/lmdb.rs
+++ b/base_layer/core/src/chain_storage/lmdb_db/lmdb.rs
@@ -29,7 +29,6 @@ use lmdb_zero::{
     CursorIter,
     Database,
     Environment,
-    Ignore,
     MaybeOwned,
     ReadTransaction,
     WriteTransaction,

--- a/base_layer/core/src/chain_storage/lmdb_db/lmdb_db.rs
+++ b/base_layer/core/src/chain_storage/lmdb_db/lmdb_db.rs
@@ -73,6 +73,7 @@ use tari_mmr::{
     ArrayLike,
     ArrayLikeExt,
     Hash as MmrHash,
+    Hash,
     MerkleCheckPoint,
     MerkleProof,
     MmrCache,
@@ -700,6 +701,14 @@ where D: Digest + Send + Sync
             leaf_nodes.push(self.fetch_mmr_node(tree.clone(), pos)?);
         }
         Ok(leaf_nodes)
+    }
+
+    fn fetch_mmr_leaf_index(&self, tree: MmrTree, hash: &Hash) -> Result<Option<u32>, ChainStorageError> {
+        Ok(match tree {
+            MmrTree::Kernel => self.kernel_mmr.find_leaf_index(hash)?,
+            MmrTree::Utxo => self.utxo_mmr.find_leaf_index(hash)?,
+            MmrTree::RangeProof => self.range_proof_mmr.find_leaf_index(hash)?,
+        })
     }
 
     /// Iterate over all the stored orphan blocks and execute the function `f` for each block.

--- a/base_layer/core/src/chain_storage/memory_db/memory_db.rs
+++ b/base_layer/core/src/chain_storage/memory_db/memory_db.rs
@@ -59,6 +59,7 @@ use tari_mmr::{
     ArrayLike,
     ArrayLikeExt,
     Hash as MmrHash,
+    Hash,
     MerkleCheckPoint,
     MerkleProof,
     MmrCache,
@@ -486,6 +487,15 @@ where D: Digest + Send + Sync
             f(Ok((key.clone(), val.clone())));
         }
         Ok(())
+    }
+
+    fn fetch_mmr_leaf_index(&self, tree: MmrTree, hash: &Hash) -> Result<Option<u32>, ChainStorageError> {
+        let db = self.db_access()?;
+        Ok(match tree {
+            MmrTree::Kernel => db.kernel_mmr.find_leaf_index(hash)?,
+            MmrTree::Utxo => db.utxo_mmr.find_leaf_index(hash)?,
+            MmrTree::RangeProof => db.range_proof_mmr.find_leaf_index(hash)?,
+        })
     }
 
     /// Returns the number of blocks in the block orphan pool.

--- a/base_layer/core/src/helpers/mock_backend.rs
+++ b/base_layer/core/src/helpers/mock_backend.rs
@@ -93,6 +93,10 @@ impl BlockchainBackend for MockBackend {
         unimplemented!()
     }
 
+    fn fetch_mmr_leaf_index(&self, _tree: MmrTree, _hash: &Hash) -> Result<Option<u32>, ChainStorageError> {
+        unimplemented!()
+    }
+
     fn for_each_orphan<F>(&self, _f: F) -> Result<(), ChainStorageError>
     where
         Self: Sized,

--- a/base_layer/mmr/src/backend.rs
+++ b/base_layer/mmr/src/backend.rs
@@ -46,6 +46,9 @@ pub trait ArrayLike {
 
     /// Remove all stored items from the the backend.
     fn clear(&mut self) -> Result<(), Self::Error>;
+
+    /// Finds the index of the specified stored item, it will return None if the object could not be found.
+    fn position(&self, item: &Self::Value) -> Result<Option<usize>, Self::Error>;
 }
 
 pub trait ArrayLikeExt {
@@ -65,7 +68,7 @@ pub trait ArrayLikeExt {
     where F: FnMut(Result<Self::Value, MerkleMountainRangeError>);
 }
 
-impl<T: Clone> ArrayLike for Vec<T> {
+impl<T: Clone + PartialEq> ArrayLike for Vec<T> {
     type Error = MerkleMountainRangeError;
     type Value = T;
 
@@ -93,6 +96,10 @@ impl<T: Clone> ArrayLike for Vec<T> {
     fn clear(&mut self) -> Result<(), Self::Error> {
         Vec::clear(self);
         Ok(())
+    }
+
+    fn position(&self, item: &Self::Value) -> Result<Option<usize>, Self::Error> {
+        Ok(self.iter().position(|stored_item| stored_item == item))
     }
 }
 

--- a/base_layer/mmr/src/common.rs
+++ b/base_layer/mmr/src/common.rs
@@ -36,6 +36,11 @@ pub fn node_index(leaf_index: usize) -> usize {
     2 * leaf_index - leaf_index.count_ones() as usize
 }
 
+/// Returns the leaf index derived from the MMR node index.
+pub fn leaf_index(node_index: usize) -> u32 {
+    n_leaves(node_index) as u32
+}
+
 /// Is this position a leaf in the MMR?
 /// We know the positions of all leaves based on the postorder height of an MMR of any size (somewhat unintuitively
 /// but this is how the PMMR is "append only").

--- a/base_layer/mmr/src/mem_backend_vec.rs
+++ b/base_layer/mmr/src/mem_backend_vec.rs
@@ -43,7 +43,7 @@ impl<T> MemBackendVec<T> {
     }
 }
 
-impl<T: Clone> ArrayLike for MemBackendVec<T> {
+impl<T: Clone + PartialEq> ArrayLike for MemBackendVec<T> {
     type Error = MerkleMountainRangeError;
     type Value = T;
 
@@ -91,9 +91,20 @@ impl<T: Clone> ArrayLike for MemBackendVec<T> {
             .clear();
         Ok(())
     }
+
+    fn position(&self, item: &Self::Value) -> Result<Option<usize>, Self::Error> {
+        for index in 0..self.len()? {
+            if let Some(stored_item) = self.get(index)? {
+                if stored_item == *item {
+                    return Ok(Some(index));
+                }
+            }
+        }
+        Ok(None)
+    }
 }
 
-impl<T: Clone> ArrayLikeExt for MemBackendVec<T> {
+impl<T: Clone + PartialEq> ArrayLikeExt for MemBackendVec<T> {
     type Value = T;
 
     fn truncate(&mut self, len: usize) -> Result<(), MerkleMountainRangeError> {

--- a/base_layer/mmr/src/merkle_checkpoint.rs
+++ b/base_layer/mmr/src/merkle_checkpoint.rs
@@ -27,9 +27,9 @@ use serde::{
     de::{self, Deserialize, Deserializer, MapAccess, SeqAccess, Visitor},
     ser::{Serialize, SerializeStruct, Serializer},
 };
-use std::fmt;
+use std::{fmt, hash::Hasher};
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct MerkleCheckPoint {
     nodes_added: Vec<Hash>,
     nodes_deleted: Bitmap,
@@ -114,6 +114,17 @@ impl MerkleCheckPoint {
     /// Break a checkpoint up into its constituent parts
     pub fn into_parts(self) -> (Vec<Hash>, Bitmap) {
         (self.nodes_added, self.nodes_deleted)
+    }
+}
+
+impl Eq for MerkleCheckPoint {}
+
+#[allow(clippy::derive_hash_xor_eq)]
+impl std::hash::Hash for MerkleCheckPoint {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.nodes_added.hash(state);
+        self.nodes_deleted.to_vec().hash(state);
+        self.prev_accumulated_nodes_added_count.hash(state);
     }
 }
 

--- a/base_layer/mmr/src/mmr_cache.rs
+++ b/base_layer/mmr/src/mmr_cache.rs
@@ -214,6 +214,15 @@ where
         }
         Ok((curr_hash, base_deleted | curr_deleted))
     }
+
+    /// Search for the leaf index of the given hash in the nodes of the current and base MMR.
+    pub fn find_leaf_index(&self, hash: &Hash) -> Result<Option<u32>, MerkleMountainRangeError> {
+        let mut index = self.base_mmr.find_leaf_index(hash)?;
+        if index.is_none() {
+            index = self.curr_mmr.find_leaf_index(hash)?;
+        }
+        Ok(index)
+    }
 }
 
 impl<D, BaseBackend, CpBackend> Deref for MmrCache<D, BaseBackend, CpBackend>

--- a/base_layer/mmr/src/mutable_mmr.rs
+++ b/base_layer/mmr/src/mutable_mmr.rs
@@ -133,7 +133,7 @@ where
     }
 
     /// See [MerkleMountainRange::find_leaf_index]
-    pub fn find_leaf_index(&self, hash: &Hash) -> Result<Option<usize>, MerkleMountainRangeError> {
+    pub fn find_leaf_index(&self, hash: &Hash) -> Result<Option<u32>, MerkleMountainRangeError> {
         self.mmr.find_leaf_index(hash)
     }
 

--- a/base_layer/mmr/src/pruned_hashset.rs
+++ b/base_layer/mmr/src/pruned_hashset.rs
@@ -113,4 +113,15 @@ impl ArrayLike for PrunedHashSet {
         self.hashes.clear();
         Ok(())
     }
+
+    fn position(&self, item: &Self::Value) -> Result<Option<usize>, Self::Error> {
+        for index in 0..self.len()? {
+            if let Some(stored_item) = self.get(index)? {
+                if stored_item == *item {
+                    return Ok(Some(index));
+                }
+            }
+        }
+        Ok(None)
+    }
 }

--- a/base_layer/mmr/tests/merkle_mountain_range.rs
+++ b/base_layer/mmr/tests/merkle_mountain_range.rs
@@ -154,3 +154,27 @@ fn restore_from_leaf_hashes() {
     assert_eq!(mmr.get_leaf_hash(3), Ok(Some(h3)));
     assert_eq!(mmr.get_leaf_hash(4), Ok(None));
 }
+
+#[test]
+fn find_leaf_index() {
+    let mut mmr = MerkleMountainRange::<Hasher, _>::new(Vec::default());
+    let h0 = int_to_hash(0);
+    let h1 = int_to_hash(1);
+    let h2 = int_to_hash(2);
+    let h3 = int_to_hash(3);
+    let h4 = int_to_hash(4);
+    let h5 = int_to_hash(5);
+    assert!(mmr.push(&h0).is_ok());
+    assert!(mmr.push(&h1).is_ok());
+    assert!(mmr.push(&h2).is_ok());
+    assert!(mmr.push(&h3).is_ok());
+    assert!(mmr.push(&h4).is_ok());
+    assert_eq!(mmr.len(), Ok(8));
+
+    assert_eq!(mmr.find_leaf_index(&h0), Ok(Some(0)));
+    assert_eq!(mmr.find_leaf_index(&h1), Ok(Some(1)));
+    assert_eq!(mmr.find_leaf_index(&h2), Ok(Some(2)));
+    assert_eq!(mmr.find_leaf_index(&h3), Ok(Some(3)));
+    assert_eq!(mmr.find_leaf_index(&h4), Ok(Some(4)));
+    assert_eq!(mmr.find_leaf_index(&h5), Ok(None));
+}


### PR DESCRIPTION
## Description
- Modified the blockchain db is_stxo function to rather query the deletion status of the UTXO MMR instead of the blockchain backend stxo_db. This change is required to allow pruned nodes and archival nodes to have the same validation results when checking if new outputs were previous STXOs. The store STXOs of a pruned node is discarded when it enters the horizon state.
- Added fetch_mmr_leaf_index to the blockchain backend trait and provided implementations for the memory and lmdb backends. This function is used to implement the is_stxo logic in blockchain db.
- Finding the leaf index from a hash was a slow operation, this was accelerated by adding a position function to the ArrayLike trait and providing an optimised implementation for the MemDbVec that is used to store the hashes in the MMR. Inefficient versions were added to the other ArrayLike implementations for completeness but these won't be used.
- The MemDbVec was accelerated by making use of two hashmaps to allow quick mapping from index to item and item to index. This will accelerate the fetch_mmr_leaf_index function allowing the is_stxo checks to be performed efficiently.
- The find_leaf_index function of the MerkleMountainRange was updated to make use of the new position function of the ArrayLike trait and find_leaf_index was added to the MmrCache to allow both the current and base Mmr to be checked.

## Motivation and Context
These changes enable consistent validation results between pruned and archival nodes and accelerate the hash to leaf index queries.

## How Has This Been Tested?
- Added the pruned_mode_is_stxo test to check the pruned mode is_stxo functionality and updated the merging_and_fetch_checkpoints_and_stxo_discard test.
- Added the find_leaf_index test to check the MerkleMountainRange changes.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [x] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch.
* [x] I ran `cargo-fmt --all` before pushing.
* [x] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
