### PR TITLE
[Feat]Allow zero-confirmation transactions

### DIFF
--- a/base_layer/core/src/mempool/mempool.rs
+++ b/base_layer/core/src/mempool/mempool.rs
@@ -94,7 +94,7 @@ impl Mempool {
     /// Only transactions that fit into a block will be returned
     pub fn retrieve(&self, total_weight: u64) -> Result<Vec<Arc<Transaction>>, MempoolError> {
         self.pool_storage
-            .read()
+            .write()
             .map_err(|e| MempoolError::BackendError(e.to_string()))?
             .retrieve(total_weight)
     }

--- a/base_layer/core/src/mempool/unconfirmed_pool/unconfirmed_pool.rs
+++ b/base_layer/core/src/mempool/unconfirmed_pool/unconfirmed_pool.rs
@@ -27,13 +27,15 @@ use crate::{
         priority::{FeePriority, PrioritizedTransaction},
         unconfirmed_pool::UnconfirmedPoolError,
     },
-    transactions::{transaction::Transaction, types::Signature},
+    transactions::{
+        transaction::Transaction,
+        types::{HashOutput, Signature},
+    },
 };
 use log::*;
 use serde::{Deserialize, Serialize};
 use std::{
     collections::{BTreeMap, HashMap},
-    convert::TryFrom,
     sync::Arc,
 };
 use tari_crypto::tari_utilities::{hex::Hex, Hashable};
@@ -71,6 +73,13 @@ pub struct UnconfirmedPool {
     config: UnconfirmedPoolConfig,
     txs_by_signature: HashMap<Signature, PrioritizedTransaction>,
     txs_by_priority: BTreeMap<FeePriority, Signature>,
+    txs_by_output: HashMap<HashOutput, Vec<Signature>>,
+}
+
+// helper class to reduce type complexity
+pub struct RetrieveResults {
+    pub retrieved_transactions: Vec<Arc<Transaction>>,
+    pub transactions_to_insert: Vec<Arc<Transaction>>,
 }
 
 impl UnconfirmedPool {
@@ -80,6 +89,7 @@ impl UnconfirmedPool {
             config,
             txs_by_signature: HashMap::new(),
             txs_by_priority: BTreeMap::new(),
+            txs_by_output: HashMap::new(),
         }
     }
 
@@ -98,12 +108,16 @@ impl UnconfirmedPool {
     /// higher priority transactions. The lowest priority transactions will be removed when the maximum capacity is
     /// reached and the new transaction has a higher priority than the currently stored lowest priority transaction.
     #[allow(clippy::map_entry)]
-    pub fn insert(&mut self, tx: Arc<Transaction>) -> Result<(), UnconfirmedPoolError> {
+    pub fn insert(
+        &mut self,
+        tx: Arc<Transaction>,
+        dependent_outputs: Option<Vec<HashOutput>>,
+    ) -> Result<(), UnconfirmedPoolError> {
         let tx_key = tx
             .first_kernel_excess_sig()
             .ok_or(UnconfirmedPoolError::TransactionNoKernels)?;
         if !self.txs_by_signature.contains_key(tx_key) {
-            let prioritized_tx = PrioritizedTransaction::try_from((*tx).clone())?;
+            let prioritized_tx = PrioritizedTransaction::convert_from_transaction((*tx).clone(), dependent_outputs)?;
             if self.txs_by_signature.len() >= self.config.storage_capacity {
                 if prioritized_tx.priority < *self.lowest_priority() {
                     return Ok(());
@@ -113,21 +127,38 @@ impl UnconfirmedPool {
             self.txs_by_priority
                 .insert(prioritized_tx.priority.clone(), tx_key.clone());
             self.txs_by_signature.insert(tx_key.clone(), prioritized_tx);
+            for output in tx.body.outputs().clone() {
+                self.txs_by_output
+                    .entry(output.hash())
+                    .or_default()
+                    .push(tx_key.clone());
+            }
             debug!(
                 target: LOG_TARGET,
                 "Inserted transaction with signature {} into unconfirmed pool:",
                 tx_key.get_signature().to_hex()
             );
+
             trace!(target: LOG_TARGET, "{}", tx);
         }
         Ok(())
+    }
+
+    /// TThis will search the unconfirmed pool for the set of outputs and return true if all of them are found
+    pub fn verify_outputs_exist(&mut self, outputs: &[HashOutput]) -> bool {
+        for hash in outputs {
+            if !self.txs_by_output.contains_key(hash) {
+                return false;
+            }
+        }
+        true
     }
 
     /// Insert a set of new transactions into the UnconfirmedPool
     #[cfg(test)]
     pub fn insert_txs(&mut self, txs: Vec<Arc<Transaction>>) -> Result<(), UnconfirmedPoolError> {
         for tx in txs.into_iter() {
-            self.insert(tx)?;
+            self.insert(tx, None)?;
         }
         Ok(())
     }
@@ -138,22 +169,41 @@ impl UnconfirmedPool {
     }
 
     /// Returns a set of the highest priority unconfirmed transactions, that can be included in a block
-    pub fn highest_priority_txs(&self, total_weight: u64) -> Result<Vec<Arc<Transaction>>, UnconfirmedPoolError> {
-        let mut selected_txs: Vec<Arc<Transaction>> = Vec::new();
+    pub fn highest_priority_txs(&mut self, total_weight: u64) -> Result<RetrieveResults, UnconfirmedPoolError> {
+        let mut selected_txs = HashMap::new();
         let mut curr_weight: u64 = 0;
         let mut curr_skip_count: usize = 0;
+        let mut transactions_to_remove_and_recheck = Vec::new();
         for (_, tx_key) in self.txs_by_priority.iter().rev() {
-            let ptx = self
+            if selected_txs.contains_key(tx_key) {
+                continue;
+            }
+            let prioritized_transaction = self
                 .txs_by_signature
                 .get(tx_key)
                 .ok_or(UnconfirmedPoolError::StorageOutofSync)?;
 
-            if curr_weight + ptx.weight <= total_weight {
-                if !UnconfirmedPool::find_duplicate_input(&selected_txs, &ptx.transaction) {
-                    curr_weight += ptx.weight;
-                    selected_txs.push(ptx.transaction.clone());
+            let mut total_transaction_weight = 0;
+            let mut potential_transactions_to_insert = HashMap::new();
+            let mut potential_transactions_to_remove_and_recheck = Vec::new();
+            self.get_all_dependant_transactions(
+                &prioritized_transaction,
+                &mut potential_transactions_to_insert,
+                &mut potential_transactions_to_remove_and_recheck,
+                &selected_txs,
+                &mut total_transaction_weight,
+            )?;
+            if curr_weight + total_transaction_weight <= total_weight &&
+                potential_transactions_to_remove_and_recheck.is_empty()
+            {
+                if !UnconfirmedPool::find_duplicate_input(&selected_txs, &potential_transactions_to_insert) {
+                    curr_weight += total_transaction_weight;
+                    for (key, transaction) in potential_transactions_to_insert {
+                        selected_txs.insert((key).clone(), transaction.transaction.clone());
+                    }
                 }
             } else {
+                transactions_to_remove_and_recheck.append(&mut potential_transactions_to_remove_and_recheck);
                 // Check if some the next few txs with slightly lower priority wont fit in the remaining space.
                 curr_skip_count += 1;
                 if curr_skip_count >= self.config.weight_tx_skip_count {
@@ -161,16 +211,107 @@ impl UnconfirmedPool {
                 }
             }
         }
-        Ok(selected_txs)
+        // we need to remove all transactions that need to be rechecked.
+        for transaction in &transactions_to_remove_and_recheck {
+            let key = transaction
+                .first_kernel_excess_sig()
+                .ok_or(UnconfirmedPoolError::TransactionNoKernels)?;
+            debug!(
+                target: LOG_TARGET,
+                "Removing transaction with key {} from unconfirmed pool because it needs re-evaluation",
+                key.get_signature().to_hex()
+            );
+            self.delete_transaction(&key);
+        }
+        let results = RetrieveResults {
+            retrieved_transactions: selected_txs.into_values().collect(),
+            transactions_to_insert: transactions_to_remove_and_recheck,
+        };
+        Ok(results)
+    }
+
+    fn get_all_dependant_transactions(
+        &self,
+        transaction: &PrioritizedTransaction,
+        required_transactions: &mut HashMap<Signature, PrioritizedTransaction>,
+        transactions_to_delete: &mut Vec<Arc<Transaction>>,
+        already_selected_txs: &HashMap<Signature, Arc<Transaction>>,
+        total_weight: &mut u64,
+    ) -> Result<(), UnconfirmedPoolError> {
+        for dependant_output in &transaction.depended_output_hashes {
+            match self.txs_by_output.get(dependant_output) {
+                Some(signatures) => {
+                    let highest_signature = self.find_highest_priority_transaction(&signatures)?;
+                    if !already_selected_txs.contains_key(&highest_signature) {
+                        let dependant_transaction = self
+                            .txs_by_signature
+                            .get(&highest_signature)
+                            .ok_or(UnconfirmedPoolError::StorageOutofSync)?;
+                        self.get_all_dependant_transactions(
+                            dependant_transaction,
+                            required_transactions,
+                            transactions_to_delete,
+                            already_selected_txs,
+                            total_weight,
+                        )?;
+                        if !transactions_to_delete.is_empty() {
+                            transactions_to_delete.push(transaction.transaction.clone());
+                            break;
+                        }
+                    }
+                },
+                None => {
+                    // this transactions requires an output, that the mempool does not currently have, but did have at
+                    // some point. This means that we need to remove this transaction and re
+                    // validate it
+                    transactions_to_delete.push(transaction.transaction.clone());
+                    break;
+                },
+            }
+        }
+        let key = transaction
+            .transaction
+            .first_kernel_excess_sig()
+            .ok_or(UnconfirmedPoolError::TransactionNoKernels)?;
+        if required_transactions
+            .insert(key.clone(), (*transaction).clone())
+            .is_none()
+        {
+            *total_weight += transaction.weight;
+        };
+        Ok(())
+    }
+
+    fn find_highest_priority_transaction(&self, signatures: &[Signature]) -> Result<Signature, UnconfirmedPoolError> {
+        let mut highest_signature = signatures[0].clone();
+        for signature in signatures.iter().skip(1) {
+            let transaction = self
+                .txs_by_signature
+                .get(signature)
+                .ok_or(UnconfirmedPoolError::StorageOutofSync)?;
+            let current_transaction = self
+                .txs_by_signature
+                .get(&highest_signature)
+                .ok_or(UnconfirmedPoolError::StorageOutofSync)?;
+            if transaction.priority > current_transaction.priority {
+                highest_signature = signature.clone();
+            }
+        }
+        Ok(highest_signature)
     }
 
     // This will search a Vec<Arc<Transaction>> for duplicate inputs of a tx
-    fn find_duplicate_input(array_of_tx: &[Arc<Transaction>], tx: &Arc<Transaction>) -> bool {
-        for transaction in array_of_tx {
-            for input in transaction.body.inputs() {
-                for tx_input in tx.body.inputs() {
-                    if tx_input.commitment == input.commitment {
-                        return true;
+    fn find_duplicate_input(
+        current_transactions: &HashMap<Signature, Arc<Transaction>>,
+        transactions_to_insert: &HashMap<Signature, PrioritizedTransaction>,
+    ) -> bool {
+        for (_, transaction_to_insert) in transactions_to_insert.iter() {
+            for (_, transaction) in current_transactions.iter() {
+                for input in transaction.body.inputs() {
+                    for tx_input in transaction_to_insert.transaction.body.inputs() {
+                        if tx_input.output_hash() == input.output_hash() {
+                            return true;
+                        }
                     }
                 }
             }
@@ -186,62 +327,104 @@ impl UnconfirmedPool {
             .map(|(_key, val)| val.transaction)
             .collect();
         self.txs_by_priority.clear();
+        self.txs_by_output.clear();
 
         mempool_txs
     }
 
-    /// Remove all published transactions from the UnconfirmedPool and discard all double spend transactions.
-    fn discard_double_spends(&mut self, published_block: &Block) {
-        let mut removed_tx_keys = Vec::new();
-        for (tx_key, ptx) in self.txs_by_signature.iter() {
-            for input in ptx.transaction.body.inputs() {
-                for published_input in published_block.body.inputs() {
-                    if published_input.commitment == input.commitment {
-                        self.txs_by_priority.remove(&ptx.priority);
-                        debug!(
-                            target: LOG_TARGET,
-                            "Removed double spend tx with key {} from unconfirmed pool",
-                            tx_key.get_signature().to_hex()
-                        );
-                        trace!(target: LOG_TARGET, "{}", &ptx.transaction);
-                        removed_tx_keys.push(tx_key.clone());
-                    }
-                }
-            }
-        }
-
-        for tx_key in &removed_tx_keys {
-            self.txs_by_signature.remove(&tx_key);
-        }
-    }
-
-    /// Remove all published transactions from the UnconfirmedPoolStorage and discard double spends
-    pub fn remove_published_and_discard_double_spends(&mut self, published_block: &Block) -> Vec<Arc<Transaction>> {
+    /// Remove all published transactions from the UnconfirmedPoolStorage and discard deprecated transactions
+    pub fn remove_published_and_discard_deprecated_transactions(
+        &mut self,
+        published_block: &Block,
+    ) -> Vec<Arc<Transaction>> {
         trace!(
             target: LOG_TARGET,
-            "Searching for txns to remove from unconfirmed pool in block {} ({})",
+            "Searching for transactions to remove from unconfirmed pool in block {} ({})",
             published_block.header.height,
             published_block.header.hash().to_hex(),
         );
-        let mut removed_txs = Vec::new();
+        // We need to make sure that none of the transactions in the block remains in the mempool
+        let mut transactions_to_remove = Vec::new();
         published_block.body.kernels().iter().for_each(|kernel| {
-            if let Some(ptx) = self.txs_by_signature.get(&kernel.excess_sig) {
-                self.txs_by_priority.remove(&ptx.priority);
-                if let Some(ptx) = self.txs_by_signature.remove(&kernel.excess_sig) {
-                    debug!(
-                        target: LOG_TARGET,
-                        "Removed tx with key {} from unconfirmed pool",
-                        kernel.excess_sig.get_signature().to_hex()
-                    );
-                    trace!(target: LOG_TARGET, "{}", &ptx.transaction);
-                    removed_txs.push(ptx.transaction);
+            transactions_to_remove.push(kernel.excess_sig.clone());
+        });
+        let mut removed_transactions = self.delete_transactions(&transactions_to_remove);
+
+        // Remove all other deprecated transactions that cannot be valid anymore
+        removed_transactions.append(&mut self.remove_deprecated_transactions(published_block));
+        removed_transactions
+    }
+
+    // Remove all deprecated transactions from the UnconfirmedPool by scanning inputs and outputs.
+    fn remove_deprecated_transactions(&mut self, published_block: &Block) -> Vec<Arc<Transaction>> {
+        let mut transaction_keys_to_remove = Vec::new();
+        for (tx_key, ptx) in self.txs_by_signature.iter() {
+            if UnconfirmedPool::find_matching_block_input(ptx, published_block) {
+                transaction_keys_to_remove.push(tx_key.clone())
+            }
+        }
+        published_block.body.outputs().iter().for_each(|output| {
+            if let Some(signatures) = self.txs_by_output.get(&output.hash()) {
+                for signature in signatures {
+                    transaction_keys_to_remove.push(signature.clone())
                 }
             }
         });
-        // First remove published transactions before discarding double spends
-        self.discard_double_spends(published_block);
+        debug!(
+            target: LOG_TARGET,
+            "Removing transactions containing duplicated commitments from unconfirmed pool"
+        );
+        self.delete_transactions(&transaction_keys_to_remove)
+    }
 
+    // This is a helper function that searches a block and transaction for matching inputs
+    fn find_matching_block_input(transaction: &PrioritizedTransaction, published_block: &Block) -> bool {
+        for input in transaction.transaction.body.inputs() {
+            for published_input in published_block.body.inputs() {
+                if published_input.output_hash() == input.output_hash() {
+                    return true;
+                }
+            }
+        }
+        false
+    }
+
+    fn delete_transactions(&mut self, signature: &[Signature]) -> Vec<Arc<Transaction>> {
+        let mut removed_txs: Vec<Arc<Transaction>> = Vec::new();
+        for tx_key in signature {
+            debug!(
+                target: LOG_TARGET,
+                "Removing transaction with key {} from unconfirmed pool",
+                tx_key.get_signature().to_hex()
+            );
+            if let Some(transaction) = self.delete_transaction(&tx_key) {
+                removed_txs.push(transaction);
+            }
+        }
         removed_txs
+    }
+
+    // Helper function to ensure that all transactions are safely deleted in order and from all storage
+    fn delete_transaction(&mut self, signature: &Signature) -> Option<Arc<Transaction>> {
+        if let Some(prioritized_transaction) = self.txs_by_signature.remove(signature) {
+            self.txs_by_priority.remove(&prioritized_transaction.priority);
+            for output in prioritized_transaction.transaction.as_ref().body.outputs() {
+                let key = output.hash();
+                if let Some(signatures) = self.txs_by_output.get_mut(&key) {
+                    signatures.retain(|x| x != signature);
+                    if signatures.is_empty() {
+                        self.txs_by_output.remove(&key);
+                    }
+                }
+            }
+            trace!(
+                target: LOG_TARGET,
+                "Deleted transaction: {}",
+                &prioritized_transaction.transaction
+            );
+            return Some(prioritized_transaction.transaction);
+        }
+        None
     }
 
     /// Remove all unconfirmed transactions that have become time locked. This can happen when the chain height was
@@ -250,22 +433,11 @@ impl UnconfirmedPool {
         let mut removed_tx_keys: Vec<Signature> = Vec::new();
         for (tx_key, ptx) in self.txs_by_signature.iter() {
             if ptx.transaction.min_spendable_height() > tip_height + 1 {
-                self.txs_by_priority.remove(&ptx.priority);
                 removed_tx_keys.push(tx_key.clone());
             }
         }
-        let mut removed_txs: Vec<Arc<Transaction>> = Vec::new();
-        for tx_key in removed_tx_keys {
-            trace!(
-                target: LOG_TARGET,
-                "Removing time locked transaction from unconfirmed pool: {:?}",
-                tx_key
-            );
-            if let Some(ptx) = self.txs_by_signature.remove(&tx_key) {
-                removed_txs.push(ptx.transaction);
-            }
-        }
-        removed_txs
+        debug!(target: LOG_TARGET, "Removing time-locked inputs from unconfirmed pool");
+        self.delete_transactions(&removed_tx_keys)
     }
 
     /// Returns the total number of unconfirmed transactions stored in the UnconfirmedPool.
@@ -323,12 +495,24 @@ mod test {
     fn test_find_duplicate_input() {
         let tx1 = Arc::new(tx!(MicroTari(5000), fee: MicroTari(50), inputs: 2, outputs: 1).0);
         let tx2 = Arc::new(tx!(MicroTari(5000), fee: MicroTari(50), inputs: 2, outputs: 1).0);
+        let mut tx_pool = HashMap::new();
+        let mut tx1_pool = HashMap::new();
+        let mut tx2_pool = HashMap::new();
+        tx_pool.insert(tx1.first_kernel_excess_sig().unwrap().clone(), tx1.clone());
+        tx1_pool.insert(
+            tx1.first_kernel_excess_sig().unwrap().clone(),
+            PrioritizedTransaction::convert_from_transaction((*tx1).clone(), None).unwrap(),
+        );
+        tx2_pool.insert(
+            tx2.first_kernel_excess_sig().unwrap().clone(),
+            PrioritizedTransaction::convert_from_transaction((*tx2).clone(), None).unwrap(),
+        );
         assert!(
-            UnconfirmedPool::find_duplicate_input(&[tx1.clone()], &tx1),
+            UnconfirmedPool::find_duplicate_input(&tx_pool, &tx1_pool),
             "Duplicate was not found"
         );
         assert!(
-            !UnconfirmedPool::find_duplicate_input(&[tx1], &tx2),
+            !UnconfirmedPool::find_duplicate_input(&tx_pool, &tx2_pool),
             "Duplicate was incorrectly found as true"
         );
     }
@@ -356,11 +540,11 @@ mod test {
         assert!(unconfirmed_pool.has_tx_with_excess_sig(&tx5.body.kernels()[0].excess_sig),);
         // Retrieve the set of highest priority unspent transactions
         let desired_weight = tx1.calculate_weight() + tx3.calculate_weight() + tx5.calculate_weight();
-        let selected_txs = unconfirmed_pool.highest_priority_txs(desired_weight).unwrap();
-        assert_eq!(selected_txs.len(), 3);
-        assert!(selected_txs.contains(&tx1));
-        assert!(selected_txs.contains(&tx3));
-        assert!(selected_txs.contains(&tx5));
+        let results = unconfirmed_pool.highest_priority_txs(desired_weight).unwrap();
+        assert_eq!(results.retrieved_transactions.len(), 3);
+        assert!(results.retrieved_transactions.contains(&tx1));
+        assert!(results.retrieved_transactions.contains(&tx3));
+        assert!(results.retrieved_transactions.contains(&tx5));
         // Note that transaction tx5 could not be included as its weight was to big to fit into the remaining allocated
         // space, the second best transaction was then included
 
@@ -419,11 +603,11 @@ mod test {
         assert_eq!(unconfirmed_pool.len(), 3);
 
         let desired_weight = tx1.calculate_weight() + tx2.calculate_weight() + tx3.calculate_weight() + 1000;
-        let selected_txs = unconfirmed_pool.highest_priority_txs(desired_weight).unwrap();
-        assert!(selected_txs.contains(&tx1));
+        let results = unconfirmed_pool.highest_priority_txs(desired_weight).unwrap();
+        assert!(results.retrieved_transactions.contains(&tx1));
         // Whether tx2 or tx3 is selected is non-deterministic
-        assert!(selected_txs.contains(&tx2) ^ selected_txs.contains(&tx3));
-        assert_eq!(selected_txs.len(), 2);
+        assert!(results.retrieved_transactions.contains(&tx2) ^ results.retrieved_transactions.contains(&tx3));
+        assert_eq!(results.retrieved_transactions.len(), 2);
     }
 
     #[test]
@@ -456,7 +640,7 @@ mod test {
         assert!(snapshot_txs.contains(&tx5));
 
         let published_block = create_orphan_block(0, vec![(*tx1).clone(), (*tx3).clone(), (*tx5).clone()], &consensus);
-        let _ = unconfirmed_pool.remove_published_and_discard_double_spends(&published_block);
+        let _ = unconfirmed_pool.remove_published_and_discard_deprecated_transactions(&published_block);
 
         assert!(!unconfirmed_pool.has_tx_with_excess_sig(&tx1.body.kernels()[0].excess_sig),);
         assert!(unconfirmed_pool.has_tx_with_excess_sig(&tx2.body.kernels()[0].excess_sig),);
@@ -502,7 +686,7 @@ mod test {
         // The publishing of tx1 and tx3 will be double-spends and orphan tx5 and tx6
         let published_block = create_orphan_block(0, vec![(*tx1).clone(), (*tx2).clone(), (*tx3).clone()], &consensus);
 
-        let _ = unconfirmed_pool.remove_published_and_discard_double_spends(&published_block); // Double spends are discarded
+        let _ = unconfirmed_pool.remove_published_and_discard_deprecated_transactions(&published_block); // Double spends are discarded
 
         assert!(!unconfirmed_pool.has_tx_with_excess_sig(&tx1.body.kernels()[0].excess_sig),);
         assert!(!unconfirmed_pool.has_tx_with_excess_sig(&tx2.body.kernels()[0].excess_sig),);
@@ -512,5 +696,71 @@ mod test {
         assert!(!unconfirmed_pool.has_tx_with_excess_sig(&tx6.body.kernels()[0].excess_sig),);
 
         assert!(unconfirmed_pool.check_status());
+    }
+
+    #[test]
+    fn test_multiple_transactions_with_same_outputs_in_mempool() {
+        let (tx1, _, _) = tx!(MicroTari(150_000), fee: MicroTari(50), inputs:5, outputs:5);
+        let (tx2, _, _) = tx!(MicroTari(250_000), fee: MicroTari(50), inputs:5, outputs:5);
+
+        // Create transactions with duplicate kernels (will not pass internal validation, but that is ok)
+        let mut tx3 = tx1.clone();
+        let mut tx4 = tx2.clone();
+        let (tx5, _, _) = tx!(MicroTari(350_000), fee: MicroTari(50), inputs:5, outputs:5);
+        let (tx6, _, _) = tx!(MicroTari(450_000), fee: MicroTari(50), inputs:5, outputs:5);
+        tx3.body.set_kernel(tx5.body.kernels()[0].clone());
+        tx4.body.set_kernel(tx6.body.kernels()[0].clone());
+
+        // Insert multiple transactions with the same outputs into the mempool
+        let mut unconfirmed_pool = UnconfirmedPool::new(UnconfirmedPoolConfig {
+            storage_capacity: 10,
+            weight_tx_skip_count: 3,
+        });
+        let txns = vec![
+            Arc::new(tx1.clone()),
+            Arc::new(tx2.clone()),
+            // Transactions with duplicate outputs
+            Arc::new(tx3.clone()),
+            Arc::new(tx4.clone()),
+        ];
+        unconfirmed_pool.insert_txs(txns.clone()).unwrap();
+
+        for txn in txns {
+            for output in txn.as_ref().body.outputs() {
+                assert!(unconfirmed_pool.verify_outputs_exist(&[output.hash()]));
+                let signatures_by_output = unconfirmed_pool.txs_by_output.get(&output.hash()).unwrap();
+                // Each output must be referenced by two transactions
+                assert_eq!(signatures_by_output.len(), 2);
+                // Verify kernel signature present at least once
+                let mut found = 0u8;
+                for signature in signatures_by_output {
+                    if signature == &txn.as_ref().body.kernels()[0].excess_sig {
+                        found += 1;
+                    }
+                }
+                assert_eq!(found, 1);
+            }
+        }
+
+        // Remove some transactions
+        unconfirmed_pool.delete_transaction(&tx1.body.kernels()[0].excess_sig);
+        unconfirmed_pool.delete_transaction(&tx4.body.kernels()[0].excess_sig);
+
+        let txns = vec![
+            Arc::new(tx2),
+            // Transactions with duplicate outputs
+            Arc::new(tx3),
+        ];
+        for txn in txns {
+            for output in txn.as_ref().body.outputs() {
+                let signatures_by_output = unconfirmed_pool.txs_by_output.get(&output.hash()).unwrap();
+                // Each output must be referenced by one transactions
+                assert_eq!(signatures_by_output.len(), 1);
+                // Verify kernel signature present exactly once
+                for signature in signatures_by_output {
+                    assert_eq!(signature, &txn.as_ref().body.kernels()[0].excess_sig);
+                }
+            }
+        }
     }
 }

--- a/base_layer/core/src/transactions/transaction.rs
+++ b/base_layer/core/src/transactions/transaction.rs
@@ -415,9 +415,11 @@ impl TransactionInput {
     }
 
     /// This will check if the input and the output is the same commitment by looking at the commitment and features.
-    /// This will ignore the output range proof
+    /// This will ignore the output rangeproof
+    // TODO: This should compare all features that are the same for an input and output, this needs the script details
+    // as well
     pub fn is_equal_to(&self, output: &TransactionOutput) -> bool {
-        self.commitment == output.commitment && self.features == output.features
+        self.output_hash() == output.hash()
     }
 
     /// This will run the script contained in the TransactionInput, returning either a script error or the resulting

--- a/base_layer/core/src/validation/block_validators.rs
+++ b/base_layer/core/src/validation/block_validators.rs
@@ -171,20 +171,20 @@ fn check_inputs_are_utxos<B: BlockchainBackend>(block: &Block, db: &B) -> Result
                 );
                 return Err(ValidationError::ContainsSTxO);
             }
-        // TODO Do we keep the height validation?
-        // if height != input.height {
-        //     warn!(
-        //         target: LOG_TARGET,
-        //         "Block validation failed due to input not having correct mined height({}): {}", height, input
-        //     );
-        //     return Err(ValidationError::InvalidMinedHeight);
-        // }
         } else {
-            warn!(
-                target: LOG_TARGET,
-                "Block validation failed because the block has invalid input: {} which does not exist", input
-            );
-            return Err(ValidationError::BlockError(BlockValidationError::InvalidInput));
+            // lets check if the input exists in the output field
+            if !block
+                .body
+                .outputs()
+                .iter()
+                .any(|output| output.hash() == input.output_hash())
+            {
+                warn!(
+                    target: LOG_TARGET,
+                    "Block validation failed because the block has invalid input: {} which does not exist", input
+                );
+                return Err(ValidationError::BlockError(BlockValidationError::InvalidInput));
+            }
         }
     }
 

--- a/base_layer/core/src/validation/error.rs
+++ b/base_layer/core/src/validation/error.rs
@@ -24,7 +24,7 @@ use crate::{
     blocks::{block_header::BlockHeaderValidationError, BlockValidationError},
     chain_storage::ChainStorageError,
     proof_of_work::{monero_rx::MergeMineError, PowError},
-    transactions::transaction::TransactionError,
+    transactions::{transaction::TransactionError, types::HashOutput},
 };
 use thiserror::Error;
 
@@ -37,7 +37,7 @@ pub enum ValidationError {
     #[error("Contains kernels or inputs that are not yet spendable")]
     MaturityError,
     #[error("Contains unknown inputs")]
-    UnknownInputs,
+    UnknownInputs(Vec<HashOutput>),
     #[error("The transaction is invalid: {0}")]
     TransactionError(#[from] TransactionError),
     #[error("Error: {0}")]

--- a/base_layer/core/tests/mempool.rs
+++ b/base_layer/core/tests/mempool.rs
@@ -333,6 +333,306 @@ fn test_retrieve() {
 
 #[test]
 #[allow(clippy::identity_op)]
+fn test_zero_conf() {
+    let network = Network::LocalNet;
+    let (mut store, mut blocks, mut outputs, consensus_manager) = create_new_blockchain(network);
+    let mempool_validator = TxInputAndMaturityValidator::new(store.clone());
+    let mempool = Mempool::new(MempoolConfig::default(), Arc::new(mempool_validator));
+    let txs = vec![txn_schema!(
+        from: vec![outputs[0][0].clone()],
+        to: vec![21 * T, 11 * T, 11 * T, 16 * T]
+    )];
+    // "Mine" Block 1
+    generate_new_block(&mut store, &mut blocks, &mut outputs, txs, &consensus_manager).unwrap();
+    mempool.process_published_block(blocks[1].to_arc_block()).unwrap();
+
+    // This transaction graph will be created, containing 3 levels of zero-conf transactions, inheriting dependent
+    // outputs from multiple parents
+    //
+    // tx01   tx02   tx03   tx04    Basis transactions using mined inputs (lowest fees, increases left to right)
+    //   | \    |      |      |
+    //   |  \   |      |      |
+    //   |   \  |      |      |
+    // tx11   tx12   tx13   tx14    Zero-conf level 1 transactions (fees up from previous, increases left to right)
+    //   | \    | \    |   /  |
+    //   |  |   |  \   |  |   |
+    //   |  |   |   \  |  |   |
+    // tx21 | tx22   tx23 | tx24    Zero-conf level 2 transactions (fees up from previous, increases left to right)
+    //   |  |   |      |  |   |
+    //   |   \  |      | /    |
+    //   |    \ |      |/     |
+    // tx31   tx32   tx33   tx34    Zero-conf level 3 transactions (highest fees, increases left to right)
+
+    // Create 4 original transactions, only submit 3 (hold back tx02)
+    let (tx01, tx01_out, _) = spend_utxos(txn_schema!(
+        from: vec![outputs[1][0].clone()],
+        to: vec![15 * T, 5 * T],
+        fee: 10*uT,
+        lock: 0,
+        features: OutputFeatures::default()
+    ));
+    let (tx02, tx02_out, _) = spend_utxos(txn_schema!(
+        from: vec![outputs[1][1].clone()],
+        to: vec![5 * T, 5 * T],
+        fee: 20*uT,
+        lock: 0,
+        features: OutputFeatures::default()
+    ));
+    let (tx03, tx03_out, _) = spend_utxos(txn_schema!(
+        from: vec![outputs[1][2].clone()],
+        to: vec![5 * T, 5 * T],
+        fee: 30*uT,
+        lock: 0,
+        features: OutputFeatures::default()
+    ));
+    let (tx04, tx04_out, _) = spend_utxos(txn_schema!(
+        from: vec![outputs[1][3].clone()],
+        to: vec![5 * T, 5 * T],
+        fee: 40*uT,
+        lock: 0,
+        features: OutputFeatures::default()
+    ));
+    assert_eq!(
+        mempool.insert(Arc::new(tx01.clone())).unwrap(),
+        TxStorageResponse::UnconfirmedPool
+    );
+    assert_eq!(
+        mempool.insert(Arc::new(tx03.clone())).unwrap(),
+        TxStorageResponse::UnconfirmedPool
+    );
+    assert_eq!(
+        mempool.insert(Arc::new(tx04.clone())).unwrap(),
+        TxStorageResponse::UnconfirmedPool
+    );
+
+    // Create 4 zero-conf level 1 transactions, try to submit all
+    let (tx11, tx11_out, _) = spend_utxos(txn_schema!(
+        from: vec![tx01_out[0].clone()],
+        to: vec![7 * T, 4 * T],
+        fee: 50*uT, lock: 0,
+        features: OutputFeatures::default()
+    ));
+    let (tx12, tx12_out, _) = spend_utxos(txn_schema!(
+        from: vec![tx01_out[1].clone(), tx02_out[0].clone(), tx02_out[1].clone()],
+        to: vec![7 * T, 4 * T],
+        fee: 60*uT,
+        lock: 0,
+        features: OutputFeatures::default()
+    ));
+    let (tx13, tx13_out, _) = spend_utxos(txn_schema!(
+        from: tx03_out,
+        to: vec![4 * T, 4 * T],
+        fee: 70*uT,
+        lock: 0,
+        features: OutputFeatures::default()
+    ));
+    let (tx14, tx14_out, _) = spend_utxos(txn_schema!(
+        from: tx04_out,
+        to: vec![10 * T, 4 * T],
+        fee: 80*uT, lock: 0,
+        features: OutputFeatures::default()
+    ));
+    assert_eq!(
+        mempool.insert(Arc::new(tx11.clone())).unwrap(),
+        TxStorageResponse::UnconfirmedPool
+    );
+    assert_eq!(
+        mempool.insert(Arc::new(tx12.clone())).unwrap(),
+        TxStorageResponse::NotStoredOrphan
+    );
+    assert_eq!(
+        mempool.insert(Arc::new(tx13.clone())).unwrap(),
+        TxStorageResponse::UnconfirmedPool
+    );
+    assert_eq!(
+        mempool.insert(Arc::new(tx14.clone())).unwrap(),
+        TxStorageResponse::UnconfirmedPool
+    );
+
+    // Create 4 zero-conf level 2 transactions, try to submit all
+    let (tx21, tx21_out, _) = spend_utxos(txn_schema!(
+        from: vec![tx11_out[0].clone()],
+        to: vec![3 * T, 3 * T],
+        fee: 90*uT,
+        lock: 0,
+        features: OutputFeatures::default()
+    ));
+    let (tx22, tx22_out, _) = spend_utxos(txn_schema!(
+        from: vec![tx12_out[0].clone()],
+        to: vec![3 * T, 3 * T],
+        fee: 100*uT,
+        lock: 0,
+        features: OutputFeatures::default()
+    ));
+    let (tx23, tx23_out, _) = spend_utxos(txn_schema!(
+        from: vec![tx12_out[1].clone(), tx13_out[0].clone(), tx13_out[1].clone()],
+        to: vec![3 * T, 3 * T],
+        fee: 110*uT,
+        lock: 0,
+        features: OutputFeatures::default()
+    ));
+    let (tx24, tx24_out, _) = spend_utxos(txn_schema!(
+        from: vec![tx14_out[0].clone()],
+        to: vec![3 * T, 3 * T],
+        fee: 120*uT, lock: 0,
+        features: OutputFeatures::default()
+    ));
+    assert_eq!(
+        mempool.insert(Arc::new(tx21.clone())).unwrap(),
+        TxStorageResponse::UnconfirmedPool
+    );
+    assert_eq!(
+        mempool.insert(Arc::new(tx22.clone())).unwrap(),
+        TxStorageResponse::NotStoredOrphan
+    );
+    assert_eq!(
+        mempool.insert(Arc::new(tx23.clone())).unwrap(),
+        TxStorageResponse::NotStoredOrphan
+    );
+    assert_eq!(
+        mempool.insert(Arc::new(tx24.clone())).unwrap(),
+        TxStorageResponse::UnconfirmedPool
+    );
+
+    // Create 4 zero-conf level 3 transactions, try to submit all
+    let (tx31, _, _) = spend_utxos(txn_schema!(
+        from: tx21_out,
+        to: vec![2 * T, 2 * T],
+        fee: 130*uT,
+        lock: 0,
+        features: OutputFeatures::default()
+    ));
+    let (tx32, _, _) = spend_utxos(txn_schema!(
+        from: vec![tx11_out[1].clone(), tx22_out[0].clone(), tx22_out[1].clone()],
+        to: vec![2 * T, 2 * T],
+        fee: 140*uT,
+        lock: 0,
+        features: OutputFeatures::default()
+    ));
+    let (tx33, _, _) = spend_utxos(txn_schema!(
+        from: vec![tx14_out[1].clone(), tx23_out[0].clone(), tx23_out[1].clone()],
+        to: vec![2 * T, 2 * T],
+        fee: 150*uT,
+        lock: 0,
+        features: OutputFeatures::default()
+    ));
+    let (tx34, _, _) = spend_utxos(txn_schema!(
+        from: tx24_out,
+        to: vec![2 * T, 2 * T],
+        fee: 160*uT,
+        lock: 0,
+        features: OutputFeatures::default()
+    ));
+    assert_eq!(
+        mempool.insert(Arc::new(tx31.clone())).unwrap(),
+        TxStorageResponse::UnconfirmedPool
+    );
+    assert_eq!(
+        mempool.insert(Arc::new(tx32.clone())).unwrap(),
+        TxStorageResponse::NotStoredOrphan
+    );
+    assert_eq!(
+        mempool.insert(Arc::new(tx33.clone())).unwrap(),
+        TxStorageResponse::NotStoredOrphan
+    );
+    assert_eq!(
+        mempool.insert(Arc::new(tx34.clone())).unwrap(),
+        TxStorageResponse::UnconfirmedPool
+    );
+
+    // Try to retrieve all transactions in the mempool (a couple of our transactions should be missing from retrieved)
+    let retrieved_txs = mempool.retrieve(mempool.stats().unwrap().total_weight).unwrap();
+    assert_eq!(retrieved_txs.len(), 10);
+    assert!(retrieved_txs.contains(&Arc::new(tx01.clone())));
+    assert!(!retrieved_txs.contains(&Arc::new(tx02.clone()))); // Missing
+    assert!(retrieved_txs.contains(&Arc::new(tx03.clone())));
+    assert!(retrieved_txs.contains(&Arc::new(tx04.clone())));
+    assert!(retrieved_txs.contains(&Arc::new(tx11.clone())));
+    assert!(!retrieved_txs.contains(&Arc::new(tx12.clone()))); // Missing
+    assert!(retrieved_txs.contains(&Arc::new(tx13.clone())));
+    assert!(retrieved_txs.contains(&Arc::new(tx14.clone())));
+    assert!(retrieved_txs.contains(&Arc::new(tx21.clone())));
+    assert!(!retrieved_txs.contains(&Arc::new(tx22.clone()))); // Missing
+    assert!(!retrieved_txs.contains(&Arc::new(tx23.clone()))); // Missing
+    assert!(retrieved_txs.contains(&Arc::new(tx24.clone())));
+    assert!(retrieved_txs.contains(&Arc::new(tx31.clone())));
+    assert!(!retrieved_txs.contains(&Arc::new(tx32.clone()))); // Missing
+    assert!(!retrieved_txs.contains(&Arc::new(tx33.clone()))); // Missing
+    assert!(retrieved_txs.contains(&Arc::new(tx34.clone())));
+
+    // Submit the missing original transactions
+    assert_eq!(
+        mempool.insert(Arc::new(tx02.clone())).unwrap(),
+        TxStorageResponse::UnconfirmedPool
+    );
+    // Re-submit failed zero-conf level 1 transactions
+    assert_eq!(
+        mempool.insert(Arc::new(tx12.clone())).unwrap(),
+        TxStorageResponse::UnconfirmedPool
+    );
+    // Re-submit failed zero-conf level 2 transactions
+    assert_eq!(
+        mempool.insert(Arc::new(tx22.clone())).unwrap(),
+        TxStorageResponse::UnconfirmedPool
+    );
+    assert_eq!(
+        mempool.insert(Arc::new(tx23.clone())).unwrap(),
+        TxStorageResponse::UnconfirmedPool
+    );
+    // Re-submit failed zero-conf level 3 transactions
+    assert_eq!(
+        mempool.insert(Arc::new(tx32.clone())).unwrap(),
+        TxStorageResponse::UnconfirmedPool
+    );
+    assert_eq!(
+        mempool.insert(Arc::new(tx33.clone())).unwrap(),
+        TxStorageResponse::UnconfirmedPool
+    );
+
+    // Try to retrieve all transactions in the mempool (all transactions should be retrieved)
+    let retrieved_txs = mempool.retrieve(mempool.stats().unwrap().total_weight).unwrap();
+    assert_eq!(retrieved_txs.len(), 16);
+    assert!(retrieved_txs.contains(&Arc::new(tx01.clone())));
+    assert!(retrieved_txs.contains(&Arc::new(tx02.clone())));
+    assert!(retrieved_txs.contains(&Arc::new(tx03.clone())));
+    assert!(retrieved_txs.contains(&Arc::new(tx04.clone())));
+    assert!(retrieved_txs.contains(&Arc::new(tx11.clone())));
+    assert!(retrieved_txs.contains(&Arc::new(tx12.clone())));
+    assert!(retrieved_txs.contains(&Arc::new(tx13.clone())));
+    assert!(retrieved_txs.contains(&Arc::new(tx14.clone())));
+    assert!(retrieved_txs.contains(&Arc::new(tx21.clone())));
+    assert!(retrieved_txs.contains(&Arc::new(tx22.clone())));
+    assert!(retrieved_txs.contains(&Arc::new(tx23.clone())));
+    assert!(retrieved_txs.contains(&Arc::new(tx24.clone())));
+    assert!(retrieved_txs.contains(&Arc::new(tx31.clone())));
+    assert!(retrieved_txs.contains(&Arc::new(tx32.clone())));
+    assert!(retrieved_txs.contains(&Arc::new(tx33.clone())));
+    assert!(retrieved_txs.contains(&Arc::new(tx34.clone())));
+
+    // Verify that a higher priority transaction is not retrieved due to its zero-conf dependency instead of the lowest
+    // priority transaction
+    let retrieved_txs = mempool.retrieve(mempool.stats().unwrap().total_weight - 1).unwrap();
+    assert_eq!(retrieved_txs.len(), 15);
+    assert!(retrieved_txs.contains(&Arc::new(tx01)));
+    assert!(retrieved_txs.contains(&Arc::new(tx02)));
+    assert!(retrieved_txs.contains(&Arc::new(tx03)));
+    assert!(retrieved_txs.contains(&Arc::new(tx04)));
+    assert!(retrieved_txs.contains(&Arc::new(tx11)));
+    assert!(retrieved_txs.contains(&Arc::new(tx12)));
+    assert!(retrieved_txs.contains(&Arc::new(tx13)));
+    assert!(retrieved_txs.contains(&Arc::new(tx14)));
+    assert!(retrieved_txs.contains(&Arc::new(tx21)));
+    assert!(retrieved_txs.contains(&Arc::new(tx22)));
+    assert!(retrieved_txs.contains(&Arc::new(tx23)));
+    assert!(retrieved_txs.contains(&Arc::new(tx24)));
+    assert!(!retrieved_txs.contains(&Arc::new(tx31))); // Missing
+    assert!(retrieved_txs.contains(&Arc::new(tx32)));
+    assert!(retrieved_txs.contains(&Arc::new(tx33)));
+    assert!(retrieved_txs.contains(&Arc::new(tx34)));
+}
+
+#[test]
+#[allow(clippy::identity_op)]
 fn test_reorg() {
     let network = Network::LocalNet;
     let (mut db, mut blocks, mut outputs, consensus_manager) = create_new_blockchain(network);

--- a/integration_tests/features/Mempool.feature
+++ b/integration_tests/features/Mempool.feature
@@ -136,3 +136,36 @@ Feature: Mempool
     Then all nodes are at height 10
     When I mine 6 blocks on NODE_C
     Then all nodes are at height 16
+
+  @critical
+  Scenario: Zero-conf transactions
+    Given I have 1 seed nodes
+    And I have a base node SENDER connected to all seed nodes
+    When I mine a block on SENDER with coinbase CB1
+    When I mine a block on SENDER with coinbase CB2
+    When I mine 4 blocks on SENDER
+    When I create a custom fee transaction TX01 spending CB1 to UTX01 with fee 100
+    When I create a custom fee transaction TX02 spending UTX01 to UTX02 with fee 100
+    When I create a custom fee transaction TX03 spending UTX02 to UTX03 with fee 100
+    When I create a custom fee transaction TX11 spending CB2 to UTX11 with fee 100
+    When I create a custom fee transaction TX12 spending UTX11 to UTX12 with fee 100
+    When I create a custom fee transaction TX13 spending UTX12 to UTX13 with fee 100
+    When I submit transaction TX01 to SENDER
+    When I submit transaction TX02 to SENDER
+    When I submit transaction TX03 to SENDER
+    When I submit transaction TX11 to SENDER
+    When I submit transaction TX12 to SENDER
+    When I submit transaction TX13 to SENDER
+    Then SENDER has TX01 in MEMPOOL state
+    Then SENDER has TX02 in MEMPOOL state
+    Then SENDER has TX03 in MEMPOOL state
+    Then SENDER has TX11 in MEMPOOL state
+    Then SENDER has TX12 in MEMPOOL state
+    Then SENDER has TX13 in MEMPOOL state
+    When I mine 1 blocks on SENDER
+    Then SENDER has TX01 in MINED state
+    Then SENDER has TX02 in MINED state
+    Then SENDER has TX03 in MINED state
+    Then SENDER has TX11 in MINED state
+    Then SENDER has TX12 in MINED state
+    Then SENDER has TX13 in MINED state

--- a/integration_tests/helpers/util.js
+++ b/integration_tests/helpers/util.js
@@ -89,6 +89,16 @@ function toLittleEndian(n, numBits) {
   return arr;
 }
 
+function littleEndianHexStringToBigEndianHexString(string) {
+  if (!string) return undefined;
+  var len = string.length;
+  var bigEndianHexString = "0x";
+  for (var i = 0; i < len / 2; i++) {
+    bigEndianHexString += string.substring(len - (i + 1) * 2, len - i * 2);
+  }
+  return bigEndianHexString;
+}
+
 function hexSwitchEndianness(val) {
   let res = "";
   for (let i = val.length - 2; i > 0; i -= 2) {
@@ -223,6 +233,7 @@ module.exports = {
   sleep,
   waitFor,
   toLittleEndian,
+  littleEndianHexStringToBigEndianHexString,
   // portInUse,
   getFreePort,
   getTransactionOutputHash,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

- Changed the mempool to search for "missing' inputs inside of itself to allow adding zero-confirmation transactions. 
- Changed the mempool selection to search the mempool for a chain of transactions when adding a zero-confirmation transaction that requires certain outputs to be mined.
- Added a utxo index to the mempool so that it known which transaction has which output.
- Changed the block validator to accept zero-confirmation transactions.
- Changed the MMR route calculation to search for inputs inside of it self as well as the database.
- Fixes cucumber transaction builder to use littleEndian as starting point for the math, and allowing wrap around.



## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This PR allows the mempool and base node to accept zero-confirmation transactions and process them. 
## How Has This Been Tested?
Created a unit tests testing zero-confirmation transactions and cucumber integration tests testing zero-confirmation tests
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [ ] I'm merging against the `development` branch.
* [x] I have squashed my commits into a single commit.
