### PR TITLE
Fix error when duplicate orphan tips are inserted

### DIFF
--- a/base_layer/core/src/chain_storage/lmdb_db/lmdb.rs
+++ b/base_layer/core/src/chain_storage/lmdb_db/lmdb.rs
@@ -71,12 +71,13 @@ where
     txn.access().put(&db, key, &val_buf, put::NOOVERWRITE).map_err(|e| {
         error!(
             target: LOG_TARGET,
-            "Could not add insert value into lmdb transaction: {:?}", e
+            "Could not insert value into lmdb transaction: {:?}", e
         );
         ChainStorageError::AccessError(e.to_string())
     })
 }
 
+/// Note that calling this on a table that does not allow duplicates will replace it
 pub fn lmdb_insert_dup<K, V>(
     txn: &WriteTransaction<'_>,
     db: &Database,
@@ -91,7 +92,7 @@ where
     txn.access().put(&db, key, &val_buf, put::Flags::empty()).map_err(|e| {
         error!(
             target: LOG_TARGET,
-            "Could not add insert value into lmdb transaction: {:?}", e
+            "Could not insert value into lmdb transaction: {:?}", e
         );
         ChainStorageError::AccessError(e.to_string())
     })
@@ -106,7 +107,7 @@ where
     txn.access().put(&db, key, &val_buf, put::Flags::empty()).map_err(|e| {
         error!(
             target: LOG_TARGET,
-            "Could not add replace value into lmdb transaction: {:?}", e
+            "Could not replace value in lmdb transaction: {:?}", e
         );
         ChainStorageError::AccessError(e.to_string())
     })

--- a/base_layer/core/src/chain_storage/lmdb_db/lmdb_db.rs
+++ b/base_layer/core/src/chain_storage/lmdb_db/lmdb_db.rs
@@ -177,7 +177,7 @@ impl LMDBDatabase {
                     lmdb_delete(&write_txn, &self.orphan_chain_tips_db, hash)?;
                 },
                 WriteOperation::InsertOrphanChainTip(hash) => {
-                    lmdb_insert(&write_txn, &self.orphan_chain_tips_db, hash, hash)?;
+                    lmdb_replace(&write_txn, &self.orphan_chain_tips_db, hash, hash)?;
                 },
                 WriteOperation::DeleteBlock(hash) => {
                     for utxo in lmdb_delete_keys_starting_with::<Option<TransactionOutputRowData>>(

--- a/integration_tests/features/Propagation.feature
+++ b/integration_tests/features/Propagation.feature
@@ -14,10 +14,38 @@ Feature: Block Propagation
       | 4        | 10          | 5         |
       | 8        | 40          | 10        |
 
-@critical
+  @critical
   Scenario: Simple propagation
     Given I have 2 seed nodes
     And I have 4 base nodes connected to all seed nodes
     And I have a base node MINER connected to all seed nodes
     When I mine 5 blocks on MINER
     Then all nodes are at height 5
+
+  Scenario: Duplicate block is rejected
+    Given I have 1 seed nodes
+    And I have a base node MINER connected to all seed nodes
+    When I mine but don't submit a block BLOCKA on MINER
+    When I submit block BLOCKA to MINER
+    Then all nodes are at height 1
+    When I submit block BLOCKA to MINER
+    Then I receive an error containing 'Block exists'
+    And all nodes are at height 1
+    # Check that the base node continues to accept blocks
+    When I mine 1 blocks on MINER
+    Then all nodes are at height 2
+
+
+  Scenario: Submit orphan
+    Given I have 1 seed nodes
+    And I have a base node MINER connected to all seed nodes
+    When I mine but don't submit a block BLOCKA on MINER
+    And I update block BLOCKA's parent to be an orphan
+    When I submit block BLOCKA to MINER
+    Then I receive an error containing 'Orphan block'
+    Then all nodes are at height 1
+    # Do it twice to be sure
+    When I submit block BLOCKA to MINER
+    Then I receive an error containing 'Orphan block'
+    And all nodes are at height 1
+

--- a/integration_tests/features/support/steps.js
+++ b/integration_tests/features/support/steps.js
@@ -102,6 +102,17 @@ When(/I mine (\d+) blocks on (.*)/, {timeout: 600*1000}, async function (numBloc
     }
 });
 
+When(/I mine but don't submit a block (.*) on (.*)/, async function (blockName, nodeName) {
+    await this.mineBlock(nodeName, block => {
+        this.saveBlock(blockName, block);
+        return false;
+    });
+});
+
+When(/I submit block (.*) to (.*)/, function (blockName, nodeName) {
+    this.submitBlock(blockName, nodeName);
+});
+
 
 When(/I mine a block on (.*) based on height (\d+)/, async function (node, atHeight) {
     let client = this.getClient(node);
@@ -141,4 +152,10 @@ Then(/I find that the UTXO (.*) exists according to (.*)/, async function (outpu
     let lastResult = await client.fetchMatchingUtxos([hash]);
     expect(lastResult[0].output.commitment.toString('hex')).to.equal(this.outputs[outputName].commitment.toString('hex'));
 });
+
+
+Then('I receive an error containing {string}', function (string) {
+    // TODO
+});
+
 

--- a/integration_tests/features/support/world.js
+++ b/integration_tests/features/support/world.js
@@ -14,6 +14,7 @@ class CustomWorld {
         this.outputs = {};
         this.testrun = `run${Date.now()}`;
         this.lastResult = null;
+        this.blocks =  {};
     }
 
     async createSeedNode(name) {
@@ -43,6 +44,17 @@ class CustomWorld {
 
     async mineBlock(name, beforeSubmit, onError) {
         await this.clients[name].mineBlockWithoutWallet(beforeSubmit, onError);
+    }
+
+    saveBlock(name, block) {
+        this.blocks[name] = block;
+    }
+
+    async submitBlock(blockName, nodeName) {
+        let result  = await this.clients[nodeName].submitBlock(this.blocks[blockName]).catch(err =>  {
+            console.log("erro", err);
+        });
+        console.log(result);
     }
 
     getClient(name) {

--- a/integration_tests/helpers/baseNodeClient.js
+++ b/integration_tests/helpers/baseNodeClient.js
@@ -80,16 +80,23 @@ class BaseNodeClient {
             );
     }
 
-    submitBlock(template, beforeSubmit) {
+    submitTemplate(template, beforeSubmit) {
         return this.client.getNewBlock().sendMessage(template)
             .then(b => {
                     console.log("Sha3 diff", this.getSha3Difficulty(b.block.header));
                     if (beforeSubmit) {
                         b = beforeSubmit(b);
+                        if (!b) {
+                            return Promise.resolve();
+                        }
                     }
                     return this.client.submitBlock().sendMessage(b.block);
                 }
             );
+    }
+
+    submitBlock(b) {
+        return this.client.submitBlock().sendMessage(b.block);
     }
 
     getTipHeight() {
@@ -162,7 +169,7 @@ class BaseNodeClient {
 
     async mineBlockWithoutWallet(beforeSubmit, onError) {
         let template = await this.getMinedCandidateBlock();
-        return this.submitBlock(template, beforeSubmit).then(async () => {
+        return this.submitTemplate(template, beforeSubmit).then(async () => {
             let tip = await this.getTipHeight();
          //   console.log("Tip:", tip);
             //expect(tip).to.equal(parseInt(template.header.height));

--- a/integration_tests/helpers/baseNodeProcess.js
+++ b/integration_tests/helpers/baseNodeProcess.js
@@ -77,7 +77,7 @@ class BaseNodeProcess {
             TARI_BASE_NODE__LOCALNET__TRANSPORT: "tcp",
             TARI_BASE_NODE__LOCALNET__TCP_LISTENER_ADDRESS: "/ip4/0.0.0.0/tcp/" + this.port,
             TARI_BASE_NODE__LOCALNET__ALLOW_TEST_ADDRESSES: true,
-            TARI_BASE_NODE__LOCALNET__PUBLIC_ADDRESS: "/ip4/10.0.0.104/tcp/" + this.port,
+            TARI_BASE_NODE__LOCALNET__PUBLIC_ADDRESS: "/ip4/10.0.0.103/tcp/" + this.port,
             TARI_BASE_NODE__LOCALNET__GRPC_ENABLED: "true",
             TARI_BASE_NODE__LOCALNET__ENABLE_WALLET: false,
             TARI_BASE_NODE__LOCALNET__GRPC_BASE_NODE_ADDRESS: "127.0.0.1:" + this.grpcPort,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Fix a case where an orphan is added twice to a database causing a DUP error in LMDB.

I also added a cucumber test to try and replicate the error, but I'm not sure if it did. The test was pretty useful, so left it in anyway. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [ ] I'm merging against the `development` branch.
* [ ] I ran `cargo-fmt --all` before pushing.
* [ ] I ran `cargo test` successfully before submitting my PR.
* [ ] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
