### PR TITLE
Add more build options and platforms

### DIFF
--- a/.github/workflows/base_node_binaries.yml
+++ b/.github/workflows/base_node_binaries.yml
@@ -17,10 +17,9 @@ jobs:
       fail-fast: false
       matrix:
 #        os: [ubuntu-latest, macos-latest, windows-latest, seelf-hosted]
-        os: [ubuntu-18.04, macos-10.15, windows-2019]
+        os: [ubuntu-18.04, ubuntu-20.04, macos-10.15, macos-11.0, windows-2016, windows-2019]
         features: ["avx2", "safe"]
-#        target_cpu: ["x86-64", "ivybridge", "skylake"]
-        target_cpu: ["x86-64", "ivybridge"]
+        target_cpu: ["x86-64", "ivybridge", "skylake"]
 #        target_release: ["release", "debug"]
         exclude:
           - target_cpu: "x86-64"

--- a/scripts/build-dists-tarball.sh
+++ b/scripts/build-dists-tarball.sh
@@ -10,9 +10,10 @@
 #
 
 if [ "$1" == "-h" ] || [ "$1" == "--help" ]; then
-  echo "$0 (clean|latest-tag|'any-string-version')"
+  echo "$0 (clean|latest-tag|latest-tagv|'any-string-version')"
   echo " 'clean' cargo clean and lock remove"
   echo " 'latest-tag' pull and switch too latest git tag"
+  echo " 'latest-tagv' pull and switch too latest git tag starting with 'v'"
   echo " 'any-string-version' archive string to tag with"
   echo "   ie: $0 nightly-development-test-\$(date +'%Y-%m-%d')"
   exit 1
@@ -129,13 +130,20 @@ else
 fi
 
 if [ "$1" == "latest-tag" ]; then
+if [[ "$1" =~ ^latest* ]]; then
   if [ "$gitclean" == "uncommitted" ]; then
-    echo "Can't use latest-tag with uncommitted changes"
+    echo "Can't use latest options with uncommitted changes"
     echo  "Suggest commit and push before re-running $0";
     exit 5
   fi
   git fetch --all --tags
-  gitTagVersion=$(git describe --tags `git rev-list --tags --max-count=1`)
+  if [ "$1" == "latest-tag" ]; then
+    gitTagVersion=$(git describe --tags `git rev-list --tags --max-count=1`)
+  fi
+
+  if [ "$1" == "latest-tagv" ]; then
+    gitTagVersion=$(git describe --tags --match "v[0-9]*" --abbrev=4 HEAD)
+  fi
   git checkout tags/$gitTagVersion -B $gitTagVersion-build
 else
   gitTagVersion="${1}"


### PR DESCRIPTION
Extend basic build binary/archive option, so that build does not need which version, just latest tag.  
  
Add new OSX, Ubuntu and older Windows build platform in build matrix.

## Motivation and Context
Begin testing with OSX 11.0 and Ubuntu 20.04

## Types of changes
* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
* [x] I'm merging against the `development` branch.
* [ ] I ran `cargo-fmt --all` before pushing.
* [ ] I ran `cargo test` successfully before submitting my PR.
* [x] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
