### PR TITLE
Provide initial sync status to merge mining proxy

### DIFF
--- a/applications/tari_app_grpc/proto/base_node.proto
+++ b/applications/tari_app_grpc/proto/base_node.proto
@@ -66,11 +66,13 @@ service BaseNode {
 /// return type of GetTipInfo
 message TipInfoResponse{
     MetaData metadata = 1;
+    bool initial_sync_achieved = 2;
 }
 /// return type of GetNewBlockTemplate
 message NewBlockTemplateResponse{
     NewBlockTemplate new_block_template = 1;
     uint64 block_reward = 2;
+    bool initial_sync_achieved = 3;
 }
 
 /// An Empty placeholder for endpoints without request parameters
@@ -145,6 +147,7 @@ message CalcTimingResponse {
     uint64 min = 2;
     double avg = 3;
 }
+
 // The request used for querying headers from the base node. The parameters `from_height` and `num_headers` can be used
 // to page through the current best chain.
 message ListHeadersRequest {
@@ -173,23 +176,21 @@ message GetBlocksResponse {
     repeated HistoricalBlock blocks = 1;
 }
 
-
 enum Sorting {
     SORTING_DESC = 0;
     SORTING_ASC = 1;
 }
 
-
 message MetaData {
-        // The current chain height, or the block number of the longest valid chain, or `None` if there is no chain
-        uint64 height_of_longest_chain = 1;
-        // The block hash of the current tip of the longest valid chain, or `None` for an empty chain
-        bytes best_block = 2;
-        // The number of blocks back from the tip that this database tracks. A value of 0 indicates that all blocks are
-        // tracked (i.e. the database is in full archival mode).
-        uint64 pruning_horizon = 4;
-        // The current geometric mean of the pow of the chain tip, or `None` if there is no chain
-        bytes accumulated_difficulty = 5;
+    // The current chain height, or the block number of the longest valid chain, or `None` if there is no chain
+    uint64 height_of_longest_chain = 1;
+    // The block hash of the current tip of the longest valid chain, or `None` for an empty chain
+    bytes best_block = 2;
+    // The number of blocks back from the tip that this database tracks. A value of 0 indicates that all blocks are
+    // tracked (i.e. the database is in full archival mode).
+    uint64 pruning_horizon = 4;
+    // The current geometric mean of the pow of the chain tip, or `None` if there is no chain
+    bytes accumulated_difficulty = 5;
 }
 
 // This is the message that is returned for a miner after it asks for a new block.

--- a/applications/tari_base_node/src/main.rs
+++ b/applications/tari_base_node/src/main.rs
@@ -220,6 +220,7 @@ fn main_inner() -> Result<(), ExitCodes> {
             rt.handle().clone(),
             ctx.local_node(),
             node_config.clone(),
+            ctx.state_machine(),
         );
 
         rt.spawn(run_grpc(grpc, node_config.grpc_base_node_address, shutdown.to_signal()));

--- a/applications/tari_merge_mining_proxy/src/main.rs
+++ b/applications/tari_merge_mining_proxy/src/main.rs
@@ -49,7 +49,7 @@ async fn main() -> Result<(), MmProxyError> {
     let config = initialize()?;
 
     let addr = config.proxy_host_address;
-    println!("Listening on {}...", addr);
+    println!("\nListening on {}...\n", addr);
 
     let config = MergeMiningProxyConfig::from(config);
     let xmrig_service = MergeMiningProxyService::new(config, BlockTemplateRepository::new());

--- a/applications/tari_merge_mining_proxy/src/test.rs
+++ b/applications/tari_merge_mining_proxy/src/test.rs
@@ -33,6 +33,7 @@ fn default_test_config() -> MergeMiningProxyConfig {
         monerod_use_auth: false,
         grpc_base_node_address: "127.0.0.1:9999".parse().unwrap(),
         grpc_console_wallet_address: "127.0.0.1:9998".parse().unwrap(),
+        proxy_host_address: "127.0.0.1:9997".parse().unwrap(),
     }
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Initial sync status is now provided via gRPC to the merge mining proxy; this will enable more efficient use of computing resources when the initial blockchain sync of the linked base node has not been achieved yet. In this implementation, the merge mining proxy will wait for initial sync to be achieved before instructing XMRig to start mining, as otherwise, it cannot provide a valid Tari block template to mine on.

Typical user feedback in the merge mining proxy with XMRig running and if the base node is not synced at startup would be:
```
Listening on 127.0.0.1:7878...

Initial base node sync not achieved, current height at #7039, waiting...
Initial base node sync not achieved, current height at #7053, waiting...
Initial base node sync not achieved, current height at #7064, waiting...
Initial base node sync not achieved, current height at #7119, waiting...
Initial base node sync not achieved, current height at #7174, waiting...
Initial base node sync not achieved, current height at #7225, waiting...
Initial base node sync not achieved, current height at #7269, waiting...
Initial base node sync not achieved, current height at #7329, waiting...
Initial base node sync not achieved, current height at #7384, waiting...
Initial base node sync not achieved, current height at #7441, waiting...
Initial base node sync not achieved, current height at #7459, waiting...
Initial base node sync not achieved, current height at #7519, waiting...
Initial base node sync not achieved, current height at #7568, waiting...
Initial base node sync not achieved, current height at #7615, waiting...
Initial base node sync not achieved, current height at #7719, waiting...
Initial base node sync not achieved, current height at #7777, waiting...
Initial base node sync not achieved, current height at #7794, waiting...
Initial base node sync not achieved, current height at #7859, waiting...
Initial base node sync not achieved, current height at #7900, waiting...
Initial base node sync achieved, continuing

Listening on 127.0.0.1:7878...
```

and if the base node is synced at startup it would only be:
```
Listening on 127.0.0.1:7878...
```

## Motivation and Context
After a fresh installation, or after a restart after some time, if a user start all (base node, console wallet, merge mining proxy, XMrig), merge mining should not start until the base node has achieved initial synced.

## How Has This Been Tested?
Tested with all components in Ubuntu Linux and Windows 10.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [X] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [X] I'm merging against the `development` branch.
* [X] I ran `cargo-fmt --all` before pushing.
* [X] I ran `cargo test` successfully before submitting my PR.
* [X] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
