### PR TITLE
[CircleCI] Add all-targets to clippy

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -74,7 +74,7 @@ commands:
             cargo fmt --all -- --check
       - run:
           name: Run clippy
-          command: cargo clippy -- -D warnings
+          command: cargo clippy --all-targets -- -D warnings
       - save_cache:
           paths:
             - /usr/local/cargo/registry


### PR DESCRIPTION
## Description
Run clippy lints against all targets. Was left out in error in prior PR's dealing with resolving clippy warnings and errors for all targets.

## Motivation and Context
Necessary for the linter to be able to run over all code, including tests.

## How Has This Been Tested?
cargo clippy --all-targets -- -D warnings

## Types of changes
* [ ] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [x] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
* [x] I'm merging against the `development` branch.
* [x] I ran `cargo-fmt --all` before pushing.
* [ ] I ran `cargo test` successfully before submitting my PR.
* [x] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
