### PR TITLE
Update fee vs amount being sent validation

### DIFF
--- a/base_layer/core/src/transactions/transaction_protocol/transaction_initializer.rs
+++ b/base_layer/core/src/transactions/transaction_protocol/transaction_initializer.rs
@@ -238,9 +238,8 @@ impl SenderTransactionInitializer {
         })
     }
 
-    fn calculate_total_amount(&self, amount_to_self: &MicroTari) -> MicroTari {
-        let to_others: MicroTari = self.amounts.clone().into_vec().iter().sum();
-        to_others + amount_to_self
+    fn calculate_amount_to_others(&self) -> MicroTari {
+        self.amounts.clone().into_vec().iter().sum()
     }
 
     /// Construct a `SenderTransactionProtocol` instance in and appropriate state. The data stored
@@ -337,15 +336,16 @@ impl SenderTransactionInitializer {
             ids.push(calculate_tx_id::<D>(&public_nonce, i));
         }
 
-        // The fee should be less than the amount. This isn't a protocol requirement, but it's what you want 99.999%
-        // of the time, however, always preventing this will also prevent spending dust in some edge cases.
-        if total_fee > self.calculate_total_amount(&amount_to_self) {
+        // The fee should be less than the amount being sent. This isn't a protocol requirement, but it's what you want
+        // 99.999% of the time, however, always preventing this will also prevent spending dust in some edge
+        // cases.
+        if total_fee > self.calculate_amount_to_others() {
             let ids_clone = ids.to_vec();
             warn!(
                 target: LOG_TARGET,
-                "Fee ({}) is greater than amount ({}) for Transaction (TxId: {}).",
+                "Fee ({}) is greater than amount ({}) being sent for Transaction (TxId: {}).",
                 total_fee,
-                self.calculate_total_amount(&amount_to_self),
+                self.calculate_amount_to_others(),
                 ids_clone[0]
             );
             if self.prevent_fee_gt_amount {


### PR DESCRIPTION
## Description
Currently when the `SenderTransactionInitializer` validates the components of the transaction it is building it will check that if the fee is more than the amount being sent + the change. 

This PR updates this behaviour to check if the fee being sent is more than just the amounts being send, ignoring the change. This prevents the case where a large UTXO that produces a lot of change will still allow a transaction to be sent where the outbound amount is less than the fee.

## How Has This Been Tested?
Manual testing

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [x] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch.
* [x] I ran `cargo-fmt --all` before pushing.
* [x] I ran `cargo test` successfully before submitting my PR.
* [x] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
