### PR TITLE
Added rate limiter to comms stress test

### DIFF
--- a/comms/examples/stress_test.rs
+++ b/comms/examples/stress_test.rs
@@ -56,6 +56,12 @@ async fn run() -> Result<(), Error> {
 
     let is_tcp = remove_arg(&mut args, "--tcp").is_some();
 
+    let mut rate_limit = 100_000;
+    if let Some(pos) = remove_arg(&mut args, "--rate-limit") {
+        rate_limit = args.remove(pos).parse().expect("Unable to parse rate limit");
+    }
+    println!("Rate limit set to: {}/s", rate_limit);
+
     let mut public_ip = None;
     if let Some(pos) = remove_arg(&mut args, "--public-ip") {
         public_ip = Some(args.remove(pos).parse::<Ipv4Addr>().unwrap());
@@ -99,7 +105,7 @@ async fn run() -> Result<(), Error> {
     }
 
     println!("Stress test service started!");
-    let (handle, mut requester) = service::start_service(comms_node, protocol_notif);
+    let (handle, mut requester) = service::start_service(comms_node, protocol_notif, rate_limit);
 
     let mut last_peer = peer.as_ref().and_then(parse_from_short_str);
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Adding a rate limiter to the comms stress test.

## Motivation and Context
Need to stress test the yamux `MAX_BUFFER_SIZE` and `RECEIVE_WINDOW` while stressing the comms.

## How Has This Been Tested?
Local test between 2 test executables.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [X] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [X] I'm merging against the `development` branch.
* [X] I ran `cargo-fmt --all` before pushing.
* [X] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
