### PR TITLE
Add database concurrency check

### DIFF
--- a/base_layer/core/src/base_node/sync/block_sync/synchronizer.rs
+++ b/base_layer/core/src/base_node/sync/block_sync/synchronizer.rs
@@ -214,7 +214,7 @@ impl<B: BlockchainBackend + 'static> BlockSynchronizer<B> {
             let timer = Instant::now();
             self.db
                 .write_transaction()
-                .insert_block(block.clone())
+                .insert_block_body(block.clone())
                 .set_best_block(
                     block.height(),
                     header_hash,

--- a/base_layer/core/src/chain_storage/async_db.rs
+++ b/base_layer/core/src/chain_storage/async_db.rs
@@ -320,11 +320,8 @@ impl<'a, B: BlockchainBackend + 'static> AsyncDbTransaction<'a, B> {
         self
     }
 
-    /// Add the BlockHeader and contents of a `Block` (i.e. inputs, outputs and kernels) to the database.
-    /// If the `BlockHeader` already exists, then just the contents are updated along with the relevant accumulated
-    /// data.
-    pub fn insert_block(&mut self, block: Arc<ChainBlock>) -> &mut Self {
-        self.transaction.insert_block(block);
+    pub fn insert_block_body(&mut self, block: Arc<ChainBlock>) -> &mut Self {
+        self.transaction.insert_block_body(block);
         self
     }
 

--- a/base_layer/core/src/chain_storage/blockchain_database.rs
+++ b/base_layer/core/src/chain_storage/blockchain_database.rs
@@ -1184,10 +1184,11 @@ fn insert_block(txn: &mut DbTransaction, block: Arc<ChainBlock>) -> Result<(), C
         txn.insert_monero_seed_height(&monero_seed, block.block.header.height);
     }
 
-    // Update metadata
+    let height = block.height();
     let accumulated_difficulty = block.accumulated_data.total_accumulated_difficulty;
-    txn.set_best_block(block.block.header.height, block_hash, accumulated_difficulty)
-        .insert_block(block);
+    txn.insert_header(block.block.header.clone(), block.accumulated_data.clone())
+        .insert_block_body(block)
+        .set_best_block(height, block_hash, accumulated_difficulty);
 
     Ok(())
 }
@@ -1459,7 +1460,7 @@ fn rewind_to_height<T: BlockchainBackend>(
             ))
         })?;
 
-    debug!(
+    info!(
         target: LOG_TARGET,
         "Rewinding headers from height {} to {}",
         last_header_height,
@@ -1480,7 +1481,7 @@ fn rewind_to_height<T: BlockchainBackend>(
     }
 
     let mut removed_blocks = Vec::with_capacity(steps_back as usize);
-    debug!(
+    info!(
         target: LOG_TARGET,
         "Rewinding blocks from height {} to {}",
         last_block_height,
@@ -1500,7 +1501,7 @@ fn rewind_to_height<T: BlockchainBackend>(
     let (last_header, header_accumulated_data) = db.fetch_header_and_accumulated_data(height)?;
 
     for h in 0..steps_back {
-        debug!(target: LOG_TARGET, "Deleting block {}", last_block_height - h,);
+        info!(target: LOG_TARGET, "Deleting block {}", last_block_height - h,);
         let block = fetch_block(db, last_block_height - h)?;
         let block = Arc::new(block.clone().try_into_chain_block()?);
         txn.delete_block(block.block.hash());
@@ -1735,7 +1736,7 @@ fn reorganize_chain<T: BlockchainBackend>(
     for block in chain {
         let mut txn = DbTransaction::new();
         let block_hash_hex = block.accumulated_data.hash.to_hex();
-        txn.delete(DbKey::OrphanBlock(block.accumulated_data.hash.clone()));
+        txn.delete_orphan(block.accumulated_data.hash.clone());
         if let Err(e) = block_validator.validate_body_for_valid_orphan(&block, backend) {
             warn!(
                 target: LOG_TARGET,
@@ -1789,7 +1790,7 @@ fn restore_reorged_chain<T: BlockchainBackend>(
     // Add removed blocks in the reverse order that they were removed
     // See: https://github.com/tari-project/tari/issues/2182
     for block in previous_chain.into_iter().rev() {
-        txn.delete(DbKey::OrphanBlock(block.accumulated_data.hash.clone()));
+        txn.delete_orphan(block.accumulated_data.hash.clone());
         insert_block(&mut txn, block)?;
     }
     db.write(txn)?;
@@ -1923,7 +1924,7 @@ fn find_orphan_descendant_tips_of<T: BlockchainBackend>(
 // Discard the the orphan block from the orphan pool that corresponds to the provided block hash.
 fn remove_orphan<T: BlockchainBackend>(db: &mut T, hash: HashOutput) -> Result<(), ChainStorageError> {
     let mut txn = DbTransaction::new();
-    txn.delete(DbKey::OrphanBlock(hash));
+    txn.delete_orphan(hash);
     db.write(txn)
 }
 

--- a/base_layer/core/src/chain_storage/db_transaction.rs
+++ b/base_layer/core/src/chain_storage/db_transaction.rs
@@ -70,19 +70,14 @@ impl DbTransaction {
         DbTransaction::default()
     }
 
-    /// A general insert request. There are convenience functions for specific delete queries.
-    pub fn delete(&mut self, delete: DbKey) -> &mut Self {
-        self.operations.push(WriteOperation::Delete(delete));
-        self
-    }
-
     pub fn delete_orphan(&mut self, hash: HashOutput) -> &mut Self {
-        self.delete(DbKey::OrphanBlock(hash))
+        self.operations.push(WriteOperation::DeleteOrphan(hash));
+        self
     }
 
     /// Delete a block header at the given height
     pub fn delete_header(&mut self, height: u64) -> &mut Self {
-        self.operations.push(WriteOperation::Delete(DbKey::BlockHeader(height)));
+        self.operations.push(WriteOperation::DeleteHeader(height));
         self
     }
 
@@ -187,8 +182,8 @@ impl DbTransaction {
     /// Add the BlockHeader and contents of a `Block` (i.e. inputs, outputs and kernels) to the database.
     /// If the `BlockHeader` already exists, then just the contents are updated along with the relevant accumulated
     /// data.
-    pub fn insert_block(&mut self, block: Arc<ChainBlock>) -> &mut Self {
-        self.operations.push(WriteOperation::InsertBlock { block });
+    pub fn insert_block_body(&mut self, block: Arc<ChainBlock>) -> &mut Self {
+        self.operations.push(WriteOperation::InsertBlockBody { block });
         self
     }
 
@@ -265,7 +260,7 @@ pub enum WriteOperation {
     InsertHeader {
         header: Box<ChainHeader>,
     },
-    InsertBlock {
+    InsertBlockBody {
         block: Arc<ChainBlock>,
     },
     InsertInput {
@@ -289,7 +284,8 @@ pub enum WriteOperation {
         proof_hash: HashOutput,
         mmr_position: u32,
     },
-    Delete(DbKey),
+    DeleteHeader(u64),
+    DeleteOrphan(HashOutput),
     DeleteBlock(HashOutput),
     DeleteOrphanChainTip(HashOutput),
     InsertOrphanChainTip(HashOutput),
@@ -340,9 +336,9 @@ impl fmt::Display for WriteOperation {
                 header.header.height,
                 header.accumulated_data.hash.to_hex()
             ),
-            InsertBlock { block } => write!(
+            InsertBlockBody { block } => write!(
                 f,
-                "InsertBlock({}, {})",
+                "InsertBlockBody({}, {})",
                 block.accumulated_data.hash.to_hex(),
                 block.block.body.to_counts_string(),
             ),
@@ -379,7 +375,6 @@ impl fmt::Display for WriteOperation {
                 header_hash.to_hex(),
                 mmr_position
             ),
-            Delete(key) => write!(f, "Delete({})", key),
             DeleteOrphanChainTip(hash) => write!(f, "DeleteOrphanChainTip({})", hash.to_hex()),
             InsertOrphanChainTip(hash) => write!(f, "InsertOrphanChainTip({})", hash.to_hex()),
             DeleteBlock(hash) => write!(f, "DeleteBlock({})", hash.to_hex()),
@@ -430,6 +425,8 @@ impl fmt::Display for WriteOperation {
             ),
             SetPruningHorizonConfig(pruning_horizon) => write!(f, "Set config: pruning horizon to {}", pruning_horizon),
             SetPrunedHeight { height, .. } => write!(f, "Set pruned height to {}", height),
+            DeleteHeader(height) => write!(f, "Delete header at height: {}", height),
+            DeleteOrphan(hash) => write!(f, "Delete orphan with hash: {}", hash.to_hex()),
         }
     }
 }

--- a/base_layer/core/src/chain_storage/lmdb_db/lmdb_db.rs
+++ b/base_layer/core/src/chain_storage/lmdb_db/lmdb_db.rs
@@ -172,19 +172,10 @@ impl LMDBDatabase {
             trace!(target: LOG_TARGET, "[apply_db_transaction] WriteOperation: {}", op);
             match op {
                 InsertOrphanBlock(block) => self.insert_orphan_block(&write_txn, &block)?,
-                Delete(delete) => self.op_delete(&write_txn, delete)?,
                 InsertHeader { header } => {
-                    let height = header.header.height;
-                    if !self.insert_header(&write_txn, &header.header, &header.accumulated_data)? {
-                        return Err(ChainStorageError::InvalidOperation(format!(
-                            "Duplicate `BlockHeader` key `{}`",
-                            height
-                        )));
-                    }
+                    self.insert_header(&write_txn, &header.header, &header.accumulated_data)?;
                 },
-                InsertBlock { block } => {
-                    // TODO: Sort out clones
-                    self.insert_header(&write_txn, &block.block.header, &block.accumulated_data)?;
+                InsertBlockBody { block } => {
                     self.insert_block_body(&write_txn, &block.block.header, block.block.body.clone())?;
                 },
                 InsertKernel {
@@ -231,6 +222,12 @@ impl LMDBDatabase {
                     );
                     self.insert_input(&write_txn, header_hash, *input, mmr_position)?;
                 },
+                DeleteHeader(height) => {
+                    self.delete_header(&write_txn, height)?;
+                },
+                DeleteOrphan(hash) => {
+                    self.delete_orphan(&write_txn, hash)?;
+                },
                 DeleteOrphanChainTip(hash) => {
                     lmdb_delete(&write_txn, &self.orphan_chain_tips_db, &hash)?;
                 },
@@ -241,9 +238,10 @@ impl LMDBDatabase {
                     let hash_hex = hash.to_hex();
                     debug!(target: LOG_TARGET, "Deleting block `{}`", hash_hex);
                     debug!(target: LOG_TARGET, "Deleting UTXOs...");
-                    if let Some(height) = self.fetch_height_from_hash(&write_txn, &hash)? {
-                        lmdb_delete(&write_txn, &self.block_accumulated_data_db, &height)?;
-                    }
+                    let height =
+                        self.fetch_height_from_hash(&write_txn, &hash)
+                            .or_not_found("Block", "hash", hash.to_hex())?;
+                    lmdb_delete(&write_txn, &self.block_accumulated_data_db, &height)?;
                     let rows = lmdb_delete_keys_starting_with::<TransactionOutputRowData>(
                         &write_txn,
                         &self.utxos_db,
@@ -617,23 +615,22 @@ impl LMDBDatabase {
         }
 
         lmdb_insert_dup(txn, &self.orphan_parent_map_index, &block.header.prev_hash, &k)?;
-        lmdb_replace(txn, &self.orphans_db, k.as_slice(), &block)?;
+        lmdb_insert(txn, &self.orphans_db, k.as_slice(), &block, "orphans_db")?;
 
         Ok(())
     }
 
-    /// Inserts the header and header accumulated data. True is returned if a new header is inserted, otherwise false if
-    /// the header already exists
+    /// Inserts the header and header accumulated data.
     fn insert_header(
         &mut self,
         txn: &WriteTransaction<'_>,
         header: &BlockHeader,
         accum_data: &BlockHeaderAccumulatedData,
-    ) -> Result<bool, ChainStorageError>
+    ) -> Result<(), ChainStorageError>
     {
         if let Some(current_header_at_height) = lmdb_get::<_, BlockHeader>(txn, &self.headers_db, &header.height)? {
             let hash = current_header_at_height.hash();
-            if current_header_at_height.hash() != accum_data.hash {
+            if hash != accum_data.hash {
                 return Err(ChainStorageError::InvalidOperation(format!(
                     "There is a different header stored at height {} already. New header ({}), current header: ({})",
                     header.height,
@@ -641,10 +638,49 @@ impl LMDBDatabase {
                     accum_data.hash.to_hex()
                 )));
             }
-            return Ok(false);
+            return Err(ChainStorageError::InvalidOperation(format!(
+                "The header at height {} already exists. Existing header hash: {}",
+                header.height,
+                hash.to_hex()
+            )));
         }
 
-        lmdb_replace(&txn, &self.header_accumulated_data_db, &header.height, &accum_data)?;
+        // Check that the current height is still header.height - 1 and that no other threads have inserted
+        if let Some(ref last_header) = self.fetch_last_header_in_txn(&txn)? {
+            if last_header.height != header.height.saturating_sub(1) {
+                return Err(ChainStorageError::InvalidOperation(format!(
+                    "Attempted to insert a header out of order. Was expecting chain height to be {} but current last \
+                     header height is {}",
+                    header.height - 1,
+                    last_header.height
+                )));
+            }
+
+            // Possibly remove this check later
+            let hash = last_header.hash();
+            if hash != header.prev_hash {
+                return Err(ChainStorageError::InvalidOperation(format!(
+                    "Attempted to insert a block header at height {} that didn't form a chain. Previous block \
+                     hash:{}, new block's previous hash:{}",
+                    header.height,
+                    hash.to_hex(),
+                    header.prev_hash.to_hex()
+                )));
+            }
+        } else if header.height != 0 {
+            return Err(ChainStorageError::InvalidOperation(format!(
+                "The first header inserted must have height 0. Height provided: {}",
+                header.height
+            )));
+        }
+
+        lmdb_insert(
+            &txn,
+            &self.header_accumulated_data_db,
+            &header.height,
+            &accum_data,
+            "header_accumulated_data_db",
+        )?;
         lmdb_insert(
             txn,
             &self.block_hashes_db,
@@ -667,72 +703,81 @@ impl LMDBDatabase {
             &(header.height, header.hash().as_slice()),
             "output_mmr_size_index",
         )?;
-        Ok(true)
+        Ok(())
     }
 
-    fn op_delete(&mut self, txn: &WriteTransaction<'_>, key: DbKey) -> Result<(), ChainStorageError> {
-        match key {
-            DbKey::BlockHeader(k) => {
-                let val: Option<BlockHeader> = lmdb_get(txn, &self.headers_db, &k)?;
-                if let Some(v) = val {
-                    let hash = v.hash();
-                    // Check that there are no utxos or kernels linked to this.
-
-                    if !lmdb_fetch_keys_starting_with::<TransactionKernelRowData>(
-                        hash.to_hex().as_str(),
-                        &txn,
-                        &self.kernels_db,
-                    )?
-                    .is_empty()
-                    {
-                        return Err(ChainStorageError::InvalidOperation(
-                            "Cannot delete header because there are kernels linked to it".to_string(),
-                        ));
-                    }
-                    if !lmdb_fetch_keys_starting_with::<TransactionOutputRowData>(
-                        hash.to_hex().as_str(),
-                        &txn,
-                        &self.utxos_db,
-                    )?
-                    .is_empty()
-                    {
-                        return Err(ChainStorageError::InvalidOperation(
-                            "Cannot delete header because there are utxos linked to it".to_string(),
-                        ));
-                    }
-
-                    lmdb_delete(&txn, &self.block_hashes_db, &hash)?;
-                    lmdb_delete(&txn, &self.headers_db, &k)?;
-                    lmdb_delete(&txn, &self.header_accumulated_data_db, &k)?;
-                    lmdb_delete(&txn, &self.kernel_mmr_size_index, &v.kernel_mmr_size.to_be_bytes())?;
-                    lmdb_delete(&txn, &self.output_mmr_size_index, &v.output_mmr_size.to_be_bytes())?;
-                }
-            },
-            DbKey::BlockHash(_) => {
-                unimplemented!("Not supported. Use delete by height");
-            },
-            DbKey::OrphanBlock(k) => {
-                if let Some(orphan) = lmdb_get::<_, Block>(&txn, &self.orphans_db, &k)? {
-                    let parent_hash = orphan.header.prev_hash;
-                    lmdb_delete_key_value(&txn, &self.orphan_parent_map_index, parent_hash.as_slice(), &k)?;
-                    let tip: Option<Vec<u8>> = lmdb_get(&txn, &self.orphan_chain_tips_db, &k)?;
-                    if tip.is_some() {
-                        if lmdb_get::<_, Block>(&txn, &self.orphans_db, parent_hash.as_slice())?.is_some() {
-                            lmdb_insert(
-                                &txn,
-                                &self.orphan_chain_tips_db,
-                                parent_hash.as_slice(),
-                                &parent_hash,
-                                "orphan_chain_tips_db",
-                            )?;
-                        }
-                        lmdb_delete(&txn, &self.orphan_chain_tips_db, &k)?;
-                    }
-                    lmdb_delete(&txn, &self.orphans_db, k.as_slice())?;
-                }
-            },
+    fn delete_header(&mut self, txn: &WriteTransaction<'_>, height: u64) -> Result<(), ChainStorageError> {
+        if self.fetch_block_accumulated_data(&txn, height)?.is_some() {
+            return Err(ChainStorageError::InvalidOperation(format!(
+                "Attempted to delete header at height {} while block accumulated data still exists",
+                height
+            )));
         }
 
+        let header =
+            self.fetch_last_header_in_txn(&txn)
+                .or_not_found("BlockHeader", "height", "last_header".to_string())?;
+        if header.height != height {
+            return Err(ChainStorageError::InvalidOperation(format!(
+                "Attempted to delete a header at height {} that was not the last header (which is at height {}). \
+                 Headers must be deleted in reverse order.",
+                height, header.height
+            )));
+        }
+
+        // TODO: This can maybe be removed for performance if the check for block_accumulated_data existing is
+        // sufficient
+
+        let hash = header.hash();
+        // Check that there are no utxos or kernels linked to this.
+
+        if !lmdb_fetch_keys_starting_with::<TransactionKernelRowData>(hash.to_hex().as_str(), &txn, &self.kernels_db)?
+            .is_empty()
+        {
+            return Err(ChainStorageError::InvalidOperation(format!(
+                "Cannot delete header {} ({}) because there are kernels linked to it",
+                header.height,
+                hash.to_hex()
+            )));
+        }
+        if !lmdb_fetch_keys_starting_with::<TransactionOutputRowData>(hash.to_hex().as_str(), &txn, &self.utxos_db)?
+            .is_empty()
+        {
+            return Err(ChainStorageError::InvalidOperation(format!(
+                "Cannot delete header at height {} ({}) because there are UTXOs linked to it",
+                height,
+                hash.to_hex()
+            )));
+        }
+
+        lmdb_delete(&txn, &self.block_hashes_db, &hash)?;
+        lmdb_delete(&txn, &self.headers_db, &height)?;
+        lmdb_delete(&txn, &self.header_accumulated_data_db, &height)?;
+        lmdb_delete(&txn, &self.kernel_mmr_size_index, &header.kernel_mmr_size.to_be_bytes())?;
+        lmdb_delete(&txn, &self.output_mmr_size_index, &header.output_mmr_size.to_be_bytes())?;
+
+        Ok(())
+    }
+
+    fn delete_orphan(&mut self, txn: &WriteTransaction<'_>, hash: HashOutput) -> Result<(), ChainStorageError> {
+        if let Some(orphan) = lmdb_get::<_, Block>(&txn, &self.orphans_db, hash.as_slice())? {
+            let parent_hash = orphan.header.prev_hash;
+            lmdb_delete_key_value(&txn, &self.orphan_parent_map_index, parent_hash.as_slice(), &hash)?;
+            let tip: Option<Vec<u8>> = lmdb_get(&txn, &self.orphan_chain_tips_db, hash.as_slice())?;
+            if tip.is_some() {
+                if lmdb_get::<_, Block>(&txn, &self.orphans_db, parent_hash.as_slice())?.is_some() {
+                    lmdb_insert(
+                        &txn,
+                        &self.orphan_chain_tips_db,
+                        parent_hash.as_slice(),
+                        &parent_hash,
+                        "orphan_chain_tips_db",
+                    )?;
+                }
+                lmdb_delete(&txn, &self.orphan_chain_tips_db, hash.as_slice())?;
+            }
+            lmdb_delete(&txn, &self.orphans_db, hash.as_slice())?;
+        }
         Ok(())
     }
 
@@ -750,6 +795,24 @@ impl LMDBDatabase {
             block_hash.to_hex(),
             body.to_counts_string()
         );
+
+        // Check that the database has not been changed by another thread
+        // 1. The header we are inserting for matches the header at that height
+        let current_header_at_height = lmdb_get::<_, BlockHeader>(txn, &self.headers_db, &header.height).or_not_found(
+            "BlockHeader",
+            "height",
+            header.height.to_string(),
+        )?;
+        let hash = current_header_at_height.hash();
+        if hash != block_hash {
+            return Err(ChainStorageError::InvalidOperation(format!(
+                "Could not insert this block body because there is a different header stored at height {}. New header \
+                 ({}), current header: ({})",
+                header.height,
+                hash.to_hex(),
+                block_hash.to_hex()
+            )));
+        }
 
         let (inputs, outputs, kernels) = body.dissolve();
 
@@ -826,7 +889,7 @@ impl LMDBDatabase {
         }
         output_mmr.compress();
 
-        self.update_block_accumulated_data(
+        self.insert_block_accumulated_data(
             txn,
             header.height,
             &BlockAccumulatedData::new(
@@ -839,6 +902,23 @@ impl LMDBDatabase {
         )?;
 
         Ok(())
+    }
+
+    #[allow(clippy::ptr_arg)]
+    fn insert_block_accumulated_data(
+        &mut self,
+        txn: &WriteTransaction<'_>,
+        header_height: u64,
+        data: &BlockAccumulatedData,
+    ) -> Result<(), ChainStorageError>
+    {
+        lmdb_insert(
+            &txn,
+            &self.block_accumulated_data_db,
+            &header_height,
+            data,
+            "block_accumulated_data_db",
+        )
     }
 
     #[allow(clippy::ptr_arg)]
@@ -901,6 +981,10 @@ impl LMDBDatabase {
     ) -> Result<Option<BlockHeaderAccumulatedData>, ChainStorageError>
     {
         lmdb_get(&txn, &self.header_accumulated_data_db, &height)
+    }
+
+    fn fetch_last_header_in_txn(&self, txn: &ConstTransaction<'_>) -> Result<Option<BlockHeader>, ChainStorageError> {
+        lmdb_last(&txn, &self.headers_db)
     }
 }
 
@@ -1508,7 +1592,7 @@ impl BlockchainBackend for LMDBDatabase {
     /// Finds and returns the last stored header.
     fn fetch_last_header(&self) -> Result<BlockHeader, ChainStorageError> {
         let txn = ReadTransaction::new(&*self.env).map_err(|e| ChainStorageError::AccessError(e.to_string()))?;
-        lmdb_last(&txn, &self.headers_db)?.ok_or_else(|| {
+        self.fetch_last_header_in_txn(&txn)?.ok_or_else(|| {
             ChainStorageError::InvalidOperation("Cannot fetch last header because database is empty".to_string())
         })
     }
@@ -1658,7 +1742,7 @@ impl BlockchainBackend for LMDBDatabase {
                 height,
                 block_hash.to_hex()
             );
-            txn.delete(DbKey::OrphanBlock(block_hash.clone()));
+            txn.delete_orphan(block_hash.clone());
         }
         self.write(txn)?;
 

--- a/base_layer/core/tests/chain_storage_tests/chain_backend.rs
+++ b/base_layer/core/tests/chain_storage_tests/chain_backend.rs
@@ -109,7 +109,7 @@ fn lmdb_insert_contains_delete_and_fetch_orphan() {
     }
 
     let mut txn = DbTransaction::new();
-    txn.delete(DbKey::OrphanBlock(hash.clone()));
+    txn.delete_orphan(hash.clone());
     assert!(db.write(txn).is_ok());
     assert_eq!(db.contains(&DbKey::OrphanBlock(hash)).unwrap(), false);
 }

--- a/base_layer/core/tests/chain_storage_tests/chain_storage.rs
+++ b/base_layer/core/tests/chain_storage_tests/chain_storage.rs
@@ -87,12 +87,9 @@ fn insert_and_fetch_header() {
     let store = create_test_blockchain_db();
     let genesis_block = store.fetch_tip_header().unwrap();
     let mut header1 = BlockHeader::from_previous(&genesis_block.header).unwrap();
-    let mut header2 = BlockHeader::from_previous(&header1).unwrap();
 
     header1.kernel_mmr_size += 1;
     header1.output_mmr_size += 1;
-    header2.kernel_mmr_size += 2;
-    header2.output_mmr_size += 2;
 
     let chain1 = store
         .create_chain_header_if_valid(header1.clone(), &genesis_block)
@@ -101,6 +98,9 @@ fn insert_and_fetch_header() {
     store
         .insert_valid_headers(vec![(header1.clone(), chain1.accumulated_data.clone())])
         .unwrap();
+    let mut header2 = BlockHeader::from_previous(&header1).unwrap();
+    header2.kernel_mmr_size += 2;
+    header2.output_mmr_size += 2;
     let chain2 = store.create_chain_header_if_valid(header2.clone(), &chain1).unwrap();
 
     store


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Add database concurrency check to make sure that another thread hasn't altered the database since we had read the data. 
Specifically we check that we can:
- only delete the latest header
- only insert a header at the tip
- only insert a block body if the header has been inserted
- only delete a header if the block body has been deleted 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
If you mine and submit a block to a node while it is syncing headers, it would replace the block and header that was there already, and then continue inserting data. This can lead to an incorrect chain of `header`->`previous header`, which I believe leads to the target difficulty being incorrect

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [ ] I'm merging against the `development` branch.
* [ ] I ran `cargo-fmt --all` before pushing.
* [ ] I ran `cargo test` successfully before submitting my PR.
* [ ] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
