### PR TITLE
Peer db migrations must be incremental

### DIFF
--- a/comms/src/peer_manager/migrations/v1.rs
+++ b/comms/src/peer_manager/migrations/v1.rs
@@ -24,10 +24,9 @@ use crate::{
     net_address::MultiaddressesWithStats,
     peer_manager::{
         connection_stats::PeerConnectionStats,
-        migrations::Migration,
+        migrations::{v2::PeerV2, Migration},
         node_id::deserialize_node_id_from_hex,
         NodeId,
-        Peer,
         PeerFeatures,
         PeerFlags,
         PeerId,
@@ -38,7 +37,6 @@ use crate::{
 use chrono::NaiveDateTime;
 use log::*;
 use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
 use tari_crypto::tari_utilities::hex::serialize_to_hex;
 use tari_storage::{
     lmdb_store::{LMDBDatabase, LMDBError},
@@ -75,21 +73,19 @@ impl Migration<LMDBDatabase> for MigrationV1 {
             match old_peer {
                 Ok((key, peer)) => {
                     debug!(target: LOG_TARGET, "Migrating peer `{}`", peer.node_id.short_str());
-                    let result = db.insert(&key, &Peer {
+                    let result = db.insert(&key, &PeerV2 {
                         id: peer.id,
                         public_key: peer.public_key,
                         node_id: peer.node_id,
                         addresses: peer.addresses,
                         flags: peer.flags,
                         banned_until: peer.banned_until,
-                        banned_reason: "".to_string(),
                         offline_at: peer.offline_at,
                         features: peer.features,
                         connection_stats: peer.connection_stats,
                         supported_protocols: peer.supported_protocols,
                         added_at: peer.added_at,
                         user_agent: String::new(),
-                        metadata: HashMap::new(),
                     });
 
                     if let Err(err) = result {

--- a/comms/src/peer_manager/migrations/v3.rs
+++ b/comms/src/peer_manager/migrations/v3.rs
@@ -49,21 +49,21 @@ const LOG_TARGET: &str = "comms::peer_manager::migrations::v3";
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct PeerV3 {
-    id: Option<PeerId>,
-    public_key: CommsPublicKey,
+    pub id: Option<PeerId>,
+    pub public_key: CommsPublicKey,
     #[serde(serialize_with = "serialize_to_hex")]
     #[serde(deserialize_with = "deserialize_node_id_from_hex")]
-    node_id: NodeId,
-    addresses: MultiaddressesWithStats,
-    flags: PeerFlags,
-    banned_until: Option<NaiveDateTime>,
-    banned_reason: String,
-    offline_at: Option<NaiveDateTime>,
-    features: PeerFeatures,
-    connection_stats: PeerConnectionStats,
-    supported_protocols: Vec<ProtocolId>,
-    added_at: NaiveDateTime,
-    user_agent: String,
+    pub node_id: NodeId,
+    pub addresses: MultiaddressesWithStats,
+    pub flags: PeerFlags,
+    pub banned_until: Option<NaiveDateTime>,
+    pub banned_reason: String,
+    pub offline_at: Option<NaiveDateTime>,
+    pub features: PeerFeatures,
+    pub connection_stats: PeerConnectionStats,
+    pub supported_protocols: Vec<ProtocolId>,
+    pub added_at: NaiveDateTime,
+    pub user_agent: String,
 }
 /// This migration is to the metadata field
 pub struct MigrationV3;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Each step in the peer db migration must be incremental.
Migration 2 broke this by adding metadata before v3 meaning that when v3
is run it cannot read the v3 peer.

This PR fixes this by only adding useragent in v1,  banned_reason in v2 and metadata in v3.


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Broken in #2318 
Results in this message:
```
[base_node::app] ERROR Could not create comms layer: CommsBuilderError(PeerManagerError(DatabaseError(DatabaseError("DatabaseError { source: Error::ValRejected(\"premature end of input\") }"))))
```

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Untested 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch.
* [x] I ran `cargo-fmt --all` before pushing.
* [ ] I ran `cargo test` successfully before submitting my PR.
* [x] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
