### PR TITLE
[windows] Run wallet on windows terminal if present.

### DIFF
--- a/applications/tari_console_wallet/windows/runtime/source_console_wallet_env.bat
+++ b/applications/tari_console_wallet/windows/runtime/source_console_wallet_env.bat
@@ -147,4 +147,10 @@ if not exist "%config_path%\log4rs_console_wallet.yml" (
 echo.
 
 cd "%base_path%"
+rem check if Windows Terminal is in path, if so, run it there, to see emojis properly.
+where /q wt
+if errorlevel 1 (
 "%console_wallet%" %INIT_FLAG% --config "%config_path%\config.toml" --log_config "%config_path%\log4rs_console_wallet.yml" --base-path "%base_path%"
+) else (
+wt "%console_wallet%" %INIT_FLAG% --config "%config_path%\config.toml" --log_config "%config_path%\log4rs_console_wallet.yml" --base-path "%base_path%"
+)


### PR DESCRIPTION
## Description
Conhost can show emojis properly. So the user can just install windows terminal from the store. And then the user can just run the console again using the .bat or .lnk file.