### PR TITLE
Register coinbase in Console Wallet's Transactions TUI

### DIFF
--- a/base_layer/wallet/src/transaction_service/service.rs
+++ b/base_layer/wallet/src/transaction_service/service.rs
@@ -1578,6 +1578,19 @@ where
                     )
                     .await?;
 
+                let _ = self
+                    .resources
+                    .event_publisher
+                    .send(Arc::new(TransactionEvent::ReceivedFinalizedTransaction(tx_id)))
+                    .map_err(|e| {
+                        trace!(
+                            target: LOG_TARGET,
+                            "Error sending event because there are no subscribers: {:?}",
+                            e
+                        );
+                        e
+                    });
+
                 debug!(
                     target: LOG_TARGET,
                     "Coinbase transaction (TxId: {}) for Block Height: {} added", tx_id, block_height

--- a/base_layer/wallet/tests/wallet/mod.rs
+++ b/base_layer/wallet/tests/wallet/mod.rs
@@ -417,7 +417,7 @@ async fn test_wallet() {
 // Useful for debugging, ignored because it takes over 30 minutes to run
 fn test_20_store_and_forward_send_tx() {
     let mut fails = 0;
-    for n in 1..=20 {
+    for _n in 1..=20 {
         let hook = panic::take_hook();
         panic::set_hook(Box::new(|_| {}));
         let result = panic::catch_unwind(move || test_store_and_forward_send_tx());


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Fixed an issue where new coinbase transactions were not registered in the Console Wallet's transactions TUI. The effect of this was that the transactions TUI would only become aware of the coinbase once it was mined unconfirmed, mined confirmed or cancelled. With this change, the transactions TUI works as expected; coinbase transactions are displayed as soon as they are created.

## Motivation and Context
See above.

## How Has This Been Tested?
Tested in a console wallet with merge mining.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [X] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [X] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [X] I'm merging against the `development` branch.
* [X] I ran `cargo-fmt --all` before pushing.
* [X] I ran `cargo test` successfully before submitting my PR.
* [X] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
