### PR TITLE
Add format specifier to get-block command

### DIFF
--- a/applications/tari_base_node/src/parser.rs
+++ b/applications/tari_base_node/src/parser.rs
@@ -67,7 +67,7 @@ use tari_core::{
     base_node::{states::StatusInfo, LocalNodeCommsInterface},
     blocks::BlockHeader,
     mempool::service::LocalMempoolService,
-    tari_utilities::{hex::Hex, Hashable},
+    tari_utilities::{hex::Hex, message_format::MessageFormat, Hashable},
     transactions::{
         tari_amount::{uT, MicroTari},
         transaction::OutputFeatures,
@@ -415,7 +415,14 @@ impl Parser {
             ),
             GetBlock => {
                 println!("View a block of a height, call this command via:");
-                println!("get-block [height of the block]");
+                println!("get-block [height of the block] [format]");
+                println!(
+                    "[height of the block] The height of the block to fetch from the main chain. The genesis block \
+                     has height zero."
+                );
+                println!(
+                    "[format] Optional. Supported options are 'json' and 'text'. 'text' is the default if omitted."
+                );
             },
             GetMempoolStats => {
                 println!("Retrieves your mempools stats");
@@ -707,21 +714,34 @@ impl Parser {
     }
 
     /// Function to process the get-block command
-    fn process_get_block<'a, I: Iterator<Item = &'a str>>(&self, args: I) {
-        let command_arg = args.take(4).collect::<Vec<&str>>();
-        let height = if command_arg.len() == 1 {
-            match command_arg[0].parse::<u64>().ok() {
-                Some(height) => height,
-                None => {
-                    println!("Invalid block height provided. Height must be an integer.");
-                    return;
-                },
-            }
-        } else {
-            println!("Invalid command, please enter as follows:");
-            println!("get-block [height of the block]");
-            println!("e.g. get-block 10");
+    fn process_get_block<'a, I: Iterator<Item = &'a str>>(&self, mut args: I) {
+        // let command_arg = args.take(4).collect::<Vec<&str>>();
+        let height = args.next();
+        if height.is_none() {
+            self.print_help("get-block".split(" "));
             return;
+        }
+        let height = match height.unwrap().parse::<u64>().ok() {
+            Some(height) => height,
+            None => {
+                println!("Invalid block height provided. Height must be an integer.");
+                self.print_help("get-block".split(" "));
+                return;
+            },
+        };
+        enum Format {
+            Json,
+            Text,
+        }
+        let format = match args.next() {
+            Some(v) if v.to_ascii_lowercase() == "json" => Format::Json,
+            Some(v) if v.to_ascii_lowercase() == "text" => Format::Text,
+            None => Format::Text,
+            Some(_) => {
+                println!("Unrecognized format sspecifier");
+                self.print_help("get-block".split(" "));
+                return;
+            },
         };
         let mut handler = self.node_service.clone();
         self.executor.spawn(async move {
@@ -734,9 +754,16 @@ impl Parser {
                     );
                     return;
                 },
-                Ok(mut data) => match data.pop() {
-                    Some(historical_block) => println!("{}", historical_block.block),
-                    None => println!("Block not found at height {}", height),
+                Ok(mut data) => match (data.pop(), format) {
+                    (Some(historical_block), Format::Text) => println!("{}", historical_block.block),
+                    (Some(historical_block), Format::Json) => println!(
+                        "{}",
+                        historical_block
+                            .block
+                            .to_json()
+                            .unwrap_or("Error deserializing block".into())
+                    ),
+                    (None, _) => println!("Block not found at height {}", height),
                 },
             };
         });


### PR DESCRIPTION
`get-block` adds a format specifier which allows the user to print
blocks in text or json format. The latter is useful in testing.

Example:

```text
>> get-block 1  // OR
>> get-block 1 text
----------------- Block -----------------
--- Header ---
Version: 1
Block height: 1
Previous block hash:
4a5af9e5dd60c2ab012ef8d75a465c6864b0e59c258f3ea76ea45ae93a332fac
Timestamp: Sun, 26 Apr 2020 07:15:47 +0000
Merkle roots:
Outputs:
2d15a802253ee980a841130cae89dd4b1536a8ab4b9f218337bb097936df48c9
Range proofs:
d6122998802c2f47de31a21e5912656f4b9744d88584c680e2412f588e4fca18
Kernels:
a455d1c3574c7283eeef45905897b8013edd36121ab4a00c6589ed58218013f4
Total offset:
0000000000000000000000000000000000000000000000000000000000000000
Nonce: 11608557920783722845
Proof of work:
Mining algorithm: Blake, Target difficulty: 60000000
Total accumulated difficulty:
Monero=1, Blake=2
Pow data:

---  Body  ---
--- Transaction Kernels ---
Kernel 0:
Fee: 0 µT
Lock height: 0
Features: COINBASE_KERNEL
Excess: 9cef94920fefc544e181c296150acad6171f141ef2c68a1eb290a009d0e22909
Excess signature:
{"public_nonce":"0842cd1d3ed1171c880157f2316df8ca0ed84cd6628259b3548d368ca4f79313","signature":"fe4bd3b639a47dd24aa4408ee4fbfc02ec0a17558dde15b2d392a82a56697503"}
Meta_info: None
Linked_kernel: None

--- Inputs (0) ---
--- Outputs (1) ---
68367c184428a77feadfc2c64caab4ca3997ab18bdcea12250ac174fa8018329
[OutputFeatures { flags: COINBASE_OUTPUT, maturity: 61 }] Proof:
f0be62d27d39d09a..89a81a0901399805
```

```text
>> get-block 1 JSON
{"header":{"version":1,"height":1,"prev_hash":"4a5af9e5dd60c2ab012ef8d75a465c6864b0e59c258f3ea76ea45ae93a332fac","timestamp":1587885347,"output_mr":"2d15a802253ee980a841130cae89dd4b1536a8ab4b9f218337bb097936df48c9","range_proof_mr":"d6122998802c2f47de31a21e5912656f4b9744d88584c680e2412f588e4fca18","kernel_mr":"a455d1c3574c7283eeef45905897b8013edd36121ab4a00c6589ed58218013f4","total_kernel_offset":"0000000000000000000000000000000000000000000000000000000000000000","nonce":11608557920783722845,"pow":{"accumulated_monero_difficulty":1,"accumulated_blake_difficulty":2,"target_difficulty":60000000,"pow_algo":"Blake","pow_data":[]}},"body":{"sorted":true,"inputs":[],"outputs":[{"features":{"flags":{"bits":1},"maturity":61},"commitment":"68367c184428a77feadfc2c64caab4ca3997ab18bdcea12250ac174fa8018329","proof":"f0be62d27d39d09a9f528ebeb9f8740a3e08fd0e140f95325f275f9d2a24b364fec732cd460d976b847d5e60230610e2bfe4cd3b29a6c02b9c5658fec9edcc1d468f73da27a813192084b6966cb7dfe23ac32c88352b06cd7ae34e951e88676a2e0dec4fbd0bcc1152a5a13a7a686e0ac7ee8b028ff801be1ecca8d28dc3791e9162186185c655d2054161503e7b1d4ae47cfae5f5af930285d38f606ba05309b9bc32abf2656489ffbad3498b028ccdc7fb2e15ee44a2d767c1fa4768294a09e208b75b21102e1be9b2c8a9c8b443745292cc16e68bedf92114904f6bfc7c0fb61205db32c08e7fabc4439a14acc479a2d9cf7dec855c148ea7e9c0c9b8151b921f53f7eb97ec5b5011ff524a2c080c1ac6c41de62c17758d1c076ff2e99810068de15bbbfea13aae1c36ba9daef35ddcec52c58c0e9368438328f398ab19619e43b269a1e7beb1655a999085d63fd096858c2f35884557a84173b623ec7c142009ad8aeab3dbc258d0cc87de451190350284c756795703461124bfc54c5f2350d8e2730400b38ad944a9f11f7b76a11d7438969bfaa22603bee6a9edadbd35bef28782e4c37aa4903b2d4f671657489375cf7617ea5e9ba844bbd135712512d68a64fa8253e2f8ef2944e4aca3a9391d6508dec4d8e10dd1d07d2b3bce223654c800a53431a5a1e47a8cdd626366be7d9965114a4826d7254754065ecee433fcf08ee16d96bdddb771e877603ffd99b14c88f47dce19f2037ad3966e2df910de86a5c1d4d4f57cf658f4f9a5f6f5cc04cfe42be235a226c6537cfa5cf25e7bb0c36053663d658fe1d86c197fd254b65dd8bc9c0c8f7a0828cc87e316d94a4d9eb94f4d1274fc72505cb83ec40c1c69abe2ee31a3c3c7dc51605639a5e9cd0111794bfa903880ddac3e2bd8447a45c407fa9e1cdcd6274b89a81a0901399805"}],"kernels":[{"features":{"bits":1},"fee":0,"lock_height":0,"meta_info":null,"linked_kernel":null,"excess":"9cef94920fefc544e181c296150acad6171f141ef2c68a1eb290a009d0e22909","excess_sig":{"public_nonce":"0842cd1d3ed1171c880157f2316df8ca0ed84cd6628259b3548d368ca4f79313","signature":"fe4bd3b639a47dd24aa4408ee4fbfc02ec0a17558dde15b2d392a82a56697503"}}]}}
```

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [ ] I'm merging against the `development` branch.
* [ ] I ran `cargo-fmt --all` before pushing.
* [ ] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
