### PR TITLE
Add TXO validation to console wallet

### DIFF
--- a/applications/tari_base_node/src/tasks/transaction_monitor.rs
+++ b/applications/tari_base_node/src/tasks/transaction_monitor.rs
@@ -131,14 +131,14 @@ async fn start_transaction_protocols_and_txo_validation(
         let event_monitoring_timeout = Duration::from_secs(cmp::max(60, base_node_query_timeout.as_secs() * 3));
 
         loop {
-            trace!(target: LOG_TARGET, "Attempting UTXO validation for Unspent Outputs.",);
+            trace!(target: LOG_TARGET, "Attempting TXO validation for Unspent Outputs.",);
             let _ = oms_handle
                 .validate_txos(TxoValidationType::Unspent, TxoValidationRetry::UntilSuccess)
                 .await
                 .map_err(|e| {
                     error!(
                         target: LOG_TARGET,
-                        "Problem starting UTXO validation protocols in the Output Manager Service: {}", e
+                        "Problem starting Unspent TXO validation protocols in the Output Manager Service: {}", e
                     );
                     e
                 });
@@ -148,10 +148,7 @@ async fn start_transaction_protocols_and_txo_validation(
         }
 
         loop {
-            trace!(
-                target: LOG_TARGET,
-                "Attempting Invalid TXO validation for Unspent Outputs.",
-            );
+            trace!(target: LOG_TARGET, "Attempting TXO validation for Invalid Outputs.",);
             let _ = oms_handle
                 .validate_txos(TxoValidationType::Invalid, TxoValidationRetry::UntilSuccess)
                 .await
@@ -168,14 +165,14 @@ async fn start_transaction_protocols_and_txo_validation(
         }
 
         loop {
-            trace!(target: LOG_TARGET, "Attempting STXO validation for Unspent Outputs.",);
+            trace!(target: LOG_TARGET, "Attempting TXO validation for Spent Outputs.",);
             let _ = oms_handle
                 .validate_txos(TxoValidationType::Spent, TxoValidationRetry::UntilSuccess)
                 .await
                 .map_err(|e| {
                     error!(
                         target: LOG_TARGET,
-                        "Problem starting STXO validation protocols in the Output Manager Service: {}", e
+                        "Problem starting Spent TXO validation protocols in the Output Manager Service: {}", e
                     );
                     e
                 });
@@ -234,61 +231,71 @@ async fn monitor_validation_protocol(
     loop {
         let mut delay = time::delay_for(event_timeout).fuse();
         futures::select! {
-            event = event_stream.select_next_some() => {
-                match event.unwrap() {
-                    // Restart the protocol if aborted (due to 'BaseNodeNotSynced')
-                    OutputManagerEvent::TxoValidationAborted(s) => {
-                        trace!(
-                            target: LOG_TARGET,
-                            "TXO validation event 'TxoValidationAborted' ({}), restarting after 30s.", s,
-                        );
-                        // This event will happen if the base node came out of sync for some reason, thus wait a bit before restarting
-                        tokio::time::delay_for(Duration::from_secs(30)).await;
-                        break;
+            result = event_stream.select_next_some() => {
+                match result {
+                    Ok(msg) => {
+                        match (*msg).clone() {
+                            // Restart the protocol if aborted (due to 'BaseNodeNotSynced')
+                            OutputManagerEvent::TxoValidationAborted(s) => {
+                                trace!(
+                                    target: LOG_TARGET,
+                                    "TXO validation event 'TxoValidationAborted' ({}), restarting after 30s.", s,
+                                );
+                                // This event will happen if the base node came out of sync for some reason, thus wait a bit before restarting
+                                tokio::time::delay_for(Duration::from_secs(30)).await;
+                                break;
+                            },
+                            // Restart the protocol if failure
+                            OutputManagerEvent::TxoValidationFailure(s) => {
+                                trace!(
+                                    target: LOG_TARGET,
+                                    "TXO validation event 'TxoValidationFailure' ({}), restarting after 30s.", s,
+                                );
+                                // This event will happen due to an unknown reason, thus wait a bit before restarting
+                                tokio::time::delay_for(Duration::from_secs(30)).await;
+                                break;
+                            },
+                            // Exit upon success
+                            OutputManagerEvent::TxoValidationSuccess(s) => {
+                                trace!(
+                                    target: LOG_TARGET,
+                                    "TXO validation event 'TxoValidationSuccess' ({}), success.", s,
+                                );
+                                success = true;
+                                break;
+                            },
+                            // Wait for the next event if timed out (several can be attempted)
+                            OutputManagerEvent::TxoValidationTimedOut(s) => {
+                                trace!(
+                                    target: LOG_TARGET,
+                                    "TXO validation event 'TxoValidationTimedOut' ({}), waiting.", s,
+                                );
+                                continue;
+                            }
+                            // Wait for the next event upon an error
+                            OutputManagerEvent::Error(s) => {
+                                trace!(
+                                    target: LOG_TARGET,
+                                    "TXO validation event 'Error({})', waiting.", s,
+                                );
+                                continue;
+                            },
+                            // Wait for the next event upon anything else
+                            _ => {
+                                trace!(
+                                    target: LOG_TARGET,
+                                    "TXO validation unknown event, waiting.",
+                                );
+                                continue;
+                            },
+                        }
+
                     },
-                    // Restart the protocol if failure
-                    OutputManagerEvent::TxoValidationFailure(s) => {
+                    Err(_) =>
                         trace!(
                             target: LOG_TARGET,
-                            "TXO validation event 'TxoValidationFailure' ({}), restarting after 30s.", s,
-                        );
-                        // This event will happen due to an unknown reason, thus wait a bit before restarting
-                        tokio::time::delay_for(Duration::from_secs(30)).await;
-                        break;
-                    },
-                    // Exit upon success
-                    OutputManagerEvent::TxoValidationSuccess(s) => {
-                        trace!(
-                            target: LOG_TARGET,
-                            "TXO validation event 'TxoValidationSuccess' ({}), success.", s,
-                        );
-                        success = true;
-                        break;
-                    },
-                    // Wait for the next event if timed out (several can be attempted)
-                    OutputManagerEvent::TxoValidationTimedOut(s) => {
-                        trace!(
-                            target: LOG_TARGET,
-                            "TXO validation event 'TxoValidationTimedOut' ({}), waiting.", s,
-                        );
-                        continue;
-                    }
-                    // Wait for the next event upon an error
-                    OutputManagerEvent::Error(s) => {
-                        trace!(
-                            target: LOG_TARGET,
-                            "TXO validation event 'Error({})', waiting.", s,
-                        );
-                        continue;
-                    },
-                    // Wait for the next event upon anything else
-                    _ => {
-                        trace!(
-                            target: LOG_TARGET,
-                            "TXO validation unknown event, waiting.",
-                        );
-                        continue;
-                    },
+                            "Lagging read on event stream",
+                        ),
                 }
             },
             // Restart the protocol if it timed out

--- a/applications/tari_console_wallet/src/ui/state/app_state.rs
+++ b/applications/tari_console_wallet/src/ui/state/app_state.rs
@@ -29,7 +29,7 @@ use tari_shutdown::ShutdownSignal;
 use tari_wallet::{
     base_node_service::{handle::BaseNodeEventReceiver, service::BaseNodeState},
     contacts_service::storage::database::Contact,
-    output_manager_service::{service::Balance, TxId},
+    output_manager_service::{handle::OutputManagerEventReceiver, service::Balance, TxId},
     transaction_service::{
         handle::{TransactionEvent, TransactionEventReceiver, TransactionServiceHandle},
         storage::models::{CompletedTransaction, TransactionStatus},
@@ -524,6 +524,10 @@ impl AppStateInner {
 
     pub fn get_transaction_service_event_stream(&self) -> Fuse<TransactionEventReceiver> {
         self.wallet.transaction_service.get_event_stream_fused()
+    }
+
+    pub fn get_output_manager_service_event_stream(&self) -> Fuse<OutputManagerEventReceiver> {
+        self.wallet.output_manager_service.get_event_stream_fused()
     }
 
     pub fn get_connectivity_event_stream(&self) -> Fuse<ConnectivityEventRx> {

--- a/base_layer/core/src/base_node/state_machine_service/handle.rs
+++ b/base_layer/core/src/base_node/state_machine_service/handle.rs
@@ -53,7 +53,7 @@ impl StateMachineHandle {
         self.state_change_event_subscriber.subscribe()
     }
 
-    /// This clones the receiver end of the channel and gives out a copy to the caller
+    /// This clones the receiver end of the channel and gives out a copy to the caller.
     /// This allows multiple subscribers to this channel by only keeping one channel and cloning the receiver for every
     /// caller.
     pub fn get_status_info_watch(&self) -> watch::Receiver<StatusInfo> {

--- a/base_layer/wallet/src/output_manager_service/handle.rs
+++ b/base_layer/wallet/src/output_manager_service/handle.rs
@@ -29,7 +29,7 @@ use crate::output_manager_service::{
 };
 use aes_gcm::Aes256Gcm;
 use futures::{stream::Fuse, StreamExt};
-use std::{collections::HashMap, fmt, time::Duration};
+use std::{collections::HashMap, fmt, sync::Arc, time::Duration};
 use tari_comms::types::CommsPublicKey;
 use tari_core::transactions::{
     tari_amount::MicroTari,
@@ -121,8 +121,8 @@ pub enum OutputManagerResponse {
     PublicRewindKeys(Box<PublicRewindKeys>),
 }
 
-pub type OutputManagerEventSender = broadcast::Sender<OutputManagerEvent>;
-pub type OutputManagerEventReceiver = broadcast::Receiver<OutputManagerEvent>;
+pub type OutputManagerEventSender = broadcast::Sender<Arc<OutputManagerEvent>>;
+pub type OutputManagerEventReceiver = broadcast::Receiver<Arc<OutputManagerEvent>>;
 
 /// Events that can be published on the Text Message Service Event Stream
 #[derive(Clone, Debug, Hash, PartialEq, Eq)]

--- a/base_layer/wallet/src/output_manager_service/protocols/txo_validation_protocol.rs
+++ b/base_layer/wallet/src/output_manager_service/protocols/txo_validation_protocol.rs
@@ -149,7 +149,7 @@ where TBackend: OutputManagerBackend + 'static
             let _ = self
                 .resources
                 .event_publisher
-                .send(OutputManagerEvent::TxoValidationSuccess(self.id))
+                .send(Arc::new(OutputManagerEvent::TxoValidationSuccess(self.id)))
                 .map_err(|e| {
                     trace!(
                         target: LOG_TARGET,
@@ -182,7 +182,7 @@ where TBackend: OutputManagerBackend + 'static
                                     let _ = self
                                         .resources
                                         .event_publisher
-                                        .send(OutputManagerEvent::TxoValidationSuccess(self.id))
+                                        .send(Arc::new(OutputManagerEvent::TxoValidationSuccess(self.id)))
                                         .map_err(|e| {
                                            trace!(
                                                 target: LOG_TARGET,
@@ -215,7 +215,7 @@ where TBackend: OutputManagerBackend + 'static
             let _ = self
                 .resources
                 .event_publisher
-                .send(OutputManagerEvent::TxoValidationTimedOut(self.id))
+                .send(Arc::new(OutputManagerEvent::TxoValidationTimedOut(self.id)))
                 .map_err(|e| {
                     trace!(
                         target: LOG_TARGET,
@@ -349,7 +349,7 @@ where TBackend: OutputManagerBackend + 'static
             let _ = self
                 .resources
                 .event_publisher
-                .send(OutputManagerEvent::TxoValidationAborted(self.id))
+                .send(Arc::new(OutputManagerEvent::TxoValidationAborted(self.id)))
                 .map_err(|e| {
                     trace!(
                         target: LOG_TARGET,

--- a/base_layer/wallet/src/output_manager_service/service.rs
+++ b/base_layer/wallet/src/output_manager_service/service.rs
@@ -254,10 +254,7 @@ where
 
                     if result.is_err() {
                         let _ = self.resources.event_publisher
-                                .send(OutputManagerEvent::Error(
-                                    "Error handling Base Node Response message".to_string(),
-                                ))
-                                ;
+                                .send(Arc::new(OutputManagerEvent::Error("Error handling Base Node Response message".to_string())));
                     }
                 }
                 join_result = utxo_validation_handles.select_next_some() => {
@@ -456,7 +453,7 @@ where
                         let _ = self
                             .resources
                             .event_publisher
-                            .send(OutputManagerEvent::TxoValidationFailure(id))
+                            .send(Arc::new(OutputManagerEvent::TxoValidationFailure(id)))
                             .map_err(|e| {
                                 trace!(
                                     target: LOG_TARGET,

--- a/base_layer/wallet/tests/output_manager_service/service.rs
+++ b/base_layer/wallet/tests/output_manager_service/service.rs
@@ -885,10 +885,15 @@ fn test_utxo_validation() {
         loop {
             futures::select! {
                 event = event_stream.select_next_some() => {
-                    match event.unwrap() {
-                        OutputManagerEvent::TxoValidationTimedOut(_) => {
-                            timeouts+=1;
-                         },
+                    match event {
+                        Ok(msg) => {
+                            match (*msg).clone() {
+                                OutputManagerEvent::TxoValidationTimedOut(_) => {
+                                    timeouts+=1;
+                                },
+                                _ => (),
+                            }
+                        }
                         _ => (),
                     }
                     if timeouts >= 2 {
@@ -969,11 +974,19 @@ fn test_utxo_validation() {
         loop {
             futures::select! {
                 event = event_stream.select_next_some() => {
-                    if let OutputManagerEvent::TxoValidationSuccess(_) = event.unwrap() {
-                        acc += 1;
-                        if acc >= 1 {
-                            break;
-                        }
+                    match event {
+                        Ok(msg) => {
+                            match (*msg).clone() {
+                                OutputManagerEvent::TxoValidationSuccess(_) => {
+                                    acc += 1;
+                                    if acc >= 1 {
+                                        break;
+                                    }
+                                },
+                                _ => (),
+                            }
+                        },
+                        _ => (),
                     }
                 },
                 () = delay => {
@@ -1053,11 +1066,19 @@ fn test_utxo_validation() {
         loop {
             futures::select! {
                 event = event_stream.select_next_some() => {
-                    if let OutputManagerEvent::TxoValidationSuccess(_) = event.unwrap() {
-                        acc += 1;
-                        if acc >= 1 {
-                            break;
-                        }
+                    match event {
+                        Ok(msg) => {
+                            match (*msg).clone() {
+                                OutputManagerEvent::TxoValidationSuccess(_) => {
+                                    acc += 1;
+                                    if acc >= 1 {
+                                        break;
+                                    }
+                                },
+                                _ => (),
+                            }
+                        },
+                        _ => (),
                     }
                 },
                 () = delay => {
@@ -1113,11 +1134,19 @@ fn test_utxo_validation() {
         loop {
             futures::select! {
                 event = event_stream.select_next_some() => {
-                    if let OutputManagerEvent::TxoValidationAborted(_r) = event.unwrap() {
-                        acc += 1;
-                        if acc >= 1 {
-                            break;
-                        }
+                    match event {
+                        Ok(msg) => {
+                            match (*msg).clone() {
+                                OutputManagerEvent::TxoValidationAborted(_) => {
+                                    acc += 1;
+                                    if acc >= 1 {
+                                        break;
+                                    }
+                                },
+                                _ => (),
+                            }
+                        },
+                        _ => (),
                     }
                 },
                 () = delay => {
@@ -1190,11 +1219,19 @@ fn test_utxo_validation() {
         loop {
             futures::select! {
                 event = event_stream.select_next_some() => {
-                    if let OutputManagerEvent::TxoValidationSuccess(_r) = event.unwrap() {
-                        acc += 1;
-                        if acc >= 1 {
-                            break;
-                        }
+                    match event {
+                        Ok(msg) => {
+                            match (*msg).clone() {
+                                OutputManagerEvent::TxoValidationSuccess(_) => {
+                                    acc += 1;
+                                    if acc >= 1 {
+                                        break;
+                                    }
+                                },
+                                _ => (),
+                            }
+                        },
+                        _ => (),
                     }
                 },
                 () = delay => {
@@ -1318,11 +1355,19 @@ fn test_spent_txo_validation() {
         loop {
             futures::select! {
                 event = event_stream.select_next_some() => {
-                    if let OutputManagerEvent::TxoValidationSuccess(_) = event.unwrap() {
-                        acc += 1;
-                        if acc >= 1 {
-                            break;
-                        }
+                    match event {
+                        Ok(msg) => {
+                            match (*msg).clone() {
+                                OutputManagerEvent::TxoValidationSuccess(_) => {
+                                    acc += 1;
+                                    if acc >= 1 {
+                                        break;
+                                    }
+                                },
+                                _ => (),
+                            }
+                        },
+                        _ => (),
                     }
                 },
                 () = delay => {

--- a/base_layer/wallet_ffi/src/callback_handler.rs
+++ b/base_layer/wallet_ffi/src/callback_handler.rs
@@ -24,7 +24,7 @@
 //! This CallbackHandler will monitor event streams from the various wallet services and on relevant events will call
 //! the assigned callbacks to provide asynchronous feedback to the client application that an event has occured
 //!
-//! ## Callbacks  
+//! ## Callbacks
 //! `callback_received_transaction` - This will be called when an inbound transaction is received from an external
 //! wallet
 //!
@@ -224,7 +224,7 @@ where TBackend: TransactionBackend + 'static
                     match result {
                         Ok(msg) => {
                             trace!(target: LOG_TARGET, "Output Manager Service Callback Handler event {:?}", msg);
-                            match msg {
+                            match (*msg).clone() {
                                 OutputManagerEvent::TxoValidationSuccess(request_key) => {
                                     self.receive_sync_process_result(request_key, true);
                                 },
@@ -711,9 +711,11 @@ mod test {
             .send(Arc::new(TransactionEvent::TransactionCancelled(5u64)))
             .unwrap();
 
-        oms_sender.send(OutputManagerEvent::TxoValidationSuccess(1u64)).unwrap();
         oms_sender
-            .send(OutputManagerEvent::TxoValidationTimedOut(1u64))
+            .send(Arc::new(OutputManagerEvent::TxoValidationSuccess(1u64)))
+            .unwrap();
+        oms_sender
+            .send(Arc::new(OutputManagerEvent::TxoValidationTimedOut(1u64)))
             .unwrap();
         dht_sender
             .send(Arc::new(DhtEvent::StoreAndForwardMessagesReceived))

--- a/base_layer/wallet_ffi/src/error.rs
+++ b/base_layer/wallet_ffi/src/error.rs
@@ -256,6 +256,10 @@ impl From<WalletError> for LibWalletError {
                 code: 425,
                 message: format!("{:?}", w),
             },
+            WalletError::WalletStorageError(WalletStorageError::NoPasswordError) => Self {
+                code: 426,
+                message: format!("{:?}", w),
+            },
             // This is the catch all error code. Any error that is not explicitly mapped above will be given this code
             _ => Self {
                 code: 999,

--- a/base_layer/wallet_ffi/src/lib.rs
+++ b/base_layer/wallet_ffi/src/lib.rs
@@ -6371,6 +6371,8 @@ mod test {
                 error_ptr,
             );
             comms_config_set_secret_key(alice_config, secret_key_alice, error_ptr);
+
+            // no passphrase
             let _alice_wallet = wallet_create(
                 alice_config,
                 ptr::null(),
@@ -6390,7 +6392,7 @@ mod test {
                 error_ptr,
             );
 
-            assert_eq!(error, 420);
+            assert_eq!(error, 426);
 
             let wrong_passphrase = "wrong pf".to_string();
             let wrong_passphrase_str = CString::new(wrong_passphrase).unwrap();


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
- Console wallet now validates all Unspent, Spent, and Invalid TXOs once wallet is started
- `OutputManagerEventSender` and `OutputManagerEventReceiver` updated to wrap `OutputManagerEvent` in  `Arc<>` to match Transaction and Connectivity service event streams. 
- Console wallet refreshes balance correctly once TXOs are validated 
- Fixed encryption test in `tari_wallet_ffi` broken by #2494   

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
An important feature that has already been implemented in the base node wallet 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- manually edited wallet sqlite outputs to alter their statuses, the console wallet then validated and updated to correct respective statuses 
- `cargo test -p tari_wallet`
- `cargo test -p tari_wallet_ffi` 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [x] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch.
* [x] I ran `cargo-fmt --all` before pushing.
* [ ] I ran `cargo test` successfully before submitting my PR.
* [x] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
