### PR TITLE
Fix for xmrig powershell script

### DIFF
--- a/buildtools/get-xmrig-win.ps1
+++ b/buildtools/get-xmrig-win.ps1
@@ -4,6 +4,7 @@ echo ""
 echo ""
 echo ""
 echo "XMRig repo: '$env:xmrig_repo'"
-$url = (Invoke-WebRequest "$env:xmrig_repo" | ConvertFrom-Json).assets.browser_download_url | Select-String -Pattern 'msvc-win64.zip'
+$url = (Invoke-WebRequest "$env:xmrig_repo" -UseBasicParsing | ConvertFrom-Json).assets.browser_download_url | `
+    Select-String -Pattern 'msvc-win64.zip'
 echo "Install from '$url'"
 Invoke-WebRequest "$url" -outfile "$env:TEMP\$env:xmrig_zip"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Small fix for the xmrig download script, I recently formatted and ran into this issue 

_"The response content cannot be parsed because the Internet Explorer engine is not available, or Internet Explorer's first-launch configuration is not complete. Specify the UseBasicParsing parameter and try again."_

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
https://stackoverflow.com/a/38054505 
_"This parameter is required when Internet Explorer is not installed on the computers"_ 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
manually on a new windows 10 install

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch.
* [x] I ran `cargo-fmt --all` before pushing.
* [ ] I ran `cargo test` successfully before submitting my PR.
* [x] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
