### PR TITLE
[wallet] Add one-sided transaction to the command line interface (tari-script)

### DIFF
--- a/applications/tari_console_wallet/src/automation/command_parser.rs
+++ b/applications/tari_console_wallet/src/automation/command_parser.rs
@@ -44,6 +44,7 @@ impl Display for ParsedCommand {
         let command = match self.command {
             WalletCommand::GetBalance => "get-balance",
             WalletCommand::SendTari => "send-tari",
+            WalletCommand::SendOneSided => "send-one-sided",
             WalletCommand::MakeItRain => "make-it-rain",
             WalletCommand::CoinSplit => "coin-split",
             WalletCommand::DiscoverPeer => "discover-peer",
@@ -97,6 +98,7 @@ pub fn parse_command(command: &str) -> Result<ParsedCommand, ParseError> {
     let args = match command {
         GetBalance => Vec::new(),
         SendTari => parse_send_tari(args)?,
+        SendOneSided => parse_send_tari(args)?,
         MakeItRain => parse_make_it_rain(args)?,
         CoinSplit => parse_coin_split(args)?,
         DiscoverPeer => parse_discover_peer(args)?,


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
Added one-sided transaction sending to the command line interface.

## Motivation and Context
Expanding tari-script functionality.

## How Has This Been Tested?
Tested from the command line sending one-side and normal transactions to another wallet, confirming that both have been mined.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [X] I'm merging against the `tari=script` branch.
* [X] I have squashed my commits into a single commit.
