### PR TITLE
[comms] Use grace period on client side handshake

### DIFF
--- a/comms/src/protocol/rpc/client.rs
+++ b/comms/src/protocol/rpc/client.rs
@@ -213,6 +213,11 @@ impl RpcClientConfig {
     pub fn timeout_with_grace_period(&self) -> Option<Duration> {
         self.deadline.map(|d| d + self.deadline_grace_period)
     }
+
+    /// Returns the handshake timeout
+    pub fn handshake_timeout(&self) -> Duration {
+        self.handshake_timeout
+    }
 }
 
 impl Default for RpcClientConfig {
@@ -220,7 +225,7 @@ impl Default for RpcClientConfig {
         Self {
             deadline: Some(Duration::from_secs(30)),
             deadline_grace_period: Duration::from_secs(10),
-            handshake_timeout: Duration::from_secs(15),
+            handshake_timeout: Duration::from_secs(30),
         }
     }
 }
@@ -310,7 +315,7 @@ where TSubstream: AsyncRead + AsyncWrite + Unpin + Send
     async fn run(mut self) {
         debug!(target: LOG_TARGET, "Performing client handshake");
         let start = Instant::now();
-        let mut handshake = Handshake::new(&mut self.framed).with_timeout(self.config.handshake_timeout);
+        let mut handshake = Handshake::new(&mut self.framed).with_timeout(self.config.handshake_timeout());
         match handshake.perform_client_handshake().await {
             Ok(_) => {
                 let latency = start.elapsed();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Makes use of the request/response grace period in the handshake on the client-side.
The handshake is no different from any other request response and should
not be treated any differently i.e. by allowing extra time for latency on the client-side.

Also increased client-side handshake timeout (the client-side should wait longer than the server-side given it has a full RTT) 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Log observations: the client would connect, the server would accept (20 seconds later), the client would timeout (15s) before the handshake response was received. It is unclear why messages can take that long to be received, but it may be because of the current peer sync protocol using up yamux credits. In any case, the client-side handshake should include a grace period.  

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Existing tests pass

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [ ] I'm merging against the `development` branch.
* [ ] I ran `cargo-fmt --all` before pushing.
* [ ] I ran `cargo test` successfully before submitting my PR.
* [ ] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
