### PR TITLE
Improve block validation

### DIFF
--- a/base_layer/core/src/validation/error.rs
+++ b/base_layer/core/src/validation/error.rs
@@ -51,6 +51,8 @@ pub enum ValidationError {
     InvalidAccountingBalance,
     #[error("Transaction contains already spent inputs")]
     ContainsSTxO,
+    #[error("Transaction contains duplicate already existing Transactional output")]
+    ContainsKnownTxO,
     #[error("The recorded chain accumulated difficulty was stronger")]
     WeakerAccumulatedDifficulty,
     #[error("Invalid output merkle root")]

--- a/base_layer/core/src/validation/helpers.rs
+++ b/base_layer/core/src/validation/helpers.rs
@@ -161,6 +161,16 @@ pub fn is_stxo<T: BlockchainBackend>(db: &T, hash: HashOutput) -> Result<bool, V
     }
 }
 
+pub fn is_utxo_in_mmr<T: BlockchainBackend>(db: &T, hash: HashOutput) -> Result<bool, ValidationError> {
+    // Check if the UTXO MMR contains the specified UTXO hash, the backend stxo_db is not used for this task as
+    // archival nodes and pruning nodes might have different STXOs in their stxo_db as horizon state STXOs are
+    // discarded by pruned nodes.
+    match db.fetch_mmr_leaf_index(MmrTree::Utxo, &hash)? {
+        Some(_v) => Ok(true),
+        None => Ok(false),
+    }
+}
+
 pub fn is_utxo<T: BlockchainBackend>(db: &T, hash: HashOutput) -> Result<bool, ValidationError> {
     db.contains(&DbKey::UnspentOutput(hash)).map_err(Into::into)
 }


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Improve validation speed by removing a redundant check
Fix hash check in code where we are suppose to check that there is not a hash clash. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The first fix fixes a check in the outputs. We already check that the output is in the unspend_txo list. If the output exists there it cannot exist in the spend_txo list. So we dont have to check that it does not. This removes an o(n) loop check on the outputs. 

The second fix fixes the hash_clash check. We need to ensure that a utxo has a unique hash, a clash here can be caused by many factors including but not limited to a actual hash clash, reused blinding factor etc. To do this we need a check that looks that the hash is unique and it needs to be consistent across pruned and archival modes. We therefor search the mmr that pruned nodes also keep to know if the hash is unique or not. Currently the test would only say it exists if it was already spent. This is incorrect, it should always be unique. 


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [x] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch.
* [x] I ran `cargo-fmt --all` before pushing.
* [x] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
