### PR TITLE
Implement metadata ComSig for transaction output

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4631,8 +4631,8 @@ dependencies = [
 
 [[package]]
 name = "tari_crypto"
-version = "0.9.0"
-source = "git+ssh://git@github.com/tari-project/tari-crypto.git?branch=main#45fba2160694ac19f51d6233fd5465da8a1614ee"
+version = "0.9.1"
+source = "git+https://github.com/tari-project/tari-crypto.git?rev=ecd77ec2b#ecd77ec2b8484d3e146257654dba28f854ca4410"
 dependencies = [
  "base64 0.10.1",
  "blake2 0.8.1",

--- a/applications/tari_app_grpc/Cargo.toml
+++ b/applications/tari_app_grpc/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2018"
 tari_common_types = { version = "^0.8", path = "../../base_layer/common_types"}
 tari_core = {  path = "../../base_layer/core"}
 tari_wallet = {  path = "../../base_layer/wallet"}
-tari_crypto = { git = "ssh://git@github.com/tari-project/tari-crypto.git", branch = "main" } #switch back to official after merge
+tari_crypto = { git = "https://github.com/tari-project/tari-crypto.git", rev = "ecd77ec2b" } #switch back to official after merge
 tari_comms = { path = "../../comms"}
 
 chrono = "0.4.6"

--- a/applications/tari_app_grpc/proto/types.proto
+++ b/applications/tari_app_grpc/proto/types.proto
@@ -168,7 +168,7 @@ message TransactionInput {
     // A signature with k_s, signing the script, input data, and mined height
     ComSignature script_signature = 7;
     // The offset public key, K_O
-    bytes script_offset_public_key = 8;
+    bytes sender_offset_public_key = 8;
 }
 
 // Output for a transaction, defining the new ownership of coins that are being transferred. The commitment is a
@@ -186,9 +186,10 @@ message TransactionOutput {
     // Tari script serialised script
     bytes script = 5;
     // Tari script offset public key, K_O
-    bytes script_offset_public_key = 6;
-    // UTXO signature with the script offset private key, k_O
-    Signature sender_metadata_signature = 7;
+    bytes sender_offset_public_key = 6;
+    // Metadata signature with the homomorphic commitment private values (amount and blinding factor) and the sender
+    // offset private key
+    ComSignature metadata_signature = 7;
 }
 
 // Options for UTXO's
@@ -318,7 +319,7 @@ message UnblindedOutput {
     // Tari script private key
     bytes script_private_key = 7;
     // Tari script offset pubkey, K_O
-    bytes script_offset_public_key = 8;
+    bytes sender_offset_public_key = 8;
     // UTXO signature with the script offset private key, k_O
-    Signature sender_metadata_signature = 9;
+    ComSignature metadata_signature = 9;
 }

--- a/applications/tari_app_grpc/src/conversions/transaction_input.rs
+++ b/applications/tari_app_grpc/src/conversions/transaction_input.rs
@@ -49,8 +49,8 @@ impl TryFrom<grpc::TransactionInput> for TransactionInput {
             .try_into()
             .map_err(|_| "script_signature could not be converted".to_string())?;
 
-        let script_offset_public_key =
-            PublicKey::from_bytes(input.script_offset_public_key.as_bytes()).map_err(|err| format!("{:?}", err))?;
+        let sender_offset_public_key =
+            PublicKey::from_bytes(input.sender_offset_public_key.as_bytes()).map_err(|err| format!("{:?}", err))?;
         let script = TariScript::from_bytes(input.script.as_slice()).map_err(|err| format!("{:?}", err))?;
         let input_data = ExecutionStack::from_bytes(input.input_data.as_slice()).map_err(|err| format!("{:?}", err))?;
 
@@ -60,7 +60,7 @@ impl TryFrom<grpc::TransactionInput> for TransactionInput {
             script,
             input_data,
             script_signature,
-            script_offset_public_key,
+            sender_offset_public_key,
         })
     }
 }
@@ -82,7 +82,7 @@ impl From<TransactionInput> for grpc::TransactionInput {
                 signature_u: Vec::from(input.script_signature.u().as_bytes()),
                 signature_v: Vec::from(input.script_signature.v().as_bytes()),
             }),
-            script_offset_public_key: input.script_offset_public_key.as_bytes().to_vec(),
+            sender_offset_public_key: input.sender_offset_public_key.as_bytes().to_vec(),
         }
     }
 }

--- a/applications/tari_app_utilities/Cargo.toml
+++ b/applications/tari_app_utilities/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 
 [dependencies]
 tari_comms = { path = "../../comms"}
-tari_crypto = { git = "ssh://git@github.com/tari-project/tari-crypto.git", branch = "main" }
+tari_crypto = { git = "https://github.com/tari-project/tari-crypto.git", rev = "ecd77ec2b" }
 tari_common = { path = "../../common" }
 tari_p2p = { path = "../../base_layer/p2p", features = ["auto-update"] }
 tari_wallet = { path = "../../base_layer/wallet" }

--- a/applications/tari_base_node/Cargo.toml
+++ b/applications/tari_base_node/Cargo.toml
@@ -14,7 +14,7 @@ tari_common = { path = "../../common" }
 tari_comms = { path = "../../comms", features = ["rpc"]}
 tari_comms_dht = { path = "../../comms/dht"}
 tari_core = { path = "../../base_layer/core", default-features = false, features = ["transactions"]}
-tari_crypto = { git = "ssh://git@github.com/tari-project/tari-crypto.git", branch = "main" }
+tari_crypto = { git = "https://github.com/tari-project/tari-crypto.git", rev = "ecd77ec2b" }
 tari_mmr = { path = "../../base_layer/mmr" }
 tari_p2p = { path = "../../base_layer/p2p", features = ["auto-update"] }
 tari_service_framework = {  path = "../../base_layer/service_framework"}

--- a/applications/tari_console_wallet/Cargo.toml
+++ b/applications/tari_console_wallet/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 
 [dependencies]
 tari_wallet = {  path = "../../base_layer/wallet" }
-tari_crypto = { git = "ssh://git@github.com/tari-project/tari-crypto.git", branch = "main" }
+tari_crypto = { git = "https://github.com/tari-project/tari-crypto.git", rev = "ecd77ec2b" }
 tari_common = {  path = "../../common" }
 tari_app_utilities = { path = "../tari_app_utilities"}
 tari_comms = {  path = "../../comms"}

--- a/applications/tari_console_wallet/src/automation/commands.rs
+++ b/applications/tari_console_wallet/src/automation/commands.rs
@@ -645,13 +645,13 @@ fn write_utxos_to_csv_file(utxos: Vec<UnblindedOutput>, file_path: String) -> Re
     let mut csv_file = LineWriter::new(file);
     writeln!(
         csv_file,
-        r##""index","value","spending_key","commitment","flags","maturity","script","input_data","script_private_key","script_offset_public_key","signature","public_nonce""##
+        r##""index","value","spending_key","commitment","flags","maturity","script","input_data","script_private_key","sender_offset_public_key","public_nonce","signature_u","signature_v""##
     )
     .map_err(|e| CommandError::CSVFile(e.to_string()))?;
     for (i, utxo) in utxos.iter().enumerate() {
         writeln!(
             csv_file,
-            r##""{}","{}","{}","{}","{:?}","{}","{}","{}","{}","{}","{}","{}""##,
+            r##""{}","{}","{}","{}","{:?}","{}","{}","{}","{}","{}","{}","{}","{}""##,
             i + 1,
             utxo.value.0,
             utxo.spending_key.to_hex(),
@@ -661,9 +661,10 @@ fn write_utxos_to_csv_file(utxos: Vec<UnblindedOutput>, file_path: String) -> Re
             utxo.script.to_hex(),
             utxo.input_data.to_hex(),
             utxo.script_private_key.to_hex(),
-            utxo.script_offset_public_key.to_hex(),
-            utxo.sender_metadata_signature.get_signature().to_hex(),
-            utxo.sender_metadata_signature.get_public_nonce().to_hex(),
+            utxo.sender_offset_public_key.to_hex(),
+            utxo.metadata_signature.public_nonce().to_hex(),
+            utxo.metadata_signature.u().to_hex(),
+            utxo.metadata_signature.v().to_hex(),
         )
         .map_err(|e| CommandError::CSVFile(e.to_string()))?;
     }

--- a/applications/tari_merge_mining_proxy/Cargo.toml
+++ b/applications/tari_merge_mining_proxy/Cargo.toml
@@ -16,7 +16,7 @@ tari_app_grpc = { path = "../tari_app_grpc" }
 tari_common = {  path = "../../common" }
 tari_core = {  path = "../../base_layer/core", default-features = false, features = ["transactions"]}
 tari_app_utilities = {  path = "../tari_app_utilities"}
-tari_crypto = { git = "ssh://git@github.com/tari-project/tari-crypto.git", branch = "main" }
+tari_crypto = { git = "https://github.com/tari-project/tari-crypto.git", rev = "ecd77ec2b" }
 tari_utilities = "^0.3"
 
 anyhow = "1.0.40"

--- a/applications/tari_mining_node/Cargo.toml
+++ b/applications/tari_mining_node/Cargo.toml
@@ -27,6 +27,6 @@ thiserror = "1.0"
 
 
 [dev-dependencies]
-tari_crypto = { git = "ssh://git@github.com/tari-project/tari-crypto.git", branch = "main" }
+tari_crypto = { git = "https://github.com/tari-project/tari-crypto.git", rev = "ecd77ec2b" }
 prost-types = "0.6.1"
 chrono = "0.4"

--- a/applications/test_faucet/Cargo.toml
+++ b/applications/test_faucet/Cargo.toml
@@ -11,7 +11,7 @@ tari_utilities = "^0.3"
 serde = { version = "1.0.97", features = ["derive"] }
 serde_json = "1.0"
 rand = "0.7.2"
-tari_crypto = { git = "ssh://git@github.com/tari-project/tari-crypto.git", branch = "main" }
+tari_crypto = { git = "https://github.com/tari-project/tari-crypto.git", rev = "ecd77ec2b" }
 
 [dependencies.tari_core]
 version = "^0.8"

--- a/base_layer/common_types/Cargo.toml
+++ b/base_layer/common_types/Cargo.toml
@@ -9,6 +9,6 @@ edition = "2018"
 [dependencies]
 futures = {version = "^0.3.1", features = ["async-await"] }
 rand = "0.7.2"
-tari_crypto = { git = "ssh://git@github.com/tari-project/tari-crypto.git", branch = "main" }
+tari_crypto = { git = "https://github.com/tari-project/tari-crypto.git", rev = "ecd77ec2b" }
 serde = { version = "1.0.106", features = ["derive"] }
 tokio = { version="^0.2", features = ["blocking", "time", "sync"] }

--- a/base_layer/core/Cargo.toml
+++ b/base_layer/core/Cargo.toml
@@ -23,7 +23,7 @@ tari_common_types = { version = "^0.8", path = "../../base_layer/common_types"}
 tari_comms = { version = "^0.8", path = "../../comms"}
 tari_comms_dht = { version = "^0.8", path = "../../comms/dht"}
 tari_comms_rpc_macros = { version = "^0.8", path = "../../comms/rpc_macros"}
-tari_crypto = { git = "ssh://git@github.com/tari-project/tari-crypto.git", branch = "main" }
+tari_crypto = { git = "https://github.com/tari-project/tari-crypto.git", rev = "ecd77ec2b" }
 tari_mmr = { version = "^0.8", path = "../../base_layer/mmr", optional = true }
 tari_p2p = { version = "^0.8", path = "../../base_layer/p2p" }
 tari_service_framework = { version = "^0.8", path = "../service_framework"}

--- a/base_layer/core/src/blocks/genesis_block.rs
+++ b/base_layer/core/src/blocks/genesis_block.rs
@@ -145,9 +145,9 @@ pub fn get_stibbons_genesis_block_raw() -> Block {
             // For genesis block: A default script can never be spent, intentionally
             script: TariScript::default(),
             // Script offset never checked for coinbase, thus can use default
-            script_offset_public_key: Default::default(),
-            // For genesis block: Sender signature will never be checked
-            sender_metadata_signature: Default::default(),
+            sender_offset_public_key: Default::default(),
+            // For genesis block: Metadata signature will never be checked
+            metadata_signature: Default::default(),
         }],
         vec![TransactionKernel {
             features: KernelFeatures::COINBASE_KERNEL,
@@ -212,9 +212,9 @@ pub fn get_weatherwax_genesis_block_raw() -> Block {
             // For genesis block: A default script can never be spent, intentionally
             script: TariScript::default(),
             // Script offset never checked for coinbase, thus can use default
-            script_offset_public_key: Default::default(),
-            // For genesis block: Sender signature will never be checked
-            sender_metadata_signature: Default::default(),
+            sender_offset_public_key: Default::default(),
+            // For genesis block: Metadata signature will never be checked
+            metadata_signature: Default::default(),
         }],
         vec![TransactionKernel {
             features: KernelFeatures::COINBASE_KERNEL,
@@ -233,7 +233,7 @@ pub fn get_weatherwax_genesis_block_raw() -> Block {
             version: 0,
             height: 0,
             prev_hash: vec![0; BLOCK_HASH_LENGTH],
-            timestamp: 1_624_957_036.into(), // Tue Jun 29 2021 08:57:16 GMT+0000
+            timestamp: 1_625_125_650.into(), // Thu, 01 Jul 2021 07:47:30 GMT
             output_mr: from_hex("dcc44f39b65e5e1e526887e7d56f7b85e2ea44bd29bc5bc195e6e015d19e1c06").unwrap(),
             witness_mr: from_hex("e4d7dab49a66358379a901b9a36c10f070aa9d7bdc8ae752947b6fc4e55d255f").unwrap(),
             output_mmr_size: 1,
@@ -319,9 +319,9 @@ pub fn get_ridcully_genesis_block_raw() -> Block {
             // For genesis block: A default script can never be spent, intentionally
             script: TariScript::default(),
             // Script offset never checked for coinbase, thus can use default
-            script_offset_public_key: Default::default(),
-            // For genesis block: Sender signature will never be checked
-            sender_metadata_signature: Default::default()
+            sender_offset_public_key: Default::default(),
+            // For genesis block: Metadata signature will never be checked
+            metadata_signature: Default::default()
         }],
         vec![TransactionKernel {
             features: KernelFeatures::COINBASE_KERNEL,

--- a/base_layer/core/src/mempool/unconfirmed_pool/unconfirmed_pool.rs
+++ b/base_layer/core/src/mempool/unconfirmed_pool/unconfirmed_pool.rs
@@ -580,7 +580,8 @@ mod test {
         );
         stx_builder
             .with_input(double_spend_utxo, double_spend_input)
-            .with_output(utxo, test_params.script_offset_pvt_key);
+            .with_output(utxo, test_params.sender_offset_private_key)
+            .unwrap();
 
         let factories = CryptoFactories::default();
         let mut stx_protocol = stx_builder.build::<HashDigest>(&factories).unwrap();

--- a/base_layer/core/src/proto/transaction.proto
+++ b/base_layer/core/src/proto/transaction.proto
@@ -41,7 +41,7 @@ message TransactionInput {
     // A signature with k_s, signing the script, input data, and mined height
     ComSignature script_signature = 6;
     // The offset pubkey, K_O
-    bytes script_offset_public_key = 7;
+    bytes sender_offset_public_key = 7;
 }
 
 // Output for a transaction, defining the new ownership of coins that are being transferred. The commitment is a
@@ -57,9 +57,9 @@ message TransactionOutput {
     // Tari script serialised script
     bytes script = 4;
     // Tari script offset pubkey, K_O
-    bytes script_offset_public_key = 5;
+    bytes sender_offset_public_key = 5;
     // UTXO signature with the script offset private key, k_O
-    Signature sender_metadata_signature = 6;
+    ComSignature metadata_signature = 6;
 }
 
 // Options for UTXO's

--- a/base_layer/core/src/proto/transaction.rs
+++ b/base_layer/core/src/proto/transaction.rs
@@ -113,8 +113,8 @@ impl TryFrom<proto::types::TransactionInput> for TransactionInput {
             .try_into()
             .map_err(|err: ByteArrayError| err.to_string())?;
 
-        let script_offset_public_key =
-            PublicKey::from_bytes(input.script_offset_public_key.as_bytes()).map_err(|err| format!("{:?}", err))?;
+        let sender_offset_public_key =
+            PublicKey::from_bytes(input.sender_offset_public_key.as_bytes()).map_err(|err| format!("{:?}", err))?;
 
         Ok(Self {
             features,
@@ -122,7 +122,7 @@ impl TryFrom<proto::types::TransactionInput> for TransactionInput {
             script: TariScript::from_bytes(input.script.as_slice()).map_err(|err| format!("{:?}", err))?,
             input_data: ExecutionStack::from_bytes(input.input_data.as_slice()).map_err(|err| format!("{:?}", err))?,
             script_signature,
-            script_offset_public_key,
+            sender_offset_public_key,
         })
     }
 }
@@ -135,7 +135,7 @@ impl From<TransactionInput> for proto::types::TransactionInput {
             script: input.script.as_bytes(),
             input_data: input.input_data.as_bytes(),
             script_signature: Some(input.script_signature.into()),
-            script_offset_public_key: input.script_offset_public_key.as_bytes().to_vec(),
+            sender_offset_public_key: input.sender_offset_public_key.as_bytes().to_vec(),
         }
     }
 }
@@ -157,24 +157,24 @@ impl TryFrom<proto::types::TransactionOutput> for TransactionOutput {
             .ok_or_else(|| "Transaction output commitment not provided".to_string())?
             .map_err(|err| err.to_string())?;
 
-        let script_offset_public_key =
-            PublicKey::from_bytes(output.script_offset_public_key.as_bytes()).map_err(|err| format!("{:?}", err))?;
+        let sender_offset_public_key =
+            PublicKey::from_bytes(output.sender_offset_public_key.as_bytes()).map_err(|err| format!("{:?}", err))?;
 
         let script = TariScript::from_bytes(&output.script.to_vec()).map_err(|err| err.to_string())?;
 
-        let sender_metadata_signature = output
-            .sender_metadata_signature
-            .ok_or_else(|| "Sender signature not provided".to_string())?
+        let metadata_signature = output
+            .metadata_signature
+            .ok_or_else(|| "Metadata signature not provided".to_string())?
             .try_into()
-            .map_err(|_| "Sender signature could not be converted".to_string())?;
+            .map_err(|_| "Metadata signature could not be converted".to_string())?;
 
         Ok(Self {
             features,
             commitment,
             proof: BulletRangeProof(output.range_proof),
             script,
-            script_offset_public_key,
-            sender_metadata_signature,
+            sender_offset_public_key,
+            metadata_signature,
         })
     }
 }
@@ -186,8 +186,8 @@ impl From<TransactionOutput> for proto::types::TransactionOutput {
             commitment: Some(output.commitment.into()),
             range_proof: output.proof.to_vec(),
             script: output.script.as_bytes(),
-            script_offset_public_key: output.script_offset_public_key.as_bytes().to_vec(),
-            sender_metadata_signature: Some(output.sender_metadata_signature.into()),
+            sender_offset_public_key: output.sender_offset_public_key.as_bytes().to_vec(),
+            metadata_signature: Some(output.metadata_signature.into()),
         }
     }
 }

--- a/base_layer/core/src/transactions/aggregated_body.rs
+++ b/base_layer/core/src/transactions/aggregated_body.rs
@@ -317,7 +317,7 @@ impl AggregateBody {
         self.validate_kernel_sum(total_offset, &factories.commitment)?;
 
         self.validate_range_proofs(&factories.range_proof)?;
-        self.validate_sender_signatures()?;
+        self.verify_metadata_signatures()?;
         self.validate_script_offset(script_offset_g, &factories.commitment)
     }
 
@@ -395,7 +395,7 @@ impl AggregateBody {
         for output in &self.outputs {
             // We should not count the coinbase tx here
             if !output.is_coinbase() {
-                output_keys = output_keys + output.script_offset_public_key.clone();
+                output_keys = output_keys + output.sender_offset_public_key.clone();
             }
         }
         let lhs = input_keys - output_keys;
@@ -417,10 +417,10 @@ impl AggregateBody {
         Ok(())
     }
 
-    fn validate_sender_signatures(&self) -> Result<(), TransactionError> {
+    fn verify_metadata_signatures(&self) -> Result<(), TransactionError> {
         trace!(target: LOG_TARGET, "Checking sender signatures");
         for o in &self.outputs {
-            o.verify_sender_signature()?;
+            o.verify_metadata_signature()?;
         }
         Ok(())
     }

--- a/base_layer/core/src/transactions/transaction_protocol/proto/transaction_sender.proto
+++ b/base_layer/core/src/transactions/transaction_protocol/proto/transaction_sender.proto
@@ -22,9 +22,9 @@ message SingleRoundSenderData {
     // Tari script serialised script
     bytes script = 7;
     // Tari script offset pubkey, K_O
-    bytes script_offset_public_key = 8;
-    // UTXO signature with the script offset private key, k_O
-    tari.types.Signature sender_metadata_signature = 9;
+    bytes sender_offset_public_key = 8;
+    // The sender's portion of the public commitment nonce
+    bytes public_commitment_nonce = 9;
     // Output features
     tari.types.OutputFeatures features = 10;
 }

--- a/base_layer/core/src/transactions/transaction_protocol/proto/transaction_sender.rs
+++ b/base_layer/core/src/transactions/transaction_protocol/proto/transaction_sender.rs
@@ -92,18 +92,15 @@ impl TryFrom<proto::SingleRoundSenderData> for SingleRoundSenderData {
     fn try_from(data: proto::SingleRoundSenderData) -> Result<Self, Self::Error> {
         let public_excess = PublicKey::from_bytes(&data.public_excess).map_err(|err| err.to_string())?;
         let public_nonce = PublicKey::from_bytes(&data.public_nonce).map_err(|err| err.to_string())?;
-        let script_offset_public_key =
-            PublicKey::from_bytes(&data.script_offset_public_key).map_err(|err| err.to_string())?;
+        let sender_offset_public_key =
+            PublicKey::from_bytes(&data.sender_offset_public_key).map_err(|err| err.to_string())?;
         let metadata = data
             .metadata
             .map(Into::into)
             .ok_or_else(|| "Transaction metadata not provided".to_string())?;
         let message = data.message;
-        let sender_metadata_signature = data
-            .sender_metadata_signature
-            .map(TryInto::try_into)
-            .ok_or_else(|| "Sender metadata signature not provided".to_string())?
-            .map_err(|err| format!("{}", err))?;
+        let public_commitment_nonce =
+            PublicKey::from_bytes(&data.public_commitment_nonce).map_err(|err| err.to_string())?;
         let features = data
             .features
             .map(TryInto::try_into)
@@ -118,8 +115,8 @@ impl TryFrom<proto::SingleRoundSenderData> for SingleRoundSenderData {
             message,
             features,
             script: TariScript::from_bytes(&data.script).map_err(|err| err.to_string())?,
-            script_offset_public_key,
-            sender_metadata_signature,
+            sender_offset_public_key,
+            public_commitment_nonce,
         })
     }
 }
@@ -137,8 +134,8 @@ impl From<SingleRoundSenderData> for proto::SingleRoundSenderData {
             message: sender_data.message,
             features: Some(sender_data.features.into()),
             script: sender_data.script.as_bytes(),
-            script_offset_public_key: sender_data.script_offset_public_key.to_vec(),
-            sender_metadata_signature: Some(sender_data.sender_metadata_signature.into()),
+            sender_offset_public_key: sender_data.sender_offset_public_key.to_vec(),
+            public_commitment_nonce: sender_data.public_commitment_nonce.to_vec(),
         }
     }
 }

--- a/base_layer/core/src/transactions/transaction_protocol/recipient.rs
+++ b/base_layer/core/src/transactions/transaction_protocol/recipient.rs
@@ -207,7 +207,7 @@ mod test {
         transactions::{
             helpers::TestParams,
             tari_amount::*,
-            transaction::{OutputFeatures, TransactionOutput},
+            transaction::OutputFeatures,
             transaction_protocol::{
                 build_challenge,
                 sender::{SingleRoundSenderData, TransactionSenderMessage},
@@ -232,25 +232,20 @@ mod test {
             fee: MicroTari(125),
             lock_height: 0,
         };
-        let script_offset_secret_key = PrivateKey::random(&mut OsRng);
-        let script_offset_public_key = PublicKey::from_secret_key(&script_offset_secret_key);
         let script = TariScript::default();
         let features = OutputFeatures::default();
+        let amount = MicroTari(500);
         let msg = SingleRoundSenderData {
             tx_id: 15,
-            amount: MicroTari(500),
+            amount,
             public_excess: PublicKey::from_secret_key(&p.spend_key), // any random key will do
             public_nonce: PublicKey::from_secret_key(&p.change_spend_key), // any random key will do
             metadata: m.clone(),
             message: "".to_string(),
             features: features.clone(),
-            script: script.clone(),
-            script_offset_public_key,
-            sender_metadata_signature: TransactionOutput::create_sender_signature(
-                &script,
-                &features,
-                &script_offset_secret_key,
-            ),
+            script,
+            sender_offset_public_key: p.sender_offset_public_key,
+            public_commitment_nonce: p.sender_public_commitment_nonce,
         };
         let sender_info = TransactionSenderMessage::Single(Box::new(msg.clone()));
         let pubkey = PublicKey::from_secret_key(&p.spend_key);
@@ -285,8 +280,6 @@ mod test {
             fee: MicroTari(125),
             lock_height: 0,
         };
-        let script_offset_secret_key = PrivateKey::random(&mut OsRng);
-        let script_offset_public_key = PublicKey::from_secret_key(&script_offset_secret_key);
         let script = TariScript::default();
         let features = OutputFeatures::default();
         let msg = SingleRoundSenderData {
@@ -297,13 +290,9 @@ mod test {
             metadata: m,
             message: "".to_string(),
             features: features.clone(),
-            script: script.clone(),
-            script_offset_public_key,
-            sender_metadata_signature: TransactionOutput::create_sender_signature(
-                &script,
-                &features,
-                &script_offset_secret_key,
-            ),
+            script,
+            sender_offset_public_key: p.sender_offset_public_key,
+            public_commitment_nonce: p.sender_public_commitment_nonce,
         };
         let sender_info = TransactionSenderMessage::Single(Box::new(msg));
         let rewind_data = RewindData {

--- a/base_layer/core/tests/mempool.rs
+++ b/base_layer/core/tests/mempool.rs
@@ -991,7 +991,7 @@ fn consensus_validation_large_tx() {
             output_amount,
         );
 
-        script_offset_pvt = script_offset_pvt - test_params.script_offset_pvt_key;
+        script_offset_pvt = script_offset_pvt - test_params.sender_offset_private_key;
         unblinded_outputs.push(output.clone());
     }
 

--- a/base_layer/key_manager/Cargo.toml
+++ b/base_layer/key_manager/Cargo.toml
@@ -8,7 +8,7 @@ version = "0.8.11"
 edition = "2018"
 
 [dependencies]
-tari_crypto = { git = "ssh://git@github.com/tari-project/tari-crypto.git", branch = "main" }
+tari_crypto = { git = "https://github.com/tari-project/tari-crypto.git", rev = "ecd77ec2b" }
 rand = "0.7.2"
 digest = "0.8.0"
 sha2 = "0.8.0"

--- a/base_layer/mmr/Cargo.toml
+++ b/base_layer/mmr/Cargo.toml
@@ -25,7 +25,7 @@ criterion = { version="0.2", optional = true }
 rand="0.7.0"
 blake2 = "0.8.0"
 tari_infra_derive= { path = "../../infrastructure/derive", version = "^0.8" }
-tari_crypto = { git = "ssh://git@github.com/tari-project/tari-crypto.git", branch = "main" }
+tari_crypto = { git = "https://github.com/tari-project/tari-crypto.git", rev = "ecd77ec2b" }
 serde_json = "1.0"
 bincode = "1.1"
 [lib]

--- a/base_layer/p2p/Cargo.toml
+++ b/base_layer/p2p/Cargo.toml
@@ -13,7 +13,7 @@ edition = "2018"
 tari_comms = { version = "^0.8", path = "../../comms"}
 tari_comms_dht = { version = "^0.8", path = "../../comms/dht"}
 tari_common = { version= "^0.8", path = "../../common" }
-tari_crypto = { git = "ssh://git@github.com/tari-project/tari-crypto.git", branch = "main" }
+tari_crypto = { git = "https://github.com/tari-project/tari-crypto.git", rev = "ecd77ec2b" }
 tari_service_framework = { version = "^0.8", path = "../service_framework"}
 tari_shutdown = { version = "^0.8", path="../../infrastructure/shutdown" }
 tari_storage = { version = "^0.8", path = "../../infrastructure/storage"}

--- a/base_layer/wallet/Cargo.toml
+++ b/base_layer/wallet/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2018"
 tari_common_types = { version = "^0.8", path = "../../base_layer/common_types"}
 tari_comms = { version = "^0.8", path = "../../comms"}
 tari_comms_dht = { version = "^0.8", path = "../../comms/dht" }
-tari_crypto = { git = "ssh://git@github.com/tari-project/tari-crypto.git", branch = "main" }
+tari_crypto = { git = "https://github.com/tari-project/tari-crypto.git", rev = "ecd77ec2b" }
 tari_key_manager = { version = "^0.8", path = "../key_manager" }
 tari_p2p = { version = "^0.8", path = "../p2p" }
 tari_service_framework = { version = "^0.8", path = "../service_framework"}

--- a/base_layer/wallet/migrations/2021-03-23-082938_update-outputs-for-tari-script/up.sql
+++ b/base_layer/wallet/migrations/2021-03-23-082938_update-outputs-for-tari-script/up.sql
@@ -17,7 +17,7 @@ CREATE TABLE outputs (
     input_data BLOB NOT NULL,
     height INTEGER NOT NULL,
     script_private_key BLOB NOT NULL,
-    script_offset_public_key BLOB NOT NULL,
+    sender_offset_public_key BLOB NOT NULL,
     CONSTRAINT unique_commitment UNIQUE (commitment)
 );
 PRAGMA foreign_keys=on;

--- a/base_layer/wallet/migrations/2021-07-05-13201407_metadata_signature/down.sql
+++ b/base_layer/wallet/migrations/2021-07-05-13201407_metadata_signature/down.sql
@@ -1,0 +1,1 @@
+-- This migration is only meant for fresh databases on a testnet reset, so the down is not needed

--- a/base_layer/wallet/migrations/2021-07-05-13201407_metadata_signature/up.sql
+++ b/base_layer/wallet/migrations/2021-07-05-13201407_metadata_signature/up.sql
@@ -1,0 +1,25 @@
+-- This migration is part of a testnet reset and should not be used on db's with existing old data in them
+-- thus this migration does not accommodate db's with existing rows.
+
+PRAGMA foreign_keys=off;
+DROP TABLE outputs;
+CREATE TABLE outputs (
+    id INTEGER NOT NULL PRIMARY KEY,
+    commitment BLOB NOT NULL,
+    spending_key BLOB NOT NULL,
+    value INTEGER NOT NULL,
+    flags INTEGER NOT NULL,
+    maturity INTEGER NOT NULL,
+    status INTEGER NOT NULL,
+    tx_id INTEGER NULL,
+    hash BLOB NOT NULL,
+    script BLOB NOT NULL,
+    input_data BLOB NOT NULL,
+    script_private_key BLOB NOT NULL,
+    sender_offset_public_key BLOB NOT NULL,
+    metadata_signature_nonce BLOB NOT NULL,
+    metadata_signature_u_key BLOB NOT NULL,
+    metadata_signature_v_key BLOB NOT NULL,
+    CONSTRAINT unique_commitment UNIQUE (commitment)
+);
+PRAGMA foreign_keys=on;

--- a/base_layer/wallet/src/output_manager_service/recovery/standard_outputs_recoverer.rs
+++ b/base_layer/wallet/src/output_manager_service/recovery/standard_outputs_recoverer.rs
@@ -80,13 +80,13 @@ where TBackend: OutputManagerBackend + 'static
                             v,
                             output.features,
                             output.script,
-                            output.script_offset_public_key,
-                            output.sender_metadata_signature,
+                            output.sender_offset_public_key,
+                            output.metadata_signature,
                         )
                     })
             })
             .map(
-                |(output, features, script, script_offset_public_key, sender_metadata_signature)| {
+                |(output, features, script, sender_offset_public_key, metadata_signature)| {
                     UnblindedOutput::new(
                         output.committed_value,
                         output.blinding_factor.clone(),
@@ -94,8 +94,8 @@ where TBackend: OutputManagerBackend + 'static
                         script,
                         inputs!(PublicKey::from_secret_key(&output.blinding_factor)),
                         output.blinding_factor,
-                        script_offset_public_key,
-                        sender_metadata_signature,
+                        sender_offset_public_key,
+                        metadata_signature,
                     )
                 },
             )

--- a/base_layer/wallet/src/schema.rs
+++ b/base_layer/wallet/src/schema.rs
@@ -98,9 +98,10 @@ table! {
         script -> Binary,
         input_data -> Binary,
         script_private_key -> Binary,
-        script_offset_public_key -> Binary,
-        sender_metadata_signature_key -> Binary,
-        sender_metadata_signature_nonce -> Binary,
+        sender_offset_public_key -> Binary,
+        metadata_signature_nonce -> Binary,
+        metadata_signature_u_key -> Binary,
+        metadata_signature_v_key -> Binary,
     }
 }
 

--- a/base_layer/wallet/src/transaction_service/protocols/transaction_receive_protocol.rs
+++ b/base_layer/wallet/src/transaction_service/protocols/transaction_receive_protocol.rs
@@ -47,6 +47,7 @@ use tari_core::transactions::{
     transaction::Transaction,
     transaction_protocol::{recipient::RecipientState, sender::TransactionSenderMessage},
 };
+use tari_crypto::tari_utilities::Hashable;
 use tokio::time::delay_for;
 
 const LOG_TARGET: &str = "wallet::transaction_service::protocols::receive_protocol";
@@ -395,7 +396,7 @@ where TBackend: TransactionBackend + 'static
 
             let finalized_outputs = finalized_transaction.body.outputs();
 
-            if !finalized_outputs.iter().any(|o| o == &rtp_output) {
+            if !finalized_outputs.iter().any(|o| o.hash() == rtp_output.hash()) {
                 warn!(
                     target: LOG_TARGET,
                     "Finalized Transaction does not contain the Receiver's output"
@@ -417,11 +418,28 @@ where TBackend: TransactionBackend + 'static
                 None,
             );
 
+            finalized_transaction
+                .validate_internal_consistency(&Default::default(), None)
+                .map_err(|e| TransactionServiceProtocolError::new(self.id, TransactionServiceError::from(e)))?;
             self.resources
                 .db
                 .complete_inbound_transaction(self.id, completed_transaction.clone())
                 .await
                 .map_err(|e| TransactionServiceProtocolError::new(self.id, TransactionServiceError::from(e)))?;
+
+            // Update output metadata signature if not valid
+            if let Some(v) = finalized_outputs
+                .iter()
+                .find(|output| output.hash() == rtp_output.hash())
+            {
+                if rtp_output.verify_metadata_signature().is_err() {
+                    self.resources
+                        .output_manager_service
+                        .update_output_metadata_signature(v.clone())
+                        .await
+                        .map_err(|e| TransactionServiceProtocolError::new(self.id, TransactionServiceError::from(e)))?;
+                }
+            }
 
             info!(
                 target: LOG_TARGET,

--- a/base_layer/wallet/src/transaction_service/service.rs
+++ b/base_layer/wallet/src/transaction_service/service.rs
@@ -750,13 +750,13 @@ where
 
         // Diffie-Hellman shared secret `k_Ob * K_Sb = K_Ob * k_Sb` results in a public key, which is converted to
         // bytes to enable conversion into a private key to be used as the spending key
-        let script_offset_private_key = stp
-            .get_recipient_script_offset_private_key(0)
+        let sender_offset_private_key = stp
+            .get_recipient_sender_offset_private_key(0)
             .map_err(|e| TransactionServiceProtocolError::new(tx_id, e.into()))?;
         // TODO: Add a standardized Diffie-Hellman method to the tari_crypto library that will return a private key,
         // TODO: then come back and use it here.
         let spending_key = PrivateKey::from_bytes(
-            CommsPublicKey::shared_secret(&script_offset_private_key.clone(), &dest_pubkey.clone()).as_bytes(),
+            CommsPublicKey::shared_secret(&sender_offset_private_key.clone(), &dest_pubkey.clone()).as_bytes(),
         )
         .map_err(|e| TransactionServiceProtocolError::new(tx_id, e.into()))?;
 

--- a/base_layer/wallet/src/transaction_service/storage/sqlite_db.rs
+++ b/base_layer/wallet/src/transaction_service/storage/sqlite_db.rs
@@ -1759,7 +1759,13 @@ mod test {
                 input,
             )
             .with_change_secret(PrivateKey::random(&mut OsRng))
-            .with_recipient_script(0, script!(Nop), PrivateKey::random(&mut OsRng), Default::default())
+            .with_recipient_data(
+                0,
+                script!(Nop),
+                PrivateKey::random(&mut OsRng),
+                Default::default(),
+                PrivateKey::random(&mut OsRng),
+            )
             .with_change_script(script!(Nop), ExecutionStack::default(), PrivateKey::random(&mut OsRng));
 
         let mut stp = builder.build::<HashDigest>(&factories).unwrap();

--- a/base_layer/wallet/src/wallet.rs
+++ b/base_layer/wallet/src/wallet.rs
@@ -61,7 +61,7 @@ use tari_comms_dht::{store_forward::StoreAndForwardRequester, Dht};
 use tari_core::transactions::{
     tari_amount::MicroTari,
     transaction::{OutputFeatures, UnblindedOutput},
-    types::{CryptoFactories, PrivateKey, PublicKey, Signature},
+    types::{ComSignature, CryptoFactories, PrivateKey, PublicKey},
 };
 use tari_crypto::{
     common::Blake256,
@@ -316,9 +316,9 @@ where
         source_public_key: &CommsPublicKey,
         features: OutputFeatures,
         message: String,
-        sender_metadata_signature: Signature,
+        metadata_signature: ComSignature,
         script_private_key: &PrivateKey,
-        script_offset_public_key: &PublicKey,
+        sender_offset_public_key: &PublicKey,
     ) -> Result<TxId, WalletError> {
         let unblinded_output = UnblindedOutput::new(
             amount,
@@ -327,8 +327,8 @@ where
             script,
             input_data,
             script_private_key.clone(),
-            script_offset_public_key.clone(),
-            sender_metadata_signature,
+            sender_offset_public_key.clone(),
+            metadata_signature,
         );
 
         let tx_id = self

--- a/base_layer/wallet/tests/output_manager_service/service.rs
+++ b/base_layer/wallet/tests/output_manager_service/service.rs
@@ -298,7 +298,13 @@ fn generate_sender_transaction_message(amount: MicroTari) -> (TxId, TransactionS
         .with_change_secret(alice.change_spend_key)
         .with_input(utxo, input)
         .with_amount(0, amount)
-        .with_recipient_script(0, script!(Nop), PrivateKey::random(&mut OsRng), Default::default())
+        .with_recipient_data(
+            0,
+            script!(Nop),
+            PrivateKey::random(&mut OsRng),
+            OutputFeatures::default(),
+            PrivateKey::random(&mut OsRng),
+        )
         .with_change_script(
             script!(Nop),
             inputs!(PublicKey::from_secret_key(&script_private_key)),

--- a/base_layer/wallet/tests/transaction_service/service.rs
+++ b/base_layer/wallet/tests/transaction_service/service.rs
@@ -550,6 +550,7 @@ fn manage_single_transaction() {
         loop {
             futures::select! {
                 _event = alice_event_stream.select_next_some() => {
+                    println!("alice: {:?}", &*_event.as_ref().unwrap());
                     count+=1;
                     if count>=2 {
                         break;
@@ -568,16 +569,17 @@ fn manage_single_transaction() {
         let mut finalized = 0;
         loop {
             futures::select! {
-                            event = bob_event_stream.select_next_some() => {
-            if let TransactionEvent::ReceivedFinalizedTransaction(id) = &*event.unwrap() {
-            tx_id = *id;
-            finalized+=1;
+                event = bob_event_stream.select_next_some() => {
+                    println!("bob: {:?}", &*event.as_ref().unwrap());
+                    if let TransactionEvent::ReceivedFinalizedTransaction(id) = &*event.unwrap() {
+                        tx_id = *id;
+                        finalized+=1;
+                    }
+                },
+                () = delay => {
+                    break;
+                },
             }
-                            },
-                            () = delay => {
-                                break;
-                            },
-                        }
         }
         assert_eq!(finalized, 1);
     });
@@ -2071,7 +2073,13 @@ fn test_transaction_cancellation() {
             input,
         )
         .with_change_secret(PrivateKey::random(&mut OsRng))
-        .with_recipient_script(0, script!(Nop), PrivateKey::random(&mut OsRng), Default::default())
+        .with_recipient_data(
+            0,
+            script!(Nop),
+            PrivateKey::random(&mut OsRng),
+            Default::default(),
+            PrivateKey::random(&mut OsRng),
+        )
         .with_change_script(script!(Nop), ExecutionStack::default(), PrivateKey::random(&mut OsRng));
 
     let mut stp = builder.build::<HashDigest>(&factories).unwrap();
@@ -2135,7 +2143,13 @@ fn test_transaction_cancellation() {
             input,
         )
         .with_change_secret(PrivateKey::random(&mut OsRng))
-        .with_recipient_script(0, script!(Nop), PrivateKey::random(&mut OsRng), Default::default())
+        .with_recipient_data(
+            0,
+            script!(Nop),
+            PrivateKey::random(&mut OsRng),
+            Default::default(),
+            PrivateKey::random(&mut OsRng),
+        )
         .with_change_script(script!(Nop), ExecutionStack::default(), PrivateKey::random(&mut OsRng));
 
     let mut stp = builder.build::<HashDigest>(&factories).unwrap();
@@ -2696,7 +2710,13 @@ fn test_restarting_transaction_protocols() {
         .with_private_nonce(bob.nonce)
         .with_input(utxo, input)
         .with_amount(0, MicroTari(2000) - fee - MicroTari(10))
-        .with_recipient_script(0, script!(Nop), PrivateKey::random(&mut OsRng), Default::default())
+        .with_recipient_data(
+            0,
+            script!(Nop),
+            PrivateKey::random(&mut OsRng),
+            Default::default(),
+            PrivateKey::random(&mut OsRng),
+        )
         .with_change_script(
             script!(Nop),
             inputs!(PublicKey::from_secret_key(&script_private_key)),
@@ -3791,7 +3811,13 @@ fn test_resend_on_startup() {
             input,
         )
         .with_change_secret(PrivateKey::random(&mut OsRng))
-        .with_recipient_script(0, script!(Nop), PrivateKey::random(&mut OsRng), Default::default())
+        .with_recipient_data(
+            0,
+            script!(Nop),
+            PrivateKey::random(&mut OsRng),
+            Default::default(),
+            PrivateKey::random(&mut OsRng),
+        )
         .with_change_script(script!(Nop), ExecutionStack::default(), PrivateKey::random(&mut OsRng));
 
     let mut stp = builder.build::<HashDigest>(&factories).unwrap();
@@ -4234,7 +4260,13 @@ fn test_transaction_timeout_cancellation() {
             input,
         )
         .with_change_secret(PrivateKey::random(&mut OsRng))
-        .with_recipient_script(0, script!(Nop), PrivateKey::random(&mut OsRng), Default::default())
+        .with_recipient_data(
+            0,
+            script!(Nop),
+            PrivateKey::random(&mut OsRng),
+            Default::default(),
+            PrivateKey::random(&mut OsRng),
+        )
         .with_change_script(script!(Nop), ExecutionStack::default(), PrivateKey::random(&mut OsRng));
 
     let mut stp = builder.build::<HashDigest>(&factories).unwrap();

--- a/base_layer/wallet/tests/transaction_service/storage.rs
+++ b/base_layer/wallet/tests/transaction_service/storage.rs
@@ -85,7 +85,13 @@ pub fn test_db_backend<T: TransactionBackend + 'static>(backend: T) {
             input,
         )
         .with_change_secret(PrivateKey::random(&mut OsRng))
-        .with_recipient_script(0, script!(Nop), PrivateKey::random(&mut OsRng), Default::default())
+        .with_recipient_data(
+            0,
+            script!(Nop),
+            PrivateKey::random(&mut OsRng),
+            Default::default(),
+            PrivateKey::random(&mut OsRng),
+        )
         .with_change_script(script!(Nop), ExecutionStack::default(), PrivateKey::random(&mut OsRng));
 
     let stp = builder.build::<HashDigest>(&factories).unwrap();

--- a/base_layer/wallet/tests/wallet/mod.rs
+++ b/base_layer/wallet/tests/wallet/mod.rs
@@ -736,9 +736,9 @@ async fn test_import_utxo() {
             base_node_identity.public_key(),
             features,
             "Testing".to_string(),
-            utxo.sender_metadata_signature.clone(),
+            utxo.metadata_signature.clone(),
             &p.script_private_key,
-            &p.script_offset_pub_key,
+            &p.sender_offset_public_key,
         )
         .await
         .unwrap();

--- a/base_layer/wallet_ffi/Cargo.toml
+++ b/base_layer/wallet_ffi/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2018"
 [dependencies]
 tari_comms = { version = "^0.8", path = "../../comms" }
 tari_comms_dht = { version = "^0.8", path = "../../comms/dht" }
-tari_crypto = { git = "ssh://git@github.com/tari-project/tari-crypto.git", branch = "main" }
+tari_crypto = { git = "https://github.com/tari-project/tari-crypto.git", rev = "ecd77ec2b" }
 tari_key_manager = { version = "^0.8", path = "../key_manager" }
 tari_p2p = { version = "^0.8", path = "../p2p" }
 tari_wallet = { version = "^0.8", path = "../wallet", features = ["test_harness", "c_integration"]}

--- a/base_layer/wallet_ffi/src/lib.rs
+++ b/base_layer/wallet_ffi/src/lib.rs
@@ -209,7 +209,7 @@ use tari_wallet::{
     WalletConfig,
 };
 
-use tari_core::transactions::types::Signature;
+use tari_core::transactions::types::ComSignature;
 use tari_crypto::script::TariScript;
 use tari_p2p::Network;
 use tari_wallet::{
@@ -4499,7 +4499,8 @@ pub unsafe extern "C" fn wallet_import_utxo(
     source_public_key: *mut TariPublicKey,
     message: *const c_char,
     error_out: *mut c_int,
-    // TODO: Update this interface to add the sender signature, script private key and script offset public keys here.
+    /* TODO: Update this interface to add the metadata signature, script private key and script offset public keys
+     * here. */
 ) -> c_ulonglong {
     let mut error = 0;
     ptr::swap(error_out, &mut error as *mut c_int);
@@ -4537,8 +4538,8 @@ pub unsafe extern "C" fn wallet_import_utxo(
         &(*source_public_key).clone(),
         OutputFeatures::default(),
         message_string,
-        // TODO: Add the actual sender signature here.
-        Signature::default(),
+        // TODO: Add the actual metadata signature here.
+        ComSignature::default(),
         // TODO:Add the actual script private key here.
         &Default::default(),
         // TODO:Add the actual script offset public keys here.

--- a/comms/Cargo.toml
+++ b/comms/Cargo.toml
@@ -10,7 +10,7 @@ version = "0.8.11"
 edition = "2018"
 
 [dependencies]
-tari_crypto = { git = "ssh://git@github.com/tari-project/tari-crypto.git", branch = "main" }
+tari_crypto = { git = "https://github.com/tari-project/tari-crypto.git", rev = "ecd77ec2b" }
 tari_storage = { version = "^0.8", path = "../infrastructure/storage" }
 tari_shutdown = { version="^0.8",  path = "../infrastructure/shutdown" }
 

--- a/comms/dht/Cargo.toml
+++ b/comms/dht/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2018"
 [dependencies]
 tari_comms  = { version = "^0.8", path = "../", features = ["rpc"]}
 tari_comms_rpc_macros  = { version = "^0.8", path = "../rpc_macros"}
-tari_crypto = { git = "ssh://git@github.com/tari-project/tari-crypto.git", branch = "main" }
+tari_crypto = { git = "https://github.com/tari-project/tari-crypto.git", rev = "ecd77ec2b" }
 tari_utilities  = { version = "^0.3" }
 tari_shutdown = { version = "^0.8", path = "../../infrastructure/shutdown"}
 tari_storage  = { version = "^0.8", path = "../../infrastructure/storage"}

--- a/integration_tests/helpers/util.js
+++ b/integration_tests/helpers/util.js
@@ -228,6 +228,30 @@ function pad(str, length, padLeft = true) {
   }
 }
 
+function combineTwoTariKeys(key1, key2) {
+  let total_key =
+    BigInt(littleEndianHexStringToBigEndianHexString(key1)) +
+    BigInt(littleEndianHexStringToBigEndianHexString(key2));
+  if (total_key < 0) {
+    total_key =
+      total_key +
+      BigInt(
+        littleEndianHexStringToBigEndianHexString(
+          "edd3f55c1a631258d69cf7a2def9de1400000000000000000000000000000010"
+        )
+      );
+  }
+  total_key = total_key.toString(16);
+  while (total_key.length < 64) {
+    total_key = "0" + total_key;
+  }
+  total_key = littleEndianHexStringToBigEndianHexString(total_key);
+  while (total_key.length < 64) {
+    total_key = "0" + total_key;
+  }
+  return total_key;
+}
+
 module.exports = {
   getRandomInt,
   sleep,
@@ -242,5 +266,6 @@ module.exports = {
   consoleLogBalance,
   consoleLogCoinbaseDetails,
   withTimeout,
+  combineTwoTariKeys,
   NO_CONNECTION,
 };

--- a/integration_tests/helpers/walletProcess.js
+++ b/integration_tests/helpers/walletProcess.js
@@ -220,13 +220,14 @@ class WalletProcess {
             script: Buffer.from(row.script, "hex"),
             input_data: Buffer.from(row.input_data, "hex"),
             script_private_key: Buffer.from(row.script_private_key, "hex"),
-            script_offset_public_key: Buffer.from(
-              row.script_offset_public_key,
+            sender_offset_public_key: Buffer.from(
+              row.sender_offset_public_key,
               "hex"
             ),
-            sender_metadata_signature: {
-              public_nonce: Buffer.from(row.public_nonce, "hex"),
-              signature: Buffer.from(row.signature, "hex"),
+            metadata_signature: {
+              public_nonce_commitment: Buffer.from(row.public_nonce, "hex"),
+              signature_u: Buffer.from(row.signature_u, "hex"),
+              signature_v: Buffer.from(row.signature_v, "hex"),
             },
           };
           unblinded_outputs.push(unblinded_output);

--- a/integration_tests/package-lock.json
+++ b/integration_tests/package-lock.json
@@ -58,9 +58,9 @@
       }
     },
     "@grpc/grpc-js": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.3.2.tgz",
-      "integrity": "sha512-UXepkOKCATJrhHGsxt+CGfpZy9zUn1q9mop5kfcXq1fBkTePxVNPOdnISlCbJFlCtld+pSLGyZCzr9/zVprFKA==",
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.3.4.tgz",
+      "integrity": "sha512-AxtZcm0mArQhY9z8T3TynCYVEaSKxNCa9mVhVwBCUnsuUEe8Zn94bPYYKVQSLt+hJJ1y0ukr3mUvtWfcATL/IQ==",
       "requires": {
         "@types/node": ">=12.12.47"
       }
@@ -3339,8 +3339,8 @@
       }
     },
     "wallet-grpc-client": {
-      "version": "git+ssh://git@github.com/tari-project/wallet-grpc-client.git#d1f4ed2dadcc538b656e4aee8b0f42ce634b4f7d",
-      "from": "wallet-grpc-client@git@github.com:tari-project/wallet-grpc-client.git#d1f4ed2dadcc538b656e4aee8b0f42ce634b4f7d",
+      "version": "git+ssh://git@github.com/tari-project/wallet-grpc-client.git#6f61748244f1ec48ca04aa7a5bb7d9c61a1e9900",
+      "from": "git+ssh://git@github.com/tari-project/wallet-grpc-client.git#6f61748244f1ec48ca04aa7a5bb7d9c61a1e9900",
       "requires": {
         "@grpc/grpc-js": "^1.2.3",
         "@grpc/proto-loader": "^0.5.5",

--- a/integration_tests/package.json
+++ b/integration_tests/package.json
@@ -44,6 +44,6 @@
     "sha3": "^2.1.3",
     "synchronized-promise": "^0.3.1",
     "tari_crypto": "^0.9.1",
-    "wallet-grpc-client": "git@github.com:tari-project/wallet-grpc-client.git#d1f4ed2dadcc538b656e4aee8b0f42ce634b4f7d"
+    "wallet-grpc-client": "git@github.com:tari-project/wallet-grpc-client.git#6f61748244f1ec48ca04aa7a5bb7d9c61a1e9900"
   }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Implementation to be in line with RFC-0201:
- Implemented metadata comsig for the transaction output
- Created new faucet data
- Updated genesis block timestamp as this is a breaking change
- Added a metadata comsig unit test

Co-Authored-By: SW van Heerden <swvheerden@gmail.com>

## Motivation and Context
See above

## How Has This Been Tested?
- Unit tests
  **Note:** Failing unit test `block_event_and_reorg_event_handling` to be fixed later
- Cucumber tests
- System level tests

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [X] I'm merging against the `tari-script` branch.
* [X] I have squashed my commits into a single commit.
