### PR TITLE
test: fix prune mode test

### DIFF
--- a/applications/tari_app_grpc/proto/base_node.proto
+++ b/applications/tari_app_grpc/proto/base_node.proto
@@ -241,9 +241,8 @@ message MetaData {
     uint64 height_of_longest_chain = 1;
     // The block hash of the current tip of the longest valid chain, or `None` for an empty chain
     bytes best_block = 2;
-    // The number of blocks back from the tip that this database tracks. A value of 0 indicates that all blocks are
-    // tracked (i.e. the database is in full archival mode).
-    uint64 pruning_horizon = 4;
+    // This is the min height this node can provide complete blocks for. A 0 here means this node is archival and can provide complete blocks for every height.
+    uint64 pruned_height = 6;
     // The current geometric mean of the pow of the chain tip, or `None` if there is no chain
     bytes accumulated_difficulty = 5;
 }

--- a/applications/tari_app_grpc/src/conversions/chain_metadata.rs
+++ b/applications/tari_app_grpc/src/conversions/chain_metadata.rs
@@ -29,7 +29,7 @@ impl From<ChainMetadata> for grpc::MetaData {
         Self {
             height_of_longest_chain: meta.height_of_longest_chain(),
             best_block: meta.best_block().clone(),
-            pruning_horizon: meta.pruning_horizon(),
+            pruned_height: meta.pruned_height(),
             accumulated_difficulty: diff.to_be_bytes().to_vec(),
         }
     }

--- a/base_layer/common_types/src/chain_metadata.rs
+++ b/base_layer/common_types/src/chain_metadata.rs
@@ -47,14 +47,14 @@ impl ChainMetadata {
         height: u64,
         hash: BlockHash,
         pruning_horizon: u64,
-        effective_pruned_height: u64,
+        pruned_height: u64,
         accumulated_difficulty: u128,
     ) -> ChainMetadata {
         ChainMetadata {
             height_of_longest_chain: height,
             best_block: hash,
             pruning_horizon,
-            pruned_height: effective_pruned_height,
+            pruned_height,
             accumulated_difficulty,
         }
     }

--- a/base_layer/core/src/base_node/chain_metadata_service/service.rs
+++ b/base_layer/core/src/base_node/chain_metadata_service/service.rs
@@ -329,8 +329,7 @@ mod test {
         proto::ChainMetadata {
             height_of_longest_chain: Some(1),
             best_block: Some(vec![]),
-            pruning_horizon: 64,
-            effective_pruned_height: 0,
+            pruned_height: 0,
             accumulated_difficulty: diff.to_be_bytes().to_vec(),
         }
     }

--- a/base_layer/core/src/base_node/proto/chain_metadata.proto
+++ b/base_layer/core/src/base_node/proto/chain_metadata.proto
@@ -9,14 +9,11 @@ message ChainMetadata {
     google.protobuf.UInt64Value height_of_longest_chain = 1;
     // The block hash of the current tip of the longest valid chain, or `None` for an empty chain
     google.protobuf.BytesValue best_block = 2;
-    // The number of blocks back from the tip that this database tracks. A value of 0 indicates that all blocks are
-    // tracked (i.e. the database is in full archival mode).
-    uint64 pruning_horizon = 4;
     // The current geometric mean of the pow of the chain tip, or `None` if there is no chain
     bytes accumulated_difficulty = 5;
     // The effective height of the pruning horizon. This indicates from what height
     // a full block can be provided (exclusive).
-    // If `effective_pruned_height` is equal to the `height_of_longest_chain` no blocks can be provided.
-    // Archival nodes wil always have an `effective_pruned_height` of zero.
-    uint64 effective_pruned_height = 6;
+    // If `pruned_height` is equal to the `height_of_longest_chain` no blocks can be provided.
+    // Archival nodes wil always have an `pruned_height` of zero.
+    uint64 pruned_height = 6;
 }

--- a/base_layer/wallet/tests/support/rpc.rs
+++ b/base_layer/wallet/tests/support/rpc.rs
@@ -114,8 +114,7 @@ impl BaseNodeWalletRpcMockState {
                     height_of_longest_chain: Some(std::u64::MAX),
                     best_block: Some(Vec::new()),
                     accumulated_difficulty: Vec::new(),
-                    pruning_horizon: 0,
-                    effective_pruned_height: 0,
+                    pruned_height: 0,
                 }),
                 is_synced: true,
             })),
@@ -537,8 +536,7 @@ mod test {
             height_of_longest_chain: Some(444),
             best_block: Some(Vec::new()),
             accumulated_difficulty: Vec::new(),
-            pruning_horizon: 0,
-            effective_pruned_height: 0,
+            pruned_height: 0,
         };
         service_state.set_tip_info_response(TipInfoResponse {
             metadata: Some(chain_metadata),

--- a/integration_tests/features/Propagation.feature
+++ b/integration_tests/features/Propagation.feature
@@ -91,3 +91,17 @@ Feature: Block Propagation
     Then node MINER is at height 7
     When I wait 20 seconds
     Then all nodes are at height 7
+
+    Scenario: Pruned node should prune outputs
+    Given I have 1 seed nodes
+    And I have a base node SENDER connected to all seed nodes
+    Given I have a pruned node PNODE1 connected to node SENDER with pruning horizon set to 5
+    When I mine a block on SENDER with coinbase CB1
+    When I mine 2 blocks on SENDER
+    When I create a transaction TX1 spending CB1 to UTX1
+    When I submit transaction TX1 to SENDER
+    When I mine 1 blocks on SENDER
+    Then TX1 is in the MINED of all nodes
+    When I mine 17 blocks on SENDER
+    Then all nodes are on the same chain at height 21
+    Then node PNODE1 has a pruned height of 15

--- a/integration_tests/features/Sync.feature
+++ b/integration_tests/features/Sync.feature
@@ -25,6 +25,18 @@ Feature: Block Sync
     # All nodes should sync to tip
     Then all nodes are at height 20
 
+  @critical 
+  Scenario: Pruned mode simple sync
+    Given I have 1 seed nodes
+    Given I have a SHA3 miner NODE1 connected to all seed nodes
+    When I mine a block on NODE1 with coinbase CB1
+    And I mine 4 blocks on NODE1
+    When I spend outputs CB1 via NODE1
+    Given mining node NODE1 mines 15 blocks
+    Given I have a pruned node PNODE1 connected to node NODE1 with pruning horizon set to 5
+    Then all nodes are at height 20
+
+@critical
   Scenario: When a new node joins the network, it should receive all peers
     Given I have 10 seed nodes
     And I have a base node NODE1 connected to all seed nodes

--- a/integration_tests/features/support/steps.js
+++ b/integration_tests/features/support/steps.js
@@ -219,7 +219,7 @@ Given(
   /I have a pruned node (.*) connected to node (.*) with pruning horizon set to (.*)/,
   { timeout: 20 * 1000 },
   async function (name, node, horizon) {
-    const miner = this.createNode(name, { horizon });
+    const miner = this.createNode(name, { pruningHorizon: horizon });
     miner.setPeerSeeds([this.nodes[node].peerAddress()]);
     await miner.startNew();
     this.addNode(name, miner);
@@ -693,6 +693,22 @@ Then(
     const currentHeight = await client.getTipHeight();
     console.log(
       `Node ${name} is at tip: ${currentHeight} (should be`,
+      height,
+      `)`
+    );
+    expect(currentHeight).to.equal(height);
+  }
+);
+
+Then(
+  /node (.*) has a pruned height of (\d+)/,
+  { timeout: 120 * 1000 },
+  async function (name, height) {
+    const client = this.getClient(name);
+    await waitFor(async () => client.getPrunedHeight(), height, 115 * 1000);
+    const currentHeight = await client.getPrunedHeight();
+    console.log(
+      `Node ${name} has a pruned height: ${currentHeight} (should be`,
       height,
       `)`
     );

--- a/integration_tests/features/support/world.js
+++ b/integration_tests/features/support/world.js
@@ -7,7 +7,6 @@ const MiningNodeProcess = require("../../helpers/miningNodeProcess");
 const glob = require("glob");
 const fs = require("fs");
 const archiver = require("archiver");
-
 class CustomWorld {
   constructor({ attach, parameters }) {
     // this.variable = 0;
@@ -298,37 +297,21 @@ BeforeAll({ timeout: 1200000 }, async function () {
 
 After(async function (testCase) {
   console.log("Stopping nodes");
-  for (const key in this.seeds) {
-    if (testCase.result.status === "failed") {
-      await attachLogs(`${this.seeds[key].baseDir}`, this);
-    }
-    await this.stopNode(key);
-  }
-  for (const key in this.nodes) {
-    if (testCase.result.status === "failed") {
-      await attachLogs(`${this.nodes[key].baseDir}`, this);
-    }
-    await this.stopNode(key);
-  }
-  for (const key in this.proxies) {
-    if (testCase.result.status === "failed") {
-      await attachLogs(`${this.proxies[key].baseDir}`, this);
-    }
-    await this.proxies[key].stop();
-  }
-  for (const key in this.wallets) {
-    if (testCase.result.status === "failed") {
-      await attachLogs(`${this.wallets[key].baseDir}`, this);
-    }
-    await this.wallets[key].stop();
-  }
-  for (const key in this.miners) {
-    if (testCase.result.status === "failed") {
-      await attachLogs(`${this.miners[key].baseDir}`, this);
-    }
-    await this.miners[key].stop();
-  }
+  await stopAndHandleLogs(this.seeds, testCase, this);
+  await stopAndHandleLogs(this.nodes, testCase, this);
+  await stopAndHandleLogs(this.proxies, testCase, this);
+  await stopAndHandleLogs(this.wallets, testCase, this);
+  await stopAndHandleLogs(this.miners, testCase, this);
 });
+
+async function stopAndHandleLogs(objects, testCase, context) {
+  for (const key in objects) {
+    if (testCase.result.status === "failed") {
+      await attachLogs(`${objects[key].baseDir}`, context);
+    }
+    await objects[key].stop();
+  }
+}
 
 function attachLogs(path, context) {
   return new Promise((outerRes) => {

--- a/integration_tests/helpers/baseNodeClient.js
+++ b/integration_tests/helpers/baseNodeClient.js
@@ -83,6 +83,13 @@ class BaseNodeClient {
       .then((tip) => parseInt(tip.metadata.height_of_longest_chain));
   }
 
+  getPrunedHeight() {
+    return this.client
+      .getTipInfo()
+      .sendMessage({})
+      .then((tip) => parseInt(tip.metadata.pruned_height));
+  }
+
   getPreviousBlockTemplate(height) {
     return cloneDeep(this.blockTemplates["height" + height]);
   }

--- a/integration_tests/helpers/config.js
+++ b/integration_tests/helpers/config.js
@@ -7,6 +7,7 @@ function mapEnvs(options) {
   if (options.pruningHorizon) {
     // In the config toml file: `base_node.network.pruning_horizon` with `network = localnet`
     res.TARI_BASE_NODE__LOCALNET__PRUNING_HORIZON = options.pruningHorizon;
+    res.TARI_BASE_NODE__LOCALNET__PRUNED_MODE_CLEANUP_INTERVAL = 1;
   }
   if ("num_confirmations" in options) {
     res.TARI_WALLET__TRANSACTION_NUM_CONFIRMATIONS_REQUIRED =


### PR DESCRIPTION
add pruned mode pruning check

<!--- Provide a general summary of your changes in the Title above -->
Currently, all prune mode cucumber tests do not test prune nodes, but rather runs as archival nodes. This fixes the prune mode test to correctly run with prune mode nodes.
This also refactors the chain_meta to not send out the config setting pruning horizon, but rather send out the actual effective pruned height. 
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tests that prune node test actual pass after the fix, but fail before the sync. 
Added a test that ensures prune nodes perform pruning.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch.
* [x] I have squashed my commits into a single commit.
