### PR TITLE
[Wallet] Implement wallet recovery process in LibWallet FFI

### DIFF
--- a/applications/tari_console_wallet/src/main.rs
+++ b/applications/tari_console_wallet/src/main.rs
@@ -65,8 +65,8 @@ fn main_inner() -> Result<(), ExitCodes> {
         tari_splash_screen("Console Wallet");
     }
 
-    // check for recovery
-    let boot_mode = boot(&bootstrap, &config)?;
+    // check for recovery based on existence of wallet file
+    let mut boot_mode = boot(&bootstrap, &config)?;
 
     let master_key = if matches!(boot_mode, WalletBoot::Recovery) {
         let private_key = prompt_private_key_from_seed_words()?;
@@ -92,6 +92,12 @@ fn main_inner() -> Result<(), ExitCodes> {
 
     // initialize wallet
     let mut wallet = runtime.block_on(init_wallet(&config, arg_password, master_key, shutdown_signal))?;
+
+    // Check if there is an in progress recovery in the wallet's database
+    if runtime.block_on(wallet.is_recovery_in_progress())? {
+        println!("A Wallet Recovery was found to be in progress, continuing.");
+        boot_mode = WalletBoot::Recovery;
+    }
 
     // get base node/s
     let base_node_config = runtime.block_on(get_base_node_peer_config(&config, &mut wallet))?;

--- a/applications/tari_console_wallet/src/wallet_modes.rs
+++ b/applications/tari_console_wallet/src/wallet_modes.rs
@@ -29,7 +29,7 @@ use crate::{
 
 use log::*;
 use rand::{rngs::OsRng, seq::SliceRandom};
-use std::{fs, fs::remove_file, io::Stdout, net::SocketAddr, path::PathBuf};
+use std::{fs, io::Stdout, net::SocketAddr, path::PathBuf};
 use tari_app_utilities::utilities::ExitCodes;
 use tari_common::GlobalConfig;
 use tari_comms::peer_manager::Peer;
@@ -186,9 +186,10 @@ pub fn recovery_mode(
         Ok(_) => println!("Wallet recovered!"),
         Err(e) => {
             error!(target: LOG_TARGET, "Recovery failed: {}", e);
-            println!("Recovery failed.");
-            // remove the wallet file
-            remove_file(config.console_wallet_db_file).map_err(|e| ExitCodes::IOError(e.to_string()))?;
+            println!(
+                "Recovery failed. Restarting the console wallet will restart the recovery process from where you left \
+                 off. If you want to start with a fresh wallet then delete the wallet data file"
+            );
 
             return Err(e);
         },

--- a/base_layer/core/src/base_node/mod.rs
+++ b/base_layer/core/src/base_node/mod.rs
@@ -48,8 +48,9 @@ pub mod state_machine_service;
 #[cfg(feature = "base_node")]
 pub use state_machine_service::{BaseNodeStateMachine, BaseNodeStateMachineConfig, StateMachineHandle};
 
-#[cfg(feature = "base_node")]
+#[cfg(any(feature = "base_node", feature = "base_node_proto"))]
 pub mod sync;
+
 #[cfg(feature = "base_node")]
 pub use sync::{
     rpc::{create_base_node_sync_rpc_service, BaseNodeSyncService},

--- a/base_layer/core/src/base_node/sync/mod.rs
+++ b/base_layer/core/src/base_node/sync/mod.rs
@@ -20,21 +20,33 @@
 //  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 //  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+#[cfg(feature = "base_node")]
 mod config;
+#[cfg(feature = "base_node")]
 pub use self::config::BlockSyncConfig;
 
+#[cfg(feature = "base_node")]
 mod block_sync;
+#[cfg(feature = "base_node")]
 pub use block_sync::{BlockSyncError, BlockSynchronizer};
 
+#[cfg(feature = "base_node")]
 mod header_sync;
+#[cfg(feature = "base_node")]
 pub use header_sync::{BlockHeaderSyncError, HeaderSynchronizer};
 
+#[cfg(feature = "base_node")]
 mod hooks;
 
+#[cfg(any(feature = "base_node", feature = "base_node_proto"))]
 pub mod rpc;
 
+#[cfg(feature = "base_node")]
 mod sync_peers;
+#[cfg(feature = "base_node")]
 pub use sync_peers::{SyncPeer, SyncPeers};
 
+#[cfg(feature = "base_node")]
 mod validators;
+#[cfg(feature = "base_node")]
 pub use validators::SyncValidators;

--- a/base_layer/core/src/base_node/sync/rpc/mod.rs
+++ b/base_layer/core/src/base_node/sync/rpc/mod.rs
@@ -20,15 +20,19 @@
 //  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 //  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+#[cfg(feature = "base_node")]
 mod service;
+#[cfg(feature = "base_node")]
 pub use service::BaseNodeSyncRpcService;
 
 // TODO: Tests need to be rewritten
 // #[cfg(test)]
 // mod tests;
 
+#[cfg(feature = "base_node")]
+use crate::chain_storage::{async_db::AsyncBlockchainDb, BlockchainBackend};
+
 use crate::{
-    chain_storage::{async_db::AsyncBlockchainDb, BlockchainBackend},
     proto,
     proto::base_node::{
         FindChainSplitRequest,
@@ -85,6 +89,7 @@ pub trait BaseNodeSyncService: Send + Sync + 'static {
     async fn sync_utxos(&self, request: Request<SyncUtxosRequest>) -> Result<Streaming<SyncUtxosResponse>, RpcStatus>;
 }
 
+#[cfg(feature = "base_node")]
 pub fn create_base_node_sync_rpc_service<B: BlockchainBackend + 'static>(
     db: AsyncBlockchainDb<B>,
 ) -> BaseNodeSyncRpcServer<BaseNodeSyncRpcService<B>> {

--- a/base_layer/core/src/blocks/block.rs
+++ b/base_layer/core/src/blocks/block.rs
@@ -22,6 +22,7 @@
 //
 // Portions of this file were originally copyrighted (c) 2018 The Grin Developers, issued under the Apache License,
 // Version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0.
+
 use crate::{
     blocks::BlockHeader,
     chain_storage::MmrTree,

--- a/base_layer/core/src/blocks/block_header.rs
+++ b/base_layer/core/src/blocks/block_header.rs
@@ -37,8 +37,10 @@
 //! state = Hash(Hash(mmr_root)|| Hash(roaring_bitmap))
 //! This hash is called the UTXO merkle root, and is used as the output_mr
 
+#[cfg(feature = "base_node")]
+use crate::blocks::{BlockBuilder, NewBlockHeaderTemplate};
+
 use crate::{
-    blocks::{BlockBuilder, NewBlockHeaderTemplate},
     proof_of_work::{PowAlgorithm, PowError, ProofOfWork},
     transactions::types::{BlindingFactor, HashDigest},
 };
@@ -153,6 +155,7 @@ impl BlockHeader {
         })
     }
 
+    #[cfg(feature = "base_node")]
     pub fn into_builder(self) -> BlockBuilder {
         BlockBuilder::new(self.version).with_header(self)
     }
@@ -215,6 +218,7 @@ impl BlockHeader {
     }
 }
 
+#[cfg(feature = "base_node")]
 impl From<NewBlockHeaderTemplate> for BlockHeader {
     fn from(header_template: NewBlockHeaderTemplate) -> Self {
         Self {

--- a/base_layer/core/src/blocks/mod.rs
+++ b/base_layer/core/src/blocks/mod.rs
@@ -20,14 +20,22 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+#[cfg(feature = "base_node")]
 mod block;
-pub(crate) mod block_header;
-mod new_block_template;
-mod new_blockheader_template;
+#[cfg(any(feature = "base_node", feature = "base_node_proto"))]
+pub mod block_header;
 
+#[cfg(feature = "base_node")]
 pub mod genesis_block;
-
+#[cfg(feature = "base_node")]
+mod new_block_template;
+#[cfg(feature = "base_node")]
+mod new_blockheader_template;
+#[cfg(feature = "base_node")]
 pub use block::{Block, BlockBuilder, BlockValidationError, NewBlock};
+#[cfg(any(feature = "base_node", feature = "base_node_proto"))]
 pub use block_header::{BlockHeader, BlockHeaderValidationError};
+#[cfg(feature = "base_node")]
 pub use new_block_template::NewBlockTemplate;
+#[cfg(feature = "base_node")]
 pub use new_blockheader_template::NewBlockHeaderTemplate;

--- a/base_layer/core/src/lib.rs
+++ b/base_layer/core/src/lib.rs
@@ -37,7 +37,7 @@
 #[macro_use]
 extern crate bitflags;
 
-#[cfg(feature = "base_node")]
+#[cfg(any(feature = "base_node", feature = "base_node_proto"))]
 pub mod blocks;
 #[cfg(feature = "base_node")]
 pub mod chain_storage;

--- a/base_layer/core/src/proof_of_work/mod.rs
+++ b/base_layer/core/src/proof_of_work/mod.rs
@@ -35,10 +35,10 @@ pub mod monero_rx;
 #[cfg(feature = "base_node")]
 pub use monero_rx::monero_difficulty;
 
-#[cfg(feature = "base_node")]
+#[cfg(any(feature = "base_node", feature = "transactions"))]
 #[allow(clippy::module_inception)]
 mod proof_of_work;
-#[cfg(feature = "base_node")]
+#[cfg(any(feature = "base_node", feature = "transactions"))]
 pub use proof_of_work::ProofOfWork;
 
 #[cfg(any(feature = "base_node", feature = "transactions"))]

--- a/base_layer/core/src/proof_of_work/proof_of_work.rs
+++ b/base_layer/core/src/proof_of_work/proof_of_work.rs
@@ -19,7 +19,8 @@
 // SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-use crate::proof_of_work::{monero_rx::MoneroData, PowAlgorithm};
+
+use crate::proof_of_work::PowAlgorithm;
 use bytes::BufMut;
 use serde::{Deserialize, Serialize};
 use std::fmt::{Display, Error, Formatter};
@@ -82,14 +83,8 @@ impl Display for PowAlgorithm {
 impl Display for ProofOfWork {
     fn fmt(&self, fmt: &mut Formatter<'_>) -> Result<(), Error> {
         writeln!(fmt, "Mining algorithm: {}", self.pow_algo)?;
-
-        match self.pow_algo {
-            PowAlgorithm::Monero => match MoneroData::from_pow_data(&self.pow_data) {
-                Ok(v) => writeln!(fmt, "Pow data: {}", v),
-                Err(_) => writeln!(fmt, "Pow data: MALFORMED DATA"),
-            },
-            _ => writeln!(fmt, "Pow data: {}", self.pow_data.to_hex()),
-        }
+        writeln!(fmt, "Pow data: {}", self.pow_data.to_hex())?;
+        Ok(())
     }
 }
 

--- a/base_layer/core/src/proto/block_header.rs
+++ b/base_layer/core/src/proto/block_header.rs
@@ -1,0 +1,107 @@
+// Copyright 2021. The Tari Project
+//
+// Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+// following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+// disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+// following disclaimer in the documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+// products derived from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+// INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+// WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+// USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+use super::core as proto;
+use crate::{
+    blocks::BlockHeader,
+    proof_of_work::{PowAlgorithm, ProofOfWork},
+    proto::utils::{datetime_to_timestamp, timestamp_to_datetime},
+    transactions::types::BlindingFactor,
+};
+use std::convert::TryFrom;
+use tari_crypto::tari_utilities::ByteArray;
+
+//---------------------------------- BlockHeader --------------------------------------------//
+impl TryFrom<proto::BlockHeader> for BlockHeader {
+    type Error = String;
+
+    fn try_from(header: proto::BlockHeader) -> Result<Self, Self::Error> {
+        let total_kernel_offset =
+            BlindingFactor::from_bytes(&header.total_kernel_offset).map_err(|err| err.to_string())?;
+
+        let timestamp = header
+            .timestamp
+            .map(timestamp_to_datetime)
+            .ok_or_else(|| "timestamp not provided".to_string())?;
+
+        let pow = match header.pow {
+            Some(p) => ProofOfWork::try_from(p)?,
+            None => return Err("No proof of work provided".into()),
+        };
+        Ok(Self {
+            version: header.version as u16,
+            height: header.height,
+            prev_hash: header.prev_hash,
+            timestamp,
+            output_mr: header.output_mr,
+            range_proof_mr: header.range_proof_mr,
+            output_mmr_size: header.output_mmr_size,
+            kernel_mr: header.kernel_mr,
+            kernel_mmr_size: header.kernel_mmr_size,
+            total_kernel_offset,
+            nonce: header.nonce,
+            pow,
+        })
+    }
+}
+
+impl From<BlockHeader> for proto::BlockHeader {
+    fn from(header: BlockHeader) -> Self {
+        Self {
+            version: header.version as u32,
+            height: header.height,
+            prev_hash: header.prev_hash,
+            timestamp: Some(datetime_to_timestamp(header.timestamp)),
+            output_mr: header.output_mr,
+            range_proof_mr: header.range_proof_mr,
+            kernel_mr: header.kernel_mr,
+            total_kernel_offset: header.total_kernel_offset.to_vec(),
+            nonce: header.nonce,
+            pow: Some(proto::ProofOfWork::from(header.pow)),
+            kernel_mmr_size: header.kernel_mmr_size,
+            output_mmr_size: header.output_mmr_size,
+        }
+    }
+}
+
+//---------------------------------- ProofOfWork --------------------------------------------//
+#[allow(deprecated)]
+impl TryFrom<proto::ProofOfWork> for ProofOfWork {
+    type Error = String;
+
+    fn try_from(pow: proto::ProofOfWork) -> Result<Self, Self::Error> {
+        Ok(Self {
+            pow_algo: PowAlgorithm::try_from(pow.pow_algo)?,
+            pow_data: pow.pow_data,
+        })
+    }
+}
+
+#[allow(deprecated)]
+impl From<ProofOfWork> for proto::ProofOfWork {
+    fn from(pow: ProofOfWork) -> Self {
+        Self {
+            pow_algo: pow.pow_algo as u64,
+            pow_data: pow.pow_data,
+        }
+    }
+}

--- a/base_layer/core/src/proto/mod.rs
+++ b/base_layer/core/src/proto/mod.rs
@@ -47,5 +47,7 @@ pub mod types {
 
 #[cfg(feature = "base_node")]
 mod block;
-#[cfg(feature = "base_node")]
+#[cfg(any(feature = "base_node", feature = "base_node_proto"))]
+mod block_header;
+#[cfg(any(feature = "base_node", feature = "base_node_proto"))]
 pub mod utils;

--- a/base_layer/wallet/Cargo.toml
+++ b/base_layer/wallet/Cargo.toml
@@ -45,7 +45,7 @@ bincode = "1.3.1"
 path = "../../base_layer/core"
 version = "^0.8"
 default-features = false
-features = ["transactions", "mempool_proto", "base_node_proto"]
+features = ["transactions", "mempool_proto", "base_node_proto",]
 
 [dev-dependencies]
 tari_p2p = { version = "^0.8", path = "../p2p", features=["test-mocks"]}

--- a/base_layer/wallet/src/error.rs
+++ b/base_layer/wallet/src/error.rs
@@ -65,6 +65,8 @@ pub enum WalletError {
     ServiceInitializationError(#[from] ServiceInitializationError),
     #[error("Base Node Service error: {0}")]
     BaseNodeServiceError(#[from] BaseNodeServiceError),
+    #[error("Error performing wallet recovery: '{0}'")]
+    WalletRecoveryError(String),
 }
 
 #[derive(Debug, Error)]

--- a/base_layer/wallet/src/lib.rs
+++ b/base_layer/wallet/src/lib.rs
@@ -33,6 +33,7 @@ extern crate diesel_migrations;
 extern crate lazy_static;
 
 pub mod schema;
+pub mod tasks;
 
 pub use wallet::Wallet;
 

--- a/base_layer/wallet/src/output_manager_service/storage/database.rs
+++ b/base_layer/wallet/src/output_manager_service/storage/database.rs
@@ -144,8 +144,8 @@ pub enum DbValue {
 }
 
 pub enum DbKeyValuePair {
-    SpentOutput(BlindingFactor, Box<DbUnblindedOutput>),
-    UnspentOutput(BlindingFactor, Box<DbUnblindedOutput>),
+    SpentOutput(Commitment, Box<DbUnblindedOutput>),
+    UnspentOutput(Commitment, Box<DbUnblindedOutput>),
     PendingTransactionOutputs(TxId, Box<PendingTransactionOutputs>),
     KeyManagerState(KeyManagerState),
 }
@@ -220,7 +220,7 @@ where T: OutputManagerBackend + 'static
         let db_clone = self.db.clone();
         tokio::task::spawn_blocking(move || {
             db_clone.write(WriteOperation::Insert(DbKeyValuePair::UnspentOutput(
-                output.unblinded_output.spending_key.clone(),
+                output.commitment.clone(),
                 Box::new(output),
             )))
         })

--- a/base_layer/wallet/src/output_manager_service/storage/memory_db.rs
+++ b/base_layer/wallet/src/output_manager_service/storage/memory_db.rs
@@ -155,26 +155,16 @@ impl OutputManagerBackend for OutputManagerMemoryDatabase {
         match op {
             WriteOperation::Insert(kvp) => match kvp {
                 DbKeyValuePair::SpentOutput(k, o) => {
-                    if db
-                        .spent_outputs
-                        .iter()
-                        .any(|v| v.output.unblinded_output.spending_key == k) ||
-                        db.unspent_outputs
-                            .iter()
-                            .any(|v| v.output.unblinded_output.spending_key == k)
+                    if db.spent_outputs.iter().any(|v| v.output.commitment == k) ||
+                        db.unspent_outputs.iter().any(|v| v.output.commitment == k)
                     {
                         return Err(OutputManagerStorageError::DuplicateOutput);
                     }
                     db.spent_outputs.push(DbOutput::from(*o));
                 },
                 DbKeyValuePair::UnspentOutput(k, o) => {
-                    if db
-                        .unspent_outputs
-                        .iter()
-                        .any(|v| v.output.unblinded_output.spending_key == k) ||
-                        db.spent_outputs
-                            .iter()
-                            .any(|v| v.output.unblinded_output.spending_key == k)
+                    if db.unspent_outputs.iter().any(|v| v.output.commitment == k) ||
+                        db.spent_outputs.iter().any(|v| v.output.commitment == k)
                     {
                         return Err(OutputManagerStorageError::DuplicateOutput);
                     }

--- a/base_layer/wallet/src/output_manager_service/storage/sqlite_db.rs
+++ b/base_layer/wallet/src/output_manager_service/storage/sqlite_db.rs
@@ -249,8 +249,8 @@ impl OutputManagerBackend for OutputManagerSqliteDatabase {
 
         match op {
             WriteOperation::Insert(kvp) => match kvp {
-                DbKeyValuePair::SpentOutput(k, o) => {
-                    if OutputSql::find(&k.to_vec(), &(*conn)).is_ok() {
+                DbKeyValuePair::SpentOutput(c, o) => {
+                    if OutputSql::find_by_commitment(&c.to_vec(), &(*conn)).is_ok() {
                         return Err(OutputManagerStorageError::DuplicateOutput);
                     }
                     let mut new_output = NewOutputSql::new(*o, OutputStatus::Spent, None);
@@ -259,8 +259,8 @@ impl OutputManagerBackend for OutputManagerSqliteDatabase {
 
                     new_output.commit(&(*conn))?
                 },
-                DbKeyValuePair::UnspentOutput(k, o) => {
-                    if OutputSql::find(&k.to_vec(), &(*conn)).is_ok() {
+                DbKeyValuePair::UnspentOutput(c, o) => {
+                    if OutputSql::find_by_commitment(&c.to_vec(), &(*conn)).is_ok() {
                         return Err(OutputManagerStorageError::DuplicateOutput);
                     }
                     let mut new_output = NewOutputSql::new(*o, OutputStatus::Unspent, None);

--- a/base_layer/wallet/src/tasks/mod.rs
+++ b/base_layer/wallet/src/tasks/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2019, The Tari Project
+// Copyright 2021. The Tari Project
 //
 // Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
 // following conditions are met:
@@ -20,33 +20,4 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use prost_types::Timestamp;
-use std::convert::TryInto;
-use tari_crypto::tari_utilities::epoch_time::EpochTime;
-
-/// Tries to convert a series of `T`s to `U`s, returning an error at the first failure
-pub fn try_convert_all<T, U, I>(into_iter: I) -> Result<Vec<U>, T::Error>
-where
-    I: IntoIterator<Item = T>,
-    T: TryInto<U>,
-{
-    let iter = into_iter.into_iter();
-    let mut result = Vec::with_capacity(iter.size_hint().0);
-    for item in iter {
-        result.push(item.try_into()?);
-    }
-    Ok(result)
-}
-
-/// Utility function that converts a `prost::Timestamp` to a `chrono::DateTime`
-pub(crate) fn timestamp_to_datetime(timestamp: Timestamp) -> EpochTime {
-    (timestamp.seconds as u64).into()
-}
-
-/// Utility function that converts a `chrono::DateTime` to a `prost::Timestamp`
-pub(crate) fn datetime_to_timestamp(datetime: EpochTime) -> Timestamp {
-    Timestamp {
-        seconds: datetime.as_u64() as i64,
-        nanos: 0,
-    }
-}
+pub mod wallet_recovery;

--- a/base_layer/wallet/src/tasks/wallet_recovery.rs
+++ b/base_layer/wallet/src/tasks/wallet_recovery.rs
@@ -1,0 +1,320 @@
+// Copyright 2021. The Tari Project
+//
+// Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+// following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+// disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+// following disclaimer in the documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+// products derived from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+// INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+// WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+// USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+use crate::{
+    error::WalletError,
+    output_manager_service::error::{OutputManagerError, OutputManagerStorageError},
+    WalletSqlite,
+};
+use chrono::Utc;
+use futures::{channel::mpsc, SinkExt, StreamExt};
+use log::*;
+use std::{cmp, convert::TryFrom};
+use tari_comms::{peer_manager::NodeId, types::CommsPublicKey};
+use tari_core::{
+    base_node::sync::rpc::BaseNodeSyncRpcClient,
+    blocks::BlockHeader,
+    proto::base_node::{SyncUtxosRequest, SyncUtxosResponse},
+    tari_utilities::Hashable,
+    transactions::{tari_amount::MicroTari, transaction::TransactionOutput},
+};
+
+pub const LOG_TARGET: &str = "wallet::recovery";
+
+pub const RECOVERY_HEIGHT_KEY: &str = "recovery_height_progress";
+const RECOVERY_NUM_UTXOS_KEY: &str = "recovery_num_utxos";
+const RECOVERY_TOTAL_AMOUNT_KEY: &str = "recovery_total_amount";
+const RECOVERY_BATCH_SIZE: u64 = 10;
+
+pub struct WalletRecoveryTask {
+    wallet: WalletSqlite,
+    base_node_public_key: CommsPublicKey,
+    event_sender: Option<mpsc::Sender<WalletRecoveryEvent>>,
+    event_receiver: Option<mpsc::Receiver<WalletRecoveryEvent>>,
+}
+
+impl WalletRecoveryTask {
+    pub fn new(wallet: WalletSqlite, base_node_public_key: CommsPublicKey) -> Self {
+        let (event_sender, event_receiver) = mpsc::channel(1000);
+        Self {
+            wallet,
+            base_node_public_key,
+            event_sender: Some(event_sender),
+            event_receiver: Some(event_receiver),
+        }
+    }
+
+    pub fn get_event_receiver(&mut self) -> Option<mpsc::Receiver<WalletRecoveryEvent>> {
+        self.event_receiver.take()
+    }
+
+    pub async fn run(mut self) -> Result<(), WalletError> {
+        let mut event_sender = match self.event_sender {
+            Some(sender) => sender,
+            None => {
+                return Err(WalletError::WalletRecoveryError(
+                    "No event channel provided".to_string(),
+                ))
+            },
+        };
+
+        let public_key = self.wallet.comms.node_identity().public_key().clone();
+
+        let base_node_node_id = NodeId::from_public_key(&self.base_node_public_key);
+
+        let mut conn = self.wallet.comms.connectivity().dial_peer(base_node_node_id).await?;
+        let mut client = conn
+            .connect_rpc::<BaseNodeSyncRpcClient>()
+            .await
+            .map_err(|e| WalletError::WalletRecoveryError(e.to_string()))?;
+
+        event_sender
+            .send(WalletRecoveryEvent::ConnectedToBaseNode(
+                self.base_node_public_key.clone(),
+            ))
+            .await
+            .map_err(|e| WalletError::WalletRecoveryError(e.to_string()))?;
+
+        loop {
+            let chain_metadata = client
+                .get_chain_metadata()
+                .await
+                .map_err(|e| WalletError::WalletRecoveryError(e.to_string()))?;
+            let chain_height = chain_metadata.height_of_longest_chain();
+
+            let start_height = match self
+                .wallet
+                .db
+                .get_client_key_value(RECOVERY_HEIGHT_KEY.to_string())
+                .await?
+            {
+                None => {
+                    // Set a value in here so that if the recovery fails on the genesis block the client will know a
+                    // recover was started. Important on Console wallet that otherwise makes this decision based on the
+                    // presence of the data file
+                    self.wallet
+                        .db
+                        .set_client_key_value(RECOVERY_HEIGHT_KEY.to_string(), "0".to_string())
+                        .await?;
+                    0
+                },
+                Some(current_height) => match current_height.parse::<u64>() {
+                    Ok(h) => h,
+                    Err(_) => 0,
+                },
+            };
+
+            let next_height = cmp::min(start_height + RECOVERY_BATCH_SIZE, chain_height);
+
+            info!(
+                target: LOG_TARGET,
+                "Wallet recovery attempting to recover from Block {} to Block {} with current chain tip at {}",
+                start_height,
+                next_height,
+                chain_height
+            );
+            debug!(
+                target: LOG_TARGET,
+                "Percentage complete: {}%",
+                ((start_height as f32) * 100f32 / (chain_height as f32)).round() as u32
+            );
+
+            let start_header = client
+                .get_header_by_height(start_height)
+                .await
+                .map_err(|e| WalletError::WalletRecoveryError(e.to_string()))?;
+            let start_header = BlockHeader::try_from(start_header).map_err(WalletError::WalletRecoveryError)?;
+            let start_mmr_leaf_index = if start_height == 0 {
+                0
+            } else {
+                start_header.output_mmr_size
+            };
+
+            let end_header = client
+                .get_header_by_height(next_height)
+                .await
+                .map_err(|e| WalletError::WalletRecoveryError(e.to_string()))?;
+            let end_header = BlockHeader::try_from(end_header).map_err(WalletError::WalletRecoveryError)?;
+
+            let end_header_hash = end_header.hash();
+            let request = SyncUtxosRequest {
+                start: start_mmr_leaf_index,
+                end_header_hash,
+            };
+            let mut output_stream = client
+                .sync_utxos(request)
+                .await
+                .map_err(|e| WalletError::WalletRecoveryError(e.to_string()))?;
+
+            let mut num_utxos = 0;
+            let mut total_amount = MicroTari::from(0);
+
+            while let Some(response) = output_stream.next().await {
+                let response: SyncUtxosResponse =
+                    response.map_err(|e| WalletError::WalletRecoveryError(e.to_string()))?;
+
+                let outputs: Vec<TransactionOutput> = response
+                    .utxos
+                    .into_iter()
+                    .filter_map(|utxo| {
+                        if let Some(output) = utxo.output {
+                            TransactionOutput::try_from(output).ok()
+                        } else {
+                            None
+                        }
+                    })
+                    .collect();
+
+                let unblinded_outputs = self.wallet.output_manager_service.rewind_outputs(outputs).await?;
+
+                if !unblinded_outputs.is_empty() {
+                    for uo in unblinded_outputs {
+                        match self
+                            .wallet
+                            .import_utxo(
+                                uo.value,
+                                &uo.spending_key,
+                                &public_key,
+                                format!("Recovered on {}.", Utc::now().naive_utc()),
+                            )
+                            .await
+                        {
+                            Ok(_) => {
+                                num_utxos += 1;
+                                total_amount += uo.value;
+                            },
+                            Err(WalletError::OutputManagerError(OutputManagerError::OutputManagerStorageError(
+                                OutputManagerStorageError::DuplicateOutput,
+                            ))) => debug!(target: LOG_TARGET, "Recovered output already in database"),
+                            Err(e) => return Err(e),
+                        }
+                    }
+                }
+            }
+
+            let current_num_utxos = match self
+                .wallet
+                .db
+                .get_client_key_value(RECOVERY_NUM_UTXOS_KEY.to_string())
+                .await?
+            {
+                None => 0,
+                Some(n_str) => match n_str.parse::<u64>() {
+                    Ok(n) => n,
+                    Err(_) => 0,
+                },
+            };
+
+            let current_total_amount = match self
+                .wallet
+                .db
+                .get_client_key_value(RECOVERY_TOTAL_AMOUNT_KEY.to_string())
+                .await?
+            {
+                None => MicroTari::from(0),
+                Some(a_str) => match a_str.parse::<u64>() {
+                    Ok(a) => MicroTari::from(a),
+                    Err(_) => MicroTari::from(0),
+                },
+            };
+
+            if next_height == chain_height {
+                let _ = self
+                    .wallet
+                    .db
+                    .clear_client_value(RECOVERY_HEIGHT_KEY.to_string())
+                    .await?;
+                let _ = self
+                    .wallet
+                    .db
+                    .clear_client_value(RECOVERY_NUM_UTXOS_KEY.to_string())
+                    .await?;
+                let _ = self
+                    .wallet
+                    .db
+                    .clear_client_value(RECOVERY_TOTAL_AMOUNT_KEY.to_string())
+                    .await?;
+                info!(
+                    target: LOG_TARGET,
+                    "Wallet recovery complete. Imported {} outputs, with a total value of {} ",
+                    current_num_utxos + num_utxos,
+                    current_total_amount + total_amount
+                );
+                event_sender
+                    .send(WalletRecoveryEvent::Progress(chain_height, chain_height))
+                    .await
+                    .map_err(|e| WalletError::WalletRecoveryError(e.to_string()))?;
+                event_sender
+                    .send(WalletRecoveryEvent::Completed(
+                        current_num_utxos + num_utxos,
+                        current_total_amount + total_amount,
+                    ))
+                    .await
+                    .map_err(|e| WalletError::WalletRecoveryError(e.to_string()))?;
+
+                break;
+            } else {
+                self.wallet
+                    .db
+                    .set_client_key_value(RECOVERY_HEIGHT_KEY.to_string(), next_height.to_string())
+                    .await?;
+                self.wallet
+                    .db
+                    .set_client_key_value(
+                        RECOVERY_NUM_UTXOS_KEY.to_string(),
+                        (current_num_utxos + num_utxos).to_string(),
+                    )
+                    .await?;
+                self.wallet
+                    .db
+                    .set_client_key_value(
+                        RECOVERY_TOTAL_AMOUNT_KEY.to_string(),
+                        (current_total_amount.0 + total_amount.0).to_string(),
+                    )
+                    .await?;
+
+                if num_utxos > 0 {
+                    debug!(
+                        target: LOG_TARGET,
+                        "Recovered {} outputs with a value of {} in this batch", num_utxos, total_amount
+                    );
+                }
+
+                event_sender
+                    .send(WalletRecoveryEvent::Progress(next_height, chain_height))
+                    .await
+                    .map_err(|e| WalletError::WalletRecoveryError(e.to_string()))?;
+            }
+        }
+
+        Ok(())
+    }
+}
+
+#[derive(Debug)]
+pub enum WalletRecoveryEvent {
+    ConnectedToBaseNode(CommsPublicKey),
+    /// Progress of the recovery process (current_block, current_chain_height)
+    Progress(u64, u64),
+    /// Completed Recovery (Num of Recovered outputs, Value of recovered outputs)
+    Completed(u64, MicroTari),
+}

--- a/base_layer/wallet/src/wallet.rs
+++ b/base_layer/wallet/src/wallet.rs
@@ -405,4 +405,15 @@ where
         self.transaction_service.remove_encryption().await?;
         Ok(())
     }
+
+    /// Utility function to find out if there is data in the database indicating that there is an incomplete recovery
+    /// process in progress
+    pub async fn is_recovery_in_progress(&self) -> Result<bool, WalletError> {
+        use crate::tasks::wallet_recovery::RECOVERY_HEIGHT_KEY;
+        Ok(self
+            .db
+            .get_client_key_value(RECOVERY_HEIGHT_KEY.to_string())
+            .await?
+            .is_some())
+    }
 }

--- a/base_layer/wallet/tests/output_manager_service/service.rs
+++ b/base_layer/wallet/tests/output_manager_service/service.rs
@@ -1294,10 +1294,11 @@ fn test_utxo_stxo_invalid_txo_validation() {
     let invalid_output = UnblindedOutput::new(MicroTari::from(invalid_value), invalid_key, None);
     let invalid_tx_output = invalid_output.as_transaction_output(&factories).unwrap();
 
+    let invalid_db_output = DbUnblindedOutput::from_unblinded_output(invalid_output.clone(), &factories).unwrap();
     backend
         .write(WriteOperation::Insert(DbKeyValuePair::UnspentOutput(
-            invalid_output.spending_key.clone(),
-            Box::new(DbUnblindedOutput::from_unblinded_output(invalid_output.clone(), &factories).unwrap()),
+            invalid_db_output.commitment.clone(),
+            Box::new(invalid_db_output),
         )))
         .unwrap();
     backend
@@ -1310,22 +1311,23 @@ fn test_utxo_stxo_invalid_txo_validation() {
     let spent_value1 = 500;
     let spent_output1 = UnblindedOutput::new(MicroTari::from(spent_value1), spent_key1, None);
     let spent_tx_output1 = spent_output1.as_transaction_output(&factories).unwrap();
+    let spent_db_output1 = DbUnblindedOutput::from_unblinded_output(spent_output1.clone(), &factories).unwrap();
 
     backend
         .write(WriteOperation::Insert(DbKeyValuePair::SpentOutput(
-            spent_output1.spending_key.clone(),
-            Box::new(DbUnblindedOutput::from_unblinded_output(spent_output1.clone(), &factories).unwrap()),
+            spent_db_output1.commitment.clone(),
+            Box::new(spent_db_output1),
         )))
         .unwrap();
 
     let spent_key2 = PrivateKey::random(&mut OsRng);
     let spent_value2 = 800;
     let spent_output2 = UnblindedOutput::new(MicroTari::from(spent_value2), spent_key2, None);
-
+    let spent_db_output2 = DbUnblindedOutput::from_unblinded_output(spent_output2, &factories).unwrap();
     backend
         .write(WriteOperation::Insert(DbKeyValuePair::SpentOutput(
-            spent_output2.spending_key.clone(),
-            Box::new(DbUnblindedOutput::from_unblinded_output(spent_output2, &factories).unwrap()),
+            spent_db_output2.commitment.clone(),
+            Box::new(spent_db_output2),
         )))
         .unwrap();
 

--- a/base_layer/wallet_ffi/Cargo.toml
+++ b/base_layer/wallet_ffi/Cargo.toml
@@ -10,6 +10,7 @@ edition = "2018"
 tari_comms = { version = "^0.8", path = "../../comms" }
 tari_comms_dht = { version = "^0.8", path = "../../comms/dht" }
 tari_crypto = "^0.8"
+tari_key_manager = { version = "^0.8", path = "../key_manager" }
 tari_p2p = { version = "^0.8", path = "../p2p" }
 tari_wallet = { version = "^0.8", path = "../wallet", features = ["test_harness", "c_integration"]}
 tari_shutdown = { version = "^0.8", path = "../../infrastructure/shutdown" }

--- a/base_layer/wallet_ffi/src/enums.rs
+++ b/base_layer/wallet_ffi/src/enums.rs
@@ -1,4 +1,4 @@
-// Copyright 2019, The Tari Project
+// Copyright 2020. The Tari Project
 //
 // Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
 // following conditions are met:
@@ -20,33 +20,10 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use prost_types::Timestamp;
-use std::convert::TryInto;
-use tari_crypto::tari_utilities::epoch_time::EpochTime;
-
-/// Tries to convert a series of `T`s to `U`s, returning an error at the first failure
-pub fn try_convert_all<T, U, I>(into_iter: I) -> Result<Vec<U>, T::Error>
-where
-    I: IntoIterator<Item = T>,
-    T: TryInto<U>,
-{
-    let iter = into_iter.into_iter();
-    let mut result = Vec::with_capacity(iter.size_hint().0);
-    for item in iter {
-        result.push(item.try_into()?);
-    }
-    Ok(result)
-}
-
-/// Utility function that converts a `prost::Timestamp` to a `chrono::DateTime`
-pub(crate) fn timestamp_to_datetime(timestamp: Timestamp) -> EpochTime {
-    (timestamp.seconds as u64).into()
-}
-
-/// Utility function that converts a `chrono::DateTime` to a `prost::Timestamp`
-pub(crate) fn datetime_to_timestamp(datetime: EpochTime) -> Timestamp {
-    Timestamp {
-        seconds: datetime.as_u64() as i64,
-        nanos: 0,
-    }
+/// Enum to indicate the result of pushing a new seed word onto a TariSeedWords instance
+pub enum SeedWordPushResult {
+    InvalidSeedWord,
+    SuccessfulPush,
+    SeedPhraseComplete,
+    InvalidSeedPhrase,
 }

--- a/base_layer/wallet_ffi/src/error.rs
+++ b/base_layer/wallet_ffi/src/error.rs
@@ -29,6 +29,7 @@ use tari_crypto::{
     signatures::SchnorrSignatureError,
     tari_utilities::{hex::HexError, ByteArrayError},
 };
+use tari_key_manager::mnemonic::MnemonicError;
 use tari_wallet::{
     contacts_service::error::{ContactsServiceError, ContactsServiceStorageError},
     error::{WalletError, WalletStorageError},
@@ -263,6 +264,10 @@ impl From<WalletError> for LibWalletError {
                 code: 426,
                 message: format!("{:?}", w),
             },
+            WalletError::WalletRecoveryError(_) => Self {
+                code: 427,
+                message: format!("{:?}", w),
+            },
             // This is the catch all error code. Any error that is not explicitly mapped above will be given this code
             _ => Self {
                 code: 999,
@@ -410,6 +415,16 @@ impl From<TransactionError> for LibWalletError {
                 code: 650,
                 message: format!("{:?}", v),
             },
+        }
+    }
+}
+
+impl From<MnemonicError> for LibWalletError {
+    fn from(err: MnemonicError) -> Self {
+        error!(target: LOG_TARGET, "{}", format!("{:?}", err));
+        Self {
+            code: 910,
+            message: format!("{:?}", err),
         }
     }
 }

--- a/base_layer/wallet_ffi/src/lib.rs
+++ b/base_layer/wallet_ffi/src/lib.rs
@@ -119,7 +119,9 @@
 #[macro_use]
 extern crate lazy_static;
 mod callback_handler;
+mod enums;
 mod error;
+mod tasks;
 
 use crate::{
     callback_handler::CallbackHandler,
@@ -199,6 +201,7 @@ use tari_wallet::{
     Wallet,
 };
 
+use crate::{enums::SeedWordPushResult, tasks::recovery_event_monitoring};
 use futures::StreamExt;
 use log4rs::append::{
     rolling_file::{
@@ -213,6 +216,7 @@ use tari_p2p::transport::TransportType::Tor;
 use tari_wallet::{
     error::WalletStorageError,
     output_manager_service::protocols::txo_validation_protocol::TxoValidationType,
+    tasks::wallet_recovery::WalletRecoveryTask,
     types::ValidationRetryStrategy,
     WalletSqlite,
 };
@@ -805,6 +809,21 @@ pub unsafe extern "C" fn private_key_from_hex(key: *const c_char, error_out: *mu
 /// -------------------------------------------------------------------------------------------- ///
 /// ----------------------------------- Seed Words ----------------------------------------------///
 
+/// Create an empty instance of TariSeedWords
+///
+/// ## Arguments
+/// None
+///
+/// ## Returns
+/// `TariSeedWords` - Returns an empty TariSeedWords instance
+///
+/// # Safety
+/// None
+#[no_mangle]
+pub unsafe extern "C" fn seed_words_create() -> *mut TariSeedWords {
+    Box::into_raw(Box::new(TariSeedWords(Vec::new())))
+}
+
 /// Gets the length of TariSeedWords
 ///
 /// ## Arguments
@@ -868,6 +887,69 @@ pub unsafe extern "C" fn seed_words_get_at(
         }
     }
     CString::into_raw(word)
+}
+
+/// Add a word to the provided TariSeedWords instance
+///
+/// ## Arguments
+/// `seed_words` - The pointer to a TariSeedWords
+/// `word` - Word to add
+/// `error_out` - Pointer to an int which will be modified to an error code should one occur, may not be null. Functions
+/// as an out parameter.
+///
+/// ## Returns
+/// 'c_uchar' - Returns a u8 version of the `SeedWordPushResult` enum indicating whether the word was not a valid seed
+/// word, if the push was successful and whether the push was successful and completed the full Seed Phrase
+///     '0' -> InvalidSeedWord
+///     '1' -> SuccessfulPush
+///     '2' -> SeedPhraseComplete     
+///     '3' -> InvalidSeedPhrase
+/// # Safety
+/// The ```string_destroy``` method must be called when finished with a string from rust to prevent a memory leak
+#[no_mangle]
+pub unsafe extern "C" fn seed_words_push_word(
+    seed_words: *mut TariSeedWords,
+    word: *const c_char,
+    error_out: *mut c_int,
+) -> c_uchar
+{
+    use tari_key_manager::mnemonic::{Mnemonic, MnemonicLanguage};
+
+    let mut error = 0;
+    ptr::swap(error_out, &mut error as *mut c_int);
+    if seed_words.is_null() {
+        error = LibWalletError::from(InterfaceError::NullError("seed words".to_string())).code;
+        ptr::swap(error_out, &mut error as *mut c_int);
+    }
+
+    let word_string;
+    if word.is_null() {
+        error = LibWalletError::from(InterfaceError::NullError("word".to_string())).code;
+        ptr::swap(error_out, &mut error as *mut c_int);
+        return SeedWordPushResult::InvalidSeedWord as u8;
+    } else {
+        word_string = CStr::from_ptr(word).to_str().unwrap().to_owned();
+    }
+
+    // Check word is from a word list
+    if MnemonicLanguage::from(word_string.as_str()).is_err() {
+        log::error!(target: LOG_TARGET, "{} is not a valid mnemonic seed word", word_string);
+        return SeedWordPushResult::InvalidSeedWord as u8;
+    }
+
+    (*seed_words).0.push(word_string);
+    if (*seed_words).0.len() >= 24 {
+        if let Err(e) = TariPrivateKey::from_mnemonic(&(*seed_words).0) {
+            log::error!(target: LOG_TARGET, "Problem building private key from seed phrase");
+            error = LibWalletError::from(e).code;
+            ptr::swap(error_out, &mut error as *mut c_int);
+            return SeedWordPushResult::InvalidSeedPhrase as u8;
+        } else {
+            return SeedWordPushResult::SeedPhraseComplete as u8;
+        }
+    }
+
+    SeedWordPushResult::SuccessfulPush as u8
 }
 
 /// Frees memory for a TariSeedWords
@@ -5309,6 +5391,107 @@ pub unsafe extern "C" fn wallet_clear_value(
     }
 }
 
+/// Check if a Wallet has the data of an In Progress Recovery in its database.
+///
+/// ## Arguments
+/// `wallet` - The TariWallet pointer.
+/// `error_out` - Pointer to an int which will be modified to an error code should one occur, may not be null. Functions
+/// as an out parameter.
+///
+/// ## Returns
+/// `bool` - Return a boolean value indicating whether there is an in progress recovery or not. An error will also
+/// result in a false result.
+///
+/// # Safety
+/// None
+#[no_mangle]
+pub unsafe extern "C" fn wallet_is_recovery_in_progress(wallet: *mut TariWallet, error_out: *mut c_int) -> bool {
+    let mut error = 0;
+    ptr::swap(error_out, &mut error as *mut c_int);
+
+    if wallet.is_null() {
+        error = LibWalletError::from(InterfaceError::NullError("wallet".to_string())).code;
+        ptr::swap(error_out, &mut error as *mut c_int);
+        return false;
+    }
+
+    match (*wallet).runtime.block_on((*wallet).wallet.is_recovery_in_progress()) {
+        Ok(result) => result,
+        Err(e) => {
+            error = LibWalletError::from(e).code;
+            ptr::swap(error_out, &mut error as *mut c_int);
+            false
+        },
+    }
+}
+
+/// Check if a Wallet has the data of an In Progress Recovery in its database.
+///
+/// ## Arguments
+/// `wallet` - The TariWallet pointer.
+/// `base_node_public_key` - The TariPublicKey pointer of the Base Node the recovery process will use
+/// `recovery_progress_callback` - The callback function pointer that will be used to asynchronously communicate
+/// progress to the client. The first argument is the current block the process has completed and the second argument is
+/// the total chain height. When the current block reaches the total chain height the process is complete.
+///     - The first callback with arguments (0,1) indicate a successful base node connection and process has started
+///     - In progress callbacks will be of the form (n, m) where n < m
+///     - If the process completed successfully then the final callback will have arguments (x, x) where x == x
+///     - If there is an error in the process then the final callback will be called with zero arguments i.e. (0, 0)
+/// `error_out` - Pointer to an int which will be modified to an error code should one occur, may not be null. Functions
+/// as an out parameter.
+///
+/// ## Returns
+/// `bool` - Return a boolean value indicating whether the process started successfully or not, the process will
+/// continue to run asynchronously and communicate it progress via the callback. An error will also produce a false
+/// result.
+///
+/// # Safety
+/// None
+#[no_mangle]
+pub unsafe extern "C" fn wallet_start_recovery(
+    wallet: *mut TariWallet,
+    base_node_public_key: *mut TariPublicKey,
+    recovery_progress_callback: unsafe extern "C" fn(u64, u64),
+    error_out: *mut c_int,
+) -> bool
+{
+    use futures::FutureExt;
+
+    let mut error = 0;
+    ptr::swap(error_out, &mut error as *mut c_int);
+
+    if wallet.is_null() {
+        error = LibWalletError::from(InterfaceError::NullError("wallet".to_string())).code;
+        ptr::swap(error_out, &mut error as *mut c_int);
+        return false;
+    }
+
+    let mut recovery_task = WalletRecoveryTask::new((*wallet).wallet.clone(), (*base_node_public_key).clone());
+
+    let event_stream = match recovery_task.get_event_receiver() {
+        None => {
+            error = LibWalletError::from(WalletError::WalletRecoveryError(
+                "No recovery event stream available".to_string(),
+            ))
+            .code;
+            ptr::swap(error_out, &mut error as *mut c_int);
+            return false;
+        },
+        Some(e) => e.fuse(),
+    };
+
+    let recovery_join_handle = (*wallet).runtime.spawn(recovery_task.run()).fuse();
+
+    // Spawn a task to monitor the recovery process events and call the callback appropriately
+    (*wallet).runtime.spawn(recovery_event_monitoring(
+        event_stream,
+        recovery_join_handle,
+        recovery_progress_callback,
+    ));
+
+    true
+}
+
 /// This function will produce a partial backup of the specified wallet database file. This backup will be written to
 /// the provided file (full path must include the filename and extension) and will include the full wallet db but will
 /// clear the sensitive Comms Private Key
@@ -7078,6 +7261,49 @@ mod test {
 
             comms_config_destroy(alice_config);
             wallet_destroy(alice_wallet);
+        }
+    }
+
+    #[test]
+    pub fn test_seed_words() {
+        unsafe {
+            let mut error = 0;
+            let error_ptr = &mut error as *mut c_int;
+
+            let mnemonic = vec![
+                "clever", "jaguar", "bus", "engage", "oil", "august", "media", "high", "trick", "remove", "tiny",
+                "join", "item", "tobacco", "orange", "pony", "tomorrow", "also", "dignity", "giraffe", "little",
+                "board", "army", "scale",
+            ];
+
+            let seed_words = seed_words_create();
+
+            let w = CString::new("hodl").unwrap();
+            let w_str: *const c_char = CString::into_raw(w) as *const c_char;
+
+            assert_eq!(
+                seed_words_push_word(seed_words, w_str, error_ptr),
+                SeedWordPushResult::InvalidSeedWord as u8
+            );
+
+            let mut count = 0;
+            for w in mnemonic.iter() {
+                count += 1;
+                let w = CString::new(*w).unwrap();
+                let w_str: *const c_char = CString::into_raw(w) as *const c_char;
+
+                if count < 24 {
+                    assert_eq!(
+                        seed_words_push_word(seed_words, w_str, error_ptr),
+                        SeedWordPushResult::SuccessfulPush as u8
+                    );
+                } else {
+                    assert_eq!(
+                        seed_words_push_word(seed_words, w_str, error_ptr),
+                        SeedWordPushResult::SeedPhraseComplete as u8
+                    );
+                }
+            }
         }
     }
 }

--- a/base_layer/wallet_ffi/src/tasks.rs
+++ b/base_layer/wallet_ffi/src/tasks.rs
@@ -1,0 +1,85 @@
+// Copyright 2021. The Tari Project
+//
+// Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+// following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+// disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+// following disclaimer in the documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+// products derived from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+// INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+// WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+// USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+use futures::{channel::mpsc::Receiver, future::Fuse as FutureFuse, stream::Fuse, StreamExt};
+use log::*;
+use tari_crypto::tari_utilities::hex::Hex;
+use tari_wallet::{error::WalletError, tasks::wallet_recovery::WalletRecoveryEvent};
+use tokio::task::JoinHandle;
+
+const LOG_TARGET: &str = "wallet_ffi";
+
+pub async fn recovery_event_monitoring(
+    mut event_stream: Fuse<Receiver<WalletRecoveryEvent>>,
+    mut recovery_join_handle: FutureFuse<JoinHandle<Result<(), WalletError>>>,
+    recovery_progress_callback: unsafe extern "C" fn(u64, u64),
+)
+{
+    loop {
+        futures::select! {
+            event = event_stream.select_next_some() => {
+                match event {
+                    WalletRecoveryEvent::ConnectedToBaseNode(pk) => {
+                       unsafe {
+                            (recovery_progress_callback)(0u64,1u64);
+                       }
+                       info!(target: LOG_TARGET, "Connected to base node: {}", pk.to_hex());
+                    },
+                    WalletRecoveryEvent::Progress(current, total) => {
+                           unsafe {
+                                (recovery_progress_callback)(current,total);
+                            }
+                            info!(target: LOG_TARGET, "Recovery progress: {}/{}", current, total);
+                            if current == total {
+                                info!(target: LOG_TARGET, "Recovery complete: {}/{}", current, total);
+                                break;
+                            }
+                    },
+                    WalletRecoveryEvent::Completed(num_utxos, total_amount) => {
+                        debug!(target: LOG_TARGET, "Recovery complete. Num UTXOs: {}, Amount: {}", num_utxos, total_amount);
+                        break;
+                    },
+                }
+            },
+            recovery_result = recovery_join_handle => {
+                match recovery_result {
+                    Err(e) => {
+                        unsafe {
+                            (recovery_progress_callback)(0u64,0u64);
+                        }
+                        error!(target: LOG_TARGET, "Recovery error: {}", e);
+                        break;
+                    },
+                    Ok(r) => {
+                        if let Err(e) = r {
+                            unsafe {
+                                (recovery_progress_callback)(0u64,0u64);
+                            }
+                            error!(target: LOG_TARGET, "Recovery error: {}", e);
+                            break;
+                        }
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Description
This PR adds the functionality to the LibWallet FFI to recovery a wallet from a set of seed words. 

There was an implementation of the recovery process in the Tari Console Wallet and this was moved into LibWallet and generalised to be used for both clients. The process is now started and a stream of events will be used to inform the client of the progress. Furthermore the progress of the process is now persisted in the LibWallet db backend to allow for the resuming of the process from where it left off. The Console wallet was updated to check if a restoration is in progress and to continue it.

- Added the ability to create a TariSeedWordsObject and add words to it. The u8 enum return from `seed_words_push_word(…)` tells the client if the word was valid and when the seed phrase of 24 words is complete.
- Add a call to check if there was an In Progress restoration. The wallet client can ignore this if they want to, the wallet functions as normal but obviously we won’t be sure that all outputs have been recovered or not.
- Add a call to start the recovery process. The client provides a callback whose arguments are what block we have recovered to and the current total chain length. Based on these two values the client will be informed of the status of the asynchronous recovery process. This call can be used to resume the process to as it will check the persisted values and start from there.

The recovery process can take hours.

## How Has This Been Tested?
This functionality was manually tested in the console wallet but the FFI interface remains untested as it is difficult to mock our the base node side of the process. @kukabi will need to let me know if there are any issues 🤞 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch.
* [x] I ran `cargo-fmt --all` before pushing.
* [x] I ran `cargo test` successfully before submitting my PR.
* [x] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
