### PR TITLE
Fix an addition overflow inside family (base_layer/mmr/common.rs)

### DIFF
--- a/base_layer/mmr/src/merkle_proof.rs
+++ b/base_layer/mmr/src/merkle_proof.rs
@@ -249,7 +249,7 @@ impl MerkleProof {
         }
 
         let sibling = self.path.remove(0); // FIXME Compare perf vs using a VecDeque
-        let (parent_pos, sibling_pos) = family(pos);
+        let (parent_pos, sibling_pos) = family(pos)?;
         if parent_pos > self.mmr_size {
             Err(MerkleProofError::Unexpected)
         } else {


### PR DESCRIPTION
# Fix an addition overflow inside family (base_layer/mmr/common.rs)

An arithmetic overflow (addition overflow) can be triggered inside the `family` function.
This overflow is triggering a panic if the code is compile in debug mode (`overflow-checks` compiler flag) and it will be completely silent if the code is compiled in release mode.

Details:
- found by @pventuzelo
- found by manual audit
- related code: https://github.com/tari-project/tari/blob/95499a7aea664407efc68d44aec0f97b6044ba86/base_layer/mmr/src/common.rs#L81-L83

# Reproducer
``` rust
fn addition_overflow_mmr_family() {
    let n = std::usize::MAX;
    let _family = common::family(n);
}
```

# Backtrace
``` sh
thread 'main' panicked at 'attempt to add with overflow', /home/scop/Documents/consulting/tari/fuzz-project/code/tari/base_layer/mmr/src/common.rs:83:10
stack backtrace:
   0: rust_begin_unwind
             at /rustc/04caa632dd10c2bf64b69524c7f9c4c30a436877/library/std/src/panicking.rs:493:5
   1: core::panicking::panic_fmt
             at /rustc/04caa632dd10c2bf64b69524c7f9c4c30a436877/library/core/src/panicking.rs:92:14
   2: core::panicking::panic
             at /rustc/04caa632dd10c2bf64b69524c7f9c4c30a436877/library/core/src/panicking.rs:50:5
   3: tari_mmr::common::family
             at /home/scop/Documents/consulting/tari/fuzz-project/code/tari/base_layer/mmr/src/common.rs:83:10
   4: crash_repro::addition_overflow_mmr_family
             at ./src/main.rs:9:19
   5: crash_repro::main
             at ./src/main.rs:15:13
   6: core::ops::function::FnOnce::call_once
             at /rustc/04caa632dd10c2bf64b69524c7f9c4c30a436877/library/core/src/ops/function.rs:227:5
note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.
```