### PR TITLE
[network] Add explicit rejection reason to RPC handshake

### DIFF
--- a/base_layer/core/src/base_node/sync/header_sync/synchronizer.rs
+++ b/base_layer/core/src/base_node/sync/header_sync/synchronizer.rs
@@ -108,7 +108,7 @@ impl<'a, B: BlockchainBackend + 'static> HeaderSynchronizer<'a, B> {
                     debug!(target: LOG_TARGET, "{}", err);
                 },
 
-                Err(err @ BlockHeaderSyncError::RpcError(RpcError::NegotiationTimedOut)) => {
+                Err(err @ BlockHeaderSyncError::RpcError(RpcError::HandshakeTimedOut)) => {
                     debug!(target: LOG_TARGET, "{}", err);
                     self.ban_peer_short(node_id, BanReason::RpcNegotiationTimedOut).await?;
                 },

--- a/comms/src/proto/rpc.proto
+++ b/comms/src/proto/rpc.proto
@@ -46,4 +46,11 @@ message RpcSessionReply {
         // Indicates the server rejected the session
         bool rejected = 2;
     }
+    enum HandshakeRejectReason {
+        HANDSHAKE_REJECT_REASON_UNKNOWN = 0;
+        HANDSHAKE_REJECT_REASON_UNSUPPORTED_VERSION = 1;
+        HANDSHAKE_REJECT_REASON_NO_SESSIONS_AVAILABLE = 2;
+        HANDSHAKE_REJECT_REASON_PROTOCOL_NOT_SUPPORTED= 3;
+    }
+    HandshakeRejectReason reject_reason = 3;
 }

--- a/comms/src/protocol/rpc/error.rs
+++ b/comms/src/protocol/rpc/error.rs
@@ -21,7 +21,12 @@
 //  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 use super::RpcStatus;
-use crate::{connectivity::ConnectivityError, peer_manager::PeerManagerError, PeerConnectionError};
+use crate::{
+    connectivity::ConnectivityError,
+    peer_manager::PeerManagerError,
+    proto::rpc as rpc_proto,
+    PeerConnectionError,
+};
 use prost::DecodeError;
 use std::io;
 use thiserror::Error;
@@ -46,12 +51,12 @@ pub enum RpcError {
     RequestCancelled,
     #[error("Client internal error: {0}")]
     ClientInternalError(String),
-    #[error("RPC negotiation timed out")]
-    NegotiationTimedOut,
-    #[error("RPC negotiation failed: The client does not support any RPC protocol version supported by this node")]
-    NegotiationClientNoSupportedVersion,
-    #[error("RPC negotiation failed: The server does not support any RPC protocol version supported by this node")]
-    NegotiationServerNoSupportedVersion,
+    #[error("RPC handshake timed out")]
+    HandshakeTimedOut,
+    #[error("RPC handshake failed: The client does not support any RPC protocol version supported by this node")]
+    HandshakeClientNoSupportedVersion,
+    #[error("RPC handshake was explicitly rejected: {0}")]
+    HandshakeRejected(#[from] HandshakeRejectReason),
     #[error("Peer connection error: {0}")]
     PeerConnectionError(#[from] PeerConnectionError),
     #[error("Peer manager error: {0}")]
@@ -65,5 +70,51 @@ pub enum RpcError {
 impl RpcError {
     pub fn client_internal_error<T: ToString>(err: T) -> Self {
         RpcError::ClientInternalError(err.to_string())
+    }
+}
+
+#[derive(Debug, Error, Clone, Copy)]
+pub enum HandshakeRejectReason {
+    #[error("protocol version not supported")]
+    UnsupportedVersion,
+    #[error("no more RPC sessions available")]
+    NoSessionsAvailable,
+    #[error("protocol not supported")]
+    ProtocolNotSupported,
+    #[error("unknown protocol error: {0}")]
+    Unknown(&'static str),
+}
+
+impl HandshakeRejectReason {
+    pub fn as_i32(&self) -> i32 {
+        rpc_proto::rpc_session_reply::HandshakeRejectReason::from(*self) as i32
+    }
+
+    pub fn from_i32(v: i32) -> Option<Self> {
+        rpc_proto::rpc_session_reply::HandshakeRejectReason::from_i32(v).map(Into::into)
+    }
+}
+
+impl From<rpc_proto::rpc_session_reply::HandshakeRejectReason> for HandshakeRejectReason {
+    fn from(reason: rpc_proto::rpc_session_reply::HandshakeRejectReason) -> Self {
+        use rpc_proto::rpc_session_reply::HandshakeRejectReason::*;
+        match reason {
+            UnsupportedVersion => HandshakeRejectReason::UnsupportedVersion,
+            NoSessionsAvailable => HandshakeRejectReason::NoSessionsAvailable,
+            ProtocolNotSupported => HandshakeRejectReason::ProtocolNotSupported,
+            Unknown => HandshakeRejectReason::Unknown("reject reason is not known"),
+        }
+    }
+}
+
+impl From<HandshakeRejectReason> for rpc_proto::rpc_session_reply::HandshakeRejectReason {
+    fn from(reason: HandshakeRejectReason) -> Self {
+        use rpc_proto::rpc_session_reply::HandshakeRejectReason::*;
+        match reason {
+            HandshakeRejectReason::UnsupportedVersion => UnsupportedVersion,
+            HandshakeRejectReason::NoSessionsAvailable => NoSessionsAvailable,
+            HandshakeRejectReason::ProtocolNotSupported => ProtocolNotSupported,
+            HandshakeRejectReason::Unknown(_) => Unknown,
+        }
     }
 }

--- a/comms/src/protocol/rpc/mod.rs
+++ b/comms/src/protocol/rpc/mod.rs
@@ -57,6 +57,7 @@ mod not_found;
 
 pub mod mock;
 
+/// Maximum frame size of each RPC message. This is enforced in tokio's length delimited codec.
 pub const RPC_MAX_FRAME_SIZE: usize = 4 * 1024 * 1024; // 4 MiB
 
 // Re-exports used to keep things orderly in the #[tari_rpc] proc macro

--- a/comms/src/protocol/rpc/router.rs
+++ b/comms/src/protocol/rpc/router.rs
@@ -92,8 +92,8 @@ impl<A, B> Router<A, B> {
     }
 
     /// Sets the maximum number of sessions this node will allow before rejecting the request to connect
-    pub fn maximum_concurrent_sessions(mut self, limit: usize) -> Self {
-        self.server = self.server.maximum_concurrent_sessions(limit);
+    pub fn with_maximum_concurrent_sessions(mut self, limit: usize) -> Self {
+        self.server = self.server.with_maximum_concurrent_sessions(limit);
         self
     }
 

--- a/comms/src/protocol/rpc/test.rs
+++ b/comms/src/protocol/rpc/test.rs
@@ -21,5 +21,6 @@
 //  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 mod comms_integration;
+mod handshake;
 mod mock;
 mod smoke;

--- a/comms/src/protocol/rpc/test/handshake.rs
+++ b/comms/src/protocol/rpc/test/handshake.rs
@@ -1,0 +1,67 @@
+//  Copyright 2021, The Tari Project
+//
+//  Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+//  following conditions are met:
+//
+//  1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+//  disclaimer.
+//
+//  2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+//  following disclaimer in the documentation and/or other materials provided with the distribution.
+//
+//  3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+//  products derived from this software without specific prior written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+//  INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+//  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+//  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+//  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+//  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+//  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+use crate::{
+    framing,
+    memsocket::MemorySocket,
+    protocol::rpc::{error::HandshakeRejectReason, handshake::SUPPORTED_RPC_VERSIONS, Handshake, RpcError},
+    runtime,
+};
+use tari_test_utils::unpack_enum;
+use tokio::task;
+
+#[runtime::test_basic]
+async fn it_performs_the_handshake() {
+    let (client, server) = MemorySocket::new_pair();
+
+    let handshake_result = task::spawn(async move {
+        let mut server_framed = framing::canonical(server, 1024);
+        let mut handshake_server = Handshake::new(&mut server_framed);
+        handshake_server.perform_server_handshake().await
+    });
+
+    let mut client_framed = framing::canonical(client, 1024);
+    let mut handshake_client = Handshake::new(&mut client_framed);
+
+    handshake_client.perform_client_handshake().await.unwrap();
+    let v = handshake_result.await.unwrap().unwrap();
+    assert!(SUPPORTED_RPC_VERSIONS.contains(&v));
+}
+
+#[runtime::test_basic]
+async fn it_rejects_the_handshake() {
+    let (client, server) = MemorySocket::new_pair();
+
+    let mut client_framed = framing::canonical(client, 1024);
+    let mut handshake_client = Handshake::new(&mut client_framed);
+
+    let mut server_framed = framing::canonical(server, 1024);
+    let mut handshake_server = Handshake::new(&mut server_framed);
+    handshake_server
+        .reject_with_reason(HandshakeRejectReason::NoSessionsAvailable)
+        .await
+        .unwrap();
+
+    let err = handshake_client.perform_client_handshake().await.unwrap_err();
+    unpack_enum!(RpcError::HandshakeRejected(reason) = err);
+    unpack_enum!(HandshakeRejectReason::NoSessionsAvailable = reason);
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Client RPC handshake can now be explicitly rejected by the server
for the following reasons:

- The given protocol version is not supported
- The server has reached it's session limit
- The protocol is not supported
- Some other unspecified reason

Additionally, add an explicit error for server responses that are larger
than the permitted max frame size.

This protocol change is backward compatible.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Previously if the session concurrency limit is reached for a peer, the peer would close the client's connection immediately.
As with other request/response based protocols (e.g. HTTP), if a server is not available the correct response should be returned. This PR adds these responses. Helpfully, this allows the client to act on a given rejection reason appropriately (e.g. try another node if the first node is too busy)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
New unit tests for handshake and _smoke_ test for the rejection interaction.
Tested backward compatibility by syncing a base node on current stibbons network, as well as sending txns via the console wallet to an old wallet.   

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [x] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [x] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [ ] I'm merging against the `development` branch.
* [ ] I ran `cargo-fmt --all` before pushing.
* [ ] I ran `cargo test` successfully before submitting my PR.
* [ ] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
