### PR TITLE
[minor fix, edge case] Header sync: fix missing edge case in header sync

### DIFF
--- a/base_layer/core/src/base_node/sync/block_sync/synchronizer.rs
+++ b/base_layer/core/src/base_node/sync/block_sync/synchronizer.rs
@@ -176,13 +176,13 @@ impl<B: BlockchainBackend + 'static> BlockSynchronizer<B> {
                 });
             }
 
+            prev_hash = header_hash.clone();
+
             let body = block
                 .body
                 .map(AggregateBody::try_from)
                 .ok_or_else(|| BlockSyncError::ReceivedInvalidBlockBody("Block body was empty".to_string()))?
                 .map_err(BlockSyncError::ReceivedInvalidBlockBody)?;
-
-            prev_hash = header.hash().clone();
 
             debug!(
                 target: LOG_TARGET,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Fix case where peer has indicated a better chain, but cannot provide
the split hash within the header sync within the limit of 10,000 (either not co-operating, 
or the genesis hash doesn't match for some reason). This PR will ban that peer.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
When testing with remote tari-script nodes, some peers advertise a better chain, but 
cannot provide a split before the local node runs out of hashes. This results in a
bad request error where the local node sends 0 hashes. 
This errors without banning, the peer is later retried and so on. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Synced to tari script nodes.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [ ] I'm merging against the `development` branch.
* [x] I have squashed my commits into a single commit.
