### PR TITLE
Include orphans in target difficulty calculation

### DIFF
--- a/applications/tari_base_node/src/builder.rs
+++ b/applications/tari_base_node/src/builder.rs
@@ -42,6 +42,7 @@ use tari_core::{
             TxInputAndMaturityValidator,
             TxInternalConsistencyValidator,
         },
+        DifficultyCalculator,
     },
 };
 use tari_service_framework::ServiceHandles;
@@ -199,7 +200,7 @@ async fn build_node_context(
     let randomx_factory = RandomXFactory::new(RandomXConfig::default(), config.max_randomx_vms);
     let validators = Validators::new(
         BodyOnlyValidator::default(),
-        HeaderValidator::new(rules.clone(), randomx_factory),
+        HeaderValidator::new(rules.clone()),
         OrphanBlockValidator::new(rules.clone(), factories.clone()),
     );
     let db_config = BlockchainDatabaseConfig {
@@ -207,7 +208,14 @@ async fn build_node_context(
         pruning_horizon: config.pruning_horizon,
         pruning_interval: config.pruned_mode_cleanup_interval,
     };
-    let blockchain_db = BlockchainDatabase::new(backend, &rules, validators, db_config, cleanup_orphans_at_startup)?;
+    let blockchain_db = BlockchainDatabase::new(
+        backend,
+        rules.clone(),
+        validators,
+        db_config,
+        DifficultyCalculator::new(rules.clone(), randomx_factory),
+        cleanup_orphans_at_startup,
+    )?;
     let mempool_validator = MempoolValidator::new(vec![
         Box::new(TxInternalConsistencyValidator::new(factories.clone())),
         Box::new(TxInputAndMaturityValidator::new(blockchain_db.clone())),

--- a/applications/tari_base_node/src/command_handler.rs
+++ b/applications/tari_base_node/src/command_handler.rs
@@ -951,7 +951,10 @@ impl CommandHandler {
                     continue;
                 }
 
-                let target_diff = try_or_print!(db.fetch_target_difficulties(prev_header.hash().clone()).await);
+                let target_diff = try_or_print!(
+                    db.fetch_target_difficulties_for_next_block(prev_header.hash().clone())
+                        .await
+                );
                 let pow_algo = header.header().pow_algo();
 
                 let min = consensus_rules.consensus_constants(height).min_pow_difficulty(pow_algo);

--- a/base_layer/core/src/base_node/comms_interface/inbound_handlers.rs
+++ b/base_layer/core/src/base_node/comms_interface/inbound_handlers.rs
@@ -34,7 +34,7 @@ use crate::{
     consensus::{ConsensusConstants, ConsensusManager},
     mempool::{async_mempool, Mempool},
     proof_of_work::{Difficulty, PowAlgorithm},
-    transactions::transaction::TransactionKernel,
+    transactions::{transaction::TransactionKernel, types::HashOutput},
 };
 use log::*;
 use std::{
@@ -364,11 +364,13 @@ where T: BlockchainBackend + 'static
                     .map(|tx| Arc::try_unwrap(tx).unwrap_or_else(|tx| (*tx).clone()))
                     .collect();
 
+                let prev_hash = header.prev_hash.clone();
                 let height = header.height;
 
                 let block_template = NewBlockTemplate::from_block(
                     header.into_builder().with_transactions(transactions).build(),
-                    self.get_target_difficulty(request.algo, constants, height).await?,
+                    self.get_target_difficulty_for_next_block(request.algo, constants, prev_hash)
+                        .await?,
                     self.consensus_manager.get_block_reward_at(height),
                 );
                 debug!(
@@ -535,20 +537,17 @@ where T: BlockchainBackend + 'static
         }
     }
 
-    async fn get_target_difficulty(
+    async fn get_target_difficulty_for_next_block(
         &self,
         pow_algo: PowAlgorithm,
         constants: &ConsensusConstants,
-        height: u64,
+        current_block_hash: HashOutput,
     ) -> Result<Difficulty, CommsInterfaceError>
     {
-        trace!(
-            target: LOG_TARGET,
-            "Calculating target difficulty at height: {} for PoW: {}",
-            height,
-            pow_algo
-        );
-        let target_difficulty = self.blockchain_db.fetch_target_difficulty(pow_algo, height).await?;
+        let target_difficulty = self
+            .blockchain_db
+            .fetch_target_difficulty_for_next_block(pow_algo, current_block_hash)
+            .await?;
 
         let target = target_difficulty.calculate(
             constants.min_pow_difficulty(pow_algo),

--- a/base_layer/core/src/base_node/sync/header_sync/validator.rs
+++ b/base_layer/core/src/base_node/sync/header_sync/validator.rs
@@ -83,7 +83,10 @@ impl<B: BlockchainBackend + 'static> BlockHeaderSyncValidator<B> {
             .await?
             .ok_or_else(|| BlockHeaderSyncError::StartHashNotFound(start_hash.to_hex()))?;
         let timestamps = self.db.fetch_block_timestamps(start_hash.clone()).await?;
-        let target_difficulties = self.db.fetch_target_difficulties(start_hash.clone()).await?;
+        let target_difficulties = self
+            .db
+            .fetch_target_difficulties_for_next_block(start_hash.clone())
+            .await?;
         let previous_accum = self
             .db
             .fetch_header_accumulated_data(start_hash.clone())

--- a/base_layer/core/src/chain_storage/async_db.rs
+++ b/base_layer/core/src/chain_storage/async_db.rs
@@ -217,9 +217,9 @@ impl<B: BlockchainBackend + 'static> AsyncBlockchainDb<B> {
     //---------------------------------- Misc. --------------------------------------------//
     make_async_fn!(fetch_block_timestamps(start_hash: HashOutput) -> RollingVec<EpochTime>, "fetch_block_timestamps");
 
-    make_async_fn!(fetch_target_difficulty(pow_algo: PowAlgorithm,height: u64) -> TargetDifficultyWindow, "fetch_target_difficulty");
+    make_async_fn!(fetch_target_difficulty_for_next_block(pow_algo: PowAlgorithm, current_block_hash: HashOutput) -> TargetDifficultyWindow, "fetch_target_difficulty");
 
-    make_async_fn!(fetch_target_difficulties(start_hash: HashOutput) -> TargetDifficulties, "fetch_target_difficulties");
+    make_async_fn!(fetch_target_difficulties_for_next_block(current_block_hash: HashOutput) -> TargetDifficulties, "fetch_target_difficulties_for_next_block");
 
     make_async_fn!(fetch_block_hashes_from_header_tip(n: usize, offset: usize) -> Vec<HashOutput>, "fetch_block_hashes_from_header_tip");
 }

--- a/base_layer/core/src/chain_storage/blockchain_backend.rs
+++ b/base_layer/core/src/chain_storage/blockchain_backend.rs
@@ -54,7 +54,7 @@ pub trait BlockchainBackend: Send + Sync {
         hash: &HashOutput,
     ) -> Result<Option<BlockHeaderAccumulatedData>, ChainStorageError>;
 
-    fn fetch_chain_header_in_all_chains(&self, hash: &HashOutput) -> Result<Option<ChainHeader>, ChainStorageError>;
+    fn fetch_chain_header_in_all_chains(&self, hash: &HashOutput) -> Result<ChainHeader, ChainStorageError>;
 
     fn fetch_header_containing_kernel_mmr(&self, mmr_position: u64) -> Result<ChainHeader, ChainStorageError>;
 

--- a/base_layer/core/src/chain_storage/blockchain_database.rs
+++ b/base_layer/core/src/chain_storage/blockchain_database.rs
@@ -38,6 +38,7 @@ use crate::{
         HistoricalBlock,
         HorizonData,
         MmrTree,
+        Optional,
         OrNotFound,
         TargetDifficulties,
     },
@@ -49,7 +50,7 @@ use crate::{
         transaction::{TransactionKernel, TransactionOutput},
         types::{Commitment, HashDigest, HashOutput, Signature},
     },
-    validation::{HeaderValidation, OrphanValidation, PostOrphanBodyValidation, ValidationError},
+    validation::{DifficultyCalculator, HeaderValidation, OrphanValidation, PostOrphanBodyValidation, ValidationError},
 };
 use croaring::Bitmap;
 use log::*;
@@ -164,6 +165,7 @@ pub struct BlockchainDatabase<B> {
     validators: Validators<B>,
     config: BlockchainDatabaseConfig,
     consensus_manager: ConsensusManager,
+    difficulty_calculator: Arc<DifficultyCalculator>,
 }
 
 #[allow(clippy::ptr_arg)]
@@ -173,9 +175,10 @@ where B: BlockchainBackend
     /// Creates a new `BlockchainDatabase` using the provided backend.
     pub fn new(
         db: B,
-        consensus_manager: &ConsensusManager,
+        consensus_manager: ConsensusManager,
         validators: Validators<B>,
         config: BlockchainDatabaseConfig,
+        difficulty_calculator: DifficultyCalculator,
         cleanup_orphans_at_startup: bool,
     ) -> Result<Self, ChainStorageError>
     {
@@ -185,11 +188,12 @@ where B: BlockchainBackend
             db: Arc::new(RwLock::new(db)),
             validators,
             config,
-            consensus_manager: consensus_manager.clone(),
+            consensus_manager,
+            difficulty_calculator: Arc::new(difficulty_calculator),
         };
         if is_empty {
             info!(target: LOG_TARGET, "Blockchain db is empty. Adding genesis block.");
-            let genesis_block = consensus_manager.get_genesis_block();
+            let genesis_block = blockchain_db.consensus_manager.get_genesis_block();
             blockchain_db.insert_block(Arc::new(genesis_block))?;
             blockchain_db.store_pruning_horizon(config.pruning_horizon)?;
         }
@@ -617,50 +621,37 @@ where B: BlockchainBackend
     /// Returns the set of target difficulties for the specified proof of work algorithm. The calculated target
     /// difficulty will be for the given height i.e calculated from the previous header backwards until the target
     /// difficulty window is populated according to consensus constants for the given height.
-    pub fn fetch_target_difficulty(
+    pub fn fetch_target_difficulty_for_next_block(
         &self,
         pow_algo: PowAlgorithm,
-        height: u64,
+        current_block_hash: HashOutput,
     ) -> Result<TargetDifficultyWindow, ChainStorageError>
     {
         let db = self.db_read_access()?;
-        fetch_target_difficulty(&*db, &self.consensus_manager, pow_algo, height)
+        fetch_target_difficulty_for_next_block(&*db, &self.consensus_manager, pow_algo, &current_block_hash)
     }
 
-    pub fn fetch_target_difficulties(&self, start_hash: HashOutput) -> Result<TargetDifficulties, ChainStorageError> {
+    pub fn fetch_target_difficulties_for_next_block(
+        &self,
+        current_block_hash: HashOutput,
+    ) -> Result<TargetDifficulties, ChainStorageError>
+    {
         let db = self.db_read_access()?;
-        let start_header =
-            fetch_header_by_block_hash(&*db, start_hash.clone())?.ok_or_else(|| ChainStorageError::ValueNotFound {
-                entity: "fetch_target_difficulties".to_string(),
-                field: "start_hash".to_string(),
-                value: start_hash.to_hex(),
-            })?;
-        let start_height = start_header.height;
-        let mut targets = TargetDifficulties::new(&self.consensus_manager, start_height);
-        let accum_data =
-            db.fetch_header_accumulated_data(&start_hash)?
-                .ok_or_else(|| ChainStorageError::ValueNotFound {
-                    entity: "BlockHeaderAccumulatedData".to_string(),
-                    field: "hash".to_string(),
-                    value: start_hash.to_hex(),
-                })?;
+        let mut current_header = db.fetch_chain_header_in_all_chains(&current_block_hash)?;
+        let mut targets = TargetDifficulties::new(&self.consensus_manager, current_header.height() + 1);
         // Add start header since we have it on hand
-        targets.add_front(&start_header, accum_data.target_difficulty);
+        targets.add_front(
+            current_header.header(),
+            current_header.accumulated_data().target_difficulty,
+        );
 
-        for h in (0..start_height).rev() {
-            // TODO: this can be optimized by retrieving the accumulated data and header at the same time, or even
-            // better by retrieving only the epoch and target difficulty in the same lmdb transaction
-            let header = fetch_header(&*db, h)?;
-            if !targets.is_algo_full(header.pow_algo()) {
-                let accum_data = db.fetch_header_accumulated_data(&header.hash())?.ok_or_else(|| {
-                    ChainStorageError::ValueNotFound {
-                        entity: "BlockHeaderAccumulatedData".to_string(),
-                        field: "hash".to_string(),
-                        value: header.hash().to_hex(),
-                    }
-                })?;
-
-                targets.add_front(&header, accum_data.target_difficulty);
+        while current_header.height() > 0 && !targets.is_full() {
+            current_header = db.fetch_chain_header_in_all_chains(&current_header.header().prev_hash)?;
+            if !targets.is_algo_full(current_header.header().pow_algo()) {
+                targets.add_front(
+                    current_header.header(),
+                    current_header.accumulated_data().target_difficulty,
+                );
             }
             if targets.is_full() {
                 break;
@@ -753,6 +744,7 @@ where B: BlockchainBackend
             &*self.validators.block,
             &*self.validators.header,
             self.consensus_manager.chain_strength_comparer(),
+            &self.difficulty_calculator,
             block,
         )?;
 
@@ -760,6 +752,11 @@ where B: BlockchainBackend
             // If blocks were added and the node is in pruned mode, perform pruning
             prune_database_if_needed(&mut *db, self.config.pruning_horizon, self.config.pruning_interval)?
         }
+
+        info!(
+            target: LOG_TARGET,
+            "Candidate block `add_block` result: {}", block_add_result
+        );
 
         trace!(
             target: LOG_TARGET,
@@ -1059,6 +1056,7 @@ fn add_block<T: BlockchainBackend>(
     block_validator: &dyn PostOrphanBodyValidation<T>,
     header_validator: &dyn HeaderValidation<T>,
     chain_strength_comparer: &dyn ChainStrengthComparer,
+    difficulty_calculator: &DifficultyCalculator,
     block: Arc<Block>,
 ) -> Result<BlockAddResult, ChainStorageError>
 {
@@ -1066,7 +1064,14 @@ fn add_block<T: BlockchainBackend>(
     if db.contains(&DbKey::BlockHash(block_hash))? {
         return Ok(BlockAddResult::BlockExists);
     }
-    handle_possible_reorg(db, block_validator, header_validator, chain_strength_comparer, block)
+    handle_possible_reorg(
+        db,
+        block_validator,
+        header_validator,
+        difficulty_calculator,
+        chain_strength_comparer,
+        block,
+    )
 }
 
 // Adds a new block onto the chain tip.
@@ -1100,32 +1105,25 @@ fn store_pruning_horizon<T: BlockchainBackend>(db: &mut T, pruning_horizon: u64)
     db.write(txn)
 }
 
-pub fn fetch_target_difficulty<T: BlockchainBackend>(
+#[allow(clippy::ptr_arg)]
+pub fn fetch_target_difficulty_for_next_block<T: BlockchainBackend>(
     db: &T,
     consensus_manager: &ConsensusManager,
     pow_algo: PowAlgorithm,
-    height: u64,
+    current_block_hash: &HashOutput,
 ) -> Result<TargetDifficultyWindow, ChainStorageError>
 {
-    let mut target_difficulties = consensus_manager.new_target_difficulty(pow_algo, height);
-    for height in (0..height).rev() {
-        // TODO: this can be optimized by retrieving the accumulated data and header at the same time, or even
-        // better by retrieving only the epoch and target difficulty in the same lmdb transaction
-        let header = fetch_header(&*db, height)?;
+    // The block may be in the chained orphan pool or in the main chain
+    let mut header = db.fetch_chain_header_in_all_chains(current_block_hash)?;
+    let mut target_difficulties = consensus_manager.new_target_difficulty(pow_algo, header.height() + 1);
+    if header.header().pow.pow_algo == pow_algo {
+        target_difficulties.add_front(header.header().timestamp(), header.accumulated_data().target_difficulty);
+    }
+    while header.height() > 0 && !target_difficulties.is_full() {
+        header = db.fetch_chain_header_in_all_chains(&header.header().prev_hash)?;
 
-        if header.pow.pow_algo == pow_algo {
-            let accum_data =
-                db.fetch_header_accumulated_data(&header.hash())?
-                    .ok_or_else(|| ChainStorageError::ValueNotFound {
-                        entity: "BlockHeaderAccumulatedData".to_string(),
-                        field: "hash".to_string(),
-                        value: header.hash().to_hex(),
-                    })?;
-
-            target_difficulties.add_front(header.timestamp(), accum_data.target_difficulty);
-            if target_difficulties.is_full() {
-                break;
-            }
+        if header.header().pow.pow_algo == pow_algo {
+            target_difficulties.add_front(header.header().timestamp(), header.accumulated_data().target_difficulty);
         }
     }
 
@@ -1290,14 +1288,21 @@ fn rewind_to_height<T: BlockchainBackend>(
             ))
         })?;
 
-    info!(
-        target: LOG_TARGET,
-        "Rewinding headers from height {} to {}",
-        last_header_height,
-        last_header_height - steps_back
-    );
+    if steps_back > 0 {
+        info!(
+            target: LOG_TARGET,
+            "Rewinding headers from height {} to {}",
+            last_header_height,
+            last_header_height - steps_back
+        );
+    }
     // We might have more headers than blocks, so we first see if we need to delete the extra headers.
     (0..steps_back).for_each(|h| {
+        info!(
+            target: LOG_TARGET,
+            "Rewinding headers at height {}",
+            last_header_height - h
+        );
         txn.delete_header(last_header_height - h);
     });
 
@@ -1399,6 +1404,7 @@ fn handle_possible_reorg<T: BlockchainBackend>(
     db: &mut T,
     block_validator: &dyn PostOrphanBodyValidation<T>,
     header_validator: &dyn HeaderValidation<T>,
+    difficulty_calculator: &DifficultyCalculator,
     chain_strength_comparer: &dyn ChainStrengthComparer,
     new_block: Arc<Block>,
 ) -> Result<BlockAddResult, ChainStorageError>
@@ -1406,7 +1412,7 @@ fn handle_possible_reorg<T: BlockchainBackend>(
     let db_height = db.fetch_chain_metadata()?.height_of_longest_chain();
     let new_block_hash = new_block.hash();
 
-    let new_tips = insert_orphan_and_find_new_tips(db, new_block.clone(), header_validator)?;
+    let new_tips = insert_orphan_and_find_new_tips(db, new_block.clone(), header_validator, difficulty_calculator)?;
     debug!(
         target: LOG_TARGET,
         "Added candidate block #{} ({}) to the orphan database. Best height is {}. New tips found: {} ",
@@ -1617,8 +1623,7 @@ fn restore_reorged_chain<T: BlockchainBackend>(
             .collect::<Vec<_>>(),
     );
     let mut txn = DbTransaction::new();
-    // Add removed blocks in the reverse order that they were removed
-    // See: https://github.com/tari-project/tari/issues/2182
+
     for block in previous_chain.into_iter().rev() {
         txn.delete_orphan(block.accumulated_data().hash.clone());
         insert_block(&mut txn, block)?;
@@ -1632,6 +1637,7 @@ fn insert_orphan_and_find_new_tips<T: BlockchainBackend>(
     db: &mut T,
     block: Arc<Block>,
     validator: &dyn HeaderValidation<T>,
+    difficulty_calculator: &DifficultyCalculator,
 ) -> Result<Vec<ChainHeader>, ChainStorageError>
 {
     let hash = block.hash();
@@ -1645,15 +1651,18 @@ fn insert_orphan_and_find_new_tips<T: BlockchainBackend>(
     let parent = match db.fetch_orphan_chain_tip_by_hash(&block.header.prev_hash)? {
         Some(curr_parent) => {
             txn.remove_orphan_chain_tip(block.header.prev_hash.clone());
-            debug!(
+            info!(
                 target: LOG_TARGET,
                 "New orphan extends a chain in the current candidate tip set"
             );
             curr_parent
         },
-        None => match db.fetch_chain_header_in_all_chains(&block.header.prev_hash)? {
+        None => match db
+            .fetch_chain_header_in_all_chains(&block.header.prev_hash)
+            .optional()?
+        {
             Some(curr_parent) => {
-                debug!(
+                info!(
                     target: LOG_TARGET,
                     "New orphan does not have a parent in the current tip set. Parent is {}",
                     curr_parent.hash().to_hex()
@@ -1661,7 +1670,7 @@ fn insert_orphan_and_find_new_tips<T: BlockchainBackend>(
                 curr_parent
             },
             None => {
-                debug!(
+                info!(
                     target: LOG_TARGET,
                     "Orphan {} was not connected to any previous headers. Inserting as true orphan",
                     hash.to_hex()
@@ -1676,7 +1685,7 @@ fn insert_orphan_and_find_new_tips<T: BlockchainBackend>(
         },
     };
 
-    let achieved_target_diff = validator.validate(db, &block.header)?;
+    let achieved_target_diff = validator.validate(db, &block.header, difficulty_calculator)?;
 
     let accumulated_data = BlockHeaderAccumulatedData::builder(parent.accumulated_data())
         .with_hash(hash)
@@ -1691,7 +1700,7 @@ fn insert_orphan_and_find_new_tips<T: BlockchainBackend>(
     // Extend orphan chain tip.
     txn.insert_chained_orphan(Arc::new(chain_block));
 
-    let tips = find_orphan_descendant_tips_of(&*db, &chain_header, validator, &mut txn)?;
+    let tips = find_orphan_descendant_tips_of(&*db, &chain_header, validator, difficulty_calculator, &mut txn)?;
     debug!(target: LOG_TARGET, "Found {} new orphan tips", tips.len());
     for new_tip in &tips {
         txn.insert_orphan_chain_tip(new_tip.hash().clone());
@@ -1706,6 +1715,7 @@ fn find_orphan_descendant_tips_of<T: BlockchainBackend>(
     db: &T,
     prev_chain_header: &ChainHeader,
     validator: &dyn HeaderValidation<T>,
+    difficulty_calculator: &DifficultyCalculator,
     txn: &mut DbTransaction,
 ) -> Result<Vec<ChainHeader>, ChainStorageError>
 {
@@ -1722,7 +1732,7 @@ fn find_orphan_descendant_tips_of<T: BlockchainBackend>(
 
     let mut res = vec![];
     for child in children {
-        match validator.validate(db, &child.header) {
+        match validator.validate(db, &child.header, difficulty_calculator) {
             Ok(achieved_target) => {
                 let child_hash = child.hash();
                 let accum_data = BlockHeaderAccumulatedData::builder(prev_chain_header.accumulated_data())
@@ -1741,7 +1751,8 @@ fn find_orphan_descendant_tips_of<T: BlockchainBackend>(
                 // Set/overwrite accumulated data for this orphan block
                 txn.set_accumulated_data_for_orphan(chain_header.clone());
 
-                let children = find_orphan_descendant_tips_of(db, &chain_header, validator, txn)?;
+                let children =
+                    find_orphan_descendant_tips_of(db, &chain_header, validator, difficulty_calculator, txn)?;
                 res.extend(children);
             },
             Err(e) => {
@@ -1840,7 +1851,7 @@ fn prune_database_if_needed<T: BlockchainBackend>(
 
     if metadata.pruned_height() < abs_pruning_horizon.saturating_sub(pruning_interval) {
         let last_pruned = metadata.pruned_height();
-        debug!(
+        info!(
             target: LOG_TARGET,
             "Pruning blockchain database at height {} (was={})", abs_pruning_horizon, last_pruned,
         );
@@ -1887,6 +1898,7 @@ impl<T> Clone for BlockchainDatabase<T> {
             validators: self.validators.clone(),
             config: self.config,
             consensus_manager: self.consensus_manager.clone(),
+            difficulty_calculator: self.difficulty_calculator.clone(),
         }
     }
 }
@@ -1914,14 +1926,20 @@ fn convert_to_option_bounds<T: RangeBounds<u64>>(bounds: T) -> (Option<u64>, Opt
 mod test {
     use super::*;
     use crate::{
-        consensus::chain_strength_comparer::strongest_chain,
+        consensus::{
+            chain_strength_comparer::strongest_chain,
+            consensus_constants::PowAlgorithmConstants,
+            ConsensusConstantsBuilder,
+            ConsensusManagerBuilder,
+            Network,
+        },
         proof_of_work::AchievedTargetDifficulty,
         test_helpers::{
             blockchain::{create_new_blockchain, create_test_blockchain_db, TempDatabase},
             create_block,
             mine_to_difficulty,
         },
-        validation::mocks::MockValidator,
+        validation::{header_validator::HeaderValidator, mocks::MockValidator},
     };
     use std::collections::HashMap;
 
@@ -1963,7 +1981,8 @@ mod test {
         fn it_gets_a_simple_link_to_genesis() {
             let db = create_new_blockchain();
             let genesis = db.fetch_block(0).unwrap().try_into_chain_block().map(Arc::new).unwrap();
-            let (_, chain) = create_orphan_chain(&db, &[("A->GB", 1), ("B->A", 1), ("C->B", 1)], genesis);
+            let (_, chain) =
+                create_orphan_chain(&db, &[("A->GB", 1, 120), ("B->A", 1, 120), ("C->B", 1, 120)], genesis);
             let access = db.db_read_access().unwrap();
             let orphan_chain = get_orphan_link_main_chain(&*access, chain.get("C").unwrap().hash()).unwrap();
             assert_eq!(orphan_chain[2].hash(), chain.get("C").unwrap().hash());
@@ -1976,12 +1995,22 @@ mod test {
         fn it_selects_a_large_reorg_chain() {
             let db = create_new_blockchain();
             // Main chain
-            let (_, mainchain) = create_main_chain(&db, &[("A->GB", 1), ("B->A", 1), ("C->B", 1), ("D->C", 1)]);
+            let (_, mainchain) = create_main_chain(&db, &[
+                ("A->GB", 1, 120),
+                ("B->A", 1, 120),
+                ("C->B", 1, 120),
+                ("D->C", 1, 120),
+            ]);
             // Create reorg chain
             let fork_root = mainchain.get("B").unwrap().clone();
             let (_, reorg_chain) = create_orphan_chain(
                 &db,
-                &[("C2->GB", 2), ("D2->C2", 1), ("E2->D2", 1), ("F2->E2", 1)],
+                &[
+                    ("C2->GB", 2, 120),
+                    ("D2->C2", 1, 120),
+                    ("E2->D2", 1, 120),
+                    ("F2->E2", 1, 120),
+                ],
                 fork_root,
             );
             let access = db.db_read_access().unwrap();
@@ -2011,10 +2040,16 @@ mod test {
             let db = create_new_blockchain();
             let validator = MockValidator::new(true);
             let genesis_block = db.fetch_block(0).unwrap().try_into_chain_block().map(Arc::new).unwrap();
-            let (_, chain) = create_chained_blocks(&[("A->GB", 1)], genesis_block);
+            let (_, chain) = create_chained_blocks(&[("A->GB", 1, 120)], genesis_block);
             let block = chain.get("A").unwrap().clone();
             let mut access = db.db_write_access().unwrap();
-            let chain = insert_orphan_and_find_new_tips(&mut *access, block.to_arc_block(), &validator).unwrap();
+            let chain = insert_orphan_and_find_new_tips(
+                &mut *access,
+                block.to_arc_block(),
+                &validator,
+                &db.difficulty_calculator,
+            )
+            .unwrap();
             assert_eq!(chain.len(), 1);
             assert_eq!(chain[0].hash(), block.hash());
 
@@ -2026,18 +2061,31 @@ mod test {
         fn it_inserts_true_orphan_chain() {
             let db = create_new_blockchain();
             let validator = MockValidator::new(true);
-            let (_, main_chain) = create_main_chain(&db, &[("A->GB", 1), ("B->GB", 1)]);
+            let (_, main_chain) = create_main_chain(&db, &[("A->GB", 1, 120), ("B->GB", 1, 120)]);
 
             let block_b = main_chain.get("B").unwrap().clone();
-            let (_, orphan_chain) = create_chained_blocks(&[("C2->GB", 1), ("D2->C2", 1), ("E2->D2", 1)], block_b);
+            let (_, orphan_chain) =
+                create_chained_blocks(&[("C2->GB", 1, 120), ("D2->C2", 1, 120), ("E2->D2", 1, 120)], block_b);
             let mut access = db.db_write_access().unwrap();
 
             let block_d2 = orphan_chain.get("D2").unwrap().clone();
-            let chain = insert_orphan_and_find_new_tips(&mut *access, block_d2.to_arc_block(), &validator).unwrap();
+            let chain = insert_orphan_and_find_new_tips(
+                &mut *access,
+                block_d2.to_arc_block(),
+                &validator,
+                &db.difficulty_calculator,
+            )
+            .unwrap();
             assert!(chain.is_empty());
 
             let block_e2 = orphan_chain.get("E2").unwrap().clone();
-            let chain = insert_orphan_and_find_new_tips(&mut *access, block_e2.to_arc_block(), &validator).unwrap();
+            let chain = insert_orphan_and_find_new_tips(
+                &mut *access,
+                block_e2.to_arc_block(),
+                &validator,
+                &db.difficulty_calculator,
+            )
+            .unwrap();
             assert!(chain.is_empty());
 
             let maybe_block = access.fetch_orphan_children_of(block_d2.hash().clone()).unwrap();
@@ -2048,14 +2096,20 @@ mod test {
         fn it_correctly_handles_duplicate_blocks() {
             let db = create_new_blockchain();
             let validator = MockValidator::new(true);
-            let (_, main_chain) = create_main_chain(&db, &[("A->GB", 1)]);
+            let (_, main_chain) = create_main_chain(&db, &[("A->GB", 1, 120)]);
 
             let fork_root = main_chain.get("A").unwrap().clone();
-            let (_, orphan_chain) = create_chained_blocks(&[("B2->GB", 2)], fork_root);
+            let (_, orphan_chain) = create_chained_blocks(&[("B2->GB", 2, 120)], fork_root);
             let mut access = db.db_write_access().unwrap();
 
             let block = orphan_chain.get("B2").unwrap().clone();
-            let chain = insert_orphan_and_find_new_tips(&mut *access, block.to_arc_block(), &validator).unwrap();
+            let chain = insert_orphan_and_find_new_tips(
+                &mut *access,
+                block.to_arc_block(),
+                &validator,
+                &db.difficulty_calculator,
+            )
+            .unwrap();
             assert_eq!(chain.len(), 1);
             assert_eq!(chain[0].header(), block.header());
             assert_eq!(chain[0].accumulated_data().total_accumulated_difficulty, 4);
@@ -2063,7 +2117,13 @@ mod test {
             assert_eq!(fork_tip, block.to_chain_header());
 
             // Insert again (block was received more than once), no new tips
-            let chain = insert_orphan_and_find_new_tips(&mut *access, block.to_arc_block(), &validator).unwrap();
+            let chain = insert_orphan_and_find_new_tips(
+                &mut *access,
+                block.to_arc_block(),
+                &validator,
+                &db.difficulty_calculator,
+            )
+            .unwrap();
             assert_eq!(chain.len(), 0);
         }
     }
@@ -2071,40 +2131,42 @@ mod test {
     #[test]
     fn test_handle_possible_reorg_case1() {
         // Normal chain
-        let (result, _blocks) = test_case_handle_possible_reorg(&[("A->GB", 1), ("B->A", 1)]).unwrap();
+        let (result, _blocks) = test_case_handle_possible_reorg(&[("A->GB", 1, 120), ("B->A", 1, 120)]).unwrap();
         result[0].assert_added();
         result[1].assert_added();
     }
 
     #[test]
     fn test_handle_possible_reorg_case2() {
-        let (result, blocks) = test_case_handle_possible_reorg(&[("A->GB", 1), ("B->A", 1), ("A2->GB", 3)]).unwrap();
+        let (result, blocks) =
+            test_case_handle_possible_reorg(&[("A->GB", 1, 120), ("B->A", 1, 120), ("A2->GB", 3, 120)]).unwrap();
         result[0].assert_added();
         result[1].assert_added();
         result[2].assert_reorg(1, 2);
-        let added_blocks = result[2].added_blocks();
-        assert_eq!(added_blocks, vec![blocks.get(&"A2".to_string()).unwrap().clone()]);
+        assert_added_hashes_eq(&result[2], vec!["A2"], &blocks);
     }
 
     #[test]
     fn test_handle_possible_reorg_case3() {
         // Switch to new chain and then reorg back
-        let (result, blocks) = test_case_handle_possible_reorg(&[("A->GB", 1), ("A2->GB", 2), ("B->A", 2)]).unwrap();
+        let (result, blocks) =
+            test_case_handle_possible_reorg(&[("A->GB", 1, 120), ("A2->GB", 2, 120), ("B->A", 2, 120)]).unwrap();
         result[0].assert_added();
         result[1].assert_reorg(1, 1);
         result[2].assert_reorg(2, 1);
-        let added_blocks = result[2].added_blocks();
-        assert_eq!(added_blocks, vec![
-            blocks.get(&"A".to_string()).unwrap().clone(),
-            blocks.get(&"B".to_string()).unwrap().clone()
-        ]);
+        assert_added_hashes_eq(&result[2], vec!["A", "B"], &blocks);
     }
 
     #[test]
     fn test_handle_possible_reorg_case4() {
-        let (result, blocks) =
-            test_case_handle_possible_reorg(&[("A->GB", 1), ("A2->GB", 2), ("B->A", 2), ("A3->GB", 4), ("C->B", 2)])
-                .unwrap();
+        let (result, blocks) = test_case_handle_possible_reorg(&[
+            ("A->GB", 1, 120),
+            ("A2->GB", 2, 120),
+            ("B->A", 2, 120),
+            ("A3->GB", 4, 120),
+            ("C->B", 2, 120),
+        ])
+        .unwrap();
         result[0].assert_added();
         result[1].assert_reorg(1, 1);
         result[2].assert_reorg(2, 1);
@@ -2117,15 +2179,15 @@ mod test {
     #[test]
     fn test_handle_possible_reorg_case5() {
         let (result, blocks) = test_case_handle_possible_reorg(&[
-            ("A->GB", 1),
-            ("B->A", 1),
-            ("A2->GB", 3),
-            ("C->B", 1),
-            ("D->C", 2),
-            ("B2->A", 5),
-            ("D2->C", 6),
-            ("D3->C", 7),
-            ("D4->C", 8),
+            ("A->GB", 1, 120),
+            ("B->A", 1, 120),
+            ("A2->GB", 3, 120),
+            ("C->B", 1, 120),
+            ("D->C", 2, 120),
+            ("B2->A", 5, 120),
+            ("D2->C", 6, 120),
+            ("D3->C", 7, 120),
+            ("D4->C", 8, 120),
         ])
         .unwrap();
         result[0].assert_added();
@@ -2154,20 +2216,29 @@ mod test {
     #[test]
     fn test_handle_possible_reorg_case6_orphan_chain_link() {
         let db = create_new_blockchain();
-        let (_, mainchain) = create_main_chain(&db, &[("A->GB", 1), ("B->A", 1), ("C->B", 1), ("D->C", 1)]);
+        let (_, mainchain) = create_main_chain(&db, &[
+            ("A->GB", 1, 120),
+            ("B->A", 1, 120),
+            ("C->B", 1, 120),
+            ("D->C", 1, 120),
+        ]);
 
         let mut access = db.db_write_access().unwrap();
         let mock_validator = MockValidator::new(true);
         let chain_strength_comparer = strongest_chain().by_sha3_difficulty().build();
 
         let fork_block = mainchain.get("B").unwrap().clone();
-        let (_, reorg_chain) = create_chained_blocks(&[("C2->GB", 1), ("D2->C2", 1), ("E2->D2", 1)], fork_block);
+        let (_, reorg_chain) = create_chained_blocks(
+            &[("C2->GB", 1, 120), ("D2->C2", 1, 120), ("E2->D2", 1, 120)],
+            fork_block,
+        );
 
         // Add true orphans
         let result = handle_possible_reorg(
             &mut *access,
             &mock_validator,
             &mock_validator,
+            &db.difficulty_calculator,
             &*chain_strength_comparer,
             reorg_chain.get("E2").unwrap().to_arc_block(),
         )
@@ -2179,6 +2250,7 @@ mod test {
             &mut *access,
             &mock_validator,
             &mock_validator,
+            &db.difficulty_calculator,
             &*chain_strength_comparer,
             reorg_chain.get("E2").unwrap().to_arc_block(),
         )
@@ -2189,6 +2261,7 @@ mod test {
             &mut *access,
             &mock_validator,
             &mock_validator,
+            &db.difficulty_calculator,
             &*chain_strength_comparer,
             reorg_chain.get("D2").unwrap().to_arc_block(),
         )
@@ -2202,6 +2275,7 @@ mod test {
             &mut *access,
             &mock_validator,
             &mock_validator,
+            &db.difficulty_calculator,
             &*chain_strength_comparer,
             reorg_chain.get("C2").unwrap().to_arc_block(),
         )
@@ -2216,20 +2290,26 @@ mod test {
     #[test]
     fn test_handle_possible_reorg_case7_fail_reorg() {
         let db = create_new_blockchain();
-        let (_, mainchain) = create_main_chain(&db, &[("A->GB", 1), ("B->A", 1), ("C->B", 1), ("D->C", 1)]);
+        let (_, mainchain) = create_main_chain(&db, &[
+            ("A->GB", 1, 120),
+            ("B->A", 1, 120),
+            ("C->B", 1, 120),
+            ("D->C", 1, 120),
+        ]);
 
         let mut access = db.db_write_access().unwrap();
         let mock_validator = MockValidator::new(true);
         let chain_strength_comparer = strongest_chain().by_sha3_difficulty().build();
 
         let fork_block = mainchain.get("C").unwrap().clone();
-        let (_, reorg_chain) = create_chained_blocks(&[("D2->GB", 1), ("E2->D2", 2)], fork_block);
+        let (_, reorg_chain) = create_chained_blocks(&[("D2->GB", 1, 120), ("E2->D2", 2, 120)], fork_block);
 
         // Add true orphans
         let result = handle_possible_reorg(
             &mut *access,
             &mock_validator,
             &mock_validator,
+            &db.difficulty_calculator,
             &*chain_strength_comparer,
             reorg_chain.get("E2").unwrap().to_arc_block(),
         )
@@ -2240,6 +2320,7 @@ mod test {
             &mut *access,
             &MockValidator::new(false),
             &mock_validator,
+            &db.difficulty_calculator,
             &*chain_strength_comparer,
             reorg_chain.get("D2").unwrap().to_arc_block(),
         )
@@ -2250,6 +2331,89 @@ mod test {
         assert_eq!(&tip, mainchain.get("D").unwrap().header());
 
         check_whole_chain(&mut *access);
+    }
+
+    #[test]
+    fn test_handle_possible_reorg_target_difficulty_is_correct_case_1() {
+        let (result, _blocks) =
+            test_case_handle_possible_reorg(&[("A->GB", 1, 120), ("B->A", 1, 60), ("C2->B", 2, 20), ("D2->C2", 4, 60)])
+                .unwrap();
+        let mut expected_target_difficulties = vec![];
+        expected_target_difficulties.extend(result[0].added_blocks());
+        expected_target_difficulties.extend(result[1].added_blocks());
+        expected_target_difficulties.extend(result[2].added_blocks());
+        expected_target_difficulties.extend(result[3].added_blocks());
+        let expected_target_difficulties: Vec<u64> = expected_target_difficulties
+            .iter()
+            .map(|b| b.accumulated_data().target_difficulty.as_u64())
+            .collect();
+        assert_eq!(expected_target_difficulties, vec![1, 1, 2, 4]);
+
+        let (result, blocks) = test_case_handle_possible_reorg(&[
+            ("A->GB", 1, 120),
+            ("B->A", 1, 60),
+            ("C->B", 3, 240),
+            ("C2->B", 2, 20),
+            ("D2->C2", 4, 60),
+        ])
+        .unwrap();
+
+        result[0].assert_added();
+        result[1].assert_added();
+        result[2].assert_added();
+        result[3].assert_orphaned();
+        result[4].assert_reorg(2, 1);
+
+        assert_added_hashes_eq(&result[4], vec!["C2", "D2"], &blocks);
+        assert_target_difficulties_eq(&result[4], vec![2, 4]);
+    }
+
+    #[test]
+    fn test_handle_possible_reorg_target_difficulty_is_correct_case_2() {
+        let _ = env_logger::builder().is_test(true).try_init();
+        // Test a straight chain to get the correct target difficulty. The block times must be reduced so that the
+        // algorithm changes
+        let (result, _blocks) = test_case_handle_possible_reorg(&[
+            ("A->GB", 1, 120),
+            ("B2->A", 1, 60),
+            ("C2->B2", 2, 60),
+            ("D2->C2", 3, 60),
+            ("E2->D2", 4, 60),
+        ])
+        .unwrap();
+        let mut expected_target_difficulties = vec![];
+        expected_target_difficulties.extend(result[0].added_blocks());
+        expected_target_difficulties.extend(result[1].added_blocks());
+        expected_target_difficulties.extend(result[2].added_blocks());
+        expected_target_difficulties.extend(result[3].added_blocks());
+        expected_target_difficulties.extend(result[4].added_blocks());
+        let expected_target_difficulties: Vec<u64> = expected_target_difficulties
+            .iter()
+            .map(|b| b.accumulated_data().target_difficulty.as_u64())
+            .collect();
+        assert_eq!(expected_target_difficulties, vec![1, 1, 2, 3, 4]);
+
+        // Now do a reorg to make sure the target difficulties are the same
+        let (result, blocks) = test_case_handle_possible_reorg(&[
+            ("A->GB", 1, 120),
+            ("B->A", 4, 120),
+            ("C->B", 4, 120),
+            ("B2->A", 1, 60),
+            ("C2->B2", 2, 60),
+            ("D2->C2", 3, 60),
+            ("E2->D2", 4, 60),
+        ])
+        .unwrap();
+        result[0].assert_added();
+        result[1].assert_added();
+        result[2].assert_added();
+        result[3].assert_orphaned();
+        result[4].assert_orphaned();
+        result[5].assert_orphaned();
+        result[6].assert_reorg(4, 2);
+
+        assert_added_hashes_eq(&result[6], vec!["B2", "C2", "D2", "E2"], &blocks);
+        assert_target_difficulties_eq(&result[6], vec![1, 2, 3, 4]);
     }
 
     fn check_whole_chain(db: &mut TempDatabase) {
@@ -2269,10 +2433,10 @@ mod test {
     {
         let added = result.added_blocks();
         assert_eq!(
-            added,
+            added.iter().map(|b| b.hash()).collect::<Vec<_>>(),
             block_names
                 .iter()
-                .map(|b| blocks.get(*b).unwrap().clone())
+                .map(|b| blocks.get(*b).unwrap().hash())
                 .collect::<Vec<_>>()
         );
     }
@@ -2286,14 +2450,41 @@ mod test {
         assert_eq!(accum_difficulty, values);
     }
 
+    fn assert_target_difficulties_eq(result: &BlockAddResult, values: Vec<u64>) {
+        let accum_difficulty: Vec<u64> = result
+            .added_blocks()
+            .iter()
+            .map(|cb| cb.accumulated_data().target_difficulty.as_u64())
+            .collect();
+        assert_eq!(accum_difficulty, values);
+    }
+
     #[allow(clippy::type_complexity)]
     fn test_case_handle_possible_reorg(
-        blocks: &[(&str, u64)],
+        blocks: &[(&str, u64, u64)],
     ) -> Result<(Vec<BlockAddResult>, HashMap<String, Arc<ChainBlock>>), ChainStorageError> {
         let db = create_new_blockchain();
         let genesis_block = db.fetch_block(0).unwrap().try_into_chain_block().map(Arc::new).unwrap();
         let (block_names, chain) = create_chained_blocks(blocks, genesis_block);
         let mock_validator = Box::new(MockValidator::new(true));
+        // A real validator is needed here to test target difficulties
+
+        let consensus = ConsensusManagerBuilder::new(Network::LocalNet)
+            .with_consensus_constants(
+                ConsensusConstantsBuilder::new(Network::LocalNet)
+                    .clear_proof_of_work()
+                    .add_proof_of_work(PowAlgorithm::Sha3, PowAlgorithmConstants {
+                        max_target_time: 1200,
+                        min_difficulty: 1.into(),
+                        max_difficulty: 4.into(),
+                        target_time: 120,
+                    })
+                    .build(),
+            )
+            .build();
+
+        let difficulty_calculator = DifficultyCalculator::new(consensus.clone(), Default::default());
+        let header_validator = Box::new(HeaderValidator::new(consensus));
         let chain_strength_comparer = strongest_chain().by_sha3_difficulty().build();
         let mut results = vec![];
         for name in block_names {
@@ -2307,7 +2498,8 @@ mod test {
             results.push(handle_possible_reorg(
                 &mut *db.db_write_access()?,
                 &*mock_validator,
-                &*mock_validator,
+                &*header_validator,
+                &difficulty_calculator,
                 &*chain_strength_comparer,
                 block.to_arc_block(),
             )?);
@@ -2317,7 +2509,7 @@ mod test {
 
     fn create_main_chain(
         db: &BlockchainDatabase<TempDatabase>,
-        blocks: &[(&str, u64)],
+        blocks: &[(&str, u64, u64)],
     ) -> (Vec<String>, HashMap<String, Arc<ChainBlock>>)
     {
         let genesis_block = db.fetch_block(0).unwrap().try_into_chain_block().map(Arc::new).unwrap();
@@ -2332,7 +2524,7 @@ mod test {
 
     fn create_orphan_chain(
         db: &BlockchainDatabase<TempDatabase>,
-        blocks: &[(&str, u64)],
+        blocks: &[(&str, u64, u64)],
         root_block: Arc<ChainBlock>,
     ) -> (Vec<String>, HashMap<String, Arc<ChainBlock>>)
     {
@@ -2349,7 +2541,7 @@ mod test {
     }
 
     fn create_chained_blocks(
-        blocks: &[(&str, u64)],
+        blocks: &[(&str, u64, u64)],
         genesis_block: Arc<ChainBlock>,
     ) -> (Vec<String>, HashMap<String, Arc<ChainBlock>>)
     {
@@ -2357,7 +2549,7 @@ mod test {
         block_hashes.insert("GB".to_string(), genesis_block);
 
         let mut block_names = Vec::with_capacity(blocks.len());
-        for (name, difficulty) in blocks {
+        for (name, difficulty, time) in blocks {
             let split = name.split("->").collect::<Vec<_>>();
             let to = split[0].to_string();
             let from = split[1].to_string();
@@ -2368,6 +2560,8 @@ mod test {
             let mut block = create_block(1, prev_block.height() + 1, vec![]);
             block.header.prev_hash = prev_block.hash().clone();
 
+            // Keep times constant in case we need a particular target difficulty
+            block.header.timestamp = prev_block.header().timestamp.increase(*time);
             block.header.output_mmr_size = prev_block.header().output_mmr_size + block.body.outputs().len() as u64;
             block.header.kernel_mmr_size = prev_block.header().kernel_mmr_size + block.body.kernels().len() as u64;
             let block = mine_to_difficulty(block, (*difficulty).into()).unwrap();

--- a/base_layer/core/src/chain_storage/error.rs
+++ b/base_layer/core/src/chain_storage/error.rs
@@ -91,8 +91,6 @@ pub enum ChainStorageError {
     BlockingTaskSpawnError(String),
     #[error("A request was out of range")]
     OutOfRange,
-    #[error("Value not found: {0}")]
-    LmdbValueNotFound(lmdb_zero::Error),
     #[error("LMDB error: {source}")]
     LmdbError {
         #[from]
@@ -125,7 +123,11 @@ impl From<lmdb_zero::Error> for ChainStorageError {
     fn from(err: lmdb_zero::Error) -> Self {
         use lmdb_zero::Error::*;
         match err {
-            Code(c) if c == lmdb_zero::error::NOTFOUND => ChainStorageError::LmdbValueNotFound(err),
+            Code(c) if c == lmdb_zero::error::NOTFOUND => ChainStorageError::ValueNotFound {
+                entity: "LMDB".to_string(),
+                field: "unknown".to_string(),
+                value: "unknown".to_string(),
+            },
             _ => ChainStorageError::AccessError(err.to_string()),
         }
     }

--- a/base_layer/core/src/chain_storage/lmdb_db/lmdb_db.rs
+++ b/base_layer/core/src/chain_storage/lmdb_db/lmdb_db.rs
@@ -1233,13 +1233,13 @@ impl BlockchainBackend for LMDBDatabase {
         }
     }
 
-    fn fetch_chain_header_in_all_chains(&self, hash: &HashOutput) -> Result<Option<ChainHeader>, ChainStorageError> {
+    fn fetch_chain_header_in_all_chains(&self, hash: &HashOutput) -> Result<ChainHeader, ChainStorageError> {
         let txn = self.read_transaction()?;
 
         let height: Option<u64> = self.fetch_height_from_hash(&txn, hash)?;
         if let Some(h) = height {
             let chain_header = self.fetch_chain_header_by_height(h)?;
-            return Ok(Some(chain_header));
+            return Ok(chain_header);
         }
 
         let orphan_accum: Option<BlockHeaderAccumulatedData> =
@@ -1261,10 +1261,14 @@ impl BlockchainBackend for LMDBDatabase {
                     details: format!("accumulated data mismatch for orphan header {}", hash.to_hex()),
                 }
             })?;
-            return Ok(Some(chain_header));
+            return Ok(chain_header);
         }
 
-        Ok(None)
+        Err(ChainStorageError::ValueNotFound {
+            entity: "chain_header_in_all_chains".to_string(),
+            field: "hash".to_string(),
+            value: hash.to_hex(),
+        })
     }
 
     fn fetch_header_containing_kernel_mmr(&self, mmr_position: u64) -> Result<ChainHeader, ChainStorageError> {

--- a/base_layer/core/src/chain_storage/mod.rs
+++ b/base_layer/core/src/chain_storage/mod.rs
@@ -47,7 +47,7 @@ pub use blockchain_database::{
     calculate_mmr_roots,
     fetch_header,
     fetch_headers,
-    fetch_target_difficulty,
+    fetch_target_difficulty_for_next_block,
     BlockchainDatabase,
     BlockchainDatabaseConfig,
     Validators,

--- a/base_layer/core/src/consensus/consensus_constants.rs
+++ b/base_layer/core/src/consensus/consensus_constants.rs
@@ -372,8 +372,13 @@ impl ConsensusConstantsBuilder {
         }
     }
 
-    pub fn with_proof_of_work(mut self, proof_of_work: HashMap<PowAlgorithm, PowAlgorithmConstants>) -> Self {
-        self.consensus.proof_of_work = proof_of_work;
+    pub fn clear_proof_of_work(mut self) -> Self {
+        self.consensus.proof_of_work = HashMap::new();
+        self
+    }
+
+    pub fn add_proof_of_work(mut self, proof_of_work: PowAlgorithm, constants: PowAlgorithmConstants) -> Self {
+        self.consensus.proof_of_work.insert(proof_of_work, constants);
         self
     }
 

--- a/base_layer/core/src/proof_of_work/target_difficulty.rs
+++ b/base_layer/core/src/proof_of_work/target_difficulty.rs
@@ -65,7 +65,7 @@ impl TargetDifficultyWindow {
     /// Returns true of the TargetDifficulty has `block_window` data points, otherwise false
     #[inline]
     pub fn is_full(&self) -> bool {
-        self.lwma.num_samples() == self.lwma.block_window() + 1
+        self.lwma.is_full()
     }
 
     pub fn len(&self) -> usize {
@@ -93,7 +93,7 @@ pub struct AchievedTargetDifficulty {
 impl AchievedTargetDifficulty {
     /// Checks if the achieved difficulty is higher than the target difficulty. If not, None is returned because a valid
     /// AchievedTargetDifficulty cannot be constructed.
-    pub(crate) fn try_construct(pow_algo: PowAlgorithm, target: Difficulty, achieved: Difficulty) -> Option<Self> {
+    pub fn try_construct(pow_algo: PowAlgorithm, target: Difficulty, achieved: Difficulty) -> Option<Self> {
         if achieved < target {
             return None;
         }

--- a/base_layer/core/src/test_helpers/mod.rs
+++ b/base_layer/core/src/test_helpers/mod.rs
@@ -35,10 +35,8 @@ use crate::{
     chain_storage::{BlockHeaderAccumulatedData, ChainHeader},
     consensus::{ConsensusManagerBuilder, Network},
     crypto::tari_utilities::Hashable,
-    proof_of_work::{sha3_difficulty, Difficulty},
-    test_helpers::blockchain::TempDatabase,
+    proof_of_work::{sha3_difficulty, AchievedTargetDifficulty, Difficulty},
     transactions::{types::CryptoFactories, CoinbaseBuilder},
-    validation::{mocks::MockValidator, HeaderValidation},
 };
 use rand::{distributions::Alphanumeric, Rng};
 use std::{iter, path::Path, sync::Arc};
@@ -106,14 +104,8 @@ pub fn create_peer_manager<P: AsRef<Path>>(data_path: P) -> Arc<PeerManager> {
     Arc::new(PeerManager::new(LMDBWrapper::new(Arc::new(peer_database)), None).unwrap())
 }
 
-pub fn create_chain_header(
-    db: &TempDatabase,
-    header: BlockHeader,
-    prev_accum: &BlockHeaderAccumulatedData,
-) -> ChainHeader
-{
-    let validator = MockValidator::new(true);
-    let achieved_target_diff = validator.validate(db, &header).unwrap();
+pub fn create_chain_header(header: BlockHeader, prev_accum: &BlockHeaderAccumulatedData) -> ChainHeader {
+    let achieved_target_diff = AchievedTargetDifficulty::try_construct(header.pow_algo(), 1.into(), 1.into()).unwrap();
     let accumulated_data = BlockHeaderAccumulatedData::builder(prev_accum)
         .with_hash(header.hash())
         .with_achieved_target_difficulty(achieved_target_diff)

--- a/base_layer/core/src/validation/header_validator.rs
+++ b/base_layer/core/src/validation/header_validator.rs
@@ -1,15 +1,11 @@
 use crate::{
     blocks::BlockHeader,
-    chain_storage::{fetch_headers, fetch_target_difficulty, BlockchainBackend},
+    chain_storage::{fetch_headers, BlockchainBackend},
     consensus::ConsensusManager,
-    proof_of_work::{randomx_factory::RandomXFactory, AchievedTargetDifficulty},
+    proof_of_work::AchievedTargetDifficulty,
     validation::{
-        helpers::{
-            check_header_timestamp_greater_than_median,
-            check_pow_data,
-            check_target_difficulty,
-            check_timestamp_ftl,
-        },
+        helpers::{check_header_timestamp_greater_than_median, check_pow_data, check_timestamp_ftl},
+        DifficultyCalculator,
         HeaderValidation,
         ValidationError,
     },
@@ -21,30 +17,11 @@ pub const LOG_TARGET: &str = "c::val::header_validators";
 
 pub struct HeaderValidator {
     rules: ConsensusManager,
-    randomx_factory: RandomXFactory,
 }
 
 impl HeaderValidator {
-    pub fn new(rules: ConsensusManager, randomx_factory: RandomXFactory) -> Self {
-        Self { rules, randomx_factory }
-    }
-
-    /// Calculates the achieved and target difficulties at the specified height and compares them.
-    pub fn check_achieved_and_target_difficulty<B: BlockchainBackend>(
-        &self,
-        db: &B,
-        block_header: &BlockHeader,
-    ) -> Result<AchievedTargetDifficulty, ValidationError>
-    {
-        let difficulty_window = fetch_target_difficulty(db, &self.rules, block_header.pow_algo(), block_header.height)?;
-        let constants = self.rules.consensus_constants(block_header.height);
-        let target = difficulty_window.calculate(
-            constants.min_pow_difficulty(block_header.pow.pow_algo),
-            constants.max_pow_difficulty(block_header.pow.pow_algo),
-        );
-        let achieved_target = check_target_difficulty(block_header, target, &self.randomx_factory)?;
-
-        Ok(achieved_target)
+    pub fn new(rules: ConsensusManager) -> Self {
+        Self { rules }
     }
 
     /// This function tests that the block timestamp is greater than the median timestamp at the specified height.
@@ -75,13 +52,19 @@ impl HeaderValidator {
     }
 }
 
-impl<B: BlockchainBackend> HeaderValidation<B> for HeaderValidator {
+impl<TBackend: BlockchainBackend> HeaderValidation<TBackend> for HeaderValidator {
     /// The consensus checks that are done (in order of cheapest to verify to most expensive):
     /// 1. Is the block timestamp within the Future Time Limit (FTL)?
     /// 1. Is the Proof of Work valid?
     /// 1. Is the achieved difficulty of this block >= the target difficulty for this block?
 
-    fn validate(&self, backend: &B, header: &BlockHeader) -> Result<AchievedTargetDifficulty, ValidationError> {
+    fn validate(
+        &self,
+        backend: &TBackend,
+        header: &BlockHeader,
+        difficulty_calculator: &DifficultyCalculator,
+    ) -> Result<AchievedTargetDifficulty, ValidationError>
+    {
         check_timestamp_ftl(&header, &self.rules)?;
         let header_id = format!("header #{} ({})", header.height, header.hash().to_hex());
         trace!(
@@ -96,7 +79,7 @@ impl<B: BlockchainBackend> HeaderValidation<B> for HeaderValidator {
             header_id
         );
         check_pow_data(header, &self.rules, backend)?;
-        let achieved_target = self.check_achieved_and_target_difficulty(backend, header)?;
+        let achieved_target = difficulty_calculator.check_achieved_and_target_difficulty(backend, header)?;
 
         trace!(
             target: LOG_TARGET,

--- a/base_layer/core/src/validation/helpers.rs
+++ b/base_layer/core/src/validation/helpers.rs
@@ -171,8 +171,9 @@ pub fn check_target_difficulty(
         None => {
             warn!(
                 target: LOG_TARGET,
-                "Proof of work for {} was below the target difficulty. Achieved: {}, Target: {}",
+                "Proof of work for {} at height {} was below the target difficulty. Achieved: {}, Target: {}",
                 block_header.hash().to_hex(),
+                block_header.height,
                 achieved,
                 target
             );

--- a/base_layer/core/src/validation/mocks.rs
+++ b/base_layer/core/src/validation/mocks.rs
@@ -28,6 +28,7 @@ use crate::{
     validation::{
         error::ValidationError,
         CandidateBlockBodyValidation,
+        DifficultyCalculator,
         FinalHorizonStateValidation,
         HeaderValidation,
         MempoolTransactionValidation,
@@ -102,14 +103,19 @@ impl OrphanValidation for MockValidator {
 }
 
 impl<B: BlockchainBackend> HeaderValidation<B> for MockValidator {
-    fn validate(&self, _db: &B, header: &BlockHeader) -> Result<AchievedTargetDifficulty, ValidationError> {
+    fn validate(
+        &self,
+        _: &B,
+        header: &BlockHeader,
+        _: &DifficultyCalculator,
+    ) -> Result<AchievedTargetDifficulty, ValidationError>
+    {
         if self.is_valid.load(Ordering::SeqCst) {
             let achieved = sha3_difficulty(header);
 
             let achieved_target =
                 AchievedTargetDifficulty::try_construct(PowAlgorithm::Sha3, achieved - Difficulty::from(1), achieved)
                     .unwrap();
-
             Ok(achieved_target)
         } else {
             Err(ValidationError::custom_error(

--- a/base_layer/core/src/validation/test.rs
+++ b/base_layer/core/src/validation/test.rs
@@ -30,12 +30,13 @@ use crate::{
 #[test]
 fn header_iter_empty_and_invalid_height() {
     let consensus_manager = ConsensusManagerBuilder::new(Network::LocalNet).build();
-    let db = create_store_with_consensus(&consensus_manager);
+    let genesis = consensus_manager.get_genesis_block();
+    let db = create_store_with_consensus(consensus_manager);
 
     let iter = HeaderIter::new(&db, 0, 10);
     let headers = iter.map(Result::unwrap).collect::<Vec<_>>();
     assert_eq!(headers.len(), 1);
-    let genesis = consensus_manager.get_genesis_block();
+
     assert_eq!(genesis.header(), &headers[0]);
 
     // Invalid header height
@@ -47,7 +48,7 @@ fn header_iter_empty_and_invalid_height() {
 #[test]
 fn header_iter_fetch_in_chunks() {
     let consensus_manager = ConsensusManagerBuilder::new(Network::LocalNet).build();
-    let db = create_store_with_consensus(&consensus_manager);
+    let db = create_store_with_consensus(consensus_manager.clone());
     let headers = (1..=15).fold(vec![db.fetch_chain_header(0).unwrap()], |mut acc, i| {
         let prev = acc.last().unwrap();
         let mut header = BlockHeader::new(0);
@@ -57,7 +58,7 @@ fn header_iter_fetch_in_chunks() {
         header.kernel_mmr_size = 2 + i;
         header.output_mmr_size = 4001 + i;
 
-        let chain_header = create_chain_header(&*db.db_read_access().unwrap(), header, &prev.accumulated_data());
+        let chain_header = create_chain_header(header, &prev.accumulated_data());
         acc.push(chain_header);
         acc
     });

--- a/base_layer/core/src/validation/traits.rs
+++ b/base_layer/core/src/validation/traits.rs
@@ -25,7 +25,7 @@ use crate::{
     chain_storage::{BlockchainBackend, ChainBlock},
     proof_of_work::AchievedTargetDifficulty,
     transactions::{transaction::Transaction, types::Commitment},
-    validation::error::ValidationError,
+    validation::{error::ValidationError, DifficultyCalculator},
 };
 
 /// A validator that determines if a block body is valid, assuming that the header has already been
@@ -47,8 +47,13 @@ pub trait OrphanValidation: Send + Sync {
     fn validate(&self, item: &Block) -> Result<(), ValidationError>;
 }
 
-pub trait HeaderValidation<B: BlockchainBackend>: Send + Sync {
-    fn validate(&self, db: &B, header: &BlockHeader) -> Result<AchievedTargetDifficulty, ValidationError>;
+pub trait HeaderValidation<TBackend: BlockchainBackend>: Send + Sync {
+    fn validate(
+        &self,
+        db: &TBackend,
+        header: &BlockHeader,
+        difficulty: &DifficultyCalculator,
+    ) -> Result<AchievedTargetDifficulty, ValidationError>;
 }
 
 pub trait FinalHorizonStateValidation<B>: Send + Sync {

--- a/base_layer/core/tests/helpers/block_builders.rs
+++ b/base_layer/core/tests/helpers/block_builders.rs
@@ -35,7 +35,7 @@ use tari_core::{
         ChainStorageError,
     },
     consensus::{ConsensusConstants, ConsensusManager, ConsensusManagerBuilder, Network},
-    proof_of_work::{sha3_difficulty, Difficulty},
+    proof_of_work::{sha3_difficulty, AchievedTargetDifficulty, Difficulty},
     transactions::{
         helpers::{create_random_signature_from_s_key, create_signature, create_utxo, spend_utxos, TransactionSchema},
         tari_amount::MicroTari,
@@ -50,7 +50,6 @@ use tari_core::{
         },
         types::{Commitment, CryptoFactories, HashDigest, HashOutput, PublicKey},
     },
-    validation::{mocks::MockValidator, HeaderValidation},
 };
 use tari_crypto::{
     keys::PublicKey as PublicKeyTrait,
@@ -535,14 +534,13 @@ pub fn construct_chained_blocks<B: BlockchainBackend>(
 }
 
 #[allow(dead_code)]
-pub fn create_chain_header<B: BlockchainBackend>(
-    db: &B,
-    header: BlockHeader,
-    prev_accum: &BlockHeaderAccumulatedData,
-) -> ChainHeader
-{
-    let validator = MockValidator::new(true);
-    let achieved_target_diff = validator.validate(db, &header).unwrap();
+pub fn create_chain_header(header: BlockHeader, prev_accum: &BlockHeaderAccumulatedData) -> ChainHeader {
+    let achieved_target_diff = AchievedTargetDifficulty::try_construct(
+        header.pow_algo(),
+        prev_accum.target_difficulty,
+        prev_accum.achieved_difficulty,
+    )
+    .unwrap();
     let accumulated_data = BlockHeaderAccumulatedData::builder(prev_accum)
         .with_hash(header.hash())
         .with_achieved_target_difficulty(achieved_target_diff)

--- a/base_layer/core/tests/helpers/nodes.rs
+++ b/base_layer/core/tests/helpers/nodes.rs
@@ -202,7 +202,7 @@ impl BaseNodeBuilder {
         let consensus_manager = self
             .consensus_manager
             .unwrap_or_else(|| ConsensusManagerBuilder::new(network).build());
-        let blockchain_db = create_store_with_consensus_and_validators(&consensus_manager, validators);
+        let blockchain_db = create_store_with_consensus_and_validators(consensus_manager.clone(), validators);
         let mempool_validator = TxInputAndMaturityValidator::new(blockchain_db.clone());
         let mempool = Mempool::new(self.mempool_config.unwrap_or_default(), Arc::new(mempool_validator));
         let node_identity = self.node_identity.unwrap_or_else(|| random_node_identity());

--- a/base_layer/core/tests/helpers/sample_blockchains.rs
+++ b/base_layer/core/tests/helpers/sample_blockchains.rs
@@ -40,6 +40,7 @@ use tari_core::{
         types::CryptoFactories,
     },
     txn_schema,
+    validation::DifficultyCalculator,
 };
 use tari_storage::lmdb_store::LMDBConfig;
 // use crate::helpers::database::{TempDatabase, create_store_with_consensus};
@@ -151,7 +152,7 @@ pub fn create_new_blockchain(
         .build();
     // let db = create_lmdb_database(&consensus_manager);
     (
-        create_store_with_consensus(&consensus_manager),
+        create_store_with_consensus(consensus_manager.clone()),
         vec![block0],
         vec![vec![output]],
         consensus_manager,
@@ -183,6 +184,14 @@ pub fn create_new_blockchain_lmdb<P: AsRef<std::path::Path>>(
         .with_block(block0.clone())
         .build();
     let db = create_lmdb_database(path, LMDBConfig::default()).unwrap();
-    let db = BlockchainDatabase::new(db, &consensus_manager, validators, config, false).unwrap();
+    let db = BlockchainDatabase::new(
+        db,
+        consensus_manager.clone(),
+        validators,
+        config,
+        DifficultyCalculator::new(consensus_manager.clone(), Default::default()),
+        false,
+    )
+    .unwrap();
     (db, vec![block0], vec![vec![output]], consensus_manager)
 }

--- a/base_layer/core/tests/node_comms_interface.rs
+++ b/base_layer/core/tests/node_comms_interface.rs
@@ -392,7 +392,7 @@ async fn inbound_fetch_blocks_before_horizon_height() {
         pruning_interval: 1,
         ..Default::default()
     };
-    let store = create_store_with_consensus_and_validators_and_config(&consensus_manager, validators, config);
+    let store = create_store_with_consensus_and_validators_and_config(consensus_manager.clone(), validators, config);
     let mempool_validator = TxInputAndMaturityValidator::new(store.clone());
     let mempool = Mempool::new(MempoolConfig::default(), Arc::new(mempool_validator));
     let (block_event_sender, _) = broadcast::channel(50);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Change the target difficulty calculation to use the hash instead of height, and in turn searches the orphan chains as well as the main chain

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
To solve the target difficulty problems seen in Stibbons network

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Added tests to reproduce the problem

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch.
* [ ] I have squashed my commits into a single commit.
