### PR TITLE
Emission math audit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4502,7 +4502,7 @@ dependencies = [
 
 [[package]]
 name = "tari_wallet_ffi"
-version = "0.16.27"
+version = "0.16.28"
 dependencies = [
  "chrono",
  "env_logger 0.7.1",

--- a/base_layer/core/src/consensus/emission.rs
+++ b/base_layer/core/src/consensus/emission.rs
@@ -21,7 +21,6 @@
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 use crate::transactions::tari_amount::MicroTari;
-use num::pow;
 
 pub trait Emission {
     fn block_reward(&self, height: u64) -> MicroTari;
@@ -36,7 +35,7 @@ pub trait Emission {
 #[derive(Debug, Clone)]
 pub struct EmissionSchedule {
     initial: MicroTari,
-    pub(crate) decay: &'static [u64],
+    decay: &'static [u64],
     tail: MicroTari,
 }
 
@@ -59,8 +58,17 @@ impl EmissionSchedule {
     /// $$ \epsilon = \sum 2^{-k} \foreach k \in decay $$
     ///
     /// So for example, if the decay rate is 0.25, then $$\epsilon$$ is 0.75 or 1/2 + 1/4 i.e. `1 >> 1 + 1 >> 2`
-    /// and the decay array is `&[1, 2]`
+    /// and the decay array is `&[1, 2]`.
+    ///
+    /// ## Panics
+    ///
+    /// The shift right operation will overflow if shifting more than 63 bits. `new` will panic if any of the decay
+    /// values are greater than or equal to 64.
     pub fn new(initial: MicroTari, decay: &'static [u64], tail: MicroTari) -> EmissionSchedule {
+        assert!(
+            decay.iter().all(|i| *i < 64),
+            "Decay value would overflow. All `decay` values must be less than 64"
+        );
         EmissionSchedule { initial, decay, tail }
     }
 
@@ -119,7 +127,7 @@ impl<'a> EmissionRate<'a> {
     ///
     /// Then we calculate k.R = (1 - e).R = R - e.R = R - (0.5 * R + 0.25 * R) = R - R >> 1 - R >> 2
     fn next_reward(&self) -> MicroTari {
-        let r: u64 = self.reward.into();
+        let r = self.reward.as_u64();
         let next = self
             .schedule
             .decay
@@ -138,7 +146,8 @@ impl<'a> Iterator for EmissionRate<'a> {
 
     fn next(&mut self) -> Option<Self::Item> {
         self.reward = self.next_reward();
-        self.supply += self.reward;
+        // Once we've reached max supply, the iterator is done
+        self.supply = self.supply.checked_add(self.reward)?;
         self.block_num += 1;
         Some((self.block_num, self.reward, self.supply))
     }
@@ -166,205 +175,65 @@ impl Emission for EmissionSchedule {
     }
 }
 
-/// The Tari emission schedule. The emission schedule determines how much Tari is mined as a block reward at every
-/// block.
-///
-/// NB: We don't know what the final emission schedule will be on Tari yet, so do not give any weight to values or
-/// formulae provided in this file, they will almost certainly change ahead of main-net release.
-#[derive(Debug, Clone)]
-// #[deprecated(note = "Use Emission instead")]
-pub struct EmissionScheduleOld {
-    initial: MicroTari,
-    decay: f64,
-    tail: MicroTari,
-}
-
-impl EmissionScheduleOld {
-    /// Create a new emission schedule instance.
-    ///
-    /// The Emission schedule follows a similar pattern to Monero; with an exponentially decaying emission rate with
-    /// a constant tail emission rate.
-    ///
-    /// The block reward is given by
-    ///  $$ r_n = A_0 r^n + t $$
-    ///
-    /// where
-    ///  * $$A_0$$ is the genesis block reward
-    ///  * $$1-r$$ is the decay rate
-    ///  * $$t$$ is the constant tail emission rate
-    pub fn new(initial: MicroTari, decay: f64, tail: MicroTari) -> EmissionScheduleOld {
-        EmissionScheduleOld { initial, decay, tail }
-    }
-
-    /// Return an iterator over the block reward and total supply. This is the most efficient way to iterate through
-    /// the emission curve if you're interested in the supply as well as the reward.
-    ///
-    /// This is an infinite iterator, and each value returned is a tuple of (block number, reward, and total supply)
-    ///
-    /// ```edition2018
-    /// use tari_core::consensus::emission::EmissionScheduleOld;
-    /// use tari_core::transactions::tari_amount::MicroTari;
-    /// // Print the reward and supply for first 100 blocks
-    /// let schedule = EmissionScheduleOld::new(10.into(), 0.9, 1.into());
-    /// for (n, reward, supply) in schedule.iter().take(100) {
-    ///     println!("{:3} {:9} {:9}", n, reward, supply);
-    /// }
-    /// ```
-    pub fn iter(&self) -> EmissionValues {
-        EmissionValues::new(self)
-    }
-}
-
-impl Emission for EmissionScheduleOld {
-    /// Calculate the block reward for the given block height, in µTari
-    fn block_reward(&self, height: u64) -> MicroTari {
-        let base = if height < std::i32::MAX as u64 {
-            let base_f = (f64::from(self.initial) * pow(self.decay, height as usize)).trunc();
-            MicroTari::from(base_f as u64)
-        } else {
-            MicroTari::from(0)
-        };
-        base + self.tail
-    }
-
-    /// Calculate the exact emitted supply after the given block, in µTari. The value is calculated by summing up the
-    /// block reward for each block, making this a very inefficient function if you wanted to call it from a loop for
-    /// example. For those cases, use the `iter` function instead.
-    fn supply_at_block(&self, height: u64) -> MicroTari {
-        let mut total = MicroTari::from(0u64);
-        for i in 0..=height {
-            total += self.block_reward(i);
-        }
-        total
-    }
-}
-
-pub struct EmissionValues<'a> {
-    block_num: u64,
-    supply: MicroTari,
-    reward: MicroTari,
-    schedule: &'a EmissionScheduleOld,
-}
-
-impl<'a> EmissionValues<'a> {
-    fn new(schedule: &'a EmissionScheduleOld) -> EmissionValues<'a> {
-        EmissionValues {
-            block_num: 0,
-            supply: MicroTari::default(),
-            reward: MicroTari::default(),
-            schedule,
-        }
-    }
-}
-
-impl<'a> Iterator for EmissionValues<'a> {
-    type Item = (u64, MicroTari, MicroTari);
-
-    fn next(&mut self) -> Option<Self::Item> {
-        let n = self.block_num;
-        self.reward = self.schedule.block_reward(n);
-        self.supply += self.reward;
-        self.block_num += 1;
-        Some((n, self.reward, self.supply))
-    }
-}
-
 #[cfg(test)]
 mod test {
     use crate::{
-        consensus::emission::{Emission, EmissionSchedule, EmissionScheduleOld},
+        consensus::emission::{Emission, EmissionSchedule},
         transactions::tari_amount::{uT, MicroTari, T},
     };
 
-    /// Commit df95cee73812689bbae77bfb547c1d73a49635d4 introduced a bug in Windows builds that resulted in certain
-    /// blocks failing validation tests. The cause was traced to an erroneous implementation of the std::f64::powi
-    /// function in Rust toolchain nightly-2020-06-10, where Windows would give a slightly different floating point
-    /// result than Linux. This affected the EmissionScheduleOld::block_reward calculation.
-    #[test]
-    #[allow(clippy::identity_op)]
-    fn block_reward_edge_cases() {
-        const EMISSION_INITIAL: u64 = 5_538_846_115;
-        const EMISSION_DECAY: f64 = 0.999_999_560_409_038_5;
-        const EMISSION_TAIL: u64 = 1;
-
-        let schedule = EmissionScheduleOld::new(EMISSION_INITIAL * uT, EMISSION_DECAY, EMISSION_TAIL * T);
-
-        // Block numbers in these tests represent the edge cases of the pow function.
-        assert_eq!(schedule.block_reward(9182), MicroTari::from(5517534590));
-        assert_eq!(schedule.block_reward(9430), MicroTari::from(5516933218));
-        assert_eq!(schedule.block_reward(10856), MicroTari::from(5513476601));
-        assert_eq!(schedule.block_reward(11708), MicroTari::from(5511412391));
-        assert_eq!(schedule.block_reward(30335), MicroTari::from(5466475914));
-        assert_eq!(schedule.block_reward(33923), MicroTari::from(5457862272));
-        assert_eq!(schedule.block_reward(34947), MicroTari::from(5455406466));
-    }
-
-    #[test]
-    #[allow(clippy::identity_op)]
-    fn block_diff() {
-        const EMISSION_INITIAL: u64 = 5_538_846_115;
-        const EMISSION_DECAY: f64 = 0.999_999_560_409_038_5;
-        const EMISSION_TAIL: u64 = 1;
-
-        let schedule = EmissionScheduleOld::new(EMISSION_INITIAL * uT, EMISSION_DECAY, EMISSION_TAIL * T);
-        let emission = EmissionSchedule::new(EMISSION_INITIAL * uT, &[22, 23, 24, 26, 27], EMISSION_TAIL * uT);
-
-        // lest test the old schedule vs the new and see if the diff is less than 0.1%
-        assert!(schedule.block_reward(9182) - emission.block_reward(9182) < schedule.block_reward(9182) / 1000);
-        assert!(schedule.block_reward(9430) - emission.block_reward(9430) < schedule.block_reward(9430) / 1000);
-        assert!(schedule.block_reward(10856) - emission.block_reward(10856) < schedule.block_reward(10856) / 1000);
-        assert!(schedule.block_reward(11708) - emission.block_reward(11708) < schedule.block_reward(11708) / 1000);
-        assert!(schedule.block_reward(30335) - emission.block_reward(30335) < schedule.block_reward(30335) / 1000);
-        assert!(schedule.block_reward(33923) - emission.block_reward(33923) < schedule.block_reward(33923) / 1000);
-        assert!(schedule.block_reward(34947) - emission.block_reward(34947) < schedule.block_reward(34947) / 1000);
-        assert!(schedule.block_reward(50000) - emission.block_reward(50000) < schedule.block_reward(50000) / 1000);
-        assert!(schedule.block_reward(100000) - emission.block_reward(100000) < schedule.block_reward(100000) / 1000);
-        assert!(schedule.block_reward(200000) - emission.block_reward(200000) < schedule.block_reward(200000) / 1000);
-        assert!(emission.block_reward(700000) - schedule.block_reward(700000) < schedule.block_reward(700000) / 1000);
-        assert!(
-            emission.block_reward(1400000) - schedule.block_reward(1400000) < schedule.block_reward(1400000) / 1000
-        );
-    }
-
     #[test]
     fn schedule() {
-        let schedule = EmissionScheduleOld::new(MicroTari::from(10_000_000), 0.999, MicroTari::from(100));
+        let schedule = EmissionSchedule::new(MicroTari::from(10_000_100), &[22, 23, 24, 26, 27], MicroTari::from(100));
         let r0 = schedule.block_reward(0);
         assert_eq!(r0, MicroTari::from(10_000_100));
         let s0 = schedule.supply_at_block(0);
         assert_eq!(s0, MicroTari::from(10_000_100));
-        assert_eq!(schedule.block_reward(100), MicroTari::from(9_048_021));
-        assert_eq!(schedule.supply_at_block(100), MicroTari::from(961_136_499));
+        assert_eq!(schedule.block_reward(100), MicroTari::from(9_999_800));
+        assert_eq!(schedule.supply_at_block(100), MicroTari::from(1_009_994_950));
     }
 
     #[test]
     fn huge_block_number() {
-        let mut n = (std::i32::MAX - 1) as u64;
-        let schedule = EmissionScheduleOld::new(MicroTari::from(1e21 as u64), 0.999_999_9, MicroTari::from(100));
-        for _ in 0..3 {
-            assert_eq!(schedule.block_reward(n), MicroTari::from(100));
-            n += 1;
-        }
+        // let mut n = (std::i32::MAX - 1) as u64;
+        let height = 262_800_000; // 1000 years' problem
+        let schedule = EmissionSchedule::new(MicroTari::from(1e7 as u64), &[22, 23, 24, 26, 27], MicroTari::from(100));
+        // Slow but does not overflow
+        assert_eq!(schedule.block_reward(height), MicroTari::from(4_194_303));
     }
 
     #[test]
     fn generate_emission_schedule_as_iterator() {
-        let schedule = EmissionScheduleOld::new(MicroTari::from(10_000_000), 0.999, MicroTari::from(100));
-        let values: Vec<(u64, MicroTari, MicroTari)> = schedule.iter().take(101).collect();
-        assert_eq!(values[0].0, 0);
-        assert_eq!(values[0].1, MicroTari::from(10_000_100));
-        assert_eq!(values[0].2, MicroTari::from(10_000_100));
-        assert_eq!(values[100].0, 100);
-        assert_eq!(values[100].1, MicroTari::from(9_048_021));
-        assert_eq!(values[100].2, MicroTari::from(961_136_499));
+        const INITIAL: u64 = 10_000_100;
+        let schedule = EmissionSchedule::new(
+            MicroTari::from(INITIAL),
+            &[2], // 0.25 decay
+            MicroTari::from(100),
+        );
+        let values = schedule.iter().take(101).collect::<Vec<_>>();
+        let (height, reward, supply) = values[0];
+        assert_eq!(height, 1);
+        assert_eq!(reward, MicroTari::from(7_500_075));
+        assert_eq!(supply, MicroTari::from(17_500_175));
+        let (height, reward, supply) = values[1];
+        assert_eq!(height, 2);
+        assert_eq!(reward, MicroTari::from(5_625_057));
+        assert_eq!(supply, MicroTari::from(23_125_232));
+        let (height, reward, supply) = values[9];
+        assert_eq!(height, 10);
+        assert_eq!(reward, MicroTari::from(563_142));
+        assert_eq!(supply, MicroTari::from(38_310_986));
+        let (height, reward, supply) = values[40];
+        assert_eq!(height, 41);
+        assert_eq!(reward, MicroTari::from(100));
+        assert_eq!(supply, MicroTari::from(40_000_252));
 
-        let mut tot_supply = MicroTari::default();
+        let mut tot_supply = MicroTari::from(INITIAL);
         for (_, reward, supply) in schedule.iter().take(1000) {
             tot_supply += reward;
             assert_eq!(tot_supply, supply);
         }
     }
-
     #[test]
     #[allow(clippy::identity_op)]
     fn emission() {

--- a/base_layer/core/src/transactions/tari_amount.rs
+++ b/base_layer/core/src/transactions/tari_amount.rs
@@ -78,20 +78,25 @@ impl Mul<MicroTari> for u64 {
 }
 
 impl MicroTari {
+    pub fn checked_add(self, v: MicroTari) -> Option<MicroTari> {
+        self.as_u64().checked_add(v.as_u64()).map(Into::into)
+    }
+
     pub fn checked_sub(self, v: MicroTari) -> Option<MicroTari> {
-        if self.0 >= v.0 {
+        if self >= v {
             return Some(self - v);
         }
         None
     }
 
     pub fn saturating_sub(self, v: MicroTari) -> MicroTari {
-        if self.0 >= v.0 {
+        if self >= v {
             return self - v;
         }
         Self(0)
     }
 
+    #[inline]
     pub fn as_u64(&self) -> u64 {
         self.0
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Check for overflows with integer math in emission schedule and adds
tests.

Shift right on u64 will overflow if shifting 64 or more bits. The shift
is ultimately controlled by hard-coded consensus constants. This PR adds
a panic if the emission decay is set too high (i.e. >=64). In release, an
shift right overflow "wraps around", meaning that in the event that
a hard-coded value is set incorrectly/maliciously, it could cause an inflation bug.
This PR adds a check that will panic if the emission  decay will cause an overflow.

EDIT: Interestingly/weirdly rust has two behaviours in release for overflows depending on whether the shifted value is static/constant `123u8 >> 256 == 123u8` (wraps around, info preserved) or dynamic  `let mut n = 123u8; for _ in 0..256*3 {  n >>= 1; }; assert_eq!(n, 0);` (bits shifted into 0, original information lost)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Consensus critical code check + cleanup of old emission code

https://play.rust-lang.org/?version=stable&mode=release&edition=2018&gist=4be9af5dbe4db22518d3c763a4c60e2b

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
New unit tests

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch.
* [x] I have squashed my commits into a single commit.
