### PR TITLE
[MMProxy] Connection Limiting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,7 +36,9 @@ report
 base_layer/wallet_ffi/build.config
 /base_layer/wallet_ffi/logs/
 base_layer/wallet_ffi/.cargo/config
-
+/config
+/stibbons
+/wallet
 keys.json
 node_modules
 /integration_tests/temp

--- a/applications/tari_merge_mining_proxy/src/error.rs
+++ b/applications/tari_merge_mining_proxy/src/error.rs
@@ -38,6 +38,8 @@ pub enum MmProxyError {
         #[from]
         source: MergeMineError,
     },
+    #[error("Reqwest error: {0}")]
+    ReqwestError(#[from] reqwest::Error),
     #[error("Missing data:{0}")]
     MissingDataError(String),
     #[error("An IO error occurred: {0}")]

--- a/applications/tari_merge_mining_proxy/src/main.rs
+++ b/applications/tari_merge_mining_proxy/src/main.rs
@@ -40,9 +40,11 @@ use crate::{block_template_data::BlockTemplateRepository, error::MmProxyError};
 use futures::future;
 use hyper::{service::make_service_fn, Server};
 use proxy::{MergeMiningProxyConfig, MergeMiningProxyService};
-use std::{convert::Infallible, io};
+use std::convert::Infallible;
 use structopt::StructOpt;
+use tari_app_grpc::tari_rpc as grpc;
 use tari_common::{configuration::bootstrap::ApplicationType, ConfigBootstrap, GlobalConfig};
+use tokio::time::Duration;
 
 #[tokio_macros::main]
 async fn main() -> Result<(), MmProxyError> {
@@ -50,14 +52,23 @@ async fn main() -> Result<(), MmProxyError> {
 
     let config = MergeMiningProxyConfig::from(config);
     let addr = config.proxy_host_address;
-
-    let xmrig_service = MergeMiningProxyService::new(config, BlockTemplateRepository::new());
-    if !xmrig_service.check_connections(&mut io::stdout()).await {
-        println!(
-            "Warning: some services have not been started or are mis-configured in the proxy config. The proxy will \
-             remain running and connect to these services on demand."
-        );
-    }
+    let client = reqwest::Client::builder()
+        .connect_timeout(Duration::from_secs(5))
+        .timeout(Duration::from_secs(10))
+        .pool_max_idle_per_host(25)
+        .build()
+        .map_err(MmProxyError::ReqwestError)?;
+    let base_node_client =
+        grpc::base_node_client::BaseNodeClient::connect(format!("http://{}", config.grpc_base_node_address)).await?;
+    let wallet_client =
+        grpc::wallet_client::WalletClient::connect(format!("http://{}", config.grpc_console_wallet_address)).await?;
+    let xmrig_service = MergeMiningProxyService::new(
+        config,
+        client,
+        base_node_client,
+        wallet_client,
+        BlockTemplateRepository::new(),
+    );
     let service = make_service_fn(|_conn| future::ready(Result::<_, Infallible>::Ok(xmrig_service.clone())));
 
     match Server::try_bind(&addr) {

--- a/applications/tari_merge_mining_proxy/src/test.rs
+++ b/applications/tari_merge_mining_proxy/src/test.rs
@@ -20,58 +20,6 @@
 //  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 //  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use crate::{common::proxy, proxy::MergeMiningProxyConfig};
-use hyper::Body;
-use tari_common::Network;
-
-fn default_test_config() -> MergeMiningProxyConfig {
-    MergeMiningProxyConfig {
-        network: Network::Rincewind,
-        monerod_url: "".to_string(),
-        monerod_username: "".to_string(),
-        monerod_password: "".to_string(),
-        monerod_use_auth: false,
-        grpc_base_node_address: "127.0.0.1:9999".parse().unwrap(),
-        grpc_console_wallet_address: "127.0.0.1:9998".parse().unwrap(),
-        proxy_host_address: "127.0.0.1:9997".parse().unwrap(),
-        proxy_submit_to_origin: false,
-        wait_for_initial_sync_at_startup: true,
-    }
-}
-
-async fn read_body_as_json(body: &mut Body) -> serde_json::Value {
-    serde_json::from_slice(&proxy::read_body_until_end(body).await.unwrap()).unwrap()
-}
-
-mod merge_mining_proxy_service {
-    use super::*;
-    use crate::{block_template_data::BlockTemplateRepository, proxy::MergeMiningProxyService};
-    use futures::task::Poll;
-    use futures_test::task::noop_context;
-    use hyper::{service::Service, Body, Request};
-
-    #[test]
-    fn it_is_always_ready() {
-        let mut service = MergeMiningProxyService::new(default_test_config(), BlockTemplateRepository::new());
-        let mut cx = noop_context();
-        let poll = service.poll_ready(&mut cx);
-        match poll {
-            Poll::Ready(v) => v.unwrap(),
-            Poll::Pending => panic!("not ready"),
-        }
-    }
-
-    #[tokio_macros::test]
-    async fn it_returns_an_error_response_empty_request() {
-        let mut service = MergeMiningProxyService::new(default_test_config(), BlockTemplateRepository::new());
-        let req = Request::new(Body::empty());
-        let mut resp = service.call(req).await.unwrap();
-        assert_eq!(resp.status().is_success(), false);
-        let json = read_body_as_json(resp.body_mut()).await;
-        assert_eq!(json["error"]["message"], "Internal error");
-    }
-}
-
 mod add_aux_data {
     use crate::{
         common::json_rpc,

--- a/integration_tests/features/support/world.js
+++ b/integration_tests/features/support/world.js
@@ -184,8 +184,13 @@ setWorldConstructor(CustomWorld);
 BeforeAll({ timeout: 1200000 }, async function () {
   const baseNode = new BaseNodeProcess("compile");
   console.log("Compiling base node...");
-  await baseNode.startNew();
-  await baseNode.stop();
+  await baseNode.init();
+  await baseNode.compile();
+
+  const wallet = new WalletProcess("compile");
+  console.log("Compiling wallet...");
+  await wallet.init();
+  await wallet.compile();
 
   const mmProxy = new MergeMiningProxyProcess(
     "compile",
@@ -193,13 +198,8 @@ BeforeAll({ timeout: 1200000 }, async function () {
     "127.0.0.1:9998"
   );
   console.log("Compiling mmproxy...");
-  await mmProxy.startNew();
-  await mmProxy.stop();
-
-  const wallet = new WalletProcess("compile");
-  console.log("Compiling wallet...");
-  await wallet.startNew();
-  await wallet.stop();
+  await mmProxy.init();
+  await mmProxy.compile();
 
   const miningNode = new MiningNodeProcess(
     "compile",


### PR DESCRIPTION
## Description
Limit number of idle connections for reqwest::Client
Used cheap clones of original connections for grpc based connections.

## Motivation and Context
Appears to solve "too many open files" problem

## How Has This Been Tested?
Tested with multiple xmrig clients mining against the merge mining proxy over a few hours. Current `ulimit -n` value is 2560. 

## Checklist:
* [x] I'm merging against the `development` branch.
* [x] I have squashed my commits into a single commit.
