### PR TITLE
Migrate to thiserror and remove dep on derive-error

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -156,7 +156,7 @@ checksum = "25f9db3b38af870bf7e5cc649167533b493928e50744e2c30ae350230b414670"
 dependencies = [
  "proc-macro2 1.0.19",
  "quote 1.0.7",
- "syn 1.0.36",
+ "syn 1.0.38",
 ]
 
 [[package]]
@@ -167,7 +167,7 @@ checksum = "a265e3abeffdce30b2e26b7a11b222fe37c6067404001b434101457d0385eb92"
 dependencies = [
  "proc-macro2 1.0.19",
  "quote 1.0.7",
- "syn 1.0.36",
+ "syn 1.0.38",
 ]
 
 [[package]]
@@ -561,9 +561,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "2.33.1"
+version = "2.33.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bdfa80d47f954d53a35a64987ca1422f495b8d6483c0fe9f7117b36c2a792129"
+checksum = "10040cdf04294b565d9e0319955430099ec3813a64c952b86a41200ad714ae48"
 dependencies = [
  "ansi_term",
  "atty",
@@ -912,7 +912,7 @@ dependencies = [
  "proc-macro2 1.0.19",
  "quote 1.0.7",
  "strsim 0.9.3",
- "syn 1.0.36",
+ "syn 1.0.38",
 ]
 
 [[package]]
@@ -923,7 +923,7 @@ checksum = "d9b5a2f4ac4969822c62224815d069952656cadc7084fdca9751e6d959189b72"
 dependencies = [
  "darling_core",
  "quote 1.0.7",
- "syn 1.0.36",
+ "syn 1.0.38",
 ]
 
 [[package]]
@@ -968,7 +968,7 @@ checksum = "45f5098f628d02a7a0f68ddba586fb61e80edec3bdc1be3b921f4ceec60858d3"
 dependencies = [
  "proc-macro2 1.0.19",
  "quote 1.0.7",
- "syn 1.0.36",
+ "syn 1.0.38",
 ]
 
 [[package]]
@@ -1079,7 +1079,7 @@ checksum = "e57001dfb2532f5a103ff869656887fae9a8defa7d236f3e39d2ee86ed629ad7"
 dependencies = [
  "proc-macro2 1.0.19",
  "quote 1.0.7",
- "syn 1.0.36",
+ "syn 1.0.38",
 ]
 
 [[package]]
@@ -1110,7 +1110,7 @@ dependencies = [
  "darling",
  "proc-macro2 1.0.19",
  "quote 1.0.7",
- "syn 1.0.36",
+ "syn 1.0.38",
 ]
 
 [[package]]
@@ -1193,7 +1193,7 @@ checksum = "aa4da3c766cd7a0db8242e326e9e4e081edd567072893ed320008189715366a4"
 dependencies = [
  "proc-macro2 1.0.19",
  "quote 1.0.7",
- "syn 1.0.36",
+ "syn 1.0.38",
  "synstructure",
 ]
 
@@ -1381,7 +1381,7 @@ dependencies = [
  "proc-macro-hack",
  "proc-macro2 1.0.19",
  "quote 1.0.7",
- "syn 1.0.36",
+ "syn 1.0.38",
 ]
 
 [[package]]
@@ -2123,7 +2123,7 @@ dependencies = [
  "migrations_internals",
  "proc-macro2 1.0.19",
  "quote 1.0.7",
- "syn 1.0.36",
+ "syn 1.0.38",
 ]
 
 [[package]]
@@ -2640,7 +2640,7 @@ checksum = "2c0e815c3ee9a031fdf5af21c10aa17c573c9c6a566328d99e3936c34e36461f"
 dependencies = [
  "proc-macro2 1.0.19",
  "quote 1.0.7",
- "syn 1.0.36",
+ "syn 1.0.38",
 ]
 
 [[package]]
@@ -2699,32 +2699,30 @@ checksum = "83ef7b3b965c0eadcb6838f34f827e1dfb2939bdd5ebd43f9647e009b12b0371"
 dependencies = [
  "fixed-hash 0.4.0",
  "impl-codec",
- "uint 0.8.3",
+ "uint 0.8.4",
 ]
 
 [[package]]
 name = "proc-macro-error"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc175e9777c3116627248584e8f8b3e2987405cabe1c0adf7d1dd28f09dc7880"
+checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
 dependencies = [
  "proc-macro-error-attr",
  "proc-macro2 1.0.19",
  "quote 1.0.7",
- "syn 1.0.36",
+ "syn 1.0.38",
  "version_check 0.9.2",
 ]
 
 [[package]]
 name = "proc-macro-error-attr"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3cc9795ca17eb581285ec44936da7fc2335a3f34f2ddd13118b6f4d515435c50"
+checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
 dependencies = [
  "proc-macro2 1.0.19",
  "quote 1.0.7",
- "syn 1.0.36",
- "syn-mid",
  "version_check 0.9.2",
 ]
 
@@ -2796,7 +2794,7 @@ dependencies = [
  "itertools",
  "proc-macro2 1.0.19",
  "quote 1.0.7",
- "syn 1.0.36",
+ "syn 1.0.38",
 ]
 
 [[package]]
@@ -3162,7 +3160,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "54a50e29610a5be68d4a586a5cce3bfb572ed2c2a74227e4168444b7bf4e5235"
 dependencies = [
  "quote 1.0.7",
- "syn 1.0.36",
+ "syn 1.0.38",
 ]
 
 [[package]]
@@ -3279,7 +3277,7 @@ checksum = "2a0be94b04690fbaed37cddffc5c134bf537c8e3329d53e982fe04c374978f8e"
 dependencies = [
  "proc-macro2 1.0.19",
  "quote 1.0.7",
- "syn 1.0.36",
+ "syn 1.0.38",
 ]
 
 [[package]]
@@ -3301,7 +3299,7 @@ checksum = "2dc6b7951b17b051f3210b063f12cc17320e2fe30ae05b0fe2a3abb068551c76"
 dependencies = [
  "proc-macro2 1.0.19",
  "quote 1.0.7",
- "syn 1.0.36",
+ "syn 1.0.38",
 ]
 
 [[package]]
@@ -3381,9 +3379,9 @@ dependencies = [
 
 [[package]]
 name = "signal-hook-registry"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94f478ede9f64724c5d173d7bb56099ec3e2d9fc2774aac65d34b8b890405f41"
+checksum = "a3e12110bc539e657a646068aaf5eb5b63af9d0c1f7b29c97113fad80e15f035"
 dependencies = [
  "arc-swap 0.4.7",
  "libc",
@@ -3471,9 +3469,9 @@ checksum = "6446ced80d6c486436db5c078dde11a9f73d42b57fb273121e160b84f63d894c"
 
 [[package]]
 name = "structopt"
-version = "0.3.15"
+version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de2f5e239ee807089b62adce73e48c625e0ed80df02c7ab3f068f5db5281065c"
+checksum = "de5472fb24d7e80ae84a7801b7978f95a19ec32cb1876faea59ab711eb901976"
 dependencies = [
  "clap",
  "lazy_static 1.4.0",
@@ -3482,15 +3480,15 @@ dependencies = [
 
 [[package]]
 name = "structopt-derive"
-version = "0.4.8"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "510413f9de616762a4fbeab62509bf15c729603b72d7cd71280fbca431b1c118"
+checksum = "1e0eb37335aeeebe51be42e2dc07f031163fbabfa6ac67d7ea68b5c2f68d5f99"
 dependencies = [
  "heck",
  "proc-macro-error",
  "proc-macro2 1.0.19",
  "quote 1.0.7",
- "syn 1.0.36",
+ "syn 1.0.38",
 ]
 
 [[package]]
@@ -3514,7 +3512,7 @@ dependencies = [
  "heck",
  "proc-macro2 1.0.19",
  "quote 1.0.7",
- "syn 1.0.36",
+ "syn 1.0.38",
 ]
 
 [[package]]
@@ -3526,7 +3524,7 @@ dependencies = [
  "heck",
  "proc-macro2 1.0.19",
  "quote 1.0.7",
- "syn 1.0.36",
+ "syn 1.0.38",
 ]
 
 [[package]]
@@ -3571,24 +3569,13 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.36"
+version = "1.0.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cdb98bcb1f9d81d07b536179c269ea15999b5d14ea958196413869445bb5250"
+checksum = "e69abc24912995b3038597a7a593be5053eb0fb44f3cc5beec0deb421790c1f4"
 dependencies = [
  "proc-macro2 1.0.19",
  "quote 1.0.7",
  "unicode-xid 0.2.1",
-]
-
-[[package]]
-name = "syn-mid"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7be3539f6c128a931cf19dcee741c1af532c7fd387baa739c03dd2e96479338a"
-dependencies = [
- "proc-macro2 1.0.19",
- "quote 1.0.7",
- "syn 1.0.36",
 ]
 
 [[package]]
@@ -3608,7 +3595,7 @@ checksum = "b834f2d66f734cb897113e34aaff2f1ab4719ca946f9a7358dba8f8064148701"
 dependencies = [
  "proc-macro2 1.0.19",
  "quote 1.0.7",
- "syn 1.0.36",
+ "syn 1.0.38",
  "unicode-xid 0.2.1",
 ]
 
@@ -3855,7 +3842,6 @@ dependencies = [
  "config",
  "croaring",
  "crossbeam-channel",
- "derive-error",
  "digest",
  "env_logger 0.7.1",
  "futures 0.3.5",
@@ -3895,7 +3881,7 @@ dependencies = [
  "tokio-test",
  "tower-service",
  "ttl_cache",
- "uint 0.8.3",
+ "uint 0.8.4",
 ]
 
 [[package]]
@@ -3935,7 +3921,6 @@ dependencies = [
 name = "tari_key_manager"
 version = "0.2.0"
 dependencies = [
- "derive-error",
  "digest",
  "rand 0.7.3",
  "serde 1.0.114",
@@ -3943,6 +3928,7 @@ dependencies = [
  "serde_json",
  "sha2",
  "tari_crypto",
+ "thiserror",
 ]
 
 [[package]]
@@ -3953,7 +3939,6 @@ dependencies = [
  "blake2",
  "criterion",
  "croaring",
- "derive-error",
  "digest",
  "log 0.4.11",
  "rand 0.7.3",
@@ -3962,6 +3947,7 @@ dependencies = [
  "tari_crypto",
  "tari_infra_derive",
  "tari_utilities 0.2.0",
+ "thiserror",
 ]
 
 [[package]]
@@ -3973,7 +3959,6 @@ dependencies = [
  "clap",
  "crossbeam-channel",
  "cursive",
- "derive-error",
  "env_logger 0.6.2",
  "futures 0.3.5",
  "futures-test-preview",
@@ -3998,6 +3983,7 @@ dependencies = [
  "tari_test_utils",
  "tari_utilities 0.2.0",
  "tempfile",
+ "thiserror",
  "tokio",
  "tokio-macros",
  "tower",
@@ -4008,12 +3994,12 @@ dependencies = [
 name = "tari_service_framework"
 version = "0.0.10"
 dependencies = [
- "derive-error",
  "futures 0.3.5",
  "futures-test",
  "log 0.4.11",
  "tari_shutdown",
  "tari_test_utils",
+ "thiserror",
  "tokio",
  "tower",
  "tower-service",
@@ -4033,7 +4019,6 @@ version = "0.2.0"
 dependencies = [
  "bincode",
  "bytes 0.4.12",
- "derive-error",
  "env_logger 0.6.2",
  "lmdb-zero",
  "log 0.4.11",
@@ -4103,7 +4088,6 @@ dependencies = [
  "blake2",
  "chrono",
  "crossbeam-channel",
- "derive-error",
  "diesel",
  "diesel_migrations",
  "digest",
@@ -4128,6 +4112,7 @@ dependencies = [
  "tari_storage",
  "tari_test_utils",
  "tempfile",
+ "thiserror",
  "time",
  "tokio",
  "tokio-macros",
@@ -4139,7 +4124,6 @@ name = "tari_wallet_ffi"
 version = "0.2.0"
 dependencies = [
  "chrono",
- "derive-error",
  "env_logger 0.7.1",
  "futures 0.3.5",
  "lazy_static 1.4.0",
@@ -4157,6 +4141,7 @@ dependencies = [
  "tari_utilities 0.2.0",
  "tari_wallet",
  "tempfile",
+ "thiserror",
  "tokio",
 ]
 
@@ -4242,7 +4227,7 @@ checksum = "bd80fc12f73063ac132ac92aceea36734f04a1d93c1240c6944e23a3b8841793"
 dependencies = [
  "proc-macro2 1.0.19",
  "quote 1.0.7",
- "syn 1.0.36",
+ "syn 1.0.38",
 ]
 
 [[package]]
@@ -4331,7 +4316,7 @@ checksum = "f0c3acc6aa564495a0f2e1d59fab677cd7f81a19994cfc7f3ad0e64301560389"
 dependencies = [
  "proc-macro2 1.0.19",
  "quote 1.0.7",
- "syn 1.0.36",
+ "syn 1.0.38",
 ]
 
 [[package]]
@@ -4430,7 +4415,7 @@ dependencies = [
  "proc-macro2 1.0.19",
  "prost-build",
  "quote 1.0.7",
- "syn 1.0.36",
+ "syn 1.0.38",
 ]
 
 [[package]]
@@ -4627,9 +4612,9 @@ dependencies = [
 
 [[package]]
 name = "tracing"
-version = "0.1.17"
+version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbdf4ccd1652592b01286a5dbe1e2a77d78afaa34beadd9872a5f7396f92aaa9"
+checksum = "f0aae59226cf195d8e74d4b34beae1859257efb4e5fed3f147d2dc2c7d372178"
 dependencies = [
  "cfg-if",
  "log 0.4.11",
@@ -4645,14 +4630,14 @@ checksum = "f0693bf8d6f2bf22c690fc61a9d21ac69efdbb894a17ed596b9af0f01e64b84b"
 dependencies = [
  "proc-macro2 1.0.19",
  "quote 1.0.7",
- "syn 1.0.36",
+ "syn 1.0.38",
 ]
 
 [[package]]
 name = "tracing-core"
-version = "0.1.11"
+version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94ae75f0d28ae10786f3b1895c55fe72e79928fd5ccdebb5438c75e93fec178f"
+checksum = "d593f98af59ebc017c0648f0117525db358745a8894a8d684e185ba3f45954f9"
 dependencies = [
  "lazy_static 1.4.0",
 ]
@@ -4736,9 +4721,9 @@ dependencies = [
 
 [[package]]
 name = "uint"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "173cd16430c206dc1a430af8a89a0e9c076cf15cb42b4aedb10e8cc8fee73681"
+checksum = "429ffcad8c8c15f874578c7337d156a3727eb4a1c2374c0ae937ad9a9b748c80"
 dependencies = [
  "byteorder",
  "crunchy 0.2.2",
@@ -5032,6 +5017,6 @@ checksum = "de251eec69fc7c1bc3923403d18ececb929380e016afe103da75f396704f8ca2"
 dependencies = [
  "proc-macro2 1.0.19",
  "quote 1.0.7",
- "syn 1.0.36",
+ "syn 1.0.38",
  "synstructure",
 ]

--- a/base_layer/core/Cargo.toml
+++ b/base_layer/core/Cargo.toml
@@ -35,8 +35,7 @@ monero = { version = "0.8.1", features= ["serde_support"], optional = true }
 bitflags = "1.0.4"
 chrono = { version = "0.4.6", features = ["serde"]}
 digest = "0.8.0"
-derive-error = "0.0.4"
-thiserror = "1.0.15"
+thiserror = "1.0.20"
 rand = "0.7.2"
 serde = { version = "1.0.106", features = ["derive"] }
 rmp-serde = "0.13.7"

--- a/base_layer/core/src/base_node/service/error.rs
+++ b/base_layer/core/src/base_node/service/error.rs
@@ -21,15 +21,17 @@
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 use crate::base_node::comms_interface::CommsInterfaceError;
-use derive_error::Error;
 use tari_comms_dht::outbound::DhtOutboundError;
+use thiserror::Error;
 
 #[derive(Debug, Error)]
 pub enum BaseNodeServiceError {
-    CommsInterfaceError(CommsInterfaceError),
-    DhtOutboundError(DhtOutboundError),
-    #[error(msg_embedded, no_from, non_std)]
+    #[error("Comms interface error: `{0}`")]
+    CommsInterfaceError(#[from] CommsInterfaceError),
+    #[error("DHT outbound error: `{0}`")]
+    DhtOutboundError(#[from] DhtOutboundError),
+    #[error("Invalid request error: `{0}`")]
     InvalidRequest(String),
-    #[error(msg_embedded, no_from, non_std)]
+    #[error("Invalid response error: `{0}`")]
     InvalidResponse(String),
 }

--- a/base_layer/core/src/base_node/states/block_sync.rs
+++ b/base_layer/core/src/base_node/states/block_sync.rs
@@ -37,7 +37,6 @@ use crate::{
     chain_storage::{async_db, BlockchainBackend, ChainMetadata, ChainStorageError},
 };
 use core::cmp::min;
-use derive_error::Error;
 use log::*;
 use std::{
     fmt::{Display, Formatter},
@@ -45,6 +44,7 @@ use std::{
 };
 use tari_comms::{connectivity::ConnectivityError, peer_manager::PeerManagerError};
 use tari_crypto::tari_utilities::{hex::Hex, Hashable};
+use thiserror::Error;
 
 const LOG_TARGET: &str = "c::bn::states::block_sync";
 
@@ -179,17 +179,28 @@ impl PartialEq for BlockSyncStrategy {
 
 #[derive(Debug, Error)]
 pub enum BlockSyncError {
+    #[error("Maximum request attempts reached error")]
     MaxRequestAttemptsReached,
+    #[error("Maximum add block attempts reached error")]
     MaxAddBlockAttemptsReached,
+    #[error("Fork chain not linked error")]
     ForkChainNotLinked,
+    #[error("Invalid chain link error")]
     InvalidChainLink,
+    #[error("Empty blockchain error")]
     EmptyBlockchain,
+    #[error("Empty network best block error")]
     EmptyNetworkBestBlock,
+    #[error("No sync peers error")]
     NoSyncPeers,
-    ChainStorageError(ChainStorageError),
-    PeerManagerError(PeerManagerError),
-    ConnectivityError(ConnectivityError),
-    CommsInterfaceError(CommsInterfaceError),
+    #[error("Chain storage error: `{0}`")]
+    ChainStorageError(#[from] ChainStorageError),
+    #[error("Peer manager error: `{0}`")]
+    PeerManagerError(#[from] PeerManagerError),
+    #[error("Connectivity error: `{0}`")]
+    ConnectivityError(#[from] ConnectivityError),
+    #[error("Comms interface error: `{0}`")]
+    CommsInterfaceError(#[from] CommsInterfaceError),
 }
 
 #[derive(Clone, Debug, PartialEq, Copy)]

--- a/base_layer/core/src/base_node/states/header_sync.rs
+++ b/base_layer/core/src/base_node/states/header_sync.rs
@@ -314,11 +314,11 @@ pub enum HeaderSyncError {
     InvalidHeader(String),
     #[error("Exceeded maximum sync attempts")]
     MaxSyncAttemptsReached,
-    #[error("Chain storage error: {0:?}")]
+    #[error("Chain storage error: {0}")]
     ChainStorageError(#[from] ChainStorageError),
-    #[error("Block sync error: {0:?}")]
+    #[error("Block sync error: {0}")]
     BlockSyncError(#[from] BlockSyncError),
-    #[error("Header validation failed: {0:?}")]
+    #[error("Header validation failed: {0}")]
     HeaderValidationFailed(ValidationError),
     #[error("Join error: {0}")]
     JoinError(#[from] task::JoinError),

--- a/base_layer/core/src/base_node/states/horizon_state_sync/error.rs
+++ b/base_layer/core/src/base_node/states/horizon_state_sync/error.rs
@@ -39,9 +39,9 @@ pub enum HorizonSyncError {
     MaxSyncAttemptsReached,
     #[error("Chain storage error: {0}")]
     ChainStorageError(#[from] ChainStorageError),
-    #[error("Comms interface error: {0:?}")]
+    #[error("Comms interface error: {0}")]
     CommsInterfaceError(#[from] CommsInterfaceError),
-    #[error("Block sync error: {0:?}")]
+    #[error("Block sync error: {0}")]
     BlockSyncError(#[from] BlockSyncError),
     #[error("Final state validation failed: {0}")]
     FinalStateValidationFailed(ValidationError),

--- a/base_layer/core/src/blocks/block.rs
+++ b/base_layer/core/src/blocks/block.rs
@@ -39,31 +39,31 @@ use crate::{
         },
     },
 };
-use derive_error::Error;
 use log::*;
 use serde::{Deserialize, Serialize};
 use std::fmt::{Display, Formatter};
 use tari_crypto::tari_utilities::{hex::Hex, Hashable};
+use thiserror::Error;
 
 pub const LOG_TARGET: &str = "c::bl::block";
 
 #[derive(Clone, Debug, PartialEq, Error)]
 pub enum BlockValidationError {
-    // A transaction in the block failed to validate
-    TransactionError(TransactionError),
-    // Invalid kernel in block
+    #[error("A transaction in the block failed to validate: `{0}`")]
+    TransactionError(#[from] TransactionError),
+    #[error("Invalid kernel in block")]
     InvalidKernel,
-    // Invalid input in block
+    #[error("Invalid input in block")]
     InvalidInput,
-    // Input maturity not reached
+    #[error("Input maturity not reached")]
     InputMaturity,
-    // Invalid coinbase maturity in block or more than one coinbase
+    #[error("Invalid coinbase maturity in block or more than one coinbase")]
     InvalidCoinbase,
-    // Mismatched MMR roots
+    #[error("Mismatched MMR roots")]
     MismatchedMmrRoots,
-    // The block contains transactions that should have been cut through.
+    #[error("The block contains transactions that should have been cut through.")]
     NoCutThrough,
-    // The block weight is above the maximum
+    #[error("The block weight is above the maximum")]
     BlockTooLarge,
 }
 

--- a/base_layer/core/src/chain_storage/error.rs
+++ b/base_layer/core/src/chain_storage/error.rs
@@ -30,11 +30,11 @@ use tokio::task;
 
 #[derive(Debug, Clone, Error)]
 pub enum ChainStorageError {
-    #[error("Access to the underlying storage mechanism failed:{0}")]
+    #[error("Access to the underlying storage mechanism failed: {0}")]
     AccessError(String),
     #[error(
         "The database may be corrupted or otherwise be in an inconsistent state. Please check logs to try and \
-         identify the issue:{0}"
+         identify the issue: {0}"
     )]
     CorruptedDatabase(String),
     #[error("A given input could not be spent because it was not in the UTXO set")]
@@ -46,9 +46,9 @@ pub enum ChainStorageError {
          internal error or bug of sorts: {0}"
     )]
     UnexpectedResult(String),
-    #[error("You tried to execute an invalid Database operation:{0}")]
+    #[error("You tried to execute an invalid Database operation: {0}")]
     InvalidOperation(String),
-    #[error("There appears to be a critical error on the back end:{0}. Check the logs for more information.")]
+    #[error("There appears to be a critical error on the back end: {0}. Check the logs for more information.")]
     CriticalError(String),
     #[error("Cannot return data for requests older than the current pruning horizon")]
     BeyondPruningHorizon,

--- a/base_layer/core/src/consensus/consensus_manager.rs
+++ b/base_layer/core/src/consensus/consensus_manager.rs
@@ -35,22 +35,21 @@ use crate::{
     proof_of_work::DifficultyAdjustmentError,
     transactions::tari_amount::MicroTari,
 };
-use derive_error::Error;
 use std::sync::Arc;
 use tari_crypto::tari_utilities::hash::Hashable;
+use thiserror::Error;
 
 #[derive(Debug, Error, Clone)]
 pub enum ConsensusManagerError {
-    /// Difficulty adjustment encountered an error
-    DifficultyAdjustmentError(DifficultyAdjustmentError),
-    /// Problem with the DB backend storage
-    ChainStorageError(ChainStorageError),
-    /// There is no blockchain to query
+    #[error("Difficulty adjustment encountered an error: `{0}`")]
+    DifficultyAdjustmentError(#[from] DifficultyAdjustmentError),
+    #[error("Problem with the DB backend storage: `{0}`")]
+    ChainStorageError(#[from] ChainStorageError),
+    #[error("There is no blockchain to query")]
     EmptyBlockchain,
-    /// RwLock access broken.
-    #[error(non_std, no_from)]
+    #[error("RwLock access broken: `{0}`")]
     PoisonedAccess(String),
-    /// No Difficulty adjustment manager present
+    #[error("No Difficulty adjustment manager present")]
     MissingDifficultyAdjustmentManager,
 }
 

--- a/base_layer/core/src/mempool/error.rs
+++ b/base_layer/core/src/mempool/error.rs
@@ -30,21 +30,26 @@ use crate::{
     },
     transactions::transaction::TransactionError,
 };
-use derive_error::Error;
+use thiserror::Error;
 
 #[derive(Debug, Error)]
 pub enum MempoolError {
-    UnconfirmedPoolError(UnconfirmedPoolError),
-    OrphanPoolError(OrphanPoolError),
-    PendingPoolError(PendingPoolError),
-    ReorgPoolError(ReorgPoolError),
-    TransactionError(TransactionError),
-    ChainStorageError(ChainStorageError),
-    /// The Blockchain height is undefined
+    #[error("Unconfirmed pool error: `{0}`")]
+    UnconfirmedPoolError(#[from] UnconfirmedPoolError),
+    #[error("Orphan pool error: `{0}`")]
+    OrphanPoolError(#[from] OrphanPoolError),
+    #[error("Pending pool error: `{0}`")]
+    PendingPoolError(#[from] PendingPoolError),
+    #[error("Reorg pool error: `{0}`")]
+    ReorgPoolError(#[from] ReorgPoolError),
+    #[error("Transaction error: `{0}`")]
+    TransactionError(#[from] TransactionError),
+    #[error("Chain storage error: `{0}`")]
+    ChainStorageError(#[from] ChainStorageError),
+    #[error("The Blockchain height is undefined")]
     ChainHeightUndefined,
-    #[error(msg_embedded, non_std, no_from)]
+    #[error("Blocking task spawn error: `{0}`")]
     BlockingTaskSpawnError(String),
-    /// A problem has been encountered with the storage backend.
-    #[error(non_std, no_from)]
+    #[error("A problem has been encountered with the storage backend: `{0}`")]
     BackendError(String),
 }

--- a/base_layer/core/src/mempool/orphan_pool/error.rs
+++ b/base_layer/core/src/mempool/orphan_pool/error.rs
@@ -21,14 +21,14 @@
 //  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 use crate::chain_storage::ChainStorageError;
-use derive_error::Error;
+use thiserror::Error;
 
 #[derive(Debug, Error)]
 pub enum OrphanPoolError {
-    /// A problem has been encountered with the storage backend.
-    #[error(non_std, no_from)]
+    #[error("A problem has been encountered with the storage backend: `{0}`")]
     BackendError(String),
-    ChainStorageError(ChainStorageError),
-    /// The Blockchain height is undefined
+    #[error("Chain storage error: `{0}`")]
+    ChainStorageError(#[from] ChainStorageError),
+    #[error("The Blockchain height is undefined")]
     ChainHeightUndefined,
 }

--- a/base_layer/core/src/mempool/pending_pool/error.rs
+++ b/base_layer/core/src/mempool/pending_pool/error.rs
@@ -21,14 +21,14 @@
 //  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 use crate::mempool::priority::PriorityError;
-use derive_error::Error;
+use thiserror::Error;
 
 #[derive(Debug, Error)]
 pub enum PendingPoolError {
-    /// The HashMap and BTreeMap are out of sync
+    #[error("The HashMap and BTreeMap are out of sync")]
     StorageOutofSync,
-    /// A problem has been encountered with the storage backend.
-    #[error(non_std, no_from)]
+    #[error("A problem has been encountered with the storage backend: `{0}`")]
     BackendError(String),
-    PriorityError(PriorityError),
+    #[error("Priority error: `{0}`")]
+    PriorityError(#[from] PriorityError),
 }

--- a/base_layer/core/src/mempool/priority/error.rs
+++ b/base_layer/core/src/mempool/priority/error.rs
@@ -20,10 +20,11 @@
 //  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 //  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use derive_error::Error;
 use tari_crypto::tari_utilities::message_format::MessageFormatError;
+use thiserror::Error;
 
 #[derive(Debug, Error)]
 pub enum PriorityError {
-    MessageFormatError(MessageFormatError),
+    #[error("Message format error: `{0}`")]
+    MessageFormatError(#[from] MessageFormatError),
 }

--- a/base_layer/core/src/mempool/reorg_pool/error.rs
+++ b/base_layer/core/src/mempool/reorg_pool/error.rs
@@ -20,11 +20,10 @@
 //  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 //  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use derive_error::Error;
+use thiserror::Error;
 
 #[derive(Debug, Error)]
 pub enum ReorgPoolError {
-    /// A problem has been encountered with the storage backend.
-    #[error(non_std, no_from)]
+    #[error("A problem has been encountered with the storage backend: `{0}`")]
     BackendError(String),
 }

--- a/base_layer/core/src/mempool/service/error.rs
+++ b/base_layer/core/src/mempool/service/error.rs
@@ -21,25 +21,32 @@
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 use crate::mempool::MempoolError;
-use derive_error::Error;
 use tari_comms_dht::outbound::DhtOutboundError;
 use tari_service_framework::reply_channel::TransportChannelError;
+use thiserror::Error;
 
 #[derive(Debug, Error)]
 pub enum MempoolServiceError {
-    DhtOutboundError(DhtOutboundError),
-    #[error(msg_embedded, no_from, non_std)]
+    #[error("DHT outbound error: `{0}`")]
+    DhtOutboundError(#[from] DhtOutboundError),
+    #[error("Invalid request error: `{0}`")]
     InvalidRequest(String),
-    #[error(msg_embedded, no_from, non_std)]
+    #[error("Invalid response error: `{0}`")]
     InvalidResponse(String),
+    #[error("Request timed out error")]
     RequestTimedOut,
+    #[error("No bootstrap nodes configured error")]
     NoBootstrapNodesConfigured,
-    #[error(non_std, no_from)]
+    #[error("Outbound message service error: `{0}`")]
     OutboundMessageService(String),
-    MempoolError(MempoolError),
+    #[error("Mempool error: `{0}`")]
+    MempoolError(#[from] MempoolError),
+    #[error("Unexpected API response error")]
     UnexpectedApiResponse,
-    TransportChannelError(TransportChannelError),
-    /// Failed to send broadcast message
+    #[error("Transport channel error: `{0}`")]
+    TransportChannelError(#[from] TransportChannelError),
+    #[error("Failed to send broadcast message")]
     BroadcastFailed,
+    #[error("Event stream error")]
     EventStreamError,
 }

--- a/base_layer/core/src/mempool/sync_protocol/error.rs
+++ b/base_layer/core/src/mempool/sync_protocol/error.rs
@@ -31,7 +31,7 @@ pub enum MempoolProtocolError {
     ExcessSignatureMissing(NodeId),
     #[error("Peer `{0}` unexpectedly closed the substream")]
     SubstreamClosed(NodeId),
-    #[error("Mempool database error: {0:?}")]
+    #[error("Mempool database error: {0}")]
     MempoolError(#[from] MempoolError),
     #[error("IO error: {0}")]
     IoError(#[from] io::Error),

--- a/base_layer/core/src/mempool/unconfirmed_pool/error.rs
+++ b/base_layer/core/src/mempool/unconfirmed_pool/error.rs
@@ -21,11 +21,12 @@
 //  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 use crate::mempool::priority::PriorityError;
-use derive_error::Error;
+use thiserror::Error;
 
 #[derive(Debug, Error)]
 pub enum UnconfirmedPoolError {
-    /// The HashMap and BTreeMap are out of sync
+    #[error("The HashMap and BTreeMap are out of sync")]
     StorageOutofSync,
-    PriorityError(PriorityError),
+    #[error("Priority error: `{0}`")]
+    PriorityError(#[from] PriorityError),
 }

--- a/base_layer/core/src/mining/error.rs
+++ b/base_layer/core/src/mining/error.rs
@@ -20,17 +20,16 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use derive_error::Error;
+use thiserror::Error;
 
 #[derive(Clone, Debug, PartialEq, Error)]
 pub enum MinerError {
-    // Could not construct the coinbase utxo and kernel for the block
+    #[error("Could not construct the coinbase utxo and kernel for the block")]
     CoinbaseError,
-    // No block provided to mine
+    #[error("No block provided to mine")]
     MissingBlock,
-    // Config issue
+    #[error("Config issue")]
     ConfigError,
-    // Error communicating to base node or wallet
-    #[error(msg_embedded, non_std, no_from)]
+    #[error("Error communicating to base node or wallet: `{0}`")]
     CommunicationError(String),
 }

--- a/base_layer/core/src/proof_of_work/error.rs
+++ b/base_layer/core/src/proof_of_work/error.rs
@@ -20,22 +20,22 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use derive_error::Error;
+use thiserror::Error;
 
 #[derive(Clone, Debug, PartialEq, Error)]
 pub enum PowError {
-    // ProofOfWorkFailed
+    #[error("ProofOfWorkFailed")]
     InvalidProofOfWork,
-    // Target difficulty not achieved
+    #[error("Target difficulty not achieved")]
     AchievedDifficultyTooLow,
-    // Invalid target difficulty
+    #[error("Invalid target difficulty")]
     InvalidTargetDifficulty,
 }
 
 #[derive(Debug, Error, Clone, PartialEq)]
 pub enum DifficultyAdjustmentError {
-    // Accumulated difficulty values can only strictly increase
+    #[error("Accumulated difficulty values can only strictly increase")]
     DecreasingAccumulatedDifficulty,
-    // Other difficulty algorithm errors
+    #[error("Other difficulty algorithm error")]
     Other,
 }

--- a/base_layer/core/src/proof_of_work/monero_rx.rs
+++ b/base_layer/core/src/proof_of_work/monero_rx.rs
@@ -21,7 +21,6 @@
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 use crate::{blocks::BlockHeader, proof_of_work::Difficulty, tari_utilities::ByteArray, U256};
-use derive_error::Error;
 use monero::{
     blockdata::{
         block::{Block as MoneroBlock, BlockHeader as MoneroBlockHeader},
@@ -34,21 +33,22 @@ use monero::{
 #[cfg(feature = "monero_merge_mining")]
 use randomx_rs::{RandomXCache, RandomXDataset, RandomXError, RandomXFlag, RandomXVM};
 use serde::{Deserialize, Serialize};
+use thiserror::Error;
 
 const MAX_TARGET: U256 = U256::MAX;
 
 #[derive(Debug, Error, Clone)]
 pub enum MergeMineError {
-    #[error(msg_embedded, no_from, non_std)]
+    #[error("Serialization error: {0}")]
     SerializeError(String),
-    // Error deserializing Monero data
+    #[error("Error deserializing Monero data")]
     DeserializeError,
-    // Hashing of Monero data failed
+    #[error("Hashing of Monero data failed")]
     HashingError,
-    // RandomX Failure
     #[cfg(feature = "monero_merge_mining")]
-    RandomXError(RandomXError),
-    #[error(msg_embedded, no_from, non_std)]
+    #[error("RandomX error: {0}")]
+    RandomXError(#[from] RandomXError),
+    #[error("Validation error: {0}")]
     ValidationError(String),
 }
 

--- a/base_layer/core/src/transactions/coinbase_builder.rs
+++ b/base_layer/core/src/transactions/coinbase_builder.rs
@@ -37,23 +37,22 @@ use crate::{
         types::{BlindingFactor, CryptoFactories, PrivateKey, PublicKey, Signature},
     },
 };
-use derive_error::Error;
 use tari_crypto::{commitment::HomomorphicCommitmentFactory, keys::PublicKey as PK};
+use thiserror::Error;
 
 #[derive(Debug, Clone, Error, PartialEq)]
 pub enum CoinbaseBuildError {
-    /// The block height for this coinbase transaction wasn't provided
+    #[error("The block height for this coinbase transaction wasn't provided")]
     MissingBlockHeight,
-    /// The value for the coinbase transaction is missing
+    #[error("The value for the coinbase transaction is missing")]
     MissingFees,
-    /// The private nonce for this coinbase transaction wasn't provided
+    #[error("The private nonce for this coinbase transaction wasn't provided")]
     MissingNonce,
-    /// The spend key for this coinbase transaction wasn't provided
+    #[error("The spend key for this coinbase transaction wasn't provided")]
     MissingSpendKey,
-    /// An error occurred building the final transaction
-    #[error(msg_embedded, no_from, non_std)]
+    #[error("An error occurred building the final transaction: `{0}`")]
     BuildError(String),
-    /// Some inconsistent data was given to the builder. This transaction is not valid
+    #[error("Some inconsistent data was given to the builder. This transaction is not valid")]
     InvalidTransaction,
 }
 

--- a/base_layer/core/src/transactions/tari_amount.rs
+++ b/base_layer/core/src/transactions/tari_amount.rs
@@ -47,7 +47,7 @@ pub struct MicroTari(pub u64);
 
 #[derive(Debug, Clone, ThisError, PartialEq)]
 pub enum MicroTariError {
-    #[error("Failed to parse value:{0}")]
+    #[error("Failed to parse value: {0}")]
     ParseError(String),
 }
 /// A convenience constant that makes it easier to define Tari amounts.

--- a/base_layer/core/src/transactions/transaction_protocol/mod.rs
+++ b/base_layer/core/src/transactions/transaction_protocol/mod.rs
@@ -91,7 +91,6 @@ use crate::transactions::{
     transaction::TransactionError,
     types::{Challenge, HashOutput, MessageHash, PublicKey},
 };
-use derive_error::Error;
 use digest::Digest;
 use serde::{Deserialize, Serialize};
 use tari_crypto::{
@@ -99,32 +98,31 @@ use tari_crypto::{
     signatures::SchnorrSignatureError,
     tari_utilities::byte_array::ByteArray,
 };
+use thiserror::Error;
 
 #[derive(Clone, Debug, PartialEq, Error, Deserialize, Serialize)]
 pub enum TransactionProtocolError {
-    // The current state is not yet completed, cannot transition to next state
-    #[error(msg_embedded, no_from, non_std)]
+    #[error("The current state is not yet completed, cannot transition to next state: `{0}`")]
     IncompleteStateError(String),
-    #[error(msg_embedded, no_from, non_std)]
+    #[error("Validation error: `{0}`")]
     ValidationError(String),
-    /// Invalid state transition
+    #[error("Invalid state transition")]
     InvalidTransitionError,
-    /// Invalid state
+    #[error("Invalid state")]
     InvalidStateError,
-    /// An error occurred while performing a signature
-    SigningError(SchnorrSignatureError),
-    /// A signature verification failed
+    #[error("An error occurred while performing a signature: `{0}`")]
+    SigningError(#[from] SchnorrSignatureError),
+    #[error("A signature verification failed")]
     InvalidSignatureError,
-    /// An error occurred while building the final transaction
-    TransactionBuildError(TransactionError),
-    /// The transaction construction broke down due to communication failure
+    #[error("An error occurred while building the final transaction: `{0}`")]
+    TransactionBuildError(#[from] TransactionError),
+    #[error("The transaction construction broke down due to communication failure")]
     TimeoutError,
-    /// An error was produced while constructing a rangeproof
-    RangeProofError(RangeProofError),
-    /// This set of parameters is currently not supported
-    #[error(msg_embedded, no_from, non_std)]
+    #[error("An error was produced while constructing a rangeproof: `{0}`")]
+    RangeProofError(#[from] RangeProofError),
+    #[error("This set of parameters is currently not supported: `{0}`")]
     UnsupportedError(String),
-    /// There has been an error serializing or deserializing this structure
+    #[error("There has been an error serializing or deserializing this structure")]
     SerializationError,
 }
 

--- a/base_layer/key_manager/Cargo.toml
+++ b/base_layer/key_manager/Cargo.toml
@@ -12,10 +12,10 @@ tari_crypto = { version = "^0.5" }
 rand = "0.7.2"
 digest = "0.8.0"
 sha2 = "0.8.0"
-derive-error = "0.0.4"
 serde = "1.0.89"
 serde_derive = "1.0.89"
 serde_json = "1.0.39"
+thiserror = "1.0.20"
 
 [features]
 avx2 = ["tari_crypto/avx2"]

--- a/base_layer/key_manager/src/file_backup.rs
+++ b/base_layer/key_manager/src/file_backup.rs
@@ -20,25 +20,25 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use derive_error::Error;
 use serde::de::DeserializeOwned;
 use std::{fs::File, io::prelude::*};
+use thiserror::Error;
 
 // TODO: file should be decrypted using Salsa20 or ChaCha20
 
 #[derive(Debug, Error)]
 pub enum FileError {
-    // The specified backup file could not be created
+    #[error("The specified backup file could not be created")]
     FileCreate,
-    // The specified backup file could not be opened
+    #[error("The specified backup file could not be opened")]
     FileOpen,
-    // Could not read from backup file
+    #[error("Could not read from backup file")]
     FileRead,
-    // Could not write to backup file
+    #[error("Could not write to backup file")]
     FileWrite,
-    // Problem serializing struct into JSON
+    #[error("Problem serializing struct into JSON")]
     Serialize,
-    // Problem deserializing JSON into a new struct
+    #[error("Problem deserializing JSON into a new struct")]
     Deserialize,
 }
 

--- a/base_layer/key_manager/src/key_manager.rs
+++ b/base_layer/key_manager/src/key_manager.rs
@@ -21,7 +21,6 @@
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 use crate::mnemonic;
-use derive_error::Error;
 use digest::Digest;
 use rand::{CryptoRng, Rng};
 use serde::de::DeserializeOwned;
@@ -31,13 +30,14 @@ use tari_crypto::{
     keys::SecretKey,
     tari_utilities::{byte_array::ByteArrayError, hex::Hex},
 };
+use thiserror::Error;
 
 #[derive(Debug, Error, PartialEq)]
 pub enum KeyManagerError {
-    // Could not convert into byte array
-    ByteArrayError(ByteArrayError),
-    // Could not convert provided Mnemonic into master key
-    MnemonicError(mnemonic::MnemonicError),
+    #[error("Could not convert into byte array: `{0}`")]
+    ByteArrayError(#[from] ByteArrayError),
+    #[error("Could not convert provided Mnemonic into master key: `{0}`")]
+    MnemonicError(#[from] mnemonic::MnemonicError),
 }
 
 #[derive(Clone, Debug)]

--- a/base_layer/key_manager/src/mnemonic.rs
+++ b/base_layer/key_manager/src/mnemonic.rs
@@ -21,12 +21,12 @@
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 use crate::{diacritics::*, mnemonic_wordlists::*};
-use derive_error::Error;
 use std::slice::Iter;
 use tari_crypto::{
     keys::SecretKey,
     tari_utilities::{bit::*, byte_array::ByteArrayError},
 };
+use thiserror::Error;
 
 /// The Mnemonic system simplifies the encoding and decoding of a secret key into and from a Mnemonic word sequence
 /// It can autodetect the language of the Mnemonic word sequence
@@ -34,16 +34,18 @@ use tari_crypto::{
 
 #[derive(Debug, Error, PartialEq)]
 pub enum MnemonicError {
-    // Only ChineseSimplified, ChineseTraditional, English, French, Italian, Japanese, Korean and Spanish are defined
-    // natural languages
+    #[error(
+        "Only ChineseSimplified, ChineseTraditional, English, French, Italian, Japanese, Korean and Spanish are \
+         defined natural languages"
+    )]
     UnknownLanguage,
-    // Only 2048 words for each language was selected to form Mnemonic word lists
+    #[error("Only 2048 words for each language was selected to form Mnemonic word lists")]
     WordNotFound,
-    // A mnemonic word does not exist for the requested index
+    #[error("A mnemonic word does not exist for the requested index")]
     IndexOutOfBounds,
-    // A problem encountered constructing a secret key from bytes or mnemonic sequence
-    ByteArrayError(ByteArrayError),
-    // Encoding and decoding a mnemonic sequence from bytes require exactly 32 bytes or 24 mnemonic words
+    #[error("A problem encountered constructing a secret key from bytes or mnemonic sequence: `{0}`")]
+    ByteArrayError(#[from] ByteArrayError),
+    #[error("Encoding and decoding a mnemonic sequence from bytes require exactly 32 bytes or 24 mnemonic words")]
     ConversionProblem,
 }
 

--- a/base_layer/mmr/Cargo.toml
+++ b/base_layer/mmr/Cargo.toml
@@ -13,7 +13,7 @@ native_bitmap = ["croaring"]
 
 [dependencies]
 tari_utilities = "^0.2"
-derive-error = "0.0.4"
+thiserror = "1.0.20"
 digest = "0.8.0"
 log = "0.4"
 serde = { version = "1.0.97", features = ["derive"] }

--- a/base_layer/mmr/src/error.rs
+++ b/base_layer/mmr/src/error.rs
@@ -20,24 +20,22 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use derive_error::Error;
+use thiserror::Error;
 
 #[derive(Debug, Error, PartialEq, Clone)]
 pub enum MerkleMountainRangeError {
-    // The next position was not a leaf node as expected
+    #[error("The next position was not a leaf node as expected")]
     CorruptDataStructure,
-    // A problem has been encountered with the backend
-    #[error(non_std, no_from)]
+    #[error("A problem has been encountered with the backend: `{0}`")]
     BackendError(String),
-    // The Merkle tree is not internally consistent. A parent hash isn't equal to the hash of its children
+    #[error("The Merkle tree is not internally consistent. A parent hash isn't equal to the hash of its children")]
     InvalidMerkleTree,
-    // The tree has reached its maximum size
+    #[error("The tree has reached its maximum size")]
     MaximumSizeReached,
-    // A node hash was not found for the given node index
-    #[error(non_std, no_from)]
+    #[error("A node hash was not found for the given node index: `{0}`")]
     HashNotFound(usize),
-    // A request was out of range
+    #[error("A request was out of range")]
     OutOfRange,
-    // Conflicting or invalid configuration parameters provided.
+    #[error("Conflicting or invalid configuration parameters provided.")]
     InvalidConfig,
 }

--- a/base_layer/mmr/src/merkle_proof.rs
+++ b/base_layer/mmr/src/merkle_proof.rs
@@ -29,28 +29,28 @@ use crate::{
     HashSlice,
     MerkleMountainRange,
 };
-use derive_error::Error;
 use digest::Digest;
 use log::error;
 use serde::{Deserialize, Serialize};
 use std::fmt::{self, Display, Formatter};
 use tari_utilities::hex::Hex;
+use thiserror::Error;
 
 /// Merkle proof errors.
 #[derive(Clone, Debug, PartialEq, Error)]
 pub enum MerkleProofError {
-    // Merkle proof root hash does not match when attempting to verify.
+    #[error("Merkle proof root hash does not match when attempting to verify.")]
     RootMismatch,
-    // You tried to construct or verify a Merkle proof using a non-leaf node as the inclusion candidate
+    #[error("You tried to construct or verify a Merkle proof using a non-leaf node as the inclusion candidate")]
     NonLeafNode,
-    // There was no hash in the merkle tree backend with the given position
-    #[error(non_std, no_from)]
+    #[error("There was no hash in the merkle tree backend with the given position: `{0}`")]
     HashNotFound(usize),
-    // The list of peak hashes provided in the proof has an error
+    #[error("The list of peak hashes provided in the proof has an error")]
     IncorrectPeakMap,
-    // Unexpected
+    #[error("Unexpected error")]
     Unexpected,
-    MerkleMountainRangeError(MerkleMountainRangeError),
+    #[error("Merkle mountain range error: `{0}`")]
+    MerkleMountainRangeError(#[from] MerkleMountainRangeError),
 }
 
 /// A Merkle proof that proves a particular element at a particular position exists in an MMR.

--- a/base_layer/p2p/Cargo.toml
+++ b/base_layer/p2p/Cargo.toml
@@ -22,7 +22,7 @@ tari_utilities = "^0.2"
 
 bytes = "0.4.12"
 chrono = {version = "0.4.6", features = ["serde"]}
-derive-error = "0.0.4"
+thiserror = "1.0.20"
 futures = {version = "^0.3.1"}
 lmdb-zero = "0.4.4"
 log = "0.4.6"
@@ -33,7 +33,7 @@ serde_derive = "1.0.90"
 tokio = {version="0.2.10", features=["blocking"]}
 tower = "0.3.0-alpha.2"
 tower-service = { version="0.3.0-alpha.2" }
- 
+
 [dev-dependencies]
 tari_test_utils = { version = "^0.2", path="../../infrastructure/test_utils" }
 

--- a/base_layer/p2p/src/services/liveness/error.rs
+++ b/base_layer/p2p/src/services/liveness/error.rs
@@ -20,28 +20,31 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use derive_error::Error;
 use tari_comms::message::MessageError;
 use tari_comms_dht::{outbound::DhtOutboundError, DhtActorError};
 use tari_service_framework::reply_channel::TransportChannelError;
+use thiserror::Error;
 
 #[derive(Debug, Error)]
 pub enum LivenessError {
-    DhtOutboundError(DhtOutboundError),
-    DhtActorError(DhtActorError),
-    /// Failed to send a pong message
+    #[error("DHT outbound error: `{0}`")]
+    DhtOutboundError(#[from] DhtOutboundError),
+    #[error("DHT actor error: `{0}`")]
+    DhtActorError(#[from] DhtActorError),
+    #[error("Failed to send a pong message")]
     SendPongFailed,
-    /// Failed to send a ping message
+    #[error("Failed to send a ping message")]
     SendPingFailed,
-    /// Occurs when a message cannot deserialize into a PingPong message
-    MessageError(MessageError),
-    /// The Handle repsonse was not what was expected for this request
+    #[error("Occurs when a message cannot deserialize into a PingPong message: `{0}`")]
+    MessageError(#[from] MessageError),
+    #[error("The Handle repsonse was not what was expected for this request")]
     UnexpectedApiResponse,
-    /// An error has occurred reading from the event subscriber stream
+    #[error("An error has occurred reading from the event subscriber stream")]
     EventStreamError,
-    TransportChannelError(TransportChannelError),
-    /// Ping pong type was invalid or unrecognised
+    #[error("Transport channel error: `{0}`")]
+    TransportChannelError(#[from] TransportChannelError),
+    #[error("Ping pong type was invalid or unrecognised")]
     InvalidPingPongType,
-    /// NodeId does not exist
+    #[error("NodeId does not exist")]
     NodeIdDoesNotExist,
 }

--- a/base_layer/service_framework/Cargo.toml
+++ b/base_layer/service_framework/Cargo.toml
@@ -11,8 +11,7 @@ license = "BSD-3-Clause"
 
 [dependencies]
 tari_shutdown = { version = "^0.0", path="../../infrastructure/shutdown" }
-
-derive-error = "0.0.4"
+thiserror = "1.0.20"
 futures = { version = "^0.3.1", features=["async-await"]}
 tower-service = { version="0.3.0" }
 tokio = "0.2.10"

--- a/base_layer/service_framework/src/initializer.rs
+++ b/base_layer/service_framework/src/initializer.rs
@@ -21,18 +21,17 @@
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 use crate::handles::ServiceHandlesFuture;
-use derive_error::Error;
 use futures::{Future, FutureExt};
 use std::pin::Pin;
 use tari_shutdown::ShutdownSignal;
+use thiserror::Error;
 use tokio::runtime;
 
 #[derive(Debug, Error)]
 pub enum ServiceInitializationError {
-    // General error for failed initialization.
-    // Specialized errors should be added and used if appropriate.
-    #[error(msg_embedded, non_std, no_from)]
+    #[error("General error for failed initialization: `{0}`")]
     Failed(String),
+    // Specialized errors should be added and used if appropriate.
 }
 
 /// Implementors of this trait will initialize a service

--- a/base_layer/service_framework/src/reply_channel.rs
+++ b/base_layer/service_framework/src/reply_channel.rs
@@ -20,7 +20,6 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use derive_error::Error;
 use futures::{
     channel::{
         mpsc::{self, SendError},
@@ -35,6 +34,7 @@ use futures::{
     StreamExt,
 };
 use std::{pin::Pin, task::Poll};
+use thiserror::Error;
 use tower_service::Service;
 
 /// Create a new Requester/Responder pair which wraps and calls the given service
@@ -103,11 +103,11 @@ impl<TReq, TRes> Service<TReq> for SenderService<TReq, TRes> {
 
 #[derive(Debug, Error, Eq, PartialEq, Clone)]
 pub enum TransportChannelError {
-    /// Error occurred when sending
-    SendError(SendError),
-    /// Request was canceled
+    #[error("Error occurred when sending: `{0}`")]
+    SendError(#[from] SendError),
+    #[error("Request was canceled")]
     Canceled,
-    /// The response channel has closed
+    #[error("The response channel has closed")]
     ChannelClosed,
 }
 

--- a/base_layer/wallet/Cargo.toml
+++ b/base_layer/wallet/Cargo.toml
@@ -18,7 +18,7 @@ tari_storage = { version = "^0.2", path = "../../infrastructure/storage"}
 
 chrono = { version = "0.4.6", features = ["serde"]}
 time = {version = "0.1.39"}
-derive-error = "0.0.4"
+thiserror = "1.0.20"
 digest = "0.8.0"
 blake2 = "0.8.0"
 serde = {version = "1.0.89", features = ["derive"] }

--- a/base_layer/wallet/src/contacts_service/error.rs
+++ b/base_layer/wallet/src/contacts_service/error.rs
@@ -21,37 +21,42 @@
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 use crate::contacts_service::storage::database::DbKey;
-use derive_error::Error;
 use diesel::result::Error as DieselError;
 use tari_service_framework::reply_channel::TransportChannelError;
+use thiserror::Error;
 
 #[derive(Debug, Error, PartialEq)]
 pub enum ContactsServiceError {
-    /// Contact is not found
+    #[error("Contact is not found")]
     ContactNotFound,
-    /// Received incorrect response from service request
+    #[error("Received incorrect response from service request")]
     UnexpectedApiResponse,
-    ContactsServiceStorageError(ContactsServiceStorageError),
-    TransportChannelError(TransportChannelError),
+    #[error("Contacts service storage error: `{0}`")]
+    ContactsServiceStorageError(#[from] ContactsServiceStorageError),
+    #[error("Transport channel error: `{0}`")]
+    TransportChannelError(#[from] TransportChannelError),
 }
 
 #[derive(Debug, Error, PartialEq)]
 pub enum ContactsServiceStorageError {
-    /// This write operation is not supported for provided DbKey
+    #[error("This write operation is not supported for provided DbKey")]
     OperationNotSupported,
-    /// Error converting a type
+    #[error("Error converting a type")]
     ConversionError,
-    /// Could not find all values specified for batch operation
+    #[error("Could not find all values specified for batch operation")]
     ValuesNotFound,
-    #[error(non_std, no_from)]
+    #[error("Value not found error: `{0}`")]
     ValueNotFound(DbKey),
-    #[error(msg_embedded, non_std, no_from)]
+    #[error("Unexpected result error: `{0}`")]
     UnexpectedResult(String),
+    #[error("R2d2 error")]
     R2d2Error,
-    DieselError(DieselError),
-    DieselConnectionError(diesel::ConnectionError),
-    #[error(msg_embedded, no_from, non_std)]
+    #[error("Diesel error: `{0}`")]
+    DieselError(#[from] DieselError),
+    #[error("Diesel connection error: `{0}`")]
+    DieselConnectionError(#[from] diesel::ConnectionError),
+    #[error("Database migration error: `{0}`")]
     DatabaseMigrationError(String),
-    #[error(msg_embedded, non_std, no_from)]
+    #[error("Blocking task spawn error: `{0}`")]
     BlockingTaskSpawnError(String),
 }

--- a/base_layer/wallet/src/error.rs
+++ b/base_layer/wallet/src/error.rs
@@ -26,7 +26,6 @@ use crate::{
     storage::database::DbKey,
     transaction_service::error::TransactionServiceError,
 };
-use derive_error::Error;
 use diesel::result::Error as DieselError;
 use log::SetLoggerError;
 use serde_json::Error as SerdeJsonError;
@@ -34,58 +33,76 @@ use tari_comms::{connectivity::ConnectivityError, multiaddr, peer_manager::PeerM
 use tari_comms_dht::store_forward::StoreAndForwardError;
 use tari_crypto::tari_utilities::{hex::HexError, ByteArrayError};
 use tari_p2p::{initialization::CommsInitializationError, services::liveness::error::LivenessError};
+use thiserror::Error;
 
 #[derive(Debug, Error)]
 pub enum WalletError {
-    CommsInitializationError(CommsInitializationError),
-    OutputManagerError(OutputManagerError),
-    TransactionServiceError(TransactionServiceError),
-    PeerManagerError(PeerManagerError),
-    MultiaddrError(multiaddr::Error),
-    WalletStorageError(WalletStorageError),
-    SetLoggerError(SetLoggerError),
-    ContactsServiceError(ContactsServiceError),
-    LivenessServiceError(LivenessError),
-    StoreAndForwardError(StoreAndForwardError),
-    ConnectivityError(ConnectivityError),
+    #[error("Comms initialization error: `{0}`")]
+    CommsInitializationError(#[from] CommsInitializationError),
+    #[error("Output manager error: `{0}`")]
+    OutputManagerError(#[from] OutputManagerError),
+    #[error("Transaction service error: `{0}`")]
+    TransactionServiceError(#[from] TransactionServiceError),
+    #[error("Peer manager error: `{0}`")]
+    PeerManagerError(#[from] PeerManagerError),
+    #[error("Multiaddr error: `{0}`")]
+    MultiaddrError(#[from] multiaddr::Error),
+    #[error("Wallet storage error: `{0}`")]
+    WalletStorageError(#[from] WalletStorageError),
+    #[error("Set logger error: `{0}`")]
+    SetLoggerError(#[from] SetLoggerError),
+    #[error("Contacts service error: `{0}`")]
+    ContactsServiceError(#[from] ContactsServiceError),
+    #[error("Liveness service error: `{0}`")]
+    LivenessServiceError(#[from] LivenessError),
+    #[error("Store and forward error: `{0}`")]
+    StoreAndForwardError(#[from] StoreAndForwardError),
+    #[error("Connectivity error: `{0}`")]
+    ConnectivityError(#[from] ConnectivityError),
 }
 
 #[derive(Debug, Error)]
 pub enum WalletStorageError {
-    /// Tried to insert an output that already exists in the database
+    #[error("Tried to insert an output that already exists in the database")]
     DuplicateContact,
-    /// This write operation is not supported for provided DbKey
+    #[error("This write operation is not supported for provided DbKey")]
     OperationNotSupported,
-    /// Error converting a type
+    #[error("Error converting a type")]
     ConversionError,
-    /// Could not find all values specified for batch operation
+    #[error("Could not find all values specified for batch operation")]
     ValuesNotFound,
-    /// Db Path does not exist
+    #[error("Db Path does not exist")]
     DbPathDoesNotExist,
-    SerdeJsonError(SerdeJsonError),
+    #[error("Serde json error: `{0}`")]
+    SerdeJsonError(#[from] SerdeJsonError),
+    #[error("R2d2 error")]
     R2d2Error,
-    DieselError(DieselError),
-    DieselConnectionError(diesel::ConnectionError),
-    #[error(msg_embedded, no_from, non_std)]
+    #[error("Diesel error: `{0}`")]
+    DieselError(#[from] DieselError),
+    #[error("Diesel connection error: `{0}`")]
+    DieselConnectionError(#[from] diesel::ConnectionError),
+    #[error("Database migration error")]
     DatabaseMigrationError(String),
-    #[error(non_std, no_from)]
+    #[error("Value not found: `{0}`")]
     ValueNotFound(DbKey),
-    #[error(msg_embedded, non_std, no_from)]
+    #[error("Unexpected result: `{0}`")]
     UnexpectedResult(String),
-    #[error(msg_embedded, non_std, no_from)]
+    #[error("Blocking task spawn error: `{0}`")]
     BlockingTaskSpawnError(String),
-    #[error(msg_embedded, non_std, no_from)]
+    #[error("File error: `{0}`")]
     FileError(String),
-    /// The storage path was invalid unicode or not supported by the host OS
+    #[error("The storage path was invalid unicode or not supported by the host OS")]
     InvalidUnicodePath,
-    HexError(HexError),
-    /// Invalid Encryption Cipher was provided to database
+    #[error("Hex error: `{0}`")]
+    HexError(#[from] HexError),
+    #[error("Invalid Encryption Cipher was provided to database")]
     InvalidEncryptionCipher,
-    /// Missing Nonce in encrypted data
+    #[error("Missing Nonce in encrypted data")]
     MissingNonce,
-    #[error(msg_embedded, non_std, no_from)]
+    #[error("Aead error: `{0}`")]
     AeadError(String),
-    /// Wallet db is already encrypted and cannot be encrypted until the previous encryption is removed
+    #[error("Wallet db is already encrypted and cannot be encrypted until the previous encryption is removed")]
     AlreadyEncrypted,
-    ByteArrayError(ByteArrayError),
+    #[error("Byte array error: `{0}`")]
+    ByteArrayError(#[from] ByteArrayError),
 }

--- a/base_layer/wallet/src/output_manager_service/error.rs
+++ b/base_layer/wallet/src/output_manager_service/error.rs
@@ -21,91 +21,104 @@
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 use crate::output_manager_service::storage::database::DbKey;
-use derive_error::Error;
 use diesel::result::Error as DieselError;
 use tari_comms_dht::outbound::DhtOutboundError;
 use tari_core::transactions::{transaction::TransactionError, transaction_protocol::TransactionProtocolError};
 use tari_crypto::tari_utilities::ByteArrayError;
 use tari_key_manager::{key_manager::KeyManagerError, mnemonic::MnemonicError};
 use tari_service_framework::reply_channel::TransportChannelError;
+use thiserror::Error;
 use time::OutOfRangeError;
 
 #[derive(Debug, Error)]
 pub enum OutputManagerError {
-    #[error(msg_embedded, no_from, non_std)]
+    #[error("Build error: `{0}`")]
     BuildError(String),
-    ByteArrayError(ByteArrayError),
-    TransactionProtocolError(TransactionProtocolError),
-    TransportChannelError(TransportChannelError),
-    OutOfRangeError(OutOfRangeError),
-    OutputManagerStorageError(OutputManagerStorageError),
-    MnemonicError(MnemonicError),
-    KeyManagerError(KeyManagerError),
-    TransactionError(TransactionError),
-    DhtOutboundError(DhtOutboundError),
-    #[error(msg_embedded, no_from, non_std)]
+    #[error("Byte array error: `{0}`")]
+    ByteArrayError(#[from] ByteArrayError),
+    #[error("Transaction protocol error: `{0}`")]
+    TransactionProtocolError(#[from] TransactionProtocolError),
+    #[error("Transport channel error: `{0}`")]
+    TransportChannelError(#[from] TransportChannelError),
+    #[error("Out of range error: `{0}`")]
+    OutOfRangeError(#[from] OutOfRangeError),
+    #[error("Output manager storage error: `{0}`")]
+    OutputManagerStorageError(#[from] OutputManagerStorageError),
+    #[error("Mnemonic error: `{0}`")]
+    MnemonicError(#[from] MnemonicError),
+    #[error("Key manager error: `{0}`")]
+    KeyManagerError(#[from] KeyManagerError),
+    #[error("Transaction error: `{0}`")]
+    TransactionError(#[from] TransactionError),
+    #[error("DHT outbound error: `{0}`")]
+    DhtOutboundError(#[from] DhtOutboundError),
+    #[error("Conversion error: `{0}`")]
     ConversionError(String),
-    /// Not all the transaction inputs and outputs are present to be confirmed
+    #[error("Not all the transaction inputs and outputs are present to be confirmed")]
     IncompleteTransaction,
-    /// Not enough funds to fulfil transaction
+    #[error("Not enough funds to fulfil transaction")]
     NotEnoughFunds,
-    /// Output already exists
+    #[error("Output already exists")]
     DuplicateOutput,
-    /// Error sending a message to the public API
+    #[error("Error sending a message to the public API")]
     ApiSendFailed,
-    /// Error receiving a message from the public API
+    #[error("Error receiving a message from the public API")]
     ApiReceiveFailed,
-    /// API returned something unexpected.
+    #[error("API returned something unexpected.")]
     UnexpectedApiResponse,
-    /// Invalid config provided to Output Manager
+    #[error("Invalid config provided to Output Manager")]
     InvalidConfig,
-    /// The response received from another service is an incorrect variant
-    #[error(msg_embedded, no_from, non_std)]
+    #[error("The response received from another service is an incorrect variant: `{0}`")]
     InvalidResponseError(String),
-    /// No Base Node public key has been provided for this service to use for contacting a base node
+    #[error("No Base Node public key has been provided for this service to use for contacting a base node")]
     NoBaseNodeKeysProvided,
-    /// An error occured sending an event out on the event stream
+    #[error("An error occured sending an event out on the event stream")]
     EventStreamError,
-    /// Maximum Attempts Exceeded
+    #[error("Maximum Attempts Exceeded")]
     MaximumAttemptsExceeded,
-    /// An error has been experienced in the service
-    #[error(msg_embedded, non_std, no_from)]
+    #[error("An error has been experienced in the service: `{0}`")]
     ServiceError(String),
 }
 
 #[derive(Debug, Error, PartialEq)]
 pub enum OutputManagerStorageError {
-    /// Tried to insert an output that already exists in the database
+    #[error("Tried to insert an output that already exists in the database")]
     DuplicateOutput,
-    #[error(non_std, no_from)]
+    #[error("Value not found: `{0}`")]
     ValueNotFound(DbKey),
-    #[error(msg_embedded, non_std, no_from)]
+    #[error("Unexpected result: `{0}`")]
     UnexpectedResult(String),
-    /// If an pending transaction does not exist to be confirmed
+    #[error("If an pending transaction does not exist to be confirmed")]
     PendingTransactionNotFound,
-    /// This write operation is not supported for provided DbKey
+    #[error("This write operation is not supported for provided DbKey")]
     OperationNotSupported,
-    /// Could not find all values specified for batch operation
+    #[error("Could not find all values specified for batch operation")]
     ValuesNotFound,
-    /// Error converting a type
+    #[error("Error converting a type")]
     ConversionError,
-    /// Output has already been spent
+    #[error("Output has already been spent")]
     OutputAlreadySpent,
-    /// Key Manager not initialized
+    #[error("Key Manager not initialized")]
     KeyManagerNotInitialized,
-    OutOfRangeError(OutOfRangeError),
+    #[error("Out of range error: `{0}`")]
+    OutOfRangeError(#[from] OutOfRangeError),
+    #[error("R2d2 error")]
     R2d2Error,
-    TransactionError(TransactionError),
-    DieselError(DieselError),
-    DieselConnectionError(diesel::ConnectionError),
-    #[error(msg_embedded, no_from, non_std)]
+    #[error("Transaction error: `{0}`")]
+    TransactionError(#[from] TransactionError),
+    #[error("Diesel error: `{0}`")]
+    DieselError(#[from] DieselError),
+    #[error("Diesel connection error: `{0}`")]
+    DieselConnectionError(#[from] diesel::ConnectionError),
+    #[error("Database migration error: `{0}`")]
     DatabaseMigrationError(String),
-    #[error(msg_embedded, non_std, no_from)]
+    #[error("Blocking task spawn error: `{0}`")]
     BlockingTaskSpawnError(String),
-    /// Wallet db is already encrypted and cannot be encrypted until the previous encryption is removed
+    #[error("Wallet db is already encrypted and cannot be encrypted until the previous encryption is removed")]
     AlreadyEncrypted,
-    ByteArrayError(ByteArrayError),
-    #[error(msg_embedded, non_std, no_from)]
+    #[error("Byte array error: `{0}`")]
+    ByteArrayError(#[from] ByteArrayError),
+    #[error("Aead error: `{0}`")]
     AeadError(String),
 }
 

--- a/base_layer/wallet/src/text_message_service/error.rs
+++ b/base_layer/wallet/src/text_message_service/error.rs
@@ -20,51 +20,63 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use derive_error::Error;
 use diesel::result::{ConnectionError as DieselConnectionError, Error as DieselError};
 use tari_comms::{builder::CommsError, connection::NetAddressError, message::MessageError};
 use tari_comms_dht::outbound::DhtOutboundError;
+use tari_crypto::tari_utilities::{hex::HexError, message_format::MessageFormatError};
 use tari_p2p::services::liveness::error::LivenessError;
 use tari_service_framework::reply_channel::TransportChannelError;
-use tari_crypto::tari_utilities::{hex::HexError, message_format::MessageFormatError};
+use thiserror::Error;
 use tokio_executor::threadpool::BlockingError;
 
 #[derive(Debug, Error)]
 pub enum TextMessageError {
-    MessageFormatError(MessageFormatError),
-    MessageError(MessageError),
-    OutboundError(DhtOutboundError),
-    CommsServicesError(CommsError),
-    HexError(HexError),
-    DatabaseError(DieselError),
-    TransportChannelError(TransportChannelError),
-    #[error(msg_embedded, no_from, non_std)]
+    #[error("Message format error: `{0}`")]
+    MessageFormatError(#[from] MessageFormatError),
+    #[error("Message error: `{0}`")]
+    MessageError(#[from] MessageError),
+    #[error("Outbound error: `{0}`")]
+    OutboundError(#[from] DhtOutboundError),
+    #[error("Comms services error: `{0}`")]
+    CommsServicesError(#[from] CommsError),
+    #[error("Hex error: `{0}`")]
+    HexError(#[from] HexError),
+    #[error("Database error: `{0}`")]
+    DatabaseError(#[from] DieselError),
+    #[error("Transport channel error: `{0}`")]
+    TransportChannelError(#[from] TransportChannelError),
+    #[error("Database migration error: `{0}`")]
     DatabaseMigrationError(String),
-    NetAddressError(NetAddressError),
-    DatabaseConnectionError(DieselConnectionError),
-    BlockingError(BlockingError),
+    #[error("Net address error: `{0}`")]
+    NetAddressError(#[from] NetAddressError),
+    #[error("Database connection error: `{0}`")]
+    DatabaseConnectionError(#[from] DieselConnectionError),
+    #[error("Blocking error: `{0}`")]
+    BlockingError(#[from] BlockingError),
+    #[error("R2d2 error")]
     R2d2Error,
-    LivenessError(LivenessError),
-    /// An error has occurred reading or writing the event subscriber stream
+    #[error("Liveness error: `{0}`")]
+    LivenessError(#[from] LivenessError),
+    #[error("An error has occurred reading or writing the event subscriber stream")]
     EventStreamError,
-    /// If a received TextMessageAck doesn't matching any pending messages
+    #[error("If a received TextMessageAck doesn't matching any pending messages")]
     MessageNotFound,
-    /// Failed to send from API
+    #[error("Failed to send from API")]
     ApiSendFailed,
-    /// Failed to receive in API from service
+    #[error("Failed to receive in API from service")]
     ApiReceiveFailed,
-    /// The Outbound Message Service is not initialized
+    #[error("The Outbound Message Service is not initialized")]
     OMSNotInitialized,
-    /// The Comms service stack is not initialized
+    #[error("The Comms service stack is not initialized")]
     CommsNotInitialized,
-    /// Received an unexpected API response
+    #[error("Received an unexpected API response")]
     UnexpectedApiResponse,
-    /// Contact not found
+    #[error("Contact not found")]
     ContactNotFound,
-    /// Contact already exists
+    #[error("Contact already exists")]
     ContactAlreadyExists,
-    /// There was an error updating a row in the database
+    #[error("There was an error updating a row in the database")]
     DatabaseUpdateError,
-    /// Error retrieving settings
+    #[error("Error retrieving settings")]
     SettingsReadError,
 }

--- a/base_layer/wallet_ffi/Cargo.toml
+++ b/base_layer/wallet_ffi/Cargo.toml
@@ -20,7 +20,7 @@ tokio = "0.2.10"
 libc = "0.2.65"
 rand = "0.7.2"
 chrono = { version = "0.4.6", features = ["serde"]}
-derive-error = "0.0.4"
+thiserror = "1.0.20"
 log = "0.4.6"
 log4rs = {version = "0.8.3", features = ["console_appender", "file_appender", "file", "yaml_format"]}
 

--- a/base_layer/wallet_ffi/src/error.rs
+++ b/base_layer/wallet_ffi/src/error.rs
@@ -19,7 +19,6 @@
 // SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-use derive_error::Error;
 use log::*;
 use tari_comms::{
     multiaddr,
@@ -35,27 +34,25 @@ use tari_wallet::{
     output_manager_service::error::{OutputManagerError, OutputManagerStorageError},
     transaction_service::error::{TransactionServiceError, TransactionStorageError},
 };
+use thiserror::Error;
 
 const LOG_TARGET: &str = "wallet_ffi::error";
 
 #[derive(Debug, Error, PartialEq)]
 pub enum InterfaceError {
-    /// An error has occurred due to one of the parameters being null
-    #[error(msg_embedded, non_std, no_from)]
+    #[error("An error has occurred due to one of the parameters being null: `{0}`")]
     NullError(String),
-    /// An error has occurred when checking the length of the allocated object
+    #[error("An error has occurred when checking the length of the allocated object")]
     AllocationError,
-    /// An error because the supplied position was out of range
+    #[error("An error because the supplied position was out of range")]
     PositionInvalidError,
-    /// An error has occurred when trying to create the tokio runtime
-    #[error(non_std, no_from)]
+    #[error("An error has occurred when trying to create the tokio runtime: `{0}`")]
     TokioError(String),
-    /// An error has occurred when attempting to deserialize input data
-    #[error(non_std, no_from)]
+    #[error("An error has occurred when attempting to deserialize input data: `{0}`")]
     DeserializationError(String),
-    /// Emoji ID is invalid
+    #[error("Emoji ID is invalid")]
     InvalidEmojiId,
-    /// Comms Private Key is not present while Db appears to be encrypted which should not happen
+    #[error("Comms Private Key is not present while Db appears to be encrypted which should not happen")]
     MissingCommsPrivateKey,
 }
 
@@ -260,7 +257,7 @@ impl From<WalletError> for LibWalletError {
     }
 }
 
-/// This implementation maps the internal HexError to a set of LibWalletErrors. The mapping is explicitly manager
+/// This implementation maps the internal HexError to a set of LibWalletErrors. The mapping is explicitly managed
 /// here and error code 999 is a catch-all code for any errors that are not explicitly mapped
 impl From<HexError> for LibWalletError {
     fn from(h: HexError) -> Self {

--- a/comms/Cargo.toml
+++ b/comms/Cargo.toml
@@ -34,7 +34,7 @@ rand = "0.7.2"
 serde = "1.0.90"
 serde_derive = "1.0.90"
 snow = {version="=0.6.2", features=["default-resolver"]}
-thiserror = "1.0.19"
+thiserror = "1.0.20"
 tokio = {version="~0.2.19", features=["blocking", "time", "tcp", "dns", "sync", "stream", "signal"]}
 tokio-util = {version="0.2.0", features=["codec"]}
 tower= "0.3.1"

--- a/comms/dht/Cargo.toml
+++ b/comms/dht/Cargo.toml
@@ -36,7 +36,7 @@ ttl_cache = "0.5.1"
 
 # tower-filter dependencies
 pin-project = "0.4"
-thiserror = "1.0.19"
+thiserror = "1.0.20"
 
 [dev-dependencies]
 tari_test_utils = { version = "^0.2", path = "../../infrastructure/test_utils"}

--- a/comms/examples/stress/error.rs
+++ b/comms/examples/stress/error.rs
@@ -52,7 +52,7 @@ pub enum Error {
     SendError(#[from] SendError),
     #[error("JoinError: {0}")]
     JoinError(#[from] task::JoinError),
-    #[error("Example did not exit cleanly")]
+    #[error("Example did not exit cleanly: `{0}`")]
     WaitTimeout(#[from] time::Elapsed),
     #[error("IO error: {0}")]
     Io(#[from] io::Error),

--- a/infrastructure/storage/Cargo.toml
+++ b/infrastructure/storage/Cargo.toml
@@ -11,10 +11,9 @@ edition = "2018"
 
 [dependencies]
 bincode = "1.1"
-derive-error = "0.0.4"
 log = "0.4.0"
 lmdb-zero = "0.4.4"
-thiserror = "1.0.15"
+thiserror = "1.0.20"
 rmp = "0.8.7"
 rmp-serde = "0.13.7"
 serde = "1.0.80"

--- a/infrastructure/storage/src/key_val_store/error.rs
+++ b/infrastructure/storage/src/key_val_store/error.rs
@@ -20,21 +20,18 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use derive_error::Error;
+use thiserror::Error;
 
 #[derive(Debug, Error, Clone)]
 pub enum KeyValStoreError {
-    /// The Thread Safety has been breached and the data access has become poisoned
+    #[error("The Thread Safety has been breached and the data access has become poisoned")]
     PoisonedAccess,
-    /// An error occurred with the key value query or store
-    #[error(no_from, non_std)]
+    #[error("An error occurred with the key value query or store: `{0}`")]
     DatabaseError(String),
-    /// An error occurred during serialization
-    #[error(no_from, non_std)]
+    #[error("An error occurred during serialization: `{0}`")]
     SerializationError(String),
-    /// An error occurred during deserialization
-    #[error(no_from, non_std)]
+    #[error("An error occurred during deserialization: `{0}`")]
     DeserializationError(String),
-    /// The specified key did not exist in the key-val store
+    #[error("The specified key did not exist in the key-val store")]
     KeyNotFound,
 }

--- a/infrastructure/storage/src/lmdb_store/error.rs
+++ b/infrastructure/storage/src/lmdb_store/error.rs
@@ -25,13 +25,13 @@ use thiserror::Error;
 pub enum LMDBError {
     #[error("Cannot create LMDB. The path does not exist")]
     InvalidPath,
-    #[error("An error occurred during serialization:{0}")]
+    #[error("An error occurred during serialization: {0}")]
     SerializationErr(String),
-    #[error("An error occurred during a get query:{0}")]
+    #[error("An error occurred during a get query: {0}")]
     GetError(String),
-    #[error("An error occurred during commit:{0}")]
+    #[error("An error occurred during commit: {0}")]
     CommitError(String),
-    #[error("An LMDB error occurred:{source}")]
+    #[error("An LMDB error occurred: {source}")]
     DatabaseError {
         #[from]
         source: lmdb_zero::error::Error,


### PR DESCRIPTION
## Description
All error types migrated to use `thiserror` crate. Dependency on `derive-error` removed. 

## Motivation and Context
#1718 motivates the migration of error types to `thiserror` crate in place of `derive-error`.
Also bumped `thiserror` to version `1.0.20` across the repo. 
In places where previous error messages were defined for `derive-error` I have used those. 
Where not previously defined, I have used generic descriptions of the errors - please advise if these are not suitable?

## How Has This Been Tested?
* [X] cargo test 
* [X] circle ci pipeline
* [X] manual sanity test

## Types of changes
* [ ] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [X] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
* [X] I'm merging against the `development` branch.
* [X] I ran `cargo-fmt --all` before pushing.
* [X] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
