### PR TITLE
Fix ChainStorageError after a reorg with new block

### DIFF
--- a/base_layer/core/src/chain_storage/async_db.rs
+++ b/base_layer/core/src/chain_storage/async_db.rs
@@ -150,9 +150,9 @@ impl<B: BlockchainBackend + 'static> AsyncBlockchainDb<B> {
     make_async_fn!(fetch_kernels_by_mmr_position(start: u64, end: u64) -> Vec<TransactionKernel>, "fetch_kernels_by_mmr_position");
 
     //---------------------------------- MMR --------------------------------------------//
-    make_async_fn!(prepare_block_merkle_roots(template: NewBlockTemplate) -> Block, "create_block");
+    make_async_fn!(prepare_block_merkle_roots(template: NewBlockTemplate) -> Block, "prepare_block_merkle_roots");
 
-    make_async_fn!(fetch_mmr_size(tree: MmrTree) -> u64, "fetch_mmr_node_count");
+    make_async_fn!(fetch_mmr_size(tree: MmrTree) -> u64, "fetch_mmr_size");
 
     make_async_fn!(rewind_to_height(height: u64) -> Vec<Arc<ChainBlock>>, "rewind_to_height");
 

--- a/base_layer/wallet/tests/support/rpc.rs
+++ b/base_layer/wallet/tests/support/rpc.rs
@@ -245,15 +245,20 @@ impl BaseNodeWalletRpcMockState {
         timeout: Duration,
     ) -> Result<Vec<Transaction>, String> {
         let now = Instant::now();
+        let mut count = 0usize;
         while now.elapsed() < timeout {
             let mut lock = acquire_lock!(self.submit_transaction_calls);
+            count = (*lock).len();
             if (*lock).len() >= num_calls {
                 return Ok((*lock).drain(..num_calls).collect());
             }
             drop(lock);
             delay_for(Duration::from_millis(100)).await;
         }
-        Err("Did not receive enough calls within the timeout period".to_string())
+        Err(format!(
+            "Did not receive enough calls within the timeout period, received {}, expected {}.",
+            count, num_calls
+        ))
     }
 
     pub async fn wait_pop_fetch_utxos_calls(

--- a/integration_tests/features/Mempool.feature
+++ b/integration_tests/features/Mempool.feature
@@ -1,7 +1,6 @@
 @mempool
 Feature: Mempool
 
- 
   Scenario: Transactions are propagated through a network
     Given I have 10 seed nodes
     And I have a base node SENDER connected to all seed nodes
@@ -74,3 +73,61 @@ Feature: Mempool
     When I mine 1 blocks on SENDER
     Then SENDER has TX1 in NOT_STORED state
     Then SENDER has TX2 in MINED state
+
+  @critical
+  Scenario: Mempool clearing out invalid transactions after a reorg
+        #
+        # Chain 1:
+        #   Collects 7 coinbases into one wallet, send 7 transactions
+        #   Stronger chain
+        #
+    Given I have a seed node SEED_A
+    And I have a base node NODE_A1 connected to seed SEED_A
+    And I have wallet WALLET_A1 connected to seed node SEED_A
+    And I have wallet WALLET_A2 connected to seed node SEED_A
+    And I have mining node MINER_A1 connected to base node SEED_A and wallet WALLET_A1
+    When I wait 5 seconds
+    When mining node MINER_A1 mines 7 blocks with min difficulty 200 and max difficulty 100000
+    Then node SEED_A is at height 7
+    Then node NODE_A1 is at height 7
+    When I mine 3 blocks on SEED_A
+    Then wallet WALLET_A1 detects at least 7 coinbase transactions as Mined_Confirmed
+    Then node SEED_A is at height 10
+    Then node NODE_A1 is at height 10
+    And I multi-send 7 transactions of 1000000 uT from wallet WALLET_A1 to wallet WALLET_A2 at fee 100
+    Then wallet WALLET_A1 detects all transactions are at least Broadcast
+    When I wait 1 seconds
+        #
+        # Chain 2:
+        #   Collects 7 coinbases into one wallet, send 7 transactions
+        #   Weaker chain
+        #
+    And I have a seed node SEED_B
+    And I have a base node NODE_B1 connected to seed SEED_B
+    And I have wallet WALLET_B1 connected to seed node SEED_B
+    And I have wallet WALLET_B2 connected to seed node SEED_B
+    And I have mining node MINER_B1 connected to base node SEED_B and wallet WALLET_B1
+    When I wait 5 seconds
+    When mining node MINER_B1 mines 7 blocks with min difficulty 1 and max difficulty 100
+    Then node SEED_B is at height 7
+    Then node NODE_B1 is at height 7
+    When I mine 5 blocks on SEED_B
+    Then wallet WALLET_B1 detects at least 7 coinbase transactions as Mined_Confirmed
+    Then node SEED_B is at height 12
+    Then node NODE_B1 is at height 12
+    And I multi-send 7 transactions of 1000000 uT from wallet WALLET_B1 to wallet WALLET_B2 at fee 100
+    Then wallet WALLET_B1 detects all transactions are at least Broadcast
+    When I wait 1 seconds
+        #
+        # Connect Chain 1 and 2 in stages
+        #    New node connects to weaker chain, receives all broadcast (not mined) transactions into mempool
+        #    New node connects to stronger chain, then reorgs its complete chain
+        #    New node mines blocks; no invalid inputs from the weaker chain should be used in the block template
+        #
+    And I have a base node NODE_C connected to seed SEED_B
+    Then node NODE_C is at height 12
+        # Wait for the reorg to filter through
+    And I connect node SEED_A to node NODE_C and wait 30 seconds
+    Then all nodes are at height 10
+    When I mine 6 blocks on NODE_C
+    Then all nodes are at height 16

--- a/integration_tests/features/WalletMonitoring.feature
+++ b/integration_tests/features/WalletMonitoring.feature
@@ -21,6 +21,7 @@ Scenario: Wallets monitoring coinbase after a reorg
         # Use 7 of the 10 coinbase UTXOs in transactions (others require 3 confirmations)
     And I multi-send 7 transactions of 1000000 uT from wallet WALLET_A1 to wallet WALLET_A2 at fee 100
     Then wallet WALLET_A1 detects all transactions are at least Broadcast
+    When I wait 1 seconds
         #
         # Chain 2:
         #   Collects 10 coinbases into one wallet, send 7 transactions
@@ -39,11 +40,10 @@ Scenario: Wallets monitoring coinbase after a reorg
         # Use 7 of the 10 coinbase UTXOs in transactions (others require 3 confirmations)
     And I multi-send 7 transactions of 1000000 uT from wallet WALLET_B1 to wallet WALLET_B2 at fee 100
     Then wallet WALLET_B1 detects all transactions are at least Broadcast
+    When I wait 1 seconds
         #
         # Connect Chain 1 and 2
         #
-        # TODO: This wait is needed to stop next base node task from continuing
-    When I wait 1 seconds
     And I have a SHA3 miner NODE_C connected to all seed nodes
         # Wait for the reorg to filter through
     When I wait 30 seconds

--- a/integration_tests/features/WalletRecovery.feature
+++ b/integration_tests/features/WalletRecovery.feature
@@ -1,7 +1,7 @@
 @wallet-recovery
 Feature: Wallet Recovery
 
-@critical @broken
+@critical
 Scenario: Wallet recovery with connected base node staying online
     Given I have a seed node NODE
     And I have 1 base nodes connected to all seed nodes

--- a/integration_tests/features/support/steps.js
+++ b/integration_tests/features/support/steps.js
@@ -544,7 +544,13 @@ Then(
   async function (name, height) {
     const client = this.getClient(name);
     await waitFor(async () => client.getTipHeight(), height, 115 * 1000);
-    expect(await client.getTipHeight()).to.equal(height);
+    const currentHeight = await client.getTipHeight();
+    console.log(
+      `Node ${name} is at tip: ${currentHeight} (should be`,
+      height,
+      `)`
+    );
+    expect(currentHeight).to.equal(height);
   }
 );
 

--- a/integration_tests/helpers/transactionBuilder.js
+++ b/integration_tests/helpers/transactionBuilder.js
@@ -125,9 +125,10 @@ class TransactionBuilder {
     let scriptOffsetPublicKey = tari_crypto.pubkey_from_secret(
       scriptOffsetPrivateKey.toString("hex")
     );
+    let nop_script_bytes = Buffer.from([0x73]);
 
     let beta = calculateBeta(
-      nopScriptHash,
+      nop_script_bytes,
       outputFeatures,
       scriptOffsetPublicKey
     );
@@ -140,7 +141,6 @@ class TransactionBuilder {
       new_range_proof_key,
       BigInt(amount)
     ).proof;
-    let nop_script_bytes = Buffer.from([0x73]);
 
     let output = {
       amount: amount,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Fix ChainStorageError after a reorg with new block

- Fixed a ChainStorageError that occurs due to invalid transactions remaining in the mempool when the 1st block is requested for mining via GRPC directly after a chain reorg.
- Added a failing cucumber test for the above condition (fixed now): `Mempool clearing out invalid transactions after a reorg`.
- Minor cucumber improvements.
- ~~Fixed flaky test `tx_broadcast_protocol_submit_success`~~

## Motivation and Context
See above

## How Has This Been Tested?
Cucumber test `Mempool clearing out invalid transactions after a reorg`

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [X] I'm merging against the `tari-script` branch.
* [X] I have squashed my commits into a single commit.
