### PR TITLE
Fix flaky wallet test

### DIFF
--- a/base_layer/wallet/tests/support/rpc.rs
+++ b/base_layer/wallet/tests/support/rpc.rs
@@ -200,15 +200,20 @@ impl BaseNodeWalletRpcMockState {
     ) -> Result<Vec<Vec<Signature>>, String>
     {
         let now = Instant::now();
+        let mut count = 0usize;
         while now.elapsed() < timeout {
             let mut lock = acquire_lock!(self.transaction_batch_query_calls);
+            count = (*lock).len();
             if (*lock).len() >= num_calls {
                 return Ok((*lock).drain(..num_calls).collect());
             }
             drop(lock);
             delay_for(Duration::from_millis(100)).await;
         }
-        Err("Did not receive enough calls within the timeout period".to_string())
+        Err(format!(
+            "Did not receive enough calls within the timeout period, received {}, expected {}.",
+            count, num_calls
+        ))
     }
 
     pub async fn wait_pop_submit_transaction_calls(

--- a/base_layer/wallet/tests/transaction_service/service.rs
+++ b/base_layer/wallet/tests/transaction_service/service.rs
@@ -4406,7 +4406,7 @@ fn start_validation_protocol_then_broadcast_protocol_change_base_node() {
         _shutdown,
         _mock_rpc_server,
         server_node_identity,
-        rpc_service_state,
+        mut rpc_service_state,
     ) = setup_transaction_service_no_comms(&mut runtime, factories.clone(), backend, None);
 
     rpc_service_state.set_transaction_query_response(TxQueryResponse {
@@ -4415,6 +4415,7 @@ fn start_validation_protocol_then_broadcast_protocol_change_base_node() {
         confirmations: 1,
         is_synced: true,
     });
+    rpc_service_state.set_response_delay(Some(Duration::from_secs(2)));
 
     runtime
         .block_on(alice_ts.set_base_node_public_key(server_node_identity.public_key().clone()))
@@ -4486,7 +4487,7 @@ fn start_validation_protocol_then_broadcast_protocol_change_base_node() {
         .unwrap();
 
     let _tx_batch_query_calls =
-        runtime.block_on(rpc_service_state.wait_pop_transaction_batch_query_calls(3, Duration::from_secs(60)));
+        runtime.block_on(rpc_service_state.wait_pop_transaction_batch_query_calls(6, Duration::from_secs(30)));
 
     let completed_txs = runtime.block_on(alice_ts.get_completed_transactions()).unwrap();
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
`start_validation_protocol_then_broadcast_protocol_change_base_node` proved to be flaky in Windows and Ubuntu release mode, especially ona fast machine.

Thanks to @philipr-za for providing part of the answer.

## Motivation and Context
Unit tests should not be flaky.

## How Has This Been Tested?
Running `cargo test --release --all-features --no-fail-fast` in Windows and Ubuntu successfully.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [X] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [X] I'm merging against the `development` branch.
* [X] I ran `cargo-fmt --all` before pushing.
* [X] I ran `cargo test` successfully before submitting my PR.
* [X] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
