### PR TITLE
Minor optimisation for MMR + clippy fixes

### DIFF
--- a/base_layer/core/src/chain_storage/lmdb_db/lmdb_db.rs
+++ b/base_layer/core/src/chain_storage/lmdb_db/lmdb_db.rs
@@ -463,7 +463,7 @@ where D: Digest + Send + Sync
             MmrTree::Utxo => {
                 let mut pruned_mmr = prune_mutable_mmr(&*self.utxo_mmr)?;
                 for hash in self.curr_utxo_checkpoint.nodes_added() {
-                    pruned_mmr.push(&hash)?;
+                    pruned_mmr.push(hash.clone())?;
                 }
                 for index in self.curr_utxo_checkpoint.nodes_deleted().to_vec() {
                     pruned_mmr.delete_and_compress(index, false);
@@ -474,14 +474,14 @@ where D: Digest + Send + Sync
             MmrTree::Kernel => {
                 let mut pruned_mmr = prune_mutable_mmr(&*self.kernel_mmr)?;
                 for hash in self.curr_kernel_checkpoint.nodes_added() {
-                    pruned_mmr.push(&hash)?;
+                    pruned_mmr.push(hash.clone())?;
                 }
                 pruned_mmr
             },
             MmrTree::RangeProof => {
                 let mut pruned_mmr = prune_mutable_mmr(&*self.range_proof_mmr)?;
                 for hash in self.curr_range_proof_checkpoint.nodes_added() {
-                    pruned_mmr.push(&hash)?;
+                    pruned_mmr.push(hash.clone())?;
                 }
                 pruned_mmr
             },
@@ -638,7 +638,7 @@ where D: Digest + Send + Sync
     {
         let mut pruned_mmr = self.get_pruned_mmr(&tree)?;
         for hash in additions {
-            pruned_mmr.push(&hash)?;
+            pruned_mmr.push(hash)?;
         }
         if tree == MmrTree::Utxo {
             for hash in deletions {

--- a/base_layer/core/src/chain_storage/lmdb_db/lmdb_vec.rs
+++ b/base_layer/core/src/chain_storage/lmdb_db/lmdb_vec.rs
@@ -141,9 +141,9 @@ where
         Ok(lmdb_get::<i64, T>(&self.env, &self.db, &key)?)
     }
 
-    fn get_or_panic(&self, index: usize) -> Self::Value {
-        self.get(index).unwrap().unwrap()
-    }
+    // fn get_or_panic(&self, index: usize) -> Self::Value {
+    //     self.get(index).unwrap().unwrap()
+    // }
 
     fn clear(&mut self) -> Result<(), Self::Error> {
         let txn = WriteTransaction::new(self.env.clone()).map_err(|e| ChainStorageError::AccessError(e.to_string()))?;

--- a/base_layer/core/src/chain_storage/memory_db/mem_db_vec.rs
+++ b/base_layer/core/src/chain_storage/memory_db/mem_db_vec.rs
@@ -70,9 +70,9 @@ where T: PartialEq + Eq + Hash + Clone
         self.key_to_item.get(&key).map(Clone::clone)
     }
 
-    fn get_or_panic(&self, index: usize) -> T {
-        self.get(index).unwrap()
-    }
+    // fn get_or_panic(&self, index: usize) -> T {
+    //     self.get(index).unwrap()
+    // }
 
     fn clear(&mut self) {
         self.key_to_item.clear();
@@ -205,10 +205,6 @@ where T: PartialEq + Eq + Hash + Clone
             .read()
             .map_err(|e| ChainStorageError::AccessError(e.to_string()))?
             .get(index))
-    }
-
-    fn get_or_panic(&self, index: usize) -> Self::Value {
-        self.storage.read().unwrap().get_or_panic(index)
     }
 
     fn clear(&mut self) -> Result<(), Self::Error> {

--- a/base_layer/core/src/chain_storage/memory_db/memory_db.rs
+++ b/base_layer/core/src/chain_storage/memory_db/memory_db.rs
@@ -446,7 +446,7 @@ where D: Digest + Send + Sync
         let db = self.db_access()?;
         let mut pruned_mmr = get_pruned_mmr(&db, &tree)?;
         for hash in additions {
-            pruned_mmr.push(&hash)?;
+            pruned_mmr.push(hash)?;
         }
         if tree == MmrTree::Utxo {
             deletions.iter().for_each(|hash| {
@@ -855,7 +855,7 @@ fn get_pruned_mmr<D: Digest>(
         MmrTree::Utxo => {
             let mut pruned_mmr = prune_mutable_mmr(&db.utxo_mmr)?;
             for hash in db.curr_utxo_checkpoint.nodes_added() {
-                pruned_mmr.push(&hash)?;
+                pruned_mmr.push(hash.clone())?;
             }
             db.curr_utxo_checkpoint
                 .nodes_deleted()
@@ -870,14 +870,14 @@ fn get_pruned_mmr<D: Digest>(
         MmrTree::Kernel => {
             let mut pruned_mmr = prune_mutable_mmr(&db.kernel_mmr)?;
             for hash in db.curr_kernel_checkpoint.nodes_added() {
-                pruned_mmr.push(&hash)?;
+                pruned_mmr.push(hash.clone())?;
             }
             pruned_mmr
         },
         MmrTree::RangeProof => {
             let mut pruned_mmr = prune_mutable_mmr(&db.range_proof_mmr)?;
             for hash in db.curr_range_proof_checkpoint.nodes_added() {
-                pruned_mmr.push(&hash)?;
+                pruned_mmr.push(hash.clone())?;
             }
             pruned_mmr
         },

--- a/base_layer/core/tests/chain_storage_tests/chain_backend.rs
+++ b/base_layer/core/tests/chain_storage_tests/chain_backend.rs
@@ -439,9 +439,9 @@ fn fetch_mmr_root_and_proof_for_utxo_and_rp<T: BlockchainBackend>(mut db: T) {
     assert!(db.write(txn).is_ok());
 
     let mut utxo_mmr_check = MutableMmr::<HashDigest, _>::new(Vec::new(), Bitmap::create());
-    assert!(utxo_mmr_check.push(&utxo_hash1).is_ok());
-    assert!(utxo_mmr_check.push(&utxo_hash2).is_ok());
-    assert!(utxo_mmr_check.push(&utxo_hash3).is_ok());
+    assert!(utxo_mmr_check.push(utxo_hash1.clone()).is_ok());
+    assert!(utxo_mmr_check.push(utxo_hash2.clone()).is_ok());
+    assert!(utxo_mmr_check.push(utxo_hash3.clone()).is_ok());
     assert_eq!(
         db.fetch_mmr_root(MmrTree::Utxo).unwrap().to_hex(),
         utxo_mmr_check.get_merkle_root().unwrap().to_hex()
@@ -456,9 +456,9 @@ fn fetch_mmr_root_and_proof_for_utxo_and_rp<T: BlockchainBackend>(mut db: T) {
     assert!(proof3.verify_leaf::<HashDigest>(&mmr_only_root, &utxo_hash3, 2).is_ok());
 
     let mut rp_mmr_check = MutableMmr::<HashDigest, _>::new(Vec::new(), Bitmap::create());
-    assert_eq!(rp_mmr_check.push(&rp_hash1), Ok(1));
-    assert_eq!(rp_mmr_check.push(&rp_hash2), Ok(2));
-    assert_eq!(rp_mmr_check.push(&rp_hash3), Ok(3));
+    assert_eq!(rp_mmr_check.push(rp_hash1.clone()), Ok(1));
+    assert_eq!(rp_mmr_check.push(rp_hash2.clone()), Ok(2));
+    assert_eq!(rp_mmr_check.push(rp_hash3.clone()), Ok(3));
     assert_eq!(
         db.fetch_mmr_root(MmrTree::RangeProof).unwrap().to_hex(),
         rp_mmr_check.get_merkle_root().unwrap().to_hex()
@@ -517,9 +517,9 @@ fn fetch_mmr_root_and_proof_for_kernel<T: BlockchainBackend>(mut db: T) {
     assert!(db.write(txn).is_ok());
 
     let mut kernel_mmr_check = MutableMmr::<HashDigest, _>::new(Vec::new(), Bitmap::create());
-    assert!(kernel_mmr_check.push(&hash1).is_ok());
-    assert!(kernel_mmr_check.push(&hash2).is_ok());
-    assert!(kernel_mmr_check.push(&hash3).is_ok());
+    assert!(kernel_mmr_check.push(hash1.clone()).is_ok());
+    assert!(kernel_mmr_check.push(hash2.clone()).is_ok());
+    assert!(kernel_mmr_check.push(hash3.clone()).is_ok());
     assert_eq!(
         db.fetch_mmr_root(MmrTree::Kernel).unwrap().to_hex(),
         kernel_mmr_check.get_merkle_root().unwrap().to_hex()
@@ -1883,10 +1883,10 @@ fn insert_mmr_node_for_utxo_and_rp<T: BlockchainBackend>(mut db: T) {
     assert!(db.write(txn).is_ok());
 
     let mut utxo_mmr_check = MutableMmr::<HashDigest, _>::new(Vec::new(), Bitmap::create());
-    assert!(utxo_mmr_check.push(&utxo_hash1).is_ok());
-    assert!(utxo_mmr_check.push(&utxo_hash2).is_ok());
-    assert!(utxo_mmr_check.push(&utxo_hash3).is_ok());
-    assert!(utxo_mmr_check.push(&utxo_hash4).is_ok());
+    assert!(utxo_mmr_check.push(utxo_hash1.clone()).is_ok());
+    assert!(utxo_mmr_check.push(utxo_hash2.clone()).is_ok());
+    assert!(utxo_mmr_check.push(utxo_hash3.clone()).is_ok());
+    assert!(utxo_mmr_check.push(utxo_hash4.clone()).is_ok());
     let leaf_index = utxo_mmr_check.find_leaf_index(&utxo_hash2).unwrap().unwrap();
     assert!(utxo_mmr_check.delete(leaf_index));
     assert_eq!(
@@ -1905,10 +1905,10 @@ fn insert_mmr_node_for_utxo_and_rp<T: BlockchainBackend>(mut db: T) {
     assert!(proof4.verify_leaf::<HashDigest>(&mmr_only_root, &utxo_hash4, 3).is_ok());
 
     let mut rp_mmr_check = MutableMmr::<HashDigest, _>::new(Vec::new(), Bitmap::create());
-    assert_eq!(rp_mmr_check.push(&rp_hash1), Ok(1));
-    assert_eq!(rp_mmr_check.push(&rp_hash2), Ok(2));
-    assert_eq!(rp_mmr_check.push(&rp_hash3), Ok(3));
-    assert_eq!(rp_mmr_check.push(&rp_hash4), Ok(4));
+    assert_eq!(rp_mmr_check.push(rp_hash1.clone()), Ok(1));
+    assert_eq!(rp_mmr_check.push(rp_hash2.clone()), Ok(2));
+    assert_eq!(rp_mmr_check.push(rp_hash3.clone()), Ok(3));
+    assert_eq!(rp_mmr_check.push(rp_hash4.clone()), Ok(4));
     assert_eq!(
         db.fetch_mmr_root(MmrTree::RangeProof).unwrap().to_hex(),
         rp_mmr_check.get_merkle_root().unwrap().to_hex()

--- a/base_layer/core/tests/chain_storage_tests/chain_storage.rs
+++ b/base_layer/core/tests/chain_storage_tests/chain_storage.rs
@@ -260,9 +260,9 @@ fn utxo_and_rp_merkle_root() {
     let hash2 = utxo2.hash();
     // Calculate the Range proof MMR root as a check
     let mut rp_mmr_check = MutableMmr::<HashDigest, _>::new(Vec::new(), Bitmap::create());
-    assert_eq!(rp_mmr_check.push(&utxo0.proof.hash()).unwrap(), 1);
-    assert_eq!(rp_mmr_check.push(&utxo1.proof.hash()).unwrap(), 2);
-    assert_eq!(rp_mmr_check.push(&utxo2.proof.hash()).unwrap(), 3);
+    assert_eq!(rp_mmr_check.push(utxo0.proof.hash()).unwrap(), 1);
+    assert_eq!(rp_mmr_check.push(utxo1.proof.hash()).unwrap(), 2);
+    assert_eq!(rp_mmr_check.push(utxo2.proof.hash()).unwrap(), 3);
     // Store the UTXOs
     let mut txn = DbTransaction::new();
     txn.insert_utxo(utxo1);
@@ -271,9 +271,9 @@ fn utxo_and_rp_merkle_root() {
     let root = store.fetch_mmr_root(MmrTree::Utxo).unwrap();
     let rp_root = store.fetch_mmr_root(MmrTree::RangeProof).unwrap();
     let mut mmr_check = MutableMmr::<HashDigest, _>::new(Vec::new(), Bitmap::create());
-    assert!(mmr_check.push(&hash0).is_ok());
-    assert!(mmr_check.push(&hash1).is_ok());
-    assert!(mmr_check.push(&hash2).is_ok());
+    assert!(mmr_check.push(hash0).is_ok());
+    assert!(mmr_check.push(hash1).is_ok());
+    assert!(mmr_check.push(hash2).is_ok());
     assert_eq!(root.to_hex(), mmr_check.get_merkle_root().unwrap().to_hex());
     assert_eq!(rp_root.to_hex(), rp_mmr_check.get_merkle_root().unwrap().to_hex());
 }
@@ -299,10 +299,10 @@ fn kernel_merkle_root() {
     assert!(store.commit(txn).is_ok());
     let root = store.fetch_mmr_root(MmrTree::Kernel).unwrap();
     let mut mmr_check = MutableMmr::<HashDigest, _>::new(Vec::new(), Bitmap::create());
-    assert!(mmr_check.push(&hash0).is_ok());
-    assert!(mmr_check.push(&hash1).is_ok());
-    assert!(mmr_check.push(&hash2).is_ok());
-    assert!(mmr_check.push(&hash3).is_ok());
+    assert!(mmr_check.push(hash0).is_ok());
+    assert!(mmr_check.push(hash1).is_ok());
+    assert!(mmr_check.push(hash2).is_ok());
+    assert!(mmr_check.push(hash3).is_ok());
     assert_eq!(root.to_hex(), mmr_check.get_merkle_root().unwrap().to_hex());
 }
 

--- a/base_layer/mmr/src/backend.rs
+++ b/base_layer/mmr/src/backend.rs
@@ -40,10 +40,6 @@ pub trait ArrayLike {
     /// Return the item at the given index
     fn get(&self, index: usize) -> Result<Option<Self::Value>, Self::Error>;
 
-    /// Return the item at the given index. Use this if you *know* that the index is valid. Requesting a hash for an
-    /// invalid index may cause the a panic
-    fn get_or_panic(&self, index: usize) -> Self::Value;
-
     /// Remove all stored items from the the backend.
     fn clear(&mut self) -> Result<(), Self::Error>;
 
@@ -87,10 +83,6 @@ impl<T: Clone + PartialEq> ArrayLike for Vec<T> {
 
     fn get(&self, index: usize) -> Result<Option<Self::Value>, Self::Error> {
         Ok((self as &[Self::Value]).get(index).map(Clone::clone))
-    }
-
-    fn get_or_panic(&self, index: usize) -> Self::Value {
-        self[index].clone()
     }
 
     fn clear(&mut self) -> Result<(), Self::Error> {

--- a/base_layer/mmr/src/error.rs
+++ b/base_layer/mmr/src/error.rs
@@ -39,3 +39,9 @@ pub enum MerkleMountainRangeError {
     #[error("Conflicting or invalid configuration parameters provided.")]
     InvalidConfig,
 }
+
+impl MerkleMountainRangeError {
+    pub fn backend_error<E: ToString>(err: E) -> Self {
+        Self::BackendError(err.to_string())
+    }
+}

--- a/base_layer/mmr/src/functions.rs
+++ b/base_layer/mmr/src/functions.rs
@@ -90,7 +90,7 @@ where
 {
     let mut pruned_mmr = prune_mutable_mmr(src)?;
     for hash in additions {
-        pruned_mmr.push(&hash)?;
+        pruned_mmr.push(hash)?;
     }
     for index in deletions {
         pruned_mmr.delete(index);
@@ -108,7 +108,7 @@ where
 {
     let mut mmr = prune_mmr(src)?;
     for hash in additions {
-        mmr.push(&hash)?;
+        mmr.push(hash)?;
     }
     Ok(mmr.get_merkle_root()?)
 }

--- a/base_layer/mmr/src/mem_backend_vec.rs
+++ b/base_layer/mmr/src/mem_backend_vec.rs
@@ -80,10 +80,6 @@ impl<T: Clone + PartialEq> ArrayLike for MemBackendVec<T> {
             .map_err(|e| MerkleMountainRangeError::BackendError(e.to_string()))?)
     }
 
-    fn get_or_panic(&self, index: usize) -> Self::Value {
-        self.db.read().unwrap()[index].clone()
-    }
-
     fn clear(&mut self) -> Result<(), Self::Error> {
         self.db
             .write()

--- a/base_layer/mmr/src/merkle_checkpoint.rs
+++ b/base_layer/mmr/src/merkle_checkpoint.rs
@@ -58,7 +58,7 @@ impl MerkleCheckPoint {
         B2: ArrayLike<Value = Hash>,
     {
         for node in &self.nodes_added {
-            mmr.push(node)?;
+            mmr.push(node.clone())?;
         }
         mmr.deleted.or_inplace(&self.nodes_deleted);
         Ok(())

--- a/base_layer/mmr/src/mmr_cache.rs
+++ b/base_layer/mmr/src/mmr_cache.rs
@@ -216,7 +216,7 @@ where
     }
 
     /// Search for the leaf index of the given hash in the nodes of the current and base MMR.
-    pub fn find_leaf_index(&self, hash: &Hash) -> Result<Option<u32>, MerkleMountainRangeError> {
+    pub fn find_leaf_index(&self, hash: &[u8]) -> Result<Option<u32>, MerkleMountainRangeError> {
         let mut index = self.base_mmr.find_leaf_index(hash)?;
         if index.is_none() {
             index = self.curr_mmr.find_leaf_index(hash)?;

--- a/base_layer/mmr/src/mutable_mmr.rs
+++ b/base_layer/mmr/src/mutable_mmr.rs
@@ -128,18 +128,18 @@ where
     }
 
     /// See [MerkleMountainRange::find_node_index]
-    pub fn find_node_index(&self, hash: &Hash) -> Result<Option<usize>, MerkleMountainRangeError> {
+    pub fn find_node_index(&self, hash: &[u8]) -> Result<Option<usize>, MerkleMountainRangeError> {
         self.mmr.find_node_index(hash)
     }
 
     /// See [MerkleMountainRange::find_leaf_index]
-    pub fn find_leaf_index(&self, hash: &Hash) -> Result<Option<u32>, MerkleMountainRangeError> {
+    pub fn find_leaf_index(&self, hash: &[u8]) -> Result<Option<u32>, MerkleMountainRangeError> {
         self.mmr.find_leaf_index(hash)
     }
 
     /// Push a new element into the MMR. Computes new related peaks at the same time if applicable.
     /// Returns the new number of leaf nodes (regardless of deleted state) in the mutable MMR
-    pub fn push(&mut self, hash: &Hash) -> Result<usize, MerkleMountainRangeError> {
+    pub fn push(&mut self, hash: Hash) -> Result<usize, MerkleMountainRangeError> {
         if self.size == std::u32::MAX {
             return Err(MerkleMountainRangeError::MaximumSizeReached);
         }

--- a/base_layer/mmr/src/pruned_hashset.rs
+++ b/base_layer/mmr/src/pruned_hashset.rs
@@ -100,12 +100,6 @@ impl ArrayLike for PrunedHashSet {
         Ok(self.hashes.get(index - self.base_offset)?)
     }
 
-    fn get_or_panic(&self, index: usize) -> Self::Value {
-        self.get(index)
-            .unwrap()
-            .expect("PrunedHashSet only tracks peaks before the offset")
-    }
-
     fn clear(&mut self) -> Result<(), Self::Error> {
         self.base_offset = 0;
         self.peak_indices.clear();

--- a/base_layer/mmr/tests/merkle_mountain_range.rs
+++ b/base_layer/mmr/tests/merkle_mountain_range.rs
@@ -44,7 +44,7 @@ fn build_mmr() {
     // Add a single item
     let h0 = int_to_hash(0);
 
-    assert!(mmr.push(&h0).is_ok());
+    assert!(mmr.push(h0.clone()).is_ok());
     // The root of a single hash is the hash of that hash
     assert_eq!(mmr.len(), Ok(1));
     assert_eq!(mmr.get_merkle_root(), Ok(combine_hashes(&[&h0])));
@@ -52,7 +52,7 @@ fn build_mmr() {
     //    2
     //  0   1
     let h1 = int_to_hash(1);
-    assert!(mmr.push(&h1).is_ok());
+    assert!(mmr.push(h1.clone()).is_ok());
     let h_2 = combine_hashes(&[&h0, &h1]);
     assert_eq!(mmr.get_merkle_root(), Ok(combine_hashes(&[&h_2])));
     assert_eq!(mmr.len(), Ok(3));
@@ -60,7 +60,7 @@ fn build_mmr() {
     //    2
     //  0   1  3
     let h3 = int_to_hash(3);
-    assert!(mmr.push(&h3).is_ok());
+    assert!(mmr.push(h3.clone()).is_ok());
     // The root is a bagged root
     let root = combine_hashes(&[&h_2, &h3]);
     assert_eq!(mmr.get_merkle_root(), Ok(root));
@@ -70,7 +70,7 @@ fn build_mmr() {
     //    2      5
     //  0   1  3   4
     let h4 = int_to_hash(4);
-    assert!(mmr.push(&h4).is_ok());
+    assert!(mmr.push(h4.clone()).is_ok());
     let h_5 = combine_hashes(&[&h3, &h4]);
     let h_6 = combine_hashes(&[&h_2, &h_5]);
     assert_eq!(mmr.get_merkle_root(), Ok(combine_hashes(&[&h_6])));
@@ -80,7 +80,7 @@ fn build_mmr() {
     //    2      5
     //  0   1  3   4  7
     let h7 = int_to_hash(7);
-    assert!(mmr.push(&h7).is_ok());
+    assert!(mmr.push(h7.clone()).is_ok());
     let root = combine_hashes(&[&h_6, &h7]);
     assert_eq!(mmr.get_merkle_root(), Ok(root));
     assert_eq!(mmr.len(), Ok(8));
@@ -90,7 +90,7 @@ fn build_mmr() {
     //  0   1  3   4  7  8
     let h8 = int_to_hash(8);
     let h_9 = combine_hashes(&[&h7, &h8]);
-    assert!(mmr.push(&h8).is_ok());
+    assert!(mmr.push(h8.clone()).is_ok());
     let root = combine_hashes(&[&h_6, &h_9]);
     assert_eq!(mmr.get_merkle_root(), Ok(root));
     assert_eq!(mmr.len(), Ok(10));
@@ -101,12 +101,12 @@ fn equality_check() {
     let mut ma = MerkleMountainRange::<Hasher, _>::new(Vec::default());
     let mut mb = MerkleMountainRange::<Hasher, _>::new(Vec::default());
     assert!(ma == mb);
-    assert!(ma.push(&int_to_hash(1)).is_ok());
+    assert!(ma.push(int_to_hash(1)).is_ok());
     assert!(ma != mb);
-    assert!(mb.push(&int_to_hash(1)).is_ok());
+    assert!(mb.push(int_to_hash(1)).is_ok());
     assert!(ma == mb);
-    assert!(ma.push(&int_to_hash(2)).is_ok());
-    assert!(mb.push(&int_to_hash(3)).is_ok());
+    assert!(ma.push(int_to_hash(2)).is_ok());
+    assert!(mb.push(int_to_hash(3)).is_ok());
     assert!(ma != mb);
 }
 
@@ -126,10 +126,10 @@ fn restore_from_leaf_hashes() {
     let h1 = int_to_hash(1);
     let h2 = int_to_hash(2);
     let h3 = int_to_hash(3);
-    assert!(mmr.push(&h0).is_ok());
-    assert!(mmr.push(&h1).is_ok());
-    assert!(mmr.push(&h2).is_ok());
-    assert!(mmr.push(&h3).is_ok());
+    assert!(mmr.push(h0.clone()).is_ok());
+    assert!(mmr.push(h1.clone()).is_ok());
+    assert!(mmr.push(h2.clone()).is_ok());
+    assert!(mmr.push(h3.clone()).is_ok());
     assert_eq!(mmr.len(), Ok(7));
 
     // Construct MMR state from multiple leaf hash queries.
@@ -142,8 +142,8 @@ fn restore_from_leaf_hashes() {
     assert_eq!(leaf_hashes[2], h2);
     assert_eq!(leaf_hashes[3], h3);
 
-    assert!(mmr.push(&int_to_hash(4)).is_ok());
-    assert!(mmr.push(&int_to_hash(5)).is_ok());
+    assert!(mmr.push(int_to_hash(4)).is_ok());
+    assert!(mmr.push(int_to_hash(5)).is_ok());
     assert_eq!(mmr.len(), Ok(10));
 
     assert!(mmr.assign(leaf_hashes).is_ok());
@@ -164,11 +164,11 @@ fn find_leaf_index() {
     let h3 = int_to_hash(3);
     let h4 = int_to_hash(4);
     let h5 = int_to_hash(5);
-    assert!(mmr.push(&h0).is_ok());
-    assert!(mmr.push(&h1).is_ok());
-    assert!(mmr.push(&h2).is_ok());
-    assert!(mmr.push(&h3).is_ok());
-    assert!(mmr.push(&h4).is_ok());
+    assert!(mmr.push(h0.clone()).is_ok());
+    assert!(mmr.push(h1.clone()).is_ok());
+    assert!(mmr.push(h2.clone()).is_ok());
+    assert!(mmr.push(h3.clone()).is_ok());
+    assert!(mmr.push(h4.clone()).is_ok());
     assert_eq!(mmr.len(), Ok(8));
 
     assert_eq!(mmr.find_leaf_index(&h0), Ok(Some(0)));

--- a/base_layer/mmr/tests/mutable_mmr.rs
+++ b/base_layer/mmr/tests/mutable_mmr.rs
@@ -54,7 +54,7 @@ fn delete() {
     let mut mmr = MutableMmr::<Hasher, _>::new(Vec::default(), Bitmap::create());
     assert_eq!(mmr.is_empty(), Ok(true));
     for i in 0..5 {
-        assert!(mmr.push(&int_to_hash(i)).is_ok());
+        assert!(mmr.push(int_to_hash(i)).is_ok());
     }
     assert_eq!(mmr.len(), 5);
     let root = mmr.get_merkle_root().unwrap();
@@ -68,7 +68,7 @@ fn delete() {
     assert_eq!(mmr.is_empty(), Ok(false));
     assert_eq!(mmr.get_merkle_root(), Ok(root));
     // Delete some nodes
-    assert!(mmr.push(&int_to_hash(5)).is_ok());
+    assert!(mmr.push(int_to_hash(5)).is_ok());
     assert!(mmr.delete_and_compress(0, false));
     assert!(mmr.delete_and_compress(2, false));
     assert!(mmr.delete_and_compress(4, true));
@@ -111,7 +111,7 @@ fn build_mmr() {
     // Create a small mutable MMR
     let mut mmr = MutableMmr::<Hasher, _>::new(Vec::default(), Bitmap::create());
     for i in 0..5 {
-        assert!(mmr.push(&int_to_hash(i)).is_ok());
+        assert!(mmr.push(int_to_hash(i)).is_ok());
     }
     // MutableMmr::len gives the size in terms of leaf nodes:
     assert_eq!(mmr.len(), 5);
@@ -130,18 +130,18 @@ fn equality_check() {
     let mut ma = MutableMmr::<Hasher, _>::new(Vec::default(), Bitmap::create());
     let mut mb = MutableMmr::<Hasher, _>::new(Vec::default(), Bitmap::create());
     assert!(ma == mb);
-    assert!(ma.push(&int_to_hash(1)).is_ok());
+    assert!(ma.push(int_to_hash(1)).is_ok());
     assert!(ma != mb);
-    assert!(mb.push(&int_to_hash(1)).is_ok());
+    assert!(mb.push(int_to_hash(1)).is_ok());
     assert!(ma == mb);
-    assert!(ma.push(&int_to_hash(2)).is_ok());
+    assert!(ma.push(int_to_hash(2)).is_ok());
     assert!(ma != mb);
     assert!(ma.delete(1));
     // Even though the two trees have the same apparent elements, they're still not equal, because we don't actually
     // delete anything
     assert!(ma != mb);
     // Add the same hash to mb and then delete it
-    assert!(mb.push(&int_to_hash(2)).is_ok());
+    assert!(mb.push(int_to_hash(2)).is_ok());
     assert!(mb.delete(1));
     // Now they're equal!
     assert!(ma == mb);
@@ -151,7 +151,7 @@ fn equality_check() {
 fn restore_from_leaf_nodes() {
     let mut mmr = MutableMmr::<Hasher, _>::new(Vec::default(), Bitmap::create());
     for i in 0..12 {
-        assert!(mmr.push(&int_to_hash(i)).is_ok());
+        assert!(mmr.push(int_to_hash(i)).is_ok());
     }
     assert!(mmr.delete_and_compress(2, true));
     assert!(mmr.delete_and_compress(4, true));
@@ -169,8 +169,8 @@ fn restore_from_leaf_nodes() {
 
     // Change the state more before the restore
     let mmr_root = mmr.get_merkle_root();
-    assert!(mmr.push(&int_to_hash(7)).is_ok());
-    assert!(mmr.push(&int_to_hash(8)).is_ok());
+    assert!(mmr.push(int_to_hash(7)).is_ok());
+    assert!(mmr.push(int_to_hash(8)).is_ok());
     assert!(mmr.delete_and_compress(3, true));
 
     // Restore from compact state

--- a/base_layer/mmr/tests/pruned_mmr.rs
+++ b/base_layer/mmr/tests/pruned_mmr.rs
@@ -54,8 +54,8 @@ fn pruned_mmrs() {
         assert_eq!(pruned.get_merkle_root(), root);
         // The pruned MMR works just like the normal one
         let new_hash = int_to_hash(*size);
-        assert!(pruned.push(&new_hash).is_ok());
-        assert!(pruned.push(&int_to_hash(*size + 1)).is_ok());
+        assert!(pruned.push(new_hash.clone()).is_ok());
+        assert!(pruned.push(int_to_hash(*size + 1)).is_ok());
         assert_eq!(pruned.get_merkle_root(), mmr2.get_merkle_root());
         // But you can only get recent hashes
         assert_eq!(pruned.get_leaf_hash(*size / 2), Ok(None));
@@ -91,7 +91,7 @@ pub fn calculate_pruned_mmr_roots() {
         calculate_pruned_mmr_root(&src, additions.clone(), deletions.clone()).expect("Did not calculate new root");
     assert_ne!(src_root, root);
     // Double check
-    additions.iter().for_each(|h| {
+    additions.into_iter().for_each(|h| {
         src.push(h).unwrap();
     });
     deletions.iter().for_each(|i| {
@@ -111,7 +111,7 @@ pub fn calculate_mmr_roots() {
     let root = calculate_mmr_root(&src, additions.clone()).expect("Did not calculate new root");
     assert_ne!(src_root, root);
     // Double check
-    additions.iter().for_each(|h| {
+    additions.into_iter().for_each(|h| {
         src.push(h).unwrap();
     });
     let new_root = src.get_merkle_root().expect("Did not calculate new root");

--- a/base_layer/mmr/tests/support/mod.rs
+++ b/base_layer/mmr/tests/support/mod.rs
@@ -32,7 +32,7 @@ pub fn create_mmr(size: usize) -> MerkleMountainRange<Hasher, Vec<Hash>> {
     let mut mmr = MerkleMountainRange::<Hasher, _>::new(Vec::default());
     for i in 0..size {
         let hash = int_to_hash(i);
-        assert!(mmr.push(&hash).is_ok());
+        assert!(mmr.push(hash).is_ok());
     }
     mmr
 }
@@ -41,7 +41,7 @@ pub fn create_mutable_mmr(size: usize) -> MutableMmr<Hasher, Vec<Hash>> {
     let mut mmr = MutableMmr::<Hasher, _>::new(Vec::default(), Bitmap::create());
     for i in 0..size {
         let hash = int_to_hash(i);
-        assert!(mmr.push(&hash).is_ok());
+        assert!(mmr.push(hash).is_ok());
     }
     mmr
 }

--- a/base_layer/mmr/tests/with_blake512_hash.rs
+++ b/base_layer/mmr/tests/with_blake512_hash.rs
@@ -83,7 +83,7 @@ fn create_mmr() -> MerkleMountainRange<Blake2b, Vec<Vec<u8>>> {
     let mut mmr = MerkleMountainRange::<Blake2b, _>::new(Vec::default());
     for i in 1..24 {
         let hash = Blake2b::digest(i.to_string().as_bytes()).to_vec();
-        assert!(mmr.push(&hash).is_ok());
+        assert!(mmr.push(hash).is_ok());
     }
     mmr
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
- Optimisation for `MerkleMountainRange::push` function. (Save one length and one get query per peak iteration)
- `push` functions take an owned version of the hash instead of
  internally cloning a reference to the hash. This means that in a
  number of cases (especially in real/non-test usage) a clone is avoided.
- Removed the `ArrayLike::get_or_panic` function. The reasons why a
  panic is allowed in a given case should be explicit. i.e
  `mmr.get(1)?.expect("we expected an index of 1 to work but it did not")`.
  Moreover, `get_or_panic` does not differentiate between an error
  returned from `get()` (DB IO error?) and the value not being found
  (Invariant violation where we may want to panic)
- Used `&[u8]` instead of `&Hash` as per clippy recommendations. It is
  reasonable that any implementation of a hash should be representable
  as a byte slice.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
MMR code improvements

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Existing tests pass. Two local base nodes synced blocks. MMR validation passes.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [x] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch.
* [x] I ran `cargo-fmt --all` before pushing.
* [x] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
