### PR TITLE
Wallet base node service fallback mode

### DIFF
--- a/applications/tari_console_wallet/src/ui/app.rs
+++ b/applications/tari_console_wallet/src/ui/app.rs
@@ -20,17 +20,20 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use crate::ui::{
-    components::{
-        base_node::BaseNode,
-        network_tab::NetworkTab,
-        send_receive_tab::SendReceiveTab,
-        tabs_container::TabsContainer,
-        transactions_tab::TransactionsTab,
-        Component,
+use crate::{
+    ui::{
+        components::{
+            base_node::BaseNode,
+            network_tab::NetworkTab,
+            send_receive_tab::SendReceiveTab,
+            tabs_container::TabsContainer,
+            transactions_tab::TransactionsTab,
+            Component,
+        },
+        state::AppState,
+        MAX_WIDTH,
     },
-    state::AppState,
-    MAX_WIDTH,
+    utils::formatting::display_address,
 };
 use log::*;
 use tari_common::Network;
@@ -79,20 +82,14 @@ impl<B: Backend> App<B> {
         // If there is a custom peer we initialize the Network tab with it, otherwise we use the peer provided from
         // config
         let (public_key_str, public_address_str) = if let Some(custom_peer) = custom_peer {
-            let public_address = match custom_peer.addresses.first() {
-                Some(address) => address.to_string(),
-                None => "".to_string(),
-            };
+            let public_address = display_address(&custom_peer);
             info!(
                 target: LOG_TARGET,
                 "Using stored custom base node - {}::{}", custom_peer.public_key, public_address
             );
             (custom_peer.public_key.to_hex(), public_address)
         } else {
-            let public_address = match base_node_config.addresses.first() {
-                Some(address) => address.to_string(),
-                None => "".to_string(),
-            };
+            let public_address = display_address(&base_node_config);
             info!(
                 target: LOG_TARGET,
                 "Using configuration specified base node - {}::{}", base_node_config.public_key, public_address

--- a/applications/tari_console_wallet/src/ui/components/send_receive_tab.rs
+++ b/applications/tari_console_wallet/src/ui/components/send_receive_tab.rs
@@ -88,6 +88,7 @@ impl SendReceiveTab {
             Span::styled("A", Style::default().add_modifier(Modifier::BOLD)),
             Span::raw(" to edit "),
             Span::styled("Amount", Style::default().add_modifier(Modifier::BOLD)),
+            Span::raw(", "),
             Span::styled("F", Style::default().add_modifier(Modifier::BOLD)),
             Span::raw(" to edit "),
             Span::styled("Fee-Per-Gram", Style::default().add_modifier(Modifier::BOLD)),

--- a/applications/tari_console_wallet/src/ui/state/app_state.rs
+++ b/applications/tari_console_wallet/src/ui/state/app_state.rs
@@ -254,8 +254,16 @@ impl AppState {
         &self.cached_data.base_node_state
     }
 
+    pub fn get_current_base_node(&self) -> &Peer {
+        &self.cached_data.base_node_peer
+    }
+
     pub fn get_config_base_node(&self) -> &Peer {
         &self.cached_data.base_node_peer_config
+    }
+
+    pub fn get_custom_base_node(&self) -> &Option<Peer> {
+        &self.cached_data.base_node_peer_custom
     }
 
     pub async fn set_custom_base_node(&mut self, public_key: String, address: String) -> Result<(), UiError> {
@@ -496,6 +504,13 @@ impl AppStateInner {
         Ok(())
     }
 
+    pub async fn refresh_base_node_peer(&mut self, peer: Peer) -> Result<(), UiError> {
+        self.data.base_node_peer = peer;
+        self.updated = true;
+
+        Ok(())
+    }
+
     pub fn get_shutdown_signal(&self) -> ShutdownSignal {
         self.wallet.comms.shutdown_signal()
     }
@@ -593,6 +608,7 @@ struct AppStateData {
     connected_peers: Vec<Peer>,
     balance: Balance,
     base_node_state: BaseNodeState,
+    base_node_peer: Peer,
     base_node_peer_config: Peer,
     base_node_peer_custom: Option<Peer>,
 }
@@ -623,6 +639,7 @@ impl AppStateData {
             emoji_id: eid,
             qr_code: image,
         };
+        let base_node_peer = base_node_peer_config.clone();
 
         AppStateData {
             pending_txs: Vec::new(),
@@ -632,6 +649,7 @@ impl AppStateData {
             connected_peers: Vec::new(),
             balance: Balance::zero(),
             base_node_state: BaseNodeState::default(),
+            base_node_peer,
             base_node_peer_config,
             base_node_peer_custom,
         }

--- a/applications/tari_console_wallet/src/utils/formatting.rs
+++ b/applications/tari_console_wallet/src/utils/formatting.rs
@@ -20,6 +20,7 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+use tari_comms::peer_manager::Peer;
 use unicode_segmentation::UnicodeSegmentation;
 
 /// Utility function to only display the first and last N characters of a long string. This function is aware of unicode
@@ -39,6 +40,14 @@ pub fn display_compressed_string(string: String, len_first: usize, len_last: usi
         result.push_str(i);
     }
     result
+}
+
+/// Utility function to display the first net address of a &Peer as a String
+pub fn display_address(peer: &Peer) -> String {
+    match peer.addresses.first() {
+        Some(address) => address.to_string(),
+        None => "".to_string(),
+    }
 }
 
 #[cfg(test)]

--- a/base_layer/wallet/src/base_node_service/error.rs
+++ b/base_layer/wallet/src/base_node_service/error.rs
@@ -28,6 +28,8 @@ use thiserror::Error;
 pub enum BaseNodeServiceError {
     #[error("No base node peer set")]
     NoBaseNodePeer,
+    #[error("No base node service peers were configured")]
+    NoBaseNodeServicePeers,
     #[error("Unexpected API Response")]
     UnexpectedApiResponse,
     #[error("Transport channel error: `{0}`")]

--- a/base_layer/wallet/src/base_node_service/service.rs
+++ b/base_layer/wallet/src/base_node_service/service.rs
@@ -65,6 +65,16 @@ pub struct BaseNodeState {
     pub chain_metadata: Option<ChainMetadata>,
     pub is_synced: Option<bool>,
     pub updated: Option<NaiveDateTime>,
+    pub latency: Option<Duration>,
+    pub online: bool,
+}
+
+impl BaseNodeState {
+    fn set_online(&mut self, online: bool) -> Self {
+        self.online = online;
+
+        self.clone()
+    }
 }
 
 impl Default for BaseNodeState {
@@ -73,11 +83,13 @@ impl Default for BaseNodeState {
             chain_metadata: None,
             is_synced: None,
             updated: None,
+            latency: None,
+            online: true,
         }
     }
 }
 
-/// To keep track of when a request was sent
+/// Keep track of the identity and the time the request was sent
 #[derive(Debug, Clone, Copy)]
 struct RequestMetadata {
     request_key: RequestKey,
@@ -92,6 +104,7 @@ pub struct BaseNodeService<BNResponseStream> {
     outbound_messaging: OutboundMessageRequester,
     event_publisher: BaseNodeEventSender,
     base_node_peer: Option<Peer>,
+    base_nodes: Vec<Peer>,
     shutdown_signal: Option<ShutdownSignal>,
     state: BaseNodeState,
     requests: Vec<RequestMetadata>,
@@ -116,6 +129,7 @@ where BNResponseStream: Stream<Item = DomainMessage<BaseNodeProto::BaseNodeServi
             outbound_messaging,
             event_publisher,
             base_node_peer: None,
+            base_nodes: Vec::new(),
             shutdown_signal: Some(shutdown_signal),
             state: BaseNodeState::default(),
             requests: Vec::new(),
@@ -207,8 +221,8 @@ where BNResponseStream: Stream<Item = DomainMessage<BaseNodeProto::BaseNodeServi
 
         self.requests.push(RequestMetadata { request_key, sent: now });
 
-        // remove old request keys
-        let (current_requests, old): (Vec<RequestMetadata>, Vec<RequestMetadata>) =
+        // remove old requests
+        let (current_requests, old_requests): (Vec<RequestMetadata>, Vec<RequestMetadata>) =
             self.requests.iter().partition(|r| {
                 let age = Utc::now().naive_utc() - r.sent;
                 // convert to std Duration
@@ -218,10 +232,14 @@ where BNResponseStream: Stream<Item = DomainMessage<BaseNodeProto::BaseNodeServi
             });
 
         trace!(target: LOG_TARGET, "current requests: {:?}", current_requests);
-        trace!(target: LOG_TARGET, "discarded requests : {:?}", old);
+        trace!(target: LOG_TARGET, "discarded requests : {:?}", old_requests);
 
         self.requests = current_requests;
 
+        // check if base node is offline
+        self.check_online_status(old_requests.len(), &base_node_peer);
+
+        // send the new request
         let request = BaseNodeRequestProto::GetChainMetadata(true);
         let service_request = BaseNodeProto::BaseNodeServiceRequest {
             request_key,
@@ -242,6 +260,51 @@ where BNResponseStream: Stream<Item = DomainMessage<BaseNodeProto::BaseNodeServi
         Ok(())
     }
 
+    fn check_online_status(&mut self, discarded: usize, base_node_peer: &Peer) {
+        // if we are discarding old requests and have never received a response
+        let never_connected = discarded > 0 && self.state.updated.is_none();
+
+        // or if the last time we received a response is greater than the max request age config
+        let timing_out = if let Some(updated) = self.state.updated {
+            let now = Utc::now().naive_utc();
+            let millis = (now - updated).num_milliseconds() as u64;
+            let last_updated = Duration::from_millis(millis);
+
+            self.state.online && last_updated > self.config.request_max_age
+        } else {
+            false
+        };
+
+        // then the base node is currently not responding
+        if never_connected || timing_out {
+            info!(
+                target: LOG_TARGET,
+                "Base node is offline. Either we never connected ({}), or haven't received a response newer than the \
+                 max request age ({}).",
+                never_connected,
+                timing_out
+            );
+            let state = self.state.set_online(false);
+            let event = BaseNodeEvent::BaseNodeState(state);
+            self.publish_event(event);
+
+            // switch to a new base node if we can
+            let base_nodes = self.base_nodes.clone();
+            if base_nodes.len() > 1 {
+                let next_index = base_nodes.iter().position(|b| b == base_node_peer).unwrap_or_default() + 1;
+                let peer = match base_nodes.get(next_index) {
+                    Some(peer) => peer.clone(),
+                    None => base_nodes.first().unwrap().clone(),
+                };
+                info!(
+                    target: LOG_TARGET,
+                    "Switching to new base node peer. Public Key: {}.", peer.public_key
+                );
+                self.set_base_node_peer(peer);
+            }
+        }
+    }
+
     /// Handles the response from the connected base node.
     async fn handle_base_node_response(
         &mut self,
@@ -257,10 +320,16 @@ where BNResponseStream: Stream<Item = DomainMessage<BaseNodeProto::BaseNodeServi
 
         if !found.is_empty() {
             debug!(target: LOG_TARGET, "Handle base node response message: {:?}", message);
+
+            let now = Utc::now().naive_utc();
+            let time_sent = found.first().unwrap().sent;
+            let millis = (now - time_sent).num_milliseconds() as u64;
+            let latency = Duration::from_millis(millis);
+
             match message.response {
                 Some(BaseNodeResponseProto::ChainMetadata(chain_metadata)) => {
                     trace!(target: LOG_TARGET, "Chain Metadata response {:?}", chain_metadata);
-                    let now = Utc::now().naive_utc();
+                    info!(target: LOG_TARGET, "Base node latency: {}ms", millis);
                     let state = BaseNodeState {
                         is_synced: Some(message.is_synced),
                         chain_metadata: Some(
@@ -269,6 +338,8 @@ where BNResponseStream: Stream<Item = DomainMessage<BaseNodeProto::BaseNodeServi
                                 .map_err(|_| BaseNodeServiceError::UnexpectedApiResponse)?,
                         ),
                         updated: Some(now),
+                        latency: Some(latency),
+                        online: true,
                     };
                     self.publish_event(BaseNodeEvent::BaseNodeState(state.clone()));
                     self.set_state(state);
@@ -287,8 +358,31 @@ where BNResponseStream: Stream<Item = DomainMessage<BaseNodeProto::BaseNodeServi
         Ok(())
     }
 
-    fn set_base_node_peer(&mut self, peer: Box<Peer>) {
-        self.base_node_peer = Some(*peer);
+    fn reset_state(&mut self) {
+        // drop outstanding reqs
+        self.requests = Vec::new();
+
+        // reset base node state
+        let state = BaseNodeState::default();
+        self.publish_event(BaseNodeEvent::BaseNodeState(state.clone()));
+        self.set_state(state);
+    }
+
+    fn set_base_node_peers(&mut self, peers: Vec<Peer>) -> Result<(), BaseNodeServiceError> {
+        self.base_nodes = peers;
+
+        if self.base_nodes.is_empty() {
+            return Err(BaseNodeServiceError::NoBaseNodeServicePeers);
+        }
+
+        Ok(())
+    }
+
+    fn set_base_node_peer(&mut self, peer: Peer) {
+        self.reset_state();
+
+        self.base_node_peer = Some(peer.clone());
+        self.publish_event(BaseNodeEvent::BaseNodePeerSet(Box::new(peer)));
     }
 
     fn publish_event(&mut self, event: BaseNodeEvent) {
@@ -312,8 +406,12 @@ where BNResponseStream: Stream<Item = DomainMessage<BaseNodeProto::BaseNodeServi
             "Handling Wallet Base Node Service Request: {:?}", request
         );
         match request {
+            BaseNodeServiceRequest::SetBaseNodePeers(peers) => {
+                self.set_base_node_peers(peers)?;
+                Ok(BaseNodeServiceResponse::BaseNodePeersSet)
+            },
             BaseNodeServiceRequest::SetBaseNodePeer(peer) => {
-                self.set_base_node_peer(peer);
+                self.set_base_node_peer(*peer);
                 Ok(BaseNodeServiceResponse::BaseNodePeerSet)
             },
             BaseNodeServiceRequest::GetChainMetadata => Ok(BaseNodeServiceResponse::ChainMetadata(

--- a/common/config/presets/windows.toml
+++ b/common/config/presets/windows.toml
@@ -105,9 +105,13 @@ base_node_query_timeout = 120
 #command_send_wait_stage = "Broadcast"
 #command_send_wait_timeout = 300
 
-# The base node that the wallet should use for service requests and tracking chain state
-# base_node_service_peer = "public_key::net_address"
-# base_node_service_peer = "e856839057aac496b9e25f10821116d02b58f20129e9b9ba681b830568e47c4d::/onion3/exe2zgehnw3tvrbef3ep6taiacr6sdyeb54be2s25fpru357r4skhtad:18141" #tbn-oregon
+# The base nodes that the wallet should use for service requests and tracking chain state.
+# base_node_service_peers = ["public_key::net_address", ...]
+# base_node_service_peers = ["e856839057aac496b9e25f10821116d02b58f20129e9b9ba681b830568e47c4d::/onion3/exe2zgehnw3tvrbef3ep6taiacr6sdyeb54be2s25fpru357r4skhtad:18141"]
+
+# This determines if the wallet should also use the peer_seeds as backup base node service peers.
+# Defaults to true. If set to false, then at least one base node service peer should be provided above.
+# base_node_service_fallback_enabled = true
 
 # Configuration for the wallet's base node service
 # The refresh interval, defaults to 10 seconds

--- a/common/config/tari_config_example.toml
+++ b/common/config/tari_config_example.toml
@@ -105,9 +105,13 @@ base_node_query_timeout = 120
 #command_send_wait_stage = "Broadcast"
 #command_send_wait_timeout = 300
 
-# The base node that the wallet should use for service requests and tracking chain state
-# base_node_service_peer = "public_key::net_address"
-# base_node_service_peer = "e856839057aac496b9e25f10821116d02b58f20129e9b9ba681b830568e47c4d::/onion3/exe2zgehnw3tvrbef3ep6taiacr6sdyeb54be2s25fpru357r4skhtad:18141" #tbn-oregon
+# The base nodes that the wallet should use for service requests and tracking chain state.
+# base_node_service_peers = ["public_key::net_address", ...]
+# base_node_service_peers = ["e856839057aac496b9e25f10821116d02b58f20129e9b9ba681b830568e47c4d::/onion3/exe2zgehnw3tvrbef3ep6taiacr6sdyeb54be2s25fpru357r4skhtad:18141"]
+
+# This determines if the wallet should also use the peer_seeds as backup base node service peers.
+# Defaults to true. If set to false, then at least one base node service peer should be provided above.
+# base_node_service_fallback_enabled = true
 
 # Configuration for the wallet's base node service
 # The refresh interval, defaults to 10 seconds

--- a/common/src/configuration/utils.rs
+++ b/common/src/configuration/utils.rs
@@ -89,7 +89,8 @@ pub fn default_config(bootstrap: &ConfigBootstrap) -> Config {
     cfg.set_default("wallet.transaction_broadcast_send_timeout", 600)
         .unwrap();
     cfg.set_default("wallet.prevent_fee_gt_amount", true).unwrap();
-    cfg.set_default("wallet.base_node_service_peer", "").unwrap();
+    cfg.set_default("wallet.base_node_service_peers", Vec::<String>::new())
+        .unwrap();
 
     //---------------------------------- Mainnet Defaults --------------------------------------------//
 
@@ -303,6 +304,8 @@ pub fn default_config(bootstrap: &ConfigBootstrap) -> Config {
     cfg.set_default("base_node.ridcully.dns_seeds_name_server", "1.1.1.1:53")
         .unwrap();
     cfg.set_default("base_node.ridcully.dns_seeds_use_dnssec", true)
+        .unwrap();
+    cfg.set_default("wallet.base_node_service_peers", Vec::<String>::new())
         .unwrap();
 
     set_transport_defaults(&mut cfg);

--- a/comms/src/net_address/multiaddr_with_stats.rs
+++ b/comms/src/net_address/multiaddr_with_stats.rs
@@ -4,6 +4,7 @@ use serde::{Deserialize, Serialize};
 use std::{
     cmp::{Ord, Ordering},
     fmt,
+    hash::{Hash, Hasher},
     time::Duration,
 };
 
@@ -169,6 +170,12 @@ impl PartialOrd for MutliaddrWithStats {
 impl PartialEq for MutliaddrWithStats {
     fn eq(&self, other: &MutliaddrWithStats) -> bool {
         self.address == other.address
+    }
+}
+
+impl Hash for MutliaddrWithStats {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.address.hash(state)
     }
 }
 

--- a/comms/src/net_address/mutliaddresses_with_stats.rs
+++ b/comms/src/net_address/mutliaddresses_with_stats.rs
@@ -5,7 +5,7 @@ use serde::{Deserialize, Serialize};
 use std::{ops::Index, time::Duration};
 
 /// This struct is used to store a set of different net addresses such as IPv4, IPv6, Tor or I2P for a single peer.
-#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Default)]
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Default, Eq)]
 pub struct MultiaddressesWithStats {
     pub addresses: Vec<MutliaddrWithStats>,
     last_attempted: Option<DateTime<Utc>>,

--- a/comms/src/peer_manager/connection_stats.rs
+++ b/comms/src/peer_manager/connection_stats.rs
@@ -28,7 +28,7 @@ use std::{
     time::Duration,
 };
 
-#[derive(Debug, Clone, Default, Deserialize, Serialize, PartialEq)]
+#[derive(Debug, Clone, Default, Deserialize, Serialize, PartialEq, Eq)]
 pub struct PeerConnectionStats {
     /// The last time a connection was successfully made or, None if a successful
     /// connection has never been made.
@@ -108,7 +108,7 @@ impl fmt::Display for PeerConnectionStats {
 }
 
 /// Peer connection statistics
-#[derive(Debug, Clone, Deserialize, Serialize, PartialOrd, PartialEq)]
+#[derive(Debug, Clone, Deserialize, Serialize, PartialOrd, PartialEq, Eq)]
 pub enum LastConnectionAttempt {
     /// This node has never attempted to connect to this peer
     Never,

--- a/comms/src/peer_manager/migrations/v3.rs
+++ b/comms/src/peer_manager/migrations/v3.rs
@@ -65,7 +65,7 @@ pub struct PeerV3 {
     pub added_at: NaiveDateTime,
     pub user_agent: String,
 }
-/// This migration is to the metadata field
+/// This migration is to add the metadata field
 pub struct MigrationV3;
 
 impl Migration<LMDBDatabase> for MigrationV3 {

--- a/comms/src/peer_manager/peer.rs
+++ b/comms/src/peer_manager/peer.rs
@@ -37,7 +37,12 @@ use bitflags::bitflags;
 use chrono::{DateTime, NaiveDateTime, Utc};
 use multiaddr::Multiaddr;
 use serde::{Deserialize, Serialize};
-use std::{collections::HashMap, fmt::Display, time::Duration};
+use std::{
+    collections::HashMap,
+    fmt::Display,
+    hash::{Hash, Hasher},
+    time::Duration,
+};
 use tari_crypto::tari_utilities::hex::serialize_to_hex;
 
 bitflags! {
@@ -56,7 +61,7 @@ pub struct PeerIdentity {
 /// A Peer represents a communication peer that is identified by a Public Key and NodeId. The Peer struct maintains a
 /// collection of the NetAddressesWithStats that this Peer can be reached by. The struct also maintains a set of flags
 /// describing the status of the Peer.
-#[derive(Debug, Clone, Deserialize, Serialize)]
+#[derive(Debug, Clone, Deserialize, Serialize, Eq)]
 pub struct Peer {
     /// The local id of the peer. If this is None, the peer has never been persisted
     pub(super) id: Option<PeerId>,
@@ -85,7 +90,7 @@ pub struct Peer {
     /// User agent advertised by the peer
     pub user_agent: String,
     /// Metadata field. This field is for use by upstream clients to record extra info about a peer.
-    /// We use a hashmap here so that we can use more than one "info set"
+    /// We use a btreemap here so that we can use more than one "info set"
     pub metadata: HashMap<u8, Vec<u8>>,
 }
 
@@ -323,6 +328,12 @@ impl Display for Peer {
 impl PartialEq for Peer {
     fn eq(&self, other: &Self) -> bool {
         self.public_key == other.public_key
+    }
+}
+
+impl Hash for Peer {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.public_key.hash(state)
     }
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Requires PR #2430 (merged) 

## Description
<!--- Describe your changes in detail -->
Implement the ability for the wallet base node service to be configured with multiple peers, and ability to fallback to peer seeds as well (if configured). When the current base node is detected as being offline, the base node service will switch to the next in the list. The console wallet now also shows the latency of the connected base node.  
 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. --> 

Allows the console wallet to be configured with multiple base nodes, and automatic switching when not receiving a response within the configured request maximum age 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. --> 

cargo test, and manually 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [x] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [x] Documentation 

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch.
* [x] I ran `cargo-fmt --all` before pushing.
* [x] I ran `cargo test` successfully before submitting my PR.
* [x] I have squashed my commits into a single commit.
* [x] My change requires a change to the documentation.
* [x] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
