### PR TITLE
Add Extra Wallet FFI Build to Circle CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,6 +32,15 @@ commands:
       - run:
           name: Run tests
           command: cargo test --workspace --all-features --jobs=3 <<#parameters.release>>--release<</parameters.release>>
+      - run:
+          # The FFI lib uses different features, so this tests that it still compiles with the feature subset
+          name: Build FFI lib
+          command: cargo build <<#parameters.release>>--release<</parameters.release>>
+          working_directory: base_layer/wallet_ffi
+      - run:
+          name: Test FFI lib
+          command: cargo test <<#parameters.release>>--release<</parameters.release>>
+          working_directory: base_layer/wallet_ffi
       - save_cache:
           paths:
             - /usr/local/cargo/registry


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->
Added 2 new `run` steps to the Circle CI config to run `cargo build` and `cargo test` from the `wallet_ffi` directory.

## Description
<!--- Describe your changes in detail -->
This is in order to catch compile and test errors on the feature subsets used by the wallet FFI

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
In PR #2038, a compile error crept in when run these commands in the wallet_ffi directory. This change hopefully will prevent that from happening again.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I ran the commands locally in the subdirectory, but will only know if it works when running on Circle CI

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [x] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch.
* [ ] I ran `cargo-fmt --all` before pushing.
* [x] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
