### PR TITLE
[wallet] Tests for maturity aware UTXO selection

### DIFF
--- a/base_layer/wallet/src/base_node_service/mock_base_node_service.rs
+++ b/base_layer/wallet/src/base_node_service/mock_base_node_service.rs
@@ -85,10 +85,28 @@ impl MockBaseNodeService {
         }
     }
 
-    pub fn set_default_base_node_state(&mut self) {
-        let meta = ChainMetadata::new(std::u64::MAX, Vec::new(), 0, 0, 0);
+    /// Set the mock server state, either online and synced to a specific height, or offline with None
+    pub fn set_base_node_state(&mut self, height: Option<u64>) {
+        let (chain_metadata, is_synced, online) = match height {
+            Some(height) => {
+                let metadata = ChainMetadata::new(height, Vec::new(), 0, 0, 0);
+                (Some(metadata), Some(true), OnlineState::Online)
+            },
+            None => (None, None, OnlineState::Offline),
+        };
         self.state = BaseNodeState {
-            chain_metadata: Some(meta),
+            chain_metadata,
+            is_synced,
+            updated: None,
+            latency: None,
+            online,
+        }
+    }
+
+    pub fn set_default_base_node_state(&mut self) {
+        let metadata = ChainMetadata::new(std::u64::MAX, Vec::new(), 0, 0, 0);
+        self.state = BaseNodeState {
+            chain_metadata: Some(metadata),
             is_synced: Some(true),
             updated: None,
             latency: None,

--- a/base_layer/wallet/src/output_manager_service/handle.rs
+++ b/base_layer/wallet/src/output_manager_service/handle.rs
@@ -398,6 +398,8 @@ impl OutputManagerHandle {
         }
     }
 
+    /// Create a coin split transaction.
+    /// Returns (tx_id, tx, fee, utxo_total_value).
     pub async fn create_coin_split(
         &mut self,
         amount_per_split: MicroTari,

--- a/base_layer/wallet/tests/support/utils.rs
+++ b/base_layer/wallet/tests/support/utils.rs
@@ -77,6 +77,7 @@ impl TestParams {
         }
     }
 }
+
 pub fn make_input<R: Rng + CryptoRng>(
     rng: &mut R,
     val: MicroTari,
@@ -87,6 +88,19 @@ pub fn make_input<R: Rng + CryptoRng>(
     let commitment = factory.commit_value(&key, val.into());
     let input = TransactionInput::new(OutputFeatures::default(), commitment);
     (input, UnblindedOutput::new(val, key, None))
+}
+
+pub fn make_input_with_features<R: Rng + CryptoRng>(
+    rng: &mut R,
+    value: MicroTari,
+    factory: &CommitmentFactory,
+    features: Option<OutputFeatures>,
+) -> (TransactionInput, UnblindedOutput)
+{
+    let spending_key = PrivateKey::random(rng);
+    let commitment = factory.commit_value(&spending_key, value.into());
+    let input = TransactionInput::new(features.clone().unwrap_or_default(), commitment);
+    (input, UnblindedOutput::new(value, spending_key, features))
 }
 
 pub fn random_string(len: usize) -> String {

--- a/comms/dht/src/store_forward/store.rs
+++ b/comms/dht/src/store_forward/store.rs
@@ -431,7 +431,6 @@ mod test {
     use super::*;
     use crate::{
         envelope::{DhtMessageFlags, NodeDestination},
-        proto::{dht::JoinMessage, envelope::DhtMessageType},
         test_utils::{
             build_peer_manager,
             create_store_and_forward_mock,
@@ -442,7 +441,7 @@ mod test {
     };
     use chrono::Utc;
     use std::time::Duration;
-    use tari_comms::{message::MessageExt, wrap_in_envelope_body};
+    use tari_comms::wrap_in_envelope_body;
     use tari_test_utils::async_assert_eventually;
     use tari_utilities::hex::Hex;
 
@@ -464,8 +463,6 @@ mod test {
         let messages = mock_state.get_messages().await;
         assert_eq!(messages.len(), 0);
     }
-
-
 
     #[tokio_macros::test_basic]
     async fn decryption_succeeded_no_store() {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Adds tests to the output manager service that ensure that UTXO selection is maturity aware when chain metadata is available. Also tests that transaction preparation, fee estimates, and coin splits use the desired UTXO selection whether chain metadata is available or not.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
No tests were specifically covering UTXO selection. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
cargo test

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [x] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch.
* [x] I ran `cargo-fmt --all` before pushing.
* [x] I ran `cargo test` successfully before submitting my PR.
* [x] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
