### PR TITLE
Fix geometric mean comparison halting the blockchain

### DIFF
--- a/base_layer/core/src/validation/accum_difficulty_validators.rs
+++ b/base_layer/core/src/validation/accum_difficulty_validators.rs
@@ -35,7 +35,7 @@ impl<B: BlockchainBackend> Validation<Difficulty, B> for AccumDifficultyValidato
         let tip_header = db
             .fetch_last_header()?
             .ok_or_else(|| ValidationError::custom_error("Cannot retrieve tip header. Blockchain DB is empty"))?;
-        if *accum_difficulty <= tip_header.total_accumulated_difficulty_inclusive() {
+        if *accum_difficulty < tip_header.total_accumulated_difficulty_inclusive() {
             return Err(ValidationError::WeakerAccumulatedDifficulty);
         }
         Ok(())


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
When the geometric mean of a new block is compared to that of the network, it must be accepted if it is equal, due to the number being rounded. `geo_mean = sqrt(achieved_difficulty_01 ^ 2 x achieved_difficulty_02 ^ 2)`

## Motivation and Context

If achieved difficulty is `49999999` in the example below, the absolute rounded up geometric mean stays the same:
|           | diff_01 | diff_02             | geo_mean   |
| --------- | ------- | ------------------- | ---------- |
| chain tip | 1       | 740 390 525 623 642 | 27 210 119 |
| new block | 1       | 740 390 575 623 641 | 27 210 119 |

## How Has This Been Tested?
On two Windows nodes

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [X] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [X] I'm merging against the `development` branch.
* [X] I ran `cargo-fmt --all` before pushing.
* [X] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
