### PR TITLE
[WIP] Update the Ubuntu archive build for distributions with GHA

### DIFF
--- a/.github/workflows/base_node_binaries.yml
+++ b/.github/workflows/base_node_binaries.yml
@@ -28,7 +28,7 @@ jobs:
 #        os: [windows-2016]
 #        os: [ubuntu-latest, macos-latest, windows-latest, self-hosted]
 #        os: [ubuntu-18.04, ubuntu-20.04, macos-10.15, macos-11.0, windows-2016, windows-2019]
-        os: [ubuntu-18.04, macos-10.15, self-hosted]
+        os: [ubuntu-18.04, macos-10.15, windows-2019, self-hosted]
         # https://gcc.gnu.org/onlinedocs/gcc/x86-Options.html
 #        features: ["safe", "avx2"]
 #        features: ["safe"]
@@ -46,7 +46,8 @@ jobs:
           - os: "windows-2019"
             target_cpu: "x86-64"
           - os: "self-hosted"
-            target_cpu: "x86-64"
+            target_cpu: "haswell"
+#            target_cpu: "x86-64"
 
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/base_node_binaries.yml
+++ b/.github/workflows/base_node_binaries.yml
@@ -4,10 +4,10 @@ on:
   push:
     tags:
       - "v[0-9]+.[0-9]+.[0-9]+"
-#    branches:
-#      - leet-*
+    branches:
+      - leet-*
   schedule:
-    - cron: '05 00 * * *'
+    - cron: '05 00 01 * *'
   workflow_dispatch:
     inputs:
       customTag:
@@ -24,11 +24,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-#        os: [ubuntu-18.04, ubuntu-20.04, macos-10.15, macos-11.0, windows-2019]
+#        # Broke build - cmake issue?
+#        os: [windows-2016]
 #        os: [ubuntu-latest, macos-latest, windows-latest, self-hosted]
 #        os: [ubuntu-18.04, ubuntu-20.04, macos-10.15, macos-11.0, windows-2016, windows-2019]
-        os: [ubuntu-18.04, macos-10.15, windows-2016, self-hosted]
-#        os: [ubuntu-20.04]
+        os: [ubuntu-18.04, self-hosted]
         # https://gcc.gnu.org/onlinedocs/gcc/x86-Options.html
 #        features: ["safe", "avx2"]
 #        features: ["safe"]
@@ -57,7 +57,7 @@ jobs:
         echo "S3DESTOVERRIDE=" >> $GITHUB_ENV
 
     - name: Scheduled Destination Folder Override
-      if: ${{ github.event_name == 'schedule' && github.event.schedule == '05 00 * * *' }}
+      if: ${{ github.event_name == 'schedule' && github.event.schedule == '05 00 01 * *' }}
       run: |
         echo "S3DESTOVERRIDE=daily/" >> $GITHUB_ENV
 
@@ -65,13 +65,14 @@ jobs:
       uses: actions-rs/toolchain@v1
       with:
 #        toolchain: stable
-        toolchain: nightly-2020-08-13
+        toolchain: nightly-2021-05-06
         components: rustfmt
 #        target: ${{ matrix.target }}
         override: true
 
-    - name: Install Ubuntu dependencies
-      if: startsWith(matrix.os,'ubuntu')
+    - name: Install Linux dependencies - Ubuntu
+#      if: startsWith(matrix.os,'ubuntu')
+      if: startsWith(runner.os,'Linux')
       run: |
         sudo apt-get update
         sudo apt-get -y install \
@@ -140,7 +141,7 @@ jobs:
           ~/.cargo/registry
           ~/.cargo/git
           target
-        key: ${{ runner.os }}-${{ matrix.target_cpu }}-${{ matrix.features }}-cargo-build-target-${{ hashFiles('**/Cargo.lock') }}
+        key: ${{ runner.os }}-${{ matrix.os }}-${{ matrix.target_cpu }}-${{ matrix.features }}-cargo-build-target-${{ hashFiles('**/Cargo.lock') }}
 # ToDo: Look at making caching less strict
 #        key: ${{ runner.os }}-cargo-build-target-${{ hashFiles('**/Cargo.lock') }}
 
@@ -150,9 +151,18 @@ jobs:
         ROARING_ARCH: '${{ matrix.target_cpu }}'
       shell: bash
       run: |
+        echo "Cache Key: ${{ runner.os }}-${{ matrix.os }}-${{ matrix.target_cpu }}-${{ matrix.features }}-cargo-build-target-${{ hashFiles('**/Cargo.lock') }}"
         #cd applications/tari_base_node
         #cargo build --release --bin tari_base_node --features ${{ matrix.features}}
         cargo build --release
+
+    - name: Prepare Archives
+      shell: bash
+      run: |
+        ls -la "$GITHUB_WORKSPACE"
+        mkdir -p "$GITHUB_WORKSPACE${TBN_DIST}/archives"
+        export distDir="$GITHUB_WORKSPACE${TBN_DIST}/archives"
+        "$GITHUB_WORKSPACE/scripts/build_dists_tarball.sh" noBuild
 
     - name: Prepare binaries
       shell: bash
@@ -200,6 +210,7 @@ jobs:
       shell: bash
       run: |
         echo "Starting upload ... ${{ env.SOURCE }}"
+        ls -al ${{ env.SOURCE }}
         aws s3 ${{ env.S3CMD }} --region ${{ secrets.AWS_REGION }} \
           "${{ env.SOURCE }}" \
           s3://${{ secrets.AWS_S3_BUCKET }}/${{ env.DEST_DIR }} \

--- a/.github/workflows/base_node_binaries.yml
+++ b/.github/workflows/base_node_binaries.yml
@@ -29,19 +29,14 @@ jobs:
 #        os: [ubuntu-latest, macos-latest, windows-latest, self-hosted]
 #        os: [ubuntu-18.04, ubuntu-20.04, macos-10.15, macos-11.0, windows-2016, windows-2019]
         os: [ubuntu-18.04, macos-10.15, windows-2019, self-hosted]
-#        os: [ubuntu-20.04]
         # https://gcc.gnu.org/onlinedocs/gcc/x86-Options.html
 #        features: ["safe", "avx2"]
-#        features: ["safe"]
 #        target_cpu: ["x86-64", "broadwell", "skylake"]
-        target_cpu: ["x86-64", "haswell"]
+        target_cpu: ["haswell"]
 #        target_release: ["release", "debug"]
 #        exclude:
 #          - target_cpu: "x86-64"
 #            features: "avx2"
-        exclude:
-          - os: "macos-10.15"
-            target_cpu: "haswell"
         include:
           - os: "macos-10.15"
             target_cpu: "x86-64"
@@ -214,7 +209,7 @@ jobs:
 
     - name: Sync dist to S3 - Bash
       continue-on-error: true  # Don't break if s3 upload fails
-      if: ${{ env.AWS_SECRET_ACCESS_KEY != '' }}
+      if: ${{ env.AWS_SECRET_ACCESS_KEY != '' && matrix.os != 'self-hosted' }}
       shell: bash
       run: |
         echo "Starting upload ... ${{ env.SOURCE }}"

--- a/.github/workflows/base_node_binaries.yml
+++ b/.github/workflows/base_node_binaries.yml
@@ -28,16 +28,25 @@ jobs:
 #        os: [windows-2016]
 #        os: [ubuntu-latest, macos-latest, windows-latest, self-hosted]
 #        os: [ubuntu-18.04, ubuntu-20.04, macos-10.15, macos-11.0, windows-2016, windows-2019]
-        os: [ubuntu-18.04, self-hosted]
+        os: [ubuntu-18.04, macos-10.15, self-hosted]
         # https://gcc.gnu.org/onlinedocs/gcc/x86-Options.html
 #        features: ["safe", "avx2"]
 #        features: ["safe"]
 #        target_cpu: ["x86-64", "broadwell", "skylake"]
-        target_cpu: ["haswell"]
+        target_cpu: ["x86-64", "haswell"]
 #        target_release: ["release", "debug"]
 #        exclude:
 #          - target_cpu: "x86-64"
 #            features: "avx2"
+        exclude:
+          - os: "macos-10.15"
+            target_cpu: "haswell"
+          - os: "ubuntu-18.04"
+            target_cpu: "x86-64"
+          - os: "windows-2019"
+            target_cpu: "x86-64"
+          - os: "self-hosted"
+            target_cpu: "x86-64"
 
     runs-on: ${{ matrix.os }}
 
@@ -90,17 +99,19 @@ jobs:
 #        sudo apt-get -y upgrade
 
     - name: Install macOS dependencies
-      if: startsWith(matrix.os,'macos')
+#      if: startsWith(matrix.os,'macos')
+      if: startsWith(runner.os,'macOS')
       run: brew install cmake zip
 
     - name: Install Windows dependencies
-      if: startsWith(matrix.os,'windows')
+#      if: startsWith(matrix.os,'windows')
+      if: startsWith(runner.os,'Windows')
       run: |
         vcpkg.exe install sqlite3:x64-windows zlib:x64-windows
-        choco upgrade llvm zip psutils openssl -y
+        choco upgrade llvm zip psutils openssl strawberryperl -y
 
     - name: Set environment variables - Nix
-      if: "!startsWith(matrix.os,'Windows')"
+      if: "!startsWith(runner.os,'Windows')"
       run: |
         echo "SHARUN=shasum --algorithm 256" >> $GITHUB_ENV
         echo "CC=gcc" >> $GITHUB_ENV
@@ -109,12 +120,12 @@ jobs:
         echo "TBN_DIST=/dist" >> $GITHUB_ENV
 
     - name: Set environment variables - macOS
-      if: startsWith(matrix.os,'macos')
+      if: startsWith(runner.os,'macOS')
       run: |
         echo "S3DESTDIR=osx" >> $GITHUB_ENV
 
     - name: Set environment variables - Windows
-      if: startsWith(matrix.os,'Windows')
+      if: startsWith(runner.os,'Windows')
       shell: bash
       run: |
         echo "SHARUN=pwsh C:\ProgramData\chocolatey\lib\psutils\tools\psutils-master\shasum.ps1 --algorithm 256" >> $GITHUB_ENV
@@ -130,7 +141,7 @@ jobs:
     # issue https://github.com/microsoft/STL/issues/1300
     # temp fix https://github.com/mono/CppSharp/pull/1514/files
     - name: fix intrin.h file - Windows
-      if: startsWith(matrix.os,'Windows')
+      if: startsWith(runner.os,'Windows')
       shell: powershell
       run: .github/hacks/intrin.ps1
 

--- a/.github/workflows/base_node_binaries.yml
+++ b/.github/workflows/base_node_binaries.yml
@@ -65,7 +65,7 @@ jobs:
       uses: actions-rs/toolchain@v1
       with:
 #        toolchain: stable
-        toolchain: nightly-2021-05-06
+        toolchain: nightly-2021-05-09
         components: rustfmt
 #        target: ${{ matrix.target }}
         override: true


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Have an process on Tag release that is automated that will build and upload to S3 as an archive that is used by Ubuntu users.

## Description
Add noBuild option for ```build_dists_tarball.sh``` to be used by GHA for build an Ubuntu archive distribution. Also fix the GHA caching resource for reduced build time by adding a key on OS for builds. 

## Motivation and Context
Trying to use the code base inside the GHA build process, so that builds on GH and any other service will be the same as a local build without the need for more tools.

## How Has This Been Tested?
Built with GHA for Ubuntu, OSX and Windows, but with caveats:
 - OSX does not build in GHA due to issue with typenum v1.12.0
 - Windows 2016 has a cmake build issue (might not be worth fixing)
 - We can't have sub-folders for checksums - runtime folder usage is broken
 - Can't use scripts in their current state
 - Documentation needs updating to reflect changes

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch.
* [x] I have squashed my commits into a single commit.
