### PR TITLE
Remove "end of time" panic in emission

### DIFF
--- a/applications/tari_base_node/src/grpc/base_node_grpc_server.rs
+++ b/applications/tari_base_node/src/grpc/base_node_grpc_server.rs
@@ -926,12 +926,21 @@ impl tari_rpc::base_node_server::BaseNode for BaseNodeGrpcServer {
                 .drain(..cmp::min(heights.len(), GET_TOKENS_IN_CIRCULATION_PAGE_SIZE))
                 .collect();
             while !page.is_empty() {
+                // TODO: This is not ideal. The main issue here is the interface to get_tokens_in_circulation includes
+                // blocks at any height to be selected instead of a more coherent start - end range. This means we
+                // cannot use the Emission iterator as intended and instead, must query the supply at a
+                // given height for each block (the docs mention to use the iterator instead of supply_at_block in a
+                // loop, however the Iterator was not exposed at the time this handler was written).
                 let values: Vec<tari_rpc::ValueAtHeightResponse> = page
                     .clone()
                     .into_iter()
                     .map(|height| tari_rpc::ValueAtHeightResponse {
                         height,
-                        value: consensus_manager.emission_schedule().supply_at_block(height).into(),
+                        value: consensus_manager
+                            .emission_schedule()
+                            .supply_at_block(height)
+                            .map(Into::into)
+                            .unwrap_or(0),
                     })
                     .collect();
                 let result_size = values.len();

--- a/base_layer/core/src/consensus/consensus_manager.rs
+++ b/base_layer/core/src/consensus/consensus_manager.rs
@@ -37,7 +37,7 @@ use crate::{
     chain_storage::{ChainBlock, ChainStorageError},
     consensus::{
         chain_strength_comparer::{strongest_chain, ChainStrengthComparer},
-        emission::{Emission, EmissionSchedule},
+        emission::EmissionSchedule,
         network::Network,
         ConsensusConstants,
     },
@@ -103,7 +103,7 @@ impl ConsensusManager {
     /// Get a pointer to the emission schedule
     /// The height provided here, decides the emission curve to use. It swaps to the integer curve upon reaching
     /// 1_000_000_000
-    pub fn emission_schedule(&self) -> &dyn Emission {
+    pub fn emission_schedule(&self) -> &EmissionSchedule {
         &self.inner.emission
     }
 
@@ -111,8 +111,9 @@ impl ConsensusManager {
         self.emission_schedule().block_reward(height)
     }
 
-    // Get the emission reward at height
-    pub fn get_total_emission_at(&self, height: u64) -> MicroTari {
+    /// Get the emission reward at height
+    /// Returns None if the total supply > u64::MAX
+    pub fn get_total_emission_at(&self, height: u64) -> Option<MicroTari> {
         self.inner.emission.supply_at_block(height)
     }
 

--- a/base_layer/core/src/transactions/coinbase_builder.rs
+++ b/base_layer/core/src/transactions/coinbase_builder.rs
@@ -22,7 +22,7 @@
 //
 
 use crate::{
-    consensus::{emission::Emission, ConsensusConstants},
+    consensus::{emission::EmissionSchedule, ConsensusConstants},
     transactions::{
         tari_amount::{uT, MicroTari},
         transaction::{
@@ -131,7 +131,7 @@ impl CoinbaseBuilder {
     pub fn build(
         self,
         constants: &ConsensusConstants,
-        emission_schedule: &dyn Emission,
+        emission_schedule: &EmissionSchedule,
     ) -> Result<(Transaction, UnblindedOutput), CoinbaseBuildError>
     {
         let height = self

--- a/base_layer/core/src/transactions/tari_amount.rs
+++ b/base_layer/core/src/transactions/tari_amount.rs
@@ -78,6 +78,10 @@ impl Mul<MicroTari> for u64 {
 }
 
 impl MicroTari {
+    pub fn checked_add(self, v: MicroTari) -> Option<MicroTari> {
+        self.as_u64().checked_add(v.as_u64()).map(Into::into)
+    }
+
     pub fn checked_sub(self, v: MicroTari) -> Option<MicroTari> {
         if self.0 >= v.0 {
             return Some(self - v);

--- a/base_layer/core/src/validation/chain_balance.rs
+++ b/base_layer/core/src/validation/chain_balance.rs
@@ -61,7 +61,7 @@ impl<B: BlockchainBackend> FinalHorizonStateValidation<B> for ChainBalanceValida
         backend: &B,
     ) -> Result<(), ValidationError>
     {
-        let emission_h = self.get_emission_commitment_at(height);
+        let emission_h = self.get_emission_commitment_at(height)?;
         let total_offset = self.fetch_total_offset_commitment(height, backend)?;
 
         debug!(
@@ -89,14 +89,15 @@ impl<B: BlockchainBackend> ChainBalanceValidator<B> {
         Ok(self.factories.commitment.commit(&offset, &0u64.into()))
     }
 
-    fn get_emission_commitment_at(&self, height: u64) -> Commitment {
-        let total_supply =
-            self.rules.get_total_emission_at(height) + self.rules.consensus_constants(height).faucet_value();
+    fn get_emission_commitment_at(&self, height: u64) -> Result<Commitment, ValidationError> {
+        let total_supply = self.rules.get_total_emission_at(height).ok_or_else(|| {
+            ValidationError::EndOfTimeError("Supply value has exceeded what can be stored in a u64".to_string())
+        })? + self.rules.consensus_constants(height).faucet_value();
         debug!(
             target: LOG_TARGET,
             "Expected emission at height {} is {}", height, total_supply
         );
-        self.commit_value(total_supply)
+        Ok(self.commit_value(total_supply))
     }
 
     #[inline]

--- a/base_layer/core/src/validation/error.rs
+++ b/base_layer/core/src/validation/error.rs
@@ -79,6 +79,8 @@ pub enum ValidationError {
     InvalidMinedHeight,
     #[error("Maximum transaction weight exceeded")]
     MaxTransactionWeightExceeded,
+    #[error("End of time: {0}")]
+    EndOfTimeError(String),
 }
 
 // ChainStorageError has a ValidationError variant, so to prevent a cyclic dependency we use a string representation in


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Removed `Option::expect` when total supply overflows `u64`. In this
case, the `EmissionRate` iterator considers itself "finished" and so
returns None as per the Iterator contract.

Removes the `Emission` trait, although nothing incorrect about using a
trait in this case, it did not provide much of an advantage (decoupling)
over using the concrete type. It also hid the Iterator impl, that should
have been used in `get_tokens_in_circulation`

Merging into tari-script branch

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Remove a panic which is not impossible. The (working) policy for panics is never to panic if a panic is possible (no matter how unlikely) in normal program operation.  

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Existing emission tests updated. ~~Pruned synced base node from scratch~~ currently not possible on current tari-script chain

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [ ] I'm merging against the `development` branch.
* [x] I have squashed my commits into a single commit.
