### PR TITLE
Fix unexpected error with wallet power updates

### DIFF
--- a/base_layer/wallet/src/transaction_service/service.rs
+++ b/base_layer/wallet/src/transaction_service/service.rs
@@ -1228,9 +1228,13 @@ where
             PowerMode::Low => self.config.low_power_polling_timeout,
             PowerMode::Normal => self.config.base_node_monitoring_timeout,
         };
-        self.timeout_update_publisher
-            .send(timeout)
-            .map_err(|_| TransactionServiceError::ProtocolChannelError)?;
+        if let Err(e) = self.timeout_update_publisher.send(timeout) {
+            trace!(
+                target: LOG_TARGET,
+                "Could not send Timeout update, no subscribers to receive. (Err {:?})",
+                e
+            );
+        }
 
         Ok(())
     }

--- a/base_layer/wallet/tests/transaction_service/service.rs
+++ b/base_layer/wallet/tests/transaction_service/service.rs
@@ -1813,6 +1813,9 @@ fn transaction_base_node_monitoring() {
     let (_, _, bob_outbound_service, mut bob_tx_sender, _, _, _, _) =
         setup_transaction_service_no_comms(&mut runtime, factories.clone(), TransactionMemoryDatabase::new(), None);
 
+    runtime.block_on(alice_ts.set_low_power_mode()).unwrap();
+    runtime.block_on(alice_ts.set_normal_power_mode()).unwrap();
+
     let mut alice_total_available = 250000 * uT;
     let (_utxo, uo) = make_input(&mut OsRng, alice_total_available, &factories.commitment);
     runtime.block_on(alice_output_manager.add_output(uo)).unwrap();


### PR DESCRIPTION
## Description
If the power state is updated in the wallet before any Transaction activity occurs there are no subscribers to the broadcast channel which produced an incorrect error.

This PR logs the event but does not send it back across the FFI as an error.

## How Has This Been Tested?
Test updated to test this case.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch.
* [x] I ran `cargo-fmt --all` before pushing.
* [ ] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
