### PR TITLE
[wallet] Friendly incorrect password message

### DIFF
--- a/applications/tari_console_wallet/src/automation/error.rs
+++ b/applications/tari_console_wallet/src/automation/error.rs
@@ -54,8 +54,7 @@ pub enum CommandError {
 impl From<CommandError> for ExitCodes {
     fn from(err: CommandError) -> Self {
         error!(target: LOG_TARGET, "{}", err);
-        let msg = format!("Command error: {}", err);
-        Self::CommandError(msg)
+        Self::CommandError(err.to_string())
     }
 }
 

--- a/applications/tari_console_wallet/src/init/mod.rs
+++ b/applications/tari_console_wallet/src/init/mod.rs
@@ -283,18 +283,15 @@ pub async fn init_wallet(
             // wallet is not encrypted
             (backends, false)
         },
-        Err(e) => {
-            if matches!(e, WalletStorageError::NoPasswordError) {
-                // get supplied or prompt password
-                let passphrase = get_or_prompt_password(arg_password.clone(), config.console_wallet_password.clone())?;
-                let backends = initialize_sqlite_database_backends(db_path, passphrase)
-                    .map_err(|e| ExitCodes::WalletError(format!("Error creating Wallet database backends. {}", e)))?;
+        Err(WalletStorageError::NoPasswordError) => {
+            // get supplied or prompt password
+            let passphrase = get_or_prompt_password(arg_password.clone(), config.console_wallet_password.clone())?;
+            let backends = initialize_sqlite_database_backends(db_path, passphrase)?;
 
-                (backends, true)
-            } else {
-                return Err(e)
-                    .map_err(|e| ExitCodes::WalletError(format!("Error creating Wallet database backends. {}", e)));
-            }
+            (backends, true)
+        },
+        Err(e) => {
+            return Err(e.into());
         },
     };
     let (wallet_backend, transaction_backend, output_manager_backend, contacts_backend) = backends;

--- a/applications/tari_console_wallet/src/main.rs
+++ b/applications/tari_console_wallet/src/main.rs
@@ -40,8 +40,13 @@ fn main() {
     match main_inner() {
         Ok(_) => std::process::exit(0),
         Err(exit_code) => {
-            eprintln!("Exiting with code: {}", exit_code);
-            error!(target: LOG_TARGET, "Exiting with code: {}", exit_code);
+            eprintln!("{}", exit_code);
+            error!(
+                target: LOG_TARGET,
+                "Exiting with code ({}): {}",
+                exit_code.as_i32(),
+                exit_code
+            );
             std::process::exit(exit_code.as_i32())
         },
     }

--- a/base_layer/wallet/src/error.rs
+++ b/base_layer/wallet/src/error.rs
@@ -121,4 +121,6 @@ pub enum WalletStorageError {
     IoError(#[from] std::io::Error),
     #[error("No password provided for encrypted wallet")]
     NoPasswordError,
+    #[error("Incorrect password provided for encrypted wallet")]
+    IncorrectPassword,
 }

--- a/base_layer/wallet/src/storage/sqlite_db.rs
+++ b/base_layer/wallet/src/storage/sqlite_db.rs
@@ -109,7 +109,8 @@ impl WalletSqliteDatabase {
                             let nonce = GenericArray::from_slice(sk_bytes.as_slice());
 
                             let decrypted_key = cipher_inner.decrypt(nonce, data.as_ref()).map_err(|e| {
-                                WalletStorageError::AeadError(format!("Decryption Error:{}", e.to_string()))
+                                error!(target: LOG_TARGET, "Incorrect password ({})", e);
+                                WalletStorageError::IncorrectPassword
                             })?;
                             CommsSecretKey::from_bytes(decrypted_key.as_slice()).map_err(|_| {
                                 error!(

--- a/base_layer/wallet/src/storage/sqlite_utilities.rs
+++ b/base_layer/wallet/src/storage/sqlite_utilities.rs
@@ -149,14 +149,11 @@ pub fn initialize_sqlite_database_backends(
     WalletStorageError,
 >
 {
-    let cipher = match passphrase {
-        None => None,
-        Some(passphrase_str) => {
-            let passphrase_hash = Blake256::new().chain(passphrase_str.as_bytes()).result().to_vec();
-            let key = GenericArray::from_slice(passphrase_hash.as_slice());
-            Some(Aes256Gcm::new(key))
-        },
-    };
+    let cipher = passphrase.map(|passphrase_str| {
+        let passphrase_hash = Blake256::new().chain(passphrase_str.as_bytes()).result();
+        let key = GenericArray::from_slice(passphrase_hash.as_slice());
+        Aes256Gcm::new(key)
+    });
 
     let connection = run_migration_and_create_sqlite_connection(&db_path).map_err(|e| {
         error!(

--- a/base_layer/wallet/tests/wallet/mod.rs
+++ b/base_layer/wallet/tests/wallet/mod.rs
@@ -312,8 +312,8 @@ async fn test_wallet() {
     let cipher = Aes256Gcm::new(key);
     let result = WalletSqliteDatabase::new(connection.clone(), Some(cipher));
 
-    if let Err(WalletStorageError::AeadError(s)) = result {
-        assert_eq!(s, "Decryption Error:aead::Error".to_string());
+    if let Err(err) = result {
+        assert!(matches!(err, WalletStorageError::IncorrectPassword));
     } else {
         panic!("Should not be able to instantiate encrypted wallet without cipher");
     }

--- a/base_layer/wallet_ffi/src/error.rs
+++ b/base_layer/wallet_ffi/src/error.rs
@@ -272,6 +272,10 @@ impl From<WalletError> for LibWalletError {
                 code: 427,
                 message: format!("{:?}", w),
             },
+            WalletError::WalletStorageError(WalletStorageError::IncorrectPassword) => Self {
+                code: 428,
+                message: format!("{:?}", w),
+            },
             // This is the catch all error code. Any error that is not explicitly mapped above will be given this code
             _ => Self {
                 code: 999,

--- a/base_layer/wallet_ffi/src/lib.rs
+++ b/base_layer/wallet_ffi/src/lib.rs
@@ -902,7 +902,7 @@ pub unsafe extern "C" fn seed_words_get_at(
 /// word, if the push was successful and whether the push was successful and completed the full Seed Phrase
 ///     '0' -> InvalidSeedWord
 ///     '1' -> SuccessfulPush
-///     '2' -> SeedPhraseComplete     
+///     '2' -> SeedPhraseComplete
 ///     '3' -> InvalidSeedPhrase
 /// # Safety
 /// The ```string_destroy``` method must be called when finished with a string from rust to prevent a memory leak
@@ -7085,7 +7085,7 @@ mod test {
                 saf_messages_received_callback,
                 error_ptr,
             );
-            assert_eq!(error, 423);
+            assert_eq!(error, 428);
 
             let alice_wallet = wallet_create(
                 alice_config,


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Change wallet error messages including the incorrect password to be more
user-friendly.

![image](https://user-images.githubusercontent.com/1057902/111479539-bab14f00-8739-11eb-828d-b1c0effdce83.png)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Previously the wallet would exit with error
`Exiting with code: Wallet Error (104): Error creating Wallet database backends. Aead error: Decryption Error:aead::Error`

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested by running wallet with `--password 'wrong'` 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [x] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [ ] I'm merging against the `development` branch.
* [ ] I ran `cargo-fmt --all` before pushing.
* [ ] I ran `cargo test` successfully before submitting my PR.
* [ ] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
