### PR TITLE
[base-node] Move capping of target difficulty

### DIFF
--- a/base_layer/core/src/base_node/sync/header_sync/validator.rs
+++ b/base_layer/core/src/base_node/sync/header_sync/validator.rs
@@ -124,7 +124,11 @@ impl<B: BlockchainBackend + 'static> BlockHeaderSyncValidator<B> {
         let state = self.state();
         check_header_timestamp_greater_than_median(&header, &state.timestamps)?;
 
-        let target_difficulty = state.target_difficulties.get(header.pow_algo()).calculate();
+        let constants = self.consensus_rules.consensus_constants(header.height);
+        let target_difficulty = state.target_difficulties.get(header.pow_algo()).calculate(
+            constants.min_pow_difficulty(header.pow_algo()),
+            constants.max_pow_difficulty(header.pow_algo()),
+        );
         let achieved = check_target_difficulty(&header, target_difficulty, &self.randomx_factory)?;
         let metadata = BlockHeaderAccumulatedDataBuilder::default()
             .hash(header.hash())

--- a/base_layer/core/src/consensus/consensus_constants.rs
+++ b/base_layer/core/src/consensus/consensus_constants.rs
@@ -249,18 +249,31 @@ impl ConsensusConstants {
 
     pub fn stibbons() -> Vec<Self> {
         let mut algos = HashMap::new();
-        // seting sha3/monero to 40/60 split
+        // Previously these were incorrectly set to `target_time` of 20 and 30, so
+        // most blocks before 1400 hit the minimum difficulty of 60M and 60k
+        // algos.insert(PowAlgorithm::Sha3, PowAlgorithmConstants {
+        //     max_target_time: 1800,
+        //     min_difficulty: 60_000_000.into(),
+        //     max_difficulty: u64::MAX.into(),
+        //     target_time: 30,
+        // });
+        // algos.insert(PowAlgorithm::Monero, PowAlgorithmConstants {
+        //     max_target_time: 1200,
+        //     min_difficulty: 60_000.into(),
+        //     max_difficulty: u64::MAX.into(),
+        //     target_time: 20,
+        // });
         algos.insert(PowAlgorithm::Sha3, PowAlgorithmConstants {
             max_target_time: 1800,
             min_difficulty: 60_000_000.into(),
-            max_difficulty: u64::MAX.into(),
-            target_time: 30,
+            max_difficulty: 60_000_000.into(),
+            target_time: 300,
         });
         algos.insert(PowAlgorithm::Monero, PowAlgorithmConstants {
             max_target_time: 1200,
             min_difficulty: 60_000.into(),
-            max_difficulty: u64::MAX.into(),
-            target_time: 20,
+            max_difficulty: 60_000.into(),
+            target_time: 200,
         });
         let mut algos2 = HashMap::new();
         // seting sha3/monero to 40/60 split

--- a/base_layer/core/src/consensus/consensus_manager.rs
+++ b/base_layer/core/src/consensus/consensus_manager.rs
@@ -128,8 +128,6 @@ impl ConsensusManager {
         TargetDifficultyWindow::new(
             usize::try_from(block_window).expect("difficulty block window exceeds usize::MAX"),
             constants.get_diff_target_block_interval(pow_algo),
-            constants.min_pow_difficulty(pow_algo),
-            constants.max_pow_difficulty(pow_algo),
             constants.get_difficulty_max_block_interval(pow_algo),
         )
     }

--- a/base_layer/core/src/proof_of_work/difficulty.rs
+++ b/base_layer/core/src/proof_of_work/difficulty.rs
@@ -108,7 +108,7 @@ pub trait DifficultyAdjustment {
     ) -> Result<(), DifficultyAdjustmentError>;
 
     /// Return the calculated target difficulty for the next block.
-    fn get_difficulty(&self) -> Difficulty;
+    fn get_difficulty(&self) -> Option<Difficulty>;
 }
 
 #[cfg(feature = "base_node")]

--- a/base_layer/core/src/proof_of_work/lwma_diff.rs
+++ b/base_layer/core/src/proof_of_work/lwma_diff.rs
@@ -21,24 +21,22 @@ pub struct LinearWeightedMovingAverage {
     target_difficulties: Vec<(EpochTime, Difficulty)>,
     block_window: usize,
     target_time: u64,
-    initial_difficulty: Difficulty,
     max_block_time: u64,
 }
 
 impl LinearWeightedMovingAverage {
-    pub fn new(block_window: usize, target_time: u64, initial_difficulty: Difficulty, max_block_time: u64) -> Self {
+    pub fn new(block_window: usize, target_time: u64, max_block_time: u64) -> Self {
         Self {
             target_difficulties: Vec::with_capacity(block_window + 1),
             block_window,
             target_time,
-            initial_difficulty,
             max_block_time,
         }
     }
 
-    fn calculate(&self) -> Difficulty {
+    fn calculate(&self) -> Option<Difficulty> {
         if self.target_difficulties.len() <= 1 {
-            return self.initial_difficulty;
+            return None;
         }
 
         // Use the array length rather than block_window to include early cases where the no. of pts < block_window
@@ -99,7 +97,7 @@ impl LinearWeightedMovingAverage {
         }
         let target = target.ceil() as u64; // difficulty difference of 1 should not matter much, but difficulty should never be below 1, ceil(0.9) = 1
         trace!(target: LOG_TARGET, "New target difficulty: {}", target);
-        target.into()
+        Some(target.into())
     }
 
     #[inline]
@@ -151,7 +149,7 @@ impl DifficultyAdjustment for LinearWeightedMovingAverage {
         Ok(())
     }
 
-    fn get_difficulty(&self) -> Difficulty {
+    fn get_difficulty(&self) -> Option<Difficulty> {
         self.calculate()
     }
 }

--- a/base_layer/core/src/validation/header_validator.rs
+++ b/base_layer/core/src/validation/header_validator.rs
@@ -44,7 +44,12 @@ impl HeaderValidator {
     {
         let difficulty_window = fetch_target_difficulty(db, &self.rules, block_header.pow_algo(), block_header.height)?;
 
-        let target = difficulty_window.calculate();
+        let constants = self.rules.consensus_constants(block_header.height);
+
+        let target = difficulty_window.calculate(
+            constants.min_pow_difficulty(block_header.pow.pow_algo),
+            constants.max_pow_difficulty(block_header.pow.pow_algo),
+        );
         Ok((
             check_target_difficulty(block_header, target, &self.randomx_factory)?,
             target,


### PR DESCRIPTION
An alternative fix to #2603 and #2602 

The main theory here is that the caller of `TargetDifficultyWindow::calculate()` has control of the max and min values allowed, and thus can use the latest constants for that height. My assumption is that if this is done at every point where the target difficulty is calculated just before it is saved to the database, it will always be within the bounds of the consensus constants for that height