### PR TITLE
Add Weight Constants to transactions feature

### DIFF
--- a/base_layer/core/src/consensus/consensus_constants.rs
+++ b/base_layer/core/src/consensus/consensus_constants.rs
@@ -21,17 +21,13 @@
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 use crate::{
-    consensus::network::Network,
+    consensus::{network::Network, KERNEL_WEIGHT, WEIGHT_PER_OUTPUT},
     proof_of_work::{Difficulty, PowAlgorithm},
     transactions::tari_amount::{uT, MicroTari, T},
 };
 use chrono::{DateTime, Duration, Utc};
 use std::ops::Add;
 use tari_crypto::tari_utilities::epoch_time::EpochTime;
-
-pub const WEIGHT_PER_INPUT: u64 = 1;
-pub const WEIGHT_PER_OUTPUT: u64 = 13;
-pub const KERNEL_WEIGHT: u64 = 3; // Constant weight per transaction; covers kernel and part of header.
 
 /// This is the inner struct used to control all consensus values.
 #[derive(Clone)]

--- a/base_layer/core/src/consensus/mod.rs
+++ b/base_layer/core/src/consensus/mod.rs
@@ -20,18 +20,25 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+#[cfg(feature = "base_node")]
 mod consensus_constants;
+#[cfg(feature = "base_node")]
 mod consensus_manager;
+#[cfg(feature = "base_node")]
+pub mod emission;
+#[cfg(feature = "base_node")]
 mod network;
 
-pub mod emission;
+#[cfg(any(feature = "base_node", feature = "transactions"))]
+pub const WEIGHT_PER_INPUT: u64 = 1;
+#[cfg(any(feature = "base_node", feature = "transactions"))]
+pub const WEIGHT_PER_OUTPUT: u64 = 13;
+#[cfg(any(feature = "base_node", feature = "transactions"))]
+pub const KERNEL_WEIGHT: u64 = 3; // Constant weight per transaction; covers kernel and part of header.
 
-pub use consensus_constants::{
-    ConsensusConstants,
-    ConsensusConstantsBuilder,
-    KERNEL_WEIGHT,
-    WEIGHT_PER_INPUT,
-    WEIGHT_PER_OUTPUT,
-};
+#[cfg(feature = "base_node")]
+pub use consensus_constants::{ConsensusConstants, ConsensusConstantsBuilder};
+#[cfg(feature = "base_node")]
 pub use consensus_manager::{ConsensusManager, ConsensusManagerBuilder, ConsensusManagerError};
+#[cfg(feature = "base_node")]
 pub use network::Network;

--- a/base_layer/core/src/lib.rs
+++ b/base_layer/core/src/lib.rs
@@ -35,7 +35,7 @@ extern crate bitflags;
 pub mod blocks;
 #[cfg(feature = "base_node")]
 pub mod chain_storage;
-#[cfg(feature = "base_node")]
+#[cfg(any(feature = "base_node", feature = "transactions"))]
 pub mod consensus;
 #[cfg(feature = "base_node")]
 pub mod helpers;


### PR DESCRIPTION
Add the WEIGHT* related constants to the `transactions` feature so that they
can be referenced by the FFI crate

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Currently running `cargo test` and `cargo build` in the `wallet_ffi` folder doesn't work. Exposing the constants to the feature allows the crate to reference them.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested with `cargo test` in the `base_layer/wallet_ffi` directory

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch.
* [x] I ran `cargo-fmt --all` before pushing.
* [x] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
