### PR TITLE
Fix console wallet calls in runtime scripts for stibbons

### DIFF
--- a/applications/tari_base_node/ubuntu/runtime/start_tor.sh
+++ b/applications/tari_base_node/ubuntu/runtime/start_tor.sh
@@ -8,6 +8,15 @@ then
 else
     no_output=">/dev/null"
 fi
+
+# TODO: Fix - The Tor command breaks at `"${no_output}"`; we do not need many Tor terminals if using `start_all`
+# TODO: Detect if Tor is running on ports `9050` and `9051` and change startup logic accordingly.
+
+#gnome-terminal --working-directory="$PWD" -- tor --allow-missing-torrc --ignore-missing-torrc \
+#  --clientonly 1 --socksport 9050 --controlport 127.0.0.1:9051 \
+#  --log "notice stdout" --clientuseipv6 1 "${no_output}"
+
 gnome-terminal --working-directory="$PWD" -- tor --allow-missing-torrc --ignore-missing-torrc \
   --clientonly 1 --socksport 9050 --controlport 127.0.0.1:9051 \
-  --log "notice stdout" --clientuseipv6 1 "${no_output}"
+  --log "notice stdout" --clientuseipv6 1
+

--- a/applications/tari_console_wallet/osx/runtime/start_tari_console_wallet.sh
+++ b/applications/tari_console_wallet/osx/runtime/start_tari_console_wallet.sh
@@ -20,26 +20,19 @@ then
     ping -c 15 localhost > /dev/null
 fi
 
-if [ ! -f "${config_path}/console_wallet_id.json" ]
-then
-    echo Creating new "${config_path}/console_wallet_id.json";
-    "${exe_path}/tari_console_wallet" --create_id --init --config "${config_path}/config.toml" --log_config "${config_path}/log4rs_console_wallet.yml" --base-path ${base_path}
-else
-    echo Using existing "${config_path}/console_wallet_id.json";
-fi
-
 if [ ! -f "${config_path}/log4rs_console_wallet.yml" ]
 then
     echo Creating new "${config_path}/log4rs_console_wallet.yml";
-    "${exe_path}/tari_console_wallet" --init --config "${config_path}/config.toml" --log_config "${config_path}/log4rs_console_wallet.yml" --base-path ${base_path}
+    init_flag="--init"
 else
     echo Using existing "${config_path}/log4rs_console_wallet.yml";
+    init_flag=""
 fi
 echo
 
 # Run
 echo Spawning Console Wallet into new terminal..
-echo "${exe_path}/tari_console_wallet" --config="${config_path}/config.toml" --log_config="${config_path}/log4rs_console_wallet.yml" --base-path=${base_path} > $exe_path/tari_console_wallet_command.sh
+echo "${exe_path}/tari_console_wallet" ${init_flag} --config="${config_path}/config.toml" --log_config="${config_path}/log4rs_console_wallet.yml" --base-path=${base_path} > $exe_path/tari_console_wallet_command.sh
 chmod +x $exe_path/tari_console_wallet_command.sh
 
 open -a terminal $exe_path/tari_console_wallet_command.sh

--- a/applications/tari_console_wallet/ubuntu/runtime/start_tari_console_wallet.sh
+++ b/applications/tari_console_wallet/ubuntu/runtime/start_tari_console_wallet.sh
@@ -13,23 +13,17 @@ then
 fi
 "${exe_path}/start_tor.sh"
 
-if [ ! -f "${config_path}/console_wallet_id.json" ]
-then
-    echo Creating new "${config_path}/console_wallet_id.json";
-    "${exe_path}/tari_console_wallet" --create_id --init --config "${config_path}/config.toml" --log_config "${config_path}/log4rs_console_wallet.yml" --base-path ${base_path}
-else
-    echo Using existing "${config_path}/console_wallet_id.json";
-fi
 if [ ! -f "${config_path}/log4rs_console_wallet.yml" ]
 then
     echo Creating new "${config_path}/log4rs_console_wallet.yml";
-    "${exe_path}/tari_console_wallet" --init --config "${config_path}/config.toml" --log_config "${config_path}/log4rs_console_wallet.yml" --base-path ${base_path}
+    init_flag="--init"
 else
     echo Using existing "${config_path}/log4rs_console_wallet.yml";
+    init_flag=""
 fi
 echo
 
 # Run
 echo Spawning Console Wallet into new terminal..
-gnome-terminal --working-directory="$PWD" -- "${exe_path}/tari_console_wallet" --config "${config_path}/config.toml" --log_config "${config_path}/log4rs_console_wallet.yml" --base-path ${base_path}
 echo
+gnome-terminal --working-directory="$PWD" -- "${exe_path}/tari_console_wallet" ${init_flag} --config "${config_path}/config.toml" --log_config "${config_path}/log4rs_console_wallet.yml" --base-path ${base_path}

--- a/applications/tari_console_wallet/windows/runtime/source_console_wallet_env.bat
+++ b/applications/tari_console_wallet/windows/runtime/source_console_wallet_env.bat
@@ -135,34 +135,16 @@ if exist "%my_exe_path%\%my_exe%" (
     )
 )
 
-rem First time run
-if not exist "%config_path%\console_wallet_id.json" (
-    cd "%base_path%"
-    "%console_wallet%" --create-id --init --config "%config_path%\config.toml" --log_config "%config_path%\log4rs_console_wallet.yml" --base-path "%base_path%"
-    echo.
-    echo.
-    echo Created "%config_path%\console_wallet_id.json".
-    echo.
-) else (
-    echo.
-    echo.
-    echo Using existing "%config_path%\console_wallet_id.json"
-    echo.
-)
+echo.
+echo.
 if not exist "%config_path%\log4rs_console_wallet.yml" (
-    cd "%base_path%"
-    "%console_wallet%" --init --config "%config_path%\config.toml" --log_config "%config_path%\log4rs_console_wallet.yml" --base-path "%base_path%"
-    echo.
-    echo.
-    echo Created "%config_path%\log4rs_console_wallet.yml".
-    echo.
+    echo Creating new "%config_path%\log4rs_console_wallet.yml".
+    set INIT_FLAG=--init
 ) else (
-    echo.
-    echo.
     echo Using existing "%config_path%\log4rs_console_wallet.yml"
-    echo.
+    set INIT_FLAG=
 )
+echo.
 
-rem Consecutive runs
 cd "%base_path%"
-"%console_wallet%" --config "%config_path%\config.toml" --log_config "%config_path%\log4rs_console_wallet.yml" --base-path "%base_path%"
+"%console_wallet%" %INIT_FLAG% --config "%config_path%\config.toml" --log_config "%config_path%\log4rs_console_wallet.yml" --base-path "%base_path%"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Due to changes in how the wallet starts up, it does not have to run twice anymore if `init` needs to be done. This PR changes the startup scripts accordingly. See related changes in #2571.

## Motivation and Context
See above,

## How Has This Been Tested?
Tested in `tari_console_wallet` startup in  Windows and Ubuntu

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [X] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [X] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [X] I'm merging against the `development` branch.
* [ ] I ran `cargo-fmt --all` before pushing.
* [ ] I ran `cargo test` successfully before submitting my PR.
* [X] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
