### PR TITLE
Refactor UXTO Validation in Output Manager into async protocol

### DIFF
--- a/base_layer/wallet/Cargo.toml
+++ b/base_layer/wallet/Cargo.toml
@@ -11,7 +11,6 @@ test_harness = ["tari_test_utils"]
 c_integration = []
 
 [dependencies]
-tari_broadcast_channel = "^0.2"
 tari_comms = { path = "../../comms", version = "^0.1"}
 tari_comms_dht = { path = "../../comms/dht", version = "^0.1"}
 tari_crypto = { version = "^0.3" }

--- a/base_layer/wallet/src/output_manager_service/error.rs
+++ b/base_layer/wallet/src/output_manager_service/error.rs
@@ -66,6 +66,11 @@ pub enum OutputManagerError {
     NoBaseNodeKeysProvided,
     /// An error occured sending an event out on the event stream
     EventStreamError,
+    /// Maximum Attempts Exceeded
+    MaximumAttemptsExceeded,
+    /// An error has been experienced in the service
+    #[error(msg_embedded, non_std, no_from)]
+    ServiceError(String),
 }
 
 #[derive(Debug, Error, PartialEq)]
@@ -88,6 +93,7 @@ pub enum OutputManagerStorageError {
     OutputAlreadySpent,
     /// Key Manager not initialized
     KeyManagerNotInitialized,
+
     OutOfRangeError(OutOfRangeError),
     R2d2Error,
     TransactionError(TransactionError),
@@ -97,4 +103,24 @@ pub enum OutputManagerStorageError {
     DatabaseMigrationError(String),
     #[error(msg_embedded, non_std, no_from)]
     BlockingTaskSpawnError(String),
+}
+
+/// This error type is used to return OutputManagerError from inside a Output Manager Service protocol but also
+/// include the ID of the protocol
+#[derive(Debug)]
+pub struct OutputManagerProtocolError {
+    pub id: u64,
+    pub error: OutputManagerError,
+}
+
+impl OutputManagerProtocolError {
+    pub fn new(id: u64, error: OutputManagerError) -> Self {
+        Self { id, error }
+    }
+}
+
+impl From<OutputManagerProtocolError> for OutputManagerError {
+    fn from(tspe: OutputManagerProtocolError) -> Self {
+        tspe.error
+    }
 }

--- a/base_layer/wallet/src/output_manager_service/protocols/mod.rs
+++ b/base_layer/wallet/src/output_manager_service/protocols/mod.rs
@@ -1,0 +1,23 @@
+// Copyright 2020. The Tari Project
+//
+// Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+// following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+// disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+// following disclaimer in the documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+// products derived from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+// INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+// WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+// USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+pub mod utxo_validation_protocol;

--- a/base_layer/wallet/src/output_manager_service/protocols/utxo_validation_protocol.rs
+++ b/base_layer/wallet/src/output_manager_service/protocols/utxo_validation_protocol.rs
@@ -1,0 +1,497 @@
+// Copyright 2020. The Tari Project
+//
+// Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+// following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+// disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+// following disclaimer in the documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+// products derived from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+// INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+// WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+// USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+use crate::output_manager_service::{
+    error::{OutputManagerError, OutputManagerProtocolError},
+    handle::OutputManagerEvent,
+    service::OutputManagerResources,
+    storage::{database::OutputManagerBackend, models::DbUnblindedOutput},
+};
+use futures::{FutureExt, StreamExt};
+use log::*;
+use rand::{rngs::OsRng, RngCore};
+use std::{cmp, collections::HashMap, convert::TryFrom, fmt, sync::Arc, time::Duration};
+use tari_comms::types::CommsPublicKey;
+use tari_comms_dht::domain_message::OutboundDomainMessage;
+use tari_core::{
+    base_node::proto::{
+        base_node as BaseNodeProto,
+        base_node::{
+            base_node_service_request::Request as BaseNodeRequestProto,
+            base_node_service_response::Response as BaseNodeResponseProto,
+        },
+    },
+    transactions::transaction::TransactionOutput,
+};
+use tari_crypto::tari_utilities::{hash::Hashable, hex::Hex};
+use tari_p2p::tari_message::TariMessageType;
+use tokio::{sync::broadcast, time::delay_for};
+
+const LOG_TARGET: &str = "wallet::output_manager_service::protocols::utxo_validation_protocol";
+
+pub struct UtxoValidationProtocol<TBackend>
+where TBackend: OutputManagerBackend + Clone + 'static
+{
+    id: u64,
+    validation_type: UtxoValidationType,
+    retry_strategy: UtxoValidationRetry,
+    resources: OutputManagerResources<TBackend>,
+    base_node_public_key: CommsPublicKey,
+    timeout: Duration,
+    base_node_response_receiver: Option<broadcast::Receiver<Arc<BaseNodeProto::BaseNodeServiceResponse>>>,
+    pending_queries: HashMap<u64, Vec<Vec<u8>>>,
+}
+
+/// This protocol defines the process of submitting our current UTXO set to the Base Node to validate it.
+impl<TBackend> UtxoValidationProtocol<TBackend>
+where TBackend: OutputManagerBackend + Clone + 'static
+{
+    pub fn new(
+        id: u64,
+        validation_type: UtxoValidationType,
+        retry_strategy: UtxoValidationRetry,
+        resources: OutputManagerResources<TBackend>,
+        base_node_public_key: CommsPublicKey,
+        timeout: Duration,
+        base_node_response_receiver: broadcast::Receiver<Arc<BaseNodeProto::BaseNodeServiceResponse>>,
+    ) -> Self
+    {
+        Self {
+            id,
+            validation_type,
+            retry_strategy,
+            resources,
+            base_node_public_key,
+            timeout,
+            base_node_response_receiver: Some(base_node_response_receiver),
+            pending_queries: Default::default(),
+        }
+    }
+
+    /// The task that defines the execution of the protocol.
+    pub async fn execute(mut self) -> Result<u64, OutputManagerProtocolError> {
+        let mut base_node_response_receiver = self
+            .base_node_response_receiver
+            .take()
+            .ok_or_else(|| {
+                OutputManagerProtocolError::new(
+                    self.id,
+                    OutputManagerError::ServiceError("No base node response channel provided".to_string()),
+                )
+            })?
+            .fuse();
+
+        trace!(
+            target: LOG_TARGET,
+            "Starting UTXO validation protocol (Id: {}) for {}",
+            self.id,
+            self.validation_type,
+        );
+
+        let outputs_to_query: Vec<Vec<u8>> = match self.validation_type {
+            UtxoValidationType::Unspent => self
+                .resources
+                .db
+                .get_unspent_outputs()
+                .await
+                .map_err(|e| {
+                    OutputManagerProtocolError::new(self.id, OutputManagerError::OutputManagerStorageError(e))
+                })?
+                .iter()
+                .map(|uo| uo.hash.clone())
+                .collect(),
+            UtxoValidationType::Invalid => self
+                .resources
+                .db
+                .get_invalid_outputs()
+                .await
+                .map_err(|e| {
+                    OutputManagerProtocolError::new(self.id, OutputManagerError::OutputManagerStorageError(e))
+                })?
+                .into_iter()
+                .map(|uo| uo.hash)
+                .collect(),
+        };
+
+        if outputs_to_query.is_empty() {
+            trace!(
+                target: LOG_TARGET,
+                "UTXO validation protocol (Id: {}) has no outputs to validate",
+                self.id,
+            );
+            return Ok(self.id);
+        }
+
+        let total_retries_str = match self.retry_strategy {
+            UtxoValidationRetry::Limited(n) => format!("{}", n),
+            UtxoValidationRetry::UntilSuccess => "∞".to_string(),
+        };
+
+        let mut retries = 0;
+        loop {
+            self.send_queries(outputs_to_query.clone()).await?;
+
+            let mut delay = delay_for(self.timeout).fuse();
+
+            loop {
+                futures::select! {
+                    base_node_response = base_node_response_receiver.select_next_some() => {
+                        match base_node_response {
+                            Ok(response) => if self.handle_base_node_response(response).await? {
+                            error!(target: LOG_TARGET, "Response handled with success for {} and pending_queries len: {}", self.id, self.pending_queries.len());
+                                if self.pending_queries.is_empty() {
+                                    let _ = self
+                                        .resources
+                                        .event_publisher
+                                        .send(OutputManagerEvent::UtxoValidationSuccess(self.id))
+                                        .map_err(|e| {
+                                           trace!(
+                                                target: LOG_TARGET,
+                                                "Error sending event {:?}, because there are no subscribers.",
+                                                e.0
+                                            );
+                                            e
+                                        });
+                                    return Ok(self.id);
+                                }
+                            },
+                            Err(e) => trace!(target: LOG_TARGET, "Error reading broadcast base_node_response: {:?}", e),
+                        }
+
+                    },
+                    () = delay => {
+                        break;
+                    },
+                }
+            }
+
+            info!(
+                target: LOG_TARGET,
+                "UTXO Validation protocol (Id: {}) attempt {} out of {} timed out.",
+                self.id,
+                retries + 1,
+                total_retries_str
+            );
+
+            let _ = self
+                .resources
+                .event_publisher
+                .send(OutputManagerEvent::UtxoValidationTimedOut(self.id))
+                .map_err(|e| {
+                    trace!(
+                        target: LOG_TARGET,
+                        "Error sending event {:?}, because there are no subscribers.",
+                        e.0
+                    );
+                    e
+                });
+
+            retries += 1;
+            match self.retry_strategy {
+                UtxoValidationRetry::Limited(n) => {
+                    if retries >= n {
+                        break;
+                    }
+                },
+                UtxoValidationRetry::UntilSuccess => (),
+            }
+
+            self.pending_queries.clear();
+        }
+
+        info!(
+            target: LOG_TARGET,
+            "Maximum attempts exceeded for UTXO Validation Protocol (Id: {})", self.id
+        );
+        Err(OutputManagerProtocolError::new(
+            self.id,
+            OutputManagerError::MaximumAttemptsExceeded,
+        ))
+    }
+
+    async fn send_queries(&mut self, mut outputs_to_query: Vec<Vec<u8>>) -> Result<(), OutputManagerProtocolError> {
+        // Determine how many rounds of base node request we need to query all the outputs in batches of
+        // max_utxo_query_size
+        let rounds =
+            ((outputs_to_query.len() as f32) / (self.resources.config.max_utxo_query_size as f32 + 0.1)) as usize + 1;
+
+        for r in 0..rounds {
+            let mut output_hashes = Vec::new();
+            for uo_hash in
+                outputs_to_query.drain(..cmp::min(self.resources.config.max_utxo_query_size, outputs_to_query.len()))
+            {
+                output_hashes.push(uo_hash);
+            }
+
+            let request_key = if r == 0 { self.id } else { OsRng.next_u64() };
+
+            let request = BaseNodeRequestProto::FetchUtxos(BaseNodeProto::HashOutputs {
+                outputs: output_hashes.clone(),
+            });
+
+            let service_request = BaseNodeProto::BaseNodeServiceRequest {
+                request_key,
+                request: Some(request),
+            };
+
+            let send_message_response = self
+                .resources
+                .outbound_message_service
+                .send_direct(
+                    self.base_node_public_key.clone(),
+                    OutboundDomainMessage::new(TariMessageType::BaseNodeRequest, service_request),
+                )
+                .await
+                .map_err(|e| OutputManagerProtocolError::new(self.id, OutputManagerError::from(e)))?;
+
+            // Here we are going to spawn a non-blocking task that will monitor and log the progress of the
+            // send process.
+            tokio::spawn(async move {
+                match send_message_response.resolve().await {
+                    Err(e) => trace!(
+                        target: LOG_TARGET,
+                        "Failed to send Output Manager UTXO query ({}) to Base Node: {}",
+                        request_key,
+                        e
+                    ),
+                    Ok(send_states) => {
+                        trace!(
+                            target: LOG_TARGET,
+                            "Output Manager UTXO query ({}) queued for sending with Message {}",
+                            request_key,
+                            send_states[0].tag,
+                        );
+                        let message_tag = send_states[0].tag;
+                        if send_states.wait_single().await {
+                            trace!(
+                                target: LOG_TARGET,
+                                "Output Manager UTXO query ({}) successfully sent to Base Node with Message {}",
+                                request_key,
+                                message_tag,
+                            )
+                        } else {
+                            trace!(
+                                target: LOG_TARGET,
+                                "Failed to send Output Manager UTXO query ({}) to Base Node with Message {}",
+                                request_key,
+                                message_tag,
+                            );
+                        }
+                    },
+                }
+            });
+
+            self.pending_queries.insert(request_key, output_hashes);
+
+            info!(
+                target: LOG_TARGET,
+                "Output Manager {} query (Id: {}) sent to Base Node, part {} of {} requests",
+                self.validation_type,
+                request_key,
+                r + 1,
+                rounds
+            );
+        }
+
+        Ok(())
+    }
+
+    async fn handle_base_node_response(
+        &mut self,
+        response: Arc<BaseNodeProto::BaseNodeServiceResponse>,
+    ) -> Result<bool, OutputManagerProtocolError>
+    {
+        let request_key = response.request_key;
+
+        let queried_hashes = if let Some(hashes) = self.pending_queries.remove(&request_key) {
+            hashes
+        } else {
+            trace!(
+                target: LOG_TARGET,
+                "Base Node Response (Id: {}) not expected for UTXO Validation protocol {}",
+                request_key,
+                self.id
+            );
+            return Ok(false);
+        };
+
+        trace!(
+            target: LOG_TARGET,
+            "Handling a Base Node Response for {} request (Id: {}) for UTXO Validation protocol {}",
+            self.validation_type,
+            request_key,
+            self.id
+        );
+
+        let response: Vec<tari_core::transactions::proto::types::TransactionOutput> = match (*response).clone().response
+        {
+            Some(BaseNodeResponseProto::TransactionOutputs(outputs)) => outputs.outputs,
+            _ => {
+                return Err(OutputManagerProtocolError::new(
+                    self.id,
+                    OutputManagerError::InvalidResponseError("Base Node Response of unexpected variant".to_string()),
+                ));
+            },
+        };
+
+        match self.validation_type {
+            UtxoValidationType::Unspent => {
+                // Construct a HashMap of all the unspent outputs
+                let unspent_outputs: Vec<DbUnblindedOutput> =
+                    self.resources.db.get_unspent_outputs().await.map_err(|e| {
+                        OutputManagerProtocolError::new(self.id, OutputManagerError::OutputManagerStorageError(e))
+                    })?;
+
+                // We only want to check outputs that we were expecting and are still valid
+                let mut output_hashes = HashMap::new();
+                for uo in unspent_outputs.iter() {
+                    let hash = uo.hash.clone();
+                    if queried_hashes.iter().any(|h| &hash == h) {
+                        output_hashes.insert(hash, uo.clone());
+                    }
+                }
+
+                // Go through all the returned UTXOs and if they are in the hashmap remove them
+                for output in response.iter() {
+                    let response_hash = TransactionOutput::try_from(output.clone())
+                        .map_err(|_| {
+                            OutputManagerProtocolError::new(
+                                self.id,
+                                OutputManagerError::ConversionError(
+                                    "Could not convert protobuf TransactionOutput".to_string(),
+                                ),
+                            )
+                        })?
+                        .hash();
+
+                    let _ = output_hashes.remove(&response_hash);
+                }
+
+                // If there are any remaining Unspent Outputs we will move them to the invalid collection
+                for (_k, v) in output_hashes {
+                    // Get the transaction these belonged to so we can display the kernel signature of the transaction
+                    // this output belonged to.
+
+                    warn!(
+                        target: LOG_TARGET,
+                        "Output with value {} not returned from Base Node query ({}) and is thus being invalidated",
+                        v.unblinded_output.value,
+                        request_key,
+                    );
+                    // If the output that is being invalidated has an associated TxId then get the kernel signature of
+                    // the transaction and display for easier debugging
+                    if let Some(tx_id) = self.resources.db.invalidate_output(v).await.map_err(|e| {
+                        OutputManagerProtocolError::new(self.id, OutputManagerError::OutputManagerStorageError(e))
+                    })? {
+                        if let Ok(transaction) = self
+                            .resources
+                            .transaction_service
+                            .get_completed_transaction(tx_id)
+                            .await
+                        {
+                            info!(
+                                target: LOG_TARGET,
+                                "Invalidated Output is from Transaction (TxId: {}) with message: {} and Kernel \
+                                 Signature: {}",
+                                transaction.tx_id,
+                                transaction.message,
+                                transaction.transaction.body.kernels()[0]
+                                    .excess_sig
+                                    .get_signature()
+                                    .to_hex()
+                            )
+                        }
+                    } else {
+                        info!(
+                            target: LOG_TARGET,
+                            "Invalidated Output does not have an associated TxId so it is likely a Coinbase output \
+                             lost to a Re-Org"
+                        );
+                    }
+                }
+                debug!(
+                    target: LOG_TARGET,
+                    "Handled Base Node response (Id: {}) for Unspent Outputs Query {}", request_key, self.id
+                );
+            },
+            UtxoValidationType::Invalid => {
+                let invalid_outputs = self.resources.db.get_invalid_outputs().await.map_err(|e| {
+                    OutputManagerProtocolError::new(self.id, OutputManagerError::OutputManagerStorageError(e))
+                })?;
+
+                for output in response.iter() {
+                    let response_hash = TransactionOutput::try_from(output.clone())
+                        .map_err(|_| {
+                            OutputManagerProtocolError::new(
+                                self.id,
+                                OutputManagerError::ConversionError("Could not convert Transaction Output".to_string()),
+                            )
+                        })?
+                        .hash();
+
+                    if let Some(output) = invalid_outputs.iter().find(|o| o.hash == response_hash) {
+                        if self
+                            .resources
+                            .db
+                            .revalidate_output(output.unblinded_output.spending_key.clone())
+                            .await
+                            .is_ok()
+                        {
+                            trace!(
+                                target: LOG_TARGET,
+                                "Output with value {} has been restored to a valid spendable output",
+                                output.unblinded_output.value
+                            );
+                        }
+                    }
+                }
+
+                debug!(
+                    target: LOG_TARGET,
+                    "Handled Base Node response (Id: {}) for Invalidated Outputs Query {}", request_key, self.id
+                );
+            },
+        }
+        Ok(true)
+    }
+}
+
+pub enum UtxoValidationType {
+    Unspent,
+    Invalid,
+}
+
+impl fmt::Display for UtxoValidationType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            UtxoValidationType::Unspent => write!(f, "Unspent Outputs Validation"),
+            UtxoValidationType::Invalid => write!(f, "Invalid Outputs Validation"),
+        }
+    }
+}
+
+// 0 means keep retying until success
+#[derive(Debug)]
+pub enum UtxoValidationRetry {
+    Limited(u8),
+    UntilSuccess,
+}

--- a/base_layer/wallet/src/storage/database.rs
+++ b/base_layer/wallet/src/storage/database.rs
@@ -96,7 +96,7 @@ where T: WalletBackend + 'static
 
         tokio::task::spawn_blocking(move || fetch!(db_clone, pub_key.clone(), Peer))
             .await
-            .or_else(|err| Err(WalletStorageError::BlockingTaskSpawnError(err.to_string())))
+            .map_err(|err| WalletStorageError::BlockingTaskSpawnError(err.to_string()))
             .and_then(|inner_result| inner_result)
     }
 

--- a/base_layer/wallet/src/testnet_utils.rs
+++ b/base_layer/wallet/src/testnet_utils.rs
@@ -168,7 +168,7 @@ pub fn get_next_memory_address() -> Multiaddr {
 pub fn generate_wallet_test_data<
     T: WalletBackend,
     U: TransactionBackend + Clone,
-    V: OutputManagerBackend,
+    V: OutputManagerBackend + Clone,
     W: ContactsBackend,
     P: AsRef<Path>,
 >(
@@ -691,7 +691,7 @@ pub fn generate_wallet_test_data<
 pub fn complete_sent_transaction<
     T: WalletBackend,
     U: TransactionBackend + Clone,
-    V: OutputManagerBackend,
+    V: OutputManagerBackend + Clone,
     W: ContactsBackend,
 >(
     wallet: &mut Wallet<T, U, V, W>,
@@ -735,7 +735,7 @@ pub fn complete_sent_transaction<
 pub fn receive_test_transaction<
     T: WalletBackend,
     U: TransactionBackend + Clone,
-    V: OutputManagerBackend,
+    V: OutputManagerBackend + Clone,
     W: ContactsBackend,
 >(
     wallet: &mut Wallet<T, U, V, W>,
@@ -765,7 +765,7 @@ pub fn receive_test_transaction<
 pub fn finalize_received_transaction<
     T: WalletBackend,
     U: TransactionBackend + Clone,
-    V: OutputManagerBackend,
+    V: OutputManagerBackend + Clone,
     W: ContactsBackend,
 >(
     wallet: &mut Wallet<T, U, V, W>,
@@ -786,7 +786,7 @@ pub fn finalize_received_transaction<
 pub fn broadcast_transaction<
     T: WalletBackend,
     U: TransactionBackend + Clone,
-    V: OutputManagerBackend,
+    V: OutputManagerBackend + Clone,
     W: ContactsBackend,
 >(
     wallet: &mut Wallet<T, U, V, W>,
@@ -807,7 +807,7 @@ pub fn broadcast_transaction<
 pub fn mine_transaction<
     T: WalletBackend,
     U: TransactionBackend + Clone,
-    V: OutputManagerBackend,
+    V: OutputManagerBackend + Clone,
     W: ContactsBackend,
 >(
     wallet: &mut Wallet<T, U, V, W>,

--- a/base_layer/wallet/src/transaction_service/handle.rs
+++ b/base_layer/wallet/src/transaction_service/handle.rs
@@ -108,7 +108,7 @@ pub enum TransactionServiceResponse {
     PendingInboundTransactions(HashMap<u64, InboundTransaction>),
     PendingOutboundTransactions(HashMap<u64, OutboundTransaction>),
     CompletedTransactions(HashMap<u64, CompletedTransaction>),
-    CompletedTransaction(CompletedTransaction),
+    CompletedTransaction(Box<CompletedTransaction>),
     BaseNodePublicKeySet,
     UtxoImported(TxId),
     TransactionSubmitted,
@@ -290,7 +290,7 @@ impl TransactionServiceHandle {
             .call(TransactionServiceRequest::GetCompletedTransaction(tx_id))
             .await??
         {
-            TransactionServiceResponse::CompletedTransaction(t) => Ok(t),
+            TransactionServiceResponse::CompletedTransaction(t) => Ok(*t),
             _ => Err(TransactionServiceError::UnexpectedApiResponse),
         }
     }

--- a/base_layer/wallet/src/transaction_service/protocols/transaction_broadcast_protocol.rs
+++ b/base_layer/wallet/src/transaction_service/protocols/transaction_broadcast_protocol.rs
@@ -257,12 +257,7 @@ where TBackend: TransactionBackend + Clone + 'static
                 error!(target: LOG_TARGET, "Invalid Mempool response variant");
             },
             MempoolResponse::TxStorage(ts) => {
-                let completed_tx = match self
-                    .resources
-                    .db
-                    .get_completed_transaction(response.request_key.clone())
-                    .await
-                {
+                let completed_tx = match self.resources.db.get_completed_transaction(response.request_key).await {
                     Ok(tx) => tx,
                     Err(e) => {
                         error!(

--- a/base_layer/wallet/src/transaction_service/storage/database.rs
+++ b/base_layer/wallet/src/transaction_service/storage/database.rs
@@ -32,7 +32,7 @@ use std::{
 };
 use tari_comms::types::CommsPublicKey;
 use tari_core::transactions::{
-    tari_amount::{uT, MicroTari},
+    tari_amount::MicroTari,
     transaction::Transaction,
     types::{BlindingFactor, PrivateKey},
     ReceiverTransactionProtocol,
@@ -393,7 +393,7 @@ where T: TransactionBackend + 'static
             )))
         })
         .await
-        .or_else(|err| Err(TransactionStorageError::BlockingTaskSpawnError(err.to_string())))??;
+        .map_err(|err| TransactionStorageError::BlockingTaskSpawnError(err.to_string()))??;
 
         Ok(())
     }
@@ -412,7 +412,7 @@ where T: TransactionBackend + 'static
             )))
         })
         .await
-        .or_else(|err| Err(TransactionStorageError::BlockingTaskSpawnError(err.to_string())))??;
+        .map_err(|err| TransactionStorageError::BlockingTaskSpawnError(err.to_string()))??;
         Ok(())
     }
 
@@ -422,7 +422,7 @@ where T: TransactionBackend + 'static
             db_clone.write(WriteOperation::Remove(DbKey::PendingOutboundTransaction(tx_id)))
         })
         .await
-        .or_else(|err| Err(TransactionStorageError::BlockingTaskSpawnError(err.to_string())))??;
+        .map_err(|err| TransactionStorageError::BlockingTaskSpawnError(err.to_string()))??;
         Ok(())
     }
 
@@ -432,7 +432,7 @@ where T: TransactionBackend + 'static
         let tx_id_clone = tx_id;
         tokio::task::spawn_blocking(move || db_clone.transaction_exists(tx_id_clone))
             .await
-            .or_else(|err| Err(TransactionStorageError::BlockingTaskSpawnError(err.to_string())))
+            .map_err(|err| TransactionStorageError::BlockingTaskSpawnError(err.to_string()))
             .and_then(|inner_result| inner_result)
     }
 
@@ -451,7 +451,7 @@ where T: TransactionBackend + 'static
             )))
         })
         .await
-        .or_else(|err| Err(TransactionStorageError::BlockingTaskSpawnError(err.to_string())))
+        .map_err(|err| TransactionStorageError::BlockingTaskSpawnError(err.to_string()))
         .and_then(|inner_result| inner_result)
     }
 
@@ -490,7 +490,7 @@ where T: TransactionBackend + 'static
             Err(e) => log_error(key, e),
         })
         .await
-        .or_else(|err| Err(TransactionStorageError::BlockingTaskSpawnError(err.to_string())))??;
+        .map_err(|err| TransactionStorageError::BlockingTaskSpawnError(err.to_string()))??;
         Ok(*t)
     }
 
@@ -529,7 +529,7 @@ where T: TransactionBackend + 'static
             Err(e) => log_error(key, e),
         })
         .await
-        .or_else(|err| Err(TransactionStorageError::BlockingTaskSpawnError(err.to_string())))??;
+        .map_err(|err| TransactionStorageError::BlockingTaskSpawnError(err.to_string()))??;
         Ok(*t)
     }
 
@@ -568,7 +568,7 @@ where T: TransactionBackend + 'static
             Err(e) => log_error(key, e),
         })
         .await
-        .or_else(|err| Err(TransactionStorageError::BlockingTaskSpawnError(err.to_string())))??;
+        .map_err(|err| TransactionStorageError::BlockingTaskSpawnError(err.to_string()))??;
         Ok(*t)
     }
 
@@ -609,7 +609,7 @@ where T: TransactionBackend + 'static
             Err(e) => log_error(key, e),
         })
         .await
-        .or_else(|err| Err(TransactionStorageError::BlockingTaskSpawnError(err.to_string())))??;
+        .map_err(|err| TransactionStorageError::BlockingTaskSpawnError(err.to_string()))??;
         Ok(t)
     }
 
@@ -650,7 +650,7 @@ where T: TransactionBackend + 'static
             Err(e) => log_error(key, e),
         })
         .await
-        .or_else(|err| Err(TransactionStorageError::BlockingTaskSpawnError(err.to_string())))??;
+        .map_err(|err| TransactionStorageError::BlockingTaskSpawnError(err.to_string()))??;
         Ok(t)
     }
 
@@ -663,7 +663,7 @@ where T: TransactionBackend + 'static
         let pub_key =
             tokio::task::spawn_blocking(move || db_clone.get_pending_transaction_counterparty_pub_key_by_tx_id(tx_id))
                 .await
-                .or_else(|err| Err(TransactionStorageError::BlockingTaskSpawnError(err.to_string())))??;
+                .map_err(|err| TransactionStorageError::BlockingTaskSpawnError(err.to_string()))??;
         Ok(pub_key)
     }
 
@@ -702,7 +702,7 @@ where T: TransactionBackend + 'static
             Err(e) => log_error(key, e),
         })
         .await
-        .or_else(|err| Err(TransactionStorageError::BlockingTaskSpawnError(err.to_string())))??;
+        .map_err(|err| TransactionStorageError::BlockingTaskSpawnError(err.to_string()))??;
         Ok(t)
     }
 
@@ -717,7 +717,7 @@ where T: TransactionBackend + 'static
 
         tokio::task::spawn_blocking(move || db_clone.complete_outbound_transaction(tx_id, transaction))
             .await
-            .or_else(|err| Err(TransactionStorageError::BlockingTaskSpawnError(err.to_string())))
+            .map_err(|err| TransactionStorageError::BlockingTaskSpawnError(err.to_string()))
             .and_then(|inner_result| inner_result)
     }
 
@@ -732,57 +732,56 @@ where T: TransactionBackend + 'static
 
         tokio::task::spawn_blocking(move || db_clone.complete_inbound_transaction(tx_id, transaction))
             .await
-            .or_else(|err| Err(TransactionStorageError::BlockingTaskSpawnError(err.to_string())))
+            .map_err(|err| TransactionStorageError::BlockingTaskSpawnError(err.to_string()))
             .and_then(|inner_result| inner_result)
     }
 
-    pub async fn cancel_completed_transaction(&mut self, tx_id: TxId) -> Result<(), TransactionStorageError> {
+    pub async fn cancel_completed_transaction(&self, tx_id: TxId) -> Result<(), TransactionStorageError> {
         let db_clone = self.db.clone();
         tokio::task::spawn_blocking(move || db_clone.cancel_completed_transaction(tx_id))
             .await
-            .or_else(|err| Err(TransactionStorageError::BlockingTaskSpawnError(err.to_string())))??;
+            .map_err(|err| TransactionStorageError::BlockingTaskSpawnError(err.to_string()))??;
         Ok(())
     }
 
-    pub async fn cancel_pending_transaction(&mut self, tx_id: TxId) -> Result<(), TransactionStorageError> {
+    pub async fn cancel_pending_transaction(&self, tx_id: TxId) -> Result<(), TransactionStorageError> {
         let db_clone = self.db.clone();
         tokio::task::spawn_blocking(move || db_clone.cancel_pending_transaction(tx_id))
             .await
-            .or_else(|err| Err(TransactionStorageError::BlockingTaskSpawnError(err.to_string())))??;
+            .map_err(|err| TransactionStorageError::BlockingTaskSpawnError(err.to_string()))??;
         Ok(())
     }
 
-    pub async fn mark_direct_send_success(&mut self, tx_id: TxId) -> Result<(), TransactionStorageError> {
+    pub async fn mark_direct_send_success(&self, tx_id: TxId) -> Result<(), TransactionStorageError> {
         let db_clone = self.db.clone();
         tokio::task::spawn_blocking(move || db_clone.mark_direct_send_success(tx_id))
             .await
-            .or_else(|err| Err(TransactionStorageError::BlockingTaskSpawnError(err.to_string())))??;
+            .map_err(|err| TransactionStorageError::BlockingTaskSpawnError(err.to_string()))??;
         Ok(())
     }
 
     /// Indicated that the specified completed transaction has been broadcast into the mempool
-    pub async fn broadcast_completed_transaction(&mut self, tx_id: TxId) -> Result<(), TransactionStorageError> {
+    pub async fn broadcast_completed_transaction(&self, tx_id: TxId) -> Result<(), TransactionStorageError> {
         let db_clone = self.db.clone();
 
         tokio::task::spawn_blocking(move || db_clone.broadcast_completed_transaction(tx_id))
             .await
-            .or_else(|err| Err(TransactionStorageError::BlockingTaskSpawnError(err.to_string())))
+            .map_err(|err| TransactionStorageError::BlockingTaskSpawnError(err.to_string()))
             .and_then(|inner_result| inner_result)
     }
 
     /// Indicated that the specified completed transaction has been detected as mined on the base layer
-    pub async fn mine_completed_transaction(&mut self, tx_id: TxId) -> Result<(), TransactionStorageError> {
+    pub async fn mine_completed_transaction(&self, tx_id: TxId) -> Result<(), TransactionStorageError> {
         let db_clone = self.db.clone();
 
         tokio::task::spawn_blocking(move || db_clone.mine_completed_transaction(tx_id))
             .await
-            .or_else(|err| Err(TransactionStorageError::BlockingTaskSpawnError(err.to_string())))
+            .map_err(|err| TransactionStorageError::BlockingTaskSpawnError(err.to_string()))
             .and_then(|inner_result| inner_result)
     }
 
-    #[allow(clippy::erasing_op)] // this is for 0 * uT
     pub async fn add_utxo_import_transaction(
-        &mut self,
+        &self,
         tx_id: TxId,
         amount: MicroTari,
         source_public_key: CommsPublicKey,
@@ -795,7 +794,7 @@ where T: TransactionBackend + 'static
             source_public_key.clone(),
             comms_public_key.clone(),
             amount,
-            0 * uT,
+            MicroTari::from(0),
             Transaction::new(Vec::new(), Vec::new(), Vec::new(), BlindingFactor::default()),
             TransactionStatus::Imported,
             message,
@@ -810,7 +809,7 @@ where T: TransactionBackend + 'static
             )))
         })
         .await
-        .or_else(|err| Err(TransactionStorageError::BlockingTaskSpawnError(err.to_string())))??;
+        .map_err(|err| TransactionStorageError::BlockingTaskSpawnError(err.to_string()))??;
         Ok(())
     }
 }

--- a/base_layer/wallet/src/transaction_service/storage/memory_db.rs
+++ b/base_layer/wallet/src/transaction_service/storage/memory_db.rs
@@ -160,7 +160,7 @@ impl TransactionBackend for TransactionMemoryDatabase {
                 let mut result = HashMap::new();
                 for (k, v) in db.completed_transactions.iter() {
                     if v.cancelled {
-                        result.insert(k.clone(), v.clone());
+                        result.insert(*k, v.clone());
                     }
                 }
                 Some(DbValue::CompletedTransactions(result))

--- a/base_layer/wallet/tests/output_manager_service/storage.rs
+++ b/base_layer/wallet/tests/output_manager_service/storage.rs
@@ -45,7 +45,7 @@ use tari_wallet::{
 use tempdir::TempDir;
 use tokio::runtime::Runtime;
 
-pub fn test_db_backend<T: OutputManagerBackend + 'static>(backend: T) {
+pub fn test_db_backend<T: OutputManagerBackend + Clone + 'static>(backend: T) {
     let mut runtime = Runtime::new().unwrap();
     let db = OutputManagerDatabase::new(backend);
     let factories = CryptoFactories::default();
@@ -349,7 +349,7 @@ pub fn test_output_manager_sqlite_db() {
     test_db_backend(OutputManagerSqliteDatabase::new(connection));
 }
 
-pub fn test_key_manager_crud<T: OutputManagerBackend + 'static>(backend: T) {
+pub fn test_key_manager_crud<T: OutputManagerBackend + Clone + 'static>(backend: T) {
     let mut runtime = Runtime::new().unwrap();
 
     let db = OutputManagerDatabase::new(backend);
@@ -400,7 +400,7 @@ pub fn test_key_manager_crud_sqlite_db() {
     test_key_manager_crud(OutputManagerSqliteDatabase::new(connection));
 }
 
-pub async fn test_short_term_encumberance<T: OutputManagerBackend + 'static>(backend: T) {
+pub async fn test_short_term_encumberance<T: OutputManagerBackend + Clone + 'static>(backend: T) {
     let factories = CryptoFactories::default();
 
     let db = OutputManagerDatabase::new(backend);

--- a/base_layer/wallet_ffi/Cargo.toml
+++ b/base_layer/wallet_ffi/Cargo.toml
@@ -20,7 +20,6 @@ tokio = "0.2.10"
 libc = "0.2.65"
 rand = "0.7.2"
 chrono = { version = "0.4.6", features = ["serde"]}
-tari_broadcast_channel = "^0.2"
 derive-error = "0.0.4"
 log = "0.4.6"
 log4rs = {version = "0.8.3", features = ["console_appender", "file_appender", "file", "yaml_format"]}

--- a/base_layer/wallet_ffi/src/lib.rs
+++ b/base_layer/wallet_ffi/src/lib.rs
@@ -154,7 +154,10 @@ use tari_utilities::{hex, hex::Hex, message_format::MessageFormat};
 use tari_wallet::{
     contacts_service::storage::{database::Contact, sqlite_db::ContactsServiceSqliteDatabase},
     error::WalletError,
-    output_manager_service::storage::sqlite_db::OutputManagerSqliteDatabase,
+    output_manager_service::{
+        protocols::utxo_validation_protocol::UtxoValidationRetry,
+        storage::sqlite_db::OutputManagerSqliteDatabase,
+    },
     storage::{
         connection_manager::run_migration_and_create_sqlite_connection,
         database::WalletDatabase,
@@ -4138,7 +4141,7 @@ pub unsafe extern "C" fn wallet_sync_with_base_node(wallet: *mut TariWallet, err
         return 0;
     }
 
-    match (*wallet).sync_with_base_node() {
+    match (*wallet).validate_utxos(UtxoValidationRetry::Limited(1)) {
         Ok(request_key) => request_key,
         Err(e) => {
             error = LibWalletError::from(e).code;


### PR DESCRIPTION
## Description
UTXO validation in the Output Manager currently has a few elements that are synchronous relative to the main Select! Loop in the service. This meant that when there were a large number of outputs in the wallet that this could bog down the entire service.

This PR refactors the UTXO validation process into a fully asynchronous and more modular Protocol pattern that runs in its own task. The API to the process is also updated to allow clients to select the appropriate Retry strategy. The automatic Utxo Validation of Unspent outputs was removed and must now be done explicitly but the client so they have more control over when it happens. The Automatic Invalid UTXO validation is still in place but instead of repeating until success it is reduced to 5 attempts as it is not critical.

It was also found that there was one synchronous Mutex being used in the service outside of a `spawn_blocking(…)` context which could cause problems with the Tokio runtime so that has been updated to use an asynchronous Mutex.

The Output Manager was also updated to use to the Tokio Broadcast channel and the tari_broadcast_channel dependency has been removed from the Wallet crate.

A test has been added to fully test the wallet_ffi callback handler which ingests the new events the OMS is emitting.

A bunch of Clippy fixes

Closes https://github.com/tari-project/tari/issues/1968
Closes https://github.com/tari-project/tari/issues/1969

## How Has This Been Tested?
Tests updated and a new test of the Callback Handler provided

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [x] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [x] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch.
* [x] I ran `cargo-fmt --all` before pushing.
* [ ] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
