### PR TITLE
Made messaging pipeline optional in CommsBuilder

### DIFF
--- a/comms/src/bounded_executor.rs
+++ b/comms/src/bounded_executor.rs
@@ -20,7 +20,7 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use crate::runtime::current_executor;
+use crate::runtime::current;
 use std::{future::Future, sync::Arc};
 use tokio::{runtime, sync::Semaphore, task::JoinHandle};
 
@@ -42,7 +42,7 @@ impl BoundedExecutor {
     }
 
     pub fn from_current(num_permits: usize) -> Self {
-        Self::new(current_executor(), num_permits)
+        Self::new(current(), num_permits)
     }
 
     /// Spawn a future onto the Tokio runtime asynchronously blocking if there are too many

--- a/comms/src/builder/error.rs
+++ b/comms/src/builder/error.rs
@@ -33,11 +33,6 @@ pub enum CommsBuilderError {
     NodeIdentityNotSet,
     #[error("The PeerStorage was not provided to the CommsBuilder. Use `with_peer_storage` to set it.")]
     PeerStorageNotProvided,
-    #[error(
-        "The messaging pipeline was not provided to the CommsBuilder. Use `with_messaging_pipeline` to set it's \
-         pipeline."
-    )]
-    MessagingPiplineNotProvided,
     #[error("Unable to receive a ConnectionManagerEvent within timeout")]
     ConnectionManagerEventStreamTimeout,
     #[error("ConnectionManagerEvent stream unexpectedly closed")]

--- a/comms/src/builder/tests.rs
+++ b/comms/src/builder/tests.rs
@@ -58,7 +58,7 @@ async fn spawn_node(
     let comms_node = CommsBuilder::new()
         // These calls are just to get rid of unused function warnings. 
         // <IrrelevantCalls>
-        .with_executor(runtime::current_executor())
+        .with_executor(runtime::current())
         .with_dial_backoff(ConstantBackoff::new(Duration::from_millis(500)))
         .on_shutdown(|| {})
         // </IrrelevantCalls>
@@ -103,12 +103,14 @@ async fn peer_to_peer_custom_protocols() {
     // Setup test protocols
     let (test_sender, _test_protocol_rx1) = mpsc::channel(10);
     let (another_test_sender, mut another_test_protocol_rx1) = mpsc::channel(10);
-    let protocols1 = Protocols::new()
+    let mut protocols1 = Protocols::new();
+    protocols1
         .add(&[TEST_PROTOCOL], test_sender)
         .add(&[ANOTHER_TEST_PROTOCOL], another_test_sender);
     let (test_sender, mut test_protocol_rx2) = mpsc::channel(10);
     let (another_test_sender, _another_test_protocol_rx2) = mpsc::channel(10);
-    let protocols2 = Protocols::new()
+    let mut protocols2 = Protocols::new();
+    protocols2
         .add(&[TEST_PROTOCOL], test_sender)
         .add(&[ANOTHER_TEST_PROTOCOL], another_test_sender);
 
@@ -288,7 +290,7 @@ async fn peer_to_peer_messaging_simultaneous() {
         .unwrap();
 
     // Simultaneously send messages between the two nodes
-    let rt_handle = runtime::current_executor();
+    let rt_handle = runtime::current();
     let handle1 = rt_handle.spawn(async move {
         for i in 0..NUM_MSGS {
             let outbound_msg = OutboundMessage::new(

--- a/comms/src/connection_manager/liveness.rs
+++ b/comms/src/connection_manager/liveness.rs
@@ -57,7 +57,7 @@ mod test {
     async fn echos() {
         let (inbound, outbound) = MemorySocket::new_pair();
         let liveness = LivenessSession::new(inbound);
-        let join_handle = runtime::current_executor().spawn(liveness.run());
+        let join_handle = runtime::current().spawn(liveness.run());
         let mut outbound = Framed::new(IoCompat::new(outbound), LinesCodec::new());
         for _ in 0..10usize {
             outbound.send("ECHO".to_string()).await.unwrap()

--- a/comms/src/connection_manager/peer_connection.rs
+++ b/comms/src/connection_manager/peer_connection.rs
@@ -88,7 +88,7 @@ pub fn create(
         event_notifier,
         our_supported_protocols,
     );
-    runtime::current_executor().spawn(peer_actor.run());
+    runtime::current().spawn(peer_actor.run());
 
     Ok(peer_conn)
 }

--- a/comms/src/connection_manager/tests/listener_dialer.rs
+++ b/comms/src/connection_manager/tests/listener_dialer.rs
@@ -66,7 +66,6 @@ async fn listen() -> Result<(), Box<dyn Error>> {
         event_tx.clone(),
         peer_manager.into(),
         node_identity,
-        vec![],
         shutdown.to_signal(),
     );
 
@@ -98,7 +97,7 @@ async fn smoke() {
     let expected_proto = ProtocolId::from_static(b"/tari/test-proto");
     let supported_protocols = vec![expected_proto.clone()];
     let peer_manager1 = build_peer_manager();
-    let listener = PeerListener::new(
+    let mut listener = PeerListener::new(
         ConnectionManagerConfig {
             listener_address: "/memory/0".parse().unwrap(),
             ..Default::default()
@@ -108,9 +107,9 @@ async fn smoke() {
         event_tx.clone(),
         peer_manager1.clone().into(),
         node_identity1.clone(),
-        supported_protocols.clone(),
         shutdown.to_signal(),
     );
+    listener.set_supported_protocols(supported_protocols.clone());
 
     let listener_fut = rt_handle.spawn(listener.run());
 
@@ -118,7 +117,7 @@ async fn smoke() {
     let noise_config2 = NoiseConfig::new(node_identity2.clone());
     let (mut request_tx, request_rx) = mpsc::channel(1);
     let peer_manager2 = build_peer_manager();
-    let dialer = Dialer::new(
+    let mut dialer = Dialer::new(
         ConnectionManagerConfig::default(),
         node_identity2.clone(),
         peer_manager2.clone().into(),
@@ -127,9 +126,9 @@ async fn smoke() {
         ConstantBackoff::new(Duration::from_millis(100)),
         request_rx,
         event_tx,
-        supported_protocols,
         shutdown.to_signal(),
     );
+    dialer.set_supported_protocols(supported_protocols.clone());
 
     let dialer_fut = rt_handle.spawn(dialer.run());
 
@@ -200,7 +199,7 @@ async fn banned() {
     let expected_proto = ProtocolId::from_static(b"/tari/test-proto");
     let supported_protocols = vec![expected_proto.clone()];
     let peer_manager1 = build_peer_manager();
-    let listener = PeerListener::new(
+    let mut listener = PeerListener::new(
         ConnectionManagerConfig {
             listener_address: "/memory/0".parse().unwrap(),
             ..Default::default()
@@ -210,9 +209,9 @@ async fn banned() {
         event_tx.clone(),
         peer_manager1.clone().into(),
         node_identity1.clone(),
-        supported_protocols.clone(),
         shutdown.to_signal(),
     );
+    listener.set_supported_protocols(supported_protocols.clone());
 
     let listener_fut = rt_handle.spawn(listener.run());
 
@@ -225,7 +224,7 @@ async fn banned() {
     let noise_config2 = NoiseConfig::new(node_identity2.clone());
     let (mut request_tx, request_rx) = mpsc::channel(1);
     let peer_manager2 = build_peer_manager();
-    let dialer = Dialer::new(
+    let mut dialer = Dialer::new(
         ConnectionManagerConfig::default(),
         node_identity2.clone(),
         peer_manager2.clone().into(),
@@ -234,9 +233,9 @@ async fn banned() {
         ConstantBackoff::new(Duration::from_millis(100)),
         request_rx,
         event_tx,
-        supported_protocols,
         shutdown.to_signal(),
     );
+    dialer.set_supported_protocols(supported_protocols);
 
     let dialer_fut = rt_handle.spawn(dialer.run());
 

--- a/comms/src/connection_manager/tests/manager.rs
+++ b/comms/src/connection_manager/tests/manager.rs
@@ -65,7 +65,6 @@ async fn connect_to_nonexistent_peer() {
         request_rx,
         node_identity,
         peer_manager.into(),
-        Protocols::new(),
         event_tx,
         shutdown.to_signal(),
     );
@@ -98,26 +97,31 @@ async fn dial_success() {
 
     // Setup connection manager 1
     let peer_manager1 = build_peer_manager();
+
+    let mut protocols = Protocols::new();
+    protocols.add([TEST_PROTO], proto_tx1);
     let mut conn_man1 = build_connection_manager(
         TestNodeConfig {
             node_identity: node_identity1.clone(),
             ..Default::default()
         },
         peer_manager1.clone(),
-        Protocols::new().add([TEST_PROTO], proto_tx1),
+        protocols,
         shutdown.to_signal(),
     );
 
     conn_man1.wait_until_listening().await.unwrap();
 
     let peer_manager2 = build_peer_manager();
+    let mut protocols = Protocols::new();
+    protocols.add([TEST_PROTO], proto_tx2);
     let mut conn_man2 = build_connection_manager(
         TestNodeConfig {
             node_identity: node_identity2.clone(),
             ..Default::default()
         },
         peer_manager2.clone(),
-        Protocols::new().add([TEST_PROTO], proto_tx2),
+        protocols,
         shutdown.to_signal(),
     );
     let mut subscription2 = conn_man2.get_event_subscription();

--- a/comms/src/multiplexing/yamux.rs
+++ b/comms/src/multiplexing/yamux.rs
@@ -99,7 +99,7 @@ impl Yamux {
         let (incoming_tx, incoming_rx) = mpsc::channel(10);
         let stream = yamux::into_stream(connection).boxed();
         let incoming = IncomingWorker::new(stream, incoming_tx, shutdown.to_signal());
-        runtime::current_executor().spawn(incoming.run());
+        runtime::current().spawn(incoming.run());
         IncomingSubstreams::new(incoming_rx, counter, shutdown)
     }
 

--- a/comms/src/protocol/mod.rs
+++ b/comms/src/protocol/mod.rs
@@ -30,7 +30,7 @@ mod negotiation;
 pub use negotiation::ProtocolNegotiation;
 
 mod protocols;
-pub use protocols::{ProtocolEvent, ProtocolNotification, Protocols};
+pub use protocols::{ProtocolEvent, ProtocolNotification, ProtocolNotifier, Protocols};
 
 pub mod messaging;
 

--- a/comms/src/runtime.rs
+++ b/comms/src/runtime.rs
@@ -31,6 +31,6 @@ pub use tokio_macros::test_basic;
 
 /// Return the current tokio executor. Panics if the tokio runtime is not started.
 #[inline]
-pub fn current_executor() -> runtime::Handle {
+pub fn current() -> runtime::Handle {
     runtime::Handle::current()
 }

--- a/comms/src/test_utils/test_node.rs
+++ b/comms/src/test_utils/test_node.rs
@@ -81,7 +81,7 @@ pub fn build_connection_manager(
 
     let requester = ConnectionManagerRequester::new(request_tx, event_tx.clone());
 
-    let connection_manager = ConnectionManager::new(
+    let mut connection_manager = ConnectionManager::new(
         config.connection_manager_config,
         config.transport,
         noise_config,
@@ -89,12 +89,12 @@ pub fn build_connection_manager(
         request_rx,
         config.node_identity,
         peer_manager.into(),
-        protocols,
         event_tx,
         shutdown,
     );
+    connection_manager.set_protocols(protocols);
 
-    runtime::current_executor().spawn(connection_manager.run());
+    runtime::current().spawn(connection_manager.run());
 
     requester
 }

--- a/comms/src/tor/control_client/test_server.rs
+++ b/comms/src/tor/control_client/test_server.rs
@@ -36,7 +36,7 @@ pub async fn spawn() -> (Multiaddr, State, MemorySocket) {
 
     let server = TorControlPortTestServer::new(socket_in);
     let state = server.get_shared_state();
-    runtime::current_executor().spawn(server.run());
+    runtime::current().spawn(server.run());
 
     (addr, state, socket_out)
 }


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Messaging pipeline is optional. If a `MessageingPipeline` is not specified
in the builder, the messaging protocol, associated channels and `tokio` tasks
will never be initialised/spawned. 


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This allows a more light-weight comms to be
initialised in tests that do not require the messaging pipeline (such as
integration tests for components using e.g. RPC only) without the added
cruft of setting up a _no-op_ messaging pipeline.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Existing tests pass

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [x] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch.
* [x] I ran `cargo-fmt --all` before pushing.
* [x] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
