### PR TITLE
Add support for optional rolling log files to FFI wallet library

### DIFF
--- a/base_layer/wallet_ffi/wallet.h
+++ b/base_layer/wallet_ffi/wallet.h
@@ -358,6 +358,10 @@ void comms_config_destroy(struct TariCommsConfig *wc);
 /// `config` - The TariCommsConfig pointer
 /// `log_path` - An optional file path to the file where the logs will be written. If no log is required pass *null*
 /// pointer.
+/// `num_rolling_log_files` - Specifies how many rolling log files to produce, if no rolling files are wanted then set
+/// this to 0
+/// `size_per_log_file_bytes` - Specifies the size, in bytes, at which the logs files will roll over, if no
+/// rolling files are wanted then set this to 0
 /// `passphrase` - An optional string that represents the passphrase used to encrypt/decrypt the databases for this
 /// wallet. If it is left Null no encryption is used. If the databases have been encrypted then the correct passphrase
 /// is required or this function will fail.
@@ -388,6 +392,8 @@ void comms_config_destroy(struct TariCommsConfig *wc);
 /// The ```wallet_destroy``` method must be called when finished with a TariWallet to prevent a memory leak
 struct TariWallet *wallet_create(struct TariWalletConfig *config,
                                     const char *log_path,
+                                    unsigned int num_rolling_log_files,
+                                    unsigned int size_per_log_file_bytes,
                                     const char *passphrase,
                                     void (*callback_received_transaction)(struct TariPendingInboundTransaction*),
                                     void (*callback_received_transaction_reply)(struct TariCompletedTransaction*),


### PR DESCRIPTION
## Description
Currently LibWallet accepts a single file path for logging and write all logs to that file. This PR adds the ability to optionally specify whether you want the logs to use multiple rolling files and at what size of file to trigger the roll over. If non zero values are provided for both `num_rolling_log_files` and `size_per_log_file_bytes` then the fixed window rolling functionality of log4rs will be used. If this is not desired 0 values should be passed for these arguments.

The rolled over archived files will be numbered version of the original filename. For example if the logging file path that is provided is `/User/me/wallet/log_170820_14382455.log`, 2 roll over files are specified and the size threshold is 10_000 bytes. 
1. The most current log file will always be `log_170820_14382455.log` 
2. When that reaches 10_000 bytes in size it will be renamed to `log_170820_14382455.0.log` and logging will continue in `log_170820_14382455.log`.
3. When the next roll over limit is reached: 
    1. `log_170820_14382455.0.log` will be renamed to `log_170820_14382455.1.log` 
    2. the current `log_170820_14382455.log` will be renamed to `log_170820_14382455.0.log`
    3. logging will continue in `log_170820_14382455.log`.
4. When the next roll over occurs because we specified only 2 roll over files the oldest one (index 1) will be deleted, 0 will be renamed to 1 and the current file renamed to index 0.

This can be used to limit the amount of logs LibWallet generates per session.

@kukabi @Jasonvdb for changes to `wallet_create(...)`

## Motivation and Context
Closes https://github.com/tari-project/tari/issues/2124

## How Has This Been Tested?
Both old and new logging is now used in LibWallet tests to a temporary directory to confirm they are working.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch.
* [x] I ran `cargo-fmt --all` before pushing.
* [ ] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
