### PR TITLE
GRPC proto name collision fix

### DIFF
--- a/applications/tari_app_grpc/proto/types.proto
+++ b/applications/tari_app_grpc/proto/types.proto
@@ -67,12 +67,12 @@ message ProofOfWork {
 }
 
 //This is used to request the which pow algo should be used with the block template
-message PowAlgo{
-    enum PowAlgo {
-        POW_ALGO_MONERO = 0;
-        POW_ALGO_BLAKE = 1;
+message PowAlgo {
+    enum PowAlgos {
+        POW_ALGOS_MONERO = 0;
+        POW_ALGOS_BLAKE = 1;
     }
-    PowAlgo pow_algo = 1;
+    PowAlgos pow_algo = 1;
 }
 
 

--- a/applications/tari_app_grpc/src/generated/tari.rpc.rs
+++ b/applications/tari_app_grpc/src/generated/tari.rpc.rs
@@ -57,13 +57,13 @@ pub struct ProofOfWork {
 /// This is used to request the which pow algo should be used with the block template
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct PowAlgo {
-    #[prost(enumeration = "pow_algo::PowAlgo", tag = "1")]
+    #[prost(enumeration = "pow_algo::PowAlgos", tag = "1")]
     pub pow_algo: i32,
 }
 pub mod pow_algo {
     #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
     #[repr(i32)]
-    pub enum PowAlgo {
+    pub enum PowAlgos {
         Monero = 0,
         Blake = 1,
     }

--- a/applications/tari_merge_mining_proxy/src/proxy.rs
+++ b/applications/tari_merge_mining_proxy/src/proxy.rs
@@ -285,7 +285,7 @@ impl InnerService {
         debug!(target: LOG_TARGET, "Requested new block template from Tari base node");
         let new_block_template_response = grpc_client
             .get_new_block_template(grpc::PowAlgo {
-                pow_algo: grpc::pow_algo::PowAlgo::Monero.into(),
+                pow_algo: grpc::pow_algo::PowAlgos::Monero.into(),
             })
             .await
             .map_err(|status| MmProxyError::GrpcRequestError {


### PR DESCRIPTION
#Description
Fixes name collision between message PowAlgo and enum PowAlgo in types.proto.

## Motivation and Context
`protoc` doesn't seem to have the logic currently to automatically fix name collisions.

## How Has This Been Tested?
cargo test --all
external Qt-based application.

## Types of changes
* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
* [x] I'm merging against the `development` branch.
* [x] I ran `cargo-fmt --all` before pushing.
* [x] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
