### PR TITLE
Implement entry and persistence of custom base node in console wallet

### DIFF
--- a/applications/tari_app_utilities/src/utilities.rs
+++ b/applications/tari_app_utilities/src/utilities.rs
@@ -237,7 +237,7 @@ pub fn parse_peer_seeds(seeds: &[String]) -> Vec<Peer> {
     for s in seeds {
         let parts: Vec<&str> = s.split("::").map(|s| s.trim()).collect();
         if parts.len() != 2 {
-            warn!(target: LOG_TARGET, "Invalid peer seed: {}", s);
+            debug!(target: LOG_TARGET, "Invalid peer seed: {}", s);
             continue;
         }
         let pub_key = match PublicKey::from_hex(parts[0]) {

--- a/applications/tari_console_wallet/src/main.rs
+++ b/applications/tari_console_wallet/src/main.rs
@@ -124,11 +124,9 @@ fn main_inner() -> Result<(), ExitCodes> {
 
     debug!(target: LOG_TARGET, "Starting app");
 
-    let node_identity = wallet.comms.node_identity().as_ref().clone();
-
     let handle = runtime.handle().clone();
     let result = match wallet_mode(bootstrap) {
-        WalletMode::Tui => tui_mode(handle, config, node_identity, wallet.clone(), base_node),
+        WalletMode::Tui => tui_mode(handle, config, wallet.clone(), base_node),
         WalletMode::Grpc => grpc_mode(handle, wallet.clone(), config),
         WalletMode::Script(path) => script_mode(handle, path, wallet.clone(), config),
         WalletMode::Command(command) => command_mode(handle, command, wallet.clone(), config),

--- a/applications/tari_console_wallet/src/ui/app.rs
+++ b/applications/tari_console_wallet/src/ui/app.rs
@@ -32,8 +32,14 @@ use crate::ui::{
     state::AppState,
     MAX_WIDTH,
 };
+use log::*;
 use tari_common::Network;
-use tari_comms::{peer_manager::Peer, NodeIdentity};
+use tari_comms::{
+    multiaddr::Multiaddr,
+    peer_manager::{NodeId, Peer, PeerFeatures, PeerFlags},
+};
+use tari_core::transactions::types::PublicKey;
+use tari_crypto::tari_utilities::hex::Hex;
 use tari_wallet::WalletSqlite;
 use tokio::runtime::Handle;
 use tui::{
@@ -43,6 +49,8 @@ use tui::{
 };
 
 pub const LOG_TARGET: &str = "wallet::ui::app";
+pub const CUSTOM_BASE_NODE_PUBLIC_KEY_KEY: &str = "console_wallet_custom_base_node_public_key";
+pub const CUSTOM_BASE_NODE_ADDRESS_KEY: &str = "console_wallet_custom_base_node_address";
 
 pub struct App<B: Backend> {
     pub title: String,
@@ -55,29 +63,55 @@ pub struct App<B: Backend> {
 }
 
 impl<B: Backend> App<B> {
-    pub fn new(
-        title: String,
-        node_identity: &NodeIdentity,
-        wallet: WalletSqlite,
-        network: Network,
-        base_node: Peer,
-    ) -> Self
-    {
-        // TODO: It's probably better to read the node_identity from the wallet, but that requires
-        // taking a read lock and making this method async, which adds some read/write cycles,
-        // so it's easier to just ask for it right now
-        let app_state = AppState::new(&node_identity, network, wallet, base_node);
+    pub async fn new(title: String, mut wallet: WalletSqlite, network: Network, base_node_config: Peer) -> Self {
+        // Attempt to read a stored custom base node public key and address from the wallet database. If this fails we
+        // will not use a custom peer and fall back to the config peer
+        let custom_peer = get_custom_base_node_peer_from_db(&mut wallet).await;
+
+        let app_state = AppState::new(
+            wallet.comms.node_identity().as_ref(),
+            network,
+            wallet,
+            base_node_config.clone(),
+            custom_peer.clone(),
+        );
+
+        // If there is a custom peer we initialize the Network tab with it, otherwise we use the peer provided from
+        // config
+        let (public_key_str, public_address_str) = if let Some(custom_peer) = custom_peer {
+            let public_address = match custom_peer.addresses.first() {
+                Some(address) => address.to_string(),
+                None => "".to_string(),
+            };
+            info!(
+                target: LOG_TARGET,
+                "Using stored custom base node - {}::{}", custom_peer.public_key, public_address
+            );
+            (custom_peer.public_key.to_hex(), public_address)
+        } else {
+            let public_address = match base_node_config.addresses.first() {
+                Some(address) => address.to_string(),
+                None => "".to_string(),
+            };
+            info!(
+                target: LOG_TARGET,
+                "Using configuration specified base node - {}::{}", base_node_config.public_key, public_address
+            );
+            (base_node_config.public_key.to_hex(), public_address)
+        };
 
         let tabs = TabsContainer::<B>::new(title.clone())
             .add("Transactions".into(), Box::new(TransactionsTab::new()))
             .add("Send/Receive".into(), Box::new(SendReceiveTab::new()))
-            .add("Network".into(), Box::new(NetworkTab::new()));
+            .add(
+                "Network".into(),
+                Box::new(NetworkTab::new(public_key_str, public_address_str)),
+            );
 
         let base_node_status = BaseNode::new();
 
         Self {
             title,
-
             should_quit: false,
             app_state,
             tabs,
@@ -112,14 +146,10 @@ impl<B: Backend> App<B> {
     }
 
     pub fn on_right(&mut self) {
-        // This currently doesn't need app_state, but is async
-        // to match others
         self.tabs.next();
     }
 
     pub fn on_left(&mut self) {
-        // This currently doesn't need app_state, but is async
-        // to match others
         self.tabs.previous();
     }
 
@@ -153,5 +183,70 @@ impl<B: Backend> App<B> {
 
         self.base_node_status.draw(f, title_halves[1], &self.app_state);
         self.tabs.draw_content(f, title_chunks[1], &mut self.app_state);
+    }
+}
+
+/// This helper function will attempt to read a stored base node public key and address from the wallet database if
+/// possible. If both are found they are used to construct and return a Peer.
+async fn get_custom_base_node_peer_from_db(wallet: &mut WalletSqlite) -> Option<Peer> {
+    let custom_base_node_peer_pubkey = match wallet
+        .db
+        .get_client_key_value(CUSTOM_BASE_NODE_PUBLIC_KEY_KEY.to_string())
+        .await
+    {
+        Ok(val) => val,
+        Err(e) => {
+            warn!(target: LOG_TARGET, "Problem reading from wallet database: {}", e);
+            return None;
+        },
+    };
+    let custom_base_node_peer_address = match wallet
+        .db
+        .get_client_key_value(CUSTOM_BASE_NODE_ADDRESS_KEY.to_string())
+        .await
+    {
+        Ok(val) => val,
+        Err(e) => {
+            warn!(target: LOG_TARGET, "Problem reading from wallet database: {}", e);
+            return None;
+        },
+    };
+
+    match (custom_base_node_peer_pubkey, custom_base_node_peer_address) {
+        (Some(public_key), Some(address)) => {
+            let pub_key_str = PublicKey::from_hex(public_key.as_str());
+            let addr_str = address.parse::<Multiaddr>();
+            let (pub_key, address) = match (pub_key_str, addr_str) {
+                (Ok(pk), Ok(addr)) => (pk, addr),
+                (_, _) => {
+                    debug!(
+                        target: LOG_TARGET,
+                        "Problem converting stored custom base node public key or address"
+                    );
+                    return None;
+                },
+            };
+
+            let node_id = match NodeId::from_key(&pub_key) {
+                Ok(n) => n,
+                Err(e) => {
+                    debug!(
+                        target: LOG_TARGET,
+                        "Problem converting stored base node public key to Node Id: {}", e
+                    );
+                    return None;
+                },
+            };
+            Some(Peer::new(
+                pub_key,
+                node_id,
+                address.into(),
+                PeerFlags::default(),
+                PeerFeatures::COMMUNICATION_NODE,
+                &[],
+                Default::default(),
+            ))
+        },
+        (_, _) => None,
     }
 }

--- a/applications/tari_console_wallet/src/ui/ui_error.rs
+++ b/applications/tari_console_wallet/src/ui/ui_error.rs
@@ -1,6 +1,8 @@
-use tari_comms::connectivity::ConnectivityError;
+use tari_comms::{connectivity::ConnectivityError, peer_manager::node_id::NodeIdError};
+use tari_crypto::tari_utilities::hex::HexError;
 use tari_wallet::{
     contacts_service::error::ContactsServiceError,
+    error::{WalletError, WalletStorageError},
     output_manager_service::error::OutputManagerError,
     transaction_service::error::TransactionServiceError,
 };
@@ -16,6 +18,18 @@ pub enum UiError {
     ContactsServiceError(#[from] ContactsServiceError),
     #[error(transparent)]
     ConnectivityError(#[from] ConnectivityError),
+    #[error(transparent)]
+    HexError(#[from] HexError),
+    #[error(transparent)]
+    NodeIdError(#[from] NodeIdError),
+    #[error(transparent)]
+    WalletError(#[from] WalletError),
+    #[error(transparent)]
+    WalletStorageError(#[from] WalletStorageError),
     #[error("Could not convert string into Public Key")]
     PublicKeyParseError,
+    #[error("Could not convert string into Net Address")]
+    AddressParseError,
+    #[error("Peer did not include an address")]
+    NoAddressError,
 }

--- a/applications/tari_console_wallet/src/wallet_modes.rs
+++ b/applications/tari_console_wallet/src/wallet_modes.rs
@@ -29,7 +29,7 @@ use log::*;
 use std::{fs, io::Stdout, net::SocketAddr, path::PathBuf};
 use tari_app_utilities::utilities::ExitCodes;
 use tari_common::GlobalConfig;
-use tari_comms::{peer_manager::Peer, NodeIdentity};
+use tari_comms::peer_manager::Peer;
 
 use tari_wallet::WalletSqlite;
 use tokio::runtime::Handle;
@@ -93,7 +93,6 @@ pub fn script_mode(handle: Handle, path: PathBuf, wallet: WalletSqlite, config: 
 pub fn tui_mode(
     handle: Handle,
     node_config: GlobalConfig,
-    node_identity: NodeIdentity,
     wallet: WalletSqlite,
     base_node: Peer,
 ) -> Result<(), ExitCodes>
@@ -101,13 +100,12 @@ pub fn tui_mode(
     let grpc = WalletGrpcServer::new(wallet.clone());
     handle.spawn(run_grpc(grpc, node_config.grpc_wallet_address));
 
-    let app = App::<CrosstermBackend<Stdout>>::new(
+    let app = handle.block_on(App::<CrosstermBackend<Stdout>>::new(
         "Tari Console Wallet".into(),
-        &node_identity,
         wallet,
         node_config.network,
         base_node,
-    );
+    ));
     handle.enter(|| run(app))?;
 
     info!(

--- a/base_layer/wallet/src/base_node_service/service.rs
+++ b/base_layer/wallet/src/base_node_service/service.rs
@@ -195,7 +195,7 @@ where BNResponseStream: Stream<Item = DomainMessage<BaseNodeProto::BaseNodeServi
 
     /// Sends a request to the connected base node to retrieve chain metadata.
     async fn refresh_chain_metadata(&mut self) -> Result<(), BaseNodeServiceError> {
-        debug!(target: LOG_TARGET, "Refresh chain metadata");
+        trace!(target: LOG_TARGET, "Refresh chain metadata");
         let base_node_peer = self
             .base_node_peer
             .clone()
@@ -236,7 +236,7 @@ where BNResponseStream: Stream<Item = DomainMessage<BaseNodeProto::BaseNodeServi
             .await
             .map_err(BaseNodeServiceError::OutboundError)?;
 
-        debug!(target: LOG_TARGET, "Refresh chain metadata sent");
+        debug!(target: LOG_TARGET, "Refresh chain metadata message sent");
 
         Ok(())
     }
@@ -287,7 +287,7 @@ where BNResponseStream: Stream<Item = DomainMessage<BaseNodeProto::BaseNodeServi
     }
 
     fn publish_event(&mut self, event: BaseNodeEvent) {
-        debug!(target: LOG_TARGET, "Publishing event: {:?}", event);
+        trace!(target: LOG_TARGET, "Publishing event: {:?}", event);
         let _ = self.event_publisher.send(Arc::new(event)).map_err(|_| {
             trace!(
                 target: LOG_TARGET,


### PR DESCRIPTION
## Description
This PR adds the functionality to allow a user to specify a custom base node public key and address in the Network tab of the console wallet. If the public key and address can be parsed into a Comms Public Key and valid Net address this bae node is set to be used by all the wallet services and is saved into the wallet’s client key-value store.

On startup if there is a valid public key and address stored in the wallets client key-value store this is used as the base node for the wallet to connect to. If these values don’t exist or cannot be parsed into a valid public key or net address the wallet will fallback to the base node specified in the config.

A function is also added to clear the custom base node which, after a confirmation dialog, will delete the custom data from the database and revert to the config specified base node.

## How Has This Been Tested?
Manually tested

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch.
* [x] I ran `cargo-fmt --all` before pushing.
* [x] I ran `cargo test` successfully before submitting my PR.
* [x] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
