### PR TITLE
Added Ridcully dns seed

### DIFF
--- a/base_layer/p2p/src/initialization.rs
+++ b/base_layer/p2p/src/initialization.rs
@@ -486,8 +486,16 @@ impl P2pInitializer {
         let start = Instant::now();
 
         let resolver = if use_dnssec {
+            debug!(
+                target: LOG_TARGET,
+                "Using {} to resove DNS seeds. DNSSEC is enabled", resolver_addr
+            );
             DnsSeedResolver::connect_secure(resolver_addr).await?
         } else {
+            debug!(
+                target: LOG_TARGET,
+                "Using {} to resove DNS seeds. DNSSEC is disabled", resolver_addr
+            );
             DnsSeedResolver::connect(resolver_addr).await?
         };
         let resolving = dns_seeds.iter().map(|addr| {

--- a/common/config/presets/tari_sample.toml
+++ b/common/config/presets/tari_sample.toml
@@ -20,6 +20,8 @@ grpc_enabled = true
 grpc_base_node_address = "127.0.0.1:18142"
 grpc_console_wallet_address = "127.0.0.1:18143"
 transport = "tor"
+dns_seeds =["seeds.ridcully.tari.com"]
+dns_seeds_use_dnssec = false
 
 [merge_mining_proxy.ridcully]
 monerod_url = "http://18.133.55.120:38081"

--- a/common/config/presets/windows.toml
+++ b/common/config/presets/windows.toml
@@ -185,11 +185,11 @@ peer_seeds = [
 # DNS seeds
 # The DNS records in these hostnames should provide TXT records as per https://github.com/tari-project/tari/pull/2319
 # Enter a domain name for the TXT records: seeds.tari.com
-dns_seeds = []
+dns_seeds =["seeds.ridcully.tari.com"]
 # The name server used to resolve DNS seeds
 # dns_seeds_name_server = "1.1.1.1:53"
 # Set to true to only accept DNS records that pass DNSSEC validation (Default: true)
-# dns_seeds_use_dnssec = true
+dns_seeds_use_dnssec = false
 
 # Determines the method of syncing blocks when the node is lagging. If you are not struggling with syncing, then
 # it is recommended to leave this setting as it. Available values are ViaBestChainMetadata and ViaRandomPeer.

--- a/common/config/tari_config_example.toml
+++ b/common/config/tari_config_example.toml
@@ -183,6 +183,12 @@ peer_seeds = [
     "ac7fba427913a653a27b69c05549e14d9e87cb7849ea0c740d6c8a5855a3882a::/onion3/avteohvrvvfy4fff7ona2wy6yhb7i4ss4aklp74v64knofvev3vd5yyd:18141",
 ]
 
+# DNS seeds
+# The DNS records in these hostnames should provide TXT records as per https://github.com/tari-project/tari/pull/2319
+# Enter a domain name for the TXT records: seeds.tari.com
+dns_seeds =["seeds.ridcully.tari.com"]
+dns_seeds_use_dnssec = false
+
 # Determines the method of syncing blocks when the node is lagging. If you are not struggling with syncing, then
 # it is recommended to leave this setting as it. Available values are ViaBestChainMetadata and ViaRandomPeer.
 #block_sync_strategy="ViaBestChainMetadata"


### PR DESCRIPTION
Added `dns_seeds =["seeds.ridcully.tari.com"]` default for ridcully config
`seeds.ridcully.tari.com` does not currently support DNSSEC and so that has been turned off