### PR TITLE
Retry peers that have been marked as offline after a length of time

### DIFF
--- a/comms/dht/src/config.rs
+++ b/comms/dht/src/config.rs
@@ -114,6 +114,11 @@ pub struct DhtConfig {
     /// `flood_ban_max_count / flood_ban_timespan (as seconds) = avg. messages per second over the timespan`
     /// Default: 100 seconds
     pub flood_ban_timespan: Duration,
+    /// Once a peer has been marked as offline, wait at least this length of time before reconsidering them.
+    /// In a situation where a node is not well-connected and many nodes are locally marked as offline, we can retry
+    /// peers that were previously tried.
+    /// Default: 24 hours
+    pub offline_peer_cooldown: Duration,
 }
 
 impl DhtConfig {
@@ -175,6 +180,7 @@ impl Default for DhtConfig {
             allow_test_addresses: false,
             flood_ban_max_msg_count: 1000,
             flood_ban_timespan: Duration::from_secs(100),
+            offline_peer_cooldown: Duration::from_secs(24 * 60 * 60),
         }
     }
 }

--- a/comms/dht/src/connectivity/mod.rs
+++ b/comms/dht/src/connectivity/mod.rs
@@ -562,7 +562,11 @@ impl DhtConnectivity {
                     return false;
                 }
 
-                if peer.is_offline() {
+                if peer
+                    .offline_since()
+                    .map(|since| since <= self.config.offline_peer_cooldown)
+                    .unwrap_or(false)
+                {
                     connect_ineligable_count += 1;
                     return false;
                 }


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
While querying for neighbouring peers, offline peers can be reattempted
after 24 hours (default). If a node is not well-connected, or has been banned many
peers, this will increase the pool of possible peers to connect to.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
During the recent flood, a node may loose connection to all peers and have no 
further peers to choose from. This allows previously offline peers to be re-attempted.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Minor change not explicitly tested

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [ ] I'm merging against the `development` branch.
* [ ] I ran `cargo-fmt --all` before pushing.
* [ ] I ran `cargo test` successfully before submitting my PR.
* [ ] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
