### PR TITLE
Add get_version, get_transaction_info call to wallet GRPC

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3800,12 +3800,14 @@ dependencies = [
 name = "tari_app_grpc"
 version = "0.7.3"
 dependencies = [
+ "chrono",
  "prost",
  "prost-types",
  "tari_common_types",
  "tari_comms",
  "tari_core",
  "tari_crypto",
+ "tari_wallet",
  "tonic",
  "tonic-build",
 ]

--- a/applications/tari_app_grpc/Cargo.toml
+++ b/applications/tari_app_grpc/Cargo.toml
@@ -10,9 +10,11 @@ edition = "2018"
 [dependencies]
 tari_common_types = { version = "^0.7", path = "../../base_layer/common_types"}
 tari_core = {  path = "../../base_layer/core"}
+tari_wallet = {  path = "../../base_layer/wallet"}
 tari_crypto = "^0.8"
-tari_comms = { path = "../../comms", features = ["rpc"]}
+tari_comms = { path = "../../comms"}
 
+chrono = "0.4.6"
 prost = "0.6"
 prost-types = "0.6.1"
 tonic = "0.2"

--- a/applications/tari_app_grpc/proto/base_node.proto
+++ b/applications/tari_app_grpc/proto/base_node.proto
@@ -22,8 +22,6 @@
 syntax = "proto3";
 
 
-import "google/protobuf/wrappers.proto";
-import "google/protobuf/timestamp.proto";
 import "types.proto";
 
 package tari.rpc;
@@ -80,9 +78,6 @@ message NewBlockTemplateResponse{
     bool initial_sync_achieved = 3;
     MinerData miner_data = 4;
 }
-
-/// An Empty placeholder for endpoints without request parameters
-message Empty {}
 
 // Network difficulty response
 message NetworkDifficultyResponse {

--- a/applications/tari_app_grpc/proto/types.proto
+++ b/applications/tari_app_grpc/proto/types.proto
@@ -25,6 +25,8 @@ package tari.rpc;
 
 import "google/protobuf/timestamp.proto";
 
+/// An Empty placeholder for endpoints without request parameters
+message Empty {}
 
 // The BlockHeader contains all the metadata for the block, including proof of work, a link to the previous block
 // and the transaction kernels.

--- a/applications/tari_app_grpc/proto/wallet.proto
+++ b/applications/tari_app_grpc/proto/wallet.proto
@@ -24,15 +24,18 @@ syntax = "proto3";
 package tari.rpc;
 
 import "types.proto";
-import "google/protobuf/wrappers.proto";
-import "google/protobuf/timestamp.proto";
 
 // The gRPC interface for interacting with the wallet.
 service Wallet {
+    rpc GetVersion (Empty) returns (GetVersionResponse);
     // This returns a coinbase transaction
     rpc GetCoinbase (GetCoinbaseRequest) returns (GetCoinbaseResponse);
     // Send Tari to a number of recipients
     rpc Transfer (TransferRequest)  returns (TransferResponse);
+}
+
+message GetVersionResponse {
+    string version = 1;
 }
 
 message TransferRequest {

--- a/applications/tari_app_grpc/proto/wallet.proto
+++ b/applications/tari_app_grpc/proto/wallet.proto
@@ -23,16 +23,21 @@ syntax = "proto3";
 
 package tari.rpc;
 
+import "google/protobuf/timestamp.proto";
 import "types.proto";
 
 // The gRPC interface for interacting with the wallet.
 service Wallet {
-    rpc GetVersion (Empty) returns (GetVersionResponse);
+    rpc GetVersion (GetVersionRequest) returns (GetVersionResponse);
     // This returns a coinbase transaction
     rpc GetCoinbase (GetCoinbaseRequest) returns (GetCoinbaseResponse);
     // Send Tari to a number of recipients
     rpc Transfer (TransferRequest)  returns (TransferResponse);
+    // Returns the transaction details for the given transaction IDs
+    rpc GetTransactionInfo (GetTransactionInfoRequest) returns (GetTransactionInfoResponse);
 }
+
+message GetVersionRequest { }
 
 message GetVersionResponse {
     string version = 1;
@@ -58,6 +63,49 @@ message TransferResult {
     uint64 transaction_id = 2;
     bool is_success = 3;
     string failure_message = 4;
+}
+
+message GetTransactionInfoRequest {
+    repeated uint64 transaction_ids = 1;
+}
+
+message GetTransactionInfoResponse {
+    repeated TransactionInfo statuses = 1;
+}
+
+message TransactionInfo {
+    uint64 tx_id = 1;
+    bytes source_pk = 2;
+    bytes dest_pk = 3;
+    TransactionStatus status = 4;
+    TransactionDirection direction = 5;
+    uint64 amount = 6;
+    uint64 fee = 7;
+    bool is_cancelled = 8;
+    bytes excess_sig = 9;
+    google.protobuf.Timestamp timestamp = 10;
+    string message = 11;
+}
+
+enum TransactionDirection {
+    TRANSACTION_DIRECTION_UNKNOWN = 0;
+    TRANSACTION_DIRECTION_INBOUND = 1;
+    TRANSACTION_DIRECTION_OUTBOUND = 2;
+}
+
+enum TransactionStatus {
+    // This transaction has been completed between the parties but has not been broadcast to the base layer network.
+    TRANSACTION_STATUS_COMPLETED = 0;
+    // This transaction has been broadcast to the base layer network and is currently in one or more base node mempools.
+    TRANSACTION_STATUS_BROADCAST = 1;
+    // This transaction has been mined and included in a block.
+    TRANSACTION_STATUS_MINED = 2;
+    // This transaction was generated as part of importing a spendable UTXO
+    TRANSACTION_STATUS_IMPORTED = 3;
+    // This transaction is still being negotiated by the parties
+    TRANSACTION_STATUS_PENDING = 4;
+    // This is a created Coinbase Transaction
+    TRANSACTION_STATUS_COINBASE = 5;
 }
 
 message GetCoinbaseRequest {

--- a/applications/tari_app_grpc/src/conversions/mod.rs
+++ b/applications/tari_app_grpc/src/conversions/mod.rs
@@ -58,10 +58,18 @@ use crate::{tari_rpc as grpc, tari_rpc::BlockGroupRequest};
 use prost_types::Timestamp;
 use tari_crypto::tari_utilities::epoch_time::EpochTime;
 
-/// Utility function that converts a `chrono::DateTime` to a `prost::Timestamp`
+/// Utility function that converts a `EpochTime` to a `prost::Timestamp`
 pub fn datetime_to_timestamp(datetime: EpochTime) -> Timestamp {
     Timestamp {
         seconds: datetime.as_u64() as i64,
+        nanos: 0,
+    }
+}
+
+/// Utility function that converts a `chrono::NaiveDateTime` to a `prost::Timestamp`
+pub fn naive_datetime_to_timestamp(datetime: chrono::NaiveDateTime) -> Timestamp {
+    Timestamp {
+        seconds: datetime.timestamp(),
         nanos: 0,
     }
 }

--- a/applications/tari_app_grpc/src/conversions/transaction.rs
+++ b/applications/tari_app_grpc/src/conversions/transaction.rs
@@ -20,12 +20,11 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use tari_crypto::tari_utilities::ByteArray;
-
 use crate::tari_rpc as grpc;
 use std::convert::{TryFrom, TryInto};
 use tari_core::transactions::transaction::Transaction;
-use tari_crypto::ristretto::RistrettoSecretKey;
+use tari_crypto::{ristretto::RistrettoSecretKey, tari_utilities::ByteArray};
+use tari_wallet::transaction_service::storage::models;
 
 impl From<Transaction> for grpc::Transaction {
     fn from(source: Transaction) -> Self {
@@ -48,5 +47,30 @@ impl TryFrom<grpc::Transaction> for Transaction {
                 .ok_or_else(|| "Transaction body not provided".to_string())?
                 .try_into()?,
         })
+    }
+}
+
+impl From<models::TransactionStatus> for grpc::TransactionStatus {
+    fn from(status: models::TransactionStatus) -> Self {
+        use models::TransactionStatus::*;
+        match status {
+            Completed => grpc::TransactionStatus::Completed,
+            Broadcast => grpc::TransactionStatus::Broadcast,
+            Mined => grpc::TransactionStatus::Mined,
+            Imported => grpc::TransactionStatus::Imported,
+            Pending => grpc::TransactionStatus::Pending,
+            Coinbase => grpc::TransactionStatus::Coinbase,
+        }
+    }
+}
+
+impl From<models::TransactionDirection> for grpc::TransactionDirection {
+    fn from(status: models::TransactionDirection) -> Self {
+        use models::TransactionDirection::*;
+        match status {
+            Unknown => grpc::TransactionDirection::Unknown,
+            Inbound => grpc::TransactionDirection::Inbound,
+            Outbound => grpc::TransactionDirection::Outbound,
+        }
     }
 }

--- a/applications/tari_console_wallet/src/grpc/wallet_grpc_server.rs
+++ b/applications/tari_console_wallet/src/grpc/wallet_grpc_server.rs
@@ -2,8 +2,10 @@ use futures::future;
 use log::*;
 use tari_app_grpc::tari_rpc::{
     wallet_server,
+    Empty,
     GetCoinbaseRequest,
     GetCoinbaseResponse,
+    GetVersionResponse,
     TransferRequest,
     TransferResponse,
     TransferResult,
@@ -31,6 +33,12 @@ impl WalletGrpcServer {
 
 #[tonic::async_trait]
 impl wallet_server::Wallet for WalletGrpcServer {
+    async fn get_version(&self, _: Request<Empty>) -> Result<Response<GetVersionResponse>, Status> {
+        Ok(Response::new(GetVersionResponse {
+            version: env!("CARGO_PKG_VERSION").to_string(),
+        }))
+    }
+
     async fn get_coinbase(
         &self,
         request: Request<GetCoinbaseRequest>,

--- a/base_layer/wallet/src/transaction_service/storage/models.rs
+++ b/base_layer/wallet/src/transaction_service/storage/models.rs
@@ -35,6 +35,7 @@ use tari_core::transactions::{
     ReceiverTransactionProtocol,
     SenderTransactionProtocol,
 };
+
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub enum TransactionStatus {
     /// This transaction has been completed between the parties but has not been broadcast to the base layer network.
@@ -231,6 +232,7 @@ impl CompletedTransaction {
         }
     }
 }
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub enum TransactionDirection {
     Inbound,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
`getVersion` returns the version of the wallet. This is useful for
testing (is the wallet listening where I think it is? Is my GRPC client working?) and for client compatibility.

`get_transaction_info` bulk queries transactions given by their
transaction IDs returning basic information required to tell that a
transaction has succeeded or is failed/canceled.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Initial implementation of calls needed for pool integration. These calls may change when a "transaction queue" is implemented.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Cucumber tests are TODO. Not explicitly tested.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [ ] I'm merging against the `development` branch.
* [ ] I ran `cargo-fmt --all` before pushing.
* [ ] I ran `cargo test` successfully before submitting my PR.
* [ ] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
