### PR TITLE
[base-node] Check minimum number of headers for calc-timing

### DIFF
--- a/applications/tari_app_grpc/proto/base_node.proto
+++ b/applications/tari_app_grpc/proto/base_node.proto
@@ -35,7 +35,11 @@ service BaseNode {
     // Returns blocks in the current best chain. Currently only supports querying by height
     rpc GetBlocks(GetBlocksRequest) returns (stream HistoricalBlock);
     // Returns the calc timing for the chain heights
-    rpc GetCalcTiming(HeightRequest) returns (CalcTimingResponse);
+    rpc GetCalcTiming(HeightRequest) returns (CalcTimingResponse) {
+        option deprecated = true;
+    };
+    // Returns the block timing for the chain heights
+    rpc GetBlockTiming(HeightRequest) returns (BlockTimingResponse);
     // Returns the network Constants
     rpc GetConstants(Empty) returns (ConsensusConstants);
     // Returns Block Sizes
@@ -159,6 +163,14 @@ message HeightRequest {
 
 // The return type of the rpc GetCalcTiming
 message CalcTimingResponse {
+    option deprecated = true;
+    uint64 max = 1;
+    uint64 min = 2;
+    double avg = 3;
+}
+
+// The return type of the rpc GetBlockTiming
+message BlockTimingResponse {
     uint64 max = 1;
     uint64 min = 2;
     double avg = 3;

--- a/applications/tari_base_node/src/command_handler.rs
+++ b/applications/tari_base_node/src/command_handler.rs
@@ -724,7 +724,7 @@ impl CommandHandler {
         }
     }
 
-    pub fn calc_timing(&self, start: u64, end: Option<u64>) {
+    pub fn block_timing(&self, start: u64, end: Option<u64>) {
         let blockchain_db = self.blockchain_db.clone();
         self.executor.spawn(async move {
             let headers = match Self::get_chain_headers(&blockchain_db, start, end).await {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
- Checks for the number of blocks requested when calling `calc-timing`
- Start renaming `calc-timing` to more descriptive `block-timing`, will be done in 2 stages since block explorer must be updated as well.  

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
`calc-timing 1` would previously return the value for u64::MAX as min block time (which is the initial value in the calculation). It's impossible to know how long 1 block took to mine without the timestamp of the previous block.

```
>> calc-timing 1
Timing for blocks #2975 - #2975
Max block time: 0
Min block time: 18446744073709551615
Avg block time: 0
```

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- New rust tests added. 
- Command tested manually in base node. 
- GRPC call for `CalcTiming` tested with bloomRPC to ensure it's still working.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `tari-script` branch.
* [x] I have squashed my commits into a single commit.
