### PR TITLE
Move log message outside waiting loop

### DIFF
--- a/applications/tari_base_node/src/tasks/transaction_monitor.rs
+++ b/applications/tari_base_node/src/tasks/transaction_monitor.rs
@@ -93,12 +93,12 @@ async fn start_transaction_protocols_and_txo_validation(
 {
     let mut status_watch = state_machine.get_status_info_watch();
 
+    debug!(
+        target: LOG_TARGET,
+        "Waiting for initial sync before performing TXO validation and restarting of broadcast and transaction \
+         protocols."
+    );
     loop {
-        debug!(
-            target: LOG_TARGET,
-            "Waiting for initial sync before performing TXO validation and restarting of broadcast and transaction \
-             protocols."
-        );
         // Only start the transaction broadcast and TXO validation protocols once the local node is synced
         match status_watch.recv().await {
             // Status watch has closed


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
Moved log message outside the waiting loop to be only logged once; the default behaviour was changed due to a recent PR.

## Motivation and Context
This log message only needs to be written to the log file once, not with every non-bootstrapped event from the status watch.

## How Has This Been Tested?
Tested in a base node on Windows

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [X] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [X] I'm merging against the `development` branch.
* [X] I ran `cargo-fmt --all` before pushing.
* [X] I ran `cargo test` successfully before submitting my PR.
* [X] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
