### PR TITLE
DHT connectivity waits for comms connectivity before starting

### DIFF
--- a/comms/src/connectivity/manager.rs
+++ b/comms/src/connectivity/manager.rs
@@ -192,6 +192,9 @@ impl ConnectivityManagerActor {
         use ConnectivityRequest::*;
         trace!(target: LOG_TARGET, "Request: {:?}", req);
         match req {
+            WaitStarted(reply) => {
+                let _ = reply.send(());
+            },
             GetConnectivityStatus(reply) => {
                 let _ = reply.send(self.status);
             },

--- a/comms/src/test_utils/mocks/connectivity_manager.rs
+++ b/comms/src/test_utils/mocks/connectivity_manager.rs
@@ -184,6 +184,7 @@ impl ConnectivityManagerMock {
                     .send(self.state.active_conns.lock().await.values().cloned().collect())
                     .unwrap();
             },
+            WaitStarted(reply) => reply.send(()).unwrap(),
         }
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Fix for a race condition that could cause the DHT connectivity actor to
start before seed peers are added. In this case, the actor would wait two minutes
before being able to connect to seed peers.

The DHT connectivity actor now waits for the comms connectivity actor to
start before continuing.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Integration tests can fail because of this race condition. 
This may reduce the time to start connecting for newly initialised base nodes. 
