### PR TITLE
Make OS assigned Tor forward address the default in config toml files

### DIFF
--- a/common/config/presets/windows.toml
+++ b/common/config/presets/windows.toml
@@ -215,7 +215,7 @@ tor_control_auth = "none" # or "password=xxxxxx"
 # The onion port to use.
 tor_onion_port = 18150
 # The address to which traffic on the node's onion address will be forwarded
-tor_forward_address = "/ip4/127.0.0.1/tcp/18150"
+#tor_forward_address = "/ip4/127.0.0.1/tcp/18150"
 # Instead of attemping to get the SOCKS5 address from the tor control port, use this one. The default is to
 # use the first address returned by the tor control port (GETINFO /net/listeners/socks).
 #tor_socks_address_override=

--- a/common/config/tari_config_sample.toml
+++ b/common/config/tari_config_sample.toml
@@ -215,7 +215,7 @@ tor_control_auth = "none" # or "password=xxxxxx"
 # The onion port to use.
 tor_onion_port = 18141
 # The address to which traffic on the node's onion address will be forwarded
-tor_forward_address = "/ip4/127.0.0.1/tcp/18141"
+#tor_forward_address = "/ip4/127.0.0.1/tcp/18141"
 # Instead of attemping to get the SOCKS5 address from the tor control port, use this one. The default is to
 # use the first address returned by the tor control port (GETINFO /net/listeners/socks).
 #tor_socks_address_override=


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Commented out user assigned `tor_forward_address` from config toml files

## Motivation and Context
- `tor_forward_address` should only be assigned in special cases, and should not be the default.
- This also circumvents the duplicate port issue introduced with #2138 if `tor_forward_address` is assigned by the user.

## How Has This Been Tested?
Tested in a base node on Windows

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [X] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [X] I'm merging against the `development` branch.
* [X] I ran `cargo-fmt --all` before pushing.
* [X] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
