### PR TITLE
Horizon state syncing for pruned nodes

### DIFF
--- a/base_layer/core/src/base_node/state_machine.rs
+++ b/base_layer/core/src/base_node/state_machine.rs
@@ -24,7 +24,7 @@ use crate::{
         chain_metadata_service::ChainMetadataEvent,
         comms_interface::{LocalNodeCommsInterface, OutboundNodeCommsInterface},
         states,
-        states::{BaseNodeState, BlockSyncConfig, StateEvent, StatusInfo},
+        states::{BaseNodeState, BlockSyncConfig, HorizonSyncConfig, StateEvent, StatusInfo, SyncPeerConfig},
     },
     chain_storage::{BlockchainBackend, BlockchainDatabase},
 };
@@ -41,12 +41,16 @@ const LOG_TARGET: &str = "c::bn::base_node";
 #[derive(Clone, Copy)]
 pub struct BaseNodeStateMachineConfig {
     pub block_sync_config: BlockSyncConfig,
+    pub horizon_sync_config: HorizonSyncConfig,
+    pub sync_peer_config: SyncPeerConfig,
 }
 
 impl Default for BaseNodeStateMachineConfig {
     fn default() -> Self {
         Self {
             block_sync_config: BlockSyncConfig::default(),
+            horizon_sync_config: HorizonSyncConfig::default(),
+            sync_peer_config: SyncPeerConfig::default(),
         }
     }
 }

--- a/base_layer/core/src/base_node/states/helpers.rs
+++ b/base_layer/core/src/base_node/states/helpers.rs
@@ -1,0 +1,487 @@
+// Copyright 2019. The Tari Project
+//
+// Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+// following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+// disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+// following disclaimer in the documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+// products derived from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+// INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+// WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+// USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+use crate::{
+    base_node::{
+        comms_interface::CommsInterfaceError,
+        state_machine::BaseNodeStateMachine,
+        states::block_sync::BlockSyncError,
+    },
+    blocks::blockheader::BlockHeader,
+    chain_storage::{BlockchainBackend, MmrTree},
+    transactions::{
+        transaction::{TransactionKernel, TransactionOutput},
+        types::HashOutput,
+    },
+};
+use croaring::Bitmap;
+use log::*;
+use rand::seq::SliceRandom;
+use std::time::Duration;
+use tari_comms::{connectivity::ConnectivityRequester, peer_manager::NodeId};
+
+// If more than one sync peer discovered with the correct chain, enable or disable the selection of a random sync peer
+// to query headers and blocks.
+const RANDOM_SYNC_PEER_WITH_CHAIN: bool = true;
+// The default length of time to ban a misbehaving/malfunctioning sync peer (24 hours)
+const DEFAULT_PEER_BAN_DURATION: Duration = Duration::from_secs(24 * 60 * 60);
+// The length of time for a short term ban of a misbehaving/malfunctioning sync peer (5 min)
+const SHORT_TERM_PEER_BAN_DURATION: Duration = Duration::from_secs(5 * 60);
+
+/// Configuration for the Sync Peer Selection and Banning.
+#[derive(Clone, Copy)]
+pub struct SyncPeerConfig {
+    pub random_sync_peer_with_chain: bool,
+    pub peer_ban_duration: Duration,
+    pub short_term_peer_ban_duration: Duration,
+}
+
+impl Default for SyncPeerConfig {
+    fn default() -> Self {
+        Self {
+            random_sync_peer_with_chain: RANDOM_SYNC_PEER_WITH_CHAIN,
+            peer_ban_duration: DEFAULT_PEER_BAN_DURATION,
+            short_term_peer_ban_duration: SHORT_TERM_PEER_BAN_DURATION,
+        }
+    }
+}
+
+/// Selects the first sync peer or a random peer from the set of sync peers that have the current network tip depending
+/// on the selected configuration.
+pub fn select_sync_peer(config: &SyncPeerConfig, sync_peers: &[NodeId]) -> Result<NodeId, BlockSyncError> {
+    if config.random_sync_peer_with_chain {
+        sync_peers.choose(&mut rand::thread_rng())
+    } else {
+        sync_peers.first()
+    }
+    .map(Clone::clone)
+    .ok_or(BlockSyncError::NoSyncPeers)
+}
+
+/// Excluded the provided peer from the sync peers.
+pub async fn exclude_sync_peer(
+    log_target: &str,
+    sync_peers: &mut Vec<NodeId>,
+    sync_peer: NodeId,
+) -> Result<(), BlockSyncError>
+{
+    trace!(target: log_target, "Excluding peer ({}) from sync peers.", sync_peer,);
+    sync_peers.retain(|p| *p != sync_peer);
+    if sync_peers.is_empty() {
+        return Err(BlockSyncError::NoSyncPeers);
+    }
+    Ok(())
+}
+
+/// Ban and disconnect the provided sync peer if this node is online
+pub async fn ban_sync_peer_if_online(
+    log_target: &str,
+    connectivity: &mut ConnectivityRequester,
+    sync_peers: &mut Vec<NodeId>,
+    sync_peer: NodeId,
+    ban_duration: Duration,
+) -> Result<(), BlockSyncError>
+{
+    if !connectivity.get_connectivity_status().await?.is_online() {
+        warn!(
+            target: log_target,
+            "Unable to ban peer {} because local node is offline.", sync_peer
+        );
+        return Ok(());
+    }
+    ban_sync_peer(log_target, connectivity, sync_peers, sync_peer, ban_duration).await
+}
+
+/// Ban and disconnect the provided sync peer.
+pub async fn ban_sync_peer(
+    log_target: &str,
+    connectivity: &mut ConnectivityRequester,
+    sync_peers: &mut Vec<NodeId>,
+    sync_peer: NodeId,
+    ban_duration: Duration,
+) -> Result<(), BlockSyncError>
+{
+    info!(target: log_target, "Banning peer {} from local node.", sync_peer);
+    connectivity.ban_peer(sync_peer.clone(), ban_duration).await?;
+    exclude_sync_peer(log_target, sync_peers, sync_peer).await
+}
+
+/// Ban and disconnect entire set of sync peers.
+pub async fn ban_all_sync_peers<B: BlockchainBackend + 'static>(
+    log_target: &str,
+    shared: &mut BaseNodeStateMachine<B>,
+    sync_peers: &mut Vec<NodeId>,
+    ban_duration: Duration,
+) -> Result<(), BlockSyncError>
+{
+    while !sync_peers.is_empty() {
+        ban_sync_peer(
+            log_target,
+            &mut shared.connectivity,
+            sync_peers,
+            sync_peers[0].clone(),
+            ban_duration,
+        )
+        .await?;
+    }
+    Ok(())
+}
+
+/// Request a set of headers from a remote sync peer.
+pub async fn request_headers<B: BlockchainBackend + 'static>(
+    log_target: &str,
+    shared: &mut BaseNodeStateMachine<B>,
+    sync_peers: &mut Vec<NodeId>,
+    block_nums: &[u64],
+    request_retry_attempts: usize,
+) -> Result<(Vec<BlockHeader>, NodeId), BlockSyncError>
+{
+    let config = shared.config.sync_peer_config;
+    for attempt in 1..=request_retry_attempts {
+        let sync_peer = select_sync_peer(&config, sync_peers)?;
+        debug!(target: log_target, "Requesting headers from {}.", sync_peer);
+        match shared
+            .comms
+            .request_headers_from_peer(block_nums.to_vec(), Some(sync_peer.clone()))
+            .await
+        {
+            Ok(headers) => {
+                debug!(target: log_target, "Received {} headers from peer", headers.len());
+                if block_nums.len() == headers.len() {
+                    if (0..block_nums.len()).all(|i| headers[i].height == block_nums[i]) {
+                        return Ok((headers, sync_peer));
+                    } else {
+                        debug!(target: log_target, "This was NOT the headers we were expecting.");
+                        debug!(
+                            target: log_target,
+                            "Banning peer {} from local node, because they supplied the incorrect headers", sync_peer
+                        );
+                        ban_sync_peer(
+                            log_target,
+                            &mut shared.connectivity,
+                            sync_peers,
+                            sync_peer.clone(),
+                            config.peer_ban_duration,
+                        )
+                        .await?;
+                    }
+                } else {
+                    debug!(
+                        target: log_target,
+                        "Incorrect number of headers returned. Expected {}. Got {}",
+                        block_nums.len(),
+                        headers.len()
+                    );
+                    debug!(
+                        target: log_target,
+                        "Banning peer {} from local node, because they supplied the incorrect number of headers",
+                        sync_peer
+                    );
+                    ban_sync_peer(
+                        log_target,
+                        &mut shared.connectivity,
+                        sync_peers,
+                        sync_peer.clone(),
+                        config.peer_ban_duration,
+                    )
+                    .await?;
+                }
+            },
+            Err(CommsInterfaceError::UnexpectedApiResponse) => {
+                debug!(target: log_target, "Remote node provided an unexpected api response.",);
+                debug!(
+                    target: log_target,
+                    "Banning peer {} from local node, because they provided an unexpected api response", sync_peer
+                );
+                ban_sync_peer(
+                    log_target,
+                    &mut shared.connectivity,
+                    sync_peers,
+                    sync_peer.clone(),
+                    config.peer_ban_duration,
+                )
+                .await?;
+            },
+            Err(CommsInterfaceError::RequestTimedOut) => {
+                debug!(
+                    target: log_target,
+                    "Failed to fetch header from peer: {:?}. Retrying.",
+                    CommsInterfaceError::RequestTimedOut,
+                );
+                ban_sync_peer_if_online(
+                    log_target,
+                    &mut shared.connectivity,
+                    sync_peers,
+                    sync_peer.clone(),
+                    config.short_term_peer_ban_duration,
+                )
+                .await?;
+            },
+            Err(e) => return Err(BlockSyncError::CommsInterfaceError(e)),
+        }
+        debug!(target: log_target, "Retrying header download. Attempt {}", attempt);
+    }
+    Err(BlockSyncError::MaxRequestAttemptsReached)
+}
+
+/// Request the total merkle mountain range node count upto the specified height for the selected MMR from remote base
+/// nodes.
+pub async fn request_mmr_node_count<B: BlockchainBackend + 'static>(
+    log_target: &str,
+    shared: &mut BaseNodeStateMachine<B>,
+    sync_peers: &mut Vec<NodeId>,
+    tree: MmrTree,
+    height: u64,
+    request_retry_attempts: usize,
+) -> Result<(u32, NodeId), BlockSyncError>
+{
+    let config = shared.config.sync_peer_config;
+    for attempt in 1..=request_retry_attempts {
+        let sync_peer = select_sync_peer(&config, sync_peers)?;
+        debug!(target: log_target, "Requesting mmr node count from {}.", sync_peer);
+        match shared
+            .comms
+            .fetch_mmr_node_count(tree.clone(), height, Some(sync_peer.clone()))
+            .await
+        {
+            Ok(num_nodes) => {
+                return Ok((num_nodes, sync_peer));
+            },
+            Err(CommsInterfaceError::UnexpectedApiResponse) => {
+                debug!(target: log_target, "Remote node provided an unexpected api response.",);
+                debug!(
+                    target: log_target,
+                    "Banning peer {} from local node, because they provided an unexpected api response", sync_peer
+                );
+                ban_sync_peer(
+                    log_target,
+                    &mut shared.connectivity,
+                    sync_peers,
+                    sync_peer.clone(),
+                    config.peer_ban_duration,
+                )
+                .await?;
+            },
+            Err(CommsInterfaceError::RequestTimedOut) => {
+                debug!(
+                    target: log_target,
+                    "Failed to fetch mmr node count from peer: {:?}. Retrying.",
+                    CommsInterfaceError::RequestTimedOut,
+                );
+                ban_sync_peer_if_online(
+                    log_target,
+                    &mut shared.connectivity,
+                    sync_peers,
+                    sync_peer.clone(),
+                    config.short_term_peer_ban_duration,
+                )
+                .await?;
+            },
+            Err(e) => return Err(BlockSyncError::CommsInterfaceError(e)),
+        }
+        debug!(
+            target: log_target,
+            "Retrying mmr node count request. Attempt {}", attempt
+        );
+    }
+    Err(BlockSyncError::MaxRequestAttemptsReached)
+}
+
+/// Request the total merkle mountain range node count upto the specified height for the selected MMR from remote base
+/// nodes.
+pub async fn request_mmr_nodes<B: BlockchainBackend + 'static>(
+    log_target: &str,
+    shared: &mut BaseNodeStateMachine<B>,
+    sync_peers: &mut Vec<NodeId>,
+    tree: MmrTree,
+    pos: u32,
+    count: u32,
+    height: u64,
+    request_retry_attempts: usize,
+) -> Result<(Vec<HashOutput>, Bitmap, NodeId), BlockSyncError>
+{
+    let config = shared.config.sync_peer_config;
+    for attempt in 1..=request_retry_attempts {
+        let sync_peer = select_sync_peer(&config, sync_peers)?;
+        debug!(target: log_target, "Requesting mmr nodes from {}.", sync_peer);
+        match shared
+            .comms
+            .fetch_mmr_nodes(tree.clone(), pos, count, height, Some(sync_peer.clone()))
+            .await
+        {
+            Ok((added, deleted)) => {
+                return Ok((added, Bitmap::deserialize(&deleted), sync_peer));
+            },
+            Err(CommsInterfaceError::UnexpectedApiResponse) => {
+                debug!(target: log_target, "Remote node provided an unexpected api response.",);
+                debug!(
+                    target: log_target,
+                    "Banning peer {} from local node, because they provided an unexpected api response", sync_peer
+                );
+                ban_sync_peer(
+                    log_target,
+                    &mut shared.connectivity,
+                    sync_peers,
+                    sync_peer.clone(),
+                    config.peer_ban_duration,
+                )
+                .await?;
+            },
+            Err(CommsInterfaceError::RequestTimedOut) => {
+                debug!(
+                    target: log_target,
+                    "Failed to fetch mmr nodes from peer: {:?}. Retrying.",
+                    CommsInterfaceError::RequestTimedOut,
+                );
+                ban_sync_peer_if_online(
+                    log_target,
+                    &mut shared.connectivity,
+                    sync_peers,
+                    sync_peer.clone(),
+                    config.short_term_peer_ban_duration,
+                )
+                .await?;
+            },
+            Err(e) => return Err(BlockSyncError::CommsInterfaceError(e)),
+        }
+        debug!(target: log_target, "Retrying mmr nodes download. Attempt {}", attempt);
+    }
+    Err(BlockSyncError::MaxRequestAttemptsReached)
+}
+
+/// Request the total merkle mountain range node count upto the specified height for the selected MMR from remote base
+/// nodes.
+pub async fn request_kernels<B: BlockchainBackend + 'static>(
+    log_target: &str,
+    shared: &mut BaseNodeStateMachine<B>,
+    sync_peers: &mut Vec<NodeId>,
+    hashes: Vec<HashOutput>,
+    request_retry_attempts: usize,
+) -> Result<(Vec<TransactionKernel>, NodeId), BlockSyncError>
+{
+    let config = shared.config.sync_peer_config;
+    for attempt in 1..=request_retry_attempts {
+        let sync_peer = select_sync_peer(&config, sync_peers)?;
+        debug!(target: log_target, "Requesting kernels from {}.", sync_peer);
+        match shared
+            .comms
+            .request_kernels_from_peer(hashes.clone(), Some(sync_peer.clone()))
+            .await
+        {
+            Ok(kernels) => {
+                return Ok((kernels, sync_peer));
+            },
+            Err(CommsInterfaceError::UnexpectedApiResponse) => {
+                debug!(target: log_target, "Remote node provided an unexpected api response.",);
+                debug!(
+                    target: log_target,
+                    "Banning peer {} from local node, because they provided an unexpected api response", sync_peer
+                );
+                ban_sync_peer(
+                    log_target,
+                    &mut shared.connectivity,
+                    sync_peers,
+                    sync_peer.clone(),
+                    config.peer_ban_duration,
+                )
+                .await?;
+            },
+            Err(CommsInterfaceError::RequestTimedOut) => {
+                debug!(
+                    target: log_target,
+                    "Failed to fetch kernels from peer: {:?}. Retrying.",
+                    CommsInterfaceError::RequestTimedOut,
+                );
+                ban_sync_peer_if_online(
+                    log_target,
+                    &mut shared.connectivity,
+                    sync_peers,
+                    sync_peer.clone(),
+                    config.short_term_peer_ban_duration,
+                )
+                .await?;
+            },
+            Err(e) => return Err(BlockSyncError::CommsInterfaceError(e)),
+        }
+        debug!(target: log_target, "Retrying kernels download. Attempt {}", attempt);
+    }
+    Err(BlockSyncError::MaxRequestAttemptsReached)
+}
+
+/// Request the total merkle mountain range node count upto the specified height for the selected MMR from remote base
+/// nodes.
+pub async fn request_txos<B: BlockchainBackend + 'static>(
+    log_target: &str,
+    shared: &mut BaseNodeStateMachine<B>,
+    sync_peers: &mut Vec<NodeId>,
+    hashes: Vec<HashOutput>,
+    request_retry_attempts: usize,
+) -> Result<(Vec<TransactionOutput>, NodeId), BlockSyncError>
+{
+    let config = shared.config.sync_peer_config;
+    for attempt in 1..=request_retry_attempts {
+        let sync_peer = select_sync_peer(&config, sync_peers)?;
+        debug!(target: log_target, "Requesting kernels from {}.", sync_peer);
+        match shared
+            .comms
+            .request_txos_from_peer(hashes.clone(), Some(sync_peer.clone()))
+            .await
+        {
+            Ok(utxos) => {
+                return Ok((utxos, sync_peer));
+            },
+            Err(CommsInterfaceError::UnexpectedApiResponse) => {
+                debug!(target: log_target, "Remote node provided an unexpected api response.",);
+                debug!(
+                    target: log_target,
+                    "Banning peer {} from local node, because they provided an unexpected api response", sync_peer
+                );
+                ban_sync_peer(
+                    log_target,
+                    &mut shared.connectivity,
+                    sync_peers,
+                    sync_peer.clone(),
+                    config.peer_ban_duration,
+                )
+                .await?;
+            },
+            Err(CommsInterfaceError::RequestTimedOut) => {
+                debug!(
+                    target: log_target,
+                    "Failed to fetch kernels from peer: {:?}. Retrying.",
+                    CommsInterfaceError::RequestTimedOut,
+                );
+                ban_sync_peer_if_online(
+                    log_target,
+                    &mut shared.connectivity,
+                    sync_peers,
+                    sync_peer.clone(),
+                    config.short_term_peer_ban_duration,
+                )
+                .await?;
+            },
+            Err(e) => return Err(BlockSyncError::CommsInterfaceError(e)),
+        }
+        debug!(target: log_target, "Retrying kernels download. Attempt {}", attempt);
+    }
+    Err(BlockSyncError::MaxRequestAttemptsReached)
+}

--- a/base_layer/core/src/base_node/states/horizon_state_sync.rs
+++ b/base_layer/core/src/base_node/states/horizon_state_sync.rs
@@ -1,0 +1,663 @@
+// Copyright 2019. The Tari Project
+//
+// Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+// following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+// disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+// following disclaimer in the documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+// products derived from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+// INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+// WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+// USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+use crate::{
+    base_node::{
+        comms_interface::CommsInterfaceError,
+        state_machine::BaseNodeStateMachine,
+        states::{
+            block_sync::BlockSyncError,
+            helpers::{
+                ban_sync_peer,
+                request_headers,
+                request_kernels,
+                request_mmr_node_count,
+                request_mmr_nodes,
+                request_txos,
+            },
+        },
+    },
+    blocks::blockheader::BlockHeader,
+    chain_storage::{async_db, BlockchainBackend, BlockchainDatabase, ChainMetadata, ChainStorageError, MmrTree},
+    transactions::{
+        transaction::{TransactionKernel, TransactionOutput},
+        types::HashOutput,
+    },
+};
+use croaring::Bitmap;
+use derive_error::Error;
+use log::*;
+use std::cmp::min;
+use tari_comms::peer_manager::NodeId;
+use tari_crypto::tari_utilities::hash::Hashable;
+
+const LOG_TARGET: &str = "c::bn::states::horizon_state_sync";
+
+// TODO: The horizon state tends to be stable, but when a pruned node was on the incorrect chain and the node was turned
+// off until its tip falls below the horizon sync height then the current horizon state sync code cannot continue as it
+// needs to delete some of the previous chain data before attempting to extend it.
+
+// The selected horizon block height might be similar to other pruned nodes resulting in spent UTXOs being discarded
+// before the horizon sync has completed. A height offset is used to help with this problem by selecting a future height
+// after the current horizon block height.
+const HORIZON_SYNC_HEIGHT_OFFSET: u64 = 50;
+// The maximum number of retry attempts a node can perform a request from remote nodes.
+const MAX_SYNC_REQUEST_RETRY_ATTEMPTS: usize = 3;
+const MAX_HEADER_REQUEST_RETRY_ATTEMPTS: usize = 5;
+const MAX_MMR_NODE_REQUEST_RETRY_ATTEMPTS: usize = 5;
+const MAX_KERNEL_REQUEST_RETRY_ATTEMPTS: usize = 5;
+const MAX_TXO_REQUEST_RETRY_ATTEMPTS: usize = 5;
+// The number of headers that can be requested in a single query.
+const HEADER_REQUEST_SIZE: usize = 100;
+// The number of MMR nodes or UTXOs that can be requested in a single query.
+const MMR_NODE_OR_UTXO_REQUEST_SIZE: usize = 1000;
+
+/// Configuration for the Horizon State Synchronization.
+#[derive(Clone, Copy)]
+pub struct HorizonSyncConfig {
+    pub horizon_sync_height_offset: u64,
+    pub max_sync_request_retry_attempts: usize,
+    pub max_header_request_retry_attempts: usize,
+    pub max_mmr_node_request_retry_attempts: usize,
+    pub max_kernel_request_retry_attempts: usize,
+    pub max_txo_request_retry_attempts: usize,
+    pub header_request_size: usize,
+    pub mmr_node_or_utxo_request_size: usize,
+}
+
+impl Default for HorizonSyncConfig {
+    fn default() -> Self {
+        Self {
+            horizon_sync_height_offset: HORIZON_SYNC_HEIGHT_OFFSET,
+            max_sync_request_retry_attempts: MAX_SYNC_REQUEST_RETRY_ATTEMPTS,
+            max_header_request_retry_attempts: MAX_HEADER_REQUEST_RETRY_ATTEMPTS,
+            max_mmr_node_request_retry_attempts: MAX_MMR_NODE_REQUEST_RETRY_ATTEMPTS,
+            max_kernel_request_retry_attempts: MAX_KERNEL_REQUEST_RETRY_ATTEMPTS,
+            max_txo_request_retry_attempts: MAX_TXO_REQUEST_RETRY_ATTEMPTS,
+            header_request_size: HEADER_REQUEST_SIZE,
+            mmr_node_or_utxo_request_size: MMR_NODE_OR_UTXO_REQUEST_SIZE,
+        }
+    }
+}
+
+#[derive(Clone, Debug, Error)]
+pub enum HorizonSyncError {
+    EmptyResponse,
+    IncorrectResponse,
+    InvalidHeader,
+    MaxSyncAttemptsReached,
+    ChainStorageError(ChainStorageError),
+    CommsInterfaceError(CommsInterfaceError),
+    BlockSyncError(BlockSyncError),
+}
+
+/// Perform a horizon state sync by syncing the headers, kernels, UTXO MMR Nodes, RangeProof MMR Nodes and UTXO set.
+pub async fn synchronize_horizon_state<B: BlockchainBackend + 'static>(
+    shared: &mut BaseNodeStateMachine<B>,
+    network_metadata: &ChainMetadata,
+    sync_peers: &mut Vec<NodeId>,
+) -> Result<(), HorizonSyncError>
+{
+    info!(target: LOG_TARGET, "Synchronizing horizon state.");
+    let local_metadata = shared.db.get_metadata()?;
+    let network_tip_height = network_metadata.height_of_longest_chain.unwrap_or(0);
+    let horizon_sync_height = select_horizon_sync_height(
+        &local_metadata,
+        network_tip_height,
+        shared.config.horizon_sync_config.horizon_sync_height_offset,
+    );
+    let local_tip_height = local_metadata.height_of_longest_chain.unwrap_or(0);
+    if local_tip_height >= horizon_sync_height {
+        trace!(
+            target: LOG_TARGET,
+            "Horizon state already synchronized, continue with block sync."
+        );
+        return Ok(());
+    }
+    trace!(
+        target: LOG_TARGET,
+        "Syncing from height {} to horizon sync height {}.",
+        local_tip_height,
+        horizon_sync_height
+    );
+
+    // During horizon state syncing the blockchain backend will be in an inconsistent state until the entire horizon
+    // state has been synced. Reset the local chain metadata will limit other nodes and local service from
+    // requesting data while the horizon sync is in progress.
+    trace!(target: LOG_TARGET, "Resetting chain metadata.");
+    reset_chain_metadata(&shared.db).await?;
+    trace!(target: LOG_TARGET, "Synchronizing headers");
+    synchronize_headers(shared, sync_peers, horizon_sync_height).await?;
+    trace!(target: LOG_TARGET, "Synchronizing kernels");
+    synchronize_kernels(shared, sync_peers, horizon_sync_height).await?;
+    trace!(target: LOG_TARGET, "Check the deletion state of current UTXOs");
+    check_state_of_current_utxos(shared, sync_peers, local_tip_height, horizon_sync_height).await?;
+    trace!(target: LOG_TARGET, "Synchronizing UTXOs and RangeProofs");
+    synchronize_utxos_and_rangeproofs(shared, sync_peers, horizon_sync_height).await?;
+    trace!(target: LOG_TARGET, "Finalizing horizon synchronizing");
+    finalize_horizon_sync(shared).await?;
+
+    Ok(())
+}
+
+// Calculate the target horizon sync height from the horizon height, network tip and a height offset.
+fn select_horizon_sync_height(
+    local_metadata: &ChainMetadata,
+    network_tip_height: u64,
+    horizon_sync_height_offset: u64,
+) -> u64
+{
+    let horizon_height = local_metadata.horizon_block(network_tip_height);
+    min(horizon_height + horizon_sync_height_offset, network_tip_height)
+}
+
+// Reset the chain metadata to the genesis block while in horizon sync mode. The chain metadata will be restored to the
+// latest data once the horizon sync has been finalized.
+async fn reset_chain_metadata<B: BlockchainBackend + 'static>(
+    db: &BlockchainDatabase<B>,
+) -> Result<(), HorizonSyncError> {
+    let genesis_header = db.fetch_header(0)?;
+    let mut metadata = db.get_metadata()?;
+    metadata.height_of_longest_chain = Some(genesis_header.height);
+    metadata.best_block = Some(genesis_header.hash());
+    metadata.accumulated_difficulty = Some(genesis_header.achieved_difficulty());
+    async_db::write_metadata(db.clone(), metadata).await?;
+    Ok(())
+}
+
+// Check the received set of headers.
+async fn validate_headers<B: BlockchainBackend + 'static>(
+    db: &BlockchainDatabase<B>,
+    block_nums: &[u64],
+    headers: &[BlockHeader],
+) -> Result<(), HorizonSyncError>
+{
+    if headers.is_empty() {
+        return Err(HorizonSyncError::EmptyResponse);
+    }
+    // Check that the received headers are the requested headers
+    if (0..block_nums.len()).any(|i| headers[i].height != block_nums[i]) {
+        return Err(HorizonSyncError::IncorrectResponse);
+    }
+    // Check that the first header is linked to the chain tip header
+    if let Some(curr_header) = headers.first() {
+        let prev_header = async_db::fetch_tip_header(db.clone()).await?;
+        if prev_header.height + 1 != curr_header.height {
+            return Err(HorizonSyncError::InvalidHeader);
+        }
+        if curr_header.prev_hash != prev_header.hash() {
+            return Err(HorizonSyncError::InvalidHeader);
+        }
+    }
+    // Check that header set forms a sequence
+    for index in 1..headers.len() {
+        let prev_header = &headers[index.saturating_sub(1)];
+        let curr_header = &headers[index];
+        if prev_header.height + 1 != curr_header.height {
+            return Err(HorizonSyncError::InvalidHeader);
+        }
+        if curr_header.prev_hash != (*prev_header).hash() {
+            return Err(HorizonSyncError::InvalidHeader);
+        }
+    }
+
+    // TODO: Check header PoW
+
+    Ok(())
+}
+
+// Synchronize headers upto the horizon sync height from remote sync peers.
+async fn synchronize_headers<B: BlockchainBackend + 'static>(
+    shared: &mut BaseNodeStateMachine<B>,
+    sync_peers: &mut Vec<NodeId>,
+    horizon_sync_height: u64,
+) -> Result<(), HorizonSyncError>
+{
+    let config = shared.config.horizon_sync_config;
+    let tip_header = shared.db.fetch_tip_header()?;
+    if tip_header.height >= horizon_sync_height {
+        return Ok(());
+    }
+
+    for block_nums in ((tip_header.height + 1)..=horizon_sync_height)
+        .collect::<Vec<u64>>()
+        .chunks(config.header_request_size)
+    {
+        for attempt in 1..=config.max_sync_request_retry_attempts {
+            let (headers, sync_peer) = request_headers(
+                LOG_TARGET,
+                shared,
+                sync_peers,
+                block_nums,
+                config.max_header_request_retry_attempts,
+            )
+            .await?;
+            match validate_headers(&shared.db, block_nums, &headers).await {
+                Ok(_) => {
+                    async_db::insert_headers(shared.db.clone(), headers).await?;
+                    trace!(
+                        target: LOG_TARGET,
+                        "Headers successfully added to database: {:?}",
+                        block_nums
+                    );
+                    break;
+                },
+                Err(HorizonSyncError::EmptyResponse) |
+                Err(HorizonSyncError::IncorrectResponse) |
+                Err(HorizonSyncError::InvalidHeader) => {
+                    warn!(target: LOG_TARGET, "Invalid headers received from peer.",);
+                    debug!(
+                        target: LOG_TARGET,
+                        "Banning peer {} from local node, because they supplied invalid headers", sync_peer
+                    );
+                    ban_sync_peer(
+                        LOG_TARGET,
+                        &mut shared.connectivity,
+                        sync_peers,
+                        sync_peer.clone(),
+                        shared.config.sync_peer_config.peer_ban_duration,
+                    )
+                    .await?;
+                },
+                Err(e) => return Err(e),
+            };
+            debug!(target: LOG_TARGET, "Retrying header sync. Attempt {}", attempt);
+            if attempt == config.max_sync_request_retry_attempts {
+                return Err(HorizonSyncError::MaxSyncAttemptsReached);
+            }
+        }
+    }
+    Ok(())
+}
+
+// Check the received set of kernels.
+fn validate_kernels(kernel_hashes: &[HashOutput], kernels: &[TransactionKernel]) -> Result<(), HorizonSyncError> {
+    if kernels.is_empty() {
+        return Err(HorizonSyncError::EmptyResponse);
+    }
+    // Check if the correct number of kernels returned
+    if kernel_hashes.len() != kernels.len() {
+        return Err(HorizonSyncError::IncorrectResponse);
+    }
+
+    // Check that kernel set is the requested kernels
+    if (0..kernel_hashes.len()).any(|i| kernels[i].hash() != kernel_hashes[i]) {
+        return Err(HorizonSyncError::IncorrectResponse);
+    }
+    Ok(())
+}
+
+// Synchronize kernels upto the horizon sync height from remote sync peers.
+async fn synchronize_kernels<B: BlockchainBackend + 'static>(
+    shared: &mut BaseNodeStateMachine<B>,
+    sync_peers: &mut Vec<NodeId>,
+    horizon_sync_height: u64,
+) -> Result<(), HorizonSyncError>
+{
+    let config = shared.config.horizon_sync_config;
+    let local_num_kernels =
+        async_db::fetch_mmr_node_count(shared.db.clone(), MmrTree::Kernel, horizon_sync_height).await?;
+    let (remote_num_kernels, sync_peer) = request_mmr_node_count(
+        LOG_TARGET,
+        shared,
+        sync_peers,
+        MmrTree::Kernel,
+        horizon_sync_height,
+        config.max_mmr_node_request_retry_attempts,
+    )
+    .await?;
+
+    if local_num_kernels >= remote_num_kernels {
+        return Ok(());
+    }
+
+    for indices in (local_num_kernels..remote_num_kernels)
+        .collect::<Vec<u32>>()
+        .chunks(config.mmr_node_or_utxo_request_size)
+    {
+        for attempt in 1..=config.max_sync_request_retry_attempts {
+            let pos = indices.first().map(Clone::clone).unwrap_or(0);
+            let count = indices.len() as u32;
+            let (kernel_hashes, _, sync_peer1) = request_mmr_nodes(
+                LOG_TARGET,
+                shared,
+                sync_peers,
+                MmrTree::Kernel,
+                pos,
+                count,
+                horizon_sync_height,
+                config.max_mmr_node_request_retry_attempts,
+            )
+            .await?;
+            let (kernels, sync_peer2) = request_kernels(
+                LOG_TARGET,
+                shared,
+                sync_peers,
+                kernel_hashes.clone(),
+                config.max_kernel_request_retry_attempts,
+            )
+            .await?;
+
+            match validate_kernels(&kernel_hashes, &kernels) {
+                Ok(_) => {
+                    async_db::insert_kernels(shared.db.clone(), kernels).await?;
+                    trace!(
+                        target: LOG_TARGET,
+                        "Kernels successfully added to database: {:?}",
+                        kernel_hashes
+                    );
+                    break;
+                },
+                Err(HorizonSyncError::EmptyResponse) | Err(HorizonSyncError::IncorrectResponse) => {
+                    warn!(target: LOG_TARGET, "Invalid kernels received from peer.",);
+                    if sync_peer1 == sync_peer2 {
+                        debug!(
+                            target: LOG_TARGET,
+                            "Banning peer {} from local node, because they supplied invalid kernels", sync_peer
+                        );
+                        ban_sync_peer(
+                            LOG_TARGET,
+                            &mut shared.connectivity,
+                            sync_peers,
+                            sync_peer.clone(),
+                            shared.config.sync_peer_config.peer_ban_duration,
+                        )
+                        .await?;
+                    }
+                },
+                Err(e) => return Err(e),
+            };
+            debug!(target: LOG_TARGET, "Retrying kernel sync. Attempt {}", attempt);
+            if attempt == config.max_sync_request_retry_attempts {
+                return Err(HorizonSyncError::MaxSyncAttemptsReached);
+            }
+        }
+    }
+    Ok(())
+}
+
+// Validate the received UTXO set and, UTXO and RangeProofs MMR nodes.
+fn validate_utxo_hashes(
+    local_utxo_hashes: &[HashOutput],
+    remote_utxo_hashes: &[HashOutput],
+) -> Result<(), HorizonSyncError>
+{
+    // Check that the correct number of utxo hashes returned
+    if local_utxo_hashes.len() != remote_utxo_hashes.len() {
+        return Err(HorizonSyncError::IncorrectResponse);
+    }
+
+    // Check that the received utxo set is the same as local
+    if (0..local_utxo_hashes.len()).any(|i| local_utxo_hashes[i] != remote_utxo_hashes[i]) {
+        return Err(HorizonSyncError::IncorrectResponse);
+    }
+
+    Ok(())
+}
+
+async fn check_state_of_current_utxos<B: BlockchainBackend + 'static>(
+    shared: &mut BaseNodeStateMachine<B>,
+    sync_peers: &mut Vec<NodeId>,
+    local_tip_height: u64,
+    horizon_sync_height: u64,
+) -> Result<(), HorizonSyncError>
+{
+    let config = shared.config.horizon_sync_config;
+    let local_num_utxo_nodes =
+        async_db::fetch_mmr_node_count(shared.db.clone(), MmrTree::Utxo, local_tip_height).await?;
+    for indices in (0..local_num_utxo_nodes)
+        .collect::<Vec<u32>>()
+        .chunks(config.mmr_node_or_utxo_request_size)
+    {
+        for attempt in 1..=config.max_sync_request_retry_attempts {
+            let pos = indices.first().map(Clone::clone).unwrap_or(0);
+            let count = indices.len() as u32;
+            let (remote_utxo_hashes, remote_utxo_deleted, _sync_peer) = request_mmr_nodes(
+                LOG_TARGET,
+                shared,
+                sync_peers,
+                MmrTree::Utxo,
+                pos,
+                count,
+                horizon_sync_height,
+                config.max_mmr_node_request_retry_attempts,
+            )
+            .await?;
+            let (local_utxo_hashes, local_utxo_bitmap_bytes) = shared
+                .local_node_interface
+                .fetch_mmr_nodes(MmrTree::Utxo, pos, count, horizon_sync_height)
+                .await?;
+            let local_utxo_deleted = Bitmap::deserialize(&local_utxo_bitmap_bytes);
+
+            match validate_utxo_hashes(&remote_utxo_hashes, &local_utxo_hashes) {
+                Ok(_) => {
+                    for (index, utxo_hash) in local_utxo_hashes.iter().enumerate() {
+                        let local_deleted = local_utxo_deleted.contains(index as u32);
+                        let remote_deleted = remote_utxo_deleted.contains(index as u32);
+                        if remote_deleted && !local_deleted {
+                            shared.db.delete_mmr_node(MmrTree::Utxo, &utxo_hash)?;
+                        }
+                    }
+                    trace!(
+                        target: LOG_TARGET,
+                        "Existing UTXOs checked and updated: {:?}",
+                        local_utxo_hashes
+                    );
+
+                    break;
+                },
+                Err(HorizonSyncError::IncorrectResponse) => {
+                    // TODO: not sure you can ban here as the local node might have the incorrect chain.
+                    warn!(target: LOG_TARGET, "Invalid UTXO hashes received from peer.",);
+                },
+                Err(e) => return Err(e),
+            };
+            debug!(target: LOG_TARGET, "Retrying UTXO state check. Attempt {}", attempt);
+            if attempt == config.max_sync_request_retry_attempts {
+                return Err(HorizonSyncError::MaxSyncAttemptsReached);
+            }
+        }
+    }
+    Ok(())
+}
+
+// Validate the received UTXO set and, UTXO and RangeProofs MMR nodes.
+fn validate_utxos_and_rps(
+    utxo_hashes: &[HashOutput],
+    rp_hashes: &[HashOutput],
+    request_utxo_hashes: &[HashOutput],
+    request_rp_hashes: &[HashOutput],
+    utxos: &[TransactionOutput],
+) -> Result<(), HorizonSyncError>
+{
+    if utxo_hashes.is_empty() | rp_hashes.is_empty() | utxos.is_empty() {
+        return Err(HorizonSyncError::EmptyResponse);
+    }
+    // Check if the same number of utxo and rp MMR nodes returned
+    if utxo_hashes.len() != rp_hashes.len() {
+        return Err(HorizonSyncError::IncorrectResponse);
+    }
+    // Check that the correct number of utxos returned
+    if request_utxo_hashes.len() != utxos.len() {
+        return Err(HorizonSyncError::IncorrectResponse);
+    }
+
+    // Check that utxo set is the requested utxos
+    if (0..request_utxo_hashes.len()).any(|i| utxos[i].hash() != request_utxo_hashes[i]) {
+        return Err(HorizonSyncError::IncorrectResponse);
+    }
+
+    // Check that utxo set matches the provided RangeProof MMR Nodes
+    if (0..request_rp_hashes.len()).any(|i| utxos[i].proof.hash() != request_rp_hashes[i]) {
+        return Err(HorizonSyncError::IncorrectResponse);
+    }
+
+    Ok(())
+}
+
+// Synchronize UTXO MMR Nodes, RangeProof MMR Nodes and the UTXO set upto the horizon sync height from remote sync
+// peers.
+async fn synchronize_utxos_and_rangeproofs<B: BlockchainBackend + 'static>(
+    shared: &mut BaseNodeStateMachine<B>,
+    sync_peers: &mut Vec<NodeId>,
+    horizon_sync_height: u64,
+) -> Result<(), HorizonSyncError>
+{
+    let config = shared.config.horizon_sync_config;
+    let local_num_utxo_nodes =
+        async_db::fetch_mmr_node_count(shared.db.clone(), MmrTree::Utxo, horizon_sync_height).await?;
+    let (remote_num_utxo_nodes, _sync_peer) = request_mmr_node_count(
+        LOG_TARGET,
+        shared,
+        sync_peers,
+        MmrTree::Utxo,
+        horizon_sync_height,
+        config.max_mmr_node_request_retry_attempts,
+    )
+    .await?;
+
+    for indices in (local_num_utxo_nodes..remote_num_utxo_nodes)
+        .collect::<Vec<u32>>()
+        .chunks(config.mmr_node_or_utxo_request_size)
+    {
+        for attempt in 1..=config.max_sync_request_retry_attempts {
+            let pos = indices.first().map(Clone::clone).unwrap_or(0);
+            let count = indices.len() as u32;
+            let (utxo_hashes, utxo_bitmap, sync_peer1) = request_mmr_nodes(
+                LOG_TARGET,
+                shared,
+                sync_peers,
+                MmrTree::Utxo,
+                pos,
+                count,
+                horizon_sync_height,
+                config.max_mmr_node_request_retry_attempts,
+            )
+            .await?;
+            let (rp_hashes, _, sync_peer2) = request_mmr_nodes(
+                LOG_TARGET,
+                shared,
+                sync_peers,
+                MmrTree::RangeProof,
+                pos,
+                count,
+                horizon_sync_height,
+                config.max_mmr_node_request_retry_attempts,
+            )
+            .await?;
+
+            // Construct the list of hashes of the UTXOs that need to be requested.
+            let mut request_utxo_hashes = Vec::<HashOutput>::new();
+            let mut request_rp_hashes = Vec::<HashOutput>::new();
+            let mut is_stxos = Vec::<bool>::new();
+            for index in 0..utxo_hashes.len() {
+                let deleted = utxo_bitmap.contains(index as u32 + 1);
+                is_stxos.push(deleted);
+                if !deleted {
+                    request_utxo_hashes.push(utxo_hashes[index].clone());
+                    request_rp_hashes.push(rp_hashes[index].clone());
+                }
+            }
+            // Download a partial UTXO set
+            let (utxos, sync_peer3) = request_txos(
+                LOG_TARGET,
+                shared,
+                sync_peers,
+                request_utxo_hashes.clone(),
+                config.max_txo_request_retry_attempts,
+            )
+            .await?;
+
+            match validate_utxos_and_rps(
+                &utxo_hashes,
+                &rp_hashes,
+                &request_utxo_hashes,
+                &request_rp_hashes,
+                &utxos,
+            ) {
+                Ok(_) => {
+                    // The order of these inserts are important to ensure the MMRs are constructed correctly and the
+                    // roots match.
+                    let mut utxos_index = 0;
+                    for (index, is_stxo) in is_stxos.into_iter().enumerate() {
+                        if is_stxo {
+                            shared
+                                .db
+                                .insert_mmr_node(MmrTree::Utxo, utxo_hashes[index].clone(), is_stxo)?;
+                            shared
+                                .db
+                                .insert_mmr_node(MmrTree::RangeProof, rp_hashes[index].clone(), false)?;
+                        } else {
+                            // Inserting the UTXO will also insert the corresponding UTXO and RangeProof MMR Nodes.
+                            shared.db.insert_utxo(utxos[utxos_index].clone())?;
+                            utxos_index += 1;
+                        }
+                    }
+                    trace!(
+                        target: LOG_TARGET,
+                        "UTXOs and MMR nodes inserted into database: {:?}",
+                        utxo_hashes
+                    );
+
+                    break;
+                },
+                Err(HorizonSyncError::EmptyResponse) | Err(HorizonSyncError::IncorrectResponse) => {
+                    warn!(target: LOG_TARGET, "Invalid UTXOs or MMR Nodes received from peer.",);
+                    if (sync_peer1 == sync_peer2) && (sync_peer1 == sync_peer3) {
+                        debug!(
+                            target: LOG_TARGET,
+                            "Banning peer {} from local node, because they supplied invalid UTXOs or MMR Nodes",
+                            sync_peer1
+                        );
+                        ban_sync_peer(
+                            LOG_TARGET,
+                            &mut shared.connectivity,
+                            sync_peers,
+                            sync_peer1.clone(),
+                            shared.config.sync_peer_config.peer_ban_duration,
+                        )
+                        .await?;
+                    }
+                },
+                Err(e) => return Err(e),
+            };
+            debug!(target: LOG_TARGET, "Retrying kernel sync. Attempt {}", attempt);
+            if attempt == config.max_sync_request_retry_attempts {
+                return Err(HorizonSyncError::MaxSyncAttemptsReached);
+            }
+        }
+    }
+    Ok(())
+}
+
+// Finalize the horizon state synchronization by setting the chain metadata to the local tip and committing the horizon
+// state to the blockchain backend.
+async fn finalize_horizon_sync<B: BlockchainBackend + 'static>(
+    shared: &mut BaseNodeStateMachine<B>,
+) -> Result<(), HorizonSyncError> {
+    // TODO: Perform final validation on full synced horizon state before committing horizon state checkpoint.
+    // TODO: Verify header and kernel set using Mmr Roots
+
+    shared.db.commit_horizon_state()?;
+
+    Ok(())
+}

--- a/base_layer/core/src/base_node/states/mod.rs
+++ b/base_layer/core/src/base_node/states/mod.rs
@@ -59,6 +59,8 @@
 mod block_sync;
 mod events_and_states;
 mod forward_block_sync;
+mod helpers;
+mod horizon_state_sync;
 mod listening;
 mod shutdown_state;
 mod starting_state;
@@ -67,6 +69,8 @@ mod waiting;
 pub use block_sync::{BestChainMetadataBlockSyncInfo, BlockSyncConfig, BlockSyncInfo, BlockSyncStrategy};
 pub use events_and_states::{BaseNodeState, StateEvent, StatusInfo, SyncStatus};
 pub use forward_block_sync::ForwardBlockSyncInfo;
+pub use helpers::SyncPeerConfig;
+pub use horizon_state_sync::{synchronize_horizon_state, HorizonSyncConfig};
 pub use listening::{ListeningData, ListeningInfo};
 pub use shutdown_state::Shutdown;
 pub use starting_state::Starting;

--- a/base_layer/core/src/chain_storage/async_db.rs
+++ b/base_layer/core/src/chain_storage/async_db.rs
@@ -91,9 +91,13 @@ macro_rules! make_async {
 }
 
 make_async!(get_metadata() -> ChainMetadata, "get_metadata");
+make_async!(write_metadata(metadata: ChainMetadata) -> (), "write_metadata");
 make_async!(fetch_kernel(hash: HashOutput) -> TransactionKernel, "fetch_kernel");
+make_async!(insert_kernels(kernels: Vec<TransactionKernel>) -> (), "insert_kernels");
 make_async!(fetch_header_with_block_hash(hash: HashOutput) -> BlockHeader, "fetch_header_with_block_hash");
 make_async!(fetch_header(block_num: u64) -> BlockHeader, "fetch_header");
+make_async!(insert_headers(headers: Vec<BlockHeader>) -> (), "insert_headers");
+make_async!(fetch_tip_header() -> BlockHeader, "fetch_header");
 make_async!(fetch_utxo(hash: HashOutput) -> TransactionOutput, "fetch_utxo");
 make_async!(fetch_stxo(hash: HashOutput) -> TransactionOutput, "fetch_stxo");
 make_async!(fetch_txo(hash: HashOutput) -> Option<TransactionOutput>, "fetch_txo");
@@ -107,7 +111,6 @@ make_async!(fetch_mmr_node_count(tree: MmrTree, height: u64) -> u32, "fetch_mmr_
 make_async!(fetch_mmr_nodes(tree: MmrTree, pos: u32, count: u32, hist_height:Option<u64>) -> Vec<(Vec<u8>, bool)>, "fetch_mmr_nodes");
 make_async!(add_block(block: Block) -> BlockAddResult, "add_block");
 make_async!(calculate_mmr_roots(template: NewBlockTemplate) -> Block, "calculate_mmr_roots");
-
 make_async!(fetch_block(height: u64) -> HistoricalBlock, "fetch_block");
 make_async!(fetch_block_with_hash(hash: HashOutput) -> Option<HistoricalBlock>, "fetch_block_with_hash");
 make_async!(block_exists(block_hash: BlockHash) -> bool, "block_exists");

--- a/base_layer/core/tests/helpers/nodes.rs
+++ b/base_layer/core/tests/helpers/nodes.rs
@@ -90,6 +90,7 @@ pub struct NodeInterfaces {
 pub struct BaseNodeBuilder {
     node_identity: Option<Arc<NodeIdentity>>,
     peers: Option<Vec<Arc<NodeIdentity>>>,
+    blockchain_db_config: Option<BlockchainDatabaseConfig>,
     base_node_service_config: Option<BaseNodeServiceConfig>,
     mmr_cache_config: Option<MmrCacheConfig>,
     mempool_config: Option<MempoolConfig>,
@@ -106,6 +107,7 @@ impl BaseNodeBuilder {
         Self {
             node_identity: None,
             peers: None,
+            blockchain_db_config: None,
             base_node_service_config: None,
             mmr_cache_config: None,
             mempool_config: None,
@@ -126,6 +128,12 @@ impl BaseNodeBuilder {
     /// Set the initial peers that will be available in the peer manager.
     pub fn with_peers(mut self, peers: Vec<Arc<NodeIdentity>>) -> Self {
         self.peers = Some(peers);
+        self
+    }
+
+    /// Set the configuration of the Blockchain db
+    pub fn with_blockchain_db_config(mut self, config: BlockchainDatabaseConfig) -> Self {
+        self.blockchain_db_config = Some(config);
         self
     }
 
@@ -189,8 +197,8 @@ impl BaseNodeBuilder {
             .consensus_manager
             .unwrap_or(ConsensusManagerBuilder::new(self.network).build());
         let db = MemoryDatabase::<HashDigest>::new(mmr_cache_config);
-        let blockchain_db =
-            BlockchainDatabase::new(db, &consensus_manager, validators, BlockchainDatabaseConfig::default()).unwrap();
+        let blockchain_db_config = self.blockchain_db_config.unwrap_or(BlockchainDatabaseConfig::default());
+        let blockchain_db = BlockchainDatabase::new(db, &consensus_manager, validators, blockchain_db_config).unwrap();
         let mempool_validator = MempoolValidators::new(TxInputAndMaturityValidator {}, TxInputAndMaturityValidator {});
         let mempool = Mempool::new(
             blockchain_db.clone(),
@@ -277,6 +285,7 @@ pub fn create_network_with_2_base_nodes(
 // Creates a network with two Base Nodes where each node in the network knows the other nodes in the network.
 pub fn create_network_with_2_base_nodes_with_config<P: AsRef<Path>>(
     runtime: &mut Runtime,
+    blockchain_db_config: BlockchainDatabaseConfig,
     base_node_service_config: BaseNodeServiceConfig,
     mmr_cache_config: MmrCacheConfig,
     mempool_service_config: MempoolServiceConfig,
@@ -290,6 +299,7 @@ pub fn create_network_with_2_base_nodes_with_config<P: AsRef<Path>>(
     let network = Network::LocalNet;
     let (alice_node, consensus_manager) = BaseNodeBuilder::new(network)
         .with_node_identity(alice_node_identity.clone())
+        .with_blockchain_db_config(blockchain_db_config)
         .with_base_node_service_config(base_node_service_config)
         .with_mmr_cache_config(mmr_cache_config)
         .with_mempool_service_config(mempool_service_config)
@@ -298,6 +308,7 @@ pub fn create_network_with_2_base_nodes_with_config<P: AsRef<Path>>(
         .start(runtime, data_path.as_ref().join("alice").as_os_str().to_str().unwrap());
     let (bob_node, consensus_manager) = BaseNodeBuilder::new(network)
         .with_node_identity(bob_node_identity)
+        .with_blockchain_db_config(blockchain_db_config)
         .with_peers(vec![alice_node_identity])
         .with_base_node_service_config(base_node_service_config)
         .with_mmr_cache_config(mmr_cache_config)
@@ -322,6 +333,7 @@ pub fn create_network_with_3_base_nodes(
     let mmr_cache_config = MmrCacheConfig { rewind_hist_len: 10 };
     create_network_with_3_base_nodes_with_config(
         runtime,
+        BlockchainDatabaseConfig::default(),
         BaseNodeServiceConfig::default(),
         mmr_cache_config,
         MempoolServiceConfig::default(),
@@ -334,6 +346,7 @@ pub fn create_network_with_3_base_nodes(
 // Creates a network with three Base Nodes where each node in the network knows the other nodes in the network.
 pub fn create_network_with_3_base_nodes_with_config<P: AsRef<Path>>(
     runtime: &mut Runtime,
+    blockchain_db_config: BlockchainDatabaseConfig,
     base_node_service_config: BaseNodeServiceConfig,
     mmr_cache_config: MmrCacheConfig,
     mempool_service_config: MempoolServiceConfig,
@@ -355,6 +368,7 @@ pub fn create_network_with_3_base_nodes_with_config<P: AsRef<Path>>(
     );
     let (carol_node, consensus_manager) = BaseNodeBuilder::new(network)
         .with_node_identity(carol_node_identity.clone())
+        .with_blockchain_db_config(blockchain_db_config)
         .with_base_node_service_config(base_node_service_config)
         .with_mmr_cache_config(mmr_cache_config)
         .with_mempool_service_config(mempool_service_config)
@@ -364,6 +378,7 @@ pub fn create_network_with_3_base_nodes_with_config<P: AsRef<Path>>(
     let (bob_node, consensus_manager) = BaseNodeBuilder::new(network)
         .with_node_identity(bob_node_identity.clone())
         .with_peers(vec![carol_node_identity.clone()])
+        .with_blockchain_db_config(blockchain_db_config)
         .with_base_node_service_config(base_node_service_config)
         .with_mmr_cache_config(mmr_cache_config)
         .with_mempool_service_config(mempool_service_config)
@@ -373,6 +388,7 @@ pub fn create_network_with_3_base_nodes_with_config<P: AsRef<Path>>(
     let (alice_node, consensus_manager) = BaseNodeBuilder::new(network)
         .with_node_identity(alice_node_identity.clone())
         .with_peers(vec![bob_node_identity.clone(), carol_node_identity.clone()])
+        .with_blockchain_db_config(blockchain_db_config)
         .with_base_node_service_config(base_node_service_config)
         .with_mmr_cache_config(mmr_cache_config)
         .with_mempool_service_config(mempool_service_config)

--- a/base_layer/core/tests/mempool.rs
+++ b/base_layer/core/tests/mempool.rs
@@ -39,6 +39,7 @@ use std::{ops::Deref, sync::Arc, time::Duration};
 use tari_comms_dht::domain_message::OutboundDomainMessage;
 use tari_core::{
     base_node::{comms_interface::Broadcast, service::BaseNodeServiceConfig},
+    chain_storage::BlockchainDatabaseConfig,
     consensus::{ConsensusConstantsBuilder, ConsensusManagerBuilder, Network},
     helpers::create_mem_db,
     mempool::{
@@ -487,6 +488,7 @@ fn request_response_get_stats() {
         .build();
     let (mut alice, bob, _consensus_manager) = create_network_with_2_base_nodes_with_config(
         &mut runtime,
+        BlockchainDatabaseConfig::default(),
         BaseNodeServiceConfig::default(),
         MmrCacheConfig { rewind_hist_len: 10 },
         MempoolServiceConfig::default(),
@@ -549,6 +551,7 @@ fn request_response_get_tx_state_with_excess_sig() {
         .build();
     let (mut alice_node, bob_node, carol_node, _consensus_manager) = create_network_with_3_base_nodes_with_config(
         &mut runtime,
+        BlockchainDatabaseConfig::default(),
         BaseNodeServiceConfig::default(),
         MmrCacheConfig { rewind_hist_len: 10 },
         MempoolServiceConfig::default(),
@@ -622,6 +625,7 @@ fn receive_and_propagate_transaction() {
         .build();
     let (mut alice_node, bob_node, carol_node, _consensus_manager) = create_network_with_3_base_nodes_with_config(
         &mut runtime,
+        BlockchainDatabaseConfig::default(),
         BaseNodeServiceConfig::default(),
         MmrCacheConfig { rewind_hist_len: 10 },
         MempoolServiceConfig::default(),
@@ -708,6 +712,7 @@ fn service_request_timeout() {
     let temp_dir = TempDir::new(string(8).as_str()).unwrap();
     let (mut alice_node, bob_node, _consensus_manager) = create_network_with_2_base_nodes_with_config(
         &mut runtime,
+        BlockchainDatabaseConfig::default(),
         BaseNodeServiceConfig::default(),
         MmrCacheConfig::default(),
         mempool_service_config,
@@ -744,6 +749,7 @@ fn block_event_and_reorg_event_handling() {
         .build();
     let (alice, mut bob, consensus_manager) = create_network_with_2_base_nodes_with_config(
         &mut runtime,
+        BlockchainDatabaseConfig::default(),
         BaseNodeServiceConfig::default(),
         MmrCacheConfig { rewind_hist_len: 10 },
         MempoolServiceConfig::default(),

--- a/base_layer/core/tests/mining.rs
+++ b/base_layer/core/tests/mining.rs
@@ -34,6 +34,7 @@ use tari_broadcast_channel::{bounded, Publisher, Subscriber};
 use tari_comms_dht::domain_message::OutboundDomainMessage;
 use tari_core::{
     base_node::{service::BaseNodeServiceConfig, states::StateEvent},
+    chain_storage::BlockchainDatabaseConfig,
     consensus::{ConsensusManagerBuilder, Network},
     mempool::{MempoolServiceConfig, TxStorageResponse},
     mining::Miner,
@@ -62,6 +63,7 @@ fn mining() {
         .build();
     let (alice_node, mut bob_node, consensus_manager) = create_network_with_2_base_nodes_with_config(
         &mut runtime,
+        BlockchainDatabaseConfig::default(),
         BaseNodeServiceConfig::default(),
         MmrCacheConfig { rewind_hist_len: 10 },
         MempoolServiceConfig::default(),

--- a/base_layer/core/tests/node_service.rs
+++ b/base_layer/core/tests/node_service.rs
@@ -53,7 +53,7 @@ use tari_core::{
         service::BaseNodeServiceConfig,
     },
     blocks::{BlockHeader, NewBlock},
-    chain_storage::{BlockAddResult, DbTransaction, MmrTree},
+    chain_storage::{BlockAddResult, BlockchainDatabaseConfig, DbTransaction, MmrTree},
     consensus::{ConsensusConstantsBuilder, ConsensusManagerBuilder, Network},
     mempool::MempoolServiceConfig,
     proof_of_work::{Difficulty, PowAlgorithm},
@@ -92,6 +92,7 @@ fn request_response_get_metadata() {
         .build();
     let (mut alice_node, bob_node, carol_node, _consensus_manager) = create_network_with_3_base_nodes_with_config(
         &mut runtime,
+        BlockchainDatabaseConfig::default(),
         BaseNodeServiceConfig::default(),
         MmrCacheConfig { rewind_hist_len: 10 },
         MempoolServiceConfig::default(),
@@ -288,6 +289,7 @@ fn request_and_response_fetch_blocks() {
         .build();
     let (mut alice_node, mut bob_node, carol_node, _) = create_network_with_3_base_nodes_with_config(
         &mut runtime,
+        BlockchainDatabaseConfig::default(),
         BaseNodeServiceConfig::default(),
         MmrCacheConfig { rewind_hist_len: 10 },
         MempoolServiceConfig::default(),
@@ -338,6 +340,7 @@ fn request_and_response_fetch_blocks_with_hashes() {
         .build();
     let (mut alice_node, mut bob_node, carol_node, _) = create_network_with_3_base_nodes_with_config(
         &mut runtime,
+        BlockchainDatabaseConfig::default(),
         BaseNodeServiceConfig::default(),
         MmrCacheConfig { rewind_hist_len: 10 },
         MempoolServiceConfig::default(),
@@ -695,6 +698,7 @@ fn service_request_timeout() {
     let temp_dir = TempDir::new(random::string(8).as_str()).unwrap();
     let (mut alice_node, bob_node, _consensus_manager) = create_network_with_2_base_nodes_with_config(
         &mut runtime,
+        BlockchainDatabaseConfig::default(),
         base_node_service_config,
         MmrCacheConfig::default(),
         MempoolServiceConfig::default(),
@@ -872,6 +876,7 @@ fn request_and_response_fetch_mmr_node_and_count() {
         .build();
     let (mut alice_node, mut bob_node, _) = create_network_with_2_base_nodes_with_config(
         &mut runtime,
+        BlockchainDatabaseConfig::default(),
         BaseNodeServiceConfig::default(),
         MmrCacheConfig::default(),
         MempoolServiceConfig::default(),

--- a/base_layer/core/tests/node_state_machine.rs
+++ b/base_layer/core/tests/node_state_machine.rs
@@ -23,6 +23,7 @@
 #[allow(dead_code)]
 mod helpers;
 
+use crate::helpers::block_builders::{append_block_with_coinbase, generate_new_block};
 use futures::StreamExt;
 use helpers::{
     block_builders::{
@@ -52,18 +53,22 @@ use tari_core::{
         states::{
             BestChainMetadataBlockSyncInfo,
             BlockSyncConfig,
+            HorizonSyncConfig,
             ListeningData,
             StateEvent,
+            SyncPeerConfig,
             SyncStatus,
             SyncStatus::Lagging,
         },
         BaseNodeStateMachine,
         BaseNodeStateMachineConfig,
     },
+    chain_storage::{BlockchainDatabaseConfig, MmrTree},
     consensus::{ConsensusConstantsBuilder, ConsensusManagerBuilder, Network},
     helpers::create_mem_db,
     mempool::MempoolServiceConfig,
-    transactions::types::CryptoFactories,
+    transactions::{tari_amount::T, transaction::TransactionOutput, types::CryptoFactories},
+    txn_schema,
     validation::{
         accum_difficulty_validators::MockAccumDifficultyValidator,
         block_validators::MockStatelessBlockValidator,
@@ -93,6 +98,7 @@ fn test_listening_lagging() {
         .build();
     let (alice_node, bob_node, consensus_manager) = create_network_with_2_base_nodes_with_config(
         &mut runtime,
+        BlockchainDatabaseConfig::default(),
         BaseNodeServiceConfig::default(),
         MmrCacheConfig::default(),
         MempoolServiceConfig::default(),
@@ -226,6 +232,7 @@ fn test_block_sync() {
         .build();
     let (alice_node, bob_node, consensus_manager) = create_network_with_2_base_nodes_with_config(
         &mut runtime,
+        BlockchainDatabaseConfig::default(),
         BaseNodeServiceConfig::default(),
         MmrCacheConfig::default(),
         MempoolServiceConfig::default(),
@@ -235,7 +242,6 @@ fn test_block_sync() {
     );
     let state_machine_config = BaseNodeStateMachineConfig {
         block_sync_config: BlockSyncConfig {
-            random_sync_peer_with_chain: true,
             max_metadata_request_retry_attempts: 3,
             max_header_request_retry_attempts: 20,
             max_block_request_retry_attempts: 20,
@@ -244,6 +250,8 @@ fn test_block_sync() {
             block_request_size: 1,
             ..Default::default()
         },
+        horizon_sync_config: HorizonSyncConfig::default(),
+        sync_peer_config: SyncPeerConfig::default(),
     };
     let shutdown = Shutdown::new();
     let mut alice_state_machine = BaseNodeStateMachine::new(
@@ -305,6 +313,7 @@ fn test_lagging_block_sync() {
         .build();
     let (alice_node, bob_node, consensus_manager) = create_network_with_2_base_nodes_with_config(
         &mut runtime,
+        BlockchainDatabaseConfig::default(),
         BaseNodeServiceConfig::default(),
         MmrCacheConfig::default(),
         MempoolServiceConfig::default(),
@@ -314,7 +323,6 @@ fn test_lagging_block_sync() {
     );
     let state_machine_config = BaseNodeStateMachineConfig {
         block_sync_config: BlockSyncConfig {
-            random_sync_peer_with_chain: true,
             max_metadata_request_retry_attempts: 3,
             max_header_request_retry_attempts: 20,
             max_block_request_retry_attempts: 20,
@@ -323,6 +331,8 @@ fn test_lagging_block_sync() {
             block_request_size: 1,
             ..Default::default()
         },
+        horizon_sync_config: HorizonSyncConfig::default(),
+        sync_peer_config: SyncPeerConfig::default(),
     };
     let shutdown = Shutdown::new();
     let mut alice_state_machine = BaseNodeStateMachine::new(
@@ -401,6 +411,7 @@ fn test_block_sync_recovery() {
         .build();
     let (alice_node, bob_node, carol_node, _) = create_network_with_3_base_nodes_with_config(
         &mut runtime,
+        BlockchainDatabaseConfig::default(),
         BaseNodeServiceConfig::default(),
         MmrCacheConfig::default(),
         MempoolServiceConfig::default(),
@@ -410,7 +421,6 @@ fn test_block_sync_recovery() {
     );
     let state_machine_config = BaseNodeStateMachineConfig {
         block_sync_config: BlockSyncConfig {
-            random_sync_peer_with_chain: true,
             max_metadata_request_retry_attempts: 3,
             max_header_request_retry_attempts: 20,
             max_block_request_retry_attempts: 20,
@@ -419,6 +429,8 @@ fn test_block_sync_recovery() {
             block_request_size: 1,
             ..Default::default()
         },
+        horizon_sync_config: HorizonSyncConfig::default(),
+        sync_peer_config: SyncPeerConfig::default(),
     };
     let shutdown = Shutdown::new();
     let mut alice_state_machine = BaseNodeStateMachine::new(
@@ -497,6 +509,7 @@ fn test_forked_block_sync() {
         .build();
     let (alice_node, bob_node, consensus_manager) = create_network_with_2_base_nodes_with_config(
         &mut runtime,
+        BlockchainDatabaseConfig::default(),
         BaseNodeServiceConfig::default(),
         MmrCacheConfig::default(),
         MempoolServiceConfig::default(),
@@ -506,7 +519,6 @@ fn test_forked_block_sync() {
     );
     let state_machine_config = BaseNodeStateMachineConfig {
         block_sync_config: BlockSyncConfig {
-            random_sync_peer_with_chain: true,
             max_metadata_request_retry_attempts: 3,
             max_header_request_retry_attempts: 20,
             max_block_request_retry_attempts: 20,
@@ -515,6 +527,8 @@ fn test_forked_block_sync() {
             block_request_size: 1,
             ..Default::default()
         },
+        horizon_sync_config: HorizonSyncConfig::default(),
+        sync_peer_config: SyncPeerConfig::default(),
     };
     let shutdown = Shutdown::new();
     let mut alice_state_machine = BaseNodeStateMachine::new(
@@ -644,7 +658,6 @@ fn test_sync_peer_banning() {
 
     let state_machine_config = BaseNodeStateMachineConfig {
         block_sync_config: BlockSyncConfig {
-            random_sync_peer_with_chain: true,
             max_metadata_request_retry_attempts: 3,
             max_header_request_retry_attempts: 20,
             max_block_request_retry_attempts: 20,
@@ -653,6 +666,8 @@ fn test_sync_peer_banning() {
             block_request_size: 1,
             ..Default::default()
         },
+        horizon_sync_config: HorizonSyncConfig::default(),
+        sync_peer_config: SyncPeerConfig::default(),
     };
     let shutdown = Shutdown::new();
     let mut alice_state_machine = BaseNodeStateMachine::new(
@@ -750,6 +765,333 @@ fn test_sync_peer_banning() {
 
         let peer = alice_peer_manager.find_by_public_key(bob_public_key).await.unwrap();
         assert_eq!(peer.is_banned(), true);
+
+        alice_node.comms.shutdown().await;
+        bob_node.comms.shutdown().await;
+    });
+}
+
+#[test]
+fn test_pruned_mode_sync_with_future_horizon_sync_height() {
+    let mut runtime = Runtime::new().unwrap();
+    let factories = CryptoFactories::default();
+    let temp_dir = TempDir::new(string(8).as_str()).unwrap();
+    let network = Network::LocalNet;
+    let consensus_constants = ConsensusConstantsBuilder::new(network)
+        .with_emission_amounts(100_000_000.into(), 0.999, 100.into())
+        .build();
+    let (mut prev_block, _) = create_genesis_block(&factories, &consensus_constants);
+    let consensus_manager = ConsensusManagerBuilder::new(network)
+        .with_consensus_constants(consensus_constants)
+        .with_block(prev_block.clone())
+        .build();
+    let blockchain_db_config = BlockchainDatabaseConfig {
+        orphan_storage_capacity: 3,
+        pruning_horizon: 4,
+        pruned_mode_cleanup_interval: 2,
+    };
+    let (alice_node, bob_node, consensus_manager) = create_network_with_2_base_nodes_with_config(
+        &mut runtime,
+        blockchain_db_config,
+        BaseNodeServiceConfig::default(),
+        MmrCacheConfig::default(),
+        MempoolServiceConfig::default(),
+        LivenessConfig::default(),
+        consensus_manager,
+        temp_dir.path().to_str().unwrap(),
+    );
+    let mut horizon_sync_config = HorizonSyncConfig::default();
+    horizon_sync_config.horizon_sync_height_offset = 2;
+    let state_machine_config = BaseNodeStateMachineConfig {
+        block_sync_config: BlockSyncConfig::default(),
+        horizon_sync_config,
+        sync_peer_config: SyncPeerConfig::default(),
+    };
+    let shutdown = Shutdown::new();
+    let mut alice_state_machine = BaseNodeStateMachine::new(
+        &alice_node.blockchain_db,
+        &alice_node.local_nci,
+        &alice_node.outbound_nci,
+        alice_node.comms.peer_manager(),
+        alice_node.comms.connectivity(),
+        alice_node.chain_metadata_handle.get_event_stream(),
+        state_machine_config,
+        shutdown.to_signal(),
+    );
+
+    runtime.block_on(async {
+        let alice_db = &alice_node.blockchain_db;
+        let bob_db = &bob_node.blockchain_db;
+        for _ in 1..10 {
+            // Need coinbases for kernels and utxos
+            prev_block =
+                append_block_with_coinbase(&factories, bob_db, &prev_block, vec![], &consensus_manager, 1.into())
+                    .unwrap();
+        }
+
+        // Both nodes are running in pruned mode and can not use block sync to synchronize state. Sync horizon state
+        // from genesis block to horizon_sync_height and then block sync to the tip.
+        let network_tip = bob_db.get_metadata().unwrap();
+        let mut sync_peers = vec![bob_node.node_identity.node_id().clone()];
+        let state_event = BestChainMetadataBlockSyncInfo {}
+            .next_event(&mut alice_state_machine, &network_tip, &mut sync_peers)
+            .await;
+        assert_eq!(state_event, StateEvent::BlocksSynchronized);
+        let alice_metadata = alice_db.get_metadata().unwrap();
+        assert_eq!(alice_metadata, network_tip);
+
+        // Check headers
+        let network_tip_height = network_tip.height_of_longest_chain.unwrap_or(0);
+        let block_nums = (0..=network_tip_height).collect::<Vec<u64>>();
+        let alice_headers = alice_db.fetch_headers(block_nums.clone()).unwrap();
+        let bob_headers = bob_db.fetch_headers(block_nums).unwrap();
+        assert_eq!(alice_headers, bob_headers);
+        // Check Kernel MMR nodes
+        let alice_num_kernels = alice_db
+            .fetch_mmr_node_count(MmrTree::Kernel, network_tip_height)
+            .unwrap();
+        let bob_num_kernels = bob_db
+            .fetch_mmr_node_count(MmrTree::Kernel, network_tip_height)
+            .unwrap();
+        assert_eq!(alice_num_kernels, bob_num_kernels);
+        let alice_kernel_nodes = alice_db
+            .fetch_mmr_nodes(MmrTree::Kernel, 0, alice_num_kernels, Some(network_tip_height))
+            .unwrap();
+        let bob_kernel_nodes = bob_db
+            .fetch_mmr_nodes(MmrTree::Kernel, 0, bob_num_kernels, Some(network_tip_height))
+            .unwrap();
+        assert_eq!(alice_kernel_nodes, bob_kernel_nodes);
+        // Check Kernels
+        let alice_kernel_hashes = alice_kernel_nodes.iter().map(|n| n.0.clone()).collect::<Vec<_>>();
+        let bob_kernels_hashes = bob_kernel_nodes.iter().map(|n| n.0.clone()).collect::<Vec<_>>();
+        let alice_kernels = alice_db.fetch_kernels(alice_kernel_hashes).unwrap();
+        let bob_kernels = bob_db.fetch_kernels(bob_kernels_hashes).unwrap();
+        assert_eq!(alice_kernels, bob_kernels);
+        // Check UTXO MMR nodes
+        let alice_num_utxos = alice_db
+            .fetch_mmr_node_count(MmrTree::Utxo, network_tip_height)
+            .unwrap();
+        let bob_num_utxos = bob_db.fetch_mmr_node_count(MmrTree::Utxo, network_tip_height).unwrap();
+        assert_eq!(alice_num_utxos, bob_num_utxos);
+        let alice_utxo_nodes = alice_db
+            .fetch_mmr_nodes(MmrTree::Utxo, 0, alice_num_utxos, Some(network_tip_height))
+            .unwrap();
+        let bob_utxo_nodes = bob_db
+            .fetch_mmr_nodes(MmrTree::Utxo, 0, bob_num_utxos, Some(network_tip_height))
+            .unwrap();
+        assert_eq!(alice_utxo_nodes, bob_utxo_nodes);
+        // Check RangeProof MMR nodes
+        let alice_num_rps = alice_db
+            .fetch_mmr_node_count(MmrTree::RangeProof, network_tip_height)
+            .unwrap();
+        let bob_num_rps = bob_db
+            .fetch_mmr_node_count(MmrTree::RangeProof, network_tip_height)
+            .unwrap();
+        assert_eq!(alice_num_rps, bob_num_rps);
+        let alice_rps_nodes = alice_db
+            .fetch_mmr_nodes(MmrTree::RangeProof, 0, alice_num_rps, Some(network_tip_height))
+            .unwrap();
+        let bob_rps_nodes = bob_db
+            .fetch_mmr_nodes(MmrTree::RangeProof, 0, bob_num_rps, Some(network_tip_height))
+            .unwrap();
+        assert_eq!(alice_rps_nodes, bob_rps_nodes);
+        // Check UTXOs
+        let mut alice_utxos = Vec::<TransactionOutput>::new();
+        for (hash, deleted) in alice_utxo_nodes {
+            if !deleted {
+                alice_utxos.push(alice_db.fetch_utxo(hash).unwrap());
+            }
+        }
+        let mut bob_utxos = Vec::<TransactionOutput>::new();
+        for (hash, deleted) in bob_utxo_nodes {
+            if !deleted {
+                bob_utxos.push(bob_db.fetch_utxo(hash).unwrap());
+            }
+        }
+        assert_eq!(alice_utxos, bob_utxos);
+
+        alice_node.comms.shutdown().await;
+        bob_node.comms.shutdown().await;
+    });
+}
+
+#[test]
+fn test_pruned_mode_sync_with_spent_utxos() {
+    let mut runtime = Runtime::new().unwrap();
+    let factories = CryptoFactories::default();
+    let temp_dir = TempDir::new(string(8).as_str()).unwrap();
+    let network = Network::LocalNet;
+    let consensus_constants = ConsensusConstantsBuilder::new(network)
+        .with_emission_amounts(100_000_000.into(), 0.999, 100.into())
+        .build();
+    let (block0, output) = create_genesis_block(&factories, &consensus_constants);
+    let consensus_manager = ConsensusManagerBuilder::new(network)
+        .with_consensus_constants(consensus_constants)
+        .with_block(block0.clone())
+        .build();
+    let blockchain_db_config = BlockchainDatabaseConfig {
+        orphan_storage_capacity: 3,
+        pruning_horizon: 4,
+        pruned_mode_cleanup_interval: 2,
+    };
+    let (alice_node, mut bob_node, consensus_manager) = create_network_with_2_base_nodes_with_config(
+        &mut runtime,
+        blockchain_db_config,
+        BaseNodeServiceConfig::default(),
+        MmrCacheConfig::default(),
+        MempoolServiceConfig::default(),
+        LivenessConfig::default(),
+        consensus_manager,
+        temp_dir.path().to_str().unwrap(),
+    );
+    let mut horizon_sync_config = HorizonSyncConfig::default();
+    horizon_sync_config.horizon_sync_height_offset = 0;
+    let state_machine_config = BaseNodeStateMachineConfig {
+        block_sync_config: BlockSyncConfig::default(),
+        horizon_sync_config,
+        sync_peer_config: SyncPeerConfig::default(),
+    };
+    let shutdown = Shutdown::new();
+    let mut alice_state_machine = BaseNodeStateMachine::new(
+        &alice_node.blockchain_db,
+        &alice_node.local_nci,
+        &alice_node.outbound_nci,
+        alice_node.comms.peer_manager(),
+        alice_node.comms.connectivity(),
+        alice_node.chain_metadata_handle.get_event_stream(),
+        state_machine_config,
+        shutdown.to_signal(),
+    );
+
+    runtime.block_on(async {
+        let mut blocks = vec![block0];
+        let mut outputs = vec![vec![output]];
+        // Block1
+        let txs = vec![txn_schema!(
+            from: vec![outputs[0][0].clone()],
+            to: vec![10 * T, 10 * T, 10 * T, 10 * T]
+        )];
+        assert!(generate_new_block(
+            &mut bob_node.blockchain_db,
+            &mut blocks,
+            &mut outputs,
+            txs,
+            &consensus_manager.consensus_constants()
+        )
+        .is_ok());
+        // Block2
+        let txs = vec![txn_schema!(from: vec![outputs[1][3].clone()], to: vec![6 * T])];
+        assert!(generate_new_block(
+            &mut bob_node.blockchain_db,
+            &mut blocks,
+            &mut outputs,
+            txs,
+            &consensus_manager.consensus_constants()
+        )
+        .is_ok());
+        // Block3
+        let txs = vec![txn_schema!(from: vec![outputs[2][0].clone()], to: vec![2 * T])];
+        assert!(generate_new_block(
+            &mut bob_node.blockchain_db,
+            &mut blocks,
+            &mut outputs,
+            txs,
+            &consensus_manager.consensus_constants()
+        )
+        .is_ok());
+        // Block4
+        let txs = vec![txn_schema!(from: vec![outputs[1][0].clone()], to: vec![2 * T])];
+        assert!(generate_new_block(
+            &mut bob_node.blockchain_db,
+            &mut blocks,
+            &mut outputs,
+            txs,
+            &consensus_manager.consensus_constants()
+        )
+        .is_ok());
+
+        // Both nodes are running in pruned mode and can not use block sync to synchronize state. Sync horizon state
+        // from genesis block to horizon_sync_height and then block sync to the tip.
+        let alice_db = &alice_node.blockchain_db;
+        let bob_db = &bob_node.blockchain_db;
+        let network_tip = bob_db.get_metadata().unwrap();
+        let mut sync_peers = vec![bob_node.node_identity.node_id().clone()];
+        let state_event = BestChainMetadataBlockSyncInfo {}
+            .next_event(&mut alice_state_machine, &network_tip, &mut sync_peers)
+            .await;
+        assert_eq!(state_event, StateEvent::BlocksSynchronized);
+        let alice_metadata = alice_db.get_metadata().unwrap();
+        assert_eq!(alice_metadata, network_tip);
+
+        // Check headers
+        let network_tip_height = network_tip.height_of_longest_chain.unwrap_or(0);
+        let block_nums = (0..=network_tip_height).collect::<Vec<u64>>();
+        let alice_headers = alice_db.fetch_headers(block_nums.clone()).unwrap();
+        let bob_headers = bob_db.fetch_headers(block_nums).unwrap();
+        assert_eq!(alice_headers, bob_headers);
+        // Check Kernel MMR nodes
+        let alice_num_kernels = alice_db
+            .fetch_mmr_node_count(MmrTree::Kernel, network_tip_height)
+            .unwrap();
+        let bob_num_kernels = bob_db
+            .fetch_mmr_node_count(MmrTree::Kernel, network_tip_height)
+            .unwrap();
+        assert_eq!(alice_num_kernels, bob_num_kernels);
+        let alice_kernel_nodes = alice_db
+            .fetch_mmr_nodes(MmrTree::Kernel, 0, alice_num_kernels, Some(network_tip_height))
+            .unwrap();
+        let bob_kernel_nodes = bob_db
+            .fetch_mmr_nodes(MmrTree::Kernel, 0, bob_num_kernels, Some(network_tip_height))
+            .unwrap();
+        assert_eq!(alice_kernel_nodes, bob_kernel_nodes);
+        // Check Kernels
+        let alice_kernel_hashes = alice_kernel_nodes.iter().map(|n| n.0.clone()).collect::<Vec<_>>();
+        let bob_kernels_hashes = bob_kernel_nodes.iter().map(|n| n.0.clone()).collect::<Vec<_>>();
+        let alice_kernels = alice_db.fetch_kernels(alice_kernel_hashes).unwrap();
+        let bob_kernels = bob_db.fetch_kernels(bob_kernels_hashes).unwrap();
+        assert_eq!(alice_kernels, bob_kernels);
+        // Check UTXO MMR nodes
+        let alice_num_utxos = alice_db
+            .fetch_mmr_node_count(MmrTree::Utxo, network_tip_height)
+            .unwrap();
+        let bob_num_utxos = bob_db.fetch_mmr_node_count(MmrTree::Utxo, network_tip_height).unwrap();
+        assert_eq!(alice_num_utxos, bob_num_utxos);
+        let alice_utxo_nodes = alice_db
+            .fetch_mmr_nodes(MmrTree::Utxo, 0, alice_num_utxos, Some(network_tip_height))
+            .unwrap();
+        let bob_utxo_nodes = bob_db
+            .fetch_mmr_nodes(MmrTree::Utxo, 0, bob_num_utxos, Some(network_tip_height))
+            .unwrap();
+        assert_eq!(alice_utxo_nodes, bob_utxo_nodes);
+        // Check RangeProof MMR nodes
+        let alice_num_rps = alice_db
+            .fetch_mmr_node_count(MmrTree::RangeProof, network_tip_height)
+            .unwrap();
+        let bob_num_rps = bob_db
+            .fetch_mmr_node_count(MmrTree::RangeProof, network_tip_height)
+            .unwrap();
+        assert_eq!(alice_num_rps, bob_num_rps);
+        let alice_rps_nodes = alice_db
+            .fetch_mmr_nodes(MmrTree::RangeProof, 0, alice_num_rps, Some(network_tip_height))
+            .unwrap();
+        let bob_rps_nodes = bob_db
+            .fetch_mmr_nodes(MmrTree::RangeProof, 0, bob_num_rps, Some(network_tip_height))
+            .unwrap();
+        assert_eq!(alice_rps_nodes, bob_rps_nodes);
+        // Check UTXOs
+        let mut alice_utxos = Vec::<TransactionOutput>::new();
+        for (hash, deleted) in alice_utxo_nodes {
+            if !deleted {
+                alice_utxos.push(alice_db.fetch_utxo(hash).unwrap());
+            }
+        }
+        let mut bob_utxos = Vec::<TransactionOutput>::new();
+        for (hash, deleted) in bob_utxo_nodes {
+            if !deleted {
+                bob_utxos.push(bob_db.fetch_utxo(hash).unwrap());
+            }
+        }
+        assert_eq!(alice_utxos, bob_utxos);
 
         alice_node.comms.shutdown().await;
         bob_node.comms.shutdown().await;


### PR DESCRIPTION
## Description
- Added functionality to determine if horizon syncing should be performed and to synchronize header, kernels, utxos, utxo mmr nodes, range proof mmr nodes and check the state of the current utxos set.
- Fixed an issue in the lmdb_db and mermory_db where the fetch_mmr_nodes_added_count was calculating the checkpoint index incorrectly from the height.
- Additional async db calls were added and used in the horizon sync system.
- Added chain data request functions for requesting kernels, txos, mmr node counts and mmr nodes
- Moved reused peer banning and chain data request functions from BlockSync to helpers.
- Moved the state machine configuration of the sync peers to SyncPeerConfig as the block sync and horizon sync will make use of these configurations.
- Added HorizonSyncConfig to BaseNodeStateMachineConfig for configuring the horizon sync system.
- Added the BlockchainDatabaseConfig to the test base node builder to enable testing of pruned nodes
- Added the fetch_mmr_nodes request to the local base node interface.

## Motivation and Context
These changes add horizon state syncing allowing pruned nodes to download the horizon state instead of individual blocks. Once the horizon sync height has been reached then block sync is used to sync to the chain tip. 

## How Has This Been Tested?
- Added the test_pruned_mode_sync_with_future_horizon_sync_height to test horizon state syncing and block syncing when a height offset is used.
- Added the test_pruned_mode_sync_with_spent_utxos test to check the horizon state syncing including deleted utxos and existing utxos that need to be updated.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [x] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [x] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [x] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch.
* [x] I ran `cargo-fmt --all` before pushing.
* [x] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
