### PR TITLE
Clean out orphan database at startup (optionally) and before a block sync

### DIFF
--- a/applications/tari_base_node/src/bootstrap/base_node.rs
+++ b/applications/tari_base_node/src/bootstrap/base_node.rs
@@ -131,6 +131,7 @@ where B: BlockchainBackend + 'static
                 self.rules,
                 self.factories,
                 sync_strategy,
+                config.orphan_db_clean_out_threshold,
             ))
             .build()
             .await?;

--- a/applications/tari_base_node/src/main.rs
+++ b/applications/tari_base_node/src/main.rs
@@ -206,6 +206,7 @@ fn main_inner() -> Result<(), ExitCodes> {
             node_identity,
             wallet_identity,
             shutdown.to_signal(),
+            bootstrap.clean_orphans_db,
         ))
         .map_err(|err| {
             error!(target: LOG_TARGET, "{}", err);

--- a/applications/tari_base_node/src/recovery.rs
+++ b/applications/tari_base_node/src/recovery.rs
@@ -103,7 +103,7 @@ pub async fn run_recovery(node_config: &GlobalConfig) -> Result<(), anyhow::Erro
         pruning_horizon: node_config.pruning_horizon,
         pruning_interval: node_config.pruned_mode_cleanup_interval,
     };
-    let db = BlockchainDatabase::new(main_db, &rules, validators, db_config)?;
+    let db = BlockchainDatabase::new(main_db, &rules, validators, db_config, true)?;
     do_recovery(db, temp_db).await?;
 
     info!(
@@ -134,7 +134,8 @@ async fn do_recovery<D: BlockchainBackend + 'static>(
     // We dont care about the values, here, so we just use mock validators, and a mainnet CM.
     let rules = ConsensusManagerBuilder::new(NetworkType::LocalNet).build();
     let validators = Validators::new(MockValidator::new(true), MockValidator::new(true));
-    let temp_db_backend = BlockchainDatabase::new(temp_db, &rules, validators, BlockchainDatabaseConfig::default())?;
+    let temp_db_backend =
+        BlockchainDatabase::new(temp_db, &rules, validators, BlockchainDatabaseConfig::default(), false)?;
     let max_height = temp_db_backend
         .get_chain_metadata()
         .map_err(|e| anyhow!("Could not get max chain height: {}", e))?

--- a/base_layer/core/src/base_node/state_machine_service/states/block_sync.rs
+++ b/base_layer/core/src/base_node/state_machine_service/states/block_sync.rs
@@ -73,6 +73,7 @@ pub struct BlockSyncConfig {
     pub max_add_block_retry_attempts: usize,
     pub header_request_size: usize,
     pub block_request_size: usize,
+    pub orphan_db_clean_out_threshold: usize,
 }
 
 #[derive(Clone, Debug, PartialEq, Default)]
@@ -114,6 +115,7 @@ impl Default for BlockSyncConfig {
             max_add_block_retry_attempts: MAX_ADD_BLOCK_RETRY_ATTEMPTS,
             header_request_size: HEADER_REQUEST_SIZE,
             block_request_size: BLOCK_REQUEST_SIZE,
+            orphan_db_clean_out_threshold: 0,
         }
     }
 }
@@ -325,6 +327,28 @@ async fn synchronize_blocks<B: BlockchainBackend + 'static>(
 
             if let StateInfo::BlockSync(ref mut info) = shared.info {
                 info.tip_height = network_tip_height;
+            }
+
+            // Searching through the orphan database for every block to be added during a large block sync can
+            // be inefficient - this is one way to optimize it by clearing out the database before hand
+            if shared.config.block_sync_config.orphan_db_clean_out_threshold > 0 &&
+                network_tip_height as i64 - sync_height as i64 >
+                    shared.config.block_sync_config.orphan_db_clean_out_threshold as i64
+            {
+                match async_db::cleanup_all_orphans(shared.db.clone()).await {
+                    Ok(_) => info!(
+                        target: LOG_TARGET,
+                        "Orphan database cleaned out in preparation for multiple blocks sync ({} blocks)",
+                        network_tip_height as i64 - sync_height as i64
+                    ),
+                    Err(e) => warn!(
+                        target: LOG_TARGET,
+                        "Orphan database could not be cleaned out ({} blocks) in preparation for multiple blocks \
+                         sync: {:?}.",
+                        network_tip_height as i64 - sync_height as i64,
+                        e,
+                    ),
+                }
             }
 
             while sync_height <= network_tip_height {

--- a/base_layer/core/src/chain_storage/async_db.rs
+++ b/base_layer/core/src/chain_storage/async_db.rs
@@ -123,6 +123,7 @@ make_async!(rewind_to_height(height: u64) -> Vec<Arc<Block>>, "rewind_to_height"
 
 //---------------------------------- Block --------------------------------------------//
 make_async!(add_block(block: Arc<Block>) -> BlockAddResult, "add_block");
+make_async!(cleanup_all_orphans() -> (), "cleanup_all_orphans");
 make_async!(block_exists(block_hash: BlockHash) -> bool, "block_exists");
 make_async!(fetch_block(height: u64) -> HistoricalBlock, "fetch_block");
 make_async!(fetch_orphan(hash: HashOutput) -> Block, "fetch_orphan");

--- a/base_layer/core/src/helpers/mod.rs
+++ b/base_layer/core/src/helpers/mod.rs
@@ -46,5 +46,12 @@ pub fn create_orphan_block(block_height: u64, transactions: Vec<Transaction>, co
 pub fn create_mem_db(consensus_manager: &ConsensusManager) -> BlockchainDatabase<MemoryDatabase<HashDigest>> {
     let validators = Validators::new(MockValidator::new(true), MockValidator::new(true));
     let db = MemoryDatabase::<HashDigest>::default();
-    BlockchainDatabase::new(db, consensus_manager, validators, BlockchainDatabaseConfig::default()).unwrap()
+    BlockchainDatabase::new(
+        db,
+        consensus_manager,
+        validators,
+        BlockchainDatabaseConfig::default(),
+        false,
+    )
+    .unwrap()
 }

--- a/base_layer/core/src/transactions/transaction.rs
+++ b/base_layer/core/src/transactions/transaction.rs
@@ -399,7 +399,7 @@ impl Display for TransactionOutput {
     fn fmt(&self, fmt: &mut Formatter<'_>) -> Result<(), std::fmt::Error> {
         let proof = self.proof.to_hex();
         fmt.write_str(&format!(
-            "{} [{:?}] Proof: {}..{}\n",
+            "({} [{:?}] Proof: {}..{})",
             self.commitment.to_hex(),
             self.features,
             proof[0..16].to_string(),

--- a/base_layer/core/tests/block_validation.rs
+++ b/base_layer/core/tests/block_validation.rs
@@ -37,7 +37,7 @@ fn test_genesis_block() {
         FullConsensusValidator::new(rules.clone()),
         StatelessBlockValidator::new(rules.clone(), factories),
     );
-    let db = BlockchainDatabase::new(backend, &rules, validators, BlockchainDatabaseConfig::default()).unwrap();
+    let db = BlockchainDatabase::new(backend, &rules, validators, BlockchainDatabaseConfig::default(), false).unwrap();
     let block = rules.get_genesis_block();
     let result = db.add_block(block.into()).unwrap();
     assert_eq!(result, BlockAddResult::BlockExists);

--- a/base_layer/core/tests/chain_storage_tests/chain_backend.rs
+++ b/base_layer/core/tests/chain_storage_tests/chain_backend.rs
@@ -109,7 +109,10 @@ fn lmdb_insert_contains_delete_and_fetch_header() {
 
     // Cleanup test data - in Windows the LMBD `set_mapsize` sets file size equals to map size; Linux use sparse files
     if std::path::Path::new(&temp_path).exists() {
-        std::fs::remove_dir_all(&temp_path).unwrap();
+        match std::fs::remove_dir_all(&temp_path) {
+            Err(e) => println!("\n{:?}\n", e),
+            _ => (),
+        }
     }
 }
 
@@ -154,7 +157,10 @@ fn lmdb_insert_contains_delete_and_fetch_utxo() {
 
     // Cleanup test data - in Windows the LMBD `set_mapsize` sets file size equals to map size; Linux use sparse files
     if std::path::Path::new(&temp_path).exists() {
-        std::fs::remove_dir_all(&temp_path).unwrap();
+        match std::fs::remove_dir_all(&temp_path) {
+            Err(e) => println!("\n{:?}\n", e),
+            _ => (),
+        }
     }
 }
 
@@ -200,7 +206,10 @@ fn lmdb_insert_contains_delete_and_fetch_kernel() {
 
     // Cleanup test data - in Windows the LMBD `set_mapsize` sets file size equals to map size; Linux use sparse files
     if std::path::Path::new(&temp_path).exists() {
-        std::fs::remove_dir_all(&temp_path).unwrap();
+        match std::fs::remove_dir_all(&temp_path) {
+            Err(e) => println!("\n{:?}\n", e),
+            _ => (),
+        }
     }
 }
 
@@ -253,7 +262,10 @@ fn lmdb_insert_contains_delete_and_fetch_orphan() {
 
     // Cleanup test data - in Windows the LMBD `set_mapsize` sets file size equals to map size; Linux use sparse files
     if std::path::Path::new(&temp_path).exists() {
-        std::fs::remove_dir_all(&temp_path).unwrap();
+        match std::fs::remove_dir_all(&temp_path) {
+            Err(e) => println!("\n{:?}\n", e),
+            _ => (),
+        }
     }
 }
 
@@ -325,7 +337,10 @@ fn lmdb_spend_utxo_and_unspend_stxo() {
 
     // Cleanup test data - in Windows the LMBD `set_mapsize` sets file size equals to map size; Linux use sparse files
     if std::path::Path::new(&temp_path).exists() {
-        std::fs::remove_dir_all(&temp_path).unwrap();
+        match std::fs::remove_dir_all(&temp_path) {
+            Err(e) => println!("\n{:?}\n", e),
+            _ => (),
+        }
     }
 }
 
@@ -415,7 +430,10 @@ fn lmdb_insert_fetch_metadata() {
 
     // Cleanup test data - in Windows the LMBD `set_mapsize` sets file size equals to map size; Linux use sparse files
     if std::path::Path::new(&temp_path).exists() {
-        std::fs::remove_dir_all(&temp_path).unwrap();
+        match std::fs::remove_dir_all(&temp_path) {
+            Err(e) => println!("\n{:?}\n", e),
+            _ => (),
+        }
     }
 }
 
@@ -501,7 +519,10 @@ fn lmdb_fetch_mmr_root_and_proof_for_utxo_and_rp() {
 
     // Cleanup test data - in Windows the LMBD `set_mapsize` sets file size equals to map size; Linux use sparse files
     if std::path::Path::new(&temp_path).exists() {
-        std::fs::remove_dir_all(&temp_path).unwrap();
+        match std::fs::remove_dir_all(&temp_path) {
+            Err(e) => println!("\n{:?}\n", e),
+            _ => (),
+        }
     }
 }
 
@@ -562,7 +583,10 @@ fn lmdb_fetch_mmr_root_and_proof_for_kernel() {
 
     // Cleanup test data - in Windows the LMBD `set_mapsize` sets file size equals to map size; Linux use sparse files
     if std::path::Path::new(&temp_path).exists() {
-        std::fs::remove_dir_all(&temp_path).unwrap();
+        match std::fs::remove_dir_all(&temp_path) {
+            Err(e) => println!("\n{:?}\n", e),
+            _ => (),
+        }
     }
 }
 
@@ -624,7 +648,10 @@ fn lmdb_fetch_future_mmr_root_for_utxo_and_rp() {
 
     // Cleanup test data - in Windows the LMBD `set_mapsize` sets file size equals to map size; Linux use sparse files
     if std::path::Path::new(&temp_path).exists() {
-        std::fs::remove_dir_all(&temp_path).unwrap();
+        match std::fs::remove_dir_all(&temp_path) {
+            Err(e) => println!("\n{:?}\n", e),
+            _ => (),
+        }
     }
 }
 
@@ -674,7 +701,10 @@ fn lmdb_fetch_future_mmr_root_for_for_kernel() {
 
     // Cleanup test data - in Windows the LMBD `set_mapsize` sets file size equals to map size; Linux use sparse files
     if std::path::Path::new(&temp_path).exists() {
-        std::fs::remove_dir_all(&temp_path).unwrap();
+        match std::fs::remove_dir_all(&temp_path) {
+            Err(e) => println!("\n{:?}\n", e),
+            _ => (),
+        }
     }
 }
 
@@ -792,7 +822,10 @@ fn lmdb_commit_block_and_create_fetch_checkpoint_and_rewind_mmr() {
 
     // Cleanup test data - in Windows the LMBD `set_mapsize` sets file size equals to map size; Linux use sparse files
     if std::path::Path::new(&temp_path).exists() {
-        std::fs::remove_dir_all(&temp_path).unwrap();
+        match std::fs::remove_dir_all(&temp_path) {
+            Err(e) => println!("\n{:?}\n", e),
+            _ => (),
+        }
     }
 }
 
@@ -866,7 +899,10 @@ fn lmdb_for_each_orphan() {
 
     // Cleanup test data - in Windows the LMBD `set_mapsize` sets file size equals to map size; Linux use sparse files
     if std::path::Path::new(&temp_path).exists() {
-        std::fs::remove_dir_all(&temp_path).unwrap();
+        match std::fs::remove_dir_all(&temp_path) {
+            Err(e) => println!("\n{:?}\n", e),
+            _ => (),
+        }
     }
 }
 
@@ -924,7 +960,10 @@ fn lmdb_for_each_kernel() {
 
     // Cleanup test data - in Windows the LMBD `set_mapsize` sets file size equals to map size; Linux use sparse files
     if std::path::Path::new(&temp_path).exists() {
-        std::fs::remove_dir_all(&temp_path).unwrap();
+        match std::fs::remove_dir_all(&temp_path) {
+            Err(e) => println!("\n{:?}\n", e),
+            _ => (),
+        }
     }
 }
 
@@ -982,7 +1021,10 @@ fn lmdb_for_each_header() {
 
     // Cleanup test data - in Windows the LMBD `set_mapsize` sets file size equals to map size; Linux use sparse files
     if std::path::Path::new(&temp_path).exists() {
-        std::fs::remove_dir_all(&temp_path).unwrap();
+        match std::fs::remove_dir_all(&temp_path) {
+            Err(e) => println!("\n{:?}\n", e),
+            _ => (),
+        }
     }
 }
 
@@ -1041,7 +1083,10 @@ fn lmdb_for_each_utxo() {
 
     // Cleanup test data - in Windows the LMBD `set_mapsize` sets file size equals to map size; Linux use sparse files
     if std::path::Path::new(&temp_path).exists() {
-        std::fs::remove_dir_all(&temp_path).unwrap();
+        match std::fs::remove_dir_all(&temp_path) {
+            Err(e) => println!("\n{:?}\n", e),
+            _ => (),
+        }
     }
 }
 
@@ -1104,7 +1149,10 @@ fn lmdb_backend_restore() {
 
     // Cleanup test data - in Windows the LMBD `set_mapsize` sets file size equals to map size; Linux use sparse files
     if std::path::Path::new(&path).exists() {
-        std::fs::remove_dir_all(&path).unwrap();
+        match std::fs::remove_dir_all(&path) {
+            Err(e) => println!("\n{:?}\n", e),
+            _ => (),
+        }
     }
 }
 
@@ -1214,7 +1262,10 @@ fn lmdb_mmr_reset_and_commit() {
 
     // Cleanup test data - in Windows the LMBD `set_mapsize` sets file size equals to map size; Linux use sparse files
     if std::path::Path::new(&temp_path).exists() {
-        std::fs::remove_dir_all(&temp_path).unwrap();
+        match std::fs::remove_dir_all(&temp_path) {
+            Err(e) => println!("\n{:?}\n", e),
+            _ => (),
+        }
     }
 }
 
@@ -1337,7 +1388,10 @@ fn lmdb_fetch_checkpoint() {
 
     // Cleanup test data - in Windows the LMBD `set_mapsize` sets file size equals to map size; Linux use sparse files
     if std::path::Path::new(&temp_path).exists() {
-        std::fs::remove_dir_all(&temp_path).unwrap();
+        match std::fs::remove_dir_all(&temp_path) {
+            Err(e) => println!("\n{:?}\n", e),
+            _ => (),
+        }
     }
 }
 
@@ -1484,7 +1538,10 @@ fn lmdb_merging_and_fetch_checkpoints_and_stxo_discard() {
 
     // Cleanup test data - in Windows the LMBD `set_mapsize` sets file size equals to map size; Linux use sparse files
     if std::path::Path::new(&temp_path).exists() {
-        std::fs::remove_dir_all(&temp_path).unwrap();
+        match std::fs::remove_dir_all(&temp_path) {
+            Err(e) => println!("\n{:?}\n", e),
+            _ => (),
+        }
     }
 }
 
@@ -1532,7 +1589,10 @@ fn lmdb_duplicate_utxo() {
 
     // Cleanup test data - in Windows the LMBD `set_mapsize` sets file size equals to map size; Linux use sparse files
     if std::path::Path::new(&temp_path).exists() {
-        std::fs::remove_dir_all(&temp_path).unwrap();
+        match std::fs::remove_dir_all(&temp_path) {
+            Err(e) => println!("\n{:?}\n", e),
+            _ => (),
+        }
     }
 }
 
@@ -1576,7 +1636,10 @@ fn lmdb_fetch_last_header() {
 
     // Cleanup test data - in Windows the LMBD `set_mapsize` sets file size equals to map size; Linux use sparse files
     if std::path::Path::new(&temp_path).exists() {
-        std::fs::remove_dir_all(&temp_path).unwrap();
+        match std::fs::remove_dir_all(&temp_path) {
+            Err(e) => println!("\n{:?}\n", e),
+            _ => (),
+        }
     }
 }
 
@@ -1726,7 +1789,10 @@ fn lmdb_fetch_target_difficulties() {
 
     // Cleanup test data - in Windows the LMBD `set_mapsize` sets file size equals to map size; Linux use sparse files
     if std::path::Path::new(&temp_path).exists() {
-        std::fs::remove_dir_all(&temp_path).unwrap();
+        match std::fs::remove_dir_all(&temp_path) {
+            Err(e) => println!("\n{:?}\n", e),
+            _ => (),
+        }
     }
 }
 
@@ -1835,7 +1901,10 @@ fn lmdb_fetch_utxo_rp_nodes_and_count() {
 
     // Cleanup test data - in Windows the LMBD `set_mapsize` sets file size equals to map size; Linux use sparse files
     if std::path::Path::new(&temp_path).exists() {
-        std::fs::remove_dir_all(&temp_path).unwrap();
+        match std::fs::remove_dir_all(&temp_path) {
+            Err(e) => println!("\n{:?}\n", e),
+            _ => (),
+        }
     }
 }
 
@@ -1912,7 +1981,10 @@ fn lmdb_fetch_kernel_nodes_and_count() {
 
     // Cleanup test data - in Windows the LMBD `set_mapsize` sets file size equals to map size; Linux use sparse files
     if std::path::Path::new(&temp_path).exists() {
-        std::fs::remove_dir_all(&temp_path).unwrap();
+        match std::fs::remove_dir_all(&temp_path) {
+            Err(e) => println!("\n{:?}\n", e),
+            _ => (),
+        }
     }
 }
 
@@ -2004,6 +2076,9 @@ fn lmdb_insert_mmr_node_for_utxo_and_rp() {
 
     // Cleanup test data - in Windows the LMBD `set_mapsize` sets file size equals to map size; Linux use sparse files
     if std::path::Path::new(&temp_path).exists() {
-        std::fs::remove_dir_all(&temp_path).unwrap();
+        match std::fs::remove_dir_all(&temp_path) {
+            Err(e) => println!("\n{:?}\n", e),
+            _ => (),
+        }
     }
 }

--- a/base_layer/core/tests/chain_storage_tests/chain_storage.rs
+++ b/base_layer/core/tests/chain_storage_tests/chain_storage.rs
@@ -554,7 +554,7 @@ fn rewind_past_horizon_height() {
         pruning_horizon: 2,
         pruning_interval: 50,
     };
-    let store = BlockchainDatabase::new(db, &consensus_manager, validators, config).unwrap();
+    let store = BlockchainDatabase::new(db, &consensus_manager, validators, config, false).unwrap();
 
     let block1 = append_block(&store, &block0, vec![], &consensus_manager, 1.into()).unwrap();
     let block2 = append_block(&store, &block1, vec![], &consensus_manager, 1.into()).unwrap();
@@ -1019,7 +1019,10 @@ fn handle_reorg_failure_recovery() {
     }
     // Cleanup test data - in Windows the LMBD `set_mapsize` sets file size equals to map size; Linux use sparse files
     if std::path::Path::new(&temp_path).exists() {
-        std::fs::remove_dir_all(&temp_path).unwrap();
+        match std::fs::remove_dir_all(&temp_path) {
+            Err(e) => println!("\n{:?}\n", e),
+            _ => (),
+        }
     }
 }
 
@@ -1030,7 +1033,7 @@ fn store_and_retrieve_blocks() {
     let network = Network::LocalNet;
     let rules = ConsensusManagerBuilder::new(network).build();
     let db = MemoryDatabase::<HashDigest>::new(mmr_cache_config);
-    let store = BlockchainDatabase::new(db, &rules, validators, BlockchainDatabaseConfig::default()).unwrap();
+    let store = BlockchainDatabase::new(db, &rules, validators, BlockchainDatabaseConfig::default(), false).unwrap();
 
     let block0 = store.fetch_block(0).unwrap().block().clone();
     let block1 = append_block(&store, &block0, vec![], &rules, 1.into()).unwrap();
@@ -1053,7 +1056,7 @@ fn store_and_retrieve_chain_and_orphan_blocks_with_hashes() {
     let network = Network::LocalNet;
     let rules = ConsensusManagerBuilder::new(network).build();
     let db = MemoryDatabase::<HashDigest>::new(mmr_cache_config);
-    let store = BlockchainDatabase::new(db, &rules, validators, BlockchainDatabaseConfig::default()).unwrap();
+    let store = BlockchainDatabase::new(db, &rules, validators, BlockchainDatabaseConfig::default(), false).unwrap();
 
     let block0 = store.fetch_block(0).unwrap().block().clone();
     let block1 = append_block(&store, &block0, vec![], &rules, 1.into()).unwrap();
@@ -1121,7 +1124,7 @@ fn restore_metadata_and_pruning_horizon_update() {
         {
             let db = create_lmdb_database(&path, LMDBConfig::default(), MmrCacheConfig::default()).unwrap();
             config.pruning_horizon = pruning_horizon1;
-            let db = BlockchainDatabase::new(db, &rules, validators.clone(), config).unwrap();
+            let db = BlockchainDatabase::new(db, &rules, validators.clone(), config, false).unwrap();
 
             let block1 = append_block(&db, &block0, vec![], &rules, 1.into()).unwrap();
             db.add_block(block1.clone().into()).unwrap();
@@ -1135,7 +1138,7 @@ fn restore_metadata_and_pruning_horizon_update() {
         {
             config.pruning_horizon = 2000;
             let db = create_lmdb_database(&path, LMDBConfig::default(), MmrCacheConfig::default()).unwrap();
-            let db = BlockchainDatabase::new(db, &rules, validators.clone(), config).unwrap();
+            let db = BlockchainDatabase::new(db, &rules, validators.clone(), config, false).unwrap();
 
             let metadata = db.get_chain_metadata().unwrap();
             assert_eq!(metadata.height_of_longest_chain, Some(1));
@@ -1146,7 +1149,7 @@ fn restore_metadata_and_pruning_horizon_update() {
         {
             config.pruning_horizon = 900;
             let db = create_lmdb_database(&path, LMDBConfig::default(), MmrCacheConfig::default()).unwrap();
-            let db = BlockchainDatabase::new(db, &rules, validators, config).unwrap();
+            let db = BlockchainDatabase::new(db, &rules, validators, config, false).unwrap();
 
             let metadata = db.get_chain_metadata().unwrap();
             assert_eq!(metadata.height_of_longest_chain, Some(1));
@@ -1157,7 +1160,10 @@ fn restore_metadata_and_pruning_horizon_update() {
 
     // Cleanup test data - in Windows the LMBD `set_mapsize` sets file size equals to map size; Linux use sparse files
     if std::path::Path::new(&path).exists() {
-        std::fs::remove_dir_all(&path).unwrap();
+        match std::fs::remove_dir_all(&path) {
+            Err(e) => println!("\n{:?}\n", e),
+            _ => (),
+        }
     }
 }
 
@@ -1180,8 +1186,14 @@ fn invalid_block() {
             MockStatelessBlockValidator::new(consensus_manager.clone(), factories.clone()),
         );
         let db = create_lmdb_database(&temp_path, LMDBConfig::default(), MmrCacheConfig::default()).unwrap();
-        let mut store =
-            BlockchainDatabase::new(db, &consensus_manager, validators, BlockchainDatabaseConfig::default()).unwrap();
+        let mut store = BlockchainDatabase::new(
+            db,
+            &consensus_manager,
+            validators,
+            BlockchainDatabaseConfig::default(),
+            false,
+        )
+        .unwrap();
         let mut blocks = vec![block0];
         let mut outputs = vec![vec![output]];
         let block0_hash = blocks[0].hash();
@@ -1289,7 +1301,10 @@ fn invalid_block() {
 
     // Cleanup test data - in Windows the LMBD `set_mapsize` sets file size equals to map size; Linux use sparse files
     if std::path::Path::new(&temp_path).exists() {
-        std::fs::remove_dir_all(&temp_path).unwrap();
+        match std::fs::remove_dir_all(&temp_path) {
+            Err(e) => println!("\n{:?}\n", e),
+            _ => (),
+        }
     }
 }
 
@@ -1304,7 +1319,7 @@ fn orphan_cleanup_on_block_add() {
         pruning_horizon: 0,
         pruning_interval: 50,
     };
-    let store = BlockchainDatabase::new(db, &consensus_manager, validators, config).unwrap();
+    let store = BlockchainDatabase::new(db, &consensus_manager, validators, config, false).unwrap();
 
     let orphan1 = create_orphan_block(500, vec![], &consensus_manager);
     let orphan2 = create_orphan_block(5, vec![], &consensus_manager);
@@ -1359,7 +1374,7 @@ fn horizon_height_orphan_cleanup() {
         pruning_horizon: 2,
         pruning_interval: 50,
     };
-    let store = BlockchainDatabase::new(db, &consensus_manager, validators, config).unwrap();
+    let store = BlockchainDatabase::new(db, &consensus_manager, validators, config, false).unwrap();
     let orphan1 = create_orphan_block(2, vec![], &consensus_manager);
     let orphan2 = create_orphan_block(3, vec![], &consensus_manager);
     let orphan3 = create_orphan_block(1, vec![], &consensus_manager);
@@ -1412,7 +1427,7 @@ fn orphan_cleanup_on_reorg() {
         pruning_horizon: 0,
         pruning_interval: 50,
     };
-    let mut store = BlockchainDatabase::new(db, &consensus_manager, validators, config).unwrap();
+    let mut store = BlockchainDatabase::new(db, &consensus_manager, validators, config, false).unwrap();
     let mut blocks = vec![block0];
     let mut outputs = vec![vec![output]];
 
@@ -1527,6 +1542,92 @@ fn orphan_cleanup_on_reorg() {
 }
 
 #[test]
+fn orphan_cleanup_delete_all_orphans() {
+    let path = create_temporary_data_path();
+    let network = Network::LocalNet;
+    let consensus_manager = ConsensusManagerBuilder::new(network).build();
+    let validators = Validators::new(MockValidator::new(true), MockValidator::new(true));
+    let config = BlockchainDatabaseConfig {
+        orphan_storage_capacity: 5,
+        pruning_horizon: 0,
+        pruning_interval: 50,
+    };
+    // Test cleanup during runtime
+    {
+        let db = create_lmdb_database(&path, LMDBConfig::default(), MmrCacheConfig::default()).unwrap();
+        let store = BlockchainDatabase::new(db, &consensus_manager, validators.clone(), config, false).unwrap();
+
+        let orphan1 = create_orphan_block(500, vec![], &consensus_manager);
+        let orphan2 = create_orphan_block(5, vec![], &consensus_manager);
+        let orphan3 = create_orphan_block(30, vec![], &consensus_manager);
+        let orphan4 = create_orphan_block(700, vec![], &consensus_manager);
+        let orphan5 = create_orphan_block(43, vec![], &consensus_manager);
+
+        // Add orphans and verify
+        assert_eq!(
+            store.add_block(orphan1.clone().into()).unwrap(),
+            BlockAddResult::OrphanBlock
+        );
+        assert_eq!(
+            store.add_block(orphan2.clone().into()).unwrap(),
+            BlockAddResult::OrphanBlock
+        );
+        assert_eq!(
+            store.add_block(orphan3.clone().into()).unwrap(),
+            BlockAddResult::OrphanBlock
+        );
+        assert_eq!(
+            store.add_block(orphan4.clone().clone().into()).unwrap(),
+            BlockAddResult::OrphanBlock
+        );
+        assert_eq!(
+            store.add_block(orphan5.clone().into()).unwrap(),
+            BlockAddResult::OrphanBlock
+        );
+        assert_eq!(store.db_read_access().unwrap().get_orphan_count().unwrap(), 5);
+
+        // Cleanup orphans and verify
+        assert_eq!(store.cleanup_all_orphans().unwrap(), ());
+        assert_eq!(store.db_read_access().unwrap().get_orphan_count().unwrap(), 0);
+
+        // Add orphans again
+        assert_eq!(
+            store.add_block(orphan1.clone().into()).unwrap(),
+            BlockAddResult::OrphanBlock
+        );
+        assert_eq!(store.add_block(orphan2.into()).unwrap(), BlockAddResult::OrphanBlock);
+        assert_eq!(store.add_block(orphan3.into()).unwrap(), BlockAddResult::OrphanBlock);
+        assert_eq!(
+            store.add_block(orphan4.clone().into()).unwrap(),
+            BlockAddResult::OrphanBlock
+        );
+        assert_eq!(store.add_block(orphan5.into()).unwrap(), BlockAddResult::OrphanBlock);
+    }
+
+    // Test orphans are present on open
+    {
+        let db = create_lmdb_database(&path, LMDBConfig::default(), MmrCacheConfig::default()).unwrap();
+        let store = BlockchainDatabase::new(db, &consensus_manager, validators.clone(), config, false).unwrap();
+        assert_eq!(store.db_read_access().unwrap().get_orphan_count().unwrap(), 5);
+    }
+
+    // Test orphans cleanup on open
+    {
+        let db = create_lmdb_database(&path, LMDBConfig::default(), MmrCacheConfig::default()).unwrap();
+        let store = BlockchainDatabase::new(db, &consensus_manager, validators.clone(), config, true).unwrap();
+        assert_eq!(store.db_read_access().unwrap().get_orphan_count().unwrap(), 0);
+    }
+
+    // Cleanup test data - in Windows the LMBD `set_mapsize` sets file size equals to map size; Linux use sparse files
+    if std::path::Path::new(&path).exists() {
+        match std::fs::remove_dir_all(&path) {
+            Err(e) => println!("\n{:?}\n", e),
+            _ => (),
+        }
+    }
+}
+
+#[test]
 fn fails_validation() {
     let network = Network::LocalNet;
     let factories = CryptoFactories::default();
@@ -1543,7 +1644,7 @@ fn fails_validation() {
         pruning_horizon: 0,
         pruning_interval: 50,
     };
-    let mut store = BlockchainDatabase::new(db, &consensus_manager, validators, config).unwrap();
+    let mut store = BlockchainDatabase::new(db, &consensus_manager, validators, config, false).unwrap();
     let mut blocks = vec![block0];
     let mut outputs = vec![vec![]];
 
@@ -1576,7 +1677,7 @@ fn pruned_mode_cleanup_and_fetch_block() {
         pruning_horizon: 2,
         pruning_interval: 2,
     };
-    let store = BlockchainDatabase::new(db, &consensus_manager, validators, config).unwrap();
+    let store = BlockchainDatabase::new(db, &consensus_manager, validators, config, false).unwrap();
     let block1 = append_block(&store, &block0, vec![], &consensus_manager, 1.into()).unwrap();
     let block2 = append_block(&store, &block1, vec![], &consensus_manager, 1.into()).unwrap();
     let block3 = append_block(&store, &block2, vec![], &consensus_manager, 1.into()).unwrap();
@@ -1614,7 +1715,7 @@ fn pruned_mode_is_stxo() {
         pruning_horizon: 2,
         pruning_interval: 2,
     };
-    let mut store = BlockchainDatabase::new(db, &consensus_manager, validators, config).unwrap();
+    let mut store = BlockchainDatabase::new(db, &consensus_manager, validators, config, false).unwrap();
     let mut blocks = vec![block0];
     let mut outputs = vec![vec![output]];
     let txo_hash1 = blocks[0].body.outputs()[0].hash();
@@ -1777,6 +1878,7 @@ fn pruned_mode_fetch_insert_and_commit() {
         &consensus_manager,
         validators,
         config,
+        false,
     )
     .unwrap();
     let network_tip_height = alice_store

--- a/base_layer/core/tests/helpers/nodes.rs
+++ b/base_layer/core/tests/helpers/nodes.rs
@@ -202,7 +202,8 @@ impl BaseNodeBuilder {
             .unwrap_or(ConsensusManagerBuilder::new(self.network).build());
         let db = MemoryDatabase::<HashDigest>::new(mmr_cache_config);
         let blockchain_db_config = self.blockchain_db_config.unwrap_or(BlockchainDatabaseConfig::default());
-        let blockchain_db = BlockchainDatabase::new(db, &consensus_manager, validators, blockchain_db_config).unwrap();
+        let blockchain_db =
+            BlockchainDatabase::new(db, &consensus_manager, validators, blockchain_db_config, false).unwrap();
         let mempool_validator = MempoolValidators::new(
             TxInputAndMaturityValidator::new(blockchain_db.clone()),
             TxInputAndMaturityValidator::new(blockchain_db.clone()),

--- a/base_layer/core/tests/helpers/sample_blockchains.rs
+++ b/base_layer/core/tests/helpers/sample_blockchains.rs
@@ -172,6 +172,6 @@ pub fn create_new_blockchain_lmdb<P: AsRef<std::path::Path>>(
         .with_block(block0.clone())
         .build();
     let db = create_lmdb_database(path, LMDBConfig::default(), MmrCacheConfig::default()).unwrap();
-    let db = BlockchainDatabase::new(db, &consensus_manager, validators, config).unwrap();
+    let db = BlockchainDatabase::new(db, &consensus_manager, validators, config, false).unwrap();
     (db, vec![block0], vec![vec![output]], consensus_manager)
 }

--- a/base_layer/core/tests/node_comms_interface.rs
+++ b/base_layer/core/tests/node_comms_interface.rs
@@ -416,7 +416,7 @@ async fn inbound_fetch_blocks_before_horizon_height() {
     let db = MemoryDatabase::<HashDigest>::default();
     let mut config = BlockchainDatabaseConfig::default();
     config.pruning_horizon = 2;
-    let store = BlockchainDatabase::new(db, &consensus_manager, validators, config).unwrap();
+    let store = BlockchainDatabase::new(db, &consensus_manager, validators, config, false).unwrap();
     let mempool_validator = MempoolValidators::new(
         TxInputAndMaturityValidator::new(store.clone()),
         TxInputAndMaturityValidator::new(store.clone()),

--- a/common/config/presets/windows.toml
+++ b/common/config/presets/windows.toml
@@ -139,6 +139,9 @@ db_type = "lmdb"
 
 # The maximum number of orphans that can be stored in the Orphan block pool. Default value is "720".
 #orphan_storage_capacity = 720
+# The size that the orphan pool will be allowed to grow before it is cleaned out, with threshold being tested every
+# time before fetch and add blocks. Default value is "0", which indicates the orphan pool will not be cleaned out.
+#orphan_db_clean_out_threshold = 0
 # The pruning horizon that indicates how many full blocks without pruning must be kept by the base node. Default value
 # is "0", which indicates an archival node without any pruning.
 #pruning_horizon = 0
@@ -267,6 +270,9 @@ wallet_tor_identity_file = ".\\config\\wallet-tor.json"
 
 # The maximum number of orphans that can be stored in the Orphan block pool. Default value is "720".
 #orphan_storage_capacity = 720
+# The size that the orphan pool will be allowed to grow before it is cleaned out, with threshold being tested every
+# time before fetch and add blocks. Default value is "0", which indicates the orphan pool will not be cleaned out.
+#orphan_db_clean_out_threshold = 0
 # The pruning horizon that indicates how many full blocks without pruning must be kept by the base node. Default value
 # is "0", which indicates an archival node without any pruning.
 #pruning_horizon = 0

--- a/common/config/tari_config_sample.toml
+++ b/common/config/tari_config_sample.toml
@@ -141,6 +141,9 @@ db_type = "lmdb"
 
 # The maximum number of orphans that can be stored in the Orphan block pool. Default value is "720".
 #orphan_storage_capacity = 720
+# The size that the orphan pool will be allowed to grow before it is cleaned out, with threshold being tested every
+# time before fetch and add blocks. Default value is "0", which indicates the orphan pool will not be cleaned out.
+#orphan_db_clean_out_threshold = 0
 # The pruning horizon that indicates how many full blocks without pruning must be kept by the base node. Default value
 # is "0", which indicates an archival node without any pruning.
 #pruning_horizon = 0
@@ -269,6 +272,9 @@ wallet_tor_identity_file = "./wallet-tor.json" # or ".\\wallet-tor.json"
 
 # The maximum number of orphans that can be stored in the Orphan block pool. Default value is "720".
 #orphan_storage_capacity = 720
+# The size that the orphan pool will be allowed to grow before it is cleaned out, with threshold being tested every
+# time before fetch and add blocks. Default value is "0", which indicates the orphan pool will not be cleaned out.
+#orphan_db_clean_out_threshold = 0
 # The pruning horizon that indicates how many full blocks without pruning must be kept by the base node. Default value
 # is "0", which indicates an archival node without any pruning.
 #pruning_horizon = 0

--- a/common/src/configuration/bootstrap.rs
+++ b/common/src/configuration/bootstrap.rs
@@ -110,6 +110,9 @@ pub struct ConfigBootstrap {
     /// Single input command
     #[structopt(long)]
     pub command: Option<String>,
+    /// This will clean out the orphans db at startup
+    #[structopt(long, alias("clean_orphans_db"))]
+    pub clean_orphans_db: bool,
 }
 
 impl Default for ConfigBootstrap {
@@ -124,6 +127,7 @@ impl Default for ConfigBootstrap {
             rebuild_db: false,
             input_file: None,
             command: None,
+            clean_orphans_db: false,
         }
     }
 }
@@ -280,6 +284,7 @@ mod test {
             "--init",
             "--create-id",
             "--rebuild_db",
+            "--clean_orphans_db",
             "--base-path",
             "no-temp-path-created",
             "--log-config",
@@ -293,6 +298,7 @@ mod test {
         assert!(bootstrap.init);
         assert!(bootstrap.create_id);
         assert!(bootstrap.rebuild_db);
+        assert!(bootstrap.clean_orphans_db);
         assert_eq!(bootstrap.base_path.to_str(), Some("no-temp-path-created"));
         assert_eq!(bootstrap.log_config.to_str(), Some("no-log-config-file-created"));
         assert_eq!(bootstrap.config.to_str(), Some("no-config-file-created"));

--- a/common/src/configuration/global.rs
+++ b/common/src/configuration/global.rs
@@ -56,6 +56,7 @@ pub struct GlobalConfig {
     pub db_type: DatabaseType,
     pub db_config: LMDBConfig,
     pub orphan_storage_capacity: usize,
+    pub orphan_db_clean_out_threshold: usize,
     pub pruning_horizon: u64,
     pub pruned_mode_cleanup_interval: u64,
     pub core_threads: usize,
@@ -194,6 +195,11 @@ fn convert_node_config(network: Network, cfg: Config) -> Result<GlobalConfig, Co
 
     let key = config_string("base_node", &net_str, "orphan_storage_capacity");
     let orphan_storage_capacity = cfg
+        .get_int(&key)
+        .map_err(|e| ConfigurationError::new(&key, &e.to_string()))? as usize;
+
+    let key = config_string("base_node", &net_str, "orphan_db_clean_out_threshold");
+    let orphan_db_clean_out_threshold = cfg
         .get_int(&key)
         .map_err(|e| ConfigurationError::new(&key, &e.to_string()))? as usize;
 
@@ -436,6 +442,7 @@ fn convert_node_config(network: Network, cfg: Config) -> Result<GlobalConfig, Co
         db_type,
         db_config,
         orphan_storage_capacity,
+        orphan_db_clean_out_threshold,
         pruning_horizon,
         pruned_mode_cleanup_interval,
         core_threads,

--- a/common/src/configuration/utils.rs
+++ b/common/src/configuration/utils.rs
@@ -90,6 +90,8 @@ pub fn default_config(bootstrap: &ConfigBootstrap) -> Config {
     cfg.set_default("base_node.mainnet.db_type", "lmdb").unwrap();
     cfg.set_default("base_node.mainnet.orphan_storage_capacity", 720)
         .unwrap();
+    cfg.set_default("base_node.mainnet.orphan_db_clean_out_threshold", 0)
+        .unwrap();
     cfg.set_default("base_node.mainnet.pruning_horizon", 0).unwrap();
     cfg.set_default("base_node.mainnet.pruned_mode_cleanup_interval", 50)
         .unwrap();
@@ -139,6 +141,8 @@ pub fn default_config(bootstrap: &ConfigBootstrap) -> Config {
 
     cfg.set_default("base_node.rincewind.db_type", "lmdb").unwrap();
     cfg.set_default("base_node.rincewind.orphan_storage_capacity", 720)
+        .unwrap();
+    cfg.set_default("base_node.rincewind.orphan_db_clean_out_threshold", 0)
         .unwrap();
     cfg.set_default("base_node.rincewind.pruning_horizon", 0).unwrap();
     cfg.set_default("base_node.rincewind.pruned_mode_cleanup_interval", 50)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR adds the ability to optionally clean out the orphan database at startup and as well as before block sync of a preset size. _(Note: As a side issue, this PR also removes `\n` characters from the `Display for TransactionOutput` to make it more readable in the log files.)_

The orphan database is used as an integral part of normal block sync and for reorgs. Every block that needs to be added to the blockchain database in normal sync operation is validated and submitted to the orphan database; if validation succeeds it is removed from the orphan database and added to the main blockchain database. As part of this process, the entire orphan database is searched to discover and validate links to other blocks, however, searching through the entire orphan database every time can be hugely inefficient, especially if there are many orphan blocks in the orphan database (see related issue #2247). 

Reorgs will still happen as per the current design as the orphan database will only be cleared once before missing blocks are requested and added to the database.

As can be seen below orphan search is done for every block added to the blockchain, and if a coupe of thousand blocks need to be synced, this will be hugely ineffective if there are many orphans. This change improves sync performance considerably.
``` rust
2020-10-09 07:15:19.044207800 [c::cs::database] DEBUG Searched 1031 orphan(s) in 4s
2020-10-09 07:15:23.087208500 [c::cs::database] DEBUG Searched 1031 orphan(s) in 4s
2020-10-09 07:15:27.297718300 [c::cs::database] DEBUG Searched 1031 orphan(s) in 4s
2020-10-09 07:15:32.445717800 [c::cs::database] DEBUG Searched 1031 orphan(s) in 4s
2020-10-09 07:15:36.493718400 [c::cs::database] DEBUG Searched 1031 orphan(s) in 4s
2020-10-09 07:15:40.719718700 [c::cs::database] DEBUG Searched 1031 orphan(s) in 4s
2020-10-09 07:15:44.851719100 [c::cs::database] DEBUG Searched 1031 orphan(s) in 4s
2020-10-09 07:15:48.913227100 [c::cs::database] DEBUG Searched 1031 orphan(s) in 4s
2020-10-09 07:15:53.902735900 [c::cs::database] DEBUG Searched 1031 orphan(s) in 4s
2020-10-09 07:15:58.066735500 [c::cs::database] DEBUG Searched 1031 orphan(s) in 4s
2020-10-09 07:16:02.222735400 [c::cs::database] DEBUG Searched 1031 orphan(s) in 4s
2020-10-09 07:16:06.221737100 [c::cs::database] DEBUG Searched 1031 orphan(s) in 4s
```

## Motivation and Context
Blockchain sync needs to fast and efficient.

## How Has This Been Tested?
Tested in a base node in Windows

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [X] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [X] I'm merging against the `development` branch.
* [X] I ran `cargo-fmt --all` before pushing.
* [X] I ran `cargo test` successfully before submitting my PR.
* [X] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [X] I have added tests to cover my changes.
