### PR TITLE
Add header hash to block Display impl

### DIFF
--- a/base_layer/core/src/blocks/block.rs
+++ b/base_layer/core/src/blocks/block.rs
@@ -26,6 +26,7 @@ use crate::{
     blocks::{BlockHash, BlockHeader},
     consensus::ConsensusConstants,
     proof_of_work::ProofOfWork,
+    tari_utilities::hex::Hex,
     transactions::{
         aggregated_body::AggregateBody,
         tari_amount::MicroTari,
@@ -116,6 +117,7 @@ impl Display for Block {
     fn fmt(&self, fmt: &mut Formatter<'_>) -> Result<(), std::fmt::Error> {
         fmt.write_str("----------------- Block -----------------\n")?;
         fmt.write_str("--- Header ---\n")?;
+        fmt.write_str(&format!("Hash: {}\n", self.header.hash().to_hex()))?;
         fmt.write_str(&format!("{}\n", self.header))?;
         fmt.write_str("---  Body  ---\n")?;
         fmt.write_str(&format!("{}\n", self.body))


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Adds the block header hash to the block display implementation, since it was annoying to have to use `list-headers` just to get the header hash after `get-block` 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
#2255 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Code builds and runs, displays the header hash in `get-block` output 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch.
* [x] I ran `cargo-fmt --all` before pushing.
* [x] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
