### PR TITLE
DNM [merge-mining] Submit_block AUX data includes tari block hash

### DIFF
--- a/applications/tari_merge_mining_proxy/src/error.rs
+++ b/applications/tari_merge_mining_proxy/src/error.rs
@@ -70,4 +70,6 @@ pub enum MmProxyError {
     HexError(#[from] FromHexError),
     #[error("Coinbase builder error: {0}")]
     CoinbaseBuilderError(#[from] CoinbaseBuildError),
+    #[error("Unexpected Tari base node response: {0}")]
+    UnexpectedTariBaseNodeResponse(String),
 }

--- a/applications/tari_merge_mining_proxy/src/test.rs
+++ b/applications/tari_merge_mining_proxy/src/test.rs
@@ -103,3 +103,20 @@ mod add_aux_data {
         assert!(v["result"][MMPROXY_AUX_KEY_NAME]["it"].as_str().is_none());
     }
 }
+
+mod append_aux_chain_data {
+    use crate::{
+        common::json_rpc,
+        proxy::{append_aux_chain_data, MMPROXY_AUX_KEY_NAME},
+    };
+    use serde_json::json;
+
+    #[test]
+    fn it_adds_a_chain_object() {
+        let v = json_rpc::success_response(None, json!({}));
+        let v = append_aux_chain_data(v, json!({"test": "works"}));
+        assert_eq!(v["result"][MMPROXY_AUX_KEY_NAME]["chains"].as_array().unwrap(), &[
+            json!({"test": "works"})
+        ]);
+    }
+}


### PR DESCRIPTION
Calls to submit_block return the tari hash if the block is accepted by
the Tari blockchain.

- [fix] Return the correct response when tari's get_header_by_hash GRPC call
  returns "not found"
- [feat] get_block_template includes tari block height in aux chain data
- [fix] get_block_header_by_hash should not forward the request to tari
  base node if block was found by monerod.
- [fix] Add correct `Host` http header on proxied requests. Some public monero
  daemons require this.
- [chore] Minor request logging improvements
