### PR TITLE
Add optional fee_per_gram field to console wallet Send Tx form

### DIFF
--- a/applications/tari_console_wallet/src/ui/app.rs
+++ b/applications/tari_console_wallet/src/ui/app.rs
@@ -80,16 +80,16 @@ impl<B: Backend> App<B> {
     }
 
     pub fn on_control_key(&mut self, c: char) {
-        if let 'c' = c {
-            self.should_quit = true;
+        match c {
+            'q' | 'c' => {
+                self.should_quit = true;
+            },
+            _ => (),
         }
     }
 
     pub fn on_key(&mut self, c: char) {
         match c {
-            'q' => {
-                self.should_quit = true;
-            },
             '\t' => {
                 self.tabs.next();
             },

--- a/applications/tari_console_wallet/src/ui/components/send_receive_tab.rs
+++ b/applications/tari_console_wallet/src/ui/components/send_receive_tab.rs
@@ -7,6 +7,7 @@ use crate::{
     },
     utils::formatting::display_compressed_string,
 };
+use tari_wallet::types::DEFAULT_FEE_PER_GRAM;
 use tokio::{runtime::Handle, sync::watch};
 use tui::{
     backend::Backend,
@@ -26,6 +27,7 @@ pub struct SendReceiveTab {
     show_edit_contact: bool,
     to_field: String,
     amount_field: String,
+    fee_field: String,
     message_field: String,
     alias_field: String,
     public_key_field: String,
@@ -46,6 +48,7 @@ impl SendReceiveTab {
             show_edit_contact: false,
             to_field: "".to_string(),
             amount_field: "".to_string(),
+            fee_field: u64::from(DEFAULT_FEE_PER_GRAM).to_string(),
             message_field: "".to_string(),
             alias_field: "".to_string(),
             public_key_field: "".to_string(),
@@ -85,6 +88,9 @@ impl SendReceiveTab {
             Span::styled("A", Style::default().add_modifier(Modifier::BOLD)),
             Span::raw(" to edit "),
             Span::styled("Amount", Style::default().add_modifier(Modifier::BOLD)),
+            Span::styled("F", Style::default().add_modifier(Modifier::BOLD)),
+            Span::raw(" to edit "),
+            Span::styled("Fee-Per-Gram", Style::default().add_modifier(Modifier::BOLD)),
             Span::raw(" field, "),
             Span::styled("C", Style::default().add_modifier(Modifier::BOLD)),
             Span::raw(" to select a contact, "),
@@ -106,13 +112,26 @@ impl SendReceiveTab {
             );
         f.render_widget(to_input, vert_chunks[1]);
 
+        let amount_fee_layout = Layout::default()
+            .direction(Direction::Horizontal)
+            .constraints([Constraint::Percentage(50), Constraint::Percentage(50)].as_ref())
+            .split(vert_chunks[2]);
+
         let amount_input = Paragraph::new(self.amount_field.as_ref())
             .style(match self.send_input_mode {
                 SendInputMode::Amount => Style::default().fg(Color::Magenta),
                 _ => Style::default(),
             })
             .block(Block::default().borders(Borders::ALL).title("(A)mount (uT):"));
-        f.render_widget(amount_input, vert_chunks[2]);
+        f.render_widget(amount_input, amount_fee_layout[0]);
+
+        let fee_input = Paragraph::new(self.fee_field.as_ref())
+            .style(match self.send_input_mode {
+                SendInputMode::Fee => Style::default().fg(Color::Magenta),
+                _ => Style::default(),
+            })
+            .block(Block::default().borders(Borders::ALL).title("(F)ee-per-gram (uT):"));
+        f.render_widget(fee_input, amount_fee_layout[1]);
 
         let message_input = Paragraph::new(self.message_field.as_ref())
             .style(match self.send_input_mode {
@@ -132,9 +151,15 @@ impl SendReceiveTab {
             ),
             SendInputMode::Amount => f.set_cursor(
                 // Put cursor past the end of the input text
-                vert_chunks[2].x + self.amount_field.width() as u16 + 1,
+                amount_fee_layout[0].x + self.amount_field.width() as u16 + 1,
                 // Move one line down, from the border to the input line
-                vert_chunks[2].y + 1,
+                amount_fee_layout[0].y + 1,
+            ),
+            SendInputMode::Fee => f.set_cursor(
+                // Put cursor past the end of the input text
+                amount_fee_layout[1].x + self.fee_field.width() as u16 + 1,
+                // Move one line down, from the border to the input line
+                amount_fee_layout[1].y + 1,
             ),
             SendInputMode::Message => f.set_cursor(
                 // Put cursor past the end of the input text
@@ -461,11 +486,20 @@ impl<B: Backend> Component<B> for SendReceiveTab {
                             return;
                         };
 
+                        let fee_per_gram = if let Ok(v) = self.fee_field.parse::<u64>() {
+                            v
+                        } else {
+                            self.error_message =
+                                Some("Fee-per-gram should be an integer\nPress Enter to continue.".to_string());
+                            return;
+                        };
+
                         let (tx, rx) = watch::channel(UiTransactionSendStatus::Initiated);
 
                         match Handle::current().block_on(app_state.send_transaction(
                             self.to_field.clone(),
                             amount,
+                            fee_per_gram,
                             self.message_field.clone(),
                             tx,
                         )) {
@@ -476,6 +510,7 @@ impl<B: Backend> Component<B> for SendReceiveTab {
                             Ok(_) => {
                                 self.to_field = "".to_string();
                                 self.amount_field = "".to_string();
+                                self.fee_field = u64::from(DEFAULT_FEE_PER_GRAM).to_string();
                                 self.message_field = "".to_string();
                                 self.send_input_mode = SendInputMode::None;
                                 self.send_result_watch = Some(rx);
@@ -522,6 +557,15 @@ impl<B: Backend> Component<B> for SendReceiveTab {
                     c => {
                         if c.is_numeric() {
                             self.amount_field.push(c);
+                        }
+                        return;
+                    },
+                },
+                SendInputMode::Fee => match c {
+                    '\n' => self.send_input_mode = SendInputMode::None,
+                    c => {
+                        if c.is_numeric() {
+                            self.fee_field.push(c);
                         }
                         return;
                     },
@@ -630,6 +674,7 @@ impl<B: Backend> Component<B> for SendReceiveTab {
             },
             't' => self.send_input_mode = SendInputMode::To,
             'a' => self.send_input_mode = SendInputMode::Amount,
+            'f' => self.send_input_mode = SendInputMode::Fee,
             'm' => self.send_input_mode = SendInputMode::Message,
             's' => {
                 if self.amount_field.is_empty() || self.to_field.is_empty() {
@@ -672,6 +717,9 @@ impl<B: Backend> Component<B> for SendReceiveTab {
             SendInputMode::Amount => {
                 let _ = self.amount_field.pop();
             },
+            SendInputMode::Fee => {
+                let _ = self.fee_field.pop();
+            },
             SendInputMode::Message => {
                 let _ = self.message_field.pop();
             },
@@ -696,6 +744,7 @@ pub enum SendInputMode {
     To,
     Amount,
     Message,
+    Fee,
 }
 
 #[derive(PartialEq, Debug)]

--- a/applications/tari_console_wallet/src/ui/state/app_state.rs
+++ b/applications/tari_console_wallet/src/ui/state/app_state.rs
@@ -116,6 +116,7 @@ impl AppState {
         &mut self,
         public_key: String,
         amount: u64,
+        fee_per_gram: u64,
         message: String,
         result_tx: watch::Sender<UiTransactionSendStatus>,
     ) -> Result<(), UiError>
@@ -126,8 +127,7 @@ impl AppState {
             Err(_) => EmojiId::str_to_pubkey(public_key.as_str()).map_err(|_| UiError::PublicKeyParseError)?,
         };
 
-        // TODO: use configured fee per gram
-        let fee_per_gram = 25 * uT;
+        let fee_per_gram = fee_per_gram * uT;
         let tx_service_handle = inner.wallet.transaction_service.clone();
         tokio::spawn(send_transaction_task(
             public_key,

--- a/base_layer/core/src/base_node/comms_interface/local_interface.rs
+++ b/base_layer/core/src/base_node/comms_interface/local_interface.rs
@@ -132,7 +132,7 @@ impl LocalNodeCommsInterface {
                     }
                 } else {
                     Err(CommsInterfaceError::ApiError(
-                        error.unwrap_or("Unspecified error".to_string()),
+                        error.unwrap_or_else(|| "Unspecified error".to_string()),
                     ))
                 }
             },

--- a/base_layer/core/src/base_node/proto/response.rs
+++ b/base_layer/core/src/base_node/proto/response.rs
@@ -113,7 +113,7 @@ impl From<ci::NodeCommsResponse> for ProtoNodeCommsResponse {
             NewBlockTemplate(block_template) => ProtoNodeCommsResponse::NewBlockTemplate(block_template.into()),
             NewBlock { success, error, block } => ProtoNodeCommsResponse::NewBlock(ProtoNewBlockResponse {
                 success,
-                error: error.unwrap_or("".to_string()),
+                error: error.unwrap_or_else(|| "".to_string()),
                 block: block.map(|b| b.into()),
             }),
             TargetDifficulty(difficulty) => ProtoNodeCommsResponse::TargetDifficulty(difficulty.as_u64()),

--- a/base_layer/wallet/src/types.rs
+++ b/base_layer/wallet/src/types.rs
@@ -20,7 +20,12 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+use tari_core::transactions::tari_amount::MicroTari;
 use tari_crypto::common::Blake256;
+
+/// The default fee per gram that the wallet will use to build transactions.
+/// TODO discuss what the default fee value should actually be
+pub const DEFAULT_FEE_PER_GRAM: MicroTari = MicroTari(25);
 
 /// Specify the Hash function used by the key manager
 pub type KeyDigest = Blake256;


### PR DESCRIPTION
## Description
This PR adds an optional editable fee_per_gram field to the send transaction form in the console wallet.

This field is populated by the default value specified by a constant in LibWallet and is not included in the flow of fields edited while sending a transaction as editing this field should be very rare. If the user wants to edit the field they can use the hotkey and after this transaction is sent the field will be repopulated with the default value again.

## How Has This Been Tested?

This functionality was not able to be tested as the network is currently experiencing some issues that make sending transactions difficult.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch.
* [x] I ran `cargo-fmt --all` before pushing.
* [x] I ran `cargo test` successfully before submitting my PR.
* [x] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
