### PR TITLE
Base node shuts down cleanly

### DIFF
--- a/applications/tari_base_node/src/main.rs
+++ b/applications/tari_base_node/src/main.rs
@@ -106,10 +106,11 @@ mod utils;
 // recovery mode
 mod recovery;
 
+use futures::FutureExt;
 use log::*;
 use parser::Parser;
 use rustyline::{config::OutputStreamType, error::ReadlineError, CompletionType, Config, EditMode, Editor};
-use std::{net::SocketAddr, time::Duration};
+use std::net::SocketAddr;
 use structopt::StructOpt;
 use tari_app_utilities::{
     identity_management::setup_node_identity,
@@ -117,7 +118,7 @@ use tari_app_utilities::{
 };
 use tari_common::{configuration::bootstrap::ApplicationType, ConfigBootstrap, GlobalConfig};
 use tari_comms::peer_manager::PeerFeatures;
-use tari_shutdown::Shutdown;
+use tari_shutdown::{Shutdown, ShutdownSignal};
 use tonic::transport::Server;
 
 pub const LOG_TARGET: &str = "base_node::app";
@@ -210,33 +211,37 @@ fn main_inner() -> Result<(), ExitCodes> {
             error!(target: LOG_TARGET, "{}", err);
             ExitCodes::UnknownError
         })?;
-    // Run, node, run!
-    let parser = Parser::new(rt.handle().clone(), &ctx, &node_config);
 
-    cli::print_banner(parser.get_commands(), 3);
     if node_config.grpc_enabled {
+        // Go, GRPC , go go
         let grpc = crate::grpc::base_node_grpc_server::BaseNodeGrpcServer::new(
             rt.handle().clone(),
             ctx.local_node(),
             node_config.clone(),
         );
 
-        rt.spawn(run_grpc(grpc, node_config.grpc_address));
+        rt.spawn(run_grpc(grpc, node_config.grpc_address, shutdown.to_signal()));
     }
+
+    // Run, node, run!
+    let parser = Parser::new(rt.handle().clone(), &ctx, &node_config);
+    cli::print_banner(parser.get_commands(), 3);
     let base_node_handle = rt.spawn(ctx.run());
 
     info!(
         target: LOG_TARGET,
         "Node has been successfully configured and initialized. Starting CLI loop."
     );
+
     cli_loop(parser, shutdown);
+
     match rt.block_on(base_node_handle) {
         Ok(_) => info!(target: LOG_TARGET, "Node shutdown successfully."),
         Err(e) => error!(target: LOG_TARGET, "Node has crashed: {}", e),
     }
 
-    // Wait for all tasks to exit or a timeout, whichever comes first
-    rt.shutdown_timeout(Duration::from_secs(20));
+    // Wait until tasks have shut down
+    drop(rt);
 
     println!("Goodbye!");
     Ok(())
@@ -246,15 +251,16 @@ fn main_inner() -> Result<(), ExitCodes> {
 async fn run_grpc(
     grpc: crate::grpc::base_node_grpc_server::BaseNodeGrpcServer,
     grpc_address: SocketAddr,
-) -> Result<(), String>
+    interrupt_signal: ShutdownSignal,
+) -> Result<(), anyhow::Error>
 {
     info!(target: LOG_TARGET, "Starting GRPC on {}", grpc_address);
 
     Server::builder()
         .add_service(tari_app_grpc::tari_rpc::base_node_server::BaseNodeServer::new(grpc))
-        .serve(grpc_address)
-        .await
-        .map_err(|e| format!("GRPC server returned error:{}", e))?;
+        .serve_with_shutdown(grpc_address, interrupt_signal.map(|_| ()))
+        .await?;
+
     info!(target: LOG_TARGET, "Stopping GRPC");
     Ok(())
 }

--- a/applications/tari_base_node/src/tasks/mod.rs
+++ b/applications/tari_base_node/src/tasks/mod.rs
@@ -24,7 +24,4 @@ mod sync_peers;
 pub use sync_peers::sync_peers;
 
 mod transaction_monitor;
-pub use transaction_monitor::{
-    spawn_transaction_protocols_and_utxo_validation,
-    start_transaction_protocols_and_txo_validation,
-};
+pub use transaction_monitor::spawn_transaction_protocols_and_utxo_validation;

--- a/applications/tari_base_node/src/tasks/transaction_monitor.rs
+++ b/applications/tari_base_node/src/tasks/transaction_monitor.rs
@@ -69,6 +69,10 @@ pub fn spawn_transaction_protocols_and_utxo_validation(
         futures::pin_mut!(transaction_task_fut);
         // Exit on shutdown
         future::select(transaction_task_fut, interrupt_signal).await;
+        info!(
+            target: LOG_TARGET,
+            "transaction_protocols_and_utxo_validation shut down"
+        );
     });
 }
 
@@ -79,7 +83,7 @@ pub fn spawn_transaction_protocols_and_utxo_validation(
 /// `oms_handle` - A handle to the output manager service
 /// `base_node_query_timeout` - A time after which queries to the base node times out
 /// `base_node_public_key` - The base node's public key
-pub async fn start_transaction_protocols_and_txo_validation(
+async fn start_transaction_protocols_and_txo_validation(
     state_machine: StateMachineHandle,
     mut transaction_service_handle: TransactionServiceHandle,
     mut oms_handle: OutputManagerHandle,
@@ -88,120 +92,125 @@ pub async fn start_transaction_protocols_and_txo_validation(
 )
 {
     let mut status_watch = state_machine.get_status_info_watch();
-    debug!(
-        target: LOG_TARGET,
-        "Waiting for initial sync before performing TXO validation and restarting of broadcast and transaction \
-         protocols."
-    );
+
     loop {
-        let bootstrapped = match status_watch.recv().await {
-            None => false,
-            Some(s) => s.bootstrapped,
+        debug!(
+            target: LOG_TARGET,
+            "Waiting for initial sync before performing TXO validation and restarting of broadcast and transaction \
+             protocols."
+        );
+        // Only start the transaction broadcast and TXO validation protocols once the local node is synced
+        match status_watch.recv().await {
+            // Status watch has closed
+            None => break,
+            // Still not bootstrapped, carry on waiting
+            Some(s) if !s.bootstrapped => {
+                continue;
+            },
+            // Bootstrapped!
+            _ => {},
         };
 
-        // Only start the transaction broadcast and TXO validation protocols once the local node is synced
-        if bootstrapped {
-            debug!(
+        debug!(
+            target: LOG_TARGET,
+            "Initial sync achieved, performing TXO validation and restarting protocols.",
+        );
+        let _ = oms_handle
+            .set_base_node_public_key(base_node_public_key.clone())
+            .await
+            .map_err(|e| {
+                error!(
+                    target: LOG_TARGET,
+                    "Problem with Output Manager Service setting the base node public key: {}", e
+                );
+                e
+            });
+
+        // The event monitoring timeout must not be aggressive, as the validation protocols use
+        // 'base_node_query_timeout' internally
+        let event_monitoring_timeout = Duration::from_secs(cmp::max(60, base_node_query_timeout.as_secs() * 3));
+
+        loop {
+            trace!(target: LOG_TARGET, "Attempting UTXO validation for Unspent Outputs.",);
+            let _ = oms_handle
+                .validate_txos(TxoValidationType::Unspent, TxoValidationRetry::UntilSuccess)
+                .await
+                .map_err(|e| {
+                    error!(
+                        target: LOG_TARGET,
+                        "Problem starting UTXO validation protocols in the Output Manager Service: {}", e
+                    );
+                    e
+                });
+            if monitor_validation_protocol(event_monitoring_timeout, oms_handle.get_event_stream_fused()).await {
+                break;
+            }
+        }
+
+        loop {
+            trace!(
                 target: LOG_TARGET,
-                "Initial sync achieved, performing TXO validation and restarting protocols.",
+                "Attempting Invalid TXO validation for Unspent Outputs.",
             );
             let _ = oms_handle
-                .set_base_node_public_key(base_node_public_key.clone())
+                .validate_txos(TxoValidationType::Invalid, TxoValidationRetry::UntilSuccess)
                 .await
                 .map_err(|e| {
                     error!(
                         target: LOG_TARGET,
-                        "Problem with Output Manager Service setting the base node public key: {}", e
+                        "Problem starting Invalid TXO validation protocols in the Output Manager Service: {}", e
                     );
                     e
                 });
-
-            // The event monitoring timeout must not be aggressive, as the validation protocols use
-            // 'base_node_query_timeout' internally
-            let event_monitoring_timeout = Duration::from_secs(cmp::max(60, base_node_query_timeout.as_secs() * 3));
-
-            loop {
-                trace!(target: LOG_TARGET, "Attempting UTXO validation for Unspent Outputs.",);
-                let _ = oms_handle
-                    .validate_txos(TxoValidationType::Unspent, TxoValidationRetry::UntilSuccess)
-                    .await
-                    .map_err(|e| {
-                        error!(
-                            target: LOG_TARGET,
-                            "Problem starting UTXO validation protocols in the Output Manager Service: {}", e
-                        );
-                        e
-                    });
-                if monitor_validation_protocol(event_monitoring_timeout, oms_handle.get_event_stream_fused()).await {
-                    break;
-                }
+            if monitor_validation_protocol(event_monitoring_timeout, oms_handle.get_event_stream_fused()).await {
+                break;
             }
-
-            loop {
-                trace!(
-                    target: LOG_TARGET,
-                    "Attempting Invalid TXO validation for Unspent Outputs.",
-                );
-                let _ = oms_handle
-                    .validate_txos(TxoValidationType::Invalid, TxoValidationRetry::UntilSuccess)
-                    .await
-                    .map_err(|e| {
-                        error!(
-                            target: LOG_TARGET,
-                            "Problem starting Invalid TXO validation protocols in the Output Manager Service: {}", e
-                        );
-                        e
-                    });
-                if monitor_validation_protocol(event_monitoring_timeout, oms_handle.get_event_stream_fused()).await {
-                    break;
-                }
-            }
-
-            loop {
-                trace!(target: LOG_TARGET, "Attempting STXO validation for Unspent Outputs.",);
-                let _ = oms_handle
-                    .validate_txos(TxoValidationType::Spent, TxoValidationRetry::UntilSuccess)
-                    .await
-                    .map_err(|e| {
-                        error!(
-                            target: LOG_TARGET,
-                            "Problem starting STXO validation protocols in the Output Manager Service: {}", e
-                        );
-                        e
-                    });
-                if monitor_validation_protocol(event_monitoring_timeout, oms_handle.get_event_stream_fused()).await {
-                    break;
-                }
-            }
-
-            // We want to ensure transaction protocols only use a fully validated TXO set, thus delaying this until
-            // after the prior validation
-            trace!(target: LOG_TARGET, "Attempting restart of the broadcast protocols.",);
-            let _ = transaction_service_handle
-                .restart_broadcast_protocols()
-                .await
-                .map_err(|e| {
-                    error!(
-                        target: LOG_TARGET,
-                        "Problem restarting broadcast protocols in the Transaction Service: {}", e
-                    );
-                    e
-                });
-
-            trace!(target: LOG_TARGET, "Attempting restart of the transaction protocols.",);
-            let _ = transaction_service_handle
-                .restart_transaction_protocols()
-                .await
-                .map_err(|e| {
-                    error!(
-                        target: LOG_TARGET,
-                        "Problem restarting transaction negotiation protocols in the Transaction Service: {}", e
-                    );
-                    e
-                });
-
-            break;
         }
+
+        loop {
+            trace!(target: LOG_TARGET, "Attempting STXO validation for Unspent Outputs.",);
+            let _ = oms_handle
+                .validate_txos(TxoValidationType::Spent, TxoValidationRetry::UntilSuccess)
+                .await
+                .map_err(|e| {
+                    error!(
+                        target: LOG_TARGET,
+                        "Problem starting STXO validation protocols in the Output Manager Service: {}", e
+                    );
+                    e
+                });
+            if monitor_validation_protocol(event_monitoring_timeout, oms_handle.get_event_stream_fused()).await {
+                break;
+            }
+        }
+
+        // We want to ensure transaction protocols only use a fully validated TXO set, thus delaying this until
+        // after the prior validation
+        trace!(target: LOG_TARGET, "Attempting restart of the broadcast protocols.",);
+        let _ = transaction_service_handle
+            .restart_broadcast_protocols()
+            .await
+            .map_err(|e| {
+                error!(
+                    target: LOG_TARGET,
+                    "Problem restarting broadcast protocols in the Transaction Service: {}", e
+                );
+                e
+            });
+
+        trace!(target: LOG_TARGET, "Attempting restart of the transaction protocols.",);
+        let _ = transaction_service_handle
+            .restart_transaction_protocols()
+            .await
+            .map_err(|e| {
+                error!(
+                    target: LOG_TARGET,
+                    "Problem restarting transaction negotiation protocols in the Transaction Service: {}", e
+                );
+                e
+            });
+
+        break;
     }
     debug!(
         target: LOG_TARGET,


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
There were three issues preventing a "clean" shutdown from occurring:
1. GRPC server shutdown was not attached to the shutdown signal
1. If the watch channel closed (as it does on shutdown), the
  `start_transaction_protocols_and_txo_validation` would block its
  future's poll function (by going into an infinite loop), preventing
  the select from polling the shutdown signal.
1. There seems to be a bug with `Runtime::shutdown_timeout(n)` which causes
   it to wait `n` even if all tasks have completed.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Base node would always wait 20 seconds to shutdown

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested on local base node

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch.
* [x] I ran `cargo-fmt --all` before pushing.
* [ ] I ran `cargo test` successfully before submitting my PR.
* [x] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
