### PR TITLE
Fix bug where the failed UTXO Sync callback is called twice

### DIFF
--- a/base_layer/wallet/src/output_manager_service/protocols/utxo_validation_protocol.rs
+++ b/base_layer/wallet/src/output_manager_service/protocols/utxo_validation_protocol.rs
@@ -100,11 +100,9 @@ where TBackend: OutputManagerBackend + Clone + 'static
             })?
             .fuse();
 
-        trace!(
+        debug!(
             target: LOG_TARGET,
-            "Starting UTXO validation protocol (Id: {}) for {}",
-            self.id,
-            self.validation_type,
+            "Starting UTXO validation protocol (Id: {}) for {}", self.id, self.validation_type,
         );
 
         let outputs_to_query: Vec<Vec<u8>> = match self.validation_type {
@@ -133,10 +131,9 @@ where TBackend: OutputManagerBackend + Clone + 'static
         };
 
         if outputs_to_query.is_empty() {
-            trace!(
+            debug!(
                 target: LOG_TARGET,
-                "UTXO validation protocol (Id: {}) has no outputs to validate",
-                self.id,
+                "UTXO validation protocol (Id: {}) has no outputs to validate", self.id,
             );
             return Ok(self.id);
         }
@@ -157,7 +154,7 @@ where TBackend: OutputManagerBackend + Clone + 'static
                     base_node_response = base_node_response_receiver.select_next_some() => {
                         match base_node_response {
                             Ok(response) => if self.handle_base_node_response(response).await? {
-                            error!(target: LOG_TARGET, "Response handled with success for {} and pending_queries len: {}", self.id, self.pending_queries.len());
+                                trace!(target: LOG_TARGET, "Response handled with success for {} and pending_queries len: {}", self.id, self.pending_queries.len());
                                 if self.pending_queries.is_empty() {
                                     let _ = self
                                         .resources


### PR DESCRIPTION
## Description
Currently when the output manager service performs a UTXO validation if the process times out two events are emitted: one for the timeout and 1 for the failed protocol as by default only 1 attempt was made. Both these events trigger a callback to the FFI client. 

This PR stops the emission of one of these events on a Validation protocol timeout so only 1 callback occurs.

This PR also updates some of the logging in the Output Manager Service.

## How Has This Been Tested?
Existing tests

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch.
* [x] I ran `cargo-fmt --all` before pushing.
* [ ] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
