### PR TITLE
[Tests] Increase delay on test_store_and_forward_send_tx()

### DIFF
--- a/base_layer/wallet/tests/wallet/mod.rs
+++ b/base_layer/wallet/tests/wallet/mod.rs
@@ -22,7 +22,7 @@
 
 use crate::support::utils::{make_input, random_string};
 use rand::rngs::OsRng;
-use std::{sync::Arc, time::Duration};
+use std::{panic, sync::Arc, time::Duration};
 use tari_comms::{
     multiaddr::Multiaddr,
     peer_manager::{NodeId, NodeIdentity, Peer, PeerFeatures, PeerFlags},
@@ -412,9 +412,26 @@ async fn test_wallet() {
     bob_wallet.wait_until_shutdown().await;
 }
 
-// TODO Figure out why this test is so flakey. It is an integration test that is fairly simple on the surface but there
-// is something about it that is very flakey.
+#[test]
 #[ignore]
+// Useful for debugging, ignored because it takes over 30 minutes to run
+fn test_20_store_and_forward_send_tx() {
+    let mut fails = 0;
+    for n in 1..=20 {
+        let hook = panic::take_hook();
+        panic::set_hook(Box::new(|_| {}));
+        let result = panic::catch_unwind(move || test_store_and_forward_send_tx());
+        panic::set_hook(hook);
+        match result {
+            Ok(_) => {},
+            Err(_) => {
+                fails += 1;
+            },
+        }
+    }
+    assert_eq!(fails, 0);
+}
+
 #[test]
 fn test_store_and_forward_send_tx() {
     let mut shutdown_a = Shutdown::new();
@@ -493,13 +510,13 @@ fn test_store_and_forward_send_tx() {
         .unwrap();
 
     // Waiting here for a while to make sure the discovery retry is over
-    alice_runtime.block_on(async { delay_for(Duration::from_secs(10)).await });
+    alice_runtime.block_on(async { delay_for(Duration::from_secs(60)).await });
 
     alice_runtime
         .block_on(alice_wallet.transaction_service.cancel_transaction(tx_id))
         .unwrap();
 
-    alice_runtime.block_on(async { delay_for(Duration::from_secs(10)).await });
+    alice_runtime.block_on(async { delay_for(Duration::from_secs(60)).await });
 
     let carol_wallet = carol_runtime.block_on(create_wallet(
         carol_identity.clone(),


### PR DESCRIPTION
## Description
Increasing the delay on test_store_and_forward_send_tx() appears to eliminate flakiness in the test.

Passed successfully on 100, 50 and 20 iterations.

## Motivation and Context
Test fixes

## How Has This Been Tested?
cargo test 

## Types of changes
* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
* [x] I'm merging against the `development` branch.
* [x] I ran `cargo-fmt --all` before pushing.
* [ ] I ran `cargo test` successfully before submitting my PR.
* [x] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
