### PR TITLE
[base-node] Add transaction consensus validator to mempool

### DIFF
--- a/applications/tari_base_node/src/builder.rs
+++ b/applications/tari_base_node/src/builder.rs
@@ -36,7 +36,12 @@ use tari_core::{
     validation::{
         block_validators::{BodyOnlyValidator, OrphanBlockValidator},
         header_validator::HeaderValidator,
-        transaction_validators::{MempoolValidator, TxInputAndMaturityValidator, TxInternalConsistencyValidator},
+        transaction_validators::{
+            MempoolValidator,
+            TxConsensusValidator,
+            TxInputAndMaturityValidator,
+            TxInternalConsistencyValidator,
+        },
     },
 };
 use tari_service_framework::ServiceHandles;
@@ -195,6 +200,7 @@ async fn build_node_context(
     let mempool_validator = MempoolValidator::new(vec![
         Box::new(TxInternalConsistencyValidator::new(factories.clone())),
         Box::new(TxInputAndMaturityValidator::new(blockchain_db.clone())),
+        Box::new(TxConsensusValidator::new(blockchain_db.clone())),
     ]);
     let mempool = Mempool::new(MempoolConfig::default(), Arc::new(mempool_validator));
 

--- a/base_layer/core/src/mempool/service/inbound_handlers.rs
+++ b/base_layer/core/src/mempool/service/inbound_handlers.rs
@@ -136,15 +136,8 @@ impl MempoolInboundHandlers {
                     target: LOG_TARGET,
                     "Transaction inserted into mempool: {}, pool: {}.", kernel_excess_sig, tx_storage
                 );
-                let propagate = match tx_storage {
-                    TxStorageResponse::UnconfirmedPool => true,
-                    TxStorageResponse::ReorgPool => false,
-                    TxStorageResponse::NotStored => false,
-                    TxStorageResponse::NotStoredOrphan => false,
-                    TxStorageResponse::NotStoredTimeLocked => false,
-                    TxStorageResponse::NotStoredAlreadySpent => false,
-                };
-                if propagate {
+                // propagate the tx if it was accepted to the unconfirmed pool
+                if matches!(tx_storage, TxStorageResponse::UnconfirmedPool) {
                     debug!(
                         target: LOG_TARGET,
                         "Propagate transaction ({}) to network.", kernel_excess_sig,

--- a/base_layer/core/src/transactions/transaction_protocol/sender.rs
+++ b/base_layer/core/src/transactions/transaction_protocol/sender.rs
@@ -330,7 +330,7 @@ impl SenderTransactionProtocol {
         tx_builder.build(factories).map_err(TPE::from)
     }
 
-    /// Performs sanitary checks on the collected transaction pieces prior to building the final Transaction instance
+    /// Performs sanity checks on the collected transaction pieces prior to building the final Transaction instance
     fn validate(&self) -> Result<(), TPE> {
         if let SenderState::Finalizing(info) = &self.state {
             let fee = info.metadata.fee;

--- a/base_layer/core/src/validation/error.rs
+++ b/base_layer/core/src/validation/error.rs
@@ -75,6 +75,8 @@ pub enum ValidationError {
     UnsortedOrDuplicateOutput,
     #[error("Error in merge mine data:{0}")]
     MergeMineError(#[from] MergeMineError),
+    #[error("Maximum transaction weight exceeded")]
+    MaxTransactionWeightExceeded,
 }
 
 // ChainStorageError has a ValidationError variant, so to prevent a cyclic dependency we use a string representation in

--- a/base_layer/core/src/validation/transaction_validators.rs
+++ b/base_layer/core/src/validation/transaction_validators.rs
@@ -56,6 +56,32 @@ impl MempoolTransactionValidation for TxInternalConsistencyValidator {
     }
 }
 
+/// This validator will check the transaction against the current consensus rules.
+///
+/// 1. The transaction weight should not exceed the maximum weight for 1 block
+#[derive(Clone)]
+pub struct TxConsensusValidator<B> {
+    db: BlockchainDatabase<B>,
+}
+
+impl<B: BlockchainBackend> TxConsensusValidator<B> {
+    pub fn new(db: BlockchainDatabase<B>) -> Self {
+        Self { db }
+    }
+}
+
+impl<B: BlockchainBackend> MempoolTransactionValidation for TxConsensusValidator<B> {
+    fn validate(&self, tx: &Transaction) -> Result<(), ValidationError> {
+        let consensus_constants = self.db.consensus_constants()?;
+        // validate maximum tx weight
+        if tx.calculate_weight() > consensus_constants.get_max_block_transaction_weight() {
+            return Err(ValidationError::MaxTransactionWeightExceeded);
+        }
+
+        Ok(())
+    }
+}
+
 /// This validator assumes that the transaction was already validated and it will skip this step. It will only check, in
 /// order,: All inputs exist in the backend, All timelocks (kernel lock heights and output maturities) have passed
 #[derive(Clone)]
@@ -73,7 +99,7 @@ impl<B: BlockchainBackend> MempoolTransactionValidation for TxInputAndMaturityVa
     fn validate(&self, tx: &Transaction) -> Result<(), ValidationError> {
         let db = self.db.db_read_access()?;
         verify_not_stxos(tx, &*db)?;
-        // verify_inputs_are_utxos(tx, &*db)?;
+
         let tip_height = db.fetch_chain_metadata()?.height_of_longest_chain();
         verify_timelocks(tx, tip_height)?;
         verify_no_duplicated_inputs_outputs(tx)?;

--- a/base_layer/core/tests/mempool.rs
+++ b/base_layer/core/tests/mempool.rs
@@ -35,6 +35,7 @@ use helpers::{
     nodes::{create_network_with_2_base_nodes_with_config, create_network_with_3_base_nodes_with_config},
     sample_blockchains::create_new_blockchain,
 };
+use tari_crypto::keys::PublicKey as PublicKeyTrait;
 // use crate::helpers::database::create_store;
 use std::{ops::Deref, sync::Arc, time::Duration};
 use tari_comms_dht::domain_message::OutboundDomainMessage;
@@ -50,14 +51,16 @@ use tari_core::{
     proof_of_work::Difficulty,
     proto,
     transactions::{
-        helpers::{schema_to_transaction, spend_utxos},
-        tari_amount::{uT, T},
-        transaction::{OutputFeatures, Transaction},
-        types::CryptoFactories,
+        fee::Fee,
+        helpers::{schema_to_transaction, spend_utxos, TestParams},
+        tari_amount::{uT, MicroTari, T},
+        transaction::{KernelBuilder, OutputFeatures, Transaction, TransactionOutput, UnblindedOutput},
+        transaction_protocol::{build_challenge, TransactionMetadata},
+        types::{Commitment, CryptoFactories, PublicKey, Signature},
     },
     tx,
     txn_schema,
-    validation::transaction_validators::TxInputAndMaturityValidator,
+    validation::transaction_validators::{TxConsensusValidator, TxInputAndMaturityValidator},
 };
 use tari_p2p::{services::liveness::LivenessConfig, tari_message::TariMessageType};
 use tari_test_utils::async_assert_eventually;
@@ -634,6 +637,87 @@ fn receive_and_propagate_transaction() {
             expect = TxStorageResponse::NotStored,
         );
     });
+}
+
+#[test]
+fn consensus_validation() {
+    let network = Network::LocalNet;
+    let (mut store, mut blocks, mut outputs, consensus_manager) = create_new_blockchain(network);
+    let mempool_validator = TxConsensusValidator::new(store.clone());
+    let mempool = Mempool::new(MempoolConfig::default(), Arc::new(mempool_validator));
+    // Create a block with 1 output
+    let txs = vec![txn_schema!(from: vec![outputs[0][0].clone()], to: vec![5 * T])];
+    generate_new_block(&mut store, &mut blocks, &mut outputs, txs, &consensus_manager).unwrap();
+
+    // build huge tx manually - the TransactionBuilder already has checks for max inputs/outputs
+    let factories = CryptoFactories::default();
+    let test_params = TestParams::new();
+    let fee_per_gram = 15;
+    let input_count = 1;
+    let output_count = 1_600; // 😵
+    let amount = MicroTari::from(5_000_000);
+
+    let input = outputs[1][0].clone();
+    let sum_inputs_blinding_factors = input.spending_key.clone();
+    let inputs = vec![input.as_transaction_input(&factories.commitment, OutputFeatures::default())];
+
+    let fee = Fee::calculate(fee_per_gram.into(), 1, input_count, output_count);
+    let amount_per_output = (amount - fee) / output_count as u64;
+    let amount_for_last_output = (amount - fee) - amount_per_output * (output_count as u64 - 1);
+    let mut unblinded_outputs = Vec::with_capacity(output_count);
+    for i in 0..output_count {
+        let output_amount = if i < output_count - 1 {
+            amount_per_output
+        } else {
+            amount_for_last_output
+        };
+        let utxo = UnblindedOutput::new(output_amount, test_params.spend_key.clone(), None);
+        unblinded_outputs.push(utxo.clone());
+    }
+
+    let mut sum_outputs_blinding_factors = unblinded_outputs[0].spending_key.clone();
+    for uo in unblinded_outputs.iter().skip(1) {
+        sum_outputs_blinding_factors = sum_outputs_blinding_factors + uo.spending_key.clone();
+    }
+    let excess_blinding_factor = sum_outputs_blinding_factors - sum_inputs_blinding_factors;
+
+    let outputs = unblinded_outputs
+        .iter()
+        .map(|o| o.as_transaction_output(&factories))
+        .collect::<Result<Vec<TransactionOutput>, _>>()
+        .unwrap();
+
+    let tx_meta = TransactionMetadata { fee, lock_height: 0 };
+
+    let nonce = test_params.nonce.clone();
+    let public_nonce = PublicKey::from_secret_key(&nonce);
+    let offset = test_params.offset;
+    let offset_blinding_factor = &excess_blinding_factor - &offset;
+    let excess = PublicKey::from_secret_key(&offset_blinding_factor);
+    let e = build_challenge(&public_nonce, &tx_meta);
+    let k = offset_blinding_factor;
+    let r = nonce;
+    let s = Signature::sign(k, r, &e).unwrap();
+
+    let kernel = KernelBuilder::new()
+        .with_fee(fee)
+        .with_lock_height(0)
+        .with_excess(&Commitment::from_public_key(&excess))
+        .with_signature(&s)
+        .build()
+        .unwrap();
+    let kernels = vec![kernel];
+    let tx = Transaction::new(inputs, outputs, kernels, offset);
+    let weight = tx.calculate_weight();
+
+    let height = blocks.len() as u64;
+    let constants = consensus_manager.consensus_constants(height);
+    // check the tx weight is more than the max for 1 block
+    assert!(weight > constants.get_max_block_transaction_weight());
+
+    let response = mempool.insert(Arc::new(tx)).unwrap();
+    // make sure the tx was not accepted into the mempool
+    assert!(matches!(response, TxStorageResponse::NotStored));
 }
 
 #[test]


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Adds a new consensus validator to the base node mempool service, which checks that any transaction submitted to the mempool must be below the one block maximum weight.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Although the transaction builder and internal validation has checks on the number of inputs/outputs to keep the transaction weight below the one block maximum, the mempool had no such validation. This new validator checks that a transaction submitted to the mempool has an acceptable weight to be mined in one block. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
New test added and existing tests pass.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [x] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [x] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch.
* [x] I ran `cargo-fmt --all` before pushing.
* [x] I ran `cargo test` successfully before submitting my PR.
* [x] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
