### PR TITLE
Fix accumulated difficulty while syncing

### DIFF
--- a/applications/tari_app_grpc/proto/base_node.proto
+++ b/applications/tari_app_grpc/proto/base_node.proto
@@ -75,8 +75,8 @@ message TipInfoResponse{
 /// return type of GetNewBlockTemplate
 message NewBlockTemplateResponse{
     NewBlockTemplate new_block_template = 1;
-    uint64 block_reward = 2;
     bool initial_sync_achieved = 3;
+    MinerData miner_data = 4;
 }
 
 /// An Empty placeholder for endpoints without request parameters
@@ -203,8 +203,7 @@ message GetNewBlockResult{
     bytes block_hash = 1;
     // This is the completed block
     Block block = 2;
-    // This is the merge_mining hash of the completed block.
-    MinerData miner_data = 3;
+    bytes merge_mining_hash =3;
 }
 
 // This is mining data for the miner asking for a new block
@@ -212,7 +211,7 @@ message MinerData{
     PowAlgo algo = 1;
     uint64 target_difficulty = 2;
     uint64 reward = 3;
-    bytes merge_mining_hash =4;
+    uint64 total_fees = 5;
 }
 
 // This is the request type for the Search Kernels rpc

--- a/applications/tari_app_grpc/proto/types.proto
+++ b/applications/tari_app_grpc/proto/types.proto
@@ -60,8 +60,8 @@ message ProofOfWork {
     // 0 = Monero
     // 1 = Blake
     uint64 pow_algo = 1;
-    uint64 accumulated_monero_difficulty = 2;
-    uint64 accumulated_blake_difficulty = 3;
+//    uint64 accumulated_monero_difficulty = 2;
+//    uint64 accumulated_blake_difficulty = 3;
     bytes pow_data = 4;
    // uint64 target_difficulty = 5;
 }
@@ -108,7 +108,7 @@ message NewBlockHeaderTemplate {
     // Proof of work metadata
     ProofOfWork pow = 5;
 
-    uint64 target_difficulty = 6;
+//    uint64 target_difficulty = 6;
 }
 
 // The new block template is used constructing a new partial block, allowing a miner to added the coinbase utxo and as a final step the Base node to add the MMR roots to the header.
@@ -262,5 +262,5 @@ message Peer{
     /// used as information for more efficient protocol negotiation.
     repeated bytes supported_protocols = 11;
     /// User agent advertised by the peer
-    string user_agent = 12; 
+    string user_agent = 12;
 }

--- a/applications/tari_app_grpc/src/conversions/block_header.rs
+++ b/applications/tari_app_grpc/src/conversions/block_header.rs
@@ -43,10 +43,7 @@ impl From<BlockHeader> for grpc::BlockHeader {
             nonce: h.nonce,
             pow: Some(grpc::ProofOfWork {
                 pow_algo: h.pow_algo().as_u64(),
-                accumulated_monero_difficulty: h.pow.accumulated_monero_difficulty.into(),
-                accumulated_blake_difficulty: h.pow.accumulated_blake_difficulty.into(),
                 pow_data: h.pow.pow_data,
-                // target_difficulty: h.pow.target_difficulty.as_u64(),
             }),
         }
     }

--- a/applications/tari_app_grpc/src/conversions/new_block_template.rs
+++ b/applications/tari_app_grpc/src/conversions/new_block_template.rs
@@ -37,11 +37,8 @@ impl From<NewBlockTemplate> for grpc::NewBlockTemplate {
             total_kernel_offset: Vec::from(block.header.total_kernel_offset.as_bytes()),
             pow: Some(grpc::ProofOfWork {
                 pow_algo: block.header.pow.pow_algo.as_u64(),
-                accumulated_monero_difficulty: block.header.pow.accumulated_monero_difficulty.into(),
-                accumulated_blake_difficulty: block.header.pow.accumulated_blake_difficulty.into(),
                 pow_data: block.header.pow.pow_data,
             }),
-            target_difficulty: block.header.target_difficulty.into(),
         };
         Self {
             body: Some(grpc::AggregateBody {
@@ -85,13 +82,20 @@ impl TryFrom<grpc::NewBlockTemplate> for NewBlockTemplate {
             prev_hash: header.prev_hash,
             total_kernel_offset,
             pow,
-            target_difficulty: header.target_difficulty.into(),
         };
         let body = block
             .body
             .map(TryInto::try_into)
             .ok_or_else(|| "Block body not provided".to_string())??;
 
-        Ok(Self { header, body })
+        // Note,  the target_difficulty fields won't be used when converting back, but this
+        // should probably be addressed at some point
+        Ok(Self {
+            header,
+            body,
+            target_difficulty: Default::default(),
+            reward: Default::default(),
+            total_fees: Default::default(),
+        })
     }
 }

--- a/applications/tari_app_grpc/src/conversions/proof_of_work.rs
+++ b/applications/tari_app_grpc/src/conversions/proof_of_work.rs
@@ -22,7 +22,7 @@
 
 use crate::tari_rpc as grpc;
 use std::convert::TryFrom;
-use tari_core::proof_of_work::{Difficulty, PowAlgorithm, ProofOfWork};
+use tari_core::proof_of_work::{PowAlgorithm, ProofOfWork};
 
 impl TryFrom<grpc::ProofOfWork> for ProofOfWork {
     type Error = String;
@@ -30,8 +30,8 @@ impl TryFrom<grpc::ProofOfWork> for ProofOfWork {
     fn try_from(pow: grpc::ProofOfWork) -> Result<Self, Self::Error> {
         Ok(Self {
             pow_algo: PowAlgorithm::try_from(pow.pow_algo)?,
-            accumulated_monero_difficulty: Difficulty::from(pow.accumulated_monero_difficulty),
-            accumulated_blake_difficulty: Difficulty::from(pow.accumulated_blake_difficulty),
+            accumulated_monero_difficulty: 1.into(),
+            accumulated_blake_difficulty: 1.into(),
             target_difficulty: 1.into(),
             pow_data: pow.pow_data,
         })

--- a/base_layer/core/src/base_node/chain_metadata_service/service.rs
+++ b/base_layer/core/src/base_node/chain_metadata_service/service.rs
@@ -31,6 +31,7 @@ use crate::{
 };
 use futures::stream::StreamExt;
 use log::*;
+use num_format::{Locale, ToFormattedString};
 use prost::Message;
 use std::{convert::TryFrom, sync::Arc, time::Instant};
 use tari_common::log_if_error;
@@ -247,9 +248,10 @@ impl ChainMetadataService {
                 .map_err(|err| ChainMetadataSyncError::ReceivedInvalidChainMetadata(node_id.clone(), err))?;
             debug!(
                 target: LOG_TARGET,
-                "Received chain metadata from NodeId '{}' #{}",
+                "Received chain metadata from NodeId '{}' #{}, Acc_diff {}",
                 node_id,
                 chain_metadata.height_of_longest_chain(),
+                chain_metadata.accumulated_difficulty().to_formatted_string(&Locale::en),
             );
 
             if let Some(pos) = self
@@ -280,9 +282,10 @@ impl ChainMetadataService {
             .map_err(|err| ChainMetadataSyncError::ReceivedInvalidChainMetadata(node_id.clone(), err))?;
         debug!(
             target: LOG_TARGET,
-            "Received chain metadata from NodeId '{}' #{}",
+            "Received chain metadata from NodeId '{}' #{}, Acc_diff {}",
             node_id,
-            chain_metadata.height_of_longest_chain()
+            chain_metadata.height_of_longest_chain(),
+            chain_metadata.accumulated_difficulty().to_formatted_string(&Locale::en),
         );
 
         if let Some(pos) = self

--- a/base_layer/core/src/base_node/comms_interface/inbound_handlers.rs
+++ b/base_layer/core/src/base_node/comms_interface/inbound_handlers.rs
@@ -395,6 +395,7 @@ where T: BlockchainBackend + 'static
                 let block_template = NewBlockTemplate::from_block(
                     header.into_builder().with_transactions(transactions).build(),
                     self.get_target_difficulty(pow_algo, height).await?,
+                    self.consensus_manager.get_block_reward_at(height),
                 );
                 debug!(
                     target: LOG_TARGET,

--- a/base_layer/core/src/base_node/state_machine_service/states/block_sync.rs
+++ b/base_layer/core/src/base_node/state_machine_service/states/block_sync.rs
@@ -92,11 +92,6 @@ impl BlockSync {
         match synchronizer.synchronize().await {
             Ok(()) => {
                 info!(target: LOG_TARGET, "Blocks synchronized in {:.0?}", timer.elapsed());
-                if !shared.bootstrapped_sync {
-                    debug!(target: LOG_TARGET, "Initial sync achieved, bootstrap done",);
-                    shared.bootstrapped_sync = true;
-                    shared.publish_event_info();
-                }
                 StateEvent::BlocksSynchronized
             },
             Err(err) => {

--- a/base_layer/core/src/base_node/state_machine_service/states/listening.rs
+++ b/base_layer/core/src/base_node/state_machine_service/states/listening.rs
@@ -33,6 +33,7 @@ use crate::{
 };
 use futures::StreamExt;
 use log::*;
+use num_format::{Locale, ToFormattedString};
 use serde::{Deserialize, Serialize};
 use std::{
     fmt::{Display, Formatter},
@@ -277,9 +278,9 @@ fn determine_sync_mode(local: &ChainMetadata, network: ChainMetadata, sync_peers
              with an accumulated difficulty of {}, and the network chain tip is at #{} with an accumulated difficulty \
              of {}",
             local_tip_height,
-            local_tip_accum_difficulty,
+            local_tip_accum_difficulty.to_formatted_string(&Locale::en),
             network_tip_height,
-            network_tip_accum_difficulty,
+            network_tip_accum_difficulty.to_formatted_string(&Locale::en),
         );
 
         let network_horizon_block = local.horizon_block(network_tip_height);
@@ -300,9 +301,9 @@ fn determine_sync_mode(local: &ChainMetadata, network: ChainMetadata, sync_peers
             "Our blockchain is up-to-date. We're at block {} with an accumulated difficulty of {} and the network \
              chain tip is at {} with an accumulated difficulty of {}",
             local.height_of_longest_chain(),
-            local_tip_accum_difficulty,
+            local_tip_accum_difficulty.to_formatted_string(&Locale::en),
             network.height_of_longest_chain(),
-            network_tip_accum_difficulty,
+            network_tip_accum_difficulty.to_formatted_string(&Locale::en),
         );
         UpToDate
     }

--- a/base_layer/core/src/base_node/sync/block_sync/synchronizer.rs
+++ b/base_layer/core/src/base_node/sync/block_sync/synchronizer.rs
@@ -32,6 +32,7 @@ use crate::{
 };
 use futures::StreamExt;
 use log::*;
+use num_format::{Locale, ToFormattedString};
 use std::{
     convert::TryFrom,
     sync::Arc,
@@ -232,9 +233,15 @@ impl<B: BlockchainBackend + 'static> BlockSynchronizer<B> {
 
             debug!(
                 target: LOG_TARGET,
-                "Block body #{} added in {:.0?}",
+                "Block body #{} added in {:.0?}, Tot_acc_diff {}, Monero {}, SHA3 {}",
                 block.block.header.height,
-                timer.elapsed()
+                timer.elapsed(),
+                block
+                    .accumulated_data
+                    .total_accumulated_difficulty
+                    .to_formatted_string(&Locale::en),
+                block.accumulated_data.accumulated_monero_difficulty,
+                block.accumulated_data.accumulated_blake_difficulty,
             );
             current_block = Some(block);
         }

--- a/base_layer/core/src/base_node/sync/block_sync/synchronizer.rs
+++ b/base_layer/core/src/base_node/sync/block_sync/synchronizer.rs
@@ -211,6 +211,7 @@ impl<B: BlockchainBackend + 'static> BlockSynchronizer<B> {
             );
 
             let timer = Instant::now();
+            let accumulated_difficulty = block.accumulated_data.total_accumulated_difficulty;
             self.db
                 .write_transaction()
                 .insert_block(block.clone())
@@ -219,6 +220,10 @@ impl<B: BlockchainBackend + 'static> BlockSynchronizer<B> {
                     MetadataValue::ChainHeight(block.block.header.height),
                 )
                 .set_metadata(MetadataKey::BestBlock, MetadataValue::BestBlock(header_hash))
+                .set_metadata(
+                    MetadataKey::AccumulatedWork,
+                    MetadataValue::AccumulatedWork(accumulated_difficulty),
+                )
                 .commit()
                 .await?;
 

--- a/base_layer/core/src/blocks/new_block_template.rs
+++ b/base_layer/core/src/blocks/new_block_template.rs
@@ -23,7 +23,7 @@
 use crate::{
     blocks::{new_blockheader_template::NewBlockHeaderTemplate, Block},
     proof_of_work::Difficulty,
-    transactions::aggregated_body::AggregateBody,
+    transactions::{aggregated_body::AggregateBody, tari_amount::MicroTari},
 };
 use serde::{Deserialize, Serialize};
 use std::fmt::{Display, Formatter};
@@ -34,14 +34,21 @@ use std::fmt::{Display, Formatter};
 pub struct NewBlockTemplate {
     pub header: NewBlockHeaderTemplate,
     pub body: AggregateBody,
+    pub target_difficulty: Difficulty,
+    pub reward: MicroTari,
+    pub total_fees: MicroTari,
 }
 
 impl NewBlockTemplate {
-    pub fn from_block(block: Block, target_difficulty: Difficulty) -> Self {
+    pub fn from_block(block: Block, target_difficulty: Difficulty, reward: MicroTari) -> Self {
         let Block { header, body } = block;
+        let total_fees = body.get_total_fee();
         Self {
-            header: NewBlockHeaderTemplate::from_header(header, target_difficulty),
+            header: NewBlockHeaderTemplate::from_header(header),
             body,
+            target_difficulty,
+            reward,
+            total_fees,
         }
     }
 }
@@ -52,6 +59,10 @@ impl Display for NewBlockTemplate {
         fmt.write_str("--- Header ---\n")?;
         fmt.write_str(&format!("{}\n", self.header))?;
         fmt.write_str("---  Body  ---\n")?;
-        fmt.write_str(&format!("{}\n", self.body))
+        fmt.write_str(&format!("{}\n", self.body))?;
+        fmt.write_str(&format!(
+            "Target difficulty: {}\nReward: {}\nTotal fees: {}\n",
+            self.target_difficulty, self.reward, self.total_fees
+        ))
     }
 }

--- a/base_layer/core/src/blocks/new_blockheader_template.rs
+++ b/base_layer/core/src/blocks/new_blockheader_template.rs
@@ -22,7 +22,7 @@
 
 use crate::{
     blocks::block_header::{hash_serializer, BlockHeader},
-    proof_of_work::{Difficulty, ProofOfWork},
+    proof_of_work::ProofOfWork,
     transactions::types::BlindingFactor,
 };
 use serde::{Deserialize, Serialize};
@@ -46,19 +46,16 @@ pub struct NewBlockHeaderTemplate {
     pub total_kernel_offset: BlindingFactor,
     /// Proof of work summary
     pub pow: ProofOfWork,
-    /// Target difficulty for this block template
-    pub target_difficulty: Difficulty,
 }
 
 impl NewBlockHeaderTemplate {
-    pub(crate) fn from_header(header: BlockHeader, target_difficulty: Difficulty) -> Self {
+    pub(crate) fn from_header(header: BlockHeader) -> Self {
         Self {
             version: header.version,
             height: header.height,
             prev_hash: header.prev_hash,
             total_kernel_offset: header.total_kernel_offset,
             pow: header.pow,
-            target_difficulty,
         }
     }
 }
@@ -66,11 +63,10 @@ impl NewBlockHeaderTemplate {
 impl Display for NewBlockHeaderTemplate {
     fn fmt(&self, fmt: &mut Formatter<'_>) -> Result<(), Error> {
         let msg = format!(
-            "Version: {}\nBlock height: {}\nPrevious block hash: {}\nTarget Difficulty: {}\n",
+            "Version: {}\nBlock height: {}\nPrevious block hash: {}\n",
             self.version,
             self.height,
             self.prev_hash.to_hex(),
-            self.target_difficulty,
         );
         fmt.write_str(&msg)?;
         fmt.write_str(&format!(

--- a/base_layer/core/src/chain_storage/accumulated_data.rs
+++ b/base_layer/core/src/chain_storage/accumulated_data.rs
@@ -27,6 +27,8 @@ use crate::{
     transactions::types::{BlindingFactor, Commitment, HashOutput},
 };
 use croaring::Bitmap;
+use log::*;
+use num_format::{Locale, ToFormattedString};
 use serde::{
     de,
     de::{MapAccess, SeqAccess, Visitor},
@@ -38,6 +40,8 @@ use serde::{
 };
 use std::fmt;
 use tari_mmr::pruned_hashset::PrunedHashSet;
+
+const LOG_TARGET: &str = "c::bn::acc_data";
 
 #[derive(Debug)]
 pub struct BlockAccumulatedData {
@@ -283,7 +287,7 @@ impl BlockHeaderAccumulatedDataBuilder {
             .accumulated_blake_difficulty
             .ok_or_else(|| ChainStorageError::InvalidOperation("difficulty not provided".to_string()))?;
 
-        Ok(BlockHeaderAccumulatedData {
+        let result = BlockHeaderAccumulatedData {
             hash: self
                 .hash
                 .ok_or_else(|| ChainStorageError::InvalidOperation("hash not provided".to_string()))?,
@@ -299,7 +303,15 @@ impl BlockHeaderAccumulatedDataBuilder {
             target_difficulty: self
                 .target_difficulty
                 .ok_or_else(|| ChainStorageError::InvalidOperation("target difficulty not provided".to_string()))?,
-        })
+        };
+        trace!(
+            target: LOG_TARGET,
+            "Calculated: Tot_acc_diff {}, Monero {}, SHA3 {}",
+            result.total_accumulated_difficulty.to_formatted_string(&Locale::en),
+            result.accumulated_monero_difficulty,
+            result.accumulated_blake_difficulty,
+        );
+        Ok(result)
     }
 }
 

--- a/base_layer/core/src/chain_storage/blockchain_database.rs
+++ b/base_layer/core/src/chain_storage/blockchain_database.rs
@@ -690,7 +690,7 @@ where B: BlockchainBackend
     }
 
     pub fn prepare_block_merkle_roots(&self, template: NewBlockTemplate) -> Result<Block, ChainStorageError> {
-        let NewBlockTemplate { header, mut body } = template;
+        let NewBlockTemplate { header, mut body, .. } = template;
         body.sort();
         let header = BlockHeader::from(header);
         let mut block = Block { header, body };

--- a/base_layer/core/src/consensus/consensus_manager.rs
+++ b/base_layer/core/src/consensus/consensus_manager.rs
@@ -94,6 +94,10 @@ impl ConsensusManager {
         &self.inner.emission
     }
 
+    pub fn get_block_reward_at(&self, height: u64) -> MicroTari {
+        self.emission_schedule().block_reward(height)
+    }
+
     // Get the emission reward at height
     pub fn get_total_emission_at(&self, height: u64) -> MicroTari {
         self.inner.emission.supply_at_block(height)

--- a/base_layer/core/src/mining/miner.rs
+++ b/base_layer/core/src/mining/miner.rs
@@ -166,7 +166,7 @@ impl Miner {
             return Ok(self);
         };
         let mut block_template = block_template.unwrap();
-        let target_difficulty = block_template.header.target_difficulty;
+        let target_difficulty = block_template.target_difficulty;
         let output = self.add_coinbase(&mut block_template);
         if output.is_err() {
             error!(

--- a/base_layer/core/src/proto/block.proto
+++ b/base_layer/core/src/proto/block.proto
@@ -93,11 +93,14 @@ message NewBlockHeaderTemplate {
     bytes total_kernel_offset = 4;
     // Proof of work metadata
     ProofOfWork pow = 5;
-    uint64 target_difficulty = 6;
+
 }
 
 // The new block template is used constructing a new partial block, allowing a miner to added the coinbase utxo and as a final step the Base node to add the MMR roots to the header.
 message NewBlockTemplate {
     NewBlockHeaderTemplate header = 1;
     tari.types.AggregateBody body = 2;
+    uint64 target_difficulty = 3;
+    uint64 reward = 4;
+    uint64 total_fees  = 5;
 }

--- a/base_layer/core/src/proto/block.rs
+++ b/base_layer/core/src/proto/block.rs
@@ -211,7 +211,13 @@ impl TryFrom<proto::NewBlockTemplate> for NewBlockTemplate {
             .map(TryInto::try_into)
             .ok_or_else(|| "Block body not provided".to_string())??;
 
-        Ok(Self { header, body })
+        Ok(Self {
+            header,
+            body,
+            target_difficulty: block_template.target_difficulty.into(),
+            reward: block_template.reward.into(),
+            total_fees: block_template.total_fees.into(),
+        })
     }
 }
 
@@ -220,6 +226,9 @@ impl From<NewBlockTemplate> for proto::NewBlockTemplate {
         Self {
             header: Some(block_template.header.into()),
             body: Some(block_template.body.into()),
+            target_difficulty: block_template.target_difficulty.as_u64(),
+            reward: block_template.reward.0,
+            total_fees: block_template.total_fees.0,
         }
     }
 }
@@ -242,7 +251,6 @@ impl TryFrom<proto::NewBlockHeaderTemplate> for NewBlockHeaderTemplate {
             prev_hash: header.prev_hash,
             total_kernel_offset,
             pow,
-            target_difficulty: Default::default(),
         })
     }
 }
@@ -255,7 +263,6 @@ impl From<NewBlockHeaderTemplate> for proto::NewBlockHeaderTemplate {
             prev_hash: header.prev_hash,
             total_kernel_offset: header.total_kernel_offset.to_vec(),
             pow: Some(proto::ProofOfWork::from(header.pow)),
-            target_difficulty: header.target_difficulty.into(),
         }
     }
 }

--- a/base_layer/core/src/proto/generated/tari.core.rs
+++ b/base_layer/core/src/proto/generated/tari.core.rs
@@ -116,8 +116,6 @@ pub struct NewBlockHeaderTemplate {
     /// Proof of work metadata
     #[prost(message, optional, tag = "5")]
     pub pow: ::std::option::Option<ProofOfWork>,
-    #[prost(uint64, tag = "6")]
-    pub target_difficulty: u64,
 }
 /// The new block template is used constructing a new partial block, allowing a miner to added the coinbase utxo and as
 /// a final step the Base node to add the MMR roots to the header.
@@ -127,4 +125,10 @@ pub struct NewBlockTemplate {
     pub header: ::std::option::Option<NewBlockHeaderTemplate>,
     #[prost(message, optional, tag = "2")]
     pub body: ::std::option::Option<super::types::AggregateBody>,
+    #[prost(uint64, tag = "3")]
+    pub target_difficulty: u64,
+    #[prost(uint64, tag = "4")]
+    pub reward: u64,
+    #[prost(uint64, tag = "5")]
+    pub total_fees: u64,
 }

--- a/base_layer/core/tests/helpers/database.rs
+++ b/base_layer/core/tests/helpers/database.rs
@@ -50,6 +50,7 @@ pub fn create_orphan_block(block_height: u64, transactions: Vec<Transaction>, co
             .with_coinbase_utxo(coinbase_utxo, coinbase_kernel)
             .build(),
         1.into(),
+        coinbase_value,
     );
     Block::new(template.header.into(), template.body)
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Fix a bug where the accumulated difficulty was not set in the chain metadata db while syncing blocks. Also moved the `target_difficulty` fields around in the GRPC proto file and added `reward` and `total_fees` to make it easier for miners
