### PR TITLE
[Bugfix] Correct file paths

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,12 +33,9 @@ report
 *.mdb
 /data/
 *.sqlite3
-base_layer/wallet_ffi/build.config
+/base_layer/wallet_ffi/build.config
 /base_layer/wallet_ffi/logs/
-base_layer/wallet_ffi/.cargo/config
-/config
-/stibbons
-/wallet
+/base_layer/wallet_ffi/.cargo/config
 keys.json
 node_modules
 /integration_tests/temp

--- a/applications/tari_app_utilities/src/initialization.rs
+++ b/applications/tari_app_utilities/src/initialization.rs
@@ -1,7 +1,7 @@
 use crate::utilities::ExitCodes;
 use config::Config;
 use structopt::StructOpt;
-use tari_common::{configuration::bootstrap::ApplicationType, ConfigBootstrap, GlobalConfig};
+use tari_common::{configuration::bootstrap::ApplicationType, ConfigBootstrap, DatabaseType, GlobalConfig};
 
 pub const LOG_TARGET: &str = "tari::application";
 
@@ -21,7 +21,72 @@ pub fn init_configuration(
     bootstrap.initialize_logging()?;
 
     // Populate the configuration struct
-    let global_config =
+    let mut global_config =
         GlobalConfig::convert_from(cfg.clone()).map_err(|err| ExitCodes::ConfigError(err.to_string()))?;
+    check_file_paths(&mut global_config, &bootstrap);
     Ok((bootstrap, global_config, cfg))
+}
+
+fn check_file_paths(config: &mut GlobalConfig, bootstrap: &ConfigBootstrap) {
+    let prepend = bootstrap.base_path.clone();
+    if !config.data_dir.is_absolute() {
+        let mut path = prepend.clone();
+        path.push(config.data_dir.clone());
+        config.data_dir = path;
+        if let DatabaseType::LMDB(_) = config.db_type {
+            config.db_type = DatabaseType::LMDB(config.data_dir.join("db"));
+        }
+    }
+    if !config.peer_db_path.is_absolute() {
+        let mut path = prepend.clone();
+        path.push(config.peer_db_path.clone());
+        config.peer_db_path = path;
+    }
+    if !config.base_node_identity_file.is_absolute() {
+        let mut path = prepend.clone();
+        path.push(config.base_node_identity_file.clone());
+        config.base_node_identity_file = path;
+    }
+    if !config.base_node_tor_identity_file.is_absolute() {
+        let mut path = prepend.clone();
+        path.push(config.base_node_tor_identity_file.clone());
+        config.base_node_tor_identity_file = path;
+    }
+    if !config.console_wallet_db_file.is_absolute() {
+        let mut path = prepend.clone();
+        path.push(config.console_wallet_db_file.clone());
+        config.console_wallet_db_file = path;
+    }
+    if !config.console_wallet_peer_db_path.is_absolute() {
+        let mut path = prepend.clone();
+        path.push(config.console_wallet_peer_db_path.clone());
+        config.console_wallet_peer_db_path = path;
+    }
+    if !config.console_wallet_identity_file.is_absolute() {
+        let mut path = prepend.clone();
+        path.push(config.console_wallet_identity_file.clone());
+        config.console_wallet_identity_file = path;
+    }
+    if !config.console_wallet_tor_identity_file.is_absolute() {
+        let mut path = prepend.clone();
+        path.push(config.console_wallet_tor_identity_file.clone());
+        config.console_wallet_tor_identity_file = path;
+    }
+    if !config.wallet_db_file.is_absolute() {
+        let mut path = prepend.clone();
+        path.push(config.wallet_db_file.clone());
+        config.wallet_db_file = path;
+    }
+    if !config.wallet_peer_db_path.is_absolute() {
+        let mut path = prepend.clone();
+        path.push(config.wallet_db_file.clone());
+        config.wallet_db_file = path;
+    }
+    if let Some(file_path) = config.console_wallet_notify_file.clone() {
+        if file_path.is_absolute() {
+            let mut path = prepend;
+            path.push(file_path);
+            config.console_wallet_notify_file = Some(path);
+        }
+    }
 }

--- a/applications/tari_base_node/src/main.rs
+++ b/applications/tari_base_node/src/main.rs
@@ -123,10 +123,10 @@ pub const LOG_TARGET: &str = "base_node::app";
 /// Application entry point
 fn main() {
     if let Err(exit_code) = main_inner() {
-        eprintln!("{}", exit_code);
+        eprintln!("{:?}", exit_code);
         error!(
             target: LOG_TARGET,
-            "Exiting with code ({}): {}",
+            "Exiting with code ({}): {:?}",
             exit_code.as_i32(),
             exit_code
         );

--- a/applications/tari_console_wallet/src/main.rs
+++ b/applications/tari_console_wallet/src/main.rs
@@ -43,10 +43,10 @@ fn main() {
     match main_inner() {
         Ok(_) => process::exit(0),
         Err(exit_code) => {
-            eprintln!("{}", exit_code);
+            eprintln!("{:?}", exit_code);
             error!(
                 target: LOG_TARGET,
-                "Exiting with code ({}): {}",
+                "Exiting with code ({}): {:?}",
                 exit_code.as_i32(),
                 exit_code
             );

--- a/common/config/presets/tari_config_example.toml
+++ b/common/config/presets/tari_config_example.toml
@@ -263,10 +263,10 @@ grpc_base_node_address = "127.0.0.1:18142"
 grpc_console_wallet_address = "127.0.0.1:18143"
 
 # A path to the file that stores your node identity and secret key
-base_node_identity_file = "./config/base_node_id.json"
+base_node_identity_file = "config/base_node_id.json"
 
 # A path to the file that stores your console wallet's node identity and secret key
-console_wallet_identity_file = "./config/console_wallet_id.json"
+console_wallet_identity_file = "config/console_wallet_id.json"
 
 # -------------- Transport configuration --------------
 # Use TCP to connect to the Tari network. This transport can only communicate with TCP/IP addresses, so peers with
@@ -304,10 +304,10 @@ tor_control_auth = "none" # or "password=xxxxxx"
 #socks5_auth = "none" # or "username_password=username:xxxxxxx"
 
 # A path to the file that stores the tor hidden service private key, if using the tor transport.
-base_node_tor_identity_file = "./config/base_node_tor.json"
+base_node_tor_identity_file = "config/base_node_tor.json"
 
 # A path to the file that stores the console wallet's tor hidden service private key, if using the tor transport.
-console_wallet_tor_identity_file = "./config/cosole_wallet_tor.json"
+console_wallet_tor_identity_file = "config/cosole_wallet_tor.json"
 
 ########################################################################################################################
 #                                                                                                                      #

--- a/common/src/dir_utils.rs
+++ b/common/src/dir_utils.rs
@@ -47,9 +47,12 @@ pub fn default_subdir(path: &str, base_dir: Option<&PathBuf>) -> String {
 
 pub fn default_path(filename: &str, base_path: Option<&PathBuf>) -> PathBuf {
     let mut home = base_path.cloned().unwrap_or_else(|| {
-        let mut home = dirs_next::home_dir().unwrap_or_else(|| PathBuf::from("."));
-        home.push(".tari");
-        home
+        [
+            dirs_next::home_dir().unwrap_or_else(|| PathBuf::from(".")),
+            PathBuf::from(".tari"),
+        ]
+        .iter()
+        .collect()
     });
     home.push(filename);
     home


### PR DESCRIPTION
## Description
Correct file paths in GlobalConfig to use base_path from ConfigBootstrap instead of using current directory for relative paths in the config file.
Update gitignore

## Motivation and Context
Fixes a bug where the base_path (either default or passed in as an argument) is overwritten and instead of the paths being relative to the base_path it is relative to the current executing directory. 

## How Has This Been Tested?
```
cargo run --bin tari_base_node -- --init --create_id
cargo run --bin tari_base_node 
cargo run --bin tari_base_node -- --init --create_id --base_path=$PWD/temp
cargo run --bin tari_base_node -- --base_path=$PWD/temp
cargo run --bin tari_console_wallet -- --init --create_id 
cargo run --bin tari_console_wallet
cargo run --bin tari_console_wallet  -- --init --create_id --base_path=$PWD/temp
cargo run --bin tari_console_wallet -- --base_path=$PWD/temp
cargo run --bin tari_merge_mining_proxy
cargo run --bin tari_merge_mining_proxy -- --base_path=$PWD/temp
cargo test --all
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch.
* [x] I have squashed my commits into a single commit.
