### PR TITLE
Remove "add one to port" hack in console wallet

### DIFF
--- a/applications/tari_app_utilities/src/utilities.rs
+++ b/applications/tari_app_utilities/src/utilities.rs
@@ -27,7 +27,6 @@ use std::{fmt, fmt::Formatter, net::SocketAddr, path::Path};
 use tari_common::{CommsTransport, GlobalConfig, SocksAuthentication, TorControlAuthentication};
 use tari_comms::{
     connectivity::ConnectivityError,
-    multiaddr::{Multiaddr, Protocol},
     peer_manager::NodeId,
     protocol::rpc::RpcError,
     socks,
@@ -147,22 +146,13 @@ pub fn setup_wallet_transport_type(config: &GlobalConfig) -> TransportType {
         "Console wallet transport is set to '{:?}'", config.comms_transport
     );
 
-    let add_to_port = |addr: Multiaddr, n| -> Multiaddr {
-        addr.iter()
-            .map(|p| match p {
-                Protocol::Tcp(port) => Protocol::Tcp(port + n),
-                p => p,
-            })
-            .collect()
-    };
-
     match config.comms_transport.clone() {
         CommsTransport::Tcp {
             listener_address,
             tor_socks_address,
             tor_socks_auth,
         } => TransportType::Tcp {
-            listener_address: add_to_port(listener_address, 1),
+            listener_address,
             tor_socks_config: tor_socks_address.map(|proxy_address| SocksConfig {
                 proxy_address,
                 authentication: tor_socks_auth.map(convert_socks_authentication).unwrap_or_default(),
@@ -206,7 +196,6 @@ pub fn setup_wallet_transport_type(config: &GlobalConfig) -> TransportType {
                 },
                 identity: identity.map(Box::new),
                 port_mapping,
-                // TODO: make configurable
                 socks_address_override,
                 socks_auth: socks::Authentication::None,
             })
@@ -220,7 +209,7 @@ pub fn setup_wallet_transport_type(config: &GlobalConfig) -> TransportType {
                 proxy_address,
                 authentication: convert_socks_authentication(auth),
             },
-            listener_address: add_to_port(listener_address, 1),
+            listener_address,
         },
     }
 }


### PR DESCRIPTION
The "add one to port" hack was used to ensure
that port numbers don't conflict between the base node and it's wallet .
Due to deficiencies in the current configuration framework assigning custom 
configuration to other applications requires a lot of boilerplate and mapping code.

This PR removes this hack from the console wallet code (only effects TCP
transport) as it creates confusion when implementing cucumber tests.
