### PR TITLE
WIP Ensure that UTXO sync is performed atomically during horizon sync

### DIFF
--- a/base_layer/core/src/chain_storage/async_db.rs
+++ b/base_layer/core/src/chain_storage/async_db.rs
@@ -23,7 +23,7 @@
 use crate::{
     blocks::{Block, BlockHash, BlockHeader, NewBlockTemplate},
     chain_storage::{
-        blockchain_database::BlockAddResult,
+        blockchain_database::{BlockAddResult, HorizonSyncTxo},
         metadata::ChainMetadata,
         BlockchainBackend,
         BlockchainDatabase,
@@ -102,6 +102,7 @@ make_async!(spend_utxo(hash: HashOutput) -> (), "spend_utxo");
 make_async!(insert_utxo(utxo: TransactionOutput) -> (), "insert_utxo");
 make_async!(is_stxo(hash: HashOutput) -> bool, "is_stxo");
 make_async!(is_utxo(hash: HashOutput) -> bool, "is_utxo");
+make_async!(count_utxos() -> usize, "count_utxos");
 
 //---------------------------------- Headers --------------------------------------------//
 make_async!(fetch_header(block_num: u64) -> BlockHeader, "fetch_header");
@@ -138,5 +139,6 @@ make_async!(horizon_sync_begin() -> InProgressHorizonSyncState, "horizon_sync_be
 make_async!(horizon_sync_commit() -> (), "horizon_sync_commit");
 make_async!(horizon_sync_rollback() -> (), "horizon_sync_rollback");
 make_async!(horizon_sync_insert_kernels(kernels: Vec<TransactionKernel>) -> (), "horizon_sync_insert_kernels");
+make_async!(horizon_sync_insert_txos(txos: Vec<HorizonSyncTxo>) -> (), "horizon_sync_insert_txos");
 make_async!(horizon_sync_spend_utxos(hash: Vec<HashOutput>) -> (), "horizon_sync_spend_utxos");
 make_async!(horizon_sync_create_mmr_checkpoint(tree: MmrTree) -> (), "horizon_sync_create_mmr_checkpoint");

--- a/base_layer/core/src/chain_storage/db_transaction.rs
+++ b/base_layer/core/src/chain_storage/db_transaction.rs
@@ -228,6 +228,8 @@ pub enum DbKeyValuePair {
     UnspentOutput(HashOutput, Box<TransactionOutput>),
     TransactionKernel(HashOutput, Box<TransactionKernel>),
     OrphanBlock(HashOutput, Arc<Block>),
+    /// MMR node to insert. The tuple contains the MMR tree, the leaf hash and the "is deleted" flag (UTXOs only)
+    MmrNode(MmrTree, HashOutput, bool),
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Copy)]

--- a/base_layer/core/src/chain_storage/mod.rs
+++ b/base_layer/core/src/chain_storage/mod.rs
@@ -36,6 +36,7 @@ pub use blockchain_database::{
     BlockchainBackend,
     BlockchainDatabase,
     BlockchainDatabaseConfig,
+    HorizonSyncTxo,
     MutableMmrState,
     Validators,
 };
@@ -53,8 +54,6 @@ pub use db_transaction::{
     MmrTree,
     WriteOperation,
 };
-
-// mod entity;
 
 mod error;
 pub use error::ChainStorageError;

--- a/base_layer/core/src/iterators/chunk.rs
+++ b/base_layer/core/src/iterators/chunk.rs
@@ -101,8 +101,11 @@ edge_chunk_impl!(usize);
 #[cfg(test)]
 mod test {
     use super::*;
+
     #[test]
     fn zero_size() {
+        let mut iter = NonOverlappingIntegerPairIter::new(0u32, 0, 10);
+        assert!(iter.next().is_none());
         let mut iter = NonOverlappingIntegerPairIter::new(10u32, 10, 0);
         assert!(iter.next().is_none());
         let mut iter = VecChunkIter::new(10u32, 10, 0);

--- a/base_layer/mmr/src/merkle_checkpoint.rs
+++ b/base_layer/mmr/src/merkle_checkpoint.rs
@@ -68,14 +68,18 @@ impl MerkleCheckPoint {
     /// count.
     pub fn reset(&mut self) {
         self.prev_accumulated_nodes_added_count = self.accumulated_nodes_added_count();
-        self.nodes_added.clear();
-        self.nodes_deleted = Bitmap::create();
+        self.clear();
     }
 
     /// Resets the current MerkleCheckpoint. The accumulated_nodes_added_count is set to the given `MerkleCheckpoint`s
     /// count.
     pub fn reset_to(&mut self, checkpoint: &Self) {
         self.prev_accumulated_nodes_added_count = checkpoint.accumulated_nodes_added_count();
+        self.clear();
+    }
+
+    /// Clear the contents of this checkpoint without updating the previous accumulated nodes added count.
+    pub fn clear(&mut self) {
         self.nodes_added.clear();
         self.nodes_deleted = Bitmap::create();
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
WIP: More tests are needed
- Added `horizon_sync_insert_txos` to `BlockchainDatabase` to allow an
atomic ordered bulk insert of spent TXO MMR nodes and UTXOs.
- Update node state info while horizon sync is in progress (fixes #2195)
- Added `DbKeyValuePair::MmrNode` to allow txo mmr hashes to be added to
  the in-memory checkpoint as part of a transaction. The checkpoint is
  committed in the final operation in the transaction. Alternatively, if
  the transaction fails the in-memory checkpoint is cleared.
- Added a missing conditional in UTXO sync that exits early if already
  synced.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
It should be impossible for the MMRs and UTXO / kernel / rangeproof databases to be out of sync. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
WIP tests :/

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch.
* [x] I ran `cargo-fmt --all` before pushing.
* [x] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
