### PR TITLE
Document the NO_OP TariScript vulnerability

### DIFF
--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -1,3 +1,5 @@
 # Summary
 
 - [Wallet to Wallet negotiation with TariScript](wallet_to_wallet_with_tariscript.md)
+- [TariScript No-Op script vulnerability](tari_script_no_op_vulnerability.md)
+

--- a/docs/src/tari_script_no_op_vulnerability.md
+++ b/docs/src/tari_script_no_op_vulnerability.md
@@ -1,0 +1,83 @@
+# TariScript No-Op script vulnerability
+
+This document describes a vulnerability in the current version of TariScript found by [@mikethetike](https://github.com/mikethetike).
+
+The initial specification of how TariScript is incorporated into a Tari Mimblewimble (MW) style transaction is defined in the Tari [RFC-0201](https://rfc.tari.com/RFC-0201_TariScript.html). 
+
+This vulnerability applies to transactions where a Sender is spending one, or more, of their inputs where all the inputs are bound by a NO_OP script like is suggested in [RFC-0201](https://rfc.tari.com/RFC-0201_TariScript.html#standard-mw-transaction)
+for use in implementing a "Standard" MW transaction while using TariScript. When a Sender constructs a transaction spending an input with a NO_OP script and does not include a change output
+it turns out that the spending script applied to the Receiver's output become malleable after the transaction has been finalized by the Sender.
+
+For this example we will call the Sender Alice and the Receiver Bob. We reproduce the components of a finalized transaction here for a transaction with no change output. 
+The full derivation of these components can be found [here](wallet_to_wallet_with_tariscript.md#final-transaction).
+
+| Transaction        |              |
+|--------------------|-------       |
+| offset          | \\( x_s \\)     |
+| script_offset   | \\( \gamma \\)  |
+
+| Transaction Input |      |
+|--------------------|-------|
+| Commitment                |  \\( C_a = k_a \cdot G + v_a \cdot H  \\) |
+| Features                  | Fa                                        |
+| Script                    | \\( \alpha_a \\)                          |
+| Input Data                | \\( \theta_a \\)                          |
+| height                    | \\( h \\)                                 |
+| Script Signature          | \\( (s_{sa}, R_{sa}) \\)                  |
+| Script offset public key  | \\( K_{Oa} \\)                            |
+
+| Transaction Output |      |
+|--------------------|-------|
+| Commitment    |  \\( C_b = k_b \cdot G + v_b \cdot H  \\)     |
+| Features      | Fb                                            |
+| Rangeproof    | \\( RP_b \\) for \\( \hat{C}_b \\)            |
+| Script Hash   | \\( \sigma_b = H( \alpha_b) \\)               |
+| Script offset public key | \\( K_{Ob} \\)                     |
+
+| Transaction Kernel |       |
+|--------------------|-------|
+| Public Excess      | \\( X_s + K_b \\)    |
+| Signature          | \\( s, R \\)         |
+| Fee                | f                    |
+| Metadata           | m                    |
+
+The mechanism that stops Bob's script, whose hash is \\( \sigma_b \\), from being malleable after the transaction is completed is the following. During Bob's round of 
+transaction negotiation they commit to the script hash \\( \sigma_b \\), and the Public UTXO script offset, \\( K_{Ob} \\), which is provided by Alice. These are committed 
+to in the construction of 
+
+\\( \beta_b = H(\sigma_b || F_b || K_{Ob}) \\).
+
+\\( \beta_b \\) is then used to create the modified commitment 
+
+\\( \hat{C}_b = (k_b + \beta_b) \cdot G + v_b \cdot H \\)
+
+
+used to produce the range proof \\( RP_b \\). The assumption is that only Alice has access to the private key, \\( k_{Ob} \\) used to produce the Public UTXO script 
+offset for Bob script. 
+
+Once Bob has replied with their part of the transaction negotiation Alice completes the transaction by producing the complete MW transaction kernel signature and 
+two more operations for TariScript aspects of the transaction. Firstly, Alice constructs a script signature (\\( s_{sa}, R_{sa} \\)) for spending \\( C_a \\) by signing 
+\\( H( R_{sa} || \alpha_a || \theta_a || h) \\) with her private script key \\( k_{sa} \\). Secondly, Alice constructs the transaction's script offset
+
+\\( \gamma =  k_{sa} - k_{Ob}U_b \\).
+
+This offset can ostensibly only be constructed by someone who has knowledge of \\( k_{sa} \\) and \\( k_{Ob} \\). \\( k_{sa} \\) is the private script key whose public value, 
+\\( K_{sa} \\) is the public key that will be left on the stack when Alice's input script, \\( \alpha_a \\), is executed using Alice's input data \\( \theta_a \\).
+
+However, the public script key-pair \\( k_{sa} / K_{sa} \\) is purely a product of the script \\( \alpha_a \\) and the input data \\( \theta_a \\) and in the case of the NO_OP script
+there are no operations in the script that use data that Bob is not aware of. This means that Bob could choose a new set of input data \\( \hat{\theta_a} \\) which contains a public script
+key of his choosing, \\( \hat{K_{sa}} \\) to which he knows the private key \\( \hat{k_{sa}} \\). The execution of the NO_OP script for Alice's input will now leave \\( \hat{K_{sa}} \\) on 
+the stack. Bob can choose a new nonce \\( \hat{R_{sa}} \\) and then produce a valid script signature (\\( \hat{s_{sa}}, \hat{R_{sa}} \\)) for the challenge 
+\\( H( \hat{R_{sa}} || \alpha_a || \hat{\theta_a} || h) \\).
+
+Bob can also now produce a new transaction script offset while choosing a new UTXO script offset for his UTXO, \\( \hat{k_{Ob}} \\). This means he can modify the script attached 
+to his UTXO, \\( \hat{\sigma_{b}} \\), calculate a new modified commitment and range proof \\( \hat{RP_{b}} \\) for his new script and commit to it in a new transaction script offset
+
+\\( \hat{\gamma} =  \hat{k_{sa}} - \hat{k_{Ob}} \hat{U_b} \\).
+
+This attack is only possible if Alice did not have a change output in the transaction and all Alice's inputs have the NO_OP script. This is because the case that Alice has a change output, Bob would not know the 
+private script offset for the change output, \\( k_{oc} \\), to produce
+
+\\( \gamma =  k_{sa} - k_{Ob}U_b - k_{Oc}U_c \\).
+
+


### PR DESCRIPTION
## Description
This PR contains a write up off the NO_OP TariScript vulnerability spotted by @mikethetike .

This was put into the mdbook in the repo in /docs/. To view the document do the following:

In a terminal navigate to /docs
cargo install mdbook
mdbook serve
In a browser navigate to localhost:3000

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [x] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch.
* [ ] I ran `cargo-fmt --all` before pushing.
* [ ] I ran `cargo test` successfully before submitting my PR.
* [ ] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [x] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
