### PR TITLE
Add one-sided payments transaction protocol for tari script

### DIFF
--- a/base_layer/core/src/transactions/transaction_protocol/mod.rs
+++ b/base_layer/core/src/transactions/transaction_protocol/mod.rs
@@ -126,6 +126,8 @@ pub enum TransactionProtocolError {
     SerializationError,
     #[error("Conversion error: `{0}`")]
     ConversionError(String),
+    #[error("The script offset private key could not be found")]
+    ScriptOffsetPrivateKeyNotFound,
 }
 
 /// Transaction metadata, including the fee and lock height

--- a/base_layer/wallet/src/output_manager_service/handle.rs
+++ b/base_layer/wallet/src/output_manager_service/handle.rs
@@ -42,6 +42,7 @@ use tari_core::transactions::{
     ReceiverTransactionProtocol,
     SenderTransactionProtocol,
 };
+use tari_crypto::script::TariScript;
 use tari_service_framework::reply_channel::SenderService;
 use tokio::sync::broadcast;
 use tower::Service;
@@ -54,7 +55,7 @@ pub enum OutputManagerRequest {
     GetCoinbaseTransaction((u64, MicroTari, MicroTari, u64)),
     ConfirmPendingTransaction(u64),
     ConfirmTransaction((u64, Vec<TransactionInput>, Vec<TransactionOutput>)),
-    PrepareToSendTransaction((MicroTari, MicroTari, Option<u64>, String)),
+    PrepareToSendTransaction((MicroTari, MicroTari, Option<u64>, String, TariScript)),
     CreatePayToSelfTransaction((MicroTari, MicroTari, Option<u64>, String)),
     CancelTransaction(u64),
     TimeoutTransactions(Duration),
@@ -83,7 +84,7 @@ impl fmt::Display for OutputManagerRequest {
             GetRecipientTransaction(_) => write!(f, "GetRecipientTransaction"),
             ConfirmTransaction(v) => write!(f, "ConfirmTransaction ({})", v.0),
             ConfirmPendingTransaction(v) => write!(f, "ConfirmPendingTransaction ({})", v),
-            PrepareToSendTransaction((_, _, _, msg)) => write!(f, "PrepareToSendTransaction ({})", msg),
+            PrepareToSendTransaction((_, _, _, msg, _)) => write!(f, "PrepareToSendTransaction ({})", msg),
             CreatePayToSelfTransaction((_, _, _, msg)) => write!(f, "CreatePayToSelfTransaction ({})", msg),
             CancelTransaction(v) => write!(f, "CancelTransaction ({})", v),
             TimeoutTransactions(d) => write!(f, "TimeoutTransactions ({}s)", d.as_secs()),
@@ -240,6 +241,7 @@ impl OutputManagerHandle {
         fee_per_gram: MicroTari,
         lock_height: Option<u64>,
         message: String,
+        recipient_script: TariScript,
     ) -> Result<SenderTransactionProtocol, OutputManagerError>
     {
         match self
@@ -249,6 +251,7 @@ impl OutputManagerHandle {
                 fee_per_gram,
                 lock_height,
                 message,
+                recipient_script,
             )))
             .await??
         {

--- a/base_layer/wallet/src/output_manager_service/service.rs
+++ b/base_layer/wallet/src/output_manager_service/service.rs
@@ -299,8 +299,14 @@ where TBackend: OutputManagerBackend + 'static
                 .get_coinbase_transaction(tx_id, reward, fees, block_height)
                 .await
                 .map(OutputManagerResponse::CoinbaseTransaction),
-            OutputManagerRequest::PrepareToSendTransaction((amount, fee_per_gram, lock_height, message)) => self
-                .prepare_transaction_to_send(amount, fee_per_gram, lock_height, message)
+            OutputManagerRequest::PrepareToSendTransaction((
+                amount,
+                fee_per_gram,
+                lock_height,
+                message,
+                recipient_script,
+            )) => self
+                .prepare_transaction_to_send(amount, fee_per_gram, lock_height, message, recipient_script)
                 .await
                 .map(OutputManagerResponse::TransactionToSend),
             OutputManagerRequest::CreatePayToSelfTransaction((amount, fee_per_gram, lock_height, message)) => self
@@ -650,6 +656,7 @@ where TBackend: OutputManagerBackend + 'static
         fee_per_gram: MicroTari,
         lock_height: Option<u64>,
         message: String,
+        recipient_script: TariScript,
     ) -> Result<SenderTransactionProtocol, OutputManagerError>
     {
         debug!(
@@ -668,7 +675,7 @@ where TBackend: OutputManagerBackend + 'static
             .with_offset(offset.clone())
             .with_private_nonce(nonce.clone())
             .with_amount(0, amount)
-            .with_recipient_script(0, script!(Nop), PrivateKey::random(&mut OsRng))
+            .with_recipient_script(0, recipient_script, PrivateKey::random(&mut OsRng))
             .with_message(message)
             .with_prevent_fee_gt_amount(self.resources.config.prevent_fee_gt_amount);
 

--- a/base_layer/wallet/src/transaction_service/error.rs
+++ b/base_layer/wallet/src/transaction_service/error.rs
@@ -40,6 +40,8 @@ use tokio::sync::broadcast::RecvError;
 pub enum TransactionServiceError {
     #[error("Transaction protocol is not in the correct state for this operation")]
     InvalidStateError,
+    #[error("One-sided transaction error: `{0}`")]
+    OneSidedTransactionError(String),
     #[error("Transaction Protocol Error: `{0}`")]
     TransactionProtocolError(#[from] TransactionProtocolError),
     #[error("The message being processed is not recognized by the Transaction Manager")]
@@ -137,6 +139,8 @@ pub enum TransactionServiceError {
     ProtobufConversionError(String),
     #[error("Maximum Attempts Exceeded")]
     MaximumAttemptsExceeded,
+    #[error("Byte array error")]
+    ByteArrayError(#[from] tari_crypto::tari_utilities::ByteArrayError),
 }
 
 #[derive(Debug, Error)]

--- a/base_layer/wallet/tests/output_manager_service/service.rs
+++ b/base_layer/wallet/tests/output_manager_service/service.rs
@@ -242,7 +242,13 @@ fn sending_transaction_and_confirmation<T: Clone + OutputManagerBackend + 'stati
     }
 
     let stp = runtime
-        .block_on(oms.prepare_transaction_to_send(MicroTari::from(1000), MicroTari::from(20), None, "".to_string()))
+        .block_on(oms.prepare_transaction_to_send(
+            MicroTari::from(1000),
+            MicroTari::from(20),
+            None,
+            "".to_string(),
+            script!(Nop),
+        ))
         .unwrap();
 
     let sender_tx_id = stp.get_tx_id().unwrap();
@@ -428,7 +434,7 @@ fn test_utxo_selection_no_chain_metadata() {
     let amount = MicroTari::from(1000);
     let fee_per_gram = MicroTari::from(10);
     let err = runtime
-        .block_on(oms.prepare_transaction_to_send(amount, fee_per_gram, None, "".to_string()))
+        .block_on(oms.prepare_transaction_to_send(amount, fee_per_gram, None, "".to_string(), script!(Nop)))
         .unwrap_err();
     assert!(matches!(err, OutputManagerError::NotEnoughFunds));
 
@@ -445,7 +451,7 @@ fn test_utxo_selection_no_chain_metadata() {
 
     // but we have no chain state so the lowest maturity should be used
     let stp = runtime
-        .block_on(oms.prepare_transaction_to_send(amount, fee_per_gram, None, "".to_string()))
+        .block_on(oms.prepare_transaction_to_send(amount, fee_per_gram, None, "".to_string(), script!(Nop)))
         .unwrap();
     assert!(stp.get_tx_id().is_ok());
 
@@ -516,7 +522,7 @@ fn test_utxo_selection_with_chain_metadata() {
     let amount = MicroTari::from(1000);
     let fee_per_gram = MicroTari::from(10);
     let err = runtime
-        .block_on(oms.prepare_transaction_to_send(amount, fee_per_gram, None, "".to_string()))
+        .block_on(oms.prepare_transaction_to_send(amount, fee_per_gram, None, "".to_string(), script!(Nop)))
         .unwrap_err();
     assert!(matches!(err, OutputManagerError::NotEnoughFunds));
 
@@ -561,7 +567,7 @@ fn test_utxo_selection_with_chain_metadata() {
 
     // test transactions
     let stp = runtime
-        .block_on(oms.prepare_transaction_to_send(amount, fee_per_gram, None, "".to_string()))
+        .block_on(oms.prepare_transaction_to_send(amount, fee_per_gram, None, "".to_string(), script!(Nop)))
         .unwrap();
     assert!(stp.get_tx_id().is_ok());
 
@@ -577,7 +583,7 @@ fn test_utxo_selection_with_chain_metadata() {
 
     // when the amount is greater than the largest utxo, then "Largest" selection strategy is used
     let stp = runtime
-        .block_on(oms.prepare_transaction_to_send(6 * amount, fee_per_gram, None, "".to_string()))
+        .block_on(oms.prepare_transaction_to_send(6 * amount, fee_per_gram, None, "".to_string(), script!(Nop)))
         .unwrap();
     assert!(stp.get_tx_id().is_ok());
 
@@ -640,6 +646,7 @@ fn send_not_enough_funds<T: OutputManagerBackend + 'static>(backend: T) {
         MicroTari::from(20),
         None,
         "".to_string(),
+        script!(Nop),
     )) {
         Err(OutputManagerError::NotEnoughFunds) => {},
         _ => panic!(),
@@ -708,6 +715,7 @@ fn send_no_change<T: OutputManagerBackend + 'static>(backend: T) {
             fee_per_gram,
             None,
             "".to_string(),
+            script!(Nop),
         ))
         .unwrap();
 
@@ -805,6 +813,7 @@ fn send_not_enough_for_change<T: OutputManagerBackend + 'static>(backend: T) {
         MicroTari::from(20),
         None,
         "".to_string(),
+        script!(Nop),
     )) {
         Err(OutputManagerError::NotEnoughFunds) => {},
         _ => panic!(),
@@ -915,7 +924,13 @@ fn cancel_transaction<T: OutputManagerBackend + 'static>(backend: T) {
         runtime.block_on(oms.add_output(uo)).unwrap();
     }
     let stp = runtime
-        .block_on(oms.prepare_transaction_to_send(MicroTari::from(1000), MicroTari::from(20), None, "".to_string()))
+        .block_on(oms.prepare_transaction_to_send(
+            MicroTari::from(1000),
+            MicroTari::from(20),
+            None,
+            "".to_string(),
+            script!(Nop),
+        ))
         .unwrap();
 
     match runtime.block_on(oms.cancel_transaction(1)) {
@@ -962,7 +977,13 @@ fn timeout_transaction<T: OutputManagerBackend + 'static>(backend: T) {
         runtime.block_on(oms.add_output(uo)).unwrap();
     }
     let _stp = runtime
-        .block_on(oms.prepare_transaction_to_send(MicroTari::from(1000), MicroTari::from(20), None, "".to_string()))
+        .block_on(oms.prepare_transaction_to_send(
+            MicroTari::from(1000),
+            MicroTari::from(20),
+            None,
+            "".to_string(),
+            script!(Nop),
+        ))
         .unwrap();
 
     let remaining_outputs = runtime.block_on(oms.get_unspent_outputs()).unwrap().len();
@@ -1023,7 +1044,7 @@ fn test_get_balance<T: OutputManagerBackend + 'static>(backend: T) {
 
     let send_value = MicroTari::from(1000);
     let stp = runtime
-        .block_on(oms.prepare_transaction_to_send(send_value, MicroTari::from(20), None, "".to_string()))
+        .block_on(oms.prepare_transaction_to_send(send_value, MicroTari::from(20), None, "".to_string(), script!(Nop)))
         .unwrap();
 
     let change_val = stp.get_change_amount().unwrap();
@@ -1115,7 +1136,13 @@ fn sending_transaction_with_short_term_clear<T: Clone + OutputManagerBackend + '
 
     // Check that funds are encumbered and then unencumbered if the pending tx is not confirmed before restart
     let _stp = runtime
-        .block_on(oms.prepare_transaction_to_send(MicroTari::from(1000), MicroTari::from(20), None, "".to_string()))
+        .block_on(oms.prepare_transaction_to_send(
+            MicroTari::from(1000),
+            MicroTari::from(20),
+            None,
+            "".to_string(),
+            script!(Nop),
+        ))
         .unwrap();
 
     let balance = runtime.block_on(oms.get_balance()).unwrap();
@@ -1130,7 +1157,13 @@ fn sending_transaction_with_short_term_clear<T: Clone + OutputManagerBackend + '
 
     // Check that a unconfirm Pending Transaction can be cancelled
     let stp = runtime
-        .block_on(oms.prepare_transaction_to_send(MicroTari::from(1000), MicroTari::from(20), None, "".to_string()))
+        .block_on(oms.prepare_transaction_to_send(
+            MicroTari::from(1000),
+            MicroTari::from(20),
+            None,
+            "".to_string(),
+            script!(Nop),
+        ))
         .unwrap();
     let sender_tx_id = stp.get_tx_id().unwrap();
 
@@ -1143,7 +1176,13 @@ fn sending_transaction_with_short_term_clear<T: Clone + OutputManagerBackend + '
 
     // Check that is the pending tx is confirmed that the encumberance persists after restart
     let stp = runtime
-        .block_on(oms.prepare_transaction_to_send(MicroTari::from(1000), MicroTari::from(20), None, "".to_string()))
+        .block_on(oms.prepare_transaction_to_send(
+            MicroTari::from(1000),
+            MicroTari::from(20),
+            None,
+            "".to_string(),
+            script!(Nop),
+        ))
         .unwrap();
     let sender_tx_id = stp.get_tx_id().unwrap();
     runtime.block_on(oms.confirm_pending_transaction(sender_tx_id)).unwrap();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- Added one-sided payment transaction to other to the transaction sending protocols as another tari script transaction variant. Consecutive PRs must extend the wiring into the user interfaces.
- Added one-sided unit tests.
- Generalized the normal `prepare_transaction_to_send` interface in the output manager service to accept a variable tari script

## Motivation and Context
Expanding tari script

## How Has This Been Tested?
Developed two unit tests

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [X] I'm merging against the `tari-script` branch.
* [X] I have squashed my commits into a single commit.
