### PR TITLE
[base-node] Create new orphan chain tip on chain reorg

### DIFF
--- a/base_layer/core/src/chain_storage/blockchain_backend.rs
+++ b/base_layer/core/src/chain_storage/blockchain_backend.rs
@@ -22,25 +22,25 @@ use croaring::Bitmap;
 use tari_common_types::chain_metadata::ChainMetadata;
 use tari_mmr::Hash;
 
-/// Identify behaviour for Blockchain database back ends. Implementations must support `Send` and `Sync` so that
+/// Identify behaviour for Blockchain database backends. Implementations must support `Send` and `Sync` so that
 /// `BlockchainDatabase` can be thread-safe. The backend *must* also execute transactions atomically; i.e., every
 /// operation within it must succeed, or they all fail. Failure to support this contract could lead to
 /// synchronisation issues in your database backend.
 ///
 /// Data is passed to and from the backend via the [DbKey], [DbValue], and [DbValueKey] enums. This strategy allows
-/// us to keep the reading and writing API extremely simple. Extending the types of data that the back ends can handle
-/// will entail adding to those enums, and the back ends, while this trait can remain unchanged.
+/// us to keep the reading and writing API extremely simple. Extending the types of data that the backends can handle
+/// will entail adding to those enums, and the backends, while this trait can remain unchanged.
 #[allow(clippy::ptr_arg)]
 pub trait BlockchainBackend: Send + Sync {
     /// Commit the transaction given to the backend. If there is an error, the transaction must be rolled back, and
     /// the error condition returned. On success, every operation in the transaction will have been committed, and
     /// the function will return `Ok(())`.
     fn write(&mut self, tx: DbTransaction) -> Result<(), ChainStorageError>;
-    /// Fetch a value from the back end corresponding to the given key. If the value is not found, `get` must return
-    /// `Ok(None)`. It should only error if there is an access or integrity issue with the underlying back end.
+    /// Fetch a value from the backend corresponding to the given key. If the value is not found, `get` must return
+    /// `Ok(None)`. It should only error if there is an access or integrity issue with the underlying backend.
     fn fetch(&self, key: &DbKey) -> Result<Option<DbValue>, ChainStorageError>;
-    /// Checks to see whether the given key exists in the back end. This function should only fail if there is an
-    /// access or integrity issue with the back end.
+    /// Checks to see whether the given key exists in the backend. This function should only fail if there is an
+    /// access or integrity issue with the backend.
     fn contains(&self, key: &DbKey) -> Result<bool, ChainStorageError>;
 
     /// Fetches data that is calculated and accumulated for blocks that have been
@@ -129,7 +129,7 @@ pub trait BlockchainBackend: Send + Sync {
     /// Returns the kernel count
     fn kernel_count(&self) -> Result<usize, ChainStorageError>;
 
-    /// Fetches an current tip orphan by hash or returns None if the prohan is not found or is not a tip of any
+    /// Fetches an current tip orphan by hash or returns None if the orphan is not found or is not a tip of any
     /// alternate chain
     fn fetch_orphan_chain_tip_by_hash(&self, hash: &HashOutput) -> Result<Option<ChainHeader>, ChainStorageError>;
     /// Fetch all orphans that have `hash` as a previous hash

--- a/base_layer/core/src/mempool/sync_protocol/mod.rs
+++ b/base_layer/core/src/mempool/sync_protocol/mod.rs
@@ -44,10 +44,10 @@
 //!  +-------+                    +-----+
 //!  |                                |
 //!  | Txn Inventory                  |
-//!  |------------------------------->|   
+//!  |------------------------------->|
 //!  |                                |
 //!  |      TransactionItem(tx_b1)    |
-//!  |<-------------------------------|    
+//!  |<-------------------------------|
 //!  |             ...streaming...    |
 //!  |      TransactionItem(empty)    |
 //!  |<-------------------------------|
@@ -55,7 +55,7 @@
 //!  |<-------------------------------|
 //!  |                                |
 //!  | TransactionItem(tx_a1)         |
-//!  |------------------------------->|    
+//!  |------------------------------->|
 //!  |             ...streaming...    |
 //!  | TransactionItem(empty)         |
 //!  |------------------------------->|
@@ -147,7 +147,7 @@ where TSubstream: AsyncRead + AsyncWrite + Unpin + Send + Sync + 'static
             if (*status_watch.borrow()).bootstrapped {
                 break;
             }
-            debug!(
+            trace!(
                 target: LOG_TARGET,
                 "Mempool sync still on hold, waiting for bootstrap to finish",
             );


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Updates the `handle_possible_reorg` function to insert a new orphan chain tip from the removed blocks, and a test to check this logic. Some minor typos and comments updated.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
On reorgs where blocks were removed, the new orphan chain tip was not added to the database. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
New unit test that was failing before the fix.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch.
* [x] I have squashed my commits into a single commit.
