### PR TITLE
Edge case/race condition fix for incorrect connectivity connection state 

### DIFF
--- a/comms/src/peer_manager/mod.rs
+++ b/comms/src/peer_manager/mod.rs
@@ -30,7 +30,7 @@
 //! If the Peer Manager is instantiated with a provided DataStore it will provide persistence via the provided DataStore
 //! implementation.
 //!
-//! ```norun
+//! ```no_compile
 //! # use tari_comms::peer_manager::{NodeId, Peer, PeerManager, PeerFlags, PeerFeatures};
 //! # use tari_comms::types::CommsPublicKey;
 //! # use tari_comms::connection::{NetAddress, NetAddressesWithStats};
@@ -44,14 +44,22 @@
 //! let (dest_sk, pk) = CommsPublicKey::random_keypair(&mut rng);
 //! let node_id = NodeId::from_key(&pk).unwrap();
 //! let net_addresses = NetAddressesWithStats::from("1.2.3.4:8000".parse::<NetAddress>().unwrap());
-//! let peer = Peer::new(pk, node_id.clone(), net_addresses, PeerFlags::default(), PeerFeatures::COMMUNICATION_NODE);
+//! let peer = Peer::new(
+//!     pk,
+//!     node_id.clone(),
+//!     net_addresses,
+//!     PeerFlags::default(),
+//!     PeerFeatures::COMMUNICATION_NODE,
+//!     Default::default(),
+//! );
 //! let database_name = "pm_peer_database";
 //! let datastore = LMDBBuilder::new()
-//!            .set_path("/tmp/")
-//!            .set_environment_size(10)
-//!            .set_max_number_of_databases(1)
-//!            .add_database(database_name, lmdb_zero::db::CREATE)
-//!           .build().unwrap();
+//!     .set_path("/tmp/")
+//!     .set_environment_size(10)
+//!     .set_max_number_of_databases(1)
+//!     .add_database(database_name, lmdb_zero::db::CREATE)
+//!     .build()
+//!     .unwrap();
 //! let peer_database = datastore.get_handle(database_name).unwrap();
 //! let peer_database = LMDBWrapper::new(Arc::new(peer_database));
 //! let peer_manager = PeerManager::new(peer_database).unwrap();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Recognise if a dial is cancelled due to an inbound connection beating the dial.
In this case, the `PeerConnectionFailed(DialCancelled)` event should not be published.
This fixes an issue which causes connectivity manager to mistakenly
assign a `Failed` state to a connection in some cases.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
If the connectivity connection state says that the connection has failed, it prevents that peer from receiving propagation messages destined for it. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Added a dial cancellation test and tested on base nodes (running two base nodes and attempting wallet discovery can reproduce this condition) 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch.
* [x] I ran `cargo-fmt --all` before pushing.
* [x] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
