### PR TITLE
Improve Closest broadcast strategy and use it for saf txn broadcast

### DIFF
--- a/base_layer/core/src/base_node/service/service.rs
+++ b/base_layer/core/src/base_node/service/service.rs
@@ -574,7 +574,7 @@ async fn handle_outbound_block(
     outbound_message_service
         .flood(
             NodeDestination::Unknown,
-            OutboundEncryption::None,
+            OutboundEncryption::ClearText,
             exclude_peers,
             OutboundDomainMessage::new(
                 TariMessageType::NewBlock,

--- a/base_layer/core/src/mempool/service/service.rs
+++ b/base_layer/core/src/mempool/service/service.rs
@@ -427,7 +427,7 @@ async fn handle_outbound_request(
         .send_random(
             1,
             NodeDestination::Unknown,
-            OutboundEncryption::None,
+            OutboundEncryption::ClearText,
             OutboundDomainMessage::new(TariMessageType::MempoolRequest, service_request),
         )
         .await;
@@ -518,7 +518,7 @@ async fn handle_outbound_tx(
     let result = outbound_message_service
         .propagate(
             NodeDestination::Unknown,
-            OutboundEncryption::None,
+            OutboundEncryption::ClearText,
             exclude_peers,
             OutboundDomainMessage::new(TariMessageType::NewTransaction, ProtoTransaction::from(tx)),
         )

--- a/base_layer/wallet/src/transaction_service/protocols/transaction_send_protocol.rs
+++ b/base_layer/wallet/src/transaction_service/protocols/transaction_send_protocol.rs
@@ -44,7 +44,6 @@ use futures::channel::oneshot;
 use tari_comms::{peer_manager::NodeId, types::CommsPublicKey};
 use tari_comms_dht::{
     domain_message::OutboundDomainMessage,
-    envelope::NodeDestination,
     outbound::{OutboundEncryption, SendMessageResponse},
 };
 use tari_core::transactions::{
@@ -570,10 +569,8 @@ where TBackend: TransactionBackend + Clone + 'static
         match self
             .resources
             .outbound_message_service
-            .broadcast(
-                NodeDestination::NodeId(Box::new(NodeId::from_key(&self.dest_pubkey).map_err(|e| {
-                    TransactionServiceProtocolError::new(self.id, TransactionServiceError::from(e))
-                })?)),
+            .closest_broadcast(
+                NodeId::from_public_key(&self.dest_pubkey),
                 OutboundEncryption::EncryptFor(Box::new(self.dest_pubkey.clone())),
                 vec![],
                 OutboundDomainMessage::new(TariMessageType::SenderPartialTransaction, proto_message),

--- a/base_layer/wallet/src/transaction_service/tasks/send_finalized_transaction.rs
+++ b/base_layer/wallet/src/transaction_service/tasks/send_finalized_transaction.rs
@@ -28,7 +28,6 @@ use std::time::Duration;
 use tari_comms::{peer_manager::NodeId, types::CommsPublicKey};
 use tari_comms_dht::{
     domain_message::OutboundDomainMessage,
-    envelope::NodeDestination,
     outbound::{OutboundEncryption, OutboundMessageRequester, SendMessageResponse},
 };
 use tari_core::transactions::{transaction::Transaction, transaction_protocol::proto};
@@ -148,8 +147,8 @@ async fn send_transaction_finalized_message_store_and_forward(
 ) -> Result<bool, TransactionServiceError>
 {
     match outbound_message_service
-        .broadcast(
-            NodeDestination::NodeId(Box::new(NodeId::from_key(&destination_pubkey)?)),
+        .closest_broadcast(
+            NodeId::from_public_key(&destination_pubkey),
             OutboundEncryption::EncryptFor(Box::new(destination_pubkey.clone())),
             vec![],
             OutboundDomainMessage::new(TariMessageType::TransactionFinalized, msg.clone()),

--- a/base_layer/wallet/src/transaction_service/tasks/send_transaction_cancelled.rs
+++ b/base_layer/wallet/src/transaction_service/tasks/send_transaction_cancelled.rs
@@ -23,7 +23,6 @@ use crate::{output_manager_service::TxId, transaction_service::error::Transactio
 use tari_comms::{peer_manager::NodeId, types::CommsPublicKey};
 use tari_comms_dht::{
     domain_message::OutboundDomainMessage,
-    envelope::NodeDestination,
     outbound::{OutboundEncryption, OutboundMessageRequester},
 };
 use tari_core::transactions::transaction_protocol::proto;
@@ -47,9 +46,9 @@ pub async fn send_transaction_cancelled_message(
         .await?;
 
     let _ = outbound_message_service
-        .broadcast(
-            NodeDestination::NodeId(Box::new(NodeId::from_key(&destination_public_key)?)),
-            OutboundEncryption::EncryptFor(Box::new(destination_public_key.clone())),
+        .closest_broadcast(
+            NodeId::from_public_key(&destination_public_key),
+            OutboundEncryption::EncryptFor(Box::new(destination_public_key)),
             vec![],
             OutboundDomainMessage::new(TariMessageType::SenderPartialTransaction, proto_message),
         )

--- a/base_layer/wallet/src/transaction_service/tasks/send_transaction_reply.rs
+++ b/base_layer/wallet/src/transaction_service/tasks/send_transaction_reply.rs
@@ -32,10 +32,7 @@ use crate::transaction_service::{
 };
 use std::time::Duration;
 use tari_comms::{peer_manager::NodeId, types::CommsPublicKey};
-use tari_comms_dht::{
-    envelope::NodeDestination,
-    outbound::{OutboundEncryption, OutboundMessageRequester},
-};
+use tari_comms_dht::outbound::{OutboundEncryption, OutboundMessageRequester};
 use tari_core::transactions::transaction_protocol::proto;
 
 const LOG_TARGET: &str = "wallet::transaction_service::tasks::send_transaction_reply";
@@ -146,8 +143,8 @@ async fn send_transaction_reply_store_and_forward(
 ) -> Result<bool, TransactionServiceError>
 {
     match outbound_message_service
-        .broadcast(
-            NodeDestination::NodeId(Box::new(NodeId::from_key(&destination_pubkey)?)),
+        .closest_broadcast(
+            NodeId::from_public_key(&destination_pubkey),
             OutboundEncryption::EncryptFor(Box::new(destination_pubkey.clone())),
             vec![],
             OutboundDomainMessage::new(TariMessageType::ReceiverPartialTransactionReply, msg),

--- a/comms/dht/examples/memory_net/utilities.rs
+++ b/comms/dht/examples/memory_net/utilities.rs
@@ -295,7 +295,7 @@ pub async fn do_network_wide_propagation(nodes: &mut [TestNode], origin_node_ind
         .outbound_requester()
         .broadcast(
             NodeDestination::Unknown,
-            OutboundEncryption::None,
+            OutboundEncryption::ClearText,
             vec![],
             OutboundDomainMessage::new(0i32, PUBLIC_MESSAGE.to_string()),
         )
@@ -351,7 +351,7 @@ pub async fn do_network_wide_propagation(nodes: &mut [TestNode], origin_node_ind
                         let send_states = outbound_req
                             .propagate(
                                 NodeDestination::Unknown,
-                                OutboundEncryption::None,
+                                OutboundEncryption::ClearText,
                                 vec![msg.source_peer.node_id.clone()],
                                 OutboundDomainMessage::new(0i32, public_msg),
                             )
@@ -465,8 +465,8 @@ pub async fn do_store_and_forward_message_propagation(
         let send_states = wallet
             .dht
             .outbound_requester()
-            .broadcast(
-                node_identity.node_id().clone().into(),
+            .closest_broadcast(
+                node_identity.node_id().clone(),
                 OutboundEncryption::EncryptFor(Box::new(node_identity.public_key().clone())),
                 vec![],
                 OutboundDomainMessage::new(123i32, secret_message.clone()),

--- a/comms/dht/src/broadcast_strategy.rs
+++ b/comms/dht/src/broadcast_strategy.rs
@@ -21,15 +21,29 @@
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 use crate::envelope::NodeDestination;
-use std::{fmt, fmt::Formatter};
+use std::{
+    fmt,
+    fmt::{Display, Formatter},
+};
 use tari_comms::{peer_manager::node_id::NodeId, types::CommsPublicKey};
 
 #[derive(Debug, Clone)]
 pub struct BroadcastClosestRequest {
-    pub n: usize,
     pub node_id: NodeId,
     pub excluded_peers: Vec<NodeId>,
     pub connected_only: bool,
+}
+
+impl Display for BroadcastClosestRequest {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "ClosestRequest: node_id = {}, excluded_peers = {} peer(s), connected_only = {}",
+            self.node_id,
+            self.excluded_peers.len(),
+            self.connected_only
+        )
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -56,7 +70,7 @@ impl fmt::Display for BroadcastStrategy {
             DirectPublicKey(pk) => write!(f, "DirectPublicKey({})", pk),
             DirectNodeId(node_id) => write!(f, "DirectNodeId({})", node_id),
             Flood(excluded) => write!(f, "Flood({} excluded)", excluded.len()),
-            Closest(request) => write!(f, "Closest({})", request.n),
+            Closest(request) => write!(f, "Closest({})", request),
             Random(n, excluded) => write!(f, "Random({}, {} excluded)", n, excluded.len()),
             Broadcast(excluded) => write!(f, "Broadcast({} excluded)", excluded.len()),
             Propagate(destination, excluded) => write!(f, "Propagate({}, {} excluded)", destination, excluded.len(),),
@@ -124,7 +138,6 @@ mod test {
         assert_eq!(
             BroadcastStrategy::Closest(Box::new(BroadcastClosestRequest {
                 node_id: NodeId::default(),
-                n: 0,
                 excluded_peers: Default::default(),
                 connected_only: false
             }))
@@ -150,7 +163,6 @@ mod test {
             .is_none());
         assert!(BroadcastStrategy::Closest(Box::new(BroadcastClosestRequest {
             node_id: NodeId::default(),
-            n: 0,
             excluded_peers: Default::default(),
             connected_only: false
         }))
@@ -176,7 +188,6 @@ mod test {
         assert!(BroadcastStrategy::Flood(Default::default()).direct_node_id().is_none());
         assert!(BroadcastStrategy::Closest(Box::new(BroadcastClosestRequest {
             node_id: NodeId::default(),
-            n: 0,
             excluded_peers: Default::default(),
             connected_only: false
         }))

--- a/comms/dht/src/builder.rs
+++ b/comms/dht/src/builder.rs
@@ -115,6 +115,11 @@ impl DhtBuilder {
         self
     }
 
+    pub fn with_broadcast_factor(mut self, broadcast_factor: usize) -> Self {
+        self.config.broadcast_factor = broadcast_factor;
+        self
+    }
+
     pub fn with_discovery_timeout(mut self, timeout: Duration) -> Self {
         self.config.discovery_request_timeout = timeout;
         self

--- a/comms/dht/src/config.rs
+++ b/comms/dht/src/config.rs
@@ -47,7 +47,10 @@ pub struct DhtConfig {
     /// Number of random peers to include
     /// Default: [DEFAULT_NUM_RANDOM_NODES](self::DEFAULT_NUM_RANDOM_NODES)
     pub num_random_nodes: usize,
-    /// For each message to propagate, propagate to this many peers
+    /// Send to this many peers when using the broadcast strategy
+    /// Default: 8
+    pub broadcast_factor: usize,
+    /// Send to this many peers when using the propagate strategy
     /// Default: 4
     pub propagation_factor: usize,
     /// The maximum number of messages that can be stored using the Store-and-forward middleware. Default: 10_000
@@ -135,6 +138,7 @@ impl Default for DhtConfig {
             num_neighbouring_nodes: DEFAULT_NUM_NEIGHBOURING_NODES,
             num_random_nodes: DEFAULT_NUM_RANDOM_NODES,
             propagation_factor: 4,
+            broadcast_factor: 8,
             saf_num_closest_nodes: 10,
             saf_max_returned_messages: 50,
             outbound_buffer_size: 20,

--- a/comms/dht/src/dht.rs
+++ b/comms/dht/src/dht.rs
@@ -295,16 +295,15 @@ impl Dht {
                 self.node_identity.node_id().short_str()
             )))
             .layer(inbound::DecryptionLayer::new(Arc::clone(&self.node_identity)))
-            .layer(store_forward::ForwardLayer::new(
-                self.config.clone(),
-                self.outbound_requester(),
-                self.node_identity.features().contains(PeerFeatures::DHT_STORE_FORWARD),
-            ))
             .layer(store_forward::StoreLayer::new(
                 self.config.clone(),
                 Arc::clone(&self.peer_manager),
                 Arc::clone(&self.node_identity),
                 self.store_and_forward_requester(),
+            ))
+            .layer(store_forward::ForwardLayer::new(
+                self.outbound_requester(),
+                self.node_identity.features().contains(PeerFeatures::DHT_STORE_FORWARD),
             ))
             .layer(store_forward::MessageHandlerLayer::new(
                 self.config.clone(),

--- a/comms/dht/src/inbound/dht_handler/task.rs
+++ b/comms/dht/src/inbound/dht_handler/task.rs
@@ -245,7 +245,7 @@ where S: Service<DecryptedDhtMessage, Response = (), Error = PipelineError>
             self.outbound_service
                 .send_raw(
                     SendMessageParams::new()
-                        .closest_connected(origin_node_id.clone(), self.config.num_neighbouring_nodes, vec![
+                        .closest_connected(origin_node_id.clone(), vec![
                             origin_node_id,
                             source_peer.node_id.clone(),
                         ])

--- a/comms/dht/src/outbound/broadcast.rs
+++ b/comms/dht/src/outbound/broadcast.rs
@@ -491,7 +491,7 @@ where S: Service<DhtOutboundMessage, Response = (), Error = PipelineError>
                     encrypted_body.into(),
                 ))
             },
-            OutboundEncryption::None => {
+            OutboundEncryption::ClearText => {
                 trace!(target: LOG_TARGET, "Encryption not requested for message");
 
                 if include_origin {

--- a/comms/dht/src/outbound/message.rs
+++ b/comms/dht/src/outbound/message.rs
@@ -39,7 +39,7 @@ use thiserror::Error;
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum OutboundEncryption {
     /// Message should not be encrypted
-    None,
+    ClearText,
     /// Message should be encrypted using a shared secret derived from the given public key
     EncryptFor(Box<CommsPublicKey>),
 }
@@ -57,7 +57,7 @@ impl OutboundEncryption {
     pub fn is_encrypt(&self) -> bool {
         use OutboundEncryption::*;
         match self {
-            None => false,
+            ClearText => false,
             EncryptFor(_) => true,
         }
     }
@@ -66,7 +66,7 @@ impl OutboundEncryption {
 impl Display for OutboundEncryption {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
         match self {
-            OutboundEncryption::None => write!(f, "None"),
+            OutboundEncryption::ClearText => write!(f, "ClearText"),
             OutboundEncryption::EncryptFor(ref key) => write!(f, "EncryptFor:{}", key.to_hex()),
         }
     }
@@ -74,7 +74,7 @@ impl Display for OutboundEncryption {
 
 impl Default for OutboundEncryption {
     fn default() -> Self {
-        OutboundEncryption::None
+        OutboundEncryption::ClearText
     }
 }
 

--- a/comms/dht/src/outbound/message_params.rs
+++ b/comms/dht/src/outbound/message_params.rs
@@ -110,12 +110,15 @@ impl SendMessageParams {
         self
     }
 
-    /// Set broadcast_strategy to Closest.`excluded_peers` are excluded.
-    pub fn closest(&mut self, node_id: NodeId, n: usize, excluded_peers: Vec<NodeId>) -> &mut Self {
+    /// Use the `Closest` broadcast strategy.
+    ///
+    /// # Parameters
+    /// `node_id` - Select the closest known peers to this `NodeId`
+    /// `excluded_peers` - vector of `NodeId`s to exclude from broadcast.
+    pub fn closest(&mut self, node_id: NodeId, excluded_peers: Vec<NodeId>) -> &mut Self {
         self.params_mut().broadcast_strategy = BroadcastStrategy::Closest(Box::new(BroadcastClosestRequest {
             excluded_peers,
             node_id,
-            n,
             connected_only: false,
         }));
         self
@@ -123,11 +126,10 @@ impl SendMessageParams {
 
     /// Set broadcast_strategy to Closest.`excluded_peers` are excluded. Only peers that are currently connected will be
     /// included.
-    pub fn closest_connected(&mut self, node_id: NodeId, n: usize, excluded_peers: Vec<NodeId>) -> &mut Self {
+    pub fn closest_connected(&mut self, node_id: NodeId, excluded_peers: Vec<NodeId>) -> &mut Self {
         self.params_mut().broadcast_strategy = BroadcastStrategy::Closest(Box::new(BroadcastClosestRequest {
             excluded_peers,
             node_id,
-            n,
             connected_only: true,
         }));
         self

--- a/comms/dht/src/outbound/mock.rs
+++ b/comms/dht/src/outbound/mock.rs
@@ -205,7 +205,7 @@ impl OutboundServiceMock {
                                 },
                             };
                         },
-                        BroadcastStrategy::Broadcast(_) => {
+                        BroadcastStrategy::Closest(_) => {
                             if behaviour.broadcast == ResponseType::Queued {
                                 let (response, mut inner_reply_tx) = self.add_call((*params).clone(), body);
                                 reply_tx.send(response).expect("Reply channel cancelled");

--- a/comms/dht/src/store_forward/forward.rs
+++ b/comms/dht/src/store_forward/forward.rs
@@ -25,7 +25,6 @@ use crate::{
     inbound::DecryptedDhtMessage,
     outbound::{OutboundMessageRequester, SendMessageParams},
     store_forward::error::StoreAndForwardError,
-    DhtConfig,
 };
 use futures::{task::Context, Future};
 use log::*;
@@ -39,13 +38,11 @@ const LOG_TARGET: &str = "comms::dht::storeforward::forward";
 pub struct ForwardLayer {
     outbound_service: OutboundMessageRequester,
     is_enabled: bool,
-    config: DhtConfig,
 }
 
 impl ForwardLayer {
-    pub fn new(config: DhtConfig, outbound_service: OutboundMessageRequester, is_enabled: bool) -> Self {
+    pub fn new(outbound_service: OutboundMessageRequester, is_enabled: bool) -> Self {
         Self {
-            config,
             outbound_service,
             is_enabled,
         }
@@ -59,7 +56,6 @@ impl<S> Layer<S> for ForwardLayer {
         ForwardMiddleware::new(
             service,
             // Pass in just the config item needed by the middleware for almost free copies
-            self.config.clone(),
             self.outbound_service.clone(),
             self.is_enabled,
         )
@@ -73,15 +69,13 @@ impl<S> Layer<S> for ForwardLayer {
 pub struct ForwardMiddleware<S> {
     next_service: S,
     outbound_service: OutboundMessageRequester,
-    config: DhtConfig,
     is_enabled: bool,
 }
 
 impl<S> ForwardMiddleware<S> {
-    pub fn new(service: S, config: DhtConfig, outbound_service: OutboundMessageRequester, is_enabled: bool) -> Self {
+    pub fn new(service: S, outbound_service: OutboundMessageRequester, is_enabled: bool) -> Self {
         Self {
             next_service: service,
-            config,
             outbound_service,
             is_enabled,
         }
@@ -102,7 +96,6 @@ where S: Service<DecryptedDhtMessage, Response = (), Error = PipelineError> + Cl
 
     fn call(&mut self, message: DecryptedDhtMessage) -> Self::Future {
         let next_service = self.next_service.clone();
-        let config = self.config.clone();
         let outbound_service = self.outbound_service.clone();
         let is_enabled = self.is_enabled;
         async move {
@@ -122,7 +115,7 @@ where S: Service<DecryptedDhtMessage, Response = (), Error = PipelineError> + Cl
                 message.tag,
                 message.dht_header.message_tag
             );
-            let forwarder = Forwarder::new(next_service, config, outbound_service);
+            let forwarder = Forwarder::new(next_service, outbound_service);
             forwarder.handle(message).await
         }
     }
@@ -132,15 +125,13 @@ where S: Service<DecryptedDhtMessage, Response = (), Error = PipelineError> + Cl
 /// to the next service.
 struct Forwarder<S> {
     next_service: S,
-    config: DhtConfig,
     outbound_service: OutboundMessageRequester,
 }
 
 impl<S> Forwarder<S> {
-    pub fn new(service: S, config: DhtConfig, outbound_service: OutboundMessageRequester) -> Self {
+    pub fn new(service: S, outbound_service: OutboundMessageRequester) -> Self {
         Self {
             next_service: service,
-            config,
             outbound_service,
         }
     }
@@ -208,7 +199,7 @@ where S: Service<DecryptedDhtMessage, Response = (), Error = PipelineError>
         let mut send_params = SendMessageParams::new();
         match (dest_node_id, is_saf_stored) {
             (Some(node_id), Some(true)) => {
-                send_params.closest_connected(node_id.clone(), self.config.num_neighbouring_nodes, excluded_peers);
+                send_params.closest_connected(node_id.clone(), excluded_peers);
             },
             _ => {
                 send_params.propagate(dht_header.destination.clone(), excluded_peers);
@@ -251,7 +242,7 @@ mod test {
         let spy = service_spy();
         let (oms_tx, mut oms_rx) = mpsc::channel(1);
         let oms = OutboundMessageRequester::new(oms_tx);
-        let mut service = ForwardLayer::new(DhtConfig::default(), oms, true).layer(spy.to_service::<PipelineError>());
+        let mut service = ForwardLayer::new(oms, true).layer(spy.to_service::<PipelineError>());
 
         let node_identity = make_node_identity();
         let inbound_msg = make_dht_inbound_message(&node_identity, b"".to_vec(), DhtMessageFlags::empty(), false);
@@ -273,8 +264,7 @@ mod test {
         let oms_mock_state = oms_mock.get_state();
         rt.spawn(oms_mock.run());
 
-        let mut service =
-            ForwardLayer::new(DhtConfig::default(), oms_requester, true).layer(spy.to_service::<PipelineError>());
+        let mut service = ForwardLayer::new(oms_requester, true).layer(spy.to_service::<PipelineError>());
 
         let sample_body = b"Lorem ipsum";
         let inbound_msg = make_dht_inbound_message(


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Closest broadcast strategy changed as follow:
1. A predefined number of peers is used instead of an arbitrary `n`
   (broadcast_factor)
1. A minimum of 2 peers are dialled that are closer to the message
   destination. This is in addition to closer peers with existing
   connections.

- Transaction protocols use the new closest broadcast strategy
- The orders of the store and forward layers are switched as forward
depends on a message flag from store to determine how to propagate the
message (enabling a 'bloom' of messages around a region)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This increases the likelihood that directed broadcast messages are propagated to the correct peers. The new connections that could possibly be established should reduce the number of hops to the destination. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Existing tests pass - sent transactions via network propagation / SAF to mobile.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [x] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch.
* [x] I ran `cargo-fmt --all` before pushing.
* [x] I ran `cargo test` successfully before submitting my PR.
* [ ] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
