### PR TITLE
[tests] Make Cucumber stop async

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -84,6 +84,15 @@ commands:
     description: Run cucumber scenarios
     steps:
       - run:
+          name: Pre-build base node
+          command: cargo build --release --bin tari_base_node
+      - run:
+          name: Pre-build wallet
+          command: cargo build --release --bin tari_console_wallet
+      - run:
+          name: Pre-build mmproxy
+          command: cargo build --release --bin tari_merge_mining_proxy
+      - run:
           name: npm install
           command: cd integration_tests && npm install
       - run:

--- a/integration_tests/features/support/steps.js
+++ b/integration_tests/features/support/steps.js
@@ -138,8 +138,8 @@ When(/I start (.*)/, {timeout: 20*1000}, async function (name) {
     await this.startNode(name);
 });
 
-When(/I stop (.*)/, function (name) {
-    this.stopNode(name)
+When(/I stop (.*)/, async function (name) {
+    await this.stopNode(name)
 });
 
 Then(/node (.*) is at height (\d+)/, {timeout: 120*1000}, async function (name, height) {

--- a/integration_tests/helpers/baseNodeProcess.js
+++ b/integration_tests/helpers/baseNodeProcess.js
@@ -144,7 +144,15 @@ class BaseNodeProcess {
     }
 
     stop() {
-        this.ps.kill("SIGINT");
+        return new Promise((resolve) => {
+            this.ps.on('close', (code) => {
+                if (code) {
+                    console.log(`child process exited with code ${code}`);
+                }
+                resolve();
+            });
+            this.ps.kill("SIGTERM");
+        });
     }
 
     createGrpcClient() {

--- a/integration_tests/helpers/walletProcess.js
+++ b/integration_tests/helpers/walletProcess.js
@@ -80,19 +80,27 @@ class WalletProcess {
 
     async startNew() {
         await this.init();
-        return await this.run(await this.compile(),  ["--base-path", ".", "--init", "--create_id", "--password", "kensentme", "--daemon"], true);
+        return await this.run(await this.compile(), ["--base-path", ".", "--init", "--create_id", "--password", "kensentme", "--daemon"], true);
     }
 
     async compile() {
         if (!outputProcess) {
-            await this.run("cargo", ["build", "--release", "--bin", "tari_console_wallet","-Z", "unstable-options", "--out-dir", __dirname + "/../temp/out"]);
+            await this.run("cargo", ["build", "--release", "--bin", "tari_console_wallet", "-Z", "unstable-options", "--out-dir", __dirname + "/../temp/out"]);
             outputProcess = __dirname + "/../temp/out/tari_console_wallet";
         }
         return outputProcess;
     }
 
     stop() {
-        this.ps.kill("SIGINT");
+        return new Promise((resolve) => {
+            this.ps.on('close', (code) => {
+                if (code) {
+                    console.log(`child process exited with code ${code}`);
+                }
+                resolve();
+            });
+            this.ps.kill("SIGTERM");
+        });
     }
 
 }


### PR DESCRIPTION
Change the base node `stop` method in the cucumber integration tests to wait until the process has actually stopped.