### PR TITLE
Revert change to fetch blocks utxos txos (#2357)

### DIFF
--- a/applications/tari_base_node/src/parser.rs
+++ b/applications/tari_base_node/src/parser.rs
@@ -1586,8 +1586,8 @@ impl Parser {
                             missing_blocks.push(height);
                         },
                         Ok(mut data) => match data.pop() {
-                            // We need to check the data it self, as FetchBlocks will suppress any error, only logging
-                            // it.
+                            // We need to check the data it self, as FetchMatchingBlocks will suppress any error, only
+                            // logging it.
                             Some(_historical_block) => {},
                             None => missing_blocks.push(height),
                         },
@@ -1666,8 +1666,8 @@ impl Parser {
                         break;
                     },
                     Ok(mut data) => match data.pop() {
-                        // We need to check the data it self, as FetchBlocks will suppress any error, only logging
-                        // it.
+                        // We need to check the data it self, as FetchMatchingBlocks will suppress any error, only
+                        // logging it.
                         Some(historical_block) => historical_block.block,
                         None => {
                             println!("Error in db, could not get block");
@@ -1681,8 +1681,8 @@ impl Parser {
                         break;
                     },
                     Ok(mut data) => match data.pop() {
-                        // We need to check the data it self, as FetchBlocks will suppress any error, only logging
-                        // it.
+                        // We need to check the data it self, as FetchMatchingBlocks will suppress any error, only
+                        // logging it.
                         Some(historical_block) => historical_block.block,
                         None => {
                             println!("Error in db, could not get block");

--- a/base_layer/core/src/base_node/comms_interface/comms_request.rs
+++ b/base_layer/core/src/base_node/comms_interface/comms_request.rs
@@ -45,9 +45,9 @@ pub enum NodeCommsRequest {
     FetchHeaders(Vec<u64>),
     FetchHeadersWithHashes(Vec<HashOutput>),
     FetchHeadersAfter(Vec<HashOutput>, HashOutput),
-    FetchUtxos(Vec<HashOutput>),
-    FetchTxos(Vec<HashOutput>),
-    FetchBlocks(Vec<u64>),
+    FetchMatchingUtxos(Vec<HashOutput>),
+    FetchMatchingTxos(Vec<HashOutput>),
+    FetchMatchingBlocks(Vec<u64>),
     FetchBlocksWithHashes(Vec<HashOutput>),
     FetchBlocksWithKernels(Vec<Signature>),
     FetchBlocksWithStxos(Vec<Commitment>),
@@ -55,7 +55,7 @@ pub enum NodeCommsRequest {
     GetNewBlockTemplate(PowAlgorithm),
     GetNewBlock(NewBlockTemplate),
     FetchMmrNodeCount(MmrTree, u64),
-    FetchMmrNodes(MmrTree, u32, u32, u64),
+    FetchMatchingMmrNodes(MmrTree, u32, u32, u64),
 }
 
 impl Display for NodeCommsRequest {
@@ -64,12 +64,16 @@ impl Display for NodeCommsRequest {
             NodeCommsRequest::GetChainMetadata => f.write_str("GetChainMetadata"),
             NodeCommsRequest::FetchKernels(v) => f.write_str(&format!("FetchKernels (n={})", v.len())),
             NodeCommsRequest::FetchHeaders(v) => f.write_str(&format!("FetchHeaders (n={})", v.len())),
-            NodeCommsRequest::FetchHeadersWithHashes(v) => f.write_str(&format!("FetchHeaders (n={})", v.len())),
+            NodeCommsRequest::FetchHeadersWithHashes(v) => {
+                f.write_str(&format!("FetchHeadersWithHashes (n={})", v.len()))
+            },
             NodeCommsRequest::FetchHeadersAfter(v, _hash) => f.write_str(&format!("FetchHeadersAfter (n={})", v.len())),
-            NodeCommsRequest::FetchUtxos(v) => f.write_str(&format!("FetchUtxos (n={})", v.len())),
-            NodeCommsRequest::FetchTxos(v) => f.write_str(&format!("FetchTxos (n={})", v.len())),
-            NodeCommsRequest::FetchBlocks(v) => f.write_str(&format!("FetchBlocks (n={})", v.len())),
-            NodeCommsRequest::FetchBlocksWithHashes(v) => f.write_str(&format!("FetchBlocks (n={})", v.len())),
+            NodeCommsRequest::FetchMatchingUtxos(v) => f.write_str(&format!("FetchMatchingUtxos (n={})", v.len())),
+            NodeCommsRequest::FetchMatchingTxos(v) => f.write_str(&format!("FetchMatchingTxos (n={})", v.len())),
+            NodeCommsRequest::FetchMatchingBlocks(v) => f.write_str(&format!("FetchMatchingBlocks (n={})", v.len())),
+            NodeCommsRequest::FetchBlocksWithHashes(v) => {
+                f.write_str(&format!("FetchBlocksWithHashes (n={})", v.len()))
+            },
             NodeCommsRequest::FetchBlocksWithKernels(v) => {
                 f.write_str(&format!("FetchBlocksWithKernels (n={})", v.len()))
             },
@@ -80,8 +84,8 @@ impl Display for NodeCommsRequest {
             NodeCommsRequest::FetchMmrNodeCount(tree, height) => {
                 f.write_str(&format!("FetchMmrNodeCount (tree={},Block Height={})", tree, height))
             },
-            NodeCommsRequest::FetchMmrNodes(tree, pos, count, hist_height) => f.write_str(&format!(
-                "FetchMmrNodeCount (tree={},pos={},count={},hist_height={})",
+            NodeCommsRequest::FetchMatchingMmrNodes(tree, pos, count, hist_height) => f.write_str(&format!(
+                "FetchMatchingMmrNodes (tree={},pos={},count={},hist_height={})",
                 tree, pos, count, hist_height
             )),
         }

--- a/base_layer/core/src/base_node/comms_interface/local_interface.rs
+++ b/base_layer/core/src/base_node/comms_interface/local_interface.rs
@@ -80,7 +80,7 @@ impl LocalNodeCommsInterface {
     pub async fn get_blocks(&mut self, block_heights: Vec<u64>) -> Result<Vec<HistoricalBlock>, CommsInterfaceError> {
         match self
             .request_sender
-            .call(NodeCommsRequest::FetchBlocks(block_heights))
+            .call(NodeCommsRequest::FetchMatchingBlocks(block_heights))
             .await??
         {
             NodeCommsResponse::HistoricalBlocks(blocks) => Ok(blocks),
@@ -150,7 +150,7 @@ impl LocalNodeCommsInterface {
     {
         match self
             .request_sender
-            .call(NodeCommsRequest::FetchMmrNodes(tree, pos, count, hist_height))
+            .call(NodeCommsRequest::FetchMatchingMmrNodes(tree, pos, count, hist_height))
             .await??
         {
             NodeCommsResponse::MmrNodes(added, deleted) => Ok((added, deleted)),

--- a/base_layer/core/src/base_node/comms_interface/outbound_interface.rs
+++ b/base_layer/core/src/base_node/comms_interface/outbound_interface.rs
@@ -203,7 +203,7 @@ impl OutboundNodeCommsInterface {
     {
         if let NodeCommsResponse::TransactionOutputs(utxos) = self
             .request_sender
-            .call((NodeCommsRequest::FetchUtxos(hashes), node_id))
+            .call((NodeCommsRequest::FetchMatchingUtxos(hashes), node_id))
             .await??
         {
             Ok(utxos)
@@ -227,7 +227,7 @@ impl OutboundNodeCommsInterface {
     {
         if let NodeCommsResponse::TransactionOutputs(txos) = self
             .request_sender
-            .call((NodeCommsRequest::FetchTxos(hashes), node_id))
+            .call((NodeCommsRequest::FetchMatchingTxos(hashes), node_id))
             .await??
         {
             Ok(txos)
@@ -251,7 +251,7 @@ impl OutboundNodeCommsInterface {
     {
         if let NodeCommsResponse::HistoricalBlocks(blocks) = self
             .request_sender
-            .call((NodeCommsRequest::FetchBlocks(block_nums), node_id))
+            .call((NodeCommsRequest::FetchMatchingBlocks(block_nums), node_id))
             .await??
         {
             Ok(blocks)
@@ -335,7 +335,10 @@ impl OutboundNodeCommsInterface {
     {
         if let NodeCommsResponse::MmrNodes(added, deleted) = self
             .request_sender
-            .call((NodeCommsRequest::FetchMmrNodes(tree, pos, count, hist_height), node_id))
+            .call((
+                NodeCommsRequest::FetchMatchingMmrNodes(tree, pos, count, hist_height),
+                node_id,
+            ))
             .await??
         {
             Ok((added, deleted))

--- a/base_layer/core/src/base_node/proto/request.proto
+++ b/base_layer/core/src/base_node/proto/request.proto
@@ -18,10 +18,10 @@ message BaseNodeServiceRequest {
         BlockHeights fetch_headers = 4;
         // Indicates a FetchHeadersWithHashes request.
         HashOutputs fetch_headers_with_hashes = 5;
-        // Indicates a FetchUtxos request.
-        HashOutputs fetch_utxos = 6;
-        // Indicates a FetchBlocks request.
-        BlockHeights fetch_blocks = 7;
+        // Indicates a FetchMatchingUtxos request.
+        HashOutputs fetch_matching_utxos = 6;
+        // Indicates a FetchMatchingBlocks request.
+        BlockHeights fetch_matching_blocks = 7;
         // Indicates a FetchBlocksWithHashes request.
         HashOutputs fetch_blocks_with_hashes = 8;
         // Indicates a GetNewBlockTemplate request.
@@ -32,10 +32,10 @@ message BaseNodeServiceRequest {
         FetchHeadersAfter fetch_headers_after = 12;
         // Indicates a FetchMmrNodeCount request.
         FetchMmrNodeCount fetch_mmr_node_count = 13;
-        // Indicates a FetchMmrNodes request.
-        FetchMmrNodes fetch_mmr_nodes = 14;
-        // Indicates a FetchTxos request.
-        HashOutputs fetch_txos = 15;
+        // Indicates a FetchMatchingMmrNodes request.
+        FetchMatchingMmrNodes fetch_matching_mmr_nodes = 14;
+        // Indicates a FetchMatchingTxos request.
+        HashOutputs fetch_matching_txos = 15;
         // Indicates a Fetch block with kernels request
         Signatures fetch_blocks_with_kernels = 16;
         // Indicates a Fetch block with kernels request
@@ -71,7 +71,7 @@ message FetchMmrNodeCount {
     uint64 height = 2;
 }
 
-message FetchMmrNodes{
+message FetchMatchingMmrNodes{
     MmrTree tree = 1;
     uint32 pos = 2;
     uint32 count = 3;

--- a/base_layer/core/src/base_node/proto/request.rs
+++ b/base_layer/core/src/base_node/proto/request.rs
@@ -24,8 +24,8 @@ use super::base_node::{
     base_node_service_request::Request as ProtoNodeCommsRequest,
     BlockHeights,
     FetchHeadersAfter as ProtoFetchHeadersAfter,
+    FetchMatchingMmrNodes as ProtoFetchMmrNodes,
     FetchMmrNodeCount as ProtoFetchMmrNodeCount,
-    FetchMmrNodes as ProtoFetchMmrNodes,
     HashOutputs,
 };
 use crate::{
@@ -51,9 +51,9 @@ impl TryInto<ci::NodeCommsRequest> for ProtoNodeCommsRequest {
             FetchHeadersAfter(request) => {
                 ci::NodeCommsRequest::FetchHeadersAfter(request.hashes, request.stopping_hash)
             },
-            FetchUtxos(hash_outputs) => ci::NodeCommsRequest::FetchUtxos(hash_outputs.outputs),
-            FetchTxos(hash_outputs) => ci::NodeCommsRequest::FetchTxos(hash_outputs.outputs),
-            FetchBlocks(block_heights) => ci::NodeCommsRequest::FetchBlocks(block_heights.heights),
+            FetchMatchingUtxos(hash_outputs) => ci::NodeCommsRequest::FetchMatchingUtxos(hash_outputs.outputs),
+            FetchMatchingTxos(hash_outputs) => ci::NodeCommsRequest::FetchMatchingTxos(hash_outputs.outputs),
+            FetchMatchingBlocks(block_heights) => ci::NodeCommsRequest::FetchMatchingBlocks(block_heights.heights),
             FetchBlocksWithHashes(block_hashes) => ci::NodeCommsRequest::FetchBlocksWithHashes(block_hashes.outputs),
             FetchBlocksWithKernels(signatures) => {
                 let mut sigs = Vec::new();
@@ -83,7 +83,7 @@ impl TryInto<ci::NodeCommsRequest> for ProtoNodeCommsRequest {
             FetchMmrNodeCount(request) => {
                 ci::NodeCommsRequest::FetchMmrNodeCount(request.tree.try_into()?, request.height)
             },
-            FetchMmrNodes(request) => ci::NodeCommsRequest::FetchMmrNodes(
+            FetchMatchingMmrNodes(request) => ci::NodeCommsRequest::FetchMatchingMmrNodes(
                 request.tree.try_into()?,
                 request.pos,
                 request.count,
@@ -105,9 +105,9 @@ impl From<ci::NodeCommsRequest> for ProtoNodeCommsRequest {
             FetchHeadersAfter(hashes, stopping_hash) => {
                 ProtoNodeCommsRequest::FetchHeadersAfter(ProtoFetchHeadersAfter { hashes, stopping_hash })
             },
-            FetchUtxos(hash_outputs) => ProtoNodeCommsRequest::FetchUtxos(hash_outputs.into()),
-            FetchTxos(hash_outputs) => ProtoNodeCommsRequest::FetchTxos(hash_outputs.into()),
-            FetchBlocks(block_heights) => ProtoNodeCommsRequest::FetchBlocks(block_heights.into()),
+            FetchMatchingUtxos(hash_outputs) => ProtoNodeCommsRequest::FetchMatchingUtxos(hash_outputs.into()),
+            FetchMatchingTxos(hash_outputs) => ProtoNodeCommsRequest::FetchMatchingTxos(hash_outputs.into()),
+            FetchMatchingBlocks(block_heights) => ProtoNodeCommsRequest::FetchMatchingBlocks(block_heights.into()),
             FetchBlocksWithHashes(block_hashes) => ProtoNodeCommsRequest::FetchBlocksWithHashes(block_hashes.into()),
             FetchBlocksWithKernels(signatures) => {
                 let sigs = signatures.into_iter().map(Into::into).collect();
@@ -127,12 +127,14 @@ impl From<ci::NodeCommsRequest> for ProtoNodeCommsRequest {
                 tree: tree as i32,
                 height,
             }),
-            FetchMmrNodes(tree, pos, count, hist_height) => ProtoNodeCommsRequest::FetchMmrNodes(ProtoFetchMmrNodes {
-                tree: tree as i32,
-                pos,
-                count,
-                hist_height,
-            }),
+            FetchMatchingMmrNodes(tree, pos, count, hist_height) => {
+                ProtoNodeCommsRequest::FetchMatchingMmrNodes(ProtoFetchMmrNodes {
+                    tree: tree as i32,
+                    pos,
+                    count,
+                    hist_height,
+                })
+            },
         }
     }
 }

--- a/base_layer/core/src/proto/generated/tari.base_node.rs
+++ b/base_layer/core/src/proto/generated/tari.base_node.rs
@@ -170,12 +170,12 @@ pub mod base_node_service_request {
         /// Indicates a FetchHeadersWithHashes request.
         #[prost(message, tag = "5")]
         FetchHeadersWithHashes(super::HashOutputs),
-        /// Indicates a FetchUtxos request.
+        /// Indicates a FetchMatchingUtxos request.
         #[prost(message, tag = "6")]
-        FetchUtxos(super::HashOutputs),
-        /// Indicates a FetchBlocks request.
+        FetchMatchingUtxos(super::HashOutputs),
+        /// Indicates a FetchMatchingBlocks request.
         #[prost(message, tag = "7")]
-        FetchBlocks(super::BlockHeights),
+        FetchMatchingBlocks(super::BlockHeights),
         /// Indicates a FetchBlocksWithHashes request.
         #[prost(message, tag = "8")]
         FetchBlocksWithHashes(super::HashOutputs),
@@ -191,12 +191,12 @@ pub mod base_node_service_request {
         /// Indicates a FetchMmrNodeCount request.
         #[prost(message, tag = "13")]
         FetchMmrNodeCount(super::FetchMmrNodeCount),
-        /// Indicates a FetchMmrNodes request.
+        /// Indicates a FetchMatchingMmrNodes request.
         #[prost(message, tag = "14")]
-        FetchMmrNodes(super::FetchMmrNodes),
-        /// Indicates a FetchTxos request.
+        FetchMatchingMmrNodes(super::FetchMatchingMmrNodes),
+        /// Indicates a FetchMatchingTxos request.
         #[prost(message, tag = "15")]
-        FetchTxos(super::HashOutputs),
+        FetchMatchingTxos(super::HashOutputs),
         /// Indicates a Fetch block with kernels request
         #[prost(message, tag = "16")]
         FetchBlocksWithKernels(super::Signatures),
@@ -243,7 +243,7 @@ pub struct FetchMmrNodeCount {
     pub height: u64,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
-pub struct FetchMmrNodes {
+pub struct FetchMatchingMmrNodes {
     #[prost(enumeration = "MmrTree", tag = "1")]
     pub tree: i32,
     #[prost(uint32, tag = "2")]

--- a/base_layer/wallet/src/output_manager_service/protocols/txo_validation_protocol.rs
+++ b/base_layer/wallet/src/output_manager_service/protocols/txo_validation_protocol.rs
@@ -264,7 +264,7 @@ where TBackend: OutputManagerBackend + 'static
 
             let request_key = if r == 0 { self.id } else { OsRng.next_u64() };
 
-            let request = BaseNodeRequestProto::FetchUtxos(BaseNodeProto::HashOutputs {
+            let request = BaseNodeRequestProto::FetchMatchingUtxos(BaseNodeProto::HashOutputs {
                 outputs: output_hashes.clone(),
             });
 

--- a/base_layer/wallet/src/transaction_service/protocols/transaction_broadcast_protocol.rs
+++ b/base_layer/wallet/src/transaction_service/protocols/transaction_broadcast_protocol.rs
@@ -175,7 +175,7 @@ where TBackend: TransactionBackend + 'static
                 hashes.push(o.hash());
             }
 
-            let request = BaseNodeRequestProto::FetchUtxos(BaseNodeProto::HashOutputs { outputs: hashes });
+            let request = BaseNodeRequestProto::FetchMatchingUtxos(BaseNodeProto::HashOutputs { outputs: hashes });
             let service_request = BaseNodeProto::BaseNodeServiceRequest {
                 request_key: self.id,
                 request: Some(request),

--- a/base_layer/wallet/src/transaction_service/protocols/transaction_chain_monitoring_protocol.rs
+++ b/base_layer/wallet/src/transaction_service/protocols/transaction_chain_monitoring_protocol.rs
@@ -194,7 +194,7 @@ where TBackend: TransactionBackend + 'static
                 .map_err(|e| TransactionServiceProtocolError::new(self.id, TransactionServiceError::from(e)))?;
 
             // Send Base Node query
-            let request = BaseNodeRequestProto::FetchUtxos(BaseNodeProto::HashOutputs { outputs: hashes });
+            let request = BaseNodeRequestProto::FetchMatchingUtxos(BaseNodeProto::HashOutputs { outputs: hashes });
             let service_request = BaseNodeProto::BaseNodeServiceRequest {
                 request_key: self.id,
                 request: Some(request),

--- a/base_layer/wallet/src/transaction_service/protocols/transaction_coinbase_monitoring_protocol.rs
+++ b/base_layer/wallet/src/transaction_service/protocols/transaction_coinbase_monitoring_protocol.rs
@@ -176,7 +176,7 @@ where TBackend: TransactionBackend + 'static
                 .await
                 .map_err(|e| TransactionServiceProtocolError::new(self.id, TransactionServiceError::from(e)))?;
 
-            let request = BaseNodeRequestProto::FetchUtxos(BaseNodeProto::HashOutputs { outputs: hashes });
+            let request = BaseNodeRequestProto::FetchMatchingUtxos(BaseNodeProto::HashOutputs { outputs: hashes });
             let service_request = BaseNodeProto::BaseNodeServiceRequest {
                 request_key: self.id,
                 request: Some(request),

--- a/base_layer/wallet/tests/output_manager_service/service.rs
+++ b/base_layer/wallet/tests/output_manager_service/service.rs
@@ -749,7 +749,7 @@ fn test_utxo_validation() {
     match bn_request1.request {
         None => assert!(false, "Invalid request"),
         Some(request) => match request {
-            Request::FetchUtxos(hash_outputs) => {
+            Request::FetchMatchingUtxos(hash_outputs) => {
                 for h in hash_outputs.outputs {
                     if hashes.iter().find(|i| **i == h).is_some() {
                         hashes_found += 1;
@@ -770,7 +770,7 @@ fn test_utxo_validation() {
     match bn_request2.request {
         None => assert!(false, "Invalid request"),
         Some(request) => match request {
-            Request::FetchUtxos(hash_outputs) => {
+            Request::FetchMatchingUtxos(hash_outputs) => {
                 for h in hash_outputs.outputs {
                     if hashes.iter().find(|i| **i == h).is_some() {
                         hashes_found += 1;
@@ -791,7 +791,7 @@ fn test_utxo_validation() {
     match bn_request3.request {
         None => assert!(false, "Invalid request"),
         Some(request) => match request {
-            Request::FetchUtxos(hash_outputs) => {
+            Request::FetchMatchingUtxos(hash_outputs) => {
                 for h in hash_outputs.outputs {
                     if hashes.iter().find(|i| **i == h).is_some() {
                         hashes_found += 1;
@@ -844,7 +844,7 @@ fn test_utxo_validation() {
             .unwrap()
             .unwrap();
 
-        let request_hashes = if let Request::FetchUtxos(outputs) = bn_request.request.unwrap() {
+        let request_hashes = if let Request::FetchMatchingUtxos(outputs) = bn_request.request.unwrap() {
             outputs.outputs
         } else {
             assert!(false, "Wrong request type");
@@ -1209,7 +1209,7 @@ fn test_spent_txo_validation() {
     match bn_request1.request {
         None => assert!(false, "Invalid request"),
         Some(request) => match request {
-            Request::FetchUtxos(hash_outputs) => {
+            Request::FetchMatchingUtxos(hash_outputs) => {
                 assert_eq!(hash_outputs.outputs.len(), 2, "There should be 2 hashes in the query");
                 for h in hash_outputs.outputs {
                     if hashes.iter().find(|i| **i == h).is_some() {

--- a/base_layer/wallet/tests/transaction_service/service.rs
+++ b/base_layer/wallet/tests/transaction_service/service.rs
@@ -3687,7 +3687,7 @@ fn test_handling_coinbase_transactions() {
                 BaseNodeRequestProto::GetChainMetadata(_c) => {
                     chain_metadata_request.insert(bsr.request_key);
                 },
-                BaseNodeRequestProto::FetchUtxos(f) => {
+                BaseNodeRequestProto::FetchMatchingUtxos(f) => {
                     fetch_utxo_request.insert(bsr.request_key, f);
                 },
                 _ => (),
@@ -3885,7 +3885,7 @@ fn test_handling_coinbase_transactions() {
                     }
                     metadata_count += 1;
                 },
-                BaseNodeRequestProto::FetchUtxos(_f) => {
+                BaseNodeRequestProto::FetchMatchingUtxos(_f) => {
                     if request_key == 0 {
                         request_key = bsr.request_key;
                     } else {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- The change to `fetch_utxos`, `fetch_txos` and `fetch_blocks` introduced in #2357 caused the those calls to timeout and fail in the client, as nothing was returned if matching data could not be found, contrary to the original design. This commit reverts that change, as well as a change to the unit test, and renames the affected `NodeCommsRequest` functions so their intent can be clear.
- The change to `NodeCommsRequest::fetch_mmr_nodes` was reverted in #2364; this PR also renames that function aptly.

## Motivation and Context
Calls to `fetch_utxos`, `fetch_txos` and `fetch_blocks` should return the data that a node has to the client, even if it is an empty set, and not return a local error to the base node, otherwise the base node request will time out in the client and system operation is broken.

## How Has This Been Tested?
Tested in a base node on Windows with invalid UTXOs and TXOs. The time out problem with `fetch_utxos` and `fetch_txos` problem would never occur if a wallet only tries to validate valid UTXOs or TXOs, so the only way to properly test if the system works properly is for a wallet to try and validate invalid UTXOs or TXOs.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [X] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [X] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [X] I'm merging against the `development` branch.
* [X] I ran `cargo-fmt --all` before pushing.
* [X] I ran `cargo test` successfully before submitting my PR.
* [X] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
