### PR TITLE
Remove Ban if Online

### DIFF
--- a/base_layer/core/src/base_node/state_machine_service/states/helpers.rs
+++ b/base_layer/core/src/base_node/state_machine_service/states/helpers.rs
@@ -94,26 +94,6 @@ pub fn exclude_sync_peer(
     Ok(())
 }
 
-/// Ban and disconnect the provided sync peer if this node is online
-pub async fn ban_sync_peer_if_online(
-    log_target: &str,
-    connectivity: &mut ConnectivityRequester,
-    sync_peers: &mut SyncPeers,
-    sync_peer: &SyncPeer,
-    ban_duration: Duration,
-    reason: String,
-) -> Result<(), BlockSyncError>
-{
-    if !connectivity.get_connectivity_status().await?.is_online() {
-        warn!(
-            target: log_target,
-            "Unable to ban peer {} because local node is offline.", sync_peer
-        );
-        return Ok(());
-    }
-    ban_sync_peer(log_target, connectivity, sync_peers, sync_peer, ban_duration, reason).await
-}
-
 /// Ban and disconnect the provided sync peer.
 pub async fn ban_sync_peer(
     log_target: &str,
@@ -243,7 +223,7 @@ pub async fn request_headers<B: BlockchainBackend + 'static>(
                     "Failed to fetch header from peer: {:?}. Retrying.",
                     CommsInterfaceError::RequestTimedOut,
                 );
-                ban_sync_peer_if_online(
+                ban_sync_peer(
                     log_target,
                     &mut shared.connectivity,
                     sync_peers,
@@ -308,7 +288,7 @@ pub async fn request_mmr_node_count<B: BlockchainBackend + 'static>(
                     "Failed to fetch mmr node count from peer: {:?}. Retrying.",
                     CommsInterfaceError::RequestTimedOut,
                 );
-                ban_sync_peer_if_online(
+                ban_sync_peer(
                     log_target,
                     &mut shared.connectivity,
                     sync_peers,
@@ -383,7 +363,7 @@ pub async fn request_mmr_nodes<B: BlockchainBackend + 'static>(
                     "Failed to fetch mmr nodes from peer: {:?}. Retrying.",
                     CommsInterfaceError::RequestTimedOut,
                 );
-                ban_sync_peer_if_online(
+                ban_sync_peer(
                     log_target,
                     &mut shared.connectivity,
                     sync_peers,
@@ -449,7 +429,7 @@ pub async fn request_kernels<B: BlockchainBackend + 'static>(
                     "Failed to fetch kernels from peer: {:?}. Retrying.",
                     CommsInterfaceError::RequestTimedOut,
                 );
-                ban_sync_peer_if_online(
+                ban_sync_peer(
                     log_target,
                     &mut shared.connectivity,
                     sync_peers,
@@ -522,7 +502,7 @@ pub async fn request_txos<B: BlockchainBackend + 'static>(
                     "Failed to fetch kernels from peer: {:?}. Retrying.",
                     CommsInterfaceError::RequestTimedOut,
                 );
-                ban_sync_peer_if_online(
+                ban_sync_peer(
                     log_target,
                     &mut shared.connectivity,
                     sync_peers,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Remove `ban_if_online` in favour of always banning them. If a request times out to calling a base node, it will cause the current node to go into "Offline" status. The node being called is actually offline, but it can't be banned because the node is now offline. This results in a loop of continually trying to contact the node 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [ ] I'm merging against the `development` branch.
* [ ] I ran `cargo-fmt --all` before pushing.
* [ ] I ran `cargo test` successfully before submitting my PR.
* [ ] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
