### PR TITLE
Update wallet to display pretty error for tor offline

### DIFF
--- a/base_layer/p2p/src/initialization.rs
+++ b/base_layer/p2p/src/initialization.rs
@@ -97,15 +97,12 @@ impl CommsInitializationError {
     pub fn to_friendly_string(&self) -> String {
         // Add any helpful user-facing messages here
         match self {
-            CommsInitializationError::HiddenServiceBuilderError(
-                tor::HiddenServiceBuilderError::HiddenServiceControllerError(
-                    tor::HiddenServiceControllerError::TorControlPortOffline,
-                ),
-            ) => r#"Unable to connect to the Tor control port.
-Please check that you have the Tor proxy running and that access to the Tor control port is turned on.
-If you are unsure of what to do, use the following command to start the Tor proxy:
-tor --allow-missing-torrc --ignore-missing-torrc --clientonly 1 --socksport 9050 --controlport 127.0.0.1:9051 --log "notice stdout" --clientuseipv6 1"#
-                .to_string(),
+            CommsInitializationError::HiddenServiceControllerError(HiddenServiceControllerError::TorControlPortOffline)
+                 => r#"Unable to connect to the Tor control port.
+    Please check that you have the Tor proxy running and that access to the Tor control port is turned on.
+    If you are unsure of what to do, use the following command to start the Tor proxy:
+    tor --allow-missing-torrc --ignore-missing-torrc --clientonly 1 --socksport 9050 --controlport 127.0.0.1:9051 --log "notice stdout" --clientuseipv6 1"#
+                    .to_string(),
             err => format!("Failed to initialize comms: {:?}", err),
         }
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
When tor is offline, the wallet gives a very generic error. This updates the error to a pretty version

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
When you start up the wallet with tor offline, the cmd prints out: `ERROR: CommsInitializationError::HiddenServiceControllerError(HiddenServiceControllerError::TorControlPortOffline)`

after this PR it prints out:
```
Unable to connect to the Tor control port.
    Please check that you have the Tor proxy running and that access to the Tor control port is turned on.
    If you are unsure of what to do, use the following command to start the Tor proxy:
    tor --allow-missing-torrc --ignore-missing-torrc --clientonly 1 --socksport 9050 --controlport 127.0.0.1:9051 --log "notice stdout" --clientuseipv6 1"#
```

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Ran the wallet without tor to ensure correct message is displayed 

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch.
* [x] I have squashed my commits into a single commit.
