### PR TITLE
Fix returned field name in getTransactionInfo call

### DIFF
--- a/applications/tari_app_grpc/proto/wallet.proto
+++ b/applications/tari_app_grpc/proto/wallet.proto
@@ -70,7 +70,7 @@ message GetTransactionInfoRequest {
 }
 
 message GetTransactionInfoResponse {
-    repeated TransactionInfo statuses = 1;
+    repeated TransactionInfo transactions = 1;
 }
 
 message TransactionInfo {

--- a/applications/tari_console_wallet/src/grpc/wallet_grpc_server.rs
+++ b/applications/tari_console_wallet/src/grpc/wallet_grpc_server.rs
@@ -155,12 +155,12 @@ impl wallet_server::Wallet for WalletGrpcServer {
 
         let wallet_pk = self.wallet.comms.node_identity_ref().public_key();
 
-        let statuses = transactions
+        let transactions = transactions
             .into_iter()
             .map(|tx| convert_wallet_transaction_into_transaction_info(tx, wallet_pk))
             .collect();
 
-        Ok(Response::new(GetTransactionInfoResponse { statuses }))
+        Ok(Response::new(GetTransactionInfoResponse { transactions }))
     }
 }
 


### PR DESCRIPTION
Returned field name in getTransactionInfo call should be `transactions`
instead of `statuses`
