### PR TITLE
Add partial wallet backup using only file paths

### DIFF
--- a/base_layer/wallet/src/storage/connection_manager.rs
+++ b/base_layer/wallet/src/storage/connection_manager.rs
@@ -66,7 +66,7 @@ pub async fn partial_wallet_backup<P: AsRef<Path>>(current_db: P, backup_path: P
 
     // open a connection and clear the Comms Private Key
     let connection = run_migration_and_create_sqlite_connection(backup_path)?;
-    let db = WalletDatabase::new(WalletSqliteDatabase::new(connection), None);
+    let db = WalletDatabase::new(WalletSqliteDatabase::new(connection));
     db.clear_comms_secret_key().await?;
 
     Ok(())

--- a/base_layer/wallet/src/wallet.rs
+++ b/base_layer/wallet/src/wallet.rs
@@ -139,12 +139,7 @@ where
         contacts_backend: W,
     ) -> Result<Wallet<T, U, V, W>, WalletError>
     {
-        let database_path = config
-            .comms_config
-            .datastore_path
-            .join(config.comms_config.peer_database_name.clone())
-            .with_extension("sqlite3");
-        let db = WalletDatabase::new(wallet_backend, Some(database_path));
+        let db = WalletDatabase::new(wallet_backend);
 
         #[cfg(feature = "test_harness")]
         let transaction_backend_handle = transaction_backend.clone();
@@ -191,10 +186,10 @@ where
             })
             .expect("Service initialization failed");
 
-        let mut output_manager_handle = handles
+        let output_manager_handle = handles
             .get_handle::<OutputManagerHandle>()
             .expect("Could not get Output Manager Service Handle");
-        let mut transaction_service_handle = handles
+        let transaction_service_handle = handles
             .get_handle::<TransactionServiceHandle>()
             .expect("Could not get Transaction Service Handle");
         let contacts_handle = handles

--- a/base_layer/wallet/tests/wallet/mod.rs
+++ b/base_layer/wallet/tests/wallet/mod.rs
@@ -253,12 +253,12 @@ fn test_wallet() {
 
     let connection =
         run_migration_and_create_sqlite_connection(&current_wallet_path).expect("Could not open Sqlite db");
-    let wallet_db = WalletDatabase::new(WalletSqliteDatabase::new(connection.clone()), None);
+    let wallet_db = WalletDatabase::new(WalletSqliteDatabase::new(connection.clone()));
     let comms_private_key = runtime.block_on(wallet_db.get_comms_secret_key()).unwrap();
     assert!(comms_private_key.is_some());
     // Checking that the backup has had its Comms Private Key is cleared.
     let connection = run_migration_and_create_sqlite_connection(&backup_wallet_path).expect("Could not open Sqlite db");
-    let backup_wallet_db = WalletDatabase::new(WalletSqliteDatabase::new(connection.clone()), None);
+    let backup_wallet_db = WalletDatabase::new(WalletSqliteDatabase::new(connection.clone()));
     let comms_private_key = runtime.block_on(backup_wallet_db.get_comms_secret_key()).unwrap();
     assert!(comms_private_key.is_none());
 }

--- a/base_layer/wallet_ffi/wallet.h
+++ b/base_layer/wallet_ffi/wallet.h
@@ -464,11 +464,13 @@ unsigned long long wallet_coin_split(struct TariWallet *wallet, unsigned long lo
 /// Get the seed words representing the seed private key of the provided TariWallet
 struct TariSeedWords *wallet_get_seed_words(struct TariWallet *wallet, int* error_out);
 
-// This function will produce a partial backup of the wallet at the location specified but with the sensitive data cleared.
-void wallet_partial_backup(struct TariWallet *wallet, const char *backup_file_path, int* error_out);
-
 // Frees memory for a TariWallet
 void wallet_destroy(struct TariWallet *wallet);
+
+// This function will produce a partial backup of the specified wallet database file (full file path must be provided.
+// This backup will be written to the provided file (full path must include the filename and extension) and will include
+// the full wallet db but will clear the sensitive Comms Private Key
+void file_partial_backup(const char *original_file_path, const char *backup_file_path, int* error_out);
 
 /// This function will log the provided string at debug level. To be used to have a client log messages to the LibWallet
 void log_debug_message(const char* msg);


### PR DESCRIPTION
## Description

The previous feature that allowed for a partial wallet backup (excluding the Comms Private Key) used an instantiated wallet instance to get the path of its database. This turned out to be unwieldy and it was requested that this feature be updated to just accept the file paths to the database file being backed up and to the backup location.

This PR replaces the `wallet_partial_backup(…)` FFI function with the `file_partial_backup(…)` which will copy the wallet database file and clear the Comms Private Key for unencrypted backup.

@kukabi @Jasonvdb please note the changes to the FFI interface.

## How Has This Been Tested?
tests updated

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [x] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch.
* [x] I ran `cargo-fmt --all` before pushing.
* [ ] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
