### PR TITLE
Add user-configurable chain monitoring timeout

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3814,7 +3814,7 @@ dependencies = [
  "futures 0.3.5",
  "prost",
  "quote 1.0.7",
- "syn 1.0.38",
+ "syn 1.0.39",
  "tari_comms",
  "tari_test_utils",
  "tokio",

--- a/applications/tari_base_node/src/builder.rs
+++ b/applications/tari_base_node/src/builder.rs
@@ -506,7 +506,8 @@ where
         wallet_subscriptions,
         factories.clone(),
         config.base_node_query_timeout,
-        config.transaction_base_node_monitoring_timeout,
+        config.transaction_broadcast_monitoring_timeout,
+        config.transaction_chain_monitoring_timeout,
         config.transaction_direct_send_timeout,
         config.transaction_broadcast_send_timeout,
         network,
@@ -899,7 +900,8 @@ async fn register_wallet_services(
     subscription_factory: Arc<SubscriptionFactory>,
     factories: CryptoFactories,
     base_node_query_timeout: Duration,
-    base_node_monitoring_timeout: Duration,
+    broadcast_monitoring_timeout: Duration,
+    chain_monitoring_timeout: Duration,
     direct_send_timeout: Duration,
     broadcast_send_timeout: Duration,
     network: NetworkType,
@@ -927,7 +929,8 @@ async fn register_wallet_services(
             network
         ))
         .add_initializer(TransactionServiceInitializer::new(
-            TransactionServiceConfig::new(base_node_monitoring_timeout,
+            TransactionServiceConfig::new(broadcast_monitoring_timeout,
+                                          chain_monitoring_timeout,
                                           direct_send_timeout,
                                           broadcast_send_timeout,),
             subscription_factory,

--- a/base_layer/core/tests/wallet.rs
+++ b/base_layer/core/tests/wallet.rs
@@ -159,7 +159,7 @@ fn wallet_base_node_integration_test() {
         alice_comms_config,
         factories.clone(),
         Some(TransactionServiceConfig {
-            base_node_monitoring_timeout: Duration::from_secs(1),
+            broadcast_monitoring_timeout: Duration::from_secs(1),
             low_power_polling_timeout: Duration::from_secs(10),
             ..Default::default()
         }),

--- a/base_layer/wallet/src/output_manager_service/config.rs
+++ b/base_layer/wallet/src/output_manager_service/config.rs
@@ -43,7 +43,7 @@ impl OutputManagerServiceConfig {
     pub fn new(base_node_query_timeout: Duration) -> Self {
         trace!(
             target: LOG_TARGET,
-            "Timeouts - Base node query: {}s",
+            "Timeouts - Base node query: {} s",
             base_node_query_timeout.as_secs()
         );
         Self {

--- a/base_layer/wallet/src/transaction_service/config.rs
+++ b/base_layer/wallet/src/transaction_service/config.rs
@@ -27,7 +27,8 @@ const LOG_TARGET: &str = "wallet::transaction_service::config";
 
 #[derive(Clone)]
 pub struct TransactionServiceConfig {
-    pub base_node_monitoring_timeout: Duration,
+    pub broadcast_monitoring_timeout: Duration,
+    pub chain_monitoring_timeout: Duration,
     pub direct_send_timeout: Duration,
     pub broadcast_send_timeout: Duration,
     pub low_power_polling_timeout: Duration, /* This is the timeout period that will be used when the wallet is in
@@ -37,7 +38,8 @@ pub struct TransactionServiceConfig {
 impl Default for TransactionServiceConfig {
     fn default() -> Self {
         Self {
-            base_node_monitoring_timeout: Duration::from_secs(30),
+            broadcast_monitoring_timeout: Duration::from_secs(30),
+            chain_monitoring_timeout: Duration::from_secs(30),
             direct_send_timeout: Duration::from_secs(20),
             broadcast_send_timeout: Duration::from_secs(30),
             low_power_polling_timeout: Duration::from_secs(300),
@@ -47,20 +49,23 @@ impl Default for TransactionServiceConfig {
 
 impl TransactionServiceConfig {
     pub fn new(
-        base_node_monitoring_timeout: Duration,
+        broadcast_monitoring_timeout: Duration,
+        chain_monitoring_timeout: Duration,
         direct_send_timeout: Duration,
         broadcast_send_timeout: Duration,
     ) -> Self
     {
         trace!(
             target: LOG_TARGET,
-            "Timeouts - Base node monitoring: {}s, Direct send: {}s, Broadcast send: {}s",
-            base_node_monitoring_timeout.as_secs(),
+            "Timeouts - Broadcast monitoring: {} s, Chain monitoring: {} s, Direct send: {} s, Broadcast send: {} s",
+            broadcast_monitoring_timeout.as_secs(),
+            chain_monitoring_timeout.as_secs(),
             direct_send_timeout.as_secs(),
             broadcast_send_timeout.as_secs(),
         );
         Self {
-            base_node_monitoring_timeout,
+            broadcast_monitoring_timeout,
+            chain_monitoring_timeout,
             direct_send_timeout,
             broadcast_send_timeout,
             ..Default::default()

--- a/base_layer/wallet/src/transaction_service/protocols/transaction_chain_monitoring_protocol.rs
+++ b/base_layer/wallet/src/transaction_service/protocols/transaction_chain_monitoring_protocol.rs
@@ -238,9 +238,20 @@ where TBackend: TransactionBackend + Clone + 'static
                                 "Chain monitoring protocol (Id: {}) timeout updated to {:?}", self.id, self.timeout
                             );
                             break;
+                        } else {
+                            trace!(
+                                target: LOG_TARGET,
+                                "Chain monitoring protocol event 'updated_timeout' triggered (Id: {}) ({:?})",
+                                self.id,
+                                updated_timeout,
+                            );
                         }
                     },
                     () = delay => {
+                        trace!(
+                            target: LOG_TARGET,
+                            "Transaction monitoring event 'time_out' for Mempool broadcast (Id: {}) ", self.id
+                        );
                         break;
                     },
                 }

--- a/base_layer/wallet/src/transaction_service/service.rs
+++ b/base_layer/wallet/src/transaction_service/service.rs
@@ -1027,7 +1027,7 @@ where
             return Err(TransactionServiceError::InvalidCompletedTransaction);
         }
         let timeout = match self.power_mode {
-            PowerMode::Normal => self.config.base_node_monitoring_timeout,
+            PowerMode::Normal => self.config.broadcast_monitoring_timeout,
             PowerMode::Low => self.config.low_power_polling_timeout,
         };
         match self.base_node_public_key.clone() {
@@ -1172,7 +1172,7 @@ where
             return Err(TransactionServiceError::InvalidCompletedTransaction);
         }
         let timeout = match self.power_mode {
-            PowerMode::Normal => self.config.base_node_monitoring_timeout,
+            PowerMode::Normal => self.config.chain_monitoring_timeout,
             PowerMode::Low => self.config.low_power_polling_timeout,
         };
         match self.base_node_public_key.clone() {
@@ -1287,7 +1287,7 @@ where
         self.power_mode = mode;
         let timeout = match mode {
             PowerMode::Low => self.config.low_power_polling_timeout,
-            PowerMode::Normal => self.config.base_node_monitoring_timeout,
+            PowerMode::Normal => self.config.broadcast_monitoring_timeout,
         };
         if let Err(e) = self.timeout_update_publisher.send(timeout) {
             trace!(
@@ -1450,7 +1450,7 @@ where
         };
 
         let timeout = match self.power_mode {
-            PowerMode::Normal => self.config.base_node_monitoring_timeout,
+            PowerMode::Normal => self.config.broadcast_monitoring_timeout,
             PowerMode::Low => self.config.low_power_polling_timeout,
         };
         match self.base_node_public_key.clone() {

--- a/base_layer/wallet/tests/transaction_service/service.rs
+++ b/base_layer/wallet/tests/transaction_service/service.rs
@@ -169,7 +169,7 @@ pub fn setup_transaction_service<T: TransactionBackend + Clone + 'static, P: AsR
         ))
         .add_initializer(TransactionServiceInitializer::new(
             TransactionServiceConfig {
-                base_node_monitoring_timeout: Duration::from_secs(5),
+                broadcast_monitoring_timeout: Duration::from_secs(5),
                 low_power_polling_timeout: Duration::from_secs(20),
                 ..Default::default()
             },
@@ -244,7 +244,7 @@ pub fn setup_transaction_service_no_comms<T: TransactionBackend + Clone + 'stati
 
     let ts_service = TransactionService::new(
         TransactionServiceConfig {
-            base_node_monitoring_timeout: mined_request_timeout.unwrap_or(Duration::from_secs(5)),
+            broadcast_monitoring_timeout: mined_request_timeout.unwrap_or(Duration::from_secs(5)),
             direct_send_timeout: Duration::from_secs(5),
             broadcast_send_timeout: Duration::from_secs(5),
             low_power_polling_timeout: Duration::from_secs(15),

--- a/common/config/presets/windows.toml
+++ b/common/config/presets/windows.toml
@@ -77,8 +77,10 @@ wallet_file = "wallet\\wallet.dat"
 # This is the timeout period that will be used to monitor TXO queries to the base node (default = 30). Larger values
 # are needed for wallets with many (>1000) TXOs to be validated.
 base_node_query_timeout = 120
-# This is the timeout period that will be used for base node monitoring tasks (default = 30)
-#transaction_base_node_monitoring_timeout = 30
+# This is the timeout period that will be used for base node broadcast monitoring tasks (default = 30)
+#transaction_broadcast_monitoring_timeout = 30
+# This is the timeout period that will be used for chain monitoring tasks (default = 30)
+#transaction_chain_monitoring_timeout = 30
 # This is the timeout period that will be used for sending transactions directly (default = 20)
 #transaction_direct_send_timeout = 20
 # This is the timeout period that will be used for sending transactions via broadcast mode (default = 30)

--- a/common/config/tari_config_sample.toml
+++ b/common/config/tari_config_sample.toml
@@ -77,8 +77,10 @@
 # This is the timeout period that will be used to monitor TXO queries to the base node (default = 30). Larger values
 # are needed for wallets with many (>1000) TXOs to be validated.
 base_node_query_timeout = 120
-# This is the timeout period that will be used for base node monitoring tasks (default = 30)
-#transaction_base_node_monitoring_timeout = 30
+# This is the timeout period that will be used for base node broadcast monitoring tasks (default = 30)
+#transaction_broadcast_monitoring_timeout = 30
+# This is the timeout period that will be used for chain monitoring tasks (default = 30)
+#transaction_chain_monitoring_timeout = 30
 # This is the timeout period that will be used for sending transactions directly (default = 20)
 #transaction_direct_send_timeout = 20
 # This is the timeout period that will be used for sending transactions via broadcast mode (default = 30)

--- a/common/src/configuration/global.rs
+++ b/common/src/configuration/global.rs
@@ -69,7 +69,8 @@ pub struct GlobalConfig {
     pub buffer_rate_limit_base_node: usize,
     pub buffer_rate_limit_base_node_wallet: usize,
     pub base_node_query_timeout: Duration,
-    pub transaction_base_node_monitoring_timeout: Duration,
+    pub transaction_broadcast_monitoring_timeout: Duration,
+    pub transaction_chain_monitoring_timeout: Duration,
     pub transaction_direct_send_timeout: Duration,
     pub transaction_broadcast_send_timeout: Duration,
     pub monerod_url: String,
@@ -239,8 +240,14 @@ fn convert_node_config(network: Network, cfg: Config) -> Result<GlobalConfig, Co
             .map_err(|e| ConfigurationError::new(&key, &e.to_string()))? as u64,
     );
 
-    let key = "wallet.transaction_base_node_monitoring_timeout";
-    let transaction_base_node_monitoring_timeout = Duration::from_secs(
+    let key = "wallet.transaction_broadcast_monitoring_timeout";
+    let transaction_broadcast_monitoring_timeout = Duration::from_secs(
+        cfg.get_int(&key)
+            .map_err(|e| ConfigurationError::new(&key, &e.to_string()))? as u64,
+    );
+
+    let key = "wallet.transaction_chain_monitoring_timeout";
+    let transaction_chain_monitoring_timeout = Duration::from_secs(
         cfg.get_int(&key)
             .map_err(|e| ConfigurationError::new(&key, &e.to_string()))? as u64,
     );
@@ -353,7 +360,8 @@ fn convert_node_config(network: Network, cfg: Config) -> Result<GlobalConfig, Co
         buffer_rate_limit_base_node,
         buffer_rate_limit_base_node_wallet,
         base_node_query_timeout,
-        transaction_base_node_monitoring_timeout,
+        transaction_broadcast_monitoring_timeout,
+        transaction_chain_monitoring_timeout,
         transaction_direct_send_timeout,
         transaction_broadcast_send_timeout,
         proxy_host_address,

--- a/common/src/configuration/utils.rs
+++ b/common/src/configuration/utils.rs
@@ -73,7 +73,9 @@ pub fn default_config(bootstrap: &ConfigBootstrap) -> Config {
     )
     .unwrap();
     cfg.set_default("wallet.base_node_query_timeout", 30).unwrap();
-    cfg.set_default("wallet.transaction_base_node_monitoring_timeout", 30)
+    cfg.set_default("wallet.transaction_broadcast_monitoring_timeout", 30)
+        .unwrap();
+    cfg.set_default("wallet.transaction_chain_monitoring_timeout", 30)
         .unwrap();
     cfg.set_default("wallet.transaction_direct_send_timeout", 20).unwrap();
     cfg.set_default("wallet.transaction_broadcast_send_timeout", 30)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Added a user-configurable chain monitoring timeout, to be different from the base node monitoring timeout.

## Motivation and Context
Currently, the timeout used to re-transmit a transaction to the mempool is the same as used to monitor the blockchain if a transaction has been mined. For better control during testing and in operation,  a user-configurable chain monitoring timeout is now added.

## How Has This Been Tested?
Tested in a base node on Windows.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [X] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [X] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [X] I'm merging against the `development` branch.
* [X] I ran `cargo-fmt --all` before pushing.
* [X] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
