### PR TITLE
Add ConfigWriter trait to generate toml configs

### DIFF
--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -29,3 +29,4 @@ tempdir = "0.3.7"
 tari_test_utils = { version = "^0.0", path = "../infrastructure/test_utils"}
 serde = { version = "1.0.106", features = ["derive"] }
 anyhow = "1.0"
+toml = "0.5"

--- a/common/src/configuration/loader.rs
+++ b/common/src/configuration/loader.rs
@@ -149,6 +149,11 @@ pub trait ConfigPath {
 pub trait NetworkConfigPath {
     /// Main configuration section
     fn main_key_prefix() -> &'static str;
+    /// Path for `use_network` key in config
+    fn network_config_key() -> String {
+        let main = <Self as NetworkConfigPath>::main_key_prefix();
+        format!("{}.use_network", main)
+    }
 }
 impl<C: NetworkConfigPath> ConfigPath for C {
     fn main_key_prefix() -> &'static str {
@@ -156,12 +161,11 @@ impl<C: NetworkConfigPath> ConfigPath for C {
     }
 
     fn overload_key_prefix(config: &Config) -> Result<Option<String>, ConfigurationError> {
-        let main = <Self as NetworkConfigPath>::main_key_prefix();
-        let network_key = format!("{}.use_network", main);
+        let network_key = Self::network_config_key();
         let network_val: Option<String> = config.get_str(network_key.as_str()).ok();
         if let Some(s) = network_val {
             let network: Network = s.parse()?;
-            Ok(Some(format!("{}.{}", main, network)))
+            Ok(Some(format!("{}.{}", Self::main_key_prefix(), network)))
         } else {
             Ok(None)
         }

--- a/common/src/configuration/mod.rs
+++ b/common/src/configuration/mod.rs
@@ -39,6 +39,7 @@ pub mod error;
 pub mod global;
 pub mod loader;
 pub mod utils;
+pub mod writer;
 
 pub use bootstrap::ConfigBootstrap;
 pub use global::{CommsTransport, DatabaseType, GlobalConfig, Network, SocksAuthentication, TorControlAuthentication};

--- a/common/src/configuration/writer.rs
+++ b/common/src/configuration/writer.rs
@@ -1,0 +1,87 @@
+//! Configuration writer based on ConfigPath selectors.
+//!
+//! ## Example
+//! ```
+//! use config::Config;
+//! use serde::{Deserialize, Serialize};
+//! use tari_common::{
+//!     configuration::writer::ConfigWriter,
+//!     ConfigLoader,
+//!     ConfigPath,
+//!     ConfigurationError,
+//!     NetworkConfigPath,
+//! };
+//! use toml::value::Value;
+//!
+//! #[derive(Serialize, Deserialize)]
+//! struct MainConfig {
+//!     name: String,
+//! }
+//! impl ConfigPath for MainConfig {
+//!     fn main_key_prefix() -> &'static str {
+//!         "main"
+//!     }
+//!
+//!     fn overload_key_prefix(config: &Config) -> Result<Option<String>, ConfigurationError> {
+//!         Ok(None)
+//!     }
+//! }
+//! #[derive(Serialize, Deserialize)]
+//! struct MyNodeConfig {
+//!     port: u16,
+//!     address: String,
+//! }
+//! impl NetworkConfigPath for MyNodeConfig {
+//!     fn main_key_prefix() -> &'static str {
+//!         "my_node"
+//!     }
+//! }
+//! let main_config = MainConfig {
+//!     name: "test_server".to_string(),
+//! };
+//! let node_config = MyNodeConfig {
+//!     port: 3001,
+//!     address: "localhost".to_string(),
+//! };
+//! // Merging configs into resulting structure, accounting preset use_network params
+//! let mut config = Config::new();
+//! config.set(&MyNodeConfig::network_config_key(), "rincewind");
+//! main_config.merge_into(&mut config).unwrap();
+//! node_config.merge_into(&mut config).unwrap();
+//!
+//! let toml_value: Value = config.try_into().unwrap();
+//! let res = toml::to_string(&toml_value).unwrap();
+//! assert_eq!(
+//!     res,
+//!     r#"[main]
+//! name = "test_server"
+//!
+//! [my_node]
+//! use_network = "rincewind"
+//!
+//! [my_node.rincewind]
+//! address = "localhost"
+//! port = 3001
+//! "#
+//! );
+//! ```
+use super::{loader::ConfigPath, ConfigurationError};
+use config::Config;
+
+/// Configuration writer based on ConfigPath selectors
+///
+/// It is autoimplemented for types implementing [`ConfigPath`] and [`serde::ser::Serialize`]
+/// Refer to [module](crate::configuration::writer) documentation for example
+pub trait ConfigWriter: ConfigPath + serde::ser::Serialize {
+    /// Merges structure into configuration by `main_key_prefix()`
+    /// with values overloaded from `overload_key_prefix()`.
+    fn merge_into(&self, config: &mut Config) -> Result<(), ConfigurationError> {
+        use serde::de::Deserialize;
+        let overload = Self::overload_key_prefix(&config)?;
+        let key = overload.as_deref().unwrap_or(Self::main_key_prefix());
+        let value = config::Value::deserialize(serde_json::to_value(self)?)?;
+        config.set(key, value)?;
+        Ok(())
+    }
+}
+impl<C> ConfigWriter for C where C: ConfigPath + serde::ser::Serialize {}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
`ConfigWriter` provides `merge_into` method which  based on paths and network parameters already defined in supplied config would serialize and merge current structure by relevant path. Trait is autoimplemented for `ConfigPath` and `NetworkConfigPath` implementations which also implementing `Serialize`.

There was slight not breaking change to NetworkConfigPath trait `.network_config_key()` would provide guidance where `use_network` key is expected by the struct.

## Motivation and Context
This would be helpful to reconstruct tari toml config from config builder
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Added doc with doc test
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [X] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [X] New Tests
* [X] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [X] I'm merging against the `development` branch.
* [X] I ran `cargo-fmt --all` before pushing.
* [X] I have squashed my commits into a single commit.
* [X] My change requires a change to the documentation.
* [X] I have updated the documentation accordingly.
* [X] I have added tests to cover my changes.
