### PR TITLE
Update FFI to use stored Tx direction for Inbound Tx list

### DIFF
--- a/base_layer/wallet_ffi/src/lib.rs
+++ b/base_layer/wallet_ffi/src/lib.rs
@@ -3559,7 +3559,7 @@ pub unsafe extern "C" fn wallet_get_pending_inbound_transactions(
                 for ct in completed_txs
                     .values()
                     .filter(|ct| ct.status == TransactionStatus::Completed || ct.status == TransactionStatus::Broadcast)
-                    .filter(|ct| ct.destination_public_key == my_public_key)
+                    .filter(|ct| ct.direction == TransactionDirection::Inbound)
                 {
                     pending.push(InboundTransaction::from(ct.clone()));
                 }


### PR DESCRIPTION
## Description

This PR fixes one last place where LibWallet was comparing public keys to determine transaction direction rather than using the direction stored in the database. This resulted in problems after a partial wallet restore where a new public key is generated.

@kukabi 

## How Has This Been Tested?
Existing Tests

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch.
* [x] I ran `cargo-fmt --all` before pushing.
* [ ] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
