### PR TITLE
Revert time stamp in genesis block

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -756,11 +756,20 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-channel"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8ec7fcd21571dc78f96cc96243cab8d8f035247c3efd16c687be154c3fa9efa"
+dependencies = [
+ "crossbeam-utils 0.6.6",
+]
+
+[[package]]
+name = "crossbeam-channel"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b153fe7cbef478c567df0f972e02e6d736db11affe43dfc9c56a9374d1adfb87"
 dependencies = [
- "crossbeam-utils",
+ "crossbeam-utils 0.7.2",
  "maybe-uninit",
 ]
 
@@ -771,7 +780,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f02af974daeee82218205558e51ec8768b48cf524bd01d550abe5573a608285"
 dependencies = [
  "crossbeam-epoch",
- "crossbeam-utils",
+ "crossbeam-utils 0.7.2",
  "maybe-uninit",
 ]
 
@@ -783,11 +792,21 @@ checksum = "058ed274caafc1f60c4997b5fc07bf7dc7cca454af7c6e81edffe5f33f70dace"
 dependencies = [
  "autocfg",
  "cfg-if 0.1.10",
- "crossbeam-utils",
+ "crossbeam-utils 0.7.2",
  "lazy_static 1.4.0",
  "maybe-uninit",
  "memoffset",
  "scopeguard",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04973fa96e96579258a5091af6003abde64af786b860f18622b82e026cca60e6"
+dependencies = [
+ "cfg-if 0.1.10",
+ "lazy_static 1.4.0",
 ]
 
 [[package]]
@@ -2979,9 +2998,9 @@ version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8c4fec834fb6e6d2dd5eece3c7b432a52f0ba887cf40e595190c4107edc08bf"
 dependencies = [
- "crossbeam-channel",
+ "crossbeam-channel 0.4.4",
  "crossbeam-deque",
- "crossbeam-utils",
+ "crossbeam-utils 0.7.2",
  "lazy_static 1.4.0",
  "num_cpus",
 ]
@@ -3115,7 +3134,7 @@ dependencies = [
  "base64 0.12.3",
  "blake2b_simd",
  "constant_time_eq",
- "crossbeam-utils",
+ "crossbeam-utils 0.7.2",
 ]
 
 [[package]]
@@ -4197,6 +4216,7 @@ dependencies = [
  "aes-gcm",
  "blake2",
  "chrono",
+ "crossbeam-channel 0.3.9",
  "diesel",
  "diesel_migrations",
  "digest 0.8.1",

--- a/base_layer/core/src/blocks/genesis_block.rs
+++ b/base_layer/core/src/blocks/genesis_block.rs
@@ -197,8 +197,7 @@ pub fn get_ridcully_genesis_block_raw() -> Block {
             prev_hash: vec![
                 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
             ],
-            // timestamp: 1_603_843_200.into(), // 10/28/2020 @ 12:00am (UTC)
-            timestamp: 1_603_782_277.into(), // todo remove and swop to top.
+            timestamp: 1_603_843_200.into(), // 10/28/2020 @ 12:00am (UTC)
             output_mr: from_hex("dcc44f39b65e5e1e526887e7d56f7b85e2ea44bd29bc5bc195e6e015d19e1c06").unwrap(),
             range_proof_mr: from_hex("e4d7dab49a66358379a901b9a36c10f070aa9d7bdc8ae752947b6fc4e55d255f").unwrap(),
             kernel_mr: from_hex("589bc62ac5d9139f921c68b8075c32d8d130024acaf3196d1d6a89df601e2bcf").unwrap(),


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR reverts an accidental change to the time stamp in the genesis block. New nodes could not sync to the existing network.

## Motivation and Context
The change in the genesis block resulted in a hard fork in the network, which was unintended.

Previous behaviour, unsuccessful start of sync:
```
2020-11-03 15:35:14.408333700 [c::bn::base_node_service::service] TRACE Response for BlockHeaders (request key: 17395099602236773273) received after 2499ms and is_synced: true
2020-11-03 15:35:14.408381300 [c::bn::state_machine_service::states::block_sync] DEBUG Received 1 headers from peer
2020-11-03 15:35:14.408419900 [c::bn::state_machine_service::states::block_sync] DEBUG Chain split detected, finding chain split height.
``` 

This PR, successful start of sync:
```
2020-11-04 09:45:02.308558200 [c::bn::base_node_service::service] TRACE Response for BlockHeaders (request key: 5383178967293083719) received after 781ms and is_synced: true
2020-11-04 09:45:02.308614700 [c::bn::state_machine_service::states::block_sync] DEBUG Received 1 headers from peer
2020-11-04 09:45:02.308641500 [c::bn::state_machine_service::states::block_sync] DEBUG Block hash c37a74827ebdead7f417bb0ec4e37fe262b3daa359299e60b00cac059c904c4b is common between our chain and the network.
```

## How Has This Been Tested?
Tested in a base node that started syncing from scratch successfully.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [X] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [X] I'm merging against the `development` branch.
* [X] I ran `cargo-fmt --all` before pushing.
* [X] I ran `cargo test` successfully before submitting my PR.
* [X] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
