### PR TITLE
[wallet] Leverage streaming for UTXO recovery

### DIFF
--- a/applications/tari_console_wallet/src/recovery.rs
+++ b/applications/tari_console_wallet/src/recovery.rs
@@ -27,7 +27,6 @@ use rustyline::Editor;
 use tari_app_utilities::utilities::ExitCodes;
 use tari_comms::types::CommsPublicKey;
 use tari_core::transactions::types::PrivateKey;
-use tari_crypto::tari_utilities::hex::Hex;
 use tari_key_manager::mnemonic::to_secretkey;
 use tari_wallet::{
     tasks::wallet_recovery::{WalletRecoveryEvent, WalletRecoveryTask},
@@ -75,47 +74,87 @@ pub fn get_private_key_from_seed_words(seed_words: Vec<String>) -> Result<Privat
 /// Recovers wallet funds by connecting to a given base node peer, downloading the transaction outputs stored in the
 /// blockchain, and attempting to rewind them. Any outputs that are successfully rewound are then imported into the
 /// wallet.
-pub async fn wallet_recovery(
-    wallet: &mut WalletSqlite,
-    peer_seed_public_keys: Vec<CommsPublicKey>,
-) -> Result<(), ExitCodes>
-{
+pub async fn wallet_recovery(wallet: WalletSqlite, peer_seeds: Vec<CommsPublicKey>) -> Result<(), ExitCodes> {
     println!("\nPress Ctrl-C to stop the recovery process\n");
-    let mut recovery_task = WalletRecoveryTask::new(wallet.clone(), peer_seed_public_keys);
-    recovery_task.set_connection_retries_limit(250);
-    recovery_task.set_print_to_console(true);
+    let mut recovery_task = WalletRecoveryTask::builder()
+        .with_peer_seeds(peer_seeds)
+        .with_retry_limit(10)
+        .build(wallet);
 
-    let mut event_stream = recovery_task
-        .get_event_receiver()
-        .ok_or_else(|| ExitCodes::RecoveryError("Unable to get recovery event stream".to_string()))?
-        .fuse();
+    let mut event_stream = recovery_task.get_event_receiver().fuse();
 
-    let mut recovery_join_handle = tokio::spawn(recovery_task.run()).fuse();
+    let recovery_join_handle = tokio::spawn(recovery_task.run()).fuse();
 
-    loop {
-        futures::select! {
-            event = event_stream.select_next_some() => {
-                match event {
-                    WalletRecoveryEvent::ConnectedToBaseNode(pk) => {
-                        println!("Connected to base node: {}", pk.to_hex());
-                    },
-                    WalletRecoveryEvent::Progress(current, total) => {
-                        let percentage_progress = ((current as f32) * 100f32 / (total as f32)).round() as u32;
-                        println!(
-                            "{}: Recovery process {}% complete ({} of {} blocks).",
-                            Local::now(), percentage_progress, current, total
-                        );
-                    },
-                    WalletRecoveryEvent::Completed(num_utxos, total_amount) => {
-                        println!("Recovered {} outputs with a value of {}", num_utxos, total_amount);
-                    },
-                }
+    // Read recovery task events. The event stream will end once recovery has completed.
+    while let Some(event) = event_stream.next().await {
+        match event {
+            Ok(WalletRecoveryEvent::ConnectingToBaseNode(peer)) => {
+                print!("Connecting to base node {}... ", peer);
             },
-            recovery_result = recovery_join_handle => {
-                return recovery_result.map_err(|e| ExitCodes::RecoveryError(format!("{}", e)))?
-                    .map_err(|e| ExitCodes::RecoveryError(format!("{}", e))
+            Ok(WalletRecoveryEvent::ConnectedToBaseNode(_, latency)) => {
+                println!("OK (latency = {:.2?})", latency);
+            },
+            Ok(WalletRecoveryEvent::Progress(current, total)) => {
+                let percentage_progress = ((current as f32) * 100f32 / (total as f32)).round() as u32;
+                debug!(
+                    target: LOG_TARGET,
+                    "{}: Recovery process {}% complete ({} of {} utxos).",
+                    Local::now(),
+                    percentage_progress,
+                    current,
+                    total
                 );
-            }
+                println!(
+                    "{}: Recovery process {}% complete ({} of {} utxos).",
+                    Local::now(),
+                    percentage_progress,
+                    current,
+                    total
+                );
+            },
+            Ok(WalletRecoveryEvent::RecoveryRoundFailed {
+                num_retries,
+                retry_limit,
+            }) => {
+                let s = format!("Failed to sync. Attempt {} of {}", num_retries, retry_limit);
+                println!("{}", s);
+                warn!(target: LOG_TARGET, "{}", s);
+            },
+            Ok(WalletRecoveryEvent::ConnectionFailedToBaseNode {
+                peer,
+                num_retries,
+                retry_limit,
+                error,
+            }) => {
+                let s = format!(
+                    "Base node connection error to {} (retries {} of {}: {})",
+                    peer, num_retries, retry_limit, error
+                );
+                println!("{}", s);
+                warn!(target: LOG_TARGET, "{}", s);
+            },
+            Ok(WalletRecoveryEvent::Completed(num_scanned, num_utxos, total_amount, elapsed)) => {
+                let stats = format!(
+                    "Recovery complete! Scanned = {} in {:.2?} ({} utxos/s), Recovered {} worth {}",
+                    num_scanned,
+                    elapsed,
+                    num_scanned / elapsed.as_secs(),
+                    num_utxos,
+                    total_amount
+                );
+                info!(target: LOG_TARGET, "{}", stats);
+                println!("{}", stats);
+            },
+            Err(e) => {
+                // Can occur if we read events too slowly (lagging/slow subscriber)
+                debug!(target: LOG_TARGET, "Error receiving Wallet recovery events: {}", e);
+                continue;
+            },
         }
     }
+
+    recovery_join_handle
+        .await
+        .map_err(|e| ExitCodes::RecoveryError(format!("{}", e)))?
+        .map_err(|e| ExitCodes::RecoveryError(format!("{}", e)))
 }

--- a/applications/tari_console_wallet/src/wallet_modes.rs
+++ b/applications/tari_console_wallet/src/wallet_modes.rs
@@ -176,7 +176,7 @@ pub fn tui_mode(
 pub fn recovery_mode(
     handle: Handle,
     config: GlobalConfig,
-    mut wallet: WalletSqlite,
+    wallet: WalletSqlite,
     base_node_selected: Peer,
     base_node_config: PeerConfig,
     notify_script: Option<PathBuf>,
@@ -188,7 +188,7 @@ pub fn recovery_mode(
         .map(|f| f.public_key.clone())
         .collect();
     println!("Starting recovery...");
-    match handle.block_on(wallet_recovery(&mut wallet, peer_seed_public_keys)) {
+    match handle.block_on(wallet_recovery(wallet.clone(), peer_seed_public_keys)) {
         Ok(_) => println!("Wallet recovered!"),
         Err(e) => {
             error!(target: LOG_TARGET, "Recovery failed: {}", e);

--- a/base_layer/core/src/base_node/proto/rpc.proto
+++ b/base_layer/core/src/base_node/proto/rpc.proto
@@ -52,6 +52,8 @@ message SyncKernelsRequest {
 message SyncUtxosRequest  {
   uint64 start = 1;
   bytes end_header_hash = 2;
+  bool include_pruned_utxos = 3;
+  bool include_deleted_bitmaps = 4;
 }
 
 message SyncUtxosResponse  {
@@ -65,9 +67,34 @@ message SyncUtxo {
   // The output. optional, if deleted at the time of the requested height,
   // will be empty and `hash` and `rangeproof_hash` will be populated instead
   tari.types.TransactionOutput output = 1;
-  // Only present if 'output` is empty
+  // Only present if `output` is empty
   bytes hash = 2;
   // Only present if `output` is empty
   bytes rangeproof_hash = 3;
 }
 
+message SyncUtxos2Response  {
+  oneof utxo_or_deleted {
+    SyncUtxo2 utxo = 1;
+    Bitmaps deleted_bitmaps = 2;
+  }
+  uint64 mmr_index = 3;
+}
+
+message Bitmaps {
+  repeated bytes bitmaps = 1;
+}
+
+message SyncUtxo2 {
+  oneof utxo {
+    // The unspent transaction output
+    tari.types.TransactionOutput output = 1;
+    // If the UTXO is deleted/pruned, the hashes are returned
+    PrunedOutput pruned_output = 2;
+  }
+}
+
+message PrunedOutput {
+  bytes hash = 1;
+  bytes rangeproof_hash = 2;
+}

--- a/base_layer/core/src/base_node/proto/rpc.rs
+++ b/base_layer/core/src/base_node/proto/rpc.rs
@@ -20,13 +20,32 @@
 //  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 //  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use crate::{blocks::Block, proto::base_node as proto, tari_utilities::Hashable};
+use crate::{blocks::Block, chain_storage::PrunedOutput, proto::base_node as proto, tari_utilities::Hashable};
 
 impl From<Block> for proto::BlockBodyResponse {
     fn from(block: Block) -> Self {
         Self {
             hash: block.hash(),
             body: Some(block.body.into()),
+        }
+    }
+}
+
+impl From<PrunedOutput> for proto::SyncUtxo2 {
+    fn from(output: PrunedOutput) -> Self {
+        match output {
+            PrunedOutput::Pruned {
+                output_hash,
+                range_proof_hash,
+            } => proto::SyncUtxo2 {
+                utxo: Some(proto::sync_utxo2::Utxo::PrunedOutput(proto::PrunedOutput {
+                    hash: output_hash,
+                    rangeproof_hash: range_proof_hash,
+                })),
+            },
+            PrunedOutput::NotPruned { output } => proto::SyncUtxo2 {
+                utxo: Some(proto::sync_utxo2::Utxo::Output(output.into())),
+            },
         }
     }
 }

--- a/base_layer/core/src/base_node/proto/wallet_rpc.rs
+++ b/base_layer/core/src/base_node/proto/wallet_rpc.rs
@@ -20,7 +20,11 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use crate::{crypto::tari_utilities::ByteArrayError, proto::base_node as proto, transactions::types::Signature};
+use crate::{
+    crypto::tari_utilities::ByteArrayError,
+    proto::{base_node as proto, types},
+    transactions::types::Signature,
+};
 use serde::{Deserialize, Serialize};
 use std::{
     convert::TryFrom,
@@ -221,5 +225,33 @@ impl TryFrom<proto::TxQueryBatchResponse> for TxQueryBatchResponse {
             block_hash: proto_response.block_hash,
             confirmations: proto_response.confirmations,
         })
+    }
+}
+
+impl proto::SyncUtxos2Response {
+    pub fn into_utxo(self) -> Option<proto::SyncUtxo2> {
+        use proto::sync_utxos2_response::UtxoOrDeleted::*;
+        match self.utxo_or_deleted? {
+            Utxo(utxo) => Some(utxo),
+            DeletedBitmaps(_) => None,
+        }
+    }
+
+    pub fn into_bitmaps(self) -> Option<proto::Bitmaps> {
+        use proto::sync_utxos2_response::UtxoOrDeleted::*;
+        match self.utxo_or_deleted? {
+            Utxo(_) => None,
+            DeletedBitmaps(bitmaps) => Some(bitmaps),
+        }
+    }
+}
+
+impl proto::sync_utxo2::Utxo {
+    pub fn into_transaction_output(self) -> Option<types::TransactionOutput> {
+        use proto::sync_utxo2::Utxo::*;
+        match self {
+            Output(output) => Some(output),
+            PrunedOutput(_) => None,
+        }
     }
 }

--- a/base_layer/core/src/base_node/state_machine_service/states/horizon_state_sync/horizon_state_synchronization.rs
+++ b/base_layer/core/src/base_node/state_machine_service/states/horizon_state_sync/horizon_state_synchronization.rs
@@ -282,6 +282,8 @@ impl<'a, B: BlockchainBackend + 'static> HorizonStateSynchronization<'a, B> {
         let req = SyncUtxosRequest {
             start,
             end_header_hash: end_hash,
+            include_deleted_bitmaps: true,
+            include_pruned_utxos: true,
         };
         let mut output_stream = client.sync_utxos(req).await?;
 

--- a/base_layer/core/src/base_node/sync/rpc/mod.rs
+++ b/base_layer/core/src/base_node/sync/rpc/mod.rs
@@ -40,6 +40,7 @@ use crate::{
         SyncBlocksRequest,
         SyncHeadersRequest,
         SyncKernelsRequest,
+        SyncUtxos2Response,
         SyncUtxosRequest,
         SyncUtxosResponse,
     },
@@ -87,6 +88,10 @@ pub trait BaseNodeSyncService: Send + Sync + 'static {
 
     #[rpc(method = 7)]
     async fn sync_utxos(&self, request: Request<SyncUtxosRequest>) -> Result<Streaming<SyncUtxosResponse>, RpcStatus>;
+
+    #[rpc(method = 8)]
+    async fn sync_utxos2(&self, request: Request<SyncUtxosRequest>)
+        -> Result<Streaming<SyncUtxos2Response>, RpcStatus>;
 }
 
 #[cfg(feature = "base_node")]

--- a/base_layer/core/src/chain_storage/lmdb_db/lmdb_db.rs
+++ b/base_layer/core/src/chain_storage/lmdb_db/lmdb_db.rs
@@ -1466,8 +1466,8 @@ impl BlockchainBackend for LMDBDatabase {
                                 range_proof_hash: row.range_proof_hash,
                             };
                         }
-                        if let Some(output) = &row.output {
-                            PrunedOutput::NotPruned { output: output.clone() }
+                        if let Some(output) = row.output {
+                            PrunedOutput::NotPruned { output }
                         } else {
                             PrunedOutput::Pruned {
                                 output_hash: row.hash,
@@ -1674,7 +1674,7 @@ impl BlockchainBackend for LMDBDatabase {
         );
         let txn = ReadTransaction::new(&*self.env).map_err(|e| ChainStorageError::AccessError(e.to_string()))?;
         let orphan_hashes: Vec<HashOutput> = lmdb_get_multiple(&txn, &self.orphan_parent_map_index, hash.as_slice())?;
-        let mut res = vec![];
+        let mut res = Vec::with_capacity(orphan_hashes.len());
         for hash in orphan_hashes {
             res.push(lmdb_get(&txn, &self.orphans_db, hash.as_slice())?.ok_or_else(|| {
                 ChainStorageError::ValueNotFound {

--- a/base_layer/core/src/chain_storage/pruned_output.rs
+++ b/base_layer/core/src/chain_storage/pruned_output.rs
@@ -30,3 +30,8 @@ pub enum PrunedOutput {
         output: TransactionOutput,
     },
 }
+impl PrunedOutput {
+    pub fn is_pruned(&self) -> bool {
+        matches!(self, PrunedOutput::Pruned {..})
+    }
+}

--- a/base_layer/core/src/transactions/tari_amount.rs
+++ b/base_layer/core/src/transactions/tari_amount.rs
@@ -92,6 +92,10 @@ impl MicroTari {
         Self(0)
     }
 
+    pub fn as_u64(&self) -> u64 {
+        self.0
+    }
+
     pub fn formatted(self) -> FormattedMicroTari {
         self.into()
     }

--- a/comms/src/protocol/rpc/status.rs
+++ b/comms/src/protocol/rpc/status.rs
@@ -186,6 +186,10 @@ impl RpcStatusCode {
     pub fn is_not_found(self) -> bool {
         self == Self::NotFound
     }
+
+    pub fn is_timeout(self) -> bool {
+        self == Self::Timeout
+    }
 }
 
 impl From<u32> for RpcStatusCode {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Implements a streaming protocol for sync_utxo method. This differs from
the previous protocol in the following ways:
- a single request is made that streams the entire utxo set
- it streams many smaller messages rather than a "batch"
- it optionally does not send pruned/deleted UTXOs (not necessary for wallet recovery)
- it optionally does not send the deleted bitmaps (also not for wallet
  recovery)

The recovery client side was changed in these ways:
- implements the new protocol
- current UTXO MMR index is recorded as part of the receovery resume
  state
- previous UTXO mmr index is used to resume recovery
- retry recovery for each peer a given amount of times before giving up
- print_to_console removed in favour of leveraging recovery events

**Compatibility Notes**
- Wallets including this change will not be able to recover using base nodes that do not support the new protocol
- Current pruned sync is unaffected (Previous sync protocol kept)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Recovery times greatly reduced. 
Last test took 7 minutes (including a failure and resume due to minor reorg)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manually tested:
- recovering a wallet 
- resuming after wallet shutdown/startup
- resuming after base node shutdown/startup
- recovery after base node error due to minor reorg 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [x] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [ ] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch.
* [x] I ran `cargo-fmt --all` before pushing.
* [ ] I ran `cargo test` successfully before submitting my PR.
* [ ] I have squashed my commits into a single commit.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
