### PR TITLE
Set port + 1 for base node wallet in TCP mode

### DIFF
--- a/applications/tari_base_node/src/builder.rs
+++ b/applications/tari_base_node/src/builder.rs
@@ -325,7 +325,7 @@ where
     //---------------------------------- Wallet --------------------------------------------//
     let wallet_handles = WalletBootstrapper {
         node_identity: wallet_node_identity,
-        config,
+        config: config.clone(),
         interrupt_signal: interrupt_signal.clone(),
         base_node_peer: base_node_comms.node_identity().to_peer(),
         factories,


### PR DESCRIPTION
This "temporary fix" only applies to TCP and SOCKS transport mode and
was refactored out at some point. This PR re-adds it (but the code is more explicit about what it's doing).
