### PR TITLE
[wallet] Fix bug where cancelled output is spent

### DIFF
--- a/base_layer/core/src/mining/miner.rs
+++ b/base_layer/core/src/mining/miner.rs
@@ -411,7 +411,7 @@ impl Miner {
         info!(target: LOG_TARGET, "Mined a block: {}", block);
         match self.node_interface.submit_block(block, Broadcast::from(true)).await {
             Ok(_) => {
-                trace!("Miner successfully submitted block");
+                trace!(target: LOG_TARGET, "Miner successfully submitted block");
                 Ok(())
             },
             Err(CommsInterfaceError::ChainStorageError(e)) => {

--- a/base_layer/wallet/src/output_manager_service/storage/sqlite_db.rs
+++ b/base_layer/wallet/src/output_manager_service/storage/sqlite_db.rs
@@ -885,7 +885,9 @@ impl OutputSql {
         conn: &SqliteConnection,
     ) -> Result<OutputSql, OutputManagerStorageError>
     {
+        let cancelled = OutputStatus::CancelledInbound as i32;
         Ok(outputs::table
+            .filter(outputs::status.ne(cancelled))
             .filter(outputs::commitment.eq(commitment))
             .first::<OutputSql>(conn)?)
     }

--- a/base_layer/wallet/tests/output_manager_service/storage.rs
+++ b/base_layer/wallet/tests/output_manager_service/storage.rs
@@ -544,3 +544,81 @@ pub async fn test_short_term_encumberance_sqlite_db() {
 
     test_short_term_encumberance(OutputManagerSqliteDatabase::new(connection, None)).await;
 }
+
+#[tokio_macros::test]
+pub async fn test_cancelled_outputs_excluded_sqlite_db() {
+    // reproduces the bug - https://github.com/tari-project/tari/issues/2443
+    let db_name = format!("{}.sqlite3", random_string(8).as_str());
+    let temp_dir = tempdir().unwrap();
+    let db_folder = temp_dir.path().to_str().unwrap().to_string();
+    let connection = run_migration_and_create_sqlite_connection(&format!("{}/{}", db_folder, db_name)).unwrap();
+    test_cancelled_outputs_excluded(OutputManagerSqliteDatabase::new(connection, None)).await;
+}
+
+pub async fn test_cancelled_outputs_excluded<T: OutputManagerBackend + 'static>(backend: T) {
+    let factories = CryptoFactories::default();
+
+    let db = OutputManagerDatabase::new(backend);
+
+    let (_ti, uo) = make_input(&mut OsRng, MicroTari::from(1000), &factories.commitment);
+    let uo = DbUnblindedOutput::from_unblinded_output(uo, &factories).unwrap();
+
+    // create cancelled txs with same output commitment
+    for _ in 1..=3 {
+        let pending_tx = PendingTransactionOutputs {
+            tx_id: OsRng.next_u64(),
+            outputs_to_be_spent: vec![],
+            outputs_to_be_received: vec![uo.clone()],
+            timestamp: Utc::now().naive_utc() - ChronoDuration::from_std(Duration::from_millis(120_000_000)).unwrap(),
+            coinbase_block_height: None,
+        };
+        db.encumber_outputs(
+            pending_tx.tx_id,
+            pending_tx.outputs_to_be_spent.clone(),
+            pending_tx.outputs_to_be_received.clone(),
+        )
+        .await
+        .unwrap();
+        db.cancel_pending_transaction_outputs(pending_tx.tx_id).await.unwrap();
+    }
+
+    // add a confirmed tx with same output commitment
+    let pending_tx = PendingTransactionOutputs {
+        tx_id: OsRng.next_u64(),
+        outputs_to_be_spent: vec![],
+        outputs_to_be_received: vec![uo.clone()],
+        timestamp: Utc::now().naive_utc() - ChronoDuration::from_std(Duration::from_millis(120_000_000)).unwrap(),
+        coinbase_block_height: None,
+    };
+    db.add_pending_transaction_outputs(pending_tx.clone()).await.unwrap();
+    db.confirm_pending_transaction_outputs(pending_tx.tx_id).await.unwrap();
+
+    let balance = db.get_balance(None).await.unwrap();
+    assert_eq!(balance.available_balance, MicroTari(1000));
+
+    // spend the utxo
+    let pending_tx = PendingTransactionOutputs {
+        tx_id: OsRng.next_u64(),
+        outputs_to_be_spent: vec![uo.clone()],
+        outputs_to_be_received: vec![],
+        timestamp: Utc::now().naive_utc() - ChronoDuration::from_std(Duration::from_millis(120_000_000)).unwrap(),
+        coinbase_block_height: None,
+    };
+
+    db.encumber_outputs(
+        pending_tx.tx_id,
+        pending_tx.outputs_to_be_spent.clone(),
+        pending_tx.outputs_to_be_received.clone(),
+    )
+    .await
+    .unwrap();
+
+    db.confirm_encumbered_outputs(pending_tx.tx_id).await.unwrap();
+    db.confirm_pending_transaction_outputs(pending_tx.tx_id).await.unwrap();
+
+    // we should have 0 balance, as we spent the only utxo
+    // find_by_commitment was including cancelled outputs
+    // so it actually spent a cancelled output instead of the utxo
+    let balance = db.get_balance(None).await.unwrap();
+    assert_eq!(balance.available_balance, MicroTari(0));
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
During merge mining, sometimes a number of cancelled outputs are added to the wallet before the mined coinbase utxo.
When spending this valid utxo, the _cancelled_ output was marked as encumbered and then spent, instead of the valid utxo.
This led to the bug where after "spending" a utxo, it would still exist in the db as unspent. It would then be selected for transactions, but reported as spent and be unspendable.
Fundamentally the issue was that `OutputSql::find_by_commitment` was not excluding cancelled outputs.

If testing this on a wallet that already exhibits the issue, the sqlite db will have to be cleared of matching outputs that exist in both spent and unspent status. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #2443

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
cargo test, and manually checked in console wallet

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [x] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch.
* [x] I ran `cargo-fmt --all` before pushing.
* [ ] I ran `cargo test` successfully before submitting my PR.
* [x] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
