### PR TITLE
Added dial-peer and get-peer commands

### DIFF
--- a/applications/tari_app_utilities/src/utilities.rs
+++ b/applications/tari_app_utilities/src/utilities.rs
@@ -237,3 +237,10 @@ pub fn parse_emoji_id_or_public_key_or_node_id(key: &str) -> Option<Either<Comms
         .map(Either::Left)
         .or_else(|| NodeId::from_hex(key).ok().map(Either::Right))
 }
+
+pub fn either_to_node_id(either: Either<CommsPublicKey, NodeId>) -> NodeId {
+    match either {
+        Either::Left(pk) => NodeId::from_public_key(&pk),
+        Either::Right(n) => n,
+    }
+}


### PR DESCRIPTION
- `dial-peer` attempts to dial the peer identified by the node id/public
  key or emoji id
- `get-peer` fetches more detailed information about a peer
```
>> dial-peer 9eb14d257aa581be84048af24cf4d90e179b35224882a548cb08885e09f48d30
☎️  Dialing peer...
⚡️ Peer connected in 7448ms!
Connection: Id = 87, Node ID = dcac197cd7d3d156, Direction = Outbound, Peer Address = /onion3/xxxx:18141, Age = 69µs
>> get-peer dcac197cd7d3d1562018406f56
Emoji ID: 👚💌🎨🍕🐜👣🐪💭🐮🌋🐵🚓🎧🚗🔩🌷🍆👗🍴🍒🎢🐬👣🎢📝🌞🐳🎽🌟🚗🐸🍬🍸
Public Key: 9eb14d257aa581be84048af24cf4d90e179b35224882a548cb08885e09f48d30
NodeId: dcac197cd7d3d1562018406f56
Addresses:
- /onion3/xxxxxxx:18141
User agent: tari/basenode/0.6.1
Features: MESSAGE_PROPAGATION | DHT_STORE_FORWARD | COMMUNICATION_NODE
Supported protocols:
- /tari/identity/1.0.0
- t/dht/1
- t/mempool-sync/1
- /tari/messaging/0.1.0
- t/mempool/1
- t/bnsync/1
Last seen: 2020-12-02 10:30:54.639503 UTC
```