### PR TITLE
Fix feature flags for wallet build

### DIFF
--- a/base_layer/core/src/base_node/proto/mod.rs
+++ b/base_layer/core/src/base_node/proto/mod.rs
@@ -22,7 +22,10 @@
 
 pub use crate::proto::generated::base_node::*;
 
-pub mod chain_metadata;
-pub mod mmr_tree;
-pub mod request;
-pub mod response;
+mod chain_metadata;
+#[cfg(feature = "base_node")]
+mod mmr_tree;
+#[cfg(feature = "base_node")]
+mod request;
+#[cfg(feature = "base_node")]
+mod response;

--- a/base_layer/core/src/mempool/mod.rs
+++ b/base_layer/core/src/mempool/mod.rs
@@ -62,13 +62,14 @@ pub use self::config::{MempoolConfig, MempoolServiceConfig};
 pub use error::MempoolError;
 #[cfg(feature = "base_node")]
 pub use mempool::{Mempool, MempoolValidators};
-#[cfg(feature = "base_node")]
-pub use service::{MempoolServiceError, MempoolServiceInitializer, OutboundMempoolServiceInterface};
 
 #[cfg(any(feature = "base_node", feature = "mempool_proto"))]
 pub mod proto;
+
 #[cfg(any(feature = "base_node", feature = "mempool_proto"))]
 pub mod service;
+#[cfg(feature = "base_node")]
+pub use service::{MempoolServiceError, MempoolServiceInitializer, OutboundMempoolServiceInterface};
 
 #[cfg(feature = "base_node")]
 mod sync_protocol;


### PR DESCRIPTION
Quick fix: Ensure that compile succeeds when `base_node` feature is disabled
