### PR TITLE
[MM_Proxy] Submit to origin daemon configuration

### DIFF
--- a/common/config/presets/tari_sample.toml
+++ b/common/config/presets/tari_sample.toml
@@ -27,7 +27,7 @@ pruning_horizon = 100
 [merge_mining_proxy.stibbons]
 monerod_url = "http://18.133.55.120:38081"
 proxy_host_address = "127.0.0.1:7878"
+proxy_submit_to_origin = true
 monerod_use_auth=false
 monerod_username=""
 monerod_password=""
-

--- a/common/config/presets/windows.toml
+++ b/common/config/presets/windows.toml
@@ -373,6 +373,12 @@ monerod_url = "http://18.133.55.120:38081"
 # Address of the tari_merge_mining_proxy application
 proxy_host_address = "127.0.0.1:7878"
 
+## In sole merged mining, the block solution is usually submitted to the Monero blockchain
+# (monerod) as well as to the Tari blockchain, then this setting should be "true". With pool
+# merged mining, there is no sense in submitting the solution to the Monero blockchain as the
+# pool does that, then this setting should be "false". (default = true).
+proxy_submit_to_origin = true
+
 # If authentication is being used for curl
 monerod_use_auth=false
 
@@ -401,13 +407,13 @@ monerod_password=""
 # Default: value from `base_node.grpc_console_wallet_address`
 #wallet_grpc_address = "127.0.0.1:18143"
 
-# Start mining only when base node is bootstrapped 
+# Start mining only when base node is bootstrapped
 # and current block height is on the tip of network
 # Default: true
 #mine_on_tip_only=true
 
 # Will check tip with node every N seconds and restart mining
-# if height already taken and option `mine_on_tip_only` is set 
+# if height already taken and option `mine_on_tip_only` is set
 # to true
 # Default: 30 seconds
 #validate_tip_timeout_sec=30

--- a/common/config/tari_config_example.toml
+++ b/common/config/tari_config_example.toml
@@ -373,6 +373,12 @@ monerod_url = "http://18.133.55.120:38081"
 # Address of the tari_merge_mining_proxy application
 proxy_host_address = "127.0.0.1:7878"
 
+# In sole merged mining, the block solution is usually submitted to the Monero blockchain
+# (monerod) as well as to the Tari blockchain, then this setting should be "true". With pool
+# merged mining, there is no sense in submitting the solution to the Monero blockchain as the
+# pool does that, then this setting should be "false". (default = true).
+proxy_submit_to_origin = true
+
 # If authentication is being used for curl
 monerod_use_auth=false
 
@@ -400,13 +406,13 @@ monerod_password=""
 # Default: value from `base_node.grpc_console_wallet_address`
 #wallet_grpc_address = "127.0.0.1:18143"
 
-# Start mining only when base node is bootstrapped 
+# Start mining only when base node is bootstrapped
 # and current block height is on the tip of network
 # Default: true
 #mine_on_tip_only=true
 
 # Will check tip with node every N seconds and restart mining
-# if height already taken and option `mine_on_tip_only` is set 
+# if height already taken and option `mine_on_tip_only` is set
 # to true
 # Default: 30 seconds
 #validate_tip_timeout_sec=30

--- a/common/src/configuration/global.rs
+++ b/common/src/configuration/global.rs
@@ -108,6 +108,7 @@ pub struct GlobalConfig {
     pub monerod_password: String,
     pub monerod_use_auth: bool,
     pub proxy_host_address: SocketAddr,
+    pub proxy_submit_to_origin: bool,
     pub force_sync_peers: Vec<String>,
     pub wait_for_initial_sync_at_startup: bool,
     pub max_randomx_vms: usize,
@@ -557,6 +558,9 @@ fn convert_node_config(network: Network, cfg: Config) -> Result<GlobalConfig, Co
         .get_bool(&key)
         .map_err(|e| ConfigurationError::new(&key, &e.to_string()))?;
 
+    let key = config_string("merge_mining_proxy", &net_str, "proxy_submit_to_origin");
+    let proxy_submit_to_origin = cfg.get_bool(&key).unwrap_or_else(|_| true);
+
     Ok(GlobalConfig {
         network,
         comms_transport,
@@ -614,6 +618,7 @@ fn convert_node_config(network: Network, cfg: Config) -> Result<GlobalConfig, Co
         wallet_base_node_service_request_max_age,
         prevent_fee_gt_amount,
         proxy_host_address,
+        proxy_submit_to_origin,
         monerod_url,
         monerod_username,
         monerod_password,

--- a/common/src/configuration/utils.rs
+++ b/common/src/configuration/utils.rs
@@ -262,6 +262,8 @@ fn set_merge_mining_defaults(cfg: &mut Config) {
         .unwrap();
     cfg.set_default("merge_mining_proxy.stibbons.proxy_host_address", "127.0.0.1:7878")
         .unwrap();
+    cfg.set_default("merge_mining_proxy.stibbons.proxy_submit_to_origin", true)
+        .unwrap();
     cfg.set_default("merge_mining_proxy.stibbons.monerod_use_auth", "false")
         .unwrap();
     cfg.set_default("merge_mining_proxy.stibbons.monerod_username", "")


### PR DESCRIPTION
## Description
This PR allows configuring the proxy to submit to the original monero daemon. 

## Motivation and Context
When using self-select mode in XMRig, submitting to monero will be done by the pool and is not necessary to do so from the proxy.

## How Has This Been Tested?

## Types of changes
* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
* [x] I'm merging against the `development` branch.
* [x] I ran `cargo-fmt --all` before pushing.
* [x] I ran `cargo test` successfully before submitting my PR.
* [x] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
