### PR TITLE
[wallet] Differentiate "funds pending" case in UTXO selection

### DIFF
--- a/base_layer/wallet/src/output_manager_service/error.rs
+++ b/base_layer/wallet/src/output_manager_service/error.rs
@@ -63,6 +63,8 @@ pub enum OutputManagerError {
     IncompleteTransaction(&'static str),
     #[error("Not enough funds to fulfil transaction")]
     NotEnoughFunds,
+    #[error("Funds are still pending. Unable to fulfil transaction right now.")]
+    FundsPending,
     #[error("Output already exists")]
     DuplicateOutput,
     #[error("Error sending a message to the public API")]

--- a/base_layer/wallet/src/output_manager_service/handle.rs
+++ b/base_layer/wallet/src/output_manager_service/handle.rs
@@ -402,7 +402,7 @@ impl OutputManagerHandle {
     }
 
     /// Create a coin split transaction.
-    /// Returns (tx_id, tx, fee, utxo_total_value).
+    /// Returns (tx_id, tx, fee, utxos_total_value).
     pub async fn create_coin_split(
         &mut self,
         amount_per_split: MicroTari,

--- a/base_layer/wallet/tests/output_manager_service/service.rs
+++ b/base_layer/wallet/tests/output_manager_service/service.rs
@@ -414,7 +414,6 @@ fn test_utxo_selection_with_chain_metadata_memory_db() {
     test_utxo_selection_with_chain_metadata(OutputManagerMemoryDatabase::new());
 }
 
-#[allow(clippy::identity_op)]
 fn test_utxo_selection_no_chain_metadata<T: Clone + OutputManagerBackend + 'static>(backend: T) {
     let factories = CryptoFactories::default();
     let mut runtime = Runtime::new().unwrap();
@@ -460,12 +459,28 @@ fn test_utxo_selection_no_chain_metadata<T: Clone + OutputManagerBackend + 'stat
     let fee = runtime.block_on(oms.fee_estimate(amount, fee_per_gram, 1, 2)).unwrap();
     assert_eq!(fee, MicroTari::from(300));
 
+    // test if a fee estimate would be possible with pending funds included
+    // at this point 52000 uT is still spendable, with pending change incoming of 1690 uT
+    // so instead of returning "not enough funds", return "funds pending"
+    let spendable_amount = (3..=10).sum::<u64>() * amount;
+    let err = runtime
+        .block_on(oms.fee_estimate(spendable_amount, fee_per_gram, 1, 2))
+        .unwrap_err();
+    assert!(matches!(err, OutputManagerError::FundsPending));
+
+    // test not enough funds
+    let broke_amount = spendable_amount + MicroTari::from(2000);
+    let err = runtime
+        .block_on(oms.fee_estimate(broke_amount, fee_per_gram, 1, 2))
+        .unwrap_err();
+    assert!(matches!(err, OutputManagerError::NotEnoughFunds));
+
     // coin split uses the "Largest" selection strategy
-    let (_, _, fee, utxo_total_value) = runtime
+    let (_, _, fee, utxos_total_value) = runtime
         .block_on(oms.create_coin_split(amount, 5, fee_per_gram, None))
         .unwrap();
     assert_eq!(fee, MicroTari::from(820));
-    assert_eq!(utxo_total_value, MicroTari::from(10_000));
+    assert_eq!(utxos_total_value, MicroTari::from(10_000));
 
     // test that largest utxo was encumbered
     let utxos = runtime.block_on(oms.get_unspent_outputs()).unwrap();
@@ -477,7 +492,6 @@ fn test_utxo_selection_no_chain_metadata<T: Clone + OutputManagerBackend + 'stat
     }
 }
 
-#[allow(clippy::identity_op)]
 fn test_utxo_selection_with_chain_metadata<T: Clone + OutputManagerBackend + 'static>(backend: T) {
     let factories = CryptoFactories::default();
     let mut runtime = Runtime::new().unwrap();
@@ -520,10 +534,10 @@ fn test_utxo_selection_with_chain_metadata<T: Clone + OutputManagerBackend + 'st
     assert!(matches!(err, OutputManagerError::NotEnoughFunds));
 
     // test coin split is maturity aware
-    let (_, _, fee, utxo_total_value) = runtime
+    let (_, _, fee, utxos_total_value) = runtime
         .block_on(oms.create_coin_split(amount, 5, fee_per_gram, None))
         .unwrap();
-    assert_eq!(utxo_total_value, MicroTari::from(6_000));
+    assert_eq!(utxos_total_value, MicroTari::from(6_000));
     assert_eq!(fee, MicroTari::from(820));
 
     // test that largest spendable utxo was encumbered
@@ -543,7 +557,7 @@ fn test_utxo_selection_with_chain_metadata<T: Clone + OutputManagerBackend + 'st
     assert_eq!(utxos.len(), 7);
     for utxo in utxos.iter() {
         assert_ne!(utxo.features.maturity, 1);
-        assert_ne!(utxo.value, 1 * amount);
+        assert_ne!(utxo.value, amount);
         assert_ne!(utxo.features.maturity, 2);
         assert_ne!(utxo.value, 2 * amount);
     }

--- a/base_layer/wallet_ffi/src/error.rs
+++ b/base_layer/wallet_ffi/src/error.rs
@@ -106,6 +106,10 @@ impl From<WalletError> for LibWalletError {
                 code: 101,
                 message: format!("{:?}", w),
             },
+            WalletError::OutputManagerError(OutputManagerError::FundsPending) => Self {
+                code: 115,
+                message: format!("{:?}", w),
+            },
             WalletError::OutputManagerError(OutputManagerError::IncompleteTransaction(_)) => Self {
                 code: 102,
                 message: format!("{:?}", w),

--- a/base_layer/wallet_ffi/src/lib.rs
+++ b/base_layer/wallet_ffi/src/lib.rs
@@ -6437,6 +6437,11 @@ mod test {
                 .block_on((*alice_wallet).wallet.output_manager_service.get_balance())
                 .unwrap();
 
+            // test "funds pending" when pending incoming would cover
+            let fee = wallet_get_fee_estimate(alice_wallet, pre_balance.available_balance.into(), 25, 1, 2, error_ptr);
+            assert_eq!(fee, 0);
+            assert_eq!(error, 115);
+
             let secret_key_base_node = private_key_generate();
             let public_key_base_node = public_key_from_private_key(secret_key_base_node, error_ptr);
             let utxo_message_str = CString::new("UTXO Import").unwrap();


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Adds a new error case to the output manager service. When selecting UTXOs and not enough spendable funds are available, check if the pending incoming balance would cover the shortfall. If so, return the new `FundsPending` error instead of `NotEnoughFunds`. This way, the caller can differentiate between the two cases.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Currently when selecting UTXOs for a fee estimate, "not enough funds" is returned even when the pending incoming balance makes it appear that the funds are available.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
New assertions added in UTXO selection tests. Existing tests pass. 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [x] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [x] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch.
* [x] I ran `cargo-fmt --all` before pushing.
* [x] I ran `cargo test` successfully before submitting my PR.
* [x] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
