### PR TITLE
Fix flaky tests on tari_script

### DIFF
--- a/base_layer/wallet/tests/output_manager_service/service.rs
+++ b/base_layer/wallet/tests/output_manager_service/service.rs
@@ -1249,7 +1249,7 @@ fn coin_split_with_change<T: Clone + OutputManagerBackend + 'static>(backend: T)
     let uo = runtime
         .block_on(oms.rewind_outputs(vec![coin_split_tx.body.outputs()[3].clone()], 0))
         .expect("Should be able to rewind outputs");
-    assert_eq!(uo[0].value, MicroTari::from(1000))
+    assert!(uo[0].value == MicroTari::from(1000) || uo[0].value == MicroTari::from(3950))
 }
 
 #[test]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

**transaction_service::transaction_protocols::tx_broadcast_protocol_submit_success**

- Upped the timeouts
- Added sleep time after each update tx to ensure db has enough time to write changes, before being asked form them.

**output_manager_service::service::coin_split_with_change_sqlite_db**

- Scanned for both values of the coinsplit as the check only cares about the rewind, and not the value

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [ ] I'm merging against the `development` branch.
* [ ] I have squashed my commits into a single commit.
