### PR TITLE
Only clean orphans after syncing

### DIFF
--- a/base_layer/core/src/base_node/comms_interface/inbound_handlers.rs
+++ b/base_layer/core/src/base_node/comms_interface/inbound_handlers.rs
@@ -556,6 +556,8 @@ where T: BlockchainBackend + 'static
                     BlockAddResult::ChainReorg(_, _) => true,
                 };
 
+                self.blockchain_db.cleanup_orphans().await?;
+
                 self.publish_block_event(BlockEvent::ValidBlockAdded(block, block_add_result, broadcast));
 
                 if should_propagate && broadcast.is_true() {

--- a/base_layer/core/src/base_node/sync/block_sync/synchronizer.rs
+++ b/base_layer/core/src/base_node/sync/block_sync/synchronizer.rs
@@ -90,6 +90,7 @@ impl<B: BlockchainBackend + 'static> BlockSynchronizer<B> {
         );
         self.attempt_block_sync(peer_conn).await?;
 
+        self.db.cleanup_all_orphans().await?;
         Ok(())
     }
 

--- a/base_layer/core/src/chain_storage/async_db.rs
+++ b/base_layer/core/src/chain_storage/async_db.rs
@@ -183,6 +183,8 @@ impl<B: BlockchainBackend + 'static> AsyncBlockchainDb<B> {
     //---------------------------------- Block --------------------------------------------//
     make_async_fn!(add_block(block: Arc<Block>) -> BlockAddResult, "add_block");
 
+    make_async_fn!(cleanup_orphans() -> (), "cleanup_orphans");
+
     make_async_fn!(cleanup_all_orphans() -> (), "cleanup_all_orphans");
 
     make_async_fn!(block_exists(block_hash: BlockHash) -> bool, "block_exists");

--- a/base_layer/core/src/chain_storage/blockchain_database.rs
+++ b/base_layer/core/src/chain_storage/blockchain_database.rs
@@ -799,14 +799,6 @@ where B: BlockchainBackend
             block,
         )?;
 
-        // Cleanup orphan block pool
-        match block_add_result {
-            BlockAddResult::OrphanBlock | BlockAddResult::ChainReorg(_, _) => {
-                cleanup_orphans(&mut *db, self.config.orphan_storage_capacity)?
-            },
-            _ => {},
-        }
-
         // Cleanup of backend when in pruned mode.
         match block_add_result {
             BlockAddResult::Ok(_) | BlockAddResult::ChainReorg(_, _) => prune_database(
@@ -824,6 +816,13 @@ where B: BlockchainBackend
             &new_height
         );
         Ok(block_add_result)
+    }
+
+    /// Clean out the entire orphan pool
+    pub fn cleanup_orphans(&self) -> Result<(), ChainStorageError> {
+        let mut db = self.db_write_access()?;
+        let _ = cleanup_orphans(&mut *db, self.config.orphan_storage_capacity)?;
+        Ok(())
     }
 
     /// Clean out the entire orphan pool


### PR DESCRIPTION
Instead of checking and deleting orphans on every block add, this changes the logic to only run clean up after batches have completed. 