### PR TITLE
Delay UTXO validation process until after initial blockchain sync has been achieved

### DIFF
--- a/applications/tari_base_node/src/main.rs
+++ b/applications/tari_base_node/src/main.rs
@@ -1,3 +1,4 @@
+#![recursion_limit = "256"]
 // Copyright 2019. The Tari Project
 //
 // Redistribution and use in source and binary forms, with or without modification, are permitted provided that the

--- a/base_layer/wallet/src/output_manager_service/service.rs
+++ b/base_layer/wallet/src/output_manager_service/service.rs
@@ -388,9 +388,11 @@ where
                     "Error completing UTXO Validation Protocol (Id: {}): {:?}", id, error
                 );
                 match error {
-                    // This is the only error where we do not want to send this event as it was sent as a Timeout event
-                    // in the protocol
+                    // An event for this error has already been sent at this time
                     OutputManagerError::MaximumAttemptsExceeded => (),
+                    // An event for this error has already been sent at this time
+                    OutputManagerError::BaseNodeNotSynced => (),
+                    // A generic event is sent for all other errors
                     _ => {
                         let _ = self
                             .resources


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- Delay UTXO validation process until after initial blockchain sync has been achieved, monitor OMS events to determine success. 
- Squash double event emitted for `OutputManagerError::BaseNodeNotSynced`.
- Fix clippy warnings in the same file.

_**Note:** See review comments in #2216_

## Motivation and Context
If not delayed, UTXO validation will almost never succeed, as the validation is aborted if the node is not synced.

## How Has This Been Tested?
Tested in a base node on Windows

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [X] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [X] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [X] I'm merging against the `development` branch.
* [X] I ran `cargo-fmt --all` before pushing.
* [X] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
