### PR TITLE
[Merge Mining] Issue 2418

### DIFF
--- a/applications/tari_merge_mining_proxy/src/proxy.rs
+++ b/applications/tari_merge_mining_proxy/src/proxy.rs
@@ -180,14 +180,6 @@ impl InnerService {
         monerod_resp: Response<json::Value>,
     ) -> Result<Response<Body>, MmProxyError>
     {
-        let resp = monerod_resp.body();
-        if resp["result"]["status"] != "OK" {
-            return Err(MmProxyError::InvalidMonerodResponse(format!(
-                "Response status failed: {:#}",
-                resp["result"]
-            )));
-        }
-
         let params = match request.body()["params"].as_array() {
             Some(v) => v,
             None => {

--- a/base_layer/core/src/base_node/comms_interface/local_interface.rs
+++ b/base_layer/core/src/base_node/comms_interface/local_interface.rs
@@ -132,7 +132,7 @@ impl LocalNodeCommsInterface {
                     }
                 } else {
                     Err(CommsInterfaceError::ApiError(
-                        error.unwrap_or("Unspecified error".to_string()),
+                        error.unwrap_or_else(|| "Unspecified error".to_string()),
                     ))
                 }
             },

--- a/base_layer/core/src/base_node/proto/response.rs
+++ b/base_layer/core/src/base_node/proto/response.rs
@@ -113,7 +113,7 @@ impl From<ci::NodeCommsResponse> for ProtoNodeCommsResponse {
             NewBlockTemplate(block_template) => ProtoNodeCommsResponse::NewBlockTemplate(block_template.into()),
             NewBlock { success, error, block } => ProtoNodeCommsResponse::NewBlock(ProtoNewBlockResponse {
                 success,
-                error: error.unwrap_or("".to_string()),
+                error: error.unwrap_or_else(|| "".to_string()),
                 block: block.map(|b| b.into()),
             }),
             TargetDifficulty(difficulty) => ProtoNodeCommsResponse::TargetDifficulty(difficulty.as_u64()),


### PR DESCRIPTION
## Description
Previous logic contained in the proxy determined if a block should be submitted to Monero, or Tari, or Both based on the mining difficulty being used. In the case of submitting to both, the Monero response was checked before submitting to Tari.

Current logic is that a block should be submitted to both Tari and Monero regardless of the difficulty being used. This removes checking that a successful submit response was received from Monero before attempting to submit to Tari. By consequence this also stops an internal server error being returned to XMRig in this case which is part of issue 2417. This change accounts for the 55 missing submissions to Tari in Issue 2418.

## Motivation and Context
Issue #2418 
Issue #2417 (Partial)

## How Has This Been Tested?

## Types of changes
* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
* [x] I'm merging against the `development` branch.
* [x] I ran `cargo-fmt --all` before pushing.
* [x] I ran `cargo test` successfully before submitting my PR.
* [x] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
