### PR TITLE
Display connected peers in TUI

### DIFF
--- a/applications/tari_console_wallet/src/main.rs
+++ b/applications/tari_console_wallet/src/main.rs
@@ -5,7 +5,7 @@
 #![deny(unused_must_use)]
 #![deny(unreachable_patterns)]
 #![deny(unknown_lints)]
-#![recursion_limit = "256"]
+#![recursion_limit = "512"]
 use log::*;
 use rand::{rngs::OsRng, RngCore};
 use std::{fs, sync::Arc};

--- a/applications/tari_console_wallet/src/ui/mod.rs
+++ b/applications/tari_console_wallet/src/ui/mod.rs
@@ -58,6 +58,9 @@ pub fn run(app: App<CrosstermBackend<Stdout>>) -> Result<(), ExitCodes> {
     Handle::current()
         .block_on(app.app_state.refresh_contacts_state())
         .map_err(|e| ExitCodes::WalletError(e.to_string()))?;
+    Handle::current()
+        .block_on(app.app_state.refresh_connected_peers_state())
+        .map_err(|e| ExitCodes::WalletError(e.to_string()))?;
     Handle::current().block_on(app.app_state.start_event_monitor());
     crossterm_loop(app)
 }

--- a/applications/tari_console_wallet/src/ui/state/app_state.rs
+++ b/applications/tari_console_wallet/src/ui/state/app_state.rs
@@ -3,7 +3,7 @@ use futures::{stream::Fuse, StreamExt};
 use qrcode::{render::unicode, QrCode};
 use std::sync::Arc;
 use tari_common::Network;
-use tari_comms::{types::CommsPublicKey, NodeIdentity};
+use tari_comms::{connectivity::ConnectivityEventRx, peer_manager::Peer, types::CommsPublicKey, NodeIdentity};
 use tari_core::transactions::tari_amount::{uT, MicroTari};
 use tari_crypto::tari_utilities::hex::Hex;
 use tari_shutdown::ShutdownSignal;
@@ -54,6 +54,15 @@ impl AppState {
     pub async fn refresh_contacts_state(&mut self) -> Result<(), UiError> {
         let mut inner = self.inner.write().await;
         inner.refresh_contacts_state().await?;
+        if let Some(data) = inner.get_updated_app_state() {
+            self.cached_data = data;
+        }
+        Ok(())
+    }
+
+    pub async fn refresh_connected_peers_state(&mut self) -> Result<(), UiError> {
+        let mut inner = self.inner.write().await;
+        inner.refresh_connected_peers_state().await?;
         if let Some(data) = inner.get_updated_app_state() {
             self.cached_data = data;
         }
@@ -194,6 +203,10 @@ impl AppState {
         } else {
             None
         }
+    }
+
+    pub fn get_connected_peers(&self) -> &Vec<Peer> {
+        &self.cached_data.connected_peers
     }
 }
 
@@ -367,12 +380,32 @@ impl AppStateInner {
         Ok(())
     }
 
-    pub async fn get_shutdown_signal(&self) -> ShutdownSignal {
+    pub async fn refresh_connected_peers_state(&mut self) -> Result<(), UiError> {
+        let connections = self.wallet.comms.connectivity().get_active_connections().await?;
+
+        let peer_manager = self.wallet.comms.peer_manager();
+        let mut peers = Vec::with_capacity(connections.len());
+        for c in connections.iter() {
+            if let Ok(p) = peer_manager.find_by_node_id(c.peer_node_id()).await {
+                peers.push(p);
+            }
+        }
+
+        self.data.connected_peers = peers;
+        self.updated = true;
+        Ok(())
+    }
+
+    pub fn get_shutdown_signal(&self) -> ShutdownSignal {
         self.wallet.comms.shutdown_signal()
     }
 
-    pub async fn get_transaction_service_event_stream(&self) -> Fuse<TransactionEventReceiver> {
+    pub fn get_transaction_service_event_stream(&self) -> Fuse<TransactionEventReceiver> {
         self.wallet.transaction_service.get_event_stream_fused()
+    }
+
+    pub fn get_connectivity_event_stream(&self) -> Fuse<ConnectivityEventRx> {
+        self.wallet.comms.connectivity().get_event_subscription().fuse()
     }
 }
 
@@ -382,6 +415,7 @@ struct AppStateData {
     completed_txs: Vec<CompletedTransaction>,
     my_identity: MyIdentity,
     contacts: Vec<UiContact>,
+    connected_peers: Vec<Peer>,
 }
 
 impl AppStateData {
@@ -408,6 +442,7 @@ impl AppStateData {
             completed_txs: Vec::new(),
             my_identity: identity,
             contacts: Vec::new(),
+            connected_peers: Vec::new(),
         }
     }
 }

--- a/applications/tari_console_wallet/src/ui/ui_error.rs
+++ b/applications/tari_console_wallet/src/ui/ui_error.rs
@@ -1,3 +1,4 @@
+use tari_comms::connectivity::ConnectivityError;
 use tari_wallet::{contacts_service::error::ContactsServiceError, transaction_service::error::TransactionServiceError};
 use thiserror::Error;
 
@@ -7,6 +8,8 @@ pub enum UiError {
     TransactionServiceError(#[from] TransactionServiceError),
     #[error(transparent)]
     ContactsServiceError(#[from] ContactsServiceError),
+    #[error(transparent)]
+    ConnectivityError(#[from] ConnectivityError),
     #[error("Could not convert string into Public Key")]
     PublicKeyParseError,
 }

--- a/applications/tari_console_wallet/src/ui/widgets/multi_column_list.rs
+++ b/applications/tari_console_wallet/src/ui/widgets/multi_column_list.rs
@@ -109,7 +109,7 @@ where T: Into<Vec<ListItem<'a>>>
             let list_area = match column.heading {
                 None => column_areas[c + 1],
                 Some(heading) => {
-                    let padded_heading = if c == 0 {
+                    let padded_heading = if c == 0 && self.highlight_style.is_some() {
                         format!("  {}", heading)
                     } else {
                         heading.to_string()


### PR DESCRIPTION
## Description
This PR adds monitoring of the Connectivity Manager event stream and display of the currently connected Peers in the Network Tab of the TUI.

When a connectivity event is detected that would affect the connected peer list the list is updated in the backend.

## How Has This Been Tested?
Manually tested

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch.
* [x] I ran `cargo-fmt --all` before pushing.
* [x] I ran `cargo test` successfully before submitting my PR.
* [x] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
