### PR TITLE
feat: add support for `/dns` multiaddrs to dns resolver

### DIFF
--- a/comms/Cargo.toml
+++ b/comms/Cargo.toml
@@ -14,6 +14,7 @@ tari_crypto = "0.11.1"
 tari_storage = { version = "^0.9", path = "../infrastructure/storage" }
 tari_shutdown = { version="^0.9",  path = "../infrastructure/shutdown" }
 
+async-trait = "0.1.36"
 bitflags = "1.0.4"
 blake2 = "0.9.0"
 bytes = { version = "0.5.x", features=["serde"] }
@@ -42,7 +43,6 @@ tower= "0.3.1"
 yamux = "=0.4.7"
 
 # RPC dependencies
-async-trait = {version="0.1.36", optional=true}
 tower-make = {version="0.3.0", optional=true}
 anyhow = "1.0.32"
 
@@ -59,4 +59,4 @@ tari_common = { version = "^0.9", path="../common", features = ["build"]}
 
 [features]
 avx2 = ["tari_crypto/avx2"]
-rpc = ["async-trait", "tower-make"]
+rpc = ["tower-make"]

--- a/comms/src/socks/client.rs
+++ b/comms/src/socks/client.rs
@@ -394,7 +394,7 @@ where TSocket: AsyncRead + AsyncWrite + Unpin
                 self.len = 7 + len;
             },
             // Special case for Tor resolve
-            (Protocol::Dns4(domain), None) => {
+            (Protocol::Dns4(domain), None) | (Protocol::Dns(domain), None) => {
                 self.buf[3] = 0x03;
                 let domain = domain.as_bytes();
                 let len = domain.len();

--- a/comms/src/transports/dns/common.rs
+++ b/comms/src/transports/dns/common.rs
@@ -26,7 +26,7 @@ use std::net::SocketAddr;
 
 pub fn is_dns4_addr(addr: &Multiaddr) -> bool {
     let proto = addr.iter().next();
-    matches!(proto, Some(Protocol::Dns4(_)))
+    matches!(proto, Some(Protocol::Dns4(_))) || matches!(proto, Some(Protocol::Dns(_)))
 }
 
 pub fn convert_tcpip_multiaddr_to_socketaddr(addr: &Multiaddr) -> Result<SocketAddr, DnsResolverError> {

--- a/comms/src/transports/dns/system.rs
+++ b/comms/src/transports/dns/system.rs
@@ -46,7 +46,9 @@ impl DnsResolver for SystemDnsResolver {
         };
 
         match protos {
-            (Protocol::Dns4(domain), Protocol::Tcp(port)) => dns_lookup(format!("{}:{}", domain, port)).boxed(),
+            (Protocol::Dns(domain), Protocol::Tcp(port)) | (Protocol::Dns4(domain), Protocol::Tcp(port)) => {
+                dns_lookup(format!("{}:{}", domain, port)).boxed()
+            },
             (Protocol::Ip4(host), Protocol::Tcp(port)) => boxed_ready(Ok((host, port).into())),
             (Protocol::Ip6(host), Protocol::Tcp(port)) => boxed_ready(Ok((host, port).into())),
             _ => boxed_ready(Err(DnsResolverError::UnsupportedAddress(addr))),

--- a/comms/src/transports/dns/tor.rs
+++ b/comms/src/transports/dns/tor.rs
@@ -101,5 +101,11 @@ mod test {
             .await
             .unwrap();
         assert_eq!(addr.port(), 443);
+
+        let addr = resolver
+            .resolve("/dns/tari.com/tcp/443".parse().unwrap())
+            .await
+            .unwrap();
+        assert_eq!(addr.port(), 443);
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
- `Protocol::Dns` variant was missing from the system and tor DNS resolvers
- This allows one to use `/dns` multiaddrs
- not related: async-trait should not be optional since #3056

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Users may miss the `4` in `/dns4` when configuring tari applications. `/dns` is a valid multiaddr and should be supported. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested "manually" using `comms::transports::dns::tor::test::resolve`

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch.
* [x] I have squashed my commits into a single commit.
