### PR TITLE
Improve display of Difficulty

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -954,7 +954,7 @@ dependencies = [
  "libsqlite3-sys",
  "num-bigint 0.2.6",
  "num-integer",
- "num-traits 0.1.43",
+ "num-traits 0.2.12",
  "serde_json",
 ]
 
@@ -2440,6 +2440,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b05ad05bd8977050b171b3f6b48175fea6e0565b7981059b486075e1026a9fb5"
 dependencies = [
  "num-traits 0.2.12",
+]
+
+[[package]]
+name = "num-format"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bafe4179722c2894288ee77a9f044f02811c86af699344c498b0840c698a2465"
+dependencies = [
+ "arrayvec 0.4.12",
+ "itoa",
 ]
 
 [[package]]
@@ -3999,6 +4009,7 @@ dependencies = [
  "monero",
  "newtype-ops",
  "num 0.3.0",
+ "num-format",
  "prost",
  "prost-types",
  "rand 0.7.3",

--- a/base_layer/core/Cargo.toml
+++ b/base_layer/core/Cargo.toml
@@ -55,6 +55,7 @@ thiserror = "1.0.20"
 tokio = { version="^0.2", features = ["blocking", "time", "sync"] }
 ttl_cache = "0.5.1"
 uint = { version = "0.8", default-features = false }
+num-format = "0.4.0"
 
 [dev-dependencies]
 tari_p2p = { version = "^0.2", path = "../../base_layer/p2p", features=["test-mocks"]}

--- a/base_layer/core/src/proof_of_work/difficulty.rs
+++ b/base_layer/core/src/proof_of_work/difficulty.rs
@@ -22,6 +22,7 @@
 
 use crate::proof_of_work::error::DifficultyAdjustmentError;
 use newtype_ops::newtype_ops;
+use num_format::{Locale, ToFormattedString};
 use serde::{Deserialize, Serialize};
 use std::{fmt, ops::Div};
 use tari_crypto::tari_utilities::epoch_time::EpochTime;
@@ -78,7 +79,8 @@ impl Div for Difficulty {
 
 impl fmt::Display for Difficulty {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", self.0)
+        let formatted = self.0.to_formatted_string(&Locale::en);
+        write!(f, "{}", formatted)
     }
 }
 
@@ -121,5 +123,11 @@ mod test {
         );
         assert_eq!(Difficulty::default() + Difficulty::from(42), Difficulty::from(43));
         assert_eq!(&Difficulty::from(15) + &Difficulty::from(5), Difficulty::from(20));
+    }
+
+    #[test]
+    fn test_format() {
+        let d = Difficulty::from(1_000_000);
+        assert_eq!("1,000,000", format!("{}", d));
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Add large number formatting to the display trait of Difficulty struct. eg: `1000000` will be displayed as `1,000,000` 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Reading Difficulties in logs is not easy because they have no formatting 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
`cargo test`

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [x] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch.
* [x] I ran `cargo-fmt --all` before pushing.
* [x] I ran `cargo test` successfully before submitting my PR.
* [x] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
