### PR TITLE
v0.8.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3880,7 +3880,7 @@ dependencies = [
 
 [[package]]
 name = "tari_app_grpc"
-version = "0.8.5"
+version = "0.8.6"
 dependencies = [
  "chrono",
  "prost",
@@ -3896,7 +3896,7 @@ dependencies = [
 
 [[package]]
 name = "tari_app_utilities"
-version = "0.8.5"
+version = "0.8.6"
 dependencies = [
  "config",
  "dirs-next",
@@ -3921,7 +3921,7 @@ dependencies = [
 
 [[package]]
 name = "tari_base_node"
-version = "0.8.5"
+version = "0.8.6"
 dependencies = [
  "anyhow",
  "bincode",
@@ -3986,7 +3986,7 @@ dependencies = [
 
 [[package]]
 name = "tari_common"
-version = "0.8.5"
+version = "0.8.6"
 dependencies = [
  "anyhow",
  "config",
@@ -4009,7 +4009,7 @@ dependencies = [
 
 [[package]]
 name = "tari_common_types"
-version = "0.8.5"
+version = "0.8.6"
 dependencies = [
  "futures 0.3.12",
  "rand 0.7.3",
@@ -4020,7 +4020,7 @@ dependencies = [
 
 [[package]]
 name = "tari_comms"
-version = "0.8.5"
+version = "0.8.6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4063,7 +4063,7 @@ dependencies = [
 
 [[package]]
 name = "tari_comms_dht"
-version = "0.8.5"
+version = "0.8.6"
 dependencies = [
  "anyhow",
  "bitflags 1.2.1",
@@ -4108,7 +4108,7 @@ dependencies = [
 
 [[package]]
 name = "tari_comms_rpc_macros"
-version = "0.8.5"
+version = "0.8.6"
 dependencies = [
  "futures 0.3.12",
  "proc-macro2 1.0.24",
@@ -4124,7 +4124,7 @@ dependencies = [
 
 [[package]]
 name = "tari_console_wallet"
-version = "0.8.5"
+version = "0.8.6"
 dependencies = [
  "chrono",
  "chrono-english",
@@ -4162,7 +4162,7 @@ dependencies = [
 
 [[package]]
 name = "tari_core"
-version = "0.8.5"
+version = "0.8.6"
 dependencies = [
  "bincode",
  "bitflags 1.2.1",
@@ -4241,7 +4241,7 @@ dependencies = [
 
 [[package]]
 name = "tari_infra_derive"
-version = "0.8.5"
+version = "0.8.6"
 dependencies = [
  "blake2",
  "proc-macro2 0.4.30",
@@ -4267,7 +4267,7 @@ dependencies = [
 
 [[package]]
 name = "tari_key_manager"
-version = "0.8.5"
+version = "0.8.6"
 dependencies = [
  "digest 0.8.1",
  "rand 0.7.3",
@@ -4281,7 +4281,7 @@ dependencies = [
 
 [[package]]
 name = "tari_merge_mining_proxy"
-version = "0.8.5"
+version = "0.8.6"
 dependencies = [
  "bincode",
  "bytes 0.5.6",
@@ -4319,7 +4319,7 @@ dependencies = [
 
 [[package]]
 name = "tari_mining_node"
-version = "0.8.5"
+version = "0.8.6"
 dependencies = [
  "chrono",
  "crossbeam",
@@ -4342,7 +4342,7 @@ dependencies = [
 
 [[package]]
 name = "tari_mmr"
-version = "0.8.5"
+version = "0.8.6"
 dependencies = [
  "bincode",
  "blake2",
@@ -4361,7 +4361,7 @@ dependencies = [
 
 [[package]]
 name = "tari_p2p"
-version = "0.8.5"
+version = "0.8.6"
 dependencies = [
  "anyhow",
  "bytes 0.4.12",
@@ -4401,7 +4401,7 @@ dependencies = [
 
 [[package]]
 name = "tari_service_framework"
-version = "0.8.5"
+version = "0.8.6"
 dependencies = [
  "anyhow",
  "futures 0.3.12",
@@ -4418,7 +4418,7 @@ dependencies = [
 
 [[package]]
 name = "tari_shutdown"
-version = "0.8.5"
+version = "0.8.6"
 dependencies = [
  "futures 0.3.12",
  "tokio",
@@ -4426,7 +4426,7 @@ dependencies = [
 
 [[package]]
 name = "tari_storage"
-version = "0.8.5"
+version = "0.8.6"
 dependencies = [
  "bincode",
  "bytes 0.4.12",
@@ -4444,7 +4444,7 @@ dependencies = [
 
 [[package]]
 name = "tari_test_utils"
-version = "0.8.5"
+version = "0.8.6"
 dependencies = [
  "futures 0.3.12",
  "futures-test",
@@ -4474,7 +4474,7 @@ dependencies = [
 
 [[package]]
 name = "tari_wallet"
-version = "0.8.5"
+version = "0.8.6"
 dependencies = [
  "aes-gcm",
  "bincode",
@@ -4500,7 +4500,7 @@ dependencies = [
  "tari_comms_dht",
  "tari_core",
  "tari_crypto",
- "tari_key_manager 0.8.5",
+ "tari_key_manager 0.8.6",
  "tari_p2p",
  "tari_service_framework",
  "tari_shutdown",
@@ -4531,7 +4531,7 @@ dependencies = [
  "tari_comms_dht",
  "tari_core",
  "tari_crypto",
- "tari_key_manager 0.8.5",
+ "tari_key_manager 0.8.6",
  "tari_p2p",
  "tari_shutdown",
  "tari_utilities",
@@ -4566,7 +4566,7 @@ dependencies = [
 
 [[package]]
 name = "test_faucet"
-version = "0.8.5"
+version = "0.8.6"
 dependencies = [
  "rand 0.7.3",
  "serde 1.0.123",

--- a/applications/tari_app_grpc/Cargo.toml
+++ b/applications/tari_app_grpc/Cargo.toml
@@ -4,7 +4,7 @@ authors = ["The Tari Development Community"]
 description = "This crate is to provide a single source for all cross application grpc files and conversions to and from tari::core"
 repository = "https://github.com/tari-project/tari"
 license = "BSD-3-Clause"
-version = "0.8.5"
+version = "0.8.6"
 edition = "2018"
 
 [dependencies]

--- a/applications/tari_app_utilities/Cargo.toml
+++ b/applications/tari_app_utilities/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tari_app_utilities"
-version = "0.8.5"
+version = "0.8.6"
 authors = ["Philip Robinson <simian@tari.com>"]
 edition = "2018"
 

--- a/applications/tari_base_node/Cargo.toml
+++ b/applications/tari_base_node/Cargo.toml
@@ -4,7 +4,7 @@ authors = ["The Tari Development Community"]
 description = "The tari full base node implementation"
 repository = "https://github.com/tari-project/tari"
 license = "BSD-3-Clause"
-version = "0.8.5"
+version = "0.8.6"
 edition = "2018"
 
 [dependencies]

--- a/applications/tari_console_wallet/Cargo.toml
+++ b/applications/tari_console_wallet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tari_console_wallet"
-version = "0.8.5"
+version = "0.8.6"
 authors = ["Philip Robinson <simian@tari.com>"]
 edition = "2018"
 

--- a/applications/tari_merge_mining_proxy/Cargo.toml
+++ b/applications/tari_merge_mining_proxy/Cargo.toml
@@ -4,7 +4,7 @@ authors = ["The Tari Development Community"]
 description = "The tari merge miner proxy for xmrig"
 repository = "https://github.com/tari-project/tari"
 license = "BSD-3-Clause"
-version = "0.8.5"
+version = "0.8.6"
 edition = "2018"
 
 [features]

--- a/applications/tari_mining_node/Cargo.toml
+++ b/applications/tari_mining_node/Cargo.toml
@@ -4,7 +4,7 @@ authors = ["The Tari Development Community"]
 description = "The tari mining node implementation"
 repository = "https://github.com/tari-project/tari"
 license = "BSD-3-Clause"
-version = "0.8.5"
+version = "0.8.6"
 edition = "2018"
 
 [dependencies]

--- a/applications/test_faucet/Cargo.toml
+++ b/applications/test_faucet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "test_faucet"
-version = "0.8.5"
+version = "0.8.6"
 authors = ["The Tari Development Community"]
 edition = "2018"
 

--- a/base_layer/common_types/Cargo.toml
+++ b/base_layer/common_types/Cargo.toml
@@ -3,7 +3,7 @@ name = "tari_common_types"
 authors = ["The Tari Development Community"]
 description = "Tari cryptocurrency common types"
 license = "BSD-3-Clause"
-version = "0.8.5"
+version = "0.8.6"
 edition = "2018"
 
 [dependencies]

--- a/base_layer/core/Cargo.toml
+++ b/base_layer/core/Cargo.toml
@@ -6,7 +6,7 @@ repository = "https://github.com/tari-project/tari"
 homepage = "https://tari.com"
 readme = "README.md"
 license = "BSD-3-Clause"
-version = "0.8.5"
+version = "0.8.6"
 edition = "2018"
 
 [features]

--- a/base_layer/key_manager/Cargo.toml
+++ b/base_layer/key_manager/Cargo.toml
@@ -4,7 +4,7 @@ authors = ["The Tari Development Community"]
 description = "Tari cryptocurrency wallet key management"
 repository = "https://github.com/tari-project/tari"
 license = "BSD-3-Clause"
-version = "0.8.5"
+version = "0.8.6"
 edition = "2018"
 
 [dependencies]

--- a/base_layer/mmr/Cargo.toml
+++ b/base_layer/mmr/Cargo.toml
@@ -4,7 +4,7 @@ authors = ["The Tari Development Community"]
 description = "A Merkle Mountain Range implementation"
 repository = "https://github.com/tari-project/tari"
 license = "BSD-3-Clause"
-version = "0.8.5"
+version = "0.8.6"
 edition = "2018"
 
 [features]

--- a/base_layer/p2p/Cargo.toml
+++ b/base_layer/p2p/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tari_p2p"
-version = "0.8.5"
+version = "0.8.6"
 authors = ["The Tari Development community"]
 description = "Tari base layer-specific peer-to-peer communication features"
 repository = "https://github.com/tari-project/tari"

--- a/base_layer/service_framework/Cargo.toml
+++ b/base_layer/service_framework/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tari_service_framework"
-version = "0.8.5"
+version = "0.8.6"
 authors = ["The Tari Development Community"]
 description = "The Tari communication stack service framework"
 repository = "https://github.com/tari-project/tari"

--- a/base_layer/wallet/Cargo.toml
+++ b/base_layer/wallet/Cargo.toml
@@ -3,7 +3,7 @@ name = "tari_wallet"
 authors = ["The Tari Development Community"]
 description = "Tari cryptocurrency wallet library"
 license = "BSD-3-Clause"
-version = "0.8.5"
+version = "0.8.6"
 edition = "2018"
 
 [dependencies]

--- a/base_layer/wallet_ffi/Cargo.toml
+++ b/base_layer/wallet_ffi/Cargo.toml
@@ -3,7 +3,7 @@ name = "tari_wallet_ffi"
 authors = ["The Tari Development Community"]
 description = "Tari cryptocurrency wallet C FFI bindings"
 license = "BSD-3-Clause"
-version = "0.16.23"
+version = "0.16.24"
 edition = "2018"
 
 [dependencies]

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -6,7 +6,7 @@ repository = "https://github.com/tari-project/tari"
 homepage = "https://tari.com"
 readme = "README.md"
 license = "BSD-3-Clause"
-version = "0.8.5"
+version = "0.8.6"
 edition = "2018"
 
 

--- a/comms/Cargo.toml
+++ b/comms/Cargo.toml
@@ -6,7 +6,7 @@ repository = "https://github.com/tari-project/tari"
 homepage = "https://tari.com"
 readme = "README.md"
 license = "BSD-3-Clause"
-version = "0.8.5"
+version = "0.8.6"
 edition = "2018"
 
 [dependencies]

--- a/comms/dht/Cargo.toml
+++ b/comms/dht/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tari_comms_dht"
-version = "0.8.5"
+version = "0.8.6"
 authors = ["The Tari Development Community"]
 description = "Tari comms DHT module"
 repository = "https://github.com/tari-project/tari"

--- a/comms/rpc_macros/Cargo.toml
+++ b/comms/rpc_macros/Cargo.toml
@@ -6,7 +6,7 @@ repository = "https://github.com/tari-project/tari"
 homepage = "https://tari.com"
 readme = "README.md"
 license = "BSD-3-Clause"
-version = "0.8.5"
+version = "0.8.6"
 edition = "2018"
 
 [lib]

--- a/infrastructure/derive/Cargo.toml
+++ b/infrastructure/derive/Cargo.toml
@@ -6,7 +6,7 @@ repository = "https://github.com/tari-project/tari"
 homepage = "https://tari.com"
 readme = "README.md"
 license = "BSD-3-Clause"
-version = "0.8.5"
+version = "0.8.6"
 edition = "2018"
 
 [lib]

--- a/infrastructure/shutdown/Cargo.toml
+++ b/infrastructure/shutdown/Cargo.toml
@@ -6,7 +6,7 @@ repository = "https://github.com/tari-project/tari"
 homepage = "https://tari.com"
 readme = "README.md"
 license = "BSD-3-Clause"
-version = "0.8.5"
+version = "0.8.6"
 edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/infrastructure/storage/Cargo.toml
+++ b/infrastructure/storage/Cargo.toml
@@ -6,7 +6,7 @@ repository = "https://github.com/tari-project/tari"
 homepage = "https://tari.com"
 readme = "README.md"
 license = "BSD-3-Clause"
-version = "0.8.5"
+version = "0.8.6"
 edition = "2018"
 
 [dependencies]

--- a/infrastructure/test_utils/Cargo.toml
+++ b/infrastructure/test_utils/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tari_test_utils"
 description = "Utility functions used in Tari test functions"
-version = "0.8.5"
+version = "0.8.6"
 authors = ["The Tari Development Community"]
 edition = "2018"
 license = "BSD-3-Clause"


### PR DESCRIPTION
v0.8.6

Changes since v0.8.5:
Base Node
---
- [#2735](https://github.com/tari-project/tari/pull/2735) [base-node] Add messages in last 60s to status
- [#2733](https://github.com/tari-project/tari/pull/2733) [base-node] get-block command accepts height or hash
- [#2736](https://github.com/tari-project/tari/pull/2736) [base-node] Fix state machine never bootstraps with empty network
- [#2677](https://github.com/tari-project/tari/pull/2677) [base-node] Fix UTXO horizon sum calculation
- [#2715](https://github.com/tari-project/tari/pull/2715) [base-node] Remove wallet from base node
- [#2709](https://github.com/tari-project/tari/pull/2709) [base-node] Removed Miner from Base Node
- [#2705](https://github.com/tari-project/tari/pull/2705) [base-node] Create minimal log4rs sample for seed nodes

Wallet
---
- [#2741](https://github.com/tari-project/tari/pull/2741) [wallet] Fix duplicate coinbase key generation, derive from height
- [#2731](https://github.com/tari-project/tari/pull/2731) [wallet] Add list-utxos and count-utxos to command mode
- [#2730](https://github.com/tari-project/tari/pull/2730) [wallet] Fix `make-it-rain` bug
- [#2724](https://github.com/tari-project/tari/pull/2724) [wallet] Add whois command
- [#2722](https://github.com/tari-project/tari/pull/2722) [wallet] Wallet should not broadcast invalid transactions
- [#2708](https://github.com/tari-project/tari/pull/2708) [wallet] Fix base node selection UI not visible
- [#2707](https://github.com/tari-project/tari/pull/2707) [wallet] Allow transactions sent to self
- [#2646](https://github.com/tari-project/tari/pull/2646) [base-node] Add GPRC call to search mempool

Merge Mining
---
- [#2692](https://github.com/tari-project/tari/pull/2692) [merge-mining] Submit_block AUX data includes tari block hash

Other
---
- [#2742](https://github.com/tari-project/tari/pull/2742) [tests] Fix rate_limit test flakiness
- [#2732](https://github.com/tari-project/tari/pull/2732) [common] Expiry of SAF messages
- [#2737](https://github.com/tari-project/tari/pull/2737) [tests] Tweak Cucumber stress tests to make them more stable
- [#2728](https://github.com/tari-project/tari/pull/2728) [docs] Write up of wallet to wallet negotiation with TariScript
- [#2726](https://github.com/tari-project/tari/pull/2726) [tests] Add custom log path for cucumber tests
- [#2727](https://github.com/tari-project/tari/pull/2727) [tests] Update cucumber stress test timeouts
- [#27270](https://github.com/tari-project/tari/pull/27270) [tests] Fix failing cucumber tests
- [#2717](https://github.com/tari-project/tari/pull/2717) [tests] Fixed clippy errors and warnings for `cargo clippy --all-targets`
- [#2719](https://github.com/tari-project/tari/pull/2719) [tests] Update Cucumber stress test to be a Scenario Outline
- [#2723](https://github.com/tari-project/tari/pull/2723) [common] Add explicit rejection reason to RPC handshake
- [#2687](https://github.com/tari-project/tari/pull/2687) [tests] Fix commslayer tests
- [#2703](https://github.com/tari-project/tari/pull/2703) [common] Update README for Tari Mining Node
- [#2690](https://github.com/tari-project/tari/pull/2690) [common] Use rusttls for dnssec for peer seeds