### PR TITLE
[base-node] Refactor chain storage and rule out some target diff bugs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4502,7 +4502,7 @@ dependencies = [
 
 [[package]]
 name = "tari_wallet_ffi"
-version = "0.16.27"
+version = "0.16.28"
 dependencies = [
  "chrono",
  "env_logger 0.7.1",

--- a/applications/tari_base_node/src/command_handler.rs
+++ b/applications/tari_base_node/src/command_handler.rs
@@ -769,7 +769,7 @@ impl CommandHandler {
                     println!("No headers found");
                     return;
                 },
-                Ok(h) => h.into_iter().map(|ch| ch.header).rev().collect::<Vec<_>>(),
+                Ok(h) => h.into_iter().map(|ch| ch.into_header()).rev().collect::<Vec<_>>(),
                 Err(err) => {
                     println!("Failed to retrieve headers: {:?}", err);
                     warn!(target: LOG_TARGET, "Error communicating with base node: {}", err,);
@@ -888,11 +888,11 @@ impl CommandHandler {
                     },
                 };
                 height -= 1;
-                if block.block().header.timestamp.as_u64() > period_ticker_end {
+                if block.header().timestamp.as_u64() > period_ticker_end {
                     print!("\x1B[{}D\x1B[K", (height + 1).to_string().chars().count());
                     continue;
                 };
-                while block.block().header.timestamp.as_u64() < period_ticker_start {
+                while block.header().timestamp.as_u64() < period_ticker_start {
                     results.push((
                         period_tx_count,
                         period_hash,
@@ -910,10 +910,10 @@ impl CommandHandler {
                 }
                 period_tx_count += block.block().body.kernels().len() - 1;
                 period_block_count += 1;
-                let st = if prev_block.block().header.timestamp.as_u64() >= block.block().header.timestamp.as_u64() {
+                let st = if prev_block.header().timestamp.as_u64() >= block.header().timestamp.as_u64() {
                     1.0
                 } else {
-                    (block.block().header.timestamp.as_u64() - prev_block.block().header.timestamp.as_u64()) as f64
+                    (block.header().timestamp.as_u64() - prev_block.header().timestamp.as_u64()) as f64
                 };
                 let diff = block.accumulated_data.target_difficulty.as_u64();
                 period_difficulty += diff;
@@ -970,31 +970,29 @@ impl CommandHandler {
                 let header = try_or_print!(db.fetch_chain_header(height).await);
 
                 // Optionally, filter out pow algos
-                if pow_algo.map(|algo| header.header.pow_algo() != algo).unwrap_or(false) {
+                if pow_algo.map(|algo| header.header().pow_algo() != algo).unwrap_or(false) {
                     continue;
                 }
 
                 let target_diff = try_or_print!(db.fetch_target_difficulties(prev_header.hash().clone()).await);
+                let pow_algo = header.header().pow_algo();
 
-                let min = consensus_rules
-                    .consensus_constants(height)
-                    .min_pow_difficulty(header.header.pow_algo());
-                let max = consensus_rules
-                    .consensus_constants(height)
-                    .max_pow_difficulty(header.header.pow_algo());
+                let min = consensus_rules.consensus_constants(height).min_pow_difficulty(pow_algo);
+                let max = consensus_rules.consensus_constants(height).max_pow_difficulty(pow_algo);
 
-                let calculated_target_difficulty = target_diff.get(header.header.pow_algo()).calculate(min, max);
-                let existing_target_difficulty = header.accumulated_data.target_difficulty;
-                let achieved = header.accumulated_data.achieved_difficulty;
-                let solve_time = header.header.timestamp.as_u64() as i64 - prev_header.header.timestamp.as_u64() as i64;
+                let calculated_target_difficulty = target_diff.get(pow_algo).calculate(min, max);
+                let existing_target_difficulty = header.accumulated_data().target_difficulty;
+                let achieved = header.accumulated_data().achieved_difficulty;
+                let solve_time =
+                    header.header().timestamp.as_u64() as i64 - prev_header.header().timestamp.as_u64() as i64;
                 let normalized_solve_time = cmp::min(
                     cmp::max(solve_time, 1) as u64,
                     consensus_rules
                         .consensus_constants(height)
-                        .get_difficulty_max_block_interval(header.header.pow_algo()),
+                        .get_difficulty_max_block_interval(pow_algo),
                 );
-                let acc_sha3 = header.accumulated_data.accumulated_blake_difficulty;
-                let acc_monero = header.accumulated_data.accumulated_monero_difficulty;
+                let acc_sha3 = header.accumulated_data().accumulated_blake_difficulty;
+                let acc_monero = header.accumulated_data().accumulated_monero_difficulty;
 
                 writeln!(
                     output,
@@ -1005,9 +1003,9 @@ impl CommandHandler {
                     calculated_target_difficulty.as_u64(),
                     solve_time,
                     normalized_solve_time,
-                    header.header.pow_algo(),
-                    chrono::DateTime::from(header.header.timestamp),
-                    target_diff.get(header.header.pow_algo()).len(),
+                    pow_algo,
+                    chrono::DateTime::from(header.header().timestamp),
+                    target_diff.get(pow_algo).len(),
                     acc_monero.as_u64(),
                     acc_sha3.as_u64(),
                 )

--- a/base_layer/core/src/base_node/state_machine_service/states/block_sync.rs
+++ b/base_layer/core/src/base_node/state_machine_service/states/block_sync.rs
@@ -69,10 +69,10 @@ impl BlockSync {
         let local_nci = shared.local_node_interface.clone();
         let bootstrapped = shared.is_bootstrapped();
         synchronizer.on_progress(move |block, remote_tip_height, sync_peers| {
-            let local_height = block.block.header.height;
+            let local_height = block.height();
             local_nci.publish_block_event(BlockEvent::ValidBlockAdded(
-                block.block.clone().into(),
-                BlockAddResult::Ok(block.clone()),
+                block.block().clone().into(),
+                BlockAddResult::Ok(block),
                 false.into(),
             ));
 

--- a/base_layer/core/src/base_node/sync/block_sync/synchronizer.rs
+++ b/base_layer/core/src/base_node/sync/block_sync/synchronizer.rs
@@ -23,7 +23,6 @@
 use super::error::BlockSyncError;
 use crate::{
     base_node::sync::{hooks::Hooks, rpc},
-    blocks::Block,
     chain_storage::{async_db::AsyncBlockchainDb, BlockchainBackend, ChainBlock},
     proto::base_node::SyncBlocksRequest,
     tari_utilities::{hex::Hex, Hashable},
@@ -138,9 +137,9 @@ impl<B: BlockchainBackend + 'static> BlockSynchronizer<B> {
         let tip_hash = tip_header.hash();
         let tip_height = tip_header.height;
         let best_height = local_metadata.height_of_longest_chain();
-        let (_best_block, accumulated_data) = self.db.fetch_header_and_accumulated_data(best_height).await?;
+        let chain_header = self.db.fetch_chain_header(best_height).await?;
 
-        let best_full_block_hash = accumulated_data.hash;
+        let best_full_block_hash = chain_header.accumulated_data().hash.clone();
         debug!(
             target: LOG_TARGET,
             "Starting block sync from peer `{}`. Current best block is #{} `{}`. Syncing to #{} ({}).",
@@ -172,10 +171,10 @@ impl<B: BlockchainBackend + 'static> BlockSynchronizer<B> {
 
             let header_hash = header.hash().clone();
 
-            if header.header.prev_hash != prev_hash {
+            if header.header().prev_hash != prev_hash {
                 return Err(BlockSyncError::PeerSentBlockThatDidNotFormAChain {
                     expected: prev_hash.to_hex(),
-                    got: header.header.prev_hash.to_hex(),
+                    got: header.header().prev_hash.to_hex(),
                 });
             }
 
@@ -190,25 +189,22 @@ impl<B: BlockchainBackend + 'static> BlockSynchronizer<B> {
             debug!(
                 target: LOG_TARGET,
                 "Validating block body #{} (PoW = {}, {})",
-                header.header.height,
-                header.header.pow_algo(),
+                header.height(),
+                header.header().pow_algo(),
                 body.to_counts_string(),
             );
 
             let timer = Instant::now();
-            let block = Arc::new(ChainBlock {
-                accumulated_data: header.accumulated_data.clone(),
-                block: Block::new(header.header, body),
-            });
+            let block = Arc::new(header.upgrade_to_chain_block(body));
             self.validate_block(block.clone()).await?;
 
             debug!(
                 target: LOG_TARGET,
                 "Validated in {:.0?}. Storing block body #{} (PoW = {}, {})",
                 timer.elapsed(),
-                block.block.header.height,
-                block.block.header.pow_algo(),
-                block.block.body.to_counts_string(),
+                block.header().height,
+                block.header().pow_algo(),
+                block.block().body.to_counts_string(),
             );
 
             let timer = Instant::now();
@@ -218,7 +214,7 @@ impl<B: BlockchainBackend + 'static> BlockSynchronizer<B> {
                 .set_best_block(
                     block.height(),
                     header_hash,
-                    block.accumulated_data.total_accumulated_difficulty,
+                    block.accumulated_data().total_accumulated_difficulty,
                 )
                 .commit()
                 .await?;
@@ -229,24 +225,24 @@ impl<B: BlockchainBackend + 'static> BlockSynchronizer<B> {
             debug!(
                 target: LOG_TARGET,
                 "Block body #{} added in {:.0?}, Tot_acc_diff {}, Monero {}, SHA3 {}",
-                block.block.header.height,
+                block.height(),
                 timer.elapsed(),
                 block
-                    .accumulated_data
+                    .accumulated_data()
                     .total_accumulated_difficulty
                     .to_formatted_string(&Locale::en),
-                block.accumulated_data.accumulated_monero_difficulty,
-                block.accumulated_data.accumulated_blake_difficulty,
+                block.accumulated_data().accumulated_monero_difficulty,
+                block.accumulated_data().accumulated_blake_difficulty,
             );
             current_block = Some(block);
         }
 
         if let Some(block) = current_block {
             // Update metadata to last tip header
-            let header = &block.block.header;
+            let header = &block.header();
             let height = header.height;
             let best_block = header.hash();
-            let accumulated_difficulty = block.accumulated_data.total_accumulated_difficulty;
+            let accumulated_difficulty = block.accumulated_data().total_accumulated_difficulty;
             self.db
                 .write_transaction()
                 .set_best_block(height, best_block.to_vec(), accumulated_difficulty)
@@ -267,7 +263,7 @@ impl<B: BlockchainBackend + 'static> BlockSynchronizer<B> {
         let db = self.db.clone();
         task::spawn_blocking(move || {
             let db = db.inner().db_read_access()?;
-            validator.validate_body(&block, &*db)?;
+            validator.validate_body(block.block(), &*db)?;
             Result::<_, BlockSyncError>::Ok(())
         })
         .await

--- a/base_layer/core/src/base_node/sync/rpc/service.rs
+++ b/base_layer/core/src/base_node/sync/rpc/service.rs
@@ -357,14 +357,14 @@ impl<B: BlockchainBackend + 'static> BaseNodeSyncService for BaseNodeSyncRpcServ
                 .map_err(RpcStatus::log_internal_error(LOG_TARGET))
             {
                 Ok(header) => {
-                    if header.header.kernel_mmr_size < req.start {
+                    if header.header().kernel_mmr_size < req.start {
                         let _ = tx
                             .send(Err(RpcStatus::bad_request("Start mmr position after requested header")))
                             .await;
                         return;
                     }
 
-                    header.header.kernel_mmr_size
+                    header.header().kernel_mmr_size
                 },
                 Err(err) => {
                     let _ = tx.send(Err(err)).await;
@@ -468,7 +468,7 @@ impl<B: BlockchainBackend + 'static> BaseNodeSyncService for BaseNodeSyncRpcServ
                     .fetch_header_containing_utxo_mmr(self.request.start)
                     .await
                     .map_err(RpcStatus::log_internal_error(LOG_TARGET))?;
-                let mut prev_header = prev_header.header;
+                let (mut prev_header, _) = prev_header.into_parts();
 
                 if prev_header.height > end_header.height {
                     return Err(RpcStatus::bad_request("start index is greater than end index"));

--- a/base_layer/core/src/blocks/block.rs
+++ b/base_layer/core/src/blocks/block.rs
@@ -243,7 +243,6 @@ impl Hashable for Block {
     /// The block hash is just the header hash, since the inputs, outputs and range proofs are captured by their
     /// respective MMR roots in the header itself.
     fn hash(&self) -> Vec<u8> {
-        // Note. If this changes, there will be a bug in chain_database::add_block_modifying_header
         self.header.hash()
     }
 }

--- a/base_layer/core/src/blocks/block_header.rs
+++ b/base_layer/core/src/blocks/block_header.rs
@@ -134,12 +134,11 @@ impl BlockHeader {
     }
 
     /// Create a new block header using relevant data from the previous block. The height is incremented by one, the
-    /// previous block hash is set, and the timestamp is set to the current time and the proof of work is partially
-    /// initialized, although the `accumulated_difficulty_<algo>` stats are updated using the previous block's proof
-    /// of work information.
-    pub fn from_previous(prev: &BlockHeader) -> Result<BlockHeader, BlockHeaderValidationError> {
+    /// previous block hash is set, the timestamp is set to the current time, and the kernel/output mmr sizes are set to
+    /// the previous block. All other fields, including proof of work are set to defaults.
+    pub fn from_previous(prev: &BlockHeader) -> BlockHeader {
         let prev_hash = prev.hash();
-        Ok(BlockHeader {
+        BlockHeader {
             version: prev.version,
             height: prev.height + 1,
             prev_hash,
@@ -152,7 +151,7 @@ impl BlockHeader {
             total_kernel_offset: BlindingFactor::default(),
             nonce: 0,
             pow: ProofOfWork::default(),
-        })
+        }
     }
 
     #[cfg(feature = "base_node")]
@@ -337,7 +336,7 @@ mod test {
         h1.nonce = 7600;
         assert_eq!(h1.height, 0, "Default block height");
         let hash1 = h1.hash();
-        let h2 = BlockHeader::from_previous(&h1).unwrap();
+        let h2 = BlockHeader::from_previous(&h1);
         assert_eq!(h2.height, h1.height + 1, "Incrementing block height");
         assert!(h2.timestamp > h1.timestamp, "Timestamp");
         assert_eq!(h2.prev_hash, hash1, "Previous hash");

--- a/base_layer/core/src/blocks/genesis_block.rs
+++ b/base_layer/core/src/blocks/genesis_block.rs
@@ -36,18 +36,11 @@ use crate::{
         types::{Commitment, PrivateKey, PublicKey, Signature},
     },
 };
+use std::sync::Arc;
 use tari_crypto::tari_utilities::{hash::Hashable, hex::*};
 
 pub fn get_mainnet_genesis_block() -> ChainBlock {
     unimplemented!()
-}
-
-pub fn get_mainnet_block_hash() -> Vec<u8> {
-    get_mainnet_genesis_block().accumulated_data.hash
-}
-
-pub fn get_mainnet_gen_header() -> BlockHeader {
-    get_mainnet_genesis_block().block.header
 }
 
 pub fn get_stibbons_genesis_block() -> ChainBlock {
@@ -85,10 +78,8 @@ pub fn get_stibbons_genesis_block() -> ChainBlock {
         accumulated_blake_difficulty: 1.into(),
         target_difficulty: 1.into(),
     };
-    ChainBlock {
-        block,
-        accumulated_data,
-    }
+    // NOTE: Panic is impossible, accumulated_data is created from the block
+    ChainBlock::try_construct(Arc::new(block), accumulated_data).unwrap()
 }
 
 #[allow(deprecated)]
@@ -185,10 +176,8 @@ pub fn get_ridcully_genesis_block() -> ChainBlock {
         accumulated_blake_difficulty: 1.into(),
         target_difficulty: 1.into(),
     };
-    ChainBlock {
-        block,
-        accumulated_data,
-    }
+    // NOTE: Panic is impossible, accumulated_data hash is set from block
+    ChainBlock::try_construct(Arc::new(block), accumulated_data).unwrap()
 }
 
 #[allow(deprecated)]
@@ -249,18 +238,6 @@ pub fn get_ridcully_genesis_block_raw() -> Block {
     }
 }
 
-pub fn get_ridcully_block_hash() -> Vec<u8> {
-    get_ridcully_genesis_block().accumulated_data.hash
-}
-
-pub fn get_stibbons_block_hash() -> Vec<u8> {
-    get_stibbons_genesis_block().accumulated_data.hash
-}
-
-pub fn get_ridcully_gen_header() -> BlockHeader {
-    get_ridcully_genesis_block().block.header
-}
-
 #[cfg(test)]
 mod test {
     use super::*;
@@ -269,18 +246,18 @@ mod test {
     #[test]
     fn ridcully_genesis_sanity_check() {
         let block = get_ridcully_genesis_block();
-        assert_eq!(block.block.body.outputs().len(), 4001);
+        assert_eq!(block.block().body.outputs().len(), 4001);
 
         let factories = CryptoFactories::default();
-        let coinbase = block.block.body.outputs().first().unwrap();
+        let coinbase = block.block().body.outputs().first().unwrap();
         assert!(coinbase.is_coinbase());
         coinbase.verify_range_proof(&factories.range_proof).unwrap();
-        assert_eq!(block.block.body.kernels().len(), 2);
-        for kernel in block.block.body.kernels() {
+        assert_eq!(block.block().body.kernels().len(), 2);
+        for kernel in block.block().body.kernels() {
             kernel.verify_signature().unwrap();
         }
 
-        let coinbase_kernel = block.block.body.kernels().first().unwrap();
+        let coinbase_kernel = block.block().body.kernels().first().unwrap();
         assert!(coinbase_kernel.features.contains(KernelFeatures::COINBASE_KERNEL));
     }
 }

--- a/base_layer/core/src/chain_storage/accumulated_data.rs
+++ b/base_layer/core/src/chain_storage/accumulated_data.rs
@@ -23,8 +23,12 @@
 use crate::{
     blocks::{Block, BlockHeader},
     chain_storage::ChainStorageError,
-    proof_of_work::{Difficulty, PowAlgorithm},
-    transactions::types::{BlindingFactor, Commitment, HashOutput},
+    proof_of_work::{AchievedTargetDifficulty, Difficulty, PowAlgorithm},
+    tari_utilities::Hashable,
+    transactions::{
+        aggregated_body::AggregateBody,
+        types::{BlindingFactor, Commitment, HashOutput},
+    },
 };
 use croaring::Bitmap;
 use log::*;
@@ -41,6 +45,7 @@ use serde::{
 use std::{
     fmt,
     fmt::{Display, Formatter},
+    sync::Arc,
 };
 use tari_crypto::tari_utilities::hex::Hex;
 use tari_mmr::{pruned_hashset::PrunedHashSet, ArrayLike};
@@ -182,84 +187,81 @@ impl<'de> Visitor<'de> for DeletedBitmapVisitor {
     }
 }
 
-#[derive(Default)]
-pub struct BlockHeaderAccumulatedDataBuilder {
+pub struct BlockHeaderAccumulatedDataBuilder<'a> {
+    previous_accum: &'a BlockHeaderAccumulatedData,
     hash: Option<HashOutput>,
-    total_kernel_offset: Option<BlindingFactor>,
-    achieved_difficulty: Option<Difficulty>,
-    pub accumulated_monero_difficulty: Option<Difficulty>,
-    pub accumulated_blake_difficulty: Option<Difficulty>,
-    pub target_difficulty: Option<Difficulty>,
+    current_total_kernel_offset: Option<BlindingFactor>,
+    current_achieved_target: Option<AchievedTargetDifficulty>,
 }
 
-impl BlockHeaderAccumulatedDataBuilder {
-    pub fn hash(mut self, hash: HashOutput) -> Self {
+impl<'a> BlockHeaderAccumulatedDataBuilder<'a> {
+    pub fn from_previous(previous_accum: &'a BlockHeaderAccumulatedData) -> Self {
+        Self {
+            previous_accum,
+            hash: None,
+            current_total_kernel_offset: None,
+            current_achieved_target: None,
+        }
+    }
+}
+
+impl BlockHeaderAccumulatedDataBuilder<'_> {
+    pub fn with_hash(mut self, hash: HashOutput) -> Self {
         self.hash = Some(hash);
         self
     }
 
-    pub fn total_kernel_offset(
-        mut self,
-        previous_kernel_offset: &BlindingFactor,
-        current_offset: &BlindingFactor,
-    ) -> Self
-    {
-        self.total_kernel_offset = Some(previous_kernel_offset + current_offset);
+    pub fn with_total_kernel_offset(mut self, current_offset: BlindingFactor) -> Self {
+        self.current_total_kernel_offset = Some(current_offset);
         self
     }
 
-    pub fn target_difficulty(mut self, target: Difficulty) -> Self {
-        self.target_difficulty = Some(target);
-        self
-    }
-
-    pub fn achieved_difficulty(
-        mut self,
-        previous: &BlockHeaderAccumulatedData,
-        algo: PowAlgorithm,
-        achieved: Difficulty,
-    ) -> Self
-    {
-        match algo {
-            PowAlgorithm::Monero => {
-                self.accumulated_monero_difficulty = Some(previous.accumulated_monero_difficulty + achieved);
-                self.accumulated_blake_difficulty = Some(previous.accumulated_blake_difficulty);
-            },
-            PowAlgorithm::Blake => unimplemented!(),
-            PowAlgorithm::Sha3 => {
-                self.accumulated_monero_difficulty = Some(previous.accumulated_monero_difficulty);
-                self.accumulated_blake_difficulty = Some(previous.accumulated_blake_difficulty + achieved);
-            },
-        }
-        self.achieved_difficulty = Some(achieved);
+    pub fn with_achieved_target_difficulty(mut self, achieved_target: AchievedTargetDifficulty) -> Self {
+        self.current_achieved_target = Some(achieved_target);
         self
     }
 
     pub fn build(self) -> Result<BlockHeaderAccumulatedData, ChainStorageError> {
-        let monero_diff = self
-            .accumulated_monero_difficulty
-            .ok_or_else(|| ChainStorageError::InvalidOperation("difficulty not provided".to_string()))?;
+        let previous_accum = self.previous_accum;
+        let hash = self
+            .hash
+            .ok_or_else(|| ChainStorageError::InvalidOperation("hash not provided".to_string()))?;
 
-        let blake_diff = self
-            .accumulated_blake_difficulty
-            .ok_or_else(|| ChainStorageError::InvalidOperation("difficulty not provided".to_string()))?;
+        if hash == self.previous_accum.hash {
+            return Err(ChainStorageError::InvalidOperation(
+                "Hash was set to the same hash that is contained in previous accumulated data".to_string(),
+            ));
+        }
+
+        let achieved_target = self.current_achieved_target.ok_or_else(|| {
+            ChainStorageError::InvalidOperation("Current achieved difficulty not provided".to_string())
+        })?;
+
+        let (monero_diff, blake_diff) = match achieved_target.pow_algo() {
+            PowAlgorithm::Monero => (
+                previous_accum.accumulated_monero_difficulty + achieved_target.achieved(),
+                previous_accum.accumulated_blake_difficulty,
+            ),
+            PowAlgorithm::Blake => unimplemented!(),
+            PowAlgorithm::Sha3 => (
+                previous_accum.accumulated_monero_difficulty,
+                previous_accum.accumulated_blake_difficulty + achieved_target.achieved(),
+            ),
+        };
+
+        let total_kernel_offset = self
+            .current_total_kernel_offset
+            .map(|offset| &previous_accum.total_kernel_offset + offset)
+            .ok_or_else(|| ChainStorageError::InvalidOperation("total_kernel_offset not provided".to_string()))?;
 
         let result = BlockHeaderAccumulatedData {
-            hash: self
-                .hash
-                .ok_or_else(|| ChainStorageError::InvalidOperation("hash not provided".to_string()))?,
-            total_kernel_offset: self
-                .total_kernel_offset
-                .ok_or_else(|| ChainStorageError::InvalidOperation("total_kernel_offset not provided".to_string()))?,
-            achieved_difficulty: self
-                .achieved_difficulty
-                .ok_or_else(|| ChainStorageError::InvalidOperation("achieved_difficulty not provided".to_string()))?,
+            hash,
+            total_kernel_offset,
+            achieved_difficulty: achieved_target.achieved(),
             total_accumulated_difficulty: monero_diff.as_u64() as u128 * blake_diff.as_u64() as u128,
             accumulated_monero_difficulty: monero_diff,
             accumulated_blake_difficulty: blake_diff,
-            target_difficulty: self
-                .target_difficulty
-                .ok_or_else(|| ChainStorageError::InvalidOperation("target difficulty not provided".to_string()))?,
+            target_difficulty: achieved_target.target(),
         };
         trace!(
             target: LOG_TARGET,
@@ -282,14 +284,15 @@ pub struct BlockHeaderAccumulatedData {
     /// The total accumulated difficulty for each proof of work algorithms for all blocks since Genesis,
     /// but not including this block, tracked separately.
     pub accumulated_monero_difficulty: Difficulty,
+    // TODO: Rename #testnetreset
     pub accumulated_blake_difficulty: Difficulty,
     /// The target difficulty for solving the current block using the specified proof of work algorithm.
     pub target_difficulty: Difficulty,
 }
 
 impl BlockHeaderAccumulatedData {
-    pub fn builder() -> BlockHeaderAccumulatedDataBuilder {
-        BlockHeaderAccumulatedDataBuilder::default()
+    pub fn builder(previous: &BlockHeaderAccumulatedData) -> BlockHeaderAccumulatedDataBuilder<'_> {
+        BlockHeaderAccumulatedDataBuilder::from_previous(previous)
     }
 }
 
@@ -309,10 +312,12 @@ impl Display for BlockHeaderAccumulatedData {
     }
 }
 
-#[derive(Debug, Clone, Deserialize, Serialize)]
+/// A block linked to a chain.
+/// A ChainHeader guarantees (i.e cannot be constructed) that the block and accumulated data correspond by hash.
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq)]
 pub struct ChainHeader {
-    pub header: BlockHeader,
-    pub accumulated_data: BlockHeaderAccumulatedData,
+    header: BlockHeader,
+    accumulated_data: BlockHeaderAccumulatedData,
 }
 
 impl Display for ChainHeader {
@@ -324,27 +329,153 @@ impl Display for ChainHeader {
 }
 
 impl ChainHeader {
+    /// Attempts to construct a `ChainHeader` from a `BlockHeader` and associate `BlockHeaderAccumulatedData`. Returns
+    /// None if the Block and the BlockHeaderAccumulatedData do not correspond (i.e have different hashes)
+    pub fn try_construct(header: BlockHeader, accumulated_data: BlockHeaderAccumulatedData) -> Option<Self> {
+        if accumulated_data.hash != header.hash() {
+            return None;
+        }
+
+        Some(Self {
+            header,
+            accumulated_data,
+        })
+    }
+
+    #[inline]
     pub fn height(&self) -> u64 {
         self.header.height
     }
 
+    #[inline]
     pub fn hash(&self) -> &HashOutput {
         &self.accumulated_data.hash
     }
+
+    #[inline]
+    pub fn header(&self) -> &BlockHeader {
+        &self.header
+    }
+
+    #[inline]
+    pub fn accumulated_data(&self) -> &BlockHeaderAccumulatedData {
+        &self.accumulated_data
+    }
+
+    #[inline]
+    pub fn into_parts(self) -> (BlockHeader, BlockHeaderAccumulatedData) {
+        (self.header, self.accumulated_data)
+    }
+
+    #[inline]
+    pub fn into_header(self) -> BlockHeader {
+        self.header
+    }
+
+    pub fn upgrade_to_chain_block(self, body: AggregateBody) -> ChainBlock {
+        // NOTE: Panic cannot occur because a ChainBlock has the same guarantees as ChainHeader
+        ChainBlock::try_construct(Arc::new(Block::new(self.header, body)), self.accumulated_data).unwrap()
+    }
 }
 
-#[derive(Debug, Clone, Deserialize, Serialize, PartialEq)]
+/// A block linked to a chain.
+/// A ChainBlock MUST have the same or stronger guarantees than `ChainHeader`
+#[derive(Debug, Clone, PartialEq)]
 pub struct ChainBlock {
-    pub accumulated_data: BlockHeaderAccumulatedData,
-    pub block: Block,
+    accumulated_data: BlockHeaderAccumulatedData,
+    block: Arc<Block>,
 }
 
 impl ChainBlock {
+    /// Attempts to construct a `ChainBlock` from a `Block` and associate `BlockHeaderAccumulatedData`. Returns None if
+    /// the Block and the BlockHeaderAccumulatedData do not correspond (i.e have different hashes)
+    pub fn try_construct(block: Arc<Block>, accumulated_data: BlockHeaderAccumulatedData) -> Option<Self> {
+        if accumulated_data.hash != block.hash() {
+            return None;
+        }
+
+        Some(Self {
+            block,
+            accumulated_data,
+        })
+    }
+
+    #[inline]
     pub fn height(&self) -> u64 {
         self.block.header.height
     }
 
+    #[inline]
     pub fn hash(&self) -> &HashOutput {
         &self.accumulated_data.hash
+    }
+
+    /// Returns a reference to the inner block
+    #[inline]
+    pub fn block(&self) -> &Block {
+        &self.block
+    }
+
+    /// Returns a reference to the inner block's header
+    #[inline]
+    pub fn header(&self) -> &BlockHeader {
+        &self.block.header
+    }
+
+    /// Returns the inner block wrapped in an atomically reference counted (ARC) pointer. This call is cheap and does
+    /// not copy the block in memory.
+    #[inline]
+    pub fn to_arc_block(&self) -> Arc<Block> {
+        self.block.clone()
+    }
+
+    #[inline]
+    pub fn accumulated_data(&self) -> &BlockHeaderAccumulatedData {
+        &self.accumulated_data
+    }
+
+    pub fn to_chain_header(&self) -> ChainHeader {
+        // NOTE: Panic is impossible, a ChainBlock cannot be constructed if inconsistencies between the header and
+        // accum data exist
+        ChainHeader::try_construct(self.block.header.clone(), self.accumulated_data.clone()).unwrap()
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::blocks::genesis_block::get_ridcully_genesis_block;
+
+    mod chain_block {
+        use super::*;
+
+        #[test]
+        fn it_converts_to_a_chain_header() {
+            let genesis = get_ridcully_genesis_block();
+            let header = genesis.to_chain_header();
+            assert_eq!(header.header(), genesis.header());
+            assert_eq!(header.accumulated_data(), genesis.accumulated_data());
+        }
+
+        #[test]
+        fn it_provides_guarantees_about_data_integrity() {
+            let mut genesis = get_ridcully_genesis_block();
+            // Mess with the header, only possible using the non-public fields
+            genesis.block = Arc::new({
+                let mut b = (*genesis.block).clone();
+                b.header.height = 1;
+                b
+            });
+            assert!(ChainBlock::try_construct(genesis.to_arc_block(), genesis.accumulated_data().clone()).is_none());
+            assert!(ChainHeader::try_construct(genesis.header().clone(), genesis.accumulated_data().clone()).is_none());
+
+            genesis.block = Arc::new({
+                let mut b = (*genesis.block).clone();
+                b.header.height = 0;
+                b
+            });
+            ChainBlock::try_construct(genesis.to_arc_block(), genesis.accumulated_data().clone()).unwrap();
+            ChainHeader::try_construct(genesis.header().clone(), genesis.accumulated_data().clone()).unwrap();
+        }
     }
 }

--- a/base_layer/core/src/chain_storage/async_db.rs
+++ b/base_layer/core/src/chain_storage/async_db.rs
@@ -165,8 +165,6 @@ impl<B: BlockchainBackend + 'static> AsyncBlockchainDb<B> {
 
     make_async_fn!(fetch_chain_headers<T: RangeBounds<u64>>(bounds: T) -> Vec<ChainHeader>, "fetch_chain_headers");
 
-    make_async_fn!(fetch_header_and_accumulated_data(height: u64) -> (BlockHeader, BlockHeaderAccumulatedData), "fetch_header_and_accumulated_data");
-
     make_async_fn!(fetch_header_accumulated_data(hash: HashOutput) -> Option<BlockHeaderAccumulatedData>, "fetch_header_accumulated_data");
 
     make_async_fn!(fetch_headers<T: RangeBounds<u64>>(bounds: T) -> Vec<BlockHeader>, "fetch_headers");
@@ -189,7 +187,7 @@ impl<B: BlockchainBackend + 'static> AsyncBlockchainDb<B> {
 
     make_async_fn!(fetch_tip_header() -> ChainHeader, "fetch_tip_header");
 
-    make_async_fn!(insert_valid_headers(headers: Vec<(BlockHeader, BlockHeaderAccumulatedData)>) -> (), "insert_valid_headers");
+    make_async_fn!(insert_valid_headers(headers: Vec<ChainHeader>) -> (), "insert_valid_headers");
 
     //---------------------------------- Block --------------------------------------------//
     make_async_fn!(add_block(block: Arc<Block>) -> BlockAddResult, "add_block");
@@ -315,8 +313,8 @@ impl<'a, B: BlockchainBackend + 'static> AsyncDbTransaction<'a, B> {
         self
     }
 
-    pub fn insert_header(&mut self, header: BlockHeader, accum_data: BlockHeaderAccumulatedData) -> &mut Self {
-        self.transaction.insert_header(header, accum_data);
+    pub fn insert_chain_header(&mut self, chain_header: ChainHeader) -> &mut Self {
+        self.transaction.insert_chain_header(chain_header);
         self
     }
 

--- a/base_layer/core/src/chain_storage/blockchain_backend.rs
+++ b/base_layer/core/src/chain_storage/blockchain_backend.rs
@@ -4,6 +4,7 @@ use crate::{
         pruned_output::PrunedOutput,
         BlockAccumulatedData,
         BlockHeaderAccumulatedData,
+        ChainBlock,
         ChainHeader,
         ChainStorageError,
         DbKey,
@@ -44,10 +45,7 @@ pub trait BlockchainBackend: Send + Sync {
 
     /// Fetches data that is calculated and accumulated for blocks that have been
     /// added to a chain of headers
-    fn fetch_header_and_accumulated_data(
-        &self,
-        height: u64,
-    ) -> Result<(BlockHeader, BlockHeaderAccumulatedData), ChainStorageError>;
+    fn fetch_chain_header_by_height(&self, height: u64) -> Result<ChainHeader, ChainStorageError>;
 
     /// Fetches data that is calculated and accumulated for blocks that have been
     /// added to a chain of headers
@@ -131,15 +129,13 @@ pub trait BlockchainBackend: Send + Sync {
     /// Returns the kernel count
     fn kernel_count(&self) -> Result<usize, ChainStorageError>;
 
-    /// Fetches all of the orphans (hash) that are currently at the tip of an alternate chain
+    /// Fetches an current tip orphan by hash or returns None if the prohan is not found or is not a tip of any
+    /// alternate chain
     fn fetch_orphan_chain_tip_by_hash(&self, hash: &HashOutput) -> Result<Option<ChainHeader>, ChainStorageError>;
     /// Fetch all orphans that have `hash` as a previous hash
     fn fetch_orphan_children_of(&self, hash: HashOutput) -> Result<Vec<Block>, ChainStorageError>;
 
-    fn fetch_orphan_header_accumulated_data(
-        &self,
-        hash: HashOutput,
-    ) -> Result<BlockHeaderAccumulatedData, ChainStorageError>;
+    fn fetch_orphan_chain_block(&self, hash: HashOutput) -> Result<Option<ChainBlock>, ChainStorageError>;
 
     /// Delete orphans according to age. Used to keep the orphan pool at a certain capacity
     fn delete_oldest_orphans(

--- a/base_layer/core/src/chain_storage/error.rs
+++ b/base_layer/core/src/chain_storage/error.rs
@@ -46,6 +46,8 @@ pub enum ChainStorageError {
     UnexpectedResult(String),
     #[error("You tried to execute an invalid Database operation: {0}")]
     InvalidOperation(String),
+    #[error("DATABASE INCONSISTENCY DETECTED at {function}: {details}")]
+    DataInconsistencyDetected { function: &'static str, details: String },
     #[error("There appears to be a critical error on the back end: {0}. Check the logs for more information.")]
     CriticalError(String),
     #[error("A full block cannot be constructed from the historical block because it contains pruned TXOs")]

--- a/base_layer/core/src/chain_storage/historical_block.rs
+++ b/base_layer/core/src/chain_storage/historical_block.rs
@@ -21,12 +21,12 @@
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 use crate::{
-    blocks::Block,
+    blocks::{Block, BlockHeader},
     chain_storage::{BlockHeaderAccumulatedData, ChainBlock, ChainStorageError},
     transactions::types::HashOutput,
 };
 use serde::{Deserialize, Serialize};
-use std::{fmt, fmt::Display};
+use std::{fmt, fmt::Display, sync::Arc};
 use tari_crypto::tari_utilities::hex::Hex;
 
 /// The representation of a historical block in the blockchain. It is essentially identical to a protocol-defined
@@ -66,6 +66,10 @@ impl HistoricalBlock {
         self.confirmations
     }
 
+    pub fn header(&self) -> &BlockHeader {
+        &self.block.header
+    }
+
     /// Returns a reference to the block of the HistoricalBlock
     pub fn block(&self) -> &Block {
         &self.block
@@ -89,13 +93,14 @@ impl HistoricalBlock {
 
     pub fn try_into_chain_block(self) -> Result<ChainBlock, ChainStorageError> {
         if self.contains_pruned_txos() {
-            Err(ChainStorageError::HistoricalBlockContainsPrunedTxos)
-        } else {
-            Ok(ChainBlock {
-                accumulated_data: self.accumulated_data,
-                block: self.block,
-            })
+            return Err(ChainStorageError::HistoricalBlockContainsPrunedTxos);
         }
+
+        let chain_block = ChainBlock::try_construct(Arc::new(self.block), self.accumulated_data).ok_or_else(|| {
+            ChainStorageError::InvalidOperation("Unable to construct ChainBlock because of a hash mismatch".to_string())
+        })?;
+
+        Ok(chain_block)
     }
 
     pub fn pruned_outputs(&self) -> &[(HashOutput, HashOutput)] {

--- a/base_layer/core/src/consensus/chain_strength_comparer.rs
+++ b/base_layer/core/src/consensus/chain_strength_comparer.rs
@@ -10,8 +10,8 @@ pub struct AccumulatedDifficultySquaredComparer {}
 
 impl ChainStrengthComparer for AccumulatedDifficultySquaredComparer {
     fn compare(&self, a: &ChainHeader, b: &ChainHeader) -> Ordering {
-        let a_val = a.accumulated_data.total_accumulated_difficulty;
-        let b_val = b.accumulated_data.total_accumulated_difficulty;
+        let a_val = a.accumulated_data().total_accumulated_difficulty;
+        let b_val = b.accumulated_data().total_accumulated_difficulty;
         a_val.cmp(&b_val)
     }
 }
@@ -47,9 +47,9 @@ pub struct MoneroDifficultyComparer {}
 
 impl ChainStrengthComparer for MoneroDifficultyComparer {
     fn compare(&self, a: &ChainHeader, b: &ChainHeader) -> Ordering {
-        a.accumulated_data
+        a.accumulated_data()
             .accumulated_monero_difficulty
-            .cmp(&b.accumulated_data.accumulated_monero_difficulty)
+            .cmp(&b.accumulated_data().accumulated_monero_difficulty)
     }
 }
 
@@ -58,9 +58,9 @@ pub struct Sha3DifficultyComparer {}
 
 impl ChainStrengthComparer for Sha3DifficultyComparer {
     fn compare(&self, a: &ChainHeader, b: &ChainHeader) -> Ordering {
-        a.accumulated_data
+        a.accumulated_data()
             .accumulated_blake_difficulty
-            .cmp(&b.accumulated_data.accumulated_blake_difficulty)
+            .cmp(&b.accumulated_data().accumulated_blake_difficulty)
     }
 }
 
@@ -69,7 +69,7 @@ pub struct HeightComparer {}
 
 impl ChainStrengthComparer for HeightComparer {
     fn compare(&self, a: &ChainHeader, b: &ChainHeader) -> Ordering {
-        a.header.height.cmp(&b.header.height)
+        a.height().cmp(&b.height())
     }
 }
 

--- a/base_layer/core/src/consensus/consensus_manager.rs
+++ b/base_layer/core/src/consensus/consensus_manager.rs
@@ -22,14 +22,7 @@
 
 use crate::{
     blocks::{
-        genesis_block::{
-            get_mainnet_block_hash,
-            get_mainnet_genesis_block,
-            get_ridcully_block_hash,
-            get_ridcully_genesis_block,
-            get_stibbons_block_hash,
-            get_stibbons_genesis_block,
-        },
+        genesis_block::{get_mainnet_genesis_block, get_ridcully_genesis_block, get_stibbons_genesis_block},
         Block,
     },
     chain_storage::{ChainBlock, ChainStorageError},
@@ -77,17 +70,6 @@ impl ConsensusManager {
             Network::Ridcully => get_ridcully_genesis_block(),
             Network::Stibbons => get_stibbons_genesis_block(),
             Network::LocalNet => self.inner.gen_block.clone().unwrap_or_else(get_stibbons_genesis_block),
-        }
-    }
-
-    /// Returns the genesis block hash for the selected network.
-    #[deprecated]
-    pub fn get_genesis_block_hash(&self) -> Vec<u8> {
-        match self.inner.network {
-            Network::MainNet => get_mainnet_block_hash(),
-            Network::Ridcully => get_ridcully_block_hash(),
-            Network::Stibbons => get_stibbons_block_hash(),
-            Network::LocalNet => get_ridcully_block_hash(),
         }
     }
 

--- a/base_layer/core/src/mempool/service/inbound_handlers.rs
+++ b/base_layer/core/src/mempool/service/inbound_handlers.rs
@@ -163,8 +163,8 @@ impl MempoolInboundHandlers {
             ValidBlockAdded(_, BlockAddResult::ChainReorg { added, removed }, broadcast) => {
                 async_mempool::process_reorg(
                     self.mempool.clone(),
-                    removed.iter().map(|b| b.block.clone().into()).collect(),
-                    added.iter().map(|b| b.block.clone().into()).collect(),
+                    removed.iter().map(|b| b.to_arc_block()).collect(),
+                    added.iter().map(|b| b.to_arc_block()).collect(),
                 )
                 .await?;
                 if broadcast.is_true() {
@@ -174,14 +174,14 @@ impl MempoolInboundHandlers {
             BlockSyncRewind(removed_blocks) if !removed_blocks.is_empty() => {
                 async_mempool::process_reorg(
                     self.mempool.clone(),
-                    removed_blocks.iter().map(|b| b.block.clone().into()).collect(),
+                    removed_blocks.iter().map(|b| b.to_arc_block()).collect(),
                     vec![],
                 )
                 .await?;
                 let _ = self.event_publisher.send(MempoolStateEvent::Updated);
             },
             BlockSyncComplete(tip_block) => {
-                async_mempool::process_published_block(self.mempool.clone(), tip_block.block.clone().into()).await?;
+                async_mempool::process_published_block(self.mempool.clone(), tip_block.to_arc_block()).await?;
                 let _ = self.event_publisher.send(MempoolStateEvent::Updated);
             },
             _ => {},

--- a/base_layer/core/src/proof_of_work/mod.rs
+++ b/base_layer/core/src/proof_of_work/mod.rs
@@ -56,7 +56,7 @@ pub use sha3_pow::test as sha3_test;
 #[cfg(feature = "base_node")]
 mod target_difficulty;
 #[cfg(feature = "base_node")]
-pub use target_difficulty::TargetDifficultyWindow;
+pub use target_difficulty::{AchievedTargetDifficulty, TargetDifficultyWindow};
 
 #[cfg(feature = "base_node")]
 pub mod lwma_diff;

--- a/base_layer/core/src/proof_of_work/proof_of_work_algorithm.rs
+++ b/base_layer/core/src/proof_of_work/proof_of_work_algorithm.rs
@@ -26,6 +26,7 @@ use std::convert::TryFrom;
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Hash, Eq)]
 pub enum PowAlgorithm {
     Monero = 0,
+    // TODO: remove #testnetreset
     Blake = 1,
     Sha3 = 2,
 }

--- a/base_layer/core/src/proof_of_work/target_difficulty.rs
+++ b/base_layer/core/src/proof_of_work/target_difficulty.rs
@@ -20,7 +20,12 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use crate::proof_of_work::{difficulty::DifficultyAdjustment, lwma_diff::LinearWeightedMovingAverage, Difficulty};
+use crate::proof_of_work::{
+    difficulty::DifficultyAdjustment,
+    lwma_diff::LinearWeightedMovingAverage,
+    Difficulty,
+    PowAlgorithm,
+};
 use std::cmp;
 use tari_crypto::tari_utilities::epoch_time::EpochTime;
 
@@ -75,6 +80,40 @@ impl TargetDifficultyWindow {
     /// Calculates the target difficulty for the current set of target difficulties.
     pub fn calculate(&self, min: Difficulty, max: Difficulty) -> Difficulty {
         cmp::max(min, cmp::min(max, self.lwma.get_difficulty().unwrap_or(min)))
+    }
+}
+
+/// Immutable struct that is guaranteed to have achieved the target difficulty
+pub struct AchievedTargetDifficulty {
+    pow_algo: PowAlgorithm,
+    achieved: Difficulty,
+    target: Difficulty,
+}
+
+impl AchievedTargetDifficulty {
+    /// Checks if the achieved difficulty is higher than the target difficulty. If not, None is returned because a valid
+    /// AchievedTargetDifficulty cannot be constructed.
+    pub(crate) fn try_construct(pow_algo: PowAlgorithm, target: Difficulty, achieved: Difficulty) -> Option<Self> {
+        if achieved < target {
+            return None;
+        }
+        Some(Self {
+            pow_algo,
+            achieved,
+            target,
+        })
+    }
+
+    pub fn achieved(&self) -> Difficulty {
+        self.achieved
+    }
+
+    pub fn target(&self) -> Difficulty {
+        self.target
+    }
+
+    pub fn pow_algo(&self) -> PowAlgorithm {
+        self.pow_algo
     }
 }
 

--- a/base_layer/core/src/test_helpers/blockchain.rs
+++ b/base_layer/core/src/test_helpers/blockchain.rs
@@ -29,6 +29,7 @@ use crate::{
         BlockchainBackend,
         BlockchainDatabase,
         BlockchainDatabaseConfig,
+        ChainBlock,
         ChainHeader,
         ChainStorageError,
         DbKey,
@@ -168,12 +169,8 @@ impl BlockchainBackend for TempDatabase {
         self.db.contains(key)
     }
 
-    fn fetch_header_and_accumulated_data(
-        &self,
-        height: u64,
-    ) -> Result<(BlockHeader, BlockHeaderAccumulatedData), ChainStorageError>
-    {
-        self.db.fetch_header_and_accumulated_data(height)
+    fn fetch_chain_header_by_height(&self, height: u64) -> Result<ChainHeader, ChainStorageError> {
+        self.db.fetch_chain_header_by_height(height)
     }
 
     fn fetch_header_accumulated_data(
@@ -302,12 +299,8 @@ impl BlockchainBackend for TempDatabase {
         self.db.fetch_orphan_children_of(hash)
     }
 
-    fn fetch_orphan_header_accumulated_data(
-        &self,
-        hash: HashOutput,
-    ) -> Result<BlockHeaderAccumulatedData, ChainStorageError>
-    {
-        self.db.fetch_orphan_header_accumulated_data(hash)
+    fn fetch_orphan_chain_block(&self, hash: HashOutput) -> Result<Option<ChainBlock>, ChainStorageError> {
+        self.db.fetch_orphan_chain_block(hash)
     }
 
     fn delete_oldest_orphans(

--- a/base_layer/core/src/validation/block_validators.rs
+++ b/base_layer/core/src/validation/block_validators.rs
@@ -130,15 +130,15 @@ impl<B: BlockchainBackend> PostOrphanBodyValidation<B> for BodyOnlyValidator {
     /// 1. Are all inputs and outputs not in the STXO set?
     /// 1. Are the block header MMR roots valid?
     fn validate_body_for_valid_orphan(&self, block: &ChainBlock, backend: &B) -> Result<(), ValidationError> {
-        let block_id = format!("block #{} ({})", block.block.header.height, block.hash().to_hex());
-        check_inputs_are_utxos(&block.block, backend)?;
-        check_not_duplicate_txos(&block.block, backend)?;
+        let block_id = format!("block #{} ({})", block.header().height, block.hash().to_hex());
+        check_inputs_are_utxos(&block.block(), backend)?;
+        check_not_duplicate_txos(&block.block(), backend)?;
         trace!(
             target: LOG_TARGET,
             "Block validation: All inputs and outputs are valid for {}",
             block_id
         );
-        check_mmr_roots(&block.block, backend)?;
+        check_mmr_roots(block.block(), backend)?;
         trace!(
             target: LOG_TARGET,
             "Block validation: MMR roots are valid for {}",
@@ -439,25 +439,25 @@ impl<B: BlockchainBackend> CandidateBlockBodyValidation<B> for BlockValidator<B>
     /// The following consensus checks are done:
     /// 1. Does the block satisfy the stateless checks?
     /// 1. Are the block header MMR roots valid?
-    fn validate_body(&self, block: &ChainBlock, backend: &B) -> Result<(), ValidationError> {
-        let block_id = format!("block #{}", block.block.header.height);
+    fn validate_body(&self, block: &Block, backend: &B) -> Result<(), ValidationError> {
+        let block_id = format!("block #{}", block.header.height);
         trace!(target: LOG_TARGET, "Validating {}", block_id);
 
-        let constants = self.rules.consensus_constants(block.block.header.height);
-        check_block_weight(&block.block, &constants)?;
+        let constants = self.rules.consensus_constants(block.header.height);
+        check_block_weight(block, &constants)?;
         trace!(target: LOG_TARGET, "SV - Block weight is ok for {} ", &block_id);
 
-        self.check_inputs(&block.block)?;
-        self.check_outputs(&block.block)?;
+        self.check_inputs(block)?;
+        self.check_outputs(block)?;
 
-        check_accounting_balance(&block.block, &self.rules, &self.factories)?;
+        check_accounting_balance(block, &self.rules, &self.factories)?;
         trace!(target: LOG_TARGET, "SV - accounting balance correct for {}", &block_id);
         debug!(
             target: LOG_TARGET,
             "{} has PASSED stateless VALIDATION check.", &block_id
         );
 
-        self.check_mmr_roots(backend, &block.block)?;
+        self.check_mmr_roots(backend, &block)?;
         trace!(
             target: LOG_TARGET,
             "Block validation: MMR roots are valid for {}",

--- a/base_layer/core/src/validation/chain_balance.rs
+++ b/base_layer/core/src/validation/chain_balance.rs
@@ -85,7 +85,8 @@ impl<B: BlockchainBackend> FinalHorizonStateValidation<B> for ChainBalanceValida
 
 impl<B: BlockchainBackend> ChainBalanceValidator<B> {
     fn fetch_total_offset_commitment(&self, height: u64, backend: &B) -> Result<Commitment, ValidationError> {
-        let offset = backend.fetch_header_and_accumulated_data(height)?.1.total_kernel_offset;
+        let chain_header = backend.fetch_chain_header_by_height(height)?;
+        let offset = &chain_header.accumulated_data().total_kernel_offset;
         Ok(self.factories.commitment.commit(&offset, &0u64.into()))
     }
 

--- a/base_layer/core/src/validation/header_validator.rs
+++ b/base_layer/core/src/validation/header_validator.rs
@@ -1,14 +1,8 @@
 use crate::{
     blocks::BlockHeader,
-    chain_storage::{
-        fetch_headers,
-        fetch_target_difficulty,
-        BlockHeaderAccumulatedData,
-        BlockHeaderAccumulatedDataBuilder,
-        BlockchainBackend,
-    },
+    chain_storage::{fetch_headers, fetch_target_difficulty, BlockchainBackend},
     consensus::ConsensusManager,
-    proof_of_work::{randomx_factory::RandomXFactory, Difficulty},
+    proof_of_work::{randomx_factory::RandomXFactory, AchievedTargetDifficulty},
     validation::{
         helpers::{
             check_header_timestamp_greater_than_median,
@@ -40,20 +34,17 @@ impl HeaderValidator {
         &self,
         db: &B,
         block_header: &BlockHeader,
-    ) -> Result<(Difficulty, Difficulty), ValidationError>
+    ) -> Result<AchievedTargetDifficulty, ValidationError>
     {
         let difficulty_window = fetch_target_difficulty(db, &self.rules, block_header.pow_algo(), block_header.height)?;
-
         let constants = self.rules.consensus_constants(block_header.height);
-
         let target = difficulty_window.calculate(
             constants.min_pow_difficulty(block_header.pow.pow_algo),
             constants.max_pow_difficulty(block_header.pow.pow_algo),
         );
-        Ok((
-            check_target_difficulty(block_header, target, &self.randomx_factory)?,
-            target,
-        ))
+        let achieved_target = check_target_difficulty(block_header, target, &self.randomx_factory)?;
+
+        Ok(achieved_target)
     }
 
     /// This function tests that the block timestamp is greater than the median timestamp at the specified height.
@@ -90,15 +81,8 @@ impl<B: BlockchainBackend> HeaderValidation<B> for HeaderValidator {
     /// 1. Is the Proof of Work valid?
     /// 1. Is the achieved difficulty of this block >= the target difficulty for this block?
 
-    fn validate(
-        &self,
-        backend: &B,
-        header: &BlockHeader,
-        previous_data: &BlockHeaderAccumulatedData,
-    ) -> Result<BlockHeaderAccumulatedDataBuilder, ValidationError>
-    {
+    fn validate(&self, backend: &B, header: &BlockHeader) -> Result<AchievedTargetDifficulty, ValidationError> {
         check_timestamp_ftl(&header, &self.rules)?;
-        let hash = header.hash();
         let header_id = format!("header #{} ({})", header.height, header.hash().to_hex());
         trace!(
             target: LOG_TARGET,
@@ -112,11 +96,8 @@ impl<B: BlockchainBackend> HeaderValidation<B> for HeaderValidator {
             header_id
         );
         check_pow_data(header, &self.rules, backend)?;
-        let (achieved, target) = self.check_achieved_and_target_difficulty(backend, header)?;
-        let accum_data = BlockHeaderAccumulatedDataBuilder::default()
-            .hash(hash)
-            .target_difficulty(target)
-            .achieved_difficulty(previous_data, header.pow_algo(), achieved);
+        let achieved_target = self.check_achieved_and_target_difficulty(backend, header)?;
+
         trace!(
             target: LOG_TARGET,
             "BlockHeader validation: Achieved difficulty is ok for {} ",
@@ -126,6 +107,6 @@ impl<B: BlockchainBackend> HeaderValidation<B> for HeaderValidator {
             target: LOG_TARGET,
             "Block header validation: BlockHeader is VALID for {}", header_id
         );
-        Ok(accum_data)
+        Ok(achieved_target)
     }
 }

--- a/base_layer/core/src/validation/test.rs
+++ b/base_layer/core/src/validation/test.rs
@@ -23,7 +23,7 @@
 use crate::{
     blocks::BlockHeader,
     consensus::{ConsensusManagerBuilder, Network},
-    test_helpers::blockchain::create_store_with_consensus,
+    test_helpers::{blockchain::create_store_with_consensus, create_chain_header},
     validation::header_iter::HeaderIter,
 };
 
@@ -36,7 +36,7 @@ fn header_iter_empty_and_invalid_height() {
     let headers = iter.map(Result::unwrap).collect::<Vec<_>>();
     assert_eq!(headers.len(), 1);
     let genesis = consensus_manager.get_genesis_block();
-    assert_eq!(&genesis.block.header, &headers[0]);
+    assert_eq!(genesis.header(), &headers[0]);
 
     // Invalid header height
     let iter = HeaderIter::new(&db, 1, 10);
@@ -57,24 +57,17 @@ fn header_iter_fetch_in_chunks() {
         header.kernel_mmr_size = 2 + i;
         header.output_mmr_size = 4001 + i;
 
-        let chain_header = db.create_chain_header_if_valid(header, prev).unwrap();
+        let chain_header = create_chain_header(&*db.db_read_access().unwrap(), header, &prev.accumulated_data());
         acc.push(chain_header);
         acc
     });
-    db.insert_valid_headers(
-        headers
-            .into_iter()
-            .skip(1)
-            .map(|chain_header| (chain_header.header, chain_header.accumulated_data))
-            .collect(),
-    )
-    .unwrap();
+    db.insert_valid_headers(headers.into_iter().skip(1).collect()).unwrap();
 
     let iter = HeaderIter::new(&db, 11, 3);
     let headers = iter.map(Result::unwrap).collect::<Vec<_>>();
     assert_eq!(headers.len(), 12);
     let genesis = consensus_manager.get_genesis_block();
-    assert_eq!(&genesis.block.header, &headers[0]);
+    assert_eq!(genesis.header(), &headers[0]);
 
     (1..=11).for_each(|i| {
         assert_eq!(headers[i].height, i as u64);

--- a/base_layer/core/src/validation/traits.rs
+++ b/base_layer/core/src/validation/traits.rs
@@ -22,7 +22,8 @@
 
 use crate::{
     blocks::{Block, BlockHeader},
-    chain_storage::{BlockHeaderAccumulatedData, BlockHeaderAccumulatedDataBuilder, BlockchainBackend, ChainBlock},
+    chain_storage::{BlockchainBackend, ChainBlock},
+    proof_of_work::AchievedTargetDifficulty,
     transactions::{transaction::Transaction, types::Commitment},
     validation::error::ValidationError,
 };
@@ -30,7 +31,7 @@ use crate::{
 /// A validator that determines if a block body is valid, assuming that the header has already been
 /// validated
 pub trait CandidateBlockBodyValidation<B: BlockchainBackend>: Send + Sync {
-    fn validate_body(&self, block: &ChainBlock, backend: &B) -> Result<(), ValidationError>;
+    fn validate_body(&self, block: &Block, backend: &B) -> Result<(), ValidationError>;
 }
 
 /// A validator that validates a body after it has been determined to be a valid orphan
@@ -47,12 +48,7 @@ pub trait OrphanValidation: Send + Sync {
 }
 
 pub trait HeaderValidation<B: BlockchainBackend>: Send + Sync {
-    fn validate(
-        &self,
-        db: &B,
-        header: &BlockHeader,
-        previous_data: &BlockHeaderAccumulatedData,
-    ) -> Result<BlockHeaderAccumulatedDataBuilder, ValidationError>;
+    fn validate(&self, db: &B, header: &BlockHeader) -> Result<AchievedTargetDifficulty, ValidationError>;
 }
 
 pub trait FinalHorizonStateValidation<B>: Send + Sync {

--- a/base_layer/core/tests/async_db.rs
+++ b/base_layer/core/tests/async_db.rs
@@ -62,14 +62,14 @@ fn fetch_async_headers() {
     test_async(move |rt| {
         let db = AsyncBlockchainDb::new(db);
         for block in blocks.into_iter() {
-            let height = block.block.header.height;
+            let height = block.height();
             let hash = block.hash().clone();
             let db = db.clone();
             rt.spawn(async move {
                 let header_height = db.fetch_header(height).await.unwrap().unwrap();
                 let header_hash = db.fetch_header_by_block_hash(hash).await.unwrap().unwrap();
-                assert_eq!(block.block.header, header_height);
-                assert_eq!(block.block.header, header_hash);
+                assert_eq!(block.header(), &header_height);
+                assert_eq!(block.header(), &header_hash);
             });
         }
     });
@@ -86,7 +86,7 @@ fn async_rewind_to_height() {
             assert!(result.is_err());
             let block = db.fetch_block(2).await.unwrap();
             assert_eq!(block.confirmations(), 1);
-            assert_eq!(&blocks[2].block, block.block());
+            assert_eq!(blocks[2].block(), block.block());
         });
     });
 }
@@ -96,8 +96,8 @@ fn fetch_async_utxo() {
     let (adb, blocks, outputs, _) = create_blockchain_db_no_cut_through();
     let factory = CommitmentFactory::default();
     // Retrieve a UTXO and an STXO
-    let utxo = find_utxo(&outputs[4][0], &blocks[4].block, &factory).unwrap();
-    let stxo = find_utxo(&outputs[1][0], &blocks[1].block, &factory).unwrap();
+    let utxo = find_utxo(&outputs[4][0], blocks[4].block(), &factory).unwrap();
+    let stxo = find_utxo(&outputs[1][0], blocks[1].block(), &factory).unwrap();
     test_async(move |rt| {
         let db = AsyncBlockchainDb::new(adb.clone());
         let db2 = AsyncBlockchainDb::new(adb);
@@ -119,9 +119,9 @@ fn fetch_async_block() {
         let db = AsyncBlockchainDb::new(db);
         rt.spawn(async move {
             for block in blocks.into_iter() {
-                let height = block.block.header.height;
+                let height = block.height();
                 let block_check = db.fetch_block(height).await.unwrap();
-                assert_eq!(&block.block, block_check.block());
+                assert_eq!(block.block(), block_check.block());
             }
         });
     });

--- a/base_layer/core/tests/base_node_rpc.rs
+++ b/base_layer/core/tests/base_node_rpc.rs
@@ -186,7 +186,7 @@ fn test_base_node_wallet_rpc() {
     // Now submit a block with Tx1 in it so that Tx2 is no longer an orphan
     let block1 = base_node
         .blockchain_db
-        .prepare_block_merkle_roots(chain_block(&block0.block, vec![tx1.clone()], &consensus_manager))
+        .prepare_block_merkle_roots(chain_block(&block0.block(), vec![tx1.clone()], &consensus_manager))
         .unwrap();
 
     assert!(runtime

--- a/base_layer/core/tests/block_validation.rs
+++ b/base_layer/core/tests/block_validation.rs
@@ -64,7 +64,7 @@ fn test_genesis_block() {
     );
     let db = BlockchainDatabase::new(backend, &rules, validators, BlockchainDatabaseConfig::default(), false).unwrap();
     let block = rules.get_genesis_block();
-    match db.add_block(block.block.into()).unwrap_err() {
+    match db.add_block(block.to_arc_block()).unwrap_err() {
         ChainStorageError::ValidationError { source } => match source {
             ValidationError::ValidatingGenesis => (),
             _ => panic!("Failed because incorrect validation error was received"),

--- a/base_layer/core/tests/helpers/block_proxy.rs
+++ b/base_layer/core/tests/helpers/block_proxy.rs
@@ -31,7 +31,7 @@ pub struct BlockProxy {
 
 impl PartialEq for BlockProxy {
     fn eq(&self, other: &Self) -> bool {
-        self.block.block.eq(&other.block.block)
+        self.block.block().eq(other.block.block())
     }
 }
 

--- a/base_layer/core/tests/helpers/pow_blockchain.rs
+++ b/base_layer/core/tests/helpers/pow_blockchain.rs
@@ -117,7 +117,7 @@ pub fn calculate_accumulated_difficulty(
         consensus_constants.get_difficulty_max_block_interval(pow_algo),
     );
     for height in heights {
-        let (header, accum) = db.fetch_header_and_accumulated_data(height).unwrap();
+        let (header, accum) = db.fetch_chain_header(height).unwrap().into_parts();
         lwma.add(header.timestamp, accum.target_difficulty).unwrap();
     }
     lwma.get_difficulty().unwrap()

--- a/base_layer/core/tests/helpers/test_blockchain.rs
+++ b/base_layer/core/tests/helpers/test_blockchain.rs
@@ -113,7 +113,7 @@ impl TestBlockchain {
 
     pub fn chain(&self) -> Vec<&str> {
         let mut result = vec![];
-        let mut tip = self.store.fetch_tip_header().unwrap().header;
+        let (mut tip, _) = self.store.fetch_tip_header().unwrap().into_parts();
 
         while tip.height > 0 {
             result.push(self.get_block_by_hash(&tip.hash()).unwrap().name.as_str());

--- a/base_layer/core/tests/node_comms_interface.rs
+++ b/base_layer/core/tests/node_comms_interface.rs
@@ -176,7 +176,7 @@ async fn inbound_fetch_headers() {
         consensus_manager,
         outbound_nci,
     );
-    let header = store.fetch_block(0).unwrap().block().header.clone();
+    let header = store.fetch_block(0).unwrap().header().clone();
 
     if let Ok(NodeCommsResponse::BlockHeaders(received_headers)) = inbound_nch
         .handle_request(NodeCommsRequest::FetchHeaders(vec![0]))
@@ -427,7 +427,7 @@ async fn inbound_fetch_blocks_before_horizon_height() {
         .await
     {
         assert_eq!(received_blocks.len(), 1);
-        assert_eq!(*received_blocks[0].block(), block2.block);
+        assert_eq!(received_blocks[0].block(), block2.block());
     } else {
         panic!();
     }

--- a/base_layer/core/tests/node_state_machine.rs
+++ b/base_layer/core/tests/node_state_machine.rs
@@ -116,7 +116,7 @@ fn test_listening_lagging() {
         let prev_block = append_block(&bob_db, &prev_block, vec![], &consensus_manager, 3.into()).unwrap();
         // Bob Block 2 - with block event and liveness service metadata update
         let mut prev_block = bob_db
-            .prepare_block_merkle_roots(chain_block(&prev_block.block, vec![], &consensus_manager))
+            .prepare_block_merkle_roots(chain_block(&prev_block.block(), vec![], &consensus_manager))
             .unwrap();
         prev_block.header.output_mmr_size += 1;
         prev_block.header.kernel_mmr_size += 1;

--- a/infrastructure/storage/src/lmdb_store/store.rs
+++ b/infrastructure/storage/src/lmdb_store/store.rs
@@ -324,8 +324,8 @@ impl LMDBBuilder {
 pub struct LMDBStore {
     path: String,
     env_config: LMDBConfig,
-    pub(crate) env: Arc<Environment>,
-    pub(crate) databases: HashMap<String, LMDBDatabase>,
+    env: Arc<Environment>,
+    databases: HashMap<String, LMDBDatabase>,
 }
 
 impl LMDBStore {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
- Adds `AchievedTargetDifficulty` that cannot be constructed unless achieved
  difficulty > target difficulty
- Header validator returns `AchievedTargetDifficulty`
- Refactor BlockHeaderAccumulatedDataBuilder to prevent possible bugs
  and to use `AchievedTargetDifficulty`
- Removes public fields from Chain(Block|Header)
- Chain(Block|Header) guarantee that the accumulated data hash matches
  (small cost)
- Remove in-memory cache of ChainMetadata
  - lmdb already is in-memory
  - block sync performance was similar
  - a stale value has carries a high risk of db corruption
- Rollback + error if duplicate orphans inserted (insert_orphan and
  insert_chained_orphan)
- `chain-storage` DeleteOrphan deletes accumulated orphan data
- Adds more reorg unit tests to blockchain database
- ~~Allow serde to (de)serialize reference counted fields.~~ (no longer needed)
  (https://serde.rs/feature-flags.html#-features-rc - the behaviour
  defined here is expected/correct)

The majority of the changed LOC are a result of making fields private
and other structural changes that can prevent bugs.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Prevent future bugs by making it impossible (without changing the relevant public interfaces) to make mistakes that were previously easy to do.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Added a number of blockchain database unit tests. Manually tested on pruned/archival nodes.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch.
* [x] I have squashed my commits into a single commit.
