### PR TITLE
Update Wallet FFI interface for new wallet validation behaviour

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4425,7 +4425,7 @@ dependencies = [
 
 [[package]]
 name = "tari_wallet_ffi"
-version = "0.16.18"
+version = "0.16.19"
 dependencies = [
  "chrono",
  "env_logger 0.7.1",

--- a/base_layer/wallet/src/transaction_service/service.rs
+++ b/base_layer/wallet/src/transaction_service/service.rs
@@ -589,7 +589,7 @@ where
             TransactionServiceRequest::ValidateTransactions(retry_strategy) => self
                 .start_transaction_validation_protocol(retry_strategy, transaction_validation_join_handles)
                 .await
-                .map(|id| TransactionServiceResponse::ValidationStarted(id)),
+                .map(TransactionServiceResponse::ValidationStarted),
         }
     }
 

--- a/base_layer/wallet_ffi/wallet.h
+++ b/base_layer/wallet_ffi/wallet.h
@@ -445,7 +445,7 @@ struct TariWallet *wallet_create(struct TariWalletConfig *config,
                                     void (*callback_received_finalized_transaction)(struct TariCompletedTransaction*),
                                     void (*callback_transaction_broadcast)(struct TariCompletedTransaction*),
                                     void (*callback_transaction_mined)(struct TariCompletedTransaction*),
-                                    void (*callback_transaction_mined)(struct TariCompletedTransaction*, unsigned long long),
+                                    void (*callback_transaction_mined_unconfirmed)(struct TariCompletedTransaction*, unsigned long long),
                                     void (*callback_direct_send_result)(unsigned long long, bool),
                                     void (*callback_store_and_forward_send_result)(unsigned long long, bool),
                                     void (*callback_transaction_cancellation)(struct TariCompletedTransaction*),
@@ -544,6 +544,10 @@ unsigned long long wallet_start_invalid_txo_validation(struct TariWallet *wallet
 
 //This function will tell the wallet to query the set base node to confirm the status of mined transactions.
 unsigned long long wallet_start_transaction_validation(struct TariWallet *wallet, int* error_out);
+
+//This function will tell the wallet retart any broadcast protocols for completed transactions. Ideally this should be
+// called after a successfuly Transaction Validation is complete
+bool wallet_restart_transaction_broadcast(struct TariWallet *wallet, int* error_out);
 
 // Set the power mode of the wallet to Low Power mode which will reduce the amount of network operations the wallet performs to conserve power
 void wallet_set_low_power_mode(struct TariWallet *wallet, int* error_out);


### PR DESCRIPTION
## Description

This PR updates the way a client launches validation tasks in the wallet and updates the FFI interface to reflect these new methods and maps the new Event types to new callbacks to monitor the progress of the various validation protocols.

Previously the wallet would automatically launch these validation protocols when a base node was set and changed. However, to offer the clients of LibWallet more flexibility in how they handle the results of validation this automatic launching of validation was removed from LibWallet and the responsibility for launching the various validation protocols was moved to the Client of the library. Now the Console Wallet and the Mobile wallet will have to explicitly launch the various validation protocols. They will be provided with a request key for that protocol and then they can monitor its progress via the event stream, and in the FFI libs case via the new Callbacks which the events will trigger.

There are 4 different Validation protocols in the wallet now:
1. UTXO Validation (Unspent TXOs)
2. STXO Validation (Spent TXOs)
3. Invalid TXO Validation (Invalid TXOs)
4. Transaction Validation

The three TXO validations will confirm your balance according the base node you are connected to. The Transaction Validation will confirm which of your mined transaction are valid according to the Base Node you are connected to. This validation will indicate its results by updating the `.valid` on a CompletedTransaction. 

It is now the Client’s responsibility to launch all 4 of these validations when a new base node is set or changed.  Once the First set of Validation protocols are complete the Client must also manually trigger restarting Transaction Broadcast Protocols. This only needs to happen when the wallet first sets a base node, subsequent base node changes do not need to restart broadcast protocols but doing so is not an issue. The console wallet and base node wallet was updated to reflect this change but the FFI clients will still need do this.

The FFI interface has been updated by adding/updating/removing the following methods:

`unsigned long long wallet_sync_with_base_node(struct TariWallet *wallet, int* error_out);` is removed in favour of the following 4 methods:

`unsigned long long wallet_start_utxo_validation(struct TariWallet *wallet, int* error_out);`
`unsigned long long wallet_start_stxo_validation(struct TariWallet *wallet, int* error_out);`
`unsigned long long wallet_start_invalid_txo_validation(struct TariWallet *wallet, int* error_out);`
`unsigned long long wallet_start_transaction_validation(struct TariWallet *wallet, int* error_out);`

This PR also adds the `bool wallet_restart_transaction_broadcast(struct TariWallet *wallet, int* error_out);` method which used to be started automatically after Validation but now will need to be called by the client. It restarts any Transaction Broadcast Protocols for completed transactions that need to be broadcast. Ideally it should be called after the first successful Transaction Validation on startup but it can be called after the Base Node is set. It only needs to be called once on startup, not on every base node change. However, there is no harm in calling it again.

To check a transaction validity the following method is added:
`bool completed_transaction_is_valid(struct TariCompletedTransaction *tx, int* error_out);`

A number of new callbacks have been added for 2 sets of functionality. Firstly the Wallet now has the concept of a Mined but Unconfirmed transaction. When a transaction is unconfirmed it means its mined but needs few more blocks to be mined before the wallet will decided its sure that transaction is valid. Only once a transaction in Confirmed will the balance become available to spend.

The `callback_transaction_mined_unconfirmed: unsafe extern "C" fn(*mut CompletedTransaction, u64)` callback is added to the FFI which will be called multiple times while a transaction is detected as Mined but not Unconfirmed, the second argument in the callback will contain how many confirmations the transaction currently has. This will be called every time the base node is polled.

The existing `callback_transaction_mined: unsafe extern "C" fn(*mut CompletedTransaction)` callback will be used to indicate that a transaction is Mined and Confirmed.

The `callback_base_node_sync_complete: unsafe extern "C" fn(TxId, bool)` callback has been removed and replaced with 4 separate callbacks, one for each type of validation:
`callback_utxo_validation_complete: unsafe extern "C" fn(TxId, u8)`
`callback_stxo_validation_complete: unsafe extern "C" fn(TxId, u8)`
`callback_invalid_txo_validation_complete: unsafe extern "C" fn(TxId, u8)`
`callback_transaction_validation_complete: unsafe extern "C" fn(TxId, u8)`

For each of these callbacks the first argument is the Request Id returned by the method that launches it and the second argument encodes the result of the validation which is a u8 representation of the following enum:
```
enum CallbackValidationResults {
    Success,           // 0
    Aborted,           // 1
    Failure,           // 2
    BaseNodeNotInSync, // 3
}
```
`Success` is obvious, `Aborted` means that during the validation the Client changed the Base node so the old validation was aborted, `Failure` means the protocol could not be completed because a connection could not be made or the RPC broke, `BaseNodeNotInSync` means that the wallet was able to successfully connect to the Base Node but the Base Node reported not being in Sync and so the validation could not be completed.

The `wallet_create(…)` function has been updated to accept all these new callbacks.

@mikethetike @kukabi We will need to apply these changes to the JNI and Swift wrappers and it is quite a large change to the App logic.

## How Has This Been Tested?
Many tests updated and provided

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [x] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch.
* [x] I ran `cargo-fmt --all` before pushing.
* [x] I ran `cargo test` successfully before submitting my PR.
* [x] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
