### PR TITLE
Fix restoration of previous blocks after failed reorg

### DIFF
--- a/base_layer/core/src/chain_storage/blockchain_database.rs
+++ b/base_layer/core/src/chain_storage/blockchain_database.rs
@@ -369,7 +369,7 @@ where B: BlockchainBackend
     /// Sets and stores the chain metadata, overwriting previous metadata.
     pub fn set_chain_metadata(&self, metadata: ChainMetadata) -> Result<(), ChainStorageError> {
         let mut db = self.db_write_access()?;
-        set_chain_metadata(&mut db, metadata)
+        set_chain_metadata(&mut *db, metadata)
     }
 
     /// Returns the transaction kernel with the given hash.
@@ -394,7 +394,7 @@ where B: BlockchainBackend
     /// been validated.
     pub fn insert_valid_headers(&self, headers: Vec<BlockHeader>) -> Result<(), ChainStorageError> {
         let mut db = self.db_write_access()?;
-        insert_headers(&mut db, headers)
+        insert_headers(&mut *db, headers)
     }
 
     /// Returns the set of block headers specified by the block numbers.
@@ -423,7 +423,7 @@ where B: BlockchainBackend
     /// Spends the UTXO with the given hash
     pub fn spend_utxo(&self, hash: HashOutput) -> Result<(), ChainStorageError> {
         let mut db = self.db_write_access()?;
-        spend_utxo(&mut db, hash)
+        spend_utxo(&mut *db, hash)
     }
 
     /// Returns the sum of all UTXO commitments
@@ -455,7 +455,7 @@ where B: BlockchainBackend
     /// Store the provided UTXO.
     pub fn insert_utxo(&self, utxo: TransactionOutput) -> Result<(), ChainStorageError> {
         let mut db = self.db_write_access()?;
-        insert_utxo(&mut db, utxo)
+        insert_utxo(&mut *db, utxo)
     }
 
     /// Returns the STXO with the given hash.
@@ -623,16 +623,16 @@ where B: BlockchainBackend
         );
         let mut db = self.db_write_access()?;
         let block_add_result = add_block(
-            &mut db,
-            &self.validators.block,
-            &self.validators.accum_difficulty,
+            &mut *db,
+            &*self.validators.block,
+            &*self.validators.accum_difficulty,
             block,
         )?;
 
         // Cleanup orphan block pool
         match block_add_result {
             BlockAddResult::OrphanBlock | BlockAddResult::ChainReorg(_) => {
-                cleanup_orphans(&mut db, self.config.orphan_storage_capacity)?
+                cleanup_orphans(&mut *db, self.config.orphan_storage_capacity)?
             },
             _ => {},
         }
@@ -640,7 +640,7 @@ where B: BlockchainBackend
         // Cleanup of backend when in pruned mode.
         match block_add_result {
             BlockAddResult::Ok | BlockAddResult::ChainReorg(_) => prune_database(
-                &mut db,
+                &mut *db,
                 self.config.pruning_interval,
                 self.config.pruning_horizon,
                 new_height,
@@ -657,13 +657,15 @@ where B: BlockchainBackend
     }
 
     fn store_new_block(&self, block: Block) -> Result<(), ChainStorageError> {
+        let mut txn = DbTransaction::new();
+        store_new_block(&mut txn, block);
         let mut db = self.db_write_access()?;
-        store_new_block(&mut db, block)
+        commit(&mut *db, txn)
     }
 
     fn store_pruning_horizon(&self, pruning_horizon: u64) -> Result<(), ChainStorageError> {
         let mut db = self.db_write_access()?;
-        store_pruning_horizon(&mut db, pruning_horizon)
+        store_pruning_horizon(&mut *db, pruning_horizon)
     }
 
     /// Fetch a block from the blockchain database.
@@ -720,7 +722,7 @@ where B: BlockchainBackend
     /// Atomically commit the provided transaction to the database backend. This function does not update the metadata.
     pub fn commit(&self, txn: DbTransaction) -> Result<(), ChainStorageError> {
         let mut db = self.db_write_access()?;
-        commit(&mut db, txn)
+        commit(&mut *db, txn)
     }
 
     pub fn get_horizon_sync_state(&self) -> Result<Option<InProgressHorizonSyncState>, ChainStorageError> {
@@ -741,7 +743,7 @@ where B: BlockchainBackend
     /// * The block height is before the horizon block height determined by the pruning horizon
     pub fn rewind_to_height(&self, height: u64) -> Result<Vec<Block>, ChainStorageError> {
         let mut db = self.db_write_access()?;
-        rewind_to_height(&mut db, height)
+        rewind_to_height(&mut *db, height)
     }
 
     /// Prepares the database for horizon sync. This function sets the PendingHorizonSyncState for the database
@@ -784,7 +786,7 @@ where B: BlockchainBackend
                     MetadataValue::EffectivePrunedHeight(0),
                 );
                 txn.set_metadata(MetadataKey::AccumulatedWork, MetadataValue::AccumulatedWork(None));
-                commit(&mut db, txn)?;
+                commit(&mut *db, txn)?;
 
                 Ok(state)
             },
@@ -828,7 +830,7 @@ where B: BlockchainBackend
         // Remove pending horizon sync state
         txn.delete_metadata(MetadataKey::HorizonSyncState);
 
-        commit(&mut db, txn)
+        commit(&mut *db, txn)
     }
 
     /// Rollback the current synced horizon state to a consistent state.
@@ -908,7 +910,7 @@ where B: BlockchainBackend
         // Remove pending horizon sync state
         txn.delete_metadata(MetadataKey::HorizonSyncState);
 
-        commit(&mut db, txn)
+        commit(&mut *db, txn)
     }
 
     /// Store the provided set of kernels and persists a checkpoint
@@ -917,7 +919,7 @@ where B: BlockchainBackend
         let mut txn = DbTransaction::new();
         kernels.into_iter().for_each(|kernel| txn.insert_kernel(kernel));
         txn.create_mmr_checkpoint(MmrTree::Kernel);
-        commit(&mut db, txn)
+        commit(&mut *db, txn)
     }
 
     /// Spends the UTXOs with the given hashes
@@ -926,7 +928,7 @@ where B: BlockchainBackend
         let mut txn = DbTransaction::new();
         hashes.into_iter().for_each(|hash| txn.spend_utxo(hash));
         txn.create_mmr_checkpoint(MmrTree::Utxo);
-        commit(&mut db, txn)
+        commit(&mut *db, txn)
     }
 
     /// Create a MMR checkpoint for the given `MmrTree`
@@ -934,7 +936,7 @@ where B: BlockchainBackend
         let mut db = self.db_write_access()?;
         let mut txn = DbTransaction::new();
         txn.create_mmr_checkpoint(tree);
-        commit(&mut db, txn)
+        commit(&mut *db, txn)
     }
 }
 
@@ -944,11 +946,7 @@ fn unexpected_result<T>(req: DbKey, res: DbValue) -> Result<T, ChainStorageError
     Err(ChainStorageError::UnexpectedResult(msg))
 }
 
-fn set_chain_metadata<T: BlockchainBackend>(
-    db: &mut RwLockWriteGuard<T>,
-    metadata: ChainMetadata,
-) -> Result<(), ChainStorageError>
-{
+fn set_chain_metadata<T: BlockchainBackend>(db: &mut T, metadata: ChainMetadata) -> Result<(), ChainStorageError> {
     let mut txn = DbTransaction::new();
     txn.set_metadata(
         MetadataKey::ChainHeight,
@@ -982,11 +980,7 @@ pub fn fetch_headers<T: BlockchainBackend>(
     Ok(headers)
 }
 
-fn insert_headers<T: BlockchainBackend>(
-    db: &mut RwLockWriteGuard<T>,
-    headers: Vec<BlockHeader>,
-) -> Result<(), ChainStorageError>
-{
+fn insert_headers<T: BlockchainBackend>(db: &mut T, headers: Vec<BlockHeader>) -> Result<(), ChainStorageError> {
     let mut txn = DbTransaction::new();
     headers.into_iter().for_each(|header| {
         txn.insert_header(header);
@@ -1011,11 +1005,7 @@ fn fetch_utxo<T: BlockchainBackend>(db: &T, hash: HashOutput) -> Result<Transact
     fetch!(db, hash, UnspentOutput)
 }
 
-fn insert_utxo<T: BlockchainBackend>(
-    db: &mut RwLockWriteGuard<T>,
-    utxo: TransactionOutput,
-) -> Result<(), ChainStorageError>
-{
+fn insert_utxo<T: BlockchainBackend>(db: &mut T, utxo: TransactionOutput) -> Result<(), ChainStorageError> {
     let mut txn = DbTransaction::new();
     txn.insert_utxo(utxo);
     commit(db, txn)
@@ -1025,7 +1015,7 @@ fn fetch_stxo<T: BlockchainBackend>(db: &T, hash: HashOutput) -> Result<Transact
     fetch!(db, hash, SpentOutput)
 }
 
-fn spend_utxo<T: BlockchainBackend>(db: &mut RwLockWriteGuard<T>, hash: HashOutput) -> Result<(), ChainStorageError> {
+fn spend_utxo<T: BlockchainBackend>(db: &mut T, hash: HashOutput) -> Result<(), ChainStorageError> {
     let mut txn = DbTransaction::new();
     txn.spend_utxo(hash);
     commit(db, txn)
@@ -1092,9 +1082,9 @@ fn fetch_mmr_proof<T: BlockchainBackend>(db: &T, tree: MmrTree, pos: usize) -> R
 }
 
 fn add_block<T: BlockchainBackend>(
-    db: &mut RwLockWriteGuard<T>,
-    block_validator: &Arc<Validator<Block, T>>,
-    accum_difficulty_validator: &Arc<Validator<Difficulty, T>>,
+    db: &mut T,
+    block_validator: &Validator<Block, T>,
+    accum_difficulty_validator: &Validator<Difficulty, T>,
     block: Block,
 ) -> Result<BlockAddResult, ChainStorageError>
 {
@@ -1106,7 +1096,13 @@ fn add_block<T: BlockchainBackend>(
 }
 
 // Adds a new block onto the chain tip.
-fn store_new_block<T: BlockchainBackend>(db: &mut RwLockWriteGuard<T>, block: Block) -> Result<(), ChainStorageError> {
+fn store_new_block(txn: &mut DbTransaction, block: Block) {
+    debug!(
+        target: LOG_TARGET,
+        "Storing new block #{} `{}`",
+        block.header.height,
+        block.hash().to_hex()
+    );
     let (header, inputs, outputs, kernels) = block.dissolve();
     let height = header.height;
     let best_block = header.hash();
@@ -1114,7 +1110,7 @@ fn store_new_block<T: BlockchainBackend>(db: &mut RwLockWriteGuard<T>, block: Bl
         ProofOfWork::new_from_difficulty(&header.pow, ProofOfWork::achieved_difficulty(&header))
             .total_accumulated_difficulty();
     // Build all the DB queries needed to add the block and the add it atomically
-    let mut txn = DbTransaction::new();
+
     // Update metadata
     txn.set_metadata(MetadataKey::ChainHeight, MetadataValue::ChainHeight(Some(height)));
     txn.set_metadata(MetadataKey::BestBlock, MetadataValue::BestBlock(Some(best_block)));
@@ -1128,15 +1124,9 @@ fn store_new_block<T: BlockchainBackend>(db: &mut RwLockWriteGuard<T>, block: Bl
     outputs.into_iter().for_each(|utxo| txn.insert_utxo(utxo));
     kernels.into_iter().for_each(|k| txn.insert_kernel(k));
     txn.commit_block();
-    commit(db, txn)?;
-    Ok(())
 }
 
-fn store_pruning_horizon<T: BlockchainBackend>(
-    db: &mut RwLockWriteGuard<T>,
-    pruning_horizon: u64,
-) -> Result<(), ChainStorageError>
-{
+fn store_pruning_horizon<T: BlockchainBackend>(db: &mut T, pruning_horizon: u64) -> Result<(), ChainStorageError> {
     let mut txn = DbTransaction::new();
     txn.set_metadata(
         MetadataKey::PruningHorizon,
@@ -1369,60 +1359,66 @@ fn fetch_checkpoint<T: BlockchainBackend>(
 }
 
 #[inline]
-fn commit<T: BlockchainBackend>(db: &mut RwLockWriteGuard<T>, txn: DbTransaction) -> Result<(), ChainStorageError> {
+fn commit<T: BlockchainBackend>(db: &mut T, txn: DbTransaction) -> Result<(), ChainStorageError> {
     db.write(txn)
 }
 
-fn rewind_to_height<T: BlockchainBackend>(
-    db: &mut RwLockWriteGuard<T>,
-    height: u64,
-) -> Result<Vec<Block>, ChainStorageError>
-{
-    let chain_height = check_for_valid_height(&**db, height)?;
-    let mut removed_blocks = Vec::<Block>::new();
+fn rewind_to_height<T: BlockchainBackend>(db: &mut T, height: u64) -> Result<Vec<Block>, ChainStorageError> {
+    let chain_height = check_for_valid_height(db, height)?;
     if height == chain_height {
-        return Ok(removed_blocks); // Rewind unnecessary, already on correct height
+        return Ok(Vec::new()); // Rewind unnecessary, already on correct height
     }
+    debug!(
+        target: LOG_TARGET,
+        "Rewinding from height {} to {}", chain_height, height
+    );
     let steps_back = (chain_height - height) as usize;
+    let mut removed_blocks = Vec::with_capacity(steps_back);
     let mut txn = DbTransaction::new();
     // Rewind operation must be performed in reverse from tip to height+1.
     for rewind_height in ((height + 1)..=chain_height).rev() {
         // Reconstruct block at height and add to orphan block pool
-        let orphaned_block = fetch_block(&**db, rewind_height)?.block().clone();
+        let orphaned_block = fetch_block(db, rewind_height)?.block().clone();
         removed_blocks.push(orphaned_block.clone());
         txn.insert_orphan(orphaned_block);
 
         // Remove Header and block hash
-        txn.delete(DbKey::BlockHeader(rewind_height)); // Will also delete the blockhash
+        txn.delete(DbKey::BlockHeader(rewind_height));
 
         // Remove Kernels
-        fetch_checkpoint(&**db, MmrTree::Kernel, rewind_height)?
-            .nodes_added()
-            .iter()
-            .for_each(|hash_output| {
-                txn.delete(DbKey::TransactionKernel(hash_output.clone()));
-            });
+        let (nodes_added, _) = fetch_checkpoint(db, MmrTree::Kernel, rewind_height)?.into_parts();
+        nodes_added.into_iter().for_each(|hash_output| {
+            txn.delete(DbKey::TransactionKernel(hash_output));
+        });
 
         // Remove UTXOs and move STXOs back to UTXO set
-        let (nodes_added, nodes_deleted) = fetch_checkpoint(&**db, MmrTree::Utxo, rewind_height)?.into_parts();
+        let checkpoint = fetch_checkpoint(db, MmrTree::Utxo, rewind_height)?;
+        let (nodes_added, nodes_deleted) = checkpoint.into_parts();
+        for pos in nodes_deleted.iter() {
+            let (stxo_hash, deleted) = db.fetch_mmr_node(MmrTree::Utxo, pos, None)?;
+            if !deleted {
+                warn!(
+                    target: LOG_TARGET,
+                    "**Database corruption detected** An MMR checkpoint at height {} indicated that a node {} was \
+                     spent but the corresponding MMR node did not.",
+                    rewind_height,
+                    pos
+                );
+            }
+            txn.unspend_stxo(stxo_hash);
+        }
+
+        // Delete nodes from the UTXO set
         nodes_added.iter().for_each(|hash_output| {
             txn.delete(DbKey::UnspentOutput(hash_output.clone()));
         });
-        for pos in nodes_deleted.iter() {
-            db.fetch_mmr_node(MmrTree::Utxo, pos, None)
-                .and_then(|(stxo_hash, deleted)| {
-                    assert!(deleted);
-                    txn.unspend_stxo(stxo_hash);
-                    Ok(())
-                })?;
-        }
     }
     // Rewind MMRs
     txn.rewind_kernel_mmr(steps_back);
     txn.rewind_utxo_mmr(steps_back);
     txn.rewind_rangeproof_mmr(steps_back);
     // Update metadata
-    let last_header = fetch_header(&**db, height)?;
+    let last_header = fetch_header(db, height)?;
     let accumulated_work =
         ProofOfWork::new_from_difficulty(&last_header.pow, ProofOfWork::achieved_difficulty(&last_header))
             .total_accumulated_difficulty();
@@ -1446,9 +1442,9 @@ fn rewind_to_height<T: BlockchainBackend>(
 // Checks whether we should add the block as an orphan. If it is the case, the orphan block is added and the chain
 // is reorganised if necessary.
 fn handle_possible_reorg<T: BlockchainBackend>(
-    db: &mut RwLockWriteGuard<T>,
-    block_validator: &Arc<Validator<Block, T>>,
-    accum_difficulty_validator: &Arc<Validator<Difficulty, T>>,
+    db: &mut T,
+    block_validator: &Validator<Block, T>,
+    accum_difficulty_validator: &Validator<Difficulty, T>,
     block: Block,
 ) -> Result<BlockAddResult, ChainStorageError>
 {
@@ -1483,9 +1479,9 @@ fn handle_possible_reorg<T: BlockchainBackend>(
 // reorg chain is constructed with a higher accumulated difficulty, then the main chain is rewound and updated
 // with the newly un-orphaned blocks from the reorg chain.
 fn handle_reorg<T: BlockchainBackend>(
-    db: &mut RwLockWriteGuard<T>,
+    db: &mut T,
     block_validator: &Validator<Block, T>,
-    accum_difficulty_validator: &Arc<Validator<Difficulty, T>>,
+    accum_difficulty_validator: &Validator<Difficulty, T>,
     new_block: Block,
 ) -> Result<BlockAddResult, ChainStorageError>
 {
@@ -1505,14 +1501,14 @@ fn handle_reorg<T: BlockchainBackend>(
     // Try and find all orphaned chain tips that can be linked to the new orphan block, if no better orphan chain
     // tips can be found then the new_block is a tip.
     let new_block_hash = new_block.hash();
-    let orphan_chain_tips = find_orphan_chain_tips(&**db, new_block.header.height, new_block_hash.clone());
+    let orphan_chain_tips = find_orphan_chain_tips(db, new_block.header.height, new_block_hash.clone());
     trace!(
         target: LOG_TARGET,
         "Search for orphan tips linked to block #{} complete.",
         new_block.header.height
     );
     // Check the accumulated difficulty of the best fork chain compared to the main chain.
-    let (fork_accum_difficulty, fork_tip_hash) = find_strongest_orphan_tip(&**db, orphan_chain_tips)?;
+    let (fork_accum_difficulty, fork_tip_hash) = find_strongest_orphan_tip(db, orphan_chain_tips)?;
     let tip_header = db
         .fetch_last_header()?
         .ok_or_else(|| ChainStorageError::InvalidQuery("Cannot retrieve header. Blockchain DB is empty".into()))?;
@@ -1583,13 +1579,13 @@ fn handle_reorg<T: BlockchainBackend>(
 
     // We've built the strongest orphan chain we can by going backwards and forwards from the new orphan block
     // that is linked with the main chain.
-    let fork_tip_block = fetch_orphan(&**db, fork_tip_hash.clone())?;
+    let fork_tip_block = fetch_orphan(db, fork_tip_hash.clone())?;
     let fork_tip_header = fork_tip_block.header.clone();
     if fork_tip_hash != new_block_hash {
         // New block is not the tip, find complete chain from tip to main chain.
         reorg_chain = try_construct_fork(db, fork_tip_block)?;
     }
-    let added_blocks: Vec<Block> = reorg_chain.iter().cloned().collect();
+    let added_blocks = reorg_chain.iter().cloned().collect::<Vec<_>>();
     let fork_height = reorg_chain
         .front()
         .expect("The new orphan block should be in the queue")
@@ -1634,7 +1630,7 @@ fn handle_reorg<T: BlockchainBackend>(
 
 // Reorganize the main chain with the provided fork chain, starting at the specified height.
 fn reorganize_chain<T: BlockchainBackend>(
-    db: &mut RwLockWriteGuard<T>,
+    db: &mut T,
     block_validator: &Validator<Block, T>,
     height: u64,
     chain: VecDeque<Block>,
@@ -1643,76 +1639,87 @@ fn reorganize_chain<T: BlockchainBackend>(
     let removed_blocks = rewind_to_height(db, height)?;
     debug!(
         target: LOG_TARGET,
-        "Validate and add {} chain blocks from height {}.",
+        "Validate and add {} chain block(s) from height {}. Rewound blocks: [{}]",
         chain.len(),
-        height
+        height,
+        removed_blocks
+            .iter()
+            .map(|b| b.header.height.to_string())
+            .collect::<Vec<_>>()
+            .join(", ")
     );
-    let mut validation_result: Result<(), ValidationError> = Ok(());
-    let mut orphan_hashes = Vec::<BlockHash>::with_capacity(chain.len());
+
     for block in chain {
+        let mut txn = DbTransaction::new();
         let block_hash = block.hash();
-        orphan_hashes.push(block_hash.clone());
-        validation_result = block_validator.validate(&block, db);
-        if validation_result.is_err() {
+        let block_hash_hex = block_hash.to_hex();
+        txn.delete(DbKey::OrphanBlock(block_hash));
+        if let Err(e) = block_validator.validate(&block, db) {
             warn!(
                 target: LOG_TARGET,
-                "Orphan block {} ({}) failed validation during chain reorg.",
-                block.header.height,
-                block_hash.to_hex(),
+                "Orphan block {} ({}) failed validation during chain reorg: {}", block.header.height, block_hash_hex, e
             );
             remove_orphan(db, block.hash())?;
-            break;
+
+            info!(target: LOG_TARGET, "Restoring previous chain after failed reorg.");
+            restore_reorged_chain(db, height, removed_blocks)?;
+            return Err(e.into());
         }
-        store_new_block(db, block)?;
+
+        store_new_block(&mut txn, block);
+        // Failed to store the block - this should typically never happen unless there is a bug in the validator
+        // (e.g. does not catch a double spend). In any case, we still need to restore the chain to a
+        // good state before returning.
+        if let Err(e) = commit(db, txn) {
+            warn!(
+                target: LOG_TARGET,
+                "Failed to commit reorg chain: {}. Restoring last chain.", e
+            );
+
+            restore_reorged_chain(db, height, removed_blocks)?;
+            return Err(e.into());
+        }
     }
 
-    match validation_result {
-        Ok(_) => {
-            debug!(target: LOG_TARGET, "Removing orphan blocks used for reorg.",);
-            if !orphan_hashes.is_empty() {
-                let mut txn = DbTransaction::new();
-                for orphan_hash in orphan_hashes {
-                    txn.delete(DbKey::OrphanBlock(orphan_hash));
-                }
-                commit(db, txn)?;
-            }
-            Ok(removed_blocks)
-        },
-        Err(e) => {
-            info!(target: LOG_TARGET, "Restoring previous chain after failed reorg.",);
-            let invalid_chain = rewind_to_height(db, height)?;
-            debug!(
-                target: LOG_TARGET,
-                "Removed incomplete chain of blocks during chain restore: {:?}.",
-                invalid_chain
-                    .iter()
-                    .map(|block| block.hash().to_hex())
-                    .collect::<Vec<_>>(),
-            );
-            let mut txn = DbTransaction::new();
-            for block in removed_blocks {
-                txn.delete(DbKey::OrphanBlock(block.hash()));
-                store_new_block(db, block)?;
-            }
-            commit(db, txn)?;
-            Err(e.into())
-        },
+    Ok(removed_blocks)
+}
+
+fn restore_reorged_chain<T: BlockchainBackend>(
+    db: &mut T,
+    height: u64,
+    previous_chain: Vec<Block>,
+) -> Result<(), ChainStorageError>
+{
+    let invalid_chain = rewind_to_height(db, height)?;
+    debug!(
+        target: LOG_TARGET,
+        "Removed {} blocks during chain restore: {:?}.",
+        invalid_chain.len(),
+        invalid_chain
+            .iter()
+            .map(|block| block.hash().to_hex())
+            .collect::<Vec<_>>(),
+    );
+    let mut txn = DbTransaction::new();
+    // Add removed blocks in the reverse order that they were removed
+    // See: https://github.com/tari-project/tari/issues/2182
+    for block in previous_chain.into_iter().rev() {
+        txn.delete(DbKey::OrphanBlock(block.hash()));
+        store_new_block(&mut txn, block);
     }
+    commit(db, txn)?;
+    Ok(())
 }
 
 // Insert the provided block into the orphan pool.
-fn insert_orphan<T: BlockchainBackend>(db: &mut RwLockWriteGuard<T>, block: Block) -> Result<(), ChainStorageError> {
+fn insert_orphan<T: BlockchainBackend>(db: &mut T, block: Block) -> Result<(), ChainStorageError> {
     let mut txn = DbTransaction::new();
     txn.insert_orphan(block);
     commit(db, txn)
 }
 
 // Discard the the orphan block from the orphan pool that corresponds to the provided block hash.
-fn remove_orphan<T: BlockchainBackend>(
-    db: &mut RwLockWriteGuard<T>,
-    hash: HashOutput,
-) -> Result<(), ChainStorageError>
-{
+fn remove_orphan<T: BlockchainBackend>(db: &mut T, hash: HashOutput) -> Result<(), ChainStorageError> {
     let mut txn = DbTransaction::new();
     txn.delete(DbKey::OrphanBlock(hash));
     commit(db, txn)
@@ -1723,7 +1730,7 @@ fn remove_orphan<T: BlockchainBackend>(
 /// Each successful link is pushed to the front of the queue. An empty queue is returned if the fork chain did not
 /// link to the main chain.
 fn try_construct_fork<T: BlockchainBackend>(
-    db: &mut RwLockWriteGuard<T>,
+    db: &mut T,
     new_block: Block,
 ) -> Result<VecDeque<Block>, ChainStorageError>
 {
@@ -1746,7 +1753,7 @@ fn try_construct_fork<T: BlockchainBackend>(
             fork_start_header.height,
             fork_start_header.hash().to_hex(),
         );
-        if let Ok(header) = fetch_header_by_block_hash(&**db, fork_start_header.prev_hash) {
+        if let Ok(header) = fetch_header_by_block_hash(db, fork_start_header.prev_hash) {
             if header.height + 1 == fork_start_header.height {
                 debug!(
                     target: LOG_TARGET,
@@ -1764,7 +1771,7 @@ fn try_construct_fork<T: BlockchainBackend>(
             target: LOG_TARGET,
             "Not connected, checking if fork chain can be extended.",
         );
-        match fetch_orphan(&**db, hash.clone()) {
+        match fetch_orphan(db, hash.clone()) {
             Ok(prev_block) => {
                 debug!(
                     target: LOG_TARGET,
@@ -1861,11 +1868,7 @@ fn find_strongest_orphan_tip<T: BlockchainBackend>(
 // Perform a comprehensive search to remove all the minimum height orphans to maintain the configured orphan pool
 // storage limit. If the node is configured to run in pruned mode then orphan blocks with heights lower than the horizon
 // block height will also be discarded.
-fn cleanup_orphans<T: BlockchainBackend>(
-    db: &mut RwLockWriteGuard<T>,
-    orphan_storage_capacity: usize,
-) -> Result<(), ChainStorageError>
-{
+fn cleanup_orphans<T: BlockchainBackend>(db: &mut T, orphan_storage_capacity: usize) -> Result<(), ChainStorageError> {
     let orphan_count = db.get_orphan_count()?;
     let num_over_limit = orphan_count.saturating_sub(orphan_storage_capacity);
     if num_over_limit > 0 {
@@ -1903,7 +1906,7 @@ fn cleanup_orphans<T: BlockchainBackend>(
 }
 
 fn prune_database<T: BlockchainBackend>(
-    db: &mut RwLockWriteGuard<T>,
+    db: &mut T,
     pruning_height_interval: u64,
     pruning_horizon: u64,
     height: u64,

--- a/base_layer/core/src/chain_storage/db_transaction.rs
+++ b/base_layer/core/src/chain_storage/db_transaction.rs
@@ -187,19 +187,40 @@ impl DbTransaction {
     }
 }
 
-#[derive(Debug, Display)]
+#[derive(Debug)]
 pub enum WriteOperation {
     Insert(DbKeyValuePair),
     Delete(DbKey),
     Spend(DbKey),
     UnSpend(DbKey),
     CreateMmrCheckpoint(MmrTree),
+    /// Rewind the given MMR tree. The first tuple element is the MmrTree to rewind, the second is the number of steps
+    /// to go back.
     RewindMmr(MmrTree, usize),
+    /// Merge the checkpoints for a given MMR tree. The first tuple element is the `MmrTree` to merge, the second is
+    /// the number of checkpoints that should remain after the merge.
     MergeMmrCheckpoints(MmrTree, usize),
 }
 
+impl fmt::Display for WriteOperation {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        use WriteOperation::*;
+        match self {
+            Insert(pair) => write!(f, "Insert({})", pair),
+            Delete(key) => write!(f, "Delete({})", key),
+            Spend(key) => write!(f, "Spend({})", key),
+            UnSpend(key) => write!(f, "Unspend({})", key),
+            CreateMmrCheckpoint(tree) => write!(f, "CreateMmrCheckpoint({})", tree),
+            RewindMmr(tree, steps_back) => write!(f, "RewindMmr({}, steps_back = {})", tree, steps_back),
+            MergeMmrCheckpoints(tree, max_cp_count) => {
+                write!(f, "MergeMmrCheckpoints({}, max_cp_count = {})", tree, max_cp_count)
+            },
+        }
+    }
+}
+
 /// A list of key-value pairs that are required for each insert operation
-#[derive(Debug)]
+#[derive(Debug, Display)]
 pub enum DbKeyValuePair {
     Metadata(MetadataKey, MetadataValue),
     BlockHeader(u64, Box<BlockHeader>),

--- a/base_layer/core/src/chain_storage/lmdb_db/lmdb_db.rs
+++ b/base_layer/core/src/chain_storage/lmdb_db/lmdb_db.rs
@@ -40,7 +40,17 @@ use crate::{
         },
         error::ChainStorageError,
         lmdb_db::{
-            lmdb::{lmdb_delete, lmdb_exists, lmdb_for_each, lmdb_get, lmdb_insert, lmdb_len, lmdb_replace},
+            lmdb::{
+                lmdb_delete,
+                lmdb_exists,
+                lmdb_exists_txn,
+                lmdb_for_each,
+                lmdb_get,
+                lmdb_get_txn,
+                lmdb_insert,
+                lmdb_len,
+                lmdb_replace,
+            },
             LMDBVec,
             LMDB_DB_BLOCK_HASHES,
             LMDB_DB_HEADERS,
@@ -67,7 +77,7 @@ use croaring::Bitmap;
 use digest::Digest;
 use lmdb_zero::{Database, Environment, WriteTransaction};
 use log::*;
-use std::{collections::VecDeque, path::Path, sync::Arc};
+use std::{collections::VecDeque, path::Path, sync::Arc, time::Instant};
 use tari_crypto::tari_utilities::{epoch_time::EpochTime, hash::Hashable, hex::Hex};
 use tari_mmr::{
     functions::{calculate_pruned_mmr_root, prune_mutable_mmr, PrunedMutableMmr},
@@ -156,6 +166,34 @@ where D: Digest + Send + Sync
             env,
             is_mem_metadata_dirty: false,
         })
+    }
+
+    // Perform all the storage txns and all MMR transactions excluding CreateMmrCheckpoint and RewindMmr on the
+    // header_mmr, utxo_mmr, range_proof_mmr and kernel_mmr. Only when all the txns can successfully be applied is the
+    // changes committed to the backend databases. CreateMmrCheckpoint and RewindMmr txns will be performed after these
+    // txns have been successfully applied.
+    fn apply_db_transaction(&mut self, txn: &DbTransaction) -> Result<(), ChainStorageError> {
+        let write_txn =
+            WriteTransaction::new(self.env.clone()).map_err(|e| ChainStorageError::AccessError(e.to_string()))?;
+        for op in txn.operations.iter() {
+            trace!(target: LOG_TARGET, "[apply_db_transaction] WriteOperation: {}", op);
+            match op {
+                WriteOperation::Insert(insert) => self.op_insert(&write_txn, insert)?,
+                WriteOperation::Delete(delete) => self.op_delete(&write_txn, delete)?,
+                WriteOperation::Spend(key) => self.op_spend(&write_txn, key)?,
+                WriteOperation::UnSpend(key) => self.op_unspend(&write_txn, key)?,
+                _ => {},
+            }
+        }
+        write_txn
+            .commit()
+            .map_err(|e| ChainStorageError::AccessError(e.to_string()))?;
+
+        if self.is_mem_metadata_dirty {
+            self.mem_metadata = fetch_metadata(&self.env, &self.metadata_db)?;
+            self.is_mem_metadata_dirty = false;
+        }
+        Ok(())
     }
 
     // Perform the RewindMmr and CreateMmrCheckpoint operations after MMR txns and storage txns have been applied.
@@ -263,35 +301,10 @@ where D: Digest + Send + Sync
 
     // Reset any mmr txns that have been applied.
     fn reset_mmrs(&mut self) -> Result<(), ChainStorageError> {
-        trace!(target: LOG_TARGET, "Reset mmrs called");
+        trace!(target: LOG_TARGET, "Resetting MMRs");
         self.kernel_mmr.reset()?;
         self.utxo_mmr.reset()?;
         self.range_proof_mmr.reset()?;
-        Ok(())
-    }
-
-    // Perform all the storage txns and all MMR transactions excluding CreateMmrCheckpoint and RewindMmr on the
-    // header_mmr, utxo_mmr, range_proof_mmr and kernel_mmr. Only when all the txns can successfully be applied is the
-    // changes committed to the backend databases. CreateMmrCheckpoint and RewindMmr txns will be performed after these
-    // txns have been successfully applied.
-    fn apply_mmr_and_storage_txs(&mut self, tx: &DbTransaction) -> Result<(), ChainStorageError> {
-        let txn = WriteTransaction::new(self.env.clone()).map_err(|e| ChainStorageError::AccessError(e.to_string()))?;
-        for op in tx.operations.iter() {
-            match op {
-                WriteOperation::Insert(insert) => self.op_insert(&txn, insert)?,
-                WriteOperation::Delete(delete) => self.op_delete(&txn, delete)?,
-                WriteOperation::Spend(key) => self.op_spend(&txn, key)?,
-                WriteOperation::UnSpend(key) => self.op_unspend(&txn, key)?,
-                _ => {},
-            }
-        }
-        txn.commit()
-            .map_err(|e| ChainStorageError::AccessError(e.to_string()))?;
-
-        if self.is_mem_metadata_dirty {
-            self.mem_metadata = fetch_metadata(&self.env, &self.metadata_db)?;
-            self.is_mem_metadata_dirty = false;
-        }
         Ok(())
     }
 
@@ -302,7 +315,7 @@ where D: Digest + Send + Sync
                 self.is_mem_metadata_dirty = true;
             },
             DbKeyValuePair::BlockHeader(k, v) => {
-                if lmdb_exists(&self.env, &self.headers_db, &k)? {
+                if lmdb_exists_txn(txn, &self.headers_db, &k)? {
                     return Err(ChainStorageError::InvalidOperation(format!(
                         "Duplicate `BlockHeader` key `{}`",
                         k
@@ -313,7 +326,7 @@ where D: Digest + Send + Sync
                 lmdb_insert(&txn, &self.headers_db, &k, &v)?;
             },
             DbKeyValuePair::UnspentOutput(k, v) => {
-                if lmdb_exists(&self.env, &self.utxos_db, &k)? {
+                if lmdb_exists_txn(txn, &self.utxos_db, &k)? {
                     return Err(ChainStorageError::InvalidOperation(format!(
                         "Duplicate `UnspentOutput` key `{}`",
                         k.to_hex()
@@ -327,7 +340,7 @@ where D: Digest + Send + Sync
                 lmdb_insert(&txn, &self.txos_hash_to_index_db, &k, &index)?;
             },
             DbKeyValuePair::TransactionKernel(k, v) => {
-                if lmdb_exists(&self.env, &self.kernels_db, &k)? {
+                if lmdb_exists_txn(txn, &self.kernels_db, &k)? {
                     return Err(ChainStorageError::InvalidOperation(format!(
                         "Duplicate `TransactionKernel` key `{}`",
                         k.to_hex()
@@ -354,7 +367,7 @@ where D: Digest + Send + Sync
                 }
             },
             DbKey::BlockHeader(k) => {
-                let val: Option<BlockHeader> = lmdb_get(&self.env, &self.headers_db, &k)?;
+                let val: Option<BlockHeader> = lmdb_get_txn(txn, &self.headers_db, &k)?;
                 if let Some(v) = val {
                     let hash = v.hash();
                     lmdb_delete(&txn, &self.block_hashes_db, &hash)?;
@@ -362,7 +375,7 @@ where D: Digest + Send + Sync
                 }
             },
             DbKey::BlockHash(hash) => {
-                let result: Option<u64> = lmdb_get(&self.env, &self.block_hashes_db, &hash)?;
+                let result: Option<u64> = lmdb_get_txn(txn, &self.block_hashes_db, &hash)?;
                 if let Some(k) = result {
                     lmdb_delete(&txn, &self.block_hashes_db, &hash)?;
                     lmdb_delete(&txn, &self.headers_db, &k)?;
@@ -390,16 +403,16 @@ where D: Digest + Send + Sync
     fn op_spend(&mut self, txn: &WriteTransaction<'_>, key: &DbKey) -> Result<(), ChainStorageError> {
         match key {
             DbKey::UnspentOutput(hash) => {
-                let utxo: TransactionOutput = lmdb_get(&self.env, &self.utxos_db, &hash)?.ok_or_else(|| {
+                let utxo: TransactionOutput = lmdb_get_txn(txn, &self.utxos_db, &hash)?.ok_or_else(|| {
                     error!(
                         target: LOG_TARGET,
-                        "Could spend UTXO: hash `{}` not found in UTXO db",
+                        "Could not spend UTXO: hash `{}` not found in UTXO db",
                         hash.to_hex()
                     );
                     ChainStorageError::UnspendableInput
                 })?;
 
-                let index = lmdb_get(&self.env, &self.txos_hash_to_index_db, &hash)?.ok_or_else(|| {
+                let index = lmdb_get_txn(txn, &self.txos_hash_to_index_db, &hash)?.ok_or_else(|| {
                     error!(
                         target: LOG_TARGET,
                         "** Blockchain DB out of sync! ** Hash `{}` was found in utxo_db but could not be found in \
@@ -413,7 +426,12 @@ where D: Digest + Send + Sync
                 lmdb_delete(&txn, &self.utxos_db, &hash)?;
                 lmdb_insert(&txn, &self.stxos_db, &hash, &utxo)?;
             },
-            _ => return Err(ChainStorageError::InvalidOperation("Only UTXOs can be spent".into())),
+            op => {
+                return Err(ChainStorageError::InvalidOperation(format!(
+                    "Spend operation expected a UTXO but got {}",
+                    op
+                )))
+            },
         }
         Ok(())
     }
@@ -421,7 +439,7 @@ where D: Digest + Send + Sync
     fn op_unspend(&mut self, txn: &WriteTransaction<'_>, key: &DbKey) -> Result<(), ChainStorageError> {
         match key {
             DbKey::SpentOutput(hash) => {
-                let stxo: TransactionOutput = lmdb_get(&self.env, &self.stxos_db, &hash)?.ok_or_else(|| {
+                let stxo: TransactionOutput = lmdb_get_txn(txn, &self.stxos_db, &hash)?.ok_or_else(|| {
                     error!(
                         target: LOG_TARGET,
                         "STXO could not be unspent: Hash `{}` not found in the STXO db",
@@ -519,13 +537,26 @@ pub fn create_lmdb_database<P: AsRef<Path>>(
 impl<D> BlockchainBackend for LMDBDatabase<D>
 where D: Digest + Send + Sync
 {
-    fn write(&mut self, tx: DbTransaction) -> Result<(), ChainStorageError> {
-        if tx.operations.is_empty() {
+    fn write(&mut self, txn: DbTransaction) -> Result<(), ChainStorageError> {
+        if txn.operations.is_empty() {
             return Ok(());
         }
-        match self.apply_mmr_and_storage_txs(&tx) {
-            Ok(_) => self.commit_mmrs(tx),
+
+        let mark = Instant::now();
+        let num_operations = txn.operations.len();
+        match self.apply_db_transaction(&txn) {
+            Ok(_) => {
+                self.commit_mmrs(txn)?;
+                debug!(
+                    target: LOG_TARGET,
+                    "Database completed {} operation(s) in {:.0?}",
+                    num_operations,
+                    mark.elapsed()
+                );
+                Ok(())
+            },
             Err(e) => {
+                debug!(target: LOG_TARGET, "Failed to apply DB transaction: {}", e);
                 self.reset_mmrs()?;
                 Err(e)
             },
@@ -959,4 +990,53 @@ fn get_database(store: &LMDBStore, name: &str) -> Result<DatabaseRef, ChainStora
         .get_handle(name)
         .ok_or_else(|| ChainStorageError::CriticalError(format!("Could not get `{}` database", name)))?;
     Ok(handle.db())
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    // Keeping this here in case we want to test any assumptions we have about how LMDB works
+    #[ignore]
+    #[test]
+    fn write_txn() {
+        let path = "/tmp/tmptmp";
+        let flags = db::CREATE;
+        let _ = std::fs::remove_dir_all(&path);
+        std::fs::create_dir_all(&path).unwrap();
+        let lmdb_store = LMDBBuilder::new()
+            .set_path(path)
+            .set_environment_size(1_000)
+            .set_max_number_of_databases(15)
+            .add_database("1", flags)
+            .add_database("2", flags)
+            .build()
+            .unwrap();
+
+        let env = lmdb_store.env();
+        let db1 = lmdb_store.get_handle("1").unwrap().db();
+        let db2 = lmdb_store.get_handle("2").unwrap().db();
+
+        let txn2 = WriteTransaction::new(env.clone()).unwrap();
+        {
+            let txn = WriteTransaction::new(env.clone()).unwrap();
+            lmdb_insert(&txn, &db1, &123, &"here").unwrap();
+            lmdb_insert(&txn, &db2, &1, &"also here").unwrap();
+            txn.commit().unwrap();
+        }
+
+        let a = lmdb_get::<_, String>(&env, &db2, &1).unwrap();
+        assert_eq!(a.unwrap(), "also here");
+
+        {
+            let txn = WriteTransaction::new(env.clone()).unwrap();
+            lmdb_insert(&txn, &db1, &1, &"here").unwrap();
+            lmdb_insert(&txn, &db2, &2, &"also here").unwrap();
+        }
+
+        let a = lmdb_get::<_, String>(&env, &db1, &1).unwrap();
+        assert!(a.is_none());
+        let a = lmdb_get::<_, String>(&env, &db2, &2).unwrap();
+        assert!(a.is_none());
+    }
 }

--- a/base_layer/core/src/transactions/aggregated_body.rs
+++ b/base_layer/core/src/transactions/aggregated_body.rs
@@ -144,7 +144,7 @@ impl AggregateBody {
         for input in double_inputs {
             trace!(
                 target: LOG_TARGET,
-                "removing following utxo for cut-through: {:?}",
+                "removing the following utxo for cut-through: {}",
                 input
             );
             self.outputs.retain(|x| !input.is_equal_to(x));

--- a/base_layer/core/tests/helpers/block_builders.rs
+++ b/base_layer/core/tests/helpers/block_builders.rs
@@ -292,12 +292,10 @@ pub fn generate_new_block_with_achieved_difficulty<B: BlockchainBackend>(
 {
     let mut txns = Vec::new();
     let mut block_utxos = Vec::new();
-    let mut keys = Vec::new();
     for schema in schemas {
-        let (tx, mut utxos, param) = spend_utxos(schema);
+        let (tx, mut utxos, _) = spend_utxos(schema);
         txns.push(tx);
         block_utxos.append(&mut utxos);
-        keys.push(param);
     }
     outputs.push(block_utxos);
     generate_block_with_achieved_difficulty(db, blocks, txns, achieved_difficulty, consensus_constants)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR reverses the order in which blocks that were reorged out are put
back after a failed reorg. During a reorg, the main chain is rewound to
a height where the reorged blocks link to the main chain. These rewound
blocks are kept in an in-memory buffer and are ordered in height
_decending_ order. In the event of a failed reorg, the rewound blocks
should be readded to the main chain from the current mainchain tip
upwards. This PR reverses the order that the in-memory blocks are added
to the main chain.

- Added `restore_reorged_chain` function, called in the event of a
  failure (validation, failure to commit) when reorging. [link](https://github.com/tari-project/tari/pull/2183/files#diff-e3daff4e22512430954760b7e8d4b6c6R1672)
-  `store_new_block` now adds the required operations to a mutable `DbTransaction`.
  This allows other operations to be performed atomically when storing a
  block.
- [bugfix] Restore chain on failed database commit and simplified `reorganize_chain` a bit 
  (previously it was assumed that the commit cannot fail because the
  validators had already checked the block) [link](https://github.com/tari-project/tari/pull/2183/files#diff-e3daff4e22512430954760b7e8d4b6c6R1658)
- [possible bugfix] Added `lmdb_txn_get` and `lmdb_txn_exists` functions. While a write
  transcation is in progress, any read operations should be using that
  transaction to obtain the most current state. As a contrived example:
  UTXO A exists. The db transaction `Txn[Spend(UTXO(A)), Unspend(UTXO(A))]` is performed.
  An `UnspendError` would result because the `lmdb_get` on the
  `stxos_db` would not know about the previous uncommitted spend
  operation. This is no longer the case as read operations are aware of the transaction.
- Removed all occurrences where references to `RwLock(Read|Write)Guard`s are passed around.
  This is bad form (basically it's bad because it's verbose and makes the function needlessly less flexible, 
   testing the function a little harder) and does not change anything functionally - 
   references and mutable references are now passed around where applicable.   
- [bugfix] Fixed incorrect order of operations for UTXO state rewinding (cf: [blockchain_database.rs lines: 1385-1404](https://github.com/tari-project/tari/pull/2183/files#diff-e3daff4e22512430954760b7e8d4b6c6R1378)). 
  When rewinding the UTXO checkpoints, the TXOs corresponding to nodes_added would be deleted _and then_ the STXOs 
   would be unspent. This means that if a UTXO was added and spent within the same block the rewind would error (ValueNotFound) - the rewind (therefore reorg) would rollback and fail. This changes the order to first unspend the STXO (moving it into the `utxo_db`) and then delete the added UTXOs. handle_reorg_failure_recovery only passes with this change
- [tests] Added `handle_reorg_failure_recovery` test to check 1) recovery from failure
  to commit reorged blocks, and 2) recovery from failed block validation and 3) That the UTXO rewinding is done correctly.
  This test uses the LMDB backend to increase parity between production
  and automated testing. [link](https://github.com/tari-project/tari/pull/2183/files#diff-0ec739352cf5afda478eca4db8610fc2R917)
- Allow the pass/fail flag to be set in the same test in `MockValidator`
- Various logging improvements

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #2182.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
New LMDB chain storage integration test. Basic checks on my local base nodes (still syncs and adds blocks, tested with full blocks on rincewind).

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [x] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [x] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch.
* [x] I ran `cargo-fmt --all` before pushing.
* [x] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
