### PR TITLE
Fix pruning in pruning mode

### DIFF
--- a/base_layer/core/src/base_node/sync/header_sync/synchronizer.rs
+++ b/base_layer/core/src/base_node/sync/header_sync/synchronizer.rs
@@ -406,9 +406,10 @@ impl<'a, B: BlockchainBackend + 'static> HeaderSynchronizer<'a, B> {
         for header in headers {
             debug!(
                 target: LOG_TARGET,
-                "Validating header #{} (Pow: {})",
+                "Validating header #{} (Pow: {}) with hash: ({})",
                 header.height,
                 header.pow_algo(),
+                header.hash().to_hex(),
             );
             self.header_validator.validate(header)?;
         }
@@ -510,9 +511,10 @@ impl<'a, B: BlockchainBackend + 'static> HeaderSynchronizer<'a, B> {
             let header = BlockHeader::try_from(header?).map_err(BlockHeaderSyncError::ReceivedInvalidHeader)?;
             debug!(
                 target: LOG_TARGET,
-                "Validating header: #{} (PoW = {})",
+                "Validating header #{} (Pow: {}) with hash: ({})",
                 header.height,
-                header.pow_algo()
+                header.pow_algo(),
+                header.hash().to_hex(),
             );
             let existing_header = self.db.fetch_header_by_block_hash(header.hash()).await?;
             // TODO: Due to a bug in a previous version of base node sync RPC, the duplicate headers can be sent. We

--- a/base_layer/core/src/chain_storage/lmdb_db/lmdb_db.rs
+++ b/base_layer/core/src/chain_storage/lmdb_db/lmdb_db.rs
@@ -971,9 +971,12 @@ impl LMDBDatabase {
         horizon: u64,
     ) -> Result<(), ChainStorageError> {
         for pos in output_positions {
-            let (_height, hash) =
-                lmdb_first_after::<_, (u64, Vec<u8>)>(&write_txn, &self.output_mmr_size_index, &pos.to_be_bytes())
-                    .or_not_found("BlockHeader", "mmr_position", pos.to_string())?;
+            let (_height, hash) = lmdb_first_after::<_, (u64, Vec<u8>)>(
+                &write_txn,
+                &self.output_mmr_size_index,
+                &(pos as u64).to_be_bytes(),
+            )
+            .or_not_found("BlockHeader", "mmr_position", pos.to_string())?;
             let key = format!("{}-{:010}", hash.to_hex(), pos);
             debug!(target: LOG_TARGET, "Pruning output: {}", key);
             self.prune_output(&write_txn, &key)?;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
When running a prune mode, the node would display this error in the logs:
`Failed to apply DB transaction: The requested BlockHeader was not found via mmr_position`

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
We need prune nodes to be made to prune spent UTXOs. We save the MMR position as a BigEndian u64, but when we load them, we ask for them by BigEndian u32. These are not equal. The u64 should be converted to u64 before being read.  

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Run the node and let it prune on stibbons dev. 

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [ ] I'm merging against the `development` branch.
* [x] I have squashed my commits into a single commit.
