### PR TITLE
Update FFI wallet_get_pending_outbound_transactions(…) to work after a partial wallet restore

### DIFF
--- a/base_layer/wallet_ffi/src/lib.rs
+++ b/base_layer/wallet_ffi/src/lib.rs
@@ -3577,11 +3577,10 @@ pub unsafe extern "C" fn wallet_get_pending_outbound_transactions(
                 // classified as Pending Transactions. In order to support this logic without impacting the practical
                 // definitions and storage of a MimbleWimble CompletedTransaction we will add those transaction to the
                 // list here in the FFI interface
-                let my_public_key = (*wallet).comms.node_identity().public_key().clone();
                 for ct in completed_txs
                     .values()
                     .filter(|ct| ct.status == TransactionStatus::Completed || ct.status == TransactionStatus::Broadcast)
-                    .filter(|ct| ct.source_public_key == my_public_key)
+                    .filter(|ct| ct.direction == TransactionDirection::Outbound)
                 {
                     pending.push(OutboundTransaction::from(ct.clone()));
                 }


### PR DESCRIPTION
## Description
Previously this function compared the current Comms Public Key to the Source public key of each transaction to decide if it was outbound. After a Partial wallet restore a new Comms Public Key is generated so this function would not be able to tell that a given transaction was Outbound. 

This PR updates this function to use the stored TransactionDirection to make this determination which will work after a partial wallet restore.

@kukabi 

## How Has This Been Tested?
Existing tests

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch.
* [x] I ran `cargo-fmt --all` before pushing.
* [ ] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
