### PR TITLE
Fix Tor download URL for the Windows installation to point to Tor archives

### DIFF
--- a/buildtools/install_sqlite.bat
+++ b/buildtools/install_sqlite.bat
@@ -1,44 +1,46 @@
-@rem Control variables
-@rem - SQLite {Note: `powershell` cannot `expand-archive` to `C:\Program Files (x86)`}
-@set sqlite_zip=sqlite-dll-win64-x64-3310100.zip
-@set sqlite_folder=%USERPROFILE%\.sqlite
-@set sqlite_runtime=sqlite3.dll
+@echo off
 
-@echo Downloading and installing SQLite...
-@echo.
+rem Control variables
+rem - SQLite {Note: `powershell` cannot `expand-archive` to `C:\Program Files (x86)`}
+set sqlite_zip=sqlite-dll-win64-x64-3310100.zip
+set sqlite_folder=%USERPROFILE%\.sqlite
+set sqlite_runtime=sqlite3.dll
 
-@rem Install dependencies
-@call :INSTALL_SQLITE
-@goto END:
+echo Downloading and installing SQLite...
+echo.
+
+rem Install dependencies
+call :INSTALL_SQLITE
+goto END:
 
 :INSTALL_SQLITE
-@rem Download install file
-@powershell wget https://www.sqlite.org/2020/%sqlite_zip% -outfile "%TEMP%\%sqlite_zip%"
-@rem Install
-@powershell expand-archive -Force -LiteralPath "%TEMP%\%sqlite_zip%" -DestinationPath "%sqlite_folder%"
-@rem Set Tari environment variables
-@set TARI_SQLITE_DIR=%sqlite_folder%
-@setx TARI_SQLITE_DIR %TARI_SQLITE_DIR%
-@setx /m USERNAME %USERNAME%
-@rem Test installation
-@if not exist "%TARI_SQLITE_DIR%\%sqlite_runtime%" (
-@echo.
-    @echo.
-    @echo Problem with SQLite installation, "%sqlite_runtime%" not found!
-    @echo {Please try installing this dependency using the manual procedure described in the README file.}
-    @echo.
-    @pause
+rem Download install file
+powershell wget https://www.sqlite.org/2020/%sqlite_zip% -outfile "%TEMP%\%sqlite_zip%"
+rem Install
+powershell expand-archive -Force -LiteralPath "%TEMP%\%sqlite_zip%" -DestinationPath "%sqlite_folder%"
+rem Set Tari environment variables
+set TARI_SQLITE_DIR=%sqlite_folder%
+setx TARI_SQLITE_DIR %TARI_SQLITE_DIR%
+setx /m USERNAME %USERNAME%
+rem Test installation
+if not exist "%TARI_SQLITE_DIR%\%sqlite_runtime%" (
+echo.
+    echo.
+    echo Problem with SQLite installation, "%sqlite_runtime%" not found!
+    echo {Please try installing this dependency using the manual procedure described in the README file.}
+    echo.
+    pause
 ) else (
-    @echo.
-    @echo SQLite installation found at "%TARI_SQLITE_DIR%"
+    echo.
+    echo SQLite installation found at "%TARI_SQLITE_DIR%"
 )
-@goto :eof
+goto :eof
 
 :END
-@echo.
-@if not [%1]==[NO_PAUSE] (
-    @pause
+echo.
+if not [%1]==[NO_PAUSE] (
+    pause
 ) else (
-    @ping -n 5 localhost>nul
+    ping -n 5 localhost>nul
 )
-@@if [%errorlevel%]==[10101] exit
+if [%errorlevel%]==[10101] exit

--- a/buildtools/install_tor_services.bat
+++ b/buildtools/install_tor_services.bat
@@ -1,46 +1,50 @@
-@rem Control variables
-@rem - Tor Services {Note: `powershell` cannot `expand-archive` to `C:\Program Files (x86)`}
-@rem   - Download 'Windows Expert Bundle' at https://www.torproject.org/download/tor/
-@set tor_version=9.5.3
-@set tor_zip=tor-win32-0.4.3.6.zip
-@set tor_folder=%USERPROFILE%\.tor_services
-@set tor_runtime=tor.exe
+@echo off
 
-@echo Downloading and installing Tor Services...
-@echo.
+rem Control variables
+rem - Tor Services {Note: `powershell` cannot `expand-archive` to `C:\Program Files (x86)`}
+rem   - Download 'Windows Expert Bundle' at https://archive.torproject.org/tor-package-archive/torbrowser/, 
+rem     e.g. `9.5.3/tor-win64-0.4.3.6.zip`
 
-@rem Install dependencies
-@call :INSTALL_TOR_SERVICES
-@goto END:
+set tor_version=9.5.3
+set tor_zip=tor-win64-0.4.3.6.zip
+set tor_folder=%USERPROFILE%\.tor_services
+set tor_runtime=tor.exe
+
+echo Downloading and installing Tor Services...
+echo.
+
+rem Install dependencies
+call :INSTALL_TOR_SERVICES
+goto END:
 
 :INSTALL_TOR_SERVICES
-@rem Download install file
-@powershell wget  https://www.torproject.org/dist/torbrowser/%tor_version%/%tor_zip% -outfile "%TEMP%\%tor_zip%"
-@rem Install 
-@powershell expand-archive -Force -LiteralPath "%TEMP%\%tor_zip%" -DestinationPath "%tor_folder%"
-@rem Set Tari environment variables
-@set TARI_TOR_SERVICES_DIR=%tor_folder%\Tor
-@setx TARI_TOR_SERVICES_DIR %TARI_TOR_SERVICES_DIR%
-@setx /m USERNAME %USERNAME%
+rem Download install file
+powershell wget  https://www.torproject.org/dist/torbrowser/%tor_version%/%tor_zip% -outfile "%TEMP%\%tor_zip%"
+rem Install 
+powershell expand-archive -Force -LiteralPath "%TEMP%\%tor_zip%" -DestinationPath "%tor_folder%"
+rem Set Tari environment variables
+set TARI_TOR_SERVICES_DIR=%tor_folder%\Tor
+setx TARI_TOR_SERVICES_DIR %TARI_TOR_SERVICES_DIR%
+setx /m USERNAME %USERNAME%
 
-@rem Test installation
-@if not exist "%TARI_TOR_SERVICES_DIR%\%tor_runtime%" (
-    @echo.
-    @echo Problem with Tor Services installation, "%tor_runtime%" not found!
-    @echo {Please try installing this dependency using the manual procedure described in the README file.}
-    @echo.
-    @pause
+rem Test installation
+if not exist "%TARI_TOR_SERVICES_DIR%\%tor_runtime%" (
+    echo.
+    echo Problem with Tor Services installation, "%tor_runtime%" not found!
+    echo {Please try installing this dependency using the manual procedure described in the README file.}
+    echo.
+    pause
 ) else (
-    @echo.
-    @echo Tor Services installation found at "%TARI_TOR_SERVICES_DIR%"
+    echo.
+    echo Tor Services installation found at "%TARI_TOR_SERVICES_DIR%"
 )
-@goto :eof
+goto :eof
 
 :END
-@echo.
-@if not [%1]==[NO_PAUSE] (
-    @pause
+echo.
+if not [%1]==[NO_PAUSE] (
+    pause
 ) else (
-    @ping -n 5 localhost>nul
+    ping -n 5 localhost>nul
 )
-@@if [%errorlevel%]==[10101] exit
+if [%errorlevel%]==[10101] exit

--- a/buildtools/install_vs2019_redist.bat
+++ b/buildtools/install_vs2019_redist.bat
@@ -1,26 +1,28 @@
-@rem Control variables
-@rem - Redistributable for Visual Studio 2019
-@set vc_redist_install=vc_redist.x64.exe
+echo off
 
-@echo Downloading and installing Redistributable for Visual Studio 2019...
-@echo.
+rem Control variables
+rem - Redistributable for Visual Studio 2019
+set vc_redist_install=vc_redist.x64.exe
 
-@rem Install dependencies
-@call :INSTALL_VS2019_REDIST
-@goto END:
+echo Downloading and installing Redistributable for Visual Studio 2019...
+echo.
+
+rem Install dependencies
+call :INSTALL_VS2019_REDIST
+goto END:
 
 :INSTALL_VS2019_REDIST
-@rem Download install file
-@powershell wget https://aka.ms/vs/16/release/%vc_redist_install% -outfile "%TEMP%\%vc_redist_install%"
-@rem Install
-@"%TEMP%\%vc_redist_install%"
-@goto :eof
+rem Download install file
+powershell wget https://aka.ms/vs/16/release/%vc_redist_install% -outfile "%TEMP%\%vc_redist_install%"
+rem Install
+"%TEMP%\%vc_redist_install%"
+goto :eof
 
 :END
-@echo.
-@if not [%1]==[NO_PAUSE] (
-    @pause
+echo.
+if not [%1]==[NO_PAUSE] (
+    pause
 ) else (
-    @ping -n 5 localhost>nul
+    ping -n 5 localhost>nul
 )
-@@if [%errorlevel%]==[10101] exit
+if [%errorlevel%]==[10101] exit


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- Changed download URL for Tor Services to Tor archives: https://archive.torproject.org/tor-package-archive/torbrowser/
- Standardized on 64bit Tor `9.5.3/tor-win64-0.4.3.6.zip`

## Motivation and Context
The download link for Tor Services changes all the time, which breaks the Windows installation when the download link changes.

## How Has This Been Tested?
Tor installation tested on two unique Windows 10 computers

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [X] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [X] I'm merging against the `development` branch.
* [X] I ran `cargo-fmt --all` before pushing.
* [X] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
