### PR TITLE
Output UTXOs to CSV file

### DIFF
--- a/applications/tari_console_wallet/README.md
+++ b/applications/tari_console_wallet/README.md
@@ -37,6 +37,7 @@ example:
 $ tari_console_wallet --command "send-tari 1T c69fbe5f05a304eaec65d5f234a6aa258a90b8bb5b9ceffea779653667ef2108 coffee"
 
 1. send-tari 1.000000 T c69fbe5f05a304eaec65d5f234a6aa258a90b8bb5b9ceffea779653667ef2108 coffee
+
 Monitoring 1 sent transactions to Broadcast stage...
 Done! All transactions monitored to Broadcast stage.
 ```
@@ -52,6 +53,7 @@ example:
 $ tari_console_wallet  --command "make-it-rain 1 10 8000 100 now c69fbe5f05a304eaec65d5f234a6aa258a90b8bb5b9ceffea779653667ef2108 makin it rain yo"
 
 1. make-it-rain 1 10 8000 µT 100 µT 2021-03-26 10:03:30.459157 UTC c69fbe5f05a304eaec65d5f234a6aa258a90b8bb5b9ceffea779653667ef2108 makin it rain yo
+
 Monitoring 10 sent transactions to Broadcast stage...
 Done! All transactions monitored to Broadcast stage.
 ```
@@ -66,21 +68,31 @@ example:
 $ tari_console_wallet --command "coin-split 10000 9"
 example output:
 ```
+$ tari_console_wallet  --command "coin-split 10000 µT 9"
+
 1. coin-split 10000 µT 9
+
 Coin split succeeded
 Monitoring 1 sent transactions to Broadcast stage...
 Done! All transactions monitored to Broadcast stage.
 ```
 
-- **list-utxos**
+- **export-utxos**
 
-List all of the unspent transaction outputs (UTXOs) in the wallet.
+Export all the unspent transaction outputs (UTXOs) in the wallet. This can either list the UTXOs directly in the 
+console, or write them to file. In the latter case the complete unblinded set of information will be exported. 
 
-`tari_console_wallet --command "list-utxos"`
-
-example output:
 ```
-1. list-utxos
+tari_console_wallet --command "export-utxos"
+tari_console_wallet --command "export-utxos --csv-file <file name>"
+```
+
+example output - console only:
+```
+$ tari_console_wallet  --command "export-utxos"
+
+1. export-utxos
+
 1. Value: 6000 µT OutputFeatures: Flags = (empty), Maturity = 0
 2. Value: 10000 µT OutputFeatures: Flags = (empty), Maturity = 0
 ...
@@ -88,6 +100,27 @@ example output:
 5230. Value: 5538.616395 T OutputFeatures: Flags = (empty), Maturity = 0
 Total number of UTXOs: 5230
 Total value of UTXOs: 1268921.295856 T
+```
+
+example output - `--csv-file` (console output):
+```
+$ tari_console_wallet  --command "export-utxos --csv-file utxos.csv"
+
+1. export-utxos --csv-file utxos.csv
+
+Total number of UTXOs: 11
+Total value of UTXOs: 36105.165440 T
+```
+
+example output - `--csv-file` (contents of `utxos.csv`)
+```
+"#","Value (uT)","Spending Key","Commitment","Flags","Maturity"
+"1","121999250","0b0ce2add569845ec8bb84256b731e644e2224580b568e75666399e868ea5701","22514e279bd7e7e0a6e45905e07323b16f6114e300bcc02f36b2baf44a17b43d","(empty)","0"
+"2","124000000","8829254b5267de26fe926f30518604abeec156740abe64b435ac6081269f2f0d","88f4e7216353032b90bee1c8b4243c3f25b357902a5cb145fda1c98316525214","(empty)","0"
+"3","125000000","295853fad02d56313920130c3a5fa3aa8be54297ee5375aa2d788f4e49f08309","72a42d2db4f8eebbc4d0074fcb04338b8caa22312ce6a68e8798c2452b52e465","(empty)","0"
+...
+"10","5513131148","a6323f62ef21c45f03c73b424d9823b1a0f44a4408be688e5f6fde6419a11407","dcec835619474a62b5cef8227481cebd5831aec515e85286f3932c8093e9d06b","COINBASE_OUTPUT","10655"
+"11","5513145680","5af45bff0f533999c94ec799aa4789260a1b989207363c33ec6ec388899ec906","7ec353f1f005637192d50104b3c5b4621d1ebdafb5c5cc078cf3f86754669352","COINBASE_OUTPUT","10649"
 ```
 
 - **count-utxos**
@@ -99,6 +132,7 @@ Count the number of unspent transaction outputs (UTXOs) in the wallet.
 example output:
 ```
 1. count-utxos
+
 Total number of UTXOs: 5230
 Total value of UTXOs : 1268921.295856 T
 Minimum value UTXO   : 6000 µT
@@ -115,6 +149,7 @@ Discover a peer on the network by public key or emoji id.
 example output:
 ```
 1. discover-peer c69fbe5f05a304eaec65d5f234a6aa258a90b8bb5b9ceffea779653667ef2108
+
 Waiting for connectivity... ✅
 🌎 Peer discovery started.
 ⚡️ Discovery succeeded in 16420ms.
@@ -130,6 +165,7 @@ Look up a public key or emoji id, useful for converting between the two formats.
 example output:
 ```
 1. whois c69fbe5f05a304eaec65d5f234a6aa258a90b8bb5b9ceffea779653667ef2108
+
 Public Key: c69fbe5f05a304eaec65d5f234a6aa258a90b8bb5b9ceffea779653667ef2108
 Emoji ID  : 📈👛💭🎾🌍👡🌋😻🚀🏉🔥🚓🍳👹👿🍕🐵🐼💡💦🎺👘🚌🚿👻🐛🏉🍵🏥🚌🍑🌞🍹
 ```

--- a/applications/tari_console_wallet/src/automation/command_parser.rs
+++ b/applications/tari_console_wallet/src/automation/command_parser.rs
@@ -48,7 +48,7 @@ impl Display for ParsedCommand {
             WalletCommand::CoinSplit => "coin-split",
             WalletCommand::DiscoverPeer => "discover-peer",
             WalletCommand::Whois => "whois",
-            WalletCommand::ListUtxos => "list-utxos",
+            WalletCommand::ExportUtxos => "export-utxos",
             WalletCommand::CountUtxos => "count-utxos",
         };
 
@@ -71,6 +71,8 @@ pub enum ParsedArgument {
     Float(f64),
     Int(u64),
     Date(DateTime<Utc>),
+    OutputToCSVFile(String),
+    CSVFileName(String),
 }
 
 impl Display for ParsedArgument {
@@ -82,6 +84,8 @@ impl Display for ParsedArgument {
             ParsedArgument::Float(v) => write!(f, "{}", v.to_string()),
             ParsedArgument::Int(v) => write!(f, "{}", v.to_string()),
             ParsedArgument::Date(v) => write!(f, "{}", v.to_string()),
+            ParsedArgument::OutputToCSVFile(v) => write!(f, "{}", v.to_string()),
+            ParsedArgument::CSVFileName(v) => write!(f, "{}", v.to_string()),
         }
     }
 }
@@ -101,7 +105,7 @@ pub fn parse_command(command: &str) -> Result<ParsedCommand, ParseError> {
         CoinSplit => parse_coin_split(args)?,
         DiscoverPeer => parse_discover_peer(args)?,
         Whois => parse_whois(args)?,
-        ListUtxos => Vec::new(), // todo: only show X number of utxos
+        ExportUtxos => parse_export_utxos(args)?, // todo: only show X number of utxos
         CountUtxos => Vec::new(),
     };
 
@@ -216,6 +220,29 @@ fn parse_send_tari(mut args: SplitWhitespace) -> Result<Vec<ParsedArgument>, Par
     Ok(parsed_args)
 }
 
+fn parse_export_utxos(mut args: SplitWhitespace) -> Result<Vec<ParsedArgument>, ParseError> {
+    let mut parsed_args = Vec::new();
+
+    if let Some(v) = args.next() {
+        if v == "--csv-file" {
+            let file_name = args.next().ok_or_else(|| {
+                ParseError::Empty(
+                    "file name\n  Usage:\n    export-utxos\n    export-utxos --csv-file <file name>".to_string(),
+                )
+            })?;
+            parsed_args.push(ParsedArgument::OutputToCSVFile("--csv-file".to_string()));
+            parsed_args.push(ParsedArgument::CSVFileName(file_name.to_string()));
+        } else {
+            return Err(ParseError::Empty(
+                "'--csv-file' qualifier\n  Usage:\n    export-utxos\n    export-utxos --csv-file <file name>"
+                    .to_string(),
+            ));
+        }
+    };
+
+    Ok(parsed_args)
+}
+
 fn parse_coin_split(mut args: SplitWhitespace) -> Result<Vec<ParsedArgument>, ParseError> {
     let mut parsed_args = vec![];
 
@@ -233,73 +260,87 @@ fn parse_coin_split(mut args: SplitWhitespace) -> Result<Vec<ParsedArgument>, Pa
     Ok(parsed_args)
 }
 
-#[test]
-fn test_parse_command() {
+#[cfg(test)]
+mod test {
+    use crate::automation::command_parser::{parse_command, ParsedArgument};
     use rand::rngs::OsRng;
-    use tari_core::transactions::types::PublicKey;
+    use std::str::FromStr;
+    use tari_core::transactions::{tari_amount::MicroTari, types::PublicKey};
     use tari_crypto::keys::PublicKey as PublicKeyTrait;
 
-    let (_secret_key, public_key) = PublicKey::random_keypair(&mut OsRng);
+    #[test]
+    fn test_parse_command() {
+        let (_secret_key, public_key) = PublicKey::random_keypair(&mut OsRng);
 
-    let command_str = "";
-    let parsed = parse_command(command_str);
-    assert!(parsed.is_err());
+        let command_str = "";
+        let parsed = parse_command(command_str);
+        assert!(parsed.is_err());
 
-    let command_str = "send-tari asdf";
-    let parsed = parse_command(command_str);
-    assert!(parsed.is_err());
+        let command_str = "send-tari asdf";
+        let parsed = parse_command(command_str);
+        assert!(parsed.is_err());
 
-    let command_str = "send-tari 999T";
-    let parsed = parse_command(command_str);
-    assert!(parsed.is_err());
+        let command_str = "send-tari 999T";
+        let parsed = parse_command(command_str);
+        assert!(parsed.is_err());
 
-    let command_str = "send-tari 999T asdf";
-    let parsed = parse_command(command_str);
-    assert!(parsed.is_err());
+        let command_str = "send-tari 999T asdf";
+        let parsed = parse_command(command_str);
+        assert!(parsed.is_err());
 
-    let command_str = format!("send-tari 999T {} msg text", public_key);
-    let parsed = parse_command(&command_str).unwrap();
+        let command_str = format!("send-tari 999T {} msg text", public_key);
+        let parsed = parse_command(&command_str).unwrap();
 
-    if let ParsedArgument::Amount(amount) = parsed.args[0].clone() {
-        assert_eq!(amount, MicroTari::from_str("999T").unwrap());
-    } else {
-        panic!("Parsed MicroTari amount not the same as provided.");
-    }
-    if let ParsedArgument::PublicKey(pk) = parsed.args[1].clone() {
-        assert_eq!(pk, public_key);
-    } else {
-        panic!("Parsed public key is not the same as provided.");
-    }
-    if let ParsedArgument::Text(msg) = parsed.args[2].clone() {
-        assert_eq!(msg, "msg text");
-    } else {
-        panic!("Parsed message is not the same as provided.");
-    }
+        if let ParsedArgument::Amount(amount) = parsed.args[0].clone() {
+            assert_eq!(amount, MicroTari::from_str("999T").unwrap());
+        } else {
+            panic!("Parsed MicroTari amount not the same as provided.");
+        }
+        if let ParsedArgument::PublicKey(pk) = parsed.args[1].clone() {
+            assert_eq!(pk, public_key);
+        } else {
+            panic!("Parsed public key is not the same as provided.");
+        }
+        if let ParsedArgument::Text(msg) = parsed.args[2].clone() {
+            assert_eq!(msg, "msg text");
+        } else {
+            panic!("Parsed message is not the same as provided.");
+        }
 
-    let command_str = format!("send-tari 999ut {}", public_key);
-    let parsed = parse_command(&command_str).unwrap();
+        let command_str = format!("send-tari 999ut {}", public_key);
+        let parsed = parse_command(&command_str).unwrap();
 
-    if let ParsedArgument::Amount(amount) = parsed.args[0].clone() {
-        assert_eq!(amount, MicroTari::from_str("999ut").unwrap());
-    } else {
-        panic!("Parsed MicroTari amount not the same as provided.");
-    }
+        if let ParsedArgument::Amount(amount) = parsed.args[0].clone() {
+            assert_eq!(amount, MicroTari::from_str("999ut").unwrap());
+        } else {
+            panic!("Parsed MicroTari amount not the same as provided.");
+        }
 
-    let command_str = format!("send-tari 999 {}", public_key);
-    let parsed = parse_command(&command_str).unwrap();
+        let command_str = format!("send-tari 999 {}", public_key);
+        let parsed = parse_command(&command_str).unwrap();
 
-    if let ParsedArgument::Amount(amount) = parsed.args[0].clone() {
-        assert_eq!(amount, MicroTari::from_str("999").unwrap());
-    } else {
-        panic!("Parsed MicroTari amount not the same as provided.");
-    }
+        if let ParsedArgument::Amount(amount) = parsed.args[0].clone() {
+            assert_eq!(amount, MicroTari::from_str("999").unwrap());
+        } else {
+            panic!("Parsed MicroTari amount not the same as provided.");
+        }
 
-    let command_str = format!("discover-peer {}", public_key);
-    let parsed = parse_command(&command_str).unwrap();
+        let command_str = format!("discover-peer {}", public_key);
+        let parsed = parse_command(&command_str).unwrap();
 
-    if let ParsedArgument::PublicKey(pk) = parsed.args[0].clone() {
-        assert_eq!(pk, public_key);
-    } else {
-        panic!("Parsed public key is not the same as provided.");
+        if let ParsedArgument::PublicKey(pk) = parsed.args[0].clone() {
+            assert_eq!(pk, public_key);
+        } else {
+            panic!("Parsed public key is not the same as provided.");
+        }
+
+        let command_str = "export-utxos --csv-file utxo_list.csv".to_string();
+        let parsed = parse_command(&command_str).unwrap();
+
+        if let ParsedArgument::CSVFileName(file) = parsed.args[1].clone() {
+            assert_eq!(file, "utxo_list.csv".to_string());
+        } else {
+            panic!("Parsed csv file name is not the same as provided.");
+        }
     }
 }

--- a/applications/tari_console_wallet/src/automation/error.rs
+++ b/applications/tari_console_wallet/src/automation/error.rs
@@ -49,6 +49,8 @@ pub enum CommandError {
     Config(String),
     #[error("Comms error `{0}`")]
     Comms(String),
+    #[error("CSV file error `{0}`")]
+    CSVFile(String),
 }
 
 impl From<CommandError> for ExitCodes {
@@ -66,7 +68,7 @@ pub enum ParseError {
     MicroTariAmount(#[from] MicroTariError),
     #[error("Failed to parse public key or emoji id.")]
     PublicKey,
-    #[error("Failed to parse a missing {0}.")]
+    #[error("Failed to parse a missing {0}")]
     Empty(String),
     #[error("Failed to parse float.")]
     Float(#[from] ParseFloatError),

--- a/applications/tari_console_wallet/src/main.rs
+++ b/applications/tari_console_wallet/src/main.rs
@@ -150,7 +150,7 @@ fn main_inner() -> Result<(), ExitCodes> {
         )),
     };
 
-    print!("Shutting down wallet... ");
+    print!("\nShutting down wallet... ");
     if shutdown.trigger().is_ok() {
         runtime.block_on(wallet.wait_until_shutdown());
     } else {


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
Added a command-line parameter to write all UTXOs to file in the clear: value, spending key, commitment, features.

## Motivation and Context
Needed to export UTXOs in the clear from the encrypted SQLite wallet database.

## How Has This Been Tested?
Tested with the console wallet using the command file.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [X] I'm merging against the `development` branch.
* [X] I have squashed my commits into a single commit.
