### PR TITLE
Refactor Tokio runtime out of wallet container

### DIFF
--- a/applications/tari_console_wallet/src/ui/mod.rs
+++ b/applications/tari_console_wallet/src/ui/mod.rs
@@ -53,15 +53,15 @@ use tui::{backend::CrosstermBackend, Terminal};
 
 const MAX_WIDTH: u16 = 133;
 
-pub async fn run(app: App<CrosstermBackend<Stdout>>) -> Result<(), ExitCodes> {
+pub fn run(app: App<CrosstermBackend<Stdout>>) -> Result<(), ExitCodes> {
     let mut app = app;
-    app.refresh_state()
-        .await
+    Handle::current()
+        .block_on(app.refresh_state())
         .map_err(|e| ExitCodes::WalletError(e.to_string()))?;
     crossterm_loop(app)
 }
 /// This is the main loop of the application UI using Crossterm based events
-pub fn crossterm_loop(app: App<CrosstermBackend<Stdout>>) -> Result<(), ExitCodes> {
+fn crossterm_loop(app: App<CrosstermBackend<Stdout>>) -> Result<(), ExitCodes> {
     let mut app = app;
     let events = CrosstermEvents::new();
     enable_raw_mode().map_err(|e| {

--- a/base_layer/wallet/src/lib.rs
+++ b/base_layer/wallet/src/lib.rs
@@ -16,8 +16,6 @@ pub mod wallet;
 #[cfg(feature = "test_harness")]
 pub mod testnet_utils;
 
-pub use wallet::Wallet;
-
 #[macro_use]
 extern crate diesel;
 #[macro_use]
@@ -27,3 +25,18 @@ extern crate lazy_static;
 
 pub mod schema;
 // pub mod text_message_service;
+
+pub use wallet::Wallet;
+
+use crate::{
+    contacts_service::storage::sqlite_db::ContactsServiceSqliteDatabase,
+    output_manager_service::storage::sqlite_db::OutputManagerSqliteDatabase,
+    storage::sqlite_db::WalletSqliteDatabase,
+    transaction_service::storage::sqlite_db::TransactionServiceSqliteDatabase,
+};
+pub type WalletSqlite = Wallet<
+    WalletSqliteDatabase,
+    TransactionServiceSqliteDatabase,
+    OutputManagerSqliteDatabase,
+    ContactsServiceSqliteDatabase,
+>;

--- a/base_layer/wallet/src/testnet_utils.rs
+++ b/base_layer/wallet/src/testnet_utils.rs
@@ -48,7 +48,6 @@ use std::{
     iter,
     path::{Path, PathBuf},
     sync::Arc,
-    thread,
     time::Duration,
 };
 use tari_comms::{
@@ -72,7 +71,7 @@ use tari_crypto::{
     tari_utilities::hex::Hex,
 };
 use tari_p2p::{initialization::CommsConfig, transport::TransportType};
-use tokio::{runtime::Runtime, time::delay_for};
+use tokio::time::delay_for;
 
 // Used to generate test wallet data
 
@@ -114,13 +113,12 @@ pub fn random_string(len: usize) -> String {
 }
 
 /// Create a wallet for testing purposes
-pub fn create_wallet(
+pub async fn create_wallet(
     secret_key: CommsSecretKey,
     public_address: Multiaddr,
     datastore_path: PathBuf,
 ) -> Wallet<WalletMemoryDatabase, TransactionMemoryDatabase, OutputManagerMemoryDatabase, ContactsServiceMemoryDatabase>
 {
-    let runtime = Runtime::new().unwrap();
     let factories = CryptoFactories::default();
 
     let node_identity = Arc::new(
@@ -150,12 +148,12 @@ pub fn create_wallet(
 
     Wallet::new(
         config,
-        runtime,
         WalletMemoryDatabase::new(),
         TransactionMemoryDatabase::new(),
         OutputManagerMemoryDatabase::new(),
         ContactsServiceMemoryDatabase::new(),
     )
+    .await
     .expect("Could not create Wallet")
 }
 
@@ -165,7 +163,7 @@ pub fn get_next_memory_address() -> Multiaddr {
 }
 
 /// This function will generate a set of test data for the supplied wallet. Takes a few seconds to complete
-pub fn generate_wallet_test_data<
+pub async fn generate_wallet_test_data<
     T: WalletBackend,
     U: TransactionBackend + Clone,
     V: OutputManagerBackend + Clone,
@@ -216,16 +214,17 @@ pub fn generate_wallet_test_data<
         let secret_key = CommsSecretKey::from_hex(private_keys[i]).expect("Could not parse hex key");
         let public_key = CommsPublicKey::from_secret_key(&secret_key);
         wallet
-            .runtime
-            .block_on(wallet.contacts_service.upsert_contact(Contact {
+            .contacts_service
+            .upsert_contact(Contact {
                 alias: names[i].to_string(),
                 public_key: public_key.clone(),
-            }))?;
+            })
+            .await?;
 
         let addr = get_next_memory_address();
         generated_contacts.push((secret_key, addr));
     }
-    let contacts = wallet.runtime.block_on(wallet.contacts_service.get_contacts())?;
+    let contacts = wallet.contacts_service.get_contacts().await?;
     assert_eq!(contacts.len(), names.len());
     info!(target: LOG_TARGET, "Added test contacts to wallet");
 
@@ -233,7 +232,7 @@ pub fn generate_wallet_test_data<
     let num_outputs = 75;
     for i in 0..num_outputs {
         let (_ti, uo) = make_input(&mut OsRng.clone(), MicroTari::from(5_000_000 + i * 35_000), &factories);
-        wallet.runtime.block_on(wallet.output_manager_service.add_output(uo))?;
+        wallet.output_manager_service.add_output(uo).await?;
     }
     info!(target: LOG_TARGET, "Added test outputs to wallet");
     // Generate some Tx history
@@ -248,13 +247,12 @@ pub fn generate_wallet_test_data<
         generated_contacts[0].0.clone(),
         generated_contacts[0].1.clone(),
         alice_temp_dir.clone(),
-    );
+    )
+    .await;
     let mut alice_event_stream = wallet_alice.transaction_service.get_event_stream_fused();
     for i in 0..20 {
         let (_ti, uo) = make_input(&mut OsRng.clone(), MicroTari::from(1_500_000 + i * 530_500), &factories);
-        wallet_alice
-            .runtime
-            .block_on(wallet_alice.output_manager_service.add_output(uo))?;
+        wallet_alice.output_manager_service.add_output(uo).await?;
     }
     info!(target: LOG_TARGET, "Alice Wallet created");
     info!(
@@ -268,7 +266,8 @@ pub fn generate_wallet_test_data<
         generated_contacts[1].0.clone(),
         generated_contacts[1].1.clone(),
         bob_temp_dir.clone(),
-    );
+    )
+    .await;
     let mut bob_event_stream = wallet_bob.transaction_service.get_event_stream_fused();
 
     for i in 0..20 {
@@ -277,41 +276,30 @@ pub fn generate_wallet_test_data<
             MicroTari::from(2_000_000 + i * i * 61_050),
             &factories,
         );
-        wallet_bob
-            .runtime
-            .block_on(wallet_bob.output_manager_service.add_output(uo))?;
+        wallet_bob.output_manager_service.add_output(uo).await?;
     }
     info!(target: LOG_TARGET, "Bob Wallet created");
 
     let alice_peer = wallet_alice.comms.node_identity().to_peer();
 
-    wallet
-        .runtime
-        .block_on(wallet.comms.peer_manager().add_peer(alice_peer))?;
+    wallet.comms.peer_manager().add_peer(alice_peer).await?;
 
     let bob_peer = wallet_bob.comms.node_identity().to_peer();
 
-    wallet
-        .runtime
-        .block_on(wallet.comms.peer_manager().add_peer(bob_peer))?;
+    wallet.comms.peer_manager().add_peer(bob_peer).await?;
 
     wallet
-        .runtime
-        .block_on(
-            wallet
-                .comms
-                .connection_manager()
-                .dial_peer(wallet_alice.comms.node_identity().node_id().clone()),
-        )
+        .comms
+        .connection_manager()
+        .dial_peer(wallet_alice.comms.node_identity().node_id().clone())
+        .await
         .unwrap();
+
     wallet
-        .runtime
-        .block_on(
-            wallet
-                .comms
-                .connection_manager()
-                .dial_peer(wallet_bob.comms.node_identity().node_id().clone()),
-        )
+        .comms
+        .connection_manager()
+        .dial_peer(wallet_bob.comms.node_identity().node_id().clone())
+        .await
         .unwrap();
     info!(target: LOG_TARGET, "Starting to execute test transactions");
 
@@ -319,262 +307,293 @@ pub fn generate_wallet_test_data<
     let mut outbound_tx_ids = Vec::new();
 
     // Completed TX
-    let tx_id = wallet.runtime.block_on(wallet.transaction_service.send_transaction(
-        contacts[0].public_key.clone(),
-        MicroTari::from(1_100_000),
-        MicroTari::from(100),
-        messages[message_index].clone(),
-    ))?;
+    let tx_id = wallet
+        .transaction_service
+        .send_transaction(
+            contacts[0].public_key.clone(),
+            MicroTari::from(1_100_000),
+            MicroTari::from(100),
+            messages[message_index].clone(),
+        )
+        .await?;
     outbound_tx_ids.push(tx_id);
     message_index = (message_index + 1) % messages.len();
 
-    let tx_id = wallet.runtime.block_on(wallet.transaction_service.send_transaction(
-        contacts[0].public_key.clone(),
-        MicroTari::from(2_010_500),
-        MicroTari::from(110),
-        messages[message_index].clone(),
-    ))?;
+    let tx_id = wallet
+        .transaction_service
+        .send_transaction(
+            contacts[0].public_key.clone(),
+            MicroTari::from(2_010_500),
+            MicroTari::from(110),
+            messages[message_index].clone(),
+        )
+        .await?;
     outbound_tx_ids.push(tx_id);
     message_index = (message_index + 1) % messages.len();
 
-    wallet_alice.runtime.block_on(async {
-        let mut delay = delay_for(Duration::from_secs(60)).fuse();
-        let mut count = 0;
-        loop {
-            futures::select! {
-                event = alice_event_stream.select_next_some() => {
-                    match &*event.unwrap() {
-                        TransactionEvent::ReceivedTransaction(_) => {
-                            count +=1;
-                        },
-                        TransactionEvent::ReceivedFinalizedTransaction(_) => {
-                            count +=1;
-                        },
-                        _ => (),
-                    }
-                    if count >=4 {
-                        break;
-                    }
-                },
-                () = delay => {
+    let mut delay = delay_for(Duration::from_secs(60)).fuse();
+    let mut count = 0;
+    loop {
+        futures::select! {
+            event = alice_event_stream.select_next_some() => {
+                match &*event.unwrap() {
+                    TransactionEvent::ReceivedTransaction(_) => {
+                        count +=1;
+                    },
+                    TransactionEvent::ReceivedFinalizedTransaction(_) => {
+                        count +=1;
+                    },
+                    _ => (),
+                }
+                if count >=4 {
                     break;
-                },
-            }
+                }
+            },
+            () = delay => {
+                break;
+            },
         }
-        assert!(count >= 4, "Event waiting timed out before receiving expected events 1");
-    });
+    }
+    assert!(count >= 4, "Event waiting timed out before receiving expected events 1");
 
-    wallet.runtime.block_on(wallet.transaction_service.send_transaction(
-        contacts[0].public_key.clone(),
-        MicroTari::from(10_000_000),
-        MicroTari::from(110),
-        messages[message_index].clone(),
-    ))?;
-    message_index = (message_index + 1) % messages.len();
-
-    wallet.runtime.block_on(wallet.transaction_service.send_transaction(
-        contacts[1].public_key.clone(),
-        MicroTari::from(3_441_000),
-        MicroTari::from(105),
-        messages[message_index].clone(),
-    ))?;
+    wallet
+        .transaction_service
+        .send_transaction(
+            contacts[0].public_key.clone(),
+            MicroTari::from(10_000_000),
+            MicroTari::from(110),
+            messages[message_index].clone(),
+        )
+        .await?;
     message_index = (message_index + 1) % messages.len();
 
-    wallet.runtime.block_on(wallet.transaction_service.send_transaction(
-        contacts[1].public_key.clone(),
-        MicroTari::from(14_100_000),
-        MicroTari::from(100),
-        messages[message_index].clone(),
-    ))?;
-    message_index = (message_index + 1) % messages.len();
-    wallet.runtime.block_on(wallet.transaction_service.send_transaction(
-        contacts[0].public_key.clone(),
-        MicroTari::from(22_010_500),
-        MicroTari::from(110),
-        messages[message_index].clone(),
-    ))?;
+    wallet
+        .transaction_service
+        .send_transaction(
+            contacts[1].public_key.clone(),
+            MicroTari::from(3_441_000),
+            MicroTari::from(105),
+            messages[message_index].clone(),
+        )
+        .await?;
     message_index = (message_index + 1) % messages.len();
 
-    wallet.runtime.block_on(wallet.transaction_service.send_transaction(
-        contacts[0].public_key.clone(),
-        MicroTari::from(17_000_000),
-        MicroTari::from(110),
-        messages[message_index].clone(),
-    ))?;
+    wallet
+        .transaction_service
+        .send_transaction(
+            contacts[1].public_key.clone(),
+            MicroTari::from(14_100_000),
+            MicroTari::from(100),
+            messages[message_index].clone(),
+        )
+        .await?;
+    message_index = (message_index + 1) % messages.len();
+    wallet
+        .transaction_service
+        .send_transaction(
+            contacts[0].public_key.clone(),
+            MicroTari::from(22_010_500),
+            MicroTari::from(110),
+            messages[message_index].clone(),
+        )
+        .await?;
     message_index = (message_index + 1) % messages.len();
 
-    wallet.runtime.block_on(wallet.transaction_service.send_transaction(
-        contacts[1].public_key.clone(),
-        MicroTari::from(31_441_000),
-        MicroTari::from(105),
-        messages[message_index].clone(),
-    ))?;
+    wallet
+        .transaction_service
+        .send_transaction(
+            contacts[0].public_key.clone(),
+            MicroTari::from(17_000_000),
+            MicroTari::from(110),
+            messages[message_index].clone(),
+        )
+        .await?;
     message_index = (message_index + 1) % messages.len();
 
-    wallet.runtime.block_on(wallet.transaction_service.send_transaction(
-        contacts[0].public_key.clone(),
-        MicroTari::from(12_100_000),
-        MicroTari::from(100),
-        messages[message_index].clone(),
-    ))?;
+    wallet
+        .transaction_service
+        .send_transaction(
+            contacts[1].public_key.clone(),
+            MicroTari::from(31_441_000),
+            MicroTari::from(105),
+            messages[message_index].clone(),
+        )
+        .await?;
     message_index = (message_index + 1) % messages.len();
-    wallet.runtime.block_on(wallet.transaction_service.send_transaction(
-        contacts[1].public_key.clone(),
-        MicroTari::from(28_010_500),
-        MicroTari::from(110),
-        messages[message_index].clone(),
-    ))?;
+
+    wallet
+        .transaction_service
+        .send_transaction(
+            contacts[0].public_key.clone(),
+            MicroTari::from(12_100_000),
+            MicroTari::from(100),
+            messages[message_index].clone(),
+        )
+        .await?;
+    message_index = (message_index + 1) % messages.len();
+    wallet
+        .transaction_service
+        .send_transaction(
+            contacts[1].public_key.clone(),
+            MicroTari::from(28_010_500),
+            MicroTari::from(110),
+            messages[message_index].clone(),
+        )
+        .await?;
     message_index = (message_index + 1) % messages.len();
 
     // Pending Outbound
-    let _ = wallet.runtime.block_on(wallet.transaction_service.send_transaction(
-        contacts[2].public_key.clone(),
-        MicroTari::from(2_500_000),
-        MicroTari::from(107),
-        messages[message_index].clone(),
-    ));
+    let _ = wallet
+        .transaction_service
+        .send_transaction(
+            contacts[2].public_key.clone(),
+            MicroTari::from(2_500_000),
+            MicroTari::from(107),
+            messages[message_index].clone(),
+        )
+        .await;
     message_index = (message_index + 1) % messages.len();
 
-    let _ = wallet.runtime.block_on(wallet.transaction_service.send_transaction(
-        contacts[3].public_key.clone(),
-        MicroTari::from(3_512_000),
-        MicroTari::from(117),
-        messages[message_index].clone(),
-    ));
+    let _ = wallet
+        .transaction_service
+        .send_transaction(
+            contacts[3].public_key.clone(),
+            MicroTari::from(3_512_000),
+            MicroTari::from(117),
+            messages[message_index].clone(),
+        )
+        .await;
     message_index = (message_index + 1) % messages.len();
 
-    wallet.runtime.block_on(async {
-        let mut delay = delay_for(Duration::from_secs(60)).fuse();
-        let mut count = 0;
-        loop {
-            futures::select! {
-                event = wallet_event_stream.select_next_some() => {
-                    match &*event.unwrap() {
-                        TransactionEvent::TransactionDirectSendResult(_,_) => {
-                            count+=1;
-                            if count >= 10 {
-                                break;
-                            }
-                        },
-                        _ => (),
-                    }
-                },
-                () = delay => {
-                    break;
-                },
-            }
+    let mut delay = delay_for(Duration::from_secs(60)).fuse();
+    let mut count = 0;
+    loop {
+        futures::select! {
+            event = wallet_event_stream.select_next_some() => {
+                match &*event.unwrap() {
+                    TransactionEvent::TransactionDirectSendResult(_,_) => {
+                        count+=1;
+                        if count >= 10 {
+                            break;
+                        }
+                    },
+                    _ => (),
+                }
+            },
+            () = delay => {
+                break;
+            },
         }
-        assert!(
-            count >= 10,
-            "Event waiting timed out before receiving expected events 2"
-        );
-    });
+    }
+    assert!(
+        count >= 10,
+        "Event waiting timed out before receiving expected events 2"
+    );
 
-    wallet_bob.runtime.block_on(async {
-        let mut delay = delay_for(Duration::from_secs(60)).fuse();
-        let mut count = 0;
-        loop {
-            futures::select! {
-                event = bob_event_stream.select_next_some() => {
-                    match &*event.unwrap() {
-                        TransactionEvent::ReceivedTransaction(_) => {
-                            count+=1;
-                        },
-                        TransactionEvent::ReceivedFinalizedTransaction(_) => {
-                            count+=1;
-                        },
-                        _ => (),
-                    }
-                    if count >= 8 {
-                        break;
-                    }
-                },
-                () = delay => {
+    let mut delay = delay_for(Duration::from_secs(60)).fuse();
+    let mut count = 0;
+    loop {
+        futures::select! {
+            event = bob_event_stream.select_next_some() => {
+                match &*event.unwrap() {
+                    TransactionEvent::ReceivedTransaction(_) => {
+                        count+=1;
+                    },
+                    TransactionEvent::ReceivedFinalizedTransaction(_) => {
+                        count+=1;
+                    },
+                    _ => (),
+                }
+                if count >= 8 {
                     break;
-                },
-            }
+                }
+            },
+            () = delay => {
+                break;
+            },
         }
-        assert!(count >= 8, "Event waiting timed out before receiving expected events 3");
-    });
+    }
+    assert!(count >= 8, "Event waiting timed out before receiving expected events 3");
+
     log::error!("Inbound Transactions starting");
     // Pending Inbound
     wallet_alice
-        .runtime
-        .block_on(wallet_alice.transaction_service.send_transaction(
+        .transaction_service
+        .send_transaction(
             wallet.comms.node_identity().public_key().clone(),
             MicroTari::from(1_235_000),
             MicroTari::from(117),
             messages[message_index].clone(),
-        ))?;
+        )
+        .await?;
     message_index = (message_index + 1) % messages.len();
 
     wallet_alice
-        .runtime
-        .block_on(wallet_alice.transaction_service.send_transaction(
+        .transaction_service
+        .send_transaction(
             wallet.comms.node_identity().public_key().clone(),
             MicroTari::from(3_500_000),
             MicroTari::from(117),
             messages[message_index].clone(),
-        ))?;
+        )
+        .await?;
     message_index = (message_index + 1) % messages.len();
 
     wallet_alice
-        .runtime
-        .block_on(wallet_alice.transaction_service.send_transaction(
+        .transaction_service
+        .send_transaction(
             wallet.comms.node_identity().public_key().clone(),
             MicroTari::from(2_335_000),
             MicroTari::from(117),
             messages[message_index].clone(),
-        ))?;
+        )
+        .await?;
     message_index = (message_index + 1) % messages.len();
 
     wallet_bob
-        .runtime
-        .block_on(wallet_bob.transaction_service.send_transaction(
+        .transaction_service
+        .send_transaction(
             wallet.comms.node_identity().public_key().clone(),
             MicroTari::from(8_035_000),
             MicroTari::from(117),
             messages[message_index].clone(),
-        ))?;
+        )
+        .await?;
     message_index = (message_index + 1) % messages.len();
 
     wallet_bob
-        .runtime
-        .block_on(wallet_bob.transaction_service.send_transaction(
+        .transaction_service
+        .send_transaction(
             wallet.comms.node_identity().public_key().clone(),
             MicroTari::from(5_135_000),
             MicroTari::from(117),
             messages[message_index].clone(),
-        ))?;
+        )
+        .await?;
 
-    wallet.runtime.block_on(async {
-        let mut delay = delay_for(Duration::from_secs(60)).fuse();
-        let mut count = 0;
-        loop {
-            futures::select! {
-                event = wallet_event_stream.select_next_some() => {
-                    match &*event.unwrap() {
-                        TransactionEvent::ReceivedFinalizedTransaction(_) => {
-                            count+=1;
-                            if count >= 5 {
-                                break;
-                            }
-                        },
-                        _ => (),
-                    }
-                },
-                () = delay => {
-                    break;
-                },
-            }
+    let mut delay = delay_for(Duration::from_secs(60)).fuse();
+    let mut count = 0;
+    loop {
+        futures::select! {
+            event = wallet_event_stream.select_next_some() => {
+                match &*event.unwrap() {
+                    TransactionEvent::ReceivedFinalizedTransaction(_) => {
+                        count+=1;
+                        if count >= 5 {
+                            break;
+                        }
+                    },
+                    _ => (),
+                }
+            },
+            () = delay => {
+                break;
+            },
         }
-        assert!(count >= 5, "Event waiting timed out before receiving expected events 4");
-    });
+    }
+    assert!(count >= 5, "Event waiting timed out before receiving expected events 4");
 
-    let txs = wallet
-        .runtime
-        .block_on(wallet.transaction_service.get_completed_transactions())
-        .unwrap();
+    let txs = wallet.transaction_service.get_completed_transactions().await.unwrap();
 
     let timestamps = vec![
         Utc::now()
@@ -656,25 +675,24 @@ pub fn generate_wallet_test_data<
     }
 
     // Broadcast a tx
+
     wallet
-        .runtime
-        .block_on(
-            wallet
-                .transaction_service
-                .test_broadcast_transaction(outbound_tx_ids[0]),
-        )
+        .transaction_service
+        .test_broadcast_transaction(outbound_tx_ids[0])
+        .await
         .unwrap();
 
     // Mine a tx
     wallet
-        .runtime
-        .block_on(wallet.transaction_service.test_mine_transaction(outbound_tx_ids[1]))
+        .transaction_service
+        .test_mine_transaction(outbound_tx_ids[1])
+        .await
         .unwrap();
 
-    thread::sleep(Duration::from_millis(1000));
+    delay_for(Duration::from_secs(1)).await;
 
-    wallet_alice.shutdown();
-    wallet_bob.shutdown();
+    wallet_alice.shutdown().await;
+    wallet_bob.shutdown().await;
 
     let _ = std::fs::remove_dir_all(&alice_temp_dir);
     let _ = std::fs::remove_dir_all(&bob_temp_dir);
@@ -687,7 +705,7 @@ pub fn generate_wallet_test_data<
 /// This function is only available for testing and development by the client of LibWallet. It simulates a this node,
 /// who sent a transaction out, accepting a reply to the Pending Outbound Transaction. That transaction then becomes a
 /// CompletedTransaction with the Broadcast status indicating it is in a base node Mempool but not yet mined
-pub fn complete_sent_transaction<
+pub async fn complete_sent_transaction<
     T: WalletBackend,
     U: TransactionBackend + Clone,
     V: OutputManagerBackend + Clone,
@@ -697,9 +715,7 @@ pub fn complete_sent_transaction<
     tx_id: TxId,
 ) -> Result<(), WalletError>
 {
-    let pending_outbound_tx = wallet
-        .runtime
-        .block_on(wallet.transaction_service.get_pending_outbound_transactions())?;
+    let pending_outbound_tx = wallet.transaction_service.get_pending_outbound_transactions().await?;
     match pending_outbound_tx.get(&tx_id) {
         Some(p) => {
             let completed_tx: CompletedTransaction = CompletedTransaction::new(
@@ -715,11 +731,11 @@ pub fn complete_sent_transaction<
                 TransactionDirection::Outbound,
                 None,
             );
-            wallet.runtime.block_on(
-                wallet
-                    .transaction_service
-                    .test_complete_pending_transaction(completed_tx),
-            )?;
+
+            wallet
+                .transaction_service
+                .test_complete_pending_transaction(completed_tx)
+                .await?;
         },
         None => {
             return Err(WalletError::WalletStorageError(WalletStorageError::UnexpectedResult(
@@ -733,7 +749,7 @@ pub fn complete_sent_transaction<
 
 /// This function is only available for testing by the client of LibWallet. This function simulates an external
 /// wallet sending a transaction to this wallet which will become a PendingInboundTransaction
-pub fn receive_test_transaction<
+pub async fn receive_test_transaction<
     T: WalletBackend,
     U: TransactionBackend + Clone,
     V: OutputManagerBackend + Clone,
@@ -741,7 +757,7 @@ pub fn receive_test_transaction<
 >(
     wallet: &mut Wallet<T, U, V, W>,
 ) -> Result<(), WalletError> {
-    let contacts = wallet.runtime.block_on(wallet.contacts_service.get_contacts()).unwrap();
+    let contacts = wallet.contacts_service.get_contacts().await.unwrap();
     let (_secret_key, mut public_key): (CommsSecretKey, CommsPublicKey) = PublicKey::random_keypair(&mut OsRng);
 
     if !contacts.is_empty() {
@@ -749,12 +765,13 @@ pub fn receive_test_transaction<
     }
 
     wallet
-        .runtime
-        .block_on(wallet.transaction_service.test_accept_transaction(
+        .transaction_service
+        .test_accept_transaction(
             OsRng.next_u64(),
             MicroTari::from(10_000 + OsRng.next_u64() % 101_000),
             public_key,
-        ))?;
+        )
+        .await?;
 
     Ok(())
 }
@@ -763,7 +780,7 @@ pub fn receive_test_transaction<
 /// who received a prior inbound transaction, accepting the Finalized Completed transaction from the Sender. That
 /// transaction then becomes a CompletedTransaction with the Broadcast status indicating it is in a base node Mempool
 /// but not yet mined
-pub fn finalize_received_transaction<
+pub async fn finalize_received_transaction<
     T: WalletBackend,
     U: TransactionBackend + Clone,
     V: OutputManagerBackend + Clone,
@@ -773,9 +790,7 @@ pub fn finalize_received_transaction<
     tx_id: TxId,
 ) -> Result<(), WalletError>
 {
-    wallet
-        .runtime
-        .block_on(wallet.transaction_service.test_finalize_transaction(tx_id))?;
+    wallet.transaction_service.test_finalize_transaction(tx_id).await?;
 
     Ok(())
 }
@@ -784,7 +799,7 @@ pub fn finalize_received_transaction<
 /// the event when a CompletedTransaction that is in the Complete status is broadcast to the Mempool and its status
 /// moves to Broadcast. After this function is called the status of the CompletedTransaction becomes `Mined` and the
 /// funds that were pending become spent and available respectively.
-pub fn broadcast_transaction<
+pub async fn broadcast_transaction<
     T: WalletBackend,
     U: TransactionBackend + Clone,
     V: OutputManagerBackend + Clone,
@@ -794,9 +809,7 @@ pub fn broadcast_transaction<
     tx_id: TxId,
 ) -> Result<(), WalletError>
 {
-    wallet
-        .runtime
-        .block_on(wallet.transaction_service.test_broadcast_transaction(tx_id))?;
+    wallet.transaction_service.test_broadcast_transaction(tx_id).await?;
 
     Ok(())
 }
@@ -805,7 +818,7 @@ pub fn broadcast_transaction<
 /// the event when a CompletedTransaction that is in the Broadcast status, is in a mempool but not mined, beocmes
 /// mined/confirmed. After this function is called the status of the CompletedTransaction becomes `Mined` and the funds
 /// that were pending become spent and available respectively.
-pub fn mine_transaction<
+pub async fn mine_transaction<
     T: WalletBackend,
     U: TransactionBackend + Clone,
     V: OutputManagerBackend + Clone,
@@ -815,9 +828,7 @@ pub fn mine_transaction<
     tx_id: TxId,
 ) -> Result<(), WalletError>
 {
-    wallet
-        .runtime
-        .block_on(wallet.transaction_service.test_mine_transaction(tx_id))?;
+    wallet.transaction_service.test_mine_transaction(tx_id).await?;
 
     Ok(())
 }

--- a/base_layer/wallet/src/wallet.rs
+++ b/base_layer/wallet/src/wallet.rs
@@ -73,7 +73,7 @@ use tari_p2p::{
     services::comms_outbound::CommsOutboundServiceInitializer,
 };
 use tari_service_framework::StackBuilder;
-use tokio::runtime::Runtime;
+use tokio::runtime;
 
 const LOG_TARGET: &str = "wallet";
 
@@ -124,7 +124,6 @@ where
     pub transaction_service: TransactionServiceHandle,
     pub contacts_service: ContactsServiceHandle,
     pub db: WalletDatabase<T>,
-    pub runtime: Runtime,
     pub factories: CryptoFactories,
     #[cfg(feature = "test_harness")]
     pub transaction_backend: U,
@@ -140,9 +139,8 @@ where
     V: OutputManagerBackend + Clone + 'static,
     W: ContactsBackend + 'static,
 {
-    pub fn new(
+    pub async fn new(
         config: WalletConfig,
-        mut runtime: Runtime,
         wallet_backend: T,
         transaction_backend: U,
         output_manager_backend: V,
@@ -152,28 +150,24 @@ where
         let db = WalletDatabase::new(wallet_backend);
 
         // Persist the Comms Private Key provided to this function
-        runtime.block_on(db.set_comms_secret_key(config.comms_config.node_identity.secret_key().clone()))?;
+        db.set_comms_secret_key(config.comms_config.node_identity.secret_key().clone())
+            .await?;
 
         #[cfg(feature = "test_harness")]
         let transaction_backend_handle = transaction_backend.clone();
 
         let factories = config.factories;
         let (publisher, subscription_factory) =
-            pubsub_connector(runtime.handle().clone(), config.buffer_size, config.rate_limit);
+            pubsub_connector(runtime::Handle::current(), config.buffer_size, config.rate_limit);
         let subscription_factory = Arc::new(subscription_factory);
 
         debug!(target: LOG_TARGET, "Initializing Wallet Comms");
 
-        let (comms, dht) = runtime.block_on(initialize_comms(
-            config.comms_config.clone(),
-            publisher,
-            vec![],
-            Default::default(),
-        ))?;
+        let (comms, dht) = initialize_comms(config.comms_config.clone(), publisher, vec![], Default::default()).await?;
 
         debug!(target: LOG_TARGET, "Wallet Comms Initialized");
 
-        let fut = StackBuilder::new(runtime.handle().clone(), comms.shutdown_signal())
+        let fut = StackBuilder::new(runtime::Handle::current(), comms.shutdown_signal())
             .add_initializer(CommsOutboundServiceInitializer::new(dht.outbound_requester()))
             .add_initializer(OutputManagerServiceInitializer::new(
                 OutputManagerServiceConfig::default(),
@@ -193,8 +187,8 @@ where
             .add_initializer(ContactsServiceInitializer::new(contacts_backend))
             .finish();
 
-        let handles = runtime
-            .block_on(fut)
+        let handles = fut
+            .await
             .map_err(|e| {
                 error!(target: LOG_TARGET, "Error creating Wallet stack: {:?}", e);
                 e
@@ -221,7 +215,6 @@ where
             transaction_service: transaction_service_handle,
             contacts_service: contacts_handle,
             db,
-            runtime,
             factories,
             #[cfg(feature = "test_harness")]
             transaction_backend: transaction_backend_handle,
@@ -233,13 +226,18 @@ where
 
     /// This method consumes the wallet so that the handles are dropped which will result in the services async loops
     /// exiting.
-    pub fn shutdown(mut self) {
-        self.runtime.block_on(self.comms.shutdown());
+    pub async fn shutdown(self) {
+        self.comms.shutdown().await;
     }
 
     /// This function will set the base_node that the wallet uses to broadcast transactions and monitor the blockchain
     /// state
-    pub fn set_base_node_peer(&mut self, public_key: CommsPublicKey, net_address: String) -> Result<(), WalletError> {
+    pub async fn set_base_node_peer(
+        &mut self,
+        public_key: CommsPublicKey,
+        net_address: String,
+    ) -> Result<(), WalletError>
+    {
         let address = net_address.parse::<Multiaddr>()?;
         let peer = Peer::new(
             public_key.clone(),
@@ -251,16 +249,18 @@ where
             String::new(),
         );
 
-        self.runtime
-            .block_on(self.comms.peer_manager().add_peer(peer.clone()))?;
-        self.runtime
-            .block_on(self.comms.connectivity().add_managed_peers(vec![peer.node_id.clone()]))?;
-        self.runtime.block_on(
-            self.transaction_service
-                .set_base_node_public_key(peer.public_key.clone()),
-        )?;
-        self.runtime
-            .block_on(self.output_manager_service.set_base_node_public_key(peer.public_key))?;
+        self.comms.peer_manager().add_peer(peer.clone()).await?;
+        self.comms
+            .connectivity()
+            .add_managed_peers(vec![peer.node_id.clone()])
+            .await?;
+
+        self.transaction_service
+            .set_base_node_public_key(peer.public_key.clone())
+            .await?;
+        self.output_manager_service
+            .set_base_node_public_key(peer.public_key)
+            .await?;
 
         Ok(())
     }
@@ -268,7 +268,7 @@ where
     /// Import an external spendable UTXO into the wallet. The output will be added to the Output Manager and made
     /// spendable. A faux incoming transaction will be created to provide a record of the event. The TxId of the
     /// generated transaction is returned.
-    pub fn import_utxo(
+    pub async fn import_utxo(
         &mut self,
         amount: MicroTari,
         spending_key: &PrivateKey,
@@ -278,14 +278,12 @@ where
     {
         let unblinded_output = UnblindedOutput::new(amount, spending_key.clone(), None);
 
-        self.runtime
-            .block_on(self.output_manager_service.add_output(unblinded_output.clone()))?;
+        self.output_manager_service.add_output(unblinded_output.clone()).await?;
 
-        let tx_id = self.runtime.block_on(self.transaction_service.import_utxo(
-            amount,
-            source_public_key.clone(),
-            message,
-        ))?;
+        let tx_id = self
+            .transaction_service
+            .import_utxo(amount, source_public_key.clone(), message)
+            .await?;
 
         info!(
             target: LOG_TARGET,
@@ -325,18 +323,17 @@ where
 
     /// Have all the wallet components that need to start a sync process with the set base node to confirm the wallets
     /// state is accurately reflected on the blockchain
-    pub fn validate_utxos(&mut self, retries: UtxoValidationRetry) -> Result<u64, WalletError> {
-        self.runtime
-            .block_on(self.store_and_forward_requester.request_saf_messages_from_neighbours())?;
+    pub async fn validate_utxos(&mut self, retries: UtxoValidationRetry) -> Result<u64, WalletError> {
+        self.store_and_forward_requester
+            .request_saf_messages_from_neighbours()
+            .await?;
 
-        let request_key = self
-            .runtime
-            .block_on(self.output_manager_service.validate_utxos(retries))?;
+        let request_key = self.output_manager_service.validate_utxos(retries).await?;
         Ok(request_key)
     }
 
     /// Do a coin split
-    pub fn coin_split(
+    pub async fn coin_split(
         &mut self,
         amount_per_split: MicroTari,
         split_count: usize,
@@ -345,19 +342,17 @@ where
         lock_height: Option<u64>,
     ) -> Result<TxId, WalletError>
     {
-        let coin_split_tx = self.runtime.block_on(self.output_manager_service.create_coin_split(
-            amount_per_split,
-            split_count,
-            fee_per_gram,
-            lock_height,
-        ));
+        let coin_split_tx = self
+            .output_manager_service
+            .create_coin_split(amount_per_split, split_count, fee_per_gram, lock_height)
+            .await;
 
         match coin_split_tx {
             Ok((tx_id, split_tx, amount, fee)) => {
-                let coin_tx = self.runtime.block_on(
-                    self.transaction_service
-                        .submit_transaction(tx_id, split_tx, fee, amount, message),
-                );
+                let coin_tx = self
+                    .transaction_service
+                    .submit_transaction(tx_id, split_tx, fee, amount, message)
+                    .await;
                 match coin_tx {
                     Ok(_) => Ok(tx_id),
                     Err(e) => Err(WalletError::TransactionServiceError(e)),
@@ -369,25 +364,23 @@ where
 
     /// Apply encryption to all the Wallet db backends. The Wallet backend will test if the db's are already encrypted
     /// in which case this will fail.
-    pub fn apply_encryption(&mut self, passphrase: String) -> Result<(), WalletError> {
+    pub async fn apply_encryption(&mut self, passphrase: String) -> Result<(), WalletError> {
         let passphrase_hash = Blake256::new().chain(passphrase.as_bytes()).result().to_vec();
         let key = GenericArray::from_slice(passphrase_hash.as_slice());
         let cipher = Aes256Gcm::new(key);
 
-        self.runtime.block_on(self.db.apply_encryption(cipher.clone()))?;
-        self.runtime
-            .block_on(self.output_manager_service.apply_encryption(cipher.clone()))?;
-        self.runtime
-            .block_on(self.transaction_service.apply_encryption(cipher))?;
+        self.db.apply_encryption(cipher.clone()).await?;
+        self.output_manager_service.apply_encryption(cipher.clone()).await?;
+        self.transaction_service.apply_encryption(cipher).await?;
         Ok(())
     }
 
     /// Remove encryption from all the Wallet db backends. If any backends do not have encryption applied then this will
     /// fail
-    pub fn remove_encryption(&mut self) -> Result<(), WalletError> {
-        self.runtime.block_on(self.db.remove_encryption())?;
-        self.runtime.block_on(self.output_manager_service.remove_encryption())?;
-        self.runtime.block_on(self.transaction_service.remove_encryption())?;
+    pub async fn remove_encryption(&mut self) -> Result<(), WalletError> {
+        self.db.remove_encryption().await?;
+        self.output_manager_service.remove_encryption().await?;
+        self.transaction_service.remove_encryption().await?;
         Ok(())
     }
 }

--- a/base_layer/wallet_ffi/src/lib.rs
+++ b/base_layer/wallet_ffi/src/lib.rs
@@ -193,6 +193,7 @@ use tari_wallet::{
     },
     util::emoji::{emoji_set, EmojiId},
     wallet::WalletConfig,
+    Wallet,
 };
 
 use futures::StreamExt;
@@ -207,13 +208,6 @@ use tari_core::consensus::Network;
 use tokio::runtime::Runtime;
 
 const LOG_TARGET: &str = "wallet_ffi";
-
-pub type TariWallet = tari_wallet::wallet::Wallet<
-    WalletSqliteDatabase,
-    TransactionServiceSqliteDatabase,
-    OutputManagerSqliteDatabase,
-    ContactsServiceSqliteDatabase,
->;
 
 pub type TariTransportType = tari_p2p::transport::TransportType;
 pub type TariPublicKey = tari_comms::types::CommsPublicKey;
@@ -241,6 +235,16 @@ pub struct ByteVector(Vec<c_uchar>); // declared like this so that it can be exp
 pub struct EmojiSet(Vec<ByteVector>);
 
 pub struct TariSeedWords(Vec<String>);
+
+pub struct TariWallet {
+    wallet: tari_wallet::wallet::Wallet<
+        WalletSqliteDatabase,
+        TransactionServiceSqliteDatabase,
+        OutputManagerSqliteDatabase,
+        ContactsServiceSqliteDatabase,
+    >,
+    runtime: Runtime,
+}
 
 /// -------------------------------- Strings ------------------------------------------------ ///
 
@@ -2241,7 +2245,7 @@ pub unsafe extern "C" fn wallet_get_tor_identity(wallet: *const TariWallet, erro
     ptr::swap(error_out, &mut error as *mut c_int);
     let identity_bytes;
     if !wallet.is_null() {
-        let service = (*wallet).comms.hidden_service();
+        let service = (*wallet).wallet.comms.hidden_service();
         match service {
             Some(s) => {
                 let tor_identity = s.tor_identity();
@@ -2697,7 +2701,7 @@ pub unsafe extern "C" fn wallet_create(
             // TODO remove after next TestNet
             transaction_backend.migrate((*config).node_identity.public_key().clone());
 
-            w = TariWallet::new(
+            w = runtime.block_on(Wallet::new(
                 WalletConfig::new(
                     (*config).clone(),
                     factories,
@@ -2707,12 +2711,11 @@ pub unsafe extern "C" fn wallet_create(
                     }),
                     Network::Rincewind,
                 ),
-                runtime,
                 wallet_backend,
                 transaction_backend.clone(),
                 output_manager_backend,
                 contacts_backend,
-            );
+            ));
 
             match w {
                 Ok(w) => {
@@ -2736,9 +2739,11 @@ pub unsafe extern "C" fn wallet_create(
                         callback_saf_messages_received,
                     );
 
-                    w.runtime.spawn(callback_handler.start());
+                    runtime.spawn(callback_handler.start());
 
-                    Box::into_raw(Box::new(w))
+                    let tari_wallet = TariWallet { wallet: w, runtime };
+
+                    Box::into_raw(Box::new(tari_wallet))
                 },
                 Err(e) => {
                     error = LibWalletError::from(e).code;
@@ -2792,9 +2797,9 @@ pub unsafe extern "C" fn wallet_sign_message(
     }
 
     let nonce = TariPrivateKey::random(&mut OsRng);
-    let secret = (*wallet).comms.node_identity().secret_key().clone();
+    let secret = (*wallet).wallet.comms.node_identity().secret_key().clone();
     let message = CStr::from_ptr(msg).to_str().unwrap().to_owned();
-    let signature = (*wallet).sign_message(secret, nonce, &message);
+    let signature = (*wallet).wallet.sign_message(secret, nonce, &message);
 
     match signature {
         Ok(s) => {
@@ -2873,7 +2878,11 @@ pub unsafe extern "C" fn wallet_verify_message_signature(
         Ok(p) => {
             let public_nonce = TariPublicKey::from_hex(hex_keys.get(1).unwrap());
             match public_nonce {
-                Ok(pn) => result = (*wallet).verify_message_signature((*public_key).clone(), pn, p, message),
+                Ok(pn) => {
+                    result = (*wallet)
+                        .wallet
+                        .verify_message_signature((*public_key).clone(), pn, p, message)
+                },
                 Err(e) => {
                     error = LibWalletError::from(e).code;
                     ptr::swap(error_out, &mut error as *mut c_int);
@@ -2932,11 +2941,11 @@ pub unsafe extern "C" fn wallet_test_generate_data(
         return false;
     }
 
-    match generate_wallet_test_data(
-        &mut *wallet,
+    match (*wallet).runtime.block_on(generate_wallet_test_data(
+        &mut (*wallet).wallet,
         datastore_path_string.as_str(),
-        (*wallet).transaction_backend.clone(),
-    ) {
+        (*wallet).wallet.transaction_backend.clone(),
+    )) {
         Ok(_) => true,
         Err(e) => {
             error = LibWalletError::from(e).code;
@@ -2968,7 +2977,10 @@ pub unsafe extern "C" fn wallet_test_receive_transaction(wallet: *mut TariWallet
         ptr::swap(error_out, &mut error as *mut c_int);
         return false;
     }
-    match receive_test_transaction(&mut *wallet) {
+    match (*wallet)
+        .runtime
+        .block_on(receive_test_transaction(&mut (*wallet).wallet))
+    {
         Ok(_) => true,
         Err(e) => {
             error = LibWalletError::from(e).code;
@@ -3012,7 +3024,10 @@ pub unsafe extern "C" fn wallet_test_complete_sent_transaction(
         ptr::swap(error_out, &mut error as *mut c_int);
         return false;
     }
-    match complete_sent_transaction(&mut *wallet, (*tx).tx_id) {
+    match (*wallet)
+        .runtime
+        .block_on(complete_sent_transaction(&mut (*wallet).wallet, (*tx).tx_id))
+    {
         Ok(_) => true,
         Err(e) => {
             error = LibWalletError::from(e).code;
@@ -3051,7 +3066,10 @@ pub unsafe extern "C" fn wallet_test_finalize_received_transaction(
         return false;
     }
 
-    match finalize_received_transaction(&mut *wallet, (*tx).tx_id) {
+    match (*wallet)
+        .runtime
+        .block_on(finalize_received_transaction(&mut (*wallet).wallet, (*tx).tx_id))
+    {
         Ok(_) => true,
         Err(e) => {
             error = LibWalletError::from(e).code;
@@ -3090,7 +3108,10 @@ pub unsafe extern "C" fn wallet_test_broadcast_transaction(
         return false;
     }
 
-    match broadcast_transaction(&mut *wallet, tx_id) {
+    match (*wallet)
+        .runtime
+        .block_on(broadcast_transaction(&mut (*wallet).wallet, tx_id))
+    {
         Ok(_) => true,
         Err(e) => {
             error = LibWalletError::from(e).code;
@@ -3129,7 +3150,10 @@ pub unsafe extern "C" fn wallet_test_mine_transaction(
         ptr::swap(error_out, &mut error as *mut c_int);
         return false;
     }
-    match mine_transaction(&mut *wallet, tx_id) {
+    match (*wallet)
+        .runtime
+        .block_on(mine_transaction(&mut (*wallet).wallet, tx_id))
+    {
         Ok(_) => true,
         Err(e) => {
             error = LibWalletError::from(e).code;
@@ -3184,7 +3208,11 @@ pub unsafe extern "C" fn wallet_add_base_node_peer(
         return false;
     }
 
-    match (*wallet).set_base_node_peer((*public_key).clone(), address_string) {
+    match (*wallet).runtime.block_on(
+        (*wallet)
+            .wallet
+            .set_base_node_peer((*public_key).clone(), address_string),
+    ) {
         Ok(_) => true,
         Err(e) => {
             error = LibWalletError::from(e).code;
@@ -3230,7 +3258,7 @@ pub unsafe extern "C" fn wallet_upsert_contact(
 
     match (*wallet)
         .runtime
-        .block_on((*wallet).contacts_service.upsert_contact((*contact).clone()))
+        .block_on((*wallet).wallet.contacts_service.upsert_contact((*contact).clone()))
     {
         Ok(_) => true,
         Err(e) => {
@@ -3274,10 +3302,12 @@ pub unsafe extern "C" fn wallet_remove_contact(
         return false;
     }
 
-    match (*wallet)
-        .runtime
-        .block_on((*wallet).contacts_service.remove_contact((*contact).public_key.clone()))
-    {
+    match (*wallet).runtime.block_on(
+        (*wallet)
+            .wallet
+            .contacts_service
+            .remove_contact((*contact).public_key.clone()),
+    ) {
         Ok(_) => true,
         Err(e) => {
             error = LibWalletError::from(WalletError::ContactsServiceError(e)).code;
@@ -3311,7 +3341,7 @@ pub unsafe extern "C" fn wallet_get_available_balance(wallet: *mut TariWallet, e
 
     match (*wallet)
         .runtime
-        .block_on((*wallet).output_manager_service.get_balance())
+        .block_on((*wallet).wallet.output_manager_service.get_balance())
     {
         Ok(b) => c_ulonglong::from(b.available_balance),
         Err(e) => {
@@ -3351,7 +3381,7 @@ pub unsafe extern "C" fn wallet_get_pending_incoming_balance(
 
     match (*wallet)
         .runtime
-        .block_on((*wallet).output_manager_service.get_balance())
+        .block_on((*wallet).wallet.output_manager_service.get_balance())
     {
         Ok(b) => c_ulonglong::from(b.pending_incoming_balance),
         Err(e) => {
@@ -3391,7 +3421,7 @@ pub unsafe extern "C" fn wallet_get_pending_outgoing_balance(
 
     match (*wallet)
         .runtime
-        .block_on((*wallet).output_manager_service.get_balance())
+        .block_on((*wallet).wallet.output_manager_service.get_balance())
     {
         Ok(b) => c_ulonglong::from(b.pending_outgoing_balance),
         Err(e) => {
@@ -3452,7 +3482,7 @@ pub unsafe extern "C" fn wallet_send_transaction(
 
     match (*wallet)
         .runtime
-        .block_on((*wallet).transaction_service.send_transaction(
+        .block_on((*wallet).wallet.transaction_service.send_transaction(
             (*dest_public_key).clone(),
             MicroTari::from(amount),
             MicroTari::from(fee_per_gram),
@@ -3491,7 +3521,9 @@ pub unsafe extern "C" fn wallet_get_contacts(wallet: *mut TariWallet, error_out:
         return ptr::null_mut();
     }
 
-    let retrieved_contacts = (*wallet).runtime.block_on((*wallet).contacts_service.get_contacts());
+    let retrieved_contacts = (*wallet)
+        .runtime
+        .block_on((*wallet).wallet.contacts_service.get_contacts());
     match retrieved_contacts {
         Ok(mut retrieved_contacts) => {
             contacts.append(&mut retrieved_contacts);
@@ -3536,7 +3568,7 @@ pub unsafe extern "C" fn wallet_get_completed_transactions(
 
     let completed_transactions = (*wallet)
         .runtime
-        .block_on((*wallet).transaction_service.get_completed_transactions());
+        .block_on((*wallet).wallet.transaction_service.get_completed_transactions());
     match completed_transactions {
         Ok(completed_transactions) => {
             // The frontend specification calls for completed transactions that have not yet been mined to be
@@ -3593,7 +3625,7 @@ pub unsafe extern "C" fn wallet_get_pending_inbound_transactions(
 
     let pending_transactions = (*wallet)
         .runtime
-        .block_on((*wallet).transaction_service.get_pending_inbound_transactions());
+        .block_on((*wallet).wallet.transaction_service.get_pending_inbound_transactions());
 
     match pending_transactions {
         Ok(pending_transactions) => {
@@ -3603,7 +3635,7 @@ pub unsafe extern "C" fn wallet_get_pending_inbound_transactions(
 
             if let Ok(completed_txs) = (*wallet)
                 .runtime
-                .block_on((*wallet).transaction_service.get_completed_transactions())
+                .block_on((*wallet).wallet.transaction_service.get_completed_transactions())
             {
                 // The frontend specification calls for completed transactions that have not yet been mined to be
                 // classified as Pending Transactions. In order to support this logic without impacting the practical
@@ -3661,7 +3693,7 @@ pub unsafe extern "C" fn wallet_get_pending_outbound_transactions(
 
     let pending_transactions = (*wallet)
         .runtime
-        .block_on((*wallet).transaction_service.get_pending_outbound_transactions());
+        .block_on((*wallet).wallet.transaction_service.get_pending_outbound_transactions());
     match pending_transactions {
         Ok(pending_transactions) => {
             for tx in pending_transactions.values() {
@@ -3669,7 +3701,7 @@ pub unsafe extern "C" fn wallet_get_pending_outbound_transactions(
             }
             if let Ok(completed_txs) = (*wallet)
                 .runtime
-                .block_on((*wallet).transaction_service.get_completed_transactions())
+                .block_on((*wallet).wallet.transaction_service.get_completed_transactions())
             {
                 // The frontend specification calls for completed transactions that have not yet been mined to be
                 // classified as Pending Transactions. In order to support this logic without impacting the practical
@@ -3723,10 +3755,12 @@ pub unsafe extern "C" fn wallet_get_cancelled_transactions(
         return ptr::null_mut();
     }
 
-    let completed_transactions = match (*wallet)
-        .runtime
-        .block_on((*wallet).transaction_service.get_cancelled_completed_transactions())
-    {
+    let completed_transactions = match (*wallet).runtime.block_on(
+        (*wallet)
+            .wallet
+            .transaction_service
+            .get_cancelled_completed_transactions(),
+    ) {
         Ok(txs) => txs,
         Err(e) => {
             error = LibWalletError::from(WalletError::TransactionServiceError(e)).code;
@@ -3736,6 +3770,7 @@ pub unsafe extern "C" fn wallet_get_cancelled_transactions(
     };
     let inbound_transactions = match (*wallet).runtime.block_on(
         (*wallet)
+            .wallet
             .transaction_service
             .get_cancelled_pending_inbound_transactions(),
     ) {
@@ -3748,6 +3783,7 @@ pub unsafe extern "C" fn wallet_get_cancelled_transactions(
     };
     let outbound_transactions = match (*wallet).runtime.block_on(
         (*wallet)
+            .wallet
             .transaction_service
             .get_cancelled_pending_outbound_transactions(),
     ) {
@@ -3765,12 +3801,12 @@ pub unsafe extern "C" fn wallet_get_cancelled_transactions(
     }
     for tx in inbound_transactions.values() {
         let mut inbound_tx = CompletedTransaction::from(tx.clone());
-        inbound_tx.destination_public_key = (*wallet).comms.node_identity().public_key().clone();
+        inbound_tx.destination_public_key = (*wallet).wallet.comms.node_identity().public_key().clone();
         completed.push(inbound_tx);
     }
     for tx in outbound_transactions.values() {
         let mut outbound_tx = CompletedTransaction::from(tx.clone());
-        outbound_tx.source_public_key = (*wallet).comms.node_identity().public_key().clone();
+        outbound_tx.source_public_key = (*wallet).wallet.comms.node_identity().public_key().clone();
         completed.push(outbound_tx);
     }
 
@@ -3809,7 +3845,7 @@ pub unsafe extern "C" fn wallet_get_completed_transaction_by_id(
 
     let completed_transactions = (*wallet)
         .runtime
-        .block_on((*wallet).transaction_service.get_completed_transactions());
+        .block_on((*wallet).wallet.transaction_service.get_completed_transactions());
 
     match completed_transactions {
         Ok(completed_transactions) => {
@@ -3863,11 +3899,11 @@ pub unsafe extern "C" fn wallet_get_pending_inbound_transaction_by_id(
 
     let pending_transactions = (*wallet)
         .runtime
-        .block_on((*wallet).transaction_service.get_pending_inbound_transactions());
+        .block_on((*wallet).wallet.transaction_service.get_pending_inbound_transactions());
 
     let completed_transactions = (*wallet)
         .runtime
-        .block_on((*wallet).transaction_service.get_completed_transactions());
+        .block_on((*wallet).wallet.transaction_service.get_completed_transactions());
 
     match completed_transactions {
         Ok(completed_transactions) => {
@@ -3937,11 +3973,11 @@ pub unsafe extern "C" fn wallet_get_pending_outbound_transaction_by_id(
 
     let pending_transactions = (*wallet)
         .runtime
-        .block_on((*wallet).transaction_service.get_pending_outbound_transactions());
+        .block_on((*wallet).wallet.transaction_service.get_pending_outbound_transactions());
 
     let completed_transactions = (*wallet)
         .runtime
-        .block_on((*wallet).transaction_service.get_completed_transactions());
+        .block_on((*wallet).wallet.transaction_service.get_completed_transactions());
 
     match completed_transactions {
         Ok(completed_transactions) => {
@@ -4012,10 +4048,12 @@ pub unsafe extern "C" fn wallet_get_cancelled_transaction_by_id(
 
     let mut transaction = None;
 
-    let mut completed_transactions = match (*wallet)
-        .runtime
-        .block_on((*wallet).transaction_service.get_cancelled_completed_transactions())
-    {
+    let mut completed_transactions = match (*wallet).runtime.block_on(
+        (*wallet)
+            .wallet
+            .transaction_service
+            .get_cancelled_completed_transactions(),
+    ) {
         Ok(txs) => txs,
         Err(e) => {
             error = LibWalletError::from(WalletError::TransactionServiceError(e)).code;
@@ -4029,6 +4067,7 @@ pub unsafe extern "C" fn wallet_get_cancelled_transaction_by_id(
     } else {
         let mut outbound_transactions = match (*wallet).runtime.block_on(
             (*wallet)
+                .wallet
                 .transaction_service
                 .get_cancelled_pending_outbound_transactions(),
         ) {
@@ -4042,11 +4081,12 @@ pub unsafe extern "C" fn wallet_get_cancelled_transaction_by_id(
 
         if let Some(tx) = outbound_transactions.remove(&transaction_id) {
             let mut outbound_tx = CompletedTransaction::from(tx);
-            outbound_tx.source_public_key = (*wallet).comms.node_identity().public_key().clone();
+            outbound_tx.source_public_key = (*wallet).wallet.comms.node_identity().public_key().clone();
             transaction = Some(outbound_tx);
         } else {
             let mut inbound_transactions = match (*wallet).runtime.block_on(
                 (*wallet)
+                    .wallet
                     .transaction_service
                     .get_cancelled_pending_inbound_transactions(),
             ) {
@@ -4059,7 +4099,7 @@ pub unsafe extern "C" fn wallet_get_cancelled_transaction_by_id(
             };
             if let Some(tx) = inbound_transactions.remove(&transaction_id) {
                 let mut inbound_tx = CompletedTransaction::from(tx);
-                inbound_tx.destination_public_key = (*wallet).comms.node_identity().public_key().clone();
+                inbound_tx.destination_public_key = (*wallet).wallet.comms.node_identity().public_key().clone();
                 transaction = Some(inbound_tx);
             }
         }
@@ -4103,7 +4143,7 @@ pub unsafe extern "C" fn wallet_get_public_key(wallet: *mut TariWallet, error_ou
         ptr::swap(error_out, &mut error as *mut c_int);
         return ptr::null_mut();
     }
-    let pk = (*wallet).comms.node_identity().public_key().clone();
+    let pk = (*wallet).wallet.comms.node_identity().public_key().clone();
     Box::into_raw(Box::new(pk))
 }
 
@@ -4163,12 +4203,12 @@ pub unsafe extern "C" fn wallet_import_utxo(
         CString::new("Imported UTXO").unwrap().to_str().unwrap().to_owned()
     };
 
-    match (*wallet).import_utxo(
+    match (*wallet).runtime.block_on((*wallet).wallet.import_utxo(
         MicroTari::from(amount),
         &(*spending_key).clone(),
         &(*source_public_key).clone(),
         message_string,
-    ) {
+    )) {
         Ok(tx_id) => tx_id,
         Err(e) => {
             error = LibWalletError::from(e).code;
@@ -4208,7 +4248,7 @@ pub unsafe extern "C" fn wallet_cancel_pending_transaction(
 
     match (*wallet)
         .runtime
-        .block_on((*wallet).transaction_service.cancel_transaction(transaction_id))
+        .block_on((*wallet).wallet.transaction_service.cancel_transaction(transaction_id))
     {
         Ok(_) => true,
         Err(e) => {
@@ -4244,7 +4284,10 @@ pub unsafe extern "C" fn wallet_sync_with_base_node(wallet: *mut TariWallet, err
         return 0;
     }
 
-    match (*wallet).validate_utxos(UtxoValidationRetry::Limited(1)) {
+    match (*wallet)
+        .runtime
+        .block_on((*wallet).wallet.validate_utxos(UtxoValidationRetry::Limited(1)))
+    {
         Ok(request_key) => request_key,
         Err(e) => {
             error = LibWalletError::from(e).code;
@@ -4295,13 +4338,13 @@ pub unsafe extern "C" fn wallet_coin_split(
         "Coin Split".to_string()
     };
 
-    match (*wallet).coin_split(
+    match (*wallet).runtime.block_on((*wallet).wallet.coin_split(
         MicroTari(amount),
         count as usize,
         MicroTari(fee),
         message,
         Some(lock_height),
-    ) {
+    )) {
         Ok(request_key) => request_key,
         Err(e) => {
             error = LibWalletError::from(e).code;
@@ -4336,7 +4379,7 @@ pub unsafe extern "C" fn wallet_get_seed_words(wallet: *mut TariWallet, error_ou
 
     match (*wallet)
         .runtime
-        .block_on((*wallet).output_manager_service.get_seed_words())
+        .block_on((*wallet).wallet.output_manager_service.get_seed_words())
     {
         Ok(sw) => Box::into_raw(Box::new(TariSeedWords(sw))),
         Err(e) => {
@@ -4368,7 +4411,7 @@ pub unsafe extern "C" fn wallet_set_low_power_mode(wallet: *mut TariWallet, erro
 
     if let Err(e) = (*wallet)
         .runtime
-        .block_on((*wallet).transaction_service.set_low_power_mode())
+        .block_on((*wallet).wallet.transaction_service.set_low_power_mode())
     {
         error = LibWalletError::from(WalletError::TransactionServiceError(e)).code;
         ptr::swap(error_out, &mut error as *mut c_int);
@@ -4395,7 +4438,7 @@ pub unsafe extern "C" fn wallet_set_normal_power_mode(wallet: *mut TariWallet, e
 
     if let Err(e) = (*wallet)
         .runtime
-        .block_on((*wallet).transaction_service.set_normal_power_mode())
+        .block_on((*wallet).wallet.transaction_service.set_normal_power_mode())
     {
         error = LibWalletError::from(WalletError::TransactionServiceError(e)).code;
         ptr::swap(error_out, &mut error as *mut c_int);
@@ -4439,7 +4482,7 @@ pub unsafe extern "C" fn wallet_apply_encryption(
         .expect("A non-null passphrase should be able to be converted to string")
         .to_owned();
 
-    if let Err(e) = (*wallet).apply_encryption(pf) {
+    if let Err(e) = (*wallet).runtime.block_on((*wallet).wallet.apply_encryption(pf)) {
         error = LibWalletError::from(e).code;
         ptr::swap(error_out, &mut error as *mut c_int);
     }
@@ -4464,7 +4507,7 @@ pub unsafe extern "C" fn wallet_remove_encryption(wallet: *mut TariWallet, error
         return;
     }
 
-    if let Err(e) = (*wallet).remove_encryption() {
+    if let Err(e) = (*wallet).runtime.block_on((*wallet).wallet.remove_encryption()) {
         error = LibWalletError::from(e).code;
         ptr::swap(error_out, &mut error as *mut c_int);
     }
@@ -4644,8 +4687,8 @@ pub unsafe extern "C" fn emoji_set_destroy(emoji_set: *mut EmojiSet) {
 #[no_mangle]
 pub unsafe extern "C" fn wallet_destroy(wallet: *mut TariWallet) {
     if !wallet.is_null() {
-        let m = Box::from_raw(wallet);
-        m.shutdown();
+        let mut m = Box::from_raw(wallet);
+        m.runtime.block_on(m.wallet.shutdown());
     }
 }
 
@@ -5308,7 +5351,12 @@ mod test {
                 tari_wallet::transaction_service::storage::database::InboundTransaction,
             > = (*alice_wallet)
                 .runtime
-                .block_on((*alice_wallet).transaction_service.get_pending_inbound_transactions())
+                .block_on(
+                    (*alice_wallet)
+                        .wallet
+                        .transaction_service
+                        .get_pending_inbound_transactions(),
+                )
                 .unwrap();
 
             assert_eq!(inbound_transactions.len(), 0);
@@ -5324,7 +5372,12 @@ mod test {
                 tari_wallet::transaction_service::storage::database::InboundTransaction,
             > = (*alice_wallet)
                 .runtime
-                .block_on((*alice_wallet).transaction_service.get_pending_inbound_transactions())
+                .block_on(
+                    (*alice_wallet)
+                        .wallet
+                        .transaction_service
+                        .get_pending_inbound_transactions(),
+                )
                 .unwrap();
 
             assert_eq!(inbound_transactions.len(), 1);
@@ -5364,7 +5417,7 @@ mod test {
                 tari_wallet::transaction_service::storage::database::CompletedTransaction,
             > = (*alice_wallet)
                 .runtime
-                .block_on((*alice_wallet).transaction_service.get_completed_transactions())
+                .block_on((*alice_wallet).wallet.transaction_service.get_completed_transactions())
                 .unwrap();
 
             let num_completed_tx_pre = completed_transactions.len();
@@ -5380,7 +5433,7 @@ mod test {
                 tari_wallet::transaction_service::storage::database::CompletedTransaction,
             > = (*alice_wallet)
                 .runtime
-                .block_on((*alice_wallet).transaction_service.get_completed_transactions())
+                .block_on((*alice_wallet).wallet.transaction_service.get_completed_transactions())
                 .unwrap();
 
             assert_eq!(num_completed_tx_pre + 1, completed_transactions.len());
@@ -5433,7 +5486,7 @@ mod test {
                 tari_wallet::transaction_service::storage::database::CompletedTransaction,
             > = (*alice_wallet)
                 .runtime
-                .block_on((*alice_wallet).transaction_service.get_completed_transactions())
+                .block_on((*alice_wallet).wallet.transaction_service.get_completed_transactions())
                 .unwrap();
             for (_k, v) in completed_transactions {
                 if v.status == TransactionStatus::Completed {
@@ -5455,7 +5508,7 @@ mod test {
 
             let pre_balance = (*alice_wallet)
                 .runtime
-                .block_on((*alice_wallet).output_manager_service.get_balance())
+                .block_on((*alice_wallet).wallet.output_manager_service.get_balance())
                 .unwrap();
 
             let secret_key_base_node = private_key_generate();
@@ -5474,7 +5527,7 @@ mod test {
 
             let post_balance = (*alice_wallet)
                 .runtime
-                .block_on((*alice_wallet).output_manager_service.get_balance())
+                .block_on((*alice_wallet).wallet.output_manager_service.get_balance())
                 .unwrap();
 
             assert_eq!(
@@ -5484,7 +5537,7 @@ mod test {
 
             let import_transaction = (*alice_wallet)
                 .runtime
-                .block_on((*alice_wallet).transaction_service.get_completed_transactions())
+                .block_on((*alice_wallet).wallet.transaction_service.get_completed_transactions())
                 .unwrap()
                 .remove(&utxo_tx_id)
                 .expect("Tx should be in collection");
@@ -5500,9 +5553,10 @@ mod test {
                 .runtime
                 .block_on(
                     (*alice_wallet)
+                        .wallet
                         .comms
                         .connection_manager()
-                        .dial_peer((*bob_wallet).comms.node_identity().node_id().clone()),
+                        .dial_peer((*bob_wallet).wallet.comms.node_identity().node_id().clone()),
                 )
                 .unwrap();
             assert!(wallet_sync_with_base_node(alice_wallet, error_ptr) > 0);
@@ -5519,7 +5573,12 @@ mod test {
 
             let inbound_txs = (*alice_wallet)
                 .runtime
-                .block_on((*alice_wallet).transaction_service.get_pending_inbound_transactions())
+                .block_on(
+                    (*alice_wallet)
+                        .wallet
+                        .transaction_service
+                        .get_pending_inbound_transactions(),
+                )
                 .unwrap();
 
             let mut inbound_tx_id = 0;
@@ -5532,7 +5591,7 @@ mod test {
 
                 (*alice_wallet)
                     .runtime
-                    .block_on(async { (*alice_wallet).transaction_service.cancel_transaction(k).await })
+                    .block_on(async { (*alice_wallet).wallet.transaction_service.cancel_transaction(k).await })
                     .unwrap();
 
                 let inbound_tx = wallet_get_cancelled_transaction_by_id(&mut (*alice_wallet), inbound_tx_id, error_ptr);
@@ -5558,7 +5617,9 @@ mod test {
             let cancelled_tx = completed_transactions_get_at(ffi_cancelled_txs, 0, error_ptr);
             let tx_id = completed_transaction_get_transaction_id(cancelled_tx, error_ptr);
             let dest_pubkey = completed_transaction_get_destination_public_key(cancelled_tx, error_ptr);
-            let pub_key_ptr = Box::into_raw(Box::new((*alice_wallet).comms.node_identity().public_key().clone()));
+            let pub_key_ptr = Box::into_raw(Box::new(
+                (*alice_wallet).wallet.comms.node_identity().public_key().clone(),
+            ));
             assert_eq!(tx_id, inbound_tx_id);
             assert_eq!(*dest_pubkey, *pub_key_ptr);
             public_key_destroy(pub_key_ptr);
@@ -5571,6 +5632,7 @@ mod test {
             assert_eq!(error, 0);
             let split_tx = (*alice_wallet).runtime.block_on(
                 (*alice_wallet)
+                    .wallet
                     .transaction_service
                     .get_completed_transaction(split_tx_id),
             );


### PR DESCRIPTION
## Description
Currently the wallet container in LibWallet holds the tokio runtime required by the wallet. This was done to enable the Wallet FFI library to function as the FFI wallet object needed to hold onto the runtime or else it would be dropped. However it is only needed for the FFI instance of the wallet and interferes with the standard way of managing the runtime in the other binary applications.

This PR removes the runtime from the wallet container in `tari_wallet` and creates a FFI specific TariWallet container which holds onto the runtime instance just for the FFI library.

## How Has This Been Tested?
Existing tests

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [x] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch.
* [x] I ran `cargo-fmt --all` before pushing.
* [ ] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
