### PR TITLE
Github action for building base node binaries

### DIFF
--- a/.github/workflows/base_node_binaries.yml
+++ b/.github/workflows/base_node_binaries.yml
@@ -66,4 +66,48 @@ jobs:
           AWS_REGION:  '${{ secrets.AWS_REGION }}'
           SOURCE_DIR: '$GITHUB_WORKSPACE/binaries/ubuntu'
           DEST_DIR: 'ubuntu'
-
+  osx_binaries:
+    name: Build and deploy tari_base_node for MacOs
+    runs-on: macos-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        features: ["avx2"]
+        target_cpu: ["skylake"]
+    steps:
+      - name: Checkout source code
+        uses: actions/checkout@v2
+      - name: Install dependencies
+        run: |
+          brew install cmake
+      - name: Install Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: nightly
+          target: x86_64-apple-darwin
+      - name: Build MacOs binaries, hash and zip them
+        env:
+          ROARING_ARCH: "${{ matrix.target_cpu }}"
+          RUSTFLAGS: "-C target_cpu=${{ matrix.target_cpu }}"
+          CC: gcc
+        run: |
+          cd applications/tari_base_node
+          cargo build --release --bin tari_base_node --features ${{ matrix.features }}
+          mkdir -p $GITHUB_WORKSPACE/binaries/osx
+          cd $GITHUB_WORKSPACE/binaries/osx
+          VERSION=$(awk -F ' = ' '$1 ~ /version/ { gsub(/[\"]/, "", $2); printf("%s",$2) }' $GITHUB_WORKSPACE/applications/tari_base_node/Cargo.toml)
+          BINFILE=tari_base_node-osx-${{ matrix.target_cpu }}-${{ matrix.features }}-$VERSION
+          cp $GITHUB_WORKSPACE/target/release/tari_base_node ./$BINFILE
+          bzip2 -f $BINFILE
+          sha256sum $BINFILE.bz2 >> $BINFILE.bz2.sha256
+      - name: Sync to S3
+        uses: jakejarvis/s3-sync-action@v0.5.1
+        with:
+          args: --acl public-read --follow-symlinks
+        env:
+          AWS_S3_BUCKET: ${{ secrets.AWS_S3_BUCKET }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_REGION:  '${{ secrets.AWS_REGION }}'
+          SOURCE_DIR: '$GITHUB_WORKSPACE/binaries/osx'
+          DEST_DIR: 'osx'

--- a/.github/workflows/base_node_binaries.yml
+++ b/.github/workflows/base_node_binaries.yml
@@ -1,0 +1,69 @@
+# Build a new set of libraries when a new tag containing 'libwallet' is pushed
+name: Build binaries
+on:
+  push:
+    tags:
+      - "v[0-9].[0-9]+.[0-9]+"
+jobs:
+  ubuntu_binaries:
+    name: Build and deploy tari_base_node for Ubuntu
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        features: ["avx2", "safe"]
+        target_cpu: ["x86-64", "ivybridge", "skylake",]
+        exclude:
+          - target_cpu: "x86-64"
+            features: "avx2"
+
+    steps:
+      - name: Checkout source code
+        uses: actions/checkout@v2
+      - name: Install dependencies
+        run: |
+          apt-get update && \
+          apt-get -y install \
+          openssl \
+          libssl-dev \
+          pkg-config \
+          libsqlite3-dev \
+          git \
+          cmake \
+          libc++-dev \
+          libc++abi-dev \
+          libprotobuf-dev \
+          protobuf-compiler \
+          clang \
+          libclang-dev
+      - name: Install Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: nightly
+      - name: Build ubuntu binaries, hash and zip them
+        env:
+          ROARING_ARCH: "${{ matrix.target_cpu }}"
+          RUSTFLAGS: "-C target_cpu=${{ matrix.target_cpu }}"
+          CC: gcc
+        run: |
+          cd applications/tari_base_node
+          cargo build --release --bin tari_base_node --features ${{ matrix.features }}
+          mkdir -p $GITHUB_WORKSPACE/binaries/ubuntu
+          cd $GITHUB_WORKSPACE/binaries/ubuntu
+          VERSION=$(awk -F ' = ' '$1 ~ /version/ { gsub(/[\"]/, "", $2); printf("%s",$2) }' $GITHUB_WORKSPACE/applications/tari_base_node/Cargo.toml)
+          BINFILE=tari_base_node-ubuntu-${{ matrix.target_cpu }}-${{ matrix.features }}-$VERSION
+          cp $GITHUB_WORKSPACE/target/release/tari_base_node ./$BINFILE
+          bzip2 -f $BINFILE
+          sha256sum $BINFILE.bz2 >> $BINFILE.bz2.sha256
+      - name: Sync to S3
+        uses: jakejarvis/s3-sync-action@v0.5.1
+        with:
+          args: --acl public-read --follow-symlinks
+        env:
+          AWS_S3_BUCKET: ${{ secrets.AWS_S3_BUCKET }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_REGION:  '${{ secrets.AWS_REGION }}'
+          SOURCE_DIR: '$GITHUB_WORKSPACE/binaries/ubuntu'
+          DEST_DIR: 'ubuntu'
+

--- a/.github/workflows/clippy-check.yml
+++ b/.github/workflows/clippy-check.yml
@@ -8,15 +8,26 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
+      - name: Install dependencies
+        run: |
+          sudo apt update
+          sudo apt install -y \
+          libncurses5 \
+          libncurses5-dev \
+          openssl \
+          libssl-dev \
+          pkg-config \
+          libsqlite3-0 \
+          libsqlite3-dev \
+          git \
+          cmake \
+          libc++-dev \
+          libc++abi-dev
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: nightly-2020-06-10
           components: clippy, rustfmt
           override: true
-      - name: Install dependencies
-        run: |
-           sudo apt update &&
-           sudo apt install libncurses5 libncurses5-dev openssl libssl-dev pkg-config libsqlite3-0 libsqlite3-dev clang git cmake libc++-dev libc++abi-dev
       - uses: actions-rs/clippy-check@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,7 +12,7 @@ version = "0.7.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "043164d8ba5c4c3035fec9bbee8647c0261d788f3474306f93bb65901cae0e86"
 dependencies = [
- "memchr 2.3.3",
+ "memchr",
 ]
 
 [[package]]
@@ -171,22 +171,26 @@ dependencies = [
 
 [[package]]
 name = "bindgen"
-version = "0.37.4"
+version = "0.53.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b25ab82877ea8fe6ce1ce1f8ac54361f0218bad900af9eb11803994bf67c221"
+checksum = "c72a978d268b1d70b0e963217e60fdabd9523a941457a6c42a7315d15c7e89e5"
 dependencies = [
+ "bitflags 1.2.1",
  "cexpr",
  "cfg-if",
  "clang-sys",
  "clap",
- "env_logger 0.5.13",
+ "env_logger 0.7.1",
  "lazy_static 1.4.0",
+ "lazycell",
  "log",
  "peeking_take_while",
- "proc-macro2 0.3.5",
- "quote 0.5.2",
+ "proc-macro2 1.0.18",
+ "quote 1.0.7",
  "regex",
- "which 1.0.5",
+ "rustc-hash",
+ "shlex",
+ "which",
 ]
 
 [[package]]
@@ -284,7 +288,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "31accafdb70df7871592c058eca3985b71104e15ac32f64706022c58867da931"
 dependencies = [
  "lazy_static 1.4.0",
- "memchr 2.3.3",
+ "memchr",
  "regex-automata",
  "serde 1.0.114",
 ]
@@ -382,11 +386,11 @@ checksum = "7bbb73db36c1246e9034e307d0fba23f9a2e251faa47ade70c1bd252220c8311"
 
 [[package]]
 name = "cexpr"
-version = "0.2.3"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42aac45e9567d97474a834efdee3081b3c942b2205be932092f53354ce503d6c"
+checksum = "f4aedb84272dbe89af497cf81375129abda4fc0a9e7c5d317498c15cc30c0d27"
 dependencies = [
- "nom 3.2.1",
+ "nom 5.1.2",
 ]
 
 [[package]]
@@ -445,9 +449,9 @@ dependencies = [
 
 [[package]]
 name = "clang-sys"
-version = "0.23.0"
+version = "0.29.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7f7c04e52c35222fffcc3a115b5daf5f7e2bfb71c13c4e2321afe1fc71859c2"
+checksum = "fe6837df1d5cba2397b835c8530f51723267e16abbf83892e9e5af4f0e5dd10a"
 dependencies = [
  "glob",
  "libc",
@@ -558,19 +562,20 @@ dependencies = [
 
 [[package]]
 name = "croaring"
-version = "0.3.9"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71152d60cec9dfdc5d9d793bccfa9ad95927372b80cd00e983db5eb2ce103e3b"
+checksum = "8ea5e3e6aced0d4a2da69e3d5372a4e52c495afa8d78050f48e6314ddac0a2eb"
 dependencies = [
+ "byteorder",
  "croaring-sys",
  "libc",
 ]
 
 [[package]]
 name = "croaring-sys"
-version = "0.3.9"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac84a4f975e67fc418be3911b7ca9aa74ee8a9717ca75452da7d6839421e2d67"
+checksum = "bf8df0e3c85ace1f7cbcfb0b26c244647ad8c316c6170d9256822dee9ce1f866"
 dependencies = [
  "bindgen",
  "cc",
@@ -685,7 +690,7 @@ version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b2466559f260f48ad25fe6317b3c8dac77b5bdb5763ac7d9d6103530663bc90"
 dependencies = [
- "memchr 2.3.3",
+ "memchr",
 ]
 
 [[package]]
@@ -965,19 +970,6 @@ dependencies = [
  "proc-macro2 1.0.18",
  "quote 1.0.7",
  "syn 1.0.33",
-]
-
-[[package]]
-name = "env_logger"
-version = "0.5.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15b0a4d2e39f8420210be8b27eeda28029729e2fd4291019455016c348240c38"
-dependencies = [
- "atty",
- "humantime",
- "log",
- "regex",
- "termcolor",
 ]
 
 [[package]]
@@ -1315,7 +1307,7 @@ dependencies = [
  "futures-macro",
  "futures-sink",
  "futures-task",
- "memchr 2.3.3",
+ "memchr",
  "pin-project",
  "pin-utils",
  "proc-macro-hack",
@@ -1333,7 +1325,7 @@ dependencies = [
  "futures-core-preview",
  "futures-io-preview",
  "futures-sink-preview",
- "memchr 2.3.3",
+ "memchr",
  "pin-utils",
  "slab",
 ]
@@ -1416,9 +1408,9 @@ dependencies = [
 
 [[package]]
 name = "glob"
-version = "0.2.11"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8be18de09a56b60ed0edf84bc9df007e30040691af7acd1c41874faac5895bfb"
+checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
 
 [[package]]
 name = "h2"
@@ -1670,6 +1662,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
+name = "lazycell"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b294d6fa9ee409a054354afc4352b0b9ef7ca222c69b8812cbea9e7d2bf3783f"
+
+[[package]]
 name = "libc"
 version = "0.2.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1856,15 +1854,6 @@ checksum = "60302e4db3a61da70c0cb7991976248362f30319e88850c487b9b95bbf059e00"
 
 [[package]]
 name = "memchr"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "148fab2e51b4f1cfc66da2a7c32981d1d3c083a803978268bb11fe4b86925e7a"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "memchr"
 version = "2.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3728d817d99e5ac407411fa471ff9800a778d88a24685968b36824eaf4bee400"
@@ -2039,20 +2028,11 @@ checksum = "2bf50223579dc7cdcfb3bfcacf7069ff68243f8c363f62ffa99cf000a6b9c451"
 
 [[package]]
 name = "nom"
-version = "3.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05aec50c70fd288702bcd93284a8444607f3292dbdf2a30de5ea5dcdbe72287b"
-dependencies = [
- "memchr 1.0.2",
-]
-
-[[package]]
-name = "nom"
 version = "4.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2ad2a91a8e869eeb30b9cb3119ae87773a8f4ae617f41b1eb9c154b2905f7bd6"
 dependencies = [
- "memchr 2.3.3",
+ "memchr",
  "version_check 0.1.5",
 ]
 
@@ -2062,7 +2042,7 @@ version = "5.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ffb4262d26ed83a1c0a33a38fe2bb15797329c85770da05e6b828ddb782627af"
 dependencies = [
- "memchr 2.3.3",
+ "memchr",
  "version_check 0.9.2",
 ]
 
@@ -2441,15 +2421,6 @@ checksum = "eba180dafb9038b050a4c280019bbedf9f2467b61e5d892dcad585bb57aadc5a"
 
 [[package]]
 name = "proc-macro2"
-version = "0.3.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77997c53ae6edd6d187fec07ec41b207063b5ee6f33680e9fa86d405cdd313d4"
-dependencies = [
- "unicode-xid 0.1.0",
-]
-
-[[package]]
-name = "proc-macro2"
 version = "0.4.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf3d2011ab5c909338f7887f4fc896d35932e29146c12c8d01da6b22a80ba759"
@@ -2491,7 +2462,7 @@ dependencies = [
  "prost",
  "prost-types",
  "tempfile",
- "which 3.1.1",
+ "which",
 ]
 
 [[package]]
@@ -2538,15 +2509,6 @@ name = "quote"
 version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a6e920b65c65f10b2ae65c831a81a073a89edd28c7cce89475bff467ab4167a"
-
-[[package]]
-name = "quote"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9949cfe66888ffe1d53e6ec9d9f3b70714083854be20fd5e271b232a017401e8"
-dependencies = [
- "proc-macro2 0.3.5",
-]
 
 [[package]]
 name = "quote"
@@ -2758,7 +2720,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c3780fcf44b193bc4d09f36d2a3c87b251da4a046c87795a0d35f4f927ad8e6"
 dependencies = [
  "aho-corasick",
- "memchr 2.3.3",
+ "memchr",
  "regex-syntax",
  "thread_local",
 ]
@@ -2827,6 +2789,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3e52c148ef37f8c375d49d5a73aa70713125b7f19095948a923f80afdeb22ec2"
 
 [[package]]
+name = "rustc-hash"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
+
+[[package]]
 name = "rustc-hex"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2851,7 +2819,7 @@ dependencies = [
  "dirs-next",
  "libc",
  "log",
- "memchr 2.3.3",
+ "memchr",
  "nix",
  "scopeguard",
  "unicode-segmentation",
@@ -3056,6 +3024,12 @@ dependencies = [
  "keccak",
  "opaque-debug",
 ]
+
+[[package]]
+name = "shlex"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fdf1b9db47230893d76faad238fd6097fd6d6a9245cd7a4d90dbd639536bbd2"
 
 [[package]]
 name = "signal-hook"
@@ -3930,7 +3904,7 @@ dependencies = [
  "iovec",
  "lazy_static 1.4.0",
  "libc",
- "memchr 2.3.3",
+ "memchr",
  "mio",
  "mio-uds",
  "num_cpus",
@@ -4492,15 +4466,6 @@ name = "wasi"
 version = "0.9.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
-
-[[package]]
-name = "which"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e84a603e7e0b1ce1aa1ee2b109c7be00155ce52df5081590d1ffb93f4f515cb2"
-dependencies = [
- "libc",
-]
 
 [[package]]
 name = "which"

--- a/applications/tari_base_node/Cargo.toml
+++ b/applications/tari_base_node/Cargo.toml
@@ -48,3 +48,7 @@ tonic-build = "0.2"
 serde = "1.0.90"
 toml = "0.5"
 git2 = "0.8"
+
+[features]
+avx2 = ["tari_core/avx2", "tari_crypto/avx2", "tari_p2p/avx2", "tari_wallet/avx2", "tari_comms/avx2", "tari_comms_dht/avx2"]
+safe = []

--- a/base_layer/core/Cargo.toml
+++ b/base_layer/core/Cargo.toml
@@ -59,7 +59,7 @@ prost = "0.6.1"
 bytes = "0.4.12"
 prost-types = "0.6.1"
 cfg-if = "0.1.10"
-croaring = { version = "=0.3.9", optional = true }
+croaring = { version = "=0.4.5", optional = true }
 config = { version = "0.9.3" }
 strum = "0.17.1"
 strum_macros = "0.17.1"

--- a/base_layer/key_manager/Cargo.toml
+++ b/base_layer/key_manager/Cargo.toml
@@ -17,3 +17,5 @@ serde = "1.0.89"
 serde_derive = "1.0.89"
 serde_json = "1.0.39"
 
+[features]
+avx2 = ["tari_crypto/avx2"]

--- a/base_layer/mmr/Cargo.toml
+++ b/base_layer/mmr/Cargo.toml
@@ -13,7 +13,7 @@ derive-error = "0.0.4"
 digest = "0.8.0"
 log = "0.4"
 serde = { version = "1.0.97", features = ["derive"] }
-croaring =  "=0.3.9"
+croaring =  "=0.4.5"
 tari_storage = { path = "../../infrastructure/storage", version = "^0.1" }
 
 [dev-dependencies]

--- a/base_layer/p2p/Cargo.toml
+++ b/base_layer/p2p/Cargo.toml
@@ -9,9 +9,6 @@ readme = "README.md"
 license = "BSD-3-Clause"
 edition = "2018"
 
-[features]
-test-mocks = []
-
 [dependencies]
 tari_broadcast_channel = "^0.2"
 tari_comms = { version = "^0.1", path = "../../comms"}
@@ -60,3 +57,7 @@ version = "0.12.0"
 
 [build-dependencies]
 tari_common = { version = "^0.1", path="../../common"}
+
+[features]
+test-mocks = []
+avx2 = ["tari_crypto/avx2"]

--- a/base_layer/wallet/Cargo.toml
+++ b/base_layer/wallet/Cargo.toml
@@ -6,10 +6,6 @@ license = "BSD-3-Clause"
 version = "0.1.0"
 edition = "2018"
 
-[features]
-test_harness = ["tari_test_utils"]
-c_integration = []
-
 [dependencies]
 tari_comms = { path = "../../comms", version = "^0.1"}
 tari_comms_dht = { path = "../../comms/dht", version = "^0.1"}
@@ -55,3 +51,8 @@ lazy_static = "1.3.0"
 env_logger = "0.7.1"
 prost = "0.6.1"
 tokio-macros = "0.2.4"
+
+[features]
+test_harness = ["tari_test_utils"]
+c_integration = []
+avx2 = ["tari_crypto/avx2", "tari_core/avx2"]

--- a/comms/Cargo.toml
+++ b/comms/Cargo.toml
@@ -50,3 +50,6 @@ tempdir = "0.3.7"
 
 [build-dependencies]
 tari_common = { version = "^0.1", path="../common"}
+
+[features]
+avx2 = ["tari_crypto/avx2"]

--- a/comms/dht/Cargo.toml
+++ b/comms/dht/Cargo.toml
@@ -9,9 +9,6 @@ readme = "README.md"
 license = "BSD-3-Clause"
 edition = "2018"
 
-[features]
-test-mocks = []
-
 [dependencies]
 tari_comms = { version = "^0.1", path = "../"}
 tari_crypto = { version = "^0.4" }
@@ -60,3 +57,7 @@ lazy_static = "1.4.0"
 
 [build-dependencies]
 tari_common = { version = "^0.1", path="../../common"}
+
+[features]
+test-mocks = []
+avx2 = ["tari_crypto/avx2"]


### PR DESCRIPTION
Added a new github action for building tari_base_node binaries.
The action supports Ubuntu for now, with multiple targets (in progress).
The resulting binaries are zipped, hashed and copied to an S3 bucket.

The AVX2 feature flag is consistently applied acrosss the project to
permit a build that does not support it.

Includes #2020 