### PR TITLE
Small refactor of `fetch_headers`

### DIFF
--- a/base_layer/core/src/base_node/validators/header_iter.rs
+++ b/base_layer/core/src/base_node/validators/header_iter.rs
@@ -50,9 +50,9 @@ impl<'a, B> HeaderIter<'a, B> {
         }
     }
 
-    fn next_chunk(&self) -> Vec<u64> {
+    fn next_chunk(&self) -> (u64, u64) {
         let upper_bound = cmp::min(self.cursor + self.chunk_size, self.height as usize);
-        (self.cursor..=upper_bound).map(|n| n as u64).collect()
+        (self.cursor as u64, upper_bound as u64)
     }
 }
 
@@ -65,13 +65,13 @@ impl<B: BlockchainBackend> Iterator for HeaderIter<'_, B> {
         }
 
         if self.chunk.is_empty() {
-            let block_nums = self.next_chunk();
+            let (start, end) = self.next_chunk();
             // We're done: No more block headers to fetch
-            if block_nums.is_empty() {
+            if start > end {
                 return None;
             }
 
-            match self.db.fetch_headers(block_nums) {
+            match self.db.fetch_headers(start, end) {
                 Ok(headers) => {
                     self.cursor += headers.len();
                     self.chunk.extend(headers);

--- a/base_layer/core/src/iterators/chunk.rs
+++ b/base_layer/core/src/iterators/chunk.rs
@@ -71,7 +71,7 @@ impl<Idx: PartialOrd> NonOverlappingIntegerPairIter<Idx> {
     }
 }
 
-macro_rules! edge_chunk_impl {
+macro_rules! non_overlapping_iter_impl {
     ($ty:ty) => {
         impl Iterator for NonOverlappingIntegerPairIter<$ty> {
             type Item = ($ty, $ty);
@@ -94,9 +94,9 @@ macro_rules! edge_chunk_impl {
     };
 }
 
-edge_chunk_impl!(u32);
-edge_chunk_impl!(u64);
-edge_chunk_impl!(usize);
+non_overlapping_iter_impl!(u32);
+non_overlapping_iter_impl!(u64);
+non_overlapping_iter_impl!(usize);
 
 #[cfg(test)]
 mod test {

--- a/base_layer/core/src/validation/helpers.rs
+++ b/base_layer/core/src/validation/helpers.rs
@@ -53,8 +53,7 @@ pub fn check_median_timestamp<B: BlockchainBackend>(
             .consensus_constants(block_header.height)
             .get_median_timestamp_count() as u64,
     );
-    let block_nums = (min_height..=height).collect();
-    let timestamps = fetch_headers(db, block_nums)?
+    let timestamps = fetch_headers(db, min_height, height)?
         .iter()
         .map(|h| h.timestamp)
         .collect::<Vec<_>>();

--- a/base_layer/core/tests/chain_storage_tests/chain_storage.rs
+++ b/base_layer/core/tests/chain_storage_tests/chain_storage.rs
@@ -1794,8 +1794,7 @@ fn pruned_mode_fetch_insert_and_commit() {
 
     // Sync headers
     let bob_height = bob_metadata.height_of_longest_chain.unwrap();
-    let block_nums = (bob_height + 1..=sync_horizon_height).collect::<Vec<u64>>();
-    let headers = alice_store.fetch_headers(block_nums).unwrap();
+    let headers = alice_store.fetch_headers(bob_height + 1, sync_horizon_height).unwrap();
     assert!(bob_store.insert_valid_headers(headers).is_ok());
 
     // Sync kernels
@@ -1905,9 +1904,12 @@ fn pruned_mode_fetch_insert_and_commit() {
     assert_eq!(bob_metadata.best_block, Some(sync_height_header.hash()));
 
     // Check headers
-    let block_nums = (0..=bob_metadata.height_of_longest_chain.unwrap()).collect::<Vec<u64>>();
-    let alice_headers = alice_store.fetch_headers(block_nums.clone()).unwrap();
-    let bob_headers = bob_store.fetch_headers(block_nums).unwrap();
+    let alice_headers = alice_store
+        .fetch_headers(0, bob_metadata.height_of_longest_chain())
+        .unwrap();
+    let bob_headers = bob_store
+        .fetch_headers(0, bob_metadata.height_of_longest_chain())
+        .unwrap();
     assert_eq!(alice_headers, bob_headers);
     // Check Kernel MMR nodes
     let alice_num_kernels = alice_store

--- a/base_layer/core/tests/horizon_state_sync.rs
+++ b/base_layer/core/tests/horizon_state_sync.rs
@@ -518,9 +518,8 @@ fn check_final_state<B: BlockchainBackend>(alice_db: &BlockchainDatabase<B>, bob
 
     // Check headers
     let network_tip_height = network_tip.height_of_longest_chain.unwrap_or(0);
-    let block_nums = (0..=network_tip_height).collect::<Vec<u64>>();
-    let alice_headers = alice_db.fetch_headers(block_nums.clone()).unwrap();
-    let bob_headers = bob_db.fetch_headers(block_nums).unwrap();
+    let alice_headers = alice_db.fetch_headers(0, network_tip_height).unwrap();
+    let bob_headers = bob_db.fetch_headers(0, network_tip_height).unwrap();
     assert_eq!(alice_headers, bob_headers);
 
     // Check Kernel MMR nodes

--- a/base_layer/core/tests/median_timestamp.rs
+++ b/base_layer/core/tests/median_timestamp.rs
@@ -37,8 +37,7 @@ use tari_crypto::tari_utilities::epoch_time::EpochTime;
 
 pub fn get_header_timestamps<B: BlockchainBackend>(db: &B, height: u64, timestamp_count: u64) -> Vec<EpochTime> {
     let min_height = height.checked_sub(timestamp_count).unwrap_or(0);
-    let block_nums = (min_height..=height).collect();
-    fetch_headers(db, block_nums)
+    fetch_headers(db, min_height, height)
         .unwrap()
         .iter()
         .map(|h| h.timestamp)


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
`fetch_headers` takes a `start` and `end_inclusive` numbers instead of
`Vec<u64>`. In all usages of `fetch_headers` the array was sequential.
This limits the API to only what is needed and so allows more optimal
implementations to exist (e.g. `SELECT * from headers where height >= x
AND height <= y`). However, the main reason for this is not wanting to
include this refactor in a future block sync implementation PR.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Small API ergonomic improvement that reduces memory usage a tiny amount and will assist with future block sync implementation.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Already tested in existing tests. 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [x] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch.
* [x] I ran `cargo-fmt --all` before pushing.
* [ ] I ran `cargo test` successfully before submitting my PR.
* [x] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
