### PR TITLE
Simplified messaging protocol, fix for excessive delays

### DIFF
--- a/applications/tari_base_node/src/parser.rs
+++ b/applications/tari_base_node/src/parser.rs
@@ -981,6 +981,7 @@ impl Parser {
         self.executor.spawn(async move {
             let start = Instant::now();
             println!("🌎 Peer discovery started.");
+
             match dht
                 .discover_peer(dest_pubkey.clone(), NodeDestination::PublicKey(dest_pubkey))
                 .await

--- a/comms/dht/examples/memorynet.rs
+++ b/comms/dht/examples/memorynet.rs
@@ -825,7 +825,7 @@ impl TestNode {
                 .filter_map(move |event| {
                     use MessagingEvent::*;
                     future::ready(match &*event {
-                        MessageReceived(peer_node_id, _) => Some((Clone::clone(&**peer_node_id), node_id.clone())),
+                        MessageReceived(peer_node_id, _) => Some((Clone::clone(&*peer_node_id), node_id.clone())),
                         _ => None,
                     })
                 })

--- a/comms/dht/src/dht.rs
+++ b/comms/dht/src/dht.rs
@@ -238,7 +238,7 @@ impl Dht {
         // FIXME: There is an unresolved stack overflow issue on windows in debug mode during runtime, but not in
         //        release mode, related to the amount of layers. (issue #1416)
         ServiceBuilder::new()
-            .layer(inbound::DeserializeLayer)
+            .layer(inbound::DeserializeLayer::new(self.peer_manager.clone()))
             .layer(inbound::ValidateLayer::new(self.config.network))
             .layer(DedupLayer::new(self.dht_requester()))
             .layer(tower_filter::FilterLayer::new(self.unsupported_saf_messages_filter()))
@@ -373,6 +373,8 @@ mod test {
         let peer_manager = make_peer_manager();
         let (connectivity, _) = create_connectivity_mock();
 
+        peer_manager.add_peer(node_identity.to_peer()).await.unwrap();
+
         // Dummy out channel, we are not testing outbound here.
         let (out_tx, _) = mpsc::channel(10);
 
@@ -421,6 +423,8 @@ mod test {
         let peer_manager = make_peer_manager();
         let (connectivity, _) = create_connectivity_mock();
 
+        peer_manager.add_peer(node_identity.to_peer()).await.unwrap();
+
         // Dummy out channel, we are not testing outbound here.
         let (out_tx, _out_rx) = mpsc::channel(10);
 
@@ -467,8 +471,9 @@ mod test {
     async fn stack_forward() {
         let node_identity = make_node_identity();
         let peer_manager = make_peer_manager();
-
         let shutdown = Shutdown::new();
+
+        peer_manager.add_peer(node_identity.to_peer()).await.unwrap();
 
         let (connectivity, _) = create_connectivity_mock();
         let (next_service_tx, mut next_service_rx) = mpsc::channel(10);
@@ -525,6 +530,8 @@ mod test {
         let node_identity = make_client_identity();
         let peer_manager = make_peer_manager();
         let (connectivity, _) = create_connectivity_mock();
+
+        peer_manager.add_peer(node_identity.to_peer()).await.unwrap();
 
         // Dummy out channel, we are not testing outbound here.
         let (out_tx, _) = mpsc::channel(10);

--- a/comms/dht/src/outbound/serialize.rs
+++ b/comms/dht/src/outbound/serialize.rs
@@ -95,6 +95,12 @@ where S: Service<OutboundMessage, Response = (), Error = PipelineError> + Clone 
 
             let body = Bytes::from(envelope.to_encoded_bytes());
 
+            trace!(
+                target: LOG_TARGET,
+                "Serialized outbound message {} for peer `{}`. Passing onto next service",
+                tag,
+                destination_node_id.short_str()
+            );
             next_service
                 .oneshot(OutboundMessage {
                     tag,

--- a/comms/dht/src/test_utils/makers.rs
+++ b/comms/dht/src/test_utils/makers.rs
@@ -64,18 +64,7 @@ pub fn make_peer() -> Peer {
 }
 
 pub fn make_comms_inbound_message(node_identity: &NodeIdentity, message: Bytes) -> InboundMessage {
-    InboundMessage::new(
-        Arc::new(Peer::new(
-            node_identity.public_key().clone(),
-            node_identity.node_id().clone(),
-            Vec::<Multiaddr>::new().into(),
-            PeerFlags::empty(),
-            PeerFeatures::COMMUNICATION_NODE,
-            &[],
-            Default::default(),
-        )),
-        message,
-    )
+    InboundMessage::new(node_identity.node_id().clone(), message)
 }
 
 pub fn make_dht_header(

--- a/comms/examples/stress/prompt.rs
+++ b/comms/examples/stress/prompt.rs
@@ -73,6 +73,7 @@ pub fn user_prompt(default_peer: Option<Peer>) -> Result<(Peer, StressProtocol),
         println!("Select a stress test to perform:");
         println!("1) Continuous Send (Server sends messages to client)");
         println!("2) Alternating Send (Server and client alternate send and receiving)");
+        println!("3) Messaging Flood (Both sides send a flood using the messaging protocol)");
         println!();
         println!(
             "p) Set peer (current: {})",
@@ -96,6 +97,13 @@ pub fn user_prompt(default_peer: Option<Peer>) -> Result<(Peer, StressProtocol),
                 prompt!("Enter the message size (default: 256 bytes)");
                 let msg_size = or_continue!(read_line::<u32>(256));
                 StressProtocol::new(StressProtocolKind::AlternatingSend, n, msg_size)
+            },
+            '3' => {
+                prompt!("Enter the number of messages to send (default: 5,000)");
+                let n = or_continue!(read_line::<u32>(5_000));
+                prompt!("Enter the message size (default: 256 bytes)");
+                let msg_size = or_continue!(read_line::<u32>(256));
+                StressProtocol::new(StressProtocolKind::MessagingFlood, n, msg_size)
             },
             'p' => {
                 prompt!(

--- a/comms/examples/tor.rs
+++ b/comms/examples/tor.rs
@@ -224,7 +224,7 @@ async fn start_ping_ponger(
         counter += 1;
 
         let msg_str = String::from_utf8_lossy(&msg.body);
-        println!("Received '{}' from '{}'", msg_str, msg.source_peer.node_id.short_str());
+        println!("Received '{}' from '{}'", msg_str, msg.source_peer.short_str());
 
         let mut msg_parts = msg_str.split(' ');
         match msg_parts.next() {

--- a/comms/src/builder/comms_node.rs
+++ b/comms/src/builder/comms_node.rs
@@ -168,12 +168,7 @@ where
         let mut messaging_event_tx = None;
         if let Some(messaging_pipeline) = messaging_pipeline {
             let (messaging, notifier, messaging_request_tx, inbound_message_rx, messaging_event_sender) =
-                initialize_messaging(
-                    node_identity.clone(),
-                    peer_manager.clone(),
-                    connection_manager_requester.clone(),
-                    shutdown.to_signal(),
-                );
+                initialize_messaging(connection_manager_requester.clone(), shutdown.to_signal());
             messaging_event_tx = Some(messaging_event_sender);
             protocols.add(&[messaging::MESSAGING_PROTOCOL.clone()], notifier);
             // Spawn messaging protocol
@@ -336,8 +331,6 @@ impl CommsNode {
 }
 
 fn initialize_messaging(
-    node_identity: Arc<NodeIdentity>,
-    peer_manager: Arc<PeerManager>,
     connection_manager_requester: ConnectionManagerRequester,
     shutdown_signal: ShutdownSignal,
 ) -> (
@@ -355,8 +348,6 @@ fn initialize_messaging(
     let messaging = MessagingProtocol::new(
         Default::default(),
         connection_manager_requester,
-        peer_manager,
-        node_identity,
         proto_rx,
         messaging_request_rx,
         event_tx.clone(),

--- a/comms/src/connection_manager/error.rs
+++ b/comms/src/connection_manager/error.rs
@@ -78,6 +78,8 @@ pub enum ConnectionManagerError {
     InvalidMultiaddr(String),
     #[error("Failed to send wire format byte")]
     WireFormatSendFailed,
+    #[error("Noise protocol handshake timed out")]
+    NoiseProtocolTimeout,
 }
 
 impl From<yamux::ConnectionError> for ConnectionManagerError {

--- a/comms/src/connection_manager/listener.rs
+++ b/comms/src/connection_manager/listener.rs
@@ -308,7 +308,12 @@ where
             "Starting noise protocol upgrade for peer at address '{}'", peer_addr
         );
 
-        let noise_socket = noise_config.upgrade_socket(socket, CONNECTION_DIRECTION).await?;
+        let noise_socket = time::timeout(
+            Duration::from_secs(30),
+            noise_config.upgrade_socket(socket, CONNECTION_DIRECTION),
+        )
+        .await
+        .map_err(|_| ConnectionManagerError::NoiseProtocolTimeout)??;
 
         let authenticated_public_key = noise_socket
             .get_remote_public_key()

--- a/comms/src/message/inbound.rs
+++ b/comms/src/message/inbound.rs
@@ -21,23 +21,22 @@
 //  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 use super::MessageTag;
-use crate::peer_manager::Peer;
+use crate::peer_manager::NodeId;
 use bytes::Bytes;
-use std::sync::Arc;
 
 /// Authenticated inbound message
 #[derive(Clone, Debug)]
 pub struct InboundMessage {
     pub tag: MessageTag,
     /// The connected peer which sent this message
-    pub source_peer: Arc<Peer>,
+    pub source_peer: NodeId,
     /// The raw message envelope
     pub body: Bytes,
 }
 
 impl InboundMessage {
     /// Construct a new InboundMessage
-    pub fn new(source_peer: Arc<Peer>, body: Bytes) -> Self {
+    pub fn new(source_peer: NodeId, body: Bytes) -> Self {
         Self {
             tag: MessageTag::new(),
             source_peer,

--- a/comms/src/message/outbound.rs
+++ b/comms/src/message/outbound.rs
@@ -51,6 +51,16 @@ impl OutboundMessage {
         }
     }
 
+    pub fn with_reply(peer_node_id: NodeId, body: Bytes, reply: MessagingReplyTx) -> Self {
+        Self {
+            tag: MessageTag::new(),
+            peer_node_id,
+            body,
+            reply,
+        }
+    }
+
+    #[inline]
     pub fn reply_success(&mut self) {
         self.reply.reply_success();
     }

--- a/comms/src/protocol/messaging/config.rs
+++ b/comms/src/protocol/messaging/config.rs
@@ -28,14 +28,14 @@ pub struct MessagingConfig {
     /// timeout
     ///
     /// Inbound/outbound substreams are closed independently, and they may be reopened in the future once closed.
-    /// (default: 5 mins)
+    /// (default: 8 mins)
     pub inactivity_timeout: Option<Duration>,
 }
 
 impl Default for MessagingConfig {
     fn default() -> Self {
         Self {
-            inactivity_timeout: Some(Duration::from_secs(5 * 60)),
+            inactivity_timeout: Some(Duration::from_secs(8 * 60)),
         }
     }
 }

--- a/comms/src/protocol/messaging/inbound.rs
+++ b/comms/src/protocol/messaging/inbound.rs
@@ -23,18 +23,18 @@
 use crate::{
     common::rate_limit::RateLimit,
     message::InboundMessage,
-    peer_manager::Peer,
+    peer_manager::NodeId,
     protocol::messaging::{MessagingEvent, MessagingProtocol},
 };
-use futures::{channel::mpsc, future::Either, AsyncRead, AsyncWrite, SinkExt};
+use futures::{channel::mpsc, future::Either, AsyncRead, AsyncWrite, SinkExt, StreamExt};
 use log::*;
 use std::{sync::Arc, time::Duration};
-use tokio::{stream::StreamExt, sync::broadcast};
+use tokio::sync::broadcast;
 
 const LOG_TARGET: &str = "comms::protocol::messaging::inbound";
 
 pub struct InboundMessaging {
-    peer: Arc<Peer>,
+    peer: NodeId,
     inbound_message_tx: mpsc::Sender<InboundMessage>,
     messaging_events_tx: broadcast::Sender<Arc<MessagingEvent>>,
     rate_limit_capacity: usize,
@@ -44,7 +44,7 @@ pub struct InboundMessaging {
 
 impl InboundMessaging {
     pub fn new(
-        peer: Arc<Peer>,
+        peer: NodeId,
         inbound_message_tx: mpsc::Sender<InboundMessage>,
         messaging_events_tx: broadcast::Sender<Arc<MessagingEvent>>,
         rate_limit_capacity: usize,
@@ -64,42 +64,49 @@ impl InboundMessaging {
 
     pub async fn run<S>(mut self, socket: S)
     where S: AsyncRead + AsyncWrite + Unpin {
+        let peer = &self.peer;
         debug!(
             target: LOG_TARGET,
             "Starting inbound messaging protocol for peer '{}'",
-            self.peer.node_id.short_str()
+            peer.short_str()
         );
-        let framed_socket =
-            MessagingProtocol::framed(socket).rate_limit(self.rate_limit_capacity, self.rate_limit_restock_interval);
-        let peer = &self.peer;
 
-        let mut framed_socket = match self.inactivity_timeout {
-            Some(timeout) => Either::Left(framed_socket.timeout(timeout)),
-            None => Either::Right(framed_socket.map(Ok)),
+        let (mut sink, stream) = MessagingProtocol::framed(socket).split();
+
+        if let Err(err) = sink.close().await {
+            debug!(
+                target: LOG_TARGET,
+                "Error closing sink half for peer `{}`: {}",
+                peer.short_str(),
+                err
+            );
+        }
+        let stream = stream.rate_limit(self.rate_limit_capacity, self.rate_limit_restock_interval);
+
+        let mut stream = match self.inactivity_timeout {
+            Some(timeout) => Either::Left(tokio::stream::StreamExt::timeout(stream, timeout)),
+            None => Either::Right(stream.map(Ok)),
         };
 
-        while let Some(result) = framed_socket.next().await {
+        while let Some(result) = stream.next().await {
             match result {
                 Ok(Ok(raw_msg)) => {
-                    let inbound_msg = InboundMessage::new(Arc::clone(&peer), raw_msg.clone().freeze());
+                    let inbound_msg = InboundMessage::new(peer.clone(), raw_msg.clone().freeze());
                     debug!(
                         target: LOG_TARGET,
                         "Received message {} from peer '{}' ({} bytes)",
                         inbound_msg.tag,
-                        peer.node_id.short_str(),
+                        peer.short_str(),
                         raw_msg.len()
                     );
 
-                    let event = MessagingEvent::MessageReceived(
-                        Box::new(inbound_msg.source_peer.node_id.clone()),
-                        inbound_msg.tag,
-                    );
+                    let event = MessagingEvent::MessageReceived(inbound_msg.source_peer.clone(), inbound_msg.tag);
 
                     if let Err(err) = self.inbound_message_tx.send(inbound_msg).await {
                         warn!(
                             target: LOG_TARGET,
                             "Failed to send InboundMessage for peer '{}' because '{}'",
-                            peer.node_id.short_str(),
+                            peer.short_str(),
                             err
                         );
 
@@ -114,7 +121,7 @@ impl InboundMessaging {
                     error!(
                         target: LOG_TARGET,
                         "Failed to receive from peer '{}' because '{}'",
-                        peer.node_id.short_str(),
+                        peer.short_str(),
                         err
                     );
                     break;
@@ -124,7 +131,7 @@ impl InboundMessaging {
                     debug!(
                         target: LOG_TARGET,
                         "Inbound messaging for peer '{}' has stopped because it was inactive for {:.0?}",
-                        peer.node_id.short_str(),
+                        peer.short_str(),
                         self.inactivity_timeout
                             .expect("Inactivity timeout reached but it was not enabled"),
                     );
@@ -132,5 +139,11 @@ impl InboundMessaging {
                 },
             }
         }
+
+        debug!(
+            target: LOG_TARGET,
+            "Inbound messaging handler exited for peer `{}`",
+            peer.short_str()
+        );
     }
 }

--- a/comms/src/protocol/messaging/outbound.rs
+++ b/comms/src/protocol/messaging/outbound.rs
@@ -23,28 +23,23 @@
 use super::{error::MessagingProtocolError, MessagingEvent, MessagingProtocol, SendFailReason, MESSAGING_PROTOCOL};
 use crate::{
     connection_manager::{ConnectionManagerError, ConnectionManagerRequester, NegotiatedSubstream, PeerConnection},
-    message::{MessageTag, OutboundMessage},
+    message::OutboundMessage,
     multiplexing::Substream,
     peer_manager::NodeId,
 };
-use bytes::Bytes;
-use futures::{
-    channel::mpsc,
-    future::Either,
-    ready,
-    stream::FusedStream,
-    task::{Context, Poll},
-    Sink,
-    SinkExt,
-    Stream,
-    StreamExt,
-};
+use futures::{channel::mpsc, future::Either, SinkExt, StreamExt};
 use log::*;
-use pin_project::pin_project;
-use std::{io, pin::Pin, time::Duration};
+use std::{
+    io,
+    time::{Duration, Instant},
+};
 use tokio::stream as tokio_stream;
 
 const LOG_TARGET: &str = "comms::protocol::messaging::outbound";
+/// The number of times to retry sending a failed message before publishing a SendMessageFailed event.
+/// This should only need to be 1 to handle the case where the pending dial is cancelled due to to tie breaking
+/// and because the connection manager already retries dialing a number of times for each requested dial.
+const MAX_SEND_RETRIES: usize = 1;
 
 pub struct OutboundMessaging {
     conn_man_requester: ConnectionManagerRequester,
@@ -79,6 +74,7 @@ impl OutboundMessaging {
             self.peer_node_id.short_str()
         );
         let peer_node_id = self.peer_node_id.clone();
+        let mut messaging_events_tx = self.messaging_events_tx.clone();
         match self.run_inner().await {
             Ok(_) => {
                 debug!(
@@ -98,15 +94,65 @@ impl OutboundMessaging {
                 debug!(target: LOG_TARGET, "Outbound messaging substream failed: {}", err);
             },
         }
+
+        let _ = messaging_events_tx
+            .send(MessagingEvent::OutboundProtocolExited(peer_node_id))
+            .await;
     }
 
     async fn run_inner(mut self) -> Result<(), MessagingProtocolError> {
-        let conn = self.try_dial_peer().await?;
-        let substream = self.try_open_substream(conn).await?;
+        let mut attempts = 0;
+        let substream = loop {
+            match self.try_establish().await {
+                Ok(substream) => break substream,
+                Err(err) => {
+                    assert!(
+                        attempts <= MAX_SEND_RETRIES,
+                        "Attempt count was greater than the maximum"
+                    );
+                    if attempts == MAX_SEND_RETRIES {
+                        debug!(
+                            target: LOG_TARGET,
+                            "Error establishing messaging protocol: {}. Aborting because maximum retries reached.", err
+                        );
+                        self.fail_all_pending_messages(SendFailReason::PeerDialFailed).await;
+                        return Err(err);
+                    }
+                    debug!(
+                        target: LOG_TARGET,
+                        "Error establishing messaging protocol: {}. Retrying...", err
+                    );
+                    attempts += 1;
+                },
+            }
+        };
         debug_assert_eq!(substream.protocol, MESSAGING_PROTOCOL);
         self.start_forwarding_messages(substream.stream).await?;
 
         Ok(())
+    }
+
+    async fn try_establish(&mut self) -> Result<NegotiatedSubstream<Substream>, MessagingProtocolError> {
+        debug!(
+            target: LOG_TARGET,
+            "Attempting to establish messaging protocol connection to peer `{}`",
+            self.peer_node_id.short_str()
+        );
+        let start = Instant::now();
+        let conn = self.try_dial_peer().await?;
+        debug!(
+            target: LOG_TARGET,
+            "Connection succeeded for peer `{}` in {:.0?}",
+            self.peer_node_id.short_str(),
+            start.elapsed()
+        );
+        let substream = self.try_open_substream(conn).await?;
+        debug!(
+            target: LOG_TARGET,
+            "Substream established for peer `{}`",
+            self.peer_node_id.short_str(),
+        );
+        Ok(substream)
     }
 
     async fn try_dial_peer(&mut self) -> Result<PeerConnection, MessagingProtocolError> {
@@ -129,8 +175,7 @@ impl OutboundMessaging {
                         self.peer_node_id.short_str(),
                         err
                     );
-                    self.flush_all_messages_to_failed_event(SendFailReason::PeerDialFailed)
-                        .await;
+
                     break Err(MessagingProtocolError::PeerDialFailed);
                 },
             }
@@ -151,95 +196,59 @@ impl OutboundMessaging {
                     self.peer_node_id.short_str(),
                     err
                 );
-                self.flush_all_messages_to_failed_event(SendFailReason::SubstreamOpenFailed)
-                    .await;
                 Err(err.into())
             },
         }
     }
 
     async fn start_forwarding_messages(self, substream: Substream) -> Result<(), MessagingProtocolError> {
-        let framed = MessagingProtocol::framed(substream);
+        debug!(
+            target: LOG_TARGET,
+            "Starting direct message forwarding for peer `{}`",
+            self.peer_node_id.short_str()
+        );
+        let (sink, _) = MessagingProtocol::framed(substream).split();
 
         let Self {
             request_rx,
             inactivity_timeout,
-            peer_node_id,
-            messaging_events_tx,
             ..
         } = self;
 
-        let stream = MessageForwarderStream::new(peer_node_id.clone(), request_rx, framed);
-
         let stream = match inactivity_timeout {
             Some(timeout) => {
-                let s = tokio_stream::StreamExt::timeout(stream, timeout).map(|r| match r {
-                    Ok(s) => s,
-                    Err(_) => Err(MessageSendFailure {
-                        item: None,
-                        error: MessagingProtocolError::Inactivity,
-                    }),
+                let s = tokio_stream::StreamExt::timeout(request_rx, timeout).map(|r| match r {
+                    Ok(s) => Ok(s),
+                    Err(_) => Err(io::Error::new(
+                        io::ErrorKind::TimedOut,
+                        MessagingProtocolError::Inactivity,
+                    )),
                 });
                 Either::Left(s)
             },
-            None => Either::Right(stream),
+            None => Either::Right(request_rx.map(Ok)),
         };
 
         stream
-            .fold(Result::<(), MessagingProtocolError>::Ok(()), move |_, result| {
-                let mut messaging_events_tx = messaging_events_tx.clone();
-                let peer_node_id = peer_node_id.clone();
-                async move {
-                    match result {
-                        Ok(tag) => {
-                            debug!(
-                                target: LOG_TARGET,
-                                "(peer = {}, tag = {}) Message sent",
-                                peer_node_id.short_str(),
-                                tag,
-                            );
-                            let _ = messaging_events_tx.send(MessagingEvent::MessageSent(tag)).await;
-                            Ok(())
-                        },
-                        Err(failure) => {
-                            match failure.item {
-                                Some(out_msg) => {
-                                    debug!(
-                                        target: LOG_TARGET,
-                                        "(peer = {}, tag = {}, {} bytes()) Message failed to send: {}",
-                                        peer_node_id.short_str(),
-                                        out_msg.tag,
-                                        out_msg.body.len(),
-                                        failure.error,
-                                    );
-                                    let _ = messaging_events_tx
-                                        .send(MessagingEvent::SendMessageFailed(
-                                            out_msg,
-                                            SendFailReason::SubstreamSendFailed,
-                                        ))
-                                        .await;
-                                },
-                                None => {
-                                    debug!(
-                                        target: LOG_TARGET,
-                                        "(peer = {}): {}",
-                                        peer_node_id.short_str(),
-                                        failure.error,
-                                    );
-                                },
-                            }
-
-                            Err(failure.error)
-                        },
-                    }
-                }
+            .map(|msg| {
+                msg.map(|mut out_msg| {
+                    trace!(target: LOG_TARGET, "Message buffered for sending {}", out_msg);
+                    out_msg.reply_success();
+                    out_msg.body
+                })
             })
+            .forward(sink)
             .await?;
 
+        debug!(
+            target: LOG_TARGET,
+            "Direct message forwarding successfully completed for peer `{}`.",
+            self.peer_node_id.short_str()
+        );
         Ok(())
     }
 
-    async fn flush_all_messages_to_failed_event(&mut self, reason: SendFailReason) {
+    async fn fail_all_pending_messages(&mut self, reason: SendFailReason) {
         // Close the request channel so that we can read all the remaining messages and flush them
         // to a failed event
         self.request_rx.close();
@@ -249,214 +258,6 @@ impl OutboundMessaging {
                 .messaging_events_tx
                 .send(MessagingEvent::SendMessageFailed(out_msg, reason))
                 .await;
-        }
-    }
-}
-
-#[derive(Debug)]
-struct MessageSendFailure {
-    pub item: Option<OutboundMessage>,
-    pub error: MessagingProtocolError,
-}
-
-impl From<io::Error> for MessageSendFailure {
-    fn from(err: io::Error) -> Self {
-        Self {
-            item: None,
-            error: err.into(),
-        }
-    }
-}
-
-#[pin_project(project = StateProj)]
-#[derive(Debug)]
-enum State {
-    Read,
-    Write(Option<OutboundMessage>),
-    FlushPending(bool),
-    Flush(bool),
-    Errored(bool),
-    Complete(bool),
-}
-
-/// This stream forwards messages from the mpsc receiver to the given `Sink`.
-#[pin_project(project = MessageForwarderStreamProj)]
-#[derive(Debug)]
-#[must_use = "streams do nothing unless you poll them"]
-struct MessageForwarderStream<Si> {
-    peer_node_id: NodeId,
-    #[pin]
-    sink: Option<Si>,
-    #[pin]
-    stream: mpsc::UnboundedReceiver<OutboundMessage>,
-    #[pin]
-    state: State,
-    pending_queue: Vec<OutboundMessage>,
-}
-
-impl<Si> MessageForwarderStream<Si>
-where Si: Sink<Bytes, Error = io::Error> + Unpin
-{
-    pub fn new(peer_node_id: NodeId, stream: mpsc::UnboundedReceiver<OutboundMessage>, sink: Si) -> Self {
-        Self {
-            peer_node_id,
-            stream,
-            sink: Some(sink),
-            state: State::Read,
-            // Capacity is chosen to match yamux's internal channel buffer
-            pending_queue: Vec::with_capacity(32),
-        }
-    }
-}
-
-impl<Si> Stream for MessageForwarderStream<Si>
-where Si: Sink<Bytes, Error = io::Error> + Unpin
-{
-    type Item = Result<MessageTag, MessageSendFailure>;
-
-    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
-        let MessageForwarderStreamProj {
-            mut sink,
-            mut stream,
-            peer_node_id,
-            mut state,
-            pending_queue,
-        } = self.project();
-
-        loop {
-            match state.as_mut().project() {
-                StateProj::Read => match stream.as_mut().poll_next(cx) {
-                    Poll::Ready(Some(item)) => {
-                        debug!(
-                            target: LOG_TARGET,
-                            "Buffering outbound message (tag = {}, {} bytes) for peer `{}`",
-                            item.tag,
-                            item.body.len(),
-                            peer_node_id.short_str()
-                        );
-                        *state = State::Write(Some(item));
-                    },
-                    Poll::Ready(None) => {
-                        *state = State::Complete(false);
-                    },
-                    Poll::Pending => *state = State::Flush(true),
-                },
-                StateProj::Flush(is_pending) => {
-                    let si = sink
-                        .as_mut()
-                        .as_pin_mut()
-                        .expect("polled `MessageForwarderStream` after completion");
-                    if let Err(err) = ready!(si.poll_flush(cx)) {
-                        *state = State::Errored(false);
-                        return Poll::Ready(Some(Err(err.into())));
-                    }
-                    *state = State::FlushPending(*is_pending);
-                },
-                StateProj::FlushPending(is_pending) => match pending_queue.pop() {
-                    Some(mut item) => {
-                        item.reply_success();
-                        return Poll::Ready(Some(Ok(item.tag)));
-                    },
-                    None => {
-                        let is_pending = *is_pending;
-                        *state = State::Read;
-                        if is_pending {
-                            return Poll::Pending;
-                        }
-                    },
-                },
-                StateProj::Write(item) => {
-                    let mut si = sink
-                        .as_mut()
-                        .as_pin_mut()
-                        .expect("polled `MessageForwarderStream` after completion");
-                    match ready!(si.as_mut().poll_ready(cx)) {
-                        Ok(_) => {
-                            let item = item.take().expect("State::Write without an item to write");
-                            match si.as_mut().start_send(item.body.clone()) {
-                                Ok(_) => {
-                                    pending_queue.push(item);
-                                    if pending_queue.len() >= pending_queue.capacity() {
-                                        *state = State::Flush(false);
-                                    } else {
-                                        *state = State::Read
-                                    }
-                                },
-                                Err(err) => {
-                                    *state = State::Errored(false);
-                                    let err = MessageSendFailure {
-                                        item: Some(item),
-                                        error: err.into(),
-                                    };
-                                    return Poll::Ready(Some(Err(err)));
-                                },
-                            }
-                        },
-                        Err(err) => {
-                            let item = item.take().expect("State::Write without an item to write");
-                            *state = State::Errored(false);
-                            let err = MessageSendFailure {
-                                item: Some(item),
-                                error: err.into(),
-                            };
-                            return Poll::Ready(Some(Err(err)));
-                        },
-                    }
-                },
-                StateProj::Errored(is_complete) => {
-                    // Close stream and flush
-                    if !stream.is_terminated() {
-                        stream.as_mut().close();
-                    }
-                    if let Some(item) = pending_queue.pop() {
-                        let err = MessageSendFailure {
-                            item: Some(item),
-                            error: MessagingProtocolError::MessageSendFailed,
-                        };
-                        return Poll::Ready(Some(Err(err)));
-                    }
-
-                    if *is_complete {
-                        sink.set(None);
-                        return Poll::Ready(None);
-                    }
-
-                    return match ready!(stream.as_mut().poll_next(cx)) {
-                        Some(item) => {
-                            let err = MessageSendFailure {
-                                item: Some(item),
-                                error: MessagingProtocolError::MessageSendFailed,
-                            };
-                            Poll::Ready(Some(Err(err)))
-                        },
-                        None => {
-                            sink.set(None);
-                            Poll::Ready(None)
-                        },
-                    };
-                },
-                StateProj::Complete(has_closed) => {
-                    let si = sink
-                        .as_mut()
-                        .as_pin_mut()
-                        .expect("polled `MessageForwarderStream` after completion");
-                    if !*has_closed {
-                        if let Err(err) = ready!(si.poll_close(cx)) {
-                            *state = State::Errored(true);
-                            return Poll::Ready(Some(Err(err.into())));
-                        }
-
-                        *state = State::Complete(true);
-                    }
-
-                    if let Some(mut item) = pending_queue.pop() {
-                        item.reply_success();
-                        return Poll::Ready(Some(Ok(item.tag)));
-                    }
-                    sink.set(None);
-                    return Poll::Ready(None);
-                },
-            }
         }
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR simplifies the outbound messaging and allows it to use
`StreamExt::forward` instead of a custom `Stream` impl.

This simplification means that the MessageSent event is no longer
sent and that in some rare cases a message may be "marked" as
sent even if the peer will not receive the message (e.g. sudden disconnect)

It should be acknowleged that previously this was the case anyway,
and "successfully sent" is more accurately "successfully buffered".

- Removed MessageSent event
- Removed retries from protocol
- Outbound messaging will retry once to connect and establish a
  substream, this is to handle the case where a pending dial is cancelled
  due to tie breaking - so one and only one retry is required.
- Retries happen per peer and not per message.
- Removed peer manager from messaging completely which could/would slightly delay messaging.
- A fix for a large outbound delay that can experienced in high contention situations.
- Ensure that sinks are closed if the workers exit for any reason.
- Added messaging stress test


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This PR acknowledges that guaranteed deliverability is neither easy nor desirable (RE tradeoffs) 
in a p2p system. The direct fire and forget messaging protocol was always "best effort"
and never provided guarantees around deliverability - and with those limitations, the benefits 
(simplification, performance, bug fixed by removing code) can be obtained. That being said
in the vast majority of cases with a stable connection, the message will arrive (reliability matches that of TCP/Tor)

The upcoming RPC protocol will provide the "either it worked or it didn't" semantic which has 
been sorely missing.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tests updated as necessary. Every test that uses comms (i.e. the majority of the current test suite) is also testing this
component. Ran a base node for a few hours.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [x] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch.
* [x] I ran `cargo-fmt --all` before pushing.
* [x] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
