### PR TITLE
Add partial wallet backup for unencrypted wallet backup

### DIFF
--- a/applications/tari_base_node/src/builder.rs
+++ b/applications/tari_base_node/src/builder.rs
@@ -1187,7 +1187,7 @@ async fn register_wallet_services(
         .add_initializer(TransactionServiceInitializer::new(
             TransactionServiceConfig::default(),
             subscription_factory,
-            TransactionServiceSqliteDatabase::new(wallet_db_conn.clone()),
+            TransactionServiceSqliteDatabase::new(wallet_db_conn.clone(), Some(wallet_comms.node_identity().public_key().clone())),
             wallet_comms.node_identity(),
             factories,
         ))

--- a/base_layer/wallet/migrations/2020-06-23-135346_add_completed_transaction_direction/down.sql
+++ b/base_layer/wallet/migrations/2020-06-23-135346_add_completed_transaction_direction/down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE completed_transactions
+    DROP COLUMN direction;

--- a/base_layer/wallet/migrations/2020-06-23-135346_add_completed_transaction_direction/up.sql
+++ b/base_layer/wallet/migrations/2020-06-23-135346_add_completed_transaction_direction/up.sql
@@ -1,0 +1,2 @@
+ALTER TABLE completed_transactions
+    ADD COLUMN direction INTEGER NULL DEFAULT NULL;

--- a/base_layer/wallet/src/error.rs
+++ b/base_layer/wallet/src/error.rs
@@ -74,6 +74,8 @@ pub enum WalletStorageError {
     UnexpectedResult(String),
     #[error(msg_embedded, non_std, no_from)]
     BlockingTaskSpawnError(String),
+    #[error(msg_embedded, non_std, no_from)]
+    FileError(String),
     /// The storage path was invalid unicode or not supported by the host OS
     InvalidUnicodePath,
     HexError(HexError),

--- a/base_layer/wallet/src/schema.rs
+++ b/base_layer/wallet/src/schema.rs
@@ -10,6 +10,7 @@ table! {
         message -> Text,
         timestamp -> Timestamp,
         cancelled -> Integer,
+        direction -> Nullable<Integer>,
     }
 }
 

--- a/base_layer/wallet/src/storage/connection_manager.rs
+++ b/base_layer/wallet/src/storage/connection_manager.rs
@@ -20,7 +20,10 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use crate::error::WalletStorageError;
+use crate::{
+    error::WalletStorageError,
+    storage::{database::WalletDatabase, sqlite_db::WalletSqliteDatabase},
+};
 use diesel::{Connection, SqliteConnection};
 use std::{
     io,
@@ -45,4 +48,26 @@ pub fn run_migration_and_create_sqlite_connection<P: AsRef<Path>>(
         .map_err(|err| WalletStorageError::DatabaseMigrationError(format!("Database migration failed {}", err)))?;
 
     Ok(Arc::new(Mutex::new(connection)))
+}
+
+/// This function will copy a wallet database to the provided path and then clear the CommsPrivateKey from the database.
+pub async fn partial_wallet_backup<P: AsRef<Path>>(current_db: P, backup_path: P) -> Result<(), WalletStorageError> {
+    // Copy the current db to the backup path
+    let db_path = current_db
+        .as_ref()
+        .to_str()
+        .ok_or_else(|| WalletStorageError::InvalidUnicodePath)?;
+    let backup_path = backup_path
+        .as_ref()
+        .to_str()
+        .ok_or_else(|| WalletStorageError::InvalidUnicodePath)?;
+    std::fs::copy(db_path, backup_path)
+        .map_err(|_| WalletStorageError::FileError("Could not copy database file for backup".to_string()))?;
+
+    // open a connection and clear the Comms Private Key
+    let connection = run_migration_and_create_sqlite_connection(backup_path)?;
+    let db = WalletDatabase::new(WalletSqliteDatabase::new(connection), None);
+    db.clear_comms_secret_key().await?;
+
+    Ok(())
 }

--- a/base_layer/wallet/src/storage/memory_db.rs
+++ b/base_layer/wallet/src/storage/memory_db.rs
@@ -86,7 +86,9 @@ impl WalletBackend for WalletMemoryDatabase {
                     }
                     db.peers.push(p)
                 },
-                DbKeyValuePair::CommsSecretKey(key) => db.comms_private_key = Some(key),
+                DbKeyValuePair::CommsSecretKey(secret) => {
+                    db.comms_private_key = Some(secret);
+                },
             },
             WriteOperation::Remove(k) => match k {
                 DbKey::Peer(pk) => match db.peers.iter().position(|p| p.public_key == pk) {
@@ -97,7 +99,7 @@ impl WalletBackend for WalletMemoryDatabase {
                     return Err(WalletStorageError::OperationNotSupported);
                 },
                 DbKey::CommsSecretKey => {
-                    return Err(WalletStorageError::OperationNotSupported);
+                    db.comms_private_key = None;
                 },
             },
         }

--- a/base_layer/wallet/src/testnet_utils.rs
+++ b/base_layer/wallet/src/testnet_utils.rs
@@ -33,7 +33,7 @@ use crate::{
     transaction_service::{
         handle::TransactionEvent,
         storage::{
-            database::{CompletedTransaction, TransactionBackend, TransactionStatus},
+            database::{CompletedTransaction, TransactionBackend, TransactionDirection, TransactionStatus},
             memory_db::TransactionMemoryDatabase,
         },
     },
@@ -651,8 +651,7 @@ pub fn generate_wallet_test_data<
     let mut timestamp_index = 0;
 
     for k in txs.keys() {
-        let _ = transaction_service_backend
-            .update_completed_transaction_timestamp((*k).clone(), timestamps[timestamp_index].clone());
+        let _ = transaction_service_backend.update_completed_transaction_timestamp(*k, timestamps[timestamp_index]);
         timestamp_index = (timestamp_index + 1) % timestamps.len();
     }
 
@@ -713,6 +712,7 @@ pub fn complete_sent_transaction<
                 TransactionStatus::Completed,
                 p.message.clone(),
                 Utc::now().naive_utc(),
+                TransactionDirection::Outbound,
             );
             wallet.runtime.block_on(
                 wallet

--- a/base_layer/wallet/src/transaction_service/protocols/transaction_receive_protocol.rs
+++ b/base_layer/wallet/src/transaction_service/protocols/transaction_receive_protocol.rs
@@ -26,7 +26,13 @@ use crate::{
         error::{TransactionServiceError, TransactionServiceProtocolError},
         handle::TransactionEvent,
         service::TransactionServiceResources,
-        storage::database::{CompletedTransaction, InboundTransaction, TransactionBackend, TransactionStatus},
+        storage::database::{
+            CompletedTransaction,
+            InboundTransaction,
+            TransactionBackend,
+            TransactionDirection,
+            TransactionStatus,
+        },
     },
 };
 use chrono::Utc;
@@ -467,6 +473,7 @@ where TBackend: TransactionBackend + Clone + 'static
                 TransactionStatus::Completed,
                 inbound_tx.message.clone(),
                 inbound_tx.timestamp,
+                TransactionDirection::Inbound,
             );
 
             self.resources

--- a/base_layer/wallet/src/transaction_service/protocols/transaction_send_protocol.rs
+++ b/base_layer/wallet/src/transaction_service/protocols/transaction_send_protocol.rs
@@ -30,7 +30,13 @@ use crate::transaction_service::{
     error::{TransactionServiceError, TransactionServiceProtocolError},
     handle::TransactionEvent,
     service::TransactionServiceResources,
-    storage::database::{CompletedTransaction, OutboundTransaction, TransactionBackend, TransactionStatus},
+    storage::database::{
+        CompletedTransaction,
+        OutboundTransaction,
+        TransactionBackend,
+        TransactionDirection,
+        TransactionStatus,
+    },
 };
 use futures::channel::oneshot;
 use tari_comms::{peer_manager::NodeId, types::CommsPublicKey};
@@ -284,6 +290,7 @@ where TBackend: TransactionBackend + Clone + 'static
             TransactionStatus::Completed,
             outbound_tx.message.clone(),
             Utc::now().naive_utc(),
+            TransactionDirection::Outbound,
         );
 
         self.resources

--- a/base_layer/wallet/src/transaction_service/service.rs
+++ b/base_layer/wallet/src/transaction_service/service.rs
@@ -32,7 +32,13 @@ use crate::{
             transaction_receive_protocol::{TransactionReceiveProtocol, TransactionReceiveProtocolStage},
             transaction_send_protocol::{TransactionSendProtocol, TransactionSendProtocolStage},
         },
-        storage::database::{CompletedTransaction, TransactionBackend, TransactionDatabase, TransactionStatus},
+        storage::database::{
+            CompletedTransaction,
+            TransactionBackend,
+            TransactionDatabase,
+            TransactionDirection,
+            TransactionStatus,
+        },
     },
 };
 use chrono::Utc;
@@ -1289,6 +1295,7 @@ where
                     TransactionStatus::Completed,
                     message,
                     Utc::now().naive_utc(),
+                    TransactionDirection::Inbound,
                 ),
             )
             .await?;
@@ -1522,6 +1529,7 @@ where
             TransactionStatus::Completed,
             found_tx.message.clone(),
             found_tx.timestamp,
+            TransactionDirection::Inbound,
         );
 
         self.db

--- a/base_layer/wallet/src/wallet.rs
+++ b/base_layer/wallet/src/wallet.rs
@@ -118,7 +118,12 @@ where
         contacts_backend: W,
     ) -> Result<Wallet<T, U, V, W>, WalletError>
     {
-        let db = WalletDatabase::new(wallet_backend);
+        let database_path = config
+            .comms_config
+            .datastore_path
+            .join(config.comms_config.peer_database_name.clone())
+            .with_extension("sqlite3");
+        let db = WalletDatabase::new(wallet_backend, Some(database_path));
         let base_node_peers = runtime.block_on(db.get_peers())?;
 
         #[cfg(feature = "test_harness")]

--- a/base_layer/wallet/tests/transaction_service/service.rs
+++ b/base_layer/wallet/tests/transaction_service/service.rs
@@ -105,6 +105,7 @@ use tari_wallet::{
                 OutboundTransaction,
                 TransactionBackend,
                 TransactionDatabase,
+                TransactionDirection,
                 TransactionStatus,
                 WriteOperation,
             },
@@ -444,8 +445,8 @@ fn manage_single_transaction_sqlite_db() {
     let connection_bob = run_migration_and_create_sqlite_connection(&bob_db_path).unwrap();
 
     manage_single_transaction(
-        TransactionServiceSqliteDatabase::new(connection_alice),
-        TransactionServiceSqliteDatabase::new(connection_bob),
+        TransactionServiceSqliteDatabase::new(connection_alice, None),
+        TransactionServiceSqliteDatabase::new(connection_bob, None),
         temp_dir.path().to_str().unwrap().to_string(),
     );
 }
@@ -717,9 +718,9 @@ fn manage_multiple_transactions_sqlite_db() {
     let connection_bob = run_migration_and_create_sqlite_connection(&bob_db_path).unwrap();
     let connection_carol = run_migration_and_create_sqlite_connection(&carol_db_path).unwrap();
     manage_multiple_transactions(
-        TransactionServiceSqliteDatabase::new(connection_alice),
-        TransactionServiceSqliteDatabase::new(connection_bob),
-        TransactionServiceSqliteDatabase::new(connection_carol),
+        TransactionServiceSqliteDatabase::new(connection_alice, None),
+        TransactionServiceSqliteDatabase::new(connection_bob, None),
+        TransactionServiceSqliteDatabase::new(connection_carol, None),
         path_string,
     );
 }
@@ -828,7 +829,7 @@ fn test_accepting_unknown_tx_id_and_malformed_reply_sqlite_db() {
         let alice_db_name = format!("{}.sqlite3", random_string(8).as_str());
         let alice_db_path = format!("{}/{}", path_string, alice_db_name);
         let connection_alice = run_migration_and_create_sqlite_connection(&alice_db_path).unwrap();
-        test_accepting_unknown_tx_id_and_malformed_reply(TransactionServiceSqliteDatabase::new(connection_alice));
+        test_accepting_unknown_tx_id_and_malformed_reply(TransactionServiceSqliteDatabase::new(connection_alice, None));
     });
 }
 
@@ -940,8 +941,8 @@ fn finalize_tx_with_incorrect_pubkey_sqlite_db() {
         let connection_alice = run_migration_and_create_sqlite_connection(&alice_db_path).unwrap();
         let connection_bob = run_migration_and_create_sqlite_connection(&bob_db_path).unwrap();
         finalize_tx_with_incorrect_pubkey(
-            TransactionServiceSqliteDatabase::new(connection_alice),
-            TransactionServiceSqliteDatabase::new(connection_bob),
+            TransactionServiceSqliteDatabase::new(connection_alice, None),
+            TransactionServiceSqliteDatabase::new(connection_bob, None),
         );
     });
 }
@@ -1053,8 +1054,8 @@ fn finalize_tx_with_missing_output_sqlite_db() {
         let connection_alice = run_migration_and_create_sqlite_connection(&alice_db_path).unwrap();
         let connection_bob = run_migration_and_create_sqlite_connection(&bob_db_path).unwrap();
         finalize_tx_with_missing_output(
-            TransactionServiceSqliteDatabase::new(connection_alice),
-            TransactionServiceSqliteDatabase::new(connection_bob),
+            TransactionServiceSqliteDatabase::new(connection_alice, None),
+            TransactionServiceSqliteDatabase::new(connection_bob, None),
         );
     });
 }
@@ -1631,6 +1632,7 @@ fn test_power_mode_updates() {
         message: "Yo!".to_string(),
         timestamp: Utc::now().naive_utc(),
         cancelled: false,
+        direction: TransactionDirection::Outbound,
     };
 
     let completed_tx2 = CompletedTransaction {
@@ -1644,6 +1646,7 @@ fn test_power_mode_updates() {
         message: "Yo!".to_string(),
         timestamp: Utc::now().naive_utc(),
         cancelled: false,
+        direction: TransactionDirection::Outbound,
     };
 
     backend
@@ -1712,6 +1715,7 @@ fn broadcast_all_completed_transactions_on_startup() {
         message: "Yo!".to_string(),
         timestamp: Utc::now().naive_utc(),
         cancelled: false,
+        direction: TransactionDirection::Outbound,
     };
 
     let completed_tx2 = CompletedTransaction {
@@ -2227,6 +2231,7 @@ fn query_all_completed_transactions_on_startup() {
         message: "Yo!".to_string(),
         timestamp: Utc::now().naive_utc(),
         cancelled: false,
+        direction: TransactionDirection::Outbound,
     };
 
     let completed_tx2 = CompletedTransaction {
@@ -2690,7 +2695,7 @@ fn test_transaction_cancellation_sqlite_db() {
     let db_folder = temp_dir.path().to_str().unwrap().to_string();
     let connection = run_migration_and_create_sqlite_connection(&format!("{}/{}", db_folder, db_name)).unwrap();
 
-    test_transaction_cancellation(TransactionServiceSqliteDatabase::new(connection));
+    test_transaction_cancellation(TransactionServiceSqliteDatabase::new(connection, None));
 }
 
 #[test]

--- a/base_layer/wallet/tests/transaction_service/storage.rs
+++ b/base_layer/wallet/tests/transaction_service/storage.rs
@@ -41,6 +41,7 @@ use tari_wallet::{
             OutboundTransaction,
             TransactionBackend,
             TransactionDatabase,
+            TransactionDirection,
             TransactionStatus,
         },
         memory_db::TransactionMemoryDatabase,
@@ -195,6 +196,7 @@ pub fn test_db_backend<T: TransactionBackend + 'static>(backend: T) {
             message: messages[i].clone(),
             timestamp: Utc::now().naive_utc(),
             cancelled: false,
+            direction: TransactionDirection::Outbound,
         });
         runtime
             .block_on(db.complete_outbound_transaction(outbound_txs[i].tx_id, completed_txs[i].clone()))
@@ -437,5 +439,5 @@ pub fn test_transaction_service_sqlite_db() {
     let db_path = format!("{}/{}", db_folder, db_name);
     let connection = run_migration_and_create_sqlite_connection(&db_path).unwrap();
 
-    test_db_backend(TransactionServiceSqliteDatabase::new(connection));
+    test_db_backend(TransactionServiceSqliteDatabase::new(connection, None));
 }

--- a/base_layer/wallet_ffi/wallet.h
+++ b/base_layer/wallet_ffi/wallet.h
@@ -230,6 +230,10 @@ unsigned long long completed_transaction_get_transaction_id(struct TariCompleted
 // Gets the timestamp of a TariCompletedTransaction
 unsigned long long completed_transaction_get_timestamp(struct TariCompletedTransaction *transaction,int* error_out);
 
+// Checks if a TariCompletedTransaction was originally a TariPendingOutboundTransaction,
+// i.e the transaction was originally sent from the wallet
+bool completed_transaction_is_outbound(struct TariCompletedTransaction *tx,int* error_out);
+
 // Frees memory for a TariCompletedTransaction
 void completed_transaction_destroy(struct TariCompletedTransaction *transaction);
 
@@ -426,10 +430,6 @@ struct TariCompletedTransaction *wallet_get_cancelled_transaction_by_id(struct T
 // Simulates completion of a TariPendingOutboundTransaction
 bool wallet_test_complete_sent_transaction(struct TariWallet *wallet, struct TariPendingOutboundTransaction *tx,int* error_out);
 
-// Checks if a TariCompletedTransaction was originally a TariPendingOutboundTransaction,
-// i.e the transaction was originally sent from the wallet
-bool wallet_is_completed_transaction_outbound(struct TariWallet *wallet, struct TariCompletedTransaction *tx,int* error_out);
-
 // Import a UTXO into the wallet. This will add a spendable UTXO and create a faux completed transaction to record the
 // event.
 unsigned long long wallet_import_utxo(struct TariWallet *wallet, unsigned long long amount, struct TariPrivateKey *spending_key, struct TariPublicKey *source_public_key, const char *message, int* error_out);
@@ -464,12 +464,14 @@ unsigned long long wallet_coin_split(struct TariWallet *wallet, unsigned long lo
 /// Get the seed words representing the seed private key of the provided TariWallet
 struct TariSeedWords *wallet_get_seed_words(struct TariWallet *wallet, int* error_out);
 
+// This function will produce a partial backup of the wallet at the location specified but with the sensitive data cleared.
+void wallet_partial_backup(struct TariWallet *wallet, const char *backup_file_path, int* error_out);
+
 // Frees memory for a TariWallet
 void wallet_destroy(struct TariWallet *wallet);
 
 /// This function will log the provided string at debug level. To be used to have a client log messages to the LibWallet
 void log_debug_message(const char* msg);
-
 
 struct EmojiSet *get_emoji_set(void);
 


### PR DESCRIPTION
## Description
This PR adds functionality to produce a partial wallet backup that excludes the Comms Secret Key from the backup. This is to be used when the balance in a wallet is below a certain threshold so is low risk to backup without passphrase encryption. 

This use case is to allow for automatic backing up in the early use of the wallet while there are little funds so we don’t want to bother the nascent user with passphrase when the risk is low. When the funds are above a certain threshold an encryption passphrase would be required.

This PR adds:
- DB migration to store transaction direction for CompletedTransactions rather than relying on examining the Source Public Key. This is so that after a backup where the Private Key is cleared event though a new private key is generated the wallet can still tell which transactions were inbound or outbound.
- Functionality to perform the backup, clear the sensitive data and write it to the specified file.
- FFI interface to this functionality.

Restoration will be done by copying this backup file to the device and starting the wallet providing this db file as the database.

Because it is a Sqlite file and has the migration history inside it will automatically be migrated to new DB schema. When it is detected that there is no Comms Secret Key in the database a new one will be generated.

@kukabi @jasonvdb
There is a new FFI function that will need to be added to the wrapper but also I changed `wallet_is_completed_transaction_outbound(...)` to `completed_transaction_is_outbound(...)` as this check can now be done without needing to compare to the current Comms Public Key.

## Motivation and Context
Closes https://github.com/tari-project/tari/issues/2009

## How Has This Been Tested?
Tests provided to check the manual database migration logic.
Tests provided to exercise the backup process in the backend and in the FFI.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [x] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch.
* [x] I ran `cargo-fmt --all` before pushing.
* [ ] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
