### PR TITLE
Revert change to fetch_mmr_nodes from #2357

### DIFF
--- a/base_layer/core/src/base_node/comms_interface/inbound_handlers.rs
+++ b/base_layer/core/src/base_node/comms_interface/inbound_handlers.rs
@@ -403,14 +403,27 @@ where T: BlockchainBackend + 'static
             NodeCommsRequest::FetchMmrNodes(tree, pos, count, hist_height) => {
                 let mut added = Vec::<Vec<u8>>::with_capacity(*count as usize);
                 let mut deleted = Bitmap::create();
-                let mmr_nodes =
-                    async_db::fetch_mmr_nodes(self.blockchain_db.clone(), *tree, *pos, *count, Some(*hist_height))
-                        .await?;
-                for (index, (leaf_hash, deletion_status)) in mmr_nodes.into_iter().enumerate() {
-                    added.push(leaf_hash);
-                    if deletion_status {
-                        deleted.add(*pos + index as u32);
-                    }
+                match async_db::fetch_mmr_nodes(self.blockchain_db.clone(), *tree, *pos, *count, Some(*hist_height))
+                    .await
+                {
+                    Ok(mmr_nodes) => {
+                        for (index, (leaf_hash, deletion_status)) in mmr_nodes.into_iter().enumerate() {
+                            added.push(leaf_hash);
+                            if deletion_status {
+                                deleted.add(*pos + index as u32);
+                            }
+                        }
+                        deleted.run_optimize();
+                    },
+                    // We need to suppress the error as another node might ask for mmr nodes we dont have, so we
+                    // return ok([])
+                    Err(e) => warn!(
+                        target: LOG_TARGET,
+                        "Could not provide requested mmr nodes (pos:{},count:{}) to peer because: {}",
+                        pos,
+                        count,
+                        e.to_string()
+                    ),
                 }
                 deleted.run_optimize();
                 Ok(NodeCommsResponse::MmrNodes(added, deleted.serialize()))


### PR DESCRIPTION
## Description
The change to `fetch_mmr_nodes` introduced in #2357 caused the `request_and_response_fetch_mmr_node_and_count` test to timeout and fail. This commit reverts that change, and makes the previous `debug` log into `warn` for greater visibility.



<!--- Provide a general summary of your changes in the Title above -->


<!--- Describe your changes in detail -->


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This really depends on desired behaviour - the test indicates that an empty set should be returned if a peer requests "out of bounds" MMR nodes instead of an error result. The previous code comment also indicates _"another node might ask for mmr nodes we dont have, so we return ok([])"_.

Either this specific change introduced in #2357 needs to be reverted to maintain the existing invariant, or the test itself needs to be changed. I am happy to refactor the test if that's the correct response instead, please let me know.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
cargo test

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch.
* [x] I ran `cargo-fmt --all` before pushing.
* [x] I ran `cargo test` successfully before submitting my PR.
* [x] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
