### PR TITLE
[ci] Switch to ssh urls for tari-crypto dependency, fixes circle ci issue

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4184,7 +4184,7 @@ dependencies = [
 [[package]]
 name = "tari_crypto"
 version = "0.9.0"
-source = "git+https://github.com/tari-project/tari-crypto/?branch=main#f30d56670aff2b07c93d88859da40fffe51b01f3"
+source = "git+ssh://git@github.com/tari-project/tari-crypto.git?branch=main#f30d56670aff2b07c93d88859da40fffe51b01f3"
 dependencies = [
  "base64 0.10.1",
  "blake2",

--- a/applications/tari_app_grpc/Cargo.toml
+++ b/applications/tari_app_grpc/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2018"
 tari_common_types = { version = "^0.8", path = "../../base_layer/common_types"}
 tari_core = {  path = "../../base_layer/core"}
 tari_wallet = {  path = "../../base_layer/wallet"}
-tari_crypto = { git = "https://github.com/tari-project/tari-crypto/", branch = "main" }
+tari_crypto = { git = "ssh://git@github.com/tari-project/tari-crypto.git", branch = "main" }
 tari_comms = { path = "../../comms"}
 
 chrono = "0.4.6"

--- a/applications/tari_app_utilities/Cargo.toml
+++ b/applications/tari_app_utilities/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 
 [dependencies]
 tari_comms = { path = "../../comms"}
-tari_crypto = { git = "https://github.com/tari-project/tari-crypto/", branch = "main" }
+tari_crypto = { git = "ssh://git@github.com/tari-project/tari-crypto.git", branch = "main" }
 tari_common = { path = "../../common" }
 tari_p2p = { path = "../../base_layer/p2p" }
 tari_wallet = { path = "../../base_layer/wallet" }

--- a/applications/tari_base_node/Cargo.toml
+++ b/applications/tari_base_node/Cargo.toml
@@ -14,7 +14,7 @@ tari_common = { path = "../../common" }
 tari_comms = { path = "../../comms", features = ["rpc"]}
 tari_comms_dht = { path = "../../comms/dht"}
 tari_core = { path = "../../base_layer/core", default-features = false, features = ["transactions"]}
-tari_crypto = { git = "https://github.com/tari-project/tari-crypto/", branch = "main" }
+tari_crypto = { git = "ssh://git@github.com/tari-project/tari-crypto.git", branch = "main" }
 tari_mmr = { path = "../../base_layer/mmr" }
 tari_p2p = { path = "../../base_layer/p2p" }
 tari_service_framework = {  path = "../../base_layer/service_framework"}

--- a/applications/tari_base_node/src/command_handler.rs
+++ b/applications/tari_base_node/src/command_handler.rs
@@ -55,10 +55,9 @@ use tari_core::{
     tari_utilities::{hex::Hex, message_format::MessageFormat},
     transactions::types::{Commitment, HashOutput, Signature},
 };
-use tari_crypto::ristretto::RistrettoPublicKey;
+use tari_crypto::{ristretto::RistrettoPublicKey, tari_utilities::Hashable};
 use tari_wallet::util::emoji::EmojiId;
 use tokio::{runtime, sync::watch};
-use tari_crypto::tari_utilities::Hashable;
 
 pub struct CommandHandler {
     executor: runtime::Handle,

--- a/applications/tari_console_wallet/Cargo.toml
+++ b/applications/tari_console_wallet/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 
 [dependencies]
 tari_wallet = {  path = "../../base_layer/wallet" }
-tari_crypto = { git = "https://github.com/tari-project/tari-crypto/", branch = "main" }
+tari_crypto = { git = "ssh://git@github.com/tari-project/tari-crypto.git", branch = "main" }
 tari_common = {  path = "../../common" }
 tari_app_utilities = { path = "../tari_app_utilities"}
 tari_comms = {  path = "../../comms"}

--- a/applications/tari_merge_mining_proxy/Cargo.toml
+++ b/applications/tari_merge_mining_proxy/Cargo.toml
@@ -16,7 +16,7 @@ tari_app_grpc = { path = "../tari_app_grpc" }
 tari_common = {  path = "../../common" }
 tari_core = {  path = "../../base_layer/core", default-features = false, features = ["transactions"]}
 tari_app_utilities = {  path = "../tari_app_utilities"}
-tari_crypto = { git = "https://github.com/tari-project/tari-crypto/", branch = "main" }
+tari_crypto = { git = "ssh://git@github.com/tari-project/tari-crypto.git", branch = "main" }
 tari_utilities = "^0.3"
 
 anyhow = "1.0.40"

--- a/applications/tari_mining_node/Cargo.toml
+++ b/applications/tari_mining_node/Cargo.toml
@@ -27,6 +27,6 @@ thiserror = "1.0"
 
 
 [dev-dependencies]
-tari_crypto = { git = "https://github.com/tari-project/tari-crypto/", branch = "main" }
+tari_crypto = { git = "ssh://git@github.com/tari-project/tari-crypto.git", branch = "main" }
 prost-types = "0.6.1"
 chrono = "0.4"

--- a/applications/test_faucet/Cargo.toml
+++ b/applications/test_faucet/Cargo.toml
@@ -11,7 +11,7 @@ tari_utilities = "^0.3"
 serde = { version = "1.0.97", features = ["derive"] }
 serde_json = "1.0"
 rand = "0.7.2"
-tari_crypto = { git = "https://github.com/tari-project/tari-crypto/", branch = "main" }
+tari_crypto = { git = "ssh://git@github.com/tari-project/tari-crypto.git", branch = "main" }
 
 [dependencies.tari_core]
 version = "^0.8"

--- a/base_layer/common_types/Cargo.toml
+++ b/base_layer/common_types/Cargo.toml
@@ -9,6 +9,6 @@ edition = "2018"
 [dependencies]
 futures = {version = "^0.3.1", features = ["async-await"] }
 rand = "0.7.2"
-tari_crypto = { git = "https://github.com/tari-project/tari-crypto/", branch = "main" }
+tari_crypto = { git = "ssh://git@github.com/tari-project/tari-crypto.git", branch = "main" }
 serde = { version = "1.0.106", features = ["derive"] }
 tokio = { version="^0.2", features = ["blocking", "time", "sync"] }

--- a/base_layer/core/Cargo.toml
+++ b/base_layer/core/Cargo.toml
@@ -23,7 +23,7 @@ tari_common_types = { version = "^0.8", path = "../../base_layer/common_types"}
 tari_comms = { version = "^0.8", path = "../../comms"}
 tari_comms_dht = { version = "^0.8", path = "../../comms/dht"}
 tari_comms_rpc_macros = { version = "^0.8", path = "../../comms/rpc_macros"}
-tari_crypto = { git = "https://github.com/tari-project/tari-crypto/", branch = "main" }
+tari_crypto = { git = "ssh://git@github.com/tari-project/tari-crypto.git", branch = "main" }
 tari_mmr = { version = "^0.8", path = "../../base_layer/mmr", optional = true }
 tari_p2p = { version = "^0.8", path = "../../base_layer/p2p" }
 tari_service_framework = { version = "^0.8", path = "../service_framework"}

--- a/base_layer/key_manager/Cargo.toml
+++ b/base_layer/key_manager/Cargo.toml
@@ -8,7 +8,7 @@ version = "0.8.9"
 edition = "2018"
 
 [dependencies]
-tari_crypto = { git = "https://github.com/tari-project/tari-crypto/", branch = "main" }
+tari_crypto = { git = "ssh://git@github.com/tari-project/tari-crypto.git", branch = "main" }
 rand = "0.7.2"
 digest = "0.8.0"
 sha2 = "0.8.0"

--- a/base_layer/mmr/Cargo.toml
+++ b/base_layer/mmr/Cargo.toml
@@ -25,7 +25,7 @@ criterion = { version="0.2", optional = true }
 rand="0.7.0"
 blake2 = "0.8.0"
 tari_infra_derive= { path = "../../infrastructure/derive", version = "^0.8" }
-tari_crypto = { git = "https://github.com/tari-project/tari-crypto/", branch = "main" }
+tari_crypto = { git = "ssh://git@github.com/tari-project/tari-crypto.git", branch = "main" }
 serde_json = "1.0"
 bincode = "1.1"
 [lib]

--- a/base_layer/p2p/Cargo.toml
+++ b/base_layer/p2p/Cargo.toml
@@ -13,7 +13,7 @@ edition = "2018"
 tari_comms = { version = "^0.8", path = "../../comms"}
 tari_comms_dht = { version = "^0.8", path = "../../comms/dht"}
 tari_common = { version= "^0.8", path = "../../common" }
-tari_crypto = { git = "https://github.com/tari-project/tari-crypto/", branch = "main" }
+tari_crypto = { git = "ssh://git@github.com/tari-project/tari-crypto.git", branch = "main" }
 tari_service_framework = { version = "^0.8", path = "../service_framework"}
 tari_shutdown = { version = "^0.8", path="../../infrastructure/shutdown" }
 tari_storage = { version = "^0.8", path = "../../infrastructure/storage"}

--- a/base_layer/wallet/Cargo.toml
+++ b/base_layer/wallet/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2018"
 tari_common_types = { version = "^0.8", path = "../../base_layer/common_types"}
 tari_comms = { version = "^0.8", path = "../../comms"}
 tari_comms_dht = { version = "^0.8", path = "../../comms/dht" }
-tari_crypto = { git = "https://github.com/tari-project/tari-crypto/", branch = "main" }
+tari_crypto = { git = "ssh://git@github.com/tari-project/tari-crypto.git", branch = "main" }
 tari_key_manager = { version = "^0.8", path = "../key_manager" }
 tari_p2p = { version = "^0.8", path = "../p2p" }
 tari_service_framework = { version = "^0.8", path = "../service_framework"}

--- a/base_layer/wallet_ffi/Cargo.toml
+++ b/base_layer/wallet_ffi/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2018"
 [dependencies]
 tari_comms = { version = "^0.8", path = "../../comms" }
 tari_comms_dht = { version = "^0.8", path = "../../comms/dht" }
-tari_crypto = { git = "https://github.com/tari-project/tari-crypto/", branch = "main" }
+tari_crypto = { git = "ssh://git@github.com/tari-project/tari-crypto.git", branch = "main" }
 tari_key_manager = { version = "^0.8", path = "../key_manager" }
 tari_p2p = { version = "^0.8", path = "../p2p" }
 tari_wallet = { version = "^0.8", path = "../wallet", features = ["test_harness", "c_integration"]}

--- a/base_layer/wallet_ffi/src/lib.rs
+++ b/base_layer/wallet_ffi/src/lib.rs
@@ -167,10 +167,7 @@ use tari_wallet::{
     storage::{
         database::WalletDatabase,
         sqlite_db::WalletSqliteDatabase,
-        sqlite_utilities::{
-            initialize_sqlite_database_backends,
-            partial_wallet_backup,
-        },
+        sqlite_utilities::{initialize_sqlite_database_backends, partial_wallet_backup},
     },
     testnet_utils::{
         broadcast_transaction,

--- a/comms/Cargo.toml
+++ b/comms/Cargo.toml
@@ -10,7 +10,7 @@ version = "0.8.9"
 edition = "2018"
 
 [dependencies]
-tari_crypto = { git = "https://github.com/tari-project/tari-crypto/", branch = "main" }
+tari_crypto = { git = "ssh://git@github.com/tari-project/tari-crypto.git", branch = "main" }
 tari_storage = { version = "^0.8", path = "../infrastructure/storage" }
 tari_shutdown = { version="^0.8",  path = "../infrastructure/shutdown" }
 

--- a/comms/dht/Cargo.toml
+++ b/comms/dht/Cargo.toml
@@ -13,7 +13,7 @@ edition = "2018"
 tari_common = { version = "^0.8", path = "../../common"}
 tari_comms  = { version = "^0.8", path = "../", features = ["rpc"]}
 tari_comms_rpc_macros  = { version = "^0.8", path = "../rpc_macros"}
-tari_crypto = { git = "https://github.com/tari-project/tari-crypto/", branch = "main" }
+tari_crypto = { git = "ssh://git@github.com/tari-project/tari-crypto.git", branch = "main" }
 tari_utilities  = { version = "^0.3" }
 tari_shutdown = { version = "^0.8", path = "../../infrastructure/shutdown"}
 tari_storage  = { version = "^0.8", path = "../../infrastructure/storage"}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
For whatever reason circle ci was failing to checkout the tari-crypto git repo, switching these urls to use the `ssh://` version is working

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
we should migrate to github actions (also a new release of Tari crypto to crates.io would help)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
bashing my head into circle ci

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `tari-script` branch.
* [x] I have squashed my commits into a single commit.
