### PR TITLE
Implement TXO validation on Base Node switching in LibWallet

### DIFF
--- a/applications/tari_console_wallet/src/ui/state/app_state.rs
+++ b/applications/tari_console_wallet/src/ui/state/app_state.rs
@@ -29,7 +29,7 @@ use tari_shutdown::ShutdownSignal;
 use tari_wallet::{
     base_node_service::{handle::BaseNodeEventReceiver, service::BaseNodeState},
     contacts_service::storage::database::Contact,
-    output_manager_service::{service::Balance, TxId},
+    output_manager_service::{handle::OutputManagerEventReceiver, service::Balance, TxId},
     transaction_service::{
         handle::{TransactionEvent, TransactionEventReceiver, TransactionServiceHandle},
         storage::models::{CompletedTransaction, TransactionStatus},
@@ -524,6 +524,10 @@ impl AppStateInner {
 
     pub fn get_transaction_service_event_stream(&self) -> Fuse<TransactionEventReceiver> {
         self.wallet.transaction_service.get_event_stream_fused()
+    }
+
+    pub fn get_output_manager_service_event_stream(&self) -> Fuse<OutputManagerEventReceiver> {
+        self.wallet.output_manager_service.get_event_stream_fused()
     }
 
     pub fn get_connectivity_event_stream(&self) -> Fuse<ConnectivityEventRx> {

--- a/applications/tari_console_wallet/src/ui/state/wallet_event_monitor.rs
+++ b/applications/tari_console_wallet/src/ui/state/wallet_event_monitor.rs
@@ -27,7 +27,7 @@ use std::sync::Arc;
 use tari_comms::{connectivity::ConnectivityEvent, peer_manager::Peer};
 use tari_wallet::{
     base_node_service::{handle::BaseNodeEvent, service::BaseNodeState},
-    output_manager_service::TxId,
+    output_manager_service::{handle::OutputManagerEvent, TxId},
     transaction_service::handle::TransactionEvent,
 };
 use tokio::sync::RwLock;
@@ -47,6 +47,12 @@ impl WalletEventMonitor {
         let mut shutdown_signal = self.app_state_inner.read().await.get_shutdown_signal();
 
         let mut transaction_service_events = self.app_state_inner.read().await.get_transaction_service_event_stream();
+
+        let mut output_manager_service_events = self
+            .app_state_inner
+            .read()
+            .await
+            .get_output_manager_service_event_stream();
 
         let mut connectivity_events = self.app_state_inner.read().await.get_connectivity_event_stream();
 
@@ -118,6 +124,21 @@ impl WalletEventMonitor {
                             Err(_) => debug!(target: LOG_TARGET, "Lagging read on base node event broadcast channel"),
                         }
                     },
+                    result = output_manager_service_events.select_next_some() => {
+                        match result {
+                            Ok(msg) => {
+                                trace!(target: LOG_TARGET, "Output Manager Service Callback Handler event {:?}", msg);
+                                match msg {
+                                    OutputManagerEvent::TxoValidationSuccess(request_key) => {
+                                        self.trigger_balance_refresh().await;
+                                    },
+                                    // Only the above variants are monitored
+                                    _ => (),
+                                }
+                            },
+                            Err(_e) => error!(target: LOG_TARGET, "Error reading from Output Manager Service event broadcast channel"),
+                        }
+                },
                     complete => {
                         info!(target: LOG_TARGET, "Wallet Event Monitor is exiting because all tasks have completed");
                         break;
@@ -158,6 +179,14 @@ impl WalletEventMonitor {
         let mut inner = self.app_state_inner.write().await;
 
         if let Err(e) = inner.refresh_base_node_peer(peer).await {
+            warn!(target: LOG_TARGET, "Error refresh app_state: {}", e);
+        }
+    }
+
+    async fn trigger_balance_refresh(&mut self) {
+        let mut inner = self.app_state_inner.write().await;
+
+        if let Err(e) = inner.refresh_balance().await {
             warn!(target: LOG_TARGET, "Error refresh app_state: {}", e);
         }
     }

--- a/base_layer/wallet/src/output_manager_service/error.rs
+++ b/base_layer/wallet/src/output_manager_service/error.rs
@@ -88,6 +88,8 @@ pub enum OutputManagerError {
     InvalidSenderMessage,
     #[error("Coinbase build error: `{0}`")]
     CoinbaseBuildError(#[from] CoinbaseBuildError),
+    #[error("TXO Validation protocol cancelled")]
+    Cancellation,
 }
 
 #[derive(Debug, Error, PartialEq)]


### PR DESCRIPTION
## Description
This PR adds an automatic launching of the TXO validation protocols in the Output Manager when the wallet switches base nodes. This is done from the second switch of base node to still leave the choice of when to start TXO validation on startup to the client application. After the first base node setting has occurred any subsequent changes to the base node will first cancel any existing protocols and then trigger a full set of TXO validation protocols. This process is put in place so that the balance and TXO status of a wallet will reflect what the current Base Node’s state believes.

This was also plumbed into the Transaction Service transaction broadcast protocols so they will always be querying the currently set base node.

Also added the feature to the Console Wallet that it will refresh its Balance when successful TXO validation protocols complete.

## How Has This Been Tested?
Tests have been provided to test
- Output Manager Service cancelling old TXO validation protocols and starting new ones
- Tx broadcast protocol updates to new BN 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [x] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch.
* [x] I ran `cargo-fmt --all` before pushing.
* [x] I ran `cargo test` successfully before submitting my PR.
* [x] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
