### PR TITLE
[libwallet] Set confirmations required via libwallet and config

### DIFF
--- a/applications/tari_console_wallet/src/init/mod.rs
+++ b/applications/tari_console_wallet/src/init/mod.rs
@@ -386,6 +386,7 @@ pub async fn init_wallet(
             transaction_routing_mechanism: TransactionRoutingMechanism::from(
                 config.transaction_routing_mechanism.clone(),
             ),
+            num_confirmations_required: config.transaction_num_confirmations_required,
             ..Default::default()
         }),
         Some(OutputManagerServiceConfig {

--- a/applications/tari_console_wallet/src/notifier/mod.rs
+++ b/applications/tari_console_wallet/src/notifier/mod.rs
@@ -112,7 +112,7 @@ impl Notifier {
             self.handle.spawn(async move {
                 match transaction_service.get_completed_transaction(tx_id).await {
                     Ok(tx) => {
-                        let confirmations = match transaction_service.num_confirmations_required().await {
+                        let confirmations = match transaction_service.get_num_confirmations_required().await {
                             Ok(n) => Some(n),
                             Err(e) => {
                                 error!(target: LOG_TARGET, "Transaction service error: {}", e);

--- a/base_layer/core/src/validation/test.rs
+++ b/base_layer/core/src/validation/test.rs
@@ -86,7 +86,7 @@ fn header_iter_fetch_in_chunks() {
 // TODO: Fix this test with the new DB structure
 fn chain_balance_validation() {
     // let factories = CryptoFactories::default();
-    // let consensus_manager = ConsensusManagerBuilder::new(Network::Ridcully).build();
+    // let consensus_manager = ConsensusManagerBuilder::new(Network::Stibbons).build();
     // let mut genesis = consensus_manager.get_genesis_block();
     // let faucet_value = 5000 * uT;
     // let (faucet_utxo, faucet_key) = create_utxo(faucet_value, &factories, None);

--- a/base_layer/core/tests/node_state_machine.rs
+++ b/base_layer/core/tests/node_state_machine.rs
@@ -143,7 +143,7 @@ fn test_event_channel() {
     let temp_dir = tempdir().unwrap();
     let mut runtime = Runtime::new().unwrap();
     let (node, consensus_manager) =
-        BaseNodeBuilder::new(Network::Ridcully).start(&mut runtime, temp_dir.path().to_str().unwrap());
+        BaseNodeBuilder::new(Network::Stibbons).start(&mut runtime, temp_dir.path().to_str().unwrap());
     // let shutdown = Shutdown::new();
     let db = create_test_blockchain_db();
     let shutdown = Shutdown::new();

--- a/base_layer/wallet/src/base_node_service/error.rs
+++ b/base_layer/wallet/src/base_node_service/error.rs
@@ -29,7 +29,7 @@ use thiserror::Error;
 pub enum BaseNodeServiceError {
     #[error("No base node peer set")]
     NoBaseNodePeer,
-    #[error("No chain meta data from peer")]
+    #[error("No chain metadata from peer")]
     NoChainMetadata,
     #[error("Unexpected API Response")]
     UnexpectedApiResponse,

--- a/base_layer/wallet/src/transaction_service/service.rs
+++ b/base_layer/wallet/src/transaction_service/service.rs
@@ -577,7 +577,6 @@ where
                 )
                 .await
                 .map(|_| TransactionServiceResponse::ProtocolsRestarted),
-
             TransactionServiceRequest::RestartBroadcastProtocols => {
                 if self.broadcast_restart_state == BroadcastRestartState::NotTriggered {
                     self.broadcast_restart_state = BroadcastRestartState::Triggered;
@@ -587,9 +586,13 @@ where
                     .await
                     .map(|_| TransactionServiceResponse::ProtocolsRestarted)
             },
-            TransactionServiceRequest::NumConfirmationsRequired => Ok(
+            TransactionServiceRequest::GetNumConfirmationsRequired => Ok(
                 TransactionServiceResponse::NumConfirmationsRequired(self.resources.config.num_confirmations_required),
             ),
+            TransactionServiceRequest::SetNumConfirmationsRequired(number) => {
+                self.resources.config.num_confirmations_required = number;
+                Ok(TransactionServiceResponse::NumConfirmationsSet)
+            },
         }
     }
 

--- a/base_layer/wallet/tests/output_manager_service/service.rs
+++ b/base_layer/wallet/tests/output_manager_service/service.rs
@@ -113,7 +113,7 @@ pub fn setup_output_manager_service<T: OutputManagerBackend + 'static>(
     let (event_publisher, _) = channel(100);
     let ts_handle = TransactionServiceHandle::new(ts_request_sender, event_publisher.clone());
 
-    let constants = ConsensusConstantsBuilder::new(Network::Ridcully).build();
+    let constants = ConsensusConstantsBuilder::new(Network::Stibbons).build();
 
     let (sender, receiver_bns) = reply_channel::unbounded();
     let (event_publisher_bns, _) = broadcast::channel(100);

--- a/base_layer/wallet/tests/wallet/mod.rs
+++ b/base_layer/wallet/tests/wallet/mod.rs
@@ -137,7 +137,7 @@ async fn create_wallet(
         factories,
         Some(transaction_service_config),
         None,
-        Network::Ridcully,
+        Network::Stibbons,
         None,
         None,
         None,
@@ -597,7 +597,7 @@ async fn test_import_utxo() {
         factories.clone(),
         None,
         None,
-        Network::Ridcully,
+        Network::Stibbons,
         None,
         None,
         None,
@@ -672,7 +672,7 @@ async fn test_data_generation() {
         dns_seeds_use_dnssec: false,
     };
 
-    let config = WalletConfig::new(comms_config, factories, None, None, Network::Ridcully, None, None, None);
+    let config = WalletConfig::new(comms_config, factories, None, None, Network::Stibbons, None, None, None);
 
     let (transaction_backend, _temp_dir) = make_transaction_database(None);
 

--- a/base_layer/wallet_ffi/wallet.h
+++ b/base_layer/wallet_ffi/wallet.h
@@ -460,6 +460,13 @@ unsigned long long wallet_get_pending_outgoing_balance(struct TariWallet *wallet
 // Get a fee estimate from a TariWallet for a given amount
 unsigned long long wallet_get_fee_estimate(struct TariWallet *wallet, unsigned long long amount, unsigned long long fee_per_gram, unsigned long long num_kernels, unsigned long long num_outputs, int* error_out);
 
+// Get the number of mining confirmations by the wallet transaction service
+unsigned long long wallet_get_num_confirmations_required(struct TariWallet *wallet, int* error_out);
+
+// Set the number of mining confirmations by the wallet transaction service
+void wallet_set_num_confirmations_required(struct TariWallet *wallet, unsigned long long num, int* error_out);
+
+
 // Sends a TariPendingOutboundTransaction
 unsigned long long wallet_send_transaction(struct TariWallet *wallet, struct TariPublicKey *destination, unsigned long long amount, unsigned long long fee_per_gram,const char *message,int* error_out);
 

--- a/common/config/presets/windows.toml
+++ b/common/config/presets/windows.toml
@@ -87,6 +87,8 @@ console_wallet_db_file = "wallet\\console-wallet.dat"
 # This is the timeout period that will be used to monitor TXO queries to the base node (default = 60). Larger values
 # are needed for wallets with many (>1000) TXOs to be validated.
 base_node_query_timeout = 120
+# This is the number of block confirmations required for a transaction to be considered completely mined and confirmed. (default = 3)
+#transaction_num_confirmations_required = 3
 # This is the timeout period that will be used for base node broadcast monitoring tasks (default = 60)
 #transaction_broadcast_monitoring_timeout = 60
 # This is the timeout period that will be used for chain monitoring tasks (default = 60)

--- a/common/config/tari_config_example.toml
+++ b/common/config/tari_config_example.toml
@@ -87,6 +87,8 @@
 # This is the timeout period that will be used to monitor TXO queries to the base node (default = 60). Larger values
 # are needed for wallets with many (>1000) TXOs to be validated.
 base_node_query_timeout = 120
+# This is the number of block confirmations required for a transaction to be considered completely mined and confirmed. (default = 3)
+#transaction_num_confirmations_required = 3
 # This is the timeout period that will be used for base node broadcast monitoring tasks (default = 30)
 #transaction_broadcast_monitoring_timeout = 30
 # This is the timeout period that will be used for chain monitoring tasks (default = 30)

--- a/common/src/configuration/global.rs
+++ b/common/src/configuration/global.rs
@@ -97,6 +97,7 @@ pub struct GlobalConfig {
     pub transaction_direct_send_timeout: Duration,
     pub transaction_broadcast_send_timeout: Duration,
     pub transaction_routing_mechanism: String,
+    pub transaction_num_confirmations_required: u64,
     pub console_wallet_password: Option<String>,
     pub wallet_command_send_wait_stage: String,
     pub wallet_command_send_wait_timeout: u64,
@@ -437,6 +438,9 @@ fn convert_node_config(network: Network, cfg: Config) -> Result<GlobalConfig, Co
             .map_err(|e| ConfigurationError::new(&key, &e.to_string()))? as u64,
     );
 
+    let key = "wallet.transaction_num_confirmations_required";
+    let transaction_num_confirmations_required = optional(cfg.get_int(&key))?.unwrap_or(3) as u64;
+
     let key = "wallet.prevent_fee_gt_amount";
     let prevent_fee_gt_amount = cfg
         .get_bool(&key)
@@ -620,6 +624,7 @@ fn convert_node_config(network: Network, cfg: Config) -> Result<GlobalConfig, Co
         transaction_direct_send_timeout,
         transaction_broadcast_send_timeout,
         transaction_routing_mechanism,
+        transaction_num_confirmations_required,
         console_wallet_password,
         wallet_command_send_wait_stage,
         wallet_command_send_wait_timeout,

--- a/scripts/build_dists_tarball.sh
+++ b/scripts/build_dists_tarball.sh
@@ -12,8 +12,8 @@
 if [ "$1" == "-h" ] || [ "$1" == "--help" ]; then
   echo "$0 (clean|latest-tag|latest-tagv|'any-string-version')"
   echo " 'clean' cargo clean and lock remove"
-  echo " 'latest-tag' pull and switch too latest git tag"
-  echo " 'latest-tagv' pull and switch too latest git tag starting with 'v'"
+  echo " 'latest-tag' pull and switch to latest git tag"
+  echo " 'latest-tagv' pull and switch to latest git tag starting with 'v'"
   echo " 'any-string-version' archive string to tag with"
   echo "   ie: $0 nightly-development-test-\$(date +'%Y-%m-%d')"
   exit 1
@@ -28,7 +28,7 @@ tsstamp=$(date +'%Y%m%dT%Hh%M')
 
 envFile="$sPath/.env"
 if [ -f "$envFile" ]; then
-  echo "Overriding Enviroment with $envFile file for settings ..."
+  echo "Overriding Environment with $envFile file for settings ..."
   source "$envFile"
 fi
 


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Adds a config option, transaction service methods, and libwallet FFI functions to set the number of block confirmations required for the wallet transaction service.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Allows number of confirmations required to be set from config file or programmatically. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tests provided (some previously broken tests are being fixed in #2613) 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [x] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [x] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch.
* [x] I ran `cargo-fmt --all` before pushing.
* [ ] I ran `cargo test` successfully before submitting my PR.
* [x] I have squashed my commits into a single commit.
* [x] My change requires a change to the documentation.
* [x] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
