### PR TITLE
[wallet] Add send one-sided tx to console wallet TUI (tari-script)

### DIFF
--- a/applications/tari_console_wallet/src/ui/state/app_state.rs
+++ b/applications/tari_console_wallet/src/ui/state/app_state.rs
@@ -1,7 +1,32 @@
+// Copyright 2020. The Tari Project
+//
+// Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+// following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+// disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+// following disclaimer in the documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+// products derived from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+// INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+// WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+// USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
 use crate::{
     notifier::Notifier,
     ui::{
-        state::wallet_event_monitor::WalletEventMonitor,
+        state::{
+            tasks::{send_one_sided_transaction_task, send_transaction_task},
+            wallet_event_monitor::WalletEventMonitor,
+        },
         UiContact,
         UiError,
         CUSTOM_BASE_NODE_ADDRESS_KEY,
@@ -37,7 +62,7 @@ use tari_wallet::{
         TxId,
     },
     transaction_service::{
-        handle::{TransactionEvent, TransactionEventReceiver, TransactionServiceHandle},
+        handle::TransactionEventReceiver,
         storage::models::{CompletedTransaction, TransactionStatus},
     },
     types::ValidationRetryStrategy,
@@ -167,6 +192,35 @@ impl AppState {
         let fee_per_gram = fee_per_gram * uT;
         let tx_service_handle = inner.wallet.transaction_service.clone();
         tokio::spawn(send_transaction_task(
+            public_key,
+            MicroTari::from(amount),
+            message,
+            fee_per_gram,
+            tx_service_handle,
+            result_tx,
+        ));
+
+        Ok(())
+    }
+
+    pub async fn send_one_sided_transaction(
+        &mut self,
+        public_key: String,
+        amount: u64,
+        fee_per_gram: u64,
+        message: String,
+        result_tx: watch::Sender<UiTransactionSendStatus>,
+    ) -> Result<(), UiError>
+    {
+        let inner = self.inner.write().await;
+        let public_key = match CommsPublicKey::from_hex(public_key.as_str()) {
+            Ok(pk) => pk,
+            Err(_) => EmojiId::str_to_pubkey(public_key.as_str()).map_err(|_| UiError::PublicKeyParseError)?,
+        };
+
+        let fee_per_gram = fee_per_gram * uT;
+        let tx_service_handle = inner.wallet.transaction_service.clone();
+        tokio::spawn(send_one_sided_transaction_task(
             public_key,
             MicroTari::from(amount),
             message,
@@ -823,79 +877,6 @@ pub struct MyIdentity {
     pub public_address: String,
     pub emoji_id: String,
     pub qr_code: String,
-}
-
-pub async fn send_transaction_task(
-    public_key: CommsPublicKey,
-    amount: MicroTari,
-    message: String,
-    fee_per_gram: MicroTari,
-    mut transaction_service_handle: TransactionServiceHandle,
-    result_tx: watch::Sender<UiTransactionSendStatus>,
-)
-{
-    let _ = result_tx.broadcast(UiTransactionSendStatus::Initiated);
-    let mut event_stream = transaction_service_handle.get_event_stream_fused();
-    let mut send_direct_received_result = (false, false);
-    let mut send_saf_received_result = (false, false);
-    match transaction_service_handle
-        .send_transaction(public_key, amount, fee_per_gram, message)
-        .await
-    {
-        Err(e) => {
-            let _ = result_tx.broadcast(UiTransactionSendStatus::Error(UiError::from(e).to_string()));
-        },
-        Ok(our_tx_id) => {
-            while let Some(event_result) = event_stream.next().await {
-                match event_result {
-                    Ok(event) => match &*event {
-                        TransactionEvent::TransactionDiscoveryInProgress(tx_id) => {
-                            if our_tx_id == *tx_id {
-                                let _ = result_tx.broadcast(UiTransactionSendStatus::DiscoveryInProgress);
-                            }
-                        },
-                        TransactionEvent::TransactionDirectSendResult(tx_id, result) => {
-                            if our_tx_id == *tx_id {
-                                send_direct_received_result = (true, *result);
-                                if send_saf_received_result.0 {
-                                    break;
-                                }
-                            }
-                        },
-                        TransactionEvent::TransactionStoreForwardSendResult(tx_id, result) => {
-                            if our_tx_id == *tx_id {
-                                send_saf_received_result = (true, *result);
-                                if send_direct_received_result.0 {
-                                    break;
-                                }
-                            }
-                        },
-                        TransactionEvent::TransactionCompletedImmediately(tx_id) => {
-                            if our_tx_id == *tx_id {
-                                let _ = result_tx.broadcast(UiTransactionSendStatus::TransactionComplete);
-                                return;
-                            }
-                        },
-                        _ => (),
-                    },
-                    Err(e) => {
-                        log::warn!(target: LOG_TARGET, "Error reading from event broadcast channel {:?}", e);
-                        break;
-                    },
-                }
-            }
-
-            if send_direct_received_result.1 {
-                let _ = result_tx.broadcast(UiTransactionSendStatus::SentDirect);
-            } else if send_saf_received_result.1 {
-                let _ = result_tx.broadcast(UiTransactionSendStatus::SentViaSaf);
-            } else {
-                let _ = result_tx.broadcast(UiTransactionSendStatus::Error(
-                    "Transaction could not be sent".to_string(),
-                ));
-            }
-        },
-    }
 }
 
 #[derive(Clone)]

--- a/applications/tari_console_wallet/src/ui/state/mod.rs
+++ b/applications/tari_console_wallet/src/ui/state/mod.rs
@@ -1,4 +1,27 @@
+// Copyright 2020. The Tari Project
+//
+// Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+// following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+// disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+// following disclaimer in the documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+// products derived from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+// INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+// WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+// USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
 mod app_state;
+mod tasks;
 mod wallet_event_monitor;
 
 pub use self::app_state::*;

--- a/applications/tari_console_wallet/src/ui/state/tasks.rs
+++ b/applications/tari_console_wallet/src/ui/state/tasks.rs
@@ -1,0 +1,146 @@
+// Copyright 2020. The Tari Project
+//
+// Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+// following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+// disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+// following disclaimer in the documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+// products derived from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+// INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+// WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+// USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+use crate::ui::{state::UiTransactionSendStatus, UiError};
+use futures::StreamExt;
+use tari_comms::types::CommsPublicKey;
+use tari_core::transactions::tari_amount::MicroTari;
+use tari_wallet::transaction_service::handle::{TransactionEvent, TransactionServiceHandle};
+use tokio::sync::watch;
+
+const LOG_TARGET: &str = "wallet::console_wallet::tasks ";
+
+pub async fn send_transaction_task(
+    public_key: CommsPublicKey,
+    amount: MicroTari,
+    message: String,
+    fee_per_gram: MicroTari,
+    mut transaction_service_handle: TransactionServiceHandle,
+    result_tx: watch::Sender<UiTransactionSendStatus>,
+)
+{
+    let _ = result_tx.broadcast(UiTransactionSendStatus::Initiated);
+    let mut event_stream = transaction_service_handle.get_event_stream_fused();
+    let mut send_direct_received_result = (false, false);
+    let mut send_saf_received_result = (false, false);
+    match transaction_service_handle
+        .send_transaction(public_key, amount, fee_per_gram, message)
+        .await
+    {
+        Err(e) => {
+            let _ = result_tx.broadcast(UiTransactionSendStatus::Error(UiError::from(e).to_string()));
+        },
+        Ok(our_tx_id) => {
+            while let Some(event_result) = event_stream.next().await {
+                match event_result {
+                    Ok(event) => match &*event {
+                        TransactionEvent::TransactionDiscoveryInProgress(tx_id) => {
+                            if our_tx_id == *tx_id {
+                                let _ = result_tx.broadcast(UiTransactionSendStatus::DiscoveryInProgress);
+                            }
+                        },
+                        TransactionEvent::TransactionDirectSendResult(tx_id, result) => {
+                            if our_tx_id == *tx_id {
+                                send_direct_received_result = (true, *result);
+                                if send_saf_received_result.0 {
+                                    break;
+                                }
+                            }
+                        },
+                        TransactionEvent::TransactionStoreForwardSendResult(tx_id, result) => {
+                            if our_tx_id == *tx_id {
+                                send_saf_received_result = (true, *result);
+                                if send_direct_received_result.0 {
+                                    break;
+                                }
+                            }
+                        },
+                        TransactionEvent::TransactionCompletedImmediately(tx_id) => {
+                            if our_tx_id == *tx_id {
+                                let _ = result_tx.broadcast(UiTransactionSendStatus::TransactionComplete);
+                                return;
+                            }
+                        },
+                        _ => (),
+                    },
+                    Err(e) => {
+                        log::warn!(target: LOG_TARGET, "Error reading from event broadcast channel {:?}", e);
+                        break;
+                    },
+                }
+            }
+
+            if send_direct_received_result.1 {
+                let _ = result_tx.broadcast(UiTransactionSendStatus::SentDirect);
+            } else if send_saf_received_result.1 {
+                let _ = result_tx.broadcast(UiTransactionSendStatus::SentViaSaf);
+            } else {
+                let _ = result_tx.broadcast(UiTransactionSendStatus::Error(
+                    "Transaction could not be sent".to_string(),
+                ));
+            }
+        },
+    }
+}
+
+pub async fn send_one_sided_transaction_task(
+    public_key: CommsPublicKey,
+    amount: MicroTari,
+    message: String,
+    fee_per_gram: MicroTari,
+    mut transaction_service_handle: TransactionServiceHandle,
+    result_tx: watch::Sender<UiTransactionSendStatus>,
+)
+{
+    let _ = result_tx.broadcast(UiTransactionSendStatus::Initiated);
+    let mut event_stream = transaction_service_handle.get_event_stream_fused();
+    match transaction_service_handle
+        .send_one_sided_transaction(public_key, amount, fee_per_gram, message)
+        .await
+    {
+        Err(e) => {
+            let _ = result_tx.broadcast(UiTransactionSendStatus::Error(UiError::from(e).to_string()));
+        },
+        Ok(our_tx_id) => {
+            while let Some(event_result) = event_stream.next().await {
+                match event_result {
+                    Ok(event) => {
+                        if let TransactionEvent::TransactionCompletedImmediately(tx_id) = &*event {
+                            if our_tx_id == *tx_id {
+                                let _ = result_tx.broadcast(UiTransactionSendStatus::TransactionComplete);
+                                return;
+                            }
+                        }
+                    },
+                    Err(e) => {
+                        log::warn!(target: LOG_TARGET, "Error reading from event broadcast channel {:?}", e);
+                        break;
+                    },
+                }
+            }
+
+            let _ = result_tx.broadcast(UiTransactionSendStatus::Error(
+                "One-sided transaction could not be sent".to_string(),
+            ));
+        },
+    }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Added the one-sided payment transaction sending functionality to the console wallet TUI.

_**NOTE:** Currently only the sender wallet will be able to monitor the transaction; the receiver wallet scanning the blockchain for one-sided transactions must still be implemented._

## Motivation and Context
Expanding the tari script functionality.

## How Has This Been Tested?
Tested sending one-sided transactions between console wallets, verified that the sender wallet detected the transactions as mined.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [X] I'm merging against the `tari-script` branch.
* [X] I have squashed my commits into a single commit.
