### PR TITLE
Implement config option to enable transaction fee to exceed the amount for spending dust

### DIFF
--- a/applications/tari_base_node/src/builder.rs
+++ b/applications/tari_base_node/src/builder.rs
@@ -463,6 +463,7 @@ where
         config.transaction_direct_send_timeout,
         config.transaction_broadcast_send_timeout,
         network,
+        config.prevent_fee_gt_amount,
     )
     .await;
 
@@ -1028,6 +1029,7 @@ async fn register_wallet_services(
     direct_send_timeout: Duration,
     broadcast_send_timeout: Duration,
     network: NetworkType,
+    prevent_fee_gt_amount: bool,
 ) -> Arc<ServiceHandles>
 {
     let transaction_db = TransactionServiceSqliteDatabase::new(wallet_db_conn.clone(), None);
@@ -1045,7 +1047,7 @@ async fn register_wallet_services(
     ))
         // Wallet services
         .add_initializer(OutputManagerServiceInitializer::new(
-            OutputManagerServiceConfig::new(base_node_query_timeout),
+            OutputManagerServiceConfig::new(base_node_query_timeout, prevent_fee_gt_amount),
             subscription_factory.clone(),
             OutputManagerSqliteDatabase::new(wallet_db_conn.clone(),None),
             factories.clone(),

--- a/base_layer/core/src/transactions/transaction_protocol/transaction_initializer.rs
+++ b/base_layer/core/src/transactions/transaction_protocol/transaction_initializer.rs
@@ -28,6 +28,7 @@ use crate::transactions::{
         TransactionOutput,
         UnblindedOutput,
         MAX_TRANSACTION_INPUTS,
+        MAX_TRANSACTION_OUTPUTS,
         MINIMUM_TRANSACTION_FEE,
     },
     transaction_protocol::{
@@ -38,12 +39,15 @@ use crate::transactions::{
     types::{BlindingFactor, CryptoFactories, PrivateKey, PublicKey},
 };
 use digest::Digest;
+use log::*;
 use std::{
     cmp::max,
     collections::HashMap,
     fmt::{Debug, Error, Formatter},
 };
 use tari_crypto::{keys::PublicKey as PublicKeyTrait, tari_utilities::fixed_set::FixedSet};
+
+pub const LOG_TARGET: &str = "c::tx::tx_protocol::tx_initializer";
 
 /// The SenderTransactionInitializer is a Builder that helps set up the initial state for the Sender party of a new
 /// transaction Typically you don't instantiate this object directly. Rather use
@@ -67,6 +71,7 @@ pub struct SenderTransactionInitializer {
     excess_blinding_factor: BlindingFactor,
     private_nonce: Option<PrivateKey>,
     message: Option<String>,
+    prevent_fee_gt_amount: bool,
 }
 
 pub struct BuildError {
@@ -95,6 +100,7 @@ impl SenderTransactionInitializer {
             private_nonce: None,
             excess_blinding_factor: BlindingFactor::default(),
             message: None,
+            prevent_fee_gt_amount: true,
         }
     }
 
@@ -158,6 +164,12 @@ impl SenderTransactionInitializer {
         self
     }
 
+    /// Enable or disable spending of an amount less than the fee
+    pub fn with_prevent_fee_gt_amount(&mut self, prevent_fee_gt_amount: bool) -> &mut Self {
+        self.prevent_fee_gt_amount = prevent_fee_gt_amount;
+        self
+    }
+
     /// Tries to make a change output with the given transaction parameters and add it to the set of outputs. The total
     /// fee, including the additional change output (if any) is returned along with the amount of change.
     /// The change output **always has default output features**.
@@ -211,6 +223,11 @@ impl SenderTransactionInitializer {
         })
     }
 
+    fn calculate_total_amount(&self, amount_to_self: &MicroTari) -> MicroTari {
+        let to_others: MicroTari = self.amounts.clone().into_vec().iter().sum();
+        to_others + amount_to_self
+    }
+
     /// Construct a `SenderTransactionProtocol` instance in and appropriate state. The data stored
     /// in the struct is _moved_ into the new struct. If any data is missing, the `self` instance is returned in the
     /// error (so that you can continue building) along with a string listing the missing fields.
@@ -223,20 +240,20 @@ impl SenderTransactionInitializer {
         Self::check_value("Missing Fee per gram", &self.fee_per_gram, &mut message);
         Self::check_value("Missing Offset", &self.offset, &mut message);
         Self::check_value("Missing Private nonce", &self.private_nonce, &mut message);
-        if !self.amounts.is_full() {
-            message.push(format!("Missing all {} amounts", self.amounts.size()));
-        }
-        if self.inputs.is_empty() {
-            message.push("Missing Input".to_string());
-        }
-        // Prevent overflow attacks by imposing sane limits on some key parameters
-        if self.inputs.len() > MAX_TRANSACTION_INPUTS {
-            message.push("Too many inputs".into());
-        }
         if !message.is_empty() {
             return self.build_err(&message.join(","));
         }
-        // Everything is here. Let's send some Tari!
+        if !self.amounts.is_full() {
+            let size = self.amounts.size();
+            return self.build_err(&*format!("Missing all {} amounts", size));
+        }
+        if self.inputs.is_empty() {
+            return self.build_err("A transaction cannot have zero inputs");
+        }
+        // Prevent overflow attacks by imposing sane limits on inputs
+        if self.inputs.len() > MAX_TRANSACTION_INPUTS {
+            return self.build_err("Too many inputs in transaction");
+        }
         // Calculate the fee based on whether we need to add a residual change output or not
         let (total_fee, change) = match self.add_change_if_required() {
             Ok((fee, change)) => (fee, change),
@@ -246,7 +263,7 @@ impl SenderTransactionInitializer {
         if total_fee < MINIMUM_TRANSACTION_FEE {
             return self.build_err("Fee is less than the minimum");
         }
-
+        // Create transaction outputs
         let outputs = match self
             .outputs
             .iter()
@@ -258,11 +275,15 @@ impl SenderTransactionInitializer {
                 return self.build_err(&e.to_string());
             },
         };
+        // Prevent overflow attacks by imposing sane limits on outputs
+        if outputs.len() > MAX_TRANSACTION_OUTPUTS {
+            return self.build_err("Too many outputs in transaction");
+        }
 
-        let nonce = self.private_nonce.unwrap();
+        let nonce = self.private_nonce.clone().unwrap();
         let public_nonce = PublicKey::from_secret_key(&nonce);
-        let offset = self.offset.unwrap();
-        let excess_blinding_factor = self.excess_blinding_factor;
+        let offset = self.offset.clone().unwrap();
+        let excess_blinding_factor = self.excess_blinding_factor.clone();
         let offset_blinding_factor = &excess_blinding_factor - &offset;
         let excess = PublicKey::from_secret_key(&offset_blinding_factor);
         let amount_to_self = self.outputs.iter().fold(MicroTari::from(0), |sum, o| sum + o.value);
@@ -277,6 +298,24 @@ impl SenderTransactionInitializer {
         for i in 0..num_ids {
             ids.push(calculate_tx_id::<D>(&public_nonce, i));
         }
+
+        // The fee should be less than the amount. This isn't a protocol requirement, but it's what you want 99.999%
+        // of the time, however, always preventing this will also prevent spending dust in some edge cases.
+        if total_fee > self.calculate_total_amount(&amount_to_self) {
+            let ids_clone = ids.to_vec();
+            warn!(
+                target: LOG_TARGET,
+                "Fee ({}) is greater than amount ({}) for Transaction (TxId: {}).",
+                total_fee,
+                self.calculate_total_amount(&amount_to_self),
+                ids_clone[0]
+            );
+            if self.prevent_fee_gt_amount {
+                return self.build_err("Fee is greater than amount");
+            }
+        }
+
+        // Everything is here. Let's send some Tari!
         let sender_info = RawTransactionInfo {
             num_recipients: self.num_recipients,
             amount_to_self,
@@ -301,6 +340,7 @@ impl SenderTransactionInitializer {
             signatures: Vec::new(),
             message: self.message.unwrap_or_else(|| "".to_string()),
         };
+
         let state = SenderState::Initializing(Box::new(sender_info));
         let state = state
             .initialize()
@@ -343,7 +383,7 @@ mod test {
         // We should have a bunch of fields missing still, but we can recover and continue
         assert_eq!(
             err.message,
-            "Missing Lock Height,Missing Fee per gram,Missing Offset,Missing Private nonce,Missing Input"
+            "Missing Lock Height,Missing Fee per gram,Missing Offset,Missing Private nonce"
         );
         let mut builder = err.builder;
         builder
@@ -394,7 +434,8 @@ mod test {
             .with_private_nonce(p.nonce)
             .with_output(output)
             .with_input(utxo, input)
-            .with_fee_per_gram(MicroTari(20));
+            .with_fee_per_gram(MicroTari(20))
+            .with_prevent_fee_gt_amount(false);
         let result = builder.build::<Blake256>(&factories).unwrap();
         // Peek inside and check the results
         if let SenderState::Finalizing(info) = result.state {
@@ -430,7 +471,8 @@ mod test {
             .with_private_nonce(p.nonce)
             .with_output(output)
             .with_input(utxo, input)
-            .with_fee_per_gram(MicroTari(20));
+            .with_fee_per_gram(MicroTari(20))
+            .with_prevent_fee_gt_amount(false);
         let result = builder.build::<Blake256>(&factories).unwrap();
         // Peek inside and check the results
         if let SenderState::Finalizing(info) = result.state {
@@ -466,7 +508,7 @@ mod test {
             builder.with_input(utxo, input);
         }
         let err = builder.build::<Blake256>(&factories).unwrap_err();
-        assert_eq!(err.message, "Too many inputs");
+        assert_eq!(err.message, "Too many inputs in transaction");
     }
 
     #[test]

--- a/base_layer/wallet/src/output_manager_service/config.rs
+++ b/base_layer/wallet/src/output_manager_service/config.rs
@@ -29,6 +29,7 @@ const LOG_TARGET: &str = "wallet::output_manager_service::config";
 pub struct OutputManagerServiceConfig {
     pub base_node_query_timeout: Duration,
     pub max_utxo_query_size: usize,
+    pub prevent_fee_gt_amount: bool,
 }
 
 impl Default for OutputManagerServiceConfig {
@@ -36,11 +37,12 @@ impl Default for OutputManagerServiceConfig {
         Self {
             base_node_query_timeout: Duration::from_secs(30),
             max_utxo_query_size: 5000,
+            prevent_fee_gt_amount: true,
         }
     }
 }
 impl OutputManagerServiceConfig {
-    pub fn new(base_node_query_timeout: Duration) -> Self {
+    pub fn new(base_node_query_timeout: Duration, prevent_fee_gt_amount: bool) -> Self {
         trace!(
             target: LOG_TARGET,
             "Timeouts - Base node query: {} s",
@@ -48,6 +50,7 @@ impl OutputManagerServiceConfig {
         );
         Self {
             base_node_query_timeout,
+            prevent_fee_gt_amount,
             ..Default::default()
         }
     }

--- a/base_layer/wallet/src/output_manager_service/service.rs
+++ b/base_layer/wallet/src/output_manager_service/service.rs
@@ -555,7 +555,8 @@ where
             .with_offset(offset.clone())
             .with_private_nonce(nonce.clone())
             .with_amount(0, amount)
-            .with_message(message);
+            .with_message(message)
+            .with_prevent_fee_gt_amount(self.resources.config.prevent_fee_gt_amount);
 
         for uo in outputs.iter() {
             builder.with_input(

--- a/base_layer/wallet/tests/output_manager_service/service.rs
+++ b/base_layer/wallet/tests/output_manager_service/service.rs
@@ -119,6 +119,7 @@ pub fn setup_output_manager_service<T: OutputManagerBackend + Clone + 'static>(
             OutputManagerServiceConfig {
                 base_node_query_timeout: Duration::from_secs(10),
                 max_utxo_query_size: 2,
+                ..Default::default()
             },
             outbound_message_requester.clone(),
             ts_handle.clone(),

--- a/common/config/presets/windows.toml
+++ b/common/config/presets/windows.toml
@@ -85,6 +85,10 @@ base_node_query_timeout = 120
 #transaction_direct_send_timeout = 20
 # This is the timeout period that will be used for sending transactions via broadcast mode (default = 30)
 #transaction_broadcast_send_timeout = 30
+# If a large amount of tiny valued uT UTXOs are used as inputs to a transaction, the fee may be larger than
+# the transaction amount. Set this value to `false` to allow spending of "dust" UTXOs for small valued
+# transactions (default = true).
+#prevent_fee_gt_amount = false
 
 #[base_node.transport.tor]
 #control_address = "/ip4/127.0.0.1/tcp/9051"

--- a/common/config/tari_config_sample.toml
+++ b/common/config/tari_config_sample.toml
@@ -85,6 +85,10 @@ base_node_query_timeout = 120
 #transaction_direct_send_timeout = 20
 # This is the timeout period that will be used for sending transactions via broadcast mode (default = 30)
 #transaction_broadcast_send_timeout = 30
+# If a large amount of tiny valued uT UTXOs are used as inputs to a transaction, the fee may be larger than
+# the transaction amount. Set this value to `false` to allow spending of "dust" UTXOs for small valued
+# transactions (default = true).
+#prevent_fee_gt_amount = false
 
 #[base_node.transport.tor]
 #control_address = "/ip4/127.0.0.1/tcp/9051"

--- a/common/src/configuration/global.rs
+++ b/common/src/configuration/global.rs
@@ -84,6 +84,7 @@ pub struct GlobalConfig {
     pub transaction_chain_monitoring_timeout: Duration,
     pub transaction_direct_send_timeout: Duration,
     pub transaction_broadcast_send_timeout: Duration,
+    pub prevent_fee_gt_amount: bool,
     pub monerod_url: String,
     pub monerod_username: String,
     pub monerod_password: String,
@@ -343,6 +344,11 @@ fn convert_node_config(network: Network, cfg: Config) -> Result<GlobalConfig, Co
             .map_err(|e| ConfigurationError::new(&key, &e.to_string()))? as u64,
     );
 
+    let key = "wallet.prevent_fee_gt_amount";
+    let prevent_fee_gt_amount = cfg
+        .get_bool(&key)
+        .map_err(|e| ConfigurationError::new(&key, &e.to_string()))? as bool;
+
     let key = "common.liveness_max_sessions";
     let liveness_max_sessions = cfg
         .get_int(key)
@@ -442,6 +448,7 @@ fn convert_node_config(network: Network, cfg: Config) -> Result<GlobalConfig, Co
         transaction_chain_monitoring_timeout,
         transaction_direct_send_timeout,
         transaction_broadcast_send_timeout,
+        prevent_fee_gt_amount,
         proxy_host_address,
         monerod_url,
         monerod_username,

--- a/common/src/configuration/utils.rs
+++ b/common/src/configuration/utils.rs
@@ -80,6 +80,7 @@ pub fn default_config(bootstrap: &ConfigBootstrap) -> Config {
     cfg.set_default("wallet.transaction_direct_send_timeout", 600).unwrap();
     cfg.set_default("wallet.transaction_broadcast_send_timeout", 600)
         .unwrap();
+    cfg.set_default("wallet.prevent_fee_gt_amount", true).unwrap();
 
     //---------------------------------- Mainnet Defaults --------------------------------------------//
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Preventing fee to be larger than the amount will also prevent spending dust in some cases. Added a config option as a general setting to allow the fee to be larger than the amount in order to enable spending dust for small valued transactions.

## Motivation and Context

See console output where transactions end up pending because a fee larger than the amount is not allowed below. Note the number of inputs (dust) collected to make up the amount and fee.

```
>> list-transactions
Inbound Transactions
>> No pending inbound transactions found.

Outbound Transactions
Transaction ID       | Dest Public Key                                                  | Amount    | Fee       | Status  | Sender State                                          | Timestamp           | Message
4219066494340707534  | 7ad67f1c608d25bf6126f5ce5e44cabc5f1b0464ae14efd1969d52f2dfb5c518 | 10000 µT | 36100 µT | Pending | CollectingSingleSignature(1415 input(s), 1 output(s)) | 2020-09-23 14:34:03 | #Test dust
11827765445046070496 | 7ad67f1c608d25bf6126f5ce5e44cabc5f1b0464ae14efd1969d52f2dfb5c518 | 10000 µT | 10800 µT | Pending | CollectingSingleSignature(416 input(s), 0 output(s))  | 2020-09-23 14:35:33 | #Test dust
```
Error messages form log files (as per #2260):
```
2020-09-23 16:34:03.916777200 [wallet::transaction_service::protocols::send_protocol] INFO  Pending Outbound Transaction TxId: 4219066494340707534 added. Waiting for Reply or Cancellation
2020-09-23 16:34:07.902492900 [wallet::transaction_service::protocols::send_protocol] ERROR Transaction (TxId: 4219066494340707534) could not be finalized. Failure error: ValidationError("Fee is greater than amount")
2020-09-23 16:34:07.903493300 [wallet::transaction_service::service] TRACE Send Protocol for Transaction has ended with result Ok(Err(TransactionServiceProtocolError { id: 4219066494340707534, error: TransactionProtocolError(ValidationError("Fee is greater than amount")) }))
2020-09-23 16:34:07.903493300 [wallet::transaction_service::service] WARN  Error completing Send Transaction Protocol (Id: 4219066494340707534): TransactionProtocolError(ValidationError("Fee is greater than amount"))


2020-09-23 16:35:33.836955500 [wallet::transaction_service::protocols::send_protocol] INFO  Pending Outbound Transaction TxId: 11827765445046070496 added. Waiting for Reply or Cancellation
2020-09-23 16:35:35.183538000 [wallet::transaction_service::protocols::send_protocol] ERROR Transaction (TxId: 11827765445046070496) could not be finalized. Failure error: ValidationError("Fee is greater than amount")
2020-09-23 16:35:35.183538000 [wallet::transaction_service::service] TRACE Send Protocol for Transaction has ended with result Ok(Err(TransactionServiceProtocolError { id: 11827765445046070496, error: TransactionProtocolError(ValidationError("Fee is greater than amount")) }))
2020-09-23 16:35:35.183538000 [wallet::transaction_service::service] WARN  Error completing Send Transaction Protocol (Id: 11827765445046070496): TransactionProtocolError(ValidationError("Fee is greater than amount"))
```

## How Has This Been Tested?

Tested between two base nodes in Windows.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [X] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [X] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [X] I'm merging against the `development` branch.
* [X] I ran `cargo-fmt --all` before pushing.
* [X] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [X] I have added tests to cover my changes.
