### PR TITLE
DHT RPC get_peers returns all peers and "on connect" mode for NetworkDiscovery

### DIFF
--- a/comms/dht/src/dht.rs
+++ b/comms/dht/src/dht.rs
@@ -151,10 +151,7 @@ impl Dht {
 
     /// Create a DHT RPC service
     pub fn rpc_service(&self) -> rpc::DhtService<rpc::DhtRpcServiceImpl> {
-        rpc::DhtService::new(rpc::DhtRpcServiceImpl::new(
-            self.node_identity.clone(),
-            self.peer_manager.clone(),
-        ))
+        rpc::DhtService::new(rpc::DhtRpcServiceImpl::new(self.peer_manager.clone()))
     }
 
     /// Create a DHT actor

--- a/comms/dht/src/network_discovery/discovering.rs
+++ b/comms/dht/src/network_discovery/discovering.rs
@@ -38,7 +38,7 @@ use tari_comms::{
 const LOG_TARGET: &str = "comms::dht::network_discovery";
 
 #[derive(Debug)]
-pub struct Discovering {
+pub(super) struct Discovering {
     params: DiscoveryParams,
     context: NetworkDiscoveryContext,
     candidate_peers: Vec<PeerConnection>,
@@ -141,11 +141,18 @@ impl Discovering {
     {
         debug!(
             target: LOG_TARGET,
-            "Requesting {} peers from `{}`", self.params.num_peers_to_request, sync_peer
+            "Requesting {} peers from `{}`",
+            self.params
+                .num_peers_to_request
+                .as_ref()
+                .map(ToString::to_string)
+                .unwrap_or_else(|| "∞".into()),
+            sync_peer
         );
         match client
             .get_peers(GetPeersRequest {
-                n: self.params.num_peers_to_request as u32,
+                n: self.params.num_peers_to_request.map(|v| v as u32).unwrap_or_default(),
+                include_clients: true,
             })
             .await
         {

--- a/comms/dht/src/network_discovery/initializing.rs
+++ b/comms/dht/src/network_discovery/initializing.rs
@@ -28,7 +28,7 @@ use tari_comms::connectivity::ConnectivityError;
 const LOG_TARGET: &str = "comms::dht::network_discovery";
 
 #[derive(Debug)]
-pub struct Initializing<'a> {
+pub(super) struct Initializing<'a> {
     context: &'a mut NetworkDiscoveryContext,
 }
 

--- a/comms/dht/src/network_discovery/mod.rs
+++ b/comms/dht/src/network_discovery/mod.rs
@@ -27,9 +27,6 @@
 #[cfg(test)]
 mod test;
 
-mod state_machine;
-pub use state_machine::{DhtNetworkDiscovery, DhtNetworkDiscoveryRoundInfo};
-
 mod config;
 pub use config::NetworkDiscoveryConfig;
 
@@ -39,5 +36,10 @@ mod error;
 pub use error::NetworkDiscoveryError;
 
 mod initializing;
+mod on_connect;
 mod ready;
+
+mod state_machine;
+pub use state_machine::{DhtNetworkDiscovery, DhtNetworkDiscoveryRoundInfo};
+
 mod waiting;

--- a/comms/dht/src/network_discovery/on_connect.rs
+++ b/comms/dht/src/network_discovery/on_connect.rs
@@ -1,0 +1,190 @@
+//  Copyright 2020, The Tari Project
+//
+//  Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+//  following conditions are met:
+//
+//  1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+//  disclaimer.
+//
+//  2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+//  following disclaimer in the documentation and/or other materials provided with the distribution.
+//
+//  3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+//  products derived from this software without specific prior written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+//  INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+//  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+//  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+//  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+//  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+//  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+use crate::{
+    event::DhtEvent,
+    network_discovery::{
+        state_machine::{NetworkDiscoveryContext, StateEvent},
+        DhtNetworkDiscoveryRoundInfo,
+        NetworkDiscoveryError,
+    },
+    proto::rpc::GetPeersRequest,
+    rpc,
+    DhtConfig,
+};
+use futures::StreamExt;
+use log::*;
+use std::{convert::TryInto, ops::Deref};
+use tari_comms::{
+    connectivity::ConnectivityEvent,
+    peer_manager::{NodeId, Peer},
+    validate_peer_addresses,
+    PeerConnection,
+};
+use tokio::sync::broadcast;
+
+const LOG_TARGET: &str = "comms::dht::network_discovery:onconnect";
+
+#[derive(Debug)]
+pub(super) struct OnConnect {
+    context: NetworkDiscoveryContext,
+    prev_synced: Vec<NodeId>,
+}
+
+impl OnConnect {
+    pub fn new(context: NetworkDiscoveryContext) -> Self {
+        Self {
+            context,
+            prev_synced: Vec::new(),
+        }
+    }
+
+    pub async fn next_event(&mut self) -> StateEvent {
+        let mut connectivity_events = self.context.connectivity.get_event_subscription();
+        while let Some(event) = connectivity_events.next().await {
+            match event.as_ref().map(|e| e.deref()) {
+                Ok(ConnectivityEvent::PeerConnected(conn)) => {
+                    if conn.peer_features().is_client() {
+                        continue;
+                    }
+                    if self.prev_synced.contains(conn.peer_node_id()) {
+                        debug!(
+                            target: LOG_TARGET,
+                            "Already synced from peer `{}`. Skipping",
+                            conn.peer_node_id()
+                        );
+                        continue;
+                    }
+
+                    debug!(
+                        target: LOG_TARGET,
+                        "Node peer `{}` connected. Syncing peers...",
+                        conn.peer_node_id()
+                    );
+
+                    match self.sync_peers(conn.clone()).await {
+                        Ok(_) => continue,
+                        Err(err) => debug!(
+                            target: LOG_TARGET,
+                            "Failed to peer sync from `{}`: {}",
+                            conn.peer_node_id(),
+                            err
+                        ),
+                    }
+
+                    self.prev_synced.push(conn.peer_node_id().clone());
+                },
+                Ok(_) => { /* Nothing to do */ },
+                Err(broadcast::RecvError::Lagged(n)) => {
+                    warn!(target: LOG_TARGET, "Lagged behind on {} connectivity event(s)", n)
+                },
+                Err(broadcast::RecvError::Closed) => {
+                    break;
+                },
+            }
+        }
+
+        StateEvent::Shutdown
+    }
+
+    async fn sync_peers(&self, mut conn: PeerConnection) -> Result<(), NetworkDiscoveryError> {
+        let mut client = conn.connect_rpc::<rpc::DhtClient>().await?;
+        let mut peer_stream = client
+            .get_peers(GetPeersRequest {
+                // Sync all peers
+                n: 0,
+                include_clients: true,
+            })
+            .await?;
+
+        let sync_peer = conn.peer_node_id();
+        let mut num_added = 0;
+        while let Some(resp) = peer_stream.next().await {
+            match resp {
+                Ok(resp) => match resp.peer.and_then(|peer| peer.try_into().ok()) {
+                    Some(peer) => {
+                        let is_node_added = self.validate_and_add_peer(sync_peer, peer).await?;
+                        if is_node_added {
+                            num_added += 1;
+                        }
+                    },
+                    None => {
+                        debug!(target: LOG_TARGET, "Invalid response from peer `{}`", sync_peer);
+                    },
+                },
+                Err(err) => {
+                    debug!(target: LOG_TARGET, "Error response from peer `{}`: {}", sync_peer, err);
+                },
+            }
+        }
+
+        debug!(
+            target: LOG_TARGET,
+            "Added {} peer(s) from peer `{}`", num_added, sync_peer
+        );
+        if num_added > 0 {
+            self.context
+                .publish_event(DhtEvent::NetworkDiscoveryPeersAdded(DhtNetworkDiscoveryRoundInfo {
+                    // TODO: num_new_neighbours could be incorrect here
+                    num_new_neighbours: 0,
+                    num_new_peers: num_added,
+                    num_duplicate_peers: 0,
+                    num_succeeded: num_added,
+                    sync_peers: vec![conn.peer_node_id().clone()],
+                }));
+        }
+
+        Ok(())
+    }
+
+    async fn validate_and_add_peer(&self, sync_peer: &NodeId, peer: Peer) -> Result<bool, NetworkDiscoveryError> {
+        let peer_manager = &self.context.peer_manager;
+        if peer_manager.exists_node_id(&peer.node_id).await {
+            return Ok(false);
+        }
+
+        let addresses = peer.addresses.address_iter();
+        match validate_peer_addresses(addresses, self.config().network.is_localtest()) {
+            Ok(_) => {
+                debug!(
+                    target: LOG_TARGET,
+                    "Adding peer `{}` from `{}`", peer.node_id, sync_peer
+                );
+                peer_manager.add_peer(peer).await?;
+                Ok(true)
+            },
+            Err(err) => {
+                // TODO: #banheuristic
+                debug!(
+                    target: LOG_TARGET,
+                    "Failed to validate peer received from `{}`: {}. Peer not added.", sync_peer, err
+                );
+                Ok(false)
+            },
+        }
+    }
+
+    #[inline]
+    fn config(&self) -> &DhtConfig {
+        &self.context.config
+    }
+}

--- a/comms/dht/src/proto/rpc.proto
+++ b/comms/dht/src/proto/rpc.proto
@@ -2,10 +2,20 @@ syntax = "proto3";
 
 package tari.dht.rpc;
 
-// GET peers request
-message GetPeersRequest {
+// `get_closer_peers` request
+message GetCloserPeersRequest {
   // The number of peers to return
   uint32 n = 1;
+  repeated bytes excluded = 2;
+  bytes closer_to = 3;
+  bool include_clients = 4;
+}
+
+// `get_peers` request
+message GetPeersRequest {
+  // The number of peers to return, 0 for all peers
+  uint32 n = 1;
+  bool include_clients = 2;
 }
 
 // GET peers response

--- a/comms/dht/src/proto/tari.dht.rpc.rs
+++ b/comms/dht/src/proto/tari.dht.rpc.rs
@@ -1,9 +1,24 @@
-/// GET peers request
+/// `get_closer_peers` request
 #[derive(Clone, PartialEq, ::prost::Message)]
-pub struct GetPeersRequest {
+pub struct GetCloserPeersRequest {
     /// The number of peers to return
     #[prost(uint32, tag = "1")]
     pub n: u32,
+    #[prost(bytes, repeated, tag = "2")]
+    pub excluded: ::std::vec::Vec<std::vec::Vec<u8>>,
+    #[prost(bytes, tag = "3")]
+    pub closer_to: std::vec::Vec<u8>,
+    #[prost(bool, tag = "4")]
+    pub include_clients: bool,
+}
+/// `get_peers` request
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct GetPeersRequest {
+    /// The number of peers to return, 0 for all peers
+    #[prost(uint32, tag = "1")]
+    pub n: u32,
+    #[prost(bool, tag = "2")]
+    pub include_clients: bool,
 }
 /// GET peers response
 #[derive(Clone, PartialEq, ::prost::Message)]

--- a/comms/dht/src/rpc/mock.rs
+++ b/comms/dht/src/rpc/mock.rs
@@ -21,7 +21,7 @@
 //  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 use crate::{
-    proto::rpc::{GetPeersRequest, GetPeersResponse},
+    proto::rpc::{GetCloserPeersRequest, GetPeersRequest, GetPeersResponse},
     rpc::DhtRpcService,
 };
 use tari_comms::protocol::rpc::{
@@ -34,6 +34,7 @@ use tari_comms::protocol::rpc::{
 // TODO: This mock can be generated
 #[derive(Debug, Clone, Default)]
 pub struct DhtRpcServiceMock {
+    pub get_closer_peers: RpcMockMethodState<GetCloserPeersRequest, Vec<GetPeersResponse>>,
     pub get_peers: RpcMockMethodState<GetPeersRequest, Vec<GetPeersResponse>>,
 }
 
@@ -45,6 +46,14 @@ impl DhtRpcServiceMock {
 
 #[tari_comms::async_trait]
 impl DhtRpcService for DhtRpcServiceMock {
+    async fn get_closer_peers(
+        &self,
+        request: Request<GetCloserPeersRequest>,
+    ) -> Result<Streaming<GetPeersResponse>, RpcStatus>
+    {
+        self.server_streaming(request, &self.get_closer_peers).await
+    }
+
     async fn get_peers(&self, request: Request<GetPeersRequest>) -> Result<Streaming<GetPeersResponse>, RpcStatus> {
         self.server_streaming(request, &self.get_peers).await
     }

--- a/comms/dht/src/rpc/mod.rs
+++ b/comms/dht/src/rpc/mod.rs
@@ -30,13 +30,19 @@ mod test;
 mod service;
 pub use service::DhtRpcServiceImpl;
 
-use crate::proto::rpc::{GetPeersRequest, GetPeersResponse};
+use crate::proto::rpc::{GetCloserPeersRequest, GetPeersRequest, GetPeersResponse};
 use tari_comms::protocol::rpc::{Request, Response, RpcStatus, Streaming};
 use tari_comms_rpc_macros::tari_rpc;
 
 #[tari_rpc(protocol_name = b"t/dht/1", server_struct = DhtService, client_struct = DhtClient)]
 pub trait DhtRpcService: Send + Sync + 'static {
-    /// Fetches and returns nodes (as in PeerFeatures::COMMUNICATION_NODE)  as per `GetPeersRequest`
+    /// Fetches and returns nodes (as in PeerFeatures::COMMUNICATION_NODE)  as per `GetCloserPeersRequest`
     #[rpc(method = 1)]
+    async fn get_closer_peers(
+        &self,
+        request: Request<GetCloserPeersRequest>,
+    ) -> Result<Streaming<GetPeersResponse>, RpcStatus>;
+
+    #[rpc(method = 10)]
     async fn get_peers(&self, request: Request<GetPeersRequest>) -> Result<Streaming<GetPeersResponse>, RpcStatus>;
 }

--- a/comms/dht/src/rpc/service.rs
+++ b/comms/dht/src/rpc/service.rs
@@ -21,74 +21,37 @@
 //  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 use crate::{
-    proto::rpc::{GetPeersRequest, GetPeersResponse},
+    proto::rpc::{GetCloserPeersRequest, GetPeersRequest, GetPeersResponse},
     rpc::DhtRpcService,
 };
 use futures::{channel::mpsc, stream, SinkExt};
 use log::*;
 use std::{cmp, sync::Arc};
 use tari_comms::{
-    peer_manager::PeerFeatures,
+    peer_manager::{NodeId, Peer, PeerFeatures, PeerQuery},
     protocol::rpc::{Request, RpcError, RpcStatus, Streaming},
-    NodeIdentity,
     PeerManager,
 };
+use tari_utilities::ByteArray;
 use tokio::task;
 
 const LOG_TARGET: &str = "comms::dht::rpc";
 
 const MAX_NUM_PEERS: usize = 100;
+const MAX_EXCLUDED_PEERS: usize = 1000;
 
 pub struct DhtRpcServiceImpl {
-    node_identity: Arc<NodeIdentity>,
     peer_manager: Arc<PeerManager>,
 }
 
 impl DhtRpcServiceImpl {
-    pub fn new(node_identity: Arc<NodeIdentity>, peer_manager: Arc<PeerManager>) -> Self {
-        Self {
-            node_identity,
-            peer_manager,
-        }
+    pub fn new(peer_manager: Arc<PeerManager>) -> Self {
+        Self { peer_manager }
     }
-}
 
-#[tari_comms::async_trait]
-impl DhtRpcService for DhtRpcServiceImpl {
-    async fn get_peers(&self, request: Request<GetPeersRequest>) -> Result<Streaming<GetPeersResponse>, RpcStatus> {
-        if !self.node_identity.has_peer_features(PeerFeatures::COMMUNICATION_NODE) {
-            debug!(target: LOG_TARGET, "get_peers request is not valid for client nodes");
-            // TODO: #banheuristic - nodes should never call this method for client nodes
-            return Err(RpcStatus::unsupported_method("get_peers is not supported"));
-        }
-
-        let message = request.message();
-        let node_id = request.context().peer_node_id();
-        if message.n == 0 {
-            return Err(RpcStatus::bad_request("Requesting zero peers is invalid"));
-        }
-        if message.n as usize > MAX_NUM_PEERS {
-            return Err(RpcStatus::bad_request(format!(
-                "Requested too many peers ({}). Cannot request more than `{}` peers",
-                message.n, MAX_NUM_PEERS
-            )));
-        }
-
-        let peers = self
-            .peer_manager
-            .closest_peers(node_id, message.n as usize, &[], Some(PeerFeatures::COMMUNICATION_NODE))
-            .await
-            .map_err(RpcError::from)?;
-        debug!(
-            target: LOG_TARGET,
-            "[get_peers] Returning {}/{} peer(s) to peer `{}`",
-            peers.len(),
-            message.n,
-            node_id.short_str()
-        );
-
+    pub fn stream_peers(&self, peers: Vec<Peer>) -> Streaming<GetPeersResponse> {
         if peers.is_empty() {
-            return Ok(Streaming::empty());
+            return Streaming::empty();
         }
 
         // A maximum buffer size of 10 is selected arbitrarily and is to allow the producer/consumer some room to
@@ -106,6 +69,104 @@ impl DhtRpcService for DhtRpcServiceImpl {
             let _ = tx.send_all(&mut stream).await;
         });
 
-        Ok(Streaming::new(rx))
+        Streaming::new(rx)
+    }
+}
+
+#[tari_comms::async_trait]
+impl DhtRpcService for DhtRpcServiceImpl {
+    async fn get_closer_peers(
+        &self,
+        request: Request<GetCloserPeersRequest>,
+    ) -> Result<Streaming<GetPeersResponse>, RpcStatus>
+    {
+        let message = request.message();
+        if message.n == 0 {
+            return Err(RpcStatus::bad_request("Requesting zero peers is invalid"));
+        }
+
+        if message.n as usize > MAX_NUM_PEERS {
+            return Err(RpcStatus::bad_request(format!(
+                "Requested too many peers ({}). Cannot request more than `{}` peers",
+                message.n, MAX_NUM_PEERS
+            )));
+        }
+
+        let node_id = if message.closer_to.is_empty() {
+            request.context().peer_node_id().clone()
+        } else {
+            NodeId::from_bytes(&message.closer_to)
+                .map_err(|_| RpcStatus::bad_request("`closer_to` did not contain a valid NodeId"))?
+        };
+
+        if message.excluded.len() > MAX_EXCLUDED_PEERS {
+            return Err(RpcStatus::bad_request(format!(
+                "Sending more than {} to the exclude list is not supported",
+                MAX_EXCLUDED_PEERS
+            )));
+        }
+
+        let excluded = message
+            .excluded
+            .iter()
+            .filter_map(|node_id| NodeId::from_bytes(node_id).ok())
+            .collect::<Vec<_>>();
+
+        if excluded.len() != message.excluded.len() {
+            return Err(RpcStatus::bad_request("Invalid NodeId in excluded list"));
+        }
+
+        let mut features = Some(PeerFeatures::COMMUNICATION_NODE);
+        if message.include_clients {
+            features = None;
+        }
+
+        let peers = self
+            .peer_manager
+            .closest_peers(&node_id, message.n as usize, &excluded, features)
+            .await
+            .map_err(RpcError::from)?;
+
+        debug!(
+            target: LOG_TARGET,
+            "[get_closest_peers] Returning {}/{} peer(s) to peer `{}`",
+            peers.len(),
+            message.n,
+            node_id.short_str()
+        );
+
+        Ok(self.stream_peers(peers))
+    }
+
+    async fn get_peers(&self, request: Request<GetPeersRequest>) -> Result<Streaming<GetPeersResponse>, RpcStatus> {
+        let message = request.message();
+
+        let mut query = PeerQuery::new()
+            .select_where(|peer| (message.include_clients || !peer.features.is_client()) && !peer.is_banned());
+        if message.n > 0 {
+            query = query.limit(message.n as usize);
+        }
+
+        // TODO: This result set can/will be large
+        //       Ideally, we'd need a lazy-loaded iterator, however that requires a long-lived read transaction and
+        //       the lifetime of that transaction is proportional on the time it takes to send the peers.
+        //       Either we should not need to return all peers, or we can find a way to do an iterator which does not
+        //       require a long-lived read transaction (we don't strictly care about read consistency in this case).
+        let peers = self.peer_manager.perform_query(query).await.map_err(RpcError::from)?;
+
+        let node_id = request.context().peer_node_id();
+        debug!(
+            target: LOG_TARGET,
+            "[get_peers] Returning {}/{} peer(s) to peer `{}`",
+            peers.len(),
+            Some(message.n)
+                .filter(|n| *n > 0)
+                .as_ref()
+                .map(ToString::to_string)
+                .unwrap_or_else(|| "∞".into()),
+            node_id.short_str()
+        );
+
+        Ok(self.stream_peers(peers))
     }
 }

--- a/comms/dht/src/rpc/test.rs
+++ b/comms/dht/src/rpc/test.rs
@@ -21,7 +21,7 @@
 //  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 use crate::{
-    proto::rpc::GetPeersRequest,
+    proto::rpc::GetCloserPeersRequest,
     rpc::{DhtRpcService, DhtRpcServiceImpl},
     test_utils::build_peer_manager,
 };
@@ -31,34 +31,36 @@ use tari_comms::{
     peer_manager::{node_id::NodeDistance, PeerFeatures},
     protocol::rpc::{mock::RpcRequestMock, RpcStatusCode},
     test_utils::node_identity::{build_node_identity, ordered_node_identities_by_distance},
-    NodeIdentity,
     PeerManager,
 };
 
-fn setup(node_identity: Arc<NodeIdentity>) -> (DhtRpcServiceImpl, RpcRequestMock, Arc<PeerManager>) {
+fn setup() -> (DhtRpcServiceImpl, RpcRequestMock, Arc<PeerManager>) {
     let peer_manager = build_peer_manager();
     let mock = RpcRequestMock::new(peer_manager.clone());
-    let service = DhtRpcServiceImpl::new(node_identity, peer_manager.clone());
+    let service = DhtRpcServiceImpl::new(peer_manager.clone());
 
     (service, mock, peer_manager)
 }
 
-// Unit tests for get_peers request
-mod get_peers {
+// Unit tests for get_closer_peers request
+mod get_closer_peers {
     use super::*;
-    use tari_comms::peer_manager::Peer;
+    use tari_comms::peer_manager::{NodeId, Peer};
+    use tari_utilities::ByteArray;
 
     #[tokio_macros::test_basic]
     async fn it_returns_empty_peer_stream() {
+        let (service, mock, _) = setup();
         let node_identity = build_node_identity(PeerFeatures::COMMUNICATION_NODE);
-        let (service, mock, _) = setup(node_identity.clone());
-        let req = GetPeersRequest {
+        let req = GetCloserPeersRequest {
             n: 10,
-            ..Default::default()
+            excluded: vec![],
+            closer_to: node_identity.node_id().to_vec(),
+            include_clients: false,
         };
 
         let req = mock.request_with_context(node_identity.node_id().clone(), req);
-        let mut peers_stream = service.get_peers(req).await.unwrap();
+        let mut peers_stream = service.get_closer_peers(req).await.unwrap();
         let next = peers_stream.next().await;
         // Empty stream
         assert_eq!(next.is_none(), true);
@@ -66,19 +68,21 @@ mod get_peers {
 
     #[tokio_macros::test_basic]
     async fn it_returns_closest_peers() {
+        let (service, mock, peer_manager) = setup();
         let node_identity = build_node_identity(PeerFeatures::COMMUNICATION_NODE);
-        let (service, mock, peer_manager) = setup(node_identity.clone());
         let peers = ordered_node_identities_by_distance(node_identity.node_id(), 10, PeerFeatures::COMMUNICATION_NODE);
         for peer in &peers {
             peer_manager.add_peer(peer.to_peer()).await.unwrap();
         }
-        let req = GetPeersRequest {
+        let req = GetCloserPeersRequest {
             n: 15,
-            ..Default::default()
+            excluded: vec![],
+            closer_to: node_identity.node_id().to_vec(),
+            include_clients: false,
         };
 
         let req = mock.request_with_context(node_identity.node_id().clone(), req);
-        let peers_stream = service.get_peers(req).await.unwrap();
+        let peers_stream = service.get_closer_peers(req).await.unwrap();
         let results = peers_stream.into_inner().collect::<Vec<_>>().await;
         assert_eq!(results.len(), 10);
 
@@ -99,49 +103,164 @@ mod get_peers {
 
     #[tokio_macros::test_basic]
     async fn it_returns_n_peers() {
+        let (service, mock, peer_manager) = setup();
+
         let node_identity = build_node_identity(PeerFeatures::COMMUNICATION_NODE);
-        let (service, mock, peer_manager) = setup(node_identity.clone());
         let peers = ordered_node_identities_by_distance(node_identity.node_id(), 6, PeerFeatures::COMMUNICATION_NODE);
         for peer in &peers {
             peer_manager.add_peer(peer.to_peer()).await.unwrap();
         }
-        let req = GetPeersRequest {
+        let req = GetCloserPeersRequest {
             n: 5,
-            ..Default::default()
+            excluded: vec![],
+            closer_to: node_identity.node_id().to_vec(),
+            include_clients: false,
         };
 
         let req = mock.request_with_context(node_identity.node_id().clone(), req);
-        let peers_stream = service.get_peers(req).await.unwrap();
+        let peers_stream = service.get_closer_peers(req).await.unwrap();
         let results = peers_stream.collect::<Vec<_>>().await;
         assert_eq!(results.len(), 5);
     }
 
     #[tokio_macros::test_basic]
-    async fn it_errors_if_maximum_n_exceeded() {
+    async fn it_skips_excluded_peers() {
+        let (service, mock, peer_manager) = setup();
+
         let node_identity = build_node_identity(PeerFeatures::COMMUNICATION_NODE);
-        let (service, mock, _) = setup(node_identity.clone());
-        let req = GetPeersRequest {
+        let peers = ordered_node_identities_by_distance(node_identity.node_id(), 5, PeerFeatures::COMMUNICATION_NODE);
+        for peer in &peers {
+            peer_manager.add_peer(peer.to_peer()).await.unwrap();
+        }
+        let excluded_peer = peers.last().unwrap();
+        let req = GetCloserPeersRequest {
+            n: 100,
+            excluded: vec![excluded_peer.node_id().to_vec()],
+            closer_to: node_identity.node_id().to_vec(),
+            include_clients: true,
+        };
+
+        let req = mock.request_with_context(node_identity.node_id().clone(), req);
+        let peers_stream = service.get_closer_peers(req).await.unwrap();
+        let results = peers_stream.into_inner().collect::<Vec<_>>().await;
+        let mut peers = results.into_iter().map(Result::unwrap).map(|r| r.peer.unwrap());
+        assert!(peers.all(|p| p.public_key != excluded_peer.public_key().as_bytes()));
+    }
+
+    #[tokio_macros::test_basic]
+    async fn it_errors_if_maximum_n_exceeded() {
+        let (service, mock, _) = setup();
+        let req = GetCloserPeersRequest {
             n: 5_000,
             ..Default::default()
         };
 
-        let req = mock.request_with_context(node_identity.node_id().clone(), req);
-        let err = service.get_peers(req).await.unwrap_err();
+        let node_id = NodeId::default();
+        let req = mock.request_with_context(node_id, req);
+        let err = service.get_closer_peers(req).await.unwrap_err();
         assert_eq!(err.status_code(), RpcStatusCode::BadRequest);
     }
+}
+
+mod get_peers {
+    use super::*;
+    use crate::proto::rpc::GetPeersRequest;
+    use tari_comms::{peer_manager::Peer, test_utils::node_identity::build_many_node_identities};
 
     #[tokio_macros::test_basic]
-    async fn it_errors_if_client_node() {
-        let node_identity = build_node_identity(PeerFeatures::COMMUNICATION_CLIENT);
-        let (service, mock, _) = setup(node_identity.clone());
+    async fn it_returns_empty_peer_stream() {
+        let (service, mock, _) = setup();
+        let node_identity = build_node_identity(PeerFeatures::COMMUNICATION_NODE);
         let req = GetPeersRequest {
-            n: 5,
-            ..Default::default()
+            n: 10,
+            include_clients: false,
         };
 
         let req = mock.request_with_context(node_identity.node_id().clone(), req);
-        let err = service.get_peers(req).await.unwrap_err();
-        assert_eq!(err.status_code(), RpcStatusCode::UnsupportedMethod);
-        assert_eq!(err.details(), "get_peers is not supported");
+        let mut peers_stream = service.get_peers(req).await.unwrap();
+        let next = peers_stream.next().await;
+        // Empty stream
+        assert_eq!(next.is_none(), true);
+    }
+
+    #[tokio_macros::test_basic]
+    async fn it_returns_all_peers() {
+        let (service, mock, peer_manager) = setup();
+        let nodes = build_many_node_identities(3, PeerFeatures::COMMUNICATION_NODE);
+        let clients = build_many_node_identities(2, PeerFeatures::COMMUNICATION_CLIENT);
+        for peer in nodes.iter().chain(clients.iter()) {
+            peer_manager.add_peer(peer.to_peer()).await.unwrap();
+        }
+        let req = GetPeersRequest {
+            n: 0,
+            include_clients: true,
+        };
+
+        let peers_stream = service
+            .get_peers(mock.request_with_context(Default::default(), req))
+            .await
+            .unwrap();
+        let results = peers_stream.into_inner().collect::<Vec<_>>().await;
+        assert_eq!(results.len(), 5);
+
+        let peers = results
+            .into_iter()
+            .map(Result::unwrap)
+            .map(|r| r.peer.unwrap())
+            .map(|p| p.try_into().unwrap())
+            .collect::<Vec<Peer>>();
+
+        assert_eq!(peers.iter().filter(|p| p.features.is_client()).count(), 2);
+        assert_eq!(peers.iter().filter(|p| p.features.is_node()).count(), 3);
+    }
+
+    #[tokio_macros::test_basic]
+    async fn it_excludes_clients() {
+        let (service, mock, peer_manager) = setup();
+        let nodes = build_many_node_identities(3, PeerFeatures::COMMUNICATION_NODE);
+        let clients = build_many_node_identities(2, PeerFeatures::COMMUNICATION_CLIENT);
+        for peer in nodes.iter().chain(clients.iter()) {
+            peer_manager.add_peer(peer.to_peer()).await.unwrap();
+        }
+        let req = GetPeersRequest {
+            n: 0,
+            include_clients: false,
+        };
+
+        let peers_stream = service
+            .get_peers(mock.request_with_context(Default::default(), req))
+            .await
+            .unwrap();
+        let results = peers_stream.into_inner().collect::<Vec<_>>().await;
+        assert_eq!(results.len(), 3);
+
+        let peers = results
+            .into_iter()
+            .map(Result::unwrap)
+            .map(|r| r.peer.unwrap())
+            .map(|p| p.try_into().unwrap())
+            .collect::<Vec<Peer>>();
+
+        assert!(peers.iter().all(|p| p.features.is_node()));
+    }
+
+    #[tokio_macros::test_basic]
+    async fn it_returns_n_peers() {
+        let (service, mock, peer_manager) = setup();
+
+        let node_identity = build_node_identity(PeerFeatures::COMMUNICATION_NODE);
+        let peers = build_many_node_identities(3, PeerFeatures::COMMUNICATION_NODE);
+        for peer in &peers {
+            peer_manager.add_peer(peer.to_peer()).await.unwrap();
+        }
+        let req = GetPeersRequest {
+            n: 2,
+            include_clients: false,
+        };
+
+        let req = mock.request_with_context(node_identity.node_id().clone(), req);
+        let peers_stream = service.get_peers(req).await.unwrap();
+        let results = peers_stream.collect::<Vec<_>>().await;
+        assert_eq!(results.len(), 2);
     }
 }

--- a/comms/src/protocol/rpc/client.rs
+++ b/comms/src/protocol/rpc/client.rs
@@ -209,7 +209,7 @@ impl RpcClientConfig {
 impl Default for RpcClientConfig {
     fn default() -> Self {
         Self {
-            deadline: Some(Duration::from_secs(100)),
+            deadline: Some(Duration::from_secs(30)),
             deadline_grace_period: Duration::from_secs(10),
         }
     }
@@ -366,7 +366,7 @@ where TSubstream: AsyncRead + AsyncWrite + Unpin + Send
                 Ok(resp) => {
                     trace!(
                         target: LOG_TARGET,
-                        "Received response from request {} (method={}) in {:.0?} ms",
+                        "Received response from request #{} (method={}) in {:.0?}",
                         request_id,
                         method,
                         start.elapsed()

--- a/comms/src/protocol/rpc/error.rs
+++ b/comms/src/protocol/rpc/error.rs
@@ -58,6 +58,8 @@ pub enum RpcError {
     PeerManagerError(#[from] PeerManagerError),
     #[error("Connectivity error: {0}")]
     ConnectivityError(#[from] ConnectivityError),
+    #[error(transparent)]
+    UnknownError(#[from] anyhow::Error),
 }
 
 impl RpcError {

--- a/comms/src/test_utils/node_identity.rs
+++ b/comms/src/test_utils/node_identity.rs
@@ -35,9 +35,13 @@ pub fn build_node_identity(features: PeerFeatures) -> Arc<NodeIdentity> {
 }
 
 pub fn ordered_node_identities(n: usize, features: PeerFeatures) -> Vec<Arc<NodeIdentity>> {
-    let mut ids = (0..n).map(|_| build_node_identity(features)).collect::<Vec<_>>();
+    let mut ids = build_many_node_identities(n, features);
     ids.sort_unstable_by(|a, b| a.node_id().cmp(b.node_id()));
     ids
+}
+
+pub fn build_many_node_identities(n: usize, features: PeerFeatures) -> Vec<Arc<NodeIdentity>> {
+    (0..n).map(|_| build_node_identity(features)).collect()
 }
 
 pub fn ordered_node_identities_by_distance(
@@ -46,7 +50,7 @@ pub fn ordered_node_identities_by_distance(
     features: PeerFeatures,
 ) -> Vec<Arc<NodeIdentity>>
 {
-    let mut ids = (0..n).map(|_| build_node_identity(features)).collect::<Vec<_>>();
+    let mut ids = build_many_node_identities(n, features);
     ids.sort_unstable_by(|a, b| a.node_id().distance(node_id).cmp(&b.node_id().distance(node_id)));
     ids
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

DHT RPC changes:
- `get_peers` now returns all peers
- `get_closest_peers` returns `n` peers closer to the given node id
- Added `include_clients` bool flag to indicate if client nodes should
  be returned
- New / updated unit tests

Network discovery changes:
- Added "on connect" mode. Initially, network discovery is "active" insofar
  as it actively connects to and seeks peers closer to the node's
  neighbourhood.  Once no more neighbouring nodes can be found,
  the network discovery enters "on connect" mode which syncs whenever a
  (non-client) peer connects.
- `DiscoveryReady` emits `OnConnectMode` event if no more peers are left
  to sync

Comms RPC changes:
- Changed default RPC client deadline to 30s from 100s

This change is backward compatible with previous `t/dht/1` clients. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This strategy is much more aggressive than the last iteration and allows peer lists to be synced more effectively.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Unit tests added/updated. Tested on base node with only seed peers 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [x] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [x] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch.
* [x] I ran `cargo-fmt --all` before pushing.
* [x] I ran `cargo test` successfully before submitting my PR.
* [x] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
