### PR TITLE
Correctly setup wallet default onion and local forwarding ports

### DIFF
--- a/common/config/presets/windows.toml
+++ b/common/config/presets/windows.toml
@@ -215,7 +215,7 @@ tor_control_auth = "none" # or "password=xxxxxx"
 # The onion port to use.
 tor_onion_port = 18150
 # The address to which traffic on the node's onion address will be forwarded
-tor_forward_address = "/ip4/127.0.0.1/tcp/18150"
+# tor_forward_address = "/ip4/127.0.0.1/tcp/0"
 # Instead of attemping to get the SOCKS5 address from the tor control port, use this one. The default is to
 # use the first address returned by the tor control port (GETINFO /net/listeners/socks).
 #tor_socks_address_override=
@@ -301,7 +301,7 @@ peer_seeds = []
 # The onion port to use.
 #tor_onion_port = 18141
 # The address to which traffic on the node's onion address will be forwarded
-#tor_forward_address = "/ip4/127.0.0.1/tcp/18141"
+# tor_forward_address = "/ip4/127.0.0.1/tcp/0"
 # Instead of attemping to get the SOCKS5 address from the tor control port, use this one. The default is to
 # use the first address returned by the tor control port (GETINFO /net/listeners/socks).
 #tor_socks_address_override=

--- a/common/config/tari_config_sample.toml
+++ b/common/config/tari_config_sample.toml
@@ -215,7 +215,7 @@ tor_control_auth = "none" # or "password=xxxxxx"
 # The onion port to use.
 tor_onion_port = 18141
 # The address to which traffic on the node's onion address will be forwarded
-tor_forward_address = "/ip4/127.0.0.1/tcp/18141"
+# tor_forward_address = "/ip4/127.0.0.1/tcp/0"
 # Instead of attemping to get the SOCKS5 address from the tor control port, use this one. The default is to
 # use the first address returned by the tor control port (GETINFO /net/listeners/socks).
 #tor_socks_address_override=
@@ -301,7 +301,7 @@ peer_seeds = []
 # The onion port to use.
 #tor_onion_port = 18141
 # The address to which traffic on the node's onion address will be forwarded
-#tor_forward_address = "/ip4/127.0.0.1/tcp/18141"
+#tor_forward_address = "/ip4/127.0.0.1/tcp/0"
 # Instead of attemping to get the SOCKS5 address from the tor control port, use this one. The default is to
 # use the first address returned by the tor control port (GETINFO /net/listeners/socks).
 #tor_socks_address_override=


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR removes a port collision if the user has an explicitly set
`tor_forward_address` set in their config. This option now only applies
to the base node. The wallet is always configured to use an OS-assign
forwarding port and a pre-defined wallet onion port of 18101 (the same
as the Aurora wallet).

Commented out `tor_forward_address` in config templates.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Base node would fail to start up if `tor_forward_address` was set 
because both the base node and its wallet were configured to use this port.
In the vast majority of cases, `tor_forward_address` would never need to be set (since #2138 )  

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Set `tor_forward_address` in base node and checked in logs that the listener is setup correctly and that inbound connections work.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch.
* [x] I ran `cargo-fmt --all` before pushing.
* [x] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
