### PR TITLE
Add display to pow data struct

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -147,18 +147,18 @@ checksum = "25f9db3b38af870bf7e5cc649167533b493928e50744e2c30ae350230b414670"
 dependencies = [
  "proc-macro2 1.0.21",
  "quote 1.0.7",
- "syn 1.0.41",
+ "syn 1.0.39",
 ]
 
 [[package]]
 name = "async-trait"
-version = "0.1.40"
+version = "0.1.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "687c230d85c0a52504709705fc8a53e4a692b83a2184f03dae73e38e1e93a783"
+checksum = "6e1a4a2f97ce50c9d0282c1468816208588441492b40d813b2e0419c22c05e7f"
 dependencies = [
  "proc-macro2 1.0.21",
  "quote 1.0.7",
- "syn 1.0.41",
+ "syn 1.0.39",
 ]
 
 [[package]]
@@ -236,7 +236,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f30d3a39baa26f9651f17b375061f3233dde33424a8b72b0dbe93a68a0bc896d"
 dependencies = [
  "byteorder",
- "serde 1.0.116",
+ "serde 1.0.115",
 ]
 
 [[package]]
@@ -369,7 +369,7 @@ dependencies = [
  "lazy_static 1.4.0",
  "memchr",
  "regex-automata",
- "serde 1.0.116",
+ "serde 1.0.115",
 ]
 
 [[package]]
@@ -385,7 +385,7 @@ dependencies = [
  "merlin",
  "rand 0.7.3",
  "rand_core 0.5.1",
- "serde 1.0.116",
+ "serde 1.0.115",
  "serde_derive",
  "sha3",
  "subtle 2.3.0",
@@ -438,7 +438,7 @@ version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e4cec68f03f32e44924783795810fa50a7035d8c8ebe78580ad7e6c703fba38"
 dependencies = [
- "serde 1.0.116",
+ "serde 1.0.115",
 ]
 
 [[package]]
@@ -470,9 +470,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.60"
+version = "1.0.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef611cc68ff783f18535d77ddd080185275713d852c4f5cbb6122c462a7a825c"
+checksum = "66120af515773fb005778dc07c261bd201ec8ce50bd6e7144c927753fe013381"
 
 [[package]]
 name = "cexpr"
@@ -512,7 +512,7 @@ checksum = "942f72db697d8767c22d46a598e01f2d3b475501ea43d0db4f16d90259182d0b"
 dependencies = [
  "num-integer",
  "num-traits 0.2.12",
- "serde 1.0.116",
+ "serde 1.0.115",
  "time",
 ]
 
@@ -534,7 +534,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6316c62053228eddd526a5e6deb6344c80bf2bc1e9786e7f90b3083e73197c1"
 dependencies = [
  "bitstring",
- "serde 1.0.116",
+ "serde 1.0.115",
 ]
 
 [[package]]
@@ -590,7 +590,7 @@ dependencies = [
  "lazy_static 1.4.0",
  "nom 4.2.3",
  "rust-ini",
- "serde 1.0.116",
+ "serde 1.0.115",
  "serde-hjson",
  "serde_json",
  "toml 0.4.10",
@@ -648,7 +648,7 @@ dependencies = [
  "rand_xoshiro",
  "rayon",
  "rayon-core",
- "serde 1.0.116",
+ "serde 1.0.115",
  "serde_derive",
  "serde_json",
  "tinytemplate",
@@ -699,12 +699,12 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.4.4"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b153fe7cbef478c567df0f972e02e6d736db11affe43dfc9c56a9374d1adfb87"
+checksum = "09ee0cc8804d5393478d743b035099520087a5186f3b93fa58cec08fa62407b6"
 dependencies = [
+ "cfg-if",
  "crossbeam-utils 0.7.2",
- "maybe-uninit",
 ]
 
 [[package]]
@@ -811,7 +811,7 @@ dependencies = [
  "csv-core",
  "itoa",
  "ryu",
- "serde 1.0.116",
+ "serde 1.0.115",
 ]
 
 [[package]]
@@ -875,7 +875,7 @@ dependencies = [
  "digest",
  "packed_simd",
  "rand_core 0.5.1",
- "serde 1.0.116",
+ "serde 1.0.115",
  "subtle 2.3.0",
  "zeroize",
 ]
@@ -901,7 +901,7 @@ dependencies = [
  "proc-macro2 1.0.21",
  "quote 1.0.7",
  "strsim 0.9.3",
- "syn 1.0.41",
+ "syn 1.0.39",
 ]
 
 [[package]]
@@ -912,7 +912,7 @@ checksum = "d9b5a2f4ac4969822c62224815d069952656cadc7084fdca9751e6d959189b72"
 dependencies = [
  "darling_core",
  "quote 1.0.7",
- "syn 1.0.41",
+ "syn 1.0.39",
 ]
 
 [[package]]
@@ -957,7 +957,7 @@ checksum = "45f5098f628d02a7a0f68ddba586fb61e80edec3bdc1be3b921f4ceec60858d3"
 dependencies = [
  "proc-macro2 1.0.21",
  "quote 1.0.7",
- "syn 1.0.41",
+ "syn 1.0.39",
 ]
 
 [[package]]
@@ -1040,9 +1040,9 @@ checksum = "134951f4028bdadb9b84baf4232681efbf277da25144b9b0ad65df75946c422b"
 
 [[package]]
 name = "either"
-version = "1.6.1"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
+checksum = "cd56b59865bce947ac5958779cfa508f6c3b9497cc762b7e24a12d11ccde2c4f"
 
 [[package]]
 name = "encode_unicode"
@@ -1077,7 +1077,7 @@ checksum = "e57001dfb2532f5a103ff869656887fae9a8defa7d236f3e39d2ee86ed629ad7"
 dependencies = [
  "proc-macro2 1.0.21",
  "quote 1.0.7",
- "syn 1.0.41",
+ "syn 1.0.39",
 ]
 
 [[package]]
@@ -1108,7 +1108,7 @@ dependencies = [
  "darling",
  "proc-macro2 1.0.21",
  "quote 1.0.7",
- "syn 1.0.41",
+ "syn 1.0.39",
 ]
 
 [[package]]
@@ -1146,7 +1146,7 @@ dependencies = [
  "crunchy 0.1.6",
  "ethereum-types-serialize",
  "fixed-hash 0.2.5",
- "serde 1.0.116",
+ "serde 1.0.115",
  "tiny-keccak",
 ]
 
@@ -1160,7 +1160,7 @@ dependencies = [
  "ethbloom",
  "ethereum-types-serialize",
  "fixed-hash 0.2.5",
- "serde 1.0.116",
+ "serde 1.0.115",
  "uint 0.4.1",
 ]
 
@@ -1170,7 +1170,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1873d77b32bc1891a79dad925f2acbc318ee942b38b9110f9dbc5fbeffcea350"
 dependencies = [
- "serde 1.0.116",
+ "serde 1.0.115",
 ]
 
 [[package]]
@@ -1372,7 +1372,7 @@ dependencies = [
  "proc-macro-hack",
  "proc-macro2 1.0.21",
  "quote 1.0.7",
- "syn 1.0.41",
+ "syn 1.0.39",
 ]
 
 [[package]]
@@ -1599,9 +1599,12 @@ checksum = "29fba9abe4742d586dfd0c06ae4f7e73a1c2d86b856933509b269d82cdf06e18"
 
 [[package]]
 name = "hashbrown"
-version = "0.9.0"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00d63df3d41950fb462ed38308eea019113ad1508da725bbedcd0fa5a85ef5f7"
+checksum = "e91b62f79061a0bc2e046024cb7ba44b08419ed238ecbd9adbd787434b9e8c25"
+dependencies = [
+ "autocfg",
+]
 
 [[package]]
 name = "heapsize"
@@ -1786,12 +1789,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "1.6.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55e2e4c765aa53a0424761bf9f41aa7a6ac1efa87238f59560640e27fca028f2"
+checksum = "86b45e59b16c76b11bf9738fd5d38879d3bd28ad292d7b313608becb17ae2df9"
 dependencies = [
  "autocfg",
- "hashbrown 0.9.0",
+ "hashbrown 0.8.2",
 ]
 
 [[package]]
@@ -1840,7 +1843,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "436f3455a8a4e9c7b14de9f1206198ee5d0bdc2db1b560339d2141093d7dd389"
 dependencies = [
  "hyper 0.10.16",
- "serde 1.0.116",
+ "serde 1.0.115",
  "serde_derive",
  "serde_json",
 ]
@@ -1907,9 +1910,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.77"
+version = "0.2.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2f96b10ec2560088a8e76961b00d47107b3a625fecb76dedb29ee7ccbf98235"
+checksum = "755456fae044e6fa1ebbbd1b3e902ae19e73097ed4ed87bb79934a867c007bc3"
 
 [[package]]
 name = "libgit2-sys"
@@ -1972,9 +1975,9 @@ dependencies = [
 
 [[package]]
 name = "libz-sys"
-version = "1.1.2"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "602113192b08db8f38796c4e85c39e960c145965140e918018bcde1952429655"
+checksum = "af67924b8dd885cccea261866c8ce5b74d239d272e154053ff927dae839f5ae9"
 dependencies = [
  "cc",
  "libc",
@@ -2035,7 +2038,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fabed175da42fed1fa0746b0ea71f412aa9d35e76e95e59b192c64b9dc2bf8b"
 dependencies = [
  "cfg-if",
- "serde 1.0.116",
+ "serde 1.0.115",
 ]
 
 [[package]]
@@ -2059,7 +2062,7 @@ dependencies = [
  "libc",
  "log 0.4.11",
  "log-mdc",
- "serde 1.0.116",
+ "serde 1.0.115",
  "serde-value",
  "serde_derive",
  "serde_json",
@@ -2133,7 +2136,7 @@ dependencies = [
  "migrations_internals",
  "proc-macro2 1.0.21",
  "quote 1.0.7",
- "syn 1.0.41",
+ "syn 1.0.39",
 ]
 
 [[package]]
@@ -2163,12 +2166,11 @@ dependencies = [
 
 [[package]]
 name = "miniz_oxide"
-version = "0.4.2"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c60c0dfe32c10b43a144bad8fc83538c52f58302c92300ea7ec7bf7b38d5a7b9"
+checksum = "4d7559a8a40d0f97e1edea3220f698f78b1c5ab67532e49f68fde3910323b722"
 dependencies = [
  "adler",
- "autocfg",
 ]
 
 [[package]]
@@ -2249,7 +2251,7 @@ dependencies = [
  "fixed-hash 0.3.2",
  "hex",
  "keccak-hash 0.3.0",
- "serde 1.0.116",
+ "serde 1.0.115",
  "serde-big-array",
  "thiserror",
 ]
@@ -2583,7 +2585,7 @@ dependencies = [
  "data-encoding",
  "parity-multihash",
  "percent-encoding 2.1.0",
- "serde 1.0.116",
+ "serde 1.0.115",
  "static_assertions 1.1.0",
  "unsigned-varint",
  "url 2.1.1",
@@ -2613,7 +2615,7 @@ dependencies = [
  "arrayvec 0.5.1",
  "bitvec",
  "byte-slice-cast",
- "serde 1.0.116",
+ "serde 1.0.115",
 ]
 
 [[package]]
@@ -2691,7 +2693,7 @@ checksum = "2c0e815c3ee9a031fdf5af21c10aa17c573c9c6a566328d99e3936c34e36461f"
 dependencies = [
  "proc-macro2 1.0.21",
  "quote 1.0.7",
- "syn 1.0.41",
+ "syn 1.0.39",
 ]
 
 [[package]]
@@ -2762,7 +2764,7 @@ dependencies = [
  "proc-macro-error-attr",
  "proc-macro2 1.0.21",
  "quote 1.0.7",
- "syn 1.0.41",
+ "syn 1.0.39",
  "version_check 0.9.2",
 ]
 
@@ -2845,7 +2847,7 @@ dependencies = [
  "itertools",
  "proc-macro2 1.0.21",
  "quote 1.0.7",
- "syn 1.0.41",
+ "syn 1.0.39",
 ]
 
 [[package]]
@@ -3046,11 +3048,11 @@ dependencies = [
 
 [[package]]
 name = "rayon-core"
-version = "1.8.1"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8c4fec834fb6e6d2dd5eece3c7b432a52f0ba887cf40e595190c4107edc08bf"
+checksum = "91739a34c4355b5434ce54c9086c5895604a9c278586d1f1aa95e04f66b525a0"
 dependencies = [
- "crossbeam-channel 0.4.4",
+ "crossbeam-channel 0.4.3",
  "crossbeam-deque",
  "crossbeam-utils 0.7.2",
  "lazy_static 1.4.0",
@@ -3143,7 +3145,7 @@ dependencies = [
  "native-tls",
  "percent-encoding 2.1.0",
  "pin-project-lite",
- "serde 1.0.116",
+ "serde 1.0.115",
  "serde_json",
  "serde_urlencoded",
  "tokio",
@@ -3173,7 +3175,7 @@ checksum = "011e1d58446e9fa3af7cdc1fb91295b10621d3ac4cb3a85cc86385ee9ca50cd3"
 dependencies = [
  "byteorder",
  "rmp",
- "serde 1.0.116",
+ "serde 1.0.115",
 ]
 
 [[package]]
@@ -3241,7 +3243,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "54a50e29610a5be68d4a586a5cce3bfb572ed2c2a74227e4168444b7bf4e5235"
 dependencies = [
  "quote 1.0.7",
- "syn 1.0.41",
+ "syn 1.0.39",
 ]
 
 [[package]]
@@ -3333,9 +3335,9 @@ checksum = "9dad3f759919b92c3068c696c15c3d17238234498bbdcc80f2c469606f948ac8"
 
 [[package]]
 name = "serde"
-version = "1.0.116"
+version = "1.0.115"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96fe57af81d28386a513cbc6858332abc6117cfdb5999647c6444b8f43a370a5"
+checksum = "e54c9a88f2da7238af84b5101443f0c0d0a3bbdc455e34a5c9497b1903ed55d5"
 dependencies = [
  "serde_derive",
 ]
@@ -3346,7 +3348,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "883eee5198ea51720eab8be52a36cf6c0164ac90eea0ed95b649d5e35382404e"
 dependencies = [
- "serde 1.0.116",
+ "serde 1.0.115",
  "serde_derive",
 ]
 
@@ -3370,18 +3372,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a663f873dedc4eac1a559d4c6bc0d0b2c34dc5ac4702e105014b8281489e44f"
 dependencies = [
  "ordered-float",
- "serde 1.0.116",
+ "serde 1.0.115",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.116"
+version = "1.0.115"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f630a6370fd8e457873b4bd2ffdae75408bc291ba72be773772a4c2a065d9ae8"
+checksum = "609feed1d0a73cc36a0182a840a9b37b4a82f0b1150369f0536a9e3f2a31dc48"
 dependencies = [
  "proc-macro2 1.0.21",
  "quote 1.0.7",
- "syn 1.0.41",
+ "syn 1.0.39",
 ]
 
 [[package]]
@@ -3392,7 +3394,7 @@ checksum = "164eacbdb13512ec2745fb09d51fd5b22b0d65ed294a1dcf7285a360c80a675c"
 dependencies = [
  "itoa",
  "ryu",
- "serde 1.0.116",
+ "serde 1.0.115",
 ]
 
 [[package]]
@@ -3403,7 +3405,7 @@ checksum = "2dc6b7951b17b051f3210b063f12cc17320e2fe30ae05b0fe2a3abb068551c76"
 dependencies = [
  "proc-macro2 1.0.21",
  "quote 1.0.7",
- "syn 1.0.41",
+ "syn 1.0.39",
 ]
 
 [[package]]
@@ -3423,7 +3425,7 @@ checksum = "9ec5d77e2d4c73717816afac02670d5c4f534ea95ed430442cad02e7a6e32c97"
 dependencies = [
  "dtoa",
  "itoa",
- "serde 1.0.116",
+ "serde 1.0.115",
  "url 2.1.1",
 ]
 
@@ -3435,7 +3437,7 @@ checksum = "ae3e2dd40a7cdc18ca80db804b7f461a39bb721160a85c9a1fa30134bf3c02a5"
 dependencies = [
  "dtoa",
  "linked-hash-map 0.5.3",
- "serde 1.0.116",
+ "serde 1.0.115",
  "yaml-rust",
 ]
 
@@ -3604,7 +3606,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2 1.0.21",
  "quote 1.0.7",
- "syn 1.0.41",
+ "syn 1.0.39",
 ]
 
 [[package]]
@@ -3628,7 +3630,7 @@ dependencies = [
  "heck",
  "proc-macro2 1.0.21",
  "quote 1.0.7",
- "syn 1.0.41",
+ "syn 1.0.39",
 ]
 
 [[package]]
@@ -3640,7 +3642,7 @@ dependencies = [
  "heck",
  "proc-macro2 1.0.21",
  "quote 1.0.7",
- "syn 1.0.41",
+ "syn 1.0.39",
 ]
 
 [[package]]
@@ -3685,9 +3687,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.41"
+version = "1.0.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6690e3e9f692504b941dc6c3b188fd28df054f7fb8469ab40680df52fdcc842b"
+checksum = "891d8d6567fe7c7f8835a3a98af4208f3846fba258c1bc3c31d6e506239f11f9"
 dependencies = [
  "proc-macro2 1.0.21",
  "quote 1.0.7",
@@ -3711,7 +3713,7 @@ checksum = "b834f2d66f734cb897113e34aaff2f1ab4719ca946f9a7358dba8f8064148701"
 dependencies = [
  "proc-macro2 1.0.21",
  "quote 1.0.7",
- "syn 1.0.41",
+ "syn 1.0.39",
  "unicode-xid 0.2.1",
 ]
 
@@ -3773,7 +3775,7 @@ dependencies = [
  "regex",
  "rustyline",
  "rustyline-derive",
- "serde 1.0.116",
+ "serde 1.0.115",
  "serde_json",
  "structopt",
  "strum 0.18.0",
@@ -3822,7 +3824,7 @@ dependencies = [
  "parity-multiaddr",
  "path-clean",
  "prost-build",
- "serde 1.0.116",
+ "serde 1.0.115",
  "serde_json",
  "sha2",
  "structopt",
@@ -3856,7 +3858,7 @@ dependencies = [
  "pin-project",
  "prost",
  "rand 0.7.3",
- "serde 1.0.116",
+ "serde 1.0.115",
  "serde_derive",
  "serde_json",
  "snow",
@@ -3898,7 +3900,7 @@ dependencies = [
  "prost",
  "prost-types",
  "rand 0.7.3",
- "serde 1.0.116",
+ "serde 1.0.115",
  "serde_derive",
  "serde_repr",
  "tari_common",
@@ -3926,7 +3928,7 @@ dependencies = [
  "futures 0.3.5",
  "prost",
  "quote 1.0.7",
- "syn 1.0.41",
+ "syn 1.0.39",
  "tari_comms",
  "tari_test_utils",
  "tokio",
@@ -3994,7 +3996,7 @@ dependencies = [
  "rand 0.7.3",
  "randomx-rs",
  "rmp-serde",
- "serde 1.0.116",
+ "serde 1.0.115",
  "serde_json",
  "strum 0.17.1",
  "strum_macros 0.17.1",
@@ -4038,7 +4040,7 @@ dependencies = [
  "merlin",
  "rand 0.7.3",
  "rmp-serde",
- "serde 1.0.116",
+ "serde 1.0.115",
  "serde_json",
  "sha2",
  "tari_utilities 0.2.0",
@@ -4060,7 +4062,7 @@ version = "0.2.6"
 dependencies = [
  "digest",
  "rand 0.7.3",
- "serde 1.0.116",
+ "serde 1.0.115",
  "serde_derive",
  "serde_json",
  "sha2",
@@ -4086,7 +4088,7 @@ dependencies = [
  "monero",
  "rand 0.7.3",
  "reqwest",
- "serde 1.0.116",
+ "serde 1.0.115",
  "serde_json",
  "structopt",
  "tari_app_grpc",
@@ -4113,7 +4115,7 @@ dependencies = [
  "digest",
  "log 0.4.11",
  "rand 0.7.3",
- "serde 1.0.116",
+ "serde 1.0.115",
  "serde_json",
  "tari_crypto",
  "tari_infra_derive",
@@ -4140,7 +4142,7 @@ dependencies = [
  "log4rs",
  "prost",
  "rand 0.7.3",
- "serde 1.0.116",
+ "serde 1.0.115",
  "serde_derive",
  "stream-cancel",
  "tari_broadcast_channel",
@@ -4196,7 +4198,7 @@ dependencies = [
  "rand 0.5.6",
  "rmp",
  "rmp-serde",
- "serde 1.0.116",
+ "serde 1.0.115",
  "serde_derive",
  "sys-info",
  "tari_utilities 0.2.0",
@@ -4229,7 +4231,7 @@ dependencies = [
  "derive-error",
  "newtype-ops",
  "rand 0.7.3",
- "serde 1.0.116",
+ "serde 1.0.115",
  "serde_json",
 ]
 
@@ -4246,7 +4248,7 @@ dependencies = [
  "clear_on_drop",
  "newtype-ops",
  "rand 0.7.3",
- "serde 1.0.116",
+ "serde 1.0.115",
  "serde_json",
  "thiserror",
 ]
@@ -4270,7 +4272,7 @@ dependencies = [
  "log4rs",
  "prost",
  "rand 0.7.3",
- "serde 1.0.116",
+ "serde 1.0.115",
  "serde_json",
  "tari_comms",
  "tari_comms_dht",
@@ -4365,7 +4367,7 @@ name = "test_faucet"
 version = "0.5.5"
 dependencies = [
  "rand 0.7.3",
- "serde 1.0.116",
+ "serde 1.0.115",
  "serde_json",
  "tari_core",
  "tari_utilities 0.2.0",
@@ -4398,7 +4400,7 @@ checksum = "bd80fc12f73063ac132ac92aceea36734f04a1d93c1240c6944e23a3b8841793"
 dependencies = [
  "proc-macro2 1.0.21",
  "quote 1.0.7",
- "syn 1.0.41",
+ "syn 1.0.39",
 ]
 
 [[package]]
@@ -4447,7 +4449,7 @@ version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d3dc76004a03cec1c5932bca4cdc2e39aaa798e3f82363dd94f9adf6098c12f"
 dependencies = [
- "serde 1.0.116",
+ "serde 1.0.115",
  "serde_json",
 ]
 
@@ -4488,7 +4490,7 @@ checksum = "f0c3acc6aa564495a0f2e1d59fab677cd7f81a19994cfc7f3ad0e64301560389"
 dependencies = [
  "proc-macro2 1.0.21",
  "quote 1.0.7",
- "syn 1.0.41",
+ "syn 1.0.39",
 ]
 
 [[package]]
@@ -4546,7 +4548,7 @@ version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "758664fc71a3a69038656bee8b6be6477d2a6c315a6b81f7081f591bffa4111f"
 dependencies = [
- "serde 1.0.116",
+ "serde 1.0.115",
 ]
 
 [[package]]
@@ -4555,7 +4557,7 @@ version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ffc92d160b1eef40665be3a05630d003936a3bc7da7421277846c2613e92c71a"
 dependencies = [
- "serde 1.0.116",
+ "serde 1.0.115",
 ]
 
 [[package]]
@@ -4597,7 +4599,7 @@ dependencies = [
  "proc-macro2 1.0.21",
  "prost-build",
  "quote 1.0.7",
- "syn 1.0.41",
+ "syn 1.0.39",
 ]
 
 [[package]]
@@ -4812,14 +4814,14 @@ checksum = "80e0ccfc3378da0cce270c946b676a376943f5cd16aeba64568e7939806f4ada"
 dependencies = [
  "proc-macro2 1.0.21",
  "quote 1.0.7",
- "syn 1.0.41",
+ "syn 1.0.39",
 ]
 
 [[package]]
 name = "tracing-core"
-version = "0.1.16"
+version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bcf46c1f1f06aeea2d6b81f3c863d0930a596c86ad1920d4e5bad6dd1d7119a"
+checksum = "4f0e00789804e99b20f12bc7003ca416309d28a6f495d6af58d1e2c2842461b5"
 dependencies = [
  "lazy_static 1.4.0",
 ]
@@ -5096,7 +5098,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ac64ead5ea5f05873d7c12b545865ca2b8d28adfc50a49b84770a3a97265d42"
 dependencies = [
  "cfg-if",
- "serde 1.0.116",
+ "serde 1.0.115",
  "serde_json",
  "wasm-bindgen-macro",
 ]
@@ -5112,7 +5114,7 @@ dependencies = [
  "log 0.4.11",
  "proc-macro2 1.0.21",
  "quote 1.0.7",
- "syn 1.0.41",
+ "syn 1.0.39",
  "wasm-bindgen-shared",
 ]
 
@@ -5146,7 +5148,7 @@ checksum = "f249f06ef7ee334cc3b8ff031bfc11ec99d00f34d86da7498396dc1e3b1498fe"
 dependencies = [
  "proc-macro2 1.0.21",
  "quote 1.0.7",
- "syn 1.0.41",
+ "syn 1.0.39",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -5295,6 +5297,6 @@ checksum = "c3f369ddb18862aba61aa49bf31e74d29f0f162dec753063200e1dc084345d16"
 dependencies = [
  "proc-macro2 1.0.21",
  "quote 1.0.7",
- "syn 1.0.41",
+ "syn 1.0.39",
  "synstructure",
 ]

--- a/base_layer/core/src/proof_of_work/proof_of_work.rs
+++ b/base_layer/core/src/proof_of_work/proof_of_work.rs
@@ -19,10 +19,14 @@
 // SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
 use crate::{
     blocks::BlockHeader,
-    proof_of_work::{blake_pow::blake_difficulty, monero_rx::monero_difficulty, Difficulty, PowAlgorithm},
+    proof_of_work::{
+        blake_pow::blake_difficulty,
+        monero_rx::{monero_difficulty, MoneroData},
+        Difficulty,
+        PowAlgorithm,
+    },
 };
 use bytes::{self, BufMut};
 use serde::{Deserialize, Serialize};
@@ -198,7 +202,13 @@ impl Display for ProofOfWork {
             "Total accumulated difficulty:\nMonero={}, Blake={}",
             self.accumulated_monero_difficulty, self.accumulated_blake_difficulty
         )?;
-        writeln!(fmt, "Pow data: {}", self.pow_data.to_hex())
+        match self.pow_algo {
+            PowAlgorithm::Blake => writeln!(fmt, "Pow data: {}", self.pow_data.to_hex()),
+            PowAlgorithm::Monero => match MoneroData::new_from_pow(&self.pow_data) {
+                Ok(v) => writeln!(fmt, "Pow data: {}", v),
+                Err(_) => writeln!(fmt, "Pow data: MALFORMED DATA"),
+            },
+        }
     }
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Implements display for pow_data struct

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This adds a display option so we can view the details of the monero mined blocks, and not just seeing a hash.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch.
* [x] I ran `cargo-fmt --all` before pushing.
* [x] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
