### PR TITLE
Improve block sync speed by scaling block window

### DIFF
--- a/applications/tari_app_utilities/src/utilities.rs
+++ b/applications/tari_app_utilities/src/utilities.rs
@@ -189,23 +189,10 @@ pub fn convert_socks_authentication(auth: SocksAuthentication) -> socks::Authent
 ///
 /// ## Returns
 /// A result containing the runtime on success, string indicating the error on failure
-pub fn setup_runtime(config: &GlobalConfig) -> Result<Runtime, String> {
-    let num_core_threads = config.core_threads;
-    let num_blocking_threads = config.blocking_threads;
-    let num_mining_threads = config.num_mining_threads;
-
-    info!(
-        target: LOG_TARGET,
-        "Configuring the node to run on {} core threads, {} blocking worker threads and {} mining threads.",
-        num_core_threads,
-        num_blocking_threads,
-        num_mining_threads
-    );
+pub fn setup_runtime() -> Result<Runtime, String> {
     tokio::runtime::Builder::new()
         .threaded_scheduler()
         .enable_all()
-        .max_threads(num_core_threads + num_blocking_threads + num_mining_threads)
-        .core_threads(num_core_threads)
         .build()
         .map_err(|e| format!("There was an error while building the node runtime. {}", e.to_string()))
 }

--- a/applications/tari_base_node/src/main.rs
+++ b/applications/tari_base_node/src/main.rs
@@ -154,7 +154,7 @@ fn main_inner() -> Result<(), ExitCodes> {
     debug!(target: LOG_TARGET, "Using configuration: {:?}", node_config);
 
     // Set up the Tokio runtime
-    let mut rt = setup_runtime(&node_config).map_err(|err| {
+    let mut rt = setup_runtime().map_err(|err| {
         error!(target: LOG_TARGET, "{}", err);
         ExitCodes::UnknownError
     })?;

--- a/base_layer/core/src/base_node/consts.rs
+++ b/base_layer/core/src/base_node/consts.rs
@@ -23,6 +23,12 @@
 use std::time::Duration;
 
 /// The allocated waiting time for a request waiting for service responses from remote base nodes.
-pub const BASE_NODE_SERVICE_REQUEST_TIMEOUT: Duration = Duration::from_secs(600);
+pub const BASE_NODE_SERVICE_REQUEST_TIMEOUT: Duration = Duration::from_secs(30);
+/// The minimum allocated waiting time for a request waiting for service responses from remote base nodes.
+pub const BASE_NODE_SERVICE_REQUEST_MIN_TIMEOUT: Duration = Duration::from_secs(10);
+/// The allocated waiting time for a fetch blocks request waiting for service responses from remote base nodes.
+pub const FETCH_BLOCKS_SERVICE_REQUEST_TIMEOUT: Duration = Duration::from_secs(30);
+/// The minimum allocated waiting time for a fetch blocks request waiting for service responses from remote base nodes.
+pub const FETCH_BLOCKS_SERVICE_REQUEST_MIN_TIMEOUT: Duration = Duration::from_secs(10);
 /// The fraction of responses that need to be received for a corresponding service request to be finalize.
 pub const BASE_NODE_SERVICE_DESIRED_RESPONSE_FRACTION: f32 = 0.6;

--- a/base_layer/core/src/base_node/state_machine_service/initializer.rs
+++ b/base_layer/core/src/base_node/state_machine_service/initializer.rs
@@ -23,10 +23,11 @@
 use crate::{
     base_node::{
         chain_metadata_service::ChainMetadataHandle,
+        consts::FETCH_BLOCKS_SERVICE_REQUEST_MIN_TIMEOUT,
         state_machine_service::{
             handle::StateMachineHandle,
             state_machine::{BaseNodeStateMachine, BaseNodeStateMachineConfig},
-            states::{BlockSyncStrategy, StatusInfo},
+            states::{BlockSyncConfig, BlockSyncStrategy, StatusInfo},
         },
         LocalNodeCommsInterface,
         OutboundNodeCommsInterface,
@@ -38,7 +39,7 @@ use crate::{
 };
 use futures::{future, Future};
 use log::*;
-use std::sync::Arc;
+use std::{cmp, sync::Arc, time::Duration};
 use tari_comms::{connectivity::ConnectivityRequester, PeerManager};
 use tari_service_framework::{ServiceInitializationError, ServiceInitializer, ServiceInitializerContext};
 use tokio::sync::{broadcast, watch};
@@ -50,6 +51,7 @@ pub struct BaseNodeStateMachineInitializer<B> {
     rules: ConsensusManager,
     factories: CryptoFactories,
     sync_strategy: BlockSyncStrategy,
+    fetch_blocks_timeout: Duration,
 }
 
 impl<B> BaseNodeStateMachineInitializer<B>
@@ -60,6 +62,7 @@ where B: BlockchainBackend + 'static
         rules: ConsensusManager,
         factories: CryptoFactories,
         sync_strategy: BlockSyncStrategy,
+        fetch_blocks_timeout: Duration,
     ) -> Self
     {
         Self {
@@ -67,6 +70,7 @@ where B: BlockchainBackend + 'static
             rules,
             factories,
             sync_strategy,
+            fetch_blocks_timeout,
         }
     }
 }
@@ -92,6 +96,7 @@ where B: BlockchainBackend + 'static
         let sync_strategy = self.sync_strategy;
         let rules = self.rules.clone();
         let db = self.db.clone();
+        let fetch_blocks_timeout = self.fetch_blocks_timeout.clone();
         context.spawn_when_ready(move |handles| async move {
             let outbound_interface = handles.expect_handle::<OutboundNodeCommsInterface>();
             let chain_metadata_service = handles.expect_handle::<ChainMetadataHandle>();
@@ -99,7 +104,13 @@ where B: BlockchainBackend + 'static
             let connectivity_requester = handles.expect_handle::<ConnectivityRequester>();
             let peer_manager = handles.expect_handle::<Arc<PeerManager>>();
 
-            let mut state_machine_config = BaseNodeStateMachineConfig::default();
+            let mut state_machine_config = BaseNodeStateMachineConfig {
+                block_sync_config: BlockSyncConfig {
+                    fetch_blocks_timeout: cmp::max(FETCH_BLOCKS_SERVICE_REQUEST_MIN_TIMEOUT, fetch_blocks_timeout),
+                    ..Default::default()
+                },
+                ..Default::default()
+            };
             state_machine_config.block_sync_config.sync_strategy = sync_strategy;
 
             // TODO: This should move to checking each time

--- a/base_layer/core/tests/node_service.rs
+++ b/base_layer/core/tests/node_service.rs
@@ -704,6 +704,7 @@ fn service_request_timeout() {
     let consensus_manager = ConsensusManagerBuilder::new(network).build();
     let base_node_service_config = BaseNodeServiceConfig {
         request_timeout: Duration::from_millis(1),
+        fetch_blocks_timeout: Default::default(),
         desired_response_fraction: BASE_NODE_SERVICE_DESIRED_RESPONSE_FRACTION,
     };
     let temp_dir = tempdir().unwrap();

--- a/common/config/presets/windows.toml
+++ b/common/config/presets/windows.toml
@@ -52,6 +52,15 @@
 # - Rate limit for the base node wallet (min value = 5, default value = 20).
 #buffer_rate_limit_base_node_wallet = 20
 
+# The timeout (s) for requesting blocks from a peer during blockchain sync. If this timeout expires, a new block
+# request will be sent with a smaller amount of blocks, until the amount of blocks requested are returned within
+# the timeout limit. Whenever the actual time taken are much less than the timeout, more blocks will be requested
+# next time round. (min value = 10 s, default value = 30 s)
+#fetch_blocks_timeout = 30
+
+# The timeout (s) for requesting other base node services (min value = 10 s, default value = 600 s).
+#base_node_service_request_timeout = 600
+
 ########################################################################################################################
 #                                                                                                                      #
 #                                          Wallet Configuration Options                                                #

--- a/common/config/tari_config_sample.toml
+++ b/common/config/tari_config_sample.toml
@@ -52,6 +52,15 @@
 # - Rate limit for the base node wallet (min value = 5, default value = 20).
 #buffer_rate_limit_base_node_wallet = 20
 
+# The timeout (s) for requesting blocks from a peer during blockchain sync. If this timeout expires, a new block
+# request will be sent with a smaller amount of blocks, until the amount of blocks requested are returned within
+# the timeout limit. Whenever the actual time taken are much less than the timeout, more blocks will be requested
+# next time round. (min value = 10 s, default value = 30 s)
+#fetch_blocks_timeout = 30
+
+# The timeout (s) for requesting other base node services (min value = 10 s, default value = 600 s).
+#base_node_service_request_timeout = 600
+
 ########################################################################################################################
 #                                                                                                                      #
 #                                          Wallet Configuration Options                                                #

--- a/common/src/configuration/global.rs
+++ b/common/src/configuration/global.rs
@@ -58,8 +58,6 @@ pub struct GlobalConfig {
     pub orphan_storage_capacity: usize,
     pub pruning_horizon: u64,
     pub pruned_mode_cleanup_interval: u64,
-    pub core_threads: usize,
-    pub blocking_threads: usize,
     pub identity_file: PathBuf,
     pub public_address: Multiaddr,
     pub grpc_enabled: bool,
@@ -79,6 +77,8 @@ pub struct GlobalConfig {
     pub buffer_size_base_node_wallet: usize,
     pub buffer_rate_limit_base_node: usize,
     pub buffer_rate_limit_base_node_wallet: usize,
+    pub fetch_blocks_timeout: Duration,
+    pub base_node_service_request_timeout: Duration,
     pub base_node_query_timeout: Duration,
     pub transaction_broadcast_monitoring_timeout: Duration,
     pub transaction_chain_monitoring_timeout: Duration,
@@ -204,17 +204,6 @@ fn convert_node_config(network: Network, cfg: Config) -> Result<GlobalConfig, Co
     let pruned_mode_cleanup_interval = cfg
         .get_int(&key)
         .map_err(|e| ConfigurationError::new(&key, &e.to_string()))? as u64;
-
-    // Thread counts
-    let key = config_string("base_node", &net_str, "core_threads");
-    let core_threads = cfg
-        .get_int(&key)
-        .map_err(|e| ConfigurationError::new(&key, &e.to_string()))? as usize;
-
-    let key = config_string("base_node", &net_str, "blocking_threads");
-    let blocking_threads = cfg
-        .get_int(&key)
-        .map_err(|e| ConfigurationError::new(&key, &e.to_string()))? as usize;
 
     // NodeIdentity path
     let key = config_string("base_node", &net_str, "identity_file");
@@ -382,6 +371,18 @@ fn convert_node_config(network: Network, cfg: Config) -> Result<GlobalConfig, Co
         cfg.get_int(&key)
             .map_err(|e| ConfigurationError::new(&key, &e.to_string()))? as usize;
 
+    let key = "common.fetch_blocks_timeout";
+    let fetch_blocks_timeout = Duration::from_secs(
+        cfg.get_int(&key)
+            .map_err(|e| ConfigurationError::new(&key, &e.to_string()))? as u64,
+    );
+
+    let key = "common.base_node_service_request_timeout";
+    let base_node_service_request_timeout = Duration::from_secs(
+        cfg.get_int(&key)
+            .map_err(|e| ConfigurationError::new(&key, &e.to_string()))? as u64,
+    );
+
     let key = config_string("merge_mining_proxy", &net_str, "monerod_url");
     let monerod_url = cfg
         .get_str(&key)
@@ -422,8 +423,6 @@ fn convert_node_config(network: Network, cfg: Config) -> Result<GlobalConfig, Co
         orphan_storage_capacity,
         pruning_horizon,
         pruned_mode_cleanup_interval,
-        core_threads,
-        blocking_threads,
         identity_file,
         public_address,
         grpc_enabled,
@@ -443,6 +442,8 @@ fn convert_node_config(network: Network, cfg: Config) -> Result<GlobalConfig, Co
         buffer_size_base_node_wallet,
         buffer_rate_limit_base_node,
         buffer_rate_limit_base_node_wallet,
+        fetch_blocks_timeout,
+        base_node_service_request_timeout,
         base_node_query_timeout,
         transaction_broadcast_monitoring_timeout,
         transaction_chain_monitoring_timeout,

--- a/common/src/configuration/utils.rs
+++ b/common/src/configuration/utils.rs
@@ -63,6 +63,9 @@ pub fn default_config(bootstrap: &ConfigBootstrap) -> Config {
     cfg.set_default("common.buffer_rate_limit_base_node", 1_000).unwrap();
     cfg.set_default("common.buffer_rate_limit_base_node_wallet", 1_000)
         .unwrap();
+    cfg.set_default("common.fetch_blocks_timeout", 30).unwrap();
+    cfg.set_default("common.base_node_service_request_timeout", 600)
+        .unwrap();
 
     // Wallet settings
     cfg.set_default("wallet.grpc_enabled", false).unwrap();


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Increase or decrease the number of blocks requested during block sync according to timeouts. If the request times out, halve the number of blocks requested. If the request returns in less than half of the timeout time, double the blocks requested. 
Nodes were also banned if they timed out. This has been changed to only ban if they time out when the block window requested is 1.
Note: I reduced the `BASE_NODE_SERVICE_REQUEST_TIMEOUT` to 30 seconds. This may impact other calls.

Special thanks to @hansieodendaal for his PR into this PR. His changes got combined with mine in a squash merge.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The previous code would only request 5 blocks at a time (window). This number can be increased, but there are some blocks that take a long time to process, so a window of  128 would be a problem because a single block may timeout. Changing this to a dynamic window solves the problem.  


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch.
* [x] I ran `cargo-fmt --all` before pushing.
* [ ] I ran `cargo test` successfully before submitting my PR.
* [x] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
