### PR TITLE
Implement tools to produce network graphs in MemoryNet examples

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -36,7 +36,7 @@ dependencies = [
  "aes",
  "block-cipher",
  "ghash",
- "subtle 2.3.0",
+ "subtle 2.2.3",
 ]
 
 [[package]]
@@ -145,7 +145,7 @@ version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25f9db3b38af870bf7e5cc649167533b493928e50744e2c30ae350230b414670"
 dependencies = [
- "proc-macro2 1.0.21",
+ "proc-macro2 1.0.19",
  "quote 1.0.7",
  "syn 1.0.39",
 ]
@@ -156,7 +156,7 @@ version = "0.1.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e1a4a2f97ce50c9d0282c1468816208588441492b40d813b2e0419c22c05e7f"
 dependencies = [
- "proc-macro2 1.0.21",
+ "proc-macro2 1.0.19",
  "quote 1.0.7",
  "syn 1.0.39",
 ]
@@ -255,7 +255,7 @@ dependencies = [
  "lazycell",
  "log 0.4.11",
  "peeking_take_while",
- "proc-macro2 1.0.21",
+ "proc-macro2 1.0.19",
  "quote 1.0.7",
  "regex",
  "rustc-hash",
@@ -388,7 +388,7 @@ dependencies = [
  "serde 1.0.115",
  "serde_derive",
  "sha3",
- "subtle 2.3.0",
+ "subtle 2.2.3",
  "thiserror",
 ]
 
@@ -412,9 +412,9 @@ checksum = "e3b5ca7a04898ad4bcd41c90c5285445ff5b791899bb1b0abdd2a2aa791211d7"
 
 [[package]]
 name = "bytemuck"
-version = "1.4.1"
+version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41aa2ec95ca3b5c54cf73c91acf06d24f4495d5f1b1c12506ae3483d646177ac"
+checksum = "db7a1029718df60331e557c9e83a55523c955e5dd2a7bfeffad6bbd50b538ae9"
 
 [[package]]
 name = "byteorder"
@@ -876,7 +876,7 @@ dependencies = [
  "packed_simd",
  "rand_core 0.5.1",
  "serde 1.0.115",
- "subtle 2.3.0",
+ "subtle 2.2.3",
  "zeroize",
 ]
 
@@ -898,7 +898,7 @@ checksum = "f0c960ae2da4de88a91b2d920c2a7233b400bc33cb28453a2987822d8392519b"
 dependencies = [
  "fnv",
  "ident_case",
- "proc-macro2 1.0.21",
+ "proc-macro2 1.0.19",
  "quote 1.0.7",
  "strsim 0.9.3",
  "syn 1.0.39",
@@ -955,7 +955,7 @@ version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "45f5098f628d02a7a0f68ddba586fb61e80edec3bdc1be3b921f4ceec60858d3"
 dependencies = [
- "proc-macro2 1.0.21",
+ "proc-macro2 1.0.19",
  "quote 1.0.7",
  "syn 1.0.39",
 ]
@@ -1075,7 +1075,7 @@ version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e57001dfb2532f5a103ff869656887fae9a8defa7d236f3e39d2ee86ed629ad7"
 dependencies = [
- "proc-macro2 1.0.21",
+ "proc-macro2 1.0.19",
  "quote 1.0.7",
  "syn 1.0.39",
 ]
@@ -1106,7 +1106,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "751a786cfcc7d5ceb9e0fe06f0e911da6ce3a3044633e029df4c370193c86a62"
 dependencies = [
  "darling",
- "proc-macro2 1.0.21",
+ "proc-macro2 1.0.19",
  "quote 1.0.7",
  "syn 1.0.39",
 ]
@@ -1370,7 +1370,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0b5a30a4328ab5473878237c447333c093297bded83a4983d10f4deea240d39"
 dependencies = [
  "proc-macro-hack",
- "proc-macro2 1.0.21",
+ "proc-macro2 1.0.19",
  "quote 1.0.7",
  "syn 1.0.39",
 ]
@@ -1533,9 +1533,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.1.15"
+version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc587bc0ec293155d5bfa6b9891ec18a1e330c234f896ea47fbada4cadbe47e6"
+checksum = "7abc8dd8451921606d809ba32e95b6111925cd2906060d2dcc29c070220503eb"
 dependencies = [
  "cfg-if",
  "libc",
@@ -1626,9 +1626,9 @@ dependencies = [
 
 [[package]]
 name = "hermit-abi"
-version = "0.1.16"
+version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c30f6d0bc6b00693347368a67d41b58f2fb851215ff1da49e90fe2c5c667151"
+checksum = "3deed196b6e7f9e44a2ae8d94225d80302d81208b1bb673fd21fe634645c85a9"
 dependencies = [
  "libc",
 ]
@@ -1667,12 +1667,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd179ae861f0c2e53da70d892f5f3029f9594be0c41dc5269cd371691b1dc2f9"
 
 [[package]]
-name = "httpdate"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "494b4d60369511e7dea41cf646832512a94e542f68bb9c49e54518e0f468eb47"
-
-[[package]]
 name = "humantime"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1702,9 +1696,9 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "0.13.8"
+version = "0.13.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f3afcfae8af5ad0576a31e768415edb627824129e8e5a29b8bfccb2f234e835"
+checksum = "3e68a8dd9716185d9e64ea473ea6ef63529252e3e27623295a0378a19665d5eb"
 dependencies = [
  "bytes 0.5.6",
  "futures-channel",
@@ -1714,10 +1708,10 @@ dependencies = [
  "http",
  "http-body",
  "httparse",
- "httpdate",
  "itoa",
  "pin-project",
  "socket2",
+ "time",
  "tokio",
  "tower-service",
  "tracing",
@@ -1731,7 +1725,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d979acc56dcb5b8dddba3917601745e877576475aa046df3226eabdecef78eed"
 dependencies = [
  "bytes 0.5.6",
- "hyper 0.13.8",
+ "hyper 0.13.7",
  "native-tls",
  "tokio",
  "tokio-tls",
@@ -1767,9 +1761,9 @@ dependencies = [
 
 [[package]]
 name = "image"
-version = "0.23.9"
+version = "0.23.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "974e194911d1f7efe3cd8a8f9db3b767e43536327e899e8bc9a12ef5711b74d2"
+checksum = "543904170510c1b5fb65140485d84de4a57fddb2ed685481e9020ce3d2c9f64c"
 dependencies = [
  "bytemuck",
  "byteorder",
@@ -2099,9 +2093,9 @@ checksum = "3728d817d99e5ac407411fa471ff9800a778d88a24685968b36824eaf4bee400"
 
 [[package]]
 name = "memoffset"
-version = "0.5.6"
+version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "043175f069eda7b85febe4a74abbaeff828d9f8b448515d3151a14a3542811aa"
+checksum = "c198b026e1bbf08a937e94c6c60f9ec4a2267f5b0d2eec9c1b21b061ce2be55f"
 dependencies = [
  "autocfg",
 ]
@@ -2134,7 +2128,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9753f12909fd8d923f75ae5c3258cae1ed3c8ec052e1b38c93c21a6d157f789c"
 dependencies = [
  "migrations_internals",
- "proc-macro2 1.0.21",
+ "proc-macro2 1.0.19",
  "quote 1.0.7",
  "syn 1.0.39",
 ]
@@ -2293,9 +2287,9 @@ dependencies = [
 
 [[package]]
 name = "net2"
-version = "0.2.35"
+version = "0.2.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ebc3ec692ed7c9a255596c67808dee269f64655d8baf7b4f0638e51ba1d6853"
+checksum = "2ba7c918ac76704fb42afcbbb43891e72731f3dcca3bef2a19786297baf14af7"
 dependencies = [
  "cfg-if",
  "libc",
@@ -2310,14 +2304,15 @@ checksum = "d36047f46c69ef97b60e7b069a26ce9a15cd8a7852eddb6991ea94a83ba36a78"
 
 [[package]]
 name = "nix"
-version = "0.18.0"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83450fe6a6142ddd95fb064b746083fc4ef1705fe81f64a64e1d4b39f54a1055"
+checksum = "50e4785f2c3b7589a0d0c1dd60285e1188adac4006e8abd6dd578e1567027363"
 dependencies = [
  "bitflags 1.2.1",
  "cc",
  "cfg-if",
  "libc",
+ "void",
 ]
 
 [[package]]
@@ -2608,9 +2603,9 @@ dependencies = [
 
 [[package]]
 name = "parity-scale-codec"
-version = "1.3.5"
+version = "1.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c740e5fbcb6847058b40ac7e5574766c6388f585e184d769910fe0d3a2ca861"
+checksum = "34d38aeaffc032ec69faa476b3caaca8d4dd7f3f798137ff30359e5c7869ceb6"
 dependencies = [
  "arrayvec 0.5.1",
  "bitvec",
@@ -2691,7 +2686,7 @@ version = "0.4.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c0e815c3ee9a031fdf5af21c10aa17c573c9c6a566328d99e3936c34e36461f"
 dependencies = [
- "proc-macro2 1.0.21",
+ "proc-macro2 1.0.19",
  "quote 1.0.7",
  "syn 1.0.39",
 ]
@@ -2762,7 +2757,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
 dependencies = [
  "proc-macro-error-attr",
- "proc-macro2 1.0.21",
+ "proc-macro2 1.0.19",
  "quote 1.0.7",
  "syn 1.0.39",
  "version_check 0.9.2",
@@ -2774,7 +2769,7 @@ version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
 dependencies = [
- "proc-macro2 1.0.21",
+ "proc-macro2 1.0.19",
  "quote 1.0.7",
  "version_check 0.9.2",
 ]
@@ -2802,9 +2797,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.21"
+version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36e28516df94f3dd551a587da5357459d9b36d945a7c37c3557928c1c2ff2a2c"
+checksum = "04f5f085b5d71e2188cb8271e5da0161ad52c3f227a661a3c135fdf28e258b12"
 dependencies = [
  "unicode-xid 0.2.1",
 ]
@@ -2845,7 +2840,7 @@ checksum = "537aa19b95acde10a12fec4301466386f757403de4cd4e5b4fa78fb5ecb18f72"
 dependencies = [
  "anyhow",
  "itertools",
- "proc-macro2 1.0.21",
+ "proc-macro2 1.0.19",
  "quote 1.0.7",
  "syn 1.0.39",
 ]
@@ -2897,7 +2892,7 @@ version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aa563d17ecb180e500da1cfd2b028310ac758de548efdd203e18f283af693f37"
 dependencies = [
- "proc-macro2 1.0.21",
+ "proc-macro2 1.0.19",
 ]
 
 [[package]]
@@ -3134,7 +3129,7 @@ dependencies = [
  "futures-util",
  "http",
  "http-body",
- "hyper 0.13.8",
+ "hyper 0.13.7",
  "hyper-tls",
  "ipnet",
  "js-sys",
@@ -3219,9 +3214,9 @@ dependencies = [
 
 [[package]]
 name = "rustyline"
-version = "6.3.0"
+version = "6.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f0d5e7b0219a3eadd5439498525d4765c59b7c993ef0c12244865cd2d988413"
+checksum = "3358c21cbbc1a751892528db4e1de4b7a2b6a73f001e215aaba97d712cfa9777"
 dependencies = [
  "cfg-if",
  "dirs-next",
@@ -3381,7 +3376,7 @@ version = "1.0.115"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "609feed1d0a73cc36a0182a840a9b37b4a82f0b1150369f0536a9e3f2a31dc48"
 dependencies = [
- "proc-macro2 1.0.21",
+ "proc-macro2 1.0.19",
  "quote 1.0.7",
  "syn 1.0.39",
 ]
@@ -3403,7 +3398,7 @@ version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dc6b7951b17b051f3210b063f12cc17320e2fe30ae05b0fe2a3abb068551c76"
 dependencies = [
- "proc-macro2 1.0.21",
+ "proc-macro2 1.0.19",
  "quote 1.0.7",
  "syn 1.0.39",
 ]
@@ -3530,15 +3525,15 @@ dependencies = [
  "rand_core 0.5.1",
  "rustc_version",
  "sha2",
- "subtle 2.3.0",
+ "subtle 2.2.3",
  "x25519-dalek",
 ]
 
 [[package]]
 name = "socket2"
-version = "0.3.15"
+version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1fa70dc5c8104ec096f4fe7ede7a221d35ae13dcd19ba1ad9a81d2cab9a1c44"
+checksum = "03088793f677dce356f3ccc2edb1b314ad191ab702a5de3faf49304f7e104918"
 dependencies = [
  "cfg-if",
  "libc",
@@ -3604,7 +3599,7 @@ checksum = "5e2513111825077552a6751dfad9e11ce0fba07d7276a3943a037d7e93e64c5f"
 dependencies = [
  "heck",
  "proc-macro-error",
- "proc-macro2 1.0.21",
+ "proc-macro2 1.0.19",
  "quote 1.0.7",
  "syn 1.0.39",
 ]
@@ -3628,7 +3623,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e6e163a520367c465f59e0a61a23cfae3b10b6546d78b6f672a382be79f7110"
 dependencies = [
  "heck",
- "proc-macro2 1.0.21",
+ "proc-macro2 1.0.19",
  "quote 1.0.7",
  "syn 1.0.39",
 ]
@@ -3640,7 +3635,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "87c85aa3f8ea653bfd3ddf25f7ee357ee4d204731f6aa9ad04002306f6e2774c"
 dependencies = [
  "heck",
- "proc-macro2 1.0.21",
+ "proc-macro2 1.0.19",
  "quote 1.0.7",
  "syn 1.0.39",
 ]
@@ -3653,9 +3648,9 @@ checksum = "2d67a5a62ba6e01cb2192ff309324cb4875d0c451d55fe2319433abe7a05a8ee"
 
 [[package]]
 name = "subtle"
-version = "2.3.0"
+version = "2.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "343f3f510c2915908f155e94f17220b19ccfacf2a64a2a5d8004f2c3e311e7fd"
+checksum = "502d53007c02d7605a05df1c1a73ee436952781653da5d0bf57ad608f66932c1"
 
 [[package]]
 name = "supercow"
@@ -3691,7 +3686,7 @@ version = "1.0.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "891d8d6567fe7c7f8835a3a98af4208f3846fba258c1bc3c31d6e506239f11f9"
 dependencies = [
- "proc-macro2 1.0.21",
+ "proc-macro2 1.0.19",
  "quote 1.0.7",
  "unicode-xid 0.2.1",
 ]
@@ -3711,7 +3706,7 @@ version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b834f2d66f734cb897113e34aaff2f1ab4719ca946f9a7358dba8f8064148701"
 dependencies = [
- "proc-macro2 1.0.21",
+ "proc-macro2 1.0.19",
  "quote 1.0.7",
  "syn 1.0.39",
  "unicode-xid 0.2.1",
@@ -3885,6 +3880,7 @@ dependencies = [
  "bitflags 1.2.1",
  "bytes 0.4.12",
  "chrono",
+ "clap",
  "diesel",
  "diesel_migrations",
  "digest",
@@ -3895,6 +3891,7 @@ dependencies = [
  "lazy_static 1.4.0",
  "lmdb-zero",
  "log 0.4.11",
+ "petgraph",
  "pin-project",
  "prettytable-rs",
  "prost",
@@ -4082,7 +4079,7 @@ dependencies = [
  "futures 0.3.5",
  "futures-test",
  "hex",
- "hyper 0.13.8",
+ "hyper 0.13.7",
  "jsonrpc",
  "log 0.4.11",
  "monero",
@@ -4398,7 +4395,7 @@ version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd80fc12f73063ac132ac92aceea36734f04a1d93c1240c6944e23a3b8841793"
 dependencies = [
- "proc-macro2 1.0.21",
+ "proc-macro2 1.0.19",
  "quote 1.0.7",
  "syn 1.0.39",
 ]
@@ -4488,7 +4485,7 @@ version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0c3acc6aa564495a0f2e1d59fab677cd7f81a19994cfc7f3ad0e64301560389"
 dependencies = [
- "proc-macro2 1.0.21",
+ "proc-macro2 1.0.19",
  "quote 1.0.7",
  "syn 1.0.39",
 ]
@@ -4574,7 +4571,7 @@ dependencies = [
  "futures-util",
  "http",
  "http-body",
- "hyper 0.13.8",
+ "hyper 0.13.7",
  "percent-encoding 2.1.0",
  "pin-project",
  "prost",
@@ -4596,7 +4593,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71d8d21cb568e802d77055ab7fcd43f0992206de5028de95c8d3a41118d32e8e"
 dependencies = [
- "proc-macro2 1.0.21",
+ "proc-macro2 1.0.19",
  "prost-build",
  "quote 1.0.7",
  "syn 1.0.39",
@@ -4812,7 +4809,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "80e0ccfc3378da0cce270c946b676a376943f5cd16aeba64568e7939806f4ada"
 dependencies = [
- "proc-macro2 1.0.21",
+ "proc-macro2 1.0.19",
  "quote 1.0.7",
  "syn 1.0.39",
 ]
@@ -4988,7 +4985,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8326b2c654932e3e4f9196e69d08fdf7cfd718e1dc6f66b347e6024a0c961402"
 dependencies = [
  "generic-array 0.14.4",
- "subtle 2.3.0",
+ "subtle 2.2.3",
 ]
 
 [[package]]
@@ -5059,6 +5056,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5a972e5669d67ba988ce3dc826706fb0a8b01471c088cb0b6110b805cc36aed"
 
 [[package]]
+name = "void"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
+
+[[package]]
 name = "walkdir"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5112,7 +5115,7 @@ dependencies = [
  "bumpalo",
  "lazy_static 1.4.0",
  "log 0.4.11",
- "proc-macro2 1.0.21",
+ "proc-macro2 1.0.19",
  "quote 1.0.7",
  "syn 1.0.39",
  "wasm-bindgen-shared",
@@ -5146,7 +5149,7 @@ version = "0.2.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f249f06ef7ee334cc3b8ff031bfc11ec99d00f34d86da7498396dc1e3b1498fe"
 dependencies = [
- "proc-macro2 1.0.21",
+ "proc-macro2 1.0.19",
  "quote 1.0.7",
  "syn 1.0.39",
  "wasm-bindgen-backend",
@@ -5282,20 +5285,20 @@ dependencies = [
 
 [[package]]
 name = "zeroize"
-version = "1.1.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05f33972566adbd2d3588b0491eb94b98b43695c4ef897903470ede4f3f5a28a"
+checksum = "3cbac2ed2ba24cc90f5e06485ac8c7c1e5449fe8911aef4d8877218af021a5b8"
 dependencies = [
  "zeroize_derive",
 ]
 
 [[package]]
 name = "zeroize_derive"
-version = "1.0.1"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3f369ddb18862aba61aa49bf31e74d29f0f162dec753063200e1dc084345d16"
+checksum = "de251eec69fc7c1bc3923403d18ececb929380e016afe103da75f396704f8ca2"
 dependencies = [
- "proc-macro2 1.0.21",
+ "proc-macro2 1.0.19",
  "quote 1.0.7",
  "syn 1.0.39",
  "synstructure",

--- a/base_layer/p2p/src/initialization.rs
+++ b/base_layer/p2p/src/initialization.rs
@@ -49,7 +49,6 @@ use tari_storage::{
 };
 use thiserror::Error;
 use tower::ServiceBuilder;
-
 const LOG_TARGET: &str = "p2p::initialization";
 
 #[derive(Debug, Error)]

--- a/comms/dht/Cargo.toml
+++ b/comms/dht/Cargo.toml
@@ -49,6 +49,8 @@ lmdb-zero = "0.4.4"
 prettytable-rs = "0.8.0"
 tempfile = "3.1.0"
 tokio-macros = "0.2.3"
+petgraph = "0.5.1"
+clap = "2.33.0"
 
 # tower-filter dependencies
 tower-test = { version = "^0.3" }

--- a/comms/dht/examples/graphing_utilities/mod.rs
+++ b/comms/dht/examples/graphing_utilities/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2020, The Tari Project
+// Copyright 2020. The Tari Project
 //
 // Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
 // following conditions are met:
@@ -19,8 +19,6 @@
 // SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-#[allow(dead_code)]
-mod drain_burst;
-pub use drain_burst::DrainBurst;
+
 #[allow(dead_code)]
 pub mod utilities;

--- a/comms/dht/examples/graphing_utilities/render_graph_sequence.py
+++ b/comms/dht/examples/graphing_utilities/render_graph_sequence.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+Created on Wed Sep 16 09:12:39 2020
+
+@author: Philip Robinson
+"""
+import sys;
+import matplotlib.pyplot as plt
+import networkx as nx
+import glob
+from matplotlib import animation
+
+import os;
+
+if len(sys.argv) != 5:
+    print("Usage: <Dot file directory> <Output directory>, <Plot all connections>, <Plot neighbour connections>")
+    exit(1)
+
+print(sys.argv);
+
+dot_path = sys.argv[1];
+output_path = sys.argv[2];
+plot_connections = sys.argv[3].lower() == 'true';
+plot_neighbours = sys.argv[4].lower() == 'true';
+
+if (not plot_neighbours) and (not plot_connections):
+    print("Must plot at least 1 graph type");
+    exit(5)
+
+print("Input Dot file directory: ", dot_path);
+print("Output directory: ", output_path)
+
+#Clear output directory
+if os.path.exists(output_path):
+    output_files = glob.glob(os.path.join(output_path,'*'));
+    for file in output_files:
+        os.remove(file)
+else:
+    os.makedirs(output_path)
+
+neighbour_files = []
+if plot_neighbours:
+    neighbour_files = glob.glob(os.path.join(dot_path,"neighbours*"));
+    neighbour_files.sort()
+    if len(neighbour_files) == 0:
+        print("No files to process")
+        exit(2)
+
+connections_files = []
+if plot_connections:
+    connections_files = glob.glob(os.path.join(dot_path,"connections*"));
+    connections_files.sort()
+    if len(connections_files) == 0:
+        print("No files to process")
+        exit(2)
+
+if plot_connections and plot_neighbours:
+    if len(connections_files) != len(neighbour_files):
+        print("Number of connection files and neighbour files must be the same")
+        exit(4)
+
+# Build plot
+if plot_neighbours:
+    initial_file = neighbour_files[0]
+    num_files = len(neighbour_files);
+else:
+    num_files = len(connections_files);
+    initial_file = connections_files[0]
+
+#Setup initial figure and calculate colour map based on number of nodes
+fig, ax = plt.subplots(figsize=(15,10))
+G = nx.drawing.nx_pydot.read_dot(initial_file)
+G = nx.MultiDiGraph(G.to_directed(), directed=True)
+colour_map = plt.cm.get_cmap('hsv', G.number_of_nodes());
+
+for i in range(0, num_files):
+    print("Rendering " + output_path + "/" + "{:03}.png".format(i))
+
+    # favour the neighbours for the spring layout otherwise we will use full connections
+    if plot_neighbours:
+        neighbour_G_dot = nx.drawing.nx_pydot.read_dot(neighbour_files[i])
+        pos = nx.spring_layout(neighbour_G_dot)
+        neighbour_G = nx.MultiDiGraph(neighbour_G_dot.to_directed(), directed=True)
+        nx.draw_networkx_nodes(neighbour_G, pos, cmap=colour_map, node_color=range(0,neighbour_G.number_of_nodes()))
+        nx.draw_networkx_labels(neighbour_G, pos, font_weight='bold')
+    if plot_connections:
+        connections_G_dot = nx.drawing.nx_pydot.read_dot(connections_files[i])
+        connections_G = nx.MultiDiGraph(connections_G_dot)
+        if not plot_neighbours:
+            pos = nx.spring_layout(connections_G)
+            nx.draw_networkx_nodes(connections_G, pos, cmap=colour_map, node_color=range(0,connections_G.number_of_nodes()))
+            nx.draw_networkx_labels(connections_G, pos, font_weight='bold')
+
+    if plot_neighbours:
+        if plot_connections:
+            nx.draw_networkx_edges(connections_G, pos, width=2, edge_color='Grey', alpha=0.3, arrows=False)
+        nx.draw_networkx_edges(neighbour_G, pos, arrows=True)
+    elif plot_connections:
+        nx.draw_networkx_edges(connections_G, pos)
+
+    plt.axis('off')
+    plt.savefig(output_path + "/" + "{:03}".format(i) + ".png", bbox_inches='tight', dpi=200)
+    plt.clf()
+
+exit(0)
+

--- a/comms/dht/examples/graphing_utilities/render_graph_sequence_propagation.py
+++ b/comms/dht/examples/graphing_utilities/render_graph_sequence_propagation.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+Created on Wed Sep 16 09:12:39 2020
+
+@author: Philip Robinson
+"""
+import sys;
+import matplotlib.pyplot as plt
+import networkx as nx
+import glob
+from matplotlib import animation
+
+import os;
+
+if len(sys.argv) != 3:
+    print("Usage: <Dot file directory> <Output directory>")
+    exit(1)
+
+dot_path = sys.argv[1];
+output_path = sys.argv[2];
+
+dot_path = "/tmp/memorynet_temp/join_propagation";
+output_path = "/tmp/memorynet/join_propagation";
+
+print("Input Dot file directory: ", dot_path);
+print("Output directory: ", output_path)
+
+#Clear output directory
+if os.path.exists(output_path):
+    output_files = glob.glob(os.path.join(output_path,'*'));
+    for file in output_files:
+        os.remove(file)
+else:
+    os.makedirs(output_path)
+
+if not os.path.exists(os.path.join(dot_path,'neighbours-000.dot')):
+    print("Starting file neighbours-000.dot must exist");
+    exit(3)
+    
+
+files = glob.glob(os.path.join(dot_path,"hop*"));
+files.sort()
+if len(files) == 0:
+    print("No files to process")
+    exit(2) 
+
+# Build plot
+fig, ax = plt.subplots(figsize=(15,10))
+starting_graph = nx.drawing.nx_pydot.read_dot(os.path.join(dot_path,'neighbours-000.dot'))
+starting_graph = nx.MultiDiGraph(starting_graph.to_directed(), directed=True)
+pos = nx.spring_layout(starting_graph, k=0.5)
+nx.draw_networkx_nodes(starting_graph, pos, node_color="Grey")
+nx.draw_networkx_labels(starting_graph, pos, font_weight='bold')
+nx.draw_networkx_edges(starting_graph, pos, arrows=True, alpha=0.4)
+
+frame_index = 0;
+plt.axis('off')
+plt.savefig(output_path + "/{:03d}.png".format(frame_index), bbox_inches='tight', dpi=200)
+plt.clf()
+
+old_hops = []
+for file in files:
+    frame_index
+    print("Rendering: ", file)
+    filename = file.split('.')[-2].split('/')[-1];
+    hop = nx.drawing.nx_pydot.read_dot(file)
+    
+    nx.draw_networkx_nodes(starting_graph, pos, node_color="Grey")
+    nx.draw_networkx_labels(starting_graph, pos, font_weight='bold')
+    nx.draw_networkx_edges(starting_graph, pos, arrows=True, alpha=0.4)
+
+    for h in old_hops:
+            nx.draw_networkx_edges(h, pos, arrows=True, edge_color="Red", width=3, alpha= 0.2)        
+
+
+    nx.draw_networkx_edges(hop, pos, arrows=True, edge_color="Red", width=2)
+
+    old_hops.append(hop)
+
+    plt.axis('off')
+    plt.savefig(output_path + "/" + filename + ".png", bbox_inches='tight', dpi=200)
+    plt.clf()
+
+exit(0)
+

--- a/comms/dht/examples/graphing_utilities/utilities.rs
+++ b/comms/dht/examples/graphing_utilities/utilities.rs
@@ -1,0 +1,328 @@
+// Copyright 2020. The Tari Project
+//
+// Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+// following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+// disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+// following disclaimer in the documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+// products derived from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+// INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+// WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+// USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+use crate::memory_net::{
+    utilities::{get_short_name, MessagingEventRx, TestNode},
+    DrainBurst,
+};
+use lazy_static::lazy_static;
+use petgraph::{
+    dot::Dot,
+    stable_graph::{NodeIndex, StableGraph},
+    visit::{Bfs, IntoNodeReferences},
+};
+use std::{collections::HashMap, convert::TryFrom, fs, fs::File, io::Write, path::Path, process::Command, sync::Mutex};
+use tari_comms::{connectivity::ConnectivitySelection, peer_manager::NodeId};
+
+const TEMP_GRAPH_OUTPUT_DIR: &str = "/tmp/memorynet_temp";
+
+lazy_static! {
+    static ref GRAPH_FRAME_NUM: Mutex<HashMap<String, usize>> = Mutex::new(HashMap::new());
+}
+
+fn get_next_frame_num(name: &str) -> usize {
+    let mut map = GRAPH_FRAME_NUM.lock().unwrap();
+    let current: usize;
+    match (*map).get_mut(&name.to_string()) {
+        None => {
+            current = 0;
+            (*map).insert(name.to_string(), 1);
+        },
+        Some(count) => {
+            current = *count;
+            *count += 1;
+        },
+    }
+    current
+}
+
+/// Construct a graph of a set of the provided seed nodes and test nodes for a given sequence name. The graph will be
+/// saved as dot files in the temporary file location for this named sequence.
+///
+/// `name`: The name of the sequence that this graph is a part of, the next number in the sequence will be automatically
+/// generated
+/// `seed_nodes`: The set of seed nodes in the network
+/// `network`: The set of network nodes to graph
+/// `num_neighbours`: If you only want to graph up to the neighbours provide that number in this option, else all
+/// connections are graphed.
+pub async fn network_graph_snapshot(
+    name: &str,
+    seed_nodes: &Vec<TestNode>,
+    network: &Vec<TestNode>,
+    num_neighbours: Option<usize>,
+) -> (StableGraph<NodeId, String>, StableGraph<NodeId, String>)
+{
+    let mut graph = StableGraph::new();
+    let mut node_indices = HashMap::new();
+
+    for node in seed_nodes.iter().chain(network.iter()) {
+        let node_id = node.as_ref().comms.node_identity().node_id().clone();
+        let index: NodeIndex<petgraph::stable_graph::DefaultIx> = graph.add_node(node_id.clone());
+        node_indices.insert(node_id.clone(), index);
+    }
+
+    let mut neighbour_graph = graph.clone();
+
+    for node in seed_nodes.iter().chain(network.iter()) {
+        let node_id = node.as_ref().comms.node_identity().node_id().clone();
+
+        let connected_peers = node
+            .as_ref()
+            .comms
+            .connectivity()
+            .select_connections(ConnectivitySelection::all_nodes(vec![]))
+            .await
+            .expect("Can't get connections");
+
+        let node_index = node_indices.get(&node_id).expect("Can't find Node Index 1");
+        for peer in connected_peers.iter() {
+            let distance = node_id.distance(peer.peer_node_id());
+            let peer_node_index = node_indices.get(&peer.peer_node_id()).expect("Can't find Node Index 2");
+
+            graph.add_edge(
+                node_index.clone(),
+                peer_node_index.clone(),
+                u128::try_from(distance)
+                    .expect("Couldn't convert XorDistance to U128")
+                    .to_string(),
+            );
+        }
+        if let Some(n) = num_neighbours {
+            let connected_neighbours = node
+                .as_ref()
+                .comms
+                .connectivity()
+                .select_connections(ConnectivitySelection::ClosestTo(Box::new(node_id.clone()), n, vec![]))
+                .await
+                .expect("Can't get connections");
+
+            let node_index = node_indices.get(&node_id).expect("Can't find Node Index 1");
+            for neighbour in connected_neighbours.iter() {
+                let distance = node_id.distance(neighbour.peer_node_id());
+                let peer_node_index = node_indices
+                    .get(&neighbour.peer_node_id())
+                    .expect("Can't find Node Index 2");
+
+                neighbour_graph.add_edge(
+                    node_index.clone(),
+                    peer_node_index.clone(),
+                    u128::try_from(distance)
+                        .expect("Couldn't convert XorDistance to U128")
+                        .to_string(),
+                );
+            }
+        }
+    }
+
+    let tmp_file_path = Path::new(TEMP_GRAPH_OUTPUT_DIR).join(name);
+
+    let frame_num = get_next_frame_num(name);
+    if frame_num == 0 {
+        let path = tmp_file_path.to_str().expect("Can't clean output directory");
+
+        let _ = fs::remove_dir_all(path);
+        fs::create_dir_all(path).expect("Could not create temp graph directory");
+    }
+
+    let tmp_file_path_connections = tmp_file_path.join(format!("connections-{:03}.dot", frame_num));
+    let mut file = File::create(tmp_file_path_connections).expect("Could not create dot file");
+    file.write_all(Dot::new(&graph).to_string().as_bytes())
+        .expect("Could not write dot file");
+
+    if let Some(_) = num_neighbours {
+        let tmp_file_path_neighbours = tmp_file_path.join(format!("neighbours-{:03}.dot", frame_num));
+        let mut file = File::create(tmp_file_path_neighbours).expect("Could not create dot file");
+        file.write_all(Dot::new(&neighbour_graph).to_string().as_bytes())
+            .expect("Could not write dot file");
+    }
+
+    (graph, neighbour_graph)
+}
+
+/// Run the Python visualization script that will render the graphs stored in the temporary directory for the named
+/// sequence. The rendered graphs will be saved in a named subdirectory in the provided output directory
+pub fn run_python_network_graph_render(
+    name: &str,
+    output_dir: &str,
+    graph_type: PythonRenderType,
+) -> Result<(), String>
+{
+    let temp_path = Path::new(TEMP_GRAPH_OUTPUT_DIR).join(name);
+    let tmp_file_path = match temp_path.to_str() {
+        None => return Err("Could not parse temp file directory".to_string()),
+        Some(p) => p,
+    };
+
+    let output_path = Path::new(output_dir).join(name);
+    let output_file_path = match output_path.to_str() {
+        None => return Err("Could not parse temp file directory".to_string()),
+        Some(p) => p,
+    };
+
+    let plot_full_network = (graph_type == PythonRenderType::NetworkGraphFull ||
+        graph_type == PythonRenderType::NetworkGraphOnlyConnections)
+        .to_string();
+    let plot_full_neighbours = (graph_type == PythonRenderType::NetworkGraphFull ||
+        graph_type == PythonRenderType::NetworkGraphOnlyNeighbours)
+        .to_string();
+
+    let arguments = match graph_type {
+        PythonRenderType::Propagation => vec![
+            "./comms/dht/examples/graphing_utilities/render_graph_sequence_propagation.py",
+            tmp_file_path,
+            output_file_path,
+        ],
+
+        _ => vec![
+            "./comms/dht/examples/graphing_utilities/render_graph_sequence.py",
+            tmp_file_path,
+            output_file_path,
+            plot_full_network.as_str(),
+            plot_full_neighbours.as_str(),
+        ],
+    };
+
+    let mut result = Command::new("python")
+        .args(arguments)
+        .spawn()
+        .map_err(|_| "Could not execute Python command".to_string())?;
+    match result
+        .wait()
+        .map_err(|_| "Python command did not complete".to_string())?
+        .code()
+    {
+        Some(0) => Ok(()),
+        Some(1) => Err("Problem with the arguments".to_string()),
+        Some(2) => Err("No graph files to process".to_string()),
+        _ => Err("Unexpected exit from Python script".to_string()),
+    }
+}
+
+/// This function will take a starting network layout and a message propagation tree and then plot the propagations as a
+/// breadth first traversal of the message propagation tree on top of the network layout
+/// *IMPORTANT* You must have called `network_graph_snapshot(...)` for the network_graph using the same name you used as
+/// the network_graph
+pub async fn create_message_propagation_graphs(
+    name: &str,
+    mut network_graph: StableGraph<NodeId, String>,
+    message_tree: StableGraph<NodeId, String>,
+)
+{
+    let mut bfs = Bfs::new(&message_tree, NodeIndex::new(0));
+
+    network_graph.clear_edges();
+
+    let tmp_file_path = Path::new(TEMP_GRAPH_OUTPUT_DIR).join(name);
+    let mut hop = 0;
+    while let Some(visited) = bfs.next(&message_tree) {
+        let neighbours = message_tree.neighbors(visited.clone());
+        let from_index = network_graph
+            .node_references()
+            .find_map(|(index, weight)| {
+                if weight == &message_tree[visited] {
+                    Some(index)
+                } else {
+                    None
+                }
+            })
+            .expect("Should be able to find node");
+
+        for n in neighbours {
+            let to_index = network_graph
+                .node_references()
+                .find_map(
+                    |(index, weight)| {
+                        if weight == &message_tree[n] {
+                            Some(index)
+                        } else {
+                            None
+                        }
+                    },
+                )
+                .expect("Should be able to find node2");
+            network_graph.add_edge(from_index.clone(), to_index.clone(), "".to_string());
+        }
+        let current_file_path = tmp_file_path.join(format!("hop-{:03}.dot", hop));
+        hop += 1;
+        let mut file = File::create(current_file_path).expect("Could not create dot file");
+        file.write_all(Dot::new(&network_graph).to_string().as_bytes())
+            .expect("Could not write dot file");
+        network_graph.clear_edges();
+    }
+}
+
+#[derive(PartialEq)]
+pub enum PythonRenderType {
+    NetworkGraphFull,
+    NetworkGraphOnlyConnections,
+    NetworkGraphOnlyNeighbours,
+    Propagation,
+}
+
+/// This function will drain the message event queue and then build a message propagation tree assuming the first sender
+/// is the starting node
+pub async fn track_join_message_drain_messaging_events(
+    messaging_rx: &mut MessagingEventRx,
+) -> StableGraph<NodeId, String> {
+    let drain_fut = DrainBurst::new(messaging_rx);
+
+    let messages = drain_fut.await;
+    let num_messages = messages.len();
+
+    let mut graph = StableGraph::new();
+    let mut node_indices: HashMap<NodeId, NodeIndex> = HashMap::new();
+
+    for (from_node, to_node) in &messages {
+        if !node_indices.contains_key(from_node) {
+            let index = graph.add_node(from_node.clone());
+            let _ = node_indices.insert(from_node.clone(), index);
+        }
+        if !node_indices.contains_key(to_node) {
+            let index = graph.add_node(to_node.clone());
+            let _ = node_indices.insert(to_node.clone(), index);
+        }
+    }
+
+    for (from_node, to_node) in &messages {
+        let from_index = node_indices.get(from_node).unwrap().clone();
+        let to_index = node_indices.get(to_node).unwrap().clone();
+        graph.update_edge(from_index, to_index, "".to_string());
+    }
+
+    // Print the tree using a Breadth first traversal
+    let mut bfs = Bfs::new(&graph, NodeIndex::new(0));
+
+    while let Some(visited) = bfs.next(&graph) {
+        let neighbours = graph.neighbors(visited.clone());
+        let neighbour_names: Vec<String> = neighbours.map(|n| get_short_name(&graph[n])).collect();
+        print!(
+            "{} sent {} messages to ",
+            get_short_name(&graph[visited]),
+            neighbour_names.len(),
+        );
+        println!("{}", neighbour_names.join(", "));
+    }
+
+    println!("{} messages sent between nodes", num_messages);
+
+    graph
+}

--- a/comms/dht/examples/memory_net/utilities.rs
+++ b/comms/dht/examples/memory_net/utilities.rs
@@ -1,0 +1,949 @@
+// Copyright 2020. The Tari Project
+//
+// Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+// following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+// disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+// following disclaimer in the documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+// products derived from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+// INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+// WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+// USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+use crate::memory_net::DrainBurst;
+use futures::{channel::mpsc, future, StreamExt};
+use lazy_static::lazy_static;
+use prettytable::{cell, row, Table};
+use rand::{rngs::OsRng, Rng};
+use std::{
+    collections::HashMap,
+    fmt,
+    sync::{Arc, Mutex},
+    time::{Duration, Instant},
+};
+use tari_comms::{
+    backoff::ConstantBackoff,
+    connection_manager::ConnectionDirection,
+    connectivity::ConnectivitySelection,
+    peer_manager::{NodeId, NodeIdentity, Peer, PeerFeatures, PeerStorage},
+    pipeline,
+    pipeline::SinkService,
+    protocol::messaging::MessagingEvent,
+    transports::MemoryTransport,
+    types::CommsDatabase,
+    CommsBuilder,
+    CommsNode,
+    ConnectionManagerEvent,
+    PeerConnection,
+};
+use tari_comms_dht::{
+    domain_message::OutboundDomainMessage,
+    envelope::NodeDestination,
+    inbound::DecryptedDhtMessage,
+    outbound::OutboundEncryption,
+    Dht,
+    DhtBuilder,
+};
+use tari_storage::{
+    lmdb_store::{LMDBBuilder, LMDBConfig},
+    LMDBWrapper,
+};
+use tari_test_utils::{paths::create_temporary_data_path, random};
+use tokio::{runtime, task, time};
+use tower::ServiceBuilder;
+
+pub type MessagingEventRx = mpsc::UnboundedReceiver<(NodeId, NodeId)>;
+pub type MessagingEventTx = mpsc::UnboundedSender<(NodeId, NodeId)>;
+
+#[macro_export]
+macro_rules! banner {
+    ($($arg: tt)*) => {
+        println!();
+        println!("----------------------------------------------------------");
+        println!($($arg)*);
+        println!("----------------------------------------------------------");
+        println!();
+    }
+}
+
+lazy_static! {
+    static ref NAME_MAP: Mutex<HashMap<NodeId, String>> = Mutex::new(HashMap::new());
+    static ref NAME_POS: Mutex<usize> = Mutex::new(0);
+}
+
+pub fn register_name(node_id: NodeId, name: String) {
+    NAME_MAP.lock().unwrap().insert(node_id, name);
+}
+
+pub fn get_name(node_id: &NodeId) -> String {
+    NAME_MAP
+        .lock()
+        .unwrap()
+        .get(node_id)
+        .map(|name| format!("{} ({})", name, node_id.short_str()))
+        .unwrap_or_else(|| format!("NoName ({})", node_id.short_str()))
+}
+
+pub fn get_short_name(node_id: &NodeId) -> String {
+    NAME_MAP
+        .lock()
+        .unwrap()
+        .get(node_id)
+        .map(|name| format!("{}", name))
+        .unwrap_or_else(|| format!("NoName ({})", node_id.short_str()))
+}
+
+pub fn get_next_name() -> String {
+    let pos = {
+        let mut i = NAME_POS.lock().unwrap();
+        *i = *i + 1;
+        *i - 1
+    };
+
+    format!("Node{}", pos)
+}
+
+pub async fn shutdown_all(nodes: Vec<TestNode>) {
+    let tasks = nodes.into_iter().map(|node| node.comms.shutdown());
+    future::join_all(tasks).await;
+}
+
+pub async fn discovery(wallets: &[TestNode], messaging_events_rx: &mut MessagingEventRx, quiet_mode: bool) -> usize {
+    let mut successes = 0;
+    let mut total_messages = 0;
+    let mut total_time = Duration::from_secs(0);
+    for i in 0..wallets.len() - 1 {
+        let wallet1 = wallets.get(i).unwrap();
+        let wallet2 = wallets.get(i + 1).unwrap();
+
+        banner!("🌎 '{}' is going to try discover '{}'.", wallet1, wallet2);
+
+        if !quiet_mode {
+            peer_list_summary(&[wallet1, wallet2]).await;
+        }
+
+        let start = Instant::now();
+        let discovery_result = wallet1
+            .dht
+            .discovery_service_requester()
+            .discover_peer(
+                Box::new(wallet2.node_identity().public_key().clone()),
+                wallet2.node_identity().node_id().clone().into(),
+            )
+            .await;
+
+        match discovery_result {
+            Ok(peer) => {
+                successes += 1;
+                total_time += start.elapsed();
+                banner!(
+                    "⚡️🎉😎 '{}' discovered peer '{}' ({}) in {:.2?}",
+                    wallet1,
+                    get_name(&peer.node_id),
+                    peer,
+                    start.elapsed()
+                );
+
+                time::delay_for(Duration::from_secs(5)).await;
+                total_messages += drain_messaging_events(messaging_events_rx, false).await;
+            },
+            Err(err) => {
+                banner!(
+                    "💩 '{}' failed to discover '{}' after {:.2?} because '{}'",
+                    wallet1,
+                    wallet2,
+                    start.elapsed(),
+                    err
+                );
+
+                time::delay_for(Duration::from_secs(5)).await;
+                total_messages += drain_messaging_events(messaging_events_rx, false).await;
+            },
+        }
+    }
+
+    banner!(
+        "✨ The set of discoveries succeeded {} out of {} times and took a total of {:.1}s with {} messages sent.",
+        successes,
+        wallets.len() - 1,
+        total_time.as_secs_f32(),
+        total_messages
+    );
+    total_messages
+}
+
+pub async fn peer_list_summary<'a, I: IntoIterator<Item = T>, T: AsRef<TestNode>>(network: I) {
+    for node in network {
+        let node_identity = node.as_ref().comms.node_identity();
+        let peers = node
+            .as_ref()
+            .comms
+            .peer_manager()
+            .closest_peers(node_identity.node_id(), 10, &[], None)
+            .await
+            .unwrap();
+        let mut table = Table::new();
+        table.add_row(row![
+            format!("{} closest peers (MAX: 10)", node.as_ref()),
+            "Distance".to_string(),
+            "Kind",
+        ]);
+        table.add_empty_row();
+        for peer in peers {
+            table.add_row(row![
+                get_name(&peer.node_id),
+                node_identity.node_id().distance(&peer.node_id),
+                if peer.features.contains(PeerFeatures::COMMUNICATION_NODE) {
+                    "BaseNode"
+                } else {
+                    "Wallet"
+                }
+            ]);
+        }
+        table.printstd();
+        println!();
+    }
+}
+
+pub async fn network_peer_list_stats(nodes: &[TestNode], wallets: &[TestNode]) {
+    let mut stats = HashMap::<String, usize>::with_capacity(wallets.len());
+    for wallet in wallets {
+        let mut num_known = 0;
+        for node in nodes {
+            if node
+                .comms
+                .peer_manager()
+                .exists_node_id(wallet.node_identity().node_id())
+                .await
+            {
+                num_known += 1;
+            }
+        }
+        stats.insert(get_name(wallet.node_identity().node_id()), num_known);
+    }
+
+    let mut avg = Vec::with_capacity(wallets.len());
+    for (n, v) in stats {
+        let perc = v as f32 / nodes.len() as f32;
+        avg.push(perc);
+        println!(
+            "{} is known by {} out of {} nodes ({:.2}%)",
+            n,
+            v,
+            nodes.len(),
+            perc * 100.0
+        );
+    }
+    println!(
+        "Average {:.2}%",
+        avg.into_iter().sum::<f32>() / wallets.len() as f32 * 100.0
+    );
+}
+
+pub async fn network_connectivity_stats(nodes: &[TestNode], wallets: &[TestNode], quiet_mode: bool) {
+    pub async fn display(nodes: &[TestNode], quiet_mode: bool) -> (usize, usize) {
+        let mut total = 0;
+        let mut avg = Vec::new();
+        for node in nodes {
+            let conns = node.comms.connection_manager().get_active_connections().await.unwrap();
+            total += conns.len();
+            avg.push(conns.len());
+
+            println!("{} connected to {} nodes", node, conns.len());
+            if !quiet_mode {
+                for c in conns {
+                    println!("  {} ({})", get_name(c.peer_node_id()), c.direction());
+                }
+            }
+        }
+        (total, avg.into_iter().sum())
+    }
+    let (mut total, mut avg) = display(nodes, quiet_mode).await;
+    let (t, a) = display(wallets, quiet_mode).await;
+    total += t;
+    avg += a;
+    println!(
+        "{} total connections on the network. ({} per node on average)",
+        total,
+        avg / (wallets.len() + nodes.len())
+    );
+}
+
+pub async fn do_network_wide_propagation(nodes: &mut [TestNode], origin_node_index: Option<usize>) {
+    let random_node = match origin_node_index {
+        Some(n) if n < nodes.len() => &nodes[n],
+        Some(_) | None => &nodes[OsRng.gen_range(0, nodes.len() - 1)],
+    };
+
+    let random_node_id = random_node.comms.node_identity().node_id().clone();
+    const PUBLIC_MESSAGE: &str = "This is something you're all interested in!";
+
+    banner!("🌎 {} is going to broadcast a message to the network", random_node);
+    let send_states = random_node
+        .dht
+        .outbound_requester()
+        .broadcast(
+            NodeDestination::Unknown,
+            OutboundEncryption::None,
+            vec![],
+            OutboundDomainMessage::new(0i32, PUBLIC_MESSAGE.to_string()),
+        )
+        .await
+        .unwrap();
+    let num_connections = random_node
+        .comms
+        .connection_manager()
+        .get_num_active_connections()
+        .await
+        .unwrap();
+    let (success, failed) = send_states.wait_all().await;
+    println!(
+        "🦠 {} broadcast to {}/{} peer(s) ({} connection(s))",
+        random_node.name,
+        success.len(),
+        success.len() + failed.len(),
+        num_connections
+    );
+
+    let start_global = Instant::now();
+    // Spawn task for each peer that will read the message and propagate it on
+    let tasks = nodes
+        .into_iter()
+        .filter(|n| n.comms.node_identity().node_id() != &random_node_id)
+        .enumerate()
+        .map(|(idx, node)| {
+            let mut outbound_req = node.dht.outbound_requester();
+            let mut conn_man = node.comms.connection_manager();
+            let mut ims_rx = node.ims_rx.take().unwrap();
+            let start = Instant::now();
+            let start_global = start_global.clone();
+            let node_name = node.name.clone();
+
+            task::spawn(async move {
+                let result = time::timeout(Duration::from_secs(10), ims_rx.next()).await;
+                let mut is_success = false;
+                match result {
+                    Ok(Some(msg)) => {
+                        let public_msg = msg
+                            .decryption_result
+                            .unwrap()
+                            .decode_part::<String>(1)
+                            .unwrap()
+                            .unwrap();
+                        println!(
+                            "📬 {} got public message '{}' (t={:.0?})",
+                            node_name,
+                            public_msg,
+                            start_global.elapsed(),
+                        );
+                        is_success = true;
+                        let send_states = outbound_req
+                            .propagate(
+                                NodeDestination::Unknown,
+                                OutboundEncryption::None,
+                                vec![msg.source_peer.node_id.clone()],
+                                OutboundDomainMessage::new(0i32, public_msg),
+                            )
+                            .await
+                            .unwrap();
+                        let num_connections = conn_man.get_num_active_connections().await.unwrap();
+                        let (success, failed) = send_states.wait_all().await;
+                        println!(
+                            "🦠 {} propagated to {}/{} peer(s) ({} connection(s))",
+                            node_name,
+                            success.len(),
+                            success.len() + failed.len(),
+                            num_connections
+                        );
+                    },
+                    Err(_) | Ok(None) => {
+                        banner!(
+                            "💩 {} failed to receive network message after {:.2?}",
+                            node_name,
+                            start.elapsed(),
+                        );
+                    },
+                }
+
+                (idx, ims_rx, is_success)
+            })
+        });
+
+    // Put the ims_rxs back
+    let ims_rxs = future::join_all(tasks).await;
+    let mut num_successes = 0;
+    for ims in ims_rxs {
+        let (idx, ims_rx, is_success) = ims.unwrap();
+        nodes[idx].ims_rx = Some(ims_rx);
+        if is_success {
+            num_successes += 1;
+        }
+    }
+
+    banner!(
+        "🙌 Finished propagation test. {} out of {} nodes received the message",
+        num_successes,
+        nodes.len() - 1
+    );
+}
+
+pub async fn do_store_and_forward_message_propagation(
+    wallet: TestNode,
+    wallets: &[TestNode],
+    nodes: &[TestNode],
+    messaging_tx: MessagingEventTx,
+    messaging_rx: &mut MessagingEventRx,
+    num_neighbouring_nodes: usize,
+    num_random_nodes: usize,
+    propagation_factor: usize,
+    quiet_mode: bool,
+) -> (usize, TestNode)
+{
+    banner!(
+        "{} chosen at random to be receive messages from other nodes using store and forward",
+        wallet,
+    );
+    let wallets_peers = wallet.comms.peer_manager().all().await.unwrap();
+    let node_identity = wallet.comms.node_identity().clone();
+
+    let neighbours = wallet
+        .comms
+        .connectivity()
+        .select_connections(ConnectivitySelection::closest_to(
+            wallet.node_identity().node_id().clone(),
+            num_neighbouring_nodes,
+            vec![],
+        ))
+        .await
+        .unwrap()
+        .into_iter()
+        .filter_map(
+            // If a node is not found in the node list it must be the seed node - should probably assert that this is
+            // the case
+            |p| nodes.iter().find(|n| n.node_identity().node_id() == p.peer_node_id()),
+        )
+        .collect::<Vec<_>>();
+
+    let neighbour_subs = neighbours
+        .iter()
+        .map(|n| n.comms.subscribe_messaging_events())
+        .collect::<Vec<_>>();
+
+    banner!(
+        "{} has {} neighbours ({})",
+        wallet,
+        neighbours.len(),
+        neighbours
+            .iter()
+            .map(ToString::to_string)
+            .collect::<Vec<_>>()
+            .join(", ")
+    );
+    banner!("😴 {} is going offline", wallet);
+    wallet.comms.shutdown().await;
+
+    banner!(
+        "🎤 All other wallets are going to attempt to broadcast messages to {} ({})",
+        get_name(node_identity.node_id()),
+        node_identity.public_key(),
+    );
+
+    let start = Instant::now();
+    for wallet in wallets {
+        let secret_message = format!("My name is wiki wiki {}", wallet);
+        let send_states = wallet
+            .dht
+            .outbound_requester()
+            .broadcast(
+                node_identity.node_id().clone().into(),
+                OutboundEncryption::EncryptFor(Box::new(node_identity.public_key().clone())),
+                vec![],
+                OutboundDomainMessage::new(123i32, secret_message.clone()),
+            )
+            .await
+            .unwrap();
+        let (success, failed) = send_states.wait_all().await;
+        println!(
+            "{} sent {}/{} messages",
+            wallet,
+            success.len(),
+            success.len() + failed.len(),
+        );
+    }
+
+    for (idx, mut s) in neighbour_subs.into_iter().enumerate() {
+        let neighbour = neighbours[idx].name.clone();
+        task::spawn(async move {
+            let msg = time::timeout(Duration::from_secs(2), s.next()).await;
+            match msg {
+                Ok(Some(Ok(evt))) => match &*evt {
+                    MessagingEvent::MessageReceived(_, tag) => {
+                        println!("{} received propagated SAF message ({})", neighbour, tag);
+                    },
+                    _ => {},
+                },
+                Ok(_) => {},
+                Err(_) => println!("{} did not receive the SAF message", neighbour),
+            }
+        });
+    }
+
+    banner!("⏰ Waiting a few seconds for messages to propagate around the network...");
+    time::delay_for(Duration::from_secs(5)).await;
+
+    let mut total_messages = drain_messaging_events(messaging_rx, false).await;
+
+    banner!("🤓 {} is coming back online", get_name(node_identity.node_id()));
+    let (tx, ims_rx) = mpsc::channel(1);
+    let (comms, dht) = setup_comms_dht(
+        node_identity,
+        create_peer_storage(wallets_peers),
+        tx,
+        num_neighbouring_nodes,
+        num_random_nodes,
+        propagation_factor,
+    )
+    .await;
+    let mut wallet = TestNode::new(comms, dht, vec![], ims_rx, messaging_tx, quiet_mode);
+    let mut connectivity = wallet.comms.connectivity();
+
+    connectivity
+        .wait_for_connectivity(Duration::from_secs(10))
+        .await
+        .unwrap();
+    take_a_break(nodes.len()).await;
+    let connections = wallet
+        .comms
+        .connection_manager()
+        .get_active_connections()
+        .await
+        .unwrap();
+    println!(
+        "{} has {} connections to {}",
+        wallet,
+        connections.len(),
+        connections
+            .iter()
+            .map(|p| get_name(p.peer_node_id()))
+            .collect::<Vec<_>>()
+            .join(", ")
+    );
+
+    let mut num_msgs = 0;
+    loop {
+        let result = time::timeout(Duration::from_secs(10), wallet.ims_rx.as_mut().unwrap().next()).await;
+        num_msgs += 1;
+        match result {
+            Ok(msg) => {
+                let msg = msg.unwrap();
+                let secret_msg = msg
+                    .decryption_result
+                    .unwrap()
+                    .decode_part::<String>(1)
+                    .unwrap()
+                    .unwrap();
+                banner!(
+                    "🎉 Wallet {} received propagated message '{}' from store and forward in {:.2?}",
+                    wallet,
+                    secret_msg,
+                    start.elapsed()
+                );
+            },
+            Err(err) => {
+                banner!(
+                    "💩 Failed to receive message after {:.0?} using store and forward '{}'",
+                    start.elapsed(),
+                    err
+                );
+            },
+        };
+
+        if num_msgs == wallets.len() {
+            break;
+        }
+    }
+
+    total_messages += drain_messaging_events(messaging_rx, false).await;
+
+    (total_messages, wallet)
+}
+
+pub async fn drain_messaging_events(messaging_rx: &mut MessagingEventRx, show_logs: bool) -> usize {
+    let drain_fut = DrainBurst::new(messaging_rx);
+    if show_logs {
+        let messages = drain_fut.await;
+        let num_messages = messages.len();
+        let mut node_id_buf = Vec::new();
+        let mut last_from_node = None;
+        for (from_node, to_node) in &messages {
+            match &last_from_node {
+                Some(node_id) if *node_id == from_node => {
+                    node_id_buf.push(to_node);
+                },
+                Some(_) => {
+                    println!(
+                        "📨 {} sent {} messages to {}.️",
+                        get_short_name(last_from_node.take().unwrap()),
+                        node_id_buf.len(),
+                        node_id_buf.drain(..).map(get_short_name).collect::<Vec<_>>().join(", ")
+                    );
+
+                    last_from_node = Some(from_node);
+                    node_id_buf.push(to_node)
+                },
+                None => {
+                    last_from_node = Some(from_node);
+                    node_id_buf.push(to_node)
+                },
+            }
+        }
+        println!("{} messages sent between nodes", num_messages);
+        num_messages
+    } else {
+        let len = drain_fut.await.len();
+        println!("📨 {} messages exchanged", len);
+        len
+    }
+}
+
+fn connection_manager_logger(
+    node_id: NodeId,
+    quiet_mode: bool,
+) -> impl FnMut(Arc<ConnectionManagerEvent>) -> Arc<ConnectionManagerEvent>
+{
+    let node_name = get_name(&node_id);
+    move |event| {
+        if quiet_mode {
+            return event;
+        }
+        use ConnectionManagerEvent::*;
+        print!("EVENT: ");
+        match &*event {
+            PeerConnected(conn) => match conn.direction() {
+                ConnectionDirection::Inbound => {
+                    // println!(
+                    //     "'{}' got inbound connection from '{}'",
+                    //     node_name,
+                    //     get_name(conn.peer_node_id()),
+                    // );
+                },
+                ConnectionDirection::Outbound => {
+                    println!("'{}' connected to '{}'", node_name, get_name(conn.peer_node_id()),);
+                },
+            },
+            PeerDisconnected(node_id) => {
+                println!("'{}' disconnected from '{}'", get_name(node_id), node_name);
+            },
+            PeerConnectFailed(node_id, err) => {
+                println!(
+                    "'{}' failed to connect to '{}' because '{:?}'",
+                    node_name,
+                    get_name(node_id),
+                    err
+                );
+            },
+            PeerConnectWillClose(_, node_id, direction) => {
+                println!(
+                    "'{}' will disconnect {} connection to '{}'",
+                    get_name(node_id),
+                    direction,
+                    node_name,
+                );
+            },
+            PeerInboundConnectFailed(err) => {
+                println!(
+                    "'{}' failed to accept inbound connection because '{:?}'",
+                    node_name, err
+                );
+            },
+            Listening(_) | ListenFailed(_) => unreachable!(),
+            NewInboundSubstream(node_id, protocol, _) => {
+                println!(
+                    "'{}' negotiated protocol '{}' to '{}'",
+                    get_name(node_id),
+                    String::from_utf8_lossy(protocol),
+                    node_name
+                );
+            },
+        }
+        event
+    }
+}
+
+pub struct TestNode {
+    pub name: String,
+    pub comms: CommsNode,
+    pub seed_peers: Vec<Peer>,
+    pub dht: Dht,
+    pub conn_man_events_rx: mpsc::Receiver<Arc<ConnectionManagerEvent>>,
+    pub ims_rx: Option<mpsc::Receiver<DecryptedDhtMessage>>,
+}
+
+impl TestNode {
+    pub fn new(
+        comms: CommsNode,
+        dht: Dht,
+        seed_peers: Vec<Peer>,
+        ims_rx: mpsc::Receiver<DecryptedDhtMessage>,
+        messaging_events_tx: MessagingEventTx,
+        quiet_mode: bool,
+    ) -> Self
+    {
+        let name = get_next_name();
+        register_name(comms.node_identity().node_id().clone(), name.clone());
+
+        let (conn_man_events_tx, events_rx) = mpsc::channel(100);
+        Self::spawn_event_monitor(&comms, conn_man_events_tx, messaging_events_tx, quiet_mode);
+
+        Self {
+            name,
+            seed_peers,
+            comms,
+            dht,
+            ims_rx: Some(ims_rx),
+            conn_man_events_rx: events_rx,
+        }
+    }
+
+    fn spawn_event_monitor(
+        comms: &CommsNode,
+        events_tx: mpsc::Sender<Arc<ConnectionManagerEvent>>,
+        messaging_events_tx: MessagingEventTx,
+        quiet_mode: bool,
+    )
+    {
+        let conn_man_event_sub = comms.subscribe_connection_manager_events();
+        let messaging_events = comms.subscribe_messaging_events();
+        let executor = runtime::Handle::current();
+
+        executor.spawn(
+            conn_man_event_sub
+                .filter(|r| future::ready(r.is_ok()))
+                .map(Result::unwrap)
+                .map(connection_manager_logger(
+                    comms.node_identity().node_id().clone(),
+                    quiet_mode,
+                ))
+                .map(Ok)
+                .forward(events_tx),
+        );
+
+        let node_id = comms.node_identity().node_id().clone();
+
+        executor.spawn(
+            messaging_events
+                .filter(|r| future::ready(r.is_ok()))
+                .map(Result::unwrap)
+                .filter_map(move |event| {
+                    use MessagingEvent::*;
+                    future::ready(match &*event {
+                        MessageReceived(peer_node_id, _) => Some((Clone::clone(&*peer_node_id), node_id.clone())),
+                        _ => None,
+                    })
+                })
+                .map(Ok)
+                .forward(messaging_events_tx),
+        );
+    }
+
+    #[inline]
+    pub fn node_identity(&self) -> Arc<NodeIdentity> {
+        self.comms.node_identity()
+    }
+
+    #[inline]
+    pub fn to_peer(&self) -> Peer {
+        self.comms.node_identity().to_peer()
+    }
+
+    #[allow(dead_code)]
+    pub async fn expect_peer_connection(&mut self, node_id: &NodeId) -> Option<PeerConnection> {
+        if let Some(conn) = self.comms.connectivity().get_connection(node_id.clone()).await.unwrap() {
+            return Some(conn);
+        }
+        use ConnectionManagerEvent::*;
+        loop {
+            let event = time::timeout(Duration::from_secs(30), self.conn_man_events_rx.next())
+                .await
+                .ok()??;
+
+            match &*event {
+                PeerConnected(conn) if conn.peer_node_id() == node_id => {
+                    break Some(conn.clone());
+                },
+                _ => {},
+            }
+        }
+    }
+}
+
+impl AsRef<TestNode> for TestNode {
+    fn as_ref(&self) -> &TestNode {
+        self
+    }
+}
+
+impl fmt::Display for TestNode {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(
+            f,
+            "{} ({})",
+            self.name,
+            self.comms.node_identity().node_id().short_str()
+        )
+    }
+}
+
+pub fn make_node_identity(features: PeerFeatures) -> Arc<NodeIdentity> {
+    let port = MemoryTransport::acquire_next_memsocket_port();
+    Arc::new(NodeIdentity::random(&mut OsRng, format!("/memory/{}", port).parse().unwrap(), features).unwrap())
+}
+
+fn create_peer_storage(peers: Vec<Peer>) -> CommsDatabase {
+    let database_name = random::string(8);
+    let datastore = LMDBBuilder::new()
+        .set_path(create_temporary_data_path().to_str().unwrap())
+        .set_env_config(LMDBConfig::default())
+        .set_max_number_of_databases(1)
+        .add_database(&database_name, lmdb_zero::db::CREATE)
+        .build()
+        .unwrap();
+
+    let peer_database = datastore.get_handle(&database_name).unwrap();
+    let peer_database = LMDBWrapper::new(Arc::new(peer_database));
+    let mut storage = PeerStorage::new_indexed(peer_database).unwrap();
+    for peer in peers {
+        storage.add_peer(peer).unwrap();
+    }
+
+    storage.into()
+}
+
+pub async fn make_node(
+    features: PeerFeatures,
+    peer_identities: Vec<Arc<NodeIdentity>>,
+    messaging_events_tx: MessagingEventTx,
+    num_neighbouring_nodes: usize,
+    num_random_nodes: usize,
+    propagation_factor: usize,
+    quiet_mode: bool,
+) -> TestNode
+{
+    let node_identity = make_node_identity(features);
+    make_node_from_node_identities(
+        node_identity,
+        peer_identities,
+        messaging_events_tx,
+        num_neighbouring_nodes,
+        num_random_nodes,
+        propagation_factor,
+        quiet_mode,
+    )
+    .await
+}
+
+pub async fn make_node_from_node_identities(
+    node_identity: Arc<NodeIdentity>,
+    peer_identities: Vec<Arc<NodeIdentity>>,
+    messaging_events_tx: MessagingEventTx,
+    num_neighbouring_nodes: usize,
+    num_random_nodes: usize,
+    propagation_factor: usize,
+    quiet_mode: bool,
+) -> TestNode
+{
+    let (tx, ims_rx) = mpsc::channel(1);
+    let seed_peers: Vec<Peer> = peer_identities.iter().map(|n| n.to_peer()).collect();
+    let (comms, dht) = setup_comms_dht(
+        node_identity,
+        create_peer_storage(seed_peers.clone()),
+        tx,
+        num_neighbouring_nodes,
+        num_random_nodes,
+        propagation_factor,
+    )
+    .await;
+
+    TestNode::new(comms, dht, seed_peers, ims_rx, messaging_events_tx, quiet_mode)
+}
+
+pub async fn setup_comms_dht(
+    node_identity: Arc<NodeIdentity>,
+    storage: CommsDatabase,
+    inbound_tx: mpsc::Sender<DecryptedDhtMessage>,
+    num_neighbouring_nodes: usize,
+    num_random_nodes: usize,
+    propagation_factor: usize,
+) -> (CommsNode, Dht)
+{
+    // Create inbound and outbound channels
+    let (outbound_tx, outbound_rx) = mpsc::channel(10);
+
+    let comms = CommsBuilder::new()
+        .allow_test_addresses()
+        // In this case the listener address and the public address are the same (/memory/...)
+        .with_listener_address(node_identity.public_address())
+        .with_transport(MemoryTransport)
+        .with_node_identity(node_identity)
+        .with_min_connectivity(0.3)
+        .with_peer_storage(storage)
+        .with_dial_backoff(ConstantBackoff::new(Duration::from_millis(1000)))
+        .build()
+        .unwrap();
+
+    let dht = DhtBuilder::new(
+        comms.node_identity(),
+        comms.peer_manager(),
+        outbound_tx,
+        comms.connectivity(),
+        comms.shutdown_signal(),
+    )
+        .local_test()
+        //.enable_auto_join()
+        .set_auto_store_and_forward_requests(false)
+        .with_discovery_timeout(Duration::from_secs(15))
+        .with_num_neighbouring_nodes(num_neighbouring_nodes)
+        .with_num_random_nodes(num_random_nodes)
+        .with_propagation_factor(propagation_factor)
+        .finish()
+        .await
+        .unwrap();
+
+    let dht_outbound_layer = dht.outbound_middleware_layer();
+
+    let comms = comms
+        .with_messaging_pipeline(
+            pipeline::Builder::new()
+                .outbound_buffer_size(10)
+                .with_outbound_pipeline(outbound_rx, |sink| {
+                    ServiceBuilder::new().layer(dht_outbound_layer).service(sink)
+                })
+                .max_concurrent_inbound_tasks(10)
+                .with_inbound_pipeline(
+                    ServiceBuilder::new()
+                        .layer(dht.inbound_middleware_layer())
+                        .service(SinkService::new(inbound_tx)),
+                )
+                .finish(),
+        )
+        .spawn()
+        .await
+        .unwrap();
+
+    (comms, dht)
+}
+
+pub async fn take_a_break(num_nodes: usize) {
+    banner!("Taking a break for a few seconds to let things settle...");
+    time::delay_for(Duration::from_millis(num_nodes as u64 * 100)).await;
+}

--- a/comms/dht/examples/memorynet.rs
+++ b/comms/dht/examples/memorynet.rs
@@ -35,6 +35,25 @@
 //!
 //! `RUST_BACKTRACE=1 RUST_LOG=trace cargo run --example memorynet 2> /tmp/debug.log`
 
+mod memory_net;
+
+use crate::memory_net::utilities::{
+    discovery,
+    do_network_wide_propagation,
+    do_store_and_forward_message_propagation,
+    drain_messaging_events,
+    get_name,
+    make_node,
+    network_connectivity_stats,
+    network_peer_list_stats,
+    shutdown_all,
+    take_a_break,
+};
+use futures::{channel::mpsc, future};
+use rand::{rngs::OsRng, Rng};
+use std::{iter::repeat_with, time::Duration};
+use tari_comms::peer_manager::PeerFeatures;
+
 // Size of network
 const NUM_NODES: usize = 40;
 // Must be at least 2
@@ -46,109 +65,6 @@ const NUM_NEIGHBOURING_NODES: usize = 8;
 const NUM_RANDOM_NODES: usize = 4;
 /// The number of messages that should be propagated out
 const PROPAGATION_FACTOR: usize = 4;
-
-mod memory_net;
-
-use futures::{channel::mpsc, future, StreamExt};
-use lazy_static::lazy_static;
-use memory_net::DrainBurst;
-use prettytable::{cell, row, Table};
-use rand::{rngs::OsRng, Rng};
-use std::{
-    collections::HashMap,
-    fmt,
-    iter::repeat_with,
-    sync::{Arc, Mutex},
-    time::{Duration, Instant},
-};
-use tari_comms::{
-    backoff::ConstantBackoff,
-    connection_manager::ConnectionDirection,
-    connectivity::ConnectivitySelection,
-    peer_manager::{NodeId, NodeIdentity, Peer, PeerFeatures, PeerStorage},
-    pipeline,
-    pipeline::SinkService,
-    protocol::messaging::MessagingEvent,
-    transports::MemoryTransport,
-    types::CommsDatabase,
-    CommsBuilder,
-    CommsNode,
-    ConnectionManagerEvent,
-    PeerConnection,
-};
-use tari_comms_dht::{
-    domain_message::OutboundDomainMessage,
-    envelope::NodeDestination,
-    inbound::DecryptedDhtMessage,
-    outbound::OutboundEncryption,
-    Dht,
-    DhtBuilder,
-};
-use tari_storage::{
-    lmdb_store::{LMDBBuilder, LMDBConfig},
-    LMDBWrapper,
-};
-use tari_test_utils::{paths::create_temporary_data_path, random};
-use tokio::{runtime, task, time};
-use tower::ServiceBuilder;
-
-type MessagingEventRx = mpsc::UnboundedReceiver<(NodeId, NodeId)>;
-type MessagingEventTx = mpsc::UnboundedSender<(NodeId, NodeId)>;
-
-macro_rules! banner {
-    ($($arg: tt)*) => {
-        println!();
-        println!("----------------------------------------------------------");
-        println!($($arg)*);
-        println!("----------------------------------------------------------");
-        println!();
-    }
-}
-
-const NAMES: &[&str] = &[
-    "Alice", "Bob", "Carol", "Charlie", "Dave", "Eve", "Isaac", "Ivan", "Justin", "Mallory", "Marvin", "Mallet",
-    "Matilda", "Oscar", "Pat", "Peggy", "Vanna", "Plod", "Steve", "Trent", "Trudy", "Walter", "Zoe",
-];
-
-lazy_static! {
-    static ref NAME_MAP: Mutex<HashMap<NodeId, String>> = Mutex::new(HashMap::new());
-    static ref NAME_POS: Mutex<usize> = Mutex::new(0);
-}
-
-fn register_name(node_id: NodeId, name: String) {
-    NAME_MAP.lock().unwrap().insert(node_id, name);
-}
-
-fn get_name(node_id: &NodeId) -> String {
-    NAME_MAP
-        .lock()
-        .unwrap()
-        .get(node_id)
-        .map(|name| format!("{} ({})", name, node_id.short_str()))
-        .unwrap_or_else(|| format!("NoName ({})", node_id.short_str()))
-}
-
-fn get_short_name(node_id: &NodeId) -> String {
-    NAME_MAP
-        .lock()
-        .unwrap()
-        .get(node_id)
-        .map(|name| format!("{}", name))
-        .unwrap_or_else(|| format!("NoName ({})", node_id.short_str()))
-}
-
-fn get_next_name() -> String {
-    let pos = {
-        let mut i = NAME_POS.lock().unwrap();
-        *i = *i + 1;
-        *i
-    };
-    if pos > NAMES.len() {
-        format!("Node{}", pos - NAMES.len())
-    } else {
-        NAMES[pos - 1].to_owned()
-    }
-}
 
 #[tokio_macros::main]
 async fn main() {
@@ -162,14 +78,29 @@ async fn main() {
 
     let (messaging_events_tx, mut messaging_events_rx) = mpsc::unbounded();
 
-    let seed_node = make_node(PeerFeatures::COMMUNICATION_NODE, None, messaging_events_tx.clone()).await;
+    let seed_node = vec![
+        make_node(
+            PeerFeatures::COMMUNICATION_NODE,
+            vec![],
+            messaging_events_tx.clone(),
+            NUM_NEIGHBOURING_NODES,
+            NUM_RANDOM_NODES,
+            PROPAGATION_FACTOR,
+            QUIET_MODE,
+        )
+        .await,
+    ];
 
     let mut nodes = future::join_all(
         repeat_with(|| {
             make_node(
                 PeerFeatures::COMMUNICATION_NODE,
-                Some(seed_node.to_peer()),
+                vec![seed_node[0].node_identity().clone()],
                 messaging_events_tx.clone(),
+                NUM_NEIGHBOURING_NODES,
+                NUM_RANDOM_NODES,
+                PROPAGATION_FACTOR,
+                QUIET_MODE,
             )
         })
         .take(NUM_NODES),
@@ -180,8 +111,12 @@ async fn main() {
         repeat_with(|| {
             make_node(
                 PeerFeatures::COMMUNICATION_CLIENT,
-                Some(nodes[OsRng.gen_range(0, NUM_NODES - 1)].to_peer()),
+                vec![nodes[OsRng.gen_range(0, NUM_NODES - 1)].node_identity().clone()],
                 messaging_events_tx.clone(),
+                NUM_NEIGHBOURING_NODES,
+                NUM_RANDOM_NODES,
+                PROPAGATION_FACTOR,
+                QUIET_MODE,
             )
         })
         .take(NUM_WALLETS),
@@ -210,36 +145,37 @@ async fn main() {
     //     }
     // }
 
-    log::info!("------------------------------- BASE NODE JOIN -------------------------------");
-    for node in nodes.iter_mut() {
-        println!(
-            "Node '{}' is joining the network via the seed node '{}'",
-            node, seed_node
-        );
-        node.comms
-            .connectivity()
-            .wait_for_connectivity(Duration::from_secs(10))
-            .await
-            .unwrap();
+    // Wait for all the nodes to startup and connect to seed node
+    take_a_break(NUM_NODES).await;
 
-        node.dht.dht_requester().send_join().await.unwrap();
+    log::info!("------------------------------- BASE NODE JOIN -------------------------------");
+    for index in 0..nodes.len() {
+        {
+            let node = nodes.get_mut(index).expect("Couldn't get TestNode");
+            println!(
+                "Node '{}' is joining the network via the seed node '{}'",
+                node, seed_node[0]
+            );
+            node.comms
+                .connectivity()
+                .wait_for_connectivity(Duration::from_secs(10))
+                .await
+                .unwrap();
+
+            node.dht.dht_requester().send_join().await.unwrap();
+        }
     }
 
-    take_a_break().await;
+    take_a_break(NUM_NODES).await;
 
     // peer_list_summary(&nodes).await;
-
-    banner!(
-        "Now, {} wallets are going to join from a random base node.",
-        NUM_WALLETS
-    );
 
     log::info!("------------------------------- WALLET JOIN -------------------------------");
     for wallet in wallets.iter_mut() {
         println!(
             "Wallet '{}' is joining the network via node '{}'",
             wallet,
-            get_name(&wallet.seed_peer.as_ref().unwrap().node_id)
+            get_name(&wallet.seed_peers[0].node_id)
         );
         wallet
             .comms
@@ -250,17 +186,17 @@ async fn main() {
         wallet.dht.dht_requester().send_join().await.unwrap();
     }
 
-    take_a_break().await;
+    take_a_break(NUM_NODES).await;
     let mut total_messages = 0;
     total_messages += drain_messaging_events(&mut messaging_events_rx, false).await;
 
     network_peer_list_stats(&nodes, &nodes).await;
     network_peer_list_stats(&nodes, &wallets).await;
-    network_connectivity_stats(&nodes, &wallets).await;
+    network_connectivity_stats(&nodes, &wallets, QUIET_MODE).await;
 
     {
-        let count = seed_node.comms.peer_manager().count().await;
-        let num_connections = seed_node
+        let count = seed_node[0].comms.peer_manager().count().await;
+        let num_connections = seed_node[0]
             .comms
             .connection_manager()
             .get_num_active_connections()
@@ -269,10 +205,10 @@ async fn main() {
         println!("Seed node knows {} peers ({} connections)", count, num_connections);
     }
 
-    take_a_break().await;
+    take_a_break(NUM_NODES).await;
 
     log::info!("------------------------------- DISCOVERY -------------------------------");
-    total_messages += discovery(&wallets, &mut messaging_events_rx).await;
+    total_messages += discovery(&wallets, &mut messaging_events_rx, QUIET_MODE).await;
 
     total_messages += drain_messaging_events(&mut messaging_events_rx, false).await;
 
@@ -285,6 +221,10 @@ async fn main() {
             &nodes,
             messaging_events_tx.clone(),
             &mut messaging_events_rx,
+            NUM_NEIGHBOURING_NODES,
+            NUM_RANDOM_NODES,
+            PROPAGATION_FACTOR,
+            QUIET_MODE,
         )
         .await;
         total_messages += num_msgs;
@@ -293,793 +233,18 @@ async fn main() {
     }
 
     log::info!("------------------------------- PROPAGATION -------------------------------");
-    do_network_wide_propagation(&mut nodes).await;
+    do_network_wide_propagation(&mut nodes, None).await;
 
     total_messages += drain_messaging_events(&mut messaging_events_rx, false).await;
 
     println!("{} messages sent in total across the network", total_messages);
 
     network_peer_list_stats(&nodes, &wallets).await;
-    network_connectivity_stats(&nodes, &wallets).await;
+    network_connectivity_stats(&nodes, &wallets, QUIET_MODE).await;
 
     banner!("That's it folks! Network is shutting down...");
     log::info!("------------------------------- SHUTDOWN -------------------------------");
 
     shutdown_all(nodes).await;
     shutdown_all(wallets).await;
-}
-
-async fn shutdown_all(nodes: Vec<TestNode>) {
-    let tasks = nodes.into_iter().map(|node| node.comms.shutdown());
-    future::join_all(tasks).await;
-}
-
-async fn discovery(wallets: &[TestNode], messaging_events_rx: &mut MessagingEventRx) -> usize {
-    let mut successes = 0;
-    let mut total_messages = 0;
-    let mut total_time = Duration::from_secs(0);
-    for i in 0..wallets.len() - 1 {
-        let wallet1 = wallets.get(i).unwrap();
-        let wallet2 = wallets.get(i + 1).unwrap();
-
-        banner!("🌎 '{}' is going to try discover '{}'.", wallet1, wallet2);
-
-        if !QUIET_MODE {
-            peer_list_summary(&[wallet1, wallet2]).await;
-        }
-
-        let start = Instant::now();
-        let discovery_result = wallet1
-            .dht
-            .discovery_service_requester()
-            .discover_peer(
-                Box::new(wallet2.node_identity().public_key().clone()),
-                wallet2.node_identity().node_id().clone().into(),
-            )
-            .await;
-
-        match discovery_result {
-            Ok(peer) => {
-                successes += 1;
-                total_time += start.elapsed();
-                banner!(
-                    "⚡️🎉😎 '{}' discovered peer '{}' ({}) in {:.2?}",
-                    wallet1,
-                    get_name(&peer.node_id),
-                    peer,
-                    start.elapsed()
-                );
-
-                time::delay_for(Duration::from_secs(5)).await;
-                total_messages += drain_messaging_events(messaging_events_rx, false).await;
-            },
-            Err(err) => {
-                banner!(
-                    "💩 '{}' failed to discover '{}' after {:.2?} because '{}'",
-                    wallet1,
-                    wallet2,
-                    start.elapsed(),
-                    err
-                );
-
-                time::delay_for(Duration::from_secs(5)).await;
-                total_messages += drain_messaging_events(messaging_events_rx, false).await;
-            },
-        }
-    }
-
-    banner!(
-        "✨ The set of discoveries succeeded {} out of {} times and took a total of {:.1}s with {} messages sent.",
-        successes,
-        wallets.len() - 1,
-        total_time.as_secs_f32(),
-        total_messages
-    );
-    total_messages
-}
-
-async fn peer_list_summary<'a, I: IntoIterator<Item = T>, T: AsRef<TestNode>>(network: I) {
-    for node in network {
-        let node_identity = node.as_ref().comms.node_identity();
-        let peers = node
-            .as_ref()
-            .comms
-            .peer_manager()
-            .closest_peers(node_identity.node_id(), 10, &[], None)
-            .await
-            .unwrap();
-        let mut table = Table::new();
-        table.add_row(row![
-            format!("{} closest peers (MAX: 10)", node.as_ref()),
-            "Distance".to_string(),
-            "Kind",
-        ]);
-        table.add_empty_row();
-        for peer in peers {
-            table.add_row(row![
-                get_name(&peer.node_id),
-                node_identity.node_id().distance(&peer.node_id),
-                if peer.features.contains(PeerFeatures::COMMUNICATION_NODE) {
-                    "BaseNode"
-                } else {
-                    "Wallet"
-                }
-            ]);
-        }
-        table.printstd();
-        println!();
-    }
-}
-
-async fn network_peer_list_stats(nodes: &[TestNode], wallets: &[TestNode]) {
-    let mut stats = HashMap::<String, usize>::with_capacity(wallets.len());
-    for wallet in wallets {
-        let mut num_known = 0;
-        for node in nodes {
-            if node
-                .comms
-                .peer_manager()
-                .exists_node_id(wallet.node_identity().node_id())
-                .await
-            {
-                num_known += 1;
-            }
-        }
-        stats.insert(get_name(wallet.node_identity().node_id()), num_known);
-    }
-
-    let mut avg = Vec::with_capacity(wallets.len());
-    for (n, v) in stats {
-        let perc = v as f32 / nodes.len() as f32;
-        avg.push(perc);
-        println!(
-            "{} is known by {} out of {} nodes ({:.2}%)",
-            n,
-            v,
-            nodes.len(),
-            perc * 100.0
-        );
-    }
-    println!(
-        "Average {:.2}%",
-        avg.into_iter().sum::<f32>() / wallets.len() as f32 * 100.0
-    );
-}
-
-async fn network_connectivity_stats(nodes: &[TestNode], wallets: &[TestNode]) {
-    async fn display(nodes: &[TestNode]) -> (usize, usize) {
-        let mut total = 0;
-        let mut avg = Vec::new();
-        for node in nodes {
-            let conns = node.comms.connection_manager().get_active_connections().await.unwrap();
-            total += conns.len();
-            avg.push(conns.len());
-
-            println!("{} connected to {} nodes", node, conns.len());
-            if !QUIET_MODE {
-                for c in conns {
-                    println!("  {} ({})", get_name(c.peer_node_id()), c.direction());
-                }
-            }
-        }
-        (total, avg.into_iter().sum())
-    }
-    let (mut total, mut avg) = display(nodes).await;
-    let (t, a) = display(wallets).await;
-    total += t;
-    avg += a;
-    println!(
-        "{} total connections on the network. ({} per node on average)",
-        total,
-        avg / (wallets.len() + nodes.len())
-    );
-}
-
-async fn do_network_wide_propagation(nodes: &mut [TestNode]) {
-    let random_node = &nodes[OsRng.gen_range(0, nodes.len() - 1)];
-    let random_node_id = random_node.comms.node_identity().node_id().clone();
-    const PUBLIC_MESSAGE: &str = "This is something you're all interested in!";
-
-    banner!("🌎 {} is going to broadcast a message to the network", random_node);
-    let send_states = random_node
-        .dht
-        .outbound_requester()
-        .broadcast(
-            NodeDestination::Unknown,
-            OutboundEncryption::None,
-            vec![],
-            OutboundDomainMessage::new(0i32, PUBLIC_MESSAGE.to_string()),
-        )
-        .await
-        .unwrap();
-    let num_connections = random_node
-        .comms
-        .connection_manager()
-        .get_num_active_connections()
-        .await
-        .unwrap();
-    let (success, failed) = send_states.wait_all().await;
-    println!(
-        "🦠 {} broadcast to {}/{} peer(s) ({} connection(s))",
-        random_node.name,
-        success.len(),
-        success.len() + failed.len(),
-        num_connections
-    );
-
-    let start_global = Instant::now();
-    // Spawn task for each peer that will read the message and propagate it on
-    let tasks = nodes
-        .into_iter()
-        .filter(|n| n.comms.node_identity().node_id() != &random_node_id)
-        .enumerate()
-        .map(|(idx, node)| {
-            let mut outbound_req = node.dht.outbound_requester();
-            let mut conn_man = node.comms.connection_manager();
-            let mut ims_rx = node.ims_rx.take().unwrap();
-            let start = Instant::now();
-            let start_global = start_global.clone();
-            let node_name = node.name.clone();
-
-            task::spawn(async move {
-                let result = time::timeout(Duration::from_secs(10), ims_rx.next()).await;
-                let mut is_success = false;
-                match result {
-                    Ok(Some(msg)) => {
-                        let public_msg = msg
-                            .decryption_result
-                            .unwrap()
-                            .decode_part::<String>(1)
-                            .unwrap()
-                            .unwrap();
-                        println!(
-                            "📬 {} got public message '{}' (t={:.0?})",
-                            node_name,
-                            public_msg,
-                            start_global.elapsed()
-                        );
-                        is_success = true;
-                        let send_states = outbound_req
-                            .propagate(
-                                NodeDestination::Unknown,
-                                OutboundEncryption::None,
-                                vec![msg.source_peer.node_id.clone()],
-                                OutboundDomainMessage::new(0i32, public_msg),
-                            )
-                            .await
-                            .unwrap();
-                        let num_connections = conn_man.get_num_active_connections().await.unwrap();
-                        let (success, failed) = send_states.wait_all().await;
-                        println!(
-                            "🦠 {} propagated to {}/{} peer(s) ({} connection(s))",
-                            node_name,
-                            success.len(),
-                            success.len() + failed.len(),
-                            num_connections
-                        );
-                    },
-                    Err(_) | Ok(None) => {
-                        banner!(
-                            "💩 {} failed to receive network message after {:.2?}",
-                            node_name,
-                            start.elapsed(),
-                        );
-                    },
-                }
-
-                (idx, ims_rx, is_success)
-            })
-        });
-
-    // Put the ims_rxs back
-    let ims_rxs = future::join_all(tasks).await;
-    let mut num_successes = 0;
-    for ims in ims_rxs {
-        let (idx, ims_rx, is_success) = ims.unwrap();
-        nodes[idx].ims_rx = Some(ims_rx);
-        if is_success {
-            num_successes += 1;
-        }
-    }
-
-    banner!(
-        "🙌 Finished propagation test. {} out of {} nodes received the message",
-        num_successes,
-        nodes.len() - 1
-    );
-}
-
-async fn do_store_and_forward_message_propagation(
-    wallet: TestNode,
-    wallets: &[TestNode],
-    nodes: &[TestNode],
-    messaging_tx: MessagingEventTx,
-    messaging_rx: &mut MessagingEventRx,
-) -> (usize, TestNode)
-{
-    banner!(
-        "{} chosen at random to be receive messages from other nodes using store and forward",
-        wallet,
-    );
-    let wallets_peers = wallet.comms.peer_manager().all().await.unwrap();
-    let node_identity = wallet.comms.node_identity().clone();
-
-    let neighbours = wallet
-        .comms
-        .connectivity()
-        .select_connections(ConnectivitySelection::closest_to(
-            wallet.node_identity().node_id().clone(),
-            NUM_NEIGHBOURING_NODES,
-            vec![],
-        ))
-        .await
-        .unwrap()
-        .into_iter()
-        .filter_map(
-            // If a node is not found in the node list it must be the seed node - should probably assert that this is
-            // the case
-            |p| nodes.iter().find(|n| n.node_identity().node_id() == p.peer_node_id()),
-        )
-        .collect::<Vec<_>>();
-
-    let neighbour_subs = neighbours
-        .iter()
-        .map(|n| n.comms.subscribe_messaging_events())
-        .collect::<Vec<_>>();
-
-    banner!(
-        "{} has {} neighbours ({})",
-        wallet,
-        neighbours.len(),
-        neighbours
-            .iter()
-            .map(ToString::to_string)
-            .collect::<Vec<_>>()
-            .join(", ")
-    );
-    banner!("😴 {} is going offline", wallet);
-    wallet.comms.shutdown().await;
-
-    banner!(
-        "🎤 All other wallets are going to attempt to broadcast messages to {} ({})",
-        get_name(node_identity.node_id()),
-        node_identity.public_key(),
-    );
-
-    let start = Instant::now();
-    for wallet in wallets {
-        let secret_message = format!("My name is wiki wiki {}", wallet);
-        let send_states = wallet
-            .dht
-            .outbound_requester()
-            .broadcast(
-                node_identity.node_id().clone().into(),
-                OutboundEncryption::EncryptFor(Box::new(node_identity.public_key().clone())),
-                vec![],
-                OutboundDomainMessage::new(123i32, secret_message.clone()),
-            )
-            .await
-            .unwrap();
-        let (success, failed) = send_states.wait_all().await;
-        println!(
-            "{} sent {}/{} messages",
-            wallet,
-            success.len(),
-            success.len() + failed.len(),
-        );
-    }
-
-    for (idx, mut s) in neighbour_subs.into_iter().enumerate() {
-        let neighbour = neighbours[idx].name.clone();
-        task::spawn(async move {
-            let msg = time::timeout(Duration::from_secs(2), s.next()).await;
-            match msg {
-                Ok(Some(Ok(evt))) => match &*evt {
-                    MessagingEvent::MessageReceived(_, tag) => {
-                        println!("{} received propagated SAF message ({})", neighbour, tag);
-                    },
-                    _ => {},
-                },
-                Ok(_) => {},
-                Err(_) => println!("{} did not receive the SAF message", neighbour),
-            }
-        });
-    }
-
-    banner!("⏰ Waiting a few seconds for messages to propagate around the network...");
-    time::delay_for(Duration::from_secs(5)).await;
-
-    let mut total_messages = drain_messaging_events(messaging_rx, false).await;
-
-    banner!("🤓 {} is coming back online", get_name(node_identity.node_id()));
-    let (tx, ims_rx) = mpsc::channel(1);
-    let (comms, dht) = setup_comms_dht(node_identity, create_peer_storage(wallets_peers), tx).await;
-    let mut wallet = TestNode::new(comms, dht, None, ims_rx, messaging_tx);
-    let mut connectivity = wallet.comms.connectivity();
-
-    connectivity
-        .wait_for_connectivity(Duration::from_secs(10))
-        .await
-        .unwrap();
-    take_a_break().await;
-    let connections = wallet
-        .comms
-        .connection_manager()
-        .get_active_connections()
-        .await
-        .unwrap();
-    println!(
-        "{} has {} connections to {}",
-        wallet,
-        connections.len(),
-        connections
-            .iter()
-            .map(|p| get_name(p.peer_node_id()))
-            .collect::<Vec<_>>()
-            .join(", ")
-    );
-
-    let mut num_msgs = 0;
-    loop {
-        let result = time::timeout(Duration::from_secs(10), wallet.ims_rx.as_mut().unwrap().next()).await;
-        num_msgs += 1;
-        match result {
-            Ok(msg) => {
-                let msg = msg.unwrap();
-                let secret_msg = msg
-                    .decryption_result
-                    .unwrap()
-                    .decode_part::<String>(1)
-                    .unwrap()
-                    .unwrap();
-                banner!(
-                    "🎉 Wallet {} received propagated message '{}' from store and forward in {:.2?}",
-                    wallet,
-                    secret_msg,
-                    start.elapsed()
-                );
-            },
-            Err(err) => {
-                banner!(
-                    "💩 Failed to receive message after {:.0?} using store and forward '{}'",
-                    start.elapsed(),
-                    err
-                );
-            },
-        };
-
-        if num_msgs == wallets.len() {
-            break;
-        }
-    }
-
-    total_messages += drain_messaging_events(messaging_rx, false).await;
-
-    (total_messages, wallet)
-}
-
-async fn drain_messaging_events(messaging_rx: &mut MessagingEventRx, show_logs: bool) -> usize {
-    let drain_fut = DrainBurst::new(messaging_rx);
-    if show_logs {
-        let messages = drain_fut.await;
-        let num_messages = messages.len();
-        let mut node_id_buf = Vec::new();
-        let mut last_from_node = None;
-        for (from_node, to_node) in &messages {
-            match &last_from_node {
-                Some(node_id) if *node_id == from_node => {
-                    node_id_buf.push(to_node);
-                },
-                Some(_) => {
-                    println!(
-                        "📨 {} sent {} messages to {}️",
-                        get_short_name(last_from_node.take().unwrap()),
-                        node_id_buf.len(),
-                        node_id_buf.drain(..).map(get_short_name).collect::<Vec<_>>().join(", ")
-                    );
-
-                    last_from_node = Some(from_node);
-                    node_id_buf.push(to_node)
-                },
-                None => {
-                    last_from_node = Some(from_node);
-                    node_id_buf.push(to_node)
-                },
-            }
-        }
-        println!("{} messages sent between nodes", num_messages);
-        num_messages
-    } else {
-        let len = drain_fut.await.len();
-        println!("📨 {} messages exchanged", len);
-        len
-    }
-}
-
-fn connection_manager_logger(
-    node_id: NodeId,
-) -> impl FnMut(Arc<ConnectionManagerEvent>) -> Arc<ConnectionManagerEvent> {
-    let node_name = get_name(&node_id);
-    move |event| {
-        if QUIET_MODE {
-            return event;
-        }
-        use ConnectionManagerEvent::*;
-        print!("EVENT: ");
-        match &*event {
-            PeerConnected(conn) => match conn.direction() {
-                ConnectionDirection::Inbound => {
-                    // println!(
-                    //     "'{}' got inbound connection from '{}'",
-                    //     node_name,
-                    //     get_name(conn.peer_node_id()),
-                    // );
-                },
-                ConnectionDirection::Outbound => {
-                    println!("'{}' connected to '{}'", node_name, get_name(conn.peer_node_id()),);
-                },
-            },
-            PeerDisconnected(node_id) => {
-                println!("'{}' disconnected from '{}'", get_name(node_id), node_name);
-            },
-            PeerConnectFailed(node_id, err) => {
-                println!(
-                    "'{}' failed to connect to '{}' because '{:?}'",
-                    node_name,
-                    get_name(node_id),
-                    err
-                );
-            },
-            PeerConnectWillClose(_, node_id, direction) => {
-                println!(
-                    "'{}' will disconnect {} connection to '{}'",
-                    get_name(node_id),
-                    direction,
-                    node_name,
-                );
-            },
-            PeerInboundConnectFailed(err) => {
-                println!(
-                    "'{}' failed to accept inbound connection because '{:?}'",
-                    node_name, err
-                );
-            },
-            Listening(_) | ListenFailed(_) => unreachable!(),
-            NewInboundSubstream(node_id, protocol, _) => {
-                println!(
-                    "'{}' negotiated protocol '{}' to '{}'",
-                    get_name(node_id),
-                    String::from_utf8_lossy(protocol),
-                    node_name
-                );
-            },
-        }
-        event
-    }
-}
-
-struct TestNode {
-    name: String,
-    comms: CommsNode,
-    seed_peer: Option<Peer>,
-    dht: Dht,
-    conn_man_events_rx: mpsc::Receiver<Arc<ConnectionManagerEvent>>,
-    ims_rx: Option<mpsc::Receiver<DecryptedDhtMessage>>,
-}
-
-impl TestNode {
-    pub fn new(
-        comms: CommsNode,
-        dht: Dht,
-        seed_peer: Option<Peer>,
-        ims_rx: mpsc::Receiver<DecryptedDhtMessage>,
-        messaging_events_tx: MessagingEventTx,
-    ) -> Self
-    {
-        let name = get_next_name();
-        register_name(comms.node_identity().node_id().clone(), name.clone());
-
-        let (conn_man_events_tx, events_rx) = mpsc::channel(100);
-        Self::spawn_event_monitor(&comms, conn_man_events_tx, messaging_events_tx);
-
-        Self {
-            name,
-            seed_peer,
-            comms,
-            dht,
-            ims_rx: Some(ims_rx),
-            conn_man_events_rx: events_rx,
-        }
-    }
-
-    fn spawn_event_monitor(
-        comms: &CommsNode,
-        events_tx: mpsc::Sender<Arc<ConnectionManagerEvent>>,
-        messaging_events_tx: MessagingEventTx,
-    )
-    {
-        let conn_man_event_sub = comms.subscribe_connection_manager_events();
-        let messaging_events = comms.subscribe_messaging_events();
-        let executor = runtime::Handle::current();
-
-        executor.spawn(
-            conn_man_event_sub
-                .filter(|r| future::ready(r.is_ok()))
-                .map(Result::unwrap)
-                .map(connection_manager_logger(comms.node_identity().node_id().clone()))
-                .map(Ok)
-                .forward(events_tx),
-        );
-
-        let node_id = comms.node_identity().node_id().clone();
-
-        executor.spawn(
-            messaging_events
-                .filter(|r| future::ready(r.is_ok()))
-                .map(Result::unwrap)
-                .filter_map(move |event| {
-                    use MessagingEvent::*;
-                    future::ready(match &*event {
-                        MessageReceived(peer_node_id, _) => Some((Clone::clone(&*peer_node_id), node_id.clone())),
-                        _ => None,
-                    })
-                })
-                .map(Ok)
-                .forward(messaging_events_tx),
-        );
-    }
-
-    #[inline]
-    pub fn node_identity(&self) -> Arc<NodeIdentity> {
-        self.comms.node_identity()
-    }
-
-    #[inline]
-    pub fn to_peer(&self) -> Peer {
-        self.comms.node_identity().to_peer()
-    }
-
-    #[allow(dead_code)]
-    pub async fn expect_peer_connection(&mut self, node_id: &NodeId) -> Option<PeerConnection> {
-        if let Some(conn) = self.comms.connectivity().get_connection(node_id.clone()).await.unwrap() {
-            return Some(conn);
-        }
-        use ConnectionManagerEvent::*;
-        loop {
-            let event = time::timeout(Duration::from_secs(30), self.conn_man_events_rx.next())
-                .await
-                .ok()??;
-
-            match &*event {
-                PeerConnected(conn) if conn.peer_node_id() == node_id => {
-                    break Some(conn.clone());
-                },
-                _ => {},
-            }
-        }
-    }
-}
-
-impl AsRef<TestNode> for TestNode {
-    fn as_ref(&self) -> &TestNode {
-        self
-    }
-}
-
-impl fmt::Display for TestNode {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(
-            f,
-            "{} ({})",
-            self.name,
-            self.comms.node_identity().node_id().short_str()
-        )
-    }
-}
-
-fn make_node_identity(features: PeerFeatures) -> Arc<NodeIdentity> {
-    let port = MemoryTransport::acquire_next_memsocket_port();
-    Arc::new(NodeIdentity::random(&mut OsRng, format!("/memory/{}", port).parse().unwrap(), features).unwrap())
-}
-
-fn create_peer_storage(peers: Vec<Peer>) -> CommsDatabase {
-    let database_name = random::string(8);
-    let datastore = LMDBBuilder::new()
-        .set_path(create_temporary_data_path().to_str().unwrap())
-        .set_env_config(LMDBConfig::default())
-        .set_max_number_of_databases(1)
-        .add_database(&database_name, lmdb_zero::db::CREATE)
-        .build()
-        .unwrap();
-
-    let peer_database = datastore.get_handle(&database_name).unwrap();
-    let peer_database = LMDBWrapper::new(Arc::new(peer_database));
-    let mut storage = PeerStorage::new_indexed(peer_database).unwrap();
-    for peer in peers {
-        storage.add_peer(peer).unwrap();
-    }
-
-    storage.into()
-}
-
-async fn make_node(features: PeerFeatures, seed_peer: Option<Peer>, messaging_events_tx: MessagingEventTx) -> TestNode {
-    let node_identity = make_node_identity(features);
-
-    let (tx, ims_rx) = mpsc::channel(1);
-    let (comms, dht) = setup_comms_dht(
-        node_identity,
-        create_peer_storage(seed_peer.clone().into_iter().collect()),
-        tx,
-    )
-    .await;
-
-    TestNode::new(comms, dht, seed_peer, ims_rx, messaging_events_tx)
-}
-
-async fn setup_comms_dht(
-    node_identity: Arc<NodeIdentity>,
-    storage: CommsDatabase,
-    inbound_tx: mpsc::Sender<DecryptedDhtMessage>,
-) -> (CommsNode, Dht)
-{
-    // Create inbound and outbound channels
-    let (outbound_tx, outbound_rx) = mpsc::channel(10);
-
-    let comms = CommsBuilder::new()
-        .allow_test_addresses()
-        // In this case the listener address and the public address are the same (/memory/...)
-        .with_listener_address(node_identity.public_address())
-        .with_transport(MemoryTransport)
-        .with_node_identity(node_identity)
-        .with_min_connectivity(0.3)
-        .with_peer_storage(storage)
-        .with_dial_backoff(ConstantBackoff::new(Duration::from_millis(1000)))
-        .build()
-        .unwrap();
-
-    let dht = DhtBuilder::new(
-        comms.node_identity(),
-        comms.peer_manager(),
-        outbound_tx,
-        comms.connectivity(),
-        comms.shutdown_signal(),
-    )
-    .local_test()
-    .enable_auto_join()
-    .set_auto_store_and_forward_requests(true)
-    .with_discovery_timeout(Duration::from_secs(15))
-    .with_num_neighbouring_nodes(NUM_NEIGHBOURING_NODES)
-    .with_num_random_nodes(NUM_RANDOM_NODES)
-    .with_propagation_factor(PROPAGATION_FACTOR)
-    .finish()
-    .await
-    .unwrap();
-
-    let dht_outbound_layer = dht.outbound_middleware_layer();
-
-    let comms = comms
-        .with_messaging_pipeline(
-            pipeline::Builder::new()
-                .outbound_buffer_size(10)
-                .with_outbound_pipeline(outbound_rx, |sink| {
-                    ServiceBuilder::new().layer(dht_outbound_layer).service(sink)
-                })
-                .max_concurrent_inbound_tasks(10)
-                .with_inbound_pipeline(
-                    ServiceBuilder::new()
-                        .layer(dht.inbound_middleware_layer())
-                        .service(SinkService::new(inbound_tx)),
-                )
-                .finish(),
-        )
-        .spawn()
-        .await
-        .unwrap();
-
-    (comms, dht)
-}
-
-async fn take_a_break() {
-    banner!("Taking a break for a few seconds to let things settle...");
-    time::delay_for(Duration::from_millis(NUM_NODES as u64 * 100)).await;
 }

--- a/comms/dht/examples/memorynet_graph_network_join_multiple_seeds.rs
+++ b/comms/dht/examples/memorynet_graph_network_join_multiple_seeds.rs
@@ -1,0 +1,192 @@
+// Copyright 2020, The Tari Project
+//
+// Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+// following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+// disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+// following disclaimer in the documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+// products derived from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+// INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+// WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+// USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+//! # MemoryNet
+//!
+//! This example runs a small in-memory network.
+//! It's primary purpose is to test and debug the behaviour of the DHT.
+//!
+//! The following happens:
+//! 1. A single "seed node", `NUM_NODES` "base nodes" and `NUM_WALLETS` "wallets" are generated and started.
+//! 1. All "base nodes" join the network via the "seed node"
+//! 1. All "wallets" join the network via a random "base node"
+//! 1. The first "wallet" in the list attempts to discover the last "wallet" in the list
+//!
+//! The suggested way to run this is:
+//!
+//! `RUST_BACKTRACE=1 RUST_LOG=trace cargo run --example memorynet 2> /tmp/debug.log`
+
+// Size of network
+const NUM_SEED_NODES: usize = 2;
+// Size of network
+const NUM_NODES: usize = 100;
+// Must be at least 2
+const NUM_WALLETS: usize = 6;
+const QUIET_MODE: bool = true;
+/// Number of neighbouring nodes each node should include in the connection pool
+const NUM_NEIGHBOURING_NODES: usize = 8;
+/// Number of randomly-selected nodes each node should include in the connection pool
+const NUM_RANDOM_NODES: usize = 4;
+/// The number of messages that should be propagated out
+const PROPAGATION_FACTOR: usize = 4;
+
+const DEFAULT_GRAPH_OUTPUT_DIR: &str = "/tmp/memorynet";
+
+mod graphing_utilities;
+mod memory_net;
+
+use crate::{
+    graphing_utilities::utilities::{network_graph_snapshot, run_python_network_graph_render, PythonRenderType},
+    memory_net::utilities::{
+        make_node,
+        make_node_from_node_identities,
+        make_node_identity,
+        shutdown_all,
+        take_a_break,
+    },
+};
+use clap::{App, Arg};
+use futures::channel::mpsc;
+use std::{path::Path, time::Duration};
+use tari_comms::peer_manager::PeerFeatures;
+
+#[tokio_macros::main]
+async fn main() {
+    env_logger::init();
+    let matches = App::new("MemoryNet")
+        .version("0.1.0")
+        .arg(
+            Arg::with_name("output_dir")
+                .short("o")
+                .long("output")
+                .takes_value(true)
+                .value_name("PATH")
+                .help("Graph output directory"),
+        )
+        .get_matches();
+
+    let graph_output_dir = Path::new(matches.value_of("output_dir").unwrap_or(DEFAULT_GRAPH_OUTPUT_DIR))
+        .to_str()
+        .expect("Couldn't use provided output directory path");
+
+    banner!(
+        "Bringing up virtual network consisting of {} seed nodes, {} nodes and {} wallets",
+        NUM_SEED_NODES,
+        NUM_NODES,
+        NUM_WALLETS
+    );
+
+    let (messaging_events_tx, _messaging_events_rx) = mpsc::unbounded();
+
+    let mut seed_identities = Vec::new();
+    for _ in 0..NUM_SEED_NODES {
+        seed_identities.push(make_node_identity(PeerFeatures::COMMUNICATION_NODE));
+    }
+
+    let mut seed_nodes = Vec::new();
+    for i in 0..NUM_SEED_NODES {
+        seed_nodes.push(
+            make_node_from_node_identities(
+                seed_identities[i].clone(),
+                seed_identities
+                    .iter()
+                    .filter(|s| s.node_id() != seed_identities[i].node_id())
+                    .map(|n| n.clone())
+                    .collect(),
+                messaging_events_tx.clone(),
+                NUM_NEIGHBOURING_NODES,
+                NUM_RANDOM_NODES,
+                PROPAGATION_FACTOR,
+                QUIET_MODE,
+            )
+            .await,
+        );
+    }
+
+    let mut nodes = Vec::new();
+
+    for i in 0..NUM_NODES {
+        nodes.push(
+            make_node(
+                PeerFeatures::COMMUNICATION_NODE,
+                vec![seed_nodes[i % NUM_SEED_NODES].node_identity()],
+                messaging_events_tx.clone(),
+                NUM_NEIGHBOURING_NODES,
+                NUM_RANDOM_NODES,
+                PROPAGATION_FACTOR,
+                QUIET_MODE,
+            )
+            .await,
+        );
+    }
+
+    // Wait for all the nodes to startup and connect to seed node
+    take_a_break(NUM_NODES).await;
+    let _ = network_graph_snapshot(
+        "base_node_join_multi_seed",
+        &seed_nodes,
+        &nodes,
+        Some(NUM_NEIGHBOURING_NODES),
+    )
+    .await;
+
+    log::info!("------------------------------- BASE NODES JOIN -------------------------------");
+    for index in 0..nodes.len() {
+        {
+            let node = nodes.get_mut(index).expect("Couldn't get TestNode");
+            println!(
+                "Node '{}' is joining the network via the seed node '{}'",
+                node,
+                node.seed_peers[0].node_id.short_str(),
+            );
+            node.comms
+                .connectivity()
+                .wait_for_connectivity(Duration::from_secs(10))
+                .await
+                .unwrap();
+
+            node.dht.dht_requester().send_join().await.unwrap();
+        }
+
+        // Let the network settle before taking the snapshot.
+        take_a_break(10).await;
+    }
+
+    take_a_break(NUM_NODES).await;
+    let _ = network_graph_snapshot(
+        "base_node_join_multi_seed",
+        &seed_nodes,
+        &nodes,
+        Some(NUM_NEIGHBOURING_NODES),
+    )
+    .await;
+    if let Err(e) = run_python_network_graph_render(
+        "base_node_join_multi_seed",
+        graph_output_dir,
+        PythonRenderType::NetworkGraphFull,
+    ) {
+        println!("Error rendering graphs: {}", e);
+    }
+
+    shutdown_all(nodes).await;
+    shutdown_all(seed_nodes).await;
+}

--- a/comms/dht/examples/memorynet_graph_network_track_join.rs
+++ b/comms/dht/examples/memorynet_graph_network_track_join.rs
@@ -1,0 +1,272 @@
+// Copyright 2020, The Tari Project
+//
+// Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+// following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+// disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+// following disclaimer in the documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+// products derived from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+// INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+// WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+// USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+//! # MemoryNet
+//!
+//! This example runs a small in-memory network.
+//! It's primary purpose is to test and debug the behaviour of the DHT.
+//!
+//! The following happens:
+//! 1. A single "seed node", `NUM_NODES` "base nodes" and `NUM_WALLETS` "wallets" are generated and started.
+//! 1. All "base nodes" join the network via the "seed node"
+//! 1. All "wallets" join the network via a random "base node"
+//! 1. The first "wallet" in the list attempts to discover the last "wallet" in the list
+//!
+//! The suggested way to run this is:
+//!
+//! `RUST_BACKTRACE=1 RUST_LOG=trace cargo run --example memorynet 2> /tmp/debug.log`
+
+// Size of network
+const NUM_SEED_NODES: usize = 2;
+// Size of network
+const NUM_NODES: usize = 40;
+// Must be at least 2
+const NUM_WALLETS: usize = 6;
+const QUIET_MODE: bool = true;
+/// Number of neighbouring nodes each node should include in the connection pool
+const NUM_NEIGHBOURING_NODES: usize = 8;
+/// Number of randomly-selected nodes each node should include in the connection pool
+const NUM_RANDOM_NODES: usize = 4;
+/// The number of messages that should be propagated out
+const PROPAGATION_FACTOR: usize = 4;
+
+const DEFAULT_GRAPH_OUTPUT_DIR: &str = "/tmp/memorynet";
+
+mod graphing_utilities;
+mod memory_net;
+
+use crate::{
+    graphing_utilities::utilities::{
+        create_message_propagation_graphs,
+        network_graph_snapshot,
+        run_python_network_graph_render,
+        track_join_message_drain_messaging_events,
+        PythonRenderType,
+    },
+    memory_net::utilities::{
+        drain_messaging_events,
+        make_node,
+        make_node_from_node_identities,
+        make_node_identity,
+        shutdown_all,
+        take_a_break,
+    },
+};
+use clap::{App, Arg};
+use env_logger::Env;
+use futures::channel::mpsc;
+use std::{path::Path, time::Duration};
+use tari_comms::peer_manager::PeerFeatures;
+
+#[tokio_macros::main]
+async fn main() {
+    let _ = env_logger::from_env(Env::default())
+        .format_timestamp_millis()
+        .try_init();
+    let matches = App::new("MemoryNet")
+        .version("0.1.0")
+        .arg(
+            Arg::with_name("output_dir")
+                .short("o")
+                .long("output")
+                .takes_value(true)
+                .value_name("PATH")
+                .help("Graph output directory"),
+        )
+        .get_matches();
+
+    let graph_output_dir = Path::new(matches.value_of("output_dir").unwrap_or(DEFAULT_GRAPH_OUTPUT_DIR))
+        .to_str()
+        .expect("Couldn't use provided output directory path");
+
+    banner!(
+        "Bringing up virtual network consisting of {} seed nodes, {} nodes and {} wallets",
+        NUM_SEED_NODES,
+        NUM_NODES,
+        NUM_WALLETS
+    );
+
+    let (messaging_events_tx, mut messaging_events_rx) = mpsc::unbounded();
+
+    let mut seed_identities = Vec::new();
+    for _ in 0..NUM_SEED_NODES {
+        seed_identities.push(make_node_identity(PeerFeatures::COMMUNICATION_NODE));
+    }
+
+    let mut seed_nodes = Vec::new();
+    for i in 0..NUM_SEED_NODES {
+        seed_nodes.push(
+            make_node_from_node_identities(
+                seed_identities[i].clone(),
+                seed_identities
+                    .iter()
+                    .filter(|s| s.node_id() != seed_identities[i].node_id())
+                    .map(|n| n.clone())
+                    .collect(),
+                messaging_events_tx.clone(),
+                NUM_NEIGHBOURING_NODES,
+                NUM_RANDOM_NODES,
+                PROPAGATION_FACTOR,
+                QUIET_MODE,
+            )
+            .await,
+        );
+    }
+
+    let mut nodes = Vec::new();
+
+    for i in 0..NUM_NODES {
+        nodes.push(
+            make_node(
+                PeerFeatures::COMMUNICATION_NODE,
+                vec![seed_nodes[i % NUM_SEED_NODES].node_identity()],
+                messaging_events_tx.clone(),
+                NUM_NEIGHBOURING_NODES,
+                NUM_RANDOM_NODES,
+                PROPAGATION_FACTOR,
+                QUIET_MODE,
+            )
+            .await,
+        );
+    }
+
+    // Wait for all the nodes to startup and connect to seed nodes
+    take_a_break(NUM_NODES).await;
+    // Taking this one snapshot of the network before the first non-seed node joins
+    let _ = network_graph_snapshot(
+        "base_node_track_join",
+        &seed_nodes,
+        &nodes,
+        Some(NUM_NEIGHBOURING_NODES),
+    )
+    .await;
+
+    log::info!("------------------------------- BASE NODES JOIN -------------------------------");
+    for index in 0..NUM_NODES {
+        {
+            let node = nodes.get_mut(index).expect("Couldn't get TestNode");
+            println!(
+                "Node '{}' is joining the network via the seed node '{}'",
+                node,
+                node.seed_peers[0].node_id.short_str(),
+            );
+            node.comms
+                .connectivity()
+                .wait_for_connectivity(Duration::from_secs(10))
+                .await
+                .unwrap();
+
+            node.dht.dht_requester().send_join().await.unwrap();
+        }
+    }
+
+    take_a_break(NUM_NODES).await;
+    let _ = network_graph_snapshot(
+        "base_node_track_join",
+        &seed_nodes,
+        &nodes,
+        Some(NUM_NEIGHBOURING_NODES),
+    )
+    .await;
+
+    let new_node = make_node(
+        PeerFeatures::COMMUNICATION_NODE,
+        vec![seed_nodes[0].node_identity()],
+        messaging_events_tx.clone(),
+        NUM_NEIGHBOURING_NODES,
+        NUM_RANDOM_NODES,
+        PROPAGATION_FACTOR,
+        QUIET_MODE,
+    )
+    .await;
+
+    nodes.push(new_node);
+
+    take_a_break(NUM_NODES).await;
+    let _ = network_graph_snapshot(
+        "base_node_track_join",
+        &seed_nodes,
+        &nodes,
+        Some(NUM_NEIGHBOURING_NODES),
+    )
+    .await;
+
+    // Clear all the messages till now
+    let _ = drain_messaging_events(&mut messaging_events_rx, false).await;
+
+    log::info!("------------------------------- NEW BASE NODE JOIN -------------------------------",);
+    println!("------------------------------- NEW BASE NODE JOIN -------------------------------",);
+
+    let (_, neighbour_graph) =
+        network_graph_snapshot("join_propagation", &seed_nodes, &nodes, Some(NUM_NEIGHBOURING_NODES)).await;
+
+    // Have new node join
+    {
+        println!(
+            "New Node '{}' is joining the network via the seed node '{}'",
+            nodes[nodes.len() - 1],
+            nodes[nodes.len() - 1].seed_peers[0].node_id.short_str(),
+        );
+        nodes[nodes.len() - 1]
+            .comms
+            .connectivity()
+            .wait_for_connectivity(Duration::from_secs(10))
+            .await
+            .unwrap();
+
+        nodes[nodes.len() - 1].dht.dht_requester().send_join().await.unwrap();
+    }
+
+    take_a_break(NUM_NODES).await;
+
+    // Log all the message sent in that join attempt
+    banner!("Summary of message propagation");
+    let message_tree = track_join_message_drain_messaging_events(&mut messaging_events_rx).await;
+
+    create_message_propagation_graphs("join_propagation", neighbour_graph, message_tree).await;
+
+    // Take a snapshot after the join has occured
+    let _ = network_graph_snapshot(
+        "base_node_track_join",
+        &seed_nodes,
+        &nodes,
+        Some(NUM_NEIGHBOURING_NODES),
+    )
+    .await;
+
+    banner!("Rendering graph");
+    if let Err(e) = run_python_network_graph_render(
+        "base_node_track_join",
+        graph_output_dir,
+        PythonRenderType::NetworkGraphFull,
+    ) {
+        println!("Error rendering graphs: {}", e);
+    }
+
+    if let Err(e) = run_python_network_graph_render("join_propagation", graph_output_dir, PythonRenderType::Propagation)
+    {
+        println!("Error rendering graphs: {}", e);
+    }
+
+    shutdown_all(nodes).await;
+    shutdown_all(seed_nodes).await;
+}

--- a/comms/dht/examples/memorynet_graph_network_track_propagation.rs
+++ b/comms/dht/examples/memorynet_graph_network_track_propagation.rs
@@ -1,0 +1,211 @@
+// Copyright 2020, The Tari Project
+//
+// Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+// following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+// disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+// following disclaimer in the documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+// products derived from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+// INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+// WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+// USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+//! # MemoryNet
+//!
+//! This example runs a small in-memory network.
+//! It's primary purpose is to test and debug the behaviour of the DHT.
+//!
+//! The following happens:
+//! 1. A single "seed node", `NUM_NODES` "base nodes" and `NUM_WALLETS` "wallets" are generated and started.
+//! 1. All "base nodes" join the network via the "seed node"
+//! 1. All "wallets" join the network via a random "base node"
+//! 1. The first "wallet" in the list attempts to discover the last "wallet" in the list
+//!
+//! The suggested way to run this is:
+//!
+//! `RUST_BACKTRACE=1 RUST_LOG=trace cargo run --example memorynet 2> /tmp/debug.log`
+
+// Size of network
+const NUM_SEED_NODES: usize = 4;
+// Size of network
+const NUM_NODES: usize = 40;
+// Must be at least 2
+const NUM_WALLETS: usize = 6;
+const QUIET_MODE: bool = true;
+/// Number of neighbouring nodes each node should include in the connection pool
+const NUM_NEIGHBOURING_NODES: usize = 8;
+/// Number of randomly-selected nodes each node should include in the connection pool
+const NUM_RANDOM_NODES: usize = 4;
+/// The number of messages that should be propagated out
+const PROPAGATION_FACTOR: usize = 4;
+
+const DEFAULT_GRAPH_OUTPUT_DIR: &str = "/tmp/memorynet";
+
+mod graphing_utilities;
+mod memory_net;
+
+use crate::{
+    graphing_utilities::utilities::{
+        create_message_propagation_graphs,
+        network_graph_snapshot,
+        run_python_network_graph_render,
+        track_join_message_drain_messaging_events,
+        PythonRenderType,
+    },
+    memory_net::utilities::{
+        do_network_wide_propagation,
+        drain_messaging_events,
+        make_node,
+        make_node_from_node_identities,
+        make_node_identity,
+        shutdown_all,
+        take_a_break,
+    },
+};
+use env_logger::Env;
+use futures::channel::mpsc;
+use std::time::Duration;
+use tari_comms::peer_manager::PeerFeatures;
+
+#[tokio_macros::main]
+async fn main() {
+    let _ = env_logger::from_env(Env::default())
+        .format_timestamp_millis()
+        .try_init();
+    // let matches = App::new("MemoryNet")
+    //     .version("0.1.0")
+    //     .arg(
+    //         Arg::with_name("output_dir")
+    //             .short("o")
+    //             .long("output")
+    //             .takes_value(true)
+    //             .value_name("PATH")
+    //             .help("Graph output directory"),
+    //     )
+    //     .get_matches();
+
+    // let graph_output_dir = Path::new(matches.value_of("output_dir").unwrap_or(DEFAULT_GRAPH_OUTPUT_DIR))
+    //     .to_str()
+    //     .expect("Couldn't use provided output directory path");
+
+    banner!(
+        "Bringing up virtual network consisting of {} seed nodes, {} nodes and {} wallets",
+        NUM_SEED_NODES,
+        NUM_NODES,
+        NUM_WALLETS
+    );
+
+    let (messaging_events_tx, mut messaging_events_rx) = mpsc::unbounded();
+
+    let mut seed_identities = Vec::new();
+    for _ in 0..NUM_SEED_NODES {
+        seed_identities.push(make_node_identity(PeerFeatures::COMMUNICATION_NODE));
+    }
+
+    let mut seed_nodes = Vec::new();
+    for i in 0..NUM_SEED_NODES {
+        seed_nodes.push(
+            make_node_from_node_identities(
+                seed_identities[i].clone(),
+                seed_identities
+                    .iter()
+                    .filter(|s| s.node_id() != seed_identities[i].node_id())
+                    .map(|n| n.clone())
+                    .collect(),
+                messaging_events_tx.clone(),
+                NUM_NEIGHBOURING_NODES,
+                NUM_RANDOM_NODES,
+                PROPAGATION_FACTOR,
+                QUIET_MODE,
+            )
+            .await,
+        );
+        println!("Seed node: {}", seed_nodes[i]);
+    }
+
+    let mut nodes = Vec::new();
+
+    for i in 0..NUM_NODES {
+        nodes.push(
+            make_node(
+                PeerFeatures::COMMUNICATION_NODE,
+                vec![seed_nodes[i % NUM_SEED_NODES].node_identity()],
+                messaging_events_tx.clone(),
+                NUM_NEIGHBOURING_NODES,
+                NUM_RANDOM_NODES,
+                PROPAGATION_FACTOR,
+                QUIET_MODE,
+            )
+            .await,
+        );
+        println!("Node: {}", nodes[i]);
+        take_a_break(1).await;
+    }
+
+    // Wait for all the nodes to startup and connect to seed node
+    take_a_break(NUM_NODES).await;
+
+    log::info!("------------------------------- BASE NODE JOIN -------------------------------");
+    for index in 0..NUM_NODES {
+        {
+            let node = nodes.get_mut(index).expect("Couldn't get TestNode");
+            println!(
+                "Node '{}' is joining the network via the seed node '{}'",
+                node,
+                node.seed_peers[0].node_id.short_str(),
+            );
+            node.comms
+                .connectivity()
+                .wait_for_connectivity(Duration::from_secs(10))
+                .await
+                .unwrap();
+
+            node.dht.dht_requester().send_join().await.unwrap();
+        }
+
+        // Let the network settle before taking the snapshot.
+        take_a_break(1).await;
+    }
+
+    take_a_break(NUM_NODES).await;
+    take_a_break(NUM_NODES).await;
+    take_a_break(NUM_NODES).await;
+
+    let _ = drain_messaging_events(&mut messaging_events_rx, false).await;
+
+    log::info!("------------------------------- PROPAGATION -------------------------------");
+    let (_, neighbour_graph) =
+        network_graph_snapshot("join_propagation", &seed_nodes, &nodes, Some(NUM_NEIGHBOURING_NODES)).await;
+
+    do_network_wide_propagation(&mut nodes, Some(NUM_NODES / 2 + 1)).await;
+
+    take_a_break(NUM_NODES).await;
+
+    // Still seeing Join messages flying around at this point?
+    // let _ = drain_messaging_events(&mut messaging_events_rx, true).await;
+
+    let message_tree = track_join_message_drain_messaging_events(&mut messaging_events_rx).await;
+
+    create_message_propagation_graphs("join_propagation", neighbour_graph, message_tree).await;
+    if let Err(e) = run_python_network_graph_render(
+        "join_propagation",
+        DEFAULT_GRAPH_OUTPUT_DIR,
+        PythonRenderType::Propagation,
+    ) {
+        println!("Error rendering graphs: {}", e);
+    }
+    banner!("That's it folks! Network is shutting down...");
+    log::info!("------------------------------- SHUTDOWN -------------------------------");
+    shutdown_all(nodes).await;
+    shutdown_all(seed_nodes).await;
+}

--- a/comms/dht/src/connectivity/mod.rs
+++ b/comms/dht/src/connectivity/mod.rs
@@ -207,7 +207,11 @@ impl DhtConnectivity {
             },
             ConnectivityStateDegraded(n) | ConnectivityStateOnline(n) => {
                 if self.config.auto_join && self.can_send_join() {
-                    info!(target: LOG_TARGET, "Joining the network automatically");
+                    info!(
+                        target: LOG_TARGET,
+                        "[ThisNode={}] Joining the network automatically",
+                        self.node_identity.node_id().short_str()
+                    );
                     self.dht_requester
                         .send_join()
                         .await

--- a/comms/dht/src/store_forward/service.rs
+++ b/comms/dht/src/store_forward/service.rs
@@ -388,7 +388,7 @@ impl StoreAndForwardService {
     fn check_saf_response_threshold(&mut self) {
         // This check can only be done after the `ConnectivityStateOnline` event has arrived
         if let Some(num_peers) = self.num_online_peers {
-            // We only perform the check while we are still tracking reponses
+            // We only perform the check while we are still tracking responses
             if let Some(n) = self.num_received_saf_responses {
                 if n >= num_peers {
                     // A send operation can only fail if there are no subscribers, so it is safe to ignore the error


### PR DESCRIPTION
## Description
This PR adds some utility functions to take snapshots of the network as a graph at any point during a memory net run. The utility functions provide the ability to take snapshots in separate named sequences if you want to graph different networks or elements of the networks separately. The graph files are stored in the temporary directory. Finally a Python script is included that will read the graphs for each named sequence and render them using a Force-Directed graph layout algorithm to the provided (or default) output folder.

Supported:
 - Network graphs with all connections and/or neighbour connections
- Message propagation onto of a network graph

## How Has This Been Tested?
This is not production code and is part of the Dht Examples to be used for debugging. 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch.
* [x] I ran `cargo-fmt --all` before pushing.
* [ ] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
