### PR TITLE
[Merge Mining] Monero Block Templates - Validity Period

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4178,6 +4178,7 @@ version = "0.7.0"
 dependencies = [
  "bincode",
  "bytes 0.5.6",
+ "chrono",
  "config",
  "derive-error",
  "env_logger 0.7.1",

--- a/applications/tari_merge_mining_proxy/Cargo.toml
+++ b/applications/tari_merge_mining_proxy/Cargo.toml
@@ -41,6 +41,7 @@ tracing = "0.1"
 tracing-subscriber = "0.2"
 tracing-futures = "0.2"
 url = "2.1.1"
+chrono = "0.4.19"
 
 env_logger = { version = "0.7.1", optional = true }
 

--- a/base_layer/core/src/proof_of_work/randomx_factory.rs
+++ b/base_layer/core/src/proof_of_work/randomx_factory.rs
@@ -15,7 +15,7 @@ pub struct RandomXConfig {
 
 impl From<&RandomXConfig> for RandomXFlag {
     fn from(source: &RandomXConfig) -> Self {
-        let mut result = RandomXFlag::default();
+        let mut result = RandomXFlag::get_recommended_flags();
         if source.use_large_pages {
             result |= RandomXFlag::FLAG_LARGE_PAGES
         }


### PR DESCRIPTION
## Description
This PR introduces a validity period for templates stored int the BlockTemplateRepository.

While solo mining only needs the template to be valid for one submission, pool mining (in this case self-select mining via a pool) requires that the templates remain valid for multiple submissions of solutions for a given block since the difficulty which xmrig is mining to on a pool is lower than the target difficulty of either network.

Validity period may need to be adjusted further..

## Motivation and Context
Necessary for pool mining and self-select mining

## How Has This Been Tested?
Manually tested

## Types of changes
* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [x] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
* [x] I'm merging against the `development` branch.
* [x] I ran `cargo-fmt --all` before pushing.
* [ ] I ran `cargo test` successfully before submitting my PR.
* [x] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
