### PR TITLE
remove circular dependency between tari_core and tari_wallet

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4112,7 +4112,6 @@ dependencies = [
  "tari_shutdown",
  "tari_storage",
  "tari_test_utils",
- "tari_wallet",
  "tempfile",
  "thiserror",
  "tokio",

--- a/base_layer/core/Cargo.toml
+++ b/base_layer/core/Cargo.toml
@@ -71,7 +71,6 @@ config = { version = "0.9.3" }
 env_logger = "0.7.0"
 tempfile = "3.1.0"
 tokio-macros = "0.2.4"
-tari_wallet = { version = "^0.8", path = "../../base_layer/wallet" }
 
 [build-dependencies]
 tari_common = { version = "^0.8", path="../../common"}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
#1766 identified the circular dependency between `tari_wallet` and `tari_core`. [This PR](https://github.com/tari-project/tari/pull/2545/files#diff-3ce6f3262b4ab26ea57750ff3fd16ed5e8094a21617b19d01cfd8813b8919948) removed the tests dependent on `tari_wallet`, so it just needed to be removed as a dependency.
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This PR fixes the circular dependency between `tari_wallet` and `tari_core`.
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #1766. 
## How Has This Been Tested?
`cargo test` and `cargo build` ran successfully.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [x] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch.
* [x] I ran `cargo-fmt --all` before pushing. (This command changed code unrelated to my changes, so I did not commit these changes.)
* [x] I ran `cargo test` successfully before submitting my PR.
* [x] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.