### PR TITLE
[Merge Mining] Fixed missing Merge Mining Tag

### DIFF
--- a/base_layer/core/src/proof_of_work/monero_rx.rs
+++ b/base_layer/core/src/proof_of_work/monero_rx.rs
@@ -71,7 +71,7 @@ pub struct MoneroData {
 
 // Hash algorithm in monero
 pub fn cn_fast_hash(data: &[u8]) -> Vec<u8> {
-    Hash::hash(data).0.as_bytes().to_vec()
+    Hash::hash(data).0.to_vec()
 }
 
 // Tree hash count in monero
@@ -170,16 +170,15 @@ fn monero_difficulty_calculation(header: &BlockHeader) -> Result<Difficulty, Mer
     Ok(difficulty)
 }
 
-/// Appends merge mining hash to a Monero block and returns the Monero blocktemplate_blob
-pub fn append_merge_mining_tag(block: &MoneroBlock, hash: Hash) -> Result<String, MergeMineError> {
-    let mut monero_block = block.clone();
+/// Appends merge mining hash to a Monero block and returns the encoded Monero blocktemplate_blob
+pub fn append_merge_mining_tag(block: &mut MoneroBlock, hash: Hash) -> Result<String, MergeMineError> {
     let mm_tag = SubField::MergeMining(VarInt(0), hash);
-    monero_block.miner_tx.prefix.extra.0.push(mm_tag);
+    block.miner_tx.prefix.extra.0.push(mm_tag);
     let serialized = serialize::<MoneroBlock>(&block);
     Ok(hex::encode(&serialized).into())
 }
 
-/// Calculates the Monero blockhashing_blob
+/// Calculates the encoded Monero blockhashing_blob
 pub fn create_input_blob(
     header: &MoneroBlockHeader,
     tx_count: &u16,
@@ -191,7 +190,7 @@ pub fn create_input_blob(
     let mut count = serialize::<VarInt>(&VarInt(tx_count.clone() as u64));
     let mut hashes = Vec::new();
     for item in tx_hashes {
-        hashes.push(Hash(from_slice(item.clone().as_bytes())));
+        hashes.push(Hash::from(item.clone()));
     }
     let mut root = tree_hash(hashes);
     let mut encode = header;
@@ -220,7 +219,7 @@ pub fn from_hashes(hashes: &[Hash]) -> Vec<[u8; 32]> {
 fn verify_root(monero_data: &MoneroData) -> Result<(), MergeMineError> {
     let mut hashes = Vec::new();
     for item in &monero_data.transaction_hashes {
-        hashes.push(Hash(from_slice(item.to_vec().as_slice())));
+        hashes.push(Hash::from(item));
     }
     let root = tree_hash(hashes);
 
@@ -235,7 +234,7 @@ fn verify_root(monero_data: &MoneroData) -> Result<(), MergeMineError> {
 fn merged_mining_subfield(header: &BlockHeader) -> SubField {
     let hash = header.merged_mining_hash();
     let depth = 0;
-    SubField::MergeMining(VarInt(depth), Hash::hash(&hash[..32]))
+    SubField::MergeMining(VarInt(depth), Hash::from(from_slice(&hash)))
 }
 
 fn verify_header(header: &BlockHeader, monero_data: &MoneroData) -> Result<(), MergeMineError> {


### PR DESCRIPTION
## Description
The function `append_merge_mining_tag`, the `block` parameter needed to be mutable.
Ensured miner_tx hash is first hash added to hashes when calculating root.

## Motivation and Context
Fixes missing merge mining tag

## How Has This Been Tested?
cargo test --all

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch.
* [x] I ran `cargo-fmt --all` before pushing.
* [x] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
