### PR TITLE
Update default wallet confirmation time

### DIFF
--- a/base_layer/wallet/src/transaction_service/config.rs
+++ b/base_layer/wallet/src/transaction_service/config.rs
@@ -50,7 +50,7 @@ impl Default for TransactionServiceConfig {
             transaction_resend_period: Duration::from_secs(3600),
             resend_response_cooldown: Duration::from_secs(300),
             pending_transaction_cancellation_timeout: Duration::from_secs(259200), // 3 Days
-            num_confirmations_required: 6,
+            num_confirmations_required: 3,
             peer_dial_retry_timeout: Duration::from_secs(20),
         }
     }

--- a/base_layer/wallet/tests/transaction_service/service.rs
+++ b/base_layer/wallet/tests/transaction_service/service.rs
@@ -323,8 +323,8 @@ pub fn setup_transaction_service_no_comms_and_oms_backend<
         transaction_resend_period: Duration::from_secs(200),
         resend_response_cooldown: Duration::from_secs(200),
         pending_transaction_cancellation_timeout: Duration::from_secs(300),
-        num_confirmations_required: 6,
         peer_dial_retry_timeout: Duration::from_secs(5),
+        ..Default::default()
     });
 
     let ts_service = TransactionService::new(

--- a/base_layer/wallet/tests/transaction_service/transaction_broadcast_protocol.rs
+++ b/base_layer/wallet/tests/transaction_service/transaction_broadcast_protocol.rs
@@ -270,7 +270,7 @@ async fn tx_broadcast_protocol_submit_success() {
     rpc_service_state.set_transaction_query_response(TxQueryResponse {
         location: TxLocation::Mined,
         block_hash: None,
-        confirmations: 3,
+        confirmations: 1,
     });
     // Wait for 1 query
     let _ = rpc_service_state
@@ -302,7 +302,7 @@ async fn tx_broadcast_protocol_submit_success() {
         futures::select! {
             event = event_stream.select_next_some() => {
                 match &*event.unwrap() {
-                        TransactionEvent::TransactionMinedUnconfirmed(_, confirmations) => if *confirmations == 3 {
+                        TransactionEvent::TransactionMinedUnconfirmed(_, confirmations) => if *confirmations == 1 {
                             unconfirmed = true;
                         }
                         TransactionEvent::TransactionMined(_) => {
@@ -622,7 +622,7 @@ async fn tx_broadcast_protocol_submit_mined_then_not_mined_resubmit_success() {
     rpc_service_state.set_transaction_query_response(TxQueryResponse {
         location: TxLocation::Mined,
         block_hash: None,
-        confirmations: 3,
+        confirmations: 1,
     });
     // Wait for 1 query
     let _ = rpc_service_state


### PR DESCRIPTION
## Description
Reduce the default wallet confirmation time to 3 blocks. Shorter than it is now but still long enough to avoid 1-2 block reorgs.

## How Has This Been Tested?
Manually tested via Console Wallet

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [x] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch.
* [x] I ran `cargo-fmt --all` before pushing.
* [x] I ran `cargo test` successfully before submitting my PR.
* [x] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
