### PR TITLE
[common] Emit rerun-if-changed directives for include protos

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4516,7 +4516,7 @@ dependencies = [
 
 [[package]]
 name = "tari_wallet_ffi"
-version = "0.16.23"
+version = "0.16.24"
 dependencies = [
  "chrono",
  "env_logger 0.7.1",


### PR DESCRIPTION
Adds `cargo:rerun-if-changed` directives for include proto files
(i.e proto files that are not directly generated, but used as modules
for other protos). `build.rs` will be automatically rerun if these
change without the developer having to somehow force a protobuf rebuild.
