### PR TITLE
Add Hash to grpc calls

### DIFF
--- a/applications/tari_base_node/proto/base_node.proto
+++ b/applications/tari_base_node/proto/base_node.proto
@@ -50,7 +50,7 @@ service BaseNode {
     // Get the block template
     rpc GetNewBlockTemplate(PowAlgo) returns (NewBlockTemplate);
     // Construct a new block from a provided template
-    rpc GetNewBlock(NewBlockTemplate) returns (Block);
+    rpc GetNewBlock(NewBlockTemplate) returns (GetNewBlockResult);
     // Submit a new block for propogation
     rpc SubmitBlock(Block) returns (Empty);
     // Get the base node tip information
@@ -375,4 +375,22 @@ message MetaData {
         uint64 pruning_horizon = 4;
         // The current geometric mean of the pow of the chain tip, or `None` if there is no chain
         uint64 accumulated_difficulty = 5;
+}
+
+// This is the message that is returned for a miner after it asks for a new block. 
+message GetNewBlockResult{
+    // This is the header hash of the complated block
+    bytes block_hash = 1;
+    // This is the completed block
+    Block block = 2;
+    // This is the merge_mining hash of the completed block. 
+    MinerData mining_data = 3;
+}
+
+// This is mining data for the miner asking for a new block
+message MinerData{
+    PowAlgo algo = 1;
+    uint64 target_difficulty = 2;
+    uint64 reward = 3;
+    bytes mergemining_hash =4;
 }

--- a/applications/tari_base_node/src/builder.rs
+++ b/applications/tari_base_node/src/builder.rs
@@ -1185,7 +1185,7 @@ async fn register_wallet_services(
     broadcast_send_timeout: Duration,
 ) -> Arc<ServiceHandles>
 {
-    let mut transaction_db = TransactionServiceSqliteDatabase::new(wallet_db_conn.clone(), None);
+    let transaction_db = TransactionServiceSqliteDatabase::new(wallet_db_conn.clone(), None);
     transaction_db.migrate(wallet_comms.node_identity().public_key().clone());
 
     StackBuilder::new(runtime::Handle::current(), wallet_comms.shutdown_signal())

--- a/applications/tari_base_node/src/grpc/grpc_conversions/blocks.rs
+++ b/applications/tari_base_node/src/grpc/grpc_conversions/blocks.rs
@@ -20,49 +20,19 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use crate::grpc::{
-    blocks::{block_fees, block_heights, block_size, GET_BLOCKS_MAX_HEIGHTS, GET_BLOCKS_PAGE_SIZE},
-    helpers::{mean, median},
-    server::base_node_grpc::*,
-};
+use crate::grpc::server::base_node_grpc as grpc;
 use prost_types::Timestamp;
 use std::convert::{TryFrom, TryInto};
 use tari_core::{
-    base_node::{comms_interface::Broadcast, LocalNodeCommsInterface},
     blocks::{Block, BlockHeader, NewBlockHeaderTemplate, NewBlockTemplate},
-    chain_storage::{ChainMetadata, HistoricalBlock},
-    consensus::{
-        emission::EmissionSchedule,
-        ConsensusConstants,
-        Network,
-        KERNEL_WEIGHT,
-        WEIGHT_PER_INPUT,
-        WEIGHT_PER_OUTPUT,
-    },
+    chain_storage::HistoricalBlock,
     proof_of_work::{Difficulty, PowAlgorithm, ProofOfWork},
-    proto::utils::try_convert_all,
-    transactions::{
-        aggregated_body::AggregateBody,
-        bullet_rangeproofs::BulletRangeProof,
-        tari_amount::MicroTari,
-        transaction::{
-            KernelFeatures,
-            OutputFeatures,
-            OutputFlags,
-            TransactionInput,
-            TransactionKernel,
-            TransactionOutput,
-        },
-        types::{BlindingFactor, Commitment, PrivateKey, PublicKey, Signature},
-    },
+    transactions::types::BlindingFactor,
 };
 use tari_crypto::tari_utilities::{epoch_time::EpochTime, ByteArray, Hashable};
-use tonic::Status;
-
-use crate::grpc::server::base_node_grpc as grpc;
 
 /// Utility function that converts a `chrono::DateTime` to a `prost::Timestamp`
-fn datetime_to_timestamp(datetime: EpochTime) -> Timestamp {
+pub fn datetime_to_timestamp(datetime: EpochTime) -> Timestamp {
     Timestamp {
         seconds: datetime.as_u64() as i64,
         nanos: 0,

--- a/applications/tari_base_node/src/grpc/grpc_conversions/requests.rs
+++ b/applications/tari_base_node/src/grpc/grpc_conversions/requests.rs
@@ -21,55 +21,17 @@
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 use crate::grpc::{
-    blocks::{block_fees, block_heights, block_size, GET_BLOCKS_MAX_HEIGHTS, GET_BLOCKS_PAGE_SIZE},
-    helpers::{mean, median},
+    blocks::block_heights,
     server::{base_node_grpc as grpc, base_node_grpc::*},
 };
-use prost_types::Timestamp;
-use std::convert::{TryFrom, TryInto};
+use std::convert::TryFrom;
 use tari_core::{
-    base_node::{comms_interface::Broadcast, LocalNodeCommsInterface},
-    blocks::{Block, BlockHeader, NewBlockHeaderTemplate, NewBlockTemplate},
-    chain_storage::{ChainMetadata, HistoricalBlock},
-    consensus::{
-        emission::EmissionSchedule,
-        ConsensusConstants,
-        Network,
-        KERNEL_WEIGHT,
-        WEIGHT_PER_INPUT,
-        WEIGHT_PER_OUTPUT,
-    },
-    proof_of_work::{Difficulty, PowAlgorithm, ProofOfWork},
-    proto::utils::try_convert_all,
-    transactions::{
-        aggregated_body::AggregateBody,
-        bullet_rangeproofs::BulletRangeProof,
-        tari_amount::MicroTari,
-        transaction::{
-            KernelFeatures,
-            OutputFeatures,
-            OutputFlags,
-            TransactionInput,
-            TransactionKernel,
-            TransactionOutput,
-        },
-        types::{BlindingFactor, Commitment, PrivateKey, PublicKey, Signature},
-    },
+    base_node::LocalNodeCommsInterface,
+    chain_storage::ChainMetadata,
+    consensus::{ConsensusConstants, KERNEL_WEIGHT, WEIGHT_PER_INPUT, WEIGHT_PER_OUTPUT},
+    proof_of_work::{Difficulty, PowAlgorithm},
 };
-use tari_crypto::tari_utilities::{epoch_time::EpochTime, ByteArray, Hashable};
 use tonic::Status;
-
-/// Utility function that converts a `chrono::DateTime` to a `prost::Timestamp`
-fn datetime_to_timestamp(datetime: EpochTime) -> Timestamp {
-    Timestamp {
-        seconds: datetime.as_u64() as i64,
-        nanos: 0,
-    }
-}
-
-pub(crate) fn timestamp_to_datetime(timestamp: Timestamp) -> EpochTime {
-    (timestamp.seconds as u64).into()
-}
 
 impl From<u64> for grpc::IntegerValue {
     fn from(value: u64) -> Self {

--- a/applications/tari_base_node/src/grpc/grpc_conversions/transactions.rs
+++ b/applications/tari_base_node/src/grpc/grpc_conversions/transactions.rs
@@ -20,26 +20,8 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use crate::grpc::{
-    blocks::{block_fees, block_heights, block_size, GET_BLOCKS_MAX_HEIGHTS, GET_BLOCKS_PAGE_SIZE},
-    helpers::{mean, median},
-    server::base_node_grpc::*,
-};
-use prost_types::Timestamp;
 use std::convert::{TryFrom, TryInto};
 use tari_core::{
-    base_node::{comms_interface::Broadcast, LocalNodeCommsInterface},
-    blocks::{Block, BlockHeader, NewBlockHeaderTemplate, NewBlockTemplate},
-    chain_storage::{ChainMetadata, HistoricalBlock},
-    consensus::{
-        emission::EmissionSchedule,
-        ConsensusConstants,
-        Network,
-        KERNEL_WEIGHT,
-        WEIGHT_PER_INPUT,
-        WEIGHT_PER_OUTPUT,
-    },
-    proof_of_work::{Difficulty, PowAlgorithm, ProofOfWork},
     proto::utils::try_convert_all,
     transactions::{
         aggregated_body::AggregateBody,
@@ -53,11 +35,10 @@ use tari_core::{
             TransactionKernel,
             TransactionOutput,
         },
-        types::{BlindingFactor, Commitment, PrivateKey, PublicKey, Signature},
+        types::{Commitment, PrivateKey, PublicKey, Signature},
     },
 };
-use tari_crypto::tari_utilities::{epoch_time::EpochTime, ByteArray, Hashable};
-use tonic::Status;
+use tari_crypto::tari_utilities::ByteArray;
 
 use crate::grpc::server::base_node_grpc as grpc;
 

--- a/base_layer/core/src/blocks/blockheader.rs
+++ b/base_layer/core/src/blocks/blockheader.rs
@@ -208,6 +208,22 @@ impl BlockHeader {
         };
         (max, min, avg)
     }
+
+    /// Provides a hash of the header, used for the merge mining.
+    /// This differs from the normal hash by not hashing the nonce and kernel pow.
+    pub fn merged_mining_hash(&self) -> Vec<u8> {
+        HashDigest::new()
+            .chain(self.version.to_le_bytes())
+            .chain(self.height.to_le_bytes())
+            .chain(self.prev_hash.as_bytes())
+            .chain(self.timestamp.as_u64().to_le_bytes())
+            .chain(self.output_mr.as_bytes())
+            .chain(self.range_proof_mr.as_bytes())
+            .chain(self.kernel_mr.as_bytes())
+            .chain(self.total_kernel_offset.as_bytes())
+            .result()
+            .to_vec()
+    }
 }
 
 impl From<NewBlockHeaderTemplate> for BlockHeader {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Added hash to the get_block template for the grpc
Cleanup warnings on proto files and base_node

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This allows the caller of the grpc get_block to get the hash of the block as well as the merge_mining hash

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [x] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch.
* [x] I ran `cargo-fmt --all` before pushing.
* [x] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
