### PR TITLE
fix: reduce UTXO batch size query limit to account for 4MB frame size

### DIFF
--- a/base_layer/wallet/src/output_manager_service/config.rs
+++ b/base_layer/wallet/src/output_manager_service/config.rs
@@ -36,7 +36,7 @@ impl Default for OutputManagerServiceConfig {
     fn default() -> Self {
         Self {
             base_node_query_timeout: Duration::from_secs(60),
-            max_utxo_query_size: 5000,
+            max_utxo_query_size: 3500,
             prevent_fee_gt_amount: true,
             peer_dial_retry_timeout: Duration::from_secs(20),
             seed_word_language: MnemonicLanguage::English,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
The 5000 UTXO query batch limit is not limiting enough anymore due to growth in input and output data size.

## Motivation and Context
```
2021-07-15 12:00:00.179668000 [wallet::output_manager_service::utxo_validation_task] 
  WARN  Error with RPC Client: Request failed: MalformedResponse: This node tried to 
  return a message that exceeds the maximum frame size. Max = 4.0000 MiB, 
  Got = 4.0590 MiB. Retrying RPC client connection.
```

## How Has This Been Tested?
System level test

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [X] I'm merging against the `development` branch.
* [X] I have squashed my commits into a single commit.
