### PR TITLE
Allow CI to use latest mdbook

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -118,7 +118,7 @@ jobs:
       - run:
           name: RFC documentation
           command: |
-            cargo install mdbook --version 0.4.5 --force
+            cargo install mdbook --version ^0.4
             cd RFC && mdbook test && mdbook build
 
       - persist_to_workspace:


### PR DESCRIPTION
0.4.6 is out and the current CI script forces 0.4.5