### PR TITLE
Implement Base Node Wallet RPC service

### DIFF
--- a/applications/tari_base_node/src/bootstrap/base_node.rs
+++ b/applications/tari_base_node/src/bootstrap/base_node.rs
@@ -194,8 +194,12 @@ where B: BlockchainBackend + 'static
         // Add your RPC services here ‍🏴‍☠️️☮️🌊
         let rpc_server = RpcServer::new()
             .add_service(dht.rpc_service())
-            .add_service(base_node::create_base_node_sync_rpc_service(db))
+            .add_service(base_node::create_base_node_sync_rpc_service(db.clone()))
             .add_service(mempool::create_mempool_rpc_service(
+                handles.expect_handle::<MempoolHandle>(),
+            ))
+            .add_service(base_node::rpc::create_base_node_wallet_rpc_service(
+                db,
                 handles.expect_handle::<MempoolHandle>(),
             ));
 

--- a/applications/tari_base_node/src/grpc/base_node_grpc_server.rs
+++ b/applications/tari_base_node/src/grpc/base_node_grpc_server.rs
@@ -448,10 +448,14 @@ impl tari_rpc::base_node_server::BaseNode for BaseNodeGrpcServer {
             TxStorageResponse::UnconfirmedPool => tari_rpc::SubmitTransactionResponse {
                 result: tari_rpc::SubmitTransactionResult::Accepted.into(),
             },
-            TxStorageResponse::ReorgPool => tari_rpc::SubmitTransactionResponse {
-                result: tari_rpc::SubmitTransactionResult::AlreadyMined.into(),
+            TxStorageResponse::ReorgPool | TxStorageResponse::NotStoredAlreadySpent => {
+                tari_rpc::SubmitTransactionResponse {
+                    result: tari_rpc::SubmitTransactionResult::AlreadyMined.into(),
+                }
             },
-            TxStorageResponse::NotStored => tari_rpc::SubmitTransactionResponse {
+            TxStorageResponse::NotStored |
+            TxStorageResponse::NotStoredOrphan |
+            TxStorageResponse::NotStoredTimeLocked => tari_rpc::SubmitTransactionResponse {
                 result: tari_rpc::SubmitTransactionResult::Rejected.into(),
             },
         };

--- a/base_layer/core/src/base_node/chain_metadata_service/service.rs
+++ b/base_layer/core/src/base_node/chain_metadata_service/service.rs
@@ -25,9 +25,9 @@ use crate::{
     base_node::{
         chain_metadata_service::handle::{ChainMetadataEvent, PeerChainMetadata},
         comms_interface::{BlockEvent, LocalNodeCommsInterface},
-        proto,
     },
     chain_storage::BlockAddResult,
+    proto::generated::base_node as proto,
 };
 use futures::stream::StreamExt;
 use log::*;

--- a/base_layer/core/src/base_node/mod.rs
+++ b/base_layer/core/src/base_node/mod.rs
@@ -59,3 +59,6 @@ pub use sync::{
 
 #[cfg(any(feature = "base_node", feature = "base_node_proto"))]
 pub mod proto;
+
+#[cfg(feature = "base_node")]
+pub mod rpc;

--- a/base_layer/core/src/base_node/proto/chain_metadata.rs
+++ b/base_layer/core/src/base_node/proto/chain_metadata.rs
@@ -20,7 +20,7 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use crate::base_node::proto;
+use crate::proto::generated::base_node as proto;
 use std::{convert::TryFrom, mem};
 use tari_common_types::chain_metadata::ChainMetadata;
 

--- a/base_layer/core/src/base_node/proto/mmr_tree.rs
+++ b/base_layer/core/src/base_node/proto/mmr_tree.rs
@@ -20,7 +20,7 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use crate::{base_node::proto, chain_storage::MmrTree};
+use crate::{chain_storage::MmrTree, proto::generated::base_node as proto};
 use std::convert::TryFrom;
 
 impl TryFrom<proto::MmrTree> for MmrTree {

--- a/base_layer/core/src/base_node/proto/mod.rs
+++ b/base_layer/core/src/base_node/proto/mod.rs
@@ -20,9 +20,9 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-pub use crate::proto::generated::base_node::*;
-
 mod chain_metadata;
+pub mod wallet_response;
+
 #[cfg(feature = "base_node")]
 mod mmr_tree;
 #[cfg(feature = "base_node")]

--- a/base_layer/core/src/base_node/proto/request.rs
+++ b/base_layer/core/src/base_node/proto/request.rs
@@ -20,17 +20,20 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use super::{
-    base_node_service_request::Request as ProtoNodeCommsRequest,
-    BlockHeights,
-    FetchHeadersAfter as ProtoFetchHeadersAfter,
-    FetchMatchingMmrNodes as ProtoFetchMmrNodes,
-    FetchMmrNodeCount as ProtoFetchMmrNodeCount,
-    HashOutputs,
-};
 use crate::{
     base_node::comms_interface as ci,
     proof_of_work::PowAlgorithm,
+    proto::generated::{
+        base_node as proto,
+        base_node::{
+            base_node_service_request::Request as ProtoNodeCommsRequest,
+            BlockHeights,
+            FetchHeadersAfter as ProtoFetchHeadersAfter,
+            FetchMatchingMmrNodes as ProtoFetchMmrNodes,
+            FetchMmrNodeCount as ProtoFetchMmrNodeCount,
+            HashOutputs,
+        },
+    },
     transactions::types::{Commitment, HashOutput, Signature},
 };
 use std::convert::{From, TryFrom, TryInto};
@@ -114,15 +117,15 @@ impl From<ci::NodeCommsRequest> for ProtoNodeCommsRequest {
             FetchBlocksWithHashes(block_hashes) => ProtoNodeCommsRequest::FetchBlocksWithHashes(block_hashes.into()),
             FetchBlocksWithKernels(signatures) => {
                 let sigs = signatures.into_iter().map(Into::into).collect();
-                ProtoNodeCommsRequest::FetchBlocksWithKernels(super::Signatures { sigs })
+                ProtoNodeCommsRequest::FetchBlocksWithKernels(proto::Signatures { sigs })
             },
             FetchBlocksWithStxos(commitments) => {
                 let commits = commitments.into_iter().map(Into::into).collect();
-                ProtoNodeCommsRequest::FetchBlocksWithStxos(super::Commitments { commitments: commits })
+                ProtoNodeCommsRequest::FetchBlocksWithStxos(proto::Commitments { commitments: commits })
             },
             FetchBlocksWithUtxos(commitments) => {
                 let commits = commitments.into_iter().map(Into::into).collect();
-                ProtoNodeCommsRequest::FetchBlocksWithUtxos(super::Commitments { commitments: commits })
+                ProtoNodeCommsRequest::FetchBlocksWithUtxos(proto::Commitments { commitments: commits })
             },
             GetNewBlockTemplate(pow_algo) => ProtoNodeCommsRequest::GetNewBlockTemplate(pow_algo as u64),
             GetNewBlock(block_template) => ProtoNodeCommsRequest::GetNewBlock(block_template.into()),

--- a/base_layer/core/src/base_node/proto/response.rs
+++ b/base_layer/core/src/base_node/proto/response.rs
@@ -20,11 +20,14 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-pub use super::base_node_service_response::Response as ProtoNodeCommsResponse;
+pub use crate::proto::generated::base_node::base_node_service_response::Response as ProtoNodeCommsResponse;
 use crate::{
-    base_node::{
-        comms_interface as ci,
-        proto::{
+    base_node::comms_interface as ci,
+    proof_of_work::Difficulty,
+    proto,
+    proto::{
+        core as core_proto_types,
+        generated::base_node::{
             BlockHeaders as ProtoBlockHeaders,
             HistoricalBlocks as ProtoHistoricalBlocks,
             MmrNodes as ProtoMmrNodes,
@@ -33,9 +36,6 @@ use crate::{
             TransactionOutputs as ProtoTransactionOutputs,
         },
     },
-    proof_of_work::Difficulty,
-    proto,
-    proto::core as core_proto_types,
     tari_utilities::convert::try_convert_all,
 };
 use std::{

--- a/base_layer/core/src/base_node/proto/rpc.rs
+++ b/base_layer/core/src/base_node/proto/rpc.rs
@@ -20,7 +20,7 @@
 //  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 //  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use crate::{base_node::proto, blocks::Block, tari_utilities::Hashable};
+use crate::{blocks::Block, proto::generated::base_node as proto, tari_utilities::Hashable};
 
 impl From<Block> for proto::BlockBodyResponse {
     fn from(block: Block) -> Self {

--- a/base_layer/core/src/base_node/proto/wallet_response.proto
+++ b/base_layer/core/src/base_node/proto/wallet_response.proto
@@ -1,0 +1,33 @@
+syntax = "proto3";
+
+import "google/protobuf/wrappers.proto";
+import "block.proto";
+
+package tari.base_node;
+
+enum TxSubmissionRejectionReason {
+    TxSubmissionRejectionReasonNone = 0;
+    TxSubmissionRejectionReasonAlreadyMined = 1;
+    TxSubmissionRejectionReasonDoubleSpend = 2;
+    TxSubmissionRejectionReasonOrphan = 3;
+    TxSubmissionRejectionReasonTimeLocked = 4;
+    TxSubmissionRejectionReasonValidationFailed = 5;
+}
+
+message TxSubmissionResponse {
+    bool accepted = 1;
+    TxSubmissionRejectionReason rejection_reason = 2;
+}
+
+enum TxLocation {
+    TxLocationNone = 0;
+    TxLocationNotStored = 1;
+    TxLocationInMempool = 2;
+    TxLocationMined = 3;
+}
+
+message TxQueryResponse {
+    TxLocation location = 1;
+    google.protobuf.BytesValue block_hash = 2;
+    uint64 confirmations = 3;
+}

--- a/base_layer/core/src/base_node/proto/wallet_response.rs
+++ b/base_layer/core/src/base_node/proto/wallet_response.rs
@@ -1,0 +1,165 @@
+// Copyright 2020. The Tari Project
+//
+// Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+// following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+// disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+// following disclaimer in the documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+// products derived from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+// INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+// WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+// USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+use crate::proto::generated::base_node as proto;
+use serde::{Deserialize, Serialize};
+use std::{
+    convert::TryFrom,
+    fmt::{Display, Error, Formatter},
+};
+use tari_common_types::types::BlockHash;
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct TxSubmissionResponse {
+    pub accepted: bool,
+    pub rejection_reason: TxSubmissionRejectionReason,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub enum TxSubmissionRejectionReason {
+    AlreadyMined,
+    DoubleSpend,
+    Orphan,
+    TimeLocked,
+    ValidationFailed,
+}
+
+impl Display for TxSubmissionRejectionReason {
+    fn fmt(&self, fmt: &mut Formatter<'_>) -> Result<(), Error> {
+        let response = match self {
+            TxSubmissionRejectionReason::AlreadyMined => "Already Mined ",
+            TxSubmissionRejectionReason::DoubleSpend => "Double Spend",
+            TxSubmissionRejectionReason::Orphan => "Orphan",
+            TxSubmissionRejectionReason::TimeLocked => "Time Locked",
+            TxSubmissionRejectionReason::ValidationFailed => "Validation Failed",
+        };
+        fmt.write_str(&response)
+    }
+}
+
+impl TryFrom<proto::TxSubmissionRejectionReason> for TxSubmissionRejectionReason {
+    type Error = String;
+
+    fn try_from(tx_rejection_reason: proto::TxSubmissionRejectionReason) -> Result<Self, Self::Error> {
+        use proto::TxSubmissionRejectionReason::*;
+        Ok(match tx_rejection_reason {
+            None => return Err("TxSubmissionRejectionReason not provided".to_string()),
+            AlreadyMined => TxSubmissionRejectionReason::AlreadyMined,
+            DoubleSpend => TxSubmissionRejectionReason::DoubleSpend,
+            Orphan => TxSubmissionRejectionReason::Orphan,
+            TimeLocked => TxSubmissionRejectionReason::TimeLocked,
+            ValidationFailed => TxSubmissionRejectionReason::ValidationFailed,
+        })
+    }
+}
+
+impl From<TxSubmissionRejectionReason> for proto::TxSubmissionRejectionReason {
+    fn from(resp: TxSubmissionRejectionReason) -> Self {
+        use TxSubmissionRejectionReason::*;
+        match resp {
+            AlreadyMined => proto::TxSubmissionRejectionReason::AlreadyMined,
+            DoubleSpend => proto::TxSubmissionRejectionReason::DoubleSpend,
+            Orphan => proto::TxSubmissionRejectionReason::Orphan,
+            TimeLocked => proto::TxSubmissionRejectionReason::TimeLocked,
+            ValidationFailed => proto::TxSubmissionRejectionReason::ValidationFailed,
+        }
+    }
+}
+
+impl TryFrom<proto::TxSubmissionResponse> for TxSubmissionResponse {
+    type Error = String;
+
+    fn try_from(value: proto::TxSubmissionResponse) -> Result<Self, Self::Error> {
+        Ok(Self {
+            accepted: value.accepted,
+            rejection_reason: TxSubmissionRejectionReason::try_from(
+                proto::TxSubmissionRejectionReason::from_i32(value.rejection_reason)
+                    .ok_or_else(|| "Invalid or unrecognised `TxSubmissionRejectionReason` enum".to_string())?,
+            )?,
+        })
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct TxQueryResponse {
+    pub location: TxLocation,
+    pub block_hash: Option<BlockHash>,
+    pub confirmations: u64,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub enum TxLocation {
+    NotStored,
+    InMempool,
+    Mined,
+}
+
+impl Display for TxLocation {
+    fn fmt(&self, fmt: &mut Formatter<'_>) -> Result<(), Error> {
+        let response = match self {
+            TxLocation::NotStored => "Not Stored",
+            TxLocation::InMempool => "In Mempool",
+            TxLocation::Mined => "Mined",
+        };
+        fmt.write_str(&response)
+    }
+}
+
+impl TryFrom<proto::TxLocation> for TxLocation {
+    type Error = String;
+
+    fn try_from(tx_location: proto::TxLocation) -> Result<Self, Self::Error> {
+        use proto::TxLocation::*;
+        Ok(match tx_location {
+            None => return Err("TxLocation not provided".to_string()),
+            NotStored => TxLocation::NotStored,
+            InMempool => TxLocation::InMempool,
+            Mined => TxLocation::Mined,
+        })
+    }
+}
+
+impl From<TxLocation> for proto::TxLocation {
+    fn from(resp: TxLocation) -> Self {
+        use TxLocation::*;
+        match resp {
+            NotStored => proto::TxLocation::NotStored,
+            InMempool => proto::TxLocation::InMempool,
+            Mined => proto::TxLocation::Mined,
+        }
+    }
+}
+
+impl TryFrom<proto::TxQueryResponse> for TxQueryResponse {
+    type Error = String;
+
+    fn try_from(proto_response: proto::TxQueryResponse) -> Result<Self, Self::Error> {
+        Ok(Self {
+            location: TxLocation::try_from(
+                proto::TxLocation::from_i32(proto_response.location)
+                    .ok_or_else(|| "Invalid or unrecognised `TxLocation` enum".to_string())?,
+            )?,
+            block_hash: proto_response.block_hash,
+            confirmations: proto_response.confirmations,
+        })
+    }
+}

--- a/base_layer/core/src/base_node/rpc/service.rs
+++ b/base_layer/core/src/base_node/rpc/service.rs
@@ -1,0 +1,194 @@
+//  Copyright 2020, The Tari Project
+//
+//  Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+//  following conditions are met:
+//
+//  1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+//  disclaimer.
+//
+//  2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+//  following disclaimer in the documentation and/or other materials provided with the distribution.
+//
+//  3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+//  products derived from this software without specific prior written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+//  INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+//  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+//  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+//  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+//  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+//  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+use crate::{
+    base_node::rpc::BaseNodeWalletService,
+    chain_storage::{async_db::AsyncBlockchainDb, BlockchainBackend},
+    mempool::service::MempoolHandle,
+    proto::generated::{
+        base_node::{TxLocation, TxQueryResponse, TxSubmissionResponse},
+        types::{Signature as SignatureProto, Transaction as TransactionProto},
+    },
+};
+
+use crate::{
+    mempool::TxStorageResponse,
+    proto::generated::base_node::TxSubmissionRejectionReason,
+    transactions::{transaction::Transaction, types::Signature},
+};
+use std::convert::TryFrom;
+use tari_comms::protocol::rpc::{Request, Response, RpcStatus};
+
+const LOG_TARGET: &str = "c::base_node::rpc";
+
+pub struct BaseNodeWalletRpcService<B> {
+    db: AsyncBlockchainDb<B>,
+    mempool: MempoolHandle,
+}
+
+impl<B: BlockchainBackend + 'static> BaseNodeWalletRpcService<B> {
+    pub fn new(db: AsyncBlockchainDb<B>, mempool: MempoolHandle) -> Self {
+        Self { db, mempool }
+    }
+
+    #[inline]
+    fn db(&self) -> AsyncBlockchainDb<B> {
+        self.db.clone()
+    }
+
+    #[inline]
+    pub fn mempool(&self) -> MempoolHandle {
+        self.mempool.clone()
+    }
+}
+
+#[tari_comms::async_trait]
+impl<B: BlockchainBackend + 'static> BaseNodeWalletService for BaseNodeWalletRpcService<B> {
+    async fn submit_transaction(
+        &self,
+        request: Request<TransactionProto>,
+    ) -> Result<Response<TxSubmissionResponse>, RpcStatus>
+    {
+        let message = request.into_message();
+        let transaction =
+            Transaction::try_from(message).map_err(|_| RpcStatus::bad_request("Transaction was invalid"))?;
+        let mut mempool = self.mempool();
+        let response = match mempool
+            .submit_transaction(transaction.clone())
+            .await
+            .map_err(RpcStatus::log_internal_error(LOG_TARGET))?
+        {
+            TxStorageResponse::UnconfirmedPool => TxSubmissionResponse {
+                accepted: true,
+                rejection_reason: TxSubmissionRejectionReason::None.into(),
+            },
+
+            TxStorageResponse::NotStoredOrphan => TxSubmissionResponse {
+                accepted: false,
+                rejection_reason: TxSubmissionRejectionReason::Orphan.into(),
+            },
+            TxStorageResponse::NotStoredTimeLocked => TxSubmissionResponse {
+                accepted: false,
+                rejection_reason: TxSubmissionRejectionReason::TimeLocked.into(),
+            },
+
+            TxStorageResponse::NotStored => TxSubmissionResponse {
+                accepted: false,
+                rejection_reason: TxSubmissionRejectionReason::ValidationFailed.into(),
+            },
+            TxStorageResponse::NotStoredAlreadySpent | TxStorageResponse::ReorgPool => {
+                // Is this transaction a double spend or has this transaction been mined?
+                match transaction.first_kernel_excess_sig() {
+                    None => TxSubmissionResponse {
+                        accepted: false,
+                        rejection_reason: TxSubmissionRejectionReason::DoubleSpend.into(),
+                    },
+                    Some(s) => {
+                        // Check to see if the kernel exists in the blockchain db in which case this exact transaction
+                        // already exists in the chain, otherwise it is a double spend
+                        let db = self.db();
+                        match db
+                            .fetch_kernel_by_excess_sig(s.clone())
+                            .await
+                            .map_err(RpcStatus::log_internal_error(LOG_TARGET))?
+                        {
+                            None => TxSubmissionResponse {
+                                accepted: false,
+                                rejection_reason: TxSubmissionRejectionReason::DoubleSpend.into(),
+                            },
+                            Some(_) => TxSubmissionResponse {
+                                accepted: false,
+                                rejection_reason: TxSubmissionRejectionReason::AlreadyMined.into(),
+                            },
+                        }
+                    },
+                }
+            },
+        };
+        Ok(Response::new(response))
+    }
+
+    async fn transaction_query(
+        &self,
+        request: Request<SignatureProto>,
+    ) -> Result<Response<TxQueryResponse>, RpcStatus>
+    {
+        let message = request.into_message();
+        let signature = Signature::try_from(message).map_err(|_| RpcStatus::bad_request("Signature was invalid"))?;
+
+        let db = self.db();
+        match db
+            .fetch_kernel_by_excess_sig(signature.clone())
+            .await
+            .map_err(RpcStatus::log_internal_error(LOG_TARGET))?
+        {
+            None => (),
+            Some((_, block_hash)) => {
+                match db
+                    .fetch_header_by_block_hash(block_hash.clone())
+                    .await
+                    .map_err(RpcStatus::log_internal_error(LOG_TARGET))?
+                {
+                    None => (),
+                    Some(header) => {
+                        let chain_meta_data = db
+                            .get_chain_metadata()
+                            .await
+                            .map_err(RpcStatus::log_internal_error(LOG_TARGET))?;
+                        let confirmations = chain_meta_data.height_of_longest_chain() - header.height;
+                        let response = TxQueryResponse {
+                            location: TxLocation::Mined as i32,
+                            block_hash: Some(block_hash),
+                            confirmations,
+                        };
+                        return Ok(Response::new(response));
+                    },
+                }
+            },
+        };
+
+        // If not in a block then check the mempool
+        let mut mempool = self.mempool();
+        let mempool_response = match mempool
+            .get_tx_state_by_excess_sig(signature.clone())
+            .await
+            .map_err(RpcStatus::log_internal_error(LOG_TARGET))?
+        {
+            TxStorageResponse::UnconfirmedPool => TxQueryResponse {
+                location: TxLocation::InMempool as i32,
+                block_hash: None,
+                confirmations: 0,
+            },
+            TxStorageResponse::ReorgPool |
+            TxStorageResponse::NotStoredOrphan |
+            TxStorageResponse::NotStoredTimeLocked |
+            TxStorageResponse::NotStoredAlreadySpent |
+            TxStorageResponse::NotStored => TxQueryResponse {
+                location: TxLocation::NotStored as i32,
+                block_hash: None,
+                confirmations: 0,
+            },
+        };
+
+        Ok(Response::new(mempool_response))
+    }
+}

--- a/base_layer/core/src/base_node/service/initializer.rs
+++ b/base_layer/core/src/base_node/service/initializer.rs
@@ -23,7 +23,6 @@
 use crate::{
     base_node::{
         comms_interface::{InboundNodeCommsHandlers, LocalNodeCommsInterface, OutboundNodeCommsInterface},
-        proto,
         service::service::{BaseNodeService, BaseNodeServiceConfig, BaseNodeStreams},
         StateMachineHandle,
     },
@@ -32,6 +31,7 @@ use crate::{
     consensus::ConsensusManager,
     mempool::Mempool,
     proto as shared_protos,
+    proto::generated::base_node as proto,
 };
 use futures::{channel::mpsc, future, Future, Stream, StreamExt};
 use log::*;

--- a/base_layer/core/src/base_node/service/service.rs
+++ b/base_layer/core/src/base_node/service/service.rs
@@ -29,8 +29,6 @@ use crate::{
             NodeCommsRequest,
             NodeCommsResponse,
         },
-        proto,
-        proto::base_node_service_request::Request,
         service::error::BaseNodeServiceError,
         state_machine_service::states::StateInfo,
         StateMachineHandle,
@@ -38,6 +36,7 @@ use crate::{
     blocks::{Block, NewBlock},
     chain_storage::BlockchainBackend,
     proto as shared_protos,
+    proto::generated::{base_node as proto, base_node::base_node_service_request::Request},
 };
 use futures::{
     channel::{

--- a/base_layer/core/src/base_node/sync/header_sync/synchronizer.rs
+++ b/base_layer/core/src/base_node/sync/header_sync/synchronizer.rs
@@ -22,14 +22,14 @@
 
 use super::{validator::BlockHeaderSyncValidator, BlockHeaderSyncError};
 use crate::{
-    base_node::{
-        proto,
-        sync::{hooks::Hooks, rpc, BlockSyncConfig},
-    },
+    base_node::sync::{hooks::Hooks, rpc, BlockSyncConfig},
     blocks::{Block, BlockHeader},
     chain_storage::{async_db::AsyncBlockchainDb, BlockchainBackend},
     consensus::ConsensusManager,
-    proto::base_node::{FindChainSplitRequest, SyncHeadersRequest},
+    proto::{
+        base_node::{FindChainSplitRequest, SyncHeadersRequest},
+        generated::base_node as proto,
+    },
     tari_utilities::{hex::Hex, Hashable},
     transactions::types::HashOutput,
     validation::ValidationError,

--- a/base_layer/core/src/base_node/sync/rpc/service.rs
+++ b/base_layer/core/src/base_node/sync/rpc/service.rs
@@ -21,13 +21,16 @@
 //  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 use crate::{
-    base_node::{
-        proto::{FindChainSplitRequest, FindChainSplitResponse, SyncBlocksRequest, SyncHeadersRequest},
-        sync::rpc::BaseNodeSyncService,
-    },
+    base_node::sync::rpc::BaseNodeSyncService,
     chain_storage::{async_db::AsyncBlockchainDb, BlockchainBackend},
     iterators::NonOverlappingIntegerPairIter,
     proto,
+    proto::generated::base_node::{
+        FindChainSplitRequest,
+        FindChainSplitResponse,
+        SyncBlocksRequest,
+        SyncHeadersRequest,
+    },
 };
 use futures::{channel::mpsc, stream, SinkExt};
 use log::*;

--- a/base_layer/core/src/mempool/mempool_storage.rs
+++ b/base_layer/core/src/mempool/mempool_storage.rs
@@ -79,17 +79,15 @@ impl MempoolStorage {
             },
             Err(ValidationError::UnknownInputs) => {
                 warn!(target: LOG_TARGET, "Validation failed due to unknown inputs");
-                Ok(TxStorageResponse::NotStored)
+                Ok(TxStorageResponse::NotStoredOrphan)
             },
             Err(ValidationError::ContainsSTxO) => {
                 warn!(target: LOG_TARGET, "Validation failed due to already spent output");
-
-                Ok(TxStorageResponse::NotStored)
+                Ok(TxStorageResponse::NotStoredAlreadySpent)
             },
             Err(ValidationError::MaturityError) => {
                 warn!(target: LOG_TARGET, "Validation failed due to maturity error");
-
-                Ok(TxStorageResponse::NotStored)
+                Ok(TxStorageResponse::NotStoredTimeLocked)
             },
             Err(e) => {
                 warn!(target: LOG_TARGET, "Validation failed due to error:{}", e);

--- a/base_layer/core/src/mempool/mod.rs
+++ b/base_layer/core/src/mempool/mod.rs
@@ -120,14 +120,17 @@ impl Display for StateResponse {
 pub enum TxStorageResponse {
     UnconfirmedPool,
     ReorgPool,
+    NotStoredOrphan,
+    NotStoredTimeLocked,
+    NotStoredAlreadySpent,
     NotStored,
 }
 
 impl TxStorageResponse {
     pub fn is_stored(&self) -> bool {
         match self {
-            TxStorageResponse::NotStored => false,
-            _ => true,
+            Self::UnconfirmedPool | Self::ReorgPool => true,
+            _ => false,
         }
     }
 }
@@ -137,6 +140,9 @@ impl Display for TxStorageResponse {
         let storage = match self {
             TxStorageResponse::UnconfirmedPool => "Unconfirmed pool",
             TxStorageResponse::ReorgPool => "Reorg pool",
+            TxStorageResponse::NotStoredOrphan => "Not stored orphan transaction",
+            TxStorageResponse::NotStoredTimeLocked => "Not stored time locked transaction",
+            TxStorageResponse::NotStoredAlreadySpent => "Not stored output already spent",
             TxStorageResponse::NotStored => "Not stored",
         };
         fmt.write_str(&storage)

--- a/base_layer/core/src/mempool/proto/tx_storage_response.rs
+++ b/base_layer/core/src/mempool/proto/tx_storage_response.rs
@@ -44,6 +44,9 @@ impl From<TxStorageResponse> for proto::TxStorageResponse {
             UnconfirmedPool => proto::TxStorageResponse::UnconfirmedPool,
             ReorgPool => proto::TxStorageResponse::ReorgPool,
             NotStored => proto::TxStorageResponse::NotStored,
+            NotStoredOrphan => proto::TxStorageResponse::NotStored,
+            NotStoredTimeLocked => proto::TxStorageResponse::NotStored,
+            NotStoredAlreadySpent => proto::TxStorageResponse::NotStored,
         }
     }
 }

--- a/base_layer/core/src/mempool/service/inbound_handlers.rs
+++ b/base_layer/core/src/mempool/service/inbound_handlers.rs
@@ -140,6 +140,9 @@ impl MempoolInboundHandlers {
                     TxStorageResponse::UnconfirmedPool => true,
                     TxStorageResponse::ReorgPool => false,
                     TxStorageResponse::NotStored => false,
+                    TxStorageResponse::NotStoredOrphan => false,
+                    TxStorageResponse::NotStoredTimeLocked => false,
+                    TxStorageResponse::NotStoredAlreadySpent => false,
                 };
                 if propagate {
                     debug!(

--- a/base_layer/core/src/proto/generated/tari.base_node.rs
+++ b/base_layer/core/src/proto/generated/tari.base_node.rs
@@ -279,3 +279,37 @@ pub struct FetchMatchingMmrNodes {
     #[prost(uint64, tag = "4")]
     pub hist_height: u64,
 }
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct TxSubmissionResponse {
+    #[prost(bool, tag = "1")]
+    pub accepted: bool,
+    #[prost(enumeration = "TxSubmissionRejectionReason", tag = "2")]
+    pub rejection_reason: i32,
+}
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct TxQueryResponse {
+    #[prost(enumeration = "TxLocation", tag = "1")]
+    pub location: i32,
+    #[prost(message, optional, tag = "2")]
+    pub block_hash: ::std::option::Option<::std::vec::Vec<u8>>,
+    #[prost(uint64, tag = "3")]
+    pub confirmations: u64,
+}
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
+#[repr(i32)]
+pub enum TxSubmissionRejectionReason {
+    None = 0,
+    AlreadyMined = 1,
+    DoubleSpend = 2,
+    Orphan = 3,
+    TimeLocked = 4,
+    ValidationFailed = 5,
+}
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
+#[repr(i32)]
+pub enum TxLocation {
+    None = 0,
+    NotStored = 1,
+    InMempool = 2,
+    Mined = 3,
+}

--- a/base_layer/core/tests/base_node_rpc.rs
+++ b/base_layer/core/tests/base_node_rpc.rs
@@ -1,0 +1,254 @@
+// Copyright 2020. The Tari Project
+//
+// Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+// following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+// disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+// following disclaimer in the documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+// products derived from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+// INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+// WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+// USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+//  Copyright 2020, The Tari Project
+//
+//  Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+//  following conditions are met:
+//
+//  1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+//  disclaimer.
+//
+//  2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+//  following disclaimer in the documentation and/or other materials provided with the distribution.
+//
+//  3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+//  products derived from this software without specific prior written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+//  INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+//  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+//  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+//  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+//  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+//  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+mod helpers;
+
+use crate::helpers::{
+    block_builders::{chain_block, create_genesis_block_with_coinbase_value},
+    nodes::{BaseNodeBuilder, NodeInterfaces},
+};
+use std::convert::TryFrom;
+use tari_comms::protocol::rpc::mock::RpcRequestMock;
+use tari_core::{
+    base_node::{
+        comms_interface::Broadcast,
+        proto::wallet_response::{TxLocation, TxQueryResponse, TxSubmissionRejectionReason, TxSubmissionResponse},
+        rpc::{BaseNodeWalletRpcService, BaseNodeWalletService},
+        state_machine_service::states::{ListeningInfo, StateInfo, StatusInfo},
+    },
+    blocks::Block,
+    consensus::{ConsensusManager, ConsensusManagerBuilder, Network},
+    crypto::tari_utilities::Hashable,
+    proto::generated::types::{Signature as SignatureProto, Transaction as TransactionProto},
+    test_helpers::blockchain::TempDatabase,
+    transactions::{
+        helpers::schema_to_transaction,
+        tari_amount::{uT, T},
+        transaction::UnblindedOutput,
+        types::CryptoFactories,
+    },
+    txn_schema,
+};
+use tempfile::{tempdir, TempDir};
+use tokio::runtime::Runtime;
+
+fn setup() -> (
+    BaseNodeWalletRpcService<TempDatabase>,
+    NodeInterfaces,
+    RpcRequestMock,
+    ConsensusManager,
+    Block,
+    UnblindedOutput,
+    Runtime,
+    TempDir,
+) {
+    let network = Network::LocalNet;
+    let consensus_constants = network.create_consensus_constants();
+    let factories = CryptoFactories::default();
+    let mut runtime = Runtime::new().unwrap();
+    let temp_dir = tempdir().unwrap();
+
+    let (block0, utxo0) =
+        create_genesis_block_with_coinbase_value(&factories, 100_000_000.into(), &consensus_constants[0]);
+    let consensus_manager = ConsensusManagerBuilder::new(network)
+        .with_consensus_constants(consensus_constants[0].clone())
+        .with_block(block0.clone())
+        .build();
+
+    let (mut base_node, _consensus_manager) = BaseNodeBuilder::new(network)
+        .with_consensus_manager(consensus_manager.clone())
+        .start(&mut runtime, temp_dir.path().to_str().unwrap());
+    base_node.mock_base_node_state_machine.publish_status(StatusInfo {
+        bootstrapped: true,
+        state_info: StateInfo::Listening(ListeningInfo::new(true)),
+    });
+
+    let request_mock = runtime.enter(|| RpcRequestMock::new(base_node.comms.peer_manager()));
+    let service =
+        BaseNodeWalletRpcService::new(base_node.blockchain_db.clone().into(), base_node.mempool_handle.clone());
+    (
+        service,
+        base_node,
+        request_mock,
+        consensus_manager,
+        block0,
+        utxo0,
+        runtime,
+        temp_dir,
+    )
+}
+
+#[test]
+fn test_base_node_wallet_rpc() {
+    // Testing the submit_transaction() and transaction_query() rpc calls
+    let (service, mut base_node, request_mock, consensus_manager, block0, utxo0, mut runtime, _temp_dir) = setup();
+
+    let (txs1, utxos1) = schema_to_transaction(&vec![txn_schema!(from: vec![utxo0.clone()], to: vec![1 * T, 1 * T])]);
+    let tx1 = (*txs1[0]).clone();
+    let tx1_sig = tx1.first_kernel_excess_sig().clone().unwrap().clone();
+
+    let (txs2, _utxos2) = schema_to_transaction(&vec![txn_schema!(
+        from: vec![utxos1[0].clone()],
+        to: vec![400_000 * uT, 590_000 * uT]
+    )]);
+    let tx2 = (*txs2[0]).clone();
+    let tx2_sig = tx2.first_kernel_excess_sig().clone().unwrap().clone();
+
+    // Query Tx1
+    let msg = SignatureProto::from(tx1_sig.clone());
+    let req = request_mock.request_with_context(Default::default(), msg.clone());
+    let resp =
+        TxQueryResponse::try_from(runtime.block_on(service.transaction_query(req)).unwrap().into_message()).unwrap();
+
+    assert_eq!(resp.confirmations, 0);
+    assert_eq!(resp.block_hash, None);
+    assert_eq!(resp.location, TxLocation::NotStored);
+
+    // First lets try submit tx2 which will be an orphan tx
+    let msg = TransactionProto::from(tx2.clone());
+    let req = request_mock.request_with_context(Default::default(), msg.clone());
+
+    let resp = TxSubmissionResponse::try_from(
+        runtime
+            .block_on(service.submit_transaction(req))
+            .unwrap()
+            .into_message(),
+    )
+    .unwrap();
+
+    assert!(!resp.accepted);
+    assert_eq!(resp.rejection_reason, TxSubmissionRejectionReason::Orphan);
+
+    // Query Tx2 to confirm it wasn't accepted
+    let msg = SignatureProto::from(tx2_sig.clone());
+    let req = request_mock.request_with_context(Default::default(), msg.clone());
+    let resp =
+        TxQueryResponse::try_from(runtime.block_on(service.transaction_query(req)).unwrap().into_message()).unwrap();
+
+    assert_eq!(resp.confirmations, 0);
+    assert_eq!(resp.block_hash, None);
+    assert_eq!(resp.location, TxLocation::NotStored);
+
+    // Now submit a block with Tx1 in it so that Tx2 is no longer an orphan
+    let block1 = base_node
+        .blockchain_db
+        .prepare_block_merkle_roots(chain_block(&block0, vec![tx1.clone()], &consensus_manager))
+        .unwrap();
+
+    assert!(runtime
+        .block_on(base_node.local_nci.submit_block(block1.clone(), Broadcast::from(true)))
+        .is_ok());
+
+    // Check that subitting Tx2 will now be accepted
+    let msg = TransactionProto::from(tx2.clone());
+    let req = request_mock.request_with_context(Default::default(), msg);
+    let resp = runtime
+        .block_on(service.submit_transaction(req))
+        .unwrap()
+        .into_message();
+
+    assert!(resp.accepted);
+
+    // Query Tx2 which should now be in the mempool
+    let msg = SignatureProto::from(tx2_sig.clone());
+    let req = request_mock.request_with_context(Default::default(), msg.clone());
+    let resp =
+        TxQueryResponse::try_from(runtime.block_on(service.transaction_query(req)).unwrap().into_message()).unwrap();
+
+    assert_eq!(resp.confirmations, 0);
+    assert_eq!(resp.block_hash, None);
+    assert_eq!(resp.location, TxLocation::InMempool);
+
+    // Now if we submit Tx1 is should return as rejected as AlreadyMined as Tx1's kernel is present
+    let msg = TransactionProto::from(tx1.clone());
+    let req = request_mock.request_with_context(Default::default(), msg);
+    let resp = TxSubmissionResponse::try_from(
+        runtime
+            .block_on(service.submit_transaction(req))
+            .unwrap()
+            .into_message(),
+    )
+    .unwrap();
+
+    assert!(!resp.accepted);
+    assert_eq!(resp.rejection_reason, TxSubmissionRejectionReason::AlreadyMined);
+
+    // Now create a different tx that uses the same input as Tx1 to produce a DoubleSpend rejection
+    let (txs1b, _utxos1) = schema_to_transaction(&vec![txn_schema!(from: vec![utxo0.clone()], to: vec![2 * T, 1 * T])]);
+    let tx1b = (*txs1b[0]).clone();
+
+    // Now if we submit Tx1 is should return as rejected as AlreadyMined
+    let msg = TransactionProto::from(tx1b.clone());
+    let req = request_mock.request_with_context(Default::default(), msg);
+    let resp = TxSubmissionResponse::try_from(
+        runtime
+            .block_on(service.submit_transaction(req))
+            .unwrap()
+            .into_message(),
+    )
+    .unwrap();
+
+    assert!(!resp.accepted);
+    assert_eq!(resp.rejection_reason, TxSubmissionRejectionReason::DoubleSpend);
+
+    // Now we will Mine block 2 so that we can see 1 confirmation on tx1
+    let block2 = base_node
+        .blockchain_db
+        .prepare_block_merkle_roots(chain_block(&block1, vec![], &consensus_manager))
+        .unwrap();
+
+    assert!(runtime
+        .block_on(base_node.local_nci.submit_block(block2.clone(), Broadcast::from(true)))
+        .is_ok());
+
+    // Query Tx1 which should be in block 1 with 1 confirmation
+    let msg = SignatureProto::from(tx1_sig.clone());
+    let req = request_mock.request_with_context(Default::default(), msg.clone());
+    let resp =
+        TxQueryResponse::try_from(runtime.block_on(service.transaction_query(req)).unwrap().into_message()).unwrap();
+
+    assert_eq!(resp.confirmations, 1);
+    assert_eq!(resp.block_hash, Some(block1.hash()));
+    assert_eq!(resp.location, TxLocation::Mined);
+}

--- a/base_layer/core/tests/helpers/nodes.rs
+++ b/base_layer/core/tests/helpers/nodes.rs
@@ -42,7 +42,7 @@ use tari_core::{
     chain_storage::{BlockchainDatabase, BlockchainDatabaseConfig, Validators},
     consensus::{ConsensusManager, ConsensusManagerBuilder, Network},
     mempool::{
-        service::LocalMempoolService,
+        service::{LocalMempoolService, MempoolHandle},
         Mempool,
         MempoolConfig,
         MempoolServiceConfig,
@@ -75,6 +75,7 @@ pub struct NodeInterfaces {
     pub outbound_message_service: OutboundMessageRequester,
     pub blockchain_db: BlockchainDatabase<TempDatabase>,
     pub mempool: Mempool,
+    pub mempool_handle: MempoolHandle,
     pub local_mp_interface: LocalMempoolService,
     pub chain_metadata_handle: ChainMetadataHandle,
     pub liveness_handle: LivenessHandle,
@@ -452,6 +453,7 @@ fn setup_base_node_services(
     let local_nci = handles.expect_handle::<LocalNodeCommsInterface>();
     let outbound_mp_interface = handles.expect_handle::<OutboundMempoolServiceInterface>();
     let local_mp_interface = handles.expect_handle::<LocalMempoolService>();
+    let mempool_handle = handles.expect_handle::<MempoolHandle>();
     let outbound_message_service = handles.expect_handle::<Dht>().outbound_requester();
     let chain_metadata_handle = handles.expect_handle::<ChainMetadataHandle>();
     let liveness_handle = handles.expect_handle::<LivenessHandle>();
@@ -465,6 +467,7 @@ fn setup_base_node_services(
         blockchain_db,
         mempool,
         local_mp_interface,
+        mempool_handle,
         chain_metadata_handle,
         liveness_handle,
         comms,

--- a/base_layer/wallet/src/base_node_service/mod.rs
+++ b/base_layer/wallet/src/base_node_service/mod.rs
@@ -36,7 +36,7 @@ use std::sync::Arc;
 use tari_comms_dht::Dht;
 
 use futures::{future, Future, Stream, StreamExt};
-use tari_core::base_node::proto;
+use tari_core::proto::generated::base_node as proto;
 use tari_p2p::{
     comms_connector::SubscriptionFactory,
     domain_message::DomainMessage,

--- a/base_layer/wallet/src/base_node_service/service.rs
+++ b/base_layer/wallet/src/base_node_service/service.rs
@@ -42,7 +42,11 @@ use tari_common_types::{
 };
 use tari_comms::peer_manager::Peer;
 use tari_comms_dht::{domain_message::OutboundDomainMessage, outbound::OutboundMessageRequester};
-use tari_core::base_node::{proto, proto::base_node_service_request::Request as BaseNodeRequestProto};
+use tari_core::proto::generated::{
+    base_node as proto,
+    base_node::base_node_service_request::Request as BaseNodeRequestProto,
+};
+
 use tari_p2p::{domain_message::DomainMessage, tari_message::TariMessageType};
 use tari_service_framework::reply_channel::Receiver;
 use tari_shutdown::ShutdownSignal;

--- a/base_layer/wallet/src/output_manager_service/mod.rs
+++ b/base_layer/wallet/src/output_manager_service/mod.rs
@@ -34,8 +34,8 @@ use log::*;
 use std::sync::Arc;
 use tari_comms_dht::Dht;
 use tari_core::{
-    base_node::proto,
     consensus::{ConsensusConstantsBuilder, Network},
+    proto::generated::base_node as proto,
     transactions::types::CryptoFactories,
 };
 use tari_p2p::{

--- a/base_layer/wallet/src/output_manager_service/protocols/txo_validation_protocol.rs
+++ b/base_layer/wallet/src/output_manager_service/protocols/txo_validation_protocol.rs
@@ -33,9 +33,9 @@ use std::{cmp, collections::HashMap, convert::TryFrom, fmt, sync::Arc, time::Dur
 use tari_comms::types::CommsPublicKey;
 use tari_comms_dht::domain_message::OutboundDomainMessage;
 use tari_core::{
-    base_node::{
-        proto,
-        proto::{
+    proto::generated::{
+        base_node as proto,
+        base_node::{
             base_node_service_request::Request as BaseNodeRequestProto,
             base_node_service_response::Response as BaseNodeResponseProto,
         },

--- a/base_layer/wallet/src/output_manager_service/service.rs
+++ b/base_layer/wallet/src/output_manager_service/service.rs
@@ -48,8 +48,8 @@ use std::{cmp::Ordering, collections::HashMap, fmt, sync::Arc, time::Duration};
 use tari_comms::types::CommsPublicKey;
 use tari_comms_dht::outbound::OutboundMessageRequester;
 use tari_core::{
-    base_node::proto,
     consensus::ConsensusConstants,
+    proto::generated::base_node as proto,
     transactions::{
         fee::Fee,
         tari_amount::MicroTari,

--- a/base_layer/wallet/src/transaction_service/mod.rs
+++ b/base_layer/wallet/src/transaction_service/mod.rs
@@ -43,8 +43,8 @@ use std::sync::Arc;
 use tari_comms::peer_manager::NodeIdentity;
 use tari_comms_dht::Dht;
 use tari_core::{
-    base_node::proto as base_node_proto,
     mempool::proto as mempool_proto,
+    proto::generated::base_node as base_node_proto,
     transactions::{transaction_protocol::proto, types::CryptoFactories},
 };
 use tari_p2p::{

--- a/base_layer/wallet/src/transaction_service/protocols/transaction_broadcast_protocol.rs
+++ b/base_layer/wallet/src/transaction_service/protocols/transaction_broadcast_protocol.rs
@@ -32,17 +32,17 @@ use std::{convert::TryFrom, sync::Arc, time::Duration};
 use tari_comms::types::CommsPublicKey;
 use tari_comms_dht::domain_message::OutboundDomainMessage;
 use tari_core::{
-    base_node::{
-        proto,
-        proto::{
-            base_node_service_request::Request as BaseNodeRequestProto,
-            base_node_service_response::Response as BaseNodeResponseProto,
-        },
-    },
     mempool::{
         proto as mempool_proto,
         service::{MempoolResponse, MempoolServiceResponse},
         TxStorageResponse,
+    },
+    proto::generated::{
+        base_node as proto,
+        base_node::{
+            base_node_service_request::Request as BaseNodeRequestProto,
+            base_node_service_response::Response as BaseNodeResponseProto,
+        },
     },
     transactions::transaction::TransactionOutput,
 };

--- a/base_layer/wallet/src/transaction_service/protocols/transaction_chain_monitoring_protocol.rs
+++ b/base_layer/wallet/src/transaction_service/protocols/transaction_chain_monitoring_protocol.rs
@@ -35,17 +35,17 @@ use std::{convert::TryFrom, sync::Arc, time::Duration};
 use tari_comms::types::CommsPublicKey;
 use tari_comms_dht::domain_message::OutboundDomainMessage;
 use tari_core::{
-    base_node::{
-        proto,
-        proto::{
-            base_node_service_request::Request as BaseNodeRequestProto,
-            base_node_service_response::Response as BaseNodeResponseProto,
-        },
-    },
     mempool::{
         proto as mempool_proto,
         service::{MempoolResponse, MempoolServiceResponse},
         TxStorageResponse,
+    },
+    proto::generated::{
+        base_node as proto,
+        base_node::{
+            base_node_service_request::Request as BaseNodeRequestProto,
+            base_node_service_response::Response as BaseNodeResponseProto,
+        },
     },
     transactions::transaction::TransactionOutput,
 };

--- a/base_layer/wallet/src/transaction_service/protocols/transaction_coinbase_monitoring_protocol.rs
+++ b/base_layer/wallet/src/transaction_service/protocols/transaction_coinbase_monitoring_protocol.rs
@@ -35,9 +35,9 @@ use std::{convert::TryFrom, sync::Arc, time::Duration};
 use tari_comms::types::CommsPublicKey;
 use tari_comms_dht::domain_message::OutboundDomainMessage;
 use tari_core::{
-    base_node::{
-        proto,
-        proto::{
+    proto::generated::{
+        base_node as proto,
+        base_node::{
             base_node_service_request::Request as BaseNodeRequestProto,
             base_node_service_response::Response as BaseNodeResponseProto,
         },

--- a/base_layer/wallet/src/transaction_service/service.rs
+++ b/base_layer/wallet/src/transaction_service/service.rs
@@ -66,8 +66,8 @@ use tari_comms_dht::outbound::OutboundMessageRequester;
 #[cfg(feature = "test_harness")]
 use tari_core::transactions::{tari_amount::uT, types::BlindingFactor};
 use tari_core::{
-    base_node::proto as base_node_proto,
     mempool::{proto as mempool_proto, service::MempoolServiceResponse},
+    proto::generated::base_node as base_node_proto,
     transactions::{
         tari_amount::MicroTari,
         transaction::Transaction,

--- a/base_layer/wallet/tests/output_manager_service/service.rs
+++ b/base_layer/wallet/tests/output_manager_service/service.rs
@@ -39,11 +39,14 @@ use tari_comms::{
 };
 use tari_comms_dht::outbound::mock::{create_outbound_service_mock, OutboundServiceMockState};
 use tari_core::{
-    base_node::{
-        proto as base_node_proto,
-        proto::{base_node_service_request::Request, base_node_service_response::Response as BaseNodeResponseProto},
-    },
     consensus::{ConsensusConstantsBuilder, Network},
+    proto::generated::{
+        base_node as base_node_proto,
+        base_node::{
+            base_node_service_request::Request,
+            base_node_service_response::Response as BaseNodeResponseProto,
+        },
+    },
     transactions::{
         fee::Fee,
         tari_amount::{uT, MicroTari},

--- a/base_layer/wallet/tests/transaction_service/service.rs
+++ b/base_layer/wallet/tests/transaction_service/service.rs
@@ -53,20 +53,22 @@ use tari_comms_dht::outbound::mock::{
     ResponseType,
 };
 use tari_core::{
-    base_node::{
-        proto as base_node_proto,
-        proto::{
-            base_node_service_request::Request as BaseNodeRequestProto,
-            base_node_service_response::Response as BaseNodeResponseProto,
-        },
-    },
     consensus::{ConsensusConstantsBuilder, Network},
     mempool::{
         proto as mempool_proto,
         service::{MempoolRequest, MempoolResponse, MempoolServiceRequest},
         TxStorageResponse,
     },
-    proto::types::TransactionOutput as TransactionOutputProto,
+    proto::{
+        generated::{
+            base_node as base_node_proto,
+            base_node::{
+                base_node_service_request::Request as BaseNodeRequestProto,
+                base_node_service_response::Response as BaseNodeResponseProto,
+            },
+        },
+        types::TransactionOutput as TransactionOutputProto,
+    },
     transactions::{
         fee::Fee,
         tari_amount::*,


### PR DESCRIPTION
## Description

Implement a Wallet RPC service in the Base Node

This PR implements an RPC service in the base node for the wallet to use when submitting and querying transactions. The RPC service provides two calls: 
`submit_transaction(tx)`: Will be used by a wallet to submit a transaction to the Base Node and the response informs the wallet if the tx was accepted into the mempool or it was rejected and why
`transaction_query(excess_sig)`: Lets the wallet request the status of a transaction via its excess_sig. The response will tell the wallet whether the transaction is Not Stored, in the Unconfirmed Pool or if it is Mined it will also return the block header and number of confirmations.

## Motivation

This RPC service represents the new interface that a wallet will use to interact with base nodes while trying to broadcast a transaction. This will replace the current fire-and-forget type messaging provided by the p2p comms layer which makes the logic for receiving the response to the query tricky.

## How Has This Been Tested?
The `test_base_node_wallet_rpc()` is provided that tests both the RPC calls using a test blockchain and mempool back end.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [x] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch.
* [x] I ran `cargo-fmt --all` before pushing.
* [x] I ran `cargo test` successfully before submitting my PR.
* [x] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
