### PR TITLE
Various improvements to network discovery

### DIFF
--- a/comms/dht/src/connectivity/mod.rs
+++ b/comms/dht/src/connectivity/mod.rs
@@ -222,7 +222,7 @@ impl DhtConnectivity {
             new_neighbours.len(),
             new_neighbours
                 .iter()
-                .map(ToString::to_string)
+                .map(|n| format!("{}, ", n))
                 .collect::<Vec<_>>()
                 .join(", ")
         );

--- a/comms/dht/src/inbound/dht_handler/task.rs
+++ b/comms/dht/src/inbound/dht_handler/task.rs
@@ -215,7 +215,7 @@ where S: Service<DecryptedDhtMessage, Response = (), Error = PipelineError>
             self.outbound_service
                 .send_raw(
                     SendMessageParams::new()
-                        .closest_connected(origin_node_id.clone(), vec![
+                        .propagate(origin_node_id.clone().into(), vec![
                             origin_node_id,
                             source_peer.node_id.clone(),
                         ])

--- a/comms/dht/src/network_discovery/discovering.rs
+++ b/comms/dht/src/network_discovery/discovering.rs
@@ -185,6 +185,11 @@ impl Discovering {
     }
 
     async fn validate_and_add_peer(&mut self, sync_peer: &NodeId, peer: Peer) -> Result<(), NetworkDiscoveryError> {
+        if self.context.node_identity.node_id() == &peer.node_id {
+            debug!(target: LOG_TARGET, "Received our own node from peer sync. Ignoring.");
+            return Ok(());
+        }
+
         let peer_manager = &self.context.peer_manager;
         if peer_manager.exists_node_id(&peer.node_id).await {
             self.stats.num_duplicate_peers += 1;
@@ -205,7 +210,7 @@ impl Discovering {
                     self.stats.num_new_neighbours += 1;
                     debug!(
                         target: LOG_TARGET,
-                        "Adding new neighbouring peer `{}`. {} (inclusive) have been added this round.",
+                        "Adding new neighbouring peer `{}`. A total of {} have been added this round.",
                         peer.node_id,
                         self.stats.num_new_neighbours
                     );

--- a/comms/src/connection_manager/common.rs
+++ b/comms/src/connection_manager/common.rs
@@ -94,6 +94,7 @@ pub async fn validate_and_add_peer_from_peer_identity(
     known_peer: Option<Peer>,
     authenticated_public_key: CommsPublicKey,
     mut peer_identity: PeerIdentityMsg,
+    dialed_addr: Option<&Multiaddr>,
     allow_test_addrs: bool,
 ) -> Result<NodeId, ConnectionManagerError>
 {
@@ -138,6 +139,9 @@ pub async fn validate_and_add_peer_from_peer_identity(
             peer.connection_stats.set_connection_success();
             peer.addresses = addresses.into();
             peer.set_offline(false);
+            if let Some(addr) = dialed_addr {
+                peer.addresses.mark_successful_connection_attempt(addr);
+            }
             peer.features = PeerFeatures::from_bits_truncate(peer_identity.features);
             peer.supported_protocols = supported_protocols;
             peer.user_agent = peer_identity.user_agent;
@@ -159,6 +163,9 @@ pub async fn validate_and_add_peer_from_peer_identity(
                 peer_identity.user_agent,
             );
             new_peer.connection_stats.set_connection_success();
+            if let Some(addr) = dialed_addr {
+                new_peer.addresses.mark_successful_connection_attempt(addr);
+            }
             new_peer
         },
     };

--- a/comms/src/connection_manager/dialer.rs
+++ b/comms/src/connection_manager/dialer.rs
@@ -397,6 +397,7 @@ where
             known_peer,
             authenticated_public_key,
             peer_identity,
+            Some(&dialed_addr),
             allow_test_addresses,
         )
         .await?;

--- a/comms/src/connection_manager/listener.rs
+++ b/comms/src/connection_manager/listener.rs
@@ -355,6 +355,7 @@ where
             known_peer,
             authenticated_public_key,
             peer_identity,
+            None,
             allow_test_addresses,
         )
         .await?;

--- a/comms/src/connectivity/config.rs
+++ b/comms/src/connectivity/config.rs
@@ -37,7 +37,7 @@ pub struct ConnectivityConfig {
     /// established from being reaped due to inactivity.
     pub reaper_min_inactive_age: Duration,
     /// The number of connection failures before a peer is considered offline
-    /// Default: 2
+    /// Default: 1
     pub max_failures_mark_offline: usize,
     /// The length of time to wait before disconnecting a connection that failed tie breaking.
     /// Default: 1s
@@ -51,7 +51,7 @@ impl Default for ConnectivityConfig {
             connection_pool_refresh_interval: Duration::from_secs(30),
             reaper_min_inactive_age: Duration::from_secs(60),
             is_connection_reaping_enabled: true,
-            max_failures_mark_offline: 2,
+            max_failures_mark_offline: 1,
             connection_tie_break_linger: Duration::from_secs(2),
         }
     }

--- a/comms/src/peer_manager/manager.rs
+++ b/comms/src/peer_manager/manager.rs
@@ -255,8 +255,8 @@ impl PeerManager {
             .ban_peer_by_node_id(node_id, duration, reason)
     }
 
-    /// Changes the offline flag bit of the peer
-    pub async fn set_offline(&self, node_id: &NodeId, is_offline: bool) -> Result<NodeId, PeerManagerError> {
+    /// Changes the offline flag bit of the peer. Return the previous offline state.
+    pub async fn set_offline(&self, node_id: &NodeId, is_offline: bool) -> Result<bool, PeerManagerError> {
         self.peer_storage.write().await.set_offline(node_id, is_offline)
     }
 

--- a/comms/src/peer_manager/peer_storage.rs
+++ b/comms/src/peer_manager/peer_storage.rs
@@ -476,8 +476,8 @@ where DS: KeyValueStore<PeerId, Peer>
         Ok(node_id)
     }
 
-    /// Changes the OFFLINE flag bit of the peer
-    pub fn set_offline(&mut self, node_id: &NodeId, ban_flag: bool) -> Result<NodeId, PeerManagerError> {
+    /// Changes the OFFLINE flag bit of the peer.
+    pub fn set_offline(&mut self, node_id: &NodeId, offline: bool) -> Result<bool, PeerManagerError> {
         let peer_key = *self
             .node_id_index
             .get(&node_id)
@@ -487,12 +487,12 @@ where DS: KeyValueStore<PeerId, Peer>
             .get(&peer_key)
             .map_err(PeerManagerError::DatabaseError)?
             .expect("node_id_index is out of sync with peer db");
-        peer.set_offline(ban_flag);
-        let node_id = peer.node_id.clone();
+        let was_offline = peer.is_offline();
+        peer.set_offline(offline);
         self.peer_db
             .insert(peer_key, peer)
             .map_err(PeerManagerError::DatabaseError)?;
-        Ok(node_id)
+        Ok(was_offline)
     }
 
     /// Enables Thread safe access - Adds a new net address to the peer if it doesn't yet exist


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
- `get_peers` RPC call no longer sends the requesting peer back to itself.
- Peer sync no longer accepts itself as a peer
- "on connect" peer sync mode no longer syncs as aggressively (n=1000,
  nodes only)
- Propagate join messages using the "directed propagate" strategy. This strategy
  is similar to "closest connected" used previously except it stops
  propagating if there are no closer known nodes to the destination.
- Readability improvements for `list-peers` command
- Allow network discovery to enter "on connect" mode sooner even if many
  peer syncs don't work due to peers being unavailable.
- Mark a peer as offline after 3 attempt(s) instead of 6
  (`max_failures_mark_offline` = 1 and `max_dial_attempts` = 3) so that
  it takes less time to connect to available peers.
- Set last seen for the dialled addresses when connecting.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The main issue this PR addresses is:
1. Nodes do not try and connect to themselves or have themselves in their own peer list
1. "on connect" peer syncing is a lot more light weight than before - synching 1000 peers at a time

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manual testing with blank and populated peer dbs.  

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [x] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch.
* [x] I ran `cargo-fmt --all` before pushing.
* [ ] I ran `cargo test` successfully before submitting my PR.
* [x] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
