### PR TITLE
Removed difficulty hack in monero_rx

### DIFF
--- a/base_layer/core/src/proof_of_work/monero_rx.rs
+++ b/base_layer/core/src/proof_of_work/monero_rx.rs
@@ -22,10 +22,7 @@
 
 use crate::{
     blocks::BlockHeader,
-    proof_of_work::{
-        difficulty::util::{big_endian_difficulty, little_endian_difficulty},
-        Difficulty,
-    },
+    proof_of_work::{difficulty::util::little_endian_difficulty, Difficulty},
     tari_utilities::ByteArray,
 };
 use log::*;
@@ -215,7 +212,6 @@ pub fn monero_difficulty(header: &BlockHeader) -> Result<Difficulty, MergeMineEr
     get_random_x_difficulty(&input, &key_bytes, header.height).map(|r| r.0)
 }
 
-// this swops from big_endian to little at height 108000
 fn get_random_x_difficulty(input: &[u8], key: &[u8], height: u64) -> Result<(Difficulty, Vec<u8>), MergeMineError> {
     let flags = RandomXFlag::get_recommended_flags();
     let cache = RandomXCache::new(flags, &key)?;
@@ -229,11 +225,7 @@ fn get_random_x_difficulty(input: &[u8], key: &[u8], height: u64) -> Result<(Dif
         Vec::from(key).to_hex()
     );
     // ToDo remove this post testnet. This is to fix wrongly calculated monero blocks
-    let difficulty = if height > 108000 {
-        little_endian_difficulty(&hash)
-    } else {
-        big_endian_difficulty(&hash)
-    };
+    let difficulty = little_endian_difficulty(&hash);
     Ok((difficulty, hash))
 }
 
@@ -283,10 +275,6 @@ pub fn from_hashes_to_array<T: IntoIterator<Item = Hash>>(hashes: T) -> Vec<[u8;
 }
 
 fn verify_root(monero_data: &MoneroData) -> Result<(), MergeMineError> {
-    // let mut hashes = Vec::with_capacity(monero_data.transaction_hashes.len());
-    // for item in &monero_data.transaction_hashes {
-    //     hashes.push(Hash::from(item));
-    // }
     let hashes = monero_data
         .transaction_hashes
         .iter()

--- a/base_layer/core/src/proof_of_work/monero_rx.rs
+++ b/base_layer/core/src/proof_of_work/monero_rx.rs
@@ -209,10 +209,10 @@ pub fn monero_difficulty(header: &BlockHeader) -> Result<Difficulty, MergeMineEr
     let input = from_hex(input)?;
     // Todo remove this eventually when we reset and we dont have quotes in the key anymore.
     let key_bytes = from_hex(&key.replace("\"", ""))?;
-    get_random_x_difficulty(&input, &key_bytes, header.height).map(|r| r.0)
+    get_random_x_difficulty(&input, &key_bytes).map(|r| r.0)
 }
 
-fn get_random_x_difficulty(input: &[u8], key: &[u8], height: u64) -> Result<(Difficulty, Vec<u8>), MergeMineError> {
+fn get_random_x_difficulty(input: &[u8], key: &[u8]) -> Result<(Difficulty, Vec<u8>), MergeMineError> {
     let flags = RandomXFlag::get_recommended_flags();
     let cache = RandomXCache::new(flags, &key)?;
     let dataset = RandomXDataset::new(flags, &cache, 0)?;
@@ -840,7 +840,7 @@ mod test {
         .unwrap();
         let key = from_hex("2aca6501719a5c7ab7d4acbc7cc5d277b57ad8c27c6830788c2d5a596308e5b1").unwrap();
 
-        let difficulty = get_random_x_difficulty(&input, &key, 108001).unwrap();
+        let difficulty = get_random_x_difficulty(&input, &key).unwrap();
         assert_eq!(
             difficulty.1.to_hex(),
             "f68fbc8cc85bde856cd1323e9f8e6f024483038d728835de2f8c014ff6260000"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Removes the check that determines how difficulty is calculated for monero blocks based on block height.

## Motivation and Context
Necessary for testnet reset

## How Has This Been Tested?
cargo test --all --all-features

## Types of changes
* [ ] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [x] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
* [x] I'm merging against the `development` branch.
* [x] I ran `cargo-fmt --all` before pushing.
* [x] I ran `cargo test` successfully before submitting my PR.
* [ ] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
