### PR TITLE
Update the GH action for building binaries to include OS/CPU/Feature matrix

### DIFF
--- a/.github/workflows/base_node_binaries.yml
+++ b/.github/workflows/base_node_binaries.yml
@@ -1,106 +1,145 @@
-# Build a new set of libraries when a new tag containing 'libwallet' is pushed
-name: Build binaries
+name: Build Matrix of Binaries
+
 on:
   push:
     tags:
       - "v[0-9].[0-9]+.[0-9]+"
+
+env:
+  TBN_FILENAME: 'tari_base_node'
+
 jobs:
-  ubuntu_binaries:
-    name: Build and deploy tari_base_node for Ubuntu
-    runs-on: ubuntu-latest
+  builds:
+    name: Build and deploy tari_base_node
     strategy:
       fail-fast: false
       matrix:
+#        os: [ubuntu-latest, macos-latest, windows-latest, seelf-hosted]
+        os: [ubuntu-18.04, macos-10.15, windows-2019]
         features: ["avx2", "safe"]
-        target_cpu: ["x86-64", "ivybridge", "skylake",]
+#        target_cpu: ["x86-64", "ivybridge", "skylake"]
+        target_cpu: ["x86-64", "ivybridge"]
+#        target_release: ["release", "debug"]
         exclude:
           - target_cpu: "x86-64"
             features: "avx2"
-          - target_cpu: "ivybridge"
-            features: "avx2"
+#          - target_cpu: "ivybridge"
+#            features: "avx2"
+
+    runs-on: ${{ matrix.os }}
 
     steps:
-      - name: Checkout source code
-        uses: actions/checkout@v2
-      - name: Install dependencies
-        run: |
-          sudo apt-get update && \
-          sudo apt-get -y install \
+    - name: Checkout source code
+      uses: actions/checkout@v2
+
+    - name: Setup Rust toolchain
+      uses: actions-rs/toolchain@v1
+      with:
+#        toolchain: stable
+        toolchain: nightly-2020-06-10
+        components: rustfmt
+#        target: ${{ matrix.target }}
+        override: true
+
+    - name: Install Ubuntu dependencies
+      if: startsWith(matrix.os,'ubuntu')
+      run: |
+        sudo apt-get update && \
+        sudo apt-get -y install \
           openssl \
           libssl-dev \
           pkg-config \
           libsqlite3-dev \
           git \
           cmake \
+          zip \
           libc++-dev \
           libc++abi-dev \
           libprotobuf-dev \
           protobuf-compiler
-      - name: Install Rust
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: nightly-2020-06-10
-          components: rustfmt
-      - name: Build ubuntu binaries, hash and zip them
-        env:
-          ROARING_ARCH: "${{ matrix.target_cpu }}"
-          RUSTFLAGS: "-C target_cpu=${{ matrix.target_cpu }}"
-          CC: gcc
-        run: |
-          cd applications/tari_base_node
-          cargo build --release --bin tari_base_node --features ${{ matrix.features }}
-          mkdir -p $GITHUB_WORKSPACE/binaries/ubuntu
-          cd $GITHUB_WORKSPACE/binaries/ubuntu
-          VERSION=$(awk -F ' = ' '$1 ~ /version/ { gsub(/[\"]/, "", $2); printf("%s",$2) }' $GITHUB_WORKSPACE/applications/tari_base_node/Cargo.toml)
-          BINFILE=tari_base_node-ubuntu-${{ matrix.target_cpu }}-${{ matrix.features }}-$VERSION
-          cp $GITHUB_WORKSPACE/target/release/tari_base_node ./$BINFILE
-          bzip2 -f $BINFILE
-          sha256sum $BINFILE.bz2 >> $BINFILE.bz2.sha256
-      - name: Sync to S3
-        uses: jakejarvis/s3-sync-action@v0.5.1
-        with:
-          args: --acl public-read --follow-symlinks
-        env:
-          AWS_S3_BUCKET: ${{ secrets.AWS_S3_BUCKET }}
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          AWS_REGION:  '${{ secrets.AWS_REGION }}'
-          SOURCE_DIR: '$GITHUB_WORKSPACE/binaries/ubuntu'
-          DEST_DIR: 'linux'
-  osx_binaries:
-    name: Build and deploy tari_base_node for MacOs
-    runs-on: macos-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        target_cpu: ["skylake"]
-    steps:
-      - name: Checkout source code
-        uses: actions/checkout@v2
-      - name: Install Rust
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: nightly-2020-06-10
-          target: x86_64-apple-darwin
-          components: rustfmt
-      - name: Build MacOs binaries, hash and zip them
-        env:
-          ROARING_ARCH: "${{ matrix.target_cpu }}"
-          RUSTFLAGS: "-C target_cpu=${{ matrix.target_cpu }}"
-        run: |
-          cd applications/tari_base_node
-          cargo build --release --bin tari_base_node --target x86_64-apple-darwin
-          mkdir -p $GITHUB_WORKSPACE/binaries/osx
-          cd $GITHUB_WORKSPACE/binaries/osx
-          VERSION=$(awk -F ' = ' '$1 ~ /version/ { gsub(/[\"]/, "", $2); printf("%s",$2) }' $GITHUB_WORKSPACE/applications/tari_base_node/Cargo.toml)
-          BINFILE=tari_base_node-osx-${{ matrix.target_cpu }}-$VERSION
-          cp $GITHUB_WORKSPACE/target/x86_64-apple-darwin/release/tari_base_node ./$BINFILE
-          bzip2 -f $BINFILE
-          shasum -a 256 $BINFILE.bz2 >> $BINFILE.bz2.sha256
-      - name: Sync to S3
-        env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          AWS_REGION:  '${{ secrets.AWS_REGION }}'
-        run: |
-          aws s3 cp --recursive $GITHUB_WORKSPACE/binaries/osx s3://${{ secrets.AWS_S3_BUCKET }}/osx/ --acl public-read
+    - name: Install macOS dependencies
+      if: startsWith(matrix.os,'macos')
+      run: brew install cmake zip
+    - name: Install Windows dependencies
+      if: startsWith(matrix.os,'windows')
+      run: |
+        vcpkg.exe install sqlite3:x64-windows zlib:x64-windows
+        choco upgrade llvm zip psutils -y
+
+    - name: Set environment variables - Nix
+      if: "!startsWith(matrix.os,'Windows')"
+      uses: allenevans/set-env@v1.0.0
+      with:
+        overwrite: true
+        CC: gcc
+        TBN_EXT: ''
+        S3DESTDIR: 'linux'
+        SHARUN: 'shasum --algorithm 256'
+#        SHARUN: 'shasum --portable --algorithm 256'
+    - name: Set environment variables - macOS
+      if: startsWith(matrix.os,'macos')
+      uses: allenevans/set-env@v1.0.0
+      with:
+        overwrite: true
+        S3DESTDIR: 'osx'
+    - name: Set environment variables - Windows
+      if: startsWith(matrix.os,'Windows')
+      uses: allenevans/set-env@v1.0.0
+      with:
+        overwrite: true
+        SQLITE3_LIB_DIR: 'C:\vcpkg\installed\x64-windows\lib'
+        TBN_EXT: '.exe'
+        S3DESTDIR: 'windows'
+        SHARUN: 'pwsh C:\ProgramData\chocolatey\lib\psutils\tools\psutils-master\shasum.ps1 --algorithm 256'
+#        SHARUN: 'pwsh C:\ProgramData\chocolatey\lib\psutils\tools\psutils-master\shasum.ps1 --portable --algorithm 256'
+#        RUSTFLAGS: '-Ctarget-feature=+crt-static'
+#        CC: gcc
+
+    - name: Build binaries
+#      continue-on-error: true  # WARNING: only for this example, remove it!
+      env:
+        RUSTFLAGS: '-C target_cpu=${{ matrix.target_cpu }}'
+        ROARING_ARCH: '${{ matrix.target_cpu }}'
+      shell: bash
+      run: |
+        cd applications/tari_base_node
+        cargo build --release --bin tari_base_node --features ${{ matrix.features}}
+
+    - name: Prep binaries for dist
+      shell: bash
+      run: |
+        mkdir -p "$GITHUB_WORKSPACE/dist/"
+        cd "$GITHUB_WORKSPACE/dist/"
+        VERSION=$(awk -F ' = ' '$1 ~ /version/ { gsub(/[\"]/, "", $2); printf("%s",$2) }' "$GITHUB_WORKSPACE/applications/tari_base_node/Cargo.toml")
+        echo ::set-env name=VERSION::${VERSION}
+        BINFILE="${TBN_FILENAME}-${{ matrix.os }}-${{ matrix.target_cpu }}-${{ matrix.features }}-${VERSION}${TBN_EXT}"
+        echo ::set-env name=BINFILE::${BINFILE}
+        echo "Copying file ${BINFILE} too $(pwd)"
+        cp -v "$GITHUB_WORKSPACE/target/release/${TBN_FILENAME}${TBN_EXT}" "./${BINFILE}"
+        echo "Archive ${BINFILE} too ${BINFILE}.zip"
+        zip -j "${BINFILE}.zip" "${BINFILE}"
+        echo "Compute shasum"
+        ${SHARUN} "${BINFILE}.zip" >> "${BINFILE}.zip.sha256"
+        cat "${BINFILE}.zip.sha256"
+        echo "Verifications is "
+        ${SHARUN} --check "${BINFILE}.zip.sha256"
+        rm -f "${BINFILE}"
+#        printenv
+
+#    - name: Upload binary
+#      uses: actions/upload-artifact@v2
+#      with:
+#        name: ${{ env.TBN_FILENAME }} - ${{ env.VERSION }} - release - ${{ matrix.os }} ${{ matrix.target_cpu }} ${{ matrix.features }}
+#        path: '${{ github.workspace }}/dist/${{ env.BINFILE }}.zip*'
+
+    - name: Sync dist to S3
+      uses: jakejarvis/s3-sync-action@v0.5.1
+      with:
+        args: --acl public-read --follow-symlinks
+      env:
+        AWS_S3_BUCKET: ${{ secrets.AWS_S3_BUCKET }}
+        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        AWS_REGION: '${{ secrets.AWS_REGION }}'
+        SOURCE_DIR: '$GITHUB_WORKSPACE/dist'
+        DEST_DIR: '${{ env.S3DESTDIR }}'


### PR DESCRIPTION
Update the GH action for building binaries to include OS/CPU/Feature matrix

## Description
Removed the job peer OS to use env setup and the same builder steps and uploads, should reduce
differences between OS/CPU/Feature selection and future changes only needed in one place.

## How Has This Been Tested?
Ran multiple builds in my own branch and downloaded bin/shasum

## Types of changes
* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
* [x] I'm merging against the `development` branch.
* [ ] I ran `cargo-fmt --all` before pushing.
* [x] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
