### PR TITLE
Fix Pruned mode reorg past horizon test

### DIFF
--- a/integration_tests/features/Reorgs.feature
+++ b/integration_tests/features/Reorgs.feature
@@ -39,26 +39,11 @@ Feature: Reorgs
     Given I have a base node NODE1 connected to all seed nodes
     When I mine a block on NODE1 with coinbase CB1
     Given I have a base node NODE2 connected to node NODE1
-    When I mine but don't submit a block BLOCK2 on NODE2
-    When I mine but don't submit a block BLOCK3 on NODE2
-    When I mine but don't submit a block BLOCK4 on NODE2
-    When I mine but don't submit a block BLOCK5 on NODE2
-    When I mine but don't submit a block BLOCK6 on NODE2
-    When I mine but don't submit a block BLOCK7 on NODE2
-    When I mine but don't submit a block BLOCK8 on NODE2
-    When I mine but don't submit a block BLOCK9 on NODE2
-    When I mine but don't submit a block BLOCK10 on NODE2
-    When I mine but don't submit a block BLOCK11 on NODE2
-    When I mine but don't submit a block BLOCK12 on NODE2
-    When I mine but don't submit a block BLOCK13 on NODE2
-    When I mine but don't submit a block BLOCK14 on NODE2
-    When I mine but don't submit a block BLOCK15 on NODE2
-    When I mine but don't submit a block BLOCK16 on NODE2
-    When I mine but don't submit a block BLOCK17 on NODE2
-    When I mine but don't submit a block BLOCK18 on NODE2
-    When I mine but don't submit a block BLOCK19 on NODE2
-    When I mine but don't submit a block BLOCK20 on NODE2
+    And I stop NODE1
+    When I mine 19 blocks on NODE2
+    And node NODE2 is at height 20
     And I stop NODE2
+    And I start NODE1
     When I mine 3 blocks on NODE1
     When I create a transaction TX1 spending CB1 to UTX1
     When I submit transaction TX1 to NODE1
@@ -67,25 +52,6 @@ Feature: Reorgs
     Given I have a pruned node PNODE1 connected to node NODE1 with pruning horizon set to 5
     Then node PNODE1 is at height 10
     When I start NODE2
-    When I submit block BLOCK2 to NODE2
-    When I submit block BLOCK3 to NODE2
-    When I submit block BLOCK4 to NODE2
-    When I submit block BLOCK5 to NODE2
-    When I submit block BLOCK6 to NODE2
-    When I submit block BLOCK7 to NODE2
-    When I submit block BLOCK8 to NODE2
-    When I submit block BLOCK9 to NODE2
-    When I submit block BLOCK10 to NODE2
-    When I submit block BLOCK11 to NODE2
-    When I submit block BLOCK12 to NODE2
-    When I submit block BLOCK13 to NODE2
-    When I submit block BLOCK14 to NODE2
-    When I submit block BLOCK15 to NODE2
-    When I submit block BLOCK16 to NODE2
-    When I submit block BLOCK17 to NODE2
-    When I submit block BLOCK18 to NODE2
-    When I submit block BLOCK19 to NODE2
-    When I submit block BLOCK20 to NODE2
     Then all nodes are at height 20
     # Because TX1 should have been re_orged out we should be able to spend CB1 again
     When I create a transaction TX2 spending CB1 to UTX2


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This fixes the cucumber test: Pruned mode reorg past horizon.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The test Pruned mode reorg past horizon should not have worked but did work due to a bug ion mine, but don't submit code. This bug was fixed which broke this test. This test now works with the correct code. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch.
* [x I have squashed my commits into a single commit.
