### PR TITLE
Pruned mode syncing: base node requests, blockchain db and backend changes 

### DIFF
--- a/base_layer/core/src/base_node/comms_interface/comms_request.rs
+++ b/base_layer/core/src/base_node/comms_interface/comms_request.rs
@@ -46,13 +46,14 @@ pub enum NodeCommsRequest {
     FetchHeadersWithHashes(Vec<HashOutput>),
     FetchHeadersAfter(Vec<HashOutput>, HashOutput),
     FetchUtxos(Vec<HashOutput>),
+    FetchTxos(Vec<HashOutput>),
     FetchBlocks(Vec<u64>),
     FetchBlocksWithHashes(Vec<HashOutput>),
     GetNewBlockTemplate(PowAlgorithm),
     GetNewBlock(NewBlockTemplate),
     GetTargetDifficulty(PowAlgorithm),
     FetchMmrNodeCount(MmrTree, u64),
-    FetchMmrNodes(MmrTree, u32, u32),
+    FetchMmrNodes(MmrTree, u32, u32, u64),
 }
 
 impl Display for NodeCommsRequest {
@@ -64,6 +65,7 @@ impl Display for NodeCommsRequest {
             NodeCommsRequest::FetchHeadersWithHashes(v) => f.write_str(&format!("FetchHeaders (n={})", v.len())),
             NodeCommsRequest::FetchHeadersAfter(v, _hash) => f.write_str(&format!("FetchHeadersAfter (n={})", v.len())),
             NodeCommsRequest::FetchUtxos(v) => f.write_str(&format!("FetchUtxos (n={})", v.len())),
+            NodeCommsRequest::FetchTxos(v) => f.write_str(&format!("FetchTxos (n={})", v.len())),
             NodeCommsRequest::FetchBlocks(v) => f.write_str(&format!("FetchBlocks (n={})", v.len())),
             NodeCommsRequest::FetchBlocksWithHashes(v) => f.write_str(&format!("FetchBlocks (n={})", v.len())),
             NodeCommsRequest::GetNewBlockTemplate(algo) => f.write_str(&format!("GetNewBlockTemplate ({})", algo)),
@@ -72,9 +74,9 @@ impl Display for NodeCommsRequest {
             NodeCommsRequest::FetchMmrNodeCount(tree, height) => {
                 f.write_str(&format!("FetchMmrNodeCount (tree={},Block Height={})", tree, height))
             },
-            NodeCommsRequest::FetchMmrNodes(tree, pos, count) => f.write_str(&format!(
-                "FetchMmrNodeCount (tree={},pos={},count={})",
-                tree, pos, count
+            NodeCommsRequest::FetchMmrNodes(tree, pos, count, hist_height) => f.write_str(&format!(
+                "FetchMmrNodeCount (tree={},pos={},count={},hist_height={})",
+                tree, pos, count, hist_height
             )),
         }
     }

--- a/base_layer/core/src/base_node/proto/request.proto
+++ b/base_layer/core/src/base_node/proto/request.proto
@@ -35,6 +35,8 @@ message BaseNodeServiceRequest {
         FetchMmrNodeCount fetch_mmr_node_count = 13;
         // Indicates a FetchMmrNodes request.
         FetchMmrNodes fetch_mmr_nodes = 14;
+        // Indicates a FetchTxos request.
+        HashOutputs fetch_txos = 15;
     }
 }
 
@@ -60,4 +62,5 @@ message FetchMmrNodes{
     MmrTree tree = 1;
     uint32 pos = 2;
     uint32 count = 3;
+    uint64 hist_height = 4;
 }

--- a/base_layer/core/src/base_node/proto/request.rs
+++ b/base_layer/core/src/base_node/proto/request.rs
@@ -47,6 +47,7 @@ impl TryInto<ci::NodeCommsRequest> for ProtoNodeCommsRequest {
                 ci::NodeCommsRequest::FetchHeadersAfter(request.hashes, request.stopping_hash)
             },
             FetchUtxos(hash_outputs) => ci::NodeCommsRequest::FetchUtxos(hash_outputs.outputs),
+            FetchTxos(hash_outputs) => ci::NodeCommsRequest::FetchTxos(hash_outputs.outputs),
             FetchBlocks(block_heights) => ci::NodeCommsRequest::FetchBlocks(block_heights.heights),
             FetchBlocksWithHashes(block_hashes) => ci::NodeCommsRequest::FetchBlocksWithHashes(block_hashes.outputs),
             GetNewBlockTemplate(pow_algo) => {
@@ -59,9 +60,12 @@ impl TryInto<ci::NodeCommsRequest> for ProtoNodeCommsRequest {
             FetchMmrNodeCount(request) => {
                 ci::NodeCommsRequest::FetchMmrNodeCount(request.tree.try_into()?, request.height)
             },
-            FetchMmrNodes(request) => {
-                ci::NodeCommsRequest::FetchMmrNodes(request.tree.try_into()?, request.pos, request.count)
-            },
+            FetchMmrNodes(request) => ci::NodeCommsRequest::FetchMmrNodes(
+                request.tree.try_into()?,
+                request.pos,
+                request.count,
+                request.hist_height,
+            ),
         };
         Ok(request)
     }
@@ -79,6 +83,7 @@ impl From<ci::NodeCommsRequest> for ProtoNodeCommsRequest {
                 ProtoNodeCommsRequest::FetchHeadersAfter(ProtoFetchHeadersAfter { hashes, stopping_hash })
             },
             FetchUtxos(hash_outputs) => ProtoNodeCommsRequest::FetchUtxos(hash_outputs.into()),
+            FetchTxos(hash_outputs) => ProtoNodeCommsRequest::FetchTxos(hash_outputs.into()),
             FetchBlocks(block_heights) => ProtoNodeCommsRequest::FetchBlocks(block_heights.into()),
             FetchBlocksWithHashes(block_hashes) => ProtoNodeCommsRequest::FetchBlocksWithHashes(block_hashes.into()),
             GetNewBlockTemplate(pow_algo) => ProtoNodeCommsRequest::GetNewBlockTemplate(pow_algo as u64),
@@ -88,10 +93,11 @@ impl From<ci::NodeCommsRequest> for ProtoNodeCommsRequest {
                 tree: tree as i32,
                 height,
             }),
-            FetchMmrNodes(tree, pos, count) => ProtoNodeCommsRequest::FetchMmrNodes(ProtoFetchMmrNodes {
+            FetchMmrNodes(tree, pos, count, hist_height) => ProtoNodeCommsRequest::FetchMmrNodes(ProtoFetchMmrNodes {
                 tree: tree as i32,
                 pos,
                 count,
+                hist_height,
             }),
         }
     }

--- a/base_layer/core/src/chain_storage/async_db.rs
+++ b/base_layer/core/src/chain_storage/async_db.rs
@@ -96,6 +96,7 @@ make_async!(fetch_header_with_block_hash(hash: HashOutput) -> BlockHeader, "fetc
 make_async!(fetch_header(block_num: u64) -> BlockHeader, "fetch_header");
 make_async!(fetch_utxo(hash: HashOutput) -> TransactionOutput, "fetch_utxo");
 make_async!(fetch_stxo(hash: HashOutput) -> TransactionOutput, "fetch_stxo");
+make_async!(fetch_txo(hash: HashOutput) -> Option<TransactionOutput>, "fetch_txo");
 make_async!(fetch_orphan(hash: HashOutput) -> Block, "fetch_orphan");
 make_async!(is_utxo(hash: HashOutput) -> bool, "is_utxo");
 make_async!(is_stxo(hash: HashOutput) -> bool, "is_stxo");
@@ -103,7 +104,7 @@ make_async!(fetch_mmr_root(tree: MmrTree) -> HashOutput, "fetch_mmr_root");
 make_async!(fetch_mmr_only_root(tree: MmrTree) -> HashOutput, "fetch_mmr_only_root");
 make_async!(calculate_mmr_root(tree: MmrTree,additions: Vec<HashOutput>,deletions: Vec<HashOutput>) -> HashOutput, "calculate_mmr_root");
 make_async!(fetch_mmr_node_count(tree: MmrTree, height: u64) -> u32, "fetch_mmr_node_count");
-make_async!(fetch_mmr_nodes(tree: MmrTree, pos: u32, count: u32) -> Vec<(Vec<u8>, bool)>, "fetch_mmr_nodes");
+make_async!(fetch_mmr_nodes(tree: MmrTree, pos: u32, count: u32, hist_height:Option<u64>) -> Vec<(Vec<u8>, bool)>, "fetch_mmr_nodes");
 make_async!(add_block(block: Block) -> BlockAddResult, "add_block");
 make_async!(calculate_mmr_roots(template: NewBlockTemplate) -> Block, "calculate_mmr_roots");
 

--- a/base_layer/core/src/chain_storage/lmdb_db/lmdb_db.rs
+++ b/base_layer/core/src/chain_storage/lmdb_db/lmdb_db.rs
@@ -680,10 +680,32 @@ where D: Digest + Send + Sync
         }
     }
 
-    fn fetch_mmr_node(&self, tree: MmrTree, pos: u32) -> Result<(Vec<u8>, bool), ChainStorageError> {
+    fn fetch_mmr_node(
+        &self,
+        tree: MmrTree,
+        pos: u32,
+        hist_height: Option<u64>,
+    ) -> Result<(Vec<u8>, bool), ChainStorageError>
+    {
         let (hash, deleted) = match tree {
             MmrTree::Kernel => self.kernel_mmr.fetch_mmr_node(pos)?,
-            MmrTree::Utxo => self.utxo_mmr.fetch_mmr_node(pos)?,
+            MmrTree::Utxo => {
+                let (hash, mut deleted) = self.utxo_mmr.fetch_mmr_node(pos)?;
+                // Check if the MMR node was deleted after the historic height then its deletion status should change.
+                // TODO: Find a more efficient way to query the historic deletion status of an MMR node.
+                if deleted {
+                    if let Some(hist_height) = hist_height {
+                        let tip_height = lmdb_len(&self.env, &self.headers_db)?.saturating_sub(1) as u64;
+                        for height in hist_height + 1..=tip_height {
+                            let cp = self.fetch_checkpoint(MmrTree::Utxo, height)?;
+                            if cp.nodes_deleted().contains(pos) {
+                                deleted = false;
+                            }
+                        }
+                    }
+                }
+                (hash, deleted)
+            },
             MmrTree::RangeProof => self.range_proof_mmr.fetch_mmr_node(pos)?,
         };
         let hash = hash.ok_or_else(|| {
@@ -692,12 +714,49 @@ where D: Digest + Send + Sync
         Ok((hash, deleted))
     }
 
-    fn fetch_mmr_nodes(&self, tree: MmrTree, pos: u32, count: u32) -> Result<Vec<(Vec<u8>, bool)>, ChainStorageError> {
+    fn fetch_mmr_nodes(
+        &self,
+        tree: MmrTree,
+        pos: u32,
+        count: u32,
+        hist_height: Option<u64>,
+    ) -> Result<Vec<(Vec<u8>, bool)>, ChainStorageError>
+    {
         let mut leaf_nodes = Vec::<(Vec<u8>, bool)>::with_capacity(count as usize);
         for pos in pos..pos + count {
-            leaf_nodes.push(self.fetch_mmr_node(tree.clone(), pos)?);
+            leaf_nodes.push(self.fetch_mmr_node(tree.clone(), pos, hist_height)?);
         }
         Ok(leaf_nodes)
+    }
+
+    fn insert_mmr_node(&mut self, tree: MmrTree, hash: Hash, deleted: bool) -> Result<(), ChainStorageError> {
+        match tree {
+            MmrTree::Kernel => self.curr_kernel_checkpoint.push_addition(hash),
+            MmrTree::Utxo => {
+                self.curr_utxo_checkpoint.push_addition(hash);
+                if deleted {
+                    let leaf_index = self
+                        .curr_utxo_checkpoint
+                        .accumulated_nodes_added_count()
+                        .saturating_sub(1);
+                    self.curr_utxo_checkpoint.push_deletion(leaf_index);
+                }
+            },
+            MmrTree::RangeProof => self.curr_range_proof_checkpoint.push_addition(hash),
+        };
+        Ok(())
+    }
+
+    fn delete_mmr_node(&mut self, tree: MmrTree, hash: &Hash) -> Result<(), ChainStorageError> {
+        match tree {
+            MmrTree::Kernel | MmrTree::RangeProof => {},
+            MmrTree::Utxo => {
+                if let Some(leaf_index) = self.utxo_mmr.find_leaf_index(&hash)? {
+                    self.curr_utxo_checkpoint.push_deletion(leaf_index);
+                }
+            },
+        };
+        Ok(())
     }
 
     fn fetch_mmr_leaf_index(&self, tree: MmrTree, hash: &Hash) -> Result<Option<u32>, ChainStorageError> {

--- a/base_layer/core/src/chain_storage/mod.rs
+++ b/base_layer/core/src/chain_storage/mod.rs
@@ -44,6 +44,7 @@ pub use blockchain_database::{
     fetch_header,
     fetch_headers,
     fetch_target_difficulties,
+    fetch_tip_header,
     is_stxo,
     is_utxo,
     BlockAddResult,

--- a/base_layer/core/src/helpers/mock_backend.rs
+++ b/base_layer/core/src/helpers/mock_backend.rs
@@ -79,7 +79,13 @@ impl BlockchainBackend for MockBackend {
         unimplemented!()
     }
 
-    fn fetch_mmr_node(&self, _tree: MmrTree, _pos: u32) -> Result<(Hash, bool), ChainStorageError> {
+    fn fetch_mmr_node(
+        &self,
+        _tree: MmrTree,
+        _pos: u32,
+        _hist_height: Option<u64>,
+    ) -> Result<(Hash, bool), ChainStorageError>
+    {
         unimplemented!()
     }
 
@@ -88,8 +94,17 @@ impl BlockchainBackend for MockBackend {
         _tree: MmrTree,
         _pos: u32,
         _count: u32,
+        _hist_height: Option<u64>,
     ) -> Result<Vec<(Vec<u8>, bool)>, ChainStorageError>
     {
+        unimplemented!()
+    }
+
+    fn insert_mmr_node(&mut self, _tree: MmrTree, _hash: Hash, _deleted: bool) -> Result<(), ChainStorageError> {
+        unimplemented!()
+    }
+
+    fn delete_mmr_node(&mut self, _tree: MmrTree, _hash: &Hash) -> Result<(), ChainStorageError> {
         unimplemented!()
     }
 

--- a/base_layer/core/tests/node_service.rs
+++ b/base_layer/core/tests/node_service.rs
@@ -627,7 +627,6 @@ fn propagate_and_forward_invalid_block() {
             mock_accum_difficulty_validator.clone(),
         )
         .start(&mut runtime, temp_dir.path().join("bob").to_str().unwrap());
-    let mock_validator = MockValidator::new(true);
     let (alice_node, rules) = BaseNodeBuilder::new(network)
         .with_node_identity(alice_node_identity)
         .with_peers(vec![bob_node_identity.clone(), carol_node_identity.clone()])
@@ -942,7 +941,7 @@ fn request_and_response_fetch_mmr_node_and_count() {
 
         let (added, deleted) = alice_node
             .outbound_nci
-            .fetch_mmr_nodes(MmrTree::Utxo, 1, 4, None)
+            .fetch_mmr_nodes(MmrTree::Utxo, 1, 4, 5, None)
             .await
             .unwrap();
         let deleted = Bitmap::deserialize(&deleted).to_vec();
@@ -950,7 +949,7 @@ fn request_and_response_fetch_mmr_node_and_count() {
         assert_eq!(deleted, vec![1, 3]);
         let (added, deleted) = alice_node
             .outbound_nci
-            .fetch_mmr_nodes(MmrTree::Kernel, 2, 2, None)
+            .fetch_mmr_nodes(MmrTree::Kernel, 2, 2, 5, None)
             .await
             .unwrap();
         let deleted = Bitmap::deserialize(&deleted).to_vec();
@@ -958,7 +957,7 @@ fn request_and_response_fetch_mmr_node_and_count() {
         assert_eq!(deleted.len(), 0);
         let (added, deleted) = alice_node
             .outbound_nci
-            .fetch_mmr_nodes(MmrTree::RangeProof, 2, 2, None)
+            .fetch_mmr_nodes(MmrTree::RangeProof, 2, 2, 5, None)
             .await
             .unwrap();
         let deleted = Bitmap::deserialize(&deleted).to_vec();
@@ -987,7 +986,7 @@ fn request_and_response_fetch_mmr_node_and_count() {
 
         let (added, deleted) = alice_node
             .outbound_nci
-            .fetch_mmr_nodes(MmrTree::Utxo, 4, 5, None)
+            .fetch_mmr_nodes(MmrTree::Utxo, 4, 5, 5, None)
             .await
             .unwrap();
         let deleted = Bitmap::deserialize(&deleted).to_vec();
@@ -995,7 +994,7 @@ fn request_and_response_fetch_mmr_node_and_count() {
         assert_eq!(deleted.len(), 0);
         let (added, deleted) = alice_node
             .outbound_nci
-            .fetch_mmr_nodes(MmrTree::Kernel, 4, 5, None)
+            .fetch_mmr_nodes(MmrTree::Kernel, 4, 5, 5, None)
             .await
             .unwrap();
         let deleted = Bitmap::deserialize(&deleted).to_vec();
@@ -1003,7 +1002,7 @@ fn request_and_response_fetch_mmr_node_and_count() {
         assert_eq!(deleted.len(), 0);
         let (added, deleted) = alice_node
             .outbound_nci
-            .fetch_mmr_nodes(MmrTree::RangeProof, 4, 5, None)
+            .fetch_mmr_nodes(MmrTree::RangeProof, 4, 5, 5, None)
             .await
             .unwrap();
         let deleted = Bitmap::deserialize(&deleted).to_vec();


### PR DESCRIPTION
## Description
- Added fetch Txos base node request with handlers for fetching a STXO or UTXO using a set of hashes.
- Modified the fetch mmr nodes requests and functions to allow a historic height to be configured to allow the correct deletion status to be provided as a response.
- insert_mmr_node and delete_mmr_node functions, required for horizon state syncing and restoring, were added to the blockchain backend trait with implementations.
- Blockchain db functions for changing the stored metadata was added, fetching and inserting a set of kernels, inserting utxos, fetching txos, inserting mmr nodes and deleting an existing mmr node was added.
- The commit_horizon_state function was also added to the blockchain db to allow the metadata to be restored and a horizon state checkpoint to be created after the horizon state sync has been completed.

## Motivation and Context
These are base node comms, blockchain db and backend changes required for pruned mode syncing and the restoring of a horizon state. 

## How Has This Been Tested?
- Tests were added for comms fetch txo requests, insert mmr nodes, writing and fetching the metadata, pruned mode fetch insert and commit.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [x] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch.
* [x] I ran `cargo-fmt --all` before pushing.
* [x] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
