### PR TITLE
Add fee estimate method to output manager service and wallet_ffi

### DIFF
--- a/applications/tari_base_node/src/tasks/transaction_monitor.rs
+++ b/applications/tari_base_node/src/tasks/transaction_monitor.rs
@@ -281,6 +281,7 @@ async fn monitor_validation_protocol(
                         );
                         continue;
                     },
+                    _ => (),
                 }
             },
             // Restart the protocol if it timed out

--- a/base_layer/wallet_ffi/src/callback_handler.rs
+++ b/base_layer/wallet_ffi/src/callback_handler.rs
@@ -24,7 +24,7 @@
 //! This CallbackHandler will monitor event streams from the various wallet services and on relevant events will call
 //! the assigned callbacks to provide asynchronous feedback to the client application that an event has occured
 //!
-//! ## Callbacks  
+//! ## Callbacks
 //! `callback_received_transaction` - This will be called when an inbound transaction is received from an external
 //! wallet
 //!
@@ -213,11 +213,11 @@ where TBackend: TransactionBackend + 'static
                                 TransactionEvent::TransactionMined(tx_id) => {
                                     self.receive_transaction_mined_event(tx_id).await;
                                 },
-                                /// Only the above variants are mapped to callbacks
+                                // Only the above variants are mapped to callbacks
                                 _ => (),
                             }
                         },
-                        Err(e) => error!(target: LOG_TARGET, "Error reading from Transaction Service event broadcast channel"),
+                        Err(_e) => error!(target: LOG_TARGET, "Error reading from Transaction Service event broadcast channel"),
                     }
                 },
                 result = self.output_manager_service_event_stream.select_next_some() => {
@@ -230,18 +230,18 @@ where TBackend: TransactionBackend + 'static
                                 },
                                 OutputManagerEvent::TxoValidationTimedOut(request_key) => {
                                     self.receive_sync_process_result(request_key, false);
-                                }
+                                },
                                 OutputManagerEvent::TxoValidationFailure(request_key) => {
                                     self.receive_sync_process_result(request_key, false);
-                                }
+                                },
                                 OutputManagerEvent::TxoValidationAborted(request_key) => {
                                     self.receive_sync_process_result(request_key, false);
-                                }
-                                /// Only the above variants are mapped to callbacks
+                                },
+                                // Only the above variants are mapped to callbacks
                                 _ => (),
                             }
                         },
-                        Err(e) => error!(target: LOG_TARGET, "Error reading from Output Manager Service event broadcast channel"),
+                        Err(_e) => error!(target: LOG_TARGET, "Error reading from Output Manager Service event broadcast channel"),
                     }
                 },
                 result = self.dht_event_stream.select_next_some() => {
@@ -252,11 +252,11 @@ where TBackend: TransactionBackend + 'static
                                 DhtEvent::StoreAndForwardMessagesReceived => {
                                     self.saf_messages_received_event();
                                 },
-                                /// Only the above variants are mapped to callbacks
+                                // Only the above variants are mapped to callbacks
                                 _ => (),
                             }
                         },
-                        Err(e) => error!(target: LOG_TARGET, "Error reading from DHT event broadcast channel"),
+                        Err(_e) => error!(target: LOG_TARGET, "Error reading from DHT event broadcast channel"),
                     }
                 }
                 complete => {

--- a/base_layer/wallet_ffi/src/error.rs
+++ b/base_layer/wallet_ffi/src/error.rs
@@ -256,6 +256,10 @@ impl From<WalletError> for LibWalletError {
                 code: 425,
                 message: format!("{:?}", w),
             },
+            WalletError::WalletStorageError(WalletStorageError::NoPasswordError) => Self {
+                code: 426,
+                message: format!("{:?}", w),
+            },
             // This is the catch all error code. Any error that is not explicitly mapped above will be given this code
             _ => Self {
                 code: 999,

--- a/base_layer/wallet_ffi/wallet.h
+++ b/base_layer/wallet_ffi/wallet.h
@@ -461,6 +461,9 @@ unsigned long long wallet_get_pending_incoming_balance(struct TariWallet *wallet
 // Gets the outgoing balance from a TariWallet
 unsigned long long wallet_get_pending_outgoing_balance(struct TariWallet *wallet,int* error_out);
 
+// Get a fee estimate from a TariWallet for a given amount
+unsigned long long wallet_get_fee_estimate(struct TariWallet *wallet, unsigned long long amount, unsigned long long fee_per_gram, unsigned long long num_kernels, unsigned long long num_outputs, int* error_out);
+
 // Sends a TariPendingOutboundTransaction
 unsigned long long wallet_send_transaction(struct TariWallet *wallet, struct TariPublicKey *destination, unsigned long long amount, unsigned long long fee_per_gram,const char *message,int* error_out);
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Adds a `fee_estimate` method to the output manager service and also to the wallet_ffi 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This will allow the mobile app to show accurate fees for the transaction 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- `cargo test -p tari_wallet`
- `cargo test -p tari_wallet_ffi`

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [x] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch.
* [x] I ran `cargo-fmt --all` before pushing.
* [ ] I ran `cargo test` successfully before submitting my PR.
* [x] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
