### PR TITLE
Added total faucet input value to consensus constants

### DIFF
--- a/base_layer/core/src/blocks/genesis_block.rs
+++ b/base_layer/core/src/blocks/genesis_block.rs
@@ -140,12 +140,23 @@ pub fn get_rincewind_gen_header() -> BlockHeader {
 #[cfg(test)]
 mod test {
     use super::*;
+    use crate::{
+        consensus::{ConsensusManagerBuilder, Network},
+        transactions::types::CryptoFactories,
+    };
 
     #[test]
-    fn load_rincewind() {
+    fn rincewind_genesis_sanity_check() {
         let block = get_rincewind_genesis_block();
-
         assert_eq!(block.body.outputs().len(), 4001);
+
+        let factories = CryptoFactories::default();
+        let coinbase = block.body.outputs().first().unwrap();
+        assert!(coinbase.is_coinbase());
+        coinbase.verify_range_proof(&factories.range_proof).unwrap();
+        for kernel in block.body.kernels() {
+            kernel.verify_signature().unwrap();
+        }
     }
 
     #[test]

--- a/base_layer/core/src/consensus/consensus_constants.rs
+++ b/base_layer/core/src/consensus/consensus_constants.rs
@@ -59,6 +59,7 @@ pub struct ConsensusConstants {
     pub(in crate::consensus) emission_tail: MicroTari,
     /// This is the initial min difficulty for the difficulty adjustment
     min_pow_difficulty: (Difficulty, Difficulty),
+    total_genesis_input_value: MicroTari,
 }
 // The target time used by the difficulty adjustment algorithms, their target time is the target block interval * PoW
 // algorithm count
@@ -131,12 +132,17 @@ impl ConsensusConstants {
         self.median_timestamp_count
     }
 
-    // This is the min initial difficulty that can be requested for the pow
+    /// This is the min initial difficulty that can be requested for the pow
     pub fn min_pow_difficulty(&self, pow_algo: PowAlgorithm) -> Difficulty {
         match pow_algo {
             PowAlgorithm::Monero => self.min_pow_difficulty.0,
             PowAlgorithm::Blake => self.min_pow_difficulty.1,
         }
+    }
+
+    /// The total value of the genesis block inputs
+    pub fn get_total_genesis_input_value(&self) -> MicroTari {
+        self.total_genesis_input_value
     }
 
     #[allow(clippy::identity_op)]
@@ -157,6 +163,7 @@ impl ConsensusConstants {
             emission_decay: 0.999_999_560_409_038_5,
             emission_tail: 1 * T,
             min_pow_difficulty: (1.into(), 60_000_000.into()),
+            total_genesis_input_value: 20_471_490 * T,
         }
     }
 
@@ -177,6 +184,7 @@ impl ConsensusConstants {
             emission_decay: 0.999,
             emission_tail: 100.into(),
             min_pow_difficulty: (1.into(), 1.into()),
+            total_genesis_input_value: 20_471_490 * T,
         }
     }
 
@@ -198,6 +206,7 @@ impl ConsensusConstants {
             emission_decay: 0.999,
             emission_tail: 100.into(),
             min_pow_difficulty: (1.into(), 500_000_000.into()),
+            total_genesis_input_value: 0.into(),
         }
     }
 }

--- a/base_layer/core/src/transactions/transaction.rs
+++ b/base_layer/core/src/transactions/transaction.rs
@@ -352,6 +352,11 @@ impl TransactionOutput {
     pub fn is_equal_to(&self, output: &TransactionInput) -> bool {
         self.commitment == output.commitment && self.features == output.features
     }
+
+    /// Returns true if the output is a coinbase, otherwise false
+    pub fn is_coinbase(&self) -> bool {
+        self.features.flags.contains(OutputFlags::COINBASE_OUTPUT)
+    }
 }
 
 /// Implement the canonical hashing function for TransactionOutput for use in ordering.


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
The PR adds the total value for the faucet TXOs that will be used to
validate the pruning horizon UTXO state.

Also added a sanity check to the rincewind genesis block test

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The total faucet TXO value is required to validate the pruning horizon UTXO set

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
N/A - tests making use of this value will be added in the upcoming pruned horizon sync validation PR

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch.
* [x] I ran `cargo-fmt --all` before pushing.
* [x] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
