### PR TITLE
Integrate Rewindable outputs into Transactions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -424,19 +424,18 @@ dependencies = [
 [[package]]
 name = "bulletproofs"
 version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69e6731420b125f0300427b4f7d146a7c161b02801c126bed8b66c8e1340f574"
+source = "git+https://github.com/tari-project/bulletproofs?branch=develop#7d6f48f432902c06a5efe5150f40feae32f21bf6"
 dependencies = [
  "byteorder",
  "clear_on_drop",
- "curve25519-dalek",
- "digest 0.8.1",
+ "curve25519-dalek 3.0.0",
+ "digest 0.9.0",
  "merlin",
  "rand 0.7.3",
  "rand_core 0.5.1",
  "serde 1.0.116",
  "serde_derive",
- "sha3 0.8.2",
+ "sha3 0.9.1",
  "subtle 2.3.0",
  "thiserror",
 ]
@@ -931,6 +930,20 @@ checksum = "5d85653f070353a16313d0046f173f70d1aadd5b42600a14de626f0dfb3473a5"
 dependencies = [
  "byteorder",
  "digest 0.8.1",
+ "rand_core 0.5.1",
+ "serde 1.0.116",
+ "subtle 2.3.0",
+ "zeroize",
+]
+
+[[package]]
+name = "curve25519-dalek"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8492de420e9e60bc9a1d66e2dbb91825390b738a388606600663fc529b4b307"
+dependencies = [
+ "byteorder",
+ "digest 0.9.0",
  "packed_simd",
  "rand_core 0.5.1",
  "serde 1.0.116",
@@ -2223,7 +2236,7 @@ checksum = "d53d4207d0bd4d1eb3323e33a64f9ea99e5e3d257d5cd7a659fad5be48c8b9af"
 dependencies = [
  "base58-monero",
  "byteorder",
- "curve25519-dalek",
+ "curve25519-dalek 2.1.0",
  "fixed-hash 0.3.2",
  "hex",
  "keccak-hash 0.3.0",
@@ -4006,15 +4019,14 @@ dependencies = [
 [[package]]
 name = "tari_crypto"
 version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea703e58cc4880c4d572124a8567c1285ac330257777ca17262e89bd045a821c"
+source = "git+https://github.com/tari-project/tari-crypto?branch=main#b9ffb9bc64f837b66a008ef656a9d7ec5de7035f"
 dependencies = [
  "base64 0.10.1",
  "blake2",
  "blake3",
  "bulletproofs",
  "clear_on_drop",
- "curve25519-dalek",
+ "curve25519-dalek 3.0.0",
  "digest 0.8.1",
  "k12",
  "lazy_static 1.4.0",
@@ -5283,7 +5295,7 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "637ff90c9540fa3073bb577e65033069e4bae7c79d49d74aa3ffdf5342a53217"
 dependencies = [
- "curve25519-dalek",
+ "curve25519-dalek 2.1.0",
  "rand_core 0.5.1",
  "zeroize",
 ]

--- a/applications/tari_app_grpc/Cargo.toml
+++ b/applications/tari_app_grpc/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2018"
 [dependencies]
 tari_common_types = { version = "^0.2", path = "../../base_layer/common_types"}
 tari_core = {  path = "../../base_layer/core"}
-tari_crypto = { version = "^0.8" }
+tari_crypto = { version = "^0.8", git = "https://github.com/tari-project/tari-crypto", branch="main"}
 tari_comms = { path = "../../comms", features = ["rpc"]}
 
 

--- a/applications/tari_app_utilities/Cargo.toml
+++ b/applications/tari_app_utilities/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 
 [dependencies]
 tari_comms = { version = "^0.2", path = "../../comms"}
-tari_crypto = { version = "^0.8" }
+tari_crypto = { version = "^0.8", git = "https://github.com/tari-project/tari-crypto", branch="main"}
 tari_common = { version= "^0.2", path = "../../common" }
 tari_p2p = { version= "^0.2", path = "../../base_layer/p2p" }
 tari_wallet = { path = "../../base_layer/wallet" }

--- a/applications/tari_base_node/Cargo.toml
+++ b/applications/tari_base_node/Cargo.toml
@@ -17,7 +17,7 @@ tari_service_framework = {  path = "../../base_layer/service_framework"}
 tari_shutdown = { path = "../../infrastructure/shutdown"}
 tari_mmr = {  path = "../../base_layer/mmr" }
 tari_wallet = { path = "../../base_layer/wallet" }
-tari_crypto = { version = "^0.8" }
+tari_crypto = { version = "^0.8", git = "https://github.com/tari-project/tari-crypto", branch="main"}
 tari_app_grpc = {  path = "../tari_app_grpc" }
 tari_app_utilities = { path = "../tari_app_utilities"}
 

--- a/applications/tari_base_node/src/bootstrap/wallet.rs
+++ b/applications/tari_base_node/src/bootstrap/wallet.rs
@@ -166,7 +166,6 @@ impl WalletBootstrapper {
                 transaction_db,
                 self.node_identity.clone(),
                 self.factories,
-                config.network.into(),
             ))
             .build()
             .await?;

--- a/applications/tari_console_wallet/Cargo.toml
+++ b/applications/tari_console_wallet/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 
 [dependencies]
 tari_wallet = { version = "^0.2", path = "../../base_layer/wallet" }
-tari_crypto = { version = "^0.8" }
+tari_crypto = { version = "^0.8", git = "https://github.com/tari-project/tari-crypto", branch="main"}
 tari_common = { version= "^0.2", path = "../../common" }
 tari_app_utilities = { path = "../tari_app_utilities"}
 tari_comms = { version = "^0.2", path = "../../comms"}

--- a/applications/tari_merge_mining_proxy/Cargo.toml
+++ b/applications/tari_merge_mining_proxy/Cargo.toml
@@ -15,7 +15,7 @@ envlog = ["env_logger"]
 tari_app_grpc = { path = "../tari_app_grpc" }
 tari_common = {  path = "../../common" }
 tari_core = {  path = "../../base_layer/core", default-features = false, features = ["transactions"]}
-tari_crypto = { version = "^0.8" }
+tari_crypto = { version = "^0.8", git = "https://github.com/tari-project/tari-crypto", branch="main"}
 tari_utilities = "^0.3"
 
 bincode = "1.3.1"

--- a/base_layer/common_types/Cargo.toml
+++ b/base_layer/common_types/Cargo.toml
@@ -9,6 +9,6 @@ edition = "2018"
 [dependencies]
 futures = {version = "^0.3.1", features = ["async-await"] }
 rand = "0.7.2"
+tari_crypto = { version = "^0.8", git = "https://github.com/tari-project/tari-crypto", branch="main"}
 serde = { version = "1.0.106", features = ["derive"] }
-tari_crypto = { version = "^0.8" }
 tokio = { version="^0.2", features = ["blocking", "time", "sync"] }

--- a/base_layer/core/Cargo.toml
+++ b/base_layer/core/Cargo.toml
@@ -23,7 +23,8 @@ tari_common_types = { version = "^0.2", path = "../../base_layer/common_types"}
 tari_comms = { version = "^0.2", path = "../../comms"}
 tari_comms_dht = { version = "^0.2.1", path = "../../comms/dht"}
 tari_comms_rpc_macros = { version = "^0.1", path = "../../comms/rpc_macros"}
-tari_crypto = { version = "^0.8" }
+# TODO Once the crate is pushed to crates.io reert to using the official crate.
+tari_crypto = { version = "^0.8", git = "https://github.com/tari-project/tari-crypto", branch="main"}
 tari_mmr = { version = "^0.2", path = "../../base_layer/mmr", optional = true }
 tari_p2p = { version = "^0.2", path = "../../base_layer/p2p" }
 tari_service_framework = { version = "^0.2", path = "../service_framework"}

--- a/base_layer/core/src/transactions/coinbase_builder.rs
+++ b/base_layer/core/src/transactions/coinbase_builder.rs
@@ -33,7 +33,7 @@ use crate::{
             TransactionBuilder,
             UnblindedOutput,
         },
-        transaction_protocol::{build_challenge, TransactionMetadata},
+        transaction_protocol::{build_challenge, RewindData, TransactionMetadata},
         types::{BlindingFactor, CryptoFactories, PrivateKey, PublicKey, Signature},
     },
 };
@@ -62,6 +62,7 @@ pub struct CoinbaseBuilder {
     fees: Option<MicroTari>,
     spend_key: Option<PrivateKey>,
     private_nonce: Option<PrivateKey>,
+    rewind_data: Option<RewindData>,
 }
 
 impl CoinbaseBuilder {
@@ -74,6 +75,7 @@ impl CoinbaseBuilder {
             fees: None,
             spend_key: None,
             private_nonce: None,
+            rewind_data: None,
         }
     }
 
@@ -98,6 +100,12 @@ impl CoinbaseBuilder {
     /// The nonce to be used for this transaction. This will usually be provided by a miner's wallet instance.
     pub fn with_nonce(mut self, nonce: PrivateKey) -> Self {
         self.private_nonce = Some(nonce);
+        self
+    }
+
+    /// Add the rewind data needed to make this coinbase output rewindable
+    pub fn with_rewind_data(mut self, rewind_data: RewindData) -> Self {
+        self.rewind_data = Some(rewind_data);
         self
     }
 
@@ -151,9 +159,15 @@ impl CoinbaseBuilder {
         let sig = Signature::sign(key.clone(), nonce, &challenge)
             .map_err(|_| CoinbaseBuildError::BuildError("Challenge could not be represented as a scalar".into()))?;
         let unblinded_output = UnblindedOutput::new(total_reward, key, Some(output_features));
-        let output = unblinded_output
-            .as_transaction_output(&self.factories)
-            .map_err(|e| CoinbaseBuildError::BuildError(e.to_string()))?;
+        let output = if let Some(rewind_data) = self.rewind_data.as_ref() {
+            unblinded_output
+                .as_rewindable_transaction_output(&self.factories, rewind_data)
+                .map_err(|e| CoinbaseBuildError::BuildError(e.to_string()))?
+        } else {
+            unblinded_output
+                .as_transaction_output(&self.factories)
+                .map_err(|e| CoinbaseBuildError::BuildError(e.to_string()))?
+        };
         let kernel = KernelBuilder::new()
             .with_fee(0 * uT)
             .with_features(kernel_features)
@@ -185,11 +199,13 @@ mod test {
             helpers::TestParams,
             tari_amount::uT,
             transaction::{KernelFeatures, OutputFeatures, OutputFlags, TransactionError, UnblindedOutput},
-            types::{BlindingFactor, CryptoFactories},
+            transaction_protocol::RewindData,
+            types::{BlindingFactor, CryptoFactories, PrivateKey},
             CoinbaseBuilder,
         },
     };
-    use tari_crypto::commitment::HomomorphicCommitmentFactory;
+    use rand::rngs::OsRng;
+    use tari_crypto::{commitment::HomomorphicCommitmentFactory, keys::SecretKey as SecretKeyTrait};
 
     fn get_builder() -> (CoinbaseBuilder, ConsensusManager, CryptoFactories) {
         let network = Network::LocalNet;
@@ -264,6 +280,39 @@ mod test {
             ),
             Ok(())
         );
+    }
+
+    #[test]
+    fn valid_coinbase_with_rewindable_output() {
+        let rewind_key = PrivateKey::random(&mut OsRng);
+        let rewind_blinding_key = PrivateKey::random(&mut OsRng);
+        let proof_message = b"alice__12345678910111";
+
+        let rewind_data = RewindData {
+            rewind_key: rewind_key.clone(),
+            rewind_blinding_key: rewind_blinding_key.clone(),
+            proof_message: proof_message.clone(),
+        };
+
+        let p = TestParams::new();
+        let (builder, rules, factories) = get_builder();
+        let builder = builder
+            .with_block_height(42)
+            .with_fees(145 * uT)
+            .with_nonce(p.nonce.clone())
+            .with_spend_key(p.spend_key.clone())
+            .with_rewind_data(rewind_data.clone());
+        let (tx, _unblinded_output) = builder
+            .build(rules.consensus_constants(42), rules.emission_schedule())
+            .unwrap();
+        let block_reward = rules.emission_schedule().block_reward(42) + 145 * uT;
+
+        let rewind_result = tx.body.outputs()[0]
+            .full_rewind_range_proof(&factories.range_proof, &rewind_key, &rewind_blinding_key)
+            .unwrap();
+        assert_eq!(rewind_result.committed_value, block_reward);
+        assert_eq!(&rewind_result.proof_message, proof_message);
+        assert_eq!(rewind_result.blinding_factor, p.spend_key);
     }
 
     #[test]

--- a/base_layer/core/src/transactions/helpers.rs
+++ b/base_layer/core/src/transactions/helpers.rs
@@ -314,11 +314,7 @@ pub fn spend_utxos(schema: TransactionSchema) -> (Transaction, Vec<UnblindedOutp
 
     let mut stx_protocol = stx_builder.build::<Blake256>(&factories).unwrap();
     let change = stx_protocol.get_change_amount().unwrap();
-    let change_output = UnblindedOutput {
-        value: change,
-        spending_key: test_params.change_key.clone(),
-        features: schema.features,
-    };
+    let change_output = UnblindedOutput::new(change, test_params.change_key.clone(), Some(schema.features));
     outputs.push(change_output);
     match stx_protocol.finalize(KernelFeatures::empty(), &factories) {
         Ok(_) => (),

--- a/base_layer/core/src/transactions/transaction.rs
+++ b/base_layer/core/src/transactions/transaction.rs
@@ -26,13 +26,15 @@
 use crate::transactions::{
     aggregated_body::AggregateBody,
     tari_amount::{uT, MicroTari},
-    transaction_protocol::{build_challenge, TransactionMetadata},
+    transaction_protocol::{build_challenge, RewindData, TransactionMetadata},
     types::{
         BlindingFactor,
         Commitment,
         CommitmentFactory,
         CryptoFactories,
         HashDigest,
+        PrivateKey,
+        PublicKey,
         RangeProof,
         RangeProofService,
         Signature,
@@ -49,7 +51,13 @@ use std::{
 };
 use tari_crypto::{
     commitment::HomomorphicCommitmentFactory,
-    range_proof::{RangeProofError, RangeProofService as RangeProofServiceTrait},
+    range_proof::{
+        FullRewindResult as CryptoFullRewindResult,
+        RangeProofError,
+        RangeProofService as RangeProofServiceTrait,
+        RewindResult as CryptoRewindResult,
+        REWIND_USER_MESSAGE_LENGTH,
+    },
     tari_utilities::{hex::Hex, message_format::MessageFormat, ByteArray, Hashable},
 };
 use thiserror::Error;
@@ -223,6 +231,39 @@ impl UnblindedOutput {
         }
         Ok(output)
     }
+
+    pub fn as_rewindable_transaction_output(
+        &self,
+        factories: &CryptoFactories,
+        rewind_data: &RewindData,
+    ) -> Result<TransactionOutput, TransactionError>
+    {
+        let commitment = factories.commitment.commit(&self.spending_key, &self.value.into());
+
+        let proof_bytes = factories.range_proof.construct_proof_with_rewind_key(
+            &self.spending_key,
+            self.value.into(),
+            &rewind_data.rewind_key,
+            &rewind_data.rewind_blinding_key,
+            &rewind_data.proof_message,
+        )?;
+
+        let proof = RangeProof::from_bytes(&proof_bytes)
+            .map_err(|_| TransactionError::RangeProofError(RangeProofError::ProofConstructionError))?;
+
+        let output = TransactionOutput {
+            features: self.features.clone(),
+            commitment,
+            proof,
+        };
+        // A range proof can be constructed for an invalid value so we should confirm that the proof can be verified.
+        if !output.verify_range_proof(&factories.range_proof)? {
+            return Err(TransactionError::ValidationError(
+                "Range proof could not be verified".into(),
+            ));
+        }
+        Ok(output)
+    }
 }
 
 // These implementations are used for order these outputs for UTXO selection which will be done by comparing the values
@@ -353,7 +394,38 @@ impl TransactionOutput {
 
     /// Verify that range proof is valid
     pub fn verify_range_proof(&self, prover: &RangeProofService) -> Result<bool, TransactionError> {
-        Ok(prover.verify(&self.proof.to_vec(), &self.commitment))
+        Ok(prover.verify(&self.proof.0, &self.commitment))
+    }
+
+    /// Attempt to rewind the range proof to reveal the proof message and committed value
+    pub fn rewind_range_proof_value_only(
+        &self,
+        prover: &RangeProofService,
+        rewind_public_key: &PublicKey,
+        rewind_blinding_public_key: &PublicKey,
+    ) -> Result<RewindResult, TransactionError>
+    {
+        Ok(prover
+            .rewind_proof_value_only(
+                &self.proof.0,
+                &&self.commitment,
+                rewind_public_key,
+                rewind_blinding_public_key,
+            )?
+            .into())
+    }
+
+    /// Attempt to fully rewind the range proof to reveal the proof message, committed value and blinding factor
+    pub fn full_rewind_range_proof(
+        &self,
+        prover: &RangeProofService,
+        rewind_key: &PrivateKey,
+        rewind_blinding_key: &PrivateKey,
+    ) -> Result<FullRewindResult, TransactionError>
+    {
+        Ok(prover
+            .rewind_proof_commitment_data(&self.proof.0, &&self.commitment, rewind_key, rewind_blinding_key)?
+            .into())
     }
 
     /// This will check if the input and the output is the same commitment by looking at the commitment and features.
@@ -408,6 +480,67 @@ impl Display for TransactionOutput {
         ))
     }
 }
+
+/// A wrapper struct to hold the result of a successful range proof rewinding to reveal the committed value and proof
+/// message
+#[derive(Debug, PartialEq)]
+pub struct RewindResult {
+    pub committed_value: MicroTari,
+    pub proof_message: [u8; REWIND_USER_MESSAGE_LENGTH],
+}
+
+impl RewindResult {
+    pub fn new(committed_value: MicroTari, proof_message: [u8; REWIND_USER_MESSAGE_LENGTH]) -> Self {
+        Self {
+            committed_value,
+            proof_message,
+        }
+    }
+}
+
+impl From<CryptoRewindResult> for RewindResult {
+    fn from(crr: CryptoRewindResult) -> Self {
+        Self {
+            committed_value: crr.committed_value.into(),
+            proof_message: crr.proof_message,
+        }
+    }
+}
+
+/// A wrapper struct to hold the result of a successful range proof full rewinding to reveal the committed value, proof
+/// message and blinding factor
+#[derive(Debug, PartialEq)]
+pub struct FullRewindResult {
+    pub committed_value: MicroTari,
+    pub proof_message: [u8; REWIND_USER_MESSAGE_LENGTH],
+    pub blinding_factor: BlindingFactor,
+}
+
+impl FullRewindResult {
+    pub fn new(
+        committed_value: MicroTari,
+        proof_message: [u8; REWIND_USER_MESSAGE_LENGTH],
+        blinding_factor: BlindingFactor,
+    ) -> Self
+    {
+        Self {
+            committed_value,
+            proof_message,
+            blinding_factor,
+        }
+    }
+}
+
+impl From<CryptoFullRewindResult<BlindingFactor>> for FullRewindResult {
+    fn from(crr: CryptoFullRewindResult<BlindingFactor>) -> Self {
+        Self {
+            committed_value: crr.committed_value.into(),
+            proof_message: crr.proof_message,
+            blinding_factor: crr.blinding_factor,
+        }
+    }
+}
+
 //----------------------------------------   Transaction Kernel   ----------------------------------------------------//
 
 /// The transaction kernel tracks the excess for a given transaction. For an explanation of what the excess is, and
@@ -781,7 +914,10 @@ mod test {
         txn_schema,
     };
     use rand::{self, rngs::OsRng};
-    use tari_crypto::{keys::SecretKey as SecretKeyTrait, ristretto::pedersen::PedersenCommitmentFactory};
+    use tari_crypto::{
+        keys::{PublicKey as PublicKeyTrait, SecretKey as SecretKeyTrait},
+        ristretto::pedersen::PedersenCommitmentFactory,
+    };
 
     #[test]
     fn unblinded_input() {
@@ -957,5 +1093,68 @@ mod test {
         assert_eq!(tx3.body.inputs().len(), 2);
         assert_eq!(tx3.body.outputs().len(), 4);
         assert_eq!(tx3.body.kernels().len(), 2);
+    }
+
+    #[test]
+    fn test_output_rewinding() {
+        let factories = CryptoFactories::new(32);
+        let k = BlindingFactor::random(&mut OsRng);
+        let v = MicroTari::from(42);
+        let rewind_key = PrivateKey::random(&mut OsRng);
+        let rewind_blinding_key = PrivateKey::random(&mut OsRng);
+        let random_key = PrivateKey::random(&mut OsRng);
+        let rewind_public_key = PublicKey::from_secret_key(&rewind_key);
+        let rewind_blinding_public_key = PublicKey::from_secret_key(&rewind_blinding_key);
+        let public_random_key = PublicKey::from_secret_key(&random_key);
+        let proof_message = b"testing12345678910111";
+
+        let rewind_data = RewindData {
+            rewind_key: rewind_key.clone(),
+            rewind_blinding_key: rewind_blinding_key.clone(),
+            proof_message: proof_message.clone(),
+        };
+
+        let unblinded_output = UnblindedOutput::new(v, k.clone(), None);
+
+        let output = unblinded_output
+            .as_rewindable_transaction_output(&factories, &rewind_data)
+            .unwrap();
+
+        assert_eq!(
+            output.rewind_range_proof_value_only(
+                &factories.range_proof,
+                &public_random_key,
+                &rewind_blinding_public_key
+            ),
+            Err(TransactionError::RangeProofError(RangeProofError::InvalidRewind))
+        );
+        assert_eq!(
+            output.rewind_range_proof_value_only(&factories.range_proof, &rewind_public_key, &public_random_key),
+            Err(TransactionError::RangeProofError(RangeProofError::InvalidRewind))
+        );
+
+        let rewind_result = output
+            .rewind_range_proof_value_only(&factories.range_proof, &rewind_public_key, &rewind_blinding_public_key)
+            .unwrap();
+
+        assert_eq!(rewind_result.committed_value, v);
+        assert_eq!(&rewind_result.proof_message, proof_message);
+
+        assert_eq!(
+            output.full_rewind_range_proof(&factories.range_proof, &random_key, &rewind_blinding_key),
+            Err(TransactionError::RangeProofError(RangeProofError::InvalidRewind))
+        );
+        assert_eq!(
+            output.full_rewind_range_proof(&factories.range_proof, &rewind_key, &random_key),
+            Err(TransactionError::RangeProofError(RangeProofError::InvalidRewind))
+        );
+
+        let full_rewind_result = output
+            .full_rewind_range_proof(&factories.range_proof, &rewind_key, &rewind_blinding_key)
+            .unwrap();
+
+        assert_eq!(full_rewind_result.committed_value, v);
+        assert_eq!(&full_rewind_result.proof_message, proof_message);
+        assert_eq!(full_rewind_result.blinding_factor, k);
     }
 }

--- a/base_layer/core/src/transactions/transaction_protocol/mod.rs
+++ b/base_layer/core/src/transactions/transaction_protocol/mod.rs
@@ -89,12 +89,12 @@ pub mod transaction_initializer;
 use crate::transactions::{
     tari_amount::*,
     transaction::TransactionError,
-    types::{Challenge, MessageHash, PublicKey},
+    types::{Challenge, MessageHash, PrivateKey, PublicKey},
 };
 use digest::Digest;
 use serde::{Deserialize, Serialize};
 use tari_crypto::{
-    range_proof::RangeProofError,
+    range_proof::{RangeProofError, REWIND_USER_MESSAGE_LENGTH},
     signatures::SchnorrSignatureError,
     tari_utilities::byte_array::ByteArray,
 };
@@ -133,6 +133,13 @@ pub struct TransactionMetadata {
     pub fee: MicroTari,
     /// The earliest block this transaction can be mined
     pub lock_height: u64,
+}
+
+#[derive(Debug, Clone)]
+pub struct RewindData {
+    pub rewind_key: PrivateKey,
+    pub rewind_blinding_key: PrivateKey,
+    pub proof_message: [u8; REWIND_USER_MESSAGE_LENGTH],
 }
 
 /// Convenience function that calculates the challenge for the Schnorr signatures

--- a/base_layer/core/src/transactions/transaction_protocol/recipient.rs
+++ b/base_layer/core/src/transactions/transaction_protocol/recipient.rs
@@ -25,6 +25,7 @@ use crate::transactions::{
     transaction_protocol::{
         sender::{SingleRoundSenderData as SD, TransactionSenderMessage},
         single_receiver::SingleReceiverTransactionProtocol,
+        RewindData,
         TransactionProtocolError,
     },
     types::{CryptoFactories, MessageHash, PrivateKey, PublicKey, Signature},
@@ -108,8 +109,34 @@ impl ReceiverTransactionProtocol {
         let state = match info {
             TransactionSenderMessage::None => RecipientState::Failed(TransactionProtocolError::InvalidStateError),
             TransactionSenderMessage::Single(v) => {
-                ReceiverTransactionProtocol::single_round(nonce, spending_key, features, &v, factories)
+                ReceiverTransactionProtocol::single_round(nonce, spending_key, features, &v, factories, None)
             },
+            TransactionSenderMessage::Multiple => Self::multi_round(),
+        };
+        ReceiverTransactionProtocol { state }
+    }
+
+    /// This function creates a new Receiver Transaction Protocol where the resulting receiver output range proof is
+    /// rewindable
+    pub fn new_with_rewindable_output(
+        info: TransactionSenderMessage,
+        nonce: PrivateKey,
+        spending_key: PrivateKey,
+        features: OutputFeatures,
+        factories: &CryptoFactories,
+        rewind_data: &RewindData,
+    ) -> ReceiverTransactionProtocol
+    {
+        let state = match info {
+            TransactionSenderMessage::None => RecipientState::Failed(TransactionProtocolError::InvalidStateError),
+            TransactionSenderMessage::Single(v) => ReceiverTransactionProtocol::single_round(
+                nonce,
+                spending_key,
+                features,
+                &v,
+                factories,
+                Some(rewind_data),
+            ),
             TransactionSenderMessage::Multiple => Self::multi_round(),
         };
         ReceiverTransactionProtocol { state }
@@ -154,9 +181,10 @@ impl ReceiverTransactionProtocol {
         features: OutputFeatures,
         data: &SD,
         factories: &CryptoFactories,
+        rewind_data: Option<&RewindData>,
     ) -> RecipientState
     {
-        let signer = SingleReceiverTransactionProtocol::create(data, nonce, key, features, factories);
+        let signer = SingleReceiverTransactionProtocol::create(data, nonce, key, features, factories, rewind_data);
         match signer {
             Ok(signed_data) => RecipientState::Finalized(Box::new(signed_data)),
             Err(e) => RecipientState::Failed(e),
@@ -189,12 +217,17 @@ mod test {
         transaction_protocol::{
             build_challenge,
             sender::{SingleRoundSenderData, TransactionSenderMessage},
+            RewindData,
             TransactionMetadata,
         },
-        types::{CryptoFactories, PublicKey, Signature},
+        types::{CryptoFactories, PrivateKey, PublicKey, Signature},
         ReceiverTransactionProtocol,
     };
-    use tari_crypto::{commitment::HomomorphicCommitmentFactory, keys::PublicKey as PK};
+    use rand::rngs::OsRng;
+    use tari_crypto::{
+        commitment::HomomorphicCommitmentFactory,
+        keys::{PublicKey as PK, SecretKey as SecretKeyTrait},
+    };
 
     #[test]
     fn single_round_recipient() {
@@ -233,5 +266,61 @@ mod test {
         let e = build_challenge(&r_sum, &m);
         let s = Signature::sign(p.spend_key.clone(), p.nonce.clone(), &e).unwrap();
         assert_eq!(data.partial_signature, s);
+    }
+
+    #[test]
+    fn single_round_recipient_with_rewinding() {
+        let factories = CryptoFactories::default();
+        let p = TestParams::new();
+        // Rewind params
+        let rewind_key = PrivateKey::random(&mut OsRng);
+        let rewind_blinding_key = PrivateKey::random(&mut OsRng);
+        let rewind_public_key = PublicKey::from_secret_key(&rewind_key);
+        let rewind_blinding_public_key = PublicKey::from_secret_key(&rewind_blinding_key);
+        let message = b"alice__12345678910111";
+        let amount = MicroTari(500);
+        let m = TransactionMetadata {
+            fee: MicroTari(125),
+            lock_height: 0,
+        };
+        let msg = SingleRoundSenderData {
+            tx_id: 15,
+            amount,
+            public_excess: PublicKey::from_secret_key(&p.spend_key), // any random key will do
+            public_nonce: PublicKey::from_secret_key(&p.change_key), // any random key will do
+            metadata: m.clone(),
+            message: "".to_string(),
+        };
+        let sender_info = TransactionSenderMessage::Single(Box::new(msg.clone()));
+        let rewind_data = RewindData {
+            rewind_key: rewind_key.clone(),
+            rewind_blinding_key: rewind_blinding_key.clone(),
+            proof_message: message.clone(),
+        };
+        let receiver = ReceiverTransactionProtocol::new_with_rewindable_output(
+            sender_info,
+            p.nonce.clone(),
+            p.spend_key.clone(),
+            OutputFeatures::default(),
+            &factories,
+            &rewind_data,
+        );
+        assert!(receiver.is_finalized());
+        let data = receiver.get_signed_data().unwrap();
+
+        let rr = data
+            .output
+            .rewind_range_proof_value_only(&factories.range_proof, &rewind_public_key, &rewind_blinding_public_key)
+            .unwrap();
+        assert_eq!(rr.committed_value, amount);
+        assert_eq!(&rr.proof_message, message);
+        let full_rewind_result = data
+            .output
+            .full_rewind_range_proof(&factories.range_proof, &rewind_key, &rewind_blinding_key)
+            .unwrap();
+
+        assert_eq!(full_rewind_result.committed_value, amount);
+        assert_eq!(&full_rewind_result.proof_message, message);
+        assert_eq!(full_rewind_result.blinding_factor, p.spend_key);
     }
 }

--- a/base_layer/core/src/transactions/transaction_protocol/sender.rs
+++ b/base_layer/core/src/transactions/transaction_protocol/sender.rs
@@ -102,6 +102,12 @@ pub enum TransactionSenderMessage {
     Multiple,
 }
 
+impl TransactionSenderMessage {
+    pub fn new_single_round_message(single_round_data: SingleRoundSenderData) -> Self {
+        Self::Single(Box::new(single_round_data))
+    }
+}
+
 //----------------------------------------  Sender State Protocol ----------------------------------------------------//
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 pub struct SenderTransactionProtocol {
@@ -556,12 +562,17 @@ mod test {
         transaction_protocol::{
             sender::SenderTransactionProtocol,
             single_receiver::SingleReceiverTransactionProtocol,
+            RewindData,
             TransactionProtocolError,
         },
-        types::CryptoFactories,
+        types::{CryptoFactories, PrivateKey, PublicKey},
     };
     use rand::rngs::OsRng;
-    use tari_crypto::{common::Blake256, tari_utilities::hex::Hex};
+    use tari_crypto::{
+        common::Blake256,
+        keys::{PublicKey as PublicKeyTrait, SecretKey as SecretKeyTrait},
+        tari_utilities::hex::Hex,
+    };
 
     #[test]
     fn zero_recipients() {
@@ -624,6 +635,7 @@ mod test {
             b.spend_key,
             OutputFeatures::default(),
             &factories,
+            None,
         )
         .unwrap();
         // Alice gets message back, deserializes it, etc
@@ -689,6 +701,7 @@ mod test {
             b.spend_key,
             OutputFeatures::default(),
             &factories,
+            None,
         )
         .unwrap();
         println!(
@@ -749,6 +762,7 @@ mod test {
             b.spend_key,
             OutputFeatures::default(),
             &factories,
+            None,
         )
         .unwrap();
         // Alice gets message back, deserializes it, etc
@@ -810,5 +824,118 @@ mod test {
             Ok(_) => assert!(true),
             Err(e) => panic!("Unexpected error: {:?}", e),
         };
+    }
+
+    #[test]
+    fn single_recipient_with_rewindable_change_and_receiver_outputs() {
+        let factories = CryptoFactories::default();
+        // Alice's parameters
+        let a = TestParams::new();
+        // Bob's parameters
+        let b = TestParams::new();
+        let alice_value = MicroTari(2500);
+        let (utxo, input) = make_input(&mut OsRng, alice_value, &factories.commitment);
+
+        // Rewind params
+        let rewind_key = PrivateKey::random(&mut OsRng);
+        let rewind_blinding_key = PrivateKey::random(&mut OsRng);
+        let rewind_public_key = PublicKey::from_secret_key(&rewind_key);
+        let rewind_blinding_public_key = PublicKey::from_secret_key(&rewind_blinding_key);
+        let proof_message = b"alice__12345678910111";
+
+        let rewind_data = RewindData {
+            rewind_key: rewind_key.clone(),
+            rewind_blinding_key: rewind_blinding_key.clone(),
+            proof_message: proof_message.clone(),
+        };
+
+        let mut builder = SenderTransactionProtocol::builder(1);
+        builder
+            .with_lock_height(0)
+            .with_fee_per_gram(MicroTari(20))
+            .with_offset(a.offset.clone())
+            .with_private_nonce(a.nonce.clone())
+            .with_rewindable_change_secret(a.change_key.clone(), rewind_data)
+            .with_input(utxo.clone(), input)
+            .with_amount(0, MicroTari(500));
+        let mut alice = builder.build::<Blake256>(&factories).unwrap();
+        assert!(alice.is_single_round_message_ready());
+        let msg = alice.build_single_round_message().unwrap();
+
+        let change = alice_value - msg.amount - msg.metadata.fee;
+
+        println!(
+            "amount: {}, fee: {},  Public Excess: {}, Nonce: {}, Change: {}",
+            msg.amount,
+            msg.metadata.fee,
+            msg.public_excess.to_hex(),
+            msg.public_nonce.to_hex(),
+            change
+        );
+
+        // Send message down the wire....and wait for response
+        assert!(alice.is_collecting_single_signature());
+
+        // Receiver gets message, deserializes it etc, and creates his response
+        let bob_info = SingleReceiverTransactionProtocol::create(
+            &msg,
+            b.nonce,
+            b.spend_key,
+            OutputFeatures::default(),
+            &factories,
+            None,
+        )
+        .unwrap();
+
+        // Alice gets message back, deserializes it, etc
+        alice
+            .add_single_recipient_info(bob_info.clone(), &factories.range_proof)
+            .unwrap();
+        // Transaction should be complete
+        assert!(alice.is_finalizing());
+        match alice.finalize(KernelFeatures::empty(), &factories) {
+            Ok(_0) => (),
+            Err(e) => panic!("{:?}", e),
+        };
+
+        assert!(alice.is_finalized());
+        let tx = alice.get_transaction().unwrap();
+        assert_eq!(tx.body.outputs().len(), 2);
+
+        match tx.body.outputs()[0].rewind_range_proof_value_only(
+            &factories.range_proof,
+            &rewind_public_key,
+            &rewind_blinding_public_key,
+        ) {
+            Ok(rr) => {
+                assert_eq!(rr.committed_value, change);
+                assert_eq!(&rr.proof_message, proof_message);
+                let full_rewind_result = tx.body.outputs()[0]
+                    .full_rewind_range_proof(&factories.range_proof, &rewind_key, &rewind_blinding_key)
+                    .unwrap();
+
+                assert_eq!(full_rewind_result.committed_value, change);
+                assert_eq!(&full_rewind_result.proof_message, proof_message);
+                assert_eq!(full_rewind_result.blinding_factor, a.change_key);
+            },
+            Err(_) => {
+                let rr = tx.body.outputs()[1]
+                    .rewind_range_proof_value_only(
+                        &factories.range_proof,
+                        &rewind_public_key,
+                        &rewind_blinding_public_key,
+                    )
+                    .expect("If the first output isn't alice's then the second must be");
+                assert_eq!(rr.committed_value, change);
+                assert_eq!(&rr.proof_message, proof_message);
+                let full_rewind_result = tx.body.outputs()[1]
+                    .full_rewind_range_proof(&factories.range_proof, &rewind_key, &rewind_blinding_key)
+                    .unwrap();
+
+                assert_eq!(full_rewind_result.committed_value, change);
+                assert_eq!(&full_rewind_result.proof_message, proof_message);
+                assert_eq!(full_rewind_result.blinding_factor, a.change_key);
+            },
+        }
     }
 }

--- a/base_layer/core/src/transactions/transaction_protocol/transaction_initializer.rs
+++ b/base_layer/core/src/transactions/transaction_protocol/transaction_initializer.rs
@@ -34,6 +34,7 @@ use crate::transactions::{
     transaction_protocol::{
         recipient::RecipientInfo,
         sender::{calculate_tx_id, RawTransactionInfo, SenderState, SenderTransactionProtocol},
+        RewindData,
         TransactionMetadata,
     },
     types::{BlindingFactor, CryptoFactories, PrivateKey, PublicKey},
@@ -67,6 +68,7 @@ pub struct SenderTransactionInitializer {
     unblinded_inputs: Vec<UnblindedOutput>,
     outputs: Vec<UnblindedOutput>,
     change_secret: Option<BlindingFactor>,
+    rewind_data: Option<RewindData>,
     offset: Option<BlindingFactor>,
     excess_blinding_factor: BlindingFactor,
     private_nonce: Option<PrivateKey>,
@@ -96,6 +98,7 @@ impl SenderTransactionInitializer {
             unblinded_inputs: Vec::new(),
             outputs: Vec::new(),
             change_secret: None,
+            rewind_data: None,
             offset: None,
             private_nonce: None,
             excess_blinding_factor: BlindingFactor::default(),
@@ -152,6 +155,19 @@ impl SenderTransactionInitializer {
         self
     }
 
+    /// Provide a blinding factor and rewind keys and proof message for the change output. The amount of change will
+    /// automatically be calculated when the transaction is built.
+    pub fn with_rewindable_change_secret(
+        &mut self,
+        blinding_factor: BlindingFactor,
+        rewind_data: RewindData,
+    ) -> &mut Self
+    {
+        self.change_secret = Some(blinding_factor);
+        self.rewind_data = Some(rewind_data);
+        self
+    }
+
     /// Provide the private nonce that will be used for the sender's partial signature for the transaction.
     pub fn with_private_nonce(&mut self, nonce: PrivateKey) -> &mut Self {
         self.private_nonce = Some(nonce);
@@ -173,7 +189,7 @@ impl SenderTransactionInitializer {
     /// Tries to make a change output with the given transaction parameters and add it to the set of outputs. The total
     /// fee, including the additional change output (if any) is returned along with the amount of change.
     /// The change output **always has default output features**.
-    fn add_change_if_required(&mut self) -> Result<(MicroTari, MicroTari), String> {
+    fn add_change_if_required(&mut self) -> Result<(MicroTari, MicroTari, Option<UnblindedOutput>), String> {
         // The number of outputs excluding a possible residual change output
         let num_outputs = self.outputs.len() + self.num_recipients;
         let num_inputs = self.inputs.len();
@@ -188,22 +204,21 @@ impl SenderTransactionInitializer {
         let change_amount = total_being_spent.checked_sub(total_to_self + total_amount + fee_without_change);
         match change_amount {
             None => Err("You are spending more than you're providing".into()),
-            Some(MicroTari(0)) => Ok((fee_without_change, MicroTari(0))),
+            Some(MicroTari(0)) => Ok((fee_without_change, MicroTari(0), None)),
             Some(v) => {
                 let change_amount = v.checked_sub(extra_fee);
                 match change_amount {
                     // You can't win. Just add the change to the fee (which is less than the cost of adding another
                     // output and go without a change output
-                    None => Ok((fee_without_change + v, MicroTari(0))),
-                    Some(MicroTari(0)) => Ok((fee_without_change + v, MicroTari(0))),
+                    None => Ok((fee_without_change + v, MicroTari(0), None)),
+                    Some(MicroTari(0)) => Ok((fee_without_change + v, MicroTari(0), None)),
                     Some(v) => {
                         let change_key = self
                             .change_secret
                             .as_ref()
                             .ok_or_else(|| "Change spending key was not provided")?;
-                        let change_key = change_key.clone();
-                        self.with_output(UnblindedOutput::new(v, change_key, None));
-                        Ok((fee_with_change, v))
+                        let change_unblinded_output = UnblindedOutput::new(v, change_key.clone(), None);
+                        Ok((fee_with_change, v, Some(change_unblinded_output)))
                     },
                 }
             },
@@ -255,8 +270,8 @@ impl SenderTransactionInitializer {
             return self.build_err("Too many inputs in transaction");
         }
         // Calculate the fee based on whether we need to add a residual change output or not
-        let (total_fee, change) = match self.add_change_if_required() {
-            Ok((fee, change)) => (fee, change),
+        let (total_fee, change, change_output) = match self.add_change_if_required() {
+            Ok((fee, change, output)) => (fee, change, output),
             Err(e) => return self.build_err(&e),
         };
         // Some checks on the fee
@@ -264,7 +279,7 @@ impl SenderTransactionInitializer {
             return self.build_err("Fee is less than the minimum");
         }
         // Create transaction outputs
-        let outputs = match self
+        let mut outputs = match self
             .outputs
             .iter()
             .map(|o| o.as_transaction_output(factories))
@@ -275,6 +290,29 @@ impl SenderTransactionInitializer {
                 return self.build_err(&e.to_string());
             },
         };
+        if let Some(change_unblinded_output) = change_output {
+            self.excess_blinding_factor = self.excess_blinding_factor + change_unblinded_output.spending_key.clone();
+
+            // If rewind data is present we produce a rewindable output, else a standard output
+            let change_output = if let Some(rewind_data) = self.rewind_data.as_ref() {
+                match change_unblinded_output.as_rewindable_transaction_output(factories, rewind_data) {
+                    Ok(o) => o,
+                    Err(e) => {
+                        return self.build_err(e.to_string().as_str());
+                    },
+                }
+            } else {
+                match change_unblinded_output.as_transaction_output(factories) {
+                    Ok(o) => o,
+                    Err(e) => {
+                        return self.build_err(e.to_string().as_str());
+                    },
+                }
+            };
+            self.outputs.push(change_unblinded_output);
+            outputs.push(change_output);
+        }
+
         // Prevent overflow attacks by imposing sane limits on outputs
         if outputs.len() > MAX_TRANSACTION_OUTPUTS {
             return self.build_err("Too many outputs in transaction");

--- a/base_layer/key_manager/Cargo.toml
+++ b/base_layer/key_manager/Cargo.toml
@@ -8,7 +8,7 @@ version = "0.2.11"
 edition = "2018"
 
 [dependencies]
-tari_crypto = { version = "^0.8" }
+tari_crypto = { version = "^0.8", git = "https://github.com/tari-project/tari-crypto", branch="main"}
 rand = "0.7.2"
 digest = "0.8.0"
 sha2 = "0.8.0"

--- a/base_layer/mmr/Cargo.toml
+++ b/base_layer/mmr/Cargo.toml
@@ -25,7 +25,7 @@ criterion = { version="0.2", optional = true }
 rand="0.7.0"
 blake2 = "0.8.0"
 tari_infra_derive= { path = "../../infrastructure/derive", version = "^0.0" }
-tari_crypto = { version = "^0.8" }
+tari_crypto = { version = "^0.8", git = "https://github.com/tari-project/tari-crypto", branch="main"}
 serde_json = "1.0"
 bincode = "1.1"
 [lib]

--- a/base_layer/p2p/Cargo.toml
+++ b/base_layer/p2p/Cargo.toml
@@ -13,7 +13,7 @@ edition = "2018"
 tari_comms = { version = "^0.2", path = "../../comms"}
 tari_comms_dht = { version = "^0.2.2", path = "../../comms/dht"}
 tari_common = { version= "^0.2", path = "../../common" }
-tari_crypto = { version = "^0.8" }
+tari_crypto = { version = "^0.8", git = "https://github.com/tari-project/tari-crypto", branch="main"}
 tari_service_framework = { version = "^0.2", path = "../service_framework"}
 tari_shutdown = { version = "^0.2", path="../../infrastructure/shutdown" }
 tari_storage = { version = "^0.2", path = "../../infrastructure/storage"}

--- a/base_layer/wallet/Cargo.toml
+++ b/base_layer/wallet/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2018"
 tari_common_types = { version = "^0.2", path = "../../base_layer/common_types"}
 tari_comms = { version = "^0.2", path = "../../comms"}
 tari_comms_dht = { version = "^0.2.1", path = "../../comms/dht" }
-tari_crypto = { version = "^0.8" }
+tari_crypto = { version = "^0.8", git = "https://github.com/tari-project/tari-crypto", branch="main"}
 tari_key_manager = { version = "^0.2", path = "../key_manager" }
 tari_p2p = { version = "^0.2", path = "../p2p" }
 tari_service_framework = { version = "^0.2", path = "../service_framework"}

--- a/base_layer/wallet/src/output_manager_service/error.rs
+++ b/base_layer/wallet/src/output_manager_service/error.rs
@@ -23,7 +23,11 @@
 use crate::output_manager_service::storage::database::DbKey;
 use diesel::result::Error as DieselError;
 use tari_comms_dht::outbound::DhtOutboundError;
-use tari_core::transactions::{transaction::TransactionError, transaction_protocol::TransactionProtocolError};
+use tari_core::transactions::{
+    transaction::TransactionError,
+    transaction_protocol::TransactionProtocolError,
+    CoinbaseBuildError,
+};
 use tari_crypto::tari_utilities::ByteArrayError;
 use tari_key_manager::{key_manager::KeyManagerError, mnemonic::MnemonicError};
 use tari_service_framework::reply_channel::TransportChannelError;
@@ -80,6 +84,10 @@ pub enum OutputManagerError {
     ServiceError(String),
     #[error("Base node is not synced")]
     BaseNodeNotSynced,
+    #[error("Invalid Sender Message Type")]
+    InvalidSenderMessage,
+    #[error("Coinbase build error: `{0}`")]
+    CoinbaseBuildError(#[from] CoinbaseBuildError),
 }
 
 #[derive(Debug, Error, PartialEq)]

--- a/base_layer/wallet/src/output_manager_service/mod.rs
+++ b/base_layer/wallet/src/output_manager_service/mod.rs
@@ -151,7 +151,7 @@ where T: OutputManagerBackend + 'static
                 OutputManagerDatabase::new(backend),
                 publisher,
                 factories,
-                constants.coinbase_lock_height(),
+                constants,
                 handles.get_shutdown_signal(),
             )
             .await

--- a/base_layer/wallet/src/output_manager_service/storage/database.rs
+++ b/base_layer/wallet/src/output_manager_service/storage/database.rs
@@ -363,11 +363,7 @@ where T: OutputManagerBackend + 'static
     {
         let db_clone = self.db.clone();
         let output = DbUnblindedOutput::from_unblinded_output(
-            UnblindedOutput {
-                value: amount,
-                spending_key: spending_key.clone(),
-                features: output_features,
-            },
+            UnblindedOutput::new(amount, spending_key.clone(), Some(output_features)),
             factory,
         )?;
         tokio::task::spawn_blocking(move || {

--- a/base_layer/wallet/src/output_manager_service/storage/sqlite_db.rs
+++ b/base_layer/wallet/src/output_manager_service/storage/sqlite_db.rs
@@ -990,21 +990,21 @@ impl TryFrom<OutputSql> for DbUnblindedOutput {
     type Error = OutputManagerStorageError;
 
     fn try_from(o: OutputSql) -> Result<Self, Self::Error> {
-        let unblinded_output = UnblindedOutput {
-            value: MicroTari::from(o.value as u64),
-            spending_key: PrivateKey::from_vec(&o.spending_key).map_err(|_| {
+        let unblinded_output = UnblindedOutput::new(
+            MicroTari::from(o.value as u64),
+            PrivateKey::from_vec(&o.spending_key).map_err(|_| {
                 error!(
                     target: LOG_TARGET,
                     "Could not create PrivateKey from stored bytes, They might be encrypted"
                 );
                 OutputManagerStorageError::ConversionError
             })?,
-            features: OutputFeatures {
+            Some(OutputFeatures {
                 flags: OutputFlags::from_bits(o.flags as u8)
                     .ok_or_else(|| OutputManagerStorageError::ConversionError)?,
                 maturity: o.maturity as u64,
-            },
-        };
+            }),
+        );
         let hash = match o.hash {
             None => {
                 // This should only happen if the database didn't migrate yet.

--- a/base_layer/wallet/src/testnet_utils.rs
+++ b/base_layer/wallet/src/testnet_utils.rs
@@ -151,16 +151,7 @@ pub async fn create_wallet(
         peer_seeds: Default::default(),
     };
 
-    let config = WalletConfig::new(
-        comms_config,
-        factories,
-        None,
-        None,
-        Network::Rincewind,
-        None,
-        None,
-        None,
-    );
+    let config = WalletConfig::new(comms_config, factories, None, None, Network::Ridcully, None, None, None);
 
     Wallet::new(
         config,

--- a/base_layer/wallet/src/transaction_service/error.rs
+++ b/base_layer/wallet/src/transaction_service/error.rs
@@ -29,11 +29,7 @@ use futures::channel::oneshot::Canceled;
 use serde_json::Error as SerdeJsonError;
 use tari_comms::peer_manager::node_id::NodeIdError;
 use tari_comms_dht::outbound::DhtOutboundError;
-use tari_core::transactions::{
-    transaction::TransactionError,
-    transaction_protocol::TransactionProtocolError,
-    CoinbaseBuildError,
-};
+use tari_core::transactions::{transaction::TransactionError, transaction_protocol::TransactionProtocolError};
 use tari_p2p::services::liveness::error::LivenessError;
 use tari_service_framework::reply_channel::TransportChannelError;
 use thiserror::Error;
@@ -121,8 +117,6 @@ pub enum TransactionServiceError {
     OneshotCancelled(#[from] Canceled),
     #[error("Liveness error: `{0}`")]
     LivenessError(#[from] LivenessError),
-    #[error("Coinbase build error: `{0}`")]
-    CoinbaseBuildError(#[from] CoinbaseBuildError),
     #[error("Pending Transaction Timed out")]
     Timeout,
     #[error("Shutdown Signal Received")]

--- a/base_layer/wallet/src/transaction_service/mod.rs
+++ b/base_layer/wallet/src/transaction_service/mod.rs
@@ -44,7 +44,6 @@ use tari_comms::peer_manager::NodeIdentity;
 use tari_comms_dht::Dht;
 use tari_core::{
     base_node::proto as base_node_proto,
-    consensus::{ConsensusConstantsBuilder, Network},
     mempool::proto as mempool_proto,
     transactions::{transaction_protocol::proto, types::CryptoFactories},
 };
@@ -73,7 +72,6 @@ where T: TransactionBackend
     backend: Option<T>,
     node_identity: Arc<NodeIdentity>,
     factories: CryptoFactories,
-    network: Network,
 }
 
 impl<T> TransactionServiceInitializer<T>
@@ -85,7 +83,6 @@ where T: TransactionBackend
         backend: T,
         node_identity: Arc<NodeIdentity>,
         factories: CryptoFactories,
-        network: Network,
     ) -> Self
     {
         Self {
@@ -94,7 +91,6 @@ where T: TransactionBackend
             backend: Some(backend),
             node_identity,
             factories,
-            network,
         }
     }
 
@@ -207,7 +203,7 @@ where T: TransactionBackend + 'static
         let node_identity = self.node_identity.clone();
         let factories = self.factories.clone();
         let config = self.config.clone();
-        let constants = ConsensusConstantsBuilder::new(self.network).build();
+
         context.spawn_when_ready(move |handles| async move {
             let outbound_message_service = handles.expect_handle::<Dht>().outbound_requester();
             let output_manager_service = handles.expect_handle::<OutputManagerHandle>();
@@ -227,7 +223,6 @@ where T: TransactionBackend + 'static
                 publisher,
                 node_identity,
                 factories,
-                constants,
                 handles.get_shutdown_signal(),
             )
             .start();

--- a/base_layer/wallet/src/transaction_service/service.rs
+++ b/base_layer/wallet/src/transaction_service/service.rs
@@ -67,17 +67,14 @@ use tari_comms_dht::outbound::OutboundMessageRequester;
 use tari_core::transactions::{tari_amount::uT, types::BlindingFactor};
 use tari_core::{
     base_node::proto as base_node_proto,
-    consensus::ConsensusConstants,
     mempool::{proto as mempool_proto, service::MempoolServiceResponse},
     transactions::{
         tari_amount::MicroTari,
         transaction::Transaction,
         transaction_protocol::{proto, recipient::RecipientSignedMessage, sender::TransactionSenderMessage},
         types::{CryptoFactories, PrivateKey},
-        CoinbaseBuilder,
     },
 };
-use tari_crypto::keys::SecretKey;
 use tari_p2p::domain_message::DomainMessage;
 use tari_service_framework::{reply_channel, reply_channel::Receiver};
 use tari_shutdown::ShutdownSignal;
@@ -182,7 +179,7 @@ where
         event_publisher: TransactionEventSender,
         node_identity: Arc<NodeIdentity>,
         factories: CryptoFactories,
-        consensus_constants: ConsensusConstants,
+
         shutdown_signal: ShutdownSignal,
     ) -> Self
     {
@@ -196,7 +193,7 @@ where
             node_identity: node_identity.clone(),
             factories,
             config: config.clone(),
-            consensus_constants,
+
             shutdown_signal,
         };
         let (timeout_update_publisher, _) = broadcast::channel(20);
@@ -1639,7 +1636,7 @@ where
             .find_coinbase_transaction_at_block_height(block_height, amount)
             .await?;
 
-        let completed_transaction = match find_result {
+        let (tx_id, completed_transaction) = match find_result {
             Some(completed_tx) => {
                 debug!(
                     target: LOG_TARGET,
@@ -1649,59 +1646,48 @@ where
                     amount
                 );
 
-                completed_tx
+                (completed_tx.tx_id, completed_tx.transaction)
             },
             None => {
                 // otherwise create a new coinbase tx
                 let tx_id = OsRng.next_u64();
-                let spending_key = self
+                let tx = self
                     .output_manager_service
-                    .get_coinbase_spending_key(tx_id, amount, block_height)
+                    .get_coinbase_transaction(tx_id, reward, fees, block_height)
                     .await?;
-                let nonce = PrivateKey::random(&mut OsRng);
-                let (tx, _) = CoinbaseBuilder::new(self.resources.factories.clone())
-                    .with_block_height(block_height)
-                    .with_fees(fees)
-                    .with_spend_key(spending_key)
-                    .with_nonce(nonce)
-                    .build_with_reward(&self.resources.consensus_constants, reward)?;
 
                 // Cancel existing unmined coinbase transactions for this blockheight
                 self.db
                     .cancel_coinbase_transaction_at_block_height(block_height)
                     .await?;
 
-                let completed_tx = CompletedTransaction::new(
-                    tx_id,
-                    self.node_identity.public_key().clone(),
-                    self.node_identity.public_key().clone(),
-                    amount,
-                    MicroTari::from(0),
-                    tx.clone(),
-                    TransactionStatus::Coinbase,
-                    format!("Coinbase Transaction for Block {}", block_height),
-                    Utc::now().naive_utc(),
-                    TransactionDirection::Inbound,
-                    Some(block_height),
-                );
-
                 self.db
-                    .insert_completed_transaction(tx_id, completed_tx.clone())
+                    .insert_completed_transaction(
+                        tx_id,
+                        CompletedTransaction::new(
+                            tx_id,
+                            self.node_identity.public_key().clone(),
+                            self.node_identity.public_key().clone(),
+                            amount,
+                            MicroTari::from(0),
+                            tx.clone(),
+                            TransactionStatus::Coinbase,
+                            format!("Coinbase Transaction for Block {}", block_height),
+                            Utc::now().naive_utc(),
+                            TransactionDirection::Inbound,
+                            Some(block_height),
+                        ),
+                    )
                     .await?;
 
                 debug!(
                     target: LOG_TARGET,
-                    "Coinbase transaction (TxId: {}) for Block Height: {} added. Amount {}.",
-                    tx_id,
-                    block_height,
-                    amount
+                    "Coinbase transaction (TxId: {}) for Block Height: {} added", tx_id, block_height
                 );
-
-                completed_tx
+                (tx_id, tx)
             },
         };
 
-        let tx_id = completed_transaction.tx_id;
         if let Err(e) = self
             .start_coinbase_transaction_monitoring_protocol(tx_id, coinbase_monitoring_protocol_join_handles)
             .await
@@ -1712,7 +1698,7 @@ where
             );
         }
 
-        Ok(completed_transaction.transaction)
+        Ok(completed_transaction)
     }
 
     /// Send a request to the Base Node to see if the specified coinbase transaction has been mined yet. This function
@@ -1924,7 +1910,7 @@ where
     #[cfg(feature = "test_harness")]
     pub async fn receive_test_transaction(
         &mut self,
-        tx_id: TxId,
+        _tx_id: TxId,
         amount: MicroTari,
         source_public_key: CommsPublicKey,
     ) -> Result<(), TransactionServiceError>
@@ -1932,17 +1918,14 @@ where
         use crate::{
             output_manager_service::{
                 config::OutputManagerServiceConfig,
+                error::OutputManagerError,
                 service::OutputManagerService,
                 storage::{database::OutputManagerDatabase, memory_db::OutputManagerMemoryDatabase},
             },
             transaction_service::{handle::TransactionServiceHandle, storage::models::InboundTransaction},
         };
         use futures::stream;
-        use tari_core::{
-            consensus::{ConsensusConstantsBuilder, Network},
-            transactions::{transaction::OutputFeatures, ReceiverTransactionProtocol},
-        };
-        use tari_crypto::keys::SecretKey as SecretKeyTrait;
+        use tari_core::consensus::{ConsensusConstantsBuilder, Network};
         use tari_shutdown::Shutdown;
 
         let (_sender, receiver) = reply_channel::unbounded();
@@ -1951,7 +1934,7 @@ where
         let (ts_request_sender, _ts_request_receiver) = reply_channel::unbounded();
         let (event_publisher, _) = broadcast::channel(100);
         let ts_handle = TransactionServiceHandle::new(ts_request_sender, event_publisher.clone());
-        let constants = ConsensusConstantsBuilder::new(Network::Rincewind).build();
+        let constants = ConsensusConstantsBuilder::new(Network::Ridcully).build();
         let shutdown = Shutdown::new();
         let mut fake_oms = OutputManagerService::new(
             OutputManagerServiceConfig::default(),
@@ -1962,7 +1945,7 @@ where
             OutputManagerDatabase::new(OutputManagerMemoryDatabase::new()),
             oms_event_publisher,
             self.resources.factories.clone(),
-            constants.coinbase_lock_height(),
+            constants,
             shutdown.to_signal(),
         )
         .await?;
@@ -1982,18 +1965,19 @@ where
             .try_into()
             .map_err(TransactionServiceError::InvalidMessageError)?;
 
-        let spending_key = self
+        let (tx_id, _amount) = match sender_message.clone() {
+            TransactionSenderMessage::Single(data) => (data.tx_id, data.amount),
+            _ => {
+                return Err(TransactionServiceError::OutputManagerError(
+                    OutputManagerError::InvalidSenderMessage,
+                ))
+            },
+        };
+
+        let rtp = self
             .output_manager_service
-            .get_recipient_spending_key(tx_id, amount)
+            .get_recipient_transaction(sender_message)
             .await?;
-        let nonce = PrivateKey::random(&mut OsRng);
-        let rtp = ReceiverTransactionProtocol::new(
-            sender_message,
-            nonce,
-            spending_key.clone(),
-            OutputFeatures::default(),
-            &self.resources.factories,
-        );
 
         let inbound_transaction = InboundTransaction::new(
             tx_id,
@@ -2028,11 +2012,22 @@ where
     /// wallet sending a transaction to this wallet which will become a PendingInboundTransaction
     #[cfg(feature = "test_harness")]
     pub async fn finalize_received_test_transaction(&mut self, tx_id: TxId) -> Result<(), TransactionServiceError> {
+        use tari_core::transactions::{transaction::KernelBuilder, types::Signature};
+        use tari_crypto::commitment::HomomorphicCommitmentFactory;
+
+        let factories = CryptoFactories::default();
+
         let inbound_txs = self.db.get_pending_inbound_transactions().await?;
 
         let found_tx = inbound_txs.get(&tx_id).ok_or_else(|| {
             TransactionServiceError::TestHarnessError("Could not find Pending Inbound TX to finalize.".to_string())
         })?;
+
+        let kernel = KernelBuilder::new()
+            .with_excess(&factories.commitment.zero())
+            .with_signature(&Signature::default())
+            .build()
+            .unwrap();
 
         let completed_transaction = CompletedTransaction::new(
             tx_id,
@@ -2040,7 +2035,7 @@ where
             self.node_identity.public_key().clone(),
             found_tx.amount,
             MicroTari::from(2000), // a placeholder fee for this test function
-            Transaction::new(Vec::new(), Vec::new(), Vec::new(), BlindingFactor::default()),
+            Transaction::new(Vec::new(), Vec::new(), vec![kernel], BlindingFactor::default()),
             TransactionStatus::Completed,
             found_tx.message.clone(),
             found_tx.timestamp,
@@ -2078,7 +2073,6 @@ where TBackend: TransactionBackend + 'static
     pub node_identity: Arc<NodeIdentity>,
     pub factories: CryptoFactories,
     pub config: TransactionServiceConfig,
-    pub consensus_constants: ConsensusConstants,
     pub shutdown_signal: ShutdownSignal,
 }
 

--- a/base_layer/wallet/src/wallet.rs
+++ b/base_layer/wallet/src/wallet.rs
@@ -192,7 +192,6 @@ where
                 transaction_backend,
                 node_identity.clone(),
                 factories.clone(),
-                config.network,
             ))
             .add_initializer(ContactsServiceInitializer::new(contacts_backend));
 

--- a/base_layer/wallet/tests/transaction_service/service.rs
+++ b/base_layer/wallet/tests/transaction_service/service.rs
@@ -164,7 +164,7 @@ pub fn setup_transaction_service<T: TransactionBackend + 'static, P: AsRef<Path>
             subscription_factory.clone(),
             OutputManagerMemoryDatabase::new(),
             factories.clone(),
-            Network::Rincewind,
+            Network::Ridcully,
         ))
         .add_initializer(TransactionServiceInitializer::new(
             TransactionServiceConfig {
@@ -177,7 +177,6 @@ pub fn setup_transaction_service<T: TransactionBackend + 'static, P: AsRef<Path>
             backend,
             comms.node_identity().clone(),
             factories.clone(),
-            Network::Rincewind,
         ))
         .build();
 
@@ -257,7 +256,7 @@ pub fn setup_transaction_service_no_comms_and_oms_backend<
 
     let outbound_mock_state = mock_outbound_service.get_state();
     runtime.spawn(mock_outbound_service.run());
-    let constants = ConsensusConstantsBuilder::new(Network::Rincewind).build();
+    let constants = ConsensusConstantsBuilder::new(Network::Ridcully).build();
 
     let shutdown = Shutdown::new();
 
@@ -271,13 +270,12 @@ pub fn setup_transaction_service_no_comms_and_oms_backend<
             OutputManagerDatabase::new(oms_backend),
             oms_event_publisher.clone(),
             factories.clone(),
-            constants.coinbase_lock_height(),
+            constants,
             shutdown.to_signal(),
         ))
         .unwrap();
 
     let output_manager_service_handle = OutputManagerHandle::new(oms_request_sender, oms_event_publisher);
-    let constants = ConsensusConstantsBuilder::new(Network::Rincewind).build();
 
     let test_config = config.unwrap_or(TransactionServiceConfig {
         broadcast_monitoring_timeout: Duration::from_secs(5),
@@ -307,7 +305,6 @@ pub fn setup_transaction_service_no_comms_and_oms_backend<
             NodeIdentity::random(&mut OsRng, get_next_memory_address(), PeerFeatures::COMMUNICATION_NODE).unwrap(),
         ),
         factories.clone(),
-        constants,
         shutdown.to_signal(),
     );
     runtime.spawn(async move { output_manager_service.start().await.unwrap() });

--- a/base_layer/wallet/tests/wallet/mod.rs
+++ b/base_layer/wallet/tests/wallet/mod.rs
@@ -139,7 +139,7 @@ async fn create_wallet(
         factories,
         Some(transaction_service_config),
         None,
-        Network::Rincewind,
+        Network::Ridcully,
         None,
         None,
         None,
@@ -595,7 +595,7 @@ async fn test_import_utxo() {
         factories.clone(),
         None,
         None,
-        Network::Rincewind,
+        Network::Ridcully,
         None,
         None,
         None,
@@ -670,16 +670,7 @@ async fn test_data_generation() {
         dns_seeds_use_dnssec: false,
     };
 
-    let config = WalletConfig::new(
-        comms_config,
-        factories,
-        None,
-        None,
-        Network::Rincewind,
-        None,
-        None,
-        None,
-    );
+    let config = WalletConfig::new(comms_config, factories, None, None, Network::Ridcully, None, None, None);
 
     let transaction_backend = TransactionMemoryDatabase::new();
 

--- a/base_layer/wallet_ffi/Cargo.toml
+++ b/base_layer/wallet_ffi/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2018"
 [dependencies]
 tari_comms = { version = "^0.2", path = "../../comms" }
 tari_comms_dht = { version = "^0.2.1", path = "../../comms/dht" }
-tari_crypto = { version = "^0.8" }
+tari_crypto = { version = "^0.8", git = "https://github.com/tari-project/tari-crypto", branch="main"}
 tari_p2p = { version = "^0.2", path = "../p2p" }
 tari_wallet = { version = "^0.2.2", path = "../wallet", features = ["test_harness", "c_integration"]}
 tari_shutdown = { version = "^0.2", path = "../../infrastructure/shutdown" }

--- a/comms/Cargo.toml
+++ b/comms/Cargo.toml
@@ -10,7 +10,7 @@ version = "0.2.13"
 edition = "2018"
 
 [dependencies]
-tari_crypto = { version = "^0.8" }
+tari_crypto = { version = "^0.8", git = "https://github.com/tari-project/tari-crypto", branch="main"}
 tari_storage = { version = "^0.2", path = "../infrastructure/storage" }
 tari_shutdown = { version="^0.2",  path = "../infrastructure/shutdown" }
 

--- a/comms/dht/Cargo.toml
+++ b/comms/dht/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2018"
 [dependencies]
 tari_comms  = { version = "^0.2", path = "../", features = ["rpc"]}
 tari_comms_rpc_macros  = { version = "^0.1", path = "../rpc_macros"}
-tari_crypto = { version = "^0.8" }
+tari_crypto = { version = "^0.8", git = "https://github.com/tari-project/tari-crypto", branch="main"}
 tari_utilities  = { version = "^0.3" }
 tari_shutdown = { version = "^0.2", path = "../../infrastructure/shutdown"}
 tari_storage  = { version = "^0.2", path = "../../infrastructure/storage"}


### PR DESCRIPTION
## Description

This PR adds the ability for outputs generated in transactions to be generated using rewind keys that can allow for a partial or full rewinding or a range proof. The Output Manager Service now derives two extra keys using the master_seed key and two special branches in the key manager to be used as a `rewind_key` and `rewind_blinding_key`. All transactions that are produced by the wallet (Coinbases, Sender and Recipient transactions) will now be rewindable using these keys. The public versions allow for the first level of rewinding that reveals the proof message and value and the private versions allow for a full rewind to also reveal the spending key.

It is crucial to note that the private `rewind_key` and `rewind_blinding_key` are both extremely sensitive. Because we use the same keys for all outputs generated by a given wallet if these keys are compromised the entire wallet is compromised, not just the spending key for a single UTXO. Thus a focus of the updates to the Transaction negotiation protocols and CoinbaseBuilder in the `tari_core` crate was to ensure that the private rewind keys are only ever used in memory and are never serialised in the output of the protocols. They are only ever included in the serialised output as fully formed range proofs which are secure. 

A Public API call was added to the Output Manager Service to return the public rewind keys for use as view keys and to use in testing.

The PR does not provide wallet restoration or the functionality to use the view keys as yet.

Summary:
- Added `as_rewindable_transaction_output` to Unblinded Output
- Added two levels of rewinding to `TransactionOutput`
- Added being able to produce a rewindable output to `ReceiverTransactionProtocol`
- Added being able to produce a rewindable change output to `SenderTransactionInitializer` and the `SingleReceiverTransactionProtocol`
- Added being able to produce rewindable Coinbase outputs to the `CoinbaseBuilder`
- Updated OutputManagerService to produce the two rewind keys from its embedded KeyManager
- Updated requesting the Recipients half of a inbound transaction to use rewindable outputs
- Updated producing the Sender half of an outbound transaction to use rewindable outputs and change.
- Updated producing a Coinbase transaction to create a rewindable output
- Add API to get public rewind keys from Output Manager to allow for testing rewind and providing view keys.

## Motivation and Context
This is the first half of what is needed for wallet restoration, this PR will mean that outputs on the blockchain will now be rewindable with keys generated from the wallet's master seed.

## How Has This Been Tested?
Tests were provided for all the elements added to 'tari_core' and tests were added and updated in the wallet to check for rewindability

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [x] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch.
* [x] I ran `cargo-fmt --all` before pushing.
* [x] I ran `cargo test` successfully before submitting my PR.
* [x] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
