### PR TITLE
Fix for automated wallet startup

### DIFF
--- a/applications/tari_console_wallet/src/main.rs
+++ b/applications/tari_console_wallet/src/main.rs
@@ -61,7 +61,12 @@ fn main_inner() -> Result<(), ExitCodes> {
 
     debug!(target: LOG_TARGET, "Using configuration: {:?}", config);
 
-    tari_splash_screen("Console Wallet");
+    // get command line password if provided
+    let arg_password = bootstrap.password.clone();
+
+    if arg_password.is_none() {
+        tari_splash_screen("Console Wallet");
+    }
 
     // check for recovery
     let boot_mode = boot(&bootstrap, &config)?;
@@ -89,10 +94,6 @@ fn main_inner() -> Result<(), ExitCodes> {
         _ => None,
     };
 
-    if bootstrap.init {
-        info!(target: LOG_TARGET, "Default configuration created. Done.");
-        return Ok(());
-    }
     if node_identity.is_none() {
         warn!(
             target: LOG_TARGET,
@@ -108,9 +109,6 @@ fn main_inner() -> Result<(), ExitCodes> {
         std::fs::remove_file(&config.console_wallet_identity_file)
             .map_err(|e| ExitCodes::WalletError(format!("Could not delete identity file {}", e)))?;
     }
-
-    // get command line password if provided
-    let arg_password = bootstrap.password.clone();
 
     let mut shutdown = Shutdown::new();
     let shutdown_signal = shutdown.to_signal();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This fixes the console wallet not starting correctly when automated with `--password`. Also removed the "return" from init 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

the new wallet splash screen was causing an issue in automated startup for integration tests 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
manually 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch.
* [x] I ran `cargo-fmt --all` before pushing.
* [ ] I ran `cargo test` successfully before submitting my PR.
* [x] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
