### PR TITLE
[base-node] Fix a possible error when state is not reinitialized

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4472,7 +4472,7 @@ dependencies = [
 
 [[package]]
 name = "tari_wallet_ffi"
-version = "0.16.21"
+version = "0.16.22"
 dependencies = [
  "chrono",
  "env_logger 0.7.1",

--- a/base_layer/core/src/base_node/sync/header_sync/synchronizer.rs
+++ b/base_layer/core/src/base_node/sync/header_sync/synchronizer.rs
@@ -462,6 +462,8 @@ impl<'a, B: BlockchainBackend + 'static> HeaderSynchronizer<'a, B> {
 
         debug!(target: LOG_TARGET, "Reading headers from peer `{}`", peer);
 
+        // Reset the header validator state to be sure we're using the correct data
+        self.header_validator.initialize_state(tip_header.hash()).await?;
         while let Some(header) = header_stream.next().await {
             let header = BlockHeader::try_from(header?).map_err(BlockHeaderSyncError::ReceivedInvalidHeader)?;
             debug!(


### PR DESCRIPTION
Difficult to verify, but added in a line that reinitializes the validator state in the header sync. My theory is that it could be in an invalid state from a previous branch, so best to reset it just before we're adding headers to it again