### PR TITLE
Remove cargo fmt from build CI (still in clippy/test)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,12 +51,6 @@ commands:
           keys:
             - v6-cargo-cache-{{arch}}-{{checksum "rust-version"}}-<<parameters.release>>-{{checksum "Cargo.lock"}}
       - run:
-          name: Cargo fmt
-          command: |
-            TOOLCHAIN=$(cat rust-toolchain)
-            rustup component add --toolchain $TOOLCHAIN rustfmt
-            cargo fmt --all -- --check
-      - run:
           name: Build
           command: cargo build --all --all-features --jobs=3 <<#parameters.release>>--release<</parameters.release>>
       - save_cache:


### PR DESCRIPTION
We've already got cargo fmt in the clippy and test runs, which are required to pass. 

Removing `fmt` from the build step - so we can see if the code actually compiles or not, with or without fmt fails

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [ ] I'm merging against the `development` branch.
* [ ] I ran `cargo-fmt --all` before pushing.
* [ ] I ran `cargo test` successfully before submitting my PR.
* [ ] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
