### PR TITLE
Update connectivity manager defaults

### DIFF
--- a/comms/dht/src/config.rs
+++ b/comms/dht/src/config.rs
@@ -175,7 +175,7 @@ impl Default for DhtConfig {
             allow_test_addresses: false,
             flood_ban_max_msg_count: 10000,
             flood_ban_timespan: Duration::from_secs(100),
-            offline_peer_cooldown: Duration::from_secs(24 * 60 * 60),
+            offline_peer_cooldown: Duration::from_secs(2 * 60 * 60),
             saf_msg_validity: Duration::from_secs(10800),
         }
     }

--- a/comms/src/connectivity/config.rs
+++ b/comms/src/connectivity/config.rs
@@ -51,7 +51,7 @@ impl Default for ConnectivityConfig {
             connection_pool_refresh_interval: Duration::from_secs(30),
             reaper_min_inactive_age: Duration::from_secs(60),
             is_connection_reaping_enabled: true,
-            max_failures_mark_offline: 1,
+            max_failures_mark_offline: 2,
             connection_tie_break_linger: Duration::from_secs(2),
         }
     }


### PR DESCRIPTION
## Description
This PR tweaks the `offline_peer_cooldown` and `max_failures_mark_offline` default values to better cope with intermittent disconnections.

`offline_peer_cooldown` is reduced from 24 hours to 2 hours so that the peer will become eligible for a reconnection in less time.

`max_failures_mark_offline` is changed from 1 to 2 to allow for one more round of connection retries before giving up on the node until the above cool down expires.

## How Has This Been Tested?
Existing tests

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [ ] I'm merging against the `development` branch.
* [x] I have squashed my commits into a single commit.
