### PR TITLE
[fix] Fix missing Content-Type header in some json responses

### DIFF
--- a/applications/tari_merge_mining_proxy/src/json_rpc.rs
+++ b/applications/tari_merge_mining_proxy/src/json_rpc.rs
@@ -30,8 +30,6 @@ pub fn success_response(req_id: Option<i64>, result: json::Value) -> json::Value
        "id": req_id.unwrap_or(-1),
        "jsonrpc": "2.0",
        "result": result,
-       "status": "OK",
-       "untrusted": false
     })
 }
 


### PR DESCRIPTION
Adds `Content-Type: application/json` to 'custom' proxy responses.
This is technically more correct and some clients do not interpret the
contents as JSON without it.
