### PR TITLE
Fix `Unique Constraint` bug when requesting a coinbase output at same height

### DIFF
--- a/base_layer/wallet/src/output_manager_service/error.rs
+++ b/base_layer/wallet/src/output_manager_service/error.rs
@@ -20,7 +20,7 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use crate::{base_node_service::error::BaseNodeServiceError, output_manager_service::storage::database::DbKey};
+use crate::base_node_service::error::BaseNodeServiceError;
 use diesel::result::Error as DieselError;
 use tari_comms::{peer_manager::node_id::NodeIdError, protocol::rpc::RpcError};
 use tari_comms_dht::outbound::DhtOutboundError;
@@ -115,8 +115,12 @@ pub enum OutputManagerError {
 pub enum OutputManagerStorageError {
     #[error("Tried to insert an output that already exists in the database")]
     DuplicateOutput,
-    #[error("Value not found: `{0}`")]
-    ValueNotFound(DbKey),
+    #[error(
+        "Tried to insert an pending transaction encumberance for a transaction ID that already exists in the database"
+    )]
+    DuplicateTransaction,
+    #[error("Value not found")]
+    ValueNotFound,
     #[error("Unexpected result: `{0}`")]
     UnexpectedResult(String),
     #[error("If an pending transaction does not exist to be confirmed")]

--- a/base_layer/wallet_ffi/src/error.rs
+++ b/base_layer/wallet_ffi/src/error.rs
@@ -138,7 +138,7 @@ impl From<WalletError> for LibWalletError {
                 message: format!("{:?}", w),
             },
             WalletError::OutputManagerError(OutputManagerError::OutputManagerStorageError(
-                OutputManagerStorageError::ValueNotFound(_),
+                OutputManagerStorageError::ValueNotFound,
             )) => Self {
                 code: 108,
                 message: format!("{:?}", w),


### PR DESCRIPTION
## Description
If a miner requested a Coinbase Transaction at the same height as one that was requested previously and that output had the exact same commitment the Output Manager database would return a Unique Constraint error due to the existing output in the database. This would happen rarely when a miner is experiencing many reorgs while mining.

To fix this issue logic is added to the Output Manager service to clear any existing coinbase outputs with the same commitment at the same block height as the one that was just requested before adding it to the database. I decided this presents no danger of losing funds because the newly added coinbase will have the exact same commitment as the one being removed.

## How Has This Been Tested?
Unit test provided

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [ ] I'm merging against the `development` branch.
* [x] I have squashed my commits into a single commit.
