### PR TITLE
v0.9.0

### DIFF
--- a/.clog.toml
+++ b/.clog.toml
@@ -1,0 +1,9 @@
+[clog]
+# A repository link with the trailing '.git' which will be used to generate
+# all commit and issue links
+repository = "https://github.com/tari-project/tari"
+
+# specify the style of commit links to generate, defaults to "github" if omitted
+link-style = "github"
+changelog = "changelog.md"
+from-latest-tag = true

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4162,7 +4162,7 @@ dependencies = [
 
 [[package]]
 name = "tari_app_grpc"
-version = "0.8.11"
+version = "0.9.0"
 dependencies = [
  "chrono",
  "prost",
@@ -4178,7 +4178,7 @@ dependencies = [
 
 [[package]]
 name = "tari_app_utilities"
-version = "0.8.11"
+version = "0.9.0"
 dependencies = [
  "config",
  "dirs-next",
@@ -4203,7 +4203,7 @@ dependencies = [
 
 [[package]]
 name = "tari_base_node"
-version = "0.8.11"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "bincode",
@@ -4256,7 +4256,7 @@ dependencies = [
 
 [[package]]
 name = "tari_common"
-version = "0.8.11"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "config",
@@ -4280,7 +4280,7 @@ dependencies = [
 
 [[package]]
 name = "tari_common_types"
-version = "0.8.11"
+version = "0.9.0"
 dependencies = [
  "futures 0.3.15",
  "rand 0.8.4",
@@ -4291,7 +4291,7 @@ dependencies = [
 
 [[package]]
 name = "tari_comms"
-version = "0.8.11"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4335,7 +4335,7 @@ dependencies = [
 
 [[package]]
 name = "tari_comms_dht"
-version = "0.8.11"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "bitflags 1.2.1",
@@ -4382,7 +4382,7 @@ dependencies = [
 
 [[package]]
 name = "tari_comms_rpc_macros"
-version = "0.8.11"
+version = "0.9.0"
 dependencies = [
  "futures 0.3.15",
  "proc-macro2 1.0.27",
@@ -4398,7 +4398,7 @@ dependencies = [
 
 [[package]]
 name = "tari_console_wallet"
-version = "0.8.11"
+version = "0.9.0"
 dependencies = [
  "bitflags 1.2.1",
  "chrono",
@@ -4433,7 +4433,7 @@ dependencies = [
 
 [[package]]
 name = "tari_core"
-version = "0.8.11"
+version = "0.9.0"
 dependencies = [
  "bincode",
  "bitflags 1.2.1",
@@ -4508,7 +4508,7 @@ dependencies = [
 
 [[package]]
 name = "tari_infra_derive"
-version = "0.8.11"
+version = "0.9.0"
 dependencies = [
  "blake2",
  "proc-macro2 0.4.30",
@@ -4518,7 +4518,7 @@ dependencies = [
 
 [[package]]
 name = "tari_key_manager"
-version = "0.8.11"
+version = "0.9.0"
 dependencies = [
  "digest",
  "rand 0.8.4",
@@ -4532,7 +4532,7 @@ dependencies = [
 
 [[package]]
 name = "tari_merge_mining_proxy"
-version = "0.8.11"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "bincode",
@@ -4570,7 +4570,7 @@ dependencies = [
 
 [[package]]
 name = "tari_mining_node"
-version = "0.8.11"
+version = "0.9.0"
 dependencies = [
  "chrono",
  "crossbeam",
@@ -4593,7 +4593,7 @@ dependencies = [
 
 [[package]]
 name = "tari_mmr"
-version = "0.8.11"
+version = "0.9.0"
 dependencies = [
  "bincode",
  "blake2",
@@ -4612,7 +4612,7 @@ dependencies = [
 
 [[package]]
 name = "tari_p2p"
-version = "0.8.11"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "bytes 0.5.6",
@@ -4654,7 +4654,7 @@ dependencies = [
 
 [[package]]
 name = "tari_service_framework"
-version = "0.8.11"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4672,7 +4672,7 @@ dependencies = [
 
 [[package]]
 name = "tari_shutdown"
-version = "0.8.11"
+version = "0.9.0"
 dependencies = [
  "futures 0.3.15",
  "tokio",
@@ -4680,7 +4680,7 @@ dependencies = [
 
 [[package]]
 name = "tari_storage"
-version = "0.8.11"
+version = "0.9.0"
 dependencies = [
  "bincode",
  "bytes 0.4.12",
@@ -4698,7 +4698,7 @@ dependencies = [
 
 [[package]]
 name = "tari_test_utils"
-version = "0.8.11"
+version = "0.9.0"
 dependencies = [
  "futures 0.3.15",
  "futures-test",
@@ -4728,7 +4728,7 @@ dependencies = [
 
 [[package]]
 name = "tari_wallet"
-version = "0.8.11"
+version = "0.9.0"
 dependencies = [
  "aes-gcm 0.8.0",
  "bincode",
@@ -4822,7 +4822,7 @@ dependencies = [
 
 [[package]]
 name = "test_faucet"
-version = "0.8.11"
+version = "0.9.0"
 dependencies = [
  "rand 0.8.4",
  "serde 1.0.126",

--- a/applications/tari_app_grpc/Cargo.toml
+++ b/applications/tari_app_grpc/Cargo.toml
@@ -4,11 +4,11 @@ authors = ["The Tari Development Community"]
 description = "This crate is to provide a single source for all cross application grpc files and conversions to and from tari::core"
 repository = "https://github.com/tari-project/tari"
 license = "BSD-3-Clause"
-version = "0.8.11"
+version = "0.9.0"
 edition = "2018"
 
 [dependencies]
-tari_common_types = { version = "^0.8", path = "../../base_layer/common_types"}
+tari_common_types = { version = "^0.9", path = "../../base_layer/common_types"}
 tari_core = {  path = "../../base_layer/core"}
 tari_wallet = {  path = "../../base_layer/wallet"}
 tari_crypto = "0.11.1"

--- a/applications/tari_app_utilities/Cargo.toml
+++ b/applications/tari_app_utilities/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tari_app_utilities"
-version = "0.8.11"
+version = "0.9.0"
 authors = ["The Tari Development Community"]
 edition = "2018"
 
@@ -27,7 +27,7 @@ tonic = "0.2"
 
 [dependencies.tari_core]
 path = "../../base_layer/core"
-version = "^0.8"
+version = "^0.9"
 default-features = false
 features = ["transactions"]
 

--- a/applications/tari_base_node/Cargo.toml
+++ b/applications/tari_base_node/Cargo.toml
@@ -4,7 +4,7 @@ authors = ["The Tari Development Community"]
 description = "The tari full base node implementation"
 repository = "https://github.com/tari-project/tari"
 license = "BSD-3-Clause"
-version = "0.8.11"
+version = "0.9.0"
 edition = "2018"
 
 [dependencies]

--- a/applications/tari_console_wallet/Cargo.toml
+++ b/applications/tari_console_wallet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tari_console_wallet"
-version = "0.8.11"
+version = "0.9.0"
 authors = ["The Tari Development Community"]
 edition = "2018"
 
@@ -36,7 +36,7 @@ tonic = "0.2"
 
 [dependencies.tari_core]
 path = "../../base_layer/core"
-version = "^0.8"
+version = "^0.9"
 default-features = false
 features = ["transactions", "mempool_proto", "base_node_proto"]
 

--- a/applications/tari_merge_mining_proxy/Cargo.toml
+++ b/applications/tari_merge_mining_proxy/Cargo.toml
@@ -4,7 +4,7 @@ authors = ["The Tari Development Community"]
 description = "The tari merge miner proxy for xmrig"
 repository = "https://github.com/tari-project/tari"
 license = "BSD-3-Clause"
-version = "0.8.11"
+version = "0.9.0"
 edition = "2018"
 
 [features]

--- a/applications/tari_mining_node/Cargo.toml
+++ b/applications/tari_mining_node/Cargo.toml
@@ -4,7 +4,7 @@ authors = ["The Tari Development Community"]
 description = "The tari mining node implementation"
 repository = "https://github.com/tari-project/tari"
 license = "BSD-3-Clause"
-version = "0.8.11"
+version = "0.9.0"
 edition = "2018"
 
 [dependencies]

--- a/applications/test_faucet/Cargo.toml
+++ b/applications/test_faucet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "test_faucet"
-version = "0.8.11"
+version = "0.9.0"
 authors = ["The Tari Development Community"]
 edition = "2018"
 
@@ -14,7 +14,7 @@ rand = "0.8"
 tari_crypto = "0.11.1"
 
 [dependencies.tari_core]
-version = "^0.8"
+version = "^0.9"
 path = "../../base_layer/core/"
 default-features = false
 features = ["transactions", "avx2"]

--- a/base_layer/common_types/Cargo.toml
+++ b/base_layer/common_types/Cargo.toml
@@ -3,7 +3,7 @@ name = "tari_common_types"
 authors = ["The Tari Development Community"]
 description = "Tari cryptocurrency common types"
 license = "BSD-3-Clause"
-version = "0.8.11"
+version = "0.9.0"
 edition = "2018"
 
 [dependencies]

--- a/base_layer/core/Cargo.toml
+++ b/base_layer/core/Cargo.toml
@@ -6,7 +6,7 @@ repository = "https://github.com/tari-project/tari"
 homepage = "https://tari.com"
 readme = "README.md"
 license = "BSD-3-Clause"
-version = "0.8.11"
+version = "0.9.0"
 edition = "2018"
 
 [features]
@@ -18,18 +18,18 @@ base_node_proto = []
 avx2 = ["tari_crypto/avx2"]
 
 [dependencies]
-tari_common = { version = "^0.8", path = "../../common"}
-tari_common_types = { version = "^0.8", path = "../../base_layer/common_types"}
-tari_comms = { version = "^0.8", path = "../../comms"}
-tari_comms_dht = { version = "^0.8", path = "../../comms/dht"}
-tari_comms_rpc_macros = { version = "^0.8", path = "../../comms/rpc_macros"}
+tari_common = { version = "^0.9", path = "../../common"}
+tari_common_types = { version = "^0.9", path = "../../base_layer/common_types"}
+tari_comms = { version = "^0.9", path = "../../comms"}
+tari_comms_dht = { version = "^0.9", path = "../../comms/dht"}
+tari_comms_rpc_macros = { version = "^0.9", path = "../../comms/rpc_macros"}
 tari_crypto = "0.11.1"
-tari_mmr = { version = "^0.8", path = "../../base_layer/mmr", optional = true }
-tari_p2p = { version = "^0.8", path = "../../base_layer/p2p" }
-tari_service_framework = { version = "^0.8", path = "../service_framework"}
-tari_shutdown = { version = "^0.8", path = "../../infrastructure/shutdown" }
-tari_storage = { version = "^0.8", path = "../../infrastructure/storage" }
-tari_test_utils = { version = "^0.8", path = "../../infrastructure/test_utils" }
+tari_mmr = { version = "^0.9", path = "../../base_layer/mmr", optional = true }
+tari_p2p = { version = "^0.9", path = "../../base_layer/p2p" }
+tari_service_framework = { version = "^0.9", path = "../service_framework"}
+tari_shutdown = { version = "^0.9", path = "../../infrastructure/shutdown" }
+tari_storage = { version = "^0.9", path = "../../infrastructure/storage" }
+tari_test_utils = { version = "^0.9", path = "../../infrastructure/test_utils" }
 
 bincode = "1.1.4"
 bitflags = "1.0.4"
@@ -61,8 +61,8 @@ uint = { version = "0.9", default-features = false }
 num-format = "0.4.0"
 
 [dev-dependencies]
-tari_p2p = { version = "^0.8", path = "../../base_layer/p2p", features=["test-mocks"]}
-tari_test_utils = { version = "^0.8", path = "../../infrastructure/test_utils" }
+tari_p2p = { version = "^0.9", path = "../../base_layer/p2p", features=["test-mocks"]}
+tari_test_utils = { version = "^0.9", path = "../../infrastructure/test_utils" }
 
 config = { version = "0.9.3" }
 env_logger = "0.7.0"
@@ -70,4 +70,4 @@ tempfile = "3.1.0"
 tokio-macros = "0.2.4"
 
 [build-dependencies]
-tari_common = { version = "^0.8", path="../../common", features = ["build"]}
+tari_common = { version = "^0.9", path="../../common", features = ["build"]}

--- a/base_layer/key_manager/Cargo.toml
+++ b/base_layer/key_manager/Cargo.toml
@@ -4,7 +4,7 @@ authors = ["The Tari Development Community"]
 description = "Tari cryptocurrency wallet key management"
 repository = "https://github.com/tari-project/tari"
 license = "BSD-3-Clause"
-version = "0.8.11"
+version = "0.9.0"
 edition = "2018"
 
 [dependencies]

--- a/base_layer/mmr/Cargo.toml
+++ b/base_layer/mmr/Cargo.toml
@@ -4,7 +4,7 @@ authors = ["The Tari Development Community"]
 description = "A Merkle Mountain Range implementation"
 repository = "https://github.com/tari-project/tari"
 license = "BSD-3-Clause"
-version = "0.8.11"
+version = "0.9.0"
 edition = "2018"
 
 [features]
@@ -24,7 +24,7 @@ criterion = { version="0.2", optional = true }
 [dev-dependencies]
 rand="0.8.0"
 blake2 = "0.9.0"
-tari_infra_derive= { path = "../../infrastructure/derive", version = "^0.8" }
+tari_infra_derive= { path = "../../infrastructure/derive", version = "^0.9" }
 tari_crypto = "0.11.1"
 serde_json = "1.0"
 bincode = "1.1"

--- a/base_layer/p2p/Cargo.toml
+++ b/base_layer/p2p/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tari_p2p"
-version = "0.8.11"
+version = "0.9.0"
 authors = ["The Tari Development community"]
 description = "Tari base layer-specific peer-to-peer communication features"
 repository = "https://github.com/tari-project/tari"
@@ -10,13 +10,13 @@ license = "BSD-3-Clause"
 edition = "2018"
 
 [dependencies]
-tari_comms = { version = "^0.8", path = "../../comms"}
-tari_comms_dht = { version = "^0.8", path = "../../comms/dht"}
-tari_common = { version= "^0.8", path = "../../common" }
+tari_comms = { version = "^0.9", path = "../../comms"}
+tari_comms_dht = { version = "^0.9", path = "../../comms/dht"}
+tari_common = { version= "^0.9", path = "../../common" }
 tari_crypto = "0.11.1"
-tari_service_framework = { version = "^0.8", path = "../service_framework"}
-tari_shutdown = { version = "^0.8", path="../../infrastructure/shutdown" }
-tari_storage = { version = "^0.8", path = "../../infrastructure/storage"}
+tari_service_framework = { version = "^0.9", path = "../service_framework"}
+tari_shutdown = { version = "^0.9", path="../../infrastructure/shutdown" }
+tari_storage = { version = "^0.9", path = "../../infrastructure/storage"}
 tari_utilities = "^0.3"
 
 anyhow = "1.0.32"
@@ -40,7 +40,7 @@ tower-service = { version="0.3.0-alpha.2" }
 trust-dns-client = {version="0.19.5", features=["dns-over-rustls"]}
 
 [dev-dependencies]
-tari_test_utils = { version = "^0.8", path="../../infrastructure/test_utils" }
+tari_test_utils = { version = "^0.9", path="../../infrastructure/test_utils" }
 
 clap = "2.33.0"
 env_logger = "0.6.2"
@@ -56,7 +56,7 @@ features = ["console_appender", "file_appender", "file", "yaml_format"]
 default-features = false
 
 [build-dependencies]
-tari_common = { version = "^0.8", path="../../common", features = ["build"] }
+tari_common = { version = "^0.9", path="../../common", features = ["build"] }
 
 [features]
 test-mocks = []

--- a/base_layer/service_framework/Cargo.toml
+++ b/base_layer/service_framework/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tari_service_framework"
-version = "0.8.11"
+version = "0.9.0"
 authors = ["The Tari Development Community"]
 description = "The Tari communication stack service framework"
 repository = "https://github.com/tari-project/tari"
@@ -10,7 +10,7 @@ license = "BSD-3-Clause"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-tari_shutdown = { version = "^0.8", path="../../infrastructure/shutdown" }
+tari_shutdown = { version = "^0.9", path="../../infrastructure/shutdown" }
 
 anyhow = "1.0.32"
 async-trait = "0.1.50"
@@ -21,7 +21,7 @@ tokio = { version = "0.2.10" }
 tower-service = { version="0.3.0" }
 
 [dev-dependencies]
-tari_test_utils = { version = "^0.8", path="../../infrastructure/test_utils" }
+tari_test_utils = { version = "^0.9", path="../../infrastructure/test_utils" }
 
 futures-test = { version = "0.3.3" }
 tokio-macros = "0.2.5"

--- a/base_layer/wallet/Cargo.toml
+++ b/base_layer/wallet/Cargo.toml
@@ -3,20 +3,20 @@ name = "tari_wallet"
 authors = ["The Tari Development Community"]
 description = "Tari cryptocurrency wallet library"
 license = "BSD-3-Clause"
-version = "0.8.11"
+version = "0.9.0"
 edition = "2018"
 
 [dependencies]
-tari_common_types = { version = "^0.8", path = "../../base_layer/common_types"}
-tari_comms = { version = "^0.8", path = "../../comms"}
-tari_comms_dht = { version = "^0.8", path = "../../comms/dht" }
+tari_common_types = { version = "^0.9", path = "../../base_layer/common_types"}
+tari_comms = { version = "^0.9", path = "../../comms"}
+tari_comms_dht = { version = "^0.9", path = "../../comms/dht" }
 tari_crypto = "0.11.1"
-tari_key_manager = { version = "^0.8", path = "../key_manager" }
-tari_p2p = { version = "^0.8", path = "../p2p" }
-tari_service_framework = { version = "^0.8", path = "../service_framework"}
-tari_shutdown = { version = "^0.8", path = "../../infrastructure/shutdown" }
-tari_storage = { version = "^0.8", path = "../../infrastructure/storage"}
-tari_test_utils = { version = "^0.8", path = "../../infrastructure/test_utils", optional = true}
+tari_key_manager = { version = "^0.9", path = "../key_manager" }
+tari_p2p = { version = "^0.9", path = "../p2p" }
+tari_service_framework = { version = "^0.9", path = "../service_framework"}
+tari_shutdown = { version = "^0.9", path = "../../infrastructure/shutdown" }
+tari_storage = { version = "^0.9", path = "../../infrastructure/storage"}
+tari_test_utils = { version = "^0.9", path = "../../infrastructure/test_utils", optional = true}
 
 aes-gcm = "^0.8"
 blake2 = "0.9.0"
@@ -44,14 +44,14 @@ bincode = "1.3.1"
 
 [dependencies.tari_core]
 path = "../../base_layer/core"
-version = "^0.8"
+version = "^0.9"
 default-features = false
 features = ["transactions", "mempool_proto", "base_node_proto",]
 
 [dev-dependencies]
-tari_p2p = { version = "^0.8", path = "../p2p", features=["test-mocks"]}
-tari_comms_dht = { version = "^0.8", path = "../../comms/dht", features=["test-mocks"]}
-tari_test_utils = { version = "^0.8", path = "../../infrastructure/test_utils" }
+tari_p2p = { version = "^0.9", path = "../p2p", features=["test-mocks"]}
+tari_comms_dht = { version = "^0.9", path = "../../comms/dht", features=["test-mocks"]}
+tari_test_utils = { version = "^0.9", path = "../../infrastructure/test_utils" }
 lazy_static = "1.3.0"
 env_logger = "0.7.1"
 prost = "0.6.1"

--- a/base_layer/wallet_ffi/Cargo.toml
+++ b/base_layer/wallet_ffi/Cargo.toml
@@ -7,13 +7,13 @@ version = "0.16.28"
 edition = "2018"
 
 [dependencies]
-tari_comms = { version = "^0.8", path = "../../comms" }
-tari_comms_dht = { version = "^0.8", path = "../../comms/dht" }
+tari_comms = { version = "^0.9", path = "../../comms" }
+tari_comms_dht = { version = "^0.9", path = "../../comms/dht" }
 tari_crypto = "0.11.1"
-tari_key_manager = { version = "^0.8", path = "../key_manager" }
-tari_p2p = { version = "^0.8", path = "../p2p" }
-tari_wallet = { version = "^0.8", path = "../wallet", features = ["test_harness", "c_integration"]}
-tari_shutdown = { version = "^0.8", path = "../../infrastructure/shutdown" }
+tari_key_manager = { version = "^0.9", path = "../key_manager" }
+tari_p2p = { version = "^0.9", path = "../p2p" }
+tari_wallet = { version = "^0.9", path = "../wallet", features = ["test_harness", "c_integration"]}
+tari_shutdown = { version = "^0.9", path = "../../infrastructure/shutdown" }
 tari_utilities = "^0.3"
 
 futures =  { version = "^0.3.1", features =["compat", "std"]}
@@ -27,7 +27,7 @@ log4rs = {version = "0.8.3", features = ["console_appender", "file_appender", "f
 
 [dependencies.tari_core]
 path = "../../base_layer/core"
-version = "^0.8"
+version = "^0.9"
 default-features = false
 features = ["transactions"]
 
@@ -38,7 +38,7 @@ crate-type = ["staticlib","cdylib"]
 tempfile = "3.1.0"
 lazy_static = "1.3.0"
 env_logger = "0.7.1"
-tari_key_manager = { version = "^0.8", path = "../key_manager" }
-tari_common_types = { version = "^0.8", path = "../../base_layer/common_types"}
-tari_test_utils = { version = "^0.8", path = "../../infrastructure/test_utils"}
+tari_key_manager = { version = "^0.9", path = "../key_manager" }
+tari_common_types = { version = "^0.9", path = "../../base_layer/common_types"}
+tari_test_utils = { version = "^0.9", path = "../../infrastructure/test_utils"}
 tokio = { version="0.2.10" }

--- a/changelog.md
+++ b/changelog.md
@@ -1,0 +1,56 @@
+<a name="0.9.0"></a>
+## 0.9.0 (2021-07-07)
+
+
+#### Bug Fixes
+
+*   fix missing edge case in header sync (#3060) ([0f0fb856](https://github.com/tari-project/tari/commit/0f0fb856e9369d9c7e172fc59ee64d31dff4637f))
+*   remove unstable impl trait from Tari comms (#3056) ([08b019f0](https://github.com/tari-project/tari/commit/08b019f03793f7677b72452e01bead7db89ffa18))
+*   fix db update error (#3063) ([b95d558f](https://github.com/tari-project/tari/commit/b95d558f318d045da9e1172cb802555ae3eb5a47))
+*   remove unimplemented Blake pow algo variant (#3047) ([347973e3](https://github.com/tari-project/tari/commit/347973e3e8fdd39bb74d978d14ff414c04a39212), breaks [#](https://github.com/tari-project/tari/issues/))
+*   fix small issues related to #3020 (#3026) ([da1d7579](https://github.com/tari-project/tari/commit/da1d75790fcb4eb9a71b7822c3ede3d9ba598241))
+*   update connectivity manager defaults (#3031) ([229830e5](https://github.com/tari-project/tari/commit/229830e595c6b3c97011547d18885e2c0a3e3f19))
+*   check minimum number of headers for calc-timing (#3009) ([b3522027](https://github.com/tari-project/tari/commit/b3522027b824dd8bb50a7183397adba082fdf28e))
+*   fix `Unique Constraint` bug when requesting a coinbase output at same height (#3004) ([537db06f](https://github.com/tari-project/tari/commit/537db06f33c49942d42e83fd6838f4fd405028d0))
+*   cancel faux transaction when imported UTXO is invalidated (#2984) ([472c3086](https://github.com/tari-project/tari/commit/472c30865cfa5a3cc648bffe22f6ec6e7aa22572))
+*   update console wallet on one sided payment import (#2983) ([f45cdc46](https://github.com/tari-project/tari/commit/f45cdc46f8485ea8978dd05edafa26d374c98fdc))
+*   fix prune mode (#2952) ([f7dc3a44](https://github.com/tari-project/tari/commit/f7dc3a44d2f57102024605cc6f4c93bb326b292a))
+*   fix ChainStorageError after a reorg with new block (#2915) ([7e99ea59](https://github.com/tari-project/tari/commit/7e99ea59ec11f19ba47e62729c3ee8b500d16c2e))
+*   improve error messages in tari applications (#2951) ([e04c884e](https://github.com/tari-project/tari/commit/e04c884eb4c7aaf124fa5da5d80ecfc4b00817e1))
+*   merge dev, update peer seeds (#2974) ([94ffd185](https://github.com/tari-project/tari/commit/94ffd185ff4ee9ce5575f28ae28e73464342b657))
+*   implement cucumber tests for one-sided recovery and scanning (#2955) ([b55d99fe](https://github.com/tari-project/tari/commit/b55d99fe3b08b34485bf1a9429cfad32a3fac84f))
+*   update rust nightly toolchain (#2957) ([812a1611](https://github.com/tari-project/tari/commit/812a1611a924b977a79bd5e7fe16eb986649adce))
+*   update failing rust tests (#2961) ([ed17fee3](https://github.com/tari-project/tari/commit/ed17fee3e34d3985794af621ba131e066849abec))
+* **wallet:**  increment wallet key manager index during recovery (#2973) ([c9fdeb3d](https://github.com/tari-project/tari/commit/c9fdeb3da90a297a75a53ddbea6823f3e6520b8d))
+
+#### Breaking Changes
+
+*   remove unimplemented Blake pow algo variant (#3047) ([347973e3](https://github.com/tari-project/tari/commit/347973e3e8fdd39bb74d978d14ff414c04a39212)
+* **ffi:**  `wallet_create` takes seed words for recovery (#2986) ([a2c6b17d](https://github.com/tari-project/tari/commit/a2c6b17de6fd8ac14a5379b0c44d34c1e1e71e2d)
+
+#### Features
+
+*   bundle openssl dependency (#3038) ([7fd5c286](https://github.com/tari-project/tari/commit/7fd5c2865b4093d0c89341ee49062ebf75d5eb5c))
+*   bundle sqlite dependency (#3036) ([7bd13411](https://github.com/tari-project/tari/commit/7bd1341159e8879ba9768b2268696f22b575fbe6))
+*   add tari script transaction data structures (#3064) ([266b5f1c](https://github.com/tari-project/tari/commit/266b5f1cede2e23603ab1d7eab2e1b5fc577537b))
+*   implement metadata comsig on txn output (#3057) ([8ecbb1f2](https://github.com/tari-project/tari/commit/8ecbb1f231da38f2e838c8acc79165b5b0a27136))
+*   software auto updates for base node (#3039) ([cf33cdb5](https://github.com/tari-project/tari/commit/cf33cdb5403736f67ea71f958e3ac06413c3f8e7))
+*   add zero conf tx (#3043) ([742dd9e6](https://github.com/tari-project/tari/commit/742dd9e6c9fc8c85bb6969e19489a4120d9cc9d1))
+*   network separation and protocol versioning implementation (#3030) ([2c9f6999](https://github.com/tari-project/tari/commit/2c9f69991f7cfcbda113a55ceeacdf2c13d90da3))
+*   add filtering of abandoned coinbase txs to console wallet (#3032) ([ae15fd9c](https://github.com/tari-project/tari/commit/ae15fd9c6203f8a6fe40be411fe3e4e590270ef7))
+*   add input_mr and witness_mr to header (#3041) ([65552cbd](https://github.com/tari-project/tari/commit/65552cbd7b826e76a63ca50e53c41e8986eb9860))
+*   Change script_signature type to ComSig (#3016) ([adb4a640](https://github.com/tari-project/tari/commit/adb4a64000f991df06454e86c303728af881241d))
+*   update app state when base node is set by command/script mode (#3019) ([4a499564](https://github.com/tari-project/tari/commit/4a499564d59162db25693f194f00eb4bd91f0700))
+*   add sender signature to txn output (#3020) ([7901b3ca](https://github.com/tari-project/tari/commit/7901b3ca2a6096e0f9148181b7a07ed16209d168))
+*   display local time instead of UTC. Add new wallet commands. (#2994) ([b3760202](https://github.com/tari-project/tari/commit/b3760202992676b8874a155775472820e6a22932))
+*   mininal merkle proof for monero pow data (#2996) ([ac062e57](https://github.com/tari-project/tari/commit/ac062e57903d493e09bff0ccee36660f7c088782))
+*   modify gamma calculation for TariScript ([c88d789e](https://github.com/tari-project/tari/commit/c88d789e0e8ee2180279debb59f0d53e15db3b66))
+*   fix birthday attack vulnerability in tari script offset (#2956) ([5174de0d](https://github.com/tari-project/tari/commit/5174de0d562b3ff444bceebeacbf3917b74dce85))
+*   improve LWMA (#2960) ([db303e8c](https://github.com/tari-project/tari/commit/db303e8ca9632c6a6634e52cbfb6a79cd3e43a29))
+* **ffi:**  `wallet_create` takes seed words for recovery (#2986) ([a2c6b17d](https://github.com/tari-project/tari/commit/a2c6b17de6fd8ac14a5379b0c44d34c1e1e71e2d))
+* **wallet:**
+  *  add maturity to transaction detail (#3042) ([9b281cec](https://github.com/tari-project/tari/commit/9b281cec339fea5cad48ca84cb5698302792373f))
+  *  ensure recovery will not overwrite existing wallet (#2992) ([70c21294](https://github.com/tari-project/tari/commit/70c21294fa87da8198e8b79f8b49d61bd6bee721))
+
+
+

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -6,7 +6,7 @@ repository = "https://github.com/tari-project/tari"
 homepage = "https://tari.com"
 readme = "README.md"
 license = "BSD-3-Clause"
-version = "0.8.11"
+version = "0.9.0"
 edition = "2018"
 
 [features]
@@ -24,7 +24,7 @@ log4rs = "0.8.3"
 multiaddr={package="parity-multiaddr", version = "0.11.0"}
 sha2 = "0.9.5"
 path-clean = "0.1.0"
-tari_storage = { version = "^0.8", path = "../infrastructure/storage"}
+tari_storage = { version = "^0.9", path = "../infrastructure/storage"}
 
 anyhow = { version = "1.0", optional = true }
 git2 = { version = "0.8", optional = true }
@@ -32,6 +32,6 @@ prost-build = { version = "0.6.1", optional = true }
 toml = { version = "0.5", optional = true }
 
 [dev-dependencies]
-tari_test_utils = { version = "^0.8", path = "../infrastructure/test_utils"}
+tari_test_utils = { version = "^0.9", path = "../infrastructure/test_utils"}
 tempfile = "3.1.0"
 anyhow = "1.0"

--- a/comms/Cargo.toml
+++ b/comms/Cargo.toml
@@ -6,13 +6,13 @@ repository = "https://github.com/tari-project/tari"
 homepage = "https://tari.com"
 readme = "README.md"
 license = "BSD-3-Clause"
-version = "0.8.11"
+version = "0.9.0"
 edition = "2018"
 
 [dependencies]
 tari_crypto = "0.11.1"
-tari_storage = { version = "^0.8", path = "../infrastructure/storage" }
-tari_shutdown = { version="^0.8",  path = "../infrastructure/shutdown" }
+tari_storage = { version = "^0.9", path = "../infrastructure/storage" }
+tari_shutdown = { version="^0.9",  path = "../infrastructure/shutdown" }
 
 bitflags = "1.0.4"
 blake2 = "0.9.0"
@@ -47,7 +47,7 @@ tower-make = {version="0.3.0", optional=true}
 anyhow = "1.0.32"
 
 [dev-dependencies]
-tari_test_utils = {version="^0.8", path="../infrastructure/test_utils"}
+tari_test_utils = {version="^0.9", path="../infrastructure/test_utils"}
 
 env_logger = "0.7.0"
 serde_json = "1.0.39"
@@ -55,7 +55,7 @@ tokio-macros = "0.2.3"
 tempfile = "3.1.0"
 
 [build-dependencies]
-tari_common = { version = "^0.8", path="../common", features = ["build"]}
+tari_common = { version = "^0.9", path="../common", features = ["build"]}
 
 [features]
 avx2 = ["tari_crypto/avx2"]

--- a/comms/dht/Cargo.toml
+++ b/comms/dht/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tari_comms_dht"
-version = "0.8.11"
+version = "0.9.0"
 authors = ["The Tari Development Community"]
 description = "Tari comms DHT module"
 repository = "https://github.com/tari-project/tari"
@@ -10,12 +10,12 @@ license = "BSD-3-Clause"
 edition = "2018"
 
 [dependencies]
-tari_comms  = { version = "^0.8", path = "../", features = ["rpc"]}
-tari_comms_rpc_macros  = { version = "^0.8", path = "../rpc_macros"}
+tari_comms  = { version = "^0.9", path = "../", features = ["rpc"]}
+tari_comms_rpc_macros  = { version = "^0.9", path = "../rpc_macros"}
 tari_crypto = "0.11.1"
 tari_utilities  = { version = "^0.3" }
-tari_shutdown = { version = "^0.8", path = "../../infrastructure/shutdown"}
-tari_storage  = { version = "^0.8", path = "../../infrastructure/storage"}
+tari_shutdown = { version = "^0.9", path = "../../infrastructure/shutdown"}
+tari_storage  = { version = "^0.9", path = "../../infrastructure/storage"}
 
 anyhow = "1.0.32"
 bitflags = "1.2.0"
@@ -43,7 +43,7 @@ ttl_cache = "0.5.1"
 pin-project = "0.4"
 
 [dev-dependencies]
-tari_test_utils = { version = "^0.8", path = "../../infrastructure/test_utils"}
+tari_test_utils = { version = "^0.9", path = "../../infrastructure/test_utils"}
 
 env_logger = "0.7.0"
 futures-test = { version = "0.3.0-alpha.19", package = "futures-test-preview" }
@@ -61,7 +61,7 @@ futures-util = "^0.3.1"
 lazy_static = "1.4.0"
 
 [build-dependencies]
-tari_common  = { version = "^0.8", path="../../common"}
+tari_common  = { version = "^0.9", path="../../common"}
 
 [features]
 test-mocks = []

--- a/comms/rpc_macros/Cargo.toml
+++ b/comms/rpc_macros/Cargo.toml
@@ -6,7 +6,7 @@ repository = "https://github.com/tari-project/tari"
 homepage = "https://tari.com"
 readme = "README.md"
 license = "BSD-3-Clause"
-version = "0.8.11"
+version = "0.9.0"
 edition = "2018"
 
 [lib]
@@ -16,10 +16,10 @@ proc-macro = true
 proc-macro2 = "1.0.24"
 quote = "1.0.7"
 syn = {version = "1.0.38", features = ["fold"]}
-tari_comms = { version = "^0.8", path = "../", features = ["rpc"]}
+tari_comms = { version = "^0.9", path = "../", features = ["rpc"]}
 
 [dev-dependencies]
-tari_test_utils = {version="^0.8", path="../../infrastructure/test_utils"}
+tari_test_utils = {version="^0.9", path="../../infrastructure/test_utils"}
 
 futures = "0.3.5"
 prost = "0.6.1"

--- a/infrastructure/derive/Cargo.toml
+++ b/infrastructure/derive/Cargo.toml
@@ -6,7 +6,7 @@ repository = "https://github.com/tari-project/tari"
 homepage = "https://tari.com"
 readme = "README.md"
 license = "BSD-3-Clause"
-version = "0.8.11"
+version = "0.9.0"
 edition = "2018"
 
 [lib]

--- a/infrastructure/shutdown/Cargo.toml
+++ b/infrastructure/shutdown/Cargo.toml
@@ -6,7 +6,7 @@ repository = "https://github.com/tari-project/tari"
 homepage = "https://tari.com"
 readme = "README.md"
 license = "BSD-3-Clause"
-version = "0.8.11"
+version = "0.9.0"
 edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/infrastructure/storage/Cargo.toml
+++ b/infrastructure/storage/Cargo.toml
@@ -6,7 +6,7 @@ repository = "https://github.com/tari-project/tari"
 homepage = "https://tari.com"
 readme = "README.md"
 license = "BSD-3-Clause"
-version = "0.8.11"
+version = "0.9.0"
 edition = "2018"
 
 [dependencies]

--- a/infrastructure/test_utils/Cargo.toml
+++ b/infrastructure/test_utils/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tari_test_utils"
 description = "Utility functions used in Tari test functions"
-version = "0.8.11"
+version = "0.9.0"
 authors = ["The Tari Development Community"]
 edition = "2018"
 license = "BSD-3-Clause"


### PR DESCRIPTION
<a name="0.9.0"></a>
## 0.9.0 (2021-07-07)


#### Bug Fixes

*   fix missing edge case in header sync (#3060) ([0f0fb856](https://github.com/tari-project/tari/commit/0f0fb856e9369d9c7e172fc59ee64d31dff4637f))
*   remove unstable impl trait from Tari comms (#3056) ([08b019f0](https://github.com/tari-project/tari/commit/08b019f03793f7677b72452e01bead7db89ffa18))
*   fix db update error (#3063) ([b95d558f](https://github.com/tari-project/tari/commit/b95d558f318d045da9e1172cb802555ae3eb5a47))
*   remove unimplemented Blake pow algo variant (#3047) ([347973e3](https://github.com/tari-project/tari/commit/347973e3e8fdd39bb74d978d14ff414c04a39212), breaks [#](https://github.com/tari-project/tari/issues/))
*   fix small issues related to #3020 (#3026) ([da1d7579](https://github.com/tari-project/tari/commit/da1d75790fcb4eb9a71b7822c3ede3d9ba598241))
*   update connectivity manager defaults (#3031) ([229830e5](https://github.com/tari-project/tari/commit/229830e595c6b3c97011547d18885e2c0a3e3f19))
*   check minimum number of headers for calc-timing (#3009) ([b3522027](https://github.com/tari-project/tari/commit/b3522027b824dd8bb50a7183397adba082fdf28e))
*   fix `Unique Constraint` bug when requesting a coinbase output at same height (#3004) ([537db06f](https://github.com/tari-project/tari/commit/537db06f33c49942d42e83fd6838f4fd405028d0))
*   cancel faux transaction when imported UTXO is invalidated (#2984) ([472c3086](https://github.com/tari-project/tari/commit/472c30865cfa5a3cc648bffe22f6ec6e7aa22572))
*   update console wallet on one sided payment import (#2983) ([f45cdc46](https://github.com/tari-project/tari/commit/f45cdc46f8485ea8978dd05edafa26d374c98fdc))
*   fix prune mode (#2952) ([f7dc3a44](https://github.com/tari-project/tari/commit/f7dc3a44d2f57102024605cc6f4c93bb326b292a))
*   fix ChainStorageError after a reorg with new block (#2915) ([7e99ea59](https://github.com/tari-project/tari/commit/7e99ea59ec11f19ba47e62729c3ee8b500d16c2e))
*   improve error messages in tari applications (#2951) ([e04c884e](https://github.com/tari-project/tari/commit/e04c884eb4c7aaf124fa5da5d80ecfc4b00817e1))
*   merge dev, update peer seeds (#2974) ([94ffd185](https://github.com/tari-project/tari/commit/94ffd185ff4ee9ce5575f28ae28e73464342b657))
*   implement cucumber tests for one-sided recovery and scanning (#2955) ([b55d99fe](https://github.com/tari-project/tari/commit/b55d99fe3b08b34485bf1a9429cfad32a3fac84f))
*   update rust nightly toolchain (#2957) ([812a1611](https://github.com/tari-project/tari/commit/812a1611a924b977a79bd5e7fe16eb986649adce))
*   update failing rust tests (#2961) ([ed17fee3](https://github.com/tari-project/tari/commit/ed17fee3e34d3985794af621ba131e066849abec))
* **wallet:**  increment wallet key manager index during recovery (#2973) ([c9fdeb3d](https://github.com/tari-project/tari/commit/c9fdeb3da90a297a75a53ddbea6823f3e6520b8d))

#### Breaking Changes

*   remove unimplemented Blake pow algo variant (#3047) ([347973e3](https://github.com/tari-project/tari/commit/347973e3e8fdd39bb74d978d14ff414c04a39212)
* **ffi:**  `wallet_create` takes seed words for recovery (#2986) ([a2c6b17d](https://github.com/tari-project/tari/commit/a2c6b17de6fd8ac14a5379b0c44d34c1e1e71e2d)

#### Features

*   bundle openssl dependency (#3038) ([7fd5c286](https://github.com/tari-project/tari/commit/7fd5c2865b4093d0c89341ee49062ebf75d5eb5c))
*   bundle sqlite dependency (#3036) ([7bd13411](https://github.com/tari-project/tari/commit/7bd1341159e8879ba9768b2268696f22b575fbe6))
*   add tari script transaction data structures (#3064) ([266b5f1c](https://github.com/tari-project/tari/commit/266b5f1cede2e23603ab1d7eab2e1b5fc577537b))
*   implement metadata comsig on txn output (#3057) ([8ecbb1f2](https://github.com/tari-project/tari/commit/8ecbb1f231da38f2e838c8acc79165b5b0a27136))
*   software auto updates for base node (#3039) ([cf33cdb5](https://github.com/tari-project/tari/commit/cf33cdb5403736f67ea71f958e3ac06413c3f8e7))
*   add zero conf tx (#3043) ([742dd9e6](https://github.com/tari-project/tari/commit/742dd9e6c9fc8c85bb6969e19489a4120d9cc9d1))
*   network separation and protocol versioning implementation (#3030) ([2c9f6999](https://github.com/tari-project/tari/commit/2c9f69991f7cfcbda113a55ceeacdf2c13d90da3))
*   add filtering of abandoned coinbase txs to console wallet (#3032) ([ae15fd9c](https://github.com/tari-project/tari/commit/ae15fd9c6203f8a6fe40be411fe3e4e590270ef7))
*   add input_mr and witness_mr to header (#3041) ([65552cbd](https://github.com/tari-project/tari/commit/65552cbd7b826e76a63ca50e53c41e8986eb9860))
*   Change script_signature type to ComSig (#3016) ([adb4a640](https://github.com/tari-project/tari/commit/adb4a64000f991df06454e86c303728af881241d))
*   update app state when base node is set by command/script mode (#3019) ([4a499564](https://github.com/tari-project/tari/commit/4a499564d59162db25693f194f00eb4bd91f0700))
*   add sender signature to txn output (#3020) ([7901b3ca](https://github.com/tari-project/tari/commit/7901b3ca2a6096e0f9148181b7a07ed16209d168))
*   display local time instead of UTC. Add new wallet commands. (#2994) ([b3760202](https://github.com/tari-project/tari/commit/b3760202992676b8874a155775472820e6a22932))
*   mininal merkle proof for monero pow data (#2996) ([ac062e57](https://github.com/tari-project/tari/commit/ac062e57903d493e09bff0ccee36660f7c088782))
*   modify gamma calculation for TariScript ([c88d789e](https://github.com/tari-project/tari/commit/c88d789e0e8ee2180279debb59f0d53e15db3b66))
*   fix birthday attack vulnerability in tari script offset (#2956) ([5174de0d](https://github.com/tari-project/tari/commit/5174de0d562b3ff444bceebeacbf3917b74dce85))
*   improve LWMA (#2960) ([db303e8c](https://github.com/tari-project/tari/commit/db303e8ca9632c6a6634e52cbfb6a79cd3e43a29))
* **ffi:**  `wallet_create` takes seed words for recovery (#2986) ([a2c6b17d](https://github.com/tari-project/tari/commit/a2c6b17de6fd8ac14a5379b0c44d34c1e1e71e2d))
* **wallet:**
  *  add maturity to transaction detail (#3042) ([9b281cec](https://github.com/tari-project/tari/commit/9b281cec339fea5cad48ca84cb5698302792373f))
  *  ensure recovery will not overwrite existing wallet (#2992) ([70c21294](https://github.com/tari-project/tari/commit/70c21294fa87da8198e8b79f8b49d61bd6bee721))



