### PR TITLE
Cucumber test for GRPC method relating to block explorer

### DIFF
--- a/integration_tests/features/BlockExplorerGRPC.feature
+++ b/integration_tests/features/BlockExplorerGRPC.feature
@@ -1,0 +1,12 @@
+@block-explorer
+Feature: Block Explorer GRPC
+
+  @critical
+  Scenario: GetNetworkDifficulty
+    Given I have a seed node NODE
+    And I have wallet WALLET connected to all seed nodes
+    And I have a merge mining proxy PROXY connected to NODE and WALLET
+    When I merge mine 2 blocks via PROXY
+    Then all nodes are at height 2
+    When I request the difficulties of a node NODE
+    Then Difficulties are available

--- a/integration_tests/features/support/steps.js
+++ b/integration_tests/features/support/steps.js
@@ -394,3 +394,21 @@ Then(/Transaction status of last result from (.*) to (.*) is known to both walle
     expect(found[0] && found[1]).to.equal(true);
 });
 
+When(/I request the difficulties of a node (.*)/, async function (node) {
+          let client = this.getClient(node);
+          let difficulties = await client.getNetworkDifficulties(2,0,2);
+          this.lastResult = difficulties;
+});
+
+Then('Difficulties are available', function () {
+           console.log(this.lastResult);
+           assert(this.lastResult.length,3);
+           // check genesis block, chain in reverse height order
+           assert(this.lastResult[2]["difficulty"],'1');
+           assert(this.lastResult[2]["estimated_hash_rate"],'0');
+           assert(this.lastResult[2]["height"],'1');
+           assert(this.lastResult[2]["pow_algo"],'0');
+
+});
+
+

--- a/integration_tests/helpers/baseNodeClient.js
+++ b/integration_tests/helpers/baseNodeClient.js
@@ -43,6 +43,10 @@ class BaseNodeClient {
         })
     }
 
+    getNetworkDifficulties(tip,start,end) {
+            return this.client.getNetworkDifficulty().sendMessage({from_tip: tip, start_height: start, end_height:end});
+        }
+
     getPeers() {
         return this.client.getPeers().sendMessage({}).then(peers=> {
             console.log("Got ", peers.length," peers:");


### PR DESCRIPTION
## Description
The Block Explorer depends on the GetNetworkDifficulty method, adding cucumber test to prevent its' accidental removal or deprecation

## Motivation and Context
As above

## How Has This Been Tested?
Manually run the test

## Types of changes
* [ ] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [x] New Tests
* [ ] Documentation

## Checklist:
* [x] I'm merging against the `development` branch.
* [x] I ran `cargo-fmt --all` before pushing.
* [x] I ran `cargo test` successfully before submitting my PR.
* [x] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
