### PR TITLE
Update mempool unit test to reflect actual behaviour. 

### DIFF
--- a/base_layer/core/tests/mempool.rs
+++ b/base_layer/core/tests/mempool.rs
@@ -1212,28 +1212,11 @@ fn block_event_and_reorg_event_handling() {
         );
         assert_eq!(
             alice.mempool.has_tx_with_excess_sig(tx2b_excess_sig.clone()).unwrap(),
-            TxStorageResponse::NotStored
+            TxStorageResponse::ReorgPool
         );
         assert_eq!(
             alice.mempool.has_tx_with_excess_sig(tx3b_excess_sig.clone()).unwrap(),
-            TxStorageResponse::NotStored
-        );
-
-        // Reorg chain by adding Block2b - tx2a and tx3a will be discarded as double spends.
-        assert!(bob
-            .local_nci
-            .submit_block(block2b.clone(), Broadcast::from(true))
-            .await
-            .is_ok());
-        async_assert_eventually!(
-            alice.mempool.has_tx_with_excess_sig(tx2a_excess_sig.clone()).unwrap(),
-            expect = TxStorageResponse::NotStored,
-            max_attempts = 20,
-            interval = Duration::from_millis(1000)
-        );
-        assert_eq!(
-            alice.mempool.has_tx_with_excess_sig(tx3a_excess_sig.clone()).unwrap(),
-            TxStorageResponse::NotStored
+            TxStorageResponse::ReorgPool
         );
     });
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
The test `block_event_and_reorg_event_handling` was updated and fixed on the `develpment` branch. 
Given the following double spend:
```
Tx1: U1 > U2
Tx2: U1 > U3
```
On the `development` branch the following happened in the mempool with double spend:

When Tx1 is mined:
Tx1 will go to the ReOrg pool.
Tx2 will be deleted.

On the `tari_script` branch the following happened in the mempool with double spend:

When Tx1 is mined:
Tx1 will go to the ReOrg pool.
Tx2 will go to the ReOrg pool.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
We need the test to reflect the actual behavior of the code, so this test is updated to reflect the actual behavior. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [ ] I'm merging against the `development` branch.
* [x] I have squashed my commits into a single commit.
