### PR TITLE
Encrypt Node_id and Tor_id at rest

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4380,6 +4380,7 @@ name = "tari_wallet"
 version = "0.7.3"
 dependencies = [
  "aes-gcm",
+ "bincode",
  "blake2",
  "chrono",
  "crossbeam-channel 0.3.9",

--- a/applications/tari_console_wallet/src/init/mod.rs
+++ b/applications/tari_console_wallet/src/init/mod.rs
@@ -25,23 +25,36 @@ use crate::{
     wallet_modes::{PeerConfig, WalletMode},
 };
 use log::*;
+use rand::rngs::OsRng;
 use rpassword::prompt_password_stdout;
 use std::{fs, str::FromStr, sync::Arc};
-use tari_app_utilities::{
-    identity_management,
-    utilities::{setup_wallet_transport_type, ExitCodes},
-};
+use tari_app_utilities::utilities::{setup_wallet_transport_type, ExitCodes};
 use tari_common::{ConfigBootstrap, GlobalConfig, Network};
-use tari_comms::{peer_manager::Peer, NodeIdentity};
+use tari_comms::{
+    peer_manager::{Peer, PeerFeatures},
+    NodeIdentity,
+};
 use tari_comms_dht::{DbConnectionUrl, DhtConfig};
-use tari_core::{consensus::Network as NetworkType, transactions::types::CryptoFactories};
-use tari_p2p::{initialization::CommsConfig, seed_peer::SeedPeer, DEFAULT_DNS_SEED_RESOLVER};
+use tari_core::{
+    consensus::Network as NetworkType,
+    transactions::types::{CryptoFactories, PrivateKey},
+};
+use tari_crypto::keys::SecretKey;
+use tari_p2p::{
+    initialization::CommsConfig,
+    seed_peer::SeedPeer,
+    transport::TransportType::Tor,
+    DEFAULT_DNS_SEED_RESOLVER,
+};
 use tari_shutdown::ShutdownSignal;
 use tari_wallet::{
     base_node_service::config::BaseNodeServiceConfig,
     error::{WalletError, WalletStorageError},
     output_manager_service::config::OutputManagerServiceConfig,
-    storage::sqlite_utilities::initialize_sqlite_database_backends,
+    storage::{
+        database::{DbKey, DbKeyValuePair, DbValue, WalletBackend, WriteOperation},
+        sqlite_utilities::initialize_sqlite_database_backends,
+    },
     transaction_service::config::TransactionServiceConfig,
     wallet::WalletConfig,
     Wallet,
@@ -88,7 +101,7 @@ fn prompt_password(prompt: &str) -> Result<String, ExitCodes> {
 
 pub async fn change_password(
     config: &GlobalConfig,
-    node_identity: Arc<NodeIdentity>,
+    node_identity: Option<Arc<NodeIdentity>>,
     arg_password: Option<String>,
     shutdown_signal: ShutdownSignal,
 ) -> Result<(), ExitCodes>
@@ -167,7 +180,7 @@ pub fn wallet_mode(bootstrap: ConfigBootstrap) -> WalletMode {
 /// Setup the app environment and state for use by the UI
 pub async fn init_wallet(
     config: &GlobalConfig,
-    node_identity: Arc<NodeIdentity>,
+    node_identity: Option<Arc<NodeIdentity>>,
     arg_password: Option<String>,
     shutdown_signal: ShutdownSignal,
 ) -> Result<WalletSqlite, ExitCodes>
@@ -206,21 +219,77 @@ pub async fn init_wallet(
             }
         },
     };
-
     let (wallet_backend, transaction_backend, output_manager_backend, contacts_backend) = backends;
 
     debug!(
         target: LOG_TARGET,
         "Databases Initialized. Wallet encrypted? {}.", wallet_encrypted
     );
-
+    // TODO remove after next TestNet
+    // If we know node_identity is not passed in anymore we dont have to check if we need to write it to db. This
+    // assumes that if its passed in we need to still save it the database.
+    if let Some(mut id_arc) = node_identity {
+        let v = (*Arc::make_mut(&mut id_arc)).clone();
+        wallet_backend
+            .write(WriteOperation::Insert(DbKeyValuePair::Identity(Box::new(v))))
+            .map_err(|e| ExitCodes::WalletError(format!("Error creating Wallet database backends. {}", e)))?;
+    }
+    let node_identity = match wallet_backend
+        .fetch(&DbKey::Identity)
+        .map_err(|e| ExitCodes::WalletError(format!("Error creating Wallet database backends. {}", e)))?
+    {
+        Some(DbValue::Identity(v)) => Arc::new(v),
+        _ => {
+            let private_key = PrivateKey::random(&mut OsRng);
+            let node_id = NodeIdentity::new(
+                private_key,
+                config.public_address.clone(),
+                PeerFeatures::COMMUNICATION_CLIENT,
+            )
+            .map_err(|e| ExitCodes::WalletError(format!("We were unable to construct a node identity. {}", e)))?;
+            wallet_backend
+                .write(WriteOperation::Insert(DbKeyValuePair::Identity(Box::new(
+                    node_id.clone(),
+                ))))
+                .map_err(|e| ExitCodes::WalletError(format!("Error creating Wallet database backends. {}", e)))?;
+            Arc::new(node_id)
+        },
+    };
     // TODO remove after next TestNet
     transaction_backend.migrate(node_identity.public_key().clone());
+    let transport_type = setup_wallet_transport_type(&config);
+    let transport_type = match transport_type {
+        Tor(mut tor_config) => {
+            tor_config.identity = match tor_config.identity {
+                Some(v) => {
+                    // This is temp code and should be removed after testnet
+                    wallet_backend
+                        .write(WriteOperation::Insert(DbKeyValuePair::TorId((*v).clone())))
+                        .map_err(|e| {
+                            ExitCodes::WalletError(format!("Error creating Wallet database backends. {}", e))
+                        })?;
+                    std::fs::remove_file(&config.console_wallet_tor_identity_file)
+                        .map_err(|e| ExitCodes::WalletError(format!("Could not delete identity file {}", e)))?;
+                    Some(v)
+                },
+                _ => {
+                    match wallet_backend.fetch(&DbKey::TorId).map_err(|e| {
+                        ExitCodes::WalletError(format!("Error creating Wallet database backends. {}", e))
+                    })? {
+                        Some(DbValue::TorId(v)) => Some(Box::new(v)),
+                        _ => None,
+                    }
+                },
+            };
+            Tor(tor_config)
+        },
+        _ => transport_type,
+    };
 
     let comms_config = CommsConfig {
         node_identity,
         user_agent: format!("tari/wallet/{}", env!("CARGO_PKG_VERSION")),
-        transport_type: setup_wallet_transport_type(&config),
+        transport_type,
         datastore_path: config.console_wallet_peer_db_path.clone(),
         peer_database_name: "peers".to_string(),
         max_concurrent_inbound_tasks: 100,
@@ -293,13 +362,13 @@ pub async fn init_wallet(
             ExitCodes::WalletError(format!("Error creating Wallet Container: {}", e))
         }
     })?;
-
     if let Some(hs) = wallet.comms.hidden_service() {
-        identity_management::save_as_json(&config.console_wallet_tor_identity_file, hs.tor_identity())
-            .map_err(|e| ExitCodes::WalletError(format!("Failed to save tor identity: {:?}", e)))?;
+        wallet
+            .db
+            .set_tor_identity(hs.tor_identity().clone())
+            .await
+            .map_err(|e| ExitCodes::WalletError(format!("Problem writing tor identity. {}", e)))?;
     }
-    identity_management::save_as_json(&config.console_wallet_identity_file, wallet.comms.node_identity_ref())
-        .map_err(|e| ExitCodes::WalletError(format!("Failed to save identity: {:?}", e)))?;
 
     if !wallet_encrypted {
         debug!(target: LOG_TARGET, "Wallet is not encrypted.");

--- a/base_layer/wallet/Cargo.toml
+++ b/base_layer/wallet/Cargo.toml
@@ -39,6 +39,7 @@ tower = "0.3.0-alpha.2"
 tempfile = "3.1.0"
 time = {version = "0.1.39"}
 thiserror = "1.0.20"
+bincode = "1.3.1"
 
 [dependencies.tari_core]
 path = "../../base_layer/core"

--- a/base_layer/wallet/src/error.rs
+++ b/base_layer/wallet/src/error.rs
@@ -73,8 +73,8 @@ pub enum WalletStorageError {
     DuplicateContact,
     #[error("This write operation is not supported for provided DbKey")]
     OperationNotSupported,
-    #[error("Error converting a type")]
-    ConversionError,
+    #[error("Error converting a type: `{0}`")]
+    ConversionError(String),
     #[error("Could not find all values specified for batch operation")]
     ValuesNotFound,
     #[error("Db Path does not exist")]

--- a/base_layer/wallet/src/wallet.rs
+++ b/base_layer/wallet/src/wallet.rs
@@ -161,11 +161,9 @@ where
     ) -> Result<Wallet<T, U, V, W>, WalletError>
     {
         let db = WalletDatabase::new(wallet_backend);
-
         // Persist the Comms Private Key provided to this function
         db.set_comms_secret_key(config.comms_config.node_identity.secret_key().clone())
             .await?;
-
         #[cfg(feature = "test_harness")]
         let transaction_backend_handle = transaction_backend.clone();
 

--- a/base_layer/wallet/tests/wallet/mod.rs
+++ b/base_layer/wallet/tests/wallet/mod.rs
@@ -320,7 +320,7 @@ async fn test_wallet() {
     let result = WalletSqliteDatabase::new(connection.clone(), Some(cipher));
 
     if let Err(WalletStorageError::AeadError(s)) = result {
-        assert_eq!(s, "Decryption Error".to_string());
+        assert_eq!(s, "Decryption Error:aead::Error".to_string());
     } else {
         assert!(
             false,

--- a/base_layer/wallet_ffi/src/error.rs
+++ b/base_layer/wallet_ffi/src/error.rs
@@ -48,8 +48,6 @@ pub enum InterfaceError {
     PositionInvalidError,
     #[error("An error has occurred when trying to create the tokio runtime: `{0}`")]
     TokioError(String),
-    #[error("An error has occurred when attempting to deserialize input data: `{0}`")]
-    DeserializationError(String),
     #[error("Emoji ID is invalid")]
     InvalidEmojiId,
     #[error("Comms Private Key is not present while Db appears to be encrypted which should not happen")]
@@ -82,10 +80,6 @@ impl From<InterfaceError> for LibWalletError {
             },
             InterfaceError::TokioError(_) => Self {
                 code: 4,
-                message: format!("{:?}", v),
-            },
-            InterfaceError::DeserializationError(_) => Self {
-                code: 5,
                 message: format!("{:?}", v),
             },
             InterfaceError::InvalidEmojiId => Self {

--- a/base_layer/wallet_ffi/src/lib.rs
+++ b/base_layer/wallet_ffi/src/lib.rs
@@ -209,6 +209,7 @@ use log4rs::append::{
     Append,
 };
 use tari_core::consensus::Network;
+use tari_p2p::transport::TransportType::Tor;
 use tari_wallet::{
     error::WalletStorageError,
     output_manager_service::protocols::txo_validation_protocol::TxoValidationType,
@@ -2339,7 +2340,6 @@ pub unsafe extern "C" fn transport_tcp_create(
 pub unsafe extern "C" fn transport_tor_create(
     control_server_address: *const c_char,
     tor_cookie: *const ByteVector,
-    tor_identity: *const ByteVector,
     tor_port: c_ushort,
     socks_username: *const c_char,
     socks_password: *const c_char,
@@ -2375,24 +2375,7 @@ pub unsafe extern "C" fn transport_tor_create(
         tor::Authentication::None
     };
 
-    let mut identity = None;
-    if !tor_identity.is_null() {
-        let bytes = (*tor_identity).0.as_slice();
-        match tor::TorIdentity::from_binary(bytes) {
-            Ok(ident) => {
-                identity = Some(Box::new(ident));
-            },
-            Err(err) => {
-                error = LibWalletError::from(InterfaceError::DeserializationError(format!(
-                    "Failed to deserialize tor identity: {}",
-                    err
-                )))
-                .code;
-                ptr::swap(error_out, &mut error as *mut c_int);
-                return ptr::null_mut();
-            },
-        }
-    }
+    let identity = None;
 
     let tor_config = TorConfig {
         control_server_addr: control_address_str.parse::<Multiaddr>().unwrap(),
@@ -2586,7 +2569,7 @@ pub unsafe extern "C" fn comms_config_create(
 
     // Try create a Wallet Sqlite backend without a Cipher, if it fails then the DB is encrypted and we will have to
     // extract the Comms Secret Key in wallet_create(...) with the supplied passphrase
-    let comms_secret_key = match WalletSqliteDatabase::new(connection, None) {
+    let comms_secret_key = match WalletSqliteDatabase::new(connection.clone(), None) {
         Ok(wallet_sqlite_db) => {
             let wallet_backend = WalletDatabase::new(wallet_sqlite_db);
 
@@ -2615,6 +2598,41 @@ pub unsafe extern "C" fn comms_config_create(
         Err(_) => CommsSecretKey::default(),
     };
 
+    let transport_type = (*transport_type).clone();
+    let transport_type = match transport_type {
+        Tor(mut tor_config) => {
+            match WalletSqliteDatabase::new(connection, None) {
+                Ok(database) => {
+                    let db = WalletDatabase::new(database);
+
+                    match Runtime::new() {
+                        Ok(mut rt) => {
+                            tor_config.identity = match tor_config.identity {
+                                Some(v) => {
+                                    // This is temp code and should be removed after testnet
+                                    let _ = rt.block_on(db.set_tor_identity((*v).clone()));
+                                    Some(v)
+                                },
+                                _ => match rt.block_on(db.get_tor_id()) {
+                                    Ok(Some(v)) => Some(Box::new(v)),
+                                    _ => None,
+                                },
+                            };
+                            Tor(tor_config)
+                        },
+                        Err(e) => {
+                            error = LibWalletError::from(InterfaceError::TokioError(e.to_string())).code;
+                            ptr::swap(error_out, &mut error as *mut c_int);
+                            return ptr::null_mut();
+                        },
+                    }
+                },
+                _ => Tor(tor_config),
+            }
+        },
+        _ => transport_type,
+    };
+
     let public_address = public_address_str.parse::<Multiaddr>();
 
     match public_address {
@@ -2624,7 +2642,7 @@ pub unsafe extern "C" fn comms_config_create(
                 Ok(ni) => {
                     let config = TariCommsConfig {
                         node_identity: Arc::new(ni),
-                        transport_type: (*transport_type).clone(),
+                        transport_type,
                         datastore_path,
                         peer_database_name: database_name_string,
                         max_concurrent_inbound_tasks: 100,
@@ -2951,6 +2969,12 @@ pub unsafe extern "C" fn wallet_create(
 
             match w {
                 Ok(mut w) => {
+                    // lets ensure the wallet tor_id is saved
+                    if let Some(hs) = w.comms.hidden_service() {
+                        if let Err(e) = runtime.block_on(w.db.set_tor_identity(hs.tor_identity().clone())) {
+                            warn!(target: LOG_TARGET, "Could not save tor identity to db: {}", e);
+                        }
+                    }
                     // Start Callback Handler
                     let callback_handler = CallbackHandler::new(
                         TransactionDatabase::new(transaction_backend),
@@ -5544,7 +5568,6 @@ mod test {
             let address_control_str: *const c_char = CString::into_raw(address_control.clone()) as *const c_char;
             let _transport = transport_tor_create(
                 address_control_str,
-                ptr::null_mut(),
                 ptr::null_mut(),
                 8080,
                 ptr::null_mut(),

--- a/comms/src/tor/hidden_service/mod.rs
+++ b/comms/src/tor/hidden_service/mod.rs
@@ -24,15 +24,15 @@ mod builder;
 pub use builder::{HiddenServiceBuilder, HiddenServiceBuilderError, HsFlags};
 
 mod controller;
-pub use controller::{HiddenServiceController, HiddenServiceControllerError};
-
 use crate::{
     multiaddr::Multiaddr,
     socks,
     tor::{PrivateKey, TorClientError},
     transports::{SocksConfig, SocksTransport},
 };
+pub use controller::{HiddenServiceController, HiddenServiceControllerError};
 use serde_derive::{Deserialize, Serialize};
+use std::fmt;
 use tari_shutdown::OptionalShutdownSignal;
 
 /// Handle for a Tor Hidden Service. This handle keeps the session to the Tor control port alive.
@@ -105,5 +105,14 @@ pub struct TorIdentity {
 impl TorIdentity {
     pub fn try_get_onion_address(&self) -> Result<Multiaddr, TorClientError> {
         multiaddr_from_service_id_and_port(&self.service_id, self.onion_port)
+    }
+}
+
+impl fmt::Display for TorIdentity {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        writeln!(f, "Service ID: {}", self.service_id)?;
+        writeln!(f, "Port: {}", self.onion_port)?;
+
+        Ok(())
     }
 }


### PR DESCRIPTION

## Description
This PR adds in the NodeID and TorID to the wallet's database as encrypted fields 

## Motivation and Context
This allows us to protect the sensitive private keys for the Tari Comms and Tor comms as they are not stored in a plain text file at rest anymore. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [ ] I'm merging against the `development` branch.
* [ ] I ran `cargo-fmt --all` before pushing.
* [ ] I ran `cargo test` successfully before submitting my PR.
* [ ] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
