### PR TITLE
Fix when ESC is pressed while adding contact.

### DIFF
--- a/applications/tari_console_wallet/src/ui/components/send_tab.rs
+++ b/applications/tari_console_wallet/src/ui/components/send_tab.rs
@@ -721,8 +721,10 @@ impl<B: Backend> Component<B> for SendTab {
     }
 
     fn on_esc(&mut self, _: &mut AppState) {
+        self.edit_contact_mode = ContactInputMode::None;
         self.send_input_mode = SendInputMode::None;
         self.show_contacts = false;
+        self.show_edit_contact = false;
     }
 
     fn on_backspace(&mut self, _app_state: &mut AppState) {


### PR DESCRIPTION
## Description
When ESC was pressed while adding contacts, the UI was broken. Still expecting to add the contacts, but didn't show anything. This PR fixes that. ESC properly ends adding contact and hides the contact list.