### PR TITLE
get_transaction_info no longer errors if any transaction is not found

### DIFF
--- a/applications/tari_app_grpc/proto/wallet.proto
+++ b/applications/tari_app_grpc/proto/wallet.proto
@@ -103,6 +103,7 @@ message TransactionInfo {
     google.protobuf.Timestamp timestamp = 10;
     string message = 11;
     bool valid = 12;
+    bool is_found = 13;
 }
 
 enum TransactionDirection {

--- a/applications/tari_app_grpc/src/conversions/transaction.rs
+++ b/applications/tari_app_grpc/src/conversions/transaction.rs
@@ -24,7 +24,7 @@ use crate::tari_rpc as grpc;
 use std::convert::{TryFrom, TryInto};
 use tari_core::transactions::transaction::Transaction;
 use tari_crypto::{ristretto::RistrettoSecretKey, tari_utilities::ByteArray};
-use tari_wallet::transaction_service::storage::models;
+use tari_wallet::{output_manager_service::TxId, transaction_service::storage::models};
 
 impl From<Transaction> for grpc::Transaction {
     fn from(source: Transaction) -> Self {
@@ -72,6 +72,16 @@ impl From<models::TransactionDirection> for grpc::TransactionDirection {
             Unknown => grpc::TransactionDirection::Unknown,
             Inbound => grpc::TransactionDirection::Inbound,
             Outbound => grpc::TransactionDirection::Outbound,
+        }
+    }
+}
+
+impl grpc::TransactionInfo {
+    pub fn not_found(tx_id: TxId) -> Self {
+        Self {
+            tx_id,
+            is_found: false,
+            ..Default::default()
         }
     }
 }


### PR DESCRIPTION
Changes get_transaction_info to mark an item as found/not_found using a
boolean flag, rather than returning an error.
