### PR TITLE
Fix stack overflow on `test_store_and_forward_send_tx` test

### DIFF
--- a/base_layer/core/tests/chain_storage_tests/chain_storage.rs
+++ b/base_layer/core/tests/chain_storage_tests/chain_storage.rs
@@ -71,10 +71,6 @@ use tari_mmr::{MmrCacheConfig, MutableMmr};
 use tari_storage::lmdb_store::LMDBConfig;
 use tari_test_utils::{paths::create_temporary_data_path, unpack_enum};
 
-fn init_log() {
-    let _ = env_logger::builder().is_test(true).try_init();
-}
-
 #[test]
 fn write_and_fetch_metadata() {
     let network = Network::LocalNet;
@@ -444,7 +440,6 @@ fn store_and_retrieve_block() {
 
 #[test]
 fn add_multiple_blocks() {
-    init_log();
     // Create new database with genesis block
     let network = Network::LocalNet;
     let consensus_manager = ConsensusManagerBuilder::new(network).build();
@@ -645,7 +640,6 @@ fn handle_tip_reorg() {
 
 #[test]
 fn blockchain_reorgs_to_stronger_chain() {
-    let _ = env_logger::try_init();
     let mut blockchain = TestBlockchain::with_genesis("GB");
     let blocks = blockchain.builder();
     blockchain.add_block(blocks.new_block("A1").child_of("GB").difficulty(1));


### PR DESCRIPTION
## Description

This test was overflowing its stack. Looks like running 3 wallets in a single thread is too big for the stack so to fix each wallet gets its own runtime.

Also removed an errant logging init in another test.

## How Has This Been Tested?
Update testing

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch.
* [x] I ran `cargo-fmt --all` before pushing.
* [ ] I ran `cargo test` successfully before submitting my PR.
* [ ] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
