### PR TITLE
[MM_Proxy] Restored proxy to functional state

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4472,7 +4472,7 @@ dependencies = [
 
 [[package]]
 name = "tari_wallet_ffi"
-version = "0.16.21"
+version = "0.16.22"
 dependencies = [
  "chrono",
  "env_logger 0.7.1",

--- a/README.md
+++ b/README.md
@@ -372,7 +372,7 @@ And then depending on if you are using solo mining or self-select mining you wil
 - For the Tari Merge Mining Proxy, under section **`merge_mining_proxy.stibbons`**
   ```
   [merge_mining_proxy.stibbons]
-  monerod_url = "cryptonote.social:5555"
+  monerod_url = "http://18.132.124.81:18081"
   proxy_host_address = "127.0.0.1:7878"
   proxy_submit_to_origin = false
   monerod_use_auth = false

--- a/applications/tari_merge_mining_proxy/src/common/json_rpc.rs
+++ b/applications/tari_merge_mining_proxy/src/common/json_rpc.rs
@@ -23,6 +23,18 @@
 use json::json;
 use serde_json as json;
 
+/// Default accept response for submit block that goes back to XMRig
+/// Refer to XMRig. Do not change existing json values unless it is changed in XMRig.
+pub fn default_block_accept_response(req_id: Option<i64>) -> json::Value {
+    json!({
+       "id": req_id.unwrap_or(-1),
+       "jsonrpc": "2.0",
+       "result": "{}",
+       "status": "OK",
+       "untrusted": false,
+    })
+}
+
 /// Create a JSON RPC success response
 /// More info: https://www.jsonrpc.org/specification#response_object
 pub fn success_response(req_id: Option<i64>, result: json::Value) -> json::Value {


### PR DESCRIPTION
## Description
This PR restores the proxy to a functional state.

## Motivation and Context

## How Has This Been Tested?
Manual testing of solo and self-select mining.

## Types of changes
* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
* [x] I'm merging against the `development` branch.
* [x] I ran `cargo-fmt --all` before pushing.
* [ ] I ran `cargo test` successfully before submitting my PR.
* [x] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [x] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
