### PR TITLE
Update docker build to use build-args and files in the repo

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,4 @@
-buildtools
+#buildtools
 target
 .env
 

--- a/README.md
+++ b/README.md
@@ -235,6 +235,10 @@ Run the base node
 
     docker run -ti -v /path/to/config/dir:/root/.tari tari_base_node
 
+Default docker builds for base x86-64 CPU. Better performing builds can be created by passing build options
+
+    docker build -t tari_base_node:performance --build-arg TBN_ARCH=skylake --build-arg TBN_FEATURES=avx2 -f ./buildtools/base_node.Dockerfile .
+
 ---
 
 ### Advanced build configurations

--- a/buildtools/base_node.Dockerfile
+++ b/buildtools/base_node.Dockerfile
@@ -7,11 +7,20 @@ ADD . /tari_base_node
 WORKDIR /tari_base_node
 
 RUN rustup component add rustfmt --toolchain nightly-2020-06-10-x86_64-unknown-linux-gnu
-RUN cargo build --release
+#ARG TBN_ARCH=native
+ARG TBN_ARCH=x86-64
+#ARG TBN_FEATURES=avx2
+ARG TBN_FEATURES=safe
+ENV RUSTFLAGS="-C target_cpu=$TBN_ARCH"
+ENV ROARING_ARCH=$TBN_ARCH
+RUN cd applications/tari_base_node \
+  && cargo build --release -p tari_base_node --features $TBN_FEATURES
 
 # Create a base minimal image for adding our executables to
 FROM bitnami/minideb:stretch as base
-RUN apt update && apt install \
+# Disable Prompt During Packages Installation
+ARG DEBIAN_FRONTEND=noninteractive
+RUN apt update && apt -y install \
     openssl \
     libsqlite3-0 \
     curl \
@@ -21,20 +30,13 @@ RUN apt update && apt install \
     telnet \
     gpg \
     apt-transport-https \
-    ca-certificates \
-    -y && \
+    ca-certificates && \
     # Add Sources for the latest tor
     printf "deb https://deb.torproject.org/torproject.org stretch main\ndeb-src https://deb.torproject.org/torproject.org stretch main" > /etc/apt/sources.list.d/tor.list && \
     curl https://deb.torproject.org/torproject.org/A3C4F0F979CAA22CDBA8F512EE8CBC9E886DDD89.asc | gpg --import 1>&2 && \
     gpg --export A3C4F0F979CAA22CDBA8F512EE8CBC9E886DDD89 | apt-key add - 1>&2 &&\
     apt update 1>&2 && \
-    apt install -y tor deb.torproject.org-keyring 1>&2 && \
-    # Standard config for the tor client
-    printf "SocksPort 127.0.0.1:9050\nControlPort 127.0.0.1:9051\nCookieAuthentication 0\nClientOnly 1\nClientUseIPv6 1" > /etc/tor/torrc && \
-    # start.sh script to run tor, sleep 15 seconds and start the base node
-    printf "#!/bin/bash\ntor &\nsleep 15\nif [[ ! -f ~/.tari/config.toml ]]; then\n  tari_base_node --init --create-id\nfi\ntari_base_node" > /usr/bin/start.sh && \
-    chmod +x /usr/bin/start.sh
-
+    apt install -y tor deb.torproject.org-keyring 1>&2
 
 # Now create a new image with only the essentials and throw everything else away
 FROM base
@@ -42,6 +44,8 @@ FROM base
 COPY --from=builder /tari_base_node/target/release/tari_base_node /usr/bin/
 COPY --from=builder /tari_base_node/common/config/tari_config_sample.toml /root/.tari/tari_config_sample.toml
 COPY --from=builder /tari_base_node/common/logging/log4rs-sample.yml /root/.tari/log4rs.yml
+COPY --from=builder /tari_base_node/buildtools/docker/torrc /etc/tor/torrc
+COPY --from=builder /tari_base_node/buildtools/docker/start.sh /usr/bin/start.sh
 
 # Keep the .tari directory in a volume by default
 VOLUME ["/root/.tari"]

--- a/buildtools/docker/start.sh
+++ b/buildtools/docker/start.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+#
+# Docker Start Script
+#  script to run tor, sleep 15 seconds and start the base node
+#
+
+tor
+sleep 15
+if [[ ! -f ~/.tari/config.toml ]]; then
+  tari_base_node --init --create-id
+fi
+
+cd ~/.tari
+tari_base_node "$@"

--- a/buildtools/docker/torrc
+++ b/buildtools/docker/torrc
@@ -1,0 +1,6 @@
+# Standard config for the tor client - /etc/tor/torrc
+SocksPort 127.0.0.1:9050
+ControlPort 127.0.0.1:9051
+CookieAuthentication 0
+ClientOnly 1
+ClientUseIPv6 1


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Update the docker build, so the default build only has ```x86-64``` CPU Instruction Set requirements with ```safe``` feature-set.   

## Description
<!--- Describe your changes in detail -->
Added docker build options to override the default safe options. Also moved torrc and start.sh file into the repo and out of the Dockerfile.

## Motivation and Context
Default docker builds have minimum requirements, but flexible build options. Repo is easier to maintain.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [x] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [x] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch.
* [ ] I ran `cargo-fmt --all` before pushing.
* [x] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [x] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
