### PR TITLE
Fix for block to large error

### DIFF
--- a/applications/tari_base_node/src/grpc/server.rs
+++ b/applications/tari_base_node/src/grpc/server.rs
@@ -32,9 +32,15 @@ use tari_core::{
     base_node::LocalNodeCommsInterface,
     blocks::{Block, BlockHeader},
     chain_storage::HistoricalBlock,
-    consensus::{emission::EmissionSchedule, ConsensusConstants, Network},
+    consensus::{
+        emission::EmissionSchedule,
+        ConsensusConstants,
+        Network,
+        KERNEL_WEIGHT,
+        WEIGHT_PER_INPUT,
+        WEIGHT_PER_OUTPUT,
+    },
     proof_of_work::PowAlgorithm,
-    transactions::fee::{KERNEL_WEIGHT, WEIGHT_PER_INPUT, WEIGHT_PER_OUTPUT},
 };
 use tari_crypto::tari_utilities::{epoch_time::EpochTime, ByteArray, Hashable};
 use tokio::{runtime, sync::mpsc};

--- a/base_layer/core/src/base_node/comms_interface/inbound_handlers.rs
+++ b/base_layer/core/src/base_node/comms_interface/inbound_handlers.rs
@@ -269,7 +269,7 @@ where T: BlockchainBackend + 'static
                     self.mempool.clone(),
                     self.consensus_manager
                         .consensus_constants()
-                        .get_max_block_transaction_weight(),
+                        .get_max_block_weight_excluding_coinbase(),
                 )
                 .await
                 .map_err(|e| CommsInterfaceError::MempoolError(e.to_string()))?

--- a/base_layer/core/src/consensus/consensus_constants.rs
+++ b/base_layer/core/src/consensus/consensus_constants.rs
@@ -29,6 +29,10 @@ use chrono::{DateTime, Duration, Utc};
 use std::ops::Add;
 use tari_crypto::tari_utilities::epoch_time::EpochTime;
 
+pub const WEIGHT_PER_INPUT: u64 = 1;
+pub const WEIGHT_PER_OUTPUT: u64 = 13;
+pub const KERNEL_WEIGHT: u64 = 3; // Constant weight per transaction; covers kernel and part of header.
+
 /// This is the inner struct used to control all consensus values.
 #[derive(Clone)]
 pub struct ConsensusConstants {
@@ -107,6 +111,11 @@ impl ConsensusConstants {
     /// Maximum transaction weight used for the construction of new blocks.
     pub fn get_max_block_transaction_weight(&self) -> u64 {
         self.max_block_transaction_weight
+    }
+
+    /// Maximum transaction weight used for the construction of new blocks. It leaves place for 1 kernel and 1 output
+    pub fn get_max_block_weight_excluding_coinbase(&self) -> u64 {
+        self.max_block_transaction_weight - WEIGHT_PER_OUTPUT - KERNEL_WEIGHT
     }
 
     /// The amount of PoW algorithms used by the Tari chain.

--- a/base_layer/core/src/consensus/mod.rs
+++ b/base_layer/core/src/consensus/mod.rs
@@ -26,6 +26,12 @@ mod network;
 
 pub mod emission;
 
-pub use consensus_constants::{ConsensusConstants, ConsensusConstantsBuilder};
+pub use consensus_constants::{
+    ConsensusConstants,
+    ConsensusConstantsBuilder,
+    KERNEL_WEIGHT,
+    WEIGHT_PER_INPUT,
+    WEIGHT_PER_OUTPUT,
+};
 pub use consensus_manager::{ConsensusManager, ConsensusManagerBuilder, ConsensusManagerError};
 pub use network::Network;

--- a/base_layer/core/src/transactions/fee.rs
+++ b/base_layer/core/src/transactions/fee.rs
@@ -20,13 +20,12 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use crate::transactions::{tari_amount::*, transaction::MINIMUM_TRANSACTION_FEE};
+use crate::{
+    consensus::{KERNEL_WEIGHT, WEIGHT_PER_INPUT, WEIGHT_PER_OUTPUT},
+    transactions::{tari_amount::*, transaction::MINIMUM_TRANSACTION_FEE},
+};
 
 pub struct Fee {}
-
-pub const WEIGHT_PER_INPUT: u64 = 1;
-pub const WEIGHT_PER_OUTPUT: u64 = 13;
-pub const KERNEL_WEIGHT: u64 = 3; // Constant weight per transaction; covers kernel and part of header.
 
 impl Fee {
     /// Computes the absolute transaction fee given the fee-per-gram, and the size of the transaction

--- a/base_layer/core/src/transactions/transaction_protocol/transaction_initializer.rs
+++ b/base_layer/core/src/transactions/transaction_protocol/transaction_initializer.rs
@@ -313,17 +313,20 @@ impl SenderTransactionInitializer {
 
 #[cfg(test)]
 mod test {
-    use crate::transactions::{
-        fee::{Fee, KERNEL_WEIGHT, WEIGHT_PER_INPUT, WEIGHT_PER_OUTPUT},
-        helpers::{make_input, TestParams},
-        tari_amount::*,
-        transaction::{UnblindedOutput, MAX_TRANSACTION_INPUTS},
-        transaction_protocol::{
-            sender::SenderState,
-            transaction_initializer::SenderTransactionInitializer,
-            TransactionProtocolError,
+    use crate::{
+        consensus::{KERNEL_WEIGHT, WEIGHT_PER_INPUT, WEIGHT_PER_OUTPUT},
+        transactions::{
+            fee::Fee,
+            helpers::{make_input, TestParams},
+            tari_amount::*,
+            transaction::{UnblindedOutput, MAX_TRANSACTION_INPUTS},
+            transaction_protocol::{
+                sender::SenderState,
+                transaction_initializer::SenderTransactionInitializer,
+                TransactionProtocolError,
+            },
+            types::CryptoFactories,
         },
-        types::CryptoFactories,
     };
     use rand::rngs::OsRng;
     use tari_crypto::common::Blake256;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
The mempool gives a block to the miner with max weight = consensus.max_block_weight. But that does not leave enough space for the miner to add a coinbase output. This fixes the mempool to leave enough space for exactly one output. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch.
* [x] I ran `cargo-fmt --all` before pushing.
* [x] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
