### PR TITLE
Filter out mature UTXO's when choosing UTXO's for new transactions

### DIFF
--- a/applications/tari_console_wallet/src/ui/state/app_state.rs
+++ b/applications/tari_console_wallet/src/ui/state/app_state.rs
@@ -535,11 +535,7 @@ impl AppStateInner {
     }
 
     pub fn get_base_node_event_stream(&self) -> Fuse<BaseNodeEventReceiver> {
-        self.wallet
-            .base_node_service
-            .clone()
-            .expect("The wallet base node service was never initialized!")
-            .get_event_stream_fused()
+        self.wallet.base_node_service.clone().get_event_stream_fused()
     }
 
     pub async fn set_base_node_peer(&mut self, peer: Peer) -> Result<(), UiError> {

--- a/base_layer/wallet/src/base_node_service/error.rs
+++ b/base_layer/wallet/src/base_node_service/error.rs
@@ -20,6 +20,7 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+use crate::error::WalletStorageError;
 use tari_comms_dht::outbound::DhtOutboundError;
 use tari_service_framework::reply_channel::TransportChannelError;
 use thiserror::Error;
@@ -28,6 +29,8 @@ use thiserror::Error;
 pub enum BaseNodeServiceError {
     #[error("No base node peer set")]
     NoBaseNodePeer,
+    #[error("No chain meta data from peer")]
+    NoChainMetadata,
     #[error("Unexpected API Response")]
     UnexpectedApiResponse,
     #[error("Transport channel error: `{0}`")]
@@ -36,4 +39,6 @@ pub enum BaseNodeServiceError {
     OutboundError(#[from] DhtOutboundError),
     #[error("Received invalid base node response: {0}")]
     InvalidBaseNodeResponse(String),
+    #[error("Wallet storage error: `{0}`")]
+    WalletStorageError(#[from] WalletStorageError),
 }

--- a/base_layer/wallet/src/base_node_service/handle.rs
+++ b/base_layer/wallet/src/base_node_service/handle.rs
@@ -74,6 +74,14 @@ impl BaseNodeServiceHandle {
         self.event_stream_sender.subscribe().fuse()
     }
 
+    pub async fn get_connected_base_node_state(&mut self) -> Result<ChainMetadata, BaseNodeServiceError> {
+        match self.handle.call(BaseNodeServiceRequest::GetChainMetadata).await?? {
+            BaseNodeServiceResponse::ChainMetadata(Some(v)) => Ok(v),
+            BaseNodeServiceResponse::ChainMetadata(None) => Err(BaseNodeServiceError::NoChainMetadata),
+            _ => Err(BaseNodeServiceError::UnexpectedApiResponse),
+        }
+    }
+
     pub async fn set_base_node_peer(&mut self, peer: Peer) -> Result<(), BaseNodeServiceError> {
         match self
             .handle

--- a/base_layer/wallet/src/output_manager_service/error.rs
+++ b/base_layer/wallet/src/output_manager_service/error.rs
@@ -20,7 +20,7 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use crate::output_manager_service::storage::database::DbKey;
+use crate::{base_node_service::error::BaseNodeServiceError, output_manager_service::storage::database::DbKey};
 use diesel::result::Error as DieselError;
 use tari_comms_dht::outbound::DhtOutboundError;
 use tari_core::transactions::{
@@ -90,6 +90,8 @@ pub enum OutputManagerError {
     CoinbaseBuildError(#[from] CoinbaseBuildError),
     #[error("TXO Validation protocol cancelled")]
     Cancellation,
+    #[error("Base NodeService Error: `{0}`")]
+    BaseNodeServiceError(#[from] BaseNodeServiceError),
 }
 
 #[derive(Debug, Error, PartialEq)]

--- a/base_layer/wallet/src/output_manager_service/mod.rs
+++ b/base_layer/wallet/src/output_manager_service/mod.rs
@@ -21,6 +21,7 @@
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 use crate::{
+    base_node_service::handle::BaseNodeServiceHandle,
     output_manager_service::{
         config::OutputManagerServiceConfig,
         handle::OutputManagerHandle,
@@ -141,6 +142,7 @@ where T: OutputManagerBackend + 'static
         context.spawn_when_ready(move |handles| async move {
             let outbound_message_service = handles.expect_handle::<Dht>().outbound_requester();
             let transaction_service = handles.expect_handle::<TransactionServiceHandle>();
+            let base_node_service_handle = handles.expect_handle::<BaseNodeServiceHandle>();
 
             let service = OutputManagerService::new(
                 config,
@@ -153,6 +155,7 @@ where T: OutputManagerBackend + 'static
                 factories,
                 constants,
                 handles.get_shutdown_signal(),
+                base_node_service_handle,
             )
             .await
             .expect("Could not initialize Output Manager Service")

--- a/base_layer/wallet/src/storage/memory_db.rs
+++ b/base_layer/wallet/src/storage/memory_db.rs
@@ -29,6 +29,7 @@ use std::{
     collections::HashMap,
     sync::{Arc, RwLock},
 };
+use tari_common_types::chain_metadata::ChainMetadata;
 use tari_comms::{
     multiaddr::Multiaddr,
     tor::TorIdentity,
@@ -45,6 +46,7 @@ pub struct InnerDatabase {
     features: u64,
     identity: Option<NodeIdentity>,
     tor_id: Option<TorIdentity>,
+    chain_metadata: Option<ChainMetadata>,
 }
 
 impl InnerDatabase {
@@ -56,6 +58,7 @@ impl InnerDatabase {
             features: 0,
             identity: None,
             tor_id: None,
+            chain_metadata: None,
         }
     }
 }
@@ -93,6 +96,7 @@ impl WalletBackend for WalletMemoryDatabase {
             DbKey::CommsFeatures => Some(DbValue::CommsFeatures(db.features)),
             DbKey::Identity => db.identity.clone().map(DbValue::Identity),
             DbKey::TorId => db.tor_id.clone().map(DbValue::TorId),
+            DbKey::BaseNodeChainMeta => db.chain_metadata.clone().map(DbValue::BaseNodeChainMeta),
         };
 
         Ok(result)
@@ -113,6 +117,9 @@ impl WalletBackend for WalletMemoryDatabase {
                 },
                 DbKeyValuePair::TorId(v) => {
                     db.tor_id = Some(v);
+                },
+                DbKeyValuePair::BaseNodeChainMeta(v) => {
+                    db.chain_metadata = Some(v);
                 },
             },
             WriteOperation::Remove(k) => match k {
@@ -136,6 +143,9 @@ impl WalletBackend for WalletMemoryDatabase {
                     return Err(WalletStorageError::OperationNotSupported);
                 },
                 DbKey::Identity => {
+                    return Err(WalletStorageError::OperationNotSupported);
+                },
+                DbKey::BaseNodeChainMeta => {
                     return Err(WalletStorageError::OperationNotSupported);
                 },
                 DbKey::TorId => {

--- a/base_layer/wallet/src/transaction_service/service.rs
+++ b/base_layer/wallet/src/transaction_service/service.rs
@@ -1714,6 +1714,7 @@ where
     ) -> Result<(), TransactionServiceError>
     {
         use crate::{
+            base_node_service::handle::BaseNodeServiceHandle,
             output_manager_service::{
                 config::OutputManagerServiceConfig,
                 error::OutputManagerError,
@@ -1734,6 +1735,10 @@ where
         let ts_handle = TransactionServiceHandle::new(ts_request_sender, event_publisher.clone());
         let constants = ConsensusConstantsBuilder::new(Network::Stibbons).build();
         let shutdown = Shutdown::new();
+        let (sender, _) = reply_channel::unbounded();
+        let (event_publisher_bns, _) = broadcast::channel(100);
+
+        let basenode_service_handle = BaseNodeServiceHandle::new(sender, event_publisher_bns);
         let mut fake_oms = OutputManagerService::new(
             OutputManagerServiceConfig::default(),
             OutboundMessageRequester::new(tx),
@@ -1745,6 +1750,7 @@ where
             self.resources.factories.clone(),
             constants,
             shutdown.to_signal(),
+            basenode_service_handle,
         )
         .await?;
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR adds in a handle to the OMS to the BNS so that it can query the last updated chain_meta_state from its connected base_node. 
This allows the OMS to filter out UTXO's that are not yet mature when its selecting UTXO to send out. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Select not yet mature UTXO's will result in the Base_node rejecting the transaction.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch.
* [x] I ran `cargo-fmt --all` before pushing.
* [x] I ran `cargo test` successfully before submitting my PR.
* [x] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
