### PR TITLE
[wallet] Update connectivity status when base node changes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4502,7 +4502,7 @@ dependencies = [
 
 [[package]]
 name = "tari_wallet_ffi"
-version = "0.16.27"
+version = "0.16.28"
 dependencies = [
  "chrono",
  "env_logger 0.7.1",

--- a/applications/tari_console_wallet/src/ui/app.rs
+++ b/applications/tari_console_wallet/src/ui/app.rs
@@ -65,7 +65,7 @@ pub struct App<B: Backend> {
 }
 
 impl<B: Backend> App<B> {
-    pub async fn new(
+    pub fn new(
         title: String,
         wallet: WalletSqlite,
         network: Network,

--- a/applications/tari_console_wallet/src/ui/state/wallet_event_monitor.rs
+++ b/applications/tari_console_wallet/src/ui/state/wallet_event_monitor.rs
@@ -109,14 +109,14 @@ impl WalletEventMonitor {
                         match result {
                             Ok(msg) => {
                                 trace!(target: LOG_TARGET, "Wallet Event Monitor received wallet event {:?}", msg);
-                                match (*msg).clone() {
+                                match &*msg {
                                     ConnectivityEvent::PeerDisconnected(_) |
                                     ConnectivityEvent::ManagedPeerDisconnected(_) |
                                     ConnectivityEvent::PeerConnected(_) |
                                     ConnectivityEvent::PeerBanned(_) |
                                     ConnectivityEvent::PeerOffline(_) |
                                     ConnectivityEvent::PeerConnectionWillClose(_, _) => {
-                                    self.trigger_peer_state_refresh().await;
+                                        self.trigger_peer_state_refresh().await;
                                     },
                                     // Only the above variants trigger state refresh
                                     _ => (),
@@ -130,7 +130,7 @@ impl WalletEventMonitor {
                             Ok(msg) => {
                                 trace!(target: LOG_TARGET, "Wallet Event Monitor received base node event {:?}", msg);
                                 match (*msg).clone() {
-                                    BaseNodeEvent::BaseNodeState(state) => {
+                                    BaseNodeEvent::BaseNodeStateChanged(state) => {
                                         self.trigger_base_node_state_refresh(state).await;
                                     }
                                     BaseNodeEvent::BaseNodePeerSet(peer) => {
@@ -145,8 +145,8 @@ impl WalletEventMonitor {
                         match result {
                             Ok(msg) => {
                                 trace!(target: LOG_TARGET, "Output Manager Service Callback Handler event {:?}", msg);
-                                if let OutputManagerEvent::TxoValidationSuccess(_,_) = *msg.clone() {
-                                        self.trigger_balance_refresh().await;
+                                if let OutputManagerEvent::TxoValidationSuccess(_,_) = &*msg {
+                                    self.trigger_balance_refresh().await;
                                 }
                             },
                             Err(_e) => error!(target: LOG_TARGET, "Error reading from Output Manager Service event broadcast channel"),

--- a/applications/tari_console_wallet/src/wallet_modes.rs
+++ b/applications/tari_console_wallet/src/wallet_modes.rs
@@ -24,17 +24,15 @@ use crate::{
     grpc::WalletGrpcServer,
     notifier::Notifier,
     recovery::wallet_recovery,
-    ui::{run, App},
+    ui,
+    ui::App,
 };
-
 use log::*;
 use rand::{rngs::OsRng, seq::SliceRandom};
 use std::{fs, io::Stdout, net::SocketAddr, path::PathBuf};
 use tari_app_utilities::utilities::ExitCodes;
 use tari_common::GlobalConfig;
-use tari_comms::peer_manager::Peer;
-
-use tari_comms::types::CommsPublicKey;
+use tari_comms::{peer_manager::Peer, types::CommsPublicKey};
 use tari_wallet::WalletSqlite;
 use tokio::runtime::Handle;
 use tonic::transport::Server;
@@ -154,7 +152,7 @@ pub fn tui_mode(
 
     let notifier = Notifier::new(notify_script, handle.clone(), wallet.clone());
 
-    let app = handle.block_on(App::<CrosstermBackend<Stdout>>::new(
+    let app = App::<CrosstermBackend<Stdout>>::new(
         "Tari Console Wallet".into(),
         wallet,
         node_config.network,
@@ -162,8 +160,11 @@ pub fn tui_mode(
         base_node_config,
         node_config,
         notifier,
-    ));
-    handle.enter(|| run(app))?;
+    );
+
+    info!(target: LOG_TARGET, "Starting app");
+
+    handle.enter(|| ui::run(app))?;
 
     info!(
         target: LOG_TARGET,

--- a/base_layer/wallet/src/base_node_service/config.rs
+++ b/base_layer/wallet/src/base_node_service/config.rs
@@ -27,14 +27,14 @@ const LOG_TARGET: &str = "wallet::base_node_service::config";
 
 #[derive(Clone, Debug)]
 pub struct BaseNodeServiceConfig {
-    pub refresh_interval: Duration,
+    pub base_node_monitor_refresh_interval: Duration,
     pub request_max_age: Duration,
 }
 
 impl Default for BaseNodeServiceConfig {
     fn default() -> Self {
         Self {
-            refresh_interval: Duration::from_secs(10),
+            base_node_monitor_refresh_interval: Duration::from_secs(5),
             request_max_age: Duration::from_secs(60),
         }
     }
@@ -49,7 +49,7 @@ impl BaseNodeServiceConfig {
             request_max_age
         );
         Self {
-            refresh_interval: Duration::from_secs(refresh_interval),
+            base_node_monitor_refresh_interval: Duration::from_secs(refresh_interval),
             request_max_age: Duration::from_secs(request_max_age),
         }
     }

--- a/base_layer/wallet/src/base_node_service/handle.rs
+++ b/base_layer/wallet/src/base_node_service/handle.rs
@@ -46,7 +46,7 @@ pub enum BaseNodeServiceResponse {
 }
 #[derive(Clone, Debug, Hash, PartialEq, Eq)]
 pub enum BaseNodeEvent {
-    BaseNodeState(BaseNodeState),
+    BaseNodeStateChanged(BaseNodeState),
     BaseNodePeerSet(Box<Peer>),
 }
 

--- a/base_layer/wallet/src/base_node_service/mod.rs
+++ b/base_layer/wallet/src/base_node_service/mod.rs
@@ -23,9 +23,10 @@
 pub mod config;
 pub mod error;
 pub mod handle;
-
 pub mod mock_base_node_service;
 pub mod service;
+
+mod monitor;
 
 use crate::{
     base_node_service::{config::BaseNodeServiceConfig, handle::BaseNodeServiceHandle, service::BaseNodeService},

--- a/base_layer/wallet/src/base_node_service/monitor.rs
+++ b/base_layer/wallet/src/base_node_service/monitor.rs
@@ -1,0 +1,313 @@
+//  Copyright 2021, The Tari Project
+//
+//  Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+//  following conditions are met:
+//
+//  1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+//  disclaimer.
+//
+//  2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+//  following disclaimer in the documentation and/or other materials provided with the distribution.
+//
+//  3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+//  products derived from this software without specific prior written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+//  INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+//  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+//  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+//  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+//  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+//  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+use crate::{
+    base_node_service::{
+        handle::{BaseNodeEvent, BaseNodeEventSender},
+        service::{BaseNodeState, OnlineState},
+    },
+    error::WalletStorageError,
+    storage::database::{WalletBackend, WalletDatabase},
+};
+use chrono::Utc;
+use futures::{future, future::Either};
+use log::*;
+use std::{convert::TryFrom, sync::Arc, time::Duration};
+use tari_common_types::chain_metadata::ChainMetadata;
+use tari_comms::{
+    connectivity::{ConnectivityError, ConnectivityRequester},
+    peer_manager::NodeId,
+    protocol::rpc::RpcError,
+    PeerConnection,
+};
+use tari_core::base_node::rpc::BaseNodeWalletRpcClient;
+use tari_shutdown::ShutdownSignal;
+use tokio::{
+    stream::StreamExt,
+    sync::{broadcast, RwLock},
+    time,
+};
+
+const LOG_TARGET: &str = "wallet::base_node_service::chain_metadata_monitor";
+
+pub struct BaseNodeMonitor<T> {
+    interval: Duration,
+    state: Arc<RwLock<BaseNodeState>>,
+    db: WalletDatabase<T>,
+    connectivity_manager: ConnectivityRequester,
+    event_publisher: BaseNodeEventSender,
+    shutdown_signal: ShutdownSignal,
+}
+
+impl<T: WalletBackend + 'static> BaseNodeMonitor<T> {
+    pub fn new(
+        interval: Duration,
+        state: Arc<RwLock<BaseNodeState>>,
+        db: WalletDatabase<T>,
+        connectivity_manager: ConnectivityRequester,
+        event_publisher: BaseNodeEventSender,
+        shutdown_signal: ShutdownSignal,
+    ) -> Self
+    {
+        Self {
+            interval,
+            state,
+            db,
+            connectivity_manager,
+            event_publisher,
+            shutdown_signal,
+        }
+    }
+
+    pub async fn run(mut self) {
+        loop {
+            trace!(target: LOG_TARGET, "Beginning new base node monitoring round");
+            match self.process().await {
+                Ok(_) => continue,
+                Err(BaseNodeMonitorError::NodeShuttingDown) => {
+                    debug!(
+                        target: LOG_TARGET,
+                        "Wallet Base Node Service chain metadata task shutting down because the shutdown signal was \
+                         received"
+                    );
+                    break;
+                },
+                Err(e @ BaseNodeMonitorError::RpcFailed(_)) | Err(e @ BaseNodeMonitorError::DialFailed(_)) => {
+                    debug!(target: LOG_TARGET, "Connectivity failure to base node: {}", e,);
+                    debug!(
+                        target: LOG_TARGET,
+                        "Setting as OFFLINE and retrying after {:.2?}", self.interval
+                    );
+
+                    self.set_offline().await;
+                    time::delay_for(self.interval).await;
+                    continue;
+                },
+                Err(BaseNodeMonitorError::BaseNodeChanged) => {
+                    debug!(
+                        target: LOG_TARGET,
+                        "Base node has changed. Connecting to new base node...",
+                    );
+
+                    self.set_connecting().await;
+                    continue;
+                },
+                Err(e @ BaseNodeMonitorError::InvalidBaseNodeResponse(_)) |
+                Err(e @ BaseNodeMonitorError::WalletStorageError(_)) => {
+                    error!(target: LOG_TARGET, "{}", e);
+                    time::delay_for(self.interval).await;
+                    continue;
+                },
+            }
+        }
+    }
+
+    async fn process(&mut self) -> Result<(), BaseNodeMonitorError> {
+        let peer = self.wait_for_peer_to_be_set().await?;
+        let connection = self.attempt_dial(peer.clone()).await?;
+        debug!(
+            target: LOG_TARGET,
+            "Base node connected. Establishing RPC connection...",
+        );
+        let client = self.connect_client(connection).await?;
+        debug!(target: LOG_TARGET, "RPC established",);
+        self.monitor_node(peer, client).await?;
+        Ok(())
+    }
+
+    async fn wait_for_peer_to_be_set(&mut self) -> Result<NodeId, BaseNodeMonitorError> {
+        // We aren't worried about late subscription here because we also check the state for a set base node peer, as
+        // long as we subscribe before checking state.
+        let mut event_subscription = self.event_publisher.subscribe();
+        loop {
+            let peer = self
+                .state
+                .read()
+                .await
+                .base_node_peer
+                .as_ref()
+                .map(|p| p.node_id.clone());
+
+            match peer {
+                Some(peer) => return Ok(peer),
+                None => {
+                    trace!(target: LOG_TARGET, "Base node peer not set yet. Waiting for event");
+                    let either = future::select(event_subscription.next(), &mut self.shutdown_signal).await;
+                    match either {
+                        Either::Left((Some(Ok(_)), _)) |
+                        Either::Left((Some(Err(broadcast::RecvError::Lagged(_))), _)) => {
+                            trace!(target: LOG_TARGET, "Base node monitor got event");
+                            // If we get any event (or some were missed), let's check base node peer has been set
+                            continue;
+                        },
+                        // All of these indicate that the node has been shut down
+                        Either::Left((Some(Err(broadcast::RecvError::Closed)), _)) |
+                        Either::Left((None, _)) |
+                        Either::Right((_, _)) => return Err(BaseNodeMonitorError::NodeShuttingDown),
+                    }
+                },
+            }
+        }
+    }
+
+    async fn attempt_dial(&mut self, peer: NodeId) -> Result<PeerConnection, BaseNodeMonitorError> {
+        let conn = self.connectivity_manager.dial_peer(peer).await?;
+        Ok(conn)
+    }
+
+    async fn connect_client(&self, mut conn: PeerConnection) -> Result<BaseNodeWalletRpcClient, BaseNodeMonitorError> {
+        let client = conn.connect_rpc().await?;
+        Ok(client)
+    }
+
+    async fn monitor_node(
+        &self,
+        peer_node_id: NodeId,
+        mut client: BaseNodeWalletRpcClient,
+    ) -> Result<(), BaseNodeMonitorError>
+    {
+        loop {
+            let latency = client.get_last_request_latency().await?;
+            trace!(
+                target: LOG_TARGET,
+                "Base node latency: {} ms",
+                latency.unwrap_or_default().as_millis()
+            );
+
+            let tip_info = client.get_tip_info().await?;
+            let is_synced = tip_info.is_synced;
+
+            let chain_metadata = tip_info
+                .metadata
+                .ok_or_else(|| BaseNodeMonitorError::InvalidBaseNodeResponse("Tip info no metadata".to_string()))
+                .and_then(|metadata| {
+                    ChainMetadata::try_from(metadata).map_err(BaseNodeMonitorError::InvalidBaseNodeResponse)
+                })?;
+
+            self.db.set_chain_metadata(chain_metadata.clone()).await?;
+
+            self.map_state(move |state| BaseNodeState {
+                chain_metadata: Some(chain_metadata),
+                is_synced: Some(is_synced),
+                updated: Some(Utc::now().naive_utc()),
+                latency,
+                online: OnlineState::Online,
+                base_node_peer: state.base_node_peer.clone(),
+            })
+            .await;
+
+            self.sleep_or_shutdown().await?;
+            self.check_if_base_node_changed(&peer_node_id).await?;
+        }
+
+        // loop only exits on shutdown/error
+        #[allow(unreachable_code)]
+        Ok(())
+    }
+
+    async fn check_if_base_node_changed(&self, peer_node_id: &NodeId) -> Result<(), BaseNodeMonitorError> {
+        // Check if the base node peer is no longer set or has changed
+        if self
+            .state
+            .read()
+            .await
+            .base_node_peer
+            .as_ref()
+            .filter(|p| &p.node_id == peer_node_id)
+            .is_some()
+        {
+            Ok(())
+        } else {
+            Err(BaseNodeMonitorError::BaseNodeChanged)
+        }
+    }
+
+    async fn set_connecting(&self) {
+        self.map_state(|state| BaseNodeState {
+            chain_metadata: None,
+            is_synced: None,
+            updated: Some(Utc::now().naive_utc()),
+            latency: None,
+            online: OnlineState::Connecting,
+            base_node_peer: state.base_node_peer.clone(),
+        })
+        .await;
+    }
+
+    async fn set_offline(&self) {
+        self.map_state(|state| BaseNodeState {
+            chain_metadata: None,
+            is_synced: None,
+            updated: Some(Utc::now().naive_utc()),
+            latency: None,
+            online: OnlineState::Offline,
+            base_node_peer: state.base_node_peer.clone(),
+        })
+        .await;
+    }
+
+    async fn map_state<F>(&self, transform: F)
+    where F: FnOnce(&BaseNodeState) -> BaseNodeState {
+        let new_state = {
+            let mut lock = self.state.write().await;
+            let new_state = transform(&*lock);
+            *lock = new_state.clone();
+            new_state
+        };
+        self.publish_event(BaseNodeEvent::BaseNodeStateChanged(new_state));
+    }
+
+    async fn sleep_or_shutdown(&self) -> Result<(), BaseNodeMonitorError> {
+        let delay = time::delay_for(self.interval);
+        let mut shutdown_signal = self.shutdown_signal.clone();
+        if let Either::Right(_) = future::select(delay, &mut shutdown_signal).await {
+            return Err(BaseNodeMonitorError::NodeShuttingDown);
+        }
+        Ok(())
+    }
+
+    fn publish_event(&self, event: BaseNodeEvent) {
+        trace!(target: LOG_TARGET, "Publishing event: {:?}", event);
+        let _ = self.event_publisher.send(Arc::new(event)).map_err(|_| {
+            trace!(
+                target: LOG_TARGET,
+                "Could not publish BaseNodeEvent as there are no subscribers"
+            )
+        });
+    }
+}
+
+#[derive(thiserror::Error, Debug)]
+enum BaseNodeMonitorError {
+    #[error("Node is shutting down")]
+    NodeShuttingDown,
+    #[error("Failed to dial base node: {0}")]
+    DialFailed(#[from] ConnectivityError),
+    #[error("Rpc error: {0}")]
+    RpcFailed(#[from] RpcError),
+    #[error("Invalid base node response: {0}")]
+    InvalidBaseNodeResponse(String),
+    #[error("Wallet storage error: {0}")]
+    WalletStorageError(#[from] WalletStorageError),
+    #[error("Base node changed")]
+    BaseNodeChanged,
+}

--- a/base_layer/wallet/src/base_node_service/service.rs
+++ b/base_layer/wallet/src/base_node_service/service.rs
@@ -25,21 +25,19 @@ use super::{
     error::BaseNodeServiceError,
     handle::{BaseNodeEvent, BaseNodeEventSender, BaseNodeServiceRequest, BaseNodeServiceResponse},
 };
-use crate::storage::database::{WalletBackend, WalletDatabase};
-use chrono::{NaiveDateTime, Utc};
-use futures::{future::Fuse, pin_mut, select, FutureExt, StreamExt};
-use log::*;
-use std::{
-    convert::TryFrom,
-    sync::{Arc, RwLock},
-    time::Duration,
+use crate::{
+    base_node_service::monitor::BaseNodeMonitor,
+    storage::database::{WalletBackend, WalletDatabase},
 };
+use chrono::NaiveDateTime;
+use futures::StreamExt;
+use log::*;
+use std::{sync::Arc, time::Duration};
 use tari_common_types::chain_metadata::ChainMetadata;
 use tari_comms::{connectivity::ConnectivityRequester, peer_manager::Peer};
-use tari_core::base_node::rpc::BaseNodeWalletRpcClient;
 use tari_service_framework::reply_channel::Receiver;
 use tari_shutdown::ShutdownSignal;
-use tokio::time::{delay_for, Delay};
+use tokio::sync::RwLock;
 
 const LOG_TARGET: &str = "wallet::base_node_service::service";
 
@@ -106,78 +104,72 @@ where T: WalletBackend + 'static
             connectivity_manager,
             event_publisher,
             shutdown_signal: Some(shutdown_signal),
-            state: Arc::new(RwLock::new(BaseNodeState::default())),
+            state: Default::default(),
             db,
         }
     }
 
     /// Returns the last known state of the connected base node.
-    pub fn get_state(&self) -> BaseNodeState {
-        let lock = acquire_read_lock!(self.state);
-        (*lock).clone()
+    pub async fn get_state(&self) -> BaseNodeState {
+        self.state.read().await.clone()
     }
 
     /// Starts the service.
     pub async fn start(mut self) -> Result<(), BaseNodeServiceError> {
-        let request_stream = self
-            .request_stream
-            .take()
-            .expect("Wallet Base Node Service initialized without request_stream")
-            .fuse();
-        pin_mut!(request_stream);
-
-        let mut shutdown_signal = self
+        let shutdown_signal = self
             .shutdown_signal
             .take()
             .expect("Wallet Base Node Service initialized without shutdown signal");
 
-        let join_handle = tokio::spawn(monitor_chain_metadata_task(
-            self.config.refresh_interval,
+        let monitor = BaseNodeMonitor::new(
+            self.config.base_node_monitor_refresh_interval,
             self.state.clone(),
             self.db.clone(),
             self.connectivity_manager.clone(),
             self.event_publisher.clone(),
             shutdown_signal.clone(),
-        ));
+        );
+
+        tokio::spawn(monitor.run());
+
+        let mut request_stream = self
+            .request_stream
+            .take()
+            .expect("Wallet Base Node Service initialized without request_stream")
+            .take_until(shutdown_signal);
 
         info!(target: LOG_TARGET, "Wallet Base Node Service started");
-        loop {
-            futures::select! {
-                // Incoming requests
-                request_context = request_stream.select_next_some() => {
-                    trace!(target: LOG_TARGET, "Handling Base Node Service API Request");
-                    let (request, reply_tx) = request_context.split();
-                    let response = self.handle_request(request).await.map_err(|e| {
-                        error!(target: LOG_TARGET, "Error handling request: {:?}", e);
-                        e
-                    });
-                    let _ = reply_tx.send(response).map_err(|e| {
-                        warn!(target: LOG_TARGET, "Failed to send reply");
-                        e
-                    });
-                },
-                // Shutdown
-                _ = shutdown_signal => {
-                    let _ = join_handle.await;
-                    info!(target: LOG_TARGET, "Wallet Base Node Service shutting down because the shutdown signal was received");
-                    break Ok(());
-                }
-            }
+        while let Some(request_context) = request_stream.next().await {
+            // Incoming requests
+            let (request, reply_tx) = request_context.split();
+            let response = self.handle_request(request).await.map_err(|e| {
+                error!(target: LOG_TARGET, "Error handling request: {:?}", e);
+                e
+            });
+            let _ = reply_tx.send(response).map_err(|e| {
+                warn!(target: LOG_TARGET, "Failed to send reply");
+                e
+            });
         }
+
+        info!(
+            target: LOG_TARGET,
+            "Wallet Base Node Service shutting down because the shutdown signal was received"
+        );
+        Ok(())
     }
 
-    fn set_base_node_peer(&mut self, peer: Peer) {
-        reset_state(self.state.clone(), &mut self.event_publisher);
+    async fn set_base_node_peer(&self, peer: Peer) {
+        let mut new_state = BaseNodeState::default();
+        new_state.base_node_peer = Some(peer.clone());
 
         {
-            let mut lock = acquire_write_lock!(self.state);
-            (*lock).base_node_peer = Some(peer.clone());
-        }
+            let mut lock = self.state.write().await;
+            *lock = new_state.clone();
+        };
 
-        publish_event(
-            &mut self.event_publisher,
-            BaseNodeEvent::BaseNodePeerSet(Box::new(peer)),
-        );
+        self.publish_event(BaseNodeEvent::BaseNodeStateChanged(new_state));
+        self.publish_event(BaseNodeEvent::BaseNodePeerSet(Box::new(peer)));
     }
 
     /// This handler is called when requests arrive from the various streams
@@ -192,10 +184,10 @@ where T: WalletBackend + 'static
         );
         match request {
             BaseNodeServiceRequest::SetBaseNodePeer(peer) => {
-                self.set_base_node_peer(*peer);
+                self.set_base_node_peer(*peer).await;
                 Ok(BaseNodeServiceResponse::BaseNodePeerSet)
             },
-            BaseNodeServiceRequest::GetChainMetadata => match self.get_state().chain_metadata.clone() {
+            BaseNodeServiceRequest::GetChainMetadata => match self.get_state().await.chain_metadata.clone() {
                 Some(metadata) => Ok(BaseNodeServiceResponse::ChainMetadata(Some(metadata))),
                 None => {
                     // if we don't have live state, check if we've previously stored state in the wallet db
@@ -205,213 +197,14 @@ where T: WalletBackend + 'static
             },
         }
     }
-}
 
-async fn monitor_chain_metadata_task<T: WalletBackend + 'static>(
-    interval: Duration,
-    state: Arc<RwLock<BaseNodeState>>,
-    db: WalletDatabase<T>,
-    mut connectivity_manager: ConnectivityRequester,
-    mut event_publisher: BaseNodeEventSender,
-    mut shutdown_signal: ShutdownSignal,
-)
-{
-    // RPC connectivity loop
-    loop {
-        let base_node_peer = {
-            let lock = acquire_read_lock!(state);
-            (*lock).base_node_peer.clone()
-        };
-
-        let delay = delay_for(interval).fuse();
-
-        let base_node_peer = match base_node_peer {
-            None => {
-                if wait_or_shutdown(delay, &mut shutdown_signal).await {
-                    continue;
-                } else {
-                    return;
-                }
-            },
-            Some(p) => p,
-        };
-
-        let mut connection = match connectivity_manager.dial_peer(base_node_peer.node_id.clone()).await {
-            Ok(c) => c,
-            Err(e) => {
-                set_offline(state.clone(), &mut event_publisher);
-                error!(target: LOG_TARGET, "Error dialing base node peer: {}", e);
-                if wait_or_shutdown(delay, &mut shutdown_signal).await {
-                    continue;
-                } else {
-                    return;
-                }
-            },
-        };
-
-        let mut client = match connection.connect_rpc::<BaseNodeWalletRpcClient>().await {
-            Ok(c) => c,
-            Err(e) => {
-                set_offline(state.clone(), &mut event_publisher);
-                error!(
-                    target: LOG_TARGET,
-                    "Error establishing RPC connection to base node peer: {}", e
-                );
-                if wait_or_shutdown(delay, &mut shutdown_signal).await {
-                    continue;
-                } else {
-                    return;
-                }
-            },
-        };
-
-        'inner: loop {
-            trace!(target: LOG_TARGET, "Refresh chain metadata");
-
-            let now = Utc::now().naive_utc();
-            let delay = delay_for(interval).fuse();
-
-            let latency = match client.get_last_request_latency().await {
-                Ok(l) => l,
-                Err(e) => {
-                    warn!(
-                        target: LOG_TARGET,
-                        "Error making `get_last_request_latency` RPC call to base node peer: {}", e
-                    );
-                    if wait_or_shutdown(delay, &mut shutdown_signal).await {
-                        break 'inner;
-                    } else {
-                        return;
-                    }
-                },
-            };
-
+    fn publish_event(&self, event: BaseNodeEvent) {
+        trace!(target: LOG_TARGET, "Publishing event: {:?}", event);
+        let _ = self.event_publisher.send(Arc::new(event)).map_err(|_| {
             trace!(
                 target: LOG_TARGET,
-                "Base node latency: {} ms",
-                latency.unwrap_or_default().as_millis()
-            );
-
-            let tip_info = match client.get_tip_info().await {
-                Ok(t) => t,
-                Err(e) => {
-                    warn!(
-                        target: LOG_TARGET,
-                        "Error making `get_tip_info` RPC call to base node peer: {}", e
-                    );
-                    if wait_or_shutdown(delay, &mut shutdown_signal).await {
-                        break 'inner;
-                    } else {
-                        return;
-                    }
-                },
-            };
-
-            let metadata = match tip_info
-                .metadata
-                .ok_or_else(|| BaseNodeServiceError::InvalidBaseNodeResponse("Tip info no metadata".to_string()))
-            {
-                Ok(m) => m,
-                Err(e) => {
-                    warn!(target: LOG_TARGET, "RPC return type error: {}", e);
-                    if wait_or_shutdown(delay, &mut shutdown_signal).await {
-                        continue;
-                    } else {
-                        return;
-                    }
-                },
-            };
-
-            let chain_metadata = match ChainMetadata::try_from(metadata) {
-                Ok(m) => m,
-                Err(e) => {
-                    warn!(target: LOG_TARGET, "RPC return type conversion error: {}", e);
-                    if wait_or_shutdown(delay, &mut shutdown_signal).await {
-                        continue;
-                    } else {
-                        return;
-                    }
-                },
-            };
-
-            // store chain metadata in the wallet db
-            if let Err(e) = db.set_chain_metadata(chain_metadata.clone()).await {
-                warn!(target: LOG_TARGET, "Error storing chain metadata: {:?}", e);
-                if wait_or_shutdown(delay, &mut shutdown_signal).await {
-                    continue;
-                } else {
-                    return;
-                }
-            };
-
-            let new_state = {
-                let mut lock = acquire_write_lock!(state);
-
-                let new_state = BaseNodeState {
-                    chain_metadata: Some(chain_metadata),
-                    is_synced: Some(tip_info.is_synced),
-                    updated: Some(now),
-                    latency,
-                    online: OnlineState::Online,
-                    base_node_peer: (*lock).base_node_peer.clone(),
-                };
-                (*lock) = new_state.clone();
-                new_state
-            };
-
-            let event = BaseNodeEvent::BaseNodeState(new_state);
-
-            publish_event(&mut event_publisher, event);
-        }
-    }
-}
-
-/// Utility function to set and publish offline state
-fn set_offline(state: Arc<RwLock<BaseNodeState>>, event_publisher: &mut BaseNodeEventSender) {
-    let mut lock = acquire_write_lock!(*state);
-
-    let now = Utc::now().naive_utc();
-    let new_state = BaseNodeState {
-        chain_metadata: None,
-        is_synced: None,
-        updated: Some(now),
-        latency: None,
-        online: OnlineState::Offline,
-        base_node_peer: (*lock).base_node_peer.clone(),
-    };
-
-    let event = BaseNodeEvent::BaseNodeState(new_state.clone());
-    publish_event(event_publisher, event);
-
-    (*lock) = new_state;
-}
-
-fn publish_event(event_publisher: &mut BaseNodeEventSender, event: BaseNodeEvent) {
-    trace!(target: LOG_TARGET, "Publishing event: {:?}", event);
-    let _ = event_publisher.send(Arc::new(event)).map_err(|_| {
-        trace!(
-            target: LOG_TARGET,
-            "Could not publish BaseNodeEvent as there are no subscribers"
-        )
-    });
-}
-
-fn reset_state(state: Arc<RwLock<BaseNodeState>>, event_publisher: &mut BaseNodeEventSender) {
-    let new_state = BaseNodeState::default();
-    let mut lock = acquire_write_lock!(state);
-    publish_event(event_publisher, BaseNodeEvent::BaseNodeState((*lock).clone()));
-    (*lock) = new_state;
-}
-
-// Utility function to wait for the delay to complete and return true, or return false if the shutdown signal fired.
-async fn wait_or_shutdown(mut delay: Fuse<Delay>, mut shutdown_signal: &mut ShutdownSignal) -> bool {
-    select! {
-        _ = delay => {
-            true
-        },
-         _ = shutdown_signal => {
-            debug!(target: LOG_TARGET, "Wallet Base Node Service chain metadata task shutting down because the shutdown signal was received");
-            false
-        }
+                "Could not publish BaseNodeEvent as there are no subscribers"
+            )
+        });
     }
 }

--- a/base_layer/wallet/src/storage/database.rs
+++ b/base_layer/wallet/src/storage/database.rs
@@ -88,9 +88,7 @@ pub enum WriteOperation {
 }
 
 #[derive(Clone)]
-pub struct WalletDatabase<T>
-where T: WalletBackend + 'static
-{
+pub struct WalletDatabase<T> {
     db: Arc<T>,
 }
 

--- a/base_layer/wallet/src/transaction_service/mod.rs
+++ b/base_layer/wallet/src/transaction_service/mod.rs
@@ -194,7 +194,7 @@ where T: TransactionBackend + 'static
             let output_manager_service = handles.expect_handle::<OutputManagerHandle>();
             let connectivity_manager = handles.expect_handle::<ConnectivityRequester>();
 
-            let service = TransactionService::new(
+            let result = TransactionService::new(
                 config,
                 TransactionDatabase::new(backend),
                 receiver,
@@ -211,9 +211,12 @@ where T: TransactionBackend + 'static
                 factories,
                 handles.get_shutdown_signal(),
             )
-            .start();
-            futures::pin_mut!(service);
-            future::select(service, handles.get_shutdown_signal()).await;
+            .start()
+            .await;
+
+            if let Err(e) = result {
+                error!(target: LOG_TARGET, "Transaction Service error: {}", e);
+            }
             info!(target: LOG_TARGET, "Transaction Service shutdown");
         });
 

--- a/base_layer/wallet/src/wallet.rs
+++ b/base_layer/wallet/src/wallet.rs
@@ -291,7 +291,7 @@ where
             .set_base_node_public_key(peer.public_key.clone())
             .await?;
 
-        self.base_node_service.clone().set_base_node_peer(peer).await?;
+        self.base_node_service.set_base_node_peer(peer).await?;
 
         Ok(())
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
- Slightly improve speed of broadcast protocol restart
- The monitoring task detects when the base node has changed, transactions
   to Connecting -> Connected | Offline
- Use an async RwLock to prevent holding up a tokio runtime thread with a synchronous lock

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Previously the monitoring task would not change to the new peer (without a wallet restart)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested manually

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch.
* [x] I have squashed my commits into a single commit.
