### PR TITLE
Plumb in the balance in the console wallet

### DIFF
--- a/applications/tari_console_wallet/src/ui/components/balance.rs
+++ b/applications/tari_console_wallet/src/ui/components/balance.rs
@@ -18,7 +18,7 @@ impl Balance {
 }
 
 impl<B: Backend> Component<B> for Balance {
-    fn draw(&mut self, f: &mut Frame<B>, area: Rect, _app_state: &AppState)
+    fn draw(&mut self, f: &mut Frame<B>, area: Rect, app_state: &AppState)
     where B: Backend {
         // This is a hack to produce only a top margin and not a bottom margin
         let block_title_body = Layout::default()
@@ -44,21 +44,26 @@ impl<B: Backend> Component<B> for Balance {
         ));
         f.render_widget(block, area);
 
+        let balance = app_state.get_balance();
+
         let available_balance = Spans::from(vec![
             Span::styled("Available:", Style::default().fg(Color::Magenta)),
             Span::raw(" "),
-            Span::raw(format!("{}", MicroTari::from(1234567000))),
-            Span::raw(format!(" (Time Locked: {})", MicroTari::from(20000000))),
+            Span::raw(format!("{}", balance.available_balance)),
+            Span::raw(format!(
+                " (Time Locked: {})",
+                balance.time_locked_balance.unwrap_or_else(|| MicroTari::from(0u64))
+            )),
         ]);
         let incoming_balance = Spans::from(vec![
             Span::styled("Pending Incoming:", Style::default().fg(Color::Magenta)),
             Span::raw(" "),
-            Span::raw(format!("{}", MicroTari::from(12345670500))),
+            Span::raw(format!("{}", balance.pending_incoming_balance)),
         ]);
         let outgoing_balance = Spans::from(vec![
             Span::styled("Pending Outgoing:", Style::default().fg(Color::Magenta)),
             Span::raw(" "),
-            Span::raw(format!("{}", MicroTari::from(98754))),
+            Span::raw(format!("{}", balance.pending_outgoing_balance)),
         ]);
 
         let paragraph1 = Paragraph::new(available_balance).block(Block::default());

--- a/applications/tari_console_wallet/src/ui/ui_error.rs
+++ b/applications/tari_console_wallet/src/ui/ui_error.rs
@@ -1,11 +1,17 @@
 use tari_comms::connectivity::ConnectivityError;
-use tari_wallet::{contacts_service::error::ContactsServiceError, transaction_service::error::TransactionServiceError};
+use tari_wallet::{
+    contacts_service::error::ContactsServiceError,
+    output_manager_service::error::OutputManagerError,
+    transaction_service::error::TransactionServiceError,
+};
 use thiserror::Error;
 
 #[derive(Error, Debug)]
 pub enum UiError {
     #[error(transparent)]
     TransactionServiceError(#[from] TransactionServiceError),
+    #[error(transparent)]
+    OutputManagerError(#[from] OutputManagerError),
     #[error(transparent)]
     ContactsServiceError(#[from] ContactsServiceError),
     #[error(transparent)]

--- a/base_layer/wallet/src/output_manager_service/service.rs
+++ b/base_layer/wallet/src/output_manager_service/service.rs
@@ -947,6 +947,17 @@ pub struct Balance {
     pub pending_outgoing_balance: MicroTari,
 }
 
+impl Balance {
+    pub fn zero() -> Self {
+        Self {
+            available_balance: Default::default(),
+            time_locked_balance: None,
+            pending_incoming_balance: Default::default(),
+            pending_outgoing_balance: Default::default(),
+        }
+    }
+}
+
 impl fmt::Display for Balance {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         writeln!(f, "Available balance: {}", self.available_balance)?;


### PR DESCRIPTION
## Description
This PR plumbs in the actual wallet balance to the balance UI component in `tari_console_wallet`. The balance was added to the app_state and a refresh is triggered whenever there is any update to a transaction in the app_state.

## How Has This Been Tested?
Manual Testing

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch.
* [x] I ran `cargo-fmt --all` before pushing.
* [x] I ran `cargo test` successfully before submitting my PR.
* [x] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
