### PR TITLE
Use rusttls for dnssec for peer seeds

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3270,6 +3270,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "ring"
+version = "0.16.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3053cf52e236a3ed746dfc745aa9cacf1b791d846bdaf412f60a8d7d6e17c8fc"
+dependencies = [
+ "cc",
+ "libc",
+ "once_cell",
+ "spin",
+ "untrusted",
+ "web-sys",
+ "winapi 0.3.9",
+]
+
+[[package]]
 name = "rmp"
 version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3331,6 +3346,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
 dependencies = [
  "semver",
+]
+
+[[package]]
+name = "rustls"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0d4a31f5d68413404705d6982529b0e11a9aacd4839d1d6222ee3b8cb4015e1"
+dependencies = [
+ "base64 0.11.0",
+ "log 0.4.14",
+ "ring",
+ "sct",
+ "webpki",
 ]
 
 [[package]]
@@ -3404,6 +3432,16 @@ name = "scopeguard"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
+
+[[package]]
+name = "sct"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3042af939fca8c3453b7af0f1c66e533a15a86169e39de2657310ade8f98d3c"
+dependencies = [
+ "ring",
+ "untrusted",
+]
 
 [[package]]
 name = "security-framework"
@@ -3668,6 +3706,12 @@ dependencies = [
  "libc",
  "winapi 0.3.9",
 ]
+
+[[package]]
+name = "spin"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
 name = "static_assertions"
@@ -5065,12 +5109,14 @@ dependencies = [
  "futures 0.3.12",
  "lazy_static 1.4.0",
  "log 0.4.14",
- "openssl",
  "radix_trie",
  "rand 0.7.3",
+ "ring",
+ "rustls",
  "thiserror",
  "tokio",
  "trust-dns-proto",
+ "webpki",
 ]
 
 [[package]]
@@ -5087,8 +5133,8 @@ dependencies = [
  "idna 0.2.2",
  "lazy_static 1.4.0",
  "log 0.4.14",
- "openssl",
  "rand 0.7.3",
+ "ring",
  "smallvec",
  "thiserror",
  "tokio",
@@ -5266,6 +5312,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "35581ff83d4101e58b582e607120c7f5ffb17e632a980b1f38334d76b36908b2"
 
 [[package]]
+name = "untrusted"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
+
+[[package]]
 name = "url"
 version = "1.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5427,6 +5479,16 @@ checksum = "c40dc691fc48003eba817c38da7113c15698142da971298003cac3ef175680b3"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki"
+version = "0.21.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e38c0608262c46d4a56202ebabdeb094cef7e560ca7a226c6bf055188aa4ea"
+dependencies = [
+ "ring",
+ "untrusted",
 ]
 
 [[package]]

--- a/base_layer/p2p/Cargo.toml
+++ b/base_layer/p2p/Cargo.toml
@@ -34,7 +34,7 @@ thiserror = "1.0.20"
 tokio = {version="0.2.10", features=["blocking"]}
 tower = "0.3.0-alpha.2"
 tower-service = { version="0.3.0-alpha.2" }
-trust-dns-client = {version="0.19.5", features=["dns-over-openssl"]}
+trust-dns-client = {version="0.19.5", features=["dns-over-rustls"]}
 
 [dev-dependencies]
 tari_test_utils = { version = "^0.8", path="../../infrastructure/test_utils" }

--- a/comms/dht/src/store_forward/store.rs
+++ b/comms/dht/src/store_forward/store.rs
@@ -465,8 +465,6 @@ mod test {
         assert_eq!(messages.len(), 0);
     }
 
-
-
     #[tokio_macros::test_basic]
     async fn decryption_succeeded_no_store() {
         let (requester, mock_state) = create_store_and_forward_mock();


### PR DESCRIPTION
Use `dns-over-rustls` feature on `trust-dns-client` crate. This should
remove the `openssl-sys` dependency from many crates that depend on the
`tari-p2p` crate.

Note: openssl-sys is still a dependency of hyper and reqwest (merge mining proxy) as well as `git2` build dependency
          but I expect that removing the openssl dep from tari-p2p will remove it from release builds of the base node and wallet   

UPDATE: peer seed resolver works on local base node test