### PR TITLE
Implement DHT event and Wallet FFI callback to be triggered when “enough” SAF responses are received

### DIFF
--- a/base_layer/wallet_ffi/wallet.h
+++ b/base_layer/wallet_ffi/wallet.h
@@ -382,6 +382,9 @@ void comms_config_destroy(struct TariCommsConfig *wc);
 /// when a Base Node Sync process is completed or times out. The request_key is used to identify which request this
 /// callback references and a result of true means it was successful and false that the process timed out and new one
 /// will be started
+/// `callback_saf_message_received` - The callback function pointer that will be called when the Dht has determined that
+/// is has connected to enough of its neighbours to be confident that it has received any SAF messages that were waiting
+/// for it.
 /// `error_out` - Pointer to an int which will be modified
 /// to an error code should one occur, may not be null. Functions as an out parameter.
 /// ## Returns
@@ -404,6 +407,7 @@ struct TariWallet *wallet_create(struct TariWalletConfig *config,
                                     void (*callback_store_and_forward_send_result)(unsigned long long, bool),
                                     void (*callback_transaction_cancellation)(struct TariCompletedTransaction*),
                                     void (*callback_base_node_sync_complete)(unsigned long long, bool),
+                                    void (*callback_saf_message_received)(),
                                     int* error_out);
 
 // Signs a message

--- a/comms/dht/src/event.rs
+++ b/comms/dht/src/event.rs
@@ -1,0 +1,32 @@
+// Copyright 2020. The Tari Project
+//
+// Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+// following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+// disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+// following disclaimer in the documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+// products derived from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+// INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+// WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+// USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+use std::sync::Arc;
+use tokio::sync::broadcast;
+
+pub type DhtEventSender = broadcast::Sender<Arc<DhtEvent>>;
+pub type DhtEventReceiver = broadcast::Receiver<Arc<DhtEvent>>;
+
+#[derive(Debug)]
+pub enum DhtEvent {
+    StoreAndForwardMessagesReceived,
+}

--- a/comms/dht/src/lib.rs
+++ b/comms/dht/src/lib.rs
@@ -152,6 +152,8 @@ mod utils;
 
 mod schema;
 
+pub mod event;
+
 pub mod broadcast_strategy;
 pub mod domain_message;
 pub mod envelope;

--- a/comms/dht/src/store_forward/saf_handler/layer.rs
+++ b/comms/dht/src/store_forward/saf_handler/layer.rs
@@ -27,6 +27,7 @@ use crate::{
     outbound::OutboundMessageRequester,
     store_forward::StoreAndForwardRequester,
 };
+use futures::channel::mpsc;
 use std::sync::Arc;
 use tari_comms::peer_manager::{NodeIdentity, PeerManager};
 use tower::layer::Layer;
@@ -38,6 +39,7 @@ pub struct MessageHandlerLayer {
     peer_manager: Arc<PeerManager>,
     node_identity: Arc<NodeIdentity>,
     outbound_service: OutboundMessageRequester,
+    saf_response_signal_sender: mpsc::Sender<()>,
 }
 
 impl MessageHandlerLayer {
@@ -48,6 +50,7 @@ impl MessageHandlerLayer {
         node_identity: Arc<NodeIdentity>,
         peer_manager: Arc<PeerManager>,
         outbound_service: OutboundMessageRequester,
+        saf_response_signal_sender: mpsc::Sender<()>,
     ) -> Self
     {
         Self {
@@ -57,6 +60,7 @@ impl MessageHandlerLayer {
             node_identity,
             peer_manager,
             outbound_service,
+            saf_response_signal_sender,
         }
     }
 }
@@ -73,6 +77,7 @@ impl<S> Layer<S> for MessageHandlerLayer {
             Arc::clone(&self.node_identity),
             Arc::clone(&self.peer_manager),
             self.outbound_service.clone(),
+            self.saf_response_signal_sender.clone(),
         )
     }
 }

--- a/comms/dht/src/store_forward/saf_handler/task.rs
+++ b/comms/dht/src/store_forward/saf_handler/task.rs
@@ -45,7 +45,7 @@ use crate::{
     utils::try_convert_all,
 };
 use digest::Digest;
-use futures::{future, stream, Future, StreamExt};
+use futures::{channel::mpsc, future, stream, Future, SinkExt, StreamExt};
 use log::*;
 use prost::Message;
 use std::{convert::TryInto, sync::Arc};
@@ -70,6 +70,7 @@ pub struct MessageHandlerTask<S> {
     node_identity: Arc<NodeIdentity>,
     message: Option<DecryptedDhtMessage>,
     saf_requester: StoreAndForwardRequester,
+    saf_response_signal_sender: mpsc::Sender<()>,
 }
 
 impl<S> MessageHandlerTask<S>
@@ -85,6 +86,7 @@ where S: Service<DecryptedDhtMessage, Response = (), Error = PipelineError>
         outbound_service: OutboundMessageRequester,
         node_identity: Arc<NodeIdentity>,
         message: DecryptedDhtMessage,
+        saf_response_signal_sender: mpsc::Sender<()>,
     ) -> Self
     {
         Self {
@@ -96,6 +98,7 @@ where S: Service<DecryptedDhtMessage, Response = (), Error = PipelineError>
             outbound_service,
             node_identity,
             message: Some(message),
+            saf_response_signal_sender,
         }
     }
 
@@ -206,16 +209,6 @@ where S: Service<DecryptedDhtMessage, Response = (), Error = PipelineError>
             query.with_response_type(resp_type);
             let messages = self.saf_requester.fetch_messages(query.clone()).await?;
 
-            if messages.is_empty() {
-                debug!(
-                    target: LOG_TARGET,
-                    "No {:?} stored messages for peer '{}'",
-                    resp_type,
-                    message.source_peer.node_id.short_str()
-                );
-                continue;
-            }
-
             let message_ids = messages.iter().map(|msg| msg.id).collect::<Vec<_>>();
             let stored_messages = StoredMessagesResponse {
                 messages: try_convert_all(messages)?,
@@ -266,7 +259,7 @@ where S: Service<DecryptedDhtMessage, Response = (), Error = PipelineError>
         Ok(())
     }
 
-    async fn handle_stored_messages(self, message: DecryptedDhtMessage) -> Result<(), StoreAndForwardError> {
+    async fn handle_stored_messages(mut self, message: DecryptedDhtMessage) -> Result<(), StoreAndForwardError> {
         trace!(
             target: LOG_TARGET,
             "Received stored messages from {} (Trace: {})",
@@ -353,6 +346,13 @@ where S: Service<DecryptedDhtMessage, Response = (), Error = PipelineError>
             })
             .filter(Result::is_ok)
             .map(Result::unwrap);
+
+        // Let the SAF Service know we got a SAF response.
+        let _ = self
+            .saf_response_signal_sender
+            .send(())
+            .await
+            .map_err(|e| warn!(target: LOG_TARGET, "Error sending SAF response signal; {:?}", e));
 
         self.next_service
             .call_all(stream::iter(successful_msgs_iter))
@@ -548,7 +548,9 @@ mod test {
     use chrono::Utc;
     use futures::channel::mpsc;
     use prost::Message;
+    use std::time::Duration;
     use tari_comms::{message::MessageExt, wrap_in_envelope_body};
+    use tari_test_utils::collect_stream;
     use tari_utilities::hex::Hex;
     use tokio::runtime::Handle;
 
@@ -595,9 +597,6 @@ mod test {
             false,
             MessageTag::new(),
         );
-        mock_state
-            .add_message(make_stored_message(&node_identity, dht_header))
-            .await;
 
         let since = Utc::now().checked_sub_signed(chrono::Duration::seconds(60)).unwrap();
         let mut message = DecryptedDhtMessage::succeeded(
@@ -614,7 +613,41 @@ mod test {
 
         let (tx, _) = mpsc::channel(1);
         let dht_requester = DhtRequester::new(tx);
+        let (saf_response_signal_sender, _saf_response_signal_receiver) = mpsc::channel(20);
 
+        // First test that the task will respond if there are no messages to send.
+        let task = MessageHandlerTask::new(
+            Default::default(),
+            spy.to_service::<PipelineError>(),
+            requester.clone(),
+            dht_requester.clone(),
+            peer_manager.clone(),
+            OutboundMessageRequester::new(oms_tx.clone()),
+            node_identity.clone(),
+            message.clone(),
+            saf_response_signal_sender.clone(),
+        );
+
+        rt_handle.spawn(task.run());
+
+        let (_, body) = unwrap_oms_send_msg!(oms_rx.next().await.unwrap());
+        let body = body.to_vec();
+        let body = EnvelopeBody::decode(body.as_slice()).unwrap();
+        let msg = body.decode_part::<StoredMessagesResponse>(0).unwrap().unwrap();
+        assert_eq!(msg.messages().len(), 0);
+        assert!(!spy.is_called());
+
+        assert_eq!(mock_state.call_count(), 1);
+        let calls = mock_state.take_calls().await;
+        assert!(calls[0].contains("FetchMessages"));
+        assert!(calls[0].contains(node_identity.public_key().to_hex().as_str()));
+        assert!(calls[0].contains(format!("{:?}", since).as_str()));
+
+        mock_state
+            .add_message(make_stored_message(&node_identity, dht_header))
+            .await;
+
+        // Now lets test its response where there are messages to return.
         let task = MessageHandlerTask::new(
             Default::default(),
             spy.to_service::<PipelineError>(),
@@ -624,6 +657,7 @@ mod test {
             OutboundMessageRequester::new(oms_tx),
             node_identity.clone(),
             message,
+            saf_response_signal_sender,
         );
 
         rt_handle.spawn(task.run());
@@ -636,7 +670,7 @@ mod test {
         assert_eq!(msg.messages()[0].body, b"A");
         assert!(!spy.is_called());
 
-        assert_eq!(mock_state.call_count(), 1);
+        assert_eq!(mock_state.call_count(), 2);
         let calls = mock_state.take_calls().await;
         assert!(calls[0].contains("FetchMessages"));
         assert!(calls[0].contains(node_identity.public_key().to_hex().as_str()));
@@ -696,6 +730,7 @@ mod test {
 
         let (dht_requester, mock) = create_dht_actor_mock(1);
         rt_handle.spawn(mock.run());
+        let (saf_response_signal_sender, mut saf_response_signal_receiver) = mpsc::channel(20);
 
         let task = MessageHandlerTask::new(
             Default::default(),
@@ -706,6 +741,7 @@ mod test {
             OutboundMessageRequester::new(oms_tx),
             node_identity,
             message,
+            saf_response_signal_sender,
         );
 
         task.run().await.unwrap();
@@ -720,5 +756,11 @@ mod test {
         assert!(msgs.contains(&b"A".to_vec()));
         assert!(msgs.contains(&b"B".to_vec()));
         assert!(msgs.contains(&b"Clear".to_vec()));
+        let signals = collect_stream!(
+            saf_response_signal_receiver,
+            take = 1,
+            timeout = Duration::from_secs(20)
+        );
+        assert_eq!(signals.len(), 1);
     }
 }


### PR DESCRIPTION
## Description

This PR implements a DHT event bus with 1 new event that indicates that the DHT has received “enough” Store and Forward responses from its connected neighbours that we are relatively confident we have received any SAF responses due for us.

The SAF Handler on the inbound pipeline now sends a signal every time it handles a SAF response to the StoreAndForwardService. The StoreAndForwardService counts these signals and waits for the Event from the Connectivity manager to indicate when the node is considered Online. Online means that a proportion of neighbouring peers have been connected too. The SAF service then waits until it has received SAF response for at least the number of connected peers returned by the ConnectivityEvent and then it will fire the DhtEvent::StoreAndForwardMessagesReceived.

Currently a Node will not send a SAF response if it has no SAF messages to send but to enable this functionality this PR changes that logic to send an empty response so that the requesting node knows for sure there were no messages waiting for it.

The Wallet FFI Callback handler was extended to accept a new callback for to be called on this event. The Callback handler now subscribes to the DHT event bus and calls this new callback when the DhtEvent::StoreAndForwardMessagesReceived is received.

**NOTE: This PR will only start to work when the Peers in the network are also running this code because until then they will not respond if there are not SAF messages to be delivered.**

@kukabi and @Jasonvdb Please note the change to `wallet_create(…)`

## How Has This Been Tested?
Tests updated to test:
1. That the SAF middleware does signal when it receives a SAF response
2. That the SAF service does emit the event 
3. That the Callback handler does fire when it receives the event
4. That the SAF service does respond when it has no SAF messages to return.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [x] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch.
* [x] I ran `cargo-fmt --all` before pushing.
* [ ] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
