### PR TITLE
Minor core code cleanup and improved logging

### DIFF
--- a/base_layer/core/src/base_node/comms_interface/inbound_handlers.rs
+++ b/base_layer/core/src/base_node/comms_interface/inbound_handlers.rs
@@ -316,11 +316,12 @@ where T: BlockchainBackend + 'static
     ) -> Result<(), CommsInterfaceError>
     {
         let (block, broadcast) = block_context;
+        let block_hash = block.hash();
         debug!(
             target: LOG_TARGET,
             "Block #{} ({}) received from {}",
             block.header.height,
-            block.hash().to_hex(),
+            block_hash.to_hex(),
             source_peer
                 .as_ref()
                 .map(|p| format!("remote peer: {}", p))
@@ -336,7 +337,13 @@ where T: BlockchainBackend + 'static
                 BlockEvent::Verified((Box::new(block.clone()), block_add_result, *broadcast))
             },
             Err(e) => {
-                warn!(target: LOG_TARGET, "Block validation failed: {:?}", e);
+                warn!(
+                    target: LOG_TARGET,
+                    "Block #{} ({}) validation failed: {:?}",
+                    block.header.height,
+                    block_hash.to_hex(),
+                    e
+                );
                 result = Err(CommsInterfaceError::ChainStorageError(e.clone()));
                 BlockEvent::Invalid((Box::new(block.clone()), e, *broadcast))
             },

--- a/base_layer/core/src/blocks/block.rs
+++ b/base_layer/core/src/blocks/block.rs
@@ -113,7 +113,8 @@ impl Block {
         if coinbase_counter != 1 {
             warn!(
                 target: LOG_TARGET,
-                "More then one coinbase found in block {}",
+                "{} coinbases found in block {}. Only a single coinbase is permitted.",
+                coinbase_counter,
                 self.hash().to_hex()
             );
             return Err(BlockValidationError::InvalidCoinbase);

--- a/base_layer/core/src/chain_storage/db_transaction.rs
+++ b/base_layer/core/src/chain_storage/db_transaction.rs
@@ -77,9 +77,9 @@ impl DbTransaction {
     }
 
     /// Inserts a transaction kernel into the current transaction.
-    pub fn insert_kernel(&mut self, kernel: TransactionKernel, update_mmr: bool) {
+    pub fn insert_kernel(&mut self, kernel: TransactionKernel) {
         let hash = kernel.hash();
-        self.insert(DbKeyValuePair::TransactionKernel(hash, Box::new(kernel), update_mmr));
+        self.insert(DbKeyValuePair::TransactionKernel(hash, Box::new(kernel)));
     }
 
     /// Inserts a block header into the current transaction.
@@ -89,15 +89,15 @@ impl DbTransaction {
     }
 
     /// Adds a UTXO into the current transaction and update the TXO MMR.
-    pub fn insert_utxo(&mut self, utxo: TransactionOutput, update_mmr: bool) {
+    pub fn insert_utxo(&mut self, utxo: TransactionOutput) {
         let hash = utxo.hash();
-        self.insert(DbKeyValuePair::UnspentOutput(hash, Box::new(utxo), update_mmr));
+        self.insert(DbKeyValuePair::UnspentOutput(hash, Box::new(utxo)));
     }
 
     /// Adds a UTXO into the current transaction and update the TXO MMR. This is a test only function used to ensure we
     /// block duplicate entries. This function does not calculate the hash function but accepts one as a variable.
-    pub fn insert_utxo_with_hash(&mut self, hash: Vec<u8>, utxo: TransactionOutput, update_mmr: bool) {
-        self.insert(DbKeyValuePair::UnspentOutput(hash, Box::new(utxo), update_mmr));
+    pub fn insert_utxo_with_hash(&mut self, hash: Vec<u8>, utxo: TransactionOutput) {
+        self.insert(DbKeyValuePair::UnspentOutput(hash, Box::new(utxo)));
     }
 
     /// Stores an orphan block. No checks are made as to whether this is actually an orphan. That responsibility lies
@@ -198,8 +198,8 @@ pub enum WriteOperation {
 pub enum DbKeyValuePair {
     Metadata(MetadataKey, MetadataValue),
     BlockHeader(u64, Box<BlockHeader>),
-    UnspentOutput(HashOutput, Box<TransactionOutput>, bool),
-    TransactionKernel(HashOutput, Box<TransactionKernel>, bool),
+    UnspentOutput(HashOutput, Box<TransactionOutput>),
+    TransactionKernel(HashOutput, Box<TransactionKernel>),
     OrphanBlock(HashOutput, Box<Block>),
 }
 

--- a/base_layer/core/src/validation/accum_difficulty_validators.rs
+++ b/base_layer/core/src/validation/accum_difficulty_validators.rs
@@ -47,7 +47,7 @@ impl<B: BlockchainBackend> Validation<Difficulty, B> for AccumDifficultyValidato
 /// stronger than the chain tip. This will simplify testing where small testing blockchains need to be constructed as
 /// the accumulated difficulty of preceding blocks don't have to have an increasing accumulated difficulty.
 #[derive(Clone)]
-pub struct MockAccumDifficultyValidator {}
+pub struct MockAccumDifficultyValidator;
 
 impl<B: BlockchainBackend> Validation<Difficulty, B> for MockAccumDifficultyValidator {
     fn validate(&self, accum_difficulty: &Difficulty, db: &B) -> Result<(), ValidationError> {

--- a/base_layer/core/src/validation/error.rs
+++ b/base_layer/core/src/validation/error.rs
@@ -49,3 +49,9 @@ pub enum ValidationError {
     // The recorded chain accumulated difficulty was stronger
     WeakerAccumulatedDifficulty,
 }
+
+impl ValidationError {
+    pub fn custom_error<T: ToString>(err: T) -> Self {
+        ValidationError::CustomError(err.to_string())
+    }
+}

--- a/base_layer/core/tests/block_validation.rs
+++ b/base_layer/core/tests/block_validation.rs
@@ -21,7 +21,7 @@
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 use tari_core::{
-    chain_storage::{BlockchainDatabase, BlockchainDatabaseConfig, MemoryDatabase, Validators},
+    chain_storage::{BlockAddResult, BlockchainDatabase, BlockchainDatabaseConfig, MemoryDatabase, Validators},
     consensus::{ConsensusManagerBuilder, Network},
     transactions::types::{CryptoFactories, HashDigest},
     validation::{
@@ -43,6 +43,6 @@ fn test_genesis_block() {
     );
     let db = BlockchainDatabase::new(backend, &rules, validators, BlockchainDatabaseConfig::default()).unwrap();
     let block = rules.get_genesis_block();
-    let result = db.add_block(block);
-    assert!(result.is_ok());
+    let result = db.add_block(block).unwrap();
+    assert_eq!(result, BlockAddResult::BlockExists);
 }

--- a/base_layer/core/tests/chain_storage_tests/chain_backend.rs
+++ b/base_layer/core/tests/chain_storage_tests/chain_backend.rs
@@ -110,7 +110,7 @@ fn insert_contains_delete_and_fetch_utxo<T: BlockchainBackend>(mut db: T) {
     assert_eq!(db.contains(&DbKey::UnspentOutput(hash.clone())), Ok(false));
 
     let mut txn = DbTransaction::new();
-    txn.insert_utxo(utxo.clone(), true);
+    txn.insert_utxo(utxo.clone());
     assert!(db.write(txn).is_ok());
     assert_eq!(db.contains(&DbKey::UnspentOutput(hash.clone())), Ok(true));
     if let Some(DbValue::UnspentOutput(retrieved_utxo)) = db.fetch(&DbKey::UnspentOutput(hash.clone())).unwrap() {
@@ -154,7 +154,7 @@ fn insert_contains_delete_and_fetch_kernel<T: BlockchainBackend>(mut db: T) {
     assert_eq!(db.contains(&DbKey::TransactionKernel(hash.clone())), Ok(false));
 
     let mut txn = DbTransaction::new();
-    txn.insert_kernel(kernel.clone(), true);
+    txn.insert_kernel(kernel.clone());
     assert!(db.write(txn).is_ok());
     assert_eq!(db.contains(&DbKey::TransactionKernel(hash.clone())), Ok(true));
     if let Some(DbValue::TransactionKernel(retrieved_kernel)) =
@@ -255,8 +255,8 @@ fn spend_utxo_and_unspend_stxo<T: BlockchainBackend>(mut db: T) {
     let hash2 = utxo2.hash();
 
     let mut txn = DbTransaction::new();
-    txn.insert_utxo(utxo1.clone(), true);
-    txn.insert_utxo(utxo2.clone(), true);
+    txn.insert_utxo(utxo1.clone());
+    txn.insert_utxo(utxo2.clone());
     assert!(db.write(txn).is_ok());
 
     let mut txn = DbTransaction::new();
@@ -432,9 +432,9 @@ fn fetch_mmr_root_and_proof_for_utxo_and_rp<T: BlockchainBackend>(mut db: T) {
     let rp_hash3 = utxo3.proof.hash();
 
     let mut txn = DbTransaction::new();
-    txn.insert_utxo(utxo1.clone(), true);
-    txn.insert_utxo(utxo2.clone(), true);
-    txn.insert_utxo(utxo3.clone(), true);
+    txn.insert_utxo(utxo1.clone());
+    txn.insert_utxo(utxo2.clone());
+    txn.insert_utxo(utxo3.clone());
     assert!(db.write(txn).is_ok());
 
     let mut utxo_mmr_check = MutableMmr::<HashDigest, _>::new(Vec::new(), Bitmap::create());
@@ -510,9 +510,9 @@ fn fetch_mmr_root_and_proof_for_kernel<T: BlockchainBackend>(mut db: T) {
     let hash3 = kernel3.hash();
 
     let mut txn = DbTransaction::new();
-    txn.insert_kernel(kernel1, true);
-    txn.insert_kernel(kernel2, true);
-    txn.insert_kernel(kernel3, true);
+    txn.insert_kernel(kernel1);
+    txn.insert_kernel(kernel2);
+    txn.insert_kernel(kernel3);
     assert!(db.write(txn).is_ok());
 
     let mut kernel_mmr_check = MutableMmr::<HashDigest, _>::new(Vec::new(), Bitmap::create());
@@ -570,8 +570,8 @@ fn fetch_future_mmr_root_for_utxo_and_rp<T: BlockchainBackend>(mut db: T) {
     let rp_hash4 = utxo4.proof.hash();
 
     let mut txn = DbTransaction::new();
-    txn.insert_utxo(utxo1, true);
-    txn.insert_utxo(utxo2, true);
+    txn.insert_utxo(utxo1);
+    txn.insert_utxo(utxo2);
     assert!(db.write(txn).is_ok());
 
     let utxo_future_root = db
@@ -586,8 +586,8 @@ fn fetch_future_mmr_root_for_utxo_and_rp<T: BlockchainBackend>(mut db: T) {
     assert_ne!(rp_future_root, db.fetch_mmr_root(MmrTree::RangeProof).unwrap().to_hex());
 
     let mut txn = DbTransaction::new();
-    txn.insert_utxo(utxo3, true);
-    txn.insert_utxo(utxo4, true);
+    txn.insert_utxo(utxo3);
+    txn.insert_utxo(utxo4);
     txn.spend_utxo(utxo_hash1);
     assert!(db.write(txn).is_ok());
 
@@ -627,8 +627,8 @@ fn fetch_future_mmr_root_for_for_kernel<T: BlockchainBackend>(mut db: T) {
     let hash4 = kernel4.hash();
 
     let mut txn = DbTransaction::new();
-    txn.insert_kernel(kernel1, true);
-    txn.insert_kernel(kernel2, true);
+    txn.insert_kernel(kernel1);
+    txn.insert_kernel(kernel2);
     assert!(db.write(txn).is_ok());
 
     let future_root = db
@@ -638,8 +638,8 @@ fn fetch_future_mmr_root_for_for_kernel<T: BlockchainBackend>(mut db: T) {
     assert_ne!(future_root, db.fetch_mmr_root(MmrTree::Kernel).unwrap().to_hex());
 
     let mut txn = DbTransaction::new();
-    txn.insert_kernel(kernel3, true);
-    txn.insert_kernel(kernel4, true);
+    txn.insert_kernel(kernel3);
+    txn.insert_kernel(kernel4);
     assert!(db.write(txn).is_ok());
 
     assert_eq!(future_root, db.fetch_mmr_root(MmrTree::Kernel).unwrap().to_hex());
@@ -678,8 +678,8 @@ fn commit_block_and_create_fetch_checkpoint_and_rewind_mmr<T: BlockchainBackend>
     let rp_hash1 = utxo1.proof.hash();
 
     let mut txn = DbTransaction::new();
-    txn.insert_utxo(utxo1, true);
-    txn.insert_kernel(kernel1, true);
+    txn.insert_utxo(utxo1);
+    txn.insert_kernel(kernel1);
     txn.insert_header(header1.clone());
     txn.commit_block();
     assert!(db.write(txn).is_ok());
@@ -692,9 +692,9 @@ fn commit_block_and_create_fetch_checkpoint_and_rewind_mmr<T: BlockchainBackend>
     let rp_hash2 = utxo2.proof.hash();
 
     let mut txn = DbTransaction::new();
-    txn.insert_utxo(utxo2, true);
+    txn.insert_utxo(utxo2);
     txn.spend_utxo(utxo_hash1.clone());
-    txn.insert_kernel(kernel2, true);
+    txn.insert_kernel(kernel2);
     txn.insert_header(header2);
     txn.commit_block();
     assert!(db.write(txn).is_ok());
@@ -863,9 +863,9 @@ fn for_each_kernel<T: BlockchainBackend>(mut db: T) {
     let hash3 = kernel3.hash();
 
     let mut txn = DbTransaction::new();
-    txn.insert_kernel(kernel1.clone(), false);
-    txn.insert_kernel(kernel2.clone(), false);
-    txn.insert_kernel(kernel3.clone(), false);
+    txn.insert_kernel(kernel1.clone());
+    txn.insert_kernel(kernel2.clone());
+    txn.insert_kernel(kernel3.clone());
     assert!(db.write(txn).is_ok());
     assert_eq!(db.contains(&DbKey::TransactionKernel(hash1.clone())), Ok(true));
     assert_eq!(db.contains(&DbKey::TransactionKernel(hash2.clone())), Ok(true));
@@ -980,9 +980,9 @@ fn for_each_utxo<T: BlockchainBackend>(mut db: T) {
     let hash3 = utxo3.hash();
 
     let mut txn = DbTransaction::new();
-    txn.insert_utxo(utxo1.clone(), true);
-    txn.insert_utxo(utxo2.clone(), true);
-    txn.insert_utxo(utxo3.clone(), true);
+    txn.insert_utxo(utxo1.clone());
+    txn.insert_utxo(utxo2.clone());
+    txn.insert_utxo(utxo3.clone());
     assert!(db.write(txn).is_ok());
     assert_eq!(db.contains(&DbKey::UnspentOutput(hash1.clone())), Ok(true));
     assert_eq!(db.contains(&DbKey::UnspentOutput(hash2.clone())), Ok(true));
@@ -1055,9 +1055,9 @@ fn lmdb_backend_restore() {
             let mut db = create_lmdb_database(&path, MmrCacheConfig::default()).unwrap();
             let mut txn = DbTransaction::new();
             txn.insert_orphan(orphan.clone());
-            txn.insert_utxo(utxo1, true);
-            txn.insert_utxo(utxo2, true);
-            txn.insert_kernel(kernel, true);
+            txn.insert_utxo(utxo1);
+            txn.insert_utxo(utxo2);
+            txn.insert_kernel(kernel);
             txn.insert_header(header.clone());
             txn.commit_block();
             db.write(txn).unwrap();
@@ -1112,8 +1112,8 @@ fn lmdb_mmr_reset_and_commit() {
         let header_hash1 = header1.hash();
 
         let mut txn = DbTransaction::new();
-        txn.insert_utxo(utxo1, true);
-        txn.insert_kernel(kernel1, true);
+        txn.insert_utxo(utxo1);
+        txn.insert_kernel(kernel1);
         txn.insert_header(header1);
         txn.commit_block();
         assert!(db.write(txn).is_ok());
@@ -1196,8 +1196,8 @@ fn fetch_checkpoint<T: BlockchainBackend>(mut db: T) {
     let rp_hash1 = utxo1.proof.hash();
 
     let mut txn = DbTransaction::new();
-    txn.insert_utxo(utxo1, true);
-    txn.insert_kernel(kernel1, true);
+    txn.insert_utxo(utxo1);
+    txn.insert_kernel(kernel1);
     txn.insert_header(header1.clone());
     txn.commit_block();
     assert!(db.write(txn).is_ok());
@@ -1210,8 +1210,8 @@ fn fetch_checkpoint<T: BlockchainBackend>(mut db: T) {
     let rp_hash2 = utxo2.proof.hash();
 
     let mut txn = DbTransaction::new();
-    txn.insert_utxo(utxo2, true);
-    txn.insert_kernel(kernel2, true);
+    txn.insert_utxo(utxo2);
+    txn.insert_kernel(kernel2);
     txn.insert_header(header2.clone());
     txn.commit_block();
     assert!(db.write(txn).is_ok());
@@ -1243,10 +1243,10 @@ fn fetch_checkpoint<T: BlockchainBackend>(mut db: T) {
     let rp_hash4 = utxo4.proof.hash();
 
     let mut txn = DbTransaction::new();
-    txn.insert_utxo(utxo3, true);
-    txn.insert_utxo(utxo4, true);
-    txn.insert_kernel(kernel3, true);
-    txn.insert_kernel(kernel4, true);
+    txn.insert_utxo(utxo3);
+    txn.insert_utxo(utxo4);
+    txn.insert_kernel(kernel3);
+    txn.insert_kernel(kernel4);
     txn.insert_header(header3);
     txn.commit_block();
     assert!(db.write(txn).is_ok());
@@ -1331,23 +1331,23 @@ fn merging_and_fetch_checkpoints_and_stxo_discard<T: BlockchainBackend>(mut db: 
     let rp_hash3 = utxo3.proof.hash();
 
     let mut txn = DbTransaction::new();
-    txn.insert_utxo(utxo1, true);
-    txn.insert_kernel(kernel1, true);
+    txn.insert_utxo(utxo1);
+    txn.insert_kernel(kernel1);
     txn.insert_header(header1.clone());
     txn.commit_block();
     assert!(db.write(txn).is_ok());
 
     let mut txn = DbTransaction::new();
-    txn.insert_utxo(utxo2, true);
-    txn.insert_kernel(kernel2, true);
+    txn.insert_utxo(utxo2);
+    txn.insert_kernel(kernel2);
     txn.insert_header(header2.clone());
     txn.spend_utxo(utxo_hash1.clone());
     txn.commit_block();
     assert!(db.write(txn).is_ok());
 
     let mut txn = DbTransaction::new();
-    txn.insert_utxo(utxo3, true);
-    txn.insert_kernel(kernel3, true);
+    txn.insert_utxo(utxo3);
+    txn.insert_kernel(kernel3);
     txn.insert_header(header3.clone());
     txn.spend_utxo(utxo_hash2.clone());
     txn.commit_block();
@@ -1462,7 +1462,7 @@ fn duplicate_utxo<T: BlockchainBackend>(mut db: T) {
     let hash1 = utxo1.hash();
 
     let mut txn = DbTransaction::new();
-    txn.insert_utxo_with_hash(hash1.clone(), utxo1.clone(), true);
+    txn.insert_utxo_with_hash(hash1.clone(), utxo1.clone());
     assert!(db.write(txn).is_ok());
     assert_eq!(db.contains(&DbKey::UnspentOutput(hash1.clone())), Ok(true));
     if let Some(DbValue::UnspentOutput(retrieved_utxo)) = db.fetch(&DbKey::UnspentOutput(hash1.clone())).unwrap() {
@@ -1471,7 +1471,7 @@ fn duplicate_utxo<T: BlockchainBackend>(mut db: T) {
         assert!(false);
     }
     let mut txn = DbTransaction::new();
-    txn.insert_utxo_with_hash(hash1.clone(), utxo2.clone(), true);
+    txn.insert_utxo_with_hash(hash1.clone(), utxo2.clone());
     assert!(db.write(txn).is_err()); // This should fail
     if let Some(DbValue::UnspentOutput(retrieved_utxo)) = db.fetch(&DbKey::UnspentOutput(hash1.clone())).unwrap() {
         assert_eq!(*retrieved_utxo, utxo1); // original data should still be there
@@ -1676,29 +1676,29 @@ fn fetch_utxo_rp_mmr_nodes_and_count<T: BlockchainBackend>(mut db: T) {
     ];
 
     let mut txn = DbTransaction::new();
-    txn.insert_utxo(utxo1, true);
+    txn.insert_utxo(utxo1);
     txn.operations.push(WriteOperation::CreateMmrCheckpoint(MmrTree::Utxo));
     txn.operations
         .push(WriteOperation::CreateMmrCheckpoint(MmrTree::RangeProof));
     assert!(db.write(txn).is_ok());
     let mut txn = DbTransaction::new();
-    txn.insert_utxo(utxo2, true);
-    txn.insert_utxo(utxo3, true);
+    txn.insert_utxo(utxo2);
+    txn.insert_utxo(utxo3);
     txn.spend_utxo(utxo_hash1.clone());
     txn.operations.push(WriteOperation::CreateMmrCheckpoint(MmrTree::Utxo));
     txn.operations
         .push(WriteOperation::CreateMmrCheckpoint(MmrTree::RangeProof));
     assert!(db.write(txn).is_ok());
     let mut txn = DbTransaction::new();
-    txn.insert_utxo(utxo4, true);
-    txn.insert_utxo(utxo5, true);
+    txn.insert_utxo(utxo4);
+    txn.insert_utxo(utxo5);
     txn.spend_utxo(utxo_hash3.clone());
     txn.operations.push(WriteOperation::CreateMmrCheckpoint(MmrTree::Utxo));
     txn.operations
         .push(WriteOperation::CreateMmrCheckpoint(MmrTree::RangeProof));
     assert!(db.write(txn).is_ok());
     let mut txn = DbTransaction::new();
-    txn.insert_utxo(utxo6, true);
+    txn.insert_utxo(utxo6);
     txn.spend_utxo(utxo_hash4.clone());
     txn.operations.push(WriteOperation::CreateMmrCheckpoint(MmrTree::Utxo));
     txn.operations
@@ -1769,24 +1769,24 @@ fn fetch_kernel_mmr_nodes_and_count<T: BlockchainBackend>(mut db: T) {
     ];
 
     let mut txn = DbTransaction::new();
-    txn.insert_kernel(kernel1, true);
+    txn.insert_kernel(kernel1);
     txn.operations
         .push(WriteOperation::CreateMmrCheckpoint(MmrTree::Kernel));
     assert!(db.write(txn).is_ok());
     let mut txn = DbTransaction::new();
-    txn.insert_kernel(kernel2, true);
-    txn.insert_kernel(kernel3, true);
+    txn.insert_kernel(kernel2);
+    txn.insert_kernel(kernel3);
     txn.operations
         .push(WriteOperation::CreateMmrCheckpoint(MmrTree::Kernel));
     assert!(db.write(txn).is_ok());
     let mut txn = DbTransaction::new();
-    txn.insert_kernel(kernel4, true);
-    txn.insert_kernel(kernel5, true);
+    txn.insert_kernel(kernel4);
+    txn.insert_kernel(kernel5);
     txn.operations
         .push(WriteOperation::CreateMmrCheckpoint(MmrTree::Kernel));
     assert!(db.write(txn).is_ok());
     let mut txn = DbTransaction::new();
-    txn.insert_kernel(kernel6, true);
+    txn.insert_kernel(kernel6);
     txn.operations
         .push(WriteOperation::CreateMmrCheckpoint(MmrTree::Kernel));
     assert!(db.write(txn).is_ok());

--- a/base_layer/core/tests/node_comms_interface.rs
+++ b/base_layer/core/tests/node_comms_interface.rs
@@ -172,7 +172,7 @@ fn inbound_fetch_kernels() {
     let kernel = create_test_kernel(5.into(), 0);
     let hash = kernel.hash();
     let mut txn = DbTransaction::new();
-    txn.insert_kernel(kernel.clone(), true);
+    txn.insert_kernel(kernel.clone());
     assert!(store.commit(txn).is_ok());
 
     test_async(move |rt| {
@@ -291,7 +291,7 @@ fn inbound_fetch_utxos() {
     let (utxo, _) = create_utxo(MicroTari(10_000), &factories, None);
     let hash = utxo.hash();
     let mut txn = DbTransaction::new();
-    txn.insert_utxo(utxo.clone(), true);
+    txn.insert_utxo(utxo.clone());
     assert!(store.commit(txn).is_ok());
 
     test_async(move |rt| {

--- a/base_layer/core/tests/node_service.rs
+++ b/base_layer/core/tests/node_service.rs
@@ -204,12 +204,12 @@ fn request_and_response_fetch_kernels() {
     let hash2 = kernel2.hash();
 
     let mut txn = DbTransaction::new();
-    txn.insert_kernel(kernel1.clone(), true);
-    txn.insert_kernel(kernel2.clone(), true);
+    txn.insert_kernel(kernel1.clone());
+    txn.insert_kernel(kernel2.clone());
     assert!(bob_node.blockchain_db.commit(txn).is_ok());
     let mut txn = DbTransaction::new();
-    txn.insert_kernel(kernel1.clone(), true);
-    txn.insert_kernel(kernel2.clone(), true);
+    txn.insert_kernel(kernel1.clone());
+    txn.insert_kernel(kernel2.clone());
     assert!(carol_node.blockchain_db.commit(txn).is_ok());
 
     runtime.block_on(async {
@@ -246,12 +246,12 @@ fn request_and_response_fetch_utxos() {
     let hash2 = utxo2.hash();
 
     let mut txn = DbTransaction::new();
-    txn.insert_utxo(utxo1.clone(), true);
-    txn.insert_utxo(utxo2.clone(), true);
+    txn.insert_utxo(utxo1.clone());
+    txn.insert_utxo(utxo2.clone());
     assert!(bob_node.blockchain_db.commit(txn).is_ok());
     let mut txn = DbTransaction::new();
-    txn.insert_utxo(utxo1.clone(), true);
-    txn.insert_utxo(utxo2.clone(), true);
+    txn.insert_utxo(utxo1.clone());
+    txn.insert_utxo(utxo2.clone());
     assert!(carol_node.blockchain_db.commit(txn).is_ok());
 
     runtime.block_on(async {
@@ -804,23 +804,23 @@ fn request_and_response_fetch_mmr_node_and_count() {
     let mut blocks = vec![block0];
     let db = &mut bob_node.blockchain_db;
     let mut txn = DbTransaction::new();
-    txn.insert_utxo(utxo1.clone(), true);
-    txn.insert_utxo(utxo2.clone(), true);
-    txn.insert_kernel(kernel1.clone(), true);
+    txn.insert_utxo(utxo1.clone());
+    txn.insert_utxo(utxo2.clone());
+    txn.insert_kernel(kernel1.clone());
     assert!(db.commit(txn).is_ok());
     generate_block(db, &mut blocks, vec![], &consensus_manager.consensus_constants()).unwrap();
 
     let mut txn = DbTransaction::new();
-    txn.insert_utxo(utxo3.clone(), true);
+    txn.insert_utxo(utxo3.clone());
     txn.spend_utxo(utxo_hash1.clone());
-    txn.insert_kernel(kernel2.clone(), true);
+    txn.insert_kernel(kernel2.clone());
     assert!(db.commit(txn).is_ok());
     generate_block(db, &mut blocks, vec![], &consensus_manager.consensus_constants()).unwrap();
 
     let mut txn = DbTransaction::new();
-    txn.insert_utxo(utxo4.clone(), true);
+    txn.insert_utxo(utxo4.clone());
     txn.spend_utxo(utxo_hash3.clone());
-    txn.insert_kernel(kernel3.clone(), true);
+    txn.insert_kernel(kernel3.clone());
     assert!(db.commit(txn).is_ok());
     generate_block(db, &mut blocks, vec![], &consensus_manager.consensus_constants()).unwrap();
 


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
- Improved logging for possible causes of database corruption.
  Corruption occurs when a DbTransaction operation fails and does not
  undo the operations that completed before the failure.
- Removed exrtaneous `update_mmr` bool flag on
  `DbKeyValuePair::UnspentOutput` and
  `DbKeyValuePair::TransactionKernel`. These were always hardcoded to true
  in all calls incl. tests. If they were ever set to false could cause database
  the MMR checkpoints to go out of sync with other blockchain data. I
  suspect the reason they were added in the first place no longer
  exists.
- Added a test that adds an invalid block and checks that
  `height_of_longest_chain` does not include the invalid block.
- Other small code readability changes that maintain the same
  functionality.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Changes as part of the investigation into #1990 and #1991 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Added test for correct behaviour when an invalid block is added. Existing tests pass.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [x] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [x] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch.
* [x] I ran `cargo-fmt --all` before pushing.
* [x] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
