### PR TITLE
Update tari script cucumber tests to use standalone miner

### DIFF
--- a/base_layer/wallet_ffi/Cargo.toml
+++ b/base_layer/wallet_ffi/Cargo.toml
@@ -10,11 +10,11 @@ edition = "2018"
 tari_comms = { version = "^0.8", path = "../../comms" }
 tari_comms_dht = { version = "^0.8", path = "../../comms/dht" }
 tari_crypto = { git = "https://github.com/tari-project/tari-crypto/", branch = "main" }
+tari_key_manager = { version = "^0.8", path = "../key_manager" }
 tari_p2p = { version = "^0.8", path = "../p2p" }
 tari_wallet = { version = "^0.8", path = "../wallet", features = ["test_harness", "c_integration"]}
 tari_shutdown = { version = "^0.8", path = "../../infrastructure/shutdown" }
 tari_utilities = "^0.3"
-tari_key_manager = { version = "^0.8", path = "../key_manager" }
 
 futures =  { version = "^0.3.1", features =["compat", "std"]}
 tokio = "0.2.10"

--- a/integration_tests/features/Propagation.feature
+++ b/integration_tests/features/Propagation.feature
@@ -4,8 +4,8 @@ Feature: Block Propagation
   Scenario Outline: Blocks are propagated through the network
     Given I have <NumSeeds> seed nodes
     And I have <NumNonSeeds> base nodes connected to all seed nodes
-    And I have a base node MINER connected to all seed nodes
-    When I mine <NumBlocks> blocks on MINER
+    And I have a SHA3 miner MINER connected to all seed nodes
+    And mining node MINER mines <NumBlocks> blocks
     Then all nodes are at height <NumBlocks>
     @critical
     Examples:
@@ -26,8 +26,8 @@ Feature: Block Propagation
   Scenario: Simple propagation
     Given I have 2 seed nodes
     And I have 4 base nodes connected to all seed nodes
-    And I have a base node MINER connected to all seed nodes
-    When I mine 5 blocks on MINER
+    And I have a SHA3 miner MINER connected to all seed nodes
+    And mining node MINER mines 5 blocks
     Then node MINER is at height 5
     Then all nodes are at height 5
 
@@ -60,26 +60,26 @@ Feature: Block Propagation
   @non-sync-propagation @long-running
   Scenario: Nodes should never switch to block sync but keep insync via propagation
     Given I have 1 seed nodes
-    Given I have a base node MINER connected to all seed nodes
+    Given I have a SHA3 miner MINER connected to all seed nodes
     And I have a lagging delayed node LAG1 connected to node MINER with blocks_behind_before_considered_lagging 10000
     Given I have a lagging delayed node LAG2 connected to node MINER with blocks_behind_before_considered_lagging 10000
         # Wait for node to so start and get into listing mode
     When I wait 100 seconds
-    When I mine 5 blocks on MINER
+    When mining node MINER mines 5 blocks
     Then all nodes are at height 5
-    When I mine 15 blocks on MINER
+    Given mining node MINER mines 15 blocks
     Then all nodes are at height 20
 
   @long-running
   Scenario: Node should lag for while before syncing
     Given I have 1 seed nodes
-    Given I have a base node MINER connected to all seed nodes
+    Given I have a SHA3 miner MINER connected to all seed nodes
     And I have a lagging delayed node LAG1 connected to node MINER with blocks_behind_before_considered_lagging 6
-    When I mine 1 blocks on MINER
+    Given mining node MINER mines 1 blocks
     When I wait 100 seconds
     When I stop LAG1
     When I wait 10 seconds
-    When I mine 5 blocks on MINER
+    And mining node MINER mines 5 blocks
     When I wait 100 seconds
     When I start LAG1
         # Wait for node to so start and get into listing mode
@@ -87,7 +87,7 @@ Feature: Block Propagation
     Then node MINER is at height 6
     #node was shutdown, so it never received the propagation messages
     Then node LAG1 is at height 1
-    When I mine 1 blocks on MINER
+    Given mining node MINER mines 1 blocks
     Then node MINER is at height 7
     When I wait 20 seconds
     Then all nodes are at height 7

--- a/integration_tests/features/Reorgs.feature
+++ b/integration_tests/features/Reorgs.feature
@@ -8,11 +8,11 @@ Feature: Reorgs
     And I have wallet WB connected to base node B
     And I have mining node BM connected to base node B and wallet WB
     When I stop SA
-    And Mining node BM mines 3 blocks on B
+    And mining node BM mines 3 blocks
     Given I have a base node C connected to seed SA
     And I have wallet WC connected to base node C
     And I have mining node CM connected to base node C and wallet WC
-    And Mining node CM mines 15 blocks on C
+    And mining node CM mines 15 blocks
     Then node B is at height 3
     And node C is at height 15
     When I start SA

--- a/integration_tests/features/Sync.feature
+++ b/integration_tests/features/Sync.feature
@@ -18,8 +18,8 @@ Feature: Block Sync
   @critical
   Scenario: Simple block sync
     Given I have 1 seed nodes
-    And I have a base node MINER connected to all seed nodes
-    When I mine 20 blocks on MINER
+    Given I have a SHA3 miner MINER connected to all seed nodes
+    Given mining node MINER mines 20 blocks
     Given I have 2 base nodes connected to all seed nodes
     # All nodes should sync to tip
     Then all nodes are at height 20
@@ -34,29 +34,33 @@ Feature: Block Sync
 
   @critical @reorg
   Scenario: Full block sync with small reorg
-    Given I have a base node NODE1 connected to all seed nodes
-    Given I have a base node NODE2 connected to node NODE1
-    When I mine 5 blocks on NODE1
+    Given I have a SHA3 miner NODE1 connected to all seed nodes
+    Given I have a SHA3 miner NODE2 connected to node NODE1
+    Given mining node NODE1 mines 5 blocks
     Then all nodes are at height 5
     Given I stop NODE2
-    Then I mine 5 blocks on NODE1
+    Given mining node NODE1 mines 5 blocks
+    Then node NODE1 is at height 10
     Given I stop NODE1
     And I start NODE2
-    Then I mine 7 blocks on NODE2
+    Given mining node NODE2 mines 7 blocks
+    Then node NODE2 is at height 12
     When I start NODE1
     Then all nodes are on the same chain at height 12
 
   @critical @reorg @long-running
   Scenario: Full block sync with large reorg
-    Given I have a base node NODE1 connected to all seed nodes
-    Given I have a base node NODE2 connected to node NODE1
-    When I mine 5 blocks on NODE1
+    Given I have a SHA3 miner NODE1 connected to all seed nodes
+    Given I have a SHA3 miner NODE2 connected to node NODE1
+    Given mining node NODE1 mines 5 blocks
     Then all nodes are at height 5
     Given I stop NODE2
-    Then I mine 1001 blocks on NODE1
+    Given mining node NODE1 mines 1001 blocks
+    Then node NODE1 is at height 1006
     Given I stop NODE1
     And I start NODE2
-    Then I mine 1500 blocks on NODE2
+    Given mining node NODE2 mines 1500 blocks
+    Then node NODE2 is at height 1505
     When I start NODE1
     Then all nodes are on the same chain at height 1505
 

--- a/integration_tests/features/TransactionInfo.feature
+++ b/integration_tests/features/TransactionInfo.feature
@@ -5,7 +5,7 @@ Feature: Transaction Info
 Scenario: Get Transaction Info
     Given I have a seed node NODE
         # TODO: This test takes an hour if only one base node is used
-    And I have 1 base nodes connected to all seed nodes
+    And I have a SHA3 miner MINER connected to all seed nodes
     And I have wallet WALLET_A connected to all seed nodes
     And I have wallet WALLET_B connected to all seed nodes
     And I have a merge mining proxy PROXY connected to NODE and WALLET_A with default config
@@ -23,13 +23,13 @@ Scenario: Get Transaction Info
     Then wallet WALLET_B detects all transactions are at least Broadcast
         # TODO: This wait is needed to stop next merge mining task from continuing
     When I wait 1 seconds
-    When I mine 1 blocks on NODE
+    And mining node MINER mines 1 blocks
     Then all nodes are at height 5
     Then wallet WALLET_A detects all transactions as Mined_Unconfirmed
     Then wallet WALLET_B detects all transactions as Mined_Unconfirmed
         # TODO: This wait is needed to stop base nodes from shutting down
     When I wait 1 seconds
-    When I mine 11 blocks on NODE
+    And mining node MINER mines 11 blocks
     Then all nodes are at height 16
     Then wallet WALLET_A detects all transactions as Mined_Confirmed
     Then wallet WALLET_B detects all transactions as Mined_Confirmed

--- a/integration_tests/features/WalletMonitoring.feature
+++ b/integration_tests/features/WalletMonitoring.feature
@@ -44,12 +44,12 @@ Scenario: Wallets monitoring coinbase after a reorg
         #
         # TODO: This wait is needed to stop next base node task from continuing
     When I wait 1 seconds
-    And I have a base node NODE_C connected to all seed nodes
+    And I have a SHA3 miner NODE_C connected to all seed nodes
         # Wait for the reorg to filter through
     When I wait 30 seconds
     Then all nodes are at height 10
         # When tip advances past required confirmations, invalid coinbases still being monitored will be cancelled.
-    When I mine 6 blocks on NODE_C
+    And mining node NODE_C mines 6 blocks
     Then all nodes are at height 16
         # Wait for coinbase statuses to change in the wallet
     When I wait 30 seconds

--- a/integration_tests/features/WalletRoutingMechanism.feature
+++ b/integration_tests/features/WalletRoutingMechanism.feature
@@ -5,6 +5,7 @@ Scenario Outline: Wallets transacting via specified routing mechanism only
     Given I have a seed node NODE
     And I have <NumBaseNodes> base nodes connected to all seed nodes
     And I have non-default wallet WALLET_A connected to all seed nodes using <Mechanism>
+    And I have mining node MINER connected to base node NODE and wallet WALLET_A
     And I have <NumWallets> non-default wallets connected to all seed nodes using <Mechanism>
     And I have a merge mining proxy PROXY connected to NODE and WALLET_A with default config
         # We need to ensure the coinbase lock heights are gone and we have enough individual UTXOs; mine enough blocks
@@ -20,12 +21,12 @@ Scenario Outline: Wallets transacting via specified routing mechanism only
     Then all wallets detect all transactions are at least Broadcast
         # TODO: This wait is needed to stop next merge mining task from continuing
     When I wait 1 seconds
-    When I mine 1 blocks on NODE
+    And mining node MINER mines 1 blocks
     Then all nodes are at height 21
     Then all wallets detect all transactions as Mined_Unconfirmed
         # TODO: This wait is needed to stop next merge mining task from continuing
     When I wait 1 seconds
-    When I mine 11 blocks on NODE
+    And mining node MINER mines 11 blocks
     Then all nodes are at height 32
     Then all wallets detect all transactions as Mined_Confirmed
         # TODO: This wait is needed to stop base nodes from shutting down

--- a/integration_tests/features/WalletTransfer.feature
+++ b/integration_tests/features/WalletTransfer.feature
@@ -5,16 +5,17 @@ Feature: Wallet Transfer
       # Add a 2nd node otherwise initial sync will not succeed
     And I have 1 base nodes connected to all seed nodes
     And I have wallet Wallet_A connected to all seed nodes
-    And I have a merge mining proxy PROXY connected to NODE and Wallet_A with default config
+    And I have a merge mining proxy PROXY connected to NODE and Wallet_A with default config    
+    And I have mining node MINER connected to base node NODE and wallet Wallet_A
     And I have wallet Wallet_B connected to all seed nodes
     And I have wallet Wallet_C connected to all seed nodes
     When I merge mine 2 blocks via PROXY
     Then all nodes are at height 2
       # Ensure the coinbase lock heights have expired
-    When I mine 3 blocks on NODE
+    And mining node MINER mines 3 blocks
     Then all nodes are at height 5
     When I transfer 50000 uT from Wallet_A to Wallet_B and Wallet_C at fee 100
-    And I mine 5 blocks on NODE
+    And mining node MINER mines 5 blocks
     Then all nodes are at height 10
     Then all wallets detect all transactions as Mined_Confirmed
 
@@ -27,8 +28,8 @@ Feature: Wallet Transfer
     When I merge mine 2 blocks via PROXY
     Then all nodes are at height 2
       # Ensure the coinbase lock heights have expired
-    When I mine 3 blocks on NODE
+    And mining node MINER mines 3 blocks
     When I transfer 50000 uT to self from wallet Wallet_A at fee 25
-    And I mine 5 blocks on NODE
+    And mining node MINER mines 5 blocks
     Then all nodes are at height 10
     Then all wallets detect all transactions as Mined_Confirmed

--- a/integration_tests/features/support/steps.js
+++ b/integration_tests/features/support/steps.js
@@ -303,6 +303,87 @@ Given(
   }
 );
 
+Given(
+  /I have a SHA3 miner (.*) connected to seed node (.*)/,  
+  { timeout: 40 * 1000 },
+  async function (name, seed) {
+    //add the base_node
+    const node = this.createNode(name);
+    console.log(this.seeds[seed].peerAddress());
+    node.setPeerSeeds([this.seeds[seed].peerAddress()]);
+    await node.startNew();
+    this.addNode(name, node);
+
+    // Add the wallet connected to the above base node
+    let wallet = new WalletProcess(name);
+    wallet.setPeerSeeds([node.peerAddress()]);
+    await wallet.startNew();
+    this.addWallet(name, wallet);
+
+    //Now lets add a standalone miner to both
+    const miningNode = new MiningNodeProcess(
+      name,
+      node.getGrpcAddress(),
+      wallet.getGrpcAddress()
+    );
+    this.addMiningNode(name, miningNode);
+  }
+);
+
+Given(
+  /I have a SHA3 miner (.*) connected to node (.*)/,  
+  { timeout: 40 * 1000 },
+  async function (name, seed) {
+    //add the base_node
+    const node = this.createNode(name);
+    console.log(this.nodes[seed].peerAddress());
+    node.setPeerSeeds([this.nodes[seed].peerAddress()]);
+    await node.startNew();
+    this.addNode(name, node);
+
+    // Add the wallet connected to the above base node
+    let wallet = new WalletProcess(name);
+    wallet.setPeerSeeds([node.peerAddress()]);
+    await wallet.startNew();
+    this.addWallet(name, wallet);
+
+    //Now lets add a standalone miner to both
+    const miningNode = new MiningNodeProcess(
+      name,
+      node.getGrpcAddress(),
+      wallet.getGrpcAddress()
+    );
+    this.addMiningNode(name, miningNode);
+  }
+);
+
+Given(
+  /I have a SHA3 miner (.*) connected to all seed nodes/,  
+  { timeout: 40 * 1000 },
+  async function (name) {
+    //add the base_node
+    const node = this.createNode(name);
+    node.setPeerSeeds([this.seedAddresses()]);
+    await node.startNew();
+    this.addNode(name, node);
+
+    // Add the wallet connected to the above base node
+    let wallet = new WalletProcess(name);
+    wallet.setPeerSeeds([node.peerAddress()]);
+    await wallet.startNew();
+    this.addWallet(name, wallet);
+
+    //Now lets add a standalone miner to both
+    const miningNode = new MiningNodeProcess(
+      name,
+      node.getGrpcAddress(),
+      wallet.getGrpcAddress()
+    );
+    this.addMiningNode(name, miningNode);
+  }
+);
+
+
 When(/I ask for a block height from proxy (.*)/, async function (mmProxy) {
   lastResult = "NaN";
   let proxy = this.getProxy(mmProxy);
@@ -656,14 +737,15 @@ When(
 );
 
 When(
-  /Mining node (.*) mines (\d+) blocks on (.*)/,
+  /mining node (.*) mines (\d+) blocks/,
   { timeout: 600 * 1000 },
-  async function (miner, numBlocks, node) {
+  async function (miner, numBlocks) {
     let miningNode = this.getMiningNode(miner);
     await miningNode.init(numBlocks, 1, 100000);
     await miningNode.startNew();
   }
 );
+
 
 When(
   /I update the parent of block (.*) to be an orphan/,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR requires PR #2833 
This PR ports the cucumber tests to use the standalone miner and not the build in cucumber miner.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [ ] I'm merging against the `development` branch.
* [ ] I ran `cargo-fmt --all` before pushing.
* [ ] I ran `cargo test` successfully before submitting my PR.
* [ ] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
