### PR TITLE
Prevent overflow on node_index

### DIFF
--- a/base_layer/mmr/src/common.rs
+++ b/base_layer/mmr/src/common.rs
@@ -30,7 +30,7 @@ const ALL_ONES: usize = std::usize::MAX;
 
 /// Returns the MMR node index derived from the leaf index.
 pub fn node_index(leaf_index: usize) -> usize {
-    if leaf_index == 0 {
+    if leaf_index == 0 || leaf_index > std::usize::MAX / 2 {
         return 0;
     }
     2 * leaf_index - leaf_index.count_ones() as usize


### PR DESCRIPTION
An arithmetic overflow (multiply overflow) issue can occur if leaf_index > MAX/2

