### PR TITLE
Fix transaction propagation 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -656,6 +656,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "const_fn"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28b9d6de7f49e22cf97ad17fc4036ece69300032f45f78f30b4a4482cdc3f4a6"
+
+[[package]]
 name = "constant_time_eq"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -763,7 +769,7 @@ dependencies = [
  "crossbeam-deque",
  "crossbeam-epoch",
  "crossbeam-queue",
- "crossbeam-utils 0.8.3",
+ "crossbeam-utils 0.8.1",
 ]
 
 [[package]]
@@ -782,7 +788,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dca26ee1f8d361640700bde38b2c37d8c22b3ce2d360e1fc1c74ea4b0aa7d775"
 dependencies = [
  "cfg-if 1.0.0",
- "crossbeam-utils 0.8.3",
+ "crossbeam-utils 0.8.1",
 ]
 
 [[package]]
@@ -793,17 +799,18 @@ checksum = "94af6efb46fef72616855b036a624cf27ba656ffc9be1b9a3c931cfc7749a9a9"
 dependencies = [
  "cfg-if 1.0.0",
  "crossbeam-epoch",
- "crossbeam-utils 0.8.3",
+ "crossbeam-utils 0.8.1",
 ]
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.3"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2584f639eb95fea8c798496315b297cf81b9b58b6d30ab066a75455333cf4b12"
+checksum = "a1aaa739f95311c2c7887a76863f500026092fb1dce0161dab577e559ef3569d"
 dependencies = [
  "cfg-if 1.0.0",
- "crossbeam-utils 0.8.3",
+ "const_fn",
+ "crossbeam-utils 0.8.1",
  "lazy_static 1.4.0",
  "memoffset",
  "scopeguard",
@@ -816,7 +823,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0f6cb3c7f5b8e51bc3ebb73a2327ad4abdbd119dc13223f14f961d2f38486756"
 dependencies = [
  "cfg-if 1.0.0",
- "crossbeam-utils 0.8.3",
+ "crossbeam-utils 0.8.1",
 ]
 
 [[package]]
@@ -831,9 +838,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.3"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7e9d99fa91428effe99c5c6d4634cdeba32b8cf784fc428a2a687f61a952c49"
+checksum = "02d96d1e189ef58269ebe5b97953da3274d83a93af647c2ddd6f9dab28cedb8d"
 dependencies = [
  "autocfg",
  "cfg-if 1.0.0",
@@ -2540,9 +2547,9 @@ checksum = "a9a7ab5d64814df0fe4a4b5ead45ed6c5f181ee3ff04ba344313a6c80446c5d4"
 
 [[package]]
 name = "once_cell"
-version = "1.7.0"
+version = "1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10acf907b94fc1b1a152d08ef97e7759650268cf986bf127f387e602b02c7e5a"
+checksum = "13bd41f508810a131401606d54ac32a467c97172d74ba7662562ebba5ad07fa0"
 
 [[package]]
 name = "opaque-debug"
@@ -3146,7 +3153,7 @@ checksum = "9ab346ac5921dc62ffa9f89b7a773907511cdfa5490c572ae9be1be33e8afa4a"
 dependencies = [
  "crossbeam-channel 0.5.0",
  "crossbeam-deque",
- "crossbeam-utils 0.8.3",
+ "crossbeam-utils 0.8.1",
  "lazy_static 1.4.0",
  "num_cpus",
 ]

--- a/applications/tari_app_grpc/proto/base_node.proto
+++ b/applications/tari_app_grpc/proto/base_node.proto
@@ -49,7 +49,7 @@ service BaseNode {
     // Get network difficulties
     rpc GetNetworkDifficulty(HeightRequest) returns (stream NetworkDifficultyResponse);
     // Get the block template
-    rpc GetNewBlockTemplate(PowAlgo) returns (NewBlockTemplateResponse);
+    rpc GetNewBlockTemplate(NewBlockTemplateRequest) returns (NewBlockTemplateResponse);
     // Construct a new block from a provided template
     rpc GetNewBlock(NewBlockTemplate) returns (GetNewBlockResult);
     // Submit a new block for propagation
@@ -64,10 +64,10 @@ service BaseNode {
     rpc SearchKernels(SearchKernelsRequest) returns (stream HistoricalBlock);
     // Fetch any utxos that exist in the main chain
     rpc FetchMatchingUtxos(FetchMatchingUtxosRequest) returns (stream FetchMatchingUtxosResponse);
-
     // get all peers from the base node
     rpc GetPeers(GetPeersRequest) returns (stream GetPeersResponse);
     rpc GetMempoolTransactions(GetMempoolTransactionsRequest) returns (stream GetMempoolTransactionsResponse);
+    rpc TransactionState(TransactionStateRequest) returns (TransactionStateResponse);
 }
 
 message SubmitBlockResponse {
@@ -84,6 +84,13 @@ message NewBlockTemplateResponse {
     NewBlockTemplate new_block_template = 1;
     bool initial_sync_achieved = 3;
     MinerData miner_data = 4;
+}
+
+/// return type of NewBlockTemplateRequest
+message NewBlockTemplateRequest{
+    PowAlgo algo = 1;
+    //This field should be moved to optional once optional keyword is standard
+    uint64 max_weight = 2;
 }
 
 // Network difficulty response
@@ -288,4 +295,19 @@ message GetMempoolTransactionsRequest {
 
 message GetMempoolTransactionsResponse {
     Transaction transaction = 1;
+}
+
+message TransactionStateRequest {
+    Signature excess_sig  = 1;
+}
+
+message TransactionStateResponse {
+    TransactionLocation result =1;
+}
+
+enum TransactionLocation {
+    UNKNOWN = 0;
+    MEMPOOL = 1;
+    MINED = 2;
+    NOT_STORED = 3;
 }

--- a/applications/tari_explorer/routes/blocks.js
+++ b/applications/tari_explorer/routes/blocks.js
@@ -10,8 +10,6 @@ router.get('/:height', async function(req, res, next) {
 
   let block = await client.getBlocks({heights:[height]});
 
-  // console.log(block[0].block.header);
-  // console.log(block[0].block.body);
   console.log(block[0].block.body.kernels[0]);
   res.render('blocks', { title: `Block at height:${block[0].block.header.height}`, height:height, prevHeight: parseInt(height) - 1, nextHeight: parseInt(height) + 1, block: block[0].block , pows: {"0": "Monero", "2": "SHA"}});
 });

--- a/applications/tari_merge_mining_proxy/src/proxy.rs
+++ b/applications/tari_merge_mining_proxy/src/proxy.rs
@@ -432,8 +432,11 @@ impl InnerService {
             new_block_template,
             initial_sync_achieved,
         } = grpc_client
-            .get_new_block_template(grpc::PowAlgo {
-                pow_algo: grpc::pow_algo::PowAlgos::Monero.into(),
+            .get_new_block_template(grpc::NewBlockTemplateRequest {
+                algo: Some(grpc::PowAlgo {
+                    pow_algo: grpc::pow_algo::PowAlgos::Monero.into(),
+                }),
+                max_weight: 0,
             })
             .await
             .map_err(|status| MmProxyError::GrpcRequestError {

--- a/applications/tari_mining_node/src/config.rs
+++ b/applications/tari_mining_node/src/config.rs
@@ -38,7 +38,7 @@
 
 use serde::{Deserialize, Serialize};
 use std::time::Duration;
-use tari_app_grpc::tari_rpc::{pow_algo::PowAlgos, PowAlgo};
+use tari_app_grpc::tari_rpc::{pow_algo::PowAlgos, NewBlockTemplateRequest, PowAlgo};
 use tari_common::{GlobalConfig, NetworkConfigPath};
 
 #[derive(Serialize, Deserialize)]
@@ -88,12 +88,13 @@ impl MinerConfig {
             .unwrap_or_else(|| format!("http://{}", global.grpc_console_wallet_address))
     }
 
-    pub fn pow_algo_request(&self) -> PowAlgo {
-        match self.proof_of_work_algo {
-            ProofOfWork::Sha3 => PowAlgo {
+    pub fn pow_algo_request(&self) -> NewBlockTemplateRequest {
+        let algo = match self.proof_of_work_algo {
+            ProofOfWork::Sha3 => Some(PowAlgo {
                 pow_algo: PowAlgos::Sha3.into(),
-            },
-        }
+            }),
+        };
+        NewBlockTemplateRequest { algo, max_weight: 0 }
     }
 
     pub fn wait_timeout(&self) -> Duration {

--- a/base_layer/core/src/base_node/comms_interface/comms_request.rs
+++ b/base_layer/core/src/base_node/comms_interface/comms_request.rs
@@ -55,9 +55,15 @@ pub enum NodeCommsRequest {
     FetchBlocksWithUtxos(Vec<Commitment>),
     GetHeaderByHash(HashOutput),
     GetBlockByHash(HashOutput),
-    GetNewBlockTemplate(PowAlgorithm),
+    GetNewBlockTemplate(GetNewBlockTemplateRequest),
     GetNewBlock(NewBlockTemplate),
     FetchKernelByExcessSig(Signature),
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct GetNewBlockTemplateRequest {
+    pub algo: PowAlgorithm,
+    pub max_weight: u64,
 }
 
 impl Display for NodeCommsRequest {
@@ -78,7 +84,7 @@ impl Display for NodeCommsRequest {
             FetchBlocksWithUtxos(v) => write!(f, "FetchBlocksWithUtxos (n={})", v.len()),
             GetHeaderByHash(v) => write!(f, "GetHeaderByHash({})", v.to_hex()),
             GetBlockByHash(v) => write!(f, "GetBlockByHash({})", v.to_hex()),
-            GetNewBlockTemplate(algo) => write!(f, "GetNewBlockTemplate ({})", algo),
+            GetNewBlockTemplate(v) => write!(f, "GetNewBlockTemplate ({}) with weight {}", v.algo, v.max_weight),
             GetNewBlock(b) => write!(f, "GetNewBlock (Block Height={})", b.header.height),
             FetchKernelByExcessSig(s) => write!(
                 f,

--- a/base_layer/core/src/base_node/comms_interface/mod.rs
+++ b/base_layer/core/src/base_node/comms_interface/mod.rs
@@ -21,7 +21,7 @@
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 mod comms_request;
-pub use comms_request::{MmrStateRequest, NodeCommsRequest};
+pub use comms_request::{GetNewBlockTemplateRequest, MmrStateRequest, NodeCommsRequest};
 
 mod comms_response;
 pub use comms_response::NodeCommsResponse;

--- a/base_layer/core/src/base_node/proto/request.proto
+++ b/base_layer/core/src/base_node/proto/request.proto
@@ -25,7 +25,7 @@ message BaseNodeServiceRequest {
         // Indicates a FetchBlocksWithHashes request.
         HashOutputs fetch_blocks_with_hashes = 8;
         // Indicates a GetNewBlockTemplate request.
-        uint64 get_new_block_template = 9;
+        NewBlockTemplateRequest get_new_block_template = 9;
         // Indicates a GetNewBlock request.
         tari.core.NewBlockTemplate get_new_block = 10;
         // Get headers in best chain following any headers in this list
@@ -73,3 +73,7 @@ message FetchMmrNodeCount {
     uint64 height = 2;
 }
 
+message NewBlockTemplateRequest{
+    uint64 algo = 1;
+    uint64 max_weight = 2;
+}

--- a/base_layer/core/src/base_node/proto/request.rs
+++ b/base_layer/core/src/base_node/proto/request.rs
@@ -21,7 +21,7 @@
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 use crate::{
-    base_node::comms_interface as ci,
+    base_node::{comms_interface as ci, comms_interface::GetNewBlockTemplateRequest},
     proof_of_work::PowAlgorithm,
     proto::{
         base_node as proto,
@@ -79,8 +79,12 @@ impl TryInto<ci::NodeCommsRequest> for ProtoNodeCommsRequest {
             },
             GetHeaderByHash(hash) => ci::NodeCommsRequest::GetHeaderByHash(hash),
             GetBlockByHash(hash) => ci::NodeCommsRequest::GetBlockByHash(hash),
-            GetNewBlockTemplate(pow_algo) => {
-                ci::NodeCommsRequest::GetNewBlockTemplate(PowAlgorithm::try_from(pow_algo)?)
+            GetNewBlockTemplate(message) => {
+                let request = GetNewBlockTemplateRequest {
+                    algo: PowAlgorithm::try_from(message.algo)?,
+                    max_weight: message.max_weight,
+                };
+                ci::NodeCommsRequest::GetNewBlockTemplate(request)
             },
             GetNewBlock(block_template) => ci::NodeCommsRequest::GetNewBlock(block_template.try_into()?),
             FetchKernelByExcessSig(sig) => ci::NodeCommsRequest::FetchKernelByExcessSig(
@@ -120,7 +124,12 @@ impl From<ci::NodeCommsRequest> for ProtoNodeCommsRequest {
             },
             GetHeaderByHash(hash) => ProtoNodeCommsRequest::GetHeaderByHash(hash),
             GetBlockByHash(hash) => ProtoNodeCommsRequest::GetBlockByHash(hash),
-            GetNewBlockTemplate(pow_algo) => ProtoNodeCommsRequest::GetNewBlockTemplate(pow_algo as u64),
+            GetNewBlockTemplate(request) => {
+                ProtoNodeCommsRequest::GetNewBlockTemplate(proto::NewBlockTemplateRequest {
+                    algo: request.algo as u64,
+                    max_weight: request.max_weight,
+                })
+            },
             GetNewBlock(block_template) => ProtoNodeCommsRequest::GetNewBlock(block_template.into()),
             FetchKernelByExcessSig(signature) => ProtoNodeCommsRequest::FetchKernelByExcessSig(signature.into()),
         }

--- a/base_layer/core/src/base_node/state_machine_service/states/block_sync.rs
+++ b/base_layer/core/src/base_node/state_machine_service/states/block_sync.rs
@@ -65,6 +65,7 @@ impl BlockSync {
 
         let status_event_sender = shared.status_event_sender.clone();
         let local_nci = shared.local_node_interface.clone();
+        let bootstrapped = shared.bootstrapped_sync;
         synchronizer.on_progress(move |block, remote_tip_height, sync_peers| {
             let local_height = block.block.header.height;
             local_nci.publish_block_event(BlockEvent::ValidBlockAdded(
@@ -74,7 +75,7 @@ impl BlockSync {
             ));
 
             let _ = status_event_sender.broadcast(StatusInfo {
-                bootstrapped: false,
+                bootstrapped,
                 state_info: StateInfo::BlockSync(BlockSyncInfo {
                     tip_height: remote_tip_height,
                     local_height,

--- a/base_layer/core/src/base_node/state_machine_service/states/header_sync.rs
+++ b/base_layer/core/src/base_node/state_machine_service/states/header_sync.rs
@@ -66,9 +66,10 @@ impl HeaderSync {
         );
 
         let status_event_sender = shared.status_event_sender.clone();
+        let bootstrapped = shared.bootstrapped_sync;
         synchronizer.on_progress(move |current_height, remote_tip_height, sync_peers| {
             let _ = status_event_sender.broadcast(StatusInfo {
-                bootstrapped: false,
+                bootstrapped,
                 state_info: StateInfo::HeaderSync(BlockSyncInfo {
                     tip_height: remote_tip_height,
                     local_height: current_height,

--- a/base_layer/core/src/mempool/service/local_service.rs
+++ b/base_layer/core/src/mempool/service/local_service.rs
@@ -28,7 +28,7 @@ use crate::{
         StatsResponse,
         TxStorageResponse,
     },
-    transactions::transaction::Transaction,
+    transactions::{transaction::Transaction, types::Signature},
 };
 use tari_service_framework::{reply_channel::SenderService, Service};
 use tokio::sync::broadcast;
@@ -93,6 +93,21 @@ impl LocalMempoolService {
         match self
             .request_sender
             .call(MempoolRequest::SubmitTransaction(transaction))
+            .await??
+        {
+            MempoolResponse::TxStorage(s) => Ok(s),
+            _ => Err(MempoolServiceError::UnexpectedApiResponse),
+        }
+    }
+
+    pub async fn get_transaction_state_by_excess_sig(
+        &mut self,
+        sig: Signature,
+    ) -> Result<TxStorageResponse, MempoolServiceError>
+    {
+        match self
+            .request_sender
+            .call(MempoolRequest::GetTxStateByExcessSig(sig))
             .await??
         {
             MempoolResponse::TxStorage(s) => Ok(s),

--- a/base_layer/core/src/mempool/sync_protocol/test.rs
+++ b/base_layer/core/src/mempool/sync_protocol/test.rs
@@ -82,6 +82,7 @@ fn setup(
         protocol_notif_rx,
         connectivity_events_rx,
         mempool.clone(),
+        None,
     );
 
     task::spawn(protocol.run());

--- a/base_layer/core/src/mining/miner.rs
+++ b/base_layer/core/src/mining/miner.rs
@@ -345,7 +345,7 @@ impl Miner {
         trace!(target: LOG_TARGET, "Requesting new block template from node.");
         Ok(self
             .node_interface
-            .get_new_block_template(PowAlgorithm::Sha3)
+            .get_new_block_template(PowAlgorithm::Sha3, 0)
             .await
             .map_err(|e| {
                 error!(

--- a/base_layer/core/tests/node_service.rs
+++ b/base_layer/core/tests/node_service.rs
@@ -629,7 +629,11 @@ fn local_get_new_block_template_and_get_new_block() {
     assert!(node.mempool.insert(txs[1].clone()).is_ok());
 
     runtime.block_on(async {
-        let block_template = node.local_nci.get_new_block_template(PowAlgorithm::Sha3).await.unwrap();
+        let block_template = node
+            .local_nci
+            .get_new_block_template(PowAlgorithm::Sha3, 0)
+            .await
+            .unwrap();
         assert_eq!(block_template.header.height, 1);
         assert_eq!(block_template.body.kernels().len(), 2);
 

--- a/integration_tests/features/Mempool.feature
+++ b/integration_tests/features/Mempool.feature
@@ -1,0 +1,88 @@
+@propagation
+Feature: Mempool
+
+ 
+  Scenario: Transactions are propagated through a network
+    Given I have 10 seed nodes
+    And I have a base node SENDER connected to all seed nodes
+    And I have 10 base nodes connected to all seed nodes
+    #We wait for the nodes to boot up
+    When I wait 100 seconds
+    When I mine a block on SENDER with coinbase CB1
+    When I mine 2 blocks on SENDER
+    When I create a transaction TX1 spending CB1 to UTX1
+    When I submit transaction TX1 to SENDER
+    Then SENDER has TX1 in MEMPOOL state
+    #We need to wait to ensure that the tx is propagated through the network
+    When I wait 100 seconds
+    Then TX1 is in the MEMPOOL of all nodes
+
+
+  Scenario: Transactions are synced
+    Given I have 2 seed nodes
+    And I have a base node SENDER connected to all seed nodes
+    And I have 2 base nodes connected to all seed nodes
+    #We wait for the nodes to boot up
+    When I wait 100 seconds
+    When I mine a block on SENDER with coinbase CB1
+    When I mine 2 blocks on SENDER
+    When I create a transaction TX1 spending CB1 to UTX1
+    When I submit transaction TX1 to SENDER
+    Then SENDER has TX1 in MEMPOOL state
+    When I wait 20 seconds
+    Then TX1 is in the MEMPOOL of all nodes
+    Given I have a base node NODE1 connected to all seed nodes
+    #wait for node to boot up
+    When I wait 100 seconds
+    Then NODE1 has TX1 in MEMPOOL state
+    When I mine 1 blocks on SENDER 
+    When I wait 20 seconds
+    Then SENDER has TX1 in MINED state
+    Then TX1 is in the MINED of all nodes
+
+ Scenario: Clear out mempool
+    Given I have 1 seed nodes
+    And I have a base node SENDER connected to all seed nodes
+    #We wait for the nodes to boot up
+    When I wait 30 seconds
+    When I mine a block on SENDER with coinbase CB1
+    When I mine a block on SENDER with coinbase CB2
+    When I mine a block on SENDER with coinbase CB3
+    When I mine 4 blocks on SENDER
+    When I create a custom fee transaction TX1 spending CB1 to UTX1 with fee 80
+    When I create a custom fee transaction TX2 spending CB2 to UTX2 with fee 100
+    When I create a custom fee transaction TX3 spending CB3 to UTX3 with fee 90
+    When I submit transaction TX1 to SENDER
+    When I submit transaction TX2 to SENDER
+    When I submit transaction TX3 to SENDER
+    Then SENDER has TX1 in MEMPOOL state
+    Then SENDER has TX2 in MEMPOOL state
+    Then SENDER has TX3 in MEMPOOL state
+    When I mine 1 custom weight blocks on SENDER with weight 17
+    Then SENDER has TX1 in MEMPOOL state
+    Then SENDER has TX2 in MINED state
+    Then SENDER has TX3 in MEMPOOL state
+    When I mine 1 custom weight blocks on SENDER with weight 17
+    Then SENDER has TX1 in MEMPOOL state
+    Then SENDER has TX2 in MINED state
+    Then SENDER has TX3 in MINED state
+
+
+Scenario: Double spend
+    Given I have 1 seed nodes
+    And I have a base node SENDER connected to all seed nodes
+    When I wait 30 seconds
+    When I mine a block on SENDER with coinbase CB1
+    When I mine 4 blocks on SENDER
+    When I create a custom fee transaction TX1 spending CB1 to UTX1 with fee 80
+    When I create a custom fee transaction TX2 spending CB1 to UTX2 with fee 100
+    When I submit transaction TX1 to SENDER
+    When I submit transaction TX2 to SENDER
+    Then SENDER has TX1 in MEMPOOL state
+    Then SENDER has TX2 in MEMPOOL state
+    When I mine 1 blocks on SENDER
+    Then SENDER has TX1 in NOT_STORED state
+    Then SENDER has TX2 in MINED state
+    When I mine 1 blocks on SENDER
+    Then SENDER has TX1 in NOT_STORED state
+    Then SENDER has TX2 in MINED state

--- a/integration_tests/features/support/world.js
+++ b/integration_tests/features/support/world.js
@@ -56,13 +56,13 @@ class CustomWorld {
         this.outputs[name] = output;
     }
 
-    async mineBlock(name, beforeSubmit, onError) {
-        await this.clients[name].mineBlockWithoutWallet(beforeSubmit, onError);
+    async mineBlock(name, weight, beforeSubmit,  onError) {
+        await this.clients[name].mineBlockWithoutWallet(beforeSubmit, weight, onError);
     }
 
-    async mergeMineBlock(name) {
+    async mergeMineBlock(name, weight) {
         let client = this.proxies[name].createClient();
-        await client.mineBlock();
+        await client.mineBlock(weight);
     }
 
     saveBlock(name, block) {


### PR DESCRIPTION
Set bootstrap default false

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This fixes the transaction propagation and the bootstrap flag.
Fixes transaction builder in cucumber. 
Adds in a cucumber test to test transaction propagation.
Adds cucumber test for double spends. 
Adds cucumber test for mempool clearing
Adds in a GRPC call to search the mempool for a transaction excess signature. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Transactions are sometimes sent and they dont propagate through he network. The Bootstrap flag is set to false everytime the node enters sync. When the bootstrap flag is set, the node will ignore all blocks and transactions sent to it. It should only ignore these during initial sync and not every sync. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Integration tests

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [x] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch.
* [x I ran `cargo-fmt --all` before pushing.
* [x] I ran `cargo test` successfully before submitting my PR.
* [ ] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
