### PR TITLE
Initial Mempool sync

### DIFF
--- a/applications/tari_base_node/src/builder.rs
+++ b/applications/tari_base_node/src/builder.rs
@@ -21,7 +21,7 @@
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 use crate::miner;
-use futures::future;
+use futures::{channel::mpsc, future};
 use log::*;
 use rand::rngs::OsRng;
 use std::{
@@ -38,6 +38,7 @@ use tari_common::{CommsTransport, DatabaseType, GlobalConfig, Network, SocksAuth
 use tari_comms::{
     multiaddr::{Multiaddr, Protocol},
     peer_manager::{NodeId, NodeIdentity, Peer, PeerFeatures, PeerFlags},
+    protocol::{ProtocolNotificationRx, Protocols},
     socks,
     tor,
     tor::TorIdentity,
@@ -46,6 +47,7 @@ use tari_comms::{
     CommsNode,
     ConnectionManagerEvent,
     PeerManager,
+    Substream,
 };
 use tari_comms_dht::{DbConnectionUrl, Dht, DhtConfig};
 use tari_core::{
@@ -75,6 +77,7 @@ use tari_core::{
         MempoolServiceConfig,
         MempoolServiceInitializer,
         MempoolValidators,
+        MEMPOOL_SYNC_PROTOCOL,
     },
     mining::Miner,
     tari_utilities::{hex::Hex, message_format::MessageFormat},
@@ -496,7 +499,13 @@ where
     let (publisher, base_node_subscriptions) = pubsub_connector(handle.clone(), 100);
     let base_node_subscriptions = Arc::new(base_node_subscriptions);
     create_peer_db_folder(&config.peer_db_path)?;
-    let (base_node_comms, base_node_dht) = setup_base_node_comms(base_node_identity, config, publisher).await?;
+
+    let mut protocols = Protocols::new();
+    let (mempool_protocol_tx, mempool_protocol_notif) = mpsc::channel(10);
+    protocols.add(&[MEMPOOL_SYNC_PROTOCOL.clone()], mempool_protocol_tx);
+
+    let (base_node_comms, base_node_dht) =
+        setup_base_node_comms(base_node_identity, config, publisher, protocols).await?;
     base_node_comms
         .connectivity()
         .add_managed_peers(vec![wallet_node_identity.node_id().clone()])
@@ -511,6 +520,7 @@ where
         base_node_subscriptions.clone(),
         mempool,
         rules.clone(),
+        mempool_protocol_notif,
     )
     .await;
     debug!(target: LOG_TARGET, "Base node service registration complete.");
@@ -977,6 +987,7 @@ async fn setup_base_node_comms(
     node_identity: Arc<NodeIdentity>,
     config: &GlobalConfig,
     publisher: PubsubDomainConnector,
+    protocols: Protocols<Substream>,
 ) -> Result<(CommsNode, Dht), String>
 {
     // Ensure that the node identity has the correct public address
@@ -1001,7 +1012,7 @@ async fn setup_base_node_comms(
     };
 
     let seed_peers = parse_peer_seeds(&config.peer_seeds);
-    let (comms, dht) = initialize_comms(comms_config, publisher, seed_peers)
+    let (comms, dht) = initialize_comms(comms_config, publisher, seed_peers, protocols)
         .await
         .map_err(|e| e.to_friendly_string())?;
 
@@ -1054,7 +1065,7 @@ async fn setup_wallet_comms(
 
     let mut seed_peers = parse_peer_seeds(&config.peer_seeds);
     seed_peers.push(base_node_peer);
-    let (comms, dht) = initialize_comms(comms_config, publisher, seed_peers)
+    let (comms, dht) = initialize_comms(comms_config, publisher, seed_peers, Default::default())
         .await
         .map_err(|e| format!("Could not create comms layer: {:?}", e))?;
 
@@ -1090,6 +1101,7 @@ async fn register_base_node_services<B>(
     subscription_factory: Arc<SubscriptionFactory>,
     mempool: Mempool<B>,
     consensus_manager: ConsensusManager,
+    mempool_protocol_notif: ProtocolNotificationRx<Substream>,
 ) -> Arc<ServiceHandles>
 where
     B: BlockchainBackend + 'static,
@@ -1109,6 +1121,8 @@ where
             subscription_factory.clone(),
             mempool,
             mempool_config,
+            mempool_protocol_notif,
+            comms.subscribe_connectivity_events(),
         ))
         .add_initializer(LivenessInitializer::new(
             LivenessConfig {

--- a/base_layer/core/src/mempool/config.rs
+++ b/base_layer/core/src/mempool/config.rs
@@ -63,12 +63,19 @@ pub struct MempoolServiceConfig {
     /// The allocated waiting time for a request waiting for service responses from the Mempools of remote Base nodes.
     #[serde(with = "seconds")]
     pub request_timeout: Duration,
+    /// Number of peers from which to initiate a sync. Once this many peers have successfully synced, this node will
+    /// not initiate any more mempool syncs. Default: 2
+    pub initial_sync_num_peers: usize,
+    /// The maximum number of transactions to sync in a single sync session Default: 10_000
+    pub initial_sync_max_transactions: usize,
 }
 
 impl Default for MempoolServiceConfig {
     fn default() -> Self {
         Self {
             request_timeout: consts::MEMPOOL_SERVICE_REQUEST_TIMEOUT,
+            initial_sync_num_peers: 2,
+            initial_sync_max_transactions: 10_000,
         }
     }
 }

--- a/base_layer/core/src/mempool/mod.rs
+++ b/base_layer/core/src/mempool/mod.rs
@@ -61,6 +61,11 @@ pub mod proto;
 #[cfg(any(feature = "base_node", feature = "mempool_proto"))]
 pub mod service;
 
+#[cfg(feature = "base_node")]
+mod sync_protocol;
+#[cfg(feature = "base_node")]
+pub use sync_protocol::MEMPOOL_SYNC_PROTOCOL;
+
 use crate::transactions::types::Signature;
 use core::fmt::{Display, Error, Formatter};
 use serde::{Deserialize, Serialize};
@@ -130,6 +135,15 @@ pub enum TxStorageResponse {
     PendingPool,
     ReorgPool,
     NotStored,
+}
+
+impl TxStorageResponse {
+    pub fn is_stored(&self) -> bool {
+        match self {
+            TxStorageResponse::NotStored => false,
+            _ => true,
+        }
+    }
 }
 
 impl Display for TxStorageResponse {

--- a/base_layer/core/src/mempool/proto/mod.rs
+++ b/base_layer/core/src/mempool/proto/mod.rs
@@ -22,9 +22,18 @@
 
 pub use crate::proto::generated::mempool;
 
+mod sync_protocol;
+// TODO: Clean up
 pub mod mempool_request;
 pub mod mempool_response;
 pub mod state_response;
 pub mod stats_response;
 pub mod tx_storage_response;
-pub use mempool::{MempoolServiceRequest, MempoolServiceResponse};
+pub use crate::transactions::proto::Transaction;
+pub use mempool::{
+    InventoryIndexes,
+    MempoolServiceRequest,
+    MempoolServiceResponse,
+    TransactionInventory,
+    TransactionItem,
+};

--- a/base_layer/core/src/mempool/proto/sync_protocol.proto
+++ b/base_layer/core/src/mempool/proto/sync_protocol.proto
@@ -1,0 +1,18 @@
+syntax = "proto3";
+
+import "transaction.proto";
+
+package tari.mempool;
+
+message TransactionInventory {
+    // A list of kernel excess sigs used to identify transactions
+    repeated bytes items = 1;
+}
+
+message TransactionItem {
+    tari.types.Transaction transaction = 1;
+}
+
+message InventoryIndexes {
+    repeated uint32 indexes = 1;
+}

--- a/base_layer/core/src/mempool/proto/sync_protocol.rs
+++ b/base_layer/core/src/mempool/proto/sync_protocol.rs
@@ -20,26 +20,8 @@
 //  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 //  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-mod connection_stats;
-
-mod config;
-pub use config::ConnectivityConfig;
-
-mod connection_pool;
-
-mod error;
-pub use error::ConnectivityError;
-
-mod manager;
-pub(crate) use manager::ConnectivityManager;
-pub use manager::ConnectivityStatus;
-
-mod requester;
-pub(crate) use requester::ConnectivityRequest;
-pub use requester::{ConnectivityEvent, ConnectivityEventRx, ConnectivityEventTx, ConnectivityRequester};
-
-mod selection;
-pub use selection::ConnectivitySelection;
-
-#[cfg(test)]
-mod test;
+impl super::TransactionItem {
+    pub fn empty() -> Self {
+        Self { transaction: None }
+    }
+}

--- a/base_layer/core/src/mempool/service/outbound_interface.rs
+++ b/base_layer/core/src/mempool/service/outbound_interface.rs
@@ -33,6 +33,7 @@ use log::*;
 use tari_comms::peer_manager::NodeId;
 use tari_service_framework::reply_channel::SenderService;
 use tower_service::Service;
+
 pub const LOG_TARGET: &str = "c::mp::service::outbound_interface";
 
 /// The OutboundMempoolServiceInterface provides an interface to request information from the Mempools of remote Base

--- a/base_layer/core/src/mempool/sync_protocol/mod.rs
+++ b/base_layer/core/src/mempool/sync_protocol/mod.rs
@@ -1,0 +1,567 @@
+//  Copyright 2020, The Tari Project
+//
+//  Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+//  following conditions are met:
+//
+//  1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+//  disclaimer.
+//
+//  2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+//  following disclaimer in the documentation and/or other materials provided with the distribution.
+//
+//  3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+//  products derived from this software without specific prior written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+//  INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+//  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+//  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+//  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+//  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+//  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+//! # Mempool Sync Protocol
+//!
+//! The protocol handler for the mempool is responsible for the initial sync of transactions from peers.
+//! In order to prevent duplicate transactions being received from multiple peers, syncing occurs one peer at a time.
+//! This node will initiate this protocol up to a configurable (`MempoolSyncConfig::num_initial_sync_peers`) number
+//! of times. After that, it will only respond to sync requests from remote peers.
+//!
+//! ## Protocol Flow
+//!
+//! Alice initiates (initiator) the connection to Bob (responder).
+//! As the initiator, Alice MUST send a transaction inventory
+//! Bob SHOULD respond with any transactions known to him, excluding the transactions in the inventory
+//! Bob MUST send a complete message (An empty `TransactionItem` or 1 byte in protobuf)
+//! Bob MUST send indexes of inventory items that are not known to him
+//! Alice SHOULD return the Transactions relating to those indexes
+//! Alice SHOULD close the stream immediately after sending
+//!
+//!
+//! ```text
+//!  +-------+                    +-----+
+//!  | Alice |                    | Bob |
+//!  +-------+                    +-----+
+//!  |                                |
+//!  | Txn Inventory                  |
+//!  |------------------------------->|   
+//!  |                                |
+//!  |      TransactionItem(tx_b1)    |
+//!  |<-------------------------------|    
+//!  |             ...streaming...    |
+//!  |      TransactionItem(empty)    |
+//!  |<-------------------------------|
+//!  |  Inventory missing txn indexes |
+//!  |<-------------------------------|
+//!  |                                |
+//!  | TransactionItem(tx_a1)         |
+//!  |------------------------------->|    
+//!  |             ...streaming...    |
+//!  | TransactionItem(empty)         |
+//!  |------------------------------->|
+//!  |                                |
+//!  |             END                |
+//! ```
+
+#[cfg(test)]
+mod test;
+
+mod error;
+use error::MempoolProtocolError;
+
+use crate::{
+    chain_storage::BlockchainBackend,
+    mempool::{async_mempool, proto, Mempool, MempoolServiceConfig},
+    transactions::transaction::Transaction,
+};
+use futures::{stream::Fuse, AsyncRead, AsyncWrite, SinkExt, StreamExt};
+use log::*;
+use prost::Message;
+use std::{
+    convert::TryFrom,
+    sync::{
+        atomic::{AtomicUsize, Ordering},
+        Arc,
+    },
+};
+use tari_comms::{
+    connectivity::{ConnectivityEvent, ConnectivityEventRx},
+    framing,
+    framing::CanonicalFraming,
+    message::MessageExt,
+    peer_manager::{NodeId, PeerFeatures},
+    protocol::{ProtocolEvent, ProtocolNotification, ProtocolNotificationRx},
+    Bytes,
+    PeerConnection,
+};
+use tari_crypto::tari_utilities::{hex::Hex, ByteArray};
+use tokio::{sync::Semaphore, task};
+
+const MAX_FRAME_SIZE: usize = 3 * 1024 * 1024; // 3 MiB
+const LOG_TARGET: &str = "c::mempool::sync_protocol";
+
+pub static MEMPOOL_SYNC_PROTOCOL: Bytes = Bytes::from_static(b"/tari/mempool-sync/1.0");
+
+pub struct MempoolSyncProtocol<TSubstream, B> {
+    config: MempoolServiceConfig,
+    protocol_notifier: ProtocolNotificationRx<TSubstream>,
+    connectivity_events: Fuse<ConnectivityEventRx>,
+    mempool: Mempool<B>,
+    num_synched: Arc<AtomicUsize>,
+    permits: Arc<Semaphore>,
+}
+
+impl<TSubstream, B> MempoolSyncProtocol<TSubstream, B>
+where
+    TSubstream: AsyncRead + AsyncWrite + Unpin + Send + Sync + 'static,
+    B: BlockchainBackend + 'static,
+{
+    pub fn new(
+        config: MempoolServiceConfig,
+        protocol_notifier: ProtocolNotificationRx<TSubstream>,
+        connectivity_events: ConnectivityEventRx,
+        mempool: Mempool<B>,
+    ) -> Self
+    {
+        Self {
+            config,
+            protocol_notifier,
+            connectivity_events: connectivity_events.fuse(),
+            mempool,
+            num_synched: Arc::new(AtomicUsize::new(0)),
+            permits: Arc::new(Semaphore::new(1)),
+        }
+    }
+
+    pub async fn run(mut self) {
+        info!(target: LOG_TARGET, "Mempool protocol handler has started");
+        loop {
+            futures::select! {
+                event = self.connectivity_events.select_next_some() => {
+                    if let Ok(event) = event {
+                        self.handle_connectivity_event(&*event).await;
+                    }
+                },
+
+                notif = self.protocol_notifier.select_next_some() => {
+                    self.handle_protocol_notification(notif);
+                }
+
+                // protocol_notifier and connectivity_events are closed
+                complete => {
+                    info!(target: LOG_TARGET, "Mempool protocol handler is shutting down");
+                    break;
+                }
+            }
+        }
+    }
+
+    async fn handle_connectivity_event(&mut self, event: &ConnectivityEvent) {
+        match event {
+            // If this node is connecting to a peer
+            ConnectivityEvent::PeerConnected(conn) if conn.direction().is_outbound() => {
+                // This protocol is only spoken between base nodes
+                if !conn.peer_features().contains(PeerFeatures::COMMUNICATION_NODE) {
+                    return;
+                }
+
+                if !self.is_synched() {
+                    self.spawn_initiator_protocol(conn.clone()).await;
+                }
+            },
+            _ => {},
+        }
+    }
+
+    fn is_synched(&self) -> bool {
+        self.num_synched.load(Ordering::SeqCst) >= self.config.initial_sync_num_peers
+    }
+
+    fn handle_protocol_notification(&mut self, notification: ProtocolNotification<TSubstream>) {
+        match notification.event {
+            ProtocolEvent::NewInboundSubstream(node_id, substream) => {
+                self.spawn_inbound_handler(Clone::clone(&*node_id), substream);
+            },
+        }
+    }
+
+    async fn spawn_initiator_protocol(&mut self, mut conn: PeerConnection) {
+        let mempool = self.mempool.clone();
+        let permits = self.permits.clone();
+        let num_synched = self.num_synched.clone();
+        let config = self.config;
+        task::spawn(async move {
+            // Only initiate this protocol with a single peer at a time
+            let _permit = permits.acquire().await;
+            if num_synched.load(Ordering::SeqCst) >= config.initial_sync_num_peers {
+                return;
+            }
+            match conn.open_framed_substream(&MEMPOOL_SYNC_PROTOCOL, MAX_FRAME_SIZE).await {
+                Ok(framed) => {
+                    let protocol = MempoolPeerProtocol::new(config, framed, conn.peer_node_id().clone(), mempool);
+                    match protocol.start_initiator().await {
+                        Ok(_) => {
+                            debug!(
+                                target: LOG_TARGET,
+                                "Mempool initiator protocol completed successfully for peer `{}`",
+                                conn.peer_node_id().short_str(),
+                            );
+                            num_synched.fetch_add(1, Ordering::SeqCst);
+                        },
+                        Err(err) => {
+                            debug!(
+                                target: LOG_TARGET,
+                                "Mempool initiator protocol failed for peer `{}`: {}",
+                                conn.peer_node_id().short_str(),
+                                err
+                            );
+                        },
+                    }
+                },
+                Err(err) => error!(
+                    target: LOG_TARGET,
+                    "Unable to establish mempool protocol substream to peer `{}`: {}",
+                    conn.peer_node_id().short_str(),
+                    err
+                ),
+            }
+        });
+    }
+
+    fn spawn_inbound_handler(&self, node_id: NodeId, substream: TSubstream) {
+        let mempool = self.mempool.clone();
+        let config = self.config;
+        task::spawn(async move {
+            let framed = framing::canonical(substream, MAX_FRAME_SIZE);
+            let mut protocol = MempoolPeerProtocol::new(config, framed, node_id.clone(), mempool);
+            match protocol.start_responder().await {
+                Ok(_) => {
+                    debug!(
+                        target: LOG_TARGET,
+                        "Mempool responder protocol succeeded for peer `{}`",
+                        node_id.short_str()
+                    );
+                },
+                Err(err) => {
+                    debug!(
+                        target: LOG_TARGET,
+                        "Mempool responder protocol failed for peer `{}`: {}",
+                        node_id.short_str(),
+                        err
+                    );
+                },
+            }
+        });
+    }
+}
+
+struct MempoolPeerProtocol<TSubstream, B> {
+    config: MempoolServiceConfig,
+    framed: CanonicalFraming<TSubstream>,
+    mempool: Mempool<B>,
+    peer_node_id: NodeId,
+}
+
+impl<TSubstream, B> MempoolPeerProtocol<TSubstream, B>
+where
+    TSubstream: AsyncRead + AsyncWrite + Unpin,
+    B: BlockchainBackend + 'static,
+{
+    pub fn new(
+        config: MempoolServiceConfig,
+        framed: CanonicalFraming<TSubstream>,
+        peer_node_id: NodeId,
+        mempool: Mempool<B>,
+    ) -> Self
+    {
+        Self {
+            config,
+            framed,
+            peer_node_id,
+            mempool,
+        }
+    }
+
+    pub async fn start_initiator(mut self) -> Result<(), MempoolProtocolError> {
+        match self.start_initiator_inner().await {
+            Ok(_) => {
+                debug!(target: LOG_TARGET, "Initiator protocol complete");
+                Ok(())
+            },
+            Err(err) => {
+                if let Err(err) = self.framed.flush().await {
+                    debug!(target: LOG_TARGET, "IO error when flushing stream: {}", err);
+                }
+                if let Err(err) = self.framed.close().await {
+                    debug!(target: LOG_TARGET, "IO error when closing stream: {}", err);
+                }
+                Err(err)
+            },
+        }
+    }
+
+    async fn start_initiator_inner(&mut self) -> Result<(), MempoolProtocolError> {
+        debug!(
+            target: LOG_TARGET,
+            "Starting initiator mempool sync for peer `{}`",
+            self.peer_node_id.short_str()
+        );
+
+        let transactions = async_mempool::snapshot(self.mempool.clone()).await?;
+        let items = transactions
+            .iter()
+            .take(self.config.initial_sync_max_transactions)
+            .map(|txn| txn.body.kernels()[0].excess_sig.get_signature().to_vec())
+            .map(|sig| sig.to_vec())
+            .collect();
+        let inventory = proto::TransactionInventory { items };
+
+        // Send an inventory of items currently in this node's mempool
+        debug!(
+            target: LOG_TARGET,
+            "Sending transaction inventory containing {} item(s) to peer `{}`",
+            inventory.items.len(),
+            self.peer_node_id.short_str()
+        );
+
+        self.write_message(inventory).await?;
+
+        self.read_and_insert_transactions_until_complete().await?;
+
+        let missing_items: proto::InventoryIndexes = self.read_message().await?;
+        debug!(
+            target: LOG_TARGET,
+            "Received {} missing transaction index(es) from peer `{}`",
+            missing_items.indexes.len(),
+            self.peer_node_id.short_str(),
+        );
+        let missing_txns = missing_items
+            .indexes
+            .iter()
+            .filter_map(|idx| transactions.get(*idx as usize).cloned())
+            .collect::<Vec<_>>();
+        debug!(
+            target: LOG_TARGET,
+            "Sending {} missing transaction(s) to peer `{}`",
+            missing_items.indexes.len(),
+            self.peer_node_id.short_str(),
+        );
+
+        // If we don't have any transactions at the given indexes we still need to send back an empty if they requested
+        // at least one index
+        if !missing_items.indexes.is_empty() {
+            self.write_transactions(&missing_txns).await?;
+        }
+
+        // Close the stream after writing
+        self.framed.close().await?;
+
+        Ok(())
+    }
+
+    pub async fn start_responder(&mut self) -> Result<(), MempoolProtocolError> {
+        match self.start_responder_inner().await {
+            Ok(_) => {
+                debug!(target: LOG_TARGET, "Responder protocol complete");
+                Ok(())
+            },
+            Err(err) => {
+                if let Err(err) = self.framed.flush().await {
+                    debug!(target: LOG_TARGET, "IO error when flushing stream: {}", err);
+                }
+                if let Err(err) = self.framed.close().await {
+                    debug!(target: LOG_TARGET, "IO error when closing stream: {}", err);
+                }
+                Err(err)
+            },
+        }
+    }
+
+    async fn start_responder_inner(&mut self) -> Result<(), MempoolProtocolError> {
+        debug!(
+            target: LOG_TARGET,
+            "Starting responder mempool sync for peer `{}`",
+            self.peer_node_id.short_str()
+        );
+
+        let inventory: proto::TransactionInventory = self.read_message().await?;
+
+        debug!(
+            target: LOG_TARGET,
+            "Received inventory from peer `{}` containing {} item(s)",
+            self.peer_node_id.short_str(),
+            inventory.items.len()
+        );
+
+        let transactions = async_mempool::snapshot(self.mempool.clone()).await?;
+
+        let mut duplicate_inventory_items = Vec::new();
+        let (transactions, _) = transactions.into_iter().partition::<Vec<_>, _>(|transaction| {
+            let excess_sig = transaction
+                .first_kernel_excess_sig()
+                .expect("transaction stored in mempool did not have any kernels");
+
+            let has_item = inventory
+                .items
+                .iter()
+                .position(|bytes| bytes.as_slice() == excess_sig.get_signature().as_bytes());
+
+            match has_item {
+                Some(pos) => {
+                    duplicate_inventory_items.push(pos);
+                    false
+                },
+                None => true,
+            }
+        });
+
+        debug!(
+            target: LOG_TARGET,
+            "Streaming {} transaction(s) to peer `{}`",
+            transactions.len(),
+            self.peer_node_id.short_str()
+        );
+
+        self.write_transactions(&transactions).await?;
+
+        // Generate an index list of inventory indexes that this node does not have
+        let missing_items = inventory
+            .items
+            .into_iter()
+            .enumerate()
+            .filter_map(|(i, _)| {
+                if duplicate_inventory_items.contains(&i) {
+                    None
+                } else {
+                    Some(i as u32)
+                }
+            })
+            .collect::<Vec<_>>();
+        debug!(
+            target: LOG_TARGET,
+            "Requesting {} missing transaction index(es) from peer `{}`",
+            missing_items.len(),
+            self.peer_node_id.short_str(),
+        );
+
+        let missing_items = proto::InventoryIndexes { indexes: missing_items };
+        let num_missing_items = missing_items.indexes.len();
+        self.write_message(missing_items).await?;
+        self.flush().await?;
+
+        if num_missing_items > 0 {
+            debug!(target: LOG_TARGET, "Waiting for missing transactions");
+            self.read_and_insert_transactions_until_complete().await?;
+        }
+
+        Ok(())
+    }
+
+    async fn read_and_insert_transactions_until_complete(&mut self) -> Result<(), MempoolProtocolError> {
+        let mut num_recv = 0;
+        while let Some(result) = self.framed.next().await {
+            let bytes = result?;
+            let item = proto::TransactionItem::decode(&mut bytes.freeze()).map_err(|err| {
+                MempoolProtocolError::DecodeFailed {
+                    source: err,
+                    peer: self.peer_node_id.clone(),
+                }
+            })?;
+
+            match item.transaction {
+                Some(txn) => {
+                    self.validate_and_insert_transaction(txn).await?;
+                    num_recv += 1;
+                },
+                None => {
+                    debug!(
+                        target: LOG_TARGET,
+                        "All transaction(s) (count={}) received from peer `{}`. ",
+                        num_recv,
+                        self.peer_node_id.short_str()
+                    );
+                    break;
+                },
+            }
+        }
+
+        Ok(())
+    }
+
+    async fn validate_and_insert_transaction(&mut self, txn: proto::Transaction) -> Result<(), MempoolProtocolError> {
+        let txn = Transaction::try_from(txn).map_err(|err| MempoolProtocolError::MessageConversionFailed {
+            peer: self.peer_node_id.clone(),
+            message: err,
+        })?;
+        let excess_sig = txn
+            .first_kernel_excess_sig()
+            .ok_or_else(|| MempoolProtocolError::ExcessSignatureMissing(self.peer_node_id.clone()))?;
+        let excess_sig_hex = excess_sig.get_signature().to_hex();
+
+        debug!(
+            target: LOG_TARGET,
+            "Received transaction `{}` from peer `{}`",
+            excess_sig_hex,
+            self.peer_node_id.short_str()
+        );
+
+        let store_state = async_mempool::has_tx_with_excess_sig(self.mempool.clone(), excess_sig.clone()).await?;
+        if store_state.is_stored() {
+            return Ok(());
+        }
+
+        let stored_result = async_mempool::insert(self.mempool.clone(), Arc::new(txn)).await?;
+        if stored_result.is_stored() {
+            debug!(
+                target: LOG_TARGET,
+                "Inserted transaction `{}` from peer `{}`",
+                excess_sig_hex,
+                self.peer_node_id.short_str()
+            );
+        } else {
+            debug!(
+                target: LOG_TARGET,
+                "Did not store new transaction `{}` in mempool", excess_sig_hex,
+            )
+        }
+
+        Ok(())
+    }
+
+    async fn write_transactions(&mut self, transactions: &[Arc<Transaction>]) -> Result<(), MempoolProtocolError> {
+        for transaction in transactions.into_iter().take(self.config.initial_sync_max_transactions) {
+            let txn = proto::TransactionItem {
+                transaction: Some(Clone::clone(&**transaction).into()),
+            };
+            self.write_message(txn).await?
+        }
+
+        // Write an empty `TransactionItem` to indicate we're done
+        self.write_message(proto::TransactionItem::empty()).await?;
+        self.flush().await?;
+
+        Ok(())
+    }
+
+    async fn read_message<T: prost::Message + Default>(&mut self) -> Result<T, MempoolProtocolError> {
+        let msg = self
+            .framed
+            .next()
+            .await
+            .ok_or_else(|| MempoolProtocolError::SubstreamClosed(self.peer_node_id.clone()))??;
+
+        T::decode(&mut msg.freeze()).map_err(|err| MempoolProtocolError::DecodeFailed {
+            source: err,
+            peer: self.peer_node_id.clone(),
+        })
+    }
+
+    async fn write_message<T: prost::Message>(&mut self, message: T) -> Result<(), MempoolProtocolError> {
+        self.framed.send(message.to_encoded_bytes().into()).await?;
+        Ok(())
+    }
+
+    async fn flush(&mut self) -> Result<(), MempoolProtocolError> {
+        self.framed.flush().await.map_err(Into::into)
+    }
+}

--- a/base_layer/core/src/mempool/sync_protocol/test.rs
+++ b/base_layer/core/src/mempool/sync_protocol/test.rs
@@ -1,0 +1,348 @@
+//  Copyright 2020, The Tari Project
+//
+//  Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+//  following conditions are met:
+//
+//  1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+//  disclaimer.
+//
+//  2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+//  following disclaimer in the documentation and/or other materials provided with the distribution.
+//
+//  3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+//  products derived from this software without specific prior written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+//  INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+//  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+//  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+//  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+//  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+//  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+use crate::{
+    chain_storage::{BlockchainBackend, BlockchainDatabase, MemoryDatabase},
+    consensus::{ConsensusManagerBuilder, Network},
+    helpers::create_mem_db,
+    mempool::{
+        async_mempool,
+        proto,
+        sync_protocol::{MempoolPeerProtocol, MempoolSyncProtocol, MAX_FRAME_SIZE},
+        Mempool,
+        MempoolValidators,
+        MEMPOOL_SYNC_PROTOCOL,
+    },
+    transactions::{helpers::create_tx, tari_amount::uT, transaction::Transaction, types::HashDigest},
+    validation::mocks::MockValidator,
+};
+use futures::{channel::mpsc, Sink, SinkExt, Stream, StreamExt};
+use std::{fmt, io, iter::repeat_with, sync::Arc};
+use tari_comms::{
+    connectivity::{ConnectivityEvent, ConnectivityEventTx},
+    framing,
+    memsocket::MemorySocket,
+    message::MessageExt,
+    peer_manager::PeerFeatures,
+    protocol::{ProtocolEvent, ProtocolNotification, ProtocolNotificationTx},
+    test_utils::{mocks::create_peer_connection_mock_pair, node_identity::build_node_identity},
+    Bytes,
+    BytesMut,
+};
+use tari_crypto::tari_utilities::ByteArray;
+use tokio::{sync::broadcast, task};
+
+pub fn create_transactions(n: usize) -> Vec<Transaction> {
+    repeat_with(|| {
+        let (transaction, _, _) = create_tx(5000 * uT, 15 * uT, 1, 2, 1, 4);
+        transaction
+    })
+    .take(n)
+    .collect()
+}
+
+fn new_mempool_with_transactions(
+    n: usize,
+) -> (
+    Mempool<MemoryDatabase<HashDigest>>,
+    BlockchainDatabase<MemoryDatabase<HashDigest>>,
+    Vec<Transaction>,
+) {
+    let network = Network::LocalNet;
+    let consensus_manager = ConsensusManagerBuilder::new(network).build();
+    let store = create_mem_db(&consensus_manager);
+    let mempool_validator = MempoolValidators::new(MockValidator::new(true), MockValidator::new(true));
+    let mempool = Mempool::new(store.clone(), Default::default(), mempool_validator);
+
+    let transactions = create_transactions(n);
+    for txn in &transactions {
+        mempool.insert(Arc::new(txn.clone())).unwrap();
+    }
+
+    (mempool, store, transactions)
+}
+
+fn setup(
+    num_txns: usize,
+) -> (
+    ProtocolNotificationTx<MemorySocket>,
+    ConnectivityEventTx,
+    Mempool<MemoryDatabase<HashDigest>>,
+    Vec<Transaction>,
+) {
+    let (protocol_notif_tx, protocol_notif_rx) = mpsc::channel(1);
+    let (connectivity_events_tx, connectivity_events_rx) = broadcast::channel(10);
+    let (mempool, _blockchain_db, transactions) = new_mempool_with_transactions(num_txns);
+    let protocol = MempoolSyncProtocol::new(
+        Default::default(),
+        protocol_notif_rx,
+        connectivity_events_rx,
+        mempool.clone(),
+    );
+
+    task::spawn(protocol.run());
+
+    (protocol_notif_tx, connectivity_events_tx, mempool, transactions)
+}
+
+#[tokio_macros::test_basic]
+async fn empty_set() {
+    let (_, connectivity_events_tx, mempool1, _) = setup(0);
+
+    let node1 = build_node_identity(PeerFeatures::COMMUNICATION_NODE);
+    let node2 = build_node_identity(PeerFeatures::COMMUNICATION_NODE);
+    let (_node1_conn, node1_mock, node2_conn, _) =
+        create_peer_connection_mock_pair(1, node1.to_peer(), node2.to_peer()).await;
+
+    // This node connected to a peer, so it should open the substream
+    connectivity_events_tx
+        .send(Arc::new(ConnectivityEvent::PeerConnected(node2_conn)))
+        .unwrap();
+
+    let substream = node1_mock.next_incoming_substream().await.unwrap();
+    let framed = framing::canonical(substream, MAX_FRAME_SIZE);
+
+    let (mempool2, _, _) = new_mempool_with_transactions(0);
+    MempoolPeerProtocol::new(Default::default(), framed, node2.node_id().clone(), mempool2.clone())
+        .start_responder()
+        .await
+        .unwrap();
+
+    let transactions = mempool2.snapshot().unwrap();
+    assert_eq!(transactions.len(), 0);
+
+    let transactions = mempool1.snapshot().unwrap();
+    assert_eq!(transactions.len(), 0);
+}
+
+#[tokio_macros::test_basic]
+async fn synchronise() {
+    let (_, connectivity_events_tx, mempool1, transactions1) = setup(5);
+
+    let node1 = build_node_identity(PeerFeatures::COMMUNICATION_NODE);
+    let node2 = build_node_identity(PeerFeatures::COMMUNICATION_NODE);
+    let (_node1_conn, node1_mock, node2_conn, _) =
+        create_peer_connection_mock_pair(1, node1.to_peer(), node2.to_peer()).await;
+
+    // This node connected to a peer, so it should open the substream
+    connectivity_events_tx
+        .send(Arc::new(ConnectivityEvent::PeerConnected(node2_conn)))
+        .unwrap();
+
+    let substream = node1_mock.next_incoming_substream().await.unwrap();
+    let framed = framing::canonical(substream, MAX_FRAME_SIZE);
+
+    let (mempool2, _, transactions2) = new_mempool_with_transactions(3);
+    MempoolPeerProtocol::new(Default::default(), framed, node2.node_id().clone(), mempool2.clone())
+        .start_responder()
+        .await
+        .unwrap();
+
+    let transactions = get_snapshot(&mempool2);
+    assert_eq!(transactions.len(), 8);
+    assert!(transactions1.iter().all(|txn| transactions.contains(&txn)));
+    assert!(transactions2.iter().all(|txn| transactions.contains(&txn)));
+
+    let transactions = get_snapshot(&mempool1);
+    assert_eq!(transactions.len(), 8);
+    assert!(transactions1.iter().all(|txn| transactions.contains(&txn)));
+    assert!(transactions2.iter().all(|txn| transactions.contains(&txn)));
+}
+
+#[tokio_macros::test_basic]
+async fn duplicate_set() {
+    let (_, connectivity_events_tx, mempool1, transactions1) = setup(2);
+
+    let node1 = build_node_identity(PeerFeatures::COMMUNICATION_NODE);
+    let node2 = build_node_identity(PeerFeatures::COMMUNICATION_NODE);
+    let (_node1_conn, node1_mock, node2_conn, _) =
+        create_peer_connection_mock_pair(1, node1.to_peer(), node2.to_peer()).await;
+
+    // This node connected to a peer, so it should open the substream
+    connectivity_events_tx
+        .send(Arc::new(ConnectivityEvent::PeerConnected(node2_conn)))
+        .unwrap();
+
+    let substream = node1_mock.next_incoming_substream().await.unwrap();
+    let framed = framing::canonical(substream, MAX_FRAME_SIZE);
+
+    let (mempool2, _, transactions2) = new_mempool_with_transactions(1);
+    mempool2.insert(Arc::new(transactions1[0].clone())).unwrap();
+    MempoolPeerProtocol::new(Default::default(), framed, node2.node_id().clone(), mempool2.clone())
+        .start_responder()
+        .await
+        .unwrap();
+
+    let transactions = get_snapshot(&mempool2);
+    assert_eq!(transactions.len(), 3);
+    assert!(transactions1.iter().all(|txn| transactions.contains(&txn)));
+    assert!(transactions2.iter().all(|txn| transactions.contains(&txn)));
+
+    let transactions = get_snapshot(&mempool1);
+    assert_eq!(transactions.len(), 3);
+    assert!(transactions1.iter().all(|txn| transactions.contains(&txn)));
+    assert!(transactions2.iter().all(|txn| transactions.contains(&txn)));
+}
+
+#[tokio_macros::test_basic]
+async fn responder() {
+    let (mut protocol_notif, _, _, transactions1) = setup(2);
+
+    let node1 = build_node_identity(PeerFeatures::COMMUNICATION_NODE);
+    let node2 = build_node_identity(PeerFeatures::COMMUNICATION_NODE);
+
+    let (sock_in, sock_out) = MemorySocket::new_pair();
+    protocol_notif
+        .send(ProtocolNotification::new(
+            MEMPOOL_SYNC_PROTOCOL.clone(),
+            ProtocolEvent::NewInboundSubstream(Box::new(node1.node_id().clone()), sock_in),
+        ))
+        .await
+        .unwrap();
+
+    let (mempool2, _, transactions2) = new_mempool_with_transactions(1);
+    async_mempool::insert(mempool2.clone(), Arc::new(transactions1[0].clone()))
+        .await
+        .unwrap();
+    let framed = framing::canonical(sock_out, MAX_FRAME_SIZE);
+    MempoolPeerProtocol::new(Default::default(), framed, node2.node_id().clone(), mempool2.clone())
+        .start_initiator()
+        .await
+        .unwrap();
+
+    let transactions = get_snapshot(&mempool2);
+    assert_eq!(transactions.len(), 3);
+    assert!(transactions1.iter().all(|txn| transactions.contains(&txn)));
+    assert!(transactions2.iter().all(|txn| transactions.contains(&txn)));
+
+    // We cannot be sure that the mempool1 contains all the transactions at this point because the initiator protocol
+    // can complete before the responder has inserted the final transaction. There is currently no mechanism to know
+    // this.
+}
+
+#[tokio_macros::test_basic]
+async fn initiator_messages() {
+    let (mut protocol_notif, _, _, transactions1) = setup(2);
+
+    let node1 = build_node_identity(PeerFeatures::COMMUNICATION_NODE);
+
+    let (sock_in, sock_out) = MemorySocket::new_pair();
+    protocol_notif
+        .send(ProtocolNotification::new(
+            MEMPOOL_SYNC_PROTOCOL.clone(),
+            ProtocolEvent::NewInboundSubstream(Box::new(node1.node_id().clone()), sock_in),
+        ))
+        .await
+        .unwrap();
+
+    let mut transactions = create_transactions(2);
+    transactions.push(transactions1[0].clone());
+    let mut framed = framing::canonical(sock_out, MAX_FRAME_SIZE);
+    // As the initiator, send an inventory
+    let inventory = proto::TransactionInventory {
+        items: transactions
+            .iter()
+            .map(|tx| tx.first_kernel_excess_sig().unwrap().get_signature().to_vec())
+            .collect(),
+    };
+    write_message(&mut framed, inventory).await;
+    // Expect 1 transaction, a "stop message" and indexes for missing transactions
+    let transaction: proto::TransactionItem = read_message(&mut framed).await;
+    assert!(transaction.transaction.is_some());
+    let stop: proto::TransactionItem = read_message(&mut framed).await;
+    assert!(stop.transaction.is_none());
+    let indexes: proto::InventoryIndexes = read_message(&mut framed).await;
+    assert_eq!(indexes.indexes, [0, 1]);
+}
+
+#[tokio_macros::test_basic]
+async fn responder_messages() {
+    let (_, connectivity_events_tx, _, transactions1) = setup(1);
+
+    let node1 = build_node_identity(PeerFeatures::COMMUNICATION_NODE);
+    let node2 = build_node_identity(PeerFeatures::COMMUNICATION_NODE);
+    let (_node1_conn, node1_mock, node2_conn, _) =
+        create_peer_connection_mock_pair(1, node1.to_peer(), node2.to_peer()).await;
+
+    // This node connected to a peer, so it should open the substream
+    connectivity_events_tx
+        .send(Arc::new(ConnectivityEvent::PeerConnected(node2_conn)))
+        .unwrap();
+
+    let substream = node1_mock.next_incoming_substream().await.unwrap();
+    let mut framed = framing::canonical(substream, MAX_FRAME_SIZE);
+
+    // Expect an inventory
+    let inventory: proto::TransactionInventory = read_message(&mut framed).await;
+    assert_eq!(inventory.items.len(), 1);
+    // Send no transactions back
+    let nothing = proto::TransactionItem::empty();
+    write_message(&mut framed, nothing).await;
+    // Send transaction indexes back
+    let indexes = proto::InventoryIndexes { indexes: vec![0] };
+    write_message(&mut framed, indexes).await;
+    // Expect a single transaction back and a stop message
+    let transaction: proto::TransactionItem = read_message(&mut framed).await;
+    assert_eq!(
+        transaction
+            .transaction
+            .unwrap()
+            .body
+            .unwrap()
+            .kernels
+            .remove(0)
+            .excess_sig
+            .unwrap()
+            .signature,
+        transactions1[0]
+            .first_kernel_excess_sig()
+            .unwrap()
+            .get_signature()
+            .to_vec()
+    );
+    let stop: proto::TransactionItem = read_message(&mut framed).await;
+    assert!(stop.transaction.is_none());
+    // Except stream to end
+    assert!(framed.next().await.is_none());
+}
+
+fn get_snapshot<B: BlockchainBackend>(mempool: &Mempool<B>) -> Vec<Transaction> {
+    mempool.snapshot().unwrap().iter().map(|t| &**t).cloned().collect()
+}
+
+async fn read_message<S, T>(reader: &mut S) -> T
+where
+    S: Stream<Item = io::Result<BytesMut>> + Unpin,
+    T: prost::Message + Default,
+{
+    let msg = reader.next().await.unwrap().unwrap();
+    T::decode(&mut msg.freeze()).unwrap()
+}
+
+async fn write_message<S, T>(writer: &mut S, message: T)
+where
+    S: Sink<Bytes> + Unpin,
+    S::Error: fmt::Debug,
+    T: prost::Message,
+{
+    writer.send(message.to_encoded_bytes().into()).await.unwrap();
+}

--- a/base_layer/core/src/transactions/proto/mod.rs
+++ b/base_layer/core/src/transactions/proto/mod.rs
@@ -20,7 +20,7 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-pub use crate::proto::generated::types;
+pub use crate::proto::generated::{types, types::Transaction};
 
 mod transaction;
 mod types_impls;

--- a/base_layer/core/src/transactions/transaction.rs
+++ b/base_layer/core/src/transactions/transaction.rs
@@ -680,6 +680,10 @@ impl Transaction {
         self.body.add_kernels(&mut kernels);
         self
     }
+
+    pub fn first_kernel_excess_sig(&self) -> Option<&Signature> {
+        Some(&self.body.kernels().first()?.excess_sig)
+    }
 }
 
 impl Add for Transaction {

--- a/base_layer/core/tests/helpers/nodes.rs
+++ b/base_layer/core/tests/helpers/nodes.rs
@@ -20,7 +20,7 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use futures::Sink;
+use futures::{channel::mpsc, Sink};
 use rand::{distributions::Alphanumeric, rngs::OsRng, Rng};
 use std::{error::Error, iter, path::Path, sync::Arc, time::Duration};
 use tari_comms::{
@@ -68,7 +68,7 @@ use tari_p2p::{
     },
 };
 use tari_service_framework::StackBuilder;
-use tokio::runtime::Runtime;
+use tokio::{runtime::Runtime, sync::broadcast};
 
 /// The NodeInterfaces is used as a container for providing access to all the services and interfaces of a single node.
 pub struct NodeInterfaces {
@@ -467,6 +467,16 @@ fn setup_base_node_services(
             subscription_factory,
             mempool,
             mempool_service_config,
+            // TODO: These should be settable from the outside - once an RPC-type protocol is available, this style of
+            //       service initialization may eventually be replaced
+            {
+                let (_, mempool_proto_rx) = mpsc::channel(0);
+                mempool_proto_rx
+            },
+            {
+                let (_, event_rx) = broadcast::channel(1);
+                event_rx
+            },
         ))
         .add_initializer(ChainMetadataServiceInitializer)
         .finish();

--- a/base_layer/core/tests/mempool.rs
+++ b/base_layer/core/tests/mempool.rs
@@ -703,6 +703,7 @@ fn service_request_timeout() {
     let consensus_manager = ConsensusManagerBuilder::new(network).build();
     let mempool_service_config = MempoolServiceConfig {
         request_timeout: Duration::from_millis(1),
+        ..Default::default()
     };
     let temp_dir = TempDir::new(string(8).as_str()).unwrap();
     let (mut alice_node, bob_node, _consensus_manager) = create_network_with_2_base_nodes_with_config(

--- a/base_layer/core/tests/node_service.rs
+++ b/base_layer/core/tests/node_service.rs
@@ -627,7 +627,6 @@ fn propagate_and_forward_invalid_block() {
             mock_accum_difficulty_validator.clone(),
         )
         .start(&mut runtime, temp_dir.path().join("bob").to_str().unwrap());
-    let mock_validator = MockValidator::new(true);
     let (alice_node, rules) = BaseNodeBuilder::new(network)
         .with_node_identity(alice_node_identity)
         .with_peers(vec![bob_node_identity.clone(), carol_node_identity.clone()])

--- a/base_layer/p2p/examples/pingpong.rs
+++ b/base_layer/p2p/examples/pingpong.rs
@@ -176,7 +176,9 @@ mod pingpong {
             listener_liveness_max_sessions: 0,
         };
 
-        let (comms, dht) = rt.block_on(initialize_comms(comms_config, publisher, vec![])).unwrap();
+        let (comms, dht) = rt
+            .block_on(initialize_comms(comms_config, publisher, vec![], Default::default()))
+            .unwrap();
 
         println!("Comms listening on {}", comms.listening_address());
 

--- a/base_layer/p2p/src/initialization.rs
+++ b/base_layer/p2p/src/initialization.rs
@@ -34,6 +34,7 @@ use tari_comms::{
     peer_manager::{NodeIdentity, Peer, PeerManagerError},
     pipeline,
     pipeline::SinkService,
+    protocol::Protocols,
     tor,
     transports::{MemoryTransport, SocksTransport, TcpWithTorTransport, Transport},
     utils::cidr::parse_cidrs,
@@ -41,6 +42,7 @@ use tari_comms::{
     CommsBuilderError,
     CommsNode,
     PeerManager,
+    Substream,
 };
 use tari_comms_dht::{Dht, DhtBuilder, DhtConfig, DhtInitializationError};
 use tari_storage::{lmdb_store::LMDBBuilder, LMDBWrapper};
@@ -194,6 +196,7 @@ pub async fn initialize_comms<TSink>(
     config: CommsConfig,
     connector: InboundDomainConnector<TSink>,
     seed_peers: Vec<Peer>,
+    protocols: Protocols<Substream>,
 ) -> Result<(CommsNode, Dht), CommsInitializationError>
 where
     TSink: Sink<Arc<PeerMessage>> + Unpin + Clone + Send + Sync + 'static,
@@ -209,6 +212,7 @@ where
         TransportType::Memory { listener_address } => {
             debug!(target: LOG_TARGET, "Building in-memory comms stack");
             let comms = builder
+                .with_protocols(protocols)
                 .with_transport(MemoryTransport)
                 .with_listener_address(listener_address.clone());
             configure_comms_and_dht(comms, config, connector, seed_peers).await

--- a/base_layer/wallet/src/wallet.rs
+++ b/base_layer/wallet/src/wallet.rs
@@ -127,7 +127,12 @@ where
         let (publisher, subscription_factory) = pubsub_connector(runtime.handle().clone(), 100);
         let subscription_factory = Arc::new(subscription_factory);
 
-        let (comms, dht) = runtime.block_on(initialize_comms(config.comms_config.clone(), publisher, vec![]))?;
+        let (comms, dht) = runtime.block_on(initialize_comms(
+            config.comms_config.clone(),
+            publisher,
+            vec![],
+            Default::default(),
+        ))?;
 
         let fut = StackBuilder::new(runtime.handle().clone(), comms.shutdown_signal())
             .add_initializer(CommsOutboundServiceInitializer::new(dht.outbound_requester()))

--- a/comms/src/connectivity/requester.rs
+++ b/comms/src/connectivity/requester.rs
@@ -43,8 +43,9 @@ use tokio::{sync::broadcast, time};
 const LOG_TARGET: &str = "comms::connectivity::requester";
 
 pub type ConnectivityEventRx = broadcast::Receiver<Arc<ConnectivityEvent>>;
+pub type ConnectivityEventTx = broadcast::Sender<Arc<ConnectivityEvent>>;
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub enum ConnectivityEvent {
     PeerDisconnected(NodeId),
     ManagedPeerDisconnected(NodeId),
@@ -108,11 +109,11 @@ impl ConnectivitySelection {
 #[derive(Clone)]
 pub struct ConnectivityRequester {
     sender: mpsc::Sender<ConnectivityRequest>,
-    event_tx: broadcast::Sender<Arc<ConnectivityEvent>>,
+    event_tx: ConnectivityEventTx,
 }
 
 impl ConnectivityRequester {
-    pub fn new(sender: mpsc::Sender<ConnectivityRequest>, event_tx: broadcast::Sender<Arc<ConnectivityEvent>>) -> Self {
+    pub fn new(sender: mpsc::Sender<ConnectivityRequest>, event_tx: ConnectivityEventTx) -> Self {
         Self { sender, event_tx }
     }
 

--- a/comms/src/lib.rs
+++ b/comms/src/lib.rs
@@ -26,9 +26,14 @@ pub mod connectivity;
 pub mod peer_manager;
 pub use peer_manager::{NodeIdentity, PeerManager};
 
+pub mod framing;
+
 mod common;
 mod consts;
+
 mod multiplexing;
+pub use multiplexing::Substream;
+
 mod noise;
 mod proto;
 mod runtime;
@@ -52,14 +57,16 @@ pub mod utils;
 mod builder;
 pub use builder::{BuiltCommsNode, CommsBuilder, CommsBuilderError, CommsNode};
 
-// Re-exports
-pub use bytes::Bytes;
-
 // TODO: Test utils should be part of a `tari_comms_test` crate
 // #[cfg(test)]
 pub mod test_utils;
+
+//---------------------------------- Re-exports --------------------------------------------//
+// Rather than requiring dependant crates to import dependencies for use with `tari_comms` we re-export them here.
 
 pub mod multiaddr {
     // Re-export so that client code does not have to have multiaddr as a dependency
     pub use ::multiaddr::{Error, Multiaddr, Protocol};
 }
+
+pub use bytes::{Bytes, BytesMut};

--- a/comms/src/protocol/messaging/protocol.rs
+++ b/comms/src/protocol/messaging/protocol.rs
@@ -24,6 +24,7 @@ use super::error::MessagingProtocolError;
 use crate::{
     compat::IoCompat,
     connection_manager::{ConnectionManagerEvent, ConnectionManagerRequester},
+    framing,
     message::{InboundMessage, MessageTag, OutboundMessage},
     multiplexing::Substream,
     peer_manager::{NodeId, NodeIdentity, Peer, PeerManagerError},
@@ -206,10 +207,7 @@ impl MessagingProtocol {
 
     pub fn framed<TSubstream>(socket: TSubstream) -> Framed<IoCompat<TSubstream>, LengthDelimitedCodec>
     where TSubstream: AsyncRead + AsyncWrite + Unpin {
-        let codec = LengthDelimitedCodec::builder()
-            .max_frame_length(MAX_FRAME_LENGTH)
-            .new_codec();
-        Framed::new(IoCompat::new(socket), codec)
+        framing::canonical(socket, MAX_FRAME_LENGTH)
     }
 
     async fn handle_internal_messaging_event(&mut self, event: MessagingEvent) {

--- a/comms/src/protocol/mod.rs
+++ b/comms/src/protocol/mod.rs
@@ -30,7 +30,7 @@ mod negotiation;
 pub use negotiation::ProtocolNegotiation;
 
 mod protocols;
-pub use protocols::{ProtocolEvent, ProtocolNotification, ProtocolNotifier, Protocols};
+pub use protocols::{ProtocolEvent, ProtocolNotification, ProtocolNotificationRx, ProtocolNotificationTx, Protocols};
 
 pub mod messaging;
 

--- a/comms/src/protocol/protocols.rs
+++ b/comms/src/protocol/protocols.rs
@@ -27,7 +27,8 @@ use crate::{
 use futures::{channel::mpsc, SinkExt};
 use std::collections::HashMap;
 
-pub type ProtocolNotifier<TSubStream> = mpsc::Sender<ProtocolNotification<TSubStream>>;
+pub type ProtocolNotificationTx<TSubstream> = mpsc::Sender<ProtocolNotification<TSubstream>>;
+pub type ProtocolNotificationRx<TSubstream> = mpsc::Receiver<ProtocolNotification<TSubstream>>;
 
 #[derive(Debug, Clone)]
 pub enum ProtocolEvent<TSubstream> {
@@ -47,7 +48,7 @@ impl<TSubstream> ProtocolNotification<TSubstream> {
 }
 
 pub struct Protocols<TSubstream> {
-    protocols: HashMap<ProtocolId, ProtocolNotifier<TSubstream>>,
+    protocols: HashMap<ProtocolId, ProtocolNotificationTx<TSubstream>>,
 }
 
 impl<TSubstream> Clone for Protocols<TSubstream> {
@@ -71,7 +72,16 @@ impl<TSubstream> Protocols<TSubstream> {
         Default::default()
     }
 
-    pub fn add<I: AsRef<[ProtocolId]>>(&mut self, protocols: I, notifier: ProtocolNotifier<TSubstream>) -> &mut Self {
+    pub fn empty() -> Self {
+        Default::default()
+    }
+
+    pub fn add<I: AsRef<[ProtocolId]>>(
+        &mut self,
+        protocols: I,
+        notifier: ProtocolNotificationTx<TSubstream>,
+    ) -> &mut Self
+    {
         self.protocols
             .extend(protocols.as_ref().iter().map(|p| (p.clone(), notifier.clone())));
         self


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR adds a protocol handler for initial mempool sync called `/tari/mempool-sync/1.0`.

- The protocol handler for the mempool is responsible for the initial sync of transactions from peers.
- In order to prevent duplicate transactions being received from multiple peers, syncing occurs one peer at a time.
- The node will _initiate_ this protocol up to a configurable (`MempoolSyncConfig::num_initial_sync_peers`) number
  of times. After which, it will only respond to sync requests from remote peers.
- After this protocol has completed successfully, both sides should have
  a completely synched mempool.
- Each message has a size limit of 3MiB. The maximum number of initial inventory items is `3MiB / 32 - 1 = 98303`
- This protocol has 1.5 round-trips 

```text
Alice initiates (initiator) the connection to Bob (responder).
As the initiator, Alice MUST send a transaction inventory
Bob SHOULD respond with any transactions known to him, excluding the
transactions in the inventory
Once all transactions have been streamed, Bob MUST send an empty `TransactionItem` (1 byte in protobuf) to indicate that fact to Alice
Bob MAY send indexes relating to Alice's inventory items that are not known to him
Alice SHOULD return the Transactions relating to those indexes
Alice SHOULD close the stream immediately after sending

+-------+                    +-----+
| Alice |                    | Bob |
+-------+                    +-----+
|                                |
| Txn Inventory                  |
|------------------------------->|
|                                |
|      TransactionItem(tx_b1)    |
|<-------------------------------|
|             ...streaming...    |
|      TransactionItem(empty)    |
|<-------------------------------|
|  Inventory missing txn indexes |
|<-------------------------------|
|                                |
| TransactionItem(tx_a1)         |
|------------------------------->|
|             ...streaming...    |
| TransactionItem(empty)         |
|------------------------------->|
|                                |
|             END                |
```

** Network compatibility **

TLDR; No breaking changes. 
A node supporting this protocol will use comms protocol negotiation to determine if a node speaks this protocol. If not, the protocol will fail and the mempool will not be synched (as before).  

**Extras**

- Cleaned up `#[cfg(feature = "base_node")]` by making `cfg_base_node!` macro
- Added tari_comms canonical framing and `open_framed_substream` convenience function

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The mempool is not persisted and is empty on node startup until new transactions are propagated on the network. This leads to mining nodes mining empty blocks or newer transactions as they do not have a recent view of transactions in their peer's mempool. This PR  "bootstraps" a node's mempool from peers on startup.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Numerous functional tests.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [x] New Tests
* [x] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch.
* [x] I ran `cargo-fmt --all` before pushing.
* [x] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
