### PR TITLE
update default config with stress test values

### DIFF
--- a/common/src/configuration/utils.rs
+++ b/common/src/configuration/utils.rs
@@ -58,10 +58,10 @@ pub fn default_config(bootstrap: &ConfigBootstrap) -> Config {
     )
     .unwrap();
     cfg.set_default("common.denylist_ban_period", 1440).unwrap();
-    cfg.set_default("common.buffer_size_base_node", 100).unwrap();
-    cfg.set_default("common.buffer_size_base_node_wallet", 1000).unwrap();
-    cfg.set_default("common.buffer_rate_limit_base_node", 20).unwrap();
-    cfg.set_default("common.buffer_rate_limit_base_node_wallet", 20)
+    cfg.set_default("common.buffer_size_base_node", 1_500).unwrap();
+    cfg.set_default("common.buffer_size_base_node_wallet", 50_000).unwrap();
+    cfg.set_default("common.buffer_rate_limit_base_node", 1_000).unwrap();
+    cfg.set_default("common.buffer_rate_limit_base_node_wallet", 1_000)
         .unwrap();
 
     // Wallet settings
@@ -72,13 +72,13 @@ pub fn default_config(bootstrap: &ConfigBootstrap) -> Config {
         default_subdir("wallet/wallet.dat", Some(&bootstrap.base_path)),
     )
     .unwrap();
-    cfg.set_default("wallet.base_node_query_timeout", 30).unwrap();
-    cfg.set_default("wallet.transaction_broadcast_monitoring_timeout", 30)
+    cfg.set_default("wallet.base_node_query_timeout", 900).unwrap();
+    cfg.set_default("wallet.transaction_broadcast_monitoring_timeout", 600)
         .unwrap();
-    cfg.set_default("wallet.transaction_chain_monitoring_timeout", 30)
+    cfg.set_default("wallet.transaction_chain_monitoring_timeout", 15)
         .unwrap();
-    cfg.set_default("wallet.transaction_direct_send_timeout", 20).unwrap();
-    cfg.set_default("wallet.transaction_broadcast_send_timeout", 30)
+    cfg.set_default("wallet.transaction_direct_send_timeout", 600).unwrap();
+    cfg.set_default("wallet.transaction_broadcast_send_timeout", 600)
         .unwrap();
 
     //---------------------------------- Mainnet Defaults --------------------------------------------//


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
We've been using these config values for the stress tests, which means we probably want base nodes to use these by default

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Bigger buffers for base node and base node wallet, higher rate limits for the same buffers. Higher base node query timeout, tx broadcasting timeout, shorter tx chain monitoring timeout (@hansieodendaal is this right, 15 instead of 30?) , higher tx direct and broadcast send timeouts. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Default values are updated if not overwritten from config.toml

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [X] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [X] I'm merging against the `development` branch.
* [X] I ran `cargo-fmt --all` before pushing.
* [X] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
