### PR TITLE
Updated old build scripts to include tari_mining_node

### DIFF
--- a/applications/tari_base_node/osx-pkg/build_pkg.sh
+++ b/applications/tari_base_node/osx-pkg/build_pkg.sh
@@ -46,6 +46,7 @@ COPY_BIN_FILES=(
   "tari_base_node"
   "tari_console_wallet"
   "tari_merge_mining_proxy"
+  "tari_mining_node"
 )
 for COPY_BIN_FILE in "${COPY_BIN_FILES[@]}"; do
   # Verify signed?

--- a/scripts/build_dists_tarball.sh
+++ b/scripts/build_dists_tarball.sh
@@ -142,7 +142,9 @@ if [[ "$1" =~ ^latest* ]]; then
 
   if [ "$1" == "latest-tagv" ]; then
     #gitTagVersion=$(git describe --tags --match "v[0-9]*" --abbrev=4 HEAD)
-    gitTagVersion=$(git describe --tags `git rev-list --tags=v[0-9].[0-9].[0-9]* --max-count=1`)
+    #gitTagVersion=$(git describe --tags `git rev-list --tags=v[0-9].[0-9].[0-9]* --max-count=1`)
+    # git match/tag does not do RegEx!
+    gitTagVersion=$(git tag --list --sort=-version:refname "v*" | head -n 1)
   fi
   git checkout tags/$gitTagVersion -B $gitTagVersion-build
 else
@@ -210,6 +212,7 @@ COPY_FILES=(
   "target/release/tari_base_node"
   "target/release/tari_console_wallet"
   "target/release/tari_merge_mining_proxy"
+  "target/release/tari_mining_node"
   "common/config/presets/tari_sample.toml"
   "common/config/tari_config_example.toml"
   "common/logging/log4rs_sample_base_node.yml"


### PR DESCRIPTION
Updated old build scripts to include tari_mining_node for OSX and Ubuntu.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [ ] I'm merging against the `development` branch.
* [ ] I ran `cargo-fmt --all` before pushing.
* [ ] I ran `cargo test` successfully before submitting my PR.
* [ ] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
