### PR TITLE
[console wallet] show base node chain tip and sync status

### DIFF
--- a/applications/tari_app_utilities/src/utilities.rs
+++ b/applications/tari_app_utilities/src/utilities.rs
@@ -232,7 +232,7 @@ pub fn setup_runtime(config: &GlobalConfig) -> Result<Runtime, String> {
 /// ## Returns
 /// A list of peers, peers which do not have a valid public key are excluded
 pub fn parse_peer_seeds(seeds: &[String]) -> Vec<Peer> {
-    info!("Adding {} peers to the peer database", seeds.len());
+    info!("Parsing {} peers", seeds.len());
     let mut result = Vec::with_capacity(seeds.len());
     for s in seeds {
         let parts: Vec<&str> = s.split("::").map(|s| s.trim()).collect();

--- a/applications/tari_console_wallet/src/dummy_data.rs
+++ b/applications/tari_console_wallet/src/dummy_data.rs
@@ -30,7 +30,7 @@ lazy_static! {
     static ref BN_SYNC_CALLS: AtomicU64 = AtomicU64::new(0);
 }
 
-pub fn get_dummy_base_node_status() -> Option<u64> {
+pub fn _get_dummy_base_node_status() -> Option<u64> {
     let seconds = BN_SYNC_CALLS.fetch_add(1, Ordering::SeqCst) / 4;
 
     if seconds / 6 % 2 == 0 {

--- a/applications/tari_console_wallet/src/main.rs
+++ b/applications/tari_console_wallet/src/main.rs
@@ -7,7 +7,7 @@
 #![deny(unknown_lints)]
 #![recursion_limit = "512"]
 use log::*;
-use rand::{rngs::OsRng, RngCore};
+use rand::{rngs::OsRng, seq::SliceRandom};
 use std::{fs, sync::Arc};
 use structopt::StructOpt;
 use tari_app_utilities::{
@@ -15,12 +15,16 @@ use tari_app_utilities::{
     utilities::{parse_peer_seeds, setup_wallet_transport_type, ExitCodes},
 };
 use tari_common::{configuration::bootstrap::ApplicationType, ConfigBootstrap, GlobalConfig, Network};
-use tari_comms::{peer_manager::PeerFeatures, NodeIdentity};
+use tari_comms::{
+    peer_manager::{Peer, PeerFeatures},
+    NodeIdentity,
+};
 use tari_comms_dht::{DbConnectionUrl, DhtConfig};
 use tari_core::{consensus::Network as NetworkType, transactions::types::CryptoFactories};
 use tari_p2p::initialization::CommsConfig;
 use tari_shutdown::{Shutdown, ShutdownSignal};
 use tari_wallet::{
+    base_node_service::config::BaseNodeServiceConfig,
     error::WalletError,
     storage::sqlite_utilities::initialize_sqlite_database_backends,
     transaction_service::config::TransactionServiceConfig,
@@ -109,7 +113,14 @@ fn main_inner() -> Result<(), ExitCodes> {
         return Ok(());
     }
 
-    let wallet = runtime.block_on(setup_wallet(&config, node_identity, shutdown.to_signal()))?;
+    let base_node = get_base_node_peer(&config)?;
+
+    let wallet = runtime.block_on(setup_wallet(
+        &config,
+        node_identity,
+        base_node.clone(),
+        shutdown.to_signal(),
+    ))?;
 
     debug!(target: LOG_TARGET, "Starting app");
 
@@ -117,7 +128,7 @@ fn main_inner() -> Result<(), ExitCodes> {
 
     let handle = runtime.handle().clone();
     let result = match wallet_mode(bootstrap) {
-        WalletMode::Tui => tui_mode(handle, config, node_identity, wallet.clone()),
+        WalletMode::Tui => tui_mode(handle, config, node_identity, wallet.clone(), base_node),
         WalletMode::Grpc => grpc_mode(handle, wallet.clone(), config),
         WalletMode::Script(path) => script_mode(handle, path, wallet.clone(), config),
         WalletMode::Command(command) => command_mode(handle, command, wallet.clone(), config),
@@ -135,6 +146,32 @@ fn main_inner() -> Result<(), ExitCodes> {
     println!("Done.");
 
     result
+}
+
+fn get_base_node_peer(config: &GlobalConfig) -> Result<Peer, ExitCodes> {
+    // pick a random peer from peer seeds config
+    // todo: strategy for picking peer seed: random or lowest latency
+    let peer_seeds = parse_peer_seeds(&config.peer_seeds);
+    let peer_seed = peer_seeds.choose(&mut OsRng);
+
+    // get the configured base node service peer
+    let base_node_peers = parse_peer_seeds(&[config.wallet_base_node_service_peer.clone()]);
+    let base_node = base_node_peers.first();
+
+    let peer = match (peer_seed, base_node) {
+        // base node service peer is defined, so use that
+        (_, Some(node)) => node.clone(),
+        // only peer seeds were provided in config
+        (Some(seed), None) => seed.clone(),
+        // invalid configuration
+        _ => {
+            return Err(ExitCodes::ConfigError(
+                "No peer seeds or base node peer defined in config!".to_string(),
+            ))
+        },
+    };
+
+    Ok(peer)
 }
 
 fn wallet_mode(bootstrap: ConfigBootstrap) -> WalletMode {
@@ -156,6 +193,7 @@ fn wallet_mode(bootstrap: ConfigBootstrap) -> WalletMode {
 async fn setup_wallet(
     config: &GlobalConfig,
     node_identity: Arc<NodeIdentity>,
+    base_node: Peer,
     shutdown_signal: ShutdownSignal,
 ) -> Result<WalletSqlite, ExitCodes>
 {
@@ -205,6 +243,11 @@ async fn setup_wallet(
         Network::LocalNet => NetworkType::LocalNet,
     };
 
+    let base_node_service_config = BaseNodeServiceConfig::new(
+        config.wallet_base_node_service_refresh_interval,
+        config.wallet_base_node_service_request_max_age,
+    );
+
     let factories = CryptoFactories::default();
     let mut wallet_config = WalletConfig::new(
         comms_config.clone(),
@@ -214,6 +257,7 @@ async fn setup_wallet(
             ..Default::default()
         }),
         network,
+        Some(base_node_service_config),
     );
     wallet_config.buffer_size = std::cmp::max(BASE_NODE_BUFFER_MIN_SIZE, config.buffer_size_base_node);
 
@@ -234,24 +278,19 @@ async fn setup_wallet(
         }
     })?;
 
-    debug!(target: LOG_TARGET, "Setting peer seeds");
-
-    // TODO update this to come from an explicit config field. This will be replaced by gRPC interface.
-    if !config.peer_seeds.is_empty() {
-        let seed_peers = parse_peer_seeds(&config.peer_seeds);
-        let random_seed_peer = OsRng.next_u32() as usize % seed_peers.len();
-        wallet
-            .set_base_node_peer(
-                seed_peers[random_seed_peer].public_key.clone(),
-                seed_peers[random_seed_peer]
-                    .addresses
-                    .first()
-                    .expect("The seed peers should have an address")
-                    .to_string(),
-            )
-            .await
-            .map_err(|e| ExitCodes::WalletError(format!("Error setting wallet base node peer. {}", e)))?;
-    }
+    // TODO gRPC interfaces for setting base node
+    debug!(target: LOG_TARGET, "Setting base node peer");
+    wallet
+        .set_base_node_peer(
+            base_node.public_key.clone(),
+            base_node
+                .addresses
+                .first()
+                .expect("The base node peer should have an address!")
+                .to_string(),
+        )
+        .await
+        .map_err(|e| ExitCodes::WalletError(format!("Error setting wallet base node peer. {}", e)))?;
 
     // Restart transaction protocols
     if let Err(e) = wallet.transaction_service.restart_transaction_protocols().await {

--- a/applications/tari_console_wallet/src/ui/components/base_node.rs
+++ b/applications/tari_console_wallet/src/ui/components/base_node.rs
@@ -1,0 +1,81 @@
+// Copyright 2020. The Tari Project
+//
+// Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+// following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+// disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+// following disclaimer in the documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+// products derived from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+// INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+// WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+// USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+use crate::ui::{components::Component, state::AppState};
+use tui::{
+    backend::Backend,
+    layout::Rect,
+    style::{Color, Modifier, Style},
+    text::{Span, Spans},
+    widgets::{Block, Borders, Paragraph},
+    Frame,
+};
+
+pub struct BaseNode {}
+
+impl BaseNode {
+    pub fn new() -> Self {
+        Self {}
+    }
+}
+
+impl<B: Backend> Component<B> for BaseNode {
+    fn draw(&mut self, f: &mut Frame<B>, area: Rect, app_state: &AppState)
+    where B: Backend {
+        let base_node_state = app_state.get_base_node_state();
+
+        let chain_info = match base_node_state.chain_metadata.clone() {
+            None => Spans::from(vec![
+                Span::styled("Chain Tip:", Style::default().fg(Color::Magenta)),
+                Span::raw(" "),
+                Span::styled("Connecting...", Style::default().fg(Color::Reset)),
+            ]),
+            Some(metadata) => {
+                let tip = metadata.height_of_longest_chain();
+
+                let synced = base_node_state.is_synced.unwrap_or_default();
+                let (tip_color, sync_text) = if synced {
+                    (Color::Green, "Synced ✅")
+                } else {
+                    (Color::Yellow, "Syncing ⏱")
+                };
+
+                let tip_info = vec![
+                    Span::styled("Chain Tip:", Style::default().fg(Color::Magenta)),
+                    Span::raw(" "),
+                    Span::styled(format!("#{}", tip), Style::default().fg(tip_color)),
+                    Span::raw(" "),
+                    Span::styled(sync_text.to_string(), Style::default().fg(Color::DarkGray)),
+                ];
+
+                Spans::from(tip_info)
+            },
+        };
+
+        let chain_metadata_paragraph =
+            Paragraph::new(chain_info).block(Block::default().borders(Borders::ALL).title(Span::styled(
+                "Base Node Status:",
+                Style::default().fg(Color::White).add_modifier(Modifier::BOLD),
+            )));
+        f.render_widget(chain_metadata_paragraph, area);
+    }
+}

--- a/applications/tari_console_wallet/src/ui/components/mod.rs
+++ b/applications/tari_console_wallet/src/ui/components/mod.rs
@@ -1,4 +1,27 @@
+// Copyright 2020. The Tari Project
+//
+// Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+// following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+// disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+// following disclaimer in the documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+// products derived from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+// INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+// WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+// USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
 pub mod balance;
+pub mod base_node;
 mod component;
 pub mod network_tab;
 pub mod send_receive_tab;

--- a/applications/tari_console_wallet/src/wallet_modes.rs
+++ b/applications/tari_console_wallet/src/wallet_modes.rs
@@ -29,7 +29,7 @@ use log::*;
 use std::{fs, io::Stdout, net::SocketAddr, path::PathBuf};
 use tari_app_utilities::utilities::ExitCodes;
 use tari_common::GlobalConfig;
-use tari_comms::NodeIdentity;
+use tari_comms::{peer_manager::Peer, NodeIdentity};
 
 use tari_wallet::WalletSqlite;
 use tokio::runtime::Handle;
@@ -95,6 +95,7 @@ pub fn tui_mode(
     node_config: GlobalConfig,
     node_identity: NodeIdentity,
     wallet: WalletSqlite,
+    base_node: Peer,
 ) -> Result<(), ExitCodes>
 {
     let grpc = WalletGrpcServer::new(wallet.clone());
@@ -105,6 +106,7 @@ pub fn tui_mode(
         &node_identity,
         wallet,
         node_config.network,
+        base_node,
     );
     handle.enter(|| run(app))?;
 

--- a/base_layer/core/tests/wallet.rs
+++ b/base_layer/core/tests/wallet.rs
@@ -169,6 +169,7 @@ fn wallet_base_node_integration_test() {
             ..Default::default()
         }),
         Network::Rincewind,
+        None,
     );
     let mut runtime = create_runtime();
     let mut alice_wallet = runtime
@@ -213,7 +214,7 @@ fn wallet_base_node_integration_test() {
         listener_liveness_max_sessions: 0,
         user_agent: "tari/test-wallet".to_string(),
     };
-    let bob_wallet_config = WalletConfig::new(bob_comms_config, factories.clone(), None, Network::Rincewind);
+    let bob_wallet_config = WalletConfig::new(bob_comms_config, factories.clone(), None, Network::Rincewind, None);
 
     let bob_wallet = runtime
         .block_on(Wallet::new(

--- a/base_layer/wallet/src/base_node_service/config.rs
+++ b/base_layer/wallet/src/base_node_service/config.rs
@@ -28,29 +28,29 @@ const LOG_TARGET: &str = "wallet::base_node_service::config";
 #[derive(Clone)]
 pub struct BaseNodeServiceConfig {
     pub refresh_interval: Duration,
-    pub request_keys_max_age: Duration,
+    pub request_max_age: Duration,
 }
 
 impl Default for BaseNodeServiceConfig {
     fn default() -> Self {
         Self {
-            refresh_interval: Duration::from_secs(30),
-            request_keys_max_age: Duration::from_secs(120),
+            refresh_interval: Duration::from_secs(10),
+            request_max_age: Duration::from_secs(60),
         }
     }
 }
 
 impl BaseNodeServiceConfig {
-    pub fn new(refresh_interval: Duration, request_keys_max_age: Duration) -> Self {
+    pub fn new(refresh_interval: u64, request_max_age: u64) -> Self {
         info!(
             target: LOG_TARGET,
-            "Setting new wallet base node service config, refresh_interval: {:?}, request_keys_max_age: {:?}",
+            "Setting new wallet base node service config, refresh interval: {}s, request max age: {}s",
             refresh_interval,
-            request_keys_max_age
+            request_max_age
         );
         Self {
-            refresh_interval,
-            request_keys_max_age,
+            refresh_interval: Duration::from_secs(refresh_interval),
+            request_max_age: Duration::from_secs(request_max_age),
         }
     }
 }

--- a/base_layer/wallet/src/base_node_service/error.rs
+++ b/base_layer/wallet/src/base_node_service/error.rs
@@ -26,8 +26,8 @@ use thiserror::Error;
 
 #[derive(Debug, Error)]
 pub enum BaseNodeServiceError {
-    #[error("No base node public key set")]
-    NoBaseNodePublicKey,
+    #[error("No base node peer set")]
+    NoBaseNodePeer,
     #[error("Unexpected API Response")]
     UnexpectedApiResponse,
     #[error("Transport channel error: `{0}`")]

--- a/base_layer/wallet/src/base_node_service/handle.rs
+++ b/base_layer/wallet/src/base_node_service/handle.rs
@@ -23,7 +23,7 @@
 use super::{error::BaseNodeServiceError, service::BaseNodeState};
 use futures::{stream::Fuse, StreamExt};
 use std::sync::Arc;
-use tari_comms::types::CommsPublicKey;
+use tari_comms::peer_manager::Peer;
 use tari_core::chain_storage::ChainMetadata;
 use tari_service_framework::reply_channel::SenderService;
 use tokio::sync::broadcast;
@@ -35,13 +35,13 @@ pub type BaseNodeEventReceiver = broadcast::Receiver<Arc<BaseNodeEvent>>;
 #[derive(Debug)]
 pub enum BaseNodeServiceRequest {
     GetChainMetadata,
-    SetBaseNodePublicKey(CommsPublicKey),
+    SetBaseNodePeer(Box<Peer>),
 }
 /// API Response enum
 #[derive(Debug)]
 pub enum BaseNodeServiceResponse {
     ChainMetadata(Option<ChainMetadata>),
-    BaseNodePublicKeySet,
+    BaseNodePeerSet,
 }
 #[derive(Clone, Debug, Hash, PartialEq, Eq)]
 pub enum BaseNodeEvent {
@@ -72,13 +72,13 @@ impl BaseNodeServiceHandle {
         self.event_stream_sender.subscribe().fuse()
     }
 
-    pub async fn set_base_node_public_key(&mut self, public_key: CommsPublicKey) -> Result<(), BaseNodeServiceError> {
+    pub async fn set_service_peer(&mut self, peer: Peer) -> Result<(), BaseNodeServiceError> {
         match self
             .handle
-            .call(BaseNodeServiceRequest::SetBaseNodePublicKey(public_key))
+            .call(BaseNodeServiceRequest::SetBaseNodePeer(Box::new(peer)))
             .await??
         {
-            BaseNodeServiceResponse::BaseNodePublicKeySet => Ok(()),
+            BaseNodeServiceResponse::BaseNodePeerSet => Ok(()),
             _ => Err(BaseNodeServiceError::UnexpectedApiResponse),
         }
     }

--- a/base_layer/wallet/src/testnet_utils.rs
+++ b/base_layer/wallet/src/testnet_utils.rs
@@ -147,7 +147,7 @@ pub async fn create_wallet(
         listener_liveness_max_sessions: 0,
     };
 
-    let config = WalletConfig::new(comms_config, factories, None, Network::Rincewind);
+    let config = WalletConfig::new(comms_config, factories, None, Network::Rincewind, None);
 
     Wallet::new(
         config,

--- a/base_layer/wallet/tests/wallet/mod.rs
+++ b/base_layer/wallet/tests/wallet/mod.rs
@@ -135,6 +135,7 @@ async fn create_wallet(
         factories,
         Some(transaction_service_config),
         Network::Rincewind,
+        None,
     );
 
     let wallet = Wallet::new(
@@ -578,7 +579,7 @@ async fn test_import_utxo() {
         listener_liveness_max_sessions: 0,
         user_agent: "tari/test-wallet".to_string(),
     };
-    let config = WalletConfig::new(comms_config, factories.clone(), None, Network::Rincewind);
+    let config = WalletConfig::new(comms_config, factories.clone(), None, Network::Rincewind, None);
     let mut alice_wallet = Wallet::new(
         config,
         WalletMemoryDatabase::new(),
@@ -645,7 +646,7 @@ async fn test_data_generation() {
         user_agent: "tari/test-wallet".to_string(),
     };
 
-    let config = WalletConfig::new(comms_config, factories, None, Network::Rincewind);
+    let config = WalletConfig::new(comms_config, factories, None, Network::Rincewind, None);
 
     let transaction_backend = TransactionMemoryDatabase::new();
 

--- a/base_layer/wallet_ffi/src/lib.rs
+++ b/base_layer/wallet_ffi/src/lib.rs
@@ -2933,6 +2933,7 @@ pub unsafe extern "C" fn wallet_create(
                         ..Default::default()
                     }),
                     Network::Rincewind,
+                    None,
                 ),
                 wallet_backend,
                 transaction_backend.clone(),

--- a/common/config/presets/windows.toml
+++ b/common/config/presets/windows.toml
@@ -104,6 +104,16 @@ base_node_query_timeout = 120
 #command_send_wait_stage = "Broadcast"
 #command_send_wait_timeout = 300
 
+# The base node that the wallet should use for service requests and tracking chain state
+# base_node_service_peer = "public_key::net_address"
+# base_node_service_peer = "e856839057aac496b9e25f10821116d02b58f20129e9b9ba681b830568e47c4d::/onion3/exe2zgehnw3tvrbef3ep6taiacr6sdyeb54be2s25fpru357r4skhtad:18141" #tbn-oregon
+
+# Configuration for the wallet's base node service
+# The refresh interval, defaults to 10 seconds
+# base_node_service_refresh_interval = 10
+# The maximum age of service requests in seconds, requests older than this are discarded
+# base_node_service_request_max_age = 60
+
 #[base_node.transport.tor]
 #control_address = "/ip4/127.0.0.1/tcp/9051"
 #control_auth_type = "none" # or "password"

--- a/common/config/tari_config_example.toml
+++ b/common/config/tari_config_example.toml
@@ -104,6 +104,16 @@ base_node_query_timeout = 120
 #command_send_wait_stage = "Broadcast"
 #command_send_wait_timeout = 300
 
+# The base node that the wallet should use for service requests and tracking chain state
+# base_node_service_peer = "public_key::net_address"
+# base_node_service_peer = "e856839057aac496b9e25f10821116d02b58f20129e9b9ba681b830568e47c4d::/onion3/exe2zgehnw3tvrbef3ep6taiacr6sdyeb54be2s25fpru357r4skhtad:18141" #tbn-oregon
+
+# Configuration for the wallet's base node service
+# The refresh interval, defaults to 10 seconds
+# base_node_service_refresh_interval = 10
+# The maximum age of service requests in seconds, requests older than this are discarded
+# base_node_service_request_max_age = 60
+
 #[base_node.transport.tor]
 #control_address = "/ip4/127.0.0.1/tcp/9051"
 #control_auth_type = "none" # or "password"

--- a/common/src/configuration/global.rs
+++ b/common/src/configuration/global.rs
@@ -91,6 +91,9 @@ pub struct GlobalConfig {
     pub transaction_broadcast_send_timeout: Duration,
     pub wallet_command_send_wait_stage: String,
     pub wallet_command_send_wait_timeout: u64,
+    pub wallet_base_node_service_peer: String,
+    pub wallet_base_node_service_refresh_interval: u64,
+    pub wallet_base_node_service_request_max_age: u64,
     pub prevent_fee_gt_amount: bool,
     pub monerod_url: String,
     pub monerod_username: String,
@@ -383,6 +386,26 @@ fn convert_node_config(network: Network, cfg: Config) -> Result<GlobalConfig, Co
         Err(e) => return Err(ConfigurationError::new(&key, &e.to_string())),
     };
 
+    let key = "wallet.base_node_service_peer";
+    let wallet_base_node_service_peer = match cfg.get_str(key) {
+        Ok(peer) => peer,
+        Err(e) => return Err(ConfigurationError::new(&key, &e.to_string())),
+    };
+
+    let key = "wallet.base_node_service_refresh_interval";
+    let wallet_base_node_service_refresh_interval = match cfg.get_int(key) {
+        Ok(seconds) => seconds as u64,
+        Err(ConfigError::NotFound(_)) => 10,
+        Err(e) => return Err(ConfigurationError::new(&key, &e.to_string())),
+    };
+
+    let key = "wallet.base_node_service_request_max_age";
+    let wallet_base_node_service_request_max_age = match cfg.get_int(key) {
+        Ok(seconds) => seconds as u64,
+        Err(ConfigError::NotFound(_)) => 60,
+        Err(e) => return Err(ConfigurationError::new(&key, &e.to_string())),
+    };
+
     let key = "common.liveness_max_sessions";
     let liveness_max_sessions = cfg
         .get_int(key)
@@ -507,6 +530,9 @@ fn convert_node_config(network: Network, cfg: Config) -> Result<GlobalConfig, Co
         transaction_broadcast_send_timeout,
         wallet_command_send_wait_stage,
         wallet_command_send_wait_timeout,
+        wallet_base_node_service_peer,
+        wallet_base_node_service_refresh_interval,
+        wallet_base_node_service_request_max_age,
         prevent_fee_gt_amount,
         proxy_host_address,
         monerod_url,

--- a/common/src/configuration/utils.rs
+++ b/common/src/configuration/utils.rs
@@ -84,6 +84,7 @@ pub fn default_config(bootstrap: &ConfigBootstrap) -> Config {
     cfg.set_default("wallet.transaction_broadcast_send_timeout", 600)
         .unwrap();
     cfg.set_default("wallet.prevent_fee_gt_amount", true).unwrap();
+    cfg.set_default("wallet.base_node_service_peer", "").unwrap();
 
     //---------------------------------- Mainnet Defaults --------------------------------------------//
 


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Replaces the placeholder data with live data from the base node service. Adds a configuration option to specify which base node the wallet should connect to, and then displays the chain tip and sync status.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The console wallet is still using some placeholder information

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manually -  you can use the following setting to point the wallet to `tbn-oregon` base node in `config.toml`

```toml
[wallet]
base_node_service_peer = "e856839057aac496b9e25f10821116d02b58f20129e9b9ba681b830568e47c4d::/onion3/exe2zgehnw3tvrbef3ep6taiacr6sdyeb54be2s25fpru357r4skhtad:18141"
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch.
* [x] I ran `cargo-fmt --all` before pushing.
* [x] I ran `cargo test` successfully before submitting my PR.
* [x] I have squashed my commits into a single commit.
* [x] My change requires a change to the documentation.
* [x] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
