### PR TITLE
Fix prune mode sync

### DIFF
--- a/base_layer/core/src/chain_storage/lmdb_db/lmdb_db.rs
+++ b/base_layer/core/src/chain_storage/lmdb_db/lmdb_db.rs
@@ -375,7 +375,7 @@ impl LMDBDatabase {
         mmr_position: u32,
     ) -> Result<(), ChainStorageError>
     {
-        if !lmdb_exists(txn, &self.headers_db, header_hash.as_slice())? {
+        if !lmdb_exists(txn, &self.block_hashes_db, header_hash.as_slice())? {
             return Err(ChainStorageError::InvalidOperation(format!(
                 "Unable to insert pruned output because header {} does not exist",
                 header_hash.to_hex()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Fix the database audit check to search in the correct db, it should search in the `block_hashes_db` when added a output, and not the `headers_db`

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Currently, the prune mode sync does not work at all due to a wrong database audit check. When inserting a pruned output a check is don't if the header the utxo was downloaded from exists in the DB. This check checks the wrong database. There is no `headers_db` with a hash key, only a `block_hashes_db` which returns the height, which is then used to query `headers_db`. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
This code synced on stibbons with prune mode enabled

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch.
* [x] I have squashed my commits into a single commit.
