### PR TITLE
[base-node] Update mempool consensus validator to check weight excluding coinbase

### DIFF
--- a/base_layer/core/src/validation/transaction_validators.rs
+++ b/base_layer/core/src/validation/transaction_validators.rs
@@ -74,7 +74,7 @@ impl<B: BlockchainBackend> MempoolTransactionValidation for TxConsensusValidator
     fn validate(&self, tx: &Transaction) -> Result<(), ValidationError> {
         let consensus_constants = self.db.consensus_constants()?;
         // validate maximum tx weight
-        if tx.calculate_weight() > consensus_constants.get_max_block_transaction_weight() {
+        if tx.calculate_weight() > consensus_constants.get_max_block_weight_excluding_coinbase() {
             return Err(ValidationError::MaxTransactionWeightExceeded);
         }
 


### PR DESCRIPTION



<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Thanks to @SWvheerden for pointing out that the mempool consensus validator needs to check against the max block weight excluding space for a coinbase utxo and kernel. This PR changes the check to use `get_max_block_weight_excluding_coinbase` function.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
A large transaction might have been accepted into the mempool with no way for a miner to add the coinbase utxo.  

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch.
* [x] I ran `cargo-fmt --all` before pushing.
* [ ] I ran `cargo test` successfully before submitting my PR.
* [x] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
