### PR TITLE
submit_block returns OK if block was submitted for tari or monero

### DIFF
--- a/applications/tari_merge_mining_proxy/src/helpers.rs
+++ b/applications/tari_merge_mining_proxy/src/helpers.rs
@@ -37,11 +37,9 @@ use tari_core::{
 pub fn deserialize_monero_block_from_hex<T>(data: T) -> Result<Block, MmProxyError>
 where T: AsRef<[u8]> {
     let bytes = hex::decode(data)?;
-    let obj = deserialize::<Block>(&bytes);
-    match obj {
-        Ok(obj) => Ok(obj),
-        Err(_e) => Err(MmProxyError::MissingDataError("blocktemplate blob invalid".to_string())),
-    }
+    let obj = deserialize::<Block>(&bytes)
+        .map_err(|_| MmProxyError::MissingDataError("blocktemplate blob invalid".to_string()))?;
+    Ok(obj)
 }
 
 pub fn serialize_monero_block_to_hex(obj: &Block) -> Result<String, MmProxyError> {

--- a/applications/tari_merge_mining_proxy/src/json_rpc.rs
+++ b/applications/tari_merge_mining_proxy/src/json_rpc.rs
@@ -1,0 +1,77 @@
+//  Copyright 2021, The Tari Project
+//
+//  Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+//  following conditions are met:
+//
+//  1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+//  disclaimer.
+//
+//  2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+//  following disclaimer in the documentation and/or other materials provided with the distribution.
+//
+//  3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+//  products derived from this software without specific prior written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+//  INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+//  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+//  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+//  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+//  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+//  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+use json::json;
+use serde_json as json;
+
+/// Create a JSON RPC success response
+/// More info: https://www.jsonrpc.org/specification#response_object
+pub fn success_response(req_id: Option<i64>, result: json::Value) -> json::Value {
+    json!({
+       "id": req_id.unwrap_or(-1),
+       "jsonrpc": "2.0",
+       "result": result,
+       "status": "OK",
+       "untrusted": false
+    })
+}
+
+/// Create a standard JSON RPC error response
+/// More info: https://www.jsonrpc.org/specification#error_object
+pub fn standard_error_response(
+    req_id: Option<i64>,
+    err: jsonrpc::error::StandardError,
+    data: Option<json::Value>,
+) -> json::Value
+{
+    let err = jsonrpc::error::standard_error(err, data);
+    json!({
+        "id":  req_id.unwrap_or(-1),
+        "jsonrpc": "2.0",
+        "error": err,
+    })
+}
+
+/// Create a JSON RPC error response
+/// More info: https://www.jsonrpc.org/specification#error_object
+pub fn error_response(
+    req_id: Option<i64>,
+    err_code: i32,
+    err_message: &str,
+    err_data: Option<json::Value>,
+) -> json::Value
+{
+    let mut err = json!({
+        "code": err_code,
+        "message": err_message,
+    });
+
+    if let Some(d) = err_data {
+        err["error"]["data"] = d;
+    }
+
+    json!({
+        "id":  req_id.unwrap_or(-1),
+        "jsonrpc": "2.0",
+        "error": err
+    })
+}

--- a/applications/tari_merge_mining_proxy/src/main.rs
+++ b/applications/tari_merge_mining_proxy/src/main.rs
@@ -31,7 +31,9 @@
 mod block_template_data;
 mod error;
 mod helpers;
+mod json_rpc;
 mod proxy;
+
 #[cfg(test)]
 mod test;
 

--- a/applications/tari_merge_mining_proxy/src/proxy.rs
+++ b/applications/tari_merge_mining_proxy/src/proxy.rs
@@ -24,6 +24,7 @@ use crate::{
     block_template_data::{BlockTemplateDataBuilder, BlockTemplateRepository},
     error::MmProxyError,
     helpers,
+    json_rpc,
 };
 use bytes::BytesMut;
 use futures::{StreamExt, TryFutureExt};
@@ -40,6 +41,7 @@ use hyper::{
     Uri,
     Version,
 };
+use json::json;
 use jsonrpc::error::StandardError;
 use reqwest::{ResponseBuilderExt, Url};
 use serde_json as json;
@@ -55,6 +57,7 @@ use std::{
         Arc,
     },
     task::{Context, Poll},
+    time::Instant,
 };
 use tari_app_grpc::{tari_rpc as grpc, tari_rpc::GetCoinbaseRequest};
 use tari_common::{GlobalConfig, Network};
@@ -62,10 +65,11 @@ use tari_core::{
     blocks::{Block, NewBlockTemplate},
     proof_of_work::monero_rx,
 };
-use tokio::runtime::Handle;
 use tracing::{debug, error, info, instrument, trace, warn};
 
-pub const LOG_TARGET: &str = "tari_mm_proxy::proxy";
+const LOG_TARGET: &str = "tari_mm_proxy::proxy";
+/// The JSON object key name used for merge mining proxy response extensions
+pub(crate) const MMPROXY_EXTENSIONS_KEY_NAME: &str = "_merge_mining";
 
 #[derive(Debug, Clone)]
 pub struct MergeMiningProxyConfig {
@@ -225,7 +229,15 @@ impl Service<Request<Body>> for MergeMiningProxyService {
 
                     Ok(Response::builder()
                         .status(StatusCode::INTERNAL_SERVER_ERROR)
-                        .body(standard_rpc_error(StandardError::InternalError, None))
+                        .body(
+                            json::to_string(&json_rpc::standard_error_response(
+                                None,
+                                StandardError::InternalError,
+                                None,
+                            ))
+                            .expect("unexpected failure")
+                            .into(),
+                        )
                         .unwrap())
                 },
             }
@@ -285,7 +297,7 @@ impl InnerService {
             "Monero height = #{}, Tari base node height = #{}", json["height"], height
         );
 
-        json["height"] = json::json!(cmp::max(json["height"].as_i64().unwrap_or_default(), height as i64));
+        json["height"] = json!(cmp::max(json["height"].as_i64().unwrap_or_default(), height as i64));
 
         Ok(into_body(parts, json))
     }
@@ -296,96 +308,117 @@ impl InnerService {
         monerod_resp: Response<json::Value>,
     ) -> Result<Response<Body>, MmProxyError>
     {
-        debug!(
-            target: LOG_TARGET,
-            "handle_submit_block: submit request #{}",
-            request.body()
-        );
+        let request = request.body();
+        let (parts, mut json_resp) = monerod_resp.into_parts();
+
+        debug!(target: LOG_TARGET, "handle_submit_block: submit request #{}", request);
         debug!(
             target: LOG_TARGET,
             "Params received: #{:?}",
-            request.body()["params"].as_array()
+            request["params"].as_array()
         );
-        let params = match request.body()["params"].as_array() {
+        let params = match request["params"].as_array() {
             Some(v) => v,
             None => {
                 return Ok(Response::builder()
-                    .body(standard_rpc_error(
-                        StandardError::InvalidParams,
-                        Some(
-                            "`params` field is empty or an invalid type for submit block request. Expected an array."
-                                .into(),
-                        ),
-                    ))
-                    .unwrap())
+                    .body(
+                        json::to_string(&json_rpc::standard_error_response(
+                            request["id"].as_i64(),
+                            StandardError::InvalidParams,
+                            Some(
+                                "`params` field is empty or an invalid type for submit block request. Expected an \
+                                 array."
+                                    .into(),
+                            ),
+                        ))
+                        .unwrap()
+                        .into(),
+                    )
+                    .unwrap());
             },
         };
 
-        let handle = Handle::current();
-        for param in params.iter().map(|p| p.as_str()).filter_map(|p| p) {
+        for param in params.iter().filter_map(|p| p.as_str()) {
             let monero_block = helpers::deserialize_monero_block_from_hex(param)?;
             debug!(target: LOG_TARGET, "Monero block: {}", monero_block);
-            let hash = match helpers::extract_tari_hash(&monero_block) {
-                Some(h) => *h,
+            let hash = helpers::extract_tari_hash(&monero_block)
+                .copied()
+                .ok_or_else(|| MmProxyError::MissingDataError("Could not find Tari header in coinbase".to_string()))?;
+
+            debug!(
+                target: LOG_TARGET,
+                "Tari Hash found in Monero block: {}",
+                hex::encode(&hash)
+            );
+
+            let mut block_data = match self.block_templates.get(&hash).await {
+                Some(d) => d,
                 None => {
-                    return Err(MmProxyError::MissingDataError(
-                        "Could not find Tari header in coinbase".to_string(),
-                    ))
+                    info!(
+                        target: LOG_TARGET,
+                        "Block `{}` submitted but no matching block template was found, possible duplicate submission",
+                        hex::encode(&hash)
+                    );
+                    continue;
                 },
             };
 
-            debug!(target: LOG_TARGET, "Located Tari Hash: {:?}", hash);
+            let monero_data = helpers::construct_monero_data(monero_block, block_data.monero_seed.clone())?;
 
-            if let Some(mut block_data) = self.block_templates.get(&hash).await {
-                let monero_data = helpers::construct_monero_data(monero_block, block_data.clone().monero_seed)?;
+            let header_mut = block_data.tari_block.header.as_mut().unwrap();
+            let height = header_mut.height;
+            header_mut.pow.as_mut().unwrap().pow_data = bincode::serialize(&monero_data)?;
 
-                let pow_data = bincode::serialize(&monero_data)?;
-                let h = block_data.tari_block.header.as_mut().unwrap();
-                let height = h.height;
-                let p = h.pow.as_mut().unwrap();
-                p.pow_data = pow_data;
+            let mut base_node_client = self.connect_grpc_client().await?;
+            let start = Instant::now();
+            match base_node_client.submit_block(block_data.tari_block).await {
+                Ok(_) => {
+                    json_resp = json_rpc::success_response(
+                        json_resp["id"].as_i64(),
+                        json!({
+                            "status": "OK"
+                        }),
+                    );
 
-                let mut base_node_client = self.connect_grpc_client().await?;
-                let mut block_templates_clone = self.block_templates.clone();
-                let block_data_clone = block_data.clone();
-                handle.spawn(async move {
-                    let start = std::time::Instant::now();
-                    match base_node_client
-                        .submit_block(block_data_clone.tari_block)
-                        .await
-                        .map_err(|status| MmProxyError::GrpcRequestError {
-                            status,
-                            details: "failed to submit block".to_string(),
-                        }) {
-                        Ok(..) => {
-                            debug!(
-                                target: LOG_TARGET,
-                                "Submitted block #{} to Tari node in {:.0?} (SubmitBlock)",
-                                height,
-                                start.elapsed()
-                            );
-                            block_templates_clone.remove(&hash).await;
-                        },
-                        _ => debug!(
-                            target: LOG_TARGET,
-                            "Problem submitting block #{} to Tari node, responded in  {:.0?} (SubmitBlock)",
-                            height,
-                            start.elapsed()
-                        ),
+                    debug!(
+                        target: LOG_TARGET,
+                        "Submitted block #{} to Tari node in {:.0?} (SubmitBlock)",
+                        height,
+                        start.elapsed()
+                    );
+                    self.block_templates.remove(&hash).await;
+                },
+                Err(err) => {
+                    debug!(
+                        target: LOG_TARGET,
+                        "Problem submitting block #{} to Tari node, responded in  {:.0?} (SubmitBlock): {}",
+                        height,
+                        start.elapsed(),
+                        err
+                    );
+
+                    // Because `config.proxy_submit_to_origin` could be set to `false`, monerod would not have been
+                    // called. In this case, let's add a block not accepted error if Tari rejected the block
+                    // If `config.proxy_submit_to_origin == true` then whatever monerod returned (success or fail)
+                    // should be returned.
+                    const MONERO_RPC_ERROR_CODE_BLOCK_NOT_ACCEPTED: i32 = -7;
+                    if !self.config.proxy_submit_to_origin {
+                        json_resp = json_rpc::error_response(
+                            request["id"].as_i64(),
+                            MONERO_RPC_ERROR_CODE_BLOCK_NOT_ACCEPTED,
+                            "Block not accepted",
+                            None,
+                        );
                     }
-
-                    block_templates_clone.remove_outdated().await;
-                });
-            } else {
-                info!(
-                    target: LOG_TARGET,
-                    "Block submitted but no matching block template was found, possible duplicate submission"
-                );
+                },
             }
+
+            self.block_templates.remove_outdated().await;
         }
+
+        debug!(target: LOG_TARGET, "Sending submit_block response {}", json_resp);
         // Return the Monero response as is
-        let (parts, json) = monerod_resp.into_parts();
-        Ok(into_body(parts, json))
+        Ok(into_body(parts, json_resp))
     }
 
     async fn handle_get_block_template(
@@ -477,7 +510,7 @@ impl InnerService {
             new_block_template.header.as_ref().map(|h| h.height).unwrap_or_default(),
         );
 
-        let template_block = NewBlockTemplate::try_from(new_block_template.clone())
+        let template_block = NewBlockTemplate::try_from(new_block_template)
             .map_err(|e| MmProxyError::MissingDataError(format!("GRPC Conversion Error: {}", e)))?;
 
         debug!(target: LOG_TARGET, "Trying to connect to wallet");
@@ -567,6 +600,12 @@ impl InnerService {
             "Difficulties: Tari ({}), Monero({}), Selected({})", tari_difficulty, monero_difficulty, mining_difficulty
         );
         monerod_resp["result"]["difficulty"] = mining_difficulty.into();
+        let monerod_resp = add_mmproxy_extensions(
+            monerod_resp,
+            json!({
+                "difficulties": {"xmr": monero_difficulty, "xtr": tari_difficulty}
+            }),
+        );
 
         debug!(target: LOG_TARGET, "Returning template result: {}", monerod_resp);
         Ok(into_body(parts, monerod_resp))
@@ -635,14 +674,7 @@ impl InnerService {
         let json_response;
         if submit_block && !self.config.proxy_submit_to_origin {
             // Assume it would be accepted
-            let req_id = json["id"].as_i64().unwrap_or_else(|| -1);
-            let accept_response = json::json!({
-               "id": req_id,
-               "jsonrpc": "2.0",
-               "result": "{}",
-               "status": "OK",
-               "untrusted": false
-            });
+            let accept_response = json_rpc::success_response(json["id"].as_i64(), json!({}));
             json_response =
                 convert_json_to_hyper_json_response(accept_response, StatusCode::OK, monerod_uri.clone()).await?;
         } else {
@@ -685,11 +717,10 @@ impl InnerService {
                 // Try parse the request into JSON, it is allowed fail because if we've made it this far, then monerod
                 // accepted the request
                 let json = json::from_slice::<json::Value>(request.body())?;
-                let json_method = json.clone();
                 let request = request.map(move |_| json);
                 // All post requests go to /json_rpc, body of request contains a field `method` to indicate which call
                 // takes place.
-                match json_method["method"].as_str().unwrap_or_default() {
+                match request.body()["method"].as_str().unwrap_or_default() {
                     "submitblock" | "submit_block" => self.handle_submit_block(request, monerod_resp).await,
                     "getblocktemplate" | "get_block_template" => self.handle_get_block_template(monerod_resp).await,
                     _ => Ok(into_body_from_response(monerod_resp)),
@@ -717,16 +748,6 @@ impl InnerService {
         let response = self.get_proxy_response(request, monerod_resp).await?;
         Ok(response)
     }
-}
-
-fn standard_rpc_error(err: jsonrpc::error::StandardError, data: Option<json::Value>) -> Body {
-    // TODO: jsonrpc's API is not particularly ergonomic
-    json::to_string(&jsonrpc::error::result_to_response(
-        Err(jsonrpc::error::standard_error(err, data)),
-        json::Value::from(-1i32),
-    ))
-    .expect("jsonrpc's serialization implementation is expected to always succeed")
-    .into()
 }
 
 async fn convert_json_to_hyper_json_response(
@@ -783,11 +804,30 @@ fn into_body_from_response<T: ToString>(resp: Response<T>) -> Response<Body> {
 
 /// Reads the `Body` until there is no more to read
 pub(super) async fn read_body_until_end(body: &mut Body) -> Result<BytesMut, MmProxyError> {
-    // TOOD: Perhaps there is a more efficient way to do this
+    // TODO: Perhaps there is a more efficient way to do this
     let mut bytes = BytesMut::new();
     while let Some(data) = body.next().await {
         let data = data?;
         bytes.extend(data);
     }
     Ok(bytes)
+}
+
+/// Add mmproxy extensions object to JSON RPC success response
+pub fn add_mmproxy_extensions(mut response: json::Value, mut ext: json::Value) -> json::Value {
+    if response["result"].is_null() {
+        return response;
+    }
+    match response["result"][MMPROXY_EXTENSIONS_KEY_NAME].as_object_mut() {
+        Some(obj_mut) => {
+            let ext_mut = ext
+                .as_object_mut()
+                .expect("invalid parameter: expected `ext: json::Value` to be an object but it was not");
+            obj_mut.append(ext_mut);
+        },
+        None => {
+            response["result"][MMPROXY_EXTENSIONS_KEY_NAME] = ext;
+        },
+    }
+    response
 }

--- a/applications/tari_merge_mining_proxy/src/test.rs
+++ b/applications/tari_merge_mining_proxy/src/test.rs
@@ -71,3 +71,38 @@ mod merge_mining_proxy_service {
         assert_eq!(json["error"]["message"], "Internal error");
     }
 }
+
+mod add_mmproxy_extensions {
+    use crate::{
+        json_rpc,
+        proxy::{add_mmproxy_extensions, MMPROXY_EXTENSIONS_KEY_NAME},
+    };
+    use serde_json::json;
+
+    #[test]
+    fn it_adds_extension_data() {
+        let v = json_rpc::success_response(None, json!({ "hello": "world"}));
+        let v = add_mmproxy_extensions(v, json!({"test": "works"}));
+        assert_eq!(
+            v["result"][MMPROXY_EXTENSIONS_KEY_NAME]["test"].as_str().unwrap(),
+            "works"
+        );
+    }
+
+    #[test]
+    fn it_appends_to_existing_extension_data() {
+        let v = json_rpc::success_response(None, json!({ "hello": "world"}));
+        let v = add_mmproxy_extensions(v, json!({"test1": 1}));
+        let v = add_mmproxy_extensions(v, json!({"test2": 2, "test3": 3}));
+        assert_eq!(v["result"][MMPROXY_EXTENSIONS_KEY_NAME]["test1"].as_u64().unwrap(), 1);
+        assert_eq!(v["result"][MMPROXY_EXTENSIONS_KEY_NAME]["test2"].as_u64().unwrap(), 2);
+        assert_eq!(v["result"][MMPROXY_EXTENSIONS_KEY_NAME]["test3"].as_u64().unwrap(), 3);
+    }
+
+    #[test]
+    fn it_does_not_add_data_to_errors() {
+        let v = json_rpc::error_response(None, 1, "it's on 🔥", None);
+        let v = add_mmproxy_extensions(v, json!({"it": "is broken"}));
+        assert!(v["result"][MMPROXY_EXTENSIONS_KEY_NAME]["it"].as_str().is_none());
+    }
+}


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Pool software expects for the submit block call to succeed if a block it
just mined was able to be submitted to the blockchain. Previously, if
the block was successfully submitted to the tari blockchain but not the
monero blockchain, the call would fail.

This PR changes the behaviour of submit_block to succeed if either a
tari or monero block succeeded.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
As in description.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested that the call succeeds on the pool-side and successfully mined blocks are noted by the pool.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [ ] I'm merging against the `development` branch.
* [ ] I ran `cargo-fmt --all` before pushing.
* [ ] I ran `cargo test` successfully before submitting my PR.
* [ ] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
