### PR TITLE
Add Openssl and Tor to MacOS deps

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ First you'll need to make sure you have a full development environment set up:
 #### (macOS)
 
 ```
-brew install cmake
+brew install cmake openssl tor
 ```
 
 #### (Ubuntu 18.04)


### PR DESCRIPTION
## Description
Add dependencies needed for compilation and execution on MacOS

## Motivation and Context
When trying to compile on MacOS with the current instructions the following error occurred: 

1. Trying to compile
```
Could not find directory of OpenSSL installation, and this `-sys` crate cannot
proceed without this knowledge. If OpenSSL is installed and this crate had
trouble finding it,  you can set the `OPENSSL_DIR` environment variable for the
compilation process.
```

Solved with `brew install openssl` as suggested by the error message

2. Trying to execute the release build
```
ERROR Unable to connect to the Tor control port.
Please check that you have the Tor proxy running and that access to the Tor control port is turned on.
```

Solved with `brew install tor`, and then running the Tor command line as suggested by Tari base node 
```
tor --allow-missing-torrc --ignore-missing-torrc --clientonly 1 --socksport 9050 --controlport 127.0.0.1:9051 --log "notice stdout" --clientuseipv6 1
```


## How Has This Been Tested?
Manually as I just went through a fresh format / reinstall / clone / build / run

## Types of changes
* [ ] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [X] Documentation

## Checklist:
* [X] I'm merging against the `development` branch.
* [X] I ran `cargo-fmt --all` before pushing.
* [X] I have squashed my commits into a single commit.
* [X] My change requires a change to the documentation.
* [X] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
