### PR TITLE
Fix transaction kernel not being deleted

### DIFF
--- a/base_layer/core/src/chain_storage/lmdb_db/mod.rs
+++ b/base_layer/core/src/chain_storage/lmdb_db/mod.rs
@@ -48,7 +48,7 @@ pub const LMDB_DB_ORPHAN_HEADER_ACCUMULATED_DATA: &str = "orphan_accumulated_dat
 pub const LMDB_DB_ORPHAN_CHAIN_TIPS: &str = "orphan_chain_tips";
 pub const LMDB_DB_ORPHAN_PARENT_MAP_INDEX: &str = "orphan_parent_map_index";
 
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, Debug)]
 pub(crate) struct TransactionOutputRowData {
     pub output: TransactionOutput,
     pub header_hash: HashOutput,
@@ -57,7 +57,7 @@ pub(crate) struct TransactionOutputRowData {
     pub range_proof_hash: HashOutput,
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, Debug)]
 pub(crate) struct TransactionInputRowData {
     pub input: TransactionInput,
     pub header_hash: HashOutput,
@@ -65,7 +65,7 @@ pub(crate) struct TransactionInputRowData {
     pub hash: HashOutput,
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, Debug)]
 pub(crate) struct TransactionKernelRowData {
     pub kernel: TransactionKernel,
     pub header_hash: HashOutput,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR fixes a problem where transaction kernels are not being deleted fully after a one/multiple block re-org. 

### Example: Transaction kernel not being deleted fully after a block re-org.

This example shows a new block containing the same transaction kernel received from the miner, which has a higher accumulated difficulty than the old block, but removing the old block from the blockchain database did not clear up the transaction kernel fully, so inserting the new block failed. See detail story below:

Block `#20903` containing kernel `7a64b1a3ec9..., 960dab2636e...` received via GRPC from the merge minging proxy:
``` rust
2021-01-12 23:47:58.138798800 [tari::base_node::grpc] DEBUG Received SubmitBlock #20903 request from client
2021-01-12 23:47:58.138894300 [c::bn::comms_interface::inbound_handler] INFO  Block #20903 (4875f016b0f07497d4c635e337772ec0d4de76728e28872a7d01188ca4cc38d9) received from local services
```
``` rust
--- Header ---
Hash: 6e29f5099f8d31107ecb2dec383860a1c786f34d39fef2d233f47ced6de978f1
Version: 1
Block height: 20903
Previous block hash: 09d87ca6849ebcac2eea1337ed7a2f62d8fbec5248e026e49186aa8a654c0cf4
Timestamp: Tue, 12 Jan 2021 21:46:07 +0000
--- Transaction Kernels ---
Kernel 0:
Fee: 0 µT
Lock height: 0
Features: COINBASE_KERNEL
Excess: 8ec197fe435fa779b4c03c42b80e94722f072d4338c8dbd95499703193eb0c01
Excess signature: {"public_nonce":"7a64b1a3ec9fbbeef3a28cf40a570fa4c78fad609a7f1aacc3b6f1963729bf08","signature":"960dab2636e890547c8d8896ebbd1fe578404aef503449aea46a932cacd7f606"}
```
Block passed validation and was added to the db:
``` rust
2021-01-12 23:47:58.197670600 [c::cs::database] DEBUG Storing new block #20903 `4875f016b0f07497d4c635e337772ec0d4de76728e28872a7d01188ca4cc38d9`
2021-01-12 23:47:58.197919900 [c::cs::lmdb_db::lmdb_db] DEBUG Inserting block body for header `4875f016b0f07497d4c635e337772ec0d4de76728e28872a7d01188ca4cc38d9`: 0 input(s), 1 output(s), 1 kernel(s)
2021-01-12 23:47:58.205082400 [c::cs::lmdb_db::lmdb_db] DEBUG Database completed 6 operation(s) in 7ms
2021-01-12 23:47:58.205830400 [tari::base_node::grpc] DEBUG Sending SubmitBlock #20903 response to client
```

New block `#20903` containing the same kernel `7a64b1a3ec9..., 960dab2636e...` received via GRPC from the merge minging proxy:
``` rust
2021-01-12 23:48:50.351113500 [tari::base_node::grpc] DEBUG Received SubmitBlock #20903 request from client
2021-01-12 23:48:50.351205200 [c::bn::comms_interface::inbound_handler] INFO  Block #20903 (6e
29f5099f8d31107ecb2dec383860a1c786f34d39fef2d233f47ced6de978f1) received from local services
```
``` rust
--- Header ---
Hash: 6e29f5099f8d31107ecb2dec383860a1c786f34d39fef2d233f47ced6de978f1
Version: 1
Block height: 20903
Previous block hash: 09d87ca6849ebcac2eea1337ed7a2f62d8fbec5248e026e49186aa8a654c0cf4
Timestamp: Tue, 12 Jan 2021 21:46:07 +0000
--- Transaction Kernels ---
Kernel 0:
Fee: 0 µT
Lock height: 0
Features: COINBASE_KERNEL
Excess: 8ec197fe435fa779b4c03c42b80e94722f072d4338c8dbd95499703193eb0c01
Excess signature: {"public_nonce":"7a64b1a3ec9fbbeef3a28cf40a570fa4c78fad609a7f1aacc3b6f1963729bf08","signature":"960dab2636e890547c8d8896ebbd1fe578404aef503449aea46a932cacd7f606"}
```
The new block's validation passed and has a higher accumulated difficulty than the old block:
``` rust
2021-01-12 23:48:50.392128000 [c::cs::database] DEBUG Added candidate block #20903 (6e29f5099f8d31107ecb2dec383860a1c786f34d39fef2d233f47ced6de978f1) to the orphan database. Best height is 20903. New tips found:1 
2021-01-12 23:48:50.392186000 [c::cs::database] DEBUG Comparing candidate block #20903 (accum_diff:2977507341948681650448148, hash:6e29f5099f8d31107ecb2dec383860a1c786f34d39fef2d233f47ced6de978f1) to main chain #20903 (accum_diff: 2977502965220405806733122, hash: (4875f016b0f07497d4c635e337772ec0d4de76728e28872a7d01188ca4cc38d9)).
2021-01-12 23:48:50.392208000 [c::cs::database] DEBUG Fork chain (accum_diff:20903, hash:6e29f5099f8d31107ecb2dec383860a1c786f34d39fef2d233f47ced6de978f1) is stronger than the current tip.
2021-01-12 23:48:50.392322700 [c::cs::database] DEBUG Rewinding headers from height 20903 to 20902
2021-01-12 23:48:50.392339800 [c::cs::database] DEBUG Rewinding blocks from height 20903 to 20902
```

The new block cannot be inserted into the db due to a duplicate kernel being present:
``` rust
2021-01-12 23:48:50.397115600 [c::cs::database] DEBUG Validate and add 1 chain block(s) from height 20902. Rewound blocks: [20903]
2021-01-12 23:48:50.397843500 [c::val::block_validators] TRACE Block validation: All inputs and outputs are valid for block #20903 (6e29f5099f8d31107ecb2dec383860a1c786f34d39fef2d233f47ced6de978f1)
2021-01-12 23:48:50.398465500 [c::val::block_validators] TRACE Block validation: MMR roots are valid for block #20903 (6e29f5099f8d31107ecb2dec383860a1c786f34d39fef2d233f47ced6de978f1)
2021-01-12 23:48:50.398483800 [c::val::block_validators] DEBUG Block validation: Block is VALID for block #20903 (6e29f5099f8d31107ecb2dec383860a1c786f34d39fef2d233f47ced6de978f1)
2021-01-12 23:48:50.398501300 [c::cs::database] DEBUG Storing new block #20903 `6e29f5099f8d31107ecb2dec383860a1c786f34d39fef2d233f47ced6de978f1`
2021-01-12 23:48:50.398745900 [c::cs::lmdb_db::lmdb_db] DEBUG Inserting block body for header `6e29f5099f8d31107ecb2dec383860a1c786f34d39fef2d233f47ced6de978f1`: 0 input(s), 1 output(s), 1 kernel(s)
2021-01-12 23:48:50.398907800 [c::cs::lmdb_db::lmdb_db] TRACE Inserting kernel `960dab2636e890547c8d8896ebbd1fe578404aef503449aea46a932cacd7f606`
2021-01-12 23:48:50.399147400 [c::cs::lmdb_db::lmdb] ERROR Could not insert value into lmdb transaction (7a64b1a3ec9fbbeef3a28cf40a570fa4c78fad609a7f1aacc3b6f1963729bf08960dab2636e890547c8d8896ebbd1fe578404aef503449aea46a932cacd7f606/([72, 117, 240, 22, 176, 240, 116, 151, 212, 198, 53, 227, 55, 119, 46, 192, 212, 222, 118, 114, 142, 40, 135, 42, 125, 1, 24, 140, 164, 204, 56, 217], 215727, [73, 35, 245, 7, 254, 233, 38, 122, 227, 17, 124, 233, 93, 64, 163, 75, 78, 113, 127, 229, 90, 234, 64, 78, 185, 118, 214, 136, 248, 12, 21, 46])): Error::Code(-30799, 'MDB_KEYEXIST: Key/data pair already exists')
2021-01-12 23:48:50.399173400 [c::cs::lmdb_db::lmdb_db] ERROR Failed to apply DB transaction: Access to the underlying storage mechanism failed: MDB_KEYEXIST: Key/data pair already exists
2021-01-12 23:48:50.399186900 [c::cs::database] WARN  Failed to commit reorg chain: Access to the underlying storage mechanism failed: MDB_KEYEXIST: Key/data pair already exists. Restoring last chain.
```
## Motivation and Context
The blockchain database cannot have duplicate parts of transaction kernels. 

## How Has This Been Tested?
Tested with base node sync from scratch and with merge mining afterwards, where reorg were observed.
**Note:** TODO: Add a unit test to verify a 1 block reorg containing exactly the same data except with a different nonce and thus header hash.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [X] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [X] I'm merging against the `development` branch.
* [X] I ran `cargo-fmt --all` before pushing.
* [ ] I ran `cargo test` successfully before submitting my PR.
* [X] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
