### PR TITLE
[Merge Mining] Remove merge mining template on successful submission

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3073,9 +3073,9 @@ dependencies = [
 
 [[package]]
 name = "randomx-rs"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f132cf96745b4803e0c86e2fa0c2b301ebf1eb608a705a2788d6c876062089b"
+checksum = "d5b1588934c19acc7218925816a7d6af57699c4e0d43c1c1ccda3463f619e53b"
 dependencies = [
  "bitflags 1.2.1",
  "derive-error",

--- a/applications/tari_merge_mining_proxy/src/block_template_data.rs
+++ b/applications/tari_merge_mining_proxy/src/block_template_data.rs
@@ -98,6 +98,16 @@ impl BlockTemplateRepository {
             }
         }
     }
+
+    pub async fn remove<T: AsRef<[u8]>>(&mut self, hash: T) {
+        let mut b = self.blocks.write().await;
+        trace!(
+            target: LOG_TARGET,
+            "Blocktemplate removed with merge mining hash {:?}",
+            hex::encode(hash.as_ref())
+        );
+        b.remove(hash.as_ref());
+    }
 }
 
 #[derive(Clone, Debug)]

--- a/applications/tari_merge_mining_proxy/src/proxy.rs
+++ b/applications/tari_merge_mining_proxy/src/proxy.rs
@@ -341,12 +341,15 @@ impl InnerService {
                             status,
                             details: "failed to submit block".to_string(),
                         }) {
-                        Ok(..) => debug!(
-                            target: LOG_TARGET,
-                            "Submitted block #{} to Tari node in {:.0?} (SubmitBlock)",
-                            height,
-                            start.elapsed()
-                        ),
+                        Ok(..) => {
+                            debug!(
+                                target: LOG_TARGET,
+                                "Submitted block #{} to Tari node in {:.0?} (SubmitBlock)",
+                                height,
+                                start.elapsed()
+                            );
+                            block_templates_clone.remove(&hash).await;
+                        },
                         _ => debug!(
                             target: LOG_TARGET,
                             "Problem submitting block #{} to Tari node, responded in  {:.0?} (SubmitBlock)",
@@ -360,7 +363,7 @@ impl InnerService {
             } else {
                 info!(
                     target: LOG_TARGET,
-                    "Block submitted but no matching block template was found"
+                    "Block submitted but no matching block template was found, possible duplicate submission"
                 );
             }
         }


### PR DESCRIPTION
## Description
Prevents multiple solutions being submitted for the same block.

## Motivation and Context

## How Has This Been Tested?

## Types of changes
* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch.
* [x] I ran `cargo-fmt --all` before pushing.
* [x] I ran `cargo test` successfully before submitting my PR.
* [x] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
