### PR TITLE
Fix for monero randomX key

### DIFF
--- a/base_layer/core/src/proof_of_work/monero_rx.rs
+++ b/base_layer/core/src/proof_of_work/monero_rx.rs
@@ -205,7 +205,8 @@ pub fn monero_difficulty(header: &BlockHeader) -> Result<Difficulty, MergeMineEr
     let input = &create_input_blob_from_parts(&monero.header, &tx_hashes)?;
     debug!(target: LOG_TARGET, "RandomX input: {}", input);
     let input = from_hex(input)?;
-    let key_bytes = from_hex(&key)?;
+    // Todo remove this eventually when we reset and we dont have quotes in the key anymore.
+    let key_bytes = from_hex(&key.replace("\"", ""))?;
     get_random_x_difficulty(&input, &key_bytes).map(|r| r.0)
 }
 
@@ -848,5 +849,12 @@ mod test {
             "f68fbc8cc85bde856cd1323e9f8e6f024483038d728835de2f8c014ff6260000"
         );
         assert_eq!(difficulty.0, 430603.into());
+    }
+
+    #[test]
+    fn test_remove_quotes() {
+        let mut key = "\"2aca6501719a5c7ab7d4acbc7cc5d277b57ad8c27c6830788c2d5a596308e5b1\"";
+        let key_bytes = from_hex(&key.replace("\"", ""));
+        assert!(key_bytes.is_ok());
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
One of the monero block headers in the current chain has quotes in them. This PR will remove them and allow the node to sync past that block.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The quotes in the key does not allow the key to be deserialised to hex and needs to be removed before this can happen. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch.
* [x] I ran `cargo-fmt --all` before pushing.
* [x] I ran `cargo test` successfully before submitting my PR.
* [ ] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
