### PR TITLE
Improvements for tie breaking comms, connection manager cleanup

### DIFF
--- a/applications/tari_base_node/src/parser.rs
+++ b/applications/tari_base_node/src/parser.rs
@@ -55,7 +55,6 @@ use strum::IntoEnumIterator;
 use strum_macros::{Display, EnumIter, EnumString};
 use tari_common::GlobalConfig;
 use tari_comms::{
-    connection_manager::ConnectionManagerRequester,
     connectivity::ConnectivityRequester,
     peer_manager::{NodeId, Peer, PeerFeatures, PeerManager, PeerManagerError, PeerQuery},
     types::CommsPublicKey,
@@ -140,7 +139,6 @@ pub struct Parser {
     base_node_identity: Arc<NodeIdentity>,
     peer_manager: Arc<PeerManager>,
     wallet_peer_manager: Arc<PeerManager>,
-    connection_manager: ConnectionManagerRequester,
     connectivity: ConnectivityRequester,
     wallet_connectivity: ConnectivityRequester,
     commands: Vec<String>,
@@ -201,7 +199,6 @@ impl Parser {
             base_node_identity: ctx.base_node_identity(),
             peer_manager: ctx.base_node_comms().peer_manager(),
             wallet_peer_manager: ctx.wallet_comms().peer_manager(),
-            connection_manager: ctx.base_node_comms().connection_manager(),
             connectivity: ctx.base_node_comms().connectivity(),
             wallet_connectivity: ctx.wallet_comms().connectivity(),
             commands: BaseNodeCommand::iter().map(|x| x.to_string()).collect(),
@@ -1310,11 +1307,11 @@ impl Parser {
 
     /// Function to process the list-connections command
     fn process_list_connections(&self) {
-        let mut connection_manager = self.connection_manager.clone();
+        let mut connectivity = self.connectivity.clone();
         let peer_manager = self.peer_manager.clone();
 
         self.executor.spawn(async move {
-            match connection_manager.get_active_connections().await {
+            match connectivity.get_active_connections().await {
                 Ok(conns) if conns.is_empty() => {
                     println!("No active peer connections.");
                 },

--- a/comms/dht/examples/memorynet.rs
+++ b/comms/dht/examples/memorynet.rs
@@ -198,10 +198,11 @@ async fn main() {
         let count = seed_node[0].comms.peer_manager().count().await;
         let num_connections = seed_node[0]
             .comms
-            .connection_manager()
-            .get_num_active_connections()
+            .connectivity()
+            .get_active_connections()
             .await
-            .unwrap();
+            .unwrap()
+            .len();
         println!("Seed node knows {} peers ({} connections)", count, num_connections);
     }
 

--- a/comms/src/builder/comms_node.rs
+++ b/comms/src/builder/comms_node.rs
@@ -168,6 +168,7 @@ impl UnspawnedCommsNode {
             request_rx: connectivity_rx,
             event_tx: connectivity_requester.get_event_publisher(),
             connection_manager: connection_manager_requester.clone(),
+            node_identity: node_identity.clone(),
             peer_manager: peer_manager.clone(),
             shutdown_signal: shutdown_signal.clone(),
         };

--- a/comms/src/builder/tests.rs
+++ b/comms/src/builder/tests.rs
@@ -54,7 +54,7 @@ use std::{collections::HashSet, convert::identity, hash::Hash, time::Duration};
 use tari_shutdown::{Shutdown, ShutdownSignal};
 use tari_storage::HashmapDatabase;
 use tari_test_utils::{collect_stream, unpack_enum};
-use tokio::sync::broadcast;
+use tokio::{sync::broadcast, task};
 
 async fn spawn_node(
     protocols: Protocols<Substream>,
@@ -282,6 +282,7 @@ async fn peer_to_peer_messaging() {
 
 #[runtime::test_basic]
 async fn peer_to_peer_messaging_simultaneous() {
+    env_logger::init();
     const NUM_MSGS: usize = 10;
     let shutdown = Shutdown::new();
 
@@ -327,8 +328,7 @@ async fn peer_to_peer_messaging_simultaneous() {
         .unwrap();
 
     // Simultaneously send messages between the two nodes
-    let rt_handle = runtime::current();
-    let handle1 = rt_handle.spawn(async move {
+    let handle1 = task::spawn(async move {
         for i in 0..NUM_MSGS {
             let outbound_msg = OutboundMessage::new(
                 node_identity2.node_id().clone(),
@@ -338,7 +338,7 @@ async fn peer_to_peer_messaging_simultaneous() {
         }
     });
 
-    let handle2 = rt_handle.spawn(async move {
+    let handle2 = task::spawn(async move {
         for i in 0..NUM_MSGS {
             let outbound_msg = OutboundMessage::new(
                 node_identity1.node_id().clone(),

--- a/comms/src/connection_manager/requester.rs
+++ b/comms/src/connection_manager/requester.rs
@@ -38,14 +38,6 @@ pub enum ConnectionManagerRequest {
     CancelDial(NodeId),
     /// Register a oneshot to get triggered when the node is listening, or has failed to listen
     NotifyListening(oneshot::Sender<Multiaddr>),
-    /// Retrieve an active connection for a given node id if one exists.
-    GetActiveConnection(NodeId, oneshot::Sender<Option<PeerConnection>>),
-    /// Retrieve all active connections
-    GetActiveConnections(oneshot::Sender<Vec<PeerConnection>>),
-    /// Retrieve the number of active connections
-    GetNumActiveConnections(oneshot::Sender<usize>),
-    /// Disconnect a peer
-    DisconnectPeer(NodeId),
 }
 
 /// Responsible for constructing requests to the ConnectionManagerService
@@ -66,41 +58,7 @@ impl ConnectionManagerRequester {
     }
 }
 
-macro_rules! request_fn {
-   ($name:ident($($param:ident:$param_ty:ty),+) -> $ret:ty, request = $($request:ident)::+ $(,)?) => {
-        pub async fn $name(
-            &mut self,
-            $($param: $param_ty),+
-        ) -> Result<$ret, ConnectionManagerError>
-        {
-            let (reply_tx, reply_rx) = oneshot::channel();
-            self.sender
-                .send($($request)::+($($param),+, reply_tx))
-                .await
-                .map_err(|_| ConnectionManagerError::SendToActorFailed)?;
-            reply_rx.await.map_err(|_| ConnectionManagerError::ActorRequestCanceled)
-        }
-   };
-   ($name:ident() -> $ret:ty, request = $($request:ident)::+ $(,)?) => {
-        pub async fn $name(&mut self) -> Result<$ret, ConnectionManagerError>
-        {
-            let (reply_tx, reply_rx) = oneshot::channel();
-            self.sender
-                .send($($request)::+(reply_tx))
-                .await
-                .map_err(|_| ConnectionManagerError::SendToActorFailed)?;
-            reply_rx.await.map_err(|_| ConnectionManagerError::ActorRequestCanceled)
-        }
-   };
-}
-
 impl ConnectionManagerRequester {
-    request_fn!(get_active_connections() -> Vec<PeerConnection>, request = ConnectionManagerRequest::GetActiveConnections);
-
-    request_fn!(get_num_active_connections() -> usize, request = ConnectionManagerRequest::GetNumActiveConnections);
-
-    request_fn!(get_active_connection(node_id: NodeId) -> Option<PeerConnection>, request = ConnectionManagerRequest::GetActiveConnection);
-
     /// Returns a new ConnectionManagerEvent subscription
     pub fn get_event_subscription(&self) -> broadcast::Receiver<Arc<ConnectionManagerEvent>> {
         self.event_tx.subscribe()
@@ -149,15 +107,6 @@ impl ConnectionManagerRequester {
     pub(crate) async fn send_dial_peer_no_reply(&mut self, node_id: NodeId) -> Result<(), ConnectionManagerError> {
         let (reply_tx, _) = oneshot::channel();
         self.send_dial_peer(node_id, reply_tx).await?;
-        Ok(())
-    }
-
-    /// Disconnect a peer. The peer will disconnect after a preconfigured linger time.
-    pub async fn disconnect_peer(&mut self, node_id: NodeId) -> Result<(), ConnectionManagerError> {
-        self.sender
-            .send(ConnectionManagerRequest::DisconnectPeer(node_id))
-            .await
-            .map_err(|_| ConnectionManagerError::SendToActorFailed)?;
         Ok(())
     }
 

--- a/comms/src/connection_manager/tests/manager.rs
+++ b/comms/src/connection_manager/tests/manager.rs
@@ -287,8 +287,8 @@ async fn simultaneous_dial_events() {
         .collect::<Vec<_>>();
 
     // TODO: Investigate why two PeerDisconnected events are sometimes received
-    // assert!(count_string_occurrences(&events1, &["PeerDisconnected", "PeerConnectWillClose"]) >= 1);
-    // assert!(count_string_occurrences(&events2, &["PeerDisconnected", "PeerConnectWillClose"]) >= 1);
+    // assert!(count_string_occurrences(&events1, &["PeerDisconnected"]) >= 1);
+    // assert!(count_string_occurrences(&events2, &["PeerDisconnected"]) >= 1);
 }
 
 #[tokio_macros::test_basic]

--- a/comms/src/connectivity/config.rs
+++ b/comms/src/connectivity/config.rs
@@ -39,6 +39,9 @@ pub struct ConnectivityConfig {
     /// The number of connection failures before a peer is considered offline
     /// Default: 2
     pub max_failures_mark_offline: usize,
+    /// The length of time to wait before disconnecting a connection that failed tie breaking.
+    /// Default: 1s
+    pub connection_tie_break_linger: Duration,
 }
 
 impl Default for ConnectivityConfig {
@@ -49,6 +52,7 @@ impl Default for ConnectivityConfig {
             reaper_min_inactive_age: Duration::from_secs(60),
             is_connection_reaping_enabled: true,
             max_failures_mark_offline: 2,
+            connection_tie_break_linger: Duration::from_secs(2),
         }
     }
 }

--- a/comms/src/connectivity/connection_pool.rs
+++ b/comms/src/connectivity/connection_pool.rs
@@ -53,6 +53,11 @@ impl PeerConnectionState {
         self.connection.as_ref()
     }
 
+    /// Return true if the underlying connection exists and is connected, otherwise false
+    pub fn is_connected(&self) -> bool {
+        self.connection().filter(|c| c.is_connected()).is_some()
+    }
+
     #[inline]
     pub fn connection_mut(&mut self) -> Option<&mut PeerConnection> {
         self.connection.as_mut()
@@ -152,12 +157,21 @@ impl ConnectionPool {
         self.connections.get(node_id)
     }
 
+    #[inline]
+    pub fn get_mut(&mut self, node_id: &NodeId) -> Option<&mut PeerConnectionState> {
+        self.connections.get_mut(node_id)
+    }
+
     pub fn all(&self) -> Vec<&PeerConnectionState> {
         self.connections.values().collect()
     }
 
     pub fn get_connection(&self, node_id: &NodeId) -> Option<&PeerConnection> {
         self.get(node_id).and_then(|c| c.connection())
+    }
+
+    pub fn get_connection_mut(&mut self, node_id: &NodeId) -> Option<&mut PeerConnection> {
+        self.get_mut(node_id).and_then(|c| c.connection_mut())
     }
 
     pub fn get_connection_status(&self, node_id: &NodeId) -> ConnectionStatus {
@@ -234,6 +248,13 @@ impl ConnectionPool {
                         .filter(|c| c.is_connected() && c.peer_features().is_client())
                         .is_some()
             })
+            .count()
+    }
+
+    pub fn count_connected(&self) -> usize {
+        self.connections
+            .values()
+            .filter(|c| c.status() == ConnectionStatus::Connected || c.status() == ConnectionStatus::Connecting)
             .count()
     }
 

--- a/comms/src/connectivity/error.rs
+++ b/comms/src/connectivity/error.rs
@@ -20,10 +20,10 @@
 //  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 //  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use crate::{connection_manager::ConnectionManagerError, peer_manager::PeerManagerError};
+use crate::{connection_manager::ConnectionManagerError, peer_manager::PeerManagerError, PeerConnectionError};
 use thiserror::Error;
 
-#[derive(Debug, Error, Clone)]
+#[derive(Debug, Error)]
 pub enum ConnectivityError {
     #[error("Cannot send request because ConnectivityActor disconnected")]
     ActorDisconnected,
@@ -31,6 +31,8 @@ pub enum ConnectivityError {
     ActorResponseCancelled,
     #[error("PeerManagerError: {0}")]
     PeerManagerError(#[from] PeerManagerError),
+    #[error("Peer connection error: {0}")]
+    PeerConnectionError(#[from] PeerConnectionError),
     #[error("ConnectionFailed: {0}")]
     ConnectionFailed(ConnectionManagerError),
     #[error("Connectivity event stream closed unexpectedly")]

--- a/comms/src/connectivity/test.rs
+++ b/comms/src/connectivity/test.rs
@@ -70,6 +70,7 @@ fn setup_connectivity_manager(
         config,
         event_tx,
         request_rx,
+        node_identity: node_identity.clone(),
         connection_manager: cm_requester,
         peer_manager: peer_manager.clone(),
         shutdown_signal: shutdown.to_signal(),

--- a/comms/src/protocol/messaging/extension.rs
+++ b/comms/src/protocol/messaging/extension.rs
@@ -26,7 +26,7 @@ use crate::{
     message::InboundMessage,
     pipeline,
     protocol::{
-        messaging::{consts, MessagingEventSender, MESSAGING_PROTOCOL},
+        messaging::{consts, protocol::MESSAGING_PROTOCOL, MessagingEventSender},
         ProtocolExtension,
         ProtocolExtensionContext,
         ProtocolExtensionError,

--- a/comms/src/protocol/messaging/mod.rs
+++ b/comms/src/protocol/messaging/mod.rs
@@ -40,7 +40,6 @@ pub use protocol::{
     MessagingProtocol,
     MessagingRequest,
     SendFailReason,
-    MESSAGING_PROTOCOL,
 };
 
 #[cfg(test)]

--- a/comms/src/protocol/messaging/protocol.rs
+++ b/comms/src/protocol/messaging/protocol.rs
@@ -23,7 +23,7 @@
 use super::error::MessagingProtocolError;
 use crate::{
     compat::IoCompat,
-    connectivity::ConnectivityRequester,
+    connectivity::{ConnectivityEvent, ConnectivityRequester},
     framing,
     message::{InboundMessage, MessageTag, OutboundMessage},
     multiplexing::Substream,
@@ -50,7 +50,7 @@ use tokio::sync::broadcast;
 use tokio_util::codec::{Framed, LengthDelimitedCodec};
 
 const LOG_TARGET: &str = "comms::protocol::messaging";
-pub static MESSAGING_PROTOCOL: Bytes = Bytes::from_static(b"/tari/messaging/0.1.0");
+pub(super) static MESSAGING_PROTOCOL: Bytes = Bytes::from_static(b"/tari/messaging/0.1.0");
 const INTERNAL_MESSAGING_EVENT_CHANNEL_SIZE: usize = 150;
 
 /// The maximum amount of inbound messages to accept within the `RATE_LIMIT_RESTOCK_INTERVAL` window
@@ -121,7 +121,7 @@ impl MessagingProtocol {
     #[allow(clippy::too_many_arguments)]
     pub fn new(
         config: MessagingConfig,
-        connection_manager_requester: ConnectivityRequester,
+        connectivity: ConnectivityRequester,
         proto_notification: mpsc::Receiver<ProtocolNotification<Substream>>,
         request_rx: mpsc::Receiver<MessagingRequest>,
         messaging_events_tx: MessagingEventSender,
@@ -133,7 +133,7 @@ impl MessagingProtocol {
             mpsc::channel(INTERNAL_MESSAGING_EVENT_CHANNEL_SIZE);
         Self {
             config,
-            connectivity: connection_manager_requester,
+            connectivity,
             proto_notification: proto_notification.fuse(),
             request_rx: request_rx.fuse(),
             active_queues: Default::default(),
@@ -152,6 +152,7 @@ impl MessagingProtocol {
 
     pub async fn run(mut self) {
         let mut shutdown_signal = self.shutdown_signal.clone();
+        let mut connectivity_events = self.connectivity.get_event_subscription().fuse();
 
         loop {
             futures::select! {
@@ -169,6 +170,12 @@ impl MessagingProtocol {
                     }
                 },
 
+                event = connectivity_events.select_next_some() => {
+                    if let Ok(event) = event {
+                        self.handle_connectivity_event(&event);
+                    }
+                }
+
                 notification = self.proto_notification.select_next_some() => {
                     self.handle_protocol_notification(notification).await;
                 },
@@ -185,6 +192,21 @@ impl MessagingProtocol {
     pub fn framed<TSubstream>(socket: TSubstream) -> Framed<IoCompat<TSubstream>, LengthDelimitedCodec>
     where TSubstream: AsyncRead + AsyncWrite + Unpin {
         framing::canonical(socket, MAX_FRAME_LENGTH)
+    }
+
+    fn handle_connectivity_event(&mut self, event: &ConnectivityEvent) {
+        use ConnectivityEvent::*;
+        #[allow(clippy::single_match)]
+        match event {
+            PeerConnectionWillClose(node_id, _) => {
+                // If the peer connection will close, cut off the pipe to send further messages.
+                // Any messages in the channel will be sent (hopefully) before the connection is disconnected.
+                if let Some(sender) = self.active_queues.remove(node_id) {
+                    sender.close_channel();
+                }
+            },
+            _ => {},
+        }
     }
 
     async fn handle_internal_messaging_event(&mut self, event: MessagingEvent) {
@@ -295,7 +317,6 @@ impl MessagingProtocol {
     }
 
     async fn handle_protocol_notification(&mut self, notification: ProtocolNotification<Substream>) {
-        debug_assert_eq!(notification.protocol, MESSAGING_PROTOCOL);
         match notification.event {
             // Peer negotiated to speak the messaging protocol with us
             ProtocolEvent::NewInboundSubstream(node_id, substream) => {

--- a/comms/src/protocol/rpc/test/smoke.rs
+++ b/comms/src/protocol/rpc/test/smoke.rs
@@ -215,7 +215,7 @@ async fn timeout() {
     let framed = framing::canonical(socket, 1024);
     let mut client = GreetingClient::builder()
         .with_deadline(Duration::from_millis(100))
-        .with_deadline_grace_period(Duration::from_secs(100))
+        .with_deadline_grace_period(Duration::from_secs(1))
         .connect(framed)
         .await
         .unwrap();

--- a/comms/src/test_utils/mocks/connection_manager.rs
+++ b/comms/src/test_utils/mocks/connection_manager.rs
@@ -146,22 +146,6 @@ impl ConnectionManagerMock {
             },
             CancelDial(_) => {},
             NotifyListening(_reply_tx) => {},
-            GetActiveConnection(node_id, reply_tx) => {
-                reply_tx
-                    .send(self.state.active_conns.lock().await.get(&node_id).map(Clone::clone))
-                    .unwrap();
-            },
-            GetActiveConnections(reply_tx) => {
-                reply_tx
-                    .send(self.state.active_conns.lock().await.values().cloned().collect())
-                    .unwrap();
-            },
-            GetNumActiveConnections(reply_tx) => {
-                reply_tx.send(self.state.active_conns.lock().await.len()).unwrap();
-            },
-            DisconnectPeer(node_id) => {
-                let _ = self.state.active_conns.lock().await.remove(&node_id);
-            },
         }
     }
 }


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Deduplicate the connection state management within comms.
Previously, `ConnectionManager` and `ConnectivityManager` both held `PeerConnection` handles.
This was because the `Connectivity` concept came after the connection
manager and was not refactored at the time. Now the connection state is
contained only within `ConnectivityManager` and `ConnectionManager` is
soley responsible for establishing outbound connections and handling
inbound connections.

Connections closed by tie breaking are now delayed by 2s and the 
`PeerConnectionWillClose` event is emitted to allow components to react to a
connection that will close. The prime use case is the messaging protocol
which can finish sending remaining messages and cut off further messages
from being lost before the connection is closed.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Increase messaging reliability and possibly a fix for #2295

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Existing tests cover this case. Tested on base node, observing connections for >24hours. Wallet to base node connections seem to work (though this case is not reproducible ).

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [x] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch.
* [x] I ran `cargo-fmt --all` before pushing.
* [x] I ran `cargo test` successfully before submitting my PR.
* [x] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
