### PR TITLE
Clarify Tari Script nomenclature

### DIFF
--- a/RFC/src/Glossary.md
+++ b/RFC/src/Glossary.md
@@ -4,27 +4,29 @@ Below are a list of terms and their definitions that are used throughout the Tar
 glossary to disambiguate ideas, and work towards a
 [ubiquitous language](https://blog.carbonfive.com/2016/10/04/ubiquitous-language-the-joy-of-naming/) for this project.
 
-
 ## Archive node
 [archivenode]: #archive-node	"a full history node"
 
-This is a full history [base node]. It will keep a complete history of every transaction ever received and it will not implement pruning.
+This is a full history [base node]. It will keep a complete history of every transaction ever received and it will not 
+implement pruning.
 
 ## AssetCollateral
 [AssetCollateral]: #assetcollateral
 
-The amount of tari coin that a [Validator Node] must put up on the [base layer] in order to become part of an asset [committee].
+The amount of tari coin that a [Validator Node] must put up on the [base layer] in order to become part of an asset 
+[committee].
 
 ## Asset Issuer
 [Asset Issuer]: #asset-issuer "An entity that creates digital assets on the Tari DAN"
 
-An entity that creates digital assets on the Tari DAN. The Asset Issuer will specify the parameters of the contract template
-that defines the rules that govern the asset and the number and nature of its constituent tokens on issuance. The Asset Issuer
-will, generally, be the initial owner of the tokens.
+An entity that creates digital assets on the Tari DAN. The Asset Issuer will specify the parameters of the contract 
+template that defines the rules that govern the asset and the number and nature of its constituent tokens on issuance. 
+The Asset Issuer will, generally, be the initial owner of the tokens.
 
 
 ## Bad Actor
-[Bad Actor]: #bad-actor "A participant that acts maliciously or negligently to the detriment of the network or another participant"
+[Bad Actor]: #bad-actor "A participant that acts maliciously or negligently to the detriment of the network or another 
+participant"
 
 A participant that acts maliciously or negligently to the detriment of the network or another participant.
 
@@ -37,7 +39,8 @@ the emission of new Tari, for securing and managing [Tari coin] transfers.
 
 
 ## Base Node
-[base node]: #base-node "A full Tari node running on the base layer, validating and propagating Tari coin transactions and blocks"
+[base node]: #base-node "A full Tari node running on the base layer, validating and propagating Tari coin transactions 
+and blocks"
 
 A full Tari node running on the base layer. It's primary role is validating and propagating [Tari coin] transactions
 and blocks to the rest of the network.
@@ -73,7 +76,8 @@ blockchain from that point on.
 ## Blockchain state
 [blockchainstate]: #blockchain-state	"This is a snapshot of how the blockchain looks"
 
-The complete state of the blockchain at a specific block height. This means a pruned [utxo] set, a complete set of kernels and headers up to that block height from the genesis block.
+The complete state of the blockchain at a specific block height. This means a pruned [utxo] set, a complete set of 
+kernels and headers up to that block height from the genesis block.
 
 
 ## BroadcastStrategy
@@ -99,20 +103,24 @@ awarded to the miner that performed the Proof of Work for the block.
 ## Committee
 [Committee]: #committee "A group of validator nodes that are responsible for managing a specific Digital Asset"
 
-A group of [Validator Node]s that are responsible for managing the state of a specific [Digital Asset]. A committee is selected
-during asset issuance and can be updated at [Checkpoint]s.
+A group of [Validator Node]s that are responsible for managing the state of a specific [Digital Asset]. A committee is 
+selected during asset issuance and can be updated at [Checkpoint]s.
 
 
 ## CommitteeSelectionStrategy
-[CommitteeSelectionStrategy]: #committeeselectionstrategy "A strategy for an Asset Issuer to select candidates for the committee from the available registered Validator Nodes who responded to the nomination call for that asset"
-A strategy for an Asset Issuer to select candidates for the committee from the available registered Validator Nodes who responded to the nomination call for that asset.
+[CommitteeSelectionStrategy]: #committeeselectionstrategy "A strategy for an Asset Issuer to select candidates for the 
+committee from the available registered Validator Nodes who responded to the nomination call for that asset"
+
+A strategy for an Asset Issuer to select candidates for the committee from the available registered Validator Nodes who 
+responded to the nomination call for that asset.
 
 
 ## ConsensusStrategy
-[ConsensusStrategy]: #consensusstrategy "The approach that will be taken for a committee to reach consensus on instructions"
+[ConsensusStrategy]: #consensusstrategy "The approach that will be taken for a committee to reach consensus on 
+instructions"
 
-The approach that will be taken for a committee to reach consensus on the validity of instructions that are performed on a
-given Digital Asset.
+The approach that will be taken for a committee to reach consensus on the validity of instructions that are performed 
+on a given Digital Asset.
 
 
 ## Commitment
@@ -124,27 +132,36 @@ value or statement after they have committed to it.
 
 
 ## Communication Node
-[Communication Node]: #communication-node "A communication node that is responsible for maintaining the Tari communication network"
+[Communication Node]: #communication-node "A communication node that is responsible for maintaining the Tari 
+communication network"
 
-A Communication Node is either a Validator Node or Base Node that is part of the Tari communication network. It maintains the network and is responsible for forwarding and propagating joining requests, discovery requests and data messages on the communication network.
+A Communication Node is either a Validator Node or Base Node that is part of the Tari communication network. It 
+maintains the network and is responsible for forwarding and propagating joining requests, discovery requests and data 
+messages on the communication network.
 
 
 ## Communication Client
-[Communication Client]: #communication-client "A communication client that makes use of the Tari communication network, but does not maintain it"
+[Communication Client]: #communication-client "A communication client that makes use of the Tari communication network, 
+but does not maintain it"
 
-A Communication Client is a Wallet or Asset Manager that makes use of the Tari communication network to send joining and discovery requests. A Communication Client does not maintain the communication network and is not responsible for forwarding or propagating any requests or data messages.
+A Communication Client is a Wallet or Asset Manager that makes use of the Tari communication network to send joining and 
+discovery requests. A Communication Client does not maintain the communication network and is not responsible for 
+forwarding or propagating any requests or data messages.
 
 
 ## Creator Nomination Mode
-[creator nomination mode]: #creator-nomination-mode "An asset runs in creator nomination mode when _every_ validator node in a validator committee is a [Trusted Node] that was directly nominated by the AI."
+[creator nomination mode]: #creator-nomination-mode "An asset runs in creator nomination mode when _every_ validator 
+node in a validator committee is a [Trusted Node] that was directly nominated by the AI."
 
-An asset runs in creator nomination mode when _every_ validator node in a validator committee is a [Trusted Node] that was directly nominated by the [Asset Issuer].
+An asset runs in creator nomination mode when _every_ validator node in a validator committee is a [Trusted Node] that 
+was directly nominated by the [Asset Issuer].
 
 
 ## Current head
 [currenthead]: #current-head	"The last valid block of the longest chain"
 
-The last [block] of the base layer that represents the latest valid block. This [block] must be from the longest proof-of-work chain to be the current head.
+The last [block] of the base layer that represents the latest valid block. This [block] must be from the longest 
+proof-of-work chain to be the current head.
 
 
 ## Digital asset
@@ -152,8 +169,8 @@ The last [block] of the base layer that represents the latest valid block. This 
 asset issuers on the Tari 2nd layer'
 
 Digital assets (DAs) are the sets or collections of native digital tokens (both fungible and non-fungible) that are 
-created by [asset issuer]s on the Tari 2nd layer. For example, a promoter might create a DA for a music concert event. The
- event is the digital asset, and the tickets for the event are digital asset [tokens].
+created by [asset issuer]s on the Tari 2nd layer. For example, a promoter might create a DA for a music concert event. 
+The event is the digital asset, and the tickets for the event are digital asset [tokens].
 
 
 ## Digital Asset Network
@@ -166,8 +183,8 @@ interactions (defined in [instruction]s) are processed and validated by [Validat
 ## DigitalAssetTemplate
 [DigitalAssetTemplate]: #digitalassettemplate "A set of non-turing complete contract types supported by the DAN"
 
-A DigitalAssetTemplate is one of a set of contract types supported by the DAN. These contracts are non-turing complete and consist of
-rigid rule-sets with parameters that can be set by Asset Issuers.
+A DigitalAssetTemplate is one of a set of contract types supported by the DAN. These contracts are non-turing complete 
+and consist of rigid rule-sets with parameters that can be set by Asset Issuers.
 
 
 ## Digital asset tokens
@@ -182,7 +199,8 @@ asset. Depending on the DA created, tokens can represent tickets, in-game items,
 ## Hashed Time Locked Contract
 [htlc]: #hashed-time-locked-contract 'or just, "HTLC".'
 
-A time locked contract that only pays out after a certain criteria has been met or refunds the originator if a certain period has expired.
+A time locked contract that only pays out after a certain criteria has been met or refunds the originator if a certain 
+period has expired.
 
 
 ## Emission schedule
@@ -203,8 +221,9 @@ client applications and are relayed by the DAN to the [validator node]s that are
 ## Mempool
 [mempool]: #mempool "A memory pool for unconfirmed transactions on the base layer"
 
-The mempool consists of the transaction pool, pending pool, orphan pool and reorg pool, and is responsible for managing unconfirmed transactions that have not yet been included in the
-longest proof-of-work chain. Miners usually draw verified transactions from the mempool to build up transaction [block]s.
+The mempool consists of the transaction pool, pending pool, orphan pool and reorg pool, and is responsible for managing 
+unconfirmed transactions that have not yet been included in the longest proof-of-work chain. Miners usually draw 
+verified transactions from the mempool to build up transaction [block]s.
 
 
 ## Mimblewimble
@@ -218,7 +237,8 @@ anonymous author and has since been refined by several authors, including Andrew
 ## Mining Server
 [mining server]: #mining-server
 
-A Mining Server is responsible for constructing new blocks by bundling transactions from the [mempool] of a connected [Base Node]. It also distributes Proof-of-Work tasks to Mining Workers and verifies PoW solutions.
+A Mining Server is responsible for constructing new blocks by bundling transactions from the [mempool] of a connected 
+[Base Node]. It also distributes Proof-of-Work tasks to Mining Workers and verifies PoW solutions.
 
 
 ## Mining Worker
@@ -230,7 +250,9 @@ A Mining Worker is responsible for performing Proof-of-Work tasks received from 
 ## Multisig
 [multisig]: #multisig
 
-Multi-signatures (Multisigs) are also known as N-of-M signatures, this means that a minimum of N number of the M peers need to agree before a transaction can be spent. N and M can be equal; which is a special case and is often referred to as an N-of-N Multisig.
+Multi-signatures (Multisigs) are also known as N-of-M signatures, this means that a minimum of N number of the M peers 
+need to agree before a transaction can be spent. N and M can be equal; which is a special case and is often referred to 
+as an N-of-N Multisig.
 
 [TLU musig](<https://tlu.tarilabs.com/cryptography/musig-schnorr-sig-scheme/The_MuSig_Schnorr_Signature_Scheme.html>)
 
@@ -246,23 +268,29 @@ from the public identification key of a [communication node] or [communication c
 ## Orphan Pool
 [orphan pool]: #orphan-pool "A pool in the Mempool for unconfirmed transactions that attempt to spend non-existent UTXOs"
 
-The orphan pool is part of the [mempool] and manages all [transaction]s that have been verified but attempt to spend [UTXO]s that do not exist or haven't been created yet.
+The orphan pool is part of the [mempool] and manages all [transaction]s that have been verified but attempt to spend 
+[UTXO]s that do not exist or haven't been created yet.
 
 
 ## Pending Pool
 [pending pool]: #pending-pool "A pool in the Mempool for unconfirmed transactions with time-lock restrictions"
 
-The pending pool is part of the [mempool] and manages all [transaction]s that have a time-lock restriction on when it can be processed or attempts to spend [UTXO]s with time-locks.
+The pending pool is part of the [mempool] and manages all [transaction]s that have a time-lock restriction on when it 
+can be processed or attempts to spend [UTXO]s with time-locks.
 
 
 ## Pruning horizon
 [pruninghorizon]: #pruning-horizon	"Block height at which pruning will commence"
 
-This is a local setting for each node to help reduce syncing time and bandwidth. This is the number of blocks from the chain tip beyond which a chain will be pruned.
+This is a local setting for each node to help reduce syncing time and bandwidth. This is the number of blocks from the 
+chain tip beyond which a chain will be pruned.
 
 ## Public Nomination Mode
 [public nomination mode]: #public-nomination-mode
-An asset runs in public nomination mode when the [Asset Issuer] broadcasts a call for nominations to the network and VNs from the network nominate themselves as candidates to become members of the [committee] for the asset. The [Asset Issuer] will then employ the [CommitteeSelectionStrategy] to select the committee from the list of available candidates.
+An asset runs in public nomination mode when the [Asset Issuer] broadcasts a call for nominations to the network and VNs 
+from the network nominate themselves as candidates to become members of the [committee] for the asset. The 
+[Asset Issuer] will then employ the [CommitteeSelectionStrategy] to select the committee from the list of available 
+candidates.
 
 ## Range proof
 [range proof]: #range-proof
@@ -272,7 +300,8 @@ A mathematical demonstration that a value inside a [commitment] (i.e. it is hidd
 
 
 ## Registration Deposit
-[Registration Deposit]: #registration-deposit "An amount of tari coin that is locked up on the base layer when a [Validator Node] is registered"
+[Registration Deposit]: #registration-deposit "An amount of tari coin that is locked up on the base layer when a 
+[Validator Node] is registered"
 
 An amount of tari coin that is locked up on the base layer when a [Validator Node] is registered. In order to make Sybil
 attacks expensive and to provide an authorative base layer registry of [validator node]s they will need to lock up a
@@ -289,7 +318,35 @@ minimum period has elapsed.
 ## Reorg Pool
 [reorg pool]: #reorg-pool "A backup pool in the Mempool for unconfirmed transactions that have been included in blocks"
 
-The reorg pool is part of the [mempool] and stores all [transaction]s that have recently been included in blocks in case a blockchain reorganization occurs and the transactions need to be restored to the [transaction pool].
+The reorg pool is part of the [mempool] and stores all [transaction]s that have recently been included in blocks in case 
+a blockchain reorganization occurs and the transactions need to be restored to the [transaction pool].
+
+
+## Script Keypair
+[script key]: #script-keypair
+
+The script private - public keypair, \\((k\_{Si}\\),\\(K\_{Si})\\), is used in [TariScript] to unlock and execute the 
+script associated with an output. Afterwards the execution stack must contain exactly one value that must be equal to 
+the script public key.
+
+
+## Script Offset
+[script offset]: #script-offset
+
+The script offset provides a proof that every script public key \\( K\_{Si} \\) and sender offset public key 
+\\( K\_{Oi} \\) provided for the a transaction's inputs and outputs are correct.
+
+## Sender Metadata Signature
+[sender metadata signature]: #sender-metadata-signature
+
+The sender metadata signature is used to sign the metadata of the UTXO with the [sender offset] private key
+\\( k_{Oi} \\) and this stops malleability of the UTXO metadata.
+
+## Sender Offset Keypair
+[sender offset]: #sender-offset-keypair
+
+The sender offset private - public keypair, (\\( k\_{Oi} \\),\\( K\_{Oi} \\)), is used by the sender of an output to
+lock all its metadata by virtue of a [sender metadata signature].
 
 
 ## Spending Key
@@ -327,6 +384,14 @@ network conditions etc.
 The base layer token. Tari coins are released according to the [emission schedule] on the Tari [base layer] 
 [blockchain] in [coinbase transaction]s.
 
+
+## TariScript
+[TariScript]: #tariscript "The Tari scripting system for transactions"
+
+Tari uses a scripting system for transactions, not unlike [Bitcoin's scripting system](https://en.bitcoin.it/wiki/Script), 
+called TariScript. It is also simple, stack-based, processed from left to right, not Turing-complete, with no loops. It 
+is a list of instructions linked in a non&nbsp;malleable way to each output, specifying its conditions of spending.
+
 ## Transaction
 [transaction]: #transaction "Base layer tari coin transfers."
 
@@ -337,7 +402,8 @@ transfer of [Tari coin]s.
 ## Transaction Pool
 [transaction pool]: #transaction-pool "A pool in the Mempool for valid and verified unconfirmed transactions"
 
-The transaction pool is part of the [mempool] and manages all [transaction]s that have been verified, that spend valid [UTXO]s and don't have any time-lock restrictions.
+The transaction pool is part of the [mempool] and manages all [transaction]s that have been verified, that spend valid 
+[UTXO]s and don't have any time-lock restrictions.
 
 
 ## Trusted Node
@@ -349,7 +415,8 @@ A permissioned Validator Node nominated by an Asset Issuer that will form part o
 ## Token Wallet
 [token wallet]: #token-wallet "An Asset Manager Wallet for Tari Assets and Tokens"
 
-A Tari Token Wallet is responsible for managing [Digital asset]s and [Tokens], and for constructing and negotiating [instruction]s for transferring and receiving Assets and Tokens on the [Digital Asset Network].
+A Tari Token Wallet is responsible for managing [Digital asset]s and [Tokens], and for constructing and negotiating 
+[instruction]s for transferring and receiving Assets and Tokens on the [Digital Asset Network].
 
 
 ## Unspent transaction outputs
@@ -384,8 +451,8 @@ Transactions or blocks are `unvalidated` when first received by a [Base Node]. A
 [wallet]: #wallet "A Wallet for Tari coins"
 [Registration Deposit]: #registration-deposit
 
-
-A Tari Wallet is responsible for managing key pairs, and for constructing and negotiating [transaction]s for transferring and receiving [tari coin]s on the [Base Layer].
+A Tari Wallet is responsible for managing key pairs, and for constructing and negotiating [transaction]s for 
+transferring and receiving [tari coin]s on the [Base Layer].
 
 
 # Disclaimer

--- a/RFC/src/RFC-0201_TariScript.md
+++ b/RFC/src/RFC-0201_TariScript.md
@@ -49,14 +49,14 @@ technological merits of the potential system outlined herein.
 
 ## Goals
 
-This Request for Comment (RFC) presents a proposal for introducing Tari Script into the Tari base layer protocol. Tari
+This Request for Comment (RFC) presents a proposal for introducing [TariScript] into the Tari base layer protocol. Tari
 Script aims to provide a general mechanism for enabling further extensions such as side chains, the DAN, one-sided
 payments and atomic swaps.
 
 ## Related Requests for Comment
 
 * [RFC-0200: Base Layer Extensions](BaseLayerExtensions.md)
-* [RFC-0202: Tari Script Opcodes](RFC-0202_TariScriptOpcodes.md)
+* [RFC-0202: TariScript Opcodes](RFC-0202_TariScriptOpcodes.md)
 * [RFC-0300: The Tari Digital Assets Network](RFC-0300_DAN.md)
 
 
@@ -82,7 +82,7 @@ Extensions to Mimblewimble have been proposed for most of these features, for ex
 proposal for LiteCoin ([LIP-004]), this project's [HTLC RFC](RFC-0230_HTLC.md) and the pegging proposals for the
 Clacks side-chain.
 
-Some smart contract features are possible, or partly possible in vanilla Mimblewimble using [Scriptless script], such as
+Some smart contract features are possible, or partly possible in vanilla [Mimblewimble] using [Scriptless script], such as
 
 * Atomic swaps 
 * Hash time-locked contracts
@@ -93,7 +93,7 @@ current Tari and Mimblewimble protocol.
 
 ## Scripting on Mimblewimble
 
-To the author's knowledge, none of existing Mimblewimble projects have employed a scripting language, nor are there 
+To the author's knowledge, none of existing [Mimblewimble] projects have employed a scripting language, nor are there 
 ambitions to do so. 
  
 [Grin](https://github.com/mimblewimble/grin) styles itself as a "Minimal implementation of the Mimblewimble protocol",
@@ -112,7 +112,7 @@ to be no plans to include general scripting into the protocol.
 
 ### Scriptless scripts
 
-[Scriptless script] is a wonderfully elegant technology and inclusion of Tari Script does not preclude the use of
+[Scriptless script] is a wonderfully elegant technology and inclusion of [TariScript] does not preclude the use of
 Scriptless script in Tari. However, scriptless scripts have some disadvantages:
 
 * They are often difficult to reason about, with the result that the development of features based on scriptless scripts
@@ -122,9 +122,9 @@ Scriptless script in Tari. However, scriptless scripts have some disadvantages:
 * Every feature must be written and implemented separately using the specific and specialised protocol designed for that
   feature. That is, it cannot be used as a dynamic scripting framework on a running blockchain.
 
-## Tari Script - a brief motivation
+## TariScript - a brief motivation
 
-The essential idea of Tari Script is as follows:
+The essential idea of [TariScript] is as follows:
 
 Given a standard Tari UTXO, we add _additional restrictions_ on whether that UTXO can be included as a valid input in a
 transaction.
@@ -136,7 +136,7 @@ requirement of having range proofs attached to UTXOs, which require that the val
 This argument is independent of the nature of the additional restrictions. Specifically, if these restrictions are
 manifested as a script that provides additional constraints over whether a UTXO may be spent, the same arguments apply.
 
-This means that in a very hand-wavy sort of way, there ought to be no reason that Tari Script is not workable.
+This means that in a very hand-wavy sort of way, there ought to be no reason that TariScript is not workable.
 
 Note that range proofs can be discarded after a UTXO is spent. This entails that the global security guarantees of
 Mimblewimble are not that every transaction in history was valid from an inflation perspective, but that the net effect
@@ -150,7 +150,7 @@ chain synchronisation in pruned mode.
 But if there was a steady inflation bug due to invalid range proofs making it into the blockchain, a pruned mode sync
 would still detect that _something_ was awry, because the global coin supply balance acts as another check.
 
-With Tari Script, once the script has been pruned away, and then there is a re-org to an earlier point on the chain,
+With TariScript, once the script has been pruned away, and then there is a re-org to an earlier point on the chain,
 then there's no way to ensure that the script was honoured unless you run an archival node.
 
 This is broadly in keeping with the Mimblewimble security guarantees that, in pruned-mode synchronisation, individual 
@@ -158,7 +158,7 @@ transactions are not necessarily verified during chain synchronisation.
 
 However, the guarantee that no additional coins are created or destroyed remains intact.
 
-Put another way, the blockchain relies on the network _at the time_ to enforce the Tari Script spending rules. 
+Put another way, the blockchain relies on the network _at the time_ to enforce the TariScript spending rules. 
 This means that the scheme may be susceptible to certain _horizon attacks_.
 
 Incidentally, a single honest archival node would be able to detect any fraud on the same chain and provide a simple 
@@ -181,23 +181,23 @@ The next section discusses the specific proposals for achieving these requiremen
 
 Please refer to [Notation](#notation), which provides important pre-knowledge for the remainder of the report.
 
-At a high level, Tari Script works as follows:
+At a high level, TariScript works as follows:
 
 * The spending _script_ \\((\script)\\) is recorded in the transaction UTXO.
-* UTXOs also define a new, _script offset public key_ \\((K\_{O})\\).
+* UTXOs also define a new, _[sender offset] public key_ \\((K\_{O})\\).
 * After the _script_ \\((\script)\\) is executed, the execution stack must contain exactly one value that will be interpreted as the 
-  _script public key_ \\((K\_{S})\\). One can prove ownership of a UTXO by demonstrating knowledge of both the commitment _blinding 
-  factor_ \\((k\\)), _and_ the _script private key_ \\((k_\{S})\\).
+  _[script public key]_ \\((K\_{S})\\). One can prove ownership of a UTXO by demonstrating knowledge of both the commitment _blinding 
+  factor_ \\((k\\)), _and_ the _[script private key]_ \\((k_\{S})\\).
 * The _script private key_ \\((k_\{S})\\), commitment _blinding factor_ \\((k)\\) and commitment _value_ \\((v)\\) signs the _script 
   input data_ \\((\input)\\).
-* The _script offset private keys_ \\((k\_{O})\\) and _script private keys_ \\((k\_{S})\\) are used in conjunction to create a _script 
+* The _sender offset private keys_ \\((k\_{O})\\) and _script private keys_ \\((k\_{S})\\) are used in conjunction to create a _script 
   offset_ \\((\so)\\), which are used in the consensus balance to prevent a number of attacks.
 
 ### UTXO data commitments
 
-The script, as well as other UTXO metadata, such as the output features are signed for with the script offset key to 
-prevent malleability. As we will describe later, the notion of a script offset is introduced to prevent cut-through 
-and forces the preservation of these commitments until they are recorded into the blockchain.
+The script, as well as other UTXO metadata, such as the output features are signed for with the [sender offset] private 
+key to prevent malleability. As we will describe later, the notion of a [script offset] is introduced to prevent 
+cut-through and forces the preservation of these commitments until they are recorded into the blockchain.
  
 There are two changes to the protocol data structures that must be made to allow this scheme to work. 
 
@@ -219,9 +219,9 @@ pub struct TransactionOutput {
 }
 ```
 
-_Note:_ Currently, the output features are actually malleable. Tari Script fixes this.
+_Note:_ Currently, the output features are actually malleable. TariScript fixes this.
 
-Under Tari Script, this definition changes to accommodate the script and the script offset public keys:
+Under TariScript, this definition changes to accommodate the script and the [sender offset] public keys:
 
 ```rust,ignore
 pub struct TransactionOutput {
@@ -233,9 +233,9 @@ pub struct TransactionOutput {
     proof: RangeProof,
     /// The serialised script
     script: Vec<u8>,
-    /// The script offset pubkey, K_O
-    script_offset_public_key: PublicKey
-    /// UTXO signature with the script offset private key, k_O
+    /// The sender offset pubkey, K_O
+    sender_offset_public_key: PublicKey
+    /// UTXO signature with the sender offset private key, k_O
     sender_metadata_signature : Signature
 }
 ```
@@ -249,7 +249,7 @@ C_i = v_i \cdot H  + k_i \cdot G
  \tag{1}
 $$
 
-The sender signature signs the  metadata of the UTXO with the script offset private key \\( k_{Oi} \\) and this stops 
+The [sender metadata signature] signs the metadata of the UTXO with the sender offset private key \\( k_{Oi} \\) and this stops 
 malleability of the UTXO metadata.
 
 $$
@@ -263,7 +263,7 @@ $$
 Note that:
 * The UTXO has a positive value `v` like any normal UTXO. 
 * The script and the output features can no longer be changed by the miner or any other party. Once mined, the owner can
-  also no longer change the script or output features without invalidating the meta data signature.
+  also no longer change the script or output features without invalidating the sender meta data signature.
 * We provide the complete script on the output.
 
 ### Transaction input changes
@@ -294,18 +294,18 @@ pub struct TransactionInput {
     script: Vec<u8>,
     /// The script input data, if any
     input_data: Vec<u8>,
-    /// Signature signing the script, input data, public script key and the homomorphic commitment with a combination 
-    /// of the homomorphic commitment private values (amount and blinding factor) and the private script key.
+    /// Signature signing the script, input data, [script public key] and the homomorphic commitment with a combination 
+    /// of the homomorphic commitment private values (amount and blinding factor) and the [script private key].
     script_signature: CommitmentSignature,
-    /// The script offset pubkey, K_O
-    script_offset_public_key: PublicKey
+    /// The sender offset pubkey, K_O
+    sender_offset_public_key: PublicKey
 }
 ```
 
 The `script_signature` is an aggregated Schnorr signature signed with a combination of the homomorphic commitment 
-private values \\( (v\_i \\, , \\, k\_i )\\) and private script key \\(k\_{Si}\\) to prove ownership of thereof, see 
+private values \\( (v\_i \\, , \\, k\_i )\\) and [script private key] \\(k\_{Si}\\) to prove ownership of thereof, see 
 [Signature on Commitment values] by F. Zhang et. al. and [Commitment Signature] by G. Yu. It signs the script, the 
-script input, public script key and the commitment:
+script input, [script public key] and the commitment:
 
 $$
 \begin{aligned}
@@ -332,14 +332,16 @@ a_{Si} \cdot H + b_{Si} \cdot G = R_{Si} + (C_i+K_{Si})e
  \tag{5}
 $$
 
-This signature ensures that only the owner can provide the input data  \\(\input_i\\) to the TransactionInput.
-
+The script public key \\(K\_{Si}\\) needed for the script signature verification is not stored with the TransactionInput, 
+but obtained by executing the script with the provided input data. Because this signature is signed with the script 
+private key \\(k\_{Si}\\), it ensures that only the owner can provide the input data \\(\input_i\\) to the 
+TransactionInput. 
 
 ### Script Offset
 
-For every transaction an accompanying script offset \\( \so \\) needs to be provided. This is there to prove that every 
-public script key \\( K\_{Sj} \\) and every public script offset key \\( K\_{Oi} \\) supplied with the UTXOs are the 
-correct ones. The sender will know and provide script offset private keys \\(k_{Oi} \\) and script private keys 
+For every transaction an accompanying [script offset] \\( \so \\) needs to be provided. This is there to prove that every  
+script public key \\( K\_{Sj} \\) and every sender offset public key \\( K\_{Oi} \\) supplied with the UTXOs are the 
+correct ones. The sender will know and provide sender offset private keys \\(k_{Oi} \\) and script private keys 
 \\(k_{Si} \\); these are combined to create the script offset \\( \so \\), which is calculated as follows:
 
 $$
@@ -370,7 +372,7 @@ pub struct Transaction {
 }
 ```
 
-All script offsets (\\(\so\\)) from (6) contained in a block is summed together to create a total script offset (8) 
+All script offsets (\\(\so\\)) from (6) contained in a block is summed together to create a total [script offset] (8) 
 so that algorithm (6) still holds for a block.
 
 $$
@@ -392,7 +394,7 @@ $$
 As can be seen all information required to verify (8) is contained in a block's inputs and outputs. One important 
 distinction to make is that the Coinbase output in a coinbase transaction does not count towards the script offset. 
 This is because the Coinbase UTXO already has special rules accompanying it and it has no input, thus we cannot generate a 
-script offset \\( \so \\). The coinbase output can allow any script \\(\script_i\\) and  script offset public key 
+script offset \\( \so \\). The coinbase output can allow any script \\(\script_i\\) and sender offset public key 
 \\( K\_{Oi} \\) as long as it does not break any of the rules in [RFC 120](RFC-0120_Consensus.md) and the script is 
 honored at spend. If the coinbase is used as in input, it is treated exactly the same as any other input.
 
@@ -410,16 +412,16 @@ pub struct BlockHeader {
 This notion of the script offset \\(\so\\) means that the no third party can remove any input or output from a 
 transaction or the block, as that will invalidate the script offset balance equation, either (7) or (9) depending on 
 whether the scope is a transaction or block. It is important to know that this also stops 
-[cut&#8209;through](#cut-through) so that we can verify all spent UTXO scripts. Because the private script key and private 
-script offset key is not publicly known, its impossible to create a new script offset.
+[cut&#8209;through](#cut-through) so that we can verify all spent UTXO scripts. Because the script private key and  
+sender offset private key is not publicly known, its impossible to create a new script offset.
 
 Certain scripts may allow more than one valid set of input data. Users might be led to believe that this will allow a 
 third party to change the script keypair \\((k\_{Si}\\),\\(K\_{Si})\\). If an attacker can change the \\(K\_{Si}\\) 
 keys of the input then he can take control of the \\(K\_{Oi}\\) as well, allowing the attacker to change the metadata of 
-the UTXO including the script. But as shown in [Script Offset security](#script-offset-security), this is not possible.
+the UTXO including the script. But as shown in [Script offset security](#script-offset-security), this is not possible.
 
 If equation (7) or (9) balances then we know that every included input and output in the transaction or block has its 
-correct public script key and public script offset key. Signatures (2) & (3) are checked independently from script 
+correct script public key and sender offset public key. Signatures (2) & (3) are checked independently from script 
 offset verification (7) and (9), and looked at in isolation those could verify correctly but can still be signed by fake 
 keys. When doing verification in (7) and (9) you know that the signatures and the message/metadata signed by the private 
 keys can be trusted.
@@ -430,12 +432,12 @@ The Mimblewimble balance for blocks and transactions stays the same.
 
 In addition to the changes given above, there are consensus rule changes for transaction and block validation.
 
-For every valid transaction or block,
+Verify that for every valid transaction or block:
 
-1. Check the sender signature \\(s\_{Mi}\\) is valid for every output.
+1. The [sender metadata signature] \\(s\_{Mi}\\) is valid for every output.
 2. The script executes successfully using the given input script data.
-3. The result of the script is a valid public key, \\( K\_S \\).
-4. The script signature, \\( s\_{Si} \\) is valid for every input.
+3. The result of the script is a valid script public key, \\( K\_S \\).
+4. The script signature, \\( s\_{Si} \\), is valid for every input.
 5. The script offset is valid for every transaction and block.
 
 ## Examples
@@ -457,7 +459,7 @@ To spend \\( C\_a \\), she provides:
 * A valid script signature, \\( (a_{Sa}, b_{Sa}, R_{Sa}) \\) as per (3),(4) proving that she owns the commitment 
   \\( C\_a \\), knows the private key, \\( k_{Sa} \\), corresponding to \\( K_{Sa} \\), the public key left on the stack 
   after executing \\( \script_a \\) with \\( \input_a \\).
-* An script offset public key, \\( K_{Ob} \\).
+* A sender offset public key, \\( K_{Ob} \\).
 * The script offset, \\( \so\\) with:
 $$
 \begin{aligned}
@@ -475,7 +477,7 @@ Because Alice is creating the transaction, she has a final say over the script \
 [bitcoin transaction], but Bob can also opt to send Alice a script \\(\script\_b\\) of his choosing. If Bob did not send a script, 
 she chooses something akin to a `NOP` script for the script \\(\script\_b\\).
 
-Alice calculates the sender signature \\( s_{Mb} \\) with: 
+Alice calculates the [sender metadata signature] \\( s_{Mb} \\) with: 
 
 $$
 \begin{aligned}
@@ -487,7 +489,7 @@ $$
 Alice then adds the following info to Bob's TransactionOutput:
 
 * Meta_signature \\(s_{Mb}\\),
-* Script offset public key \\( K_{Ob} \\),
+* sender offset public key \\( K_{Ob} \\),
 
 She completes the transaction as per [standard Mimblewimble protocol] and also adds the script offset \\( \so \\), after which 
 she broadcasts the transaction to the network.
@@ -499,7 +501,7 @@ Base nodes validate the transaction as follows:
 * They check that the usual Mimblewimble balance holds by summing inputs and outputs and validating against the excess
   signature. This check does not change nor do the other validation rules, such as confirming that all inputs are in
   the UTXO set etc.
-* The sender signature \\(s_{Ma}\\) on Bob's output,
+* The sender metadata signature \\(s_{Ma}\\) on Bob's output,
 * The input script must execute successfully using the provided input data; and the script result must be a valid 
   public key,
 * The script signature on Alice's input is valid by checking:
@@ -517,9 +519,9 @@ Base nodes validate the transaction as follows:
  \tag{14}
   $$
 
-Finally, when Bob spends this output, he will use \\( K\_{Sb} \\) as his script input and sign it with his private key
-\\( k\_{Sb} \\). He will choose a new \\( K\_{Oc} \\) to give to the recipient, and he will construct the 
-script offset, \\( \so_b \\) as follows:
+Finally, when Bob spends this output, he will use \\( K\_{Sb} \\) as his script input and sign it with his script 
+private key \\( k\_{Sb} \\). He will choose a new sender offset public key \\( K\_{Oc} \\) to give to the recipient, and 
+he will construct the script offset, \\( \so_b \\) as follows:
 
 $$
 \begin{aligned}
@@ -548,9 +550,9 @@ Bob requires the value \\( v_b \\) and blinding factor \\( k_b \\) to claim his 
 claim it without asking Alice for them.
 
 This information can be obtained by using Diffie-Hellman and Bulletproof rewinding. If the blinding factor \\( k\_b \\) 
-was calculated with Diffie-Hellman using the script offset keypair, (\\( k\_{Ob} \\),\\( K\_{Ob} \\)) as the sender keypair 
-and the script keypair, \\( (k\_{Sb} \\),\\( K\_{Sb}) \\) as the receiver keypair, the blinding factor \\( k\_b \\) 
-can be securely calculated without communication.
+was calculated with Diffie-Hellman using the sender offset keypair, (\\( k\_{Ob} \\),\\( K\_{Ob} \\)) as the sender 
+keypair and the script keypair, \\( (k\_{Sb} \\),\\( K\_{Sb}) \\) as the receiver keypair, the blinding factor 
+\\( k\_b \\) can be securely calculated without communication.
 
 Alice uses Bob's public key to create a shared secret, \\( k\_b \\) for the output commitment, \\( C\_b \\), using
 Diffie-Hellman key exchange.
@@ -570,7 +572,7 @@ key.
 
 Alice knows the script-redeeming private key \\( k_{Sa}\\) for the transaction input.
 
-Alice will create the entire transaction including, generating a new script offset keypair and calculating the 
+Alice will create the entire transaction including, generating a new sender offset keypair and calculating the 
 script offset,
 
 $$
@@ -622,7 +624,7 @@ To summarise, the information required for one-sided transactions is as follows:
 | script input      | \\( \input_a \\)                      | Public                                                                                        |
 | height            | \\( h_a \\)                           | Public                                                                                        |
 | script signature  | \\( a_{Sa},b_{Sa}, R_{Sa} \\)         | Alice knows \\( k_{Sa},\\, r_{Sa} \\) and \\( k_{a},\\, v_{a} \\) of the commitment \\(C_a\\) |
-| script offset public key | \\( K_{Oa} \\)                        | Not used in this transaction                                                                  |
+| sender offset public key | \\( K_{Oa} \\)                        | Not used in this transaction                                                                  |
 
 | Transaction output | Symbols                               | Knowledge                                                              |
 |---------------------------|---------------------------------------|------------------------------------------------------------|
@@ -630,7 +632,7 @@ To summarise, the information required for one-sided transactions is as follows:
 | features                  | \\( F_b \\)                           | Public                                                     |
 | script                    | \\( \script_b \\)                     | Script is public. Only Bob knows the correct script input. |
 | range proof               |                                       | Alice and Bob know opening parameters                      |
-| script offset public key  | \\( K_{Ob} \\)                        | Alice knows \\( k_{Ob} \\)                                 |
+| sender offset public key  | \\( K_{Ob} \\)                        | Alice knows \\( k_{Ob} \\)                                 |
 | sender metadata signature | \\( s_{Mb}, R_{Mb} \\)                | Alice knows \\( k_{Ob} \\)  and the metadata)              |
 
 
@@ -652,11 +654,11 @@ C_a \Rightarrow  C_s \Rightarrow  C_x
 $$
 
 Alice owns \\( C_a\\), so she knows the blinding factor \\( k_a\\) and the correct input for the script's spending 
-conditions. Alice also generates the script offset keypair, \\( (k_{Os}, K_{Os} )\\).
+conditions. Alice also generates the sender offset keypair, \\( (k_{Os}, K_{Os} )\\).
 
 Now Alice and Bob proceed with the standard transaction flow.
 
-Alice ensures that the script offset public key \\( K_{Os}\\) is part of the output metadata that contains commitment 
+Alice ensures that the sender offset public key \\( K_{Os}\\) is part of the output metadata that contains commitment 
 \\( C_s\\). Alice will fill in the script with her \\( k_{Sa}\\) to unlock the commitment \\( C_a\\). Because Alice 
 owns \\( C_a\\) she needs to construct \\( \so\\) with:
 
@@ -689,7 +691,7 @@ The script input needs to be signed by this aggregate key, and so Alice and Bob 
 following the usual Schnorr aggregate mechanics, but one person needs to add in the signature of the blinding factor and 
 value.
 
-In an analogous fashion, Alice and Bob also generate an aggregate script offset private key \\( k_{Ox}\\), each using
+In an analogous fashion, Alice and Bob also generate an aggregate sender offset private key \\( k_{Ox}\\), each using
 their own \\( k_{OxA} \\) and \\( k_{OxB}\\).
 
 To be specific, Alice calculates her portion from
@@ -724,7 +726,7 @@ Notice also that because the script resolves to an aggregate key \\( K_s\\) neit
 commitment \\( C_s\\) without the other party's key. If either party tries to cheat by editing the input, the script 
 validation will fail.
 
-If either party tries to cheat by creating a new output, the script offset will not validate correctly as the script offset locks 
+If either party tries to cheat by creating a new output, the script offset will not validate correctly as it locks 
 the output of the transaction.
 
 A base node validating the transaction will also not be able to tell this is an aggregate transaction as all keys are 
@@ -742,7 +744,7 @@ To summarise, the information required for creating a multiparty UTXO is as foll
 | script input                | \\( \input_a \\)                      | Public                                                                                        |
 | height                      | \\( h_a \\)                           | Public                                                                                        |
 | script signature            | \\( (a_{Sa},b_{Sa}, R_{Sa}) \\)     | Alice knows \\( k_{Sa},\\, r_{Sa} \\) and \\( k_{a},\\, v_{a} \\) of the commitment \\(C_a\\) |
-| script offset&nbsp;public&nbsp;key | \\( K_{Oa} \\)                        | Not used in this transaction                                                                  |
+| sender offset&nbsp;public&nbsp;key | \\( K_{Oa} \\)                        | Not used in this transaction                                                                  |
 
 <br>
 
@@ -752,7 +754,7 @@ To summarise, the information required for creating a multiparty UTXO is as foll
 | features                    | \\( F_s \\)                                                            | Public                                                                                     |
 | script                      | \\( \script_s \\)                                                      | Script is public. Alice and Bob only knows their part of the  correct script input.        |
 | range proof                 |                                                                        | Alice and Bob know opening parameters                                                      |
-| script offset&nbsp;public&nbsp;key | \\( K_{Os} = K_{OsA} + K_{OsB}\\)       | Alice knows \\( k_{OsA} \\), Bob knows \\( k_{OsB} \\). Neither party knows \\( k_{Os} \\) |
+| sender offset&nbsp;public&nbsp;key | \\( K_{Os} = K_{OsA} + K_{OsB}\\)       | Alice knows \\( k_{OsA} \\), Bob knows \\( k_{OsB} \\). Neither party knows \\( k_{Os} \\) |
 | sender&nbsp;signature       | \\( s_{Ms} = s_{MsA} + s_{MsB}, \\, \\, R_{Ss} = R_{SsA} + R_{SsB} \\) | Alice knows \\( (s_{MsA}, R_{SsA}) \\), Bob knows \\( (s_{MsB}, R_{SsB}) \\)               |
 
 When spending the multi-party input:
@@ -765,7 +767,7 @@ When spending the multi-party input:
 | script input                | \\( \input_s \\)                        | Public                                                                                                                                                             |
 | height                      | \\( h_a \\)                             | Public                                                                                                                                                             |
 | script&nbsp;signature       | \\( (a_{Ss} ,b_{Ss} , R_{Ss}) \\)     | Alice knows \\( (k_{SsA},\\, r_{SsA}) \\), Bob knows \\( (k_{SsB},\\, r_{SsB}) \\). Both parties know \\( (k_{s},\\, v_{s}) \\). Neither party knows \\( k_{Ss}\\) |
-| script offset&nbsp;public&nbsp;key | \\( K_{Os} \\)                          | As above, Alice and Bob each know part of the script offset key                                                                                                           |
+| sender offset&nbsp;public&nbsp;key | \\( K_{Os} \\)                          | As above, Alice and Bob each know part of the sender offset key                                                                                                           |
 
 
 ### Cut-through
@@ -775,10 +777,10 @@ spent in the same block it was created. This makes it so that the intervening UT
 and balances carried in that UTXO. It's also impossible to prove without additional information that cut-through even 
 occurred (though one may suspect, since the "one" transaction would contribute two kernels to the block).
 
-In particular, cut-through is devastating for an idea like Tari Script which relies on conditions present in the UTXO 
+In particular, cut-through is devastating for an idea like TariScript which relies on conditions present in the UTXO 
 being enforced.
 
-This is a reason for the presence of the script offset in the Tari Script proposal. It mathematically links all inputs 
+This is a reason for the presence of the script offset in the TariScript proposal. It mathematically links all inputs 
 and outputs of all the transactions in a block and that tallied up to create the script offset. Providing the script 
 offset requires knowledge of keys that miners do not possess; thus they are unable to produce the necessary script 
 offset when attempting to perform cut-through on a pair of transactions.
@@ -821,10 +823,10 @@ $$
 \end{aligned}
 $$
 
-A third party cannot generate a new script offset as only the original owner can provide the private script key \\(k\_{Sa}\\) 
+A third party cannot generate a new script offset as only the original owner can provide the script private key \\(k\_{Sa}\\) 
 to create a new script offset. 
 
-### Script Offset security
+### Script offset security
 
 If all the inputs in a transaction or a block contain scripts such as just `NOP` or `CompareHeight` commands, then the 
 hypothesis is that it is possible to recreate a false script offset. Lets show by example why this is not possible. In 
@@ -836,10 +838,10 @@ $$
 Alice has an output \\(C\_{a}\\) which contains a script that only has a `NOP` command in it. This means that the 
 script \\( \script\_a \\) will immediately exit on execution leaving the entire input data \\( \input\_a \\)on the 
 stack. She sends all the required information to Bob as per the [standard mw transaction](#standard-mw-transaction), who 
-creates an output \\(C\_{b}\\). Because of the `NOP` script \\( \script\_a \\), Bob can change the public script key 
+creates an output \\(C\_{b}\\). Because of the `NOP` script \\( \script\_a \\), Bob can change the script public key 
 \\( K\_{Sa}\\) contained in the input data. Bob can now use his own \\(k'\_{Sa}\\) as the script private key. He 
-replaces the script offset public key with his own \\(K'\_{Ob}\\) allowing him to change the script 
-\\( \script\_b \\) and generate a new signature as in (2). Bob cab now generate a new script offset with 
+replaces the sender offset public key with his own \\(K'\_{Ob}\\) allowing him to change the script 
+\\( \script\_b \\) and generate a new signature as in (2). Bob can now generate a new script offset with 
 \\(\so' = k'\_{Sa} - k'\_{Ob} \\). Up to this point, it all seems valid. No one can detect that Bob changed the script 
 to \\( \script\_b \\).
 
@@ -853,14 +855,14 @@ Mimblewimble terms is the  person who knows \\( k\_a, v\_a\\), can generate the 
 ### Script lock key generation
 
 At face value, it looks like the burden for wallets has tripled, since each UTXO owner has to remember three private 
-keys, the spend key, \\( k_i \\), the script offset key \\( k_{O} \\) and the script key \\( k_{S} \\). In practice, the script 
-key will often be a static key associated with the user's node or wallet. Even if it is not, the script and script offset keys
-can be deterministically derived from the spend key. For example, \\( k_{S} \\) could be 
+keys, the spend key, \\( k_i \\), the sender offset key \\( k_{O} \\) and the script key \\( k_{S} \\). In practice, the 
+script key will often be a static key associated with the user's node or wallet. Even if it is not, the script and 
+sender offset keys can be deterministically derived from the spend key. For example, \\( k_{S} \\) could be 
 \\( \hash{ k_i \cat \alpha} \\).
 
 ### Blockchain bloat
 
-The most obvious drawback to Tari Script is the effect it will have on blockchain size. UTXOs are substantially larger,
+The most obvious drawback to TariScript is the effect it will have on blockchain size. UTXOs are substantially larger,
 with the addition of the script, script signature, and a public key to every output.
 
 These can eventually be pruned, but will increase storage and bandwidth requirements.
@@ -874,7 +876,7 @@ Every header will also be bigger as it includes an extra blinding factor that wi
 
 ### Fodder for chain analysis
 
-Another potential drawback of Tari Script is the additional information that is handed to entities wishing to perform 
+Another potential drawback of TariScript is the additional information that is handed to entities wishing to perform 
 chain analysis. Having scripts attached to outputs will often clearly mark the purpose of that UTXO. Users may wish to 
 re-spend outputs into vanilla, default UTXOs in a mixing transaction to disassociate Tari funds from a particular 
 script.
@@ -883,7 +885,7 @@ script.
 
 
 Where possible, the "usual" notation is used to denote terms commonly found in cryptocurrency literature. Lower case characters are used as private keys, while uppercase characters are used as public keys. New terms 
-introduced by Tari Script are assigned greek lowercase letters in most cases. The capital letter subscripts, _R_ and _S_ 
+introduced by TariScript are assigned greek lowercase letters in most cases. The capital letter subscripts, _R_ and _S_ 
 refer to a UTXO _receiver_ and _script_ respectively.
 
 | Symbol                    | Definition                                                                                                                                                                                                                            |
@@ -892,23 +894,23 @@ refer to a UTXO _receiver_ and _script_ respectively.
 | \\( F_i \\)               | Output features for UTXO _i_.                                                                                                                                                                                                         |
 | \\( f_t \\)               | Transaction fee for transaction _t_.                                                                                                                                                                                                  |
 | \\( m_t \\)               | Metadata for transaction _t_. Currently this includes the lock height.                                                                                                                                                                |
-| \\( (k_{Oi}\, K_{Oi}) \\) | The private - public keypair for the UTXO script offset key.                                                                                                                                                                          |
+| \\( (k_{Oi}\, K_{Oi}) \\) | The private - public keypair for the UTXO sender offset key.                                                                                                                                                                          |
 | \\( (k_{Si}\, K_{Si}) \\) | The private - public keypair for the script key. The script, \\( \script_i \\) resolves to \\( K_S \\) after completing execution.                                                                                                    |
 | \\( \so_t \\)             | The script offset for transaction _t_, as \\( \so_t = \sum_j{ k_{Sjt}} - \sum_i{k_{Oit}}\\)                                                                                                                                           |
 | \\( C_i \\)               | A Pedersen commitment to a value \\( v_i \\), as \\( C_i = k_i \cdot{G} + v_i \cdot H \\)                                                                                                                                             |
 | \\( \input_i \\)          | The serialised input for script \\( \script_i \\)                                                                                                                                                                                     |
 | \\( s_{Si} \\)            | A script signature for output \\( i \\), as \\( s_{Si} = (a_{Si}, b_{Si}, R_{Si} ) = (r_{Si_a} +  e(v_{i})), (r_{Si_b} + e(k_{Si}+k_i)) \\; \text{where} \\; e = \hash{ R_{Si} \cat \script_i \cat \input_i \cat K_{Si} \cat C_i} \\) |
-| \\( s_{Mi} \\)            | A sender signature for output \\( i \\), as \\( s_{Mi} = r_{Mi} + k_{Oi}\hash{ \script_i \cat F_i \cat R_{Mi}  } \\)                                                                                                                  |
+| \\( s_{Mi} \\)            | A sender metadata signature for output \\( i \\), as \\( s_{Mi} = r_{Mi} + k_{Oi}\hash{ \script_i \cat F_i \cat R_{Mi}  } \\)                                                                                                                  |
 
 ## Extensions
 
 ### Covenants
 
-Tari Script places restrictions on _who_ can spend UTXOs. It will also be useful for Tari digital asset applications to
+TariScript places restrictions on _who_ can spend UTXOs. It will also be useful for Tari digital asset applications to
 restrict _how_ or _where_ UTXOs may be spent in some cases. The general term for these sorts of restrictions are termed
 _covenants_. The [Handshake white paper] has a fairly good description of how covenants work.
 
-It is beyond the scope of this RFC, but it's anticipated that Tari Script would play a key role in the introduction of
+It is beyond the scope of this RFC, but it's anticipated that TariScript would play a key role in the introduction of
 generalised covenant support into Tari.
 
 ### Lock-time malleability
@@ -916,7 +918,7 @@ generalised covenant support into Tari.
 The current Tari protocol has an issue with Transaction Output Maturity malleability. This output feature is enforced in
 the consensus rules, but it is actually possible for a miner to change the value without invalidating the transaction.
 
-With Tari Script, output features are properly committed to in the transaction and verified as part of the script offset
+With TariScript, output features are properly committed to in the transaction and verified as part of the script offset
 validation.
 
 ### Credits
@@ -937,3 +939,10 @@ Thanks to David Burkett for proposing a method to prevent cut-through and willin
 [cut-through]: https://tlu.tarilabs.com/protocols/grin-protocol-overview/MainReport.html#cut-through
 [standard Mimblewimble protocol]: https://tlu.tarilabs.com/protocols/mimblewimble-1/MainReport.html
 [bitcoin transaction]: https://en.bitcoin.it/wiki/Transaction
+
+[TariScript]: Glossary.md#tariscript
+[sender metadata signature]: Glossary.md#sender-metadata-signature
+[script private key]: Glossary.md#script-keypair
+[script public key]: Glossary.md#script-keypair
+[sender offset]: Glossary.md#sender-offset-keypair
+[script offset]: Glossary.md#script-offset

--- a/RFC/src/RFC-0202_TariScriptOpcodes.md
+++ b/RFC/src/RFC-0202_TariScriptOpcodes.md
@@ -1,6 +1,6 @@
 # RFC-0202/TariScriptOpcodes
 
-## Tari Script Opcodes
+## TariScript Opcodes
 
 ![status: draft](theme/images/status-draft.svg)
 
@@ -61,11 +61,11 @@ examples and applicaitons.
 ## Introduction
 
 
-## Tari Script semantics
+## TariScript semantics
 
 The proposal for TariScript is straightforward. It is based on Bitcoin script and inherits most of its ideas.
 
-The main properties of Tari script are
+The main properties of [TariScript] are
 
 * The scripting language is stack-based. At redeem time, the UTXO spender must supply an input stack. The script runs by
   operating on the stack contents.
@@ -74,7 +74,7 @@ The main properties of Tari script are
   on the stack. The script fails if the stack is empty, or contains more than one element, or aborts early.
 * It is not Turing complete, so there are no loops or timing functions.
 * The opcodes enforce type safety. e.g. A public key cannot be added to an integer scalar. Errors of this kind MUST cause
-  the script to fail. The Rust implementation of Tari Script automatically applies the type safety rules.
+  the script to fail. The Rust implementation of [TariScript] automatically applies the type safety rules.
 
 ### Failure modes
 
@@ -112,7 +112,7 @@ The full list of [Error codes](#error-codes) is given below.
 
 ## Opcodes
 
-Tari Script opcodes range from 0 to 255 and are represented as a single unsigned byte. The opcode set is
+[TariScript] opcodes range from 0 to 255 and are represented as a single unsigned byte. The opcode set is
 limited to allow for the applications specified in this RFC, but can be expanded in the future.
 
 ### Block height checks
@@ -348,7 +348,7 @@ If `ELSE` is encountered, instructions are executed until `ENDIF` is reached.
 
 ## Serialisation
 
-Tari Script and the execution stack are serialised into byte strings using a simple linear parser. Since all opcodes are
+TariScript and the execution stack are serialised into byte strings using a simple linear parser. Since all opcodes are
 a single byte, it's very easy to read and write script byte strings. If an opcode has a parameter associated with it,
 e.g. `PushHash` then it is equally known how many bytes following the opcode will contain the parameter.
 
@@ -570,3 +570,5 @@ or Bob can spend the output.
 
 Thanks to [@philipr-za](https://github.com/philipr-za) and [@SWvheerden](https://github.com/SWvheerden) for their input
 and contributions to this RFC.
+
+[TariScript]: Glossary.md#tariscript

--- a/docs/src/tari_script_no_op_vulnerability.md
+++ b/docs/src/tari_script_no_op_vulnerability.md
@@ -24,7 +24,7 @@ The full derivation of these components can be found [here](wallet_to_wallet_wit
 | Input Data                | \\( \theta_a \\)                          |
 | height                    | \\( h \\)                                 |
 | Script Signature          | \\( (s_{sa}, R_{sa}) \\)                  |
-| Script offset public key  | \\( K_{Oa} \\)                            |
+| Sender offset public key  | \\( K_{Oa} \\)                            |
 
 | Transaction Output |      |
 |--------------------|-------|
@@ -32,7 +32,7 @@ The full derivation of these components can be found [here](wallet_to_wallet_wit
 | Features      | Fb                                            |
 | Rangeproof    | \\( RP_b \\) for \\( \hat{C}_b \\)            |
 | Script Hash   | \\( \sigma_b = H( \alpha_b) \\)               |
-| Script offset public key | \\( K_{Ob} \\)                     |
+| Sender offset public key | \\( K_{Ob} \\)                     |
 
 | Transaction Kernel |       |
 |--------------------|-------|
@@ -42,7 +42,7 @@ The full derivation of these components can be found [here](wallet_to_wallet_wit
 | Metadata           | m                    |
 
 The mechanism that stops Bob's script, whose hash is \\( \sigma_b \\), from being malleable after the transaction is completed is the following. During Bob's round of 
-transaction negotiation they commit to the script hash \\( \sigma_b \\), and the Public UTXO script offset, \\( K_{Ob} \\), which is provided by Alice. These are committed 
+transaction negotiation they commit to the script hash \\( \sigma_b \\), and the Public UTXO sender offset, \\( K_{Ob} \\), which is provided by Alice. These are committed 
 to in the construction of 
 
 \\( \beta_b = H(\sigma_b || F_b || K_{Ob}) \\).
@@ -70,13 +70,13 @@ key of his choosing, \\( \hat{K_{sa}} \\) to which he knows the private key \\( 
 the stack. Bob can choose a new nonce \\( \hat{R_{sa}} \\) and then produce a valid script signature (\\( \hat{s_{sa}}, \hat{R_{sa}} \\)) for the challenge 
 \\( H( \hat{R_{sa}} || \alpha_a || \hat{\theta_a} || h) \\).
 
-Bob can also now produce a new transaction script offset while choosing a new UTXO script offset for his UTXO, \\( \hat{k_{Ob}} \\). This means he can modify the script attached 
+Bob can also now produce a new transaction script offset while choosing a new UTXO sender offset for his UTXO, \\( \hat{k_{Ob}} \\). This means he can modify the script attached 
 to his UTXO, \\( \hat{\sigma_{b}} \\), calculate a new modified commitment and range proof \\( \hat{RP_{b}} \\) for his new script and commit to it in a new transaction script offset
 
 \\( \hat{\gamma} =  \hat{k_{sa}} - \hat{k_{Ob}} \hat{U_b} \\).
 
 This attack is only possible if Alice did not have a change output in the transaction and all Alice's inputs have the NO_OP script. This is because the case that Alice has a change output, Bob would not know the 
-private script offset for the change output, \\( k_{oc} \\), to produce
+private sender offset for the change output, \\( k_{oc} \\), to produce
 
 \\( \gamma =  k_{sa} - k_{Ob}U_b - k_{Oc}U_c \\).
 

--- a/docs/src/wallet_to_wallet_with_tariscript.md
+++ b/docs/src/wallet_to_wallet_with_tariscript.md
@@ -55,7 +55,7 @@ Alice then sends the following values to Bob:
 | \\( f \\)         | fee                                                                       |
 | \\( m \\)         | Transaction metadata (currently just lockheight)                          |
 | \\( \alpha_b \\)  | Spending script for Bob's UTXO, \\( C_b \\)                               |
-| \\( K_{Ob} \\)    | Public UTXO script offset                                                 |
+| \\( K_{Ob} \\)    | Public UTXO sender offset                                                 |
 | message           | A unicode string                                                          |
 
 ### Bob Replies
@@ -127,7 +127,7 @@ Alice can now construct the final transaction:
 | Input Data                | \\( \theta_a \\)                          |
 | height                    | \\( h \\)                                 |
 | Script Signature          | \\( (s_{sa}, R_{sa}) \\)                  |
-| Script offset public key  | \\( K_{Oa} \\)                            |
+| Sender offset public key  | \\( K_{Oa} \\)                            |
 
 | Transaction Output |      |
 |--------------------|-------|
@@ -135,7 +135,7 @@ Alice can now construct the final transaction:
 | Features      | Fb                                            |
 | Rangeproof    | \\( RP_b \\) for \\( \hat{C}_b \\)                    |
 | Script Hash   | \\( \sigma_b = H( \alpha_b) \\)               |
-| Script offset public key | \\( K_{Ob} \\)                     |
+| Sender offset public key | \\( K_{Ob} \\)                     |
 
 | Transaction Output |      |
 |--------------------|-------|
@@ -143,7 +143,7 @@ Alice can now construct the final transaction:
 | Features      | Fc                                            |
 | Rangeproof    | \\( RP_c \\) for \\( \hat{C}_c \\)            |
 | Script Hash   | \\( \sigma_c = H( \alpha_c) \\)               |
-| Script offset public key | \\( K_{Oc} \\)                     |
+| Sender offset public key | \\( K_{Oc} \\)                     |
 
 | Transaction Kernel |       |
 |--------------------|-------|
@@ -185,7 +185,7 @@ pub struct SingleRoundSenderData {
     
     /// Hash of the receivers UTXO script, \sigma
     pub script_hash: Vec<u8,
-    /// Public script offset key chosen for Recipient, K_o
+    /// Public sender offset key chosen for Recipient, K_o
     pub public_script_offset_key: PublicKey,
 ```
 
@@ -207,7 +207,7 @@ pub struct UnblindedOutput {
     height : u64,
     /// Script private key, k_s
     script_private_key: PrivateKey,
-    /// Public script offset, K_O
+    /// Public sender offset, K_O
     public_script_offset: PublicKey,
 }
 ```
@@ -218,4 +218,4 @@ pub struct UnblindedOutput {
    
    1.1 Initial discussion resulted in us decided that Alice sends the full script in Round 1
 2. Do parties agree of the Output Features of the received output or does Bob just choose it? Currently it's assumed default
-3. Do you need the script offset public key in both the Transaction Input and the Transaction Output?
+3. Do you need the sender offset public key in both the Transaction Input and the Transaction Output?


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Picked less confusing script related names for RFC-0201 and updated the glossary:
- script offset
- script offset private key   => sender offset private key  _**[updated!]**_
- script offset public key    => sender offset public key   _**[updated!]**_
- script private key
- script public key
- script signature
- sender metadata signature

Co-Authored-By: SW van Heerden <swvheerden@gmail.com>


## Motivation and Context
As above

## How Has This Been Tested?
mdbook serve

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [X] I'm merging against the `tari-script` branch.
* [X] I have squashed my commits into a single commit.
