### PR TITLE
Fix target difficulty for block 1 on rincewind

### DIFF
--- a/base_layer/core/src/consensus/consensus_constants.rs
+++ b/base_layer/core/src/consensus/consensus_constants.rs
@@ -171,8 +171,28 @@ impl ConsensusConstants {
         let target_block_interval = 120;
         let difficulty_block_window = 90;
         vec![
+            // Due to a bug in previous code, block 1 has a high minimum difficulty which
+            // drops to 1 after block 2
             ConsensusConstants {
                 effective_from_height: 0,
+                coinbase_lock_height: 60,
+                blockchain_version: 1,
+                future_time_limit: target_block_interval * difficulty_block_window / 20,
+                target_block_interval,
+                difficulty_block_window,
+                difficulty_max_block_interval: target_block_interval * 60,
+                max_block_transaction_weight: 19500,
+                pow_algo_count: 1,
+                median_timestamp_count: 11,
+                emission_initial: 5_538_846_115 * uT,
+                emission_decay: 0.999_999_560_409_038_5,
+                emission_tail: 1 * T,
+                min_pow_difficulty: (1.into(), 60_000_000.into()),
+                max_randomx_seed_height: std::u64::MAX,
+                genesis_coinbase_value_offset: 5_539_846_115 * uT - 10_000_100 * uT,
+            },
+            ConsensusConstants {
+                effective_from_height: 2,
                 coinbase_lock_height: 60,
                 blockchain_version: 1,
                 future_time_limit: target_block_interval * difficulty_block_window / 20,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Previously there was a bug where only the first block would apply the `min_target_difficulty`. This means that in the current rincewind testnet chain, block at height 1 has a target difficulty of 60k, and it then drops after that. A new chain cannot currently sync until this fix is applied

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [ ] I'm merging against the `development` branch.
* [ ] I ran `cargo-fmt --all` before pushing.
* [ ] I ran `cargo test` successfully before submitting my PR.
* [ ] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
