### PR TITLE
Expose latency for last call for client RPC connections

### DIFF
--- a/comms/rpc_macros/src/generator.rs
+++ b/comms/rpc_macros/src/generator.rs
@@ -206,6 +206,10 @@ impl RpcCodeGenerator {
 
             #client_methods
 
+            pub async fn get_last_request_latency(&mut self) -> Result<Option<std::time::Duration>, #dep_mod::RpcError> {
+                self.inner.get_last_request_latency().await
+            }
+
             pub fn close(&mut self) {
                 self.inner.close();
             }

--- a/comms/src/protocol/rpc/client.rs
+++ b/comms/src/protocol/rpc/client.rs
@@ -126,6 +126,11 @@ impl RpcClient {
         self.connector.close()
     }
 
+    /// Return the latency of the last request
+    pub fn get_last_request_latency(&mut self) -> impl Future<Output = Result<Option<Duration>, RpcError>> + '_ {
+        self.connector.get_last_request_latency()
+    }
+
     async fn call_inner(
         &mut self,
         request: BaseRequest<Bytes>,
@@ -224,6 +229,16 @@ impl ClientConnector {
     pub fn close(&mut self) {
         self.inner.close_channel();
     }
+
+    pub async fn get_last_request_latency(&mut self) -> Result<Option<Duration>, RpcError> {
+        let (reply, reply_rx) = oneshot::channel();
+        self.inner
+            .send(ClientRequest::GetLastRequestLatency(reply))
+            .await
+            .map_err(|_| RpcError::ClientClosed)?;
+
+        reply_rx.await.map_err(|_| RpcError::RequestCancelled)
+    }
 }
 
 impl fmt::Debug for ClientConnector {
@@ -264,6 +279,7 @@ pub struct RpcClientWorker<TSubstream> {
     // sent determines the byte size. A u16 will be more than enough for the purpose (currently just logging)
     request_id: u16,
     ready_tx: Option<oneshot::Sender<Result<(), RpcError>>>,
+    latency: Option<Duration>,
 }
 
 impl<TSubstream> RpcClientWorker<TSubstream>
@@ -282,6 +298,7 @@ where TSubstream: AsyncRead + AsyncWrite + Unpin + Send
             framed,
             request_id: 0,
             ready_tx: Some(ready_tx),
+            latency: None,
         }
     }
 
@@ -292,11 +309,12 @@ where TSubstream: AsyncRead + AsyncWrite + Unpin + Send
         let mut handshake = Handshake::new(&mut self.framed);
         match handshake.perform_client_handshake().await {
             Ok(_) => {
+                let latency = start.elapsed();
                 debug!(
                     target: LOG_TARGET,
-                    "RPC Session negotiation completed. Latency: {:.0?}",
-                    start.elapsed()
+                    "RPC Session negotiation completed. Latency: {:.0?}", latency
                 );
+                self.latency = Some(latency);
                 if let Some(r) = self.ready_tx.take() {
                     let _ = r.send(Ok(()));
                 }
@@ -318,6 +336,9 @@ where TSubstream: AsyncRead + AsyncWrite + Unpin + Send
                         debug!(target: LOG_TARGET, "Unexpected error: {}. Worker is terminating.", err);
                         break;
                     }
+                },
+                GetLastRequestLatency(reply) => {
+                    let _ = reply.send(self.latency);
                 },
             }
         }
@@ -364,13 +385,15 @@ where TSubstream: AsyncRead + AsyncWrite + Unpin + Send
 
             let resp = match next_msg_fut.await {
                 Ok(resp) => {
+                    let latency = start.elapsed();
                     trace!(
                         target: LOG_TARGET,
                         "Received response from request #{} (method={}) in {:.0?}",
                         request_id,
                         method,
-                        start.elapsed()
+                        latency
                     );
+                    self.latency = Some(latency);
                     resp.ok_or_else(|| RpcError::ServerClosedRequest)??
                 },
                 // Timeout
@@ -445,4 +468,5 @@ pub enum ClientRequest {
         request: BaseRequest<Bytes>,
         reply: oneshot::Sender<mpsc::Receiver<Result<Response<Bytes>, RpcStatus>>>,
     },
+    GetLastRequestLatency(oneshot::Sender<Option<Duration>>),
 }

--- a/comms/src/protocol/rpc/test/smoke.rs
+++ b/comms/src/protocol/rpc/test/smoke.rs
@@ -128,6 +128,9 @@ async fn request_reponse_errors_and_streaming() // a.k.a  smoke test
         .await
         .unwrap();
 
+    // Latency is available "for free" as part of the connect protocol
+    assert!(client.get_last_request_latency().await.unwrap().is_some());
+
     let resp = client
         .say_hello(SayHelloRequest {
             name: "Yathvan".to_string(),
@@ -542,6 +545,10 @@ impl GreetingClient {
 
     pub async fn get_public_key_hex(&mut self) -> Result<String, RpcError> {
         self.inner.request_response((), 6).await
+    }
+
+    pub async fn get_last_request_latency(&mut self) -> Result<Option<Duration>, RpcError> {
+        self.inner.get_last_request_latency().await
     }
 
     pub fn close(&mut self) {


### PR DESCRIPTION
Latency measurement of the last call comes for free in RPC. This PR
exposes the latency to users of the RPC client.
