### PR TITLE
Fix wallet recovery

### DIFF
--- a/base_layer/wallet/src/output_manager_service/protocols/txo_validation_protocol.rs
+++ b/base_layer/wallet/src/output_manager_service/protocols/txo_validation_protocol.rs
@@ -464,6 +464,12 @@ where TBackend: OutputManagerBackend + 'static
                         "Output with value {} not returned from Base Node query and is thus being invalidated",
                         v.unblinded_output.value,
                     );
+                    trace!(
+                        target: LOG_TARGET,
+                        "Output {} with features {} not returned from Base Node query and is thus being invalidated",
+                        v.commitment.to_hex(),
+                        v.unblinded_output.features,
+                    );
                     // If the output that is being invalidated has an associated TxId then get the kernel signature of
                     // the transaction and display for easier debugging
                     if let Some(tx_id) = self.resources.db.invalidate_output(v).await.map_err(|e| {

--- a/base_layer/wallet/src/tasks/wallet_recovery.rs
+++ b/base_layer/wallet/src/tasks/wallet_recovery.rs
@@ -384,6 +384,7 @@ impl WalletRecoveryTask {
                         uo.value,
                         &uo.spending_key,
                         &source_public_key,
+                        uo.features,
                         format!("Recovered on {}.", Utc::now().naive_utc()),
                     )
                     .await

--- a/base_layer/wallet/src/wallet.rs
+++ b/base_layer/wallet/src/wallet.rs
@@ -304,10 +304,11 @@ where
         amount: MicroTari,
         spending_key: &PrivateKey,
         source_public_key: &CommsPublicKey,
+        features: OutputFeatures,
         message: String,
     ) -> Result<TxId, WalletError>
     {
-        let unblinded_output = UnblindedOutput::new(amount, spending_key.clone(), None);
+        let unblinded_output = UnblindedOutput::new(amount, spending_key.clone(), Some(features));
 
         self.output_manager_service.add_output(unblinded_output.clone()).await?;
 

--- a/base_layer/wallet/tests/wallet/mod.rs
+++ b/base_layer/wallet/tests/wallet/mod.rs
@@ -29,7 +29,7 @@ use tari_comms::{
     types::CommsPublicKey,
 };
 use tari_comms_dht::DhtConfig;
-use tari_core::transactions::{tari_amount::MicroTari, types::CryptoFactories};
+use tari_core::transactions::{tari_amount::MicroTari, transaction::OutputFeatures, types::CryptoFactories};
 use tari_crypto::keys::PublicKey;
 use tari_p2p::initialization::CommsConfig;
 use tari_shutdown::{Shutdown, ShutdownSignal};
@@ -626,6 +626,7 @@ async fn test_import_utxo() {
             utxo.value,
             &utxo.spending_key,
             base_node_identity.public_key(),
+            OutputFeatures::default(),
             "Testing".to_string(),
         )
         .await


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Wallet recovery atm in time can only recover non coinbase outputs. This PR fixes the coinbase UTXO importing. This will allow the wallet to recover coinbase UTXOs.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch.
* [x] I have squashed my commits into a single commit.
