### PR TITLE
Fix cucumber error introduced by full script in transaction output

### DIFF
--- a/integration_tests/helpers/transactionBuilder.js
+++ b/integration_tests/helpers/transactionBuilder.js
@@ -64,7 +64,7 @@ class TransactionBuilder {
   }
 
   addInput(input) {
-    let nop_script_bytes = Buffer.from([0x73]);
+    let nopScriptBytes = Buffer.from([0x73]);
     let scriptPublicKey = tari_crypto.pubkey_from_secret(
       input.scriptPrivateKey.toString("hex")
     );
@@ -77,7 +77,7 @@ class TransactionBuilder {
     let public_nonce = this.kv.public_key("common_nonce");
     let challenge = this.buildScriptChallenge(
       public_nonce,
-      nop_script_bytes,
+      nopScriptBytes,
       input_data,
       0
     );
@@ -92,7 +92,7 @@ class TransactionBuilder {
       input: {
         features: input.output.features,
         commitment: input.output.commitment,
-        script: nop_script_bytes,
+        script: nopScriptBytes,
         input_data: input_data,
         height: 0,
         script_signature: {
@@ -125,9 +125,10 @@ class TransactionBuilder {
     let scriptOffsetPublicKey = tari_crypto.pubkey_from_secret(
       scriptOffsetPrivateKey.toString("hex")
     );
+    let nopScriptBytes = Buffer.from([0x73]);
 
     let beta = calculateBeta(
-      nopScriptHash,
+      nopScriptBytes,
       outputFeatures,
       scriptOffsetPublicKey
     );
@@ -140,7 +141,6 @@ class TransactionBuilder {
       new_range_proof_key,
       BigInt(amount)
     ).proof;
-    let nop_script_bytes = Buffer.from([0x73]);
 
     let output = {
       amount: amount,
@@ -154,7 +154,7 @@ class TransactionBuilder {
           "hex"
         ),
         range_proof: Buffer.from(rangeproof, "hex"),
-        script: nop_script_bytes,
+        script: nopScriptBytes,
         script_offset_public_key: Buffer.from(scriptOffsetPublicKey, "hex"),
       },
     };
@@ -242,8 +242,7 @@ class TransactionBuilder {
 
   generateCoinbase(value, privateKey, fee, lockHeight) {
     let coinbase = tari_crypto.commit(privateKey, BigInt(value + fee));
-    let nopScriptHash =
-      "2682c826cae74c92c0620c9ab73c7e577a37870b4ce42465a4e63b58ee4d2408";
+    let nopScriptBytes = Buffer.from([0x73]);
     let outputFeatures = {
       flags: 1,
       maturity: lockHeight,
@@ -253,7 +252,7 @@ class TransactionBuilder {
       "hex"
     );
     let beta = calculateBeta(
-      nopScriptHash,
+      nopScriptBytes,
       outputFeatures,
       scriptOffsetPublicKey
     );
@@ -284,7 +283,7 @@ class TransactionBuilder {
           features: outputFeatures,
           commitment: Buffer.from(coinbase.commitment, "hex"),
           range_proof: Buffer.from(rangeproof, "hex"),
-          script_hash: Buffer.from(nopScriptHash, "hex"),
+          script: nopScriptBytes,
           script_offset_public_key: scriptOffsetPublicKey,
         },
       ],

--- a/integration_tests/helpers/util.js
+++ b/integration_tests/helpers/util.js
@@ -152,17 +152,17 @@ const getTransactionOutputHash = function (output) {
     flags,
     toLittleEndian(parseInt(output.features.maturity), 64),
   ]);
-  let nop_script_hash =
-    "2682c826cae74c92c0620c9ab73c7e577a37870b4ce42465a4e63b58ee4d2408";
+  let nopScriptBytes = Buffer.from([0x73]);
+
   blake2bUpdate(context, buffer);
   blake2bUpdate(context, output.commitment);
-  blake2bUpdate(context, Buffer.from(nop_script_hash, "hex"));
+  blake2bUpdate(context, nopScriptBytes);
   blake2bUpdate(context, output.script_offset_public_key);
   let final = blake2bFinal(context);
   return Buffer.from(final);
 };
 
-function calculateBeta(script_hash, features, script_offset_public_key) {
+function calculateBeta(script, features, script_offset_public_key) {
   let KEY = null; // optional key
   let OUTPUT_LENGTH = 32; // bytes
   let context = blake2bInit(OUTPUT_LENGTH, KEY);
@@ -173,7 +173,7 @@ function calculateBeta(script_hash, features, script_offset_public_key) {
     toLittleEndian(parseInt(features.maturity), 64),
   ]);
 
-  blake2bUpdate(context, Buffer.from(script_hash, "hex"));
+  blake2bUpdate(context, Buffer.from(script, "hex"));
   blake2bUpdate(context, features_buffer);
   blake2bUpdate(context, Buffer.from(script_offset_public_key, "hex"));
   let final = blake2bFinal(context);

--- a/integration_tests/package-lock.json
+++ b/integration_tests/package-lock.json
@@ -5,7 +5,6 @@
   "requires": true,
   "packages": {
     "": {
-      "name": "integration_tests",
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
@@ -237,9 +236,9 @@
       "integrity": "sha512-5tXH6Bx/kNGd3MgffdmP4dy2Z+G4eaXw0SE81Tq3BNadtnMR5/ySMzX4SLEzHJzSmPNn4HIdpQsBvXMUykr58w=="
     },
     "node_modules/@types/node": {
-      "version": "15.6.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-15.6.0.tgz",
-      "integrity": "sha512-gCYSfQpy+LYhOFTKAeE8BkyGqaxmlFxe+n4DKM6DR0wzw/HISUE/hAmkC/KT8Sw5PCJblqg062b3z9gucv3k0A=="
+      "version": "15.6.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-15.6.1.tgz",
+      "integrity": "sha512-7EIraBEyRHEe7CH+Fm1XvgqU6uwZN8Q7jppJGcqjROMT29qhAuuOxYB1uEY5UMYQKEmA5D+5tBnhdaPXSsLONA=="
     },
     "node_modules/abbrev": {
       "version": "1.1.1",
@@ -790,23 +789,10 @@
       "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
       "dev": true
     },
-    "node_modules/contains-path": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/contains-path/-/contains-path-1.0.0.tgz",
-      "integrity": "sha1-NFizMhhWA+ju0Y9RjUoQiIo6vJE=",
-      "dev": true,
-      "dependencies": {
-        "normalize-path": "^2.1.1",
-        "path-starts-with": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/core-js-pure": {
-      "version": "3.12.1",
-      "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.12.1.tgz",
-      "integrity": "sha512-1cch+qads4JnDSWsvc7d6nzlKAippwjUlf6vykkTLW53VSV+NkE6muGBToAjEA8pG90cSfcud3JgVmW2ds5TaQ==",
+      "version": "3.13.1",
+      "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.13.1.tgz",
+      "integrity": "sha512-wVlh0IAi2t1iOEh16y4u1TRk6ubd4KvLE8dlMi+3QUI6SfKphQUh7tAwihGGSQ8affxEXpVIPpOdf9kjR4v4Pw==",
       "dev": true,
       "hasInstallScript": true,
       "funding": {
@@ -1096,9 +1082,9 @@
       }
     },
     "node_modules/es-abstract": {
-      "version": "1.18.0",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.0.tgz",
-      "integrity": "sha512-LJzK7MrQa8TS0ja2w3YNLzUgJCGPdPOV1yVvezjNnS89D+VR08+Szt2mz3YB2Dck/+w5tfIq/RoUAFqJJGM2yw==",
+      "version": "1.18.3",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.3.tgz",
+      "integrity": "sha512-nQIr12dxV7SSxE6r6f1l3DtAeEYdsGpps13dR0TwJg1S8gyp4ZPgy3FZcHBgbiQqnoqSTb+oC+kO4UQ0C/J8vw==",
       "dev": true,
       "dependencies": {
         "call-bind": "^1.0.2",
@@ -1109,14 +1095,14 @@
         "has-symbols": "^1.0.2",
         "is-callable": "^1.2.3",
         "is-negative-zero": "^2.0.1",
-        "is-regex": "^1.1.2",
-        "is-string": "^1.0.5",
-        "object-inspect": "^1.9.0",
+        "is-regex": "^1.1.3",
+        "is-string": "^1.0.6",
+        "object-inspect": "^1.10.3",
         "object-keys": "^1.1.1",
         "object.assign": "^4.1.2",
         "string.prototype.trimend": "^1.0.4",
         "string.prototype.trimstart": "^1.0.4",
-        "unbox-primitive": "^1.0.0"
+        "unbox-primitive": "^1.0.1"
       },
       "engines": {
         "node": ">= 0.4"
@@ -1184,9 +1170,9 @@
       }
     },
     "node_modules/eslint": {
-      "version": "7.26.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-7.26.0.tgz",
-      "integrity": "sha512-4R1ieRf52/izcZE7AlLy56uIHHDLT74Yzz2Iv2l6kDaYvEu9x+wMB5dZArVL8SYGXSYV2YAg70FcW5Y5nGGNIg==",
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-7.27.0.tgz",
+      "integrity": "sha512-JZuR6La2ZF0UD384lcbnd0Cgg6QJjiCwhMD6eU4h/VGPcVGwawNNzKU41tgokGXnfjOOyI6QIffthhJTPzzuRA==",
       "dev": true,
       "dependencies": {
         "@babel/code-frame": "7.12.11",
@@ -1197,12 +1183,14 @@
         "debug": "^4.0.1",
         "doctrine": "^3.0.0",
         "enquirer": "^2.3.5",
+        "escape-string-regexp": "^4.0.0",
         "eslint-scope": "^5.1.1",
         "eslint-utils": "^2.1.0",
         "eslint-visitor-keys": "^2.0.0",
         "espree": "^7.3.1",
         "esquery": "^1.4.0",
         "esutils": "^2.0.2",
+        "fast-deep-equal": "^3.1.3",
         "file-entry-cache": "^6.0.1",
         "functional-red-black-tree": "^1.0.1",
         "glob-parent": "^5.0.0",
@@ -1214,7 +1202,7 @@
         "js-yaml": "^3.13.1",
         "json-stable-stringify-without-jsonify": "^1.0.1",
         "levn": "^0.4.1",
-        "lodash": "^4.17.21",
+        "lodash.merge": "^4.6.2",
         "minimatch": "^3.0.4",
         "natural-compare": "^1.4.0",
         "optionator": "^0.9.1",
@@ -1223,7 +1211,7 @@
         "semver": "^7.2.1",
         "strip-ansi": "^6.0.0",
         "strip-json-comments": "^3.1.0",
-        "table": "^6.0.4",
+        "table": "^6.0.9",
         "text-table": "^0.2.0",
         "v8-compile-cache": "^2.0.3"
       },
@@ -1250,9 +1238,9 @@
       }
     },
     "node_modules/eslint-config-standard": {
-      "version": "16.0.2",
-      "resolved": "https://registry.npmjs.org/eslint-config-standard/-/eslint-config-standard-16.0.2.tgz",
-      "integrity": "sha512-fx3f1rJDsl9bY7qzyX8SAtP8GBSk6MfXFaTfaGgk12aAYW4gJSyRm7dM790L6cbXv63fvjY4XeSzXnb4WM+SKw==",
+      "version": "16.0.3",
+      "resolved": "https://registry.npmjs.org/eslint-config-standard/-/eslint-config-standard-16.0.3.tgz",
+      "integrity": "sha512-x4fmJL5hGqNJKGHSjnLdgA6U6h1YW/G2dW9fA+cyVur4SK6lyue8+UgNKWlZtUDTXvgKDD/Oa3GQjmB5kjtVvg==",
       "dev": true,
       "funding": [
         {
@@ -1272,7 +1260,7 @@
         "eslint": "^7.12.1",
         "eslint-plugin-import": "^2.22.1",
         "eslint-plugin-node": "^11.1.0",
-        "eslint-plugin-promise": "^4.2.1"
+        "eslint-plugin-promise": "^4.2.1 || ^5.0.0"
       }
     },
     "node_modules/eslint-import-resolver-node": {
@@ -1342,14 +1330,13 @@
       }
     },
     "node_modules/eslint-plugin-import": {
-      "version": "2.23.2",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.23.2.tgz",
-      "integrity": "sha512-LmNoRptHBxOP+nb0PIKz1y6OSzCJlB+0g0IGS3XV4KaKk2q4szqQ6s6F1utVf5ZRkxk/QOTjdxe7v4VjS99Bsg==",
+      "version": "2.23.4",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.23.4.tgz",
+      "integrity": "sha512-6/wP8zZRsnQFiR3iaPFgh5ImVRM1WN5NUWfTIRqwOdeiGJlBcSk82o1FEVq8yXmy4lkIzTo7YhHCIxlU/2HyEQ==",
       "dev": true,
       "dependencies": {
         "array-includes": "^3.1.3",
         "array.prototype.flat": "^1.2.4",
-        "contains-path": "^1.0.0",
         "debug": "^2.6.9",
         "doctrine": "^2.1.0",
         "eslint-import-resolver-node": "^0.3.4",
@@ -1560,6 +1547,18 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true
+    },
+    "node_modules/eslint/node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/eslint/node_modules/has-flag": {
       "version": "4.0.0",
@@ -2007,9 +2006,9 @@
       }
     },
     "node_modules/globals": {
-      "version": "13.8.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-13.8.0.tgz",
-      "integrity": "sha512-rHtdA6+PDBIjeEvA91rpqzEvk/k3/i7EeNQiryiWuJH0Hw9cpyJMAt2jtbAwUaRdhD+573X4vWw6IcjKPasi9Q==",
+      "version": "13.9.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-13.9.0.tgz",
+      "integrity": "sha512-74/FduwI/JaIrr1H8e71UbDE+5x7pIPs1C2rrwC52SszOo043CsWOZEMW7o2Y58xwm9b+0RBKDxY5n2sUpEFxA==",
       "dev": true,
       "dependencies": {
         "type-fest": "^0.20.2"
@@ -2621,6 +2620,12 @@
       "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8=",
       "dev": true
     },
+    "node_modules/lodash.merge": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
+      "dev": true
+    },
     "node_modules/lodash.toarray": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/lodash.toarray/-/lodash.toarray-4.4.0.tgz",
@@ -2838,18 +2843,6 @@
         "semver": "bin/semver"
       }
     },
-    "node_modules/normalize-path": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
-      "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
-      "dev": true,
-      "dependencies": {
-        "remove-trailing-separator": "^1.0.1"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/npmlog": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
@@ -2917,15 +2910,14 @@
       }
     },
     "node_modules/object.values": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/object.values/-/object.values-1.1.3.tgz",
-      "integrity": "sha512-nkF6PfDB9alkOUxpf1HNm/QlkeW3SReqL5WXeBLpEJJnlPSvRaDQpW3gQTksTN3fgJX4hL42RzKyOin6ff3tyw==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/object.values/-/object.values-1.1.4.tgz",
+      "integrity": "sha512-TnGo7j4XSnKQoK3MfvkzqKCi0nVe/D9I9IjwTNYdb/fxYHpjrluHVOgw0AF6jrRFGMPHdfuidR09tIDiIvnaSg==",
       "dev": true,
       "dependencies": {
         "call-bind": "^1.0.2",
         "define-properties": "^1.1.3",
-        "es-abstract": "^1.18.0-next.2",
-        "has": "^1.0.3"
+        "es-abstract": "^1.18.2"
       },
       "engines": {
         "node": ">= 0.4"
@@ -3088,22 +3080,10 @@
       }
     },
     "node_modules/path-parse": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
-      "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "dev": true
-    },
-    "node_modules/path-starts-with": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/path-starts-with/-/path-starts-with-1.0.0.tgz",
-      "integrity": "sha1-soJDAV6LE43lcmgqxS2kLmRq2E4=",
-      "dev": true,
-      "dependencies": {
-        "normalize-path": "^2.1.1"
-      },
-      "engines": {
-        "node": ">=4"
-      }
     },
     "node_modules/path-type": {
       "version": "3.0.0",
@@ -3300,12 +3280,6 @@
       "funding": {
         "url": "https://github.com/sponsors/mysticatea"
       }
-    },
-    "node_modules/remove-trailing-separator": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
-      "integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8=",
-      "dev": true
     },
     "node_modules/repeat-string": {
       "version": "1.6.1",
@@ -3557,9 +3531,9 @@
       }
     },
     "node_modules/spdx-license-ids": {
-      "version": "3.0.8",
-      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.8.tgz",
-      "integrity": "sha512-NDgA96EnaLSvtbM7trJj+t1LUR3pirkDCcz9nOUlPb5DMBGsH7oES6C3hs3j7R9oHEa1EMvReS/BUAIT5Tcr0g==",
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.9.tgz",
+      "integrity": "sha512-Ki212dKK4ogX+xDo4CtOZBVIwhsKBEfsEEcwmJfLQzirgc2jIWdzg40Unxz/HzEUqM1WFzVlQSMF9kZZ2HboLQ==",
       "dev": true
     },
     "node_modules/sprintf-js": {
@@ -3977,6 +3951,7 @@
       "version": "3.4.0",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
       "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
+      "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
       "dev": true,
       "bin": {
         "uuid": "bin/uuid"
@@ -4016,7 +3991,7 @@
       "name": "@tari/wallet-grpc-client",
       "version": "0.0.1",
       "resolved": "git+ssh://git@github.com/tari-project/wallet-grpc-client.git#021ab164c574c9e9d91c43bd1730c90b880f6eff",
-      "integrity": "sha512-n/V33tVPFkjPZhONshvnDzN0mWW3eWjLEZPPosPF4IN9iSj/RNUlZY+B2rPkVUvvt3fHnZbMoeWTgOwmsHMXeQ==",
+      "integrity": "sha512-rL3rLtED+fJnCtqJSb+jHFdULYBw01GBuND7evRdJmrmKHE9Jkhv/d4Avm2f58Z73MUdhs4uVLiCEPQwV7fcsA==",
       "dependencies": {
         "@grpc/grpc-js": "^1.2.3",
         "@grpc/proto-loader": "^0.5.5",
@@ -4415,9 +4390,9 @@
       "integrity": "sha512-5tXH6Bx/kNGd3MgffdmP4dy2Z+G4eaXw0SE81Tq3BNadtnMR5/ySMzX4SLEzHJzSmPNn4HIdpQsBvXMUykr58w=="
     },
     "@types/node": {
-      "version": "15.6.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-15.6.0.tgz",
-      "integrity": "sha512-gCYSfQpy+LYhOFTKAeE8BkyGqaxmlFxe+n4DKM6DR0wzw/HISUE/hAmkC/KT8Sw5PCJblqg062b3z9gucv3k0A=="
+      "version": "15.6.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-15.6.1.tgz",
+      "integrity": "sha512-7EIraBEyRHEe7CH+Fm1XvgqU6uwZN8Q7jppJGcqjROMT29qhAuuOxYB1uEY5UMYQKEmA5D+5tBnhdaPXSsLONA=="
     },
     "abbrev": {
       "version": "1.1.1",
@@ -4842,20 +4817,10 @@
       "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
       "dev": true
     },
-    "contains-path": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/contains-path/-/contains-path-1.0.0.tgz",
-      "integrity": "sha1-NFizMhhWA+ju0Y9RjUoQiIo6vJE=",
-      "dev": true,
-      "requires": {
-        "normalize-path": "^2.1.1",
-        "path-starts-with": "^1.0.0"
-      }
-    },
     "core-js-pure": {
-      "version": "3.12.1",
-      "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.12.1.tgz",
-      "integrity": "sha512-1cch+qads4JnDSWsvc7d6nzlKAippwjUlf6vykkTLW53VSV+NkE6muGBToAjEA8pG90cSfcud3JgVmW2ds5TaQ==",
+      "version": "3.13.1",
+      "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.13.1.tgz",
+      "integrity": "sha512-wVlh0IAi2t1iOEh16y4u1TRk6ubd4KvLE8dlMi+3QUI6SfKphQUh7tAwihGGSQ8affxEXpVIPpOdf9kjR4v4Pw==",
       "dev": true
     },
     "core-util-is": {
@@ -5088,9 +5053,9 @@
       }
     },
     "es-abstract": {
-      "version": "1.18.0",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.0.tgz",
-      "integrity": "sha512-LJzK7MrQa8TS0ja2w3YNLzUgJCGPdPOV1yVvezjNnS89D+VR08+Szt2mz3YB2Dck/+w5tfIq/RoUAFqJJGM2yw==",
+      "version": "1.18.3",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.3.tgz",
+      "integrity": "sha512-nQIr12dxV7SSxE6r6f1l3DtAeEYdsGpps13dR0TwJg1S8gyp4ZPgy3FZcHBgbiQqnoqSTb+oC+kO4UQ0C/J8vw==",
       "dev": true,
       "requires": {
         "call-bind": "^1.0.2",
@@ -5101,14 +5066,14 @@
         "has-symbols": "^1.0.2",
         "is-callable": "^1.2.3",
         "is-negative-zero": "^2.0.1",
-        "is-regex": "^1.1.2",
-        "is-string": "^1.0.5",
-        "object-inspect": "^1.9.0",
+        "is-regex": "^1.1.3",
+        "is-string": "^1.0.6",
+        "object-inspect": "^1.10.3",
         "object-keys": "^1.1.1",
         "object.assign": "^4.1.2",
         "string.prototype.trimend": "^1.0.4",
         "string.prototype.trimstart": "^1.0.4",
-        "unbox-primitive": "^1.0.0"
+        "unbox-primitive": "^1.0.1"
       }
     },
     "es-to-primitive": {
@@ -5161,9 +5126,9 @@
       "dev": true
     },
     "eslint": {
-      "version": "7.26.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-7.26.0.tgz",
-      "integrity": "sha512-4R1ieRf52/izcZE7AlLy56uIHHDLT74Yzz2Iv2l6kDaYvEu9x+wMB5dZArVL8SYGXSYV2YAg70FcW5Y5nGGNIg==",
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-7.27.0.tgz",
+      "integrity": "sha512-JZuR6La2ZF0UD384lcbnd0Cgg6QJjiCwhMD6eU4h/VGPcVGwawNNzKU41tgokGXnfjOOyI6QIffthhJTPzzuRA==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "7.12.11",
@@ -5174,12 +5139,14 @@
         "debug": "^4.0.1",
         "doctrine": "^3.0.0",
         "enquirer": "^2.3.5",
+        "escape-string-regexp": "^4.0.0",
         "eslint-scope": "^5.1.1",
         "eslint-utils": "^2.1.0",
         "eslint-visitor-keys": "^2.0.0",
         "espree": "^7.3.1",
         "esquery": "^1.4.0",
         "esutils": "^2.0.2",
+        "fast-deep-equal": "^3.1.3",
         "file-entry-cache": "^6.0.1",
         "functional-red-black-tree": "^1.0.1",
         "glob-parent": "^5.0.0",
@@ -5191,7 +5158,7 @@
         "js-yaml": "^3.13.1",
         "json-stable-stringify-without-jsonify": "^1.0.1",
         "levn": "^0.4.1",
-        "lodash": "^4.17.21",
+        "lodash.merge": "^4.6.2",
         "minimatch": "^3.0.4",
         "natural-compare": "^1.4.0",
         "optionator": "^0.9.1",
@@ -5200,7 +5167,7 @@
         "semver": "^7.2.1",
         "strip-ansi": "^6.0.0",
         "strip-json-comments": "^3.1.0",
-        "table": "^6.0.4",
+        "table": "^6.0.9",
         "text-table": "^0.2.0",
         "v8-compile-cache": "^2.0.3"
       },
@@ -5239,6 +5206,12 @@
           "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
           "dev": true
         },
+        "escape-string-regexp": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+          "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+          "dev": true
+        },
         "has-flag": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -5264,9 +5237,9 @@
       "requires": {}
     },
     "eslint-config-standard": {
-      "version": "16.0.2",
-      "resolved": "https://registry.npmjs.org/eslint-config-standard/-/eslint-config-standard-16.0.2.tgz",
-      "integrity": "sha512-fx3f1rJDsl9bY7qzyX8SAtP8GBSk6MfXFaTfaGgk12aAYW4gJSyRm7dM790L6cbXv63fvjY4XeSzXnb4WM+SKw==",
+      "version": "16.0.3",
+      "resolved": "https://registry.npmjs.org/eslint-config-standard/-/eslint-config-standard-16.0.3.tgz",
+      "integrity": "sha512-x4fmJL5hGqNJKGHSjnLdgA6U6h1YW/G2dW9fA+cyVur4SK6lyue8+UgNKWlZtUDTXvgKDD/Oa3GQjmB5kjtVvg==",
       "dev": true,
       "requires": {}
     },
@@ -5329,14 +5302,13 @@
       }
     },
     "eslint-plugin-import": {
-      "version": "2.23.2",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.23.2.tgz",
-      "integrity": "sha512-LmNoRptHBxOP+nb0PIKz1y6OSzCJlB+0g0IGS3XV4KaKk2q4szqQ6s6F1utVf5ZRkxk/QOTjdxe7v4VjS99Bsg==",
+      "version": "2.23.4",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.23.4.tgz",
+      "integrity": "sha512-6/wP8zZRsnQFiR3iaPFgh5ImVRM1WN5NUWfTIRqwOdeiGJlBcSk82o1FEVq8yXmy4lkIzTo7YhHCIxlU/2HyEQ==",
       "dev": true,
       "requires": {
         "array-includes": "^3.1.3",
         "array.prototype.flat": "^1.2.4",
-        "contains-path": "^1.0.0",
         "debug": "^2.6.9",
         "doctrine": "^2.1.0",
         "eslint-import-resolver-node": "^0.3.4",
@@ -5791,9 +5763,9 @@
       }
     },
     "globals": {
-      "version": "13.8.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-13.8.0.tgz",
-      "integrity": "sha512-rHtdA6+PDBIjeEvA91rpqzEvk/k3/i7EeNQiryiWuJH0Hw9cpyJMAt2jtbAwUaRdhD+573X4vWw6IcjKPasi9Q==",
+      "version": "13.9.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-13.9.0.tgz",
+      "integrity": "sha512-74/FduwI/JaIrr1H8e71UbDE+5x7pIPs1C2rrwC52SszOo043CsWOZEMW7o2Y58xwm9b+0RBKDxY5n2sUpEFxA==",
       "dev": true,
       "requires": {
         "type-fest": "^0.20.2"
@@ -6233,6 +6205,12 @@
       "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8=",
       "dev": true
     },
+    "lodash.merge": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
+      "dev": true
+    },
     "lodash.toarray": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/lodash.toarray/-/lodash.toarray-4.4.0.tgz",
@@ -6415,15 +6393,6 @@
         }
       }
     },
-    "normalize-path": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
-      "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
-      "dev": true,
-      "requires": {
-        "remove-trailing-separator": "^1.0.1"
-      }
-    },
     "npmlog": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
@@ -6473,15 +6442,14 @@
       }
     },
     "object.values": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/object.values/-/object.values-1.1.3.tgz",
-      "integrity": "sha512-nkF6PfDB9alkOUxpf1HNm/QlkeW3SReqL5WXeBLpEJJnlPSvRaDQpW3gQTksTN3fgJX4hL42RzKyOin6ff3tyw==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/object.values/-/object.values-1.1.4.tgz",
+      "integrity": "sha512-TnGo7j4XSnKQoK3MfvkzqKCi0nVe/D9I9IjwTNYdb/fxYHpjrluHVOgw0AF6jrRFGMPHdfuidR09tIDiIvnaSg==",
       "dev": true,
       "requires": {
         "call-bind": "^1.0.2",
         "define-properties": "^1.1.3",
-        "es-abstract": "^1.18.0-next.2",
-        "has": "^1.0.3"
+        "es-abstract": "^1.18.2"
       }
     },
     "once": {
@@ -6602,19 +6570,10 @@
       "dev": true
     },
     "path-parse": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
-      "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "dev": true
-    },
-    "path-starts-with": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/path-starts-with/-/path-starts-with-1.0.0.tgz",
-      "integrity": "sha1-soJDAV6LE43lcmgqxS2kLmRq2E4=",
-      "dev": true,
-      "requires": {
-        "normalize-path": "^2.1.1"
-      }
     },
     "path-type": {
       "version": "3.0.0",
@@ -6760,12 +6719,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.1.0.tgz",
       "integrity": "sha512-ZOIzd8yVsQQA7j8GCSlPGXwg5PfmA1mrq0JP4nGhh54LaKN3xdai/vHUDu74pKwV8OxseMS65u2NImosQcSD0Q==",
-      "dev": true
-    },
-    "remove-trailing-separator": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
-      "integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8=",
       "dev": true
     },
     "repeat-string": {
@@ -6962,9 +6915,9 @@
       }
     },
     "spdx-license-ids": {
-      "version": "3.0.8",
-      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.8.tgz",
-      "integrity": "sha512-NDgA96EnaLSvtbM7trJj+t1LUR3pirkDCcz9nOUlPb5DMBGsH7oES6C3hs3j7R9oHEa1EMvReS/BUAIT5Tcr0g==",
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.9.tgz",
+      "integrity": "sha512-Ki212dKK4ogX+xDo4CtOZBVIwhsKBEfsEEcwmJfLQzirgc2jIWdzg40Unxz/HzEUqM1WFzVlQSMF9kZZ2HboLQ==",
       "dev": true
     },
     "sprintf-js": {
@@ -7344,7 +7297,7 @@
     },
     "wallet-grpc-client": {
       "version": "git+ssh://git@github.com/tari-project/wallet-grpc-client.git#021ab164c574c9e9d91c43bd1730c90b880f6eff",
-      "integrity": "sha512-n/V33tVPFkjPZhONshvnDzN0mWW3eWjLEZPPosPF4IN9iSj/RNUlZY+B2rPkVUvvt3fHnZbMoeWTgOwmsHMXeQ==",
+      "integrity": "sha512-rL3rLtED+fJnCtqJSb+jHFdULYBw01GBuND7evRdJmrmKHE9Jkhv/d4Avm2f58Z73MUdhs4uVLiCEPQwV7fcsA==",
       "from": "wallet-grpc-client@git://github.com/tari-project/wallet-grpc-client.git#021ab164c574c9e9d91c43bd1730c90b880f6eff",
       "requires": {
         "@grpc/grpc-js": "^1.2.3",


### PR DESCRIPTION
This PR updates the transaction builder in the Cucumber helpers to calculate the Beta hash and the Transaction Output hash correctly now that the whole script is included in the output.

## How Has This Been Tested?
PR updates tests

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [ ] I'm merging against the `development` branch.
* [x] I have squashed my commits into a single commit.
