### PR TITLE
Update `tari-common` crate feature flags to exclude git2 from lib_wallet build

### DIFF
--- a/applications/tari_app_utilities/Cargo.toml
+++ b/applications/tari_app_utilities/Cargo.toml
@@ -32,4 +32,4 @@ default-features = false
 features = ["transactions"]
 
 [build-dependencies]
-tari_common = {  path = "../../common", features = ["build"] }
+tari_common = {  path = "../../common", features = ["build", "static-application-info"] }

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -10,7 +10,8 @@ version = "0.9.0"
 edition = "2018"
 
 [features]
-build=["toml", "git2", "anyhow", "prost-build"]
+build=["toml", "anyhow", "prost-build"]
+static-application-info=["git2"]
 
 [dependencies]
 structopt = { version = "0.3.13", default_features = false }

--- a/common/src/build/mod.rs
+++ b/common/src/build/mod.rs
@@ -20,8 +20,12 @@
 //  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 //  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+#[cfg(feature = "static-application-info")]
 mod application;
+#[cfg(feature = "static-application-info")]
 pub use application::StaticApplicationInfo;
 
+#[cfg(feature = "build")]
 mod protobuf;
+#[cfg(feature = "build")]
 pub use protobuf::ProtobufCompiler;

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -76,7 +76,7 @@
 //! # std::fs::remove_dir_all(temp_dir).unwrap();
 //! ```
 
-#[cfg(feature = "build")]
+#[cfg(any(feature = "build", feature = "static-application-info"))]
 pub mod build;
 #[macro_use]
 mod logging;


### PR DESCRIPTION
## Description
This PR adds a feature flag to the Tari-common crate so that the git2 dependency can be excluded from he building of Core. This dependency contains a C dependency (libgit2) that breaks the LibWallet build.

## How Has This Been Tested?
Manually tested

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [ ] I'm merging against the `development` branch.
* [ ] I have squashed my commits into a single commit.
