### PR TITLE
Wallet: fix UTXO scanning

### DIFF
--- a/base_layer/wallet/tests/transaction_service/service.rs
+++ b/base_layer/wallet/tests/transaction_service/service.rs
@@ -922,10 +922,17 @@ fn recover_one_sided_transaction() {
             .expect("Could not find completed one-sided tx");
         let outputs = completed_tx.transaction.body.outputs().clone();
 
-        let unblinded = bob_oms.scan_outputs_for_one_sided_payments(outputs).await.unwrap();
+        let unblinded = bob_oms
+            .scan_outputs_for_one_sided_payments(outputs.clone())
+            .await
+            .unwrap();
         // Bob should be able to claim 1 output.
         assert_eq!(1, unblinded.len());
         assert_eq!(value, unblinded[0].value);
+
+        // Should ignore already existing outputs
+        let unblinded = bob_oms.scan_outputs_for_one_sided_payments(outputs).await.unwrap();
+        assert!(unblinded.is_empty());
     });
 }
 

--- a/common/src/configuration/utils.rs
+++ b/common/src/configuration/utils.rs
@@ -91,7 +91,7 @@ pub fn default_config(bootstrap: &ConfigBootstrap) -> Config {
     )
     .unwrap();
     cfg.set_default("wallet.base_node_query_timeout", 60).unwrap();
-    // 60 sec * 60 mintues * 12 hours.
+    // 60 sec * 60 minutes * 12 hours.
     cfg.set_default("wallet.scan_for_utxo_interval", 60 * 60 * 12).unwrap();
     cfg.set_default("wallet.transaction_broadcast_monitoring_timeout", 60)
         .unwrap();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
- Fixes excessive RPC sessions
- Fixes edge case: scanning has previously failed but some UTXOs
  were added. When retrying those same UTXOs are added, resulting in a
  db error that fails the UTXO sync. The correct behaviour is to continue
  scanning.
- Update one-sided payment unit test
- Minor logging improvements

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Excessive RPC sessions issue:
![image](https://user-images.githubusercontent.com/1057902/125575546-05a7e655-0880-4b08-a622-b7fff4e272b1.png)

Adding already existing UTXO issue:
```
Scanning UTXO's from #88282 to #115116 (height 4816)                                                                                                                                                                         
WARN Error handling request: OutputManagerStorageError(DuplicateOutput)
 ... rinse and repeat ...
```

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Updated unit test
Tested on wallet that previously was spamming RPC sessions. 
The wallet had many one sided payments sent via test pool that were not being detected. 
All of them were detected with these code changes.. 

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch.
* [x] I have squashed my commits into a single commit.
