### PR TITLE
Fix wallet conversion error for a valid tx status

### DIFF
--- a/base_layer/wallet/src/transaction_service/error.rs
+++ b/base_layer/wallet/src/transaction_service/error.rs
@@ -143,8 +143,8 @@ pub enum TransactionStorageError {
     TransactionAlreadyExists,
     #[error("Out of range error: `{0}`")]
     OutOfRangeError(#[from] OutOfRangeError),
-    #[error("Error converting a type")]
-    ConversionError,
+    #[error("Error converting a type: `{0}`")]
+    ConversionError(String),
     #[error("Serde json error: `{0}`")]
     SerdeJsonError(#[from] SerdeJsonError),
     #[error("R2d2 error")]

--- a/base_layer/wallet/src/transaction_service/storage/models.rs
+++ b/base_layer/wallet/src/transaction_service/storage/models.rs
@@ -62,7 +62,10 @@ impl TryFrom<i32> for TransactionStatus {
             2 => Ok(TransactionStatus::Mined),
             3 => Ok(TransactionStatus::Imported),
             4 => Ok(TransactionStatus::Pending),
-            _ => Err(TransactionStorageError::ConversionError),
+            5 => Ok(TransactionStatus::Coinbase),
+            _ => Err(TransactionStorageError::ConversionError(
+                "Invalid TransactionStatus".to_string(),
+            )),
         }
     }
 }
@@ -243,7 +246,9 @@ impl TryFrom<i32> for TransactionDirection {
             0 => Ok(TransactionDirection::Inbound),
             1 => Ok(TransactionDirection::Outbound),
             2 => Ok(TransactionDirection::Unknown),
-            _ => Err(TransactionStorageError::ConversionError),
+            _ => Err(TransactionStorageError::ConversionError(
+                "Invalid TransactionDirection".to_string(),
+            )),
         }
     }
 }

--- a/base_layer/wallet/src/transaction_service/storage/sqlite_db.rs
+++ b/base_layer/wallet/src/transaction_service/storage/sqlite_db.rs
@@ -976,7 +976,7 @@ impl TryFrom<InboundTransactionSql> for InboundTransaction {
         Ok(Self {
             tx_id: i.tx_id as u64,
             source_public_key: PublicKey::from_vec(&i.source_public_key)
-                .map_err(|_| TransactionStorageError::ConversionError)?,
+                .map_err(|_| TransactionStorageError::ConversionError("Invalid Source Publickey".to_string()))?,
             amount: MicroTari::from(i.amount as u64),
             receiver_protocol: serde_json::from_str(&i.receiver_protocol)?,
             status: TransactionStatus::Pending,
@@ -1163,7 +1163,7 @@ impl TryFrom<OutboundTransactionSql> for OutboundTransaction {
         Ok(Self {
             tx_id: o.tx_id as u64,
             destination_public_key: PublicKey::from_vec(&o.destination_public_key)
-                .map_err(|_| TransactionStorageError::ConversionError)?,
+                .map_err(|_| TransactionStorageError::ConversionError("Invalid destination PublicKey".to_string()))?,
             amount: MicroTari::from(o.amount as u64),
             fee: MicroTari::from(o.fee as u64),
             sender_protocol: serde_json::from_str(&o.sender_protocol)?,
@@ -1412,9 +1412,9 @@ impl TryFrom<CompletedTransactionSql> for CompletedTransaction {
         Ok(Self {
             tx_id: c.tx_id as u64,
             source_public_key: PublicKey::from_vec(&c.source_public_key)
-                .map_err(|_| TransactionStorageError::ConversionError)?,
+                .map_err(|_| TransactionStorageError::ConversionError("Invalid source Publickey".to_string()))?,
             destination_public_key: PublicKey::from_vec(&c.destination_public_key)
-                .map_err(|_| TransactionStorageError::ConversionError)?,
+                .map_err(|_| TransactionStorageError::ConversionError("Invalid destination PublicKey".to_string()))?,
             amount: MicroTari::from(c.amount as u64),
             fee: MicroTari::from(c.fee as u64),
             transaction: serde_json::from_str(&c.transaction_protocol)?,


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Fixes a subtle error where a valid `TransactionStatus` of 5 was
mistakenly reported as a conversion error. This caused the wallet to
fail on startup and when fetching coinbase transactions from the database.

The `TransactionStatus::try_from` method was missing the value.

Also added some additional info to conversion error, in case it appears
again it will be easier to narrow down.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Errors cropping up during merge mining 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
cargo test
manually

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch.
* [x] I ran `cargo-fmt --all` before pushing.
* [x] I ran `cargo test` successfully before submitting my PR.
* [x] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
