### PR TITLE
[Tari Mining Node] Add estimated time to block to logs

### DIFF
--- a/applications/tari_mining_node/src/miner.rs
+++ b/applications/tari_mining_node/src/miner.rs
@@ -51,6 +51,7 @@ pub struct MiningReport {
     /// Will be set for when mined header is matching required difficulty
     pub header: Option<BlockHeader>,
     pub height: u64,
+    pub last_nonce: u64,
 }
 
 /// Miner is starting number of mining threads and implements Stream for async reports polling
@@ -191,6 +192,7 @@ pub fn mining_task(
                 height: header.height,
                 header: Some(header),
                 target_difficulty,
+                last_nonce: nonce,
             }) {
                 error!("Miner {} failed to send report: {}", miner, err);
             }
@@ -207,6 +209,7 @@ pub fn mining_task(
                 header: None,
                 height: header.height,
                 target_difficulty,
+                last_nonce: nonce,
             });
             waker.clone().wake();
             trace!("Reporting from {} result {:?}", miner, res);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Add estimated time to find a block to logs. This is not accurate since it is probabilistic, but will give the user an idea of how long it would take to solo mine a block at the current network hash rate.

Example:
```
2021-01-13 09:23:58.199382000 [tari_mining_node] DEBUG Miner 3 reported 0.22MH/s with total 1.34MH/s over 6 threads. Height: 20940. Target: 423872797, Estimated block in approx. 4m14s (+/- Ave. 315s)
```

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
If I download the miner and start mining, I can get an idea of the performance of my machine vs the current network hash rate by comparing the target block time to the time it would take to mine a block. E.g. if it would take 20 mins to mine a SHA block, I know there are around 4 other miners at a similar hash rate.  

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested by running locally
