### PR TITLE
Add note to run Tor service to "Building from source" section.

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ https://visualstudio.microsoft.com/thank-you-downloading-visual-studio/?sku=Buil
     ```
 
 - Tor
-  - Donwload [Tor Windows Expert Bundle](https://www.torproject.org/download/tor/)
+  - Download [Tor Windows Expert Bundle](https://www.torproject.org/download/tor/)
   - Extract to local path, e.g. `C:\Program Files (x86)\Tor Services`
   - Ensure the directory containing the Tor executable, e.g. `C:\Program Files (x86)\Tor Services\Tor`, is in the path
 
@@ -259,7 +259,10 @@ anywhere on your system.
 The executables will either be inside your `~/tari/target/release` (on Linux) or `%USERPROFILE%\Code\tari\target\release`
 (on Windows) directory, or alternatively, inside your `~/.cargo/bin` (on Linux) `%USERPROFILE%\.cargo\bin` (on Windows)
 directory, depending on the build choice above, and must be run from the command line. If the former build method was
-used, you can run it from that directory, or you more likely want to copy it somewhere more convenient.
+used, you can run it from that directory, or you more likely want to copy it somewhere more convenient. Make sure to 
+start Tor service `~/tari/applications/tari_base_node/osx/start_tor` (on Mac),
+`~/tari/applications/tari_base_node/ubuntu/start_tor` (on Linux) or
+`%USERPROFILE%\Code\tari\applications\tari_base_node\windows\start_tor.lnk` (on Windows).
 
 To run from any directory of your choice, where the executable is visible in the path (first time use):
 


### PR DESCRIPTION
Added a note to run the Tor service, because it was not mentioned in the "Building from source" section.
Also fixed a typo.