### PR TITLE
Fix possible panic in header sync

### DIFF
--- a/base_layer/core/src/base_node/sync/header_sync/synchronizer.rs
+++ b/base_layer/core/src/base_node/sync/header_sync/synchronizer.rs
@@ -342,7 +342,7 @@ impl<'a, B: BlockchainBackend + 'static> HeaderSynchronizer<'a, B> {
             }
 
             debug!(target: LOG_TARGET, "Already in sync with peer `{}`.", peer);
-            return Ok(false);
+            return Ok(true);
         }
 
         // We can trust that the header associated with this hash exists because block_hashes is data this node


### PR DESCRIPTION
`check_chain_split` in header sync should return `Ok(true)` (sync complete)
instead of `Ok(false)` when a remote peer indicates it has no further headers to sync.
A panic is possible when validation is not initialized before the early exit
which then proceeded to call `validate` on an uninitialized header sync validator.

