### PR TITLE
Check that advertised difficulty matches actual chain difficulty after block sync

### DIFF
--- a/base_layer/core/src/base_node/comms_interface/inbound_handlers.rs
+++ b/base_layer/core/src/base_node/comms_interface/inbound_handlers.rs
@@ -535,9 +535,13 @@ where T: BlockchainBackend + 'static
         );
         let constants = self.consensus_manager.consensus_constants(height);
         let block_window = constants.get_difficulty_block_window() as usize;
-        let target_difficulties =
-            self.blockchain_db
-                .fetch_target_difficulties(pow_algo, height_of_longest_chain, block_window)?;
+        let target_difficulties = async_db::fetch_target_difficulties(
+            self.blockchain_db.clone(),
+            pow_algo,
+            height_of_longest_chain,
+            block_window,
+        )
+        .await?;
 
         let target = get_target_difficulty(
             target_difficulties,

--- a/base_layer/core/src/base_node/state_machine_service/states/header_sync.rs
+++ b/base_layer/core/src/base_node/state_machine_service/states/header_sync.rs
@@ -209,7 +209,7 @@ impl<B: BlockchainBackend + 'static> HeaderSynchronisation<'_, '_, B> {
                             target: LOG_TARGET,
                             "Banning peer {} from local node, because they supplied an invalid response", sync_peer
                         );
-                        self.ban_sync_peer(sync_peer, "Peer supplied an invalid response".to_string())
+                        self.ban_sync_peer(&sync_peer, "Peer supplied an invalid response".to_string())
                             .await?;
                     },
                     // Fatal
@@ -298,7 +298,7 @@ impl<B: BlockchainBackend + 'static> HeaderSynchronisation<'_, '_, B> {
         Ok(())
     }
 
-    async fn ban_sync_peer(&mut self, sync_peer: SyncPeer, reason: String) -> Result<(), HeaderSyncError> {
+    async fn ban_sync_peer(&mut self, sync_peer: &SyncPeer, reason: String) -> Result<(), HeaderSyncError> {
         helpers::ban_sync_peer(
             LOG_TARGET,
             &mut self.shared.connectivity,

--- a/base_layer/core/src/base_node/state_machine_service/states/helpers.rs
+++ b/base_layer/core/src/base_node/state_machine_service/states/helpers.rs
@@ -83,7 +83,7 @@ pub fn select_sync_peer(config: &SyncPeerConfig, sync_peers: &[SyncPeer]) -> Res
 pub fn exclude_sync_peer(
     log_target: &str,
     sync_peers: &mut SyncPeers,
-    sync_peer: SyncPeer,
+    sync_peer: &SyncPeer,
 ) -> Result<(), BlockSyncError>
 {
     trace!(target: log_target, "Excluding peer ({}) from sync peers.", sync_peer);
@@ -99,7 +99,7 @@ pub async fn ban_sync_peer_if_online(
     log_target: &str,
     connectivity: &mut ConnectivityRequester,
     sync_peers: &mut SyncPeers,
-    sync_peer: SyncPeer,
+    sync_peer: &SyncPeer,
     ban_duration: Duration,
     reason: String,
 ) -> Result<(), BlockSyncError>
@@ -119,7 +119,7 @@ pub async fn ban_sync_peer(
     log_target: &str,
     connectivity: &mut ConnectivityRequester,
     sync_peers: &mut SyncPeers,
-    sync_peer: SyncPeer,
+    sync_peer: &SyncPeer,
     ban_duration: Duration,
     reason: String,
 ) -> Result<(), BlockSyncError>
@@ -128,7 +128,7 @@ pub async fn ban_sync_peer(
     connectivity
         .ban_peer(sync_peer.node_id.clone(), ban_duration, reason)
         .await?;
-    exclude_sync_peer(log_target, sync_peers, sync_peer)
+    exclude_sync_peer(log_target, sync_peers, &sync_peer)
 }
 
 /// Ban and disconnect entire set of sync peers.
@@ -145,7 +145,7 @@ pub async fn ban_all_sync_peers<B: BlockchainBackend + 'static>(
             log_target,
             &mut shared.connectivity,
             sync_peers,
-            sync_peers[0].clone(),
+            &sync_peers[0].clone(),
             ban_duration,
             reason.clone(),
         )
@@ -192,7 +192,7 @@ pub async fn request_headers<B: BlockchainBackend + 'static>(
                             log_target,
                             &mut shared.connectivity,
                             sync_peers,
-                            sync_peer.clone(),
+                            &sync_peer,
                             config.short_term_peer_ban_duration,
                             "Peer supplied the incorrect headers".to_string(),
                         )
@@ -214,7 +214,7 @@ pub async fn request_headers<B: BlockchainBackend + 'static>(
                         log_target,
                         &mut shared.connectivity,
                         sync_peers,
-                        sync_peer.clone(),
+                        &sync_peer,
                         config.short_term_peer_ban_duration,
                         "Peer supplied the incorrect headers".to_string(),
                     )
@@ -231,7 +231,7 @@ pub async fn request_headers<B: BlockchainBackend + 'static>(
                     log_target,
                     &mut shared.connectivity,
                     sync_peers,
-                    sync_peer.clone(),
+                    &sync_peer,
                     config.short_term_peer_ban_duration,
                     "Peer provided an unexpected api response".to_string(),
                 )
@@ -247,7 +247,7 @@ pub async fn request_headers<B: BlockchainBackend + 'static>(
                     log_target,
                     &mut shared.connectivity,
                     sync_peers,
-                    sync_peer.clone(),
+                    &sync_peer,
                     config.short_term_peer_ban_duration,
                     "Failed to fetch header from peer".to_string(),
                 )
@@ -296,7 +296,7 @@ pub async fn request_mmr_node_count<B: BlockchainBackend + 'static>(
                     log_target,
                     &mut shared.connectivity,
                     sync_peers,
-                    sync_peer.clone(),
+                    &sync_peer,
                     config.short_term_peer_ban_duration,
                     "Peer provided an unexpected api response".to_string(),
                 )
@@ -312,7 +312,7 @@ pub async fn request_mmr_node_count<B: BlockchainBackend + 'static>(
                     log_target,
                     &mut shared.connectivity,
                     sync_peers,
-                    sync_peer.clone(),
+                    &sync_peer,
                     config.short_term_peer_ban_duration,
                     "Failed to fetch mmr node count from peer".to_string(),
                 )
@@ -371,7 +371,7 @@ pub async fn request_mmr_nodes<B: BlockchainBackend + 'static>(
                     log_target,
                     &mut shared.connectivity,
                     sync_peers,
-                    sync_peer.clone(),
+                    &sync_peer,
                     config.short_term_peer_ban_duration,
                     "Peer provided an unexpected api response".to_string(),
                 )
@@ -387,7 +387,7 @@ pub async fn request_mmr_nodes<B: BlockchainBackend + 'static>(
                     log_target,
                     &mut shared.connectivity,
                     sync_peers,
-                    sync_peer.clone(),
+                    &sync_peer,
                     config.short_term_peer_ban_duration,
                     "Failed to fetch mmr nodes from peer".to_string(),
                 )
@@ -437,7 +437,7 @@ pub async fn request_kernels<B: BlockchainBackend + 'static>(
                     log_target,
                     &mut shared.connectivity,
                     sync_peers,
-                    sync_peer.clone(),
+                    &sync_peer,
                     config.peer_ban_duration,
                     "Peer provided an unexpected api response".to_string(),
                 )
@@ -453,7 +453,7 @@ pub async fn request_kernels<B: BlockchainBackend + 'static>(
                     log_target,
                     &mut shared.connectivity,
                     sync_peers,
-                    sync_peer.clone(),
+                    &sync_peer,
                     config.short_term_peer_ban_duration,
                     "Failed to fetch kernels from peer".to_string(),
                 )
@@ -510,7 +510,7 @@ pub async fn request_txos<B: BlockchainBackend + 'static>(
                     log_target,
                     &mut shared.connectivity,
                     sync_peers,
-                    sync_peer.clone(),
+                    &sync_peer,
                     config.peer_ban_duration,
                     "Peer provided an unexpected api response".to_string(),
                 )
@@ -526,7 +526,7 @@ pub async fn request_txos<B: BlockchainBackend + 'static>(
                     log_target,
                     &mut shared.connectivity,
                     sync_peers,
-                    sync_peer.clone(),
+                    &sync_peer,
                     config.short_term_peer_ban_duration,
                     "Failed to fetch kernels from peer".to_string(),
                 )

--- a/base_layer/core/src/base_node/state_machine_service/states/horizon_state_sync/state_sync.rs
+++ b/base_layer/core/src/base_node/state_machine_service/states/horizon_state_sync/state_sync.rs
@@ -247,7 +247,7 @@ impl<B: BlockchainBackend + 'static> HorizonStateSynchronization<'_, '_, '_, B> 
                                 target: LOG_TARGET,
                                 "Banning peer {} from local node, because they supplied invalid kernels", sync_peer
                             );
-                            self.ban_sync_peer(sync_peer.clone(), "Peer supplied invalid kernels".to_string())
+                            self.ban_sync_peer(&sync_peer, "Peer supplied invalid kernels".to_string())
                                 .await?;
                         }
                     },
@@ -285,7 +285,7 @@ impl<B: BlockchainBackend + 'static> HorizonStateSynchronization<'_, '_, '_, B> 
         }
     }
 
-    async fn ban_sync_peer(&mut self, sync_peer: SyncPeer, reason: String) -> Result<(), HorizonSyncError> {
+    async fn ban_sync_peer(&mut self, sync_peer: &SyncPeer, reason: String) -> Result<(), HorizonSyncError> {
         helpers::ban_sync_peer(
             LOG_TARGET,
             &mut self.shared.connectivity,
@@ -365,7 +365,7 @@ impl<B: BlockchainBackend + 'static> HorizonStateSynchronization<'_, '_, '_, B> 
                             "Invalid UTXO hashes received from peer `{}`: {}", sync_peer, err
                         );
                         // Exclude the peer (without banning) as they could be on the wrong chain
-                        exclude_sync_peer(LOG_TARGET, self.sync_peers, sync_peer)?;
+                        exclude_sync_peer(LOG_TARGET, self.sync_peers, &sync_peer)?;
                     },
                     Err(e) => return Err(e),
                 };
@@ -521,11 +521,8 @@ impl<B: BlockchainBackend + 'static> HorizonStateSynchronization<'_, '_, '_, B> 
                                 sync_peer1
                             );
 
-                            self.ban_sync_peer(
-                                sync_peer1.clone(),
-                                "Peer supplied invalid UTXOs or MMR Nodes".to_string(),
-                            )
-                            .await?;
+                            self.ban_sync_peer(&sync_peer1, "Peer supplied invalid UTXOs or MMR Nodes".to_string())
+                                .await?;
                         }
                     },
                     Err(e) => return Err(e),

--- a/base_layer/core/src/blocks/blockheader.rs
+++ b/base_layer/core/src/blocks/blockheader.rs
@@ -160,9 +160,15 @@ impl BlockHeader {
     /// Calculates the total accumulated difficulty for the blockchain from the genesis block up until (and including)
     /// this block.
     pub fn total_accumulated_difficulty_inclusive_squared(&self) -> Result<u128, PowError> {
-        let mut prev_pow = self.pow.clone();
-        prev_pow.add_difficulty(&self.pow, self.achieved_difficulty()?);
-        Ok(prev_pow.total_accumulated_difficulty_squared())
+        Ok(self.get_proof_of_work()?.total_accumulated_difficulty_squared())
+    }
+
+    /// Gets the accumulated `ProofOfWork` from the genesis block up until (and including) this block.
+    ///
+    /// This function is fallible because it calculates the achieved difficulty.
+    pub fn get_proof_of_work(&self) -> Result<ProofOfWork, PowError> {
+        let difficulty = ProofOfWork::achieved_difficulty(self)?;
+        Ok(ProofOfWork::new_from_difficulty(&self.pow, difficulty))
     }
 
     pub fn into_builder(self) -> BlockBuilder {

--- a/base_layer/core/src/chain_storage/async_db.rs
+++ b/base_layer/core/src/chain_storage/async_db.rs
@@ -32,6 +32,8 @@ use crate::{
         InProgressHorizonSyncState,
         MmrTree,
     },
+    proof_of_work::{Difficulty, PowAlgorithm},
+    tari_utilities::epoch_time::EpochTime,
     transactions::{
         transaction::{TransactionKernel, TransactionOutput},
         types::{Commitment, HashOutput, Signature},
@@ -108,6 +110,7 @@ make_async!(fetch_header(block_num: u64) -> BlockHeader, "fetch_header");
 make_async!(fetch_header_by_block_hash(hash: HashOutput) -> BlockHeader, "fetch_header_by_block_hash");
 make_async!(fetch_tip_header() -> BlockHeader, "fetch_header");
 make_async!(insert_valid_headers(headers: Vec<BlockHeader>) -> (), "insert_valid_headers");
+make_async!(fetch_target_difficulties(pow_algo: PowAlgorithm, height: u64, block_window: usize) -> Vec<(EpochTime, Difficulty)>, "fetch_target_difficulties");
 
 //---------------------------------- MMR --------------------------------------------//
 make_async!(calculate_mmr_root(tree: MmrTree,additions: Vec<HashOutput>,deletions: Vec<HashOutput>) -> HashOutput, "calculate_mmr_root");

--- a/base_layer/core/src/chain_storage/blockchain_database.rs
+++ b/base_layer/core/src/chain_storage/blockchain_database.rs
@@ -1114,9 +1114,7 @@ fn store_new_block(txn: &mut DbTransaction, block: Block) -> Result<(), ChainSto
     let (header, inputs, outputs, kernels) = block.dissolve();
     let height = header.height;
     let best_block = header.hash();
-    let accumulated_difficulty =
-        ProofOfWork::new_from_difficulty(&header.pow, ProofOfWork::achieved_difficulty(&header)?)
-            .total_accumulated_difficulty();
+    let accumulated_difficulty = header.get_proof_of_work()?.total_accumulated_difficulty();
     // Build all the DB queries needed to add the block and the add it atomically
 
     // Update metadata

--- a/base_layer/core/src/proof_of_work/blake_pow.rs
+++ b/base_layer/core/src/proof_of_work/blake_pow.rs
@@ -37,10 +37,10 @@ pub fn blake_difficulty(header: &BlockHeader) -> Difficulty {
     blake_difficulty_with_hash(header).0
 }
 
-pub fn blake_difficulty_with_hash(header: &BlockHeader) -> (Difficulty, Vec<u8>) {
+fn blake_difficulty_with_hash(header: &BlockHeader) -> (Difficulty, Vec<u8>) {
     let bytes = header.hash();
     let hash = Blake2b::digest(&bytes);
-    let hash = Blake256::digest(&hash).to_vec();
+    let hash = Blake256::digest(&hash);
     let difficulty = big_endian_difficulty(&hash);
     (difficulty, hash.to_vec())
 }

--- a/base_layer/core/src/proof_of_work/mod.rs
+++ b/base_layer/core/src/proof_of_work/mod.rs
@@ -50,7 +50,7 @@ pub use sha3_pow::test as sha3_test;
 #[cfg(feature = "base_node")]
 pub mod lwma_diff;
 #[cfg(feature = "base_node")]
-pub use blake_pow::{blake_difficulty, blake_difficulty_with_hash};
+pub use blake_pow::blake_difficulty;
 #[cfg(any(feature = "base_node", feature = "transactions"))]
 pub use difficulty::{Difficulty, DifficultyAdjustment};
 #[cfg(any(feature = "base_node", feature = "transactions"))]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Added a check after block sync that the difficulty advertised by peers
is at least as high as the actual difficulty of the synced chain.

If this check fails, the peer is temporarily banned.

- Use effective pruned height to determine if the sync peer is able to
  supply blocks above a certain height.
- Saved some sync peer clones when using `ban_sync_peer`

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
If a peer advertises a difficulty higher than it can provide, it could continually force a peer out of listening state. This prevents the peer from doing this more than once.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Not tested. There is a refactor of block sync upcoming which will be easier to test.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch.
* [x] I ran `cargo-fmt --all` before pushing.
* [ ] I ran `cargo test` successfully before submitting my PR.
* [x] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
