### PR TITLE
Refactor transaction error return information

### DIFF
--- a/base_layer/core/src/transactions/helpers.rs
+++ b/base_layer/core/src/transactions/helpers.rs
@@ -285,8 +285,7 @@ pub fn create_tx(
 
     let mut stx_protocol = stx_builder.build::<Blake256>(&factories).unwrap();
     match stx_protocol.finalize(KernelFeatures::empty(), &factories) {
-        Ok(true) => (),
-        Ok(false) => panic!("{:?}", stx_protocol.failure_reason()),
+        Ok(_0) => (),
         Err(e) => panic!("{:?}", e),
     }
     (
@@ -332,8 +331,7 @@ pub fn spend_utxos(schema: TransactionSchema) -> (Transaction, Vec<UnblindedOutp
     };
     outputs.push(change_output);
     match stx_protocol.finalize(KernelFeatures::empty(), &factories) {
-        Ok(true) => (),
-        Ok(false) => panic!("{:?}", stx_protocol.failure_reason()),
+        Ok(_0) => (),
         Err(e) => panic!("{:?}", e),
     }
     let txn = stx_protocol.get_transaction().unwrap().clone();

--- a/base_layer/wallet/tests/transaction_service/service.rs
+++ b/base_layer/wallet/tests/transaction_service/service.rs
@@ -930,7 +930,7 @@ fn test_accepting_unknown_tx_id_and_malformed_reply<T: TransactionBackend + Clon
             futures::select! {
                 event = alice_event_stream.select_next_some() => {
                     if let TransactionEvent::Error(s) = &*event.unwrap() {
-                        if s == &"TransactionError(ValidationError(\"Transaction could not be finalized\"))".to_string() {
+                        if s == &"TransactionProtocolError(TransactionBuildError(InvalidSignatureError))".to_string() {
                             errors+=1;
                         }
                         if errors >= 2 {
@@ -3425,7 +3425,7 @@ fn test_restarting_transaction_protocols() {
         .unwrap();
 
     match bob_stp.finalize(KernelFeatures::empty(), &factories) {
-        Ok(true) => (),
+        Ok(_0) => (),
         _ => assert!(false, "Should be able to finalize tx"),
     };
     let tx = bob_stp.clone().get_transaction().unwrap().clone();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- Refactored transaction error return information to get the actual reason a transaction failed.
- Fixed unit tests.

## Motivation and Context
During stress tests ~10% transactions are not finalized and fail for some reason, without proper insight into the problem. Invrestigating this issue to was found that the `pub fn finalize(&mut self, features: KernelFeatures, factories: &CryptoFactories) -> Result<bool, TPE>` function returned a `false` upon error instead of the error itself.

## How Has This Been Tested?
Unit tests

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [X] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [X] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [X] I'm merging against the `development` branch.
* [X] I ran `cargo-fmt --all` before pushing.
* [X] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
