### PR TITLE
Remove banned or disconnected peers from chain metadata round

### DIFF
--- a/base_layer/core/src/base_node/chain_metadata_service/service.rs
+++ b/base_layer/core/src/base_node/chain_metadata_service/service.rs
@@ -34,7 +34,11 @@ use log::*;
 use prost::Message;
 use std::{sync::Arc, time::Instant};
 use tari_common::log_if_error;
-use tari_comms::{message::MessageExt, peer_manager::NodeId};
+use tari_comms::{
+    connectivity::{ConnectivityEvent, ConnectivityRequester},
+    message::MessageExt,
+    peer_manager::NodeId,
+};
 use tari_p2p::services::liveness::{LivenessEvent, LivenessHandle, Metadata, MetadataKey};
 use tokio::sync::broadcast;
 
@@ -43,6 +47,7 @@ pub(super) struct ChainMetadataService {
     base_node: LocalNodeCommsInterface,
     peer_chain_metadata: Vec<PeerChainMetadata>,
     last_chainstate_flushed_at: Option<Instant>,
+    connectivity: ConnectivityRequester,
     event_publisher: broadcast::Sender<Arc<ChainMetadataEvent>>,
 }
 
@@ -55,6 +60,7 @@ impl ChainMetadataService {
     pub fn new(
         liveness: LivenessHandle,
         base_node: LocalNodeCommsInterface,
+        connectivity: ConnectivityRequester,
         event_publisher: broadcast::Sender<Arc<ChainMetadataEvent>>,
     ) -> Self
     {
@@ -63,6 +69,7 @@ impl ChainMetadataService {
             base_node,
             peer_chain_metadata: Vec::new(),
             last_chainstate_flushed_at: None,
+            connectivity,
             event_publisher,
         }
     }
@@ -71,6 +78,7 @@ impl ChainMetadataService {
     pub async fn run(mut self) {
         let mut liveness_event_stream = self.liveness.get_event_stream().fuse();
         let mut block_event_stream = self.base_node.get_block_event_stream().fuse();
+        let mut connectivity_events = self.connectivity.get_event_subscription().fuse();
 
         log_if_error!(
             target: LOG_TARGET,
@@ -101,11 +109,33 @@ impl ChainMetadataService {
                     }
                 },
 
+                event = connectivity_events.select_next_some() => {
+                    if let Ok(event) = event {
+                        self.handle_connectivity_event(&*event);
+                    }
+                }
+
                 complete => {
                     info!(target: LOG_TARGET, "ChainStateSyncService is exiting because all tasks have completed");
                     break;
                 }
             }
+        }
+    }
+
+    fn handle_connectivity_event(&mut self, event: &ConnectivityEvent) {
+        use ConnectivityEvent::*;
+        match event {
+            PeerDisconnected(node_id) | ManagedPeerDisconnected(node_id) | PeerBanned(node_id) => {
+                if let Some(pos) = self.peer_chain_metadata.iter().position(|p| &p.node_id == node_id) {
+                    debug!(
+                        target: LOG_TARGET,
+                        "Removing banned peer `{}` from chain metadata list ", node_id
+                    );
+                    self.peer_chain_metadata.remove(pos);
+                }
+            },
+            _ => {},
         }
     }
 
@@ -123,12 +153,12 @@ impl ChainMetadataService {
         Ok(())
     }
 
-    /// Send this node's metadata to
+    /// Tack this node's metadata on to ping/pongs sent by the liveness service
     async fn update_liveness_chain_metadata(&mut self) -> Result<(), ChainMetadataSyncError> {
         let chain_metadata = self.base_node.get_metadata().await?;
         let bytes = proto::ChainMetadata::from(chain_metadata).to_encoded_bytes();
         self.liveness
-            .set_pong_metadata_entry(MetadataKey::ChainMetadata, bytes)
+            .set_metadata_entry(MetadataKey::ChainMetadata, bytes)
             .await?;
         Ok(())
     }
@@ -271,14 +301,22 @@ mod test {
     use super::*;
     use crate::base_node::comms_interface::{CommsInterfaceError, NodeCommsRequest, NodeCommsResponse};
     use std::convert::TryInto;
-    use tari_p2p::services::liveness::{mock::create_p2p_liveness_mock, LivenessRequest, PingPongEvent};
+    use tari_comms::test_utils::{
+        mocks::{create_connectivity_mock, ConnectivityManagerMockState},
+        node_identity::build_many_node_identities,
+    };
+    use tari_p2p::services::liveness::{
+        mock::{create_p2p_liveness_mock, LivenessMockState},
+        LivenessRequest,
+        PingPongEvent,
+    };
     use tari_service_framework::reply_channel;
-    use tari_test_utils::{runtime, unpack_enum};
-    use tokio::sync::broadcast;
+    use tari_test_utils::unpack_enum;
+    use tokio::{sync::broadcast, task};
 
     fn create_base_node_nci() -> (
         LocalNodeCommsInterface,
-        reply_channel::Receiver<NodeCommsRequest, Result<NodeCommsResponse, CommsInterfaceError>>,
+        reply_channel::TryReceiver<NodeCommsRequest, NodeCommsResponse, CommsInterfaceError>,
     ) {
         let (base_node_sender, base_node_receiver) = reply_channel::unbounded();
         let (block_sender, _block_receiver) = reply_channel::unbounded();
@@ -298,45 +336,63 @@ mod test {
         }
     }
 
-    #[test]
-    fn update_liveness_chain_metadata() {
-        runtime::test_async(|rt| {
-            let (liveness_handle, liveness_mock, _) = create_p2p_liveness_mock(1);
-            let liveness_mock_state = liveness_mock.get_mock_state();
-            rt.spawn(liveness_mock.run());
+    fn setup() -> (
+        ChainMetadataService,
+        LivenessMockState,
+        ConnectivityManagerMockState,
+        reply_channel::TryReceiver<NodeCommsRequest, NodeCommsResponse, CommsInterfaceError>,
+    ) {
+        let (liveness_handle, mock, _) = create_p2p_liveness_mock(1);
+        let liveness_mock_state = mock.get_mock_state();
+        task::spawn(mock.run());
 
-            let (base_node, mut base_node_receiver) = create_base_node_nci();
+        let (base_node, base_node_receiver) = create_base_node_nci();
+        let (publisher, _) = broadcast::channel(1);
 
-            let (publisher, _) = broadcast::channel(1);
-            let mut service = ChainMetadataService::new(liveness_handle, base_node, publisher);
+        let (connectivity, mock) = create_connectivity_mock();
+        let connectivity_mock_state = mock.get_shared_state();
+        task::spawn(mock.run());
 
-            let mut proto_chain_metadata = create_sample_proto_chain_metadata();
-            proto_chain_metadata.height_of_longest_chain = Some(123);
-            let chain_metadata = proto_chain_metadata.clone().try_into().unwrap();
+        let service = ChainMetadataService::new(liveness_handle, base_node, connectivity, publisher);
 
-            rt.spawn(async move {
-                let base_node_req = base_node_receiver.select_next_some().await;
-                let (_req, reply_tx) = base_node_req.split();
-                reply_tx
-                    .send(Ok(NodeCommsResponse::ChainMetadata(chain_metadata)))
-                    .unwrap();
-            });
-
-            rt.block_on(service.update_liveness_chain_metadata()).unwrap();
-
-            assert_eq!(liveness_mock_state.call_count(), 1);
-
-            let last_call = liveness_mock_state.take_calls().remove(0);
-            unpack_enum!(LivenessRequest::SetPongMetadata(metadata_key, data) = last_call);
-            assert_eq!(metadata_key, MetadataKey::ChainMetadata);
-            let chain_metadata = proto::ChainMetadata::decode(data.as_slice()).unwrap();
-            assert_eq!(chain_metadata.height_of_longest_chain, Some(123));
-        });
+        (
+            service,
+            liveness_mock_state,
+            connectivity_mock_state,
+            base_node_receiver,
+        )
     }
 
     #[tokio_macros::test]
+    async fn update_liveness_chain_metadata() {
+        let (mut service, liveness_mock_state, _, mut base_node_receiver) = setup();
+
+        let mut proto_chain_metadata = create_sample_proto_chain_metadata();
+        proto_chain_metadata.height_of_longest_chain = Some(123);
+        let chain_metadata = proto_chain_metadata.clone().try_into().unwrap();
+
+        task::spawn(async move {
+            let base_node_req = base_node_receiver.select_next_some().await;
+            let (_req, reply_tx) = base_node_req.split();
+            reply_tx
+                .send(Ok(NodeCommsResponse::ChainMetadata(chain_metadata)))
+                .unwrap();
+        });
+
+        service.update_liveness_chain_metadata().await.unwrap();
+
+        assert_eq!(liveness_mock_state.call_count(), 1);
+
+        let last_call = liveness_mock_state.take_calls().remove(0);
+        unpack_enum!(LivenessRequest::SetMetadataEntry(metadata_key, data) = last_call);
+        assert_eq!(metadata_key, MetadataKey::ChainMetadata);
+        let chain_metadata = proto::ChainMetadata::decode(data.as_slice()).unwrap();
+        assert_eq!(chain_metadata.height_of_longest_chain, Some(123));
+    }
+    #[tokio_macros::test_basic]
     async fn handle_liveness_event_ok() {
-        let (liveness_handle, _, _) = create_p2p_liveness_mock(1);
+        let (mut service, _, _, _) = setup();
+
         let mut metadata = Metadata::new();
         let proto_chain_metadata = create_sample_proto_chain_metadata();
         metadata.insert(MetadataKey::ChainMetadata, proto_chain_metadata.to_encoded_bytes());
@@ -347,11 +403,6 @@ mod test {
             node_id: node_id.clone(),
             latency: None,
         };
-
-        let (base_node, _) = create_base_node_nci();
-
-        let (publisher, _) = broadcast::channel(1);
-        let mut service = ChainMetadataService::new(liveness_handle, base_node, publisher);
 
         // To prevent the chain metadata buffer being flushed after receiving a single pong event,
         // extend it's capacity to 2
@@ -367,9 +418,44 @@ mod test {
         );
     }
 
-    #[tokio_macros::test]
+    #[tokio_macros::test_basic]
+    async fn handle_liveness_event_banned_peer() {
+        let (mut service, _, _, _) = setup();
+
+        let mut metadata = Metadata::new();
+        let proto_chain_metadata = create_sample_proto_chain_metadata();
+        metadata.insert(MetadataKey::ChainMetadata, proto_chain_metadata.to_encoded_bytes());
+
+        service.peer_chain_metadata.reserve_exact(3);
+
+        let nodes = build_many_node_identities(2, Default::default());
+        for node in &nodes {
+            let pong_event = PingPongEvent {
+                metadata: metadata.clone(),
+                node_id: node.node_id().clone(),
+                latency: None,
+            };
+
+            let sample_event = LivenessEvent::ReceivedPong(Box::new(pong_event));
+            service.handle_liveness_event(&sample_event).await.unwrap();
+        }
+
+        assert!(service
+            .peer_chain_metadata
+            .iter()
+            .any(|p| &p.node_id == nodes[0].node_id()));
+        service.handle_connectivity_event(&ConnectivityEvent::PeerBanned(nodes[0].node_id().clone()));
+        // Check that banned peer was removed
+        assert!(service
+            .peer_chain_metadata
+            .iter()
+            .all(|p| &p.node_id != nodes[0].node_id()));
+    }
+
+    #[tokio_macros::test_basic]
     async fn handle_liveness_event_no_metadata() {
-        let (liveness_handle, _, _) = create_p2p_liveness_mock(1);
+        let (mut service, _, _, _) = setup();
+
         let metadata = Metadata::new();
         let node_id = NodeId::new();
         let pong_event = PingPongEvent {
@@ -378,19 +464,16 @@ mod test {
             latency: None,
         };
 
-        let (base_node, _) = create_base_node_nci();
-        let (publisher, _) = broadcast::channel(1);
-        let mut service = ChainMetadataService::new(liveness_handle, base_node, publisher);
-
         let sample_event = LivenessEvent::ReceivedPong(Box::new(pong_event));
         let err = service.handle_liveness_event(&sample_event).await.unwrap_err();
         unpack_enum!(ChainMetadataSyncError::NoChainMetadata = err);
         assert_eq!(service.peer_chain_metadata.len(), 0);
     }
 
-    #[tokio_macros::test]
+    #[tokio_macros::test_basic]
     async fn handle_liveness_event_bad_metadata() {
-        let (liveness_handle, _, _) = create_p2p_liveness_mock(1);
+        let (mut service, _, _, _) = setup();
+
         let mut metadata = Metadata::new();
         metadata.insert(MetadataKey::ChainMetadata, b"no-good".to_vec());
         let node_id = NodeId::new();
@@ -399,10 +482,6 @@ mod test {
             node_id,
             latency: None,
         };
-
-        let (base_node, _) = create_base_node_nci();
-        let (publisher, _) = broadcast::channel(1);
-        let mut service = ChainMetadataService::new(liveness_handle, base_node, publisher);
 
         let sample_event = LivenessEvent::ReceivedPong(Box::new(pong_event));
         let err = service.handle_liveness_event(&sample_event).await.unwrap_err();

--- a/base_layer/core/tests/helpers/nodes.rs
+++ b/base_layer/core/tests/helpers/nodes.rs
@@ -450,6 +450,7 @@ fn setup_base_node_services(
 
     let fut = StackBuilder::new(shutdown.to_signal())
         .add_initializer(RegisterHandle::new(dht))
+        .add_initializer(RegisterHandle::new(comms.connectivity()))
         .add_initializer(LivenessInitializer::new(
             liveness_service_config,
             Arc::clone(&subscription_factory),

--- a/base_layer/p2p/src/services/liveness/handle.rs
+++ b/base_layer/p2p/src/services/liveness/handle.rs
@@ -39,8 +39,8 @@ pub enum LivenessRequest {
     GetPongCount,
     /// Get average latency for node ID
     GetAvgLatency(NodeId),
-    /// Set the metadata attached to each pong message
-    SetPongMetadata(MetadataKey, Vec<u8>),
+    /// Set the metadata attached to each ping/pong message
+    SetMetadataEntry(MetadataKey, Vec<u8>),
 }
 
 /// Response type for `LivenessService`
@@ -138,8 +138,12 @@ impl LivenessHandle {
     }
 
     /// Set metadata entry for the pong message
-    pub async fn set_pong_metadata_entry(&mut self, key: MetadataKey, value: Vec<u8>) -> Result<(), LivenessError> {
-        match self.handle.call(LivenessRequest::SetPongMetadata(key, value)).await?? {
+    pub async fn set_metadata_entry(&mut self, key: MetadataKey, value: Vec<u8>) -> Result<(), LivenessError> {
+        match self
+            .handle
+            .call(LivenessRequest::SetMetadataEntry(key, value))
+            .await??
+        {
             LivenessResponse::Ok => Ok(()),
             _ => Err(LivenessError::UnexpectedApiResponse),
         }

--- a/base_layer/p2p/src/services/liveness/service.rs
+++ b/base_layer/p2p/src/services/liveness/service.rs
@@ -235,7 +235,7 @@ where
                 let latency = self.state.get_avg_latency_ms(&node_id);
                 Ok(LivenessResponse::AvgLatency(latency))
             },
-            SetPongMetadata(key, value) => {
+            SetMetadataEntry(key, value) => {
                 self.state.set_metadata_entry(key, value);
                 Ok(LivenessResponse::Ok)
             },


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR allows the chain meta service to react to banned peers
by removing them from its internal collection. This ensures that newly
banned peers cannot make it into a chain metadata round result, which in
turn causes the base node state machine to attempt to sync from a banned
peer.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Ref #2302 and #2309 

This PR should remove the possibility that peers that have been banned can be 
included in the chain metadata provided to the base node state machine.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Added a single unit test. Tested that this PR almost eliminates (unlucky "just didn't make it" race conditions aside) the 
chance of banned peers from making it to the base node state machine through manual base node testing.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [x] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [x] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch.
* [x] I ran `cargo-fmt --all` before pushing.
* [ ] I ran `cargo test` successfully before submitting my PR.
* [x] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
