### PR TITLE
Move ChainMetadata to `tari_common_types` crate to fix wallet_ffi dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3701,6 +3701,7 @@ version = "0.6.1"
 dependencies = [
  "prost",
  "prost-types",
+ "tari_common_types",
  "tari_core",
  "tari_crypto",
  "tonic",
@@ -3796,6 +3797,14 @@ dependencies = [
  "tari_test_utils",
  "tempfile",
  "toml 0.5.6",
+]
+
+[[package]]
+name = "tari_common_types"
+version = "0.1.0"
+dependencies = [
+ "serde 1.0.116",
+ "tari_crypto",
 ]
 
 [[package]]
@@ -3970,6 +3979,7 @@ dependencies = [
  "strum",
  "strum_macros 0.17.1",
  "tari_common",
+ "tari_common_types",
  "tari_comms",
  "tari_comms_dht",
  "tari_comms_rpc_macros",
@@ -4231,6 +4241,7 @@ dependencies = [
  "rand 0.7.3",
  "serde 1.0.116",
  "serde_json",
+ "tari_common_types",
  "tari_comms",
  "tari_comms_dht",
  "tari_core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 
 members = [
     "base_layer/core",
+    "base_layer/common_types",
     "base_layer/key_manager",
     "base_layer/mmr",
     "base_layer/p2p",

--- a/applications/tari_app_grpc/Cargo.toml
+++ b/applications/tari_app_grpc/Cargo.toml
@@ -8,6 +8,7 @@ version = "0.6.1"
 edition = "2018"
 
 [dependencies]
+tari_common_types = { version = "^0.1", path = "../../base_layer/common_types"}
 tari_core = {  path = "../../base_layer/core"}
 tari_crypto = { version = "^0.8" }
 

--- a/base_layer/common_types/Cargo.toml
+++ b/base_layer/common_types/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "tari_common_types"
+authors = ["The Tari Development Community"]
+description = "Tari cryptocurrency common types"
+license = "BSD-3-Clause"
+version = "0.1.0"
+edition = "2018"
+
+[dependencies]
+tari_crypto = { version = "^0.8" }
+
+serde = { version = "1.0.106", features = ["derive"] }

--- a/base_layer/common_types/src/chain_metadata.rs
+++ b/base_layer/common_types/src/chain_metadata.rs
@@ -20,10 +20,9 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use crate::blocks::blockheader::BlockHash;
+use crate::types::BlockHash;
 use serde::{Deserialize, Serialize};
 use std::fmt::{Display, Error, Formatter};
-
 use tari_crypto::tari_utilities::hex::Hex;
 
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize, Hash)]
@@ -130,38 +129,6 @@ impl Display for ChainMetadata {
         fmt.write_str(&format!("Pruning horizon : {}\n", self.pruning_horizon))?;
         fmt.write_str(&format!("Effective pruned height : {}\n", self.effective_pruned_height))?;
         Ok(())
-    }
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct InProgressHorizonSyncState {
-    pub metadata: ChainMetadata,
-    pub initial_kernel_checkpoint_count: u64,
-    pub initial_utxo_checkpoint_count: u64,
-    pub initial_rangeproof_checkpoint_count: u64,
-}
-
-impl InProgressHorizonSyncState {
-    pub fn new_with_metadata(metadata: ChainMetadata) -> Self {
-        Self {
-            metadata,
-            initial_kernel_checkpoint_count: 0,
-            initial_utxo_checkpoint_count: 0,
-            initial_rangeproof_checkpoint_count: 0,
-        }
-    }
-}
-
-impl Display for InProgressHorizonSyncState {
-    fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), Error> {
-        write!(
-            f,
-            "metadata = {}, #kernel checkpoints = ({}), #UTXO checkpoints = ({}), #range proof checkpoints = ({})",
-            self.metadata,
-            self.initial_kernel_checkpoint_count,
-            self.initial_utxo_checkpoint_count,
-            self.initial_rangeproof_checkpoint_count,
-        )
     }
 }
 

--- a/base_layer/common_types/src/lib.rs
+++ b/base_layer/common_types/src/lib.rs
@@ -20,17 +20,5 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use crate::tari_rpc as grpc;
-use tari_common_types::chain_metadata::ChainMetadata;
-
-impl From<ChainMetadata> for grpc::MetaData {
-    fn from(meta: ChainMetadata) -> Self {
-        let diff = meta.accumulated_difficulty();
-        Self {
-            height_of_longest_chain: meta.height_of_longest_chain(),
-            best_block: meta.best_block().clone(),
-            pruning_horizon: meta.pruning_horizon(),
-            accumulated_difficulty: diff.to_be_bytes().to_vec(),
-        }
-    }
-}
+pub mod chain_metadata;
+pub mod types;

--- a/base_layer/common_types/src/types.rs
+++ b/base_layer/common_types/src/types.rs
@@ -20,17 +20,5 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use crate::tari_rpc as grpc;
-use tari_common_types::chain_metadata::ChainMetadata;
-
-impl From<ChainMetadata> for grpc::MetaData {
-    fn from(meta: ChainMetadata) -> Self {
-        let diff = meta.accumulated_difficulty();
-        Self {
-            height_of_longest_chain: meta.height_of_longest_chain(),
-            best_block: meta.best_block().clone(),
-            pruning_horizon: meta.pruning_horizon(),
-            accumulated_difficulty: diff.to_be_bytes().to_vec(),
-        }
-    }
-}
+pub const BLOCK_HASH_LENGTH: usize = 32;
+pub type BlockHash = Vec<u8>;

--- a/base_layer/core/Cargo.toml
+++ b/base_layer/core/Cargo.toml
@@ -19,6 +19,7 @@ avx2 = ["tari_crypto/avx2"]
 
 [dependencies]
 tari_common = { version = "^0.2", path = "../../common"}
+tari_common_types = { version = "^0.1", path = "../../base_layer/common_types"}
 tari_comms = { version = "^0.2", path = "../../comms"}
 tari_comms_dht = { version = "^0.2.1", path = "../../comms/dht"}
 tari_comms_rpc_macros = { version = "^0.1", path = "../../comms/rpc_macros"}

--- a/base_layer/core/src/base_node/chain_metadata_service/handle.rs
+++ b/base_layer/core/src/base_node/chain_metadata_service/handle.rs
@@ -20,11 +20,11 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use crate::chain_storage::ChainMetadata;
 use std::{
     fmt::{Display, Error, Formatter},
     sync::Arc,
 };
+use tari_common_types::chain_metadata::ChainMetadata;
 use tari_comms::peer_manager::NodeId;
 use tokio::sync::broadcast;
 

--- a/base_layer/core/src/base_node/chain_metadata_service/service.rs
+++ b/base_layer/core/src/base_node/chain_metadata_service/service.rs
@@ -30,13 +30,14 @@ use crate::{
         comms_interface::{BlockEvent, LocalNodeCommsInterface},
         proto,
     },
-    chain_storage::{BlockAddResult, ChainMetadata},
+    chain_storage::BlockAddResult,
 };
 use futures::stream::StreamExt;
 use log::*;
 use prost::Message;
 use std::{convert::TryInto, sync::Arc, time::Instant};
 use tari_common::log_if_error;
+use tari_common_types::chain_metadata::ChainMetadata;
 use tari_comms::{
     connectivity::{ConnectivityEvent, ConnectivityRequester},
     message::MessageExt,

--- a/base_layer/core/src/base_node/comms_interface/comms_response.rs
+++ b/base_layer/core/src/base_node/comms_interface/comms_response.rs
@@ -22,7 +22,7 @@
 
 use crate::{
     blocks::{blockheader::BlockHeader, Block, NewBlockTemplate},
-    chain_storage::{ChainMetadata, HistoricalBlock},
+    chain_storage::HistoricalBlock,
     proof_of_work::Difficulty,
     transactions::{
         transaction::{TransactionKernel, TransactionOutput},
@@ -31,6 +31,7 @@ use crate::{
 };
 use serde::{Deserialize, Serialize};
 use std::fmt::{self, Display, Formatter};
+use tari_common_types::chain_metadata::ChainMetadata;
 
 /// API Response enum
 #[derive(Debug, Serialize, Deserialize, Clone)]

--- a/base_layer/core/src/base_node/comms_interface/local_interface.rs
+++ b/base_layer/core/src/base_node/comms_interface/local_interface.rs
@@ -29,7 +29,7 @@ use crate::{
         NodeCommsResponse,
     },
     blocks::{Block, BlockHeader, NewBlockTemplate},
-    chain_storage::{ChainMetadata, HistoricalBlock, MmrTree},
+    chain_storage::{HistoricalBlock, MmrTree},
     proof_of_work::PowAlgorithm,
     transactions::{
         transaction::TransactionOutput,
@@ -37,6 +37,7 @@ use crate::{
     },
 };
 use std::sync::Arc;
+use tari_common_types::chain_metadata::ChainMetadata;
 use tari_service_framework::{reply_channel::SenderService, Service};
 use tokio::sync::broadcast;
 

--- a/base_layer/core/src/base_node/comms_interface/outbound_interface.rs
+++ b/base_layer/core/src/base_node/comms_interface/outbound_interface.rs
@@ -23,7 +23,7 @@
 use crate::{
     base_node::comms_interface::{error::CommsInterfaceError, NodeCommsRequest, NodeCommsResponse},
     blocks::{blockheader::BlockHeader, NewBlock},
-    chain_storage::{ChainMetadata, HistoricalBlock, MmrTree},
+    chain_storage::{HistoricalBlock, MmrTree},
     transactions::{
         transaction::{TransactionKernel, TransactionOutput},
         types::HashOutput,
@@ -31,6 +31,7 @@ use crate::{
 };
 use futures::channel::mpsc::UnboundedSender;
 use log::*;
+use tari_common_types::chain_metadata::ChainMetadata;
 use tari_comms::peer_manager::NodeId;
 use tari_service_framework::{reply_channel::SenderService, Service};
 

--- a/base_layer/core/src/base_node/proto/chain_metadata.rs
+++ b/base_layer/core/src/base_node/proto/chain_metadata.rs
@@ -21,8 +21,8 @@
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 use super::base_node as proto;
-use crate::chain_storage::ChainMetadata;
 use std::convert::TryFrom;
+use tari_common_types::chain_metadata::ChainMetadata;
 
 impl TryFrom<proto::ChainMetadata> for ChainMetadata {
     type Error = String;

--- a/base_layer/core/src/base_node/proto/mod.rs
+++ b/base_layer/core/src/base_node/proto/mod.rs
@@ -23,7 +23,7 @@
 #[cfg(feature = "base_node_proto")]
 pub use crate::proto::generated::base_node;
 
-#[cfg(feature = "base_node")]
+#[cfg(any(feature = "base_node", feature = "base_node_proto"))]
 pub mod chain_metadata;
 #[cfg(feature = "base_node")]
 pub mod mmr_tree;

--- a/base_layer/core/src/base_node/service/blockchain_state/handle.rs
+++ b/base_layer/core/src/base_node/service/blockchain_state/handle.rs
@@ -23,7 +23,6 @@
 use super::error::BlockchainStateServiceError;
 use crate::{
     blocks::{Block, BlockHeader},
-    chain_storage::ChainMetadata,
     transactions::types::HashOutput,
 };
 use futures::{
@@ -31,6 +30,7 @@ use futures::{
     SinkExt,
 };
 use std::ops::{Bound, RangeBounds};
+use tari_common_types::chain_metadata::ChainMetadata;
 
 type ReplySender<T> = oneshot::Sender<Result<T, BlockchainStateServiceError>>;
 

--- a/base_layer/core/src/base_node/state_machine_service/states/block_sync.rs
+++ b/base_layer/core/src/base_node/state_machine_service/states/block_sync.rs
@@ -36,7 +36,7 @@ use crate::{
         },
     },
     blocks::{blockheader::BlockHeader, Block},
-    chain_storage::{async_db, BlockAddResult, BlockchainBackend, ChainMetadata, ChainStorageError},
+    chain_storage::{async_db, BlockAddResult, BlockchainBackend, ChainStorageError},
     proof_of_work::PowError,
 };
 use core::cmp::min;
@@ -47,6 +47,7 @@ use std::{
     sync::Arc,
     time::Duration,
 };
+use tari_common_types::chain_metadata::ChainMetadata;
 use tari_comms::{connectivity::ConnectivityError, peer_manager::PeerManagerError};
 use tari_crypto::tari_utilities::{hex::Hex, Hashable};
 use thiserror::Error;

--- a/base_layer/core/src/base_node/state_machine_service/states/events_and_states.rs
+++ b/base_layer/core/src/base_node/state_machine_service/states/events_and_states.rs
@@ -20,22 +20,20 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use crate::{
-    base_node::state_machine_service::states::{
-        BlockSyncInfo,
-        BlockSyncStrategy,
-        HeaderSync,
-        HorizonStateSync,
-        Listening,
-        ListeningInfo,
-        Shutdown,
-        Starting,
-        SyncPeers,
-        Waiting,
-    },
-    chain_storage::ChainMetadata,
+use crate::base_node::state_machine_service::states::{
+    BlockSyncInfo,
+    BlockSyncStrategy,
+    HeaderSync,
+    HorizonStateSync,
+    Listening,
+    ListeningInfo,
+    Shutdown,
+    Starting,
+    SyncPeers,
+    Waiting,
 };
 use std::fmt::{Display, Error, Formatter};
+use tari_common_types::chain_metadata::ChainMetadata;
 
 #[derive(Clone, Debug, PartialEq)]
 pub enum BaseNodeState {

--- a/base_layer/core/src/base_node/state_machine_service/states/header_sync.rs
+++ b/base_layer/core/src/base_node/state_machine_service/states/header_sync.rs
@@ -35,12 +35,13 @@ use crate::{
         BaseNodeStateMachine,
     },
     blocks::BlockHeader,
-    chain_storage::{async_db, BlockchainBackend, BlockchainDatabase, ChainMetadata, ChainStorageError},
+    chain_storage::{async_db, BlockchainBackend, BlockchainDatabase, ChainStorageError},
     iterators::VecChunkIter,
     validation::ValidationError,
 };
 use log::*;
 use std::cmp;
+use tari_common_types::chain_metadata::ChainMetadata;
 use tari_crypto::tari_utilities::Hashable;
 use thiserror::Error;
 use tokio::{task, task::spawn_blocking};

--- a/base_layer/core/src/base_node/state_machine_service/states/horizon_state_sync/state_sync.rs
+++ b/base_layer/core/src/base_node/state_machine_service/states/horizon_state_sync/state_sync.rs
@@ -34,7 +34,7 @@ use crate::{
         },
         BaseNodeStateMachine,
     },
-    chain_storage::{async_db, BlockchainBackend, BlockchainDatabase, ChainMetadata, MmrTree},
+    chain_storage::{async_db, BlockchainBackend, BlockchainDatabase, MmrTree},
     iterators::NonOverlappingIntegerPairIter,
     transactions::{
         transaction::{TransactionKernel, TransactionOutput},
@@ -43,6 +43,7 @@ use crate::{
 };
 use croaring::Bitmap;
 use log::*;
+use tari_common_types::chain_metadata::ChainMetadata;
 use tari_crypto::tari_utilities::Hashable;
 // use tokio::task::spawn_blocking;
 

--- a/base_layer/core/src/base_node/state_machine_service/states/listening.rs
+++ b/base_layer/core/src/base_node/state_machine_service/states/listening.rs
@@ -28,7 +28,7 @@ use crate::{
             BaseNodeStateMachine,
         },
     },
-    chain_storage::{async_db, BlockchainBackend, ChainMetadata},
+    chain_storage::{async_db, BlockchainBackend},
 };
 
 use futures::StreamExt;
@@ -38,6 +38,7 @@ use std::{
     fmt::{Display, Formatter},
     ops::Deref,
 };
+use tari_common_types::chain_metadata::ChainMetadata;
 use tari_crypto::tari_utilities::epoch_time::EpochTime;
 use tokio::sync::broadcast;
 

--- a/base_layer/core/src/blocks/block.rs
+++ b/base_layer/core/src/blocks/block.rs
@@ -23,7 +23,7 @@
 // Portions of this file were originally copyrighted (c) 2018 The Grin Developers, issued under the Apache License,
 // Version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0.
 use crate::{
-    blocks::{BlockHash, BlockHeader},
+    blocks::BlockHeader,
     consensus::ConsensusConstants,
     proof_of_work::ProofOfWork,
     tari_utilities::hex::Hex,
@@ -37,6 +37,7 @@ use crate::{
 use log::*;
 use serde::{Deserialize, Serialize};
 use std::fmt::{Display, Formatter};
+use tari_common_types::types::BlockHash;
 use tari_crypto::tari_utilities::Hashable;
 use thiserror::Error;
 

--- a/base_layer/core/src/blocks/blockheader.rs
+++ b/base_layer/core/src/blocks/blockheader.rs
@@ -56,11 +56,9 @@ use std::{
     fmt,
     fmt::{Display, Error, Formatter},
 };
+use tari_common_types::types::{BlockHash, BLOCK_HASH_LENGTH};
 use tari_crypto::tari_utilities::{epoch_time::EpochTime, hex::Hex, ByteArray, Hashable};
 use thiserror::Error;
-
-pub const BLOCK_HASH_LENGTH: usize = 32;
-pub type BlockHash = Vec<u8>;
 
 #[derive(Debug, Error)]
 pub enum BlockHeaderValidationError {

--- a/base_layer/core/src/blocks/mod.rs
+++ b/base_layer/core/src/blocks/mod.rs
@@ -28,6 +28,6 @@ mod new_blockheader_template;
 pub mod genesis_block;
 
 pub use block::{Block, BlockBuilder, BlockValidationError, NewBlock};
-pub use blockheader::{BlockHash, BlockHeader, BlockHeaderValidationError};
+pub use blockheader::{BlockHeader, BlockHeaderValidationError};
 pub use new_block_template::NewBlockTemplate;
 pub use new_blockheader_template::NewBlockHeaderTemplate;

--- a/base_layer/core/src/blocks/new_blockheader_template.rs
+++ b/base_layer/core/src/blocks/new_blockheader_template.rs
@@ -21,15 +21,13 @@
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 use crate::{
-    blocks::{
-        blockheader::{hash_serializer, BlockHeader},
-        BlockHash,
-    },
+    blocks::blockheader::{hash_serializer, BlockHeader},
     proof_of_work::ProofOfWork,
     transactions::types::BlindingFactor,
 };
 use serde::{Deserialize, Serialize};
 use std::fmt::{Display, Error, Formatter};
+use tari_common_types::types::BlockHash;
 use tari_crypto::tari_utilities::hex::Hex;
 
 /// The NewBlockHeaderTemplate is used for the construction of a new mineable block. It contains all the metadata for

--- a/base_layer/core/src/chain_storage/async_db.rs
+++ b/base_layer/core/src/chain_storage/async_db.rs
@@ -21,10 +21,9 @@
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 use crate::{
-    blocks::{Block, BlockHash, BlockHeader, NewBlockTemplate},
+    blocks::{Block, BlockHeader, NewBlockTemplate},
     chain_storage::{
         blockchain_database::BlockAddResult,
-        metadata::ChainMetadata,
         BlockchainBackend,
         BlockchainDatabase,
         ChainStorageError,
@@ -42,6 +41,7 @@ use crate::{
 use log::*;
 use rand::{rngs::OsRng, RngCore};
 use std::{sync::Arc, time::Instant};
+use tari_common_types::{chain_metadata::ChainMetadata, types::BlockHash};
 use tari_mmr::Hash;
 
 const LOG_TARGET: &str = "c::bn::async_db";

--- a/base_layer/core/src/chain_storage/blockchain_database.rs
+++ b/base_layer/core/src/chain_storage/blockchain_database.rs
@@ -20,7 +20,7 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 use crate::{
-    blocks::{blockheader::BlockHash, Block, BlockHeader, NewBlockTemplate},
+    blocks::{Block, BlockHeader, NewBlockTemplate},
     chain_storage::{
         consts::{
             BLOCKCHAIN_DATABASE_ORPHAN_STORAGE_CAPACITY,
@@ -31,7 +31,6 @@ use crate::{
         error::ChainStorageError,
         BlockAccumulatedData,
         BlockHeaderAccumulatedData,
-        ChainMetadata,
         HistoricalBlock,
         InProgressHorizonSyncState,
     },
@@ -55,6 +54,7 @@ use std::{
     time::Instant,
 };
 use strum_macros::Display;
+use tari_common_types::{chain_metadata::ChainMetadata, types::BlockHash};
 use tari_crypto::{
     hash::blake2::Blake256,
     tari_utilities::{epoch_time::EpochTime, hex::Hex, Hashable},

--- a/base_layer/core/src/chain_storage/db_transaction.rs
+++ b/base_layer/core/src/chain_storage/db_transaction.rs
@@ -20,7 +20,7 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 use crate::{
-    blocks::{blockheader::BlockHash, Block, BlockHeader},
+    blocks::{Block, BlockHeader},
     chain_storage::{
         error::ChainStorageError,
         BlockAccumulatedData,
@@ -40,6 +40,7 @@ use std::{
     sync::Arc,
 };
 use strum_macros::Display;
+use tari_common_types::types::BlockHash;
 use tari_crypto::tari_utilities::{
     hex::{to_hex, Hex},
     Hashable,

--- a/base_layer/core/src/chain_storage/horizon_sync_state.rs
+++ b/base_layer/core/src/chain_storage/horizon_sync_state.rs
@@ -20,17 +20,38 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use crate::tari_rpc as grpc;
+use serde::{Deserialize, Serialize};
+use std::fmt::{Display, Error, Formatter};
 use tari_common_types::chain_metadata::ChainMetadata;
 
-impl From<ChainMetadata> for grpc::MetaData {
-    fn from(meta: ChainMetadata) -> Self {
-        let diff = meta.accumulated_difficulty();
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct InProgressHorizonSyncState {
+    pub metadata: ChainMetadata,
+    pub initial_kernel_checkpoint_count: u64,
+    pub initial_utxo_checkpoint_count: u64,
+    pub initial_rangeproof_checkpoint_count: u64,
+}
+
+impl InProgressHorizonSyncState {
+    pub fn new_with_metadata(metadata: ChainMetadata) -> Self {
         Self {
-            height_of_longest_chain: meta.height_of_longest_chain(),
-            best_block: meta.best_block().clone(),
-            pruning_horizon: meta.pruning_horizon(),
-            accumulated_difficulty: diff.to_be_bytes().to_vec(),
+            metadata,
+            initial_kernel_checkpoint_count: 0,
+            initial_utxo_checkpoint_count: 0,
+            initial_rangeproof_checkpoint_count: 0,
         }
+    }
+}
+
+impl Display for InProgressHorizonSyncState {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), Error> {
+        write!(
+            f,
+            "metadata = {}, #kernel checkpoints = ({}), #UTXO checkpoints = ({}), #range proof checkpoints = ({})",
+            self.metadata,
+            self.initial_kernel_checkpoint_count,
+            self.initial_utxo_checkpoint_count,
+            self.initial_rangeproof_checkpoint_count,
+        )
     }
 }

--- a/base_layer/core/src/chain_storage/lmdb_db/lmdb_db.rs
+++ b/base_layer/core/src/chain_storage/lmdb_db/lmdb_db.rs
@@ -20,10 +20,7 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 use crate::{
-    blocks::{
-        blockheader::{BlockHash, BlockHeader},
-        Block,
-    },
+    blocks::{blockheader::BlockHeader, Block},
     chain_storage::{
         blockchain_database::BlockchainBackend,
         db_transaction::{DbKey, DbKeyValuePair, DbTransaction, DbValue, MetadataValue, MmrTree, WriteOperation},
@@ -83,6 +80,7 @@ use std::{
     sync::Arc,
     time::Instant,
 };
+use tari_common_types::types::BlockHash;
 use tari_crypto::tari_utilities::{epoch_time::EpochTime, hash::Hashable, hex::Hex};
 use tari_mmr::Hash;
 use tari_storage::lmdb_store::{db, LMDBBuilder, LMDBConfig, LMDBStore};

--- a/base_layer/core/src/chain_storage/mod.rs
+++ b/base_layer/core/src/chain_storage/mod.rs
@@ -76,9 +76,7 @@ pub use lmdb_db::{
     LMDB_DB_UTXOS,
 };
 
-mod metadata;
 use croaring::Bitmap;
-pub use metadata::{ChainMetadata, InProgressHorizonSyncState};
 use serde::{
     de::{MapAccess, SeqAccess, Visitor},
     ser::SerializeStruct,
@@ -88,6 +86,9 @@ use serde::{
     Serializer,
 };
 use std::fmt;
+use tari_common_types::chain_metadata::ChainMetadata;
+pub mod horizon_sync_state;
+pub use horizon_sync_state::InProgressHorizonSyncState;
 use tari_mmr::pruned_hashset::PrunedHashSet;
 
 pub mod async_db;

--- a/base_layer/core/src/proto/block.rs
+++ b/base_layer/core/src/proto/block.rs
@@ -22,13 +22,14 @@
 
 use super::core as proto;
 use crate::{
-    blocks::{blockheader::BLOCK_HASH_LENGTH, Block, BlockHeader, NewBlock, NewBlockHeaderTemplate, NewBlockTemplate},
+    blocks::{Block, BlockHeader, NewBlock, NewBlockHeaderTemplate, NewBlockTemplate},
     chain_storage::HistoricalBlock,
     proof_of_work::{Difficulty, PowAlgorithm, ProofOfWork},
     transactions::types::BlindingFactor,
 };
 use prost_types::Timestamp;
 use std::convert::{TryFrom, TryInto};
+use tari_common_types::types::BLOCK_HASH_LENGTH;
 use tari_crypto::tari_utilities::{epoch_time::EpochTime, ByteArray};
 
 /// Utility function that converts a `prost::Timestamp` to a `chrono::DateTime`

--- a/base_layer/core/src/test_helpers/blockchain.rs
+++ b/base_layer/core/src/test_helpers/blockchain.rs
@@ -29,7 +29,6 @@ use crate::{
         BlockchainBackend,
         BlockchainDatabase,
         BlockchainDatabaseConfig,
-        ChainMetadata,
         ChainStorageError,
         DbKey,
         DbTransaction,
@@ -56,6 +55,7 @@ use crate::{
     },
 };
 use std::{ops::Deref, path::PathBuf};
+use tari_common_types::chain_metadata::ChainMetadata;
 use tari_crypto::tari_utilities::epoch_time::EpochTime;
 use tari_storage::lmdb_store::LMDBConfig;
 use tari_test_utils::paths::create_temporary_data_path;

--- a/base_layer/core/tests/chain_storage_tests/chain_storage.rs
+++ b/base_layer/core/tests/chain_storage_tests/chain_storage.rs
@@ -39,8 +39,9 @@ use crate::helpers::{
 use croaring::Bitmap;
 use rand::{rngs::OsRng, RngCore};
 use std::thread;
+use tari_common_types::types::BlockHash;
 use tari_core::{
-    blocks::{genesis_block, Block, BlockHash, BlockHeader},
+    blocks::{genesis_block, Block, BlockHeader},
     chain_storage::{
         create_lmdb_database,
         BlockAddResult,

--- a/base_layer/wallet/Cargo.toml
+++ b/base_layer/wallet/Cargo.toml
@@ -7,6 +7,7 @@ version = "0.2.12"
 edition = "2018"
 
 [dependencies]
+tari_common_types = { version = "^0.1", path = "../../base_layer/common_types"}
 tari_comms = { version = "^0.2", path = "../../comms"}
 tari_comms_dht = { version = "^0.2.1", path = "../../comms/dht" }
 tari_crypto = { version = "^0.8" }

--- a/base_layer/wallet/src/base_node_service/handle.rs
+++ b/base_layer/wallet/src/base_node_service/handle.rs
@@ -24,7 +24,8 @@ use super::{error::BaseNodeServiceError, service::BaseNodeState};
 use futures::{stream::Fuse, StreamExt};
 use std::sync::Arc;
 use tari_comms::peer_manager::Peer;
-use tari_core::chain_storage::ChainMetadata;
+
+use tari_common_types::chain_metadata::ChainMetadata;
 use tari_service_framework::reply_channel::SenderService;
 use tokio::sync::broadcast;
 use tower::Service;

--- a/base_layer/wallet/src/base_node_service/service.rs
+++ b/base_layer/wallet/src/base_node_service/service.rs
@@ -36,21 +36,19 @@ use futures::{pin_mut, Stream, StreamExt};
 use log::*;
 use rand::rngs::OsRng;
 use std::convert::TryInto;
+use tari_common_types::chain_metadata::ChainMetadata;
 use tari_comms::peer_manager::Peer;
 use tari_comms_dht::{domain_message::OutboundDomainMessage, outbound::OutboundMessageRequester};
-use tari_core::{
-    base_node::{
-        generate_request_key,
-        proto::{
-            base_node as BaseNodeProto,
-            base_node::{
-                base_node_service_request::Request as BaseNodeRequestProto,
-                base_node_service_response::Response as BaseNodeResponseProto,
-            },
+use tari_core::base_node::{
+    generate_request_key,
+    proto::{
+        base_node as BaseNodeProto,
+        base_node::{
+            base_node_service_request::Request as BaseNodeRequestProto,
+            base_node_service_response::Response as BaseNodeResponseProto,
         },
-        RequestKey,
     },
-    chain_storage::ChainMetadata,
+    RequestKey,
 };
 use tari_p2p::{domain_message::DomainMessage, tari_message::TariMessageType};
 use tari_service_framework::reply_channel::Receiver;


### PR DESCRIPTION
## Description

There is an existing issue when building ‘wallet_ffi’ for Android or iOS where the `croaring` library used in `tari_core`. To avoid this issue we have been using feature flags to exclude the parts of `tari_core` that uses `croaring`. However, now that we need the ChainMetadata struct to deserialise the chain metadata  message in the wallet made it difficult to use the feature flags for this purpose.  

To fix this issue this PR moves the ChainMetadata and BlockHash types to a new crate called `tari_common_types` so we can use this type without needing to include the `croaring` dependancy.

## How Has This Been Tested?
Existing tests 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [x] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch.
* [x] I ran `cargo-fmt --all` before pushing.
* [x] I ran `cargo test` successfully before submitting my PR.
* [ ] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
