### PR TITLE
Add a client key-value store to the wallet and wallet_ffi

### DIFF
--- a/base_layer/wallet/migrations/2020-10-20-094420_add_client_key_value_store/down.sql
+++ b/base_layer/wallet/migrations/2020-10-20-094420_add_client_key_value_store/down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS client_key_values;

--- a/base_layer/wallet/migrations/2020-10-20-094420_add_client_key_value_store/up.sql
+++ b/base_layer/wallet/migrations/2020-10-20-094420_add_client_key_value_store/up.sql
@@ -1,0 +1,4 @@
+CREATE TABLE client_key_values (
+    key TEXT PRIMARY KEY NOT NULL,
+    value TEXT NOT NULL
+);

--- a/base_layer/wallet/src/schema.rs
+++ b/base_layer/wallet/src/schema.rs
@@ -1,4 +1,11 @@
 table! {
+    client_key_values (key) {
+        key -> Text,
+        value -> Text,
+    }
+}
+
+table! {
     completed_transactions (tx_id) {
         tx_id -> BigInt,
         source_public_key -> Binary,
@@ -96,6 +103,7 @@ table! {
 }
 
 allow_tables_to_appear_in_same_query!(
+    client_key_values,
     completed_transactions,
     contacts,
     inbound_transactions,

--- a/base_layer/wallet/src/storage/database.rs
+++ b/base_layer/wallet/src/storage/database.rs
@@ -47,16 +47,20 @@ pub trait WalletBackend: Send + Sync + Clone {
 pub enum DbKey {
     CommsSecretKey,
     CommsPublicKey,
+    ClientKey(String),
 }
 
 pub enum DbValue {
     CommsSecretKey(CommsSecretKey),
     CommsPublicKey(CommsPublicKey),
+    ClientValue(String),
+    ValueCleared,
 }
 
 #[derive(Clone)]
 pub enum DbKeyValuePair {
     CommsSecretKey(CommsSecretKey),
+    ClientKeyValue(String, String),
 }
 
 pub enum WriteOperation {
@@ -126,6 +130,47 @@ where T: WalletBackend + 'static
             .map_err(|err| WalletStorageError::BlockingTaskSpawnError(err.to_string()))
             .and_then(|inner_result| inner_result)
     }
+
+    pub async fn set_client_key_value(&self, key: String, value: String) -> Result<(), WalletStorageError> {
+        let db_clone = self.db.clone();
+
+        tokio::task::spawn_blocking(move || {
+            db_clone.write(WriteOperation::Insert(DbKeyValuePair::ClientKeyValue(key, value)))
+        })
+        .await
+        .map_err(|err| WalletStorageError::BlockingTaskSpawnError(err.to_string()))??;
+        Ok(())
+    }
+
+    pub async fn get_client_key_value(&self, key: String) -> Result<Option<String>, WalletStorageError> {
+        let db_clone = self.db.clone();
+
+        let c = tokio::task::spawn_blocking(move || match db_clone.fetch(&DbKey::ClientKey(key.clone())) {
+            Ok(None) => Ok(None),
+            Ok(Some(DbValue::ClientValue(k))) => Ok(Some(k)),
+            Ok(Some(other)) => unexpected_result(DbKey::ClientKey(key), other),
+            Err(e) => log_error(DbKey::ClientKey(key), e),
+        })
+        .await
+        .map_err(|err| WalletStorageError::BlockingTaskSpawnError(err.to_string()))??;
+        Ok(c)
+    }
+
+    pub async fn clear_client_value(&self, key: String) -> Result<bool, WalletStorageError> {
+        let db_clone = self.db.clone();
+
+        let c = tokio::task::spawn_blocking(move || {
+            match db_clone.write(WriteOperation::Remove(DbKey::ClientKey(key.clone()))) {
+                Ok(None) => Ok(false),
+                Ok(Some(DbValue::ValueCleared)) => Ok(true),
+                Ok(Some(other)) => unexpected_result(DbKey::ClientKey(key), other),
+                Err(e) => log_error(DbKey::ClientKey(key), e),
+            }
+        })
+        .await
+        .map_err(|err| WalletStorageError::BlockingTaskSpawnError(err.to_string()))??;
+        Ok(c)
+    }
 }
 
 impl Display for DbKey {
@@ -133,6 +178,7 @@ impl Display for DbKey {
         match self {
             DbKey::CommsSecretKey => f.write_str(&"CommsSecretKey".to_string()),
             DbKey::CommsPublicKey => f.write_str(&"CommsPublicKey".to_string()),
+            DbKey::ClientKey(k) => f.write_str(&format!("ClientKey: {:?}", k)),
         }
     }
 }
@@ -142,6 +188,8 @@ impl Display for DbValue {
         match self {
             DbValue::CommsSecretKey(k) => f.write_str(&format!("CommsSecretKey: {:?}", k)),
             DbValue::CommsPublicKey(k) => f.write_str(&format!("CommsPublicKey: {:?}", k)),
+            DbValue::ClientValue(v) => f.write_str(&format!("ClientValue: {:?}", v)),
+            DbValue::ValueCleared => f.write_str(&"ValueCleared".to_string()),
         }
     }
 }
@@ -190,6 +238,45 @@ mod test {
         assert_eq!(secret_key, stored_key);
         runtime.block_on(db.clear_comms_secret_key()).unwrap();
         assert!(runtime.block_on(db.get_comms_secret_key()).unwrap().is_none());
+
+        let client_key_values = vec![
+            ("key1".to_string(), "value1".to_string()),
+            ("key2".to_string(), "value2".to_string()),
+            ("key3".to_string(), "value3".to_string()),
+        ];
+
+        for kv in client_key_values.iter() {
+            runtime
+                .block_on(db.set_client_key_value(kv.0.clone(), kv.1.clone()))
+                .unwrap();
+        }
+
+        assert!(runtime
+            .block_on(db.get_client_key_value("wrong".to_string()))
+            .unwrap()
+            .is_none());
+
+        runtime
+            .block_on(db.set_client_key_value(client_key_values[0].0.clone(), "updated".to_string()))
+            .unwrap();
+
+        assert_eq!(
+            runtime
+                .block_on(db.get_client_key_value(client_key_values[0].0.clone()))
+                .unwrap()
+                .unwrap(),
+            "updated".to_string()
+        );
+
+        assert!(!runtime.block_on(db.clear_client_value("wrong".to_string())).unwrap());
+
+        assert!(runtime
+            .block_on(db.clear_client_value(client_key_values[0].0.clone()))
+            .unwrap());
+
+        assert!(!runtime
+            .block_on(db.clear_client_value(client_key_values[0].0.clone()))
+            .unwrap());
     }
 
     #[test]

--- a/base_layer/wallet/src/storage/sqlite_db.rs
+++ b/base_layer/wallet/src/storage/sqlite_db.rs
@@ -22,17 +22,21 @@
 
 use crate::{
     error::WalletStorageError,
-    schema::wallet_settings,
+    schema::{client_key_values, wallet_settings},
     storage::database::{DbKey, DbKeyValuePair, DbValue, WalletBackend, WriteOperation},
-    util::encryption::{decrypt_bytes_integral_nonce, encrypt_bytes_integral_nonce, AES_NONCE_BYTES},
+    util::encryption::{decrypt_bytes_integral_nonce, encrypt_bytes_integral_nonce, Encryptable, AES_NONCE_BYTES},
 };
 use aes_gcm::{
     aead::{generic_array::GenericArray, Aead},
     Aes256Gcm,
+    Error as AeadError,
 };
 use diesel::{prelude::*, SqliteConnection};
 use log::*;
-use std::sync::{Arc, Mutex, RwLock};
+use std::{
+    str::from_utf8,
+    sync::{Arc, Mutex, RwLock},
+};
 use tari_comms::types::{CommsPublicKey, CommsSecretKey};
 use tari_crypto::{
     keys::PublicKey,
@@ -183,6 +187,24 @@ impl WalletSqliteDatabase {
 
         Ok(())
     }
+
+    fn decrypt_if_necessary<T: Encryptable<Aes256Gcm>>(&self, o: &mut T) -> Result<(), WalletStorageError> {
+        let cipher = acquire_read_lock!(self.cipher);
+        if let Some(cipher) = cipher.as_ref() {
+            o.decrypt(cipher)
+                .map_err(|_| WalletStorageError::AeadError("Decryption Error".to_string()))?;
+        }
+        Ok(())
+    }
+
+    fn encrypt_if_necessary<T: Encryptable<Aes256Gcm>>(&self, o: &mut T) -> Result<(), WalletStorageError> {
+        let cipher = acquire_read_lock!(self.cipher);
+        if let Some(cipher) = cipher.as_ref() {
+            o.encrypt(cipher)
+                .map_err(|_| WalletStorageError::AeadError("Encryption Error".to_string()))?;
+        }
+        Ok(())
+    }
 }
 
 impl WalletBackend for WalletSqliteDatabase {
@@ -215,6 +237,13 @@ impl WalletBackend for WalletSqliteDatabase {
                     None
                 }
             },
+            DbKey::ClientKey(k) => match ClientKeyValueSql::get(k, &conn)? {
+                None => None,
+                Some(mut v) => {
+                    self.decrypt_if_necessary(&mut v)?;
+                    Some(DbValue::ClientValue(v.value))
+                },
+            },
         };
 
         Ok(result)
@@ -227,12 +256,33 @@ impl WalletBackend for WalletSqliteDatabase {
                 DbKeyValuePair::CommsSecretKey(sk) => {
                     self.set_comms_private_key(&sk, &(*conn))?;
                 },
+                DbKeyValuePair::ClientKeyValue(k, v) => {
+                    // First see if we will overwrite a value so we can return the old value
+                    let value_to_return = if let Some(mut found_value) = ClientKeyValueSql::get(&k, &conn)? {
+                        self.decrypt_if_necessary(&mut found_value)?;
+                        Some(found_value)
+                    } else {
+                        None
+                    };
+
+                    let mut client_key_value = ClientKeyValueSql::new(k, v);
+                    self.encrypt_if_necessary(&mut client_key_value)?;
+
+                    client_key_value.set(&conn)?;
+
+                    return Ok(value_to_return.map(|v| DbValue::ClientValue(v.value)));
+                },
             },
             WriteOperation::Remove(k) => match k {
                 DbKey::CommsSecretKey => {
                     let _ = WalletSettingSql::clear(format!("{}", DbKey::CommsSecretKey), &conn)?;
                 },
                 DbKey::CommsPublicKey => return Err(WalletStorageError::OperationNotSupported),
+                DbKey::ClientKey(k) => {
+                    if ClientKeyValueSql::clear(&k, &conn)? {
+                        return Ok(Some(DbValue::ValueCleared));
+                    }
+                },
             },
         }
 
@@ -255,6 +305,15 @@ impl WalletBackend for WalletSqliteDatabase {
         let ciphertext_integral_nonce = encrypt_bytes_integral_nonce(&cipher, secret_key.to_vec())
             .map_err(|_| WalletStorageError::AeadError("Encryption Error".to_string()))?;
         WalletSettingSql::new(format!("{}", DbKey::CommsSecretKey), ciphertext_integral_nonce.to_hex()).set(&conn)?;
+
+        // Encrypt all the client values
+        let mut client_key_values = ClientKeyValueSql::index(&conn)?;
+        for ckv in client_key_values.iter_mut() {
+            ckv.encrypt(&cipher)
+                .map_err(|_| WalletStorageError::AeadError("Encryption Error".to_string()))?;
+            ckv.set(&conn)?;
+        }
+
         (*current_cipher) = Some(cipher);
 
         Ok(())
@@ -277,6 +336,15 @@ impl WalletBackend for WalletSqliteDatabase {
             .map_err(|_| WalletStorageError::AeadError("Decryption Error".to_string()))?;
         let decrypted_key = CommsSecretKey::from_bytes(secret_key_bytes.as_slice())?;
         WalletSettingSql::new(format!("{}", DbKey::CommsSecretKey), decrypted_key.to_hex()).set(&conn)?;
+
+        // Decrypt all the client values
+        let mut client_key_values = ClientKeyValueSql::index(&conn)?;
+        for ckv in client_key_values.iter_mut() {
+            ckv.decrypt(&cipher)
+                .map_err(|_| WalletStorageError::AeadError("Decryption Error".to_string()))?;
+            ckv.set(&conn)?;
+        }
+
         // Now that all the decryption has been completed we can safely remove the cipher fully
         let _ = (*current_cipher).take();
 
@@ -323,11 +391,74 @@ impl WalletSettingSql {
     }
 }
 
+/// A Sql version of the wallet setting key-value table
+#[derive(Clone, Debug, Queryable, Insertable, PartialEq)]
+#[table_name = "client_key_values"]
+struct ClientKeyValueSql {
+    key: String,
+    value: String,
+}
+
+impl ClientKeyValueSql {
+    pub fn new(key: String, value: String) -> Self {
+        Self { key, value }
+    }
+
+    pub fn index(conn: &SqliteConnection) -> Result<Vec<Self>, WalletStorageError> {
+        Ok(client_key_values::table.load::<ClientKeyValueSql>(conn)?)
+    }
+
+    pub fn set(&self, conn: &SqliteConnection) -> Result<(), WalletStorageError> {
+        diesel::replace_into(client_key_values::table)
+            .values(self)
+            .execute(conn)?;
+
+        Ok(())
+    }
+
+    pub fn get(key: &str, conn: &SqliteConnection) -> Result<Option<Self>, WalletStorageError> {
+        client_key_values::table
+            .filter(client_key_values::key.eq(key))
+            .first::<ClientKeyValueSql>(conn)
+            .map(Some)
+            .or_else(|err| match err {
+                diesel::result::Error::NotFound => Ok(None),
+                err => Err(err.into()),
+            })
+    }
+
+    pub fn clear(key: &str, conn: &SqliteConnection) -> Result<bool, WalletStorageError> {
+        let num_deleted =
+            diesel::delete(client_key_values::table.filter(client_key_values::key.eq(key))).execute(conn)?;
+
+        Ok(num_deleted > 0)
+    }
+}
+
+impl Encryptable<Aes256Gcm> for ClientKeyValueSql {
+    #[allow(unused_assignments)]
+    fn encrypt(&mut self, cipher: &Aes256Gcm) -> Result<(), AeadError> {
+        let encrypted_value = encrypt_bytes_integral_nonce(&cipher, self.clone().value.as_bytes().to_vec())?;
+        self.value = encrypted_value.to_hex();
+        Ok(())
+    }
+
+    #[allow(unused_assignments)]
+    fn decrypt(&mut self, cipher: &Aes256Gcm) -> Result<(), AeadError> {
+        let decrypted_value =
+            decrypt_bytes_integral_nonce(&cipher, from_hex(self.value.as_str()).map_err(|_| aes_gcm::Error)?)?;
+        self.value = from_utf8(decrypted_value.as_slice())
+            .map_err(|_| AeadError)?
+            .to_string();
+        Ok(())
+    }
+}
+
 #[cfg(test)]
 mod test {
     use crate::storage::{
         database::{DbKey, DbValue, WalletBackend},
-        sqlite_db::{WalletSettingSql, WalletSqliteDatabase},
+        sqlite_db::{ClientKeyValueSql, WalletSettingSql, WalletSqliteDatabase},
         sqlite_utilities::run_migration_and_create_sqlite_connection,
     };
     use aes_gcm::{
@@ -452,15 +583,24 @@ mod test {
     #[test]
     fn test_apply_and_remove_encryption() {
         let db_name = format!("{}.sqlite3", string(8).as_str());
-        let db_folder = tempdir().unwrap().path().to_str().unwrap().to_string();
-        let connection = run_migration_and_create_sqlite_connection(&format!("{}{}", db_folder, db_name)).unwrap();
+        let db_tempdir = tempdir().unwrap();
+        let db_folder = db_tempdir.path().to_str().unwrap().to_string();
+        let db_path = format!("{}/{}", db_folder, db_name);
+        let connection = run_migration_and_create_sqlite_connection(&db_path).unwrap();
 
         let secret_key = CommsSecretKey::random(&mut OsRng);
+        let mut key_values = vec![];
+        key_values.push(ClientKeyValueSql::new("key1".to_string(), "value1".to_string()));
+        key_values.push(ClientKeyValueSql::new("key2".to_string(), "value2".to_string()));
+        key_values.push(ClientKeyValueSql::new("key3".to_string(), "value3".to_string()));
 
         let db = WalletSqliteDatabase::new(connection.clone(), None).unwrap();
         {
             let conn = acquire_lock!(connection);
             db.set_comms_private_key(&secret_key, &conn).unwrap();
+            for kv in key_values.iter() {
+                kv.set(&conn).unwrap();
+            }
         }
 
         let read_secret_key1 = match db.fetch(&DbKey::CommsSecretKey).unwrap().unwrap() {
@@ -480,6 +620,18 @@ mod test {
                 panic!("Should be able to read Key");
             },
         };
+
+        for kv in key_values.iter() {
+            match db.fetch(&DbKey::ClientKey(kv.key.clone())).unwrap().unwrap() {
+                DbValue::ClientValue(v) => {
+                    assert_eq!(kv.value, v);
+                },
+                _ => {
+                    panic!("Should be able to read Key/Value");
+                },
+            }
+        }
+
         assert_eq!(secret_key, read_secret_key2);
         {
             let conn = acquire_lock!(connection);
@@ -509,6 +661,56 @@ mod test {
                 .unwrap()
                 .unwrap();
             assert_eq!(secret_key_str.len(), 64);
+        }
+
+        for kv in key_values.iter() {
+            match db.fetch(&DbKey::ClientKey(kv.key.clone())).unwrap().unwrap() {
+                DbValue::ClientValue(v) => {
+                    assert_eq!(kv.value, v);
+                },
+                _ => {
+                    panic!("Should be able to read Key/Value2");
+                },
+            }
+        }
+    }
+
+    #[test]
+    fn test_client_key_value_store() {
+        let db_name = format!("{}.sqlite3", string(8).as_str());
+        let db_folder = tempdir().unwrap().path().to_str().unwrap().to_string();
+        let connection = run_migration_and_create_sqlite_connection(&format!("{}{}", db_folder, db_name)).unwrap();
+        let conn = acquire_lock!(connection);
+
+        let key1 = "key1".to_string();
+        let value1 = "value1".to_string();
+        let key2 = "key2".to_string();
+        let value2 = "value2".to_string();
+
+        ClientKeyValueSql::new(key1.clone(), value1.clone()).set(&conn).unwrap();
+        assert!(ClientKeyValueSql::get(&key2, &conn).unwrap().is_none());
+        if let Some(ckv) = ClientKeyValueSql::get(&key1, &conn).unwrap() {
+            assert_eq!(ckv.value, value1);
+        } else {
+            assert!(false, "Should find value");
+        }
+        assert!(!ClientKeyValueSql::clear(&key2, &conn).unwrap());
+
+        ClientKeyValueSql::new(key2.clone(), value2.clone()).set(&conn).unwrap();
+
+        let values = ClientKeyValueSql::index(&conn).unwrap();
+        assert_eq!(values.len(), 2);
+
+        assert!(values[0].value == value1);
+        assert!(values[1].value == value2);
+
+        assert!(ClientKeyValueSql::clear(&key1, &conn).unwrap());
+        assert!(ClientKeyValueSql::get(&key1, &conn).unwrap().is_none());
+
+        if let Some(ckv) = ClientKeyValueSql::get(&key2, &conn).unwrap() {
+            assert_eq!(ckv.value, value2);
+        } else {
+            assert!(false, "Should find value2");
         }
     }
 }

--- a/base_layer/wallet_ffi/src/error.rs
+++ b/base_layer/wallet_ffi/src/error.rs
@@ -248,6 +248,10 @@ impl From<WalletError> for LibWalletError {
                 code: 423,
                 message: format!("{:?}", w),
             },
+            WalletError::WalletStorageError(WalletStorageError::ValuesNotFound) => Self {
+                code: 424,
+                message: format!("{:?}", w),
+            },
             // This is the catch all error code. Any error that is not explicitly mapped above will be given this code
             _ => Self {
                 code: 999,

--- a/base_layer/wallet_ffi/wallet.h
+++ b/base_layer/wallet_ffi/wallet.h
@@ -539,6 +539,56 @@ void wallet_apply_encryption(struct TariWallet *wallet, const char *passphrase, 
 // be removed. If it is not encrypted then this function will still succeed to make the operation idempotent
 void wallet_remove_encryption(struct TariWallet *wallet, int* error_out);
 
+/// Set a Key Value in the Wallet storage used for Client Key Value store
+///
+/// ## Arguments
+/// `wallet` - The TariWallet pointer.
+/// `key` - The pointer to a Utf8 string representing the Key
+/// `value` - The pointer to a Utf8 string representing the Value ot be stored
+/// `error_out` - Pointer to an int which will be modified to an error code should one occur, may not be null. Functions
+/// as an out parameter.
+///
+/// ## Returns
+/// `bool` - Return a boolean value indicating the operation's success or failure. The error_ptr will hold the error
+/// code if there was a failure
+///
+/// # Safety
+/// None
+bool wallet_set_key_value(struct TariWallet *wallet, const char* key, const char* value, int* error_out);
+
+/// get a stored Value that was previously stored in the Wallet storage used for Client Key Value store
+///
+/// ## Arguments
+/// `wallet` - The TariWallet pointer.
+/// `key` - The pointer to a Utf8 string representing the Key
+/// `error_out` - Pointer to an int which will be modified to an error code should one occur, may not be null. Functions
+/// as an out parameter.
+///
+/// ## Returns
+/// `*mut c_char` - Returns a pointer to a char array of the Value string. Note that it returns an null pointer if an
+/// error occured.
+///
+/// # Safety
+/// The ```string_destroy``` method must be called when finished with a string from rust to prevent a memory leak
+const char *wallet_get_value(struct TariWallet *wallet, const char* key, int* error_out);
+
+/// Clears a Value for the provided Key Value in the Wallet storage used for Client Key Value store
+///
+/// ## Arguments
+/// `wallet` - The TariWallet pointer.
+/// `key` - The pointer to a Utf8 string representing the Key
+/// `error_out` - Pointer to an int which will be modified to an error code should one occur, may not be null. Functions
+/// as an out parameter.
+///
+/// ## Returns
+/// `bool` - Return a boolean value indicating the operation's success or failure. The error_ptr will hold the error
+/// code if there was a failure
+///
+/// # Safety
+/// None
+bool wallet_clear_value(struct TariWallet *wallet, const char* key, int* error_out);
+
+
 // Frees memory for a TariWallet
 void wallet_destroy(struct TariWallet *wallet);
 


### PR DESCRIPTION
## Description
The mobile team that uses the WalletFFI library requested a feature to be able to store arbitrary Key-Values in the Wallet’s database and make use of the Wallet’s encryption for these values.

To enable this the functionality to set, get and clear client key-value pairs was added to the Wallet database as a new table. If an encryption cipher is set for the wallet the Values will be encrypted and decrypted by the database backend.

Three FFI interface functions were added to the FFI library to allow a client to access this functionality.

@kukabi 

## How Has This Been Tested?
Tests are provided for the functions in the database backend and in the FFI library.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [x] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch.
* [x] I ran `cargo-fmt --all` before pushing.
* [x] I ran `cargo test` successfully before submitting my PR.
* [x] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
