### PR TITLE
Add cucumber test to verify a base node detects miners meddling with MMR sizes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4516,7 +4516,7 @@ dependencies = [
 
 [[package]]
 name = "tari_wallet_ffi"
-version = "0.16.23"
+version = "0.16.24"
 dependencies = [
  "chrono",
  "env_logger 0.7.1",

--- a/base_layer/core/src/chain_storage/lmdb_db/lmdb_db.rs
+++ b/base_layer/core/src/chain_storage/lmdb_db/lmdb_db.rs
@@ -986,8 +986,6 @@ impl BlockchainBackend for LMDBDatabase {
     }
 
     fn fetch(&self, key: &DbKey) -> Result<Option<DbValue>, ChainStorageError> {
-        let mark = Instant::now();
-
         let txn = ReadTransaction::new(&*self.env).map_err(|e| ChainStorageError::AccessError(e.to_string()))?;
         let res = match key {
             DbKey::BlockHeader(k) => {
@@ -1029,7 +1027,6 @@ impl BlockchainBackend for LMDBDatabase {
                 .fetch_orphan(&txn, k)?
                 .map(|val| DbValue::OrphanBlock(Box::new(val))),
         };
-        trace!(target: LOG_TARGET, "Fetched key {} in {:.0?}", key, mark.elapsed());
         Ok(res)
     }
 
@@ -1472,7 +1469,6 @@ impl BlockchainBackend for LMDBDatabase {
     }
 
     fn fetch_mmr_leaf_index(&self, tree: MmrTree, hash: &Hash) -> Result<Option<u32>, ChainStorageError> {
-        trace!(target: LOG_TARGET, "Fetch MMR leaf index");
         let txn = ReadTransaction::new(&*self.env).map_err(|e| ChainStorageError::AccessError(e.to_string()))?;
         self.fetch_mmr_leaf_index(&*txn, tree, hash)
     }

--- a/integration_tests/features/BlockTemplate.feature
+++ b/integration_tests/features/BlockTemplate.feature
@@ -1,0 +1,7 @@
+Feature: BlockTemplate
+
+Scenario: Verify UTXO and kernel MMR size in header
+    Given I have a seed node SEED_A
+    And I have 1 base nodes connected to all seed nodes
+    And I have wallet WALLET_A connected to seed node SEED_A
+    Then meddling with block template data from node SEED_A for wallet WALLET_A is not allowed


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- Added a cucumber test that verifies if a base node detects when the kernel and/or UTXO MMR sizes are meddled with when a miner submits a block back to the base node.
- Removed spam trace logs.
- Fixed one clippy warning.

## Motivation and Context
Meddling with kernel and/or UTXO MMR sizes should not be allowed.

## How Has This Been Tested?
New cucumber test: _"Verify UTXO and kernel MMR size in header"_

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [X] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [X] I'm merging against the `development` branch.
* [X] I ran `cargo-fmt --all` before pushing.
* [ ] I ran `cargo test` successfully before submitting my PR.
* [X] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
