### PR TITLE
Implement pending transaction cancellation in the TUI app

### DIFF
--- a/applications/tari_console_wallet/src/ui/state/app_state.rs
+++ b/applications/tari_console_wallet/src/ui/state/app_state.rs
@@ -132,6 +132,13 @@ impl AppState {
         Ok(())
     }
 
+    pub async fn cancel_transaction(&mut self, tx_id: TxId) -> Result<(), UiError> {
+        let inner = self.inner.write().await;
+        let mut tx_service_handle = inner.wallet.transaction_service.clone();
+        tx_service_handle.cancel_transaction(tx_id).await?;
+        Ok(())
+    }
+
     pub fn get_identity(&self) -> &MyIdentity {
         &self.cached_data.my_identity
     }

--- a/applications/tari_console_wallet/src/ui/widgets/list_state.rs
+++ b/applications/tari_console_wallet/src/ui/widgets/list_state.rs
@@ -122,11 +122,15 @@ impl WindowedListState {
     }
 
     pub fn set_num_items(&mut self, num_items: usize) {
+        if num_items < self.num_items {
+            let new_offset = self.offset.saturating_sub(self.num_items - num_items);
+            self.offset = new_offset;
+        }
         self.num_items = num_items;
         if num_items > 0 {
             if let Some(p) = self.selected {
                 if p > num_items - 1 {
-                    self.selected = Some(num_items - 1)
+                    self.selected = Some(num_items - 1);
                 }
             }
         } else {
@@ -168,5 +172,21 @@ mod test {
         assert_eq!(state.selected(), Some(height - 1));
         let window = list_state.get_start_end();
         assert_eq!(slist[window.0..window.1], [7, 8, 9, 10]);
+    }
+
+    #[test]
+    fn test_removing_last_selected_items() {
+        let mut list_state = WindowedListState::new();
+        list_state.set_num_items(11);
+        for _ in 0..11 {
+            list_state.next();
+            let _state = list_state.get_list_state(4);
+        }
+
+        list_state.set_num_items(9);
+
+        let _state = list_state.get_list_state(4);
+        let window = list_state.get_start_end();
+        assert_eq!(window, (5, 9));
     }
 }


### PR DESCRIPTION
## Description
This PR implements the ability to cancel a pending transaction from the TUI app. If you have pending transactions you can select a transaction and hit C to cancel it. The PR also adds in Confirmation dialogs to the TUI app and implements from the tx cancellation, transaction sending and contact deletion.

This PR also fixes a bug in the WindowedListState logic where if an item in a list was deleted while the last element was selected it broke the List State.


## How Has This Been Tested?
Test provided for WindowListState bug and manually tested app.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [x] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [x] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch.
* [x] I ran `cargo-fmt --all` before pushing.
* [x] I ran `cargo test` successfully before submitting my PR.
* [x] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
