### PR TITLE
[Wallet] Fix wallet service API loop blocking

### DIFF
--- a/applications/tari_console_wallet/src/init/mod.rs
+++ b/applications/tari_console_wallet/src/init/mod.rs
@@ -194,13 +194,17 @@ pub async fn get_base_node_peer_config(
 }
 
 /// Determines which mode the wallet should run in.
-pub fn wallet_mode(bootstrap: ConfigBootstrap, boot_mode: WalletBoot) -> WalletMode {
+pub fn wallet_mode(bootstrap: &ConfigBootstrap, boot_mode: WalletBoot) -> WalletMode {
     // Recovery mode
     if matches!(boot_mode, WalletBoot::Recovery) {
         return WalletMode::Recovery;
     }
 
-    match (bootstrap.daemon_mode, bootstrap.input_file, bootstrap.command) {
+    match (
+        bootstrap.daemon_mode,
+        bootstrap.input_file.clone(),
+        bootstrap.command.clone(),
+    ) {
         // TUI mode
         (false, None, None) => WalletMode::Tui,
         // GRPC daemon mode
@@ -496,7 +500,12 @@ async fn set_master_key(
 }
 
 /// Starts the wallet by setting the base node peer, and restarting the transaction and broadcast protocols.
-pub async fn start_wallet(wallet: &mut WalletSqlite, base_node: &Peer) -> Result<(), ExitCodes> {
+pub async fn start_wallet(
+    wallet: &mut WalletSqlite,
+    base_node: &Peer,
+    wallet_mode: &WalletMode,
+) -> Result<(), ExitCodes>
+{
     // TODO gRPC interfaces for setting base node
     debug!(target: LOG_TARGET, "Setting base node peer");
 
@@ -511,25 +520,27 @@ pub async fn start_wallet(wallet: &mut WalletSqlite, base_node: &Peer) -> Result
         .await
         .map_err(|e| ExitCodes::WalletError(format!("Error setting wallet base node peer. {}", e)))?;
 
-    // Restart transaction protocols
-    if let Err(e) = wallet.transaction_service.restart_transaction_protocols().await {
-        error!(target: LOG_TARGET, "Problem restarting transaction protocols: {}", e);
-    }
-    if let Err(e) = start_transaction_validation_and_broadcast_protocols(
-        wallet.transaction_service.clone(),
-        ValidationRetryStrategy::UntilSuccess,
-    )
-    .await
-    {
-        error!(
-            target: LOG_TARGET,
-            "Problem validating and restarting transaction protocols: {}", e
-        );
-    }
+    // Restart transaction protocols if not running in script or command modes
 
-    // validate transaction outputs
-    validate_txos(wallet).await?;
+    if !matches!(wallet_mode, WalletMode::Command(_)) && !matches!(wallet_mode, WalletMode::Script(_)) {
+        if let Err(e) = wallet.transaction_service.restart_transaction_protocols().await {
+            error!(target: LOG_TARGET, "Problem restarting transaction protocols: {}", e);
+        }
+        if let Err(e) = start_transaction_validation_and_broadcast_protocols(
+            wallet.transaction_service.clone(),
+            ValidationRetryStrategy::UntilSuccess,
+        )
+        .await
+        {
+            error!(
+                target: LOG_TARGET,
+                "Problem validating and restarting transaction protocols: {}", e
+            );
+        }
 
+        // validate transaction outputs
+        validate_txos(wallet).await?;
+    }
     Ok(())
 }
 

--- a/applications/tari_console_wallet/src/main.rs
+++ b/applications/tari_console_wallet/src/main.rs
@@ -130,8 +130,10 @@ fn main_inner() -> Result<(), ExitCodes> {
     let base_node_config = runtime.block_on(get_base_node_peer_config(&config, &mut wallet))?;
     let base_node = base_node_config.get_base_node_peer()?;
 
+    let wallet_mode = wallet_mode(&bootstrap, boot_mode);
+
     // start wallet
-    runtime.block_on(start_wallet(&mut wallet, &base_node))?;
+    runtime.block_on(start_wallet(&mut wallet, &base_node, &wallet_mode))?;
 
     // optional path to notify script
     let notify_script = get_notify_script(&bootstrap, &config)?;
@@ -139,7 +141,7 @@ fn main_inner() -> Result<(), ExitCodes> {
     debug!(target: LOG_TARGET, "Starting app");
 
     let handle = runtime.handle().clone();
-    let result = match wallet_mode(bootstrap, boot_mode) {
+    let result = match wallet_mode {
         WalletMode::Tui => tui_mode(
             handle,
             config,

--- a/base_layer/wallet/src/base_node_service/mock_base_node_service.rs
+++ b/base_layer/wallet/src/base_node_service/mock_base_node_service.rs
@@ -100,6 +100,7 @@ impl MockBaseNodeService {
             updated: None,
             latency: None,
             online,
+            base_node_peer: self.state.base_node_peer.clone(),
         }
     }
 
@@ -111,11 +112,12 @@ impl MockBaseNodeService {
             updated: None,
             latency: None,
             online: OnlineState::Online,
+            base_node_peer: None,
         }
     }
 
     fn set_base_node_peer(&mut self, peer: Peer) {
-        self.base_node_peer = Some(peer);
+        self.state.base_node_peer = Some(peer);
     }
 
     /// This handler is called when requests arrive from the various streams

--- a/base_layer/wallet/src/base_node_service/mod.rs
+++ b/base_layer/wallet/src/base_node_service/mod.rs
@@ -92,7 +92,7 @@ where T: WalletBackend + 'static
             )
             .start();
             futures::pin_mut!(service);
-            future::select(service, handles.get_shutdown_signal()).await;
+            let _ = service.await;
             info!(target: LOG_TARGET, "Wallet Base Node Service shutdown");
         });
 


### PR DESCRIPTION
## Description
It was observed that during a stress test which fires a series of send_transaction calls in the wallet that there was a significant delay between some calls up to 30 seconds long during which no other Transaction Service events were firing in the services main select! loop. This turned out to be because the `send_transaction `operation involved a call to the Base Node Service (BNS) to check the latest tip height and this service was blocking its select! Loop when it made RPC calls to the base node. If these RPC calls took long the BNS service would not respond to API calls until The RPC request was complete. This blocked the select loops of the Output Manager Service and Transaction Service that relied on this call being fast. This also impacted the `get_balance` operation from the Output Manager Service which relies on a check of the last known tip height.

To fix this the BNS service was refactored so that the GetChainMetadata monitoring occurs in a separate asynchronous task that updates the services state when it gets an answer via RPC. The main select! loop was thus freed up to only respond to API requests that provide either the last updated chain metadata OR if no contact has been made with a base node during this run it will get the last persisted data from the database.

Another improvement that was made for the make-it-rain operation in the console wallet was to prevent the console wallet from performing the UTXO and Transaction validation operations when being run in `script` or `command` mode. The validation operations are long running tasks and should only be run if the console wallet is being run in a long running TUI mode.

@kukabi 

## How Has This Been Tested?
Existing tests 

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch.
* [x] I have squashed my commits into a single commit.
