### PR TITLE
Remove incorrect error response in blockchain rewind

### DIFF
--- a/base_layer/core/tests/chain_storage_tests/chain_storage.rs
+++ b/base_layer/core/tests/chain_storage_tests/chain_storage.rs
@@ -1057,6 +1057,7 @@ fn orphan_cleanup_on_block_add() {
         BlockAddResult::OrphanBlock
     );
 
+    store.cleanup_orphans().unwrap();
     assert_eq!(store.db_read_access().unwrap().orphan_count().unwrap(), 3);
     assert_eq!(store.fetch_orphan(orphan1_hash).unwrap(), orphan1);
     assert!(store.fetch_orphan(orphan2_hash).is_err());
@@ -1247,6 +1248,7 @@ fn orphan_cleanup_on_reorg() {
 
     // Check that A2, A3 and A4 is in the orphan block pool, A1 and the other orphans were discarded by the orphan
     // cleanup.
+    store.cleanup_orphans().unwrap();
     assert_eq!(store.db_read_access().unwrap().orphan_count().unwrap(), 3);
     assert_eq!(store.fetch_orphan(blocks[2].hash().clone()).unwrap(), blocks[2].block);
     assert_eq!(store.fetch_orphan(blocks[3].hash().clone()).unwrap(), blocks[3].block);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
`rewind_to_height` only rewind block bodies _if they exist_.
This means that calling `rewind_to_height(h)` where `h` is greater than the current
_block_ height is valid.

This fixes a continuous failure of header sync, causing nodes to get
stuck at a particular block height.


Also fixed 2 unrelated tari_core tests

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Reports of seed nodes being stuck at a height

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Existing tests pass, tested syncing from scratch

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [ ] I'm merging against the `development` branch.
* [ ] I ran `cargo-fmt --all` before pushing.
* [ ] I ran `cargo test` successfully before submitting my PR.
* [ ] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
