### PR TITLE
Make croaring optional compile for mmr for WASM support

### DIFF
--- a/base_layer/mmr/Cargo.toml
+++ b/base_layer/mmr/Cargo.toml
@@ -7,14 +7,17 @@ license = "BSD-3-Clause"
 version = "0.2.0"
 edition = "2018"
 
+[features]
+default = ["native_bitmap"]
+native_bitmap = ["croaring"]
+
 [dependencies]
 tari_utilities = "^0.2"
 derive-error = "0.0.4"
 digest = "0.8.0"
 log = "0.4"
 serde = { version = "1.0.97", features = ["derive"] }
-croaring =  "=0.4.5"
-tari_storage = { version = "^0.2", path = "../../infrastructure/storage" }
+croaring =  { version = "=0.4.5", optional = true }
 
 [dev-dependencies]
 criterion = "0.2"

--- a/base_layer/mmr/README.md
+++ b/base_layer/mmr/README.md
@@ -11,3 +11,8 @@ at the bottom of the MMR is the hashes of the data. The MMR allows easy to add a
 tree. MMR always tries to have the largest possible single binary tree, so in effect it is possible to have more than
 one binary tree. Every time you have to get the merkle root (the single merkle proof of the whole MMR) you have the bag
 the peaks of the individual trees, or mountain peaks.
+
+### Features
+
+* `native_bitmap` - default feature, provides implementation for `MerkleCheckPoint`, `MmrCache`, `MutableMmr` via
+using linked C library `croaring` (make sure to disable this feature when compiling to WASM).

--- a/base_layer/mmr/src/lib.rs
+++ b/base_layer/mmr/src/lib.rs
@@ -137,18 +137,13 @@ pub type HashSlice = [u8];
 
 mod backend;
 mod mem_backend_vec;
-mod merkle_checkpoint;
 mod merkle_mountain_range;
 mod merkle_proof;
-mod mmr_cache;
-mod mutable_mmr;
-mod mutable_mmr_leaf_nodes;
 mod serde_support;
 
 // Less commonly used exports
 pub mod common;
 pub mod error;
-pub mod functions;
 /// A function for snapshotting and pruning a Merkle Mountain Range
 pub mod pruned_hashset;
 
@@ -157,16 +152,34 @@ pub mod pruned_hashset;
 pub use backend::{ArrayLike, ArrayLikeExt};
 /// MemBackendVec is a shareable, memory only, vector that can be be used with MmrCache to store checkpoints.
 pub use mem_backend_vec::MemBackendVec;
-/// A Merkle checkpoint contains the set of hash additions and deletion indices.
-pub use merkle_checkpoint::MerkleCheckPoint;
 /// An immutable, append-only Merkle Mountain range (MMR) data structure
 pub use merkle_mountain_range::MerkleMountainRange;
 /// A data structure for proving a hash inclusion in an MMR
 pub use merkle_proof::{MerkleProof, MerkleProofError};
-/// The MMR cache is used to calculate Merkle and Merklish roots based on the state of the set of shared
-/// checkpoints.
-pub use mmr_cache::{MmrCache, MmrCacheConfig};
-/// An append-only Merkle Mountain range (MMR) data structure that allows deletion of existing leaf nodes.
-pub use mutable_mmr::MutableMmr;
-/// A data structure for storing all the data required to restore the state of an MMR.
-pub use mutable_mmr_leaf_nodes::MutableMmrLeafNodes;
+
+macro_rules! if_native_bitmap {
+    ($($item:item)*) => {
+        $(
+            #[cfg(feature = "native_bitmap")]
+            $item
+        )*
+    }
+}
+
+if_native_bitmap! {
+    mod merkle_checkpoint;
+    mod mmr_cache;
+    mod mutable_mmr;
+    mod mutable_mmr_leaf_nodes;
+    pub mod functions;
+
+    /// A Merkle checkpoint contains the set of hash additions and deletion indices.
+    pub use merkle_checkpoint::MerkleCheckPoint;
+    /// The MMR cache is used to calculate Merkle and Merklish roots based on the state of the set of shared
+    /// checkpoints.
+    pub use mmr_cache::{MmrCache, MmrCacheConfig};
+    /// An append-only Merkle Mountain range (MMR) data structure that allows deletion of existing leaf nodes.
+    pub use mutable_mmr::MutableMmr;
+    /// A data structure for storing all the data required to restore the state of an MMR.
+    pub use mutable_mmr_leaf_nodes::MutableMmrLeafNodes;
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This is PoC for making mmr compile to WASM. The only dependency which does not compile is croaring, hence I have added default feature `native_bitmap`. If we would need to add support for mutable mmr in WASM we will need to pick rust implementation of Bitmap.

## Motivation and Context
This would allow to use MerkleRoot of emoji_id from WASM-enabled clients

## How Has This Been Tested?
I have checked that module compiles to wasm via:
```
cargo build --target=wasm32-unknown-unknown --no-default-features
```

If compiled with all features there is exception:
```
  Compiling croaring-sys v0.4.5
The following warnings were emitted during compilation:

warning: In file included from CRoaring/roaring.c:2:
warning: CRoaring/roaring.h:39:10: fatal error: 'stdlib.h' file not found
warning: #include <stdlib.h>  // will provide posix_memalign with _POSIX_C_SOURCE as defined above
warning:          ^~~~~~~~~~
warning: 1 error generated.

error: failed to run custom build command for `croaring-sys v0.4.5`

Caused by:
  process didn't exit successfully: `/Users/max/src/tari/tari/target/release/build/croaring-sys-8cdf53bbba342588/build-script-build` (exit
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [X] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [x] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [X] I'm merging against the `development` branch.
* [X] I ran `cargo-fmt --all` before pushing.
* [X] I have squashed my commits into a single commit.
* [x] My change requires a change to the documentation.
* [x] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
