### PR TITLE
Fix flaky test when syncing small nodes.

### DIFF
--- a/integration_tests/features/Sync.feature
+++ b/integration_tests/features/Sync.feature
@@ -39,7 +39,7 @@ Feature: Block Sync
     Given mining node NODE1 mines 5 blocks
     Then all nodes are at height 5
     Given I stop NODE2
-    Given mining node NODE1 mines 5 blocks
+    Given mining node NODE1 mines 5 blocks with min difficulty 1 and max difficulty 1
     Then node NODE1 is at height 10
     Given I stop NODE1
     And I start NODE2


### PR DESCRIPTION
## Description
The test was flaky, because it compared 5 additional blocks on one node vs 7 additional block on another node and expected the longer chain to "win". But that's not always the case. Sometime the shorter chain had higher accumulated difficulty.
The fix set the maximum difficulty to 1 for the shorter chain. So when the nodes sync it's always the longer chain with higher accumulated difficulty.