### PR TITLE
Add stream to  `get_completed_transactions` method for console wallet GRPC server

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4472,7 +4472,7 @@ dependencies = [
 
 [[package]]
 name = "tari_wallet_ffi"
-version = "0.16.21"
+version = "0.16.22"
 dependencies = [
  "chrono",
  "env_logger 0.7.1",

--- a/applications/tari_app_grpc/proto/wallet.proto
+++ b/applications/tari_app_grpc/proto/wallet.proto
@@ -39,7 +39,7 @@ service Wallet {
     // Returns the transaction details for the given transaction IDs
     rpc GetTransactionInfo (GetTransactionInfoRequest) returns (GetTransactionInfoResponse);
     // Returns all transactions' details
-    rpc GetAllCompletedTransactions (GetAllCompletedTransactionsRequest) returns (GetTransactionInfoResponse);
+    rpc GetCompletedTransactions (GetCompletedTransactionsRequest) returns (stream GetCompletedTransactionsResponse);
     // Returns the balance
     rpc GetBalance (GetBalanceRequest) returns (GetBalanceResponse);
 }
@@ -126,7 +126,11 @@ enum TransactionStatus {
     TRANSACTION_STATUS_MINED_CONFIRMED = 6;
 }
 
-message GetAllCompletedTransactionsRequest { }
+message GetCompletedTransactionsRequest { }
+
+message GetCompletedTransactionsResponse {
+    TransactionInfo transaction = 1;
+}
 
 message GetBalanceRequest { }
 

--- a/base_layer/wallet/src/transaction_service/service.rs
+++ b/base_layer/wallet/src/transaction_service/service.rs
@@ -408,7 +408,7 @@ where
                     trace!(target: LOG_TARGET, "Coinbase transaction monitoring protocol has ended with result {:?}",
                     join_result);
                     match join_result {
-                        Ok(join_result_inner) => self.complete_coinbase_transaction_monitoring_protocol(join_result_inner).await,
+                        Ok(join_result_inner) => self.complete_coinbase_transaction_monitoring_protocol(join_result_inner),
                         Err(e) => error!(target: LOG_TARGET, "Error resolving Coinbase Monitoring protocol: {:?}", e),
                     };
                 }
@@ -1650,7 +1650,7 @@ where
     }
 
     /// Handle the final clean up after a Coinbase Transaction Monitoring protocol completes
-    async fn complete_coinbase_transaction_monitoring_protocol(
+    fn complete_coinbase_transaction_monitoring_protocol(
         &mut self,
         join_result: Result<u64, TransactionServiceProtocolError>,
     )
@@ -1664,16 +1664,6 @@ where
                     target: LOG_TARGET,
                     "Coinbase Transaction monitoring Protocol for TxId: {} completed successfully", id
                 );
-                if let Ok(tx) = self.resources.db.get_completed_transaction(id).await {
-                    trace!(
-                        target: LOG_TARGET,
-                        "Coinbase transaction (TxId: {}) has status '{}' and is cancelled ({}) and is valid ({}).",
-                        id,
-                        tx.status,
-                        tx.cancelled,
-                        tx.valid,
-                    );
-                };
             },
             Err(TransactionServiceProtocolError { id, error }) => {
                 let _ = self.active_coinbase_monitoring_protocols.remove(&id);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Changed `get_completed_transactions` in the console wallet grpc server to return a stream of completed transactions rather than a list of items.

## Motivation and Context
Retrieving a large number of items in a list can be inefficient; streaming each item in turn is a much more efficient solution.

## How Has This Been Tested?
Tested between a console wallet and a GRPC client (BloomRPC).

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [X] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [X] I'm merging against the `development` branch.
* [X] I ran `cargo-fmt --all` before pushing.
* [X] I ran `cargo test` successfully before submitting my PR.
* [X] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
