### PR TITLE
[base-node] Optimise pruned UTXO sync streaming protocol

### DIFF
--- a/base_layer/core/src/base_node/proto/rpc.proto
+++ b/base_layer/core/src/base_node/proto/rpc.proto
@@ -55,37 +55,15 @@ message SyncUtxosRequest  {
   bool include_pruned_utxos = 3;
   bool include_deleted_bitmaps = 4;
 }
-
 message SyncUtxosResponse  {
-  repeated SyncUtxo utxos = 1;
-  // present if a utxo in utxos is the last in a block so that the merkle root can be
-  // checked
-  repeated bytes deleted_bitmaps = 2;
-}
-
-message SyncUtxo {
-  // The output. optional, if deleted at the time of the requested height,
-  // will be empty and `hash` and `rangeproof_hash` will be populated instead
-  tari.types.TransactionOutput output = 1;
-  // Only present if `output` is empty
-  bytes hash = 2;
-  // Only present if `output` is empty
-  bytes rangeproof_hash = 3;
-}
-
-message SyncUtxos2Response  {
   oneof utxo_or_deleted {
-    SyncUtxo2 utxo = 1;
-    Bitmaps deleted_bitmaps = 2;
+    SyncUtxo utxo = 1;
+    bytes deleted_diff = 2;
   }
   uint64 mmr_index = 3;
 }
 
-message Bitmaps {
-  repeated bytes bitmaps = 1;
-}
-
-message SyncUtxo2 {
+message SyncUtxo {
   oneof utxo {
     // The unspent transaction output
     tari.types.TransactionOutput output = 1;

--- a/base_layer/core/src/base_node/proto/rpc.rs
+++ b/base_layer/core/src/base_node/proto/rpc.rs
@@ -31,20 +31,20 @@ impl From<Block> for proto::BlockBodyResponse {
     }
 }
 
-impl From<PrunedOutput> for proto::SyncUtxo2 {
+impl From<PrunedOutput> for proto::SyncUtxo {
     fn from(output: PrunedOutput) -> Self {
         match output {
             PrunedOutput::Pruned {
                 output_hash,
                 range_proof_hash,
-            } => proto::SyncUtxo2 {
-                utxo: Some(proto::sync_utxo2::Utxo::PrunedOutput(proto::PrunedOutput {
+            } => proto::SyncUtxo {
+                utxo: Some(proto::sync_utxo::Utxo::PrunedOutput(proto::PrunedOutput {
                     hash: output_hash,
                     rangeproof_hash: range_proof_hash,
                 })),
             },
-            PrunedOutput::NotPruned { output } => proto::SyncUtxo2 {
-                utxo: Some(proto::sync_utxo2::Utxo::Output(output.into())),
+            PrunedOutput::NotPruned { output } => proto::SyncUtxo {
+                utxo: Some(proto::sync_utxo::Utxo::Output(output.into())),
             },
         }
     }

--- a/base_layer/core/src/base_node/proto/wallet_rpc.rs
+++ b/base_layer/core/src/base_node/proto/wallet_rpc.rs
@@ -228,27 +228,27 @@ impl TryFrom<proto::TxQueryBatchResponse> for TxQueryBatchResponse {
     }
 }
 
-impl proto::SyncUtxos2Response {
-    pub fn into_utxo(self) -> Option<proto::SyncUtxo2> {
-        use proto::sync_utxos2_response::UtxoOrDeleted::*;
+impl proto::SyncUtxosResponse {
+    pub fn into_utxo(self) -> Option<proto::SyncUtxo> {
+        use proto::sync_utxos_response::UtxoOrDeleted::*;
         match self.utxo_or_deleted? {
             Utxo(utxo) => Some(utxo),
-            DeletedBitmaps(_) => None,
+            DeletedDiff(_) => None,
         }
     }
 
-    pub fn into_bitmaps(self) -> Option<proto::Bitmaps> {
-        use proto::sync_utxos2_response::UtxoOrDeleted::*;
+    pub fn into_bitmap(self) -> Option<Vec<u8>> {
+        use proto::sync_utxos_response::UtxoOrDeleted::*;
         match self.utxo_or_deleted? {
             Utxo(_) => None,
-            DeletedBitmaps(bitmaps) => Some(bitmaps),
+            DeletedDiff(bitmap) => Some(bitmap),
         }
     }
 }
 
-impl proto::sync_utxo2::Utxo {
+impl proto::sync_utxo::Utxo {
     pub fn into_transaction_output(self) -> Option<types::TransactionOutput> {
-        use proto::sync_utxo2::Utxo::*;
+        use proto::sync_utxo::Utxo::*;
         match self {
             Output(output) => Some(output),
             PrunedOutput(_) => None,

--- a/base_layer/core/src/base_node/state_machine_service/state_machine.rs
+++ b/base_layer/core/src/base_node/state_machine_service/state_machine.rs
@@ -153,7 +153,7 @@ impl<B: BlockchainBackend + 'static> BaseNodeStateMachine<B> {
     }
 
     /// This function will publish the current StatusInfo to the channel
-    pub fn publish_event_info(&mut self) {
+    pub fn publish_event_info(&self) {
         let status = StatusInfo {
             bootstrapped: self.is_bootstrapped(),
             state_info: self.info.clone(),

--- a/base_layer/core/src/base_node/state_machine_service/states/horizon_state_sync/error.rs
+++ b/base_layer/core/src/base_node/state_machine_service/states/horizon_state_sync/error.rs
@@ -26,6 +26,7 @@ use crate::{
     transactions::transaction::TransactionError,
     validation::ValidationError,
 };
+use std::num::TryFromIntError;
 use tari_comms::protocol::rpc::{RpcError, RpcStatus};
 use tari_mmr::error::MerkleMountainRangeError;
 use thiserror::Error;
@@ -47,7 +48,7 @@ pub enum HorizonSyncError {
     JoinError(#[from] task::JoinError),
     #[error("Invalid kernel signature: {0}")]
     InvalidKernelSignature(TransactionError),
-    #[error("MMR did not match for {mmr_tree} at height {at_height}. {expected_hex} did not equal {actual_hex}")]
+    #[error("MMR did not match for {mmr_tree} at height {at_height}. Expected {actual_hex} to equal {expected_hex}")]
     InvalidMmrRoot {
         mmr_tree: MmrTree,
         at_height: u64,
@@ -66,4 +67,10 @@ pub enum HorizonSyncError {
     ConversionError(String),
     #[error("MerkleMountainRangeError: {0}")]
     MerkleMountainRangeError(#[from] MerkleMountainRangeError),
+}
+
+impl From<TryFromIntError> for HorizonSyncError {
+    fn from(err: TryFromIntError) -> Self {
+        HorizonSyncError::ConversionError(err.to_string())
+    }
 }

--- a/base_layer/core/src/base_node/sync/rpc/mod.rs
+++ b/base_layer/core/src/base_node/sync/rpc/mod.rs
@@ -25,6 +25,8 @@ mod service;
 #[cfg(feature = "base_node")]
 pub use service::BaseNodeSyncRpcService;
 
+// mod sync_utxos;
+
 // TODO: Tests need to be rewritten
 // #[cfg(test)]
 // mod tests;
@@ -40,7 +42,6 @@ use crate::{
         SyncBlocksRequest,
         SyncHeadersRequest,
         SyncKernelsRequest,
-        SyncUtxos2Response,
         SyncUtxosRequest,
         SyncUtxosResponse,
     },
@@ -86,12 +87,8 @@ pub trait BaseNodeSyncService: Send + Sync + 'static {
         request: Request<SyncKernelsRequest>,
     ) -> Result<Streaming<proto::types::TransactionKernel>, RpcStatus>;
 
-    #[rpc(method = 7)]
-    async fn sync_utxos(&self, request: Request<SyncUtxosRequest>) -> Result<Streaming<SyncUtxosResponse>, RpcStatus>;
-
     #[rpc(method = 8)]
-    async fn sync_utxos2(&self, request: Request<SyncUtxosRequest>)
-        -> Result<Streaming<SyncUtxos2Response>, RpcStatus>;
+    async fn sync_utxos(&self, request: Request<SyncUtxosRequest>) -> Result<Streaming<SyncUtxosResponse>, RpcStatus>;
 }
 
 #[cfg(feature = "base_node")]

--- a/base_layer/core/src/chain_storage/accumulated_data.rs
+++ b/base_layer/core/src/chain_storage/accumulated_data.rs
@@ -38,9 +38,12 @@ use serde::{
     Serialize,
     Serializer,
 };
-use std::{fmt, fmt::Display};
+use std::{
+    fmt,
+    fmt::{Display, Formatter},
+};
 use tari_crypto::tari_utilities::hex::Hex;
-use tari_mmr::pruned_hashset::PrunedHashSet;
+use tari_mmr::{pruned_hashset::PrunedHashSet, ArrayLike};
 
 const LOG_TARGET: &str = "c::bn::acc_data";
 
@@ -102,6 +105,19 @@ impl Default for BlockAccumulatedData {
             range_proofs: Default::default(),
             kernel_sum: Default::default(),
         }
+    }
+}
+
+impl Display for BlockAccumulatedData {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), fmt::Error> {
+        write!(
+            f,
+            "{} output(s), {} spent, {} kernel(s), {} rangeproof(s)",
+            self.outputs.len().unwrap_or(0),
+            self.deleted.deleted.cardinality(),
+            self.kernels.len().unwrap_or(0),
+            self.range_proofs.len().unwrap_or(0)
+        )
     }
 }
 

--- a/base_layer/core/src/chain_storage/async_db.rs
+++ b/base_layer/core/src/chain_storage/async_db.rs
@@ -142,7 +142,7 @@ impl<B: BlockchainBackend + 'static> AsyncBlockchainDb<B> {
 
     make_async_fn!(fetch_utxos(hashes: Vec<HashOutput>, is_spent_as_of: Option<HashOutput>) -> Vec<Option<(TransactionOutput, bool)>>, "fetch_utxos");
 
-    make_async_fn!(fetch_utxos_by_mmr_position(start: u64, end: u64, end_header_hash: HashOutput) -> (Vec<PrunedOutput>, Vec<Bitmap>), "fetch_utxos_by_mmr_position");
+    make_async_fn!(fetch_utxos_by_mmr_position(start: u64, end: u64, end_header_hash: HashOutput) -> (Vec<PrunedOutput>, Bitmap), "fetch_utxos_by_mmr_position");
 
     //---------------------------------- Kernel --------------------------------------------//
     make_async_fn!(fetch_kernel_by_excess_sig(excess_sig: Signature) -> Option<(TransactionKernel, HashOutput)>, "fetch_kernel_by_excess_sig");

--- a/base_layer/core/src/chain_storage/blockchain_backend.rs
+++ b/base_layer/core/src/chain_storage/blockchain_backend.rs
@@ -101,7 +101,7 @@ pub trait BlockchainBackend: Send + Sync {
         start: u64,
         end: u64,
         deleted: &Bitmap,
-    ) -> Result<(Vec<PrunedOutput>, Vec<Bitmap>), ChainStorageError>;
+    ) -> Result<(Vec<PrunedOutput>, Bitmap), ChainStorageError>;
 
     /// Fetch a specific output. Returns the output and the leaf index in the output MMR
     fn fetch_output(&self, output_hash: &HashOutput) -> Result<Option<(TransactionOutput, u32)>, ChainStorageError>;

--- a/base_layer/core/src/chain_storage/blockchain_database.rs
+++ b/base_layer/core/src/chain_storage/blockchain_database.rs
@@ -409,7 +409,7 @@ where B: BlockchainBackend
         start: u64,
         end: u64,
         end_header_hash: HashOutput,
-    ) -> Result<(Vec<PrunedOutput>, Vec<Bitmap>), ChainStorageError>
+    ) -> Result<(Vec<PrunedOutput>, Bitmap), ChainStorageError>
     {
         let db = self.db_read_access()?;
         let accum_data = db.fetch_block_accumulated_data(&end_header_hash).or_not_found(

--- a/base_layer/core/src/test_helpers/blockchain.rs
+++ b/base_layer/core/src/test_helpers/blockchain.rs
@@ -245,7 +245,7 @@ impl BlockchainBackend for TempDatabase {
         start: u64,
         end: u64,
         deleted: &Bitmap,
-    ) -> Result<(Vec<PrunedOutput>, Vec<Bitmap>), ChainStorageError>
+    ) -> Result<(Vec<PrunedOutput>, Bitmap), ChainStorageError>
     {
         self.db.fetch_utxos_by_mmr_position(start, end, deleted)
     }

--- a/comms/src/protocol/rpc/status.rs
+++ b/comms/src/protocol/rpc/status.rs
@@ -63,6 +63,8 @@ impl RpcStatus {
         }
     }
 
+    /// Returns a general error. As with all other errors care should be taken not to leak sensitive data to remote
+    /// peers through error messages.
     pub fn general<T: ToString>(details: T) -> Self {
         Self {
             code: RpcStatusCode::General,
@@ -88,10 +90,12 @@ impl RpcStatus {
         }
     }
 
+    /// Returns a closure that logs the given error and returns a generic general error that does not leak any
+    /// potentially sensitive error information. Use this function with map_err to catch "miscellaneous" errors.
     pub fn log_internal_error<'a, E: std::error::Error + 'a>(target: &'a str) -> impl Fn(E) -> Self + 'a {
         move |err| {
             log::error!(target: target, "Internal error: {}", err);
-            Self::general(err.to_string())
+            Self::general_default()
         }
     }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Streams a pruned UTXO set to a client. Each block boundary (given by the
header) is punctuated by a deleted MMR difference bitmap.

Replaces the previous sync_rpc method, which has been removed and so,
this PR is not backward-compatible.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Continues from changes in https://github.com/tari-project/tari/pull/2847. 
There are a few other performance optimisations still to be made for horizon sync. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manually tested. Sync took 15m.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch.
* [x] I have squashed my commits into a single commit.
