### PR TITLE
Increase lagging broadcast channels' capacities

### DIFF
--- a/base_layer/core/src/base_node/state_machine_service/initializer.rs
+++ b/base_layer/core/src/base_node/state_machine_service/initializer.rs
@@ -84,7 +84,7 @@ where B: BlockchainBackend + 'static
 
     fn initialize(&mut self, context: ServiceInitializerContext) -> Self::Future {
         trace!(target: LOG_TARGET, "init of base_node");
-        let (state_event_publisher, _) = broadcast::channel(10);
+        let (state_event_publisher, _) = broadcast::channel(500);
         let (status_event_sender, status_event_receiver) = watch::channel(StatusInfo::new());
 
         let handle = StateMachineHandle::new(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
During adverse conditions, it was found that the state events and transaction service broadcast channel capacities were inadequate to handle the load. Subscribers lagged up to 92 state events (capacity of 10) and 490 transaction events (capacity of 200). As a rule of thumb, the capacities were increased sufficiently to accommodate 5 to 10 times more events than the peak amount they lagged by. The tokio broadcast channels are also self-regulating i.t.o. memory usage.

```
2020-10-21 19:25:57.722798300 [c::bn::state_machine_service::states::listening]
    DEBUG Metadata event subscriber lagged by 92 item(s)
```
```
2020-10-21 22:44:13.858514800 [base_node::app::utils] WARN  Error reading from
    event broadcast channel Lagged(490)
```

**Edit**: Changes to the transaction service broadcast channel reverted.

## Motivation and Context
Subscribers to state events and transaction service events should never miss any messages.

## How Has This Been Tested?
Tested in 3 base nodes on Windows.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [X] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [X] I'm merging against the `development` branch.
* [X] I ran `cargo-fmt --all` before pushing.
* [X] I ran `cargo test` successfully before submitting my PR.
* [X] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
