### PR TITLE
Get transaction details via GRPC

### DIFF
--- a/applications/tari_app_grpc/proto/wallet.proto
+++ b/applications/tari_app_grpc/proto/wallet.proto
@@ -31,6 +31,8 @@ import "google/protobuf/timestamp.proto";
 service Wallet {
     // This returns a coinbase transaction
     rpc GetCoinbase (GetCoinbaseRequest) returns (GetCoinbaseResponse);
+    // This returns the transaction status
+    rpc GetTransactionDetails (GetTransactionDetailsRequest) returns (GetTransactionDetailsResponse);
     // Send Tari to a number of recipients
     rpc Transfer (TransferRequest)  returns (TransferResponse);
 }
@@ -65,4 +67,24 @@ message GetCoinbaseRequest {
 
 message GetCoinbaseResponse {
     Transaction transaction = 1;
+}
+
+message GetTransactionDetailsRequest {
+    string tx_id = 1;
+}
+message GetTransactionDetailsResponse {
+    TransactionDetailsResult tx_details = 1;
+}
+
+message TransactionDetailsResult {
+    string txid = 1;
+    string source_pub_key = 2;
+    string dest_pub_key = 3;
+    string direction = 4;
+    string amount = 5;
+    string fee = 6;
+    string status = 7;
+    bool cancelled = 8;
+    string message = 9;
+    string time_stamp = 10;
 }

--- a/base_layer/wallet/src/base_node_service/service.rs
+++ b/base_layer/wallet/src/base_node_service/service.rs
@@ -232,9 +232,6 @@ where BNResponseStream: Stream<Item = DomainMessage<proto::BaseNodeServiceRespon
                 age <= self.config.request_max_age
             });
 
-        trace!(target: LOG_TARGET, "current requests: {:?}", current_requests);
-        trace!(target: LOG_TARGET, "discarded requests : {:?}", old_requests);
-
         self.requests = current_requests;
 
         // check if base node is offline
@@ -255,8 +252,6 @@ where BNResponseStream: Stream<Item = DomainMessage<proto::BaseNodeServiceRespon
             .send_direct(dest_public_key, message)
             .await
             .map_err(BaseNodeServiceError::OutboundError)?;
-
-        debug!(target: LOG_TARGET, "Refresh chain metadata message sent");
 
         Ok(())
     }

--- a/base_layer/wallet/src/transaction_service/handle.rs
+++ b/base_layer/wallet/src/transaction_service/handle.rs
@@ -29,12 +29,15 @@ use crate::{
 };
 use aes_gcm::Aes256Gcm;
 use futures::{stream::Fuse, StreamExt};
+use log::*;
 use std::{collections::HashMap, fmt, sync::Arc};
 use tari_comms::types::CommsPublicKey;
 use tari_core::transactions::{tari_amount::MicroTari, transaction::Transaction};
 use tari_service_framework::reply_channel::SenderService;
 use tokio::sync::broadcast;
 use tower::Service;
+
+const LOG_TARGET: &str = "wallet::transaction_service::handle";
 
 /// API Request enum
 #[allow(clippy::large_enum_variant)]
@@ -322,6 +325,7 @@ impl TransactionServiceHandle {
         tx_id: TxId,
     ) -> Result<Option<WalletTransaction>, TransactionServiceError>
     {
+        trace!(target: LOG_TARGET, "tx_id: {}", tx_id);
         match self
             .handle
             .call(TransactionServiceRequest::GetAnyTransaction(tx_id))


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This change adds a method to the console wallet's GRPC server to query the status of a transaction. Most relevant transaction metadata are returned.

Also removed spam log messages in `base_layer/wallet/src/base_node_service/service.rs`.

## Motivation and Context
Extending the console wallet's GRPC interface is important in order to enhance its flexibility of use.

## How Has This Been Tested?
Tested on a running console wallet in Windows interfacing with a GRPC client.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [X] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [X] I'm merging against the `development` branch.
* [X] I ran `cargo-fmt --all` before pushing.
* [ ] I ran `cargo test` successfully before submitting my PR.
* [X] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
