### PR TITLE
[wallet] Ensure recovery will not overwrite existing wallet

### DIFF
--- a/applications/tari_console_wallet/src/ui/components/send_tab.rs
+++ b/applications/tari_console_wallet/src/ui/components/send_tab.rs
@@ -527,7 +527,7 @@ impl<B: Backend> Component<B> for SendTab {
             .constraints(
                 [
                     Constraint::Length(3),
-                    Constraint::Length(13),
+                    Constraint::Length(14),
                     Constraint::Min(42),
                     Constraint::Length(1),
                 ]

--- a/common/src/configuration/bootstrap.rs
+++ b/common/src/configuration/bootstrap.rs
@@ -129,7 +129,7 @@ pub struct ConfigBootstrap {
     #[structopt(long, alias("seed_words"))]
     pub seed_words: Option<String>,
     /// Supply the optional file name to save the wallet seed words into
-    #[structopt(long, alias("seed_words_file_name"), parse(from_os_str))]
+    #[structopt(long, aliases(&["seed_words_file_name", "seed-words-file"]), parse(from_os_str))]
     pub seed_words_file_name: Option<PathBuf>,
     /// Wallet notify script
     #[structopt(long, alias("notify"))]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
- wallet given a recovery key should not overwrite an existing wallet master key
- console wallet sending message box was squished 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Before running recovery the console wallet already checks that it won't overwrite an existing wallet, this check is now included in the wallet library itself. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
new unit test, and tested manually

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `tari-script` branch.
* [x] I have squashed my commits into a single commit.
