### PR TITLE
Add support for choosing Termion backend in console_wallet

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2689,6 +2689,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "numtoa"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8f8bdf33df195859076e54ab11ee78a1b208382d3a26ec40d142ffc1ecc49ef"
+
+[[package]]
 name = "object"
 version = "0.25.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3374,6 +3380,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ab49abadf3f9e1c4bc499e8845e152ad87d2ad2d30371841171169e9d75feee"
 dependencies = [
  "bitflags 1.2.1",
+]
+
+[[package]]
+name = "redox_termios"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8440d8acb4fd3d277125b4bd01a6f38aee8d814b3b5fc09b3f2b825d37d3fe8f"
+dependencies = [
+ "redox_syscall 0.2.9",
 ]
 
 [[package]]
@@ -4423,6 +4438,7 @@ dependencies = [
  "tari_p2p",
  "tari_shutdown",
  "tari_wallet",
+ "termion",
  "thiserror",
  "tokio",
  "tonic",
@@ -4818,6 +4834,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dfed899f0eb03f32ee8c6a0aabdb8a7949659e3466561fc0adf54e26d88c5f4"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "termion"
+version = "1.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "077185e2eac69c3f8379a4298e1e07cd36beb962290d4a51199acf0fdc10607e"
+dependencies = [
+ "libc",
+ "numtoa",
+ "redox_syscall 0.2.9",
+ "redox_termios",
 ]
 
 [[package]]
@@ -5432,6 +5460,7 @@ dependencies = [
  "bitflags 1.2.1",
  "cassowary",
  "crossterm",
+ "termion",
  "unicode-segmentation",
  "unicode-width",
 ]

--- a/applications/tari_console_wallet/Cargo.toml
+++ b/applications/tari_console_wallet/Cargo.toml
@@ -30,9 +30,11 @@ rpassword = "5.0"
 rustyline = "6.0"
 strum = "^0.19"
 strum_macros = "^0.19"
+termion = "1.5.6"
 tokio = { version="0.2.10", features = ["signal"] }
 thiserror = "1.0.20"
 tonic = "0.2"
+
 
 [dependencies.tari_core]
 path = "../../base_layer/core"
@@ -43,4 +45,4 @@ features = ["transactions", "mempool_proto", "base_node_proto"]
 [dependencies.tui]
 version = "^0.12"
 default-features = false
-features = ["crossterm"]
+features = ["crossterm", "termion"]

--- a/applications/tari_console_wallet/src/main.rs
+++ b/applications/tari_console_wallet/src/main.rs
@@ -121,7 +121,7 @@ fn main_inner() -> Result<(), ExitCodes> {
     let base_node_config = runtime.block_on(get_base_node_peer_config(&global_config, &mut wallet))?;
     let base_node_selected = base_node_config.get_base_node_peer()?;
 
-    let wallet_mode = wallet_mode(&bootstrap, boot_mode);
+    let (wallet_mode, tui_backend) = wallet_mode(&bootstrap, boot_mode);
 
     // start wallet
     runtime.block_on(start_wallet(&mut wallet, &base_node_selected, &wallet_mode))?;
@@ -140,6 +140,7 @@ fn main_inner() -> Result<(), ExitCodes> {
         handle,
         notify_script,
         wallet_mode: wallet_mode.clone(),
+        tui_backend: tui_backend.clone(),
     };
     let result = match wallet_mode {
         WalletMode::Tui => tui_mode(config, wallet.clone()),

--- a/applications/tari_console_wallet/src/ui/mod.rs
+++ b/applications/tari_console_wallet/src/ui/mod.rs
@@ -20,9 +20,36 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use crate::utils::crossterm_events::CrosstermEvents;
-use log::error;
+use crate::{
+    notifier::Notifier,
+    utils::{
+        crossterm_events::CrosstermEvents,
+        events::{Event, EventStream},
+        termion_events::TermionEvents,
+    },
+    wallet_modes::{PeerConfig, TuiBackend},
+};
+use crossterm::{
+    event::{KeyCode, KeyModifiers},
+    execute,
+    terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
+};
+use log::{error, trace};
+use std::io::{stdout, Stdout, Write};
 use tari_app_utilities::utilities::ExitCodes;
+use tari_common::{configuration::Network, GlobalConfig};
+use tari_comms::peer_manager::Peer;
+use tari_wallet::WalletSqlite;
+use termion::{
+    event::Key,
+    raw::{IntoRawMode, RawTerminal},
+    screen::AlternateScreen,
+};
+use tokio::runtime::Handle;
+use tui::{
+    backend::{CrosstermBackend, TermionBackend},
+    Terminal,
+};
 
 mod app;
 mod components;
@@ -37,36 +64,75 @@ pub use app::*;
 pub use ui_contact::*;
 pub use ui_error::*;
 
-use crate::utils::events::{Event, EventStream};
-use crossterm::{
-    event::{KeyCode, KeyModifiers},
-    execute,
-    terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
-};
-use log::*;
-use std::io::{stdout, Stdout, Write};
-use tokio::runtime::Handle;
-use tui::{backend::CrosstermBackend, Terminal};
-
 pub const MAX_WIDTH: u16 = 133;
 
-pub fn run(app: App<CrosstermBackend<Stdout>>) -> Result<(), ExitCodes> {
-    let mut app = app;
-    Handle::current()
-        .block_on(async {
-            trace!(target: LOG_TARGET, "Refreshing transaction state");
-            app.app_state.refresh_transaction_state().await?;
-            trace!(target: LOG_TARGET, "Refreshing contacts state");
-            app.app_state.refresh_contacts_state().await?;
-            trace!(target: LOG_TARGET, "Refreshing connected peers state");
-            app.app_state.refresh_connected_peers_state().await?;
-            trace!(target: LOG_TARGET, "Starting app state event monitor");
-            app.app_state.start_event_monitor(app.notifier.clone()).await;
-            Result::<_, UiError>::Ok(())
-        })
-        .map_err(|e| ExitCodes::WalletError(e.to_string()))?;
-    crossterm_loop(app)
+pub fn run(
+    title: String,
+    wallet: WalletSqlite,
+    network: Network,
+    base_node_selected: Peer,
+    base_node_config: PeerConfig,
+    node_config: GlobalConfig,
+    notifier: Notifier,
+    tui_backend: TuiBackend,
+) -> Result<(), ExitCodes> {
+    match tui_backend {
+        TuiBackend::Termion => {
+            let mut app = App::<TermionBackend<AlternateScreen<RawTerminal<Stdout>>>>::new(
+                title,
+                wallet,
+                network,
+                base_node_selected,
+                base_node_config,
+                node_config,
+                notifier,
+            );
+            Handle::current()
+                .block_on(async {
+                    trace!(target: LOG_TARGET, "Refreshing transaction state");
+                    app.app_state.refresh_transaction_state().await?;
+                    trace!(target: LOG_TARGET, "Refreshing contacts state");
+                    app.app_state.refresh_contacts_state().await?;
+                    trace!(target: LOG_TARGET, "Refreshing connected peers state");
+                    app.app_state.refresh_connected_peers_state().await?;
+                    trace!(target: LOG_TARGET, "Starting app state event monitor");
+                    app.app_state.start_event_monitor(app.notifier.clone()).await;
+                    Result::<_, UiError>::Ok(())
+                })
+                .map_err(|e| ExitCodes::WalletError(e.to_string()))?;
+            termion_loop(app)
+        },
+        TuiBackend::Crossterm => {
+            let mut app = App::<CrosstermBackend<Stdout>>::new(
+                title,
+                wallet,
+                network,
+                base_node_selected,
+                base_node_config,
+                node_config,
+                notifier,
+            );
+            // Can't DRY this up as the Backend generic clashes with the Crossterm macro's used below
+            Handle::current()
+                .block_on(async {
+                    trace!(target: LOG_TARGET, "Refreshing transaction state");
+                    app.app_state.refresh_transaction_state().await?;
+                    trace!(target: LOG_TARGET, "Refreshing contacts state");
+                    app.app_state.refresh_contacts_state().await?;
+                    trace!(target: LOG_TARGET, "Refreshing connected peers state");
+                    app.app_state.refresh_connected_peers_state().await?;
+                    trace!(target: LOG_TARGET, "Starting app state event monitor");
+                    app.app_state.start_event_monitor(app.notifier.clone()).await;
+                    Result::<_, UiError>::Ok(())
+                })
+                .map_err(|e| ExitCodes::WalletError(e.to_string()))?;
+            crossterm_loop(app)
+        },
+    }
 }
+
+// fn refresh_app_state<B: Backend>(app: &mut App<B>) -> Result<(), ExitCodes> {}
+
 /// This is the main loop of the application UI using Crossterm based events
 fn crossterm_loop(mut app: App<CrosstermBackend<Stdout>>) -> Result<(), ExitCodes> {
     let events = CrosstermEvents::new();
@@ -141,6 +207,55 @@ fn crossterm_loop(mut app: App<CrosstermBackend<Stdout>>) -> Result<(), ExitCode
         error!(target: LOG_TARGET, "Error showing cursor: {}", e);
         ExitCodes::InterfaceError
     })?;
+
+    Ok(())
+}
+
+/// This is the main loop of the application UI using Termion based events
+fn termion_loop(mut app: App<TermionBackend<AlternateScreen<RawTerminal<Stdout>>>>) -> Result<(), ExitCodes> {
+    let events = TermionEvents::new();
+
+    let stdout = stdout().into_raw_mode().map_err(|e| {
+        error!(target: LOG_TARGET, "Error setting terminal to Raw mode. {}", e);
+        ExitCodes::InterfaceError
+    })?;
+
+    let stdout = AlternateScreen::from(stdout);
+    let backend = TermionBackend::new(stdout);
+    let mut terminal = Terminal::new(backend).map_err(|e| {
+        error!(target: LOG_TARGET, "Error creating Terminal context. {}", e);
+        ExitCodes::InterfaceError
+    })?;
+
+    loop {
+        terminal.draw(|f| app.draw(f)).map_err(|e| {
+            error!(target: LOG_TARGET, "Error drawing interface. {}", e);
+            ExitCodes::InterfaceError
+        })?;
+        match events.next().map_err(|e| {
+            error!(target: LOG_TARGET, "Error reading input event: {}", e);
+            ExitCodes::InterfaceError
+        })? {
+            Event::Input(event) => match event {
+                Key::Ctrl(c) => app.on_control_key(c),
+                Key::Char(c) => app.on_key(c),
+                Key::Left => app.on_left(),
+                Key::Up => app.on_up(),
+                Key::Right => app.on_right(),
+                Key::Down => app.on_down(),
+                Key::Esc => app.on_esc(),
+                Key::Backspace => app.on_backspace(),
+                Key::F(10) => app.on_f10(),
+                _ => {},
+            },
+            Event::Tick => {
+                app.on_tick();
+            },
+        }
+        if app.should_quit {
+            break;
+        }
+    }
 
     Ok(())
 }

--- a/applications/tari_console_wallet/src/utils/mod.rs
+++ b/applications/tari_console_wallet/src/utils/mod.rs
@@ -24,5 +24,4 @@ pub mod crossterm_events;
 pub mod db;
 pub mod events;
 pub mod formatting;
-
-// pub mod termion_events;
+pub mod termion_events;

--- a/common/src/configuration/bootstrap.rs
+++ b/common/src/configuration/bootstrap.rs
@@ -136,6 +136,9 @@ pub struct ConfigBootstrap {
     /// Automatically exit wallet command/script mode when done
     #[structopt(long, alias = "auto-exit")]
     pub command_mode_auto_exit: bool,
+    /// Tui backend selection
+    #[structopt(long, alias = "termion")]
+    pub console_termion: bool,
     /// Mining node options
     #[structopt(long, alias = "mine-until-height")]
     pub mine_until_height: Option<u64>,
@@ -175,6 +178,7 @@ impl Default for ConfigBootstrap {
             seed_words_file_name: None,
             wallet_notify: None,
             command_mode_auto_exit: false,
+            console_termion: false,
             mine_until_height: None,
             miner_max_blocks: None,
             miner_min_diff: None,


### PR DESCRIPTION
## Description
This PR adds support for using the Termion terminal backend in the console_wallet. This is chosen via a command line switch `console_wallet —termion`. If the switch is not present the default cross term backend will be used.

## Motivation and Context
@CjS77 was having some trouble with the tui in a Docker instance so this is to provide an alternative backend that might work better in Docker. Untested in Docker at this point.

## How Has This Been Tested?
manually

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch.
* [x] I have squashed my commits into a single commit.
