### PR TITLE
[base-node] Node bootstraps after initial sync even if all other nodes are h=0

### DIFF
--- a/base_layer/core/src/base_node/state_machine_service/states/block_sync.rs
+++ b/base_layer/core/src/base_node/state_machine_service/states/block_sync.rs
@@ -38,6 +38,7 @@ const LOG_TARGET: &str = "c::bn::block_sync";
 #[derive(Debug, Default)]
 pub struct BlockSync {
     sync_peer: Option<PeerConnection>,
+    is_synced: bool,
 }
 
 impl BlockSync {
@@ -48,6 +49,7 @@ impl BlockSync {
     pub fn with_peer(sync_peer: PeerConnection) -> Self {
         Self {
             sync_peer: Some(sync_peer),
+            is_synced: false,
         }
     }
 
@@ -93,6 +95,7 @@ impl BlockSync {
         match synchronizer.synchronize().await {
             Ok(()) => {
                 info!(target: LOG_TARGET, "Blocks synchronized in {:.0?}", timer.elapsed());
+                self.is_synced = true;
                 StateEvent::BlocksSynchronized
             },
             Err(err) => {
@@ -100,6 +103,10 @@ impl BlockSync {
                 StateEvent::BlockSyncFailed
             },
         }
+    }
+
+    pub fn is_synced(&self) -> bool {
+        self.is_synced
     }
 }
 

--- a/base_layer/core/src/base_node/state_machine_service/states/listening.rs
+++ b/base_layer/core/src/base_node/state_machine_service/states/listening.rs
@@ -236,8 +236,10 @@ impl From<HeaderSync> for Listening {
 }
 
 impl From<BlockSync> for Listening {
-    fn from(_: BlockSync) -> Self {
-        Default::default()
+    fn from(sync: BlockSync) -> Self {
+        Self {
+            is_synced: sync.is_synced(),
+        }
     }
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Fixes an edge case where a node will never bootstrap (and therefore not
accept mined blocks) if header/block sync completes but there are no
blocks (other than genesis) on the network.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Mainly for test cases, however this would prevent blocks from being mined on
any new network. 

The fix was to set is_synced in listening state to true when transitioning from a successful
block sync state.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested on existing base node. Awaiting cucumber CI tests.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [ ] I'm merging against the `development` branch.
* [ ] I ran `cargo-fmt --all` before pushing.
* [ ] I ran `cargo test` successfully before submitting my PR.
* [ ] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
