### PR TITLE
Message contents malleability detect and ban

### DIFF
--- a/applications/tari_base_node/src/parser.rs
+++ b/applications/tari_base_node/src/parser.rs
@@ -1223,7 +1223,7 @@ impl Parser {
 
             if must_ban {
                 match connectivity
-                    .ban_peer(node_id.clone(), duration, "UI manual ban".to_string())
+                    .ban_peer_until(node_id.clone(), duration, "UI manual ban".to_string())
                     .await
                 {
                     Ok(_) => println!("Peer was banned in base node."),
@@ -1235,7 +1235,7 @@ impl Parser {
 
                 if let Some(mut wallet_connectivity) = wallet_connectivity {
                     match wallet_connectivity
-                        .ban_peer(node_id, duration, "UI manual ban".to_string())
+                        .ban_peer_until(node_id, duration, "UI manual ban".to_string())
                         .await
                     {
                         Ok(_) => println!("Peer was banned in wallet."),

--- a/base_layer/core/src/base_node/state_machine_service/states/helpers.rs
+++ b/base_layer/core/src/base_node/state_machine_service/states/helpers.rs
@@ -106,7 +106,7 @@ pub async fn ban_sync_peer(
 {
     info!(target: log_target, "Banning peer {} from local node.", sync_peer);
     connectivity
-        .ban_peer(sync_peer.node_id.clone(), ban_duration, reason)
+        .ban_peer_until(sync_peer.node_id.clone(), ban_duration, reason)
         .await?;
     exclude_sync_peer(log_target, sync_peers, &sync_peer)
 }

--- a/comms/dht/src/actor.rs
+++ b/comms/dht/src/actor.rs
@@ -30,7 +30,7 @@
 use crate::{
     broadcast_strategy::BroadcastStrategy,
     discovery::DhtDiscoveryError,
-    outbound::{OutboundMessageRequester, SendMessageParams},
+    outbound::{DhtOutboundError, OutboundMessageRequester, SendMessageParams},
     proto::{dht::JoinMessage, envelope::DhtMessageType},
     storage::{DbConnection, DhtDatabase, DhtMetadataKey, StorageError},
     DhtConfig,
@@ -70,7 +70,7 @@ pub enum DhtActorError {
     #[error("PeerManagerError: {0}")]
     PeerManagerError(#[from] PeerManagerError),
     #[error("Failed to broadcast join message: {0}")]
-    FailedToBroadcastJoinMessage(String),
+    FailedToBroadcastJoinMessage(DhtOutboundError),
     #[error("DiscoveryError: {0}")]
     DiscoveryError(#[from] DhtDiscoveryError),
     #[error("StorageError: {0}")]
@@ -358,9 +358,7 @@ impl DhtActor {
                 message,
             )
             .await
-            .map_err(|err| {
-                DhtActorError::FailedToBroadcastJoinMessage(format!("Failed to send join message: {}", err))
-            })?;
+            .map_err(DhtActorError::FailedToBroadcastJoinMessage)?;
 
         Ok(())
     }

--- a/comms/dht/src/config.rs
+++ b/comms/dht/src/config.rs
@@ -102,6 +102,7 @@ pub struct DhtConfig {
     pub network: Network,
     /// Network discovery config
     pub network_discovery: NetworkDiscoveryConfig,
+    pub short_ban_duration: Duration,
 }
 
 impl DhtConfig {
@@ -158,6 +159,7 @@ impl Default for DhtConfig {
             join_cooldown_interval: Duration::from_secs(10 * 60),
             network: Network::TestNet,
             network_discovery: Default::default(),
+            short_ban_duration: Duration::from_secs(30 * 60),
         }
     }
 }

--- a/comms/dht/src/dht.rs
+++ b/comms/dht/src/dht.rs
@@ -291,7 +291,11 @@ impl Dht {
                 "Inbound [{}]",
                 self.node_identity.node_id().short_str()
             )))
-            .layer(inbound::DecryptionLayer::new(Arc::clone(&self.node_identity)))
+            .layer(inbound::DecryptionLayer::new(
+                self.config.clone(),
+                self.node_identity.clone(),
+                self.connectivity.clone(),
+            ))
             .layer(store_forward::StoreLayer::new(
                 self.config.clone(),
                 Arc::clone(&self.peer_manager),

--- a/comms/dht/src/envelope.rs
+++ b/comms/dht/src/envelope.rs
@@ -28,7 +28,7 @@ use std::{
     fmt,
     fmt::Display,
 };
-use tari_comms::{message::MessageTag, peer_manager::NodeId, types::CommsPublicKey};
+use tari_comms::{message::MessageTag, peer_manager::NodeId, types::CommsPublicKey, NodeIdentity};
 use tari_utilities::{ByteArray, ByteArrayError};
 use thiserror::Error;
 
@@ -256,6 +256,23 @@ impl NodeDestination {
             NodeDestination::Unknown => true,
             _ => false,
         }
+    }
+
+    #[inline]
+    pub fn equals_node_identity(&self, other: &NodeIdentity) -> bool {
+        self == other.node_id() || self == other.public_key()
+    }
+}
+
+impl PartialEq<CommsPublicKey> for NodeDestination {
+    fn eq(&self, other: &CommsPublicKey) -> bool {
+        self.public_key().map(|pk| pk == other).unwrap_or(false)
+    }
+}
+
+impl PartialEq<NodeId> for NodeDestination {
+    fn eq(&self, other: &NodeId) -> bool {
+        self.node_id().map(|node_id| node_id == other).unwrap_or(false)
     }
 }
 

--- a/comms/src/connectivity/requester.rs
+++ b/comms/src/connectivity/requester.rs
@@ -202,7 +202,7 @@ impl ConnectivityRequester {
         reply_rx.await.map_err(|_| ConnectivityError::ActorResponseCancelled)
     }
 
-    pub async fn ban_peer(
+    pub async fn ban_peer_until(
         &mut self,
         node_id: NodeId,
         duration: Duration,
@@ -214,6 +214,11 @@ impl ConnectivityRequester {
             .await
             .map_err(|_| ConnectivityError::ActorDisconnected)?;
         Ok(())
+    }
+
+    pub async fn ban_peer(&mut self, node_id: NodeId, reason: String) -> Result<(), ConnectivityError> {
+        self.ban_peer_until(node_id, Duration::from_secs(u64::MAX), reason)
+            .await
     }
 
     pub async fn wait_started(&mut self) -> Result<(), ConnectivityError> {

--- a/comms/src/connectivity/test.rs
+++ b/comms/src/connectivity/test.rs
@@ -281,8 +281,8 @@ async fn online_then_offline() {
     streams::assert_in_stream(
         &mut event_stream,
         |item| match &*item.unwrap() {
-            ConnectivityEvent::ConnectivityStateDegraded(2) => true,
-            _ => false,
+            ConnectivityEvent::ConnectivityStateDegraded(2) => Some(()),
+            _ => None,
         },
         Duration::from_secs(10),
     )
@@ -304,8 +304,8 @@ async fn online_then_offline() {
     streams::assert_in_stream(
         &mut event_stream,
         |item| match &*item.unwrap() {
-            ConnectivityEvent::ConnectivityStateOffline => true,
-            _ => false,
+            ConnectivityEvent::ConnectivityStateOffline => Some(()),
+            _ => None,
         },
         Duration::from_secs(10),
     )
@@ -334,7 +334,7 @@ async fn ban_peer() {
     assert!(conn.is_some());
 
     connectivity
-        .ban_peer(peer.node_id.clone(), Duration::from_secs(3600), "".to_string())
+        .ban_peer_until(peer.node_id.clone(), Duration::from_secs(3600), "".to_string())
         .await
         .unwrap();
 

--- a/comms/src/pipeline/outbound.rs
+++ b/comms/src/pipeline/outbound.rs
@@ -27,7 +27,7 @@ use crate::{
 };
 use futures::{channel::mpsc, future, future::Either, stream::FusedStream, SinkExt, Stream, StreamExt};
 use log::*;
-use std::fmt::Debug;
+use std::fmt::Display;
 use tokio::runtime;
 use tower::{Service, ServiceExt};
 
@@ -47,7 +47,7 @@ where
     TStream: Stream + FusedStream + Unpin + Send + 'static,
     TStream::Item: Send + 'static,
     TPipeline: Service<TStream::Item, Response = ()> + Clone + Send + 'static,
-    TPipeline::Error: Debug + Send,
+    TPipeline::Error: Display + Send,
     TPipeline::Future: Send,
 {
     pub fn new(
@@ -72,7 +72,7 @@ where
                     let pipeline = self.config.pipeline.clone();
                     self.executor.spawn(async move {
                         if let Err(err) = pipeline.oneshot(msg).await {
-                            error!(target: LOG_TARGET, "Outbound pipeline returned an error: '{:?}'", err);
+                            error!(target: LOG_TARGET, "Outbound pipeline returned an error: '{}'", err);
                         }
                     });
                 },

--- a/comms/src/protocol/extensions.rs
+++ b/comms/src/protocol/extensions.rs
@@ -135,6 +135,7 @@ impl ProtocolExtensionContext {
         self
     }
 
+    /// Register a signal that triggers once the task is complete.
     pub fn register_complete_signal(&mut self, signal: ShutdownSignal) -> &mut Self {
         self.complete_signals.push(signal);
         self

--- a/comms/src/protocol/messaging/extension.rs
+++ b/comms/src/protocol/messaging/extension.rs
@@ -52,10 +52,10 @@ impl<TInPipe, TOutPipe, TOutReq> MessagingProtocolExtension<TInPipe, TOutPipe, T
 impl<TInPipe, TOutPipe, TOutReq> ProtocolExtension for MessagingProtocolExtension<TInPipe, TOutPipe, TOutReq>
 where
     TOutPipe: Service<TOutReq, Response = ()> + Clone + Send + Sync + 'static,
-    TOutPipe::Error: fmt::Debug + Send + Sync,
+    TOutPipe::Error: fmt::Display + Send + Sync,
     TOutPipe::Future: Send + Sync + 'static,
     TInPipe: Service<InboundMessage> + Clone + Send + Sync + 'static,
-    TInPipe::Error: fmt::Debug + Send + Sync,
+    TInPipe::Error: fmt::Display + Send + Sync,
     TInPipe::Future: Send + Sync + 'static,
     TOutReq: Send + Sync + 'static,
 {
@@ -76,8 +76,9 @@ where
             context.shutdown_signal(),
         );
 
-        // Spawn messaging protocol
         context.register_complete_signal(messaging.complete_signal());
+
+        // Spawn messaging protocol
         task::spawn(messaging.run());
 
         // Spawn inbound pipeline

--- a/comms/src/test_utils/mocks/connectivity_manager.rs
+++ b/comms/src/test_utils/mocks/connectivity_manager.rs
@@ -178,7 +178,7 @@ impl ConnectivityManagerMock {
                     .unwrap();
             },
             GetAllConnectionStates(_) => unimplemented!(),
-            BanPeer(_, _, _) => unimplemented!(),
+            BanPeer(_, _, _) => {},
             GetActiveConnections(reply) => {
                 reply
                     .send(self.state.active_conns.lock().await.values().cloned().collect())

--- a/infrastructure/test_utils/src/streams/mod.rs
+++ b/infrastructure/test_utils/src/streams/mod.rs
@@ -121,18 +121,18 @@ macro_rules! collect_stream_count {
     }};
 }
 
-pub async fn assert_in_stream<S, P>(stream: &mut S, mut predicate: P, timeout: Duration)
+pub async fn assert_in_stream<S, P, R>(stream: &mut S, mut predicate: P, timeout: Duration) -> R
 where
     S: Stream + Unpin,
-    P: FnMut(S::Item) -> bool,
+    P: FnMut(S::Item) -> Option<R>,
 {
     loop {
         if let Some(item) = tokio::time::timeout(timeout, stream.next())
             .await
             .expect("Timeout before stream emitted")
         {
-            if (predicate)(item) {
-                break;
+            if let Some(r) = (predicate)(item) {
+                break r;
             }
         } else {
             panic!("Predicate did not return true before the stream ended");


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Messaging layer bans peers if tampering is detected. Specifically,
if origin mac and/or the ephemeral key is removed from the message or
the signature validation for signed cleartext messages fails.

- Added test to verify that a message that was tampered with results in
  the message being ignored and the node that propagated it being
  banned.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Peers should be banned if they tamper with a message or propagate messages that have been tampered with. The original reason for this PR is to check that a signed message cannot be tampered with (which can also break dedup).

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
A new integration test. Existing unit/functional tests updated. Briefly tested on base node.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [x] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [x] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch.
* [x] I ran `cargo-fmt --all` before pushing.
* [ ] I ran `cargo test` successfully before submitting my PR.
* [x] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
