### PR TITLE
[base-node] Fix state machine never bootstraps with empty network

### DIFF
--- a/applications/tari_merge_mining_proxy/src/proxy.rs
+++ b/applications/tari_merge_mining_proxy/src/proxy.rs
@@ -483,7 +483,7 @@ impl InnerService {
             } else {
                 self.initial_sync_achieved.store(true, Ordering::Relaxed);
                 let msg = format!(
-                    "Initial base node sync achieved at height #{}",
+                    "Initial base node sync achieved. Ready to mine at height #{}",
                     new_block_template.header.as_ref().map(|h| h.height).unwrap_or_default()
                 );
                 debug!(target: LOG_TARGET, "{}", msg);

--- a/applications/tari_mining_node/src/difficulty.rs
+++ b/applications/tari_mining_node/src/difficulty.rs
@@ -99,8 +99,7 @@ impl BlockHeaderSha3 {
             .clone()
             .chain(self.nonce.to_le_bytes())
             .chain(&self.pow_bytes)
-            .finalize()
-            .to_vec();
+            .finalize();
         let hash = Sha3_256::digest(&hash);
         big_endian_difficulty(&hash)
     }

--- a/base_layer/core/src/base_node/chain_metadata_service/service.rs
+++ b/base_layer/core/src/base_node/chain_metadata_service/service.rs
@@ -198,9 +198,7 @@ impl ChainMetadataService {
                 );
                 // If we have chain metadata to send to the base node service, send them now
                 // because the next round of pings is happening.
-                if !self.peer_chain_metadata.is_empty() {
-                    self.flush_chain_metadata_to_event_publisher().await?;
-                }
+                self.flush_chain_metadata_to_event_publisher().await?;
                 // Ensure that we're waiting for the correct amount of peers to respond
                 // and have allocated space for their replies
                 self.resize_chainstate_buffer(*num_peers);

--- a/base_layer/core/src/base_node/state_machine_service/states/block_sync.rs
+++ b/base_layer/core/src/base_node/state_machine_service/states/block_sync.rs
@@ -65,7 +65,7 @@ impl BlockSync {
 
         let status_event_sender = shared.status_event_sender.clone();
         let local_nci = shared.local_node_interface.clone();
-        let bootstrapped = shared.bootstrapped_sync;
+        let bootstrapped = shared.is_bootstrapped();
         synchronizer.on_progress(move |block, remote_tip_height, sync_peers| {
             let local_height = block.block.header.height;
             local_nci.publish_block_event(BlockEvent::ValidBlockAdded(

--- a/base_layer/core/src/base_node/state_machine_service/states/events_and_states.rs
+++ b/base_layer/core/src/base_node/state_machine_service/states/events_and_states.rs
@@ -88,10 +88,11 @@ pub enum SyncStatus {
 
 impl SyncStatus {
     pub fn is_lagging(&self) -> bool {
-        match self {
-            SyncStatus::Lagging(_, _) | SyncStatus::LaggingBehindHorizon(_, _) => true,
-            SyncStatus::UpToDate => false,
-        }
+        !self.is_up_to_date()
+    }
+
+    pub fn is_up_to_date(&self) -> bool {
+        matches!(self, SyncStatus::UpToDate)
     }
 }
 
@@ -205,6 +206,14 @@ impl StateInfo {
         match self {
             Self::BlockSync(info) => Some(info.clone()),
             _ => None,
+        }
+    }
+
+    pub fn is_synced(&self) -> bool {
+        use StateInfo::*;
+        match self {
+            StartUp | HeaderSync(_) | HorizonSync(_) | BlockSync(_) => false,
+            Listening(info) => info.is_synced(),
         }
     }
 }

--- a/base_layer/core/src/base_node/sync/header_sync/error.rs
+++ b/base_layer/core/src/base_node/sync/header_sync/error.rs
@@ -57,4 +57,6 @@ pub enum BlockHeaderSyncError {
     InvalidBlockHeight(u64, u64),
     #[error("Unable to find chain split from peer `{0}`")]
     ChainSplitNotFound(NodeId),
+    #[error("Node could not find any other node with which to sync. Silence.")]
+    NetworkSilence,
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
When the base node is at height 0 and has no contact with any other
peers (chain metadata service has no peers to ping), it now changes
state to (boostrapped) listening so that miners can begin mining.


As before, the network is still monitored and if there are peers to contact
the bootstrap will not complete until after sync.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Previously, mining could not occur through the mm proxy and standalone
miner because the base node would never bootstrap.

Cucumber integration test nodes would 'spin' when starting from height == 0 
and being the only node
i.e `starting -> listening -> sync -> fail -> listening -> sync -> fail ->listening ->(etc)`
This change recognises "network silence" and breaks that loop 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested on stibbons node and a "network of one" private node with miners attached.
Waiting for Integration tests on CI

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [ ] I'm merging against the `development` branch.
* [ ] I ran `cargo-fmt --all` before pushing.
* [ ] I ran `cargo test` successfully before submitting my PR.
* [ ] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
