### PR TITLE
Add in integer emission curve with swop over point

### DIFF
--- a/base_layer/core/src/base_node/validators/chain_balance.rs
+++ b/base_layer/core/src/base_node/validators/chain_balance.rs
@@ -84,7 +84,7 @@ impl<B: BlockchainBackend> ChainBalanceValidator<B> {
     }
 
     fn get_emission_commitment_at(&self, height: u64) -> Commitment {
-        let total_supply = self.rules.emission_schedule().supply_at_block(height) -
+        let total_supply = self.rules.get_emission_reward_at(height) -
             self.rules
                 .consensus_constants(height)
                 .get_genesis_coinbase_value_offset();

--- a/base_layer/core/src/base_node/validators/test.rs
+++ b/base_layer/core/src/base_node/validators/test.rs
@@ -147,7 +147,7 @@ fn chain_balance_validation() {
 
     //---------------------------------- Add a new coinbase and header --------------------------------------------//
     let mut txn = DbTransaction::new();
-    let coinbase_value = consensus_manager.emission_schedule().block_reward(1);
+    let coinbase_value = consensus_manager.emission_schedule(1).block_reward(1);
     let (coinbase, coinbase_key) = create_utxo(coinbase_value, &factories, Some(OutputFeatures::create_coinbase(1)));
     let coinbase_hash = coinbase.hash();
     txn.insert_utxo(coinbase.clone());
@@ -183,7 +183,7 @@ fn chain_balance_validation() {
         txn.insert_kernel(kernel.clone());
     }
 
-    let v = consensus_manager.emission_schedule().block_reward(2) + fee;
+    let v = consensus_manager.emission_schedule(2).block_reward(2) + fee;
     let (coinbase, key) = create_utxo(v, &factories, Some(OutputFeatures::create_coinbase(1)));
     txn.insert_utxo(coinbase.clone());
     let (pk, sig) = create_random_signature_from_s_key(key, 0.into(), 0);
@@ -219,7 +219,7 @@ fn chain_balance_validation() {
         txn.insert_kernel(kernel.clone());
     }
 
-    let v = consensus_manager.emission_schedule().block_reward(3) + fee;
+    let v = consensus_manager.emission_schedule(3).block_reward(3) + fee;
     let (coinbase, key) = create_utxo(v, &factories, Some(OutputFeatures::create_coinbase(1)));
     txn.insert_utxo(coinbase.clone());
     let (pk, sig) = create_random_signature_from_s_key(key, 0.into(), 0);
@@ -242,7 +242,7 @@ fn chain_balance_validation() {
     //---------------------------------- Try to inflate --------------------------------------------//
     let mut txn = DbTransaction::new();
 
-    let v = consensus_manager.emission_schedule().block_reward(4) + 1 * uT;
+    let v = consensus_manager.emission_schedule(4).block_reward(4) + 1 * uT;
     let (coinbase, key) = create_utxo(v, &factories, Some(OutputFeatures::create_coinbase(1)));
     txn.insert_utxo(coinbase.clone());
     let (pk, sig) = create_random_signature_from_s_key(key, 0.into(), 0);

--- a/base_layer/core/src/blocks/genesis_block.rs
+++ b/base_layer/core/src/blocks/genesis_block.rs
@@ -166,7 +166,7 @@ mod test {
 
         // BUG: Mainnet value was committed to in the Rincewind genesis block coinbase
         let consensus_manager = ConsensusManagerBuilder::new(Network::MainNet).build();
-        let supply = consensus_manager.emission_schedule().supply_at_block(0);
+        let supply = consensus_manager.emission_schedule(0).supply_at_block(0);
         let expected_kernel =
             &coinbase.commitment - &factories.commitment.commit_value(&PrivateKey::default(), supply.into());
         assert_eq!(coinbase_kernel.excess, expected_kernel);

--- a/base_layer/core/src/consensus/consensus_constants.rs
+++ b/base_layer/core/src/consensus/consensus_constants.rs
@@ -52,6 +52,8 @@ pub struct ConsensusConstants {
     pub(in crate::consensus) emission_initial: MicroTari,
     /// This is the emission curve delay
     pub(in crate::consensus) emission_decay: f64,
+    /// This is the emission curve delay for the int
+    pub(in crate::consensus) emission_decay_int: &'static [u64],
     /// This is the emission curve tail amount
     pub(in crate::consensus) emission_tail: MicroTari,
     /// The offset relative to the expected genesis coinbase value
@@ -85,6 +87,11 @@ impl ConsensusConstants {
     /// This gets the emission curve values as (initial, decay, tail)
     pub fn emission_amounts(&self) -> (MicroTari, f64, MicroTari) {
         (self.emission_initial, self.emission_decay, self.emission_tail)
+    }
+
+    /// This gets the emission curve values as (initial, decay, tail)
+    pub fn emission_amounts_int(&self) -> (MicroTari, &[u64], MicroTari) {
+        (self.emission_initial, self.emission_decay_int, self.emission_tail)
     }
 
     /// The min height maturity a coinbase utxo must have.
@@ -237,6 +244,7 @@ impl ConsensusConstants {
                 median_timestamp_count: 11,
                 emission_initial: 5_538_846_115 * uT,
                 emission_decay: 0.999_999_560_409_038_5,
+                emission_decay_int: &EMISSION_DECAY,
                 emission_tail: 1 * T,
                 max_randomx_seed_height: std::u64::MAX,
                 genesis_coinbase_value_offset: 5_539_846_115 * uT - 10_000_100 * uT,
@@ -252,6 +260,7 @@ impl ConsensusConstants {
                 median_timestamp_count: 11,
                 emission_initial: 5_538_846_115 * uT,
                 emission_decay: 0.999_999_560_409_038_5,
+                emission_decay_int: &EMISSION_DECAY,
                 emission_tail: 1 * T,
                 max_randomx_seed_height: std::u64::MAX,
                 genesis_coinbase_value_offset: 5_539_846_115 * uT - 10_000_100 * uT,
@@ -269,6 +278,7 @@ impl ConsensusConstants {
                 median_timestamp_count: 11,
                 emission_initial: 5_538_846_115 * uT,
                 emission_decay: 0.999_999_560_409_038_5,
+                emission_decay_int: &EMISSION_DECAY,
                 emission_tail: 1 * T,
                 max_randomx_seed_height: std::u64::MAX,
                 genesis_coinbase_value_offset: 5_539_846_115 * uT - 10_000_100 * uT,
@@ -276,7 +286,7 @@ impl ConsensusConstants {
             },
             // set max difficulty_max_block_interval to target_time * 6
             ConsensusConstants {
-                effective_from_height: 120000,
+                effective_from_height: 120_000,
                 coinbase_lock_height: 60,
                 blockchain_version: 1,
                 future_time_limit: 540,
@@ -285,6 +295,7 @@ impl ConsensusConstants {
                 median_timestamp_count: 11,
                 emission_initial: 5_538_846_115 * uT,
                 emission_decay: 0.999_999_560_409_038_5,
+                emission_decay_int: &EMISSION_DECAY,
                 emission_tail: 1 * T,
                 max_randomx_seed_height: std::u64::MAX,
                 genesis_coinbase_value_offset: 5_539_846_115 * uT - 10_000_100 * uT,
@@ -316,6 +327,7 @@ impl ConsensusConstants {
             median_timestamp_count: 11,
             emission_initial: 10_000_000.into(),
             emission_decay: 0.999,
+            emission_decay_int: &EMISSION_DECAY,
             emission_tail: 100.into(),
             max_randomx_seed_height: std::u64::MAX,
             genesis_coinbase_value_offset: 0.into(),
@@ -347,6 +359,7 @@ impl ConsensusConstants {
             median_timestamp_count: 11,
             emission_initial: 10_000_000.into(),
             emission_decay: 0.999,
+            emission_decay_int: &EMISSION_DECAY,
             emission_tail: 100.into(),
             max_randomx_seed_height: std::u64::MAX,
             genesis_coinbase_value_offset: 0.into(),
@@ -354,6 +367,8 @@ impl ConsensusConstants {
         }]
     }
 }
+
+static EMISSION_DECAY: [u64; 5] = [22, 23, 24, 26, 27];
 
 /// Class to create custom consensus constants
 pub struct ConsensusConstantsBuilder {

--- a/base_layer/core/src/consensus/emission.rs
+++ b/base_layer/core/src/consensus/emission.rs
@@ -23,19 +23,24 @@
 use crate::transactions::tari_amount::MicroTari;
 use num::pow;
 
+pub trait Emission {
+    fn block_reward(&self, height: u64) -> MicroTari;
+    fn supply_at_block(&self, height: u64) -> MicroTari;
+}
+
 /// The Tari emission schedule. The emission schedule determines how much Tari is mined as a block reward at every
 /// block.
 ///
 /// NB: We don't know what the final emission schedule will be on Tari yet, so do not give any weight to values or
 /// formulae provided in this file, they will almost certainly change ahead of main-net release.
-#[derive(Clone)]
-pub struct Emission {
+#[derive(Debug, Clone)]
+pub struct EmissionSchedule {
     initial: MicroTari,
-    decay: &'static [u64],
+    pub(crate) decay: &'static [u64],
     tail: MicroTari,
 }
 
-impl Emission {
+impl EmissionSchedule {
     /// Create a new emission schedule instance.
     ///
     /// The Emission schedule follows a similar pattern to Monero; with an exponentially decaying emission rate with
@@ -55,8 +60,8 @@ impl Emission {
     ///
     /// So for example, if the decay rate is 0.25, then $$\epsilon$$ is 0.75 or 1/2 + 1/4 i.e. `1 >> 1 + 1 >> 2`
     /// and the decay array is `&[1, 2]`
-    pub fn new(initial: MicroTari, decay: &'static [u64], tail: MicroTari) -> Emission {
-        Emission { initial, decay, tail }
+    pub fn new(initial: MicroTari, decay: &'static [u64], tail: MicroTari) -> EmissionSchedule {
+        EmissionSchedule { initial, decay, tail }
     }
 
     /// Return an iterator over the block reward and total supply. This is the most efficient way to iterate through
@@ -65,10 +70,10 @@ impl Emission {
     /// This is an infinite iterator, and each value returned is a tuple of (block number, reward, and total supply)
     ///
     /// ```edition2018
-    /// use tari_core::consensus::emission::Emission;
+    /// use tari_core::consensus::emission::EmissionSchedule;
     /// use tari_core::transactions::tari_amount::MicroTari;
     /// // Print the reward and supply for first 100 blocks
-    /// let schedule = Emission::new(10.into(), &[3], 1.into());
+    /// let schedule = EmissionSchedule::new(10.into(), &[3], 1.into());
     /// for (n, reward, supply) in schedule.iter().take(100) {
     ///     println!("{:3} {:9} {:9}", n, reward, supply);
     /// }
@@ -82,11 +87,11 @@ pub struct EmissionRate<'a> {
     block_num: u64,
     supply: MicroTari,
     reward: MicroTari,
-    schedule: &'a Emission,
+    schedule: &'a EmissionSchedule,
 }
 
 impl<'a> EmissionRate<'a> {
-    fn new(schedule: &'a Emission) -> EmissionRate<'a> {
+    fn new(schedule: &'a EmissionSchedule) -> EmissionRate<'a> {
         EmissionRate {
             block_num: 0,
             supply: schedule.initial,
@@ -139,6 +144,28 @@ impl<'a> Iterator for EmissionRate<'a> {
     }
 }
 
+impl Emission for EmissionSchedule {
+    /// Calculate the block reward for the given block height, in µTari
+    fn block_reward(&self, height: u64) -> MicroTari {
+        let mut iterator = self.iter();
+        while iterator.block_height() < height {
+            iterator.next();
+        }
+        iterator.block_reward()
+    }
+
+    /// Calculate the exact emitted supply after the given block, in µTari. The value is calculated by summing up the
+    /// block reward for each block, making this a very inefficient function if you wanted to call it from a loop for
+    /// example. For those cases, use the `iter` function instead.
+    fn supply_at_block(&self, height: u64) -> MicroTari {
+        let mut iterator = self.iter();
+        while iterator.block_height() < height {
+            iterator.next();
+        }
+        iterator.supply()
+    }
+}
+
 /// The Tari emission schedule. The emission schedule determines how much Tari is mined as a block reward at every
 /// block.
 ///
@@ -146,13 +173,13 @@ impl<'a> Iterator for EmissionRate<'a> {
 /// formulae provided in this file, they will almost certainly change ahead of main-net release.
 #[derive(Debug, Clone)]
 // #[deprecated(note = "Use Emission instead")]
-pub struct EmissionSchedule {
+pub struct EmissionScheduleOld {
     initial: MicroTari,
     decay: f64,
     tail: MicroTari,
 }
 
-impl EmissionSchedule {
+impl EmissionScheduleOld {
     /// Create a new emission schedule instance.
     ///
     /// The Emission schedule follows a similar pattern to Monero; with an exponentially decaying emission rate with
@@ -165,14 +192,34 @@ impl EmissionSchedule {
     ///  * $$A_0$$ is the genesis block reward
     ///  * $$1-r$$ is the decay rate
     ///  * $$t$$ is the constant tail emission rate
-    pub fn new(initial: MicroTari, decay: f64, tail: MicroTari) -> EmissionSchedule {
-        EmissionSchedule { initial, decay, tail }
+    pub fn new(initial: MicroTari, decay: f64, tail: MicroTari) -> EmissionScheduleOld {
+        EmissionScheduleOld { initial, decay, tail }
     }
 
+    /// Return an iterator over the block reward and total supply. This is the most efficient way to iterate through
+    /// the emission curve if you're interested in the supply as well as the reward.
+    ///
+    /// This is an infinite iterator, and each value returned is a tuple of (block number, reward, and total supply)
+    ///
+    /// ```edition2018
+    /// use tari_core::consensus::emission::EmissionScheduleOld;
+    /// use tari_core::transactions::tari_amount::MicroTari;
+    /// // Print the reward and supply for first 100 blocks
+    /// let schedule = EmissionScheduleOld::new(10.into(), 0.9, 1.into());
+    /// for (n, reward, supply) in schedule.iter().take(100) {
+    ///     println!("{:3} {:9} {:9}", n, reward, supply);
+    /// }
+    /// ```
+    pub fn iter(&self) -> EmissionValues {
+        EmissionValues::new(self)
+    }
+}
+
+impl Emission for EmissionScheduleOld {
     /// Calculate the block reward for the given block height, in µTari
-    pub fn block_reward(&self, block: u64) -> MicroTari {
-        let base = if block < std::i32::MAX as u64 {
-            let base_f = (f64::from(self.initial) * pow(self.decay, block as usize)).trunc();
+    fn block_reward(&self, height: u64) -> MicroTari {
+        let base = if height < std::i32::MAX as u64 {
+            let base_f = (f64::from(self.initial) * pow(self.decay, height as usize)).trunc();
             MicroTari::from(base_f as u64)
         } else {
             MicroTari::from(0)
@@ -183,30 +230,12 @@ impl EmissionSchedule {
     /// Calculate the exact emitted supply after the given block, in µTari. The value is calculated by summing up the
     /// block reward for each block, making this a very inefficient function if you wanted to call it from a loop for
     /// example. For those cases, use the `iter` function instead.
-    pub fn supply_at_block(&self, block: u64) -> MicroTari {
+    fn supply_at_block(&self, height: u64) -> MicroTari {
         let mut total = MicroTari::from(0u64);
-        for i in 0..=block {
+        for i in 0..=height {
             total += self.block_reward(i);
         }
         total
-    }
-
-    /// Return an iterator over the block reward and total supply. This is the most efficient way to iterate through
-    /// the emission curve if you're interested in the supply as well as the reward.
-    ///
-    /// This is an infinite iterator, and each value returned is a tuple of (block number, reward, and total supply)
-    ///
-    /// ```edition2018
-    /// use tari_core::consensus::emission::EmissionSchedule;
-    /// use tari_core::transactions::tari_amount::MicroTari;
-    /// // Print the reward and supply for first 100 blocks
-    /// let schedule = EmissionSchedule::new(10.into(), 0.9, 1.into());
-    /// for (n, reward, supply) in schedule.iter().take(100) {
-    ///     println!("{:3} {:9} {:9}", n, reward, supply);
-    /// }
-    /// ```
-    pub fn iter(&self) -> EmissionValues {
-        EmissionValues::new(self)
     }
 }
 
@@ -214,11 +243,11 @@ pub struct EmissionValues<'a> {
     block_num: u64,
     supply: MicroTari,
     reward: MicroTari,
-    schedule: &'a EmissionSchedule,
+    schedule: &'a EmissionScheduleOld,
 }
 
 impl<'a> EmissionValues<'a> {
-    fn new(schedule: &'a EmissionSchedule) -> EmissionValues<'a> {
+    fn new(schedule: &'a EmissionScheduleOld) -> EmissionValues<'a> {
         EmissionValues {
             block_num: 0,
             supply: MicroTari::default(),
@@ -243,21 +272,21 @@ impl<'a> Iterator for EmissionValues<'a> {
 #[cfg(test)]
 mod test {
     use crate::{
-        consensus::emission::{Emission, EmissionSchedule},
+        consensus::emission::{Emission, EmissionSchedule, EmissionScheduleOld},
         transactions::tari_amount::{uT, MicroTari, T},
     };
 
     /// Commit df95cee73812689bbae77bfb547c1d73a49635d4 introduced a bug in Windows builds that resulted in certain
     /// blocks failing validation tests. The cause was traced to an erroneous implementation of the std::f64::powi
     /// function in Rust toolchain nightly-2020-06-10, where Windows would give a slightly different floating point
-    /// result than Linux. This affected the EmissionSchedule::block_reward calculation.
+    /// result than Linux. This affected the EmissionScheduleOld::block_reward calculation.
     #[test]
     fn block_reward_edge_cases() {
         const EMISSION_INITIAL: u64 = 5_538_846_115;
         const EMISSION_DECAY: f64 = 0.999_999_560_409_038_5;
         const EMISSION_TAIL: u64 = 1;
 
-        let schedule = EmissionSchedule::new(
+        let schedule = EmissionScheduleOld::new(
             MicroTari::from(EMISSION_INITIAL * uT),
             EMISSION_DECAY,
             MicroTari::from(EMISSION_TAIL * T),
@@ -274,8 +303,38 @@ mod test {
     }
 
     #[test]
+    fn block_diff() {
+        const EMISSION_INITIAL: u64 = 5_538_846_115;
+        const EMISSION_DECAY: f64 = 0.999_999_560_409_038_5;
+        const EMISSION_TAIL: u64 = 1;
+
+        let schedule = EmissionScheduleOld::new(
+            MicroTari::from(EMISSION_INITIAL * uT),
+            EMISSION_DECAY,
+            MicroTari::from(EMISSION_TAIL * T),
+        );
+        let emission = EmissionSchedule::new(EMISSION_INITIAL * uT, &[22, 23, 24, 26, 27], EMISSION_TAIL * uT);
+
+        // lest test the old schedule vs the new and see if the diff is less than 0.1%
+        assert!(schedule.block_reward(9182) - emission.block_reward(9182) < schedule.block_reward(9182) / 1000);
+        assert!(schedule.block_reward(9430) - emission.block_reward(9430) < schedule.block_reward(9430) / 1000);
+        assert!(schedule.block_reward(10856) - emission.block_reward(10856) < schedule.block_reward(10856) / 1000);
+        assert!(schedule.block_reward(11708) - emission.block_reward(11708) < schedule.block_reward(11708) / 1000);
+        assert!(schedule.block_reward(30335) - emission.block_reward(30335) < schedule.block_reward(30335) / 1000);
+        assert!(schedule.block_reward(33923) - emission.block_reward(33923) < schedule.block_reward(33923) / 1000);
+        assert!(schedule.block_reward(34947) - emission.block_reward(34947) < schedule.block_reward(34947) / 1000);
+        assert!(schedule.block_reward(50000) - emission.block_reward(50000) < schedule.block_reward(50000) / 1000);
+        assert!(schedule.block_reward(100000) - emission.block_reward(100000) < schedule.block_reward(100000) / 1000);
+        assert!(schedule.block_reward(200000) - emission.block_reward(200000) < schedule.block_reward(200000) / 1000);
+        assert!(emission.block_reward(700000) - schedule.block_reward(700000) < schedule.block_reward(700000) / 1000);
+        assert!(
+            emission.block_reward(1400000) - schedule.block_reward(1400000) < schedule.block_reward(1400000) / 1000
+        );
+    }
+
+    #[test]
     fn schedule() {
-        let schedule = EmissionSchedule::new(MicroTari::from(10_000_000), 0.999, MicroTari::from(100));
+        let schedule = EmissionScheduleOld::new(MicroTari::from(10_000_000), 0.999, MicroTari::from(100));
         let r0 = schedule.block_reward(0);
         assert_eq!(r0, MicroTari::from(10_000_100));
         let s0 = schedule.supply_at_block(0);
@@ -287,7 +346,7 @@ mod test {
     #[test]
     fn huge_block_number() {
         let mut n = (std::i32::MAX - 1) as u64;
-        let schedule = EmissionSchedule::new(MicroTari::from(1e21 as u64), 0.999_9999, MicroTari::from(100));
+        let schedule = EmissionScheduleOld::new(MicroTari::from(1e21 as u64), 0.999_9999, MicroTari::from(100));
         for _ in 0..3 {
             assert_eq!(schedule.block_reward(n), MicroTari::from(100));
             n += 1;
@@ -296,7 +355,7 @@ mod test {
 
     #[test]
     fn generate_emission_schedule_as_iterator() {
-        let schedule = EmissionSchedule::new(MicroTari::from(10_000_000), 0.999, MicroTari::from(100));
+        let schedule = EmissionScheduleOld::new(MicroTari::from(10_000_000), 0.999, MicroTari::from(100));
         let values: Vec<(u64, MicroTari, MicroTari)> = schedule.iter().take(101).collect();
         assert_eq!(values[0].0, 0);
         assert_eq!(values[0].1, MicroTari::from(10_000_100));
@@ -314,7 +373,7 @@ mod test {
 
     #[test]
     fn emission() {
-        let emission = Emission::new(1 * T, &[1, 2], 100 * uT);
+        let emission = EmissionSchedule::new(1 * T, &[1, 2], 100 * uT);
         let mut emission = emission.iter();
         // decay is 1 - 0.25 - 0.125 = 0.625
         assert_eq!(emission.block_height(), 0);
@@ -334,5 +393,8 @@ mod test {
         assert_eq!(emission.block_height(), 8);
         assert_eq!(emission.block_reward(), 100 * uT);
         assert_eq!(emission.supply(), 1333455 * uT);
+        let schedule = EmissionSchedule::new(1 * T, &[1, 2], 100 * uT);
+        assert_eq!(emission.block_reward(), schedule.block_reward(8));
+        assert_eq!(emission.supply(), schedule.supply_at_block(8));
     }
 }

--- a/base_layer/core/src/mining/miner.rs
+++ b/base_layer/core/src/mining/miner.rs
@@ -391,7 +391,7 @@ impl Miner {
         let (tx, unblinded_output) = builder
             .build(
                 self.consensus.consensus_constants(block.header.height),
-                self.consensus.emission_schedule(),
+                self.consensus.emission_schedule(block.header.height),
             )
             .expect("invalid constructed coinbase");
         block.body.add_output(tx.body.outputs()[0].clone());

--- a/base_layer/core/tests/chain_storage_tests/chain_storage.rs
+++ b/base_layer/core/tests/chain_storage_tests/chain_storage.rs
@@ -1199,7 +1199,7 @@ fn invalid_block() {
             from: vec![outputs[0][0].clone()],
             to: vec![10 * T, 5 * T, 10 * T, 15 * T]
         )];
-        let coinbase_value = consensus_manager.emission_schedule().block_reward(1);
+        let coinbase_value = consensus_manager.emission_schedule(1).block_reward(1);
         assert_eq!(
             generate_new_block_with_coinbase(
                 &mut store,
@@ -1229,7 +1229,7 @@ fn invalid_block() {
 
         // Invalid Block 2 - Double spends genesis block output
         let txs = vec![txn_schema!(from: vec![outputs[0][0].clone()], to: vec![20 * T, 20 * T])];
-        let coinbase_value = consensus_manager.emission_schedule().block_reward(2);
+        let coinbase_value = consensus_manager.emission_schedule(2).block_reward(2);
         unpack_enum!(
             ChainStorageError::UnspendableInput = generate_new_block_with_coinbase(
                 &mut store,
@@ -1257,7 +1257,7 @@ fn invalid_block() {
 
         // Valid Block 2
         let txs = vec![txn_schema!(from: vec![outputs[1][0].clone()], to: vec![4 * T, 4 * T])];
-        let coinbase_value = consensus_manager.emission_schedule().block_reward(2);
+        let coinbase_value = consensus_manager.emission_schedule(0).block_reward(2);
         assert_eq!(
             generate_new_block_with_coinbase(
                 &mut store,
@@ -1622,7 +1622,7 @@ fn pruned_mode_is_stxo() {
 
     // Block 1
     let txs = vec![txn_schema!(from: vec![outputs[0][0].clone()], to: vec![50 * T])];
-    let coinbase_value = consensus_manager.emission_schedule().block_reward(1);
+    let coinbase_value = consensus_manager.emission_schedule(0).block_reward(1);
     assert_eq!(
         generate_new_block_with_coinbase(
             &mut store,
@@ -1648,7 +1648,7 @@ fn pruned_mode_is_stxo() {
 
     // Block 2
     let txs = vec![txn_schema!(from: vec![outputs[1][1].clone()], to: vec![40 * T])];
-    let coinbase_value = consensus_manager.emission_schedule().block_reward(2);
+    let coinbase_value = consensus_manager.emission_schedule(0).block_reward(2);
     assert_eq!(
         generate_new_block_with_coinbase(
             &mut store,
@@ -1677,7 +1677,7 @@ fn pruned_mode_is_stxo() {
 
     // Block 3
     let txs = vec![txn_schema!(from: vec![outputs[2][2].clone()], to: vec![30 * T])];
-    let coinbase_value = consensus_manager.emission_schedule().block_reward(3);
+    let coinbase_value = consensus_manager.emission_schedule(0).block_reward(3);
     assert_eq!(
         generate_new_block_with_coinbase(
             &mut store,
@@ -1709,7 +1709,7 @@ fn pruned_mode_is_stxo() {
 
     // Block 4
     let txs = vec![txn_schema!(from: vec![outputs[3][1].clone()], to: vec![20 * T])];
-    let coinbase_value = consensus_manager.emission_schedule().block_reward(4);
+    let coinbase_value = consensus_manager.emission_schedule(0).block_reward(4);
     assert_eq!(
         generate_new_block_with_coinbase(
             &mut store,

--- a/base_layer/core/tests/helpers/block_builders.rs
+++ b/base_layer/core/tests/helpers/block_builders.rs
@@ -90,7 +90,7 @@ pub fn create_act_gen_block() {
     let consensus_manager: ConsensusManager = ConsensusManagerBuilder::new(network).build();
     let factories = CryptoFactories::default();
     let mut header = BlockHeader::new(consensus_manager.consensus_constants(0).blockchain_version());
-    let value = consensus_manager.emission_schedule().block_reward(0);
+    let value = consensus_manager.emission_schedule(0).block_reward(0);
     let (mut utxo, key) = create_utxo(value, &factories, None);
     utxo.features = OutputFeatures::create_coinbase(1);
     let (pk, sig) = create_random_signature_from_s_key(key.clone(), 0.into(), 0);
@@ -238,7 +238,7 @@ pub fn append_block_with_coinbase<B: BlockchainBackend>(
 ) -> Result<(Block, UnblindedOutput), ChainStorageError>
 {
     let height = prev_block.header.height + 1;
-    let coinbase_value = consensus_manager.emission_schedule().block_reward(height);
+    let coinbase_value = consensus_manager.emission_schedule(height).block_reward(height);
     let (coinbase_utxo, coinbase_kernel, coinbase_output) = create_coinbase(
         &factories,
         coinbase_value,

--- a/base_layer/core/tests/horizon_state_sync.rs
+++ b/base_layer/core/tests/horizon_state_sync.rs
@@ -272,7 +272,7 @@ fn test_pruned_mode_sync_with_spent_utxos() {
 
         // Spend coinbases before horizon height
         {
-            let supply = consensus_manager.emission_schedule().supply_at_block(4);
+            let supply = consensus_manager.emission_schedule(4).supply_at_block(4);
             let fee = Fee::calculate(25 * uT, 5, 5, 2);
             let schema = txn_schema!(from: outputs, to: vec![supply - fee], fee: 25 * uT);
             let (tx, _, _) = spend_utxos(schema);
@@ -307,7 +307,7 @@ fn test_pruned_mode_sync_with_spent_utxos() {
 
         // Spend the other coinbases (why not?)
         {
-            let supply = consensus_manager.emission_schedule().supply_at_block(4);
+            let supply = consensus_manager.emission_schedule(0).supply_at_block(4);
             let fee = Fee::calculate(25 * uT, 5, 5, 2);
             let schema = txn_schema!(from: outputs, to: vec![supply - fee], fee: 25 * uT);
             let (tx, _, _) = spend_utxos(schema);

--- a/base_layer/core/tests/node_state_machine.rs
+++ b/base_layer/core/tests/node_state_machine.rs
@@ -672,7 +672,7 @@ fn test_sync_peer_banning() {
         let bob_db = &bob_node.blockchain_db;
         let bob_public_key = &bob_node.node_identity.public_key();
         for height in 1..=2 {
-            let coinbase_value = consensus_manager.emission_schedule().block_reward(height);
+            let coinbase_value = consensus_manager.emission_schedule(0).block_reward(height);
             let (mut coinbase_utxo, coinbase_kernel, mut coinbase) = create_coinbase(
                 &factories,
                 coinbase_value,
@@ -699,7 +699,7 @@ fn test_sync_peer_banning() {
         // Alice fork
         let mut alice_prev_block = prev_block.clone();
         for height in 3..=4 {
-            let coinbase_value = consensus_manager.emission_schedule().block_reward(height);
+            let coinbase_value = consensus_manager.emission_schedule(0).block_reward(height);
             let (coinbase_utxo, coinbase_kernel, _) = create_coinbase(
                 &factories,
                 coinbase_value,


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Adds in a trait for use by emission curve
adds integer emission curve to consensus_manager
Adds swap over point for hot swapping across points

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
We keep getting floating point errors in testnet. This PR provides a method to swop between the two curves going forward that will keep consensus but it requires a hard_fork. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [x] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch.
* [x] I ran `cargo-fmt --all` before pushing.
* [x] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
