### PR TITLE
Add missing connectivity handle for state machine tests

### DIFF
--- a/base_layer/core/tests/helpers/nodes.rs
+++ b/base_layer/core/tests/helpers/nodes.rs
@@ -450,6 +450,7 @@ fn setup_base_node_services(
 
     let fut = StackBuilder::new(shutdown.to_signal())
         .add_initializer(RegisterHandle::new(dht))
+        .add_initializer(RegisterHandle::new(comms.connectivity()))
         .add_initializer(LivenessInitializer::new(
             liveness_service_config,
             Arc::clone(&subscription_factory),


### PR DESCRIPTION
Fixes `tari_core::node_state_machine` tests by registering a missing
handle in the test node builder.
