### PR TITLE
Remove Ridcully references from Stibbons code

### DIFF
--- a/README.md
+++ b/README.md
@@ -346,18 +346,18 @@ was run, the main configuration file will be located in the installation directo
 With the main configuration file, in addition to the settings already present, the following must also be enabled if 
 they are not enabled already:
 
-- For the Tari Base Node and the Tari Console Wallet, under section **`base_node.ridcully`**
+- For the Tari Base Node and the Tari Console Wallet, under section **`base_node.stibbons`**
   ```
-  [base_node.ridcully]
+  [base_node.stibbons]
   transport = "tor"
   allow_test_addresses = false
   grpc_enabled = true
   grpc_base_node_address = "127.0.0.1:18142"
   grpc_console_wallet_address = "127.0.0.1:18143"
   ```
-- For the Tari Merge Mining Proxy, under section **`merge_mining_proxy.ridcully`**
+- For the Tari Merge Mining Proxy, under section **`merge_mining_proxy.stibbons`**
   ```
-  [merge_mining_proxy.ridcully]
+  [merge_mining_proxy.stibbons]
   monerod_url = "http://18.133.55.120:38081"
   proxy_host_address = "127.0.0.1:7878"
   monerod_use_auth = false

--- a/applications/tari_base_node/osx/install.sh
+++ b/applications/tari_base_node/osx/install.sh
@@ -54,7 +54,7 @@ if [ ! "$(uname)" == "Darwin" ]; then
 fi
 
 DATA_DIR=${1:-"$HOME/.tari"}
-NETWORK=ridcully
+NETWORK=stibbons
 
 banner Installing and setting up your Tari Base Node
 if [ ! -d "$DATA_DIR/$NETWORK" ]; then

--- a/applications/tari_base_node/osx/post_install.sh
+++ b/applications/tari_base_node/osx/post_install.sh
@@ -183,7 +183,7 @@ wget -qO - https://api.ipify.org; echo
 torsocks wget -qO - https://api.ipify.org; echo
 
 DATA_DIR=${1:-"$HOME/.tari"}
-NETWORK=ridcully
+NETWORK=stibbons
 
 banner Installing and setting up your Tari Base Node
 if [ ! -d "$DATA_DIR/$NETWORK" ]; then

--- a/applications/tari_base_node/windows/README.md
+++ b/applications/tari_base_node/windows/README.md
@@ -81,7 +81,7 @@ Notes:
 - Execute the `.\start_tari_merge_mining_proxy` shortcut.
 - Execute the `.\start_xmrig` shortcut.
 - Runtime artefacts:
-  - The blockchain will be created in the `.\ridcully` folder.
+  - The blockchain will be created in the `.\stibbons` folder.
   - The wallet will be created in the `.\wallet` folfder.
   - All log files will be created in the `.\log\base_node`, `.\log\wallet` and 
     `.\log\proxy` folders.
@@ -100,7 +100,7 @@ Notes:
 ## Start Fresh
 
 - To delete log files, delete the `.\log` folder.
-- To re-sync the blockchain, delete the `.\ridcully` folder.
+- To re-sync the blockchain, delete the `.\stibbons` folder.
 - To destroy your wallet and loose all your hard-earned tXTR Tari coins, delete 
   the `.\wallet` folder.
 

--- a/applications/tari_console_wallet/src/ui/state/wallet_event_monitor.rs
+++ b/applications/tari_console_wallet/src/ui/state/wallet_event_monitor.rs
@@ -128,12 +128,8 @@ impl WalletEventMonitor {
                         match result {
                             Ok(msg) => {
                                 trace!(target: LOG_TARGET, "Output Manager Service Callback Handler event {:?}", msg);
-                                match msg {
-                                    OutputManagerEvent::TxoValidationSuccess(_) => {
+                                if let OutputManagerEvent::TxoValidationSuccess(_) = msg {
                                         self.trigger_balance_refresh().await;
-                                    },
-                                    // Only the above variants are monitored
-                                    _ => (),
                                 }
                             },
                             Err(_e) => error!(target: LOG_TARGET, "Error reading from Output Manager Service event broadcast channel"),

--- a/base_layer/core/src/blocks/genesis_block.rs
+++ b/base_layer/core/src/blocks/genesis_block.rs
@@ -53,7 +53,7 @@ pub fn get_mainnet_gen_header() -> BlockHeader {
 pub fn get_stibbons_genesis_block() -> ChainBlock {
     // lets get the block
     let mut block = get_stibbons_genesis_block_raw();
-    // Lets load in the ridcully faucet tx's
+    // Lets load in the stibbons faucet tx's
     let mut utxos = Vec::new();
     let file = include_str!("faucets/stibbons_faucet.json");
     // last 2 lines are used for the kernel creation

--- a/base_layer/core/src/test_helpers/blockchain.rs
+++ b/base_layer/core/src/test_helpers/blockchain.rs
@@ -68,7 +68,7 @@ use tari_test_utils::paths::create_temporary_data_path;
 
 /// Create a new blockchain database containing no blocks.
 pub fn create_new_blockchain() -> BlockchainDatabase<TempDatabase> {
-    let network = Network::Ridcully;
+    let network = Network::Stibbons;
     let consensus_constants = ConsensusConstantsBuilder::new(network).build();
     let genesis = get_ridcully_genesis_block();
     let consensus_manager = ConsensusManagerBuilder::new(network)
@@ -103,7 +103,7 @@ pub fn create_store_with_consensus(rules: &ConsensusManager) -> BlockchainDataba
     create_store_with_consensus_and_validators(rules, validators)
 }
 pub fn create_test_blockchain_db() -> BlockchainDatabase<TempDatabase> {
-    let network = Network::Ridcully;
+    let network = Network::Stibbons;
     let rules = ConsensusManagerBuilder::new(network).build();
     create_store_with_consensus(&rules)
 }

--- a/base_layer/core/tests/block_validation.rs
+++ b/base_layer/core/tests/block_validation.rs
@@ -53,7 +53,7 @@ mod helpers;
 #[test]
 fn test_genesis_block() {
     let factories = CryptoFactories::default();
-    let network = Network::Ridcully;
+    let network = Network::Stibbons;
     let rules = ConsensusManagerBuilder::new(network).build();
     let backend = create_test_db();
     let rx = RandomXFactory::new(RandomXConfig::default(), 1);
@@ -80,7 +80,7 @@ fn test_monero_blocks() {
     let seed2 = "9f02e032f9b15d2aded991e0f68cc3c3427270b568b782e55fbd269ead0bad98".to_string();
 
     let factories = CryptoFactories::default();
-    let network = Network::Ridcully;
+    let network = Network::Stibbons;
     let mut algos = HashMap::new();
     algos.insert(PowAlgorithm::Sha3, PowAlgorithmConstants {
         max_target_time: 1800,

--- a/base_layer/wallet/src/testnet_utils.rs
+++ b/base_layer/wallet/src/testnet_utils.rs
@@ -151,7 +151,7 @@ pub async fn create_wallet(
         peer_seeds: Default::default(),
     };
 
-    let config = WalletConfig::new(comms_config, factories, None, None, Network::Ridcully, None, None, None);
+    let config = WalletConfig::new(comms_config, factories, None, None, Network::Stibbons, None, None, None);
 
     Wallet::new(
         config,

--- a/base_layer/wallet/src/transaction_service/protocols/transaction_broadcast_protocol.rs
+++ b/base_layer/wallet/src/transaction_service/protocols/transaction_broadcast_protocol.rs
@@ -118,7 +118,7 @@ where TBackend: TransactionBackend + 'static
             futures::select! {
                 dial_result = self.resources.connectivity_manager.dial_peer(base_node_node_id.clone()).fuse() => {
                     match dial_result {
-                        Ok(mut base_node_connection) => {
+                        Ok(base_node_connection) => {
                             connection = Some(base_node_connection);
                         },
                         Err(e) => {

--- a/base_layer/wallet/src/transaction_service/service.rs
+++ b/base_layer/wallet/src/transaction_service/service.rs
@@ -1714,7 +1714,7 @@ where
         let (ts_request_sender, _ts_request_receiver) = reply_channel::unbounded();
         let (event_publisher, _) = broadcast::channel(100);
         let ts_handle = TransactionServiceHandle::new(ts_request_sender, event_publisher.clone());
-        let constants = ConsensusConstantsBuilder::new(Network::Ridcully).build();
+        let constants = ConsensusConstantsBuilder::new(Network::Stibbons).build();
         let shutdown = Shutdown::new();
         let mut fake_oms = OutputManagerService::new(
             OutputManagerServiceConfig::default(),

--- a/base_layer/wallet_ffi/src/lib.rs
+++ b/base_layer/wallet_ffi/src/lib.rs
@@ -2955,7 +2955,7 @@ pub unsafe extern "C" fn wallet_create(
                         ..Default::default()
                     }),
                     None,
-                    Network::Ridcully,
+                    Network::Stibbons,
                     None,
                     None,
                     None,

--- a/buildtools/create_osx_install_zip.sh
+++ b/buildtools/create_osx_install_zip.sh
@@ -11,7 +11,7 @@ fi
 rm -f "./$1.tar.gz" >/dev/null
 
 tarball_parent=/tmp
-tarball_source=tari_ridcully_testnet
+tarball_source=tari_stibbons_testnet
 tarball_folder=${tarball_parent}/${tarball_source}
 if [ -d "${tarball_folder}" ]
 then

--- a/buildtools/create_ubuntu_install_zip.sh
+++ b/buildtools/create_ubuntu_install_zip.sh
@@ -11,7 +11,7 @@ fi
 rm -f "./$1.tar.gz" >/dev/null
 
 tarball_parent=/tmp
-tarball_source=tari_ridcully_testnet
+tarball_source=tari_stibbons_testnet
 tarball_folder=${tarball_parent}/${tarball_source}
 if [ -d "${tarball_folder}" ]
 then

--- a/common/config/presets/tari_sample.toml
+++ b/common/config/presets/tari_sample.toml
@@ -1,4 +1,4 @@
-# A simple set of sane defaults for connecting to the Ridcully testnet
+# A simple set of sane defaults for connecting to the Stibbons testnet
 
 [base_node]
 network = "stibbons"

--- a/common/config/presets/windows.toml
+++ b/common/config/presets/windows.toml
@@ -142,12 +142,12 @@ base_node_query_timeout = 120
 
 # Select the network to connect to. Valid options are:
 #   mainnet - the "real" Tari network (default)
-#   ridcully - the Tari test net
-network = "ridcully"
+#   stibbons - the Tari test net
+network = "stibbons"
 
 # Configuration options for testnet
 
-[base_node.ridcully]
+[base_node.stibbons]
 # The type of database backend to use. Currently supported options are "memory" and "lmdb". LMDB is recommnded for
 # almost all use cases.
 db_type = "lmdb"
@@ -171,7 +171,7 @@ db_type = "lmdb"
 #num_mining_threads = 1
 
 # The relative path to store persistent data
-data_dir = "ridcully"
+data_dir = "stibbons"
 
 # When first logging onto the Tari network, you need to find a few peers to bootstrap the process. In the absence of
 # any servers, this is a little more challenging than usual. Our best strategy is just to try and connect to the peers
@@ -203,7 +203,7 @@ force_sync_peers = [
 # DNS seeds
 # The DNS records in these hostnames should provide TXT records as per https://github.com/tari-project/tari/pull/2319
 # Enter a domain name for the TXT records: seeds.tari.com
-dns_seeds =["seeds.ridcully.tari.com"]
+dns_seeds =["seeds.stibbons.tari.com"]
 # The name server used to resolve DNS seeds
 # dns_seeds_name_server = "1.1.1.1:53"
 # Set to true to only accept DNS records that pass DNSSEC validation (Default: true)
@@ -293,7 +293,7 @@ console_wallet_tor_identity_file = ".\\config\\cosole_wallet_tor.json"
 #                                             Mempool Configuration Options                                            #
 #                                                                                                                      #
 ########################################################################################################################
-[mempool.ridcully]
+[mempool.stibbons]
 
 # The maximum number of transactions that can be stored in the Unconfirmed Transaction pool. This is the main waiting
 # area in the mempool and almost all transactions will end up in this pool before being mined. It's for this reason
@@ -365,7 +365,7 @@ console_wallet_tor_identity_file = ".\\config\\cosole_wallet_tor.json"
 ########################################################################################################################
 
 
-[merge_mining_proxy.ridcully]
+[merge_mining_proxy.stibbons]
 
 # URL to monerod, currently set to a seed node
 monerod_url = "http://18.133.55.120:38081"

--- a/common/config/tari_config_example.toml
+++ b/common/config/tari_config_example.toml
@@ -142,12 +142,12 @@ base_node_query_timeout = 120
 
 # Select the network to connect to. Valid options are:
 #   mainnet - the "real" Tari network (default)
-#   ridcully - the Tari test net
-network = "ridcully"
+#   stibbons - the Tari test net
+network = "stibbons"
 
 # Configuration options for testnet
 
-[base_node.ridcully]
+[base_node.stibbons]
 # The type of database backend to use. Currently supported options are "memory" and "lmdb". LMDB is recommnded for
 # almost all use cases.
 db_type = "lmdb"
@@ -171,7 +171,7 @@ db_type = "lmdb"
 #num_mining_threads = 1
 
 # The relative path to store persistent data
-data_dir = "ridcully"
+data_dir = "stibbons"
 
 # When first logging onto the Tari network, you need to find a few peers to bootstrap the process. In the absence of
 # any servers, this is a little more challenging than usual. Our best strategy is just to try and connect to the peers
@@ -203,7 +203,7 @@ force_sync_peers = [
 # DNS seeds
 # The DNS records in these hostnames should provide TXT records as per https://github.com/tari-project/tari/pull/2319
 # Enter a domain name for the TXT records: seeds.tari.com
-dns_seeds =["seeds.ridcully.tari.com"]
+dns_seeds =["seeds.stibbons.tari.com"]
 dns_seeds_use_dnssec = false
 
 # Determines the method of syncing blocks when the node is lagging. If you are not struggling with syncing, then
@@ -293,7 +293,7 @@ console_wallet_tor_identity_file = "./cosole_wallet_tor.json" # or ".\\cosole_wa
 #                                             Mempool Configuration Options                                            #
 #                                                                                                                      #
 ########################################################################################################################
-[mempool.ridcully]
+[mempool.stibbons]
 
 # The maximum number of transactions that can be stored in the Unconfirmed Transaction pool. This is the main waiting
 # area in the mempool and almost all transactions will end up in this pool before being mined. It's for this reason
@@ -365,7 +365,7 @@ console_wallet_tor_identity_file = "./cosole_wallet_tor.json" # or ".\\cosole_wa
 ########################################################################################################################
 
 
-[merge_mining_proxy.ridcully]
+[merge_mining_proxy.stibbons]
 
 # URL to monerod, currently set to a seed node
 monerod_url = "http://18.133.55.120:38081"

--- a/common/src/configuration/utils.rs
+++ b/common/src/configuration/utils.rs
@@ -167,7 +167,7 @@ pub fn default_config(bootstrap: &ConfigBootstrap) -> Config {
     cfg.set_default("base_node.mainnet.enable_wallet", true).unwrap();
     cfg.set_default("base_node.mainnet.num_mining_threads", 1).unwrap();
 
-    //---------------------------------- Ridcully Defaults --------------------------------------------//
+    //---------------------------------- Stibbons Defaults --------------------------------------------//
 
     cfg.set_default("base_node.stibbons.db_type", "lmdb").unwrap();
     cfg.set_default("base_node.stibbons.orphan_storage_capacity", 720)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- This fix removed Ridcully references from the Stibbons release code base, necessitated due to the recent testnet reset, for example, configuration file settings and network setting in the wallet FFI.
- Also fixed some clippy errors that popped up.

## Motivation and Context
See above.

## How Has This Been Tested?
Run all cargo tests in release mode.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [X] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [X] I'm merging against the `development` branch.
* [X] I ran `cargo-fmt --all` before pushing.
* [X] I ran `cargo test` successfully before submitting my PR.
* [X] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
