### PR TITLE
Fix hash estimation for block explorer

### DIFF
--- a/applications/tari_base_node/src/grpc/base_node_grpc_server.rs
+++ b/applications/tari_base_node/src/grpc/base_node_grpc_server.rs
@@ -130,7 +130,7 @@ impl tari_rpc::base_node_server::BaseNode for BaseNodeGrpcServer {
                         let mut iter = data.iter().peekable();
                         let mut result = Vec::new();
                         while let Some(next) = iter.next() {
-                            let current_difficulty = next.pow.accumulated_blake_difficulty.as_u64();
+                            let current_difficulty = next.pow.target_difficulty.as_u64();
                             let current_timestamp = next.timestamp.as_u64();
                             let current_height = next.height;
                             let estimated_hash_rate = if let Some(peek) = iter.peek() {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Changed the network hash estimation to use the target difficulty and not the total network accumulated difficulty. 


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Currently the hash estimate of the network hash rate is looking at accumulated difficulty. This means that the calculation of the network hash rate is dependant on how old the chain is, and not the target difficulty that needed to be solved for that specific block. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch.
* [x] I ran `cargo-fmt --all` before pushing.
* [x] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
