### PR TITLE
Fix UTXO validation protocol not sending callback if there are no spendable outputs

### DIFF
--- a/base_layer/wallet/src/output_manager_service/protocols/utxo_validation_protocol.rs
+++ b/base_layer/wallet/src/output_manager_service/protocols/utxo_validation_protocol.rs
@@ -135,6 +135,18 @@ where TBackend: OutputManagerBackend + Clone + 'static
                 target: LOG_TARGET,
                 "UTXO validation protocol (Id: {}) has no outputs to validate", self.id,
             );
+            let _ = self
+                .resources
+                .event_publisher
+                .send(OutputManagerEvent::UtxoValidationSuccess(self.id))
+                .map_err(|e| {
+                    trace!(
+                        target: LOG_TARGET,
+                        "Error sending event {:?}, because there are no subscribers.",
+                        e.0
+                    );
+                    e
+                });
             return Ok(self.id);
         }
 


### PR DESCRIPTION
## Description

In the Output Manager service when the UTXO validation protocol is started the mobile clients expect a callback saying it succeeded or failed. However, there was a bug where if there were no spendable outputs to validate the protocol ended early and did not send the callback. 

This PR updates the protocol to send the callback with a success if this occurs.

## How Has This Been Tested?
Existing tests

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch.
* [x] I ran `cargo-fmt --all` before pushing.
* [ ] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
