### PR TITLE
[Bugfix] Fixes path separators

### DIFF
--- a/applications/tari_app_utilities/src/initialization.rs
+++ b/applications/tari_app_utilities/src/initialization.rs
@@ -1,5 +1,6 @@
 use crate::utilities::ExitCodes;
 use config::Config;
+use std::path::PathBuf;
 use structopt::StructOpt;
 use tari_common::{configuration::bootstrap::ApplicationType, ConfigBootstrap, DatabaseType, GlobalConfig};
 
@@ -30,63 +31,55 @@ pub fn init_configuration(
 fn check_file_paths(config: &mut GlobalConfig, bootstrap: &ConfigBootstrap) {
     let prepend = bootstrap.base_path.clone();
     if !config.data_dir.is_absolute() {
-        let mut path = prepend.clone();
-        path.push(config.data_dir.clone());
-        config.data_dir = path;
+        config.data_dir = concatenate_paths_normalized(prepend.clone(), config.data_dir.clone());
         if let DatabaseType::LMDB(_) = config.db_type {
             config.db_type = DatabaseType::LMDB(config.data_dir.join("db"));
         }
     }
     if !config.peer_db_path.is_absolute() {
-        let mut path = prepend.clone();
-        path.push(config.peer_db_path.clone());
-        config.peer_db_path = path;
+        config.peer_db_path = concatenate_paths_normalized(prepend.clone(), config.peer_db_path.clone());
     }
     if !config.base_node_identity_file.is_absolute() {
-        let mut path = prepend.clone();
-        path.push(config.base_node_identity_file.clone());
-        config.base_node_identity_file = path;
+        config.base_node_identity_file =
+            concatenate_paths_normalized(prepend.clone(), config.base_node_identity_file.clone());
     }
     if !config.base_node_tor_identity_file.is_absolute() {
-        let mut path = prepend.clone();
-        path.push(config.base_node_tor_identity_file.clone());
-        config.base_node_tor_identity_file = path;
+        config.base_node_tor_identity_file =
+            concatenate_paths_normalized(prepend.clone(), config.base_node_tor_identity_file.clone());
     }
     if !config.console_wallet_db_file.is_absolute() {
-        let mut path = prepend.clone();
-        path.push(config.console_wallet_db_file.clone());
-        config.console_wallet_db_file = path;
+        config.console_wallet_db_file =
+            concatenate_paths_normalized(prepend.clone(), config.console_wallet_db_file.clone());
     }
     if !config.console_wallet_peer_db_path.is_absolute() {
-        let mut path = prepend.clone();
-        path.push(config.console_wallet_peer_db_path.clone());
-        config.console_wallet_peer_db_path = path;
+        config.console_wallet_peer_db_path =
+            concatenate_paths_normalized(prepend.clone(), config.console_wallet_peer_db_path.clone());
     }
     if !config.console_wallet_identity_file.is_absolute() {
-        let mut path = prepend.clone();
-        path.push(config.console_wallet_identity_file.clone());
-        config.console_wallet_identity_file = path;
+        config.console_wallet_identity_file =
+            concatenate_paths_normalized(prepend.clone(), config.console_wallet_identity_file.clone());
     }
     if !config.console_wallet_tor_identity_file.is_absolute() {
-        let mut path = prepend.clone();
-        path.push(config.console_wallet_tor_identity_file.clone());
-        config.console_wallet_tor_identity_file = path;
+        config.console_wallet_tor_identity_file =
+            concatenate_paths_normalized(prepend.clone(), config.console_wallet_tor_identity_file.clone());
     }
     if !config.wallet_db_file.is_absolute() {
-        let mut path = prepend.clone();
-        path.push(config.wallet_db_file.clone());
-        config.wallet_db_file = path;
+        config.wallet_db_file = concatenate_paths_normalized(prepend.clone(), config.wallet_db_file.clone());
     }
     if !config.wallet_peer_db_path.is_absolute() {
-        let mut path = prepend.clone();
-        path.push(config.wallet_db_file.clone());
-        config.wallet_db_file = path;
+        config.wallet_peer_db_path = concatenate_paths_normalized(prepend.clone(), config.wallet_peer_db_path.clone());
     }
     if let Some(file_path) = config.console_wallet_notify_file.clone() {
         if file_path.is_absolute() {
-            let mut path = prepend;
-            path.push(file_path);
-            config.console_wallet_notify_file = Some(path);
+            config.console_wallet_notify_file = Some(concatenate_paths_normalized(prepend, file_path));
         }
     }
+}
+
+fn concatenate_paths_normalized(prepend: PathBuf, extension_path: PathBuf) -> PathBuf {
+    let mut result = prepend;
+    for component in extension_path.components() {
+        result.push(component);
+    }
+    result
 }

--- a/common/src/configuration/bootstrap.rs
+++ b/common/src/configuration/bootstrap.rs
@@ -140,12 +140,20 @@ pub struct ConfigBootstrap {
     pub miner_max_diff: Option<u64>,
 }
 
+fn normalize_path(path: PathBuf) -> PathBuf {
+    let mut result = PathBuf::new();
+    for component in path.components() {
+        result.push(component);
+    }
+    result
+}
+
 impl Default for ConfigBootstrap {
     fn default() -> Self {
         ConfigBootstrap {
-            base_path: dir_utils::default_path("", None),
-            config: dir_utils::default_path(DEFAULT_CONFIG, None),
-            log_config: dir_utils::default_path(DEFAULT_BASE_NODE_LOG_CONFIG, None),
+            base_path: normalize_path(dir_utils::default_path("", None)),
+            config: normalize_path(dir_utils::default_path(DEFAULT_CONFIG, None)),
+            log_config: normalize_path(dir_utils::default_path(DEFAULT_BASE_NODE_LOG_CONFIG, None)),
             init: false,
             create_id: false,
             daemon_mode: false,
@@ -190,23 +198,34 @@ impl ConfigBootstrap {
         })?;
 
         if self.config.to_str() == Some("") {
-            self.config = dir_utils::default_path(DEFAULT_CONFIG, Some(&self.base_path));
+            self.config = normalize_path(dir_utils::default_path(DEFAULT_CONFIG, Some(&self.base_path)));
         }
 
         if self.log_config.to_str() == Some("") {
             match application_type {
                 ApplicationType::BaseNode => {
-                    self.log_config = dir_utils::default_path(DEFAULT_BASE_NODE_LOG_CONFIG, Some(&self.base_path));
+                    self.log_config = normalize_path(dir_utils::default_path(
+                        DEFAULT_BASE_NODE_LOG_CONFIG,
+                        Some(&self.base_path),
+                    ));
                 },
                 ApplicationType::ConsoleWallet => {
-                    self.log_config = dir_utils::default_path(DEFAULT_WALLET_LOG_CONFIG, Some(&self.base_path));
+                    self.log_config = normalize_path(dir_utils::default_path(
+                        DEFAULT_WALLET_LOG_CONFIG,
+                        Some(&self.base_path),
+                    ));
                 },
                 ApplicationType::MergeMiningProxy => {
-                    self.log_config =
-                        dir_utils::default_path(DEFAULT_MERGE_MINING_PROXY_LOG_CONFIG, Some(&self.base_path))
+                    self.log_config = normalize_path(dir_utils::default_path(
+                        DEFAULT_MERGE_MINING_PROXY_LOG_CONFIG,
+                        Some(&self.base_path),
+                    ))
                 },
                 ApplicationType::MiningNode => {
-                    self.log_config = dir_utils::default_path(DEFAULT_MINING_NODE_LOG_CONFIG, Some(&self.base_path))
+                    self.log_config = normalize_path(dir_utils::default_path(
+                        DEFAULT_MINING_NODE_LOG_CONFIG,
+                        Some(&self.base_path),
+                    ))
                 },
             }
         }


### PR DESCRIPTION
## Description
Fixes problems with UNIX path separators in Windows

## Motivation and Context
Paths are stored with UNIX path separators in some constant variables for bootstrap.
Relative paths in configuration file have UNIX paths separators. 

## How Has This Been Tested?
Manually tested on Windows and Mac

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch.
* [x] I have squashed my commits into a single commit.
