### PR TITLE
Implement optimised outbound messaging

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3657,7 +3657,6 @@ dependencies = [
  "serde_json",
  "tari_crypto",
  "tari_infra_derive",
- "tari_storage",
  "tari_utilities",
 ]
 

--- a/comms/dht/src/outbound/broadcast.rs
+++ b/comms/dht/src/outbound/broadcast.rs
@@ -438,7 +438,7 @@ where S: Service<DhtOutboundMessage, Response = (), Error = PipelineError>
                         dht_flags,
                         custom_header: custom_header.clone(),
                         body: body.clone(),
-                        reply_tx: reply_tx.into(),
+                        reply: reply_tx.into(),
                         ephemeral_public_key: ephemeral_public_key.clone(),
                         origin_mac: origin_mac.clone(),
                         is_broadcast,

--- a/comms/dht/src/outbound/serialize.rs
+++ b/comms/dht/src/outbound/serialize.rs
@@ -77,7 +77,7 @@ where S: Service<OutboundMessage, Response = (), Error = PipelineError> + Clone 
                 network,
                 dht_flags,
                 origin_mac,
-                reply_tx,
+                reply,
                 ..
             } = message;
 
@@ -99,7 +99,7 @@ where S: Service<OutboundMessage, Response = (), Error = PipelineError> + Clone 
                 .oneshot(OutboundMessage {
                     tag,
                     peer_node_id: destination_node_id,
-                    reply_tx: reply_tx.into_inner(),
+                    reply,
                     body,
                 })
                 .await

--- a/comms/dht/src/test_utils/makers.rs
+++ b/comms/dht/src/test_utils/makers.rs
@@ -23,7 +23,7 @@ use crate::{
     crypt,
     envelope::{DhtMessageFlags, DhtMessageHeader, NodeDestination},
     inbound::DhtInboundMessage,
-    outbound::message::{DhtOutboundMessage, WrappedReplyTx},
+    outbound::message::DhtOutboundMessage,
     proto::envelope::{DhtEnvelope, DhtMessageType, Network, OriginMac},
 };
 use rand::rngs::OsRng;
@@ -201,7 +201,7 @@ pub fn create_outbound_message(body: &[u8]) -> DhtOutboundMessage {
         custom_header: None,
         body: body.to_vec().into(),
         ephemeral_public_key: None,
-        reply_tx: WrappedReplyTx::none(),
+        reply: None.into(),
         origin_mac: None,
         is_broadcast: false,
     }

--- a/comms/examples/stress_test.rs
+++ b/comms/examples/stress_test.rs
@@ -30,7 +30,7 @@ use tari_crypto::tari_utilities::message_format::MessageFormat;
 use tempfile::Builder;
 use tokio::time;
 
-#[tokio_macros::main]
+#[tokio_macros::main_basic(max_threads = 1)]
 async fn main() {
     env_logger::init();
     match run().await {

--- a/comms/src/protocol/messaging/error.rs
+++ b/comms/src/protocol/messaging/error.rs
@@ -21,6 +21,7 @@
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 use crate::{connection_manager::PeerConnectionError, peer_manager::PeerManagerError, protocol::ProtocolError};
+use futures::channel::mpsc;
 use std::io;
 use thiserror::Error;
 
@@ -31,6 +32,7 @@ pub enum InboundMessagingError {
     #[error("Failed to decode message: {0}")]
     MessageDecodeError(#[from] prost::DecodeError),
 }
+
 #[derive(Debug, Error)]
 pub enum MessagingProtocolError {
     #[error("Failed to send message")]
@@ -41,8 +43,10 @@ pub enum MessagingProtocolError {
     PeerConnectionError(#[from] PeerConnectionError),
     #[error("Failed to dial peer")]
     PeerDialFailed,
-    #[error("Failure when sending on an outbound substream")]
-    OutboundSubstreamFailure,
     #[error("IO Error: {0}")]
     Io(#[from] io::Error),
+    #[error("Sender error: {0}")]
+    SenderError(#[from] mpsc::SendError),
+    #[error("Stream closed due to inactivity")]
+    Inactivity,
 }

--- a/comms/src/protocol/messaging/inbound.rs
+++ b/comms/src/protocol/messaging/inbound.rs
@@ -82,20 +82,20 @@ impl InboundMessaging {
             match result {
                 Ok(Ok(raw_msg)) => {
                     let inbound_msg = InboundMessage::new(Arc::clone(&peer), raw_msg.clone().freeze());
-                    trace!(
+                    debug!(
                         target: LOG_TARGET,
                         "Received message {} from peer '{}' ({} bytes)",
-                        inbound_msg.clone().tag,
+                        inbound_msg.tag,
                         peer.node_id.short_str(),
                         raw_msg.len()
                     );
 
                     let event = MessagingEvent::MessageReceived(
                         Box::new(inbound_msg.source_peer.node_id.clone()),
-                        inbound_msg.clone().tag,
+                        inbound_msg.tag,
                     );
 
-                    if let Err(err) = self.inbound_message_tx.send(inbound_msg.clone()).await {
+                    if let Err(err) = self.inbound_message_tx.send(inbound_msg).await {
                         warn!(
                             target: LOG_TARGET,
                             "Failed to send InboundMessage for peer '{}' because '{}'",
@@ -108,7 +108,6 @@ impl InboundMessaging {
                         }
                     }
 
-                    debug!(target: LOG_TARGET, "Inbound handler sending event '{}'", event);
                     let _ = self.messaging_events_tx.send(Arc::new(event));
                 },
                 Ok(Err(err)) => {

--- a/comms/src/protocol/messaging/outbound.rs
+++ b/comms/src/protocol/messaging/outbound.rs
@@ -23,14 +23,26 @@
 use super::{error::MessagingProtocolError, MessagingEvent, MessagingProtocol, SendFailReason, MESSAGING_PROTOCOL};
 use crate::{
     connection_manager::{ConnectionManagerError, ConnectionManagerRequester, NegotiatedSubstream, PeerConnection},
-    message::OutboundMessage,
+    message::{MessageTag, OutboundMessage},
     multiplexing::Substream,
     peer_manager::NodeId,
 };
-use futures::{channel::mpsc, future::Either, FutureExt, SinkExt, StreamExt};
+use bytes::Bytes;
+use futures::{
+    channel::mpsc,
+    future::Either,
+    ready,
+    stream::FusedStream,
+    task::{Context, Poll},
+    Sink,
+    SinkExt,
+    Stream,
+    StreamExt,
+};
 use log::*;
-use std::time::{Duration, Instant};
-use tokio::time;
+use pin_project::pin_project;
+use std::{io, pin::Pin, time::Duration};
+use tokio::stream as tokio_stream;
 
 const LOG_TARGET: &str = "comms::protocol::messaging::outbound";
 
@@ -60,12 +72,35 @@ impl OutboundMessaging {
         }
     }
 
-    pub async fn run(mut self) -> Result<(), MessagingProtocolError> {
+    pub async fn run(self) {
         debug!(
             target: LOG_TARGET,
             "Attempting to dial peer '{}' if required",
             self.peer_node_id.short_str()
         );
+        let peer_node_id = self.peer_node_id.clone();
+        match self.run_inner().await {
+            Ok(_) => {
+                debug!(
+                    target: LOG_TARGET,
+                    "Outbound messaging for peer '{}' has stopped because the stream was closed",
+                    peer_node_id.short_str()
+                );
+            },
+            Err(MessagingProtocolError::Inactivity) => {
+                debug!(
+                    target: LOG_TARGET,
+                    "Outbound messaging for peer '{}' has stopped because it was inactive",
+                    peer_node_id.short_str()
+                );
+            },
+            Err(err) => {
+                debug!(target: LOG_TARGET, "Outbound messaging substream failed: {}", err);
+            },
+        }
+    }
+
+    async fn run_inner(mut self) -> Result<(), MessagingProtocolError> {
         let conn = self.try_dial_peer().await?;
         let substream = self.try_open_substream(conn).await?;
         debug_assert_eq!(substream.protocol, MESSAGING_PROTOCOL);
@@ -123,84 +158,83 @@ impl OutboundMessaging {
         }
     }
 
-    async fn start_forwarding_messages(mut self, substream: Substream) -> Result<(), MessagingProtocolError> {
-        let mut framed = MessagingProtocol::framed(substream);
+    async fn start_forwarding_messages(self, substream: Substream) -> Result<(), MessagingProtocolError> {
+        let framed = MessagingProtocol::framed(substream);
 
-        loop {
-            let request_rx = match self.inactivity_timeout {
-                Some(timeout) => Either::Left(time::timeout(timeout, self.request_rx.next())),
-                None => Either::Right(self.request_rx.next().map(Ok)),
-            };
+        let Self {
+            request_rx,
+            inactivity_timeout,
+            peer_node_id,
+            messaging_events_tx,
+            ..
+        } = self;
 
-            match request_rx.await {
-                Ok(Some(mut out_msg)) => {
-                    debug!(
-                        target: LOG_TARGET,
-                        "Sending message ({} bytes) ({}) to peer `{}` on outbound messaging substream",
-                        out_msg.body.len(),
-                        out_msg.tag,
-                        self.peer_node_id.short_str()
-                    );
-                    let start = Instant::now();
-                    match framed.send(out_msg.body.clone()).await {
-                        Ok(_) => {
+        let stream = MessageForwarderStream::new(peer_node_id.clone(), request_rx, framed);
+
+        let stream = match inactivity_timeout {
+            Some(timeout) => {
+                let s = tokio_stream::StreamExt::timeout(stream, timeout).map(|r| match r {
+                    Ok(s) => s,
+                    Err(_) => Err(MessageSendFailure {
+                        item: None,
+                        error: MessagingProtocolError::Inactivity,
+                    }),
+                });
+                Either::Left(s)
+            },
+            None => Either::Right(stream),
+        };
+
+        stream
+            .fold(Result::<(), MessagingProtocolError>::Ok(()), move |_, result| {
+                let mut messaging_events_tx = messaging_events_tx.clone();
+                let peer_node_id = peer_node_id.clone();
+                async move {
+                    match result {
+                        Ok(tag) => {
                             debug!(
                                 target: LOG_TARGET,
-                                "Message ({}) sent to peer `{}` in {}ms",
-                                out_msg.tag,
-                                self.peer_node_id.short_str(),
-                                start.elapsed().as_millis()
+                                "(peer = {}, tag = {}) Message sent",
+                                peer_node_id.short_str(),
+                                tag,
                             );
-                            out_msg.reply_success();
-                            let _ = self
-                                .messaging_events_tx
-                                .send(MessagingEvent::MessageSent(out_msg.tag))
-                                .await;
+                            let _ = messaging_events_tx.send(MessagingEvent::MessageSent(tag)).await;
+                            Ok(())
                         },
-                        Err(err) => {
-                            debug!(
-                                target: LOG_TARGET,
-                                "OutboundMessaging failed to send message ({}) to peer `{}` after {}ms because '{}'",
-                                out_msg.tag,
-                                self.peer_node_id.short_str(),
-                                start.elapsed().as_millis(),
-                                err
-                            );
-                            out_msg.reply_fail();
-                            let _ = self
-                                .messaging_events_tx
-                                .send(MessagingEvent::SendMessageFailed(
-                                    out_msg,
-                                    SendFailReason::SubstreamSendFailed,
-                                ))
-                                .await;
-                            // FATAL: Failed to send on the substream
-                            self.flush_all_messages_to_failed_event(SendFailReason::SubstreamSendFailed)
-                                .await;
-                            return Err(MessagingProtocolError::OutboundSubstreamFailure);
+                        Err(failure) => {
+                            match failure.item {
+                                Some(out_msg) => {
+                                    debug!(
+                                        target: LOG_TARGET,
+                                        "(peer = {}, tag = {}, {} bytes()) Message failed to send: {}",
+                                        peer_node_id.short_str(),
+                                        out_msg.tag,
+                                        out_msg.body.len(),
+                                        failure.error,
+                                    );
+                                    let _ = messaging_events_tx
+                                        .send(MessagingEvent::SendMessageFailed(
+                                            out_msg,
+                                            SendFailReason::SubstreamSendFailed,
+                                        ))
+                                        .await;
+                                },
+                                None => {
+                                    debug!(
+                                        target: LOG_TARGET,
+                                        "(peer = {}): {}",
+                                        peer_node_id.short_str(),
+                                        failure.error,
+                                    );
+                                },
+                            }
+
+                            Err(failure.error)
                         },
                     }
-                },
-                Ok(None) => {
-                    debug!(
-                        target: LOG_TARGET,
-                        "Outbound messaging for peer '{}' has stopped because the stream was closed",
-                        self.peer_node_id.short_str()
-                    );
-                    framed.close().await?;
-                    break;
-                },
-                Err(_) => {
-                    debug!(
-                        target: LOG_TARGET,
-                        "Outbound messaging for peer '{}' has stopped because it was inactive",
-                        self.peer_node_id.short_str()
-                    );
-                    framed.close().await?;
-                    break;
-                },
-            }
-        }
+                }
+            })
+            .await?;
 
         Ok(())
     }
@@ -209,11 +243,220 @@ impl OutboundMessaging {
         // Close the request channel so that we can read all the remaining messages and flush them
         // to a failed event
         self.request_rx.close();
-        while let Some(out_msg) = self.request_rx.next().await {
+        while let Some(mut out_msg) = self.request_rx.next().await {
+            out_msg.reply_fail(reason);
             let _ = self
                 .messaging_events_tx
                 .send(MessagingEvent::SendMessageFailed(out_msg, reason))
                 .await;
+        }
+    }
+}
+
+#[derive(Debug)]
+struct MessageSendFailure {
+    pub item: Option<OutboundMessage>,
+    pub error: MessagingProtocolError,
+}
+
+impl From<io::Error> for MessageSendFailure {
+    fn from(err: io::Error) -> Self {
+        Self {
+            item: None,
+            error: err.into(),
+        }
+    }
+}
+
+#[pin_project(project = StateProj)]
+#[derive(Debug)]
+enum State {
+    Read,
+    Write(Option<OutboundMessage>),
+    FlushPending(bool),
+    Flush(bool),
+    Errored(bool),
+    Complete(bool),
+}
+
+/// This stream forwards messages from the mpsc receiver to the given `Sink`.
+#[pin_project(project = MessageForwarderStreamProj)]
+#[derive(Debug)]
+#[must_use = "streams do nothing unless you poll them"]
+struct MessageForwarderStream<Si> {
+    peer_node_id: NodeId,
+    #[pin]
+    sink: Option<Si>,
+    #[pin]
+    stream: mpsc::UnboundedReceiver<OutboundMessage>,
+    #[pin]
+    state: State,
+    pending_queue: Vec<OutboundMessage>,
+}
+
+impl<Si> MessageForwarderStream<Si>
+where Si: Sink<Bytes, Error = io::Error> + Unpin
+{
+    pub fn new(peer_node_id: NodeId, stream: mpsc::UnboundedReceiver<OutboundMessage>, sink: Si) -> Self {
+        Self {
+            peer_node_id,
+            stream,
+            sink: Some(sink),
+            state: State::Read,
+            // Capacity is chosen to match yamux's internal channel buffer
+            pending_queue: Vec::with_capacity(32),
+        }
+    }
+}
+
+impl<Si> Stream for MessageForwarderStream<Si>
+where Si: Sink<Bytes, Error = io::Error> + Unpin
+{
+    type Item = Result<MessageTag, MessageSendFailure>;
+
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        let MessageForwarderStreamProj {
+            mut sink,
+            mut stream,
+            peer_node_id,
+            mut state,
+            pending_queue,
+        } = self.project();
+
+        loop {
+            match state.as_mut().project() {
+                StateProj::Read => match stream.as_mut().poll_next(cx) {
+                    Poll::Ready(Some(item)) => {
+                        debug!(
+                            target: LOG_TARGET,
+                            "Buffering outbound message (tag = {}, {} bytes) for peer `{}`",
+                            item.tag,
+                            item.body.len(),
+                            peer_node_id.short_str()
+                        );
+                        *state = State::Write(Some(item));
+                    },
+                    Poll::Ready(None) => {
+                        *state = State::Complete(false);
+                    },
+                    Poll::Pending => *state = State::Flush(true),
+                },
+                StateProj::Flush(is_pending) => {
+                    let si = sink
+                        .as_mut()
+                        .as_pin_mut()
+                        .expect("polled `MessageForwarderStream` after completion");
+                    if let Err(err) = ready!(si.poll_flush(cx)) {
+                        *state = State::Errored(false);
+                        return Poll::Ready(Some(Err(err.into())));
+                    }
+                    *state = State::FlushPending(*is_pending);
+                },
+                StateProj::FlushPending(is_pending) => match pending_queue.pop() {
+                    Some(mut item) => {
+                        item.reply_success();
+                        return Poll::Ready(Some(Ok(item.tag)));
+                    },
+                    None => {
+                        let is_pending = *is_pending;
+                        *state = State::Read;
+                        if is_pending {
+                            return Poll::Pending;
+                        }
+                    },
+                },
+                StateProj::Write(item) => {
+                    let mut si = sink
+                        .as_mut()
+                        .as_pin_mut()
+                        .expect("polled `MessageForwarderStream` after completion");
+                    match ready!(si.as_mut().poll_ready(cx)) {
+                        Ok(_) => {
+                            let item = item.take().expect("State::Write without an item to write");
+                            match si.as_mut().start_send(item.body.clone()) {
+                                Ok(_) => {
+                                    pending_queue.push(item);
+                                    if pending_queue.len() >= pending_queue.capacity() {
+                                        *state = State::Flush(false);
+                                    } else {
+                                        *state = State::Read
+                                    }
+                                },
+                                Err(err) => {
+                                    *state = State::Errored(false);
+                                    let err = MessageSendFailure {
+                                        item: Some(item),
+                                        error: err.into(),
+                                    };
+                                    return Poll::Ready(Some(Err(err)));
+                                },
+                            }
+                        },
+                        Err(err) => {
+                            let item = item.take().expect("State::Write without an item to write");
+                            *state = State::Errored(false);
+                            let err = MessageSendFailure {
+                                item: Some(item),
+                                error: err.into(),
+                            };
+                            return Poll::Ready(Some(Err(err)));
+                        },
+                    }
+                },
+                StateProj::Errored(is_complete) => {
+                    // Close stream and flush
+                    if !stream.is_terminated() {
+                        stream.as_mut().close();
+                    }
+                    if let Some(item) = pending_queue.pop() {
+                        let err = MessageSendFailure {
+                            item: Some(item),
+                            error: MessagingProtocolError::MessageSendFailed,
+                        };
+                        return Poll::Ready(Some(Err(err)));
+                    }
+
+                    if *is_complete {
+                        sink.set(None);
+                        return Poll::Ready(None);
+                    }
+
+                    return match ready!(stream.as_mut().poll_next(cx)) {
+                        Some(item) => {
+                            let err = MessageSendFailure {
+                                item: Some(item),
+                                error: MessagingProtocolError::MessageSendFailed,
+                            };
+                            Poll::Ready(Some(Err(err)))
+                        },
+                        None => {
+                            sink.set(None);
+                            Poll::Ready(None)
+                        },
+                    };
+                },
+                StateProj::Complete(has_closed) => {
+                    let si = sink
+                        .as_mut()
+                        .as_pin_mut()
+                        .expect("polled `MessageForwarderStream` after completion");
+                    if !*has_closed {
+                        if let Err(err) = ready!(si.poll_close(cx)) {
+                            *state = State::Errored(true);
+                            return Poll::Ready(Some(Err(err.into())));
+                        }
+
+                        *state = State::Complete(true);
+                    }
+
+                    if let Some(mut item) = pending_queue.pop() {
+                        item.reply_success();
+                        return Poll::Ready(Some(Ok(item.tag)));
+                    }
+                    sink.set(None);
+                    return Poll::Ready(None);
+                },
+            }
         }
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR optimises the outbound messaging by flushing less regularly as
suggested by the `Sink` trait documentation.

The previous implementation would receive a message, write it and flush.
This is sub-optimal because a buffer may not be full and so many smaller
"chunks" are being sent.

This implementation reads a message, writes it and continues to read
until there is a "pause" (`Poll::Pending`) at which point is flushes any
remaining data still to be sent. Ensuring that the buffer is utilised.

This implementation is made much more complex (and slightly slower) by the current
requirement to report on if each message was put in a buffer (considered sent)
which allows the message send to be reattempted.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Performance improvements for outbound messaging.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Public behaviour is extensively tested in existing tests/examples/applications. All of these function as expected.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [x] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch.
* [x] I ran `cargo-fmt --all` before pushing.
* [x] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
