### PR TITLE
[wallet] Fix duplicate coinbase key generation, derive from height

### DIFF
--- a/base_layer/wallet/src/output_manager_service/service.rs
+++ b/base_layer/wallet/src/output_manager_service/service.rs
@@ -491,7 +491,7 @@ where TBackend: OutputManagerBackend + 'static
             .cancel_pending_transaction_at_block_height(block_height)
             .await?;
 
-        let key = self.get_next_coinbase_key().await?;
+        let key = self.get_coinbase_key_for_height(block_height).await?;
 
         let nonce = PrivateKey::random(&mut OsRng);
         let (tx, _) = CoinbaseBuilder::new(self.resources.factories.clone())
@@ -1141,9 +1141,9 @@ where TBackend: OutputManagerBackend + 'static
         Ok(key.k)
     }
 
-    async fn get_next_coinbase_key(&self) -> Result<PrivateKey, OutputManagerError> {
-        let mut km = self.coinbase_key_manager.lock().await;
-        let key = km.next_key()?;
+    async fn get_coinbase_key_for_height(&self, height: u64) -> Result<PrivateKey, OutputManagerError> {
+        let km = self.coinbase_key_manager.lock().await;
+        let key = km.derive_key(height)?;
         Ok(key.k)
     }
 }


### PR DESCRIPTION
Use block height as coinbase key index instead of next_key. This bug
was introduced in PR #2707.

This causes the key_index for the coinbase key manager to start from 0 every wallet start
leading to duplicate coinbase spend keys. This would cause mined blocks to be rejected (duplicate kernel)
if miners had previously won blocks with coinbases generated with this bug.