### PR TITLE
chore: upgrade yamux v0.9.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -962,7 +962,7 @@ dependencies = [
  "lazy_static 1.4.0",
  "libc",
  "mio 0.7.13",
- "parking_lot",
+ "parking_lot 0.10.2",
  "signal-hook",
  "winapi 0.3.9",
 ]
@@ -1956,6 +1956,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "instant"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bee0328b1209d157ef001c94dd85b4f8f64139adb0eac2659f4b08382b2f474d"
+dependencies = [
+ "cfg-if 1.0.0",
+]
+
+[[package]]
 name = "iovec"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2172,6 +2181,15 @@ name = "lock_api"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4da24a77a3d8a6d4862d95f72e6fdb9c09a643ecdb402d754004a557f2bec75"
+dependencies = [
+ "scopeguard",
+]
+
+[[package]]
+name = "lock_api"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0382880606dff6d15c9476c416d18690b72742aa7b605bb6dd6ec9030fbf07eb"
 dependencies = [
  "scopeguard",
 ]
@@ -2795,8 +2813,19 @@ version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3a704eb390aafdc107b0e392f56a82b668e3a71366993b5340f5833fd62505e"
 dependencies = [
- "lock_api",
- "parking_lot_core",
+ "lock_api 0.3.4",
+ "parking_lot_core 0.7.2",
+]
+
+[[package]]
+name = "parking_lot"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d7744ac029df22dca6284efe4e898991d28e3085c706c972bcd7da4a27a15eb"
+dependencies = [
+ "instant",
+ "lock_api 0.4.4",
+ "parking_lot_core 0.8.3",
 ]
 
 [[package]]
@@ -2809,6 +2838,20 @@ dependencies = [
  "cloudabi",
  "libc",
  "redox_syscall 0.1.57",
+ "smallvec",
+ "winapi 0.3.9",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa7a782938e745763fe6907fc6ba86946d72f49fe7e21de074e08128a99fb018"
+dependencies = [
+ "cfg-if 1.0.0",
+ "instant",
+ "libc",
+ "redox_syscall 0.2.9",
  "smallvec",
  "winapi 0.3.9",
 ]
@@ -5856,15 +5899,15 @@ dependencies = [
 
 [[package]]
 name = "yamux"
-version = "0.4.7"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd37e58a1256a0b328ce9c67d8b62ecdd02f4803ba443df478835cb1a41a637c"
+checksum = "e7d9028f208dd5e63c614be69f115c1b53cacc1111437d4c765185856666c107"
 dependencies = [
  "futures 0.3.15",
  "log 0.4.14",
  "nohash-hasher",
- "parking_lot",
- "rand 0.7.3",
+ "parking_lot 0.11.1",
+ "rand 0.8.4",
  "static_assertions",
 ]
 

--- a/comms/Cargo.toml
+++ b/comms/Cargo.toml
@@ -39,7 +39,7 @@ thiserror = "1.0.20"
 tokio = {version="~0.2.19", features=["blocking", "time", "tcp", "dns", "sync", "stream", "signal"]}
 tokio-util = {version="0.2.0", features=["codec"]}
 tower= "0.3.1"
-yamux = "=0.4.7"
+yamux = "=0.9.0"
 
 # RPC dependencies
 async-trait = {version="0.1.36", optional=true}

--- a/comms/src/multiplexing/yamux.rs
+++ b/comms/src/multiplexing/yamux.rs
@@ -51,8 +51,8 @@ pub struct Yamux {
     substream_counter: SubstreamCounter,
 }
 
-const MAX_BUFFER_SIZE: u32 = 8 * 1024 * 1024; // 8MB
-const RECEIVE_WINDOW: u32 = 4 * 1024 * 1024; // 4MB
+const MAX_BUFFER_SIZE: u32 = 8 * 1024 * 1024; // 8MiB
+const RECEIVE_WINDOW: u32 = 5 * 1024 * 1024; // 5MiB
 
 impl Yamux {
     /// Upgrade the underlying socket to use yamux


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Upgrade `yamux` library used for TCP stream muxing in comms to 0.9.0.
This upgrade contains a number of [changes and fixes](https://github.com/libp2p/rust-yamux/blob/develop/CHANGELOG.md) that should be incorporated.

Increased the recieve window size to be larger than the maximum RPC
message size. Anecdotally, since RPC messages are allowed to be 4Mib
which happens to be the size of the yamux window, large messages will
exhaust the entire window which is not optimal. The deadlock case doesn't
make sense because the RPC protocol never writes at the same time (strictly
alternating between read/write).

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Include yamux bug fixes 
The console wallet does not always maintain connections to the base node over long periods, this
could conceivably fix the issue.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Existing tests pass. Tested on base node archival sync, and previous version wallet which had no trouble connecting 
to the network or each other.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch.
* [x] I have squashed my commits into a single commit.
