### PR TITLE
Remove re_org transactions from total_tx stats

### DIFF
--- a/base_layer/core/src/mempool/mempool_storage.rs
+++ b/base_layer/core/src/mempool/mempool_storage.rs
@@ -209,7 +209,7 @@ impl MempoolStorage {
 
     // Returns the total number of transactions in the Mempool.
     fn len(&self) -> Result<usize, MempoolError> {
-        Ok(self.unconfirmed_pool.len() + self.reorg_pool.len()?)
+        Ok(self.unconfirmed_pool.len())
     }
 
     // Returns the total weight of all transactions stored in the Mempool.

--- a/base_layer/core/tests/mempool.rs
+++ b/base_layer/core/tests/mempool.rs
@@ -191,7 +191,7 @@ fn test_insert_and_process_published_block() {
     assert_eq!(snapshot_txs.len(), 0);
 
     let stats = mempool.stats().unwrap();
-    assert_eq!(stats.total_txs, 1);
+    assert_eq!(stats.total_txs, 0);
     assert_eq!(stats.unconfirmed_txs, 0);
     assert_eq!(stats.reorg_txs, 1);
     assert_eq!(stats.total_weight, 30);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Because the re-org pool is internal only and not really reported to outside, reporting the re-orgs as part of the total_tx count causes confusion. This removes the re-org transactions from the total count. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [ ] I'm merging against the `development` branch.
* [ ] I ran `cargo-fmt --all` before pushing.
* [ ] I ran `cargo test` successfully before submitting my PR.
* [ ] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
