### PR TITLE
Add specific log targets for stress test messages

### DIFF
--- a/base_layer/wallet/src/output_manager_service/service.rs
+++ b/base_layer/wallet/src/output_manager_service/service.rs
@@ -71,6 +71,7 @@ use tokio::{
 };
 
 const LOG_TARGET: &str = "wallet::output_manager_service";
+const LOG_TARGET_STRESS: &str = "stress_test::output_manager_service";
 
 /// This service will manage a wallet's available outputs and the key manager that produces the keys for these outputs.
 /// The service will assemble transactions to be sent from the wallets available outputs and provide keys to receive
@@ -609,6 +610,11 @@ where
 
         debug!(
             target: LOG_TARGET,
+            "Prepared transaction (TxId: {}) to send",
+            stp.get_tx_id()?
+        );
+        debug!(
+            target: LOG_TARGET_STRESS,
             "Prepared transaction (TxId: {}) to send",
             stp.get_tx_id()?
         );

--- a/base_layer/wallet/src/transaction_service/protocols/transaction_broadcast_protocol.rs
+++ b/base_layer/wallet/src/transaction_service/protocols/transaction_broadcast_protocol.rs
@@ -51,6 +51,7 @@ use tari_p2p::tari_message::TariMessageType;
 use tokio::{sync::broadcast, time::delay_for};
 
 const LOG_TARGET: &str = "wallet::transaction_service::protocols::broadcast_protocol";
+const LOG_TARGET_STRESS: &str = "stress_test::broadcast_protocol";
 
 /// This protocol defines the process of monitoring a mempool and base node to detect when a Completed transaction is
 /// Broadcast to the mempool or potentially Mined
@@ -347,6 +348,17 @@ where TBackend: TransactionBackend + Clone + 'static
                             // Broadcast state
                             info!(
                                 target: LOG_TARGET,
+                                "Completed Transaction (TxId: {} and Kernel Excess Sig: {}) detected as Broadcast to \
+                                 Base Node Mempool in {:?}",
+                                self.id,
+                                completed_tx.transaction.body.kernels()[0]
+                                    .excess_sig
+                                    .get_signature()
+                                    .to_hex(),
+                                ts
+                            );
+                            debug!(
+                                target: LOG_TARGET_STRESS,
                                 "Completed Transaction (TxId: {} and Kernel Excess Sig: {}) detected as Broadcast to \
                                  Base Node Mempool in {:?}",
                                 self.id,

--- a/base_layer/wallet/src/transaction_service/protocols/transaction_chain_monitoring_protocol.rs
+++ b/base_layer/wallet/src/transaction_service/protocols/transaction_chain_monitoring_protocol.rs
@@ -53,6 +53,7 @@ use tari_crypto::tari_utilities::{hex::Hex, Hashable};
 use tari_p2p::tari_message::TariMessageType;
 use tokio::{sync::broadcast, time::delay_for};
 const LOG_TARGET: &str = "wallet::transaction_service::protocols::chain_monitoring_protocol";
+const LOG_TARGET_STRESS: &str = "stress_test::chain_monitoring_protocol";
 
 /// This protocol defines the process of monitoring a mempool and base node to detect when a Broadcast transaction is
 /// Mined or leaves the mempool in which case it should be cancelled
@@ -498,6 +499,10 @@ where TBackend: TransactionBackend + Clone + 'static
 
                 info!(
                     target: LOG_TARGET,
+                    "Transaction (TxId: {:?}) detected as mined on the Base Layer", completed_tx.tx_id
+                );
+                debug!(
+                    target: LOG_TARGET_STRESS,
                     "Transaction (TxId: {:?}) detected as mined on the Base Layer", completed_tx.tx_id
                 );
 

--- a/base_layer/wallet/src/transaction_service/protocols/transaction_receive_protocol.rs
+++ b/base_layer/wallet/src/transaction_service/protocols/transaction_receive_protocol.rs
@@ -54,6 +54,7 @@ use tari_crypto::keys::SecretKey;
 use tokio::time::delay_for;
 
 const LOG_TARGET: &str = "wallet::transaction_service::protocols::receive_protocol";
+const LOG_TARGET_STRESS: &str = "stress_test::receive_protocol";
 
 #[derive(Debug, PartialEq)]
 pub enum TransactionReceiveProtocolStage {
@@ -369,6 +370,12 @@ where TBackend: TransactionBackend + Clone + 'static
 
             info!(
                 target: LOG_TARGET,
+                "Finalized Transaction with TX_ID = {} received from {}",
+                self.id,
+                self.source_pubkey.clone()
+            );
+            debug!(
+                target: LOG_TARGET_STRESS,
                 "Finalized Transaction with TX_ID = {} received from {}",
                 self.id,
                 self.source_pubkey.clone()

--- a/base_layer/wallet/src/transaction_service/protocols/transaction_send_protocol.rs
+++ b/base_layer/wallet/src/transaction_service/protocols/transaction_send_protocol.rs
@@ -56,6 +56,7 @@ use tari_p2p::tari_message::TariMessageType;
 use tokio::time::delay_for;
 
 const LOG_TARGET: &str = "wallet::transaction_service::protocols::send_protocol";
+const LOG_TARGET_STRESS: &str = "stress_test::send_protocol";
 
 #[derive(Debug, PartialEq)]
 pub enum TransactionSendProtocolStage {
@@ -372,6 +373,10 @@ where TBackend: TransactionBackend + Clone + 'static
                     target: LOG_TARGET,
                     "Transaction (TxId: {}) could not be finalized. Failure error: {:?}", self.id, e,
                 );
+                debug!(
+                    target: LOG_TARGET_STRESS,
+                    "Transaction (TxId: {}) could not be finalized. Failure error: {:?}", self.id, e,
+                );
                 TransactionServiceProtocolError::new(self.id, TransactionServiceError::from(e))
             })?;
 
@@ -401,6 +406,10 @@ where TBackend: TransactionBackend + Clone + 'static
             .map_err(|e| TransactionServiceProtocolError::new(self.id, TransactionServiceError::from(e)))?;
         info!(
             target: LOG_TARGET,
+            "Transaction Recipient Reply for TX_ID = {} received", tx_id,
+        );
+        debug!(
+            target: LOG_TARGET_STRESS,
             "Transaction Recipient Reply for TX_ID = {} received", tx_id,
         );
 
@@ -484,6 +493,10 @@ where TBackend: TransactionBackend + Clone + 'static
                         target: LOG_TARGET,
                         "Transaction Send Direct for TxID {} failed: {}", self.id, err
                     );
+                    debug!(
+                        target: LOG_TARGET_STRESS,
+                        "Transaction Send Direct for TxID {} failed: {}", self.id, err
+                    );
                     store_and_forward_send_result = self.send_transaction_store_and_forward(msg.clone()).await?;
                 },
                 SendMessageResponse::PendingDiscovery(rx) => {
@@ -517,6 +530,7 @@ where TBackend: TransactionBackend + Clone + 'static
             },
             Err(e) => {
                 warn!(target: LOG_TARGET, "Direct Transaction Send failed: {:?}", e);
+                debug!(target: LOG_TARGET_STRESS, "Direct Transaction Send failed: {:?}", e);
             },
         }
 
@@ -589,6 +603,13 @@ where TBackend: TransactionBackend + Clone + 'static
                         self.id,
                         successful_sends[0],
                     );
+                    debug!(
+                        target: LOG_TARGET_STRESS,
+                        "Transaction (TxId: {}) Send to Neighbours for Store and Forward successful with Message \
+                         Tags: {:?}",
+                        self.id,
+                        successful_sends[0],
+                    );
                     Ok(true)
                 } else if !failed_sends.is_empty() {
                     warn!(
@@ -597,10 +618,22 @@ where TBackend: TransactionBackend + Clone + 'static
                          messages were sent",
                         self.id
                     );
+                    debug!(
+                        target: LOG_TARGET_STRESS,
+                        "Transaction Send to Neighbours for Store and Forward for TX_ID: {} was unsuccessful and no \
+                         messages were sent",
+                        self.id
+                    );
                     Ok(false)
                 } else {
                     warn!(
                         target: LOG_TARGET,
+                        "Transaction Send to Neighbours for Store and Forward for TX_ID: {} timed out and was \
+                         unsuccessful. Some message might still be sent.",
+                        self.id
+                    );
+                    debug!(
+                        target: LOG_TARGET_STRESS,
                         "Transaction Send to Neighbours for Store and Forward for TX_ID: {} timed out and was \
                          unsuccessful. Some message might still be sent.",
                         self.id
@@ -615,11 +648,21 @@ where TBackend: TransactionBackend + Clone + 'static
                      messages were sent",
                     self.id
                 );
+                debug!(
+                    target: LOG_TARGET_STRESS,
+                    "Transaction Send to Neighbours for Store and Forward for TX_ID: {} was unsuccessful and no \
+                     messages were sent",
+                    self.id
+                );
                 Ok(false)
             },
             Err(e) => {
                 warn!(
                     target: LOG_TARGET,
+                    "Transaction Send (TxId: {}) to neighbours for Store and Forward failed: {:?}", self.id, e
+                );
+                debug!(
+                    target: LOG_TARGET_STRESS,
                     "Transaction Send (TxId: {}) to neighbours for Store and Forward failed: {:?}", self.id, e
                 );
                 Ok(false)

--- a/base_layer/wallet/src/transaction_service/tasks/send_finalized_transaction.rs
+++ b/base_layer/wallet/src/transaction_service/tasks/send_finalized_transaction.rs
@@ -34,6 +34,7 @@ use tari_core::transactions::{transaction::Transaction, transaction_protocol::pr
 use tari_p2p::tari_message::TariMessageType;
 
 const LOG_TARGET: &str = "wallet::transaction_service::tasks::send_finalized_transaction";
+const LOG_TARGET_STRESS: &str = "stress_test::send_finalized_transaction";
 
 pub async fn send_finalized_transaction_message(
     tx_id: TxId,
@@ -86,6 +87,10 @@ pub async fn send_finalized_transaction_message(
                     target: LOG_TARGET,
                     "Finalized Transaction Send Direct for TxID {} failed: {}", tx_id, err
                 );
+                debug!(
+                    target: LOG_TARGET_STRESS,
+                    "Finalized Transaction Send Direct for TxID {} failed: {}", tx_id, err
+                );
                 store_and_forward_send_result = send_transaction_finalized_message_store_and_forward(
                     tx_id,
                     destination_public_key.clone(),
@@ -131,6 +136,10 @@ pub async fn send_finalized_transaction_message(
         },
         Err(e) => {
             warn!(target: LOG_TARGET, "Direct Finalized Transaction Send failed: {:?}", e);
+            debug!(
+                target: LOG_TARGET_STRESS,
+                "Direct Finalized Transaction Send failed: {:?}", e
+            );
         },
     }
     if !direct_send_result && !store_and_forward_send_result {
@@ -163,10 +172,21 @@ async fn send_transaction_finalized_message_store_and_forward(
                 tx_id,
                 send_states.to_tags(),
             );
+            debug!(
+                target: LOG_TARGET_STRESS,
+                "Sending Finalized Transaction (TxId: {}) to Neighbours for Store and Forward successful with Message \
+                 Tags: {:?}",
+                tx_id,
+                send_states.to_tags(),
+            );
         },
         Err(e) => {
             warn!(
                 target: LOG_TARGET,
+                "Sending Finalized Transaction (TxId: {}) to neighbours for Store and Forward failed: {:?}", tx_id, e
+            );
+            debug!(
+                target: LOG_TARGET_STRESS,
                 "Sending Finalized Transaction (TxId: {}) to neighbours for Store and Forward failed: {:?}", tx_id, e
             );
             return Ok(false);

--- a/base_layer/wallet/src/transaction_service/tasks/wait_on_dial.rs
+++ b/base_layer/wallet/src/transaction_service/tasks/wait_on_dial.rs
@@ -27,6 +27,7 @@ use tari_comms::types::CommsPublicKey;
 use tari_comms_dht::outbound::MessageSendStates;
 
 const LOG_TARGET: &str = "wallet::transaction_service::tasks";
+const LOG_TARGET_STRESS: &str = "stress_test::transaction_service::tasks";
 
 /// This function contains the logic to wait on a dial and send of a queued message
 pub async fn wait_on_dial(
@@ -46,10 +47,22 @@ pub async fn wait_on_dial(
             destination_pubkey,
             send_states[0].tag,
         );
+        debug!(
+            target: LOG_TARGET_STRESS,
+            "{} (TxId: {}) Direct Send to {} queued with Message {}",
+            message,
+            tx_id,
+            destination_pubkey,
+            send_states[0].tag,
+        );
         let (sent, failed) = send_states.wait_n_timeout(direct_send_timeout, 1).await;
         if !sent.is_empty() {
             info!(
                 target: LOG_TARGET,
+                "Direct Send process for {} TX_ID: {} was successful with Message: {}", message, tx_id, sent[0]
+            );
+            debug!(
+                target: LOG_TARGET_STRESS,
                 "Direct Send process for {} TX_ID: {} was successful with Message: {}", message, tx_id, sent[0]
             );
             true
@@ -59,9 +72,20 @@ pub async fn wait_on_dial(
                     target: LOG_TARGET,
                     "Direct Send process for {} TX_ID: {} timed out", message, tx_id
                 );
+                debug!(
+                    target: LOG_TARGET_STRESS,
+                    "Direct Send process for {} TX_ID: {} timed out", message, tx_id
+                );
             } else {
                 warn!(
                     target: LOG_TARGET,
+                    "Direct Send process for {} TX_ID: {} and Message {} was unsuccessful and no message was sent",
+                    message,
+                    tx_id,
+                    failed[0]
+                );
+                debug!(
+                    target: LOG_TARGET_STRESS,
                     "Direct Send process for {} TX_ID: {} and Message {} was unsuccessful and no message was sent",
                     message,
                     tx_id,

--- a/common/logging/log4rs-debug-sample.yml
+++ b/common/logging/log4rs-debug-sample.yml
@@ -25,11 +25,11 @@ appenders:
       kind: compound
       trigger:
         kind: size
-        limit: 10mb
+        limit: 20mb
       roller:
         kind: fixed_window
         base: 1
-        count: 5
+        count: 10
         pattern: "log/network.{}.log"
     encoder:
       pattern: "{d(%Y-%m-%d %H:%M:%S.%f)} [{t}] {l:5} {m}{n}"
@@ -42,16 +42,16 @@ appenders:
       kind: compound
       trigger:
         kind: size
-        limit: 10mb
+        limit: 20mb
       roller:
         kind: fixed_window
         base: 1
-        count: 5
+        count: 10
         pattern: "log/base_layer.{}.log"
     encoder:
       pattern: "{d(%Y-%m-%d %H:%M:%S.%f)} [{t}] {l:5} {m}{n}"
 
-       # An appender named "base_layer" that writes to a file with a custom pattern encoder
+  # An appender named "other" that writes to a file with a custom pattern encoder
   other:
     kind: rolling_file
     path: "log/other.log"
@@ -65,6 +65,40 @@ appenders:
         base: 1
         count: 5
         pattern: "log/other.{}.log"
+    encoder:
+      pattern: "{d(%Y-%m-%d %H:%M:%S.%f)} [{t}] {l:5} {m}{n}"
+
+  # An appender named "mm_proxy" that writes to a file with a custom pattern encoder
+  mm_proxy:
+    kind: rolling_file
+    path: "log/mm_proxy.log"
+    policy:
+      kind: compound
+      trigger:
+        kind: size
+        limit: 10mb
+      roller:
+        kind: fixed_window
+        base: 1
+        count: 10
+        pattern: "log/mm_proxy.{}.log"
+    encoder:
+      pattern: "{d(%Y-%m-%d %H:%M:%S.%f)} [{t}] {l:5} {m}{n}"
+
+  # An appender named "stress_test" that writes to a file with a custom pattern encoder
+  stress_test:
+    kind: rolling_file
+    path: "log/stress_test.log"
+    policy:
+      kind: compound
+      trigger:
+        kind: size
+        limit: 10mb
+      roller:
+        kind: fixed_window
+        base: 1
+        count: 10
+        pattern: "log/stress_test.{}.log"
     encoder:
       pattern: "{d(%Y-%m-%d %H:%M:%S.%f)} [{t}] {l:5} {m}{n}"
 
@@ -99,13 +133,13 @@ loggers:
     appenders:
       - network
     additive: false
-    # Route log events sent to the "p2p" logger to the "network" appender
+  # Route log events sent to the "yamux" logger to the "network" appender
   yamux:
     level: warn
     appenders:
       - network
     additive: false
- # Route log events sent to the "mio" logger to the "other" appender
+  # Route log events sent to the "mio" logger to the "network" appender
   mio:
     level: warn
     appenders:
@@ -122,4 +156,16 @@ loggers:
     level: warn
     appenders:
       - other
+    additive: false
+  # Route log events sent to the "tari_mm_proxy" logger to the "mm_proxy" appender
+  tari_mm_proxy:
+    level: debug
+    appenders:
+      - mm_proxy
+    additive: false
+  # Route log events sent to the "stress_test" logger to the "stress_test" appender
+  stress_test:
+    level: debug
+    appenders:
+      - stress_test
     additive: false

--- a/common/logging/log4rs-sample.yml
+++ b/common/logging/log4rs-sample.yml
@@ -51,7 +51,7 @@ appenders:
     encoder:
       pattern: "{d(%Y-%m-%d %H:%M:%S.%f)} [{t}] {l:5} {m}{n}"
 
-       # An appender named "base_layer" that writes to a file with a custom pattern encoder
+  # An appender named "other" that writes to a file with a custom pattern encoder
   other:
     kind: rolling_file
     path: "log/other.log"
@@ -68,21 +68,6 @@ appenders:
     encoder:
       pattern: "{d(%Y-%m-%d %H:%M:%S.%f)} [{t}] {l:5} {m}{n}"
 
-  mm_proxy:
-    kind: rolling_file
-    path: "log/mm_proxy.log"
-    policy:
-      kind: compound
-      trigger:
-        kind: size
-        limit: 60mb
-      roller:
-        kind: fixed_window
-        base: 1
-        count: 5
-        pattern: "log/mm_proxy.{}.log"
-    encoder:
-      pattern: "{d(%Y-%m-%d %H:%M:%S.%f)} [{t}] {l:5} {m}{n}"
 # Set the default logging level to "warn" and attach the "stdout" appender to the root
 root:
   level: warn
@@ -96,12 +81,6 @@ loggers:
     appenders:
       - base_layer
     additive: false
-
-  tari_mm_proxy:
-    level: debug
-    appenders:
-      - mm_proxy
-    additive: false
   # Route log events sent to the "wallet" logger to the "base_layer" appender
   wallet:
     level: info
@@ -114,18 +93,19 @@ loggers:
     appenders:
       - network
     additive: false
+  # Route log events sent to the "p2p" logger to the "network" appender
   p2p:
     level: info
     appenders:
       - network
     additive: false
-    # Route log events sent to the "p2p" logger to the "network" appender
+   # Route log events sent to the "yamux" logger to the "network" appender
   yamux:
     level: info
     appenders:
       - network
     additive: false
- # Route log events sent to the "mio" logger to the "other" appender
+  # Route log events sent to the "mio" logger to the "network" appender
   mio:
     level: error
     appenders:
@@ -142,4 +122,16 @@ loggers:
     level: error
     appenders:
       - other
+    additive: false
+  # Route log events sent to the "tari_mm_proxy" logger to the "base_layer" appender
+  tari_mm_proxy:
+    level: info
+    appenders:
+      - base_layer
+    additive: false
+  # Route log events sent to the "stress_test" logger to the "base_layer" appender
+  stress_test:
+    level: info
+    appenders:
+      - base_layer
     additive: false


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

During stress tests, an immense amount of trace level log files are generated. In order to more efficiently capture stress test profiling data, a `stress_test` log target and appender have been added for selective log messages.

## Motivation and Context

Stress tests are an important part of evolving and stabilizing the network, and this needs to happen more regularly and more efficiently. This PR is the first in a range of PRs that will be submitted in order to get closer to the goal of performing a _**one-click-stress-test-one-click-analysis**_.

## How Has This Been Tested?

Tested in a base node on Windows.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [X] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [X] I'm merging against the `development` branch.
* [X] I ran `cargo-fmt --all` before pushing.
* [X] I ran `cargo test` successfully before submitting my PR.
* [X] I have squashed my commits into a single commit.
* [X] My change requires a change to the documentation.
* [X] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
