### PR TITLE
Fix flaky test in `test_wallet_ffi`

### DIFF
--- a/base_layer/wallet_ffi/src/lib.rs
+++ b/base_layer/wallet_ffi/src/lib.rs
@@ -5831,16 +5831,6 @@ mod test {
             assert_eq!(peer_added, true);
             peer_added = wallet_add_base_node_peer(bob_wallet, public_key_alice.clone(), address_alice_str, error_ptr);
             assert_eq!(peer_added, true);
-            (*alice_wallet)
-                .runtime
-                .block_on(
-                    (*alice_wallet)
-                        .wallet
-                        .comms
-                        .connection_manager()
-                        .dial_peer((*bob_wallet).wallet.comms.node_identity().node_id().clone()),
-                )
-                .unwrap();
             assert!(wallet_sync_with_base_node(alice_wallet, error_ptr) > 0);
 
             // Test pending tx cancellation


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Handle runtime error by ~retrying~ _removing an unnecessary_ dial-peer _command_, otherwise, _when sometimes_ ~if~ it is not successful, the code panics.

_UPDATE: As per @sdbondi review comments below._

## Motivation and Context

```
---- test::test_wallet_ffi stdout ----
thread 'test::test_wallet_ffi' panicked at 'called `Result::unwrap()` on an `Err` value: DialCancelled', base_layer\wallet_ffi\src\lib.rs:5812:13
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

## How Has This Been Tested?

Running `cargo test --release --all-features --no-fail-fast` in Windows and Ubuntu Linux

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [X] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [X] I'm merging against the `development` branch.
* [X] I ran `cargo-fmt --all` before pushing.
* [X] I ran `cargo test` successfully before submitting my PR.
* [X] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
