### PR TITLE
Refactor wallet bootup to not cause confusion

### DIFF
--- a/applications/tari_console_wallet/src/main.rs
+++ b/applications/tari_console_wallet/src/main.rs
@@ -61,6 +61,18 @@ fn main_inner() -> Result<(), ExitCodes> {
         Ok(v) => Some(v),
         _ => None,
     };
+
+    if bootstrap.init {
+        info!(target: LOG_TARGET, "Default configuration created. Done.");
+        return Ok(());
+    }
+    if node_identity.is_none() {
+        warn!(
+            target: LOG_TARGET,
+            "Wallet has no identity, new wallet identity will be created"
+        );
+    }
+
     if node_identity.is_some() {
         // This is for wallets that still have a file with the password in it, we need to remove the file to protect the
         // sensitive tari_comms private key
@@ -68,11 +80,6 @@ fn main_inner() -> Result<(), ExitCodes> {
         // If we know files dont exist anymore we dont have to check for a file and delete a file
         std::fs::remove_file(&config.console_wallet_identity_file)
             .map_err(|e| ExitCodes::WalletError(format!("Could not delete identity file {}", e)))?;
-    }
-
-    if bootstrap.init {
-        info!(target: LOG_TARGET, "Default configuration created. Done.");
-        return Ok(());
     }
 
     // get command line password if provided


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
The wallet previously required a node_id file to run. This was only created if the wallet was run with --create_id. After which the node will ext. 

This behaviour is changed in that the node will create an id, if none is found and not exit. But if run the node with --create_id it would create a new id file, delete this and exit. This is now changed to exit before deletion of the file. 

A warning was also added to explain to the error message from the shared code between the wallet and the BN, which still requires the error message. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [x] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x ] I'm merging against the `development` branch.
* [x] I ran `cargo-fmt --all` before pushing.
* [ ] I ran `cargo test` successfully before submitting my PR.
* [ ] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
