### PR TITLE
Only allow one transaction broadcast protocol at a time

### DIFF
--- a/base_layer/wallet/tests/transaction_service/service.rs
+++ b/base_layer/wallet/tests/transaction_service/service.rs
@@ -4169,3 +4169,61 @@ fn transaction_service_tx_broadcast_with_base_node_change() {
         assert!(tx_mined);
     });
 }
+
+#[test]
+fn only_start_one_tx_braodcast_protocol_at_a_time() {
+    let mut runtime = Runtime::new().unwrap();
+    let factories = CryptoFactories::default();
+
+    let temp_dir = tempdir().unwrap();
+    let db_name = format!("{}.sqlite3", random_string(8).as_str());
+    let db_path = format!("{}/{}", temp_dir.path().to_str().unwrap(), db_name);
+    let connection = run_migration_and_create_sqlite_connection(&db_path).unwrap();
+    let backend = TransactionServiceSqliteDatabase::new(connection, None);
+
+    let kernel = KernelBuilder::new()
+        .with_excess(&factories.commitment.zero())
+        .with_signature(&Signature::default())
+        .build()
+        .unwrap();
+
+    let tx = Transaction::new(vec![], vec![], vec![kernel], PrivateKey::random(&mut OsRng));
+
+    let completed_tx1 = CompletedTransaction {
+        tx_id: 1,
+        source_public_key: PublicKey::from_secret_key(&PrivateKey::random(&mut OsRng)),
+        destination_public_key: PublicKey::from_secret_key(&PrivateKey::random(&mut OsRng)),
+        amount: 5000 * uT,
+        fee: MicroTari::from(100),
+        transaction: tx.clone(),
+        status: TransactionStatus::Completed,
+        message: "Yo!".to_string(),
+        timestamp: Utc::now().naive_utc(),
+        cancelled: false,
+        direction: TransactionDirection::Outbound,
+        coinbase_block_height: None,
+        send_count: 0,
+        last_send_timestamp: None,
+    };
+
+    backend
+        .write(WriteOperation::Insert(DbKeyValuePair::CompletedTransaction(
+            completed_tx1.tx_id,
+            Box::new(completed_tx1.clone()),
+        )))
+        .unwrap();
+
+    let (mut alice_ts, _, _, _, _, _, _, _, _, _shutdown, _mock_rpc_server, server_node_identity, rpc_service_state) =
+        setup_transaction_service_no_comms(&mut runtime, factories.clone(), backend, None);
+
+    runtime
+        .block_on(alice_ts.set_base_node_public_key(server_node_identity.public_key().clone()))
+        .unwrap();
+
+    assert!(runtime.block_on(alice_ts.restart_broadcast_protocols()).is_ok());
+    assert!(runtime.block_on(alice_ts.restart_broadcast_protocols()).is_ok());
+
+    let tx_submit_calls =
+        runtime.block_on(rpc_service_state.wait_pop_submit_transaction_calls(2, Duration::from_secs(2)));
+    assert!(tx_submit_calls.is_err(), "Should not be 2 calls made");
+}


### PR DESCRIPTION
## Description
Noticed a bug where if the client calls the API method to restart transaction broadcast protocols while one is already running a second would be spawned. Might produce future unforeseen bugs and it does produce some confusing logs. 

This PR adds in a Hashset to keep track of the tx broadcast protocols that have been started and only spawn one at a time for a given transaction.

## How Has This Been Tested?
Test provided

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch.
* [x] I ran `cargo-fmt --all` before pushing.
* [x] I ran `cargo test` successfully before submitting my PR.
* [x] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
