### PR TITLE
[console-wallet] Update app state after setting base node via command. Allow amount field to parse Tari.

### DIFF
--- a/applications/tari_console_wallet/src/automation/commands.rs
+++ b/applications/tari_console_wallet/src/automation/commands.rs
@@ -577,7 +577,6 @@ pub async fn command_runner(
             },
             SetCustomBaseNode => {
                 let (public_key, net_address) = set_base_node_peer(wallet.clone(), &parsed.args).await?;
-                println!("Saving custom base node peer in wallet database.");
                 wallet
                     .db
                     .set_client_key_value(CUSTOM_BASE_NODE_PUBLIC_KEY_KEY.to_string(), public_key.to_string())
@@ -586,9 +585,9 @@ pub async fn command_runner(
                     .db
                     .set_client_key_value(CUSTOM_BASE_NODE_ADDRESS_KEY.to_string(), net_address.to_string())
                     .await?;
+                println!("Custom base node peer saved in wallet database.");
             },
             ClearCustomBaseNode => {
-                println!("Clearing custom base node peer in wallet database.");
                 wallet
                     .db
                     .clear_client_value(CUSTOM_BASE_NODE_PUBLIC_KEY_KEY.to_string())
@@ -597,6 +596,7 @@ pub async fn command_runner(
                     .db
                     .clear_client_value(CUSTOM_BASE_NODE_ADDRESS_KEY.to_string())
                     .await?;
+                println!("Custom base node peer cleared from wallet database.");
             },
         }
     }

--- a/applications/tari_console_wallet/src/main.rs
+++ b/applications/tari_console_wallet/src/main.rs
@@ -135,7 +135,7 @@ fn main_inner() -> Result<(), ExitCodes> {
     let config = WalletModeConfig {
         base_node_config,
         base_node_selected,
-        daemon_mode: bootstrap.daemon_mode,
+        bootstrap,
         global_config,
         handle,
         notify_script,

--- a/applications/tari_console_wallet/src/ui/app.rs
+++ b/applications/tari_console_wallet/src/ui/app.rs
@@ -49,8 +49,6 @@ use tui::{
 };
 
 pub const LOG_TARGET: &str = "wallet::ui::app";
-pub const CUSTOM_BASE_NODE_PUBLIC_KEY_KEY: &str = "console_wallet_custom_base_node_public_key";
-pub const CUSTOM_BASE_NODE_ADDRESS_KEY: &str = "console_wallet_custom_base_node_address";
 
 pub struct App<B: Backend> {
     pub title: String,

--- a/applications/tari_console_wallet/src/ui/components/network_tab.rs
+++ b/applications/tari_console_wallet/src/ui/components/network_tab.rs
@@ -426,6 +426,30 @@ impl<B: Backend> Component<B> for NetworkTab {
                     self.detailed_base_node = app_state.get_base_node_list().get(0).map(|(_, peer)| peer.clone());
                 }
             },
+            's' => {
+                // set the currently selected base node as a custom base node
+                let base_node = app_state.get_selected_base_node();
+                let public_key = base_node.public_key.to_hex();
+                let address = base_node
+                    .addresses
+                    .first()
+                    .map(|a| a.to_string())
+                    .unwrap_or_else(|| "".to_string());
+
+                match Handle::current().block_on(app_state.set_custom_base_node(public_key, address)) {
+                    Ok(peer) => {
+                        self.previous_address_field = self.address_field.clone();
+                        self.previous_public_key_field = self.public_key_field.clone();
+                        self.detailed_base_node = Some(peer);
+                    },
+                    Err(e) => {
+                        warn!(target: LOG_TARGET, "Could not set custom base node peer: {}", e);
+                        self.error_message = Some(format!("Error setting new Base Node Address:\n{}", e.to_string()));
+                        self.address_field = self.previous_address_field.clone();
+                        self.public_key_field = self.previous_public_key_field.clone();
+                    },
+                }
+            },
             _ => {},
         }
     }

--- a/applications/tari_console_wallet/src/ui/mod.rs
+++ b/applications/tari_console_wallet/src/ui/mod.rs
@@ -60,6 +60,7 @@ pub fn run(app: App<CrosstermBackend<Stdout>>) -> Result<(), ExitCodes> {
             app.app_state.refresh_contacts_state().await?;
             trace!(target: LOG_TARGET, "Refreshing connected peers state");
             app.app_state.refresh_connected_peers_state().await?;
+            trace!(target: LOG_TARGET, "Starting app state event monitor");
             app.app_state.start_event_monitor(app.notifier.clone()).await;
             Result::<_, UiError>::Ok(())
         })

--- a/applications/tari_console_wallet/src/ui/state/app_state.rs
+++ b/applications/tari_console_wallet/src/ui/state/app_state.rs
@@ -29,9 +29,8 @@ use crate::{
         },
         UiContact,
         UiError,
-        CUSTOM_BASE_NODE_ADDRESS_KEY,
-        CUSTOM_BASE_NODE_PUBLIC_KEY_KEY,
     },
+    utils::db::{CUSTOM_BASE_NODE_ADDRESS_KEY, CUSTOM_BASE_NODE_PUBLIC_KEY_KEY},
     wallet_modes::PeerConfig,
 };
 use futures::{stream::Fuse, StreamExt};

--- a/applications/tari_console_wallet/src/utils/db.rs
+++ b/applications/tari_console_wallet/src/utils/db.rs
@@ -33,8 +33,8 @@ pub const LOG_TARGET: &str = "wallet::utils::db";
 pub const CUSTOM_BASE_NODE_PUBLIC_KEY_KEY: &str = "console_wallet_custom_base_node_public_key";
 pub const CUSTOM_BASE_NODE_ADDRESS_KEY: &str = "console_wallet_custom_base_node_address";
 
-/// This helper function will attempt to read a stored base node public key and address from the wallet database if
-/// possible. If both are found they are used to construct and return a Peer.
+/// This helper function will attempt to read a stored base node public key and address from the wallet database.
+/// If both are found they are used to construct and return a Peer.
 pub async fn get_custom_base_node_peer_from_db(wallet: &mut WalletSqlite) -> Option<Peer> {
     let custom_base_node_peer_pubkey = match wallet
         .db

--- a/applications/tari_console_wallet/src/wallet_modes.rs
+++ b/applications/tari_console_wallet/src/wallet_modes.rs
@@ -26,6 +26,7 @@ use crate::{
     recovery::wallet_recovery,
     ui,
     ui::App,
+    utils::db::get_custom_base_node_peer_from_db,
 };
 use log::*;
 use rand::{rngs::OsRng, seq::SliceRandom};
@@ -106,6 +107,8 @@ impl PeerConfig {
         }
     }
 
+    /// Returns all the peers from the PeerConfig.
+    /// In order: Custom base node, service peers, peer seeds.
     pub fn get_all_peers(&self) -> Vec<Peer> {
         let num_peers = self.base_node_peers.len();
         let num_seeds = self.peer_seeds.len();
@@ -170,6 +173,7 @@ pub fn script_mode(config: WalletModeConfig, wallet: WalletSqlite, path: PathBuf
     wallet_or_exit(config, wallet)
 }
 
+/// Prompts the user to continue to the wallet, or exit.
 fn wallet_or_exit(config: WalletModeConfig, wallet: WalletSqlite) -> Result<(), ExitCodes> {
     if config.daemon_mode {
         info!(target: LOG_TARGET, "Daemon mode detected - auto exiting.");
@@ -195,10 +199,10 @@ fn wallet_or_exit(config: WalletModeConfig, wallet: WalletSqlite) -> Result<(), 
     }
 }
 
-pub fn tui_mode(config: WalletModeConfig, wallet: WalletSqlite) -> Result<(), ExitCodes> {
+pub fn tui_mode(config: WalletModeConfig, mut wallet: WalletSqlite) -> Result<(), ExitCodes> {
     let WalletModeConfig {
-        base_node_config,
-        base_node_selected,
+        mut base_node_config,
+        mut base_node_selected,
         global_config,
         handle,
         notify_script,
@@ -208,6 +212,14 @@ pub fn tui_mode(config: WalletModeConfig, wallet: WalletSqlite) -> Result<(), Ex
     handle.spawn(run_grpc(grpc, global_config.grpc_console_wallet_address));
 
     let notifier = Notifier::new(notify_script, handle.clone(), wallet.clone());
+
+    // update the selected/custom base node since it may have been changed by script/command mode
+    if let Some(peer) = handle.block_on(get_custom_base_node_peer_from_db(&mut wallet)) {
+        base_node_config.base_node_custom = Some(peer.clone());
+        base_node_selected = peer;
+    } else if let Some(peer) = handle.block_on(wallet.get_base_node_peer())? {
+        base_node_selected = peer;
+    }
 
     let app = App::<CrosstermBackend<Stdout>>::new(
         "Tari Console Wallet".into(),

--- a/applications/tari_console_wallet/src/wallet_modes.rs
+++ b/applications/tari_console_wallet/src/wallet_modes.rs
@@ -219,8 +219,9 @@ pub fn tui_mode(config: WalletModeConfig, mut wallet: WalletSqlite) -> Result<()
     let notifier = Notifier::new(notify_script, handle.clone(), wallet.clone());
 
     // update the selected/custom base node since it may have been changed by script/command mode
-    if let Some(peer) = handle.block_on(get_custom_base_node_peer_from_db(&mut wallet)) {
-        base_node_config.base_node_custom = Some(peer.clone());
+    let base_node_custom = handle.block_on(get_custom_base_node_peer_from_db(&mut wallet));
+    base_node_config.base_node_custom = base_node_custom.clone();
+    if let Some(peer) = base_node_custom {
         base_node_selected = peer;
     } else if let Some(peer) = handle.block_on(wallet.get_base_node_peer())? {
         base_node_selected = peer;

--- a/applications/tari_console_wallet/src/wallet_modes.rs
+++ b/applications/tari_console_wallet/src/wallet_modes.rs
@@ -32,7 +32,7 @@ use log::*;
 use rand::{rngs::OsRng, seq::SliceRandom};
 use std::{fs, io::Stdout, net::SocketAddr, path::PathBuf};
 use tari_app_utilities::utilities::ExitCodes;
-use tari_common::GlobalConfig;
+use tari_common::{ConfigBootstrap, GlobalConfig};
 use tari_comms::peer_manager::Peer;
 use tari_wallet::WalletSqlite;
 use tokio::runtime::Handle;
@@ -56,7 +56,7 @@ pub enum WalletMode {
 pub struct WalletModeConfig {
     pub base_node_config: PeerConfig,
     pub base_node_selected: Peer,
-    pub daemon_mode: bool,
+    pub bootstrap: ConfigBootstrap,
     pub global_config: GlobalConfig,
     pub handle: Handle,
     pub notify_script: Option<PathBuf>,
@@ -175,9 +175,14 @@ pub fn script_mode(config: WalletModeConfig, wallet: WalletSqlite, path: PathBuf
 
 /// Prompts the user to continue to the wallet, or exit.
 fn wallet_or_exit(config: WalletModeConfig, wallet: WalletSqlite) -> Result<(), ExitCodes> {
-    if config.daemon_mode {
-        info!(target: LOG_TARGET, "Daemon mode detected - auto exiting.");
-        Ok(())
+    if config.bootstrap.command_mode_auto_exit {
+        info!(target: LOG_TARGET, "Auto exit argument supplied - exiting.");
+        return Ok(());
+    }
+
+    if config.bootstrap.daemon_mode {
+        info!(target: LOG_TARGET, "Starting GRPC server.");
+        grpc_mode(config, wallet)
     } else {
         debug!(target: LOG_TARGET, "Prompting for run or exit key.");
         println!("\nPress Enter to continue to the wallet, or type q (or quit) followed by Enter.");

--- a/base_layer/wallet/src/base_node_service/handle.rs
+++ b/base_layer/wallet/src/base_node_service/handle.rs
@@ -37,12 +37,14 @@ pub type BaseNodeEventReceiver = broadcast::Receiver<Arc<BaseNodeEvent>>;
 pub enum BaseNodeServiceRequest {
     GetChainMetadata,
     SetBaseNodePeer(Box<Peer>),
+    GetBaseNodePeer,
 }
 /// API Response enum
 #[derive(Debug)]
 pub enum BaseNodeServiceResponse {
     ChainMetadata(Option<ChainMetadata>),
     BaseNodePeerSet,
+    BaseNodePeer(Option<Box<Peer>>),
 }
 #[derive(Clone, Debug, Hash, PartialEq, Eq)]
 pub enum BaseNodeEvent {
@@ -87,6 +89,13 @@ impl BaseNodeServiceHandle {
             .await??
         {
             BaseNodeServiceResponse::BaseNodePeerSet => Ok(()),
+            _ => Err(BaseNodeServiceError::UnexpectedApiResponse),
+        }
+    }
+
+    pub async fn get_base_node_peer(&mut self) -> Result<Option<Peer>, BaseNodeServiceError> {
+        match self.handle.call(BaseNodeServiceRequest::GetBaseNodePeer).await?? {
+            BaseNodeServiceResponse::BaseNodePeer(peer) => Ok(peer.map(|p| *p)),
             _ => Err(BaseNodeServiceError::UnexpectedApiResponse),
         }
     }

--- a/base_layer/wallet/src/base_node_service/mock_base_node_service.rs
+++ b/base_layer/wallet/src/base_node_service/mock_base_node_service.rs
@@ -121,6 +121,10 @@ impl MockBaseNodeService {
                 self.set_base_node_peer(*peer);
                 Ok(BaseNodeServiceResponse::BaseNodePeerSet)
             },
+            BaseNodeServiceRequest::GetBaseNodePeer => {
+                let peer = self.state.base_node_peer.clone();
+                Ok(BaseNodeServiceResponse::BaseNodePeer(peer.map(Box::new)))
+            },
             BaseNodeServiceRequest::GetChainMetadata => Ok(BaseNodeServiceResponse::ChainMetadata(
                 self.state.chain_metadata.clone(),
             )),

--- a/base_layer/wallet/src/base_node_service/service.rs
+++ b/base_layer/wallet/src/base_node_service/service.rs
@@ -187,6 +187,10 @@ where T: WalletBackend + 'static
                 self.set_base_node_peer(*peer).await;
                 Ok(BaseNodeServiceResponse::BaseNodePeerSet)
             },
+            BaseNodeServiceRequest::GetBaseNodePeer => {
+                let peer = self.get_state().await.base_node_peer.map(Box::new);
+                Ok(BaseNodeServiceResponse::BaseNodePeer(peer))
+            },
             BaseNodeServiceRequest::GetChainMetadata => match self.get_state().await.chain_metadata.clone() {
                 Some(metadata) => Ok(BaseNodeServiceResponse::ChainMetadata(Some(metadata))),
                 None => {

--- a/base_layer/wallet/src/wallet.rs
+++ b/base_layer/wallet/src/wallet.rs
@@ -250,7 +250,7 @@ where
         self.comms.clone().wait_until_shutdown().await;
     }
 
-    /// This function will set the base_node that the wallet uses to broadcast transactions, monitor outputs, and
+    /// This function will set the base node that the wallet uses to broadcast transactions, monitor outputs, and
     /// monitor the base node state.
     pub async fn set_base_node_peer(
         &mut self,
@@ -294,6 +294,13 @@ where
         self.base_node_service.set_base_node_peer(peer).await?;
 
         Ok(())
+    }
+
+    pub async fn get_base_node_peer(&mut self) -> Result<Option<Peer>, WalletError> {
+        self.base_node_service
+            .get_base_node_peer()
+            .await
+            .map_err(WalletError::BaseNodeServiceError)
     }
 
     /// Import an external spendable UTXO into the wallet. The output will be added to the Output Manager and made

--- a/common/src/configuration/bootstrap.rs
+++ b/common/src/configuration/bootstrap.rs
@@ -69,15 +69,13 @@ use std::{
 };
 use structopt::StructOpt;
 
-#[derive(StructOpt, Debug)]
+#[derive(StructOpt, Debug, Clone)]
 pub struct ConfigBootstrap {
     /// A path to a directory to store your files
     #[structopt(
         short,
         long,
-        alias("base_path"),
-        alias("base_dir"),
-        alias("base-dir"),
+        aliases = &["base_path", "base_dir", "base-dir"],
         hide_default_value(true),
         default_value = ""
     )]
@@ -89,7 +87,7 @@ pub struct ConfigBootstrap {
     #[structopt(
         short,
         long,
-        alias("log_config"),
+        alias = "log_config",
         env = "TARI_LOG_CONFIGURATION",
         hide_default_value(true),
         default_value = ""
@@ -99,48 +97,52 @@ pub struct ConfigBootstrap {
     #[structopt(long)]
     pub init: bool,
     /// Create and save new node identity if one doesn't exist
-    #[structopt(long, alias("create_id"))]
+    #[structopt(long, alias = "create_id")]
     pub create_id: bool,
     /// Run in daemon mode, with no interface
-    #[structopt(short, long, alias("daemon"))]
+    #[structopt(short, long, alias = "daemon")]
     pub daemon_mode: bool,
     /// This will rebuild the db, adding block for block in
-    #[structopt(long, alias("rebuild_db"))]
+    #[structopt(long, alias = "rebuild_db")]
     pub rebuild_db: bool,
     /// Path to input file of commands
-    #[structopt(short, long, alias("input"), alias("script"), parse(from_os_str))]
+    #[structopt(short, long, aliases = &["input", "script"], parse(from_os_str))]
     pub input_file: Option<PathBuf>,
     /// Single input command
     #[structopt(long)]
     pub command: Option<String>,
     /// This will clean out the orphans db at startup
-    #[structopt(long, alias("clean_orphans_db"))]
+    #[structopt(long, alias = "clean_orphans_db")]
     pub clean_orphans_db: bool,
     /// Supply the password for the console wallet
     #[structopt(long)]
     pub password: Option<String>,
     /// Change the password for the console wallet
-    #[structopt(long, alias("update-password"))]
+    #[structopt(long, alias = "update-password")]
     pub change_password: bool,
     /// Force wallet recovery
-    #[structopt(long, alias("recover"))]
+    #[structopt(long, alias = "recover")]
     pub recovery: bool,
     /// Supply the optional wallet seed words for recovery on the command line
-    #[structopt(long, alias("seed_words"))]
+    #[structopt(long, alias = "seed_words")]
     pub seed_words: Option<String>,
     /// Supply the optional file name to save the wallet seed words into
-    #[structopt(long, aliases(&["seed_words_file_name", "seed-words-file"]), parse(from_os_str))]
+    #[structopt(long, aliases = &["seed_words_file_name", "seed-words-file"], parse(from_os_str))]
     pub seed_words_file_name: Option<PathBuf>,
     /// Wallet notify script
-    #[structopt(long, alias("notify"))]
+    #[structopt(long, alias = "notify")]
     pub wallet_notify: Option<PathBuf>,
-    #[structopt(long, alias("mine-until-height"))]
+    /// Automatically exit wallet command/script mode when done
+    #[structopt(long, alias = "auto-exit")]
+    pub command_mode_auto_exit: bool,
+    /// Mining node options
+    #[structopt(long, alias = "mine-until-height")]
     pub mine_until_height: Option<u64>,
-    #[structopt(long, alias("max-blocks"))]
+    #[structopt(long, alias = "max-blocks")]
     pub miner_max_blocks: Option<u64>,
-    #[structopt(long, alias("min-difficulty"))]
+    #[structopt(long, alias = "min-difficulty")]
     pub miner_min_diff: Option<u64>,
-    #[structopt(long, alias("max-difficulty"))]
+    #[structopt(long, alias = "max-difficulty")]
     pub miner_max_diff: Option<u64>,
 }
 
@@ -171,6 +173,7 @@ impl Default for ConfigBootstrap {
             seed_words: None,
             seed_words_file_name: None,
             wallet_notify: None,
+            command_mode_auto_exit: false,
             mine_until_height: None,
             miner_max_blocks: None,
             miner_min_diff: None,

--- a/integration_tests/features/support/steps.js
+++ b/integration_tests/features/support/steps.js
@@ -379,8 +379,8 @@ When(
     let walletB = this.getWallet(walletNameB);
     let clientB = walletB.getClient();
 
-    await walletA.export_spent_outputs();
-    let spent_outputs = await walletA.read_exported_outputs();
+    await walletA.exportSpentOutputs();
+    let spent_outputs = await walletA.readExportedOutputs();
     let result = await clientB.importUtxos(spent_outputs);
     lastResult = result.tx_ids;
   }
@@ -393,8 +393,8 @@ When(
     let walletB = this.getWallet(walletNameB);
     let clientB = walletB.getClient();
 
-    await walletA.export_unspent_outputs();
-    let outputs = await walletA.read_exported_outputs();
+    await walletA.exportUnspentOutputs();
+    let outputs = await walletA.readExportedOutputs();
     let result = await clientB.importUtxos(outputs);
     lastResult = result.tx_ids;
   }

--- a/integration_tests/helpers/walletProcess.js
+++ b/integration_tests/helpers/walletProcess.js
@@ -148,8 +148,7 @@ class WalletProcess {
   }
 
   async start() {
-    let args;
-    args = [
+    const args = [
       "--base-path",
       ".",
       "--init",
@@ -169,29 +168,27 @@ class WalletProcess {
     return await this.run(await this.compile(), args, true);
   }
 
-  async export_spent_outputs() {
-    let args;
-    args = [
+  async exportSpentOutputs() {
+    const args = [
       "--init",
       "--base-path",
       ".",
-      "--daemon",
+      "--auto-exit",
       "--password",
       "kensentme",
       "--command",
-      "export-spent-utxos  --csv-file exported_outputs.csv",
+      "export-spent-utxos --csv-file exported_outputs.csv",
     ];
     outputProcess = __dirname + "/../temp/out/tari_console_wallet";
     await this.run(outputProcess, args, true);
   }
 
-  async export_unspent_outputs() {
-    let args;
-    args = [
+  async exportUnspentOutputs() {
+    const args = [
       "--init",
       "--base-path",
       ".",
-      "--daemon",
+      "--auto-exit",
       "--password",
       "kensentme",
       "--command",
@@ -201,7 +198,7 @@ class WalletProcess {
     await this.run(outputProcess, args, true);
   }
 
-  async read_exported_outputs() {
+  async readExportedOutputs() {
     const filePath = path.resolve(this.baseDir + "/exported_outputs.csv");
     expect(fs.existsSync(filePath)).to.equal(
       true,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
- Updates the app state in console wallet to correctly display the base node set by new commands `set-base-node` and `set-custom-base-node`
- Allows the `amount` field in the send tab to accept `T` or `uT` and checks that it parses to a valid amount of (micro)Tari

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Bugfix and a quality of life improvement 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manually tested

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `tar-script` branch.
* [ ] I have squashed my commits into a single commit.
