### PR TITLE
Added user-configurable timeout for base node queries

### DIFF
--- a/applications/tari_base_node/src/builder.rs
+++ b/applications/tari_base_node/src/builder.rs
@@ -598,6 +598,7 @@ where
         &wallet_conn,
         wallet_subscriptions,
         factories.clone(),
+        config.base_node_query_timeout,
         config.transaction_base_node_monitoring_timeout,
         config.transaction_direct_send_timeout,
         config.transaction_broadcast_send_timeout,
@@ -1214,6 +1215,7 @@ async fn register_wallet_services(
     wallet_db_conn: &WalletDbConnection,
     subscription_factory: Arc<SubscriptionFactory>,
     factories: CryptoFactories,
+    base_node_query_timeout: Duration,
     base_node_monitoring_timeout: Duration,
     direct_send_timeout: Duration,
     broadcast_send_timeout: Duration,
@@ -1235,7 +1237,7 @@ async fn register_wallet_services(
     ))
         // Wallet services
         .add_initializer(OutputManagerServiceInitializer::new(
-            OutputManagerServiceConfig{ base_node_query_timeout: Duration::from_secs(120), ..Default::default() },
+            OutputManagerServiceConfig::new(base_node_query_timeout),
             subscription_factory.clone(),
             OutputManagerSqliteDatabase::new(wallet_db_conn.clone(),None),
             factories.clone(),

--- a/base_layer/core/src/proto/generated/tari.base_node.rs
+++ b/base_layer/core/src/proto/generated/tari.base_node.rs
@@ -20,82 +20,6 @@ pub struct ChainMetadata {
     #[prost(uint64, tag = "6")]
     pub effective_pruned_height: u64,
 }
-/// Response type for a received BaseNodeService requests
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct BaseNodeServiceResponse {
-    #[prost(uint64, tag = "1")]
-    pub request_key: u64,
-    #[prost(
-        oneof = "base_node_service_response::Response",
-        tags = "2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12"
-    )]
-    pub response: ::std::option::Option<base_node_service_response::Response>,
-}
-pub mod base_node_service_response {
-    #[derive(Clone, PartialEq, ::prost::Oneof)]
-    pub enum Response {
-        /// Indicates a ChainMetadata response.
-        #[prost(message, tag = "2")]
-        ChainMetadata(super::ChainMetadata),
-        /// Indicates a TransactionKernels response.
-        #[prost(message, tag = "3")]
-        TransactionKernels(super::TransactionKernels),
-        /// Indicates a BlockHeaders response.
-        #[prost(message, tag = "4")]
-        BlockHeaders(super::BlockHeaders),
-        /// Indicates a TransactionOutputs response.
-        #[prost(message, tag = "5")]
-        TransactionOutputs(super::TransactionOutputs),
-        /// Indicates a HistoricalBlocks response.
-        #[prost(message, tag = "6")]
-        HistoricalBlocks(super::HistoricalBlocks),
-        /// Indicates a NewBlockTemplate response.
-        #[prost(message, tag = "7")]
-        NewBlockTemplate(super::super::core::NewBlockTemplate),
-        /// Indicates a NewBlock response.
-        #[prost(message, tag = "8")]
-        NewBlock(super::super::core::Block),
-        /// Indicates a TargetDifficulty response.
-        #[prost(uint64, tag = "9")]
-        TargetDifficulty(u64),
-        /// Block headers in range response
-        #[prost(message, tag = "10")]
-        FetchHeadersAfterResponse(super::BlockHeaders),
-        /// Indicates a MmrNodeCount response
-        #[prost(uint32, tag = "11")]
-        MmrNodeCount(u32),
-        /// Indicates a MmrNodes response
-        #[prost(message, tag = "12")]
-        MmrNodes(super::MmrNodes),
-    }
-}
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct BlockHeaders {
-    #[prost(message, repeated, tag = "1")]
-    pub headers: ::std::vec::Vec<super::core::BlockHeader>,
-}
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct TransactionKernels {
-    #[prost(message, repeated, tag = "1")]
-    pub kernels: ::std::vec::Vec<super::types::TransactionKernel>,
-}
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct TransactionOutputs {
-    #[prost(message, repeated, tag = "1")]
-    pub outputs: ::std::vec::Vec<super::types::TransactionOutput>,
-}
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct HistoricalBlocks {
-    #[prost(message, repeated, tag = "1")]
-    pub blocks: ::std::vec::Vec<super::core::HistoricalBlock>,
-}
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct MmrNodes {
-    #[prost(bytes, repeated, tag = "1")]
-    pub added: ::std::vec::Vec<std::vec::Vec<u8>>,
-    #[prost(bytes, tag = "2")]
-    pub deleted: std::vec::Vec<u8>,
-}
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
 #[repr(i32)]
 pub enum MmrTree {
@@ -215,4 +139,80 @@ pub struct FetchMmrNodes {
     pub count: u32,
     #[prost(uint64, tag = "4")]
     pub hist_height: u64,
+}
+/// Response type for a received BaseNodeService requests
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct BaseNodeServiceResponse {
+    #[prost(uint64, tag = "1")]
+    pub request_key: u64,
+    #[prost(
+        oneof = "base_node_service_response::Response",
+        tags = "2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12"
+    )]
+    pub response: ::std::option::Option<base_node_service_response::Response>,
+}
+pub mod base_node_service_response {
+    #[derive(Clone, PartialEq, ::prost::Oneof)]
+    pub enum Response {
+        /// Indicates a ChainMetadata response.
+        #[prost(message, tag = "2")]
+        ChainMetadata(super::ChainMetadata),
+        /// Indicates a TransactionKernels response.
+        #[prost(message, tag = "3")]
+        TransactionKernels(super::TransactionKernels),
+        /// Indicates a BlockHeaders response.
+        #[prost(message, tag = "4")]
+        BlockHeaders(super::BlockHeaders),
+        /// Indicates a TransactionOutputs response.
+        #[prost(message, tag = "5")]
+        TransactionOutputs(super::TransactionOutputs),
+        /// Indicates a HistoricalBlocks response.
+        #[prost(message, tag = "6")]
+        HistoricalBlocks(super::HistoricalBlocks),
+        /// Indicates a NewBlockTemplate response.
+        #[prost(message, tag = "7")]
+        NewBlockTemplate(super::super::core::NewBlockTemplate),
+        /// Indicates a NewBlock response.
+        #[prost(message, tag = "8")]
+        NewBlock(super::super::core::Block),
+        /// Indicates a TargetDifficulty response.
+        #[prost(uint64, tag = "9")]
+        TargetDifficulty(u64),
+        /// Block headers in range response
+        #[prost(message, tag = "10")]
+        FetchHeadersAfterResponse(super::BlockHeaders),
+        /// Indicates a MmrNodeCount response
+        #[prost(uint32, tag = "11")]
+        MmrNodeCount(u32),
+        /// Indicates a MmrNodes response
+        #[prost(message, tag = "12")]
+        MmrNodes(super::MmrNodes),
+    }
+}
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct BlockHeaders {
+    #[prost(message, repeated, tag = "1")]
+    pub headers: ::std::vec::Vec<super::core::BlockHeader>,
+}
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct TransactionKernels {
+    #[prost(message, repeated, tag = "1")]
+    pub kernels: ::std::vec::Vec<super::types::TransactionKernel>,
+}
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct TransactionOutputs {
+    #[prost(message, repeated, tag = "1")]
+    pub outputs: ::std::vec::Vec<super::types::TransactionOutput>,
+}
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct HistoricalBlocks {
+    #[prost(message, repeated, tag = "1")]
+    pub blocks: ::std::vec::Vec<super::core::HistoricalBlock>,
+}
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct MmrNodes {
+    #[prost(bytes, repeated, tag = "1")]
+    pub added: ::std::vec::Vec<std::vec::Vec<u8>>,
+    #[prost(bytes, tag = "2")]
+    pub deleted: std::vec::Vec<u8>,
 }

--- a/base_layer/core/src/proto/generated/tari.mempool.rs
+++ b/base_layer/core/src/proto/generated/tari.mempool.rs
@@ -1,3 +1,28 @@
+/// Request type for a received MempoolService request.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct MempoolServiceRequest {
+    #[prost(uint64, tag = "1")]
+    pub request_key: u64,
+    #[prost(oneof = "mempool_service_request::Request", tags = "2, 3, 4, 5")]
+    pub request: ::std::option::Option<mempool_service_request::Request>,
+}
+pub mod mempool_service_request {
+    #[derive(Clone, PartialEq, ::prost::Oneof)]
+    pub enum Request {
+        /// Indicates a GetStats request. The value of the bool should be ignored.
+        #[prost(bool, tag = "2")]
+        GetStats(bool),
+        /// Indicates a GetState request. The value of the bool should be ignored.
+        #[prost(bool, tag = "3")]
+        GetState(bool),
+        /// Indicates a GetTxStateWithExcessSig request.
+        #[prost(message, tag = "4")]
+        GetTxStateWithExcessSig(super::super::types::Signature),
+        /// Indicates a SubmitTransaction request.
+        #[prost(message, tag = "5")]
+        SubmitTransaction(super::super::types::Transaction),
+    }
+}
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct StatsResponse {
     #[prost(uint64, tag = "1")]
@@ -65,31 +90,6 @@ pub mod mempool_service_response {
         State(super::StateResponse),
         #[prost(enumeration = "super::TxStorageResponse", tag = "4")]
         TxStorage(i32),
-    }
-}
-/// Request type for a received MempoolService request.
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct MempoolServiceRequest {
-    #[prost(uint64, tag = "1")]
-    pub request_key: u64,
-    #[prost(oneof = "mempool_service_request::Request", tags = "2, 3, 4, 5")]
-    pub request: ::std::option::Option<mempool_service_request::Request>,
-}
-pub mod mempool_service_request {
-    #[derive(Clone, PartialEq, ::prost::Oneof)]
-    pub enum Request {
-        /// Indicates a GetStats request. The value of the bool should be ignored.
-        #[prost(bool, tag = "2")]
-        GetStats(bool),
-        /// Indicates a GetState request. The value of the bool should be ignored.
-        #[prost(bool, tag = "3")]
-        GetState(bool),
-        /// Indicates a GetTxStateWithExcessSig request.
-        #[prost(message, tag = "4")]
-        GetTxStateWithExcessSig(super::super::types::Signature),
-        /// Indicates a SubmitTransaction request.
-        #[prost(message, tag = "5")]
-        SubmitTransaction(super::super::types::Transaction),
     }
 }
 #[derive(Clone, PartialEq, ::prost::Message)]

--- a/base_layer/core/src/proto/generated/tari.transaction_protocol.rs
+++ b/base_layer/core/src/proto/generated/tari.transaction_protocol.rs
@@ -1,3 +1,15 @@
+/// This is the message containing the public data that the Receiver will send back to the Sender
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct RecipientSignedMessage {
+    #[prost(uint64, tag = "1")]
+    pub tx_id: u64,
+    #[prost(message, optional, tag = "2")]
+    pub output: ::std::option::Option<super::types::TransactionOutput>,
+    #[prost(bytes, tag = "3")]
+    pub public_spend_key: std::vec::Vec<u8>,
+    #[prost(message, optional, tag = "4")]
+    pub partial_signature: ::std::option::Option<super::types::Signature>,
+}
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct TransactionFinalizedMessage {
     /// The transaction id for the recipient
@@ -60,16 +72,4 @@ pub mod transaction_sender_message {
         #[prost(bool, tag = "3")]
         Multiple(bool),
     }
-}
-/// This is the message containing the public data that the Receiver will send back to the Sender
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct RecipientSignedMessage {
-    #[prost(uint64, tag = "1")]
-    pub tx_id: u64,
-    #[prost(message, optional, tag = "2")]
-    pub output: ::std::option::Option<super::types::TransactionOutput>,
-    #[prost(bytes, tag = "3")]
-    pub public_spend_key: std::vec::Vec<u8>,
-    #[prost(message, optional, tag = "4")]
-    pub partial_signature: ::std::option::Option<super::types::Signature>,
 }

--- a/base_layer/wallet/src/output_manager_service/config.rs
+++ b/base_layer/wallet/src/output_manager_service/config.rs
@@ -20,7 +20,10 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+use log::*;
 use std::time::Duration;
+
+const LOG_TARGET: &str = "wallet::output_manager_service::config";
 
 #[derive(Clone)]
 pub struct OutputManagerServiceConfig {
@@ -33,6 +36,19 @@ impl Default for OutputManagerServiceConfig {
         Self {
             base_node_query_timeout: Duration::from_secs(30),
             max_utxo_query_size: 5000,
+        }
+    }
+}
+impl OutputManagerServiceConfig {
+    pub fn new(base_node_query_timeout: Duration) -> Self {
+        trace!(
+            target: LOG_TARGET,
+            "Timeouts - Base node query: {}s",
+            base_node_query_timeout.as_secs()
+        );
+        Self {
+            base_node_query_timeout,
+            ..Default::default()
         }
     }
 }

--- a/common/config/presets/windows.toml
+++ b/common/config/presets/windows.toml
@@ -74,6 +74,9 @@
 #  b) know what you are doing!
 wallet_file = "wallet\\wallet.dat"
 
+# This is the timeout period that will be used to monitor TXO queries to the base node (default = 30). Larger values
+# are needed for wallets with many (>1000) TXOs to be validated.
+base_node_query_timeout = 120
 # This is the timeout period that will be used for base node monitoring tasks (default = 30)
 #transaction_base_node_monitoring_timeout = 30
 # This is the timeout period that will be used for sending transactions directly (default = 20)

--- a/common/config/tari_config_sample.toml
+++ b/common/config/tari_config_sample.toml
@@ -74,6 +74,9 @@
 #  b) know what you are doing!
 #wallet_file = "wallet/wallet.dat" # or "wallet\\wallet.dat"
 
+# This is the timeout period that will be used to monitor TXO queries to the base node (default = 30). Larger values
+# are needed for wallets with many (>1000) TXOs to be validated.
+base_node_query_timeout = 120
 # This is the timeout period that will be used for base node monitoring tasks (default = 30)
 #transaction_base_node_monitoring_timeout = 30
 # This is the timeout period that will be used for sending transactions directly (default = 20)

--- a/common/src/configuration/global.rs
+++ b/common/src/configuration/global.rs
@@ -68,6 +68,7 @@ pub struct GlobalConfig {
     pub buffer_size_base_node_wallet: usize,
     pub buffer_rate_limit_base_node: usize,
     pub buffer_rate_limit_base_node_wallet: usize,
+    pub base_node_query_timeout: Duration,
     pub transaction_base_node_monitoring_timeout: Duration,
     pub transaction_direct_send_timeout: Duration,
     pub transaction_broadcast_send_timeout: Duration,
@@ -232,6 +233,12 @@ fn convert_node_config(network: Network, cfg: Config) -> Result<GlobalConfig, Co
         .map_err(|e| ConfigurationError::new(&key, &e.to_string()))?
         .into();
 
+    let key = "wallet.base_node_query_timeout";
+    let base_node_query_timeout = Duration::from_secs(
+        cfg.get_int(&key)
+            .map_err(|e| ConfigurationError::new(&key, &e.to_string()))? as u64,
+    );
+
     let key = "wallet.transaction_base_node_monitoring_timeout";
     let transaction_base_node_monitoring_timeout = Duration::from_secs(
         cfg.get_int(&key)
@@ -345,6 +352,7 @@ fn convert_node_config(network: Network, cfg: Config) -> Result<GlobalConfig, Co
         buffer_size_base_node_wallet,
         buffer_rate_limit_base_node,
         buffer_rate_limit_base_node_wallet,
+        base_node_query_timeout,
         transaction_base_node_monitoring_timeout,
         transaction_direct_send_timeout,
         transaction_broadcast_send_timeout,

--- a/common/src/configuration/utils.rs
+++ b/common/src/configuration/utils.rs
@@ -72,6 +72,7 @@ pub fn default_config(bootstrap: &ConfigBootstrap) -> Config {
         default_subdir("wallet/wallet.dat", Some(&bootstrap.base_path)),
     )
     .unwrap();
+    cfg.set_default("wallet.base_node_query_timeout", 30).unwrap();
     cfg.set_default("wallet.transaction_base_node_monitoring_timeout", 30)
         .unwrap();
     cfg.set_default("wallet.transaction_direct_send_timeout", 20).unwrap();


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
Added user-configurable timeout for base node queries (`base_node_query_timeout`)

## Motivation and Context
Base node queries for large wallets have difficulty to return in the short default period of time (120s), thus continue to time out. This timeout can now be set uniquely per base node.

## How Has This Been Tested?
In a base node in Widows

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [X] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [X] I'm merging against the `development` branch.
* [X] I ran `cargo-fmt --all` before pushing.
* [X] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
