### PR TITLE
WIP [base-node] Exit if unable to validate RandomX headers due to memory issues 

### DIFF
--- a/base_layer/core/src/base_node/state_machine_service/states/header_sync.rs
+++ b/base_layer/core/src/base_node/state_machine_service/states/header_sync.rs
@@ -102,6 +102,11 @@ impl HeaderSync {
                 self.is_synced = true;
                 StateEvent::NetworkSilence
             },
+            Err(BlockHeaderSyncError::RandomXError(err)) => {
+                let msg = format!("A fatal RandomX error has occurred: {}", err);
+                error!(target: LOG_TARGET, "{}", msg);
+                StateEvent::FatalError(msg)
+            },
             Err(err) => {
                 debug!(target: LOG_TARGET, "Header sync failed: {}", err);
                 StateEvent::HeaderSyncFailed

--- a/base_layer/core/src/base_node/sync/header_sync/error.rs
+++ b/base_layer/core/src/base_node/sync/header_sync/error.rs
@@ -21,6 +21,7 @@
 //  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 use crate::{chain_storage::ChainStorageError, validation::ValidationError};
+use randomx_rs::RandomXError;
 use tari_comms::{
     connectivity::ConnectivityError,
     peer_manager::NodeId,
@@ -63,4 +64,6 @@ pub enum BlockHeaderSyncError {
     InvalidProtocolResponse(String),
     #[error("Headers did not form a chain. Expected {actual} to equal the previous hash {expected}")]
     ChainLinkBroken { actual: String, expected: String },
+    #[error("RandomX Error: {0}")]
+    RandomXError(#[from] RandomXError),
 }


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
- attempting to fallback to default flags for randomx dataset and vm creation
- return errors on randomx creation failures 
- don't ban sync peers on randomx creation error since it's a local issue 
- base node state machine shuts down
- improved logging for randomx creation and errors 
- WIP get whole base node to shut down 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
When attempting to run the base node and sync headers with less than `2080MiB` of RAM, creation of the RandomX dataset fails and it's not possible to validate the block headers. Node is then stuck in a sync loop. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Running base node in a VM with 1GB RAM 

Sample Vagrantfile 

```ruby
Vagrant.configure("2") do |config|
  config.vm.box = "ubuntu/focal64"

  # Share an additional folder to the guest VM. The first argument is
  # the path on the host to the actual folder. The second argument is
  # the path on the guest to mount the folder. And the optional third
  # argument is a set of non-required options.
  # config.vm.synced_folder "../data", "/vagrant_data"
  config.vm.synced_folder ".", "/home/vagrant/base_node", :mount_options => ["dmode=777", "fmode=777"]

  config.vm.provider "virtualbox" do |vb|
    vb.cpus = 2
    vb.memory = "1024"
  end
end

```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch.
* [x] I have squashed my commits into a single commit.
