### PR TITLE
Only update mempool after block sync is complete

### DIFF
--- a/applications/tari_base_node/src/grpc/base_node_grpc_server.rs
+++ b/applications/tari_base_node/src/grpc/base_node_grpc_server.rs
@@ -377,7 +377,7 @@ impl tari_rpc::base_node_server::BaseNode for BaseNodeGrpcServer {
 
         let mut handler = self.node_service.clone();
         handler
-            .submit_block(block, Broadcast::from(true))
+            .submit_block(block.into(), Broadcast::from(true))
             .await
             .map_err(|e| Status::internal(e.to_string()))?;
         let response: tari_rpc::Empty = tari_rpc::Empty {};

--- a/base_layer/core/src/base_node/chain_metadata_service/service.rs
+++ b/base_layer/core/src/base_node/chain_metadata_service/service.rs
@@ -112,8 +112,9 @@ impl ChainMetadataService {
     /// Handle BlockEvents
     async fn handle_block_event(&mut self, event: &BlockEvent) -> Result<(), ChainMetadataSyncError> {
         match event {
-            BlockEvent::Verified((_, BlockAddResult::Ok, _)) |
-            BlockEvent::Verified((_, BlockAddResult::ChainReorg(_), _)) => {
+            BlockEvent::ValidBlockAdded(_, BlockAddResult::Ok, _) |
+            BlockEvent::ValidBlockAdded(_, BlockAddResult::ChainReorg(_, _), _) |
+            BlockEvent::BlockSyncComplete(_) => {
                 self.update_liveness_chain_metadata().await?;
             },
             _ => {},

--- a/base_layer/core/src/base_node/comms_interface/local_interface.rs
+++ b/base_layer/core/src/base_node/comms_interface/local_interface.rs
@@ -155,6 +155,11 @@ impl LocalNodeCommsInterface {
         self.block_sender.call((block, propagate)).await?
     }
 
+    pub fn publish_block_event(&mut self, event: BlockEvent) -> usize {
+        // If event send fails, that means that there are no receivers (i.e. it was sent to zero receivers)
+        self.block_event_sender.send(Arc::new(event)).unwrap_or(0)
+    }
+
     /// Fetches the set of leaf node hashes and their deletion status' for the nth to nth+count leaf node index in the
     /// given MMR tree.
     pub async fn fetch_mmr_nodes(

--- a/base_layer/core/src/base_node/service/initializer.rs
+++ b/base_layer/core/src/base_node/service/initializer.rs
@@ -194,7 +194,7 @@ where T: BlockchainBackend + 'static
                 .get_handle::<StateMachineHandle>()
                 .expect("StateMachineHandle required to initialize MempoolService");
 
-            let streams = BaseNodeStreams::new(
+            let streams = BaseNodeStreams {
                 outbound_request_stream,
                 outbound_block_stream,
                 inbound_request_stream,
@@ -202,7 +202,7 @@ where T: BlockchainBackend + 'static
                 inbound_block_stream,
                 local_request_stream,
                 local_block_stream,
-            );
+            };
             let service =
                 BaseNodeService::new(outbound_message_service, inbound_nch, config, state_machine).start(streams);
             futures::pin_mut!(service);

--- a/base_layer/core/src/base_node/service/mod.rs
+++ b/base_layer/core/src/base_node/service/mod.rs
@@ -21,14 +21,15 @@
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 mod error;
+
 mod initializer;
+pub use initializer::BaseNodeServiceInitializer;
+
 #[allow(clippy::module_inception)]
 mod service;
-mod service_request;
-mod service_response;
-
-// Public re-exports
-pub use initializer::BaseNodeServiceInitializer;
-pub use service::{BaseNodeService, BaseNodeServiceConfig};
+pub use service::BaseNodeServiceConfig;
 pub use service_request::BaseNodeServiceRequest;
 pub use service_response::BaseNodeServiceResponse;
+
+mod service_request;
+mod service_response;

--- a/base_layer/core/src/base_node/state_machine_service/state_machine.rs
+++ b/base_layer/core/src/base_node/state_machine_service/state_machine.rs
@@ -235,6 +235,10 @@ impl<B: BlockchainBackend + 'static> BaseNodeStateMachine<B> {
     pub fn get_interrupt_signal(&self) -> ShutdownSignal {
         self.interrupt_signal.clone()
     }
+
+    pub fn db(&self) -> BlockchainDatabase<B> {
+        self.db.clone()
+    }
 }
 
 /// Polls both the interrupt signal and the given future. If the given future `state_fut` is ready first it's value is

--- a/base_layer/core/src/base_node/state_machine_service/states/events_and_states.rs
+++ b/base_layer/core/src/base_node/state_machine_service/states/events_and_states.rs
@@ -68,6 +68,12 @@ pub enum StateEvent {
     UserQuit,
 }
 
+impl<E: std::error::Error> From<E> for StateEvent {
+    fn from(err: E) -> Self {
+        Self::FatalError(err.to_string())
+    }
+}
+
 /// Some state transition functions must return `SyncStatus`. The sync status indicates how far behind the network's
 /// blockchain the local node is. It can either be very far behind (`LaggingBehindHorizon`), in which case we will just
 /// synchronise against the pruning horizon; we're somewhat behind (`Lagging`) and need to download the missing

--- a/base_layer/core/src/base_node/state_machine_service/states/forward_block_sync.rs
+++ b/base_layer/core/src/base_node/state_machine_service/states/forward_block_sync.rs
@@ -254,14 +254,15 @@ async fn download_blocks<B: BlockchainBackend + 'static>(
                 }
                 shared.publish_event_info();
             }
-            for i in 0..blocks.len() {
-                let hist_block = &blocks[i];
+            for (i, hist_block) in blocks.into_iter().enumerate() {
                 let header = &curr_headers[i];
-                let block_hash = hist_block.block().hash();
+                let block = hist_block.into_block();
+                let block_hash = block.hash();
+                let block_height = block.header.height;
                 if &block_hash == header {
                     match shared
                         .local_node_interface
-                        .submit_block(hist_block.block.clone(), Broadcast::from(false))
+                        .submit_block(block, Broadcast::from(false))
                         .await
                     {
                         Ok(result) => {
@@ -295,7 +296,7 @@ async fn download_blocks<B: BlockchainBackend + 'static>(
                     warn!(
                         target: LOG_TARGET,
                         "Block at height {} from peer does not match expected hash. Expected:{} Actual:{}",
-                        hist_block.block.header.height,
+                        block_height,
                         header.to_hex(),
                         block_hash.to_hex(),
                     );

--- a/base_layer/core/src/base_node/state_machine_service/states/mod.rs
+++ b/base_layer/core/src/base_node/state_machine_service/states/mod.rs
@@ -57,7 +57,7 @@
 //! required, and then shutdown.
 
 mod block_sync;
-pub use block_sync::{BestChainMetadataBlockSyncInfo, BlockSyncConfig, BlockSyncInfo, BlockSyncStrategy};
+pub use block_sync::{BestChainMetadataBlockSync, BlockSyncConfig, BlockSyncInfo, BlockSyncStrategy};
 
 mod events_and_states;
 pub use events_and_states::{BaseNodeState, StateEvent, StateInfo, StatusInfo, SyncStatus};

--- a/base_layer/core/src/chain_storage/async_db.rs
+++ b/base_layer/core/src/chain_storage/async_db.rs
@@ -39,7 +39,7 @@ use crate::{
 };
 use log::*;
 use rand::{rngs::OsRng, RngCore};
-use std::time::Instant;
+use std::{sync::Arc, time::Instant};
 use tari_mmr::{Hash, MerkleProof};
 
 const LOG_TARGET: &str = "c::bn::async_db";
@@ -119,10 +119,10 @@ make_async!(fetch_mmr_proof(tree: MmrTree, pos: usize) -> MerkleProof, "fetch_mm
 make_async!(fetch_mmr_root(tree: MmrTree) -> HashOutput, "fetch_mmr_root");
 make_async!(insert_mmr_node(tree: MmrTree, hash: Hash, deleted: bool) -> (), "insert_mmr_node");
 make_async!(validate_merkle_root(tree: MmrTree, height: u64) -> bool, "validate_merkle_root");
-make_async!(rewind_to_height(height: u64) -> Vec<Block>, "rewind_to_height");
+make_async!(rewind_to_height(height: u64) -> Vec<Arc<Block>>, "rewind_to_height");
 
 //---------------------------------- Block --------------------------------------------//
-make_async!(add_block(block: Block) -> BlockAddResult, "add_block");
+make_async!(add_block(block: Arc<Block>) -> BlockAddResult, "add_block");
 make_async!(block_exists(block_hash: BlockHash) -> bool, "block_exists");
 make_async!(fetch_block(height: u64) -> HistoricalBlock, "fetch_block");
 make_async!(fetch_orphan(hash: HashOutput) -> Block, "fetch_orphan");

--- a/base_layer/core/src/chain_storage/db_transaction.rs
+++ b/base_layer/core/src/chain_storage/db_transaction.rs
@@ -33,6 +33,7 @@ use std::{
     convert::TryFrom,
     fmt,
     fmt::{Display, Error, Formatter},
+    sync::Arc,
 };
 use strum_macros::Display;
 use tari_crypto::tari_utilities::{
@@ -116,9 +117,9 @@ impl DbTransaction {
 
     /// Stores an orphan block. No checks are made as to whether this is actually an orphan. That responsibility lies
     /// with the calling function.
-    pub fn insert_orphan(&mut self, orphan: Block) {
+    pub fn insert_orphan(&mut self, orphan: Arc<Block>) {
         let hash = orphan.hash();
-        self.insert(DbKeyValuePair::OrphanBlock(hash, Box::new(orphan)));
+        self.insert(DbKeyValuePair::OrphanBlock(hash, orphan));
     }
 
     /// Moves a UTXO to the STXO set and mark it as spent on the MRR. If the UTXO is not in the UTXO set, the
@@ -226,7 +227,7 @@ pub enum DbKeyValuePair {
     BlockHeader(u64, Box<BlockHeader>),
     UnspentOutput(HashOutput, Box<TransactionOutput>),
     TransactionKernel(HashOutput, Box<TransactionKernel>),
-    OrphanBlock(HashOutput, Box<Block>),
+    OrphanBlock(HashOutput, Arc<Block>),
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Copy)]

--- a/base_layer/core/src/chain_storage/historical_block.rs
+++ b/base_layer/core/src/chain_storage/historical_block.rs
@@ -61,6 +61,10 @@ impl HistoricalBlock {
     pub fn block(&self) -> &Block {
         &self.block
     }
+
+    pub fn into_block(self) -> Block {
+        self.block
+    }
 }
 
 impl From<HistoricalBlock> for Block {

--- a/base_layer/core/src/chain_storage/lmdb_db/lmdb_db.rs
+++ b/base_layer/core/src/chain_storage/lmdb_db/lmdb_db.rs
@@ -352,7 +352,7 @@ where D: Digest + Send + Sync
                 lmdb_insert(&txn, &self.kernels_db, &k, &v)?;
             },
             DbKeyValuePair::OrphanBlock(k, v) => {
-                lmdb_replace(&txn, &self.orphans_db, &k, &v)?;
+                lmdb_replace(&txn, &self.orphans_db, &k, &**v)?;
             },
         }
         Ok(())

--- a/base_layer/core/src/mempool/async_mempool.rs
+++ b/base_layer/core/src/mempool/async_mempool.rs
@@ -63,8 +63,8 @@ macro_rules! make_async {
 }
 
 make_async!(insert(tx: Arc<Transaction>) -> TxStorageResponse);
-make_async!(process_published_block(published_block: Block) -> ());
-make_async!(process_reorg(removed_blocks: Vec<Block>, new_blocks: Vec<Block>) -> ());
+make_async!(process_published_block(published_block: Arc<Block>) -> ());
+make_async!(process_reorg(removed_blocks: Vec<Arc<Block>>, new_blocks: Vec<Arc<Block>>) -> ());
 make_async!(snapshot() -> Vec<Arc<Transaction>>);
 make_async!(retrieve(total_weight: u64) -> Vec<Arc<Transaction>>);
 make_async!(has_tx_with_excess_sig(excess_sig: Signature) -> TxStorageResponse);

--- a/base_layer/core/src/mempool/mempool.rs
+++ b/base_layer/core/src/mempool/mempool.rs
@@ -86,7 +86,7 @@ where T: BlockchainBackend
     }
 
     /// Update the Mempool based on the received published block.
-    pub fn process_published_block(&self, published_block: Block) -> Result<(), MempoolError> {
+    pub fn process_published_block(&self, published_block: Arc<Block>) -> Result<(), MempoolError> {
         self.pool_storage
             .write()
             .map_err(|e| MempoolError::BackendError(e.to_string()))?
@@ -95,7 +95,12 @@ where T: BlockchainBackend
 
     /// In the event of a ReOrg, resubmit all ReOrged transactions into the Mempool and process each newly introduced
     /// block from the latest longest chain.
-    pub fn process_reorg(&self, removed_blocks: Vec<Block>, new_blocks: Vec<Block>) -> Result<(), MempoolError> {
+    pub fn process_reorg(
+        &self,
+        removed_blocks: Vec<Arc<Block>>,
+        new_blocks: Vec<Arc<Block>>,
+    ) -> Result<(), MempoolError>
+    {
         self.pool_storage
             .write()
             .map_err(|e| MempoolError::BackendError(e.to_string()))?

--- a/base_layer/core/src/mempool/mempool_storage.rs
+++ b/base_layer/core/src/mempool/mempool_storage.rs
@@ -113,7 +113,7 @@ where T: BlockchainBackend
     }
 
     /// Update the Mempool based on the received published block.
-    pub fn process_published_block(&mut self, published_block: Block) -> Result<(), MempoolError> {
+    pub fn process_published_block(&mut self, published_block: Arc<Block>) -> Result<(), MempoolError> {
         trace!(target: LOG_TARGET, "Mempool processing new block: {}", published_block);
         // Move published txs to ReOrgPool and discard double spends
         self.reorg_pool.insert_txs(
@@ -138,7 +138,7 @@ where T: BlockchainBackend
     }
 
     // Update the Mempool based on the received set of published blocks.
-    fn process_published_blocks(&mut self, published_blocks: Vec<Block>) -> Result<(), MempoolError> {
+    fn process_published_blocks(&mut self, published_blocks: Vec<Arc<Block>>) -> Result<(), MempoolError> {
         for published_block in published_blocks {
             self.process_published_block(published_block)?;
         }
@@ -147,7 +147,12 @@ where T: BlockchainBackend
 
     /// In the event of a ReOrg, resubmit all ReOrged transactions into the Mempool and process each newly introduced
     /// block from the latest longest chain.
-    pub fn process_reorg(&mut self, removed_blocks: Vec<Block>, new_blocks: Vec<Block>) -> Result<(), MempoolError> {
+    pub fn process_reorg(
+        &mut self,
+        removed_blocks: Vec<Arc<Block>>,
+        new_blocks: Vec<Arc<Block>>,
+    ) -> Result<(), MempoolError>
+    {
         debug!(target: LOG_TARGET, "Mempool processing reorg");
         for block in &removed_blocks {
             debug!(

--- a/base_layer/core/src/mempool/reorg_pool/reorg_pool.rs
+++ b/base_layer/core/src/mempool/reorg_pool/reorg_pool.rs
@@ -104,8 +104,8 @@ impl ReorgPool {
     /// resubmitted to the Unconfirmed Pool.
     pub fn remove_reorged_txs_and_discard_double_spends(
         &self,
-        removed_blocks: Vec<Block>,
-        new_blocks: &Vec<Block>,
+        removed_blocks: Vec<Arc<Block>>,
+        new_blocks: &[Arc<Block>],
     ) -> Result<Vec<Arc<Transaction>>, ReorgPoolError>
     {
         Ok(self
@@ -306,8 +306,8 @@ mod test {
         );
 
         let reorg_blocks = vec![
-            create_orphan_block(3000, vec![(*tx3).clone(), (*tx4).clone()], &consensus_constants),
-            create_orphan_block(4000, vec![(*tx1).clone(), (*tx2).clone()], &consensus_constants),
+            create_orphan_block(3000, vec![(*tx3).clone(), (*tx4).clone()], &consensus_constants).into(),
+            create_orphan_block(4000, vec![(*tx1).clone(), (*tx2).clone()], &consensus_constants).into(),
         ];
 
         let removed_txs = reorg_pool

--- a/base_layer/core/src/mempool/reorg_pool/reorg_pool_storage.rs
+++ b/base_layer/core/src/mempool/reorg_pool/reorg_pool_storage.rs
@@ -100,8 +100,8 @@ impl ReorgPoolStorage {
     /// can be resubmitted to the Unconfirmed Pool.
     pub fn remove_reorged_txs_and_discard_double_spends(
         &mut self,
-        removed_blocks: Vec<Block>,
-        new_blocks: &Vec<Block>,
+        removed_blocks: Vec<Arc<Block>>,
+        new_blocks: &[Arc<Block>],
     ) -> Vec<Arc<Transaction>>
     {
         for block in new_blocks {

--- a/base_layer/core/src/mempool/unconfirmed_pool/unconfirmed_pool.rs
+++ b/base_layer/core/src/mempool/unconfirmed_pool/unconfirmed_pool.rs
@@ -176,7 +176,7 @@ impl UnconfirmedPool {
     /// Remove all published transactions from the UnconfirmedPool and discard all double spend transactions.
     /// Returns a list of all transactions that were removed the unconfirmed pool as a result of appearing in the block.
     fn discard_double_spends(&mut self, published_block: &Block) {
-        let mut removed_tx_keys: Vec<Signature> = Vec::new();
+        let mut removed_tx_keys = Vec::new();
         for (tx_key, ptx) in self.txs_by_signature.iter() {
             for input in ptx.transaction.body.inputs() {
                 if published_block.body.inputs().contains(input) {
@@ -198,7 +198,7 @@ impl UnconfirmedPool {
 
     /// Remove all published transactions from the UnconfirmedPoolStorage and discard double spends
     pub fn remove_published_and_discard_double_spends(&mut self, published_block: &Block) -> Vec<Arc<Transaction>> {
-        let mut removed_txs: Vec<Arc<Transaction>> = Vec::new();
+        let mut removed_txs = Vec::new();
         published_block.body.kernels().iter().for_each(|kernel| {
             if let Some(ptx) = self.txs_by_signature.get(&kernel.excess_sig) {
                 self.txs_by_priority.remove(&ptx.priority);

--- a/base_layer/core/tests/async_db.rs
+++ b/base_layer/core/tests/async_db.rs
@@ -199,7 +199,9 @@ fn async_add_new_block() {
     test_async(|rt| {
         let dbc = db.clone();
         rt.spawn(async move {
-            let result = async_db::add_block(dbc.clone(), new_block.clone()).await.unwrap();
+            let result = async_db::add_block(dbc.clone(), new_block.clone().into())
+                .await
+                .unwrap();
             let block = async_db::fetch_block(dbc.clone(), 1).await.unwrap();
             match result {
                 BlockAddResult::Ok => assert_eq!(Block::from(block).hash(), new_block.hash()),
@@ -240,7 +242,7 @@ fn async_add_block_fetch_orphan() {
     test_async(move |rt| {
         let dbc = db.clone();
         rt.spawn(async move {
-            async_db::add_block(dbc.clone(), orphan.clone()).await.unwrap();
+            async_db::add_block(dbc.clone(), orphan.clone().into()).await.unwrap();
             let block = async_db::fetch_orphan(dbc.clone(), block_hash).await.unwrap();
             assert_eq!(orphan, block);
         });

--- a/base_layer/core/tests/block_validation.rs
+++ b/base_layer/core/tests/block_validation.rs
@@ -43,6 +43,6 @@ fn test_genesis_block() {
     );
     let db = BlockchainDatabase::new(backend, &rules, validators, BlockchainDatabaseConfig::default()).unwrap();
     let block = rules.get_genesis_block();
-    let result = db.add_block(block).unwrap();
+    let result = db.add_block(block.into()).unwrap();
     assert_eq!(result, BlockAddResult::BlockExists);
 }

--- a/base_layer/core/tests/chain_storage_tests/chain_backend.rs
+++ b/base_layer/core/tests/chain_storage_tests/chain_backend.rs
@@ -205,7 +205,7 @@ fn insert_contains_delete_and_fetch_orphan<T: BlockchainBackend>(mut db: T, cons
     assert_eq!(db.contains(&DbKey::OrphanBlock(hash.clone())).unwrap(), false);
 
     let mut txn = DbTransaction::new();
-    txn.insert_orphan(orphan.clone());
+    txn.insert_orphan(orphan.clone().into());
     assert!(db.write(txn).is_ok());
 
     assert_eq!(db.contains(&DbKey::OrphanBlock(hash.clone())).unwrap(), true);
@@ -808,9 +808,9 @@ fn for_each_orphan<T: BlockchainBackend>(mut db: T, consensus_constants: &Consen
     let hash3 = orphan3.hash();
 
     let mut txn = DbTransaction::new();
-    txn.insert_orphan(orphan1.clone());
-    txn.insert_orphan(orphan2.clone());
-    txn.insert_orphan(orphan3.clone());
+    txn.insert_orphan(orphan1.clone().into());
+    txn.insert_orphan(orphan2.clone().into());
+    txn.insert_orphan(orphan3.clone().into());
     assert!(db.write(txn).is_ok());
     assert_eq!(db.contains(&DbKey::OrphanBlock(hash1.clone())).unwrap(), true);
     assert_eq!(db.contains(&DbKey::OrphanBlock(hash2.clone())).unwrap(), true);
@@ -1061,7 +1061,7 @@ fn lmdb_backend_restore() {
         {
             let mut db = create_lmdb_database(&path, LMDBConfig::default(), MmrCacheConfig::default()).unwrap();
             let mut txn = DbTransaction::new();
-            txn.insert_orphan(orphan.clone());
+            txn.insert_orphan(orphan.clone().into());
             txn.insert_utxo(utxo1);
             txn.insert_utxo(utxo2);
             txn.insert_kernel(kernel);

--- a/base_layer/core/tests/helpers/block_builders.rs
+++ b/base_layer/core/tests/helpers/block_builders.rs
@@ -22,7 +22,7 @@
 
 use croaring::Bitmap;
 use rand::{rngs::OsRng, RngCore};
-use std::iter::repeat_with;
+use std::{iter::repeat_with, sync::Arc};
 use tari_core::{
     blocks::{Block, BlockHeader, NewBlockTemplate},
     chain_storage::{BlockAddResult, BlockchainBackend, BlockchainDatabase, ChainStorageError},
@@ -222,7 +222,7 @@ pub fn append_block<B: BlockchainBackend>(
     let mut block = db.calculate_mmr_roots(template)?;
     block.header.nonce = OsRng.next_u64();
     find_header_with_achieved_difficulty(&mut block.header, achieved_difficulty);
-    db.add_block(block.clone())?;
+    db.add_block(Arc::new(block.clone()))?;
     Ok(block)
 }
 
@@ -254,7 +254,7 @@ pub fn append_block_with_coinbase<B: BlockchainBackend>(
     let mut block = db.calculate_mmr_roots(template)?;
     block.header.nonce = OsRng.next_u64();
     find_header_with_achieved_difficulty(&mut block.header, achieved_difficulty);
-    db.add_block(block.clone())?;
+    db.add_block(Arc::new(block.clone()))?;
     Ok((block, coinbase_output))
 }
 
@@ -348,7 +348,7 @@ pub fn generate_block<B: BlockchainBackend>(
 {
     let template = chain_block(&blocks.last().unwrap(), transactions, consensus_constants);
     let new_block = db.calculate_mmr_roots(template)?;
-    let result = db.add_block(new_block.clone());
+    let result = db.add_block(new_block.clone().into());
     if let Ok(BlockAddResult::Ok) = result {
         blocks.push(new_block);
     }
@@ -367,7 +367,7 @@ pub fn generate_block_with_achieved_difficulty<B: BlockchainBackend>(
     let mut new_block = db.calculate_mmr_roots(template)?;
     new_block.header.nonce = OsRng.next_u64();
     find_header_with_achieved_difficulty(&mut new_block.header, achieved_difficulty);
-    let result = db.add_block(new_block.clone());
+    let result = db.add_block(new_block.clone().into());
     if let Ok(BlockAddResult::Ok) = result {
         blocks.push(new_block);
     }
@@ -393,7 +393,7 @@ pub fn generate_block_with_coinbase<B: BlockchainBackend>(
         consensus_constants,
     );
     let new_block = db.calculate_mmr_roots(template)?;
-    let result = db.add_block(new_block.clone());
+    let result = db.add_block(new_block.clone().into());
     if let Ok(BlockAddResult::Ok) = result {
         blocks.push(new_block);
     }

--- a/base_layer/core/tests/helpers/pow_blockchain.rs
+++ b/base_layer/core/tests/helpers/pow_blockchain.rs
@@ -77,7 +77,7 @@ pub fn append_to_pow_blockchain<T: BlockchainBackend>(
             constants.get_difficulty_max_block_interval(),
         )
         .unwrap();
-        db.add_block(new_block.clone()).unwrap();
+        db.add_block(new_block.clone().into()).unwrap();
         prev_block = new_block;
     }
 }

--- a/base_layer/core/tests/median_timestamp.rs
+++ b/base_layer/core/tests/median_timestamp.rs
@@ -122,7 +122,7 @@ fn test_median_timestamp_odd_order() {
     timestamps.push(timestamps[0].increase(&consensus_manager.consensus_constants().get_target_block_interval() / 2));
     new_block.header.timestamp = timestamps[2];
     new_block.header.pow.pow_algo = PowAlgorithm::Blake;
-    store.add_block(new_block).unwrap();
+    store.add_block(new_block.into()).unwrap();
 
     timestamps.push(timestamps[2].increase(consensus_manager.consensus_constants().get_target_block_interval() / 2));
     let height = store.get_chain_metadata().unwrap().height_of_longest_chain.unwrap();

--- a/base_layer/core/tests/mempool.rs
+++ b/base_layer/core/tests/mempool.rs
@@ -122,7 +122,7 @@ fn test_insert_and_process_published_block() {
     mempool.insert(tx2.clone()).unwrap();
     mempool.insert(tx3.clone()).unwrap();
     mempool.insert(tx5.clone()).unwrap();
-    mempool.process_published_block(blocks[1].clone()).unwrap();
+    mempool.process_published_block(blocks[1].clone().into()).unwrap();
 
     assert_eq!(
         mempool
@@ -179,7 +179,7 @@ fn test_insert_and_process_published_block() {
         &consensus_manager.consensus_constants(),
     )
     .unwrap();
-    mempool.process_published_block(blocks[2].clone()).unwrap();
+    mempool.process_published_block(blocks[2].clone().into()).unwrap();
 
     assert_eq!(
         mempool
@@ -246,7 +246,7 @@ fn test_retrieve() {
         &consensus_manager.consensus_constants(),
     )
     .unwrap();
-    mempool.process_published_block(blocks[1].clone()).unwrap();
+    mempool.process_published_block(blocks[1].clone().into()).unwrap();
     // 1-Block, 8 UTXOs, empty mempool
     let txs = vec![
         txn_schema!(from: vec![outputs[1][0].clone()], to: vec![], fee: 30*uT),
@@ -295,7 +295,7 @@ fn test_retrieve() {
     .unwrap();
     println!("{}", blocks[2]);
     outputs.push(utxos);
-    mempool.process_published_block(blocks[2].clone()).unwrap();
+    mempool.process_published_block(blocks[2].clone().into()).unwrap();
     // 2-blocks, 2 unconfirmed txs in mempool, 0 time locked (tx5 time-lock will expire)
     let stats = mempool.stats().unwrap();
     assert_eq!(stats.unconfirmed_txs, 3);
@@ -343,7 +343,7 @@ fn test_reorg() {
         &consensus_manager.consensus_constants(),
     )
     .unwrap();
-    mempool.process_published_block(blocks[1].clone()).unwrap();
+    mempool.process_published_block(blocks[1].clone().into()).unwrap();
 
     // "Mine" block 2
     let schemas = vec![
@@ -360,7 +360,7 @@ fn test_reorg() {
     assert_eq!(stats.unconfirmed_txs, 3);
     let txns2 = txns2.iter().map(|t| t.deref().clone()).collect();
     generate_block(&mut db, &mut blocks, txns2, &consensus_manager.consensus_constants()).unwrap();
-    mempool.process_published_block(blocks[2].clone()).unwrap();
+    mempool.process_published_block(blocks[2].clone().into()).unwrap();
 
     // "Mine" block 3
     let schemas = vec![
@@ -382,7 +382,7 @@ fn test_reorg() {
         &consensus_manager.consensus_constants(),
     )
     .unwrap();
-    mempool.process_published_block(blocks[3].clone()).unwrap();
+    mempool.process_published_block(blocks[3].clone().into()).unwrap();
 
     let stats = mempool.stats().unwrap();
     assert_eq!(stats.unconfirmed_txs, 0);
@@ -395,7 +395,7 @@ fn test_reorg() {
     let reorg_block3 = db.calculate_mmr_roots(template).unwrap();
 
     mempool
-        .process_reorg(vec![blocks[3].clone()], vec![reorg_block3])
+        .process_reorg(vec![blocks[3].clone().into()], vec![reorg_block3.into()])
         .unwrap();
     let stats = mempool.stats().unwrap();
     assert_eq!(stats.unconfirmed_txs, 2);
@@ -408,7 +408,7 @@ fn test_reorg() {
 
     // test that process_reorg can handle the case when removed_blocks is empty
     // see https://github.com/tari-project/tari/issues/2101#issuecomment-680726940
-    mempool.process_reorg(vec![], vec![reorg_block4]).unwrap();
+    mempool.process_reorg(vec![], vec![reorg_block4.into()]).unwrap();
 }
 
 #[test]
@@ -429,7 +429,7 @@ fn test_orphaned_mempool_transactions() {
         &consensus_manager.consensus_constants(),
     )
     .unwrap();
-    store.add_block(blocks[1].clone()).unwrap();
+    store.add_block(blocks[1].clone().into()).unwrap();
     let schemas = vec![
         txn_schema!(from: vec![outputs[1][0].clone(), outputs[1][1].clone()], to: vec![], fee: 500*uT, lock: 1100, OutputFeatures::default()),
         txn_schema!(from: vec![outputs[1][2].clone()], to: vec![], fee: 300*uT, lock: 1700, OutputFeatures::default()),
@@ -473,10 +473,10 @@ fn test_orphaned_mempool_transactions() {
     assert_eq!(stats.unconfirmed_txs, 1);
     assert_eq!(stats.timelocked_txs, 1);
     assert_eq!(stats.orphan_txs, 2);
-    store.add_block(blocks[1].clone()).unwrap();
-    store.add_block(blocks[2].clone()).unwrap();
-    mempool.process_published_block(blocks[1].clone()).unwrap();
-    mempool.process_published_block(blocks[2].clone()).unwrap();
+    store.add_block(blocks[1].clone().into()).unwrap();
+    store.add_block(blocks[2].clone().into()).unwrap();
+    mempool.process_published_block(blocks[1].clone().into()).unwrap();
+    mempool.process_published_block(blocks[2].clone().into()).unwrap();
     let stats = mempool.stats().unwrap();
     assert_eq!(stats.total_txs, 3);
     assert_eq!(stats.unconfirmed_txs, 1);

--- a/base_layer/core/tests/node_state_machine.rs
+++ b/base_layer/core/tests/node_state_machine.rs
@@ -52,7 +52,7 @@ use tari_core::{
         service::BaseNodeServiceConfig,
         state_machine_service::{
             states::{
-                BestChainMetadataBlockSyncInfo,
+                BestChainMetadataBlockSync,
                 BlockSyncConfig,
                 HorizonSyncConfig,
                 Listening,
@@ -314,7 +314,7 @@ fn test_block_sync() {
             node_id: bob_node.node_identity.node_id().clone(),
             chain_metadata: network_tip.clone(),
         }];
-        let state_event = BestChainMetadataBlockSyncInfo {}
+        let state_event = BestChainMetadataBlockSync {}
             .next_event(&mut alice_state_machine, &network_tip, &mut sync_peers)
             .await;
         assert_eq!(state_event, StateEvent::BlocksSynchronized);
@@ -422,7 +422,7 @@ fn test_lagging_block_sync() {
                 1.into(),
             )
             .unwrap();
-            alice_db.add_block(prev_block.clone()).unwrap();
+            alice_db.add_block(prev_block.clone().into()).unwrap();
         }
         for _ in 0..4 {
             prev_block = append_block(
@@ -443,7 +443,7 @@ fn test_lagging_block_sync() {
             node_id: bob_node.node_identity.node_id().clone(),
             chain_metadata: network_tip.clone(),
         }];
-        let state_event = BestChainMetadataBlockSyncInfo {}
+        let state_event = BestChainMetadataBlockSync {}
             .next_event(&mut alice_state_machine, &network_tip, &mut sync_peers)
             .await;
         assert_eq!(state_event, StateEvent::BlocksSynchronized);
@@ -531,7 +531,7 @@ fn test_block_sync_recovery() {
             1.into(),
         )
         .unwrap();
-        carol_db.add_block(prev_block.clone()).unwrap();
+        carol_db.add_block(prev_block.clone().into()).unwrap();
         for _ in 0..2 {
             prev_block = append_block(
                 bob_db,
@@ -552,7 +552,7 @@ fn test_block_sync_recovery() {
             node_id: bob_node.node_identity.node_id().clone(),
             chain_metadata: network_tip.clone(),
         }];
-        let state_event = BestChainMetadataBlockSyncInfo
+        let state_event = BestChainMetadataBlockSync
             .next_event(&mut alice_state_machine, &network_tip, &mut sync_peers)
             .await;
         assert_eq!(state_event, StateEvent::BlocksSynchronized);
@@ -639,7 +639,7 @@ fn test_forked_block_sync() {
                 1.into(),
             )
             .unwrap();
-            alice_db.add_block(prev_block.clone()).unwrap();
+            alice_db.add_block(prev_block.clone().into()).unwrap();
         }
 
         assert_eq!(alice_db.get_height().unwrap(), Some(2));
@@ -677,7 +677,7 @@ fn test_forked_block_sync() {
             node_id: bob_node.node_identity.node_id().clone(),
             chain_metadata: network_tip.clone(),
         }];
-        let state_event = BestChainMetadataBlockSyncInfo {}
+        let state_event = BestChainMetadataBlockSync {}
             .next_event(&mut alice_state_machine, &network_tip, &mut sync_peers)
             .await;
         assert_eq!(state_event, StateEvent::BlocksSynchronized);
@@ -807,8 +807,8 @@ fn test_sync_peer_banning() {
             prev_block.header.nonce = OsRng.next_u64();
             find_header_with_achieved_difficulty(&mut prev_block.header, 1.into());
 
-            alice_db.add_block(prev_block.clone()).unwrap();
-            bob_db.add_block(prev_block.clone()).unwrap();
+            alice_db.add_block(prev_block.clone().into()).unwrap();
+            bob_db.add_block(prev_block.clone().into()).unwrap();
         }
         assert_eq!(alice_db.get_height().unwrap(), Some(2));
         assert_eq!(bob_db.get_height().unwrap(), Some(2));
@@ -835,7 +835,7 @@ fn test_sync_peer_banning() {
             alice_prev_block.header.nonce = OsRng.next_u64();
             find_header_with_achieved_difficulty(&mut alice_prev_block.header, 1.into());
 
-            alice_db.add_block(alice_prev_block.clone()).unwrap();
+            alice_db.add_block(alice_prev_block.clone().into()).unwrap();
         }
         // Bob fork with invalid maturity
         let mut bob_prev_block = prev_block;
@@ -866,7 +866,7 @@ fn test_sync_peer_banning() {
             node_id: bob_node.node_identity.node_id().clone(),
             chain_metadata: network_tip.clone(),
         }];
-        let state_event = BestChainMetadataBlockSyncInfo {}
+        let state_event = BestChainMetadataBlockSync {}
             .next_event(&mut alice_state_machine, &network_tip, &mut sync_peers)
             .await;
         assert_eq!(state_event, StateEvent::BlockSyncFailure);


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
In block sync:
- Removed the call to submit_block in favour of calling
  `BlockchainDatabase::add_block` directly.
- Don't emit block events during sync.
- Emit BlockSyncCompleted after block sync is completed

In chain storage:
- A single read only atomic reference of a Block is passed around
  instead of multiple in-memory clones of the same Block.

Misc.
- Updated one existing test to check for the new
  `BlockEvent::BlockSyncComplete` event.

**NOTE: The chain metadata that is advertised to the network will not change until sync is complete**

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
During block sync we don't particularly care maintaining mempool state (@SWvheerden is this correct?). Some of the algorithms in the mempool are expensive to run repeatedly during block sync. With this PR they are only run once block sync is complete.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Base node test. Tested for the correct emitted event. Existing block sync tests pass.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [x] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [ ] I'm merging against the `development` branch.
* [ ] I ran `cargo-fmt --all` before pushing.
* [ ] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
