### PR TITLE
Rollback on pruned sync validation failure

### DIFF
--- a/applications/tari_base_node/src/builder.rs
+++ b/applications/tari_base_node/src/builder.rs
@@ -491,7 +491,7 @@ where
     let db_config = BlockchainDatabaseConfig {
         orphan_storage_capacity: config.orphan_storage_capacity,
         pruning_horizon: config.pruning_horizon,
-        pruned_mode_cleanup_interval: config.pruned_mode_cleanup_interval,
+        pruning_interval: config.pruned_mode_cleanup_interval,
     };
     let db = BlockchainDatabase::new(backend, &rules, validators, db_config).map_err(|e| e.to_string())?;
     let mempool_validator =

--- a/base_layer/core/src/base_node/chain_metadata_service/error.rs
+++ b/base_layer/core/src/base_node/chain_metadata_service/error.rs
@@ -21,20 +21,23 @@
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 use crate::base_node::comms_interface::CommsInterfaceError;
-use derive_error::Error;
 use prost::DecodeError;
 use tari_comms::message::MessageError;
 use tari_p2p::services::liveness::error::LivenessError;
+use thiserror::Error;
 
 #[derive(Debug, Error)]
 pub enum ChainMetadataSyncError {
-    /// Failed to decode chain metadata
-    DecodeError(DecodeError),
-    /// Peer did not send any chain metadata
+    #[error("Failed to decode chain metadata")]
+    DecodeError(#[from] DecodeError),
+    #[error("Peer did not send any chain metadata")]
     NoChainMetadata,
-    LivenessError(LivenessError),
-    CommsInterfaceError(CommsInterfaceError),
-    MessageError(MessageError),
-    /// Failed to publish `ChainMetadataEvent`
+    #[error("Liveness error: {0}")]
+    LivenessError(#[from] LivenessError),
+    #[error("Comms interface error: {0}")]
+    CommsInterfaceError(#[from] CommsInterfaceError),
+    #[error("Message error: {0}")]
+    MessageError(#[from] MessageError),
+    #[error("Failed to publish `ChainMetadataEvent`")]
     EventPublishFailed,
 }

--- a/base_layer/core/src/base_node/chain_metadata_service/handle.rs
+++ b/base_layer/core/src/base_node/chain_metadata_service/handle.rs
@@ -26,7 +26,7 @@ use std::fmt::{Display, Error, Formatter};
 use tari_broadcast_channel::Subscriber;
 use tari_comms::peer_manager::NodeId;
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct PeerChainMetadata {
     pub node_id: NodeId,
     pub chain_metadata: ChainMetadata,

--- a/base_layer/core/src/base_node/chain_metadata_service/service.rs
+++ b/base_layer/core/src/base_node/chain_metadata_service/service.rs
@@ -294,6 +294,7 @@ mod test {
             height_of_longest_chain: Some(1),
             best_block: Some(vec![]),
             pruning_horizon: 64,
+            effective_pruned_height: 0,
             accumulated_difficulty: 1.into(),
         }
     }

--- a/base_layer/core/src/base_node/comms_interface/outbound_interface.rs
+++ b/base_layer/core/src/base_node/comms_interface/outbound_interface.rs
@@ -299,7 +299,9 @@ impl OutboundNodeCommsInterface {
     {
         self.block_sender
             .unbounded_send((new_block, exclude_peers))
-            .map_err(|_| CommsInterfaceError::BroadcastFailed)
+            .map_err(|err| {
+                CommsInterfaceError::InternalChannelError(format!("Failed to send on block_sender: {}", err))
+            })
     }
 
     /// Fetches the total merkle mountain range node count upto the specified height from remote base nodes.

--- a/base_layer/core/src/base_node/proto/chain_metadata.proto
+++ b/base_layer/core/src/base_node/proto/chain_metadata.proto
@@ -14,4 +14,9 @@ message ChainMetadata {
     uint64 pruning_horizon = 4;
     // The current geometric mean of the pow of the chain tip, or `None` if there is no chain
     google.protobuf.UInt64Value accumulated_difficulty = 5;
+    // The effective height of the pruning horizon. This indicates from what height
+    // a full block can be provided (exclusive).
+    // If `effective_pruned_height` is equal to the `height_of_longest_chain` no blocks can be provided.
+    // Archival nodes wil always have an `effective_pruned_height` of zero.
+    uint64 effective_pruned_height = 6;
 }

--- a/base_layer/core/src/base_node/proto/chain_metadata.rs
+++ b/base_layer/core/src/base_node/proto/chain_metadata.rs
@@ -30,6 +30,7 @@ impl From<proto::ChainMetadata> for ChainMetadata {
             height_of_longest_chain: metadata.height_of_longest_chain,
             best_block: metadata.best_block,
             pruning_horizon: metadata.pruning_horizon,
+            effective_pruned_height: metadata.effective_pruned_height,
             accumulated_difficulty,
         }
     }
@@ -45,6 +46,7 @@ impl From<ChainMetadata> for proto::ChainMetadata {
             height_of_longest_chain: metadata.height_of_longest_chain,
             best_block: metadata.best_block,
             pruning_horizon: metadata.pruning_horizon,
+            effective_pruned_height: metadata.effective_pruned_height,
             accumulated_difficulty,
         }
     }

--- a/base_layer/core/src/base_node/service/service.rs
+++ b/base_layer/core/src/base_node/service/service.rs
@@ -525,8 +525,7 @@ async fn handle_outbound_request(
             send_msg_params.finish(),
             OutboundDomainMessage::new(TariMessageType::BaseNodeRequest, service_request),
         )
-        .await
-        .map_err(|e| CommsInterfaceError::OutboundMessageService(e.to_string()))?;
+        .await?;
 
     match send_result.resolve().await {
         Ok(send_states) if send_states.is_empty() => {
@@ -596,12 +595,8 @@ async fn handle_outbound_block(
                 shared_protos::core::NewBlock::from(new_block),
             ),
         )
-        .await
-        .map_err(|e| {
-            error!(target: LOG_TARGET, "Handle outbound block failed: {:?}", e);
-            CommsInterfaceError::OutboundMessageService(e.to_string())
-        })
-        .map(|_| ())
+        .await?;
+    Ok(())
 }
 
 async fn handle_request_timeout(

--- a/base_layer/core/src/base_node/states/events_and_states.rs
+++ b/base_layer/core/src/base_node/states/events_and_states.rs
@@ -30,20 +30,20 @@ use crate::{
         ListeningInfo,
         Shutdown,
         Starting,
+        SyncPeers,
         Waiting,
     },
     chain_storage::ChainMetadata,
     proof_of_work::Difficulty,
 };
 use std::fmt::{Display, Error, Formatter};
-use tari_comms::peer_manager::NodeId;
 
 #[derive(Clone, Debug, PartialEq)]
 pub enum BaseNodeState {
     Starting(Starting),
     HeaderSync(HeaderSync),
     HorizonStateSync(HorizonStateSync),
-    BlockSync(BlockSyncStrategy, ChainMetadata, Vec<NodeId>),
+    BlockSync(BlockSyncStrategy, ChainMetadata, SyncPeers),
     // The best network chain metadata
     Listening(Listening),
     // We're in a paused state, and will return to Listening after a timeout
@@ -75,9 +75,9 @@ pub enum StateEvent {
 #[derive(Debug, Clone, PartialEq)]
 pub enum SyncStatus {
     // We are behind the chain tip.
-    Lagging(ChainMetadata, Vec<NodeId>),
+    Lagging(ChainMetadata, SyncPeers),
     // We are behind the pruning horizon.
-    LaggingBehindHorizon(ChainMetadata, Vec<NodeId>),
+    LaggingBehindHorizon(ChainMetadata, SyncPeers),
     UpToDate,
 }
 
@@ -98,7 +98,7 @@ impl Display for SyncStatus {
                 f,
                 "Lagging behind {} peers (#{}, Difficulty: {})",
                 v.len(),
-                m.height_of_longest_chain.unwrap_or(0),
+                m.height_of_longest_chain(),
                 m.accumulated_difficulty.unwrap_or_else(Difficulty::min),
             ),
             LaggingBehindHorizon(m, v) => write!(

--- a/base_layer/core/src/base_node/states/mod.rs
+++ b/base_layer/core/src/base_node/states/mod.rs
@@ -83,5 +83,8 @@ pub use shutdown_state::Shutdown;
 mod starting_state;
 pub use starting_state::Starting;
 
+mod sync_peers;
+pub use sync_peers::{SyncPeer, SyncPeers};
+
 mod waiting;
 pub use waiting::Waiting;

--- a/base_layer/core/src/base_node/states/sync_peers.rs
+++ b/base_layer/core/src/base_node/states/sync_peers.rs
@@ -20,45 +20,8 @@
 //  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 //  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use crate::{
-    base_node::{comms_interface::CommsInterfaceError, states::block_sync::BlockSyncError},
-    chain_storage::{ChainStorageError, MmrTree},
-    transactions::transaction::TransactionError,
-    validation::ValidationError,
-};
-use thiserror::Error;
-use tokio::task;
+use crate::base_node::chain_metadata_service::PeerChainMetadata;
 
-#[derive(Debug, Error)]
-pub enum HorizonSyncError {
-    #[error("Peer sent an empty response")]
-    EmptyResponse,
-    #[error("Peer sent an invalid response")]
-    IncorrectResponse,
-    #[error("Exceeded maximum sync attempts")]
-    MaxSyncAttemptsReached,
-    #[error("Chain storage error: {0}")]
-    ChainStorageError(#[from] ChainStorageError),
-    #[error("Comms interface error: {0:?}")]
-    CommsInterfaceError(#[from] CommsInterfaceError),
-    #[error("Block sync error: {0:?}")]
-    BlockSyncError(#[from] BlockSyncError),
-    #[error("Final state validation failed: {0}")]
-    FinalStateValidationFailed(ValidationError),
-    #[error("Join error: {0}")]
-    JoinError(#[from] task::JoinError),
-    #[error("Invalid kernel signature: {0}")]
-    InvalidKernelSignature(TransactionError),
-    #[error("Validation failed for {0} MMR")]
-    InvalidMmrRoot(MmrTree),
-}
-
-impl HorizonSyncError {
-    pub fn is_recoverable(&self) -> bool {
-        use HorizonSyncError::*;
-        match self {
-            FinalStateValidationFailed(_) | InvalidMmrRoot(_) => false,
-            _ => true,
-        }
-    }
-}
+pub type SyncPeer = PeerChainMetadata;
+/// Type alias for a collection of PeerChainMetadata
+pub type SyncPeers = Vec<SyncPeer>;

--- a/base_layer/core/src/base_node/validators/headers.rs
+++ b/base_layer/core/src/base_node/validators/headers.rs
@@ -152,10 +152,7 @@ impl<B: BlockchainBackend> HeaderValidator<B> {
         let heights = (0..block_header.height).rev().collect::<Vec<_>>();
         let mut target_difficulties = Vec::with_capacity(block_window);
         for block_nums in heights.chunks(block_window) {
-            let headers = self
-                .db
-                .fetch_headers(block_nums.to_vec())
-                .map_err(|err| ValidationError::CustomError(err.to_string()))?;
+            let headers = self.db.fetch_headers(block_nums.to_vec())?;
 
             let max_remaining = block_window.saturating_sub(target_difficulties.len());
             trace!(
@@ -206,8 +203,7 @@ impl<B: BlockchainBackend> HeaderValidator<B> {
         let block_nums = (start_height..block_header.height).collect();
         let timestamps = self
             .db
-            .fetch_headers(block_nums)
-            .map_err(ValidationError::custom_error)?
+            .fetch_headers(block_nums)?
             .iter()
             .map(|h| h.timestamp)
             .collect::<Vec<_>>();

--- a/base_layer/core/src/blocks/blockheader.rs
+++ b/base_layer/core/src/blocks/blockheader.rs
@@ -44,7 +44,6 @@ use crate::{
     transactions::types::{BlindingFactor, HashDigest},
 };
 use chrono::{DateTime, Utc};
-use derive_error::Error;
 use digest::Digest;
 use serde::{
     de::{self, Visitor},
@@ -58,27 +57,28 @@ use std::{
     fmt::{Display, Error, Formatter},
 };
 use tari_crypto::tari_utilities::{epoch_time::EpochTime, hex::Hex, ByteArray, Hashable};
+use thiserror::Error;
 
 pub const BLOCK_HASH_LENGTH: usize = 32;
 pub type BlockHash = Vec<u8>;
 
 #[derive(Clone, Debug, PartialEq, Error)]
 pub enum BlockHeaderValidationError {
-    // The Genesis block header is incorrectly chained
+    #[error("The Genesis block header is incorrectly chained")]
     ChainedGenesisBlockHeader,
-    // Incorrect Genesis block header,
+    #[error("Incorrect Genesis block header")]
     IncorrectGenesisBlockHeader,
-    // Header does not form a valid chain
+    #[error("Header does not form a valid chain")]
     InvalidChaining,
-    // Invalid timestamp received on the header
+    #[error("Invalid timestamp received on the header")]
     InvalidTimestamp,
-    // Invalid timestamp future time limit received on the header
+    #[error("Invalid timestamp future time limit received on the header")]
     InvalidTimestampFutureTimeLimit,
-    // Invalid Proof of work for the header
-    ProofOfWorkError(PowError),
-    // Mismatched MMR roots
+    #[error("Invalid Proof of work for the header: {0}")]
+    ProofOfWorkError(#[from] PowError),
+    #[error("Mismatched MMR roots")]
     MismatchedMmrRoots,
-    // Monero seed hash too old
+    #[error("Monero seed hash too old")]
     OldSeedHash,
 }
 

--- a/base_layer/core/src/chain_storage/checkpoint_utils.rs
+++ b/base_layer/core/src/chain_storage/checkpoint_utils.rs
@@ -1,0 +1,140 @@
+//  Copyright 2020, The Tari Project
+//
+//  Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+//  following conditions are met:
+//
+//  1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+//  disclaimer.
+//
+//  2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+//  following disclaimer in the documentation and/or other materials provided with the distribution.
+//
+//  3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+//  products derived from this software without specific prior written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+//  INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+//  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+//  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+//  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+//  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+//  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+//! ## Common blockchain utility functions for ArrayLike impls
+
+use crate::chain_storage::ChainStorageError;
+use std::cmp;
+use tari_mmr::{ArrayLike, ArrayLikeExt, MerkleCheckPoint};
+
+/// Calculate the total leaf node count upto a specified height. If the height is less than the effective pruning
+/// horizon the total number of nodes up to the effective pruned height is returned.
+pub fn fetch_mmr_nodes_added_count<T>(checkpoints: &T, tip_height: u64, height: u64) -> Result<u32, ChainStorageError>
+where
+    T: ArrayLike<Value = MerkleCheckPoint>,
+    ChainStorageError: From<T::Error>,
+{
+    let cp_count = checkpoints.len()?;
+    match cp_count.checked_sub(1) {
+        Some(last_index) => {
+            let index = last_index.saturating_sub(tip_height.saturating_sub(height) as usize);
+            let nodes_added = checkpoints
+                .get(index)?
+                .map(|cp| cp.accumulated_nodes_added_count())
+                .unwrap_or(0);
+            Ok(nodes_added)
+        },
+        None => Ok(0),
+    }
+}
+
+/// Returns the accumulated node added count.
+pub fn fetch_last_mmr_node_added_count<T>(checkpoints: &T) -> Result<u32, ChainStorageError>
+where
+    T: ArrayLike<Value = MerkleCheckPoint>,
+    ChainStorageError: From<T::Error>,
+{
+    let cp_count = checkpoints.len()?;
+    match cp_count.checked_sub(1) {
+        Some(last_index) => Ok(checkpoints
+            .get(last_index)?
+            .map(|cp| cp.accumulated_nodes_added_count())
+            .unwrap_or(0)),
+        None => Ok(0),
+    }
+}
+
+/// Retrieves the checkpoint corresponding to the provided height, if the checkpoint is part of the horizon state then a
+/// BeyondPruningHorizon error will be returned.
+pub fn fetch_checkpoint<T>(
+    checkpoints: &T,
+    pruned_mode: bool,
+    tip_height: u64,
+    height: u64,
+) -> Result<Option<MerkleCheckPoint>, ChainStorageError>
+where
+    T: ArrayLike<Value = MerkleCheckPoint>,
+    ChainStorageError: From<T::Error>,
+{
+    let tip_index = tip_height.saturating_sub(1);
+    let height_offset = tip_index
+        .checked_sub(height)
+        .ok_or_else(|| ChainStorageError::OutOfRange)?;
+
+    let last_cp_index = checkpoints.len()?.saturating_sub(1);
+    let index = last_cp_index
+        .checked_sub(height_offset as usize)
+        .ok_or_else(|| ChainStorageError::BeyondPruningHorizon)?;
+    if pruned_mode && index == 0 {
+        // In pruned mode the first checkpoint is an accumulation of all checkpoints from the genesis block to horizon
+        // block height.
+        return Err(ChainStorageError::BeyondPruningHorizon);
+    }
+    checkpoints.get(index as usize).map_err(Into::into)
+}
+
+/// Rewinds checkpoints by `steps_back` elements and returns the last checkpoint.
+pub fn rewind_checkpoints<T>(checkpoints: &mut T, steps_back: usize) -> Result<MerkleCheckPoint, ChainStorageError>
+where
+    T: ArrayLike<Value = MerkleCheckPoint> + ArrayLikeExt<Value = MerkleCheckPoint>,
+    ChainStorageError: From<T::Error>,
+{
+    let cp_count = checkpoints.len()?;
+    assert!(cp_count > 0, "rewind_checkpoints: `checkpoints` is empty.");
+    let rewind_len = cmp::max(cp_count.saturating_sub(steps_back), 1);
+    checkpoints.truncate(rewind_len)?;
+
+    let last_cp = checkpoints
+        .get(rewind_len - 1)?
+        .expect("rewind_checkpoints: `checkpoints` is empty after truncate");
+
+    Ok(last_cp)
+}
+
+/// Attempt to merge the set of oldest checkpoints into the horizon state and return the number of checkpoints that have
+/// been merged.
+pub fn merge_checkpoints<T>(checkpoints: &mut T, max_cp_count: usize) -> Result<(usize, Vec<u32>), ChainStorageError>
+where
+    T: ArrayLike<Value = MerkleCheckPoint> + ArrayLikeExt<Value = MerkleCheckPoint>,
+    ChainStorageError: From<T::Error>,
+{
+    let cp_count = checkpoints.len()?;
+    let mut stxo_leaf_indices = Vec::new();
+    match (cp_count + 1).checked_sub(max_cp_count) {
+        Some(num_cps_merged) => match checkpoints.get(0)? {
+            Some(mut merged_cp) => {
+                for index in 1..num_cps_merged {
+                    if let Some(cp) = checkpoints.get(index)? {
+                        stxo_leaf_indices.append(&mut cp.nodes_deleted().to_vec());
+                        merged_cp.append(cp);
+                    }
+                }
+                checkpoints.shift(num_cps_merged)?;
+                checkpoints.push_front(merged_cp)?;
+
+                Ok((num_cps_merged, stxo_leaf_indices))
+            },
+            None => Ok((0, stxo_leaf_indices)),
+        },
+        None => Ok((0, stxo_leaf_indices)),
+    }
+}

--- a/base_layer/core/src/chain_storage/consts.rs
+++ b/base_layer/core/src/chain_storage/consts.rs
@@ -24,5 +24,5 @@
 pub const BLOCKCHAIN_DATABASE_ORPHAN_STORAGE_CAPACITY: usize = 720;
 /// The pruning horizon that is set for a default configuration of the blockchain db.
 pub const BLOCKCHAIN_DATABASE_PRUNING_HORIZON: u64 = 0;
-/// The chain height interval used to determine when pruned mode cleanup should be performed.
-pub const BLOCKCHAIN_DATABASE_PRUNED_MODE_CLEANUP_INTERVAL: u64 = 50;
+/// The chain height interval used to determine when a pruned node should perform pruning.
+pub const BLOCKCHAIN_DATABASE_PRUNED_MODE_PRUNING_INTERVAL: u64 = 50;

--- a/base_layer/core/src/chain_storage/lmdb_db/lmdb_db.rs
+++ b/base_layer/core/src/chain_storage/lmdb_db/lmdb_db.rs
@@ -27,6 +27,7 @@ use crate::{
     },
     chain_storage::{
         blockchain_database::BlockchainBackend,
+        checkpoint_utils,
         db_transaction::{
             DbKey,
             DbKeyValuePair,
@@ -66,12 +67,11 @@ use croaring::Bitmap;
 use digest::Digest;
 use lmdb_zero::{Database, Environment, WriteTransaction};
 use log::*;
-use std::{collections::VecDeque, fmt::Display, path::Path, sync::Arc};
+use std::{collections::VecDeque, path::Path, sync::Arc};
 use tari_crypto::tari_utilities::{epoch_time::EpochTime, hash::Hashable, hex::Hex};
 use tari_mmr::{
     functions::{calculate_pruned_mmr_root, prune_mutable_mmr, PrunedMutableMmr},
     ArrayLike,
-    ArrayLikeExt,
     Hash as MmrHash,
     Hash,
     MerkleCheckPoint,
@@ -109,6 +109,7 @@ where D: Digest
     range_proof_mmr: MmrCache<D, MemDbVec<MmrHash>, LMDBVec<MerkleCheckPoint>>,
     range_proof_checkpoints: LMDBVec<MerkleCheckPoint>,
     curr_range_proof_checkpoint: MerkleCheckPoint,
+    is_mem_metadata_dirty: bool,
 }
 
 impl<D> LMDBDatabase<D>
@@ -136,23 +137,24 @@ where D: Digest + Send + Sync
             orphans_db: get_database(&store, LMDB_DB_ORPHANS)?,
             utxo_mmr: MmrCache::new(MemDbVec::new(), utxo_checkpoints.clone(), mmr_cache_config)?,
             curr_utxo_checkpoint: {
-                let acc_count = fetch_last_mmr_node_added_count(&utxo_checkpoints)?;
+                let acc_count = checkpoint_utils::fetch_last_mmr_node_added_count(&utxo_checkpoints)?;
                 MerkleCheckPoint::new(Vec::new(), Bitmap::create(), acc_count)
             },
             utxo_checkpoints,
             kernel_mmr: MmrCache::new(MemDbVec::new(), kernel_checkpoints.clone(), mmr_cache_config)?,
             curr_kernel_checkpoint: {
-                let acc_count = fetch_last_mmr_node_added_count(&kernel_checkpoints)?;
+                let acc_count = checkpoint_utils::fetch_last_mmr_node_added_count(&kernel_checkpoints)?;
                 MerkleCheckPoint::new(Vec::new(), Bitmap::create(), acc_count)
             },
             kernel_checkpoints,
             range_proof_mmr: MmrCache::new(MemDbVec::new(), range_proof_checkpoints.clone(), mmr_cache_config)?,
             curr_range_proof_checkpoint: {
-                let acc_count = fetch_last_mmr_node_added_count(&range_proof_checkpoints)?;
+                let acc_count = checkpoint_utils::fetch_last_mmr_node_added_count(&range_proof_checkpoints)?;
                 MerkleCheckPoint::new(Vec::new(), Bitmap::create(), acc_count)
             },
             range_proof_checkpoints,
             env,
+            is_mem_metadata_dirty: false,
         })
     }
 
@@ -162,21 +164,22 @@ where D: Digest + Send + Sync
             match op {
                 WriteOperation::RewindMmr(tree, steps_back) => match tree {
                     MmrTree::Kernel => {
-                        let last_cp = rewind_checkpoints(&mut self.kernel_checkpoints, steps_back)?;
+                        let last_cp = checkpoint_utils::rewind_checkpoints(&mut self.kernel_checkpoints, steps_back)?;
                         self.kernel_mmr
                             .update()
                             .map_err(|e| ChainStorageError::AccessError(e.to_string()))?;
                         self.curr_kernel_checkpoint.reset_to(&last_cp);
                     },
                     MmrTree::Utxo => {
-                        let last_cp = rewind_checkpoints(&mut self.utxo_checkpoints, steps_back)?;
+                        let last_cp = checkpoint_utils::rewind_checkpoints(&mut self.utxo_checkpoints, steps_back)?;
                         self.utxo_mmr
                             .update()
                             .map_err(|e| ChainStorageError::AccessError(e.to_string()))?;
                         self.curr_utxo_checkpoint.reset_to(&last_cp);
                     },
                     MmrTree::RangeProof => {
-                        let last_cp = rewind_checkpoints(&mut self.range_proof_checkpoints, steps_back)?;
+                        let last_cp =
+                            checkpoint_utils::rewind_checkpoints(&mut self.range_proof_checkpoints, steps_back)?;
                         self.range_proof_mmr
                             .update()
                             .map_err(|e| ChainStorageError::AccessError(e.to_string()))?;
@@ -220,7 +223,8 @@ where D: Digest + Send + Sync
                 },
                 WriteOperation::MergeMmrCheckpoints(tree, max_cp_count) => match tree {
                     MmrTree::Kernel => {
-                        let (num_cps_merged, _) = merge_checkpoints(&mut self.kernel_checkpoints, max_cp_count)?;
+                        let (num_cps_merged, _) =
+                            checkpoint_utils::merge_checkpoints(&mut self.kernel_checkpoints, max_cp_count)?;
                         self.kernel_mmr
                             .checkpoints_merged(num_cps_merged)
                             .map_err(|e| ChainStorageError::AccessError(e.to_string()))?;
@@ -228,7 +232,7 @@ where D: Digest + Send + Sync
                     },
                     MmrTree::Utxo => {
                         let (num_cps_merged, stxo_leaf_indices) =
-                            merge_checkpoints(&mut self.utxo_checkpoints, max_cp_count)?;
+                            checkpoint_utils::merge_checkpoints(&mut self.utxo_checkpoints, max_cp_count)?;
                         self.utxo_mmr
                             .checkpoints_merged(num_cps_merged)
                             .map_err(|e| ChainStorageError::AccessError(e.to_string()))?;
@@ -243,7 +247,8 @@ where D: Digest + Send + Sync
                         );
                     },
                     MmrTree::RangeProof => {
-                        let (num_cps_merged, _) = merge_checkpoints(&mut self.range_proof_checkpoints, max_cp_count)?;
+                        let (num_cps_merged, _) =
+                            checkpoint_utils::merge_checkpoints(&mut self.range_proof_checkpoints, max_cp_count)?;
                         self.range_proof_mmr
                             .checkpoints_merged(num_cps_merged)
                             .map_err(|e| ChainStorageError::AccessError(e.to_string()))?;
@@ -270,141 +275,164 @@ where D: Digest + Send + Sync
     // changes committed to the backend databases. CreateMmrCheckpoint and RewindMmr txns will be performed after these
     // txns have been successfully applied.
     fn apply_mmr_and_storage_txs(&mut self, tx: &DbTransaction) -> Result<(), ChainStorageError> {
-        let mut update_mem_metadata = false;
         let txn = WriteTransaction::new(self.env.clone()).map_err(|e| ChainStorageError::AccessError(e.to_string()))?;
         for op in tx.operations.iter() {
             match op {
-                WriteOperation::Insert(insert) => match insert {
-                    DbKeyValuePair::Metadata(k, v) => {
-                        lmdb_replace(&txn, &self.metadata_db, &(k.clone() as u32), &v)?;
-                        update_mem_metadata = true;
-                    },
-                    DbKeyValuePair::BlockHeader(k, v) => {
-                        if lmdb_exists(&self.env, &self.headers_db, &k)? {
-                            return Err(ChainStorageError::InvalidOperation(format!(
-                                "Duplicate `BlockHeader` key `{}`",
-                                k
-                            )));
-                        }
-                        let hash = v.hash();
-                        lmdb_insert(&txn, &self.block_hashes_db, &hash, &k)?;
-                        lmdb_insert(&txn, &self.headers_db, &k, &v)?;
-                    },
-                    DbKeyValuePair::UnspentOutput(k, v) => {
-                        if lmdb_exists(&self.env, &self.utxos_db, &k)? {
-                            return Err(ChainStorageError::InvalidOperation(format!(
-                                "Duplicate `UnspentOutput` key `{}`",
-                                k.to_hex()
-                            )));
-                        }
-                        self.curr_utxo_checkpoint.push_addition(k.clone());
-                        self.curr_range_proof_checkpoint.push_addition(v.proof().hash());
-
-                        lmdb_insert(&txn, &self.utxos_db, &k, &v)?;
-                        let index = self.curr_range_proof_checkpoint.accumulated_nodes_added_count() - 1;
-                        lmdb_insert(&txn, &self.txos_hash_to_index_db, &k, &index)?;
-                    },
-                    DbKeyValuePair::TransactionKernel(k, v) => {
-                        if lmdb_exists(&self.env, &self.kernels_db, &k)? {
-                            return Err(ChainStorageError::InvalidOperation(format!(
-                                "Duplicate `TransactionKernel` key `{}`",
-                                k.to_hex()
-                            )));
-                        }
-                        self.curr_kernel_checkpoint.push_addition(k.clone());
-                        lmdb_insert(&txn, &self.kernels_db, &k, &v)?;
-                    },
-                    DbKeyValuePair::OrphanBlock(k, v) => {
-                        lmdb_replace(&txn, &self.orphans_db, &k, &v)?;
-                    },
-                },
-                WriteOperation::Delete(delete) => match delete {
-                    DbKey::Metadata(_) => {}, // no-op
-                    DbKey::BlockHeader(k) => {
-                        let val: Option<BlockHeader> = lmdb_get(&self.env, &self.headers_db, &k)?;
-                        if let Some(v) = val {
-                            let hash = v.hash();
-                            lmdb_delete(&txn, &self.block_hashes_db, &hash)?;
-                            lmdb_delete(&txn, &self.headers_db, &k)?;
-                        }
-                    },
-                    DbKey::BlockHash(hash) => {
-                        let result: Option<u64> = lmdb_get(&self.env, &self.block_hashes_db, &hash)?;
-                        if let Some(k) = result {
-                            lmdb_delete(&txn, &self.block_hashes_db, &hash)?;
-                            lmdb_delete(&txn, &self.headers_db, &k)?;
-                        }
-                    },
-                    DbKey::UnspentOutput(k) => {
-                        lmdb_delete(&txn, &self.utxos_db, &k)?;
-                        lmdb_delete(&txn, &self.txos_hash_to_index_db, &k)?;
-                    },
-                    DbKey::SpentOutput(k) => {
-                        lmdb_delete(&txn, &self.stxos_db, &k)?;
-                        lmdb_delete(&txn, &self.txos_hash_to_index_db, &k)?;
-                    },
-                    DbKey::TransactionKernel(k) => {
-                        lmdb_delete(&txn, &self.kernels_db, &k)?;
-                    },
-                    DbKey::OrphanBlock(k) => {
-                        lmdb_delete(&txn, &self.orphans_db, &k)?;
-                    },
-                },
-                WriteOperation::Spend(key) => match key {
-                    DbKey::UnspentOutput(hash) => {
-                        let utxo: TransactionOutput = lmdb_get(&self.env, &self.utxos_db, &hash)?.ok_or_else(|| {
-                            error!(
-                                target: LOG_TARGET,
-                                "Could spend UTXO: hash `{}` not found in UTXO db",
-                                hash.to_hex()
-                            );
-                            ChainStorageError::UnspendableInput
-                        })?;
-
-                        let index = lmdb_get(&self.env, &self.txos_hash_to_index_db, &hash)?.ok_or_else(|| {
-                            error!(
-                                target: LOG_TARGET,
-                                "** Blockchain DB out of sync! ** Hash `{}` was found in utxo_db but could not be \
-                                 found in txos_hash_to_index db!",
-                                hash.to_hex()
-                            );
-                            ChainStorageError::UnspendableInput
-                        })?;
-                        self.curr_utxo_checkpoint.push_deletion(index);
-
-                        lmdb_delete(&txn, &self.utxos_db, &hash)?;
-                        lmdb_insert(&txn, &self.stxos_db, &hash, &utxo)?;
-                    },
-                    _ => return Err(ChainStorageError::InvalidOperation("Only UTXOs can be spent".into())),
-                },
-                WriteOperation::UnSpend(key) => match key {
-                    DbKey::SpentOutput(hash) => {
-                        let stxo: TransactionOutput = lmdb_get(&self.env, &self.stxos_db, &hash)?.ok_or_else(|| {
-                            error!(
-                                target: LOG_TARGET,
-                                "STXO could not be unspent: Hash `{}` not found in the STXO db",
-                                hash.to_hex()
-                            );
-                            ChainStorageError::UnspendError
-                        })?;
-                        lmdb_delete(&txn, &self.stxos_db, &hash)?;
-                        lmdb_insert(&txn, &self.utxos_db, &hash, &stxo)?;
-                    },
-                    _ => return Err(ChainStorageError::InvalidOperation("Only STXOs can be unspent".into())),
-                },
+                WriteOperation::Insert(insert) => self.op_insert(&txn, insert)?,
+                WriteOperation::Delete(delete) => self.op_delete(&txn, delete)?,
+                WriteOperation::Spend(key) => self.op_spend(&txn, key)?,
+                WriteOperation::UnSpend(key) => self.op_unspend(&txn, key)?,
                 _ => {},
             }
         }
         txn.commit()
             .map_err(|e| ChainStorageError::AccessError(e.to_string()))?;
 
-        if update_mem_metadata {
-            self.mem_metadata = ChainMetadata {
-                height_of_longest_chain: fetch_chain_height(&self.env, &self.metadata_db)?,
-                best_block: fetch_best_block(&self.env, &self.metadata_db)?,
-                pruning_horizon: fetch_pruning_horizon(&self.env, &self.metadata_db)?,
-                accumulated_difficulty: fetch_accumulated_work(&self.env, &self.metadata_db)?,
-            };
+        if self.is_mem_metadata_dirty {
+            self.mem_metadata = fetch_metadata(&self.env, &self.metadata_db)?;
+            self.is_mem_metadata_dirty = false;
+        }
+        Ok(())
+    }
+
+    fn op_insert(&mut self, txn: &WriteTransaction<'_>, kv_pair: &DbKeyValuePair) -> Result<(), ChainStorageError> {
+        match kv_pair {
+            DbKeyValuePair::Metadata(k, v) => {
+                lmdb_replace(&txn, &self.metadata_db, &(k.clone() as u32), &v)?;
+                self.is_mem_metadata_dirty = true;
+            },
+            DbKeyValuePair::BlockHeader(k, v) => {
+                if lmdb_exists(&self.env, &self.headers_db, &k)? {
+                    return Err(ChainStorageError::InvalidOperation(format!(
+                        "Duplicate `BlockHeader` key `{}`",
+                        k
+                    )));
+                }
+                let hash = v.hash();
+                lmdb_insert(&txn, &self.block_hashes_db, &hash, &k)?;
+                lmdb_insert(&txn, &self.headers_db, &k, &v)?;
+            },
+            DbKeyValuePair::UnspentOutput(k, v) => {
+                if lmdb_exists(&self.env, &self.utxos_db, &k)? {
+                    return Err(ChainStorageError::InvalidOperation(format!(
+                        "Duplicate `UnspentOutput` key `{}`",
+                        k.to_hex()
+                    )));
+                }
+                self.curr_utxo_checkpoint.push_addition(k.clone());
+                self.curr_range_proof_checkpoint.push_addition(v.proof().hash());
+
+                lmdb_insert(&txn, &self.utxos_db, &k, &v)?;
+                let index = self.curr_range_proof_checkpoint.accumulated_nodes_added_count() - 1;
+                lmdb_insert(&txn, &self.txos_hash_to_index_db, &k, &index)?;
+            },
+            DbKeyValuePair::TransactionKernel(k, v) => {
+                if lmdb_exists(&self.env, &self.kernels_db, &k)? {
+                    return Err(ChainStorageError::InvalidOperation(format!(
+                        "Duplicate `TransactionKernel` key `{}`",
+                        k.to_hex()
+                    )));
+                }
+                self.curr_kernel_checkpoint.push_addition(k.clone());
+                lmdb_insert(&txn, &self.kernels_db, &k, &v)?;
+            },
+            DbKeyValuePair::OrphanBlock(k, v) => {
+                lmdb_replace(&txn, &self.orphans_db, &k, &v)?;
+            },
+        }
+        Ok(())
+    }
+
+    fn op_delete(&mut self, txn: &WriteTransaction<'_>, key: &DbKey) -> Result<(), ChainStorageError> {
+        match key {
+            DbKey::Metadata(key) => {
+                match lmdb_delete(&txn, &self.metadata_db, &(*key as u32)) {
+                    Ok(_) => {},
+                    // Ignore if the value didn't exist in the first place
+                    Err(ChainStorageError::LmdbValueNotFound(_)) => {},
+                    Err(err) => return Err(err),
+                }
+            },
+            DbKey::BlockHeader(k) => {
+                let val: Option<BlockHeader> = lmdb_get(&self.env, &self.headers_db, &k)?;
+                if let Some(v) = val {
+                    let hash = v.hash();
+                    lmdb_delete(&txn, &self.block_hashes_db, &hash)?;
+                    lmdb_delete(&txn, &self.headers_db, &k)?;
+                }
+            },
+            DbKey::BlockHash(hash) => {
+                let result: Option<u64> = lmdb_get(&self.env, &self.block_hashes_db, &hash)?;
+                if let Some(k) = result {
+                    lmdb_delete(&txn, &self.block_hashes_db, &hash)?;
+                    lmdb_delete(&txn, &self.headers_db, &k)?;
+                }
+            },
+            DbKey::UnspentOutput(k) => {
+                lmdb_delete(&txn, &self.utxos_db, &k)?;
+                lmdb_delete(&txn, &self.txos_hash_to_index_db, &k)?;
+            },
+            DbKey::SpentOutput(k) => {
+                lmdb_delete(&txn, &self.stxos_db, &k)?;
+                lmdb_delete(&txn, &self.txos_hash_to_index_db, &k)?;
+            },
+            DbKey::TransactionKernel(k) => {
+                lmdb_delete(&txn, &self.kernels_db, &k)?;
+            },
+            DbKey::OrphanBlock(k) => {
+                lmdb_delete(&txn, &self.orphans_db, &k)?;
+            },
+        }
+
+        Ok(())
+    }
+
+    fn op_spend(&mut self, txn: &WriteTransaction<'_>, key: &DbKey) -> Result<(), ChainStorageError> {
+        match key {
+            DbKey::UnspentOutput(hash) => {
+                let utxo: TransactionOutput = lmdb_get(&self.env, &self.utxos_db, &hash)?.ok_or_else(|| {
+                    error!(
+                        target: LOG_TARGET,
+                        "Could spend UTXO: hash `{}` not found in UTXO db",
+                        hash.to_hex()
+                    );
+                    ChainStorageError::UnspendableInput
+                })?;
+
+                let index = lmdb_get(&self.env, &self.txos_hash_to_index_db, &hash)?.ok_or_else(|| {
+                    error!(
+                        target: LOG_TARGET,
+                        "** Blockchain DB out of sync! ** Hash `{}` was found in utxo_db but could not be found in \
+                         txos_hash_to_index db!",
+                        hash.to_hex()
+                    );
+                    ChainStorageError::UnspendableInput
+                })?;
+                self.curr_utxo_checkpoint.push_deletion(index);
+
+                lmdb_delete(&txn, &self.utxos_db, &hash)?;
+                lmdb_insert(&txn, &self.stxos_db, &hash, &utxo)?;
+            },
+            _ => return Err(ChainStorageError::InvalidOperation("Only UTXOs can be spent".into())),
+        }
+        Ok(())
+    }
+
+    fn op_unspend(&mut self, txn: &WriteTransaction<'_>, key: &DbKey) -> Result<(), ChainStorageError> {
+        match key {
+            DbKey::SpentOutput(hash) => {
+                let stxo: TransactionOutput = lmdb_get(&self.env, &self.stxos_db, &hash)?.ok_or_else(|| {
+                    error!(
+                        target: LOG_TARGET,
+                        "STXO could not be unspent: Hash `{}` not found in the STXO db",
+                        hash.to_hex()
+                    );
+                    ChainStorageError::UnspendError
+                })?;
+                lmdb_delete(&txn, &self.stxos_db, &hash)?;
+                lmdb_insert(&txn, &self.utxos_db, &hash, &stxo)?;
+            },
+            _ => return Err(ChainStorageError::InvalidOperation("Only STXOs can be unspent".into())),
         }
         Ok(())
     }
@@ -545,7 +573,7 @@ where D: Digest + Send + Sync
 
     fn contains(&self, key: &DbKey) -> Result<bool, ChainStorageError> {
         Ok(match key {
-            DbKey::Metadata(k) => lmdb_exists(&self.env, &self.metadata_db, &(k.clone() as u32))?,
+            DbKey::Metadata(k) => lmdb_exists(&self.env, &self.metadata_db, &(*k as u32))?,
             DbKey::BlockHeader(k) => lmdb_exists(&self.env, &self.headers_db, k)?,
             DbKey::BlockHash(h) => lmdb_exists(&self.env, &self.block_hashes_db, h)?,
             DbKey::UnspentOutput(k) => lmdb_exists(&self.env, &self.utxos_db, k)?,
@@ -600,24 +628,48 @@ where D: Digest + Send + Sync
 
     // Retrieves the checkpoint corresponding to the provided height, if the checkpoint is part of the horizon state
     // then a BeyondPruningHorizon error will be produced.
-    fn fetch_checkpoint(&self, tree: MmrTree, height: u64) -> Result<MerkleCheckPoint, ChainStorageError> {
+    fn fetch_checkpoint_at_height(&self, tree: MmrTree, height: u64) -> Result<MerkleCheckPoint, ChainStorageError> {
         let tip_height = lmdb_len(&self.env, &self.headers_db)? as u64;
         let pruned_mode = self.mem_metadata.is_pruned_node();
         match tree {
-            MmrTree::Kernel => fetch_checkpoint(&self.kernel_checkpoints, pruned_mode, tip_height, height),
-            MmrTree::Utxo => fetch_checkpoint(&self.utxo_checkpoints, pruned_mode, tip_height, height),
-            MmrTree::RangeProof => fetch_checkpoint(&self.range_proof_checkpoints, pruned_mode, tip_height, height),
+            MmrTree::Kernel => {
+                checkpoint_utils::fetch_checkpoint(&self.kernel_checkpoints, pruned_mode, tip_height, height)
+            },
+            MmrTree::Utxo => {
+                checkpoint_utils::fetch_checkpoint(&self.utxo_checkpoints, pruned_mode, tip_height, height)
+            },
+            MmrTree::RangeProof => {
+                checkpoint_utils::fetch_checkpoint(&self.range_proof_checkpoints, pruned_mode, tip_height, height)
+            },
         }
         .map_err(|e| ChainStorageError::AccessError(format!("Checkpoint error: {}", e.to_string())))?
         .ok_or_else(|| ChainStorageError::OutOfRange)
     }
 
+    fn fetch_checkpoint_at_index(
+        &self,
+        tree: MmrTree,
+        index: usize,
+    ) -> Result<Option<MerkleCheckPoint>, ChainStorageError>
+    {
+        let checkpoints = match tree {
+            MmrTree::Utxo => self.utxo_checkpoints.get(index),
+            MmrTree::Kernel => self.kernel_checkpoints.get(index),
+            MmrTree::RangeProof => self.range_proof_checkpoints.get(index),
+        }?;
+        Ok(checkpoints)
+    }
+
     fn fetch_mmr_node_count(&self, tree: MmrTree, height: u64) -> Result<u32, ChainStorageError> {
         let tip_height = lmdb_len(&self.env, &self.headers_db)?.saturating_sub(1) as u64;
         match tree {
-            MmrTree::Kernel => fetch_mmr_nodes_added_count(&self.kernel_checkpoints, tip_height, height),
-            MmrTree::Utxo => fetch_mmr_nodes_added_count(&self.utxo_checkpoints, tip_height, height),
-            MmrTree::RangeProof => fetch_mmr_nodes_added_count(&self.range_proof_checkpoints, tip_height, height),
+            MmrTree::Kernel => {
+                checkpoint_utils::fetch_mmr_nodes_added_count(&self.kernel_checkpoints, tip_height, height)
+            },
+            MmrTree::Utxo => checkpoint_utils::fetch_mmr_nodes_added_count(&self.utxo_checkpoints, tip_height, height),
+            MmrTree::RangeProof => {
+                checkpoint_utils::fetch_mmr_nodes_added_count(&self.range_proof_checkpoints, tip_height, height)
+            },
         }
     }
 
@@ -638,7 +690,7 @@ where D: Digest + Send + Sync
                     if let Some(hist_height) = hist_height {
                         let tip_height = lmdb_len(&self.env, &self.headers_db)?.saturating_sub(1) as u64;
                         for height in hist_height + 1..=tip_height {
-                            let cp = self.fetch_checkpoint(MmrTree::Utxo, height)?;
+                            let cp = self.fetch_checkpoint_at_height(MmrTree::Utxo, height)?;
                             if cp.nodes_deleted().contains(pos) {
                                 deleted = false;
                             }
@@ -751,7 +803,7 @@ where D: Digest + Send + Sync
     }
 
     /// Returns the metadata of the chain.
-    fn fetch_metadata(&self) -> Result<ChainMetadata, ChainStorageError> {
+    fn fetch_chain_metadata(&self) -> Result<ChainMetadata, ChainStorageError> {
         Ok(self.mem_metadata.clone())
     }
 
@@ -790,6 +842,16 @@ where D: Digest + Send + Sync
 
     fn count_kernels(&self) -> Result<usize, ChainStorageError> {
         lmdb_len(&self.env, &self.kernels_db)
+    }
+
+    fn count_checkpoints(&self, tree: MmrTree) -> Result<usize, ChainStorageError> {
+        let len = match tree {
+            MmrTree::Utxo => self.utxo_checkpoints.len()?,
+            MmrTree::Kernel => self.kernel_checkpoints.len()?,
+            MmrTree::RangeProof => self.range_proof_checkpoints.len()?,
+        };
+
+        Ok(len)
     }
 
     /// Validate the MMR root for the given `MmrTree` matches the header at the given height
@@ -837,6 +899,7 @@ fn fetch_metadata(env: &Environment, db: &Database) -> Result<ChainMetadata, Cha
         height_of_longest_chain: fetch_chain_height(&env, &db)?,
         best_block: fetch_best_block(&env, &db)?,
         pruning_horizon: fetch_pruning_horizon(&env, &db)?,
+        effective_pruned_height: fetch_effective_pruned_height(&env, &db)?,
         accumulated_difficulty: fetch_accumulated_work(&env, &db)?,
     })
 }
@@ -848,6 +911,16 @@ fn fetch_chain_height(env: &Environment, db: &Database) -> Result<Option<u64>, C
     match val {
         Some(MetadataValue::ChainHeight(height)) => Ok(height),
         _ => Ok(None),
+    }
+}
+
+// Fetches the effective pruned height from the provided metadata db.
+fn fetch_effective_pruned_height(env: &Environment, db: &Database) -> Result<u64, ChainStorageError> {
+    let k = MetadataKey::EffectivePrunedHeight;
+    let val: Option<MetadataValue> = lmdb_get(&env, &db, &(k as u32))?;
+    match val {
+        Some(MetadataValue::EffectivePrunedHeight(height)) => Ok(height),
+        _ => Ok(0),
     }
 }
 
@@ -879,150 +952,6 @@ fn fetch_pruning_horizon(env: &Environment, db: &Database) -> Result<u64, ChainS
         Some(MetadataValue::PruningHorizon(pruning_horizon)) => Ok(pruning_horizon),
         _ => Ok(0),
     }
-}
-
-// Retrieves the checkpoint corresponding to the provided height, if the checkpoint is part of the horizon state then a
-// BeyondPruningHorizon error will be produced.
-fn fetch_checkpoint<T>(
-    checkpoints: &T,
-    pruned_mode: bool,
-    tip_height: u64,
-    height: u64,
-) -> Result<Option<MerkleCheckPoint>, ChainStorageError>
-where
-    T: ArrayLike<Value = MerkleCheckPoint>,
-    T::Error: Display,
-{
-    let tip_index = tip_height.saturating_sub(1);
-    let offset = tip_index
-        .checked_sub(height)
-        .ok_or_else(|| ChainStorageError::OutOfRange)?;
-
-    let last_cp_index = checkpoints
-        .len()
-        .map_err(|e| ChainStorageError::AccessError(e.to_string()))?
-        .saturating_sub(1);
-    let index = last_cp_index
-        .checked_sub(offset as usize)
-        .ok_or_else(|| ChainStorageError::BeyondPruningHorizon)?;
-    if pruned_mode && index == 0 {
-        // In pruned mode the first checkpoint is an accumulation of all checkpoints from the genesis block to horizon
-        // block height.
-        return Err(ChainStorageError::BeyondPruningHorizon);
-    }
-    checkpoints
-        .get(index as usize)
-        .map_err(|e| ChainStorageError::AccessError(e.to_string()))
-}
-
-// Calculate the total leaf node count upto a specified height.
-fn fetch_mmr_nodes_added_count<T>(checkpoints: &T, tip_height: u64, height: u64) -> Result<u32, ChainStorageError>
-where
-    T: ArrayLike<Value = MerkleCheckPoint>,
-    T::Error: Display,
-{
-    let cp_count = checkpoints
-        .len()
-        .map_err(|e| ChainStorageError::AccessError(e.to_string()))?;
-    Ok(match cp_count.checked_sub(1) {
-        Some(last_index) => {
-            let index = last_index.saturating_sub(tip_height.saturating_sub(height) as usize);
-            checkpoints
-                .get(index)
-                .map_err(|e| ChainStorageError::AccessError(format!("Checkpoint error: {}", e.to_string())))?
-                .map(|cp| cp.accumulated_nodes_added_count())
-                .unwrap_or(0)
-        },
-        None => 0,
-    })
-}
-
-// Returns the accumulated node added count.
-fn fetch_last_mmr_node_added_count<T>(checkpoints: &T) -> Result<u32, ChainStorageError>
-where
-    T: ArrayLike<Value = MerkleCheckPoint>,
-    T::Error: Display,
-{
-    let cp_count = checkpoints
-        .len()
-        .map_err(|e| ChainStorageError::AccessError(e.to_string()))?;
-    Ok(match cp_count.checked_sub(1) {
-        Some(last_index) => checkpoints
-            .get(last_index)
-            .map_err(|e| ChainStorageError::AccessError(format!("Checkpoint error: {}", e.to_string())))?
-            .map(|cp| cp.accumulated_nodes_added_count())
-            .unwrap_or(0),
-        None => 0,
-    })
-}
-
-// Calculated the new checkpoint count after rewinding a set number of steps back.
-fn rewind_checkpoint_index(cp_count: usize, steps_back: usize) -> usize {
-    if cp_count > steps_back {
-        cp_count - steps_back
-    } else {
-        1
-    }
-}
-
-// Rewinds checkpoints by `steps_back` elements and returns the last checkpoint.
-fn rewind_checkpoints(
-    checkpoints: &mut LMDBVec<MerkleCheckPoint>,
-    steps_back: usize,
-) -> Result<MerkleCheckPoint, ChainStorageError>
-{
-    let cp_count = checkpoints
-        .len()
-        .map_err(|e| ChainStorageError::AccessError(e.to_string()))?;
-    let rewind_len = rewind_checkpoint_index(cp_count, steps_back);
-    checkpoints
-        .truncate(rewind_len)
-        .map_err(|e| ChainStorageError::AccessError(e.to_string()))?;
-
-    let last_cp = checkpoints
-        .get(rewind_len - 1)
-        .map_err(|e| ChainStorageError::AccessError(e.to_string()))?
-        .expect("rewind_checkpoint_index should ensure that all checkpoints cannot be removed");
-
-    Ok(last_cp)
-}
-
-// Attempt to merge the set of oldest checkpoints into the horizon state and return the number of checkpoints that have
-// been merged.
-fn merge_checkpoints(
-    checkpoints: &mut LMDBVec<MerkleCheckPoint>,
-    max_cp_count: usize,
-) -> Result<(usize, Vec<u32>), ChainStorageError>
-{
-    let cp_count = checkpoints
-        .len()
-        .map_err(|e| ChainStorageError::AccessError(e.to_string()))?;
-    let mut stxo_leaf_indices = Vec::<u32>::new();
-    if let Some(num_cps_merged) = (cp_count + 1).checked_sub(max_cp_count) {
-        if let Some(mut merged_cp) = checkpoints
-            .get(0)
-            .map_err(|e| ChainStorageError::AccessError(e.to_string()))?
-        {
-            for index in 1..num_cps_merged {
-                if let Some(cp) = checkpoints
-                    .get(index)
-                    .map_err(|e| ChainStorageError::AccessError(e.to_string()))?
-                {
-                    stxo_leaf_indices.append(&mut cp.nodes_deleted().to_vec());
-                    merged_cp.append(cp);
-                }
-            }
-            checkpoints
-                .shift(num_cps_merged)
-                .map_err(|e| ChainStorageError::AccessError(e.to_string()))?;
-            checkpoints
-                .push_front(merged_cp)
-                .map_err(|e| ChainStorageError::AccessError(e.to_string()))?;
-            return Ok((num_cps_merged, stxo_leaf_indices));
-        }
-    }
-
-    Ok((0, stxo_leaf_indices))
 }
 
 fn get_database(store: &LMDBStore, name: &str) -> Result<DatabaseRef, ChainStorageError> {

--- a/base_layer/core/src/chain_storage/lmdb_db/lmdb_vec.rs
+++ b/base_layer/core/src/chain_storage/lmdb_db/lmdb_vec.rs
@@ -24,22 +24,25 @@ use crate::chain_storage::{
     error::ChainStorageError,
     lmdb_db::lmdb::{lmdb_clear_db, lmdb_delete, lmdb_get, lmdb_insert, lmdb_len, lmdb_replace},
 };
-use derive_error::Error;
 use lmdb_zero::{Database, Environment, WriteTransaction};
 use log::*;
 use std::{cmp::min, marker::PhantomData, sync::Arc};
 use tari_crypto::tari_utilities::message_format::MessageFormatError;
 use tari_mmr::{error::MerkleMountainRangeError, ArrayLike, ArrayLikeExt};
 use tari_storage::lmdb_store::LMDBError;
+use thiserror::Error;
 
 const INDEX_OFFSET_DB_KEY: i64 = i64::min_value();
 pub const LOG_TARGET: &str = "c::cs::lmdb_db::lmdb_vec";
 
 #[derive(Debug, Error)]
 pub enum LMDBVecError {
-    MessageFormatError(MessageFormatError),
-    LMDBError(LMDBError),
-    ChainStorageError(ChainStorageError),
+    #[error("Message format error: {0}")]
+    MessageFormatError(#[from] MessageFormatError),
+    #[error("LMDB error: {0}")]
+    LMDBError(#[from] LMDBError),
+    #[error("Chain storage error: {0}")]
+    ChainStorageError(#[from] ChainStorageError),
 }
 
 pub struct LMDBVec<T> {

--- a/base_layer/core/src/chain_storage/lmdb_db/mod.rs
+++ b/base_layer/core/src/chain_storage/lmdb_db/mod.rs
@@ -23,11 +23,10 @@
 mod lmdb;
 #[allow(clippy::module_inception)]
 mod lmdb_db;
-mod lmdb_vec;
-
-// Public API exports
 pub use lmdb_db::{create_lmdb_database, LMDBDatabase};
-pub use lmdb_vec::LMDBVec;
+
+mod lmdb_vec;
+pub use lmdb_vec::{LMDBVec, LMDBVecError};
 
 pub const LMDB_DB_METADATA: &str = "metadata";
 pub const LMDB_DB_HEADERS: &str = "headers";

--- a/base_layer/core/src/chain_storage/memory_db/mod.rs
+++ b/base_layer/core/src/chain_storage/memory_db/mod.rs
@@ -21,9 +21,8 @@
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 mod mem_db_vec;
+pub use mem_db_vec::MemDbVec;
+
 #[allow(clippy::module_inception)]
 mod memory_db;
-
-// Public API exports
-pub use mem_db_vec::MemDbVec;
 pub use memory_db::MemoryDatabase;

--- a/base_layer/core/src/chain_storage/mod.rs
+++ b/base_layer/core/src/chain_storage/mod.rs
@@ -27,26 +27,11 @@
 //! backed by LMDB, while the merkle trees are stored in flat files for example.
 
 mod blockchain_database;
-mod consts;
-mod db_transaction;
-mod error;
-mod historical_block;
-mod lmdb_db;
-mod memory_db;
-mod metadata;
-
-// public modules
-pub mod async_db;
-
-// Public API exports
 pub use blockchain_database::{
     calculate_mmr_roots,
     fetch_header,
     fetch_headers,
-    fetch_target_difficulties,
     fetch_tip_header,
-    is_stxo,
-    is_utxo,
     BlockAddResult,
     BlockchainBackend,
     BlockchainDatabase,
@@ -54,6 +39,10 @@ pub use blockchain_database::{
     MutableMmrState,
     Validators,
 };
+
+mod consts;
+
+mod db_transaction;
 pub use db_transaction::{
     DbKey,
     DbKeyValuePair,
@@ -64,8 +53,16 @@ pub use db_transaction::{
     MmrTree,
     WriteOperation,
 };
+
+// mod entity;
+
+mod error;
 pub use error::ChainStorageError;
+
+mod historical_block;
 pub use historical_block::HistoricalBlock;
+
+mod lmdb_db;
 pub use lmdb_db::{
     create_lmdb_database,
     LMDBDatabase,
@@ -80,5 +77,13 @@ pub use lmdb_db::{
     LMDB_DB_UTXOS,
     LMDB_DB_UTXO_MMR_CP_BACKEND,
 };
+
+mod memory_db;
 pub use memory_db::MemoryDatabase;
-pub use metadata::ChainMetadata;
+
+mod metadata;
+pub use metadata::{ChainMetadata, InProgressHorizonSyncState};
+
+mod checkpoint_utils;
+
+pub mod async_db;

--- a/base_layer/core/src/consensus/consensus_manager.rs
+++ b/base_layer/core/src/consensus/consensus_manager.rs
@@ -39,7 +39,7 @@ use derive_error::Error;
 use std::sync::Arc;
 use tari_crypto::tari_utilities::hash::Hashable;
 
-#[derive(Debug, Error, Clone, PartialEq)]
+#[derive(Debug, Error, Clone)]
 pub enum ConsensusManagerError {
     /// Difficulty adjustment encountered an error
     DifficultyAdjustmentError(DifficultyAdjustmentError),

--- a/base_layer/core/src/consensus/emission.rs
+++ b/base_layer/core/src/consensus/emission.rs
@@ -246,7 +246,6 @@ mod test {
         consensus::emission::{Emission, EmissionSchedule},
         transactions::tari_amount::{uT, MicroTari, T},
     };
-    use num::pow;
 
     /// Commit df95cee73812689bbae77bfb547c1d73a49635d4 introduced a bug in Windows builds that resulted in certain
     /// blocks failing validation tests. The cause was traced to an erroneous implementation of the std::f64::powi

--- a/base_layer/core/src/helpers/mock_backend.rs
+++ b/base_layer/core/src/helpers/mock_backend.rs
@@ -71,7 +71,16 @@ impl BlockchainBackend for MockBackend {
         unimplemented!()
     }
 
-    fn fetch_checkpoint(&self, _tree: MmrTree, _index: u64) -> Result<MerkleCheckPoint, ChainStorageError> {
+    fn fetch_checkpoint_at_height(&self, _tree: MmrTree, _index: u64) -> Result<MerkleCheckPoint, ChainStorageError> {
+        unimplemented!()
+    }
+
+    fn fetch_checkpoint_at_index(
+        &self,
+        _tree: MmrTree,
+        _index: usize,
+    ) -> Result<Option<MerkleCheckPoint>, ChainStorageError>
+    {
         unimplemented!()
     }
 
@@ -152,7 +161,7 @@ impl BlockchainBackend for MockBackend {
         unimplemented!()
     }
 
-    fn fetch_metadata(&self) -> Result<ChainMetadata, ChainStorageError> {
+    fn fetch_chain_metadata(&self) -> Result<ChainMetadata, ChainStorageError> {
         unimplemented!()
     }
 
@@ -171,6 +180,10 @@ impl BlockchainBackend for MockBackend {
     }
 
     fn count_kernels(&self) -> Result<usize, ChainStorageError> {
+        unimplemented!()
+    }
+
+    fn count_checkpoints(&self, _tree: MmrTree) -> Result<usize, ChainStorageError> {
         unimplemented!()
     }
 

--- a/base_layer/core/src/proof_of_work/blake_pow.rs
+++ b/base_layer/core/src/proof_of_work/blake_pow.rs
@@ -38,12 +38,12 @@ pub fn blake_difficulty(header: &BlockHeader) -> Difficulty {
 
 pub fn blake_difficulty_with_hash(header: &BlockHeader) -> (Difficulty, Vec<u8>) {
     let bytes = header.hash();
-    let hash = Blake2b::digest(&bytes).to_vec();
-    let hash = Blake256::digest(&hash).to_vec();
+    let hash = Blake2b::digest(&bytes);
+    let hash = Blake256::digest(&hash);
     let scalar = U256::from_big_endian(&hash); // Big endian so the hash has leading zeroes
     let result = MAX_TARGET / scalar;
     let difficulty = result.low_u64().into();
-    (difficulty, hash)
+    (difficulty, hash.to_vec())
 }
 
 #[cfg(test)]

--- a/base_layer/core/src/proof_of_work/proof_of_work.rs
+++ b/base_layer/core/src/proof_of_work/proof_of_work.rs
@@ -26,10 +26,7 @@ use crate::{
 };
 use bytes::{self, BufMut};
 use serde::{Deserialize, Serialize};
-use std::{
-    convert::TryFrom,
-    fmt::{Display, Error, Formatter},
-};
+use std::fmt::{Display, Error, Formatter};
 use tari_crypto::tari_utilities::hex::Hex;
 
 pub trait AchievedDifficulty {}

--- a/base_layer/core/src/transactions/transaction.rs
+++ b/base_layer/core/src/transactions/transaction.rs
@@ -40,7 +40,6 @@ use crate::transactions::{
         Signature,
     },
 };
-use derive_error::Error;
 use digest::Input;
 use serde::{Deserialize, Serialize};
 use std::{
@@ -55,6 +54,7 @@ use tari_crypto::{
     range_proof::{RangeProofError, RangeProofService as RangeProofServiceTrait},
     tari_utilities::{hex::Hex, message_format::MessageFormat, ByteArray, Hashable},
 };
+use thiserror::Error;
 
 // Tx_weight(inputs(12,500), outputs(500), kernels(1)) = 19,003, still well enough below block weight of 19,500
 pub const MAX_TRANSACTION_INPUTS: usize = 12_500;
@@ -156,15 +156,14 @@ bitflags! {
 
 #[derive(Clone, Debug, PartialEq, Error, Deserialize, Serialize)]
 pub enum TransactionError {
-    // Error validating the transaction
-    #[error(msg_embedded, no_from, non_std)]
+    #[error("Error validating the transaction: {0}")]
     ValidationError(String),
-    // Signature could not be verified
+    #[error("Signature could not be verified")]
     InvalidSignatureError,
-    // Transaction kernel does not contain a signature
+    #[error("Transaction kernel does not contain a signature")]
     NoSignatureError,
-    // A range proof construction or verification has produced an error
-    RangeProofError(RangeProofError),
+    #[error("A range proof construction or verification has produced an error: {0}")]
+    RangeProofError(#[from] RangeProofError),
 }
 
 //-----------------------------------------     UnblindedOutput   ----------------------------------------------------//

--- a/base_layer/core/src/transactions/transaction_protocol/transaction_initializer.rs
+++ b/base_layer/core/src/transactions/transaction_protocol/transaction_initializer.rs
@@ -600,7 +600,7 @@ mod test {
 
         match result {
             Ok(_) => panic!("Range proof should have failed to verify"),
-            Err(e) => assert_eq!(e.message, "Range proof could not be verified".to_string()),
+            Err(e) => assert!(e.message.contains("Range proof could not be verified")),
         }
     }
 }

--- a/base_layer/core/src/validation/accum_difficulty_validators.rs
+++ b/base_layer/core/src/validation/accum_difficulty_validators.rs
@@ -33,9 +33,8 @@ pub struct AccumDifficultyValidator {}
 impl<B: BlockchainBackend> Validation<Difficulty, B> for AccumDifficultyValidator {
     fn validate(&self, accum_difficulty: &Difficulty, db: &B) -> Result<(), ValidationError> {
         let tip_header = db
-            .fetch_last_header()
-            .map_err(|e| ValidationError::CustomError(e.to_string()))?
-            .ok_or_else(|| ValidationError::CustomError("Cannot retrieve tip header. Blockchain DB is empty".into()))?;
+            .fetch_last_header()?
+            .ok_or_else(|| ValidationError::custom_error("Cannot retrieve tip header. Blockchain DB is empty"))?;
         if *accum_difficulty <= tip_header.total_accumulated_difficulty_inclusive() {
             return Err(ValidationError::WeakerAccumulatedDifficulty);
         }
@@ -52,9 +51,8 @@ pub struct MockAccumDifficultyValidator;
 impl<B: BlockchainBackend> Validation<Difficulty, B> for MockAccumDifficultyValidator {
     fn validate(&self, accum_difficulty: &Difficulty, db: &B) -> Result<(), ValidationError> {
         let tip_header = db
-            .fetch_last_header()
-            .map_err(|e| ValidationError::CustomError(e.to_string()))?
-            .ok_or_else(|| ValidationError::CustomError("Cannot retrieve tip header. Blockchain DB is empty".into()))?;
+            .fetch_last_header()?
+            .ok_or_else(|| ValidationError::custom_error("Cannot retrieve tip header. Blockchain DB is empty"))?;
         if *accum_difficulty < tip_header.total_accumulated_difficulty_inclusive() {
             return Err(ValidationError::WeakerAccumulatedDifficulty);
         }

--- a/base_layer/core/src/validation/mocks.rs
+++ b/base_layer/core/src/validation/mocks.rs
@@ -39,8 +39,8 @@ impl<T, B: BlockchainBackend> Validation<T, B> for MockValidator {
         if self.is_valid {
             Ok(())
         } else {
-            Err(ValidationError::CustomError(
-                "This mock validator always returns an error".into(),
+            Err(ValidationError::custom_error(
+                "This mock validator always returns an error",
             ))
         }
     }
@@ -51,8 +51,8 @@ impl<T> StatelessValidation<T> for MockValidator {
         if self.is_valid {
             Ok(())
         } else {
-            Err(ValidationError::CustomError(
-                "This mock validator always returns an error".into(),
+            Err(ValidationError::custom_error(
+                "This mock validator always returns an error",
             ))
         }
     }

--- a/base_layer/core/tests/chain_storage_tests/chain_backend.rs
+++ b/base_layer/core/tests/chain_storage_tests/chain_backend.rs
@@ -54,14 +54,14 @@ fn insert_contains_delete_and_fetch_header<T: BlockchainBackend>(mut db: T) {
     let mut header = BlockHeader::new(0);
     header.height = 42;
     let hash = header.hash();
-    assert_eq!(db.contains(&DbKey::BlockHeader(header.height)), Ok(false));
-    assert_eq!(db.contains(&DbKey::BlockHash(hash.clone())), Ok(false));
+    assert_eq!(db.contains(&DbKey::BlockHeader(header.height)).unwrap(), false);
+    assert_eq!(db.contains(&DbKey::BlockHash(hash.clone())).unwrap(), false);
 
     let mut txn = DbTransaction::new();
     txn.insert_header(header.clone());
     assert!(db.write(txn).is_ok());
-    assert_eq!(db.contains(&DbKey::BlockHeader(header.height)), Ok(true));
-    assert_eq!(db.contains(&DbKey::BlockHash(hash.clone())), Ok(true));
+    assert_eq!(db.contains(&DbKey::BlockHeader(header.height)).unwrap(), true);
+    assert_eq!(db.contains(&DbKey::BlockHash(hash.clone())).unwrap(), true);
     if let Some(DbValue::BlockHeader(retrieved_header)) = db.fetch(&DbKey::BlockHeader(header.height)).unwrap() {
         assert_eq!(*retrieved_header, header);
     } else {
@@ -76,8 +76,8 @@ fn insert_contains_delete_and_fetch_header<T: BlockchainBackend>(mut db: T) {
     let mut txn = DbTransaction::new();
     txn.delete(DbKey::BlockHash(hash.clone()));
     assert!(db.write(txn).is_ok());
-    assert_eq!(db.contains(&DbKey::BlockHeader(header.height)), Ok(false));
-    assert_eq!(db.contains(&DbKey::BlockHash(hash)), Ok(false));
+    assert_eq!(db.contains(&DbKey::BlockHeader(header.height)).unwrap(), false);
+    assert_eq!(db.contains(&DbKey::BlockHash(hash)).unwrap(), false);
 }
 
 #[test]
@@ -107,12 +107,12 @@ fn insert_contains_delete_and_fetch_utxo<T: BlockchainBackend>(mut db: T) {
     let factories = CryptoFactories::default();
     let (utxo, _) = create_utxo(MicroTari(10_000), &factories, None);
     let hash = utxo.hash();
-    assert_eq!(db.contains(&DbKey::UnspentOutput(hash.clone())), Ok(false));
+    assert_eq!(db.contains(&DbKey::UnspentOutput(hash.clone())).unwrap(), false);
 
     let mut txn = DbTransaction::new();
     txn.insert_utxo(utxo.clone());
     assert!(db.write(txn).is_ok());
-    assert_eq!(db.contains(&DbKey::UnspentOutput(hash.clone())), Ok(true));
+    assert_eq!(db.contains(&DbKey::UnspentOutput(hash.clone())).unwrap(), true);
     if let Some(DbValue::UnspentOutput(retrieved_utxo)) = db.fetch(&DbKey::UnspentOutput(hash.clone())).unwrap() {
         assert_eq!(*retrieved_utxo, utxo);
     } else {
@@ -122,7 +122,7 @@ fn insert_contains_delete_and_fetch_utxo<T: BlockchainBackend>(mut db: T) {
     let mut txn = DbTransaction::new();
     txn.delete(DbKey::UnspentOutput(hash.clone()));
     assert!(db.write(txn).is_ok());
-    assert_eq!(db.contains(&DbKey::UnspentOutput(hash)), Ok(false));
+    assert_eq!(db.contains(&DbKey::UnspentOutput(hash)).unwrap(), false);
 }
 
 #[test]
@@ -151,12 +151,12 @@ fn lmdb_insert_contains_delete_and_fetch_utxo() {
 fn insert_contains_delete_and_fetch_kernel<T: BlockchainBackend>(mut db: T) {
     let kernel = create_test_kernel(5.into(), 0);
     let hash = kernel.hash();
-    assert_eq!(db.contains(&DbKey::TransactionKernel(hash.clone())), Ok(false));
+    assert_eq!(db.contains(&DbKey::TransactionKernel(hash.clone())).unwrap(), false);
 
     let mut txn = DbTransaction::new();
     txn.insert_kernel(kernel.clone());
     assert!(db.write(txn).is_ok());
-    assert_eq!(db.contains(&DbKey::TransactionKernel(hash.clone())), Ok(true));
+    assert_eq!(db.contains(&DbKey::TransactionKernel(hash.clone())).unwrap(), true);
     if let Some(DbValue::TransactionKernel(retrieved_kernel)) =
         db.fetch(&DbKey::TransactionKernel(hash.clone())).unwrap()
     {
@@ -168,7 +168,7 @@ fn insert_contains_delete_and_fetch_kernel<T: BlockchainBackend>(mut db: T) {
     let mut txn = DbTransaction::new();
     txn.delete(DbKey::TransactionKernel(hash.clone()));
     assert!(db.write(txn).is_ok());
-    assert_eq!(db.contains(&DbKey::TransactionKernel(hash)), Ok(false));
+    assert_eq!(db.contains(&DbKey::TransactionKernel(hash)).unwrap(), false);
 }
 
 #[test]
@@ -201,13 +201,13 @@ fn insert_contains_delete_and_fetch_orphan<T: BlockchainBackend>(mut db: T, cons
     ];
     let orphan = create_orphan_block(10, txs, consensus_constants);
     let hash = orphan.hash();
-    assert_eq!(db.contains(&DbKey::OrphanBlock(hash.clone())), Ok(false));
+    assert_eq!(db.contains(&DbKey::OrphanBlock(hash.clone())).unwrap(), false);
 
     let mut txn = DbTransaction::new();
     txn.insert_orphan(orphan.clone());
     assert!(db.write(txn).is_ok());
 
-    assert_eq!(db.contains(&DbKey::OrphanBlock(hash.clone())), Ok(true));
+    assert_eq!(db.contains(&DbKey::OrphanBlock(hash.clone())).unwrap(), true);
     if let Some(DbValue::OrphanBlock(retrieved_orphan)) = db.fetch(&DbKey::OrphanBlock(hash.clone())).unwrap() {
         assert_eq!(*retrieved_orphan, orphan);
     } else {
@@ -217,7 +217,7 @@ fn insert_contains_delete_and_fetch_orphan<T: BlockchainBackend>(mut db: T, cons
     let mut txn = DbTransaction::new();
     txn.delete(DbKey::OrphanBlock(hash.clone()));
     assert!(db.write(txn).is_ok());
-    assert_eq!(db.contains(&DbKey::OrphanBlock(hash)), Ok(false));
+    assert_eq!(db.contains(&DbKey::OrphanBlock(hash)).unwrap(), false);
 }
 
 #[test]
@@ -262,19 +262,19 @@ fn spend_utxo_and_unspend_stxo<T: BlockchainBackend>(mut db: T) {
     let mut txn = DbTransaction::new();
     txn.spend_utxo(hash1.clone());
     assert!(db.write(txn).is_ok());
-    assert_eq!(db.contains(&DbKey::UnspentOutput(hash1.clone())), Ok(false));
-    assert_eq!(db.contains(&DbKey::UnspentOutput(hash2.clone())), Ok(true));
-    assert_eq!(db.contains(&DbKey::SpentOutput(hash1.clone())), Ok(true));
-    assert_eq!(db.contains(&DbKey::SpentOutput(hash2.clone())), Ok(false));
+    assert_eq!(db.contains(&DbKey::UnspentOutput(hash1.clone())).unwrap(), false);
+    assert_eq!(db.contains(&DbKey::UnspentOutput(hash2.clone())).unwrap(), true);
+    assert_eq!(db.contains(&DbKey::SpentOutput(hash1.clone())).unwrap(), true);
+    assert_eq!(db.contains(&DbKey::SpentOutput(hash2.clone())).unwrap(), false);
 
     let mut txn = DbTransaction::new();
     txn.spend_utxo(hash2.clone());
     txn.unspend_stxo(hash1.clone());
     assert!(db.write(txn).is_ok());
-    assert_eq!(db.contains(&DbKey::UnspentOutput(hash1.clone())), Ok(true));
-    assert_eq!(db.contains(&DbKey::UnspentOutput(hash2.clone())), Ok(false));
-    assert_eq!(db.contains(&DbKey::SpentOutput(hash1.clone())), Ok(false));
-    assert_eq!(db.contains(&DbKey::SpentOutput(hash2.clone())), Ok(true));
+    assert_eq!(db.contains(&DbKey::UnspentOutput(hash1.clone())).unwrap(), true);
+    assert_eq!(db.contains(&DbKey::UnspentOutput(hash2.clone())).unwrap(), false);
+    assert_eq!(db.contains(&DbKey::SpentOutput(hash1.clone())).unwrap(), false);
+    assert_eq!(db.contains(&DbKey::SpentOutput(hash2.clone())).unwrap(), true);
 
     if let Some(DbValue::UnspentOutput(retrieved_utxo)) = db.fetch(&DbKey::UnspentOutput(hash1.clone())).unwrap() {
         assert_eq!(*retrieved_utxo, utxo1);
@@ -290,10 +290,10 @@ fn spend_utxo_and_unspend_stxo<T: BlockchainBackend>(mut db: T) {
     let mut txn = DbTransaction::new();
     txn.delete(DbKey::SpentOutput(hash2.clone()));
     assert!(db.write(txn).is_ok());
-    assert_eq!(db.contains(&DbKey::UnspentOutput(hash1.clone())), Ok(true));
-    assert_eq!(db.contains(&DbKey::UnspentOutput(hash2.clone())), Ok(false));
-    assert_eq!(db.contains(&DbKey::SpentOutput(hash1)), Ok(false));
-    assert_eq!(db.contains(&DbKey::SpentOutput(hash2)), Ok(false));
+    assert_eq!(db.contains(&DbKey::UnspentOutput(hash1.clone())).unwrap(), true);
+    assert_eq!(db.contains(&DbKey::UnspentOutput(hash2.clone())).unwrap(), false);
+    assert_eq!(db.contains(&DbKey::SpentOutput(hash1)).unwrap(), false);
+    assert_eq!(db.contains(&DbKey::SpentOutput(hash2)).unwrap(), false);
 }
 
 #[test]
@@ -699,12 +699,12 @@ fn commit_block_and_create_fetch_checkpoint_and_rewind_mmr<T: BlockchainBackend>
     txn.commit_block();
     assert!(db.write(txn).is_ok());
 
-    let utxo_cp0 = db.fetch_checkpoint(MmrTree::Utxo, 0).unwrap();
-    let kernel_cp0 = db.fetch_checkpoint(MmrTree::Kernel, 0).unwrap();
-    let range_proof_cp0 = db.fetch_checkpoint(MmrTree::RangeProof, 0).unwrap();
-    let utxo_cp1 = db.fetch_checkpoint(MmrTree::Utxo, 1).unwrap();
-    let kernel_cp1 = db.fetch_checkpoint(MmrTree::Kernel, 1).unwrap();
-    let range_proof_cp1 = db.fetch_checkpoint(MmrTree::RangeProof, 1).unwrap();
+    let utxo_cp0 = db.fetch_checkpoint_at_height(MmrTree::Utxo, 0).unwrap();
+    let kernel_cp0 = db.fetch_checkpoint_at_height(MmrTree::Kernel, 0).unwrap();
+    let range_proof_cp0 = db.fetch_checkpoint_at_height(MmrTree::RangeProof, 0).unwrap();
+    let utxo_cp1 = db.fetch_checkpoint_at_height(MmrTree::Utxo, 1).unwrap();
+    let kernel_cp1 = db.fetch_checkpoint_at_height(MmrTree::Kernel, 1).unwrap();
+    let range_proof_cp1 = db.fetch_checkpoint_at_height(MmrTree::RangeProof, 1).unwrap();
     assert_eq!(utxo_cp0.nodes_added().len(), 1);
     assert_eq!(utxo_cp0.accumulated_nodes_added_count(), 1);
     assert_eq!(utxo_cp0.nodes_added()[0], utxo_hash1);
@@ -716,14 +716,20 @@ fn commit_block_and_create_fetch_checkpoint_and_rewind_mmr<T: BlockchainBackend>
     assert_eq!(utxo_cp1.nodes_deleted().to_vec()[0], 0);
     assert_eq!(kernel_cp1.nodes_added()[0], kernel_hash2);
     assert_eq!(range_proof_cp1.nodes_added()[0], rp_hash2);
-    assert_eq!(db.contains(&DbKey::UnspentOutput(utxo_hash1.clone())), Ok(false));
-    assert_eq!(db.contains(&DbKey::UnspentOutput(utxo_hash2.clone())), Ok(true));
-    assert_eq!(db.contains(&DbKey::SpentOutput(utxo_hash1.clone())), Ok(true));
-    assert_eq!(db.contains(&DbKey::SpentOutput(utxo_hash2.clone())), Ok(false));
-    assert_eq!(db.contains(&DbKey::TransactionKernel(kernel_hash1.clone())), Ok(true));
-    assert_eq!(db.contains(&DbKey::TransactionKernel(kernel_hash2.clone())), Ok(true));
-    assert_eq!(db.contains(&DbKey::BlockHeader(0)), Ok(true));
-    assert_eq!(db.contains(&DbKey::BlockHeader(1)), Ok(true));
+    assert_eq!(db.contains(&DbKey::UnspentOutput(utxo_hash1.clone())).unwrap(), false);
+    assert_eq!(db.contains(&DbKey::UnspentOutput(utxo_hash2.clone())).unwrap(), true);
+    assert_eq!(db.contains(&DbKey::SpentOutput(utxo_hash1.clone())).unwrap(), true);
+    assert_eq!(db.contains(&DbKey::SpentOutput(utxo_hash2.clone())).unwrap(), false);
+    assert_eq!(
+        db.contains(&DbKey::TransactionKernel(kernel_hash1.clone())).unwrap(),
+        true
+    );
+    assert_eq!(
+        db.contains(&DbKey::TransactionKernel(kernel_hash2.clone())).unwrap(),
+        true
+    );
+    assert_eq!(db.contains(&DbKey::BlockHeader(0)).unwrap(), true);
+    assert_eq!(db.contains(&DbKey::BlockHeader(1)).unwrap(), true);
 
     let mut txn = DbTransaction::new();
     txn.delete(DbKey::BlockHeader(1));
@@ -732,29 +738,29 @@ fn commit_block_and_create_fetch_checkpoint_and_rewind_mmr<T: BlockchainBackend>
     txn.unspend_stxo(utxo_hash1.clone());
     txn.rewind_kernel_mmr(1);
     txn.rewind_utxo_mmr(1);
-    txn.rewind_rp_mmr(1);
+    txn.rewind_rangeproof_mmr(1);
     assert!(db.write(txn).is_ok());
 
-    let utxo_cp0 = db.fetch_checkpoint(MmrTree::Utxo, 0).unwrap();
-    let kernel_cp0 = db.fetch_checkpoint(MmrTree::Kernel, 0).unwrap();
-    let range_proof_cp0 = db.fetch_checkpoint(MmrTree::RangeProof, 0).unwrap();
+    let utxo_cp0 = db.fetch_checkpoint_at_height(MmrTree::Utxo, 0).unwrap();
+    let kernel_cp0 = db.fetch_checkpoint_at_height(MmrTree::Kernel, 0).unwrap();
+    let range_proof_cp0 = db.fetch_checkpoint_at_height(MmrTree::RangeProof, 0).unwrap();
     assert_eq!(utxo_cp0.accumulated_nodes_added_count(), 1);
     assert_eq!(utxo_cp0.nodes_added()[0], utxo_hash1);
     assert_eq!(utxo_cp0.nodes_deleted().to_vec().len(), 0);
     assert_eq!(kernel_cp0.nodes_added()[0], kernel_hash1);
     assert_eq!(range_proof_cp0.nodes_added()[0], rp_hash1);
-    assert!(db.fetch_checkpoint(MmrTree::Utxo, 1).is_err());
-    assert!(db.fetch_checkpoint(MmrTree::Kernel, 1).is_err());
-    assert!(db.fetch_checkpoint(MmrTree::RangeProof, 1).is_err());
+    assert!(db.fetch_checkpoint_at_height(MmrTree::Utxo, 1).is_err());
+    assert!(db.fetch_checkpoint_at_height(MmrTree::Kernel, 1).is_err());
+    assert!(db.fetch_checkpoint_at_height(MmrTree::RangeProof, 1).is_err());
 
-    assert_eq!(db.contains(&DbKey::UnspentOutput(utxo_hash1.clone())), Ok(true));
-    assert_eq!(db.contains(&DbKey::UnspentOutput(utxo_hash2.clone())), Ok(false));
-    assert_eq!(db.contains(&DbKey::SpentOutput(utxo_hash1)), Ok(false));
-    assert_eq!(db.contains(&DbKey::SpentOutput(utxo_hash2)), Ok(false));
-    assert_eq!(db.contains(&DbKey::TransactionKernel(kernel_hash1)), Ok(true));
-    assert_eq!(db.contains(&DbKey::TransactionKernel(kernel_hash2)), Ok(false));
-    assert_eq!(db.contains(&DbKey::BlockHeader(0)), Ok(true));
-    assert_eq!(db.contains(&DbKey::BlockHeader(1)), Ok(false));
+    assert_eq!(db.contains(&DbKey::UnspentOutput(utxo_hash1.clone())).unwrap(), true);
+    assert_eq!(db.contains(&DbKey::UnspentOutput(utxo_hash2.clone())).unwrap(), false);
+    assert_eq!(db.contains(&DbKey::SpentOutput(utxo_hash1)).unwrap(), false);
+    assert_eq!(db.contains(&DbKey::SpentOutput(utxo_hash2)).unwrap(), false);
+    assert_eq!(db.contains(&DbKey::TransactionKernel(kernel_hash1)).unwrap(), true);
+    assert_eq!(db.contains(&DbKey::TransactionKernel(kernel_hash2)).unwrap(), false);
+    assert_eq!(db.contains(&DbKey::BlockHeader(0)).unwrap(), true);
+    assert_eq!(db.contains(&DbKey::BlockHeader(1)).unwrap(), false);
 }
 
 #[test]
@@ -805,9 +811,9 @@ fn for_each_orphan<T: BlockchainBackend>(mut db: T, consensus_constants: &Consen
     txn.insert_orphan(orphan2.clone());
     txn.insert_orphan(orphan3.clone());
     assert!(db.write(txn).is_ok());
-    assert_eq!(db.contains(&DbKey::OrphanBlock(hash1.clone())), Ok(true));
-    assert_eq!(db.contains(&DbKey::OrphanBlock(hash2.clone())), Ok(true));
-    assert_eq!(db.contains(&DbKey::OrphanBlock(hash3.clone())), Ok(true));
+    assert_eq!(db.contains(&DbKey::OrphanBlock(hash1.clone())).unwrap(), true);
+    assert_eq!(db.contains(&DbKey::OrphanBlock(hash2.clone())).unwrap(), true);
+    assert_eq!(db.contains(&DbKey::OrphanBlock(hash3.clone())).unwrap(), true);
 
     let mut orphan1_found = false;
     let mut orphan2_found = false;
@@ -867,9 +873,9 @@ fn for_each_kernel<T: BlockchainBackend>(mut db: T) {
     txn.insert_kernel(kernel2.clone());
     txn.insert_kernel(kernel3.clone());
     assert!(db.write(txn).is_ok());
-    assert_eq!(db.contains(&DbKey::TransactionKernel(hash1.clone())), Ok(true));
-    assert_eq!(db.contains(&DbKey::TransactionKernel(hash2.clone())), Ok(true));
-    assert_eq!(db.contains(&DbKey::TransactionKernel(hash3.clone())), Ok(true));
+    assert_eq!(db.contains(&DbKey::TransactionKernel(hash1.clone())).unwrap(), true);
+    assert_eq!(db.contains(&DbKey::TransactionKernel(hash2.clone())).unwrap(), true);
+    assert_eq!(db.contains(&DbKey::TransactionKernel(hash3.clone())).unwrap(), true);
 
     let mut kernel1_found = false;
     let mut kernel2_found = false;
@@ -925,9 +931,9 @@ fn for_each_header<T: BlockchainBackend>(mut db: T) {
     txn.insert_header(header2.clone());
     txn.insert_header(header3.clone());
     assert!(db.write(txn).is_ok());
-    assert_eq!(db.contains(&DbKey::BlockHeader(key1)), Ok(true));
-    assert_eq!(db.contains(&DbKey::BlockHeader(key2)), Ok(true));
-    assert_eq!(db.contains(&DbKey::BlockHeader(key3)), Ok(true));
+    assert_eq!(db.contains(&DbKey::BlockHeader(key1)).unwrap(), true);
+    assert_eq!(db.contains(&DbKey::BlockHeader(key2)).unwrap(), true);
+    assert_eq!(db.contains(&DbKey::BlockHeader(key3)).unwrap(), true);
 
     let mut header1_found = false;
     let mut header2_found = false;
@@ -984,9 +990,9 @@ fn for_each_utxo<T: BlockchainBackend>(mut db: T) {
     txn.insert_utxo(utxo2.clone());
     txn.insert_utxo(utxo3.clone());
     assert!(db.write(txn).is_ok());
-    assert_eq!(db.contains(&DbKey::UnspentOutput(hash1.clone())), Ok(true));
-    assert_eq!(db.contains(&DbKey::UnspentOutput(hash2.clone())), Ok(true));
-    assert_eq!(db.contains(&DbKey::UnspentOutput(hash3.clone())), Ok(true));
+    assert_eq!(db.contains(&DbKey::UnspentOutput(hash1.clone())).unwrap(), true);
+    assert_eq!(db.contains(&DbKey::UnspentOutput(hash2.clone())).unwrap(), true);
+    assert_eq!(db.contains(&DbKey::UnspentOutput(hash3.clone())).unwrap(), true);
 
     let mut utxo1_found = false;
     let mut utxo2_found = false;
@@ -1065,21 +1071,24 @@ fn lmdb_backend_restore() {
             txn.spend_utxo(stxo_hash.clone());
             db.write(txn).unwrap();
 
-            assert_eq!(db.contains(&DbKey::BlockHeader(header.height)), Ok(true));
-            assert_eq!(db.contains(&DbKey::BlockHash(header_hash.clone())), Ok(true));
-            assert_eq!(db.contains(&DbKey::UnspentOutput(utxo_hash.clone())), Ok(true));
-            assert_eq!(db.contains(&DbKey::SpentOutput(stxo_hash.clone())), Ok(true));
-            assert_eq!(db.contains(&DbKey::TransactionKernel(kernel_hash.clone())), Ok(true));
-            assert_eq!(db.contains(&DbKey::OrphanBlock(orphan_hash.clone())), Ok(true));
+            assert_eq!(db.contains(&DbKey::BlockHeader(header.height)).unwrap(), true);
+            assert_eq!(db.contains(&DbKey::BlockHash(header_hash.clone())).unwrap(), true);
+            assert_eq!(db.contains(&DbKey::UnspentOutput(utxo_hash.clone())).unwrap(), true);
+            assert_eq!(db.contains(&DbKey::SpentOutput(stxo_hash.clone())).unwrap(), true);
+            assert_eq!(
+                db.contains(&DbKey::TransactionKernel(kernel_hash.clone())).unwrap(),
+                true
+            );
+            assert_eq!(db.contains(&DbKey::OrphanBlock(orphan_hash.clone())).unwrap(), true);
         }
         // Restore backend storage
         let db = create_lmdb_database(&path, MmrCacheConfig::default()).unwrap();
-        assert_eq!(db.contains(&DbKey::BlockHeader(header.height)), Ok(true));
-        assert_eq!(db.contains(&DbKey::BlockHash(header_hash)), Ok(true));
-        assert_eq!(db.contains(&DbKey::UnspentOutput(utxo_hash)), Ok(true));
-        assert_eq!(db.contains(&DbKey::SpentOutput(stxo_hash)), Ok(true));
-        assert_eq!(db.contains(&DbKey::TransactionKernel(kernel_hash)), Ok(true));
-        assert_eq!(db.contains(&DbKey::OrphanBlock(orphan_hash)), Ok(true));
+        assert_eq!(db.contains(&DbKey::BlockHeader(header.height)).unwrap(), true);
+        assert_eq!(db.contains(&DbKey::BlockHash(header_hash)).unwrap(), true);
+        assert_eq!(db.contains(&DbKey::UnspentOutput(utxo_hash)).unwrap(), true);
+        assert_eq!(db.contains(&DbKey::SpentOutput(stxo_hash)).unwrap(), true);
+        assert_eq!(db.contains(&DbKey::TransactionKernel(kernel_hash)).unwrap(), true);
+        assert_eq!(db.contains(&DbKey::OrphanBlock(orphan_hash)).unwrap(), true);
     }
 
     // Cleanup test data - in Windows the LMBD `set_mapsize` sets file size equals to map size; Linux use sparse files
@@ -1124,28 +1133,36 @@ fn lmdb_mmr_reset_and_commit() {
         txn.commit_block();
         assert!(db.write(txn).is_err());
 
-        assert_eq!(db.contains(&DbKey::UnspentOutput(utxo_hash1.clone())), Ok(true));
-        assert_eq!(db.contains(&DbKey::UnspentOutput(utxo_hash2.clone())), Ok(false));
-        assert_eq!(db.contains(&DbKey::SpentOutput(utxo_hash1.clone())), Ok(false));
-        assert_eq!(db.contains(&DbKey::SpentOutput(utxo_hash2.clone())), Ok(false));
-        assert_eq!(db.contains(&DbKey::TransactionKernel(kernel_hash1.clone())), Ok(true));
-        assert_eq!(db.contains(&DbKey::TransactionKernel(kernel_hash2.clone())), Ok(false));
-        assert_eq!(db.contains(&DbKey::BlockHash(header_hash1.clone())), Ok(true));
+        assert_eq!(db.contains(&DbKey::UnspentOutput(utxo_hash1.clone())).unwrap(), true);
+        assert_eq!(db.contains(&DbKey::UnspentOutput(utxo_hash2.clone())).unwrap(), false);
+        assert_eq!(db.contains(&DbKey::SpentOutput(utxo_hash1.clone())).unwrap(), false);
+        assert_eq!(db.contains(&DbKey::SpentOutput(utxo_hash2.clone())).unwrap(), false);
         assert_eq!(
-            db.fetch_checkpoint(MmrTree::Utxo, 0).unwrap().nodes_added()[0],
+            db.contains(&DbKey::TransactionKernel(kernel_hash1.clone())).unwrap(),
+            true
+        );
+        assert_eq!(
+            db.contains(&DbKey::TransactionKernel(kernel_hash2.clone())).unwrap(),
+            false
+        );
+        assert_eq!(db.contains(&DbKey::BlockHash(header_hash1.clone())).unwrap(), true);
+        assert_eq!(
+            db.fetch_checkpoint_at_height(MmrTree::Utxo, 0).unwrap().nodes_added()[0],
             utxo_hash1
         );
         assert_eq!(
-            db.fetch_checkpoint(MmrTree::Kernel, 0).unwrap().nodes_added()[0],
+            db.fetch_checkpoint_at_height(MmrTree::Kernel, 0).unwrap().nodes_added()[0],
             kernel_hash1
         );
         assert_eq!(
-            db.fetch_checkpoint(MmrTree::RangeProof, 0).unwrap().nodes_added()[0],
+            db.fetch_checkpoint_at_height(MmrTree::RangeProof, 0)
+                .unwrap()
+                .nodes_added()[0],
             rp_hash1
         );
-        assert!(db.fetch_checkpoint(MmrTree::Utxo, 1).is_err());
-        assert!(db.fetch_checkpoint(MmrTree::Kernel, 1).is_err());
-        assert!(db.fetch_checkpoint(MmrTree::RangeProof, 1).is_err());
+        assert!(db.fetch_checkpoint_at_height(MmrTree::Utxo, 1).is_err());
+        assert!(db.fetch_checkpoint_at_height(MmrTree::Kernel, 1).is_err());
+        assert!(db.fetch_checkpoint_at_height(MmrTree::RangeProof, 1).is_err());
 
         // Reset mmrs as a storage txn failed after the mmr txns were applied, ensure the previous state was preserved.
         let mut txn = DbTransaction::new();
@@ -1155,28 +1172,33 @@ fn lmdb_mmr_reset_and_commit() {
         txn.commit_block();
         assert!(db.write(txn).is_err());
 
-        assert_eq!(db.contains(&DbKey::UnspentOutput(utxo_hash1.clone())), Ok(true));
-        assert_eq!(db.contains(&DbKey::UnspentOutput(utxo_hash2.clone())), Ok(false));
-        assert_eq!(db.contains(&DbKey::SpentOutput(utxo_hash1.clone())), Ok(false));
-        assert_eq!(db.contains(&DbKey::SpentOutput(utxo_hash2)), Ok(false));
-        assert_eq!(db.contains(&DbKey::TransactionKernel(kernel_hash1.clone())), Ok(true));
-        assert_eq!(db.contains(&DbKey::TransactionKernel(kernel_hash2)), Ok(false));
-        assert_eq!(db.contains(&DbKey::BlockHash(header_hash1.clone())), Ok(true));
+        assert_eq!(db.contains(&DbKey::UnspentOutput(utxo_hash1.clone())).unwrap(), true);
+        assert_eq!(db.contains(&DbKey::UnspentOutput(utxo_hash2.clone())).unwrap(), false);
+        assert_eq!(db.contains(&DbKey::SpentOutput(utxo_hash1.clone())).unwrap(), false);
+        assert_eq!(db.contains(&DbKey::SpentOutput(utxo_hash2)).unwrap(), false);
         assert_eq!(
-            db.fetch_checkpoint(MmrTree::Utxo, 0).unwrap().nodes_added()[0],
+            db.contains(&DbKey::TransactionKernel(kernel_hash1.clone())).unwrap(),
+            true
+        );
+        assert_eq!(db.contains(&DbKey::TransactionKernel(kernel_hash2)).unwrap(), false);
+        assert_eq!(db.contains(&DbKey::BlockHash(header_hash1.clone())).unwrap(), true);
+        assert_eq!(
+            db.fetch_checkpoint_at_height(MmrTree::Utxo, 0).unwrap().nodes_added()[0],
             utxo_hash1
         );
         assert_eq!(
-            db.fetch_checkpoint(MmrTree::Kernel, 0).unwrap().nodes_added()[0],
+            db.fetch_checkpoint_at_height(MmrTree::Kernel, 0).unwrap().nodes_added()[0],
             kernel_hash1
         );
         assert_eq!(
-            db.fetch_checkpoint(MmrTree::RangeProof, 0).unwrap().nodes_added()[0],
+            db.fetch_checkpoint_at_height(MmrTree::RangeProof, 0)
+                .unwrap()
+                .nodes_added()[0],
             rp_hash1
         );
-        assert!(db.fetch_checkpoint(MmrTree::Utxo, 1).is_err());
-        assert!(db.fetch_checkpoint(MmrTree::Kernel, 1).is_err());
-        assert!(db.fetch_checkpoint(MmrTree::RangeProof, 1).is_err());
+        assert!(db.fetch_checkpoint_at_height(MmrTree::Utxo, 1).is_err());
+        assert!(db.fetch_checkpoint_at_height(MmrTree::Kernel, 1).is_err());
+        assert!(db.fetch_checkpoint_at_height(MmrTree::RangeProof, 1).is_err());
     }
 
     // Cleanup test data - in Windows the LMBD `set_mapsize` sets file size equals to map size; Linux use sparse files
@@ -1216,12 +1238,12 @@ fn fetch_checkpoint<T: BlockchainBackend>(mut db: T) {
     txn.commit_block();
     assert!(db.write(txn).is_ok());
 
-    let utxo_cp0 = db.fetch_checkpoint(MmrTree::Utxo, 0);
-    let utxo_cp1 = db.fetch_checkpoint(MmrTree::Utxo, 1);
-    let kernel_cp0 = db.fetch_checkpoint(MmrTree::Kernel, 0);
-    let kernel_cp1 = db.fetch_checkpoint(MmrTree::Kernel, 1);
-    let rp_cp0 = db.fetch_checkpoint(MmrTree::RangeProof, 0);
-    let rp_cp1 = db.fetch_checkpoint(MmrTree::RangeProof, 1);
+    let utxo_cp0 = db.fetch_checkpoint_at_height(MmrTree::Utxo, 0);
+    let utxo_cp1 = db.fetch_checkpoint_at_height(MmrTree::Utxo, 1);
+    let kernel_cp0 = db.fetch_checkpoint_at_height(MmrTree::Kernel, 0);
+    let kernel_cp1 = db.fetch_checkpoint_at_height(MmrTree::Kernel, 1);
+    let rp_cp0 = db.fetch_checkpoint_at_height(MmrTree::RangeProof, 0);
+    let rp_cp1 = db.fetch_checkpoint_at_height(MmrTree::RangeProof, 1);
     assert!(utxo_cp0.unwrap().nodes_added().contains(&utxo_hash1));
     assert!(utxo_cp1.unwrap().nodes_added().contains(&utxo_hash2));
     assert!(kernel_cp0.unwrap().nodes_added().contains(&kernel_hash1));
@@ -1251,15 +1273,15 @@ fn fetch_checkpoint<T: BlockchainBackend>(mut db: T) {
     txn.commit_block();
     assert!(db.write(txn).is_ok());
 
-    let utxo_cp0 = db.fetch_checkpoint(MmrTree::Utxo, 0).unwrap();
-    let utxo_cp1 = db.fetch_checkpoint(MmrTree::Utxo, 1).unwrap();
-    let utxo_cp2 = db.fetch_checkpoint(MmrTree::Utxo, 2).unwrap();
-    let kernel_cp0 = db.fetch_checkpoint(MmrTree::Kernel, 0).unwrap();
-    let kernel_cp1 = db.fetch_checkpoint(MmrTree::Kernel, 1).unwrap();
-    let kernel_cp2 = db.fetch_checkpoint(MmrTree::Kernel, 2).unwrap();
-    let rp_cp0 = db.fetch_checkpoint(MmrTree::RangeProof, 0).unwrap();
-    let rp_cp1 = db.fetch_checkpoint(MmrTree::RangeProof, 1).unwrap();
-    let rp_cp2 = db.fetch_checkpoint(MmrTree::RangeProof, 2).unwrap();
+    let utxo_cp0 = db.fetch_checkpoint_at_height(MmrTree::Utxo, 0).unwrap();
+    let utxo_cp1 = db.fetch_checkpoint_at_height(MmrTree::Utxo, 1).unwrap();
+    let utxo_cp2 = db.fetch_checkpoint_at_height(MmrTree::Utxo, 2).unwrap();
+    let kernel_cp0 = db.fetch_checkpoint_at_height(MmrTree::Kernel, 0).unwrap();
+    let kernel_cp1 = db.fetch_checkpoint_at_height(MmrTree::Kernel, 1).unwrap();
+    let kernel_cp2 = db.fetch_checkpoint_at_height(MmrTree::Kernel, 2).unwrap();
+    let rp_cp0 = db.fetch_checkpoint_at_height(MmrTree::RangeProof, 0).unwrap();
+    let rp_cp1 = db.fetch_checkpoint_at_height(MmrTree::RangeProof, 1).unwrap();
+    let rp_cp2 = db.fetch_checkpoint_at_height(MmrTree::RangeProof, 2).unwrap();
     assert!(utxo_cp0.nodes_added().contains(&utxo_hash1));
     assert_eq!(utxo_cp0.accumulated_nodes_added_count(), 1);
     assert!(utxo_cp1.nodes_added().contains(&utxo_hash2));
@@ -1357,18 +1379,18 @@ fn merging_and_fetch_checkpoints_and_stxo_discard<T: BlockchainBackend>(mut db: 
     let mut txn = DbTransaction::new();
     txn.merge_checkpoints(100);
     assert!(db.write(txn).is_ok());
-    let utxo_cp0 = db.fetch_checkpoint(MmrTree::Utxo, 0);
-    let utxo_cp1 = db.fetch_checkpoint(MmrTree::Utxo, 1);
-    let utxo_cp2 = db.fetch_checkpoint(MmrTree::Utxo, 2);
-    let kernel_cp0 = db.fetch_checkpoint(MmrTree::Kernel, 0);
-    let kernel_cp1 = db.fetch_checkpoint(MmrTree::Kernel, 1);
-    let kernel_cp2 = db.fetch_checkpoint(MmrTree::Kernel, 2);
-    let rp_cp0 = db.fetch_checkpoint(MmrTree::RangeProof, 0);
-    let rp_cp1 = db.fetch_checkpoint(MmrTree::RangeProof, 1);
-    let rp_cp2 = db.fetch_checkpoint(MmrTree::RangeProof, 2);
-    assert_eq!(db.contains(&DbKey::SpentOutput(utxo_hash1.clone())), Ok(true));
-    assert_eq!(db.contains(&DbKey::SpentOutput(utxo_hash2.clone())), Ok(true));
-    assert_eq!(db.contains(&DbKey::SpentOutput(utxo_hash3.clone())), Ok(false));
+    let utxo_cp0 = db.fetch_checkpoint_at_height(MmrTree::Utxo, 0);
+    let utxo_cp1 = db.fetch_checkpoint_at_height(MmrTree::Utxo, 1);
+    let utxo_cp2 = db.fetch_checkpoint_at_height(MmrTree::Utxo, 2);
+    let kernel_cp0 = db.fetch_checkpoint_at_height(MmrTree::Kernel, 0);
+    let kernel_cp1 = db.fetch_checkpoint_at_height(MmrTree::Kernel, 1);
+    let kernel_cp2 = db.fetch_checkpoint_at_height(MmrTree::Kernel, 2);
+    let rp_cp0 = db.fetch_checkpoint_at_height(MmrTree::RangeProof, 0);
+    let rp_cp1 = db.fetch_checkpoint_at_height(MmrTree::RangeProof, 1);
+    let rp_cp2 = db.fetch_checkpoint_at_height(MmrTree::RangeProof, 2);
+    assert_eq!(db.contains(&DbKey::SpentOutput(utxo_hash1.clone())).unwrap(), true);
+    assert_eq!(db.contains(&DbKey::SpentOutput(utxo_hash2.clone())).unwrap(), true);
+    assert_eq!(db.contains(&DbKey::SpentOutput(utxo_hash3.clone())).unwrap(), false);
     assert!(utxo_cp0.unwrap().nodes_added().contains(&utxo_hash1));
     assert!(utxo_cp1.unwrap().nodes_added().contains(&utxo_hash2));
     assert!(utxo_cp2.unwrap().nodes_added().contains(&utxo_hash3));
@@ -1382,18 +1404,18 @@ fn merging_and_fetch_checkpoints_and_stxo_discard<T: BlockchainBackend>(mut db: 
     let mut txn = DbTransaction::new();
     txn.merge_checkpoints(2);
     assert!(db.write(txn).is_ok());
-    let utxo_cp0 = db.fetch_checkpoint(MmrTree::Utxo, 0);
-    let utxo_cp1 = db.fetch_checkpoint(MmrTree::Utxo, 1);
-    let utxo_cp2 = db.fetch_checkpoint(MmrTree::Utxo, 2);
-    let kernel_cp0 = db.fetch_checkpoint(MmrTree::Kernel, 0);
-    let kernel_cp1 = db.fetch_checkpoint(MmrTree::Kernel, 1);
-    let kernel_cp2 = db.fetch_checkpoint(MmrTree::Kernel, 2);
-    let rp_cp0 = db.fetch_checkpoint(MmrTree::RangeProof, 0);
-    let rp_cp1 = db.fetch_checkpoint(MmrTree::RangeProof, 1);
-    let rp_cp2 = db.fetch_checkpoint(MmrTree::RangeProof, 2);
-    assert_eq!(db.contains(&DbKey::SpentOutput(utxo_hash1.clone())), Ok(false));
-    assert_eq!(db.contains(&DbKey::SpentOutput(utxo_hash2.clone())), Ok(true));
-    assert_eq!(db.contains(&DbKey::SpentOutput(utxo_hash3.clone())), Ok(false));
+    let utxo_cp0 = db.fetch_checkpoint_at_height(MmrTree::Utxo, 0);
+    let utxo_cp1 = db.fetch_checkpoint_at_height(MmrTree::Utxo, 1);
+    let utxo_cp2 = db.fetch_checkpoint_at_height(MmrTree::Utxo, 2);
+    let kernel_cp0 = db.fetch_checkpoint_at_height(MmrTree::Kernel, 0);
+    let kernel_cp1 = db.fetch_checkpoint_at_height(MmrTree::Kernel, 1);
+    let kernel_cp2 = db.fetch_checkpoint_at_height(MmrTree::Kernel, 2);
+    let rp_cp0 = db.fetch_checkpoint_at_height(MmrTree::RangeProof, 0);
+    let rp_cp1 = db.fetch_checkpoint_at_height(MmrTree::RangeProof, 1);
+    let rp_cp2 = db.fetch_checkpoint_at_height(MmrTree::RangeProof, 2);
+    assert_eq!(db.contains(&DbKey::SpentOutput(utxo_hash1.clone())).unwrap(), false);
+    assert_eq!(db.contains(&DbKey::SpentOutput(utxo_hash2.clone())).unwrap(), true);
+    assert_eq!(db.contains(&DbKey::SpentOutput(utxo_hash3.clone())).unwrap(), false);
     assert!(utxo_cp0.is_err());
     assert!(utxo_cp1.unwrap().nodes_added().contains(&utxo_hash2));
     assert!(utxo_cp2.unwrap().nodes_added().contains(&utxo_hash3));
@@ -1407,18 +1429,18 @@ fn merging_and_fetch_checkpoints_and_stxo_discard<T: BlockchainBackend>(mut db: 
     let mut txn = DbTransaction::new();
     txn.merge_checkpoints(1);
     assert!(db.write(txn).is_ok());
-    let utxo_cp0 = db.fetch_checkpoint(MmrTree::Utxo, 0);
-    let utxo_cp1 = db.fetch_checkpoint(MmrTree::Utxo, 1);
-    let utxo_cp2 = db.fetch_checkpoint(MmrTree::Utxo, 2);
-    let kernel_cp0 = db.fetch_checkpoint(MmrTree::Kernel, 0);
-    let kernel_cp1 = db.fetch_checkpoint(MmrTree::Kernel, 1);
-    let kernel_cp2 = db.fetch_checkpoint(MmrTree::Kernel, 2);
-    let rp_cp0 = db.fetch_checkpoint(MmrTree::RangeProof, 0);
-    let rp_cp1 = db.fetch_checkpoint(MmrTree::RangeProof, 1);
-    let rp_cp2 = db.fetch_checkpoint(MmrTree::RangeProof, 2);
-    assert_eq!(db.contains(&DbKey::SpentOutput(utxo_hash1.clone())), Ok(false));
-    assert_eq!(db.contains(&DbKey::SpentOutput(utxo_hash2.clone())), Ok(false));
-    assert_eq!(db.contains(&DbKey::SpentOutput(utxo_hash3.clone())), Ok(false));
+    let utxo_cp0 = db.fetch_checkpoint_at_height(MmrTree::Utxo, 0);
+    let utxo_cp1 = db.fetch_checkpoint_at_height(MmrTree::Utxo, 1);
+    let utxo_cp2 = db.fetch_checkpoint_at_height(MmrTree::Utxo, 2);
+    let kernel_cp0 = db.fetch_checkpoint_at_height(MmrTree::Kernel, 0);
+    let kernel_cp1 = db.fetch_checkpoint_at_height(MmrTree::Kernel, 1);
+    let kernel_cp2 = db.fetch_checkpoint_at_height(MmrTree::Kernel, 2);
+    let rp_cp0 = db.fetch_checkpoint_at_height(MmrTree::RangeProof, 0);
+    let rp_cp1 = db.fetch_checkpoint_at_height(MmrTree::RangeProof, 1);
+    let rp_cp2 = db.fetch_checkpoint_at_height(MmrTree::RangeProof, 2);
+    assert_eq!(db.contains(&DbKey::SpentOutput(utxo_hash1.clone())).unwrap(), false);
+    assert_eq!(db.contains(&DbKey::SpentOutput(utxo_hash2.clone())).unwrap(), false);
+    assert_eq!(db.contains(&DbKey::SpentOutput(utxo_hash3.clone())).unwrap(), false);
     assert!(utxo_cp0.is_err());
     assert!(utxo_cp1.is_err());
     assert!(utxo_cp2.unwrap().nodes_added().contains(&utxo_hash3));
@@ -1464,7 +1486,7 @@ fn duplicate_utxo<T: BlockchainBackend>(mut db: T) {
     let mut txn = DbTransaction::new();
     txn.insert_utxo_with_hash(hash1.clone(), utxo1.clone());
     assert!(db.write(txn).is_ok());
-    assert_eq!(db.contains(&DbKey::UnspentOutput(hash1.clone())), Ok(true));
+    assert_eq!(db.contains(&DbKey::UnspentOutput(hash1.clone())).unwrap(), true);
     if let Some(DbValue::UnspentOutput(retrieved_utxo)) = db.fetch(&DbKey::UnspentOutput(hash1.clone())).unwrap() {
         assert_eq!(*retrieved_utxo, utxo1);
     } else {
@@ -1510,18 +1532,18 @@ fn fetch_last_header<T: BlockchainBackend>(mut db: T) {
     header1.height = 1;
     let mut header2 = BlockHeader::new(0);
     header2.height = 2;
-    assert_eq!(db.fetch_last_header(), Ok(None));
+    assert_eq!(db.fetch_last_header().unwrap(), None);
 
     let mut txn = DbTransaction::new();
     txn.insert_header(header0);
     txn.insert_header(header1.clone());
     assert!(db.write(txn).is_ok());
-    assert_eq!(db.fetch_last_header(), Ok(Some(header1)));
+    assert_eq!(db.fetch_last_header().unwrap(), Some(header1));
 
     let mut txn = DbTransaction::new();
     txn.insert_header(header2.clone());
     assert!(db.write(txn).is_ok());
-    assert_eq!(db.fetch_last_header(), Ok(Some(header2)));
+    assert_eq!(db.fetch_last_header().unwrap(), Some(header2));
 }
 
 #[test]
@@ -1588,16 +1610,18 @@ fn fetch_target_difficulties<T: BlockchainBackend>(mut db: T) {
         (header3.timestamp, header3.pow.target_difficulty),
     ];
     assert_eq!(
-        db.fetch_target_difficulties(PowAlgorithm::Blake, header4.height, 2),
-        Ok(desired_targets)
+        db.fetch_target_difficulties(PowAlgorithm::Blake, header4.height, 2)
+            .unwrap(),
+        desired_targets
     );
     let desired_targets: Vec<(EpochTime, Difficulty)> = vec![
         (header1.timestamp, header1.pow.target_difficulty),
         (header4.timestamp, header4.pow.target_difficulty),
     ];
     assert_eq!(
-        db.fetch_target_difficulties(PowAlgorithm::Monero, header4.height, 2),
-        Ok(desired_targets)
+        db.fetch_target_difficulties(PowAlgorithm::Monero, header4.height, 2)
+            .unwrap(),
+        desired_targets
     );
     // Check search from tip to genesis block
     let desired_targets: Vec<(EpochTime, Difficulty)> = vec![
@@ -1607,16 +1631,18 @@ fn fetch_target_difficulties<T: BlockchainBackend>(mut db: T) {
         (header5.timestamp, header5.pow.target_difficulty),
     ];
     assert_eq!(
-        db.fetch_target_difficulties(PowAlgorithm::Blake, header5.height, 100),
-        Ok(desired_targets)
+        db.fetch_target_difficulties(PowAlgorithm::Blake, header5.height, 100)
+            .unwrap(),
+        desired_targets
     );
     let desired_targets: Vec<(EpochTime, Difficulty)> = vec![
         (header1.timestamp, header1.pow.target_difficulty),
         (header4.timestamp, header4.pow.target_difficulty),
     ];
     assert_eq!(
-        db.fetch_target_difficulties(PowAlgorithm::Monero, header5.height, 100),
-        Ok(desired_targets)
+        db.fetch_target_difficulties(PowAlgorithm::Monero, header5.height, 100)
+            .unwrap(),
+        desired_targets
     );
 }
 

--- a/base_layer/core/tests/helpers/chain_metadata.rs
+++ b/base_layer/core/tests/helpers/chain_metadata.rs
@@ -69,6 +69,6 @@ pub fn random_peer_metadata(height: u64, difficulty: Difficulty) -> PeerChainMet
     let key: Vec<u8> = (0..13).map(|_| rand::random::<u8>()).collect();
     let id = NodeId::from_key(&key).unwrap();
     let block_hash = Blake256::digest(id.as_bytes()).to_vec();
-    let metadata = ChainMetadata::new(height, block_hash, 2800, difficulty);
+    let metadata = ChainMetadata::new(height, block_hash, 2800, 0, difficulty);
     PeerChainMetadata::new(id, metadata)
 }

--- a/base_layer/core/tests/helpers/pow_blockchain.rs
+++ b/base_layer/core/tests/helpers/pow_blockchain.rs
@@ -65,7 +65,7 @@ pub fn append_to_pow_blockchain<T: BlockchainBackend>(
             .increase(constants.get_target_block_interval());
         new_block.header.pow.pow_algo = pow_algo;
 
-        let height = db.get_metadata().unwrap().height_of_longest_chain.unwrap();
+        let height = db.get_chain_metadata().unwrap().height_of_longest_chain.unwrap();
         let target_difficulties = db
             .fetch_target_difficulties(pow_algo, height, constants.get_difficulty_block_window() as usize)
             .unwrap();

--- a/base_layer/core/tests/median_timestamp.rs
+++ b/base_layer/core/tests/median_timestamp.rs
@@ -92,7 +92,7 @@ fn test_median_timestamp_odd_order() {
     let pow_algos = vec![PowAlgorithm::Blake]; // GB default
     create_test_pow_blockchain(&store, pow_algos, &consensus_manager);
     let mut timestamps = vec![store.fetch_block(0).unwrap().block().header.timestamp.clone()];
-    let height = store.get_metadata().unwrap().height_of_longest_chain.unwrap();
+    let height = store.get_chain_metadata().unwrap().height_of_longest_chain.unwrap();
     let mut median_timestamp = get_median_timestamp(get_header_timestamps(
         &*store.db_read_access().unwrap(),
         height,
@@ -105,7 +105,7 @@ fn test_median_timestamp_odd_order() {
     let tip = store.fetch_block(store.get_height().unwrap().unwrap()).unwrap().block;
     append_to_pow_blockchain(&store, tip, pow_algos.clone(), &consensus_manager);
     timestamps.push(timestamps[0].increase(consensus_manager.consensus_constants().get_target_block_interval()));
-    let height = store.get_metadata().unwrap().height_of_longest_chain.unwrap();
+    let height = store.get_chain_metadata().unwrap().height_of_longest_chain.unwrap();
     median_timestamp = get_median_timestamp(get_header_timestamps(
         &*store.db_read_access().unwrap(),
         height,
@@ -125,7 +125,7 @@ fn test_median_timestamp_odd_order() {
     store.add_block(new_block).unwrap();
 
     timestamps.push(timestamps[2].increase(consensus_manager.consensus_constants().get_target_block_interval() / 2));
-    let height = store.get_metadata().unwrap().height_of_longest_chain.unwrap();
+    let height = store.get_chain_metadata().unwrap().height_of_longest_chain.unwrap();
     median_timestamp = get_median_timestamp(get_header_timestamps(
         &*store.db_read_access().unwrap(),
         height,

--- a/base_layer/core/tests/mempool.rs
+++ b/base_layer/core/tests/mempool.rs
@@ -739,7 +739,6 @@ fn block_event_and_reorg_event_handling() {
     let network = Network::LocalNet;
     let consensus_constants = network.create_consensus_constants();
 
-    let runtime = tokio::runtime::Builder::new().enable_time().build().unwrap();
     let mut runtime = Runtime::new().unwrap();
     let temp_dir = tempdir().unwrap();
     let (block0, utxos0) =

--- a/base_layer/core/tests/node_comms_interface.rs
+++ b/base_layer/core/tests/node_comms_interface.rs
@@ -88,7 +88,7 @@ fn outbound_get_metadata() {
     let mut outbound_nci = OutboundNodeCommsInterface::new(request_sender, block_sender);
 
     block_on(async {
-        let metadata = ChainMetadata::new(5, vec![0u8], 3, 5.into());
+        let metadata = ChainMetadata::new(5, vec![0u8], 3, 0, 5.into());
         let metadata_response = NodeCommsResponse::ChainMetadata(metadata.clone());
         let (received_metadata, _) = futures::join!(
             outbound_nci.get_metadata(),

--- a/base_layer/core/tests/node_service.rs
+++ b/base_layer/core/tests/node_service.rs
@@ -710,12 +710,7 @@ fn service_request_timeout() {
     runtime.block_on(async {
         // Bob should not be reachable
         bob_node.comms.shutdown().await;
-
-        assert_eq!(
-            alice_node.outbound_nci.get_metadata().await,
-            Err(CommsInterfaceError::RequestTimedOut)
-        );
-
+        unpack_enum!(CommsInterfaceError::RequestTimedOut = alice_node.outbound_nci.get_metadata().await.unwrap_err());
         alice_node.comms.shutdown().await;
     });
 }
@@ -795,7 +790,7 @@ fn local_get_target_difficulty() {
 
     let db = &node.blockchain_db;
     let block0 = db.fetch_block(0).unwrap().block().clone();
-    assert_eq!(node.blockchain_db.get_height(), Ok(Some(0)));
+    assert_eq!(node.blockchain_db.get_height().unwrap(), Some(0));
 
     runtime.block_on(async {
         let monero_target_difficulty1 = node
@@ -815,7 +810,7 @@ fn local_get_target_difficulty() {
             .increase(consensus_manager.consensus_constants().get_target_block_interval());
         block1.header.pow.pow_algo = PowAlgorithm::Blake;
         node.blockchain_db.add_block(block1).unwrap();
-        assert_eq!(node.blockchain_db.get_height(), Ok(Some(1)));
+        assert_eq!(node.blockchain_db.get_height().unwrap(), Some(1));
         let monero_target_difficulty2 = node
             .local_nci
             .get_target_difficulty(PowAlgorithm::Monero)

--- a/base_layer/core/tests/regression_tests.rs
+++ b/base_layer/core/tests/regression_tests.rs
@@ -28,7 +28,6 @@ use tari_core::{
     transactions::types::CryptoFactories,
     validation::{block_validators::StatelessBlockValidator, StatelessValidation},
 };
-use tari_crypto::range_proof::RangeProofService;
 
 /// Commit df95cee73812689bbae77bfb547c1d73a49635d4 introduced a bug in Windows builds that resulted in Block 9182
 /// failing validation tests. This test checks to see that this issue has been resolved.

--- a/base_layer/core/tests/target_difficulty.rs
+++ b/base_layer/core/tests/target_difficulty.rs
@@ -53,7 +53,7 @@ fn test_target_difficulty_at_tip() {
         PowAlgorithm::Blake,
     ];
     create_test_pow_blockchain(&store, pow_algos.clone(), &consensus_manager);
-    let height = store.get_metadata().unwrap().height_of_longest_chain.unwrap();
+    let height = store.get_chain_metadata().unwrap().height_of_longest_chain.unwrap();
 
     let pow_algo = PowAlgorithm::Monero;
     let target_difficulties = store.fetch_target_difficulties(pow_algo, height, block_window).unwrap();
@@ -64,13 +64,9 @@ fn test_target_difficulty_at_tip() {
             target_time,
             constants.min_pow_difficulty(pow_algo),
             max_block_time
-        ),
-        Ok(calculate_accumulated_difficulty(
-            &store,
-            pow_algo,
-            vec![2, 5, 6, 8],
-            &constants
-        ))
+        )
+        .unwrap(),
+        calculate_accumulated_difficulty(&store, pow_algo, vec![2, 5, 6, 8], &constants)
     );
 
     let pow_algo = PowAlgorithm::Blake;
@@ -82,13 +78,9 @@ fn test_target_difficulty_at_tip() {
             target_time,
             constants.min_pow_difficulty(pow_algo),
             max_block_time
-        ),
-        Ok(calculate_accumulated_difficulty(
-            &store,
-            pow_algo,
-            vec![0, 1, 3, 4, 7, 9],
-            &constants
-        ))
+        )
+        .unwrap(),
+        calculate_accumulated_difficulty(&store, pow_algo, vec![0, 1, 3, 4, 7, 9], &constants)
     );
 }
 
@@ -120,13 +112,9 @@ fn test_target_difficulty_with_height() {
             target_time,
             constants.min_pow_difficulty(pow_algo),
             max_block_time
-        ),
-        Ok(calculate_accumulated_difficulty(
-            &store,
-            pow_algo,
-            vec![1, 4],
-            &constants
-        ))
+        )
+        .unwrap(),
+        calculate_accumulated_difficulty(&store, pow_algo, vec![1, 4], &constants)
     );
 
     let pow_algo = PowAlgorithm::Blake;
@@ -137,13 +125,9 @@ fn test_target_difficulty_with_height() {
             target_time,
             constants.min_pow_difficulty(pow_algo),
             max_block_time
-        ),
-        Ok(calculate_accumulated_difficulty(
-            &store,
-            pow_algo,
-            vec![0, 2, 3, 5],
-            &constants
-        ))
+        )
+        .unwrap(),
+        calculate_accumulated_difficulty(&store, pow_algo, vec![0, 2, 3, 5], &constants)
     );
 
     let pow_algo = PowAlgorithm::Monero;
@@ -154,8 +138,9 @@ fn test_target_difficulty_with_height() {
             target_time,
             constants.min_pow_difficulty(pow_algo),
             max_block_time
-        ),
-        Ok(calculate_accumulated_difficulty(&store, pow_algo, vec![1], &constants))
+        )
+        .unwrap(),
+        calculate_accumulated_difficulty(&store, pow_algo, vec![1], &constants)
     );
 
     let pow_algo = PowAlgorithm::Blake;
@@ -166,13 +151,9 @@ fn test_target_difficulty_with_height() {
             target_time,
             constants.min_pow_difficulty(pow_algo),
             max_block_time
-        ),
-        Ok(calculate_accumulated_difficulty(
-            &store,
-            pow_algo,
-            vec![0, 2],
-            &constants
-        ))
+        )
+        .unwrap(),
+        calculate_accumulated_difficulty(&store, pow_algo, vec![0, 2], &constants)
     );
     let pow_algo = PowAlgorithm::Monero;
     assert_eq!(
@@ -182,8 +163,9 @@ fn test_target_difficulty_with_height() {
             target_time,
             constants.min_pow_difficulty(pow_algo),
             max_block_time
-        ),
-        Ok(calculate_accumulated_difficulty(&store, pow_algo, vec![1], &constants))
+        )
+        .unwrap(),
+        calculate_accumulated_difficulty(&store, pow_algo, vec![1], &constants)
     );
 
     let pow_algo = PowAlgorithm::Blake;
@@ -194,12 +176,8 @@ fn test_target_difficulty_with_height() {
             target_time,
             constants.min_pow_difficulty(pow_algo),
             max_block_time
-        ),
-        Ok(calculate_accumulated_difficulty(
-            &store,
-            pow_algo,
-            vec![0, 2, 3],
-            &constants
-        ))
+        )
+        .unwrap(),
+        calculate_accumulated_difficulty(&store, pow_algo, vec![0, 2, 3], &constants)
     );
 }

--- a/base_layer/mmr/src/merkle_checkpoint.rs
+++ b/base_layer/mmr/src/merkle_checkpoint.rs
@@ -117,6 +117,16 @@ impl MerkleCheckPoint {
     }
 }
 
+impl Default for MerkleCheckPoint {
+    fn default() -> Self {
+        Self {
+            nodes_added: Default::default(),
+            nodes_deleted: Bitmap::create(),
+            prev_accumulated_nodes_added_count: Default::default(),
+        }
+    }
+}
+
 impl Eq for MerkleCheckPoint {}
 
 #[allow(clippy::derive_hash_xor_eq)]

--- a/base_layer/wallet/tests/transaction_service/service.rs
+++ b/base_layer/wallet/tests/transaction_service/service.rs
@@ -3467,6 +3467,7 @@ fn test_handling_coinbase_transactions() {
             best_block: None,
             pruning_horizon: 0,
             accumulated_difficulty: None,
+            effective_pruned_height: 0,
         })),
     };
     runtime
@@ -3552,6 +3553,7 @@ fn test_handling_coinbase_transactions() {
             best_block: None,
             pruning_horizon: 0,
             accumulated_difficulty: None,
+            effective_pruned_height: 0,
         })),
     };
     runtime


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR adds an `EffectivePrunedHeight` chain metadata entry and
`InProgressPrunedSyncState` metadata item to the blockchain db.
`InProgressPrunedSyncState` is constructed and persisted once pruned sync
starts and is used to keep track of the start index of "temporary"
checkpoints created during sync.

If a horizon state validation error occurs the sync data is rolled back
by fetching each temporary checkpoint and reversing the operations and
deleting the checkpoints. A bit more intelligence can be added here depending 
on the kind of validation failure, certain state could not be rolled back and therefore 
not need to be redownloaded. 

If horizon sync is interrupted, the state is loaded again and the sync is resumed.
_EDIT: If a request times out, or some other non-validation
failure occurs the sync state is kept and the sync is resumed later ( WAITING>LISTENING>HEADER_SYNC>HORIZON_SYNC)_ 

Once the sync is complete, the InProgressPrunedSyncState is deleted and
the chain metadata updated accordingly.

Other changes:

- Sync peers now contains each peer's chain metadata so that an appropriate
  peer can be selected for block sync i.e. a peer with an effective
  pruned height lower than the syncing nodes current height.
- Header sync does not reset the chain metadata to genesis anymore as a
  that should be in pruned sync.
- Prefixed all database functions that ony are applicable for horizon
  sync with `horizon_sync_` to indicate that they are specialized and
  shouldn't used in other areas of the system at this time.
- DRY'd up all the checkpoint "utility" functions. It is no longer
  required to maintain separate functions for lmdb and memorydb.
- Removed `n` clones when storing a block
- Added `set_metadata` and `delete_metadata` convenience calls to
  `DbTransaction`
- Optimised chain balance validation to not have to hold every
  kernel/UTXO in memory while summing commitments.
- A few error improvements and migration to `thiserror`
- New basic test for horizon sync rollback

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Previously, if a horizon state validation error occurs the database needed to be deleted to recover. This PR adds some simple metadata to allow the database to rollback in this case.  

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Added new test for behaviour when validation fails. Admittedly, this test is a little simple and more effort needs to be put into testing. A few scenarios were tested on a 2 node network and current testnet:

1. Sync from 0 to tip
1. Interrupt sync and test that it resumes on restart
1. Artificially fail validation and test that the sync rolls back, resyncs, fails, rollsback. Allow validation to succeed, and check that sync succeeds
1. Set a large pruned height, sync until block sync has started - stop the base node, set a small pruned height - begin horizon sync and check that it succeeds without redownloading state that was obtained during block sync.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [x] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [x] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch.
* [x] I ran `cargo-fmt --all` before pushing.
* [x] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
