### PR TITLE
Add one-sided transactions to `make-it-rain`, improve its async sending

### DIFF
--- a/applications/tari_console_wallet/README.md
+++ b/applications/tari_console_wallet/README.md
@@ -47,18 +47,37 @@ Monitoring 1 sent transactions to Broadcast stage...
 Done! All transactions monitored to Broadcast stage.
 ```
 
-- **make-it-rain**
+- **send-one-sided**
 
-Make it rain! Send many transactions to a public key or emoji id.
+Send an amount of Tari to a public key or emoji id in a one-sided transaction.
 
-`tari_console_wallet --command "make-it-rain <tx/sec> <duration> <amount> <increment> <start time or now> <pubkey> <optional message>"`
+`tari_console_wallet --command send-one-sided <amount> <pubkey> <optional message>"`
 
 example:
 
 ```
-$ tari_console_wallet --command "make-it-rain 1 10 8000 100 now c69fbe5f05a304eaec65d5f234a6aa258a90b8bb5b9ceffea779653667ef2108 makin it rain yo"
+$ tari_console_wallet --command "send-one-sided 1T c69fbe5f05a304eaec65d5f234a6aa258a90b8bb5b9ceffea779653667ef2108 coffee"
 
-1. make-it-rain 1 10 8000 µT 100 µT 2021-03-26 10:03:30.459157 UTC c69fbe5f05a304eaec65d5f234a6aa258a90b8bb5b9ceffea779653667ef2108 makin it rain yo
+1. send-tari 1.000000 T c69fbe5f05a304eaec65d5f234a6aa258a90b8bb5b9ceffea779653667ef2108 coffee
+
+Monitoring 1 sent transactions to Broadcast stage...
+Done! All transactions monitored to Broadcast stage.
+```
+
+- **make-it-rain**
+
+Make it rain! Send many transactions to a public key or emoji id.
+
+`tari_console_wallet --command "make-it-rain <tx/sec> <duration> <amount> <increment> <start time or now> <pubkey> <transaction type> <optional message>"`
+
+`<type>` can be `negotiated` or `one_sided`
+
+example:
+
+```
+$ tari_console_wallet --command "make-it-rain 1 10 8000 100 now c69fbe5f05a304eaec65d5f234a6aa258a90b8bb5b9ceffea779653667ef2108 negotiated makin it rain yo"
+
+1. make-it-rain 1 10 8000 µT 100 µT 2021-03-26 10:03:30.459157 UTC c69fbe5f05a304eaec65d5f234a6aa258a90b8bb5b9ceffea779653667ef2108 negotiated makin it rain yo
 
 Monitoring 10 sent transactions to Broadcast stage...
 Done! All transactions monitored to Broadcast stage.

--- a/applications/tari_console_wallet/src/automation/commands.rs
+++ b/applications/tari_console_wallet/src/automation/commands.rs
@@ -58,7 +58,7 @@ use tari_wallet::{
     WalletSqlite,
 };
 use tokio::{
-    runtime::Handle,
+    sync::mpsc,
     time::{delay_for, timeout},
 };
 
@@ -248,10 +248,9 @@ pub async fn discover_peer(
 }
 
 pub async fn make_it_rain(
-    handle: Handle,
     wallet_transaction_service: TransactionServiceHandle,
     args: Vec<ParsedArgument>,
-) -> Result<Vec<TxId>, CommandError> {
+) -> Result<(), CommandError> {
     use ParsedArgument::*;
 
     let txps = match args[0].clone() {
@@ -284,60 +283,148 @@ pub async fn make_it_rain(
         _ => Err(CommandError::Argument),
     }?;
 
-    let message = match args[6].clone() {
+    let negotiated = match args[6].clone() {
+        Negotiated(val) => Ok(val),
+        _ => Err(CommandError::Argument),
+    }?;
+
+    let message = match args[7].clone() {
         Text(m) => Ok(m),
         _ => Err(CommandError::Argument),
     }?;
 
-    // Wait until specified test start time
-    let now = Utc::now();
-    let delay_ms = if start_time > now {
-        println!(
-            "`make-it-rain` scheduled to start at {}: msg \"{}\"",
-            start_time, message
+    // We are spawning this command in parallel, thus not collecting transaction IDs
+    tokio::task::spawn(async move {
+        // Wait until specified test start time
+        let now = Utc::now();
+        let delay_ms = if start_time > now {
+            println!(
+                "`make-it-rain` scheduled to start at {}: msg \"{}\"",
+                start_time, message
+            );
+            (start_time - now).num_milliseconds() as u64
+        } else {
+            0
+        };
+
+        debug!(
+            target: LOG_TARGET,
+            "make-it-rain delaying for {:?} ms - scheduled to start at {}", delay_ms, start_time
         );
-        (start_time - now).num_milliseconds() as u64
-    } else {
-        0
-    };
+        delay_for(Duration::from_millis(delay_ms)).await;
 
-    debug!(
-        target: LOG_TARGET,
-        "make-it-rain delaying for {:?} ms - scheduled to start at {}", delay_ms, start_time
-    );
-    delay_for(Duration::from_millis(delay_ms)).await;
+        let num_txs = (txps * duration as f64) as usize;
+        let started_at = Utc::now();
 
-    let num_txs = (txps * duration as f64) as usize;
-
-    let mut tx_ids = Vec::new();
-    let started_at = Utc::now();
-
-    for i in 0..num_txs {
-        // Manage Tx rate
-        let actual_ms = (Utc::now() - started_at).num_milliseconds();
-        let target_ms = (i as f64 / (txps / 1000.0)) as i64;
-        if target_ms - actual_ms > 0 {
-            // Maximum delay between Txs set to 120 s
-            delay_for(Duration::from_millis((target_ms - actual_ms).min(120_000i64) as u64)).await;
+        struct TransactionSendStats {
+            i: usize,
+            tx_id: Result<TxId, CommandError>,
+            delayed_for: Duration,
+            submit_time: Duration,
         }
-        // Send Tx
-        let amount = start_amount + inc_amount * (i as u64);
-        let send_args = vec![
-            ParsedArgument::Amount(amount),
-            ParsedArgument::PublicKey(public_key.clone()),
-            ParsedArgument::Text(message.clone()),
-        ];
-        let tx_service = wallet_transaction_service.clone();
-        let tx_id = handle
-            .spawn(send_tari(tx_service, send_args))
-            .await
-            .map_err(CommandError::Join)??;
+        let transaction_type = if negotiated { "negotiated" } else { "one-sided" };
+        println!(
+            "\n`make-it-rain` starting {} {} transactions \"{}\"\n",
+            num_txs, transaction_type, message
+        );
+        let (sender, mut receiver) = mpsc::channel(num_txs);
+        {
+            let sender = sender;
+            for i in 0..num_txs {
+                debug!(
+                    target: LOG_TARGET,
+                    "make-it-rain starting {} of {} {} transactions",
+                    i + 1,
+                    num_txs,
+                    transaction_type
+                );
+                let loop_started_at = Instant::now();
+                let tx_service = wallet_transaction_service.clone();
+                // Transaction details
+                let amount = start_amount + inc_amount * (i as u64);
+                let send_args = vec![
+                    ParsedArgument::Amount(amount),
+                    ParsedArgument::PublicKey(public_key.clone()),
+                    ParsedArgument::Text(message.clone()),
+                ];
+                // Manage transaction submission rate
+                let actual_ms = (Utc::now() - started_at).num_milliseconds();
+                let target_ms = (i as f64 / (txps / 1000.0)) as i64;
+                if target_ms - actual_ms > 0 {
+                    // Maximum delay between Txs set to 120 s
+                    delay_for(Duration::from_millis((target_ms - actual_ms).min(120_000i64) as u64)).await;
+                }
+                let delayed_for = Instant::now();
+                let mut sender_clone = sender.clone();
+                tokio::task::spawn(async move {
+                    let spawn_start = Instant::now();
+                    // Send transaction
+                    let tx_id = if negotiated {
+                        send_tari(tx_service, send_args).await
+                    } else {
+                        send_one_sided(tx_service, send_args).await
+                    };
+                    let submit_time = Instant::now();
+                    tokio::task::spawn(async move {
+                        print!("{} ", i + 1);
+                    });
+                    if let Err(e) = sender_clone
+                        .send(TransactionSendStats {
+                            i: i + 1,
+                            tx_id,
+                            delayed_for: delayed_for.duration_since(loop_started_at),
+                            submit_time: submit_time.duration_since(spawn_start),
+                        })
+                        .await
+                    {
+                        warn!(
+                            target: LOG_TARGET,
+                            "make-it-rain: Error sending transaction send stats to channel: {}",
+                            e.to_string()
+                        );
+                    }
+                });
+            }
+        }
+        while let Some(send_stats) = receiver.recv().await {
+            match send_stats.tx_id {
+                Ok(tx_id) => {
+                    debug!(
+                        target: LOG_TARGET,
+                        "make-it-rain transaction {} ({}) submitted to queue, tx_id: {}, delayed for ({}ms), submit \
+                         time ({}ms)",
+                        send_stats.i,
+                        transaction_type,
+                        tx_id,
+                        send_stats.delayed_for.as_millis(),
+                        send_stats.submit_time.as_millis()
+                    );
+                },
+                Err(e) => {
+                    warn!(
+                        target: LOG_TARGET,
+                        "make-it-rain transaction {} ({}) error: {}",
+                        send_stats.i,
+                        transaction_type,
+                        e.to_string(),
+                    );
+                },
+            }
+        }
+        debug!(
+            target: LOG_TARGET,
+            "make-it-rain concluded {} {} transactions", num_txs, transaction_type
+        );
+        println!(
+            "\n`make-it-rain` concluded {} {} transactions (\"{}\") at {}",
+            num_txs,
+            transaction_type,
+            message,
+            Utc::now()
+        );
+    });
 
-        debug!(target: LOG_TARGET, "make-it-rain tx_id: {}", tx_id);
-        tx_ids.push(tx_id);
-    }
-
-    Ok(tx_ids)
+    Ok(())
 }
 
 pub async fn monitor_transactions(
@@ -460,7 +547,6 @@ pub async fn monitor_transactions(
 }
 
 pub async fn command_runner(
-    handle: Handle,
     commands: Vec<ParsedCommand>,
     wallet: WalletSqlite,
     config: GlobalConfig,
@@ -507,8 +593,7 @@ pub async fn command_runner(
                 tx_ids.push(tx_id);
             },
             MakeItRain => {
-                let rain_ids = make_it_rain(handle.clone(), transaction_service.clone(), parsed.args).await?;
-                tx_ids.extend(rain_ids);
+                make_it_rain(transaction_service.clone(), parsed.args).await?;
             },
             CoinSplit => {
                 let tx_id = coin_split(&parsed.args, &mut output_service, &mut transaction_service.clone()).await?;
@@ -623,7 +708,7 @@ pub async fn command_runner(
             },
             Err(_e) => {
                 println!(
-                    "The configured timeout ({:#?}s) was reached before all transactions reached the {:?} stage. See \
+                    "The configured timeout ({:#?}) was reached before all transactions reached the {:?} stage. See \
                      the logs for more info.",
                     duration, wait_stage
                 );

--- a/applications/tari_console_wallet/src/automation/error.rs
+++ b/applications/tari_console_wallet/src/automation/error.rs
@@ -86,8 +86,8 @@ pub enum ParseError {
     Date(#[from] DateError),
     #[error("Failed to parse a net address.")]
     Address,
-    #[error("Invalid combination of arguments.")]
-    Invalid,
+    #[error("Invalid combination of arguments ({0}).")]
+    Invalid(String),
     #[error("Parsing not yet implemented for {0}.")]
     Unimplemented(String),
 }

--- a/applications/tari_console_wallet/src/wallet_modes.rs
+++ b/applications/tari_console_wallet/src/wallet_modes.rs
@@ -134,7 +134,7 @@ pub fn command_mode(config: WalletModeConfig, wallet: WalletSqlite, command: Str
     } = config.clone();
     let commands = vec![parse_command(&command)?];
     info!(target: LOG_TARGET, "Starting wallet command mode");
-    handle.block_on(command_runner(handle.clone(), commands, wallet.clone(), global_config))?;
+    handle.block_on(command_runner(commands, wallet.clone(), global_config))?;
 
     info!(target: LOG_TARGET, "Completed wallet command mode");
 
@@ -166,7 +166,7 @@ pub fn script_mode(config: WalletModeConfig, wallet: WalletSqlite, path: PathBuf
     println!("{} commands parsed successfully.", commands.len());
 
     println!("Starting the command runner!");
-    handle.block_on(command_runner(handle.clone(), commands, wallet.clone(), global_config))?;
+    handle.block_on(command_runner(commands, wallet.clone(), global_config))?;
 
     info!(target: LOG_TARGET, "Completed wallet script mode");
 

--- a/common/config/presets/tari_config_example.toml
+++ b/common/config/presets/tari_config_example.toml
@@ -142,7 +142,7 @@ scan_for_utxo_interval=60
 
 # The default values are:
 #command_send_wait_stage = "Broadcast"
-#command_send_wait_timeout = 600
+#command_send_wait_timeout = 300
 
 # The base nodes that the wallet should use for service requests and tracking chain state.
 # base_node_service_peers = ["public_key::net_address", ...]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR focused on adding one-sided transactions to `make-it-rain` and to improve its async sending ability:
- Added one-sided transactions to the `make-it-rain` command.
- Made sending transactions for `make-it-rain` asynchronous,
- Updated the wallet README.md,
- Added test cases for `make-it-rain` command parser.
- Added time measurements for processing transaction service events to assist in finding processing bottlenecks, _**this can be removed later on**_.
- Improved logic around the database call to `get_balance` when selecting UTXOs for sending.

## Motivation and Context
- Before this PR executing the `make-it-rain` command was really slow.  Transactions were also not submitted at the required rate but held back by the slow transaction sending process.
- It was unclear where time was spent sending transactions, and if transactions were sent in parallel.
- After parallelizing the `make-it-rain` command, it was apparent that transaction sending became progressively slower as transactions were sent, which was also dependent on the UTXO set size in the wallet database to select from.
- Transaction sending becoming progressively slower was found to be caused by a database call to `get_balance` that was unnecessary 99% of the time. The balance query includes UTXOs encumbered to be sent and received, and with the growing set of those UTXOs as the test progressed, the query grew in complexity. The database call to `get_balance`'s primary purpose in the transaction sending context is to add UTXOs encumbered to be received to the available balance if the latter was insufficient when selecting UTXOs for sending. The solution was to not call `get_balance` if the available balance was sufficient.

With testing `make-it-rain` _on this branch_:
- After making `make-it-rain` asynchronous, _before fixing_ the call to `get_balance` :
  - Using a "big" sized wallet database (~8,000 available UTXOs):
    - 2,500 (`one-sided`, `negotiated`) transactions between one sender wallet and one receiver wallet in **one** `make-it-rain` task (not including mining):
      - Submitted all transactions at an actual rate of 5 transactions/s in parallel tasks.
      - Finalizing send commands at ~7.6 transactions/minute, irrespective of using `one-sided` or `negotiated` transactions.
  - Using a "medium" sized wallet database (~3,000  available UTXOs):
    - 1,000 (negotiated`) transactions between one sender wallet and one receiver wallet in **five** `make-it-rain` tasks (not including mining):
      - Submitted all transactions at an actual rate of 5 x 5 transactions/s in parallel tasks.
      - All 1,000 transactions' initial sending were concluded in 744s, thus ~80.6 transactions/minute
  - Using a "big" sized wallet database (~7,000 available UTXOs):
    - 2,500 (negotiated`) transactions between one sender wallet and one receiver wallet in **five** `make-it-rain` tasks (not including mining):
      - Submitted all transactions at an actual rate of 5 x 5 transactions/s in parallel tasks.
      - Finalizing send commands at ~9.3 transactions/minute, irrespective of using `one-sided` or `negotiated` transactions.
- After making `make-it-rain` asynchronous, _after fixing_ the call to `get_balance` :
  - Using a "big" sized wallet database (~9,500 available UTXOs):
    - 2,500 (negotiated`) transactions between one sender wallet and one receiver wallet in **five** `make-it-rain` tasks (not including mining):
      - Submitted all transactions at an actual rate of 5 x 5 transactions/s in parallel tasks.
      - Finalizing send commands at ~67.4 transactions/minute.

![image](https://user-images.githubusercontent.com/39146854/125582735-4072be73-e82b-4a3d-b136-8cfcdc55e262.png)

Intuitively, database requests for spendable UTXOs should become quicker as the list becomes smaller; this is now evident in the graph above.

## How Has This Been Tested?
- Unit test added
- System level testing

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [X] I'm merging against the `development` branch.
* [X] I have squashed my commits into a single commit.
