### PR TITLE
Remove type alias impl trait unstable feature requirement from DHT

### DIFF
--- a/base_layer/service_framework/src/context/handles.rs
+++ b/base_layer/service_framework/src/context/handles.rs
@@ -67,7 +67,7 @@ impl ServiceInitializerContext {
 
     /// Insert a service handle with the given name
     pub fn register_handle<H>(&self, handle: H)
-    where H: Any + Send + Sync {
+    where H: Any + Send {
         self.inner.register(handle);
     }
 
@@ -160,7 +160,7 @@ impl ServiceHandles {
 
     /// Register a handle
     pub fn register<H>(&self, handle: H)
-    where H: Any + Send + Sync {
+    where H: Any + Send {
         acquire_lock!(self.handles).insert(TypeId::of::<H>(), Box::new(handle));
     }
 

--- a/comms/Cargo.toml
+++ b/comms/Cargo.toml
@@ -54,7 +54,7 @@ tokio-macros = "0.2.3"
 tempfile = "3.1.0"
 
 [build-dependencies]
-tari_common = { version = "^0.8", path="../common"}
+tari_common = { version = "^0.8", path="../common", features = ["build"]}
 
 [features]
 avx2 = ["tari_crypto/avx2"]

--- a/comms/dht/src/dht.rs
+++ b/comms/dht/src/dht.rs
@@ -278,9 +278,8 @@ impl Dht {
             InboundMessage,
             Response = (),
             Error = PipelineError,
-            Future = impl Future<Output = Result<(), PipelineError>> + Send,
-        > + Clone
-                      + Send,
+            Future = impl Future<Output = Result<(), PipelineError>>,
+        > + Clone,
     >
     where
         S: Service<DecryptedDhtMessage, Response = (), Error = PipelineError> + Clone + Send + Sync + 'static,
@@ -341,9 +340,8 @@ impl Dht {
             DhtOutboundRequest,
             Response = (),
             Error = PipelineError,
-            Future = impl Future<Output = Result<(), PipelineError>> + Send,
-        > + Clone
-                      + Send,
+            Future = impl Future<Output = Result<(), PipelineError>>,
+        > + Clone,
     >
     where
         S: Service<OutboundMessage, Response = (), Error = PipelineError> + Clone + Send + 'static,

--- a/comms/dht/src/inbound/dht_handler/middleware.rs
+++ b/comms/dht/src/inbound/dht_handler/middleware.rs
@@ -22,7 +22,7 @@
 
 use super::task::ProcessDhtMessage;
 use crate::{discovery::DhtDiscoveryRequester, inbound::DecryptedDhtMessage, outbound::OutboundMessageRequester};
-use futures::{task::Context, Future};
+use futures::{future::BoxFuture, task::Context};
 use std::{sync::Arc, task::Poll};
 use tari_comms::{
     peer_manager::{NodeIdentity, PeerManager},
@@ -60,26 +60,29 @@ impl<S> DhtHandlerMiddleware<S> {
 }
 
 impl<S> Service<DecryptedDhtMessage> for DhtHandlerMiddleware<S>
-where S: Service<DecryptedDhtMessage, Response = (), Error = PipelineError> + Clone
+where
+    S: Service<DecryptedDhtMessage, Response = (), Error = PipelineError> + Clone + Send + 'static,
+    S::Future: Send,
 {
     type Error = PipelineError;
+    type Future = BoxFuture<'static, Result<Self::Response, Self::Error>>;
     type Response = ();
-
-    type Future = impl Future<Output = Result<Self::Response, Self::Error>>;
 
     fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
         self.next_service.poll_ready(cx)
     }
 
     fn call(&mut self, message: DecryptedDhtMessage) -> Self::Future {
-        ProcessDhtMessage::new(
-            self.next_service.clone(),
-            Arc::clone(&self.peer_manager),
-            self.outbound_service.clone(),
-            Arc::clone(&self.node_identity),
-            self.discovery_requester.clone(),
-            message,
+        Box::pin(
+            ProcessDhtMessage::new(
+                self.next_service.clone(),
+                Arc::clone(&self.peer_manager),
+                self.outbound_service.clone(),
+                Arc::clone(&self.node_identity),
+                self.discovery_requester.clone(),
+                message,
+            )
+            .run(),
         )
-        .run()
     }
 }

--- a/comms/dht/src/lib.rs
+++ b/comms/dht/src/lib.rs
@@ -111,10 +111,6 @@
 //! ```
 
 #![recursion_limit = "256"]
-// Details: https://doc.rust-lang.org/beta/unstable-book/language-features/type-alias-impl-trait.html
-#![allow(incomplete_features)]
-#![feature(type_alias_impl_trait)]
-#![feature(min_type_alias_impl_trait)]
 #[macro_use]
 extern crate diesel;
 #[macro_use]

--- a/comms/dht/src/outbound/broadcast.rs
+++ b/comms/dht/src/outbound/broadcast.rs
@@ -41,9 +41,9 @@ use digest::Digest;
 use futures::{
     channel::oneshot,
     future,
+    future::BoxFuture,
     stream::{self, StreamExt},
     task::Context,
-    Future,
 };
 use log::*;
 use rand::rngs::OsRng;
@@ -109,7 +109,7 @@ impl<S> Layer<S> for BroadcastLayer {
 /// the worker task.
 #[derive(Clone)]
 pub struct BroadcastMiddleware<S> {
-    next: S,
+    next_service: S,
     dht_requester: DhtRequester,
     dht_discovery_requester: DhtDiscoveryRequester,
     node_identity: Arc<NodeIdentity>,
@@ -127,7 +127,7 @@ impl<S> BroadcastMiddleware<S> {
         message_validity_window: chrono::Duration,
     ) -> Self {
         Self {
-            next: service,
+            next_service: service,
             dht_requester,
             dht_discovery_requester,
             node_identity,
@@ -138,28 +138,31 @@ impl<S> BroadcastMiddleware<S> {
 }
 
 impl<S> Service<DhtOutboundRequest> for BroadcastMiddleware<S>
-where S: Service<DhtOutboundMessage, Response = (), Error = PipelineError> + Clone
+where
+    S: Service<DhtOutboundMessage, Response = (), Error = PipelineError> + Clone + Send + 'static,
+    S::Future: Send,
 {
     type Error = PipelineError;
+    type Future = BoxFuture<'static, Result<Self::Response, Self::Error>>;
     type Response = ();
-
-    type Future = impl Future<Output = Result<(), Self::Error>>;
 
     fn poll_ready(&mut self, _: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
         Poll::Ready(Ok(()))
     }
 
     fn call(&mut self, msg: DhtOutboundRequest) -> Self::Future {
-        BroadcastTask::new(
-            self.next.clone(),
-            Arc::clone(&self.node_identity),
-            self.dht_requester.clone(),
-            self.dht_discovery_requester.clone(),
-            self.target_network,
-            msg,
-            self.message_validity_window,
+        Box::pin(
+            BroadcastTask::new(
+                self.next_service.clone(),
+                Arc::clone(&self.node_identity),
+                self.dht_requester.clone(),
+                self.dht_discovery_requester.clone(),
+                self.target_network,
+                msg,
+                self.message_validity_window,
+            )
+            .handle(),
         )
-        .handle()
     }
 }
 
@@ -523,7 +526,14 @@ mod test {
     use super::*;
     use crate::{
         outbound::SendMessageParams,
-        test_utils::{create_dht_actor_mock, create_dht_discovery_mock, make_peer, service_spy, DhtDiscoveryMockState},
+        test_utils::{
+            assert_send_static_service,
+            create_dht_actor_mock,
+            create_dht_discovery_mock,
+            make_peer,
+            service_spy,
+            DhtDiscoveryMockState,
+        },
     };
     use futures::channel::oneshot;
     use rand::rngs::OsRng;
@@ -585,6 +595,7 @@ mod test {
             Network::LocalTest,
             chrono::Duration::seconds(10800),
         );
+        assert_send_static_service(&service);
         let (reply_tx, _reply_rx) = oneshot::channel();
 
         service

--- a/comms/dht/src/store_forward/saf_handler/task.rs
+++ b/comms/dht/src/store_forward/saf_handler/task.rs
@@ -39,7 +39,7 @@ use crate::{
     store_forward::{error::StoreAndForwardError, service::FetchStoredMessageQuery, StoreAndForwardRequester},
 };
 use digest::Digest;
-use futures::{channel::mpsc, future, stream, Future, SinkExt, StreamExt};
+use futures::{channel::mpsc, future, stream, SinkExt, StreamExt};
 use log::*;
 use prost::Message;
 use std::{convert::TryInto, sync::Arc};
@@ -267,14 +267,15 @@ where S: Service<DecryptedDhtMessage, Response = (), Error = PipelineError>
             message_tag
         );
 
-        let tasks = response
-            .messages
-            .into_iter()
-            // Map to futures which process the stored message
-            .map(|msg| self.process_incoming_stored_message(Arc::clone(&source_peer), msg));
+        let mut results = Vec::with_capacity(response.messages.len());
+        for msg in response.messages {
+            let result = self
+                .process_incoming_stored_message(Arc::clone(&source_peer), msg)
+                .await;
+            results.push(result);
+        }
 
-        let successful_msgs_iter = future::join_all(tasks)
-            .await
+        let successful_msgs_iter = results
             .into_iter()
             .map(|result| {
                 match &result {
@@ -352,71 +353,68 @@ where S: Service<DecryptedDhtMessage, Response = (), Error = PipelineError>
         Ok(())
     }
 
-    fn process_incoming_stored_message(
-        &self,
+    async fn process_incoming_stored_message(
+        &mut self,
         source_peer: Arc<Peer>,
         message: ProtoStoredMessage,
-    ) -> impl Future<Output = Result<DecryptedDhtMessage, StoreAndForwardError>> {
-        let node_identity = Arc::clone(&self.node_identity);
-        let peer_manager = Arc::clone(&self.peer_manager);
-        let config = self.config.clone();
-        let mut dht_requester = self.dht_requester.clone();
+    ) -> Result<DecryptedDhtMessage, StoreAndForwardError> {
+        let node_identity = &self.node_identity;
+        let peer_manager = &self.peer_manager;
+        let config = &self.config;
 
-        async move {
-            if message.dht_header.is_none() {
-                return Err(StoreAndForwardError::DhtHeaderNotProvided);
-            }
-
-            let dht_header: DhtMessageHeader = message
-                .dht_header
-                .expect("previously checked")
-                .try_into()
-                .map_err(StoreAndForwardError::DhtMessageError)?;
-
-            if !dht_header.is_valid() {
-                return Err(StoreAndForwardError::InvalidDhtHeader);
-            }
-            let message_type = dht_header.message_type;
-
-            if message_type.is_dht_message() {
-                if !message_type.is_dht_discovery() {
-                    debug!(
-                        target: LOG_TARGET,
-                        "Discarding {} message from peer '{}'",
-                        message_type,
-                        source_peer.node_id.short_str()
-                    );
-                    return Err(StoreAndForwardError::InvalidDhtMessageType);
-                }
-                if dht_header.destination.is_unknown() {
-                    debug!(
-                        target: LOG_TARGET,
-                        "Discarding anonymous discovery message from peer '{}'",
-                        source_peer.node_id.short_str()
-                    );
-                    return Err(StoreAndForwardError::InvalidDhtMessageType);
-                }
-            }
-
-            // Check that the destination is either undisclosed, for us or for our network region
-            Self::check_destination(&config, &peer_manager, &node_identity, &dht_header).await?;
-            // Check that the message has not already been received.
-            Self::check_duplicate(&mut dht_requester, &message.body).await?;
-
-            // Attempt to decrypt the message (if applicable), and deserialize it
-            let (authenticated_pk, decrypted_body) =
-                Self::authenticate_and_decrypt_if_required(&node_identity, &dht_header, &message.body)?;
-
-            let mut inbound_msg =
-                DhtInboundMessage::new(MessageTag::new(), dht_header, Arc::clone(&source_peer), message.body);
-            inbound_msg.is_saf_message = true;
-
-            Ok(DecryptedDhtMessage::succeeded(
-                decrypted_body,
-                authenticated_pk,
-                inbound_msg,
-            ))
+        if message.dht_header.is_none() {
+            return Err(StoreAndForwardError::DhtHeaderNotProvided);
         }
+
+        let dht_header: DhtMessageHeader = message
+            .dht_header
+            .expect("previously checked")
+            .try_into()
+            .map_err(StoreAndForwardError::DhtMessageError)?;
+
+        if !dht_header.is_valid() {
+            return Err(StoreAndForwardError::InvalidDhtHeader);
+        }
+        let message_type = dht_header.message_type;
+
+        if message_type.is_dht_message() {
+            if !message_type.is_dht_discovery() {
+                debug!(
+                    target: LOG_TARGET,
+                    "Discarding {} message from peer '{}'",
+                    message_type,
+                    source_peer.node_id.short_str()
+                );
+                return Err(StoreAndForwardError::InvalidDhtMessageType);
+            }
+            if dht_header.destination.is_unknown() {
+                debug!(
+                    target: LOG_TARGET,
+                    "Discarding anonymous discovery message from peer '{}'",
+                    source_peer.node_id.short_str()
+                );
+                return Err(StoreAndForwardError::InvalidDhtMessageType);
+            }
+        }
+
+        // Check that the destination is either undisclosed, for us or for our network region
+        Self::check_destination(&config, &peer_manager, &node_identity, &dht_header).await?;
+        // Check that the message has not already been received.
+        Self::check_duplicate(&mut self.dht_requester, &message.body).await?;
+
+        // Attempt to decrypt the message (if applicable), and deserialize it
+        let (authenticated_pk, decrypted_body) =
+            Self::authenticate_and_decrypt_if_required(&node_identity, &dht_header, &message.body)?;
+
+        let mut inbound_msg =
+            DhtInboundMessage::new(MessageTag::new(), dht_header, Arc::clone(&source_peer), message.body);
+        inbound_msg.is_saf_message = true;
+
+        Ok(DecryptedDhtMessage::succeeded(
+            decrypted_body,
+            authenticated_pk,
+            inbound_msg,
+        ))
     }
 
     async fn check_duplicate(dht_requester: &mut DhtRequester, body: &[u8]) -> Result<(), StoreAndForwardError> {

--- a/comms/dht/src/test_utils/mod.rs
+++ b/comms/dht/src/test_utils/mod.rs
@@ -51,3 +51,10 @@ pub use service::service_spy;
 
 mod store_and_forward_mock;
 pub use store_and_forward_mock::{create_store_and_forward_mock, StoreAndForwardMockState};
+
+pub fn assert_send_static_service<T, S>(_: &S)
+where
+    S: tower::Service<T> + Send + 'static,
+    S::Future: Send,
+{
+}

--- a/comms/dht/tests/dht.rs
+++ b/comms/dht/tests/dht.rs
@@ -178,24 +178,22 @@ async fn setup_comms_dht(
     }
 
     let dht_outbound_layer = dht.outbound_middleware_layer();
+    let pipeline = pipeline::Builder::new()
+        .outbound_buffer_size(10)
+        .with_outbound_pipeline(outbound_rx, |sink| {
+            ServiceBuilder::new().layer(dht_outbound_layer).service(sink)
+        })
+        .max_concurrent_inbound_tasks(10)
+        .with_inbound_pipeline(
+            ServiceBuilder::new()
+                .layer(dht.inbound_middleware_layer())
+                .service(SinkService::new(inbound_tx)),
+        )
+        .build();
 
     let (event_tx, _) = broadcast::channel(100);
     let comms = comms
-        .add_protocol_extension(MessagingProtocolExtension::new(
-            event_tx.clone(),
-            pipeline::Builder::new()
-                .outbound_buffer_size(10)
-                .with_outbound_pipeline(outbound_rx, |sink| {
-                    ServiceBuilder::new().layer(dht_outbound_layer).service(sink)
-                })
-                .max_concurrent_inbound_tasks(10)
-                .with_inbound_pipeline(
-                    ServiceBuilder::new()
-                        .layer(dht.inbound_middleware_layer())
-                        .service(SinkService::new(inbound_tx)),
-                )
-                .build(),
-        ))
+        .add_protocol_extension(MessagingProtocolExtension::new(event_tx.clone(), pipeline))
         .spawn_with_transport(MemoryTransport)
         .await
         .unwrap();

--- a/comms/src/pipeline/inbound.rs
+++ b/comms/src/pipeline/inbound.rs
@@ -42,7 +42,7 @@ pub struct Inbound<TSvc, TStream> {
 
 impl<TSvc, TStream> Inbound<TSvc, TStream>
 where
-    TStream: Stream + FusedStream + Unpin + Send + 'static,
+    TStream: Stream + FusedStream + Unpin,
     TStream::Item: Send + 'static,
     TSvc: Service<TStream::Item> + Clone + Send + 'static,
     TSvc::Error: Display + Send,

--- a/comms/src/pipeline/outbound.rs
+++ b/comms/src/pipeline/outbound.rs
@@ -44,7 +44,7 @@ pub struct Outbound<TPipeline, TStream> {
 
 impl<TPipeline, TStream> Outbound<TPipeline, TStream>
 where
-    TStream: Stream + FusedStream + Unpin + Send + 'static,
+    TStream: Stream + FusedStream + Unpin,
     TStream::Item: Send + 'static,
     TPipeline: Service<TStream::Item, Response = ()> + Clone + Send + 'static,
     TPipeline::Error: Display + Send,

--- a/comms/src/protocol/extensions.rs
+++ b/comms/src/protocol/extensions.rs
@@ -31,7 +31,7 @@ use tari_shutdown::ShutdownSignal;
 
 pub type ProtocolExtensionError = anyhow::Error;
 
-pub trait ProtocolExtension: Send + Sync {
+pub trait ProtocolExtension: Send {
     // TODO: The Box<Self> is easier to do for now at the cost of ProtocolExtension being less generic.
     fn install(self: Box<Self>, context: &mut ProtocolExtensionContext) -> Result<(), ProtocolExtensionError>;
 }

--- a/comms/src/protocol/messaging/extension.rs
+++ b/comms/src/protocol/messaging/extension.rs
@@ -51,13 +51,13 @@ impl<TInPipe, TOutPipe, TOutReq> MessagingProtocolExtension<TInPipe, TOutPipe, T
 
 impl<TInPipe, TOutPipe, TOutReq> ProtocolExtension for MessagingProtocolExtension<TInPipe, TOutPipe, TOutReq>
 where
-    TOutPipe: Service<TOutReq, Response = ()> + Clone + Send + Sync + 'static,
-    TOutPipe::Error: fmt::Display + Send + Sync,
-    TOutPipe::Future: Send + Sync + 'static,
-    TInPipe: Service<InboundMessage> + Clone + Send + Sync + 'static,
-    TInPipe::Error: fmt::Display + Send + Sync,
-    TInPipe::Future: Send + Sync + 'static,
-    TOutReq: Send + Sync + 'static,
+    TOutPipe: Service<TOutReq, Response = ()> + Clone + Send + 'static,
+    TOutPipe::Error: fmt::Display + Send,
+    TOutPipe::Future: Send + 'static,
+    TInPipe: Service<InboundMessage> + Clone + Send + 'static,
+    TInPipe::Error: fmt::Display + Send,
+    TInPipe::Future: Send + 'static,
+    TOutReq: Send + 'static,
 {
     fn install(self: Box<Self>, context: &mut ProtocolExtensionContext) -> Result<(), ProtocolExtensionError> {
         let (proto_tx, proto_rx) = mpsc::channel(consts::MESSAGING_PROTOCOL_EVENTS_BUFFER_SIZE);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Replaces the `type_alias_impl_trait` feature requirement with boxed or
statically typed Futures on all services. Removes/simplifies some redundant trait bounds.

SAF handler task had to be implemented to be a less concurrent because
of the additional trait bounds required for boxing.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Move towards stable rust
Related to #3034 
Ref #3035 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Existing tests pass.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [ ] I'm merging against the `development` branch.
* [x] I have squashed my commits into a single commit.
