### PR TITLE
Implement Display for TorConfig that excludes sensitive data

### DIFF
--- a/base_layer/p2p/src/initialization.rs
+++ b/base_layer/p2p/src/initialization.rs
@@ -232,10 +232,7 @@ where
             configure_comms_and_dht(comms, config, connector, seed_peers).await
         },
         TransportType::Tor(tor_config) => {
-            debug!(
-                target: LOG_TARGET,
-                "Building TOR comms stack with configuration: {:?}", tor_config
-            );
+            debug!(target: LOG_TARGET, "Building TOR comms stack ({})", tor_config);
             let hidden_service = initialize_hidden_service(tor_config.clone()).await?;
             debug!(
                 target: LOG_TARGET,

--- a/base_layer/p2p/src/transport.rs
+++ b/base_layer/p2p/src/transport.rs
@@ -20,6 +20,7 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+use std::fmt;
 use tari_comms::{multiaddr::Multiaddr, socks, tor, transports::SocksConfig};
 
 #[derive(Debug, Clone)]
@@ -57,4 +58,14 @@ pub struct TorConfig {
     pub socks_address_override: Option<Multiaddr>,
     /// Authentication for the Tor SOCKS5 proxy
     pub socks_auth: socks::Authentication,
+}
+
+impl fmt::Display for TorConfig {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "control_server_addr = {}, control_server_auth = {}, {}, socks_address_override = {:?}",
+            self.control_server_addr, self.control_server_auth, self.port_mapping, self.socks_address_override
+        )
+    }
 }

--- a/comms/src/tor/control_client/client.rs
+++ b/comms/src/tor/control_client/client.rs
@@ -36,7 +36,7 @@ use crate::{
 };
 use futures::{channel::mpsc, AsyncRead, AsyncWrite, SinkExt, StreamExt};
 use log::*;
-use std::{borrow::Cow, fmt::Display, num::NonZeroU16};
+use std::{borrow::Cow, fmt, fmt::Display, num::NonZeroU16};
 use tokio::sync::broadcast;
 
 /// Client for the Tor control port.
@@ -257,9 +257,21 @@ pub enum Authentication {
     /// Cookie authentication. The contents of the cookie file encoded as hex
     Cookie(String),
 }
+
 impl Default for Authentication {
     fn default() -> Self {
         Authentication::None
+    }
+}
+
+impl fmt::Display for Authentication {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        use Authentication::*;
+        match self {
+            None => write!(f, "None"),
+            HashedPassword(_) => write!(f, "HashedPassword"),
+            Cookie(_) => write!(f, "Cookie"),
+        }
     }
 }
 


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
- Implement Display for TorConfig that excludes sensitive data from logs
- Implement Display for tor::Authentication to only show the auth mode
  and not the actual credentials

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Credentials should never be displayed
