### PR TITLE
Increase comms wire mode

### DIFF
--- a/comms/src/connection_manager/wire_mode.rs
+++ b/comms/src/connection_manager/wire_mode.rs
@@ -22,7 +22,7 @@
 
 use std::convert::TryFrom;
 
-const COMMS_WIRE_MODE: u8 = 0x04;
+const COMMS_WIRE_MODE: u8 = 0x05;
 const LIVENESS_WIRE_MODE: u8 = 0x45; // E
 
 #[repr(u8)]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Increase comms wire mode to force a network split due to recent changes in the blockchain database that influence consensus.

## Motivation and Context
Old and new versions of the blockchain database do not mix as consensus is broken.

## How Has This Been Tested?
Tested between base nodes in Windows

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [X] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [X] I'm merging against the `development` branch.
* [X] I ran `cargo-fmt --all` before pushing.
* [ ] I ran `cargo test` successfully before submitting my PR.
* [X] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
