### PR TITLE
Remove DhtJoin reply and only send join when node comes online

### DIFF
--- a/base_layer/p2p/src/initialization.rs
+++ b/base_layer/p2p/src/initialization.rs
@@ -341,7 +341,7 @@ where
         .node_identity()
         .has_peer_features(PeerFeatures::COMMUNICATION_NODE)
     {
-        comms = comms.add_rpc(RpcServer::new().add_service(dht.rpc_service()));
+        comms = comms.add_rpc_server(RpcServer::new().add_service(dht.rpc_service()));
     }
 
     // Hook up DHT messaging middlewares

--- a/comms/dht/examples/graphing_utilities/utilities.rs
+++ b/comms/dht/examples/graphing_utilities/utilities.rs
@@ -201,19 +201,20 @@ pub fn run_python_network_graph_render(
         ],
     };
 
-    let mut result = Command::new("python")
+    let result = Command::new("python")
         .args(arguments)
         .spawn()
         .map_err(|_| "Could not execute Python command".to_string())?;
-    match result
-        .wait()
-        .map_err(|_| "Python command did not complete".to_string())?
-        .code()
-    {
+    let output = result
+        .wait_with_output()
+        .map_err(|e| format!("Python command did not complete: {}", e))?;
+    match output.status.code() {
         Some(0) => Ok(()),
-        Some(1) => Err("Problem with the arguments".to_string()),
-        Some(2) => Err("No graph files to process".to_string()),
-        _ => Err("Unexpected exit from Python script".to_string()),
+        _ => Err(format!(
+            "stdout: {}, stderr:{}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        )),
     }
 }
 

--- a/comms/dht/examples/memory_net/utilities.rs
+++ b/comms/dht/examples/memory_net/utilities.rs
@@ -37,7 +37,10 @@ use tari_comms::{
     peer_manager::{NodeId, NodeIdentity, Peer, PeerFeatures, PeerStorage},
     pipeline,
     pipeline::SinkService,
-    protocol::messaging::{MessagingEvent, MessagingEventReceiver, MessagingEventSender, MessagingProtocolExtension},
+    protocol::{
+        messaging::{MessagingEvent, MessagingEventReceiver, MessagingEventSender, MessagingProtocolExtension},
+        rpc::RpcServer,
+    },
     transports::MemoryTransport,
     types::CommsDatabase,
     CommsBuilder,
@@ -52,6 +55,7 @@ use tari_comms_dht::{
     outbound::OutboundEncryption,
     Dht,
     DhtBuilder,
+    DhtConfig,
 };
 use tari_shutdown::{Shutdown, ShutdownSignal};
 use tari_storage::{
@@ -294,7 +298,7 @@ pub async fn do_network_wide_propagation(nodes: &mut [TestNode], origin_node_ind
             let node_name = node.name.clone();
 
             task::spawn(async move {
-                let result = time::timeout(Duration::from_secs(10), ims_rx.next()).await;
+                let result = time::timeout(Duration::from_secs(30), ims_rx.next()).await;
                 let mut is_success = false;
                 match result {
                     Ok(Some(msg)) => {
@@ -472,11 +476,13 @@ pub async fn do_store_and_forward_message_propagation(
     let shutdown = Shutdown::new();
     let (comms, dht, messaging_events) = setup_comms_dht(
         node_identity,
-        create_peer_storage(wallets_peers),
+        create_peer_storage(),
         tx,
         num_neighbouring_nodes,
         num_random_nodes,
         propagation_factor,
+        wallets_peers,
+        true,
         shutdown.to_signal(),
     )
     .await;
@@ -788,7 +794,7 @@ pub fn make_node_identity(features: PeerFeatures) -> Arc<NodeIdentity> {
     Arc::new(NodeIdentity::random(&mut OsRng, format!("/memory/{}", port).parse().unwrap(), features).unwrap())
 }
 
-fn create_peer_storage(peers: Vec<Peer>) -> CommsDatabase {
+fn create_peer_storage() -> CommsDatabase {
     let database_name = random::string(8);
     let datastore = LMDBBuilder::new()
         .set_path(create_temporary_data_path().to_str().unwrap())
@@ -800,12 +806,7 @@ fn create_peer_storage(peers: Vec<Peer>) -> CommsDatabase {
 
     let peer_database = datastore.get_handle(&database_name).unwrap();
     let peer_database = LMDBWrapper::new(Arc::new(peer_database));
-    let mut storage = PeerStorage::new_indexed(peer_database).unwrap();
-    for peer in peers {
-        storage.add_peer(peer).unwrap();
-    }
-
-    storage.into()
+    PeerStorage::new_indexed(peer_database).unwrap().into()
 }
 
 pub async fn make_node(
@@ -846,11 +847,13 @@ pub async fn make_node_from_node_identities(
     let shutdown = Shutdown::new();
     let (comms, dht, messaging_events) = setup_comms_dht(
         node_identity,
-        create_peer_storage(seed_peers.clone()),
+        create_peer_storage(),
         tx,
         num_neighbouring_nodes,
         num_random_nodes,
         propagation_factor,
+        seed_peers.clone(),
+        false,
         shutdown.to_signal(),
     )
     .await;
@@ -867,13 +870,15 @@ pub async fn make_node_from_node_identities(
     )
 }
 
-pub async fn setup_comms_dht(
+async fn setup_comms_dht(
     node_identity: Arc<NodeIdentity>,
     storage: CommsDatabase,
     inbound_tx: mpsc::Sender<DecryptedDhtMessage>,
     num_neighbouring_nodes: usize,
     num_random_nodes: usize,
     propagation_factor: usize,
+    seed_peers: Vec<Peer>,
+    saf_auto_request: bool,
     shutdown_signal: ShutdownSignal,
 ) -> (CommsNode, Dht, MessagingEventSender)
 {
@@ -891,6 +896,9 @@ pub async fn setup_comms_dht(
         .with_dial_backoff(ConstantBackoff::new(Duration::from_millis(1000)))
         .build()
         .unwrap();
+    for peer in seed_peers {
+        comms.peer_manager().add_peer(peer).await.unwrap();
+    }
 
     let dht = DhtBuilder::new(
         comms.node_identity(),
@@ -899,22 +907,26 @@ pub async fn setup_comms_dht(
         comms.connectivity(),
         comms.shutdown_signal(),
     )
-        .local_test()
-        //.enable_auto_join()
-        .set_auto_store_and_forward_requests(false)
-        .with_discovery_timeout(Duration::from_secs(15))
-        .with_num_neighbouring_nodes(num_neighbouring_nodes)
-        .with_num_random_nodes(num_random_nodes)
-        .with_propagation_factor(propagation_factor)
-        .build()
-        .await
-        .unwrap();
+    .with_config(DhtConfig {
+        saf_auto_request,
+        auto_join: false,
+        discovery_request_timeout: Duration::from_secs(15),
+        num_neighbouring_nodes,
+        num_random_nodes,
+        propagation_factor,
+        network_discovery: Default::default(),
+        ..DhtConfig::default_local_test()
+    })
+    .build()
+    .await
+    .unwrap();
 
     let dht_outbound_layer = dht.outbound_middleware_layer();
 
     let (messaging_events_tx, _) = broadcast::channel(100);
 
     let comms = comms
+        .add_rpc_server(RpcServer::new().add_service(dht.rpc_service()))
         .add_protocol_extension(MessagingProtocolExtension::new(
             messaging_events_tx.clone(),
             pipeline::Builder::new()

--- a/comms/dht/examples/memorynet.rs
+++ b/comms/dht/examples/memorynet.rs
@@ -148,23 +148,23 @@ async fn main() {
     // Wait for all the nodes to startup and connect to seed node
     take_a_break(NUM_NODES).await;
 
-    log::info!("------------------------------- BASE NODE JOIN -------------------------------");
-    for index in 0..nodes.len() {
-        {
-            let node = nodes.get_mut(index).expect("Couldn't get TestNode");
-            println!(
-                "Node '{}' is joining the network via the seed node '{}'",
-                node, seed_node[0]
-            );
-            node.comms
-                .connectivity()
-                .wait_for_connectivity(Duration::from_secs(10))
-                .await
-                .unwrap();
-
-            node.dht.dht_requester().send_join().await.unwrap();
-        }
-    }
+    // log::info!("------------------------------- BASE NODE JOIN -------------------------------");
+    // for index in 0..nodes.len() {
+    //     {
+    //         let node = nodes.get_mut(index).expect("Couldn't get TestNode");
+    //         println!(
+    //             "Node '{}' is joining the network via the seed node '{}'",
+    //             node, seed_node[0]
+    //         );
+    //         node.comms
+    //             .connectivity()
+    //             .wait_for_connectivity(Duration::from_secs(10))
+    //             .await
+    //             .unwrap();
+    //
+    //         node.dht.dht_requester().send_join().await.unwrap();
+    //     }
+    // }
 
     take_a_break(NUM_NODES).await;
 

--- a/comms/dht/examples/memorynet_graph_network_track_propagation.rs
+++ b/comms/dht/examples/memorynet_graph_network_track_propagation.rs
@@ -74,7 +74,6 @@ use crate::{
 };
 use env_logger::Env;
 use futures::channel::mpsc;
-use std::time::Duration;
 use tari_comms::peer_manager::PeerFeatures;
 
 #[tokio_macros::main]
@@ -149,37 +148,32 @@ async fn main() {
             .await,
         );
         println!("Node: {}", nodes[i]);
-        take_a_break(1).await;
     }
 
     // Wait for all the nodes to startup and connect to seed node
-    take_a_break(NUM_NODES).await;
+    take_a_break(NUM_NODES * 5).await;
 
-    log::info!("------------------------------- BASE NODE JOIN -------------------------------");
-    for index in 0..NUM_NODES {
-        {
-            let node = nodes.get_mut(index).expect("Couldn't get TestNode");
-            println!(
-                "Node '{}' is joining the network via the seed node '{}'",
-                node,
-                node.seed_peers[0].node_id.short_str(),
-            );
-            node.comms
-                .connectivity()
-                .wait_for_connectivity(Duration::from_secs(10))
-                .await
-                .unwrap();
-
-            node.dht.dht_requester().send_join().await.unwrap();
-        }
-
-        // Let the network settle before taking the snapshot.
-        take_a_break(1).await;
-    }
-
-    take_a_break(NUM_NODES).await;
-    take_a_break(NUM_NODES).await;
-    take_a_break(NUM_NODES).await;
+    // log::info!("------------------------------- BASE NODE JOIN -------------------------------");
+    // for index in 0..NUM_NODES {
+    //     {
+    //         let node = nodes.get_mut(index).expect("Couldn't get TestNode");
+    //         println!(
+    //             "Node '{}' is joining the network via the seed node '{}'",
+    //             node,
+    //             node.seed_peers[0].node_id.short_str(),
+    //         );
+    //         node.comms
+    //             .connectivity()
+    //             .wait_for_connectivity(Duration::from_secs(10))
+    //             .await
+    //             .unwrap();
+    //
+    //         node.dht.dht_requester().send_join().await.unwrap();
+    //     }
+    //
+    //     // Let the network settle before taking the snapshot.
+    //     take_a_break(1).await;
+    // }
 
     let _ = drain_messaging_events(&mut messaging_events_rx, false).await;
 
@@ -204,6 +198,10 @@ async fn main() {
     ) {
         println!("Error rendering graphs: {}", e);
     }
+    println!(
+        "Wrote graph output to {}/{}",
+        DEFAULT_GRAPH_OUTPUT_DIR, "join_propagation"
+    );
     banner!("That's it folks! Network is shutting down...");
     log::info!("------------------------------- SHUTDOWN -------------------------------");
     shutdown_all(nodes).await;

--- a/comms/dht/src/connectivity/test.rs
+++ b/comms/dht/src/connectivity/test.rs
@@ -40,221 +40,217 @@ use tari_comms::{
 };
 use tari_shutdown::Shutdown;
 use tari_test_utils::async_assert;
+use tokio::sync::broadcast;
 
-mod connectivity {
-    use super::*;
-    use tokio::sync::broadcast;
+async fn setup(
+    config: DhtConfig,
+    node_identity: Arc<NodeIdentity>,
+    initial_peers: Vec<Peer>,
+) -> (
+    DhtConnectivity,
+    DhtMockState,
+    ConnectivityManagerMockState,
+    Arc<PeerManager>,
+    Arc<NodeIdentity>,
+    Shutdown,
+)
+{
+    let peer_manager = build_peer_manager();
+    for peer in initial_peers {
+        peer_manager.add_peer(peer).await.unwrap();
+    }
 
-    async fn setup(
-        config: DhtConfig,
-        node_identity: Arc<NodeIdentity>,
-        initial_peers: Vec<Peer>,
-    ) -> (
-        DhtConnectivity,
-        DhtMockState,
-        ConnectivityManagerMockState,
-        Arc<PeerManager>,
-        Arc<NodeIdentity>,
-        Shutdown,
+    let shutdown = Shutdown::new();
+    let (connectivity, mock) = create_connectivity_mock();
+    let connectivity_state = mock.get_shared_state();
+    mock.spawn();
+    let (dht_requester, mock) = create_dht_actor_mock(1);
+    let dht_state = mock.get_shared_state();
+    mock.spawn();
+    let (event_publisher, _) = broadcast::channel(1);
+
+    let dht_connectivity = DhtConnectivity::new(
+        config,
+        peer_manager.clone(),
+        node_identity.clone(),
+        connectivity,
+        dht_requester,
+        event_publisher.subscribe(),
+        shutdown.to_signal(),
+    );
+
+    (
+        dht_connectivity,
+        dht_state,
+        connectivity_state,
+        peer_manager,
+        node_identity,
+        shutdown,
     )
-    {
-        let peer_manager = build_peer_manager();
-        for peer in initial_peers {
-            peer_manager.add_peer(peer).await.unwrap();
-        }
+}
 
-        let shutdown = Shutdown::new();
-        let (connectivity, mock) = create_connectivity_mock();
-        let connectivity_state = mock.get_shared_state();
-        mock.spawn();
-        let (dht_requester, mock) = create_dht_actor_mock(1);
-        let dht_state = mock.get_shared_state();
-        mock.spawn();
-        let (event_publisher, _) = broadcast::channel(1);
+#[tokio_macros::test_basic]
+async fn initialize() {
+    let config = DhtConfig {
+        num_neighbouring_nodes: 4,
+        num_random_nodes: 2,
+        ..Default::default()
+    };
+    let peers = repeat_with(|| make_node_identity().to_peer()).take(10).collect();
+    let (dht_connectivity, _, connectivity, peer_manager, node_identity, _shutdown) =
+        setup(config, make_node_identity(), peers).await;
+    dht_connectivity.spawn();
+    let neighbours = peer_manager
+        .closest_peers(node_identity.node_id(), 4, &[], Some(PeerFeatures::COMMUNICATION_NODE))
+        .await
+        .unwrap()
+        .into_iter()
+        .map(|p| p.node_id)
+        .collect::<Vec<_>>();
 
-        let dht_connectivity = DhtConnectivity::new(
-            config,
-            peer_manager.clone(),
-            node_identity.clone(),
-            connectivity,
-            dht_requester,
-            event_publisher.subscribe(),
-            shutdown.to_signal(),
-        );
+    // Wait for calls to add peers
+    async_assert!(
+        connectivity.call_count().await >= 2,
+        max_attempts = 20,
+        interval = Duration::from_millis(10),
+    );
 
-        (
-            dht_connectivity,
-            dht_state,
-            connectivity_state,
-            peer_manager,
-            node_identity,
-            shutdown,
-        )
+    let calls = connectivity.take_calls().await;
+    assert_eq!(count_string_occurrences(&calls, &["AddManagedPeers"]), 2);
+
+    // Check that neighbours are added
+    let mut managed = connectivity.get_managed_peers().await;
+    for neighbour in &neighbours {
+        let pos = managed.iter().position(|n| n == neighbour).unwrap();
+        managed.remove(pos);
     }
 
-    #[tokio_macros::test_basic]
-    async fn initialize() {
-        let config = DhtConfig {
-            num_neighbouring_nodes: 4,
-            num_random_nodes: 2,
-            ..Default::default()
-        };
-        let peers = repeat_with(|| make_node_identity().to_peer()).take(10).collect();
-        let (dht_connectivity, _, connectivity, peer_manager, node_identity, _shutdown) =
-            setup(config, make_node_identity(), peers).await;
-        dht_connectivity.spawn();
-        let neighbours = peer_manager
-            .closest_peers(node_identity.node_id(), 4, &[], Some(PeerFeatures::COMMUNICATION_NODE))
-            .await
-            .unwrap()
-            .into_iter()
-            .map(|p| p.node_id)
-            .collect::<Vec<_>>();
+    // Check that random peers (excl neighbours) are added
+    assert_eq!(managed.len(), 2);
+    assert!(managed.iter().all(|n| !neighbours.contains(n)));
+}
 
-        // Wait for calls to add peers
-        async_assert!(
-            connectivity.call_count().await >= 2,
-            max_attempts = 20,
-            interval = Duration::from_millis(10),
-        );
+#[tokio_macros::test_basic]
+async fn added_neighbours() {
+    let node_identity = make_node_identity();
+    let mut node_identities =
+        ordered_node_identities_by_distance(node_identity.node_id(), 6, PeerFeatures::COMMUNICATION_NODE);
+    // Closest to this node
+    let closer_peer = node_identities.remove(0);
+    let peers = node_identities.iter().map(|ni| ni.to_peer()).collect::<Vec<_>>();
 
-        let calls = connectivity.take_calls().await;
-        assert_eq!(count_string_occurrences(&calls, &["AddManagedPeers"]), 2);
+    let config = DhtConfig {
+        num_neighbouring_nodes: 5,
+        num_random_nodes: 0,
+        ..Default::default()
+    };
+    let (dht_connectivity, _, connectivity, _, _, _shutdown) = setup(config, node_identity, peers).await;
+    dht_connectivity.spawn();
 
-        // Check that neighbours are added
-        let mut managed = connectivity.get_managed_peers().await;
-        for neighbour in &neighbours {
-            let pos = managed.iter().position(|n| n == neighbour).unwrap();
-            managed.remove(pos);
-        }
+    // Wait for calls to add peers
+    async_assert!(
+        connectivity.call_count().await >= 1,
+        max_attempts = 20,
+        interval = Duration::from_millis(10),
+    );
 
-        // Check that random peers (excl neighbours) are added
-        assert_eq!(managed.len(), 2);
-        assert!(managed.iter().all(|n| !neighbours.contains(n)));
+    let calls = connectivity.take_calls().await;
+    assert_eq!(count_string_occurrences(&calls, &["AddManagedPeers"]), 1);
+
+    let (conn, _) = create_dummy_peer_connection(closer_peer.node_id().clone());
+    connectivity.publish_event(ConnectivityEvent::PeerConnected(conn));
+
+    async_assert!(
+        connectivity.call_count().await >= 2,
+        max_attempts = 20,
+        interval = Duration::from_millis(10),
+    );
+
+    let calls = connectivity.take_calls().await;
+    assert_eq!(count_string_occurrences(&calls, &["AddManagedPeers"]), 1);
+    assert_eq!(count_string_occurrences(&calls, &["RemovePeer"]), 1);
+
+    // Check that the closer neighbour was added to managed peers
+    let managed = connectivity.get_managed_peers().await;
+    assert_eq!(managed.len(), 5);
+    assert!(managed.contains(closer_peer.node_id()));
+}
+
+#[tokio_macros::test_basic]
+async fn reinitialize_pools_when_offline() {
+    let node_identity = make_node_identity();
+    let node_identities = repeat_with(|| make_node_identity()).take(5).collect::<Vec<_>>();
+    // Closest to this node
+    let peers = node_identities.iter().map(|ni| ni.to_peer()).collect::<Vec<_>>();
+
+    let config = DhtConfig {
+        num_neighbouring_nodes: 5,
+        num_random_nodes: 0,
+        ..Default::default()
+    };
+    let (dht_connectivity, _, connectivity, _, _, _shutdown) = setup(config, node_identity, peers).await;
+    dht_connectivity.spawn();
+
+    // Wait for calls to add peers
+    async_assert!(
+        connectivity.call_count().await >= 1,
+        max_attempts = 20,
+        interval = Duration::from_millis(10),
+    );
+
+    let calls = connectivity.take_calls().await;
+    assert_eq!(count_string_occurrences(&calls, &["AddManagedPeers"]), 1);
+
+    connectivity.publish_event(ConnectivityEvent::ConnectivityStateOffline);
+
+    async_assert!(
+        connectivity.call_count().await >= 1,
+        max_attempts = 20,
+        interval = Duration::from_millis(10),
+    );
+    let calls = connectivity.take_calls().await;
+    assert_eq!(count_string_occurrences(&calls, &["RemovePeer"]), 5);
+    assert_eq!(count_string_occurrences(&calls, &["AddManagedPeers"]), 1);
+
+    // Check that the closer neighbour was added to managed peers
+    let managed = connectivity.get_managed_peers().await;
+    assert_eq!(managed.len(), 5);
+}
+
+#[tokio_macros::test_basic]
+async fn insert_neighbour() {
+    let node_identity = make_node_identity();
+    let node_identities =
+        ordered_node_identities_by_distance(node_identity.node_id(), 10, PeerFeatures::COMMUNICATION_NODE);
+
+    let (mut dht_connectivity, _, _, _, _, _) = setup(Default::default(), node_identity.clone(), vec![]).await;
+    dht_connectivity.config.num_neighbouring_nodes = 8;
+
+    let shuffled = {
+        let mut v = node_identities.clone();
+        v.shuffle(&mut OsRng);
+        v
+    };
+
+    // First 8 inserts should not remove a peer (because num_neighbouring_nodes == 8)
+    for ni in shuffled.iter().take(8) {
+        assert!(dht_connectivity.insert_neighbour(ni.node_id().clone()).is_none());
     }
 
-    #[tokio_macros::test_basic]
-    async fn added_neighbours() {
-        let node_identity = make_node_identity();
-        let mut node_identities =
-            ordered_node_identities_by_distance(node_identity.node_id(), 6, PeerFeatures::COMMUNICATION_NODE);
-        // Closest to this node
-        let closer_peer = node_identities.remove(0);
-        let peers = node_identities.iter().map(|ni| ni.to_peer()).collect::<Vec<_>>();
-
-        let config = DhtConfig {
-            num_neighbouring_nodes: 5,
-            num_random_nodes: 0,
-            ..Default::default()
-        };
-        let (dht_connectivity, _, connectivity, _, _, _shutdown) = setup(config, node_identity, peers).await;
-        dht_connectivity.spawn();
-
-        // Wait for calls to add peers
-        async_assert!(
-            connectivity.call_count().await >= 1,
-            max_attempts = 20,
-            interval = Duration::from_millis(10),
-        );
-
-        let calls = connectivity.take_calls().await;
-        assert_eq!(count_string_occurrences(&calls, &["AddManagedPeers"]), 1);
-
-        let (conn, _) = create_dummy_peer_connection(closer_peer.node_id().clone());
-        connectivity.publish_event(ConnectivityEvent::PeerConnected(conn));
-
-        async_assert!(
-            connectivity.call_count().await >= 2,
-            max_attempts = 20,
-            interval = Duration::from_millis(10),
-        );
-
-        let calls = connectivity.take_calls().await;
-        assert_eq!(count_string_occurrences(&calls, &["AddManagedPeers"]), 1);
-        assert_eq!(count_string_occurrences(&calls, &["RemovePeer"]), 1);
-
-        // Check that the closer neighbour was added to managed peers
-        let managed = connectivity.get_managed_peers().await;
-        assert_eq!(managed.len(), 5);
-        assert!(managed.contains(closer_peer.node_id()));
+    // Next 2 inserts will always remove a node id
+    for ni in shuffled.iter().skip(8) {
+        assert!(dht_connectivity.insert_neighbour(ni.node_id().clone()).is_some())
     }
 
-    #[tokio_macros::test_basic]
-    async fn reinitialize_pools_when_offline() {
-        let node_identity = make_node_identity();
-        let node_identities = repeat_with(|| make_node_identity()).take(5).collect::<Vec<_>>();
-        // Closest to this node
-        let peers = node_identities.iter().map(|ni| ni.to_peer()).collect::<Vec<_>>();
-
-        let config = DhtConfig {
-            num_neighbouring_nodes: 5,
-            num_random_nodes: 0,
-            ..Default::default()
-        };
-        let (dht_connectivity, _, connectivity, _, _, _shutdown) = setup(config, node_identity, peers).await;
-        dht_connectivity.spawn();
-
-        // Wait for calls to add peers
-        async_assert!(
-            connectivity.call_count().await >= 1,
-            max_attempts = 20,
-            interval = Duration::from_millis(10),
-        );
-
-        let calls = connectivity.take_calls().await;
-        assert_eq!(count_string_occurrences(&calls, &["AddManagedPeers"]), 1);
-
-        connectivity.publish_event(ConnectivityEvent::ConnectivityStateOffline);
-
-        async_assert!(
-            connectivity.call_count().await >= 1,
-            max_attempts = 20,
-            interval = Duration::from_millis(10),
-        );
-        let calls = connectivity.take_calls().await;
-        assert_eq!(count_string_occurrences(&calls, &["RemovePeer"]), 5);
-        assert_eq!(count_string_occurrences(&calls, &["AddManagedPeers"]), 1);
-
-        // Check that the closer neighbour was added to managed peers
-        let managed = connectivity.get_managed_peers().await;
-        assert_eq!(managed.len(), 5);
-    }
-
-    #[tokio_macros::test_basic]
-    async fn insert_neighbour() {
-        let node_identity = make_node_identity();
-        let node_identities =
-            ordered_node_identities_by_distance(node_identity.node_id(), 10, PeerFeatures::COMMUNICATION_NODE);
-
-        let (mut dht_connectivity, _, _, _, _, _) = setup(Default::default(), node_identity.clone(), vec![]).await;
-        dht_connectivity.config.num_neighbouring_nodes = 8;
-
-        let shuffled = {
-            let mut v = node_identities.clone();
-            v.shuffle(&mut OsRng);
-            v
-        };
-
-        // First 8 inserts should not remove a peer (because num_neighbouring_nodes == 8)
-        for ni in shuffled.iter().take(8) {
-            assert!(dht_connectivity.insert_neighbour(ni.node_id().clone()).is_none());
-        }
-
-        // Next 2 inserts will always remove a node id
-        for ni in shuffled.iter().skip(8) {
-            assert!(dht_connectivity.insert_neighbour(ni.node_id().clone()).is_some())
-        }
-
-        // Check the first 7 node ids match our neighbours, the last element depends on distance and ordering of inserts
-        // (these are random). insert_neighbour only cares about inserting the element in the right order and preserving
-        // the length of the neighbour list. It doesnt care if it kicks out a closer peer (that is left for the
-        // calling code).
-        let ordered_node_ids = node_identities
-            .iter()
-            .take(7)
-            .map(|ni| ni.node_id())
-            .cloned()
-            .collect::<Vec<_>>();
-        assert_eq!(&dht_connectivity.neighbours[..7], ordered_node_ids.as_slice());
-    }
+    // Check the first 7 node ids match our neighbours, the last element depends on distance and ordering of inserts
+    // (these are random). insert_neighbour only cares about inserting the element in the right order and preserving
+    // the length of the neighbour list. It doesnt care if it kicks out a closer peer (that is left for the
+    // calling code).
+    let ordered_node_ids = node_identities
+        .iter()
+        .take(7)
+        .map(|ni| ni.node_id())
+        .cloned()
+        .collect::<Vec<_>>();
+    assert_eq!(&dht_connectivity.neighbours[..7], ordered_node_ids.as_slice());
 }

--- a/comms/dht/src/dht.rs
+++ b/comms/dht/src/dht.rs
@@ -312,7 +312,6 @@ impl Dht {
                 self.saf_response_signal_sender.clone(),
             ))
             .layer(inbound::DhtHandlerLayer::new(
-                self.config.clone(),
                 Arc::clone(&self.node_identity),
                 Arc::clone(&self.peer_manager),
                 self.discovery_service_requester(),

--- a/comms/dht/src/inbound/dht_handler/layer.rs
+++ b/comms/dht/src/inbound/dht_handler/layer.rs
@@ -21,13 +21,12 @@
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 use super::middleware::DhtHandlerMiddleware;
-use crate::{config::DhtConfig, discovery::DhtDiscoveryRequester, outbound::OutboundMessageRequester};
+use crate::{discovery::DhtDiscoveryRequester, outbound::OutboundMessageRequester};
 use std::sync::Arc;
 use tari_comms::peer_manager::{NodeIdentity, PeerManager};
 use tower::layer::Layer;
 
 pub struct DhtHandlerLayer {
-    config: DhtConfig,
     peer_manager: Arc<PeerManager>,
     node_identity: Arc<NodeIdentity>,
     outbound_service: OutboundMessageRequester,
@@ -36,7 +35,6 @@ pub struct DhtHandlerLayer {
 
 impl DhtHandlerLayer {
     pub fn new(
-        config: DhtConfig,
         node_identity: Arc<NodeIdentity>,
         peer_manager: Arc<PeerManager>,
         discovery_requester: DhtDiscoveryRequester,
@@ -44,7 +42,6 @@ impl DhtHandlerLayer {
     ) -> Self
     {
         Self {
-            config,
             node_identity,
             peer_manager,
             discovery_requester,
@@ -58,7 +55,6 @@ impl<S> Layer<S> for DhtHandlerLayer {
 
     fn layer(&self, service: S) -> Self::Service {
         DhtHandlerMiddleware::new(
-            self.config.clone(),
             service,
             Arc::clone(&self.node_identity),
             Arc::clone(&self.peer_manager),

--- a/comms/dht/src/inbound/dht_handler/middleware.rs
+++ b/comms/dht/src/inbound/dht_handler/middleware.rs
@@ -21,12 +21,7 @@
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 use super::task::ProcessDhtMessage;
-use crate::{
-    config::DhtConfig,
-    discovery::DhtDiscoveryRequester,
-    inbound::DecryptedDhtMessage,
-    outbound::OutboundMessageRequester,
-};
+use crate::{discovery::DhtDiscoveryRequester, inbound::DecryptedDhtMessage, outbound::OutboundMessageRequester};
 use futures::{task::Context, Future};
 use std::{sync::Arc, task::Poll};
 use tari_comms::{
@@ -37,7 +32,6 @@ use tower::Service;
 
 #[derive(Clone)]
 pub struct DhtHandlerMiddleware<S> {
-    config: DhtConfig,
     next_service: S,
     peer_manager: Arc<PeerManager>,
     node_identity: Arc<NodeIdentity>,
@@ -47,7 +41,6 @@ pub struct DhtHandlerMiddleware<S> {
 
 impl<S> DhtHandlerMiddleware<S> {
     pub fn new(
-        config: DhtConfig,
         next_service: S,
         node_identity: Arc<NodeIdentity>,
         peer_manager: Arc<PeerManager>,
@@ -57,7 +50,6 @@ impl<S> DhtHandlerMiddleware<S> {
     ) -> Self
     {
         Self {
-            config,
             next_service,
             node_identity,
             peer_manager,
@@ -81,7 +73,6 @@ where S: Service<DecryptedDhtMessage, Response = (), Error = PipelineError> + Cl
 
     fn call(&mut self, message: DecryptedDhtMessage) -> Self::Future {
         ProcessDhtMessage::new(
-            self.config.clone(),
             self.next_service.clone(),
             Arc::clone(&self.peer_manager),
             self.outbound_service.clone(),

--- a/comms/dht/src/inbound/dht_handler/task.rs
+++ b/comms/dht/src/inbound/dht_handler/task.rs
@@ -21,7 +21,6 @@
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 use crate::{
-    config::DhtConfig,
     discovery::DhtDiscoveryRequester,
     envelope::NodeDestination,
     inbound::{error::DhtInboundError, message::DecryptedDhtMessage},
@@ -45,7 +44,6 @@ use tower::{Service, ServiceExt};
 const LOG_TARGET: &str = "comms::dht::dht_handler";
 
 pub struct ProcessDhtMessage<S> {
-    config: DhtConfig,
     next_service: S,
     peer_manager: Arc<PeerManager>,
     outbound_service: OutboundMessageRequester,
@@ -58,7 +56,6 @@ impl<S> ProcessDhtMessage<S>
 where S: Service<DecryptedDhtMessage, Response = (), Error = PipelineError>
 {
     pub fn new(
-        config: DhtConfig,
         next_service: S,
         peer_manager: Arc<PeerManager>,
         outbound_service: OutboundMessageRequester,
@@ -68,7 +65,6 @@ where S: Service<DecryptedDhtMessage, Response = (), Error = PipelineError>
     ) -> Self
     {
         Self {
-            config,
             next_service,
             peer_manager,
             outbound_service,
@@ -196,32 +192,6 @@ where S: Service<DecryptedDhtMessage, Response = (), Error = PipelineError>
             return Ok(());
         }
 
-        let origin_node_id = origin_peer.node_id;
-
-        // Send a join request back to the origin peer of the join request if:
-        // - this join request was not sent directly from the origin peer but was forwarded (from the source peer), and
-        // - that peer is from the same region of network.
-        //
-        // If it was not forwarded then we assume the source peer already has this node's details in
-        // it's peer list.
-        if source_peer.public_key != origin_peer.public_key &&
-            self.peer_manager
-                .in_network_region(
-                    &origin_node_id,
-                    self.node_identity.node_id(),
-                    self.config.num_neighbouring_nodes,
-                )
-                .await?
-        {
-            trace!(
-                target: LOG_TARGET,
-                "Sending Join to joining peer with public key '{}'",
-                origin_peer.public_key
-            );
-
-            self.send_join_direct(origin_peer.public_key).await?;
-        }
-
         if is_saf_message {
             debug!(
                 target: LOG_TARGET,
@@ -230,9 +200,9 @@ where S: Service<DecryptedDhtMessage, Response = (), Error = PipelineError>
             return Ok(());
         }
 
-        // Only propagate a join that was not directly sent to this node (presumably in response to a join this node
-        // sent)
-        // TODO: Join should have a response message type
+        let origin_node_id = origin_peer.node_id;
+
+        // Only propagate a join that was not directly sent to this node
         if dht_header.destination != self.node_identity.public_key() &&
             dht_header.destination != self.node_identity.node_id()
         {
@@ -335,26 +305,6 @@ where S: Service<DecryptedDhtMessage, Response = (), Error = PipelineError>
 
         // Send the origin the current nodes latest contact info
         self.send_discovery_response(origin_peer.public_key, discover_msg.nonce)
-            .await?;
-
-        Ok(())
-    }
-
-    /// Send a network join update request directly to a specific known peer
-    async fn send_join_direct(&mut self, dest_public_key: CommsPublicKey) -> Result<(), DhtInboundError> {
-        let join_msg = JoinMessage::from(&self.node_identity);
-
-        trace!(target: LOG_TARGET, "Sending direct join request to {}", dest_public_key);
-        self.outbound_service
-            .send_message_no_header(
-                SendMessageParams::new()
-                    .direct_public_key(dest_public_key.clone())
-                    .with_destination(NodeDestination::PublicKey(Box::new(dest_public_key)))
-                    .with_dht_message_type(DhtMessageType::Join)
-                    .force_origin()
-                    .finish(),
-                join_msg,
-            )
             .await?;
 
         Ok(())

--- a/comms/dht/src/network_discovery/test.rs
+++ b/comms/dht/src/network_discovery/test.rs
@@ -132,7 +132,7 @@ mod state_machine {
             .await;
 
         connectivity_mock
-            .set_connectivity_status(ConnectivityStatus::Online)
+            .set_connectivity_status(ConnectivityStatus::Online(NUM_PEERS))
             .await;
         connectivity_mock.add_active_connection(connection).await;
 

--- a/comms/dht/src/proto/mod.rs
+++ b/comms/dht/src/proto/mod.rs
@@ -92,7 +92,7 @@ impl fmt::Display for dht::JoinMessage {
             "JoinMessage(NodeId = {}, Addresses = {:?}, Features = {:?})",
             self.node_id.to_hex(),
             self.addresses,
-            self.peer_features
+            PeerFeatures::from_bits_truncate(self.peer_features),
         )
     }
 }

--- a/comms/dht/tests/dht.rs
+++ b/comms/dht/tests/dht.rs
@@ -230,12 +230,12 @@ async fn dht_join_propagation() {
     // to A.
     node_A.dht.dht_requester().send_join().await.unwrap();
 
-    let node_A_peer_manager = node_A.comms.peer_manager();
+    let node_B_peer_manager = node_B.comms.peer_manager();
     let node_C_peer_manager = node_C.comms.peer_manager();
 
-    // Check that Node A knows about Node C and vice versa
+    // Check that Node B and C know node A
     async_assert_eventually!(
-        node_A_peer_manager.exists(node_C.node_identity().public_key()).await,
+        node_B_peer_manager.exists(node_A.node_identity().public_key()).await,
         expect = true,
         max_attempts = 10,
         interval = Duration::from_millis(1000)
@@ -247,11 +247,11 @@ async fn dht_join_propagation() {
         interval = Duration::from_millis(500)
     );
 
-    let node_C_peer = node_A_peer_manager
-        .find_by_public_key(node_C.node_identity().public_key())
+    let node_A_peer = node_C_peer_manager
+        .find_by_public_key(node_A.node_identity().public_key())
         .await
         .unwrap();
-    assert_eq!(node_C_peer.features, node_C.comms.node_identity().features());
+    assert_eq!(node_A_peer.features, node_A.comms.node_identity().features());
 
     node_A.shutdown().await;
     node_B.shutdown().await;

--- a/comms/src/builder/comms_node.rs
+++ b/comms/src/builder/comms_node.rs
@@ -77,7 +77,7 @@ impl UnspawnedCommsNode {
     /// CommsBuilder::new().add_rpc_service(server).build();
     /// ```
     #[cfg(feature = "rpc")]
-    pub fn add_rpc<T: ProtocolExtension + 'static>(mut self, rpc: T) -> Self {
+    pub fn add_rpc_server<T: ProtocolExtension + 'static>(mut self, rpc: T) -> Self {
         // Rpc router is treated the same as any other `ProtocolExtension` however this method may make it clearer for
         // users that this is the correct way to add the RPC server
         self.protocol_extensions.add(rpc);

--- a/comms/src/connectivity/error.rs
+++ b/comms/src/connectivity/error.rs
@@ -27,7 +27,7 @@ use thiserror::Error;
 pub enum ConnectivityError {
     #[error("Cannot send request because ConnectivityActor disconnected")]
     ActorDisconnected,
-    #[error("Response was unexpectedly cancelled")]
+    #[error("Internal actor response was unexpectedly cancelled")]
     ActorResponseCancelled,
     #[error("PeerManagerError: {0}")]
     PeerManagerError(#[from] PeerManagerError),

--- a/comms/src/macros.rs
+++ b/comms/src/macros.rs
@@ -176,5 +176,16 @@ macro_rules! is_fn {
                 _ => false
             }
         }
-    }
+    };
+    (
+        $(#[$outer:meta])*
+        $name: ident, $($enum_key:ident)::+ ( $($p:tt),* )
+    ) => {
+      pub fn $name(&self) -> bool {
+            match self {
+                $($enum_key)::+($($p),*) => true,
+                _ => false
+            }
+        }
+    };
 }

--- a/comms/src/protocol/error.rs
+++ b/comms/src/protocol/error.rs
@@ -29,8 +29,8 @@ pub enum ProtocolError {
     IoError(#[from] io::Error),
     #[error("The ProtocolId was longer than {}", u8::max_value())]
     ProtocolIdTooLong,
-    #[error("Protocol negotiation failed because the peer did not accept any protocols")]
-    ProtocolOutboundNegotiationFailed,
+    #[error("Protocol negotiation failed because the peer did not accept any of the given protocols: {0}")]
+    ProtocolOutboundNegotiationFailed(String),
     #[error("Protocol negotiation failed because the peer did not offer any protocols supported by this node")]
     ProtocolInboundNegotiationFailed,
     #[error("Optimistic protocol negotiation failed because the peer did not offer a protocol supported by this node")]

--- a/comms/src/protocol/rpc/test/comms_integration.rs
+++ b/comms/src/protocol/rpc/test/comms_integration.rs
@@ -50,7 +50,7 @@ async fn run_service() {
         .with_peer_storage(CommsDatabase::new())
         .build()
         .unwrap()
-        .add_rpc(RpcServer::new().add_service(rpc_service))
+        .add_rpc_server(RpcServer::new().add_service(rpc_service))
         .spawn_with_transport(MemoryTransport)
         .await
         .unwrap();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
- Node will no longer reply to join messages as this method is
  deprecated in favour of #2306. Until #2306 is released to mobile,
  mobile wallets will fail to discover neighbouring nodes that include
  this PR.
- DHT connectivity actor only sends a join when online. Join is now more
  like an "announce" that optionally announces to the neighbourhood of the node that
  the node is online. `Join` could be renamed to `Announce` in future. 
- Only publish ConnectivityDegraded event only if the number of peers has changed
- Updated _memorynet_

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The primary suspect for why join messages are flooding is:
- Network discovery finds many new peers/neighbours, then
- Connectivity manager is notified and the new peers are added as "managed peers", then
- Each time this happens the connectivity status event (online, degraded) is published,
- This causes a Join message to be sent (as the node is now has a connection)

However there is a protection in place for this:
If a join was sent in the last 10 minutes, don't send another UNLESS there is only a single peer connected.
A node can only connect to a single peer + network discovery is doing its work and finding new peers = flooding.

It is currently not clear why the node may be in this state, however removing bug surface is the best approach.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Existing tests updated where necessary. 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch.
* [x] I ran `cargo-fmt --all` before pushing.
* [ ] I ran `cargo test` successfully before submitting my PR.
* [x] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
