### PR TITLE
Prevent loop in peer sync by storing all peers attempted

### DIFF
--- a/comms/dht/src/network_discovery/ready.rs
+++ b/comms/dht/src/network_discovery/ready.rs
@@ -27,7 +27,7 @@ use super::{
 use crate::{network_discovery::DhtNetworkDiscoveryRoundInfo, DhtConfig};
 use log::*;
 use std::cmp;
-use tari_comms::peer_manager::{NodeId, PeerFeatures};
+use tari_comms::peer_manager::PeerFeatures;
 
 const LOG_TARGET: &str = "comms::dht::network_discovery::ready";
 
@@ -76,7 +76,7 @@ impl DiscoveryReady {
                 .peer_manager
                 .random_peers(
                     self.config().network_discovery.max_sync_peers,
-                    self.previous_sync_peers(),
+                    self.context.all_attempted_peers.read().await.as_slice(),
                 )
                 .await?;
             let peers = peers.into_iter().map(|p| p.node_id).collect::<Vec<_>>();
@@ -140,7 +140,7 @@ impl DiscoveryReady {
                         .closest_peers(
                             self.context.node_identity.node_id(),
                             num_peers_to_select,
-                            self.previous_sync_peers(),
+                            self.context.all_attempted_peers.read().await.as_slice(),
                             Some(PeerFeatures::COMMUNICATION_NODE),
                         )
                         .await?
@@ -165,7 +165,7 @@ impl DiscoveryReady {
                     .peer_manager
                     .random_peers(
                         self.config().network_discovery.max_sync_peers,
-                        self.previous_sync_peers(),
+                        self.context.all_attempted_peers.read().await.as_slice(),
                     )
                     .await?
                     .into_iter()
@@ -188,13 +188,6 @@ impl DiscoveryReady {
             num_peers_to_request: None,
             peers,
         }))
-    }
-
-    fn previous_sync_peers(&self) -> &[NodeId] {
-        self.last_discovery
-            .as_ref()
-            .map(|info| info.sync_peers.as_slice())
-            .unwrap_or(&[])
     }
 
     #[inline]

--- a/comms/dht/src/network_discovery/state_machine.rs
+++ b/comms/dht/src/network_discovery/state_machine.rs
@@ -126,6 +126,7 @@ pub(super) struct NetworkDiscoveryContext {
     pub connectivity: ConnectivityRequester,
     pub node_identity: Arc<NodeIdentity>,
     pub num_rounds: Arc<AtomicUsize>,
+    pub all_attempted_peers: Arc<RwLock<Vec<NodeId>>>,
     pub event_tx: broadcast::Sender<Arc<DhtEvent>>,
     pub last_round: Arc<RwLock<Option<DhtNetworkDiscoveryRoundInfo>>>,
 }
@@ -151,6 +152,10 @@ impl NetworkDiscoveryContext {
     }
 
     pub(super) async fn set_last_round(&self, last_round: DhtNetworkDiscoveryRoundInfo) {
+        self.all_attempted_peers
+            .write()
+            .await
+            .append(&mut last_round.sync_peers.clone());
         *self.last_round.write().await = Some(last_round);
     }
 
@@ -180,6 +185,7 @@ impl DhtNetworkDiscovery {
                 peer_manager,
                 connectivity,
                 node_identity,
+                all_attempted_peers: Default::default(),
                 num_rounds: Default::default(),
                 last_round: Default::default(),
                 event_tx,

--- a/comms/dht/src/network_discovery/test.rs
+++ b/comms/dht/src/network_discovery/test.rs
@@ -191,6 +191,7 @@ mod discovery_ready {
             connectivity,
             node_identity: node_identity.clone(),
             num_rounds: Default::default(),
+            all_attempted_peers: Default::default(),
             event_tx,
             last_round: Default::default(),
         };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Using 3 base nodes, I found that the one node would hit 100% cpu. This was caused by it trying to sync peers with one peer and then the other peer in an infinite loop. The attempt here is to store all peers attempted in a single place. 

I think a better solution in future would be to store the last_peer_sync_succeeded time in the peer database so that it isn't retried again.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [ ] I'm merging against the `development` branch.
* [ ] I ran `cargo-fmt --all` before pushing.
* [ ] I ran `cargo test` successfully before submitting my PR.
* [ ] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
