### PR TITLE
[wallet] Add unique constraint to commitment in outputs table

### DIFF
--- a/base_layer/wallet/migrations/2021-02-15-084900_add_outputs_unique_commitment/down.sql
+++ b/base_layer/wallet/migrations/2021-02-15-084900_add_outputs_unique_commitment/down.sql
@@ -1,0 +1,16 @@
+PRAGMA foreign_keys=off;
+ALTER TABLE outputs RENAME TO outputs_old;
+CREATE TABLE outputs (
+    id INTEGER NOT NULL PRIMARY KEY,
+    commitment BLOB NULL DEFAULT NULL,
+    spending_key BLOB NOT NULL,
+    value INTEGER NOT NULL,
+    flags INTEGER NOT NULL,
+    maturity INTEGER NOT NULL,
+    status INTEGER NOT NULL,
+    tx_id INTEGER NULL,
+    hash BLOB NULL DEFAULT NULL,
+);
+INSERT INTO outputs SELECT * FROM outputs_old;
+DROP TABLE outputs_old;
+PRAGMA foreign_keys=on;

--- a/base_layer/wallet/migrations/2021-02-15-084900_add_outputs_unique_commitment/up.sql
+++ b/base_layer/wallet/migrations/2021-02-15-084900_add_outputs_unique_commitment/up.sql
@@ -1,0 +1,17 @@
+PRAGMA foreign_keys=off;
+ALTER TABLE outputs RENAME TO outputs_old;
+CREATE TABLE outputs (
+    id INTEGER NOT NULL PRIMARY KEY,
+    commitment BLOB NULL DEFAULT NULL,
+    spending_key BLOB NOT NULL,
+    value INTEGER NOT NULL,
+    flags INTEGER NOT NULL,
+    maturity INTEGER NOT NULL,
+    status INTEGER NOT NULL,
+    tx_id INTEGER NULL,
+    hash BLOB NULL DEFAULT NULL,
+    CONSTRAINT unique_commitment UNIQUE (commitment)
+);
+INSERT INTO outputs SELECT * FROM outputs_old;
+DROP TABLE outputs_old;
+PRAGMA foreign_keys=on;

--- a/base_layer/wallet/src/output_manager_service/storage/memory_db.rs
+++ b/base_layer/wallet/src/output_manager_service/storage/memory_db.rs
@@ -243,11 +243,17 @@ impl OutputManagerBackend for OutputManagerMemoryDatabase {
 
         // Add Spent outputs
         for o in pending_tx.outputs_to_be_spent.drain(..) {
+            if db.spent_outputs.iter().any(|uo| uo.output == o) {
+                return Err(OutputManagerStorageError::DuplicateOutput);
+            }
             db.spent_outputs.push(DbOutput::new(tx_id, o))
         }
 
         // Add Unspent outputs
         for o in pending_tx.outputs_to_be_received.drain(..) {
+            if db.unspent_outputs.iter().any(|uo| uo.output == o) {
+                return Err(OutputManagerStorageError::DuplicateOutput);
+            }
             db.unspent_outputs.push(DbOutput::new(tx_id, o));
         }
 


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Fixes a potential issue where a duplicate output is allowed to be added
to the wallet database. Ensures a unique commitment per output at the
database level with a unique constraint, and adds tests to verify.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Outputs should always be unique in the wallet database 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
New tests provided 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch.
* [x] I ran `cargo-fmt --all` before pushing.
* [x] I ran `cargo test` successfully before submitting my PR.
* [x] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
