### PR TITLE
test: fix prune mode test

### DIFF
--- a/integration_tests/features/Sync.feature
+++ b/integration_tests/features/Sync.feature
@@ -25,6 +25,18 @@ Feature: Block Sync
     # All nodes should sync to tip
     Then all nodes are at height 20
 
+  @critical 
+  Scenario: Pruned mode simple sync
+    Given I have 1 seed nodes
+    Given I have a SHA3 miner NODE1 connected to all seed nodes
+    When I mine a block on NODE1 with coinbase CB1
+    And I mine 4 blocks on NODE1
+    When I spend outputs CB1 via NODE1
+    Given mining node NODE1 mines 15 blocks
+    Given I have a pruned node PNODE1 connected to node NODE1 with pruning horizon set to 5
+    Then all nodes are at height 20
+
+@critical
   Scenario: When a new node joins the network, it should receive all peers
     Given I have 10 seed nodes
     And I have a base node NODE1 connected to all seed nodes

--- a/integration_tests/features/support/steps.js
+++ b/integration_tests/features/support/steps.js
@@ -217,7 +217,7 @@ Given(
   /I have a pruned node (.*) connected to node (.*) with pruning horizon set to (.*)/,
   { timeout: 20 * 1000 },
   async function (name, node, horizon) {
-    const miner = this.createNode(name, { horizon });
+    const miner = this.createNode(name, { pruningHorizon: horizon });
     miner.setPeerSeeds([this.nodes[node].peerAddress()]);
     await miner.startNew();
     this.addNode(name, miner);

--- a/integration_tests/features/support/world.js
+++ b/integration_tests/features/support/world.js
@@ -7,7 +7,6 @@ const MiningNodeProcess = require("../../helpers/miningNodeProcess");
 const glob = require("glob");
 const fs = require("fs");
 const archiver = require("archiver");
-
 class CustomWorld {
   constructor({ attach, parameters }) {
     // this.variable = 0;
@@ -281,37 +280,21 @@ BeforeAll({ timeout: 1200000 }, async function () {
 
 After(async function (testCase) {
   console.log("Stopping nodes");
-  for (const key in this.seeds) {
-    if (testCase.result.status === "failed") {
-      await attachLogs(`${this.seeds[key].baseDir}`, this);
-    }
-    await this.stopNode(key);
-  }
-  for (const key in this.nodes) {
-    if (testCase.result.status === "failed") {
-      await attachLogs(`${this.nodes[key].baseDir}`, this);
-    }
-    await this.stopNode(key);
-  }
-  for (const key in this.proxies) {
-    if (testCase.result.status === "failed") {
-      await attachLogs(`${this.proxies[key].baseDir}`, this);
-    }
-    await this.proxies[key].stop();
-  }
-  for (const key in this.wallets) {
-    if (testCase.result.status === "failed") {
-      await attachLogs(`${this.wallets[key].baseDir}`, this);
-    }
-    await this.wallets[key].stop();
-  }
-  for (const key in this.miners) {
-    if (testCase.result.status === "failed") {
-      await attachLogs(`${this.miners[key].baseDir}`, this);
-    }
-    await this.miners[key].stop();
-  }
+  await stopAndHandleLogs(this.seeds, testCase, this);
+  await stopAndHandleLogs(this.nodes, testCase, this);
+  await stopAndHandleLogs(this.proxies, testCase, this);
+  await stopAndHandleLogs(this.wallets, testCase, this);
+  await stopAndHandleLogs(this.miners, testCase, this);
 });
+
+async function stopAndHandleLogs(objects, testCase, context) {
+  for (const key in objects) {
+    if (testCase.result.status === "failed") {
+      await attachLogs(`${objects[key].baseDir}`, context);
+    }
+    await objects[key].stop();
+  }
+}
 
 function attachLogs(path, context) {
   return new Promise((outerRes) => {

--- a/integration_tests/helpers/config.js
+++ b/integration_tests/helpers/config.js
@@ -7,6 +7,7 @@ function mapEnvs(options) {
   if (options.pruningHorizon) {
     // In the config toml file: `base_node.network.pruning_horizon` with `network = localnet`
     res.TARI_BASE_NODE__LOCALNET__PRUNING_HORIZON = options.pruningHorizon;
+    res.TARI_BASE_NODE__LOCALNET__PRUNED_MODE_CLEANUP_INTERVAL = 1;
   }
   if ("num_confirmations" in options) {
     res.TARI_WALLET__TRANSACTION_NUM_CONFIRMATIONS_REQUIRED =


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Currently, all prune mode cucumber tests do not test prune nodes, but rather runs as archival nodes. This fixes the prune mode test to correctly run with prune mode nodes.
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch.
* [x] I have squashed my commits into a single commit.
