### PR TITLE
[merge-mining] Add Tari aux chain data to getlastblockheader

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11,9 +11,9 @@ dependencies = [
 
 [[package]]
 name = "adler"
-version = "1.0.1"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bedc89c5c7b5550ffb9372eb5c5ffc7f9f705cc3f4a128bd4669b9745f555093"
+checksum = "ee2a4ec343196209d6594e19543ae87a39f96d5534d7174822a3ad825dd6ed7e"
 
 [[package]]
 name = "aead"
@@ -251,9 +251,9 @@ dependencies = [
 
 [[package]]
 name = "bincode"
-version = "1.3.2"
+version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d175dfa69e619905c4c3cdb7c3c203fa3bdd5d51184e3afdb2742c0280493772"
+checksum = "f30d3a39baa26f9651f17b375061f3233dde33424a8b72b0dbe93a68a0bc896d"
 dependencies = [
  "byteorder",
  "serde 1.0.123",
@@ -428,9 +428,9 @@ checksum = "bed57e2090563b83ba8f83366628ce535a7584c9afa4c9fc0612a03925c6df58"
 
 [[package]]
 name = "byteorder"
-version = "1.3.4"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08c48aae112d48ed9f069b33538ea9e3e90aa263cfa3d1c24309612b1f7472de"
+checksum = "ae44d1a3d5a19df61dd0c8beb138458ac2a53a7ac09eba97d55592540004306b"
 
 [[package]]
 name = "bytes"
@@ -505,9 +505,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.67"
+version = "1.0.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3c69b077ad434294d3ce9f1f6143a2a4b89a8a2d54ef813d85003a4fd1137fd"
+checksum = "4c0496836a84f8d0495758516b8621a622beb77c0fed418570e50764093ced48"
 
 [[package]]
 name = "cexpr"
@@ -591,9 +591,9 @@ dependencies = [
 
 [[package]]
 name = "clang-sys"
-version = "1.1.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f54d78e30b388d4815220c8dd03fea5656b6c6d32adb59e89061552a102f8da1"
+checksum = "5cb92721cb37482245ed88428f72253ce422b3b4ee169c70a0642521bb5db4cc"
 dependencies = [
  "glob",
  "libc",
@@ -654,6 +654,12 @@ dependencies = [
  "toml 0.4.10",
  "yaml-rust",
 ]
+
+[[package]]
+name = "const_fn"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28b9d6de7f49e22cf97ad17fc4036ece69300032f45f78f30b4a4482cdc3f4a6"
 
 [[package]]
 name = "constant_time_eq"
@@ -763,7 +769,7 @@ dependencies = [
  "crossbeam-deque",
  "crossbeam-epoch",
  "crossbeam-queue",
- "crossbeam-utils 0.8.3",
+ "crossbeam-utils 0.8.1",
 ]
 
 [[package]]
@@ -782,7 +788,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dca26ee1f8d361640700bde38b2c37d8c22b3ce2d360e1fc1c74ea4b0aa7d775"
 dependencies = [
  "cfg-if 1.0.0",
- "crossbeam-utils 0.8.3",
+ "crossbeam-utils 0.8.1",
 ]
 
 [[package]]
@@ -793,17 +799,18 @@ checksum = "94af6efb46fef72616855b036a624cf27ba656ffc9be1b9a3c931cfc7749a9a9"
 dependencies = [
  "cfg-if 1.0.0",
  "crossbeam-epoch",
- "crossbeam-utils 0.8.3",
+ "crossbeam-utils 0.8.1",
 ]
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.3"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2584f639eb95fea8c798496315b297cf81b9b58b6d30ab066a75455333cf4b12"
+checksum = "a1aaa739f95311c2c7887a76863f500026092fb1dce0161dab577e559ef3569d"
 dependencies = [
  "cfg-if 1.0.0",
- "crossbeam-utils 0.8.3",
+ "const_fn",
+ "crossbeam-utils 0.8.1",
  "lazy_static 1.4.0",
  "memoffset",
  "scopeguard",
@@ -816,7 +823,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0f6cb3c7f5b8e51bc3ebb73a2327ad4abdbd119dc13223f14f961d2f38486756"
 dependencies = [
  "cfg-if 1.0.0",
- "crossbeam-utils 0.8.3",
+ "crossbeam-utils 0.8.1",
 ]
 
 [[package]]
@@ -831,9 +838,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.3"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7e9d99fa91428effe99c5c6d4634cdeba32b8cf784fc428a2a687f61a952c49"
+checksum = "02d96d1e189ef58269ebe5b97953da3274d83a93af647c2ddd6f9dab28cedb8d"
 dependencies = [
  "autocfg",
  "cfg-if 1.0.0",
@@ -850,7 +857,7 @@ dependencies = [
  "crossterm_winapi",
  "lazy_static 1.4.0",
  "libc",
- "mio 0.7.9",
+ "mio 0.7.8",
  "parking_lot",
  "signal-hook",
  "winapi 0.3.9",
@@ -1292,15 +1299,15 @@ checksum = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
 
 [[package]]
 name = "futures"
-version = "0.1.31"
+version = "0.1.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a471a38ef8ed83cd6e40aa59c1ffe17db6855c18e3604d9c4ed8c08ebc28678"
+checksum = "4c7e4c2612746b0df8fed4ce0c69156021b704c9aefa360311c04e6e9e002eed"
 
 [[package]]
 name = "futures"
-version = "0.3.13"
+version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f55667319111d593ba876406af7c409c0ebb44dc4be6132a783ccf163ea14c1"
+checksum = "da9052a1a50244d8d5aa9bf55cbc2fb6f357c86cc52e46c62ed390a7180cf150"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1313,9 +1320,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.13"
+version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c2dd2df839b57db9ab69c2c9d8f3e8c81984781937fe2807dc6dcf3b2ad2939"
+checksum = "f2d31b7ec7efab6eefc7c57233bb10b847986139d88cc2f5a02a1ae6871a1846"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -1333,9 +1340,9 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.13"
+version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15496a72fabf0e62bdc3df11a59a3787429221dd0710ba8ef163d6f7a9112c94"
+checksum = "79e5145dde8da7d1b3892dad07a9c98fc04bc39892b1ecc9692cf53e2b780a65"
 
 [[package]]
 name = "futures-core-preview"
@@ -1345,9 +1352,9 @@ checksum = "b35b6263fb1ef523c3056565fa67b1d16f0a8604ff12b11b08c25f28a734c60a"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.13"
+version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "891a4b7b96d84d5940084b2a37632dd65deeae662c114ceaa2c879629c9c0ad1"
+checksum = "e9e59fdc009a4b3096bf94f740a0f2424c082521f20a9b08c5c07c48d90fd9b9"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -1367,9 +1374,9 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.13"
+version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71c2c65c57704c32f5241c1223167c2c3294fd34ac020c807ddbe6db287ba59"
+checksum = "28be053525281ad8259d47e4de5de657b25e7bac113458555bb4b70bc6870500"
 
 [[package]]
 name = "futures-io-preview"
@@ -1379,9 +1386,9 @@ checksum = "f4914ae450db1921a56c91bde97a27846287d062087d4a652efc09bb3a01ebda"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.13"
+version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea405816a5139fb39af82c2beb921d52143f556038378d6db21183a5c37fbfb7"
+checksum = "c287d25add322d9f9abdcdc5927ca398917996600182178774032e9f8258fedd"
 dependencies = [
  "proc-macro-hack",
  "proc-macro2 1.0.24",
@@ -1405,9 +1412,9 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.13"
+version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85754d98985841b7d4f5e8e6fbfa4a4ac847916893ec511a2917ccd8525b8bb3"
+checksum = "caf5c69029bda2e743fddd0582d1083951d65cc9539aebf8812f36c3491342d6"
 
 [[package]]
 name = "futures-sink-preview"
@@ -1417,15 +1424,18 @@ checksum = "86f148ef6b69f75bb610d4f9a2336d4fc88c4b5b67129d1a340dd0fd362efeec"
 
 [[package]]
 name = "futures-task"
-version = "0.3.13"
+version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa189ef211c15ee602667a6fcfe1c1fd9e07d42250d2156382820fba33c9df80"
+checksum = "13de07eb8ea81ae445aca7b69f5f7bf15d7bf4912d8ca37d6645c77ae8a58d86"
+dependencies = [
+ "once_cell",
+]
 
 [[package]]
 name = "futures-test"
-version = "0.3.13"
+version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1fe5e51002528907757d5f1648101086f7197f792112db43ba23b06b09e6bce"
+checksum = "8b30f48f6b9cd26d8739965d6e3345c511718884fb223795b80dc71d24a9ea9a"
 dependencies = [
  "futures-core",
  "futures-executor",
@@ -1433,6 +1443,7 @@ dependencies = [
  "futures-sink",
  "futures-task",
  "futures-util",
+ "once_cell",
  "pin-project 1.0.5",
  "pin-utils",
 ]
@@ -1462,11 +1473,11 @@ dependencies = [
 
 [[package]]
 name = "futures-util"
-version = "0.3.13"
+version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1812c7ab8aedf8d6f2701a43e1243acdbcc2b36ab26e2ad421eb99ac963d96d1"
+checksum = "632a8cd0f2a4b3fdea1657f08bde063848c3bd00f9bbf6e256b8be78802e624b"
 dependencies = [
- "futures 0.1.31",
+ "futures 0.1.30",
  "futures-channel",
  "futures-core",
  "futures-io",
@@ -1973,9 +1984,9 @@ dependencies = [
 
 [[package]]
 name = "libloading"
-version = "0.7.0"
+version = "0.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f84d96438c15fcd6c3f244c8fce01d1e2b9c6b5623e9c711dc9286d8fc92d6a"
+checksum = "351a32417a12d5f7e82c368a66781e307834dae04c6ce0cd4456d52989229883"
 dependencies = [
  "cfg-if 1.0.0",
  "winapi 0.3.9",
@@ -2201,9 +2212,9 @@ dependencies = [
 
 [[package]]
 name = "miniz_oxide"
-version = "0.4.4"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a92518e98c078586bc6c934028adcca4c92a53d6a958196de835170a01d84e4b"
+checksum = "0f2d26ec3309788e423cfbf68ad1800f061638098d76a83681af979dc4eda19d"
 dependencies = [
  "adler",
  "autocfg",
@@ -2230,9 +2241,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.7.9"
+version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5dede4e2065b3842b8b0af444119f3aa331cc7cc2dd20388bfb0f5d5a38823a"
+checksum = "dc250d6848c90d719ea2ce34546fb5df7af1d3fd189d10bf7bad80bfcebecd95"
 dependencies = [
  "libc",
  "log 0.4.14",
@@ -2540,9 +2551,9 @@ checksum = "a9a7ab5d64814df0fe4a4b5ead45ed6c5f181ee3ff04ba344313a6c80446c5d4"
 
 [[package]]
 name = "once_cell"
-version = "1.7.0"
+version = "1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10acf907b94fc1b1a152d08ef97e7759650268cf986bf127f387e602b02c7e5a"
+checksum = "13bd41f508810a131401606d54ac32a467c97172d74ba7662562ebba5ad07fa0"
 
 [[package]]
 name = "opaque-debug"
@@ -3146,7 +3157,7 @@ checksum = "9ab346ac5921dc62ffa9f89b7a773907511cdfa5490c572ae9be1be33e8afa4a"
 dependencies = [
  "crossbeam-channel 0.5.0",
  "crossbeam-deque",
- "crossbeam-utils 0.8.3",
+ "crossbeam-utils 0.8.1",
  "lazy_static 1.4.0",
  "num_cpus",
 ]
@@ -3260,9 +3271,9 @@ dependencies = [
 
 [[package]]
 name = "rmp"
-version = "0.8.9"
+version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f10b46df14cf1ee1ac7baa4d2fbc2c52c0622a4b82fa8740e37bc452ac0184f"
+checksum = "4f55e5fa1446c4d5dd1f5daeed2a4fe193071771a2636274d0d7a3b082aa7ad6"
 dependencies = [
  "byteorder",
  "num-traits 0.2.14",
@@ -3396,9 +3407,9 @@ checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "security-framework"
-version = "2.1.0"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6af1b6204f89cf0069736daf8b852573e3bc34898eee600e95d3dd855c12e81"
+checksum = "c1759c2e3c8580017a484a7ac56d3abc5a6c1feadf88db2f3633f12ae4268c69"
 dependencies = [
  "bitflags 1.2.1",
  "core-foundation",
@@ -3409,9 +3420,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.1.0"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31531d257baab426203cf81c5ce1b0b55159dda7ed602ac81b582ccd62265741"
+checksum = "f99b9d5e26d2a71633cc4f2ebae7cc9f874044e0c351a27e17892d76dce5678b"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -3493,9 +3504,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.63"
+version = "1.0.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43535db9747a4ba938c0ce0a98cc631a46ebf943c9e1d604e091df6007620bf6"
+checksum = "ea1c6153794552ea7cf7cf63b1231a25de00ec90db326ba6264440fa08e31486"
 dependencies = [
  "itoa",
  "ryu",
@@ -3605,7 +3616,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e31d442c16f047a671b5a71e2161d6e68814012b7f5379d269ebd915fac2729"
 dependencies = [
  "libc",
- "mio 0.7.9",
+ "mio 0.7.8",
  "signal-hook-registry",
 ]
 
@@ -3676,7 +3687,7 @@ version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d62fea0968935ec8eedcf671b2738bf49c58e133db968097c301d32e32eaedf"
 dependencies = [
- "futures 0.1.31",
+ "futures 0.1.30",
 ]
 
 [[package]]
@@ -3845,7 +3856,7 @@ version = "0.8.5"
 dependencies = [
  "config",
  "dirs-next",
- "futures 0.3.13",
+ "futures 0.3.12",
  "log 0.4.14",
  "qrcode",
  "rand 0.7.3",
@@ -3874,7 +3885,7 @@ dependencies = [
  "chrono-english",
  "config",
  "dirs-next",
- "futures 0.3.13",
+ "futures 0.3.12",
  "git2",
  "log 0.4.14",
  "log4rs",
@@ -3956,7 +3967,7 @@ dependencies = [
 name = "tari_common_types"
 version = "0.8.5"
 dependencies = [
- "futures 0.3.13",
+ "futures 0.3.12",
  "rand 0.7.3",
  "serde 1.0.123",
  "tari_crypto",
@@ -3978,7 +3989,7 @@ dependencies = [
  "data-encoding",
  "digest 0.8.1",
  "env_logger 0.7.1",
- "futures 0.3.13",
+ "futures 0.3.12",
  "lazy_static 1.4.0",
  "lmdb-zero",
  "log 0.4.14",
@@ -4019,7 +4030,7 @@ dependencies = [
  "diesel_migrations",
  "digest 0.8.1",
  "env_logger 0.7.1",
- "futures 0.3.13",
+ "futures 0.3.12",
  "futures-test-preview",
  "futures-util",
  "lazy_static 1.4.0",
@@ -4055,7 +4066,7 @@ dependencies = [
 name = "tari_comms_rpc_macros"
 version = "0.8.5"
 dependencies = [
- "futures 0.3.13",
+ "futures 0.3.12",
  "proc-macro2 1.0.24",
  "prost",
  "quote 1.0.9",
@@ -4076,7 +4087,7 @@ dependencies = [
  "config",
  "crossterm",
  "dirs-next",
- "futures 0.3.13",
+ "futures 0.3.12",
  "log 0.4.14",
  "qrcode",
  "rand 0.7.3",
@@ -4120,7 +4131,7 @@ dependencies = [
  "digest 0.8.1",
  "env_logger 0.7.1",
  "fs2",
- "futures 0.3.13",
+ "futures 0.3.12",
  "hex",
  "lmdb-zero",
  "log 0.4.14",
@@ -4234,7 +4245,7 @@ dependencies = [
  "config",
  "derive-error",
  "env_logger 0.7.1",
- "futures 0.3.13",
+ "futures 0.3.12",
  "futures-test",
  "hex",
  "hyper 0.13.10",
@@ -4268,7 +4279,7 @@ version = "0.8.5"
 dependencies = [
  "chrono",
  "crossbeam",
- "futures 0.3.13",
+ "futures 0.3.12",
  "log 0.4.14",
  "num_cpus",
  "prost-types",
@@ -4314,7 +4325,7 @@ dependencies = [
  "clap",
  "env_logger 0.6.2",
  "fs2",
- "futures 0.3.13",
+ "futures 0.3.12",
  "futures-test-preview",
  "futures-timer",
  "lazy_static 1.4.0",
@@ -4349,7 +4360,7 @@ name = "tari_service_framework"
 version = "0.8.5"
 dependencies = [
  "anyhow",
- "futures 0.3.13",
+ "futures 0.3.12",
  "futures-test",
  "log 0.4.14",
  "tari_shutdown",
@@ -4365,7 +4376,7 @@ dependencies = [
 name = "tari_shutdown"
 version = "0.8.5"
 dependencies = [
- "futures 0.3.13",
+ "futures 0.3.12",
  "tokio",
 ]
 
@@ -4391,7 +4402,7 @@ dependencies = [
 name = "tari_test_utils"
 version = "0.8.5"
 dependencies = [
- "futures 0.3.13",
+ "futures 0.3.12",
  "futures-test",
  "lazy_static 1.4.0",
  "rand 0.7.3",
@@ -4431,7 +4442,7 @@ dependencies = [
  "digest 0.8.1",
  "env_logger 0.7.1",
  "fs2",
- "futures 0.3.13",
+ "futures 0.3.12",
  "lazy_static 1.4.0",
  "lmdb-zero",
  "log 0.4.14",
@@ -4465,7 +4476,7 @@ version = "0.16.23"
 dependencies = [
  "chrono",
  "env_logger 0.7.1",
- "futures 0.3.13",
+ "futures 0.3.12",
  "lazy_static 1.4.0",
  "libc",
  "log 0.4.14",
@@ -4952,9 +4963,9 @@ dependencies = [
 
 [[package]]
 name = "tracing"
-version = "0.1.25"
+version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01ebdc2bb4498ab1ab5f5b73c5803825e60199229ccba0698170e3be0e7f959f"
+checksum = "f77d3842f76ca899ff2dbcf231c5c65813dea431301d6eb686279c15c4464f12"
 dependencies = [
  "cfg-if 1.0.0",
  "log 0.4.14",
@@ -4995,9 +5006,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-log"
-version = "0.1.2"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6923477a48e41c1951f1999ef8bb5a3023eb723ceadafe78ffb65dc366761e3"
+checksum = "5e0f8c7178e13481ff6765bd169b33e8d554c5d2bbede5e32c356194be02b9b9"
 dependencies = [
  "lazy_static 1.4.0",
  "log 0.4.14",
@@ -5016,9 +5027,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.2.16"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ab8966ac3ca27126141f7999361cc97dd6fb4b71da04c02044fa9045d98bb96"
+checksum = "a1fa8f0c8f4c594e4fc9debc1990deab13238077271ba84dd853d54902ee3401"
 dependencies = [
  "ansi_term 0.12.1",
  "chrono",
@@ -5051,7 +5062,7 @@ dependencies = [
  "backtrace",
  "chrono",
  "data-encoding",
- "futures 0.3.13",
+ "futures 0.3.12",
  "lazy_static 1.4.0",
  "log 0.4.14",
  "openssl",
@@ -5072,7 +5083,7 @@ dependencies = [
  "backtrace",
  "data-encoding",
  "enum-as-inner",
- "futures 0.3.13",
+ "futures 0.3.12",
  "idna 0.2.2",
  "lazy_static 1.4.0",
  "log 0.4.14",
@@ -5515,7 +5526,7 @@ version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd37e58a1256a0b328ce9c67d8b62ecdd02f4803ba443df478835cb1a41a637c"
 dependencies = [
- "futures 0.3.13",
+ "futures 0.3.12",
  "log 0.4.14",
  "nohash-hasher",
  "parking_lot",

--- a/applications/tari_merge_mining_proxy/src/block_template_data.rs
+++ b/applications/tari_merge_mining_proxy/src/block_template_data.rs
@@ -69,7 +69,7 @@ impl BlockTemplateRepository {
         b.get(hash.as_ref()).map(|item| item.data.clone())
     }
 
-    pub async fn save(&mut self, hash: Vec<u8>, block_template: BlockTemplateData) {
+    pub async fn save(&self, hash: Vec<u8>, block_template: BlockTemplateData) {
         trace!(
             target: LOG_TARGET,
             "Saving blocktemplate with merge mining hash: {:?}",
@@ -80,21 +80,21 @@ impl BlockTemplateRepository {
         b.insert(hash, repository_item);
     }
 
-    pub async fn remove_outdated(&mut self) {
+    pub async fn remove_outdated(&self) {
         trace!(target: LOG_TARGET, "Removing outdated blocktemplates");
         let mut b = self.blocks.write().await;
         let threshold = Utc::now() - Duration::minutes(20);
         *b = b.drain().filter(|(_, i)| i.datetime() >= threshold).collect();
     }
 
-    pub async fn remove<T: AsRef<[u8]>>(&mut self, hash: T) {
+    pub async fn remove<T: AsRef<[u8]>>(&self, hash: T) -> Option<BlockTemplateRepositoryItem> {
         trace!(
             target: LOG_TARGET,
             "Blocktemplate removed with merge mining hash {:?}",
             hex::encode(hash.as_ref())
         );
         let mut b = self.blocks.write().await;
-        b.remove(hash.as_ref());
+        b.remove(hash.as_ref())
     }
 }
 

--- a/applications/tari_merge_mining_proxy/src/error.rs
+++ b/applications/tari_merge_mining_proxy/src/error.rs
@@ -73,3 +73,12 @@ pub enum MmProxyError {
     #[error("Unexpected Tari base node response: {0}")]
     UnexpectedTariBaseNodeResponse(String),
 }
+
+impl From<tonic::Status> for MmProxyError {
+    fn from(status: tonic::Status) -> Self {
+        Self::GrpcRequestError {
+            details: String::from_utf8_lossy(status.details()).to_string(),
+            status,
+        }
+    }
+}

--- a/applications/tari_merge_mining_proxy/src/error.rs
+++ b/applications/tari_merge_mining_proxy/src/error.rs
@@ -70,4 +70,6 @@ pub enum MmProxyError {
     HexError(#[from] FromHexError),
     #[error("Coinbase builder error: {0}")]
     CoinbaseBuilderError(#[from] CoinbaseBuildError),
+    #[error("Unexpected Tari base node response: {0}")]
+    UnexpectedTariBaseNodeResponse(String),
 }

--- a/applications/tari_merge_mining_proxy/src/test.rs
+++ b/applications/tari_merge_mining_proxy/src/test.rs
@@ -103,3 +103,20 @@ mod add_aux_data {
         assert!(v["result"][MMPROXY_AUX_KEY_NAME]["it"].as_str().is_none());
     }
 }
+
+mod append_aux_chain_data {
+    use crate::{
+        common::json_rpc,
+        proxy::{append_aux_chain_data, MMPROXY_AUX_KEY_NAME},
+    };
+    use serde_json::json;
+
+    #[test]
+    fn it_adds_a_chain_object() {
+        let v = json_rpc::success_response(None, json!({}));
+        let v = append_aux_chain_data(v, json!({"test": "works"}));
+        assert_eq!(v["result"][MMPROXY_AUX_KEY_NAME]["chains"].as_array().unwrap(), &[
+            json!({"test": "works"})
+        ]);
+    }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Merge mining proxy now includes tari block header data as aux chain data
    on getlastblockheader call.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Pool uses this to know if a new block template should be requested.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested on nodejs-pool fork
