### PR TITLE
[libwallet] Remove the Tor identity getter from the FFI.

### DIFF
--- a/base_layer/wallet_ffi/wallet.h
+++ b/base_layer/wallet_ffi/wallet.h
@@ -98,9 +98,6 @@ struct TariTransportType *transport_tor_create(
     const char *socks_password,
     int* error_out);
 
-// Gets the tor private key from the wallet
-struct ByteVector *wallet_get_tor_identity(struct TariWallet *wallet,int* error_out );
-
 // Gets the address from a memory transport type
 char *transport_memory_get_address(struct TariTransportType *transport,int* error_out);
 


### PR DESCRIPTION
Tor identity is completely managed by the wallet library after the recent changes, and the exposure of it through the FFI is redundant.

## Description
This PR removes the Tor identity getter from the FFI, and removes the comment for the Tor id parameter in the transport initializer.

## Motivation and Context
The exposure of the Tor identity through the FFI is not necessary anymore.

## How Has This Been Tested?
I've built the wallet library with `mobile_build.sh`.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [x] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch.
* [x] I ran `cargo-fmt --all` before pushing.
* [ ] I ran `cargo test` successfully before submitting my PR.
* [x] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
