### PR TITLE
Add ban peer if header sync fails

### DIFF
--- a/base_layer/core/src/base_node/sync/header_sync/synchronizer.rs
+++ b/base_layer/core/src/base_node/sync/header_sync/synchronizer.rs
@@ -111,10 +111,14 @@ impl<'a, B: BlockchainBackend + 'static> HeaderSynchronizer<'a, B> {
                     debug!(target: LOG_TARGET, "Block header validation failed: {}", err);
                     self.ban_peer_temporarily(node_id, err.into()).await?;
                 },
-                Err(err) => debug!(
-                    target: LOG_TARGET,
-                    "Failed to synchronize headers from peer `{}`: {}", node_id, err
-                ),
+                Err(err) => {
+                    debug!(
+                        target: LOG_TARGET,
+                        "Failed to synchronize headers from peer `{}`: {}", node_id, err
+                    );
+                    self.ban_peer_temporarily(node_id, BanReason::GeneralHeaderSyncFailure)
+                        .await?;
+                },
             }
         }
 
@@ -494,4 +498,6 @@ enum BanReason {
     ValidationFailed(#[from] ValidationError),
     #[error("Peer could not find the location of a chain split")]
     ChainSplitNotFound,
+    #[error("Failed to synchronize headers from peer")]
+    GeneralHeaderSyncFailure,
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Sync peers are now also banned temporarily if they fail to supply headers except if the peer is not in sync; this is an additional ban over and above if header validation fails.

**Update -** This is an attack vector as well; publish a strong chain and fail to supply headers because there will be no recourse. The unexpecting base node will then forever try to get those headers. If you have enough of these bogies around, you can stall the network. This is like a DDoS attack. If the proposal is implemented, the ban is only temporarily; thus not splitting the network if it was an honest mistake not to be able to supply headers one time around.

**Update -** Examples where peers failed to supply headers:
```
[c::bn::header_sync] DEBUG Failed to synchronize headers from peer `b5bb6f8db72037588f91449805`: RPC error: Peer 
  connection error: Protocol error: Protocol negotiation failed because the peer did not accept any of the given 
  protocols: t/blksync/1
```
and
```
[c::bn::header_sync] DEBUG Failed to synchronize headers from peer `d1085ff28065d04d55332dd427`: RPC request 
  failed: General: General error
```
and
```
[c::bn::header_sync] DEBUG Failed to synchronize headers from peer `d1085ff28065d04d55332dd427`: Chain storage error: 
  The requested BlockHeaderAccumulatedData was not found via 
  hash:c900757f84a380ff28e1296c67dcd41217c0f487013f786a249f78bf908a7e4e in the database
```

## Motivation and Context
If peers are not banned they are kept as sync peers although they cannot sypply valid headers. In certain circuimstances this prevents a base node from finding a sync peer that can provide proper header information.

## How Has This Been Tested?
Tested in a base node on Windows.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [X] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [X] I'm merging against the `development` branch.
* [X] I ran `cargo-fmt --all` before pushing.
* [ ] I ran `cargo test` successfully before submitting my PR.
* [X] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
