### PR TITLE
Implement daemon-mode in tari_base_node

### DIFF
--- a/applications/tari_base_node/src/main.rs
+++ b/applications/tari_base_node/src/main.rs
@@ -238,9 +238,8 @@ fn main_inner() -> Result<(), ExitCodes> {
 
         cli_loop(Some(parser), shutdown);
     } else {
-        println!("Node has been successfully configured and initialized in daemon mode. Starting CLI loop.");
+        println!("Node has been successfully configured and initialized in daemon mode.");
         base_node_handle = rt.spawn(ctx.run());
-        cli_loop(None, shutdown);
     }
     match rt.block_on(base_node_handle) {
         Ok(_) => info!(target: LOG_TARGET, "Node shutdown successfully."),

--- a/base_layer/core/src/blocks/genesis_block.rs
+++ b/base_layer/core/src/blocks/genesis_block.rs
@@ -197,7 +197,8 @@ pub fn get_ridcully_genesis_block_raw() -> Block {
             prev_hash: vec![
                 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
             ],
-            timestamp: 1_603_843_200.into(), // 10/28/2020 @ 12:00am (UTC)
+            // timestamp: 1_603_843_200.into(), // 10/28/2020 @ 12:00am (UTC)
+            timestamp: 1_603_782_277.into(), // todo remove and swop to top.
             output_mr: from_hex("dcc44f39b65e5e1e526887e7d56f7b85e2ea44bd29bc5bc195e6e015d19e1c06").unwrap(),
             range_proof_mr: from_hex("e4d7dab49a66358379a901b9a36c10f070aa9d7bdc8ae752947b6fc4e55d255f").unwrap(),
             kernel_mr: from_hex("589bc62ac5d9139f921c68b8075c32d8d130024acaf3196d1d6a89df601e2bcf").unwrap(),


### PR DESCRIPTION
Implements a daemon mode for the Tari Base Node

## Description
Starts application without CLI parser when --daemon-mode argument is present.

## Motivation and Context


## How Has This Been Tested?
cargo-test --all --all-features

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch.
* [x] I ran `cargo-fmt --all` before pushing.
* [x] I ran `cargo test` successfully before submitting my PR.
* [x] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
