### PR TITLE
Add automated stress test to base node wallet

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3924,6 +3924,7 @@ dependencies = [
  "dirs-next",
  "futures 0.3.6",
  "git2",
+ "itertools",
  "log 0.4.11",
  "log4rs",
  "prost",

--- a/applications/tari_base_node/Cargo.toml
+++ b/applications/tari_base_node/Cargo.toml
@@ -44,6 +44,7 @@ strum = "^0.19"
 strum_macros = "0.18.0"
 thiserror = "^1.0.20"
 tonic = "0.2"
+itertools = "0.8.2"
 
 [build-dependencies]
 tonic-build = "0.2"

--- a/applications/tari_base_node/src/main.rs
+++ b/applications/tari_base_node/src/main.rs
@@ -1,4 +1,4 @@
-#![recursion_limit = "256"]
+#![recursion_limit = "1024"]
 // Copyright 2019. The Tari Project
 //
 // Redistribution and use in source and binary forms, with or without modification, are permitted provided that the

--- a/applications/test_faucet/src/main.rs
+++ b/applications/test_faucet/src/main.rs
@@ -110,7 +110,7 @@ async fn write_keys(mut rx: mpsc::Receiver<(TransactionOutput, PrivateKey, Micro
     let excess = Commitment::from_public_key(&pk);
     let kernel = TransactionKernel {
         features: KernelFeatures::empty(),
-        fee: 0 * T,
+        fee: MicroTari::from(0),
         lock_height: 0,
         excess,
         excess_sig: sig,

--- a/base_layer/core/src/blocks/genesis_block.rs
+++ b/base_layer/core/src/blocks/genesis_block.rs
@@ -232,6 +232,7 @@ mod test {
     use crate::transactions::types::CryptoFactories;
 
     // This test is not run able anymore as we need to generate a new rincewind block as the kernel's changed
+    #[allow(dead_code)]
     pub fn rincewind_genesis_sanity_check() {
         let block = get_rincewind_genesis_block();
         assert_eq!(block.body.outputs().len(), 4001);

--- a/base_layer/core/src/consensus/consensus_constants.rs
+++ b/base_layer/core/src/consensus/consensus_constants.rs
@@ -257,7 +257,7 @@ impl ConsensusConstants {
                 emission_tail: 1 * T,
                 max_randomx_seed_height: std::u64::MAX,
                 proof_of_work: algos1,
-                faucet_value: 0 * T,
+                faucet_value: MicroTari::from(0),
             },
             ConsensusConstants {
                 effective_from_height: 2,
@@ -272,7 +272,7 @@ impl ConsensusConstants {
                 emission_tail: 1 * T,
                 max_randomx_seed_height: std::u64::MAX,
                 proof_of_work: algos2,
-                faucet_value: 0 * T,
+                faucet_value: MicroTari::from(0),
             },
             // min_pow_difficulty increased. Previous blocks would treat this value as 1 because of
             // a bug that was fixed.
@@ -289,7 +289,7 @@ impl ConsensusConstants {
                 emission_tail: 1 * T,
                 max_randomx_seed_height: std::u64::MAX,
                 proof_of_work: algos3,
-                faucet_value: 0 * T,
+                faucet_value: MicroTari::from(0),
             },
             // set max difficulty_max_block_interval to target_time * 6
             ConsensusConstants {
@@ -305,7 +305,7 @@ impl ConsensusConstants {
                 emission_tail: 1 * T,
                 max_randomx_seed_height: std::u64::MAX,
                 proof_of_work: algos4,
-                faucet_value: 0 * T,
+                faucet_value: MicroTari::from(0),
             },
         ]
     }
@@ -338,7 +338,7 @@ impl ConsensusConstants {
             emission_tail: 100.into(),
             max_randomx_seed_height: std::u64::MAX,
             proof_of_work: algos,
-            faucet_value: 0 * T,
+            faucet_value: MicroTari::from(0),
         }]
     }
 
@@ -404,7 +404,7 @@ impl ConsensusConstants {
             emission_tail: 100.into(),
             max_randomx_seed_height: std::u64::MAX,
             proof_of_work: algos,
-            faucet_value: 0 * T,
+            faucet_value: MicroTari::from(0),
         }]
     }
 }

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -71,7 +71,7 @@
 //! args.init_dirs(ApplicationType::BaseNode);
 //! let config = args.load_configuration().unwrap();
 //! let global = GlobalConfig::convert_from(config).unwrap();
-//! assert_eq!(global.network, Network::Rincewind);
+//! assert_eq!(global.network, Network::Ridcully);
 //! assert!(global.max_threads.is_none());
 //! # std::fs::remove_dir_all(temp_dir).unwrap();
 //! ```


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
1. This change adds the ability to perform an automated stress test that uses a command file as input. The command file accommodates one optional `coin-split` command and one or more `make-it-rain` commands. The number and amount of
test UTXOs will be assessed, and if found to be inadequate to perform the entire test, the `coin-split` will be attempted if requested. In the event of a `coin-split`, the wallet will be monitored for up to 30 minutes to determine if a sufficient number of UTXOs became available, and when that is achieved, the stress test will start. The `make-it-rain` commands can be scheduled to start at a specific time, thus the test can be started in advance.
2. Updated the `make-it-rain` to not rely on peer discovery anymore before starting the test, but rather using a ping transaction's direct send results to determine connectivity.
3. Fixed a bug in the `make-it-rain` transaction rate controller where subtracting two unsigned ints resulted in a large positive number, which broke the logic.
4. Fixed clippy warnings.
5. Fixed doc test.

Example console command:
```
stress-test ../stress_test.txt
```

Example command file:
```
# We need these!
coin-split 10000 121
# Let us stress the network
make-it-rain 10 15 8000 1 now 7ad67f1c608d25bf6126f5ce5e44cabc5f1b0464ae14efd1969d52f2dfb5c518 Testing the network!
make-it-rain 10 15 9000 1 now 7ad67f1c608d25bf6126f5ce5e44cabc5f1b0464ae14efd1969d52f2dfb5c518 Testing the network!
```
Example terminal output - test could not be performed due to time-out:
``` 
>> stress-test ..\stress_test.txt

>>
The test requires 300 UTXOs, minimum value of 9925 each (average fee included); 
  our current wallet has 271 UTXOs that is adequate.

Command: coin-split 10000 121

coin-split 10000 99
Coin split transaction created with tx_id:
16124744115680775216
coin-split 10000 22
Coin split transaction created with tx_id:
9181473920642184746

We still need 33 UTXOs, waiting for them to be created...

We have created enough UTXOs, initiating the stress test.

Command: make-it-rain 10 15 8000 1 now 7ad67f1c608d25bf6126f5ce5e44cabc5f1b0464ae14efd1969d52f2dfb5c518 Testing the network!
Command: make-it-rain 10 15 9000 1 now 7ad67f1c608d25bf6126f5ce5e44cabc5f1b0464ae14efd1969d52f2dfb5c518 Testing the network!
💀 Test transaction to `7ad67f1c608d25bf6126f5ce5e44cabc5f1b0464ae14efd1969d52f2dfb5c518` timed out , cannot perform 'make-it-rain' test
💀 Test transaction to `7ad67f1c608d25bf6126f5ce5e44cabc5f1b0464ae14efd1969d52f2dfb5c518` timed out , cannot perform 'make-it-rain' test
```
Example terminal output - test successful:
```
>> stress-test ..\stress_test.txt

>>
The test requires 300 UTXOs, minimum value of 9925 each (average fee included); our current wallet has 386 UTXOs that is adequate.

Command: make-it-rain 10 15 8000 1 now 7ad67f1c608d25bf6126f5ce5e44cabc5f1b0464ae14efd1969d52f2dfb5c518 Testing the network!
Command: make-it-rain 10 15 9000 1 now 7ad67f1c608d25bf6126f5ce5e44cabc5f1b0464ae14efd1969d52f2dfb5c518 Testing the network!
Sending 9000 µT Tari to 7ad67f1c608d25bf6126f5ce5e44cabc5f1b0464ae14efd1969d52f2dfb5c518
Sending 8000 µT Tari to 7ad67f1c608d25bf6126f5ce5e44cabc5f1b0464ae14efd1969d52f2dfb5c518
Sending 8001 µT Tari to 7ad67f1c608d25bf6126f5ce5e44cabc5f1b0464ae14efd1969d52f2dfb5c518
Sending 9001 µT Tari to 7ad67f1c608d25bf6126f5ce5e44cabc5f1b0464ae14efd1969d52f2dfb5c518
...
```

## Motivation and Context
Stress tests need to be performed more frequent for testnet an easy barrier for entry for community members.

## How Has This Been Tested?
Tested between three base nodes in Windows.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [X] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [X] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [X] I'm merging against the `development` branch.
* [X] I ran `cargo-fmt --all` before pushing.
* [X] I ran `cargo test` successfully before submitting my PR.
* [X] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
