### PR TITLE
Update Transaction Receiver protocol to persist transaction earlier

### DIFF
--- a/base_layer/wallet/src/transaction_service/protocols/transaction_receive_protocol.rs
+++ b/base_layer/wallet/src/transaction_service/protocols/transaction_receive_protocol.rs
@@ -155,20 +155,20 @@ where TBackend: TransactionBackend + 'static
                 Utc::now().naive_utc(),
             );
 
+            self.resources
+                .db
+                .add_pending_inbound_transaction(inbound_transaction.tx_id, inbound_transaction.clone())
+                .await
+                .map_err(|e| TransactionServiceProtocolError::new(self.id, TransactionServiceError::from(e)))?;
+
             let send_result = send_transaction_reply(
-                inbound_transaction.clone(),
+                inbound_transaction,
                 self.resources.outbound_message_service.clone(),
                 self.resources.config.direct_send_timeout,
                 self.resources.config.transaction_routing_mechanism,
             )
             .await
             .map_err(|e| TransactionServiceProtocolError::new(self.id, e))?;
-
-            self.resources
-                .db
-                .add_pending_inbound_transaction(inbound_transaction.tx_id, inbound_transaction)
-                .await
-                .map_err(|e| TransactionServiceProtocolError::new(self.id, TransactionServiceError::from(e)))?;
 
             self.resources
                 .db


### PR DESCRIPTION
## Description
Currently when a wallet receives a transaction it attempts to send the reply before persisting the received transaction data to the database. Send the reply can take a while so in the iOS application where this process was done by the constrained background service the process was closing before the data was persisted and so it was not available when the user opened the app.

This PR makes a simple change where the data is persisted as soon as possible and only then the reply is attempted to be sent. If the process closes before the reply is sent it is not an issue. After a reply is sent a timestamp of when it was sent is written to the database. If the wallet is opened later it checks to see if the reply sent timestamp exists or was a long time ago and if it wasn’t sent recently it will send the reply again.

## How Has This Been Tested?
Existing Tests

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch.
* [x] I ran `cargo-fmt --all` before pushing.
* [x] I ran `cargo test` successfully before submitting my PR.
* [x] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
