### PR TITLE
fix: console wallet now recognises wallet.network comms settings

### DIFF
--- a/applications/tari_app_utilities/src/initialization.rs
+++ b/applications/tari_app_utilities/src/initialization.rs
@@ -24,8 +24,8 @@ pub fn init_configuration(
     log::info!(target: LOG_TARGET, "{} ({})", application_type, consts::APP_VERSION);
 
     // Populate the configuration struct
-    let mut global_config =
-        GlobalConfig::convert_from(cfg.clone()).map_err(|err| ExitCodes::ConfigError(err.to_string()))?;
+    let mut global_config = GlobalConfig::convert_from(application_type, cfg.clone())
+        .map_err(|err| ExitCodes::ConfigError(err.to_string()))?;
     check_file_paths(&mut global_config, &bootstrap);
     Ok((bootstrap, global_config, cfg))
 }

--- a/applications/tari_base_node/src/bootstrap.rs
+++ b/applications/tari_base_node/src/bootstrap.rs
@@ -23,19 +23,9 @@
 use anyhow::anyhow;
 use log::*;
 use std::{cmp, fs, str::FromStr, sync::Arc, time::Duration};
-use tari_app_utilities::{consts, identity_management, utilities};
-use tari_common::{configuration::bootstrap::ApplicationType, CommsTransport, GlobalConfig, TorControlAuthentication};
-use tari_comms::{
-    peer_manager::Peer,
-    protocol::rpc::RpcServer,
-    socks,
-    tor,
-    tor::TorIdentity,
-    transports::SocksConfig,
-    utils::multiaddr::multiaddr_to_socketaddr,
-    NodeIdentity,
-    UnspawnedCommsNode,
-};
+use tari_app_utilities::{consts, identity_management, utilities::create_transport_type};
+use tari_common::{configuration::bootstrap::ApplicationType, GlobalConfig};
+use tari_comms::{peer_manager::Peer, protocol::rpc::RpcServer, NodeIdentity, UnspawnedCommsNode};
 use tari_comms_dht::{DbConnectionUrl, Dht, DhtConfig};
 use tari_core::{
     base_node,
@@ -66,7 +56,6 @@ use tari_p2p::{
     initialization::{CommsConfig, P2pInitializer},
     peer_seeds::SeedPeer,
     services::liveness::{LivenessConfig, LivenessInitializer},
-    transport::{TorConfig, TransportType},
 };
 use tari_service_framework::{ServiceHandles, StackBuilder};
 use tari_shutdown::ShutdownSignal;
@@ -244,7 +233,7 @@ where B: BlockchainBackend + 'static
         CommsConfig {
             network: self.config.network,
             node_identity: self.node_identity.clone(),
-            transport_type: self.create_transport_type(),
+            transport_type: create_transport_type(self.config),
             datastore_path: self.config.peer_db_path.clone(),
             peer_database_name: "peers".to_string(),
             max_concurrent_inbound_tasks: 100,
@@ -272,87 +261,6 @@ where B: BlockchainBackend + 'static
             dns_seeds: self.config.dns_seeds.clone(),
             dns_seeds_name_server: self.config.dns_seeds_name_server,
             dns_seeds_use_dnssec: self.config.dns_seeds_use_dnssec,
-        }
-    }
-
-    /// Creates a transport type from the given configuration
-    ///
-    /// ## Paramters
-    /// `config` - The reference to the configuration in which to set up the comms stack, see [GlobalConfig]
-    ///
-    /// ##Returns
-    /// TransportType based on the configuration
-    fn create_transport_type(&self) -> TransportType {
-        let config = self.config;
-        debug!(target: LOG_TARGET, "Transport is set to '{:?}'", config.comms_transport);
-
-        match config.comms_transport.clone() {
-            CommsTransport::Tcp {
-                listener_address,
-                tor_socks_address,
-                tor_socks_auth,
-            } => TransportType::Tcp {
-                listener_address,
-                tor_socks_config: tor_socks_address.map(|proxy_address| SocksConfig {
-                    proxy_address,
-                    authentication: tor_socks_auth
-                        .map(utilities::convert_socks_authentication)
-                        .unwrap_or_default(),
-                }),
-            },
-            CommsTransport::TorHiddenService {
-                control_server_address,
-                socks_address_override,
-                forward_address,
-                auth,
-                onion_port,
-            } => {
-                let identity = Some(&config.base_node_tor_identity_file)
-                    .filter(|p| p.exists())
-                    .and_then(|p| {
-                        // If this fails, we can just use another address
-                        identity_management::load_from_json::<_, TorIdentity>(p).ok()
-                    });
-                info!(
-                    target: LOG_TARGET,
-                    "Tor identity at path '{}' {:?}",
-                    config.base_node_tor_identity_file.to_string_lossy(),
-                    identity
-                        .as_ref()
-                        .map(|ident| format!("loaded for address '{}.onion'", ident.service_id))
-                        .or_else(|| Some("not found".to_string()))
-                        .unwrap()
-                );
-
-                let forward_addr = multiaddr_to_socketaddr(&forward_address).expect("Invalid tor forward address");
-                TransportType::Tor(TorConfig {
-                    control_server_addr: control_server_address,
-                    control_server_auth: {
-                        match auth {
-                            TorControlAuthentication::None => tor::Authentication::None,
-                            TorControlAuthentication::Password(password) => {
-                                tor::Authentication::HashedPassword(password)
-                            },
-                        }
-                    },
-                    identity: identity.map(Box::new),
-                    port_mapping: (onion_port, forward_addr).into(),
-                    // TODO: make configurable
-                    socks_address_override,
-                    socks_auth: socks::Authentication::None,
-                })
-            },
-            CommsTransport::Socks5 {
-                proxy_address,
-                listener_address,
-                auth,
-            } => TransportType::Socks {
-                socks_config: SocksConfig {
-                    proxy_address,
-                    authentication: utilities::convert_socks_authentication(auth),
-                },
-                listener_address,
-            },
         }
     }
 }

--- a/applications/tari_console_wallet/src/init/mod.rs
+++ b/applications/tari_console_wallet/src/init/mod.rs
@@ -28,7 +28,7 @@ use log::*;
 use rpassword::prompt_password_stdout;
 use rustyline::Editor;
 use std::{fs, path::PathBuf, str::FromStr, sync::Arc};
-use tari_app_utilities::utilities::{setup_wallet_transport_type, ExitCodes};
+use tari_app_utilities::utilities::{create_transport_type, ExitCodes};
 use tari_common::{ConfigBootstrap, GlobalConfig};
 use tari_comms::{
     peer_manager::{Peer, PeerFeatures},
@@ -306,7 +306,7 @@ pub async fn init_wallet(
         node_features,
     ));
 
-    let transport_type = setup_wallet_transport_type(&config);
+    let transport_type = create_transport_type(&config);
     let transport_type = match transport_type {
         Tor(mut tor_config) => {
             tor_config.identity = wallet_db.get_tor_id().await?.map(Box::new);

--- a/common/config/presets/tari_config_example.toml
+++ b/common/config/presets/tari_config_example.toml
@@ -17,6 +17,11 @@
 # default, or the location specified in the TARI_LOGFILE environment variable.
 
 [common]
+# Select the network to connect to. Valid options are:
+#   mainnet - the "real" Tari network (default)
+#   weatherwax - the Tari test net
+network = "weatherwax"
+
 # Tari is a 100% peer-to-peer network, so there are no servers to hold messages for you while you're offline.
 # Instead, we rely on our peers to hold messages for us while we're offline. This settings sets maximum size of the
 # message cache that for holding our peers' messages, in MB.
@@ -80,6 +85,8 @@
 # If you are not running a wallet from this configuration, you can simply leave everything in this section commented out
 
 [wallet]
+# Override common.network for wallet
+# network = "weatherwax"
 
 # The relative folder to store your local key data and transaction history. DO NOT EVER DELETE THIS FILE unless you
 #  a) have backed up your seed phrase and
@@ -160,6 +167,43 @@ scan_for_utxo_interval=60
 # Required for control_auth_type = "password"
 #control_auth_password = "super-secure-password"
 
+# Wallet configuration options for testnet
+[wallet.weatherwax]
+# -------------- Transport configuration --------------
+# Use TCP to connect to the Tari network. This transport can only communicate with TCP/IP addresses, so peers with
+# e.g. tor onion addresses will not be contactable.
+#transport = "tcp"
+# The address and port to listen for peer connections over TCP.
+#tcp_listener_address = "/ip4/0.0.0.0/tcp/18188"
+# Configures a tor proxy used to connect to onion addresses. All other traffic uses direct TCP connections.
+# This setting is optional however, if it is not specified, this node will not be able to connect to nodes that
+# only advertise an onion address.
+#tcp_tor_socks_address = "/ip4/127.0.0.1/tcp/36050"
+#tcp_tor_socks_auth = "none"
+
+# Configures the node to run over a tor hidden service using the Tor proxy. This transport recognises ip/tcp,
+# onion v2, onion v3 and dns addresses.
+transport = "tor"
+# Address of the tor control server
+tor_control_address = "/ip4/127.0.0.1/tcp/9051"
+# Authentication to use for the tor control server
+tor_control_auth = "none" # or "password=xxxxxx"
+# The onion port to use.
+#tor_onion_port = 18141
+# The address to which traffic on the node's onion address will be forwarded
+# tor_forward_address = "/ip4/127.0.0.1/tcp/0"
+# Instead of attemping to get the SOCKS5 address from the tor control port, use this one. The default is to
+# use the first address returned by the tor control port (GETINFO /net/listeners/socks).
+#tor_socks_address_override=
+
+# Use a SOCKS5 proxy transport. This transport recognises any addresses supported by the proxy.
+#transport = "socks5"
+# The address of the SOCKS5 proxy
+#socks5_proxy_address = "/ip4/127.0.0.1/tcp/9050"
+# The address to which traffic will be forwarded
+#socks5_listener_address = "/ip4/127.0.0.1/tcp/18188"
+#socks5_auth = "none" # or "username_password=username:xxxxxxx"
+
 ########################################################################################################################
 #                                                                                                                      #
 #                                          Base Node Configuration Options                                             #
@@ -171,14 +215,10 @@ scan_for_utxo_interval=60
 # no-one is cheating you out of your money.
 
 [base_node]
-
-# Select the network to connect to. Valid options are:
-#   mainnet - the "real" Tari network (default)
-#   weatherwax - the Tari test net
-network = "weatherwax"
+# Override common.network for base node
+# network = "weatherwax"
 
 # Configuration options for testnet
-
 [base_node.weatherwax]
 # The type of database backend to use. Currently supported options are "memory" and "lmdb". LMDB is recommnded for
 # almost all use cases.

--- a/common/src/configuration/bootstrap.rs
+++ b/common/src/configuration/bootstrap.rs
@@ -342,12 +342,12 @@ impl ApplicationType {
         }
     }
 
-    pub const fn as_tag_str(&self) -> &'static str {
+    pub const fn as_config_str(&self) -> &'static str {
         use ApplicationType::*;
         match self {
-            BaseNode => "base-node",
-            ConsoleWallet => "console-wallet",
-            MergeMiningProxy => "mm-proxy",
+            BaseNode => "base_node",
+            ConsoleWallet => "wallet",
+            MergeMiningProxy => "mm_proxy",
             MiningNode => "miner",
         }
     }
@@ -359,9 +359,9 @@ impl FromStr for ApplicationType {
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use ApplicationType::*;
         match s {
-            "base-node" => Ok(BaseNode),
-            "console-wallet" => Ok(ConsoleWallet),
-            "mm-proxy" => Ok(MergeMiningProxy),
+            "base-node" | "base_node" => Ok(BaseNode),
+            "console-wallet" | "console_wallet" => Ok(ConsoleWallet),
+            "mm-proxy" | "mm_proxy" => Ok(MergeMiningProxy),
             "miner" => Ok(MiningNode),
             _ => Err(ConfigError::new("Invalid ApplicationType", None)),
         }

--- a/common/src/configuration/global.rs
+++ b/common/src/configuration/global.rs
@@ -22,13 +22,16 @@
 //
 //! # Global configuration of tari base layer system
 
-use crate::{configuration::Network, ConfigurationError};
+use crate::{
+    configuration::{bootstrap::ApplicationType, Network},
+    ConfigurationError,
+};
 use config::{Config, ConfigError, Environment};
 use multiaddr::Multiaddr;
 use std::{
     convert::TryInto,
     fmt,
-    fmt::Formatter,
+    fmt::{Display, Formatter},
     net::SocketAddr,
     num::{NonZeroU16, TryFromIntError},
     path::PathBuf,
@@ -128,24 +131,30 @@ pub struct GlobalConfig {
 }
 
 impl GlobalConfig {
-    pub fn convert_from(mut cfg: Config) -> Result<Self, ConfigurationError> {
+    pub fn convert_from(application: ApplicationType, mut cfg: Config) -> Result<Self, ConfigurationError> {
         // Add in settings from the environment (with a prefix of TARI_NODE)
         // Eg.. `TARI_NODE_DEBUG=1 ./target/app` would set the `debug` key
         let env = Environment::with_prefix("tari").separator("__");
         cfg.merge(env)
             .map_err(|e| ConfigurationError::new("environment variable", &e.to_string()))?;
 
-        let network = cfg
-            .get_str("base_node.network")
-            .map_err(|e| ConfigurationError::new("base_node.network", &e.to_string()))?
-            .parse()?;
+        let network = one_of::<Network>(&cfg, &[
+            &format!("{}.network", application.as_config_str()),
+            "common.network",
+            // TODO: Remove this once some time has passed and folks have upgraded their configs
+            "base_node.network",
+        ])?;
 
-        convert_node_config(network, cfg)
+        convert_node_config(application, network, cfg)
     }
 }
 
-fn convert_node_config(network: Network, cfg: Config) -> Result<GlobalConfig, ConfigurationError> {
-    let net_str = network.to_string().to_lowercase();
+fn convert_node_config(
+    application: ApplicationType,
+    network: Network,
+    cfg: Config,
+) -> Result<GlobalConfig, ConfigurationError> {
+    let net_str = network.as_str();
 
     let key = config_string("base_node", &net_str, "data_dir");
     let data_dir: PathBuf = cfg
@@ -290,7 +299,7 @@ fn convert_node_config(network: Network, cfg: Config) -> Result<GlobalConfig, Co
         .into();
 
     // Transport
-    let comms_transport = network_transport_config(&cfg, &net_str)?;
+    let comms_transport = network_transport_config(&cfg, application, &net_str)?;
 
     let key = config_string("base_node", &net_str, "allow_test_addresses");
     let allow_test_addresses = cfg
@@ -723,7 +732,29 @@ fn optional<T>(result: Result<T, ConfigError>) -> Result<Option<T>, ConfigError>
     }
 }
 
-fn network_transport_config(cfg: &Config, network: &str) -> Result<CommsTransport, ConfigurationError> {
+fn one_of<T>(cfg: &Config, keys: &[&str]) -> Result<T, ConfigError>
+where
+    T: FromStr,
+    T::Err: Display,
+{
+    for k in keys {
+        if let Some(v) = optional(cfg.get_str(k))? {
+            return v
+                .parse()
+                .map_err(|err| ConfigError::Message(format!("Failed to parse {}: {}", k, err)));
+        }
+    }
+    Err(ConfigError::NotFound(format!(
+        "None of the config keys [{}] were found",
+        keys.join(", ")
+    )))
+}
+
+fn network_transport_config(
+    cfg: &Config,
+    application: ApplicationType,
+    network: &str,
+) -> Result<CommsTransport, ConfigurationError> {
     let get_conf_str = |key| {
         cfg.get_str(key)
             .map_err(|err| ConfigurationError::new(key, &err.to_string()))
@@ -736,16 +767,17 @@ fn network_transport_config(cfg: &Config, network: &str) -> Result<CommsTranspor
             .map_err(|err| ConfigurationError::new(key, &err.to_string()))
     };
 
-    let transport_key = config_string("base_node", network, "transport");
+    let app_str = application.as_config_str();
+    let transport_key = config_string(app_str, network, "transport");
     let transport = get_conf_str(&transport_key)?;
 
     match transport.to_lowercase().as_str() {
         "tcp" => {
-            let key = config_string("base_node", network, "tcp_listener_address");
+            let key = config_string(app_str, network, "tcp_listener_address");
             let listener_address = get_conf_multiaddr(&key)?;
-            let key = config_string("base_node", network, "tcp_tor_socks_address");
+            let key = config_string(app_str, network, "tcp_tor_socks_address");
             let tor_socks_address = get_conf_multiaddr(&key).ok();
-            let key = config_string("base_node", network, "tcp_tor_socks_auth");
+            let key = config_string(app_str, network, "tcp_tor_socks_auth");
             let tor_socks_auth = get_conf_str(&key).ok().and_then(|auth_str| auth_str.parse().ok());
 
             Ok(CommsTransport::Tcp {
@@ -755,23 +787,23 @@ fn network_transport_config(cfg: &Config, network: &str) -> Result<CommsTranspor
             })
         },
         "tor" => {
-            let key = config_string("base_node", network, "tor_control_address");
+            let key = config_string(app_str, network, "tor_control_address");
             let control_server_address = get_conf_multiaddr(&key)?;
 
-            let key = config_string("base_node", network, "tor_control_auth");
+            let key = config_string(app_str, network, "tor_control_auth");
             let auth_str = get_conf_str(&key)?;
             let auth = auth_str
                 .parse()
                 .map_err(|err: String| ConfigurationError::new(&key, &err))?;
 
-            let key = config_string("base_node", network, "tor_forward_address");
+            let key = config_string(app_str, network, "tor_forward_address");
             let forward_address = get_conf_multiaddr(&key)?;
-            let key = config_string("base_node", network, "tor_onion_port");
+            let key = config_string(app_str, network, "tor_onion_port");
             let onion_port = cfg
                 .get::<NonZeroU16>(&key)
                 .map_err(|err| ConfigurationError::new(&key, &err.to_string()))?;
 
-            let key = config_string("base_node", network, "tor_socks_address_override");
+            let key = config_string(app_str, network, "tor_socks_address_override");
             let socks_address_override = match get_conf_str(&key).ok() {
                 Some(addr) => Some(
                     addr.parse::<Multiaddr>()
@@ -789,16 +821,16 @@ fn network_transport_config(cfg: &Config, network: &str) -> Result<CommsTranspor
             })
         },
         "socks5" => {
-            let key = config_string("base_node", network, "socks5_proxy_address");
+            let key = config_string(app_str, network, "socks5_proxy_address");
             let proxy_address = get_conf_multiaddr(&key)?;
 
-            let key = config_string("base_node", network, "socks5_auth");
+            let key = config_string(app_str, network, "socks5_auth");
             let auth_str = get_conf_str(&key)?;
             let auth = auth_str
                 .parse()
                 .map_err(|err: String| ConfigurationError::new(&key, &err))?;
 
-            let key = config_string("base_node", network, "socks5_listener_address");
+            let key = config_string(app_str, network, "socks5_listener_address");
             let listener_address = get_conf_multiaddr(&key)?;
 
             Ok(CommsTransport::Socks5 {

--- a/common/src/configuration/network.rs
+++ b/common/src/configuration/network.rs
@@ -43,6 +43,17 @@ impl Network {
     pub fn as_byte(self) -> u8 {
         self as u8
     }
+
+    pub const fn as_str(self) -> &'static str {
+        use Network::*;
+        match self {
+            MainNet => "mainnet",
+            Ridcully => "ridcully",
+            Stibbons => "stibbons",
+            Weatherwax => "weatherwax",
+            LocalNet => "localnet",
+        }
+    }
 }
 
 impl Default for Network {
@@ -72,14 +83,6 @@ impl FromStr for Network {
 
 impl Display for Network {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
-        use Network::*;
-        let msg = match self {
-            MainNet => "mainnet",
-            Ridcully => "ridcully",
-            Stibbons => "stibbons",
-            Weatherwax => "weatherwax",
-            LocalNet => "localnet",
-        };
-        f.write_str(msg)
+        f.write_str(self.as_str())
     }
 }

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -70,7 +70,7 @@
 //! # args.init = true;
 //! args.init_dirs(ApplicationType::BaseNode);
 //! let config = args.load_configuration().unwrap();
-//! let global = GlobalConfig::convert_from(config).unwrap();
+//! let global = GlobalConfig::convert_from(ApplicationType::BaseNode, config).unwrap();
 //! assert_eq!(global.network, Network::Weatherwax);
 //! assert!(global.max_threads.is_none());
 //! # std::fs::remove_dir_all(temp_dir).unwrap();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
- fix: setup comms transport using application name prefix (`base_node`/ `wallet`)
- feat!: default transport is now tor
- feat: network can be configured by one of (in order) `common.network`,
  `{application}.network` and `base_node.network` (for backward-compatibility)
- chore: cleanup transport setup code in base node and common utilities
- chore: update preset config

BREAKING CHANGE: if you relied on default transport configuration (TCP
transport) previously, you will now need to set `transport = "tcp"`

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Some comms configuration on the console wallet was not possible or was configured 
using the base_node key. This makes docker configuration difficult.   

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested by running console wallet and base node. Tested console wallet with tor_forward_address set.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch.
* [x] I have squashed my commits into a single commit.
