### PR TITLE
Update XMRig version installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -601,9 +601,7 @@ its reference pool implementation running [here](http://monerop.com/),  and
 template from a third party and submits the solution to the mining pool. Tari added a `submit-to-origin` option to the 
 self select mode whereby, if a solution has been found that only matches the pool difficulty, XMRig will submit the 
 solution to the pool only, but if the achieved difficulty meets both that of the pool and Tari, it will be submitted to 
-the Merge Mining Proxy as well as to the mining pool. The specially adapted XMRig code is available 
-[here](https://github.com/tari-project/xmrig/tree/feature-self-select); the latest version or commit must be built for 
-your target operating system in release mode without debug symbols.
+the Merge Mining Proxy as well as to the mining pool.
 
 ##### Merge Mining Proxy configuration
 

--- a/buildtools/get_xmrig_osx.ps1
+++ b/buildtools/get_xmrig_osx.ps1
@@ -1,9 +1,6 @@
 echo "XMRig repo: '$env:xmrig_repo'"
-# TODO: Standardize on version 6.6.2 for now as later version(s) has a breaking interface change with the merge mining proxy
-#$url = (Invoke-WebRequest "$env:xmrig_repo" -UseBasicParsing | ConvertFrom-Json).assets.browser_download_url | `
-#    Select-String -Pattern 'macos-x64.tar.gz'
 $url = (Invoke-WebRequest "$env:xmrig_repo" -UseBasicParsing | ConvertFrom-Json).assets.browser_download_url | `
-    Select-String -Pattern '6.6.2-macos-x64.tar.gz'
+    Select-String -Pattern 'macos-x64.tar.gz'
 echo "Install from '$url'"
 Invoke-WebRequest "$url" -outfile "/tmp/$env:xmrig_zip"
 echo "Downloaded  '$url'"

--- a/buildtools/get_xmrig_ubuntu.ps1
+++ b/buildtools/get_xmrig_ubuntu.ps1
@@ -1,9 +1,6 @@
 echo "XMRig repo: '$env:xmrig_repo'"
-# TODO: Standardize on version 6.6.2 for now as later version(s) has a breaking interface change with the merge mining proxy
-#$url = (Invoke-WebRequest "$env:xmrig_repo" -UseBasicParsing | ConvertFrom-Json).assets.browser_download_url | `
-#    Select-String -Pattern 'linux-x64.tar.gz'
 $url = (Invoke-WebRequest "$env:xmrig_repo" -UseBasicParsing | ConvertFrom-Json).assets.browser_download_url | `
-    Select-String -Pattern '6.6.2-linux-x64.tar.gz'
+    Select-String -Pattern 'linux-x64.tar.gz'
 echo "Install from '$url'"
 Invoke-WebRequest "$url" -outfile "/tmp/$env:xmrig_zip"
 echo "Downloaded  '$url'"

--- a/buildtools/get_xmrig_win.ps1
+++ b/buildtools/get_xmrig_win.ps1
@@ -4,10 +4,7 @@ echo ""
 echo ""
 echo ""
 echo "XMRig repo: '$env:xmrig_repo'"
-# TODO: Standardize on version 6.6.2 for now as later version(s) has a breaking interface change with the merge mining proxy
-#$url = (Invoke-WebRequest "$env:xmrig_repo" -UseBasicParsing | ConvertFrom-Json).assets.browser_download_url | `
-#    Select-String -Pattern 'msvc-win64.zip'
 $url = (Invoke-WebRequest "$env:xmrig_repo" -UseBasicParsing | ConvertFrom-Json).assets.browser_download_url | `
-    Select-String -Pattern '6.6.2-msvc-win64.zip'
+    Select-String -Pattern 'msvc-win64.zip'
 echo "Install from '$url'"
 Invoke-WebRequest "$url" -outfile "$env:TEMP\$env:xmrig_zip"

--- a/buildtools/install_xmrig.bat
+++ b/buildtools/install_xmrig.bat
@@ -7,9 +7,7 @@ rem   - Download `XMRig` at `https://github.com/xmrig/xmrig/releases/`
 set xmrig_zip=xmrig-win64.zip
 set xmrig_folder=%USERPROFILE%\.xmrig
 set xmrig_runtime=xmrig.exe
-rem TODO: Standardize on version 6.6.2 for now as later version(s) has a breaking interface change with the merge mining proxy
-rem set xmrig_repo=https://api.github.com/repos/xmrig/xmrig/releases/latest
-set xmrig_repo=https://api.github.com/repos/xmrig/xmrig/releases
+set xmrig_repo=https://api.github.com/repos/xmrig/xmrig/releases/latest
 
 echo Downloading and installing XMRig...
 echo.

--- a/buildtools/install_xmrig.sh
+++ b/buildtools/install_xmrig.sh
@@ -6,9 +6,7 @@
 export xmrig_zip="xmrig-linux64.tar.gz"
 export xmrig_folder="${HOME}/xmrig"
 export xmrig_runtime="xmrig"
-# TODO: Standardize on version 6.6.2 for now as later version(s) has a breaking interface change with the merge mining proxy
-#export xmrig_repo="https://api.github.com/repos/xmrig/xmrig/releases/latest"
-export xmrig_repo="https://api.github.com/repos/xmrig/xmrig/releases"
+export xmrig_repo="https://api.github.com/repos/xmrig/xmrig/releases/latest"
 
 echo "Downloading and installing XMRig..."
 echo


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Since the `self-select` with `submit-to-origin` has been merged into the main branch of the xmrig repo, we do not need a reference to the Tari XMRig branch anymore:
- Removed reference to the Tari XMRig branch in the main README.md
- Updated XMRig installers to get latest release version again, as it was still pinned to version `6.6.2` from a previous PR.

## Motivation and Context
See above.

## How Has This Been Tested?
- Tested XMRig installation on Windows and Ubuntu.
- Merge mining with  `self-select` and `submit-to-origin` tested with the latest XMRig installation on Windows and Ubuntu.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [X] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [X] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [X] I'm merging against the `development` branch.
* [ ] I ran `cargo-fmt --all` before pushing.
* [ ] I ran `cargo test` successfully before submitting my PR.
* [ ] I have squashed my commits into a single commit.
* [X] My change requires a change to the documentation.
* [X] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
