### PR TITLE
[Documentation] Minor Fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -606,8 +606,12 @@ The XMRig configuration must be prepared for either solo or pool merged mining w
 configuration file for XMRig as this offers more flexibility, otherwise, the configuration parameters can be passed 
 in via the command line upon runtime.
 
-**Note:** Monero mainnet and stagenet wallet addresses can only be used with the corresponding network. The `monerod_url` 
-configuration setting (see [Tari applications](#tari-applications)) must also correspond to the chosen network.
+**Notes:** 
+* Monero mainnet and stagenet wallet addresses can only be used with the corresponding network. The `monerod_url` 
+configuration setting (see [Tari applications](#tari-applications)) must also correspond to the chosen network. 
+* For the solo mining configuration, Monero doesn't currently support requesting templates to mine on with the address 
+being a subaddress. It is possible to do with the self-select configuration since the template is requested by the miner 
+with the wallet address of the pool.
 
 ###### Solo mining
 
@@ -625,8 +629,7 @@ in JSON format:
        addresses:
        - Public stagenet address at https://coin.fyi/news/monero/stagenet-wallet-8jyt89#!
          `55LTR8KniP4LQGJSPtbYDacR7dz8RBFnsfAKMaMuwUNYX6aQbBcovzDPyrQF9KXF9tVU6Xk3K8no1BywnJX6GvZX8yJsXvt`
-       - Public mainnet address at https://www.getmonero.org/get-started/contributing/
-         `888tNkZrPN6JsEgekjMnABU4TBzc2Dt29EPAvkRxbANsAnjyPbb3iQ1YBRk1UXcdRsiKc9dhwMVgN5S9cQUiyoogDavup3H`
+       - Mainnet address `<Enter your own mainnet wallet address here>`
 
 - Backends -> Select `CPU` (`OpenCL` or `CUDA` also possible depending on your computer hardware).
 
@@ -669,7 +672,7 @@ be augmented with Tari specific settings. Using the wizard, create the following
     - `nicehash`: Uncheck.
     - `User`: This must be your own mainnet wallet address, or you can use this address to donate to Monero:
        - Public mainnet address at https://www.getmonero.org/get-started/contributing/
-         `888tNkZrPN6JsEgekjMnABU4TBzc2Dt29EPAvkRxbANsAnjyPbb3iQ1YBRk1UXcdRsiKc9dhwMVgN5S9cQUiyoogDavup3H`
+       `888tNkZrPN6JsEgekjMnABU4TBzc2Dt29EPAvkRxbANsAnjyPbb3iQ1YBRk1UXcdRsiKc9dhwMVgN5S9cQUiyoogDavup3H`
     - `Password`: A custom field that could be your wallet name or some other pool settings.
     - `Coin`: Monero.
     - `Algorithm`: rx/0.

--- a/common/xmrig_config/config_example_mainnet.json
+++ b/common/xmrig_config/config_example_mainnet.json
@@ -7,8 +7,7 @@
         {
             "coin": "monero",
             "url": "127.0.0.1:7878",
-            "user": "888tNkZrPN6JsEgekjMnABU4TBzc2Dt29EPAvkRxbANsAnjyPbb3iQ1YBRk1UXcdRsiKc9dhwMVgN5S9cQUiyoogDavup3H",
-            "pass": "MyWallet",
+            "user": "YOUR MONERO WALLET ADDRESS HERE",
             "tls": false,
             "daemon": true
         }


### PR DESCRIPTION
## Description
Fix solo merged mining example config that was mistakenly using a subaddress instead of normal address for mainnet configuration, ModeroD doesn't currently support requesting block templates using subaddresses. Self-select configuration can remain the same as the pool wallet address is used to request the template, the miner address is purely for the pool to be able to pay out the miner.

Updated docs to reflect the same.

## Motivation and Context

## How Has This Been Tested?

## Types of changes
* [ ] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [x] Documentation

## Checklist:
* [x] I'm merging against the `development` branch.
* [x] I ran `cargo-fmt --all` before pushing.
* [ ] I ran `cargo test` successfully before submitting my PR.
* [x] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [x] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
