### PR TITLE
Added methods to expose current emoji set via FFI

### DIFF
--- a/base_layer/wallet/src/util/emoji.rs
+++ b/base_layer/wallet/src/util/emoji.rs
@@ -77,6 +77,11 @@ lazy_static! {
 #[derive(Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
 pub struct EmojiId(String);
 
+/// Returns the current emoji set as a vector of char
+pub const fn emoji_set() -> [char; 256] {
+    EMOJI
+}
+
 impl EmojiId {
     /// Construct an Emoji ID from the given pubkey.
     pub fn from_pubkey(key: &PublicKey) -> Self {

--- a/base_layer/wallet_ffi/wallet.h
+++ b/base_layer/wallet_ffi/wallet.h
@@ -73,6 +73,8 @@ struct TariTransportType;
 
 struct TariSeedWords;
 
+struct EmojiSet;
+
 /// -------------------------------- Transport Types ----------------------------------------------- ///
 
 // Creates a memory transport type
@@ -464,6 +466,15 @@ void wallet_destroy(struct TariWallet *wallet);
 
 /// This function will log the provided string at debug level. To be used to have a client log messages to the LibWallet
 void log_debug_message(const char* msg);
+
+
+struct EmojiSet *get_emoji_set(void);
+
+void emoji_set_destroy(struct EmojiSet *emoji_set);
+
+struct ByteVector *emoji_set_get_at(struct EmojiSet *emoji_set, unsigned int position, int* error_out);
+
+unsigned int emoji_set_get_length(struct EmojiSet *emoji_set, int* error_out);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
## Description
Added pub fn emoji_set() to emoji.rs.
Added get_emoji_set(), emoji_set_get_length(), emoji_set_get_at() and emoji_set_destroy() to lib.rs.
Updated wallet.h.

## Motivation and Context
Emoji set is currently duplicated in mobile wallets, leading to potential risk that the emoji set used in the wallet does not match the one used by the library.

## How Has This Been Tested?
cargo test --all --all-features

## Types of changes
* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
* [x] I'm merging against the `development` branch.
* [x] I ran `cargo-fmt --all` before pushing.
* [x] I have squashed my commits into a single commit.
* [x] My change requires a change to the documentation.
* [x] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
