### PR TITLE
Add wallet recovery cucumber test, seed words to file

### DIFF
--- a/applications/tari_console_wallet/src/recovery.rs
+++ b/applications/tari_console_wallet/src/recovery.rs
@@ -59,6 +59,19 @@ pub fn prompt_private_key_from_seed_words() -> Result<PrivateKey, ExitCodes> {
     }
 }
 
+/// Return secret key matching the seed words.
+pub fn get_private_key_from_seed_words(seed_words: Vec<String>) -> Result<PrivateKey, ExitCodes> {
+    debug!(target: LOG_TARGET, "Return secret key matching the provided seed words");
+    match to_secretkey(&seed_words) {
+        Ok(key) => Ok(key),
+        Err(e) => {
+            let err_msg = format!("MnemonicError parsing seed words: {}", e);
+            debug!(target: LOG_TARGET, "{}", err_msg);
+            Err(ExitCodes::RecoveryError(err_msg))
+        },
+    }
+}
+
 /// Recovers wallet funds by connecting to a given base node peer, downloading the transaction outputs stored in the
 /// blockchain, and attempting to rewind them. Any outputs that are successfully rewound are then imported into the
 /// wallet.

--- a/common/src/configuration/bootstrap.rs
+++ b/common/src/configuration/bootstrap.rs
@@ -123,6 +123,12 @@ pub struct ConfigBootstrap {
     /// Force wallet recovery
     #[structopt(long, alias("recover"))]
     pub recovery: bool,
+    /// Supply the optional wallet seed words for recovery on the command line
+    #[structopt(long, alias("seed_words"))]
+    pub seed_words: Option<String>,
+    /// Supply the optional file name to save the wallet seed words into
+    #[structopt(long, alias("seed_words_file_name"), parse(from_os_str))]
+    pub seed_words_file_name: Option<PathBuf>,
     /// Wallet notify script
     #[structopt(long, alias("notify"))]
     pub wallet_notify: Option<PathBuf>,
@@ -150,6 +156,8 @@ impl Default for ConfigBootstrap {
             password: None,
             change_password: false,
             recovery: false,
+            seed_words: None,
+            seed_words_file_name: None,
             wallet_notify: None,
             miner_max_blocks: None,
             miner_min_diff: None,
@@ -326,6 +334,10 @@ mod test {
             "no-config-file-created",
             "--command",
             "no-command-provided",
+            "--seed-words-file-name",
+            "no-seed-words-file-name-provided",
+            "--seed-words",
+            "purse soup tornado success arch expose submit",
         ])
         .expect("failed to process arguments");
         assert!(bootstrap.init);
@@ -336,6 +348,14 @@ mod test {
         assert_eq!(bootstrap.log_config.to_str(), Some("no-log-config-file-created"));
         assert_eq!(bootstrap.config.to_str(), Some("no-config-file-created"));
         assert_eq!(bootstrap.command.unwrap(), "no-command-provided");
+        assert_eq!(
+            bootstrap.seed_words_file_name.unwrap().to_str(),
+            Some("no-seed-words-file-name-provided")
+        );
+        assert_eq!(
+            bootstrap.seed_words.unwrap().as_str(),
+            "purse soup tornado success arch expose submit"
+        );
 
         // Test command line argument aliases
         let bootstrap = ConfigBootstrap::from_iter_safe(vec![
@@ -344,16 +364,28 @@ mod test {
             "no-temp-path-created",
             "--log_config",
             "no-log-config-file-created",
+            "--seed_words_file_name",
+            "no-seed-words-file-name-provided",
+            "--seed_words",
+            "crunch zone nasty work zoo december three",
         ])
         .expect("failed to process arguments");
         assert_eq!(bootstrap.base_path.to_str(), Some("no-temp-path-created"));
         assert_eq!(bootstrap.log_config.to_str(), Some("no-log-config-file-created"));
+        assert_eq!(
+            bootstrap.seed_words_file_name.unwrap().to_str(),
+            Some("no-seed-words-file-name-provided")
+        );
+        assert_eq!(
+            bootstrap.seed_words.unwrap().as_str(),
+            "crunch zone nasty work zoo december three"
+        );
         let bootstrap = ConfigBootstrap::from_iter_safe(vec!["", "--base-dir", "no-temp-path-created"])
             .expect("failed to process arguments");
         assert_eq!(bootstrap.base_path.to_str(), Some("no-temp-path-created"));
-        let bootstrap = ConfigBootstrap::from_iter_safe(vec!["", "--base_dir", "no-temp-path-created"])
+        let bootstrap = ConfigBootstrap::from_iter_safe(vec!["", "--base_dir", "no-temp-path-created-again"])
             .expect("failed to process arguments");
-        assert_eq!(bootstrap.base_path.to_str(), Some("no-temp-path-created"));
+        assert_eq!(bootstrap.base_path.to_str(), Some("no-temp-path-created-again"));
 
         // Check if log configuration file environment variable is recognized in the bootstrap
         // Note: This cannot be tested in parallel with any other `ConfigBootstrap::from_iter_safe` command

--- a/integration_tests/README.md
+++ b/integration_tests/README.md
@@ -25,13 +25,13 @@
   npm test
   ```
 
-- To run all tests and generate the reports:
+- To run all tests and generate the reports (\*nix):
 
   ```
   ./run-tests.sh
   ```
 
-- To run a specific test, add `-- --name <REGEXP>` to the command line.
+- To run a specific test, add `-- --name <REGEXP>` to the command line:
 
 ```shell
   # eg: run a specific test
@@ -58,5 +58,15 @@
 
 ## Code Contribution
 
-[prettier](https://prettier.io/) is used for JS code formatting. To ensure that your code is correctly
-formatted, run `npm run fmt` to format your code in-place. Alternatively, use a prettier plugin for your favourite IDE.
+[Prettier](https://prettier.io/) is used for JS code formatting. To ensure that your code is correctly
+formatted, run the following to format or check your code in-place:
+
+- Enforce \*nix style line endings, i.e `lf` only:
+  - `npm run fmt`
+  - `npm run check-fmt`
+- Allow prevalent line endings, i.e. `lf`, `crlf` or `cr` (_this is useful if your git is configured to correctly manage
+  all line endings_):
+  - `npm run fmt-auto`
+  - `npm run check-fmt-auto`
+
+Alternatively, use a prettier plugin for your favourite IDE.

--- a/integration_tests/features/StressTest.feature
+++ b/integration_tests/features/StressTest.feature
@@ -5,7 +5,7 @@ Feature: Stress Test
     Scenario Outline: Ramped Stress Test
         Given I have a seed node NODE1
         And I have stress-test wallet WALLET_A connected to the seed node NODE1 with broadcast monitoring timeout <MonitoringTimeout>
-        And I have a merge mining proxy PROXY connected to NODE1 and WALLET_A
+        And I have a merge mining proxy PROXY connected to NODE1 and WALLET_A with default config
         # We mine some blocks before starting the other nodes to avoid a spinning sync state when all the nodes are at height 0
         When I merge mine 6 blocks via PROXY
         And I have a seed node NODE2
@@ -14,7 +14,7 @@ Feature: Stress Test
         # There need to be at least as many mature coinbase UTXOs in the wallet coin splits required for the number of transactions
         When I merge mine <NumCoinsplitsNeeded> blocks via PROXY
         Then all nodes are at current tip height
-        When I wait for wallet WALLET_A to have at least 5100000000 tari
+        When I wait for wallet WALLET_A to have at least 5100000000 uT
 
         Then I coin split tari in wallet WALLET_A to produce <NumTransactions> UTXOs of 5000 uT each with fee_per_gram 20 uT
         When I merge mine 3 blocks via PROXY
@@ -42,7 +42,7 @@ Feature: Stress Test
     Scenario: Simple Stress Test
         Given I have a seed node NODE1
         And I have stress-test wallet WALLET_A connected to the seed node NODE1 with broadcast monitoring timeout 60
-        And I have a merge mining proxy PROXY connected to NODE1 and WALLET_A
+        And I have a merge mining proxy PROXY connected to NODE1 and WALLET_A with default config
         When I merge mine 1 blocks via PROXY
         And I have a seed node NODE2
         And I have 1 base nodes connected to all seed nodes
@@ -51,7 +51,7 @@ Feature: Stress Test
         # The following line is how you could mine directly on the node
         When I merge mine 8 blocks via PROXY
         Then all nodes are at current tip height
-        When I wait for wallet WALLET_A to have at least 15100000000 tari
+        When I wait for wallet WALLET_A to have at least 15100000000 uT
 
         Then I coin split tari in wallet WALLET_A to produce 2000 UTXOs of 5000 uT each with fee_per_gram 20 uT
 

--- a/integration_tests/features/TransactionInfo.feature
+++ b/integration_tests/features/TransactionInfo.feature
@@ -13,7 +13,7 @@ Scenario: Get Transaction Info
     When I merge mine 4 blocks via PROXY
     Then all nodes are at height 4
     Then I list all coinbase transactions for wallet WALLET_A
-    When I wait for wallet WALLET_A to have at least 1002000 tari
+    When I wait for wallet WALLET_A to have at least 1002000 uT
     And I send 1000000 uT from wallet WALLET_A to wallet WALLET_B at fee 100
     Then wallet WALLET_A detects all transactions are at least Pending
     Then wallet WALLET_B detects all transactions are at least Pending

--- a/integration_tests/features/WalletMonitoring.feature
+++ b/integration_tests/features/WalletMonitoring.feature
@@ -12,7 +12,7 @@ Scenario: Wallets monitoring coinbase after a reorg
     And I have a base node NODE_A1 connected to seed SEED_A
     And I have wallet WALLET_A1 connected to seed node SEED_A
     And I have wallet WALLET_A2 connected to seed node SEED_A
-    And I have a merge mining proxy PROXY_A connected to SEED_A and WALLET_A1
+    And I have a merge mining proxy PROXY_A connected to SEED_A and WALLET_A1 with default config
     When I merge mine 10 blocks via PROXY_A
     Then all nodes are at height 10
     And I list all coinbase transactions for wallet WALLET_A1
@@ -30,7 +30,7 @@ Scenario: Wallets monitoring coinbase after a reorg
     And I have a base node NODE_B1 connected to seed SEED_B
     And I have wallet WALLET_B1 connected to seed node SEED_B
     And I have wallet WALLET_B2 connected to seed node SEED_B
-    And I have a merge mining proxy PROXY_B connected to SEED_B and WALLET_B1
+    And I have a merge mining proxy PROXY_B connected to SEED_B and WALLET_B1 with default config
     When I merge mine 10 blocks via PROXY_B
     Then all nodes are at height 10
     And I list all coinbase transactions for wallet WALLET_B1

--- a/integration_tests/features/WalletRecovery.feature
+++ b/integration_tests/features/WalletRecovery.feature
@@ -1,0 +1,15 @@
+@wallet-recovery
+Feature: Wallet Recovery
+
+@critical
+Scenario: Wallet recovery with connected base node staying online
+    Given I have a seed node NODE
+    And I have 1 base nodes connected to all seed nodes
+    And I have wallet WALLET_A connected to all seed nodes
+    And I have a merge mining proxy PROXY connected to NODE and WALLET_A with default config
+    When I merge mine 10 blocks via PROXY
+    When I mine 5 blocks on NODE
+    When I wait for wallet WALLET_A to have at least 55000000000 uT
+    Then all nodes are at height 15
+    When I recover wallet WALLET_A into wallet WALLET_B connected to all seed nodes
+    Then wallet WALLET_A and wallet WALLET_B have the same balance

--- a/integration_tests/features/WalletRoutingMechanism.feature
+++ b/integration_tests/features/WalletRoutingMechanism.feature
@@ -12,7 +12,7 @@ Scenario Outline: Wallets transacting via specified routing mechanism only
     Then all nodes are at height 20
         # TODO: This wait is needed to stop base nodes from shutting down
     When I wait 1 seconds
-    When I wait for wallet WALLET_A to have at least 100000000 tari
+    When I wait for wallet WALLET_A to have at least 100000000 uT
     #When I print the world
     And I multi-send 1000000 uT from wallet WALLET_A to all wallets at fee 100
     Then all wallets detect all transactions are at least Pending

--- a/integration_tests/features/WalletTransfer.feature
+++ b/integration_tests/features/WalletTransfer.feature
@@ -8,14 +8,14 @@ Feature: Wallet Transfer
     And I have a merge mining proxy PROXY connected to NODE and Wallet_A with default config
     And I have wallet Wallet_B connected to all seed nodes
     And I have wallet Wallet_C connected to all seed nodes
-    When I merge mine 2 blocks via PROXY
-    Then all nodes are at height 2
-      # Ensure the coinbase lock heights have expired
-    When I mine 3 blocks on NODE
+    When I merge mine 5 blocks via PROXY
     Then all nodes are at height 5
+      # Ensure the coinbase lock heights have expired
+    When I mine 5 blocks on NODE
+    Then all nodes are at height 10
     When I transfer 50000 uT from Wallet_A to Wallet_B and Wallet_C at fee 100
     And I mine 5 blocks on NODE
-    Then all nodes are at height 10
+    Then all nodes are at height 15
     Then all wallets detect all transactions as Mined_Confirmed
 
   Scenario: As a wallet I want to submit transfers to myself
@@ -24,11 +24,11 @@ Feature: Wallet Transfer
     And I have 1 base nodes connected to all seed nodes
     And I have wallet Wallet_A connected to all seed nodes
     And I have a merge mining proxy PROXY connected to NODE and Wallet_A with default config
-    When I merge mine 2 blocks via PROXY
-    Then all nodes are at height 2
+    When I merge mine 5 blocks via PROXY
+    Then all nodes are at height 5
       # Ensure the coinbase lock heights have expired
-    When I mine 3 blocks on NODE
+    When I mine 5 blocks on NODE
     When I transfer 50000 uT to self from wallet Wallet_A at fee 25
     And I mine 5 blocks on NODE
-    Then all nodes are at height 10
+    Then all nodes are at height 15
     Then all wallets detect all transactions as Mined_Confirmed

--- a/integration_tests/package.json
+++ b/integration_tests/package.json
@@ -5,7 +5,9 @@
   "scripts": {
     "test": "cucumber-js",
     "fmt": "prettier -w .",
-    "check-fmt": "prettier -c ."
+    "check-fmt": "prettier -c .",
+    "fmt-auto": "prettier --end-of-line auto -w .",
+    "check-fmt-auto": "prettier --end-of-line auto -c ."
   },
   "author": "",
   "license": "ISC",


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
- Added the ability to save seed words into a file, opt-in from the command line
- Added the ability to enter recovery seed words on the command line
- Added wallet recovery cucumber test:
  `Scenario: Wallet recovery with connected base node staying online`

## Motivation and Context
Improve test cases

## How Has This Been Tested?
With the cucumber test

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [X] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [X] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [X] I'm merging against the `development` branch.
* [X] I ran `cargo-fmt --all` before pushing.
* [X] I ran `cargo test` successfully before submitting my PR.
* [X] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
