### PR TITLE
Add grace period to SAF message request time

### DIFF
--- a/comms/dht/src/config.rs
+++ b/comms/dht/src/config.rs
@@ -93,6 +93,10 @@ pub struct DhtConfig {
     pub connectivity_random_pool_refresh: Duration,
     /// The active Network. Default: TestNet
     pub network: Network,
+    /// The minimum period used to request SAF messages from a peer. When requesting SAF messages,
+    /// it will request messages since the DHT last went offline, but this may be a small amount of
+    /// time, so `minimum_request_period` can be used so that messages aren't missed.
+    pub minimum_request_period: Duration,
 }
 
 impl DhtConfig {
@@ -141,6 +145,7 @@ impl Default for DhtConfig {
             auto_join: false,
             join_cooldown_interval: Duration::from_secs(10 * 60),
             network: Network::TestNet,
+            minimum_request_period: SAF_HIGH_PRIORITY_MSG_STORAGE_TTL,
         }
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Add minimum request time for requesting SAF messages

## Description
<!--- Describe your changes in detail -->


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
On iOS specifically, there are cases where the DHT is shut down before the SAF request can finish. The next time it requests SAF messages, it will use the DHT shut down time. I suspect there may be windows where a message arrives after a node has requested SAF messages and before the DHT shuts down. This can result in missing messages. While it may be better to have a more robust timing mechanism, AFAIK there is no danger in receiving a message twice and so for now a simple fix is to just ask for all messages inside of the high priority TTL period. At a later stage it might be worth looking into this problem again.


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch.
* [x] I ran `cargo-fmt --all` before pushing.
* [x] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
