### PR TITLE
Change SQLite RENAME to DROP and CREATE

### DIFF
--- a/base_layer/wallet/migrations/2020-07-20-084915_add_coinbase_handling/down.sql
+++ b/base_layer/wallet/migrations/2020-07-20-084915_add_coinbase_handling/down.sql
@@ -1,5 +1,20 @@
 -- This file should undo anything in `up.sql`
-ALTER TABLE key_manager_states RENAME COLUMN master_key TO master_seed;
+PRAGMA foreign_keys=off;
+ALTER TABLE key_manager_states RENAME TO key_manager_states_old;
+
+CREATE TABLE key_manager_states (
+                                    id INTEGER PRIMARY KEY,
+                                    master_seed BLOB NOT NULL,
+                                    branch_seed TEXT NOT NULL,
+                                    primary_key_index INTEGER NOT NULL,
+                                    timestamp DATETIME NOT NULL
+);
+INSERT INTO key_manager_states (id, master_seed, branch_seed, primary_key_index, timestamp)
+SELECT id, master_key, branch_seed, primary_key_index, timestamp
+FROM key_manager_states_old;
+DROP TABLE key_manager_states_old;
+
+PRAGMA foreign_keys=on;
 
 PRAGMA foreign_keys=off;
 ALTER TABLE pending_transaction_outputs RENAME TO pending_transaction_outputs_old;

--- a/base_layer/wallet/migrations/2020-07-20-084915_add_coinbase_handling/up.sql
+++ b/base_layer/wallet/migrations/2020-07-20-084915_add_coinbase_handling/up.sql
@@ -1,6 +1,20 @@
 -- Rename the master_seed column to master_key
-ALTER TABLE key_manager_states RENAME COLUMN master_seed TO master_key;
+PRAGMA foreign_keys=off;
+ALTER TABLE key_manager_states RENAME TO key_manager_states_old;
 
+CREATE TABLE key_manager_states (
+                                    id INTEGER PRIMARY KEY,
+                                    master_key BLOB NOT NULL,
+                                    branch_seed TEXT NOT NULL,
+                                    primary_key_index INTEGER NOT NULL,
+                                    timestamp DATETIME NOT NULL
+);
+INSERT INTO key_manager_states (id, master_key, branch_seed, primary_key_index, timestamp)
+SELECT id, master_seed, branch_seed, primary_key_index, timestamp
+    FROM key_manager_states_old;
+DROP TABLE key_manager_states_old;
+
+PRAGMA foreign_keys=on;
 ALTER TABLE pending_transaction_outputs ADD COLUMN coinbase_block_height INTEGER NULL DEFAULT NULL;
 
 ALTER TABLE completed_transactions ADD COLUMN coinbase_block_height INTEGER NULL DEFAULT NULL;


### PR DESCRIPTION
Older SQLite version do not support RENAME for columns
so use DROP and CREATE to change the name of the table
instead
