### PR TITLE
Docker - Setup tari_base_node to run as non-root user

### DIFF
--- a/buildtools/docker/start.sh
+++ b/buildtools/docker/start.sh
@@ -4,8 +4,11 @@
 #  script to run tor, sleep 15 seconds and start the base node
 #
 
+# ToDo:
+#  Add tor running check
 tor &
 sleep 15
+
 TARI_CONFIG=~/.tari/config/config.toml
 if [[ ! -f $TARI_CONFIG ]]; then
   tari_base_node --init --create-id


### PR DESCRIPTION

## Motivation and Context
Running docker applications as non-root user is a more secure and best practice.

## How Has This Been Tested?
Clean local build and sync to tip

## Checklist:
* [x] I'm merging against the `development` branch.
* [x] I have squashed my commits into a single commit.
