### PR TITLE
Add coinbase handling ability via GRPC with cucumber tests for reorg scenario

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4424,7 +4424,7 @@ dependencies = [
 
 [[package]]
 name = "tari_wallet_ffi"
-version = "0.16.19"
+version = "0.16.21"
 dependencies = [
  "chrono",
  "env_logger 0.7.1",

--- a/applications/tari_app_grpc/proto/wallet.proto
+++ b/applications/tari_app_grpc/proto/wallet.proto
@@ -38,6 +38,10 @@ service Wallet {
     rpc Transfer (TransferRequest)  returns (TransferResponse);
     // Returns the transaction details for the given transaction IDs
     rpc GetTransactionInfo (GetTransactionInfoRequest) returns (GetTransactionInfoResponse);
+    // Returns all transactions' details
+    rpc GetAllCompletedTransactions (GetAllCompletedTransactionsRequest) returns (GetTransactionInfoResponse);
+    // Returns the balance
+    rpc GetBalance (GetBalanceRequest) returns (GetBalanceResponse);
 }
 
 message GetVersionRequest { }
@@ -96,6 +100,7 @@ message TransactionInfo {
     bytes excess_sig = 9;
     google.protobuf.Timestamp timestamp = 10;
     string message = 11;
+    bool valid = 12;
 }
 
 enum TransactionDirection {
@@ -119,6 +124,16 @@ enum TransactionStatus {
     TRANSACTION_STATUS_COINBASE = 5;
     // This transaction is mined and confirmed at the current base node's height
     TRANSACTION_STATUS_MINED_CONFIRMED = 6;
+}
+
+message GetAllCompletedTransactionsRequest { }
+
+message GetBalanceRequest { }
+
+message GetBalanceResponse {
+    uint64 available_balance = 1;
+    uint64 pending_incoming_balance = 2;
+    uint64 pending_outgoing_balance = 3;
 }
 
 message GetCoinbaseRequest {

--- a/base_layer/wallet/src/storage/sqlite_db.rs
+++ b/base_layer/wallet/src/storage/sqlite_db.rs
@@ -442,7 +442,6 @@ impl WalletBackend for WalletSqliteDatabase {
         if current_cipher.is_some() {
             return Err(WalletStorageError::AlreadyEncrypted);
         }
-        dbg!("apply encryp");
 
         let conn = self.database_connection.acquire_lock();
         let secret_key_str = match WalletSettingSql::get(DbKey::CommsSecretKey.to_string(), &conn)? {

--- a/base_layer/wallet/src/transaction_service/protocols/transaction_coinbase_monitoring_protocol.rs
+++ b/base_layer/wallet/src/transaction_service/protocols/transaction_coinbase_monitoring_protocol.rs
@@ -139,7 +139,11 @@ where TBackend: TransactionBackend + 'static
             };
             debug!(
                 target: LOG_TARGET,
-                "Coinbase transaction (TxId: {}) has status '{}'", self.tx_id, completed_tx.status,
+                "Coinbase transaction (TxId: {}) has status '{}' and is cancelled ({}) and is valid ({}).",
+                self.tx_id,
+                completed_tx.status,
+                completed_tx.cancelled,
+                completed_tx.valid,
             );
 
             let mut hashes = Vec::new();
@@ -510,6 +514,12 @@ where TBackend: TransactionBackend + 'static
                         completed_tx.transaction.body.inputs().clone(),
                         completed_tx.transaction.body.outputs().clone(),
                     )
+                    .await
+                    .map_err(|e| TransactionServiceProtocolError::new(self.tx_id, TransactionServiceError::from(e)))?;
+
+                self.resources
+                    .db
+                    .confirm_broadcast_or_coinbase_transaction(self.tx_id)
                     .await
                     .map_err(|e| TransactionServiceProtocolError::new(self.tx_id, TransactionServiceError::from(e)))?;
 

--- a/base_layer/wallet/src/transaction_service/protocols/transaction_validation_protocol.rs
+++ b/base_layer/wallet/src/transaction_service/protocols/transaction_validation_protocol.rs
@@ -480,7 +480,12 @@ where TBackend: TransactionBackend + 'static
                                  updated",
                                 queried_tx.tx_id
                             );
-                            if let Err(e) = self.resources.db.confirm_broadcast_transaction(queried_tx.tx_id).await {
+                            if let Err(e) = self
+                                .resources
+                                .db
+                                .confirm_broadcast_or_coinbase_transaction(queried_tx.tx_id)
+                                .await
+                            {
                                 warn!(
                                     target: LOG_TARGET,
                                     "Error confirming mined transaction (TxId: {}): {}", queried_tx.tx_id, e

--- a/base_layer/wallet/src/transaction_service/storage/database.rs
+++ b/base_layer/wallet/src/transaction_service/storage/database.rs
@@ -82,7 +82,7 @@ pub trait TransactionBackend: Send + Sync + Clone {
     /// Indicated that a completed transaction has been detected as mined on a base node
     fn mine_completed_transaction(&self, tx_id: TxId) -> Result<(), TransactionStorageError>;
     /// Indicated that a broadcast transaction has been detected as confirm on a base node
-    fn confirm_broadcast_transaction(&self, tx_id: TxId) -> Result<(), TransactionStorageError>;
+    fn confirm_broadcast_or_coinbase_transaction(&self, tx_id: TxId) -> Result<(), TransactionStorageError>;
     /// Indicated that a mined transaction has been detected as unconfirmed on a base node, due to reorg or base node
     /// switch
     fn unconfirm_mined_transaction(&self, tx_id: TxId) -> Result<(), TransactionStorageError>;
@@ -698,9 +698,9 @@ where T: TransactionBackend + 'static
         Ok(())
     }
 
-    pub async fn confirm_broadcast_transaction(&self, tx_id: TxId) -> Result<(), TransactionStorageError> {
+    pub async fn confirm_broadcast_or_coinbase_transaction(&self, tx_id: TxId) -> Result<(), TransactionStorageError> {
         let db_clone = self.db.clone();
-        tokio::task::spawn_blocking(move || db_clone.confirm_broadcast_transaction(tx_id))
+        tokio::task::spawn_blocking(move || db_clone.confirm_broadcast_or_coinbase_transaction(tx_id))
             .await
             .map_err(|err| TransactionStorageError::BlockingTaskSpawnError(err.to_string()))??;
         Ok(())

--- a/base_layer/wallet/src/transaction_service/storage/sqlite_db.rs
+++ b/base_layer/wallet/src/transaction_service/storage/sqlite_db.rs
@@ -838,13 +838,14 @@ impl TransactionBackend for TransactionServiceSqliteDatabase {
         Ok(())
     }
 
-    fn confirm_broadcast_transaction(&self, tx_id: u64) -> Result<(), TransactionStorageError> {
+    fn confirm_broadcast_or_coinbase_transaction(&self, tx_id: u64) -> Result<(), TransactionStorageError> {
         let conn = self.database_connection.acquire_lock();
         match CompletedTransactionSql::find_by_cancelled(tx_id, false, &(*conn)) {
             Ok(v) => {
                 if v.status == TransactionStatus::MinedUnconfirmed as i32 ||
                     v.status == TransactionStatus::MinedConfirmed as i32 ||
-                    v.status == TransactionStatus::Broadcast as i32
+                    v.status == TransactionStatus::Broadcast as i32 ||
+                    v.status == TransactionStatus::Coinbase as i32
                 {
                     v.confirm(&(*conn))?;
                 } else {

--- a/base_layer/wallet/tests/transaction_service/transaction_protocols.rs
+++ b/base_layer/wallet/tests/transaction_service/transaction_protocols.rs
@@ -1520,7 +1520,7 @@ async fn tx_validation_protocol_rpc_client_broken_finite_retries() {
         block_hash: None,
         confirmations: 1,
         is_synced: true,
-        height_of_longest_chain: 0
+        height_of_longest_chain: 0,
     });
     rpc_service_state.set_rpc_status_error(Some(RpcStatus::bad_request("blah".to_string())));
 
@@ -1626,7 +1626,7 @@ async fn tx_validation_protocol_base_node_not_synced() {
         block_hash: None,
         confirmations: resources.config.num_confirmations_required.into(),
         is_synced: false,
-        height_of_longest_chain: 0
+        height_of_longest_chain: 0,
     });
 
     rpc_service_state.set_is_synced(false);

--- a/integration_tests/features/TransactionInfo.feature
+++ b/integration_tests/features/TransactionInfo.feature
@@ -12,8 +12,9 @@ Scenario: Get Transaction Info
         # We need to ensure the coinbase lock heights are gone; mine enough blocks
     When I merge mine 4 blocks via PROXY
     Then all nodes are at height 4
-    When I wait for wallet WALLET_A to have more than 1002000 tari
-    And I send 1000000 tari from wallet WALLET_A to wallet WALLET_B at fee 100
+    Then wallet WALLET_A lists all coinbase transactions
+    When I wait for wallet WALLET_A to have at least 1002000 tari
+    And I send 1000000 uT from wallet WALLET_A to wallet WALLET_B at fee 100
     Then wallet WALLET_A detects all transactions are at least Pending
     Then wallet WALLET_B detects all transactions are at least Pending
     Then wallet WALLET_A detects all transactions are at least Completed

--- a/integration_tests/features/WalletMonitoring .feature
+++ b/integration_tests/features/WalletMonitoring .feature
@@ -1,0 +1,58 @@
+@coinbase_reorg
+Feature: Wallet Monitoring 
+
+@critical
+Scenario: Wallets monitoring coinbase after a reorg
+        #
+        # Chain 1:
+        #   Collects 10 coinbases into one wallet, send 7 transactions
+        #
+    Given I have a seed node SEED_A
+        # Add multiple base nodes to ensure more robust comms
+    And I have a base node NODE_A1 connected to seed SEED_A
+    And I have wallet WALLET_A1 connected to seed node SEED_A
+    And I have wallet WALLET_A2 connected to seed node SEED_A
+    And I have a merge mining proxy PROXY_A connected to SEED_A and WALLET_A1
+    When I merge mine 10 blocks via PROXY_A
+    Then all nodes are at height 10
+    And I list all coinbase transactions for wallet WALLET_A1
+    Then wallet WALLET_A1 has 10 coinbase transactions
+    Then wallet WALLET_A1 detects at least 7 coinbase transactions as Mined_Confirmed
+        # Use 7 of the 10 coinbase UTXOs in transactions (others require 3 confirmations)
+    And I multi-send 7 transactions of 1000000 uT from wallet WALLET_A1 to wallet WALLET_A2 at fee 100
+    Then wallet WALLET_A1 detects all transactions are at least Broadcast
+        #
+        # Chain 2:
+        #   Collects 10 coinbases into one wallet, send 7 transactions
+        #
+    And I have a seed node SEED_B
+        # Add multiple base nodes to ensure more robust comms
+    And I have a base node NODE_B1 connected to seed SEED_B
+    And I have wallet WALLET_B1 connected to seed node SEED_B
+    And I have wallet WALLET_B2 connected to seed node SEED_B
+    And I have a merge mining proxy PROXY_B connected to SEED_B and WALLET_B1
+    When I merge mine 10 blocks via PROXY_B
+    Then all nodes are at height 10
+    And I list all coinbase transactions for wallet WALLET_B1
+    Then wallet WALLET_B1 has 10 coinbase transactions
+    Then wallet WALLET_B1 detects at least 7 coinbase transactions as Mined_Confirmed
+        # Use 7 of the 10 coinbase UTXOs in transactions (others require 3 confirmations)
+    And I multi-send 7 transactions of 1000000 uT from wallet WALLET_B1 to wallet WALLET_B2 at fee 100
+    Then wallet WALLET_B1 detects all transactions are at least Broadcast
+        #
+        # Connect Chain 1 and 2
+        #
+        # TODO: This wait is needed to stop next base node task from continuing
+    When I wait 1 seconds
+    And I have a base node NODE_C connected to all seed nodes
+        # Wait for the reorg to filter through
+    When I wait 30 seconds
+    Then all nodes are at height 10
+        # When tip advances past required confirmations, invalid coinbases still being monitored will be cancelled.
+    When I mine 6 blocks on NODE_C
+    Then all nodes are at height 16
+        # Wait for coinbase statuses to change in the wallet
+    When I wait 30 seconds
+    And I list all coinbase transactions for wallet WALLET_A1
+    And I list all coinbase transactions for wallet WALLET_B1
+    Then the number of coinbase transactions for wallet WALLET_A1 and wallet WALLET_B1 are 3 less

--- a/integration_tests/features/WalletRoutingMechanism.feature
+++ b/integration_tests/features/WalletRoutingMechanism.feature
@@ -13,9 +13,9 @@ Scenario Outline: Wallets transacting via specified routing mechanism only
     Then all nodes are at height 20
         # TODO: This wait is needed to stop base nodes from shutting down
     When I wait 1 seconds
-    When I wait for wallet WALLET_A to have more than 100000000 tari
+    When I wait for wallet WALLET_A to have at least 100000000 tari
     #When I print the world
-    And I multi-send 1000000 tari from wallet WALLET_A to all wallets at fee 100
+    And I multi-send 1000000 uT from wallet WALLET_A to all wallets at fee 100
     Then all wallets detect all transactions are at least Pending
     Then all wallets detect all transactions are at least Completed
     Then all wallets detect all transactions are at least Broadcast

--- a/integration_tests/features/support/world.js
+++ b/integration_tests/features/support/world.js
@@ -20,6 +20,7 @@ class CustomWorld {
         this.transactions = {};
         this.peers = {};
         this.transactionsMap = new Map();
+        this.resultStack = [];
     }
 
     async createSeedNode(name) {

--- a/integration_tests/helpers/util.js
+++ b/integration_tests/helpers/util.js
@@ -131,14 +131,46 @@ const getTransactionOutputHash = function(output) {
 }
 
 function consoleLogTransactionDetails(txnDetails, txId) {
-     var found = txnDetails[0];
-     var status = txnDetails[1];
-     if (found) {
-         console.log("  Transaction '" + status.transactions[0]["tx_id"] + "' has status '" +
-             status.transactions[0]["status"] + "' and is_cancelled(" + status.transactions[0]["is_cancelled"] + ")");
-     } else {
+    var found = txnDetails[0];
+    var status = txnDetails[1];
+    if (found) {
+         console.log(
+             "  Transaction " + pad("'" + status.transactions[0]["tx_id"] + "'", 24) +
+             " has status " + pad("'" + status.transactions[0]["status"] + "'", 40) +
+             " and " + pad("is_cancelled(" + status.transactions[0]["is_cancelled"] + ")", 21) +
+             " and " + pad("is_valid(" + status.transactions[0]["valid"] + ")", 16)
+         );
+    } else {
          console.log("  Transaction '" + txId + "' " + status);
-     }
+    }
+}
+
+function consoleLogBalance(balance) {
+    console.log(
+        "  Available " + pad(balance["available_balance"], 16) +
+        " uT, Pending incoming " + pad(balance["pending_incoming_balance"], 16) +
+        " uT, Pending outgoing " + pad(balance["pending_outgoing_balance"], 16) + " uT"
+    );
+}
+
+function consoleLogCoinbaseDetails(txnDetails) {
+    console.log(
+        "  Transaction " + pad("'" + txnDetails["tx_id"] + "'", 24) +
+        " has status " + pad("'" + txnDetails["status"] + "'", 40) +
+        " and " + pad("is_cancelled(" + txnDetails["is_cancelled"] + ")", 21) +
+        " and " + pad("is_valid(" + txnDetails["valid"] + ")", 16)
+    );
+}
+
+function pad(str, length, padLeft=true) {
+    var padding = Array(length).join(' ')
+    if (typeof str === 'undefined')
+        return padding;
+    if (padLeft) {
+        return (padding + str).slice(-padding.length);
+    } else {
+        return (str + padding).substring(' ', padding.length);
+    }
 }
 
 module.exports = {
@@ -150,5 +182,7 @@ module.exports = {
     getFreePort,
     getTransactionOutputHash,
     hexSwitchEndianness,
-    consoleLogTransactionDetails
+    consoleLogTransactionDetails,
+    consoleLogBalance,
+    consoleLogCoinbaseDetails
 };

--- a/integration_tests/package-lock.json
+++ b/integration_tests/package-lock.json
@@ -297,20 +297,15 @@
       "dev": true
     },
     "@grpc/grpc-js": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.2.5.tgz",
-      "integrity": "sha512-CBCNwedw8McnEBq9jvoiJikws16WN0OiHFejQPovY71XkFWSiIqgvydYiDwpvIYDJmhPQ7qZNzW9BPndhXbx1Q==",
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.2.8.tgz",
+      "integrity": "sha512-9C1xiCbnYe/3OFpSuRqz2JgFSOxv6+SlqFhXgRC1nHfXYbLnXvtmsI/NpaMs6k9ZNyV4gyaOOh5Z4McfegQGew==",
       "requires": {
-        "@types/node": "^12.12.47",
+        "@types/node": ">=12.12.47",
         "google-auth-library": "^6.1.1",
         "semver": "^6.2.0"
       },
       "dependencies": {
-        "@types/node": {
-          "version": "12.19.15",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.19.15.tgz",
-          "integrity": "sha512-lowukE3GUI+VSYSu6VcBXl14d61Rp5hA1D+61r16qnwC0lYNSqdxcvRh0pswejorHfS+HgwBasM8jLXz0/aOsw=="
-        },
         "semver": {
           "version": "6.3.0",
           "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
@@ -437,8 +432,7 @@
     "@types/node": {
       "version": "14.11.5",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-14.11.5.tgz",
-      "integrity": "sha512-jVFzDV6NTbrLMxm4xDSIW/gKnk8rQLF9wAzLWIOg+5nU6ACrIMndeBdXci0FGtqJbP9tQvm6V39eshc96TO2wQ==",
-      "dev": true
+      "integrity": "sha512-jVFzDV6NTbrLMxm4xDSIW/gKnk8rQLF9wAzLWIOg+5nU6ACrIMndeBdXci0FGtqJbP9tQvm6V39eshc96TO2wQ=="
     },
     "@types/normalize-package-data": {
       "version": "2.4.0",
@@ -3028,8 +3022,8 @@
       }
     },
     "wallet-grpc-client": {
-      "version": "git://github.com/tari-project/wallet-grpc-client.git#1abca1c91bac9a76ca0db208b6b08f759d4096a4",
-      "from": "git://github.com/tari-project/wallet-grpc-client.git#1abca1c91bac9a76ca0db208b6b08f759d4096a4",
+      "version": "git://github.com/tari-project/wallet-grpc-client.git#c66220fd16e0b0a2f3057a82efd509fd14676a8d",
+      "from": "git://github.com/tari-project/wallet-grpc-client.git#c66220fd16e0b0a2f3057a82efd509fd14676a8d",
       "requires": {
         "@grpc/grpc-js": "^1.2.3",
         "@grpc/proto-loader": "^0.5.5",

--- a/integration_tests/package.json
+++ b/integration_tests/package.json
@@ -25,6 +25,6 @@
     "sha3": "^2.1.3",
     "synchronized-promise": "^0.3.1",
     "tari_crypto": "^0.8.0",
-    "wallet-grpc-client": "git://github.com/tari-project/wallet-grpc-client.git#c4bcea779b9d56dbbca359a9217a5d98d4ba9c95"
+    "wallet-grpc-client": "git://github.com/tari-project/wallet-grpc-client.git#c66220fd16e0b0a2f3057a82efd509fd14676a8d"
   }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Added GRPC interfaces for `get balance` and `get all completed transactions`. Added new cucumber integration tests to verify handling of coinbase transactions after a reorg. Fixed bug in coinbase monitoring protocol regarding the update of statues in the sqlite db.

~~**Note:** Changes to default logging files will be reverted before finalizing this PR; those are needed to do proper analysis for cucumber tests.~~

## Motivation and Context
Problem: Mined coinbases that are reorged out continues to show "mined unconfirmed" instead of being cancelled in the console wallet.

## How Has This Been Tested?
Cucumber integration test `Scenario: Wallets monitoring coinbase after a reorg`.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [X] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [X] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [X] I'm merging against the `development` branch.
* [X] I ran `cargo-fmt --all` before pushing.
* [X] I ran `cargo test` successfully before submitting my PR.
* [X] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [X] I have added tests to cover my changes.
