### PR TITLE
Added support for OS-assigned proxied listening address (tor)

### DIFF
--- a/applications/tari_base_node/src/builder.rs
+++ b/applications/tari_base_node/src/builder.rs
@@ -914,8 +914,7 @@ fn setup_wallet_transport_type(config: &GlobalConfig) -> TransportType {
                     .unwrap()
             );
 
-            let mut forward_addr = multiaddr_to_socketaddr(&forward_address).expect("Invalid tor forward address");
-            forward_addr.set_port(forward_addr.port() + 1);
+            let forward_addr = multiaddr_to_socketaddr(&forward_address).expect("Invalid tor forward address");
             TransportType::Tor(TorConfig {
                 control_server_addr: control_server_address,
                 control_server_auth: {
@@ -926,7 +925,7 @@ fn setup_wallet_transport_type(config: &GlobalConfig) -> TransportType {
                 },
                 identity: identity.map(Box::new),
 
-                port_mapping: (onion_port.get() + 1, forward_addr).into(),
+                port_mapping: (onion_port.get(), forward_addr).into(),
                 // TODO: make configurable
                 socks_address_override,
                 socks_auth: socks::Authentication::None,

--- a/base_layer/p2p/examples/gen_tor_identity.rs
+++ b/base_layer/p2p/examples/gen_tor_identity.rs
@@ -85,14 +85,17 @@ async fn main() {
         .parse::<u16>()
         .expect("Invalid port");
 
-    let hidden_service = tor::HiddenServiceBuilder::new()
+    let hidden_service_ctl = tor::HiddenServiceBuilder::new()
         .with_port_mapping(port)
         .with_control_server_address(tor_control_addr)
         .finish()
         .await
+        .unwrap()
+        .create_hidden_service()
+        .await
         .unwrap();
 
-    let json = hidden_service.tor_identity().to_json().unwrap();
+    let json = hidden_service_ctl.tor_identity().to_json().unwrap();
     let out_path = to_abs_path(matches.value_of("output").unwrap());
     fs::write(out_path, json).unwrap();
 }

--- a/base_layer/p2p/src/initialization.rs
+++ b/base_layer/p2p/src/initialization.rs
@@ -244,17 +244,10 @@ where
         },
         TransportType::Tor(tor_config) => {
             debug!(target: LOG_TARGET, "Building TOR comms stack ({})", tor_config);
-            let hidden_service = initialize_hidden_service(tor_config.clone()).await?;
-            debug!(
-                target: LOG_TARGET,
-                "Created hidden service {}",
-                hidden_service.get_onion_address()
-            );
-            let comms = builder.configure_from_hidden_service(hidden_service);
-            debug!(target: LOG_TARGET, "Comms stack configured");
-
+            let hidden_service_ctl = initialize_hidden_service(tor_config.clone()).await?;
+            let comms = builder.configure_from_hidden_service(hidden_service_ctl).await?;
             let (comms, dht) = configure_comms_and_dht(comms, config, connector, seed_peers).await?;
-            debug!(target: LOG_TARGET, "DHT configured");
+            debug!(target: LOG_TARGET, "Comms and DHT configured");
             // Set the public address to the onion address that comms is using
             comms.node_identity().set_public_address(
                 comms
@@ -277,7 +270,9 @@ where
     }
 }
 
-async fn initialize_hidden_service(config: TorConfig) -> Result<tor::HiddenService, tor::HiddenServiceBuilderError> {
+async fn initialize_hidden_service(
+    config: TorConfig,
+) -> Result<tor::HiddenServiceController, tor::HiddenServiceBuilderError> {
     let mut builder = tor::HiddenServiceBuilder::new()
         .with_hs_flags(tor::HsFlags::DETACH)
         .with_port_mapping(config.port_mapping)

--- a/base_layer/wallet_ffi/src/lib.rs
+++ b/base_layer/wallet_ffi/src/lib.rs
@@ -2172,7 +2172,8 @@ pub unsafe extern "C" fn transport_tor_create(
         control_server_addr: control_address_str.parse::<Multiaddr>().unwrap(),
         control_server_auth: tor_authentication,
         identity,
-        port_mapping: tor::PortMapping::from_port(tor_port),
+        // Proxy the onion address to an OS-assigned local port
+        port_mapping: tor::PortMapping::new(tor_port, "127.0.0.1:0".parse().unwrap()),
         socks_address_override: None,
         socks_auth: authentication,
     };

--- a/common/src/configuration/utils.rs
+++ b/common/src/configuration/utils.rs
@@ -197,7 +197,7 @@ fn set_transport_defaults(cfg: &mut Config) {
     cfg.set_default("base_node.mainnet.tor_control_address", "/ip4/127.0.0.1/tcp/9051")
         .unwrap();
     cfg.set_default("base_node.mainnet.tor_control_auth", "none").unwrap();
-    cfg.set_default("base_node.mainnet.tor_forward_address", "/ip4/127.0.0.1/tcp/18141")
+    cfg.set_default("base_node.mainnet.tor_forward_address", "/ip4/127.0.0.1/tcp/0")
         .unwrap();
     cfg.set_default("base_node.mainnet.tor_onion_port", "18141").unwrap();
 
@@ -216,7 +216,7 @@ fn set_transport_defaults(cfg: &mut Config) {
     cfg.set_default("base_node.rincewind.tor_control_address", "/ip4/127.0.0.1/tcp/9051")
         .unwrap();
     cfg.set_default("base_node.rincewind.tor_control_auth", "none").unwrap();
-    cfg.set_default("base_node.rincewind.tor_forward_address", "/ip4/127.0.0.1/tcp/18041")
+    cfg.set_default("base_node.rincewind.tor_forward_address", "/ip4/127.0.0.1/tcp/0")
         .unwrap();
     cfg.set_default("base_node.rincewind.tor_onion_port", "18141").unwrap();
 

--- a/comms/examples/stress/node.rs
+++ b/comms/examples/stress/node.rs
@@ -131,16 +131,11 @@ pub async fn create(
             hs_builder = hs_builder.with_tor_identity(tor_identity);
         }
 
-        let tor_hidden_service = hs_builder.finish().await?;
+        let hs_ctl = hs_builder.finish().await?;
 
-        println!(
-            "Tor hidden service created with address '{}'",
-            tor_hidden_service.get_onion_address()
-        );
-
-        node_identity.set_public_address(tor_hidden_service.get_onion_address());
         builder
-            .configure_from_hidden_service(tor_hidden_service)
+            .configure_from_hidden_service(hs_ctl)
+            .await?
             .build()?
             .with_messaging_pipeline(
                 pipeline::Builder::new()

--- a/comms/src/builder/error.rs
+++ b/comms/src/builder/error.rs
@@ -20,7 +20,11 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use crate::{connection_manager::ConnectionManagerError, peer_manager::PeerManagerError};
+use crate::{
+    connection_manager::ConnectionManagerError,
+    peer_manager::PeerManagerError,
+    tor::HiddenServiceControllerError,
+};
 use thiserror::Error;
 
 #[derive(Debug, Error)]
@@ -39,4 +43,6 @@ pub enum CommsBuilderError {
     ConnectionManagerEventStreamClosed,
     #[error("Receiving on ConnectionManagerEvent stream lagged unexpectedly")]
     ConnectionManagerEventStreamLagged,
+    #[error("Failed to initialize tor hidden service: {0}")]
+    HiddenServiceControllerError(#[from] HiddenServiceControllerError),
 }

--- a/comms/src/tor/control_client/commands/add_onion.rs
+++ b/comms/src/tor/control_client/commands/add_onion.rs
@@ -30,7 +30,7 @@ use crate::tor::control_client::{
 };
 use std::{borrow::Cow, fmt, num::NonZeroU16};
 
-#[derive(Debug)]
+#[derive(Debug, Copy, Clone)]
 pub enum AddOnionFlag {
     /// The server should not include the newly generated private key as part of the response.
     DiscardPK,

--- a/comms/src/tor/control_client/types.rs
+++ b/comms/src/tor/control_client/types.rs
@@ -101,7 +101,7 @@ impl Drop for PrivateKey {
 
 /// Represents a mapping between an onion port and a proxied address (usually 127.0.0.1:xxxx).
 /// If the proxied_address is not specified, the default `127.0.0.1:[onion_port]` will be used.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Copy)]
 pub struct PortMapping(u16, SocketAddr);
 
 impl PortMapping {
@@ -121,6 +121,10 @@ impl PortMapping {
 
     pub fn proxied_address(&self) -> &SocketAddr {
         &self.1
+    }
+
+    pub fn set_proxied_addr(&mut self, proxied_addr: SocketAddr) {
+        self.1 = proxied_addr
     }
 }
 

--- a/comms/src/tor/hidden_service/builder.rs
+++ b/comms/src/tor/hidden_service/builder.rs
@@ -24,13 +24,7 @@ use super::controller::HiddenServiceControllerError;
 use crate::{
     multiaddr::Multiaddr,
     socks,
-    tor::{
-        hidden_service::controller::HiddenServiceController,
-        Authentication,
-        HiddenService,
-        PortMapping,
-        TorIdentity,
-    },
+    tor::{hidden_service::controller::HiddenServiceController, Authentication, PortMapping, TorIdentity},
 };
 use bitflags::bitflags;
 use log::*;
@@ -112,7 +106,7 @@ impl HiddenServiceBuilder {
 
 impl HiddenServiceBuilder {
     /// Create a HiddenService with the given builder parameters.
-    pub async fn finish(self) -> Result<HiddenService, HiddenServiceBuilderError> {
+    pub async fn finish(self) -> Result<HiddenServiceController, HiddenServiceBuilderError> {
         let proxied_port_mapping = self
             .port_mapping
             .ok_or(HiddenServiceBuilderError::ProxiedPortMappingNotProvided)?;
@@ -127,19 +121,16 @@ impl HiddenServiceBuilder {
             proxied_port_mapping
         );
 
-        let controller = HiddenServiceController {
-            client: None,
+        let controller = HiddenServiceController::new(
             control_server_addr,
-            control_server_auth: self.control_server_auth,
-            socks_address_override: self.socks_addr_override,
+            self.control_server_auth,
             proxied_port_mapping,
-            socks_auth: self.socks_auth,
-            hs_flags: self.hs_flags,
-            identity: self.identity,
-        };
+            self.socks_addr_override,
+            self.socks_auth,
+            self.identity,
+            self.hs_flags,
+        );
 
-        let hidden_service = controller.start_hidden_service().await?;
-
-        Ok(hidden_service)
+        Ok(controller)
     }
 }

--- a/comms/src/tor/hidden_service/mod.rs
+++ b/comms/src/tor/hidden_service/mod.rs
@@ -24,7 +24,7 @@ mod builder;
 pub use builder::{HiddenServiceBuilder, HiddenServiceBuilderError, HsFlags};
 
 mod controller;
-pub use controller::HiddenServiceControllerError;
+pub use controller::{HiddenServiceController, HiddenServiceControllerError};
 
 use crate::{
     multiaddr::Multiaddr,

--- a/comms/src/tor/mod.rs
+++ b/comms/src/tor/mod.rs
@@ -46,6 +46,7 @@ pub use hidden_service::{
     HiddenService,
     HiddenServiceBuilder,
     HiddenServiceBuilderError,
+    HiddenServiceController,
     HiddenServiceControllerError,
     HsFlags,
     TorIdentity,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
The tor proxy is configured to proxy a hidden service to a local
address. Previously, that local address would have to be configured to
some non-zero value so that comms could listen on it. This PR allows the
local port to be assigned by the OS (i.e. port `0`). The comms listener will listen on
an OS-assigned port and the hidden service will be automatically configured to forward
traffic to the local address. This does not effect the onion address port, typically
this would be set to a hardcoded value (e.g. 18100).

- FFI updated (no public (or other) breaking changes)
- Tari base node configuration now uses an OS-assigned port by default

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
In the vast majority of use-cases, the tari_comms api user does not care about the proxied listener port and just wants some appropriate open port to be selected.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Existing tests pass. Tested on base nodes. 
Untested on mobile but this can be tested by checking for app crashes on startup.

To test a base node:
1. Remove `tor_forward_address` setting from the config if present (so that the default is used) 
1. Start up a wallet/base node
1. Find the listening port in the logs e.g `INFO  Listening for peer connections on '/ip4/127.0.0.1/tcp/63746'`
1. Check that `list-connections` has inbound connections
1. Restart the node and check that a different listening port is used as per step 3 and we have inbound connections

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [x] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch.
* [x] I ran `cargo-fmt --all` before pushing.
* [x] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
