### PR TITLE
Expand searching of blockchain

### DIFF
--- a/base_layer/core/src/base_node/comms_interface/comms_request.rs
+++ b/base_layer/core/src/base_node/comms_interface/comms_request.rs
@@ -24,7 +24,7 @@ use crate::{
     blocks::NewBlockTemplate,
     chain_storage::MmrTree,
     proof_of_work::PowAlgorithm,
-    transactions::types::HashOutput,
+    transactions::types::{Commitment, HashOutput, Signature},
 };
 use serde::{Deserialize, Serialize};
 use std::fmt::{Display, Error, Formatter};
@@ -49,6 +49,9 @@ pub enum NodeCommsRequest {
     FetchTxos(Vec<HashOutput>),
     FetchBlocks(Vec<u64>),
     FetchBlocksWithHashes(Vec<HashOutput>),
+    FetchBlocksWithKernels(Vec<Signature>),
+    FetchBlocksWithStxos(Vec<Commitment>),
+    FetchBlocksWithUtxos(Vec<Commitment>),
     GetNewBlockTemplate(PowAlgorithm),
     GetNewBlock(NewBlockTemplate),
     GetTargetDifficulty(PowAlgorithm),
@@ -68,6 +71,11 @@ impl Display for NodeCommsRequest {
             NodeCommsRequest::FetchTxos(v) => f.write_str(&format!("FetchTxos (n={})", v.len())),
             NodeCommsRequest::FetchBlocks(v) => f.write_str(&format!("FetchBlocks (n={})", v.len())),
             NodeCommsRequest::FetchBlocksWithHashes(v) => f.write_str(&format!("FetchBlocks (n={})", v.len())),
+            NodeCommsRequest::FetchBlocksWithKernels(v) => {
+                f.write_str(&format!("FetchBlocksWithKernels (n={})", v.len()))
+            },
+            NodeCommsRequest::FetchBlocksWithStxos(v) => f.write_str(&format!("FetchBlocksWithStxos (n={})", v.len())),
+            NodeCommsRequest::FetchBlocksWithUtxos(v) => f.write_str(&format!("FetchBlocksWithUtxos (n={})", v.len())),
             NodeCommsRequest::GetNewBlockTemplate(algo) => f.write_str(&format!("GetNewBlockTemplate ({})", algo)),
             NodeCommsRequest::GetNewBlock(b) => f.write_str(&format!("GetNewBlock (Block Height={})", b.header.height)),
             NodeCommsRequest::GetTargetDifficulty(algo) => f.write_str(&format!("GetTargetDifficulty ({})", algo)),

--- a/base_layer/core/src/base_node/comms_interface/inbound_handlers.rs
+++ b/base_layer/core/src/base_node/comms_interface/inbound_handlers.rs
@@ -19,7 +19,6 @@
 // SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
 use crate::{
     base_node::{
         comms_interface::{
@@ -246,6 +245,82 @@ where T: BlockchainBackend + 'static
                             target: LOG_TARGET,
                             "Could not provide requested block {} to peer because: {}",
                             block_hash.to_hex(),
+                            e.to_string()
+                        ),
+                    }
+                }
+                Ok(NodeCommsResponse::HistoricalBlocks(blocks))
+            },
+            NodeCommsRequest::FetchBlocksWithKernels(excess_sigs) => {
+                let mut blocks = Vec::<HistoricalBlock>::with_capacity(excess_sigs.len());
+                for sig in excess_sigs {
+                    debug!(
+                        target: LOG_TARGET,
+                        "A peer has requested a block with kernel with sig {}",
+                        sig.get_signature().to_hex(),
+                    );
+                    match async_db::fetch_block_with_kernel(self.blockchain_db.clone(), sig.clone()).await {
+                        Ok(Some(block)) => blocks.push(block),
+                        Ok(None) => warn!(
+                            target: LOG_TARGET,
+                            "Could not provide requested block containing kernel with sig {} to peer because not \
+                             stored",
+                            sig.get_signature().to_hex(),
+                        ),
+                        Err(e) => warn!(
+                            target: LOG_TARGET,
+                            "Could not provide requested block containing kernel with sig {} to peer because: {}",
+                            sig.get_signature().to_hex(),
+                            e.to_string()
+                        ),
+                    }
+                }
+                Ok(NodeCommsResponse::HistoricalBlocks(blocks))
+            },
+            NodeCommsRequest::FetchBlocksWithStxos(hashes) => {
+                let mut blocks = Vec::<HistoricalBlock>::with_capacity(hashes.len());
+                for hash in hashes {
+                    debug!(
+                        target: LOG_TARGET,
+                        "A peer has requested a block with hash {}",
+                        hash.to_hex()
+                    );
+                    match async_db::fetch_block_with_stxo(self.blockchain_db.clone(), hash.clone()).await {
+                        Ok(Some(block)) => blocks.push(block),
+                        Ok(None) => warn!(
+                            target: LOG_TARGET,
+                            "Could not provide requested block {} to peer because not stored",
+                            hash.to_hex(),
+                        ),
+                        Err(e) => warn!(
+                            target: LOG_TARGET,
+                            "Could not provide requested block {} to peer because: {}",
+                            hash.to_hex(),
+                            e.to_string()
+                        ),
+                    }
+                }
+                Ok(NodeCommsResponse::HistoricalBlocks(blocks))
+            },
+            NodeCommsRequest::FetchBlocksWithUtxos(hashes) => {
+                let mut blocks = Vec::<HistoricalBlock>::with_capacity(hashes.len());
+                for hash in hashes {
+                    debug!(
+                        target: LOG_TARGET,
+                        "A peer has requested a block with hash {}",
+                        hash.to_hex()
+                    );
+                    match async_db::fetch_block_with_utxo(self.blockchain_db.clone(), hash.clone()).await {
+                        Ok(Some(block)) => blocks.push(block),
+                        Ok(None) => warn!(
+                            target: LOG_TARGET,
+                            "Could not provide requested block {} to peer because not stored",
+                            hash.to_hex(),
+                        ),
+                        Err(e) => warn!(
+                            target: LOG_TARGET,
+                            "Could not provide requested block {} to peer because: {}",
+                            hash.to_hex(),
                             e.to_string()
                         ),
                     }

--- a/base_layer/core/src/base_node/comms_interface/local_interface.rs
+++ b/base_layer/core/src/base_node/comms_interface/local_interface.rs
@@ -31,7 +31,7 @@ use crate::{
     blocks::{Block, BlockHeader, NewBlockTemplate},
     chain_storage::{ChainMetadata, HistoricalBlock, MmrTree},
     proof_of_work::{Difficulty, PowAlgorithm},
-    transactions::types::HashOutput,
+    transactions::types::{Commitment, HashOutput, Signature},
 };
 use futures::{stream::Fuse, StreamExt};
 use std::sync::Arc;
@@ -171,6 +171,54 @@ impl LocalNodeCommsInterface {
             .await??
         {
             NodeCommsResponse::MmrNodes(added, deleted) => Ok((added, deleted)),
+            _ => Err(CommsInterfaceError::UnexpectedApiResponse),
+        }
+    }
+
+    /// Fetches the blocks with the specified utxo commitments
+    pub async fn get_blocks_with_utxos(
+        &mut self,
+        commitments: Vec<Commitment>,
+    ) -> Result<Vec<HistoricalBlock>, CommsInterfaceError>
+    {
+        match self
+            .request_sender
+            .call(NodeCommsRequest::FetchBlocksWithUtxos(commitments))
+            .await??
+        {
+            NodeCommsResponse::HistoricalBlocks(blocks) => Ok(blocks),
+            _ => Err(CommsInterfaceError::UnexpectedApiResponse),
+        }
+    }
+
+    /// Fetches the blocks with the specified stxo commitments
+    pub async fn get_blocks_with_stxos(
+        &mut self,
+        commitments: Vec<Commitment>,
+    ) -> Result<Vec<HistoricalBlock>, CommsInterfaceError>
+    {
+        match self
+            .request_sender
+            .call(NodeCommsRequest::FetchBlocksWithStxos(commitments))
+            .await??
+        {
+            NodeCommsResponse::HistoricalBlocks(blocks) => Ok(blocks),
+            _ => Err(CommsInterfaceError::UnexpectedApiResponse),
+        }
+    }
+
+    /// Fetches the blocks with the specified kernel signatures commitments
+    pub async fn get_blocks_with_kernels(
+        &mut self,
+        kernels: Vec<Signature>,
+    ) -> Result<Vec<HistoricalBlock>, CommsInterfaceError>
+    {
+        match self
+            .request_sender
+            .call(NodeCommsRequest::FetchBlocksWithKernels(kernels))
+            .await??
+        {
+            NodeCommsResponse::HistoricalBlocks(blocks) => Ok(blocks),
             _ => Err(CommsInterfaceError::UnexpectedApiResponse),
         }
     }

--- a/base_layer/core/src/base_node/proto/request.proto
+++ b/base_layer/core/src/base_node/proto/request.proto
@@ -2,6 +2,7 @@ syntax = "proto3";
 
 import "block.proto";
 import "mmr_tree.proto";
+import "types.proto"; 
 
 package tari.base_node;
 
@@ -37,6 +38,12 @@ message BaseNodeServiceRequest {
         FetchMmrNodes fetch_mmr_nodes = 14;
         // Indicates a FetchTxos request.
         HashOutputs fetch_txos = 15;
+        // Indicates a Fetch block with kernels request
+        Signatures fetch_blocks_with_kernels = 16;
+        // Indicates a Fetch block with kernels request
+        Commitments fetch_blocks_with_stxos = 17;
+        // Indicates a Fetch block with kernels request
+        Commitments fetch_blocks_with_utxos = 18;
     }
 }
 
@@ -46,6 +53,14 @@ message BlockHeights {
 
 message HashOutputs {
     repeated bytes outputs = 1;
+}
+
+message Signatures {
+    repeated tari.types.Signature sigs = 1;
+}
+
+message Commitments{
+    repeated tari.types.Commitment commitments = 1;
 }
 
 message FetchHeadersAfter {

--- a/base_layer/core/src/chain_storage/async_db.rs
+++ b/base_layer/core/src/chain_storage/async_db.rs
@@ -33,7 +33,7 @@ use crate::{
     },
     transactions::{
         transaction::{TransactionKernel, TransactionOutput},
-        types::HashOutput,
+        types::{Commitment, HashOutput, Signature},
     },
 };
 use log::*;
@@ -116,6 +116,9 @@ make_async!(add_block(block: Block) -> BlockAddResult, "add_block");
 make_async!(calculate_mmr_roots(template: NewBlockTemplate) -> Block, "calculate_mmr_roots");
 make_async!(fetch_block(height: u64) -> HistoricalBlock, "fetch_block");
 make_async!(fetch_block_with_hash(hash: HashOutput) -> Option<HistoricalBlock>, "fetch_block_with_hash");
+make_async!(fetch_block_with_kernel(excess_sig: Signature) -> Option<HistoricalBlock>, "fetch_block_with_kernel");
+make_async!(fetch_block_with_stxo(commitment: Commitment) -> Option<HistoricalBlock>, "fetch_block_with_stxo");
+make_async!(fetch_block_with_utxo(commitment: Commitment) -> Option<HistoricalBlock>, "fetch_block_with_utxo");
 make_async!(block_exists(block_hash: BlockHash) -> bool, "block_exists");
 make_async!(rewind_to_height(height: u64) -> Vec<Block>, "rewind_to_height");
 make_async!(fetch_mmr_proof(tree: MmrTree, pos: usize) -> MerkleProof, "fetch_mmr_proof");

--- a/base_layer/core/src/chain_storage/error.rs
+++ b/base_layer/core/src/chain_storage/error.rs
@@ -20,10 +20,7 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use crate::{
-    chain_storage::{db_transaction::DbKey, MmrTree},
-    validation::ValidationError,
-};
+use crate::{chain_storage::MmrTree, validation::ValidationError};
 use tari_mmr::{error::MerkleMountainRangeError, MerkleProofError};
 use thiserror::Error;
 
@@ -53,8 +50,12 @@ pub enum ChainStorageError {
     BeyondPruningHorizon,
     #[error("A parameter to the request was invalid")]
     InvalidQuery(String),
-    #[error("The requested value '{0}' was not found in the database")]
-    ValueNotFound(DbKey),
+    #[error("The requested {entity} was not found via {field}:{value} in the database")]
+    ValueNotFound {
+        entity: String,
+        field: String,
+        value: String,
+    },
     #[error("MMR error: {source}")]
     MerkleMountainRangeError {
         #[from]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Add search via kernel using the excess signature.
Adds search via STXO using the commitment.
Adds search via UTXO using the commitment.
Adds linking calls on the UI so users can use the CLI to call these calls.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This allows users to find out if transactions was mined and or not. This will tell the user of the blockchain knows of Kernels, Utxos and or Stxos. If the BN is a pruned node, and the info if past pruning horizon, it will only tell the user that the Info exists, but it does not know which block. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [x] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch.
* [x] I ran `cargo-fmt --all` before pushing.
* [x] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
