### PR TITLE
chore: DRY up script signature construction in input malleability test

### DIFF
--- a/base_layer/core/src/transactions/helpers.rs
+++ b/base_layer/core/src/transactions/helpers.rs
@@ -140,11 +140,19 @@ impl TestParams {
             params.script.clone(),
             params
                 .input_data
-                .unwrap_or_else(|| inputs!(PublicKey::from_secret_key(&self.script_private_key))),
+                .unwrap_or_else(|| inputs!(self.get_script_public_key())),
             self.script_private_key.clone(),
             self.sender_offset_public_key.clone(),
             metadata_signature,
         )
+    }
+
+    pub fn get_script_public_key(&self) -> PublicKey {
+        PublicKey::from_secret_key(&self.script_private_key)
+    }
+
+    pub fn get_script_keypair(&self) -> (PrivateKey, PublicKey) {
+        (self.script_private_key.clone(), self.get_script_public_key())
     }
 
     /// Create a random transaction input for the given amount and maturity period. The input ,its unblinded

--- a/base_layer/core/src/transactions/transaction.rs
+++ b/base_layer/core/src/transactions/transaction.rs
@@ -260,7 +260,7 @@ impl UnblindedOutput {
         );
         let script_signature = ComSignature::sign(
             self.value.into(),
-            self.script_private_key.clone() + self.spending_key.clone(),
+            &self.script_private_key + &self.spending_key,
             script_nonce_a,
             script_nonce_b,
             &challenge,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Comsig signing code in tests was duplicated unnecessarily. This PR uses
TestParams to construct a signed input and copies the new input signature
into the block.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Clean up that didn't quite make the merged PR (ref https://github.com/tari-project/tari/pull/3053), making use of the TestParams improvements.
In general, better not to duplicate hash construction code. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tests pass

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [ ] I'm merging against the `development` branch.
* [x] I have squashed my commits into a single commit.
