### PR TITLE
[Merge Mining] Adjust difficulty

### DIFF
--- a/applications/tari_merge_mining_proxy/build.rs
+++ b/applications/tari_merge_mining_proxy/build.rs
@@ -1,4 +1,0 @@
-fn main() -> Result<(), Box<dyn std::error::Error>> {
-    tonic_build::compile_protos("../tari_app_grpc/proto/base_node.proto")?;
-    Ok(())
-}

--- a/applications/tari_merge_mining_proxy/src/state.rs
+++ b/applications/tari_merge_mining_proxy/src/state.rs
@@ -33,6 +33,9 @@ pub struct SharedState {
 pub struct TransientData {
     pub tari_block: Option<grpc::GetNewBlockResult>,
     pub monero_seed: Option<String>,
+    pub monero_difficulty: Option<u64>,
     pub tari_height: Option<u64>,
+    pub tari_difficulty: Option<u64>,
     pub tari_prev_submit_height: Option<u64>,
+    pub current_difficulty: Option<u64>,
 }


### PR DESCRIPTION
## Description
Selects lowest difficulty between Monero and Tari.
Simulates accept message for XMRig when only submitting to Tari.

## Motivation and Context
Allows XMRig to mine at the lowest difficulty.

## How Has This Been Tested?
Manual testing.

## Types of changes
* [x] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
* [x] I'm merging against the `development` branch.
* [x] I ran `cargo-fmt --all` before pushing.
* [x] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
