### PR TITLE
Tweak Cucumber stress tests to make them more stable

### DIFF
--- a/integration_tests/features/StressTest.feature
+++ b/integration_tests/features/StressTest.feature
@@ -4,13 +4,13 @@ Feature: Stress Test
     @long-running
     Scenario Outline: Ramped Stress Test
         Given I have a seed node NODE1
-        And I have stress-test wallet WALLET_A connected to the seed node NODE1 with broadcast monitoring timeout 30
+        And I have stress-test wallet WALLET_A connected to the seed node NODE1 with broadcast monitoring timeout <MonitoringTimeout>
         And I have a merge mining proxy PROXY connected to NODE1 and WALLET_A
         # We mine some blocks before starting the other nodes to avoid a spinning sync state when all the nodes are at height 0
         When I merge mine 6 blocks via PROXY
         And I have a seed node NODE2
         And I have <NumNodes> base nodes connected to all seed nodes
-        And I have stress-test wallet WALLET_B connected to the seed node NODE2 with broadcast monitoring timeout 30
+        And I have stress-test wallet WALLET_B connected to the seed node NODE2 with broadcast monitoring timeout <MonitoringTimeout>
         # There need to be at least as many mature coinbase UTXOs in the wallet coin splits required for the number of transactions
         When I merge mine <NumCoinsplitsNeeded> blocks via PROXY
         Then all nodes are at current tip height
@@ -32,21 +32,21 @@ Feature: Stress Test
         # Then wallet WALLET_B detects all transactions as Mined_Confirmed
         Then while mining via NODE1 all transactions in wallet WALLET_B are found to be Mined_Confirmed
         Examples:
-            | NumTransactions   | NumCoinsplitsNeeded   | NumNodes  |
-            | 10                | 1                     | 3         |
-            | 100               | 1                     | 3         |
-            | 1000              | 3                     | 3         |
-            | 10000             | 21                    | 3         |
+            | NumTransactions   | NumCoinsplitsNeeded   | NumNodes  | MonitoringTimeout |
+            | 10                | 1                     | 3         | 10                |
+            | 100               | 1                     | 3         | 10                |
+            | 1000              | 3                     | 3         | 30                |
+            | 10000             | 21                    | 3         | 60                |
 
     @long-running
     Scenario: Simple Stress Test
         Given I have a seed node NODE1
-        And I have wallet WALLET_A connected to seed node NODE1
+        And I have stress-test wallet WALLET_A connected to the seed node NODE1 with broadcast monitoring timeout 60
         And I have a merge mining proxy PROXY connected to NODE1 and WALLET_A
         When I merge mine 1 blocks via PROXY
         And I have a seed node NODE2
         And I have 1 base nodes connected to all seed nodes
-        And I have wallet WALLET_B connected to seed node NODE2
+        And I have stress-test wallet WALLET_B connected to the seed node NODE2 with broadcast monitoring timeout 60
         # We need to ensure the coinbase lock heights are reached; mine enough blocks
         # The following line is how you could mine directly on the node
         When I merge mine 8 blocks via PROXY

--- a/integration_tests/features/support/steps.js
+++ b/integration_tests/features/support/steps.js
@@ -849,6 +849,7 @@ Then(/while mining via (.*) all transactions in wallet (.*) are found to be Mine
                     return true;
                 } else {
                     await nodeClient.mineBlock(walletClient);
+                    this.tipHeight += 1;
                     return false;
                 }
             }
@@ -879,6 +880,7 @@ Then(/while merge mining via (.*) all transactions in wallet (.*) are found to b
                     return true;
                 } else {
                     await this.mergeMineBlock(mmProxy);
+                    this.tipHeight += 1;
                     return false;
                 }
             }
@@ -1038,6 +1040,7 @@ When(/I send (.*) transactions of (.*) uT each from wallet (.*) to wallet (.*) a
             batch++;
             console.log(i, "/", numTransactions, " transactions sent");
         }
+        await sleep(50);
     }
 
     console.log(numTransactions, " transactions successfully sent.");


### PR DESCRIPTION
## Description
This PR lengthens the wallet broadcast and monitoring timeout to lessen the load on the base node during the large stress test. It also adds a small 50ms delay between transactions being submitted to spread the transactions on the big stress test out over a larger period. These changes only add 7 minutes to the 10_000 tx stress test but should make it more stable.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch.
* [x] I ran `cargo-fmt --all` before pushing.
* [x] I ran `cargo test` successfully before submitting my PR.
* [x] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
