### PR TITLE
Improve wallet recovery resiliency

### DIFF
--- a/applications/tari_console_wallet/src/recovery.rs
+++ b/applications/tari_console_wallet/src/recovery.rs
@@ -25,7 +25,7 @@ use futures::{FutureExt, StreamExt};
 use log::*;
 use rustyline::Editor;
 use tari_app_utilities::utilities::ExitCodes;
-use tari_comms::peer_manager::Peer;
+use tari_comms::types::CommsPublicKey;
 use tari_core::transactions::types::PrivateKey;
 use tari_crypto::tari_utilities::hex::Hex;
 use tari_key_manager::mnemonic::to_secretkey;
@@ -62,8 +62,15 @@ pub fn prompt_private_key_from_seed_words() -> Result<PrivateKey, ExitCodes> {
 /// Recovers wallet funds by connecting to a given base node peer, downloading the transaction outputs stored in the
 /// blockchain, and attempting to rewind them. Any outputs that are successfully rewound are then imported into the
 /// wallet.
-pub async fn wallet_recovery(wallet: &mut WalletSqlite, base_node: &Peer) -> Result<(), ExitCodes> {
-    let mut recovery_task = WalletRecoveryTask::new(wallet.clone(), base_node.public_key.clone());
+pub async fn wallet_recovery(
+    wallet: &mut WalletSqlite,
+    peer_seed_public_keys: Vec<CommsPublicKey>,
+) -> Result<(), ExitCodes>
+{
+    println!("\nPress Ctrl-C to stop the recovery process\n");
+    let mut recovery_task = WalletRecoveryTask::new(wallet.clone(), peer_seed_public_keys);
+    recovery_task.set_connection_retries_limit(250);
+    recovery_task.set_print_to_console(true);
 
     let mut event_stream = recovery_task
         .get_event_receiver()
@@ -81,7 +88,10 @@ pub async fn wallet_recovery(wallet: &mut WalletSqlite, base_node: &Peer) -> Res
                     },
                     WalletRecoveryEvent::Progress(current, total) => {
                         let percentage_progress = ((current as f32) * 100f32 / (total as f32)).round() as u32;
-                        println!("{}: Recovery process {}% complete.", Local::now(), percentage_progress);
+                        println!(
+                            "{}: Recovery process {}% complete ({} of {} blocks).",
+                            Local::now(), percentage_progress, current, total
+                        );
                     },
                     WalletRecoveryEvent::Completed(num_utxos, total_amount) => {
                         println!("Recovered {} outputs with a value of {}", num_utxos, total_amount);
@@ -89,7 +99,9 @@ pub async fn wallet_recovery(wallet: &mut WalletSqlite, base_node: &Peer) -> Res
                 }
             },
             recovery_result = recovery_join_handle => {
-               return recovery_result.map_err(|e| ExitCodes::RecoveryError(format!("{}", e)))?.map_err(|e| ExitCodes::RecoveryError(format!("{}", e)));
+                return recovery_result.map_err(|e| ExitCodes::RecoveryError(format!("{}", e)))?
+                    .map_err(|e| ExitCodes::RecoveryError(format!("{}", e))
+                );
             }
         }
     }

--- a/applications/tari_console_wallet/src/wallet_modes.rs
+++ b/applications/tari_console_wallet/src/wallet_modes.rs
@@ -34,6 +34,7 @@ use tari_app_utilities::utilities::ExitCodes;
 use tari_common::GlobalConfig;
 use tari_comms::peer_manager::Peer;
 
+use tari_comms::types::CommsPublicKey;
 use tari_wallet::WalletSqlite;
 use tokio::runtime::Handle;
 use tonic::transport::Server;
@@ -181,8 +182,13 @@ pub fn recovery_mode(
     notify_script: Option<PathBuf>,
 ) -> Result<(), ExitCodes>
 {
+    let peer_seed_public_keys: Vec<CommsPublicKey> = base_node_config
+        .peer_seeds
+        .iter()
+        .map(|f| f.public_key.clone())
+        .collect();
     println!("Starting recovery...");
-    match handle.block_on(wallet_recovery(&mut wallet, &base_node_selected)) {
+    match handle.block_on(wallet_recovery(&mut wallet, peer_seed_public_keys)) {
         Ok(_) => println!("Wallet recovered!"),
         Err(e) => {
             error!(target: LOG_TARGET, "Recovery failed: {}", e);

--- a/base_layer/wallet/src/base_node_service/service.rs
+++ b/base_layer/wallet/src/base_node_service/service.rs
@@ -221,6 +221,9 @@ where T: WalletBackend + 'static
 
         let tip_info = client.get_tip_info().await?;
 
+        // Note: Dropping the client here reduces the number of concurrent RPC connections
+        drop(client);
+
         let metadata = tip_info
             .metadata
             .ok_or_else(|| BaseNodeServiceError::InvalidBaseNodeResponse("Tip info no metadata".to_string()))?;

--- a/base_layer/wallet/src/error.rs
+++ b/base_layer/wallet/src/error.rs
@@ -30,7 +30,11 @@ use crate::{
 use diesel::result::Error as DieselError;
 use log::SetLoggerError;
 use serde_json::Error as SerdeJsonError;
-use tari_comms::{connectivity::ConnectivityError, multiaddr, peer_manager::PeerManagerError};
+use tari_comms::{
+    connectivity::ConnectivityError,
+    multiaddr,
+    peer_manager::{node_id::NodeIdError, PeerManagerError},
+};
 use tari_comms_dht::store_forward::StoreAndForwardError;
 use tari_crypto::tari_utilities::{hex::HexError, ByteArrayError};
 use tari_p2p::{initialization::CommsInitializationError, services::liveness::error::LivenessError};
@@ -65,8 +69,12 @@ pub enum WalletError {
     ServiceInitializationError(#[from] ServiceInitializationError),
     #[error("Base Node Service error: {0}")]
     BaseNodeServiceError(#[from] BaseNodeServiceError),
+    #[error("Node ID error: `{0}`")]
+    NodeIdError(#[from] NodeIdError),
     #[error("Error performing wallet recovery: '{0}'")]
     WalletRecoveryError(String),
+    #[error("Shutdown Signal Received")]
+    Shutdown,
 }
 
 #[derive(Debug, Error)]

--- a/base_layer/wallet/src/tasks/wallet_recovery.rs
+++ b/base_layer/wallet/src/tasks/wallet_recovery.rs
@@ -26,49 +26,328 @@ use crate::{
     WalletSqlite,
 };
 use chrono::Utc;
-use futures::{channel::mpsc, SinkExt, StreamExt};
+use futures::{channel::mpsc, FutureExt, SinkExt, StreamExt};
 use log::*;
-use std::{cmp, convert::TryFrom};
-use tari_comms::{peer_manager::NodeId, types::CommsPublicKey};
+use std::{cmp, cmp::max, convert::TryFrom, time::Instant};
+use tari_comms::{peer_manager::NodeId, protocol::rpc::ClientStreaming, types::CommsPublicKey, PeerConnection};
 use tari_core::{
     base_node::sync::rpc::BaseNodeSyncRpcClient,
     blocks::BlockHeader,
-    proto::base_node::{SyncUtxosRequest, SyncUtxosResponse},
+    proto::base_node::{ChainMetadata, SyncUtxosRequest, SyncUtxosResponse},
     tari_utilities::Hashable,
     transactions::{tari_amount::MicroTari, transaction::TransactionOutput},
 };
 
+use tari_comms::protocol::rpc::RpcStatusCode;
+use tokio::time::{delay_for, Duration};
+
 pub const LOG_TARGET: &str = "wallet::recovery";
+
+const RPC_RETRIES_LIMIT: usize = 10;
 
 pub const RECOVERY_HEIGHT_KEY: &str = "recovery_height_progress";
 const RECOVERY_NUM_UTXOS_KEY: &str = "recovery_num_utxos";
 const RECOVERY_TOTAL_AMOUNT_KEY: &str = "recovery_total_amount";
-const RECOVERY_BATCH_SIZE: u64 = 10;
+const RECOVERY_BATCH_SIZE: u64 = 100;
 
 pub struct WalletRecoveryTask {
     wallet: WalletSqlite,
-    base_node_public_key: CommsPublicKey,
+    peer_seed_public_keys: Vec<CommsPublicKey>,
     event_sender: Option<mpsc::Sender<WalletRecoveryEvent>>,
     event_receiver: Option<mpsc::Receiver<WalletRecoveryEvent>>,
+    connection_retries_limit: usize,
+    connection_retries: usize,
+    rpc_retries: usize,
+    print_to_console: bool,
+    base_node_connection: Option<PeerConnection>,
+    base_node_public_key: CommsPublicKey,
+    sync_client_initialized: bool,
+    sync_client: Option<BaseNodeSyncRpcClient>,
 }
 
 impl WalletRecoveryTask {
-    pub fn new(wallet: WalletSqlite, base_node_public_key: CommsPublicKey) -> Self {
+    pub fn new(wallet: WalletSqlite, peer_seed_public_keys: Vec<CommsPublicKey>) -> Self {
         let (event_sender, event_receiver) = mpsc::channel(1000);
         Self {
             wallet,
-            base_node_public_key,
+            peer_seed_public_keys,
             event_sender: Some(event_sender),
             event_receiver: Some(event_receiver),
+            connection_retries_limit: 1,
+            connection_retries: 0,
+            rpc_retries: 1,
+            print_to_console: false,
+            base_node_connection: None,
+            base_node_public_key: CommsPublicKey::default(),
+            sync_client_initialized: false,
+            sync_client: None,
         }
+    }
+
+    pub fn set_connection_retries_limit(&mut self, connection_retries_limit: usize) {
+        self.connection_retries_limit = max(connection_retries_limit, 1);
+    }
+
+    pub fn set_print_to_console(&mut self, print_to_console: bool) {
+        self.print_to_console = print_to_console;
     }
 
     pub fn get_event_receiver(&mut self) -> Option<mpsc::Receiver<WalletRecoveryEvent>> {
         self.event_receiver.take()
     }
 
+    async fn get_connected_base_node_public_key(&mut self) -> Result<CommsPublicKey, WalletError> {
+        if !self.sync_client_initialized {
+            let _ = self.connect_sync_client().await;
+        }
+        Ok(self.base_node_public_key.clone())
+    }
+
+    async fn connect_sync_client(&mut self) -> Result<(), WalletError> {
+        let mut shutdown = self.wallet.comms.shutdown_signal().clone();
+        if !self.sync_client_initialized {
+            trace!(
+                target: LOG_TARGET,
+                "Peer seed public keys: {:?}",
+                self.peer_seed_public_keys
+            );
+            if self.peer_seed_public_keys.is_empty() {
+                return Err(WalletError::WalletRecoveryError(
+                    "No base node defined to connect to".to_string(),
+                ));
+            }
+        }
+        let mut select_new_base_node = false;
+        let mut last_base_node_public_key = if self.sync_client_initialized {
+            self.base_node_public_key.clone()
+        } else {
+            (&self.peer_seed_public_keys[self.peer_seed_public_keys.len() - 1]).clone()
+        };
+        self.rpc_retries = 1;
+        loop {
+            // Allow PRC connections to be retried N times before using up a retry
+            if self.rpc_retries > RPC_RETRIES_LIMIT {
+                self.rpc_retries = 1;
+                self.connection_retries += 1;
+            }
+            if self.connection_retries > self.connection_retries_limit {
+                return Err(WalletError::WalletRecoveryError(format!(
+                    "Could not connect to base node within the specified number of retries ({})",
+                    self.connection_retries_limit
+                )));
+            }
+
+            let mut reconnect_to_base_node = true;
+            if let Some(connection) = self.base_node_connection.clone() {
+                reconnect_to_base_node = !connection.is_connected();
+                trace!(
+                    target: LOG_TARGET,
+                    "Base node {} is connected {}",
+                    self.base_node_public_key.clone(),
+                    connection.is_connected(),
+                );
+            }
+
+            if reconnect_to_base_node {
+                // Select next base node in list to try and connect to, wrapping around
+                let mut new_base_node_public_key = last_base_node_public_key.clone();
+                if select_new_base_node {
+                    for i in 0..(self.peer_seed_public_keys.len()) {
+                        if self.peer_seed_public_keys[i] == last_base_node_public_key.clone() {
+                            if i != self.peer_seed_public_keys.len() - 1 {
+                                new_base_node_public_key = (&self.peer_seed_public_keys[i + 1]).clone();
+                            } else {
+                                new_base_node_public_key = (&self.peer_seed_public_keys[0]).clone();
+                            }
+                            last_base_node_public_key = new_base_node_public_key.clone();
+                            break;
+                        }
+                    }
+                }
+
+                // Attempt new base node connection
+                debug!(
+                    target: LOG_TARGET,
+                    "Trying to connect to {} (retries {} of {})",
+                    new_base_node_public_key,
+                    self.connection_retries,
+                    self.connection_retries_limit
+                );
+                if select_new_base_node && self.print_to_console {
+                    println!(
+                        "Trying to connect to {} (retries {} of {})",
+                        new_base_node_public_key.clone(),
+                        self.connection_retries,
+                        self.connection_retries_limit
+                    );
+                }
+                let base_node_node_id = NodeId::from_public_key(&new_base_node_public_key);
+                let mut connectivity_requester = self.wallet.comms.connectivity();
+                let delay = delay_for(Duration::from_secs(60));
+                futures::select! {
+                    dial_result = connectivity_requester.dial_peer(base_node_node_id.clone()).fuse() => {
+                        match dial_result {
+                            Ok(c) => {
+                                self.base_node_connection = Some(c);
+                                self.base_node_public_key = new_base_node_public_key.clone();
+                                select_new_base_node = false;
+                                trace!(
+                                    target: LOG_TARGET,
+                                    "New base node connection to {}",
+                                    self.base_node_public_key.clone(),
+                                );
+                            },
+                            Err(e) => {
+                                warn!(
+                                    target: LOG_TARGET,
+                                    "Base node connection error to {} (retries {} of {}): {}",
+                                    new_base_node_public_key.clone(),
+                                    self.connection_retries,
+                                    self.connection_retries_limit,
+                                    e
+                                );
+                                if self.print_to_console {
+                                    println!(
+                                        "Base node connection error to {} (retries {} of {}: {})",
+                                        new_base_node_public_key.clone(),
+                                        self.connection_retries,
+                                        self.connection_retries_limit,
+                                        e
+                                    );
+                                }
+                                select_new_base_node = true;
+                                self.connection_retries += 1;
+                                continue;
+                            },
+                        }
+                    },
+                    _ = delay.fuse() => {
+                        continue;
+                    },
+                    _ = shutdown => {
+                        info!(
+                            target: LOG_TARGET,
+                            "Wallet recovery shutting down because it received the shutdown signal",
+                        );
+                        return Err(WalletError::Shutdown)
+                    },
+                }
+            }
+
+            // Attempt new RPC connection to the connected base node
+            if let Some(mut connection) = self.base_node_connection.clone() {
+                if connection.is_connected() {
+                    self.rpc_retries += 1;
+                    self.sync_client = match connection
+                        .connect_rpc_using_builder(
+                            BaseNodeSyncRpcClient::builder().with_deadline(Duration::from_secs(60)),
+                        )
+                        .await
+                    {
+                        Ok(c) => Some(c),
+                        Err(e) => {
+                            warn!(
+                                target: LOG_TARGET,
+                                "RPC connection error to base node {}: {}", self.base_node_public_key, e
+                            );
+                            continue;
+                        },
+                    };
+                    if !self.sync_client_initialized {
+                        self.sync_client_initialized = true;
+                    }
+                    debug!(
+                        target: LOG_TARGET,
+                        "New RPC connection for base node {}",
+                        self.base_node_public_key.clone(),
+                    );
+                    return Ok(());
+                }
+            };
+        }
+    }
+
+    async fn get_chain_metadata(&mut self) -> Result<ChainMetadata, WalletError> {
+        loop {
+            if let Some(ref mut client) = self.sync_client {
+                match client
+                    .get_chain_metadata()
+                    .await
+                    .map_err(|e| WalletError::WalletRecoveryError(e.to_string()))
+                {
+                    Ok(r) => {
+                        return Ok(r);
+                    },
+                    Err(e) => {
+                        warn!(
+                            target: LOG_TARGET,
+                            "Error communicating to RPC client (get_chain_metadata): {}", e
+                        );
+                        // Note: `connect_sync_client()` will err with too many connection attempts, exiting loop
+                        let _ = self.connect_sync_client().await?;
+                        continue;
+                    },
+                };
+            }
+        }
+    }
+
+    async fn get_header_by_height(&mut self, height: u64) -> Result<tari_core::proto::core::BlockHeader, WalletError> {
+        loop {
+            if let Some(ref mut client) = self.sync_client {
+                match client
+                    .get_header_by_height(height)
+                    .await
+                    .map_err(|e| WalletError::WalletRecoveryError(e.to_string()))
+                {
+                    Ok(h) => {
+                        return Ok(h);
+                    },
+                    Err(e) => {
+                        warn!(
+                            target: LOG_TARGET,
+                            "Error communicating to RPC client (get_header_by_height): {}", e
+                        );
+                        // Note: `connect_sync_client()` will err with too many connection attempts, exiting loop
+                        let _ = self.connect_sync_client().await?;
+                        continue;
+                    },
+                };
+            }
+        }
+    }
+
+    async fn get_sync_utxos_stream(
+        &mut self,
+        request: SyncUtxosRequest,
+    ) -> Result<ClientStreaming<SyncUtxosResponse>, WalletError>
+    {
+        loop {
+            if let Some(ref mut client) = self.sync_client {
+                match client
+                    .sync_utxos(request.clone())
+                    .await
+                    .map_err(|e| WalletError::WalletRecoveryError(e.to_string()))
+                {
+                    Ok(s) => {
+                        return Ok(s);
+                    },
+                    Err(e) => {
+                        warn!(
+                            target: LOG_TARGET,
+                            "Error communicating to RPC client (sync_utxos): {}", e
+                        );
+                        // Note: `connect_sync_client()` will err with too many connection attempts, exiting loop
+                        let _ = self.connect_sync_client().await?;
+                        continue;
+                    },
+                };
+            }
+        }
+    }
+
     pub async fn run(mut self) -> Result<(), WalletError> {
-        let mut event_sender = match self.event_sender {
+        let mut event_sender = match self.event_sender.clone() {
             Some(sender) => sender,
             None => {
                 return Err(WalletError::WalletRecoveryError(
@@ -77,30 +356,17 @@ impl WalletRecoveryTask {
             },
         };
 
-        let public_key = self.wallet.comms.node_identity().public_key().clone();
-
-        let base_node_node_id = NodeId::from_public_key(&self.base_node_public_key);
-
-        let mut conn = self.wallet.comms.connectivity().dial_peer(base_node_node_id).await?;
-        let mut client = conn
-            .connect_rpc::<BaseNodeSyncRpcClient>()
-            .await
-            .map_err(|e| WalletError::WalletRecoveryError(e.to_string()))?;
-
         event_sender
             .send(WalletRecoveryEvent::ConnectedToBaseNode(
-                self.base_node_public_key.clone(),
+                self.get_connected_base_node_public_key().await?,
             ))
             .await
             .map_err(|e| WalletError::WalletRecoveryError(e.to_string()))?;
 
-        loop {
-            let chain_metadata = client
-                .get_chain_metadata()
-                .await
-                .map_err(|e| WalletError::WalletRecoveryError(e.to_string()))?;
-            let chain_height = chain_metadata.height_of_longest_chain();
+        let chain_metadata = &self.get_chain_metadata().await?.clone();
+        let mut chain_height = chain_metadata.height_of_longest_chain();
 
+        'main: loop {
             let start_height = match self
                 .wallet
                 .db
@@ -123,6 +389,10 @@ impl WalletRecoveryTask {
                 },
             };
 
+            if start_height + RECOVERY_BATCH_SIZE >= chain_height {
+                let chain_metadata = &self.get_chain_metadata().await?;
+                chain_height = chain_metadata.height_of_longest_chain();
+            }
             let next_height = cmp::min(start_height + RECOVERY_BATCH_SIZE, chain_height);
 
             info!(
@@ -138,10 +408,8 @@ impl WalletRecoveryTask {
                 ((start_height as f32) * 100f32 / (chain_height as f32)).round() as u32
             );
 
-            let start_header = client
-                .get_header_by_height(start_height)
-                .await
-                .map_err(|e| WalletError::WalletRecoveryError(e.to_string()))?;
+            let timer = Instant::now();
+            let start_header = self.get_header_by_height(start_height).await?;
             let start_header = BlockHeader::try_from(start_header).map_err(WalletError::WalletRecoveryError)?;
             let start_mmr_leaf_index = if start_height == 0 {
                 0
@@ -149,67 +417,85 @@ impl WalletRecoveryTask {
                 start_header.output_mmr_size
             };
 
-            let end_header = client
-                .get_header_by_height(next_height)
-                .await
-                .map_err(|e| WalletError::WalletRecoveryError(e.to_string()))?;
+            let end_header = self.get_header_by_height(next_height).await?;
             let end_header = BlockHeader::try_from(end_header).map_err(WalletError::WalletRecoveryError)?;
-
             let end_header_hash = end_header.hash();
+            let fetch_header_info_time = timer.elapsed().as_millis();
+
             let request = SyncUtxosRequest {
                 start: start_mmr_leaf_index,
                 end_header_hash,
             };
-            let mut output_stream = client
-                .sync_utxos(request)
-                .await
-                .map_err(|e| WalletError::WalletRecoveryError(e.to_string()))?;
-
+            let mut processing_time = 0u128;
             let mut num_utxos = 0;
             let mut total_amount = MicroTari::from(0);
+            'stream_utxos: loop {
+                let mut output_stream = self.get_sync_utxos_stream(request.clone()).await?;
+                while let Some(result) = output_stream.next().await {
+                    match result {
+                        Ok(response) => {
+                            let timer = Instant::now();
 
-            while let Some(response) = output_stream.next().await {
-                let response: SyncUtxosResponse =
-                    response.map_err(|e| WalletError::WalletRecoveryError(e.to_string()))?;
+                            let outputs: Vec<TransactionOutput> = response
+                                .utxos
+                                .into_iter()
+                                .filter_map(|utxo| {
+                                    if let Some(output) = utxo.output {
+                                        TransactionOutput::try_from(output).ok()
+                                    } else {
+                                        None
+                                    }
+                                })
+                                .collect();
 
-                let outputs: Vec<TransactionOutput> = response
-                    .utxos
-                    .into_iter()
-                    .filter_map(|utxo| {
-                        if let Some(output) = utxo.output {
-                            TransactionOutput::try_from(output).ok()
-                        } else {
-                            None
-                        }
-                    })
-                    .collect();
+                            let unblinded_outputs = self.wallet.output_manager_service.rewind_outputs(outputs).await?;
 
-                let unblinded_outputs = self.wallet.output_manager_service.rewind_outputs(outputs).await?;
-
-                if !unblinded_outputs.is_empty() {
-                    for uo in unblinded_outputs {
-                        match self
-                            .wallet
-                            .import_utxo(
-                                uo.value,
-                                &uo.spending_key,
-                                &public_key,
-                                format!("Recovered on {}.", Utc::now().naive_utc()),
-                            )
-                            .await
-                        {
-                            Ok(_) => {
-                                num_utxos += 1;
-                                total_amount += uo.value;
-                            },
-                            Err(WalletError::OutputManagerError(OutputManagerError::OutputManagerStorageError(
-                                OutputManagerStorageError::DuplicateOutput,
-                            ))) => debug!(target: LOG_TARGET, "Recovered output already in database"),
-                            Err(e) => return Err(e),
-                        }
+                            if !unblinded_outputs.is_empty() {
+                                for uo in unblinded_outputs {
+                                    match self
+                                        .wallet
+                                        .import_utxo(
+                                            uo.value,
+                                            &uo.spending_key,
+                                            &self.wallet.comms.node_identity().public_key().clone(),
+                                            format!("Recovered on {}.", Utc::now().naive_utc()),
+                                        )
+                                        .await
+                                    {
+                                        Ok(_) => {
+                                            num_utxos += 1;
+                                            total_amount += uo.value;
+                                        },
+                                        Err(WalletError::OutputManagerError(
+                                            OutputManagerError::OutputManagerStorageError(
+                                                OutputManagerStorageError::DuplicateOutput,
+                                            ),
+                                        )) => debug!(target: LOG_TARGET, "Recovered output already in database"),
+                                        Err(e) => return Err(e),
+                                    }
+                                }
+                            }
+                            processing_time += timer.elapsed().as_millis();
+                        },
+                        Err(e) => {
+                            if e.status_code() == RpcStatusCode::Timeout {
+                                debug!(target: LOG_TARGET, "Fetch UTXOs RPC response timeout, retrying...");
+                                continue 'stream_utxos;
+                            };
+                            return Err(WalletError::WalletRecoveryError(e.to_string()));
+                        },
                     }
                 }
+                break 'stream_utxos;
             }
+            let fetch_utxos_time = timer.elapsed().as_millis() - fetch_header_info_time - processing_time;
+            trace!(
+                target: LOG_TARGET,
+                "Timings - RPC fetch header info: {} ms, RPC fetch UTXOs: {} ms, Bulletproofs rewinding: {} ms",
+                fetch_header_info_time,
+                fetch_utxos_time,
+                processing_time,
+            );
 
             let current_num_utxos = match self
                 .wallet
@@ -271,7 +557,7 @@ impl WalletRecoveryTask {
                     .await
                     .map_err(|e| WalletError::WalletRecoveryError(e.to_string()))?;
 
-                break;
+                break 'main;
             } else {
                 self.wallet
                     .db

--- a/base_layer/wallet_ffi/src/lib.rs
+++ b/base_layer/wallet_ffi/src/lib.rs
@@ -5468,7 +5468,8 @@ pub unsafe extern "C" fn wallet_start_recovery(
         return false;
     }
 
-    let mut recovery_task = WalletRecoveryTask::new((*wallet).wallet.clone(), (*base_node_public_key).clone());
+    let peer_seed_public_keys: Vec<TariPublicKey> = vec![(*base_node_public_key).clone()];
+    let mut recovery_task = WalletRecoveryTask::new((*wallet).wallet.clone(), peer_seed_public_keys);
 
     let event_stream = match recovery_task.get_event_receiver() {
         None => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- Resiliency improvements:
  - Added multiple retries connecting to a peer seed node instead of only trying once.
  - Added reconnect logic for every RPC call if the RPC connection drops.
- Improved logging.
- Wallet recovery time improvements:
  - Efficiency improvements with chain metadata RPC calls; a significant overhead was measured if done for every block of UTXOs to stream. This is not done for every block of UTXOs to stream anymore, just once at the start and then close to the end.
  - Efficiency improvements when streaming UTXOs; a significant overhead was measured in fetching start and end headers at the heights in question for every block of UTXOs to stream. Block size was increased 10 fold to reduce the amount of calls fetching headers.

**Issues for a next PR:**
- The recovered amount after recovery is reduced when connecting to a new base node and performing UTXO validation; many recovered UTXOs are invalidated straight away.
- This new issue seen, but not often: `[wallet::recovery] WARN  Error communicating to RPC client (get_header_by_height): Error performing wallet recovery: 'Failed to decode message: failed to decode Protobuf message: BlockHeader.version: invalid wire type: LengthDelimited (expected Varint)'`
- RPC response times seem generally slow; 2.4s average to fetch both the start and end headers for the new block of UTXOs to stream.

## Motivation and Context
Wallet recovery was not resilient in the face of disconnecting base nodes and RPC errors and also slower than it could have been.

## How Has This Been Tested?
Many test runs performing wallet recovery.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [X] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [X] I'm merging against the `development` branch.
* [X] I ran `cargo-fmt --all` before pushing.
* [X] I ran `cargo test` successfully before submitting my PR.
* [X] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
