### PR TITLE
Expiry of SAF messages

### DIFF
--- a/base_layer/p2p/src/services/liveness/service.rs
+++ b/base_layer/p2p/src/services/liveness/service.rs
@@ -434,6 +434,7 @@ mod test {
                 network: Network::LocalTest,
                 flags: Default::default(),
                 message_tag: MessageTag::new(),
+                expires: None,
             },
             authenticated_origin: None,
             source_peer,

--- a/base_layer/p2p/src/test_utils.rs
+++ b/base_layer/p2p/src/test_utils.rs
@@ -70,6 +70,7 @@ pub fn make_dht_header(trace: MessageTag) -> DhtMessageHeader {
         network: Network::LocalTest,
         flags: DhtMessageFlags::NONE,
         message_tag: trace,
+        expires: None,
     }
 }
 

--- a/base_layer/wallet/tests/support/comms_and_services.rs
+++ b/base_layer/wallet/tests/support/comms_and_services.rs
@@ -93,6 +93,7 @@ pub fn create_dummy_message<T>(inner: T, public_key: &CommsPublicKey) -> DomainM
             network: Network::LocalTest,
             destination: Default::default(),
             message_tag: MessageTag::new(),
+            expires: None,
         },
         authenticated_origin: None,
         source_peer: peer_source,

--- a/comms/dht/src/config.rs
+++ b/comms/dht/src/config.rs
@@ -42,6 +42,10 @@ pub struct DhtConfig {
     /// Send to this many peers when using the propagate strategy
     /// Default: 4
     pub propagation_factor: usize,
+    /// The amount of seconds added to the current time (Utc) which will then be used to check if the message has
+    /// expired or not when processing the message
+    /// Default: 10800
+    pub saf_msg_validity: Duration,
     /// The maximum number of messages that can be stored using the Store-and-forward middleware.
     /// Default: 100,000
     pub saf_msg_storage_capacity: usize,
@@ -172,6 +176,7 @@ impl Default for DhtConfig {
             flood_ban_max_msg_count: 1000,
             flood_ban_timespan: Duration::from_secs(100),
             offline_peer_cooldown: Duration::from_secs(24 * 60 * 60),
+            saf_msg_validity: Duration::from_secs(10800),
         }
     }
 }

--- a/comms/dht/src/dht.rs
+++ b/comms/dht/src/dht.rs
@@ -355,6 +355,7 @@ impl Dht {
                 self.dht_requester(),
                 self.discovery_service_requester(),
                 self.config.network,
+                chrono::Duration::from_std(self.config.saf_msg_validity).unwrap(),
             ))
             .layer(MessageLoggingLayer::new(format!(
                 "Outbound [{}]",

--- a/comms/dht/src/outbound/message.rs
+++ b/comms/dht/src/outbound/message.rs
@@ -167,6 +167,7 @@ pub struct DhtOutboundMessage {
     pub network: Network,
     pub dht_flags: DhtMessageFlags,
     pub is_broadcast: bool,
+    pub expires: Option<prost_types::Timestamp>,
 }
 
 impl fmt::Display for DhtOutboundMessage {

--- a/comms/dht/src/outbound/serialize.rs
+++ b/comms/dht/src/outbound/serialize.rs
@@ -76,6 +76,7 @@ where S: Service<OutboundMessage, Response = (), Error = PipelineError> + Clone 
                 dht_flags,
                 origin_mac,
                 reply,
+                expires,
                 ..
             } = message;
             trace!(
@@ -84,7 +85,6 @@ where S: Service<OutboundMessage, Response = (), Error = PipelineError> + Clone 
                 message.tag,
                 destination_node_id.short_str()
             );
-
             let dht_header = custom_header.map(DhtHeader::from).unwrap_or_else(|| DhtHeader {
                 version: DHT_ENVELOPE_HEADER_VERSION,
                 origin_mac: origin_mac.map(|b| b.to_vec()).unwrap_or_else(Vec::new),
@@ -94,6 +94,7 @@ where S: Service<OutboundMessage, Response = (), Error = PipelineError> + Clone 
                 flags: dht_flags.bits(),
                 destination: Some(destination.into()),
                 message_tag: tag.as_value(),
+                expires,
             });
             let envelope = DhtEnvelope::new(dht_header, body);
 

--- a/comms/dht/src/proto/envelope.proto
+++ b/comms/dht/src/proto/envelope.proto
@@ -2,6 +2,8 @@ syntax = "proto3";
 
 package tari.dht.envelope;
 
+import "google/protobuf/timestamp.proto";
+
 enum DhtMessageType {
     // Indicated this message is not a DHT message
     DhtMessageTypeNone = 0;
@@ -43,6 +45,8 @@ message DhtHeader {
     // Message trace ID
     // TODO: Remove for mainnet or when testing message traces is not required
     uint64 message_tag = 10;
+    // Expiry timestamp for the message
+    google.protobuf.Timestamp expires = 11;
 }
 
 enum Network {

--- a/comms/dht/src/store_forward/message.rs
+++ b/comms/dht/src/store_forward/message.rs
@@ -21,34 +21,17 @@
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 use crate::{
+    envelope::datetime_to_timestamp,
     proto::{
         envelope::DhtHeader,
         store_forward::{StoredMessage, StoredMessagesRequest, StoredMessagesResponse},
     },
     store_forward::{database, StoreAndForwardError},
 };
-use chrono::{DateTime, NaiveDateTime, Utc};
+use chrono::{DateTime, Utc};
 use prost::Message;
-use prost_types::Timestamp;
 use rand::{rngs::OsRng, RngCore};
-use std::{
-    cmp,
-    convert::{TryFrom, TryInto},
-};
-
-/// Utility function that converts a `chrono::DateTime<Utc>` to a `prost::Timestamp`
-pub(crate) fn datetime_to_timestamp(datetime: DateTime<Utc>) -> Timestamp {
-    Timestamp {
-        seconds: datetime.timestamp(),
-        nanos: datetime.timestamp_subsec_nanos().try_into().unwrap_or(std::i32::MAX),
-    }
-}
-
-/// Utility function that converts a `prost::Timestamp` to a `chrono::DateTime<Utc>`
-pub(crate) fn timestamp_to_datetime(timestamp: Timestamp) -> DateTime<Utc> {
-    let naive = NaiveDateTime::from_timestamp(timestamp.seconds, cmp::max(0, timestamp.nanos) as u32);
-    DateTime::from_utc(naive, Utc)
-}
+use std::convert::{TryFrom, TryInto};
 
 impl StoredMessagesRequest {
     pub fn new() -> Self {

--- a/comms/dht/src/store_forward/saf_handler/task.rs
+++ b/comms/dht/src/store_forward/saf_handler/task.rs
@@ -24,7 +24,7 @@ use crate::{
     actor::DhtRequester,
     config::DhtConfig,
     crypt,
-    envelope::{DhtMessageFlags, DhtMessageHeader, NodeDestination},
+    envelope::{timestamp_to_datetime, DhtMessageFlags, DhtMessageHeader, NodeDestination},
     inbound::{DecryptedDhtMessage, DhtInboundMessage},
     outbound::{OutboundMessageRequester, SendMessageParams},
     proto::{
@@ -36,12 +36,7 @@ use crate::{
             StoredMessagesResponse,
         },
     },
-    store_forward::{
-        error::StoreAndForwardError,
-        message::timestamp_to_datetime,
-        service::FetchStoredMessageQuery,
-        StoreAndForwardRequester,
-    },
+    store_forward::{error::StoreAndForwardError, service::FetchStoredMessageQuery, StoreAndForwardRequester},
 };
 use digest::Digest;
 use futures::{channel::mpsc, future, stream, Future, SinkExt, StreamExt};

--- a/comms/dht/src/test_utils/makers.rs
+++ b/comms/dht/src/test_utils/makers.rs
@@ -90,6 +90,7 @@ pub fn make_dht_header(
         network: Network::LocalTest,
         flags,
         message_tag: trace,
+        expires: None,
     }
 }
 
@@ -195,5 +196,6 @@ pub fn create_outbound_message(body: &[u8]) -> DhtOutboundMessage {
         reply: None.into(),
         origin_mac: None,
         is_broadcast: false,
+        expires: None,
     }
 }


### PR DESCRIPTION
## Description
This PR will add an expiry timestamp to SAF messages.

When trying to forward or store these messages, should the timestamp be less than the current time, the message will be discarded.

Should there not be a expiry timestamp, the message will be treated as normal for backwards compatibility.

## Motivation and Context

## How Has This Been Tested?

## Types of changes
* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
* [x] I'm merging against the `development` branch.
* [x] I ran `cargo-fmt --all` before pushing.
* [x] I ran `cargo test` successfully before submitting my PR.
* [x] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
