### PR TITLE
Restore get_network_difficulty grpc method

### DIFF
--- a/applications/tari_app_grpc/proto/base_node.proto
+++ b/applications/tari_app_grpc/proto/base_node.proto
@@ -85,6 +85,7 @@ message NetworkDifficultyResponse {
     uint64 estimated_hash_rate = 2;
     uint64 height = 3;
     uint64 timestamp = 4;
+    uint64 pow_algo = 5;
 }
 
 // A generic single value response for a specific height

--- a/applications/tari_base_node/src/grpc/base_node_grpc_server.rs
+++ b/applications/tari_base_node/src/grpc/base_node_grpc_server.rs
@@ -57,8 +57,8 @@ const GET_TOKENS_IN_CIRCULATION_PAGE_SIZE: usize = 1_000;
 // The maximum number of difficulty ints that can be requested at a time. These will be streamed to the
 // client, so memory is not really a concern here, but a malicious client could request a large
 // number here to keep the node busy
-// const GET_DIFFICULTY_MAX_HEIGHTS: usize = 10_000;
-// const GET_DIFFICULTY_PAGE_SIZE: usize = 1_000;
+const GET_DIFFICULTY_MAX_HEIGHTS: usize = 10_000;
+const GET_DIFFICULTY_PAGE_SIZE: usize = 1_000;
 // The maximum number of headers a client can request at a time. If the client requests more than
 // this, this is the maximum that will be returned.
 const LIST_HEADERS_MAX_NUM_HEADERS: u64 = 10_000;
@@ -116,113 +116,133 @@ impl tari_rpc::base_node_server::BaseNode for BaseNodeGrpcServer {
     type ListHeadersStream = mpsc::Receiver<Result<tari_rpc::BlockHeader, Status>>;
     type SearchKernelsStream = mpsc::Receiver<Result<tari_rpc::HistoricalBlock, Status>>;
 
-    #[allow(deprecated)]
     async fn get_network_difficulty(
         &self,
-        _request: Request<tari_rpc::HeightRequest>,
+        request: Request<tari_rpc::HeightRequest>,
     ) -> Result<Response<Self::GetNetworkDifficultyStream>, Status>
     {
-        unimplemented!("Need to fix where target difficulty comes from")
-        // let request = request.into_inner();
-        // debug!(
-        //     target: LOG_TARGET,
-        //     "Incoming GRPC request for GetNetworkDifficulty: from_tip: {:?} start_height: {:?} end_height: {:?}",
-        //     request.from_tip,
-        //     request.start_height,
-        //     request.end_height
-        // );
-        // let mut handler = self.node_service.clone();
-        // let mut heights: Vec<u64> = get_heights(&request, handler.clone()).await?;
-        // heights = heights
-        //     .drain(..cmp::min(heights.len(), GET_DIFFICULTY_MAX_HEIGHTS))
-        //     .collect();
-        // let (mut tx, rx) = mpsc::channel(GET_DIFFICULTY_MAX_HEIGHTS);
-        //
-        // self.executor.spawn(async move {
-        //     let mut page: Vec<u64> = heights
-        //         .drain(..cmp::min(heights.len(), GET_DIFFICULTY_PAGE_SIZE))
-        //         .collect();
-        //     while !page.is_empty() {
-        //         let mut difficulties = match handler.get_headers(page.clone()).await {
-        //             Err(err) => {
-        //                 warn!(
-        //                     target: LOG_TARGET,
-        //                     "Error communicating with local base node: {:?}", err,
-        //                 );
-        //                 return;
-        //             },
-        //             Ok(mut data) => {
-        //                 data.sort_by(|a, b| a.height.cmp(&b.height));
-        //                 let mut iter = data.iter().peekable();
-        //                 let mut result = Vec::new();
-        //                 while let Some(next) = iter.next() {
-        //                     let current_difficulty: u64 = unimplemented!("Need to retrieve difficulty correctly");
-        //                     let current_timestamp = next.timestamp.as_u64();
-        //                     let current_height = next.height;
-        //                     let estimated_hash_rate = if let Some(peek) = iter.peek() {
-        //                         let peeked_timestamp = peek.timestamp.as_u64();
-        //                         // Sometimes blocks can have the same timestamp, lucky miner and some clock drift.
-        //                         if peeked_timestamp > current_timestamp {
-        //                             current_difficulty / (peeked_timestamp - current_timestamp)
-        //                         } else {
-        //                             0
-        //                         }
-        //                     } else {
-        //                         0
-        //                     };
-        //
-        //                     result.push((
-        //                         current_height,
-        //                         current_difficulty,
-        //                         estimated_hash_rate,
-        //                         current_timestamp,
-        //                     ))
-        //                 }
-        //
-        //                 result
-        //             },
-        //         };
-        //         difficulties.sort_by(|a, b| b.0.cmp(&a.0));
-        //         let result_size = difficulties.len();
-        //         for difficulty in difficulties {
-        //             match tx
-        //                 .send(Ok({
-        //                     tari_rpc::NetworkDifficultyResponse {
-        //                         height: difficulty.0,
-        //                         difficulty: difficulty.1,
-        //                         estimated_hash_rate: difficulty.2,
-        //                         timestamp: difficulty.3,
-        //                     }
-        //                 }))
-        //                 .await
-        //             {
-        //                 Ok(_) => (),
-        //                 Err(err) => {
-        //                     warn!(target: LOG_TARGET, "Error sending difficulty via GRPC:  {}", err);
-        //                     match tx.send(Err(Status::unknown("Error sending data"))).await {
-        //                         Ok(_) => (),
-        //                         Err(send_err) => {
-        //                             warn!(target: LOG_TARGET, "Error sending error to GRPC client: {}", send_err)
-        //                         },
-        //                     }
-        //                     return;
-        //                 },
-        //             }
-        //         }
-        //         if result_size < GET_DIFFICULTY_PAGE_SIZE {
-        //             break;
-        //         }
-        //         page = heights
-        //             .drain(..cmp::min(heights.len(), GET_DIFFICULTY_PAGE_SIZE))
-        //             .collect();
-        //     }
-        // });
-        //
-        // debug!(
-        //     target: LOG_TARGET,
-        //     "Sending GetNetworkDifficulty response stream to client"
-        // );
-        // Ok(Response::new(rx))
+        let request = request.into_inner();
+        debug!(
+            target: LOG_TARGET,
+            "Incoming GRPC request for GetNetworkDifficulty: from_tip: {:?} start_height: {:?} end_height: {:?}",
+            request.from_tip,
+            request.start_height,
+            request.end_height
+        );
+        let mut handler = self.node_service.clone();
+        let mut heights: Vec<u64> = get_heights(&request, handler.clone()).await?;
+        heights = heights
+            .drain(..cmp::min(heights.len(), GET_DIFFICULTY_MAX_HEIGHTS))
+            .collect();
+        let (mut tx, rx) = mpsc::channel(GET_DIFFICULTY_MAX_HEIGHTS);
+
+        self.executor.spawn(async move {
+            let mut page: Vec<u64> = heights
+                .drain(..cmp::min(heights.len(), GET_DIFFICULTY_PAGE_SIZE))
+                .collect();
+            while !page.is_empty() {
+                let mut difficulties = match handler.get_headers(page.clone()).await {
+                    Err(err) => {
+                        warn!(
+                            target: LOG_TARGET,
+                            "Error communicating with local base node: {:?}", err,
+                        );
+                        return;
+                    },
+                    Ok(mut data) => {
+                        data.sort_by(|a, b| a.height.cmp(&b.height));
+                        let mut iter = data.iter().peekable();
+                        let mut result = Vec::new();
+                        while let Some(next) = iter.next() {
+                            match handler.get_blocks(vec![next.height]).await {
+                                Err(err) => {
+                                    warn!(
+                                        target: LOG_TARGET,
+                                        "Error communicating with local base node: {:?}", err,
+                                    );
+                                    return;
+                                },
+                                Ok(blocks) => {
+                                    match blocks.first() {
+                                        Some(block) => {
+                                            let current_difficulty: u64 =
+                                                block.accumulated_data.target_difficulty.as_u64();
+                                            let current_timestamp = next.timestamp.as_u64();
+                                            let current_height = next.height;
+                                            let pow_algo = next.pow.pow_algo.as_u64();
+                                            let estimated_hash_rate = if let Some(peek) = iter.peek() {
+                                                let peeked_timestamp = peek.timestamp.as_u64();
+                                                // Sometimes blocks can have the same timestamp, lucky miner and some
+                                                // clock drift.
+                                                if peeked_timestamp > current_timestamp {
+                                                    current_difficulty / (peeked_timestamp - current_timestamp)
+                                                } else {
+                                                    0
+                                                }
+                                            } else {
+                                                0
+                                            };
+                                            result.push((
+                                                current_difficulty,
+                                                estimated_hash_rate,
+                                                current_height,
+                                                current_timestamp,
+                                                pow_algo,
+                                            ))
+                                        },
+                                        None => {
+                                            return;
+                                        },
+                                    }
+                                },
+                            };
+                        }
+                        result
+                    },
+                };
+
+                difficulties.sort_by(|a, b| b.2.cmp(&a.2));
+                let result_size = difficulties.len();
+                for difficulty in difficulties {
+                    match tx
+                        .send(Ok({
+                            tari_rpc::NetworkDifficultyResponse {
+                                difficulty: difficulty.0,
+                                estimated_hash_rate: difficulty.1,
+                                height: difficulty.2,
+                                timestamp: difficulty.3,
+                                pow_algo: difficulty.4,
+                            }
+                        }))
+                        .await
+                    {
+                        Ok(_) => (),
+                        Err(err) => {
+                            warn!(target: LOG_TARGET, "Error sending difficulty via GRPC:  {}", err);
+                            match tx.send(Err(Status::unknown("Error sending data"))).await {
+                                Ok(_) => (),
+                                Err(send_err) => {
+                                    warn!(target: LOG_TARGET, "Error sending error to GRPC client: {}", send_err)
+                                },
+                            }
+                            return;
+                        },
+                    }
+                }
+                if result_size < GET_DIFFICULTY_PAGE_SIZE {
+                    break;
+                }
+                page = heights
+                    .drain(..cmp::min(heights.len(), GET_DIFFICULTY_PAGE_SIZE))
+                    .collect();
+            }
+        });
+
+        debug!(
+            target: LOG_TARGET,
+            "Sending GetNetworkDifficulty response stream to client"
+        );
+        Ok(Response::new(rx))
     }
 
     async fn list_headers(


### PR DESCRIPTION
## Description
This PR restores the get_network_difficulty method for the block explorer, the difficulty is now returned as according to the target_difficulty, it also adds and extra field which returns which algorithm was used to mine the block.

## Motivation and Context
Required by the block explorer

## How Has This Been Tested?
Tested locally

## Types of changes
* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
* [x] I'm merging against the `development` branch.
* [x] I ran `cargo-fmt --all` before pushing.
* [ ] I ran `cargo test` successfully before submitting my PR.
* [x] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
