### PR TITLE
Protect against possible panics in header/horizon sync

### DIFF
--- a/base_layer/core/src/base_node/state_machine_service/states/horizon_state_sync/state_sync.rs
+++ b/base_layer/core/src/base_node/state_machine_service/states/horizon_state_sync/state_sync.rs
@@ -392,6 +392,12 @@ impl<B: BlockchainBackend + 'static> HorizonStateSynchronization<'_, '_, '_, B> 
             config.max_sync_request_retry_attempts,
         )
         .await?;
+
+        if local_num_utxo_nodes >= remote_num_utxo_nodes {
+            debug!(target: LOG_TARGET, "UTXOs and range proofs are already synchronized.");
+            return Ok(());
+        }
+
         debug!(
             target: LOG_TARGET,
             "Synchronizing {} UTXO MMR nodes from {} to {}",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Added two missing checks in the header sync and horizon sync.
These checks exit early if the headers/utxo set is aready synchonized or
is ahead of the peer. Previously if this case occurred, the counter iterator
would panic (start > end is invalid).

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Remove the possibility of a failed assertion (panic) in the base node.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Header sync tested with base node.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch.
* [x] I ran `cargo-fmt --all` before pushing.
* [x] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
