### PR TITLE
[tests] Fix rate_limit test flakiness

### DIFF
--- a/comms/src/common/rate_limit.rs
+++ b/comms/src/common/rate_limit.rs
@@ -136,7 +136,7 @@ mod test {
     async fn rate_limit() {
         let repeater = stream::repeat(());
 
-        let mut rate_limited = repeater.rate_limit(10, Duration::from_millis(100)).fuse();
+        let mut rate_limited = repeater.rate_limit(10, Duration::from_secs(100)).fuse();
 
         let mut timeout = time::delay_for(Duration::from_millis(50)).fuse();
         let mut count = 0usize;


### PR DESCRIPTION
`rate_limit` test should not have had time to restock but in resource
constrained environments it could. This fix increases the restock time
to make it practically impossible to hit.
