### PR TITLE
Fix mining ON/OFF toggle delayed response

### DIFF
--- a/base_layer/core/src/mining/mod.rs
+++ b/base_layer/core/src/mining/mod.rs
@@ -25,3 +25,11 @@ mod error;
 mod miner;
 
 pub use miner::Miner;
+
+/// Events that can be published on state changes of the Miner
+#[derive(Debug, Clone)]
+pub enum MinerInstruction {
+    PauseMining,
+    StartMining,
+    IgnoreInstruction,
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- Fixed mining ON/OFF delayed response when `toggle-mining` was requested from the CLI, by introducing an event channel that directly interrupts the blocking mining loop.
- Provided better user feedback by displaying the global mining enabled state as well as the actual mining state.

```
>> get-mining-state
Mining is DISABLED by the user
Mining state is currently OFF
Mining hash rate is: 0.000000 MH/s
>>
>> toggle-mining
Mining requested to be turned ON
>> Mining is ON
>>
>> get-mining-state
Mining is ENABLED by the user
Mining state is currently ON
Mining hash rate is: 0.000000 MH/s
>>
>> toggle-mining
Mining requested to be turned OFF
>> Mining is OFF
>>
>> get-mining-state
Mining is DISABLED by the user
Mining state is currently OFF
Mining hash rate is: 0.000000 MH/s
>>
```

## Motivation and Context
When mining was disabled from the CLI whilst in progress, changing the global mining enabled state, it only stopped after the miner received an interrupt based on mempool events and blockchain status. Consequently, requesting mining status from the CLI also reported the global mining enabled state instead of the actual mining state.

## How Has This Been Tested?
Tested with the base node runtime on Windows 10 and Ubuntu Linux

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [X] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [X] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [X] I'm merging against the `development` branch.
* [X] I ran `cargo-fmt --all` before pushing.
* [X] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
