### PR TITLE
Update the Wallet FFI backend to persist the Comms Secret Key

### DIFF
--- a/base_layer/wallet/migrations/2020-06-15-084821_add_wallet_settings/down.sql
+++ b/base_layer/wallet/migrations/2020-06-15-084821_add_wallet_settings/down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS wallet_settings;

--- a/base_layer/wallet/migrations/2020-06-15-084821_add_wallet_settings/up.sql
+++ b/base_layer/wallet/migrations/2020-06-15-084821_add_wallet_settings/up.sql
@@ -1,0 +1,4 @@
+CREATE TABLE wallet_settings (
+    key TEXT PRIMARY KEY NOT NULL,
+    value TEXT NOT NULL
+);

--- a/base_layer/wallet/src/error.rs
+++ b/base_layer/wallet/src/error.rs
@@ -32,6 +32,7 @@ use log::SetLoggerError;
 use serde_json::Error as SerdeJsonError;
 use tari_comms::{connectivity::ConnectivityError, multiaddr, peer_manager::PeerManagerError};
 use tari_comms_dht::store_forward::StoreAndForwardError;
+use tari_crypto::tari_utilities::hex::HexError;
 use tari_p2p::{initialization::CommsInitializationError, services::liveness::error::LivenessError};
 
 #[derive(Debug, Error)]
@@ -75,4 +76,5 @@ pub enum WalletStorageError {
     BlockingTaskSpawnError(String),
     /// The storage path was invalid unicode or not supported by the host OS
     InvalidUnicodePath,
+    HexError(HexError),
 }

--- a/base_layer/wallet/src/schema.rs
+++ b/base_layer/wallet/src/schema.rs
@@ -84,6 +84,13 @@ table! {
     }
 }
 
+table! {
+    wallet_settings (key) {
+        key -> Text,
+        value -> Text,
+    }
+}
+
 allow_tables_to_appear_in_same_query!(
     completed_transactions,
     contacts,
@@ -93,4 +100,5 @@ allow_tables_to_appear_in_same_query!(
     outputs,
     peers,
     pending_transaction_outputs,
+    wallet_settings,
 );

--- a/base_layer/wallet/src/wallet.rs
+++ b/base_layer/wallet/src/wallet.rs
@@ -109,7 +109,7 @@ where
     W: ContactsBackend + 'static,
 {
     pub fn new(
-        mut config: WalletConfig,
+        config: WalletConfig,
         mut runtime: Runtime,
         wallet_backend: T,
         transaction_backend: U,
@@ -127,8 +127,6 @@ where
         let (publisher, subscription_factory) = pubsub_connector(runtime.handle().clone(), 100);
         let subscription_factory = Arc::new(subscription_factory);
 
-        // Wallet should join the network
-        config.comms_config.dht.auto_join = true;
         let (comms, dht) = runtime.block_on(initialize_comms(config.comms_config.clone(), publisher, vec![]))?;
 
         let fut = StackBuilder::new(runtime.handle().clone(), comms.shutdown_signal())

--- a/base_layer/wallet_ffi/wallet.h
+++ b/base_layer/wallet_ffi/wallet.h
@@ -337,9 +337,12 @@ struct TariCommsConfig *comms_config_create(const char *public_address,
                                      struct TariTransportType *transport,
                                      const char *database_name,
                                      const char *datastore_path,
-                                     struct TariPrivateKey *secret_key,
                                      unsigned long long discovery_timeout_in_secs,
                                      int* error_out);
+
+// Set the Comms Secret Key for an existing TariCommsConfig. Usually this key is maintained by the backend but if it is required to set a specific
+// new one this function can be used.
+void comms_config_set_secret_key(struct TariCommsConfig *comms_config, struct TariPrivateKey *secret_key, int* error_out);
 
 // Frees memory for a TariCommsConfig
 void comms_config_destroy(struct TariCommsConfig *wc);


### PR DESCRIPTION
## Description
Previously the frontend client of the Wallet FFI library was responsible for persisting the Comms Secret Key. This made backing up and restoring the wallet tricky and as such it was decided that this private key should be persisted in the backend sqlite db.

This PR updates wallet backend DB with a new table called `wallet_settings` which will be a key-value store of wallet settings. The FFI function `comms_config_create(…)` to first check the wallet backend to see if a Comms Private Key is stored. If it is then it is used else a new one is generated.  The `wallet_create(…)` function will write whatever Comms Private Key is provided to it to the db for persistence.

In order to facilitate the migration to this new setup a new function is added to the FFI, `comms_config_set_secret_key(…)` which allows the frontend to specify the Comms Secret Key used. When migrating the Comms Config will be created. This will generate a new key because none will be found in the backend and then the frontend persisted Secret key will be set using the `comms_config_set_secret_key(…)` function and there after the backend will persist this secret key.

Tagging @kukabi and @Jasonvdm to note the required migration to happen in the frontends.

## Motivation and Context
Closes https://github.com/tari-project/tari/issues/1979

## How Has This Been Tested?
Test was added to exercise the updates to the `comms_config_create`, `comms_config_set_secret_key` and 'wallet_create' functions.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [x] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch.
* [x] I ran `cargo-fmt --all` before pushing.
* [ ] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
