### PR TITLE
[fix] Dont store messages of a banned peer

### DIFF
--- a/comms/dht/src/envelope.rs
+++ b/comms/dht/src/envelope.rs
@@ -219,27 +219,36 @@ pub enum NodeDestination {
 
 impl NodeDestination {
     pub fn to_inner_bytes(&self) -> Vec<u8> {
+        use NodeDestination::*;
         match self {
-            NodeDestination::Unknown => Vec::default(),
-            NodeDestination::PublicKey(pk) => pk.to_vec(),
-            NodeDestination::NodeId(node_id) => node_id.to_vec(),
+            Unknown => Vec::default(),
+            PublicKey(pk) => pk.to_vec(),
+            NodeId(node_id) => node_id.to_vec(),
         }
     }
 
     pub fn public_key(&self) -> Option<&CommsPublicKey> {
+        use NodeDestination::*;
         match self {
-            NodeDestination::Unknown => None,
-            NodeDestination::PublicKey(pk) => Some(pk),
-            NodeDestination::NodeId(_) => None,
+            Unknown => None,
+            PublicKey(pk) => Some(pk),
+            NodeId(_) => None,
         }
     }
 
     pub fn node_id(&self) -> Option<&NodeId> {
+        use NodeDestination::*;
         match self {
-            NodeDestination::Unknown => None,
-            NodeDestination::PublicKey(_) => None,
-            NodeDestination::NodeId(node_id) => Some(node_id),
+            Unknown => None,
+            PublicKey(_) => None,
+            NodeId(node_id) => Some(node_id),
         }
+    }
+
+    pub fn to_derived_node_id(&self) -> Option<NodeId> {
+        self.node_id()
+            .cloned()
+            .or_else(|| self.public_key().map(NodeId::from_public_key))
     }
 
     pub fn is_unknown(&self) -> bool {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Changes to SAF behaviour:
- Dont store messages if origin peer is banned
- Consistency between messages with `NodeDestination::PublicKey` and
  `NodeDestination::NodeId`, only store messages if a peer is in the
  network region. Previously, the store logic would be different
  depending on the destination enum variant set in the DhtHeader.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Node would store banned peer's messages.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
New unit test. Tested on base node by banning peers and checking in the DHT db that 
new messages for the peer are not being added.
memorynet passed

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [ ] I'm merging against the `development` branch.
* [ ] I ran `cargo-fmt --all` before pushing.
* [ ] I ran `cargo test` successfully before submitting my PR.
* [ ] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
