### PR TITLE
Clean up a deprecated function definition in wallet.h

### DIFF
--- a/base_layer/wallet_ffi/wallet.h
+++ b/base_layer/wallet_ffi/wallet.h
@@ -505,9 +505,6 @@ void wallet_apply_encryption(struct TariWallet *wallet, const char *passphrase, 
 // be removed. If it is not encrypted then this function will still succeed to make the operation idempotent
 void wallet_remove_encryption(struct TariWallet *wallet, int* error_out);
 
-// This function will produce a partial backup of the wallet at the location specified but with the sensitive data cleared.
-void wallet_partial_backup(struct TariWallet *wallet, const char *backup_file_path, int* error_out);
-
 // Frees memory for a TariWallet
 void wallet_destroy(struct TariWallet *wallet);
 


### PR DESCRIPTION
## Description

An auto merge resulted in an old function definition sneaking back into the wallet.h header file in wallet_ffi. This PR removes it.

## How Has This Been Tested?
Existing tests

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [ ] I'm merging against the `development` branch.
* [ ] I ran `cargo-fmt --all` before pushing.
* [ ] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
