### PR TITLE
Fix transaction service bug with tx send/receive cancellation

### DIFF
--- a/base_layer/wallet/src/transaction_service/protocols/transaction_receive_protocol.rs
+++ b/base_layer/wallet/src/transaction_service/protocols/transaction_receive_protocol.rs
@@ -333,12 +333,14 @@ where TBackend: TransactionBackend + 'static
                             break;
                         }
                     },
-                     _ = cancellation_receiver => {
-                        info!(target: LOG_TARGET, "Cancelling Transaction Receive Protocol for TxId: {}", self.id);
-                        return Err(TransactionServiceProtocolError::new(
-                            self.id,
-                            TransactionServiceError::TransactionCancelled,
-                        ));
+                    result = cancellation_receiver => {
+                        if result.is_ok() {
+                            info!(target: LOG_TARGET, "Cancelling Transaction Receive Protocol for TxId: {}", self.id);
+                            return Err(TransactionServiceProtocolError::new(
+                                self.id,
+                                TransactionServiceError::TransactionCancelled,
+                            ));
+                        }
                     },
                     () = resend_timeout => {
                         match send_transaction_reply(


### PR DESCRIPTION
## Description
Fix a bug where the result of the cancellation oneshot in the send and receive protocols was not checked if it was Ok(()). This meant that on a shutdown when the sender side of that oneshot channel is dropped the receiver side resolves to a Err(_) and triggered an attempt to cancel the transaction. Generally the database was already broken down during the shutdown but depending on when stuff is dropped this could mistakenly cancel a pending transaction on wallet shutdown.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch.
* [x] I ran `cargo-fmt --all` before pushing.
* [x] I ran `cargo test` successfully before submitting my PR.
* [x] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
