### PR TITLE
[Base Node] Prevent internal miner being enabled in the config.

### DIFF
--- a/applications/tari_base_node/src/builder.rs
+++ b/applications/tari_base_node/src/builder.rs
@@ -29,7 +29,7 @@ use futures::{future, StreamExt};
 use log::*;
 use std::{
     sync::{
-        atomic::{AtomicBool, AtomicU64, Ordering},
+        atomic::{AtomicBool, AtomicU64},
         Arc,
     },
     time::Duration,
@@ -394,8 +394,11 @@ async fn build_node_context(
         config.num_mining_threads,
     );
     if config.enable_mining {
-        info!(target: LOG_TARGET, "Enabling solo miner");
-        miner.enable_mining_flag().store(true, Ordering::Relaxed);
+        info!(
+            target: LOG_TARGET,
+            "Please use standalone miner, enabling the internal solo miner is no longer supported."
+        );
+    // miner.enable_mining_flag().store(true, Ordering::Relaxed);
     } else {
         info!(
             target: LOG_TARGET,


### PR DESCRIPTION
## Description
Prevents enabling of the internal miner in tari_base_node via the configuration file.

## Motivation and Context
Internal miner is no longer supported.

## How Has This Been Tested?
Manual testing with the following in the config:
```
[base_node.stibbons]
enable_mining = true
```

## Types of changes
* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
* [x] I'm merging against the `development` branch.
* [x] I ran `cargo-fmt --all` before pushing.
* [ ] I ran `cargo test` successfully before submitting my PR.
* [x] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
