### PR TITLE
Assign wallet GRPC port for cucumber tests

### DIFF
--- a/integration_tests/helpers/walletProcess.js
+++ b/integration_tests/helpers/walletProcess.js
@@ -14,6 +14,7 @@ class WalletProcess {
     async init() {
         this.port = await getFreePort(19000, 25000);
         this.name = `Wallet${this.port}-${this.name}`;
+        this.grpcPort = await getFreePort(19000, 25000);
         this.nodeFile = "cwalletid.json";
         this.baseDir = `./temp/base_nodes/${dateFormat(new Date(), "yyyymmddHHMM")}/${this.name}`;
            await this.run("cargo",
@@ -38,7 +39,7 @@ class WalletProcess {
 
 
     getGrpcAddress() {
-        return "127.0.0.1:" + this.port;
+        return "127.0.0.1:" + this.grpcPort;
     }
 
     getClient() {
@@ -54,7 +55,7 @@ class WalletProcess {
             RUST_BACKTRACE: 1,
             TARI_BASE_NODE__NETWORK: "localnet",
             TARI_BASE_NODE__LOCALNET__GRPC_BASE_NODE_ADDRESS: "127.0.0.1:1",
-            TARI_BASE_NODE__LOCALNET__GRPC_CONSOLE_WALLET_ADDRESS: `127.0.0.1:${this.port}`,
+            TARI_BASE_NODE__LOCALNET__GRPC_CONSOLE_WALLET_ADDRESS: `127.0.0.1:${this.grpcPort}`,
             // Defaults:
             TARI_BASE_NODE__LOCALNET__DATA_DIR: "localnet",
             TARI_BASE_NODE__LOCALNET__DB_TYPE: "lmdb",

--- a/integration_tests/package-lock.json
+++ b/integration_tests/package-lock.json
@@ -1442,9 +1442,9 @@
       }
     },
     "google-auth-library": {
-      "version": "6.1.5",
-      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-6.1.5.tgz",
-      "integrity": "sha512-vlizrMSlHIu6blPtSC9AJZ1xYQWqUp1xqhcMzYff+hNKTSqVlsynMQIE8BdCo/FhPib4U1fvv1gnczMDHB2Wmg==",
+      "version": "6.1.6",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-6.1.6.tgz",
+      "integrity": "sha512-Q+ZjUEvLQj/lrVHF/IQwRo6p3s8Nc44Zk/DALsN+ac3T4HY/g/3rrufkgtl+nZ1TW7DNAw5cTChdVp4apUXVgQ==",
       "requires": {
         "arrify": "^2.0.0",
         "base64-js": "^1.3.0",
@@ -1491,14 +1491,13 @@
       "integrity": "sha512-4BBXHXb5OjjBh7luylu8vFqL6H6aPn/LeqpQaSBeRzO/Xv95wHW/WkU9TJRqaCTMZ5wq9jTSvlJWp0vRJy1pVA=="
     },
     "gtoken": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-5.2.0.tgz",
-      "integrity": "sha512-qbf6JWEYFMj3WMAluvYXl8GAiji6w8d9OmAGCbBg0xF4xD/yu6ZaO6BhoXNddRjKcOUpZD81iea1H5B45gAo1g==",
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-5.2.1.tgz",
+      "integrity": "sha512-OY0BfPKe3QnMsY9MzTHTSKn+Vl2l1CcLe6BwDEQj00mbbkl5nyQ/7EUREstg4fQNZ8iYE7br4JJ7TdKeDOPWmw==",
       "requires": {
         "gaxios": "^4.0.0",
         "google-p12-pem": "^3.0.3",
-        "jws": "^4.0.0",
-        "mime": "^2.2.0"
+        "jws": "^4.0.0"
       }
     },
     "has": {
@@ -1921,11 +1920,6 @@
       "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
       "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
       "dev": true
-    },
-    "mime": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/mime/-/mime-2.5.0.tgz",
-      "integrity": "sha512-ft3WayFSFUVBuJj7BMLKAQcSlItKtfjsKDDsii3rqFDAZ7t11zRe8ASw/GlmivGwVUYtwkQrxiGGpL6gFvB0ag=="
     },
     "minimatch": {
       "version": "3.0.4",
@@ -3034,8 +3028,8 @@
       }
     },
     "wallet-grpc-client": {
-      "version": "git://github.com/tari-project/wallet-grpc-client.git#6f200e4bb81edd86c7b09d3b6dea58c3d10de680",
-      "from": "git://github.com/tari-project/wallet-grpc-client.git#6f200e4bb81edd86c7b09d3b6dea58c3d10de680",
+      "version": "git://github.com/tari-project/wallet-grpc-client.git#c1c6ff88ef8282fce1b363378cff09967877823e",
+      "from": "git://github.com/tari-project/wallet-grpc-client.git#c1c6ff88ef8282fce1b363378cff09967877823e",
       "requires": {
         "@grpc/grpc-js": "^1.2.3",
         "@grpc/proto-loader": "^0.5.5",

--- a/integration_tests/package.json
+++ b/integration_tests/package.json
@@ -25,6 +25,6 @@
     "sha3": "^2.1.3",
     "synchronized-promise": "^0.3.1",
     "tari_crypto": "^0.8.0",
-    "wallet-grpc-client": "git://github.com/tari-project/wallet-grpc-client.git#6f200e4bb81edd86c7b09d3b6dea58c3d10de680"
+    "wallet-grpc-client": "git://github.com/tari-project/wallet-grpc-client.git#c1c6ff88ef8282fce1b363378cff09967877823e"
   }
 }


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
- This changes assigned a unique port for the wallet's GRPC server; previously it shared the same port with the public address.
- Updated the commit id for the `tari-project/wallet-grpc-client `

## Motivation and Context
Port numbers should not be shared between processes.

## How Has This Been Tested?
Tested in cucumber test "Simple Merge Mining"

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [X] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [X] I'm merging against the `development` branch.
* [ ] I ran `cargo-fmt --all` before pushing.
* [ ] I ran `cargo test` successfully before submitting my PR.
* [X] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
