### PR TITLE
Fix flakey `transaction_base_node_monitoring` test

### DIFF
--- a/base_layer/core/tests/async_db.rs
+++ b/base_layer/core/tests/async_db.rs
@@ -232,7 +232,6 @@ fn fetch_async_mmr_roots() {
 
 #[test]
 fn async_add_block_fetch_orphan() {
-    env_logger::init();
     let network = Network::LocalNet;
     let consensus: ConsensusManager = ConsensusManagerBuilder::new(network).build();
     let (db, _, _, _) = create_blockchain_db_no_cut_through();

--- a/base_layer/wallet/src/transaction_service/protocols/transaction_send_protocol.rs
+++ b/base_layer/wallet/src/transaction_service/protocols/transaction_send_protocol.rs
@@ -296,6 +296,8 @@ where TBackend: TransactionBackend + Clone + 'static
             "Transaction Recipient Reply for TX_ID = {} received", tx_id,
         );
 
+        self.send_transaction_finalized_message(tx.clone()).await?;
+
         let _ = self
             .resources
             .event_publisher
@@ -308,8 +310,6 @@ where TBackend: TransactionBackend + Clone + 'static
                 );
                 e
             });
-
-        self.send_transaction_finalized_message(tx.clone()).await?;
 
         Ok(())
     }

--- a/base_layer/wallet_ffi/src/lib.rs
+++ b/base_layer/wallet_ffi/src/lib.rs
@@ -5374,7 +5374,6 @@ mod test {
 
     #[test]
     fn test_comms_private_key_persistence() {
-        let _ = env_logger::try_init();
         unsafe {
             let mut error = 0;
             let error_ptr = &mut error as *mut c_int;


### PR DESCRIPTION
## Description
This test had a subtle error in it where it was not properly waiting for the send protocol to finish which sometime resulted in an extra broadcast protocol being launched producing the wrong number of messages to the mock outbound requester.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch.
* [x] I ran `cargo-fmt --all` before pushing.
* [ ] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
