### PR TITLE
Fix db update error

### DIFF
--- a/base_layer/wallet/src/output_manager_service/service.rs
+++ b/base_layer/wallet/src/output_manager_service/service.rs
@@ -406,7 +406,6 @@ where TBackend: OutputManagerBackend + 'static
         &mut self,
         output: TransactionOutput,
     ) -> Result<(), OutputManagerError> {
-        debug!(target: LOG_TARGET, "Update metadata signature for output {}", output);
         self.resources.db.update_output_metadata_signature(output).await?;
         Ok(())
     }

--- a/base_layer/wallet/src/transaction_service/protocols/transaction_receive_protocol.rs
+++ b/base_layer/wallet/src/transaction_service/protocols/transaction_receive_protocol.rs
@@ -433,11 +433,26 @@ where TBackend: TransactionBackend + 'static
                 .find(|output| output.hash() == rtp_output.hash())
             {
                 if rtp_output.verify_metadata_signature().is_err() {
-                    self.resources
+                    match self
+                        .resources
                         .output_manager_service
                         .update_output_metadata_signature(v.clone())
                         .await
-                        .map_err(|e| TransactionServiceProtocolError::new(self.id, TransactionServiceError::from(e)))?;
+                        .map_err(|e| TransactionServiceProtocolError::new(self.id, TransactionServiceError::from(e)))
+                    {
+                        Ok(..) => {
+                            debug!(target: LOG_TARGET, "Updated metadata signature for output {}", v);
+                        },
+                        Err(e) => {
+                            warn!(
+                                target: LOG_TARGET,
+                                "Could not updated metadata signature for output {} ({}, {})",
+                                v,
+                                e.id,
+                                e.error.to_string()
+                            );
+                        },
+                    }
                 }
             }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
The transaction receive protocol should finish gracefully if the sender's metadata signature cannot be updated in the wallet database.

## Motivation and Context
- Unit test `test_restarting_transaction_protocols` failed
- The transaction receive protocol exited with an error if the sender's metadata signature could not be updated in the wallet database instead of running to completion.

## How Has This Been Tested?
Unit test

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [X] I'm merging against the `tari-script` branch.
* [X] I have squashed my commits into a single commit.
