### PR TITLE
[comms] Connection manager requester not exposed on CommsNode

### DIFF
--- a/base_layer/wallet/src/testnet_utils.rs
+++ b/base_layer/wallet/src/testnet_utils.rs
@@ -319,14 +319,14 @@ pub async fn generate_wallet_test_data<
 
     wallet
         .comms
-        .connection_manager()
+        .connectivity()
         .dial_peer(wallet_alice.comms.node_identity().node_id().clone())
         .await
         .unwrap();
 
     wallet
         .comms
-        .connection_manager()
+        .connectivity()
         .dial_peer(wallet_bob.comms.node_identity().node_id().clone())
         .await
         .unwrap();

--- a/base_layer/wallet/tests/transaction_service/service.rs
+++ b/base_layer/wallet/tests/transaction_service/service.rs
@@ -513,7 +513,7 @@ fn manage_single_transaction() {
 
     let _ = runtime.block_on(
         bob_comms
-            .connection_manager()
+            .connectivity()
             .dial_peer(alice_node_identity.node_id().clone()),
     );
 
@@ -765,7 +765,7 @@ fn manage_multiple_transactions() {
 
     let _ = runtime.block_on(
         bob_comms
-            .connection_manager()
+            .connectivity()
             .dial_peer(alice_node_identity.node_id().clone()),
     );
     runtime.block_on(async { delay_for(Duration::from_secs(3)).await });
@@ -773,7 +773,7 @@ fn manage_multiple_transactions() {
     // Connect alice to carol
     let _ = runtime.block_on(
         alice_comms
-            .connection_manager()
+            .connectivity()
             .dial_peer(carol_node_identity.node_id().clone()),
     );
 

--- a/comms/dht/examples/memory_net/utilities.rs
+++ b/comms/dht/examples/memory_net/utilities.rs
@@ -33,7 +33,7 @@ use std::{
 };
 use tari_comms::{
     backoff::ConstantBackoff,
-    connection_manager::ConnectionDirection,
+    connection_manager::{ConnectionDirection, ConnectionManagerEvent},
     connectivity::ConnectivitySelection,
     peer_manager::{NodeId, NodeIdentity, Peer, PeerFeatures, PeerStorage},
     pipeline,
@@ -46,7 +46,6 @@ use tari_comms::{
     types::CommsDatabase,
     CommsBuilder,
     CommsNode,
-    ConnectionManagerEvent,
     PeerConnection,
 };
 use tari_comms_dht::{

--- a/comms/dht/src/actor.rs
+++ b/comms/dht/src/actor.rs
@@ -47,7 +47,6 @@ use futures::{
 use log::*;
 use std::{cmp, fmt, fmt::Display, sync::Arc};
 use tari_comms::{
-    connection_manager::ConnectionManagerError,
     connectivity::{ConnectivityError, ConnectivityRequester, ConnectivitySelection},
     peer_manager::{NodeId, NodeIdentity, PeerFeatures, PeerManager, PeerManagerError, PeerQuery, PeerQuerySortBy},
 };
@@ -79,8 +78,6 @@ pub enum DhtActorError {
     StoredValueFailedToDeserialize(MessageFormatError),
     #[error("FailedToSerializeValue: {0}")]
     FailedToSerializeValue(MessageFormatError),
-    #[error("ConnectionManagerError: {0}")]
-    ConnectionManagerError(#[from] ConnectionManagerError),
     #[error("ConnectivityError: {0}")]
     ConnectivityError(#[from] ConnectivityError),
     #[error("Connectivity event stream closed")]

--- a/comms/dht/src/discovery/error.rs
+++ b/comms/dht/src/discovery/error.rs
@@ -22,7 +22,7 @@
 
 use crate::outbound::{message::SendFailure, DhtOutboundError};
 use futures::channel::mpsc::SendError;
-use tari_comms::{connection_manager::ConnectionManagerError, peer_manager::PeerManagerError};
+use tari_comms::peer_manager::PeerManagerError;
 use thiserror::Error;
 
 #[derive(Debug, Error)]
@@ -47,8 +47,6 @@ pub enum DhtDiscoveryError {
     PeerManagerError(#[from] PeerManagerError),
     #[error("InvalidPeerMultiaddr: {0}")]
     InvalidPeerMultiaddr(String),
-    #[error("ConnectionManagerError: {0}")]
-    ConnectionManagerError(#[from] ConnectionManagerError),
 }
 
 impl DhtDiscoveryError {

--- a/comms/dht/tests/dht.rs
+++ b/comms/dht/tests/dht.rs
@@ -286,7 +286,7 @@ async fn dht_discover_propagation() {
     node_D.comms.peer_manager().add_peer(node_C.to_peer()).await.unwrap();
     node_D
         .comms
-        .connection_manager()
+        .connectivity()
         .dial_peer(node_C.comms.node_identity().node_id().clone())
         .await
         .unwrap();
@@ -449,7 +449,7 @@ async fn dht_propagate_dedup() {
     async fn connect_nodes(node1: &mut TestNode, node2: &mut TestNode) {
         node1
             .comms
-            .connection_manager()
+            .connectivity()
             .dial_peer(node2.node_identity().node_id().clone())
             .await
             .unwrap();
@@ -553,7 +553,7 @@ async fn dht_propagate_message_contents_not_malleable_ban() {
     // Connect the peers that should be connected
     node_A
         .comms
-        .connection_manager()
+        .connectivity()
         .dial_peer(node_B.node_identity().node_id().clone())
         .await
         .unwrap();

--- a/comms/src/builder/comms_node.rs
+++ b/comms/src/builder/comms_node.rs
@@ -337,12 +337,7 @@ impl CommsNode {
         self.hidden_service.as_ref()
     }
 
-    /// Return an owned copy of a ConnectionManagerRequester. Used to initiate connections to peers.
-    pub fn connection_manager(&self) -> ConnectionManagerRequester {
-        self.connection_manager_requester.clone()
-    }
-
-    /// Return an owned copy of a ConnectivityRequester. This is the async interface to the ConnectivityManager
+    /// Return a handle that is used to call the connectivity service.
     pub fn connectivity(&self) -> ConnectivityRequester {
         self.connectivity_requester.clone()
     }

--- a/comms/src/builder/tests.rs
+++ b/comms/src/builder/tests.rs
@@ -76,7 +76,7 @@ async fn spawn_node(
     let (outbound_tx, outbound_rx) = mpsc::channel(10);
 
     let comms_node = CommsBuilder::new()
-        // These calls are just to get rid of unused function warnings. 
+        // These calls are just to get rid of unused function warnings.
         // <IrrelevantCalls>
         .with_dial_backoff(ConstantBackoff::new(Duration::from_millis(500)))
         .with_shutdown_signal(shutdown_sig)
@@ -152,7 +152,7 @@ async fn peer_to_peer_custom_protocols() {
         .unwrap();
 
     let mut conn_man_events1 = comms_node1.subscribe_connection_manager_events();
-    let mut conn_man_requester1 = comms_node1.connection_manager();
+    let mut conn_man_requester1 = comms_node1.connectivity();
     let mut conn_man_events2 = comms_node2.subscribe_connection_manager_events();
 
     let mut conn1 = conn_man_requester1

--- a/comms/src/connectivity/manager.rs
+++ b/comms/src/connectivity/manager.rs
@@ -28,11 +28,15 @@ use super::{
     selection::ConnectivitySelection,
 };
 use crate::{
-    connection_manager::{ConnectionDirection, ConnectionManagerError, ConnectionManagerRequester},
+    connection_manager::{
+        ConnectionDirection,
+        ConnectionManagerError,
+        ConnectionManagerEvent,
+        ConnectionManagerRequester,
+    },
     peer_manager::NodeId,
     runtime::task,
     utils::datetime::format_duration,
-    ConnectionManagerEvent,
     NodeIdentity,
     PeerConnection,
     PeerManager,

--- a/comms/src/connectivity/test.rs
+++ b/comms/src/connectivity/test.rs
@@ -27,7 +27,7 @@ use super::{
     selection::ConnectivitySelection,
 };
 use crate::{
-    connection_manager::ConnectionManagerError,
+    connection_manager::{ConnectionManagerError, ConnectionManagerEvent},
     peer_manager::{Peer, PeerFeatures},
     runtime,
     runtime::task,
@@ -36,7 +36,6 @@ use crate::{
         node_identity::{build_many_node_identities, build_node_identity},
         test_node::build_peer_manager,
     },
-    ConnectionManagerEvent,
     NodeIdentity,
     PeerManager,
 };

--- a/comms/src/lib.rs
+++ b/comms/src/lib.rs
@@ -30,7 +30,7 @@ mod builder;
 pub use builder::{CommsBuilder, CommsBuilderError, CommsNode, UnspawnedCommsNode};
 
 pub mod connection_manager;
-pub use connection_manager::{validate_peer_addresses, ConnectionManagerEvent, PeerConnection, PeerConnectionError};
+pub use connection_manager::{validate_peer_addresses, PeerConnection, PeerConnectionError};
 
 pub mod connectivity;
 


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Removes deprecated `CommsNode::connection_manager` method that exposes
an interface internal to comms. The connectivity interface should be used instead.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Connection manager is an internal comms interface and should never be interfaced with externally. Doing this could lead to bugs so the interface was removed.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Existing tests pass

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [x] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [ ] I'm merging against the `development` branch.
* [ ] I ran `cargo-fmt --all` before pushing.
* [ ] I ran `cargo test` successfully before submitting my PR.
* [ ] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
