### PR TITLE
Add tx sending mechanism to wallet

### DIFF
--- a/applications/tari_base_node/src/bootstrap/wallet.rs
+++ b/applications/tari_base_node/src/bootstrap/wallet.rs
@@ -62,7 +62,7 @@ use tari_wallet::{
         sqlite_utilities::WalletDbConnection,
     },
     transaction_service::{
-        config::TransactionServiceConfig,
+        config::{TransactionRoutingMechanism, TransactionServiceConfig},
         storage::sqlite_db::TransactionServiceSqliteDatabase,
         TransactionServiceInitializer,
     },
@@ -159,6 +159,7 @@ impl WalletBootstrapper {
                     chain_monitoring_timeout: config.transaction_chain_monitoring_timeout,
                     direct_send_timeout: config.transaction_direct_send_timeout,
                     broadcast_send_timeout: config.transaction_broadcast_send_timeout,
+                    transaction_routing_mechanism: TransactionRoutingMechanism::from(config.transaction_routing_mechanism.clone()),
                     ..Default::default()
                 },
                 peer_message_subscriptions.clone(),

--- a/applications/tari_console_wallet/src/init/mod.rs
+++ b/applications/tari_console_wallet/src/init/mod.rs
@@ -68,7 +68,7 @@ use tari_wallet::{
         database::{DbKey, DbKeyValuePair, DbValue, WalletBackend, WriteOperation},
         sqlite_utilities::initialize_sqlite_database_backends,
     },
-    transaction_service::config::TransactionServiceConfig,
+    transaction_service::config::{TransactionRoutingMechanism, TransactionServiceConfig},
     wallet::WalletConfig,
     Wallet,
     WalletSqlite,
@@ -383,6 +383,9 @@ pub async fn init_wallet(
             chain_monitoring_timeout: config.transaction_chain_monitoring_timeout,
             direct_send_timeout: config.transaction_direct_send_timeout,
             broadcast_send_timeout: config.transaction_broadcast_send_timeout,
+            transaction_routing_mechanism: TransactionRoutingMechanism::from(
+                config.transaction_routing_mechanism.clone(),
+            ),
             ..Default::default()
         }),
         Some(OutputManagerServiceConfig {

--- a/base_layer/wallet/src/base_node_service/config.rs
+++ b/base_layer/wallet/src/base_node_service/config.rs
@@ -25,7 +25,7 @@ use std::time::Duration;
 
 const LOG_TARGET: &str = "wallet::base_node_service::config";
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct BaseNodeServiceConfig {
     pub refresh_interval: Duration,
     pub request_max_age: Duration,

--- a/base_layer/wallet/src/base_node_service/service.rs
+++ b/base_layer/wallet/src/base_node_service/service.rs
@@ -238,9 +238,6 @@ where
                 age <= self.config.request_max_age
             });
 
-        trace!(target: LOG_TARGET, "current requests: {:?}", current_requests);
-        trace!(target: LOG_TARGET, "discarded requests : {:?}", old_requests);
-
         self.requests = current_requests;
 
         // check if base node is offline
@@ -261,8 +258,6 @@ where
             .send_direct(dest_public_key, message)
             .await
             .map_err(BaseNodeServiceError::OutboundError)?;
-
-        debug!(target: LOG_TARGET, "Refresh chain metadata message sent");
 
         Ok(())
     }

--- a/base_layer/wallet/src/output_manager_service/config.rs
+++ b/base_layer/wallet/src/output_manager_service/config.rs
@@ -22,7 +22,7 @@
 
 use std::time::Duration;
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct OutputManagerServiceConfig {
     pub base_node_query_timeout: Duration,
     pub max_utxo_query_size: usize,

--- a/base_layer/wallet/src/transaction_service/config.rs
+++ b/base_layer/wallet/src/transaction_service/config.rs
@@ -21,11 +21,11 @@
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 use log::*;
-use std::time::Duration;
+use std::{fmt, time::Duration};
 
 const LOG_TARGET: &str = "wallet::transaction_service::config";
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct TransactionServiceConfig {
     pub broadcast_monitoring_timeout: Duration,
     pub chain_monitoring_timeout: Duration,
@@ -37,6 +37,7 @@ pub struct TransactionServiceConfig {
     pub pending_transaction_cancellation_timeout: Duration,
     pub num_confirmations_required: u64,
     pub peer_dial_retry_timeout: Duration,
+    pub transaction_routing_mechanism: TransactionRoutingMechanism,
 }
 
 impl Default for TransactionServiceConfig {
@@ -52,32 +53,48 @@ impl Default for TransactionServiceConfig {
             pending_transaction_cancellation_timeout: Duration::from_secs(259200), // 3 Days
             num_confirmations_required: 3,
             peer_dial_retry_timeout: Duration::from_secs(20),
+            transaction_routing_mechanism: TransactionRoutingMechanism::default(),
         }
     }
 }
 
-impl TransactionServiceConfig {
-    pub fn new(
-        broadcast_monitoring_timeout: Duration,
-        chain_monitoring_timeout: Duration,
-        direct_send_timeout: Duration,
-        broadcast_send_timeout: Duration,
-    ) -> Self
-    {
-        trace!(
-            target: LOG_TARGET,
-            "Timeouts - Broadcast monitoring: {} s, Chain monitoring: {} s, Direct send: {} s, Broadcast send: {} s",
-            broadcast_monitoring_timeout.as_secs(),
-            chain_monitoring_timeout.as_secs(),
-            direct_send_timeout.as_secs(),
-            broadcast_send_timeout.as_secs(),
-        );
-        Self {
-            broadcast_monitoring_timeout,
-            chain_monitoring_timeout,
-            direct_send_timeout,
-            broadcast_send_timeout,
-            ..Default::default()
+#[derive(Copy, Clone, PartialEq, Debug)]
+pub enum TransactionRoutingMechanism {
+    DirectOnly,
+    StoreAndForwardOnly,
+    DirectAndStoreAndForward,
+}
+
+impl fmt::Display for TransactionRoutingMechanism {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::DirectOnly => f.write_str("'DirectOnly'"),
+            Self::StoreAndForwardOnly => f.write_str("'StoreAndForwardOnly'"),
+            Self::DirectAndStoreAndForward => f.write_str("'DirectAndStoreAndForward'"),
         }
+    }
+}
+
+impl From<String> for TransactionRoutingMechanism {
+    fn from(value: String) -> Self {
+        match value.as_str() {
+            "DirectOnly" => Self::DirectOnly,
+            "StoreAndForwardOnly" => Self::StoreAndForwardOnly,
+            "DirectAndStoreAndForward" => Self::DirectAndStoreAndForward,
+            _ => {
+                warn!(
+                    target: LOG_TARGET,
+                    "Transaction sending mechanism config setting not recognized, using default value {}",
+                    Self::DirectAndStoreAndForward
+                );
+                Self::DirectAndStoreAndForward
+            },
+        }
+    }
+}
+
+impl Default for TransactionRoutingMechanism {
+    fn default() -> Self {
+        Self::DirectAndStoreAndForward
     }
 }

--- a/base_layer/wallet/src/transaction_service/protocols/transaction_receive_protocol.rs
+++ b/base_layer/wallet/src/transaction_service/protocols/transaction_receive_protocol.rs
@@ -159,6 +159,7 @@ where TBackend: TransactionBackend + 'static
                 inbound_transaction.clone(),
                 self.resources.outbound_message_service.clone(),
                 self.resources.config.direct_send_timeout,
+                self.resources.config.transaction_routing_mechanism,
             )
             .await
             .map_err(|e| TransactionServiceProtocolError::new(self.id, e))?;
@@ -287,6 +288,7 @@ where TBackend: TransactionBackend + 'static
                 inbound_tx.clone(),
                 self.resources.outbound_message_service.clone(),
                 self.resources.config.direct_send_timeout,
+                self.resources.config.transaction_routing_mechanism,
             )
             .await
             {
@@ -337,6 +339,7 @@ where TBackend: TransactionBackend + 'static
                             inbound_tx.clone(),
                             self.resources.outbound_message_service.clone(),
                             self.resources.config.direct_send_timeout,
+                            self.resources.config.transaction_routing_mechanism,
                         )
                         .await {
                             Ok(_) => self.resources

--- a/base_layer/wallet/src/transaction_service/service.rs
+++ b/base_layer/wallet/src/transaction_service/service.rs
@@ -677,6 +677,7 @@ where
                     source_pubkey.clone(),
                     self.resources.outbound_message_service.clone(),
                     self.resources.config.direct_send_timeout,
+                    self.resources.config.transaction_routing_mechanism,
                 ));
             }
 
@@ -944,6 +945,7 @@ where
                     inbound_tx,
                     self.resources.outbound_message_service.clone(),
                     self.resources.config.direct_send_timeout,
+                    self.resources.config.transaction_routing_mechanism,
                 ));
                 if let Err(e) = self.resources.db.increment_send_count(tx_id).await {
                     warn!(

--- a/base_layer/wallet/src/wallet.rs
+++ b/base_layer/wallet/src/wallet.rs
@@ -168,7 +168,7 @@ where
         #[cfg(feature = "test_harness")]
         let transaction_backend_handle = transaction_backend.clone();
 
-        let factories = config.factories;
+        let factories = config.clone().factories;
         let (publisher, subscription_factory) =
             pubsub_connector(runtime::Handle::current(), config.buffer_size, config.rate_limit);
         let peer_message_subscription_factory = Arc::new(subscription_factory);
@@ -176,6 +176,24 @@ where
         let node_identity = config.comms_config.node_identity.clone();
 
         debug!(target: LOG_TARGET, "Wallet Initializing");
+        info!(
+            target: LOG_TARGET,
+            "Transaction sending mechanism is {}",
+            config
+                .clone()
+                .transaction_service_config
+                .unwrap_or_default()
+                .transaction_routing_mechanism
+        );
+        trace!(
+            target: LOG_TARGET,
+            "Wallet config: {:?}, {:?}, {:?}, buffer_size: {}, rate_limit: {}",
+            config.base_node_service_config,
+            config.output_manager_service_config,
+            config.transaction_service_config,
+            config.buffer_size,
+            config.rate_limit
+        );
         let stack = StackBuilder::new(shutdown_signal)
             .add_initializer(P2pInitializer::new(config.comms_config, publisher))
             .add_initializer(OutputManagerServiceInitializer::new(

--- a/common/config/presets/windows.toml
+++ b/common/config/presets/windows.toml
@@ -99,6 +99,10 @@ base_node_query_timeout = 120
 # the transaction amount. Set this value to `false` to allow spending of "dust" UTXOs for small valued
 # transactions (default = true).
 #prevent_fee_gt_amount = false
+# This option specifies the transaction routing mechanism as being directly between wallets, making
+# use of store and forward or using any combination of these.
+# (options: "DirectOnly", "StoreAndForwardOnly", DirectAndStoreAndForward". default: "DirectAndStoreAndForward").
+#transaction_routing_mechanism = "DirectAndStoreAndForward"
 
 # When running the console wallet in command mode, use these values to determine what "stage" and timeout to wait
 # for sent transactions.

--- a/common/config/tari_config_example.toml
+++ b/common/config/tari_config_example.toml
@@ -99,6 +99,10 @@ base_node_query_timeout = 120
 # the transaction amount. Set this value to `false` to allow spending of "dust" UTXOs for small valued
 # transactions (default = true).
 #prevent_fee_gt_amount = false
+# This option specifies the transaction routing mechanism as being directly between wallets, making
+# use of store and forward or using any combination of these.
+# (options: "DirectOnly", "StoreAndForwardOnly", DirectAndStoreAndForward". default: "DirectAndStoreAndForward").
+#transaction_routing_mechanism = "DirectAndStoreAndForward"
 
 # When running the console wallet in command mode, use these values to determine what "stage" and timeout to wait
 # for sent transactions.

--- a/common/src/configuration/global.rs
+++ b/common/src/configuration/global.rs
@@ -96,6 +96,7 @@ pub struct GlobalConfig {
     pub transaction_chain_monitoring_timeout: Duration,
     pub transaction_direct_send_timeout: Duration,
     pub transaction_broadcast_send_timeout: Duration,
+    pub transaction_routing_mechanism: String,
     pub console_wallet_password: Option<String>,
     pub wallet_command_send_wait_stage: String,
     pub wallet_command_send_wait_timeout: u64,
@@ -441,6 +442,10 @@ fn convert_node_config(network: Network, cfg: Config) -> Result<GlobalConfig, Co
         .get_bool(&key)
         .map_err(|e| ConfigurationError::new(&key, &e.to_string()))?;
 
+    let key = "wallet.transaction_routing_mechanism";
+    let transaction_routing_mechanism =
+        optional(cfg.get_str(key))?.unwrap_or_else(|| "DirectAndStoreAndForward".to_string());
+
     let key = "wallet.command_send_wait_stage";
     let wallet_command_send_wait_stage = optional(cfg.get_str(key))?.unwrap_or_else(|| "Broadcast".to_string());
 
@@ -614,6 +619,7 @@ fn convert_node_config(network: Network, cfg: Config) -> Result<GlobalConfig, Co
         transaction_chain_monitoring_timeout,
         transaction_direct_send_timeout,
         transaction_broadcast_send_timeout,
+        transaction_routing_mechanism,
         console_wallet_password,
         wallet_command_send_wait_stage,
         wallet_command_send_wait_timeout,

--- a/common/src/configuration/utils.rs
+++ b/common/src/configuration/utils.rs
@@ -93,6 +93,10 @@ pub fn default_config(bootstrap: &ConfigBootstrap) -> Config {
     cfg.set_default("wallet.transaction_broadcast_send_timeout", 60)
         .unwrap();
     cfg.set_default("wallet.prevent_fee_gt_amount", true).unwrap();
+    cfg.set_default("wallet.transaction_routing_mechanism", "DirectAndStoreAndForward")
+        .unwrap();
+    cfg.set_default("wallet.command_send_wait_stage", "Broadcast").unwrap();
+    cfg.set_default("wallet.command_send_wait_timeout", 300).unwrap();
     cfg.set_default("wallet.base_node_service_peers", Vec::<String>::new())
         .unwrap();
 

--- a/integration_tests/README.md
+++ b/integration_tests/README.md
@@ -4,7 +4,10 @@
 
 - Install `Node.js`
 
-- Open terminal in the `tari-project\integration_tests` folder and run `npm install`
+- Open terminal in the `tari-project\integration_tests` folder and run 
+  ```
+  npm install
+  ```
 
 ## Procedure to run
 

--- a/integration_tests/features/TransactionInfo.feature
+++ b/integration_tests/features/TransactionInfo.feature
@@ -1,20 +1,26 @@
-@merge-mining
+@transaction-info
     Feature: Transaction Info
 
-    @critical
-        Scenario: Get Transaction Info
-            Given I have a seed node NODE
-            And I have 1 base nodes connected to all seed nodes
-            And I have wallet WALLET_A connected to all seed nodes
-            And I have wallet WALLET_B connected to all seed nodes
-            And I have a merge mining proxy PROXY connected to NODE and WALLET_A
-            When I merge mine 2 blocks via PROXY
-            Then all nodes are at height 2
-            When I wait 10 seconds
-            And I send 1000000 tari from WALLET_A to one wallet WALLET_B at fee 100
-            When I wait 10 seconds
-            Then Transaction status of last result from WALLET_A to WALLET_B is known to both wallets
-            When I merge mine 2 blocks via PROXY
-            Then all nodes are at height 4
-            When I wait 10 seconds
-            Then Transaction status of last result from WALLET_A to WALLET_B is known to both wallets
+    Scenario: Get Transaction Info
+        Given I have a seed node NODE
+        # TODO: This test takes an hour if only one base node is used
+        And I have 1 base nodes connected to all seed nodes
+        And I have wallet WALLET_A connected to all seed nodes
+        And I have wallet WALLET_B connected to all seed nodes
+        And I have a merge mining proxy PROXY connected to NODE and WALLET_A
+        When I merge mine 2 blocks via PROXY
+        Then all nodes are at height 2
+        When I wait for wallet WALLET_A to have more than 1002000 tari
+        And I send 1000000 tari from wallet WALLET_A to wallet WALLET_B at fee 100
+        Then wallet WALLET_A detects all transactions are at least pending
+        Then wallet WALLET_B detects all transactions are at least pending
+        Then wallet WALLET_A detects all transactions are at least completed
+        Then wallet WALLET_B detects all transactions are at least completed
+        # TODO: This wait is needed to stop next merge mining task from continuing
+        When I wait 1 seconds
+        When I merge mine 12 blocks via PROXY
+        Then all nodes are at height 14
+        Then wallet WALLET_A detects all transactions as mined
+        Then wallet WALLET_B detects all transactions as mined
+        # TODO: This wait is needed to stop base nodes from shutting down
+        When I wait 1 seconds

--- a/integration_tests/features/WalletSendingMechanism.feature
+++ b/integration_tests/features/WalletSendingMechanism.feature
@@ -1,0 +1,30 @@
+@sending_mechanism
+Feature: Wallet Sending Mechanism
+
+    Scenario Outline: Wallets transacting via specified routing mechanism only
+        Given I have a seed node NODE
+        And I have <NumBaseNodes> base nodes connected to all seed nodes
+        And I have non-default wallet WALLET_A connected to all seed nodes using <Mechanism>
+        And I have <NumWallets> non-default wallets connected to all seed nodes using <Mechanism>
+        And I have a merge mining proxy PROXY connected to NODE and WALLET_A
+        When I merge mine 20 blocks via PROXY
+        Then all nodes are at height 20
+        # TODO: This wait is needed to stop base nodes from shutting down
+        When I wait 1 seconds
+        When I wait for wallet WALLET_A to have more than 100000000 tari
+        #When I print the world
+        And I multi-send 1000000 tari from wallet WALLET_A to all wallets at fee 100
+        Then all wallets detect all transactions are at least pending
+        Then all wallets detect all transactions are at least completed
+        # TODO: This wait is needed to stop next merge mining task from continuing
+        When I wait 1 seconds
+        When I merge mine 12 blocks via PROXY
+        Then all nodes are at height 32
+        Then all wallets detect all transactions as mined
+        # TODO: This wait is needed to stop base nodes from shutting down
+        When I wait 1 seconds
+        Examples:
+            | NumBaseNodes | NumWallets | Mechanism                |
+            |  5           |  5         | DirectAndStoreAndForward |
+            |  5           |  5         | DirectOnly               |
+            |  5           |  5         | StoreAndForwardOnly      |

--- a/integration_tests/features/support/steps.js
+++ b/integration_tests/features/support/steps.js
@@ -5,13 +5,10 @@ const BaseNodeProcess = require('../../helpers/baseNodeProcess');
 const MergeMiningProxyProcess = require('../../helpers/mergeMiningProxyProcess');
 const WalletProcess = require('../../helpers/walletProcess');
 const expect = require('chai').expect;
-const {waitFor, getTransactionOutputHash} = require('../../helpers/util');
+const {waitFor, getTransactionOutputHashm, sleep, consoleLogTransactionDetails} = require('../../helpers/util');
 const TransactionBuilder = require('../../helpers/transactionBuilder');
 var lastResult;
 
-function sleep(ms) {
-    return new Promise(resolve => setTimeout(resolve, ms));
-  }
 
 Given(/I have a seed node (.*)/, {timeout: 20*1000}, async function (name) {
     return await this.createSeedNode(name);
@@ -63,7 +60,7 @@ Given(/I have a base node (.*) unconnected/, {timeout: 20*1000}, async function 
     this.addNode(name, node);
 });
 
-Given('I have {int} base nodes connected to all seed nodes',{timeout: 190*1000}, async  function (n) {
+Given('I have {int} base nodes connected to all seed nodes', {timeout: 190*1000}, async  function (n) {
     let promises = [];
     for (let i=0; i< n; i++) {
        const miner = new BaseNodeProcess(`BaseNode${i}`);
@@ -79,6 +76,35 @@ Given(/I have wallet (.*) connected to all seed nodes/, {timeout: 20*1000}, asyn
     await wallet.startNew();
     this.addWallet(name, wallet);
 });
+
+Given(/I have non-default wallet (.*) connected to all seed nodes using (.*)/, {timeout: 20*1000}, async function (name, mechanism) {
+    // mechanism: DirectOnly, StoreAndForwardOnly, DirectAndStoreAndForward
+    let wallet = new WalletProcess(name, { routingMechanism: mechanism });
+    console.log(wallet.name, wallet.options);
+    wallet.setPeerSeeds([this.seedAddresses()]);
+    await wallet.startNew();
+    this.addWallet(name, wallet);
+});
+
+Given(/I have (.*) non-default wallets connected to all seed nodes using (.*)/, {timeout: 190*1000}, async  function (n, mechanism) {
+    // mechanism: DirectOnly, StoreAndForwardOnly, DirectAndStoreAndForward
+    let promises = [];
+    for (let i=0; i< n; i++) {
+        if (i<10) {
+            const wallet = new WalletProcess("Wallet_0" + String(i), { routingMechanism: mechanism});
+            console.log(wallet.name, wallet.options);
+            wallet.setPeerSeeds([this.seedAddresses()]);
+            promises.push(wallet.startNew().then(() => this.addWallet("Wallet_0" + String(i), wallet)));
+        } else {
+            const wallet = new WalletProcess("Wallet_0" + String(i), { routingMechanism: mechanism});
+            console.log(wallet.name, wallet.options);
+            wallet.setPeerSeeds([this.seedAddresses()]);
+            promises.push(wallet.startNew().then(() => this.addWallet("Wallet_" + String(i), wallet)));
+        }
+   }
+    await Promise.all(promises);
+});
+
 
 
 Given(/I have a merge mining proxy (.*) connected to (.*) and (.*)/,{timeout: 20*1000}, async function (mmProxy, node, wallet) {
@@ -243,33 +269,74 @@ Then(/(.*) should have (\d+) peers/, async function (nodeName, peerCount){
     expect(peers.length).to.equal(peerCount+1)
 })
 
-When(/I send (.*) tari from (.*) to one wallet (.*) at fee (.*)/, {timeout: 260*1000}, async function (tariAmount, source, dest, fee) {
-    let sourceWalletClient = this.getWallet(source).getClient();
-    let destWalletClient = this.getWallet(dest).getClient();
-    var destInfo = await destWalletClient.identify();
+When('I print the world', function () {
+    console.log(this);
+});
+
+
+
+When(/I wait for wallet (.*) to have more than (.*) tari/, {timeout: 60*1000}, async function (wallet, amount) {
+    // TODO: Need to implement get-balance GRPC interface for this wait on to work
     console.log("\n");
-    console.log("Sending " + tariAmount + "uT to `" + destInfo["public_key"] + "`");
+    console.log("Waiting for " + wallet + " balance to be greater than " + amount + "uT");
+    await sleep(10 + 1000);
+});
+
+async function send_tari(sourceWallet, destWallet, tariAmount, fee) {
+    // TODO: Remove the while loop when wait on step above and get-balance GRPC interface is implemented
+    let sourceWalletClient = sourceWallet.getClient();
+    let destInfo = await destWallet.getClient().identify();
+    console.log(sourceWallet.name + " sending " + tariAmount + "uT to " + destWallet.name + " `" + destInfo["public_key"] + "`");
     let success = false;
     let retries = 1;
     let retries_limit = 25;
+    var lastResult;
     while (!success && retries <= retries_limit) {
-        this.lastResult = await sourceWalletClient.transfer({
+        lastResult = await sourceWalletClient.transfer({
             "recipients": [{"address": destInfo["public_key"],
             "amount": tariAmount,
             "fee_per_gram": fee,
             "message": "msg"}]
         });
-        success = this.lastResult.results[0]["is_success"]
+        success = lastResult.results[0]["is_success"]
         if (!success) {
-            let wait_seconds = 10;
-            console.log("  " + this.lastResult.results[0]["failure_message"] + ", trying again after " + wait_seconds +
+            let wait_seconds = 5;
+            console.log("  " + lastResult.results[0]["failure_message"] + ", trying again after " + wait_seconds +
                 "s (" + retries + " of " + retries_limit + ")");
             await sleep(wait_seconds * 1000);
             retries++;
         }
     }
+    return lastResult;
+}
+
+When(/I send (.*) tari from wallet (.*) to wallet (.*) at fee (.*)/, {timeout: 25*5*1000}, async function (tariAmount, source, dest, fee) {
+    let sourceInfo = await this.getWallet(source).getClient().identify();
+    let destInfo = await this.getWallet(dest).getClient().identify();
+    this.lastResult = await send_tari(this.getWallet(source), this.getWallet(dest), tariAmount, fee);
+    expect(this.lastResult.results[0]["is_success"]).to.equal(true);
+    this.addTransaction(sourceInfo["public_key"], this.lastResult.results[0]["transaction_id"]);
+    this.addTransaction(destInfo["public_key"], this.lastResult.results[0]["transaction_id"]);
     console.log("  Transaction '" + this.lastResult.results[0]["transaction_id"] + "' is_success(" +
         this.lastResult.results[0]["is_success"] + ")");
+});
+
+When(/I multi-send (.*) tari from wallet (.*) to all wallets at fee (.*)/, {timeout: 25*5*1000}, async function (tariAmount, source, fee) {
+    let sourceWalletClient = this.getWallet(source).getClient();
+    let sourceInfo = await sourceWalletClient.identify();
+
+    for (const wallet in this.wallets) {
+        if (this.getWallet(source).name == this.getWallet(wallet).name) {
+            continue;
+        }
+        let destInfo = await this.getWallet(wallet).getClient().identify()
+        this.lastResult = await send_tari(this.getWallet(source), this.getWallet(wallet), tariAmount, fee);
+        expect(this.lastResult.results[0]["is_success"]).to.equal(true);
+        this.addTransaction(sourceInfo["public_key"], this.lastResult.results[0]["transaction_id"]);
+        this.addTransaction(destInfo["public_key"], this.lastResult.results[0]["transaction_id"]);
+        console.log("  Transaction '" + this.lastResult.results[0]["transaction_id"] + "' is_success(" +
+            this.lastResult.results[0]["is_success"] + ")");
+    }
 });
 
 When(/I send (.*) tari from (.*) to (.*),(.*) at fee (.*)/, async function (tariAmount,source,dest,dest2,fee) {
@@ -356,42 +423,121 @@ Then(/Batch transfer of (.*) transactions was a success from (.*) to (.*),(.*)/,
    console.log("All transactions found");
 });
 
-Then(/Transaction status of last result from (.*) to (.*) is known to both wallets/, {timeout: 2*360*10*1000}, async function (walletA, walletB) {
-    let wallets = [this.getWallet(walletA), this.getWallet(walletB)];
-    let found = [false, false];
+Then(/wallet (.*) detects all transactions are at least pending/, {timeout: 3800*1000}, async function (walletName) {
+    // Note: This initial step can take a long time if network conditions are not favourable
+    let wallet = this.getWallet(walletName)
+    let walletClient = wallet.getClient();
+    var walletInfo = await walletClient.identify();
 
-    if (this.lastResult.results[0]["is_success"] == false) {
-        console.log("Transaction '" + this.lastResult.results[0]["transaction_id"] + "' failed");
-        expect(this.lastResult.results[0]["is_success"]).to.equal(true);
+    let txIds = this.transactionsMap.get(walletInfo["public_key"]);
+    console.log("\nDetecting transactions as at least pending: ", walletName, txIds)
+    for (i = 0; i < txIds.length; i++) {
+         console.log("\n" + wallet.name + ": Waiting for transaction " + txIds[i] + " to register at least pending in the wallet ...");
+         await waitFor(async() => wallet.getClient().isTransactionAtLeastPending(txIds[i]), true, 3700*1000, 5*1000, 5);
+         let transactionPending = await wallet.getClient().isTransactionAtLeastPending(txIds[i]);
+         let txnDetails = await wallet.getClient().getTransactionDetails(txIds[i]);
+         consoleLogTransactionDetails(txnDetails, txIds[i]);
+         expect(transactionPending).to.equal(true);
+   }
+
+});
+
+Then(/all wallets detect all transactions are at least pending/, {timeout: 3800*1000}, async function () {
+    // Note: This initial step to register pending can take a long time if network conditions are not favourable
+    for (const walletName in this.wallets) {
+        let wallet = this.getWallet(walletName)
+        let walletClient = wallet.getClient();
+        var walletInfo = await walletClient.identify();
+
+        let txIds = this.transactionsMap.get(walletInfo["public_key"]);
+        console.log("\nDetecting transactions as at least pending: ", walletName, txIds)
+        for (i = 0; i < txIds.length; i++) {
+             console.log("\n" + wallet.name + ": Waiting for transaction " + txIds[i] + " to register at least pending in the wallet ...");
+             await waitFor(async() => wallet.getClient().isTransactionAtLeastPending(txIds[i]), true, 3700*1000, 5*1000, 5);
+             let transactionPending = await wallet.getClient().isTransactionAtLeastPending(txIds[i]);
+             let txnDetails = await wallet.getClient().getTransactionDetails(txIds[i]);
+             consoleLogTransactionDetails(txnDetails, txIds[i]);
+             expect(transactionPending).to.equal(true);
+       }
+   }
+});
+
+Then(/wallet (.*) detects all transactions are at least completed/, {timeout: 700*1000}, async function (walletName) {
+    // Note: Check pending status before checking completed status
+    let wallet = this.getWallet(walletName)
+    let walletClient = wallet.getClient();
+    var walletInfo = await walletClient.identify();
+
+    let txIds = this.transactionsMap.get(walletInfo["public_key"]);
+    console.log("\nDetecting transactions as at least completed: ", walletName, txIds)
+    for (i = 0; i < txIds.length; i++) {
+        // Get details
+        console.log("\n" + wallet.name + ": Waiting for transaction " + txIds[i] + " to register at least completed in the wallet ...");
+        await waitFor(async() => wallet.getClient().isTransactionAtLeastCompleted(txIds[i]), true, 600*1000, 5*1000, 5);
+        let transactionCompleted = await wallet.getClient().isTransactionAtLeastCompleted(txIds[i]);
+        let txnDetails = await wallet.getClient().getTransactionDetails(txIds[i]);
+        consoleLogTransactionDetails(txnDetails, txIds[i]);
+        expect(transactionCompleted).to.equal(true);
     }
-    let tx_id = this.lastResult.results[0]["transaction_id"];
-    console.log("\n");
-    var i, retries, retries_limit;
-    for (i = 0; i < wallets.length; i++) {
-        console.log("Get transaction status from " + wallets[i].name + " for tx_id " + tx_id);
-        retries = 1;
-        retries_limit = 360;
-        while (!found[i] && retries <= retries_limit) {
-            try {
-                let txnDetails = await wallets[i].getClient().getTransactionInfo({
-                    "transaction_ids": [ tx_id.toString() ]
-                });
-                found[i] = true;
-                console.log("  " + wallets[i].name + ": transaction '" + txnDetails.transactions[0]["tx_id"] +
-                    "' has status '" + txnDetails.transactions[0]["status"] + "' and is_cancelled(" +
-                    txnDetails.transactions[0]["is_cancelled"] + ")");
-            } catch (err) {
-                let wait_seconds = 10;
-                console.log("  msg: '" + err.details + "', trying again after " + wait_seconds +
-                    "s (" + retries + " of " + retries_limit + ")");
-                await sleep(wait_seconds * 1000);
-                retries++;
-            }
+});
+
+Then(/all wallets detect all transactions are at least completed/, {timeout: 1200*1000}, async function () {
+    // Note: Check pending status before checking completed status
+    for (const walletName in this.wallets) {
+        let wallet = this.getWallet(walletName)
+        let walletClient = wallet.getClient();
+        var walletInfo = await walletClient.identify();
+
+        let txIds = this.transactionsMap.get(walletInfo["public_key"]);
+        console.log("\nDetecting transactions as at least completed: ", walletName, txIds)
+        for (i = 0; i < txIds.length; i++) {
+            // Get details
+            console.log("\n" + wallet.name + ": Waiting for transaction " + txIds[i] + " to register at least completed in the wallet ...");
+            await waitFor(async() => wallet.getClient().isTransactionAtLeastCompleted(txIds[i]), true, 1100*1000, 5*1000, 5);
+            let transactionCompleted = await wallet.getClient().isTransactionAtLeastCompleted(txIds[i]);
+            let txnDetails = await wallet.getClient().getTransactionDetails(txIds[i]);
+            consoleLogTransactionDetails(txnDetails, txIds[i]);
+            expect(transactionCompleted).to.equal(true);
         }
     }
-    console.log("\n");
+});
 
-    expect(found[0] && found[1]).to.equal(true);
+Then(/wallet (.*) detects all transactions as mined/, {timeout: 700*1000}, async function (walletName) {
+    // Note: Check completed status before checking mined status
+    let wallet = this.getWallet(walletName)
+    let walletClient = wallet.getClient();
+    var walletInfo = await walletClient.identify();
+
+    let txIds = this.transactionsMap.get(walletInfo["public_key"]);
+    console.log("\nDetecting transactions as mined: ", walletName, txIds)
+    for (i = 0; i < txIds.length; i++) {
+        console.log("\n" + wallet.name + ": Waiting for transaction " + txIds[i] + " to be detected as mined in the wallet ...");
+        await waitFor(async() => wallet.getClient().isTransactionMined(txIds[i]), true, 600*1000, 5*1000, 5);
+        let isTransactionMined = await wallet.getClient().isTransactionMined(txIds[i]);
+        let txnDetails = await wallet.getClient().getTransactionDetails(txIds[i]);
+        consoleLogTransactionDetails(txnDetails, txIds[i]);
+        expect(isTransactionMined).to.equal(true);
+    }
+});
+
+Then(/all wallets detect all transactions as mined/, {timeout: 1200*1000}, async function () {
+    // Note: Check completed status before checking mined status
+    for (const walletName in this.wallets) {
+        let wallet = this.getWallet(walletName)
+        let walletClient = wallet.getClient();
+        var walletInfo = await walletClient.identify();
+
+        let txIds = this.transactionsMap.get(walletInfo["public_key"]);
+        console.log("\nDetecting transactions as mined: ", walletName, txIds)
+        for (i = 0; i < txIds.length; i++) {
+            console.log("\n" + wallet.name + ": Waiting for transaction " + txIds[i] + " to be detected as mined in the wallet ...");
+            await waitFor(async() => wallet.getClient().isTransactionMined(txIds[i]), true, 1100*1000, 5*1000, 5);
+            let isTransactionMined = await wallet.getClient().isTransactionMined(txIds[i]);
+            let txnDetails = await wallet.getClient().getTransactionDetails(txIds[i]);
+            consoleLogTransactionDetails(txnDetails, txIds[i]);
+            expect(isTransactionMined).to.equal(true);
+        }
+    }
 });
 
 When(/I request the difficulties of a node (.*)/, async function (node) {

--- a/integration_tests/features/support/world.js
+++ b/integration_tests/features/support/world.js
@@ -19,6 +19,7 @@ class CustomWorld {
         this.blocks =  {};
         this.transactions = {};
         this.peers = {};
+        this.transactionsMap = new Map();
     }
 
     async createSeedNode(name) {
@@ -106,6 +107,13 @@ class CustomWorld {
     async startNode(name) {
         const node = this.seeds[name] || this.nodes[name];
         await node.start();
+    }
+
+    addTransaction(pubKey, txId) {
+        if (!this.transactionsMap.has(pubKey)) {
+            this.transactionsMap.set(pubKey, [])
+        }
+        this.transactionsMap.get(pubKey).push(txId)
     }
 }
 

--- a/integration_tests/helpers/baseNodeProcess.js
+++ b/integration_tests/helpers/baseNodeProcess.js
@@ -83,7 +83,8 @@ class BaseNodeProcess {
                 fs.mkdirSync(this.baseDir + "/log", {recursive: true});
             }
 
-            let envs = createEnv(this.name,false, this.nodeFile,"127.0.0.1", "8082","8081","127.0.0.1",this.grpcPort,this.port,"127.0.0.1:8080",this.options,this.peerSeeds);
+            let envs = createEnv(this.name, false, this.nodeFile, "127.0.0.1", "8082", "8081", "127.0.0.1",
+                this.grpcPort, this.port, "127.0.0.1:8080", this.options, this.peerSeeds);
 
             var ps = spawn(cmd, args, {
                 cwd: this.baseDir,

--- a/integration_tests/helpers/config.js
+++ b/integration_tests/helpers/config.js
@@ -7,9 +7,14 @@
  function mapEnvs(options) {
      let res = {};
      if (options.pruningHorizon) {
-         res.TARI_BASE_NODE__LOCALNET__PRUNING_HORIZON=options.pruningHorizon;
+        // In the config toml file: `base_node.network.pruning_horizon` with `network = localnet`
+         res.TARI_BASE_NODE__LOCALNET__PRUNING_HORIZON = options.pruningHorizon;
      }
-    return res;
+     if (options.routingMechanism) {
+        // In the config toml file: `wallet.transaction_routing_mechanism`
+        res.TARI_WALLET__TRANSACTION_ROUTING_MECHANISM = options.routingMechanism;
+     }
+     return res;
 }
 
 function baseEnvs(peerSeeds = [])
@@ -59,21 +64,26 @@ function baseEnvs(peerSeeds = [])
      return envs;
 }
 
-function createEnv(name="config_identity",isWallet=false, nodeFile="newnodeid.json",walletGrpcAddress="127.0.0.1", walletGrpcPort="8082", walletPort="8083", baseNodeGrpcAddress="127.0.0.1", baseNodeGrpcPort="8080", baseNodePort="8081",proxyFullAddress="127.0.0.1:8084",options, peerSeeds=[]) {
-          var envs = baseEnvs(peerSeeds);
-          var configEnvs = {
-             TARI_BASE_NODE__LOCALNET__GRPC_BASE_NODE_ADDRESS: `${baseNodeGrpcAddress}:${baseNodeGrpcPort}`,
-             TARI_BASE_NODE__LOCALNET__GRPC_CONSOLE_WALLET_ADDRESS: `${walletGrpcAddress}:${walletGrpcPort}`,
-             TARI_BASE_NODE__LOCALNET__BASE_NODE_IDENTITY_FILE: `${nodeFile}`,
-             TARI_BASE_NODE__LOCALNET__TCP_LISTENER_ADDRESS: "/ip4/0.0.0.0/tcp/" + (isWallet ? `${walletPort}` : `${baseNodePort}`),
-             TARI_BASE_NODE__LOCALNET__PUBLIC_ADDRESS: "/ip4/127.0.0.1/tcp/" + (isWallet ? `${walletPort}` : `${baseNodePort}`),
-             TARI_MERGE_MINING_PROXY__LOCALNET__PROXY_HOST_ADDRESS: `${proxyFullAddress}`,
-             TARI_BASE_NODE__LOCALNET__TRANSPORT: "tcp",
-         }
-         //console.log(configEnvs);
-         //console.log(configEnvs);
-         var fullEnvs = {...envs,...configEnvs};
-         return {...fullEnvs, ...mapEnvs(options || {}) } ;
+function createEnv(name="config_identity", isWallet=false, nodeFile="newnodeid.json", walletGrpcAddress="127.0.0.1",
+        walletGrpcPort="8082", walletPort="8083", baseNodeGrpcAddress="127.0.0.1", baseNodeGrpcPort="8080",
+        baseNodePort="8081", proxyFullAddress="127.0.0.1:8084", options, peerSeeds=[],
+        txnSendingMechanism="DirectAndStoreAndForward") {
+    var envs = baseEnvs(peerSeeds);
+    var configEnvs = {
+        TARI_BASE_NODE__LOCALNET__GRPC_BASE_NODE_ADDRESS: `${baseNodeGrpcAddress}:${baseNodeGrpcPort}`,
+        TARI_BASE_NODE__LOCALNET__GRPC_CONSOLE_WALLET_ADDRESS: `${walletGrpcAddress}:${walletGrpcPort}`,
+        TARI_BASE_NODE__LOCALNET__BASE_NODE_IDENTITY_FILE: `${nodeFile}`,
+        TARI_BASE_NODE__LOCALNET__TCP_LISTENER_ADDRESS: "/ip4/0.0.0.0/tcp/" + (isWallet ? `${walletPort}` : `${baseNodePort}`),
+        TARI_BASE_NODE__LOCALNET__PUBLIC_ADDRESS: "/ip4/127.0.0.1/tcp/" + (isWallet ? `${walletPort}` : `${baseNodePort}`),
+        TARI_MERGE_MINING_PROXY__LOCALNET__PROXY_HOST_ADDRESS: `${proxyFullAddress}`,
+        TARI_BASE_NODE__LOCALNET__TRANSPORT: "tcp",
+    }
+    //console.log(configEnvs);
+    var fullEnvs = {...envs,...configEnvs};
+    if (isWallet) {
+        //console.log(name, mapEnvs(options || {}));
+    }
+    return {...fullEnvs, ...mapEnvs(options || {}) } ;
 }
 
 module.exports = {

--- a/integration_tests/helpers/walletClient.js
+++ b/integration_tests/helpers/walletClient.js
@@ -1,8 +1,19 @@
 const {Client} = require('wallet-grpc-client');
+const {sleep} = require("./util");
+
+function transactionStatus() {
+    return [
+        "TRANSACTION_STATUS_PENDING",
+        "TRANSACTION_STATUS_COMPLETED",
+        "TRANSACTION_STATUS_BROADCAST",
+        "TRANSACTION_STATUS_MINED"
+    ];
+}
 
 class WalletClient {
-     constructor(walletAddress) {
+     constructor(walletAddress, name) {
        this.client = Client.connect(walletAddress)
+       this.name = name;
      }
 
     async getVersion() {
@@ -24,6 +35,88 @@ class WalletClient {
          "public_address": info["public_address"],
          "node_id": info["node_id"].toString('utf8'),
        };
+    }
+
+    async isTransactionRegistered(tx_id) {
+        try {
+            await this.getTransactionInfo({
+                "transaction_ids": [ tx_id.toString() ]
+            });
+            return true;
+        } catch (err) {
+            return false;
+        }
+    }
+
+    async isTransactionAtLeastPending(tx_id) {
+        try {
+            let txnDetails = await this.getTransactionInfo({
+                "transaction_ids": [ tx_id.toString() ]
+            });
+            if (transactionStatus().indexOf(txnDetails.transactions[0]["status"]) >= 0) {
+                return true;
+            } else {
+                return false;
+            }
+        } catch (err) {
+            return false;
+        }
+    }
+
+    async isTransactionAtLeastCompleted(tx_id) {
+        try {
+            let txnDetails = await this.getTransactionInfo({
+                "transaction_ids": [ tx_id.toString() ]
+            });
+            if (transactionStatus().indexOf(txnDetails.transactions[0]["status"]) >= 1) {
+                return true;
+            } else {
+                return false;
+            }
+        } catch (err) {
+            return false;
+        }
+    }
+
+    async isTransactionAtLeastBroadcast(tx_id) {
+        try {
+            let txnDetails = await this.getTransactionInfo({
+                "transaction_ids": [ tx_id.toString() ]
+            });
+            if (transactionStatus().indexOf(txnDetails.transactions[0]["status"]) >= 2) {
+                return true;
+            } else {
+                return false;
+            }
+        } catch (err) {
+            return false;
+        }
+    }
+
+    async isTransactionMined(tx_id) {
+        try {
+            let txnDetails = await this.getTransactionInfo({
+                "transaction_ids": [ tx_id.toString() ]
+            });
+            if (transactionStatus().indexOf(xnDetails.transactions[0]["status"]) == 3) {
+                return true;
+            } else {
+                return false;
+            }
+        } catch (err) {
+            return false;
+        }
+    }
+
+    async getTransactionDetails(tx_id) {
+        try {
+            let txnDetails = await this.getTransactionInfo({
+                "transaction_ids": [ tx_id.toString() ]
+            });
+            return [true, txnDetails];
+        } catch (err) {
+            return [false, err];
+        }
     }
 }
 

--- a/integration_tests/helpers/walletProcess.js
+++ b/integration_tests/helpers/walletProcess.js
@@ -8,8 +8,9 @@ const WalletClient = require('./walletClient');
 
 class WalletProcess {
 
-    constructor(name) {
+    constructor(name, options) {
         this.name = name;
+        this.options = options;
     }
 
     async init() {
@@ -25,7 +26,7 @@ class WalletProcess {
     }
 
     getClient() {
-        return new WalletClient(this.getGrpcAddress());
+        return new WalletClient(this.getGrpcAddress(), this.name);
     }
 
     setPeerSeeds(addresses) {
@@ -39,7 +40,8 @@ class WalletProcess {
                 fs.mkdirSync(this.baseDir + "/log", {recursive: true});
             }
 
-           let envs = createEnv(this.name, true, "cwalletid.json", "127.0.0.1", this.grpcPort, this.port, "127.0.0.1", "8080", "8081", "127.0.0.1:8084", [], this.peerSeeds)
+            let envs = createEnv(this.name, true, "cwalletid.json", "127.0.0.1", this.grpcPort, this.port, "127.0.0.1",
+                "8080", "8081", "127.0.0.1:8084", this.options, this.peerSeeds)
 
             var ps = spawn(cmd, args, {
                 cwd: this.baseDir,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- This option specifies the transaction sending mechanism as being directly between wallets, making use of store and
forward or using any combination of these (the default). It also adds a cucumber integration test for multiple transaction sending using the specified mechanism.
- Updated the _Get Transaction Info_ cucumber feature to use the new and updated transaction sending and detecting methods.

**TODO:** ~~Fix environment variable `TARI_CONSOLE_WALLET__LOCALNET__TRANSACTION_SENDING_MECHANISM` not being set in the console wallet for cucumber test(s). _(The new config option via config file has been tested at the system level and works as expected.)_~~

## Motivation and Context
This feature is mainly needed for testing purposes, but also offers users the ability to choose how transactions will be sent and finalized.

## How Has This Been Tested?
Tested all the options between different console wallets in Windows at system level

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [X] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [X] New Tests
* [X] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [ ] I'm merging against the `development` branch.
* [X] I ran `cargo-fmt --all` before pushing.
* [ ] I ran `cargo test` successfully before submitting my PR.
* [X] I have squashed my commits into a single commit.
* [X] My change requires a change to the documentation.
* [X] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
