### PR TITLE
Add filtering of abandoned coinbase txs to console wallet

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3999,6 +3999,7 @@ dependencies = [
 name = "tari_console_wallet"
 version = "0.8.11"
 dependencies = [
+ "bitflags 1.2.1",
  "chrono",
  "chrono-english",
  "crossterm",

--- a/applications/tari_console_wallet/Cargo.toml
+++ b/applications/tari_console_wallet/Cargo.toml
@@ -16,6 +16,7 @@ tari_app_grpc = {  path = "../tari_app_grpc" }
 tari_shutdown = {  path = "../../infrastructure/shutdown" }
 tari_key_manager = { path = "../../base_layer/key_manager"  }
 
+bitflags = "1.2.1"
 chrono = { version = "0.4.6", features = ["serde"]}
 chrono-english = "0.1"
 futures = { version = "^0.3.1", default-features = false, features = ["alloc"]}

--- a/applications/tari_console_wallet/src/ui/state/app_state.rs
+++ b/applications/tari_console_wallet/src/ui/state/app_state.rs
@@ -34,6 +34,7 @@ use crate::{
     },
     wallet_modes::PeerConfig,
 };
+use bitflags::bitflags;
 use futures::{stream::Fuse, StreamExt};
 use log::*;
 use qrcode::{render::unicode, QrCode};
@@ -72,6 +73,7 @@ const LOG_TARGET: &str = "wallet::console_wallet::app_state";
 pub struct AppState {
     inner: Arc<RwLock<AppStateInner>>,
     cached_data: AppStateData,
+    completed_tx_filter: TransactionFilter,
     node_config: GlobalConfig,
 }
 
@@ -86,9 +88,11 @@ impl AppState {
     ) -> Self {
         let inner = AppStateInner::new(node_identity, network, wallet, base_node_selected, base_node_config);
         let cached_data = inner.data.clone();
+
         Self {
             inner: Arc::new(RwLock::new(inner)),
             cached_data,
+            completed_tx_filter: TransactionFilter::ABANDONED_COINBASES,
             node_config,
         }
     }
@@ -101,33 +105,31 @@ impl AppState {
     pub async fn refresh_transaction_state(&mut self) -> Result<(), UiError> {
         let mut inner = self.inner.write().await;
         inner.refresh_full_transaction_state().await?;
-        if let Some(data) = inner.get_updated_app_state() {
-            self.cached_data = data;
-        }
+        drop(inner);
+        self.update_cache().await;
         Ok(())
     }
 
     pub async fn refresh_contacts_state(&mut self) -> Result<(), UiError> {
         let mut inner = self.inner.write().await;
         inner.refresh_contacts_state().await?;
-        if let Some(data) = inner.get_updated_app_state() {
-            self.cached_data = data;
-        }
+        drop(inner);
+        self.update_cache().await;
         Ok(())
     }
 
     pub async fn refresh_connected_peers_state(&mut self) -> Result<(), UiError> {
         let mut inner = self.inner.write().await;
         inner.refresh_connected_peers_state().await?;
-        if let Some(data) = inner.get_updated_app_state() {
-            self.cached_data = data;
-        }
+        drop(inner);
+        self.update_cache().await;
         Ok(())
     }
 
     pub async fn update_cache(&mut self) {
         let mut inner = self.inner.write().await;
-        if let Some(data) = inner.get_updated_app_state() {
+        let updated_state = inner.get_updated_app_state();
+        if let Some(data) = updated_state {
             self.cached_data = data;
         }
     }
@@ -146,9 +148,8 @@ impl AppState {
         inner.wallet.contacts_service.upsert_contact(contact).await?;
 
         inner.refresh_contacts_state().await?;
-        if let Some(data) = inner.get_updated_app_state() {
-            self.cached_data = data;
-        }
+        drop(inner);
+        self.update_cache().await;
         Ok(())
     }
 
@@ -162,9 +163,8 @@ impl AppState {
         inner.wallet.contacts_service.remove_contact(public_key).await?;
 
         inner.refresh_contacts_state().await?;
-        if let Some(data) = inner.get_updated_app_state() {
-            self.cached_data = data;
-        }
+        drop(inner);
+        self.update_cache().await;
         Ok(())
     }
 
@@ -275,16 +275,19 @@ impl AppState {
         }
     }
 
-    pub fn get_completed_txs_slice(&self, start: usize, end: usize) -> &[CompletedTransaction] {
-        if self.cached_data.completed_txs.is_empty() || start > end || end > self.cached_data.completed_txs.len() {
-            return &[];
+    pub fn get_completed_txs(&self) -> Vec<&CompletedTransaction> {
+        if self
+            .completed_tx_filter
+            .contains(TransactionFilter::ABANDONED_COINBASES)
+        {
+            self.cached_data
+                .completed_txs
+                .iter()
+                .filter(|tx| !(tx.cancelled && tx.status == TransactionStatus::Coinbase))
+                .collect()
+        } else {
+            self.cached_data.completed_txs.iter().collect()
         }
-
-        &self.cached_data.completed_txs[start..end]
-    }
-
-    pub fn get_completed_txs(&self) -> &Vec<CompletedTransaction> {
-        &self.cached_data.completed_txs
     }
 
     pub fn get_confirmations(&self, tx_id: &TxId) -> Option<&u64> {
@@ -292,8 +295,9 @@ impl AppState {
     }
 
     pub fn get_completed_tx(&self, index: usize) -> Option<&CompletedTransaction> {
-        if index < self.cached_data.completed_txs.len() {
-            Some(&self.cached_data.completed_txs[index])
+        let filtered_completed_txs = self.get_completed_txs();
+        if index < filtered_completed_txs.len() {
+            Some(filtered_completed_txs[index])
         } else {
             None
         }
@@ -363,6 +367,10 @@ impl AppState {
 
     pub fn get_required_confirmations(&self) -> u64 {
         (&self.node_config.transaction_num_confirmations_required).to_owned()
+    }
+
+    pub fn toggle_abandoned_coinbase_filter(&mut self) {
+        self.completed_tx_filter.toggle(TransactionFilter::ABANDONED_COINBASES);
     }
 }
 
@@ -864,4 +872,11 @@ pub enum UiTransactionSendStatus {
     DiscoveryInProgress,
     SentViaSaf,
     Error(String),
+}
+
+bitflags! {
+    pub struct TransactionFilter: u8 {
+        const NONE = 0b0000_0000;
+        const ABANDONED_COINBASES = 0b0000_0001;
+    }
 }


### PR DESCRIPTION
## Description
This PR adds the ability to filter abandoned coinbase transactions in the completed transaction list of the console wallet. The filter is on by default and can be toggled with the A key. Transactions that have the Coinbase status and are also cancelled are filtered out and when displayed have the status of `Abandoned`.

A TransactionFilter bitfield has been added to the AppState which currently only includes the AbandonedCoinbase flag but will allow for more filters to be added and combined. The filtering is done when the UI draw requests the vector of references to the current list of transactions. If no filter is applied the full vector of references is returned, otherwise a iterator filtered version is returned applying the conditions of the filter.

## How Has This Been Tested?
Manually tested, this is a console wallet UI change

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [ ] I'm merging against the `development` branch.
* [x] I have squashed my commits into a single commit.
