### PR TITLE
[Wallet] Persist transaction confirmations for complete transaction and expose via FFI

### DIFF
--- a/base_layer/wallet/migrations/2021-04-01-081220_add_transaction_confirmations/down.sql
+++ b/base_layer/wallet/migrations/2021-04-01-081220_add_transaction_confirmations/down.sql
@@ -1,0 +1,22 @@
+PRAGMA foreign_keys=off;
+ALTER TABLE completed_transactions RENAME TO completed_transactions_old;
+CREATE TABLE completed_transactions (
+                                        tx_id INTEGER PRIMARY KEY NOT NULL,
+                                        source_public_key BLOB NOT NULL,
+                                        destination_public_key BLOB NOT NULL,
+                                        amount INTEGER NOT NULL,
+                                        fee INTEGER NOT NULL,
+                                        transaction_protocol TEXT NOT NULL,
+                                        status INTEGER NOT NULL,
+                                        message TEXT NOT NULL,
+                                        timestamp DATETIME NOT NULL,
+                                        cancelled INTEGER NOT NULL DEFAULT 0,
+                                        direction INTEGER NULL DEFAULT NULL,
+                                        coinbase_block_height INTEGER NULL DEFAULT NULL,
+                                        send_count INTEGER NOT NULL DEFAULT 0,
+                                        last_send_timestamp DATETIME NULL DEFAULT NULL,
+                                        valid INTEGER NOT NULL DEFAULT 0,
+);
+INSERT INTO completed_transactions (tx_id, source_public_key, destination_public_key, amount, fee, transaction_protocol, status, message, timestamp, cancelled, direction, coinbase_block_height, send_count, last_send_timestamp, valid)
+SELECT tx_id, source_public_key, destination_public_key, amount, fee, transaction_protocol, status, message, timestamp, cancelled, direction, coinbase_block_height, send_count, last_send_timestamp, valid
+FROM completed_transactions_old;

--- a/base_layer/wallet/migrations/2021-04-01-081220_add_transaction_confirmations/up.sql
+++ b/base_layer/wallet/migrations/2021-04-01-081220_add_transaction_confirmations/up.sql
@@ -1,0 +1,2 @@
+ALTER TABLE completed_transactions
+    ADD COLUMN confirmations INTEGER NULL DEFAULT NULL;

--- a/base_layer/wallet/src/schema.rs
+++ b/base_layer/wallet/src/schema.rs
@@ -22,6 +22,7 @@ table! {
         send_count -> Integer,
         last_send_timestamp -> Nullable<Timestamp>,
         valid -> Integer,
+        confirmations -> Nullable<BigInt>,
     }
 }
 

--- a/base_layer/wallet/src/transaction_service/protocols/transaction_broadcast_protocol.rs
+++ b/base_layer/wallet/src/transaction_service/protocols/transaction_broadcast_protocol.rs
@@ -488,6 +488,12 @@ where TBackend: TransactionBackend + 'static
 
         // Mined?
         if response.location == TxLocation::Mined {
+            self.resources
+                .db
+                .set_transaction_confirmations(self.tx_id, response.confirmations)
+                .await
+                .map_err(|e| TransactionServiceProtocolError::new(self.tx_id, TransactionServiceError::from(e)))?;
+
             if response.confirmations >= self.resources.config.num_confirmations_required as u64 {
                 info!(
                     target: LOG_TARGET,

--- a/base_layer/wallet/src/transaction_service/storage/database.rs
+++ b/base_layer/wallet/src/transaction_service/storage/database.rs
@@ -120,6 +120,8 @@ pub trait TransactionBackend: Send + Sync + Clone {
     fn remove_encryption(&self) -> Result<(), TransactionStorageError>;
     /// Increment the send counter and timestamp of a transaction
     fn increment_send_count(&self, tx_id: TxId) -> Result<(), TransactionStorageError>;
+    /// Update a tranasctions number of confirmations
+    fn update_confirmations(&self, tx_id: TxId, confirmations: u64) -> Result<(), TransactionStorageError>;
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -722,6 +724,19 @@ where T: TransactionBackend + 'static
     {
         let db_clone = self.db.clone();
         tokio::task::spawn_blocking(move || db_clone.set_completed_transaction_validity(tx_id, valid))
+            .await
+            .map_err(|err| TransactionStorageError::BlockingTaskSpawnError(err.to_string()))??;
+        Ok(())
+    }
+
+    pub async fn set_transaction_confirmations(
+        &self,
+        tx_id: TxId,
+        confirmations: u64,
+    ) -> Result<(), TransactionStorageError>
+    {
+        let db_clone = self.db.clone();
+        tokio::task::spawn_blocking(move || db_clone.update_confirmations(tx_id, confirmations))
             .await
             .map_err(|err| TransactionStorageError::BlockingTaskSpawnError(err.to_string()))??;
         Ok(())

--- a/base_layer/wallet/src/transaction_service/storage/models.rs
+++ b/base_layer/wallet/src/transaction_service/storage/models.rs
@@ -201,6 +201,7 @@ pub struct CompletedTransaction {
     pub send_count: u32,
     pub last_send_timestamp: Option<NaiveDateTime>,
     pub valid: bool,
+    pub confirmations: Option<u64>,
 }
 
 impl CompletedTransaction {
@@ -235,6 +236,7 @@ impl CompletedTransaction {
             send_count: 0,
             last_send_timestamp: None,
             valid: true,
+            confirmations: None,
         }
     }
 }
@@ -327,6 +329,7 @@ impl From<OutboundTransaction> for CompletedTransaction {
             send_count: 0,
             last_send_timestamp: None,
             valid: true,
+            confirmations: None,
         }
     }
 }
@@ -349,11 +352,13 @@ impl From<InboundTransaction> for CompletedTransaction {
             send_count: 0,
             last_send_timestamp: None,
             valid: true,
+            confirmations: None,
         }
     }
 }
 
 #[derive(Debug)]
+#[allow(clippy::large_enum_variant)]
 pub enum WalletTransaction {
     PendingInbound(InboundTransaction),
     PendingOutbound(OutboundTransaction),

--- a/base_layer/wallet/src/transaction_service/storage/sqlite_db.rs
+++ b/base_layer/wallet/src/transaction_service/storage/sqlite_db.rs
@@ -517,6 +517,7 @@ impl TransactionBackend for TransactionServiceSqliteDatabase {
                             send_count: None,
                             last_send_timestamp: None,
                             valid: None,
+                            confirmations: None,
                         }),
                         &(*conn),
                     )?;
@@ -546,6 +547,7 @@ impl TransactionBackend for TransactionServiceSqliteDatabase {
                         send_count: None,
                         last_send_timestamp: None,
                         valid: None,
+                        confirmations: None,
                     }),
                     &(*conn),
                 )?;
@@ -655,6 +657,7 @@ impl TransactionBackend for TransactionServiceSqliteDatabase {
                     send_count: None,
                     last_send_timestamp: None,
                     valid: None,
+                    confirmations: None,
                 }),
                 &(*conn),
             )?;
@@ -811,6 +814,7 @@ impl TransactionBackend for TransactionServiceSqliteDatabase {
                 send_count: Some(tx.send_count + 1),
                 last_send_timestamp: Some(Some(Utc::now().naive_utc())),
                 valid: None,
+                confirmations: None,
             };
             tx.update(update, &conn)?;
         } else if let Ok(tx) = OutboundTransactionSql::find(tx_id, &conn) {
@@ -889,6 +893,22 @@ impl TransactionBackend for TransactionServiceSqliteDatabase {
         match CompletedTransactionSql::find_by_cancelled(tx_id, false, &(*conn)) {
             Ok(v) => {
                 v.set_validity(valid, &(*conn))?;
+            },
+            Err(TransactionStorageError::DieselError(DieselError::NotFound)) => {
+                return Err(TransactionStorageError::ValueNotFound(DbKey::CompletedTransaction(
+                    tx_id,
+                )));
+            },
+            Err(e) => return Err(e),
+        };
+        Ok(())
+    }
+
+    fn update_confirmations(&self, tx_id: u64, confirmations: u64) -> Result<(), TransactionStorageError> {
+        let conn = self.database_connection.acquire_lock();
+        match CompletedTransactionSql::find_by_cancelled(tx_id, false, &(*conn)) {
+            Ok(v) => {
+                v.update_confirmations(confirmations, &(*conn))?;
             },
             Err(TransactionStorageError::DieselError(DieselError::NotFound)) => {
                 return Err(TransactionStorageError::ValueNotFound(DbKey::CompletedTransaction(
@@ -1292,6 +1312,7 @@ struct CompletedTransactionSql {
     send_count: i32,
     last_send_timestamp: Option<NaiveDateTime>,
     valid: i32,
+    confirmations: Option<i64>,
 }
 
 impl CompletedTransactionSql {
@@ -1388,6 +1409,7 @@ impl CompletedTransactionSql {
                 send_count: None,
                 last_send_timestamp: None,
                 valid: None,
+                confirmations: None,
             },
             conn,
         )?;
@@ -1406,6 +1428,7 @@ impl CompletedTransactionSql {
                 send_count: None,
                 last_send_timestamp: None,
                 valid: None,
+                confirmations: None,
             },
             conn,
         )?;
@@ -1424,6 +1447,7 @@ impl CompletedTransactionSql {
                 send_count: None,
                 last_send_timestamp: None,
                 valid: None,
+                confirmations: None,
             },
             conn,
         )?;
@@ -1442,6 +1466,7 @@ impl CompletedTransactionSql {
                 send_count: None,
                 last_send_timestamp: None,
                 valid: Some(valid as i32),
+                confirmations: None,
             },
             conn,
         )?;
@@ -1460,6 +1485,31 @@ impl CompletedTransactionSql {
                 send_count: None,
                 last_send_timestamp: None,
                 valid: None,
+                confirmations: None,
+            },
+            conn,
+        )?;
+
+        Ok(())
+    }
+
+    pub fn update_confirmations(
+        &self,
+        confirmations: u64,
+        conn: &SqliteConnection,
+    ) -> Result<(), TransactionStorageError>
+    {
+        self.update(
+            UpdateCompletedTransactionSql {
+                status: None,
+                timestamp: None,
+                cancelled: None,
+                direction: None,
+                transaction_protocol: Some(self.transaction_protocol.clone()),
+                send_count: None,
+                last_send_timestamp: None,
+                valid: None,
+                confirmations: Some(Some(confirmations as i64)),
             },
             conn,
         )?;
@@ -1508,6 +1558,7 @@ impl TryFrom<CompletedTransaction> for CompletedTransactionSql {
             send_count: c.send_count as i32,
             last_send_timestamp: c.last_send_timestamp,
             valid: c.valid as i32,
+            confirmations: c.confirmations.map(|ic| ic as i64),
         })
     }
 }
@@ -1534,6 +1585,7 @@ impl TryFrom<CompletedTransactionSql> for CompletedTransaction {
             send_count: c.send_count as u32,
             last_send_timestamp: c.last_send_timestamp,
             valid: c.valid != 0,
+            confirmations: c.confirmations.map(|ic| ic as u64),
         })
     }
 }
@@ -1547,6 +1599,7 @@ pub struct UpdateCompletedTransaction {
     send_count: Option<u32>,
     last_send_timestamp: Option<Option<NaiveDateTime>>,
     valid: Option<bool>,
+    confirmations: Option<Option<u64>>,
 }
 
 #[derive(AsChangeset)]
@@ -1560,6 +1613,7 @@ pub struct UpdateCompletedTransactionSql {
     send_count: Option<i32>,
     last_send_timestamp: Option<Option<NaiveDateTime>>,
     valid: Option<i32>,
+    confirmations: Option<Option<i64>>,
 }
 
 /// Map a Rust friendly UpdateCompletedTransaction to the Sql data type form
@@ -1574,6 +1628,7 @@ impl From<UpdateCompletedTransaction> for UpdateCompletedTransactionSql {
             send_count: u.send_count.map(|c| c as i32),
             last_send_timestamp: u.last_send_timestamp,
             valid: u.valid.map(|c| c as i32),
+            confirmations: u.confirmations.map(|c| c.map(|ic| ic as i64)),
         }
     }
 }
@@ -1776,6 +1831,7 @@ mod test {
             send_count: 0,
             last_send_timestamp: None,
             valid: true,
+            confirmations: None,
         };
         let completed_tx2 = CompletedTransaction {
             tx_id: 3,
@@ -1793,6 +1849,7 @@ mod test {
             send_count: 0,
             last_send_timestamp: None,
             valid: true,
+            confirmations: None,
         };
 
         CompletedTransactionSql::try_from(completed_tx1.clone())
@@ -1908,6 +1965,7 @@ mod test {
             send_count: 0,
             last_send_timestamp: None,
             valid: true,
+            confirmations: None,
         };
 
         let coinbase_tx2 = CompletedTransaction {
@@ -1926,6 +1984,7 @@ mod test {
             send_count: 0,
             last_send_timestamp: None,
             valid: true,
+            confirmations: None,
         };
 
         let coinbase_tx3 = CompletedTransaction {
@@ -1944,6 +2003,7 @@ mod test {
             send_count: 0,
             last_send_timestamp: None,
             valid: true,
+            confirmations: None,
         };
 
         CompletedTransactionSql::try_from(coinbase_tx1)
@@ -1979,6 +2039,7 @@ mod test {
                     send_count: None,
                     last_send_timestamp: None,
                     valid: None,
+                    confirmations: None,
                 },
                 &conn,
             )
@@ -2064,6 +2125,7 @@ mod test {
             send_count: 0,
             last_send_timestamp: None,
             valid: true,
+            confirmations: None,
         };
 
         let mut completed_tx_sql = CompletedTransactionSql::try_from(completed_tx.clone()).unwrap();
@@ -2137,6 +2199,7 @@ mod test {
             send_count: 0,
             last_send_timestamp: None,
             valid: true,
+            confirmations: None,
         };
         let completed_tx_sql = CompletedTransactionSql::try_from(completed_tx).unwrap();
         completed_tx_sql.commit(&conn).unwrap();

--- a/base_layer/wallet/tests/transaction_service/service.rs
+++ b/base_layer/wallet/tests/transaction_service/service.rs
@@ -1471,6 +1471,7 @@ fn test_power_mode_updates() {
         send_count: 0,
         last_send_timestamp: None,
         valid: true,
+        confirmations: None,
     };
 
     let completed_tx2 = CompletedTransaction {
@@ -1489,6 +1490,7 @@ fn test_power_mode_updates() {
         send_count: 0,
         last_send_timestamp: None,
         valid: true,
+        confirmations: None,
     };
 
     backend
@@ -4336,6 +4338,7 @@ fn broadcast_all_completed_transactions_on_startup() {
         send_count: 0,
         last_send_timestamp: None,
         valid: true,
+        confirmations: None,
     };
 
     let completed_tx2 = CompletedTransaction {
@@ -4665,6 +4668,7 @@ fn only_start_one_tx_broadcast_protocol_at_a_time() {
         send_count: 0,
         last_send_timestamp: None,
         valid: true,
+        confirmations: None,
     };
 
     backend
@@ -4724,6 +4728,7 @@ fn dont_broadcast_invalid_transactions() {
         send_count: 0,
         last_send_timestamp: None,
         valid: false,
+        confirmations: None,
     };
 
     backend

--- a/base_layer/wallet/tests/transaction_service/storage.rs
+++ b/base_layer/wallet/tests/transaction_service/storage.rs
@@ -241,6 +241,7 @@ pub fn test_db_backend<T: TransactionBackend + 'static>(backend: T) {
             send_count: 0,
             last_send_timestamp: None,
             valid: true,
+            confirmations: None,
         });
         runtime
             .block_on(db.complete_outbound_transaction(outbound_txs[i].tx_id, completed_txs[i].clone()))
@@ -283,6 +284,15 @@ pub fn test_db_backend<T: TransactionBackend + 'static>(backend: T) {
         .unwrap();
     assert_eq!(retrieved_completed_tx.send_count, 2);
     assert!(retrieved_completed_tx.last_send_timestamp.is_some());
+    assert!(retrieved_completed_tx.confirmations.is_none());
+
+    runtime
+        .block_on(db.set_transaction_confirmations(retrieved_completed_tx.tx_id, 1))
+        .unwrap();
+    let retrieved_completed_tx = runtime
+        .block_on(db.get_completed_transaction(completed_txs[0].tx_id))
+        .unwrap();
+    assert_eq!(retrieved_completed_tx.confirmations, Some(1));
 
     let any_completed_tx = runtime
         .block_on(db.get_any_transaction(completed_txs[0].tx_id))

--- a/base_layer/wallet/tests/transaction_service/transaction_protocols.rs
+++ b/base_layer/wallet/tests/transaction_service/transaction_protocols.rs
@@ -259,6 +259,9 @@ async fn tx_broadcast_protocol_submit_success() {
 
     add_transaction_to_database(1, 1 * T, true, None, resources.db.clone()).await;
 
+    let db_completed_tx = resources.db.get_completed_transaction(1).await.unwrap();
+    assert!(db_completed_tx.confirmations.is_none());
+
     let protocol = TransactionBroadcastProtocol::new(
         1,
         resources.clone(),
@@ -330,6 +333,7 @@ async fn tx_broadcast_protocol_submit_success() {
     // Check transaction status is updated
     let db_completed_tx = resources.db.get_completed_transaction(1).await.unwrap();
     assert_eq!(db_completed_tx.status, TransactionStatus::MinedUnconfirmed);
+    assert_eq!(db_completed_tx.confirmations, Some(1));
 
     // Set base node response to mined and confirmed but not synced
     rpc_service_state.set_transaction_query_response(TxQueryResponse {
@@ -365,6 +369,10 @@ async fn tx_broadcast_protocol_submit_success() {
     // Check transaction status is updated
     let db_completed_tx = resources.db.get_completed_transaction(1).await.unwrap();
     assert_eq!(db_completed_tx.status, TransactionStatus::MinedConfirmed);
+    assert_eq!(
+        db_completed_tx.confirmations,
+        Some(resources.config.num_confirmations_required)
+    );
 
     // Check that the appropriate events were emitted
     let mut delay = delay_for(Duration::from_secs(1)).fuse();

--- a/base_layer/wallet_ffi/src/lib.rs
+++ b/base_layer/wallet_ffi/src/lib.rs
@@ -1916,6 +1916,39 @@ pub unsafe extern "C" fn completed_transaction_is_outbound(
     false
 }
 
+/// Gets the number of confirmations of a TariCompletedTransaction
+///
+/// ## Arguments
+/// `tx` - The TariCompletedTransaction
+/// `error_out` - Pointer to an int which will be modified to an error code should one occur, may not be null. Functions
+/// as an out parameter.
+///
+/// ## Returns
+/// `c_ulonglong` - Returns the number of confirmations of a Completed Transaction
+///
+/// # Safety
+/// None
+#[no_mangle]
+pub unsafe extern "C" fn completed_transaction_get_confirmations(
+    tx: *mut TariCompletedTransaction,
+    error_out: *mut c_int,
+) -> c_ulonglong
+{
+    let mut error = 0;
+    ptr::swap(error_out, &mut error as *mut c_int);
+
+    if tx.is_null() {
+        error = LibWalletError::from(InterfaceError::NullError("tx".to_string())).code;
+        ptr::swap(error_out, &mut error as *mut c_int);
+        return 0;
+    }
+
+    match (*tx).confirmations {
+        None => 0,
+        Some(c) => c,
+    }
+}
+
 /// Frees memory for a TariCompletedTransaction
 ///
 /// ## Arguments
@@ -6537,6 +6570,8 @@ mod test {
                 let id_completed = completed_transactions_get_at(&mut (*ffi_completed_txs), x, error_ptr);
                 let id_completed_get =
                     wallet_get_completed_transaction_by_id(&mut (*alice_wallet), (*id_completed).tx_id, error_ptr);
+                let confirmations = completed_transaction_get_confirmations(id_completed, error_ptr);
+                assert_eq!(confirmations, 0);
                 if (*id_completed).status == TransactionStatus::MinedUnconfirmed {
                     assert_eq!((*id_completed), (*id_completed_get));
                     assert_eq!((*id_completed_get).status, TransactionStatus::MinedUnconfirmed);

--- a/base_layer/wallet_ffi/wallet.h
+++ b/base_layer/wallet_ffi/wallet.h
@@ -261,6 +261,9 @@ bool completed_transaction_is_valid(struct TariCompletedTransaction *tx,int* err
 // i.e the transaction was originally sent from the wallet
 bool completed_transaction_is_outbound(struct TariCompletedTransaction *tx,int* error_out);
 
+/// Gets the number of confirmations of a TariCompletedTransaction
+unsigned long long completed_transaction_get_confirmations(struct TariCompletedTransaction *transaction,int* error_out);
+
 // Frees memory for a TariCompletedTransaction
 void completed_transaction_destroy(struct TariCompletedTransaction *transaction);
 


### PR DESCRIPTION
## Description
This PR add persistence of a CompletedTransactions confirmations as it is monitored. It also provides the accessor method in the FFI so that a client application can use the data.


@kukabi 

## How Has This Been Tested?
Tests have been updated to test the changes to the DB, Transaction monitoring and FFI accessor method.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch.
* [x] I ran `cargo-fmt --all` before pushing.
* [x] I ran `cargo test` successfully before submitting my PR.
* [x] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
