### PR TITLE
Fix flakey ` test_output_manager_XXX` tests 🤞

### DIFF
--- a/base_layer/wallet/tests/output_manager_service/storage.rs
+++ b/base_layer/wallet/tests/output_manager_service/storage.rs
@@ -322,11 +322,6 @@ pub fn test_db_backend<T: OutputManagerBackend + Clone + 'static>(backend: T) {
     assert_eq!(invalid_outputs.len(), 1);
     assert_eq!(invalid_outputs[0], unspent_outputs[0]);
 
-    let tx_id = runtime
-        .block_on(db.invalidate_output(pending_txs[0].outputs_to_be_received[0].clone()))
-        .unwrap();
-    assert_eq!(tx_id, Some(pending_txs[0].tx_id));
-
     // test revalidating output
     let unspent_outputs = runtime.block_on(db.get_unspent_outputs()).unwrap();
     assert!(
@@ -334,7 +329,7 @@ pub fn test_db_backend<T: OutputManagerBackend + Clone + 'static>(backend: T) {
             .iter()
             .find(|o| o.unblinded_output == invalid_outputs[0].unblinded_output)
             .is_none(),
-        "Should not find ouput"
+        "Should not find output"
     );
 
     assert!(runtime
@@ -350,14 +345,14 @@ pub fn test_db_backend<T: OutputManagerBackend + Clone + 'static>(backend: T) {
         )))
         .unwrap();
     let new_invalid_outputs = runtime.block_on(db.get_invalid_outputs()).unwrap();
-    assert_eq!(new_invalid_outputs.len(), 1);
+    assert_eq!(new_invalid_outputs.len(), 0);
     let unspent_outputs = runtime.block_on(db.get_unspent_outputs()).unwrap();
     assert!(
         unspent_outputs
             .iter()
             .find(|o| o.unblinded_output == invalid_outputs[0].unblinded_output)
             .is_some(),
-        "Should find revalidated ouput"
+        "Should find revalidated output"
     );
 }
 


### PR DESCRIPTION
## Description
The various `test_output_manager_XXX` tests have been flakey and I think this PR fixes the issue. Though its hard to test so we will need to see.

The issue seemed to be that there was a small chance that the first Unspent Output ended up being the same as the first output from the first Pending Transaction so when it was invalidated it still left an output with the same spending key in the db to be found when it shouldn’t.

The removed invalidation was not actually testing anything the rest of the test doesn’t test so was superfluous.

## How Has This Been Tested?
Fixing a test


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch.
* [x] I ran `cargo-fmt --all` before pushing.
* [ ] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
