### PR TITLE
Update crates to v0.2.0 and publish them

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2,9 +2,9 @@
 # It is not intended for manual editing.
 [[package]]
 name = "adler"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccc9a9dd069569f212bc4330af9f17c4afb5e8ce185e83dbb14f1349dda18b10"
+checksum = "ee2a4ec343196209d6594e19543ae87a39f96d5534d7174822a3ad825dd6ed7e"
 
 [[package]]
 name = "aho-corasick"
@@ -93,7 +93,7 @@ checksum = "25f9db3b38af870bf7e5cc649167533b493928e50744e2c30ae350230b414670"
 dependencies = [
  "proc-macro2 1.0.18",
  "quote 1.0.7",
- "syn 1.0.33",
+ "syn 1.0.34",
 ]
 
 [[package]]
@@ -104,7 +104,7 @@ checksum = "a265e3abeffdce30b2e26b7a11b222fe37c6067404001b434101457d0385eb92"
 dependencies = [
  "proc-macro2 1.0.18",
  "quote 1.0.7",
- "syn 1.0.33",
+ "syn 1.0.34",
 ]
 
 [[package]]
@@ -349,11 +349,10 @@ dependencies = [
 
 [[package]]
 name = "bytes"
-version = "0.5.5"
+version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "118cf036fbb97d0816e3c34b2d7a1e8cfc60f68fcf63d550ddbe9bd5f59c213b"
+checksum = "0e4cec68f03f32e44924783795810fa50a7035d8c8ebe78580ad7e6c703fba38"
 dependencies = [
- "loom",
  "serde 1.0.114",
 ]
 
@@ -380,9 +379,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.57"
+version = "1.0.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fde55d2a2bfaa4c9668bbc63f531fbdeee3ffe188f4662511ce2c22b3eedebe"
+checksum = "f9a06fb2e53271d7c279ec1efea6ab691c35a2ae67ec0d91d7acec0caf13b518"
 
 [[package]]
 name = "cexpr"
@@ -771,7 +770,7 @@ dependencies = [
  "proc-macro2 1.0.18",
  "quote 1.0.7",
  "strsim 0.9.3",
- "syn 1.0.33",
+ "syn 1.0.34",
 ]
 
 [[package]]
@@ -782,7 +781,7 @@ checksum = "d9b5a2f4ac4969822c62224815d069952656cadc7084fdca9751e6d959189b72"
 dependencies = [
  "darling_core",
  "quote 1.0.7",
- "syn 1.0.33",
+ "syn 1.0.34",
 ]
 
 [[package]]
@@ -827,7 +826,7 @@ checksum = "45f5098f628d02a7a0f68ddba586fb61e80edec3bdc1be3b921f4ceec60858d3"
 dependencies = [
  "proc-macro2 1.0.18",
  "quote 1.0.7",
- "syn 1.0.33",
+ "syn 1.0.34",
 ]
 
 [[package]]
@@ -938,7 +937,7 @@ checksum = "e57001dfb2532f5a103ff869656887fae9a8defa7d236f3e39d2ee86ed629ad7"
 dependencies = [
  "proc-macro2 1.0.18",
  "quote 1.0.7",
- "syn 1.0.33",
+ "syn 1.0.34",
 ]
 
 [[package]]
@@ -969,7 +968,7 @@ dependencies = [
  "darling",
  "proc-macro2 1.0.18",
  "quote 1.0.7",
- "syn 1.0.33",
+ "syn 1.0.34",
 ]
 
 [[package]]
@@ -1218,7 +1217,7 @@ dependencies = [
  "proc-macro-hack",
  "proc-macro2 1.0.18",
  "quote 1.0.7",
- "syn 1.0.33",
+ "syn 1.0.34",
 ]
 
 [[package]]
@@ -1337,19 +1336,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f5f3913fa0bfe7ee1fd8248b6b9f42a5af4b9d65ec2dd2c3c26132b950ecfc2"
 
 [[package]]
-name = "generator"
-version = "0.6.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "add72f17bb81521258fcc8a7a3245b1e184e916bfbe34f0ea89558f440df5c68"
-dependencies = [
- "cc",
- "libc",
- "log",
- "rustc_version",
- "winapi 0.3.9",
-]
-
-[[package]]
 name = "generic-array"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1414,21 +1400,21 @@ checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
 
 [[package]]
 name = "h2"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79b7246d7e4b979c03fa093da39cfb3617a96bbeee6310af63991668d7e843ff"
+checksum = "993f9e0baeed60001cf565546b0d3dbe6a6ad23f2bd31644a133c641eccf6d53"
 dependencies = [
- "bytes 0.5.5",
+ "bytes 0.5.6",
  "fnv",
  "futures-core",
  "futures-sink",
  "futures-util",
  "http",
  "indexmap",
- "log",
  "slab",
  "tokio",
  "tokio-util 0.3.1",
+ "tracing",
 ]
 
 [[package]]
@@ -1476,7 +1462,7 @@ version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28d569972648b2c512421b5f2a405ad6ac9666547189d0c5477a3f200f3e02f9"
 dependencies = [
- "bytes 0.5.5",
+ "bytes 0.5.6",
  "fnv",
  "itoa",
 ]
@@ -1487,7 +1473,7 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13d5ff830006f7646652e057693569bfe0d51760c0085a071769d142a205111b"
 dependencies = [
- "bytes 0.5.5",
+ "bytes 0.5.6",
  "http",
 ]
 
@@ -1508,11 +1494,11 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "0.13.6"
+version = "0.13.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6e7655b9594024ad0ee439f3b5a7299369dc2a3f459b47c696f9ff676f9aa1f"
+checksum = "3e68a8dd9716185d9e64ea473ea6ef63529252e3e27623295a0378a19665d5eb"
 dependencies = [
- "bytes 0.5.5",
+ "bytes 0.5.6",
  "futures-channel",
  "futures-core",
  "futures-util",
@@ -1521,12 +1507,12 @@ dependencies = [
  "http-body",
  "httparse",
  "itoa",
- "log",
  "pin-project",
  "socket2",
  "time",
  "tokio",
  "tower-service",
+ "tracing",
  "want",
 ]
 
@@ -1560,9 +1546,9 @@ dependencies = [
 
 [[package]]
 name = "image"
-version = "0.23.6"
+version = "0.23.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5b0553fec6407d63fe2975b794dfb099f3f790bdc958823851af37b26404ab4"
+checksum = "a2397fc43bd5648b7117aabb3c5e62d0e62c194826ec77b0b4d0c41e62744635"
 dependencies = [
  "bytemuck",
  "byteorder",
@@ -1669,9 +1655,9 @@ checksum = "b294d6fa9ee409a054354afc4352b0b9ef7ca222c69b8812cbea9e7d2bf3783f"
 
 [[package]]
 name = "libc"
-version = "0.2.71"
+version = "0.2.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9457b06509d27052635f90d6466700c65095fdf75409b3fbdd903e988b886f49"
+checksum = "a9f8082297d534141b30c8d39e9b1773713ab50fdbe4ff30f750d063b3bfd701"
 
 [[package]]
 name = "libgit2-sys"
@@ -1824,17 +1810,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "loom"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ecc775857611e1df29abba5c41355cdf540e7e9d4acfdf0f355eefee82330b7"
-dependencies = [
- "cfg-if",
- "generator",
- "scoped-tls",
-]
-
-[[package]]
 name = "maplit"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1897,7 +1872,7 @@ dependencies = [
  "migrations_internals",
  "proc-macro2 1.0.18",
  "quote 1.0.7",
- "syn 1.0.33",
+ "syn 1.0.34",
 ]
 
 [[package]]
@@ -2269,7 +2244,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a1cd2ba02391b81367bec529fb209019d718684fdc8ad6a712c2b536e46f775"
 dependencies = [
  "blake2",
- "bytes 0.5.5",
+ "bytes 0.5.6",
  "rand 0.7.3",
  "sha-1",
  "sha2",
@@ -2364,7 +2339,7 @@ checksum = "6a0ffd45cf79d88737d7cc85bfd5d2894bee1139b356e616fe85dc389c61aaf7"
 dependencies = [
  "proc-macro2 1.0.18",
  "quote 1.0.7",
- "syn 1.0.33",
+ "syn 1.0.34",
 ]
 
 [[package]]
@@ -2381,9 +2356,9 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pkg-config"
-version = "0.3.17"
+version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05da548ad6865900e60eaba7f589cc0783590a92e940c26953ff81ddbab2d677"
+checksum = "d36492546b6af1463394d46f0c834346f31548646f6ba10849802c9c9a27ac33"
 
 [[package]]
 name = "ppv-lite86"
@@ -2425,7 +2400,7 @@ dependencies = [
  "proc-macro-error-attr",
  "proc-macro2 1.0.18",
  "quote 1.0.7",
- "syn 1.0.33",
+ "syn 1.0.34",
  "version_check 0.9.2",
 ]
 
@@ -2437,7 +2412,7 @@ checksum = "3cc9795ca17eb581285ec44936da7fc2335a3f34f2ddd13118b6f4d515435c50"
 dependencies = [
  "proc-macro2 1.0.18",
  "quote 1.0.7",
- "syn 1.0.33",
+ "syn 1.0.34",
  "syn-mid",
  "version_check 0.9.2",
 ]
@@ -2478,7 +2453,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce49aefe0a6144a45de32927c77bd2859a5f7677b55f220ae5b744e87389c212"
 dependencies = [
- "bytes 0.5.5",
+ "bytes 0.5.6",
  "prost-derive",
 ]
 
@@ -2488,7 +2463,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02b10678c913ecbd69350e8535c3aef91a8676c0773fc1d7b95cdd196d7f2f26"
 dependencies = [
- "bytes 0.5.5",
+ "bytes 0.5.6",
  "heck",
  "itertools",
  "log",
@@ -2510,7 +2485,7 @@ dependencies = [
  "itertools",
  "proc-macro2 1.0.18",
  "quote 1.0.7",
- "syn 1.0.33",
+ "syn 1.0.34",
 ]
 
 [[package]]
@@ -2519,7 +2494,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1834f67c0697c001304b75be76f67add9c89742eda3a085ad8ee0bb38c3417aa"
 dependencies = [
- "bytes 0.5.5",
+ "bytes 0.5.6",
  "prost",
 ]
 
@@ -2733,9 +2708,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.1.56"
+version = "0.1.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2439c63f3f6139d1b57529d16bc3b8bb855230c8efcc5d3a896c8bea7c3b1e84"
+checksum = "41cc0f7e4d5d4544e8861606a285bb08d3e70712ccc7d2b84d7c0ccfaf4b05ce"
 
 [[package]]
 name = "redox_users"
@@ -2870,7 +2845,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "54a50e29610a5be68d4a586a5cce3bfb572ed2c2a74227e4168444b7bf4e5235"
 dependencies = [
  "quote 1.0.7",
- "syn 1.0.33",
+ "syn 1.0.34",
 ]
 
 [[package]]
@@ -2893,12 +2868,6 @@ name = "scanlex"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6a2c84b697bc9496978f7457b17039a22b5d89c674964e8a480de4d5ddd55dc"
-
-[[package]]
-name = "scoped-tls"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "332ffa32bf586782a3efaeb58f127980944bbc8c4d6913a86107ac2a5ab24b28"
 
 [[package]]
 name = "scopeguard"
@@ -2977,7 +2946,7 @@ checksum = "2a0be94b04690fbaed37cddffc5c134bf537c8e3329d53e982fe04c374978f8e"
 dependencies = [
  "proc-macro2 1.0.18",
  "quote 1.0.7",
- "syn 1.0.33",
+ "syn 1.0.34",
 ]
 
 [[package]]
@@ -2999,7 +2968,7 @@ checksum = "2dc6b7951b17b051f3210b063f12cc17320e2fe30ae05b0fe2a3abb068551c76"
 dependencies = [
  "proc-macro2 1.0.18",
  "quote 1.0.7",
- "syn 1.0.33",
+ "syn 1.0.34",
 ]
 
 [[package]]
@@ -3094,9 +3063,9 @@ checksum = "c111b5bd5695e56cffe5129854aa230b39c93a305372fdbb2668ca2394eea9f8"
 
 [[package]]
 name = "smallvec"
-version = "1.4.0"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7cb5678e1615754284ec264d9bb5b4c27d2018577fd90ac0ceb578591ed5ee4"
+checksum = "3757cb9d89161a2f24e1cf78efa0c1fcff485d18e3f55e0aa3480824ddaa0f3f"
 
 [[package]]
 name = "snow"
@@ -3129,9 +3098,9 @@ dependencies = [
 
 [[package]]
 name = "stable_deref_trait"
-version = "1.1.1"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dba1a27d3efae4351c8051072d619e3ade2820635c3958d826bfea39d59b54c8"
+checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
 name = "static_assertions"
@@ -3187,7 +3156,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2 1.0.18",
  "quote 1.0.7",
- "syn 1.0.33",
+ "syn 1.0.34",
 ]
 
 [[package]]
@@ -3211,7 +3180,7 @@ dependencies = [
  "heck",
  "proc-macro2 1.0.18",
  "quote 1.0.7",
- "syn 1.0.33",
+ "syn 1.0.34",
 ]
 
 [[package]]
@@ -3223,7 +3192,7 @@ dependencies = [
  "heck",
  "proc-macro2 1.0.18",
  "quote 1.0.7",
- "syn 1.0.33",
+ "syn 1.0.34",
 ]
 
 [[package]]
@@ -3268,9 +3237,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.33"
+version = "1.0.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8d5d96e8cbb005d6959f119f773bfaebb5684296108fb32600c00cde305b2cd"
+checksum = "936cae2873c940d92e697597c5eee105fb570cd5689c695806f672883653349b"
 dependencies = [
  "proc-macro2 1.0.18",
  "quote 1.0.7",
@@ -3285,7 +3254,7 @@ checksum = "7be3539f6c128a931cf19dcee741c1af532c7fd387baa739c03dd2e96479338a"
 dependencies = [
  "proc-macro2 1.0.18",
  "quote 1.0.7",
- "syn 1.0.33",
+ "syn 1.0.34",
 ]
 
 [[package]]
@@ -3305,7 +3274,7 @@ checksum = "b834f2d66f734cb897113e34aaff2f1ab4719ca946f9a7358dba8f8064148701"
 dependencies = [
  "proc-macro2 1.0.18",
  "quote 1.0.7",
- "syn 1.0.33",
+ "syn 1.0.34",
  "unicode-xid 0.2.1",
 ]
 
@@ -3374,7 +3343,7 @@ dependencies = [
 
 [[package]]
 name = "tari_common"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "config",
@@ -3396,11 +3365,11 @@ dependencies = [
 
 [[package]]
 name = "tari_comms"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "bitflags 1.2.1",
  "blake2",
- "bytes 0.5.5",
+ "bytes 0.5.6",
  "chrono",
  "cidr",
  "clear_on_drop",
@@ -3436,7 +3405,7 @@ dependencies = [
 
 [[package]]
 name = "tari_comms_dht"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "bitflags 1.2.1",
  "bytes 0.4.12",
@@ -3465,7 +3434,7 @@ dependencies = [
  "tari_shutdown",
  "tari_storage",
  "tari_test_utils",
- "tari_utilities 0.1.2",
+ "tari_utilities",
  "tempfile",
  "thiserror",
  "tokio",
@@ -3478,7 +3447,7 @@ dependencies = [
 
 [[package]]
 name = "tari_core"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "arrayref",
  "base64 0.10.1",
@@ -3522,7 +3491,6 @@ dependencies = [
  "tari_shutdown",
  "tari_storage",
  "tari_test_utils",
- "tari_wallet",
  "tempfile",
  "thiserror",
  "tokio",
@@ -3535,9 +3503,9 @@ dependencies = [
 
 [[package]]
 name = "tari_crypto"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b18fb51209654df1a6f8e6c8aa96ffb87cd17111c76ac1dfdc688884dd964d64"
+checksum = "839d2194109b890290feb2c349856996e123d6710238f8f203232574069316e0"
 dependencies = [
  "base64 0.10.1",
  "blake2",
@@ -3553,7 +3521,7 @@ dependencies = [
  "serde 1.0.114",
  "serde_json",
  "sha2",
- "tari_utilities 0.1.2",
+ "tari_utilities",
 ]
 
 [[package]]
@@ -3568,7 +3536,7 @@ dependencies = [
 
 [[package]]
 name = "tari_key_manager"
-version = "0.0.10"
+version = "0.2.0"
 dependencies = [
  "derive-error",
  "digest",
@@ -3597,12 +3565,12 @@ dependencies = [
  "tari_crypto",
  "tari_infra_derive",
  "tari_storage",
- "tari_utilities 0.2.0",
+ "tari_utilities",
 ]
 
 [[package]]
 name = "tari_p2p"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "bytes 0.4.12",
  "chrono",
@@ -3633,7 +3601,7 @@ dependencies = [
  "tari_shutdown",
  "tari_storage",
  "tari_test_utils",
- "tari_utilities 0.1.2",
+ "tari_utilities",
  "tempfile",
  "tokio",
  "tokio-macros",
@@ -3666,7 +3634,7 @@ dependencies = [
 
 [[package]]
 name = "tari_storage"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "bincode",
  "bytes 0.4.12",
@@ -3680,13 +3648,13 @@ dependencies = [
  "serde 1.0.114",
  "serde_derive",
  "sys-info",
- "tari_utilities 0.1.2",
+ "tari_utilities",
  "thiserror",
 ]
 
 [[package]]
 name = "tari_test_utils"
-version = "0.0.10"
+version = "0.2.0"
 dependencies = [
  "futures 0.3.5",
  "futures-test",
@@ -3694,24 +3662,6 @@ dependencies = [
  "rand 0.7.3",
  "tempfile",
  "tokio",
-]
-
-[[package]]
-name = "tari_utilities"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ac12ea38b89b19042ec822ef99dda6ad5af2f2329d5c82c9a2ba89ae0dd2d16"
-dependencies = [
- "base64 0.10.1",
- "bincode",
- "bitflags 1.2.1",
- "chrono",
- "clear_on_drop",
- "derive-error",
- "newtype-ops",
- "rand 0.7.3",
- "serde 1.0.114",
- "serde_json",
 ]
 
 [[package]]
@@ -3734,7 +3684,7 @@ dependencies = [
 
 [[package]]
 name = "tari_wallet"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "blake2",
  "chrono",
@@ -3772,7 +3722,7 @@ dependencies = [
 
 [[package]]
 name = "tari_wallet_ffi"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "chrono",
  "derive-error",
@@ -3790,7 +3740,7 @@ dependencies = [
  "tari_key_manager",
  "tari_p2p",
  "tari_shutdown",
- "tari_utilities 0.1.2",
+ "tari_utilities",
  "tari_wallet",
  "tempfile",
  "tokio",
@@ -3848,7 +3798,7 @@ dependencies = [
  "serde 1.0.114",
  "serde_json",
  "tari_core",
- "tari_utilities 0.1.2",
+ "tari_utilities",
  "tokio",
 ]
 
@@ -3878,7 +3828,7 @@ checksum = "bd80fc12f73063ac132ac92aceea36734f04a1d93c1240c6944e23a3b8841793"
 dependencies = [
  "proc-macro2 1.0.18",
  "quote 1.0.7",
- "syn 1.0.33",
+ "syn 1.0.34",
 ]
 
 [[package]]
@@ -3942,7 +3892,7 @@ version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d099fa27b9702bed751524694adbe393e18b36b204da91eb1cbbbbb4a5ee2d58"
 dependencies = [
- "bytes 0.5.5",
+ "bytes 0.5.6",
  "fnv",
  "futures-core",
  "iovec",
@@ -3967,7 +3917,7 @@ checksum = "f0c3acc6aa564495a0f2e1d59fab677cd7f81a19994cfc7f3ad0e64301560389"
 dependencies = [
  "proc-macro2 1.0.18",
  "quote 1.0.7",
- "syn 1.0.33",
+ "syn 1.0.34",
 ]
 
 [[package]]
@@ -3976,7 +3926,7 @@ version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed0049c119b6d505c4447f5c64873636c7af6c75ab0d45fd9f618d82acb8016d"
 dependencies = [
- "bytes 0.5.5",
+ "bytes 0.5.6",
  "futures-core",
  "tokio",
 ]
@@ -3987,7 +3937,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "571da51182ec208780505a32528fc5512a8fe1443ab960b3f2f3ef093cd16930"
 dependencies = [
- "bytes 0.5.5",
+ "bytes 0.5.6",
  "futures-core",
  "futures-sink",
  "log",
@@ -4001,7 +3951,7 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be8242891f2b6cbef26a2d7e8605133c2c554cd35b3e4948ea892d6d68436499"
 dependencies = [
- "bytes 0.5.5",
+ "bytes 0.5.6",
  "futures-core",
  "futures-sink",
  "log",
@@ -4036,7 +3986,7 @@ dependencies = [
  "async-stream",
  "async-trait",
  "base64 0.11.0",
- "bytes 0.5.5",
+ "bytes 0.5.6",
  "futures-core",
  "futures-util",
  "http",
@@ -4066,7 +4016,7 @@ dependencies = [
  "proc-macro2 1.0.18",
  "prost-build",
  "quote 1.0.7",
- "syn 1.0.33",
+ "syn 1.0.34",
 ]
 
 [[package]]
@@ -4263,9 +4213,9 @@ dependencies = [
 
 [[package]]
 name = "tracing"
-version = "0.1.15"
+version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a41f40ed0e162c911ac6fcb53ecdc8134c46905fdbbae8c50add462a538b495f"
+checksum = "c2e2a2de6b0d5cbb13fc21193a2296888eaab62b6044479aafb3c54c01c29fcd"
 dependencies = [
  "cfg-if",
  "log",
@@ -4275,20 +4225,20 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99bbad0de3fd923c9c3232ead88510b783e5a4d16a6154adffa3d53308de984c"
+checksum = "f0693bf8d6f2bf22c690fc61a9d21ac69efdbb894a17ed596b9af0f01e64b84b"
 dependencies = [
  "proc-macro2 1.0.18",
  "quote 1.0.7",
- "syn 1.0.33",
+ "syn 1.0.34",
 ]
 
 [[package]]
 name = "tracing-core"
-version = "0.1.10"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0aa83a9a47081cd522c09c81b31aec2c9273424976f922ad61c053b58350b715"
+checksum = "94ae75f0d28ae10786f3b1895c55fe72e79928fd5ccdebb5438c75e93fec178f"
 dependencies = [
  "lazy_static 1.4.0",
 ]
@@ -4311,9 +4261,9 @@ checksum = "efd1f82c56340fdf16f2a953d7bda4f8fdffba13d93b00844c25572110b26079"
 
 [[package]]
 name = "try-lock"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e604eb7b43c06650e854be16a2a03155743d3752dd1c943f6829e26b7a36e382"
+checksum = "59547bce71d9c38b83d9c0e92b6066c4253371f15005def0c30d9657f50c7642"
 
 [[package]]
 name = "ttl_cache"
@@ -4630,6 +4580,6 @@ checksum = "de251eec69fc7c1bc3923403d18ececb929380e016afe103da75f396704f8ca2"
 dependencies = [
  "proc-macro2 1.0.18",
  "quote 1.0.7",
- "syn 1.0.33",
+ "syn 1.0.34",
  "synstructure",
 ]

--- a/RELEASE_CHECKLIST.md
+++ b/RELEASE_CHECKLIST.md
@@ -17,16 +17,16 @@ THings to do before pushing a new commit to `master`:
 |:-----------------------------|:--------|:-----------------------------------------|
 | infrastructure/derive        | 0.0.10  | 7d734a2e79bfe2dd5d4ae00a2b760614d21e69c4 |
 | infrastructure/shutdown      | 0.0.10  | 7d734a2e79bfe2dd5d4ae00a2b760614d21e69c4 |
-| infrastructure/storage       | 0.1.0   |                                          |
-| infrastructure/test_utils    | 0.0.10  | 7d734a2e79bfe2dd5d4ae00a2b760614d21e69c4 |
-| base_layer/core              | 0.1.0   |                                          |
-| base_layer/key_manager       | 0.0.10  | 7d734a2e79bfe2dd5d4ae00a2b760614d21e69c4 |
-| base_layer/mmr               | 0.1.0   |                                          |
-| base_layer/p2p               | 0.1.0   |                                          |
+| infrastructure/storage       | 0.2.0   |                                          |
+| infrastructure/test_utils    | 0.2.0   |                                          |
+| base_layer/core              | 0.2.0   |                                          |
+| base_layer/key_manager       | 0.2.0   |                                          |
+| base_layer/mmr               | 0.2.0   | d4780a588942d9bd5f3188fa373e9aa869a26870 |
+| base_layer/p2p               | 0.2.0   |                                          |
 | base_layer/service_framework | 0.0.10  | 7d734a2e79bfe2dd5d4ae00a2b760614d21e69c4 |
-| base_layer/wallet            | 0.1.0   |                                          |
-| base_layer/wallet_ffi        | 0.1.0   |                                          |
-| common                       | 0.1.0   |                                          |
-| comms                        | 0.1.0   |                                          |
-| comms/dht                    | 0.1.0   |                                          |
-| applications/tari_base_node  | 0.1.0   |                                          |
+| base_layer/wallet            | 0.2.0   |                                          |
+| base_layer/wallet_ffi        | 0.2.0   |                                          |
+| common                       | 0.2.0   |                                          |
+| comms                        | 0.2.0   |                                          |
+| comms/dht                    | 0.2.0   |                                          |
+| applications/tari_base_node  | 0.4.2   | 1f097732faf957323129d3bcfe073dd6dbdf8e41 |

--- a/applications/tari_base_node/Cargo.toml
+++ b/applications/tari_base_node/Cargo.toml
@@ -10,17 +10,17 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-tari_common = { version= "^0.1", path = "../../common" }
-tari_comms = { version = "^0.1", path = "../../comms"}
-tari_comms_dht = { version = "^0.1", path = "../../comms/dht"}
-tari_core = {path = "../../base_layer/core", version= "^0.1"}
-tari_p2p = {path = "../../base_layer/p2p", version= "^0.1"}
+tari_common = { version= "^0.2", path = "../../common" }
+tari_comms = { version = "^0.2", path = "../../comms"}
+tari_comms_dht = { version = "^0.2", path = "../../comms/dht"}
+tari_core = { version= "^0.2", path = "../../base_layer/core" }
+tari_p2p = { version= "^0.2", path = "../../base_layer/p2p" }
 tari_service_framework = { version = "^0.0", path = "../../base_layer/service_framework"}
 tari_shutdown = { path = "../../infrastructure/shutdown", version = "^0.0" }
-tari_mmr = { path = "../../base_layer/mmr", version = "^0.2" }
-tari_wallet = { path = "../../base_layer/wallet", version = "^0.1" }
+tari_mmr = { version = "^0.2", path = "../../base_layer/mmr" }
+tari_wallet = { version = "^0.2", path = "../../base_layer/wallet" }
 tari_broadcast_channel = "^0.2"
-tari_crypto = { version = "^0.4" }
+tari_crypto = { version = "^0.5" }
 
 structopt = { version = "0.3.13", default_features = false }
 config = { version = "0.9.3" }

--- a/applications/test_faucet/Cargo.toml
+++ b/applications/test_faucet/Cargo.toml
@@ -7,13 +7,13 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-tari_utilities = "^0.1"
+tari_utilities = "^0.2"
 serde = { version = "1.0.97", features = ["derive"] }
 serde_json = "1.0"
 rand = "0.7.2"
 
 [dependencies.tari_core]
-version = "^0.1"
+version = "^0.2"
 path = "../../base_layer/core/"
 default-features = false
 features = ["transactions", "avx2"]

--- a/base_layer/core/Cargo.toml
+++ b/base_layer/core/Cargo.toml
@@ -6,7 +6,7 @@ repository = "https://github.com/tari-project/tari"
 homepage = "https://tari.com"
 readme = "README.md"
 license = "BSD-3-Clause"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2018"
 
 [features]
@@ -19,14 +19,14 @@ base_node_proto = []
 avx2 = ["tari_crypto/avx2"]
 
 [dependencies]
-tari_comms = { version = "^0.1", path = "../../comms"}
+tari_comms = { version = "^0.2", path = "../../comms"}
 tari_infra_derive = {  version = "^0.0", path = "../../infrastructure/derive" }
-tari_crypto = { version = "^0.4" }
-tari_storage = { version = "^0.1", path = "../../infrastructure/storage" }
-tari_common = { version= "^0.1", path = "../../common"}
+tari_crypto = { version = "^0.5" }
+tari_storage = { version = "^0.2", path = "../../infrastructure/storage" }
+tari_common = { version= "^0.2", path = "../../common"}
 tari_service_framework = { version = "^0.0", path = "../service_framework"}
-tari_p2p = { version = "^0.1", path = "../../base_layer/p2p" }
-tari_comms_dht = { version = "^0.1", path = "../../comms/dht"}
+tari_p2p = { version = "^0.2", path = "../../base_layer/p2p" }
+tari_comms_dht = { version = "^0.2", path = "../../comms/dht"}
 tari_broadcast_channel = "^0.2"
 tari_shutdown = { version = "^0.0", path = "../../infrastructure/shutdown" }
 tari_mmr = { version = "^0.2", path = "../../base_layer/mmr", optional = true }
@@ -66,13 +66,13 @@ strum_macros = "0.17.1"
 num = "0.3"
 
 [dev-dependencies]
-tari_p2p = {path = "../../base_layer/p2p", version = "^0.1", features=["test-mocks"]}
-tari_test_utils = { path = "../../infrastructure/test_utils", version = "^0.0" }
+tari_p2p = { version = "^0.2", path = "../../base_layer/p2p", features=["test-mocks"]}
+tari_test_utils = { version = "^0.2", path = "../../infrastructure/test_utils" }
 env_logger = "0.7.0"
 tempfile = "3.1.0"
 tokio-macros = "0.2.4"
-tari_wallet = { path = "../../base_layer/wallet", version = "^0.1" }
+tari_wallet = { version = "^0.2", path = "../../base_layer/wallet" }
 tokio-test = "0.2.0"
 
 [build-dependencies]
-tari_common = { version = "^0.1", path="../../common"}
+tari_common = { version = "^0.2", path="../../common"}

--- a/base_layer/key_manager/Cargo.toml
+++ b/base_layer/key_manager/Cargo.toml
@@ -4,11 +4,11 @@ authors = ["The Tari Development Community"]
 description = "Tari cryptocurrency wallet key management"
 repository = "https://github.com/tari-project/tari"
 license = "BSD-3-Clause"
-version = "0.0.10"
+version = "0.2.0"
 edition = "2018"
 
 [dependencies]
-tari_crypto = { version = "^0.4" }
+tari_crypto = { version = "^0.5" }
 rand = "0.7.2"
 digest = "0.8.0"
 sha2 = "0.8.0"

--- a/base_layer/mmr/Cargo.toml
+++ b/base_layer/mmr/Cargo.toml
@@ -14,14 +14,14 @@ digest = "0.8.0"
 log = "0.4"
 serde = { version = "1.0.97", features = ["derive"] }
 croaring =  "=0.4.5"
-tari_storage = { path = "../../infrastructure/storage", version = "^0.1" }
+tari_storage = { version = "^0.2", path = "../../infrastructure/storage" }
 
 [dev-dependencies]
 criterion = "0.2"
 rand="0.7.0"
 blake2 = "0.8.0"
 tari_infra_derive= { path = "../../infrastructure/derive", version = "^0.0" }
-tari_crypto = { version = "^0.4" }
+tari_crypto = { version = "^0.5" }
 serde_json = "1.0"
 bincode = "1.1"
 [lib]

--- a/base_layer/p2p/Cargo.toml
+++ b/base_layer/p2p/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tari_p2p"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["The Tari Development community"]
 description = "Tari base layer-specific peer-to-peer communication features"
 repository = "https://github.com/tari-project/tari"
@@ -11,14 +11,14 @@ edition = "2018"
 
 [dependencies]
 tari_broadcast_channel = "^0.2"
-tari_comms = { version = "^0.1", path = "../../comms"}
-tari_comms_dht = { version = "^0.1", path = "../../comms/dht"}
-tari_common = { version= "^0.1", path = "../../common" }
-tari_crypto = { version = "^0.4" }
+tari_comms = { version = "^0.2", path = "../../comms"}
+tari_comms_dht = { version = "^0.2", path = "../../comms/dht"}
+tari_common = { version= "^0.2", path = "../../common" }
+tari_crypto = { version = "^0.5" }
 tari_service_framework = { version = "^0.0", path = "../service_framework"}
 tari_shutdown = { version = "^0.0", path="../../infrastructure/shutdown" }
-tari_storage = {version = "^0.1", path = "../../infrastructure/storage"}
-tari_utilities = "^0.1"
+tari_storage = {version = "^0.2", path = "../../infrastructure/storage"}
+tari_utilities = "^0.2"
 
 bytes = "0.4.12"
 chrono = {version = "0.4.6", features = ["serde"]}
@@ -35,7 +35,7 @@ tower = "0.3.0-alpha.2"
 tower-service = { version="0.3.0-alpha.2" }
  
 [dev-dependencies]
-tari_test_utils = { version = "^0.0", path="../../infrastructure/test_utils" }
+tari_test_utils = { version = "^0.2", path="../../infrastructure/test_utils" }
 
 clap = "2.33.0"
 crossbeam-channel = "0.3.8"
@@ -57,7 +57,7 @@ default-features = false
 version = "0.12.0"
 
 [build-dependencies]
-tari_common = { version = "^0.1", path="../../common"}
+tari_common = { version = "^0.2", path="../../common"}
 
 [features]
 test-mocks = []

--- a/base_layer/service_framework/Cargo.toml
+++ b/base_layer/service_framework/Cargo.toml
@@ -19,6 +19,6 @@ tokio = "0.2.10"
 log = "0.4.8"
 
 [dev-dependencies]
-tari_test_utils = { version = "^0.0", path="../../infrastructure/test_utils" }
+tari_test_utils = { version = "^0.2", path="../../infrastructure/test_utils" }
 futures-test = { version = "0.3.3" }
 tower = "0.3.1"

--- a/base_layer/wallet/Cargo.toml
+++ b/base_layer/wallet/Cargo.toml
@@ -3,18 +3,18 @@ name = "tari_wallet"
 authors = ["The Tari Development Community"]
 description = "Tari cryptocurrency wallet library"
 license = "BSD-3-Clause"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2018"
 
 [dependencies]
-tari_comms = { path = "../../comms", version = "^0.1"}
-tari_comms_dht = { path = "../../comms/dht", version = "^0.1"}
-tari_crypto = { version = "^0.4" }
-tari_key_manager = {path = "../key_manager", version = "^0.0"}
-tari_p2p = {path = "../p2p", version = "^0.1"}
+tari_comms = { version = "^0.2", path = "../../comms"}
+tari_comms_dht = { version = "^0.2", path = "../../comms/dht" }
+tari_crypto = { version = "^0.5" }
+tari_key_manager = { version = "^0.2", path = "../key_manager" }
+tari_p2p = { version = "^0.2", path = "../p2p" }
 tari_service_framework = { version = "^0.0", path = "../service_framework"}
-tari_shutdown = { path = "../../infrastructure/shutdown", version = "^0.0"}
-tari_storage = { version = "^0.1", path = "../../infrastructure/storage"}
+tari_shutdown = { version = "^0.0", path = "../../infrastructure/shutdown" }
+tari_storage = { version = "^0.2", path = "../../infrastructure/storage"}
 
 chrono = { version = "0.4.6", features = ["serde"]}
 time = {version = "0.1.39"}
@@ -35,18 +35,18 @@ futures =  { version = "^0.3.1", features =["compat", "std"]}
 tokio = { version = "0.2.10", features = ["blocking", "sync"]}
 tower = "0.3.0-alpha.2"
 tempfile = "3.1.0"
-tari_test_utils = { path = "../../infrastructure/test_utils", version = "^0.0", optional = true}
+tari_test_utils = { version = "^0.2", path = "../../infrastructure/test_utils", optional = true}
 
 [dependencies.tari_core]
 path = "../../base_layer/core"
-version = "^0.1"
+version = "^0.2"
 default-features = false
 features = ["transactions", "mempool_proto", "base_node_proto"]
 
 [dev-dependencies]
-tari_p2p = {path = "../p2p", version = "^0.1", features=["test-mocks"]}
-tari_comms_dht = { path = "../../comms/dht", version = "^0.1", features=["test-mocks"]}
-tari_test_utils = { path = "../../infrastructure/test_utils", version = "^0.0"}
+tari_p2p = { version = "^0.2", path = "../p2p", features=["test-mocks"]}
+tari_comms_dht = { version = "^0.2", path = "../../comms/dht", features=["test-mocks"]}
+tari_test_utils = { version = "^0.2", path = "../../infrastructure/test_utils" }
 lazy_static = "1.3.0"
 env_logger = "0.7.1"
 prost = "0.6.1"

--- a/base_layer/wallet_ffi/Cargo.toml
+++ b/base_layer/wallet_ffi/Cargo.toml
@@ -3,17 +3,17 @@ name = "tari_wallet_ffi"
 authors = ["The Tari Development Community"]
 description = "Tari cryptocurrency wallet C FFI bindings"
 license = "BSD-3-Clause"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2018"
 
 [dependencies]
-tari_comms = { path = "../../comms", version = "^0.1"}
-tari_comms_dht = { path = "../../comms/dht", version = "^0.1"}
-tari_crypto = { version = "^0.4" }
-tari_p2p = {path = "../p2p", version = "^0.1"}
-tari_wallet = { path = "../wallet", version = "^0.1", features = ["test_harness", "c_integration"]}
-tari_shutdown = { path = "../../infrastructure/shutdown", version = "^0.0"}
-tari_utilities = "^0.1"
+tari_comms = { version = "^0.2", path = "../../comms" }
+tari_comms_dht = { version = "^0.2", path = "../../comms/dht" }
+tari_crypto = { version = "^0.5" }
+tari_p2p = { version = "^0.2", path = "../p2p" }
+tari_wallet = { version = "^0.2", path = "../wallet", features = ["test_harness", "c_integration"]}
+tari_shutdown = { version = "^0.0", path = "../../infrastructure/shutdown" }
+tari_utilities = "^0.2"
 
 futures =  { version = "^0.3.1", features =["compat", "std"]}
 tokio = "0.2.10"
@@ -26,7 +26,7 @@ log4rs = {version = "0.8.3", features = ["console_appender", "file_appender", "f
 
 [dependencies.tari_core]
 path = "../../base_layer/core"
-version = "^0.1"
+version = "^0.2"
 default-features = false
 features = ["transactions"]
 
@@ -37,4 +37,4 @@ crate-type = ["staticlib","cdylib"]
 tempfile = "3.1.0"
 lazy_static = "1.3.0"
 env_logger = "0.7.1"
-tari_key_manager = {path = "../key_manager", version = "^0.0"}
+tari_key_manager = { version = "^0.2", path = "../key_manager" }

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -6,7 +6,7 @@ repository = "https://github.com/tari-project/tari"
 homepage = "https://tari.com"
 readme = "README.md"
 license = "BSD-3-Clause"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2018"
 
 
@@ -26,7 +26,7 @@ path-clean = "0.1.0"
 
 [dev-dependencies]
 tempfile = "3.1.0"
-tari_test_utils = { version = "^0.0", path = "../infrastructure/test_utils"}
+tari_test_utils = { version = "^0.2", path = "../infrastructure/test_utils"}
 serde = { version = "1.0.106", features = ["derive"] }
 anyhow = "1.0"
 toml = "0.5"

--- a/comms/Cargo.toml
+++ b/comms/Cargo.toml
@@ -6,12 +6,12 @@ repository = "https://github.com/tari-project/tari"
 homepage = "https://tari.com"
 readme = "README.md"
 license = "BSD-3-Clause"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2018"
 
 [dependencies]
-tari_crypto = { version = "^0.4" }
-tari_storage = { version="^0.1", path = "../infrastructure/storage" }
+tari_crypto = { version = "^0.5" }
+tari_storage = { version = "^0.2", path = "../infrastructure/storage" }
 tari_shutdown = { version="^0.0",  path = "../infrastructure/shutdown" }
 
 bitflags = "1.0.4"
@@ -41,7 +41,7 @@ tower= "0.3.1"
 yamux = "=0.4.7"
 
 [dev-dependencies]
-tari_test_utils = {version="^0.0", path="../infrastructure/test_utils"}
+tari_test_utils = {version="^0.2", path="../infrastructure/test_utils"}
 
 env_logger = "0.7.0"
 serde_json = "1.0.39"
@@ -49,7 +49,7 @@ tokio-macros = "0.2.3"
 tempfile = "3.1.0"
 
 [build-dependencies]
-tari_common = { version = "^0.1", path="../common"}
+tari_common = { version = "^0.2", path="../common"}
 
 [features]
 avx2 = ["tari_crypto/avx2"]

--- a/comms/dht/Cargo.toml
+++ b/comms/dht/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tari_comms_dht"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["The Tari Development Community"]
 description = "Tari comms DHT module"
 repository = "https://github.com/tari-project/tari"
@@ -10,11 +10,11 @@ license = "BSD-3-Clause"
 edition = "2018"
 
 [dependencies]
-tari_comms = { version = "^0.1", path = "../"}
-tari_crypto = { version = "^0.4" }
-tari_utilities = { version = "^0.1" }
+tari_comms  = { version = "^0.2", path = "../"}
+tari_crypto = { version = "^0.5" }
+tari_utilities  = { version = "^0.2" }
 tari_shutdown = { version = "^0.0", path = "../../infrastructure/shutdown"}
-tari_storage = { version = "^0.1", path = "../../infrastructure/storage"}
+tari_storage  = { version = "^0.2", path = "../../infrastructure/storage"}
 
 bitflags = "1.2.0"
 bytes = "0.4.12"
@@ -39,7 +39,7 @@ pin-project = "0.4"
 thiserror = "1.0.19"
 
 [dev-dependencies]
-tari_test_utils = { version = "^0.0", path = "../../infrastructure/test_utils"}
+tari_test_utils = { version = "^0.2", path = "../../infrastructure/test_utils"}
 
 env_logger = "0.7.0"
 futures-test = { version = "0.3.0-alpha.19", package = "futures-test-preview" }
@@ -56,7 +56,7 @@ futures-util = "^0.3.1"
 lazy_static = "1.4.0"
 
 [build-dependencies]
-tari_common = { version = "^0.1", path="../../common"}
+tari_common  = { version = "^0.2", path="../../common"}
 
 [features]
 test-mocks = []

--- a/infrastructure/storage/Cargo.toml
+++ b/infrastructure/storage/Cargo.toml
@@ -6,7 +6,7 @@ repository = "https://github.com/tari-project/tari"
 homepage = "https://tari.com"
 readme = "README.md"
 license = "BSD-3-Clause"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2018"
 
 [dependencies]
@@ -19,7 +19,7 @@ rmp = "0.8.7"
 rmp-serde = "0.13.7"
 serde = "1.0.80"
 serde_derive = "1.0.80"
-tari_utilities = "^0.1"
+tari_utilities = "^0.2"
 bytes = "0.4.12"
 
 [dev-dependencies]

--- a/infrastructure/test_utils/Cargo.toml
+++ b/infrastructure/test_utils/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tari_test_utils"
 description = "Utility functions used in Tari test functions"
-version = "0.0.10"
+version = "0.2.0"
 authors = ["The Tari Development Community"]
 edition = "2018"
 license = "BSD-3-Clause"

--- a/scripts/publish_crates.sh
+++ b/scripts/publish_crates.sh
@@ -1,23 +1,18 @@
 #!/usr/bin/env bash
 # NB: The order these are listed in is IMPORTANT! Dependencies must go first
 
-#infrastructure/derive
-#infrastructure/shutdown
-#infrastructure/storage
-#infrastructure/test_utils
-#common
-#comms
-#comms/dht
-#base_layer/service_framework
-#base_layer/mmr
-#base_layer/key_manager
-#base_layer/p2p
-#base_layer/core
-#base_layer/wallet
-#base_layer/wallet_ffi
-#applications/tari_base_node
-
 packages=${@:-'
+infrastructure/derive
+infrastructure/shutdown
+infrastructure/storage
+infrastructure/test_utils
+common
+comms
+comms/dht
+base_layer/service_framework
+base_layer/mmr
+base_layer/key_manager
+base_layer/p2p
 base_layer/core
 base_layer/wallet
 base_layer/wallet_ffi


### PR DESCRIPTION
* Updated all crates that have changed since last release to v0.2.0
* Published crate set to crates.io
* Upgrade to tari_crypto 0.5
* Format cargo.toml to put `version` first for easier regex search/replace in future

Notes:

The following changes were made to the tari_core crate to get it to
build and publish

* Removed dev-dependency on tari-wallets
* Used `--no-verify` flag to prevent protobuf code generation from
breaking publication.

