### PR TITLE
Don't delete existing files in S3 when uploading

### DIFF
--- a/.github/workflows/libwallet.yml
+++ b/.github/workflows/libwallet.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Sync to S3
         uses: jakejarvis/s3-sync-action@v0.5.1
         with:
-          args: --acl public-read --follow-symlinks --delete
+          args: --acl public-read --follow-symlinks
         env:
           AWS_S3_BUCKET: ${{ secrets.AWS_S3_BUCKET }}
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}


### PR DESCRIPTION
Removing the `--delete` flag, which was removing older versions of the
libraries, which is not what we want.

