### PR TITLE
Fix bug with reading the state machine watch channel

### DIFF
--- a/base_layer/core/src/base_node/service/service.rs
+++ b/base_layer/core/src/base_node/service/service.rs
@@ -352,14 +352,11 @@ where B: BlockchainBackend + 'static
 
     async fn spawn_handle_incoming_block(&self, new_block: DomainMessage<NewBlock>) {
         // Determine if we are bootstrapped
-        let mut status_watch = self.state_machine_handle.get_status_info_watch();
+        let status_watch = self.state_machine_handle.get_status_info_watch();
 
-        let bootstrapped = match status_watch.recv().await {
-            None => false,
-            Some(s) => match s {
-                StatusInfo::Listening(li) => li.is_bootstrapped(),
-                _ => false,
-            },
+        let bootstrapped = match *(status_watch.borrow()) {
+            StatusInfo::Listening(li) => li.is_bootstrapped(),
+            _ => false,
         };
 
         if !bootstrapped {

--- a/base_layer/core/src/mempool/service/service.rs
+++ b/base_layer/core/src/mempool/service/service.rs
@@ -296,13 +296,10 @@ where B: BlockchainBackend + 'static
 
     async fn spawn_handle_incoming_tx(&self, tx_msg: DomainMessage<Transaction>) {
         // Determine if we are bootstrapped
-        let mut status_watch = self.state_machine.get_status_info_watch();
-        let bootstrapped = match status_watch.recv().await {
-            None => false,
-            Some(s) => match s {
-                StatusInfo::Listening(li) => li.is_bootstrapped(),
-                _ => false,
-            },
+        let status_watch = self.state_machine.get_status_info_watch();
+        let bootstrapped = match *(status_watch.borrow()) {
+            StatusInfo::Listening(li) => li.is_bootstrapped(),
+            _ => false,
         };
         if !bootstrapped {
             debug!(


### PR DESCRIPTION
## Description
Used the `recv()` function to read the state in the base node service which will only return when the value in the watch is updated. Should have used the `borrow()` function which returns whatever the current status is.

## How Has This Been Tested?
Not easily testable, testing on a live node

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch.
* [x] I ran `cargo-fmt --all` before pushing.
* [ ] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
