### PR TITLE
Input and output previous STXO block validation check

### DIFF
--- a/base_layer/core/src/chain_storage/lmdb_db/lmdb.rs
+++ b/base_layer/core/src/chain_storage/lmdb_db/lmdb.rs
@@ -29,7 +29,6 @@ use lmdb_zero::{
     CursorIter,
     Database,
     Environment,
-    Ignore,
     MaybeOwned,
     ReadTransaction,
     WriteTransaction,

--- a/base_layer/core/src/validation/block_validators.rs
+++ b/base_layer/core/src/validation/block_validators.rs
@@ -27,7 +27,7 @@ use crate::{
         BlockValidationError,
         NewBlockTemplate,
     },
-    chain_storage::{calculate_mmr_roots, is_utxo, BlockchainBackend},
+    chain_storage::{calculate_mmr_roots, is_stxo, is_utxo, BlockchainBackend},
     consensus::{ConsensusConstants, ConsensusManager},
     transactions::{transaction::OutputFlags, types::CryptoFactories},
     validation::{
@@ -108,6 +108,7 @@ impl<B: BlockchainBackend> Validation<Block, B> for FullConsensusValidator {
     /// The consensus checks that are done (in order of cheapest to verify to most expensive):
     /// 1. Does the block satisfy the stateless checks?
     /// 1. Are all inputs currently in the UTXO set?
+    /// 1. Are all inputs and outputs not in the STXO set?
     /// 1. Are the block header MMR roots valid?
     /// 1. Is the block header timestamp less than the ftl?
     /// 1. Is the block header timestamp greater than the median timestamp?
@@ -116,9 +117,10 @@ impl<B: BlockchainBackend> Validation<Block, B> for FullConsensusValidator {
     fn validate(&self, block: &Block, db: &B) -> Result<(), ValidationError> {
         let block_id = format!("block #{} ({})", block.header.height, block.hash().to_hex());
         check_inputs_are_utxos(block, db)?;
+        check_not_stxos(block, db)?;
         trace!(
             target: LOG_TARGET,
-            "Block validation: All inputs are valid for {}",
+            "Block validation: All inputs and outputs are valid for {}",
             &block_id
         );
         check_mmr_roots(block, db)?;
@@ -267,6 +269,30 @@ fn check_inputs_are_utxos<B: BlockchainBackend>(block: &Block, db: &B) -> Result
                 "Block validation failed because the block has invalid input: {}", utxo
             );
             return Err(ValidationError::BlockError(BlockValidationError::InvalidInput));
+        }
+    }
+    Ok(())
+}
+
+// This function checks that the inputs and outputs do not exist in the STxO set.
+fn check_not_stxos<B: BlockchainBackend>(block: &Block, db: &B) -> Result<(), ValidationError> {
+    for input in block.body.inputs() {
+        if is_stxo(db, input.hash()).map_err(|e| ValidationError::CustomError(e.to_string()))? {
+            // we dont want to log this as a node or wallet might retransmit a transaction
+            debug!(
+                target: LOG_TARGET,
+                "Block validation failed due to already spent input: {}", input
+            );
+            return Err(ValidationError::ContainsSTxO);
+        }
+    }
+    for output in block.body.outputs() {
+        if is_stxo(db, output.hash()).map_err(|e| ValidationError::CustomError(e.to_string()))? {
+            debug!(
+                target: LOG_TARGET,
+                "Block validation failed due to previously spent output: {}", output
+            );
+            return Err(ValidationError::ContainsSTxO);
         }
     }
     Ok(())


### PR DESCRIPTION
## Description
Added a full consensus block validation check that ensures that the inputs and outputs are not part of the STXO set. This duplicate hash check should be performed to ensure that when a block is added to the blockchain backend that it does not leave the backend in an inconsistent state.

**I synced my base node from scratch and these changes do not seem to be consensus breaking.**

## Motivation and Context
As key value stores are used in the blockchain backend, adding of duplicate hashes can cause the backend to be in an inconsistent state.

## How Has This Been Tested?
Code similar to transaction validation check, no tests were added.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch.
* [x] I ran `cargo-fmt --all` before pushing.
* [x] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
