### PR TITLE
Upgrade yamux to 0.4.7

### DIFF
--- a/comms/Cargo.toml
+++ b/comms/Cargo.toml
@@ -38,7 +38,7 @@ thiserror = "1.0.19"
 tokio = {version="~0.2.19", features=["blocking", "time", "tcp", "dns", "sync", "stream", "signal"]}
 tokio-util = {version="0.2.0", features=["codec"]}
 tower= "0.3.1"
-yamux = "=0.4.5"
+yamux = "=0.4.7"
 
 [dev-dependencies]
 tari_test_utils = {version="^0.0", path="../infrastructure/test_utils"}


### PR DESCRIPTION
Include yamux bug fix See [CHANGELOG](https://github.com/paritytech/yamux/blob/develop/CHANGELOG.md)

Non breaking change tested on base node.