### PR TITLE
Added basic RPC interface (get_peers) to DHT

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3744,6 +3744,7 @@ dependencies = [
 name = "tari_comms_dht"
 version = "0.2.5"
 dependencies = [
+ "anyhow",
  "bitflags 1.2.1",
  "bytes 0.4.12",
  "chrono",
@@ -3767,6 +3768,7 @@ dependencies = [
  "serde_repr",
  "tari_common",
  "tari_comms",
+ "tari_comms_rpc_macros",
  "tari_crypto",
  "tari_shutdown",
  "tari_storage",
@@ -3780,6 +3782,21 @@ dependencies = [
  "tower",
  "tower-test",
  "ttl_cache",
+]
+
+[[package]]
+name = "tari_comms_rpc_macros"
+version = "0.1.0"
+dependencies = [
+ "futures 0.3.5",
+ "prost",
+ "quote 1.0.7",
+ "syn 1.0.38",
+ "tari_comms",
+ "tari_test_utils",
+ "tokio",
+ "tokio-macros",
+ "tower-service",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ members = [
     "base_layer/wallet_ffi",
     "comms",
     "comms/dht",
+    "comms/rpc_macros",
     "infrastructure/shutdown",
     "infrastructure/storage",
     "infrastructure/test_utils",

--- a/applications/tari_base_node/Cargo.toml
+++ b/applications/tari_base_node/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2018"
 
 [dependencies]
 tari_common = {  path = "../../common" }
-tari_comms = { path = "../../comms"}
+tari_comms = { path = "../../comms", features = ["rpc"]}
 tari_comms_dht = {  path = "../../comms/dht"}
 tari_core = {  path = "../../base_layer/core", default-features = false, features = ["transactions"]}
 tari_p2p = {  path = "../../base_layer/p2p" }

--- a/base_layer/p2p/src/services/liveness/service.rs
+++ b/base_layer/p2p/src/services/liveness/service.rs
@@ -352,7 +352,6 @@ mod test {
     use futures::{
         channel::{mpsc, oneshot},
         stream,
-        FutureExt,
     };
     use rand::rngs::OsRng;
     use std::time::Duration;
@@ -369,7 +368,7 @@ mod test {
     use tari_crypto::keys::PublicKey;
     use tari_service_framework::reply_channel;
     use tari_shutdown::Shutdown;
-    use tokio::{sync::broadcast, task, time::delay_for};
+    use tokio::{sync::broadcast, task};
 
     #[tokio_macros::test_basic]
     async fn get_ping_pong_count() {
@@ -595,19 +594,8 @@ mod test {
 
         // No further events (malicious_msg was ignored)
         let mut subscriber = publisher.subscribe().fuse();
-
-        let mut delay = delay_for(Duration::from_secs(10)).fuse();
-        let mut count: i32 = 0;
-        loop {
-            futures::select! {
-                _ = subscriber.select_next_some() => {
-                    count+=1;
-                },
-                () = delay => {
-                    break;
-                },
-            }
-        }
-        assert_eq!(count, 0);
+        drop(publisher);
+        let msg = subscriber.next().await;
+        assert_eq!(msg.is_none(), true);
     }
 }

--- a/comms/dht/Cargo.toml
+++ b/comms/dht/Cargo.toml
@@ -10,12 +10,14 @@ license = "BSD-3-Clause"
 edition = "2018"
 
 [dependencies]
-tari_comms  = { version = "^0.2", path = "../"}
+tari_comms  = { version = "^0.2", path = "../", features = ["rpc"]}
+tari_comms_rpc_macros  = { version = "^0.1", path = "../rpc_macros"}
 tari_crypto = { version = "^0.5" }
 tari_utilities  = { version = "^0.2" }
 tari_shutdown = { version = "^0.2", path = "../../infrastructure/shutdown"}
 tari_storage  = { version = "^0.2", path = "../../infrastructure/storage"}
 
+anyhow = "1.0.32"
 bitflags = "1.2.0"
 bytes = "0.4.12"
 chrono = "0.4.9"
@@ -30,13 +32,13 @@ rand = "0.7.2"
 serde = "1.0.90"
 serde_derive = "1.0.90"
 serde_repr = "0.1.5"
+thiserror = "1.0.20"
 tokio = {version="0.2.10", features=["rt-threaded", "blocking"]}
 tower= "0.3.1"
 ttl_cache = "0.5.1"
 
 # tower-filter dependencies
 pin-project = "0.4"
-thiserror = "1.0.20"
 
 [dev-dependencies]
 tari_test_utils = { version = "^0.2", path = "../../infrastructure/test_utils"}

--- a/comms/dht/src/actor.rs
+++ b/comms/dht/src/actor.rs
@@ -636,7 +636,7 @@ mod test {
     use crate::{
         broadcast_strategy::BroadcastClosestRequest,
         envelope::NodeDestination,
-        test_utils::{make_client_identity, make_node_identity, make_peer_manager},
+        test_utils::{build_peer_manager, make_client_identity, make_node_identity},
     };
     use chrono::{DateTime, Utc};
     use tari_comms::test_utils::mocks::{create_connectivity_mock, create_peer_connection_mock_pair};
@@ -652,7 +652,7 @@ mod test {
     #[tokio_macros::test_basic]
     async fn send_join_request() {
         let node_identity = make_node_identity();
-        let peer_manager = make_peer_manager();
+        let peer_manager = build_peer_manager();
         let (out_tx, mut out_rx) = mpsc::channel(1);
         let (connectivity_manager, mock) = create_connectivity_mock();
         mock.spawn();
@@ -681,7 +681,7 @@ mod test {
     #[tokio_macros::test_basic]
     async fn insert_message_signature() {
         let node_identity = make_node_identity();
-        let peer_manager = make_peer_manager();
+        let peer_manager = build_peer_manager();
         let (connectivity_manager, mock) = create_connectivity_mock();
         mock.spawn();
         let (out_tx, _) = mpsc::channel(1);
@@ -714,7 +714,7 @@ mod test {
     #[tokio_macros::test_basic]
     async fn select_peers() {
         let node_identity = make_node_identity();
-        let peer_manager = make_peer_manager();
+        let peer_manager = build_peer_manager();
 
         let client_node_identity = make_client_identity();
         peer_manager.add_peer(client_node_identity.to_peer()).await.unwrap();
@@ -805,7 +805,7 @@ mod test {
     #[tokio_macros::test_basic]
     async fn get_and_set_metadata() {
         let node_identity = make_node_identity();
-        let peer_manager = make_peer_manager();
+        let peer_manager = build_peer_manager();
         let (out_tx, _out_rx) = mpsc::channel(1);
         let (actor_tx, actor_rx) = mpsc::channel(1);
         let (connectivity_manager, mock) = create_connectivity_mock();

--- a/comms/dht/src/connectivity/test.rs
+++ b/comms/dht/src/connectivity/test.rs
@@ -22,7 +22,7 @@
 
 use crate::{
     connectivity::DhtConnectivity,
-    test_utils::{create_dht_actor_mock, make_node_identity, make_peer_manager, DhtMockState},
+    test_utils::{build_peer_manager, create_dht_actor_mock, make_node_identity, DhtMockState},
     DhtConfig,
 };
 use rand::{rngs::OsRng, seq::SliceRandom};
@@ -54,7 +54,7 @@ async fn setup(
     Shutdown,
 )
 {
-    let peer_manager = make_peer_manager();
+    let peer_manager = build_peer_manager();
     for peer in initial_peers {
         peer_manager.add_peer(peer).await.unwrap();
     }

--- a/comms/dht/src/discovery/service.rs
+++ b/comms/dht/src/discovery/service.rs
@@ -392,7 +392,7 @@ mod test {
     use crate::{
         discovery::DhtDiscoveryRequester,
         outbound::mock::create_outbound_service_mock,
-        test_utils::{make_node_identity, make_peer_manager},
+        test_utils::{build_peer_manager, make_node_identity},
     };
     use std::time::Duration;
     use tari_shutdown::Shutdown;
@@ -400,7 +400,7 @@ mod test {
     #[tokio_macros::test_basic]
     async fn send_discovery() {
         let node_identity = make_node_identity();
-        let peer_manager = make_peer_manager();
+        let peer_manager = build_peer_manager();
         let (outbound_requester, outbound_mock) = create_outbound_service_mock(10);
         let oms_mock_state = outbound_mock.get_state();
         task::spawn(outbound_mock.run());

--- a/comms/dht/src/inbound/deserialize.rs
+++ b/comms/dht/src/inbound/deserialize.rs
@@ -137,10 +137,10 @@ mod test {
     use crate::{
         envelope::DhtMessageFlags,
         test_utils::{
+            build_peer_manager,
             make_comms_inbound_message,
             make_dht_envelope,
             make_node_identity,
-            make_peer_manager,
             service_spy,
         },
     };
@@ -149,7 +149,7 @@ mod test {
     #[tokio_macros::test_basic]
     async fn deserialize() {
         let spy = service_spy();
-        let peer_manager = make_peer_manager();
+        let peer_manager = build_peer_manager();
         let node_identity = make_node_identity();
         peer_manager.add_peer(node_identity.to_peer()).await.unwrap();
 

--- a/comms/dht/src/lib.rs
+++ b/comms/dht/src/lib.rs
@@ -147,6 +147,7 @@ pub use dedup::DedupLayer;
 
 mod logging_middleware;
 mod proto;
+mod rpc;
 mod tower_filter;
 mod utils;
 

--- a/comms/dht/src/proto/rpc.proto
+++ b/comms/dht/src/proto/rpc.proto
@@ -1,0 +1,23 @@
+syntax = "proto3";
+
+package tari.dht.rpc;
+
+// GET peers request
+message GetPeersRequest {
+  // The number of peers to return
+  uint32 n = 1;
+}
+
+// GET peers response
+message GetPeersResponse {
+  Peer peer = 1;
+}
+
+// Minimal peer information
+message Peer {
+  bytes public_key = 1;
+  repeated string addresses = 2;
+  uint64 peer_features = 3;
+}
+
+

--- a/comms/dht/src/proto/tari.dht.rpc.rs
+++ b/comms/dht/src/proto/tari.dht.rpc.rs
@@ -1,0 +1,23 @@
+/// GET peers request
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct GetPeersRequest {
+    /// The number of peers to return
+    #[prost(uint32, tag = "1")]
+    pub n: u32,
+}
+/// GET peers response
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct GetPeersResponse {
+    #[prost(message, optional, tag = "1")]
+    pub peer: ::std::option::Option<Peer>,
+}
+/// Minimal peer information
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct Peer {
+    #[prost(bytes, tag = "1")]
+    pub public_key: std::vec::Vec<u8>,
+    #[prost(string, repeated, tag = "2")]
+    pub addresses: ::std::vec::Vec<std::string::String>,
+    #[prost(uint64, tag = "3")]
+    pub peer_features: u64,
+}

--- a/comms/dht/src/rpc/service.rs
+++ b/comms/dht/src/rpc/service.rs
@@ -1,0 +1,111 @@
+//  Copyright 2020, The Tari Project
+//
+//  Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+//  following conditions are met:
+//
+//  1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+//  disclaimer.
+//
+//  2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+//  following disclaimer in the documentation and/or other materials provided with the distribution.
+//
+//  3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+//  products derived from this software without specific prior written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+//  INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+//  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+//  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+//  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+//  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+//  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+use crate::{
+    proto::rpc::{GetPeersRequest, GetPeersResponse},
+    rpc::DhtRpcService,
+};
+use futures::{channel::mpsc, stream, SinkExt};
+use log::*;
+use std::{cmp, sync::Arc};
+use tari_comms::{
+    peer_manager::PeerFeatures,
+    protocol::rpc::{Request, RpcError, RpcStatus, Streaming},
+    NodeIdentity,
+    PeerManager,
+};
+use tokio::task;
+
+const LOG_TARGET: &str = "comms::dht::rpc";
+
+const MAX_NUM_PEERS: usize = 100;
+
+pub struct DhtRpcServiceImpl {
+    node_identity: Arc<NodeIdentity>,
+    peer_manager: Arc<PeerManager>,
+}
+
+impl DhtRpcServiceImpl {
+    pub fn new(node_identity: Arc<NodeIdentity>, peer_manager: Arc<PeerManager>) -> Self {
+        Self {
+            node_identity,
+            peer_manager,
+        }
+    }
+}
+
+#[tari_comms::async_trait]
+impl DhtRpcService for DhtRpcServiceImpl {
+    async fn get_peers(&self, request: Request<GetPeersRequest>) -> Result<Streaming<GetPeersResponse>, RpcStatus> {
+        if !self.node_identity.has_peer_features(PeerFeatures::COMMUNICATION_NODE) {
+            debug!(target: LOG_TARGET, "get_peers request is not valid for client nodes");
+            // TODO: #banheuristic
+            return Err(RpcStatus::unsupported_method("get_peers is not supported"));
+        }
+
+        let message = request.message();
+        let node_id = request.context().peer_node_id();
+        if message.n == 0 {
+            return Err(RpcStatus::bad_request("Requesting zero peers is invalid"));
+        }
+        if message.n as usize > MAX_NUM_PEERS {
+            return Err(RpcStatus::bad_request(format!(
+                "Requested too many peers ({}). Cannot request more than `{}` peers",
+                message.n, MAX_NUM_PEERS
+            )));
+        }
+
+        let peers = self
+            .peer_manager
+            .closest_peers(node_id, message.n as usize, &[], Some(PeerFeatures::COMMUNICATION_NODE))
+            .await
+            .map_err(RpcError::from)?;
+        debug!(
+            target: LOG_TARGET,
+            "[get_peers] Returning {}/{} peer(s) to peer `{}`",
+            peers.len(),
+            message.n,
+            node_id.short_str()
+        );
+
+        if peers.is_empty() {
+            return Ok(Streaming::empty());
+        }
+
+        // A maximum buffer size of 10 is selected arbitrarily and is to allow the producer/consumer some room to
+        // buffer.
+        let (mut tx, rx) = mpsc::channel(cmp::min(10, peers.len() as usize));
+        task::spawn(async move {
+            let iter = peers
+                .into_iter()
+                .map(|peer| GetPeersResponse {
+                    peer: Some(peer.into()),
+                })
+                .map(Ok)
+                .map(Ok);
+            let mut stream = stream::iter(iter);
+            let _ = tx.send_all(&mut stream).await;
+        });
+
+        Ok(Streaming::new(rx))
+    }
+}

--- a/comms/dht/src/rpc/test.rs
+++ b/comms/dht/src/rpc/test.rs
@@ -1,0 +1,147 @@
+//  Copyright 2020, The Tari Project
+//
+//  Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+//  following conditions are met:
+//
+//  1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+//  disclaimer.
+//
+//  2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+//  following disclaimer in the documentation and/or other materials provided with the distribution.
+//
+//  3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+//  products derived from this software without specific prior written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+//  INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+//  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+//  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+//  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+//  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+//  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+use crate::{
+    proto::rpc::GetPeersRequest,
+    rpc::{DhtRpcService, DhtRpcServiceImpl},
+    test_utils::build_peer_manager,
+};
+use futures::StreamExt;
+use std::{convert::TryInto, sync::Arc};
+use tari_comms::{
+    peer_manager::{node_id::NodeDistance, PeerFeatures},
+    protocol::rpc::{test_utils::RpcRequestMock, RpcStatusCode},
+    test_utils::node_identity::{build_node_identity, ordered_node_identities_by_distance},
+    NodeIdentity,
+    PeerManager,
+};
+
+fn setup(node_identity: Arc<NodeIdentity>) -> (DhtRpcServiceImpl, RpcRequestMock, Arc<PeerManager>) {
+    let peer_manager = build_peer_manager();
+    let mock = RpcRequestMock::new(peer_manager.clone());
+    let service = DhtRpcServiceImpl::new(node_identity, peer_manager.clone());
+
+    (service, mock, peer_manager)
+}
+
+// Unit tests for get_peers request
+mod get_peers {
+    use super::*;
+    use tari_comms::peer_manager::Peer;
+
+    #[tokio_macros::test_basic]
+    async fn it_returns_empty_peer_stream() {
+        let node_identity = build_node_identity(PeerFeatures::COMMUNICATION_NODE);
+        let (service, mock, _) = setup(node_identity.clone());
+        let req = GetPeersRequest {
+            n: 10,
+            ..Default::default()
+        };
+
+        let req = mock.request_with_context(node_identity.node_id().clone(), req);
+        let mut peers_stream = service.get_peers(req).await.unwrap();
+        let next = peers_stream.next().await;
+        // Empty stream
+        assert_eq!(next.is_none(), true);
+    }
+
+    #[tokio_macros::test_basic]
+    async fn it_returns_closest_peers() {
+        let node_identity = build_node_identity(PeerFeatures::COMMUNICATION_NODE);
+        let (service, mock, peer_manager) = setup(node_identity.clone());
+        let peers = ordered_node_identities_by_distance(node_identity.node_id(), 10, PeerFeatures::COMMUNICATION_NODE);
+        for peer in &peers {
+            peer_manager.add_peer(peer.to_peer()).await.unwrap();
+        }
+        let req = GetPeersRequest {
+            n: 15,
+            ..Default::default()
+        };
+
+        let req = mock.request_with_context(node_identity.node_id().clone(), req);
+        let peers_stream = service.get_peers(req).await.unwrap();
+        let results = peers_stream.into_inner().collect::<Vec<_>>().await;
+        assert_eq!(results.len(), 10);
+
+        let peers = results
+            .into_iter()
+            .map(Result::unwrap)
+            .map(|r| r.peer.unwrap())
+            .map(|p| p.try_into().unwrap())
+            .collect::<Vec<Peer>>();
+
+        let mut dist = NodeDistance::zero();
+        for p in &peers {
+            let current = p.node_id.distance(node_identity.node_id());
+            assert!(dist < current);
+            dist = current;
+        }
+    }
+
+    #[tokio_macros::test_basic]
+    async fn it_returns_n_peers() {
+        let node_identity = build_node_identity(PeerFeatures::COMMUNICATION_NODE);
+        let (service, mock, peer_manager) = setup(node_identity.clone());
+        let peers = ordered_node_identities_by_distance(node_identity.node_id(), 6, PeerFeatures::COMMUNICATION_NODE);
+        for peer in &peers {
+            peer_manager.add_peer(peer.to_peer()).await.unwrap();
+        }
+        let req = GetPeersRequest {
+            n: 5,
+            ..Default::default()
+        };
+
+        let req = mock.request_with_context(node_identity.node_id().clone(), req);
+        let peers_stream = service.get_peers(req).await.unwrap();
+        let results = peers_stream.collect::<Vec<_>>().await;
+        assert_eq!(results.len(), 5);
+    }
+
+    #[tokio_macros::test_basic]
+    async fn it_errors_if_maximum_n_exceeded() {
+        let node_identity = build_node_identity(PeerFeatures::COMMUNICATION_NODE);
+        let (service, mock, _) = setup(node_identity.clone());
+        let req = GetPeersRequest {
+            n: 5_000,
+            ..Default::default()
+        };
+
+        let req = mock.request_with_context(node_identity.node_id().clone(), req);
+        let err = service.get_peers(req).await.unwrap_err();
+        assert_eq!(err.status_code(), RpcStatusCode::BadRequest);
+    }
+
+    #[tokio_macros::test_basic]
+    async fn it_errors_if_client_node() {
+        let node_identity = build_node_identity(PeerFeatures::COMMUNICATION_CLIENT);
+        let (service, mock, _) = setup(node_identity.clone());
+        let req = GetPeersRequest {
+            n: 5,
+            ..Default::default()
+        };
+
+        let req = mock.request_with_context(node_identity.node_id().clone(), req);
+        let err = service.get_peers(req).await.unwrap_err();
+        assert_eq!(err.status_code(), RpcStatusCode::UnsupportedMethod);
+        assert_eq!(err.details(), "get_peers is not supported");
+    }
+}

--- a/comms/dht/src/store_forward/saf_handler/task.rs
+++ b/comms/dht/src/store_forward/saf_handler/task.rs
@@ -527,13 +527,13 @@ mod test {
         proto::envelope::DhtHeader,
         store_forward::{message::StoredMessagePriority, StoredMessage},
         test_utils::{
+            build_peer_manager,
             create_dht_actor_mock,
             create_store_and_forward_mock,
             make_dht_header,
             make_dht_inbound_message,
             make_keypair,
             make_node_identity,
-            make_peer_manager,
             service_spy,
         },
     };
@@ -573,7 +573,7 @@ mod test {
         let spy = service_spy();
         let (requester, mock_state) = create_store_and_forward_mock();
 
-        let peer_manager = make_peer_manager();
+        let peer_manager = build_peer_manager();
         let (oms_tx, mut oms_rx) = mpsc::channel(1);
 
         let node_identity = make_node_identity();
@@ -675,7 +675,7 @@ mod test {
         let spy = service_spy();
         let (requester, _) = create_store_and_forward_mock();
 
-        let peer_manager = make_peer_manager();
+        let peer_manager = build_peer_manager();
         let (oms_tx, _) = mpsc::channel(1);
 
         let node_identity = make_node_identity();

--- a/comms/dht/src/store_forward/store.rs
+++ b/comms/dht/src/store_forward/store.rs
@@ -442,10 +442,10 @@ mod test {
         envelope::DhtMessageFlags,
         proto::{dht::JoinMessage, envelope::DhtMessageType},
         test_utils::{
+            build_peer_manager,
             create_store_and_forward_mock,
             make_dht_inbound_message,
             make_node_identity,
-            make_peer_manager,
             service_spy,
         },
     };
@@ -460,7 +460,7 @@ mod test {
         let (requester, mock_state) = create_store_and_forward_mock();
 
         let spy = service_spy();
-        let peer_manager = make_peer_manager();
+        let peer_manager = build_peer_manager();
         let node_identity = make_node_identity();
         let mut service = StoreLayer::new(Default::default(), peer_manager, node_identity, requester)
             .layer(spy.to_service::<PipelineError>());
@@ -480,7 +480,7 @@ mod test {
         let (requester, mock_state) = create_store_and_forward_mock();
 
         let spy = service_spy();
-        let peer_manager = make_peer_manager();
+        let peer_manager = build_peer_manager();
         let node_identity = make_node_identity();
         let join_msg_bytes = JoinMessage::from(&node_identity).to_encoded_bytes();
 
@@ -515,7 +515,7 @@ mod test {
         let (requester, mock_state) = create_store_and_forward_mock();
 
         let spy = service_spy();
-        let peer_manager = make_peer_manager();
+        let peer_manager = build_peer_manager();
         let node_identity = make_node_identity();
         let mut service = StoreLayer::new(Default::default(), peer_manager, node_identity, requester)
             .layer(spy.to_service::<PipelineError>());
@@ -542,7 +542,7 @@ mod test {
     async fn decryption_failed_should_store() {
         let (requester, mock_state) = create_store_and_forward_mock();
         let spy = service_spy();
-        let peer_manager = make_peer_manager();
+        let peer_manager = build_peer_manager();
         let origin_node_identity = make_node_identity();
         peer_manager.add_peer(origin_node_identity.to_peer()).await.unwrap();
         let node_identity = make_node_identity();

--- a/comms/dht/src/test_utils/makers.rs
+++ b/comms/dht/src/test_utils/makers.rs
@@ -162,7 +162,7 @@ pub fn make_dht_envelope(
     DhtEnvelope::new(header, message.into())
 }
 
-pub fn make_peer_manager() -> Arc<PeerManager> {
+pub fn build_peer_manager() -> Arc<PeerManager> {
     let database_name = random::string(8);
     let path = create_temporary_data_path();
     let datastore = LMDBBuilder::new()

--- a/comms/rpc_macros/src/generator.rs
+++ b/comms/rpc_macros/src/generator.rs
@@ -104,8 +104,8 @@ impl RpcCodeGenerator {
 
             impl<T: #trait_ident> #dep_mod::Service<#dep_mod::Request<#dep_mod::Bytes>> for #server_struct<T> {
                 type Error = #dep_mod::RpcStatus;
-                type Future = #dep_mod::BoxFuture<'static, Result<#dep_mod::Response<#dep_mod::Body>,
-        #dep_mod::RpcStatus>>;         type Response = #dep_mod::Response<#dep_mod::Body>;
+                type Future = #dep_mod::BoxFuture<'static, Result<#dep_mod::Response<#dep_mod::Body>, #dep_mod::RpcStatus>>;
+                type Response = #dep_mod::Response<#dep_mod::Body>;
 
                 fn poll_ready(&mut self, _: &mut #dep_mod::Context<'_>) -> #dep_mod::Poll<Result<(), Self::Error>> {
                     #dep_mod::Poll::Ready(Ok(()))

--- a/comms/src/builder/comms_node.rs
+++ b/comms/src/builder/comms_node.rs
@@ -116,7 +116,7 @@ where
     /// CommsBuilder::new().add_rpc_service(server).build();
     /// ```
     #[cfg(feature = "rpc")]
-    pub async fn add_rpc<T: ProtocolExtension + 'static>(mut self, rpc: T) -> Self {
+    pub fn add_rpc<T: ProtocolExtension + 'static>(mut self, rpc: T) -> Self {
         self.protocol_extensions.add(rpc);
         self
     }

--- a/comms/src/peer_manager/node_id.rs
+++ b/comms/src/peer_manager/node_id.rs
@@ -20,6 +20,7 @@
 //  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 //  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+use crate::types::CommsPublicKey;
 use blake2::{
     digest::{Input, VariableOutput},
     VarBlake2b,
@@ -216,6 +217,13 @@ impl NodeId {
         hasher.input(bytes);
         let v = hasher.vec_result();
         Self::try_from(v.as_slice())
+    }
+
+    /// Derive a node id from a public key: node_id=hash(public_key)
+    /// This function uses `NodeId::from_key` internally but is infallible because `NodeId::from_key` cannot fail when
+    /// used with a `CommsPublicKey`.
+    pub fn from_public_key(key: &CommsPublicKey) -> Self {
+        Self::from_key(key).expect("NodeId::from_key is implemented incorrectly for CommsPublicKey")
     }
 
     /// Calculate the distance between the current node id and the provided node id using the XOR metric

--- a/comms/src/protocol/rpc/body.rs
+++ b/comms/src/protocol/rpc/body.rs
@@ -210,6 +210,7 @@ impl Buf for BodyBytes {
     }
 }
 
+#[derive(Debug)]
 pub struct Streaming<T> {
     inner: mpsc::Receiver<Result<T, RpcStatus>>,
 }
@@ -217,6 +218,15 @@ pub struct Streaming<T> {
 impl<T> Streaming<T> {
     pub fn new(inner: mpsc::Receiver<Result<T, RpcStatus>>) -> Self {
         Self { inner }
+    }
+
+    pub fn empty() -> Self {
+        let (_, rx) = mpsc::channel(0);
+        Self { inner: rx }
+    }
+
+    pub fn into_inner(self) -> mpsc::Receiver<Result<T, RpcStatus>> {
+        self.inner
     }
 }
 

--- a/comms/src/protocol/rpc/mod.rs
+++ b/comms/src/protocol/rpc/mod.rs
@@ -55,6 +55,8 @@ pub use status::{RpcStatus, RpcStatusCode};
 
 mod not_found;
 
+pub mod test_utils;
+
 pub const RPC_MAX_FRAME_SIZE: usize = 4 * 1024 * 1024; // 4 MiB
 
 // Re-exports used to keep things orderly in the #[tari_rpc] proc macro


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
- Added `DhtRpcService` trait with `get_peers` call
- `get_peers` returns peers that are closer to the caller's `NodeId`
- Added tests for `get_peers`
- Added some basic test utils/mocks to make testing RPC easier
- Added infallible `NodeId::from_public_key` function

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Part of an implementation of _outbound only_  peer discovery which is more in-line with kademlia.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Number of unit tests testing all code paths in `get_peers` call

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [x] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch.
* [x] I ran `cargo-fmt --all` before pushing.
* [x] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
