### PR TITLE
Implement wallet base node service

### DIFF
--- a/base_layer/core/src/chain_storage/metadata.rs
+++ b/base_layer/core/src/chain_storage/metadata.rs
@@ -26,7 +26,7 @@ use std::fmt::{Display, Error, Formatter};
 
 use tari_crypto::tari_utilities::hex::Hex;
 
-#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize, Hash)]
 pub struct ChainMetadata {
     /// The current chain height, or the block number of the longest valid chain, or `None` if there is no chain
     pub height_of_longest_chain: Option<u64>,

--- a/base_layer/service_framework/src/reply_channel.rs
+++ b/base_layer/service_framework/src/reply_channel.rs
@@ -51,7 +51,7 @@ type Tx<TReq, TRes> = mpsc::UnboundedSender<(TReq, oneshot::Sender<TRes>)>;
 pub type TrySenderService<TReq, TResp, TErr> = SenderService<TReq, Result<TResp, TErr>>;
 pub type TryReceiver<TReq, TResp, TErr> = Receiver<TReq, Result<TResp, TErr>>;
 
-/// Requester is sends requests on a given `Tx` sender and returns a
+/// Requester sends `TReq` requests on a given `Tx` sender, and returns an
 /// AwaitResponseFuture which will resolve to the generic `TRes`.
 ///
 /// This should be used to make requests which require a response.

--- a/base_layer/wallet/src/base_node_service/config.rs
+++ b/base_layer/wallet/src/base_node_service/config.rs
@@ -1,0 +1,56 @@
+// Copyright 2020. The Tari Project
+//
+// Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+// following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+// disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+// following disclaimer in the documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+// products derived from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+// INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+// WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+// USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+use log::*;
+use std::time::Duration;
+
+const LOG_TARGET: &str = "wallet::base_node_service::config";
+
+#[derive(Clone)]
+pub struct BaseNodeServiceConfig {
+    pub refresh_interval: Duration,
+    pub request_keys_max_age: Duration,
+}
+
+impl Default for BaseNodeServiceConfig {
+    fn default() -> Self {
+        Self {
+            refresh_interval: Duration::from_secs(30),
+            request_keys_max_age: Duration::from_secs(120),
+        }
+    }
+}
+
+impl BaseNodeServiceConfig {
+    pub fn new(refresh_interval: Duration, request_keys_max_age: Duration) -> Self {
+        info!(
+            target: LOG_TARGET,
+            "Setting new wallet base node service config, refresh_interval: {:?}, request_keys_max_age: {:?}",
+            refresh_interval,
+            request_keys_max_age
+        );
+        Self {
+            refresh_interval,
+            request_keys_max_age,
+        }
+    }
+}

--- a/base_layer/wallet/src/base_node_service/error.rs
+++ b/base_layer/wallet/src/base_node_service/error.rs
@@ -1,0 +1,37 @@
+// Copyright 2020. The Tari Project
+//
+// Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+// following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+// disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+// following disclaimer in the documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+// products derived from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+// INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+// WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+// USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+use tari_comms_dht::outbound::DhtOutboundError;
+use tari_service_framework::reply_channel::TransportChannelError;
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum BaseNodeServiceError {
+    #[error("No base node public key set")]
+    NoBaseNodePublicKey,
+    #[error("Unexpected API Response")]
+    UnexpectedApiResponse,
+    #[error("Transport channel error: `{0}`")]
+    TransportChannelError(#[from] TransportChannelError),
+    #[error("Outbound Error: `{0}`")]
+    OutboundError(#[from] DhtOutboundError),
+}

--- a/base_layer/wallet/src/base_node_service/handle.rs
+++ b/base_layer/wallet/src/base_node_service/handle.rs
@@ -1,0 +1,85 @@
+// Copyright 2020. The Tari Project
+//
+// Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+// following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+// disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+// following disclaimer in the documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+// products derived from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+// INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+// WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+// USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+use super::{error::BaseNodeServiceError, service::BaseNodeState};
+use futures::{stream::Fuse, StreamExt};
+use std::sync::Arc;
+use tari_comms::types::CommsPublicKey;
+use tari_core::chain_storage::ChainMetadata;
+use tari_service_framework::reply_channel::SenderService;
+use tokio::sync::broadcast;
+use tower::Service;
+
+pub type BaseNodeEventSender = broadcast::Sender<Arc<BaseNodeEvent>>;
+pub type BaseNodeEventReceiver = broadcast::Receiver<Arc<BaseNodeEvent>>;
+/// API Request enum
+#[derive(Debug)]
+pub enum BaseNodeServiceRequest {
+    GetChainMetadata,
+    SetBaseNodePublicKey(CommsPublicKey),
+}
+/// API Response enum
+#[derive(Debug)]
+pub enum BaseNodeServiceResponse {
+    ChainMetadata(Option<ChainMetadata>),
+    BaseNodePublicKeySet,
+}
+#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+pub enum BaseNodeEvent {
+    BaseNodeState(BaseNodeState),
+}
+
+/// The Base Node Service Handle is a struct that contains the interfaces used to communicate with a running
+/// Base Node
+#[derive(Clone)]
+pub struct BaseNodeServiceHandle {
+    handle: SenderService<BaseNodeServiceRequest, Result<BaseNodeServiceResponse, BaseNodeServiceError>>,
+    event_stream_sender: BaseNodeEventSender,
+}
+
+impl BaseNodeServiceHandle {
+    pub fn new(
+        handle: SenderService<BaseNodeServiceRequest, Result<BaseNodeServiceResponse, BaseNodeServiceError>>,
+        event_stream_sender: BaseNodeEventSender,
+    ) -> Self
+    {
+        Self {
+            handle,
+            event_stream_sender,
+        }
+    }
+
+    pub fn get_event_stream_fused(&self) -> Fuse<BaseNodeEventReceiver> {
+        self.event_stream_sender.subscribe().fuse()
+    }
+
+    pub async fn set_base_node_public_key(&mut self, public_key: CommsPublicKey) -> Result<(), BaseNodeServiceError> {
+        match self
+            .handle
+            .call(BaseNodeServiceRequest::SetBaseNodePublicKey(public_key))
+            .await??
+        {
+            BaseNodeServiceResponse::BaseNodePublicKeySet => Ok(()),
+            _ => Err(BaseNodeServiceError::UnexpectedApiResponse),
+        }
+    }
+}

--- a/base_layer/wallet/src/base_node_service/mod.rs
+++ b/base_layer/wallet/src/base_node_service/mod.rs
@@ -1,0 +1,121 @@
+// Copyright 2020. The Tari Project
+//
+// Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+// following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+// disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+// following disclaimer in the documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+// products derived from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+// INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+// WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+// USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+pub mod config;
+pub mod error;
+pub mod handle;
+pub mod service;
+
+use crate::base_node_service::{
+    config::BaseNodeServiceConfig,
+    handle::BaseNodeServiceHandle,
+    service::BaseNodeService,
+};
+
+use log::*;
+use std::sync::Arc;
+use tari_comms_dht::Dht;
+
+use futures::{future, Future, Stream, StreamExt};
+use tari_core::base_node::proto::base_node as BaseNodeProto;
+use tari_p2p::{
+    comms_connector::SubscriptionFactory,
+    domain_message::DomainMessage,
+    services::utils::{map_decode, ok_or_skip_result},
+    tari_message::TariMessageType,
+};
+use tari_service_framework::{
+    reply_channel,
+    ServiceInitializationError,
+    ServiceInitializer,
+    ServiceInitializerContext,
+};
+use tokio::sync::broadcast;
+
+const LOG_TARGET: &str = "wallet::base_node_service";
+const SUBSCRIPTION_LABEL: &str = "Base Node";
+
+pub struct BaseNodeServiceInitializer {
+    config: BaseNodeServiceConfig,
+    subscription_factory: Arc<SubscriptionFactory>,
+}
+
+impl BaseNodeServiceInitializer {
+    pub fn new(config: BaseNodeServiceConfig, subscription_factory: Arc<SubscriptionFactory>) -> Self {
+        Self {
+            config,
+            subscription_factory,
+        }
+    }
+
+    fn base_node_response_stream(&self) -> impl Stream<Item = DomainMessage<BaseNodeProto::BaseNodeServiceResponse>> {
+        trace!(
+            target: LOG_TARGET,
+            "Subscription '{}' for topic '{:?}' created.",
+            SUBSCRIPTION_LABEL,
+            TariMessageType::BaseNodeResponse
+        );
+        self.subscription_factory
+            .get_subscription(TariMessageType::BaseNodeResponse, SUBSCRIPTION_LABEL)
+            .map(map_decode::<BaseNodeProto::BaseNodeServiceResponse>)
+            .filter_map(ok_or_skip_result)
+    }
+}
+impl ServiceInitializer for BaseNodeServiceInitializer {
+    type Future = impl Future<Output = Result<(), ServiceInitializationError>>;
+
+    fn initialize(&mut self, context: ServiceInitializerContext) -> Self::Future {
+        info!(target: LOG_TARGET, "Wallet base node service initializing.");
+
+        let (sender, request_stream) = reply_channel::unbounded();
+        let base_node_response_stream = self.base_node_response_stream();
+
+        let (event_publisher, _) = broadcast::channel(200);
+
+        let basenode_service_handle = BaseNodeServiceHandle::new(sender, event_publisher.clone());
+
+        // Register handle before waiting for handles to be ready
+        context.register_handle(basenode_service_handle);
+
+        let config = self.config.clone();
+
+        context.spawn_when_ready(move |handles| async move {
+            let dht = handles.expect_handle::<Dht>();
+            let outbound_messaging = dht.outbound_requester();
+
+            let service = BaseNodeService::new(
+                config,
+                base_node_response_stream,
+                request_stream,
+                outbound_messaging,
+                event_publisher,
+                handles.get_shutdown_signal(),
+            )
+            .start();
+            futures::pin_mut!(service);
+            future::select(service, handles.get_shutdown_signal()).await;
+            info!(target: LOG_TARGET, "Wallet Base Node Service shutdown");
+        });
+
+        future::ready(Ok(()))
+    }
+}

--- a/base_layer/wallet/src/base_node_service/service.rs
+++ b/base_layer/wallet/src/base_node_service/service.rs
@@ -1,0 +1,317 @@
+// Copyright 2020. The Tari Project
+//
+// Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+// following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+// disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+// following disclaimer in the documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+// products derived from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+// INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+// WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+// USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+use std::{
+    sync::Arc,
+    time::{Duration, Instant},
+};
+
+use super::{
+    config::BaseNodeServiceConfig,
+    error::BaseNodeServiceError,
+    handle::{BaseNodeEvent, BaseNodeEventSender, BaseNodeServiceRequest, BaseNodeServiceResponse},
+};
+
+use chrono::{NaiveDateTime, Utc};
+use futures::{pin_mut, Stream, StreamExt};
+use log::*;
+use rand::rngs::OsRng;
+use tari_comms::types::CommsPublicKey;
+use tari_comms_dht::{domain_message::OutboundDomainMessage, outbound::OutboundMessageRequester};
+use tari_core::{
+    base_node::{
+        generate_request_key,
+        proto::{
+            base_node as BaseNodeProto,
+            base_node::{
+                base_node_service_request::Request as BaseNodeRequestProto,
+                base_node_service_response::Response as BaseNodeResponseProto,
+            },
+        },
+        RequestKey,
+    },
+    chain_storage::ChainMetadata,
+};
+use tari_p2p::{domain_message::DomainMessage, tari_message::TariMessageType};
+use tari_service_framework::reply_channel::Receiver;
+use tari_shutdown::ShutdownSignal;
+use tokio::time;
+
+const LOG_TARGET: &str = "wallet::base_node_service::service";
+
+/// State determined from Base Node Service Requests
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct BaseNodeState {
+    pub chain_metadata: Option<ChainMetadata>,
+    pub is_synced: Option<bool>,
+    pub updated: Option<NaiveDateTime>,
+}
+
+impl Default for BaseNodeState {
+    fn default() -> Self {
+        Self {
+            chain_metadata: None,
+            is_synced: None,
+            updated: None,
+        }
+    }
+}
+
+/// To keep track of when a request was sent
+#[derive(Debug, Clone, Copy)]
+struct RequestMetadata {
+    request_key: RequestKey,
+    sent: NaiveDateTime,
+}
+
+/// The wallet base node service is responsible for handling requests to be sent to the connected base node.
+pub struct BaseNodeService<BNResponseStream> {
+    config: BaseNodeServiceConfig,
+    base_node_response_stream: Option<BNResponseStream>,
+    request_stream: Option<Receiver<BaseNodeServiceRequest, Result<BaseNodeServiceResponse, BaseNodeServiceError>>>,
+    outbound_messaging: OutboundMessageRequester,
+    event_publisher: BaseNodeEventSender,
+    base_node_public_key: Option<CommsPublicKey>,
+    shutdown_signal: Option<ShutdownSignal>,
+    state: BaseNodeState,
+    requests: Vec<RequestMetadata>,
+}
+
+impl<BNResponseStream> BaseNodeService<BNResponseStream>
+where BNResponseStream: Stream<Item = DomainMessage<BaseNodeProto::BaseNodeServiceResponse>>
+{
+    pub fn new(
+        config: BaseNodeServiceConfig,
+        base_node_response_stream: BNResponseStream,
+        request_stream: Receiver<BaseNodeServiceRequest, Result<BaseNodeServiceResponse, BaseNodeServiceError>>,
+        outbound_messaging: OutboundMessageRequester,
+        event_publisher: BaseNodeEventSender,
+        shutdown_signal: ShutdownSignal,
+    ) -> Self
+    {
+        Self {
+            config,
+            base_node_response_stream: Some(base_node_response_stream),
+            request_stream: Some(request_stream),
+            outbound_messaging,
+            event_publisher,
+            base_node_public_key: None,
+            shutdown_signal: Some(shutdown_signal),
+            state: BaseNodeState::default(),
+            requests: Vec::new(),
+        }
+    }
+
+    fn set_state(&mut self, state: BaseNodeState) {
+        self.state = state;
+    }
+
+    /// Returns the last known state of the connected base node.
+    pub fn get_state(&self) -> &BaseNodeState {
+        &self.state
+    }
+
+    /// Starts the service.
+    pub async fn start(mut self) -> Result<(), BaseNodeServiceError> {
+        let request_stream = self
+            .request_stream
+            .take()
+            .expect("Wallet Base Node Service initialized without request_stream")
+            .fuse();
+        pin_mut!(request_stream);
+
+        let base_node_response_stream = self
+            .base_node_response_stream
+            .take()
+            .expect("Wallet Base Node Service initialized without base_node_response_stream")
+            .fuse();
+        pin_mut!(base_node_response_stream);
+
+        let interval = self.config.refresh_interval;
+        let mut refresh_tick = time::interval_at((Instant::now() + interval).into(), interval).fuse();
+
+        let mut shutdown_signal = self
+            .shutdown_signal
+            .take()
+            .expect("Wallet Base Node Service initialized without shutdown signal");
+
+        info!(target: LOG_TARGET, "Wallet Base Node Service started");
+        loop {
+            futures::select! {
+                // Incoming requests
+                request_context = request_stream.select_next_some() => {
+                    trace!(target: LOG_TARGET, "Handling Base Node Service API Request");
+                    let (request, reply_tx) = request_context.split();
+                    let _ = reply_tx.send(self.handle_request(request).await.or_else(|resp| {
+                        error!(target: LOG_TARGET, "Error handling request: {:?}", resp);
+                        Err(resp)
+                    })).or_else(|resp| {
+                        warn!(target: LOG_TARGET, "Failed to send reply");
+                        Err(resp)
+                    });
+                },
+
+                // Base Node Responses
+                response = base_node_response_stream.select_next_some() => {
+                    if let Err(e) = self.handle_base_node_response(response).await {
+                        warn!(target: LOG_TARGET, "Failed to handle base node response: {}", e);
+                    }
+                },
+
+                // Refresh Interval Tick
+                _ = refresh_tick.select_next_some() => {
+                    if let Err(e) = self.refresh_chain_metadata().await {
+                        warn!(target: LOG_TARGET, "Error when sending refresh chain metadata request: {}", e);
+                    }
+                },
+
+                // Shutdown
+                _ = shutdown_signal => {
+                    info!(target: LOG_TARGET, "Wallet Base Node Service shutting down because the shutdown signal was received");
+                    break Ok(());
+                }
+            }
+        }
+    }
+
+    /// Sends a request to the connected base node to retrieve chain metadata.
+    async fn refresh_chain_metadata(&mut self) -> Result<(), BaseNodeServiceError> {
+        debug!(target: LOG_TARGET, "Refresh chain metadata");
+        let dest_public_key = self
+            .base_node_public_key
+            .clone()
+            .ok_or_else(|| BaseNodeServiceError::NoBaseNodePublicKey)?;
+
+        let request_key = generate_request_key(&mut OsRng);
+        let now = Utc::now().naive_utc();
+
+        self.requests.push(RequestMetadata { request_key, sent: now });
+
+        // remove old request keys
+        let (current_requests, old): (Vec<RequestMetadata>, Vec<RequestMetadata>) =
+            self.requests.iter().partition(|r| {
+                let age = Utc::now().naive_utc() - r.sent;
+                // convert to std Duration
+                let age = Duration::from_millis(age.num_milliseconds() as u64);
+
+                age <= self.config.request_keys_max_age
+            });
+
+        trace!(target: LOG_TARGET, "current requests: {:?}", current_requests);
+        trace!(target: LOG_TARGET, "discarded requests : {:?}", old);
+
+        self.requests = current_requests;
+
+        let request = BaseNodeRequestProto::GetChainMetadata(true);
+        let service_request = BaseNodeProto::BaseNodeServiceRequest {
+            request_key,
+            request: Some(request),
+        };
+
+        let message = OutboundDomainMessage::new(TariMessageType::BaseNodeRequest, service_request);
+
+        self.outbound_messaging
+            .send_direct(dest_public_key, message)
+            .await
+            .map_err(BaseNodeServiceError::OutboundError)?;
+
+        debug!(target: LOG_TARGET, "Refresh chain metadata sent");
+
+        Ok(())
+    }
+
+    /// Handles the response from the connected base node.
+    async fn handle_base_node_response(
+        &mut self,
+        response: DomainMessage<BaseNodeProto::BaseNodeServiceResponse>,
+    ) -> Result<(), BaseNodeServiceError>
+    {
+        let DomainMessage::<_> { inner: message, .. } = response;
+
+        let (found, remaining): (Vec<RequestMetadata>, Vec<RequestMetadata>) = self
+            .requests
+            .iter()
+            .partition(|&&r| r.request_key == message.request_key);
+
+        if !found.is_empty() {
+            debug!(target: LOG_TARGET, "Handle base node response message: {:?}", message);
+            match message.response {
+                Some(BaseNodeResponseProto::ChainMetadata(chain_metadata)) => {
+                    trace!(target: LOG_TARGET, "Chain Metadata response {:?}", chain_metadata);
+                    let now = Utc::now().naive_utc();
+                    let state = BaseNodeState {
+                        is_synced: Some(message.is_synced),
+                        chain_metadata: Some(chain_metadata.into()),
+                        updated: Some(now),
+                    };
+                    self.publish_event(BaseNodeEvent::BaseNodeState(state.clone()));
+                    self.set_state(state);
+                    self.requests = remaining;
+                },
+                _ => {
+                    trace!(
+                        target: LOG_TARGET,
+                        "Received a base node response currently unaccounted for: {:?}",
+                        message
+                    );
+                },
+            }
+        }
+
+        Ok(())
+    }
+
+    fn set_base_node_public_key(&mut self, base_node_public_key: CommsPublicKey) {
+        self.base_node_public_key = Some(base_node_public_key);
+    }
+
+    fn publish_event(&mut self, event: BaseNodeEvent) {
+        debug!(target: LOG_TARGET, "Publishing event: {:?}", event);
+        let _ = self.event_publisher.send(Arc::new(event)).map_err(|_| {
+            trace!(
+                target: LOG_TARGET,
+                "Could not publish BaseNodeEvent as there are no subscribers"
+            )
+        });
+    }
+
+    /// This handler is called when requests arrive from the various streams
+    async fn handle_request(
+        &mut self,
+        request: BaseNodeServiceRequest,
+    ) -> Result<BaseNodeServiceResponse, BaseNodeServiceError>
+    {
+        debug!(
+            target: LOG_TARGET,
+            "Handling Wallet Base Node Service Request: {:?}", request
+        );
+        match request {
+            BaseNodeServiceRequest::SetBaseNodePublicKey(public_key) => {
+                self.set_base_node_public_key(public_key);
+                Ok(BaseNodeServiceResponse::BaseNodePublicKeySet)
+            },
+            BaseNodeServiceRequest::GetChainMetadata => Ok(BaseNodeServiceResponse::ChainMetadata(
+                self.state.chain_metadata.clone(),
+            )),
+        }
+    }
+}

--- a/base_layer/wallet/src/error.rs
+++ b/base_layer/wallet/src/error.rs
@@ -21,6 +21,7 @@
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 use crate::{
+    base_node_service::error::BaseNodeServiceError,
     contacts_service::error::ContactsServiceError,
     output_manager_service::error::OutputManagerError,
     storage::database::DbKey,
@@ -62,6 +63,8 @@ pub enum WalletError {
     ConnectivityError(#[from] ConnectivityError),
     #[error("Failed to initialize services: {0}")]
     ServiceInitializationError(#[from] ServiceInitializationError),
+    #[error("Base Node Service error: {0}")]
+    BaseNodeServiceError(#[from] BaseNodeServiceError),
 }
 
 #[derive(Debug, Error)]

--- a/base_layer/wallet/src/lib.rs
+++ b/base_layer/wallet/src/lib.rs
@@ -11,6 +11,7 @@
 
 #[macro_use]
 mod macros;
+pub mod base_node_service;
 pub mod contacts_service;
 pub mod error;
 pub mod output_manager_service;


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Adds a base node service to the wallet, to start tracking a connected base node's state. This will be required for the wallet to know the base node sync status, chain height, and when last the information was updated.

The service has a configurable refresh interval to call `GetChainMetadata` on the base node, as well as a "maximum age" config for requests that remain unanswered. Future improvements could add latency and other metrics. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The console wallet needs a way to track a connected base node's state in order to display balance, time locked utxos, and chain metadata. Future work will use this to show pertinent information in the console wallet TUI. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
`cargo test` and manually 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch.
* [x] I ran `cargo-fmt --all` before pushing.
* [x] I ran `cargo test` successfully before submitting my PR.
* [x] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
