### PR TITLE
fix: update transaction status from broadcast if already mined

### DIFF
--- a/base_layer/wallet/src/transaction_service/protocols/transaction_broadcast_protocol.rs
+++ b/base_layer/wallet/src/transaction_service/protocols/transaction_broadcast_protocol.rs
@@ -416,6 +416,18 @@ where TBackend: TransactionBackend + 'static
                 .mine_completed_transaction(self.tx_id)
                 .await
                 .map_err(|e| TransactionServiceProtocolError::new(self.tx_id, TransactionServiceError::from(e)))?;
+            let _ = self
+                .resources
+                .event_publisher
+                .send(Arc::new(TransactionEvent::TransactionMined(self.tx_id)))
+                .map_err(|e| {
+                    trace!(
+                        target: LOG_TARGET,
+                        "Error sending event because there are no subscribers: {:?}",
+                        e
+                    );
+                    e
+                });
         } else {
             info!(
                 target: LOG_TARGET,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Updated the transaction status from broadcast if already mined.

## Motivation and Context
Transaction status was not updated in the broadcast protocol monitoring loop if detected that it was already mined; added the transaction mined to the event publisher. A wallet restart was required to update the status.

## How Has This Been Tested?
Unit testing. Will still monitor in future stress tests.

Checklist:
---
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [X] I'm merging against the `development` branch.
* [X] I have squashed my commits into a single commit.
