### PR TITLE
Update stagenet URL for merged mining

### DIFF
--- a/common/config/presets/tari-sample.toml
+++ b/common/config/presets/tari-sample.toml
@@ -22,7 +22,7 @@ grpc_wallet_address = "127.0.0.1:18143"
 transport = "tor"
 
 [merge_mining_proxy.ridcully]
-monerod_url = "http://192.110.160.146:38081"
+monerod_url = "http://18.133.55.120:38081"
 proxy_host_address = "127.0.0.1:7878"
 monerod_use_auth=false
 monerod_username=""

--- a/common/config/presets/windows.toml
+++ b/common/config/presets/windows.toml
@@ -190,13 +190,13 @@ peer_seeds = [
 #public_address = "/ip4/172.2.3.4/tcp/18189"
 
 # Enable the gRPC server for the base node. Set this to true if you want to enable third-party wallet software
-#grpc_enabled = false
+grpc_enabled = true
 # The socket to expose for the gRPC base node server. This value is ignored if grpc_enabled is false.
 # Valid values here are IPv4 and IPv6 TCP sockets, local unix sockets (e.g. "ipc://base-node-gprc.sock.100")
-#grpc_address = "127.0.0.1:18142"
+grpc_address = "127.0.0.1:18142"
 # The socket to expose for the gRPC wallet server. This value is ignored if grpc_enabled is false.
 # Valid values here are IPv4 and IPv6 TCP sockets, local unix sockets (e.g. "ipc://base-node-gprc.sock.100")
-#grpc_wallet_address = "127.0.0.1:18143"
+grpc_wallet_address = "127.0.0.1:18143"
 
 # A path to the file that stores your node identity and secret key
 identity_file = ".\\config\\node_id.json"
@@ -325,7 +325,7 @@ wallet_tor_identity_file = ".\\config\\wallet-tor.json"
 [merge_mining_proxy.ridcully]
 
 # URL to monerod, currently set to a seed node
-monerod_url = "http://192.110.160.146:38081"
+monerod_url = "http://18.133.55.120:38081"
 
 # Address of the tari_merge_mining_proxy application
 proxy_host_address = "127.0.0.1:7878"

--- a/common/config/tari_config_example.toml
+++ b/common/config/tari_config_example.toml
@@ -190,13 +190,13 @@ peer_seeds = [
 #public_address = "/ip4/172.2.3.4/tcp/18189"
 
 # Enable the gRPC server for the base node. Set this to true if you want to enable third-party wallet software
-#grpc_enabled = false
+grpc_enabled = true
 # The socket to expose for the gRPC base node server. This value is ignored if grpc_enabled is false.
 # Valid values here are IPv4 and IPv6 TCP sockets, local unix sockets (e.g. "ipc://base-node-gprc.sock.100")
-#grpc_address = "127.0.0.1:18142"
+grpc_address = "127.0.0.1:18142"
 # The socket to expose for the gRPC wallet server. This value is ignored if grpc_enabled is false.
 # Valid values here are IPv4 and IPv6 TCP sockets, local unix sockets (e.g. "ipc://base-node-gprc.sock.100")
-#grpc_wallet_address = "127.0.0.1:18143"
+grpc_wallet_address = "127.0.0.1:18143"
 
 # A path to the file that stores your node identity and secret key
 identity_file = "./node_id.json" # or ".\\node_id.json"
@@ -325,7 +325,7 @@ wallet_tor_identity_file = "./wallet-tor.json" # or ".\\wallet-tor.json"
 [merge_mining_proxy.ridcully]
 
 # URL to monerod, currently set to a seed node
-monerod_url = "http://192.110.160.146:38081"
+monerod_url = "http://18.133.55.120:38081"
 
 # Address of the tari_merge_mining_proxy application
 proxy_host_address = "127.0.0.1:7878"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- Updated the monerod_url to one that sees active mining. The previous URI did not reflect the active stagenet block
explorer; it is stationary and only basically advances when someone starts an xmrig miner pointing to it.
- Updated default grpc settings - disabled to enabled - in the config files.

This block has evidence of a Tari merge mined block being submitted to stagenet when using the updated monerod_url (compare `Tx public Key`):
https://community.xmr.to/explorer/stagenet/tx/b1a71f841857fdffb8d23465d56ec80ee7332559980213cdda4c1f6a3c5f200d
```
2020-11-03 11:18:31.546754400 [tari_mm_proxy::xmrig] TRACE Monero block: Block header: Major version: 14
Minor version: 14
Timestamp: 1604395082
Previous id: 0xcba3…649f
Nonce: 36616
Miner tx: Prefix: Version: 2
Unlock time: 700714
Extra field: Subfield: Tx public Key: 4ae7a1feea999e61645e6febf8df89c737f283d18c46f6e163aabd98c931899a
Subfield: Nonce: 0898c2cbd78dc6f544
Subfield: Merge mining: 0, 0x55d3…4f96
RCT signature: Signature: RCT type: Null
Tx fee: 0
```

## Motivation and Context
Monero merged mining could not be demonstrated properly with the old monerod_url  that was used.

## How Has This Been Tested?
Tested with all required components for Tari merge mining with Monero stagenet, using the new URL. Used code changes in #2339 to test the URL.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [X] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [X] I'm merging against the `development` branch.
* [X] I ran `cargo-fmt --all` before pushing.
* [X] I ran `cargo test` successfully before submitting my PR.
* [X] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
