### PR TITLE
Add extra validation to `wallet_get_pending_X_transaction_by_id` methods

### DIFF
--- a/base_layer/wallet_ffi/src/lib.rs
+++ b/base_layer/wallet_ffi/src/lib.rs
@@ -3821,7 +3821,9 @@ pub unsafe extern "C" fn wallet_get_pending_inbound_transaction_by_id(
     match completed_transactions {
         Ok(completed_transactions) => {
             if let Some(tx) = completed_transactions.get(&transaction_id) {
-                if tx.status == TransactionStatus::Broadcast || tx.status == TransactionStatus::Completed {
+                if (tx.status == TransactionStatus::Broadcast || tx.status == TransactionStatus::Completed) &&
+                    tx.direction == TransactionDirection::Inbound
+                {
                     let completed = tx.clone();
                     let pending_tx = TariPendingInboundTransaction::from(completed);
                     return Box::into_raw(Box::new(pending_tx));
@@ -3893,7 +3895,9 @@ pub unsafe extern "C" fn wallet_get_pending_outbound_transaction_by_id(
     match completed_transactions {
         Ok(completed_transactions) => {
             if let Some(tx) = completed_transactions.get(&transaction_id) {
-                if tx.status == TransactionStatus::Broadcast || tx.status == TransactionStatus::Completed {
+                if (tx.status == TransactionStatus::Broadcast || tx.status == TransactionStatus::Completed) &&
+                    tx.direction == TransactionDirection::Outbound
+                {
                     let completed = tx.clone();
                     let pending_tx = TariPendingOutboundTransaction::from(completed);
                     return Box::into_raw(Box::new(pending_tx));


### PR DESCRIPTION
## Description
This PR adds an extra validation check to the `wallet_get_pending_outbound_transaction_by_id` and `wallet_get_pending_inbound_transaction_by_id` FFI methods. Previously if you called these functions with the TxId of an inbound/outbound completed transaction, respectively, that was not mined it would be mistakenly returns as the direction of the function that was called. The extra validation ensures that the transaction will not be returned unless the direction is strictly correct.

This should not have been an issue as the functions that return the TxIds for pending transactions that would be used to call these functions are correct but this validation makes sure this error is not possible.

## How Has This Been Tested?
Existing Tests

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch.
* [x] I ran `cargo-fmt --all` before pushing.
* [ ] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
