### PR TITLE
Remove `height` field from outputs

### DIFF
--- a/RFC/src/RFC-0201_TariScript.md
+++ b/RFC/src/RFC-0201_TariScript.md
@@ -622,7 +622,6 @@ To summarise, the information required for one-sided transactions is as follows:
 | features          | \\( F_a \\)                           | Public                                                                                        |
 | script            | \\( \alpha_a \\)                      | Public                                                                                        |
 | script input      | \\( \input_a \\)                      | Public                                                                                        |
-| height            | \\( h_a \\)                           | Public                                                                                        |
 | script signature  | \\( a_{Sa},b_{Sa}, R_{Sa} \\)         | Alice knows \\( k_{Sa},\\, r_{Sa} \\) and \\( k_{a},\\, v_{a} \\) of the commitment \\(C_a\\) |
 | sender offset public key | \\( K_{Oa} \\)                        | Not used in this transaction                                                                  |
 
@@ -742,7 +741,6 @@ To summarise, the information required for creating a multiparty UTXO is as foll
 | features                    | \\( F_a \\)                           | Public                                                                                        |
 | script                      | \\( \alpha_a \\)                      | Public                                                                                        |
 | script input                | \\( \input_a \\)                      | Public                                                                                        |
-| height                      | \\( h_a \\)                           | Public                                                                                        |
 | script signature            | \\( (a_{Sa},b_{Sa}, R_{Sa}) \\)     | Alice knows \\( k_{Sa},\\, r_{Sa} \\) and \\( k_{a},\\, v_{a} \\) of the commitment \\(C_a\\) |
 | sender offset&nbsp;public&nbsp;key | \\( K_{Oa} \\)                        | Not used in this transaction                                                                  |
 
@@ -765,7 +763,6 @@ When spending the multi-party input:
 | features                    | \\( F_s \\)                             | Public                                                                                                                                                             |
 | script                      | \\( \alpha_s \\)                        | Public                                                                                                                                                             |
 | script input                | \\( \input_s \\)                        | Public                                                                                                                                                             |
-| height                      | \\( h_a \\)                             | Public                                                                                                                                                             |
 | script&nbsp;signature       | \\( (a_{Ss} ,b_{Ss} , R_{Ss}) \\)     | Alice knows \\( (k_{SsA},\\, r_{SsA}) \\), Bob knows \\( (k_{SsB},\\, r_{SsB}) \\). Both parties know \\( (k_{s},\\, v_{s}) \\). Neither party knows \\( k_{Ss}\\) |
 | sender offset&nbsp;public&nbsp;key | \\( K_{Os} \\)                          | As above, Alice and Bob each know part of the sender offset key                                                                                                           |
 

--- a/applications/tari_app_grpc/proto/types.proto
+++ b/applications/tari_app_grpc/proto/types.proto
@@ -166,8 +166,6 @@ message TransactionInput {
     bytes script = 4;
     // The script input data, if any
     bytes input_data = 5;
-    // The block height that the UTXO was mined
-    uint64 height = 6;
     // A signature with k_s, signing the script, input data, and mined height
     ComSignature script_signature = 7;
     // The offset public key, K_O
@@ -318,8 +316,6 @@ message UnblindedOutput {
     bytes script = 4;
     // Tari script input data for spending
     bytes input_data = 5;
-    // The block height that the UTXO was mined
-    uint64 height = 6;
     // Tari script private key
     bytes script_private_key = 7;
     // Tari script offset pubkey, K_O

--- a/applications/tari_app_grpc/src/conversions/transaction_input.rs
+++ b/applications/tari_app_grpc/src/conversions/transaction_input.rs
@@ -59,7 +59,6 @@ impl TryFrom<grpc::TransactionInput> for TransactionInput {
             commitment,
             script,
             input_data,
-            height: input.height,
             script_signature,
             script_offset_public_key,
         })
@@ -78,7 +77,6 @@ impl From<TransactionInput> for grpc::TransactionInput {
             hash,
             script: input.script.as_bytes(),
             input_data: input.input_data.as_bytes(),
-            height: input.height,
             script_signature: Some(grpc::ComSignature {
                 public_nonce_commitment: Vec::from(input.script_signature.public_nonce().as_bytes()),
                 signature_u: Vec::from(input.script_signature.u().as_bytes()),

--- a/applications/tari_app_grpc/src/conversions/unblinded_output.rs
+++ b/applications/tari_app_grpc/src/conversions/unblinded_output.rs
@@ -43,7 +43,6 @@ impl From<UnblindedOutput> for grpc::UnblindedOutput {
             }),
             script: output.script.as_bytes(),
             input_data: output.input_data.as_bytes(),
-            height: output.height,
             script_private_key: output.script_private_key.as_bytes().to_vec(),
             script_offset_public_key: output.script_offset_public_key.as_bytes().to_vec(),
             sender_metadata_signature: Some(grpc::Signature {
@@ -89,7 +88,6 @@ impl TryFrom<grpc::UnblindedOutput> for UnblindedOutput {
             features,
             script,
             input_data,
-            height: output.height,
             script_private_key,
             script_offset_public_key,
             sender_metadata_signature,

--- a/applications/tari_console_wallet/src/automation/commands.rs
+++ b/applications/tari_console_wallet/src/automation/commands.rs
@@ -645,13 +645,13 @@ fn write_utxos_to_csv_file(utxos: Vec<UnblindedOutput>, file_path: String) -> Re
     let mut csv_file = LineWriter::new(file);
     writeln!(
         csv_file,
-        r##""index","value","spending_key","commitment","flags","maturity","script","input_data","height","script_private_key","script_offset_public_key","signature","public_nonce""##
+        r##""index","value","spending_key","commitment","flags","maturity","script","input_data","script_private_key","script_offset_public_key","signature","public_nonce""##
     )
     .map_err(|e| CommandError::CSVFile(e.to_string()))?;
     for (i, utxo) in utxos.iter().enumerate() {
         writeln!(
             csv_file,
-            r##""{}","{}","{}","{}","{:?}","{}","{}","{}","{}","{}","{}","{}","{}""##,
+            r##""{}","{}","{}","{}","{:?}","{}","{}","{}","{}","{}","{}","{}""##,
             i + 1,
             utxo.value.0,
             utxo.spending_key.to_hex(),
@@ -660,7 +660,6 @@ fn write_utxos_to_csv_file(utxos: Vec<UnblindedOutput>, file_path: String) -> Re
             utxo.features.maturity,
             utxo.script.to_hex(),
             utxo.input_data.to_hex(),
-            utxo.height,
             utxo.script_private_key.to_hex(),
             utxo.script_offset_public_key.to_hex(),
             utxo.sender_metadata_signature.get_signature().to_hex(),

--- a/base_layer/core/src/proto/transaction.proto
+++ b/base_layer/core/src/proto/transaction.proto
@@ -38,8 +38,6 @@ message TransactionInput {
     bytes script = 3;
     // The script input data, if any
     bytes input_data = 4;
-    // The block height that the UTXO was mined
-    uint64 height = 5;
     // A signature with k_s, signing the script, input data, and mined height
     ComSignature script_signature = 6;
     // The offset pubkey, K_O

--- a/base_layer/core/src/proto/transaction.rs
+++ b/base_layer/core/src/proto/transaction.rs
@@ -121,7 +121,6 @@ impl TryFrom<proto::types::TransactionInput> for TransactionInput {
             commitment,
             script: TariScript::from_bytes(input.script.as_slice()).map_err(|err| format!("{:?}", err))?,
             input_data: ExecutionStack::from_bytes(input.input_data.as_slice()).map_err(|err| format!("{:?}", err))?,
-            height: input.height,
             script_signature,
             script_offset_public_key,
         })
@@ -135,7 +134,6 @@ impl From<TransactionInput> for proto::types::TransactionInput {
             commitment: Some(input.commitment.into()),
             script: input.script.as_bytes(),
             input_data: input.input_data.as_bytes(),
-            height: input.height,
             script_signature: Some(input.script_signature.into()),
             script_offset_public_key: input.script_offset_public_key.as_bytes().to_vec(),
         }

--- a/base_layer/core/src/transactions/coinbase_builder.rs
+++ b/base_layer/core/src/transactions/coinbase_builder.rs
@@ -201,7 +201,6 @@ impl CoinbaseBuilder {
             Some(output_features),
             script,
             inputs!(PublicKey::from_secret_key(&script_private_key)),
-            height,
             script_private_key,
             script_offset_pub_key,
             sender_sig,

--- a/base_layer/core/src/transactions/helpers.rs
+++ b/base_layer/core/src/transactions/helpers.rs
@@ -169,7 +169,6 @@ pub fn create_unblinded_output(
         Some(output_features),
         script,
         inputs!(PublicKey::from_secret_key(&test_params.script_private_key)),
-        0, // TODO: This will be removed by a later PR
         test_params.script_private_key,
         test_params.script_offset_pub_key,
         sender_sig,
@@ -211,12 +210,11 @@ macro_rules! tx {
 /// The output of this macro is intended to be used in [spend_utxos].
 #[macro_export]
 macro_rules! txn_schema {
-    (from: $input:expr, to: $outputs:expr, fee: $fee:expr, lock: $lock:expr, mined_height: $mined_height:expr, features: $features:expr) => {{
+    (from: $input:expr, to: $outputs:expr, fee: $fee:expr, lock: $lock:expr, features: $features:expr) => {{
         $crate::transactions::helpers::TransactionSchema {
             from: $input.clone(),
             to: $outputs.clone(),
             fee: $fee,
-            mined_height: $mined_height,
             lock_height: $lock,
             features: $features
         }
@@ -228,7 +226,6 @@ macro_rules! txn_schema {
             to:$outputs,
             fee:$fee,
             lock:$lock,
-            mined_height: 0,
             features: $features
         )
     }};
@@ -259,7 +256,6 @@ macro_rules! txn_schema {
 pub struct TransactionSchema {
     pub from: Vec<UnblindedOutput>,
     pub to: Vec<MicroTari>,
-    pub mined_height: u64,
     pub fee: MicroTari,
     pub lock_height: u64,
     pub features: OutputFeatures,
@@ -354,8 +350,7 @@ pub fn spend_utxos(schema: TransactionSchema) -> (Transaction, Vec<UnblindedOutp
         );
 
     for tx_input in &schema.from {
-        let mut input = tx_input.clone();
-        input.height = schema.mined_height;
+        let input = tx_input.clone();
         let utxo = input
             .as_transaction_input(&factories.commitment)
             .expect("Should be able to make a transaction input");
@@ -396,7 +391,6 @@ pub fn spend_utxos(schema: TransactionSchema) -> (Transaction, Vec<UnblindedOutp
         inputs!(PublicKey::from_secret_key(
             &test_params_change_and_txn.script_private_key
         )),
-        0,
         test_params_change_and_txn.script_private_key.clone(),
         change_script_offset_public_key,
         sender_sig,

--- a/base_layer/core/src/transactions/transaction.rs
+++ b/base_layer/core/src/transactions/transaction.rs
@@ -210,7 +210,6 @@ pub struct UnblindedOutput {
     pub features: OutputFeatures,
     pub script: TariScript,
     pub input_data: ExecutionStack,
-    pub height: u64,
     pub script_private_key: PrivateKey,
     pub script_offset_public_key: PublicKey,
     pub sender_metadata_signature: Signature,
@@ -225,7 +224,6 @@ impl UnblindedOutput {
         features: Option<OutputFeatures>,
         script: TariScript,
         input_data: ExecutionStack,
-        height: u64,
         script_private_key: PrivateKey,
         script_offset_public_key: PublicKey,
         sender_metadata_signature: Signature,
@@ -236,7 +234,6 @@ impl UnblindedOutput {
             features: features.unwrap_or_default(),
             script,
             input_data,
-            height,
             script_private_key,
             script_offset_public_key,
             sender_metadata_signature,
@@ -273,7 +270,6 @@ impl UnblindedOutput {
             commitment,
             script: self.script.clone(),
             input_data: self.input_data.clone(),
-            height: self.height,
             script_signature,
             script_offset_public_key: self.script_offset_public_key.clone(),
         })
@@ -381,8 +377,6 @@ pub struct TransactionInput {
     pub script: TariScript,
     /// The script input data, if any
     pub input_data: ExecutionStack,
-    /// The block height that the UTXO was mined
-    pub height: u64,
     /// A signature with k_s, signing the script, input data, and mined height
     pub script_signature: ComSignature,
     /// The offset pubkey, K_O
@@ -397,7 +391,6 @@ impl TransactionInput {
         commitment: Commitment,
         script: TariScript,
         input_data: ExecutionStack,
-        height: u64,
         script_signature: ComSignature,
         script_offset_public_key: PublicKey,
     ) -> TransactionInput {
@@ -406,7 +399,6 @@ impl TransactionInput {
             commitment,
             script,
             input_data,
-            height,
             script_signature,
             script_offset_public_key,
         }
@@ -1366,7 +1358,6 @@ mod test {
 
         let script = TariScript::default();
         let input_data = ExecutionStack::default();
-        let height = 0;
         let script_signature = ComSignature::default();
         let offset_pub_key = PublicKey::default();
         let mut input = TransactionInput::new(
@@ -1374,7 +1365,6 @@ mod test {
             c,
             script,
             input_data,
-            height,
             script_signature,
             offset_pub_key,
         );

--- a/base_layer/core/src/transactions/transaction_protocol/transaction_initializer.rs
+++ b/base_layer/core/src/transactions/transaction_protocol/transaction_initializer.rs
@@ -287,7 +287,6 @@ impl SenderTransactionInitializer {
                                 .as_ref()
                                 .ok_or("Change script was not provided")?
                                 .clone(),
-                            0,
                             self.change_script_private_key
                                 .as_ref()
                                 .ok_or("Change script private key was not provided")?
@@ -722,7 +721,6 @@ mod test {
         let factories = CryptoFactories::default();
         let p = TestParams::new();
         let (utxo, input) = create_test_input(MicroTari(500), 0, &factories.commitment);
-
         let script = script!(Nop);
         let output = create_unblinded_output(script.clone(), OutputFeatures::default(), p.clone(), MicroTari(400));
         // Start the builder
@@ -747,7 +745,6 @@ mod test {
         let factories = CryptoFactories::default();
         let p = TestParams::new();
         let (utxo, input) = create_test_input(MicroTari(400), 0, &factories.commitment);
-
         let script = script!(Nop);
         let output = create_unblinded_output(script.clone(), OutputFeatures::default(), p.clone(), MicroTari(400));
         // Start the builder
@@ -772,7 +769,6 @@ mod test {
         let factories = CryptoFactories::default();
         let p = TestParams::new();
         let (utxo, input) = create_test_input(MicroTari(100_000), 0, &factories.commitment);
-
         let script = script!(Nop);
         let output = create_unblinded_output(script.clone(), OutputFeatures::default(), p.clone(), MicroTari(15000));
         // Start the builder

--- a/base_layer/core/tests/base_node_rpc.rs
+++ b/base_layer/core/tests/base_node_rpc.rs
@@ -145,7 +145,7 @@ fn test_base_node_wallet_rpc() {
         from: vec![utxos1[0].clone()],
         to: vec![400_000 * uT, 590_000 * uT]
     )]);
-    let mut tx2 = (*txs2[0]).clone();
+    let tx2 = (*txs2[0]).clone();
     let tx2_sig = tx2.first_kernel_excess_sig().unwrap().clone();
 
     // Query Tx1
@@ -193,10 +193,6 @@ fn test_base_node_wallet_rpc() {
         .block_on(base_node.local_nci.submit_block(block1.clone(), Broadcast::from(true)))
         .is_ok());
 
-    // fix tx mined height
-    for input in tx2.body.inputs_mut() {
-        input.height = 1;
-    }
     // Check that subitting Tx2 will now be accepted
     let msg = TransactionProto::from(tx2);
     let req = request_mock.request_with_context(Default::default(), msg);

--- a/base_layer/core/tests/mempool.rs
+++ b/base_layer/core/tests/mempool.rs
@@ -77,14 +77,14 @@ fn test_insert_and_process_published_block() {
     // Create a block with 4 outputs
     let txs = vec![txn_schema!(
         from: vec![outputs[0][0].clone()],
-        to: vec![2 * T, 2 * T, 2 * T, 2 * T],fee: 25.into(), lock: 0,mined_height: 0, features: OutputFeatures::default()
+        to: vec![2 * T, 2 * T, 2 * T, 2 * T],fee: 25.into(), lock: 0, features: OutputFeatures::default()
     )];
     generate_new_block(&mut store, &mut blocks, &mut outputs, txs, &consensus_manager).unwrap();
     // Create 6 new transactions to add to the mempool
     let (orphan, _, _) = tx!(1*T, fee: 100*uT);
     let orphan = Arc::new(orphan);
 
-    let tx2 = txn_schema!(from: vec![outputs[1][0].clone()], to: vec![1*T], fee: 20*uT, lock: 0,mined_height: 1, features: OutputFeatures::default());
+    let tx2 = txn_schema!(from: vec![outputs[1][0].clone()], to: vec![1*T], fee: 20*uT, lock: 0, features: OutputFeatures::default());
     let tx2 = Arc::new(spend_utxos(tx2).0);
 
     let tx3 = txn_schema!(
@@ -92,7 +92,6 @@ fn test_insert_and_process_published_block() {
         to: vec![1*T],
         fee: 20*uT,
         lock: 4,
-        mined_height: 1,
         features: OutputFeatures::with_maturity(1)
     );
     let tx3 = Arc::new(spend_utxos(tx3).0);
@@ -102,11 +101,10 @@ fn test_insert_and_process_published_block() {
         to: vec![1*T],
         fee: 20*uT,
         lock: 3,
-        mined_height: 1,
         features: OutputFeatures::with_maturity(2)
     );
     let tx5 = Arc::new(spend_utxos(tx5).0);
-    let tx6 = txn_schema!(from: vec![outputs[1][3].clone()], to: vec![1 * T], fee: 25*uT, lock: 0,mined_height: 1, features: OutputFeatures::default());
+    let tx6 = txn_schema!(from: vec![outputs[1][3].clone()], to: vec![1 * T], fee: 25*uT, lock: 0, features: OutputFeatures::default());
     let tx6 = spend_utxos(tx6).0;
 
     mempool.insert(orphan.clone()).unwrap();
@@ -212,12 +210,12 @@ fn test_time_locked() {
     // Create a block with 4 outputs
     let txs = vec![txn_schema!(
         from: vec![outputs[0][0].clone()],
-        to: vec![2 * T, 2 * T, 2 * T, 2 * T], fee: 25*uT, lock: 0,mined_height: 0, features: OutputFeatures::default()
+        to: vec![2 * T, 2 * T, 2 * T, 2 * T], fee: 25*uT, lock: 0, features: OutputFeatures::default()
     )];
     generate_new_block(&mut store, &mut blocks, &mut outputs, txs, &consensus_manager).unwrap();
     mempool.process_published_block(blocks[1].to_arc_block()).unwrap();
     // Block height should be 1
-    let mut tx2 = txn_schema!(from: vec![outputs[1][0].clone()], to: vec![1*T], fee: 20*uT, lock: 0,mined_height: 1, features: OutputFeatures::default());
+    let mut tx2 = txn_schema!(from: vec![outputs[1][0].clone()], to: vec![1*T], fee: 20*uT, lock: 0, features: OutputFeatures::default());
     tx2.lock_height = 3;
     let tx2 = Arc::new(spend_utxos(tx2).0);
 
@@ -226,7 +224,6 @@ fn test_time_locked() {
         to: vec![1*T],
         fee: 20*uT,
         lock: 4,
-        mined_height: 1,
         features: OutputFeatures::with_maturity(1)
     );
     tx3.lock_height = 2;
@@ -263,17 +260,17 @@ fn test_retrieve() {
     mempool.process_published_block(blocks[1].to_arc_block()).unwrap();
     // 1-Block, 8 UTXOs, empty mempool
     let txs = vec![
-        txn_schema!(from: vec![outputs[1][0].clone()], to: vec![], fee: 30*uT, lock: 0, mined_height: 1, features: OutputFeatures::default()),
-        txn_schema!(from: vec![outputs[1][1].clone()], to: vec![], fee: 20*uT, lock: 0, mined_height: 1, features: OutputFeatures::default()),
-        txn_schema!(from: vec![outputs[1][2].clone()], to: vec![], fee: 40*uT, lock: 0, mined_height: 1, features: OutputFeatures::default()),
-        txn_schema!(from: vec![outputs[1][3].clone()], to: vec![], fee: 50*uT, lock: 0, mined_height: 1, features: OutputFeatures::default()),
-        txn_schema!(from: vec![outputs[1][4].clone()], to: vec![], fee: 20*uT, lock: 2, mined_height: 1, features: OutputFeatures::default()),
-        txn_schema!(from: vec![outputs[1][5].clone()], to: vec![], fee: 20*uT, lock: 3, mined_height: 1, features: OutputFeatures::default()),
+        txn_schema!(from: vec![outputs[1][0].clone()], to: vec![], fee: 30*uT, lock: 0, features: OutputFeatures::default()),
+        txn_schema!(from: vec![outputs[1][1].clone()], to: vec![], fee: 20*uT, lock: 0, features: OutputFeatures::default()),
+        txn_schema!(from: vec![outputs[1][2].clone()], to: vec![], fee: 40*uT, lock: 0, features: OutputFeatures::default()),
+        txn_schema!(from: vec![outputs[1][3].clone()], to: vec![], fee: 50*uT, lock: 0, features: OutputFeatures::default()),
+        txn_schema!(from: vec![outputs[1][4].clone()], to: vec![], fee: 20*uT, lock: 2, features: OutputFeatures::default()),
+        txn_schema!(from: vec![outputs[1][5].clone()], to: vec![], fee: 20*uT, lock: 3, features: OutputFeatures::default()),
         // Will be time locked when a tx is added to mempool with this as an input:
-        txn_schema!(from: vec![outputs[1][6].clone()], to: vec![800_000*uT], fee: 60*uT, lock: 0, mined_height: 1,
+        txn_schema!(from: vec![outputs[1][6].clone()], to: vec![800_000*uT], fee: 60*uT, lock: 0, 
         features: OutputFeatures::with_maturity(4)),
         // Will be time locked when a tx is added to mempool with this as an input:
-        txn_schema!(from: vec![outputs[1][7].clone()], to: vec![800_000*uT], fee: 25*uT, lock: 0, mined_height: 1,
+        txn_schema!(from: vec![outputs[1][7].clone()], to: vec![800_000*uT], fee: 25*uT, lock: 0, 
         features: OutputFeatures::with_maturity(3)),
     ];
     let (tx, utxos) = schema_to_transaction(&txs);
@@ -310,9 +307,9 @@ fn test_retrieve() {
     assert_eq!(stats.reorg_txs, 5);
     // Create transactions wih time-locked inputs
     let txs = vec![
-        txn_schema!(from: vec![outputs[2][6].clone()], to: vec![], fee: 80*uT, lock: 0,mined_height: 2, features: OutputFeatures::default()),
+        txn_schema!(from: vec![outputs[2][6].clone()], to: vec![], fee: 80*uT, lock: 0, features: OutputFeatures::default()),
         // account for change output
-        txn_schema!(from: vec![outputs[2][8].clone()], to: vec![], fee: 40*uT, lock: 0,mined_height: 2, features: OutputFeatures::default()),
+        txn_schema!(from: vec![outputs[2][8].clone()], to: vec![], fee: 40*uT, lock: 0, features: OutputFeatures::default()),
     ];
     let (tx2, _) = schema_to_transaction(&txs);
     tx2.iter().for_each(|t| {
@@ -343,16 +340,16 @@ fn test_reorg() {
 
     // "Mine" Block 1
     let txs = vec![
-        txn_schema!(from: vec![outputs[0][0].clone()], to: vec![1 * T, 1 * T], fee: 25*uT, lock: 0,mined_height: 0, features: OutputFeatures::default()),
+        txn_schema!(from: vec![outputs[0][0].clone()], to: vec![1 * T, 1 * T], fee: 25*uT, lock: 0, features: OutputFeatures::default()),
     ];
     generate_new_block(&mut db, &mut blocks, &mut outputs, txs, &consensus_manager).unwrap();
     mempool.process_published_block(blocks[1].to_arc_block()).unwrap();
 
     // "Mine" block 2
     let schemas = vec![
-        txn_schema!(from: vec![outputs[1][0].clone()], to: vec![], fee: 25*uT, lock: 0,mined_height: 1, features: OutputFeatures::default()),
-        txn_schema!(from: vec![outputs[1][1].clone()], to: vec![], fee: 25*uT, lock: 0,mined_height: 1, features: OutputFeatures::default()),
-        txn_schema!(from: vec![outputs[1][2].clone()], to: vec![], fee: 25*uT, lock: 0,mined_height: 1, features: OutputFeatures::default()),
+        txn_schema!(from: vec![outputs[1][0].clone()], to: vec![], fee: 25*uT, lock: 0, features: OutputFeatures::default()),
+        txn_schema!(from: vec![outputs[1][1].clone()], to: vec![], fee: 25*uT, lock: 0, features: OutputFeatures::default()),
+        txn_schema!(from: vec![outputs[1][2].clone()], to: vec![], fee: 25*uT, lock: 0, features: OutputFeatures::default()),
     ];
     let (txns2, utxos) = schema_to_transaction(&schemas);
     outputs.push(utxos);
@@ -367,9 +364,9 @@ fn test_reorg() {
 
     // "Mine" block 3
     let schemas = vec![
-        txn_schema!(from: vec![outputs[2][0].clone()], to: vec![], fee: 25*uT, lock: 0,mined_height: 2, features: OutputFeatures::default()),
-        txn_schema!(from: vec![outputs[2][1].clone()], to: vec![], fee: 25*uT, lock: 5, mined_height: 2, features: OutputFeatures::default()),
-        txn_schema!(from: vec![outputs[2][2].clone()], to: vec![], fee: 25*uT, lock: 0,mined_height: 2, features: OutputFeatures::default()),
+        txn_schema!(from: vec![outputs[2][0].clone()], to: vec![], fee: 25*uT, lock: 0, features: OutputFeatures::default()),
+        txn_schema!(from: vec![outputs[2][1].clone()], to: vec![], fee: 25*uT, lock: 5, features: OutputFeatures::default()),
+        txn_schema!(from: vec![outputs[2][2].clone()], to: vec![], fee: 25*uT, lock: 0, features: OutputFeatures::default()),
     ];
     let (txns3, utxos) = schema_to_transaction(&schemas);
     outputs.push(utxos);

--- a/base_layer/wallet/migrations/2021-07-02-090239_remove_height_from_output/down.sql
+++ b/base_layer/wallet/migrations/2021-07-02-090239_remove_height_from_output/down.sql
@@ -1,0 +1,27 @@
+PRAGMA foreign_keys=off;
+ALTER TABLE outputs RENAME TO outputs_old;
+CREATE TABLE outputs (
+                         id INTEGER NOT NULL PRIMARY KEY,
+                         commitment BLOB NOT NULL,
+                         spending_key BLOB NOT NULL,
+                         value INTEGER NOT NULL,
+                         flags INTEGER NOT NULL,
+                         maturity INTEGER NOT NULL,
+                         status INTEGER NOT NULL,
+                         tx_id INTEGER NULL,
+                         hash BLOB NOT NULL,
+                         script BLOB NOT NULL,
+                         input_data BLOB NOT NULL,
+                         height INTEGER NOT NULL,
+                         script_private_key BLOB NOT NULL,
+                         script_offset_public_key BLOB NOT NULL,
+                         sender_metadata_signature_key BLOB NOT NULL,
+                         sender_metadata_signature_nonce BLOB NOT NULL,
+                         CONSTRAINT unique_commitment UNIQUE (commitment)
+);
+
+INSERT INTO outputs (id, commitment, spending_key, value, flags, maturity, status, tx_id, hash, script, input_data, height, script_private_key, script_offset_public_key, sender_metadata_signature_key, sender_metadata_signature_nonce)
+SELECT id, commitment, spending_key, value, flags, maturity, status, tx_id, hash, script, input_data, 0, script_private_key, script_offset_public_key, sender_metadata_signature_key, sender_metadata_signature_nonce
+FROM outputs_old;
+DROP TABLE outputs_old;
+PRAGMA foreign_keys=on;

--- a/base_layer/wallet/migrations/2021-07-02-090239_remove_height_from_output/up.sql
+++ b/base_layer/wallet/migrations/2021-07-02-090239_remove_height_from_output/up.sql
@@ -1,0 +1,26 @@
+PRAGMA foreign_keys=off;
+ALTER TABLE outputs RENAME TO outputs_old;
+CREATE TABLE outputs (
+                         id INTEGER NOT NULL PRIMARY KEY,
+                         commitment BLOB NOT NULL,
+                         spending_key BLOB NOT NULL,
+                         value INTEGER NOT NULL,
+                         flags INTEGER NOT NULL,
+                         maturity INTEGER NOT NULL,
+                         status INTEGER NOT NULL,
+                         tx_id INTEGER NULL,
+                         hash BLOB NOT NULL,
+                         script BLOB NOT NULL,
+                         input_data BLOB NOT NULL,
+                         script_private_key BLOB NOT NULL,
+                         script_offset_public_key BLOB NOT NULL,
+                         sender_metadata_signature_key BLOB NOT NULL,
+                         sender_metadata_signature_nonce BLOB NOT NULL,
+                         CONSTRAINT unique_commitment UNIQUE (commitment)
+);
+
+INSERT INTO outputs (id, commitment, spending_key, value, flags, maturity, status, tx_id, hash, script, input_data, script_private_key, script_offset_public_key, sender_metadata_signature_key, sender_metadata_signature_nonce)
+SELECT id, commitment, spending_key, value, flags, maturity, status, tx_id, hash, script, input_data, script_private_key, script_offset_public_key, sender_metadata_signature_key, sender_metadata_signature_nonce
+FROM outputs_old;
+DROP TABLE outputs_old;
+PRAGMA foreign_keys=on;

--- a/base_layer/wallet/src/output_manager_service/recovery/standard_outputs_recoverer.rs
+++ b/base_layer/wallet/src/output_manager_service/recovery/standard_outputs_recoverer.rs
@@ -64,7 +64,6 @@ where TBackend: OutputManagerBackend + 'static
     pub async fn scan_and_recover_outputs(
         &mut self,
         outputs: Vec<TransactionOutput>,
-        height: u64,
     ) -> Result<Vec<UnblindedOutput>, OutputManagerError> {
         let mut rewound_outputs: Vec<UnblindedOutput> = outputs
             .into_iter()
@@ -94,7 +93,6 @@ where TBackend: OutputManagerBackend + 'static
                         Some(features),
                         script,
                         inputs!(PublicKey::from_secret_key(&output.blinding_factor)),
-                        height,
                         output.blinding_factor,
                         script_offset_public_key,
                         sender_metadata_signature,

--- a/base_layer/wallet/src/output_manager_service/service.rs
+++ b/base_layer/wallet/src/output_manager_service/service.rs
@@ -323,29 +323,22 @@ where TBackend: OutputManagerBackend + 'static
             OutputManagerRequest::GetPublicRewindKeys => Ok(OutputManagerResponse::PublicRewindKeys(Box::new(
                 self.resources.master_key_manager.get_rewind_public_keys(),
             ))),
-            OutputManagerRequest::ScanForRecoverableOutputs(outputs, height) => StandardUtxoRecoverer::new(
+            OutputManagerRequest::ScanForRecoverableOutputs(outputs) => StandardUtxoRecoverer::new(
                 self.resources.master_key_manager.clone(),
                 self.resources.factories.clone(),
                 self.resources.db.clone(),
             )
-            .scan_and_recover_outputs(outputs, height)
+            .scan_and_recover_outputs(outputs)
             .await
             .map(OutputManagerResponse::RewoundOutputs),
-            OutputManagerRequest::ScanOutputs(outputs, height) => self
-                .scan_outputs_for_one_sided_payments(outputs, height)
+            OutputManagerRequest::ScanOutputs(outputs) => self
+                .scan_outputs_for_one_sided_payments(outputs)
                 .await
                 .map(OutputManagerResponse::ScanOutputs),
             OutputManagerRequest::AddKnownOneSidedPaymentScript(known_script) => self
                 .add_known_script(known_script)
                 .await
                 .map(|_| OutputManagerResponse::AddKnownOneSidedPaymentScript),
-            OutputManagerRequest::UpdateMinedHeight(tx_id, height) => self
-                .resources
-                .db
-                .update_output_mined_height(tx_id, height)
-                .await
-                .map(|_| OutputManagerResponse::MinedHeightUpdated)
-                .map_err(OutputManagerError::OutputManagerStorageError),
         }
     }
 
@@ -439,7 +432,6 @@ where TBackend: OutputManagerBackend + 'static
                 single_round_sender_data.script.clone(),
                 // TODO: The input data should be variable; this will only work for a Nop script
                 inputs!(PublicKey::from_secret_key(&script_private_key)),
-                0,
                 script_private_key,
                 single_round_sender_data.script_offset_public_key.clone(),
                 single_round_sender_data.sender_metadata_signature.clone(),
@@ -667,12 +659,12 @@ where TBackend: OutputManagerBackend + 'static
             .cancel_pending_transaction_at_block_height(block_height)
             .await?;
 
-        // Clear any matching coinbase outputs for this block_height AND commitment. Even if the older output is valid
+        // Clear any matching outputs for this commitment. Even if the older output is valid
         // we are losing no information as this output has the same commitment.
         match self
             .resources
             .db
-            .remove_coinbase_output_at_block_height(output.commitment.clone(), output.unblinded_output.height)
+            .remove_output_by_commitment(output.commitment.clone())
             .await
         {
             Ok(_) => {},
@@ -686,6 +678,7 @@ where TBackend: OutputManagerBackend + 'static
             .await?;
 
         self.confirm_encumberance(tx_id).await?;
+
         Ok(tx)
     }
 
@@ -736,7 +729,6 @@ where TBackend: OutputManagerBackend + 'static
                 Some(output_features),
                 script,
                 inputs!(PublicKey::from_secret_key(&script_private_key)),
-                0,
                 script_private_key,
                 PublicKey::from_secret_key(&script_offset_private_key),
                 sender_signature,
@@ -1118,7 +1110,6 @@ where TBackend: OutputManagerBackend + 'static
                     Some(output_features),
                     script,
                     inputs!(PublicKey::from_secret_key(&script_private_key)),
-                    0,
                     script_private_key,
                     PublicKey::from_secret_key(&script_offset_private_key),
                     sender_signature,
@@ -1170,7 +1161,6 @@ where TBackend: OutputManagerBackend + 'static
     async fn scan_outputs_for_one_sided_payments(
         &mut self,
         outputs: Vec<TransactionOutput>,
-        height: u64,
     ) -> Result<Vec<UnblindedOutput>, OutputManagerError> {
         let known_one_sided_payment_scripts: Vec<KnownOneSidedPaymentScript> =
             self.resources.db.get_all_known_one_sided_payment_scripts().await?;
@@ -1200,7 +1190,6 @@ where TBackend: OutputManagerBackend + 'static
                         Some(output.features),
                         known_one_sided_payment_scripts[i].script.clone(),
                         known_one_sided_payment_scripts[i].input.clone(),
-                        height,
                         known_one_sided_payment_scripts[i].private_key.clone(),
                         output.script_offset_public_key,
                         output.sender_metadata_signature,

--- a/base_layer/wallet/src/output_manager_service/storage/sqlite_db.rs
+++ b/base_layer/wallet/src/output_manager_service/storage/sqlite_db.rs
@@ -135,6 +135,21 @@ impl OutputManagerBackend for OutputManagerSqliteDatabase {
                     None
                 },
             },
+            DbKey::AnyOutputByCommitment(commitment) => {
+                match OutputSql::find_by_commitment(&commitment.to_vec(), &(*conn)) {
+                    Ok(mut o) => {
+                        self.decrypt_if_necessary(&mut o)?;
+                        Some(DbValue::SpentOutput(Box::new(DbUnblindedOutput::try_from(o)?)))
+                    },
+                    Err(e) => {
+                        match e {
+                            OutputManagerStorageError::DieselError(DieselError::NotFound) => (),
+                            e => return Err(e),
+                        };
+                        None
+                    },
+                }
+            },
             DbKey::PendingTransactionOutputs(tx_id) => match PendingTransactionOutputSql::find(*tx_id, &(*conn)) {
                 Ok(p) => {
                     let mut outputs = OutputSql::find_by_tx_id_and_encumbered(*tx_id, &(*conn))?;
@@ -253,22 +268,6 @@ impl OutputManagerBackend for OutputManagerSqliteDatabase {
                         .collect::<Result<Vec<_>, _>>()?,
                 ))
             },
-            DbKey::CoinbaseOutput {
-                commitment,
-                block_height,
-            } => match OutputSql::find_by_commitment_and_block_height(&commitment.to_vec(), *block_height, &(*conn)) {
-                Ok(mut o) => {
-                    self.decrypt_if_necessary(&mut o)?;
-                    Some(DbValue::CoinbaseOutput(Box::new(DbUnblindedOutput::try_from(o)?)))
-                },
-                Err(e) => {
-                    match e {
-                        OutputManagerStorageError::DieselError(DieselError::NotFound) => (),
-                        e => return Err(e),
-                    };
-                    None
-                },
-            },
         };
 
         Ok(result)
@@ -280,7 +279,7 @@ impl OutputManagerBackend for OutputManagerSqliteDatabase {
         match op {
             WriteOperation::Insert(kvp) => match kvp {
                 DbKeyValuePair::SpentOutput(c, o) => {
-                    if OutputSql::find_by_commitment(&c.to_vec(), &(*conn)).is_ok() {
+                    if OutputSql::find_by_commitment_and_cancelled(&c.to_vec(), false, &(*conn)).is_ok() {
                         return Err(OutputManagerStorageError::DuplicateOutput);
                     }
                     let mut new_output = NewOutputSql::new(*o, OutputStatus::Spent, None)?;
@@ -290,7 +289,7 @@ impl OutputManagerBackend for OutputManagerSqliteDatabase {
                     new_output.commit(&(*conn))?
                 },
                 DbKeyValuePair::UnspentOutput(c, o) => {
-                    if OutputSql::find_by_commitment(&c.to_vec(), &(*conn)).is_ok() {
+                    if OutputSql::find_by_commitment_and_cancelled(&c.to_vec(), false, &(*conn)).is_ok() {
                         return Err(OutputManagerStorageError::DuplicateOutput);
                     }
                     let mut new_output = NewOutputSql::new(*o, OutputStatus::Unspent, None)?;
@@ -298,7 +297,7 @@ impl OutputManagerBackend for OutputManagerSqliteDatabase {
                     new_output.commit(&(*conn))?
                 },
                 DbKeyValuePair::UnspentOutputWithTxId(c, (tx_id, o)) => {
-                    if OutputSql::find_by_commitment(&c.to_vec(), &(*conn)).is_ok() {
+                    if OutputSql::find_by_commitment_and_cancelled(&c.to_vec(), false, &(*conn)).is_ok() {
                         return Err(OutputManagerStorageError::DuplicateOutput);
                     }
                     let mut new_output = NewOutputSql::new(*o, OutputStatus::Unspent, Some(tx_id))?;
@@ -364,14 +363,11 @@ impl OutputManagerBackend for OutputManagerSqliteDatabase {
                         };
                     },
                 },
-                DbKey::CoinbaseOutput {
-                    commitment,
-                    block_height,
-                } => {
-                    match OutputSql::find_by_commitment_and_block_height(&commitment.to_vec(), block_height, &(*conn)) {
+                DbKey::AnyOutputByCommitment(commitment) => {
+                    match OutputSql::find_by_commitment(&commitment.to_vec(), &(*conn)) {
                         Ok(o) => {
                             o.delete(&(*conn))?;
-                            return Ok(Some(DbValue::CoinbaseOutput(Box::new(DbUnblindedOutput::try_from(o)?))));
+                            return Ok(Some(DbValue::AnyOutput(Box::new(DbUnblindedOutput::try_from(o)?))));
                         },
                         Err(e) => {
                             match e {
@@ -433,7 +429,6 @@ impl OutputManagerBackend for OutputManagerSqliteDatabase {
                                 status: Some(OutputStatus::Unspent),
                                 tx_id: None,
                                 spending_key: None,
-                                height: None,
                                 script_private_key: None,
                             },
                             &(*conn),
@@ -444,7 +439,6 @@ impl OutputManagerBackend for OutputManagerSqliteDatabase {
                                 status: Some(OutputStatus::Spent),
                                 tx_id: None,
                                 spending_key: None,
-                                height: None,
                                 script_private_key: None,
                             },
                             &(*conn),
@@ -475,7 +469,7 @@ impl OutputManagerBackend for OutputManagerSqliteDatabase {
 
         let mut outputs_to_be_spent = Vec::with_capacity(outputs_to_send.len());
         for i in outputs_to_send {
-            let output = OutputSql::find_by_commitment(i.commitment.as_bytes(), &(*conn))?;
+            let output = OutputSql::find_by_commitment_and_cancelled(i.commitment.as_bytes(), false, &(*conn))?;
             if output.status == (OutputStatus::Spent as i32) {
                 return Err(OutputManagerStorageError::OutputAlreadySpent);
             }
@@ -490,7 +484,6 @@ impl OutputManagerBackend for OutputManagerSqliteDatabase {
                     status: Some(OutputStatus::EncumberedToBeSpent),
                     tx_id: Some(tx_id),
                     spending_key: None,
-                    height: None,
                     script_private_key: None,
                 },
                 &(*conn),
@@ -553,7 +546,6 @@ impl OutputManagerBackend for OutputManagerSqliteDatabase {
                                 status: Some(OutputStatus::CancelledInbound),
                                 tx_id: None,
                                 spending_key: None,
-                                height: None,
                                 script_private_key: None,
                             },
                             &(*conn),
@@ -564,7 +556,6 @@ impl OutputManagerBackend for OutputManagerSqliteDatabase {
                                 status: Some(OutputStatus::Unspent),
                                 tx_id: None,
                                 spending_key: None,
-                                height: None,
                                 script_private_key: None,
                             },
                             &(*conn),
@@ -620,14 +611,13 @@ impl OutputManagerBackend for OutputManagerSqliteDatabase {
 
     fn invalidate_unspent_output(&self, output: &DbUnblindedOutput) -> Result<Option<TxId>, OutputManagerStorageError> {
         let conn = self.database_connection.acquire_lock();
-        let output = OutputSql::find_by_commitment(&output.commitment.to_vec(), &conn)?;
+        let output = OutputSql::find_by_commitment_and_cancelled(&output.commitment.to_vec(), false, &conn)?;
         let tx_id = output.tx_id.map(|id| id as u64);
         let _ = output.update(
             UpdateOutput {
                 status: Some(OutputStatus::Invalid),
                 tx_id: None,
                 spending_key: None,
-                height: None,
                 script_private_key: None,
             },
             &(*conn),
@@ -638,7 +628,7 @@ impl OutputManagerBackend for OutputManagerSqliteDatabase {
 
     fn revalidate_unspent_output(&self, commitment: &Commitment) -> Result<(), OutputManagerStorageError> {
         let conn = self.database_connection.acquire_lock();
-        let output = OutputSql::find_by_commitment(&commitment.to_vec(), &conn)?;
+        let output = OutputSql::find_by_commitment_and_cancelled(&commitment.to_vec(), false, &conn)?;
 
         if OutputStatus::try_from(output.status)? != OutputStatus::Invalid {
             return Err(OutputManagerStorageError::ValuesNotFound);
@@ -648,7 +638,6 @@ impl OutputManagerBackend for OutputManagerSqliteDatabase {
                 status: Some(OutputStatus::Unspent),
                 tx_id: None,
                 spending_key: None,
-                height: None,
                 script_private_key: None,
             },
             &(*conn),
@@ -661,7 +650,7 @@ impl OutputManagerBackend for OutputManagerSqliteDatabase {
         commitment: &Commitment,
     ) -> Result<DbUnblindedOutput, OutputManagerStorageError> {
         let conn = self.database_connection.acquire_lock();
-        let output = OutputSql::find_by_commitment(&commitment.to_vec(), &conn)?;
+        let output = OutputSql::find_by_commitment_and_cancelled(&commitment.to_vec(), false, &conn)?;
 
         if OutputStatus::try_from(output.status)? != OutputStatus::Spent {
             return Err(OutputManagerStorageError::ValuesNotFound);
@@ -672,7 +661,6 @@ impl OutputManagerBackend for OutputManagerSqliteDatabase {
                 status: Some(OutputStatus::Unspent),
                 tx_id: None,
                 spending_key: None,
-                height: None,
                 script_private_key: None,
             },
             &(*conn),
@@ -691,26 +679,6 @@ impl OutputManagerBackend for OutputManagerSqliteDatabase {
         for p in pending_txs {
             self.cancel_pending_transaction(p.tx_id as u64)?;
         }
-        Ok(())
-    }
-
-    fn update_mined_height(&self, tx_id: u64, height: u64) -> Result<(), OutputManagerStorageError> {
-        let conn = self.database_connection.acquire_lock();
-        let output = OutputSql::find_by_tx_id(tx_id, &conn)?;
-
-        for o in output.iter() {
-            let _ = o.update(
-                UpdateOutput {
-                    status: None,
-                    tx_id: None,
-                    spending_key: None,
-                    height: Some(height),
-                    script_private_key: None,
-                },
-                &(*conn),
-            )?;
-        }
-
         Ok(())
     }
 
@@ -880,7 +848,6 @@ struct NewOutputSql {
     hash: Option<Vec<u8>>,
     script: Vec<u8>,
     input_data: Vec<u8>,
-    height: i64,
     script_private_key: Vec<u8>,
     script_offset_public_key: Vec<u8>,
     sender_metadata_signature_key: Vec<u8>,
@@ -904,7 +871,6 @@ impl NewOutputSql {
             hash: Some(output.hash),
             script: output.unblinded_output.script.as_bytes(),
             input_data: output.unblinded_output.input_data.as_bytes(),
-            height: output.unblinded_output.height as i64,
             script_private_key: output.unblinded_output.script_private_key.to_vec(),
             script_offset_public_key: output.unblinded_output.script_offset_public_key.to_vec(),
             sender_metadata_signature_key: output
@@ -955,7 +921,6 @@ struct OutputSql {
     hash: Option<Vec<u8>>,
     script: Vec<u8>,
     input_data: Vec<u8>,
-    height: i64,
     script_private_key: Vec<u8>,
     script_offset_public_key: Vec<u8>,
     sender_metadata_signature_key: Vec<u8>,
@@ -995,29 +960,26 @@ impl OutputSql {
         commitment: &[u8],
         conn: &SqliteConnection,
     ) -> Result<OutputSql, OutputManagerStorageError> {
-        let cancelled = OutputStatus::CancelledInbound as i32;
         Ok(outputs::table
-            .filter(outputs::status.ne(cancelled))
             .filter(outputs::commitment.eq(commitment))
             .first::<OutputSql>(conn)?)
     }
 
-    pub fn find_by_commitment_and_block_height(
+    pub fn find_by_commitment_and_cancelled(
         commitment: &[u8],
-        height: u64,
+        cancelled: bool,
         conn: &SqliteConnection,
     ) -> Result<OutputSql, OutputManagerStorageError> {
-        Ok(outputs::table
-            .filter(outputs::commitment.eq(commitment))
-            .filter(outputs::height.eq(height as i64))
-            .first::<OutputSql>(conn)?)
-    }
+        let cancelled_flag = OutputStatus::CancelledInbound as i32;
 
-    /// Find outputs via tx_id
-    pub fn find_by_tx_id(tx_id: TxId, conn: &SqliteConnection) -> Result<Vec<OutputSql>, OutputManagerStorageError> {
-        Ok(outputs::table
-            .filter(outputs::tx_id.eq(Some(tx_id as i64)))
-            .load(conn)?)
+        let mut request = outputs::table.filter(outputs::commitment.eq(commitment)).into_boxed();
+        if cancelled {
+            request = request.filter(outputs::status.eq(cancelled_flag))
+        } else {
+            request = request.filter(outputs::status.ne(cancelled_flag))
+        };
+
+        Ok(request.first::<OutputSql>(conn)?)
     }
 
     /// Find outputs via tx_id that are encumbered. Any outputs that are encumbered cannot be marked as spent.
@@ -1102,7 +1064,6 @@ impl OutputSql {
                 status: None,
                 tx_id: None,
                 spending_key: Some(self.spending_key.clone()),
-                height: None,
                 script_private_key: Some(self.script_private_key.clone()),
             },
             conn,
@@ -1131,7 +1092,6 @@ impl TryFrom<OutputSql> for DbUnblindedOutput {
             }),
             TariScript::from_bytes(o.script.as_slice())?,
             ExecutionStack::from_bytes(o.input_data.as_slice())?,
-            o.height as u64,
             PrivateKey::from_vec(&o.script_private_key).map_err(|_| {
                 error!(
                     target: LOG_TARGET,
@@ -1216,7 +1176,6 @@ impl From<OutputSql> for NewOutputSql {
             hash: o.hash,
             script: o.script,
             input_data: o.input_data,
-            height: o.height,
             script_private_key: o.script_private_key,
             script_offset_public_key: o.script_offset_public_key,
             sender_metadata_signature_key: o.sender_metadata_signature_key,
@@ -1236,7 +1195,6 @@ pub struct UpdateOutput {
     status: Option<OutputStatus>,
     tx_id: Option<TxId>,
     spending_key: Option<Vec<u8>>,
-    height: Option<u64>,
     script_private_key: Option<Vec<u8>>,
 }
 
@@ -1246,7 +1204,6 @@ pub struct UpdateOutputSql {
     status: Option<i32>,
     tx_id: Option<i64>,
     spending_key: Option<Vec<u8>>,
-    height: Option<i64>,
     script_private_key: Option<Vec<u8>>,
 }
 
@@ -1265,7 +1222,6 @@ impl From<UpdateOutput> for UpdateOutputSql {
             status: u.status.map(|t| t as i32),
             tx_id: u.tx_id.map(|t| t as i64),
             spending_key: u.spending_key,
-            height: u.height.map(|t| t as i64),
             script_private_key: u.script_private_key,
         }
     }
@@ -1822,7 +1778,6 @@ mod test {
                     status: Some(OutputStatus::Unspent),
                     tx_id: Some(44u64),
                     spending_key: None,
-                    height: None,
                     script_private_key: None,
                 },
                 &conn,
@@ -1836,7 +1791,6 @@ mod test {
                     status: Some(OutputStatus::EncumberedToBeReceived),
                     tx_id: Some(44u64),
                     spending_key: None,
-                    height: None,
                     script_private_key: None,
                 },
                 &conn,

--- a/base_layer/wallet/src/schema.rs
+++ b/base_layer/wallet/src/schema.rs
@@ -97,7 +97,6 @@ table! {
         hash -> Nullable<Binary>,
         script -> Binary,
         input_data -> Binary,
-        height -> BigInt,
         script_private_key -> Binary,
         script_offset_public_key -> Binary,
         sender_metadata_signature_key -> Binary,

--- a/base_layer/wallet/src/utxo_scanner_service/utxo_scanning.rs
+++ b/base_layer/wallet/src/utxo_scanner_service/utxo_scanning.rs
@@ -479,13 +479,12 @@ where TBackend: WalletBackend + 'static
         outputs: Vec<TransactionOutput>,
     ) -> Result<Vec<(UnblindedOutput, String)>, UtxoScannerError> {
         let mut found_outputs: Vec<(UnblindedOutput, String)> = Vec::new();
-        let height = 0;
         if self.mode == UtxoScannerMode::Recovery {
             found_outputs.append(
                 &mut self
                     .resources
                     .output_manager_service
-                    .scan_for_recoverable_outputs(outputs.clone(), height)
+                    .scan_for_recoverable_outputs(outputs.clone())
                     .await?
                     .into_iter()
                     .map(|v| (v, format!("Recovered on {}.", Utc::now().naive_utc())))
@@ -496,7 +495,7 @@ where TBackend: WalletBackend + 'static
             &mut self
                 .resources
                 .output_manager_service
-                .scan_outputs_for_one_sided_payments(outputs.clone(), height)
+                .scan_outputs_for_one_sided_payments(outputs.clone())
                 .await?
                 .into_iter()
                 .map(|v| {

--- a/base_layer/wallet/src/wallet.rs
+++ b/base_layer/wallet/src/wallet.rs
@@ -326,7 +326,6 @@ where
             Some(features.clone()),
             script,
             input_data,
-            0,
             script_private_key.clone(),
             script_offset_public_key.clone(),
             sender_metadata_signature,

--- a/base_layer/wallet/tests/transaction_service/service.rs
+++ b/base_layer/wallet/tests/transaction_service/service.rs
@@ -895,7 +895,7 @@ fn recover_one_sided_transaction() {
             .expect("Could not find completed one-sided tx");
         let outputs = completed_tx.transaction.body.outputs().clone();
 
-        let unblinded = bob_oms.scan_outputs_for_one_sided_payments(outputs, 0).await.unwrap();
+        let unblinded = bob_oms.scan_outputs_for_one_sided_payments(outputs).await.unwrap();
         // Bob should be able to claim 1 output.
         assert_eq!(1, unblinded.len());
         assert_eq!(value, unblinded[0].value);

--- a/base_layer/wallet/tests/transaction_service/transaction_protocols.rs
+++ b/base_layer/wallet/tests/transaction_service/transaction_protocols.rs
@@ -219,7 +219,6 @@ pub async fn oms_reply_channel_task(
         let response = match request {
             OutputManagerRequest::ConfirmTransaction(_) => Ok(OutputManagerResponse::TransactionConfirmed),
             OutputManagerRequest::CancelTransaction(_) => Ok(OutputManagerResponse::TransactionCancelled),
-            OutputManagerRequest::UpdateMinedHeight(_, _) => Ok(OutputManagerResponse::MinedHeightUpdated),
             _ => Err(OutputManagerError::InvalidResponseError(
                 "Unhandled request type".to_string(),
             )),

--- a/integration_tests/helpers/walletProcess.js
+++ b/integration_tests/helpers/walletProcess.js
@@ -219,7 +219,6 @@ class WalletProcess {
             },
             script: Buffer.from(row.script, "hex"),
             input_data: Buffer.from(row.input_data, "hex"),
-            height: parseInt(row.height),
             script_private_key: Buffer.from(row.script_private_key, "hex"),
             script_offset_public_key: Buffer.from(
               row.script_offset_public_key,


### PR DESCRIPTION
## Description
In the discussion around [RFC-0201](https://rfc.tari.com/RFC-0201_TariScript.html) it was decided that the `height` field is not actually required to prevent replay attacks with the introduction of TariScript. We rely on the enforcement of unique commitments in the mempool and blockchain to prevent this. As such this PR removes the height field from the TransactionInput and UnblindedOutput structs.

## How Has This Been Tested?
Existing tests

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [ ] I'm merging against the `development` branch.
* [x] I have squashed my commits into a single commit.
