### PR TITLE
Wallet should not broadcast invalid transactions

### DIFF
--- a/base_layer/wallet/src/transaction_service/service.rs
+++ b/base_layer/wallet/src/transaction_service/service.rs
@@ -1366,12 +1366,11 @@ where
         trace!(target: LOG_TARGET, "Attempting to Broadcast all Completed Transactions");
         let completed_txs = self.db.get_completed_transactions().await?;
         for completed_tx in completed_txs.values() {
-            if completed_tx.status == TransactionStatus::Completed ||
-                completed_tx.status == TransactionStatus::Broadcast ||
-                completed_tx.status == TransactionStatus::MinedUnconfirmed
+            if completed_tx.valid &&
+                (completed_tx.status == TransactionStatus::Completed ||
+                    completed_tx.status == TransactionStatus::Broadcast ||
+                    completed_tx.status == TransactionStatus::MinedUnconfirmed)
             {
-                // Restart this protocol by first querying to see if the tx is in the mempool to avoid a false
-                // DoubleSpend rejection
                 self.broadcast_completed_transaction(completed_tx.tx_id, join_handles)
                     .await?;
             }


### PR DESCRIPTION
## Description
This PR just adds a check to make sure that broadcast protocols are not started for invalid transactions.

## How Has This Been Tested?
Unit test provided

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [x] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch.
* [x] I ran `cargo-fmt --all` before pushing.
* [x] I ran `cargo test` successfully before submitting my PR.
* [x] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
