### PR TITLE
Fix issue where mempool is not cleared of invalid tx

### DIFF
--- a/base_layer/core/tests/mempool.rs
+++ b/base_layer/core/tests/mempool.rs
@@ -397,6 +397,14 @@ fn test_reorg() {
     assert_eq!(stats.unconfirmed_txs, 2);
     assert_eq!(stats.timelocked_txs, 1);
     assert_eq!(stats.published_txs, 3);
+
+    // "Mine" block 4
+    let template = chain_block(&blocks[3], vec![], consensus_manager.consensus_constants());
+    let reorg_block4 = db.calculate_mmr_roots(template).unwrap();
+
+    // test that process_reorg can handle the case when removed_blocks is empty
+    // see https://github.com/tari-project/tari/issues/2101#issuecomment-680726940
+    mempool.process_reorg(vec![], vec![reorg_block4]).unwrap();
 }
 
 #[test]


### PR DESCRIPTION
## Description

This commit fixes a logical error where a mempool reorg is not
being processed when more than one block is added and _no_ blocks are
removed. Previously when no blocks were removed, `handle_reorg` would
return `BlockAddResult::Ok` - even if multiple blocks were added. This
introduced a bug where transactions from the added blocks could be left
in the mempool. A test was added to `chain_storage` to ensure a reorg in
this case.

As a consequence of now forcing a reorg even if no blocks are removed,
an additional issue was uncovered with `Mempool::process_reorg` causing
a panic when `removed_blocks` was empty. A test has been added to catch
this case, and the code refactored to remove calls to `expect` in favor
of explicitly handling the `Option`s.

## Motivation and Context
Issue #2101 

## How Has This Been Tested?
* Existing tests pass
* New tests catch the issues they are fixing
* Manually ran the node 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [X] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [X] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [X] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [X] I'm merging against the `development` branch.
* [X] I ran `cargo-fmt --all` before pushing.
* [X] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [X] I have added tests to cover my changes.
