### PR TITLE
Fix potential overflow and improve performance of n_leaves

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4502,7 +4502,7 @@ dependencies = [
 
 [[package]]
 name = "tari_wallet_ffi"
-version = "0.16.27"
+version = "0.16.28"
 dependencies = [
  "chrono",
  "env_logger 0.7.1",

--- a/base_layer/mmr/src/mutable_mmr.rs
+++ b/base_layer/mmr/src/mutable_mmr.rs
@@ -22,7 +22,7 @@
 
 use crate::{
     backend::ArrayLike,
-    common::{n_leaves, node_index},
+    common::node_index,
     error::MerkleMountainRangeError,
     mutable_mmr_leaf_nodes::MutableMmrLeafNodes,
     Hash,
@@ -255,20 +255,5 @@ where
 {
     fn eq(&self, other: &MutableMmr<D, B2>) -> bool {
         self.get_merkle_root() == other.get_merkle_root()
-    }
-}
-
-impl<D, B> From<MerkleMountainRange<D, B>> for MutableMmr<D, B>
-where
-    D: Digest,
-    B: ArrayLike<Value = Hash>,
-{
-    fn from(mmr: MerkleMountainRange<D, B>) -> Self {
-        let size = n_leaves(mmr.len().unwrap()) as u32; // TODO: fix unwrap
-        MutableMmr {
-            mmr,
-            deleted: Bitmap::create(),
-            size,
-        }
     }
 }


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
- Fix overflow when using usize::MAX as input to n_leaves
- Remove Vec allocation from n_leaves calculation
- Remove unused type conversion impl, if used could panic

Details:

- found by @pventuzelo
- found using manual code audit/review & fuzzing
- related code (n_leaves): https://github.com/tari-project/tari/blob/95499a7aea664407efc68d44aec0f97b6044ba86/base_layer/mmr/src/common.rs#L184-L186
- can also be triggered using leaf_index: https://github.com/tari-project/tari/blob/95499a7aea664407efc68d44aec0f97b6044ba86/base_layer/mmr/src/common.rs#L40-L42

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fix potential integer overflow

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Added overflow case to existing unit test

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch.
* [x] I have squashed my commits into a single commit.
