### PR TITLE
[Wallet] Update wallet gRPC server to send one-sided payments

### DIFF
--- a/applications/tari_app_grpc/proto/wallet.proto
+++ b/applications/tari_app_grpc/proto/wallet.proto
@@ -69,6 +69,11 @@ message PaymentRecipient {
     uint64 amount = 2;
     uint64 fee_per_gram = 3;
     string message = 4;
+    enum PaymentType {
+        STANDARD_MIMBLEWIMBLE = 0;
+        ONE_SIDED = 1;
+    }
+    PaymentType payment_type = 5;
 }
 
 message TransferResponse {


### PR DESCRIPTION
## Description
This PR adds an enum to the PaymentRecipient Protocol struct that is used with the Transfer method to allow the user to specify if a payment is made using the traditional Mimblewimble method or as a One-sided payment.

## How Has This Been Tested?
This was tested manually as the Cucumber tests seem broken in the TariScript branch currently.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch.
* [x] I have squashed my commits into a single commit.
