### PR TITLE
Fix bug with rolling log file pattern in Wallet FFI

### DIFF
--- a/base_layer/wallet_ffi/src/lib.rs
+++ b/base_layer/wallet_ffi/src/lib.rs
@@ -2581,8 +2581,9 @@ pub unsafe extern "C" fn wallet_create(
             if split_str.len() <= 1 {
                 pattern = format!("{}{}", path.clone(), "{}");
             } else {
-                for i in 0..split_str.len() - 1 {
-                    pattern = format!("{}{}", pattern, split_str[i]);
+                pattern = format!("{}", split_str[0]);
+                for i in 1..split_str.len() - 1 {
+                    pattern = format!("{}.{}", pattern, split_str[i]);
                 }
 
                 pattern = format!("{}{}", pattern, ".{}.");


### PR DESCRIPTION
## Description
For the rolling file functionality a file pattern must be generated to show log4rs where to put the index in the file name. There was a bug in the code that generated this pattern from the provided file path if the path had more dots in it that just for the file extension the other dots were lost. For example:

`/data/user/0/com.tari.android.wallet/files/tari_logs/tari_wallet_20200819_1597860350418.log`

becomes

`/data/user/0/comtariandroidwallet/files/tari_logs/tari_wallet_20200819_1597860350418.{}.log`

When it should be:

`/data/user/0/com.tari.android.wallet/files/tari_logs/tari_wallet_20200819_1597860350418.{}.log`

This PR fixes that bug.

@kukabi 

## How Has This Been Tested?
Existing tests

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch.
* [x] I ran `cargo-fmt --all` before pushing.
* [ ] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
