### PR TITLE
INFO log messages must be on a single line

### DIFF
--- a/base_layer/core/src/base_node/state_machine_service/states/block_sync.rs
+++ b/base_layer/core/src/base_node/state_machine_service/states/block_sync.rs
@@ -541,7 +541,11 @@ async fn request_and_add_blocks<B: BlockchainBackend + 'static>(
             }
 
             shared.publish_event_info();
-            info!(target: LOG_TARGET, "Adding block to db: {}", block);
+            info!(
+                target: LOG_TARGET,
+                "Adding block #{} ({}) to DB.", block_height, block_hash_hex
+            );
+            trace!(target: LOG_TARGET, "{}", block);
             match async_db::add_block(shared.db.clone(), block.clone()).await {
                 Ok(BlockAddResult::Ok) => {
                     info!(


### PR DESCRIPTION
Logging policy is that DEBUG and higher messages fit on one line.
Printing the entire block must be trace level.

