### PR TITLE
Fix console wallet menu spacing

### DIFF
--- a/applications/tari_console_wallet/src/ui/components/menu.rs
+++ b/applications/tari_console_wallet/src/ui/components/menu.rs
@@ -28,7 +28,7 @@ impl<B: Backend> Component<B> for Menu {
             Span::styled("LeftArrow", Style::default().fg(Color::Green)),
             Span::styled(":", Style::default().fg(Color::White)),
             Span::styled(
-                "PrevTab ",
+                " PrevTab ",
                 Style::default()
                     .fg(Color::Magenta)
                     .bg(Color::LightGreen)
@@ -38,7 +38,7 @@ impl<B: Backend> Component<B> for Menu {
             Span::styled("Tab/RightArrow", Style::default().fg(Color::Green)),
             Span::styled(":", Style::default().fg(Color::White)),
             Span::styled(
-                "NextTab ",
+                " NextTab ",
                 Style::default()
                     .fg(Color::Magenta)
                     .bg(Color::LightGreen)
@@ -46,10 +46,10 @@ impl<B: Backend> Component<B> for Menu {
             ),
         ]);
         let quit = Spans::from(vec![
-            Span::styled("F10/Ctrl-Q/Ctrl-C", Style::default().fg(Color::Green)),
+            Span::styled("F10/Ctrl-Q", Style::default().fg(Color::Green)),
             Span::styled(":", Style::default().fg(Color::White)),
             Span::styled(
-                "Quit    ",
+                " Quit    ",
                 Style::default()
                     .fg(Color::Magenta)
                     .bg(Color::LightGreen)

--- a/applications/tari_console_wallet/src/ui/components/transactions_tab.rs
+++ b/applications/tari_console_wallet/src/ui/components/transactions_tab.rs
@@ -395,21 +395,20 @@ impl<B: Backend> Component<B> for TransactionsTab {
             vec![]
         } else {
             vec![
-                Span::raw(" Use "),
                 Span::styled("P/T", Style::default().add_modifier(Modifier::BOLD)),
-                Span::raw(" to move between transaction lists, "),
+                Span::raw(" moves between transaction lists, "),
             ]
         };
 
         span_vec.push(Span::styled(
-            "Up/Down Arrow Keys",
+            "Up/Down Arrow",
             Style::default().add_modifier(Modifier::BOLD),
         ));
-        span_vec.push(Span::raw(" to select a transaction, "));
+        span_vec.push(Span::raw(" selects a transaction, "));
         span_vec.push(Span::styled("C", Style::default().add_modifier(Modifier::BOLD)));
-        span_vec.push(Span::raw(" to cancel a selected Pending Tx, "));
+        span_vec.push(Span::raw(" cancels a selected Pending Tx, "));
         span_vec.push(Span::styled("Esc", Style::default().add_modifier(Modifier::BOLD)));
-        span_vec.push(Span::raw(" to go to the top of the list."));
+        span_vec.push(Span::raw(" exits the list."));
 
         let instructions = Paragraph::new(Spans::from(span_vec)).wrap(Wrap { trim: true });
         f.render_widget(instructions, areas[1]);


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
- Fixed instruction message being cut off when there are pending transactions.
- Improved menu visual effect by adding an additional space before the action (_as per previous unimplemented @delta1  comment_).

With pending transactions:
![image](https://user-images.githubusercontent.com/39146854/114178824-826aee00-993e-11eb-85b6-bc09564fe2de.png)

Without pending transactions:
![image](https://user-images.githubusercontent.com/39146854/114178805-7c750d00-993e-11eb-81ac-80e6817ad4ba.png)

## Motivation and Context
See above.

## How Has This Been Tested?
Running the console wallet.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [X] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [X] I'm merging against the `development` branch.
* [X] I ran `cargo-fmt --all` before pushing.
* [ ] I ran `cargo test` successfully before submitting my PR.
* [X] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
