### PR TITLE
Prevent simultaneous dial between wallet and base node

### DIFF
--- a/applications/tari_base_node/src/builder.rs
+++ b/applications/tari_base_node/src/builder.rs
@@ -392,11 +392,6 @@ where
         .add_peer(wallet_node_identity.to_peer())
         .await
         .map_err(|err| err.to_string())?;
-    base_node_comms
-        .connectivity()
-        .add_managed_peers(vec![wallet_node_identity.node_id().clone()])
-        .await
-        .map_err(|err| err.to_string())?;
 
     debug!(target: LOG_TARGET, "Registering base node services");
     let base_node_handles = register_base_node_services(
@@ -852,7 +847,7 @@ async fn register_wallet_services(
         .add_initializer(CommsOutboundServiceInitializer::new(wallet_dht.outbound_requester()))
         .add_initializer(LivenessInitializer::new(
             LivenessConfig{
-                auto_ping_interval: None,
+                auto_ping_interval: Some(Duration::from_secs(60)),
                 ..Default::default()
             },
             subscription_factory.clone(),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Removed the wallet as a managed peer from the base node. This prevents
the need to resolve simultaneous dialing within comms. To ensure that
a connection is kept alive between the base node and wallet, the wallet
will send pings periodically (every minute).

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
There have been some reported (rare?) cases of the base node and wallet not being able to establish connections. This PR will either confirm or rule out that simultaneous dial resolution is to blame. In either case, avoiding a simultaneous dial is recommended if it can be helped and results in a quicker connect time.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested on local base node

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch.
* [x] I ran `cargo-fmt --all` before pushing.
* [x] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
