### PR TITLE
Fix tests breaking due to Fee vs Sent amount validation

### DIFF
--- a/base_layer/core/src/transactions/transaction_protocol/sender.rs
+++ b/base_layer/core/src/transactions/transaction_protocol/sender.rs
@@ -650,7 +650,7 @@ mod test {
         let a = TestParams::new();
         // Bob's parameters
         let b = TestParams::new();
-        let (utxo, input) = make_input(&mut OsRng, MicroTari(2500), &factories.commitment);
+        let (utxo, input) = make_input(&mut OsRng, MicroTari(25000), &factories.commitment);
         let mut builder = SenderTransactionProtocol::builder(1);
         let fee = Fee::calculate(MicroTari(20), 1, 1, 2);
         builder
@@ -660,7 +660,7 @@ mod test {
             .with_private_nonce(a.nonce.clone())
             .with_change_secret(a.change_key.clone())
             .with_input(utxo.clone(), input)
-            .with_amount(0, MicroTari(500));
+            .with_amount(0, MicroTari(5000));
         let mut alice = builder.build::<Blake256>(&factories).unwrap();
         assert!(alice.is_single_round_message_ready());
         let msg = alice.build_single_round_message().unwrap();
@@ -818,7 +818,7 @@ mod test {
         let a = TestParams::new();
         // Bob's parameters
         let b = TestParams::new();
-        let alice_value = MicroTari(2500);
+        let alice_value = MicroTari(25000);
         let (utxo, input) = make_input(&mut OsRng, alice_value, &factories.commitment);
 
         // Rewind params
@@ -842,7 +842,7 @@ mod test {
             .with_private_nonce(a.nonce.clone())
             .with_rewindable_change_secret(a.change_key.clone(), rewind_data)
             .with_input(utxo.clone(), input)
-            .with_amount(0, MicroTari(500));
+            .with_amount(0, MicroTari(5000));
         let mut alice = builder.build::<Blake256>(&factories).unwrap();
         assert!(alice.is_single_round_message_ready());
         let msg = alice.build_single_round_message().unwrap();

--- a/base_layer/core/src/transactions/transaction_protocol/transaction_initializer.rs
+++ b/base_layer/core/src/transactions/transaction_protocol/transaction_initializer.rs
@@ -339,7 +339,7 @@ impl SenderTransactionInitializer {
         // The fee should be less than the amount being sent. This isn't a protocol requirement, but it's what you want
         // 99.999% of the time, however, always preventing this will also prevent spending dust in some edge
         // cases.
-        if total_fee > self.calculate_amount_to_others() {
+        if self.amounts.size() > 0 && total_fee > self.calculate_amount_to_others() {
             let ids_clone = ids.to_vec();
             warn!(
                 target: LOG_TARGET,
@@ -595,14 +595,14 @@ mod test {
         let factories = CryptoFactories::default();
         let p = TestParams::new();
         let (utxo, input) = make_input(&mut OsRng, MicroTari(100_000), &factories.commitment);
-        let output = UnblindedOutput::new(MicroTari(150), p.spend_key, None);
+        let output = UnblindedOutput::new(MicroTari(15000), p.spend_key, None);
         // Start the builder
         let mut builder = SenderTransactionInitializer::new(2);
         builder
             .with_lock_height(0)
             .with_offset(p.offset)
-            .with_amount(0, MicroTari(120))
-            .with_amount(1, MicroTari(110))
+            .with_amount(0, MicroTari(1200))
+            .with_amount(1, MicroTari(1100))
             .with_private_nonce(p.nonce)
             .with_input(utxo, input)
             .with_output(output)

--- a/base_layer/wallet/tests/transaction_service/service.rs
+++ b/base_layer/wallet/tests/transaction_service/service.rs
@@ -885,8 +885,8 @@ fn test_accepting_unknown_tx_id_and_malformed_reply() {
     runtime
         .block_on(alice_ts.send_transaction(
             bob_node_identity.public_key().clone(),
-            MicroTari::from(500),
-            MicroTari::from(1000),
+            MicroTari::from(5000),
+            MicroTari::from(20),
             "".to_string(),
         ))
         .unwrap();
@@ -1010,8 +1010,8 @@ fn finalize_tx_with_incorrect_pubkey() {
 
     let mut stp = runtime
         .block_on(bob_output_manager.prepare_transaction_to_send(
-            MicroTari::from(500),
-            MicroTari::from(1000),
+            MicroTari::from(5000),
+            MicroTari::from(25),
             None,
             "".to_string(),
         ))
@@ -1134,8 +1134,8 @@ fn finalize_tx_with_missing_output() {
 
     let mut stp = runtime
         .block_on(bob_output_manager.prepare_transaction_to_send(
-            MicroTari::from(500),
-            MicroTari::from(1000),
+            MicroTari::from(5000),
+            MicroTari::from(20),
             None,
             "".to_string(),
         ))


### PR DESCRIPTION
## Description
In a previous PR which changed the transaction builder validation to check that the fee of a transaction is not more than the amount being sent (as opposed to the total amount). This broke a lot of tests due to the helper functions to make transaction building the transaction without using the Amounts part of the transaction builder. Another feature that uses the transaction builder without a recipient is the Coinsplit.

In order to fix this, this PR only applies the Fee vs Sent amount validation if there is an amount being sent.

## How Has This Been Tested?
tweaked some tests

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch.
* [x] I ran `cargo-fmt --all` before pushing.
* [x] I ran `cargo test` successfully before submitting my PR.
* [x] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
