### PR TITLE
Propagate block hashes to all connected nodes

### DIFF
--- a/base_layer/core/src/base_node/service/service.rs
+++ b/base_layer/core/src/base_node/service/service.rs
@@ -630,7 +630,7 @@ async fn handle_outbound_block(
 ) -> Result<(), CommsInterfaceError>
 {
     outbound_message_service
-        .propagate(
+        .flood(
             NodeDestination::Unknown,
             OutboundEncryption::None,
             exclude_peers,

--- a/base_layer/core/src/proof_of_work/monero_rx.rs
+++ b/base_layer/core/src/proof_of_work/monero_rx.rs
@@ -395,7 +395,7 @@ mod test {
         for item in block.clone().tx_hashes {
             hashes.push(item);
         }
-        let mut root = tree_hash(&hashes).unwrap(); // tree_hash.c used by monero
+        let root = tree_hash(&hashes).unwrap();
         let mut encode2 = header;
         encode2.extend_from_slice(root.as_bytes());
         encode2.append(&mut count);

--- a/comms/dht/src/actor.rs
+++ b/comms/dht/src/actor.rs
@@ -393,11 +393,11 @@ impl DhtActor {
                     .map(|peer| peer.map(|p| vec![p.node_id]).unwrap_or_default())
                     .map_err(Into::into)
             },
-            Flood => {
-                // Send to all known peers
-                // TODO: This should never be needed, remove
-                let peers = peer_manager.flood_peers().await?;
-                Ok(peers.into_iter().map(|p| p.node_id).collect())
+            Flood(exclude) => {
+                let peers = connectivity
+                    .select_connections(ConnectivitySelection::all_nodes(exclude))
+                    .await?;
+                Ok(peers.into_iter().map(|p| p.peer_node_id().clone()).collect())
             },
             Closest(closest_request) => {
                 let candidates = if closest_request.connected_only {

--- a/comms/dht/src/outbound/broadcast.rs
+++ b/comms/dht/src/outbound/broadcast.rs
@@ -271,7 +271,7 @@ where S: Service<DhtOutboundMessage, Response = (), Error = PipelineError>
                     is_discovery_enabled,
                 );
 
-                let is_broadcast = broadcast_strategy.is_broadcast();
+                let is_broadcast = broadcast_strategy.is_multi_message();
 
                 // Discovery is required if:
                 //  - Discovery is enabled for this request
@@ -585,7 +585,7 @@ mod test {
 
         service
             .call(DhtOutboundRequest::SendMessage(
-                Box::new(SendMessageParams::new().flood().finish()),
+                Box::new(SendMessageParams::new().flood(vec![]).finish()),
                 "custom_msg".as_bytes().into(),
                 reply_tx,
             ))

--- a/comms/dht/src/outbound/message_params.rs
+++ b/comms/dht/src/outbound/message_params.rs
@@ -71,7 +71,7 @@ pub struct FinalSendMessageParams {
 impl Default for FinalSendMessageParams {
     fn default() -> Self {
         Self {
-            broadcast_strategy: BroadcastStrategy::Flood,
+            broadcast_strategy: BroadcastStrategy::Flood(Default::default()),
             destination: Default::default(),
             encryption: Default::default(),
             dht_message_type: Default::default(),
@@ -146,8 +146,8 @@ impl SendMessageParams {
     }
 
     /// Set broadcast_strategy to Flood
-    pub fn flood(&mut self) -> &mut Self {
-        self.params_mut().broadcast_strategy = BroadcastStrategy::Flood;
+    pub fn flood(&mut self, excluded: Vec<NodeId>) -> &mut Self {
+        self.params_mut().broadcast_strategy = BroadcastStrategy::Flood(excluded);
         self
     }
 

--- a/comms/dht/src/outbound/requester.rs
+++ b/comms/dht/src/outbound/requester.rs
@@ -150,14 +150,12 @@ impl OutboundMessageRequester {
         .map_err(Into::into)
     }
 
-    /// Send to _ALL_ known peers.
-    ///
-    /// This should be used with caution as, depending on the number of known peers, a lot of network
-    /// traffic could be generated from this node.
-    pub async fn send_flood<T>(
+    /// Send to all _connected_ peers.
+    pub async fn flood<T>(
         &mut self,
         destination: NodeDestination,
         encryption: OutboundEncryption,
+        exclude_peers: Vec<NodeId>,
         message: OutboundDomainMessage<T>,
     ) -> Result<MessageSendStates, DhtOutboundError>
     where
@@ -165,7 +163,7 @@ impl OutboundMessageRequester {
     {
         self.send_message(
             SendMessageParams::new()
-                .flood()
+                .flood(exclude_peers)
                 .with_destination(destination)
                 .with_encryption(encryption)
                 .finish(),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR changes the (previously unused) `Flood` broadcast strategy to send a message to
every _connected_ peer node. Since PR #1986, block hashes
are propagated across the network and the full block is only downloaded
once per peer (push became push-pull gossip). This large drop in propagation
overhead means that we can afford to spread the hash a little more
widely and use the modified `Flood` strategy. Previously, the hash propagation 
used the propagate strategy which only sends to 4 random connected peers.


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The flood strategy is changed from sending _all_ valid peers in the peer list, 
to only sending to currently connected peers (inbound and outbound connections). 
As before, client nodes are exempt from flood propagation messages.

Using this strategy for block hash propagation may improve block propagation 
across the network. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
The flood strategy is already partially tested and those tests pass. Existing base node tests pass.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch.
* [x] I ran `cargo-fmt --all` before pushing.
* [x] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
