### PR TITLE
Add resilient bootstrap detection

### DIFF
--- a/base_layer/core/src/base_node/state_machine_service/states/block_sync.rs
+++ b/base_layer/core/src/base_node/state_machine_service/states/block_sync.rs
@@ -229,6 +229,11 @@ impl BestChainMetadataBlockSync {
         match synchronize_blocks(shared, network_tip, sync_peers).await {
             Ok(_) => {
                 info!(target: LOG_TARGET, "Block sync state has synchronised.");
+                if !shared.bootstrapped_sync {
+                    debug!(target: LOG_TARGET, "Initial sync achieved, bootstrap done",);
+                    shared.bootstrapped_sync = true;
+                    shared.publish_event_info();
+                }
                 StateEvent::BlocksSynchronized
             },
             Err(BlockSyncError::MaxRequestAttemptsReached) => {

--- a/base_layer/core/src/base_node/state_machine_service/states/forward_block_sync.rs
+++ b/base_layer/core/src/base_node/state_machine_service/states/forward_block_sync.rs
@@ -67,6 +67,11 @@ impl ForwardBlockSyncInfo {
         match synchronize_blocks(shared, sync_peers).await {
             Ok(StateEvent::BlocksSynchronized) => {
                 info!(target: LOG_TARGET, "Block sync state has synchronised");
+                if !shared.bootstrapped_sync {
+                    debug!(target: LOG_TARGET, "Initial sync achieved, bootstrap done",);
+                    shared.bootstrapped_sync = true;
+                    shared.publish_event_info();
+                }
                 StateEvent::BlocksSynchronized
             },
             Ok(state_event) => state_event,

--- a/base_layer/core/src/base_node/state_machine_service/states/listening.rs
+++ b/base_layer/core/src/base_node/state_machine_service/states/listening.rs
@@ -131,13 +131,17 @@ impl Listening {
                         let sync_peers = select_sync_peers(local_tip_height, &best_metadata, &peer_metadata_list);
 
                         let sync_mode = determine_sync_mode(&local, best_metadata, sync_peers);
-                        if !shared.bootstrapped_sync && sync_mode == SyncStatus::UpToDate {
-                            shared.bootstrapped_sync = true;
-                        }
                         if sync_mode.is_lagging() {
                             debug!(target: LOG_TARGET, "{}", sync_mode);
                             return StateEvent::FallenBehind(sync_mode);
                         } else {
+                            if !shared.bootstrapped_sync && sync_mode == SyncStatus::UpToDate {
+                                shared.bootstrapped_sync = true;
+                                debug!(
+                                    target: LOG_TARGET,
+                                    "Initial sync achieved, bootstrap done: {}", sync_mode
+                                );
+                            }
                             self.is_synced = true;
                             shared
                                 .set_state_info(StateInfo::Listening(ListeningInfo::new(true)))


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Detecting bootstrap based on accumulated difficulty comparison is not always successful, as peers can supply a different accumulated difficulty for the same block height as part of their blockchain metadata. This detection will always yield a positive result whenever the `c::bn::state_machine_service::states::block_sync` service synchronized missing blocks the first time around and added them to the database successfully.

DEBUG logs after this change:
``` rust
2020-10-08 14:21:39.293983200 [c::bn::transaction_protocols_and_utxo_validation] DEBUG Waiting for initial sync before performing TXO validation and restarting of broadcast and transaction protocols.
2020-10-08 14:22:08.945049800 [c::bn::state_machine_service::states::block_sync] DEBUG Initial sync achieved, bootstrap done
2020-10-08 14:22:08.945049800 [c::bn::transaction_protocols_and_utxo_validation] DEBUG Initial sync achieved, performing TXO validation and restarting protocols.
```

## Motivation and Context
During testing, it was found that sometimes the initial sync state was not reached, where in actual fact the blockchain has been synced for many hours. A more robust method to determine the initial sync status is therefore needed.

## How Has This Been Tested?
Tested in a base node on Windows

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [X] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [X] I'm merging against the `development` branch.
* [X] I ran `cargo-fmt --all` before pushing.
* [X] I ran `cargo test` successfully before submitting my PR.
* [X] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [X] I have added tests to cover my changes.
