### PR TITLE
[wallet] Remove tx/s from make-it-rain

### DIFF
--- a/applications/tari_console_wallet/src/automation/command_parser.rs
+++ b/applications/tari_console_wallet/src/automation/command_parser.rs
@@ -63,7 +63,6 @@ pub enum ParsedArgument {
     Amount(MicroTari),
     PublicKey(PublicKey),
     Text(String),
-    Float(f64),
     Int(u64),
     Date(DateTime<Utc>),
 }
@@ -74,7 +73,6 @@ impl Display for ParsedArgument {
             ParsedArgument::Amount(v) => write!(f, "{}", v.to_string()),
             ParsedArgument::PublicKey(v) => write!(f, "{}", v.to_string()),
             ParsedArgument::Text(v) => write!(f, "{}", v.to_string()),
-            ParsedArgument::Float(v) => write!(f, "{}", v.to_string()),
             ParsedArgument::Int(v) => write!(f, "{}", v.to_string()),
             ParsedArgument::Date(v) => write!(f, "{}", v.to_string()),
         }
@@ -102,23 +100,9 @@ fn parse_make_it_rain(mut args: SplitWhitespace) -> Result<Vec<ParsedArgument>, 
     let mut parsed_args = Vec::new();
 
     // txs per second
-    let txps = args.next().ok_or_else(|| ParseError::Empty("Txs/s".to_string()))?;
-    let txps = txps.parse::<f64>().map_err(ParseError::Float)?;
-    if txps > 25.0 {
-        println!("Maximum transaction rate is 25/sec");
-        return Err(ParseError::Invalid);
-    }
-    parsed_args.push(ParsedArgument::Float(txps));
-
-    // duration
-    let duration = args.next().ok_or_else(|| ParseError::Empty("duration".to_string()))?;
-    let duration = duration.parse::<u64>().map_err(ParseError::Int)?;
-    parsed_args.push(ParsedArgument::Int(duration));
-
-    if (txps * duration as f64) < 1.0 {
-        println!("Invalid data provided for [number of Txs/s] * [test duration (s)], must be >= 1\n");
-        return Err(ParseError::Invalid);
-    }
+    let txs = args.next().ok_or_else(|| ParseError::Empty("Txs".to_string()))?;
+    let txs = txs.parse::<u64>().map_err(ParseError::Int)?;
+    parsed_args.push(ParsedArgument::Int(txs));
 
     // start amount
     let start_amount = args

--- a/applications/tari_console_wallet/src/automation/commands.rs
+++ b/applications/tari_console_wallet/src/automation/commands.rs
@@ -106,37 +106,32 @@ pub async fn make_it_rain(
 {
     use ParsedArgument::*;
 
-    let txps = match args[0].clone() {
-        Float(r) => Ok(r),
+    let txs = match args[0].clone() {
+        Int(r) => Ok(r),
         _ => Err(CommandError::Argument),
     }?;
 
-    let duration = match args[1].clone() {
-        Int(s) => Ok(s),
-        _ => Err(CommandError::Argument),
-    }?;
-
-    let start_amount = match args[2].clone() {
+    let start_amount = match args[1].clone() {
         Amount(mtari) => Ok(mtari),
         _ => Err(CommandError::Argument),
     }?;
 
-    let inc_amount = match args[3].clone() {
+    let inc_amount = match args[2].clone() {
         Amount(mtari) => Ok(mtari),
         _ => Err(CommandError::Argument),
     }?;
 
-    let start_time = match args[4].clone() {
+    let start_time = match args[3].clone() {
         Date(dt) => Ok(dt as DateTime<Utc>),
         _ => Err(CommandError::Argument),
     }?;
 
-    let public_key = match args[5].clone() {
+    let public_key = match args[4].clone() {
         PublicKey(pk) => Ok(pk),
         _ => Err(CommandError::Argument),
     }?;
 
-    let message = match args[6].clone() {
+    let message = match args[5].clone() {
         Text(m) => Ok(m),
         _ => Err(CommandError::Argument),
     }?;
@@ -159,19 +154,9 @@ pub async fn make_it_rain(
     );
     delay_for(Duration::from_millis(delay_ms)).await;
 
-    let num_txs = (txps * duration as f64) as usize;
-
     let mut tx_ids = Vec::new();
-    let started_at = Utc::now();
 
-    for i in 0..num_txs {
-        // Manage Tx rate
-        let actual_ms = (Utc::now() - started_at).num_milliseconds() as u64;
-        let target_ms = (i as f64 / (txps / 1000.0)) as u64;
-        if target_ms - actual_ms > 0 {
-            // Maximum delay between Txs set to 120 s
-            delay_for(Duration::from_millis((target_ms - actual_ms).min(120_000u64))).await;
-        }
+    for i in 0..txs {
         // Send Tx
         let amount = start_amount + inc_amount * (i as u64);
         let send_args = vec![


### PR DESCRIPTION
Remove transactions per second from this call in favour of a single amount of transactions to be sent.

The existing code could not guarantee that the tx/s would be reached and was buggy. When calling it with 10 tx/s for 10 seconds, it would always use the 2 minute max timing.  It's a much simpler interface to use a full set of transactions and call them in one go