### PR TITLE
Increase number of allowed Tx inputs and outputs

### DIFF
--- a/base_layer/core/src/transactions/transaction.rs
+++ b/base_layer/core/src/transactions/transaction.rs
@@ -56,9 +56,9 @@ use tari_crypto::{
     tari_utilities::{hex::Hex, message_format::MessageFormat, ByteArray, Hashable},
 };
 
-// These are set fairly arbitrarily at the moment. We'll need to do some modelling / testing to tune these values.
-pub const MAX_TRANSACTION_INPUTS: usize = 500;
-pub const MAX_TRANSACTION_OUTPUTS: usize = 100;
+// Tx_weight(inputs(12,500), outputs(500), kernels(1)) = 19,003, still well enough below block weight of 19,500
+pub const MAX_TRANSACTION_INPUTS: usize = 12_500;
+pub const MAX_TRANSACTION_OUTPUTS: usize = 500;
 pub const MAX_TRANSACTION_RECIPIENTS: usize = 15;
 pub const MINIMUM_TRANSACTION_FEE: MicroTari = MicroTari(100);
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Increase number of allowed Tx inputs and outputs to facilitate spending of "Dust".

## Motivation and Context
When doing many simultaneous transactions, lots of small valued UTXOs are gathered in the wallet. A consecutive Tx will try to spend the lowest valued UTXOs, and in many cases, this is limited by the overly conservative `MAX_TRANSACTION_INPUTS` limit. Increasing this limit will have the desired effect.

The proposed values translate to:
```
Tx_weight(inputs(12,500), outputs(500), kernels(1)) = 19,003
```
which is still well enough below the block weight of 19,500.

## How Has This Been Tested?
Tested in a base node

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [X] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [X] I'm merging against the `development` branch.
* [X] I ran `cargo-fmt --all` before pushing.
* [X] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
