### PR TITLE
[chore] Use tari_crypto 0.11, update digest, rand and sha3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,18 +4,18 @@ version = 3
 
 [[package]]
 name = "addr2line"
-version = "0.14.1"
+version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a55f82cfe485775d02112886f4169bde0c5894d75e79ead7eafe7e40a25e45f7"
+checksum = "e7a2e47a1fbe209ee101dd6d61285226744c6c8d3c21c8dc878ba6cb9f467f3a"
 dependencies = [
  "gimli",
 ]
 
 [[package]]
 name = "adler"
-version = "0.2.3"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee2a4ec343196209d6594e19543ae87a39f96d5534d7174822a3ad825dd6ed7e"
+checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
 name = "aead"
@@ -23,7 +23,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7fc95d1bdb8e6666b2b217308eeeb09f2d6728d104be3e31916cc74d15420331"
 dependencies = [
- "generic-array 0.14.4",
+ "generic-array",
 ]
 
 [[package]]
@@ -32,7 +32,7 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "922b33332f54fc0ad13fa3e514601e8d30fb54e1f3eadc36643f6526db645621"
 dependencies = [
- "generic-array 0.14.4",
+ "generic-array",
 ]
 
 [[package]]
@@ -66,7 +66,7 @@ dependencies = [
  "cfg-if 1.0.0",
  "cipher 0.3.0",
  "cpufeatures",
- "opaque-debug 0.3.0",
+ "opaque-debug",
 ]
 
 [[package]]
@@ -80,7 +80,7 @@ dependencies = [
  "cipher 0.2.5",
  "ctr 0.6.0",
  "ghash 0.3.1",
- "subtle 2.4.0",
+ "subtle",
 ]
 
 [[package]]
@@ -94,7 +94,7 @@ dependencies = [
  "cipher 0.3.0",
  "ctr 0.7.0",
  "ghash 0.4.2",
- "subtle 2.4.0",
+ "subtle",
 ]
 
 [[package]]
@@ -105,7 +105,7 @@ checksum = "63dd91889c49327ad7ef3b500fd1109dbd3c509a03db0d4a9ce413b79f575cb6"
 dependencies = [
  "block-cipher",
  "byteorder",
- "opaque-debug 0.3.0",
+ "opaque-debug",
 ]
 
 [[package]]
@@ -115,7 +115,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be14c7498ea50828a38d0e24a765ed2effe92a705885b57d029cd67d45744072"
 dependencies = [
  "cipher 0.2.5",
- "opaque-debug 0.3.0",
+ "opaque-debug",
 ]
 
 [[package]]
@@ -125,7 +125,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0a6fe808308bb07d393e2ea47780043ec47683fcf19cf5efc8ca51c50cc8c68a"
 dependencies = [
  "block-cipher",
- "opaque-debug 0.3.0",
+ "opaque-debug",
 ]
 
 [[package]]
@@ -135,14 +135,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea2e11f5e94c2f7d386164cc2aa1f97823fed6f259e486940a71c174dd01b0ce"
 dependencies = [
  "cipher 0.2.5",
- "opaque-debug 0.3.0",
+ "opaque-debug",
 ]
 
 [[package]]
 name = "aho-corasick"
-version = "0.7.15"
+version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7404febffaa47dac81aa44dba71523c9d069b1bdc50a77db41195149e17f68e5"
+checksum = "1e37cfd5e7657ada45f742d6e99ca5788580b5c529dc78faf11ece6dc702656f"
 dependencies = [
  "memchr",
 ]
@@ -173,9 +173,9 @@ checksum = "34fde25430d87a9388dadbe6e34d7f72a462c8b43ac8d309b42b0a8505d7e2a5"
 
 [[package]]
 name = "anyhow"
-version = "1.0.40"
+version = "1.0.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28b2cd92db5cbd74e8e5028f7e27dd7aa3090e89e4f2a197cc7c8dfb69c7063b"
+checksum = "15af2628f6890fe2609a3b91bef4c83450512802e59489f9c1cb1fa5df064a61"
 
 [[package]]
 name = "arc-swap"
@@ -199,12 +199,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "arrayvec"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
-
-[[package]]
 name = "async-stream"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -220,9 +214,9 @@ version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25f9db3b38af870bf7e5cc649167533b493928e50744e2c30ae350230b414670"
 dependencies = [
- "proc-macro2 1.0.24",
+ "proc-macro2 1.0.27",
  "quote 1.0.9",
- "syn 1.0.67",
+ "syn 1.0.73",
 ]
 
 [[package]]
@@ -231,9 +225,9 @@ version = "0.1.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b98e84bbb4cbcdd97da190ba0c58a1bb0de2c1fdf67d159e192ed766aeca722"
 dependencies = [
- "proc-macro2 1.0.24",
+ "proc-macro2 1.0.27",
  "quote 1.0.9",
- "syn 1.0.67",
+ "syn 1.0.73",
 ]
 
 [[package]]
@@ -261,11 +255,12 @@ checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
 
 [[package]]
 name = "backtrace"
-version = "0.3.56"
+version = "0.3.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d117600f438b1707d4e4ae15d3595657288f8235a0eb593e80ecc98ab34e1bc"
+checksum = "b7815ea54e4d821e791162e078acbebfd6d8c8939cd559c9335dceb1c8ca7282"
 dependencies = [
  "addr2line",
+ "cc",
  "cfg-if 1.0.0",
  "libc",
  "miniz_oxide",
@@ -332,11 +327,10 @@ dependencies = [
 
 [[package]]
 name = "bincode"
-version = "1.3.1"
+version = "1.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f30d3a39baa26f9651f17b375061f3233dde33424a8b72b0dbe93a68a0bc896d"
+checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
 dependencies = [
- "byteorder",
  "serde 1.0.126",
 ]
 
@@ -350,12 +344,12 @@ dependencies = [
  "cexpr",
  "clang-sys",
  "clap",
- "env_logger 0.8.3",
+ "env_logger 0.8.4",
  "lazy_static 1.4.0",
  "lazycell",
  "log 0.4.14",
  "peeking_take_while",
- "proc-macro2 1.0.24",
+ "proc-macro2 1.0.27",
  "quote 1.0.9",
  "regex",
  "rustc-hash",
@@ -389,52 +383,13 @@ checksum = "3e54f7b7a46d7b183eb41e2d82965261fa8a1597c68b50aced268ee1fc70272d"
 
 [[package]]
 name = "blake2"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94cb07b0da6a73955f8fb85d24c466778e70cda767a568229b104f0264089330"
-dependencies = [
- "byte-tools",
- "crypto-mac 0.7.0",
- "digest 0.8.1",
- "opaque-debug 0.2.3",
-]
-
-[[package]]
-name = "blake2"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "10a5720225ef5daecf08657f23791354e1685a8c91a4c60c7f3d3b2892f978f4"
 dependencies = [
- "crypto-mac 0.8.0",
- "digest 0.9.0",
- "opaque-debug 0.3.0",
-]
-
-[[package]]
-name = "blake3"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9ff35b701f3914bdb8fad3368d822c766ef2858b2583198e41639b936f09d3f"
-dependencies = [
- "arrayref",
- "arrayvec 0.5.2",
- "cc",
- "cfg-if 0.1.10",
- "constant_time_eq",
- "crypto-mac 0.8.0",
- "digest 0.9.0",
-]
-
-[[package]]
-name = "block-buffer"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0940dc441f31689269e10ac70eb1002a3a1d3ad1390e030043662eb7fe4688b"
-dependencies = [
- "block-padding 0.1.5",
- "byte-tools",
- "byteorder",
- "generic-array 0.12.3",
+ "crypto-mac",
+ "digest",
+ "opaque-debug",
 ]
 
 [[package]]
@@ -443,8 +398,8 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
 dependencies = [
- "block-padding 0.2.1",
- "generic-array 0.14.4",
+ "block-padding",
+ "generic-array",
 ]
 
 [[package]]
@@ -453,7 +408,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f337a3e6da609650eb74e02bc9fac7b735049f7623ab12f2e4c719316fcc7e80"
 dependencies = [
- "generic-array 0.14.4",
+ "generic-array",
 ]
 
 [[package]]
@@ -463,16 +418,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c9b14fd8a4739e6548d4b6018696cf991dcf8c6effd9ef9eb33b29b8a650972"
 dependencies = [
  "block-cipher",
- "block-padding 0.2.1",
-]
-
-[[package]]
-name = "block-padding"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa79dedbb091f449f1f39e53edf88d5dbe95f895dae6135a8d7b881fb5af73f5"
-dependencies = [
- "byte-tools",
+ "block-padding",
 ]
 
 [[package]]
@@ -489,7 +435,7 @@ checksum = "0f06850ba969bc59388b2cc0a4f186fc6d9d37208863b15b84ae3866ac90ac06"
 dependencies = [
  "block-cipher",
  "byteorder",
- "opaque-debug 0.3.0",
+ "opaque-debug",
 ]
 
 [[package]]
@@ -500,9 +446,9 @@ checksum = "771fe0050b883fcc3ea2359b1a96bcfbc090b7116eae7c3c512c7a083fdf23d3"
 
 [[package]]
 name = "bstr"
-version = "0.2.15"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a40b47ad93e1a5404e6c18dec46b628214fee441c70f4ab5d6942142cc268a3d"
+checksum = "90682c8d613ad3373e66de8c6411e0ae2ab2571e879d2efbf73558cc66f21279"
 dependencies = [
  "lazy_static 1.4.0",
  "memchr",
@@ -522,27 +468,21 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.6.1"
+version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63396b8a4b9de3f4fdfb320ab6080762242f66a8ef174c49d8e19b674db4cdbe"
-
-[[package]]
-name = "byte-tools"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3b5ca7a04898ad4bcd41c90c5285445ff5b791899bb1b0abdd2a2aa791211d7"
+checksum = "9c59e7af012c713f529e7a3ee57ce9b31ddd858d4b512923602f74608b009631"
 
 [[package]]
 name = "bytemuck"
-version = "1.5.1"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bed57e2090563b83ba8f83366628ce535a7584c9afa4c9fc0612a03925c6df58"
+checksum = "9966d2ab714d0f785dbac0a0396251a35280aeb42413281617d0209ab4898435"
 
 [[package]]
 name = "byteorder"
-version = "1.4.2"
+version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae44d1a3d5a19df61dd0c8beb138458ac2a53a7ac09eba97d55592540004306b"
+checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
 name = "bytes"
@@ -589,11 +529,11 @@ checksum = "df8670b8c7b9dae1793364eafadf7239c40d669904660c5960d74cfd80b46a53"
 
 [[package]]
 name = "cast"
-version = "0.2.3"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b9434b9a5aa1450faa3f9cb14ea0e8c53bb5d2b3c1bfd1ab4fc03e9f33fbfb0"
+checksum = "4c24dab4283a142afa2fdca129b80ad2c6284e073930f964c3a1293c225ee39a"
 dependencies = [
- "rustc_version 0.2.3",
+ "rustc_version 0.4.0",
 ]
 
 [[package]]
@@ -604,7 +544,7 @@ checksum = "e3ed1e6b53a3de8bafcce4b88867893c234e57f91686a4726d8e803771f0b55b"
 dependencies = [
  "block-cipher",
  "byteorder",
- "opaque-debug 0.3.0",
+ "opaque-debug",
 ]
 
 [[package]]
@@ -617,20 +557,20 @@ dependencies = [
  "heck",
  "indexmap",
  "log 0.4.14",
- "proc-macro2 1.0.24",
+ "proc-macro2 1.0.27",
  "quote 1.0.9",
  "serde 1.0.126",
  "serde_json",
- "syn 1.0.67",
+ "syn 1.0.73",
  "tempfile",
  "toml 0.5.8",
 ]
 
 [[package]]
 name = "cc"
-version = "1.0.66"
+version = "1.0.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c0496836a84f8d0495758516b8621a622beb77c0fed418570e50764093ced48"
+checksum = "4a72c244c1ff497a746a7e1fb3d14bd08420ecda70c8f25c7112f2781652d787"
 
 [[package]]
 name = "cexpr"
@@ -709,9 +649,9 @@ dependencies = [
 
 [[package]]
 name = "chrono-english"
-version = "0.1.4"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4233ee19352739cfdcb5d7c2085005b166f6170ef2845ed9eef27a8fa5f95206"
+checksum = "0be5180df5f7c41fc2416bc038bc8d78d44db8136c415b94ccbc95f523dc38e9"
 dependencies = [
  "chrono",
  "scanlex",
@@ -734,7 +674,7 @@ version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "12f8e7987cbd042a63249497f41aed09f8e65add917ea6566effbc56578d6801"
 dependencies = [
- "generic-array 0.14.4",
+ "generic-array",
 ]
 
 [[package]]
@@ -743,7 +683,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ee52072ec15386f770805afd189a01c8841be8696bed250fa2f13c4c0d6dfb7"
 dependencies = [
- "generic-array 0.14.4",
+ "generic-array",
 ]
 
 [[package]]
@@ -754,9 +694,9 @@ checksum = "b0fc239e0f6cb375d2402d48afb92f76f5404fd1df208a41930ec81eda078bea"
 
 [[package]]
 name = "clang-sys"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cb92721cb37482245ed88428f72253ce422b3b4ee169c70a0642521bb5db4cc"
+checksum = "853eda514c284c2287f4bf20ae614f8781f40a81d32ecda6e91449304dfe077c"
 dependencies = [
  "glob",
  "libc",
@@ -819,18 +759,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "const_fn"
-version = "0.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28b9d6de7f49e22cf97ad17fc4036ece69300032f45f78f30b4a4482cdc3f4a6"
-
-[[package]]
-name = "constant_time_eq"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
-
-[[package]]
 name = "core-foundation"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -848,9 +776,9 @@ checksum = "ea221b5284a47e40033bf9b66f35f984ec0ea2931eb03505246cd27a963f981b"
 
 [[package]]
 name = "cpufeatures"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed00c67cb5d0a7d64a44f6ad2668db7e7530311dd53ea79bcd4fb022c64911c8"
+checksum = "66c99696f6c9dd7f35d486b9d04d7e6e202aa3e8c40d553f2fdf5e7e0c6a71ef"
 dependencies = [
  "libc",
 ]
@@ -938,16 +866,16 @@ dependencies = [
 
 [[package]]
 name = "crossbeam"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd01a6eb3daaafa260f6fc94c3a6c36390abc2080e38e3e34ced87393fb77d80"
+checksum = "4ae5588f6b3c3cb05239e90bd110f257254aecd01e4635400391aeae07497845"
 dependencies = [
  "cfg-if 1.0.0",
- "crossbeam-channel 0.5.0",
+ "crossbeam-channel 0.5.1",
  "crossbeam-deque",
  "crossbeam-epoch",
  "crossbeam-queue",
- "crossbeam-utils 0.8.1",
+ "crossbeam-utils 0.8.5",
 ]
 
 [[package]]
@@ -961,12 +889,12 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dca26ee1f8d361640700bde38b2c37d8c22b3ce2d360e1fc1c74ea4b0aa7d775"
+checksum = "06ed27e177f16d65f0f0c22a213e17c696ace5dd64b14258b52f9417ccb52db4"
 dependencies = [
  "cfg-if 1.0.0",
- "crossbeam-utils 0.8.1",
+ "crossbeam-utils 0.8.5",
 ]
 
 [[package]]
@@ -977,18 +905,17 @@ checksum = "94af6efb46fef72616855b036a624cf27ba656ffc9be1b9a3c931cfc7749a9a9"
 dependencies = [
  "cfg-if 1.0.0",
  "crossbeam-epoch",
- "crossbeam-utils 0.8.1",
+ "crossbeam-utils 0.8.5",
 ]
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.1"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1aaa739f95311c2c7887a76863f500026092fb1dce0161dab577e559ef3569d"
+checksum = "4ec02e091aa634e2c3ada4a392989e7c3116673ef0ac5b72232439094d73b7fd"
 dependencies = [
  "cfg-if 1.0.0",
- "const_fn",
- "crossbeam-utils 0.8.1",
+ "crossbeam-utils 0.8.5",
  "lazy_static 1.4.0",
  "memoffset",
  "scopeguard",
@@ -996,12 +923,12 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-queue"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f6cb3c7f5b8e51bc3ebb73a2327ad4abdbd119dc13223f14f961d2f38486756"
+checksum = "9b10ddc024425c88c2ad148c1b0fd53f4c6d38db9697c9f1588381212fa657c9"
 dependencies = [
  "cfg-if 1.0.0",
- "crossbeam-utils 0.8.1",
+ "crossbeam-utils 0.8.5",
 ]
 
 [[package]]
@@ -1016,11 +943,10 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.1"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02d96d1e189ef58269ebe5b97953da3274d83a93af647c2ddd6f9dab28cedb8d"
+checksum = "d82cfc11ce7f2c3faef78d8a684447b40d503d9681acebed6cb728d45940c4db"
 dependencies = [
- "autocfg 1.0.1",
  "cfg-if 1.0.0",
  "lazy_static 1.4.0",
 ]
@@ -1035,7 +961,7 @@ dependencies = [
  "crossterm_winapi",
  "lazy_static 1.4.0",
  "libc",
- "mio 0.7.8",
+ "mio 0.7.13",
  "parking_lot",
  "signal-hook",
  "winapi 0.3.9",
@@ -1058,29 +984,19 @@ checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 
 [[package]]
 name = "crypto-mac"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4434400df11d95d556bac068ddfedd482915eb18fe8bea89bc80b6e4b1c179e5"
-dependencies = [
- "generic-array 0.12.3",
- "subtle 1.0.0",
-]
-
-[[package]]
-name = "crypto-mac"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b584a330336237c1eecd3e94266efb216c56ed91225d634cb2991c5f3fd1aeab"
 dependencies = [
- "generic-array 0.14.4",
- "subtle 2.4.0",
+ "generic-array",
+ "subtle",
 ]
 
 [[package]]
 name = "csv"
-version = "1.1.5"
+version = "1.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9d58633299b24b515ac72a3f869f8b91306a3cec616a602843a383acd6f9e97"
+checksum = "22813a6dc45b335f9bade10bf7271dc477e81113e89eb251a0bc2a8a81c536e1"
 dependencies = [
  "bstr",
  "csv-core",
@@ -1118,9 +1034,9 @@ dependencies = [
 
 [[package]]
 name = "curl-sys"
-version = "0.4.40+curl-7.75.0"
+version = "0.4.44+curl-7.77.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ffafc1c35958318bd7fdd0582995ce4c72f4f461a8e70499ccee83a619fd562"
+checksum = "4b6d85e9322b193f117c966e79c2d6929ec08c02f339f950044aba12e20bbaf1"
 dependencies = [
  "cc",
  "libc",
@@ -1133,30 +1049,30 @@ dependencies = [
 
 [[package]]
 name = "curve25519-dalek"
-version = "2.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434e1720189a637d44fe464f4df1e6eb900b4835255b14354497c78af37d9bb8"
-dependencies = [
- "byteorder",
- "digest 0.8.1",
- "packed_simd_2",
- "rand_core 0.5.1",
- "serde 1.0.126",
- "subtle 2.4.0",
- "zeroize",
-]
-
-[[package]]
-name = "curve25519-dalek"
 version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "639891fde0dbea823fc3d798a0fdf9d2f9440a42d64a78ab3488b0ca025117b3"
 dependencies = [
  "byteorder",
- "digest 0.9.0",
+ "digest",
  "rand_core 0.5.1",
  "serde 1.0.126",
- "subtle 2.4.0",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "curve25519-dalek-ng"
+version = "4.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "574d8b2cd0bae5434fd50d53280f8299d95557a978686555880aaf5b8f4f81e9"
+dependencies = [
+ "byteorder",
+ "digest",
+ "packed_simd_2",
+ "rand_core 0.6.3",
+ "serde 1.0.126",
+ "subtle-ng",
  "zeroize",
 ]
 
@@ -1178,10 +1094,10 @@ checksum = "f0c960ae2da4de88a91b2d920c2a7233b400bc33cb28453a2987822d8392519b"
 dependencies = [
  "fnv",
  "ident_case",
- "proc-macro2 1.0.24",
+ "proc-macro2 1.0.27",
  "quote 1.0.9",
  "strsim 0.9.3",
- "syn 1.0.67",
+ "syn 1.0.73",
 ]
 
 [[package]]
@@ -1192,7 +1108,7 @@ checksum = "d9b5a2f4ac4969822c62224815d069952656cadc7084fdca9751e6d959189b72"
 dependencies = [
  "darling_core",
  "quote 1.0.9",
- "syn 1.0.67",
+ "syn 1.0.73",
 ]
 
 [[package]]
@@ -1220,9 +1136,9 @@ checksum = "a2658621297f2cf68762a6f7dc0bb7e1ff2cfd6583daef8ee0fed6f7ec468ec0"
 dependencies = [
  "darling",
  "derive_builder_core",
- "proc-macro2 1.0.24",
+ "proc-macro2 1.0.27",
  "quote 1.0.9",
- "syn 1.0.67",
+ "syn 1.0.73",
 ]
 
 [[package]]
@@ -1232,9 +1148,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2791ea3e372c8495c0bc2033991d76b512cd799d07491fbd6890124db9458bef"
 dependencies = [
  "darling",
- "proc-macro2 1.0.24",
+ "proc-macro2 1.0.27",
  "quote 1.0.9",
- "syn 1.0.67",
+ "syn 1.0.73",
 ]
 
 [[package]]
@@ -1245,14 +1161,14 @@ checksum = "e084b5048dec677e6c9f27d7abc551dde7d127cf4127fea82323c98a30d7fa0d"
 dependencies = [
  "block-cipher",
  "byteorder",
- "opaque-debug 0.3.0",
+ "opaque-debug",
 ]
 
 [[package]]
 name = "diesel"
-version = "1.4.5"
+version = "1.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e2de9deab977a153492a1468d1b1c0662c1cf39e5ea87d0c060ecd59ef18d8c"
+checksum = "bba51ca66f57261fd17cadf8b73e4775cc307d0521d855de3f5de91a8f074e0e"
 dependencies = [
  "bigdecimal",
  "byteorder",
@@ -1271,9 +1187,9 @@ version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "45f5098f628d02a7a0f68ddba586fb61e80edec3bdc1be3b921f4ceec60858d3"
 dependencies = [
- "proc-macro2 1.0.24",
+ "proc-macro2 1.0.27",
  "quote 1.0.9",
- "syn 1.0.67",
+ "syn 1.0.73",
 ]
 
 [[package]]
@@ -1288,20 +1204,11 @@ dependencies = [
 
 [[package]]
 name = "digest"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3d0c8c8752312f9713efd397ff63acb9f85585afbf179282e720e7704954dd5"
-dependencies = [
- "generic-array 0.12.3",
-]
-
-[[package]]
-name = "digest"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
 dependencies = [
- "generic-array 0.14.4",
+ "generic-array",
 ]
 
 [[package]]
@@ -1327,9 +1234,9 @@ dependencies = [
 
 [[package]]
 name = "dtoa"
-version = "0.4.7"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88d7ed2934d741c6b37e33e3832298e8850b53fd2d2bea03873375596c7cea4e"
+checksum = "56899898ce76aaf4a0f24d914c97ea6ed976d42fec6ad33fcbb0a1103e07b2b0"
 
 [[package]]
 name = "ed25519"
@@ -1346,11 +1253,11 @@ version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c762bae6dcaf24c4c84667b8579785430908723d5c889f469d76a41d59cc7a9d"
 dependencies = [
- "curve25519-dalek 3.1.0",
+ "curve25519-dalek",
  "ed25519",
  "rand 0.7.3",
  "serde 1.0.126",
- "sha2 0.9.5",
+ "sha2",
  "zeroize",
 ]
 
@@ -1382,9 +1289,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c5f0096a91d210159eceb2ff5e1c4da18388a170e1e3ce948aac9c8fdbbf595"
 dependencies = [
  "heck",
- "proc-macro2 1.0.24",
+ "proc-macro2 1.0.27",
  "quote 1.0.9",
- "syn 1.0.67",
+ "syn 1.0.73",
 ]
 
 [[package]]
@@ -1415,9 +1322,9 @@ dependencies = [
 
 [[package]]
 name = "env_logger"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17392a012ea30ef05a610aa97dfb49496e71c9f676b27879922ea5bdf60d9d3f"
+checksum = "a19187fea3ac7e84da7dacf48de0c45d63c6a76f9490dae389aead16c243fce3"
 dependencies = [
  "atty",
  "humantime 2.1.0",
@@ -1427,19 +1334,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "fake-simd"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e88a8acf291dafb59c2d96e8f59828f3838bb1a70398823ade51a84de6a6deed"
-
-[[package]]
 name = "fixed-hash"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfcf0ed7fe52a17a03854ec54a9f76d6d84508d1c0e66bc1793301c73fc8493c"
 dependencies = [
  "byteorder",
- "rand 0.8.3",
+ "rand 0.8.4",
  "rustc-hex",
  "static_assertions",
 ]
@@ -1528,15 +1429,15 @@ checksum = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
 
 [[package]]
 name = "futures"
-version = "0.1.30"
+version = "0.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c7e4c2612746b0df8fed4ce0c69156021b704c9aefa360311c04e6e9e002eed"
+checksum = "3a471a38ef8ed83cd6e40aa59c1ffe17db6855c18e3604d9c4ed8c08ebc28678"
 
 [[package]]
 name = "futures"
-version = "0.3.12"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da9052a1a50244d8d5aa9bf55cbc2fb6f357c86cc52e46c62ed390a7180cf150"
+checksum = "0e7e43a803dae2fa37c1f6a8fe121e1f7bf9548b4dfc0522a42f34145dadfc27"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1549,9 +1450,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.12"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2d31b7ec7efab6eefc7c57233bb10b847986139d88cc2f5a02a1ae6871a1846"
+checksum = "e682a68b29a882df0545c143dc3646daefe80ba479bcdede94d5a703de2871e2"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -1569,9 +1470,9 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.12"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79e5145dde8da7d1b3892dad07a9c98fc04bc39892b1ecc9692cf53e2b780a65"
+checksum = "0402f765d8a89a26043b889b26ce3c4679d268fa6bb22cd7c6aad98340e179d1"
 
 [[package]]
 name = "futures-core-preview"
@@ -1581,9 +1482,9 @@ checksum = "b35b6263fb1ef523c3056565fa67b1d16f0a8604ff12b11b08c25f28a734c60a"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.12"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9e59fdc009a4b3096bf94f740a0f2424c082521f20a9b08c5c07c48d90fd9b9"
+checksum = "badaa6a909fac9e7236d0620a2f57f7664640c56575b71a7552fbd68deafab79"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -1603,9 +1504,9 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.12"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28be053525281ad8259d47e4de5de657b25e7bac113458555bb4b70bc6870500"
+checksum = "acc499defb3b348f8d8f3f66415835a9131856ff7714bf10dadfc4ec4bdb29a1"
 
 [[package]]
 name = "futures-io-preview"
@@ -1615,14 +1516,15 @@ checksum = "f4914ae450db1921a56c91bde97a27846287d062087d4a652efc09bb3a01ebda"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.12"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c287d25add322d9f9abdcdc5927ca398917996600182178774032e9f8258fedd"
+checksum = "a4c40298486cdf52cc00cd6d6987892ba502c7656a16a4192a9992b1ccedd121"
 dependencies = [
+ "autocfg 1.0.1",
  "proc-macro-hack",
- "proc-macro2 1.0.24",
+ "proc-macro2 1.0.27",
  "quote 1.0.9",
- "syn 1.0.67",
+ "syn 1.0.73",
 ]
 
 [[package]]
@@ -1641,9 +1543,9 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.12"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "caf5c69029bda2e743fddd0582d1083951d65cc9539aebf8812f36c3491342d6"
+checksum = "a57bead0ceff0d6dde8f465ecd96c9338121bb7717d3e7b108059531870c4282"
 
 [[package]]
 name = "futures-sink-preview"
@@ -1653,27 +1555,24 @@ checksum = "86f148ef6b69f75bb610d4f9a2336d4fc88c4b5b67129d1a340dd0fd362efeec"
 
 [[package]]
 name = "futures-task"
-version = "0.3.12"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13de07eb8ea81ae445aca7b69f5f7bf15d7bf4912d8ca37d6645c77ae8a58d86"
-dependencies = [
- "once_cell",
-]
+checksum = "8a16bef9fc1a4dddb5bee51c989e3fbba26569cbb0e31f5b303c184e3dd33dae"
 
 [[package]]
 name = "futures-test"
-version = "0.3.12"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b30f48f6b9cd26d8739965d6e3345c511718884fb223795b80dc71d24a9ea9a"
+checksum = "2e771858b95154d86bc76b412e4cea3bc104803a7838179e5a1315d9c8a4c2b6"
 dependencies = [
  "futures-core",
  "futures-executor",
  "futures-io",
+ "futures-macro",
  "futures-sink",
  "futures-task",
  "futures-util",
- "once_cell",
- "pin-project 1.0.5",
+ "pin-project 1.0.7",
  "pin-utils",
 ]
 
@@ -1702,11 +1601,12 @@ dependencies = [
 
 [[package]]
 name = "futures-util"
-version = "0.3.12"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "632a8cd0f2a4b3fdea1657f08bde063848c3bd00f9bbf6e256b8be78802e624b"
+checksum = "feb5c238d27e2bf94ffdfd27b2c29e3df4a68c4193bb6427384259e2bf191967"
 dependencies = [
- "futures 0.1.30",
+ "autocfg 1.0.1",
+ "futures 0.1.31",
  "futures-channel",
  "futures-core",
  "futures-io",
@@ -1714,7 +1614,7 @@ dependencies = [
  "futures-sink",
  "futures-task",
  "memchr",
- "pin-project-lite 0.2.4",
+ "pin-project-lite 0.2.7",
  "pin-utils",
  "proc-macro-hack",
  "proc-macro-nested",
@@ -1744,21 +1644,12 @@ checksum = "8f5f3913fa0bfe7ee1fd8248b6b9f42a5af4b9d65ec2dd2c3c26132b950ecfc2"
 
 [[package]]
 name = "generic-array"
-version = "0.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c68f0274ae0e023facc3c97b2e00f076be70e254bc851d972503b328db79b2ec"
-dependencies = [
- "typenum",
-]
-
-[[package]]
-name = "generic-array"
 version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "501466ecc8a30d1d3b7fc9229b122b2ce8ed6e9d9223f1138d4babb253e51817"
 dependencies = [
  "typenum",
- "version_check 0.9.2",
+ "version_check 0.9.3",
 ]
 
 [[package]]
@@ -1796,9 +1687,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9495705279e7140bf035dde1f6e750c162df8b625267cd52cc44e0b156732c8"
+checksum = "7fcd999463524c52659517fe2cea98493cfe485d10565e7b0fb07dbba7ad2753"
 dependencies = [
  "cfg-if 1.0.0",
  "libc",
@@ -1811,7 +1702,7 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97304e4cd182c3846f7575ced3890c53012ce534ad9114046b0a9e00bb30a375"
 dependencies = [
- "opaque-debug 0.3.0",
+ "opaque-debug",
  "polyval 0.4.5",
 ]
 
@@ -1821,15 +1712,15 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7bbd60caa311237d508927dbba7594b483db3ef05faa55172fcf89b1bcda7853"
 dependencies = [
- "opaque-debug 0.3.0",
+ "opaque-debug",
  "polyval 0.5.1",
 ]
 
 [[package]]
 name = "gimli"
-version = "0.23.0"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6503fe142514ca4799d4c26297c4248239fe8838d827db6bd6065c6ed29a6ce"
+checksum = "0e4075386626662786ddb0ec9081e7c7eeb1ba31951f447ca780ef9f5d568189"
 
 [[package]]
 name = "git2"
@@ -1874,24 +1765,24 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.9.1"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7afe4a420e3fe79967a00898cc1f4db7c8a49a9333a29f8a4bd76a253d5cd04"
+checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
 
 [[package]]
 name = "heck"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87cbf45460356b7deeb5e3415b5563308c0a9b057c85e12b06ad551f98d0a6ac"
+checksum = "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c"
 dependencies = [
  "unicode-segmentation",
 ]
 
 [[package]]
 name = "hermit-abi"
-version = "0.1.18"
+version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "322f4de77956e22ed0e5032c359a0f1273f1f7f0d79bfa3b8ffbc730d7fbcc5c"
+checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
 dependencies = [
  "libc",
 ]
@@ -1904,15 +1795,15 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hex-literal"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5af1f635ef1bc545d78392b136bfe1c9809e029023c84a3638a864a10b8819c8"
+checksum = "76505e26b6ca3bbdbbb360b68472abbb80998c5fa5dc43672eca34f28258e138"
 
 [[package]]
 name = "http"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7245cd7449cc792608c3c8a9eaf69bd4eabbabf802713748fd739c98b82f0747"
+checksum = "527e8c9ac747e28542699a951517aa9a6945af506cd1f2e1b53a576c17b6cc11"
 dependencies = [
  "bytes 1.0.1",
  "fnv",
@@ -1991,7 +1882,7 @@ dependencies = [
  "httparse",
  "httpdate",
  "itoa",
- "pin-project 1.0.5",
+ "pin-project 1.0.7",
  "socket2",
  "tokio",
  "tower-service",
@@ -2031,9 +1922,9 @@ dependencies = [
 
 [[package]]
 name = "idna"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89829a5d69c23d348314a7ac337fe39173b61149a9864deabd260983aed48c21"
+checksum = "418a0a6fab821475f634efe3ccc45c013f742efe03d853e8d3355d5cb850ecf8"
 dependencies = [
  "matches",
  "unicode-bidi",
@@ -2042,9 +1933,9 @@ dependencies = [
 
 [[package]]
 name = "image"
-version = "0.23.13"
+version = "0.23.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "293f07a1875fa7e9c5897b51aa68b2d8ed8271b87e1a44cb64b9c3d98aabbc0d"
+checksum = "24ffcb7e7244a9bf19d35bf2883b9c080c4ced3c07a9895572178cdb8f13f6a1"
 dependencies = [
  "bytemuck",
  "byteorder",
@@ -2056,9 +1947,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "1.6.1"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fb1fa934250de4de8aef298d81c729a7d33d8c239daa3a7575e6b92bfc7313b"
+checksum = "bc633605454125dec4b66843673f01c7df2b89479b32e0ed634e43a91cff62a5"
 dependencies = [
  "autocfg 1.0.1",
  "hashbrown",
@@ -2075,9 +1966,9 @@ dependencies = [
 
 [[package]]
 name = "ipnet"
-version = "2.3.0"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47be2f14c678be2fdcab04ab1171db51b2762ce6f0a8ee87c8dd4a04ed216135"
+checksum = "68f2d64f2edebec4ce84ad108148e67e1064789bee435edc5b60ad398714a3a9"
 
 [[package]]
 name = "itertools"
@@ -2096,9 +1987,9 @@ checksum = "dd25036021b0de88a0aff6b850051563c6516d0bf53f8638938edbb9de732736"
 
 [[package]]
 name = "js-sys"
-version = "0.3.47"
+version = "0.3.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cfb73131c35423a367daf8cbd24100af0d077668c8c2943f0e7dd775fef0f65"
+checksum = "83bdfbace3a0e81a4253f73b49e960b053e396a11012cbd49b9b74d6a2b67062"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -2113,15 +2004,6 @@ dependencies = [
  "serde 1.0.126",
  "serde_derive",
  "serde_json",
-]
-
-[[package]]
-name = "k12"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b30ee8519cea318b5b6796063dda942efd4e3bcabf4a412598f3d96cf990f9d"
-dependencies = [
- "digest 0.9.0",
 ]
 
 [[package]]
@@ -2169,9 +2051,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.86"
+version = "0.2.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7282d924be3275cec7f6756ff4121987bc6481325397dde6ba3e7802b1a8b1c"
+checksum = "12b8adadd720df158f4d70dfe7ccc6adb0472d7c55ca83445f6a5ab3e36f8fb6"
 
 [[package]]
 name = "libgit2-sys"
@@ -2200,9 +2082,9 @@ dependencies = [
 
 [[package]]
 name = "libloading"
-version = "0.6.7"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "351a32417a12d5f7e82c368a66781e307834dae04c6ce0cd4456d52989229883"
+checksum = "6f84d96438c15fcd6c3f244c8fce01d1e2b9c6b5623e9c711dc9286d8fc92d6a"
 dependencies = [
  "cfg-if 1.0.0",
  "winapi 0.3.9",
@@ -2222,9 +2104,9 @@ checksum = "c7d73b3f436185384286bd8098d17ec07c9a7d2388a6599f824d8502b529702a"
 
 [[package]]
 name = "libsqlite3-sys"
-version = "0.18.0"
+version = "0.22.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e704a02bcaecd4a08b93a23f6be59d0bd79cd161e0963e9499165a0a35df7bd"
+checksum = "290b64917f8b0cb885d9de0f9959fe1f775d7fa12f1da2db9001c1c8ab60f89d"
 dependencies = [
  "pkg-config",
  "vcpkg",
@@ -2246,9 +2128,9 @@ dependencies = [
 
 [[package]]
 name = "libz-sys"
-version = "1.1.2"
+version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "602113192b08db8f38796c4e85c39e960c145965140e918018bcde1952429655"
+checksum = "de5435b8549c16d423ed0c03dbaafe57cf6c3344744f1242520d59c9d8ecec66"
 dependencies = [
  "cc",
  "libc",
@@ -2365,35 +2247,35 @@ version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b5a279bb9607f9f53c22d496eade00d138d1bdcccd07d74650387cf94942a15"
 dependencies = [
- "block-buffer 0.9.0",
- "digest 0.9.0",
- "opaque-debug 0.3.0",
+ "block-buffer",
+ "digest",
+ "opaque-debug",
 ]
 
 [[package]]
 name = "memchr"
-version = "2.3.4"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ee1c47aaa256ecabcaea351eae4a9b01ef39ed810004e298d2511ed284b1525"
+checksum = "b16bd47d9e329435e309c58469fe0791c2d0d1ba96ec0954152a5ae2b04387dc"
 
 [[package]]
 name = "memoffset"
-version = "0.6.1"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "157b4208e3059a8f9e78d559edc658e13df41410cb3ae03979c83130067fdd87"
+checksum = "59accc507f1338036a0477ef61afdae33cde60840f4dfe481319ce3ad116ddf9"
 dependencies = [
  "autocfg 1.0.1",
 ]
 
 [[package]]
 name = "merlin"
-version = "2.0.1"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e261cf0f8b3c42ded9f7d2bb59dea03aa52bc8a1cbc7482f9fc3fd1229d3b42"
+checksum = "58c38e2799fc0978b65dfff8023ec7843e2330bb462f19198840b34b6582397d"
 dependencies = [
  "byteorder",
  "keccak",
- "rand_core 0.5.1",
+ "rand_core 0.6.3",
  "zeroize",
 ]
 
@@ -2413,9 +2295,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9753f12909fd8d923f75ae5c3258cae1ed3c8ec052e1b38c93c21a6d157f789c"
 dependencies = [
  "migrations_internals",
- "proc-macro2 1.0.24",
+ "proc-macro2 1.0.27",
  "quote 1.0.9",
- "syn 1.0.67",
+ "syn 1.0.73",
 ]
 
 [[package]]
@@ -2445,9 +2327,9 @@ dependencies = [
 
 [[package]]
 name = "miniz_oxide"
-version = "0.4.3"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f2d26ec3309788e423cfbf68ad1800f061638098d76a83681af979dc4eda19d"
+checksum = "a92518e98c078586bc6c934028adcca4c92a53d6a958196de835170a01d84e4b"
 dependencies = [
  "adler",
  "autocfg 1.0.1",
@@ -2474,13 +2356,13 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.7.8"
+version = "0.7.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc250d6848c90d719ea2ce34546fb5df7af1d3fd189d10bf7bad80bfcebecd95"
+checksum = "8c2bdb6314ec10835cd3293dd268473a835c02b7b352e788be788b3c6ca6bb16"
 dependencies = [
  "libc",
  "log 0.4.14",
- "miow 0.3.6",
+ "miow 0.3.7",
  "ntapi",
  "winapi 0.3.9",
 ]
@@ -2510,11 +2392,10 @@ dependencies = [
 
 [[package]]
 name = "miow"
-version = "0.3.6"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a33c1b55807fbed163481b5ba66db4b2fa6cde694a5027be10fb724206c5897"
+checksum = "b9f1c5b025cda876f66ef43a113f91ebc9f4ccef34843000e0adf6ebbab84e21"
 dependencies = [
- "socket2",
  "winapi 0.3.9",
 ]
 
@@ -2525,7 +2406,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a7038b6ba92588189248fbb4f8b2744d4918a9732f826e414814a50c168dca3"
 dependencies = [
  "base58-monero",
- "curve25519-dalek 3.1.0",
+ "curve25519-dalek",
  "fixed-hash",
  "hex",
  "hex-literal",
@@ -2541,30 +2422,30 @@ version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4dac63698b887d2d929306ea48b63760431ff8a24fac40ddb22f9c7f49fb7cab"
 dependencies = [
- "generic-array 0.14.4",
+ "generic-array",
  "multihash-derive",
  "unsigned-varint 0.5.1",
 ]
 
 [[package]]
 name = "multihash-derive"
-version = "0.7.1"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85ee3c48cb9d9b275ad967a0e96715badc13c6029adb92f34fa17b9ff28fd81f"
+checksum = "424f6e86263cd5294cbd7f1e95746b95aca0e0d66bff31e5a40d6baa87b4aa99"
 dependencies = [
  "proc-macro-crate",
  "proc-macro-error",
- "proc-macro2 1.0.24",
+ "proc-macro2 1.0.27",
  "quote 1.0.9",
- "syn 1.0.67",
+ "syn 1.0.73",
  "synstructure",
 ]
 
 [[package]]
 name = "multimap"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1255076139a83bb467426e7f8d0134968a8118844faa755985e077cf31850333"
+checksum = "e5ce46fe64a9d73be07dcbe690a38ce1b293be448fd8ce1e6c1b8062c9f72c6a"
 
 [[package]]
 name = "native-tls"
@@ -2648,7 +2529,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ffb4262d26ed83a1c0a33a38fe2bb15797329c85770da05e6b828ddb782627af"
 dependencies = [
  "memchr",
- "version_check 0.9.2",
+ "version_check 0.9.3",
 ]
 
 [[package]]
@@ -2666,7 +2547,7 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b7a8e9be5e039e2ff869df49155f1c06bd01ade2117ec783e56ab0932b67a8f"
 dependencies = [
- "num-bigint 0.3.1",
+ "num-bigint 0.3.2",
  "num-complex",
  "num-integer",
  "num-iter",
@@ -2687,9 +2568,9 @@ dependencies = [
 
 [[package]]
 name = "num-bigint"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e9a41747ae4633fce5adffb4d2e81ffc5e89593cb19917f8fb2cc5ff76507bf"
+checksum = "7d0a3d5e207573f948a9e5376662aa743a2ea13f7c50a554d7af443a73fbfeba"
 dependencies = [
  "autocfg 1.0.1",
  "num-integer",
@@ -2730,9 +2611,9 @@ version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "876a53fff98e03a936a674b29568b0e605f06b29372c2489ff4de23f1949743d"
 dependencies = [
- "proc-macro2 1.0.24",
+ "proc-macro2 1.0.27",
  "quote 1.0.9",
- "syn 1.0.67",
+ "syn 1.0.73",
 ]
 
 [[package]]
@@ -2741,7 +2622,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bafe4179722c2894288ee77a9f044f02811c86af699344c498b0840c698a2465"
 dependencies = [
- "arrayvec 0.4.12",
+ "arrayvec",
  "itoa",
 ]
 
@@ -2773,7 +2654,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "12ac428b1cb17fce6f731001d307d351ec70a6d202fc2e60f7d4c5e42d8f4f07"
 dependencies = [
  "autocfg 1.0.1",
- "num-bigint 0.3.1",
+ "num-bigint 0.3.2",
  "num-integer",
  "num-traits 0.2.14",
 ]
@@ -2808,21 +2689,18 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.23.0"
+version = "0.25.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9a7ab5d64814df0fe4a4b5ead45ed6c5f181ee3ff04ba344313a6c80446c5d4"
+checksum = "a38f2be3697a57b4060074ff41b44c16870d916ad7877c17696e063257482bc7"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "once_cell"
-version = "1.5.2"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13bd41f508810a131401606d54ac32a467c97172d74ba7662562ebba5ad07fa0"
-
-[[package]]
-name = "opaque-debug"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2839e79665f131bdb5782e51f2c6c9599c133c6098982a54c794358bf432529c"
+checksum = "692fcb63b64b1758029e0a96ee63e049ce8c5948587f2f7208df04625e5f6b56"
 
 [[package]]
 name = "opaque-debug"
@@ -2832,29 +2710,29 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "openssl"
-version = "0.10.32"
+version = "0.10.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "038d43985d1ddca7a9900630d8cd031b56e4794eecc2e9ea39dd17aa04399a70"
+checksum = "549430950c79ae24e6d02e0b7404534ecf311d94cc9f861e9e4020187d13d885"
 dependencies = [
  "bitflags 1.2.1",
  "cfg-if 1.0.0",
  "foreign-types",
- "lazy_static 1.4.0",
  "libc",
+ "once_cell",
  "openssl-sys",
 ]
 
 [[package]]
 name = "openssl-probe"
-version = "0.1.2"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77af24da69f9d9341038eba93a073b1fdaaa1b788221b00a69bce9e762cb32de"
+checksum = "28988d872ab76095a6e6ac88d99b54fd267702734fd7ffe610ca27f533ddb95a"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.60"
+version = "0.9.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "921fc71883267538946025deffb622905ecad223c28efbfdef9bb59a0175f3e6"
+checksum = "7a7907e3bfa08bb85105209cdfcb6c63d109f8f6c1ed6ca318fff5c1853fbc1d"
 dependencies = [
  "autocfg 1.0.1",
  "cc",
@@ -2874,9 +2752,9 @@ dependencies = [
 
 [[package]]
 name = "packed_simd_2"
-version = "0.3.4"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3278e0492f961fd4ae70909f56b2723a7e8d01a228427294e19cdfdebda89a17"
+checksum = "0e64858a2d3733fdd61adfdd6da89aa202f7ff0e741d2fc7ed1e452ba9dc99d7"
 dependencies = [
  "cfg-if 0.1.10",
  "libm 0.1.4",
@@ -2897,7 +2775,7 @@ dependencies = [
  "serde 1.0.126",
  "static_assertions",
  "unsigned-varint 0.6.0",
- "url 2.2.1",
+ "url 2.2.2",
 ]
 
 [[package]]
@@ -2988,7 +2866,7 @@ dependencies = [
  "base64 0.12.3",
  "bitfield",
  "block-modes",
- "block-padding 0.2.1",
+ "block-padding",
  "blowfish",
  "buf_redux",
  "byteorder",
@@ -3000,10 +2878,10 @@ dependencies = [
  "crc24",
  "derive_builder",
  "des",
- "digest 0.9.0",
+ "digest",
  "ed25519-dalek",
  "flate2",
- "generic-array 0.14.4",
+ "generic-array",
  "hex",
  "lazy_static 1.4.0",
  "log 0.4.14",
@@ -3016,8 +2894,8 @@ dependencies = [
  "ripemd160",
  "rsa",
  "sha-1",
- "sha2 0.9.5",
- "sha3 0.9.1",
+ "sha2",
+ "sha3",
  "signature",
  "smallvec",
  "thiserror",
@@ -3029,55 +2907,55 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "0.4.27"
+version = "0.4.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ffbc8e94b38ea3d2d8ba92aea2983b503cd75d0888d75b86bb37970b5698e15"
+checksum = "918192b5c59119d51e0cd221f4d49dde9112824ba717369e903c97d076083d0f"
 dependencies = [
- "pin-project-internal 0.4.27",
+ "pin-project-internal 0.4.28",
 ]
 
 [[package]]
 name = "pin-project"
-version = "1.0.5"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96fa8ebb90271c4477f144354485b8068bd8f6b78b428b01ba892ca26caf0b63"
+checksum = "c7509cc106041c40a4518d2af7a61530e1eed0e6285296a3d8c5472806ccc4a4"
 dependencies = [
- "pin-project-internal 1.0.5",
+ "pin-project-internal 1.0.7",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "0.4.27"
+version = "0.4.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65ad2ae56b6abe3a1ee25f15ee605bacadb9a764edaba9c2bf4103800d4a1895"
+checksum = "3be26700300be6d9d23264c73211d8190e755b6b5ca7a1b28230025511b52a5e"
 dependencies = [
- "proc-macro2 1.0.24",
+ "proc-macro2 1.0.27",
  "quote 1.0.9",
- "syn 1.0.67",
+ "syn 1.0.73",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.0.5"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "758669ae3558c6f74bd2a18b41f7ac0b5a195aea6639d6a9b5e5d1ad5ba24c0b"
+checksum = "48c950132583b500556b1efd71d45b319029f2b71518d979fcc208e16b42426f"
 dependencies = [
- "proc-macro2 1.0.24",
+ "proc-macro2 1.0.27",
  "quote 1.0.9",
- "syn 1.0.67",
+ "syn 1.0.73",
 ]
 
 [[package]]
 name = "pin-project-lite"
-version = "0.1.11"
+version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c917123afa01924fc84bb20c4c03f004d9c38e5127e3c039bbf7f4b9c76a2f6b"
+checksum = "257b64915a082f7811703966789728173279bdebb956b143dbcd23f6f970a777"
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.4"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "439697af366c49a6d0a010c56a0d97685bc140ce0d377b13a2ea2aa42d64a827"
+checksum = "8d31d11c69a6b52a174b42bdc0c30e5e11670f90788b2c471c31c1d17d449443"
 
 [[package]]
 name = "pin-utils"
@@ -3098,7 +2976,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fe800695325da85083cd23b56826fccb2e2dc29b218e7811a6f33bc93f414be"
 dependencies = [
  "cpufeatures",
- "opaque-debug 0.3.0",
+ "opaque-debug",
  "universal-hash",
 ]
 
@@ -3109,7 +2987,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eebcc4aa140b9abd2bc40d9c3f7ccec842679cd79045ac3a7ac698c1a064b7cd"
 dependencies = [
  "cpuid-bool",
- "opaque-debug 0.3.0",
+ "opaque-debug",
  "universal-hash",
 ]
 
@@ -3121,7 +2999,7 @@ checksum = "e597450cbf209787f0e6de80bf3795c6b2356a380ee87837b545aded8dbc1823"
 dependencies = [
  "cfg-if 1.0.0",
  "cpufeatures",
- "opaque-debug 0.3.0",
+ "opaque-debug",
  "universal-hash",
 ]
 
@@ -3133,10 +3011,11 @@ checksum = "ac74c624d6b2d21f425f752262f42188365d7b8ff1aff74c82e45136510a4857"
 
 [[package]]
 name = "proc-macro-crate"
-version = "0.1.5"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d6ea3c4595b96363c13943497db34af4460fb474a95c43f4446ad341b8c9785"
+checksum = "41fdbd1df62156fbc5945f4762632564d7d038153091c3fcf1067f6aef7cff92"
 dependencies = [
+ "thiserror",
  "toml 0.5.8",
 ]
 
@@ -3147,10 +3026,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
 dependencies = [
  "proc-macro-error-attr",
- "proc-macro2 1.0.24",
+ "proc-macro2 1.0.27",
  "quote 1.0.9",
- "syn 1.0.67",
- "version_check 0.9.2",
+ "syn 1.0.73",
+ "version_check 0.9.3",
 ]
 
 [[package]]
@@ -3159,9 +3038,9 @@ version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
 dependencies = [
- "proc-macro2 1.0.24",
+ "proc-macro2 1.0.27",
  "quote 1.0.9",
- "version_check 0.9.2",
+ "version_check 0.9.3",
 ]
 
 [[package]]
@@ -3187,11 +3066,11 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.24"
+version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e0704ee1a7e00d7bb417d0770ea303c1bccbabf0ef1667dae92b5967f5f8a71"
+checksum = "f0d8caf72986c1a598726adc988bb5984792ef84f5ee5aa50209145ee8077038"
 dependencies = [
- "unicode-xid 0.2.1",
+ "unicode-xid 0.2.2",
 ]
 
 [[package]]
@@ -3230,9 +3109,9 @@ checksum = "537aa19b95acde10a12fec4301466386f757403de4cd4e5b4fa78fb5ecb18f72"
 dependencies = [
  "anyhow",
  "itertools",
- "proc-macro2 1.0.24",
+ "proc-macro2 1.0.27",
  "quote 1.0.9",
- "syn 1.0.67",
+ "syn 1.0.73",
 ]
 
 [[package]]
@@ -3282,7 +3161,7 @@ version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d0b9745dc2debf507c8422de05d7226cc1f0644216dfdfead988f9b1ab32a7"
 dependencies = [
- "proc-macro2 1.0.24",
+ "proc-macro2 1.0.27",
 ]
 
 [[package]]
@@ -3293,19 +3172,6 @@ checksum = "3d3681b28cd95acfb0560ea9441f82d6a4504fa3b15b97bd7b6e952131820e95"
 dependencies = [
  "endian-type",
  "nibble_vec",
-]
-
-[[package]]
-name = "rand"
-version = "0.5.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c618c47cd3ebd209790115ab837de41425723956ad3ce2e6a7f09890947cacb9"
-dependencies = [
- "cloudabi",
- "fuchsia-cprng",
- "libc",
- "rand_core 0.3.1",
- "winapi 0.3.9",
 ]
 
 [[package]]
@@ -3324,14 +3190,14 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ef9e7e66b4468674bfcb0c81af8b7fa0bb154fa9f28eb840da5c447baeb8d7e"
+checksum = "2e7573632e6454cf6b99d7aac4ccca54be06da05aca2ef7423d22d27d4d4bcd8"
 dependencies = [
  "libc",
- "rand_chacha 0.3.0",
- "rand_core 0.6.2",
- "rand_hc 0.3.0",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.3",
+ "rand_hc 0.3.1",
 ]
 
 [[package]]
@@ -3346,12 +3212,12 @@ dependencies = [
 
 [[package]]
 name = "rand_chacha"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e12735cf05c9e10bf21534da50a147b924d555dc7a547c42e6bb2d5b6017ae0d"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core 0.6.2",
+ "rand_core 0.6.3",
 ]
 
 [[package]]
@@ -3380,11 +3246,11 @@ dependencies = [
 
 [[package]]
 name = "rand_core"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34cf66eb183df1c5876e2dcf6b13d57340741e8dc255b48e40a26de954d06ae7"
+checksum = "d34f1408f55294453790c48b2f1ebbb1c5b4b7563eb1f418bcfcfdbb06ebb4e7"
 dependencies = [
- "getrandom 0.2.2",
+ "getrandom 0.2.3",
 ]
 
 [[package]]
@@ -3398,11 +3264,11 @@ dependencies = [
 
 [[package]]
 name = "rand_hc"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3190ef7066a446f2e7f42e239d161e905420ccab01eb967c9eb27d21b2322a73"
+checksum = "d51e9f596de227fda2ea6c84607f5558e196eeaf43c986b724ba4fb8fdf497e7"
 dependencies = [
- "rand_core 0.6.2",
+ "rand_core 0.6.3",
 ]
 
 [[package]]
@@ -3452,9 +3318,9 @@ dependencies = [
 
 [[package]]
 name = "rayon"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b0d8e0819fadc20c74ea8373106ead0600e3a67ef1fe8da56e39b9ae7275674"
+checksum = "c06aca804d41dbc8ba42dfd964f0d01334eceb64314b9ecf7c5fad5188a06d90"
 dependencies = [
  "autocfg 1.0.1",
  "crossbeam-deque",
@@ -3464,13 +3330,13 @@ dependencies = [
 
 [[package]]
 name = "rayon-core"
-version = "1.9.0"
+version = "1.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ab346ac5921dc62ffa9f89b7a773907511cdfa5490c572ae9be1be33e8afa4a"
+checksum = "d78120e2c850279833f1dd3582f730c4ab53ed95aeaaaa862a2a5c71b1656d8e"
 dependencies = [
- "crossbeam-channel 0.5.0",
+ "crossbeam-channel 0.5.1",
  "crossbeam-deque",
- "crossbeam-utils 0.8.1",
+ "crossbeam-utils 0.8.5",
  "lazy_static 1.4.0",
  "num_cpus",
 ]
@@ -3492,9 +3358,9 @@ checksum = "41cc0f7e4d5d4544e8861606a285bb08d3e70712ccc7d2b84d7c0ccfaf4b05ce"
 
 [[package]]
 name = "redox_syscall"
-version = "0.2.5"
+version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94341e4e44e24f6b591b59e47a8a027df12e008d73fd5672dbea9cc22f4507d9"
+checksum = "5ab49abadf3f9e1c4bc499e8845e152ad87d2ad2d30371841171169e9d75feee"
 dependencies = [
  "bitflags 1.2.1",
 ]
@@ -3505,37 +3371,35 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "528532f3d801c87aec9def2add9ca802fe569e44a544afe633765267840abe64"
 dependencies = [
- "getrandom 0.2.2",
- "redox_syscall 0.2.5",
+ "getrandom 0.2.3",
+ "redox_syscall 0.2.9",
 ]
 
 [[package]]
 name = "regex"
-version = "1.4.3"
+version = "1.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9251239e129e16308e70d853559389de218ac275b515068abc96829d05b948a"
+checksum = "d07a8629359eb56f1e2fb1652bb04212c072a87ba68546a04065d525673ac461"
 dependencies = [
  "aho-corasick",
  "memchr",
  "regex-syntax",
- "thread_local",
 ]
 
 [[package]]
 name = "regex-automata"
-version = "0.1.9"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae1ded71d66a4a97f5e961fd0cb25a5f366a42a41570d16a763a69c092c26ae4"
+checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
 dependencies = [
- "byteorder",
  "regex-syntax",
 ]
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.22"
+version = "0.6.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5eb417147ba9860a96cfe72a0b93bf88fee1744b5636ec99ab20c1aa9376581"
+checksum = "f497285884f3fcff424ffc933e56d7cbca511def0c9831a7f9b5f6153e3cc89b"
 
 [[package]]
 name = "remove_dir_all"
@@ -3569,13 +3433,13 @@ dependencies = [
  "mime_guess",
  "native-tls",
  "percent-encoding 2.1.0",
- "pin-project-lite 0.2.4",
+ "pin-project-lite 0.2.7",
  "serde 1.0.126",
  "serde_json",
  "serde_urlencoded",
  "tokio",
  "tokio-tls",
- "url 2.2.1",
+ "url 2.2.2",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
@@ -3603,9 +3467,9 @@ version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2eca4ecc81b7f313189bf73ce724400a07da2a6dac19588b03c8bd76a2dcc251"
 dependencies = [
- "block-buffer 0.9.0",
- "digest 0.9.0",
- "opaque-debug 0.3.0",
+ "block-buffer",
+ "digest",
+ "opaque-debug",
 ]
 
 [[package]]
@@ -3646,7 +3510,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3648b669b10afeab18972c105e284a7b953a669b0be3514c27f9b17acab2f9cd"
 dependencies = [
  "byteorder",
- "digest 0.9.0",
+ "digest",
  "lazy_static 1.4.0",
  "num-bigint-dig",
  "num-integer",
@@ -3654,9 +3518,9 @@ dependencies = [
  "num-traits 0.2.14",
  "pem",
  "rand 0.7.3",
- "sha2 0.9.5",
+ "sha2",
  "simple_asn1",
- "subtle 2.4.0",
+ "subtle",
  "thiserror",
  "zeroize",
 ]
@@ -3669,9 +3533,9 @@ checksum = "3e52c148ef37f8c375d49d5a73aa70713125b7f19095948a923f80afdeb22ec2"
 
 [[package]]
 name = "rustc-demangle"
-version = "0.1.18"
+version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e3bad0ee36814ca07d7968269dd4b7ec89ec2da10c4bb613928d3077083c232"
+checksum = "dead70b0b5e03e9c814bcb6b01e03e68f7c57a80aa48c72ec92152ab3e818d49"
 
 [[package]]
 name = "rustc-hash"
@@ -3687,20 +3551,20 @@ checksum = "3e75f6a532d0fd9f7f13144f392b6ad56a32696bfcd9c78f797f16bbb6f072d6"
 
 [[package]]
 name = "rustc_version"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
-dependencies = [
- "semver 0.9.0",
-]
-
-[[package]]
-name = "rustc_version"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0dfe2087c51c460008730de8b57e6a320782fbfb312e1f4d520e6c6fae155ee"
 dependencies = [
  "semver 0.11.0",
+]
+
+[[package]]
+name = "rustc_version"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
+dependencies = [
+ "semver 1.0.3",
 ]
 
 [[package]]
@@ -3742,7 +3606,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "54a50e29610a5be68d4a586a5cce3bfb572ed2c2a74227e4168444b7bf4e5235"
 dependencies = [
  "quote 1.0.9",
- "syn 1.0.67",
+ "syn 1.0.73",
 ]
 
 [[package]]
@@ -3790,9 +3654,9 @@ checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "sct"
-version = "0.6.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3042af939fca8c3453b7af0f1c66e533a15a86169e39de2657310ade8f98d3c"
+checksum = "b362b83898e0e69f38515b82ee15aa80636befe47c3b6d3d89a911e78fc228ce"
 dependencies = [
  "ring",
  "untrusted",
@@ -3800,9 +3664,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework"
-version = "2.0.0"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1759c2e3c8580017a484a7ac56d3abc5a6c1feadf88db2f3633f12ae4268c69"
+checksum = "23a2ac85147a3a11d77ecf1bc7166ec0b92febfa4461c37944e180f319ece467"
 dependencies = [
  "bitflags 1.2.1",
  "core-foundation",
@@ -3813,21 +3677,12 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.0.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f99b9d5e26d2a71633cc4f2ebae7cc9f874044e0c351a27e17892d76dce5678b"
+checksum = "7e4effb91b4b8b6fb7732e670b6cee160278ff8e6bf485c7805d9e319d76e284"
 dependencies = [
  "core-foundation-sys",
  "libc",
-]
-
-[[package]]
-name = "semver"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
-dependencies = [
- "semver-parser 0.7.0",
 ]
 
 [[package]]
@@ -3836,7 +3691,7 @@ version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f301af10236f6df4160f7c3f04eec6dbc70ace82d23326abad5edee88801c6b6"
 dependencies = [
- "semver-parser 0.10.2",
+ "semver-parser",
 ]
 
 [[package]]
@@ -3844,12 +3699,6 @@ name = "semver"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f3aac57ee7f3272d8395c6e4f502f434f0e289fcd62876f70daa008c20dcabe"
-
-[[package]]
-name = "semver-parser"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "semver-parser"
@@ -3914,16 +3763,16 @@ version = "1.0.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "963a7dbc9895aeac7ac90e74f34a5d5261828f79df35cbed41e10189d3804d43"
 dependencies = [
- "proc-macro2 1.0.24",
+ "proc-macro2 1.0.27",
  "quote 1.0.9",
- "syn 1.0.67",
+ "syn 1.0.73",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.62"
+version = "1.0.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea1c6153794552ea7cf7cf63b1231a25de00ec90db326ba6264440fa08e31486"
+checksum = "799e97dc9fdae36a5c8b8f2cae9ce2ee9fdce2058c57a93e6099d919fd982f79"
 dependencies = [
  "itoa",
  "ryu",
@@ -3932,13 +3781,13 @@ dependencies = [
 
 [[package]]
 name = "serde_repr"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dc6b7951b17b051f3210b063f12cc17320e2fe30ae05b0fe2a3abb068551c76"
+checksum = "98d0516900518c29efa217c298fa1f4e6c6ffc85ae29fd7f4ee48f176e1a9ed5"
 dependencies = [
- "proc-macro2 1.0.24",
+ "proc-macro2 1.0.27",
  "quote 1.0.9",
- "syn 1.0.67",
+ "syn 1.0.73",
 ]
 
 [[package]]
@@ -3980,23 +3829,11 @@ version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c4cfa741c5832d0ef7fab46cabed29c2aae926db0b11bb2069edd8db5e64e16"
 dependencies = [
- "block-buffer 0.9.0",
+ "block-buffer",
  "cfg-if 1.0.0",
  "cpufeatures",
- "digest 0.9.0",
- "opaque-debug 0.3.0",
-]
-
-[[package]]
-name = "sha2"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a256f46ea78a0c0d9ff00077504903ac881a1dafdc20da66545699e7776b3e69"
-dependencies = [
- "block-buffer 0.7.3",
- "digest 0.8.1",
- "fake-simd",
- "opaque-debug 0.2.3",
+ "digest",
+ "opaque-debug",
 ]
 
 [[package]]
@@ -4005,24 +3842,11 @@ version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b362ae5752fd2137731f9fa25fd4d9058af34666ca1966fb969119cc35719f12"
 dependencies = [
- "block-buffer 0.9.0",
+ "block-buffer",
  "cfg-if 1.0.0",
  "cpufeatures",
- "digest 0.9.0",
- "opaque-debug 0.3.0",
-]
-
-[[package]]
-name = "sha3"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd26bc0e7a2e3a7c959bc494caf58b72ee0c71d67704e9520f736ca7e4853ecf"
-dependencies = [
- "block-buffer 0.7.3",
- "byte-tools",
- "digest 0.8.1",
- "keccak",
- "opaque-debug 0.2.3",
+ "digest",
+ "opaque-debug",
 ]
 
 [[package]]
@@ -4031,10 +3855,10 @@ version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f81199417d4e5de3f04b1e871023acea7389672c4135918f05aa9cbf2f2fa809"
 dependencies = [
- "block-buffer 0.9.0",
- "digest 0.9.0",
+ "block-buffer",
+ "digest",
  "keccak",
- "opaque-debug 0.3.0",
+ "opaque-debug",
 ]
 
 [[package]]
@@ -4059,15 +3883,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e31d442c16f047a671b5a71e2161d6e68814012b7f5379d269ebd915fac2729"
 dependencies = [
  "libc",
- "mio 0.7.8",
+ "mio 0.7.13",
  "signal-hook-registry",
 ]
 
 [[package]]
 name = "signal-hook-registry"
-version = "1.3.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16f1d0fef1604ba8f7a073c7e701f213e056707210e9020af4528e0101ce11a6"
+checksum = "e51e73328dc4ac0c7ccbda3a494dfa03df1de2f46018127f60c693f2648455b0"
 dependencies = [
  "libc",
 ]
@@ -4091,9 +3915,9 @@ dependencies = [
 
 [[package]]
 name = "slab"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c111b5bd5695e56cffe5129854aa230b39c93a305372fdbb2668ca2394eea9f8"
+checksum = "f173ac3d1a7e3b28003f40de0b5ce7fe2710f9b9dc3fc38664cebee46b3b6527"
 
 [[package]]
 name = "smallvec"
@@ -4108,13 +3932,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6142f7c25e94f6fd25a32c3348ec230df9109b463f59c8c7acc4bd34936babb7"
 dependencies = [
  "aes-gcm 0.9.2",
- "blake2 0.9.1",
+ "blake2",
  "chacha20poly1305",
- "rand 0.8.3",
- "rand_core 0.6.2",
+ "rand 0.8.4",
+ "rand_core 0.6.3",
  "rustc_version 0.3.3",
- "sha2 0.9.5",
- "subtle 2.4.0",
+ "sha2",
+ "subtle",
  "x25519-dalek",
 ]
 
@@ -4147,7 +3971,7 @@ version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d62fea0968935ec8eedcf671b2738bf49c58e133db968097c301d32e32eaedf"
 dependencies = [
- "futures 0.1.30",
+ "futures 0.1.31",
 ]
 
 [[package]]
@@ -4157,7 +3981,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c80e15f898d8d8f25db24c253ea615cc14acf418ff307822995814e7d42cfa89"
 dependencies = [
  "block-cipher",
- "generic-array 0.14.4",
+ "generic-array",
 ]
 
 [[package]]
@@ -4174,9 +3998,9 @@ checksum = "6446ced80d6c486436db5c078dde11a9f73d42b57fb273121e160b84f63d894c"
 
 [[package]]
 name = "structopt"
-version = "0.3.21"
+version = "0.3.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5277acd7ee46e63e5168a80734c9f6ee81b1367a7d8772a2d765df2a3705d28c"
+checksum = "69b041cdcb67226aca307e6e7be44c8806423d83e018bd662360a93dabce4d71"
 dependencies = [
  "clap",
  "lazy_static 1.4.0",
@@ -4185,15 +4009,15 @@ dependencies = [
 
 [[package]]
 name = "structopt-derive"
-version = "0.4.14"
+version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ba9cdfda491b814720b6b06e0cac513d922fc407582032e8706e9f137976f90"
+checksum = "7813934aecf5f51a54775e00068c237de98489463968231a51746bbbc03f9c10"
 dependencies = [
  "heck",
  "proc-macro-error",
- "proc-macro2 1.0.24",
+ "proc-macro2 1.0.27",
  "quote 1.0.9",
- "syn 1.0.67",
+ "syn 1.0.73",
 ]
 
 [[package]]
@@ -4209,9 +4033,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e6e163a520367c465f59e0a61a23cfae3b10b6546d78b6f672a382be79f7110"
 dependencies = [
  "heck",
- "proc-macro2 1.0.24",
+ "proc-macro2 1.0.27",
  "quote 1.0.9",
- "syn 1.0.67",
+ "syn 1.0.73",
 ]
 
 [[package]]
@@ -4221,9 +4045,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "87c85aa3f8ea653bfd3ddf25f7ee357ee4d204731f6aa9ad04002306f6e2774c"
 dependencies = [
  "heck",
- "proc-macro2 1.0.24",
+ "proc-macro2 1.0.27",
  "quote 1.0.9",
- "syn 1.0.67",
+ "syn 1.0.73",
 ]
 
 [[package]]
@@ -4233,22 +4057,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e61bb0be289045cb80bfce000512e32d09f8337e54c186725da381377ad1f8d5"
 dependencies = [
  "heck",
- "proc-macro2 1.0.24",
+ "proc-macro2 1.0.27",
  "quote 1.0.9",
- "syn 1.0.67",
+ "syn 1.0.73",
 ]
-
-[[package]]
-name = "subtle"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d67a5a62ba6e01cb2192ff309324cb4875d0c451d55fe2319433abe7a05a8ee"
 
 [[package]]
 name = "subtle"
 version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e81da0851ada1f3e9d4312c704aa4f8806f0f9d69faaf8df2f3464b4a9437c2"
+
+[[package]]
+name = "subtle-ng"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8049cf85f0e715d6af38dde439cb0ccb91f67fb9f5f63c80f8b43e48356e1a3f"
 
 [[package]]
 name = "supercow"
@@ -4280,13 +4104,13 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.67"
+version = "1.0.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6498a9efc342871f91cc2d0d694c674368b4ceb40f62b65a7a08c3792935e702"
+checksum = "f71489ff30030d2ae598524f61326b902466f72a0fb1a8564c001cc63425bcc7"
 dependencies = [
- "proc-macro2 1.0.24",
+ "proc-macro2 1.0.27",
  "quote 1.0.9",
- "unicode-xid 0.2.1",
+ "unicode-xid 0.2.2",
 ]
 
 [[package]]
@@ -4304,10 +4128,10 @@ version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b834f2d66f734cb897113e34aaff2f1ab4719ca946f9a7358dba8f8064148701"
 dependencies = [
- "proc-macro2 1.0.24",
+ "proc-macro2 1.0.27",
  "quote 1.0.9",
- "syn 1.0.67",
- "unicode-xid 0.2.1",
+ "syn 1.0.73",
+ "unicode-xid 0.2.2",
 ]
 
 [[package]]
@@ -4332,10 +4156,10 @@ version = "0.8.11"
 dependencies = [
  "config",
  "dirs-next",
- "futures 0.3.12",
+ "futures 0.3.15",
  "log 0.4.14",
  "qrcode",
- "rand 0.7.3",
+ "rand 0.8.4",
  "serde_json",
  "structopt",
  "strum",
@@ -4359,7 +4183,7 @@ dependencies = [
  "bincode",
  "chrono",
  "config",
- "futures 0.3.12",
+ "futures 0.3.15",
  "log 0.4.14",
  "log4rs",
  "regex",
@@ -4386,21 +4210,21 @@ dependencies = [
 
 [[package]]
 name = "tari_bulletproofs"
-version = "2.1.0"
+version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4b6531abd01ccba175a24e7a72061156524f8f435e1532fe6295254f4c4e5b9"
+checksum = "0c04fe42cf122b2b5a77f1f4e20562e05c422efddb2ede470d7d8988cc2bf3a7"
 dependencies = [
  "byteorder",
  "clear_on_drop",
- "curve25519-dalek 2.1.2",
- "digest 0.8.1",
+ "curve25519-dalek-ng",
+ "digest",
  "merlin",
- "rand 0.7.3",
- "rand_core 0.5.1",
+ "rand 0.8.4",
+ "rand_core 0.6.3",
  "serde 1.0.126",
  "serde_derive",
- "sha3 0.8.2",
- "subtle 2.4.0",
+ "sha3",
+ "subtle-ng",
  "thiserror",
 ]
 
@@ -4420,7 +4244,7 @@ dependencies = [
  "prost-build",
  "serde 1.0.126",
  "serde_json",
- "sha2 0.8.2",
+ "sha2",
  "structopt",
  "tari_storage",
  "tari_test_utils",
@@ -4432,8 +4256,8 @@ dependencies = [
 name = "tari_common_types"
 version = "0.8.11"
 dependencies = [
- "futures 0.3.12",
- "rand 0.7.3",
+ "futures 0.3.15",
+ "rand 0.8.4",
  "serde 1.0.126",
  "tari_crypto",
  "tokio",
@@ -4446,23 +4270,23 @@ dependencies = [
  "anyhow",
  "async-trait",
  "bitflags 1.2.1",
- "blake2 0.8.1",
+ "blake2",
  "bytes 0.5.6",
  "chrono",
  "cidr",
  "clear_on_drop",
  "data-encoding",
- "digest 0.8.1",
+ "digest",
  "env_logger 0.7.1",
- "futures 0.3.12",
+ "futures 0.3.15",
  "lazy_static 1.4.0",
  "lmdb-zero",
  "log 0.4.14",
  "nom 5.1.2",
  "parity-multiaddr",
- "pin-project 0.4.27",
+ "pin-project 0.4.28",
  "prost",
- "rand 0.7.3",
+ "rand 0.8.4",
  "serde 1.0.126",
  "serde_derive",
  "serde_json",
@@ -4494,19 +4318,19 @@ dependencies = [
  "clap",
  "diesel",
  "diesel_migrations",
- "digest 0.8.1",
+ "digest",
  "env_logger 0.7.1",
- "futures 0.3.12",
+ "futures 0.3.15",
  "futures-test-preview",
  "futures-util",
  "lazy_static 1.4.0",
  "lmdb-zero",
  "log 0.4.14",
  "petgraph",
- "pin-project 0.4.27",
+ "pin-project 0.4.28",
  "prost",
  "prost-types",
- "rand 0.7.3",
+ "rand 0.8.4",
  "serde 1.0.126",
  "serde_derive",
  "serde_repr",
@@ -4532,11 +4356,11 @@ dependencies = [
 name = "tari_comms_rpc_macros"
 version = "0.8.11"
 dependencies = [
- "futures 0.3.12",
- "proc-macro2 1.0.24",
+ "futures 0.3.15",
+ "proc-macro2 1.0.27",
  "prost",
  "quote 1.0.9",
- "syn 1.0.67",
+ "syn 1.0.73",
  "tari_comms",
  "tari_test_utils",
  "tokio",
@@ -4552,10 +4376,10 @@ dependencies = [
  "chrono",
  "chrono-english",
  "crossterm",
- "futures 0.3.12",
+ "futures 0.3.15",
  "log 0.4.14",
  "qrcode",
- "rand 0.7.3",
+ "rand 0.8.4",
  "rpassword",
  "rustyline",
  "strum",
@@ -4585,15 +4409,15 @@ version = "0.8.11"
 dependencies = [
  "bincode",
  "bitflags 1.2.1",
- "blake2 0.8.1",
+ "blake2",
  "bytes 0.4.12",
  "chrono",
  "config",
  "croaring",
- "digest 0.8.1",
+ "digest",
  "env_logger 0.7.1",
  "fs2",
- "futures 0.3.12",
+ "futures 0.3.15",
  "hex",
  "lmdb-zero",
  "log 0.4.14",
@@ -4603,11 +4427,11 @@ dependencies = [
  "num-format",
  "prost",
  "prost-types",
- "rand 0.7.3",
+ "rand 0.8.4",
  "randomx-rs",
  "serde 1.0.126",
  "serde_json",
- "sha3 0.9.1",
+ "sha3",
  "strum_macros 0.17.1",
  "tari_common",
  "tari_common_types",
@@ -4631,25 +4455,24 @@ dependencies = [
 
 [[package]]
 name = "tari_crypto"
-version = "0.9.1"
-source = "git+https://github.com/tari-project/tari-crypto.git?rev=ecd77ec2b#ecd77ec2b8484d3e146257654dba28f854ca4410"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30b9ce61aed22e369ec3ad4dae46c0a19858fe29ad8bea03d4632b69be1cb09a"
 dependencies = [
  "base64 0.10.1",
- "blake2 0.8.1",
- "blake3",
+ "blake2",
  "cbindgen",
  "clear_on_drop",
- "curve25519-dalek 2.1.2",
- "digest 0.8.1",
- "k12",
+ "curve25519-dalek-ng",
+ "digest",
  "lazy_static 1.4.0",
  "merlin",
- "rand 0.7.3",
+ "rand 0.8.4",
  "rmp-serde",
  "serde 1.0.126",
  "serde_json",
- "sha2 0.8.2",
- "sha3 0.9.1",
+ "sha2",
+ "sha3",
  "tari_bulletproofs",
  "tari_utilities",
  "thiserror",
@@ -4659,7 +4482,7 @@ dependencies = [
 name = "tari_infra_derive"
 version = "0.8.11"
 dependencies = [
- "blake2 0.8.1",
+ "blake2",
  "proc-macro2 0.4.30",
  "quote 0.6.13",
  "syn 0.15.44",
@@ -4669,12 +4492,12 @@ dependencies = [
 name = "tari_key_manager"
 version = "0.8.11"
 dependencies = [
- "digest 0.8.1",
- "rand 0.7.3",
+ "digest",
+ "rand 0.8.4",
  "serde 1.0.126",
  "serde_derive",
  "serde_json",
- "sha2 0.8.2",
+ "sha2",
  "tari_crypto",
  "thiserror",
 ]
@@ -4690,13 +4513,13 @@ dependencies = [
  "config",
  "derive-error",
  "env_logger 0.7.1",
- "futures 0.3.12",
+ "futures 0.3.15",
  "futures-test",
  "hex",
  "hyper 0.13.10",
  "jsonrpc",
  "log 0.4.14",
- "rand 0.7.3",
+ "rand 0.8.4",
  "reqwest",
  "serde 1.0.126",
  "serde_json",
@@ -4714,7 +4537,7 @@ dependencies = [
  "tracing",
  "tracing-futures",
  "tracing-subscriber",
- "url 2.2.1",
+ "url 2.2.2",
 ]
 
 [[package]]
@@ -4723,13 +4546,13 @@ version = "0.8.11"
 dependencies = [
  "chrono",
  "crossbeam",
- "futures 0.3.12",
+ "futures 0.3.15",
  "log 0.4.14",
  "num_cpus",
  "prost-types",
- "rand 0.7.3",
+ "rand 0.8.4",
  "serde 1.0.126",
- "sha3 0.9.1",
+ "sha3",
  "tari_app_grpc",
  "tari_app_utilities",
  "tari_common",
@@ -4745,12 +4568,12 @@ name = "tari_mmr"
 version = "0.8.11"
 dependencies = [
  "bincode",
- "blake2 0.8.1",
+ "blake2",
  "criterion",
  "croaring",
- "digest 0.8.1",
+ "digest",
  "log 0.4.14",
- "rand 0.7.3",
+ "rand 0.8.4",
  "serde 1.0.126",
  "serde_json",
  "tari_crypto",
@@ -4769,7 +4592,7 @@ dependencies = [
  "clap",
  "env_logger 0.6.2",
  "fs2",
- "futures 0.3.12",
+ "futures 0.3.15",
  "futures-timer",
  "lazy_static 1.4.0",
  "lmdb-zero",
@@ -4777,7 +4600,7 @@ dependencies = [
  "log4rs",
  "pgp",
  "prost",
- "rand 0.7.3",
+ "rand 0.8.4",
  "reqwest",
  "semver 1.0.3",
  "serde 1.0.126",
@@ -4807,7 +4630,7 @@ version = "0.8.11"
 dependencies = [
  "anyhow",
  "async-trait",
- "futures 0.3.12",
+ "futures 0.3.15",
  "futures-test",
  "log 0.4.14",
  "tari_shutdown",
@@ -4823,7 +4646,7 @@ dependencies = [
 name = "tari_shutdown"
 version = "0.8.11"
 dependencies = [
- "futures 0.3.12",
+ "futures 0.3.15",
  "tokio",
 ]
 
@@ -4836,7 +4659,7 @@ dependencies = [
  "env_logger 0.6.2",
  "lmdb-zero",
  "log 0.4.14",
- "rand 0.5.6",
+ "rand 0.8.4",
  "rmp",
  "rmp-serde",
  "serde 1.0.126",
@@ -4849,10 +4672,10 @@ dependencies = [
 name = "tari_test_utils"
 version = "0.8.11"
 dependencies = [
- "futures 0.3.12",
+ "futures 0.3.15",
  "futures-test",
  "lazy_static 1.4.0",
- "rand 0.7.3",
+ "rand 0.8.4",
  "tempfile",
  "tokio",
 ]
@@ -4881,21 +4704,21 @@ version = "0.8.11"
 dependencies = [
  "aes-gcm 0.8.0",
  "bincode",
- "blake2 0.8.1",
+ "blake2",
  "chrono",
  "crossbeam-channel 0.3.9",
  "diesel",
  "diesel_migrations",
- "digest 0.8.1",
+ "digest",
  "env_logger 0.7.1",
  "fs2",
- "futures 0.3.12",
+ "futures 0.3.15",
  "lazy_static 1.4.0",
  "lmdb-zero",
  "log 0.4.14",
  "log4rs",
  "prost",
- "rand 0.7.3",
+ "rand 0.8.4",
  "serde 1.0.126",
  "serde_json",
  "tari_common_types",
@@ -4923,12 +4746,12 @@ version = "0.16.28"
 dependencies = [
  "chrono",
  "env_logger 0.7.1",
- "futures 0.3.12",
+ "futures 0.3.15",
  "lazy_static 1.4.0",
  "libc",
  "log 0.4.14",
  "log4rs",
- "rand 0.7.3",
+ "rand 0.8.4",
  "tari_common_types",
  "tari_comms",
  "tari_comms_dht",
@@ -4937,6 +4760,7 @@ dependencies = [
  "tari_key_manager",
  "tari_p2p",
  "tari_shutdown",
+ "tari_test_utils",
  "tari_utilities",
  "tari_wallet",
  "tempfile",
@@ -4952,8 +4776,8 @@ checksum = "dac1c663cfc93810f88aed9b8941d48cabf856a1b111c29a40439018d870eb22"
 dependencies = [
  "cfg-if 1.0.0",
  "libc",
- "rand 0.8.3",
- "redox_syscall 0.2.5",
+ "rand 0.8.4",
+ "redox_syscall 0.2.9",
  "remove_dir_all",
  "winapi 0.3.9",
 ]
@@ -4971,7 +4795,7 @@ dependencies = [
 name = "test_faucet"
 version = "0.8.11"
 dependencies = [
- "rand 0.7.3",
+ "rand 0.8.4",
  "serde 1.0.126",
  "serde_json",
  "tari_core",
@@ -4991,22 +4815,22 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.24"
+version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0f4a65597094d4483ddaed134f409b2cb7c1beccf25201a9f73c719254fa98e"
+checksum = "93119e4feac1cbe6c798c34d3a53ea0026b0b1de6a120deef895137c0529bfe2"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.24"
+version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7765189610d8241a44529806d6fd1f2e0a08734313a35d5b3a556f92b381f3c0"
+checksum = "060d69a0afe7796bf42e9e2ff91f5ee691fb15c53d38b4b62a9a53eb23164745"
 dependencies = [
- "proc-macro2 1.0.24",
+ "proc-macro2 1.0.27",
  "quote 1.0.9",
- "syn 1.0.67",
+ "syn 1.0.73",
 ]
 
 [[package]]
@@ -5051,9 +4875,9 @@ dependencies = [
 
 [[package]]
 name = "tinytemplate"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2ada8616fad06a2d0c455adc530de4ef57605a8120cc65da9653e0e9623ca74"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
 dependencies = [
  "serde 1.0.126",
  "serde_json",
@@ -5061,9 +4885,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.1.1"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "317cca572a0e89c3ce0ca1f1bdc9369547fe318a683418e42ac8f59d14701023"
+checksum = "5b5220f05bb7de7f3f53c7c065e1199b3172696fe2db9f9c4d8ad9b4ee74c342"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -5090,7 +4914,7 @@ dependencies = [
  "mio 0.6.23",
  "mio-uds",
  "num_cpus",
- "pin-project-lite 0.1.11",
+ "pin-project-lite 0.1.12",
  "signal-hook-registry",
  "slab",
  "tokio-macros",
@@ -5103,9 +4927,9 @@ version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e44da00bfc73a25f814cd8d7e57a68a5c31b74b3152a0a1d1f590c97ed06265a"
 dependencies = [
- "proc-macro2 1.0.24",
+ "proc-macro2 1.0.27",
  "quote 1.0.9",
- "syn 1.0.67",
+ "syn 1.0.73",
 ]
 
 [[package]]
@@ -5139,7 +4963,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "log 0.4.14",
- "pin-project-lite 0.1.11",
+ "pin-project-lite 0.1.12",
  "tokio",
 ]
 
@@ -5153,7 +4977,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "log 0.4.14",
- "pin-project-lite 0.1.11",
+ "pin-project-lite 0.1.12",
  "tokio",
 ]
 
@@ -5191,7 +5015,7 @@ dependencies = [
  "http-body",
  "hyper 0.13.10",
  "percent-encoding 2.1.0",
- "pin-project 0.4.27",
+ "pin-project 0.4.28",
  "prost",
  "prost-derive",
  "tokio",
@@ -5211,10 +5035,10 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71d8d21cb568e802d77055ab7fcd43f0992206de5028de95c8d3a41118d32e8e"
 dependencies = [
- "proc-macro2 1.0.24",
+ "proc-macro2 1.0.27",
  "prost-build",
  "quote 1.0.9",
- "syn 1.0.67",
+ "syn 1.0.73",
 ]
 
 [[package]]
@@ -5244,7 +5068,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "indexmap",
- "pin-project 0.4.27",
+ "pin-project 0.4.28",
  "rand 0.7.3",
  "slab",
  "tokio",
@@ -5264,7 +5088,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4887dc2a65d464c8b9b66e0e4d51c2fd6cf5b3373afc72805b0a60bce00446a"
 dependencies = [
  "futures-core",
- "pin-project 0.4.27",
+ "pin-project 0.4.28",
  "tokio",
  "tower-layer",
  "tower-service",
@@ -5278,7 +5102,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0f6b5000c3c54d269cc695dff28136bb33d08cbf1df2c48129e143ab65bf3c2a"
 dependencies = [
  "futures-core",
- "pin-project 0.4.27",
+ "pin-project 0.4.28",
  "tower-service",
 ]
 
@@ -5295,7 +5119,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92c3040c5dbed68abffaa0d4517ac1a454cd741044f33ab0eefab6b8d1361404"
 dependencies = [
  "futures-core",
- "pin-project 0.4.27",
+ "pin-project 0.4.28",
  "tokio",
  "tower-layer",
  "tower-load",
@@ -5310,7 +5134,7 @@ checksum = "8cc79fc3afd07492b7966d7efa7c6c50f8ed58d768a6075dd7ae6591c5d2017b"
 dependencies = [
  "futures-core",
  "log 0.4.14",
- "pin-project 0.4.27",
+ "pin-project 0.4.28",
  "tokio",
  "tower-discover",
  "tower-service",
@@ -5323,7 +5147,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f021e23900173dc315feb4b6922510dae3e79c689b74c089112066c11f0ae4e"
 dependencies = [
  "futures-core",
- "pin-project 0.4.27",
+ "pin-project 0.4.28",
  "tower-layer",
  "tower-service",
 ]
@@ -5359,7 +5183,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6727956aaa2f8957d4d9232b308fe8e4e65d99db30f42b225646e86c9b6a952"
 dependencies = [
  "futures-core",
- "pin-project 0.4.27",
+ "pin-project 0.4.28",
  "tokio",
  "tower-layer",
  "tower-service",
@@ -5378,7 +5202,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ba4bbc2c1e4a8543c30d4c13a4c8314ed72d6e07581910f665aa13fde0153c8"
 dependencies = [
  "futures-util",
- "pin-project 0.4.27",
+ "pin-project 0.4.28",
  "tokio",
  "tokio-test",
  "tower-layer",
@@ -5391,7 +5215,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "127b8924b357be938823eaaec0608c482d40add25609481027b96198b2e4b31e"
 dependencies = [
- "pin-project 0.4.27",
+ "pin-project 0.4.28",
  "tokio",
  "tower-layer",
  "tower-service",
@@ -5405,39 +5229,39 @@ checksum = "d1093c19826d33807c72511e68f73b4a0469a3f22c2bd5f7d5212178b4b89674"
 dependencies = [
  "futures-core",
  "futures-util",
- "pin-project 0.4.27",
+ "pin-project 0.4.28",
  "tower-service",
 ]
 
 [[package]]
 name = "tracing"
-version = "0.1.24"
+version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f77d3842f76ca899ff2dbcf231c5c65813dea431301d6eb686279c15c4464f12"
+checksum = "09adeb8c97449311ccd28a427f96fb563e7fd31aabf994189879d9da2394b89d"
 dependencies = [
  "cfg-if 1.0.0",
  "log 0.4.14",
- "pin-project-lite 0.2.4",
+ "pin-project-lite 0.2.7",
  "tracing-attributes",
  "tracing-core",
 ]
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.13"
+version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8a9bd1db7706f2373a190b0d067146caa39350c486f3d455b0e33b431f94c07"
+checksum = "c42e6fa53307c8a17e4ccd4dc81cf5ec38db9209f59b222210375b54ee40d1e2"
 dependencies = [
- "proc-macro2 1.0.24",
+ "proc-macro2 1.0.27",
  "quote 1.0.9",
- "syn 1.0.67",
+ "syn 1.0.73",
 ]
 
 [[package]]
 name = "tracing-core"
-version = "0.1.17"
+version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f50de3927f93d202783f4513cda820ab47ef17f624b03c096e86ef00c67e6b5f"
+checksum = "a9ff14f98b1a4b289c6248a023c1c2fa1491062964e9fed67ab29c4e4da4a052"
 dependencies = [
  "lazy_static 1.4.0",
 ]
@@ -5448,15 +5272,15 @@ version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97d095ae15e245a057c8e8451bab9b3ee1e1f68e9ba2b4fbc18d0ac5237835f2"
 dependencies = [
- "pin-project 1.0.5",
+ "pin-project 1.0.7",
  "tracing",
 ]
 
 [[package]]
 name = "tracing-log"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e0f8c7178e13481ff6765bd169b33e8d554c5d2bbede5e32c356194be02b9b9"
+checksum = "a6923477a48e41c1951f1999ef8bb5a3023eb723ceadafe78ffb65dc366761e3"
 dependencies = [
  "lazy_static 1.4.0",
  "log 0.4.14",
@@ -5475,9 +5299,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.2.15"
+version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1fa8f0c8f4c594e4fc9debc1990deab13238077271ba84dd853d54902ee3401"
+checksum = "ab69019741fca4d98be3c62d2b75254528b5432233fd8a4d2739fec20278de48"
 dependencies = [
  "ansi_term 0.12.1",
  "chrono",
@@ -5503,14 +5327,14 @@ checksum = "efd1f82c56340fdf16f2a953d7bda4f8fdffba13d93b00844c25572110b26079"
 
 [[package]]
 name = "trust-dns-client"
-version = "0.19.6"
+version = "0.19.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85c4955b0005f14233f0a85cda61c17ebe6ea5dcec4f01611280649017fb227d"
+checksum = "e935ae5a26a2745fb5a6b95f0e206e1cfb7f00066892d2cf78a8fee87bc2e0c6"
 dependencies = [
- "backtrace",
+ "cfg-if 1.0.0",
  "chrono",
  "data-encoding",
- "futures 0.3.12",
+ "futures 0.3.15",
  "lazy_static 1.4.0",
  "log 0.4.14",
  "radix_trie",
@@ -5525,16 +5349,17 @@ dependencies = [
 
 [[package]]
 name = "trust-dns-proto"
-version = "0.19.6"
+version = "0.19.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53861fcb288a166aae4c508ae558ed18b53838db728d4d310aad08270a7d4c2b"
+checksum = "1cad71a0c0d68ab9941d2fb6e82f8fb2e86d9945b94e1661dd0aaea2b88215a9"
 dependencies = [
  "async-trait",
  "backtrace",
+ "cfg-if 1.0.0",
  "data-encoding",
  "enum-as-inner",
- "futures 0.3.12",
- "idna 0.2.2",
+ "futures 0.3.15",
+ "idna 0.2.3",
  "lazy_static 1.4.0",
  "log 0.4.14",
  "rand 0.7.3",
@@ -5542,7 +5367,7 @@ dependencies = [
  "smallvec",
  "thiserror",
  "tokio",
- "url 2.2.1",
+ "url 2.2.2",
 ]
 
 [[package]]
@@ -5590,7 +5415,7 @@ checksum = "e7a30db256d7388f6e08efa0a8e9e62ee34dd1af59706c76c9e8c97c2a500f12"
 dependencies = [
  "block-cipher",
  "byteorder",
- "opaque-debug 0.3.0",
+ "opaque-debug",
 ]
 
 [[package]]
@@ -5610,9 +5435,9 @@ dependencies = [
 
 [[package]]
 name = "typenum"
-version = "1.12.0"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "373c8a200f9e67a0c95e62a4f52fbf80c23b4381c05a17845531982fa99e6b33"
+checksum = "879f6906492a7cd215bfa4cf595b600146ccfac0c79bcbd1f3000162af5e8b06"
 
 [[package]]
 name = "ucd-trie"
@@ -5622,9 +5447,9 @@ checksum = "56dee185309b50d1f11bfedef0fe6d036842e3fb77413abef29f8f8d1c5d4c1c"
 
 [[package]]
 name = "uint"
-version = "0.9.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e11fe9a9348741cf134085ad57c249508345fe16411b3d7fb4ff2da2f1d6382e"
+checksum = "6470ab50f482bde894a037a57064480a246dbfdd5960bd65a44824693f08da5f"
 dependencies = [
  "byteorder",
  "crunchy",
@@ -5647,32 +5472,32 @@ version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "50f37be617794602aabbeee0be4f259dc1778fabe05e2d67ee8f79326d5cb4f6"
 dependencies = [
- "version_check 0.9.2",
+ "version_check 0.9.3",
 ]
 
 [[package]]
 name = "unicode-bidi"
-version = "0.3.4"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49f2bd0c6468a8230e1db229cff8029217cf623c767ea5d60bfbd42729ea54d5"
+checksum = "eeb8be209bb1c96b7c177c7420d26e04eccacb0eeae6b980e35fcb74678107e0"
 dependencies = [
  "matches",
 ]
 
 [[package]]
 name = "unicode-normalization"
-version = "0.1.17"
+version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07fbfce1c8a97d547e8b5334978438d9d6ec8c20e38f56d4a4374d181493eaef"
+checksum = "d54590932941a9e9266f0832deed84ebe1bf2e4c9e4a3554d393d18f5e854bf9"
 dependencies = [
  "tinyvec",
 ]
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.7.1"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb0d2e7be6ae3a5fa87eed5fb451aff96f2573d2694942e40543ae0bbe19c796"
+checksum = "8895849a949e7845e06bd6dc1aa51731a103c42707010a5b591c0038fb73385b"
 
 [[package]]
 name = "unicode-width"
@@ -5694,9 +5519,9 @@ checksum = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"
 
 [[package]]
 name = "unicode-xid"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7fe0bb3479651439c9112f72b6c505038574c9fbb575ed1bf3b797fa39dd564"
+checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
 
 [[package]]
 name = "universal-hash"
@@ -5704,8 +5529,8 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8326b2c654932e3e4f9196e69d08fdf7cfd718e1dc6f66b347e6024a0c961402"
 dependencies = [
- "generic-array 0.14.4",
- "subtle 2.4.0",
+ "generic-array",
+ "subtle",
 ]
 
 [[package]]
@@ -5748,12 +5573,12 @@ dependencies = [
 
 [[package]]
 name = "url"
-version = "2.2.1"
+version = "2.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ccd964113622c8e9322cfac19eb1004a07e636c545f325da085d5cdde6f1f8b"
+checksum = "a507c383b2d33b5fc35d1861e77e6b383d158b2da5e14fe51b83dfedf6fd578c"
 dependencies = [
  "form_urlencoded",
- "idna 0.2.2",
+ "idna 0.2.3",
  "matches",
  "percent-encoding 2.1.0",
 ]
@@ -5766,9 +5591,9 @@ checksum = "936e4b492acfd135421d8dca4b1aa80a7bfc26e702ef3af710e0752684df5372"
 
 [[package]]
 name = "vcpkg"
-version = "0.2.11"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b00bca6106a5e23f3eee943593759b7fcddb00554332e856d990c893966879fb"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "vec_map"
@@ -5784,15 +5609,15 @@ checksum = "914b1a6776c4c929a602fafd8bc742e06365d4bcbe48c30f9cca5824f70dc9dd"
 
 [[package]]
 name = "version_check"
-version = "0.9.2"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5a972e5669d67ba988ce3dc826706fb0a8b01471c088cb0b6110b805cc36aed"
+checksum = "5fecdca9a5291cc2b8dcf7dc02453fee791a280f3743cb0905f8822ae463b3fe"
 
 [[package]]
 name = "walkdir"
-version = "2.3.1"
+version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "777182bc735b6424e1a57516d35ed72cb8019d85c8c9bf536dccb3445c1a2f7d"
+checksum = "808cf2735cd4b6866113f648b791c6adc5714537bc222d9347bb203386ffda56"
 dependencies = [
  "same-file",
  "winapi 0.3.9",
@@ -5823,9 +5648,9 @@ checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.70"
+version = "0.2.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55c0f7123de74f0dab9b7d00fd614e7b19349cd1e2f5252bbe9b1754b59433be"
+checksum = "d54ee1d4ed486f78874278e63e4069fc1ab9f6a18ca492076ffb90c5eb2997fd"
 dependencies = [
  "cfg-if 1.0.0",
  "serde 1.0.126",
@@ -5835,24 +5660,24 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.70"
+version = "0.2.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7bc45447f0d4573f3d65720f636bbcc3dd6ce920ed704670118650bcd47764c7"
+checksum = "3b33f6a0694ccfea53d94db8b2ed1c3a8a4c86dd936b13b9f0a15ec4a451b900"
 dependencies = [
  "bumpalo",
  "lazy_static 1.4.0",
  "log 0.4.14",
- "proc-macro2 1.0.24",
+ "proc-macro2 1.0.27",
  "quote 1.0.9",
- "syn 1.0.67",
+ "syn 1.0.73",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.20"
+version = "0.4.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3de431a2910c86679c34283a33f66f4e4abd7e0aec27b6669060148872aadf94"
+checksum = "5fba7978c679d53ce2d0ac80c8c175840feb849a161664365d1287b41f2e67f1"
 dependencies = [
  "cfg-if 1.0.0",
  "js-sys",
@@ -5862,9 +5687,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.70"
+version = "0.2.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b8853882eef39593ad4174dd26fc9865a64e84026d223f63bb2c42affcbba2c"
+checksum = "088169ca61430fe1e58b8096c24975251700e7b1f6fd91cc9d59b04fb9b18bd4"
 dependencies = [
  "quote 1.0.9",
  "wasm-bindgen-macro-support",
@@ -5872,28 +5697,28 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.70"
+version = "0.2.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4133b5e7f2a531fa413b3a1695e925038a05a71cf67e87dafa295cb645a01385"
+checksum = "be2241542ff3d9f241f5e2cb6dd09b37efe786df8851c54957683a49f0987a97"
 dependencies = [
- "proc-macro2 1.0.24",
+ "proc-macro2 1.0.27",
  "quote 1.0.9",
- "syn 1.0.67",
+ "syn 1.0.73",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.70"
+version = "0.2.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd4945e4943ae02d15c13962b38a5b1e81eadd4b71214eee75af64a4d6a4fd64"
+checksum = "d7cff876b8f18eed75a66cf49b65e7f967cb354a7aa16003fb55dbfd25b44b4f"
 
 [[package]]
 name = "web-sys"
-version = "0.3.47"
+version = "0.3.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c40dc691fc48003eba817c38da7113c15698142da971298003cac3ef175680b3"
+checksum = "e828417b379f3df7111d3a2a9e5753706cae29c41f7c4029ee9fd77f3e09e582"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -5986,7 +5811,7 @@ version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a0c105152107e3b96f6a00a65e86ce82d9b125230e1c4302940eca58ff71f4f"
 dependencies = [
- "curve25519-dalek 3.1.0",
+ "curve25519-dalek",
  "rand_core 0.5.1",
  "zeroize",
 ]
@@ -6006,7 +5831,7 @@ version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd37e58a1256a0b328ce9c67d8b62ecdd02f4803ba443df478835cb1a41a637c"
 dependencies = [
- "futures 0.3.12",
+ "futures 0.3.15",
  "log 0.4.14",
  "nohash-hasher",
  "parking_lot",
@@ -6016,21 +5841,21 @@ dependencies = [
 
 [[package]]
 name = "zeroize"
-version = "1.2.0"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81a974bcdd357f0dca4d41677db03436324d45a4c9ed2d0b873a5a360ce41c36"
+checksum = "4756f7db3f7b5574938c3eb1c117038b8e07f95ee6718c0efad4ac21508f1efd"
 dependencies = [
  "zeroize_derive",
 ]
 
 [[package]]
 name = "zeroize_derive"
-version = "1.0.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3f369ddb18862aba61aa49bf31e74d29f0f162dec753063200e1dc084345d16"
+checksum = "a2c1e130bebaeab2f23886bf9acbaca14b092408c452543c857f66399cd6dab1"
 dependencies = [
- "proc-macro2 1.0.24",
+ "proc-macro2 1.0.27",
  "quote 1.0.9",
- "syn 1.0.67",
+ "syn 1.0.73",
  "synstructure",
 ]

--- a/applications/tari_app_grpc/Cargo.toml
+++ b/applications/tari_app_grpc/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2018"
 tari_common_types = { version = "^0.8", path = "../../base_layer/common_types"}
 tari_core = {  path = "../../base_layer/core"}
 tari_wallet = {  path = "../../base_layer/wallet"}
-tari_crypto = { git = "https://github.com/tari-project/tari-crypto.git", rev = "ecd77ec2b" } #switch back to official after merge
+tari_crypto = "0.11.1"
 tari_comms = { path = "../../comms"}
 
 chrono = "0.4.6"

--- a/applications/tari_app_utilities/Cargo.toml
+++ b/applications/tari_app_utilities/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 
 [dependencies]
 tari_comms = { path = "../../comms"}
-tari_crypto = { git = "https://github.com/tari-project/tari-crypto.git", rev = "ecd77ec2b" }
+tari_crypto = "0.11.1"
 tari_common = { path = "../../common" }
 tari_p2p = { path = "../../base_layer/p2p", features = ["auto-update"] }
 tari_wallet = { path = "../../base_layer/wallet" }
@@ -17,7 +17,7 @@ qrcode = { version = "0.12" }
 dirs-next = "1.0.2"
 serde_json = "1.0"
 log = { version = "0.4.8", features = ["std"] }
-rand = "0.7.2"
+rand = "0.8"
 tokio = { version="0.2.10", features = ["signal"] }
 structopt = { version = "0.3.13", default_features = false }
 strum = "^0.19"

--- a/applications/tari_app_utilities/src/identity_management.rs
+++ b/applications/tari_app_utilities/src/identity_management.rs
@@ -139,8 +139,7 @@ pub fn create_new_identity<P: AsRef<Path>>(
     features: PeerFeatures,
 ) -> Result<NodeIdentity, String> {
     let private_key = PrivateKey::random(&mut OsRng);
-    let node_identity = NodeIdentity::new(private_key, public_addr, features)
-        .map_err(|e| format!("We were unable to construct a node identity. {}", e.to_string()))?;
+    let node_identity = NodeIdentity::new(private_key, public_addr, features);
     save_as_json(path, &node_identity)?;
     Ok(node_identity)
 }
@@ -160,14 +159,8 @@ pub fn recover_node_identity<P: AsRef<Path>>(
     public_addr: &Multiaddr,
     features: PeerFeatures,
 ) -> Result<Arc<NodeIdentity>, ExitCodes> {
-    let node_identity = NodeIdentity::new(private_key, public_addr.clone(), features).map_err(|e| {
-        ExitCodes::ConfigError(format!(
-            "We were unable to construct a node identity. {}",
-            e.to_string()
-        ))
-    })?;
+    let node_identity = NodeIdentity::new(private_key, public_addr.clone(), features);
     save_as_json(path, &node_identity).map_err(ExitCodes::IOError)?;
-
     Ok(Arc::new(node_identity))
 }
 

--- a/applications/tari_base_node/Cargo.toml
+++ b/applications/tari_base_node/Cargo.toml
@@ -14,7 +14,7 @@ tari_common = { path = "../../common" }
 tari_comms = { path = "../../comms", features = ["rpc"]}
 tari_comms_dht = { path = "../../comms/dht"}
 tari_core = { path = "../../base_layer/core", default-features = false, features = ["transactions"]}
-tari_crypto = { git = "https://github.com/tari-project/tari-crypto.git", rev = "ecd77ec2b" }
+tari_crypto = "0.11.1"
 tari_mmr = { path = "../../base_layer/mmr" }
 tari_p2p = { path = "../../base_layer/p2p", features = ["auto-update"] }
 tari_service_framework = {  path = "../../base_layer/service_framework"}

--- a/applications/tari_console_wallet/Cargo.toml
+++ b/applications/tari_console_wallet/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 
 [dependencies]
 tari_wallet = {  path = "../../base_layer/wallet" }
-tari_crypto = { git = "https://github.com/tari-project/tari-crypto.git", rev = "ecd77ec2b" }
+tari_crypto = "0.11.1"
 tari_common = {  path = "../../common" }
 tari_app_utilities = { path = "../tari_app_utilities"}
 tari_comms = {  path = "../../comms"}
@@ -21,7 +21,7 @@ chrono = { version = "0.4.6", features = ["serde"]}
 chrono-english = "0.1"
 futures = { version = "^0.3.1", default-features = false, features = ["alloc"]}
 crossterm = { version = "0.17"}
-rand = "0.7.2"
+rand = "0.8"
 unicode-width = "0.1"
 unicode-segmentation = "1.6.0"
 log = { version = "0.4.8", features = ["std"] }

--- a/applications/tari_console_wallet/src/init/mod.rs
+++ b/applications/tari_console_wallet/src/init/mod.rs
@@ -300,10 +300,11 @@ pub async fn init_wallet(
         Some(nf) => nf,
     };
 
-    let node_identity = Arc::new(
-        NodeIdentity::new(CommsSecretKey::default(), node_address, node_features)
-            .map_err(|e| ExitCodes::NetworkError(e.to_string()))?,
-    );
+    let node_identity = Arc::new(NodeIdentity::new(
+        CommsSecretKey::default(),
+        node_address,
+        node_features,
+    ));
 
     let transport_type = setup_wallet_transport_type(&config);
     let transport_type = match transport_type {

--- a/applications/tari_console_wallet/src/ui/state/app_state.rs
+++ b/applications/tari_console_wallet/src/ui/state/app_state.rs
@@ -339,7 +339,7 @@ impl AppState {
     pub async fn set_custom_base_node(&mut self, public_key: String, address: String) -> Result<Peer, UiError> {
         let pub_key = PublicKey::from_hex(public_key.as_str())?;
         let addr = address.parse::<Multiaddr>().map_err(|_| UiError::AddressParseError)?;
-        let node_id = NodeId::from_key(&pub_key)?;
+        let node_id = NodeId::from_key(&pub_key);
         let peer = Peer::new(
             pub_key,
             node_id,

--- a/applications/tari_console_wallet/src/ui/ui_error.rs
+++ b/applications/tari_console_wallet/src/ui/ui_error.rs
@@ -1,4 +1,4 @@
-use tari_comms::{connectivity::ConnectivityError, peer_manager::node_id::NodeIdError};
+use tari_comms::connectivity::ConnectivityError;
 use tari_crypto::tari_utilities::hex::HexError;
 use tari_wallet::{
     contacts_service::error::ContactsServiceError,
@@ -20,8 +20,6 @@ pub enum UiError {
     ConnectivityError(#[from] ConnectivityError),
     #[error(transparent)]
     HexError(#[from] HexError),
-    #[error(transparent)]
-    NodeIdError(#[from] NodeIdError),
     #[error(transparent)]
     WalletError(#[from] WalletError),
     #[error(transparent)]

--- a/applications/tari_console_wallet/src/utils/db.rs
+++ b/applications/tari_console_wallet/src/utils/db.rs
@@ -74,16 +74,7 @@ pub async fn get_custom_base_node_peer_from_db(wallet: &mut WalletSqlite) -> Opt
                 },
             };
 
-            let node_id = match NodeId::from_key(&pub_key) {
-                Ok(n) => n,
-                Err(e) => {
-                    debug!(
-                        target: LOG_TARGET,
-                        "Problem converting stored base node public key to Node Id: {}", e
-                    );
-                    return None;
-                },
-            };
+            let node_id = NodeId::from_key(&pub_key);
             Some(Peer::new(
                 pub_key,
                 node_id,

--- a/applications/tari_merge_mining_proxy/Cargo.toml
+++ b/applications/tari_merge_mining_proxy/Cargo.toml
@@ -16,7 +16,7 @@ tari_app_grpc = { path = "../tari_app_grpc" }
 tari_common = {  path = "../../common" }
 tari_core = {  path = "../../base_layer/core", default-features = false, features = ["transactions"]}
 tari_app_utilities = {  path = "../tari_app_utilities"}
-tari_crypto = { git = "https://github.com/tari-project/tari-crypto.git", rev = "ecd77ec2b" }
+tari_crypto = "0.11.1"
 tari_utilities = "^0.3"
 
 anyhow = "1.0.40"
@@ -31,7 +31,7 @@ hex = "0.4.2"
 hyper = "0.13.7"
 jsonrpc = "0.11.0"
 log = { version = "0.4.8", features = ["std"] }
-rand = "0.7.2"
+rand = "0.8"
 reqwest = {version = "0.10.8", features=["json"]}
 serde = { version="1.0.106", features = ["derive"] }
 serde_json = "1.0.57"

--- a/applications/tari_mining_node/Cargo.toml
+++ b/applications/tari_mining_node/Cargo.toml
@@ -18,7 +18,7 @@ futures = "0.3"
 log = { version = "0.4", features = ["std"] }
 num_cpus = "1.13"
 prost-types = "0.6"
-rand = "0.7.2"
+rand = "0.8"
 sha3 = "0.9"
 serde = { version = "1.0", default_features = false, features = ["derive"] }
 tonic = { version = "0.2", features = ["transport"] }
@@ -27,6 +27,6 @@ thiserror = "1.0"
 
 
 [dev-dependencies]
-tari_crypto = { git = "https://github.com/tari-project/tari-crypto.git", rev = "ecd77ec2b" }
+tari_crypto = "0.11.1"
 prost-types = "0.6.1"
 chrono = "0.4"

--- a/applications/test_faucet/Cargo.toml
+++ b/applications/test_faucet/Cargo.toml
@@ -10,8 +10,8 @@ edition = "2018"
 tari_utilities = "^0.3"
 serde = { version = "1.0.97", features = ["derive"] }
 serde_json = "1.0"
-rand = "0.7.2"
-tari_crypto = { git = "https://github.com/tari-project/tari-crypto.git", rev = "ecd77ec2b" }
+rand = "0.8"
+tari_crypto = "0.11.1"
 
 [dependencies.tari_core]
 version = "^0.8"

--- a/base_layer/common_types/Cargo.toml
+++ b/base_layer/common_types/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 
 [dependencies]
 futures = {version = "^0.3.1", features = ["async-await"] }
-rand = "0.7.2"
-tari_crypto = { git = "https://github.com/tari-project/tari-crypto.git", rev = "ecd77ec2b" }
+rand = "0.8"
+tari_crypto = "0.11.1"
 serde = { version = "1.0.106", features = ["derive"] }
 tokio = { version="^0.2", features = ["blocking", "time", "sync"] }

--- a/base_layer/core/Cargo.toml
+++ b/base_layer/core/Cargo.toml
@@ -23,7 +23,7 @@ tari_common_types = { version = "^0.8", path = "../../base_layer/common_types"}
 tari_comms = { version = "^0.8", path = "../../comms"}
 tari_comms_dht = { version = "^0.8", path = "../../comms/dht"}
 tari_comms_rpc_macros = { version = "^0.8", path = "../../comms/rpc_macros"}
-tari_crypto = { git = "https://github.com/tari-project/tari-crypto.git", rev = "ecd77ec2b" }
+tari_crypto = "0.11.1"
 tari_mmr = { version = "^0.8", path = "../../base_layer/mmr", optional = true }
 tari_p2p = { version = "^0.8", path = "../../base_layer/p2p" }
 tari_service_framework = { version = "^0.8", path = "../service_framework"}
@@ -33,12 +33,12 @@ tari_test_utils = { version = "^0.8", path = "../../infrastructure/test_utils" }
 
 bincode = "1.1.4"
 bitflags = "1.0.4"
-blake2 = "^0.8.0"
+blake2 = "^0.9.0"
 sha3 = "0.9"
 bytes = "0.4.12"
 chrono = { version = "0.4.6", features = ["serde"]}
 croaring = { version = "=0.4.5", optional = true }
-digest = "0.8.0"
+digest = "0.9.0"
 futures = {version = "^0.3.1", features = ["async-await"] }
 fs2 = "0.3.0"
 hex = "0.4.2"
@@ -49,7 +49,7 @@ newtype-ops = "0.1.4"
 num = "0.3"
 prost = "0.6.1"
 prost-types = "0.6.1"
-rand = "0.7.2"
+rand = "0.8"
 randomx-rs = { version = "0.5.0", optional = true }
 serde = { version = "1.0.106", features = ["derive"] }
 serde_json = "1.0"

--- a/base_layer/core/src/base_node/state_machine_service/states/listening.rs
+++ b/base_layer/core/src/base_node/state_machine_service/states/listening.rs
@@ -346,7 +346,7 @@ mod test {
 
     fn random_node_id() -> NodeId {
         let (_secret_key, public_key) = CommsPublicKey::random_keypair(&mut OsRng);
-        NodeId::from_key(&public_key).unwrap()
+        NodeId::from_key(&public_key)
     }
 
     #[test]

--- a/base_layer/core/src/blocks/block_header.rs
+++ b/base_layer/core/src/blocks/block_header.rs
@@ -213,7 +213,7 @@ impl BlockHeader {
             .chain(self.kernel_mmr_size.to_le_bytes())
             .chain(self.total_kernel_offset.as_bytes())
             .chain(self.total_script_offset.as_bytes())
-            .result()
+            .finalize()
             .to_vec()
     }
 
@@ -257,7 +257,7 @@ impl Hashable for BlockHeader {
             .chain(self.merged_mining_hash())
             .chain(self.pow.to_bytes())
             .chain(self.nonce.to_le_bytes())
-            .result()
+            .finalize()
             .to_vec()
     }
 }

--- a/base_layer/core/src/test_helpers/mod.rs
+++ b/base_layer/core/src/test_helpers/mod.rs
@@ -84,7 +84,7 @@ pub fn create_peer_manager<P: AsRef<Path>>(data_path: P) -> Arc<PeerManager> {
     let peer_database_name = {
         let mut rng = rand::thread_rng();
         iter::repeat(())
-            .map(|_| rng.sample(Alphanumeric))
+            .map(|_| rng.sample(Alphanumeric) as char)
             .take(8)
             .collect::<String>()
     };

--- a/base_layer/core/src/transactions/bullet_rangeproofs.rs
+++ b/base_layer/core/src/transactions/bullet_rangeproofs.rs
@@ -37,7 +37,7 @@ pub struct BulletRangeProof(pub Vec<u8>);
 /// Implement the hashing function for RangeProof for use in the MMR
 impl Hashable for BulletRangeProof {
     fn hash(&self) -> Vec<u8> {
-        HashDigest::new().chain(&self.0).result().to_vec()
+        HashDigest::new().chain(&self.0).finalize().to_vec()
     }
 }
 

--- a/base_layer/core/src/transactions/transaction.rs
+++ b/base_layer/core/src/transactions/transaction.rs
@@ -43,7 +43,7 @@ use crate::transactions::{
         Signature,
     },
 };
-use digest::Input;
+use blake2::Digest;
 use rand::rngs::OsRng;
 use serde::{Deserialize, Serialize};
 use std::{
@@ -420,7 +420,7 @@ impl TransactionInput {
             .chain(input_data.as_bytes().as_slice())
             .chain(script_public_key.as_bytes())
             .chain(commitment.as_bytes())
-            .result()
+            .finalize()
             .to_vec()
     }
 
@@ -490,7 +490,7 @@ impl TransactionInput {
             .chain(self.features.to_bytes())
             .chain(self.commitment.as_bytes())
             .chain(self.script.as_bytes())
-            .result()
+            .finalize()
             .to_vec()
     }
 }
@@ -507,7 +507,7 @@ impl Hashable for TransactionInput {
             .chain(self.script_signature.v().as_bytes())
             .chain(self.script_signature.public_nonce().as_bytes())
             .chain(self.input_data.as_bytes())
-            .result()
+            .finalize()
             .to_vec()
     }
 }
@@ -685,7 +685,7 @@ impl TransactionOutput {
             .chain(features.to_bytes())
             .chain(sender_offset_public_key.as_bytes())
             .chain(commitment.as_bytes())
-            .result()
+            .finalize()
             .to_vec()
     }
 
@@ -775,7 +775,7 @@ impl TransactionOutput {
             .chain(self.metadata_signature.u().as_bytes())
             .chain(self.metadata_signature.v().as_bytes())
             .chain(self.metadata_signature.public_nonce().as_bytes())
-            .result()
+            .finalize()
             .to_vec()
     }
 }
@@ -793,7 +793,7 @@ impl Hashable for TransactionOutput {
             .chain(self.commitment.as_bytes())
             // .chain(range proof) // See docs as to why we exclude this
             .chain(self.script.as_bytes())
-            .result()
+            .finalize()
             .to_vec()
     }
 }
@@ -1035,7 +1035,7 @@ impl Hashable for TransactionKernel {
             .chain(self.excess.as_bytes())
             .chain(self.excess_sig.get_public_nonce().as_bytes())
             .chain(self.excess_sig.get_signature().as_bytes())
-            .result()
+            .finalize()
             .to_vec()
     }
 }

--- a/base_layer/core/src/transactions/transaction_protocol/mod.rs
+++ b/base_layer/core/src/transactions/transaction_protocol/mod.rs
@@ -152,6 +152,6 @@ pub fn build_challenge(sum_public_nonces: &PublicKey, metadata: &TransactionMeta
         .chain(sum_public_nonces.as_bytes())
         .chain(&u64::from(metadata.fee).to_le_bytes())
         .chain(&metadata.lock_height.to_le_bytes())
-        .result()
+        .finalize()
         .to_vec()
 }

--- a/base_layer/core/src/transactions/transaction_protocol/sender.rs
+++ b/base_layer/core/src/transactions/transaction_protocol/sender.rs
@@ -616,7 +616,10 @@ impl fmt::Display for SenderTransactionProtocol {
 }
 
 pub fn calculate_tx_id<D: Digest>(pub_nonce: &PublicKey, index: usize) -> u64 {
-    let hash = D::new().chain(pub_nonce.as_bytes()).chain(index.to_le_bytes()).result();
+    let hash = D::new()
+        .chain(pub_nonce.as_bytes())
+        .chain(index.to_le_bytes())
+        .finalize();
     let mut bytes: [u8; 8] = [0u8; 8];
     bytes.copy_from_slice(&hash[..8]);
     u64::from_le_bytes(bytes)

--- a/base_layer/core/tests/helpers/chain_metadata.rs
+++ b/base_layer/core/tests/helpers/chain_metadata.rs
@@ -24,8 +24,11 @@ use blake2::Digest;
 use std::sync::Arc;
 use tari_common_types::chain_metadata::ChainMetadata;
 use tari_comms::peer_manager::NodeId;
-use tari_core::base_node::chain_metadata_service::{ChainMetadataEvent, ChainMetadataHandle, PeerChainMetadata};
-use tari_crypto::{common::Blake256, tari_utilities::ByteArray};
+use tari_core::{
+    base_node::chain_metadata_service::{ChainMetadataEvent, ChainMetadataHandle, PeerChainMetadata},
+    tari_utilities::ByteArray,
+};
+use tari_crypto::common::Blake256;
 use tokio::sync::broadcast;
 
 /// Create a mock Chain Metadata stream.
@@ -69,7 +72,7 @@ impl MockChainMetadata {
 #[allow(dead_code)]
 pub fn random_peer_metadata(height: u64, difficulty: u128) -> PeerChainMetadata {
     let key: Vec<u8> = (0..13).map(|_| rand::random::<u8>()).collect();
-    let id = NodeId::from_key(&key).unwrap();
+    let id = NodeId::from_key(&key);
     let block_hash = Blake256::digest(id.as_bytes()).to_vec();
     let metadata = ChainMetadata::new(height, block_hash, 2800, 0, difficulty);
     PeerChainMetadata::new(id, metadata)

--- a/base_layer/core/tests/helpers/nodes.rs
+++ b/base_layer/core/tests/helpers/nodes.rs
@@ -22,8 +22,8 @@
 
 use crate::helpers::mock_state_machine::MockBaseNodeStateMachine;
 use futures::Sink;
-use rand::{distributions::Alphanumeric, rngs::OsRng, Rng};
-use std::{error::Error, iter, path::Path, sync::Arc, time::Duration};
+use rand::rngs::OsRng;
+use std::{error::Error, path::Path, sync::Arc, time::Duration};
 use tari_common::configuration::Network;
 use tari_comms::{
     peer_manager::{NodeIdentity, PeerFeatures},
@@ -352,23 +352,15 @@ pub fn create_network_with_3_base_nodes_with_config<P: AsRef<Path>>(
     (alice_node, bob_node, carol_node, consensus_manager)
 }
 
-#[allow(dead_code)]
-fn random_string(len: usize) -> String {
-    iter::repeat(()).map(|_| OsRng.sample(Alphanumeric)).take(len).collect()
-}
-
 // Helper function for creating a random node indentity.
 #[allow(dead_code)]
 pub fn random_node_identity() -> Arc<NodeIdentity> {
     let next_port = MemoryTransport::acquire_next_memsocket_port();
-    Arc::new(
-        NodeIdentity::random(
-            &mut OsRng,
-            format!("/memory/{}", next_port).parse().unwrap(),
-            PeerFeatures::COMMUNICATION_NODE,
-        )
-        .unwrap(),
-    )
+    Arc::new(NodeIdentity::random(
+        &mut OsRng,
+        format!("/memory/{}", next_port).parse().unwrap(),
+        PeerFeatures::COMMUNICATION_NODE,
+    ))
 }
 
 // Helper function for starting the comms stack.

--- a/base_layer/key_manager/Cargo.toml
+++ b/base_layer/key_manager/Cargo.toml
@@ -8,10 +8,10 @@ version = "0.8.11"
 edition = "2018"
 
 [dependencies]
-tari_crypto = { git = "https://github.com/tari-project/tari-crypto.git", rev = "ecd77ec2b" }
-rand = "0.7.2"
-digest = "0.8.0"
-sha2 = "0.8.0"
+tari_crypto = "0.11.1"
+rand = "0.8"
+digest = "0.9.0"
+sha2 = "0.9.5"
 serde = "1.0.89"
 serde_derive = "1.0.89"
 serde_json = "1.0.39"

--- a/base_layer/mmr/Cargo.toml
+++ b/base_layer/mmr/Cargo.toml
@@ -15,17 +15,17 @@ benches = ["criterion"]
 [dependencies]
 tari_utilities = "^0.3"
 thiserror = "1.0.20"
-digest = "0.8.0"
+digest = "0.9.0"
 log = "0.4"
 serde = { version = "1.0.97", features = ["derive"] }
 croaring =  { version = "=0.4.5", optional = true }
 criterion = { version="0.2", optional = true }
 
 [dev-dependencies]
-rand="0.7.0"
-blake2 = "0.8.0"
+rand="0.8.0"
+blake2 = "0.9.0"
 tari_infra_derive= { path = "../../infrastructure/derive", version = "^0.8" }
-tari_crypto = { git = "https://github.com/tari-project/tari-crypto.git", rev = "ecd77ec2b" }
+tari_crypto = "0.11.1"
 serde_json = "1.0"
 bincode = "1.1"
 [lib]

--- a/base_layer/mmr/src/common.rs
+++ b/base_layer/mmr/src/common.rs
@@ -171,7 +171,7 @@ pub fn is_left_sibling(pos: usize) -> bool {
 }
 
 pub fn hash_together<D: Digest>(left: &[u8], right: &[u8]) -> Hash {
-    D::new().chain(left).chain(right).result().to_vec()
+    D::new().chain(left).chain(right).finalize().to_vec()
 }
 
 /// The number of leaves in a MMR of the provided size.

--- a/base_layer/mmr/src/merkle_mountain_range.rs
+++ b/base_layer/mmr/src/merkle_mountain_range.rs
@@ -138,7 +138,7 @@ where
             return Ok(MerkleMountainRange::<D, B>::null_hash());
         }
         let hasher = D::new();
-        Ok(self.hash_to_root(hasher)?.result().to_vec())
+        Ok(self.hash_to_root(hasher)?.finalize().to_vec())
     }
 
     pub(crate) fn hash_to_root(&self, hasher: D) -> Result<D, MerkleMountainRangeError> {

--- a/base_layer/mmr/src/merkle_proof.rs
+++ b/base_layer/mmr/src/merkle_proof.rs
@@ -212,7 +212,7 @@ impl MerkleProof {
                     (hasher.chain(hash), peak_hashes)
                 }
             });
-        Ok(hasher.result().to_vec())
+        Ok(hasher.finalize().to_vec())
     }
 
     /// Consumes the Merkle proof while verifying it.

--- a/base_layer/mmr/src/mutable_mmr.rs
+++ b/base_layer/mmr/src/mutable_mmr.rs
@@ -123,8 +123,8 @@ where
         // both sets.
         let mmr_root = self.mmr.get_merkle_root()?;
         let mut hasher = D::new();
-        hasher.input(&mmr_root);
-        Ok(self.hash_deleted(hasher).result().to_vec())
+        hasher.update(&mmr_root);
+        Ok(self.hash_deleted(hasher).finalize().to_vec())
     }
 
     /// Returns only the MMR merkle root without the compressed serialisation of the bitmap
@@ -197,7 +197,7 @@ where
     /// Hash the roaring bitmap of nodes that are marked for deletion
     fn hash_deleted(&self, mut hasher: D) -> D {
         let bitmap_ser = self.deleted.serialize();
-        hasher.input(&bitmap_ser);
+        hasher.update(&bitmap_ser);
         hasher
     }
 

--- a/base_layer/mmr/tests/mutable_mmr.rs
+++ b/base_layer/mmr/tests/mutable_mmr.rs
@@ -32,7 +32,7 @@ use tari_mmr::{Hash, HashSlice, MutableMmr};
 fn hash_with_bitmap(hash: &HashSlice, bitmap: &mut Bitmap) -> Hash {
     bitmap.run_optimize();
     let hasher = Hasher::new();
-    hasher.chain(hash).chain(&bitmap.serialize()).result().to_vec()
+    hasher.chain(hash).chain(&bitmap.serialize()).finalize().to_vec()
 }
 
 /// MMRs with no elements should provide sane defaults. The merkle root must be the hash of an empty string, b"".

--- a/base_layer/mmr/tests/pruned_mmr.rs
+++ b/base_layer/mmr/tests/pruned_mmr.rs
@@ -65,15 +65,15 @@ fn pruned_mmrs() {
 
 fn get_changes() -> (usize, Vec<Hash>, Vec<u32>) {
     let mut rng = rand::thread_rng();
-    let src_size: usize = rng.gen_range(25, 150);
-    let addition_length = rng.gen_range(1, 100);
+    let src_size: usize = rng.gen_range(25..150);
+    let addition_length = rng.gen_range(1..100);
     let additions: Vec<Hash> = Uniform::from(1..1000)
-        .sample_iter(rng)
+        .sample_iter(&mut rng)
         .take(addition_length)
         .map(int_to_hash)
         .collect();
     let deletions: Vec<u32> = Uniform::from(0..src_size)
-        .sample_iter(rng)
+        .sample_iter(&mut rng)
         .take(src_size / 5)
         .map(|v| v as u32)
         .collect();

--- a/base_layer/mmr/tests/support/mod.rs
+++ b/base_layer/mmr/tests/support/mod.rs
@@ -55,6 +55,6 @@ pub fn combine_hashes(hashes: &[&HashSlice]) -> Hash {
     hashes
         .iter()
         .fold(hasher, |hasher, h| hasher.chain(*h))
-        .result()
+        .finalize()
         .to_vec()
 }

--- a/base_layer/p2p/Cargo.toml
+++ b/base_layer/p2p/Cargo.toml
@@ -13,7 +13,7 @@ edition = "2018"
 tari_comms = { version = "^0.8", path = "../../comms"}
 tari_comms_dht = { version = "^0.8", path = "../../comms/dht"}
 tari_common = { version= "^0.8", path = "../../common" }
-tari_crypto = { git = "https://github.com/tari-project/tari-crypto.git", rev = "ecd77ec2b" }
+tari_crypto = "0.11.1"
 tari_service_framework = { version = "^0.8", path = "../service_framework"}
 tari_shutdown = { version = "^0.8", path="../../infrastructure/shutdown" }
 tari_storage = { version = "^0.8", path = "../../infrastructure/storage"}
@@ -28,7 +28,7 @@ lmdb-zero = "0.4.4"
 log = "0.4.6"
 pgp = {version = "0.7.1", optional = true}
 prost = "0.6.1"
-rand = "0.7.2"
+rand = "0.8"
 reqwest = {version = "0.10", optional = true, default-features = false}
 semver = "1.0.1"
 serde = "1.0.90"

--- a/base_layer/p2p/examples/gen_node_identity.rs
+++ b/base_layer/p2p/examples/gen_node_identity.rs
@@ -39,7 +39,7 @@ use tari_comms::{
 use tari_crypto::tari_utilities::message_format::MessageFormat;
 
 fn random_address() -> Multiaddr {
-    let port = OsRng.gen_range(9000, std::u16::MAX);
+    let port = OsRng.gen_range(9000..std::u16::MAX);
     let socket_addr: SocketAddr = (Ipv4Addr::LOCALHOST, port).into();
     socketaddr_to_multiaddr(&socket_addr)
 }
@@ -71,7 +71,7 @@ fn main() {
         .get_matches();
 
     let address = random_address();
-    let node_identity = NodeIdentity::random(&mut OsRng, address, PeerFeatures::COMMUNICATION_NODE).unwrap();
+    let node_identity = NodeIdentity::random(&mut OsRng, address, PeerFeatures::COMMUNICATION_NODE);
     let json = node_identity.to_json().unwrap();
     let out_path = to_abs_path(matches.value_of("output").unwrap());
     fs::write(out_path, json).unwrap();

--- a/base_layer/p2p/src/initialization.rs
+++ b/base_layer/p2p/src/initialization.rs
@@ -168,7 +168,7 @@ where
     let peer_database_name = {
         let mut rng = thread_rng();
         iter::repeat(())
-            .map(|_| rng.sample(Alphanumeric))
+            .map(|_| rng.sample(Alphanumeric) as char)
             .take(8)
             .collect::<String>()
     };

--- a/base_layer/p2p/src/services/liveness/service.rs
+++ b/base_layer/p2p/src/services/liveness/service.rs
@@ -394,7 +394,7 @@ mod test {
         task::spawn(service.run());
 
         let (_, pk) = CommsPublicKey::random_keypair(&mut rand::rngs::OsRng);
-        let node_id = NodeId::from_key(&pk).unwrap();
+        let node_id = NodeId::from_key(&pk);
         // Receive outbound request
         task::spawn(async move {
             match outbound_rx.select_next_some().await {
@@ -416,7 +416,7 @@ mod test {
         let (_, pk) = CommsPublicKey::random_keypair(&mut OsRng);
         let source_peer = Peer::new(
             pk.clone(),
-            NodeId::from_key(&pk).unwrap(),
+            NodeId::from_key(&pk),
             Vec::<Multiaddr>::new().into(),
             PeerFlags::empty(),
             PeerFeatures::COMMUNICATION_NODE,

--- a/base_layer/p2p/src/test_utils.rs
+++ b/base_layer/p2p/src/test_utils.rs
@@ -50,14 +50,11 @@ macro_rules! unwrap_oms_send_msg {
 }
 
 pub fn make_node_identity() -> Arc<NodeIdentity> {
-    Arc::new(
-        NodeIdentity::random(
-            &mut OsRng,
-            "/ip4/127.0.0.1/tcp/9000".parse().unwrap(),
-            PeerFeatures::COMMUNICATION_NODE,
-        )
-        .unwrap(),
-    )
+    Arc::new(NodeIdentity::random(
+        &mut OsRng,
+        "/ip4/127.0.0.1/tcp/9000".parse().unwrap(),
+        PeerFeatures::COMMUNICATION_NODE,
+    ))
 }
 
 pub fn make_dht_header(trace: MessageTag) -> DhtMessageHeader {

--- a/base_layer/p2p/tests/services/liveness.rs
+++ b/base_layer/p2p/tests/services/liveness.rs
@@ -68,14 +68,11 @@ pub async fn setup_liveness_service(
 
 fn make_node_identity() -> Arc<NodeIdentity> {
     let next_port = MemoryTransport::acquire_next_memsocket_port();
-    Arc::new(
-        NodeIdentity::random(
-            &mut OsRng,
-            format!("/memory/{}", next_port).parse().unwrap(),
-            PeerFeatures::COMMUNICATION_NODE,
-        )
-        .unwrap(),
-    )
+    Arc::new(NodeIdentity::random(
+        &mut OsRng,
+        format!("/memory/{}", next_port).parse().unwrap(),
+        PeerFeatures::COMMUNICATION_NODE,
+    ))
 }
 
 #[tokio_macros::test_basic]

--- a/base_layer/wallet/Cargo.toml
+++ b/base_layer/wallet/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2018"
 tari_common_types = { version = "^0.8", path = "../../base_layer/common_types"}
 tari_comms = { version = "^0.8", path = "../../comms"}
 tari_comms_dht = { version = "^0.8", path = "../../comms/dht" }
-tari_crypto = { git = "https://github.com/tari-project/tari-crypto.git", rev = "ecd77ec2b" }
+tari_crypto = "0.11.1"
 tari_key_manager = { version = "^0.8", path = "../key_manager" }
 tari_p2p = { version = "^0.8", path = "../p2p" }
 tari_service_framework = { version = "^0.8", path = "../service_framework"}
@@ -19,10 +19,10 @@ tari_storage = { version = "^0.8", path = "../../infrastructure/storage"}
 tari_test_utils = { version = "^0.8", path = "../../infrastructure/test_utils", optional = true}
 
 aes-gcm = "^0.8"
-blake2 = "0.8.0"
+blake2 = "0.9.0"
 chrono = { version = "0.4.6", features = ["serde"]}
 crossbeam-channel = "0.3.8"
-digest = "0.8.0"
+digest = "0.9.0"
 diesel_migrations =  "1.4"
 diesel = {version="1.4", features = ["sqlite", "serde_json", "chrono"]}
 fs2 = "0.3.0"
@@ -31,7 +31,7 @@ lazy_static = "1.4.0"
 log = "0.4.6"
 log4rs = {version = "0.8.3", features = ["console_appender", "file_appender", "file", "yaml_format"]}
 lmdb-zero = "0.4.4"
-rand = "0.7.2"
+rand = "0.8"
 serde = {version = "1.0.89", features = ["derive"] }
 serde_json = "1.0.39"
 tokio = { version = "0.2.10", features = ["blocking", "sync"]}

--- a/base_layer/wallet/src/error.rs
+++ b/base_layer/wallet/src/error.rs
@@ -34,7 +34,7 @@ use serde_json::Error as SerdeJsonError;
 use tari_comms::{
     connectivity::ConnectivityError,
     multiaddr,
-    peer_manager::{node_id::NodeIdError, NodeIdentityError, PeerManagerError},
+    peer_manager::{node_id::NodeIdError, PeerManagerError},
 };
 use tari_comms_dht::store_forward::StoreAndForwardError;
 use tari_core::transactions::transaction::TransactionError;
@@ -73,8 +73,6 @@ pub enum WalletError {
     BaseNodeServiceError(#[from] BaseNodeServiceError),
     #[error("Node ID error: `{0}`")]
     NodeIdError(#[from] NodeIdError),
-    #[error("Node Identity error: `{0}`")]
-    NodeIdentityError(#[from] NodeIdentityError),
     #[error("Error performing wallet recovery: '{0}'")]
     WalletRecoveryError(String),
     #[error("Shutdown Signal Received")]

--- a/base_layer/wallet/src/output_manager_service/service.rs
+++ b/base_layer/wallet/src/output_manager_service/service.rs
@@ -39,8 +39,8 @@ use crate::{
     transaction_service::handle::TransactionServiceHandle,
     types::{HashDigest, ValidationRetryStrategy},
 };
+use blake2::Digest;
 use diesel::result::{DatabaseErrorKind, Error as DieselError};
-use digest::Digest;
 use futures::{pin_mut, StreamExt};
 use log::*;
 use rand::{rngs::OsRng, RngCore};
@@ -1320,5 +1320,5 @@ impl fmt::Display for Balance {
 }
 
 fn hash_secret_key(key: &PrivateKey) -> Vec<u8> {
-    HashDigest::new().chain(key.as_bytes()).result().to_vec()
+    HashDigest::new().chain(key.as_bytes()).finalize().to_vec()
 }

--- a/base_layer/wallet/src/output_manager_service/storage/sqlite_db.rs
+++ b/base_layer/wallet/src/output_manager_service/storage/sqlite_db.rs
@@ -1707,8 +1707,8 @@ mod test {
     };
     use chrono::{Duration as ChronoDuration, Utc};
     use diesel::{Connection, SqliteConnection};
-    use rand::{distributions::Alphanumeric, rngs::OsRng, Rng, RngCore};
-    use std::{convert::TryFrom, iter, time::Duration};
+    use rand::{rngs::OsRng, RngCore};
+    use std::{convert::TryFrom, time::Duration};
     use tari_core::transactions::{
         helpers::{create_unblinded_output, TestParams as TestParamsHelpers},
         tari_amount::MicroTari,
@@ -1716,11 +1716,8 @@ mod test {
         types::{CommitmentFactory, CryptoFactories, PrivateKey},
     };
     use tari_crypto::{keys::SecretKey, script};
+    use tari_test_utils::random;
     use tempfile::tempdir;
-
-    pub fn random_string(len: usize) -> String {
-        iter::repeat(()).map(|_| OsRng.sample(Alphanumeric)).take(len).collect()
-    }
 
     pub fn make_input(val: MicroTari) -> (TransactionInput, UnblindedOutput) {
         let test_params = TestParamsHelpers::new();
@@ -1734,7 +1731,7 @@ mod test {
 
     #[test]
     fn test_crud() {
-        let db_name = format!("{}.sqlite3", random_string(8).as_str());
+        let db_name = format!("{}.sqlite3", random::string(8).as_str());
         let temp_dir = tempdir().unwrap();
         let db_folder = temp_dir.path().to_str().unwrap().to_string();
         let db_path = format!("{}{}", db_folder, db_name);
@@ -1881,7 +1878,7 @@ mod test {
 
     #[test]
     fn test_key_manager_crud() {
-        let db_name = format!("{}.sqlite3", random_string(8).as_str());
+        let db_name = format!("{}.sqlite3", random::string(8).as_str());
         let temp_dir = tempdir().unwrap();
         let db_folder = temp_dir.path().to_str().unwrap().to_string();
         let db_path = format!("{}{}", db_folder, db_name);
@@ -1897,7 +1894,7 @@ mod test {
 
         let state1 = KeyManagerState {
             master_key: PrivateKey::random(&mut OsRng),
-            branch_seed: random_string(8),
+            branch_seed: random::string(8),
             primary_key_index: 0,
         };
 
@@ -1908,7 +1905,7 @@ mod test {
 
         let state2 = KeyManagerState {
             master_key: PrivateKey::random(&mut OsRng),
-            branch_seed: random_string(8),
+            branch_seed: random::string(8),
             primary_key_index: 0,
         };
 
@@ -1928,7 +1925,7 @@ mod test {
 
     #[test]
     fn test_output_encryption() {
-        let db_name = format!("{}.sqlite3", random_string(8).as_str());
+        let db_name = format!("{}.sqlite3", random::string(8).as_str());
         let tempdir = tempdir().unwrap();
         let db_folder = tempdir.path().to_str().unwrap().to_string();
         let db_path = format!("{}{}", db_folder, db_name);
@@ -1987,7 +1984,7 @@ mod test {
 
     #[test]
     fn test_key_manager_encryption() {
-        let db_name = format!("{}.sqlite3", random_string(8).as_str());
+        let db_name = format!("{}.sqlite3", random::string(8).as_str());
         let temp_dir = tempdir().unwrap();
         let db_folder = temp_dir.path().to_str().unwrap().to_string();
         let db_path = format!("{}{}", db_folder, db_name);
@@ -2029,7 +2026,7 @@ mod test {
 
     #[test]
     fn test_apply_remove_encryption() {
-        let db_name = format!("{}.sqlite3", random_string(8).as_str());
+        let db_name = format!("{}.sqlite3", random::string(8).as_str());
         let temp_dir = tempdir().unwrap();
         let db_folder = temp_dir.path().to_str().unwrap().to_string();
         let db_path = format!("{}{}", db_folder, db_name);

--- a/base_layer/wallet/src/output_manager_service/tasks/txo_validation_task.rs
+++ b/base_layer/wallet/src/output_manager_service/tasks/txo_validation_task.rs
@@ -177,8 +177,7 @@ where TBackend: OutputManagerBackend + 'static
             // Assume base node is synced until we achieve a connection and it tells us it is not synced
             self.base_node_synced = true;
 
-            let base_node_node_id = NodeId::from_key(&self.base_node_public_key.clone())
-                .map_err(|e| OutputManagerProtocolError::new(self.id, OutputManagerError::from(e)))?;
+            let base_node_node_id = NodeId::from_key(&self.base_node_public_key.clone());
             let mut connection: Option<PeerConnection> = None;
 
             let delay = delay_for(self.resources.config.peer_dial_retry_timeout);

--- a/base_layer/wallet/src/storage/sqlite_utilities.rs
+++ b/base_layer/wallet/src/storage/sqlite_utilities.rs
@@ -150,7 +150,7 @@ pub fn initialize_sqlite_database_backends(
     WalletStorageError,
 > {
     let cipher = passphrase.map(|passphrase_str| {
-        let passphrase_hash = Blake256::new().chain(passphrase_str.as_bytes()).result();
+        let passphrase_hash = Blake256::new().chain(passphrase_str.as_bytes()).finalize();
         let key = GenericArray::from_slice(passphrase_hash.as_slice());
         Aes256Gcm::new(key)
     });

--- a/base_layer/wallet/src/test_utils.rs
+++ b/base_layer/wallet/src/test_utils.rs
@@ -32,7 +32,10 @@ use std::path::Path;
 use tempfile::{tempdir, TempDir};
 
 pub fn random_string(len: usize) -> String {
-    iter::repeat(()).map(|_| OsRng.sample(Alphanumeric)).take(len).collect()
+    iter::repeat(())
+        .map(|_| OsRng.sample(Alphanumeric) as char)
+        .take(len)
+        .collect()
 }
 
 /// A test helper to create a temporary wallet service databases

--- a/base_layer/wallet/src/testnet_utils.rs
+++ b/base_layer/wallet/src/testnet_utils.rs
@@ -48,9 +48,8 @@ use crate::{
 use chrono::{Duration as ChronoDuration, Utc};
 use futures::{FutureExt, StreamExt};
 use log::*;
-use rand::{distributions::Alphanumeric, rngs::OsRng, CryptoRng, Rng, RngCore};
+use rand::{rngs::OsRng, CryptoRng, Rng, RngCore};
 use std::{
-    iter,
     path::{Path, PathBuf},
     sync::Arc,
     time::Duration,
@@ -76,6 +75,7 @@ use tari_crypto::{
 };
 use tari_p2p::{initialization::CommsConfig, transport::TransportType, Network};
 use tari_shutdown::{Shutdown, ShutdownSignal};
+use tari_test_utils::random;
 use tokio::{runtime::Handle, time::delay_for};
 
 // Used to generate test wallet data
@@ -111,10 +111,6 @@ pub fn make_input(val: MicroTari, factories: &CryptoFactories) -> (TransactionIn
     )
 }
 
-pub fn random_string(len: usize) -> String {
-    iter::repeat(()).map(|_| OsRng.sample(Alphanumeric)).take(len).collect()
-}
-
 /// Create a wallet for testing purposes
 pub async fn create_wallet(
     public_address: Multiaddr,
@@ -128,14 +124,11 @@ pub async fn create_wallet(
 > {
     let factories = CryptoFactories::default();
 
-    let node_identity = Arc::new(
-        NodeIdentity::new(
-            CommsSecretKey::random(&mut OsRng),
-            public_address.clone(),
-            PeerFeatures::COMMUNICATION_NODE,
-        )
-        .expect("Could not construct Node Identity"),
-    );
+    let node_identity = Arc::new(NodeIdentity::new(
+        CommsSecretKey::random(&mut OsRng),
+        public_address.clone(),
+        PeerFeatures::COMMUNICATION_NODE,
+    ));
     let comms_config = CommsConfig {
         network: Network::Weatherwax,
         transport_type: TransportType::Memory {
@@ -143,7 +136,7 @@ pub async fn create_wallet(
         },
         node_identity,
         datastore_path: datastore_path.clone(),
-        peer_database_name: random_string(8),
+        peer_database_name: random::string(8),
         max_concurrent_inbound_tasks: 100,
         outbound_buffer_size: 100,
         user_agent: "/tari/wallet/test".to_string(),
@@ -275,7 +268,7 @@ pub async fn generate_wallet_test_data<
         target: LOG_TARGET,
         "Spinning up Alice wallet to generate test transactions"
     );
-    let alice_temp_dir = data_path.as_ref().join(random_string(8));
+    let alice_temp_dir = data_path.as_ref().join(random::string(8));
     let _ = std::fs::create_dir(&alice_temp_dir);
 
     let mut shutdown_a = Shutdown::new();
@@ -298,7 +291,7 @@ pub async fn generate_wallet_test_data<
         target: LOG_TARGET,
         "Spinning up Bob wallet to generate test transactions"
     );
-    let bob_temp_dir = data_path.as_ref().join(random_string(8));
+    let bob_temp_dir = data_path.as_ref().join(random::string(8));
     let _ = std::fs::create_dir(&bob_temp_dir);
 
     let mut wallet_bob = create_wallet(

--- a/base_layer/wallet/src/transaction_service/protocols/transaction_broadcast_protocol.rs
+++ b/base_layer/wallet/src/transaction_service/protocols/transaction_broadcast_protocol.rs
@@ -105,8 +105,7 @@ where TBackend: TransactionBackend + 'static
         let mut shutdown = self.resources.shutdown_signal.clone();
         // Main protocol loop
         loop {
-            let base_node_node_id = NodeId::from_key(&self.base_node_public_key.clone())
-                .map_err(|e| TransactionServiceProtocolError::new(self.tx_id, TransactionServiceError::from(e)))?;
+            let base_node_node_id = NodeId::from_key(&self.base_node_public_key);
             let mut connection: Option<PeerConnection> = None;
 
             let delay = delay_for(self.timeout);

--- a/base_layer/wallet/src/transaction_service/protocols/transaction_coinbase_monitoring_protocol.rs
+++ b/base_layer/wallet/src/transaction_service/protocols/transaction_coinbase_monitoring_protocol.rs
@@ -159,8 +159,7 @@ where TBackend: TransactionBackend + 'static
             );
 
             // Get a base node RPC connection
-            let base_node_node_id = NodeId::from_key(&self.base_node_public_key.clone())
-                .map_err(|e| TransactionServiceProtocolError::new(self.tx_id, TransactionServiceError::from(e)))?;
+            let base_node_node_id = NodeId::from_key(&self.base_node_public_key);
             let mut connection: Option<PeerConnection> = None;
             debug!(
                 target: LOG_TARGET,

--- a/base_layer/wallet/src/transaction_service/protocols/transaction_validation_protocol.rs
+++ b/base_layer/wallet/src/transaction_service/protocols/transaction_validation_protocol.rs
@@ -155,8 +155,7 @@ where TBackend: TransactionBackend + 'static
             // Assume base node is synced until we achieve a connection and it tells us it is not synced
             self.base_node_synced = true;
 
-            let base_node_node_id = NodeId::from_key(&self.base_node_public_key.clone())
-                .map_err(|e| TransactionServiceProtocolError::new(self.id, TransactionServiceError::from(e)))?;
+            let base_node_node_id = NodeId::from_key(&self.base_node_public_key);
             let mut connection: Option<PeerConnection> = None;
 
             let delay = delay_for(self.timeout);

--- a/base_layer/wallet/src/transaction_service/service.rs
+++ b/base_layer/wallet/src/transaction_service/service.rs
@@ -2061,12 +2061,12 @@ where
                 storage::{database::OutputManagerDatabase, sqlite_db::OutputManagerSqliteDatabase},
             },
             storage::sqlite_utilities::run_migration_and_create_sqlite_connection,
-            test_utils::random_string,
             transaction_service::{handle::TransactionServiceHandle, storage::models::InboundTransaction},
         };
         use tari_comms::types::CommsSecretKey;
         use tari_core::consensus::ConsensusConstantsBuilder;
         use tari_p2p::Network;
+        use tari_test_utils::random;
         use tempfile::tempdir;
 
         let (_sender, receiver) = reply_channel::unbounded();
@@ -2087,7 +2087,7 @@ where
         let mut mock_base_node_service = MockBaseNodeService::new(receiver_bns, shutdown_signal.clone());
         mock_base_node_service.set_default_base_node_state();
 
-        let db_name = format!("{}.sqlite3", random_string(8).as_str());
+        let db_name = format!("{}.sqlite3", random::string(8).as_str());
         let db_tempdir = tempdir().unwrap();
         let db_folder = db_tempdir.path().to_str().unwrap().to_string();
         let db_path = format!("{}/{}", db_folder, db_name);
@@ -2257,5 +2257,5 @@ pub struct PendingCoinbaseSpendingKey {
 }
 
 fn hash_secret_key(key: &PrivateKey) -> Vec<u8> {
-    HashDigest::new().chain(key.as_bytes()).result().to_vec()
+    HashDigest::new().chain(key.as_bytes()).finalize().to_vec()
 }

--- a/base_layer/wallet/src/wallet.rs
+++ b/base_layer/wallet/src/wallet.rs
@@ -131,7 +131,7 @@ where
             comms_secret_key,
             config.comms_config.node_identity.public_address(),
             config.comms_config.node_identity.features(),
-        )?);
+        ));
 
         let mut comms_config = config.comms_config.clone();
         comms_config.node_identity = node_identity.clone();
@@ -265,7 +265,7 @@ where
         let address = net_address.parse::<Multiaddr>()?;
         let peer = Peer::new(
             public_key.clone(),
-            NodeId::from_key(&public_key).unwrap(),
+            NodeId::from_key(&public_key),
             vec![address].into(),
             PeerFlags::empty(),
             PeerFeatures::COMMUNICATION_NODE,
@@ -442,7 +442,7 @@ where
     /// in which case this will fail.
     pub async fn apply_encryption(&mut self, passphrase: String) -> Result<(), WalletError> {
         debug!(target: LOG_TARGET, "Applying wallet encryption.");
-        let passphrase_hash = Blake256::new().chain(passphrase.as_bytes()).result().to_vec();
+        let passphrase_hash = Blake256::new().chain(passphrase.as_bytes()).finalize();
         let key = GenericArray::from_slice(passphrase_hash.as_slice());
         let cipher = Aes256Gcm::new(key);
 

--- a/base_layer/wallet/tests/contacts_service/mod.rs
+++ b/base_layer/wallet/tests/contacts_service/mod.rs
@@ -20,12 +20,13 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use crate::support::{data::get_temp_sqlite_database_connection, utils::random_string};
+use crate::support::data::get_temp_sqlite_database_connection;
 use rand::rngs::OsRng;
 use tari_core::transactions::types::PublicKey;
 use tari_crypto::keys::PublicKey as PublicKeyTrait;
 use tari_service_framework::StackBuilder;
 use tari_shutdown::Shutdown;
+use tari_test_utils::random;
 use tari_wallet::contacts_service::{
     error::{ContactsServiceError, ContactsServiceStorageError},
     handle::ContactsServiceHandle,
@@ -66,7 +67,7 @@ pub fn test_contacts_service() {
         let (_secret_key, public_key) = PublicKey::random_keypair(&mut OsRng);
 
         contacts.push(Contact {
-            alias: random_string(8),
+            alias: random::string(8),
             public_key,
         });
 

--- a/base_layer/wallet/tests/support/comms_and_services.rs
+++ b/base_layer/wallet/tests/support/comms_and_services.rs
@@ -73,7 +73,7 @@ where
 pub fn create_dummy_message<T>(inner: T, public_key: &CommsPublicKey) -> DomainMessage<T> {
     let peer_source = Peer::new(
         public_key.clone(),
-        NodeId::from_key(public_key).unwrap(),
+        NodeId::from_key(public_key),
         Vec::<Multiaddr>::new().into(),
         PeerFlags::empty(),
         PeerFeatures::COMMUNICATION_NODE,

--- a/base_layer/wallet/tests/support/data.rs
+++ b/base_layer/wallet/tests/support/data.rs
@@ -20,8 +20,8 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use crate::support::utils::random_string;
 use std::path::PathBuf;
+use tari_test_utils::random;
 use tari_wallet::storage::sqlite_utilities::{run_migration_and_create_sqlite_connection, WalletDbConnection};
 use tempfile::{tempdir, TempDir};
 
@@ -45,7 +45,7 @@ pub fn init_sql_database(name: &str) {
 }
 
 pub fn get_temp_sqlite_database_connection() -> (WalletDbConnection, TempDir) {
-    let db_name = format!("{}.sqlite3", random_string(8).as_str());
+    let db_name = format!("{}.sqlite3", random::string(8).as_str());
     let db_tempdir = tempdir().unwrap();
     let db_folder = db_tempdir.path().to_str().unwrap().to_string();
     let db_path = format!("{}/{}", db_folder, db_name);

--- a/base_layer/wallet/tests/support/utils.rs
+++ b/base_layer/wallet/tests/support/utils.rs
@@ -20,8 +20,8 @@
 //  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 //  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use rand::{distributions::Alphanumeric, rngs::OsRng, CryptoRng, Rng};
-use std::{fmt::Debug, iter, thread, time::Duration};
+use rand::{CryptoRng, Rng};
+use std::{fmt::Debug, thread, time::Duration};
 use tari_core::transactions::{
     helpers::{create_unblinded_output, TestParams as TestParamsHelpers},
     tari_amount::MicroTari,
@@ -109,8 +109,4 @@ pub fn make_input_with_features<R: Rng + CryptoRng>(
             .expect("Should be able to make transaction input"),
         utxo,
     )
-}
-
-pub fn random_string(len: usize) -> String {
-    iter::repeat(()).map(|_| OsRng.sample(Alphanumeric)).take(len).collect()
 }

--- a/base_layer/wallet/tests/transaction_service/service.rs
+++ b/base_layer/wallet/tests/transaction_service/service.rs
@@ -24,7 +24,7 @@ use crate::{
     support::{
         comms_and_services::{create_dummy_message, get_next_memory_address, setup_comms_services},
         rpc::{BaseNodeWalletRpcMockService, BaseNodeWalletRpcMockState},
-        utils::{make_input, random_string, TestParams},
+        utils::{make_input, TestParams},
     },
     transaction_service::transaction_protocols::add_transaction_to_database,
 };
@@ -91,6 +91,7 @@ use tari_crypto::{
 use tari_p2p::{comms_connector::pubsub_connector, domain_message::DomainMessage, Network};
 use tari_service_framework::{reply_channel, RegisterHandle, StackBuilder};
 use tari_shutdown::{Shutdown, ShutdownSignal};
+use tari_test_utils::random;
 use tari_wallet::{
     base_node_service::{
         config::BaseNodeServiceConfig,
@@ -369,9 +370,11 @@ pub fn setup_transaction_service_no_comms_and_oms_backend<
         outbound_message_requester,
         connectivity_manager,
         event_publisher,
-        Arc::new(
-            NodeIdentity::random(&mut OsRng, get_next_memory_address(), PeerFeatures::COMMUNICATION_NODE).unwrap(),
-        ),
+        Arc::new(NodeIdentity::random(
+            &mut OsRng,
+            get_next_memory_address(),
+            PeerFeatures::COMMUNICATION_NODE,
+        )),
         factories,
         shutdown.to_signal(),
     );
@@ -450,18 +453,24 @@ fn manage_single_transaction() {
 
     let factories = CryptoFactories::default();
     // Alice's parameters
-    let alice_node_identity = Arc::new(
-        NodeIdentity::random(&mut OsRng, get_next_memory_address(), PeerFeatures::COMMUNICATION_NODE).unwrap(),
-    );
+    let alice_node_identity = Arc::new(NodeIdentity::random(
+        &mut OsRng,
+        get_next_memory_address(),
+        PeerFeatures::COMMUNICATION_NODE,
+    ));
 
     // Bob's parameters
-    let bob_node_identity = Arc::new(
-        NodeIdentity::random(&mut OsRng, get_next_memory_address(), PeerFeatures::COMMUNICATION_NODE).unwrap(),
-    );
+    let bob_node_identity = Arc::new(NodeIdentity::random(
+        &mut OsRng,
+        get_next_memory_address(),
+        PeerFeatures::COMMUNICATION_NODE,
+    ));
 
-    let base_node_identity = Arc::new(
-        NodeIdentity::random(&mut OsRng, get_next_memory_address(), PeerFeatures::COMMUNICATION_NODE).unwrap(),
-    );
+    let base_node_identity = Arc::new(NodeIdentity::random(
+        &mut OsRng,
+        get_next_memory_address(),
+        PeerFeatures::COMMUNICATION_NODE,
+    ));
 
     log::info!(
         "manage_single_transaction: Alice: '{}', Bob: '{}', Base: '{}'",
@@ -606,13 +615,17 @@ fn single_transaction_to_self() {
 
     let factories = CryptoFactories::default();
     // Alice's parameters
-    let alice_node_identity = Arc::new(
-        NodeIdentity::random(&mut OsRng, get_next_memory_address(), PeerFeatures::COMMUNICATION_NODE).unwrap(),
-    );
+    let alice_node_identity = Arc::new(NodeIdentity::random(
+        &mut OsRng,
+        get_next_memory_address(),
+        PeerFeatures::COMMUNICATION_NODE,
+    ));
 
-    let base_node_identity = Arc::new(
-        NodeIdentity::random(&mut OsRng, get_next_memory_address(), PeerFeatures::COMMUNICATION_NODE).unwrap(),
-    );
+    let base_node_identity = Arc::new(NodeIdentity::random(
+        &mut OsRng,
+        get_next_memory_address(),
+        PeerFeatures::COMMUNICATION_NODE,
+    ));
 
     log::info!(
         "manage_single_transaction: Alice: '{}', Base: '{}'",
@@ -686,18 +699,24 @@ fn send_one_sided_transaction_to_other() {
 
     let factories = CryptoFactories::default();
     // Alice's parameters
-    let alice_node_identity = Arc::new(
-        NodeIdentity::random(&mut OsRng, get_next_memory_address(), PeerFeatures::COMMUNICATION_NODE).unwrap(),
-    );
+    let alice_node_identity = Arc::new(NodeIdentity::random(
+        &mut OsRng,
+        get_next_memory_address(),
+        PeerFeatures::COMMUNICATION_NODE,
+    ));
 
     // Bob's parameters
-    let bob_node_identity = Arc::new(
-        NodeIdentity::random(&mut OsRng, get_next_memory_address(), PeerFeatures::COMMUNICATION_NODE).unwrap(),
-    );
+    let bob_node_identity = Arc::new(NodeIdentity::random(
+        &mut OsRng,
+        get_next_memory_address(),
+        PeerFeatures::COMMUNICATION_NODE,
+    ));
 
-    let base_node_identity = Arc::new(
-        NodeIdentity::random(&mut OsRng, get_next_memory_address(), PeerFeatures::COMMUNICATION_NODE).unwrap(),
-    );
+    let base_node_identity = Arc::new(NodeIdentity::random(
+        &mut OsRng,
+        get_next_memory_address(),
+        PeerFeatures::COMMUNICATION_NODE,
+    ));
 
     log::info!(
         "manage_single_transaction: Alice: '{}', Bob: '{}', Base: '{}'",
@@ -798,18 +817,24 @@ fn recover_one_sided_transaction() {
 
     let factories = CryptoFactories::default();
     // Alice's parameters
-    let alice_node_identity = Arc::new(
-        NodeIdentity::random(&mut OsRng, get_next_memory_address(), PeerFeatures::COMMUNICATION_NODE).unwrap(),
-    );
+    let alice_node_identity = Arc::new(NodeIdentity::random(
+        &mut OsRng,
+        get_next_memory_address(),
+        PeerFeatures::COMMUNICATION_NODE,
+    ));
 
     // Bob's parameters
-    let bob_node_identity = Arc::new(
-        NodeIdentity::random(&mut OsRng, get_next_memory_address(), PeerFeatures::COMMUNICATION_NODE).unwrap(),
-    );
+    let bob_node_identity = Arc::new(NodeIdentity::random(
+        &mut OsRng,
+        get_next_memory_address(),
+        PeerFeatures::COMMUNICATION_NODE,
+    ));
 
-    let base_node_identity = Arc::new(
-        NodeIdentity::random(&mut OsRng, get_next_memory_address(), PeerFeatures::COMMUNICATION_NODE).unwrap(),
-    );
+    let base_node_identity = Arc::new(NodeIdentity::random(
+        &mut OsRng,
+        get_next_memory_address(),
+        PeerFeatures::COMMUNICATION_NODE,
+    ));
 
     log::info!(
         "manage_single_transaction: Alice: '{}', Bob: '{}', Base: '{}'",
@@ -910,13 +935,17 @@ fn send_one_sided_transaction_to_self() {
 
     let factories = CryptoFactories::default();
     // Alice's parameters
-    let alice_node_identity = Arc::new(
-        NodeIdentity::random(&mut OsRng, get_next_memory_address(), PeerFeatures::COMMUNICATION_NODE).unwrap(),
-    );
+    let alice_node_identity = Arc::new(NodeIdentity::random(
+        &mut OsRng,
+        get_next_memory_address(),
+        PeerFeatures::COMMUNICATION_NODE,
+    ));
 
-    let base_node_identity = Arc::new(
-        NodeIdentity::random(&mut OsRng, get_next_memory_address(), PeerFeatures::COMMUNICATION_NODE).unwrap(),
-    );
+    let base_node_identity = Arc::new(NodeIdentity::random(
+        &mut OsRng,
+        get_next_memory_address(),
+        PeerFeatures::COMMUNICATION_NODE,
+    ));
 
     log::info!(
         "manage_single_transaction: Alice: '{}', Base: '{}'",
@@ -981,19 +1010,25 @@ fn manage_multiple_transactions() {
     let mut runtime = create_runtime();
     let factories = CryptoFactories::default();
     // Alice's parameters
-    let alice_node_identity = Arc::new(
-        NodeIdentity::random(&mut OsRng, get_next_memory_address(), PeerFeatures::COMMUNICATION_NODE).unwrap(),
-    );
+    let alice_node_identity = Arc::new(NodeIdentity::random(
+        &mut OsRng,
+        get_next_memory_address(),
+        PeerFeatures::COMMUNICATION_NODE,
+    ));
 
     // Bob's parameters
-    let bob_node_identity = Arc::new(
-        NodeIdentity::random(&mut OsRng, get_next_memory_address(), PeerFeatures::COMMUNICATION_NODE).unwrap(),
-    );
+    let bob_node_identity = Arc::new(NodeIdentity::random(
+        &mut OsRng,
+        get_next_memory_address(),
+        PeerFeatures::COMMUNICATION_NODE,
+    ));
 
     // Carols's parameters
-    let carol_node_identity = Arc::new(
-        NodeIdentity::random(&mut OsRng, get_next_memory_address(), PeerFeatures::COMMUNICATION_NODE).unwrap(),
-    );
+    let carol_node_identity = Arc::new(NodeIdentity::random(
+        &mut OsRng,
+        get_next_memory_address(),
+        PeerFeatures::COMMUNICATION_NODE,
+    ));
 
     log::info!(
         "wallet::manage_multiple_transactions: Alice: '{}', Bob: '{}', carol: '{}'",
@@ -1235,14 +1270,14 @@ fn test_accepting_unknown_tx_id_and_malformed_reply() {
 
     let temp_dir = tempdir().unwrap();
     let path_string = temp_dir.path().to_str().unwrap().to_string();
-    let alice_db_name = format!("{}.sqlite3", random_string(8).as_str());
+    let alice_db_name = format!("{}.sqlite3", random::string(8).as_str());
     let alice_db_path = format!("{}/{}", path_string, alice_db_name);
     let connection_alice = run_migration_and_create_sqlite_connection(&alice_db_path).unwrap();
     let alice_backend = TransactionServiceSqliteDatabase::new(connection_alice.clone(), None);
     let oms_backend = OutputManagerSqliteDatabase::new(connection_alice, None);
 
     let bob_node_identity =
-        NodeIdentity::random(&mut OsRng, get_next_memory_address(), PeerFeatures::COMMUNICATION_NODE).unwrap();
+        NodeIdentity::random(&mut OsRng, get_next_memory_address(), PeerFeatures::COMMUNICATION_NODE);
     let (
         mut alice_ts,
         mut alice_output_manager,
@@ -1344,9 +1379,9 @@ fn finalize_tx_with_incorrect_pubkey() {
     let temp_dir = tempdir().unwrap();
     let path_string = temp_dir.path().to_str().unwrap().to_string();
 
-    let alice_db_name = format!("{}.sqlite3", random_string(8).as_str());
+    let alice_db_name = format!("{}.sqlite3", random::string(8).as_str());
     let alice_db_path = format!("{}/{}", path_string, alice_db_name);
-    let bob_db_name = format!("{}.sqlite3", random_string(8).as_str());
+    let bob_db_name = format!("{}.sqlite3", random::string(8).as_str());
     let bob_db_path = format!("{}/{}", path_string, bob_db_name);
     let connection_alice = run_migration_and_create_sqlite_connection(&alice_db_path).unwrap();
     let connection_bob = run_migration_and_create_sqlite_connection(&bob_db_path).unwrap();
@@ -1374,7 +1409,7 @@ fn finalize_tx_with_incorrect_pubkey() {
     let mut alice_event_stream = alice_ts.get_event_stream_fused();
 
     let bob_node_identity =
-        NodeIdentity::random(&mut OsRng, get_next_memory_address(), PeerFeatures::COMMUNICATION_NODE).unwrap();
+        NodeIdentity::random(&mut OsRng, get_next_memory_address(), PeerFeatures::COMMUNICATION_NODE);
     let (
         _bob_ts,
         mut bob_output_manager,
@@ -1471,9 +1506,9 @@ fn finalize_tx_with_missing_output() {
     let temp_dir = tempdir().unwrap();
     let path_string = temp_dir.path().to_str().unwrap().to_string();
 
-    let alice_db_name = format!("{}.sqlite3", random_string(8).as_str());
+    let alice_db_name = format!("{}.sqlite3", random::string(8).as_str());
     let alice_db_path = format!("{}/{}", path_string, alice_db_name);
-    let bob_db_name = format!("{}.sqlite3", random_string(8).as_str());
+    let bob_db_name = format!("{}.sqlite3", random::string(8).as_str());
     let bob_db_path = format!("{}/{}", path_string, bob_db_name);
     let connection_alice = run_migration_and_create_sqlite_connection(&alice_db_path).unwrap();
     let connection_bob = run_migration_and_create_sqlite_connection(&bob_db_path).unwrap();
@@ -1500,7 +1535,7 @@ fn finalize_tx_with_missing_output() {
     let mut alice_event_stream = alice_ts.get_event_stream_fused();
 
     let bob_node_identity =
-        NodeIdentity::random(&mut OsRng, get_next_memory_address(), PeerFeatures::COMMUNICATION_NODE).unwrap();
+        NodeIdentity::random(&mut OsRng, get_next_memory_address(), PeerFeatures::COMMUNICATION_NODE);
     let (
         _bob_ts,
         mut bob_output_manager,
@@ -1611,19 +1646,25 @@ fn discovery_async_return_test() {
     let factories = CryptoFactories::default();
 
     // Alice's parameters
-    let alice_node_identity = Arc::new(
-        NodeIdentity::random(&mut OsRng, get_next_memory_address(), PeerFeatures::COMMUNICATION_NODE).unwrap(),
-    );
+    let alice_node_identity = Arc::new(NodeIdentity::random(
+        &mut OsRng,
+        get_next_memory_address(),
+        PeerFeatures::COMMUNICATION_NODE,
+    ));
 
     // Bob's parameters
-    let bob_node_identity = Arc::new(
-        NodeIdentity::random(&mut OsRng, get_next_memory_address(), PeerFeatures::COMMUNICATION_NODE).unwrap(),
-    );
+    let bob_node_identity = Arc::new(NodeIdentity::random(
+        &mut OsRng,
+        get_next_memory_address(),
+        PeerFeatures::COMMUNICATION_NODE,
+    ));
 
     // Carols's parameters
-    let carol_node_identity = Arc::new(
-        NodeIdentity::random(&mut OsRng, get_next_memory_address(), PeerFeatures::COMMUNICATION_NODE).unwrap(),
-    );
+    let carol_node_identity = Arc::new(NodeIdentity::random(
+        &mut OsRng,
+        get_next_memory_address(),
+        PeerFeatures::COMMUNICATION_NODE,
+    ));
 
     log::info!(
         "discovery_async_return_test: Alice: '{}', Bob: '{}', Carol: '{}'",
@@ -1884,7 +1925,7 @@ fn test_set_num_confirmations() {
     let factories = CryptoFactories::default();
     let mut runtime = Runtime::new().unwrap();
 
-    let db_name = format!("{}.sqlite3", random_string(8).as_str());
+    let db_name = format!("{}.sqlite3", random::string(8).as_str());
     let temp_dir = tempdir().unwrap();
     let db_folder = temp_dir.path().to_str().unwrap().to_string();
     let connection = run_migration_and_create_sqlite_connection(&format!("{}/{}", db_folder, db_name)).unwrap();
@@ -1925,9 +1966,9 @@ fn test_transaction_cancellation() {
     let mut runtime = Runtime::new().unwrap();
 
     let bob_node_identity =
-        NodeIdentity::random(&mut OsRng, get_next_memory_address(), PeerFeatures::COMMUNICATION_NODE).unwrap();
+        NodeIdentity::random(&mut OsRng, get_next_memory_address(), PeerFeatures::COMMUNICATION_NODE);
 
-    let db_name = format!("{}.sqlite3", random_string(8).as_str());
+    let db_name = format!("{}.sqlite3", random::string(8).as_str());
     let temp_dir = tempdir().unwrap();
     let db_folder = temp_dir.path().to_str().unwrap().to_string();
     let connection = run_migration_and_create_sqlite_connection(&format!("{}/{}", db_folder, db_name)).unwrap();
@@ -2235,10 +2276,10 @@ fn test_direct_vs_saf_send_of_tx_reply_and_finalize() {
     let mut runtime = Runtime::new().unwrap();
 
     let alice_node_identity =
-        NodeIdentity::random(&mut OsRng, get_next_memory_address(), PeerFeatures::COMMUNICATION_NODE).unwrap();
+        NodeIdentity::random(&mut OsRng, get_next_memory_address(), PeerFeatures::COMMUNICATION_NODE);
 
     let bob_node_identity =
-        NodeIdentity::random(&mut OsRng, get_next_memory_address(), PeerFeatures::COMMUNICATION_NODE).unwrap();
+        NodeIdentity::random(&mut OsRng, get_next_memory_address(), PeerFeatures::COMMUNICATION_NODE);
     let (_wallet_backend, tx_backend, oms_backend, _, _temp_dir) = make_wallet_databases(None);
 
     let (
@@ -2478,7 +2519,7 @@ fn test_tx_direct_send_behaviour() {
     let mut runtime = Runtime::new().unwrap();
 
     let bob_node_identity =
-        NodeIdentity::random(&mut OsRng, get_next_memory_address(), PeerFeatures::COMMUNICATION_NODE).unwrap();
+        NodeIdentity::random(&mut OsRng, get_next_memory_address(), PeerFeatures::COMMUNICATION_NODE);
     let (_wallet_backend, backend, oms_backend, _, _temp_dir) = make_wallet_databases(None);
 
     let (
@@ -2684,17 +2725,23 @@ fn test_restarting_transaction_protocols() {
     let (_wallet_backend, alice_backend, alice_oms_backend, _, _temp_dir) = make_wallet_databases(None);
     let (_, bob_backend, bob_oms_backend, _, _temp_dir2) = make_wallet_databases(None);
 
-    let base_node_identity = Arc::new(
-        NodeIdentity::random(&mut OsRng, get_next_memory_address(), PeerFeatures::COMMUNICATION_NODE).unwrap(),
-    );
+    let base_node_identity = Arc::new(NodeIdentity::random(
+        &mut OsRng,
+        get_next_memory_address(),
+        PeerFeatures::COMMUNICATION_NODE,
+    ));
 
-    let alice_identity = Arc::new(
-        NodeIdentity::random(&mut OsRng, get_next_memory_address(), PeerFeatures::COMMUNICATION_NODE).unwrap(),
-    );
+    let alice_identity = Arc::new(NodeIdentity::random(
+        &mut OsRng,
+        get_next_memory_address(),
+        PeerFeatures::COMMUNICATION_NODE,
+    ));
 
-    let bob_identity = Arc::new(
-        NodeIdentity::random(&mut OsRng, get_next_memory_address(), PeerFeatures::COMMUNICATION_NODE).unwrap(),
-    );
+    let bob_identity = Arc::new(NodeIdentity::random(
+        &mut OsRng,
+        get_next_memory_address(),
+        PeerFeatures::COMMUNICATION_NODE,
+    ));
 
     // Bob is going to send a transaction to Alice
     let alice = TestParams::new(&mut OsRng);
@@ -3589,9 +3636,9 @@ fn test_transaction_resending() {
     let mut runtime = Runtime::new().unwrap();
 
     let alice_node_identity =
-        NodeIdentity::random(&mut OsRng, get_next_memory_address(), PeerFeatures::COMMUNICATION_NODE).unwrap();
+        NodeIdentity::random(&mut OsRng, get_next_memory_address(), PeerFeatures::COMMUNICATION_NODE);
     let bob_node_identity =
-        NodeIdentity::random(&mut OsRng, get_next_memory_address(), PeerFeatures::COMMUNICATION_NODE).unwrap();
+        NodeIdentity::random(&mut OsRng, get_next_memory_address(), PeerFeatures::COMMUNICATION_NODE);
     // Setup Alice wallet with no comms stack
     let (_, alice_backend, alice_oms_backend, _, _tempdir) = make_wallet_databases(None);
 
@@ -3786,7 +3833,7 @@ fn test_resend_on_startup() {
     let mut runtime = Runtime::new().unwrap();
 
     let alice_node_identity =
-        NodeIdentity::random(&mut OsRng, get_next_memory_address(), PeerFeatures::COMMUNICATION_NODE).unwrap();
+        NodeIdentity::random(&mut OsRng, get_next_memory_address(), PeerFeatures::COMMUNICATION_NODE);
 
     // First we will check the Send Tranasction message
     let input = create_unblinded_output(
@@ -4027,9 +4074,9 @@ fn test_replying_to_cancelled_tx() {
     let mut runtime = Runtime::new().unwrap();
 
     let alice_node_identity =
-        NodeIdentity::random(&mut OsRng, get_next_memory_address(), PeerFeatures::COMMUNICATION_NODE).unwrap();
+        NodeIdentity::random(&mut OsRng, get_next_memory_address(), PeerFeatures::COMMUNICATION_NODE);
     let bob_node_identity =
-        NodeIdentity::random(&mut OsRng, get_next_memory_address(), PeerFeatures::COMMUNICATION_NODE).unwrap();
+        NodeIdentity::random(&mut OsRng, get_next_memory_address(), PeerFeatures::COMMUNICATION_NODE);
     // Testing if a Tx Reply is received for a Cancelled Outbound Tx that a Cancelled message is sent back:
     let (_, alice_backend, alice_oms_backend, _, _tempdir) = make_wallet_databases(None);
 
@@ -4161,7 +4208,7 @@ fn test_transaction_timeout_cancellation() {
     let mut runtime = Runtime::new().unwrap();
 
     let bob_node_identity =
-        NodeIdentity::random(&mut OsRng, get_next_memory_address(), PeerFeatures::COMMUNICATION_NODE).unwrap();
+        NodeIdentity::random(&mut OsRng, get_next_memory_address(), PeerFeatures::COMMUNICATION_NODE);
     // Testing if a Tx Reply is received for a Cancelled Outbound Tx that a Cancelled message is sent back:
     let (_, alice_backend, alice_oms_backend, _, _tempdir) = make_wallet_databases(None);
 
@@ -4402,10 +4449,10 @@ fn transaction_service_tx_broadcast() {
     let mut runtime = Runtime::new().unwrap();
 
     let alice_node_identity =
-        NodeIdentity::random(&mut OsRng, get_next_memory_address(), PeerFeatures::COMMUNICATION_NODE).unwrap();
+        NodeIdentity::random(&mut OsRng, get_next_memory_address(), PeerFeatures::COMMUNICATION_NODE);
 
     let bob_node_identity =
-        NodeIdentity::random(&mut OsRng, get_next_memory_address(), PeerFeatures::COMMUNICATION_NODE).unwrap();
+        NodeIdentity::random(&mut OsRng, get_next_memory_address(), PeerFeatures::COMMUNICATION_NODE);
     let (_, backend, oms_backend, _, _temp_dir) = make_wallet_databases(None);
 
     let (
@@ -4837,10 +4884,10 @@ fn transaction_service_tx_broadcast_with_base_node_change() {
     let mut runtime = Runtime::new().unwrap();
 
     let alice_node_identity =
-        NodeIdentity::random(&mut OsRng, get_next_memory_address(), PeerFeatures::COMMUNICATION_NODE).unwrap();
+        NodeIdentity::random(&mut OsRng, get_next_memory_address(), PeerFeatures::COMMUNICATION_NODE);
 
     let bob_node_identity =
-        NodeIdentity::random(&mut OsRng, get_next_memory_address(), PeerFeatures::COMMUNICATION_NODE).unwrap();
+        NodeIdentity::random(&mut OsRng, get_next_memory_address(), PeerFeatures::COMMUNICATION_NODE);
     let (_, backend, oms_backend, _, _temp_dir) = make_wallet_databases(None);
 
     let (
@@ -5042,7 +5089,7 @@ fn only_start_one_tx_broadcast_protocol_at_a_time() {
     let factories = CryptoFactories::default();
 
     let temp_dir = tempdir().unwrap();
-    let db_name = format!("{}.sqlite3", random_string(8).as_str());
+    let db_name = format!("{}.sqlite3", random::string(8).as_str());
     let db_path = format!("{}/{}", temp_dir.path().to_str().unwrap(), db_name);
     let connection = run_migration_and_create_sqlite_connection(&db_path).unwrap();
     let backend = TransactionServiceSqliteDatabase::new(connection.clone(), None);
@@ -5110,7 +5157,7 @@ fn dont_broadcast_invalid_transactions() {
     let factories = CryptoFactories::default();
 
     let temp_dir = tempdir().unwrap();
-    let db_name = format!("{}.sqlite3", random_string(8).as_str());
+    let db_name = format!("{}.sqlite3", random::string(8).as_str());
     let db_path = format!("{}/{}", temp_dir.path().to_str().unwrap(), db_name);
     let connection = run_migration_and_create_sqlite_connection(&db_path).unwrap();
     let backend = TransactionServiceSqliteDatabase::new(connection.clone(), None);
@@ -5177,7 +5224,7 @@ fn start_validation_protocol_then_broadcast_protocol_change_base_node() {
     let factories = CryptoFactories::default();
 
     let temp_dir = tempdir().unwrap();
-    let db_name = format!("{}.sqlite3", random_string(8).as_str());
+    let db_name = format!("{}.sqlite3", random::string(8).as_str());
     let db_path = format!("{}/{}", temp_dir.path().to_str().unwrap(), db_name);
     let connection = run_migration_and_create_sqlite_connection(&db_path).unwrap();
     let tx_backend = TransactionServiceSqliteDatabase::new(connection.clone(), None);

--- a/base_layer/wallet/tests/transaction_service/storage.rs
+++ b/base_layer/wallet/tests/transaction_service/storage.rs
@@ -20,7 +20,6 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use crate::support::utils::random_string;
 use aes_gcm::{
     aead::{generic_array::GenericArray, NewAead},
     Aes256Gcm,
@@ -41,6 +40,7 @@ use tari_crypto::{
     script,
     script::{ExecutionStack, TariScript},
 };
+use tari_test_utils::random;
 use tari_wallet::{
     storage::sqlite_utilities::run_migration_and_create_sqlite_connection,
     transaction_service::storage::{
@@ -556,7 +556,7 @@ pub fn test_db_backend<T: TransactionBackend + 'static>(backend: T) {
 
 #[test]
 pub fn test_transaction_service_sqlite_db() {
-    let db_name = format!("{}.sqlite3", random_string(8).as_str());
+    let db_name = format!("{}.sqlite3", random::string(8));
     let db_tempdir = tempdir().unwrap();
     let db_folder = db_tempdir.path().to_str().unwrap().to_string();
     let db_path = format!("{}/{}", db_folder, db_name);
@@ -567,7 +567,7 @@ pub fn test_transaction_service_sqlite_db() {
 
 #[test]
 pub fn test_transaction_service_sqlite_db_encrypted() {
-    let db_name = format!("{}.sqlite3", random_string(8).as_str());
+    let db_name = format!("{}.sqlite3", random::string(8));
     let db_tempdir = tempdir().unwrap();
     let db_folder = db_tempdir.path().to_str().unwrap().to_string();
     let db_path = format!("{}/{}", db_folder, db_name);

--- a/base_layer/wallet/tests/transaction_service/transaction_protocols.rs
+++ b/base_layer/wallet/tests/transaction_service/transaction_protocols.rs
@@ -22,7 +22,7 @@
 
 use crate::support::{
     rpc::{BaseNodeWalletRpcMockService, BaseNodeWalletRpcMockState},
-    utils::{make_input, random_string},
+    utils::make_input,
 };
 use chrono::Utc;
 use futures::{FutureExt, StreamExt};
@@ -54,6 +54,7 @@ use tari_core::{
 };
 use tari_service_framework::{reply_channel, reply_channel::Receiver};
 use tari_shutdown::Shutdown;
+use tari_test_utils::random;
 use tari_wallet::{
     output_manager_service::{
         error::OutputManagerError,
@@ -128,7 +129,7 @@ pub async fn setup(
         connectivity_mock_state.add_active_connection(connection).await;
     }
 
-    let db_name = format!("{}.sqlite3", random_string(8).as_str());
+    let db_name = format!("{}.sqlite3", random::string(8).as_str());
     let temp_dir = tempdir().unwrap();
     let db_folder = temp_dir.path().to_str().unwrap().to_string();
     let db_connection = run_migration_and_create_sqlite_connection(&format!("{}/{}", db_folder, db_name)).unwrap();

--- a/base_layer/wallet_ffi/Cargo.toml
+++ b/base_layer/wallet_ffi/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2018"
 [dependencies]
 tari_comms = { version = "^0.8", path = "../../comms" }
 tari_comms_dht = { version = "^0.8", path = "../../comms/dht" }
-tari_crypto = { git = "https://github.com/tari-project/tari-crypto.git", rev = "ecd77ec2b" }
+tari_crypto = "0.11.1"
 tari_key_manager = { version = "^0.8", path = "../key_manager" }
 tari_p2p = { version = "^0.8", path = "../p2p" }
 tari_wallet = { version = "^0.8", path = "../wallet", features = ["test_harness", "c_integration"]}
@@ -19,7 +19,7 @@ tari_utilities = "^0.3"
 futures =  { version = "^0.3.1", features =["compat", "std"]}
 tokio = "0.2.10"
 libc = "0.2.65"
-rand = "0.7.2"
+rand = "0.8"
 chrono = { version = "0.4.6", features = ["serde"]}
 thiserror = "1.0.20"
 log = "0.4.6"
@@ -40,4 +40,5 @@ lazy_static = "1.3.0"
 env_logger = "0.7.1"
 tari_key_manager = { version = "^0.8", path = "../key_manager" }
 tari_common_types = { version = "^0.8", path = "../../base_layer/common_types"}
+tari_test_utils = { version = "^0.8", path = "../../infrastructure/test_utils"}
 tokio = { version="0.2.10" }

--- a/base_layer/wallet_ffi/src/error.rs
+++ b/base_layer/wallet_ffi/src/error.rs
@@ -20,10 +20,7 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 use log::*;
-use tari_comms::{
-    multiaddr,
-    peer_manager::{node_id::NodeIdError, NodeIdentityError},
-};
+use tari_comms::multiaddr;
 use tari_comms_dht::store_forward::StoreAndForwardError;
 use tari_crypto::{
     signatures::SchnorrSignatureError,
@@ -314,25 +311,6 @@ impl From<ByteArrayError> for LibWalletError {
             ByteArrayError::IncorrectLength => Self {
                 code: 601,
                 message: format!("{:?}", b),
-            },
-        }
-    }
-}
-
-impl From<NodeIdentityError> for LibWalletError {
-    fn from(n: NodeIdentityError) -> Self {
-        error!(target: LOG_TARGET, "{}", format!("{:?}", n));
-        match n {
-            NodeIdentityError::NodeIdError(NodeIdError::IncorrectByteCount) => Self {
-                code: 701,
-                message: format!("{:?}", n),
-            },
-            // No longer applicable:
-            // 702 NodeIdentityError::OutOfBounds
-            // 703 NodeIdentityError::AddressLockPoisoned
-            NodeIdentityError::NodeIdError(NodeIdError::InvalidDigestOutputSize) => Self {
-                code: 704,
-                message: format!("{:?}", n),
             },
         }
     }

--- a/base_layer/wallet_ffi/src/lib.rs
+++ b/base_layer/wallet_ffi/src/lib.rs
@@ -2623,43 +2623,34 @@ pub unsafe extern "C" fn comms_config_create(
                 public_address,
                 PeerFeatures::COMMUNICATION_CLIENT,
             );
-            match ni {
-                Ok(ni) => {
-                    let config = TariCommsConfig {
-                        network: Network::Weatherwax,
-                        node_identity: Arc::new(ni),
-                        transport_type: (*transport_type).clone(),
-                        datastore_path,
-                        peer_database_name: database_name_string,
-                        max_concurrent_inbound_tasks: 100,
-                        outbound_buffer_size: 100,
-                        dht: DhtConfig {
-                            discovery_request_timeout: Duration::from_secs(discovery_timeout_in_secs),
-                            database_url: DbConnectionUrl::File(dht_database_path),
-                            auto_join: true,
-                            saf_msg_validity: Duration::from_secs(saf_message_duration_in_secs),
-                            ..Default::default()
-                        },
-                        // TODO: This should be set to false for non-test wallets. See the `allow_test_addresses` field
-                        //       docstring for more info.
-                        allow_test_addresses: true,
-                        listener_liveness_allowlist_cidrs: Vec::new(),
-                        listener_liveness_max_sessions: 0,
-                        user_agent: format!("tari/wallet/{}", env!("CARGO_PKG_VERSION")),
-                        dns_seeds_name_server: "1.1.1.1:53".parse().unwrap(),
-                        peer_seeds: Default::default(),
-                        dns_seeds: Default::default(),
-                        dns_seeds_use_dnssec: true,
-                    };
+            let config = TariCommsConfig {
+                network: Network::Weatherwax,
+                node_identity: Arc::new(ni),
+                transport_type: (*transport_type).clone(),
+                datastore_path,
+                peer_database_name: database_name_string,
+                max_concurrent_inbound_tasks: 100,
+                outbound_buffer_size: 100,
+                dht: DhtConfig {
+                    discovery_request_timeout: Duration::from_secs(discovery_timeout_in_secs),
+                    database_url: DbConnectionUrl::File(dht_database_path),
+                    auto_join: true,
+                    saf_msg_validity: Duration::from_secs(saf_message_duration_in_secs),
+                    ..Default::default()
+                },
+                // TODO: This should be set to false for non-test wallets. See the `allow_test_addresses` field
+                //       docstring for more info.
+                allow_test_addresses: true,
+                listener_liveness_allowlist_cidrs: Vec::new(),
+                listener_liveness_max_sessions: 0,
+                user_agent: format!("tari/wallet/{}", env!("CARGO_PKG_VERSION")),
+                dns_seeds_name_server: "1.1.1.1:53".parse().unwrap(),
+                peer_seeds: Default::default(),
+                dns_seeds: Default::default(),
+                dns_seeds_use_dnssec: true,
+            };
 
-                    Box::into_raw(Box::new(config))
-                },
-                Err(e) => {
-                    error = LibWalletError::from(e).code;
-                    ptr::swap(error_out, &mut error as *mut c_int);
-                    ptr::null_mut()
-                },
-            }
+            Box::into_raw(Box::new(config))
         },
         Err(e) => {
             error = LibWalletError::from(e).code;
@@ -5522,7 +5513,6 @@ pub unsafe extern "C" fn log_debug_message(msg: *const c_char) {
 
 #[cfg(test)]
 mod test {
-
     use crate::*;
     use libc::{c_char, c_uchar, c_uint};
     use std::{
@@ -5534,9 +5524,9 @@ mod test {
     };
     use tari_core::transactions::{fee::Fee, tari_amount::uT, types::PrivateKey};
     use tari_key_manager::mnemonic::Mnemonic;
+    use tari_test_utils::random;
     use tari_wallet::{
         storage::sqlite_utilities::run_migration_and_create_sqlite_connection,
-        testnet_utils::random_string,
         transaction_service::{config::TransactionServiceConfig, storage::models::TransactionStatus},
         util::emoji,
     };
@@ -6086,7 +6076,7 @@ mod test {
             let error_ptr = &mut error as *mut c_int;
             let secret_key_alice = private_key_generate();
             let public_key_alice = public_key_from_private_key(secret_key_alice, error_ptr);
-            let db_name_alice = CString::new(random_string(8).as_str()).unwrap();
+            let db_name_alice = CString::new(random::string(8).as_str()).unwrap();
             let db_name_alice_str: *const c_char = CString::into_raw(db_name_alice) as *const c_char;
             let alice_temp_dir = tempdir().unwrap();
             let db_path_alice = CString::new(alice_temp_dir.path().to_str().unwrap()).unwrap();
@@ -6135,7 +6125,7 @@ mod test {
             );
             let secret_key_bob = private_key_generate();
             let public_key_bob = public_key_from_private_key(secret_key_bob, error_ptr);
-            let db_name_bob = CString::new(random_string(8).as_str()).unwrap();
+            let db_name_bob = CString::new(random::string(8).as_str()).unwrap();
             let db_name_bob_str: *const c_char = CString::into_raw(db_name_bob) as *const c_char;
             let bob_temp_dir = tempdir().unwrap();
             let db_path_bob = CString::new(bob_temp_dir.path().to_str().unwrap()).unwrap();
@@ -6647,7 +6637,7 @@ mod test {
 
             let secret_key_alice = private_key_generate();
             let public_key_alice = public_key_from_private_key(secret_key_alice, error_ptr);
-            let db_name = random_string(8);
+            let db_name = random::string(8);
             let db_name_alice = CString::new(db_name.as_str()).unwrap();
             let db_name_alice_str: *const c_char = CString::into_raw(db_name_alice) as *const c_char;
             let alice_temp_dir = tempdir().unwrap();
@@ -6799,7 +6789,7 @@ mod test {
 
             let secret_key_alice = private_key_generate();
             let public_key_alice = public_key_from_private_key(secret_key_alice, error_ptr);
-            let db_name_alice = CString::new(random_string(8).as_str()).unwrap();
+            let db_name_alice = CString::new(random::string(8).as_str()).unwrap();
             let db_name_alice_str: *const c_char = CString::into_raw(db_name_alice) as *const c_char;
             let alice_temp_dir = tempdir().unwrap();
             let db_path_alice = CString::new(alice_temp_dir.path().to_str().unwrap()).unwrap();
@@ -7015,7 +7005,7 @@ mod test {
             let error_ptr = &mut error as *mut c_int;
 
             let secret_key_alice = private_key_generate();
-            let db_name_alice = CString::new(random_string(8).as_str()).unwrap();
+            let db_name_alice = CString::new(random::string(8).as_str()).unwrap();
             let db_name_alice_str: *const c_char = CString::into_raw(db_name_alice) as *const c_char;
             let alice_temp_dir = tempdir().unwrap();
             let db_path_alice = CString::new(alice_temp_dir.path().to_str().unwrap()).unwrap();
@@ -7158,7 +7148,7 @@ mod test {
             }
 
             // create a new wallet
-            let db_name = CString::new(random_string(8).as_str()).unwrap();
+            let db_name = CString::new(random::string(8).as_str()).unwrap();
             let db_name_str: *const c_char = CString::into_raw(db_name) as *const c_char;
             let temp_dir = tempdir().unwrap();
             let db_path = CString::new(temp_dir.path().to_str().unwrap()).unwrap();
@@ -7208,7 +7198,7 @@ mod test {
             assert_eq!(error, 0);
 
             // use seed words to create recovery wallet
-            let db_name = CString::new(random_string(8).as_str()).unwrap();
+            let db_name = CString::new(random::string(8).as_str()).unwrap();
             let db_name_str: *const c_char = CString::into_raw(db_name) as *const c_char;
             let temp_dir = tempdir().unwrap();
             let db_path = CString::new(temp_dir.path().to_str().unwrap()).unwrap();

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -22,7 +22,7 @@ get_if_addrs = "0.5.3"
 log = "0.4.8"
 log4rs = "0.8.3"
 multiaddr={package="parity-multiaddr", version = "0.11.0"}
-sha2 = "0.8.0"
+sha2 = "0.9.5"
 path-clean = "0.1.0"
 tari_storage = { version = "^0.8", path = "../infrastructure/storage"}
 

--- a/common/src/build/protobuf.rs
+++ b/common/src/build/protobuf.rs
@@ -116,7 +116,7 @@ impl ProtobufCompiler {
         let mut file = File::open(file_path).unwrap();
         let mut file_hash = Sha256::default();
         io::copy(&mut file, &mut file_hash).map_err(|err| format!("Failed to hash file: '{}'", err))?;
-        Ok(file_hash.result().to_vec())
+        Ok(file_hash.finalize().to_vec())
     }
 
     fn compare_and_move<P: AsRef<Path>>(&self, tmp_out_dir: P, out_dir: P) {

--- a/comms/Cargo.toml
+++ b/comms/Cargo.toml
@@ -10,18 +10,18 @@ version = "0.8.11"
 edition = "2018"
 
 [dependencies]
-tari_crypto = { git = "https://github.com/tari-project/tari-crypto.git", rev = "ecd77ec2b" }
+tari_crypto = "0.11.1"
 tari_storage = { version = "^0.8", path = "../infrastructure/storage" }
 tari_shutdown = { version="^0.8",  path = "../infrastructure/shutdown" }
 
 bitflags = "1.0.4"
-blake2 = "0.8.1"
+blake2 = "0.9.0"
 bytes = { version = "0.5.x", features=["serde"] }
 chrono = { version = "0.4.6", features = ["serde"] }
 cidr = "0.1.0"
 clear_on_drop = "=0.2.4"
 data-encoding = "2.2.0"
-digest = "0.8.0"
+digest = "0.9.0"
 futures =  { version = "^0.3", features = ["async-await"]}
 lazy_static = "1.3.0"
 lmdb-zero = "0.4.4"
@@ -30,7 +30,7 @@ multiaddr = {version = "=0.11.0", package = "parity-multiaddr"}
 nom = {version = "5.1.0", features=["std"], default-features=false}
 pin-project = "0.4.17"
 prost = "=0.6.1"
-rand = "0.7.2"
+rand = "0.8"
 serde = "1.0.119"
 serde_derive = "1.0.119"
 snow = {version="=0.8.0", features=["default-resolver"]}

--- a/comms/dht/Cargo.toml
+++ b/comms/dht/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2018"
 [dependencies]
 tari_comms  = { version = "^0.8", path = "../", features = ["rpc"]}
 tari_comms_rpc_macros  = { version = "^0.8", path = "../rpc_macros"}
-tari_crypto = { git = "https://github.com/tari-project/tari-crypto.git", rev = "ecd77ec2b" }
+tari_crypto = "0.11.1"
 tari_utilities  = { version = "^0.3" }
 tari_shutdown = { version = "^0.8", path = "../../infrastructure/shutdown"}
 tari_storage  = { version = "^0.8", path = "../../infrastructure/storage"}
@@ -24,12 +24,12 @@ chacha20 = "0.7.1"
 chrono = "0.4.9"
 diesel = {version="1.4", features = ["sqlite", "serde_json", "chrono", "numeric"]}
 diesel_migrations =  "1.4"
-digest = "0.8.1"
+digest = "0.9.0"
 futures= {version= "^0.3.1"}
 log = "0.4.8"
 prost = "=0.6.1"
 prost-types = "=0.6.1"
-rand = "0.7.2"
+rand = "0.8"
 serde = "1.0.90"
 serde_derive = "1.0.90"
 serde_repr = "0.1.5"

--- a/comms/dht/examples/memory_net/utilities.rs
+++ b/comms/dht/examples/memory_net/utilities.rs
@@ -249,7 +249,7 @@ pub async fn network_connectivity_stats(nodes: &[TestNode], wallets: &[TestNode]
 pub async fn do_network_wide_propagation(nodes: &mut [TestNode], origin_node_index: Option<usize>) -> (usize, usize) {
     let random_node = match origin_node_index {
         Some(n) if n < nodes.len() => &nodes[n],
-        Some(_) | None => &nodes[OsRng.gen_range(0, nodes.len() - 1)],
+        Some(_) | None => &nodes[OsRng.gen_range(0..nodes.len() - 1)],
     };
 
     let random_node_id = random_node.comms.node_identity().node_id().clone();
@@ -788,7 +788,11 @@ impl fmt::Display for TestNode {
 
 pub fn make_node_identity(features: PeerFeatures) -> Arc<NodeIdentity> {
     let port = MemoryTransport::acquire_next_memsocket_port();
-    Arc::new(NodeIdentity::random(&mut OsRng, format!("/memory/{}", port).parse().unwrap(), features).unwrap())
+    Arc::new(NodeIdentity::random(
+        &mut OsRng,
+        format!("/memory/{}", port).parse().unwrap(),
+        features,
+    ))
 }
 
 fn create_peer_storage() -> CommsDatabase {

--- a/comms/dht/examples/memorynet.rs
+++ b/comms/dht/examples/memorynet.rs
@@ -112,7 +112,7 @@ async fn main() {
         repeat_with(|| {
             make_node(
                 PeerFeatures::COMMUNICATION_CLIENT,
-                vec![nodes[OsRng.gen_range(0, NUM_NODES - 1)].node_identity()],
+                vec![nodes[OsRng.gen_range(0..NUM_NODES - 1)].node_identity()],
                 node_message_tx.clone(),
                 NUM_NEIGHBOURING_NODES,
                 NUM_RANDOM_NODES,
@@ -221,7 +221,7 @@ async fn main() {
     let mut total_saf_timeouts = 0;
     let total_saf_done = 5;
     for _ in 0..5 {
-        let random_wallet = wallets.remove(OsRng.gen_range(0, wallets.len() - 1));
+        let random_wallet = wallets.remove(OsRng.gen_range(0..wallets.len() - 1));
         let (num_msgs, random_wallet, num_successes, num_attempts) = do_store_and_forward_message_propagation(
             random_wallet,
             &wallets,

--- a/comms/dht/src/dedup.rs
+++ b/comms/dht/src/dedup.rs
@@ -21,7 +21,7 @@
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 use crate::{actor::DhtRequester, inbound::DhtInboundMessage};
-use digest::Input;
+use digest::Digest;
 use futures::{future::BoxFuture, task::Context};
 use log::*;
 use std::task::Poll;
@@ -32,7 +32,7 @@ use tower::{layer::Layer, Service, ServiceExt};
 const LOG_TARGET: &str = "comms::dht::dedup";
 
 fn hash_inbound_message(message: &DhtInboundMessage) -> Vec<u8> {
-    Challenge::new().chain(&message.body).result().to_vec()
+    Challenge::new().chain(&message.body).finalize().to_vec()
 }
 
 /// # DHT Deduplication middleware

--- a/comms/dht/src/discovery/service.rs
+++ b/comms/dht/src/discovery/service.rs
@@ -271,7 +271,7 @@ impl DhtDiscoveryService {
         // The reason that we check the given node id against what we expect instead of just using the given node id
         // is in future the NodeId may not necessarily be derived from the public key (i.e. DAN node is registered on
         // the base layer)
-        let expected_node_id = NodeId::from_key(public_key).map_err(|_| DhtDiscoveryError::InvalidNodeId)?;
+        let expected_node_id = NodeId::from_key(public_key);
         let node_id = NodeId::from_bytes(raw_node_id).map_err(|_| DhtDiscoveryError::InvalidNodeId)?;
         if expected_node_id == node_id {
             Ok(expected_node_id)

--- a/comms/dht/src/inbound/dht_handler/task.rs
+++ b/comms/dht/src/inbound/dht_handler/task.rs
@@ -119,7 +119,7 @@ where S: Service<DecryptedDhtMessage, Response = (), Error = PipelineError>
         // The reason that we check the given node id against what we expect instead of just using the given node id
         // is in future the NodeId may not necessarily be derived from the public key (i.e. DAN node is registered on
         // the base layer)
-        let expected_node_id = NodeId::from_key(public_key).map_err(|_| DhtInboundError::InvalidNodeId)?;
+        let expected_node_id = NodeId::from_key(public_key);
         let node_id = NodeId::from_bytes(raw_node_id).map_err(|_| DhtInboundError::InvalidNodeId)?;
         if expected_node_id == node_id {
             Ok(expected_node_id)

--- a/comms/dht/src/outbound/broadcast.rs
+++ b/comms/dht/src/outbound/broadcast.rs
@@ -448,7 +448,7 @@ where S: Service<DhtOutboundMessage, Response = (), Error = PipelineError>
     }
 
     async fn add_to_dedup_cache(&mut self, body: &[u8]) -> Result<bool, DhtOutboundError> {
-        let hash = Challenge::new().chain(&body).result().to_vec();
+        let hash = Challenge::new().chain(&body).finalize().to_vec();
         trace!(
             target: LOG_TARGET,
             "Dedup added message hash {} to cache for message",
@@ -541,7 +541,7 @@ mod test {
         let pk = CommsPublicKey::default();
         let example_peer = Peer::new(
             pk.clone(),
-            NodeId::from_key(&pk).unwrap(),
+            NodeId::from_key(&pk),
             vec!["/ip4/127.0.0.1/tcp/9999".parse::<Multiaddr>().unwrap()].into(),
             PeerFlags::empty(),
             PeerFeatures::COMMUNICATION_NODE,
@@ -552,19 +552,16 @@ mod test {
         let other_peer = {
             let mut p = example_peer.clone();
             let (_, pk) = CommsPublicKey::random_keypair(&mut OsRng);
-            p.node_id = NodeId::from_key(&pk).unwrap();
+            p.node_id = NodeId::from_key(&pk);
             p.public_key = pk;
             p
         };
 
-        let node_identity = Arc::new(
-            NodeIdentity::random(
-                &mut OsRng,
-                "/ip4/127.0.0.1/tcp/9000".parse().unwrap(),
-                PeerFeatures::COMMUNICATION_NODE,
-            )
-            .unwrap(),
-        );
+        let node_identity = Arc::new(NodeIdentity::random(
+            &mut OsRng,
+            "/ip4/127.0.0.1/tcp/9000".parse().unwrap(),
+            PeerFeatures::COMMUNICATION_NODE,
+        ));
 
         let (dht_requester, dht_mock) = create_dht_actor_mock(10);
         let (dht_discover_requester, _) = create_dht_discovery_mock(10, Duration::from_secs(10));
@@ -612,9 +609,7 @@ mod test {
             &mut OsRng,
             "/ip4/127.0.0.1/tcp/9000".parse().unwrap(),
             PeerFeatures::COMMUNICATION_NODE,
-        )
-        .unwrap();
-
+        );
         let (dht_requester, dht_mock) = create_dht_actor_mock(10);
         task::spawn(dht_mock.run());
         let (dht_discover_requester, _) = create_dht_discovery_mock(10, Duration::from_secs(10));
@@ -655,9 +650,7 @@ mod test {
             &mut OsRng,
             "/ip4/127.0.0.1/tcp/9000".parse().unwrap(),
             PeerFeatures::COMMUNICATION_NODE,
-        )
-        .unwrap();
-
+        );
         let (dht_requester, dht_mock) = create_dht_actor_mock(10);
         task::spawn(dht_mock.run());
         let (dht_discover_requester, mut discovery_mock) = create_dht_discovery_mock(10, Duration::from_secs(10));

--- a/comms/dht/src/store_forward/database/stored_message.rs
+++ b/comms/dht/src/store_forward/database/stored_message.rs
@@ -27,10 +27,10 @@ use crate::{
     store_forward::message::StoredMessagePriority,
 };
 use chrono::NaiveDateTime;
-use digest::Input;
+use digest::Digest;
 use std::convert::TryInto;
 use tari_comms::{message::MessageExt, types::Challenge};
-use tari_utilities::hex::Hex;
+use tari_utilities::{hex, hex::Hex};
 
 #[derive(Clone, Debug, Insertable, Default)]
 #[table_name = "stored_messages"]
@@ -74,7 +74,7 @@ impl NewStoredMessage {
                 let dht_header: DhtHeader = dht_header.into();
                 dht_header.to_encoded_bytes()
             },
-            body_hash: Challenge::new().chain(body.clone()).result().to_vec().to_hex(),
+            body_hash: hex::to_hex(&Challenge::new().chain(body.clone()).finalize()),
             body,
         })
     }

--- a/comms/dht/src/store_forward/saf_handler/task.rs
+++ b/comms/dht/src/store_forward/saf_handler/task.rs
@@ -418,7 +418,7 @@ where S: Service<DecryptedDhtMessage, Response = (), Error = PipelineError>
     }
 
     async fn check_duplicate(dht_requester: &mut DhtRequester, body: &[u8]) -> Result<(), StoreAndForwardError> {
-        let msg_hash = Challenge::new().chain(body).result().to_vec();
+        let msg_hash = Challenge::new().chain(body).finalize().to_vec();
         if dht_requester.insert_message_hash(msg_hash).await? {
             Err(StoreAndForwardError::DuplicateMessage)
         } else {
@@ -529,6 +529,7 @@ mod test {
     use prost::Message;
     use std::time::Duration;
     use tari_comms::{message::MessageExt, wrap_in_envelope_body};
+    use tari_crypto::tari_utilities::hex;
     use tari_test_utils::collect_stream;
     use tari_utilities::hex::Hex;
     use tokio::runtime::Handle;
@@ -537,7 +538,7 @@ mod test {
 
     fn make_stored_message(node_identity: &NodeIdentity, dht_header: DhtMessageHeader) -> StoredMessage {
         let body = b"A".to_vec();
-        let body_hash = Challenge::new().chain(body.clone()).result().to_vec().to_hex();
+        let body_hash = hex::to_hex(&Challenge::new().chain(body.clone()).finalize());
         StoredMessage {
             id: 1,
             version: 0,

--- a/comms/dht/src/test_utils/makers.rs
+++ b/comms/dht/src/test_utils/makers.rs
@@ -48,7 +48,7 @@ pub fn make_identity(features: PeerFeatures) -> Arc<NodeIdentity> {
     let public_addr = format!("/memory/{}", MemoryTransport::acquire_next_memsocket_port())
         .parse()
         .unwrap();
-    Arc::new(NodeIdentity::random(&mut OsRng, public_addr, features).unwrap())
+    Arc::new(NodeIdentity::random(&mut OsRng, public_addr, features))
 }
 
 pub fn make_node_identity() -> Arc<NodeIdentity> {

--- a/comms/dht/src/test_utils/store_and_forward_mock.rs
+++ b/comms/dht/src/test_utils/store_and_forward_mock.rs
@@ -22,7 +22,7 @@
 
 use crate::store_forward::{StoreAndForwardRequest, StoreAndForwardRequester, StoredMessage};
 use chrono::Utc;
-use digest::Input;
+use digest::Digest;
 use futures::{channel::mpsc, stream::Fuse, StreamExt};
 use log::*;
 use rand::{rngs::OsRng, RngCore};
@@ -31,7 +31,7 @@ use std::sync::{
     Arc,
 };
 use tari_comms::types::Challenge;
-use tari_utilities::hex::Hex;
+use tari_utilities::hex;
 use tokio::{runtime, sync::RwLock};
 
 const LOG_TARGET: &str = "comms::dht::discovery_mock";
@@ -132,7 +132,7 @@ impl StoreAndForwardMock {
                     is_encrypted: msg.is_encrypted,
                     priority: msg.priority,
                     stored_at: Utc::now().naive_utc(),
-                    body_hash: Challenge::new().chain(msg.body).result().to_vec().to_hex(),
+                    body_hash: hex::to_hex(&Challenge::new().chain(msg.body).finalize()),
                 });
                 reply_tx.send(Ok(false)).unwrap();
             },

--- a/comms/dht/tests/dht.rs
+++ b/comms/dht/tests/dht.rs
@@ -92,7 +92,11 @@ impl TestNode {
 
 fn make_node_identity(features: PeerFeatures) -> Arc<NodeIdentity> {
     let port = MemoryTransport::acquire_next_memsocket_port();
-    Arc::new(NodeIdentity::random(&mut OsRng, format!("/memory/{}", port).parse().unwrap(), features).unwrap())
+    Arc::new(NodeIdentity::random(
+        &mut OsRng,
+        format!("/memory/{}", port).parse().unwrap(),
+        features,
+    ))
 }
 
 fn create_peer_storage() -> CommsDatabase {

--- a/comms/examples/stress/error.rs
+++ b/comms/examples/stress/error.rs
@@ -23,7 +23,7 @@ use futures::channel::{mpsc::SendError, oneshot};
 use std::io;
 use tari_comms::{
     connectivity::ConnectivityError,
-    peer_manager::{NodeIdentityError, PeerManagerError},
+    peer_manager::PeerManagerError,
     tor,
     CommsBuilderError,
     PeerConnectionError,
@@ -34,8 +34,6 @@ use tokio::{task, time};
 
 #[derive(Debug, Error)]
 pub enum Error {
-    #[error("NodeIdentityError: {0}")]
-    NodeIdentityError(#[from] NodeIdentityError),
     #[error("HiddenServiceBuilderError: {0}")]
     HiddenServiceBuilderError(#[from] tor::HiddenServiceBuilderError),
     #[error("HiddenServiceControllerError: {0}")]

--- a/comms/examples/stress/node.rs
+++ b/comms/examples/stress/node.rs
@@ -89,7 +89,7 @@ pub async fn create(
             ni.set_public_address(public_addr.clone());
             ni
         })
-        .unwrap_or_else(|| Arc::new(NodeIdentity::random(&mut OsRng, public_addr, Default::default()).unwrap()));
+        .unwrap_or_else(|| Arc::new(NodeIdentity::random(&mut OsRng, public_addr, Default::default())));
 
     let listener_addr = format!("/ip4/0.0.0.0/tcp/{}", port).parse().unwrap();
 

--- a/comms/examples/stress/prompt.rs
+++ b/comms/examples/stress/prompt.rs
@@ -140,7 +140,7 @@ pub fn to_short_str(peer: &Peer) -> String {
 pub fn parse_from_short_str(s: &String) -> Option<Peer> {
     let mut split = s.splitn(2, "::");
     let pk = split.next().and_then(|s| CommsPublicKey::from_hex(s).ok())?;
-    let node_id = NodeId::from_key(&pk).ok()?;
+    let node_id = NodeId::from_key(&pk);
     let address = split.next().and_then(|s| s.parse::<Multiaddr>().ok())?;
     Some(Peer::new(
         pk,

--- a/comms/examples/tor.rs
+++ b/comms/examples/tor.rs
@@ -171,7 +171,7 @@ async fn setup_node_with_tor<P: Into<tor::PortMapping>>(
         &mut OsRng,
         "/ip4/127.0.0.1/tcp/0".parse().unwrap(),
         PeerFeatures::COMMUNICATION_CLIENT,
-    )?);
+    ));
 
     let comms_node = CommsBuilder::new()
         .with_node_identity(node_identity)

--- a/comms/src/peer_manager/manager.rs
+++ b/comms/src/peer_manager/manager.rs
@@ -320,7 +320,7 @@ mod test {
 
     fn create_test_peer(ban_flag: bool, features: PeerFeatures) -> Peer {
         let (_sk, pk) = RistrettoPublicKey::random_keypair(&mut OsRng);
-        let node_id = NodeId::from_key(&pk).unwrap();
+        let node_id = NodeId::from_key(&pk);
         let net_addresses = MultiaddressesWithStats::from("/ip4/1.2.3.4/tcp/8000".parse::<Multiaddr>().unwrap());
         let mut peer = Peer::new(
             pk,

--- a/comms/src/peer_manager/mod.rs
+++ b/comms/src/peer_manager/mod.rs
@@ -79,7 +79,7 @@ pub mod node_id;
 pub use node_id::NodeId;
 
 mod node_identity;
-pub use node_identity::{NodeIdentity, NodeIdentityError};
+pub use node_identity::NodeIdentity;
 
 mod peer;
 pub use peer::{Peer, PeerFlags};

--- a/comms/src/peer_manager/node_id.rs
+++ b/comms/src/peer_manager/node_id.rs
@@ -22,7 +22,7 @@
 
 use crate::types::CommsPublicKey;
 use blake2::{
-    digest::{Input, VariableOutput},
+    digest::{Update, VariableOutput},
     VarBlake2b,
 };
 use serde::{de, Deserialize, Deserializer, Serialize};
@@ -230,19 +230,22 @@ impl NodeId {
     }
 
     /// Derive a node id from a public key: node_id=hash(public_key)
-    pub fn from_key<K: ByteArray>(key: &K) -> Result<Self, NodeIdError> {
+    pub fn from_key<K: ByteArray>(key: &K) -> Self {
         let bytes = key.as_bytes();
-        let mut hasher = VarBlake2b::new(NODE_ID_ARRAY_SIZE).map_err(|_| NodeIdError::InvalidDigestOutputSize)?;
-        hasher.input(bytes);
-        let v = hasher.vec_result();
-        Self::try_from(v.as_slice())
+        let mut buf = [0u8; NODE_ID_ARRAY_SIZE];
+        VarBlake2b::new(NODE_ID_ARRAY_SIZE)
+            .expect("NODE_ID_ARRAY_SIZE is invalid")
+            .chain(bytes)
+            .finalize_variable(|hash| {
+                // Safety: output size and buf size are equal
+                buf.copy_from_slice(hash)
+            });
+        NodeId(buf)
     }
 
-    /// Derive a node id from a public key: node_id=hash(public_key)
-    /// This function uses `NodeId::from_key` internally but is infallible because `NodeId::from_key` cannot fail when
-    /// used with a `CommsPublicKey`.
+    /// Derive a node id from a public key: node_id = hash(public_key)
     pub fn from_public_key(key: &CommsPublicKey) -> Self {
-        Self::from_key(key).expect("NodeId::from_key is implemented incorrectly for CommsPublicKey")
+        Self::from_key(key)
     }
 
     /// Calculate the distance between the current node id and the provided node id using the XOR metric
@@ -423,7 +426,7 @@ mod test {
         let mut rng = rand::rngs::OsRng;
         let sk = CommsSecretKey::random(&mut rng);
         let pk = CommsPublicKey::from_secret_key(&sk);
-        let node_id = NodeId::from_key(&pk).unwrap();
+        let node_id = NodeId::from_key(&pk);
         assert_ne!(node_id.0.to_vec(), NodeId::new().0.to_vec());
         // Ensure node id is different to original public key
         let mut pk_array: [u8; 32] = [0; 32];

--- a/comms/src/peer_manager/node_identity.rs
+++ b/comms/src/peer_manager/node_identity.rs
@@ -22,12 +22,7 @@
 
 use super::node_id::deserialize_node_id_from_hex;
 use crate::{
-    peer_manager::{
-        node_id::{NodeId, NodeIdError},
-        Peer,
-        PeerFeatures,
-        PeerFlags,
-    },
+    peer_manager::{node_id::NodeId, Peer, PeerFeatures, PeerFlags},
     types::{CommsPublicKey, CommsSecretKey},
 };
 use multiaddr::Multiaddr;
@@ -38,13 +33,6 @@ use tari_crypto::{
     keys::{PublicKey, SecretKey},
     tari_utilities::hex::serialize_to_hex,
 };
-use thiserror::Error;
-
-#[derive(Debug, Error)]
-pub enum NodeIdentityError {
-    #[error("NodeIdError: {0}")]
-    NodeIdError(#[from] NodeIdError),
-}
 
 /// The public and private identity of this node on the network
 #[derive(Debug, Serialize, Deserialize)]
@@ -60,43 +48,33 @@ pub struct NodeIdentity {
 
 impl NodeIdentity {
     /// Create a new NodeIdentity from the provided key pair and control service address
-    pub fn new(
-        secret_key: CommsSecretKey,
-        public_address: Multiaddr,
-        features: PeerFeatures,
-    ) -> Result<Self, NodeIdentityError> {
+    pub fn new(secret_key: CommsSecretKey, public_address: Multiaddr, features: PeerFeatures) -> Self {
         let public_key = CommsPublicKey::from_secret_key(&secret_key);
-        let node_id = NodeId::from_key(&public_key).map_err(NodeIdentityError::NodeIdError)?;
+        let node_id = NodeId::from_key(&public_key);
 
-        Ok(NodeIdentity {
+        NodeIdentity {
             node_id,
             public_key,
             features,
             secret_key,
             public_address: RwLock::new(public_address),
-        })
+        }
     }
 
     /// Generates a new random NodeIdentity for CommsPublicKey
-    pub fn random<R>(
-        rng: &mut R,
-        public_address: Multiaddr,
-        features: PeerFeatures,
-    ) -> Result<Self, NodeIdentityError>
-    where
-        R: CryptoRng + Rng,
-    {
+    pub fn random<R>(rng: &mut R, public_address: Multiaddr, features: PeerFeatures) -> Self
+    where R: CryptoRng + Rng {
         let secret_key = CommsSecretKey::random(rng);
         let public_key = CommsPublicKey::from_secret_key(&secret_key);
-        let node_id = NodeId::from_key(&public_key).map_err(NodeIdentityError::NodeIdError)?;
+        let node_id = NodeId::from_key(&public_key);
 
-        Ok(NodeIdentity {
+        NodeIdentity {
             node_id,
             public_key,
             features,
             secret_key,
             public_address: RwLock::new(public_address),
-        })
+        }
     }
 
     /// Retrieve the publicly accessible address that peers must connect to establish a connection
@@ -120,7 +98,6 @@ impl NodeIdentity {
                 .unwrap(),
             features,
         )
-        .unwrap()
     }
 
     #[inline]

--- a/comms/src/peer_manager/peer.rs
+++ b/comms/src/peer_manager/peer.rs
@@ -359,7 +359,7 @@ mod test {
     fn test_is_banned_and_ban_for() {
         let mut rng = rand::rngs::OsRng;
         let (_sk, pk) = RistrettoPublicKey::random_keypair(&mut rng);
-        let node_id = NodeId::from_key(&pk).unwrap();
+        let node_id = NodeId::from_key(&pk);
         let addresses = MultiaddressesWithStats::from("/ip4/123.0.0.123/tcp/8000".parse::<Multiaddr>().unwrap());
         let mut peer: Peer = Peer::new(
             pk,
@@ -398,7 +398,7 @@ mod test {
     fn test_update() {
         let mut rng = rand::rngs::OsRng;
         let (_sk, public_key1) = RistrettoPublicKey::random_keypair(&mut rng);
-        let node_id = NodeId::from_key(&public_key1).unwrap();
+        let node_id = NodeId::from_key(&public_key1);
         let net_address1 = "/ip4/124.0.0.124/tcp/7000".parse::<Multiaddr>().unwrap();
         let mut peer: Peer = Peer::new(
             public_key1.clone(),
@@ -450,7 +450,7 @@ mod test {
         let expected_pk_hex = "02622ace8f7303a31cafc63f8fc48fdc16e1c8c8d234b2f0d6685282a9076031";
         let expected_nodeid_hex = "c1a7552e5d9e9b257c4008b965";
         let pk = CommsPublicKey::from_hex(expected_pk_hex).unwrap();
-        let node_id = NodeId::from_key(&pk).unwrap();
+        let node_id = NodeId::from_key(&pk);
         let peer = Peer::new(
             pk,
             node_id,

--- a/comms/src/peer_manager/peer_query.rs
+++ b/comms/src/peer_manager/peer_query.rs
@@ -224,7 +224,7 @@ mod test {
 
     fn create_test_peer(ban_flag: bool) -> Peer {
         let (_sk, pk) = RistrettoPublicKey::random_keypair(&mut OsRng);
-        let node_id = NodeId::from_key(&pk).unwrap();
+        let node_id = NodeId::from_key(&pk);
         let net_addresses = MultiaddressesWithStats::from("/ip4/1.2.3.4/tcp/8000".parse::<Multiaddr>().unwrap());
         let mut peer = Peer::new(
             pk,

--- a/comms/src/peer_manager/peer_storage.rs
+++ b/comms/src/peer_manager/peer_storage.rs
@@ -553,7 +553,7 @@ mod test {
         // Create Peers
         let mut rng = rand::rngs::OsRng;
         let (_sk, pk) = RistrettoPublicKey::random_keypair(&mut rng);
-        let node_id = NodeId::from_key(&pk).unwrap();
+        let node_id = NodeId::from_key(&pk);
         let net_address1 = "/ip4/1.2.3.4/tcp/8000".parse::<Multiaddr>().unwrap();
         let net_address2 = "/ip4/5.6.7.8/tcp/8000".parse::<Multiaddr>().unwrap();
         let net_address3 = "/ip4/5.6.7.8/tcp/7000".parse::<Multiaddr>().unwrap();
@@ -571,7 +571,7 @@ mod test {
         );
 
         let (_sk, pk) = RistrettoPublicKey::random_keypair(&mut rng);
-        let node_id = NodeId::from_key(&pk).unwrap();
+        let node_id = NodeId::from_key(&pk);
         let net_address4 = "/ip4/9.10.11.12/tcp/7000".parse::<Multiaddr>().unwrap();
         let net_addresses = MultiaddressesWithStats::from(net_address4);
         let peer2: Peer = Peer::new(
@@ -585,7 +585,7 @@ mod test {
         );
 
         let (_sk, pk) = RistrettoPublicKey::random_keypair(&mut rng);
-        let node_id = NodeId::from_key(&pk).unwrap();
+        let node_id = NodeId::from_key(&pk);
         let net_address5 = "/ip4/13.14.15.16/tcp/6000".parse::<Multiaddr>().unwrap();
         let net_address6 = "/ip4/17.18.19.20/tcp/8000".parse::<Multiaddr>().unwrap();
         let mut net_addresses = MultiaddressesWithStats::from(net_address5);
@@ -632,7 +632,7 @@ mod test {
         // Create Peers
         let mut rng = rand::rngs::OsRng;
         let (_sk, pk) = RistrettoPublicKey::random_keypair(&mut rng);
-        let node_id = NodeId::from_key(&pk).unwrap();
+        let node_id = NodeId::from_key(&pk);
         let net_address1 = "/ip4/1.2.3.4/tcp/8000".parse::<Multiaddr>().unwrap();
         let net_address2 = "/ip4/5.6.7.8/tcp/8000".parse::<Multiaddr>().unwrap();
         let net_address3 = "/ip4/5.6.7.8/tcp/7000".parse::<Multiaddr>().unwrap();
@@ -650,7 +650,7 @@ mod test {
         );
 
         let (_sk, pk) = RistrettoPublicKey::random_keypair(&mut rng);
-        let node_id = NodeId::from_key(&pk).unwrap();
+        let node_id = NodeId::from_key(&pk);
         let net_address4 = "/ip4/9.10.11.12/tcp/7000".parse::<Multiaddr>().unwrap();
         let net_addresses = MultiaddressesWithStats::from(net_address4);
         let peer2: Peer = Peer::new(
@@ -664,7 +664,7 @@ mod test {
         );
 
         let (_sk, pk) = RistrettoPublicKey::random_keypair(&mut rng);
-        let node_id = NodeId::from_key(&pk).unwrap();
+        let node_id = NodeId::from_key(&pk);
         let net_address5 = "/ip4/13.14.15.16/tcp/6000".parse::<Multiaddr>().unwrap();
         let net_address6 = "/ip4/17.18.19.20/tcp/8000".parse::<Multiaddr>().unwrap();
         let mut net_addresses = MultiaddressesWithStats::from(net_address5);
@@ -778,7 +778,7 @@ mod test {
     fn create_test_peer(features: PeerFeatures, ban: bool, offline: bool) -> Peer {
         let mut rng = rand::rngs::OsRng;
         let (_sk, pk) = RistrettoPublicKey::random_keypair(&mut rng);
-        let node_id = NodeId::from_key(&pk).unwrap();
+        let node_id = NodeId::from_key(&pk);
         let net_address = "/ip4/1.2.3.4/tcp/8000".parse::<Multiaddr>().unwrap();
         let net_addresses = MultiaddressesWithStats::from(net_address);
         let mut peer = Peer::new(

--- a/comms/src/test_utils/factories/node_identity.rs
+++ b/comms/src/test_utils/factories/node_identity.rs
@@ -54,14 +54,20 @@ impl TestFactory for NodeIdentityFactory {
 
     fn build(self) -> Result<Self::Object, TestFactoryError> {
         // Generate a test identity, set it and return it
-        let secret_key = self.secret_key.or_else(|| Some(CommsSecretKey::random(&mut OsRng))).unwrap();
+        let secret_key = self
+            .secret_key
+            .or_else(|| Some(CommsSecretKey::random(&mut OsRng)))
+            .unwrap();
 
         let control_service_address = self
             .control_service_address
             .or(Some(super::net_address::create().build()?))
             .unwrap();
 
-        NodeIdentity::new(secret_key, control_service_address, self.peer_features)
-            .map_err(TestFactoryError::build_failed())
+        Ok(NodeIdentity::new(
+            secret_key,
+            control_service_address,
+            self.peer_features,
+        ))
     }
 }

--- a/comms/src/test_utils/factories/peer.rs
+++ b/comms/src/test_utils/factories/peer.rs
@@ -79,7 +79,7 @@ impl TestFactory for PeerFactory {
         let node_id = self
             .node_id
             .clone()
-            .or_else(|| Some(NodeId::from_key(&public_key).unwrap()))
+            .or_else(|| Some(NodeId::from_key(&public_key)))
             .unwrap();
 
         let default = self.net_addresses_factory.build().ok();

--- a/comms/src/test_utils/node_id.rs
+++ b/comms/src/test_utils/node_id.rs
@@ -26,5 +26,5 @@ use tari_crypto::keys::PublicKey;
 
 pub fn random() -> NodeId {
     let (_, pk) = CommsPublicKey::random_keypair(&mut OsRng);
-    NodeId::from_key(&pk).unwrap()
+    NodeId::from_key(&pk)
 }

--- a/comms/src/test_utils/node_identity.rs
+++ b/comms/src/test_utils/node_identity.rs
@@ -31,7 +31,7 @@ pub fn build_node_identity(features: PeerFeatures) -> Arc<NodeIdentity> {
     let public_addr = format!("/memory/{}", MemoryTransport::acquire_next_memsocket_port())
         .parse()
         .unwrap();
-    Arc::new(NodeIdentity::random(&mut OsRng, public_addr, features).unwrap())
+    Arc::new(NodeIdentity::random(&mut OsRng, public_addr, features))
 }
 
 pub fn ordered_node_identities(n: usize, features: PeerFeatures) -> Vec<Arc<NodeIdentity>> {

--- a/comms/src/test_utils/test_node.rs
+++ b/comms/src/test_utils/test_node.rs
@@ -47,14 +47,11 @@ pub struct TestNodeConfig {
 
 impl Default for TestNodeConfig {
     fn default() -> Self {
-        let node_identity = Arc::new(
-            NodeIdentity::random(
-                &mut OsRng,
-                "/memory/0".parse().unwrap(),
-                PeerFeatures::COMMUNICATION_NODE,
-            )
-            .unwrap(),
-        );
+        let node_identity = Arc::new(NodeIdentity::random(
+            &mut OsRng,
+            "/memory/0".parse().unwrap(),
+            PeerFeatures::COMMUNICATION_NODE,
+        ));
 
         Self {
             transport: MemoryTransport,
@@ -73,8 +70,7 @@ pub fn build_connection_manager(
     peer_manager: Arc<PeerManager>,
     protocols: Protocols<Substream>,
     shutdown: ShutdownSignal,
-) -> ConnectionManagerRequester
-{
+) -> ConnectionManagerRequester {
     let noise_config = NoiseConfig::new(config.node_identity.clone());
     let (request_tx, request_rx) = mpsc::channel(10);
     let (event_tx, _) = broadcast::channel(100);

--- a/infrastructure/derive/Cargo.toml
+++ b/infrastructure/derive/Cargo.toml
@@ -15,5 +15,5 @@ proc-macro = true
 [dependencies]
 quote = "0.6.11"
 syn = "0.15.29"
-blake2 = "0.8.0"
+blake2 = "0.9.0"
 proc-macro2 =   "0.4.27"

--- a/infrastructure/storage/Cargo.toml
+++ b/infrastructure/storage/Cargo.toml
@@ -22,5 +22,5 @@ tari_utilities = "^0.3"
 bytes = "0.4.12"
 
 [dev-dependencies]
-rand = "0.5.5"
+rand = "0.8"
 env_logger = "0.6.2"

--- a/infrastructure/test_utils/Cargo.toml
+++ b/infrastructure/test_utils/Cargo.toml
@@ -11,7 +11,7 @@ license = "BSD-3-Clause"
 [dependencies]
 futures-test = { version = "^0.3.1" }
 futures = {version= "^0.3.1"}
-rand = "0.7.0"
+rand = "0.8"
 tokio = {version= "0.2.10", features=["rt-threaded", "time", "io-driver"]}
 lazy_static = "1.3.0"
 tempfile = "3.1.0"

--- a/infrastructure/test_utils/src/random/mod.rs
+++ b/infrastructure/test_utils/src/random/mod.rs
@@ -26,14 +26,17 @@ use std::iter;
 /// Generate a random alphanumeric string of the given size using the default `ThreadRng`.
 pub fn string(len: usize) -> String {
     let mut rng = thread_rng();
-    iter::repeat(()).map(|_| rng.sample(Alphanumeric)).take(len).collect()
+    iter::repeat(())
+        .map(|_| rng.sample(Alphanumeric) as char)
+        .take(len)
+        .collect()
 }
 
 /// Generate a random alphanumeric string of the given size using the default `ThreadRng`.
 pub fn prefixed_string(prefix: &str, len: usize) -> String {
     let mut rng = thread_rng();
     let rand_str = iter::repeat(())
-        .map(|_| rng.sample(Alphanumeric))
+        .map(|_| rng.sample(Alphanumeric) as char)
         .take(len)
         .collect::<String>();
     format!("{}{}", prefix, rand_str)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
- Update crates `digest 0.9` `rand 0.8` and `sha3 0.9` to fix compilation errors
  (Ref https://github.com/tari-project/tari-crypto/pull/49)
- NodeId::from_key is infallible
- This in turn meant that NodeIdentity::new and NodeIdentity::randoma are infallible
- This in turn meant that NodeIdentityError is unused, so it was removed
- Remove multiple copies of the random string test utility (all of which
  needed `rand` crate updates) in favour of using the one provided in tari_test_utils

Stable Rust was not set in this PR because `subtle-ng` (https://github.com/dalek-cryptography/subtle/pull/85) does not currently compile.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fix compilation errors. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Existing unit tests must pass in CI.
- Tested a base node connected to current tari script nodes
- Tested merge mining and that nodes accepted newly mined blocks

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [ ] I'm merging against the `development` branch.
* [x] I have squashed my commits into a single commit.
