### PR TITLE
Remove Peer persistence in Wallet

### DIFF
--- a/base_layer/wallet/migrations/2020-07-08-083612_remove_peer_table/down.sql
+++ b/base_layer/wallet/migrations/2020-07-08-083612_remove_peer_table/down.sql
@@ -1,0 +1,4 @@
+CREATE TABLE peers (
+    public_key BLOB PRIMARY KEY NOT NULL UNIQUE,
+    peer TEXT NOT NULL
+);

--- a/base_layer/wallet/migrations/2020-07-08-083612_remove_peer_table/up.sql
+++ b/base_layer/wallet/migrations/2020-07-08-083612_remove_peer_table/up.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS peers;

--- a/base_layer/wallet/src/schema.rs
+++ b/base_layer/wallet/src/schema.rs
@@ -71,13 +71,6 @@ table! {
 }
 
 table! {
-    peers (public_key) {
-        public_key -> Binary,
-        peer -> Text,
-    }
-}
-
-table! {
     pending_transaction_outputs (tx_id) {
         tx_id -> BigInt,
         short_term -> Integer,
@@ -99,7 +92,6 @@ allow_tables_to_appear_in_same_query!(
     key_manager_states,
     outbound_transactions,
     outputs,
-    peers,
     pending_transaction_outputs,
     wallet_settings,
 );

--- a/base_layer/wallet/src/storage/database.rs
+++ b/base_layer/wallet/src/storage/database.rs
@@ -27,10 +27,7 @@ use std::{
     path::PathBuf,
     sync::Arc,
 };
-use tari_comms::{
-    peer_manager::Peer,
-    types::{CommsPublicKey, CommsSecretKey},
-};
+use tari_comms::types::CommsSecretKey;
 
 const LOG_TARGET: &str = "wallet::database";
 
@@ -44,39 +41,21 @@ pub trait WalletBackend: Send + Sync {
 
 #[derive(Debug, Clone, PartialEq)]
 pub enum DbKey {
-    Peer(CommsPublicKey),
-    Peers,
     CommsSecretKey,
 }
 
 pub enum DbValue {
-    Peer(Box<Peer>),
-    Peers(Vec<Peer>),
     CommsSecretKey(CommsSecretKey),
 }
 
 #[derive(Clone)]
 pub enum DbKeyValuePair {
-    Peer(CommsPublicKey, Peer),
     CommsSecretKey(CommsSecretKey),
 }
 
 pub enum WriteOperation {
     Insert(DbKeyValuePair),
     Remove(DbKey),
-}
-
-// Private macro that pulls out all the boiler plate of extracting a DB query result from its variants
-macro_rules! fetch {
-    ($db:ident, $key_val:expr, $key_var:ident) => {{
-        let key = DbKey::$key_var($key_val);
-        match $db.fetch(&key) {
-            Ok(None) => Err(WalletStorageError::ValueNotFound(key)),
-            Ok(Some(DbValue::$key_var(k))) => Ok(*k),
-            Ok(Some(other)) => unexpected_result(key, other),
-            Err(e) => log_error(key, e),
-        }
-    }};
 }
 
 pub struct WalletDatabase<T>
@@ -91,65 +70,6 @@ where T: WalletBackend + 'static
 {
     pub fn new(db: T, path: Option<PathBuf>) -> Self {
         Self { db: Arc::new(db), path }
-    }
-
-    pub async fn get_peer(&self, pub_key: CommsPublicKey) -> Result<Peer, WalletStorageError> {
-        let db_clone = self.db.clone();
-
-        tokio::task::spawn_blocking(move || fetch!(db_clone, pub_key.clone(), Peer))
-            .await
-            .map_err(|err| WalletStorageError::BlockingTaskSpawnError(err.to_string()))
-            .and_then(|inner_result| inner_result)
-    }
-
-    pub async fn get_peers(&self) -> Result<Vec<Peer>, WalletStorageError> {
-        let db_clone = self.db.clone();
-
-        let c = tokio::task::spawn_blocking(move || match db_clone.fetch(&DbKey::Peers) {
-            Ok(None) => log_error(
-                DbKey::Peers,
-                WalletStorageError::UnexpectedResult("Could not retrieve peers".to_string()),
-            ),
-            Ok(Some(DbValue::Peers(c))) => Ok(c),
-            Ok(Some(other)) => unexpected_result(DbKey::Peers, other),
-            Err(e) => log_error(DbKey::Peers, e),
-        })
-        .await
-        .map_err(|err| WalletStorageError::BlockingTaskSpawnError(err.to_string()))??;
-        Ok(c)
-    }
-
-    pub async fn save_peer(&self, peer: Peer) -> Result<(), WalletStorageError> {
-        let db_clone = self.db.clone();
-
-        tokio::task::spawn_blocking(move || {
-            db_clone.write(WriteOperation::Insert(DbKeyValuePair::Peer(
-                peer.public_key.clone(),
-                peer,
-            )))
-        })
-        .await
-        .map_err(|err| WalletStorageError::BlockingTaskSpawnError(err.to_string()))??;
-        Ok(())
-    }
-
-    pub async fn remove_peer(&self, pub_key: CommsPublicKey) -> Result<Peer, WalletStorageError> {
-        let db_clone = self.db.clone();
-
-        tokio::task::spawn_blocking(move || {
-            match db_clone
-                .write(WriteOperation::Remove(DbKey::Peer(pub_key.clone())))?
-                .ok_or_else(|| WalletStorageError::ValueNotFound(DbKey::Peer(pub_key.clone())))?
-            {
-                DbValue::Peer(c) => Ok(*c),
-                _ => Err(WalletStorageError::UnexpectedResult(
-                    "Incorrect response from backend.".to_string(),
-                )),
-            }
-        })
-        .await
-        .map_err(|err| WalletStorageError::BlockingTaskSpawnError(err.to_string()))
-        .and_then(|inner_result| inner_result)
     }
 
     pub async fn get_comms_secret_key(&self) -> Result<Option<CommsSecretKey>, WalletStorageError> {
@@ -195,8 +115,6 @@ fn unexpected_result<T>(req: DbKey, res: DbValue) -> Result<T, WalletStorageErro
 impl Display for DbKey {
     fn fmt(&self, f: &mut Formatter) -> Result<(), Error> {
         match self {
-            DbKey::Peer(c) => f.write_str(&format!("Peer: {:?}", c)),
-            DbKey::Peers => f.write_str(&"Peers".to_string()),
             DbKey::CommsSecretKey => f.write_str(&"CommsSecretKey".to_string()),
         }
     }
@@ -205,8 +123,6 @@ impl Display for DbKey {
 impl Display for DbValue {
     fn fmt(&self, f: &mut Formatter) -> Result<(), Error> {
         match self {
-            DbValue::Peer(p) => f.write_str(&format!("Peer: {:?}", p)),
-            DbValue::Peers(_) => f.write_str(&"Peers".to_string()),
             DbValue::CommsSecretKey(k) => f.write_str(&format!("CommsSecretKey: {:?}", k)),
         }
     }
@@ -224,23 +140,15 @@ fn log_error<T>(req: DbKey, err: WalletStorageError) -> Result<T, WalletStorageE
 
 #[cfg(test)]
 mod test {
-    use crate::{
-        error::WalletStorageError,
-        storage::{
-            connection_manager::run_migration_and_create_sqlite_connection,
-            database::{DbKey, WalletBackend, WalletDatabase},
-            memory_db::WalletMemoryDatabase,
-            sqlite_db::WalletSqliteDatabase,
-        },
+    use crate::storage::{
+        connection_manager::run_migration_and_create_sqlite_connection,
+        database::{WalletBackend, WalletDatabase},
+        memory_db::WalletMemoryDatabase,
+        sqlite_db::WalletSqliteDatabase,
     };
     use rand::rngs::OsRng;
-    use tari_comms::{
-        multiaddr::Multiaddr,
-        peer_manager::{NodeId, Peer, PeerFeatures, PeerFlags},
-        types::{CommsPublicKey, CommsSecretKey},
-    };
-    use tari_core::transactions::types::PublicKey;
-    use tari_crypto::keys::{PublicKey as PublicKeyTrait, SecretKey};
+    use tari_comms::types::CommsSecretKey;
+    use tari_crypto::keys::SecretKey;
     use tari_test_utils::random::string;
     use tempfile::tempdir;
     use tokio::runtime::Runtime;
@@ -249,53 +157,6 @@ mod test {
         let mut runtime = Runtime::new().unwrap();
 
         let db = WalletDatabase::new(backend, None);
-
-        let mut peers = Vec::new();
-        for i in 0..5 {
-            let (_secret_key, public_key): (CommsSecretKey, CommsPublicKey) = PublicKey::random_keypair(&mut OsRng);
-
-            let peer = Peer::new(
-                public_key.clone(),
-                NodeId::from_key(&public_key).unwrap(),
-                "/ip4/1.2.3.4/tcp/9000".parse::<Multiaddr>().unwrap().into(),
-                PeerFlags::empty(),
-                PeerFeatures::COMMUNICATION_NODE,
-                &[],
-            );
-
-            peers.push(peer);
-
-            runtime.block_on(db.save_peer(peers[i].clone())).unwrap();
-
-            match runtime.block_on(db.save_peer(peers[i].clone())) {
-                Err(WalletStorageError::DuplicateContact) => (),
-                _ => assert!(false),
-            }
-        }
-
-        let got_peers = runtime.block_on(db.get_peers()).unwrap();
-        assert_eq!(peers, got_peers);
-
-        let peer = runtime.block_on(db.get_peer(peers[0].public_key.clone())).unwrap();
-        assert_eq!(peer, peers[0]);
-
-        let (_secret_key, public_key): (_, PublicKey) = PublicKeyTrait::random_keypair(&mut OsRng);
-
-        match runtime.block_on(db.get_peer(public_key.clone())) {
-            Err(WalletStorageError::ValueNotFound(DbKey::Peer(_p))) => (),
-            _ => assert!(false),
-        }
-
-        match runtime.block_on(db.remove_peer(public_key.clone())) {
-            Err(WalletStorageError::ValueNotFound(DbKey::Peer(_p))) => (),
-            _ => assert!(false),
-        }
-
-        let _ = runtime.block_on(db.remove_peer(peers[0].public_key.clone())).unwrap();
-        peers.remove(0);
-        let got_peers = runtime.block_on(db.get_peers()).unwrap();
-
-        assert_eq!(peers, got_peers);
 
         // Test wallet settings
         assert!(runtime.block_on(db.get_comms_secret_key()).unwrap().is_none());

--- a/base_layer/wallet_ffi/src/lib.rs
+++ b/base_layer/wallet_ffi/src/lib.rs
@@ -509,6 +509,7 @@ pub unsafe extern "C" fn public_key_from_hex(key: *const c_char, error_out: *mut
     match public_key {
         Ok(public_key) => Box::into_raw(Box::new(public_key)),
         Err(e) => {
+            error!(target: LOG_TARGET, "Error creating a Public Key from Hex: {:?}", e);
             error = LibWalletError::from(e).code;
             ptr::swap(error_out, &mut error as *mut c_int);
             ptr::null_mut()
@@ -713,6 +714,8 @@ pub unsafe extern "C" fn private_key_from_hex(key: *const c_char, error_out: *mu
     match secret_key {
         Ok(secret_key) => Box::into_raw(Box::new(secret_key)),
         Err(e) => {
+            error!(target: LOG_TARGET, "Error creating a Public Key from Hex: {:?}", e);
+
             error = LibWalletError::from(e).code;
             ptr::swap(error_out, &mut error as *mut c_int);
             ptr::null_mut()
@@ -2567,6 +2570,7 @@ pub unsafe extern "C" fn wallet_create(
                 .datastore_path
                 .join((*config).peer_database_name.clone())
                 .with_extension("sqlite3");
+            debug!(target: LOG_TARGET, "Running Wallet database migrations");
             let connection = run_migration_and_create_sqlite_connection(&sql_database_path)
                 .map_err(|e| {
                     error!(


### PR DESCRIPTION
## Description
The persistence of base node peers is a vestigial feature from a time where we though the Wallet backend would handle all of the base node address monitoring. It has turned out that the Clients will manage base node peers and provide them to the wallet during Runtime. Further more this db implementation was producing a bug in the mobile clients due to its lack of a db transaction between reading the db and deleting all the peers on startup. 

This PR removes the unneeded Peer persistence to get rid of this bug. 

Some extra logging is added to the wallet and wallet_ffi for better future debugging purposes.

## How Has This Been Tested?
Existing tests

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch.
* [x] I ran `cargo-fmt --all` before pushing.
* [ ] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
