### PR TITLE
Configure LibWallet to use Stibbons network for messaging

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4472,7 +4472,7 @@ dependencies = [
 
 [[package]]
 name = "tari_wallet_ffi"
-version = "0.16.21"
+version = "0.16.22"
 dependencies = [
  "chrono",
  "env_logger 0.7.1",

--- a/base_layer/wallet/src/output_manager_service/protocols/txo_validation_protocol.rs
+++ b/base_layer/wallet/src/output_manager_service/protocols/txo_validation_protocol.rs
@@ -273,6 +273,7 @@ where TBackend: OutputManagerBackend + 'static
                 Err(e) => {
                     warn!(target: LOG_TARGET, "Problem establishing RPC connection: {}", e);
                     delay.await;
+                    retries += 1;
                     continue;
                 },
             };

--- a/base_layer/wallet/src/transaction_service/protocols/transaction_validation_protocol.rs
+++ b/base_layer/wallet/src/transaction_service/protocols/transaction_validation_protocol.rs
@@ -267,6 +267,7 @@ where TBackend: TransactionBackend + 'static
                 Err(e) => {
                     warn!(target: LOG_TARGET, "Problem establishing RPC connection: {}", e);
                     delay.await;
+                    retries += 1;
                     continue;
                 },
             };

--- a/base_layer/wallet_ffi/src/lib.rs
+++ b/base_layer/wallet_ffi/src/lib.rs
@@ -207,6 +207,7 @@ use log4rs::append::{
     },
     Append,
 };
+use tari_comms_dht::envelope::Network as DhtNetwork;
 use tari_core::consensus::Network;
 use tari_p2p::transport::TransportType::Tor;
 use tari_wallet::{
@@ -2643,7 +2644,7 @@ pub unsafe extern "C" fn comms_config_create(
                             discovery_request_timeout: Duration::from_secs(discovery_timeout_in_secs),
                             database_url: DbConnectionUrl::File(dht_database_path),
                             auto_join: true,
-                            network: Network::Stibbons,
+                            network: DhtNetwork::Stibbons,
                             ..Default::default()
                         },
                         // TODO: This should be set to false for non-test wallets. See the `allow_test_addresses` field

--- a/base_layer/wallet_ffi/src/lib.rs
+++ b/base_layer/wallet_ffi/src/lib.rs
@@ -2643,6 +2643,7 @@ pub unsafe extern "C" fn comms_config_create(
                             discovery_request_timeout: Duration::from_secs(discovery_timeout_in_secs),
                             database_url: DbConnectionUrl::File(dht_database_path),
                             auto_join: true,
+                            network: Network::Stibbons,
                             ..Default::default()
                         },
                         // TODO: This should be set to false for non-test wallets. See the `allow_test_addresses` field


### PR DESCRIPTION
## Description
LibWallet was just using the default value for Network in messaging leading to it being ignored by Stibbons nodes.

I also added retry count to when the validation protocols fail to negotiate an RPC session in Tx and TXO validation.


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch.
* [x] I ran `cargo-fmt --all` before pushing.
* [x] I ran `cargo test` successfully before submitting my PR.
* [ ] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
