### PR TITLE
Decouple Mempool and BlockchainDatabase

### DIFF
--- a/base_layer/core/src/base_node/comms_interface/inbound_handlers.rs
+++ b/base_layer/core/src/base_node/comms_interface/inbound_handlers.rs
@@ -93,7 +93,7 @@ impl From<bool> for Broadcast {
 pub struct InboundNodeCommsHandlers<T> {
     block_event_sender: BlockEventSender,
     blockchain_db: BlockchainDatabase<T>,
-    mempool: Mempool<T>,
+    mempool: Mempool,
     consensus_manager: ConsensusManager,
     new_block_request_semaphore: Arc<Semaphore>,
     outbound_nci: OutboundNodeCommsInterface,
@@ -106,7 +106,7 @@ where T: BlockchainBackend + 'static
     pub fn new(
         block_event_sender: BlockEventSender,
         blockchain_db: BlockchainDatabase<T>,
-        mempool: Mempool<T>,
+        mempool: Mempool,
         consensus_manager: ConsensusManager,
         outbound_nci: OutboundNodeCommsInterface,
     ) -> Self

--- a/base_layer/core/src/base_node/service/initializer.rs
+++ b/base_layer/core/src/base_node/service/initializer.rs
@@ -59,7 +59,7 @@ const SUBSCRIPTION_LABEL: &str = "Base Node";
 pub struct BaseNodeServiceInitializer<T> {
     inbound_message_subscription_factory: Arc<SubscriptionFactory>,
     blockchain_db: BlockchainDatabase<T>,
-    mempool: Mempool<T>,
+    mempool: Mempool,
     consensus_manager: ConsensusManager,
     config: BaseNodeServiceConfig,
 }
@@ -71,7 +71,7 @@ where T: BlockchainBackend
     pub fn new(
         inbound_message_subscription_factory: Arc<SubscriptionFactory>,
         blockchain_db: BlockchainDatabase<T>,
-        mempool: Mempool<T>,
+        mempool: Mempool,
         consensus_manager: ConsensusManager,
         config: BaseNodeServiceConfig,
     ) -> Self

--- a/base_layer/core/src/base_node/validators.rs
+++ b/base_layer/core/src/base_node/validators.rs
@@ -36,21 +36,21 @@ use crate::{
     chain_storage::{BlockchainBackend, BlockchainDatabase},
     consensus::ConsensusManager,
     transactions::types::CryptoFactories,
-    validation::{StatelessValidation, StatelessValidator},
+    validation::{Validation, Validator},
 };
 use std::{fmt, sync::Arc};
 
 #[derive(Clone)]
 pub struct SyncValidators {
-    pub header: Arc<StatelessValidator<BlockHeader>>,
-    pub final_state: Arc<StatelessValidator<u64>>,
+    pub header: Arc<Validator<BlockHeader>>,
+    pub final_state: Arc<Validator<u64>>,
 }
 
 impl SyncValidators {
     pub fn new<THeader, TFinal>(header: THeader, final_state: TFinal) -> Self
     where
-        THeader: StatelessValidation<BlockHeader> + 'static,
-        TFinal: StatelessValidation<u64> + 'static,
+        THeader: Validation<BlockHeader> + 'static,
+        TFinal: Validation<u64> + 'static,
     {
         Self {
             header: Arc::new(Box::new(header)),

--- a/base_layer/core/src/base_node/validators/chain_balance.rs
+++ b/base_layer/core/src/base_node/validators/chain_balance.rs
@@ -28,7 +28,7 @@ use crate::{
         tari_amount::MicroTari,
         types::{BlindingFactor, Commitment, CryptoFactories, PrivateKey},
     },
-    validation::{StatelessValidation, ValidationError},
+    validation::{Validation, ValidationError},
 };
 use log::*;
 use tari_crypto::commitment::HomomorphicCommitmentFactory;
@@ -48,7 +48,7 @@ impl<B: BlockchainBackend> ChainBalanceValidator<B> {
     }
 }
 
-impl<B: BlockchainBackend> StatelessValidation<u64> for ChainBalanceValidator<B> {
+impl<B: BlockchainBackend> Validation<u64> for ChainBalanceValidator<B> {
     fn validate(&self, horizon_height: &u64) -> Result<(), ValidationError> {
         let total_offset = self.fetch_total_offset_commitment(*horizon_height)?;
         let emission_h = self.get_emission_commitment_at(*horizon_height);

--- a/base_layer/core/src/base_node/validators/headers.rs
+++ b/base_layer/core/src/base_node/validators/headers.rs
@@ -25,7 +25,7 @@ use crate::{
     chain_storage::{BlockchainBackend, BlockchainDatabase},
     consensus::ConsensusManager,
     proof_of_work::{get_median_timestamp, get_target_difficulty, Difficulty, PowError},
-    validation::{StatelessValidation, ValidationError},
+    validation::{Validation, ValidationError},
 };
 use log::*;
 use tari_crypto::tari_utilities::{epoch_time::EpochTime, hex::Hex, Hashable};
@@ -43,7 +43,7 @@ impl<B: BlockchainBackend> HeaderValidator<B> {
     }
 }
 
-impl<B: BlockchainBackend> StatelessValidation<BlockHeader> for HeaderValidator<B> {
+impl<B: BlockchainBackend> Validation<BlockHeader> for HeaderValidator<B> {
     fn validate(&self, header: &BlockHeader) -> Result<(), ValidationError> {
         let header_id = format!("header #{} ({})", header.height, header.hash().to_hex());
         self.check_median_timestamp(header)?;

--- a/base_layer/core/src/base_node/validators/test.rs
+++ b/base_layer/core/src/base_node/validators/test.rs
@@ -35,7 +35,7 @@ use crate::{
         types::{Commitment, CryptoFactories},
     },
     txn_schema,
-    validation::{StatelessValidation, ValidationError},
+    validation::{Validation, ValidationError},
 };
 use tari_crypto::tari_utilities::{epoch_time::EpochTime, Hashable};
 use tari_test_utils::unpack_enum;

--- a/base_layer/core/src/mempool/async_mempool.rs
+++ b/base_layer/core/src/mempool/async_mempool.rs
@@ -22,7 +22,6 @@
 
 use crate::{
     blocks::Block,
-    chain_storage::BlockchainBackend,
     mempool::{error::MempoolError, Mempool, StateResponse, StatsResponse, TxStorageResponse},
     transactions::{transaction::Transaction, types::Signature},
 };
@@ -30,8 +29,7 @@ use std::sync::Arc;
 
 macro_rules! make_async {
     ($fn:ident($($param1:ident:$ptype1:ty,$param2:ident:$ptype2:ty),+) -> $rtype:ty) => {
-        pub async fn $fn<T>(mp: Mempool<T>, $($param1: $ptype1, $param2: $ptype2),+) -> Result<$rtype, MempoolError>
-        where T: BlockchainBackend + 'static {
+        pub async fn $fn(mp: Mempool, $($param1: $ptype1, $param2: $ptype2),+) -> Result<$rtype, MempoolError> {
             tokio::task::spawn_blocking(move || mp.$fn($($param1,$param2),+))
                 .await
                 .or_else(|err| Err(MempoolError::BlockingTaskSpawnError(err.to_string())))
@@ -40,8 +38,7 @@ macro_rules! make_async {
     };
 
     ($fn:ident($($param:ident:$ptype:ty),+) -> $rtype:ty) => {
-        pub async fn $fn<T>(mp: Mempool<T>, $($param: $ptype),+) -> Result<$rtype, MempoolError>
-        where T: BlockchainBackend + 'static {
+        pub async fn $fn(mp: Mempool, $($param: $ptype),+) -> Result<$rtype, MempoolError> {
             tokio::task::spawn_blocking(move || mp.$fn($($param),+))
                 .await
                 .or_else(|err| Err(MempoolError::BlockingTaskSpawnError(err.to_string())))
@@ -50,8 +47,7 @@ macro_rules! make_async {
     };
 
     ($fn:ident() -> $rtype:ty) => {
-        pub async fn $fn<T>(mp: Mempool<T>) -> Result<$rtype, MempoolError>
-        where T: BlockchainBackend + 'static {
+        pub async fn $fn(mp: Mempool) -> Result<$rtype, MempoolError> {
             tokio::task::spawn_blocking(move || {
                 mp.$fn()
             })

--- a/base_layer/core/src/mempool/mempool.rs
+++ b/base_layer/core/src/mempool/mempool.rs
@@ -22,7 +22,6 @@
 
 use crate::{
     blocks::Block,
-    chain_storage::{BlockchainBackend, BlockchainDatabase},
     mempool::{
         error::MempoolError,
         mempool_storage::MempoolStorage,
@@ -37,15 +36,15 @@ use crate::{
 use std::sync::{Arc, RwLock};
 
 /// Struct containing the validators the mempool needs to run, It forces the correct amount of validators are given
-pub struct MempoolValidators<B: BlockchainBackend> {
-    mempool: Validator<Transaction, B>,
-    orphan: Validator<Transaction, B>,
+pub struct MempoolValidators {
+    mempool: Validator<Transaction>,
+    orphan: Validator<Transaction>,
 }
 
-impl<B: BlockchainBackend> MempoolValidators<B> {
+impl MempoolValidators {
     pub fn new(
-        mempool: impl Validation<Transaction, B> + 'static,
-        orphan: impl Validation<Transaction, B> + 'static,
+        mempool: impl Validation<Transaction> + 'static,
+        orphan: impl Validation<Transaction> + 'static,
     ) -> Self
     {
         Self {
@@ -54,7 +53,7 @@ impl<B: BlockchainBackend> MempoolValidators<B> {
         }
     }
 
-    pub fn into_validators(self) -> (Validator<Transaction, B>, Validator<Transaction, B>) {
+    pub fn into_validators(self) -> (Validator<Transaction>, Validator<Transaction>) {
         (self.mempool, self.orphan)
     }
 }
@@ -62,17 +61,16 @@ impl<B: BlockchainBackend> MempoolValidators<B> {
 /// The Mempool consists of an Unconfirmed Transaction Pool, Pending Pool, Orphan Pool and Reorg Pool and is responsible
 /// for managing and maintaining all unconfirmed transactions have not yet been included in a block, and transactions
 /// that have recently been included in a block.
-pub struct Mempool<T> {
-    pool_storage: Arc<RwLock<MempoolStorage<T>>>,
+#[derive(Clone)]
+pub struct Mempool {
+    pool_storage: Arc<RwLock<MempoolStorage>>,
 }
 
-impl<T> Mempool<T>
-where T: BlockchainBackend
-{
+impl Mempool {
     /// Create a new Mempool with an UnconfirmedPool, OrphanPool, PendingPool and ReOrgPool.
-    pub fn new(blockchain_db: BlockchainDatabase<T>, config: MempoolConfig, validators: MempoolValidators<T>) -> Self {
+    pub fn new(config: MempoolConfig, validators: MempoolValidators) -> Self {
         Self {
-            pool_storage: Arc::new(RwLock::new(MempoolStorage::new(blockchain_db, config, validators))),
+            pool_storage: Arc::new(RwLock::new(MempoolStorage::new(config, validators))),
         }
     }
 
@@ -147,13 +145,5 @@ where T: BlockchainBackend
             .read()
             .map_err(|e| MempoolError::BackendError(e.to_string()))?
             .state()
-    }
-}
-
-impl<T> Clone for Mempool<T> {
-    fn clone(&self) -> Self {
-        Mempool {
-            pool_storage: self.pool_storage.clone(),
-        }
     }
 }

--- a/base_layer/core/src/mempool/mempool_storage.rs
+++ b/base_layer/core/src/mempool/mempool_storage.rs
@@ -22,7 +22,6 @@
 
 use crate::{
     blocks::Block,
-    chain_storage::{BlockchainBackend, BlockchainDatabase},
     mempool::{
         error::MempoolError,
         mempool::MempoolValidators,
@@ -47,27 +46,23 @@ pub const LOG_TARGET: &str = "c::mp::mempool";
 /// The Mempool consists of an Unconfirmed Transaction Pool, Pending Pool, Orphan Pool and Reorg Pool and is responsible
 /// for managing and maintaining all unconfirmed transactions have not yet been included in a block, and transactions
 /// that have recently been included in a block.
-pub struct MempoolStorage<T> {
-    blockchain_db: BlockchainDatabase<T>,
+pub struct MempoolStorage {
     unconfirmed_pool: UnconfirmedPool,
-    orphan_pool: OrphanPool<T>,
+    orphan_pool: OrphanPool,
     pending_pool: PendingPool,
     reorg_pool: ReorgPool,
-    validator: Arc<Validator<Transaction, T>>,
+    validator: Arc<Validator<Transaction>>,
 }
 
-impl<T> MempoolStorage<T>
-where T: BlockchainBackend
-{
+impl MempoolStorage {
     /// Create a new Mempool with an UnconfirmedPool, OrphanPool, PendingPool and ReOrgPool.
-    pub fn new(blockchain_db: BlockchainDatabase<T>, config: MempoolConfig, validators: MempoolValidators<T>) -> Self {
+    pub fn new(config: MempoolConfig, validators: MempoolValidators) -> Self {
         let (mempool_validator, orphan_validator) = validators.into_validators();
         Self {
             unconfirmed_pool: UnconfirmedPool::new(config.unconfirmed_pool),
-            orphan_pool: OrphanPool::new(config.orphan_pool, orphan_validator, blockchain_db.clone()),
+            orphan_pool: OrphanPool::new(config.orphan_pool, orphan_validator),
             pending_pool: PendingPool::new(config.pending_pool),
             reorg_pool: ReorgPool::new(config.reorg_pool),
-            blockchain_db,
             validator: Arc::new(mempool_validator),
         }
     }
@@ -78,12 +73,14 @@ where T: BlockchainBackend
         debug!(
             target: LOG_TARGET,
             "Inserting tx into mempool: {}",
-            tx.body.kernels()[0].excess_sig.get_signature().to_hex()
+            tx.body
+                .kernels()
+                .first()
+                .map(|k| k.excess_sig.get_signature().to_hex())
+                .unwrap_or_else(|| "None".into())
         );
-        // The transaction is already internally consistent
-        let db = self.blockchain_db.db_read_access()?;
 
-        match self.validator.validate(&tx, &db) {
+        match self.validator.validate(&tx) {
             Ok(()) => {
                 self.unconfirmed_pool.insert(tx)?;
                 Ok(TxStorageResponse::UnconfirmedPool)

--- a/base_layer/core/src/mempool/orphan_pool/error.rs
+++ b/base_layer/core/src/mempool/orphan_pool/error.rs
@@ -31,4 +31,6 @@ pub enum OrphanPoolError {
     ChainStorageError(#[from] ChainStorageError),
     #[error("The Blockchain height is undefined")]
     ChainHeightUndefined,
+    #[error("Cannot insert transaction with zero kernels")]
+    InsertFailedNoKernels,
 }

--- a/base_layer/core/src/mempool/service/inbound_handlers.rs
+++ b/base_layer/core/src/mempool/service/inbound_handlers.rs
@@ -22,7 +22,7 @@
 
 use crate::{
     base_node::comms_interface::BlockEvent,
-    chain_storage::{BlockAddResult, BlockchainBackend},
+    chain_storage::BlockAddResult,
     mempool::{
         async_mempool,
         service::{MempoolRequest, MempoolResponse, MempoolServiceError, OutboundMempoolServiceInterface},
@@ -44,19 +44,18 @@ pub const LOG_TARGET: &str = "c::mp::service::inbound_handlers";
 
 /// The MempoolInboundHandlers is used to handle all received inbound mempool requests and transactions from remote
 /// nodes.
-pub struct MempoolInboundHandlers<T> {
+#[derive(Clone)]
+pub struct MempoolInboundHandlers {
     event_publisher: Arc<RwLock<Publisher<MempoolStateEvent>>>,
-    mempool: Mempool<T>,
+    mempool: Mempool,
     outbound_nmi: OutboundMempoolServiceInterface,
 }
 
-impl<T> MempoolInboundHandlers<T>
-where T: BlockchainBackend + 'static
-{
+impl MempoolInboundHandlers {
     /// Construct the MempoolInboundHandlers.
     pub fn new(
         event_publisher: Publisher<MempoolStateEvent>,
-        mempool: Mempool<T>,
+        mempool: Mempool,
         outbound_nmi: OutboundMempoolServiceInterface,
     ) -> Self
     {
@@ -211,18 +210,5 @@ where T: BlockchainBackend + 'static
         }
 
         Ok(())
-    }
-}
-
-impl<T> Clone for MempoolInboundHandlers<T>
-where T: BlockchainBackend + 'static
-{
-    fn clone(&self) -> Self {
-        // All members use Arc's internally so calling clone should be cheap.
-        Self {
-            event_publisher: self.event_publisher.clone(),
-            mempool: self.mempool.clone(),
-            outbound_nmi: self.outbound_nmi.clone(),
-        }
     }
 }

--- a/base_layer/core/src/mempool/service/initializer.rs
+++ b/base_layer/core/src/mempool/service/initializer.rs
@@ -22,7 +22,6 @@
 
 use crate::{
     base_node::{comms_interface::LocalNodeCommsInterface, StateMachineHandle},
-    chain_storage::BlockchainBackend,
     mempool::{
         mempool::Mempool,
         proto,
@@ -60,19 +59,17 @@ const LOG_TARGET: &str = "c::bn::mempool_service::initializer";
 const SUBSCRIPTION_LABEL: &str = "Mempool";
 
 /// Initializer for the Mempool service and service future.
-pub struct MempoolServiceInitializer<T> {
+pub struct MempoolServiceInitializer {
     inbound_message_subscription_factory: Arc<SubscriptionFactory>,
-    mempool: Mempool<T>,
+    mempool: Mempool,
     config: MempoolServiceConfig,
 }
 
-impl<T> MempoolServiceInitializer<T>
-where T: BlockchainBackend
-{
+impl MempoolServiceInitializer {
     /// Create a new MempoolServiceInitializer from the inbound message subscriber.
     pub fn new(
         inbound_message_subscription_factory: Arc<SubscriptionFactory>,
-        mempool: Mempool<T>,
+        mempool: Mempool,
         config: MempoolServiceConfig,
     ) -> Self
     {
@@ -138,9 +135,7 @@ async fn extract_transaction(msg: Arc<PeerMessage>) -> Option<DomainMessage<Tran
     }
 }
 
-impl<T> ServiceInitializer for MempoolServiceInitializer<T>
-where T: BlockchainBackend + 'static
-{
+impl ServiceInitializer for MempoolServiceInitializer {
     type Future = impl Future<Output = Result<(), ServiceInitializationError>>;
 
     fn initialize(

--- a/base_layer/core/src/mempool/sync_protocol/extension.rs
+++ b/base_layer/core/src/mempool/sync_protocol/extension.rs
@@ -20,30 +20,27 @@
 //  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 //  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use crate::{
-    chain_storage::BlockchainBackend,
-    mempool::{
-        sync_protocol::{MempoolSyncProtocol, MEMPOOL_SYNC_PROTOCOL},
-        Mempool,
-        MempoolServiceConfig,
-    },
+use crate::mempool::{
+    sync_protocol::{MempoolSyncProtocol, MEMPOOL_SYNC_PROTOCOL},
+    Mempool,
+    MempoolServiceConfig,
 };
 use futures::channel::mpsc;
 use tari_comms::protocol::{ProtocolExtension, ProtocolExtensionContext, ProtocolExtensionError};
 use tokio::task;
 
-pub struct MempoolSyncProtocolExtension<T> {
+pub struct MempoolSyncProtocolExtension {
     config: MempoolServiceConfig,
-    mempool: Mempool<T>,
+    mempool: Mempool,
 }
 
-impl<T> MempoolSyncProtocolExtension<T> {
-    pub fn new(config: MempoolServiceConfig, mempool: Mempool<T>) -> Self {
+impl MempoolSyncProtocolExtension {
+    pub fn new(config: MempoolServiceConfig, mempool: Mempool) -> Self {
         Self { mempool, config }
     }
 }
 
-impl<T: BlockchainBackend + 'static> ProtocolExtension for MempoolSyncProtocolExtension<T> {
+impl ProtocolExtension for MempoolSyncProtocolExtension {
     fn install(self: Box<Self>, context: &mut ProtocolExtensionContext) -> Result<(), ProtocolExtensionError> {
         let (notif_tx, notif_rx) = mpsc::channel(3);
 

--- a/base_layer/core/src/mempool/sync_protocol/mod.rs
+++ b/base_layer/core/src/mempool/sync_protocol/mod.rs
@@ -73,7 +73,6 @@ mod extension;
 pub use extension::MempoolSyncProtocolExtension;
 
 use crate::{
-    chain_storage::BlockchainBackend,
     mempool::{async_mempool, proto, Mempool, MempoolServiceConfig},
     transactions::transaction::Transaction,
 };
@@ -106,25 +105,23 @@ const LOG_TARGET: &str = "c::mempool::sync_protocol";
 
 pub static MEMPOOL_SYNC_PROTOCOL: Bytes = Bytes::from_static(b"/tari/mempool-sync/1.0");
 
-pub struct MempoolSyncProtocol<TSubstream, B> {
+pub struct MempoolSyncProtocol<TSubstream> {
     config: MempoolServiceConfig,
     protocol_notifier: ProtocolNotificationRx<TSubstream>,
     connectivity_events: Fuse<ConnectivityEventRx>,
-    mempool: Mempool<B>,
+    mempool: Mempool,
     num_synched: Arc<AtomicUsize>,
     permits: Arc<Semaphore>,
 }
 
-impl<TSubstream, B> MempoolSyncProtocol<TSubstream, B>
-where
-    TSubstream: AsyncRead + AsyncWrite + Unpin + Send + Sync + 'static,
-    B: BlockchainBackend + 'static,
+impl<TSubstream> MempoolSyncProtocol<TSubstream>
+where TSubstream: AsyncRead + AsyncWrite + Unpin + Send + Sync + 'static
 {
     pub fn new(
         config: MempoolServiceConfig,
         protocol_notifier: ProtocolNotificationRx<TSubstream>,
         connectivity_events: ConnectivityEventRx,
-        mempool: Mempool<B>,
+        mempool: Mempool,
     ) -> Self
     {
         Self {
@@ -259,23 +256,21 @@ where
     }
 }
 
-struct MempoolPeerProtocol<TSubstream, B> {
+struct MempoolPeerProtocol<TSubstream> {
     config: MempoolServiceConfig,
     framed: CanonicalFraming<TSubstream>,
-    mempool: Mempool<B>,
+    mempool: Mempool,
     peer_node_id: NodeId,
 }
 
-impl<TSubstream, B> MempoolPeerProtocol<TSubstream, B>
-where
-    TSubstream: AsyncRead + AsyncWrite + Unpin,
-    B: BlockchainBackend + 'static,
+impl<TSubstream> MempoolPeerProtocol<TSubstream>
+where TSubstream: AsyncRead + AsyncWrite + Unpin
 {
     pub fn new(
         config: MempoolServiceConfig,
         framed: CanonicalFraming<TSubstream>,
         peer_node_id: NodeId,
-        mempool: Mempool<B>,
+        mempool: Mempool,
     ) -> Self
     {
         Self {

--- a/base_layer/core/src/mempool/sync_protocol/test.rs
+++ b/base_layer/core/src/mempool/sync_protocol/test.rs
@@ -21,9 +21,6 @@
 //  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 use crate::{
-    chain_storage::{BlockchainBackend, BlockchainDatabase, MemoryDatabase},
-    consensus::{ConsensusManagerBuilder, Network},
-    helpers::create_mem_db,
     mempool::{
         async_mempool,
         proto,
@@ -31,7 +28,7 @@ use crate::{
         Mempool,
         MempoolValidators,
     },
-    transactions::{helpers::create_tx, tari_amount::uT, transaction::Transaction, types::HashDigest},
+    transactions::{helpers::create_tx, tari_amount::uT, transaction::Transaction},
     validation::mocks::MockValidator,
 };
 use futures::{channel::mpsc, Sink, SinkExt, Stream, StreamExt};
@@ -59,25 +56,16 @@ pub fn create_transactions(n: usize) -> Vec<Transaction> {
     .collect()
 }
 
-fn new_mempool_with_transactions(
-    n: usize,
-) -> (
-    Mempool<MemoryDatabase<HashDigest>>,
-    BlockchainDatabase<MemoryDatabase<HashDigest>>,
-    Vec<Transaction>,
-) {
-    let network = Network::LocalNet;
-    let consensus_manager = ConsensusManagerBuilder::new(network).build();
-    let store = create_mem_db(&consensus_manager);
+fn new_mempool_with_transactions(n: usize) -> (Mempool, Vec<Transaction>) {
     let mempool_validator = MempoolValidators::new(MockValidator::new(true), MockValidator::new(true));
-    let mempool = Mempool::new(store.clone(), Default::default(), mempool_validator);
+    let mempool = Mempool::new(Default::default(), mempool_validator);
 
     let transactions = create_transactions(n);
     for txn in &transactions {
         mempool.insert(Arc::new(txn.clone())).unwrap();
     }
 
-    (mempool, store, transactions)
+    (mempool, transactions)
 }
 
 fn setup(
@@ -85,12 +73,12 @@ fn setup(
 ) -> (
     ProtocolNotificationTx<MemorySocket>,
     ConnectivityEventTx,
-    Mempool<MemoryDatabase<HashDigest>>,
+    Mempool,
     Vec<Transaction>,
 ) {
     let (protocol_notif_tx, protocol_notif_rx) = mpsc::channel(1);
     let (connectivity_events_tx, connectivity_events_rx) = broadcast::channel(10);
-    let (mempool, _blockchain_db, transactions) = new_mempool_with_transactions(num_txns);
+    let (mempool, transactions) = new_mempool_with_transactions(num_txns);
     let protocol = MempoolSyncProtocol::new(
         Default::default(),
         protocol_notif_rx,
@@ -120,7 +108,7 @@ async fn empty_set() {
     let substream = node1_mock.next_incoming_substream().await.unwrap();
     let framed = framing::canonical(substream, MAX_FRAME_SIZE);
 
-    let (mempool2, _, _) = new_mempool_with_transactions(0);
+    let (mempool2, _) = new_mempool_with_transactions(0);
     MempoolPeerProtocol::new(Default::default(), framed, node2.node_id().clone(), mempool2.clone())
         .start_responder()
         .await
@@ -150,7 +138,7 @@ async fn synchronise() {
     let substream = node1_mock.next_incoming_substream().await.unwrap();
     let framed = framing::canonical(substream, MAX_FRAME_SIZE);
 
-    let (mempool2, _, transactions2) = new_mempool_with_transactions(3);
+    let (mempool2, transactions2) = new_mempool_with_transactions(3);
     MempoolPeerProtocol::new(Default::default(), framed, node2.node_id().clone(), mempool2.clone())
         .start_responder()
         .await
@@ -184,7 +172,7 @@ async fn duplicate_set() {
     let substream = node1_mock.next_incoming_substream().await.unwrap();
     let framed = framing::canonical(substream, MAX_FRAME_SIZE);
 
-    let (mempool2, _, transactions2) = new_mempool_with_transactions(1);
+    let (mempool2, transactions2) = new_mempool_with_transactions(1);
     mempool2.insert(Arc::new(transactions1[0].clone())).unwrap();
     MempoolPeerProtocol::new(Default::default(), framed, node2.node_id().clone(), mempool2.clone())
         .start_responder()
@@ -218,7 +206,7 @@ async fn responder() {
         .await
         .unwrap();
 
-    let (mempool2, _, transactions2) = new_mempool_with_transactions(1);
+    let (mempool2, transactions2) = new_mempool_with_transactions(1);
     async_mempool::insert(mempool2.clone(), Arc::new(transactions1[0].clone()))
         .await
         .unwrap();
@@ -324,7 +312,7 @@ async fn responder_messages() {
     assert!(framed.next().await.is_none());
 }
 
-fn get_snapshot<B: BlockchainBackend>(mempool: &Mempool<B>) -> Vec<Transaction> {
+fn get_snapshot(mempool: &Mempool) -> Vec<Transaction> {
     mempool.snapshot().unwrap().iter().map(|t| &**t).cloned().collect()
 }
 

--- a/base_layer/core/src/validation/accum_difficulty_validators.rs
+++ b/base_layer/core/src/validation/accum_difficulty_validators.rs
@@ -23,14 +23,14 @@
 use crate::{
     chain_storage::BlockchainBackend,
     proof_of_work::Difficulty,
-    validation::{Validation, ValidationError},
+    validation::{StatefulValidation, ValidationError},
 };
 
 /// This validator will check if a provided accumulated difficulty is stronger than the chain tip.
 #[derive(Clone)]
 pub struct AccumDifficultyValidator {}
 
-impl<B: BlockchainBackend> Validation<Difficulty, B> for AccumDifficultyValidator {
+impl<B: BlockchainBackend> StatefulValidation<Difficulty, B> for AccumDifficultyValidator {
     fn validate(&self, accum_difficulty: &Difficulty, db: &B) -> Result<(), ValidationError> {
         let tip_header = db
             .fetch_last_header()?
@@ -48,7 +48,7 @@ impl<B: BlockchainBackend> Validation<Difficulty, B> for AccumDifficultyValidato
 #[derive(Clone)]
 pub struct MockAccumDifficultyValidator;
 
-impl<B: BlockchainBackend> Validation<Difficulty, B> for MockAccumDifficultyValidator {
+impl<B: BlockchainBackend> StatefulValidation<Difficulty, B> for MockAccumDifficultyValidator {
     fn validate(&self, accum_difficulty: &Difficulty, db: &B) -> Result<(), ValidationError> {
         let tip_header = db
             .fetch_last_header()?

--- a/base_layer/core/src/validation/and_then.rs
+++ b/base_layer/core/src/validation/and_then.rs
@@ -20,7 +20,7 @@
 //  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 //  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use crate::validation::{StatelessValidation, ValidationError};
+use crate::validation::{Validation, ValidationError};
 
 pub struct AndThenValidator<T, U> {
     first: T,
@@ -33,10 +33,10 @@ impl<T, U> AndThenValidator<T, U> {
     }
 }
 
-impl<T, U, I> StatelessValidation<I> for AndThenValidator<T, U>
+impl<T, U, I> Validation<I> for AndThenValidator<T, U>
 where
-    T: StatelessValidation<I>,
-    U: StatelessValidation<I>,
+    T: Validation<I>,
+    U: Validation<I>,
 {
     fn validate(&self, item: &I) -> Result<(), ValidationError> {
         self.first.validate(item)?;

--- a/base_layer/core/src/validation/block_validators.rs
+++ b/base_layer/core/src/validation/block_validators.rs
@@ -32,7 +32,7 @@ use crate::{
     transactions::types::CryptoFactories,
     validation::{
         helpers::{check_achieved_and_target_difficulty, check_median_timestamp, is_stxo},
-        StatelessValidation,
+        StatefulValidation,
         Validation,
         ValidationError,
     },
@@ -55,7 +55,7 @@ impl StatelessBlockValidator {
     }
 }
 
-impl StatelessValidation<Block> for StatelessBlockValidator {
+impl Validation<Block> for StatelessBlockValidator {
     /// The consensus checks that are done (in order of cheapest to verify to most expensive):
     /// 1. Is the block weight of the block under the prescribed limit?
     /// 1. Does it contain only unique inputs and outputs?
@@ -102,7 +102,7 @@ impl FullConsensusValidator {
     }
 }
 
-impl<B: BlockchainBackend> Validation<Block, B> for FullConsensusValidator {
+impl<B: BlockchainBackend> StatefulValidation<Block, B> for FullConsensusValidator {
     /// The consensus checks that are done (in order of cheapest to verify to most expensive):
     /// 1. Does the block satisfy the stateless checks?
     /// 1. Are all inputs currently in the UTXO set?
@@ -134,7 +134,7 @@ impl<B: BlockchainBackend> Validation<Block, B> for FullConsensusValidator {
     }
 }
 
-impl<B: BlockchainBackend> Validation<BlockHeader, B> for FullConsensusValidator {
+impl<B: BlockchainBackend> StatefulValidation<BlockHeader, B> for FullConsensusValidator {
     /// The consensus checks that are done (in order of cheapest to verify to most expensive):
     /// 1. Is the Proof of Work valid?
     /// 1. Is the achieved difficulty of this block >= the target difficulty for this block?
@@ -181,7 +181,7 @@ impl MockStatelessBlockValidator {
     }
 }
 
-impl StatelessValidation<Block> for MockStatelessBlockValidator {
+impl Validation<Block> for MockStatelessBlockValidator {
     /// The consensus checks that are done (in order of cheapest to verify to most expensive):
     /// 1. Is there precisely one Coinbase output and is it correctly defined?
     /// 1. Is the block weight of the block under the prescribed limit?

--- a/base_layer/core/src/validation/mocks.rs
+++ b/base_layer/core/src/validation/mocks.rs
@@ -20,7 +20,7 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use super::{StatelessValidation, Validation};
+use super::{StatefulValidation, Validation};
 use crate::{chain_storage::BlockchainBackend, validation::error::ValidationError};
 use std::sync::{
     atomic::{AtomicBool, Ordering},
@@ -44,7 +44,7 @@ impl MockValidator {
     }
 }
 
-impl<T, B: BlockchainBackend> Validation<T, B> for MockValidator {
+impl<T, B: BlockchainBackend> StatefulValidation<T, B> for MockValidator {
     fn validate(&self, _item: &T, _db: &B) -> Result<(), ValidationError> {
         if self.is_valid.load(Ordering::SeqCst) {
             Ok(())
@@ -56,7 +56,7 @@ impl<T, B: BlockchainBackend> Validation<T, B> for MockValidator {
     }
 }
 
-impl<T> StatelessValidation<T> for MockValidator {
+impl<T> Validation<T> for MockValidator {
     fn validate(&self, _item: &T) -> Result<(), ValidationError> {
         if self.is_valid.load(Ordering::SeqCst) {
             Ok(())
@@ -70,17 +70,17 @@ impl<T> StatelessValidation<T> for MockValidator {
 
 #[cfg(test)]
 mod test {
-    use crate::validation::{mocks::MockValidator, StatelessValidation};
+    use crate::validation::{mocks::MockValidator, Validation};
 
     #[test]
     fn mock_is_valid() {
         let validator = MockValidator::new(true);
-        assert!(<MockValidator as StatelessValidation<_>>::validate(&validator, &()).is_ok());
+        assert!(<MockValidator as Validation<_>>::validate(&validator, &()).is_ok());
     }
 
     #[test]
     fn mock_is_invalid() {
         let validator = MockValidator::new(false);
-        assert!(<MockValidator as StatelessValidation<_>>::validate(&validator, &()).is_err());
+        assert!(<MockValidator as Validation<_>>::validate(&validator, &()).is_err());
     }
 }

--- a/base_layer/core/src/validation/mod.rs
+++ b/base_layer/core/src/validation/mod.rs
@@ -35,7 +35,7 @@ pub use error::ValidationError;
 mod helpers;
 
 mod traits;
-pub use traits::{StatelessValidation, StatelessValidationExt, StatelessValidator, Validation, Validator};
+pub use traits::{StatefulValidation, StatefulValidator, Validation, ValidationExt, Validator};
 
 pub mod accum_difficulty_validators;
 pub mod block_validators;

--- a/base_layer/core/tests/mempool.rs
+++ b/base_layer/core/tests/mempool.rs
@@ -76,8 +76,11 @@ use tokio::runtime::Runtime;
 fn test_insert_and_process_published_block() {
     let network = Network::LocalNet;
     let (mut store, mut blocks, mut outputs, consensus_manager) = create_new_blockchain(network);
-    let mempool_validator = MempoolValidators::new(TxInputAndMaturityValidator {}, TxInputAndMaturityValidator {});
-    let mempool = Mempool::new(store.clone(), MempoolConfig::default(), mempool_validator);
+    let mempool_validator = MempoolValidators::new(
+        TxInputAndMaturityValidator::new(store.clone()),
+        TxInputAndMaturityValidator::new(store.clone()),
+    );
+    let mempool = Mempool::new(MempoolConfig::default(), mempool_validator);
     // Create a block with 4 outputs
     let txs = vec![txn_schema!(
         from: vec![outputs[0][0].clone()],
@@ -231,8 +234,11 @@ fn test_insert_and_process_published_block() {
 fn test_retrieve() {
     let network = Network::LocalNet;
     let (mut store, mut blocks, mut outputs, consensus_manager) = create_new_blockchain(network);
-    let mempool_validator = MempoolValidators::new(TxInputAndMaturityValidator {}, TxInputAndMaturityValidator {});
-    let mempool = Mempool::new(store.clone(), MempoolConfig::default(), mempool_validator);
+    let mempool_validator = MempoolValidators::new(
+        TxInputAndMaturityValidator::new(store.clone()),
+        TxInputAndMaturityValidator::new(store.clone()),
+    );
+    let mempool = Mempool::new(MempoolConfig::default(), mempool_validator);
     let txs = vec![txn_schema!(
         from: vec![outputs[0][0].clone()],
         to: vec![1 * T, 1 * T, 1 * T, 1 * T, 1 * T, 1 * T, 1 * T]
@@ -330,8 +336,11 @@ fn test_retrieve() {
 fn test_reorg() {
     let network = Network::LocalNet;
     let (mut db, mut blocks, mut outputs, consensus_manager) = create_new_blockchain(network);
-    let mempool_validator = MempoolValidators::new(TxInputAndMaturityValidator {}, TxInputAndMaturityValidator {});
-    let mempool = Mempool::new(db.clone(), MempoolConfig::default(), mempool_validator);
+    let mempool_validator = MempoolValidators::new(
+        TxInputAndMaturityValidator::new(db.clone()),
+        TxInputAndMaturityValidator::new(db.clone()),
+    );
+    let mempool = Mempool::new(MempoolConfig::default(), mempool_validator);
 
     // "Mine" Block 1
     let txs = vec![txn_schema!(from: vec![outputs[0][0].clone()], to: vec![1 * T, 1 * T])];
@@ -459,8 +468,11 @@ fn test_orphaned_mempool_transactions() {
         &consensus_manager.consensus_constants(),
     )
     .unwrap();
-    let mempool_validator = MempoolValidators::new(TxInputAndMaturityValidator {}, TxInputAndMaturityValidator {});
-    let mempool = Mempool::new(store.clone(), MempoolConfig::default(), mempool_validator);
+    let mempool_validator = MempoolValidators::new(
+        TxInputAndMaturityValidator::new(store.clone()),
+        TxInputAndMaturityValidator::new(store.clone()),
+    );
+    let mempool = Mempool::new(MempoolConfig::default(), mempool_validator);
     // There are 2 orphan txs
     vec![txns[2].clone(), txns2[0].clone(), txns2[1].clone(), txns2[2].clone()]
         .into_iter()

--- a/base_layer/core/tests/regression_tests.rs
+++ b/base_layer/core/tests/regression_tests.rs
@@ -26,7 +26,7 @@ use tari_core::{
     proof_of_work::Difficulty,
     tari_utilities::message_format::MessageFormat,
     transactions::types::CryptoFactories,
-    validation::{block_validators::StatelessBlockValidator, StatelessValidation},
+    validation::{block_validators::StatelessBlockValidator, Validation},
 };
 
 /// Commit df95cee73812689bbae77bfb547c1d73a49635d4 introduced a bug in Windows builds that resulted in Block 9182

--- a/infrastructure/test_utils/src/runtime.rs
+++ b/infrastructure/test_utils/src/runtime.rs
@@ -37,6 +37,7 @@ pub fn create_runtime() -> Runtime {
 
 /// Create a runtime and report if it panics. If there are tasks still running after the panic, this
 /// will carry on running forever.
+// #[deprecated(note = "use tokio_macros::test instead")]
 pub fn test_async<F>(f: F)
 where F: FnOnce(&mut TestRuntime) {
     let mut rt = TestRuntime::from(create_runtime());


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
The Mempool should be independent of the blockchain database.
The only reason a coupling currently exsits is because the Mempool requires a generic
`B: BlockchainBackend` just to satisfy the `impl Validator<B>` interface
for its validators.  The `Validator` trait leaks `B: BlockchainBackend`.

To fix this:
- `Validator` renamed to `StatefulValidator`
- `StatelessValidator` renamed to `Validator`
- `FullTxValidator` renamed to `TxInternalConsistencyValidator` and
  performs the internal consistency check only (no db required)
- TxInputAndMaturityValidator implements `Validator`
  (previously `StatelessValidator`) and now takes a
  `BlockchainDatabase<B>`
- The two validators are composed (using the `and_then` combinator)
- Removed the `B` generic from `Mempool` and `OrphanPool`.
- Because of this change, a few mempool tests no longer require the creation
  of a blockchain database.

Extras:
- Fixed a panic if the node receives a transaction with zero kernels.
- Updated some async tests to use the tokio test runtime instead of a mix of futures-rs and the test_async helper

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Code simplification and decoupling

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Rust's type system provides the guarantees that this is correct. Existing tests pass.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [x] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch.
* [x] I ran `cargo-fmt --all` before pushing.
* [x] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
