### PR TITLE
[common] Add rpc_max_simultaneous_sessions setting to config

### DIFF
--- a/common/config/presets/windows.toml
+++ b/common/config/presets/windows.toml
@@ -61,6 +61,9 @@
 # The timeout (s) for requesting other base node services (min value = 10 s, default value = 180 s).
 #service_request_timeout = 180
 
+# The maximum simultaneous comms RPC sessions allowed. Setting this to -1 will allow unlimited sessions.
+# rpc_max_simultaneous_sessions = 1000
+
 ########################################################################################################################
 #                                                                                                                      #
 #                                          Wallet Configuration Options                                                #

--- a/common/config/tari_config_example.toml
+++ b/common/config/tari_config_example.toml
@@ -61,6 +61,9 @@
 # The timeout (s) for requesting other base node services (min value = 10 s, default value = 180 s).
 #service_request_timeout = 180
 
+# The maximum simultaneous comms RPC sessions allowed. Setting this to -1 will allow unlimited sessions.
+# rpc_max_simultaneous_sessions = 1000
+
 ########################################################################################################################
 #                                                                                                                      #
 #                                          Wallet Configuration Options                                                #

--- a/common/src/configuration/global.rs
+++ b/common/src/configuration/global.rs
@@ -53,6 +53,7 @@ pub struct GlobalConfig {
     pub allow_test_addresses: bool,
     pub listnener_liveness_max_sessions: usize,
     pub listener_liveness_allowlist_cidrs: Vec<String>,
+    pub rpc_max_simultaneous_sessions: Option<usize>,
     pub data_dir: PathBuf,
     pub db_type: DatabaseType,
     pub db_config: LMDBConfig,
@@ -501,6 +502,19 @@ fn convert_node_config(network: Network, cfg: Config) -> Result<GlobalConfig, Co
         .map(|values| values.iter().map(ToString::to_string).collect())
         .unwrap_or_else(|_| vec!["127.0.0.1/32".to_string()]);
 
+    let key = "common.rpc_max_simultaneous_sessions";
+    let rpc_max_simultaneous_sessions = cfg
+        .get_int(key)
+        .map_err(|e| ConfigurationError::new(key, &e.to_string()))
+        .and_then(|v| match v {
+            -1 => Ok(None),
+            n if n.is_positive() => Ok(Some(n as usize)),
+            v => Err(ConfigurationError::new(
+                key,
+                &format!("invalid value {} for rpc_max_simultaneous_sessions", v),
+            )),
+        })?;
+
     let key = "common.buffer_size_base_node";
     let buffer_size_base_node = cfg
         .get_int(&key)
@@ -582,6 +596,7 @@ fn convert_node_config(network: Network, cfg: Config) -> Result<GlobalConfig, Co
         allow_test_addresses,
         listnener_liveness_max_sessions: liveness_max_sessions,
         listener_liveness_allowlist_cidrs: liveness_allowlist_cidrs,
+        rpc_max_simultaneous_sessions,
         data_dir,
         db_type,
         db_config,

--- a/common/src/configuration/utils.rs
+++ b/common/src/configuration/utils.rs
@@ -55,6 +55,7 @@ pub fn default_config(bootstrap: &ConfigBootstrap) -> Config {
     cfg.set_default("common.message_cache_size", 10).unwrap();
     cfg.set_default("common.message_cache_ttl", 1440).unwrap();
     cfg.set_default("common.peer_allowlist", Vec::<String>::new()).unwrap();
+    cfg.set_default("common.rpc_max_simultaneous_sessions", 1000).unwrap();
     cfg.set_default("common.liveness_max_sessions", 0).unwrap();
     cfg.set_default(
         "common.peer_database ",

--- a/comms/src/protocol/rpc/router.rs
+++ b/comms/src/protocol/rpc/router.rs
@@ -93,13 +93,13 @@ impl<A, B> Router<A, B> {
 
     /// Sets the maximum number of sessions this node will allow before rejecting the request to connect
     pub fn with_maximum_concurrent_sessions(mut self, limit: usize) -> Self {
-        self.server = self.server.with_maximum_concurrent_sessions(limit);
+        self.server = self.server.with_maximum_simultaneous_sessions(limit);
         self
     }
 
     /// Allows unlimited (memory-bound) sessions. This should probably only be used for scalability testing.
     pub fn with_unlimited_concurrent_sessions(mut self) -> Self {
-        self.server = self.server.with_unlimited_concurrent_sessions();
+        self.server = self.server.with_unlimited_simultaneous_sessions();
         self
     }
 

--- a/comms/src/protocol/rpc/server.rs
+++ b/comms/src/protocol/rpc/server.rs
@@ -76,7 +76,7 @@ pub trait NamedProtocolService {
 
 #[derive(Debug, Clone)]
 pub struct RpcServer {
-    maximum_concurrent_sessions: Option<usize>,
+    maximum_simultaneous_sessions: Option<usize>,
     minimum_client_deadline: Duration,
     handshake_timeout: Duration,
     shutdown_signal: OptionalShutdownSignal,
@@ -98,13 +98,13 @@ impl RpcServer {
         Router::new(self, service)
     }
 
-    pub fn with_maximum_concurrent_sessions(mut self, limit: usize) -> Self {
-        self.maximum_concurrent_sessions = Some(limit);
+    pub fn with_maximum_simultaneous_sessions(mut self, limit: usize) -> Self {
+        self.maximum_simultaneous_sessions = Some(limit);
         self
     }
 
-    pub fn with_unlimited_concurrent_sessions(mut self) -> Self {
-        self.maximum_concurrent_sessions = None;
+    pub fn with_unlimited_simultaneous_sessions(mut self) -> Self {
+        self.maximum_simultaneous_sessions = None;
         self
     }
 
@@ -144,7 +144,7 @@ impl RpcServer {
 impl Default for RpcServer {
     fn default() -> Self {
         Self {
-            maximum_concurrent_sessions: Some(1000),
+            maximum_simultaneous_sessions: Some(1000),
             minimum_client_deadline: Duration::from_secs(1),
             handshake_timeout: Duration::from_secs(15),
             shutdown_signal: Default::default(),
@@ -179,7 +179,7 @@ where
     ) -> Self
     {
         Self {
-            executor: OptionallyBoundedExecutor::from_current(config.maximum_concurrent_sessions),
+            executor: OptionallyBoundedExecutor::from_current(config.maximum_simultaneous_sessions),
             config,
             service,
             protocol_notifications: Some(protocol_notifications),

--- a/comms/src/protocol/rpc/test/smoke.rs
+++ b/comms/src/protocol/rpc/test/smoke.rs
@@ -88,7 +88,7 @@ async fn setup_service<T: GreetingRpc>(
     let (context, _) = create_mocked_rpc_context();
     let server_hnd = task::spawn(
         RpcServer::new()
-            .with_maximum_concurrent_sessions(num_concurrent_sessions)
+            .with_maximum_simultaneous_sessions(num_concurrent_sessions)
             .with_minimum_client_deadline(Duration::from_secs(0))
             .with_shutdown_signal(shutdown.to_signal())
             .add_service(GreetingServer::new(service))
@@ -336,7 +336,7 @@ impl GreetingRpc for GreetingService {
         task::spawn(async move {
             let iter = greetings.into_iter().map(Ok);
             let mut stream = stream::iter(iter)
-                // "Extra" Result::Ok is to satisfy send_all 
+                // "Extra" Result::Ok is to satisfy send_all
                 .map(Ok);
             match tx.send_all(&mut stream).await {
                 Ok(_) => {},


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Adds `common.rpc_max_simultaneous_sessions` setting to config with a default of
1000.  Setting to `-1` means there is no session limit.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Seed nodes may want to support many thousands of simultaneous RPC sessions.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
'lightly' tested on existing base node. The RPC session restriction mechanism itself is not new and has been unit tested.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [ ] I'm merging against the `development` branch.
* [ ] I ran `cargo-fmt --all` before pushing.
* [ ] I ran `cargo test` successfully before submitting my PR.
* [ ] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
