### PR TITLE
Add contact lookup in wallet.

### DIFF
--- a/applications/tari_console_wallet/src/ui/components/transactions_tab.rs
+++ b/applications/tari_console_wallet/src/ui/components/transactions_tab.rs
@@ -98,7 +98,7 @@ impl TransactionsTab {
             let text_color = text_colors.get(&t.cancelled).unwrap_or(&Color::Reset).to_owned();
             if t.direction == TransactionDirection::Outbound {
                 column0_items.push(ListItem::new(Span::styled(
-                    format!("{}", t.destination_public_key),
+                    app_state.get_alias(&t.destination_public_key),
                     Style::default().fg(text_color),
                 )));
                 let amount_style = if t.cancelled {
@@ -109,7 +109,7 @@ impl TransactionsTab {
                 column1_items.push(ListItem::new(Span::styled(format!("{}", t.amount), amount_style)));
             } else {
                 column0_items.push(ListItem::new(Span::styled(
-                    format!("{}", t.source_public_key),
+                    app_state.get_alias(&t.source_public_key),
                     Style::default().fg(text_color),
                 )));
                 let amount_style = if t.cancelled {
@@ -183,7 +183,7 @@ impl TransactionsTab {
             let text_color = text_colors.get(&cancelled).unwrap_or(&Color::Reset).to_owned();
             if t.direction == TransactionDirection::Outbound {
                 column0_items.push(ListItem::new(Span::styled(
-                    format!("{}", t.destination_public_key),
+                    app_state.get_alias(&t.destination_public_key),
                     Style::default().fg(text_color),
                 )));
                 let amount_style = if t.cancelled {
@@ -194,7 +194,7 @@ impl TransactionsTab {
                 column1_items.push(ListItem::new(Span::styled(format!("{}", t.amount), amount_style)));
             } else {
                 column0_items.push(ListItem::new(Span::styled(
-                    format!("{}", t.source_public_key),
+                    app_state.get_alias(&t.source_public_key),
                     Style::default().fg(text_color),
                 )));
                 let maturity = if let Some(output) = t.transaction.body.outputs().first() {

--- a/applications/tari_console_wallet/src/ui/state/app_state.rs
+++ b/applications/tari_console_wallet/src/ui/state/app_state.rs
@@ -50,7 +50,7 @@ use tari_core::transactions::{
     tari_amount::{uT, MicroTari},
     types::PublicKey,
 };
-use tari_crypto::tari_utilities::hex::Hex;
+use tari_crypto::{ristretto::RistrettoPublicKey, tari_utilities::hex::Hex};
 use tari_shutdown::ShutdownSignal;
 use tari_wallet::{
     base_node_service::{handle::BaseNodeEventReceiver, service::BaseNodeState},
@@ -150,6 +150,24 @@ impl AppState {
         drop(inner);
         self.update_cache().await;
         Ok(())
+    }
+
+    // Return alias or pub key if the contact is not in the list.
+    pub fn get_alias(&self, pub_key: &RistrettoPublicKey) -> String {
+        let pub_key_hex = format!("{}", pub_key);
+        // TODO: We can uncomment this to indicated unknown origin, otherwise there is our pub key.
+        // if self.get_identity().public_key == pub_key_hex {
+        //     return "Unknown".to_string();
+        // }
+        match self
+            .cached_data
+            .contacts
+            .iter()
+            .find(|&contact| contact.public_key.eq(&pub_key_hex))
+        {
+            Some(contact) => contact.alias.clone(),
+            None => pub_key_hex,
+        }
     }
 
     pub async fn delete_contact(&mut self, public_key: String) -> Result<(), UiError> {


### PR DESCRIPTION
## Description
Show alias if present in contact list. If it's not there return pub key.
The pub key is still shown in the transactions details. That should stay there.