### PR TITLE
[base-node] Don't send duplicate kernels and utxos in sync mode

### DIFF
--- a/applications/tari_base_node/src/command_handler.rs
+++ b/applications/tari_base_node/src/command_handler.rs
@@ -163,12 +163,15 @@ impl CommandHandler {
             let banned_peers = banned_peers(&peer_manager).await.unwrap();
             let conns = connectivity.get_active_connections().await.unwrap();
             println!(
-                "{}: State: {}, Tip: {} ({}), Mempool: {} tx, Mining (H/R): {} ({} MH/s), Connections: {}, Banned: {}",
+                "{}: State: {}, Tip: {} ({}), Mempool: {}tx ({}g, +/- {}blks), Mining: {} ({} MH/s), Connections: {}, \
+                 Banned: {}",
                 Utc::now().format("%H:%M"),
                 state.state_info.short_desc(),
                 metadata.height_of_longest_chain(),
                 last_block_time.to_rfc2822(),
                 mempool_stats.total_txs,
+                mempool_stats.total_weight,
+                mempool_stats.total_weight / 19500,
                 mining_status,
                 hash_rate,
                 conns.len(),

--- a/base_layer/core/src/base_node/state_machine_service/states/horizon_state_sync/error.rs
+++ b/base_layer/core/src/base_node/state_machine_service/states/horizon_state_sync/error.rs
@@ -47,8 +47,13 @@ pub enum HorizonSyncError {
     JoinError(#[from] task::JoinError),
     #[error("Invalid kernel signature: {0}")]
     InvalidKernelSignature(TransactionError),
-    #[error("Validation failed for {0} MMR")]
-    InvalidMmrRoot(MmrTree),
+    #[error("MMR did not match for {mmr_tree} at height {at_height}. {expected_hex} did not equal {actual_hex}")]
+    InvalidMmrRoot {
+        mmr_tree: MmrTree,
+        at_height: u64,
+        expected_hex: String,
+        actual_hex: String,
+    },
     #[error("Invalid range proof for output:{0} : {1}")]
     InvalidRangeProof(String, String),
     #[error("Base node request error: {0}")]

--- a/base_layer/core/src/chain_storage/lmdb_db/lmdb_db.rs
+++ b/base_layer/core/src/chain_storage/lmdb_db/lmdb_db.rs
@@ -1290,16 +1290,18 @@ impl BlockchainBackend for LMDBDatabase {
                 header.kernel_mmr_size
             };
 
-            let mut result = Vec::with_capacity((end - start) as usize);
+            let total_size = (end - start) as usize + 1;
+            let mut result = Vec::with_capacity(total_size);
 
             let mut skip_amount = (start - previous_mmr_count) as usize;
             debug!(
                 target: LOG_TARGET,
-                "Fetching kernels by MMR position. Start {}, end {}, starting in header at height {},  prev mmr \
-                 count: {}, skipping the first:{}",
+                "Fetching kernels by MMR position. Start {}, end {}, in headers at height {}-{},  prev mmr count: {}, \
+                 skipping the first:{}",
                 start,
                 end,
                 start_height,
+                end_height,
                 previous_mmr_count,
                 skip_amount
             );
@@ -1321,6 +1323,7 @@ impl BlockchainBackend for LMDBDatabase {
                     )?
                     .into_iter()
                     .skip(skip_amount)
+                    .take(total_size - result.len())
                     .map(|f| f.kernel),
                 );
 
@@ -1353,7 +1356,8 @@ impl BlockchainBackend for LMDBDatabase {
                 header.output_mmr_size
             };
 
-            let mut result = Vec::with_capacity((end - start) as usize);
+            let total_size = (end - start) as usize + 1;
+            let mut result = Vec::with_capacity(total_size);
             let mut deleted_result = vec![];
 
             let mut skip_amount = (start - previous_mmr_count) as usize;
@@ -1385,6 +1389,7 @@ impl BlockchainBackend for LMDBDatabase {
                     )?
                     .into_iter()
                     .skip(skip_amount)
+                    .take(total_size - result.len())
                     .map(|row| {
                         if deleted.contains(row.mmr_position) {
                             return PrunedOutput::Pruned {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Previously when requesting kernels and utxos (e.g. 2-1000), if the end MMR node requested was in the middle of a block, the rest of the block would be transmitted resulting in duplicate MMR nodes being sent. This caused the error: 
MMR did not match for kernels, b776677e03d29f9debfcec364286e9c94a5b8b98593826168cfc382c2c68ddf0 != 2a834b68f70a355034c11bba8f1ace763dbbdf0535540a33cd8f96848bb33f29

Also added the weight and number of blocks in the transaction to the mempool stats displayed in the `status()` command of the base node
