### PR TITLE
Change log level to warn (on 2+ block deletion) during reorg.

### DIFF
--- a/applications/tari_base_node/src/cli.rs
+++ b/applications/tari_base_node/src/cli.rs
@@ -156,7 +156,7 @@ pub fn print_banner(commands: Vec<String>, chunk_size: i32) {
     println!("{}", box_data("~~~~~~~~~~~~~~".to_string(), target_line_length));
     println!(
         "{}",
-        box_data(format!("Copyright 2019-2020. {}", AUTHOR), target_line_length)
+        box_data(format!("Copyright 2019-2021. {}", AUTHOR), target_line_length)
     );
     println!("{}", box_data(format!("Version {}", VERSION), target_line_length));
     println!("{}", box_separator(target_line_length));

--- a/base_layer/core/src/chain_storage/blockchain_database.rs
+++ b/base_layer/core/src/chain_storage/blockchain_database.rs
@@ -1519,8 +1519,9 @@ fn handle_possible_reorg<T: BlockchainBackend>(
     // reorg is required when any blocks are removed or more than one are added
     // see https://github.com/tari-project/tari/issues/2101
     if num_removed_blocks > 0 || num_added_blocks > 1 {
-        info!(
+        log!(
             target: LOG_TARGET,
+            if num_removed_blocks > 1 {Level::Warn} else {Level::Info}, // We want a warning if the number of removed blocks is at least 2.
             "Chain reorg required from {} to {} (accum_diff:{}, hash:{}) to (accum_diff:{}, hash:{}). Number of \
              blocks to remove: {}, to add: {}.
             ",

--- a/integration_tests/helpers/baseNodeProcess.js
+++ b/integration_tests/helpers/baseNodeProcess.js
@@ -116,7 +116,7 @@ class BaseNodeProcess {
         if (
           data
             .toString()
-            .match(/Copyright 2019-2020. The Tari Development Community/)
+            .match(/Copyright 2019-2021. The Tari Development Community/)
         ) {
           resolve(ps);
         }


### PR DESCRIPTION
## Description
Change log level to warning if at least two blocks are being deleted during reorg.
Change copyright year to 2021.