### PR TITLE
[Wallet] Add mined height to display of mined transactions in Console Wallet

### DIFF
--- a/applications/tari_console_wallet/src/ui/components/transactions_tab.rs
+++ b/applications/tari_console_wallet/src/ui/components/transactions_tab.rs
@@ -237,6 +237,7 @@ impl TransactionsTab {
                     Constraint::Length(1),
                     Constraint::Length(1),
                     Constraint::Length(1),
+                    Constraint::Length(1),
                 ]
                 .as_ref(),
             )
@@ -253,6 +254,7 @@ impl TransactionsTab {
         let timestamp = Span::styled("Timestamp:", Style::default().fg(Color::Magenta));
         let excess = Span::styled("Excess:", Style::default().fg(Color::Magenta));
         let confirmations = Span::styled("Confirmations:", Style::default().fg(Color::Magenta));
+        let mined_height = Span::styled("Mined Height:", Style::default().fg(Color::Magenta));
         let paragraph = Paragraph::new(tx_id).wrap(Wrap { trim: true });
         f.render_widget(paragraph, label_layout[0]);
         let paragraph = Paragraph::new(source_public_key).wrap(Wrap { trim: true });
@@ -275,12 +277,15 @@ impl TransactionsTab {
         f.render_widget(paragraph, label_layout[9]);
         let paragraph = Paragraph::new(confirmations).wrap(Wrap { trim: true });
         f.render_widget(paragraph, label_layout[10]);
+        let paragraph = Paragraph::new(mined_height).wrap(Wrap { trim: true });
+        f.render_widget(paragraph, label_layout[11]);
         // Content:
         let required_confirmations = app_state.get_required_confirmations();
         if let Some(tx) = self.detailed_transaction.as_ref() {
             let content_layout = Layout::default()
                 .constraints(
                     [
+                        Constraint::Length(1),
                         Constraint::Length(1),
                         Constraint::Length(1),
                         Constraint::Length(1),
@@ -349,6 +354,13 @@ impl TransactionsTab {
                 "N/A".to_string()
             };
             let confirmations = Span::styled(confirmations_msg.as_str(), Style::default().fg(Color::White));
+            let mined_height = Span::styled(
+                tx.mined_height
+                    .map(|m| m.to_string())
+                    .unwrap_or_else(|| "N/A".to_string()),
+                Style::default().fg(Color::White),
+            );
+
             let paragraph = Paragraph::new(tx_id).wrap(Wrap { trim: true });
             f.render_widget(paragraph, content_layout[0]);
             let paragraph = Paragraph::new(source_public_key).wrap(Wrap { trim: true });
@@ -371,6 +383,8 @@ impl TransactionsTab {
             f.render_widget(paragraph, content_layout[9]);
             let paragraph = Paragraph::new(confirmations).wrap(Wrap { trim: true });
             f.render_widget(paragraph, content_layout[10]);
+            let paragraph = Paragraph::new(mined_height).wrap(Wrap { trim: true });
+            f.render_widget(paragraph, content_layout[11]);
         }
     }
 }
@@ -383,7 +397,7 @@ impl<B: Backend> Component<B> for TransactionsTab {
                     Constraint::Length(3),
                     Constraint::Length(1),
                     Constraint::Min(10),
-                    Constraint::Length(13),
+                    Constraint::Length(14),
                 ]
                 .as_ref(),
             )

--- a/base_layer/wallet/migrations/2021-04-19-085137_add_mined_height_to_completed_transaction/down.sql
+++ b/base_layer/wallet/migrations/2021-04-19-085137_add_mined_height_to_completed_transaction/down.sql
@@ -1,0 +1,23 @@
+PRAGMA foreign_keys=off;
+ALTER TABLE completed_transactions RENAME TO completed_transactions_old;
+CREATE TABLE completed_transactions (
+                                        tx_id INTEGER PRIMARY KEY NOT NULL,
+                                        source_public_key BLOB NOT NULL,
+                                        destination_public_key BLOB NOT NULL,
+                                        amount INTEGER NOT NULL,
+                                        fee INTEGER NOT NULL,
+                                        transaction_protocol TEXT NOT NULL,
+                                        status INTEGER NOT NULL,
+                                        message TEXT NOT NULL,
+                                        timestamp DATETIME NOT NULL,
+                                        cancelled INTEGER NOT NULL DEFAULT 0,
+                                        direction INTEGER NULL DEFAULT NULL,
+                                        coinbase_block_height INTEGER NULL DEFAULT NULL,
+                                        send_count INTEGER NOT NULL DEFAULT 0,
+                                        last_send_timestamp DATETIME NULL DEFAULT NULL,
+                                        valid INTEGER NOT NULL DEFAULT 0,
+                                        confirmations INTEGER NULL DEFAULT NULL
+);
+INSERT INTO completed_transactions (tx_id, source_public_key, destination_public_key, amount, fee, transaction_protocol, status, message, timestamp, cancelled, direction, coinbase_block_height, send_count, last_send_timestamp, valid, confirmations)
+SELECT tx_id, source_public_key, destination_public_key, amount, fee, transaction_protocol, status, message, timestamp, cancelled, direction, coinbase_block_height, send_count, last_send_timestamp, valid, confirmations
+FROM completed_transactions_old;

--- a/base_layer/wallet/migrations/2021-04-19-085137_add_mined_height_to_completed_transaction/up.sql
+++ b/base_layer/wallet/migrations/2021-04-19-085137_add_mined_height_to_completed_transaction/up.sql
@@ -1,0 +1,2 @@
+ALTER TABLE completed_transactions
+    ADD COLUMN mined_height INTEGER NULL;

--- a/base_layer/wallet/src/schema.rs
+++ b/base_layer/wallet/src/schema.rs
@@ -23,6 +23,7 @@ table! {
         last_send_timestamp -> Nullable<Timestamp>,
         valid -> Integer,
         confirmations -> Nullable<BigInt>,
+        mined_height -> Nullable<BigInt>,
     }
 }
 

--- a/base_layer/wallet/src/transaction_service/protocols/transaction_broadcast_protocol.rs
+++ b/base_layer/wallet/src/transaction_service/protocols/transaction_broadcast_protocol.rs
@@ -494,6 +494,15 @@ where TBackend: TransactionBackend + 'static
                 .await
                 .map_err(|e| TransactionServiceProtocolError::new(self.tx_id, TransactionServiceError::from(e)))?;
 
+            self.resources
+                .db
+                .set_transaction_mined_height(
+                    self.tx_id,
+                    response.height_of_longest_chain.saturating_sub(response.confirmations),
+                )
+                .await
+                .map_err(|e| TransactionServiceProtocolError::new(self.tx_id, TransactionServiceError::from(e)))?;
+
             if response.confirmations >= self.resources.config.num_confirmations_required as u64 {
                 info!(
                     target: LOG_TARGET,
@@ -514,7 +523,6 @@ where TBackend: TransactionBackend + 'static
                 .mine_completed_transaction(self.tx_id)
                 .await
                 .map_err(|e| TransactionServiceProtocolError::new(self.tx_id, TransactionServiceError::from(e)))?;
-
             let _ = self
                 .resources
                 .event_publisher

--- a/base_layer/wallet/src/transaction_service/protocols/transaction_coinbase_monitoring_protocol.rs
+++ b/base_layer/wallet/src/transaction_service/protocols/transaction_coinbase_monitoring_protocol.rs
@@ -540,6 +540,12 @@ where TBackend: TransactionBackend + 'static
                 self.tx_id,
                 response.confirmations
             );
+
+            self.resources
+                .db
+                .set_transaction_mined_height(self.tx_id, self.block_height)
+                .await
+                .map_err(|e| TransactionServiceProtocolError::new(self.tx_id, TransactionServiceError::from(e)))?;
             self.resources
                 .db
                 .mine_completed_transaction(self.tx_id)

--- a/base_layer/wallet/src/transaction_service/storage/models.rs
+++ b/base_layer/wallet/src/transaction_service/storage/models.rs
@@ -202,6 +202,7 @@ pub struct CompletedTransaction {
     pub last_send_timestamp: Option<NaiveDateTime>,
     pub valid: bool,
     pub confirmations: Option<u64>,
+    pub mined_height: Option<u64>,
 }
 
 impl CompletedTransaction {
@@ -237,6 +238,7 @@ impl CompletedTransaction {
             last_send_timestamp: None,
             valid: true,
             confirmations: None,
+            mined_height: None,
         }
     }
 }
@@ -330,6 +332,7 @@ impl From<OutboundTransaction> for CompletedTransaction {
             last_send_timestamp: None,
             valid: true,
             confirmations: None,
+            mined_height: None,
         }
     }
 }
@@ -353,6 +356,7 @@ impl From<InboundTransaction> for CompletedTransaction {
             last_send_timestamp: None,
             valid: true,
             confirmations: None,
+            mined_height: None,
         }
     }
 }

--- a/base_layer/wallet/src/transaction_service/storage/sqlite_db.rs
+++ b/base_layer/wallet/src/transaction_service/storage/sqlite_db.rs
@@ -518,6 +518,7 @@ impl TransactionBackend for TransactionServiceSqliteDatabase {
                             last_send_timestamp: None,
                             valid: None,
                             confirmations: None,
+                            mined_height: None,
                         }),
                         &(*conn),
                     )?;
@@ -548,6 +549,7 @@ impl TransactionBackend for TransactionServiceSqliteDatabase {
                         last_send_timestamp: None,
                         valid: None,
                         confirmations: None,
+                        mined_height: None,
                     }),
                     &(*conn),
                 )?;
@@ -658,6 +660,7 @@ impl TransactionBackend for TransactionServiceSqliteDatabase {
                     last_send_timestamp: None,
                     valid: None,
                     confirmations: None,
+                    mined_height: None,
                 }),
                 &(*conn),
             )?;
@@ -815,6 +818,7 @@ impl TransactionBackend for TransactionServiceSqliteDatabase {
                 last_send_timestamp: Some(Some(Utc::now().naive_utc())),
                 valid: None,
                 confirmations: None,
+                mined_height: None,
             };
             tx.update(update, &conn)?;
         } else if let Ok(tx) = OutboundTransactionSql::find(tx_id, &conn) {
@@ -909,6 +913,22 @@ impl TransactionBackend for TransactionServiceSqliteDatabase {
         match CompletedTransactionSql::find_by_cancelled(tx_id, false, &(*conn)) {
             Ok(v) => {
                 v.update_confirmations(confirmations, &(*conn))?;
+            },
+            Err(TransactionStorageError::DieselError(DieselError::NotFound)) => {
+                return Err(TransactionStorageError::ValueNotFound(DbKey::CompletedTransaction(
+                    tx_id,
+                )));
+            },
+            Err(e) => return Err(e),
+        };
+        Ok(())
+    }
+
+    fn update_mined_height(&self, tx_id: u64, mined_height: u64) -> Result<(), TransactionStorageError> {
+        let conn = self.database_connection.acquire_lock();
+        match CompletedTransactionSql::find_by_cancelled(tx_id, false, &(*conn)) {
+            Ok(v) => {
+                v.update_mined_height(mined_height, &(*conn))?;
             },
             Err(TransactionStorageError::DieselError(DieselError::NotFound)) => {
                 return Err(TransactionStorageError::ValueNotFound(DbKey::CompletedTransaction(
@@ -1313,6 +1333,7 @@ struct CompletedTransactionSql {
     last_send_timestamp: Option<NaiveDateTime>,
     valid: i32,
     confirmations: Option<i64>,
+    mined_height: Option<i64>,
 }
 
 impl CompletedTransactionSql {
@@ -1410,6 +1431,7 @@ impl CompletedTransactionSql {
                 last_send_timestamp: None,
                 valid: None,
                 confirmations: None,
+                mined_height: None,
             },
             conn,
         )?;
@@ -1429,6 +1451,7 @@ impl CompletedTransactionSql {
                 last_send_timestamp: None,
                 valid: None,
                 confirmations: None,
+                mined_height: None,
             },
             conn,
         )?;
@@ -1448,6 +1471,7 @@ impl CompletedTransactionSql {
                 last_send_timestamp: None,
                 valid: None,
                 confirmations: None,
+                mined_height: None,
             },
             conn,
         )?;
@@ -1467,6 +1491,7 @@ impl CompletedTransactionSql {
                 last_send_timestamp: None,
                 valid: Some(valid as i32),
                 confirmations: None,
+                mined_height: None,
             },
             conn,
         )?;
@@ -1486,6 +1511,7 @@ impl CompletedTransactionSql {
                 last_send_timestamp: None,
                 valid: None,
                 confirmations: None,
+                mined_height: None,
             },
             conn,
         )?;
@@ -1510,6 +1536,32 @@ impl CompletedTransactionSql {
                 last_send_timestamp: None,
                 valid: None,
                 confirmations: Some(Some(confirmations as i64)),
+                mined_height: None,
+            },
+            conn,
+        )?;
+
+        Ok(())
+    }
+
+    pub fn update_mined_height(
+        &self,
+        mined_height: u64,
+        conn: &SqliteConnection,
+    ) -> Result<(), TransactionStorageError>
+    {
+        self.update(
+            UpdateCompletedTransactionSql {
+                status: None,
+                timestamp: None,
+                cancelled: None,
+                direction: None,
+                transaction_protocol: None,
+                send_count: None,
+                last_send_timestamp: None,
+                valid: None,
+                confirmations: None,
+                mined_height: Some(Some(mined_height as i64)),
             },
             conn,
         )?;
@@ -1559,6 +1611,7 @@ impl TryFrom<CompletedTransaction> for CompletedTransactionSql {
             last_send_timestamp: c.last_send_timestamp,
             valid: c.valid as i32,
             confirmations: c.confirmations.map(|ic| ic as i64),
+            mined_height: c.mined_height.map(|ic| ic as i64),
         })
     }
 }
@@ -1586,6 +1639,7 @@ impl TryFrom<CompletedTransactionSql> for CompletedTransaction {
             last_send_timestamp: c.last_send_timestamp,
             valid: c.valid != 0,
             confirmations: c.confirmations.map(|ic| ic as u64),
+            mined_height: c.mined_height.map(|ic| ic as u64),
         })
     }
 }
@@ -1600,6 +1654,7 @@ pub struct UpdateCompletedTransaction {
     last_send_timestamp: Option<Option<NaiveDateTime>>,
     valid: Option<bool>,
     confirmations: Option<Option<u64>>,
+    mined_height: Option<Option<u64>>,
 }
 
 #[derive(AsChangeset)]
@@ -1614,6 +1669,7 @@ pub struct UpdateCompletedTransactionSql {
     last_send_timestamp: Option<Option<NaiveDateTime>>,
     valid: Option<i32>,
     confirmations: Option<Option<i64>>,
+    mined_height: Option<Option<i64>>,
 }
 
 /// Map a Rust friendly UpdateCompletedTransaction to the Sql data type form
@@ -1629,6 +1685,7 @@ impl From<UpdateCompletedTransaction> for UpdateCompletedTransactionSql {
             last_send_timestamp: u.last_send_timestamp,
             valid: u.valid.map(|c| c as i32),
             confirmations: u.confirmations.map(|c| c.map(|ic| ic as i64)),
+            mined_height: u.mined_height.map(|c| c.map(|ic| ic as i64)),
         }
     }
 }
@@ -1832,6 +1889,7 @@ mod test {
             last_send_timestamp: None,
             valid: true,
             confirmations: None,
+            mined_height: None,
         };
         let completed_tx2 = CompletedTransaction {
             tx_id: 3,
@@ -1850,6 +1908,7 @@ mod test {
             last_send_timestamp: None,
             valid: true,
             confirmations: None,
+            mined_height: None,
         };
 
         CompletedTransactionSql::try_from(completed_tx1.clone())
@@ -1966,6 +2025,7 @@ mod test {
             last_send_timestamp: None,
             valid: true,
             confirmations: None,
+            mined_height: None,
         };
 
         let coinbase_tx2 = CompletedTransaction {
@@ -1985,6 +2045,7 @@ mod test {
             last_send_timestamp: None,
             valid: true,
             confirmations: None,
+            mined_height: None,
         };
 
         let coinbase_tx3 = CompletedTransaction {
@@ -2004,6 +2065,7 @@ mod test {
             last_send_timestamp: None,
             valid: true,
             confirmations: None,
+            mined_height: None,
         };
 
         CompletedTransactionSql::try_from(coinbase_tx1)
@@ -2040,6 +2102,7 @@ mod test {
                     last_send_timestamp: None,
                     valid: None,
                     confirmations: None,
+                    mined_height: None,
                 },
                 &conn,
             )
@@ -2126,6 +2189,7 @@ mod test {
             last_send_timestamp: None,
             valid: true,
             confirmations: None,
+            mined_height: None,
         };
 
         let mut completed_tx_sql = CompletedTransactionSql::try_from(completed_tx.clone()).unwrap();
@@ -2200,6 +2264,7 @@ mod test {
             last_send_timestamp: None,
             valid: true,
             confirmations: None,
+            mined_height: None,
         };
         let completed_tx_sql = CompletedTransactionSql::try_from(completed_tx).unwrap();
         completed_tx_sql.commit(&conn).unwrap();

--- a/base_layer/wallet/tests/transaction_service/service.rs
+++ b/base_layer/wallet/tests/transaction_service/service.rs
@@ -1472,6 +1472,7 @@ fn test_power_mode_updates() {
         last_send_timestamp: None,
         valid: true,
         confirmations: None,
+        mined_height: None,
     };
 
     let completed_tx2 = CompletedTransaction {
@@ -1491,6 +1492,7 @@ fn test_power_mode_updates() {
         last_send_timestamp: None,
         valid: true,
         confirmations: None,
+        mined_height: None,
     };
 
     backend
@@ -4339,6 +4341,7 @@ fn broadcast_all_completed_transactions_on_startup() {
         last_send_timestamp: None,
         valid: true,
         confirmations: None,
+        mined_height: None,
     };
 
     let completed_tx2 = CompletedTransaction {
@@ -4669,6 +4672,7 @@ fn only_start_one_tx_broadcast_protocol_at_a_time() {
         last_send_timestamp: None,
         valid: true,
         confirmations: None,
+        mined_height: None,
     };
 
     backend
@@ -4729,6 +4733,7 @@ fn dont_broadcast_invalid_transactions() {
         last_send_timestamp: None,
         valid: false,
         confirmations: None,
+        mined_height: None,
     };
 
     backend

--- a/base_layer/wallet/tests/transaction_service/storage.rs
+++ b/base_layer/wallet/tests/transaction_service/storage.rs
@@ -242,6 +242,7 @@ pub fn test_db_backend<T: TransactionBackend + 'static>(backend: T) {
             last_send_timestamp: None,
             valid: true,
             confirmations: None,
+            mined_height: None,
         });
         runtime
             .block_on(db.complete_outbound_transaction(outbound_txs[i].tx_id, completed_txs[i].clone()))

--- a/base_layer/wallet/tests/transaction_service/transaction_protocols.rs
+++ b/base_layer/wallet/tests/transaction_service/transaction_protocols.rs
@@ -304,7 +304,7 @@ async fn tx_broadcast_protocol_submit_success() {
         block_hash: None,
         confirmations: 1,
         is_synced: false,
-        height_of_longest_chain: 0,
+        height_of_longest_chain: 10,
     });
     // Wait for 1 query
     let _ = rpc_service_state
@@ -322,7 +322,7 @@ async fn tx_broadcast_protocol_submit_success() {
         block_hash: None,
         confirmations: 1,
         is_synced: true,
-        height_of_longest_chain: 0,
+        height_of_longest_chain: 10,
     });
     // Wait for 1 query
     let _ = rpc_service_state
@@ -341,7 +341,7 @@ async fn tx_broadcast_protocol_submit_success() {
         block_hash: None,
         confirmations: resources.config.num_confirmations_required,
         is_synced: false,
-        height_of_longest_chain: 0,
+        height_of_longest_chain: 10,
     });
 
     let _ = rpc_service_state
@@ -359,7 +359,7 @@ async fn tx_broadcast_protocol_submit_success() {
         block_hash: None,
         confirmations: resources.config.num_confirmations_required,
         is_synced: true,
-        height_of_longest_chain: 0,
+        height_of_longest_chain: 10,
     });
 
     // Check that the protocol ends with success
@@ -372,6 +372,10 @@ async fn tx_broadcast_protocol_submit_success() {
     assert_eq!(
         db_completed_tx.confirmations,
         Some(resources.config.num_confirmations_required)
+    );
+    assert_eq!(
+        db_completed_tx.mined_height,
+        Some(10 - resources.config.num_confirmations_required)
     );
 
     // Check that the appropriate events were emitted
@@ -882,7 +886,7 @@ async fn tx_broadcast_protocol_submit_already_mined() {
         block_hash: None,
         confirmations: resources.config.num_confirmations_required,
         is_synced: true,
-        height_of_longest_chain: 0,
+        height_of_longest_chain: 10,
     });
 
     // Check that the protocol ends with success
@@ -892,6 +896,10 @@ async fn tx_broadcast_protocol_submit_already_mined() {
     // Check transaction status is updated
     let db_completed_tx = resources.db.get_completed_transaction(1).await.unwrap();
     assert_eq!(db_completed_tx.status, TransactionStatus::MinedConfirmed);
+    assert_eq!(
+        db_completed_tx.mined_height,
+        Some(10 - resources.config.num_confirmations_required)
+    );
 }
 
 /// A test to see that the broadcast protocol can handle a change to the base node address while it runs.


### PR DESCRIPTION
## Description

This PR adds the persistence of the height at which a transaction was mined to the CompletedTransaction table and displays this value in the Details pane in the console wallet.

## How Has This Been Tested?
Existing tests updated to also check this logic

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch.
* [x] I have squashed my commits into a single commit.
