### PR TITLE
Temp fix for monero big_endian-little_endian issue

### DIFF
--- a/base_layer/core/src/proof_of_work/blake_pow.rs
+++ b/base_layer/core/src/proof_of_work/blake_pow.rs
@@ -20,12 +20,13 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use crate::{blocks::BlockHeader, proof_of_work::Difficulty, U256};
+use crate::{
+    blocks::BlockHeader,
+    proof_of_work::{difficulty::big_endian_difficulty, Difficulty},
+};
 use blake2::Blake2b;
 use digest::Digest;
 use tari_crypto::{common::Blake256, tari_utilities::Hashable};
-
-const MAX_TARGET: U256 = U256::MAX;
 
 /// A simple Blake2b-based proof of work. This is currently intended to be used for testing and perhaps Testnet until
 /// Monero merge-mining is active.
@@ -39,10 +40,8 @@ pub fn blake_difficulty(header: &BlockHeader) -> Difficulty {
 pub fn blake_difficulty_with_hash(header: &BlockHeader) -> (Difficulty, Vec<u8>) {
     let bytes = header.hash();
     let hash = Blake2b::digest(&bytes);
-    let hash = Blake256::digest(&hash);
-    let scalar = U256::from_big_endian(&hash); // Big endian so the hash has leading zeroes
-    let result = MAX_TARGET / scalar;
-    let difficulty = result.low_u64().into();
+    let hash = Blake256::digest(&hash).to_vec();
+    let difficulty = big_endian_difficulty(&hash);
     (difficulty, hash.to_vec())
 }
 

--- a/base_layer/core/src/proof_of_work/difficulty.rs
+++ b/base_layer/core/src/proof_of_work/difficulty.rs
@@ -20,7 +20,7 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use crate::proof_of_work::error::DifficultyAdjustmentError;
+use crate::{proof_of_work::error::DifficultyAdjustmentError, U256};
 use newtype_ops::newtype_ops;
 use num_format::{Locale, ToFormattedString};
 use serde::{Deserialize, Serialize};
@@ -30,6 +30,9 @@ use tari_crypto::tari_utilities::epoch_time::EpochTime;
 /// Minimum difficulty, enforced in diff retargetting
 /// avoids getting stuck when trying to increase difficulty subject to dampening
 pub const MIN_DIFFICULTY: u64 = 1;
+
+/// Maximum target for use by calculating difficulty.
+const MAX_TARGET: U256 = U256::MAX;
 
 /// The difficulty is defined as the maximum target divided by the block hash.
 #[derive(Debug, Clone, Copy, PartialEq, PartialOrd, Eq, Ord, Deserialize, Serialize)]
@@ -109,6 +112,20 @@ pub trait DifficultyAdjustment {
 
     /// Return the calculated target difficulty for the next block.
     fn get_difficulty(&self) -> Difficulty;
+}
+
+/// This will provide the difficulty of the hash assuming the hash is big_endian
+pub fn big_endian_difficulty(hash: &[u8]) -> Difficulty {
+    let scalar = U256::from_big_endian(hash); // Big endian so the hash has leading zeroes
+    let result = MAX_TARGET / scalar;
+    result.low_u64().into()
+}
+
+/// This will provide the difficulty of the hash assuming the hash is little_endian
+pub fn little_endian_difficulty(hash: &[u8]) -> Difficulty {
+    let scalar = U256::from_little_endian(&hash); // Little endian so the hash has trailing zeroes
+    let result = MAX_TARGET / scalar;
+    result.low_u64().into()
 }
 
 #[cfg(test)]

--- a/base_layer/core/src/proof_of_work/mod.rs
+++ b/base_layer/core/src/proof_of_work/mod.rs
@@ -23,7 +23,7 @@
 #[cfg(feature = "base_node")]
 mod blake_pow;
 #[cfg(any(feature = "base_node", feature = "transactions"))]
-mod difficulty;
+pub(crate) mod difficulty;
 #[cfg(any(feature = "base_node", feature = "transactions"))]
 mod error;
 #[cfg(feature = "base_node")]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Put in temp fix for monero big_endian-little_endian issue by swapping big_endian -> little endian based on block height

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Monero blocks under 1080000 where incorrectly calculated as big_endian and not little indian

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch.
* [x] I ran `cargo-fmt --all` before pushing.
* [x] I ran `cargo test` successfully before submitting my PR.
* [ ] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
