### PR TITLE
PubSub connector buffer size increase

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3312,7 +3312,7 @@ dependencies = [
 
 [[package]]
 name = "tari_base_node"
-version = "0.3.0"
+version = "0.4.2"
 dependencies = [
  "chrono",
  "chrono-english",

--- a/applications/tari_base_node/src/builder.rs
+++ b/applications/tari_base_node/src/builder.rs
@@ -497,7 +497,7 @@ where
 
     //---------------------------------- Base Node --------------------------------------------//
 
-    let (publisher, base_node_subscriptions) = pubsub_connector(handle.clone(), 100);
+    let (publisher, base_node_subscriptions) = pubsub_connector(handle.clone(), 1500);
     let base_node_subscriptions = Arc::new(base_node_subscriptions);
     create_peer_db_folder(&config.peer_db_path)?;
 
@@ -527,7 +527,7 @@ where
     debug!(target: LOG_TARGET, "Base node service registration complete.");
 
     //---------------------------------- Wallet --------------------------------------------//
-    let (publisher, wallet_subscriptions) = pubsub_connector(handle.clone(), 1000);
+    let (publisher, wallet_subscriptions) = pubsub_connector(handle.clone(), 15000);
     let wallet_subscriptions = Arc::new(wallet_subscriptions);
     create_peer_db_folder(&config.wallet_peer_db_path)?;
     let (wallet_comms, wallet_dht) = setup_wallet_comms(

--- a/base_layer/wallet/src/wallet.rs
+++ b/base_layer/wallet/src/wallet.rs
@@ -125,7 +125,7 @@ where
         let transaction_backend_handle = transaction_backend.clone();
 
         let factories = config.factories;
-        let (publisher, subscription_factory) = pubsub_connector(runtime.handle().clone(), 100);
+        let (publisher, subscription_factory) = pubsub_connector(runtime.handle().clone(), 1500);
         let subscription_factory = Arc::new(subscription_factory);
 
         let (comms, dht) = runtime.block_on(initialize_comms(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Increased base node, base node wallet and mobile wallet `pubsub_connector` buffer sizes by a factor of 15 to cater for high volume transactions.

## Motivation and Context
During the stress test of 2020/06/08 many payload messages were dropped internal to the base node by slow readers, in the publisher-subscriber channel, between the communication messages and the domain layer. Amount of messages dropped in the publisher-subscriber channel `[comms::middleware::pubsub]` for `Transaction Service` from `17:01:32` to `17:20:08` (19 s):

| Topic                           | Amount |
| ------------------------------- | ------ |
| BaseNodeResponse                | 89880  |
| MempoolResponse                 | 90434  |
| ReceiverPartialTransactionReply | 6328   |

An example of the amount of messages dropped by some of these subscribers are:

| Topic                           | Amount |
|---------------------------------|--------|
| MempoolResponse                 | 570    |
| BaseNodeResponse                | 549    |
| MempoolResponse                 | 371    |
| MempoolResponse                 | 313    |
| BaseNodeResponse                | 305    |
| MempoolResponse                 | 295    |
| MempoolResponse                 | 290    |
| BaseNodeResponse                | 283    |
| MempoolResponse                 | 282    |
| BaseNodeResponse                | 276    |
| MempoolResponse                 | 267    |
| MempoolResponse                 | 267    |
| MempoolResponse                 | 258    |
| BaseNodeResponse                | 257    |
| BaseNodeResponse                | 252    |
| BaseNodeResponse                | 251    |
| MempoolResponse                 | 248    |
| MempoolResponse                 | 247    |
| MempoolResponse                 | 247    |
| ReceiverPartialTransactionReply | 247    |
| MempoolResponse                 | 246    |

The base node buffer size was 100 and the base node wallet's was 1000. Looking at the measurements above an increase by a factor of 15 seems warranted. The `tokio::sync::broadcast` channels are also memory optimal, i.e. from the [documentation](https://docs.rs/tokio/0.2.21/tokio/sync/broadcast/index.html#functions): _Once all receivers have received a clone of the value, the value is released from the channel._

## How Has This Been Tested?
Tested with base node executables

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [X] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [X] I'm merging against the `development` branch.
* [X] I ran `cargo-fmt --all` before pushing.
* [X] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
