### PR TITLE
Add SAF message to transaction reply and finalize

### DIFF
--- a/base_layer/wallet/src/transaction_service/tasks/send_finalized_transaction.rs
+++ b/base_layer/wallet/src/transaction_service/tasks/send_finalized_transaction.rs
@@ -72,15 +72,22 @@ pub async fn send_finalized_transaction_message(
                 .await
                 {
                     direct_send_result = true;
-                } else {
-                    store_and_forward_send_result = send_transaction_finalized_message_store_and_forward(
-                        tx_id,
-                        destination_public_key.clone(),
-                        finalized_transaction_message.clone(),
-                        &mut outbound_message_service,
-                    )
-                    .await?;
                 }
+                // Send a Store and Forward (SAF) regardless.
+                info!(
+                    target: LOG_TARGET,
+                    "Direct Send finalize result was {}. Sending SAF for TxId: {} to recipient with Public Key: {}",
+                    direct_send_result,
+                    tx_id,
+                    destination_public_key,
+                );
+                store_and_forward_send_result = send_transaction_finalized_message_store_and_forward(
+                    tx_id,
+                    destination_public_key,
+                    finalized_transaction_message.clone(),
+                    &mut outbound_message_service,
+                )
+                .await?;
             },
             SendMessageResponse::Failed(err) => {
                 warn!(

--- a/base_layer/wallet/src/transaction_service/tasks/send_transaction_reply.rs
+++ b/base_layer/wallet/src/transaction_service/tasks/send_transaction_reply.rs
@@ -70,15 +70,22 @@ pub async fn send_transaction_reply(
                 .await
                 {
                     direct_send_result = true;
-                } else {
-                    store_and_forward_send_result = send_transaction_reply_store_and_forward(
-                        tx_id,
-                        inbound_transaction.source_public_key.clone(),
-                        proto_message.clone(),
-                        &mut outbound_message_service,
-                    )
-                    .await?;
                 }
+                // Send a Store and Forward (SAF) regardless.
+                info!(
+                    target: LOG_TARGET,
+                    "Direct Send reply result was {}. Sending SAF for TxId: {} to recipient with Public Key: {}",
+                    direct_send_result,
+                    tx_id,
+                    inbound_transaction.source_public_key,
+                );
+                store_and_forward_send_result = send_transaction_reply_store_and_forward(
+                    tx_id,
+                    inbound_transaction.source_public_key,
+                    proto_message.clone(),
+                    &mut outbound_message_service,
+                )
+                .await?;
             },
             SendMessageResponse::Failed(err) => {
                 warn!(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Related to #2501, this change also sends Store and Forward (SAF) messages for the transaction reply and finalization steps of transaction negotiation. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Improving transaction reliability for mobile wallets

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested manually between 2 console wallets 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [x] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch.
* [x] I ran `cargo-fmt --all` before pushing.
* [ ] I ran `cargo test` successfully before submitting my PR.
* [x] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
