### PR TITLE
Modify gamma calculation for Tari script

### DIFF
--- a/base_layer/core/src/mempool/unconfirmed_pool/unconfirmed_pool.rs
+++ b/base_layer/core/src/mempool/unconfirmed_pool/unconfirmed_pool.rs
@@ -376,7 +376,7 @@ mod test {
             .with_fee_per_gram(20.into())
             .with_offset(Default::default())
             .with_private_nonce(test_params.nonce.clone())
-            .with_change_secret(test_params.change_key.clone());
+            .with_change_secret(test_params.change_spend_key.clone());
 
         // Double spend the input from tx2 in tx3
         let double_spend_utxo = tx2.body.inputs().first().unwrap().clone();

--- a/base_layer/core/src/transactions/aggregated_body.rs
+++ b/base_layer/core/src/transactions/aggregated_body.rs
@@ -32,7 +32,7 @@ use tari_crypto::{
     commitment::HomomorphicCommitmentFactory,
     keys::PublicKey as PublicKeyTrait,
     ristretto::pedersen::PedersenCommitment,
-    tari_utilities::{hex::Hex, ByteArray, Hashable},
+    tari_utilities::hex::Hex,
 };
 
 pub const LOG_TARGET: &str = "c::tx::aggregated_body";
@@ -390,10 +390,7 @@ impl AggregateBody {
         for output in &self.outputs {
             // We should not count the coinbase tx here
             if !output.is_coinbase() {
-                output_keys = output_keys +
-                    PrivateKey::from_bytes(&output.hash())
-                        .map_err(|e| TransactionError::ConversionError(e.to_string()))? *
-                        output.script_offset_public_key.clone();
+                output_keys = output_keys + output.script_offset_public_key.clone();
             }
         }
         let lhs = input_keys - output_keys;

--- a/base_layer/core/src/transactions/transaction_protocol/recipient.rs
+++ b/base_layer/core/src/transactions/transaction_protocol/recipient.rs
@@ -236,7 +236,7 @@ mod test {
             tx_id: 15,
             amount: MicroTari(500),
             public_excess: PublicKey::from_secret_key(&p.spend_key), // any random key will do
-            public_nonce: PublicKey::from_secret_key(&p.change_key), // any random key will do
+            public_nonce: PublicKey::from_secret_key(&p.change_spend_key), // any random key will do
             metadata: m.clone(),
             message: "".to_string(),
             script: TariScript::default(),
@@ -284,7 +284,7 @@ mod test {
             tx_id: 15,
             amount,
             public_excess: PublicKey::from_secret_key(&p.spend_key), // any random key will do
-            public_nonce: PublicKey::from_secret_key(&p.change_key), // any random key will do
+            public_nonce: PublicKey::from_secret_key(&p.change_spend_key), // any random key will do
             metadata: m,
             message: "".to_string(),
             script: TariScript::default(),

--- a/base_layer/core/src/transactions/transaction_protocol/sender.rs
+++ b/base_layer/core/src/transactions/transaction_protocol/sender.rs
@@ -49,7 +49,7 @@ use tari_crypto::{
     keys::PublicKey as PublicKeyTrait,
     ristretto::pedersen::PedersenCommitment,
     script::TariScript,
-    tari_utilities::{ByteArray, Hashable},
+    tari_utilities::ByteArray,
 };
 
 //----------------------------------------   Local Data types     ----------------------------------------------------//
@@ -350,10 +350,7 @@ impl SenderTransactionProtocol {
                             "For single recipient there should be one recipient script offset".to_string(),
                         )
                     })?;
-                info.gamma = info.gamma.clone() -
-                    PrivateKey::from_bytes(rec.output.hash().as_slice())
-                        .map_err(|e| TPE::ConversionError(e.to_string()))? *
-                        recipient_script_offset_private_key.clone();
+                info.gamma = info.gamma.clone() - recipient_script_offset_private_key.clone();
 
                 // nonce is in the signature, so we'll add those together later
                 info.public_excess = &info.public_excess + &rec.public_spend_key;
@@ -647,7 +644,7 @@ mod test {
             .with_fee_per_gram(MicroTari(10))
             .with_offset(p.offset.clone())
             .with_private_nonce(p.nonce.clone())
-            .with_change_secret(p.change_key.clone())
+            .with_change_secret(p.change_spend_key.clone())
             .with_input(utxo, input)
             .with_output(
                 UnblindedOutput::new(
@@ -762,7 +759,7 @@ mod test {
             .with_fee_per_gram(MicroTari(20))
             .with_offset(a.offset.clone())
             .with_private_nonce(a.nonce.clone())
-            .with_change_secret(a.change_key.clone())
+            .with_change_secret(a.change_spend_key.clone())
             .with_input(utxo.clone(), input)
             .with_recipient_script(0, script.clone(), script_offset)
             .with_change_script(script, ExecutionStack::default(), PrivateKey::default())
@@ -839,7 +836,7 @@ mod test {
             .with_fee_per_gram(MicroTari(20))
             .with_offset(a.offset.clone())
             .with_private_nonce(a.nonce.clone())
-            .with_change_secret(a.change_key)
+            .with_change_secret(a.change_spend_key)
             .with_input(utxo, input)
             .with_recipient_script(0, script.clone(), script_offset)
             .with_change_script(script, ExecutionStack::default(), PrivateKey::default())
@@ -887,7 +884,7 @@ mod test {
             .with_fee_per_gram(fee_per_gram)
             .with_offset(alice.offset.clone())
             .with_private_nonce(alice.nonce.clone())
-            .with_change_secret(alice.change_key)
+            .with_change_secret(alice.change_spend_key)
             .with_input(utxo, input)
             .with_amount(0, amount)
             .with_recipient_script(0, script.clone(), script_offset)
@@ -913,7 +910,7 @@ mod test {
             .with_fee_per_gram(fee_per_gram)
             .with_offset(alice.offset.clone())
             .with_private_nonce(alice.nonce.clone())
-            .with_change_secret(alice.change_key)
+            .with_change_secret(alice.change_spend_key)
             .with_input(utxo, input)
             .with_amount(0, amount)
             .with_prevent_fee_gt_amount(false)
@@ -957,7 +954,7 @@ mod test {
             .with_fee_per_gram(MicroTari(20))
             .with_offset(a.offset.clone())
             .with_private_nonce(a.nonce.clone())
-            .with_change_secret(a.change_key.clone())
+            .with_change_secret(a.change_spend_key.clone())
             .with_rewindable_outputs(rewind_data)
             .with_input(utxo, input)
             .with_amount(0, MicroTari(5000))
@@ -1021,7 +1018,7 @@ mod test {
 
                 assert_eq!(full_rewind_result.committed_value, change);
                 assert_eq!(&full_rewind_result.proof_message, proof_message);
-                assert_eq!(full_rewind_result.blinding_factor, a.change_key);
+                assert_eq!(full_rewind_result.blinding_factor, a.change_spend_key);
             },
             Err(_) => {
                 let rr = tx.body.outputs()[1]
@@ -1038,7 +1035,7 @@ mod test {
                     .unwrap();
                 assert_eq!(full_rewind_result.committed_value, change);
                 assert_eq!(&full_rewind_result.proof_message, proof_message);
-                assert_eq!(full_rewind_result.blinding_factor, a.change_key);
+                assert_eq!(full_rewind_result.blinding_factor, a.change_spend_key);
             },
         }
     }

--- a/base_layer/core/src/transactions/transaction_protocol/transaction_initializer.rs
+++ b/base_layer/core/src/transactions/transaction_protocol/transaction_initializer.rs
@@ -50,7 +50,7 @@ use std::{
 use tari_crypto::{
     keys::{PublicKey as PublicKeyTrait, SecretKey},
     script::{ExecutionStack, TariScript},
-    tari_utilities::{fixed_set::FixedSet, ByteArray, Hashable},
+    tari_utilities::fixed_set::FixedSet,
 };
 
 pub const LOG_TARGET: &str = "c::tx::tx_protocol::tx_initializer";
@@ -420,12 +420,8 @@ impl SenderTransactionInitializer {
                 .build_err("There should be the same number of sender added outputs as script offset private keys");
         }
 
-        for (o, opk) in outputs.iter().zip(self.script_offset_private_keys.iter()) {
-            let output_hash = match PrivateKey::from_bytes(&o.hash()) {
-                Ok(h) => h,
-                Err(_e) => return self.build_err("Output hash to private key conversion error"),
-            };
-            gamma = gamma - output_hash * opk.clone();
+        for script_offset_pvt_key in self.script_offset_private_keys.iter() {
+            gamma = gamma - script_offset_pvt_key.clone();
         }
 
         let nonce = self.private_nonce.clone().unwrap();
@@ -576,7 +572,7 @@ mod test {
         assert_eq!(err.message, "Change spending key was not provided");
         // Ok, give them a change output
         let mut builder = err.builder;
-        builder.with_change_secret(p.change_key);
+        builder.with_change_secret(p.change_spend_key);
         let result = builder.build::<Blake256>(&factories).unwrap();
         // Peek inside and check the results
         if let SenderState::Finalizing(info) = result.state {
@@ -741,7 +737,7 @@ mod test {
             .with_private_nonce(p.nonce)
             .with_input(utxo, input)
             .with_output(output, PrivateKey::random(&mut OsRng))
-            .with_change_secret(p.change_key)
+            .with_change_secret(p.change_spend_key)
             .with_fee_per_gram(MicroTari(1))
             .with_recipient_script(0, script.clone(), script_offset)
             .with_change_script(script, ExecutionStack::default(), PrivateKey::default());
@@ -775,7 +771,7 @@ mod test {
             .with_private_nonce(p.nonce)
             .with_input(utxo, input)
             .with_output(output, PrivateKey::random(&mut OsRng))
-            .with_change_secret(p.change_key)
+            .with_change_secret(p.change_spend_key)
             .with_fee_per_gram(MicroTari(1))
             .with_recipient_script(0, script.clone(), script_offset)
             .with_change_script(script, ExecutionStack::default(), PrivateKey::default());
@@ -811,7 +807,7 @@ mod test {
             .with_private_nonce(p.nonce)
             .with_input(utxo, input)
             .with_output(output, PrivateKey::random(&mut OsRng))
-            .with_change_secret(p.change_key)
+            .with_change_secret(p.change_spend_key)
             .with_fee_per_gram(MicroTari(20))
             .with_recipient_script(0, script.clone(), script_offset.clone())
             .with_recipient_script(1, script.clone(), script_offset)
@@ -856,7 +852,7 @@ mod test {
             .with_input(utxo1, input1)
             .with_input(utxo2, input2)
             .with_amount(0, MicroTari(2500))
-            .with_change_secret(p.change_key)
+            .with_change_secret(p.change_spend_key)
             .with_fee_per_gram(weight)
             .with_recipient_script(0, script.clone(), script_offset)
             .with_change_script(script, ExecutionStack::default(), PrivateKey::default());
@@ -904,7 +900,7 @@ mod test {
             .with_output(output, PrivateKey::default())
             .with_input(utxo1, input1)
             .with_amount(0, MicroTari(100))
-            .with_change_secret(p.change_key)
+            .with_change_secret(p.change_spend_key)
             .with_fee_per_gram(weight)
             .with_recipient_script(0, script.clone(), script_offset)
             .with_change_script(script, ExecutionStack::default(), PrivateKey::default());

--- a/base_layer/core/tests/helpers/block_builders.rs
+++ b/base_layer/core/tests/helpers/block_builders.rs
@@ -419,14 +419,12 @@ pub fn generate_new_block_with_coinbase<B: BlockchainBackend>(
 ) -> Result<BlockAddResult, ChainStorageError> {
     let mut txns = Vec::new();
     let mut block_utxos = Vec::new();
-    let mut keys = Vec::new();
     let mut fees = MicroTari(0);
     for schema in schemas {
-        let (tx, mut utxos, param) = spend_utxos(schema);
+        let (tx, mut utxos, _param) = spend_utxos(schema);
         fees += tx.body.get_total_fee();
         txns.push(tx);
         block_utxos.append(&mut utxos);
-        keys.push(param);
     }
 
     let (coinbase_utxo, coinbase_kernel, coinbase_output) = create_coinbase(factories, coinbase_value + fees, 100);

--- a/base_layer/core/tests/mempool.rs
+++ b/base_layer/core/tests/mempool.rs
@@ -35,7 +35,6 @@ use helpers::{
     nodes::{create_network_with_2_base_nodes_with_config, create_network_with_3_base_nodes_with_config},
     sample_blockchains::{create_new_blockchain, create_new_blockchain_with_constants},
 };
-use tari_core::tari_utilities::{ByteArray, Hashable};
 use tari_crypto::keys::PublicKey as PublicKeyTrait;
 // use crate::helpers::database::create_store;
 use std::{ops::Deref, sync::Arc, time::Duration};
@@ -643,7 +642,7 @@ fn receive_and_propagate_transaction() {
 }
 
 #[test]
-fn consensus_validation() {
+fn consensus_validation_large_tx() {
     let network = Network::LocalNet;
     // We dont want to compute the 19500 limit of local net, so we create smaller blocks
     let consensus_constants = ConsensusConstantsBuilder::new(network)
@@ -695,10 +694,9 @@ fn consensus_validation() {
             inputs!(PublicKey::from_secret_key(&test_params.spend_key)),
             1,
             test_params.script_private_key,
-            test_params.script_offset,
+            test_params.script_offset_pub_key,
         );
-        let hash = utxo.as_transaction_output(&factories).unwrap().hash();
-        script_offset_pvt = script_offset_pvt - PrivateKey::from_bytes(&hash).unwrap() * test_params.script_offset_pvt;
+        script_offset_pvt = script_offset_pvt - test_params.script_offset_pvt_key;
         unblinded_outputs.push(utxo.clone());
     }
 
@@ -733,6 +731,10 @@ fn consensus_validation() {
         .unwrap();
     let kernels = vec![kernel];
     let tx = Transaction::new(inputs, outputs, kernels, offset, script_offset_pvt);
+
+    // make sure the tx was correctly made and is valid
+    let factories = CryptoFactories::default();
+    assert!(tx.validate_internal_consistency(&factories, None).is_ok());
     let weight = tx.calculate_weight();
 
     let height = blocks.len() as u64;

--- a/base_layer/wallet/tests/output_manager_service/service.rs
+++ b/base_layer/wallet/tests/output_manager_service/service.rs
@@ -850,7 +850,7 @@ fn generate_sender_transaction_message(amount: MicroTari) -> (TxId, TransactionS
         .with_fee_per_gram(MicroTari(20))
         .with_offset(alice.offset.clone())
         .with_private_nonce(alice.nonce.clone())
-        .with_change_secret(alice.change_key)
+        .with_change_secret(alice.change_spend_key)
         .with_input(utxo, input)
         .with_amount(0, amount)
         .with_recipient_script(0, script!(Nop), PrivateKey::random(&mut OsRng))

--- a/base_layer/wallet/tests/support/utils.rs
+++ b/base_layer/wallet/tests/support/utils.rs
@@ -61,7 +61,7 @@ where
 
 pub struct TestParams {
     pub spend_key: PrivateKey,
-    pub change_key: PrivateKey,
+    pub change_spend_key: PrivateKey,
     pub offset: PrivateKey,
     pub nonce: PrivateKey,
     pub public_nonce: PublicKey,
@@ -71,7 +71,7 @@ impl TestParams {
         let r = PrivateKey::random(rng);
         TestParams {
             spend_key: PrivateKey::random(rng),
-            change_key: PrivateKey::random(rng),
+            change_spend_key: PrivateKey::random(rng),
             offset: PrivateKey::random(rng),
             public_nonce: PublicKey::from_secret_key(&r),
             nonce: r,

--- a/integration_tests/helpers/transactionBuilder.js
+++ b/integration_tests/helpers/transactionBuilder.js
@@ -176,17 +176,10 @@ class TransactionBuilder {
     });
     this.outputs.forEach((output) => {
       totalPrivateKey += BigInt("0x" + output.privateKey.toString());
-      let output_hash = this.hashOutput(
-        output.output.features,
-        output.output.commitment,
-        output.output.script,
-        output.output.script_offset_public_key
+      script_offset = tari_crypto.subtract_secret_keys(
+        script_offset,
+        output.scriptOffsetPrivateKey
       );
-      let kU = tari_crypto.secret_key_from_hex_bytes(
-        output_hash.toString("hex")
-      );
-      kU = tari_crypto.multiply_secret_keys(output.scriptOffsetPrivateKey, kU);
-      script_offset = tari_crypto.subtract_secret_keys(script_offset, kU);
     });
     // Assume low numbers....
 

--- a/integration_tests/package-lock.json
+++ b/integration_tests/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "integration_tests",
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- Modified gamma calculation for Tari script according to the latest RFC-0201 proposals.
- Fixed private keys re-use issue in `transactions/helpers.rs fn create_tx`.
- Clarified use of test params in `transactions/helpers.rs fn spend_utxos`.
- Ensured `consensus_validation_large_tx` will fail if the transaction internal consistency is not ok (gamma is calculated here as well).

Co-Authored-By: SW van Heerden <swvheerden@gmail.com>

## Motivation and Context
See above.

## How Has This Been Tested?
Cucumber & unit tests.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [X] I'm merging against the `tari-script` branch.
* [X] I have squashed my commits into a single commit.
