### PR TITLE
Fix installation and sourcing runtime environment for home folder with spaces on Windows

### DIFF
--- a/applications/tari_base_node/windows/runtime/run_the_base_node.bat
+++ b/applications/tari_base_node/windows/runtime/run_the_base_node.bat
@@ -1,33 +1,32 @@
 @echo off
-
 rem Verify arguments
-if [%config_path%]==[] (
-    echo Problem with "config_path" environment variable: %config_path%
+if ["%config_path%"]==[""] (
+    echo Problem with "config_path" environment variable: '%config_path%'
     pause
     exit /b 10101
 )
 if not exist "%config_path%" (
-    echo Path as per "config_path" environment variable not found: %config_path%
+    echo Path as per "config_path" environment variable not found: '%config_path%'
     pause
     exit /b 10101
 )
-if [%base_path%]==[] (
-    echo Problem with "base_path" environment variable: %base_path%
+if ["%base_path%"]==[""] (
+    echo Problem with "base_path" environment variable: '%base_path%'
     pause
     exit /b 10101
 )
 if not exist "%base_path%" (
-    echo Path as per "base_path" environment variable not found: %base_path%
+    echo Path as per "base_path" environment variable not found: '%base_path%'
     pause
     exit /b 10101
 )
-if [%my_exe%]==[] (
-    echo Problem with "my_exe" environment variable: %my_exe%
+if ["%my_exe%"]==[""] (
+    echo Problem with "my_exe" environment variable: '%my_exe%'
     pause
     exit /b 10101
 )
-if [%sqlite_runtime%]==[] (
-    echo Problem with "sqlite_runtime" environment variable: %sqlite_runtime%
+if ["%sqlite_runtime%"]==[""] (
+    echo Problem with "sqlite_runtime" environment variable: '%sqlite_runtime%'
     pause
     exit /b 10101
 )
@@ -35,6 +34,10 @@ if [%sqlite_runtime%]==[] (
 rem Verify SQLite's location and prepend the default location to the system path if it exist
 if exist "%TARI_SQLITE_DIR%\%sqlite_runtime%" (
     set "path=%TARI_SQLITE_DIR%;%path%"
+    echo.
+    echo Default location of "%sqlite_runtime%" prepended to the system path
+) else if exist "%USERPROFILE%\.sqlite\%sqlite_runtime%" (
+    set "path=%USERPROFILE%\.sqlite;%path%"
     echo.
     echo Default location of "%sqlite_runtime%" prepended to the system path
 ) else (
@@ -47,6 +50,11 @@ if exist "%TARI_SQLITE_DIR%\%sqlite_runtime%" (
     ) else (
         echo.
         echo Note: "%sqlite_runtime%" not found in the default location or in the system path; this may be a problem
+		if ["%TARI_SQLITE_DIR%"]==["%USERPROFILE%\.sqlite"] (
+			echo       {default location: tried "%TARI_SQLITE_DIR%"}
+		) else (
+			echo       {default location: tried "%TARI_SQLITE_DIR%" and "%USERPROFILE%\.sqlite"}
+		)
         echo.
         pause
     )
@@ -84,7 +92,7 @@ if exist "%my_exe_path%\%my_exe%" (
 )
 
 rem First time run
-if not exist %config_path%\node_id.json (
+if not exist "%config_path%\node_id.json" (
     "%base_node%" --create-id --config "%config_path%\windows.toml" --log_config "%config_path%\log4rs.yml" --base-path "%base_path%"
     echo.
     echo.
@@ -93,7 +101,7 @@ if not exist %config_path%\node_id.json (
 ) else (
     echo.
     echo.
-    echo Using existing "%config_path%\node_id.json"
+    echo Using old "%config_path%\node_id.json"
     echo.
 )
 

--- a/applications/tari_base_node/windows/runtime/start_tari_basenode.bat
+++ b/applications/tari_base_node/windows/runtime/start_tari_basenode.bat
@@ -23,7 +23,7 @@ echo base_path   = %base_path%
 echo.
 echo Start Tor Services
 echo ----------------------------
-call %my_exe_path%\start_tor.bat
+call "%my_exe_path%\start_tor.bat"
 if [%errorlevel%]==[10101] (
     echo.
     echo It seems Tor could not be started properly.
@@ -39,7 +39,7 @@ if [%errorlevel%]==[10101] (
 echo.
 echo Run the base node
 echo -----------------
-call %my_exe_path%\run_the_base_node.bat
+call "%my_exe_path%\run_the_base_node.bat"
 
 goto END:
 

--- a/applications/tari_base_node/windows/runtime/start_tor.bat
+++ b/applications/tari_base_node/windows/runtime/start_tor.bat
@@ -1,5 +1,4 @@
 @echo off
-
 set file_1=%TEMP%\tor1.txt
 set file_2=%TEMP%\tor2.txt
 set file_3=%TEMP%\tor3.txt
@@ -9,7 +8,29 @@ call :QUERY_TOR_SERVICE
 if not defined TOR_RUNNING (
     if exist "%TARI_TOR_SERVICES_DIR%\%TOR_EXE_NAME%" (
         set "path=%TARI_TOR_SERVICES_DIR%;%path%"
-    ) 
+		echo Default location of "%TOR_EXE_NAME%" prepended to the system path
+    ) else if exist "%USERPROFILE%\.tor_services\Tor\%TOR_EXE_NAME%" (
+		set "path=%USERPROFILE%\.tor_services\Tor\;%path%"
+		echo Default location of "%TOR_EXE_NAME%" prepended to the system path
+	) else (
+		set FOUND=
+		for %%X in (%TOR_EXE_NAME%) do (set FOUND=%%~$PATH:X)
+		if defined FOUND (
+			echo.
+			echo "%TOR_EXE_NAME%" found in system path:
+			where "%TOR_EXE_NAME%"
+		) else (
+			echo.
+			echo Note: "%TOR_EXE_NAME%" not found in the default location or in the system path; this may be a problem
+			if ["%TARI_TOR_SERVICES_DIR%"]==["%USERPROFILE%\.tor_services\Tor"] (
+				echo       {default location: tried "%TARI_TOR_SERVICES_DIR%"}
+			) else (
+				echo       {default location: tried "%TARI_TOR_SERVICES_DIR%" and "%USERPROFILE%\.tor_services\Tor"}
+			)
+			echo.
+			pause
+		)
+	)
     start tor --allow-missing-torrc --ignore-missing-torrc --clientonly 1 --socksport 9050 --controlport 127.0.0.1:9051 --clientuseipv6 1 --log "notice stdout"
     echo Attempting to start Tor service on ports 9050 and 9051
     ping -n 15 localhost>nul
@@ -28,16 +49,16 @@ if not defined TOR_RUNNING (
 goto :END
 
 :QUERY_TOR_SERVICE
-if exist %file_1% (
-    del %file_1% /f/q
+if exist "%file_1%" (
+    del "%file_1%" /f/q
 )
-if exist %file_2% (
-    del %file_2% /f/q
+if exist "%file_2%" (
+    del "%file_2%" /f/q
 )
-for /f "tokens=1,2,3,4,5*" %%i in ('netstat -aon ^| findstr ":9050" ^| findstr /i listening') do echo %j %l & tasklist | findstr %%m > %file_1%
-for /f "tokens=1,2,3,4,5*" %%i in ('netstat -aon ^| findstr ":9051" ^| findstr /i listening') do echo %j %l & tasklist | findstr %%m > %file_2%
+for /f "tokens=1,2,3,4,5*" %%i in ('netstat -aon ^| findstr ":9050" ^| findstr /i listening') do echo %j %l & tasklist | findstr %%m > "%file_1%"
+for /f "tokens=1,2,3,4,5*" %%i in ('netstat -aon ^| findstr ":9051" ^| findstr /i listening') do echo %j %l & tasklist | findstr %%m > "%file_2%"
 if exist %file_1% (
-    if exist %file_2% (
+    if exist "%file_2%" (
         echo Found tor service listening on ports 9050 and 9051. Good.
         set TOR_RUNNING=1
     ) else (

--- a/buildtools/install_sqlite.bat
+++ b/buildtools/install_sqlite.bat
@@ -17,7 +17,7 @@ goto END:
 rem Download install file
 powershell wget https://www.sqlite.org/2020/%sqlite_zip% -outfile "%TEMP%\%sqlite_zip%"
 rem Install
-powershell expand-archive -Force -LiteralPath "%TEMP%\%sqlite_zip%" -DestinationPath "%sqlite_folder%"
+powershell expand-archive -Force -LiteralPath "%TEMP%\%sqlite_zip%" -DestinationPath '%sqlite_folder%'
 rem Set Tari environment variables
 set TARI_SQLITE_DIR=%sqlite_folder%
 setx TARI_SQLITE_DIR %TARI_SQLITE_DIR%

--- a/buildtools/install_tor_services.bat
+++ b/buildtools/install_tor_services.bat
@@ -21,7 +21,7 @@ goto END:
 rem Download install file
 powershell wget  https://www.torproject.org/dist/torbrowser/%tor_version%/%tor_zip% -outfile "%TEMP%\%tor_zip%"
 rem Install 
-powershell expand-archive -Force -LiteralPath "%TEMP%\%tor_zip%" -DestinationPath "%tor_folder%"
+powershell expand-archive -Force -LiteralPath "%TEMP%\%tor_zip%" -DestinationPath '%tor_folder%'
 rem Set Tari environment variables
 set TARI_TOR_SERVICES_DIR=%tor_folder%\Tor
 setx TARI_TOR_SERVICES_DIR %TARI_TOR_SERVICES_DIR%


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Fixed an issue where sourcing the runtime environment would fail due to spaces in a home folder.

## Motivation and Context
Some users have spaces in the home folder; this needs to be sourced correctly.

## How Has This Been Tested?
Installation tested on Windows in a home folder called `C:\Users\t a r i\`:
```
Downloading and installing SQLite...

SQLite installation found at "C:\Users\t a r i\.sqlite"

Press any key to continue . . .
```
```
Downloading and installing Tor Services...

Tor Services installation found at "C:\Users\t a r i\.tor_services\Tor"

Press any key to continue . . .
```
Runtime tested on Windows in a home folder called `C:\Users\t a r i\`:
```
C:\Users\t a r i\.tari-testnet>start_tari_basenode.lnk

Set up environment variables
----------------------------
config_path = C:\Users\t a r i\.tari-testnet\runtime\..\config
my_exe_path = C:\Users\t a r i\.tari-testnet\runtime
base_path   = C:\Users\t a r i\.tari-testnet\runtime\..

Start Tor Services
----------------------------
Default location of "tor.exe" prepended to the system path
Attempting to start Tor service on ports 9050 and 9051
l
l
Found tor service listening on ports 9050 and 9051. Good.


Run the base node
-----------------

Default location of "sqlite3.dll" prepended to the system path

Using "tari_base_node.exe" found in my_exe_path



Using old "C:\Users\t a r i\.tari-testnet\runtime\..\config\node_id.json"

Initializing logging according to "C:\\Users\\t a r i\\.tari-testnet\\runtime\\..\\config\\log4rs.yml"

┌───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
│                                                                                                                                   │
│                                                           Tari Base Node                                                          │
│                                                           ~~~~~~~~~~~~~~                                                          │
│                                        Copyright 2019-2020. The Tari Development Community                                        │
│                                                   Version 0.5.3-3fc542d-release                                                   │
├───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┤
>> quit
Shutting down...
Goodbye!

Press any key to continue . . .
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [X] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [X] I'm merging against the `development` branch.
* [X] I ran `cargo-fmt --all` before pushing.
* [X] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
