### PR TITLE
Improve error messages in tari applications

### DIFF
--- a/applications/tari_app_utilities/src/utilities.rs
+++ b/applications/tari_app_utilities/src/utilities.rs
@@ -52,15 +52,15 @@ pub const LOG_TARGET: &str = "tari::application";
 pub enum ExitCodes {
     #[error("There is an error in the wallet configuration: {0}")]
     ConfigError(String),
-    #[error("The wallet exited because an unknown error occurred. Check the logs for details.")]
+    #[error("The application exited because an unknown error occurred. Check the logs for details.")]
     UnknownError,
-    #[error("The wallet exited because an interface error occurred. Check the logs for details.")]
+    #[error("The application exited because an interface error occurred. Check the logs for details.")]
     InterfaceError,
-    #[error("The wallet exited. {0}")]
+    #[error("The application exited. {0}")]
     WalletError(String),
     #[error("The wallet was not able to start the GRPC server. {0}")]
     GrpcError(String),
-    #[error("The wallet did not accept the command input: {0}")]
+    #[error("The application did not accept the command input: {0}")]
     InputError(String),
     #[error("Invalid command: {0}")]
     CommandError(String),
@@ -74,8 +74,10 @@ pub enum ExitCodes {
     ConversionError(String),
     #[error("Your password was incorrect.")]
     IncorrectPassword,
-    #[error("Your wallet is encrypted but no password was provided.")]
+    #[error("Your application is encrypted but no password was provided.")]
     NoPassword,
+    #[error("Tor connection is offline")]
+    TorOffline,
 }
 
 impl ExitCodes {
@@ -93,6 +95,7 @@ impl ExitCodes {
             Self::NetworkError(_) => 110,
             Self::ConversionError(_) => 111,
             Self::IncorrectPassword | Self::NoPassword => 112,
+            Self::TorOffline => 113,
         }
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR updates some of the error messages in tari utilities to not display wallet. 
It also prints out a pretty error message when the base_node cannot connect to a base_node

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This piece of code is shared between all tari applications and the error messages here should not display wallet, base_node, etc. 
All of the application-specific names were changed to application, except for wallet_error which should only originate inside of a wallet. 

For example currently the base_node displays: `The wallet exited because an unknown error occurred. Check the logs for details.` if tor is not corrected. 
After this PR it should display:
`The application exited because an unknown error occurred. Check the logs for details. if tor is not corrected.`

The base_node should not print out a generic error  when it cannot connect to a tor port. This creates a pretty error to print out that it cant connect to tor as well as give a potential fix for it.

After this PR the base_node now prints out:
```Unable to connect to the Tor control port.
Please check that you have the Tor proxy running and that access to the Tor control port is turned on.
If you are unsure of what to do, use the following command to start the Tor proxy:
tor --allow-missing-torrc --ignore-missing-torrc --clientonly 1 --socksport 9050 --controlport 127.0.0.1:9051 --log "notice stdout" --clientuseipv6 1
Tor connection is offline
```

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Run to ensure that the error message prints out compelelty. 

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [ ] I'm merging against the `development` branch.
* [x] I have squashed my commits into a single commit.
