### PR TITLE
v0.8.3.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3788,7 +3788,7 @@ dependencies = [
 
 [[package]]
 name = "tari_app_grpc"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
  "chrono",
  "prost",
@@ -3804,7 +3804,7 @@ dependencies = [
 
 [[package]]
 name = "tari_app_utilities"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
  "config",
  "dirs-next",
@@ -3829,7 +3829,7 @@ dependencies = [
 
 [[package]]
 name = "tari_base_node"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
  "anyhow",
  "bincode",
@@ -3894,7 +3894,7 @@ dependencies = [
 
 [[package]]
 name = "tari_common"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
  "anyhow",
  "config",
@@ -3917,7 +3917,7 @@ dependencies = [
 
 [[package]]
 name = "tari_common_types"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
  "futures 0.3.6",
  "rand 0.7.3",
@@ -3928,7 +3928,7 @@ dependencies = [
 
 [[package]]
 name = "tari_comms"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3971,7 +3971,7 @@ dependencies = [
 
 [[package]]
 name = "tari_comms_dht"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
  "anyhow",
  "bitflags 1.2.1",
@@ -4016,7 +4016,7 @@ dependencies = [
 
 [[package]]
 name = "tari_comms_rpc_macros"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
  "futures 0.3.6",
  "proc-macro2 1.0.24",
@@ -4032,7 +4032,7 @@ dependencies = [
 
 [[package]]
 name = "tari_console_wallet"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
  "chrono",
  "chrono-english",
@@ -4070,7 +4070,7 @@ dependencies = [
 
 [[package]]
 name = "tari_core"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
  "bincode",
  "bitflags 1.2.1",
@@ -4150,7 +4150,7 @@ dependencies = [
 
 [[package]]
 name = "tari_infra_derive"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
  "blake2",
  "proc-macro2 0.4.30",
@@ -4176,7 +4176,7 @@ dependencies = [
 
 [[package]]
 name = "tari_key_manager"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
  "digest 0.8.1",
  "rand 0.7.3",
@@ -4190,7 +4190,7 @@ dependencies = [
 
 [[package]]
 name = "tari_merge_mining_proxy"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
  "bincode",
  "bytes 0.5.6",
@@ -4228,7 +4228,7 @@ dependencies = [
 
 [[package]]
 name = "tari_mining_node"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
  "chrono",
  "crossbeam",
@@ -4251,7 +4251,7 @@ dependencies = [
 
 [[package]]
 name = "tari_mmr"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
  "bincode",
  "blake2",
@@ -4270,7 +4270,7 @@ dependencies = [
 
 [[package]]
 name = "tari_p2p"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
  "anyhow",
  "bytes 0.4.12",
@@ -4310,7 +4310,7 @@ dependencies = [
 
 [[package]]
 name = "tari_service_framework"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
  "anyhow",
  "futures 0.3.6",
@@ -4327,7 +4327,7 @@ dependencies = [
 
 [[package]]
 name = "tari_shutdown"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
  "futures 0.3.6",
  "tokio",
@@ -4335,7 +4335,7 @@ dependencies = [
 
 [[package]]
 name = "tari_storage"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
  "bincode",
  "bytes 0.4.12",
@@ -4353,7 +4353,7 @@ dependencies = [
 
 [[package]]
 name = "tari_test_utils"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
  "futures 0.3.6",
  "futures-test",
@@ -4383,7 +4383,7 @@ dependencies = [
 
 [[package]]
 name = "tari_wallet"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
  "aes-gcm",
  "bincode",
@@ -4409,7 +4409,7 @@ dependencies = [
  "tari_comms_dht",
  "tari_core",
  "tari_crypto",
- "tari_key_manager 0.8.2",
+ "tari_key_manager 0.8.3",
  "tari_p2p",
  "tari_service_framework",
  "tari_shutdown",
@@ -4425,7 +4425,7 @@ dependencies = [
 
 [[package]]
 name = "tari_wallet_ffi"
-version = "0.16.17"
+version = "0.16.18"
 dependencies = [
  "chrono",
  "env_logger 0.7.1",
@@ -4440,7 +4440,7 @@ dependencies = [
  "tari_comms_dht",
  "tari_core",
  "tari_crypto",
- "tari_key_manager 0.8.2",
+ "tari_key_manager 0.8.3",
  "tari_p2p",
  "tari_shutdown",
  "tari_utilities",
@@ -4475,7 +4475,7 @@ dependencies = [
 
 [[package]]
 name = "test_faucet"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
  "rand 0.7.3",
  "serde 1.0.123",

--- a/applications/tari_app_grpc/Cargo.toml
+++ b/applications/tari_app_grpc/Cargo.toml
@@ -4,7 +4,7 @@ authors = ["The Tari Development Community"]
 description = "This crate is to provide a single source for all cross application grpc files and conversions to and from tari::core"
 repository = "https://github.com/tari-project/tari"
 license = "BSD-3-Clause"
-version = "v0.8.3"
+version = "0.8.3"
 edition = "2018"
 
 [dependencies]

--- a/applications/tari_app_utilities/Cargo.toml
+++ b/applications/tari_app_utilities/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tari_app_utilities"
-version = "v0.8.3"
+version = "0.8.3"
 authors = ["Philip Robinson <simian@tari.com>"]
 edition = "2018"
 

--- a/applications/tari_base_node/Cargo.toml
+++ b/applications/tari_base_node/Cargo.toml
@@ -4,7 +4,7 @@ authors = ["The Tari Development Community"]
 description = "The tari full base node implementation"
 repository = "https://github.com/tari-project/tari"
 license = "BSD-3-Clause"
-version = "v0.8.3"
+version = "0.8.3"
 edition = "2018"
 
 [dependencies]

--- a/applications/tari_console_wallet/Cargo.toml
+++ b/applications/tari_console_wallet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tari_console_wallet"
-version = "v0.8.3"
+version = "0.8.3"
 authors = ["Philip Robinson <simian@tari.com>"]
 edition = "2018"
 

--- a/applications/tari_merge_mining_proxy/Cargo.toml
+++ b/applications/tari_merge_mining_proxy/Cargo.toml
@@ -4,7 +4,7 @@ authors = ["The Tari Development Community"]
 description = "The tari merge miner proxy for xmrig"
 repository = "https://github.com/tari-project/tari"
 license = "BSD-3-Clause"
-version = "v0.8.3"
+version = "0.8.3"
 edition = "2018"
 
 [features]

--- a/applications/tari_mining_node/Cargo.toml
+++ b/applications/tari_mining_node/Cargo.toml
@@ -4,7 +4,7 @@ authors = ["The Tari Development Community"]
 description = "The tari mining node implementation"
 repository = "https://github.com/tari-project/tari"
 license = "BSD-3-Clause"
-version = "v0.8.3"
+version = "0.8.3"
 edition = "2018"
 
 [dependencies]

--- a/applications/test_faucet/Cargo.toml
+++ b/applications/test_faucet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "test_faucet"
-version = "v0.8.3"
+version = "0.8.3"
 authors = ["The Tari Development Community"]
 edition = "2018"
 

--- a/base_layer/common_types/Cargo.toml
+++ b/base_layer/common_types/Cargo.toml
@@ -3,7 +3,7 @@ name = "tari_common_types"
 authors = ["The Tari Development Community"]
 description = "Tari cryptocurrency common types"
 license = "BSD-3-Clause"
-version = "v0.8.3"
+version = "0.8.3"
 edition = "2018"
 
 [dependencies]

--- a/base_layer/core/Cargo.toml
+++ b/base_layer/core/Cargo.toml
@@ -6,7 +6,7 @@ repository = "https://github.com/tari-project/tari"
 homepage = "https://tari.com"
 readme = "README.md"
 license = "BSD-3-Clause"
-version = "v0.8.3"
+version = "0.8.3"
 edition = "2018"
 
 [features]

--- a/base_layer/key_manager/Cargo.toml
+++ b/base_layer/key_manager/Cargo.toml
@@ -4,7 +4,7 @@ authors = ["The Tari Development Community"]
 description = "Tari cryptocurrency wallet key management"
 repository = "https://github.com/tari-project/tari"
 license = "BSD-3-Clause"
-version = "v0.8.3"
+version = "0.8.3"
 edition = "2018"
 
 [dependencies]

--- a/base_layer/mmr/Cargo.toml
+++ b/base_layer/mmr/Cargo.toml
@@ -4,7 +4,7 @@ authors = ["The Tari Development Community"]
 description = "A Merkle Mountain Range implementation"
 repository = "https://github.com/tari-project/tari"
 license = "BSD-3-Clause"
-version = "v0.8.3"
+version = "0.8.3"
 edition = "2018"
 
 [features]

--- a/base_layer/p2p/Cargo.toml
+++ b/base_layer/p2p/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tari_p2p"
-version = "v0.8.3"
+version = "0.8.3"
 authors = ["The Tari Development community"]
 description = "Tari base layer-specific peer-to-peer communication features"
 repository = "https://github.com/tari-project/tari"

--- a/base_layer/service_framework/Cargo.toml
+++ b/base_layer/service_framework/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tari_service_framework"
-version = "v0.8.3"
+version = "0.8.3"
 authors = ["The Tari Development Community"]
 description = "The Tari communication stack service framework"
 repository = "https://github.com/tari-project/tari"

--- a/base_layer/wallet/Cargo.toml
+++ b/base_layer/wallet/Cargo.toml
@@ -3,7 +3,7 @@ name = "tari_wallet"
 authors = ["The Tari Development Community"]
 description = "Tari cryptocurrency wallet library"
 license = "BSD-3-Clause"
-version = "v0.8.3"
+version = "0.8.3"
 edition = "2018"
 
 [dependencies]
@@ -43,7 +43,7 @@ bincode = "1.3.1"
 
 [dependencies.tari_core]
 path = "../../base_layer/core"
-version = "v0.8.3"
+version = "^0.8"
 default-features = false
 features = ["transactions", "mempool_proto", "base_node_proto"]
 

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -6,7 +6,7 @@ repository = "https://github.com/tari-project/tari"
 homepage = "https://tari.com"
 readme = "README.md"
 license = "BSD-3-Clause"
-version = "v0.8.3"
+version = "0.8.3"
 edition = "2018"
 
 

--- a/comms/Cargo.toml
+++ b/comms/Cargo.toml
@@ -6,7 +6,7 @@ repository = "https://github.com/tari-project/tari"
 homepage = "https://tari.com"
 readme = "README.md"
 license = "BSD-3-Clause"
-version = "v0.8.3"
+version = "0.8.3"
 edition = "2018"
 
 [dependencies]

--- a/comms/dht/Cargo.toml
+++ b/comms/dht/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tari_comms_dht"
-version = "v0.8.3"
+version = "0.8.3"
 authors = ["The Tari Development Community"]
 description = "Tari comms DHT module"
 repository = "https://github.com/tari-project/tari"

--- a/comms/rpc_macros/Cargo.toml
+++ b/comms/rpc_macros/Cargo.toml
@@ -6,7 +6,7 @@ repository = "https://github.com/tari-project/tari"
 homepage = "https://tari.com"
 readme = "README.md"
 license = "BSD-3-Clause"
-version = "v0.8.3"
+version = "0.8.3"
 edition = "2018"
 
 [lib]

--- a/infrastructure/derive/Cargo.toml
+++ b/infrastructure/derive/Cargo.toml
@@ -6,7 +6,7 @@ repository = "https://github.com/tari-project/tari"
 homepage = "https://tari.com"
 readme = "README.md"
 license = "BSD-3-Clause"
-version = "v0.8.3"
+version = "0.8.3"
 edition = "2018"
 
 [lib]

--- a/infrastructure/shutdown/Cargo.toml
+++ b/infrastructure/shutdown/Cargo.toml
@@ -6,7 +6,7 @@ repository = "https://github.com/tari-project/tari"
 homepage = "https://tari.com"
 readme = "README.md"
 license = "BSD-3-Clause"
-version = "v0.8.3"
+version = "0.8.3"
 edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/infrastructure/storage/Cargo.toml
+++ b/infrastructure/storage/Cargo.toml
@@ -6,7 +6,7 @@ repository = "https://github.com/tari-project/tari"
 homepage = "https://tari.com"
 readme = "README.md"
 license = "BSD-3-Clause"
-version = "v0.8.3"
+version = "0.8.3"
 edition = "2018"
 
 [dependencies]

--- a/infrastructure/test_utils/Cargo.toml
+++ b/infrastructure/test_utils/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tari_test_utils"
 description = "Utility functions used in Tari test functions"
-version = "v0.8.3"
+version = "0.8.3"
 authors = ["The Tari Development Community"]
 edition = "2018"
 license = "BSD-3-Clause"


### PR DESCRIPTION
Changes since v0.8.2

Base Node
---
- [#2635](https://github.com/tari-project/tari/pull/2635) [base-node] Add user agent to peer display info (#2635)
- [#2626](https://github.com/tari-project/tari/pull/2626) [base-node] Add duplicate input_output tx validator

Wallet
---
- [#2656](https://github.com/tari-project/tari/pull/2656) [wallet] Fixed timelocked balance
- [#2632](https://github.com/tari-project/tari/pull/2632) [wallet] Update TXO validation protocol to use RPC interface to base node
- [#2624](https://github.com/tari-project/tari/pull/2624) [wallet] Set confirmations required via libwallet and config
- [#2644](https://github.com/tari-project/tari/pull/2644) [wallet] Add unique constraint to commitment in outputs table
- [#2637](https://github.com/tari-project/tari/pull/2637) [wallet] Update Transaction Receiver protocol to persist transaction earlier
- [#2625](https://github.com/tari-project/tari/pull/2625) [wallet] Remove the Tor identity getter from the FFI
- [#2614](https://github.com/tari-project/tari/pull/2614) [wallet] New Transaction Validation protocol for Wallet
- [#2619](https://github.com/tari-project/tari/pull/2619) [wallet] Add tx sending mechanism to wallet

Mining Node
---
- [#2652](https://github.com/tari-project/tari/pull/2652) [mining-node] Recreated symlinks without extension
- [#2649](https://github.com/tari-project/tari/pull/2649) [mining-node] Add mining node to distribution

Merge Mining Proxy
---
- [#2631](https://github.com/tari-project/tari/pull/2631) [mmproxy] Fix missing Content-Type header in some json responses
- [#2616](https://github.com/tari-project/tari/pull/2616) [merge-mining] submit_block returns OK if block was submitted for tari or monero

Other
---
- [#2655](https://github.com/tari-project/tari/pull/2655) [tests] Remove cancelled output excluded test
- [#2647](https://github.com/tari-project/tari/pull/2647) [tests] Minor improvements to DHT logging
- [#2653](https://github.com/tari-project/tari/pull/2653) [tests] Speed up `Transaction Info` Cucumber test
- [#2643](https://github.com/tari-project/tari/pull/2643) [common] Dont propagate messages we have already
- [#2612](https://github.com/tari-project/tari/pull/2612) [ci] Optimize integration tests
- [#2651](https://github.com/tari-project/tari/pull/2651) [tests] Fix num confirmations test backend
- [#2641](https://github.com/tari-project/tari/pull/2641) [common] Retry peers that have been marked as offline after a length of time
- [#2650](https://github.com/tari-project/tari/pull/2650) [ci] Allow CI to use latest mdbook
- [#2627](https://github.com/tari-project/tari/pull/2627) [tests] Double spend test for mempool transaction selection
- [#2623](https://github.com/tari-project/tari/pull/2623) [chore] Add extra logging to help investigate fee mismatch
- [#2630](https://github.com/tari-project/tari/pull/2630) [common] Shorter ban for RPC negotiation timeout in header sync, RPC timeout configurable
- [#2629](https://github.com/tari-project/tari/pull/2629) [chore] Clean up duplicate check
- [#2628](https://github.com/tari-project/tari/pull/2628) [tests] Add test_find_duplicate_input
- [#2648](https://github.com/tari-project/tari/pull/2648) [ci] Run cargo test with verbose output
- [#2638](https://github.com/tari-project/tari/pull/2638) [common] Ban peers that flood messages
- [#2636](https://github.com/tari-project/tari/pull/2636) [explorer] Add a nodejs block explorer
- [#2634](https://github.com/tari-project/tari/pull/2634) [fix] Dont store messages of a banned peer
- [#2613](https://github.com/tari-project/tari/pull/2613) [tests] Add unit tests for lock heights
