### PR TITLE
Windows installer and Tor runtime detection improvements

### DIFF
--- a/applications/tari_base_node/windows/README.md
+++ b/applications/tari_base_node/windows/README.md
@@ -90,7 +90,7 @@ Notes:
     setx /m USERNAME %USERNAME%
     ```
   
-    in an Administrator command console.
+    in a command console.
     
     or
     
@@ -107,7 +107,7 @@ Notes:
     setx /m USERNAME %USERNAME%
     ```
   
-    in an Administrator command console.
+    in a command console.
     
     or
     

--- a/applications/tari_base_node/windows/runtime/run_the_base_node.bat
+++ b/applications/tari_base_node/windows/runtime/run_the_base_node.bat
@@ -1,97 +1,101 @@
-@rem Verify arguments
-@if [%config_path%]==[] (
-    @echo Problem with "config_path" environment variable: %config_path%
-    @pause
-    @exit /b 10101
+@echo off
+
+rem Verify arguments
+if [%config_path%]==[] (
+    echo Problem with "config_path" environment variable: %config_path%
+    pause
+    exit /b 10101
 )
-@if not exist "%config_path%" (
-    @echo Path as per "config_path" environment variable not found: %config_path%
-    @pause
-    @exit /b 10101
+if not exist "%config_path%" (
+    echo Path as per "config_path" environment variable not found: %config_path%
+    pause
+    exit /b 10101
 )
-@if [%base_path%]==[] (
-    @echo Problem with "base_path" environment variable: %base_path%
-    @pause
-    @exit /b 10101
+if [%base_path%]==[] (
+    echo Problem with "base_path" environment variable: %base_path%
+    pause
+    exit /b 10101
 )
-@if not exist "%base_path%" (
-    @echo Path as per "base_path" environment variable not found: %base_path%
-    @pause
-    @exit /b 10101
+if not exist "%base_path%" (
+    echo Path as per "base_path" environment variable not found: %base_path%
+    pause
+    exit /b 10101
 )
-@if [%my_exe%]==[] (
-    @echo Problem with "my_exe" environment variable: %my_exe%
-    @pause
-    @exit /b 10101
+if [%my_exe%]==[] (
+    echo Problem with "my_exe" environment variable: %my_exe%
+    pause
+    exit /b 10101
 )
-@if [%sqlite_runtime%]==[] (
-    @echo Problem with "sqlite_runtime" environment variable: %sqlite_runtime%
-    @pause
-    @exit /b 10101
+if [%sqlite_runtime%]==[] (
+    echo Problem with "sqlite_runtime" environment variable: %sqlite_runtime%
+    pause
+    exit /b 10101
 )
 
-@rem Verify SQLite's location and prepend the default location to the system path if it exist
-@if exist "%TARI_SQLITE_DIR%\%sqlite_runtime%" (
-    @set "path=%TARI_SQLITE_DIR%;%path%"
-    @echo.
-    @echo Default location of "%sqlite_runtime%" prepended to the system path
+rem Verify SQLite's location and prepend the default location to the system path if it exist
+if exist "%TARI_SQLITE_DIR%\%sqlite_runtime%" (
+    set "path=%TARI_SQLITE_DIR%;%path%"
+    echo.
+    echo Default location of "%sqlite_runtime%" prepended to the system path
 ) else (
-    @set FOUND=
-    @for %%X in (%sqlite_runtime%) do @(set FOUND=%%~$PATH:X)
-    @if defined FOUND (
-        @echo.
-        @echo "%sqlite_runtime%" found in system path:
-        @where "%sqlite_runtime%"
+    set FOUND=
+    for %%X in (%sqlite_runtime%) do (set FOUND=%%~$PATH:X)
+    if defined FOUND (
+        echo.
+        echo "%sqlite_runtime%" found in system path:
+        where "%sqlite_runtime%"
     ) else (
-        @echo.
-        @echo Note: "%sqlite_runtime%" not found in the default location or in the system path; this may be a problem
+        echo.
+        echo Note: "%sqlite_runtime%" not found in the default location or in the system path; this may be a problem
+        echo.
+        pause
     )
 )
 
-@rem Find the base node executable
-@if exist "%my_exe_path%\%my_exe%" (
-    @set base_node=%my_exe_path%\%my_exe%
-    @echo.
-    @echo Using "%my_exe%" found in my_exe_path
-    @echo.
+rem Find the base node executable
+if exist "%my_exe_path%\%my_exe%" (
+    set base_node=%my_exe_path%\%my_exe%
+    echo.
+    echo Using "%my_exe%" found in my_exe_path
+    echo.
 ) else (
     if exist "%base_path%\%my_exe%" (
-        @set base_node=%base_path%\%my_exe%
-        @echo.
-        @echo Using "%my_exe%" found in base_path
-        @echo.
+        set base_node=%base_path%\%my_exe%
+        echo.
+        echo Using "%my_exe%" found in base_path
+        echo.
     ) else (
-        @set FOUND=
-        @for %%X in (%my_exe%) do @(set FOUND=%%~$PATH:X)
-        @if defined FOUND (
-            @set base_node=%my_exe%
-            @echo.
-            @echo Using "%my_exe%" found in system path:
-            @where "%my_exe%"
-            @echo.
+        set FOUND=
+        for %%X in (%my_exe%) do (set FOUND=%%~$PATH:X)
+        if defined FOUND (
+            set base_node=%my_exe%
+            echo.
+            echo Using "%my_exe%" found in system path:
+            where "%my_exe%"
+            echo.
         ) else (
-            @echo.
-            @echo Runtime "%my_exe%" not found in my_exe_path, base_path or the system path
-            @echo.
-            @pause
-            @exit /b 10101
+            echo.
+            echo Runtime "%my_exe%" not found in my_exe_path, base_path or the system path
+            echo.
+            pause
+            exit /b 10101
         )
     )
 )
 
-@rem First time run
-@if not exist %config_path%\node_id.json (
+rem First time run
+if not exist %config_path%\node_id.json (
     "%base_node%" --create-id --config "%config_path%\windows.toml" --log_config "%config_path%\log4rs.yml" --base-path "%base_path%"
-    @echo.
-    @echo.
-    @echo Created "%config_path%\node_id.json". 
-    @echo.
+    echo.
+    echo.
+    echo Created "%config_path%\node_id.json". 
+    echo.
 ) else (
-    @echo.
-    @echo.
-    @echo Using old "%config_path%\node_id.json"
-    @echo.
+    echo.
+    echo.
+    echo Using old "%config_path%\node_id.json"
+    echo.
 )
 
-@rem Consecutive runs
+rem Consecutive runs
 "%base_node%" --config "%config_path%\windows.toml" --log_config "%config_path%\log4rs.yml" --base-path "%base_path%"

--- a/applications/tari_base_node/windows/runtime/start_tari_basenode.bat
+++ b/applications/tari_base_node/windows/runtime/start_tari_basenode.bat
@@ -1,38 +1,49 @@
-@echo.
-@echo Set up environment variables
-@echo ----------------------------
-@rem These are the basenode executable and SQLite dynamic link library names
-@set my_exe=tari_base_node.exe
-@set sqlite_runtime=sqlite3.dll
+@echo off
 
-@rem This is the location of the configuration and identity files
-@set config_path=%~dp0..\config
-@echo config_path = %config_path%
+echo.
+echo Set up environment variables
+echo ----------------------------
+rem These are the basenode executable and SQLite dynamic link library names
+set my_exe=tari_base_node.exe
+set sqlite_runtime=sqlite3.dll
 
-@rem The default location for the basenode executable
-@set my_exe_path=%~dp0
-@if %my_exe_path:~-1%==\ set my_exe_path=%my_exe_path:~0,-1%
-@echo my_exe_path = %my_exe_path%
+rem This is the location of the configuration and identity files
+set config_path=%~dp0..\config
+echo config_path = %config_path%
 
-@rem The base folder where the database and log files will be located
-@set base_path=%~dp0..
-@echo base_path   = %base_path%
+rem The default location for the basenode executable
+set my_exe_path=%~dp0
+if %my_exe_path:~-1%==\ set my_exe_path=%my_exe_path:~0,-1%
+echo my_exe_path = %my_exe_path%
 
-@echo.
-@echo Start Tor Services
-@echo ----------------------------
-@call %my_exe_path%\start_tor.bat
-@if [%errorlevel%]==[10101] goto :END
+rem The base folder where the database and log files will be located
+set base_path=%~dp0..
+echo base_path   = %base_path%
 
-@echo.
-@echo Run the base node
-@echo -----------------
-@call %my_exe_path%\run_the_base_node.bat
+echo.
+echo Start Tor Services
+echo ----------------------------
+call %my_exe_path%\start_tor.bat
+if [%errorlevel%]==[10101] (
+    echo.
+    echo It seems Tor could not be started properly.
+    echo If '%my_exe%' still reports an error:
+    echo   - Try to start Tor manually:
+    echo     - execute 'start_tor.bat' from '%my_exe_path%', or
+    echo     - select 'Tor Services' from the 'Tari - Testnet' menu
+    echo   - Wait for '[notice] Bootstrapped 100% (done): Done' in the Tor console
+    echo.
+    pause
+)
 
-@goto END:
+echo.
+echo Run the base node
+echo -----------------
+call %my_exe_path%\run_the_base_node.bat
+
+goto END:
 
 
 :END
-@echo.
-@pause
-
+echo.
+pause

--- a/applications/tari_base_node/windows/runtime/start_tor.bat
+++ b/applications/tari_base_node/windows/runtime/start_tor.bat
@@ -1,80 +1,51 @@
-@set file_1=%TEMP%\tor1.txt
-@set file_2=%TEMP%\tor2.txt
-@set file_3=%TEMP%\tor3.txt
-@set TOR_EXE_NAME=tor.exe
+@echo off
 
-@call :QUERY_TOR_SERVICE
-@if not defined TOR_RUNNING (
-    @if exist "%TARI_TOR_SERVICES_DIR%\%TOR_EXE_NAME%" (
-        @set "path=%TARI_TOR_SERVICES_DIR%;%path%"
+set file_1=%TEMP%\tor1.txt
+set file_2=%TEMP%\tor2.txt
+set file_3=%TEMP%\tor3.txt
+set TOR_EXE_NAME=tor.exe
+
+call :QUERY_TOR_SERVICE
+if not defined TOR_RUNNING (
+    if exist "%TARI_TOR_SERVICES_DIR%\%TOR_EXE_NAME%" (
+        set "path=%TARI_TOR_SERVICES_DIR%;%path%"
     ) 
-    @start tor --allow-missing-torrc --ignore-missing-torrc --clientonly 1 --socksport 9050 --controlport 127.0.0.1:9051 --clientuseipv6 1 --log "notice stdout"
-    @echo Attempting to start Tor service on ports 9050 and 9051
-    @ping -n 10 localhost>nul
+    start tor --allow-missing-torrc --ignore-missing-torrc --clientonly 1 --socksport 9050 --controlport 127.0.0.1:9051 --clientuseipv6 1 --log "notice stdout"
+    echo Attempting to start Tor service on ports 9050 and 9051
+    ping -n 15 localhost>nul
 ) else (
-    @goto :END
+    goto :END
 )
 
-@if not defined TOR_RUNNING (
-    @call :QUERY_TOR_SERVICE
-    @if not defined TOR_RUNNING (
-        @echo Problem starting Tor services, check if Tor is in the path
-        @pause
-        @exit /b 10101
+if not defined TOR_RUNNING (
+    call :QUERY_TOR_SERVICE
+    if not defined TOR_RUNNING (
+        echo Problem starting Tor services, check if Tor is in the path
+        pause
+        exit /b 10101
     )
 )
-@goto :END
+goto :END
 
 :QUERY_TOR_SERVICE
-@if exist %file_1% (
+if exist %file_1% (
     del %file_1% /f/q
 )
-@if exist %file_2% (
+if exist %file_2% (
     del %file_2% /f/q
 )
-@for /f "tokens=1,2,3,4,5*" %%i in ('netstat -aon ^| findstr ":9050" ^| findstr /i listening') do @echo %j %l & @tasklist | findstr %%m > %file_1%
-@for /f "tokens=1,2,3,4,5*" %%i in ('netstat -aon ^| findstr ":9051" ^| findstr /i listening') do @echo %j %l & @tasklist | findstr %%m > %file_2%
-@if exist %file_1% (
-    @if exist %file_2% (
-        @echo Found tor service listening on ports 9050 and 9051. Good.
-        @set TOR_RUNNING=1
+for /f "tokens=1,2,3,4,5*" %%i in ('netstat -aon ^| findstr ":9050" ^| findstr /i listening') do echo %j %l & tasklist | findstr %%m > %file_1%
+for /f "tokens=1,2,3,4,5*" %%i in ('netstat -aon ^| findstr ":9051" ^| findstr /i listening') do echo %j %l & tasklist | findstr %%m > %file_2%
+if exist %file_1% (
+    if exist %file_2% (
+        echo Found tor service listening on ports 9050 and 9051. Good.
+        set TOR_RUNNING=1
     ) else (
-        @taskkill /im tor.exe /f > nul
-        @set TOR_RUNNING=
+        taskkill /im tor.exe /f > nul
+        set TOR_RUNNING=
     )
 )
-@goto :eof
-
-:QUERY_TOR_EXE
-@set TOR_EXE=
-@if exist "%TARI_TOR_SERVICES_DIR%\%TOR_EXE_NAME%" (
-    @set TOR_EXE=%TARI_TOR_SERVICES_DIR%\%TOR_EXE_NAME%
-)
-@if not defined TOR_EXE (
-    @for %%X in (%TOR_EXE_NAME%) do @(set TOR_EXE=%%~$PATH:X)
-)
-@if not defined TOR_EXE (
-    @echo Could not find "%TOR_EXE_NAME%" in path
-    @echo.
-    @pause
-    @exit /b 10101
-) else (
-    @echo Using "%TOR_EXE%"
-    @echo.
-)
-@goto :eof
-
-:QUERY_TOR_STARTED
-@if exist %file_3% (
-    del %file_3% /f/q
-)
-@tasklist /fi "imagename eq tor.exe" > %file_3%
-@if exist %file_3% (
-    @set TOR_RUNNING=1
-) else (
-    @set TOR_RUNNING=
-) 
-@goto :eof
+goto :eof
 
 :END
-@echo.
+echo.

--- a/buildtools/install_sqlite.bat
+++ b/buildtools/install_sqlite.bat
@@ -7,14 +7,10 @@
 @echo Downloading and installing SQLite...
 @echo.
 
-@rem Determine if running as administrator
-@call :TEST_ADMINISTRATOR
-@if [%errorlevel%]==[10101] goto :END
-
 @rem Install dependencies
 @call :INSTALL_SQLITE
 @goto END:
-`
+
 :INSTALL_SQLITE
 @rem Download install file
 @powershell wget https://www.sqlite.org/2020/%sqlite_zip% -outfile "%TEMP%\%sqlite_zip%"
@@ -38,26 +34,11 @@
 )
 @goto :eof
 
-:TEST_ADMINISTRATOR
-@echo.
-@set guid=%random%%random%-%random%-%random%-%random%-%random%%random%%random%
-@mkdir %WINDIR%\%guid%>nul 2>&1
-@rmdir %WINDIR%\%guid%>nul 2>&1
-@if %ERRORLEVEL% equ 0 (
-    @echo Administrator OK
-    @echo.
-) else (
-    @echo Please run as administrator {hint: Right click, then "Run as administrator"}
-    @echo.
-    @exit /b 10101
-)
-@goto :eof
-
 :END
 @echo.
 @if not [%1]==[NO_PAUSE] (
     @pause
 ) else (
-    @ping -n 3 localhost>nul
+    @ping -n 5 localhost>nul
 )
 @@if [%errorlevel%]==[10101] exit

--- a/buildtools/install_tor_services.bat
+++ b/buildtools/install_tor_services.bat
@@ -1,7 +1,6 @@
 @rem Control variables
 @rem - Tor Services {Note: `powershell` cannot `expand-archive` to `C:\Program Files (x86)`}
 @rem   - Download 'Windows Expert Bundle' at https://www.torproject.org/download/tor/
-https://www.torproject.org/dist/torbrowser/9.5/tor-win32-0.4.3.5.zip
 @set tor_version=9.5
 @set tor_zip=tor-win32-0.4.3.5.zip
 @set tor_folder=%USERPROFILE%\.tor_services
@@ -9,10 +8,6 @@ https://www.torproject.org/dist/torbrowser/9.5/tor-win32-0.4.3.5.zip
 
 @echo Downloading and installing Tor Services...
 @echo.
-
-@rem Determine if running as administrator
-@call :TEST_ADMINISTRATOR
-@if [%errorlevel%]==[10101] goto :END
 
 @rem Install dependencies
 @call :INSTALL_TOR_SERVICES
@@ -41,26 +36,11 @@ https://www.torproject.org/dist/torbrowser/9.5/tor-win32-0.4.3.5.zip
 )
 @goto :eof
 
-:TEST_ADMINISTRATOR
-@echo.
-@set guid=%random%%random%-%random%-%random%-%random%-%random%%random%%random%
-@mkdir %WINDIR%\%guid%>nul 2>&1
-@rmdir %WINDIR%\%guid%>nul 2>&1
-@if %ERRORLEVEL% equ 0 (
-    @echo Administrator OK
-    @echo.
-) else (
-    @echo Please run as administrator {hint: Right click, then "Run as administrator"}
-    @echo.
-    @exit /b 10101
-)
-@goto :eof
-
 :END
 @echo.
 @if not [%1]==[NO_PAUSE] (
     @pause
 ) else (
-    @ping -n 3 localhost>nul
+    @ping -n 5 localhost>nul
 )
 @@if [%errorlevel%]==[10101] exit

--- a/buildtools/install_vs2019_redist.bat
+++ b/buildtools/install_vs2019_redist.bat
@@ -5,10 +5,6 @@
 @echo Downloading and installing Redistributable for Visual Studio 2019...
 @echo.
 
-@rem Determine if running as administrator
-@call :TEST_ADMINISTRATOR
-@if [%errorlevel%]==[10101] goto :END
-
 @rem Install dependencies
 @call :INSTALL_VS2019_REDIST
 @goto END:
@@ -20,26 +16,11 @@
 @"%TEMP%\%vc_redist_install%"
 @goto :eof
 
-:TEST_ADMINISTRATOR
-@echo.
-@set guid=%random%%random%-%random%-%random%-%random%-%random%%random%%random%
-@mkdir %WINDIR%\%guid%>nul 2>&1
-@rmdir %WINDIR%\%guid%>nul 2>&1
-@if %ERRORLEVEL% equ 0 (
-    @echo Administrator OK
-    @echo.
-) else (
-    @echo Please run as administrator {hint: Right click, then "Run as administrator"}
-    @echo.
-    @exit /b 10101
-)
-@goto :eof
-
 :END
 @echo.
 @if not [%1]==[NO_PAUSE] (
     @pause
 ) else (
-    @ping -n 3 localhost>nul
+    @ping -n 5 localhost>nul
 )
 @@if [%errorlevel%]==[10101] exit

--- a/buildtools/windows_inno_installer.iss
+++ b/buildtools/windows_inno_installer.iss
@@ -60,6 +60,8 @@ VersionInfoProductName=tari_base_node
 InfoAfterFile="..\applications\tari_base_node\windows\README.md"
 SignTool=SignTool
 
+PrivilegesRequired=none
+
 [CustomMessages]
 TariGit=Tari on GitHub
 TariWeb=Tari on the web
@@ -96,12 +98,12 @@ Name: "{group}\{#ReadmeName}"; Filename: "{app}\{#ReadmeName}"; WorkingDir: "{ap
 Name: "{group}\{cm:ProgramOnTheWeb,{#MyAppName}}"; Filename: "{#MyAppURL}"
 Name: "{group}\{cm:TariWeb,{#MyAppSupp}}"; Filename: "{#MyAppSuppURL}"
 Name: "{group}\{cm:UninstallProgram,{#MyOrgName} {#MyAppName} - Testnet}"; Filename: "{uninstallexe}"
-Name: "{commondesktop}\{#MyOrgName} {#MyAppName}"; Filename: "{app}\runtime\{#MyAppExeName}"; WorkingDir: "{app}"; Tasks: desktopicon
-Name: "{commondesktop}\{#MyOrgName} - {#TorServicesName}"; Filename: "{app}\runtime\{#TorServicesExeName}"; WorkingDir: "{app}"; Tasks: desktopicon
+Name: "{userdesktop}\{#MyOrgName} {#MyAppName}"; Filename: "{app}\runtime\{#MyAppExeName}"; WorkingDir: "{app}"; Tasks: desktopicon
+Name: "{userdesktop}\{#MyOrgName} - {#TorServicesName}"; Filename: "{app}\runtime\{#TorServicesExeName}"; WorkingDir: "{app}"; Tasks: desktopicon
 Name: "{userappdata}\Microsoft\Internet Explorer\Quick Launch\{#MyAppName}"; Filename: "{app}\{#MyAppExeName}"; Tasks: quicklaunchicon
 
-[Setup]
-PrivilegesRequired=admin
+;[Setup]
+;PrivilegesRequired=admin
 
 [Run]
 Filename: "{app}\runtime\install_sqlite.bat"; Description: "Install SQLite"; Parameters: "NO_PAUSE"; Flags: runascurrentuser postinstall 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- Removed the requirement to have administrator privileges to run the Tari Windows installation; administrator mode will now only be required for the Microsoft Visual Studio 2019 runtime components installation, which is run as a separate task.
- Better Tor detection with base node startup and manual Tor startup is also better supported, made more user friendly.

## Motivation and Context
- There was some confusion about the requirement for use of administrator mode. Previously the setup file was generated so that one needed to have administrator privileges to run it, but now that is deferred to the Microsoft Visual Studio 2019 runtime component's installation.
- Tor services take a while to start, and previously the startup script would exit and not start the base node if Tor was not detected running properly with the required ports. The behaviour now is to inform the user about mitigations and to defer Tor issues to the base node, which will display an error when starting if tor is not running as required.

## How Has This Been Tested?
Tested installation and runtime startup in Windows 10 with (a) a normal user and (b) a user with administrator privileges.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [X] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [X] I'm merging against the `development` branch.
* [X] I ran `cargo-fmt --all` before pushing.
* [X] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [X] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
