### PR TITLE
v0.8.8

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3880,7 +3880,7 @@ dependencies = [
 
 [[package]]
 name = "tari_app_grpc"
-version = "0.8.7"
+version = "0.8.8"
 dependencies = [
  "chrono",
  "prost",
@@ -3896,7 +3896,7 @@ dependencies = [
 
 [[package]]
 name = "tari_app_utilities"
-version = "0.8.7"
+version = "0.8.8"
 dependencies = [
  "config",
  "dirs-next",
@@ -3921,7 +3921,7 @@ dependencies = [
 
 [[package]]
 name = "tari_base_node"
-version = "0.8.7"
+version = "0.8.8"
 dependencies = [
  "anyhow",
  "bincode",
@@ -3978,7 +3978,7 @@ dependencies = [
 
 [[package]]
 name = "tari_common"
-version = "0.8.7"
+version = "0.8.8"
 dependencies = [
  "anyhow",
  "config",
@@ -4001,7 +4001,7 @@ dependencies = [
 
 [[package]]
 name = "tari_common_types"
-version = "0.8.7"
+version = "0.8.8"
 dependencies = [
  "futures 0.3.12",
  "rand 0.7.3",
@@ -4012,7 +4012,7 @@ dependencies = [
 
 [[package]]
 name = "tari_comms"
-version = "0.8.7"
+version = "0.8.8"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4055,7 +4055,7 @@ dependencies = [
 
 [[package]]
 name = "tari_comms_dht"
-version = "0.8.7"
+version = "0.8.8"
 dependencies = [
  "anyhow",
  "bitflags 1.2.1",
@@ -4100,7 +4100,7 @@ dependencies = [
 
 [[package]]
 name = "tari_comms_rpc_macros"
-version = "0.8.7"
+version = "0.8.8"
 dependencies = [
  "futures 0.3.12",
  "proc-macro2 1.0.24",
@@ -4116,7 +4116,7 @@ dependencies = [
 
 [[package]]
 name = "tari_console_wallet"
-version = "0.8.7"
+version = "0.8.8"
 dependencies = [
  "chrono",
  "chrono-english",
@@ -4150,7 +4150,7 @@ dependencies = [
 
 [[package]]
 name = "tari_core"
-version = "0.8.7"
+version = "0.8.8"
 dependencies = [
  "bincode",
  "bitflags 1.2.1",
@@ -4227,7 +4227,7 @@ dependencies = [
 
 [[package]]
 name = "tari_infra_derive"
-version = "0.8.7"
+version = "0.8.8"
 dependencies = [
  "blake2",
  "proc-macro2 0.4.30",
@@ -4253,7 +4253,7 @@ dependencies = [
 
 [[package]]
 name = "tari_key_manager"
-version = "0.8.7"
+version = "0.8.8"
 dependencies = [
  "digest 0.8.1",
  "rand 0.7.3",
@@ -4267,7 +4267,7 @@ dependencies = [
 
 [[package]]
 name = "tari_merge_mining_proxy"
-version = "0.8.7"
+version = "0.8.8"
 dependencies = [
  "bincode",
  "bytes 0.5.6",
@@ -4305,7 +4305,7 @@ dependencies = [
 
 [[package]]
 name = "tari_mining_node"
-version = "0.8.7"
+version = "0.8.8"
 dependencies = [
  "chrono",
  "crossbeam",
@@ -4328,7 +4328,7 @@ dependencies = [
 
 [[package]]
 name = "tari_mmr"
-version = "0.8.7"
+version = "0.8.8"
 dependencies = [
  "bincode",
  "blake2",
@@ -4347,7 +4347,7 @@ dependencies = [
 
 [[package]]
 name = "tari_p2p"
-version = "0.8.7"
+version = "0.8.8"
 dependencies = [
  "anyhow",
  "bytes 0.4.12",
@@ -4387,7 +4387,7 @@ dependencies = [
 
 [[package]]
 name = "tari_service_framework"
-version = "0.8.7"
+version = "0.8.8"
 dependencies = [
  "anyhow",
  "futures 0.3.12",
@@ -4404,7 +4404,7 @@ dependencies = [
 
 [[package]]
 name = "tari_shutdown"
-version = "0.8.7"
+version = "0.8.8"
 dependencies = [
  "futures 0.3.12",
  "tokio",
@@ -4412,7 +4412,7 @@ dependencies = [
 
 [[package]]
 name = "tari_storage"
-version = "0.8.7"
+version = "0.8.8"
 dependencies = [
  "bincode",
  "bytes 0.4.12",
@@ -4430,7 +4430,7 @@ dependencies = [
 
 [[package]]
 name = "tari_test_utils"
-version = "0.8.7"
+version = "0.8.8"
 dependencies = [
  "futures 0.3.12",
  "futures-test",
@@ -4460,7 +4460,7 @@ dependencies = [
 
 [[package]]
 name = "tari_wallet"
-version = "0.8.7"
+version = "0.8.8"
 dependencies = [
  "aes-gcm",
  "bincode",
@@ -4486,7 +4486,7 @@ dependencies = [
  "tari_comms_dht",
  "tari_core",
  "tari_crypto",
- "tari_key_manager 0.8.7",
+ "tari_key_manager 0.8.8",
  "tari_p2p",
  "tari_service_framework",
  "tari_shutdown",
@@ -4502,7 +4502,7 @@ dependencies = [
 
 [[package]]
 name = "tari_wallet_ffi"
-version = "0.16.25"
+version = "0.16.26"
 dependencies = [
  "chrono",
  "env_logger 0.7.1",
@@ -4517,7 +4517,7 @@ dependencies = [
  "tari_comms_dht",
  "tari_core",
  "tari_crypto",
- "tari_key_manager 0.8.7",
+ "tari_key_manager 0.8.8",
  "tari_p2p",
  "tari_shutdown",
  "tari_utilities",
@@ -4552,7 +4552,7 @@ dependencies = [
 
 [[package]]
 name = "test_faucet"
-version = "0.8.7"
+version = "0.8.8"
 dependencies = [
  "rand 0.7.3",
  "serde 1.0.123",

--- a/applications/tari_app_grpc/Cargo.toml
+++ b/applications/tari_app_grpc/Cargo.toml
@@ -4,7 +4,7 @@ authors = ["The Tari Development Community"]
 description = "This crate is to provide a single source for all cross application grpc files and conversions to and from tari::core"
 repository = "https://github.com/tari-project/tari"
 license = "BSD-3-Clause"
-version = "0.8.7"
+version = "0.8.8"
 edition = "2018"
 
 [dependencies]

--- a/applications/tari_app_utilities/Cargo.toml
+++ b/applications/tari_app_utilities/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tari_app_utilities"
-version = "0.8.7"
+version = "0.8.8"
 authors = ["Philip Robinson <simian@tari.com>"]
 edition = "2018"
 

--- a/applications/tari_base_node/Cargo.toml
+++ b/applications/tari_base_node/Cargo.toml
@@ -4,7 +4,7 @@ authors = ["The Tari Development Community"]
 description = "The tari full base node implementation"
 repository = "https://github.com/tari-project/tari"
 license = "BSD-3-Clause"
-version = "0.8.7"
+version = "0.8.8"
 edition = "2018"
 
 [dependencies]

--- a/applications/tari_console_wallet/Cargo.toml
+++ b/applications/tari_console_wallet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tari_console_wallet"
-version = "0.8.7"
+version = "0.8.8"
 authors = ["Philip Robinson <simian@tari.com>"]
 edition = "2018"
 

--- a/applications/tari_merge_mining_proxy/Cargo.toml
+++ b/applications/tari_merge_mining_proxy/Cargo.toml
@@ -4,7 +4,7 @@ authors = ["The Tari Development Community"]
 description = "The tari merge miner proxy for xmrig"
 repository = "https://github.com/tari-project/tari"
 license = "BSD-3-Clause"
-version = "0.8.7"
+version = "0.8.8"
 edition = "2018"
 
 [features]

--- a/applications/tari_mining_node/Cargo.toml
+++ b/applications/tari_mining_node/Cargo.toml
@@ -4,7 +4,7 @@ authors = ["The Tari Development Community"]
 description = "The tari mining node implementation"
 repository = "https://github.com/tari-project/tari"
 license = "BSD-3-Clause"
-version = "0.8.7"
+version = "0.8.8"
 edition = "2018"
 
 [dependencies]

--- a/applications/test_faucet/Cargo.toml
+++ b/applications/test_faucet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "test_faucet"
-version = "0.8.7"
+version = "0.8.8"
 authors = ["The Tari Development Community"]
 edition = "2018"
 

--- a/base_layer/common_types/Cargo.toml
+++ b/base_layer/common_types/Cargo.toml
@@ -3,7 +3,7 @@ name = "tari_common_types"
 authors = ["The Tari Development Community"]
 description = "Tari cryptocurrency common types"
 license = "BSD-3-Clause"
-version = "0.8.7"
+version = "0.8.8"
 edition = "2018"
 
 [dependencies]

--- a/base_layer/core/Cargo.toml
+++ b/base_layer/core/Cargo.toml
@@ -6,7 +6,7 @@ repository = "https://github.com/tari-project/tari"
 homepage = "https://tari.com"
 readme = "README.md"
 license = "BSD-3-Clause"
-version = "0.8.7"
+version = "0.8.8"
 edition = "2018"
 
 [features]

--- a/base_layer/key_manager/Cargo.toml
+++ b/base_layer/key_manager/Cargo.toml
@@ -4,7 +4,7 @@ authors = ["The Tari Development Community"]
 description = "Tari cryptocurrency wallet key management"
 repository = "https://github.com/tari-project/tari"
 license = "BSD-3-Clause"
-version = "0.8.7"
+version = "0.8.8"
 edition = "2018"
 
 [dependencies]

--- a/base_layer/mmr/Cargo.toml
+++ b/base_layer/mmr/Cargo.toml
@@ -4,7 +4,7 @@ authors = ["The Tari Development Community"]
 description = "A Merkle Mountain Range implementation"
 repository = "https://github.com/tari-project/tari"
 license = "BSD-3-Clause"
-version = "0.8.7"
+version = "0.8.8"
 edition = "2018"
 
 [features]

--- a/base_layer/p2p/Cargo.toml
+++ b/base_layer/p2p/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tari_p2p"
-version = "0.8.7"
+version = "0.8.8"
 authors = ["The Tari Development community"]
 description = "Tari base layer-specific peer-to-peer communication features"
 repository = "https://github.com/tari-project/tari"

--- a/base_layer/service_framework/Cargo.toml
+++ b/base_layer/service_framework/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tari_service_framework"
-version = "0.8.7"
+version = "0.8.8"
 authors = ["The Tari Development Community"]
 description = "The Tari communication stack service framework"
 repository = "https://github.com/tari-project/tari"

--- a/base_layer/wallet/Cargo.toml
+++ b/base_layer/wallet/Cargo.toml
@@ -3,7 +3,7 @@ name = "tari_wallet"
 authors = ["The Tari Development Community"]
 description = "Tari cryptocurrency wallet library"
 license = "BSD-3-Clause"
-version = "0.8.7"
+version = "0.8.8"
 edition = "2018"
 
 [dependencies]

--- a/base_layer/wallet_ffi/Cargo.toml
+++ b/base_layer/wallet_ffi/Cargo.toml
@@ -3,7 +3,7 @@ name = "tari_wallet_ffi"
 authors = ["The Tari Development Community"]
 description = "Tari cryptocurrency wallet C FFI bindings"
 license = "BSD-3-Clause"
-version = "0.16.25"
+version = "0.16.26"
 edition = "2018"
 
 [dependencies]

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -6,7 +6,7 @@ repository = "https://github.com/tari-project/tari"
 homepage = "https://tari.com"
 readme = "README.md"
 license = "BSD-3-Clause"
-version = "0.8.7"
+version = "0.8.8"
 edition = "2018"
 
 

--- a/comms/Cargo.toml
+++ b/comms/Cargo.toml
@@ -6,7 +6,7 @@ repository = "https://github.com/tari-project/tari"
 homepage = "https://tari.com"
 readme = "README.md"
 license = "BSD-3-Clause"
-version = "0.8.7"
+version = "0.8.8"
 edition = "2018"
 
 [dependencies]

--- a/comms/dht/Cargo.toml
+++ b/comms/dht/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tari_comms_dht"
-version = "0.8.7"
+version = "0.8.8"
 authors = ["The Tari Development Community"]
 description = "Tari comms DHT module"
 repository = "https://github.com/tari-project/tari"

--- a/comms/rpc_macros/Cargo.toml
+++ b/comms/rpc_macros/Cargo.toml
@@ -6,7 +6,7 @@ repository = "https://github.com/tari-project/tari"
 homepage = "https://tari.com"
 readme = "README.md"
 license = "BSD-3-Clause"
-version = "0.8.7"
+version = "0.8.8"
 edition = "2018"
 
 [lib]

--- a/infrastructure/derive/Cargo.toml
+++ b/infrastructure/derive/Cargo.toml
@@ -6,7 +6,7 @@ repository = "https://github.com/tari-project/tari"
 homepage = "https://tari.com"
 readme = "README.md"
 license = "BSD-3-Clause"
-version = "0.8.7"
+version = "0.8.8"
 edition = "2018"
 
 [lib]

--- a/infrastructure/shutdown/Cargo.toml
+++ b/infrastructure/shutdown/Cargo.toml
@@ -6,7 +6,7 @@ repository = "https://github.com/tari-project/tari"
 homepage = "https://tari.com"
 readme = "README.md"
 license = "BSD-3-Clause"
-version = "0.8.7"
+version = "0.8.8"
 edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/infrastructure/storage/Cargo.toml
+++ b/infrastructure/storage/Cargo.toml
@@ -6,7 +6,7 @@ repository = "https://github.com/tari-project/tari"
 homepage = "https://tari.com"
 readme = "README.md"
 license = "BSD-3-Clause"
-version = "0.8.7"
+version = "0.8.8"
 edition = "2018"
 
 [dependencies]

--- a/infrastructure/test_utils/Cargo.toml
+++ b/infrastructure/test_utils/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tari_test_utils"
 description = "Utility functions used in Tari test functions"
-version = "0.8.7"
+version = "0.8.8"
 authors = ["The Tari Development Community"]
 edition = "2018"
 license = "BSD-3-Clause"


### PR DESCRIPTION
Changes since v0.8.7

Base node
---
- [#2840](https://github.com/tari-project/tari/pull/2840) [base-node] Always output message when base node exits with an error
- [#2830](https://github.com/tari-project/tari/pull/2830) [base-node] Add rpc sessions to base node status line

Wallet
---
- [#2839](https://github.com/tari-project/tari/pull/2839) [wallet] Fix console wallet menu spacing
- [#2816](https://github.com/tari-project/tari/pull/2816) [wallet] Improve wallet recovery resiliency
- [#2834](https://github.com/tari-project/tari/pull/2834) [wallet] Add wallet recovery cucumber test, seed words to file

Other
---
- [#2829](https://github.com/tari-project/tari/pull/2829) [common] Add database concurrency check
