### PR TITLE
Exchange chain metadata with all connected nodes

### DIFF
--- a/base_layer/p2p/src/services/liveness/service.rs
+++ b/base_layer/p2p/src/services/liveness/service.rs
@@ -245,10 +245,7 @@ where
     async fn start_ping_round(&mut self) -> Result<(), LivenessError> {
         let selected_peers = self
             .connectivity
-            .select_connections(ConnectivitySelection::random_nodes(
-                self.config.num_peers_per_round,
-                Default::default(),
-            ))
+            .select_connections(ConnectivitySelection::all_nodes(vec![]))
             .await?;
 
         if selected_peers.is_empty() {


### PR DESCRIPTION
Include all connected nodes in ping rounds. This will reduce the time to
recognise a node advertising higher accumulated PoW in their chain
metadata.

This PR is up for discussion and is mainly to show where to make the change
should the community decide it is a good idea.