### PR TITLE
[tests] Double spend test for mempool transaction selection

### DIFF
--- a/base_layer/core/src/mempool/unconfirmed_pool/error.rs
+++ b/base_layer/core/src/mempool/unconfirmed_pool/error.rs
@@ -29,4 +29,6 @@ pub enum UnconfirmedPoolError {
     StorageOutofSync,
     #[error("Priority error: `{0}`")]
     PriorityError(#[from] PriorityError),
+    #[error("Transaction has no kernels")]
+    TransactionNoKernels,
 }

--- a/base_layer/core/src/mempool/unconfirmed_pool/unconfirmed_pool.rs
+++ b/base_layer/core/src/mempool/unconfirmed_pool/unconfirmed_pool.rs
@@ -99,8 +99,10 @@ impl UnconfirmedPool {
     /// reached and the new transaction has a higher priority than the currently stored lowest priority transaction.
     #[allow(clippy::map_entry)]
     pub fn insert(&mut self, tx: Arc<Transaction>) -> Result<(), UnconfirmedPoolError> {
-        let tx_key = tx.body.kernels()[0].excess_sig.clone();
-        if !self.txs_by_signature.contains_key(&tx_key) {
+        let tx_key = tx
+            .first_kernel_excess_sig()
+            .ok_or_else(|| UnconfirmedPoolError::TransactionNoKernels)?;
+        if !self.txs_by_signature.contains_key(tx_key) {
             debug!(
                 target: LOG_TARGET,
                 "Inserting tx into unconfirmed pool: {}",
@@ -116,7 +118,7 @@ impl UnconfirmedPool {
             }
             self.txs_by_priority
                 .insert(prioritized_tx.priority.clone(), tx_key.clone());
-            self.txs_by_signature.insert(tx_key, prioritized_tx);
+            self.txs_by_signature.insert(tx_key.clone(), prioritized_tx);
         }
         Ok(())
     }
@@ -259,8 +261,8 @@ impl UnconfirmedPool {
     }
 
     #[cfg(test)]
-    /// Checks the consistency status of the Hashmap and BtreeMap
-    pub fn check_status(&self) -> bool {
+    /// Returns false if there are any inconsistencies in the internal mempool state, otherwise true
+    fn check_status(&self) -> bool {
         if self.txs_by_priority.len() != self.txs_by_signature.len() {
             return false;
         }
@@ -276,7 +278,14 @@ mod test {
     use crate::{
         consensus::{ConsensusManagerBuilder, Network},
         test_helpers::create_orphan_block,
-        transactions::tari_amount::MicroTari,
+        transactions::{
+            fee::Fee,
+            helpers::TestParams,
+            tari_amount::MicroTari,
+            transaction::{KernelFeatures, UnblindedOutput},
+            types::{CryptoFactories, HashDigest},
+            SenderTransactionProtocol,
+        },
         tx,
     };
 
@@ -327,6 +336,60 @@ mod test {
         // space, the second best transaction was then included
 
         assert!(unconfirmed_pool.check_status());
+    }
+
+    #[test]
+    fn test_double_spend_inputs() {
+        let (tx1, _, _) = tx!(MicroTari(5_000), fee: MicroTari(50), inputs: 1, outputs: 1);
+        const INPUT_AMOUNT: MicroTari = MicroTari(5_000);
+        let (tx2, inputs, _) = tx!(INPUT_AMOUNT, fee: MicroTari(20), inputs: 1, outputs: 1);
+
+        let test_params = TestParams::new();
+
+        let mut stx_builder = SenderTransactionProtocol::builder(0);
+        stx_builder
+            .with_lock_height(0)
+            .with_fee_per_gram(20.into())
+            .with_offset(Default::default())
+            .with_private_nonce(test_params.nonce.clone())
+            .with_change_secret(test_params.change_key.clone());
+
+        // Double spend the input from tx2 in tx3
+        let double_spend_utxo = tx2.body.inputs().first().unwrap().clone();
+        let double_spend_input = inputs.first().unwrap().clone();
+
+        let estimated_fee = Fee::calculate(20.into(), 1, 1, 1);
+        let utxo = UnblindedOutput::new(INPUT_AMOUNT - estimated_fee, test_params.spend_key.clone(), None);
+        stx_builder
+            .with_input(double_spend_utxo, double_spend_input)
+            .with_output(utxo);
+
+        let factories = CryptoFactories::default();
+        let mut stx_protocol = stx_builder.build::<HashDigest>(&factories).unwrap();
+        stx_protocol.finalize(KernelFeatures::empty(), &factories).unwrap();
+
+        let tx3 = stx_protocol.get_transaction().unwrap().clone();
+
+        let tx1 = Arc::new(tx1);
+        let tx2 = Arc::new(tx2);
+        let tx3 = Arc::new(tx3);
+
+        let mut unconfirmed_pool = UnconfirmedPool::new(UnconfirmedPoolConfig {
+            storage_capacity: 4,
+            weight_tx_skip_count: 3,
+        });
+
+        unconfirmed_pool
+            .insert_txs(vec![tx1.clone(), tx2.clone(), tx3.clone()])
+            .unwrap();
+        assert_eq!(unconfirmed_pool.len(), 3);
+
+        let desired_weight = tx1.calculate_weight() + tx2.calculate_weight() + tx3.calculate_weight() + 1000;
+        let selected_txs = unconfirmed_pool.highest_priority_txs(desired_weight).unwrap();
+        assert!(selected_txs.contains(&tx1));
+        // Whether tx2 or tx3 is selected is non-deterministic
+        assert!(selected_txs.contains(&tx2) ^ selected_txs.contains(&tx3));
+        assert_eq!(selected_txs.len(), 2);
     }
 
     #[test]

--- a/base_layer/core/src/proof_of_work/proof_of_work.rs
+++ b/base_layer/core/src/proof_of_work/proof_of_work.rs
@@ -95,10 +95,7 @@ impl Display for ProofOfWork {
 
 #[cfg(test)]
 mod test {
-    use crate::proof_of_work::{
-        proof_of_work::{PowAlgorithm, ProofOfWork},
-        Difficulty,
-    };
+    use crate::proof_of_work::proof_of_work::{PowAlgorithm, ProofOfWork};
 
     #[test]
     fn display() {

--- a/base_layer/core/src/proof_of_work/sha3_pow.rs
+++ b/base_layer/core/src/proof_of_work/sha3_pow.rs
@@ -63,11 +63,7 @@ fn sha3_difficulty_with_hash(header: &BlockHeader) -> (Difficulty, Vec<u8>) {
 pub mod test {
     use crate::{
         blocks::BlockHeader,
-        proof_of_work::{
-            sha3_pow::{sha3_difficulty, sha3_difficulty_with_hash},
-            Difficulty,
-            PowAlgorithm,
-        },
+        proof_of_work::{sha3_pow::sha3_difficulty, Difficulty, PowAlgorithm},
     };
     use chrono::{DateTime, NaiveDate, Utc};
 

--- a/base_layer/core/src/validation/test.rs
+++ b/base_layer/core/src/validation/test.rs
@@ -23,7 +23,6 @@
 use crate::{
     blocks::BlockHeader,
     consensus::{ConsensusManagerBuilder, Network},
-    tari_utilities::Hashable,
     test_helpers::blockchain::create_store_with_consensus,
     validation::header_iter::HeaderIter,
 };


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Test behaviour of `UnconfirmedPool:highest_priority_txs` when two transactions attempt
to spend the same input.

Fixed a possible panic if a transaction is inserted with 0 kernels.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
It is important that double spends cannot be selected by the mempool to be put into a block. This test confirms that the selection works as expected.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tests pass

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [x] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [ ] I'm merging against the `development` branch.
* [ ] I ran `cargo-fmt --all` before pushing.
* [ ] I ran `cargo test` successfully before submitting my PR.
* [ ] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
