### PR TITLE
[base-node] get-block command accepts height or hash

### DIFF
--- a/base_layer/core/src/transactions/aggregated_body.rs
+++ b/base_layer/core/src/transactions/aggregated_body.rs
@@ -446,20 +446,20 @@ impl From<Transaction> for AggregateBody {
 impl Display for AggregateBody {
     fn fmt(&self, fmt: &mut Formatter<'_>) -> Result<(), Error> {
         if !self.is_sorted() {
-            fmt.write_str("WARNING: Block body is not sorted.\n")?;
+            writeln!(fmt, "WARNING: Block body is not sorted.")?;
         }
-        fmt.write_str("--- Transaction Kernels ---\n")?;
+        writeln!(fmt, "--- Transaction Kernels ---")?;
         for (i, kernel) in self.kernels.iter().enumerate() {
-            fmt.write_str(&format!("Kernel {}:\n", i))?;
-            fmt.write_str(&format!("{}\n", kernel))?;
+            writeln!(fmt, "Kernel {}:", i)?;
+            writeln!(fmt, "{}", kernel)?;
         }
-        fmt.write_str(&format!("--- Inputs ({}) ---\n", self.inputs.len()))?;
+        writeln!(fmt, "--- Inputs ({}) ---", self.inputs.len())?;
         for input in self.inputs.iter() {
-            fmt.write_str(&format!("{}", input))?;
+            writeln!(fmt, "{}", input)?;
         }
-        fmt.write_str(&format!("--- Outputs ({}) ---\n", self.outputs.len()))?;
+        writeln!(fmt, "--- Outputs ({}) ---", self.outputs.len())?;
         for output in self.outputs.iter() {
-            fmt.write_str(&format!("{}", output))?;
+            writeln!(fmt, "{}", output)?;
         }
         Ok(())
     }

--- a/base_layer/core/src/transactions/transaction.rs
+++ b/base_layer/core/src/transactions/transaction.rs
@@ -352,7 +352,7 @@ impl Hashable for TransactionInput {
 
 impl Display for TransactionInput {
     fn fmt(&self, fmt: &mut Formatter<'_>) -> Result<(), std::fmt::Error> {
-        fmt.write_str(&format!("{} [{:?}]\n", self.commitment.to_hex(), self.features))
+        write!(fmt, "{} [{:?}]", self.commitment.to_hex(), self.features)
     }
 }
 
@@ -471,13 +471,14 @@ impl Default for TransactionOutput {
 impl Display for TransactionOutput {
     fn fmt(&self, fmt: &mut Formatter<'_>) -> Result<(), std::fmt::Error> {
         let proof = self.proof.to_hex();
-        fmt.write_str(&format!(
-            "({} [{:?}] Proof: {}..{})",
+        write!(
+            fmt,
+            "{} [{:?}] Proof: {}..{}",
             self.commitment.to_hex(),
             self.features,
             proof[0..16].to_string(),
             proof[proof.len() - 16..proof.len()].to_string()
-        ))
+        )
     }
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
- `get-block` now accepts height _or_ block hash as input.
- fix missing newline in output list for `get-block`

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
For those times when you have a particular hash but you don't know the corresponding height.

Outputs now displayed one on a line
```
--- Transaction Kernels ---
Kernel 0:
Fee: 875 µT
Lock height: 0
Features: (empty)
Excess: dcee75f736cb4b583c01318f87ed31502c42d4f45ff18fa686cac5b0d85f2954
Excess signature: {"public_nonce":"76b234ec61bd340f10caaf89dc889be75f447c01db365405f6b96c209aff3013","signature":"d93a642b767e2b105860058edb6202d6b7bf9a208a47222b443c3e404bb24e04"}

Kernel 1:
Fee: 0 µT
Lock height: 0
Features: COINBASE_KERNEL
Excess: c0f0805f4e27ad27f0b6ce89f0d9c11643ecd423ad80718b94e491a921247964
Excess signature: {"public_nonce":"fedc4b6b5a7bdd0f2456e381c7129e55e01f3c8d87df4d9528678c27d3870775","signature":"ef7e8c80e093e77170d44b179ee8c571200e37c3100f4143342ed849b2d4500a"}

--- Inputs (6) ---
c081a8663af8221f33fe421b4c41e00a79eeb10d82421c2b17143ad8b7bf8b3e [OutputFeatures { flags: COINBASE_OUTPUT, maturity: 6683 }]
fe23082985cea982c45eea3a346b55ec420599377a4e4bbf72b5f29fa6ada95b [OutputFeatures { flags: COINBASE_OUTPUT, maturity: 6684 }]
2e80428cccf5d66d424ce1d98f0052029efb570b2f676ff562d56bae5d50fb6f [OutputFeatures { flags: COINBASE_OUTPUT, maturity: 6685 }]
843cfb96aff05d5996f78dc14393cc5c6e8f90c9eecf76623fbfee6f0af0a062 [OutputFeatures { flags: COINBASE_OUTPUT, maturity: 6686 }]
107d1ea7ee029196cce4012048367a607eed8b0f52914e9902ccd7d86c168a45 [OutputFeatures { flags: COINBASE_OUTPUT, maturity: 6687 }]
9830b052b61b6f8ec230742b149ee5593261b39b4d2e6a371591b3def9bd9a15 [OutputFeatures { flags: COINBASE_OUTPUT, maturity: 6689 }]
--- Outputs (3) ---
ee688499ca3b45bfcc01edc5b298d42123d0328cf56a4df9ff7db352428bcd25 [OutputFeatures { flags: (empty), maturity: 0 }] Proof: 7e25b17c5e81ee61..9822437d3a1d810a
fa2db4698470de2c0715618bfaad1e63fcfe7a71af53d3a097fd96c6c3b5b76c [OutputFeatures { flags: (empty), maturity: 0 }] Proof: b69cbcca5dea4cd3..df27692e1ff7e90c
d4192d8037c7fe6770fd9547637215c368579bfb025ba32504668acbf8a6c12f [OutputFeatures { flags: COINBASE_OUTPUT, maturity: 7183 }] Proof: 461e5be540aa6240..f8091b408c42040e
```


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested on base node

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [ ] I'm merging against the `development` branch.
* [ ] I ran `cargo-fmt --all` before pushing.
* [ ] I ran `cargo test` successfully before submitting my PR.
* [ ] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
