### PR TITLE
Respect client deadline on server-side

### DIFF
--- a/comms/src/protocol/rpc/body.rs
+++ b/comms/src/protocol/rpc/body.rs
@@ -172,6 +172,14 @@ impl BodyBytes {
         self.0.map(|v| v.into_iter().collect()).unwrap_or_else(BytesMut::new)
     }
 
+    pub fn len(&self) -> usize {
+        self.0.as_ref().map(|b| b.len()).unwrap_or(0)
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
     pub fn into_vec(self) -> Vec<u8> {
         self.0.map(|bytes| bytes.to_vec()).unwrap_or_else(Vec::new)
     }

--- a/comms/src/protocol/rpc/client.rs
+++ b/comms/src/protocol/rpc/client.rs
@@ -303,8 +303,7 @@ where TSubstream: AsyncRead + AsyncWrite + Unpin + Send
     }
 
     async fn run(mut self) {
-        debug!(target: LOG_TARGET, "RPC Client worker started");
-
+        debug!(target: LOG_TARGET, "Performing client handshake");
         let start = Instant::now();
         let mut handshake = Handshake::new(&mut self.framed);
         match handshake.perform_client_handshake().await {
@@ -370,7 +369,7 @@ where TSubstream: AsyncRead + AsyncWrite + Unpin + Send
         let start = Instant::now();
         self.framed.send(req.to_encoded_bytes().into()).await?;
 
-        let (mut response_tx, response_rx) = mpsc::channel(10);
+        let (mut response_tx, response_rx) = mpsc::channel(1);
         if reply.send(response_rx).is_err() {
             debug!(target: LOG_TARGET, "Client request was cancelled.");
             response_tx.close_channel();

--- a/comms/src/protocol/rpc/status.rs
+++ b/comms/src/protocol/rpc/status.rs
@@ -182,6 +182,10 @@ impl RpcStatusCode {
     pub fn is_ok(self) -> bool {
         self == Self::Ok
     }
+
+    pub fn is_not_found(self) -> bool {
+        self == Self::NotFound
+    }
 }
 
 impl From<u32> for RpcStatusCode {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
While waiting for each streamed response, if the client deadline is
reached, the server MUST abort the request and MAY await a new request.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
If the RPC handler function takes longer than the client deadline, the client will timeout however the server will continue to furnish the request.  This may delay or break proceeding requests.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested In #2436 (some additional functions are used here)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch.
* [x] I ran `cargo-fmt --all` before pushing.
* [ ] I ran `cargo test` successfully before submitting my PR.
* [x] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
