### PR TITLE
[Fix] Shorter ban for RPC negotiation timeout in header sync, RPC timeout configurable

### DIFF
--- a/base_layer/core/src/base_node/sync/config.rs
+++ b/base_layer/core/src/base_node/sync/config.rs
@@ -29,6 +29,7 @@ pub struct BlockSyncConfig {
     pub num_tip_hashes: usize,
     pub num_proof_headers: usize,
     pub ban_period: Duration,
+    pub short_ban_period: Duration,
     pub sync_peers: Vec<NodeId>,
 }
 
@@ -39,6 +40,7 @@ impl Default for BlockSyncConfig {
             num_tip_hashes: 500,
             num_proof_headers: 100,
             ban_period: Duration::from_secs(30 * 60),
+            short_ban_period: Duration::from_secs(60),
             sync_peers: Default::default(),
         }
     }

--- a/comms/src/protocol/rpc/server.rs
+++ b/comms/src/protocol/rpc/server.rs
@@ -77,6 +77,7 @@ pub struct RpcServer {
     maximum_concurrent_sessions: Option<usize>,
     max_frame_size: usize,
     minimum_client_deadline: Duration,
+    handshake_timeout: Duration,
     shutdown_signal: OptionalShutdownSignal,
 }
 
@@ -145,6 +146,7 @@ impl Default for RpcServer {
             maximum_concurrent_sessions: Some(100),
             max_frame_size: RPC_MAX_FRAME_SIZE,
             minimum_client_deadline: Duration::from_secs(1),
+            handshake_timeout: Duration::from_secs(15),
             shutdown_signal: Default::default(),
         }
     }
@@ -257,7 +259,7 @@ where
             },
         };
 
-        let mut handshake = Handshake::new(&mut framed);
+        let mut handshake = Handshake::new(&mut framed).with_timeout(self.config.handshake_timeout);
         let version = handshake.perform_server_handshake().await?;
         debug!(
             target: LOG_TARGET,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
An RPC negotiation timeout is now explicitly handled by the header sync by banning
the peer for a much shorter period rather than the longer period used for more
serious infractions.

Also, the RPC handshake timeout was made configurable and the default
was increased from 10s to 15s.


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This change prevents long bans when the network/tor is behaving slower
than is typical. These bans can cause network segregation.
```
[c::bn::header_sync] DEBUG Failed to synchronize headers from peer `xx`: RPC error: RPC negotiation timed out                                 ┤
[c::bn::header_sync] WARN  Banned sync peer because Failed to synchronize headers from peer
```

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Existing tests pass, tested on base node (short ban issued to slow peer, peer retried after short ban)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [x] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [ ] I'm merging against the `development` branch.
* [ ] I ran `cargo-fmt --all` before pushing.
* [ ] I ran `cargo test` successfully before submitting my PR.
* [ ] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
