### PR TITLE
Implement LMDB automatic resizing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3715,6 +3715,7 @@ dependencies = [
  "serde_json",
  "sha2",
  "structopt",
+ "tari_storage",
  "tari_test_utils",
  "tempfile",
  "toml 0.5.6",

--- a/applications/tari_base_node/src/builder.rs
+++ b/applications/tari_base_node/src/builder.rs
@@ -21,7 +21,7 @@
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 use crate::miner;
-use futures::{channel::mpsc, future};
+use futures::future;
 use log::*;
 use std::{
     fs,
@@ -334,7 +334,7 @@ where B: 'static
 }
 
 /// Sets up and initializes the base node, creating the context and database
-/// ## Paramters
+/// ## Parameters
 /// `config` - The configuration for the base node
 /// `node_identity` - The node identity information of the base node
 /// `wallet_node_identity` - The node identity information of the base node's wallet
@@ -367,7 +367,8 @@ pub async fn configure_and_initialize_node(
             NodeContainer::Memory(ctx)
         },
         DatabaseType::LMDB(p) => {
-            let backend = create_lmdb_database(&p, MmrCacheConfig::default()).map_err(|e| e.to_string())?;
+            let backend = create_lmdb_database(&p, config.db_config.clone(), MmrCacheConfig::default())
+                .map_err(|e| e.to_string())?;
             let ctx = build_node_context(
                 backend,
                 network,
@@ -383,8 +384,9 @@ pub async fn configure_and_initialize_node(
     Ok(result)
 }
 
-/// Constructs the base node context, this includes settin up the consensus manager, mempool, base node, wallet, miner
-/// and state machine ## Paramters
+/// Constructs the base node context, this includes setting up the consensus manager, mempool, base node, wallet, miner
+/// and state machine
+/// ## Parameters
 /// `backend` - Backend interface
 /// `network` - The NetworkType (rincewind, mainnet, local)
 /// `base_node_identity` - The node identity information of the base node

--- a/base_layer/core/src/chain_storage/error.rs
+++ b/base_layer/core/src/chain_storage/error.rs
@@ -25,6 +25,7 @@ use crate::{
     validation::ValidationError,
 };
 use tari_mmr::{error::MerkleMountainRangeError, MerkleProofError};
+use tari_storage::lmdb_store::LMDBError;
 use thiserror::Error;
 use tokio::task;
 
@@ -85,6 +86,11 @@ pub enum ChainStorageError {
     OutOfRange,
     #[error("Value not found: {0}")]
     LmdbValueNotFound(lmdb_zero::Error),
+    #[error("LMDB error: {source}")]
+    LmdbError {
+        #[from]
+        source: LMDBError,
+    },
 }
 
 impl From<LMDBVecError> for ChainStorageError {

--- a/base_layer/core/src/chain_storage/lmdb_db/lmdb.rs
+++ b/base_layer/core/src/chain_storage/lmdb_db/lmdb.rs
@@ -45,21 +45,19 @@ pub fn serialize<T>(data: &T) -> Result<Vec<u8>, ChainStorageError>
 where T: Serialize {
     let size = bincode::serialized_size(&data).map_err(|e| ChainStorageError::AccessError(e.to_string()))?;
     let mut buf = Vec::with_capacity(size as usize);
-    bincode::serialize_into(&mut buf, data)
-        .or_else(|e| {
-            error!(target: LOG_TARGET, "Could not serialize lmdb: {:?}", e);
-            Err(e)
-        })
-        .map_err(|e| ChainStorageError::AccessError(e.to_string()))?;
+    bincode::serialize_into(&mut buf, data).map_err(|e| {
+        error!(target: LOG_TARGET, "Could not serialize lmdb: {:?}", e);
+        ChainStorageError::AccessError(e.to_string())
+    })?;
     Ok(buf)
 }
 
 pub fn deserialize<T>(buf_bytes: &[u8]) -> Result<T, error::Error>
 where T: DeserializeOwned {
     bincode::deserialize(buf_bytes)
-        .or_else(|e| {
+        .map_err(|e| {
             error!(target: LOG_TARGET, "Could not deserialize lmdb: {:?}", e);
-            Err(e)
+            e
         })
         .map_err(|e| error::Error::ValRejected(e.to_string()))
 }

--- a/base_layer/core/src/chain_storage/lmdb_db/lmdb_vec.rs
+++ b/base_layer/core/src/chain_storage/lmdb_db/lmdb_vec.rs
@@ -284,7 +284,7 @@ where
 #[cfg(test)]
 mod test {
     use super::*;
-    use tari_storage::lmdb_store::{db, LMDBBuilder};
+    use tari_storage::lmdb_store::{db, LMDBBuilder, LMDBConfig};
     use tari_test_utils::paths::create_temporary_data_path;
 
     #[test]
@@ -293,7 +293,7 @@ mod test {
         let _ = std::fs::create_dir(&path).unwrap_or_default();
         let lmdb_store = LMDBBuilder::new()
             .set_path(&path)
-            .set_environment_size(1)
+            .set_env_config(LMDBConfig::default())
             .set_max_number_of_databases(1)
             .add_database("db", db::CREATE)
             .build()

--- a/base_layer/core/tests/chain_storage_tests/chain_backend.rs
+++ b/base_layer/core/tests/chain_storage_tests/chain_backend.rs
@@ -48,6 +48,7 @@ use tari_core::{
 };
 use tari_crypto::tari_utilities::{epoch_time::EpochTime, hex::Hex, Hashable};
 use tari_mmr::{MmrCacheConfig, MutableMmr};
+use tari_storage::lmdb_store::LMDBConfig;
 use tari_test_utils::paths::create_temporary_data_path;
 
 fn insert_contains_delete_and_fetch_header<T: BlockchainBackend>(mut db: T) {
@@ -93,7 +94,7 @@ fn lmdb_insert_contains_delete_and_fetch_header() {
 
     // Perform test
     {
-        let db = create_lmdb_database(&temp_path, MmrCacheConfig::default()).unwrap();
+        let db = create_lmdb_database(&temp_path, LMDBConfig::default(), MmrCacheConfig::default()).unwrap();
         insert_contains_delete_and_fetch_header(db);
     }
 
@@ -138,7 +139,7 @@ fn lmdb_insert_contains_delete_and_fetch_utxo() {
 
     // Perform test
     {
-        let db = create_lmdb_database(&temp_path, MmrCacheConfig::default()).unwrap();
+        let db = create_lmdb_database(&temp_path, LMDBConfig::default(), MmrCacheConfig::default()).unwrap();
         insert_contains_delete_and_fetch_utxo(db);
     }
 
@@ -184,7 +185,7 @@ fn lmdb_insert_contains_delete_and_fetch_kernel() {
 
     // Perform test
     {
-        let db = create_lmdb_database(&temp_path, MmrCacheConfig::default()).unwrap();
+        let db = create_lmdb_database(&temp_path, LMDBConfig::default(), MmrCacheConfig::default()).unwrap();
         insert_contains_delete_and_fetch_kernel(db);
     }
 
@@ -237,7 +238,7 @@ fn lmdb_insert_contains_delete_and_fetch_orphan() {
     {
         let network = Network::LocalNet;
         let consensus_constants = network.create_consensus_constants();
-        let db = create_lmdb_database(&temp_path, MmrCacheConfig::default()).unwrap();
+        let db = create_lmdb_database(&temp_path, LMDBConfig::default(), MmrCacheConfig::default()).unwrap();
         insert_contains_delete_and_fetch_orphan(db, &consensus_constants);
     }
 
@@ -309,7 +310,7 @@ fn lmdb_spend_utxo_and_unspend_stxo() {
 
     // Perform test
     {
-        let db = create_lmdb_database(&temp_path, MmrCacheConfig::default()).unwrap();
+        let db = create_lmdb_database(&temp_path, LMDBConfig::default(), MmrCacheConfig::default()).unwrap();
         spend_utxo_and_unspend_stxo(db);
     }
 
@@ -399,7 +400,7 @@ fn lmdb_insert_fetch_metadata() {
 
     // Perform test
     {
-        let db = create_lmdb_database(&temp_path, MmrCacheConfig::default()).unwrap();
+        let db = create_lmdb_database(&temp_path, LMDBConfig::default(), MmrCacheConfig::default()).unwrap();
         insert_fetch_metadata(db);
     }
 
@@ -485,7 +486,7 @@ fn lmdb_fetch_mmr_root_and_proof_for_utxo_and_rp() {
 
     // Perform test
     {
-        let db = create_lmdb_database(&temp_path, MmrCacheConfig::default()).unwrap();
+        let db = create_lmdb_database(&temp_path, LMDBConfig::default(), MmrCacheConfig::default()).unwrap();
         fetch_mmr_root_and_proof_for_utxo_and_rp(db);
     }
 
@@ -546,7 +547,7 @@ fn lmdb_fetch_mmr_root_and_proof_for_kernel() {
 
     // Perform test
     {
-        let db = create_lmdb_database(&temp_path, MmrCacheConfig::default()).unwrap();
+        let db = create_lmdb_database(&temp_path, LMDBConfig::default(), MmrCacheConfig::default()).unwrap();
         fetch_mmr_root_and_proof_for_kernel(db);
     }
 
@@ -608,7 +609,7 @@ fn lmdb_fetch_future_mmr_root_for_utxo_and_rp() {
 
     // Perform test
     {
-        let db = create_lmdb_database(&temp_path, MmrCacheConfig::default()).unwrap();
+        let db = create_lmdb_database(&temp_path, LMDBConfig::default(), MmrCacheConfig::default()).unwrap();
         fetch_future_mmr_root_for_utxo_and_rp(db);
     }
 
@@ -658,7 +659,7 @@ fn lmdb_fetch_future_mmr_root_for_for_kernel() {
 
     // Perform test
     {
-        let db = create_lmdb_database(&temp_path, MmrCacheConfig::default()).unwrap();
+        let db = create_lmdb_database(&temp_path, LMDBConfig::default(), MmrCacheConfig::default()).unwrap();
         fetch_future_mmr_root_for_for_kernel(db);
     }
 
@@ -776,7 +777,7 @@ fn lmdb_commit_block_and_create_fetch_checkpoint_and_rewind_mmr() {
 
     // Perform test
     {
-        let db = create_lmdb_database(&temp_path, MmrCacheConfig::default()).unwrap();
+        let db = create_lmdb_database(&temp_path, LMDBConfig::default(), MmrCacheConfig::default()).unwrap();
         commit_block_and_create_fetch_checkpoint_and_rewind_mmr(db);
     }
 
@@ -850,7 +851,7 @@ fn lmdb_for_each_orphan() {
     {
         let network = Network::LocalNet;
         let consensus_constants = network.create_consensus_constants();
-        let db = create_lmdb_database(&temp_path, MmrCacheConfig::default()).unwrap();
+        let db = create_lmdb_database(&temp_path, LMDBConfig::default(), MmrCacheConfig::default()).unwrap();
         for_each_orphan(db, &consensus_constants);
     }
 
@@ -908,7 +909,7 @@ fn lmdb_for_each_kernel() {
 
     // Perform test
     {
-        let db = create_lmdb_database(&temp_path, MmrCacheConfig::default()).unwrap();
+        let db = create_lmdb_database(&temp_path, LMDBConfig::default(), MmrCacheConfig::default()).unwrap();
         for_each_kernel(db);
     }
 
@@ -966,7 +967,7 @@ fn lmdb_for_each_header() {
 
     // Perform test
     {
-        let db = create_lmdb_database(&temp_path, MmrCacheConfig::default()).unwrap();
+        let db = create_lmdb_database(&temp_path, LMDBConfig::default(), MmrCacheConfig::default()).unwrap();
         for_each_header(db);
     }
 
@@ -1025,7 +1026,7 @@ fn lmdb_for_each_utxo() {
 
     // Perform test
     {
-        let db = create_lmdb_database(&temp_path, MmrCacheConfig::default()).unwrap();
+        let db = create_lmdb_database(&temp_path, LMDBConfig::default(), MmrCacheConfig::default()).unwrap();
         for_each_utxo(db);
     }
 
@@ -1058,7 +1059,7 @@ fn lmdb_backend_restore() {
     let path = create_temporary_data_path();
     {
         {
-            let mut db = create_lmdb_database(&path, MmrCacheConfig::default()).unwrap();
+            let mut db = create_lmdb_database(&path, LMDBConfig::default(), MmrCacheConfig::default()).unwrap();
             let mut txn = DbTransaction::new();
             txn.insert_orphan(orphan.clone());
             txn.insert_utxo(utxo1);
@@ -1082,7 +1083,7 @@ fn lmdb_backend_restore() {
             assert_eq!(db.contains(&DbKey::OrphanBlock(orphan_hash.clone())).unwrap(), true);
         }
         // Restore backend storage
-        let db = create_lmdb_database(&path, MmrCacheConfig::default()).unwrap();
+        let db = create_lmdb_database(&path, LMDBConfig::default(), MmrCacheConfig::default()).unwrap();
         assert_eq!(db.contains(&DbKey::BlockHeader(header.height)).unwrap(), true);
         assert_eq!(db.contains(&DbKey::BlockHash(header_hash)).unwrap(), true);
         assert_eq!(db.contains(&DbKey::UnspentOutput(utxo_hash)).unwrap(), true);
@@ -1105,7 +1106,7 @@ fn lmdb_mmr_reset_and_commit() {
     // Perform test
     {
         let factories = CryptoFactories::default();
-        let mut db = create_lmdb_database(&temp_path, MmrCacheConfig::default()).unwrap();
+        let mut db = create_lmdb_database(&temp_path, LMDBConfig::default(), MmrCacheConfig::default()).unwrap();
 
         let (utxo1, _) = create_utxo(MicroTari(10_000), &factories, None);
         let (utxo2, _) = create_utxo(MicroTari(15_000), &factories, None);
@@ -1320,7 +1321,7 @@ fn lmdb_fetch_checkpoint() {
     // Perform test
     {
         let mmr_cache_config = MmrCacheConfig { rewind_hist_len: 1 };
-        let db = create_lmdb_database(&temp_path, mmr_cache_config).unwrap();
+        let db = create_lmdb_database(&temp_path, LMDBConfig::default(), mmr_cache_config).unwrap();
         fetch_checkpoint(db);
     }
 
@@ -1467,7 +1468,7 @@ fn lmdb_merging_and_fetch_checkpoints_and_stxo_discard() {
     // Perform test
     {
         let mmr_cache_config = MmrCacheConfig { rewind_hist_len: 1 };
-        let db = create_lmdb_database(&temp_path, mmr_cache_config).unwrap();
+        let db = create_lmdb_database(&temp_path, LMDBConfig::default(), mmr_cache_config).unwrap();
         merging_and_fetch_checkpoints_and_stxo_discard(db);
     }
 
@@ -1515,7 +1516,7 @@ fn lmdb_duplicate_utxo() {
 
     // Perform test
     {
-        let db = create_lmdb_database(&temp_path, MmrCacheConfig::default()).unwrap();
+        let db = create_lmdb_database(&temp_path, LMDBConfig::default(), MmrCacheConfig::default()).unwrap();
         duplicate_utxo(db);
     }
 
@@ -1559,7 +1560,7 @@ fn lmdb_fetch_last_header() {
 
     // Perform test
     {
-        let db = create_lmdb_database(&temp_path, MmrCacheConfig::default()).unwrap();
+        let db = create_lmdb_database(&temp_path, LMDBConfig::default(), MmrCacheConfig::default()).unwrap();
         fetch_last_header(db);
     }
 
@@ -1659,7 +1660,7 @@ fn lmdb_fetch_target_difficulties() {
 
     // Perform test
     {
-        let db = create_lmdb_database(&temp_path, MmrCacheConfig::default()).unwrap();
+        let db = create_lmdb_database(&temp_path, LMDBConfig::default(), MmrCacheConfig::default()).unwrap();
         fetch_target_difficulties(db);
     }
 
@@ -1768,7 +1769,7 @@ fn lmdb_fetch_utxo_rp_nodes_and_count() {
 
     // Perform test
     {
-        let db = create_lmdb_database(&temp_path, MmrCacheConfig::default()).unwrap();
+        let db = create_lmdb_database(&temp_path, LMDBConfig::default(), MmrCacheConfig::default()).unwrap();
         fetch_utxo_rp_mmr_nodes_and_count(db);
     }
 
@@ -1845,7 +1846,7 @@ fn lmdb_fetch_kernel_nodes_and_count() {
 
     // Perform test
     {
-        let db = create_lmdb_database(&temp_path, MmrCacheConfig::default()).unwrap();
+        let db = create_lmdb_database(&temp_path, LMDBConfig::default(), MmrCacheConfig::default()).unwrap();
         fetch_kernel_mmr_nodes_and_count(db);
     }
 
@@ -1937,7 +1938,7 @@ fn lmdb_insert_mmr_node_for_utxo_and_rp() {
 
     // Perform test
     {
-        let db = create_lmdb_database(&temp_path, MmrCacheConfig::default()).unwrap();
+        let db = create_lmdb_database(&temp_path, LMDBConfig::default(), MmrCacheConfig::default()).unwrap();
         insert_mmr_node_for_utxo_and_rp(db);
     }
 

--- a/base_layer/core/tests/chain_storage_tests/chain_storage.rs
+++ b/base_layer/core/tests/chain_storage_tests/chain_storage.rs
@@ -72,6 +72,7 @@ use tari_core::{
 };
 use tari_crypto::tari_utilities::{hex::Hex, Hashable};
 use tari_mmr::{MmrCacheConfig, MutableMmr};
+use tari_storage::lmdb_store::LMDBConfig;
 use tari_test_utils::{paths::create_temporary_data_path, unpack_enum};
 
 fn init_log() {
@@ -1201,7 +1202,7 @@ fn restore_metadata_and_pruning_horizon_update() {
         let pruning_horizon1: u64 = 1000;
         let pruning_horizon2: u64 = 900;
         {
-            let db = create_lmdb_database(&path, MmrCacheConfig::default()).unwrap();
+            let db = create_lmdb_database(&path, LMDBConfig::default(), MmrCacheConfig::default()).unwrap();
             config.pruning_horizon = pruning_horizon1;
             let db = BlockchainDatabase::new(db, &rules, validators.clone(), config).unwrap();
 
@@ -1216,7 +1217,7 @@ fn restore_metadata_and_pruning_horizon_update() {
         // Restore blockchain db with larger pruning horizon
         {
             config.pruning_horizon = 2000;
-            let db = create_lmdb_database(&path, MmrCacheConfig::default()).unwrap();
+            let db = create_lmdb_database(&path, LMDBConfig::default(), MmrCacheConfig::default()).unwrap();
             let db = BlockchainDatabase::new(db, &rules, validators.clone(), config).unwrap();
 
             let metadata = db.get_chain_metadata().unwrap();
@@ -1227,7 +1228,7 @@ fn restore_metadata_and_pruning_horizon_update() {
         // Restore blockchain db with smaller pruning horizon update
         {
             config.pruning_horizon = 900;
-            let db = create_lmdb_database(&path, MmrCacheConfig::default()).unwrap();
+            let db = create_lmdb_database(&path, LMDBConfig::default(), MmrCacheConfig::default()).unwrap();
             let db = BlockchainDatabase::new(db, &rules, validators, config).unwrap();
 
             let metadata = db.get_chain_metadata().unwrap();
@@ -1262,7 +1263,7 @@ fn invalid_block() {
             MockStatelessBlockValidator::new(consensus_manager.clone(), factories.clone()),
             MockAccumDifficultyValidator {},
         );
-        let db = create_lmdb_database(&temp_path, MmrCacheConfig::default()).unwrap();
+        let db = create_lmdb_database(&temp_path, LMDBConfig::default(), MmrCacheConfig::default()).unwrap();
         let mut store =
             BlockchainDatabase::new(db, &consensus_manager, validators, BlockchainDatabaseConfig::default()).unwrap();
         let mut blocks = vec![block0];

--- a/base_layer/core/tests/helpers/sample_blockchains.rs
+++ b/base_layer/core/tests/helpers/sample_blockchains.rs
@@ -43,6 +43,7 @@ use tari_core::{
     txn_schema,
 };
 use tari_mmr::MmrCacheConfig;
+use tari_storage::lmdb_store::LMDBConfig;
 
 /// Create a simple 6 block memory-backed database.
 /// Genesis block:
@@ -205,7 +206,7 @@ pub fn create_new_blockchain_lmdb<P: AsRef<std::path::Path>>(
         .with_consensus_constants(consensus_constants)
         .with_block(block0.clone())
         .build();
-    let db = create_lmdb_database(path, MmrCacheConfig::default()).unwrap();
+    let db = create_lmdb_database(path, LMDBConfig::default(), MmrCacheConfig::default()).unwrap();
     let db = BlockchainDatabase::new(db, &consensus_manager, validators, config).unwrap();
     (db, vec![block0], vec![vec![output]], consensus_manager)
 }

--- a/base_layer/p2p/src/initialization.rs
+++ b/base_layer/p2p/src/initialization.rs
@@ -43,7 +43,10 @@ use tari_comms::{
     PeerManager,
 };
 use tari_comms_dht::{Dht, DhtBuilder, DhtConfig, DhtInitializationError};
-use tari_storage::{lmdb_store::LMDBBuilder, LMDBWrapper};
+use tari_storage::{
+    lmdb_store::{LMDBBuilder, LMDBConfig},
+    LMDBWrapper,
+};
 use thiserror::Error;
 use tower::ServiceBuilder;
 
@@ -134,7 +137,7 @@ where
     std::fs::create_dir_all(data_path).unwrap();
     let datastore = LMDBBuilder::new()
         .set_path(data_path)
-        .set_environment_size(50)
+        .set_env_config(LMDBConfig::default())
         .set_max_number_of_databases(1)
         .add_database(&peer_database_name, lmdb_zero::db::CREATE)
         .build()
@@ -301,7 +304,7 @@ where
 {
     let datastore = LMDBBuilder::new()
         .set_path(&config.datastore_path)
-        .set_environment_size(50)
+        .set_env_config(LMDBConfig::default())
         .set_max_number_of_databases(1)
         .add_database(&config.peer_database_name, lmdb_zero::db::CREATE)
         .build()

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -23,6 +23,7 @@ multiaddr={package="parity-multiaddr", version = "0.7.2"}
 prost-build = "0.6.1"
 sha2 = "0.8.0"
 path-clean = "0.1.0"
+tari_storage = { version = "^0.2", path = "../infrastructure/storage"}
 
 [dev-dependencies]
 tempfile = "3.1.0"

--- a/common/config/presets/windows.toml
+++ b/common/config/presets/windows.toml
@@ -116,6 +116,11 @@ network = "rincewind"
 # almost all use cases.
 db_type = "lmdb"
 
+# db config defaults
+# db_init_size_mb = 1000
+# db_grow_size_mb = 500
+# db_resize_threshold_mb = 100
+
 # The maximum number of orphans that can be stored in the Orphan block pool. Default value is "720".
 #orphan_storage_capacity = 720
 # The pruning horizon that indicates how many full blocks without pruning must be kept by the base node. Default value

--- a/common/config/tari_config_sample.toml
+++ b/common/config/tari_config_sample.toml
@@ -116,6 +116,11 @@ network = "rincewind"
 # almost all use cases.
 db_type = "lmdb"
 
+# db config defaults
+# db_init_size_mb = 1000
+# db_grow_size_mb = 500
+# db_resize_threshold_mb = 100
+
 # The maximum number of orphans that can be stored in the Orphan block pool. Default value is "720".
 #orphan_storage_capacity = 720
 # The pruning horizon that indicates how many full blocks without pruning must be kept by the base node. Default value

--- a/comms/dht/examples/memorynet.rs
+++ b/comms/dht/examples/memorynet.rs
@@ -84,7 +84,10 @@ use tari_comms_dht::{
     Dht,
     DhtBuilder,
 };
-use tari_storage::{lmdb_store::LMDBBuilder, LMDBWrapper};
+use tari_storage::{
+    lmdb_store::{LMDBBuilder, LMDBConfig},
+    LMDBWrapper,
+};
 use tari_test_utils::{paths::create_temporary_data_path, random};
 use tokio::{runtime, task, time};
 use tower::ServiceBuilder;
@@ -983,7 +986,7 @@ fn create_peer_storage(peers: Vec<Peer>) -> CommsDatabase {
     let database_name = random::string(8);
     let datastore = LMDBBuilder::new()
         .set_path(create_temporary_data_path().to_str().unwrap())
-        .set_environment_size(10)
+        .set_env_config(LMDBConfig::default())
         .set_max_number_of_databases(1)
         .add_database(&database_name, lmdb_zero::db::CREATE)
         .build()

--- a/comms/dht/src/test_utils/makers.rs
+++ b/comms/dht/src/test_utils/makers.rs
@@ -41,7 +41,7 @@ use tari_crypto::{
     keys::PublicKey,
     tari_utilities::{message_format::MessageFormat, ByteArray},
 };
-use tari_storage::lmdb_store::LMDBBuilder;
+use tari_storage::lmdb_store::{LMDBBuilder, LMDBConfig};
 use tari_test_utils::{paths::create_temporary_data_path, random};
 
 pub fn make_identity(features: PeerFeatures) -> Arc<NodeIdentity> {
@@ -167,7 +167,7 @@ pub fn build_peer_manager() -> Arc<PeerManager> {
     let path = create_temporary_data_path();
     let datastore = LMDBBuilder::new()
         .set_path(path.to_str().unwrap())
-        .set_environment_size(50)
+        .set_env_config(LMDBConfig::default())
         .set_max_number_of_databases(1)
         .add_database(&database_name, lmdb_zero::db::CREATE)
         .build()

--- a/comms/dht/tests/dht.rs
+++ b/comms/dht/tests/dht.rs
@@ -46,7 +46,10 @@ use tari_comms_dht::{
     Dht,
     DhtBuilder,
 };
-use tari_storage::{lmdb_store::LMDBBuilder, LMDBWrapper};
+use tari_storage::{
+    lmdb_store::{LMDBBuilder, LMDBConfig},
+    LMDBWrapper,
+};
 use tari_test_utils::{
     async_assert_eventually,
     collect_stream,
@@ -86,7 +89,7 @@ fn create_peer_storage() -> CommsDatabase {
     let database_name = random::string(8);
     let datastore = LMDBBuilder::new()
         .set_path(create_temporary_data_path())
-        .set_environment_size(50)
+        .set_env_config(LMDBConfig::default())
         .set_max_number_of_databases(1)
         .add_database(&database_name, lmdb_zero::db::CREATE)
         .build()

--- a/comms/examples/stress/node.rs
+++ b/comms/examples/stress/node.rs
@@ -39,7 +39,10 @@ use tari_comms::{
     NodeIdentity,
     Substream,
 };
-use tari_storage::{lmdb_store::LMDBBuilder, LMDBWrapper};
+use tari_storage::{
+    lmdb_store::{LMDBBuilder, LMDBConfig},
+    LMDBWrapper,
+};
 
 pub async fn create(
     node_identity: Option<Arc<NodeIdentity>>,
@@ -60,7 +63,7 @@ pub async fn create(
 {
     let datastore = LMDBBuilder::new()
         .set_path(database_path.to_str().unwrap())
-        .set_environment_size(50)
+        .set_env_config(LMDBConfig::default())
         .set_max_number_of_databases(1)
         .add_database("peerdb", lmdb_zero::db::CREATE)
         .build()

--- a/comms/examples/tor.rs
+++ b/comms/examples/tor.rs
@@ -19,7 +19,10 @@ use tari_comms::{
     CommsNode,
 };
 use tari_crypto::tari_utilities::message_format::MessageFormat;
-use tari_storage::{lmdb_store::LMDBBuilder, LMDBWrapper};
+use tari_storage::{
+    lmdb_store::{LMDBBuilder, LMDBConfig},
+    LMDBWrapper,
+};
 use tempfile::Builder;
 use thiserror::Error;
 use tokio::{runtime, task};
@@ -167,7 +170,7 @@ async fn setup_node_with_tor<P: Into<tor::PortMapping>>(
 {
     let datastore = LMDBBuilder::new()
         .set_path(database_path.to_str().unwrap())
-        .set_environment_size(50)
+        .set_env_config(LMDBConfig::default())
         .set_max_number_of_databases(1)
         .add_database("peerdb", lmdb_zero::db::CREATE)
         .build()

--- a/comms/src/peer_manager/mod.rs
+++ b/comms/src/peer_manager/mod.rs
@@ -39,6 +39,7 @@
 //! # use lmdb_zero::db;
 //! # use std::sync::Arc;
 //! # use tari_storage::LMDBWrapper;
+//! # use tari_storage::lmdb_store::LMDBConfig;
 //!
 //! let mut rng = rand::rngs::OsRng;
 //! let (dest_sk, pk) = CommsPublicKey::random_keypair(&mut rng);
@@ -55,7 +56,7 @@
 //! let database_name = "pm_peer_database";
 //! let datastore = LMDBBuilder::new()
 //!     .set_path("/tmp/")
-//!     .set_environment_size(10)
+//!     .set_env_config(LMDBConfig::default())
 //!     .set_max_number_of_databases(1)
 //!     .add_database(database_name, lmdb_zero::db::CREATE)
 //!     .build()

--- a/infrastructure/storage/src/key_val_store/lmdb_database.rs
+++ b/infrastructure/storage/src/key_val_store/lmdb_database.rs
@@ -109,7 +109,7 @@ where
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::lmdb_store::{LMDBBuilder, LMDBError, LMDBStore};
+    use crate::lmdb_store::{LMDBBuilder, LMDBConfig, LMDBError, LMDBStore};
     use serde::{Deserialize, Serialize};
     use std::path::PathBuf;
 
@@ -125,7 +125,7 @@ mod test {
         std::fs::create_dir(&path).unwrap_or_default();
         LMDBBuilder::new()
             .set_path(&path)
-            .set_environment_size(50)
+            .set_env_config(LMDBConfig::default())
             .set_max_number_of_databases(2)
             .add_database(name, lmdb_zero::db::CREATE)
             .build()

--- a/infrastructure/storage/src/lmdb_store/error.rs
+++ b/infrastructure/storage/src/lmdb_store/error.rs
@@ -21,7 +21,7 @@
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 use thiserror::Error;
 
-#[derive(Error, Debug)]
+#[derive(Error, Debug, Clone)]
 pub enum LMDBError {
     #[error("Cannot create LMDB. The path does not exist")]
     InvalidPath,
@@ -36,4 +36,6 @@ pub enum LMDBError {
         #[from]
         source: lmdb_zero::error::Error,
     },
+    #[error("An LMDB path error contained invalid UTF8: {0}")]
+    PathError(#[from] std::str::Utf8Error),
 }

--- a/infrastructure/storage/src/lmdb_store/mod.rs
+++ b/infrastructure/storage/src/lmdb_store/mod.rs
@@ -28,4 +28,4 @@ pub use lmdb_zero::{
     db,
     traits::{AsLmdbBytes, FromLmdbBytes},
 };
-pub use store::{LMDBBuilder, LMDBDatabase, LMDBStore};
+pub use store::{LMDBBuilder, LMDBConfig, LMDBDatabase, LMDBStore};


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This commit implements the functionality to automatically resize LMDB environment mapsize as it fills up. This should ensure that new data can always be inserted as long as there is disk space available. 

There were a few minor issues fixed: spelling, docs, and removing an unused `use` declaration. 

Thanks to @hansieodendaal for his contributions

## Motivation and Context
Issue #2181 

## How Has This Been Tested?
* [X] Existing tests pass 
* [X] New tests created 
* [X] Tested manually on macOS 
* [ ] Testing on Windows/Linux still required

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [X] Bug fix (non-breaking change which fixes an issue)
* [X] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [X] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [X] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [X] I'm merging against the `development` branch.
* [X] I ran `cargo-fmt --all` before pushing.
* [X] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [X] I have added tests to cover my changes.
