### PR TITLE
RPC protocol for tari comms

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3701,6 +3701,7 @@ dependencies = [
 name = "tari_comms"
 version = "0.2.1"
 dependencies = [
+ "async-trait",
  "bitflags 1.2.1",
  "blake2",
  "bytes 0.5.6",
@@ -3734,6 +3735,7 @@ dependencies = [
  "tokio-macros",
  "tokio-util 0.2.0",
  "tower",
+ "tower-make",
  "yamux",
 ]
 

--- a/comms/Cargo.toml
+++ b/comms/Cargo.toml
@@ -40,6 +40,10 @@ tokio-util = {version="0.2.0", features=["codec"]}
 tower= "0.3.1"
 yamux = "=0.4.7"
 
+# RPC dependencies
+async-trait = {version="0.1.36", optional=true}
+tower-make = {version="0.3.0", optional=true}
+
 [dev-dependencies]
 tari_test_utils = {version="^0.2", path="../infrastructure/test_utils"}
 
@@ -53,3 +57,4 @@ tari_common = { version = "^0.2", path="../common"}
 
 [features]
 avx2 = ["tari_crypto/avx2"]
+rpc = ["async-trait", "tower-make"]

--- a/comms/src/builder/tests.rs
+++ b/comms/src/builder/tests.rs
@@ -100,7 +100,7 @@ async fn spawn_node(
     (comms_node, inbound_rx, outbound_tx)
 }
 
-#[tokio_macros::test_basic]
+#[runtime::test_basic]
 async fn peer_to_peer_custom_protocols() {
     const TEST_PROTOCOL: Bytes = Bytes::from_static(b"/tari/test");
     const ANOTHER_TEST_PROTOCOL: Bytes = Bytes::from_static(b"/tari/test-again");
@@ -187,7 +187,7 @@ async fn peer_to_peer_custom_protocols() {
     comms_node2.shutdown().await;
 }
 
-#[tokio_macros::test_basic]
+#[runtime::test_basic]
 async fn peer_to_peer_messaging() {
     const NUM_MSGS: usize = 100;
 
@@ -264,7 +264,7 @@ async fn peer_to_peer_messaging() {
     comms_node2.shutdown().await;
 }
 
-#[tokio_macros::test_basic]
+#[runtime::test_basic]
 async fn peer_to_peer_messaging_simultaneous() {
     const NUM_MSGS: usize = 10;
 

--- a/comms/src/common/rate_limit.rs
+++ b/comms/src/common/rate_limit.rs
@@ -129,9 +129,10 @@ impl<T: Stream> Stream for RateLimiter<T> {
 #[cfg(test)]
 mod test {
     use super::*;
+    use crate::runtime;
     use futures::{future::Either, stream};
 
-    #[tokio_macros::test_basic]
+    #[runtime::test_basic]
     async fn rate_limit() {
         let repeater = stream::repeat(());
 
@@ -152,7 +153,7 @@ mod test {
         assert_eq!(count, 10);
     }
 
-    #[tokio_macros::test_basic]
+    #[runtime::test_basic]
     async fn rate_limit_restock() {
         let repeater = stream::repeat(());
 

--- a/comms/src/connection_manager/liveness.rs
+++ b/comms/src/connection_manager/liveness.rs
@@ -53,7 +53,7 @@ mod test {
     use futures::SinkExt;
     use tokio::{time, time::Duration};
 
-    #[tokio_macros::test_basic]
+    #[runtime::test_basic]
     async fn echos() {
         let (inbound, outbound) = MemorySocket::new_pair();
         let liveness = LivenessSession::new(inbound);

--- a/comms/src/connection_manager/tests/listener_dialer.rs
+++ b/comms/src/connection_manager/tests/listener_dialer.rs
@@ -32,6 +32,7 @@ use crate::{
     noise::NoiseConfig,
     peer_manager::PeerFeatures,
     protocol::ProtocolId,
+    runtime,
     test_utils::{node_identity::build_node_identity, test_node::build_peer_manager},
     transports::MemoryTransport,
 };
@@ -46,11 +47,11 @@ use multiaddr::Protocol;
 use std::{error::Error, time::Duration};
 use tari_shutdown::Shutdown;
 use tari_test_utils::unpack_enum;
-use tokio::{runtime::Handle, time::timeout};
+use tokio::time::timeout;
 
-#[tokio_macros::test_basic]
+#[runtime::test_basic]
 async fn listen() -> Result<(), Box<dyn Error>> {
-    let rt_handle = Handle::current();
+    let rt_handle = runtime::current();
     let (event_tx, mut event_rx) = mpsc::channel(1);
     let mut shutdown = Shutdown::new();
     let peer_manager = build_peer_manager();
@@ -83,9 +84,9 @@ async fn listen() -> Result<(), Box<dyn Error>> {
     Ok(())
 }
 
-#[tokio_macros::test_basic]
+#[runtime::test_basic]
 async fn smoke() {
-    let rt_handle = Handle::current();
+    let rt_handle = runtime::current();
     // This test sets up Dialer and Listener components, uses the Dialer to dial the Listener,
     // asserts the emitted events are correct, opens a substream, sends a small message over the substream,
     // receives and checks the message and then disconnects and shuts down.
@@ -188,9 +189,9 @@ async fn smoke() {
     timeout(Duration::from_secs(5), dialer_fut).await.unwrap().unwrap();
 }
 
-#[tokio_macros::test_basic]
+#[runtime::test_basic]
 async fn banned() {
-    let rt_handle = Handle::current();
+    let rt_handle = runtime::current();
     let (event_tx, mut event_rx) = mpsc::channel(10);
     let mut shutdown = Shutdown::new();
 

--- a/comms/src/connection_manager/tests/manager.rs
+++ b/comms/src/connection_manager/tests/manager.rs
@@ -32,6 +32,7 @@ use crate::{
     noise::NoiseConfig,
     peer_manager::{NodeId, Peer, PeerFeatures, PeerFlags, PeerManagerError},
     protocol::{ProtocolEvent, ProtocolId, Protocols, IDENTITY_PROTOCOL},
+    runtime,
     runtime::task,
     test_utils::{
         count_string_occurrences,
@@ -52,7 +53,7 @@ use tari_shutdown::Shutdown;
 use tari_test_utils::{collect_stream, unpack_enum};
 use tokio::{runtime::Handle, sync::broadcast};
 
-#[tokio_macros::test_basic]
+#[runtime::test_basic]
 async fn connect_to_nonexistent_peer() {
     let rt_handle = Handle::current();
     let node_identity = build_node_identity(PeerFeatures::empty());
@@ -85,7 +86,7 @@ async fn connect_to_nonexistent_peer() {
     shutdown.trigger().unwrap();
 }
 
-#[tokio_macros::test_basic]
+#[runtime::test_basic]
 async fn dial_success() {
     const TEST_PROTO: ProtocolId = ProtocolId::from_static(b"/test/valid");
     let shutdown = Shutdown::new();
@@ -189,7 +190,7 @@ async fn dial_success() {
     assert_eq!(buf, MSG);
 }
 
-#[tokio_macros::test_basic]
+#[runtime::test_basic]
 async fn simultaneous_dial_events() {
     let mut shutdown = Shutdown::new();
 

--- a/comms/src/connectivity/test.rs
+++ b/comms/src/connectivity/test.rs
@@ -29,6 +29,7 @@ use super::{
 use crate::{
     connection_manager::ConnectionManagerError,
     peer_manager::{Peer, PeerFeatures},
+    runtime,
     runtime::task,
     test_utils::{
         mocks::{create_connection_manager_mock, create_peer_connection_mock_pair, ConnectionManagerMockState},
@@ -98,7 +99,7 @@ async fn add_test_peers(peer_manager: &PeerManager, n: usize) -> Vec<Peer> {
     peers
 }
 
-#[tokio_macros::test_basic]
+#[runtime::test_basic]
 async fn connecting_peers() {
     let (mut connectivity, mut event_stream, node_identity, peer_manager, cm_mock_state, _shutdown) =
         setup_connectivity_manager(Default::default());
@@ -133,7 +134,7 @@ async fn connecting_peers() {
     }
 }
 
-#[tokio_macros::test_basic]
+#[runtime::test_basic]
 async fn add_many_managed_peers() {
     let (mut connectivity, mut event_stream, node_identity, peer_manager, cm_mock_state, _shutdown) =
         setup_connectivity_manager(Default::default());
@@ -212,7 +213,7 @@ async fn add_many_managed_peers() {
     }
 }
 
-#[tokio_macros::test_basic]
+#[runtime::test_basic]
 async fn ban_peer() {
     let (mut connectivity, mut event_stream, node_identity, peer_manager, cm_mock_state, _shutdown) =
         setup_connectivity_manager(Default::default());
@@ -253,7 +254,7 @@ async fn ban_peer() {
     assert!(conn.is_none());
 }
 
-#[tokio_macros::test_basic]
+#[runtime::test_basic]
 async fn peer_selection() {
     let config = ConnectivityConfig {
         min_connectivity: 1.0,

--- a/comms/src/multiplexing/yamux.rs
+++ b/comms/src/multiplexing/yamux.rs
@@ -336,6 +336,7 @@ mod test {
         connection_manager::ConnectionDirection,
         memsocket::MemorySocket,
         multiplexing::yamux::Yamux,
+        runtime,
         runtime::task,
     };
     use futures::{
@@ -346,7 +347,7 @@ mod test {
     use std::{io, time::Duration};
     use tari_test_utils::collect_stream;
 
-    #[tokio_macros::test_basic]
+    #[runtime::test_basic]
     async fn open_substream() -> io::Result<()> {
         let (dialer, listener) = MemorySocket::new_pair();
         let msg = b"The Way of Kings";
@@ -379,7 +380,7 @@ mod test {
         Ok(())
     }
 
-    #[tokio_macros::test_basic]
+    #[runtime::test_basic]
     async fn substream_count() {
         const NUM_SUBSTREAMS: usize = 10;
         let (dialer, listener) = MemorySocket::new_pair();
@@ -413,7 +414,7 @@ mod test {
         assert_eq!(listener.substream_count(), 0);
     }
 
-    #[tokio_macros::test_basic]
+    #[runtime::test_basic]
     async fn close() -> io::Result<()> {
         let (dialer, listener) = MemorySocket::new_pair();
         let msg = b"Words of Radiance";
@@ -453,7 +454,7 @@ mod test {
         Ok(())
     }
 
-    #[tokio_macros::test_basic]
+    #[runtime::test_basic]
     async fn send_big_message() -> io::Result<()> {
         #[allow(non_upper_case_globals)]
         static MiB: usize = 1 << 20;

--- a/comms/src/noise/socket.rs
+++ b/comms/src/noise/socket.rs
@@ -641,7 +641,7 @@ impl From<Box<TransportState>> for NoiseState {
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::{memsocket::MemorySocket, noise::config::NOISE_IX_PARAMETER};
+    use crate::{memsocket::MemorySocket, noise::config::NOISE_IX_PARAMETER, runtime};
     use futures::future::join;
     use snow::{params::NoiseParams, Builder, Error, Keypair};
     use std::io;
@@ -683,7 +683,7 @@ mod test {
         Ok((dialer_result?, listener_result?))
     }
 
-    #[tokio_macros::test]
+    #[runtime::test]
     async fn test_handshake() {
         let ((dialer_keypair, dialer), (listener_keypair, listener)) = build_test_connection().await.unwrap();
 
@@ -699,7 +699,7 @@ mod test {
         );
     }
 
-    #[tokio_macros::test]
+    #[runtime::test]
     async fn simple_test() -> io::Result<()> {
         let ((_dialer_keypair, dialer), (_listener_keypair, listener)) = build_test_connection().await.unwrap();
 
@@ -719,7 +719,7 @@ mod test {
         Ok(())
     }
 
-    #[tokio_macros::test]
+    #[runtime::test]
     async fn interleaved_writes() -> io::Result<()> {
         let ((_dialer_keypair, dialer), (_listener_keypair, listener)) = build_test_connection().await.unwrap();
 

--- a/comms/src/peer_manager/manager.rs
+++ b/comms/src/peer_manager/manager.rs
@@ -285,6 +285,7 @@ mod test {
             peer::{Peer, PeerFlags},
             PeerFeatures,
         },
+        runtime,
     };
     use rand::rngs::OsRng;
     use tari_crypto::{keys::PublicKey, ristretto::RistrettoPublicKey};
@@ -309,7 +310,7 @@ mod test {
         peer
     }
 
-    #[tokio_macros::test_basic]
+    #[runtime::test_basic]
     async fn get_broadcast_identities() {
         // Create peer manager with random peers
         let peer_manager = PeerManager::new(HashmapDatabase::new()).unwrap();
@@ -422,7 +423,7 @@ mod test {
         assert_ne!(identities1, identities2);
     }
 
-    #[tokio_macros::test_basic]
+    #[runtime::test_basic]
     async fn calc_region_threshold() {
         let n = 5;
         // Create peer manager with random peers
@@ -490,7 +491,7 @@ mod test {
         }
     }
 
-    #[tokio_macros::test_basic]
+    #[runtime::test_basic]
     async fn closest_peers() {
         let n = 5;
         // Create peer manager with random peers
@@ -524,7 +525,7 @@ mod test {
         }
     }
 
-    #[tokio_macros::test_basic]
+    #[runtime::test_basic]
     async fn add_or_update_online_peer() {
         let peer_manager = PeerManager::new(HashmapDatabase::new()).unwrap();
         let mut peer = create_test_peer(false, PeerFeatures::COMMUNICATION_NODE);

--- a/comms/src/pipeline/inbound.rs
+++ b/comms/src/pipeline/inbound.rs
@@ -85,6 +85,7 @@ where
 #[cfg(test)]
 mod test {
     use super::*;
+    use crate::runtime;
     use futures::{channel::mpsc, future, stream};
     use std::time::Duration;
     use tari_shutdown::Shutdown;
@@ -92,7 +93,7 @@ mod test {
     use tokio::{runtime::Handle, time};
     use tower::service_fn;
 
-    #[tokio_macros::test_basic]
+    #[runtime::test_basic]
     async fn run() {
         let items = vec![1, 2, 3, 4, 5, 6];
         let stream = stream::iter(items.clone()).fuse();

--- a/comms/src/pipeline/outbound.rs
+++ b/comms/src/pipeline/outbound.rs
@@ -118,14 +118,14 @@ where
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::pipeline::SinkService;
+    use crate::{pipeline::SinkService, runtime};
     use bytes::Bytes;
     use futures::stream;
     use std::time::Duration;
     use tari_test_utils::{collect_stream, unpack_enum};
     use tokio::{runtime::Handle, time};
 
-    #[tokio_macros::test_basic]
+    #[runtime::test_basic]
     async fn run() {
         const NUM_ITEMS: usize = 10;
         let items =

--- a/comms/src/pipeline/translate_sink.rs
+++ b/comms/src/pipeline/translate_sink.rs
@@ -92,9 +92,10 @@ where F: FnMut(I) -> Option<O>
 #[cfg(test)]
 mod test {
     use super::*;
+    use crate::runtime;
     use futures::{channel::mpsc, SinkExt, StreamExt};
 
-    #[tokio_macros::test_basic]
+    #[runtime::test_basic]
     async fn check_translates() {
         let (tx, mut rx) = mpsc::channel(1);
 

--- a/comms/src/proto/mod.rs
+++ b/comms/src/proto/mod.rs
@@ -25,3 +25,6 @@ pub(crate) mod envelope;
 
 #[path = "tari.comms.identity.rs"]
 pub(crate) mod identity;
+
+#[path = "tari.comms.rpc.rs"]
+pub(crate) mod rpc;

--- a/comms/src/proto/rpc.proto
+++ b/comms/src/proto/rpc.proto
@@ -1,0 +1,49 @@
+syntax = "proto3";
+
+package tari.comms.rpc;
+
+// Message type for all RPC requests
+message RpcRequest {
+    // An identifier that is unique per request per session. This value is not strictly needed as
+    // requests and responses alternate on the protocol level without the need for storing and matching
+    // request IDs. However, this value is useful for logging.
+    uint32 request_id = 1;
+    // The method identifier. The matching method for a given value is defined by each service.
+    uint32 method = 2;
+    // Message flags. Currently this is not used for requests.
+    uint32 flags = 3;
+    // The length of time in seconds that a client is willing to wait for a response
+    uint64 deadline = 4;
+
+    // The message payload
+    bytes message = 10;
+}
+
+// Message type for all RPC responses
+message RpcResponse {
+    // The request ID of a prior request.
+    uint32 request_id = 1;
+    // The status of the response. A non-zero status indicates an error.
+    uint32 status = 2;
+    // Message flags. Currently only used to indicate if a stream of messages has completed.
+    uint32 flags = 3;
+
+    // The message payload. If the status is non-zero, this contains additional error details.
+    bytes message = 10;
+}
+
+// Message sent by the client when negotiating an RPC session. A server may close the substream if it does
+// not agree with the session parameters.
+message RpcSession {
+    // The RPC versions supported by the client
+    repeated uint32 supported_versions = 1;
+}
+
+message RpcSessionReply {
+    oneof session_result {
+        // The RPC version selected by the server
+        uint32 accepted_version = 1;
+        // Indicates the server rejected the session
+        bool rejected = 2;
+    }
+}

--- a/comms/src/proto/tari.comms.rpc.rs
+++ b/comms/src/proto/tari.comms.rpc.rs
@@ -1,0 +1,61 @@
+/// Message type for all RPC requests
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct RpcRequest {
+    /// An identifier that is unique per request per session. This value is not strictly needed as
+    /// requests and responses alternate on the protocol level without the need for storing and matching
+    /// request IDs. However, this value is useful for logging.
+    #[prost(uint32, tag = "1")]
+    pub request_id: u32,
+    /// The method identifier. The matching method for a given value is defined by each service.
+    #[prost(uint32, tag = "2")]
+    pub method: u32,
+    /// Message flags. Currently this is not used for requests.
+    #[prost(uint32, tag = "3")]
+    pub flags: u32,
+    /// The length of time in seconds that a client is willing to wait for a response
+    #[prost(uint64, tag = "4")]
+    pub deadline: u64,
+    /// The message payload
+    #[prost(bytes, tag = "10")]
+    pub message: std::vec::Vec<u8>,
+}
+/// Message type for all RPC responses
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct RpcResponse {
+    /// The request ID of a prior request.
+    #[prost(uint32, tag = "1")]
+    pub request_id: u32,
+    /// The status of the response. A non-zero status indicates an error.
+    #[prost(uint32, tag = "2")]
+    pub status: u32,
+    /// Message flags. Currently only used to indicate if a stream of messages has completed.
+    #[prost(uint32, tag = "3")]
+    pub flags: u32,
+    /// The message payload. If the status is non-zero, this contains additional error details.
+    #[prost(bytes, tag = "10")]
+    pub message: std::vec::Vec<u8>,
+}
+/// Message sent by the client when negotiating an RPC session. A server may close the substream if it does
+/// not agree with the session parameters.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct RpcSession {
+    /// The RPC versions supported by the client
+    #[prost(uint32, repeated, tag = "1")]
+    pub supported_versions: ::std::vec::Vec<u32>,
+}
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct RpcSessionReply {
+    #[prost(oneof = "rpc_session_reply::SessionResult", tags = "1, 2")]
+    pub session_result: ::std::option::Option<rpc_session_reply::SessionResult>,
+}
+pub mod rpc_session_reply {
+    #[derive(Clone, PartialEq, ::prost::Oneof)]
+    pub enum SessionResult {
+        /// The RPC version selected by the server
+        #[prost(uint32, tag = "1")]
+        AcceptedVersion(u32),
+        /// Indicates the server rejected the session
+        #[prost(bool, tag = "2")]
+        Rejected(bool),
+    }
+}

--- a/comms/src/protocol/identity.rs
+++ b/comms/src/protocol/identity.rs
@@ -150,13 +150,14 @@ mod test {
     use crate::{
         connection_manager::ConnectionDirection,
         peer_manager::PeerFeatures,
+        runtime,
         test_utils::node_identity::build_node_identity,
         transports::{MemoryTransport, Transport},
     };
     use futures::{future, StreamExt};
     use tari_crypto::tari_utilities::ByteArray;
 
-    #[tokio_macros::test_basic]
+    #[runtime::test_basic]
     async fn identity_exchange() {
         let transport = MemoryTransport;
         let addr = "/memory/0".parse().unwrap();

--- a/comms/src/protocol/mod.rs
+++ b/comms/src/protocol/mod.rs
@@ -32,6 +32,11 @@ pub use negotiation::ProtocolNegotiation;
 mod protocols;
 pub use protocols::{ProtocolEvent, ProtocolNotification, ProtocolNotificationRx, ProtocolNotificationTx, Protocols};
 
+#[cfg(feature = "rpc")]
+mod rpc;
+// #[cfg(feature = "rpc")]
+// pub use rpc::RpcServer;
+
 pub mod messaging;
 
 /// Represents a protocol id string (e.g. /tari/transactions/1.0.0).

--- a/comms/src/protocol/negotiation.rs
+++ b/comms/src/protocol/negotiation.rs
@@ -197,11 +197,11 @@ where TSocket: AsyncRead + AsyncWrite + Unpin
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::memsocket::MemorySocket;
+    use crate::{memsocket::MemorySocket, runtime};
     use futures::future;
     use tari_test_utils::unpack_enum;
 
-    #[tokio_macros::test_basic]
+    #[runtime::test_basic]
     async fn negotiate_success() {
         let (mut initiator, mut responder) = MemorySocket::new_pair();
         let mut negotiate_out = ProtocolNegotiation::new(&mut initiator);
@@ -226,7 +226,7 @@ mod test {
         assert_eq!(out_proto.unwrap(), ProtocolId::from_static(b"A"));
     }
 
-    #[tokio_macros::test_basic]
+    #[runtime::test_basic]
     async fn negotiate_fail() {
         let (mut initiator, mut responder) = MemorySocket::new_pair();
         let mut negotiate_out = ProtocolNegotiation::new(&mut initiator);
@@ -251,7 +251,7 @@ mod test {
         unpack_enum!(ProtocolError::ProtocolOutboundNegotiationFailed = out_proto.unwrap_err());
     }
 
-    #[tokio_macros::test_basic]
+    #[runtime::test_basic]
     async fn negotiate_fail_max_rounds() {
         let (mut initiator, mut responder) = MemorySocket::new_pair();
         let mut negotiate_out = ProtocolNegotiation::new(&mut initiator);
@@ -276,7 +276,7 @@ mod test {
         unpack_enum!(ProtocolError::ProtocolNegotiationTerminatedByPeer = out_proto.unwrap_err());
     }
 
-    #[tokio_macros::test_basic]
+    #[runtime::test_basic]
     async fn negotiate_success_optimistic() {
         let (mut initiator, mut responder) = MemorySocket::new_pair();
         let mut negotiate_out = ProtocolNegotiation::new(&mut initiator);
@@ -297,7 +297,7 @@ mod test {
         out_proto.unwrap();
     }
 
-    #[tokio_macros::test_basic]
+    #[runtime::test_basic]
     async fn negotiate_fail_optimistic() {
         let (mut initiator, mut responder) = MemorySocket::new_pair();
         let mut negotiate_out = ProtocolNegotiation::new(&mut initiator);

--- a/comms/src/protocol/protocols.rs
+++ b/comms/src/protocol/protocols.rs
@@ -116,6 +116,7 @@ impl<TSubstream> Protocols<TSubstream> {
 #[cfg(test)]
 mod test {
     use super::*;
+    use crate::runtime;
     use futures::StreamExt;
     use tari_test_utils::unpack_enum;
 
@@ -133,7 +134,7 @@ mod test {
         assert!(protocols.get_supported_protocols().iter().all(|p| protos.contains(p)));
     }
 
-    #[tokio_macros::test_basic]
+    #[runtime::test_basic]
     async fn notify() {
         let (tx, mut rx) = mpsc::channel(1);
         let protos = [ProtocolId::from_static(b"/tari/test/1")];
@@ -153,7 +154,7 @@ mod test {
         assert_eq!(*peer_id, NodeId::new());
     }
 
-    #[tokio_macros::test_basic]
+    #[runtime::test_basic]
     async fn notify_fail_not_registered() {
         let mut protocols = Protocols::<()>::new();
 

--- a/comms/src/protocol/rpc/body.rs
+++ b/comms/src/protocol/rpc/body.rs
@@ -1,0 +1,287 @@
+//  Copyright 2020, The Tari Project
+//
+//  Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+//  following conditions are met:
+//
+//  1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+//  disclaimer.
+//
+//  2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+//  following disclaimer in the documentation and/or other materials provided with the distribution.
+//
+//  3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+//  products derived from this software without specific prior written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+//  INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+//  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+//  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+//  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+//  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+//  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+use crate::{
+    message::MessageExt,
+    protocol::rpc::{Response, RpcStatus},
+    Bytes,
+};
+use bytes::BytesMut;
+use futures::{
+    channel::mpsc,
+    ready,
+    stream::BoxStream,
+    task::{Context, Poll},
+    Stream,
+    StreamExt,
+};
+use pin_project::pin_project;
+use prost::bytes::Buf;
+use std::{marker::PhantomData, pin::Pin};
+
+pub trait IntoBody {
+    fn into_body(self) -> Body;
+}
+
+impl<T: prost::Message> IntoBody for T {
+    fn into_body(self) -> Body {
+        Body::single(self)
+    }
+}
+
+#[pin_project]
+pub struct Body {
+    #[pin]
+    kind: BodyKind,
+    is_complete: bool,
+    is_terminated: bool,
+}
+
+impl Body {
+    pub fn single<T: prost::Message>(body: T) -> Self {
+        Self {
+            kind: BodyKind::Single(Some(body.to_encoded_bytes().into())),
+            is_complete: false,
+            is_terminated: false,
+        }
+    }
+
+    pub fn streaming<S>(stream: S) -> Self
+    where S: Stream<Item = Result<Bytes, RpcStatus>> + Send + 'static {
+        Self {
+            kind: BodyKind::Streaming(stream.boxed()),
+            is_complete: false,
+            is_terminated: false,
+        }
+    }
+
+    pub fn is_single(&self) -> bool {
+        match self.kind {
+            BodyKind::Single(_) => true,
+            _ => false,
+        }
+    }
+
+    pub fn is_streaming(&self) -> bool {
+        match self.kind {
+            BodyKind::Streaming(_) => true,
+            _ => false,
+        }
+    }
+}
+
+impl Stream for Body {
+    type Item = Result<BodyBytes, RpcStatus>;
+
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        let this = self.project();
+
+        let mut next_item = None;
+
+        if !*this.is_complete {
+            match this.kind.project() {
+                BodyKindProj::Single(mut item) => {
+                    next_item = item.take().map(Ok);
+                    assert!(next_item.is_some(), "BodyKind::Single contained no message");
+                    *this.is_complete = true;
+                    *this.is_terminated = true;
+                },
+                BodyKindProj::Streaming(stream) => {
+                    next_item = ready!(stream.poll_next(cx));
+                    *this.is_complete = next_item.is_none();
+                },
+            }
+        }
+
+        match next_item.take() {
+            Some(Ok(bytes)) => Poll::Ready(Some(Ok(BodyBytes::new(bytes, *this.is_terminated)))),
+            Some(Err(err)) => {
+                *this.is_complete = true;
+                *this.is_terminated = true;
+                Poll::Ready(Some(Err(err)))
+            },
+            None => {
+                if !*this.is_terminated {
+                    *this.is_terminated = true;
+                    Poll::Ready(Some(Ok(BodyBytes::terminated())))
+                } else {
+                    Poll::Ready(None)
+                }
+            },
+        }
+    }
+}
+
+#[pin_project(project = BodyKindProj)]
+pub enum BodyKind {
+    Single(#[pin] Option<Bytes>),
+    Streaming(#[pin] BoxStream<'static, Result<Bytes, RpcStatus>>),
+}
+
+pub struct BodyBytes(Option<Bytes>, bool);
+
+impl BodyBytes {
+    pub fn new(bytes: Bytes, is_terminated: bool) -> Self {
+        Self(Some(bytes), is_terminated)
+    }
+
+    pub fn terminated() -> Self {
+        Self(None, true)
+    }
+
+    pub fn is_finished(&self) -> bool {
+        self.1
+    }
+
+    pub fn into_bytes_mut(self) -> BytesMut {
+        self.0.map(|v| v.into_iter().collect()).unwrap_or_else(BytesMut::new)
+    }
+
+    pub fn into_vec(self) -> Vec<u8> {
+        self.0.map(|bytes| bytes.to_vec()).unwrap_or_else(Vec::new)
+    }
+}
+
+impl Into<Bytes> for BodyBytes {
+    fn into(self) -> Bytes {
+        self.0.map(Bytes::from).unwrap_or_else(Bytes::new)
+    }
+}
+impl Into<Vec<u8>> for BodyBytes {
+    fn into(self) -> Vec<u8> {
+        self.into_vec()
+    }
+}
+
+impl Into<BytesMut> for BodyBytes {
+    fn into(self) -> BytesMut {
+        self.into_bytes_mut()
+    }
+}
+
+impl Buf for BodyBytes {
+    fn remaining(&self) -> usize {
+        self.0.as_ref().map(Buf::remaining).unwrap_or(0)
+    }
+
+    fn bytes(&self) -> &[u8] {
+        self.0.as_ref().map(Buf::bytes).unwrap_or(&[])
+    }
+
+    fn advance(&mut self, cnt: usize) {
+        if let Some(b) = self.0.as_mut() {
+            b.advance(cnt);
+        }
+    }
+}
+
+pub struct Streaming<T> {
+    inner: mpsc::Receiver<Result<T, RpcStatus>>,
+}
+
+impl<T> Streaming<T> {
+    pub fn new(inner: mpsc::Receiver<Result<T, RpcStatus>>) -> Self {
+        Self { inner }
+    }
+}
+
+impl<T: prost::Message> Stream for Streaming<T> {
+    type Item = Result<Bytes, RpcStatus>;
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        match ready!(self.inner.poll_next_unpin(cx)) {
+            Some(result) => {
+                let result = result.map(|msg| msg.to_encoded_bytes().into());
+                Poll::Ready(Some(result))
+            },
+            None => Poll::Ready(None),
+        }
+    }
+}
+
+impl<T: prost::Message + 'static> IntoBody for Streaming<T> {
+    fn into_body(self) -> Body {
+        Body::streaming(self)
+    }
+}
+
+#[derive(Debug)]
+pub struct ClientStreaming<T> {
+    inner: mpsc::Receiver<Result<Response<Bytes>, RpcStatus>>,
+    _out: PhantomData<T>,
+}
+
+impl<T> ClientStreaming<T> {
+    pub fn new(inner: mpsc::Receiver<Result<Response<Bytes>, RpcStatus>>) -> Self {
+        Self {
+            inner,
+            _out: PhantomData,
+        }
+    }
+}
+
+impl<T: prost::Message + Default + Unpin> Stream for ClientStreaming<T> {
+    type Item = Result<T, RpcStatus>;
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        match ready!(self.inner.poll_next_unpin(cx)) {
+            Some(Ok(resp)) => {
+                // The streaming protocol dictates that an empty finish flag MUST be sent to indicate a terminated
+                // stream. This empty response need not be emitted to downsteam consumers.
+                if resp.flags.is_fin() {
+                    return Poll::Ready(None);
+                }
+                let result = T::decode(resp.into_message()).map_err(Into::into);
+                Poll::Ready(Some(result))
+            },
+            Some(Err(err)) => Poll::Ready(Some(Err(err))),
+            None => Poll::Ready(None),
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::{protocol::rpc::body::Body, runtime};
+    use bytes::Bytes;
+    use futures::{stream, StreamExt};
+    use prost::Message;
+
+    #[runtime::test_basic]
+    async fn single_body() {
+        let mut body = Body::single(123u32);
+        let bytes = body.next().await.unwrap().unwrap();
+        assert!(bytes.is_finished());
+        assert_eq!(u32::decode(bytes).unwrap(), 123u32);
+    }
+
+    #[runtime::test_basic]
+    async fn streaming_body() {
+        let body = Body::streaming(stream::repeat(Bytes::new()).map(Ok).take(10));
+        let body = body.collect::<Vec<_>>().await;
+        assert_eq!(body.len(), 11);
+
+        let body_bytes = body.into_iter().map(|r| r.unwrap()).collect::<Vec<_>>();
+        assert!(body_bytes.iter().take(10).all(|b| !b.is_finished()));
+        assert!(body_bytes.last().unwrap().is_finished());
+    }
+}

--- a/comms/src/protocol/rpc/client.rs
+++ b/comms/src/protocol/rpc/client.rs
@@ -1,0 +1,459 @@
+//  Copyright 2020, The Tari Project
+//
+//  Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+//  following conditions are met:
+//
+//  1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+//  disclaimer.
+//
+//  2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+//  following disclaimer in the documentation and/or other materials provided with the distribution.
+//
+//  3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+//  products derived from this software without specific prior written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+//  INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+//  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+//  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+//  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+//  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+//  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+use super::message::MethodId;
+use crate::{
+    framing::CanonicalFraming,
+    message::MessageExt,
+    proto,
+    protocol::rpc::{body::ClientStreaming, Request, Response, RpcError, RpcStatus},
+    runtime::task,
+};
+use bytes::Bytes;
+use futures::{
+    channel::{mpsc, oneshot},
+    future::Either,
+    task::{Context, Poll},
+    AsyncRead,
+    AsyncWrite,
+    FutureExt,
+    SinkExt,
+    StreamExt,
+};
+use log::*;
+use prost::Message;
+use std::{
+    fmt,
+    future::Future,
+    marker::PhantomData,
+    time::{Duration, Instant},
+};
+use tokio::time;
+use tower::{Service, ServiceExt};
+
+const LOG_TARGET: &str = "comms::rpc::client";
+
+#[derive(Clone)]
+pub struct RpcClient {
+    connector: ClientConnector,
+}
+
+impl RpcClient {
+    /// Create a new RpcClient using the given framed substream and perform the RPC handshake.
+    pub async fn connect<TSubstream>(
+        config: RpcClientConfig,
+        framed: CanonicalFraming<TSubstream>,
+    ) -> Result<Self, RpcError>
+    where
+        TSubstream: AsyncRead + AsyncWrite + Unpin + Send + 'static,
+    {
+        let (request_tx, request_rx) = mpsc::channel(1);
+        let connector = ClientConnector { inner: request_tx };
+        let (ready_tx, ready_rx) = oneshot::channel();
+        task::spawn(RpcClientWorker::new(config, request_rx, framed, ready_tx).run());
+        ready_rx
+            .await
+            .expect("ready_rx oneshot is never dropped without a reply")?;
+        Ok(Self { connector })
+    }
+
+    /// Perform a single request and single response
+    pub async fn request_response<T: prost::Message, R: prost::Message + Default + std::fmt::Debug>(
+        &mut self,
+        request: T,
+        method: MethodId,
+    ) -> Result<R, RpcError>
+    {
+        let req_bytes = request.to_encoded_bytes();
+        let request = Request {
+            method,
+            message: req_bytes.into(),
+        };
+
+        let mut resp = self.call_inner(request).await?;
+        let resp = resp.next().await.ok_or_else(|| RpcError::ServerClosedRequest)??;
+        let resp = R::decode(resp.into_message())?;
+
+        Ok(resp)
+    }
+
+    /// Perform a single request and streaming response
+    pub async fn server_streaming<T: prost::Message, R: prost::Message + Default>(
+        &mut self,
+        request: T,
+        method: MethodId,
+    ) -> Result<ClientStreaming<R>, RpcError>
+    {
+        let req_bytes = request.to_encoded_bytes();
+        let request = Request {
+            method,
+            message: req_bytes.into(),
+        };
+
+        let resp = self.call_inner(request).await?;
+
+        let resp = ClientStreaming::new(resp);
+        Ok(resp)
+    }
+
+    /// Close the RPC session. Any subsequent calls will error.
+    pub fn close(&mut self) {
+        self.connector.close()
+    }
+
+    async fn call_inner(
+        &mut self,
+        request: Request<Bytes>,
+    ) -> Result<mpsc::Receiver<Result<Response<Bytes>, RpcStatus>>, RpcError>
+    {
+        let svc = self.connector.ready_and().await?;
+        let resp = svc.call(request).await?;
+        Ok(resp)
+    }
+}
+
+impl fmt::Debug for RpcClient {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "RpcClient {{ inner: ... }}")
+    }
+}
+
+pub struct RpcClientBuilder<TClient, TSubstream> {
+    config: RpcClientConfig,
+    framed: CanonicalFraming<TSubstream>,
+    _client: PhantomData<TClient>,
+}
+
+impl<TClient, TSubstream> RpcClientBuilder<TClient, TSubstream>
+where
+    TClient: From<RpcClient>,
+    TSubstream: AsyncRead + AsyncWrite + Unpin + Send + 'static,
+{
+    pub fn new(framed: CanonicalFraming<TSubstream>) -> Self {
+        Self {
+            framed,
+            _client: PhantomData,
+            config: Default::default(),
+        }
+    }
+
+    /// The deadline to send to the peer when performing a request.
+    /// If this deadline is exceeded, the server SHOULD abandon the request.
+    /// The client will return a timeout error if the deadline plus the grace period is exceeded.
+    ///
+    /// _Note: That is the deadline is set too low, the responding peer MAY immediately reject the request.
+    ///
+    /// Default: 100s
+    pub fn with_deadline(mut self, timeout: Duration) -> Self {
+        self.config.deadline = Some(timeout);
+        self
+    }
+
+    /// Sets the grace period to allow after the configured deadline before giving up and timing out.
+    /// This configuration should be set to comfortably account for the latency experienced during requests.
+    ///
+    /// Default: 10 seconds
+    pub fn with_deadline_grace_period(mut self, timeout: Duration) -> Self {
+        self.config.deadline_grace_period = timeout;
+        self
+    }
+
+    /// Negotiates and establishes a session to the peer's RPC service using the given substream
+    pub async fn connect(self) -> Result<TClient, RpcError> {
+        RpcClient::connect(self.config, self.framed).await.map(Into::into)
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct RpcClientConfig {
+    pub deadline: Option<Duration>,
+    pub deadline_grace_period: Duration,
+}
+
+impl RpcClientConfig {
+    /// Returns the timeout including the configured grace period
+    pub fn timeout_with_grace_period(&self) -> Option<Duration> {
+        self.deadline.map(|d| d + self.deadline_grace_period)
+    }
+}
+
+impl Default for RpcClientConfig {
+    fn default() -> Self {
+        Self {
+            deadline: Some(Duration::from_secs(100)),
+            deadline_grace_period: Duration::from_secs(10),
+        }
+    }
+}
+
+#[derive(Clone)]
+pub struct ClientConnector {
+    inner: mpsc::Sender<ClientRequest>,
+}
+
+impl ClientConnector {
+    pub fn close(&mut self) {
+        self.inner.close_channel();
+    }
+}
+
+impl fmt::Debug for ClientConnector {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "ClientConnector {{ inner: ... }}")
+    }
+}
+
+impl Service<Request<Bytes>> for ClientConnector {
+    type Error = RpcError;
+    type Response = mpsc::Receiver<Result<Response<Bytes>, RpcStatus>>;
+
+    type Future = impl Future<Output = Result<Self::Response, Self::Error>>;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready_unpin(cx).map_err(|_| RpcError::ClientClosed)
+    }
+
+    fn call(&mut self, request: Request<Bytes>) -> Self::Future {
+        let (reply, reply_rx) = oneshot::channel();
+        let mut inner = self.inner.clone();
+        async move {
+            inner
+                .send(ClientRequest::SendRequest { request, reply })
+                .await
+                .map_err(|_| RpcError::ClientClosed)?;
+
+            reply_rx.await.map_err(|_| RpcError::RequestCancelled)
+        }
+    }
+}
+
+pub struct RpcClientWorker<TSubstream> {
+    config: RpcClientConfig,
+    request_rx: mpsc::Receiver<ClientRequest>,
+    framed: CanonicalFraming<TSubstream>,
+    // Request ids are limited to u16::MAX because varint encoding is used over the wire and the magnitude of the value
+    // sent determines the byte size. A u16 will be more than enough for the purpose (currently just logging)
+    request_id: u16,
+    ready_tx: Option<oneshot::Sender<Result<(), RpcError>>>,
+}
+
+impl<TSubstream> RpcClientWorker<TSubstream>
+where TSubstream: AsyncRead + AsyncWrite + Unpin + Send
+{
+    pub fn new(
+        config: RpcClientConfig,
+        request_rx: mpsc::Receiver<ClientRequest>,
+        framed: CanonicalFraming<TSubstream>,
+        ready_tx: oneshot::Sender<Result<(), RpcError>>,
+    ) -> Self
+    {
+        Self {
+            config,
+            request_rx,
+            framed,
+            request_id: 0,
+            ready_tx: Some(ready_tx),
+        }
+    }
+
+    async fn run(mut self) {
+        debug!(target: LOG_TARGET, "RPC Client worker started");
+
+        let start = Instant::now();
+        match self.perform_handshake().await {
+            Ok(_) => {
+                debug!(
+                    target: LOG_TARGET,
+                    "RPC Session negotiation completed. Latency: {:.0?}",
+                    start.elapsed()
+                );
+                if let Some(r) = self.ready_tx.take() {
+                    let _ = r.send(Ok(()));
+                }
+            },
+            Err(err) => {
+                if let Some(r) = self.ready_tx.take() {
+                    let _ = r.send(Err(err));
+                }
+
+                return;
+            },
+        }
+
+        while let Some(req) = self.request_rx.next().await {
+            use ClientRequest::*;
+            match req {
+                SendRequest { request, reply } => {
+                    if let Err(err) = self.do_request_response(request, reply).await {
+                        debug!(target: LOG_TARGET, "Unexpected error: {}. Worker is terminating.", err);
+                        break;
+                    }
+                },
+            }
+        }
+        if let Err(err) = self.framed.close().await {
+            debug!(target: LOG_TARGET, "IO Error when closing substream: {}", err);
+        }
+
+        debug!(target: LOG_TARGET, "RpcClientWorker terminated.");
+    }
+
+    async fn perform_handshake(&mut self) -> Result<(), RpcError> {
+        let msg = proto::rpc::RpcSession {
+            // Only v0 is supported
+            supported_versions: vec![0],
+        };
+        self.framed.send(msg.to_encoded_bytes().into()).await?;
+        let result = time::timeout(Duration::from_secs(10), self.framed.next()).await;
+        match result {
+            Ok(Some(Ok(msg))) => {
+                let msg = proto::rpc::RpcSessionReply::decode(&mut msg.freeze())?;
+                let version = msg
+                    .accepted_version()
+                    .ok_or_else(|| RpcError::NegotiationServerNoSupportedVersion)?;
+                debug!(target: LOG_TARGET, "Server accepted version {}", version);
+                Ok(())
+            },
+            Ok(Some(Err(err))) => Err(err.into()),
+            Ok(None) => Err(RpcError::ServerClosedRequest),
+            Err(_) => Err(RpcError::NegotiationTimedOut),
+        }
+    }
+
+    async fn do_request_response(
+        &mut self,
+        request: Request<Bytes>,
+        reply: oneshot::Sender<mpsc::Receiver<Result<Response<Bytes>, RpcStatus>>>,
+    ) -> Result<(), RpcError>
+    {
+        let request_id = self.next_request_id();
+        let method = request.method;
+        let req = proto::rpc::RpcRequest {
+            request_id: request_id as u32,
+            method,
+            deadline: self.config.deadline.map(|t| t.as_secs()).unwrap_or(0),
+            flags: 0,
+            message: request.message.to_vec(),
+        };
+
+        debug!(target: LOG_TARGET, "Sending request: {}", req);
+
+        let start = Instant::now();
+        self.framed.send(req.to_encoded_bytes().into()).await?;
+
+        let (mut response_tx, response_rx) = mpsc::channel(10);
+        if reply.send(response_rx).is_err() {
+            debug!(target: LOG_TARGET, "Client request was cancelled.");
+            response_tx.close_channel();
+        }
+
+        loop {
+            // Wait until the timeout, allowing an extra grace period to account for latency
+            let next_msg_fut = match self.config.timeout_with_grace_period() {
+                Some(timeout) => Either::Left(time::timeout(timeout, self.framed.next())),
+                None => Either::Right(self.framed.next().map(Ok)),
+            };
+
+            let resp = match next_msg_fut.await {
+                Ok(resp) => {
+                    trace!(
+                        target: LOG_TARGET,
+                        "Received response from request {} (method={}) in {:.0?} ms",
+                        request_id,
+                        method,
+                        start.elapsed()
+                    );
+                    resp.ok_or_else(|| RpcError::ServerClosedRequest)??
+                },
+                // Timeout
+                Err(_) => {
+                    debug!(
+                        target: LOG_TARGET,
+                        "Request {} (method={}) timed out after {:.0?}",
+                        request_id,
+                        method,
+                        start.elapsed()
+                    );
+                    let _ = response_tx.send(Err(RpcStatus::timed_out("Response timed out"))).await;
+                    response_tx.close_channel();
+                    break;
+                },
+            };
+
+            let resp = proto::rpc::RpcResponse::decode(resp)?;
+
+            match Self::convert_to_result(resp) {
+                Ok(resp) => {
+                    // The consumer may drop the receiver before all responses are received.
+                    // We just ignore that as we still want obey the protocol and receive messages until the FIN flag or
+                    // the connection is dropped
+                    let is_finished = resp.is_finished();
+                    if !response_tx.is_closed() {
+                        let _ = response_tx.send(Ok(resp)).await;
+                    }
+                    if is_finished {
+                        response_tx.close_channel();
+                        break;
+                    }
+                },
+                Err(err) => {
+                    debug!(target: LOG_TARGET, "Remote service returned error: {}", err);
+                    if !response_tx.is_closed() {
+                        let _ = response_tx.send(Err(err)).await;
+                    }
+                    response_tx.close_channel();
+                    break;
+                },
+            }
+        }
+
+        Ok(())
+    }
+
+    fn next_request_id(&mut self) -> u16 {
+        let next_id = self.request_id;
+        // request_id is allowed to wrap around back to 0
+        self.request_id = self.request_id.checked_add(1).unwrap_or(0);
+        next_id
+    }
+
+    fn convert_to_result(resp: proto::rpc::RpcResponse) -> Result<Response<Bytes>, RpcStatus> {
+        let status = RpcStatus::from(&resp);
+        if !status.is_ok() {
+            return Err(status);
+        }
+
+        let resp = Response {
+            flags: resp.flags(),
+            message: resp.message.into(),
+        };
+
+        Ok(resp)
+    }
+}
+
+pub enum ClientRequest {
+    SendRequest {
+        request: Request<Bytes>,
+        reply: oneshot::Sender<mpsc::Receiver<Result<Response<Bytes>, RpcStatus>>>,
+    },
+}

--- a/comms/src/protocol/rpc/either.rs
+++ b/comms/src/protocol/rpc/either.rs
@@ -1,0 +1,96 @@
+//  Copyright 2020, The Tari Project
+//
+//  Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+//  following conditions are met:
+//
+//  1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+//  disclaimer.
+//
+//  2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+//  following disclaimer in the documentation and/or other materials provided with the distribution.
+//
+//  3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+//  products derived from this software without specific prior written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+//  INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+//  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+//  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+//  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+//  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+//  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+//! Contains `Either` and related types and functions.
+//!
+//! See `Either` documentation for more details.
+//!
+//! Tari changes:
+//! 1. Instead of defining a new private boxed error that all users of Either must "comply" with, this implementation
+//!    requires that `A` and `B` both have the same error type. This suits our implementation as all errors are
+//!    `RpcStatus` and removes the need for (often inelegant) error conversions.
+
+use futures::ready;
+use pin_project::pin_project;
+use std::{
+    future::Future,
+    pin::Pin,
+    task::{Context, Poll},
+};
+use tower::Service;
+
+/// Combine two different service types into a single type.
+///
+/// Both services must be of the same request, response, and error types.
+/// `Either` is useful for handling conditional branching in service middleware
+/// to different inner service types.
+#[pin_project(project = EitherProj)]
+#[derive(Clone, Debug)]
+pub enum Either<A, B> {
+    /// One type of backing `Service`.
+    A(#[pin] A),
+    /// The other type of backing `Service`.
+    B(#[pin] B),
+}
+
+impl<A, B, Request> Service<Request> for Either<A, B>
+where
+    A: Service<Request>,
+    B: Service<Request, Response = A::Response, Error = A::Error>,
+{
+    type Error = A::Error;
+    type Future = Either<A::Future, B::Future>;
+    type Response = A::Response;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        use self::Either::*;
+
+        match self {
+            A(service) => Poll::Ready(Ok(ready!(service.poll_ready(cx))?)),
+            B(service) => Poll::Ready(Ok(ready!(service.poll_ready(cx))?)),
+        }
+    }
+
+    fn call(&mut self, request: Request) -> Self::Future {
+        use self::Either::*;
+
+        match self {
+            A(service) => A(service.call(request)),
+            B(service) => B(service.call(request)),
+        }
+    }
+}
+
+impl<A, B, T, AE> Future for Either<A, B>
+where
+    A: Future<Output = Result<T, AE>>,
+    B: Future<Output = Result<T, AE>>,
+{
+    type Output = Result<T, AE>;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        match self.project() {
+            EitherProj::A(fut) => Poll::Ready(Ok(ready!(fut.poll(cx))?)),
+            EitherProj::B(fut) => Poll::Ready(Ok(ready!(fut.poll(cx))?)),
+        }
+    }
+}

--- a/comms/src/protocol/rpc/message.rs
+++ b/comms/src/protocol/rpc/message.rs
@@ -1,0 +1,172 @@
+//  Copyright 2020, The Tari Project
+//
+//  Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+//  following conditions are met:
+//
+//  1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+//  disclaimer.
+//
+//  2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+//  following disclaimer in the documentation and/or other materials provided with the distribution.
+//
+//  3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+//  products derived from this software without specific prior written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+//  INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+//  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+//  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+//  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+//  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+//  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+use super::RpcError;
+use crate::{
+    proto,
+    proto::rpc::rpc_session_reply::SessionResult,
+    protocol::rpc::body::{Body, IntoBody},
+};
+use bitflags::bitflags;
+use bytes::Bytes;
+use std::{fmt, time::Duration};
+
+#[derive(Debug)]
+pub struct Request<T> {
+    pub(super) method: MethodId,
+
+    pub message: T,
+}
+
+impl Request<Bytes> {
+    pub fn decode<T: prost::Message + Default>(&mut self) -> Result<Request<T>, RpcError> {
+        let message = T::decode(&mut self.message)?;
+        Ok(Request {
+            method: self.method,
+            message,
+        })
+    }
+}
+
+impl<T> Request<T> {
+    pub fn method(&self) -> MethodId {
+        self.method
+    }
+
+    pub fn into_message(self) -> T {
+        self.message
+    }
+}
+
+#[derive(Debug)]
+pub struct Response<T> {
+    pub flags: RpcMessageFlags,
+    pub message: T,
+}
+
+impl Response<Body> {
+    pub fn from_message<T: IntoBody>(message: T) -> Self {
+        Self {
+            flags: Default::default(),
+            message: message.into_body(),
+        }
+    }
+}
+
+impl<T> Response<T> {
+    pub fn new(message: T) -> Self {
+        Self {
+            message,
+            flags: Default::default(),
+        }
+    }
+
+    pub fn map<F, U>(self, mut f: F) -> Response<U>
+    where F: FnMut(T) -> U {
+        Response {
+            flags: self.flags,
+            message: f(self.message),
+        }
+    }
+
+    pub fn is_finished(&self) -> bool {
+        self.flags.is_fin()
+    }
+
+    pub fn into_message(self) -> T {
+        self.message
+    }
+}
+
+pub type MethodId = u32;
+
+bitflags! {
+    pub struct RpcMessageFlags: u8 {
+        const FIN = 0x01;
+    }
+}
+impl RpcMessageFlags {
+    pub fn is_fin(&self) -> bool {
+        self.contains(Self::FIN)
+    }
+}
+
+impl Default for RpcMessageFlags {
+    fn default() -> Self {
+        RpcMessageFlags::empty()
+    }
+}
+
+//---------------------------------- RpcRequest --------------------------------------------//
+
+impl proto::rpc::RpcRequest {
+    pub fn deadline(&self) -> Duration {
+        Duration::from_secs(self.deadline)
+    }
+
+    pub fn flags(&self) -> RpcMessageFlags {
+        RpcMessageFlags::from_bits_truncate(self.flags as u8)
+    }
+}
+
+impl fmt::Display for proto::rpc::RpcRequest {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "RequestID={}, Deadline={:.0?}, Flags={:?}, Message={} byte(s)",
+            self.request_id,
+            self.deadline(),
+            self.flags(),
+            self.message.len()
+        )
+    }
+}
+//---------------------------------- RpcResponse --------------------------------------------//
+
+impl proto::rpc::RpcResponse {
+    pub fn flags(&self) -> RpcMessageFlags {
+        RpcMessageFlags::from_bits_truncate(self.flags as u8)
+    }
+}
+
+impl fmt::Display for proto::rpc::RpcResponse {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "RequestID={}, Flags={:?}, Message={} byte(s)",
+            self.request_id,
+            self.flags(),
+            self.message.len()
+        )
+    }
+}
+
+//---------------------------------- RpcSessionReply --------------------------------------------//
+impl proto::rpc::RpcSessionReply {
+    /// Returns the accepted version from the reply. If the session was rejected, None is returned.
+    pub fn accepted_version(&self) -> Option<u32> {
+        match self.session_result.as_ref()? {
+            SessionResult::AcceptedVersion(v) => Some(*v),
+            SessionResult::Rejected(_) => None,
+        }
+    }
+}

--- a/comms/src/protocol/rpc/mod.rs
+++ b/comms/src/protocol/rpc/mod.rs
@@ -20,19 +20,30 @@
 //  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 //  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use crate::compat::IoCompat;
-use futures::{AsyncRead, AsyncWrite};
-use tokio_util::codec::{Framed, LengthDelimitedCodec};
+// TODO: Remove once in use
+#![allow(dead_code)]
 
-/// Tari comms canonical framing
-pub type CanonicalFraming<T> = Framed<IoCompat<T>, LengthDelimitedCodec>;
+#[cfg(test)]
+mod test;
 
-pub fn canonical<T>(stream: T, max_frame_len: usize) -> CanonicalFraming<T>
-where T: AsyncRead + AsyncWrite + Unpin {
-    Framed::new(
-        IoCompat::new(stream),
-        LengthDelimitedCodec::builder()
-            .max_frame_length(max_frame_len)
-            .new_codec(),
-    )
-}
+mod body;
+
+mod server;
+pub use server::RpcServer;
+
+mod client;
+
+mod either;
+
+mod message;
+pub use message::{Request, Response};
+
+mod error;
+pub use error::RpcError;
+
+mod router;
+
+mod status;
+pub use status::{RpcStatus, RpcStatusCode};
+
+mod not_found;

--- a/comms/src/protocol/rpc/router.rs
+++ b/comms/src/protocol/rpc/router.rs
@@ -1,0 +1,290 @@
+//  Copyright 2020, The Tari Project
+//
+//  Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+//  following conditions are met:
+//
+//  1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+//  disclaimer.
+//
+//  2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+//  following disclaimer in the documentation and/or other materials provided with the distribution.
+//
+//  3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+//  products derived from this software without specific prior written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+//  INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+//  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+//  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+//  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+//  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+//  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+use super::{
+    body::Body,
+    either::Either,
+    message::{Request, Response},
+    not_found::ProtocolServiceNotFound,
+    server::NamedProtocolService,
+    RpcError,
+    RpcServer,
+    RpcStatus,
+};
+use crate::{
+    protocol::{ProtocolId, ProtocolNotificationRx},
+    Bytes,
+};
+use futures::{
+    task::{Context, Poll},
+    AsyncRead,
+    AsyncWrite,
+    Future,
+    FutureExt,
+};
+use std::sync::Arc;
+use tower::Service;
+use tower_make::MakeService;
+
+/// Allows service factories of different types to be composed into a single service that resolves a given `ProtocolId`
+pub struct Router<A, B> {
+    server: RpcServer,
+    protocols: Vec<ProtocolId>,
+    routes: Or<A, B>,
+}
+
+impl<A> Router<A, ProtocolServiceNotFound>
+where A: NamedProtocolService
+{
+    /// Create a new Router
+    pub fn new(server: RpcServer, service: A) -> Self {
+        let expected_protocol = ProtocolId::from_static(<A as NamedProtocolService>::PROTOCOL_NAME);
+        let protocols = vec![expected_protocol.clone()];
+        let predicate = move |protocol: &ProtocolId| expected_protocol == protocol;
+        Self {
+            protocols,
+            server,
+            routes: Or::new(predicate, service, ProtocolServiceNotFound),
+        }
+    }
+}
+
+impl<A, B> Router<A, B> {
+    /// Consume this router and return a new router composed of the given service and any previously added services
+    pub fn add_service<T>(mut self, service: T) -> Router<T, Or<A, B>>
+    where T: NamedProtocolService {
+        let expected_protocol = ProtocolId::from_static(<T as NamedProtocolService>::PROTOCOL_NAME);
+        self.protocols.push(expected_protocol.clone());
+        let predicate = move |protocol: &ProtocolId| expected_protocol == protocol;
+        Router {
+            protocols: self.protocols,
+            server: self.server,
+            routes: Or::new(predicate, service, self.routes),
+        }
+    }
+
+    /// Sets the maximum number of sessions this node will allow before rejecting the request to connect
+    pub fn maximum_concurrent_sessions(mut self, limit: usize) -> Self {
+        self.server = self.server.maximum_concurrent_sessions(limit);
+        self
+    }
+
+    /// Allows unlimited (memory-bound) sessions. This should probably only be used for scalability testing.
+    pub fn with_unlimited_concurrent_sessions(mut self) -> Self {
+        self.server = self.server.with_unlimited_concurrent_sessions();
+        self
+    }
+
+    /// Sets the maximum frame size allowed for all RPC messages. Default: 4 MiB
+    pub fn max_frame_size(mut self, max_frame_size: usize) -> Self {
+        self.server = self.server.max_frame_size(max_frame_size);
+        self
+    }
+
+    pub(crate) fn all_protocols(&mut self) -> &[ProtocolId] {
+        &self.protocols
+    }
+}
+
+impl<A, B> Router<A, B>
+where
+    A: MakeService<ProtocolId, Request<Bytes>, Response = Response<Body>, Error = RpcStatus, MakeError = RpcError>
+        + Send
+        + 'static,
+    A::Service: Send + 'static,
+    A::Future: Send + 'static,
+    <A::Service as Service<Request<Bytes>>>::Future: Send + 'static,
+    B: MakeService<ProtocolId, Request<Bytes>, Response = Response<Body>, Error = RpcStatus, MakeError = RpcError>
+        + Send
+        + 'static,
+    B::Service: Send + 'static,
+    B::Future: Send + 'static,
+    <B::Service as Service<Request<Bytes>>>::Future: Send + 'static,
+{
+    /// Start all services
+    pub async fn serve<TSubstream>(
+        self,
+        protocol_notifications: ProtocolNotificationRx<TSubstream>,
+    ) -> Result<(), RpcError>
+    where
+        TSubstream: AsyncRead + AsyncWrite + Unpin + Send + 'static,
+    {
+        self.server.serve(self.routes, protocol_notifications).await
+    }
+}
+
+impl<A, B> Service<ProtocolId> for Router<A, B>
+where
+    A: MakeService<ProtocolId, Request<Bytes>, Response = Response<Body>, Error = RpcStatus, MakeError = RpcError>,
+    B: MakeService<ProtocolId, Request<Bytes>, Response = Response<Body>, Error = RpcStatus, MakeError = RpcError>,
+{
+    type Error = A::MakeError;
+    type Response = Either<A::Service, B::Service>;
+
+    type Future = impl Future<Output = Result<Self::Response, Self::Error>>;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        Service::poll_ready(&mut self.routes, cx)
+    }
+
+    fn call(&mut self, protocol: ProtocolId) -> Self::Future {
+        Service::call(&mut self.routes, protocol)
+    }
+}
+
+pub struct Or<A, B> {
+    predicate: Arc<dyn Fn(&ProtocolId) -> bool + Send + Sync + 'static>,
+    a: A,
+    b: B,
+}
+
+impl<A, B> Or<A, B> {
+    pub fn new<P>(predicate: P, a: A, b: B) -> Self
+    where P: Fn(&ProtocolId) -> bool + Send + Sync + 'static {
+        Self {
+            predicate: Arc::new(predicate),
+            a,
+            b,
+        }
+    }
+}
+
+impl<A, B> Service<ProtocolId> for Or<A, B>
+where
+    A: MakeService<ProtocolId, Request<Bytes>, Response = Response<Body>, Error = RpcStatus, MakeError = RpcError>,
+    B: MakeService<ProtocolId, Request<Bytes>, Response = Response<Body>, Error = RpcStatus, MakeError = RpcError>,
+{
+    type Error = A::MakeError;
+    type Response = Either<A::Service, B::Service>;
+
+    type Future = impl Future<Output = Result<Self::Response, Self::Error>>;
+
+    fn poll_ready(&mut self, _: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        Poll::Ready(Ok(()))
+    }
+
+    fn call(&mut self, protocol: ProtocolId) -> Self::Future {
+        if (self.predicate)(&protocol) {
+            Either::A(self.a.make_service(protocol).map(|r| r.map(Either::A)))
+        } else {
+            Either::B(self.b.make_service(protocol).map(|r| r.map(Either::B)))
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::runtime;
+    use futures::{future, StreamExt};
+    use prost::Message;
+    use tari_test_utils::unpack_enum;
+
+    #[derive(Clone)]
+    struct HelloService;
+    impl NamedProtocolService for HelloService {
+        const PROTOCOL_NAME: &'static [u8] = b"hello";
+    }
+    impl Service<ProtocolId> for HelloService {
+        type Error = RpcError;
+
+        type Future = impl Future<Output = Result<Self::Response, Self::Error>>;
+        type Response = impl Service<Request<Bytes>, Response = Response<Body>, Error = RpcStatus>;
+
+        fn poll_ready(&mut self, _: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+            Poll::Ready(Ok(()))
+        }
+
+        fn call(&mut self, _: ProtocolId) -> Self::Future {
+            let my_service = tower::service_fn(|req: Request<Bytes>| {
+                let str = String::from_utf8_lossy(&req.message);
+                future::ready(Ok(Response::from_message(format!("Hello {}", str))))
+            });
+
+            future::ready(Ok(my_service))
+        }
+    }
+
+    #[derive(Clone)]
+    struct GoodbyeService;
+    impl NamedProtocolService for GoodbyeService {
+        const PROTOCOL_NAME: &'static [u8] = b"goodbye";
+    }
+    impl Service<ProtocolId> for GoodbyeService {
+        type Error = RpcError;
+
+        type Future = impl Future<Output = Result<Self::Response, Self::Error>>;
+        type Response = impl Service<Request<Bytes>, Response = Response<Body>, Error = RpcStatus>;
+
+        fn poll_ready(&mut self, _: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+            Poll::Ready(Ok(()))
+        }
+
+        fn call(&mut self, _: ProtocolId) -> Self::Future {
+            let my_service = tower::service_fn(|req: Request<Bytes>| {
+                let str = String::from_utf8_lossy(&req.message);
+                future::ready(Ok(Response::from_message(format!("Goodbye {}", str))))
+            });
+
+            future::ready(Ok(my_service))
+        }
+    }
+
+    #[runtime::test_basic]
+    async fn find_route() {
+        let server = RpcServer::new();
+        let mut router = Router::new(server, HelloService).add_service(GoodbyeService);
+        assert_eq!(router.all_protocols(), &[
+            HelloService::PROTOCOL_NAME,
+            GoodbyeService::PROTOCOL_NAME
+        ]);
+
+        let mut hello_svc = router.call(HelloService::PROTOCOL_NAME.into()).await.unwrap();
+        let req = Request {
+            method: 1,
+            message: b"Kerbal".to_vec().into(),
+        };
+
+        let resp = hello_svc.call(req).await.unwrap();
+        let resp = resp.into_message().next().await.unwrap().unwrap().into_bytes_mut();
+        let s = String::decode(resp).unwrap();
+        assert_eq!(s, "Hello Kerbal");
+
+        let mut bye_svc = router.call(GoodbyeService::PROTOCOL_NAME.into()).await.unwrap();
+        let req = Request {
+            method: 1,
+            message: b"Xel'naga".to_vec().into(),
+        };
+        let resp = bye_svc.call(req).await.unwrap();
+        let resp = resp.into_message().next().await.unwrap().unwrap().into_bytes_mut();
+        let s = String::decode(resp).unwrap();
+        assert_eq!(s, "Goodbye Xel'naga");
+
+        let result = router.call(ProtocolId::from_static(b"/totally/real/protocol")).await;
+        let err = match result {
+            Ok(_) => panic!("Unexpected success for non-existent route"),
+            Err(err) => err,
+        };
+        unpack_enum!(RpcError::ProtocolServiceNotFound(proto_str) = err);
+        assert_eq!(proto_str, "/totally/real/protocol");
+    }
+}

--- a/comms/src/protocol/rpc/server.rs
+++ b/comms/src/protocol/rpc/server.rs
@@ -1,0 +1,431 @@
+//  Copyright 2020, The Tari Project
+//
+//  Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+//  following conditions are met:
+//
+//  1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+//  disclaimer.
+//
+//  2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+//  following disclaimer in the documentation and/or other materials provided with the distribution.
+//
+//  3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+//  products derived from this software without specific prior written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+//  INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+//  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+//  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+//  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+//  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+//  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+use super::{
+    body::Body,
+    message::{Request, Response},
+    not_found::ProtocolServiceNotFound,
+    router::Router,
+    status::RpcStatus,
+    RpcError,
+};
+use crate::{
+    bounded_executor::OptionallyBoundedExecutor,
+    framing,
+    framing::CanonicalFraming,
+    message::MessageExt,
+    peer_manager::NodeId,
+    proto,
+    protocol::{
+        rpc::message::RpcMessageFlags,
+        ProtocolEvent,
+        ProtocolId,
+        ProtocolNotification,
+        ProtocolNotificationRx,
+    },
+    Bytes,
+};
+use futures::{AsyncRead, AsyncWrite, Sink, SinkExt, StreamExt};
+use log::*;
+use prost::Message;
+use std::{
+    io,
+    time::{Duration, Instant},
+};
+use tari_shutdown::{OptionalShutdownSignal, ShutdownSignal};
+use tokio::time;
+use tower::Service;
+use tower_make::MakeService;
+
+const LOG_TARGET: &str = "comms::rpc";
+
+pub trait NamedProtocolService {
+    const PROTOCOL_NAME: &'static [u8];
+}
+
+#[derive(Debug, Clone)]
+pub struct RpcServer {
+    maximum_concurrent_sessions: Option<usize>,
+    max_frame_size: usize,
+    minimum_client_deadline: Duration,
+    shutdown_signal: OptionalShutdownSignal,
+}
+
+impl RpcServer {
+    pub fn new() -> Self {
+        Default::default()
+    }
+
+    pub fn add_service<S>(self, service: S) -> Router<S, ProtocolServiceNotFound>
+    where
+        S: MakeService<ProtocolId, Request<Bytes>, MakeError = RpcError, Response = Response<Body>, Error = RpcStatus>
+            + NamedProtocolService
+            + Send
+            + 'static,
+        S::Future: Send + 'static,
+    {
+        Router::new(self, service)
+    }
+
+    pub fn maximum_concurrent_sessions(mut self, limit: usize) -> Self {
+        self.maximum_concurrent_sessions = Some(limit);
+        self
+    }
+
+    pub fn max_frame_size(mut self, max_frame_size: usize) -> Self {
+        self.max_frame_size = max_frame_size;
+        self
+    }
+
+    pub fn with_unlimited_concurrent_sessions(mut self) -> Self {
+        self.maximum_concurrent_sessions = None;
+        self
+    }
+
+    pub fn with_minimum_client_deadline(mut self, deadline: Duration) -> Self {
+        self.minimum_client_deadline = deadline;
+        self
+    }
+
+    pub fn with_shutdown_signal(mut self, shutdown_signal: ShutdownSignal) -> Self {
+        self.shutdown_signal = Some(shutdown_signal).into();
+        self
+    }
+
+    pub(super) async fn serve<S, TSubstream>(
+        self,
+        service: S,
+        notifications: ProtocolNotificationRx<TSubstream>,
+    ) -> Result<(), RpcError>
+    where
+        TSubstream: AsyncRead + AsyncWrite + Unpin + Send + 'static,
+        S: MakeService<ProtocolId, Request<Bytes>, MakeError = RpcError, Response = Response<Body>, Error = RpcStatus>
+            + Send
+            + 'static,
+        S::Service: Send + 'static,
+        S::Future: Send + 'static,
+        S::Service: Send + 'static,
+        <S::Service as Service<Request<Bytes>>>::Future: Send + 'static,
+    {
+        PeerRpcServer::new(self, service, notifications).serve().await
+    }
+}
+
+impl Default for RpcServer {
+    fn default() -> Self {
+        Self {
+            maximum_concurrent_sessions: Some(100),
+            max_frame_size: 4 * 1024 * 1024, // 4 MiB
+            minimum_client_deadline: Duration::from_secs(1),
+            shutdown_signal: Default::default(),
+        }
+    }
+}
+
+struct PeerRpcServer<TSvc, TSubstream> {
+    executor: OptionallyBoundedExecutor,
+    config: RpcServer,
+    service: TSvc,
+    protocol_notifications: Option<ProtocolNotificationRx<TSubstream>>,
+}
+
+impl<TSvc, TSubstream> PeerRpcServer<TSvc, TSubstream>
+where
+    TSubstream: AsyncRead + AsyncWrite + Unpin + Send + 'static,
+    TSvc: MakeService<ProtocolId, Request<Bytes>, MakeError = RpcError, Response = Response<Body>, Error = RpcStatus>
+        + Send
+        + 'static,
+    TSvc::Service: Send + 'static,
+    <TSvc::Service as Service<Request<Bytes>>>::Future: Send + 'static,
+    TSvc::Future: Send + 'static,
+{
+    pub fn new(config: RpcServer, service: TSvc, protocol_notifications: ProtocolNotificationRx<TSubstream>) -> Self {
+        Self {
+            executor: OptionallyBoundedExecutor::from_current(config.maximum_concurrent_sessions),
+            config,
+            service,
+            protocol_notifications: Some(protocol_notifications),
+        }
+    }
+
+    pub async fn serve(mut self) -> Result<(), RpcError> {
+        let mut protocol_notifs = self
+            .protocol_notifications
+            .take()
+            .unwrap()
+            .take_until(self.config.shutdown_signal.clone());
+
+        while let Some(notif) = protocol_notifs.next().await {
+            self.handle_protocol_notification(notif).await?;
+        }
+
+        debug!(
+            target: LOG_TARGET,
+            "Peer RPC server is shut down because the shutdown signal was triggered or the protocol notification \
+             stream ended"
+        );
+
+        Ok(())
+    }
+
+    async fn handle_protocol_notification(
+        &mut self,
+        notification: ProtocolNotification<TSubstream>,
+    ) -> Result<(), RpcError>
+    {
+        match notification.event {
+            ProtocolEvent::NewInboundSubstream(node_id, substream) => {
+                debug!(
+                    target: LOG_TARGET,
+                    "New client connection for protocol `{}` from peer `{}`",
+                    String::from_utf8_lossy(&notification.protocol),
+                    node_id
+                );
+
+                let framed = framing::canonical(substream, self.config.max_frame_size);
+                match self.try_spawn_service(notification.protocol, *node_id, framed).await {
+                    Ok(_) => {},
+                    Err(err) => {
+                        debug!(target: LOG_TARGET, "Unable to spawn RPC service: {}", err);
+                    },
+                }
+            },
+        }
+
+        Ok(())
+    }
+
+    async fn try_spawn_service(
+        &mut self,
+        protocol: ProtocolId,
+        node_id: NodeId,
+        mut framed: CanonicalFraming<TSubstream>,
+    ) -> Result<(), RpcError>
+    {
+        if !self.executor.can_spawn() {
+            debug!(
+                target: LOG_TARGET,
+                "Closing substream to peer `{}` because maximum number of concurrent services has been reached",
+                node_id
+            );
+            framed.close().await?;
+            return Err(RpcError::MaximumConcurrencyReached);
+        }
+
+        let service = match self.service.make_service(protocol).await {
+            Ok(s) => s,
+            Err(err) => {
+                framed.close().await?;
+                return Err(err);
+            },
+        };
+
+        let version = self.perform_handshake(&mut framed).await?;
+        debug!(
+            target: LOG_TARGET,
+            "Server negotiated RPC v{} with client node `{}`", version, node_id
+        );
+
+        let service = ActivePeerRpcService {
+            config: self.config.clone(),
+            node_id,
+            framed: Some(framed),
+            service,
+            shutdown_signal: self.config.shutdown_signal.clone(),
+        };
+
+        self.executor
+            .try_spawn(service.start())
+            .map_err(|_| RpcError::MaximumConcurrencyReached)?;
+
+        Ok(())
+    }
+
+    async fn perform_handshake(&self, framed: &mut CanonicalFraming<TSubstream>) -> Result<u32, RpcError> {
+        // Only v0 is supported at this time
+        const SUPPORTED_VERSION: u32 = 0;
+        let result = time::timeout(Duration::from_secs(10), framed.next()).await;
+        match result {
+            Ok(Some(Ok(msg))) => {
+                let msg = proto::rpc::RpcSession::decode(&mut msg.freeze())?;
+                if msg.supported_versions.contains(&SUPPORTED_VERSION) {
+                    let reply = proto::rpc::RpcSessionReply {
+                        session_result: Some(proto::rpc::rpc_session_reply::SessionResult::AcceptedVersion(
+                            SUPPORTED_VERSION,
+                        )),
+                    };
+                    framed.send(reply.to_encoded_bytes().into()).await?;
+                    return Ok(SUPPORTED_VERSION);
+                }
+
+                let reply = proto::rpc::RpcSessionReply {
+                    session_result: Some(proto::rpc::rpc_session_reply::SessionResult::Rejected(true)),
+                };
+                framed.send(reply.to_encoded_bytes().into()).await?;
+                Err(RpcError::NegotiationClientNoSupportedVersion)
+            },
+            Ok(Some(Err(err))) => Err(err.into()),
+            Ok(None) => Err(RpcError::ClientClosed),
+            Err(_elapsed) => Err(RpcError::NegotiationTimedOut),
+        }
+    }
+}
+
+struct ActivePeerRpcService<TSvc, TSubstream> {
+    config: RpcServer,
+    node_id: NodeId,
+    service: TSvc,
+    framed: Option<CanonicalFraming<TSubstream>>,
+    shutdown_signal: OptionalShutdownSignal,
+}
+
+impl<TSvc, TSubstream> ActivePeerRpcService<TSvc, TSubstream>
+where
+    TSubstream: AsyncRead + AsyncWrite + Unpin,
+    TSvc: Service<Request<Bytes>, Response = Response<Body>, Error = RpcStatus>,
+{
+    async fn start(mut self) {
+        debug!(target: LOG_TARGET, "(Peer = `{}`) Rpc server started.", self.node_id);
+        if let Err(err) = self.run().await {
+            error!(
+                target: LOG_TARGET,
+                "(Peer = `{}`) Rpc server exited with an error: {}", self.node_id, err
+            );
+        }
+        debug!(target: LOG_TARGET, "(Peer = {}) Rpc service shutdown", self.node_id);
+    }
+
+    async fn run(&mut self) -> Result<(), RpcError> {
+        let (mut sink, stream) = self.framed.take().unwrap().split();
+        let mut stream = stream.fuse().take_until(self.shutdown_signal.clone());
+
+        while let Some(result) = stream.next().await {
+            let start = Instant::now();
+            if let Err(err) = self.handle(&mut sink, result?.freeze()).await {
+                sink.close().await?;
+                return Err(err);
+            }
+            debug!(target: LOG_TARGET, "RPC request completed in {:.0?}", start.elapsed());
+        }
+
+        sink.close().await?;
+        Ok(())
+    }
+
+    async fn handle<W>(&mut self, sink: &mut W, mut request: Bytes) -> Result<(), RpcError>
+    where W: Sink<Bytes, Error = io::Error> + Unpin + ?Sized {
+        let decoded_msg = proto::rpc::RpcRequest::decode(&mut request)?;
+
+        let request_id = decoded_msg.request_id;
+        let method = decoded_msg.method;
+        let deadline = Duration::from_secs(decoded_msg.deadline);
+
+        // The client side deadline MUST be greater or equal to the minimum_client_deadline
+        if deadline < self.config.minimum_client_deadline {
+            debug!(
+                target: LOG_TARGET,
+                "[Peer=`{}`] Client has an invalid deadline. {}", self.node_id, decoded_msg
+            );
+            // Let the client know that they have disobeyed the spec
+            let status = RpcStatus::bad_request(format!(
+                "Invalid deadline ({:.0?}). The deadline MUST be greater than {:.0?}.",
+                self.node_id, deadline,
+            ));
+            let bad_request = proto::rpc::RpcResponse {
+                request_id,
+                status: status.as_code(),
+                flags: RpcMessageFlags::FIN.bits().into(),
+                message: status.details_bytes(),
+            };
+            sink.send(bad_request.to_encoded_bytes().into()).await?;
+            return Ok(());
+        }
+
+        debug!(
+            target: LOG_TARGET,
+            "[Peer=`{}`] Got request {}", self.node_id, decoded_msg
+        );
+
+        let req = Request {
+            method,
+            message: decoded_msg.message.into(),
+        };
+
+        let service_fut = time::timeout(deadline, self.service.call(req));
+        let service_result = match service_fut.await {
+            Ok(a) => a,
+            Err(_) => {
+                warn!(
+                    target: LOG_TARGET,
+                    "RPC service was not able to complete within the deadline ({:.0?}). Request aborted.", deadline
+                );
+                return Ok(());
+            },
+        };
+
+        match service_result {
+            Ok(body) => {
+                let mut body = body.into_message();
+                while let Some(r) = body.next().await {
+                    let resp = match r {
+                        Ok(msg) => {
+                            let mut flags = RpcMessageFlags::empty();
+                            if msg.is_finished() {
+                                flags |= RpcMessageFlags::FIN;
+                            }
+                            proto::rpc::RpcResponse {
+                                request_id,
+                                status: RpcStatus::ok().as_code(),
+                                flags: flags.bits().into(),
+                                message: msg.into(),
+                            }
+                        },
+                        Err(err) => {
+                            debug!(target: LOG_TARGET, "Body contained an error: {}", err);
+                            proto::rpc::RpcResponse {
+                                request_id,
+                                status: err.as_code(),
+                                flags: RpcMessageFlags::FIN.bits().into(),
+                                message: err.details().as_bytes().to_vec(),
+                            }
+                        },
+                    };
+
+                    sink.send(resp.to_encoded_bytes().into()).await?;
+                }
+            },
+            Err(err) => {
+                debug!(target: LOG_TARGET, "Service returned an error: {}", err);
+                let resp = proto::rpc::RpcResponse {
+                    request_id,
+                    status: err.as_code(),
+                    flags: RpcMessageFlags::FIN.bits().into(),
+                    message: err.details_bytes(),
+                };
+
+                sink.send(resp.to_encoded_bytes().into()).await?;
+            },
+        }
+
+        Ok(())
+    }
+}

--- a/comms/src/protocol/rpc/status.rs
+++ b/comms/src/protocol/rpc/status.rs
@@ -1,0 +1,199 @@
+//  Copyright 2020, The Tari Project
+//
+//  Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+//  following conditions are met:
+//
+//  1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+//  disclaimer.
+//
+//  2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+//  following disclaimer in the documentation and/or other materials provided with the distribution.
+//
+//  3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+//  products derived from this software without specific prior written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+//  INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+//  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+//  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+//  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+//  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+//  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+use super::RpcError;
+use crate::proto;
+use log::*;
+use std::{fmt, fmt::Display};
+use thiserror::Error;
+
+const LOG_TARGET: &str = "comms::rpc::status";
+
+#[derive(Debug, Error)]
+pub struct RpcStatus {
+    code: RpcStatusCode,
+    details: String,
+}
+
+impl RpcStatus {
+    pub fn ok() -> Self {
+        RpcStatus {
+            code: RpcStatusCode::Ok,
+            details: Default::default(),
+        }
+    }
+
+    pub fn unsupported_method<T: ToString>(details: T) -> Self {
+        RpcStatus {
+            code: RpcStatusCode::UnsupportedMethod,
+            details: details.to_string(),
+        }
+    }
+
+    pub fn not_implemented<T: ToString>(details: T) -> Self {
+        RpcStatus {
+            code: RpcStatusCode::NotImplemented,
+            details: details.to_string(),
+        }
+    }
+
+    pub fn bad_request<T: ToString>(details: T) -> Self {
+        Self {
+            code: RpcStatusCode::BadRequest,
+            details: details.to_string(),
+        }
+    }
+
+    pub fn general<T: ToString>(details: T) -> Self {
+        Self {
+            code: RpcStatusCode::General,
+            details: details.to_string(),
+        }
+    }
+
+    pub fn timed_out<T: ToString>(details: T) -> Self {
+        Self {
+            code: RpcStatusCode::Timeout,
+            details: details.to_string(),
+        }
+    }
+
+    pub fn as_code(&self) -> u32 {
+        self.code as u32
+    }
+
+    pub fn status_code(&self) -> RpcStatusCode {
+        self.code
+    }
+
+    pub fn details(&self) -> &str {
+        &self.details
+    }
+
+    pub fn details_bytes(&self) -> Vec<u8> {
+        self.details.as_bytes().to_vec()
+    }
+
+    pub fn is_ok(&self) -> bool {
+        self.code.is_ok()
+    }
+}
+
+impl Display for RpcStatus {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{:?}: {}", self.code, &self.details)
+    }
+}
+
+impl From<RpcError> for RpcStatus {
+    fn from(err: RpcError) -> Self {
+        match err {
+            RpcError::DecodeError(_) => Self::bad_request("Failed to decode request"),
+            RpcError::RequestFailed(status) => status,
+            err => {
+                error!(target: LOG_TARGET, "Request failed: {}", err);
+                Self::general("Internal server error")
+            },
+        }
+    }
+}
+
+impl<'a> From<&'a proto::rpc::RpcResponse> for RpcStatus {
+    fn from(resp: &'a proto::rpc::RpcResponse) -> Self {
+        let status_code = RpcStatusCode::from(resp.status);
+        if status_code.is_ok() {
+            return RpcStatus::ok();
+        }
+
+        RpcStatus {
+            code: status_code,
+            details: String::from_utf8_lossy(&resp.message).to_string(),
+        }
+    }
+}
+
+impl From<prost::DecodeError> for RpcStatus {
+    fn from(_: prost::DecodeError) -> Self {
+        Self::bad_request("Failed to decode request")
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RpcStatusCode {
+    /// Request succeeded
+    Ok = 0,
+    /// Request is incorrect
+    BadRequest = 1,
+    /// The method is not recognised
+    UnsupportedMethod = 2,
+    /// Method is not implemented
+    NotImplemented = 3,
+    /// The timeout was reached before a response was received (client only)
+    Timeout = 4,
+    /// Received malformed response
+    MalformedResponse = 5,
+    /// Misc. errors
+    General = 6,
+    /// Unrecognised RPC status code
+    InvalidRpcStatusCode = 7,
+}
+
+impl RpcStatusCode {
+    pub fn is_ok(self) -> bool {
+        self == Self::Ok
+    }
+}
+
+impl From<u32> for RpcStatusCode {
+    fn from(code: u32) -> Self {
+        use RpcStatusCode::*;
+        match code {
+            0 => Ok,
+            1 => BadRequest,
+            2 => UnsupportedMethod,
+            3 => NotImplemented,
+            4 => Timeout,
+            5 => MalformedResponse,
+            6 => General,
+            _ => InvalidRpcStatusCode,
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn rpc_status_code_conversions() {
+        use RpcStatusCode::*;
+        assert_eq!(RpcStatusCode::from(Ok as u32), Ok);
+        assert_eq!(RpcStatusCode::from(BadRequest as u32), BadRequest);
+        assert_eq!(RpcStatusCode::from(UnsupportedMethod as u32), UnsupportedMethod);
+        assert_eq!(RpcStatusCode::from(General as u32), General);
+        assert_eq!(RpcStatusCode::from(NotImplemented as u32), NotImplemented);
+        assert_eq!(RpcStatusCode::from(MalformedResponse as u32), MalformedResponse);
+        assert_eq!(RpcStatusCode::from(Timeout as u32), Timeout);
+        assert_eq!(RpcStatusCode::from(InvalidRpcStatusCode as u32), InvalidRpcStatusCode);
+        assert_eq!(RpcStatusCode::from(123), InvalidRpcStatusCode);
+    }
+}

--- a/comms/src/protocol/rpc/test.rs
+++ b/comms/src/protocol/rpc/test.rs
@@ -1,0 +1,540 @@
+//  Copyright 2020, The Tari Project
+//
+//  Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+//  following conditions are met:
+//
+//  1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+//  disclaimer.
+//
+//  2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+//  following disclaimer in the documentation and/or other materials provided with the distribution.
+//
+//  3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+//  products derived from this software without specific prior written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+//  INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+//  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+//  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+//  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+//  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+//  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+use super::{body::Streaming, message::Request, Response, RpcError, RpcServer, RpcStatus, RpcStatusCode};
+use crate::{
+    framing,
+    memsocket::MemorySocket,
+    protocol::{ProtocolEvent, ProtocolId, ProtocolNotification},
+    runtime,
+    runtime::task,
+    test_utils::node_identity::build_node_identity,
+};
+use async_trait::async_trait;
+use futures::{channel::mpsc, stream, SinkExt, StreamExt};
+use std::{io, sync::Arc, time::Duration};
+use tari_shutdown::Shutdown;
+use tari_test_utils::unpack_enum;
+use tokio::{sync::RwLock, time};
+
+#[async_trait]
+// #[tari_rpc(module = generated, protocol_name = "/tari/greeting/1.0")]
+pub trait GreetingRpc: Send + Sync + 'static {
+    // #[rpc(method = 1)]
+    async fn say_hello(&self, request: Request<SayHelloRequest>) -> Result<Response<SayHelloResponse>, RpcStatus>;
+    // #[rpc(method = 2)]
+    async fn return_error(&self, request: Request<()>) -> Result<Response<()>, RpcStatus>;
+    // #[rpc(streaming, method = 3)]
+    async fn get_greetings(&self, request: Request<u32>) -> Result<Streaming<String>, RpcStatus>;
+    // #[rpc(streaming, method = 4)]
+    async fn streaming_error(&self, request: Request<String>) -> Result<Streaming<String>, RpcStatus>;
+    // #[rpc(streaming, method = 5)]
+    async fn streaming_error2(&self, _: Request<()>) -> Result<Streaming<String>, RpcStatus>;
+}
+
+async fn setup_service<T: GreetingRpc>(
+    service: T,
+) -> (
+    mpsc::Sender<ProtocolNotification<MemorySocket>>,
+    task::JoinHandle<Result<(), RpcError>>,
+    Shutdown,
+) {
+    let (notif_tx, notif_rx) = mpsc::channel(1);
+    let shutdown = Shutdown::new();
+    let server_hnd = task::spawn(
+        RpcServer::new()
+            .with_minimum_client_deadline(Duration::from_secs(0))
+            .with_shutdown_signal(shutdown.to_signal())
+            .add_service(generated::server::GreetingService::new(service))
+            .serve(notif_rx),
+    );
+    (notif_tx, server_hnd, shutdown)
+}
+
+async fn setup<T: GreetingRpc>(service: T) -> (MemorySocket, task::JoinHandle<Result<(), RpcError>>, Shutdown) {
+    let (mut notif_tx, server_hnd, shutdown) = setup_service(service).await;
+    let (inbound, outbound) = MemorySocket::new_pair();
+    let node_identity = build_node_identity(Default::default());
+
+    // Notify that a peer wants to speak the greeting RPC protocol
+    notif_tx
+        .send(ProtocolNotification::new(
+            ProtocolId::from_static(b"/test/greeting/1.0"),
+            ProtocolEvent::NewInboundSubstream(Box::new(node_identity.node_id().clone()), inbound),
+        ))
+        .await
+        .unwrap();
+
+    (outbound, server_hnd, shutdown)
+}
+
+#[runtime::test_basic]
+async fn request_reponse_errors_and_streaming() // a.k.a  smoke test
+{
+    let greetings = &["Sawubona", "Jambo", "Bonjour", "Hello", "Molo", "Olá"];
+    let (socket, server_hnd, mut shutdown) = setup(GreetingService::new(greetings)).await;
+
+    let framed = framing::canonical(socket, 1024);
+    let mut client = generated::client::GreetingServiceClient::builder(framed)
+        .with_deadline(Duration::from_secs(5))
+        .connect()
+        .await
+        .unwrap();
+
+    let resp = client
+        .say_hello(SayHelloRequest {
+            name: "Yathvan".to_string(),
+            language: 1,
+        })
+        .await
+        .unwrap();
+    assert_eq!(resp.greeting, "Jambo Yathvan");
+
+    let resp = client.get_greetings(4).await.unwrap();
+    let greetings = resp.map(|r| r.unwrap()).collect::<Vec<_>>().await;
+    assert_eq!(greetings, ["Sawubona", "Jambo", "Bonjour", "Hello"]);
+
+    let err = client.return_error().await.unwrap_err();
+    unpack_enum!(RpcError::RequestFailed(status) = err);
+    assert_eq!(status.status_code(), RpcStatusCode::NotImplemented);
+    assert_eq!(status.details(), "I haven't gotten to this yet :(");
+
+    let stream = client.streaming_error("Gurglesplurb".to_string()).await.unwrap();
+    let status = stream
+        // StreamExt::collect has a Default trait bound which Result<_, _> cannot satisfy
+        // so we must first collect the results into a Vec
+        .collect::<Vec<_>>()
+        .await
+        .into_iter()
+        .collect::<Result<String, _>>()
+        .unwrap_err();
+    assert_eq!(status.status_code(), RpcStatusCode::BadRequest);
+    assert_eq!(status.details(), "What does 'Gurglesplurb' mean?");
+
+    let stream = client.streaming_error2().await.unwrap();
+    let results = stream.collect::<Vec<_>>().await;
+    assert_eq!(results.len(), 2);
+    let first_reply = results.get(0).unwrap().as_ref().unwrap();
+    assert_eq!(first_reply, "This is ok");
+
+    let second_reply = results.get(1).unwrap().as_ref().unwrap_err();
+    assert_eq!(second_reply.status_code(), RpcStatusCode::BadRequest);
+    assert_eq!(second_reply.details(), "This is a problem");
+
+    client.close();
+
+    let err = client
+        .say_hello(SayHelloRequest {
+            name: String::new(),
+            language: 0,
+        })
+        .await
+        .unwrap_err();
+
+    unpack_enum!(RpcError::ClientClosed = err);
+
+    shutdown.trigger().unwrap();
+    server_hnd.await.unwrap().unwrap();
+}
+
+#[runtime::test_basic]
+async fn server_shutdown_after_connect() {
+    let (socket, _, mut shutdown) = setup(GreetingService::new(&[])).await;
+    let framed = framing::canonical(socket, 1024);
+    let mut client = generated::client::GreetingServiceClient::connect(framed).await.unwrap();
+    shutdown.trigger().unwrap();
+
+    let err = client.say_hello(Default::default()).await.unwrap_err();
+    unpack_enum!(RpcError::RequestCancelled = err);
+}
+
+#[runtime::test_basic]
+async fn server_shutdown_before_connect() {
+    let (socket, _, mut shutdown) = setup(GreetingService::new(&[])).await;
+    let framed = framing::canonical(socket, 1024);
+    shutdown.trigger().unwrap();
+
+    let err = generated::client::GreetingServiceClient::connect(framed)
+        .await
+        .unwrap_err();
+    unpack_enum!(RpcError::Io(_err) = err);
+}
+
+#[runtime::test_basic]
+async fn timeout() {
+    let delay = Arc::new(RwLock::new(Duration::from_secs(10)));
+    let (socket, _, _shutdown) = setup(SlowGreetingService::new(delay.clone())).await;
+    let framed = framing::canonical(socket, 1024);
+    let mut client = generated::client::GreetingServiceClient::builder(framed)
+        .with_deadline(Duration::from_millis(50))
+        .with_deadline_grace_period(Duration::from_secs(0))
+        .connect()
+        .await
+        .unwrap();
+
+    let err = client.say_hello(Default::default()).await.unwrap_err();
+    unpack_enum!(RpcError::RequestFailed(status) = err);
+    assert_eq!(status.status_code(), RpcStatusCode::Timeout);
+
+    *delay.write().await = Duration::from_secs(0);
+
+    // The server should have hit the deadline and "reset" by waiting for another request without sending a response.
+    // Test that this happens by checking that the next request is furnished correctly
+    let resp = client.say_hello(Default::default()).await.unwrap();
+    assert_eq!(resp.greeting, "took a while to load");
+}
+
+#[runtime::test_basic]
+async fn unknown_protocol() {
+    let (mut notif_tx, _, _shutdown) = setup_service(GreetingService::new(&[])).await;
+
+    let (inbound, socket) = MemorySocket::new_pair();
+    let node_identity = build_node_identity(Default::default());
+
+    // This case should never happen because protocols are preregistered with the connection manager and so a
+    // protocol notification should never be sent out if it is unrecognised. However it is still not a bad
+    // idea to test the behaviour.
+    notif_tx
+        .send(ProtocolNotification::new(
+            ProtocolId::from_static(b"this-is-junk"),
+            ProtocolEvent::NewInboundSubstream(Box::new(node_identity.node_id().clone()), inbound),
+        ))
+        .await
+        .unwrap();
+
+    let framed = framing::canonical(socket, 1024);
+    let err = generated::client::GreetingServiceClient::connect(framed)
+        .await
+        .unwrap_err();
+    unpack_enum!(RpcError::Io(err) = err);
+    // i.e the server just closed the stream immediately
+    assert_eq!(err.kind(), io::ErrorKind::BrokenPipe);
+}
+
+//---------------------------------- Greeting Service --------------------------------------------//
+
+pub struct GreetingService {
+    greetings: Vec<String>,
+}
+
+impl GreetingService {
+    pub fn new(greetings: &[&str]) -> Self {
+        Self {
+            greetings: greetings.iter().map(ToString::to_string).collect(),
+        }
+    }
+}
+
+#[async_trait]
+impl GreetingRpc for GreetingService {
+    async fn say_hello(&self, request: Request<SayHelloRequest>) -> Result<Response<SayHelloResponse>, RpcStatus> {
+        let greeting = self.greetings.get(request.message.language as usize).ok_or_else(|| {
+            RpcStatus::bad_request(format!(
+                "{} is not a valid language identifier",
+                request.message.language
+            ))
+        })?;
+
+        let greeting = format!("{} {}", greeting, request.message.name);
+        Ok(Response::new(SayHelloResponse { greeting }))
+    }
+
+    async fn return_error(&self, _: Request<()>) -> Result<Response<()>, RpcStatus> {
+        Err(RpcStatus::not_implemented("I haven't gotten to this yet :("))
+    }
+
+    async fn get_greetings(&self, request: Request<u32>) -> Result<Streaming<String>, RpcStatus> {
+        let (mut tx, rx) = mpsc::channel(1);
+        let greetings = self.greetings[..request.message as usize].to_vec();
+        task::spawn(async move {
+            let iter = greetings.into_iter().map(Ok);
+            let mut stream = stream::iter(iter)
+                // "Extra" Result::Ok is to satisfy send_all 
+                .map(Ok);
+            match tx.send_all(&mut stream).await {
+                Ok(_) => {},
+                Err(_err) => {
+                    // Log error
+                },
+            }
+        });
+
+        Ok(Streaming::new(rx))
+    }
+
+    async fn streaming_error(&self, request: Request<String>) -> Result<Streaming<String>, RpcStatus> {
+        Err(RpcStatus::bad_request(format!("What does '{}' mean?", request.message)))
+    }
+
+    async fn streaming_error2(&self, _: Request<()>) -> Result<Streaming<String>, RpcStatus> {
+        let (mut tx, rx) = mpsc::channel(2);
+        tx.send(Ok("This is ok".to_string())).await.unwrap();
+        tx.send(Err(RpcStatus::bad_request("This is a problem"))).await.unwrap();
+
+        Ok(Streaming::new(rx))
+    }
+}
+
+pub struct SlowGreetingService {
+    delay: Arc<RwLock<Duration>>,
+}
+
+impl SlowGreetingService {
+    pub fn new(delay: Arc<RwLock<Duration>>) -> Self {
+        Self { delay }
+    }
+}
+
+#[async_trait]
+impl GreetingRpc for SlowGreetingService {
+    async fn say_hello(&self, _: Request<SayHelloRequest>) -> Result<Response<SayHelloResponse>, RpcStatus> {
+        let delay = *self.delay.read().await;
+        time::delay_for(delay).await;
+        Ok(Response::new(SayHelloResponse {
+            greeting: "took a while to load".to_string(),
+        }))
+    }
+
+    async fn return_error(&self, _: Request<()>) -> Result<Response<()>, RpcStatus> {
+        unimplemented!()
+    }
+
+    async fn get_greetings(&self, _: Request<u32>) -> Result<Streaming<String>, RpcStatus> {
+        unimplemented!()
+    }
+
+    async fn streaming_error(&self, _: Request<String>) -> Result<Streaming<String>, RpcStatus> {
+        unimplemented!()
+    }
+
+    async fn streaming_error2(&self, _: Request<()>) -> Result<Streaming<String>, RpcStatus> {
+        unimplemented!()
+    }
+}
+
+#[derive(prost::Message)]
+pub struct SayHelloRequest {
+    #[prost(string, tag = "1")]
+    name: String,
+    #[prost(uint32, tag = "2")]
+    language: u32,
+}
+
+#[derive(prost::Message)]
+pub struct SayHelloResponse {
+    #[prost(string, tag = "1")]
+    greeting: String,
+}
+
+// TODO: This will be generated by a proc macro
+mod generated {
+    pub mod server {
+        #![allow(dead_code)]
+
+        use crate::{
+            protocol::{
+                rpc::{
+                    body::{Body, IntoBody},
+                    message::{Request, Response},
+                    server::NamedProtocolService,
+                    test::GreetingRpc,
+                    RpcError,
+                    RpcStatus,
+                },
+                ProtocolId,
+            },
+            Bytes,
+        };
+        use futures::{future, future::BoxFuture};
+        use std::{
+            future::Future,
+            sync::Arc,
+            task::{Context, Poll},
+        };
+        use tower::Service;
+
+        pub struct GreetingService<T> {
+            inner: Arc<T>,
+        }
+
+        impl<T: GreetingRpc> GreetingService<T> {
+            pub fn new(service: T) -> Self {
+                Self {
+                    inner: Arc::new(service),
+                }
+            }
+        }
+
+        impl<T: GreetingRpc> Service<Request<Bytes>> for GreetingService<T> {
+            type Error = RpcStatus;
+            type Future = BoxFuture<'static, Result<Response<Body>, RpcStatus>>;
+            type Response = Response<Body>;
+
+            fn poll_ready(&mut self, _: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+                Poll::Ready(Ok(()))
+            }
+
+            fn call(&mut self, mut req: Request<Bytes>) -> Self::Future {
+                let inner = self.inner.clone();
+                match req.method() {
+                    // say_hello
+                    1 => {
+                        let fut = async move {
+                            let resp = inner.say_hello(req.decode()?).await?;
+                            Ok(resp.map(IntoBody::into_body))
+                        };
+                        Box::pin(fut)
+                    },
+                    // return_error
+                    2 => {
+                        let fut = async move {
+                            let resp = inner.return_error(req.decode()?).await?;
+                            Ok(resp.map(IntoBody::into_body))
+                        };
+                        Box::pin(fut)
+                    },
+                    // get_greetings
+                    3 => {
+                        let fut = async move {
+                            let resp = inner.get_greetings(req.decode()?).await?;
+                            Ok(Response::new(resp.into_body()))
+                        };
+                        Box::pin(fut)
+                    },
+                    // streaming_error
+                    4 => {
+                        let fut = async move {
+                            let resp = inner.streaming_error(req.decode()?).await?;
+                            Ok(Response::new(resp.into_body()))
+                        };
+                        Box::pin(fut)
+                    },
+                    // streaming_error2
+                    5 => {
+                        let fut = async move {
+                            let resp = inner.streaming_error2(req.decode()?).await?;
+                            Ok(Response::new(resp.into_body()))
+                        };
+                        Box::pin(fut)
+                    },
+                    id => Box::pin(future::ready(Err(RpcStatus::unsupported_method(format!(
+                        "Method identifier `{}` is not recognised or supported",
+                        id
+                    ))))),
+                }
+            }
+        }
+
+        impl<T> Clone for GreetingService<T> {
+            fn clone(&self) -> Self {
+                Self {
+                    inner: self.inner.clone(),
+                }
+            }
+        }
+
+        impl<T> NamedProtocolService for GreetingService<T> {
+            const PROTOCOL_NAME: &'static [u8] = b"/test/greeting/1.0";
+        }
+
+        /// A service maker for GreetingService
+        impl<T> Service<ProtocolId> for GreetingService<T>
+        where T: GreetingRpc
+        {
+            type Error = RpcError;
+            type Response = Self;
+
+            type Future = impl Future<Output = Result<Self::Response, Self::Error>>;
+
+            fn poll_ready(&mut self, _: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+                Poll::Ready(Ok(()))
+            }
+
+            fn call(&mut self, _: ProtocolId) -> Self::Future {
+                future::ready(Ok(self.clone()))
+            }
+        }
+    }
+
+    pub mod client {
+        #![allow(dead_code)]
+
+        use crate::{
+            framing::CanonicalFraming,
+            protocol::rpc::{
+                body::ClientStreaming,
+                client::{RpcClient, RpcClientBuilder},
+                test::{SayHelloRequest, SayHelloResponse},
+                RpcError,
+            },
+        };
+        use futures::{AsyncRead, AsyncWrite};
+
+        #[derive(Debug, Clone)]
+        pub struct GreetingServiceClient {
+            inner: RpcClient,
+        }
+
+        impl GreetingServiceClient {
+            pub async fn connect<TSubstream>(framed: CanonicalFraming<TSubstream>) -> Result<Self, RpcError>
+            where TSubstream: AsyncRead + AsyncWrite + Unpin + Send + 'static {
+                let inner = RpcClient::connect(Default::default(), framed).await?;
+                Ok(Self { inner })
+            }
+
+            pub fn builder<TSubstream>(framed: CanonicalFraming<TSubstream>) -> RpcClientBuilder<Self, TSubstream>
+            where TSubstream: AsyncRead + AsyncWrite + Unpin + Send + 'static {
+                RpcClientBuilder::<Self, _>::new(framed)
+            }
+
+            pub async fn say_hello(&mut self, request: SayHelloRequest) -> Result<SayHelloResponse, RpcError> {
+                self.inner.request_response(request, 1).await
+            }
+
+            pub async fn return_error(&mut self) -> Result<(), RpcError> {
+                self.inner.request_response((), 2).await
+            }
+
+            pub async fn get_greetings(&mut self, request: u32) -> Result<ClientStreaming<String>, RpcError> {
+                self.inner.server_streaming(request, 3).await
+            }
+
+            pub async fn streaming_error(&mut self, request: String) -> Result<ClientStreaming<String>, RpcError> {
+                self.inner.server_streaming(request, 4).await
+            }
+
+            pub async fn streaming_error2(&mut self) -> Result<ClientStreaming<String>, RpcError> {
+                self.inner.server_streaming((), 5).await
+            }
+
+            pub fn close(&mut self) {
+                self.inner.close();
+            }
+        }
+
+        impl From<RpcClient> for GreetingServiceClient {
+            fn from(inner: RpcClient) -> Self {
+                Self { inner }
+            }
+        }
+    }
+}

--- a/comms/src/tor/control_client/client.rs
+++ b/comms/src/tor/control_client/client.rs
@@ -278,7 +278,10 @@ impl fmt::Display for Authentication {
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::tor::control_client::{test_server, test_server::canned_responses, types::PrivateKey};
+    use crate::{
+        runtime,
+        tor::control_client::{test_server, test_server::canned_responses, types::PrivateKey},
+    };
     use futures::future;
     use std::net::SocketAddr;
     use tari_test_utils::unpack_enum;
@@ -290,7 +293,7 @@ mod test {
         (tor, mock_state)
     }
 
-    #[tokio_macros::test]
+    #[runtime::test]
     async fn connect() {
         let (mut listener, addr) = TcpTransport::default()
             .listen("/ip4/127.0.0.1/tcp/0".parse().unwrap())
@@ -306,7 +309,7 @@ mod test {
         result_in.unwrap().unwrap().0.await.unwrap();
     }
 
-    #[tokio_macros::test]
+    #[runtime::test]
     async fn authenticate() {
         let (mut tor, mock_state) = setup_test().await;
 
@@ -330,7 +333,7 @@ mod test {
         assert_eq!(req.remove(0), "AUTHENTICATE NOTACTUALLYHEXENCODED");
     }
 
-    #[tokio_macros::test]
+    #[runtime::test]
     async fn get_conf_ok() {
         let (mut tor, mock_state) = setup_test().await;
 
@@ -345,7 +348,7 @@ mod test {
         assert_eq!(results[2], "8082 127.0.0.1:9001");
     }
 
-    #[tokio_macros::test]
+    #[runtime::test]
     async fn get_conf_err() {
         let (mut tor, mock_state) = setup_test().await;
 
@@ -355,7 +358,7 @@ mod test {
         unpack_enum!(TorClientError::TorCommandFailed(_s) = err);
     }
 
-    #[tokio_macros::test]
+    #[runtime::test]
     async fn get_info_multiline_kv_ok() {
         let (mut tor, mock_state) = setup_test().await;
 
@@ -367,7 +370,7 @@ mod test {
         assert_eq!(values, &["127.0.0.1:9050", "unix:/run/tor/socks"]);
     }
 
-    #[tokio_macros::test]
+    #[runtime::test]
     async fn get_info_kv_multiline_value_ok() {
         let (mut tor, mock_state) = setup_test().await;
 
@@ -382,7 +385,7 @@ mod test {
         ]);
     }
 
-    #[tokio_macros::test]
+    #[runtime::test]
     async fn get_info_err() {
         let (mut tor, mock_state) = setup_test().await;
 
@@ -392,7 +395,7 @@ mod test {
         unpack_enum!(TorClientError::TorCommandFailed(_s) = err);
     }
 
-    #[tokio_macros::test]
+    #[runtime::test]
     async fn add_onion_from_private_key_ok() {
         let (mut tor, mock_state) = setup_test().await;
 
@@ -413,7 +416,7 @@ mod test {
         assert_eq!(request, "ADD_ONION RSA1024:dummy-key Port=8080,127.0.0.1:8080");
     }
 
-    #[tokio_macros::test]
+    #[runtime::test]
     async fn add_onion_ok() {
         let (mut tor, mock_state) = setup_test().await;
 
@@ -445,7 +448,7 @@ mod test {
         assert_eq!(request, "ADD_ONION NEW:BEST NumStreams=10 Port=8080,127.0.0.1:8080");
     }
 
-    #[tokio_macros::test]
+    #[runtime::test]
     async fn add_onion_discard_pk_ok() {
         let (mut tor, mock_state) = setup_test().await;
 
@@ -484,7 +487,7 @@ mod test {
         );
     }
 
-    #[tokio_macros::test]
+    #[runtime::test]
     async fn add_onion_err() {
         let (mut tor, mock_state) = setup_test().await;
 
@@ -498,7 +501,7 @@ mod test {
         unpack_enum!(TorClientError::TorCommandFailed(_s) = err);
     }
 
-    #[tokio_macros::test]
+    #[runtime::test]
     async fn del_onion_ok() {
         let (mut tor, mock_state) = setup_test().await;
 
@@ -510,7 +513,7 @@ mod test {
         assert_eq!(request, "DEL_ONION some-fake-id");
     }
 
-    #[tokio_macros::test]
+    #[runtime::test]
     async fn del_onion_err() {
         let (mut tor, mock_state) = setup_test().await;
 

--- a/comms/src/transports/memory.rs
+++ b/comms/src/transports/memory.rs
@@ -131,13 +131,14 @@ impl Stream for Listener {
 #[cfg(test)]
 mod test {
     use super::*;
+    use crate::runtime;
     use futures::{
         future::join,
         io::{AsyncReadExt, AsyncWriteExt},
         stream::StreamExt,
     };
 
-    #[tokio_macros::test]
+    #[runtime::test]
     async fn simple_listen_and_dial() -> Result<(), ::std::io::Error> {
         let t = MemoryTransport::default();
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR is the first iteration on the tari comms RPC protocol. This protocol is
WIP and not currently in use in any part of the system.

Details here: https://github.com/tari-project/tari/issues/2092

- The tari comms connections are already multiplexed (like HTTP2)
  and so RPC itself carries a small footprint of a few bytes (<~ 10 bytes) per request.
- Server-side streaming supported. Client-side streaming left as a TODO as it's generally less common.
- Statically-typed service routing (tonic-RPC knock off 🙏 )
- Different from tonic however, the router is used to select the matching service factory (impl MakeService) which in turn is used to produce a service that is handed over to the executing task. 
   This service factory can be generated by the proc macro and so is transparent to the API user. 
- RPC protocol version is negotiated once ahead of time, so the version
  does not need to be sent with every message.

Few notes on concurrency:
- All service impls must be Send + 'static. 
- A SINGLE request/response can be performed per peer per protocol at a time. You may clone the client and send multiple 
  requests at once, however they will not be furnished until the previous client requests have completed. Apart from greatly 
  simplifying the code, this also reduces the potential to boundlessly exploit resources. It is expected that each client 
  "session" will only be making one request at a time anyway. If a client peer wishes to make concurrent requests to a 
  service, they are free to open more than one channel at a time.
- None of the RPC service traits may take mutable references to self (i.e. if mutation is required, some method of interior mutability must be used - that satisfies Send).

In progress:
- [ ] Integration with comms (establish client session, register services, peer info etc)
- [ ] Implement proc macro to generate domain-specific client/server code

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
See: https://github.com/tari-project/tari/issues/2092

Example usage (with possible proc macro API): 
```rust
#[tari_rpc(module = generated, protocol_name = "/tari/greeting/1.0")]
pub trait GreetingRpc: Send + Sync + 'static {
    #[rpc(method = 1)]
    async fn say_hello(&self, request: Request<SayHelloRequest>) -> Result<Response<SayHelloResponse>, RpcStatus>;
    #[rpc(method = 2)]
    async fn return_error(&self, request: Request<()>) -> Result<Response<()>, RpcStatus>;
    #[rpc(streaming, method = 3)]
    async fn get_greetings(&self, request: Request<u32>) -> Result<Streaming<String>, RpcStatus>;
    #[rpc(streaming, method = 4)]
    async fn streaming_error(&self, request: Request<String>) -> Result<Streaming<String>, RpcStatus>;
    #[rpc(streaming, method = 5)]
    async fn streaming_error2(&self, _: Request<()>) -> Result<Streaming<String>, RpcStatus>;
}

pub struct GreetingService;

#[async_trait]
impl GreetingRpc for GreetingService {
    async fn say_hello(&self, _: Request<SayHelloRequest>) -> Result<Response<SayHelloResponse>, RpcStatus> {
        Ok(Response::new(SayHelloResponse {
            greeting: "Yo".to_string(),
        }))
    }

    async fn return_error(&self, _: Request<()>) -> Result<Response<()>, RpcStatus> {
        unimplemented!()
    }
// (...)
}

async fn client() {
  let mut client = generated::client::GreetingServiceClient::builder(framed)
        .with_deadline(Duration::from_secs(5))
        .connect()
        .await
        .unwrap();

    let resp = client
        .say_hello(SayHelloRequest {
            name: "Yathvan".to_string(),
            language: 1,
        })
        .await
        .unwrap();
}
```

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Relatively comprehensive unit and smoke testing.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [x] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch.
* [x] I ran `cargo-fmt --all` before pushing.
* [x] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
