### PR TITLE
Fix unit tests for `get_target_difficulty`

### DIFF
--- a/base_layer/core/tests/helpers/pow_blockchain.rs
+++ b/base_layer/core/tests/helpers/pow_blockchain.rs
@@ -106,6 +106,7 @@ pub fn append_to_pow_blockchain<T: BlockchainBackend>(
             constants.get_difficulty_block_window() as usize,
             constants.get_diff_target_block_interval(pow_algo),
             constants.min_pow_difficulty(pow_algo),
+            constants.max_pow_difficulty(pow_algo),
             constants.get_difficulty_max_block_interval(pow_algo),
         )
         .unwrap();

--- a/base_layer/core/tests/target_difficulty.rs
+++ b/base_layer/core/tests/target_difficulty.rs
@@ -71,6 +71,7 @@ fn test_target_difficulty_at_tip() {
             block_window,
             target_time,
             constants.min_pow_difficulty(pow_algo),
+            constants.max_pow_difficulty(pow_algo),
             max_block_time
         )
         .unwrap(),
@@ -85,6 +86,7 @@ fn test_target_difficulty_at_tip() {
             block_window,
             target_time,
             constants.min_pow_difficulty(pow_algo),
+            constants.max_pow_difficulty(pow_algo),
             max_block_time
         )
         .unwrap(),
@@ -119,6 +121,7 @@ fn test_target_difficulty_with_height() {
             block_window,
             target_time,
             constants.min_pow_difficulty(pow_algo),
+            constants.max_pow_difficulty(pow_algo),
             max_block_time
         )
         .unwrap(),
@@ -132,6 +135,7 @@ fn test_target_difficulty_with_height() {
             block_window,
             target_time,
             constants.min_pow_difficulty(pow_algo),
+            constants.max_pow_difficulty(pow_algo),
             max_block_time
         )
         .unwrap(),
@@ -145,6 +149,7 @@ fn test_target_difficulty_with_height() {
             block_window,
             target_time,
             constants.min_pow_difficulty(pow_algo),
+            constants.max_pow_difficulty(pow_algo),
             max_block_time
         )
         .unwrap(),
@@ -158,6 +163,7 @@ fn test_target_difficulty_with_height() {
             block_window,
             target_time,
             constants.min_pow_difficulty(pow_algo),
+            constants.max_pow_difficulty(pow_algo),
             max_block_time
         )
         .unwrap(),
@@ -170,6 +176,7 @@ fn test_target_difficulty_with_height() {
             block_window,
             target_time,
             constants.min_pow_difficulty(pow_algo),
+            constants.max_pow_difficulty(pow_algo),
             max_block_time
         )
         .unwrap(),
@@ -183,6 +190,7 @@ fn test_target_difficulty_with_height() {
             block_window,
             target_time,
             constants.min_pow_difficulty(pow_algo),
+            constants.max_pow_difficulty(pow_algo),
             max_block_time
         )
         .unwrap(),
@@ -196,13 +204,13 @@ fn test_target_block_interval() {
     algos.insert(PowAlgorithm::Blake, PowAlgorithmConstants {
         max_target_time: 240 * 6,
         min_difficulty: 60_000_000.into(),
-        max_difficulty: 60_000_000.into(),
+        max_difficulty: u64::MAX.into(),
         target_time: 240,
     });
     algos.insert(PowAlgorithm::Monero, PowAlgorithmConstants {
         max_target_time: 240 * 6,
         min_difficulty: 60_000_000.into(),
-        max_difficulty: 60_000_000.into(),
+        max_difficulty: u64::MAX.into(),
         target_time: 240,
     });
     let constants_2_equal = ConsensusConstantsBuilder::new(Network::LocalNet)
@@ -213,13 +221,13 @@ fn test_target_block_interval() {
     algos.insert(PowAlgorithm::Blake, PowAlgorithmConstants {
         max_target_time: 300 * 6,
         min_difficulty: 60_000_000.into(),
-        max_difficulty: 60_000_000.into(),
+        max_difficulty: u64::MAX.into(),
         target_time: 300,
     });
     algos.insert(PowAlgorithm::Monero, PowAlgorithmConstants {
         max_target_time: 200 * 6,
         min_difficulty: 60_000_000.into(),
-        max_difficulty: 60_000_000.into(),
+        max_difficulty: u64::MAX.into(),
         target_time: 200,
     });
     let constants_2_split = ConsensusConstantsBuilder::new(Network::LocalNet)
@@ -230,7 +238,7 @@ fn test_target_block_interval() {
     algos.insert(PowAlgorithm::Monero, PowAlgorithmConstants {
         max_target_time: 120 * 6,
         min_difficulty: 60_000_000.into(),
-        max_difficulty: 60_000_000.into(),
+        max_difficulty: u64::MAX.into(),
         target_time: 120,
     });
     let constants_1 = ConsensusConstantsBuilder::new(Network::LocalNet)

--- a/base_layer/wallet/src/transaction_service/service.rs
+++ b/base_layer/wallet/src/transaction_service/service.rs
@@ -302,7 +302,7 @@ where
                         &mut transaction_broadcast_protocol_handles,
                         &mut transaction_chain_monitoring_protocol_handles,
                         &mut coinbase_transaction_monitoring_protocol_handles).await.or_else(|resp| {
-                        error!(target: LOG_TARGET, "Error handling request: {:?}", resp);
+                        warn!(target: LOG_TARGET, "Error handling request: {:?}", resp);
                         Err(resp)
                     })).or_else(|resp| {
                         warn!(target: LOG_TARGET, "Failed to send reply");


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- A recent PR increased parameters for `pub fn get_target_difficulty` without changing the unit tests.
- Expanded `inbound_fetch_utxos` unit test to request only a subset plus 1 fake UTXOs.
- Changed log level in `transaction_service/service.rs` to be consistent; not finding a UTXO is not an error in this case.

## Motivation and Context
Unit tests should pass

## How Has This Been Tested?
Ran unit tests locally

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [X] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [X] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [X] I'm merging against the `development` branch.
* [X] I ran `cargo-fmt --all` before pushing.
* [X] I ran `cargo test` successfully before submitting my PR.
* [X] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
