### PR TITLE
Stable rust: Remove unstable impl trait from Tari comms

### DIFF
--- a/comms/src/connection_manager/dialer.rs
+++ b/comms/src/connection_manager/dialer.rs
@@ -496,7 +496,6 @@ where
                     let dial_fut = async move {
                         let mut socket = transport
                             .dial(address.clone())
-                            .map_err(|err| ConnectionManagerError::TransportError(err.to_string()))?
                             .await
                             .map_err(|err| ConnectionManagerError::TransportError(err.to_string()))?;
                         debug!(

--- a/comms/src/connection_manager/listener.rs
+++ b/comms/src/connection_manager/listener.rs
@@ -120,10 +120,8 @@ where
                 loop {
                     futures::select! {
                         inbound_result = inbound.select_next_some() => {
-                            if let Some((inbound_future, peer_addr)) = log_if_error!(target: LOG_TARGET, inbound_result, "Inbound connection failed because '{error}'",) {
-                                if let Some(socket) = log_if_error!(target: LOG_TARGET, inbound_future.await,  "Inbound connection failed because '{error}'",) {
-                                    self.spawn_listen_task(socket, peer_addr).await;
-                                }
+                            if let Some((socket, peer_addr)) = log_if_error!(target: LOG_TARGET, inbound_result, "Inbound connection failed because '{error}'",) {
+                                self.spawn_listen_task(socket, peer_addr).await;
                             }
                         },
                         _ = shutdown_signal => {
@@ -382,7 +380,6 @@ where
         debug!(target: LOG_TARGET, "Attempting to listen on {}", listener_address);
         self.transport
             .listen(listener_address)
-            .map_err(|err| ConnectionManagerError::TransportError(err.to_string()))?
             .await
             .map_err(|err| ConnectionManagerError::TransportError(err.to_string()))
     }

--- a/comms/src/lib.rs
+++ b/comms/src/lib.rs
@@ -13,12 +13,6 @@
 //! See [CommsBuilder] for more information on using this library.
 //!
 //! [CommsBuilder]: ./builder/index.html
-// Recursion limit for futures::select!
-#![recursion_limit = "512"]
-#![feature(min_type_alias_impl_trait)]
-// Required to use `Ip4Addr::is_global`. Stabilisation imminent https://github.com/rust-lang/rust/issues/27709
-#![feature(ip)]
-
 #[macro_use]
 extern crate lazy_static;
 
@@ -76,9 +70,7 @@ pub mod multiaddr {
     pub use ::multiaddr::{Error, Multiaddr, Protocol};
 }
 
-pub use bytes::{Bytes, BytesMut};
-
-#[cfg(feature = "rpc")]
 pub use async_trait::async_trait;
+pub use bytes::{Bytes, BytesMut};
 #[cfg(feature = "rpc")]
 pub use tower_make::MakeService;

--- a/comms/src/protocol/identity.rs
+++ b/comms/src/protocol/identity.rs
@@ -174,12 +174,12 @@ mod test {
     async fn identity_exchange() {
         let transport = MemoryTransport;
         let addr = "/memory/0".parse().unwrap();
-        let (mut listener, addr) = transport.listen(addr).unwrap().await.unwrap();
+        let (mut listener, addr) = transport.listen(addr).await.unwrap();
 
-        let (out_sock, in_sock) = future::join(transport.dial(addr).unwrap(), listener.next()).await;
+        let (out_sock, in_sock) = future::join(transport.dial(addr), listener.next()).await;
 
         let out_sock = out_sock.unwrap();
-        let in_sock = in_sock.unwrap().map(|(f, _)| f).unwrap().await.unwrap();
+        let (in_sock, _) = in_sock.unwrap().unwrap();
 
         let node_identity1 = build_node_identity(PeerFeatures::COMMUNICATION_NODE);
         let node_identity2 = build_node_identity(PeerFeatures::COMMUNICATION_CLIENT);
@@ -223,12 +223,12 @@ mod test {
     async fn fail_cases() {
         let transport = MemoryTransport;
         let addr = "/memory/0".parse().unwrap();
-        let (mut listener, addr) = transport.listen(addr).unwrap().await.unwrap();
+        let (mut listener, addr) = transport.listen(addr).await.unwrap();
 
-        let (out_sock, in_sock) = future::join(transport.dial(addr).unwrap(), listener.next()).await;
+        let (out_sock, in_sock) = future::join(transport.dial(addr), listener.next()).await;
 
         let out_sock = out_sock.unwrap();
-        let in_sock = in_sock.unwrap().map(|(f, _)| f).unwrap().await.unwrap();
+        let (in_sock, _) = in_sock.unwrap().unwrap();
 
         let node_identity1 = build_node_identity(PeerFeatures::COMMUNICATION_NODE);
         let node_identity2 = build_node_identity(PeerFeatures::COMMUNICATION_CLIENT);

--- a/comms/src/test_utils/transport.rs
+++ b/comms/src/test_utils/transport.rs
@@ -30,13 +30,10 @@ use crate::{
 use futures::{future, StreamExt};
 
 pub async fn build_connected_sockets() -> (Multiaddr, MemorySocket, MemorySocket) {
-    let (mut listener, addr) = MemoryTransport
-        .listen("/memory/0".parse().unwrap())
-        .unwrap()
-        .await
-        .unwrap();
-    let (dial_sock, listen_sock) = future::join(MemoryTransport.dial(addr.clone()).unwrap(), listener.next()).await;
-    (addr, dial_sock.unwrap(), listen_sock.unwrap().unwrap().0.await.unwrap())
+    let (mut listener, addr) = MemoryTransport.listen("/memory/0".parse().unwrap()).await.unwrap();
+    let (dial_sock, listen_sock) = future::join(MemoryTransport.dial(addr.clone()), listener.next()).await;
+    let (listen_sock, _) = listen_sock.unwrap().unwrap();
+    (addr, dial_sock.unwrap(), listen_sock)
 }
 
 pub async fn build_multiplexed_connections() -> (Multiaddr, Yamux, Yamux) {

--- a/comms/src/transports/dns/tor.rs
+++ b/comms/src/transports/dns/tor.rs
@@ -55,7 +55,7 @@ impl TorDnsResolver {
 }
 
 async fn connect_inner(addr: Multiaddr) -> io::Result<TcpSocks5Client> {
-    let socket = SocksTransport::get_tcp_transport().dial(addr)?.await?;
+    let socket = SocksTransport::get_tcp_transport().dial(addr).await?;
     Ok(Socks5Client::new(socket))
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
- Uses `async_trait` for the comms `Transport` trait
- Transport trait results/futures are flattened/simplified
- Replace impl Trait usage in RPC services to use boxed alternatives
- Replace impl Trait usage in Tor control port module
- Include the single remaining still unstable `is_unicast_link_local`
  function as copied code and remove `ip` feature.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Move towards stable rust
Related to #3034
Ref #3037 #3035

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Existing tests updated and pass

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [ ] I'm merging against the `development` branch.
* [x] I have squashed my commits into a single commit.
